### PR TITLE
Fix `std.meta.TrailerFlags`

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -10,6 +10,10 @@ pub const TrailerFlags = @import("meta/trailer_flags.zig").TrailerFlags;
 
 const Type = std.builtin.Type;
 
+test "std.meta.TrailerFlags" {
+    _ = TrailerFlags;
+}
+
 pub fn tagName(v: anytype) []const u8 {
     const T = @TypeOf(v);
     switch (@typeInfo(T)) {

--- a/lib/std/meta/trailer_flags.zig
+++ b/lib/std/meta/trailer_flags.zig
@@ -24,10 +24,7 @@ pub fn TrailerFlags(comptime Fields: type) type {
                 fields[i] = Type.StructField{
                     .name = struct_field.name,
                     .field_type = ?struct_field.field_type,
-                    .default_value = @as(
-                        ??struct_field.field_type,
-                        @as(?struct_field.field_type, null),
-                    ),
+                    .default_value = &@as(?struct_field.field_type, null),
                     .is_comptime = false,
                     .alignment = @alignOf(?struct_field.field_type),
                 };


### PR DESCRIPTION
- Include `TrailerFlags` in std tests.
  Also fix a bug that was undetected because of the skipped tests.

- Previously, init() took a struct parameter, which gave the misleading impression that `TrailerFlags` was initialized with the struct's values. In fact, those values were unused.

  Before:
  ```zig
  var flags = Flags.init(.{
      .a = 1234,
      .b = "actually unused str",
  });
  ```
  After: (Edit: Now using @InKryption's suggestion)
  ```zig
  var flags = Flags.init(.{
      .a = true,
      .b = true,
  });
  ```

cc @Vexu, @andrewrk, @tadeokondrak 
