### PR TITLE
docs: add missed docs for some language feature like `defer` and `errdefer`

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4813,6 +4813,19 @@ fn deferErrorExample(is_error: bool) !void {
         print("encountered an error!\n", .{});
     }
 
+    // inside a defer method the return statement
+    // is not allowed.
+    // The following lines produce the following
+    // error if uncomment
+    // ```
+    // defer.zig:73:9: error: cannot return from defer expression
+    // return error.DeferError;
+    // ```
+    //
+    //defer {
+    //    return error.DeferError;
+    //}
+
     if (is_error) {
         return error.DeferError;
     }

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4831,9 +4831,23 @@ fn deferErrorExample(is_error: bool) !void {
     }
 }
 
+// The errdefer keyword support also an alternative syntax to capture the
+// error generated in case of one error.
+//
+// This is useful when during the clean up after an error additional
+// message want to be printed.
+fn deferErrorCaptureExample() !void {
+    errdefer |err| {
+        std.debug.print("the error is {s}\n", .{@errorName(err)});
+    }
+
+    return error.DeferError;
+}
+
 test "errdefer unwinding" {
     deferErrorExample(false) catch {};
     deferErrorExample(true) catch {};
+    deferErrorCaptureExample() catch {};
 }
       {#code_end#}
       {#see_also|Errors#}
@@ -11941,7 +11955,7 @@ fn readU32Be() u32 {}
             <pre>{#syntax#}errdefer{#endsyntax#}</pre>
           </th>
           <td>
-            {#syntax#}errdefer{#endsyntax#} will execute an expression when control flow leaves the current block if the function returns an error.
+            {#syntax#}errdefer{#endsyntax#} will execute an expression when control flow leaves the current block if the function returns an error, the errdefer expression can capture the unwrapped value.
             <ul>
               <li>See also {#link|errdefer#}</li>
             </ul>


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/11579