### PR TITLE
The first `std.mem.SplitIterator(T).next()` result is always non-`null`

### DIFF
--- a/lib/std/crypto/phc_encoding.zig
+++ b/lib/std/crypto/phc_encoding.zig
@@ -253,7 +253,7 @@ fn serializeTo(params: anytype, out: anytype) !void {
 // Split a `key=value` string into `key` and `value`
 fn kvSplit(str: []const u8) !struct { key: []const u8, value: []const u8 } {
     var it = mem.split(u8, str, kv_delimiter);
-    const key = it.next() orelse return Error.InvalidEncoding;
+    const key = it.next().?;
     const value = it.next() orelse return Error.InvalidEncoding;
     const ret = .{ .key = key, .value = value };
     return ret;

--- a/lib/std/crypto/scrypt.zig
+++ b/lib/std/crypto/scrypt.zig
@@ -289,7 +289,7 @@ const crypt_format = struct {
 
         var it = mem.split(u8, str[14..], "$");
 
-        const salt = it.next() orelse return EncodingError.InvalidEncoding;
+        const salt = it.next().?;
         if (@hasField(T, "salt")) out.salt = salt;
 
         const hash_str = it.next() orelse return EncodingError.InvalidEncoding;

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1832,7 +1832,9 @@ pub fn SplitIterator(comptime T: type) type {
 
         const Self = @This();
 
-        /// Returns a slice of the next field, or null if splitting is complete.
+        /// Returns a slice of the next field, or `null` if splitting is complete.
+        ///
+        /// Note that this is always non-`null` if `index` is also non-`null` prior to the call.
         pub fn next(self: *Self) ?[]const T {
             const start = self.index orelse return null;
             const end = if (indexOfPos(T, self.buffer, start, self.delimiter)) |delim_start| blk: {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1685,12 +1685,18 @@ test "tokenize (reset)" {
 
 /// Returns an iterator that iterates over the slices of `buffer` that
 /// are separated by bytes in `delimiter`.
-/// split(u8, "abc|def||ghi", "|")
-/// will return slices for "abc", "def", "", "ghi", null, in that order.
-/// If `delimiter` does not exist in buffer,
-/// the iterator will return `buffer`, null, in that order.
-/// The delimiter length must not be zero.
-/// See also the related function `tokenize`.
+///
+/// `split(u8, "abc|def||ghi", "|")` will return slices
+/// for "abc", "def", "", "ghi", null, in that order.
+///
+/// If `delimiter` does not exist in `buffer`,
+/// the iterator will return `buffer`, `null`, in that order.
+///
+/// Note that the result of the first `.next` call is always non-`null`.
+///
+/// Asserts that `delimiter.len != 0`.
+///
+/// See also: `tokenize`.
 pub fn split(comptime T: type, buffer: []const T, delimiter: []const T) SplitIterator(T) {
     assert(delimiter.len != 0);
     return .{

--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -64,10 +64,7 @@ pub const LibCInstallation = struct {
         while (it.next()) |line| {
             if (line.len == 0 or line[0] == '#') continue;
             var line_it = std.mem.split(u8, line, "=");
-            const name = line_it.next() orelse {
-                log.err("missing equal sign after field name\n", .{});
-                return error.ParseError;
-            };
+            const name = line_it.next().?;
             const value = line_it.rest();
             inline for (fields) |field, i| {
                 if (std.mem.eql(u8, name, field.name)) {

--- a/src/test.zig
+++ b/src/test.zig
@@ -278,7 +278,7 @@ const TestManifest = struct {
 
             // Parse key=value(s)
             var kv_it = std.mem.split(u8, trimmed, "=");
-            const key = kv_it.next() orelse return error.MissingKeyForConfig;
+            const key = kv_it.next().?;
             try manifest.config_map.putNoClobber(key, kv_it.next() orelse return error.MissingValuesForConfig);
         }
 
@@ -654,7 +654,7 @@ pub const TestContext = struct {
                 }
                 // example: "file.zig:1:2: error: bad thing happened"
                 var it = std.mem.split(u8, err_msg_line, ":");
-                const src_path = it.next() orelse @panic("missing colon");
+                const src_path = it.next().?;
                 const line_text = it.next() orelse @panic("missing line");
                 const col_text = it.next() orelse @panic("missing column");
                 const kind_text = it.next() orelse @panic("missing 'error'/'note'");

--- a/tools/update_spirv_features.zig
+++ b/tools/update_spirv_features.zig
@@ -21,7 +21,7 @@ const Version = struct {
     fn parse(str: []const u8) !Version {
         var it = std.mem.split(u8, str, ".");
 
-        const major = it.next() orelse return error.InvalidVersion;
+        const major = it.next().?;
         const minor = it.next() orelse return error.InvalidVersion;
 
         if (it.next() != null) return error.InvalidVersion;


### PR DESCRIPTION
I observed that the first `next()` call on an `std.mem.SplitIterator(T)` is always non-`null`.
I explicitly mentioned that in the docs and changed many `next()` calls to `next().?` in various places.
These `next().?`s will never panic.