### PR TITLE
cmake: add /usr/lib/llvm13 to searched paths

### DIFF
--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -12,6 +12,7 @@ find_path(LLVM_INCLUDE_DIRS NAMES llvm/IR/IRBuilder.h
     /usr/lib/llvm/13/include
     /usr/lib/llvm-13/include
     /usr/lib/llvm-13.0/include
+    /usr/lib/llvm13/include
     /usr/local/llvm13/include
     /usr/local/llvm130/include
     /usr/local/opt/llvm@13/include
@@ -31,6 +32,7 @@ if(ZIG_PREFER_CLANG_CPP_DYLIB)
       /usr/lib/llvm/13/lib
       /usr/lib/llvm/13/lib64
       /usr/lib/llvm-13/lib
+      /usr/lib/llvm13/lib
       /usr/local/llvm13/lib
       /usr/local/llvm130/lib
       /usr/local/opt/llvm@13/lib


### PR DESCRIPTION
Alpine linux installs llvm to this path and currently patches zig's
cmake file in order to build zig from source.

https://git.alpinelinux.org/aports/tree/testing/zig/llvm-include.patch?id=0c3f7850bef38fb4c63fc6af5c14724e5311b0cc