### PR TITLE
Fix indexing in the test runner's log formatting

### DIFF
--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -124,7 +124,10 @@ pub fn log(
         log_err_count += 1;
     }
     if (@enumToInt(message_level) <= @enumToInt(std.testing.log_level)) {
-        std.debug.print("[{s}] ({s}): " ++ format ++ "\n", .{ @tagName(scope), @tagName(message_level) } ++ args);
+        std.debug.print(
+            "[" ++ @tagName(scope) ++ "] (" ++ @tagName(message_level) ++ "): " ++ format ++ "\n",
+            args,
+        );
     }
 }
 


### PR DESCRIPTION
Without this fix the following fails due to the index of the args being changed by the test runner log function.

```zig
const std = @import("std");
test {
    std.log.warn("{[0]d}, 0x{[0]X}", .{123});
}
```