### PR TITLE
fix semantic error with std.os.linux.all_mask

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -3064,7 +3064,7 @@ pub const NSIG = if (is_mips) 128 else 65;
 
 pub const sigset_t = [1024 / 32]u32;
 
-pub const all_mask: sigset_t = [_]u32{0xffffffff} ** sigset_t.len;
+pub const all_mask: sigset_t = [_]u32{0xffffffff} ** @typeInfo(sigset_t).Array.len;
 pub const app_mask: sigset_t = [2]u32{ 0xfffffffc, 0x7fffffff } ++ [_]u32{0xffffffff} ** 30;
 
 const k_sigaction_funcs = if (builtin.zig_backend == .stage1) struct {


### PR DESCRIPTION
all_mask is a value of type `sigset_t`, which is defined as an array type
`[N]u32`.  However, `all_mask` references `sigset_t.len`, but, the array type
does not have a `len` field.  Fix is to use `@typeInfo(sigset_t).Array.len`
instead.