### PR TITLE
Only print steps list if step name not valid

### DIFF
--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -332,7 +332,6 @@ fn printStepsAndErr(builder: *Builder, already_ran_build: bool, out_stream: anyt
     }
 
     try out_stream.print(
-        \\Usage: {s} build [steps] [options]
         \\
         \\Steps:
         \\

--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -335,7 +335,7 @@ fn printStepsAndErr(builder: *Builder, already_ran_build: bool, out_stream: anyt
         \\
         \\Steps:
         \\
-    , .{builder.zig_exe});
+    , .{});
 
     const allocator = builder.allocator;
     for (builder.top_level_steps.items) |top_level_step| {


### PR DESCRIPTION
It helps reduce the cognitive overload when you made a typo in the command

Another solution to fix #11621 

- Other solution: #11622 