### PR TITLE
Fix stage2 c behavior tests

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1206,6 +1206,9 @@ pub const DeclGen = struct {
 
         const name_start = buffer.items.len + 1;
         try bw.print(" zig_A_{s}_{d}", .{ typeToCIdentifier(elem_type, dg.module), c_len });
+        if (t.sentinel()) |sentinel| {
+            try bw.print("_{}", .{sentinel.fmtValue(elem_type, dg.module)});
+        }
         const name_end = buffer.items.len;
 
         try bw.print("[{d}];\n", .{c_len});

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -4105,7 +4105,7 @@ fn intMax(ty: Type, target: std.Target, buf: []u8) []const u8 {
             const rhs = @intCast(u7, int_info.bits - @boolToInt(int_info.signedness == .signed));
             const val = (@as(u128, 1) << rhs) - 1;
             // TODO make this integer literal have a suffix if necessary (such as "ull")
-            return std.fmt.bufPrint(buf, "{}", .{val}) catch |err| switch (err) {
+            return std.fmt.bufPrint(buf, "{}u", .{val}) catch |err| switch (err) {
                 error.NoSpaceLeft => unreachable,
             };
         },


### PR DESCRIPTION
Partially done, fixes the minimal example given here: https://github.com/ziglang/zig/issues/11651#issuecomment-1129207386

Haven't run the full behavioral test suite, cause I compile without the LLVM backend enabled.