### PR TITLE
Add aliases to math builtins back into std.math

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -929,37 +929,6 @@ pub inline fn fabs(value: anytype) @TypeOf(value) {
     return @fabs(value);
 }
 
-/// Fused multiply add, similar to (a * b) + c, except only rounds once,
-/// and is thus more accurate.
-/// This is the same as calling the builtin @mulAdd
-pub inline fn fma(comptime T: type, a: T, b: T, c: T) T {
-    return @mulAdd(T, a, b, c);
-}
-
-/// Returns the minimum value of a and b. This builtin accepts integers,
-/// floats, and vectors of either. In the latter case, the operation is
-/// performed element wise.
-/// This is the same as calling the builtin @minimum
-pub inline fn fmin(a: anytype, b: @TypeOf(a)) @TypeOf(a) {
-    return @minimum(a, b);
-}
-
-/// Returns the maximum value of a and b. This builtin accepts integers,
-/// floats, and vectors of either. In the latter case, the operation is
-/// performed element wise.
-/// This is the same as calling the builtin @maximum
-pub inline fn fmax(a: anytype, b: @TypeOf(a)) @TypeOf(a) {
-    return @maximum(a, b);
-}
-
-/// Modulus division. For unsigned integers this is the same as numerator %
-/// denominator. Caller guarantees denominator > 0, otherwise the operation will
-/// result in a Remainder Division by Zero error when runtime safety checks are enabled.
-/// This is the same as calling the builtin @mod
-pub inline fn fmod(a: anytype, b: @TypeOf(a)) @TypeOf(a) {
-    return @mod(a, b);
-}
-
 /// Returns the absolute value of the integer parameter.
 /// Result is an unsigned integer.
 pub fn absCast(x: anytype) switch (@typeInfo(@TypeOf(x))) {

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -929,12 +929,6 @@ pub inline fn fabs(value: anytype) @TypeOf(value) {
     return @fabs(value);
 }
 
-/// Alias to fabs for backwards compatibility
-/// This is the same as calling the builtin @fabs
-pub inline fn absFloat(value: anytype) @TypeOf(value) {
-    return @fabs(value);
-}
-
 /// Returns the absolute value of the integer parameter.
 /// Result is an unsigned integer.
 pub fn absCast(x: anytype) switch (@typeInfo(@TypeOf(x))) {

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -270,6 +270,41 @@ pub const sinh = @import("math/sinh.zig").sinh;
 pub const cosh = @import("math/cosh.zig").cosh;
 pub const tanh = @import("math/tanh.zig").tanh;
 
+/// Sine trigonometric function on a floating point number.
+/// Uses a dedicated hardware instruction when available.
+/// This is the same as calling the builtin @sin
+pub inline fn sin(value: anytype) @TypeOf(value) {
+    return @sin(value);
+}
+
+/// Cosine trigonometric function on a floating point number.
+/// Uses a dedicated hardware instruction when available.
+/// This is the same as calling the builtin @cos
+pub inline fn cos(value: anytype) @TypeOf(value) {
+    return @cos(value);
+}
+
+/// Tangent trigonometric function on a floating point number.
+/// Uses a dedicated hardware instruction when available.
+/// This is the same as calling the builtin @tan
+pub inline fn tan(value: anytype) @TypeOf(value) {
+    return @tan(value);
+}
+
+/// Base-e exponential function on a floating point number.
+/// Uses a dedicated hardware instruction when available.
+/// This is the same as calling the builtin @exp
+pub inline fn exp(value: anytype) @TypeOf(value) {
+    return @exp(value);
+}
+
+/// Base-2 exponential function on a floating point number.
+/// Uses a dedicated hardware instruction when available.
+/// This is the same as calling the builtin @exp2
+pub inline fn exp2(value: anytype) @TypeOf(value) {
+    return @exp2(value);
+}
+
 pub const complex = @import("math/complex.zig");
 pub const Complex = complex.Complex;
 
@@ -887,6 +922,19 @@ fn testRem() !void {
     try testing.expectError(error.DivisionByZero, rem(f32, 10, 0));
 }
 
+/// Returns the absolute value of a floating point number.
+/// Uses a dedicated hardware instruction when available.
+/// This is the same as calling the builtin @fabs
+pub inline fn fabs(value: anytype) @TypeOf(value) {
+    return @fabs(value);
+}
+
+/// Alias to fabs for backwards compatibility
+/// This is the same as calling the builtin @fabs
+pub inline fn absFloat(value: anytype) @TypeOf(value) {
+    return @fabs(value);
+}
+
 /// Returns the absolute value of the integer parameter.
 /// Result is an unsigned integer.
 pub fn absCast(x: anytype) switch (@typeInfo(@TypeOf(x))) {
@@ -987,6 +1035,27 @@ pub fn isPowerOfTwo(v: anytype) bool {
     return (v & (v - 1)) == 0;
 }
 
+/// Rounds the given floating point number to an integer, away from zero.
+/// Uses a dedicated hardware instruction when available.
+/// This is the same as calling the builtin @round
+pub inline fn round(value: anytype) @TypeOf(value) {
+    return @round(value);
+}
+
+/// Rounds the given floating point number to an integer, towards zero.
+/// Uses a dedicated hardware instruction when available.
+/// This is the same as calling the builtin @trunc
+pub inline fn trunc(value: anytype) @TypeOf(value) {
+    return @trunc(value);
+}
+
+/// Returns the largest integral value not greater than the given floating point number.
+/// Uses a dedicated hardware instruction when available.
+/// This is the same as calling the builtin @floor
+pub inline fn floor(value: anytype) @TypeOf(value) {
+    return @floor(value);
+}
+
 /// Returns the nearest power of two less than or equal to value, or
 /// zero if value is less than or equal to zero.
 pub fn floorPowerOfTwo(comptime T: type, value: T) T {
@@ -1013,6 +1082,13 @@ fn testFloorPowerOfTwo() !void {
     try testing.expect(floorPowerOfTwo(i4, -8) == 0);
     try testing.expect(floorPowerOfTwo(i4, -1) == 0);
     try testing.expect(floorPowerOfTwo(i4, 0) == 0);
+}
+
+/// Returns the smallest integral value not less than the given floating point number.
+/// Uses a dedicated hardware instruction when available.
+/// This is the same as calling the builtin @ceil
+pub inline fn ceil(value: anytype) @TypeOf(value) {
+    return @ceil(value);
 }
 
 /// Returns the next power of two (if the value is not already a power of two).

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -929,6 +929,37 @@ pub inline fn fabs(value: anytype) @TypeOf(value) {
     return @fabs(value);
 }
 
+/// Fused multiply add, similar to (a * b) + c, except only rounds once,
+/// and is thus more accurate.
+/// This is the same as calling the builtin @mulAdd
+pub inline fn fma(comptime T: type, a: T, b: T, c: T) T {
+    return @mulAdd(T, a, b, c);
+}
+
+/// Returns the minimum value of a and b. This builtin accepts integers,
+/// floats, and vectors of either. In the latter case, the operation is
+/// performed element wise.
+/// This is the same as calling the builtin @minimum
+pub inline fn fmin(a: anytype, b: @TypeOf(a)) @TypeOf(a) {
+    return @minimum(a, b);
+}
+
+/// Returns the maximum value of a and b. This builtin accepts integers,
+/// floats, and vectors of either. In the latter case, the operation is
+/// performed element wise.
+/// This is the same as calling the builtin @maximum
+pub inline fn fmax(a: anytype, b: @TypeOf(a)) @TypeOf(a) {
+    return @maximum(a, b);
+}
+
+/// Modulus division. For unsigned integers this is the same as numerator %
+/// denominator. Caller guarantees denominator > 0, otherwise the operation will
+/// result in a Remainder Division by Zero error when runtime safety checks are enabled.
+/// This is the same as calling the builtin @mod
+pub inline fn fmod(a: anytype, b: @TypeOf(a)) @TypeOf(a) {
+    return @mod(a, b);
+}
+
 /// Returns the absolute value of the integer parameter.
 /// Result is an unsigned integer.
 pub fn absCast(x: anytype) switch (@typeInfo(@TypeOf(x))) {


### PR DESCRIPTION
Provides inline aliases to functions originally in `std.math`. This is to keep backwards compatibility (makes #11532 not breaking anymore) and keep math code unified (eg no need to mix builtins with std.math). 