### PR TITLE
Fix segfault in error note

### DIFF
--- a/src/stage1/ir.cpp
+++ b/src/stage1/ir.cpp
@@ -15500,7 +15500,7 @@ static Stage1AirInst *ir_analyze_struct_field_ptr(IrAnalyze *ira, Scope *scope, 
                 is_const, is_volatile, PtrLenSingle, field->align,
                 (uint32_t)(ptr_bit_offset + field->bit_offset_in_host),
                 (uint32_t)host_int_bytes_for_result_type, false);
-        
+
         if (field == struct_type->data.structure.misaligned_field) {
             // If field is the last single misaligned field it will be represented as array
             // of bytes in LLVM but get_pointer_to_type_extra will set its host_int_bytes to 0.
@@ -24781,7 +24781,9 @@ static Stage1AirInst *ir_analyze_instruction_end_expr(IrAnalyze *ira, Stage1ZirI
             if (type_is_invalid(store_ptr->value->type)) {
                 if (instruction->result_loc->id == ResultLocIdReturn &&
                     (value->value->type->id == ZigTypeIdErrorUnion || value->value->type->id == ZigTypeIdErrorSet) &&
-                    ira->explicit_return_type->id != ZigTypeIdErrorUnion && ira->explicit_return_type->id != ZigTypeIdErrorSet)
+                    ira->explicit_return_type->id != ZigTypeIdErrorUnion && ira->explicit_return_type->id != ZigTypeIdErrorSet &&
+                    // Only add error note if we have a node to attach it to
+                    ira->explicit_return_type_source_node)
                 {
                     add_error_note(ira->codegen, ira->new_irb.exec->first_err_trace_msg,
                         ira->explicit_return_type_source_node, buf_create_from_str("function cannot return an error"));


### PR DESCRIPTION
The following code produces a segfault in current master:

```
fn init() !u32 {
    return 0;
}

const Foo = struct {
    data: u32 = init(),
};

pub fn main() void {
    const state: Foo = .{};
    _ = state;
}
```

This is caused by default assigning `data` with an error union value when it doesn't expect one - it segfaults when it tries to add a compiler note. I think because it's trying to evaluate the `init()` body as a constant expression but the compiler note expects it to be inside a function (?)

This change just avoids adding the compiler note in this case. The error still reads fine:

```
./zig-bounded-array-repro.zig:6:21: error: cannot convert error union to payload type. consider using `try`, `catch`, or `if`. expected type 'u32', found '@typeInfo(@typeInfo(@TypeOf(init)).Fn.return_type.?).ErrorUnion.error_set!u32'
    data: u32 = init(),
```