### PR TITLE
Fixes comptime 'error: cannot assign to constant' error in siphash.

### DIFF
--- a/lib/std/crypto/siphash.zig
+++ b/lib/std/crypto/siphash.zig
@@ -78,9 +78,12 @@ fn SipHashStateless(comptime T: type, comptime c_rounds: usize, comptime d_round
         pub fn update(self: *Self, b: []const u8) void {
             std.debug.assert(b.len % 8 == 0);
 
+            const inl = std.builtin.CallOptions{ .modifier = .always_inline };
+
             var off: usize = 0;
             while (off < b.len) : (off += 8) {
-                @call(.{ .modifier = .always_inline }, self.round, .{b[off..][0..8].*});
+                const blob = b[off..][0..8].*;
+                @call(inl, round, .{ self, blob });
             }
 
             self.msg_len +%= @truncate(u8, b.len);


### PR DESCRIPTION
This is a workaround for some stage1 bug in `@call` that happens only in certain cases in comptime evaluation. [LoLa](https://github.com/MasterQ32/LoLa) is broken on `0.10.0-dev.2054+3ed9ef3e6` due to this evaluation bug.

This is likely a regression in stage1, so this is only a workaround. The same "fix" is already applied somewhat lower in siphash.