### PR TITLE
Autodoc: handling sentinel

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1130,17 +1130,20 @@ var zigAnalysis;
                   default: throw "TODO";
                   case typeKinds.Array:
                   {
-                      let arrayObj = /** @type {ArrayType} */(typeObj);
-                      let name = "[";
-                      let lenName = exprName(arrayObj.len, opts);
-                      if (opts.wantHtml) {
-                          name += '<span class="tok-number">' + lenName + '</span>';
-                      } else {
-                          name += lenName;
-                      }
-                      name += "]";
-                      name += exprName(arrayObj.child, opts);
-                      return name;
+                    let arrayObj = /** @type {ArrayType} */ (typeObj);
+                    let name = "[";
+                    let lenName = exprName(arrayObj.len, opts);
+                    let sentinel = arrayObj.sentinel !== null ? ":"+arrayObj.sentinel : "";
+
+                    if (opts.wantHtml) {
+                      name +=
+                        '<span class="tok-number">' + lenName + sentinel + "</span>";
+                    } else {
+                      name += lenName;
+                    }
+                    name += "]";
+                    name += exprName(arrayObj.child, opts);
+                    return name;
                   }
                   case typeKinds.Optional:
                       return "?" + exprName(/**@type {OptionalType} */(typeObj).child, opts);

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1133,13 +1133,13 @@ var zigAnalysis;
                     let arrayObj = /** @type {ArrayType} */ (typeObj);
                     let name = "[";
                     let lenName = exprName(arrayObj.len, opts);
-                    let sentinel = arrayObj.sentinel !== null ? ":"+arrayObj.sentinel : "";
+                    let sentinel = arrayObj.sentinel ? ":0" : "";
 
                     if (opts.wantHtml) {
                       name +=
                         '<span class="tok-number">' + lenName + sentinel + "</span>";
                     } else {
-                      name += lenName;
+                      name += lenName + sentinel;
                     }
                     name += "]";
                     name += exprName(arrayObj.child, opts);
