### PR TITLE
stage2,x64: implement @mulWithOverflow for all 1...64 bit-widths cases

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -1496,11 +1496,8 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                             rhs.freezeIfRegister(&self.register_manager);
                             defer rhs.unfreezeIfRegister(&self.register_manager);
 
-                            // TODO check if we could reuse rhs instead, and swap the values out.
                             const dst_reg: Register = blk: {
-                                if (self.reuseOperand(inst, bin_op.lhs, 0, lhs)) {
-                                    if (lhs.isRegister()) break :blk lhs.register;
-                                }
+                                if (lhs.isRegister()) break :blk lhs.register;
                                 break :blk try self.copyToTmpRegister(ty, lhs);
                             };
                             self.register_manager.freezeRegs(&.{dst_reg});

--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -1383,7 +1383,7 @@ inline fn getOpCode(tag: Tag, enc: Encoding, is_one_byte: bool) ?OpCode {
             .sub => OpCode.oneByte(if (is_one_byte) 0x2a else 0x2b),
             .xor => OpCode.oneByte(if (is_one_byte) 0x32 else 0x33),
             .@"and" => OpCode.oneByte(if (is_one_byte) 0x22 else 0x23),
-            .@"or" => OpCode.oneByte(if (is_one_byte) 0x0b else 0x0b),
+            .@"or" => OpCode.oneByte(if (is_one_byte) 0x0a else 0x0b),
             .sbb => OpCode.oneByte(if (is_one_byte) 0x1a else 0x1b),
             .cmp => OpCode.oneByte(if (is_one_byte) 0x3a else 0x3b),
             .mov => OpCode.oneByte(if (is_one_byte) 0x8a else 0x8b),

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -686,7 +686,6 @@ test "basic @mulWithOverflow" {
 // TODO migrate to this for all backends once they handle more cases
 test "extensive @mulWithOverflow" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 


### PR DESCRIPTION
~~Blocked by #11574~~

Implements `@mulWithOverflow` for variable-sized integers in the range `1...64` signed and unsigned.