### PR TITLE
init-exe: add note about log_level in ReleaseSmall and ReleaseFast build mode

### DIFF
--- a/lib/init-exe/src/main.zig
+++ b/lib/init-exe/src/main.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 
 pub fn main() anyerror!void {
+    // Note that info level log messages are by default printed only in Debug
+    // and ReleaseSafe build modes.
     std.log.info("All your codebase are belong to us.", .{});
 }
 


### PR DESCRIPTION
As suggested in https://github.com/ziglang/zig/issues/9945#issuecomment-950114977 by @wizzard0.

Fixes #9945.