### PR TITLE
stage2: fixes for error union semantics

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1798,7 +1798,7 @@ fn resetSegfaultHandler() void {
         .mask = os.empty_sigset,
         .flags = 0,
     };
-    // do nothing if an error happens to avoid a double-panic
+    // To avoid a double-panic, do nothing if an error happens here.
     updateSegfaultHandler(&act) catch {};
 }
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -23316,7 +23316,6 @@ pub fn typeHasOnePossibleValue(
         .const_slice,
         .mut_slice,
         .anyopaque,
-        .optional,
         .optional_single_mut_pointer,
         .optional_single_const_pointer,
         .enum_literal,
@@ -23350,6 +23349,16 @@ pub fn typeHasOnePossibleValue(
         .pointer,
         .bound_fn,
         => return null,
+
+        .optional => {
+            var buf: Type.Payload.ElemType = undefined;
+            const child_ty = ty.optionalChild(&buf);
+            if (child_ty.isNoReturn()) {
+                return Value.@"null";
+            } else {
+                return null;
+            }
+        },
 
         .error_set_single => {
             const name = ty.castTag(.error_set_single).?.data;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5899,12 +5899,22 @@ fn zirErrorToInt(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
         if (val.isUndef()) {
             return sema.addConstUndef(result_ty);
         }
-        const payload = try sema.arena.create(Value.Payload.U64);
-        payload.* = .{
-            .base = .{ .tag = .int_u64 },
-            .data = (try sema.mod.getErrorValue(val.castTag(.@"error").?.data.name)).value,
-        };
-        return sema.addConstant(result_ty, Value.initPayload(&payload.base));
+        switch (val.tag()) {
+            .@"error" => {
+                const payload = try sema.arena.create(Value.Payload.U64);
+                payload.* = .{
+                    .base = .{ .tag = .int_u64 },
+                    .data = (try sema.mod.getErrorValue(val.castTag(.@"error").?.data.name)).value,
+                };
+                return sema.addConstant(result_ty, Value.initPayload(&payload.base));
+            },
+
+            // This is not a valid combination with the type `anyerror`.
+            .the_only_possible_value => unreachable,
+
+            // Assume it's already encoded as an integer.
+            else => return sema.addConstant(result_ty, val),
+        }
     }
 
     try sema.requireRuntimeBlock(block, src);
@@ -6261,19 +6271,24 @@ fn zirErrUnionPayload(
         });
     }
 
+    const result_ty = operand_ty.errorUnionPayload();
     if (try sema.resolveDefinedValue(block, src, operand)) |val| {
         if (val.getError()) |name| {
             return sema.fail(block, src, "caught unexpected error '{s}'", .{name});
         }
         const data = val.castTag(.eu_payload).?.data;
-        const result_ty = operand_ty.errorUnionPayload();
         return sema.addConstant(result_ty, data);
     }
+
     try sema.requireRuntimeBlock(block, src);
-    if (safety_check and block.wantSafety()) {
+
+    // If the error set has no fields then no safety check is needed.
+    if (safety_check and block.wantSafety() and
+        operand_ty.errorUnionSet().errorSetCardinality() != .zero)
+    {
         try sema.panicUnwrapError(block, src, operand, .unwrap_errunion_err, .is_non_err);
     }
-    const result_ty = operand_ty.errorUnionPayload();
+
     return block.addTyOp(.unwrap_errunion_payload, result_ty, operand);
 }
 
@@ -6311,7 +6326,8 @@ fn analyzeErrUnionPayloadPtr(
         });
     }
 
