### PR TITLE
Prevent new issues from escaping issue trap

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+blank_issues_enabled: false
 contact_links:
   - name: Language Proposal
     about: Propose to improve the Zig language


### PR DESCRIPTION
Using docs from: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

> You can encourage contributors to use issue templates by setting blank_issues_enabled to false. If you set blank_issues_enabled to true, people will have the option to open a blank issue.

unsure if this has already been discussed, could not find discussion anywhere in issues/PRs.

## Potential Problems
- Could discourage making issues requesting documentation or error message fixes
- Could discourage newer users from reporting bugs that they do not know how to reproduce