### PR TITLE
Give the users the chose of how to indent code.

### DIFF
--- a/src/DepTokenizer.zig
+++ b/src/DepTokenizer.zig
@@ -15,7 +15,7 @@ pub fn next(self: *Tokenizer) ?Token {
         const char = self.bytes[self.index];
         switch (self.state) {
             .lhs => switch (char) {
-                '\t', '\n', '\r', ' ' => {
+                '\t', '\n', '\r', ' ', 11 => {
                     // silently ignore whitespace
                     self.index += 1;
                 },
@@ -45,10 +45,10 @@ pub fn next(self: *Tokenizer) ?Token {
                 },
             },
             .target_reverse_solidus => switch (char) {
-                '\t', '\n', '\r' => {
+                '\n', '\r' => {
                     return errorIllegalChar(.bad_target_escape, self.index, char);
                 },
-                ' ', '#', '\\' => {
+                '\t', ' ', '#', '\\' => {
                     must_resolve = true;
                     self.state = .target;
                     self.index += 1;
@@ -111,7 +111,7 @@ pub fn next(self: *Tokenizer) ?Token {
                 },
             },
             .rhs => switch (char) {
-                '\t', ' ' => {
+                '\t', ' ', 11 => {
                     // silently ignore horizontal whitespace
                     self.index += 1;
                 },

--- a/src/stage1/tokenizer.cpp
+++ b/src/stage1/tokenizer.cpp
@@ -20,7 +20,7 @@
     case '\r': \
     case '\n': \
     case '\t': \
-    case '\v': \
+    case '\v'  \
 
 #define DIGIT_NON_ZERO \
          '1': \

--- a/src/stage1/tokenizer.cpp
+++ b/src/stage1/tokenizer.cpp
@@ -18,7 +18,9 @@
 #define WHITESPACE \
          ' ': \
     case '\r': \
-    case '\n'
+    case '\n': \
+    case '\t': \
+    case '\v': \
 
 #define DIGIT_NON_ZERO \
          '1': \


### PR DESCRIPTION
I know this could reduce the consistency of zig code (allowing mixing tabs and spaces in the same project), but the best way to solve this is with a autoformater, not by having the compile throw an error when you try to use a tab.