### PR TITLE
stage2: `@intToEnum` runtime safety

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -24637,7 +24637,7 @@ fn enumHasInt(
     int: Value,
 ) CompileError!bool {
     switch (ty.tag()) {
-        .enum_nonexhaustive => return sema.intFitsInType(block, src, int, ty),
+        .enum_nonexhaustive => return sema.intFitsInType(block, src, int, ty.castTag(.enum_nonexhaustive).?.data.tag_ty),
         .enum_full => {
             const enum_full = ty.castTag(.enum_full).?.data;
             const tag_ty = enum_full.tag_ty;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6047,9 +6047,6 @@ fn zirIntToEnum(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
     }
 
     if (try sema.resolveMaybeUndefVal(block, operand_src, operand)) |int_val| {
-        if (dest_ty.isNonexhaustiveEnum()) {
-            return sema.addConstant(dest_ty, int_val);
-        }
         if (int_val.isUndef()) {
             return sema.failWithUseOfUndef(block, operand_src);
         }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6093,13 +6093,13 @@ fn zirIntToEnum(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
                     try sema.addSafetyCheck(block, is_in_range, .invalid_enum_value);
                 } else {
                     // TODO: Output a switch instead of chained OR's.
-                    var found = sema.resolveInst(.bool_false);
-                    for (dest_ty.enumValues().keys()) |value| {
+                    var found_match: Air.Inst.Ref = undefined;
+                    for (dest_ty.enumValues().keys()) |value, i| {
                         const tag_val_inst = try sema.addConstant(dest_int_ty, value);
                         const next_match = try block.addBinOp(.cmp_eq, tag_val_inst, casted_operand);
-                        found = try block.addBinOp(.bool_or, found, next_match);
+                        found_match = if (i == 0) next_match else try block.addBinOp(.bool_or, found_match, next_match);
                     }
-                    try sema.addSafetyCheck(block, found, .invalid_enum_value);
+                    try sema.addSafetyCheck(block, found_match, .invalid_enum_value);
                 }
             },
             else => unreachable,

--- a/src/type.zig
+++ b/src/type.zig
@@ -5128,6 +5128,15 @@ pub const Type = extern union {
         };
     }
 
+    /// Asserts `ty` is an enum with a `ValueMap`.
+    pub fn enumValues(ty: Type) Module.EnumFull.ValueMap {
+        return switch (ty.tag()) {
+            .enum_full, .enum_nonexhaustive => ty.cast(Payload.EnumFull).?.data.values,
+            .enum_numbered => ty.castTag(.enum_numbered).?.data.values,
+            else => unreachable,
+        };
+    }
+
     pub fn enumFieldCount(ty: Type) usize {
         return ty.enumFields().count();
     }
@@ -5138,6 +5147,11 @@ pub const Type = extern union {
 
     pub fn enumFieldIndex(ty: Type, field_name: []const u8) ?usize {
         return ty.enumFields().getIndex(field_name);
+    }
+
+    /// Asserts `ty` is an enum. Asserts `value_index` is a valid index of `ty`'s values.
+    pub fn enumValue(ty: Type, value_index: usize) Value {
+        return ty.enumValues().keys()[value_index];
     }
 
     /// Asserts `ty` is an enum. `enum_tag` can either be `enum_field_index` or

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -763,7 +763,7 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    _ = @enumToInt(a);
             \\}
         , &.{
-            ":3:20: error: expected enum or tagged union, found bool",
+            ":3:20: error: expected enum or tagged union, found 'bool'",
         });
 
         case.addError(
@@ -772,7 +772,7 @@ pub fn addCases(ctx: *TestContext) !void {
             \\    _ = @intToEnum(bool, a);
             \\}
         , &.{
-            ":3:20: error: expected enum, found bool",
+            ":3:20: error: expected enum, found 'bool'",
         });
 
         case.addError(


### PR DESCRIPTION
This implements runtime safety checks for `@intToEnum`. `intCast` is used to both cast the operand into the enum's backing integer type as well as generate shrinkage safety checks. Then enums without explicit values are range checked while enums with explicit values have each value checked individually. The current implementation is rather simplistic and chains OR's together. In the future, it would be better to instead generate a switch with each value as a case.

I've been preoccupied with non-Zig stuff, so I'm a little out of the loop on how we want to test these. I'd appreciate some pointers. Thanks.

Related to #89.