### PR TITLE
std.os.linux: fix signature of setgroups

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1051,7 +1051,7 @@ pub fn getgroups(size: usize, list: *gid_t) usize {
     }
 }
 
-pub fn setgroups(size: usize, list: *const gid_t) usize {
+pub fn setgroups(size: usize, list: [*]const gid_t) usize {
     if (@hasField(SYS, "setgroups32")) {
         return syscall2(.setgroups32, size, @ptrToInt(list));
     } else {


### PR DESCRIPTION
the list parameter should be a multi-item pointer rather than a single-item
pointer. see: https://linux.die.net/man/2/setgroups

> setgroups() sets the supplementary group IDs for the calling process...
> the size argument specifies the number of supplementary group IDs in the buffer pointed to by list.