### PR TITLE
stage1: don't lowercaseify lib names

### DIFF
--- a/src/stage1.zig
+++ b/src/stage1.zig
@@ -416,7 +416,7 @@ export fn stage2_add_link_lib(
     _ = symbol_name_len;
     _ = symbol_name_ptr;
     const comp = @intToPtr(*Compilation, stage1.userdata);
-    const lib_name = std.ascii.allocLowerString(comp.gpa, lib_name_ptr[0..lib_name_len]) catch return "out of memory";
+    const lib_name = lib_name_ptr[0..lib_name_len];
     const target = comp.getTarget();
     const is_libc = target_util.is_libc_lib_name(target, lib_name);
     if (is_libc) {


### PR DESCRIPTION
Stage1 converts library names to lowercase, which isn't good when they're not all lowercase. I suspect this was done because they're insensitively compared with a bunch of libc and libc++ names, but `is_libc_lib_name` and `is_libcpp_link_name` already do a case-insensitive comparison so all it does is mangle the string and break cases where it has uppercase characters (such as `libX11`, where I ran into it). This regression appears to have been introduced in 5fed42d.

closes #11682