### PR TITLE
test: put stage2 on passing safety test-cases manifest

### DIFF
--- a/test/cases/safety/@intCast to u0.zig
+++ b/test/cases/safety/@intCast to u0.zig
@@ -16,5 +16,5 @@ fn bar(one: u1, not_zero: i32) void {
     _ = x;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/@intToPtr address zero to non-optional byte-aligned pointer.zig
+++ b/test/cases/safety/@intToPtr address zero to non-optional byte-aligned pointer.zig
@@ -12,5 +12,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/@intToPtr address zero to non-optional pointer.zig
+++ b/test/cases/safety/@intToPtr address zero to non-optional pointer.zig
@@ -12,5 +12,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/@tagName on corrupted enum value.zig
+++ b/test/cases/safety/@tagName on corrupted enum value.zig
@@ -21,5 +21,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/calling panic.zig
+++ b/test/cases/safety/calling panic.zig
@@ -12,5 +12,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/intToPtr with misaligned address.zig
+++ b/test/cases/safety/intToPtr with misaligned address.zig
@@ -14,5 +14,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/integer addition overflow.zig
+++ b/test/cases/safety/integer addition overflow.zig
@@ -19,5 +19,5 @@ fn add(a: u16, b: u16) u16 {
 }
 
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/integer multiplication overflow.zig
+++ b/test/cases/safety/integer multiplication overflow.zig
@@ -15,5 +15,5 @@ fn mul(a: u16, b: u16) u16 {
     return a * b;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/integer negation overflow.zig
+++ b/test/cases/safety/integer negation overflow.zig
@@ -15,5 +15,5 @@ fn neg(a: i16) i16 {
     return -a;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/integer subtraction overflow.zig
+++ b/test/cases/safety/integer subtraction overflow.zig
@@ -15,5 +15,5 @@ fn sub(a: u16, b: u16) u16 {
     return a - b;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/optional unwrap operator on C pointer.zig
+++ b/test/cases/safety/optional unwrap operator on C pointer.zig
@@ -12,5 +12,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/optional unwrap operator on null pointer.zig
+++ b/test/cases/safety/optional unwrap operator on null pointer.zig
@@ -12,5 +12,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/out of bounds slice access.zig
+++ b/test/cases/safety/out of bounds slice access.zig
@@ -6,14 +6,14 @@ pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace) noretur
     std.process.exit(0);
 }
 pub fn main() !void {
-    const a = [_]i32{1, 2, 3, 4};
+    const a = [_]i32{ 1, 2, 3, 4 };
     baz(bar(&a));
     return error.TestFailed;
 }
 fn bar(a: []const i32) i32 {
     return a[4];
 }
-fn baz(_: i32) void { }
+fn baz(_: i32) void {}
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/signed integer not fitting in cast to unsigned integer - widening.zig
+++ b/test/cases/safety/signed integer not fitting in cast to unsigned integer - widening.zig
@@ -12,5 +12,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/signed integer not fitting in cast to unsigned integer.zig
+++ b/test/cases/safety/signed integer not fitting in cast to unsigned integer.zig
@@ -15,5 +15,5 @@ fn unsigned_cast(x: i32) u32 {
     return @intCast(u32, x);
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/signed shift left overflow.zig
+++ b/test/cases/safety/signed shift left overflow.zig
@@ -15,5 +15,5 @@ fn shl(a: i16, b: u4) i16 {
     return @shlExact(a, b);
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/truncating vector cast.zig
+++ b/test/cases/safety/truncating vector cast.zig
@@ -16,5 +16,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/unsigned integer not fitting in cast to signed integer - same bit count.zig
+++ b/test/cases/safety/unsigned integer not fitting in cast to signed integer - same bit count.zig
@@ -12,5 +12,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/unsigned shift left overflow.zig
+++ b/test/cases/safety/unsigned shift left overflow.zig
@@ -15,5 +15,5 @@ fn shl(a: u16, b: u4) u16 {
     return @shlExact(a, b);
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/unsigned-signed vector cast.zig
+++ b/test/cases/safety/unsigned-signed vector cast.zig
@@ -16,5 +16,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/unwrap error.zig
+++ b/test/cases/safety/unwrap error.zig
@@ -15,5 +15,5 @@ fn bar() !void {
     return error.Whatever;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/value does not fit in shortening cast - u0.zig
+++ b/test/cases/safety/value does not fit in shortening cast - u0.zig
@@ -15,5 +15,5 @@ fn shorten_cast(x: u8) u0 {
     return @intCast(u0, x);
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/value does not fit in shortening cast.zig
+++ b/test/cases/safety/value does not fit in shortening cast.zig
@@ -15,5 +15,5 @@ fn shorten_cast(x: i32) i8 {
     return @intCast(i8, x);
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/vector integer addition overflow.zig
+++ b/test/cases/safety/vector integer addition overflow.zig
@@ -16,5 +16,5 @@ fn add(a: @Vector(4, i32), b: @Vector(4, i32)) @Vector(4, i32) {
     return a + b;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/vector integer multiplication overflow.zig
+++ b/test/cases/safety/vector integer multiplication overflow.zig
@@ -16,5 +16,5 @@ fn mul(a: @Vector(4, u8), b: @Vector(4, u8)) @Vector(4, u8) {
     return a * b;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/vector integer negation overflow.zig
+++ b/test/cases/safety/vector integer negation overflow.zig
@@ -15,5 +15,5 @@ fn neg(a: @Vector(4, i16)) @Vector(4, i16) {
     return -a;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native

--- a/test/cases/safety/vector integer subtraction overflow.zig
+++ b/test/cases/safety/vector integer subtraction overflow.zig
@@ -16,5 +16,5 @@ fn sub(a: @Vector(4, u32), b: @Vector(4, u32)) @Vector(4, u32) {
     return a - b;
 }
 // run
-// backend=stage1
+// backend=stage1,stage2
 // target=native


### PR DESCRIPTION
@andrewrk 
as i mentioned in discord stage2 has some bugs and currently we can't run test-cases
so i didn't added it to CI. for now it may be more reasonable to create an issue for that?
<details>

```
$ stage2/bin/zig build test-cases
```
```zig
/home/ali/dev/zig/src/test.zig:317:26: error: unable to resolve comptime value
    ) error{OutOfMemory}![]const T {
                         ^
/home/ali/dev/zig/src/test.zig:317:26: error: unable to resolve comptime value
    ) error{OutOfMemory}![]const T {
                         ^
/home/ali/dev/zig/src/test.zig:309:49: error: unable to resolve comptime value
        return self.getConfigForKeyCustomParser(key, T, getDefaultParser(T));
                                                ^
/home/ali/dev/zig/src/test.zig:309:49: error: unable to resolve comptime value
        return self.getConfigForKeyCustomParser(key, T, getDefaultParser(T));
                                                ^
test...The following command exited with error code 1:
/home/ali/dev/zig/stage2/bin/zig test /home/ali/dev/zig/src/test.zig --cache-dir /home/ali/dev/zig/zig-cache --global-cache-dir /home/ali/.cache/zig --name test --pkg-begin test_cases /home/ali/dev/zig/test/cases.zig --pkg-end --pkg-begin build_options /home/ali/dev/zig/zig-cache/options/yMPpTYrJ9DFzBrZ-c9tGaMh9YVXUmpbX3z9VuPH_PJZkDcmdSutrhe_lHhdEcE-a --pkg-end --enable-cache
```

</details>