@@ -1150,6 +1150,7 @@ var zigAnalysis;
                   case typeKinds.Pointer:
                   {
                       let ptrObj = /** @type {PointerType} */(typeObj);
+                      let sentinel = ptrObj.sentinel ? ":0" : "";
                       let name = "";
                       switch (ptrObj.size) {
                           default:
@@ -1158,13 +1159,19 @@ var zigAnalysis;
                               name += "*";
                               break;
                           case pointerSizeEnum.Many:
-                              name += "[*]";
+                              name += "[*";
+                              name += sentinel;
+                              name += "]";
                               break;
                           case pointerSizeEnum.Slice:
-                              name += "[]";
+                              name += "[";
+                              name += sentinel;
+                              name += "]";
                               break;
                           case pointerSizeEnum.C:
-                              name += "[*c]";
+                              name += "[*c";
+                              name += sentinel;
+                              name += "]";
                               break;
                       }
                       if (ptrObj['const']) {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1134,6 +1134,7 @@ var zigAnalysis;
                     let name = "[";
                     let lenName = exprName(arrayObj.len, opts);
                     let sentinel = arrayObj.sentinel ? ":0" : "";
+                    let is_mutable = arrayObj.is_multable ? "const " : "";
 
                     if (opts.wantHtml) {
                       name +=
@@ -1142,6 +1143,7 @@ var zigAnalysis;
                       name += lenName + sentinel;
                     }
                     name += "]";
+                    name += is_mutable;
                     name += exprName(arrayObj.child, opts);
                     return name;
                   }
@@ -1151,27 +1153,32 @@ var zigAnalysis;
                   {
                       let ptrObj = /** @type {PointerType} */(typeObj);
                       let sentinel = ptrObj.sentinel ? ":0" : "";
+                      let is_mutable = !ptrObj.is_mutable ? "const " : "";
                       let name = "";
                       switch (ptrObj.size) {
                           default:
                               console.log("TODO: implement unhandled pointer size case");
                           case pointerSizeEnum.One:
                               name += "*";
+                              name += is_mutable;
                               break;
                           case pointerSizeEnum.Many:
                               name += "[*";
                               name += sentinel;
                               name += "]";
+                              name += is_mutable;
                               break;
                           case pointerSizeEnum.Slice:
                               name += "[";
                               name += sentinel;
                               name += "]";
+                              name += is_mutable;
                               break;
                           case pointerSizeEnum.C:
                               name += "[*c";
                               name += sentinel;
                               name += "]";
+                              name += is_mutable;
                               break;
                       }
                       if (ptrObj['const']) {

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -383,12 +383,12 @@ const DocData = struct {
         Pointer: struct {
             size: std.builtin.TypeInfo.Pointer.Size,
             child: Expr,
-            sentinel: ?usize = null,
+            sentinel: bool = false,
         },
         Array: struct {
             len: Expr,
             child: Expr,
-            sentinel: ?usize = null,
+            sentinel: bool = false,
         },
         Struct: struct {
             name: []const u8,
@@ -767,7 +767,7 @@ fn walkInstruction(
                     .Pointer = .{
                         .size = .One,
                         .child = .{ .type = arrTypeId },
-                        .sentinel = 0,
+                        .sentinel = true,
                         // TODO: add sentinel!
                     },
                 });
@@ -851,7 +851,7 @@ fn walkInstruction(
             const ptr = data[inst_index].ptr_type;
             const extra = file.zir.extraData(Zir.Inst.PtrType, ptr.payload_index);
 
-            const sentinel: ?usize = if (ptr.flags.has_sentinel) 0 else null;
+            const sentinel: bool = if (ptr.flags.has_sentinel) true else false;
 
             const type_slot_index = self.types.items.len;
             const elem_type_ref = try self.walkRef(
@@ -903,7 +903,7 @@ fn walkInstruction(
                 .Array = .{
                     .len = len.expr,
                     .child = elem_type.expr,
-                    .sentinel = 0,
+                    .sentinel = true,
                 },
             });
             return DocData.WalkResult{
@@ -982,7 +982,7 @@ fn walkInstruction(
                         .value = operands.len,
                         .negated = false,
                     },
-                }, .child = array_type.?, .sentinel = 0 },
+                }, .child = array_type.?, .sentinel = true },
             });
 
             return DocData.WalkResult{
@@ -1090,7 +1090,7 @@ fn walkInstruction(
                         .value = operands.len,
                         .negated = false,
                     },
-                }, .child = array_type.?, .sentinel = 0 },
+                }, .child = array_type.?, .sentinel = true },
             });
 
             return DocData.WalkResult{
@@ -1312,6 +1312,7 @@ fn walkInstruction(
             try self.types.append(self.arena, .{
                 .Int = .{ .name = name },
             });
+
             return DocData.WalkResult{
                 .typeRef = .{ .type = @enumToInt(Ref.type_type) },
                 .expr = .{ .type = self.types.items.len - 1 },

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -1007,22 +1007,16 @@ fn walkInstruction(
                 // we only ask to figure out type info for the first element
                 // as it will be used later on to find out the array type!
                 const wr = try self.walkRef(file, parent_scope, op, idx == 0);
-
                 if (idx == 0) {
                     array_type = wr.typeRef;
                 }
 
-                // create an untion to hold more than one type
-                switch (@intToEnum(Ref, wr.typeRef.?.type)) {
-                    .comptime_int_type => {
-                        array_data[idx] = wr.expr.int.value;
-                    },
-                    .comptime_float_type => {
-                        unreachable;
-                        // array_data[idx] = wr.expr.float;
-                    },
-                    else => continue,
-                }
+                // array_init_anon doesn't have the elements in @as nodes
+                // so it's necessary append them to expr array
+                // and remember their positions
+                const expr_index = self.exprs.items.len;
+                try self.exprs.append(self.arena, wr.expr);
+                array_data[idx] = expr_index;
             }
 
             const type_slot_index = self.types.items.len;


### PR DESCRIPTION
Currently handling the following code with some exceptions. 
Implementation are not fully finished there are some known issues and in some cases node still rendered as `@as` node.
```zig
const array_type: [4]u8 = undefined;
const ptr_type_simple: []u8 = undefined;
const ptr_type: [:0]u8 = undefined;
const array_init_anon = .{ 1, 2, 3 };
const array_type_and_array_init2 = [_]u8{ 1, 2, 3 };
const array_type_sentinel_and_array_init_sent = [_:0]u8{ 1, 2, 3 };
const ptr_type_simple_and_array_init_anon: [*]u8 = .{ 1, 2, 3 };
const ptr_type_and_array_init_anon: [*:0]u8 = .{ 1, 2, 3 };
const ptr_type_simple_and_array_type_and_array_init_anon: *[3]u8 = .{ 1, 2, 3 };
const ptr_type_simple_anon_init: []const u8 = .{ 1, 2, 3 };
const array_2d_anon = .{ .{ 1, 2, 3 }, .{ 2, 1, 3 }, .{ 2, 3, 1 } };
const array_2d_with_types: [][]u8 = .{ .{ 1, 2, 3 }, .{ 2, 1, 3 }, .{ 2, 3, 1 } };
const array_2d_with_types_with_sentinel: [][:0]u8 = .{ .{ 1, 2, 3 }, .{ 2, 1, 3 }, .{ 2, 3, 1 } };
const array_to_much_to_write = []u8{[]u8{ 1, 2, 3 }};

const array_init_ref = &[]u8{ 1, 2, 3 };
const array_init_anon_ref = &.{ 1, 2 };
const array_init_sent_ref = &[_:0]u8{ 1, 2, 3 };

const string_1: []const u8 = "string";
const string_2 = "string";
const string_slice_1: []const u8 = .{ "string", "string1" };
const string_slice_2 = []const u8{ "string", "string1" };

const array_const: []const u8 = .{ 1, 2, 3 };
const array_many_const: [*]const u8 = undefined;
const array_many_const_sentinel: [*:0]const u8 = undefined;

fn fun(a: []u8, b: []const u8) void {
    _ = a;
    _ = b;
}

fn fun2(comptime a: []const type, b: [4:0]u8, c: [*:0]u8) void {
    _ = a;
    _ = b;
    _ = c;
}

fn fun3(a: [*:0]const u8) void {
    _ = a;
}

// not working as expected

const array_type_and_array_init = [3]u8{ 1, 2, 3 }; // current buggy, rendering [3][3]u8
const array_type_sentinel_and_array_init = [3:0]u8{ 1, 2, 3 }; // current buggy, rendering [3][3]u8

const array_2d_with_one_slice_size_known = []u8{[3]u8{ 1, 2, 3 }}; // not showing the second length
const array_2d_with_slice_unk = []u8{[]u8{ 1, 2, 3 }}; // not showing the second length
const array_2d: [][]u8 = .{.{ 1, 2, 3 }}; // not showing the second length

const array_2d_anon_float = .{.{ 1.0, 2.0, 3.0 }}; // not showing data but it's in json
const array_2d_with_types_float: [][]f32 = .{.{ 1.0, 2.0, 3.0 }}; // not showing data but it's in json
const array_multi_types = .{ 1.0, 2, 3 }; // not showing data but it's in json

const string_slice_not_working = .{ "string", "string1" }; // showing the larger array size

fn funNotWorking1(a: [][]u8) void {
    _ = a;
}

fn funNotWorking2(a: [][]const u8) void {
    _ = a;
}

fn funNotWorking3(a: *[]const u8) void {
    _ = a;
}

const struct_working = struct {
    one: []u8,
    two: []const u8,
    three: [*]const u8,
    four: [*:0]const u8,
};
const struct_not_working = struct {
    one: *[]u8, // not working
    two: *[]const u8, // not working
    three: *[]u8, // not working
    four: [][]u8, // not working
};

```