### PR TITLE
progress towards stage2 behavior tests for all targets passing with the LLVM backend

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2693,7 +2693,10 @@ pub const MEM_RESERVE_PLACEHOLDERS = 0x2;
 pub const MEM_DECOMMIT = 0x4000;
 pub const MEM_RELEASE = 0x8000;
 
-pub const PTHREAD_START_ROUTINE = fn (LPVOID) callconv(.C) DWORD;
+pub const PTHREAD_START_ROUTINE = switch (builtin.zig_backend) {
+    .stage1 => fn (LPVOID) callconv(.C) DWORD,
+    else => *const fn (LPVOID) callconv(.C) DWORD,
+};
 pub const LPTHREAD_START_ROUTINE = PTHREAD_START_ROUTINE;
 
 pub const WIN32_FIND_DATAW = extern struct {
@@ -2866,7 +2869,10 @@ pub const IMAGE_TLS_DIRECTORY = extern struct {
 pub const IMAGE_TLS_DIRECTORY64 = IMAGE_TLS_DIRECTORY;
 pub const IMAGE_TLS_DIRECTORY32 = IMAGE_TLS_DIRECTORY;
 
-pub const PIMAGE_TLS_CALLBACK = ?fn (PVOID, DWORD, PVOID) callconv(.C) void;
+pub const PIMAGE_TLS_CALLBACK = switch (builtin.zig_backend) {
+    .stage1 => ?fn (PVOID, DWORD, PVOID) callconv(.C) void,
+    else => ?*const fn (PVOID, DWORD, PVOID) callconv(.C) void,
+};
 
 pub const PROV_RSA_FULL = 1;
 
@@ -2892,7 +2898,10 @@ pub const FILE_ACTION_MODIFIED = 0x00000003;
 pub const FILE_ACTION_RENAMED_OLD_NAME = 0x00000004;
 pub const FILE_ACTION_RENAMED_NEW_NAME = 0x00000005;
 
-pub const LPOVERLAPPED_COMPLETION_ROUTINE = ?fn (DWORD, DWORD, *OVERLAPPED) callconv(.C) void;
+pub const LPOVERLAPPED_COMPLETION_ROUTINE = switch (builtin.zig_backend) {
+    .stage1 => ?fn (DWORD, DWORD, *OVERLAPPED) callconv(.C) void,
+    else => ?*const fn (DWORD, DWORD, *OVERLAPPED) callconv(.C) void,
+};
 
 pub const FILE_NOTIFY_CHANGE_CREATION = 64;
 pub const FILE_NOTIFY_CHANGE_SIZE = 8;
@@ -2945,7 +2954,10 @@ pub const RTL_CRITICAL_SECTION = extern struct {
 pub const CRITICAL_SECTION = RTL_CRITICAL_SECTION;
 pub const INIT_ONCE = RTL_RUN_ONCE;
 pub const INIT_ONCE_STATIC_INIT = RTL_RUN_ONCE_INIT;
-pub const INIT_ONCE_FN = fn (InitOnce: *INIT_ONCE, Parameter: ?*anyopaque, Context: ?*anyopaque) callconv(.C) BOOL;
+pub const INIT_ONCE_FN = switch (builtin.zig_backend) {
+    .stage1 => fn (InitOnce: *INIT_ONCE, Parameter: ?*anyopaque, Context: ?*anyopaque) callconv(.C) BOOL,
+    else => *const fn (InitOnce: *INIT_ONCE, Parameter: ?*anyopaque, Context: ?*anyopaque) callconv(.C) BOOL,
+};
 
 pub const RTL_RUN_ONCE = extern struct {
     Ptr: ?*anyopaque,
@@ -3230,7 +3242,10 @@ pub const EXCEPTION_POINTERS = extern struct {
     ContextRecord: *std.os.windows.CONTEXT,
 };
 
-pub const VECTORED_EXCEPTION_HANDLER = fn (ExceptionInfo: *EXCEPTION_POINTERS) callconv(WINAPI) c_long;
+pub const VECTORED_EXCEPTION_HANDLER = switch (builtin.zig_backend) {
+    .stage1 => fn (ExceptionInfo: *EXCEPTION_POINTERS) callconv(WINAPI) c_long,
+    else => *const fn (ExceptionInfo: *EXCEPTION_POINTERS) callconv(WINAPI) c_long,
+};
 
 pub const OBJECT_ATTRIBUTES = extern struct {
     Length: ULONG,
@@ -3506,7 +3521,10 @@ pub const RTL_DRIVE_LETTER_CURDIR = extern struct {
     DosPath: UNICODE_STRING,
 };
 
-pub const PPS_POST_PROCESS_INIT_ROUTINE = ?fn () callconv(.C) void;
+pub const PPS_POST_PROCESS_INIT_ROUTINE = switch (builtin.zig_backend) {
+    .stage1 => ?fn () callconv(.C) void,
+    else => ?*const fn () callconv(.C) void,
+};
 
 pub const FILE_BOTH_DIR_INFORMATION = extern struct {
     NextEntryOffset: ULONG,
@@ -3526,7 +3544,10 @@ pub const FILE_BOTH_DIR_INFORMATION = extern struct {
 };
 pub const FILE_BOTH_DIRECTORY_INFORMATION = FILE_BOTH_DIR_INFORMATION;
 
-pub const IO_APC_ROUTINE = fn (PVOID, *IO_STATUS_BLOCK, ULONG) callconv(.C) void;
+pub const IO_APC_ROUTINE = switch (builtin.zig_backend) {
+    .stage1 => fn (PVOID, *IO_STATUS_BLOCK, ULONG) callconv(.C) void,
+    else => *const fn (PVOID, *IO_STATUS_BLOCK, ULONG) callconv(.C) void,
+};
 
 pub const CURDIR = extern struct {
     DosPath: UNICODE_STRING,
@@ -3598,8 +3619,14 @@ pub const ENUM_PAGE_FILE_INFORMATION = extern struct {
     PeakUsage: SIZE_T,
 };
 
-pub const PENUM_PAGE_FILE_CALLBACKW = ?fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCWSTR) callconv(.C) BOOL;
-pub const PENUM_PAGE_FILE_CALLBACKA = ?fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCSTR) callconv(.C) BOOL;
+pub const PENUM_PAGE_FILE_CALLBACKW = switch (builtin.zig_backend) {
+    .stage1 => ?fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCWSTR) callconv(.C) BOOL,
+    else => ?*const fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCWSTR) callconv(.C) BOOL,
+};
+pub const PENUM_PAGE_FILE_CALLBACKA = switch (builtin.zig_backend) {
+    .stage1 => ?fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCSTR) callconv(.C) BOOL,
+    else => ?*const fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCSTR) callconv(.C) BOOL,
+};
 
 pub const PSAPI_WS_WATCH_INFORMATION_EX = extern struct {
     BasicInfo: PSAPI_WS_WATCH_INFORMATION,
@@ -3699,4 +3726,7 @@ pub const CTRL_CLOSE_EVENT: DWORD = 2;
 pub const CTRL_LOGOFF_EVENT: DWORD = 5;
 pub const CTRL_SHUTDOWN_EVENT: DWORD = 6;
 
-pub const HANDLER_ROUTINE = fn (dwCtrlType: DWORD) callconv(.C) BOOL;
+pub const HANDLER_ROUTINE = switch (builtin.zig_backend) {
+    .stage1 => fn (dwCtrlType: DWORD) callconv(.C) BOOL,
+    else => *const fn (dwCtrlType: DWORD) callconv(.C) BOOL,
+};

--- a/lib/std/special/test_runner.zig
+++ b/lib/std/special/test_runner.zig
@@ -28,7 +28,7 @@ pub fn main() void {
     {
         return main2() catch @panic("test failure");
     }
-    if (builtin.zig_backend == .stage1) processArgs();
+    processArgs();
     const test_fn_list = builtin.test_functions;
     var ok_count: usize = 0;
     var skip_count: usize = 0;

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -29,9 +29,7 @@ comptime {
         builtin.zig_backend == .stage2_aarch64 or
         builtin.zig_backend == .stage2_arm or
         builtin.zig_backend == .stage2_riscv64 or
-        builtin.zig_backend == .stage2_sparcv9 or
-        (builtin.zig_backend == .stage2_llvm and native_os != .linux and native_os != .macos) or
-        (builtin.zig_backend == .stage2_llvm and native_arch != .x86_64 and native_arch != .aarch64))
+        builtin.zig_backend == .stage2_sparcv9)
     {
         if (builtin.output_mode == .Exe) {
             if ((builtin.link_libc or builtin.object_format == .c) and @hasDecl(root, "main")) {

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -815,6 +815,8 @@ pub const VectorCmp = struct {
 /// 1. `Inst.Ref` for every inputs_len
 /// 2. for every outputs_len
 ///    - constraint: memory at this position is reinterpreted as a null
+///      terminated string.
+///    - name: memory at this position is reinterpreted as a null
 ///      terminated string. pad to the next u32 after the null byte.
 /// 3. for every inputs_len
 ///    - constraint: memory at this position is reinterpreted as a null

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4323,7 +4323,7 @@ pub fn analyzeExport(
     const exported_decl = mod.declPtr(exported_decl_index);
     // TODO run the same checks as we do for C ABI struct fields
     switch (exported_decl.ty.zigTypeTag()) {
-        .Fn, .Int, .Enum, .Struct, .Union, .Array, .Float => {},
+        .Fn, .Int, .Enum, .Struct, .Union, .Array, .Float, .Pointer, .Optional => {},
         else => return sema.fail(block, src, "unable to export type '{}'", .{
             exported_decl.ty.fmt(sema.mod),
         }),

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -3272,10 +3272,12 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
             if (output != .none) {
                 return self.fail("TODO implement codegen for non-expr asm", .{});
             }
+            const extra_bytes = std.mem.sliceAsBytes(self.air.extra[extra_i..]);
             const constraint = std.mem.sliceTo(std.mem.sliceAsBytes(self.air.extra[extra_i..]), 0);
+            const name = std.mem.sliceTo(extra_bytes[constraint.len + 1 ..], 0);
             // This equation accounts for the fact that even if we have exactly 4 bytes
             // for the string, we still use the next u32 for the null terminator.
-            extra_i += constraint.len / 4 + 1;
+            extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
             break constraint;
         } else null;
@@ -3283,10 +3285,10 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
         for (inputs) |input| {
             const input_bytes = std.mem.sliceAsBytes(self.air.extra[extra_i..]);
             const constraint = std.mem.sliceTo(input_bytes, 0);
-            const input_name = std.mem.sliceTo(input_bytes[constraint.len + 1 ..], 0);
+            const name = std.mem.sliceTo(input_bytes[constraint.len + 1 ..], 0);
             // This equation accounts for the fact that even if we have exactly 4 bytes
             // for the string, we still use the next u32 for the null terminator.
-            extra_i += (constraint.len + input_name.len + 1) / 4 + 1;
+            extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
             if (constraint.len < 3 or constraint[0] != '{' or constraint[constraint.len - 1] != '}') {
                 return self.fail("unrecognized asm input constraint: '{s}'", .{constraint});

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -4078,10 +4078,12 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
             if (output != .none) {
                 return self.fail("TODO implement codegen for non-expr asm", .{});
             }
+            const extra_bytes = std.mem.sliceAsBytes(self.air.extra[extra_i..]);
             const constraint = std.mem.sliceTo(std.mem.sliceAsBytes(self.air.extra[extra_i..]), 0);
+            const name = std.mem.sliceTo(extra_bytes[constraint.len + 1 ..], 0);
             // This equation accounts for the fact that even if we have exactly 4 bytes
             // for the string, we still use the next u32 for the null terminator.
-            extra_i += constraint.len / 4 + 1;
+            extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
             break constraint;
         } else null;
@@ -4089,10 +4091,10 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
         for (inputs) |input| {
             const input_bytes = std.mem.sliceAsBytes(self.air.extra[extra_i..]);
             const constraint = std.mem.sliceTo(input_bytes, 0);
-            const input_name = std.mem.sliceTo(input_bytes[constraint.len + 1 ..], 0);
+            const name = std.mem.sliceTo(input_bytes[constraint.len + 1 ..], 0);
             // This equation accounts for the fact that even if we have exactly 4 bytes
             // for the string, we still use the next u32 for the null terminator.
-            extra_i += (constraint.len + input_name.len + 1) / 4 + 1;
+            extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
             if (constraint.len < 3 or constraint[0] != '{' or constraint[constraint.len - 1] != '}') {
                 return self.fail("unrecognized asm input constraint: '{s}'", .{constraint});

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -2098,10 +2098,12 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
             if (output != .none) {
                 return self.fail("TODO implement codegen for non-expr asm", .{});
             }
+            const extra_bytes = std.mem.sliceAsBytes(self.air.extra[extra_i..]);
             const constraint = std.mem.sliceTo(std.mem.sliceAsBytes(self.air.extra[extra_i..]), 0);
+            const name = std.mem.sliceTo(extra_bytes[constraint.len + 1 ..], 0);
             // This equation accounts for the fact that even if we have exactly 4 bytes
             // for the string, we still use the next u32 for the null terminator.
-            extra_i += constraint.len / 4 + 1;
+            extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
             break constraint;
         } else null;
@@ -2109,10 +2111,10 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
         for (inputs) |input| {
             const input_bytes = std.mem.sliceAsBytes(self.air.extra[extra_i..]);
             const constraint = std.mem.sliceTo(input_bytes, 0);
-            const input_name = std.mem.sliceTo(input_bytes[constraint.len + 1 ..], 0);
+            const name = std.mem.sliceTo(input_bytes[constraint.len + 1 ..], 0);
             // This equation accounts for the fact that even if we have exactly 4 bytes
             // for the string, we still use the next u32 for the null terminator.
-            extra_i += (constraint.len + input_name.len + 1) / 4 + 1;
+            extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
             if (constraint.len < 3 or constraint[0] != '{' or constraint[constraint.len - 1] != '}') {
                 return self.fail("unrecognized asm input constraint: '{s}'", .{constraint});

--- a/src/arch/sparcv9/CodeGen.zig
+++ b/src/arch/sparcv9/CodeGen.zig
@@ -642,10 +642,12 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
             if (output != .none) {
                 return self.fail("TODO implement codegen for non-expr asm", .{});
             }
+            const extra_bytes = std.mem.sliceAsBytes(self.air.extra[extra_i..]);
             const constraint = std.mem.sliceTo(std.mem.sliceAsBytes(self.air.extra[extra_i..]), 0);
+            const name = std.mem.sliceTo(extra_bytes[constraint.len + 1 ..], 0);
             // This equation accounts for the fact that even if we have exactly 4 bytes
             // for the string, we still use the next u32 for the null terminator.
-            extra_i += constraint.len / 4 + 1;
+            extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
             break constraint;
         } else null;
@@ -653,10 +655,10 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
         for (inputs) |input| {
             const input_bytes = std.mem.sliceAsBytes(self.air.extra[extra_i..]);
             const constraint = std.mem.sliceTo(input_bytes, 0);
-            const input_name = std.mem.sliceTo(input_bytes[constraint.len + 1 ..], 0);
+            const name = std.mem.sliceTo(input_bytes[constraint.len + 1 ..], 0);
             // This equation accounts for the fact that even if we have exactly 4 bytes
             // for the string, we still use the next u32 for the null terminator.
-            extra_i += (constraint.len + input_name.len + 1) / 4 + 1;
+            extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
             if (constraint.len < 3 or constraint[0] != '{' or constraint[constraint.len - 1] != '}') {
                 return self.fail("unrecognized asm input constraint: '{s}'", .{constraint});

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -4739,10 +4739,12 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
             if (output != .none) {
                 return self.fail("TODO implement codegen for non-expr asm", .{});
             }
+            const extra_bytes = std.mem.sliceAsBytes(self.air.extra[extra_i..]);
             const constraint = std.mem.sliceTo(std.mem.sliceAsBytes(self.air.extra[extra_i..]), 0);
+            const name = std.mem.sliceTo(extra_bytes[constraint.len + 1 ..], 0);
             // This equation accounts for the fact that even if we have exactly 4 bytes
             // for the string, we still use the next u32 for the null terminator.
-            extra_i += constraint.len / 4 + 1;
+            extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
             break constraint;
         } else null;
@@ -4750,10 +4752,10 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
         for (inputs) |input| {
             const input_bytes = std.mem.sliceAsBytes(self.air.extra[extra_i..]);
             const constraint = std.mem.sliceTo(input_bytes, 0);
-            const input_name = std.mem.sliceTo(input_bytes[constraint.len + 1 ..], 0);
+            const name = std.mem.sliceTo(input_bytes[constraint.len + 1 ..], 0);
             // This equation accounts for the fact that even if we have exactly 4 bytes
             // for the string, we still use the next u32 for the null terminator.
-            extra_i += (constraint.len + input_name.len + 1) / 4 + 1;
+            extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
             if (constraint.len < 3 or constraint[0] != '{' or constraint[constraint.len - 1] != '}') {
                 return self.fail("unrecognized asm input constraint: '{s}'", .{constraint});

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -3018,10 +3018,12 @@ fn airAsm(f: *Function, inst: Air.Inst.Index) !CValue {
         if (output != .none) {
             return f.fail("TODO implement codegen for non-expr asm", .{});
         }
+        const extra_bytes = std.mem.sliceAsBytes(f.air.extra[extra_i..]);
         const constraint = std.mem.sliceTo(std.mem.sliceAsBytes(f.air.extra[extra_i..]), 0);
+        const name = std.mem.sliceTo(extra_bytes[constraint.len + 1 ..], 0);
         // This equation accounts for the fact that even if we have exactly 4 bytes
         // for the string, we still use the next u32 for the null terminator.
-        extra_i += constraint.len / 4 + 1;
+        extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
         break constraint;
     } else null;
@@ -3031,10 +3033,12 @@ fn airAsm(f: *Function, inst: Air.Inst.Index) !CValue {
 
     const inputs_extra_begin = extra_i;
     for (inputs) |input, i| {
-        const constraint = std.mem.sliceTo(std.mem.sliceAsBytes(f.air.extra[extra_i..]), 0);
+        const input_bytes = std.mem.sliceAsBytes(f.air.extra[extra_i..]);
+        const constraint = std.mem.sliceTo(input_bytes, 0);
+        const name = std.mem.sliceTo(input_bytes[constraint.len + 1 ..], 0);
         // This equation accounts for the fact that even if we have exactly 4 bytes
         // for the string, we still use the next u32 for the null terminator.
-        extra_i += constraint.len / 4 + 1;
+        extra_i += (constraint.len + name.len + (2 + 3)) / 4;
 
         if (constraint[0] == '{' and constraint[constraint.len - 1] == '}') {
             const reg = constraint[1 .. constraint.len - 1];

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -340,6 +340,10 @@ pub const Object = struct {
 
         llvm_module.setModuleDataLayout(target_data);
 
+        if (options.pic) llvm_module.setModulePICLevel();
+        if (options.pie) llvm_module.setModulePIELevel();
+        if (code_model != .Default) llvm_module.setModuleCodeModel(code_model);
+
         return Object{
             .gpa = gpa,
             .module = options.module.?,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -4577,6 +4577,10 @@ pub const FuncGen = struct {
         const operand_ty = self.air.typeOf(pl_op.operand);
         const name = self.air.nullTerminatedString(pl_op.payload);
 
+        if (needDbgVarWorkaround(self.dg, operand_ty)) {
+            return null;
+        }
+
         const di_local_var = dib.createAutoVariable(
             self.di_scope.?,
             name.ptr,
@@ -6147,6 +6151,10 @@ pub const FuncGen = struct {
 
         const inst_ty = self.air.typeOfIndex(inst);
         if (self.dg.object.di_builder) |dib| {
+            if (needDbgVarWorkaround(self.dg, inst_ty)) {
+                return arg_val;
+            }
+
             const src_index = self.getSrcArgIndex(self.arg_index - 1);
             const func = self.dg.decl.getFunction().?;
             const lbrace_line = self.dg.module.declPtr(func.owner_decl).src_line + func.lbrace_line + 1;
@@ -8248,3 +8256,15 @@ const AnnotatedDITypePtr = enum(usize) {
 };
 
 const lt_errors_fn_name = "__zig_lt_errors_len";
+
+/// Without this workaround, LLVM crashes with "unknown codeview register H1"
+/// TODO use llvm-reduce and file upstream LLVM bug for this.
+fn needDbgVarWorkaround(dg: *DeclGen, ty: Type) bool {
+    if (ty.tag() == .f16) {
+        const target = dg.module.getTarget();
+        if (target.os.tag == .windows and target.cpu.arch == .aarch64) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -310,6 +310,15 @@ pub const Module = opaque {
     pub const setModuleDataLayout = LLVMSetModuleDataLayout;
     extern fn LLVMSetModuleDataLayout(*const Module, *const TargetData) void;
 
+    pub const setModulePICLevel = ZigLLVMSetModulePICLevel;
+    extern fn ZigLLVMSetModulePICLevel(module: *const Module) void;
+
+    pub const setModulePIELevel = ZigLLVMSetModulePIELevel;
+    extern fn ZigLLVMSetModulePIELevel(module: *const Module) void;
+
+    pub const setModuleCodeModel = ZigLLVMSetModuleCodeModel;
+    extern fn ZigLLVMSetModuleCodeModel(module: *const Module, code_model: CodeModel) void;
+
     pub const addFunction = LLVMAddFunction;
     extern fn LLVMAddFunction(*const Module, Name: [*:0]const u8, FunctionTy: *const Type) *const Value;
 

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -421,21 +421,10 @@ test "packed struct 24bits" {
     if (builtin.cpu.arch == .arm) return error.SkipZigTest; // TODO
 
     comptime {
-        // TODO Remove if and leave only the else branch when it is also fixed in stage2
-        if (builtin.zig_backend == .stage2_llvm or builtin.zig_backend == .stage2_x86 or
-            builtin.zig_backend == .stage2_riscv64)
-        {
-            // Stage 2 still expects the wrong values
-            try expect(@sizeOf(Foo24Bits) == 4);
-            if (@sizeOf(usize) == 4) {
-                try expect(@sizeOf(Foo96Bits) == 12);
-            } else {
-                try expect(@sizeOf(Foo96Bits) == 16);
-            }
-        } else {
-            // Stage1 is now fixed and is expected to return right values
-            try expectEqual(@sizeOf(Foo24Bits), 3);
-            try expectEqual(@sizeOf(Foo96Bits), 12);
+        // stage1 gets the wrong answer for sizeof
+        if (builtin.zig_backend != .stage1) {
+            std.debug.assert(@sizeOf(Foo24Bits) == @sizeOf(u24));
+            std.debug.assert(@sizeOf(Foo96Bits) == @sizeOf(u96));
         }
     }
 

--- a/test/incremental/aarch64-macos/hello_world_with_updates.0.zig
+++ b/test/incremental/aarch64-macos/hello_world_with_updates.0.zig
@@ -2,4 +2,4 @@
 // output_mode=Exe
 // target=aarch64-macos
 //
-// :109:9: error: struct 'tmp.tmp' has no member named 'main'
+// :107:9: error: struct 'tmp.tmp' has no member named 'main'

--- a/test/incremental/x86_64-linux/hello_world_with_updates.0.zig
+++ b/test/incremental/x86_64-linux/hello_world_with_updates.0.zig
@@ -2,4 +2,4 @@
 // output_mode=Exe
 // target=x86_64-linux
 //
-// :109:9: error: struct 'tmp.tmp' has no member named 'main'
+// :107:9: error: struct 'tmp.tmp' has no member named 'main'

--- a/test/incremental/x86_64-macos/hello_world_with_updates.0.zig
+++ b/test/incremental/x86_64-macos/hello_world_with_updates.0.zig
@@ -2,4 +2,4 @@
 // output_mode=Exe
 // target=x86_64-macos
 //
-// :109:9: error: struct 'tmp.tmp' has no member named 'main'
+// :107:9: error: struct 'tmp.tmp' has no member named 'main'


### PR DESCRIPTION
The goal of this branch is to get this command to pass:
```
stage2/bin/zig build test-behavior
```

Status:
* [x] native
* [x] native, -lc
* [x] native, -fsingle-threaded
* [x] wasm32-wasi
* [x] wasm32-wasi -lc
* [x] x86_64-linux
* [x] x86_64-linux-gnu -lc
* [x] x86_64-linux-musl -lc
* [x] x86-linux
* [x] x86-linux-musl -lc
* [x] x86-linux-gnu -lc
* [x] aarch64-linux
* [x] aarch64-linux-musl -lc
* [x] aarch64-linux-gnu -lc
* [x] aarch64-windows -lc
* [x] arm-linux generic+v8a
* [x] arm-linux-musleabihf -lc generic+v8a
* [ ] mips-linux
* [ ] mips-linux-musl -lc
* [ ] mipsel-linux
* [ ] mipsel-linux-musl -lc
* [ ] powerpc-linux
* [ ] powerpc-linux-musl -lc
* [x] riscv64-linux
* [x] riscv64-linux-musl -lc
* [x] x86_64-macos
* [x] aarch64-macos
* [ ] x86-windows-msvc
* [ ] x86_64-windows-msvc
* [ ] x86-windows-gnu -lc
* [ ] x86_64-windows-gnu -lc
* [x] native -OReleaseFast
* [ ] native -OReleaseFast -lc
* [x] native -OReleaseFast -lc -fsingle-threaded
* [x] native -OReleaseSafe
* [ ] native -OReleaseSafe -lc
* [x] native -OReleaseSafe -lc -fsingle-threaded
* [x] native -OReleaseSmall
* [ ] native -OReleaseSmall -lc
* [x] native -OReleaseSmall -lc -fsingle-threaded
