### PR TITLE
zig test: Add proper detection for Windows console

### DIFF
--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -37,7 +37,8 @@ pub fn main() void {
         .dont_print_on_dumb = true,
     };
     const root_node = progress.start("Test", test_fn_list.len);
-    const have_tty = progress.terminal != null and progress.supports_ansi_escape_codes;
+    const have_tty = progress.terminal != null and
+        (progress.supports_ansi_escape_codes or progress.is_windows_terminal);
 
     var async_frame_buffer: []align(std.Target.stack_align) u8 = undefined;
     // TODO this is on the next line (using `undefined` above) because otherwise zig incorrectly


### PR DESCRIPTION
This fixes the issue #11640 that I created yesterday. With this, running `zig test` on Windows console finally shows like this:
```
> zig test src/main.zig
All 138 tests passed.
```