### PR TITLE
stage2: wasm - Improve `@mulWithOverflow` implementation

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -5952,6 +5952,7 @@ pub const Type = extern union {
     pub const @"u64" = initTag(.u64);
 
     pub const @"i32" = initTag(.i32);
+    pub const @"i64" = initTag(.i64);
 
     pub const @"f16" = initTag(.f16);
     pub const @"f32" = initTag(.f32);

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -687,7 +687,6 @@ test "basic @mulWithOverflow" {
 test "extensive @mulWithOverflow" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     {
         var a: u5 = 3;
@@ -833,6 +832,12 @@ test "extensive @mulWithOverflow" {
         try expect(@mulWithOverflow(i32, a, b, &res));
         try expect(res == 0x7fffffff);
     }
+}
+
+test "@mulWithOverflow bitsize > 32" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     {
         var a: u62 = 3;

--- a/test/cases/binary_operands.13.zig
+++ b/test/cases/binary_operands.13.zig
@@ -1,6 +1,6 @@
 pub fn main() void {
     var i: i4 = 3;
-    if (i *% 3 != 1) unreachable;
+    if (i *% 3 != -7) unreachable;
     return;
 }
 

--- a/test/cases/binary_operands.2.zig
+++ b/test/cases/binary_operands.2.zig
@@ -1,6 +1,6 @@
 pub fn main() void {
     var i: i4 = 7;
-    if (i +% 1 != 0) unreachable;
+    if (i +% 1 != -8) unreachable;
     return;
 }
 


### PR DESCRIPTION
This improves the `@mulWithOverflow` implementation and ensures it passes all tests when bitsize <= 32.
To also support integers with bitsize 64, we will need compiler-rt support as Wasm does not have the same capabilities like the native backends with regards to carry bits, etc.

This PR ensures the Wasm backend will comply with #11316