### PR TITLE
document bufPrint, and format now uses `writer` not `output`

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -24,9 +24,9 @@ pub const FormatOptions = struct {
     fill: u8 = ' ',
 };
 
-/// Renders fmt string with args, calling output with slices of bytes.
-/// If `output` returns an error, the error is returned from `format` and
-/// `output` is not called again.
+/// Renders fmt string with args, calling `writer` with slices of bytes.
+/// If `writer` returns an error, the error is returned from `format` and
+/// `writer` is not called again.
 ///
 /// The format string must be comptime known and may contain placeholders following
 /// this format:
@@ -1869,6 +1869,10 @@ pub const BufPrintError = error{
     /// As much as possible was written to the buffer, but it was too small to fit all the printed bytes.
     NoSpaceLeft,
 };
+
+/// print a Formatter string into `buf`. Actually just a thin wrapper around `format` and `fixedBufferStream`.
+/// returns a slice of the bytes printed to.
+
 pub fn bufPrint(buf: []u8, comptime fmt: []const u8, args: anytype) BufPrintError![]u8 {
     var fbs = std.io.fixedBufferStream(buf);
     try format(fbs.writer(), fmt, args);

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1872,7 +1872,6 @@ pub const BufPrintError = error{
 
 /// print a Formatter string into `buf`. Actually just a thin wrapper around `format` and `fixedBufferStream`.
 /// returns a slice of the bytes printed to.
-
 pub fn bufPrint(buf: []u8, comptime fmt: []const u8, args: anytype) BufPrintError![]u8 {
     var fbs = std.io.fixedBufferStream(buf);
     try format(fbs.writer(), fmt, args);


### PR DESCRIPTION
just adding documentation where I needed to read the code. It was not clear from the types that bufPrint would return a slice of the bytes printed to.