-    const payload_ty = operand_ty.elemType().errorUnionPayload();
+    const err_union_ty = operand_ty.elemType();
+    const payload_ty = err_union_ty.errorUnionPayload();
     const operand_pointer_ty = try Type.ptr(sema.arena, sema.mod, .{
         .pointee_type = payload_ty,
         .mutable = !operand_ty.isConstPtr(),
@@ -6351,9 +6367,14 @@ fn analyzeErrUnionPayloadPtr(
     }
 
     try sema.requireRuntimeBlock(block, src);
-    if (safety_check and block.wantSafety()) {
+
+    // If the error set has no fields then no safety check is needed.
+    if (safety_check and block.wantSafety() and
+        err_union_ty.errorUnionSet().errorSetCardinality() != .zero)
+    {
         try sema.panicUnwrapError(block, src, operand, .unwrap_errunion_err_ptr, .is_non_err_ptr);
     }
+
     const air_tag: Air.Inst.Tag = if (initializing)
         .errunion_payload_ptr_set
     else
@@ -23301,10 +23322,7 @@ pub fn typeHasOnePossibleValue(
         .enum_literal,
         .anyerror_void_error_union,
         .error_union,
-        .error_set,
-        .error_set_single,
         .error_set_inferred,
-        .error_set_merged,
         .@"opaque",
         .var_args_param,
         .manyptr_u8,
@@ -23332,6 +23350,23 @@ pub fn typeHasOnePossibleValue(
         .pointer,
         .bound_fn,
         => return null,
+
+        .error_set_single => {
+            const name = ty.castTag(.error_set_single).?.data;
+            return try Value.Tag.@"error".create(sema.arena, .{ .name = name });
+        },
+        .error_set => {
+            const err_set_obj = ty.castTag(.error_set).?.data;
+            const names = err_set_obj.names.keys();
+            if (names.len > 1) return null;
+            return try Value.Tag.@"error".create(sema.arena, .{ .name = names[0] });
+        },
+        .error_set_merged => {
+            const name_map = ty.castTag(.error_set_merged).?.data;
+            const names = name_map.keys();
+            if (names.len > 1) return null;
+            return try Value.Tag.@"error".create(sema.arena, .{ .name = names[0] });
+        },
 
         .@"struct" => {
             const resolved_ty = try sema.resolveTypeFields(block, src, ty);

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -20950,6 +20950,11 @@ fn analyzeLoad(
         .Pointer => ptr_ty.childType(),
         else => return sema.fail(block, ptr_src, "expected pointer, found '{}'", .{ptr_ty.fmt(sema.mod)}),
     };
+
+    if (try sema.typeHasOnePossibleValue(block, src, elem_ty)) |opv| {
+        return sema.addConstant(elem_ty, opv);
+    }
+
     if (try sema.resolveDefinedValue(block, ptr_src, ptr)) |ptr_val| {
         if (try sema.pointerDeref(block, ptr_src, ptr_val, ptr_ty)) |elem_val| {
             return sema.addConstant(elem_ty, elem_val);

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const mem = std.mem;
 const math = std.math;
 const assert = std.debug.assert;
+const codegen = @import("../../codegen.zig");
 const Air = @import("../../Air.zig");
 const Mir = @import("Mir.zig");
 const Emit = @import("Emit.zig");
@@ -22,12 +23,14 @@ const leb128 = std.leb;
 const log = std.log.scoped(.codegen);
 const build_options = @import("build_options");
 
-const GenerateSymbolError = @import("../../codegen.zig").GenerateSymbolError;
-const FnResult = @import("../../codegen.zig").FnResult;
-const DebugInfoOutput = @import("../../codegen.zig").DebugInfoOutput;
+const GenerateSymbolError = codegen.GenerateSymbolError;
+const FnResult = codegen.FnResult;
+const DebugInfoOutput = codegen.DebugInfoOutput;
 
 const bits = @import("bits.zig");
 const abi = @import("abi.zig");
+const errUnionPayloadOffset = codegen.errUnionPayloadOffset;
+const errUnionErrOffset = codegen.errUnionErrOffset;
 const RegisterManager = abi.RegisterManager;
 const RegisterLock = RegisterManager.RegisterLock;
 const Register = bits.Register;
@@ -3272,7 +3275,14 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallOptions.
 
 fn ret(self: *Self, mcv: MCValue) !void {
     const ret_ty = self.fn_type.fnReturnType();
-    try self.setRegOrMem(ret_ty, self.ret_mcv, mcv);
+    switch (self.ret_mcv) {
+        .immediate => {
+            assert(ret_ty.isError());
+        },
+        else => {
+            try self.setRegOrMem(ret_ty, self.ret_mcv, mcv);
+        },
+    }
     // Just add space for an instruction, patch this later
     const index = try self.addInst(.{
         .tag = .nop,
@@ -3601,30 +3611,39 @@ fn isErr(self: *Self, ty: Type, operand: MCValue) !MCValue {
     const error_type = ty.errorUnionSet();
     const payload_type = ty.errorUnionPayload();
 
-    if (!error_type.hasRuntimeBits()) {
+    if (error_type.errorSetCardinality() == .zero) {
         return MCValue{ .immediate = 0 }; // always false
-    } else if (!payload_type.hasRuntimeBits()) {
-        if (error_type.abiSize(self.target.*) <= 8) {
-            const reg_mcv: MCValue = switch (operand) {
-                .register => operand,
-                else => .{ .register = try self.copyToTmpRegister(error_type, operand) },
-            };
+    }
 
+    const err_off = errUnionErrOffset(ty, self.target.*);
+    switch (operand) {
+        .stack_offset => |off| {
+            const offset = off - @intCast(u32, err_off);
+            const tmp_reg = try self.copyToTmpRegister(Type.anyerror, .{ .stack_offset = offset });
             _ = try self.addInst(.{
                 .tag = .cmp_immediate,
                 .data = .{ .r_imm12_sh = .{
-                    .rn = reg_mcv.register,
+                    .rn = tmp_reg,
                     .imm12 = 0,
                 } },
             });
-
-            return MCValue{ .compare_flags_unsigned = .gt };
-        } else {
-            return self.fail("TODO isErr for errors with size > 8", .{});
-        }
-    } else {
-        return self.fail("TODO isErr for non-empty payloads", .{});
+        },
+        .register => |reg| {
+            if (err_off > 0 or payload_type.hasRuntimeBitsIgnoreComptime()) {
+                return self.fail("TODO implement isErr for register operand with payload bits", .{});
+            }
+            _ = try self.addInst(.{
+                .tag = .cmp_immediate,
+                .data = .{ .r_imm12_sh = .{
+                    .rn = reg,
+                    .imm12 = 0,
+                } },
+            });
+        },
+        else => return self.fail("TODO implement isErr for {}", .{operand}),
     }
+
+    return MCValue{ .compare_flags_unsigned = .gt };
 }
 
 fn isNonErr(self: *Self, ty: Type, operand: MCValue) !MCValue {
@@ -4483,7 +4502,7 @@ fn resolveInst(self: *Self, inst: Air.Inst.Ref) InnerError!MCValue {
     const ref_int = @enumToInt(inst);
     if (ref_int < Air.Inst.Ref.typed_value_map.len) {
         const tv = Air.Inst.Ref.typed_value_map[ref_int];
-        if (!tv.ty.hasRuntimeBits()) {
+        if (!tv.ty.hasRuntimeBitsIgnoreComptime() and !tv.ty.isError()) {
             return MCValue{ .none = {} };
         }
         return self.genTypedValue(tv);
@@ -4491,7 +4510,7 @@ fn resolveInst(self: *Self, inst: Air.Inst.Ref) InnerError!MCValue {
 
     // If the type has no codegen bits, no need to store it.
     const inst_ty = self.air.typeOf(inst);
-    if (!inst_ty.hasRuntimeBits())
+    if (!inst_ty.hasRuntimeBitsIgnoreComptime() and !inst_ty.isError())
         return MCValue{ .none = {} };
 
     const inst_index = @intCast(Air.Inst.Index, ref_int - Air.Inst.Ref.typed_value_map.len);
@@ -4674,32 +4693,38 @@ fn genTypedValue(self: *Self, typed_value: TypedValue) InnerError!MCValue {
             }
         },
         .ErrorSet => {
-            const err_name = typed_value.val.castTag(.@"error").?.data.name;
-            const module = self.bin_file.options.module.?;
-            const global_error_set = module.global_error_set;
-            const error_index = global_error_set.get(err_name).?;
-            return MCValue{ .immediate = error_index };
+            switch (typed_value.val.tag()) {
+                .@"error" => {
+                    const err_name = typed_value.val.castTag(.@"error").?.data.name;
+                    const module = self.bin_file.options.module.?;
+                    const global_error_set = module.global_error_set;
+                    const error_index = global_error_set.get(err_name).?;
+                    return MCValue{ .immediate = error_index };
+                },
+                else => {
+                    // In this case we are rendering an error union which has a 0 bits payload.
+                    return MCValue{ .immediate = 0 };
+                },
+            }
         },
         .ErrorUnion => {
             const error_type = typed_value.ty.errorUnionSet();
             const payload_type = typed_value.ty.errorUnionPayload();
 
-            if (typed_value.val.castTag(.eu_payload)) |pl| {
-                if (!payload_type.hasRuntimeBits()) {
-                    // We use the error type directly as the type.
-                    return MCValue{ .immediate = 0 };
-                }
-
-                _ = pl;
-                return self.fail("TODO implement error union const of type '{}' (non-error)", .{typed_value.ty.fmtDebug()});
-            } else {
-                if (!payload_type.hasRuntimeBits()) {
-                    // We use the error type directly as the type.
-                    return self.genTypedValue(.{ .ty = error_type, .val = typed_value.val });
-                }
-
-                return self.fail("TODO implement error union const of type '{}' (error)", .{typed_value.ty.fmtDebug()});
+            if (error_type.errorSetCardinality() == .zero) {
+                const payload_val = typed_value.val.castTag(.eu_payload).?.data;
+                return self.genTypedValue(.{ .ty = payload_type, .val = payload_val });
             }
+
+            const is_pl = typed_value.val.errorUnionIsPayload();
+
+            if (!payload_type.hasRuntimeBitsIgnoreComptime()) {
+                // We use the error type directly as the type.
+                const err_val = if (!is_pl) typed_value.val else Value.initTag(.zero);
+                return self.genTypedValue(.{ .ty = error_type, .val = err_val });
+            }
+
+            return self.lowerUnnamedConst(typed_value);
         },
         .Struct => {
             return self.lowerUnnamedConst(typed_value);
@@ -4796,13 +4821,16 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
 
     if (ret_ty.zigTypeTag() == .NoReturn) {
         result.return_value = .{ .unreach = {} };
-    } else if (!ret_ty.hasRuntimeBits()) {
+    } else if (!ret_ty.hasRuntimeBitsIgnoreComptime() and !ret_ty.isError()) {
         result.return_value = .{ .none = {} };
     } else switch (cc) {
         .Naked => unreachable,
         .Unspecified, .C => {
             const ret_ty_size = @intCast(u32, ret_ty.abiSize(self.target.*));
-            if (ret_ty_size <= 8) {
+            if (ret_ty_size == 0) {
+                assert(ret_ty.isError());
+                result.return_value = .{ .immediate = 0 };
+            } else if (ret_ty_size <= 8) {
                 result.return_value = .{ .register = registerAlias(c_abi_int_return_regs[0], ret_ty_size) };
             } else {
                 return self.fail("TODO support more return types for ARM backend", .{});

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -30,7 +30,7 @@ const DebugInfoOutput = codegen.DebugInfoOutput;
 const bits = @import("bits.zig");
 const abi = @import("abi.zig");
 const errUnionPayloadOffset = codegen.errUnionPayloadOffset;
-const errUnionErrOffset = codegen.errUnionErrOffset;
+const errUnionErrorOffset = codegen.errUnionErrorOffset;
 const RegisterManager = abi.RegisterManager;
 const RegisterLock = RegisterManager.RegisterLock;
 const Register = bits.Register;
@@ -3615,7 +3615,7 @@ fn isErr(self: *Self, ty: Type, operand: MCValue) !MCValue {
         return MCValue{ .immediate = 0 }; // always false
     }
 
-    const err_off = errUnionErrOffset(ty, self.target.*);
+    const err_off = errUnionErrorOffset(payload_type, self.target.*);
     switch (operand) {
         .stack_offset => |off| {
             const offset = off - @intCast(u32, err_off);

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -30,7 +30,7 @@ const DebugInfoOutput = codegen.DebugInfoOutput;
 const bits = @import("bits.zig");
 const abi = @import("abi.zig");
 const errUnionPayloadOffset = codegen.errUnionPayloadOffset;
-const errUnionErrOffset = codegen.errUnionErrOffset;
+const errUnionErrorOffset = codegen.errUnionErrorOffset;
 const RegisterManager = abi.RegisterManager;
 const RegisterLock = RegisterManager.RegisterLock;
 const Register = bits.Register;
@@ -1775,7 +1775,7 @@ fn errUnionErr(self: *Self, error_union_mcv: MCValue, error_union_ty: Type) !MCV
         return error_union_mcv;
     }
 
-    const err_offset = @intCast(u32, errUnionErrOffset(error_union_ty, self.target.*));
+    const err_offset = @intCast(u32, errUnionErrorOffset(payload_ty, self.target.*));
     switch (error_union_mcv) {
         .register => return self.fail("TODO errUnionErr for registers", .{}),
         .stack_argument_offset => |off| {
@@ -1812,7 +1812,7 @@ fn errUnionPayload(self: *Self, error_union_mcv: MCValue, error_union_ty: Type) 
         return MCValue.none;
     }
 
-    const payload_offset = @intCast(u32, errUnionPayloadOffset(error_union_ty, self.target.*));
+    const payload_offset = @intCast(u32, errUnionPayloadOffset(payload_ty, self.target.*));
     switch (error_union_mcv) {
         .register => return self.fail("TODO errUnionPayload for registers", .{}),
         .stack_argument_offset => |off| {

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const mem = std.mem;
 const math = std.math;
 const assert = std.debug.assert;
+const codegen = @import("../../codegen.zig");
 const Air = @import("../../Air.zig");
 const Mir = @import("Mir.zig");
 const Emit = @import("Emit.zig");
@@ -22,12 +23,14 @@ const leb128 = std.leb;
 const log = std.log.scoped(.codegen);
 const build_options = @import("build_options");
 
-const FnResult = @import("../../codegen.zig").FnResult;
-const GenerateSymbolError = @import("../../codegen.zig").GenerateSymbolError;
-const DebugInfoOutput = @import("../../codegen.zig").DebugInfoOutput;
+const FnResult = codegen.FnResult;
+const GenerateSymbolError = codegen.GenerateSymbolError;
+const DebugInfoOutput = codegen.DebugInfoOutput;
 
 const bits = @import("bits.zig");
 const abi = @import("abi.zig");
+const errUnionPayloadOffset = codegen.errUnionPayloadOffset;
+const errUnionErrOffset = codegen.errUnionErrOffset;
 const RegisterManager = abi.RegisterManager;
 const RegisterLock = RegisterManager.RegisterLock;
 const Register = bits.Register;
@@ -1763,19 +1766,26 @@ fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {
 
 /// Given an error union, returns the error
 fn errUnionErr(self: *Self, error_union_mcv: MCValue, error_union_ty: Type) !MCValue {
+    const err_ty = error_union_ty.errorUnionSet();
     const payload_ty = error_union_ty.errorUnionPayload();
-    if (!payload_ty.hasRuntimeBits()) return error_union_mcv;
+    if (err_ty.errorSetCardinality() == .zero) {
+        return MCValue{ .immediate = 0 };
+    }
+    if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
+        return error_union_mcv;
+    }
 
+    const err_offset = @intCast(u32, errUnionErrOffset(error_union_ty, self.target.*));
     switch (error_union_mcv) {
         .register => return self.fail("TODO errUnionErr for registers", .{}),
         .stack_argument_offset => |off| {
-            return MCValue{ .stack_argument_offset = off };
+            return MCValue{ .stack_argument_offset = off - err_offset };
         },
         .stack_offset => |off| {
-            return MCValue{ .stack_offset = off };
+            return MCValue{ .stack_offset = off - err_offset };
         },
         .memory => |addr| {
-            return MCValue{ .memory = addr };
+            return MCValue{ .memory = addr + err_offset };
         },
         else => unreachable, // invalid MCValue for an error union
     }
@@ -1793,24 +1803,26 @@ fn airUnwrapErrErr(self: *Self, inst: Air.Inst.Index) !void {
 
 /// Given an error union, returns the payload
 fn errUnionPayload(self: *Self, error_union_mcv: MCValue, error_union_ty: Type) !MCValue {
+    const err_ty = error_union_ty.errorUnionSet();
     const payload_ty = error_union_ty.errorUnionPayload();
-    if (!payload_ty.hasRuntimeBits()) return MCValue.none;
+    if (err_ty.errorSetCardinality() == .zero) {
+        return error_union_mcv;
+    }
+    if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
+        return MCValue.none;
+    }
 
-    const error_ty = error_union_ty.errorUnionSet();
-    const error_size = @intCast(u32, error_ty.abiSize(self.target.*));
-    const eu_align = @intCast(u32, error_union_ty.abiAlignment(self.target.*));
-    const offset = std.mem.alignForwardGeneric(u32, error_size, eu_align);
-
+    const payload_offset = @intCast(u32, errUnionPayloadOffset(error_union_ty, self.target.*));
     switch (error_union_mcv) {
         .register => return self.fail("TODO errUnionPayload for registers", .{}),
         .stack_argument_offset => |off| {
-            return MCValue{ .stack_argument_offset = off - offset };
+            return MCValue{ .stack_argument_offset = off - payload_offset };
         },
         .stack_offset => |off| {
-            return MCValue{ .stack_offset = off - offset };
+            return MCValue{ .stack_offset = off - payload_offset };
         },
         .memory => |addr| {
-            return MCValue{ .memory = addr - offset };
+            return MCValue{ .memory = addr + payload_offset };
         },
         else => unreachable, // invalid MCValue for an error union
     }
@@ -3478,6 +3490,9 @@ fn airRet(self: *Self, inst: Air.Inst.Index) !void {
 
     switch (self.ret_mcv) {
         .none => {},
+        .immediate => {
+            assert(ret_ty.isError());
+        },
         .register => |reg| {
             // Return result by value
             try self.genSetReg(ret_ty, reg, operand);
@@ -3867,7 +3882,7 @@ fn isErr(self: *Self, ty: Type, operand: MCValue) !MCValue {
     const error_type = ty.errorUnionSet();
     const error_int_type = Type.initTag(.u16);
 
-    if (!error_type.hasRuntimeBits()) {
+    if (error_type.errorSetCardinality() == .zero) {
         return MCValue{ .immediate = 0 }; // always false
     }
 
@@ -4975,7 +4990,7 @@ fn resolveInst(self: *Self, inst: Air.Inst.Ref) InnerError!MCValue {
     const ref_int = @enumToInt(inst);
     if (ref_int < Air.Inst.Ref.typed_value_map.len) {
         const tv = Air.Inst.Ref.typed_value_map[ref_int];
-        if (!tv.ty.hasRuntimeBits()) {
+        if (!tv.ty.hasRuntimeBitsIgnoreComptime() and !tv.ty.isError()) {
             return MCValue{ .none = {} };
         }
         return self.genTypedValue(tv);
@@ -4983,7 +4998,7 @@ fn resolveInst(self: *Self, inst: Air.Inst.Ref) InnerError!MCValue {
 
     // If the type has no codegen bits, no need to store it.
     const inst_ty = self.air.typeOf(inst);
-    if (!inst_ty.hasRuntimeBits())
+    if (!inst_ty.hasRuntimeBitsIgnoreComptime() and !inst_ty.isError())
         return MCValue{ .none = {} };
 
     const inst_index = @intCast(Air.Inst.Index, ref_int - Air.Inst.Ref.typed_value_map.len);
@@ -5147,26 +5162,35 @@ fn genTypedValue(self: *Self, typed_value: TypedValue) InnerError!MCValue {
             }
         },
         .ErrorSet => {
-            const err_name = typed_value.val.castTag(.@"error").?.data.name;
-            const module = self.bin_file.options.module.?;
-            const global_error_set = module.global_error_set;
-            const error_index = global_error_set.get(err_name).?;
-            return MCValue{ .immediate = error_index };
+            switch (typed_value.val.tag()) {
+                .@"error" => {
+                    const err_name = typed_value.val.castTag(.@"error").?.data.name;
+                    const module = self.bin_file.options.module.?;
+                    const global_error_set = module.global_error_set;
+                    const error_index = global_error_set.get(err_name).?;
+                    return MCValue{ .immediate = error_index };
+                },
+                else => {
+                    // In this case we are rendering an error union which has a 0 bits payload.
+                    return MCValue{ .immediate = 0 };
+                },
+            }
         },
         .ErrorUnion => {
             const error_type = typed_value.ty.errorUnionSet();
             const payload_type = typed_value.ty.errorUnionPayload();
 
-            if (typed_value.val.castTag(.eu_payload)) |_| {
-                if (!payload_type.hasRuntimeBits()) {
-                    // We use the error type directly as the type.
-                    return MCValue{ .immediate = 0 };
-                }
-            } else {
-                if (!payload_type.hasRuntimeBits()) {
-                    // We use the error type directly as the type.
-                    return self.genTypedValue(.{ .ty = error_type, .val = typed_value.val });
-                }
+            if (error_type.errorSetCardinality() == .zero) {
+                const payload_val = typed_value.val.castTag(.eu_payload).?.data;
+                return self.genTypedValue(.{ .ty = payload_type, .val = payload_val });
+            }
+
+            const is_pl = typed_value.val.errorUnionIsPayload();
+
+            if (!payload_type.hasRuntimeBitsIgnoreComptime()) {
+                // We use the error type directly as the type.
+                const err_val = if (!is_pl) typed_value.val else Value.initTag(.zero);
+                return self.genTypedValue(.{ .ty = error_type, .val = err_val });
             }
         },
 
@@ -5231,7 +5255,7 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
 
             if (ret_ty.zigTypeTag() == .NoReturn) {
                 result.return_value = .{ .unreach = {} };
-            } else if (!ret_ty.hasRuntimeBits()) {
+            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime()) {
                 result.return_value = .{ .none = {} };
             } else {
                 const ret_ty_size = @intCast(u32, ret_ty.abiSize(self.target.*));
@@ -5278,11 +5302,14 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
         .Unspecified => {
             if (ret_ty.zigTypeTag() == .NoReturn) {
                 result.return_value = .{ .unreach = {} };
-            } else if (!ret_ty.hasRuntimeBits()) {
+            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime() and !ret_ty.isError()) {
                 result.return_value = .{ .none = {} };
             } else {
                 const ret_ty_size = @intCast(u32, ret_ty.abiSize(self.target.*));
-                if (ret_ty_size <= 4) {
+                if (ret_ty_size == 0) {
+                    assert(ret_ty.isError());
+                    result.return_value = .{ .immediate = 0 };
+                } else if (ret_ty_size <= 4) {
                     result.return_value = .{ .register = .r0 };
                 } else {
                     // The result is returned by reference, not by

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -636,7 +636,7 @@ fn resolveInst(self: *Self, ref: Air.Inst.Ref) InnerError!WValue {
     // means we must generate it from a constant.
     const val = self.air.value(ref).?;
     const ty = self.air.typeOf(ref);
-    if (!ty.hasRuntimeBitsIgnoreComptime() and !ty.isInt()) {
+    if (!ty.hasRuntimeBitsIgnoreComptime() and !ty.isInt() and !ty.isError()) {
         gop.value_ptr.* = WValue{ .none = {} };
         return gop.value_ptr.*;
     }
@@ -804,6 +804,8 @@ fn genFunctype(gpa: Allocator, fn_info: Type.Payload.Function.Data, target: std.
         } else {
             try returns.append(typeToValtype(fn_info.return_type, target));
         }
+    } else if (fn_info.return_type.isError()) {
+        try returns.append(.i32);
     }
 
     // param types
@@ -1373,10 +1375,15 @@ fn isByRef(ty: Type, target: std.Target) bool {
         .Int => return ty.intInfo(target).bits > 64,
         .Float => return ty.floatBits(target) > 64,
         .ErrorUnion => {
-            const has_tag = ty.errorUnionSet().hasRuntimeBitsIgnoreComptime();
-            const has_pl = ty.errorUnionPayload().hasRuntimeBitsIgnoreComptime();
-            if (!has_tag or !has_pl) return false;
-            return ty.hasRuntimeBitsIgnoreComptime();
+            const err_ty = ty.errorUnionSet();
+            const pl_ty = ty.errorUnionPayload();
+            if (err_ty.errorSetCardinality() == .zero) {
+                return isByRef(pl_ty, target);
+            }
+            if (!pl_ty.hasRuntimeBitsIgnoreComptime()) {
+                return false;
+            }
+            return true;
         },
         .Optional => {
             if (ty.isPtrLikeOptional()) return false;
@@ -1624,13 +1631,14 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
 fn airRet(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
     const un_op = self.air.instructions.items(.data)[inst].un_op;
     const operand = try self.resolveInst(un_op);
-    const ret_ty = self.decl.ty.fnReturnType();
+    const fn_info = self.decl.ty.fnInfo();
+    const ret_ty = fn_info.return_type;
 
     // result must be stored in the stack and we return a pointer
     // to the stack instead
     if (self.return_value != .none) {
-        try self.store(self.return_value, operand, self.decl.ty.fnReturnType(), 0);
-    } else if (self.decl.ty.fnInfo().cc == .C and ret_ty.hasRuntimeBitsIgnoreComptime()) {
+        try self.store(self.return_value, operand, ret_ty, 0);
+    } else if (fn_info.cc == .C and ret_ty.hasRuntimeBitsIgnoreComptime()) {
         switch (ret_ty.zigTypeTag()) {
             // Aggregate types can be lowered as a singular value
             .Struct, .Union => {
@@ -1650,7 +1658,11 @@ fn airRet(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
             else => try self.emitWValue(operand),
         }
     } else {
-        try self.emitWValue(operand);
+        if (!ret_ty.hasRuntimeBitsIgnoreComptime() and ret_ty.isError()) {
+            try self.addImm32(0);
+        } else {
+            try self.emitWValue(operand);
+        }
     }
     try self.restoreStackPointer();
     try self.addTag(.@"return");
@@ -1675,7 +1687,13 @@ fn airRetLoad(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
     const un_op = self.air.instructions.items(.data)[inst].un_op;
     const operand = try self.resolveInst(un_op);
     const ret_ty = self.air.typeOf(un_op).childType();
-    if (!ret_ty.hasRuntimeBitsIgnoreComptime()) return WValue.none;
+    if (!ret_ty.hasRuntimeBitsIgnoreComptime()) {
+        if (ret_ty.isError()) {
+            try self.addImm32(0);
+        } else {
+            return WValue.none;
+        }
+    }
 
     if (!firstParamSRet(self.decl.ty.fnInfo(), self.target)) {
         const result = try self.load(operand, ret_ty, 0);
@@ -1723,8 +1741,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallOptions.
 
     const sret = if (first_param_sret) blk: {
         const sret_local = try self.allocStack(ret_ty);
-        const ptr_offset = try self.buildPointerOffset(sret_local, 0, .new);
-        try self.emitWValue(ptr_offset);
+        try self.lowerToStack(sret_local);
         break :blk sret_local;
     } else WValue{ .none = {} };
 
@@ -1754,7 +1771,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallOptions.
         try self.addLabel(.call_indirect, fn_type_index);
     }
 
-    if (self.liveness.isUnused(inst) or !ret_ty.hasRuntimeBitsIgnoreComptime()) {
+    if (self.liveness.isUnused(inst) or (!ret_ty.hasRuntimeBitsIgnoreComptime() and !ret_ty.isError())) {
         return WValue.none;
     } else if (ret_ty.isNoReturn()) {
         try self.addTag(.@"unreachable");
@@ -1796,8 +1813,11 @@ fn store(self: *Self, lhs: WValue, rhs: WValue, ty: Type, offset: u32) InnerErro
         .ErrorUnion => {
             const err_ty = ty.errorUnionSet();
             const pl_ty = ty.errorUnionPayload();
+            if (err_ty.errorSetCardinality() == .zero) {
+                return self.store(lhs, rhs, pl_ty, 0);
+            }
             if (!pl_ty.hasRuntimeBitsIgnoreComptime()) {
-                return self.store(lhs, rhs, err_ty, 0);
+                return self.store(lhs, rhs, Type.anyerror, 0);
             }
 
             const len = @intCast(u32, ty.abiSize(self.target));
@@ -2256,6 +2276,7 @@ fn lowerConstant(self: *Self, val: Value, ty: Type) InnerError!WValue {
     const target = self.target;
 
     switch (ty.zigTypeTag()) {
+        .Void => return WValue{ .none = {} },
         .Int => {
             const int_info = ty.intInfo(self.target);
             switch (int_info.signedness) {
@@ -2324,6 +2345,10 @@ fn lowerConstant(self: *Self, val: Value, ty: Type) InnerError!WValue {
         },
         .ErrorUnion => {
             const error_type = ty.errorUnionSet();
+            if (error_type.errorSetCardinality() == .zero) {
+                const pl_val = if (val.castTag(.eu_payload)) |pl| pl.data else Value.initTag(.undef);
+                return self.lowerConstant(pl_val, ty.errorUnionPayload());
+            }
             const is_pl = val.errorUnionIsPayload();
             const err_val = if (!is_pl) val else Value.initTag(.zero);
             return self.lowerConstant(err_val, error_type);
@@ -2892,12 +2917,19 @@ fn airIsErr(self: *Self, inst: Air.Inst.Index, opcode: wasm.Opcode) InnerError!W
     const err_ty = self.air.typeOf(un_op);
     const pl_ty = err_ty.errorUnionPayload();
 
-    // load the error tag value
+    if (err_ty.errorUnionSet().errorSetCardinality() == .zero) {
+        switch (opcode) {
+            .i32_ne => return WValue{ .imm32 = 0 },
+            .i32_eq => return WValue{ .imm32 = 1 },
+            else => unreachable,
+        }
+    }
+
     try self.emitWValue(operand);
     if (pl_ty.hasRuntimeBitsIgnoreComptime()) {
         try self.addMemArg(.i32_load16_u, .{
-            .offset = operand.offset(),
-            .alignment = err_ty.errorUnionSet().abiAlignment(self.target),
+            .offset = operand.offset() + errUnionErrorOffset(pl_ty, self.target),
+            .alignment = Type.anyerror.abiAlignment(self.target),
         });
     }
 
@@ -2905,7 +2937,7 @@ fn airIsErr(self: *Self, inst: Air.Inst.Index, opcode: wasm.Opcode) InnerError!W
     try self.addImm32(0);
     try self.addTag(Mir.Inst.Tag.fromOpcode(opcode));
 
-    const is_err_tmp = try self.allocLocal(Type.initTag(.i32)); // result is always an i32
+    const is_err_tmp = try self.allocLocal(Type.i32);
     try self.addLabel(.local_set, is_err_tmp.local);
     return is_err_tmp;
 }
@@ -2917,14 +2949,18 @@ fn airUnwrapErrUnionPayload(self: *Self, inst: Air.Inst.Index, op_is_ptr: bool) 
     const op_ty = self.air.typeOf(ty_op.operand);
     const err_ty = if (op_is_ptr) op_ty.childType() else op_ty;
     const payload_ty = err_ty.errorUnionPayload();
-    if (!payload_ty.hasRuntimeBitsIgnoreComptime()) return WValue{ .none = {} };
-    const err_align = err_ty.abiAlignment(self.target);
-    const set_size = err_ty.errorUnionSet().abiSize(self.target);
-    const offset = mem.alignForwardGeneric(u64, set_size, err_align);
-    if (op_is_ptr or isByRef(payload_ty, self.target)) {
-        return self.buildPointerOffset(operand, offset, .new);
+
+    if (err_ty.errorUnionSet().errorSetCardinality() == .zero) {
+        return operand;
     }
-    return self.load(operand, payload_ty, @intCast(u32, offset));
+
+    if (!payload_ty.hasRuntimeBitsIgnoreComptime()) return WValue{ .none = {} };
+
+    const pl_offset = errUnionPayloadOffset(payload_ty, self.target);
+    if (op_is_ptr or isByRef(payload_ty, self.target)) {
+        return self.buildPointerOffset(operand, pl_offset, .new);
+    }
+    return self.load(operand, payload_ty, pl_offset);
 }
 
 fn airUnwrapErrUnionError(self: *Self, inst: Air.Inst.Index, op_is_ptr: bool) InnerError!WValue {
@@ -2935,11 +2971,16 @@ fn airUnwrapErrUnionError(self: *Self, inst: Air.Inst.Index, op_is_ptr: bool) In
     const op_ty = self.air.typeOf(ty_op.operand);
     const err_ty = if (op_is_ptr) op_ty.childType() else op_ty;
     const payload_ty = err_ty.errorUnionPayload();
+
+    if (err_ty.errorUnionSet().errorSetCardinality() == .zero) {
+        return WValue{ .imm32 = 0 };
+    }
+
     if (op_is_ptr or !payload_ty.hasRuntimeBitsIgnoreComptime()) {
         return operand;
     }
 
-    return self.load(operand, err_ty.errorUnionSet(), 0);
+    return self.load(operand, Type.anyerror, errUnionErrorOffset(payload_ty, self.target));
 }
 
 fn airWrapErrUnionPayload(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
@@ -2947,22 +2988,26 @@ fn airWrapErrUnionPayload(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
 
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const operand = try self.resolveInst(ty_op.operand);
+    const err_ty = self.air.typeOfIndex(inst);
 
-    const op_ty = self.air.typeOf(ty_op.operand);
-    if (!op_ty.hasRuntimeBitsIgnoreComptime()) return operand;
-    const err_union_ty = self.air.getRefType(ty_op.ty);
-    const err_align = err_union_ty.abiAlignment(self.target);
-    const set_size = err_union_ty.errorUnionSet().abiSize(self.target);
-    const offset = mem.alignForwardGeneric(u64, set_size, err_align);
+    if (err_ty.errorUnionSet().errorSetCardinality() == .zero) {
+        return operand;
+    }
 
-    const err_union = try self.allocStack(err_union_ty);
-    const payload_ptr = try self.buildPointerOffset(err_union, offset, .new);
-    try self.store(payload_ptr, operand, op_ty, 0);
+    const pl_ty = self.air.typeOf(ty_op.operand);
+    if (!pl_ty.hasRuntimeBitsIgnoreComptime()) {
+        return operand;
+    }
+
+    const err_union = try self.allocStack(err_ty);
+    const payload_ptr = try self.buildPointerOffset(err_union, errUnionPayloadOffset(pl_ty, self.target), .new);
+    try self.store(payload_ptr, operand, pl_ty, 0);
 
     // ensure we also write '0' to the error part, so any present stack value gets overwritten by it.
     try self.emitWValue(err_union);
     try self.addImm32(0);
-    try self.addMemArg(.i32_store16, .{ .offset = err_union.offset(), .alignment = 2 });
+    const err_val_offset = errUnionErrorOffset(pl_ty, self.target);
+    try self.addMemArg(.i32_store16, .{ .offset = err_union.offset() + err_val_offset, .alignment = 2 });
 
     return err_union;
 }
@@ -2973,17 +3018,18 @@ fn airWrapErrUnionErr(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const operand = try self.resolveInst(ty_op.operand);
     const err_ty = self.air.getRefType(ty_op.ty);
+    const pl_ty = err_ty.errorUnionPayload();
 
-    if (!err_ty.errorUnionPayload().hasRuntimeBitsIgnoreComptime()) return operand;
+    if (!pl_ty.hasRuntimeBitsIgnoreComptime()) {
+        return operand;
+    }
 
     const err_union = try self.allocStack(err_ty);
-    try self.store(err_union, operand, err_ty.errorUnionSet(), 0);
+    // store error value
+    try self.store(err_union, operand, Type.anyerror, errUnionErrorOffset(pl_ty, self.target));
 
     // write 'undefined' to the payload
-    const err_align = err_ty.abiAlignment(self.target);
-    const set_size = err_ty.errorUnionSet().abiSize(self.target);
-    const offset = mem.alignForwardGeneric(u64, set_size, err_align);
-    const payload_ptr = try self.buildPointerOffset(err_union, offset, .new);
+    const payload_ptr = try self.buildPointerOffset(err_union, errUnionPayloadOffset(pl_ty, self.target), .new);
     const len = @intCast(u32, err_ty.errorUnionPayload().abiSize(self.target));
     try self.memset(payload_ptr, .{ .imm32 = len }, .{ .imm32 = 0xaaaaaaaa });
 
@@ -3927,12 +3973,16 @@ fn airFptrunc(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
 fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const err_set_ty = self.air.typeOf(ty_op.operand).childType();
-    const err_ty = err_set_ty.errorUnionSet();
     const payload_ty = err_set_ty.errorUnionPayload();
     const operand = try self.resolveInst(ty_op.operand);
 
     // set error-tag to '0' to annotate error union is non-error
-    try self.store(operand, .{ .imm32 = 0 }, err_ty, 0);
+    try self.store(
+        operand,
+        .{ .imm32 = 0 },
+        Type.anyerror,
+        errUnionErrorOffset(payload_ty, self.target),
+    );
 
     if (self.liveness.isUnused(inst)) return WValue{ .none = {} };
 
@@ -3940,11 +3990,7 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) InnerError!WValue
         return operand;
     }
 
-    const err_align = err_set_ty.abiAlignment(self.target);
-    const set_size = err_ty.abiSize(self.target);
-    const offset = mem.alignForwardGeneric(u64, set_size, err_align);
-
-    return self.buildPointerOffset(operand, @intCast(u32, offset), .new);
+    return self.buildPointerOffset(operand, errUnionPayloadOffset(payload_ty, self.target), .new);
 }
 
 fn airFieldParentPtr(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
@@ -4571,4 +4617,18 @@ fn airDbgStmt(self: *Self, inst: Air.Inst.Index) !WValue {
         }),
     } });
     return WValue{ .none = {} };
+}
+
+fn errUnionPayloadOffset(payload_ty: Type, target: std.Target) u32 {
+    if (Type.anyerror.abiAlignment(target) > payload_ty.abiAlignment(target)) {
+        return @intCast(u32, Type.anyerror.abiSize(target));
+    }
+    return 0;
+}
+
+fn errUnionErrorOffset(payload_ty: Type, target: std.Target) u32 {
+    if (Type.anyerror.abiAlignment(target) > payload_ty.abiAlignment(target)) {
+        return 0;
+    }
+    return @intCast(u32, payload_ty.abiSize(target));
 }

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -4377,7 +4377,6 @@ fn genVarDbgInfo(
 fn addDbgInfoTypeReloc(self: *Self, ty: Type) !void {
     switch (self.debug_output) {
         .dwarf => |dw| {
-            assert(ty.hasRuntimeBits());
             const dbg_info = &dw.dbg_info;
             const index = dbg_info.items.len;
             try dbg_info.resize(index + 4); // DW.AT.type,  DW.FORM.ref4

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -854,7 +854,7 @@ fn allocMemPtr(self: *Self, inst: Air.Inst.Index) !u32 {
     const ptr_ty = self.air.typeOfIndex(inst);
     const elem_ty = ptr_ty.elemType();
 
-    if (!elem_ty.hasRuntimeBits()) {
+    if (!elem_ty.hasRuntimeBitsIgnoreComptime()) {
         return self.allocMem(inst, @sizeOf(usize), @alignOf(usize));
     }
 
@@ -1786,21 +1786,34 @@ fn airUnwrapErrErr(self: *Self, inst: Air.Inst.Index) !void {
     const err_ty = err_union_ty.errorUnionSet();
     const payload_ty = err_union_ty.errorUnionPayload();
     const operand = try self.resolveInst(ty_op.operand);
-    const operand_lock: ?RegisterLock = switch (operand) {
-        .register => |reg| self.register_manager.lockRegAssumeUnused(reg),
-        else => null,
-    };
-    defer if (operand_lock) |lock| self.register_manager.unlockReg(lock);
 
     const result: MCValue = result: {
-        if (!payload_ty.hasRuntimeBits()) break :result operand;
+        if (err_ty.errorSetCardinality() == .zero) {
+            break :result MCValue{ .immediate = 0 };
+        }
+
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
+            break :result operand;
+        }
+
+        const err_off = errUnionErrOffset(err_union_ty, self.target.*);
         switch (operand) {
             .stack_offset => |off| {
-                break :result MCValue{ .stack_offset = off };
+                const offset = off - @intCast(i32, err_off);
+                break :result MCValue{ .stack_offset = offset };
             },
-            .register => {
+            .register => |reg| {
                 // TODO reuse operand
-                break :result try self.copyToRegisterWithInstTracking(inst, err_ty, operand);
+                const lock = self.register_manager.lockRegAssumeUnused(reg);
+                defer self.register_manager.unlockReg(lock);
+                const result = try self.copyToRegisterWithInstTracking(inst, err_union_ty, operand);
+                if (err_off > 0) {
+                    const shift = @intCast(u6, err_off * 8);
+                    try self.genShiftBinOpMir(.shr, err_union_ty, result.register, .{ .immediate = shift });
+                } else {
+                    try self.truncateRegister(Type.anyerror, result.register);
+                }
+                break :result result;
             },
             else => return self.fail("TODO implement unwrap_err_err for {}", .{operand}),
         }
@@ -1815,32 +1828,37 @@ fn airUnwrapErrPayload(self: *Self, inst: Air.Inst.Index) !void {
     }
     const err_union_ty = self.air.typeOf(ty_op.operand);
     const payload_ty = err_union_ty.errorUnionPayload();
+    const err_ty = err_union_ty.errorUnionSet();
+    const operand = try self.resolveInst(ty_op.operand);
+
     const result: MCValue = result: {
-        if (!payload_ty.hasRuntimeBits()) break :result MCValue.none;
+        if (err_ty.errorSetCardinality() == .zero) {
+            // TODO check if we can reuse
+            break :result operand;
+        }
 
-        const operand = try self.resolveInst(ty_op.operand);
-        const operand_lock: ?RegisterLock = switch (operand) {
-            .register => |reg| self.register_manager.lockRegAssumeUnused(reg),
-            else => null,
-        };
-        defer if (operand_lock) |lock| self.register_manager.unlockReg(lock);
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
+            break :result MCValue.none;
+        }
 
-        const abi_align = err_union_ty.abiAlignment(self.target.*);
-        const err_ty = err_union_ty.errorUnionSet();
-        const err_abi_size = mem.alignForwardGeneric(u32, @intCast(u32, err_ty.abiSize(self.target.*)), abi_align);
+        const payload_off = errUnionPayloadOffset(err_union_ty, self.target.*);
         switch (operand) {
             .stack_offset => |off| {
-                const offset = off - @intCast(i32, err_abi_size);
+                const offset = off - @intCast(i32, payload_off);
                 break :result MCValue{ .stack_offset = offset };
             },
-            .register => {
+            .register => |reg| {
                 // TODO reuse operand
-                const shift = @intCast(u6, err_abi_size * @sizeOf(usize));
+                const lock = self.register_manager.lockRegAssumeUnused(reg);
+                defer self.register_manager.unlockReg(lock);
                 const result = try self.copyToRegisterWithInstTracking(inst, err_union_ty, operand);
-                try self.genShiftBinOpMir(.shr, Type.usize, result.register, .{ .immediate = shift });
-                break :result MCValue{
-                    .register = registerAlias(result.register, @intCast(u32, payload_ty.abiSize(self.target.*))),
-                };
+                if (payload_off > 0) {
+                    const shift = @intCast(u6, payload_off * 8);
+                    try self.genShiftBinOpMir(.shr, err_union_ty, result.register, .{ .immediate = shift });
+                } else {
+                    try self.truncateRegister(payload_ty, result.register);
+                }
+                break :result result;
             },
             else => return self.fail("TODO implement unwrap_err_payload for {}", .{operand}),
         }
@@ -1935,24 +1953,37 @@ fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {
 /// T to E!T
 fn airWrapErrUnionPayload(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
+
     if (self.liveness.isUnused(inst)) {
         return self.finishAir(inst, .dead, .{ ty_op.operand, .none, .none });
     }
+
     const error_union_ty = self.air.getRefType(ty_op.ty);
     const error_ty = error_union_ty.errorUnionSet();
     const payload_ty = error_union_ty.errorUnionPayload();
     const operand = try self.resolveInst(ty_op.operand);
-    assert(payload_ty.hasRuntimeBits());
 
-    const abi_size = @intCast(u32, error_union_ty.abiSize(self.target.*));
-    const abi_align = error_union_ty.abiAlignment(self.target.*);
-    const err_abi_size = @intCast(u32, error_ty.abiSize(self.target.*));
-    const stack_offset = @intCast(i32, try self.allocMem(inst, abi_size, abi_align));
-    const offset = mem.alignForwardGeneric(u32, err_abi_size, abi_align);
-    try self.genSetStack(error_ty, stack_offset, .{ .immediate = 0 }, .{});
-    try self.genSetStack(payload_ty, stack_offset - @intCast(i32, offset), operand, .{});
+    const result: MCValue = result: {
+        if (error_ty.errorSetCardinality() == .zero) {
+            break :result operand;
+        }
 
-    return self.finishAir(inst, .{ .stack_offset = stack_offset }, .{ ty_op.operand, .none, .none });
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
+            break :result operand;
+        }
+
+        const abi_size = @intCast(u32, error_union_ty.abiSize(self.target.*));
+        const abi_align = error_union_ty.abiAlignment(self.target.*);
+        const stack_offset = @intCast(i32, try self.allocMem(inst, abi_size, abi_align));
+        const payload_off = errUnionPayloadOffset(error_union_ty, self.target.*);
+        const err_off = errUnionErrOffset(error_union_ty, self.target.*);
+        try self.genSetStack(payload_ty, stack_offset - @intCast(i32, payload_off), operand, .{});
+        try self.genSetStack(Type.anyerror, stack_offset - @intCast(i32, err_off), .{ .immediate = 0 }, .{});
+
+        break :result MCValue{ .stack_offset = stack_offset };
+    };
+
+    return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
 
 /// E to E!T
@@ -1962,19 +1993,22 @@ fn airWrapErrUnionErr(self: *Self, inst: Air.Inst.Index) !void {
         return self.finishAir(inst, .dead, .{ ty_op.operand, .none, .none });
     }
     const error_union_ty = self.air.getRefType(ty_op.ty);
-    const error_ty = error_union_ty.errorUnionSet();
     const payload_ty = error_union_ty.errorUnionPayload();
-    const err = try self.resolveInst(ty_op.operand);
+    const operand = try self.resolveInst(ty_op.operand);
+
     const result: MCValue = result: {
-        if (!payload_ty.hasRuntimeBits()) break :result err;
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
+            break :result operand;
+        }
 
         const abi_size = @intCast(u32, error_union_ty.abiSize(self.target.*));
         const abi_align = error_union_ty.abiAlignment(self.target.*);
-        const err_abi_size = @intCast(u32, error_ty.abiSize(self.target.*));
         const stack_offset = @intCast(i32, try self.allocMem(inst, abi_size, abi_align));
-        const offset = mem.alignForwardGeneric(u32, err_abi_size, abi_align);
-        try self.genSetStack(error_ty, stack_offset, err, .{});
-        try self.genSetStack(payload_ty, stack_offset - @intCast(i32, offset), .undef, .{});
+        const payload_off = errUnionPayloadOffset(error_union_ty, self.target.*);
+        const err_off = errUnionErrOffset(error_union_ty, self.target.*);
+        try self.genSetStack(Type.anyerror, stack_offset - @intCast(i32, err_off), operand, .{});
+        try self.genSetStack(payload_ty, stack_offset - @intCast(i32, payload_off), .undef, .{});
+
         break :result MCValue{ .stack_offset = stack_offset };
     };
 
@@ -2535,7 +2569,7 @@ fn airLoad(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const elem_ty = self.air.typeOfIndex(inst);
     const result: MCValue = result: {
-        if (!elem_ty.hasRuntimeBits())
+        if (!elem_ty.hasRuntimeBitsIgnoreComptime())
             break :result MCValue.none;
 
         const ptr = try self.resolveInst(ty_op.operand);
@@ -4102,6 +4136,9 @@ fn airRet(self: *Self, inst: Air.Inst.Index) !void {
     const operand = try self.resolveInst(un_op);
     const ret_ty = self.fn_type.fnReturnType();
     switch (self.ret_mcv) {
+        .immediate => {
+            assert(ret_ty.isError());
+        },
         .stack_offset => {
             const reg = try self.copyToTmpRegister(Type.usize, self.ret_mcv);
             const reg_lock = self.register_manager.lockRegAssumeUnused(reg);
@@ -4134,6 +4171,9 @@ fn airRetLoad(self: *Self, inst: Air.Inst.Index) !void {
     const ptr_ty = self.air.typeOf(un_op);
     const elem_ty = ptr_ty.elemType();
     switch (self.ret_mcv) {
+        .immediate => {
+            assert(elem_ty.isError());
+        },
         .stack_offset => {
             const reg = try self.copyToTmpRegister(Type.usize, self.ret_mcv);
             const reg_lock = self.register_manager.lockRegAssumeUnused(reg);
@@ -4603,7 +4643,7 @@ fn isNull(self: *Self, inst: Air.Inst.Index, ty: Type, operand: MCValue) !MCValu
     const cmp_ty: Type = if (!ty.isPtrLikeOptional()) blk: {
         var buf: Type.Payload.ElemType = undefined;
         const payload_ty = ty.optionalChild(&buf);
-        break :blk if (payload_ty.hasRuntimeBits()) Type.bool else ty;
+        break :blk if (payload_ty.hasRuntimeBitsIgnoreComptime()) Type.bool else ty;
     } else ty;
 
     try self.genBinOpMir(.cmp, cmp_ty, operand, MCValue{ .immediate = 0 });
@@ -4619,25 +4659,36 @@ fn isNonNull(self: *Self, inst: Air.Inst.Index, ty: Type, operand: MCValue) !MCV
 
 fn isErr(self: *Self, inst: Air.Inst.Index, ty: Type, operand: MCValue) !MCValue {
     const err_type = ty.errorUnionSet();
-    const payload_type = ty.errorUnionPayload();
-    if (!err_type.hasRuntimeBits()) {
+
+    if (err_type.errorSetCardinality() == .zero) {
         return MCValue{ .immediate = 0 }; // always false
     }
 
     try self.spillCompareFlagsIfOccupied();
     self.compare_flags_inst = inst;
 
-    if (!payload_type.hasRuntimeBits()) {
-        if (err_type.abiSize(self.target.*) <= 8) {
-            try self.genBinOpMir(.cmp, err_type, operand, MCValue{ .immediate = 0 });
-            return MCValue{ .compare_flags_unsigned = .gt };
-        } else {
-            return self.fail("TODO isErr for errors with size larger than register size", .{});
-        }
-    } else {
-        try self.genBinOpMir(.cmp, err_type, operand, MCValue{ .immediate = 0 });
-        return MCValue{ .compare_flags_unsigned = .gt };
+    const err_off = errUnionErrOffset(ty, self.target.*);
+    switch (operand) {
+        .stack_offset => |off| {
+            const offset = off - @intCast(i32, err_off);
+            try self.genBinOpMir(.cmp, Type.anyerror, .{ .stack_offset = offset }, .{ .immediate = 0 });
+        },
+        .register => |reg| {
+            const maybe_lock = self.register_manager.lockReg(reg);
+            defer if (maybe_lock) |lock| self.register_manager.unlockReg(lock);
+            const tmp_reg = try self.copyToTmpRegister(ty, operand);
+            if (err_off > 0) {
+                const shift = @intCast(u6, err_off * 8);
+                try self.genShiftBinOpMir(.shr, ty, tmp_reg, .{ .immediate = shift });
+            } else {
+                try self.truncateRegister(Type.anyerror, tmp_reg);
+            }
+            try self.genBinOpMir(.cmp, Type.anyerror, .{ .register = tmp_reg }, .{ .immediate = 0 });
+        },
+        else => return self.fail("TODO implement isErr for {}", .{operand}),
     }
+
+    return MCValue{ .compare_flags_unsigned = .gt };
 }
 
 fn isNonErr(self: *Self, inst: Air.Inst.Index, ty: Type, operand: MCValue) !MCValue {
@@ -5460,6 +5511,21 @@ fn genSetStack(self: *Self, ty: Type, stack_offset: i32, mcv: MCValue, opts: Inl
         .immediate => |x_big| {
             const base_reg = opts.dest_stack_base orelse .rbp;
             switch (abi_size) {
+                0 => {
+                    assert(ty.isError());
+                    const payload = try self.addExtra(Mir.ImmPair{
+                        .dest_off = @bitCast(u32, -stack_offset),
+                        .operand = @truncate(u32, x_big),
+                    });
+                    _ = try self.addInst(.{
+                        .tag = .mov_mem_imm,
+                        .ops = Mir.Inst.Ops.encode(.{
+                            .reg1 = base_reg,
+                            .flags = 0b00,
+                        }),
+                        .data = .{ .payload = payload },
+                    });
+                },
                 1, 2, 4 => {
                     const payload = try self.addExtra(Mir.ImmPair{
                         .dest_off = @bitCast(u32, -stack_offset),
@@ -6642,7 +6708,7 @@ pub fn resolveInst(self: *Self, inst: Air.Inst.Ref) InnerError!MCValue {
     const ref_int = @enumToInt(inst);
     if (ref_int < Air.Inst.Ref.typed_value_map.len) {
         const tv = Air.Inst.Ref.typed_value_map[ref_int];
-        if (!tv.ty.hasRuntimeBits()) {
+        if (!tv.ty.hasRuntimeBitsIgnoreComptime() and !tv.ty.isError()) {
             return MCValue{ .none = {} };
         }
         return self.genTypedValue(tv);
@@ -6650,7 +6716,7 @@ pub fn resolveInst(self: *Self, inst: Air.Inst.Ref) InnerError!MCValue {
 
     // If the type has no codegen bits, no need to store it.
     const inst_ty = self.air.typeOf(inst);
-    if (!inst_ty.hasRuntimeBits())
+    if (!inst_ty.hasRuntimeBitsIgnoreComptime() and !inst_ty.isError())
         return MCValue{ .none = {} };
 
     const inst_index = @intCast(Air.Inst.Index, ref_int - Air.Inst.Ref.typed_value_map.len);
@@ -6779,6 +6845,7 @@ fn genTypedValue(self: *Self, typed_value: TypedValue) InnerError!MCValue {
     const target = self.target.*;
 
     switch (typed_value.ty.zigTypeTag()) {
+        .Void => return MCValue{ .none = {} },
         .Pointer => switch (typed_value.ty.ptrSize()) {
             .Slice => {},
             else => {
@@ -6840,26 +6907,35 @@ fn genTypedValue(self: *Self, typed_value: TypedValue) InnerError!MCValue {
             }
         },
         .ErrorSet => {
-            const err_name = typed_value.val.castTag(.@"error").?.data.name;
-            const module = self.bin_file.options.module.?;
-            const global_error_set = module.global_error_set;
-            const error_index = global_error_set.get(err_name).?;
-            return MCValue{ .immediate = error_index };
+            switch (typed_value.val.tag()) {
+                .@"error" => {
+                    const err_name = typed_value.val.castTag(.@"error").?.data.name;
+                    const module = self.bin_file.options.module.?;
+                    const global_error_set = module.global_error_set;
+                    const error_index = global_error_set.get(err_name).?;
+                    return MCValue{ .immediate = error_index };
+                },
+                else => {
+                    // In this case we are rendering an error union which has a 0 bits payload.
+                    return MCValue{ .immediate = 0 };
+                },
+            }
         },
         .ErrorUnion => {
             const error_type = typed_value.ty.errorUnionSet();
             const payload_type = typed_value.ty.errorUnionPayload();
 
-            if (typed_value.val.castTag(.eu_payload)) |_| {
-                if (!payload_type.hasRuntimeBits()) {
-                    // We use the error type directly as the type.
-                    return MCValue{ .immediate = 0 };
-                }
-            } else {
-                if (!payload_type.hasRuntimeBits()) {
-                    // We use the error type directly as the type.
-                    return self.genTypedValue(.{ .ty = error_type, .val = typed_value.val });
-                }
+            if (error_type.errorSetCardinality() == .zero) {
+                const payload_val = typed_value.val.castTag(.eu_payload).?.data;
+                return self.genTypedValue(.{ .ty = payload_type, .val = payload_val });
+            }
+
+            const is_pl = typed_value.val.errorUnionIsPayload();
+
+            if (!payload_type.hasRuntimeBitsIgnoreComptime()) {
+                // We use the error type directly as the type.
+                const err_val = if (!is_pl) typed_value.val else Value.initTag(.zero);
+                return self.genTypedValue(.{ .ty = error_type, .val = err_val });
             }
         },
 
@@ -6867,7 +6943,6 @@ fn genTypedValue(self: *Self, typed_value: TypedValue) InnerError!MCValue {
         .ComptimeFloat => unreachable,
         .Type => unreachable,
         .EnumLiteral => unreachable,
-        .Void => unreachable,
         .NoReturn => unreachable,
         .Undefined => unreachable,
         .Null => unreachable,
@@ -6921,11 +6996,14 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
             // Return values
             if (ret_ty.zigTypeTag() == .NoReturn) {
                 result.return_value = .{ .unreach = {} };
-            } else if (!ret_ty.hasRuntimeBits()) {
+            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime() and !ret_ty.isError()) {
                 result.return_value = .{ .none = {} };
             } else {
                 const ret_ty_size = @intCast(u32, ret_ty.abiSize(self.target.*));
-                if (ret_ty_size <= 8) {
+                if (ret_ty_size == 0) {
+                    assert(ret_ty.isError());
+                    result.return_value = .{ .immediate = 0 };
+                } else if (ret_ty_size <= 8) {
                     const aliased_reg = registerAlias(c_abi_int_return_regs[0], ret_ty_size);
                     result.return_value = .{ .register = aliased_reg };
                 } else {
@@ -7104,4 +7182,20 @@ fn intrinsicsAllowed(target: Target, ty: Type) bool {
 
 fn hasAvxSupport(target: Target) bool {
     return Target.x86.featureSetHasAny(target.cpu.features, .{ .avx, .avx2 });
+}
+
+fn errUnionPayloadOffset(ty: Type, target: std.Target) u64 {
+    const payload_ty = ty.errorUnionPayload();
+    return if (Type.anyerror.abiAlignment(target) >= payload_ty.abiAlignment(target))
+        Type.anyerror.abiSize(target)
+    else
+        0;
+}
+
+fn errUnionErrOffset(ty: Type, target: std.Target) u64 {
+    const payload_ty = ty.errorUnionPayload();
+    return if (Type.anyerror.abiAlignment(target) >= payload_ty.abiAlignment(target))
+        0
+    else
+        payload_ty.abiSize(target);
 }

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const build_options = @import("build_options");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
+const codegen = @import("../../codegen.zig");
 const leb128 = std.leb;
 const link = @import("../../link.zig");
 const log = std.log.scoped(.codegen);
@@ -12,11 +13,11 @@ const trace = @import("../../tracy.zig").trace;
 const Air = @import("../../Air.zig");
 const Allocator = mem.Allocator;
 const Compilation = @import("../../Compilation.zig");
-const DebugInfoOutput = @import("../../codegen.zig").DebugInfoOutput;
+const DebugInfoOutput = codegen.DebugInfoOutput;
 const DW = std.dwarf;
 const ErrorMsg = Module.ErrorMsg;
-const FnResult = @import("../../codegen.zig").FnResult;
-const GenerateSymbolError = @import("../../codegen.zig").GenerateSymbolError;
+const FnResult = codegen.FnResult;
+const GenerateSymbolError = codegen.GenerateSymbolError;
 const Emit = @import("Emit.zig");
 const Liveness = @import("../../Liveness.zig");
 const Mir = @import("Mir.zig");
@@ -28,6 +29,8 @@ const Value = @import("../../value.zig").Value;
 
 const bits = @import("bits.zig");
 const abi = @import("abi.zig");
+const errUnionPayloadOffset = codegen.errUnionPayloadOffset;
+const errUnionErrOffset = codegen.errUnionErrOffset;
 
 const callee_preserved_regs = abi.callee_preserved_regs;
 const caller_preserved_regs = abi.caller_preserved_regs;
@@ -7182,20 +7185,4 @@ fn intrinsicsAllowed(target: Target, ty: Type) bool {
 
 fn hasAvxSupport(target: Target) bool {
     return Target.x86.featureSetHasAny(target.cpu.features, .{ .avx, .avx2 });
-}
-
-fn errUnionPayloadOffset(ty: Type, target: std.Target) u64 {
-    const payload_ty = ty.errorUnionPayload();
-    return if (Type.anyerror.abiAlignment(target) >= payload_ty.abiAlignment(target))
-        Type.anyerror.abiSize(target)
-    else
-        0;
-}
-
-fn errUnionErrOffset(ty: Type, target: std.Target) u64 {
-    const payload_ty = ty.errorUnionPayload();
-    return if (Type.anyerror.abiAlignment(target) >= payload_ty.abiAlignment(target))
-        0
-    else
-        payload_ty.abiSize(target);
 }

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -714,7 +714,7 @@ pub fn generateSymbol(
             const is_payload = typed_value.val.errorUnionIsPayload();
 
             if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
-                const err_val = if (!is_payload) typed_value.val else Value.initTag(.zero);
+                const err_val = if (is_payload) Value.initTag(.zero) else typed_value.val;
                 return generateSymbol(bin_file, src_loc, .{
                     .ty = error_ty,
                     .val = err_val,
@@ -763,7 +763,7 @@ pub fn generateSymbol(
             }
 
             // Payload size is larger than error set, so emit our error set last
-            if (error_align < payload_align) {
+            if (error_align <= payload_align) {
                 const begin = code.items.len;
                 switch (try generateSymbol(bin_file, src_loc, .{
                     .ty = error_ty,
@@ -794,7 +794,7 @@ pub fn generateSymbol(
                     try code.writer().writeInt(u32, kv.value, endian);
                 },
                 else => {
-                    try code.writer().writeByteNTimes(0, @intCast(usize, typed_value.ty.abiSize(target)));
+                    try code.writer().writeByteNTimes(0, @intCast(usize, Type.anyerror.abiSize(target)));
                 },
             }
             return Result{ .appended = {} };

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -442,7 +442,10 @@ pub fn generateSymbol(
         .Int => {
             const info = typed_value.ty.intInfo(target);
             if (info.bits <= 8) {
-                const x = @intCast(u8, typed_value.val.toUnsignedInt(target));
+                const x: u8 = switch (info.signedness) {
+                    .unsigned => @intCast(u8, typed_value.val.toUnsignedInt(target)),
+                    .signed => @bitCast(u8, @intCast(i8, typed_value.val.toSignedInt())),
+                };
                 try code.append(x);
                 return Result{ .appended = {} };
             }

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -890,3 +890,19 @@ fn lowerDeclRef(
 
     return Result{ .appended = {} };
 }
+
+pub fn errUnionPayloadOffset(ty: Type, target: std.Target) u64 {
+    const payload_ty = ty.errorUnionPayload();
+    return if (Type.anyerror.abiAlignment(target) >= payload_ty.abiAlignment(target))
+        Type.anyerror.abiSize(target)
+    else
+        0;
+}
+
+pub fn errUnionErrOffset(ty: Type, target: std.Target) u64 {
+    const payload_ty = ty.errorUnionPayload();
+    return if (Type.anyerror.abiAlignment(target) >= payload_ty.abiAlignment(target))
+        0
+    else
+        payload_ty.abiSize(target);
+}

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -654,7 +654,7 @@ pub fn generateSymbol(
                 return Result{ .appended = {} };
             }
 
-            if (typed_value.ty.isPtrLikeOptional()) {
+            if (typed_value.ty.optionalReprIsPayload()) {
                 if (typed_value.val.castTag(.opt_payload)) |payload| {
                     switch (try generateSymbol(bin_file, src_loc, .{
                         .ty = payload_type,

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -891,18 +891,22 @@ fn lowerDeclRef(
     return Result{ .appended = {} };
 }
 
-pub fn errUnionPayloadOffset(ty: Type, target: std.Target) u64 {
-    const payload_ty = ty.errorUnionPayload();
-    return if (Type.anyerror.abiAlignment(target) >= payload_ty.abiAlignment(target))
-        Type.anyerror.abiSize(target)
-    else
-        0;
+pub fn errUnionPayloadOffset(payload_ty: Type, target: std.Target) u64 {
+    const payload_align = payload_ty.abiAlignment(target);
+    const error_align = Type.anyerror.abiAlignment(target);
+    if (payload_align >= error_align) {
+        return 0;
+    } else {
+        return mem.alignForwardGeneric(u64, Type.anyerror.abiSize(target), payload_align);
+    }
 }
 
-pub fn errUnionErrOffset(ty: Type, target: std.Target) u64 {
-    const payload_ty = ty.errorUnionPayload();
-    return if (Type.anyerror.abiAlignment(target) >= payload_ty.abiAlignment(target))
-        0
-    else
-        payload_ty.abiSize(target);
+pub fn errUnionErrorOffset(payload_ty: Type, target: std.Target) u64 {
+    const payload_align = payload_ty.abiAlignment(target);
+    const error_align = Type.anyerror.abiAlignment(target);
+    if (payload_align >= error_align) {
+        return mem.alignForwardGeneric(u64, payload_ty.abiSize(target), error_align);
+    } else {
+        return 0;
+    }
 }

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -149,12 +149,19 @@ test "implicit cast to optional to error union to return result loc" {
 }
 
 test "fn returning empty error set can be passed as fn returning any error" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
     entry();
     comptime entry();
 }
 
 test "fn returning empty error set can be passed as fn returning any error - pointer" {
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     entryPtr();
     comptime entryPtr();

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -433,9 +433,8 @@ test "return function call to error set from error union function" {
 }
 
 test "optional error set is the same size as error set" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
-
     comptime try expect(@sizeOf(?anyerror) == @sizeOf(anyerror));
+    comptime try expect(@alignOf(?anyerror) == @alignOf(anyerror));
     const S = struct {
         fn returnsOptErrSet() ?anyerror {
             return null;

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -441,6 +441,7 @@ test "return function call to error set from error union function" {
 
 test "optional error set is the same size as error set" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     comptime try expect(@sizeOf(?anyerror) == @sizeOf(anyerror));
     comptime try expect(@alignOf(?anyerror) == @alignOf(anyerror));

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -148,18 +148,39 @@ test "implicit cast to optional to error union to return result loc" {
     //comptime S.entry(); TODO
 }
 
-test "error: fn returning empty error set can be passed as fn returning any error" {
+test "fn returning empty error set can be passed as fn returning any error" {
     entry();
     comptime entry();
+}
+
+test "fn returning empty error set can be passed as fn returning any error - pointer" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+
+    entryPtr();
+    comptime entryPtr();
 }
 
 fn entry() void {
     foo2(bar2);
 }
 
+fn entryPtr() void {
+    var ptr = &bar2;
+    fooPtr(ptr);
+}
+
 fn foo2(f: fn () anyerror!void) void {
     const x = f();
-    x catch {};
+    x catch {
+        @panic("fail");
+    };
+}
+
+fn fooPtr(f: *const fn () anyerror!void) void {
+    const x = f();
+    x catch {
+        @panic("fail");
+    };
 }
 
 fn bar2() (error{}!void) {}
@@ -239,7 +260,11 @@ fn testComptimeTestErrorEmptySet(x: EmptyErrorSet!i32) !void {
 }
 
 test "comptime err to int of error set with only 1 possible value" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     testErrToIntWithOnePossibleValue(error.A, @errorToInt(error.A));
     comptime testErrToIntWithOnePossibleValue(error.A, @errorToInt(error.A));

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -440,6 +440,8 @@ test "return function call to error set from error union function" {
 }
 
 test "optional error set is the same size as error set" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
     comptime try expect(@sizeOf(?anyerror) == @sizeOf(anyerror));
     comptime try expect(@alignOf(?anyerror) == @alignOf(anyerror));
     const S = struct {

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -479,11 +479,38 @@ test "optional error set with only one error is the same size as bool" {
 test "optional empty error set" {
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
 
-    const T = ?error{};
-    var t: T = undefined;
-    if (t != null) {
+    comptime try expect(@sizeOf(error{}!void) == @sizeOf(void));
+    comptime try expect(@alignOf(error{}!void) == @alignOf(void));
+
+    var x: ?error{} = undefined;
+    if (x != null) {
         @compileError("test failed");
     }
+}
+
+test "empty error set plus zero-bit payload" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
+    comptime try expect(@sizeOf(error{}!void) == @sizeOf(void));
+    comptime try expect(@alignOf(error{}!void) == @alignOf(void));
+
+    var x: error{}!void = undefined;
+    if (x) |payload| {
+        if (payload != {}) {
+            @compileError("test failed");
+        }
+    } else |_| {
+        @compileError("test failed");
+    }
+    const S = struct {
+        fn empty() error{}!void {}
+        fn inferred() !void {
+            return empty();
+        }
+    };
+    try S.inferred();
 }
 
 test "nested catch" {

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -260,7 +260,6 @@ fn testComptimeTestErrorEmptySet(x: EmptyErrorSet!i32) !void {
 }
 
 test "comptime err to int of error set with only 1 possible value" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -646,8 +646,6 @@ pub fn TypeWithCompTimeSlice(comptime field_name: []const u8) type {
 }
 
 test "comptime function with mutable pointer is not memoized" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
-
     comptime {
         var x: i32 = 1;
         const ptr = &x;
@@ -662,8 +660,6 @@ fn increment(value: *i32) void {
 }
 
 test "const ptr to comptime mutable data is not memoized" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
-
     comptime {
         var foo = SingleFieldStruct{ .x = 1 };
         try expect(foo.read_x() == 1);

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -572,28 +572,6 @@ test "inlined loop has array literal with elided runtime scope on first iteratio
     }
 }
 
-test "call method on bound fn referring to var instance" {
-    if (builtin.zig_backend != .stage1) {
-        // Let's delay solving this one; I want to try to eliminate bound functions from
-        // the language.
-        return error.SkipZigTest; // TODO
-    }
-
-    try expect(bound_fn() == 1237);
-}
-
-const SimpleStruct = struct {
-    field: i32,
-
-    fn method(self: *const SimpleStruct) i32 {
-        return self.field + 3;
-    }
-};
-
-var simple_struct = SimpleStruct{ .field = 1234 };
-
-const bound_fn = simple_struct.method;
-
 test "ptr to local array argument at comptime" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -425,7 +425,6 @@ test "f64 at compile time is lossy" {
 }
 
 test {
-    if (builtin.zig_backend != .stage1 and builtin.os.tag == .macos) return error.SkipZigTest;
     comptime try expect(@as(f128, 1 << 113) == 10384593717069655257060992658440192);
 }
 

--- a/test/cases/compile_errors/call method on bound fn referring to var instance.zig
+++ b/test/cases/compile_errors/call method on bound fn referring to var instance.zig
@@ -1,0 +1,20 @@
+export fn entry() void {
+    bad(bound_fn() == 1237);
+}
+const SimpleStruct = struct {
+    field: i32,
+
+    fn method(self: *const SimpleStruct) i32 {
+        return self.field + 3;
+    }
+};
+var simple_struct = SimpleStruct{ .field = 1234 };
+const bound_fn = simple_struct.method;
+fn bad(ok: bool) void {
+    _ = ok;
+}
+// error
+// target=native
+// backend=stage2
+//
+// :12:18: error: unable to resolve comptime value


### PR DESCRIPTION
 * Sema: avoid unnecessary safety checks when an error set is empty.
 * Sema: make zirErrorToInt handle comptime errors that are represented
   as integers.
 * Sema: make empty error sets properly integrate with
   typeHasOnePossibleValue.
 * Type: correct the ABI alignment and size of error unions which have
   both zero-bit error set and zero-bit payload. The previous code did
   not account for the fact that we still need to store a bit for
   whether there is an error.
 * LLVM: lower error unions possibly with the payload first or with the
   error code first, depending on alignment. Previously it always put
   the error code first and used a padding array.
 * LLVM: lower functions which have an empty error set as the return
   type the same as anyerror, so that they can be used where
   fn()anyerror function pointers are expected. In such functions, Zig
   will lower ret to returning zero instead of void.

As a result, one more behavior test is passing.