### PR TITLE
add std.enums.hasName

### DIFF
--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -849,3 +849,32 @@ test "std.enums.EnumIndexer sparse" {
     try testing.expectEqual(E.b, Indexer.keyForIndex(1));
     try testing.expectEqual(E.c, Indexer.keyForIndex(2));
 }
+
+/// Returns true if `enum_value` has a name. This function always returns true
+/// for exhaustive enums.  It will return false if the enum is non-exhaustive
+/// and the value does not have a corresponding name.
+pub fn hasName(enum_value: anytype) bool {
+    const T = @TypeOf(enum_value);
+    const enum_info = switch (@typeInfo(T)) {
+        .Enum => |enum_info| enum_info,
+        else => @compileError("hasName requires an enum value but got " ++ @typeName(T)),
+    };
+    if (enum_info.is_exhaustive)
+        return true;
+
+    @setEvalBranchQuota(3 * enum_info.fields.len);
+    inline for (enum_info.fields) |enum_field| {
+        if (@enumToInt(enum_value) == enum_field.value)
+            return true;
+    }
+
+    return false;
+}
+
+test "std.enums.hasName" {
+    const Exhaustive = enum { a };
+    const NonExhaustive = enum(u8) { a, _ };
+    try testing.expect(hasName(Exhaustive.a));
+    try testing.expect(hasName(NonExhaustive.a));
+    try testing.expect(!hasName(@intToEnum(NonExhaustive, 10)));
+}

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -488,25 +488,14 @@ pub fn formatType(
         },
         .Enum => |enumInfo| {
             try writer.writeAll(@typeName(T));
-            if (enumInfo.is_exhaustive) {
+            if (enumInfo.is_exhaustive or std.enums.hasName(value)) {
                 try writer.writeAll(".");
                 try writer.writeAll(@tagName(value));
-                return;
+            } else {
+                try writer.writeAll("(");
+                try formatType(@enumToInt(value), actual_fmt, options, writer, max_depth);
+                try writer.writeAll(")");
             }
-
-            // Use @tagName only if value is one of known fields
-            @setEvalBranchQuota(3 * enumInfo.fields.len);
-            inline for (enumInfo.fields) |enumField| {
-                if (@enumToInt(value) == enumField.value) {
-                    try writer.writeAll(".");
-                    try writer.writeAll(@tagName(value));
-                    return;
-                }
-            }
-
-            try writer.writeAll("(");
-            try formatType(@enumToInt(value), actual_fmt, options, writer, max_depth);
-            try writer.writeAll(")");
         },
         .Union => |info| {
             try writer.writeAll(@typeName(T));


### PR DESCRIPTION
Added `std.enums.hasName` that returns whether an enum value has a name.
This is useful for determining whether a non-exhaustive enum value
has a tag name that can be retrieved with `@tagName`.