### PR TITLE
stage2: string literal interning

### DIFF
--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -295,6 +295,11 @@ pub fn print(
             return writer.print(".{s}", .{ty.enumFieldName(val.castTag(.enum_field_index).?.data)});
         },
         .bytes => return writer.print("\"{}\"", .{std.zig.fmtEscapes(val.castTag(.bytes).?.data)}),
+        .str_lit => {
+            const str_lit = val.castTag(.str_lit).?.data;
+            const bytes = mod.string_literal_bytes.items[str_lit.index..][0..str_lit.len];
+            return writer.print("\"{}\"", .{std.zig.fmtEscapes(bytes)});
+        },
         .repeated => {
             if (level == 0) {
                 return writer.writeAll(".{ ... }");

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -643,9 +643,18 @@ fn assertEqualPtrs(ptr1: *const u8, ptr2: *const u8) !void {
     try expect(ptr1 == ptr2);
 }
 
+// This one is still up for debate in the language specification.
+// Application code should not rely on this behavior until it is solidified.
+// Currently, stage1 has special case code to make this pass for string literals
+// but it does not work if the values are constructed with comptime code, or if
+// arrays of non-u8 elements are used instead.
+// The official language specification might not make this guarantee. However, if
+// it does make this guarantee, it will make it consistently for all types, not
+// only string literals. This is why stage2 currently has a string table for
+// string literals, to match stage1 and pass this test, however the end-game once
+// the lang spec issue is settled would be to use a global InternPool for comptime
+// memoized objects, making this behavior consistent across all types.
 test "string literal used as comptime slice is memoized" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest; // TODO
-
     const a = "link";
     const b = "link";
     comptime try expect(TypeWithCompTimeSlice(a).Node == TypeWithCompTimeSlice(b).Node);

--- a/test/cases/llvm/pointer_with_different_address_spaces.zig
+++ b/test/cases/llvm/pointer_with_different_address_spaces.zig
@@ -1,12 +1,12 @@
 fn entry(a: *addrspace(.gs) i32) *addrspace(.fs) i32 {
     return a;
 }
-pub fn main() void {
+export fn entry2() void {
     _ = entry;
 }
 
 // error
-// output_mode=Exe
+// output_mode=Obj
 // backend=stage2,llvm
 // target=x86_64-linux,x86_64-macos
 //


### PR DESCRIPTION
This is a temporary addition to stage2 in order to match stage1 behavior,
however the end-game once the lang spec is settled will be to use a global
InternPool for comptime memoized objects, making this behavior consistent
across all types, not only string literals. Or, we might decide to not
guarantee string literals to have equal comptime pointers, in which case
this commit can be reverted.