### PR TITLE
Autodoc: Anytype and Struct sentinels

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1062,13 +1062,27 @@ var zigAnalysis;
     function exprName(expr, opts) {
         switch (Object.keys(expr)[0]) {
           default: throw "oh no";
+          case "fieldRef" : {
+            // const fieldRef = zigAnalysis.decls[expr.fieldRef.index];
+            // const struct_name = zigAnalysis.decls[expr.struct[0].val.typeRef.refPath[0].declRef].name;
+            console.log(expr)
+            console.log(fieldRef)
+            // return "@enumToInt(" + exprName(enumToInt, opts) + ")";
+            // return exprName(fieldRef,opts);
+            return "WIP"
+          }
+          case "enumToInt" : {
+            console.log(expr);
+            const enumToInt = zigAnalysis.exprs[expr.enumToInt];
+            return "@enumToInt(" + exprName(enumToInt, opts) + ")";
+          }
           case "bitSizeOf" : {
             const bitSizeOf = zigAnalysis.exprs[expr.bitSizeOf];
             return "@bitSizeOf(" + exprName(bitSizeOf, opts) + ")";
           }
           case "sizeOf" : {
             const sizeOf = zigAnalysis.exprs[expr.sizeOf];
-            return "sizeOf(" + exprName(sizeOf, opts) + ")";
+            return "@sizeOf(" + exprName(sizeOf, opts) + ")";
           }
           case "binOpIndex" : {
             const binOpIndex = zigAnalysis.exprs[expr.binOpIndex];

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1158,7 +1158,10 @@ var zigAnalysis;
                   default: throw "TODO";
                   case typeKinds.ComptimeExpr:
                   {
-                      return "[ComptimeExpr]";
+                      // trying to match the std lib types
+                      // the *[1]anyopaque behavior it's happening
+                      // because of the known issue with arrays and pointers
+                      return "anyopaque";
                   }
                   case typeKinds.Array:
                   {
@@ -1443,10 +1446,11 @@ var zigAnalysis;
                                       });
                                       payloadHtml += '<span class="tok-kw">' + escapeHtml(name) + '</span>';
                                   } else if ("comptimeExpr" in value) {
+                                      let comptimeExpr = zigAnalysis.comptimeExprs[value.comptimeExpr].code;
                                       if (opts.wantHtml) {
-                                        payloadHtml += '<span class="tok-kw">[ComptimeExpr]</span>';
+                                        payloadHtml += '<span class="tok-kw">' + comptimeExpr + '</span>';
                                       } else {
-                                        payloadHtml += "[ComptimeExpr]";
+                                        payloadHtml += comptimeExpr;
                                       }
                                   } else if (opts.wantHtml) {
                                       payloadHtml += '<span class="tok-kw">anytype</span>';

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1062,6 +1062,30 @@ var zigAnalysis;
     function exprName(expr, opts) {
         switch (Object.keys(expr)[0]) {
           default: throw "oh no";
+          case "struct": {
+            const struct_name = zigAnalysis.decls[expr.struct[0].val.typeRef.refPath[0].declRef].name;
+            let struct_body = "";
+            struct_body += struct_name + "{ ";
+            for (let i = 0; i < expr.struct.length; i++) {
+              const val = expr.struct[i].name
+              const exprArg = zigAnalysis.exprs[expr.struct[i].val.expr.as.exprArg];
+              let value_field = exprArg[Object.keys(exprArg)[0]];
+              if (value_field instanceof Object) {
+                value_field = zigAnalysis.decls[value_field[0].val.typeRef.refPath[0].declRef].name;
+              };
+              struct_body += "." + val + " = " + value_field;
+              if (i !== expr.struct.length - 1) {
+                struct_body += ", ";
+              }  else {
+                struct_body += " ";
+              }
+            }
+              struct_body += "}";
+            return struct_body;
+          }
+          case "null": {
+            return "null";
+          }
           case "array": {
             let payloadHtml = ".{";
             for (let i = 0; i < expr.array.length; i++) {
@@ -1141,7 +1165,7 @@ var zigAnalysis;
                     let arrayObj = /** @type {ArrayType} */ (typeObj);
                     let name = "[";
                     let lenName = exprName(arrayObj.len, opts);
-                    let sentinel = arrayObj.sentinel ? ":0" : "";
+                    let sentinel = arrayObj.sentinel ? ":"+exprName(arrayObj.sentinel, opts) : "";
                     let is_mutable = arrayObj.is_multable ? "const " : "";
 
                     if (opts.wantHtml) {
@@ -1160,7 +1184,7 @@ var zigAnalysis;
                   case typeKinds.Pointer:
                   {
                       let ptrObj = /** @type {PointerType} */(typeObj);
-                      let sentinel = ptrObj.sentinel ? ":0" : "";
+                    let sentinel = ptrObj.sentinel ? ":"+exprName(ptrObj.sentinel, opts) : "";
                       let is_mutable = !ptrObj.is_mutable ? "const " : "";
                       let name = "";
                       switch (ptrObj.size) {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1180,6 +1180,10 @@ var zigAnalysis;
               if (typeof typeObj === 'number') typeObj = zigAnalysis.types[typeObj];
               switch (typeObj.kind) {
                   default: throw "TODO";
+                  case typeKinds.Unanalyzed:
+                  {
+                      return "Unanalyzed";
+                  }
                   case typeKinds.ComptimeExpr:
                   {
                       return "anyopaque";

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1062,6 +1062,10 @@ var zigAnalysis;
     function exprName(expr, opts) {
         switch (Object.keys(expr)[0]) {
           default: throw "oh no";
+          case "bitSizeOf" : {
+            const bitSizeOf = zigAnalysis.exprs[expr.bitSizeOf];
+            return "@bitSizeOf(" + exprName(bitSizeOf, opts) + ")";
+          }
           case "sizeOf" : {
             const sizeOf = zigAnalysis.exprs[expr.sizeOf];
             return "sizeOf(" + exprName(sizeOf, opts) + ")";

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1180,10 +1180,6 @@ var zigAnalysis;
               if (typeof typeObj === 'number') typeObj = zigAnalysis.types[typeObj];
               switch (typeObj.kind) {
                   default: throw "TODO";
-                  case typeKinds.Unanalyzed:
-                  {
-                      return "Unanalyzed";
-                  }
                   case typeKinds.ComptimeExpr:
                   {
                       return "anyopaque";
@@ -1528,8 +1524,8 @@ var zigAnalysis;
 
                       payloadHtml += ') ';
                     if (fnObj.has_cc) {
-                      let cc = zigAnalysis.types[fnObj.cc]
-                      payloadHtml += "callconv(." + cc.name + ") ";
+                      let cc = zigAnalysis.exprs[fnObj.cc]
+                      payloadHtml += "callconv(." + cc.enumLiteral + ") ";
                     }
 
                       if (fnObj.is_inferred_error) {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1062,6 +1062,97 @@ var zigAnalysis;
     function exprName(expr, opts) {
         switch (Object.keys(expr)[0]) {
           default: throw "oh no";
+          case "sizeOf" : {
+            const sizeOf = zigAnalysis.exprs[expr.sizeOf];
+            return "sizeOf(" + exprName(sizeOf, opts) + ")";
+          }
+          case "binOpIndex" : {
+            const binOpIndex = zigAnalysis.exprs[expr.binOpIndex];
+            return exprName(binOpIndex, opts);
+          }
+          case "binOp": {
+            const lhsOp = zigAnalysis.exprs[expr.binOp.lhs];
+            const rhsOp = zigAnalysis.exprs[expr.binOp.rhs];
+            let lhs = exprName(lhsOp, opts);
+            let rhs = exprName(rhsOp, opts);
+
+            let print_lhs = "";
+            let print_rhs = "";
+            if (lhsOp['binOpIndex']) {
+              print_lhs = "(" + lhs + ")";
+            } else {
+              print_lhs = lhs;
+            }
+            if (rhsOp['binOpIndex']) {
+              print_rhs = "(" + rhs + ")";
+            } else {
+              print_rhs = rhs;
+            }
+
+            let operator = "";
+            // binOp.kind is described at Autodoc.zig
+            // Expr section in BinOp struct
+            switch (expr.binOp.opKind) {
+              case 0: {
+                operator += "+";
+                break;
+              }
+              case 1: {
+                operator += "-";
+                break;
+              }
+              case 2: {
+                operator += "*";
+                break;
+              }
+              case 3: {
+                let print_div = "";
+                if (expr.binOp.exact) {
+                  print_div = "@divExact(";
+                }
+                if (expr.binOp.floor) {
+                  print_div = "@divFloor(";
+                }
+                if (expr.binOp.trunc) {
+                  print_div = "@divTrunc(";
+                }
+                return print_div + print_lhs + ", " + print_rhs + ")";
+              }
+              case 4: {
+                operator += "mod"
+                break;
+              }
+              case 5: {
+                operator += "rem"
+                break;
+              }
+              case 6: {
+                operator += "<<";
+                break;
+              }
+              case 7: {
+                operator += ">>";
+                break;
+              }
+              case 8: {
+                operator += "&";
+                break;
+              }
+              case 7: {
+                operator += "|";
+                break;
+              }
+              default: console.log("operator not handled yet or doesn't exist!");
+            };
+            if (expr.binOp.wrap) {
+              operator += "%";
+            }
+            if (expr.binOp.sat) {
+              operator += "|";
+            }
+            return print_lhs + " " + operator + " " + print_rhs;
+
+          }
           case "errorUnion": {
             const errUnionObj = zigAnalysis.types[expr.errorUnion];
             let lhs = exprName(errUnionObj.lhs, opts);

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1078,6 +1078,10 @@ var zigAnalysis;
 
             let print_lhs = "";
             let print_rhs = "";
+
+            console.log(lhsOp)
+            console.log(rhsOp)
+
             if (lhsOp['binOpIndex']) {
               print_lhs = "(" + lhs + ")";
             } else {
@@ -1119,27 +1123,29 @@ var zigAnalysis;
                 return print_div + print_lhs + ", " + print_rhs + ")";
               }
               case 4: {
-                operator += "mod"
-                break;
+                return "@mod(" + print_lhs + ", " + print_rhs + ")";
               }
               case 5: {
-                operator += "rem"
-                break;
+                return "@rem(" + print_lhs + ", " + print_rhs + ")";
               }
               case 6: {
+                // rem_mod
+                return "@rem(" + print_lhs + ", " + print_rhs + ")";
+              }
+              case 7: {
+                if (expr.binOp.exact) {
+                  let print_shl = "@shlExact(";
+                  return print_shl + print_lhs + ", " + print_rhs + ")";
+                }
                 operator += "<<";
                 break;
               }
-              case 7: {
-                operator += ">>";
-                break;
-              }
               case 8: {
-                operator += "&";
-                break;
-              }
-              case 7: {
-                operator += "|";
+                if (expr.binOp.exact) {
+                  let print_shr = "@shrExact(";
+                  return print_shr + print_lhs + ", " + print_rhs + ")";
+                }
+                operator += ">>";
                 break;
               }
               default: console.log("operator not handled yet or doesn't exist!");

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1096,7 +1096,7 @@ var zigAnalysis;
             return payloadHtml + "}";
           }
           case "comptimeExpr": {
-              return "[ComptimeExpr]";
+              return zigAnalysis.comptimeExprs[expr.comptimeExpr].code;
           }
           case "call": {
               let call = zigAnalysis.calls[expr.call];

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1193,7 +1193,7 @@ var zigAnalysis;
                     let name = "[";
                     let lenName = exprName(arrayObj.len, opts);
                     let sentinel = arrayObj.sentinel ? ":"+exprName(arrayObj.sentinel, opts) : "";
-                    let is_mutable = arrayObj.is_multable ? "const " : "";
+                    // let is_mutable = arrayObj.is_multable ? "const " : "";
 
                     if (opts.wantHtml) {
                       name +=
@@ -1202,7 +1202,7 @@ var zigAnalysis;
                       name += lenName + sentinel;
                     }
                     name += "]";
-                    name += is_mutable;
+                    // name += is_mutable;
                     name += exprName(arrayObj.child, opts);
                     return name;
                   }
@@ -1240,13 +1240,14 @@ var zigAnalysis;
                               name += is_mutable;
                               break;
                       }
-                      if (!ptrObj.is_mutable) {
-                          if (opts.wantHtml) {
-                              name += '<span class="tok-kw">const</span> ';
-                          } else {
-                              name += "const ";
-                          }
-                      }
+                      // @check: after the major changes in arrays the consts are came from switch above
+                      // if (!ptrObj.is_mutable) {
+                      //     if (opts.wantHtml) {
+                      //         name += '<span class="tok-kw">const</span> ';
+                      //     } else {
+                      //         name += "const ";
+                      //     }
+                      // }
                       if (ptrObj.is_allowzero) {
                               name += "allowzero ";
                       }

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1110,6 +1110,10 @@ var zigAnalysis;
                 break;
               }
               case 3: {
+                if (!expr.binOp.extact && !expr.binOp.floor && !expr.binOp.trunv) {
+                  operator += "/";
+                  break;
+                }
                 let print_div = "";
                 if (expr.binOp.exact) {
                   print_div = "@divExact(";

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1083,6 +1083,11 @@ var zigAnalysis;
               struct_body += "}";
             return struct_body;
           }
+          case "typeOf": {
+            const typeRefArg = zigAnalysis.exprs[expr.typeOf];
+            let payloadHtml = "@TypeOf(" + exprName(typeRefArg) + ")";
+            return payloadHtml;
+          }
           case "null": {
             return "null";
           }

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1426,16 +1426,41 @@ var zigAnalysis;
 
                                   if (isVarArgs && i === fnObj.params.length - 1) {
                                       payloadHtml += '...';
-                                  } else if ("refPath" in value) {
-                                      if (opts.wantHtml) {
-                                          payloadHtml += '<a href="">';
-                                          payloadHtml +=
-                                            '<span class="tok-kw" style="color:lightblue;">'
-                                              + exprName(value, opts) + '</span>';
-                                          payloadHtml += '</a>';
-                                      } else {
-                                          payloadHtml += exprName(value, opts);
-                                      }
+                                  } 
+                                  else if ("declRef" in value) {
+                                    if (opts.wantHtml) {
+                                      payloadHtml += '<a href="">';
+                                      payloadHtml +=
+                                        '<span class="tok-kw" style="color:lightblue;">'
+                                        + exprName(value, opts) + '</span>';
+                                      payloadHtml += '</a>';
+                                    } else {
+                                      payloadHtml += exprName(value, opts);
+                                    }
+
+                                  } 
+                                  else if ("call" in value) {
+                                    if (opts.wantHtml) {
+                                      payloadHtml += '<a href="">';
+                                      payloadHtml +=
+                                        '<span class="tok-kw" style="color:lightblue;">'
+                                        + exprName(value, opts) + '</span>';
+                                      payloadHtml += '</a>';
+                                    } else {
+                                      payloadHtml += exprName(value, opts);
+                                    }
+
+                                  } 
+                                  else if ("refPath" in value) {
+                                    if (opts.wantHtml) {
+                                      payloadHtml += '<a href="">';
+                                      payloadHtml +=
+                                        '<span class="tok-kw" style="color:lightblue;">'
+                                        + exprName(value, opts) + '</span>';
+                                      payloadHtml += '</a>';
+                                    } else {
+                                      payloadHtml += exprName(value, opts);
+                                    }
 
                                   } else if ("type" in value) {
                                       let name = exprName(value, {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1257,15 +1257,16 @@ var zigAnalysis;
                               name += ") ";
                       }
                       if (ptrObj.has_align) {
+                          let align = exprName(ptrObj.align, opts);
                           if (opts.wantHtml) {
                               name += '<span class="tok-kw">align</span>(';
                           } else {
                               name += "align(";
                           }
                           if (opts.wantHtml) {
-                              name += '<span class="tok-number">' + ptrObj.align + '</span>';
+                              name += '<span class="tok-number">' + align + '</span>';
                           } else {
-                              name += ptrObj.align;
+                              name += align;
                           }
                           if (ptrObj.hostIntBytes != null) {
                               name += ":";

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1152,6 +1152,9 @@ var zigAnalysis;
                 operator += ">>";
                 break;
               }
+              case 9 : {
+                return "@bitCast(" + print_lhs + ", " + print_rhs + ")";
+              }
               default: console.log("operator not handled yet or doesn't exist!");
             };
             if (expr.binOp.wrap) {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1155,6 +1155,13 @@ var zigAnalysis;
               case 9 : {
                 return "@bitCast(" + print_lhs + ", " + print_rhs + ")";
               }
+              case 10 : {
+                operator += "|";
+                break;
+              }
+              case 11 : {
+                return "@alignCast(" + print_lhs + ", " + print_rhs + ")";
+              }
               default: console.log("operator not handled yet or doesn't exist!");
             };
             if (expr.binOp.wrap) {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1182,9 +1182,6 @@ var zigAnalysis;
                   default: throw "TODO";
                   case typeKinds.ComptimeExpr:
                   {
-                      // trying to match the std lib types
-                      // the *[1]anyopaque behavior it's happening
-                      // because of the known issue with arrays and pointers
                       return "anyopaque";
                   }
                   case typeKinds.Array:

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1210,6 +1210,7 @@ var zigAnalysis;
                     let sentinel = ptrObj.sentinel ? ":"+exprName(ptrObj.sentinel, opts) : "";
                       let is_mutable = !ptrObj.is_mutable ? "const " : "";
                       let name = "";
+                    console.log(ptrObj);
                       switch (ptrObj.size) {
                           default:
                               console.log("TODO: implement unhandled pointer size case");
@@ -1236,21 +1237,25 @@ var zigAnalysis;
                               name += is_mutable;
                               break;
                       }
-                      if (ptrObj['const']) {
+                      if (!ptrObj.is_mutable) {
                           if (opts.wantHtml) {
                               name += '<span class="tok-kw">const</span> ';
                           } else {
                               name += "const ";
                           }
                       }
-                      if (ptrObj['volatile']) {
-                          if (opts.wantHtml) {
-                              name += '<span class="tok-kw">volatile</span> ';
-                          } else {
-                              name += "volatile ";
-                          }
+                      if (ptrObj.is_allowzero) {
+                              name += "allowzero ";
                       }
-                      if (ptrObj.align != null) {
+                      if (ptrObj.is_volatile) {
+                              name += "volatile ";
+                      }
+                      if (ptrObj.has_addrspace) {
+                              name += "addrspace(";
+                              name += "." + "";
+                              name += ") ";
+                      }
+                      if (ptrObj.has_align) {
                           if (opts.wantHtml) {
                               name += '<span class="tok-kw">align</span>(';
                           } else {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1087,7 +1087,8 @@ var zigAnalysis;
             console.log(expr)
             let payloadHtml = "@TypeOf("
             for (let i = 0; i < expr.typeOf_peer.length; i++) {
-              payloadHtml += exprName(expr.typeOf_peer[i], {wantHtml: true, wantLink:true});
+              let elem = zigAnalysis.exprs[expr.typeOf_peer[i]];
+              payloadHtml += exprName(elem, {wantHtml: true, wantLink:true});
               if (i !== expr.typeOf_peer.length - 1) {
                 payloadHtml += ", ";
               }

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1329,6 +1329,9 @@ var zigAnalysis;
                               name += is_mutable;
                               break;
                           case pointerSizeEnum.Slice:
+                              if (ptrObj.is_ref) {
+                                name += "*";
+                              }
                               name += "[";
                               name += sentinel;
                               name += "]";

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1374,7 +1374,10 @@ var zigAnalysis;
                       let payloadHtml = "";
                       if (opts.wantHtml) {
                           if (fnObj.is_extern) {
-                            payloadHtml += "pub \"extern\" ";
+                            payloadHtml += "pub extern ";
+                          }
+                          if (fnObj.has_lib_name) {
+                            payloadHtml += "\"" + fnObj.lib_name +"\" ";
                           }
                           payloadHtml += '<span class="tok-kw">fn</span>';
                           if (opts.fnDecl) {
@@ -1523,9 +1526,16 @@ var zigAnalysis;
                           }
 
                       payloadHtml += ') ';
+
+                    if (fnObj.has_align) {
+                      let align = zigAnalysis.exprs[fnObj.align]
+                      payloadHtml += "align(" + exprName(align, opts) + ") ";
+                    }
                     if (fnObj.has_cc) {
                       let cc = zigAnalysis.exprs[fnObj.cc]
-                      payloadHtml += "callconv(." + cc.enumLiteral + ") ";
+                      if (cc) {
+                        payloadHtml += "callconv(." + cc.enumLiteral + ") ";
+                      }
                     }
 
                       if (fnObj.is_inferred_error) {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1147,10 +1147,11 @@ var zigAnalysis;
               return payloadHtml;
           }
           case "as": {
-              const typeRefArg = zigAnalysis.exprs[expr.as.typeRefArg];
+              // const typeRefArg = zigAnalysis.exprs[expr.as.typeRefArg];
               const exprArg = zigAnalysis.exprs[expr.as.exprArg];
-              return "@as(" + exprName(typeRefArg, opts) +
-                ", " + exprName(exprArg, opts) + ")";
+              // return "@as(" + exprName(typeRefArg, opts) +
+              //   ", " + exprName(exprArg, opts) + ")";
+              return exprName(exprArg, opts);
           }
           case "declRef": {
             return zigAnalysis.decls[expr.declRef].name;

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1259,6 +1259,12 @@ var zigAnalysis;
           case "int": {
               return "" + expr.int;
           }
+          case "float": {
+              return "" + expr.float.toFixed(2);
+          }
+          case "undefined": {
+              return "undefined";
+          }
           case "string": {
             return "\"" + escapeHtml(expr.string) + "\"";
           }

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1062,6 +1062,13 @@ var zigAnalysis;
     function exprName(expr, opts) {
         switch (Object.keys(expr)[0]) {
           default: throw "oh no";
+          case "errorUnion": {
+            const errUnionObj = zigAnalysis.types[expr.errorUnion];
+            let lhs = exprName(errUnionObj.lhs, opts);
+            let rhs = exprName(errUnionObj.rhs, opts);
+            return lhs + "!" + rhs;
+
+          }
           case "struct": {
             const struct_name = zigAnalysis.decls[expr.struct[0].val.typeRef.refPath[0].declRef].name;
             let struct_body = "";
@@ -1084,7 +1091,6 @@ var zigAnalysis;
             return struct_body;
           }
           case "typeOf_peer": {
-            console.log(expr)
             let payloadHtml = "@TypeOf("
             for (let i = 0; i < expr.typeOf_peer.length; i++) {
               let elem = zigAnalysis.exprs[expr.typeOf_peer[i]];
@@ -1094,7 +1100,6 @@ var zigAnalysis;
               }
             }
             payloadHtml += ")";
-            console.log(payloadHtml)
             return payloadHtml;
 
           }
@@ -1111,7 +1116,7 @@ var zigAnalysis;
             for (let i = 0; i < expr.array.length; i++) {
                 if (i != 0) payloadHtml += ", ";
                 let elem = zigAnalysis.exprs[expr.array[i]];
-                payloadHtml += exprName(elem);
+                payloadHtml += exprName(elem, opts);
             }
             return payloadHtml + "}";
           }
@@ -1127,7 +1132,7 @@ var zigAnalysis;
                 default: throw "TODO";
                 case "declRef":
                 case "refPath": {
-                    payloadHtml += exprName(call.func);
+                    payloadHtml += exprName(call.func, opts);
                     break;
                 }
               }
@@ -1135,7 +1140,7 @@ var zigAnalysis;
 
               for (let i = 0; i < call.args.length; i++) {
                   if (i != 0) payloadHtml += ", ";
-                  payloadHtml += exprName(call.args[i]);
+                  payloadHtml += exprName(call.args[i], opts);
               }
 
               payloadHtml += ")";
@@ -1173,7 +1178,6 @@ var zigAnalysis;
 
               let typeObj = expr.type;
               if (typeof typeObj === 'number') typeObj = zigAnalysis.types[typeObj];
-
               switch (typeObj.kind) {
                   default: throw "TODO";
                   case typeKinds.ComptimeExpr:
@@ -1210,7 +1214,6 @@ var zigAnalysis;
                     let sentinel = ptrObj.sentinel ? ":"+exprName(ptrObj.sentinel, opts) : "";
                       let is_mutable = !ptrObj.is_mutable ? "const " : "";
                       let name = "";
-                    console.log(ptrObj);
                       switch (ptrObj.size) {
                           default:
                               console.log("TODO: implement unhandled pointer size case");
@@ -1352,40 +1355,29 @@ var zigAnalysis;
                   {
                       let errSetObj = /** @type {ErrSetType} */(typeObj);
                       if (errSetObj.fields == null) {
-                          if (wantHtml) {
                               return '<span class="tok-type">anyerror</span>';
-                          } else {
-                              return "anyerror";
-                          }
                       } else {
-                          throw "TODO";
-                          // if (wantHtml) {
-                          //     return escapeHtml(typeObj.name);
-                          // } else {
-                          //     return typeObj.name;
-                          // }
+                          // throw "TODO";
+                        let html = "error{" + errSetObj.fields[0].name + "}";
+                        return html;
                       }
                   }
+                  
                   case typeKinds.ErrorUnion:
                   {
-                      throw "TODO";
-                      // TODO: implement error union printing assuming that both
-                      // payload and error union are walk results!
-                      // let errUnionObj = /** @type {ErrUnionType} */(typeObj);
-                      // let errSetTypeObj = /** @type {ErrSetType} */ (zigAnalysis.types[errUnionObj.err]);
-                      // let payloadHtml = typeValueName(errUnionObj.payload, wantHtml, wantSubLink, null);
-                      // if (fnDecl != null && errSetTypeObj.fn === fnDecl.value.type) {
-                      //     // function index parameter supplied and this is the inferred error set of it
-                      //     return "!" + payloadHtml;
-                      // } else {
-                      //     return typeValueName(errUnionObj.err, wantHtml, wantSubLink, null) + "!" + payloadHtml;
-                      // }
+                    let errUnionObj = /** @type {ErrUnionType} */(typeObj);
+                    let lhs = exprName(errUnionObj.lhs, opts);
+                    let rhs = exprName(errUnionObj.rhs, opts);
+                    return lhs + "!" + rhs;
                   }
                   case typeKinds.Fn:
                   {
                       let fnObj = /** @type {Fn} */(typeObj);
                       let payloadHtml = "";
                       if (opts.wantHtml) {
+                          if (fnObj.is_extern) {
+                            payloadHtml += "pub \"extern\" ";
+                          }
                           payloadHtml += '<span class="tok-kw">fn</span>';
                           if (opts.fnDecl) {
                               payloadHtml += ' <span class="tok-fn">';
@@ -1533,6 +1525,14 @@ var zigAnalysis;
                           }
 
                       payloadHtml += ') ';
+                    if (fnObj.has_cc) {
+                      let cc = zigAnalysis.types[fnObj.cc]
+                      payloadHtml += "callconv(." + cc.name + ") ";
+                    }
+
+                      if (fnObj.is_inferred_error) {
+                          payloadHtml += "!";
+                      }
                       if (fnObj.ret != null) {
                           payloadHtml += exprName(fnObj.ret, opts);
                       } else if (opts.wantHtml) {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1083,9 +1083,23 @@ var zigAnalysis;
               struct_body += "}";
             return struct_body;
           }
+          case "typeOf_peer": {
+            console.log(expr)
+            let payloadHtml = "@TypeOf("
+            for (let i = 0; i < expr.typeOf_peer.length; i++) {
+              payloadHtml += exprName(expr.typeOf_peer[i], {wantHtml: true, wantLink:true});
+              if (i !== expr.typeOf_peer.length - 1) {
+                payloadHtml += ", ";
+              }
+            }
+            payloadHtml += ")";
+            console.log(payloadHtml)
+            return payloadHtml;
+
+          }
           case "typeOf": {
             const typeRefArg = zigAnalysis.exprs[expr.typeOf];
-            let payloadHtml = "@TypeOf(" + exprName(typeRefArg) + ")";
+            let payloadHtml = "@TypeOf(" + exprName(typeRefArg, {wantHtml: true, wantLink:true}) + ")";
             return payloadHtml;
           }
           case "null": {
@@ -1432,6 +1446,30 @@ var zigAnalysis;
                                   if (isVarArgs && i === fnObj.params.length - 1) {
                                       payloadHtml += '...';
                                   } 
+                                  else if ("typeOf" in value) {
+                                    if (opts.wantHtml) {
+                                      payloadHtml += '<a href="">';
+                                      payloadHtml +=
+                                        '<span class="tok-kw" style="color:lightblue;">'
+                                        + exprName(value, opts) + '</span>';
+                                      payloadHtml += '</a>';
+                                    } else {
+                                      payloadHtml += exprName(value, opts);
+                                    }
+
+                                  } 
+                                  else if ("typeOf_peer" in value) {
+                                    if (opts.wantHtml) {
+                                      payloadHtml += '<a href="">';
+                                      payloadHtml +=
+                                        '<span class="tok-kw" style="color:lightblue;">'
+                                        + exprName(value, opts) + '</span>';
+                                      payloadHtml += '</a>';
+                                    } else {
+                                      payloadHtml += exprName(value, opts);
+                                    }
+
+                                  } 
                                   else if ("declRef" in value) {
                                     if (opts.wantHtml) {
                                       payloadHtml += '<a href="">';
@@ -1454,7 +1492,6 @@ var zigAnalysis;
                                     } else {
                                       payloadHtml += exprName(value, opts);
                                     }
-
                                   } 
                                   else if ("refPath" in value) {
                                     if (opts.wantHtml) {
@@ -1466,7 +1503,6 @@ var zigAnalysis;
                                     } else {
                                       payloadHtml += exprName(value, opts);
                                     }
-
                                   } else if ("type" in value) {
                                       let name = exprName(value, {
                                         wantHtml: false,

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -416,6 +416,7 @@ const DocData = struct {
             address_space: ?Expr = null,
             bit_start: ?Expr = null,
             host_size: ?Expr = null,
+            is_ref: bool = false,
             is_allowzero: bool = false,
             is_mutable: bool = false,
             is_volatile: bool = false,
@@ -582,8 +583,9 @@ const DocData = struct {
                         \\"has_align": {},
                         \\"has_addrspace": {},
                         \\"has_bit_range": {},
+                        \\"is_ref": {},
                         \\
-                    , .{ v.is_allowzero, v.is_mutable, v.is_volatile, v.has_sentinel, v.has_align, v.has_addrspace, v.has_bit_range });
+                    , .{ v.is_allowzero, v.is_mutable, v.is_volatile, v.has_sentinel, v.has_align, v.has_addrspace, v.has_bit_range, v.is_ref });
                     if (options.whitespace) |ws| try ws.outputIndent(w);
                     try w.print(
                         \\"child":
@@ -1962,17 +1964,12 @@ fn walkInstruction(
             }
 
             const type_slot_index = self.types.items.len;
-            try self.types.append(self.arena, .{
-                .Array = .{
-                    .len = .{
-                        .int = .{
-                            .value = operands.len - 1,
-                            .negated = false,
-                        },
-                    },
-                    .child = array_type.?,
-                },
-            });
+            try self.types.append(self.arena, .{ .Pointer = .{
+                .size = .Slice,
+                .child = array_type.?,
+                .is_mutable = true,
+                .is_ref = true,
+            } });
 
             return DocData.WalkResult{
                 .typeRef = .{ .type = type_slot_index },

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -536,9 +536,9 @@ const DocData = struct {
                         \\
                     , .{ v.is_allowzero, v.is_mutable, v.is_volatile, v.has_sentinel, v.has_align, v.has_addrspace, v.has_bit_range });
                     if (options.whitespace) |ws| try ws.outputIndent(w);
-                    // try w.print(
-                    //     \\"child":
-                    // , .{});
+                    try w.print(
+                        \\"child":
+                    , .{});
 
                     if (options.whitespace) |*ws| ws.indent_level += 1;
                     try v.child.jsonStringify(options, w);
@@ -2761,9 +2761,10 @@ fn analyzeFunction(
             const extra = file.zir.extraData(Zir.Inst.ExtendedFunc, inst_data.payload_index);
             var cc_index: ?usize = null;
             if (extra.data.bits.has_cc) {
-                const cc_ref = @intToEnum(Zir.Inst.Ref, file.zir.extra[extra.end]);
-                _ = try self.walkRef(file, scope, cc_ref, false);
-                cc_index = self.types.items.len - 1;
+                // @panic with .calling_convention_inline
+                // const cc_ref = @intToEnum(Zir.Inst.Ref, file.zir.extra[extra.end]);
+                // _ = try self.walkRef(file, scope, cc_ref, false);
+                // cc_index = self.types.items.len - 1;
             }
 
             break :blk .{
@@ -2773,7 +2774,7 @@ fn analyzeFunction(
                     .params = param_type_refs.items,
                     .ret = ret_type_ref.expr,
                     .is_extern = extra.data.bits.is_extern,
-                    .has_cc = extra.data.bits.has_cc,
+                    // .has_cc = extra.data.bits.has_cc,
                     .is_inferred_error = extra.data.bits.is_inferred_error,
                     .cc = cc_index,
                 },

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -1251,6 +1251,37 @@ fn walkInstruction(
             };
         },
 
+        .div => {
+            const pl_node = data[inst_index].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
+
+            const binop_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
+
+            var lhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.lhs,
+                false,
+            );
+            var rhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.rhs,
+                false,
+            );
+
+            const lhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, lhs.expr);
+            const rhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, rhs.expr);
+            self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .opKind = 3 } };
+
+            return DocData.WalkResult{
+                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .expr = .{ .binOpIndex = binop_index },
+            };
+        },
         .div_exact => {
             const pl_node = data[inst_index].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -3423,7 +3423,9 @@ fn tryResolveRefPath(
                         "failed to match `{s}` in struct",
                         .{child_string},
                     );
-                    path[i + 1] = (try self.cteTodo("match failure")).expr;
+                    // path[i + 1] = (try self.cteTodo("match failure")).expr;
+                    // this are working, check c.zig
+                    path[i + 1] = (try self.cteTodo(child_string)).expr;
                     continue :outer;
                 },
             },

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -667,7 +667,7 @@ const DocData = struct {
             rhs: usize, // index in `exprs`
             // opKind
             // Identify the operator in js
-            // 0: add, 1: sub, 2: mul, 3: div, 4: mod, 5: rem, 6: shl, 7: shr, 8: bitwise_and, 9: bitwise_or
+            // 0: add, 1: sub, 2: mul, 3: div, 4: mod, 5: rem, 6: rem_mod, 7: shl, 8: shr
             // Others binOp are not handled yet
             opKind: usize = 0,
             // flags to operations
@@ -1342,6 +1342,260 @@ fn walkInstruction(
                 .expr = .{ .binOpIndex = binop_index },
             };
         },
+
+        .mod => {
+            const pl_node = data[inst_index].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
+
+            const binop_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
+
+            var lhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.lhs,
+                false,
+            );
+            var rhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.rhs,
+                false,
+            );
+
+            const lhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, lhs.expr);
+            const rhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, rhs.expr);
+            self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .exact = true, .opKind = 4 } };
+
+            return DocData.WalkResult{
+                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .expr = .{ .binOpIndex = binop_index },
+            };
+        },
+        .rem => {
+            const pl_node = data[inst_index].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
+
+            const binop_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
+
+            var lhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.lhs,
+                false,
+            );
+            var rhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.rhs,
+                false,
+            );
+
+            const lhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, lhs.expr);
+            const rhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, rhs.expr);
+            self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .floor = true, .opKind = 5 } };
+
+            return DocData.WalkResult{
+                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .expr = .{ .binOpIndex = binop_index },
+            };
+        },
+
+        // @check how to test it
+        .mod_rem => {
+            const pl_node = data[inst_index].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
+
+            const binop_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
+
+            var lhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.lhs,
+                false,
+            );
+            var rhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.rhs,
+                false,
+            );
+
+            const lhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, lhs.expr);
+            const rhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, rhs.expr);
+            self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .floor = true, .opKind = 6 } };
+
+            return DocData.WalkResult{
+                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .expr = .{ .binOpIndex = binop_index },
+            };
+        },
+
+        .shl => {
+            const pl_node = data[inst_index].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
+
+            const binop_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
+
+            var lhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.lhs,
+                false,
+            );
+            var rhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.rhs,
+                false,
+            );
+
+            const lhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, lhs.expr);
+            const rhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, rhs.expr);
+            self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .opKind = 7 } };
+
+            return DocData.WalkResult{
+                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .expr = .{ .binOpIndex = binop_index },
+            };
+        },
+        .shl_exact => {
+            const pl_node = data[inst_index].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
+
+            const binop_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
+
+            var lhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.lhs,
+                false,
+            );
+            var rhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.rhs,
+                false,
+            );
+
+            const lhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, lhs.expr);
+            const rhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, rhs.expr);
+            self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .exact = true, .opKind = 7 } };
+
+            return DocData.WalkResult{
+                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .expr = .{ .binOpIndex = binop_index },
+            };
+        },
+        .shl_sat => {
+            const pl_node = data[inst_index].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
+
+            const binop_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
+
+            var lhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.lhs,
+                false,
+            );
+            var rhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.rhs,
+                false,
+            );
+
+            const lhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, lhs.expr);
+            const rhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, rhs.expr);
+            self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .sat = true, .opKind = 7 } };
+
+            return DocData.WalkResult{
+                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .expr = .{ .binOpIndex = binop_index },
+            };
+        },
+
+        .shr => {
+            const pl_node = data[inst_index].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
+
+            const binop_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
+
+            var lhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.lhs,
+                false,
+            );
+            var rhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.rhs,
+                false,
+            );
+
+            const lhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, lhs.expr);
+            const rhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, rhs.expr);
+            self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .opKind = 8 } };
+
+            return DocData.WalkResult{
+                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .expr = .{ .binOpIndex = binop_index },
+            };
+        },
+        .shr_exact => {
+            const pl_node = data[inst_index].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
+
+            const binop_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
+
+            var lhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.lhs,
+                false,
+            );
+            var rhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.rhs,
+                false,
+            );
+
+            const lhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, lhs.expr);
+            const rhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, rhs.expr);
+            self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .exact = true, .opKind = 8 } };
+
+            return DocData.WalkResult{
+                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .expr = .{ .binOpIndex = binop_index },
+            };
+        },
+
         .error_union_type => {
             const pl_node = data[inst_index].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
@@ -1845,14 +2099,6 @@ fn walkInstruction(
 
             const dest_type_idx = self.exprs.items.len;
             try self.exprs.append(self.arena, dest_type_walk.expr);
-
-            const sep = "=" ** 200;
-            std.debug.print("{s}\n", .{sep});
-            std.debug.print("AS NODE\n", .{});
-            std.debug.print("extra = {any}\n", .{extra});
-            std.debug.print("desty_type_walk = {any}\n", .{dest_type_walk});
-            std.debug.print("operand = {any}\n", .{operand});
-            std.debug.print("{s}\n", .{sep});
 
             // TODO: there's something wrong with how both `as` and `WalkrResult`
             //       try to store type information.
@@ -3305,14 +3551,7 @@ fn analyzeFunctionExtended(
     if (extra.data.bits.has_align) {
         const align_ref = @intToEnum(Zir.Inst.Ref, file.zir.extra[extra_index]);
         align_index = self.exprs.items.len;
-        const result = try self.walkRef(file, scope, align_ref, false);
-
-        const sep = "=" ** 200;
-        std.debug.print("{s}\n", .{sep});
-        std.debug.print("ALIGN\n", .{});
-        std.debug.print("align_ref = {any}\n", .{align_ref});
-        std.debug.print("result = {any}\n", .{result});
-        std.debug.print("{s}\n", .{sep});
+        _ = try self.walkRef(file, scope, align_ref, false);
     }
 
     self.types.items[type_slot_index] = .{

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -143,6 +143,9 @@ pub fn generateZirData(self: *Autodoc) !void {
                         .ComptimeFloat = .{ .name = tmpbuf.toOwnedSlice() },
                     },
 
+                    .anyopaque_type => .{
+                        .ComptimeExpr = .{ .name = tmpbuf.toOwnedSlice() },
+                    },
                     .bool_type => .{
                         .Bool = .{ .name = tmpbuf.toOwnedSlice() },
                     },

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -147,6 +147,9 @@ pub fn generateZirData(self: *Autodoc) !void {
                         .Bool = .{ .name = tmpbuf.toOwnedSlice() },
                     },
 
+                    .noreturn_type => .{
+                        .NoReturn = .{ .name = tmpbuf.toOwnedSlice() },
+                    },
                     .void_type => .{
                         .Void = .{ .name = tmpbuf.toOwnedSlice() },
                     },
@@ -525,6 +528,7 @@ const DocData = struct {
                         try sentinel.jsonStringify(options, w);
                         try w.print(",", .{});
                     }
+                    if (options.whitespace) |ws| try ws.outputIndent(w);
                     try w.print(
                         \\"is_allowzero": {},
                         \\"is_mutable": {},

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -2376,7 +2376,7 @@ fn tryResolveRefPath(
                 path[i + 1] = (try self.cteTodo("match failure")).expr;
                 continue :outer;
             },
-            .comptimeExpr, .call => {
+            .comptimeExpr, .call, .typeOf => {
                 // Since we hit a cte, we leave the remaining strings unresolved
                 // and completely give up on resolving this decl path.
                 //decl_path.hasCte = true;

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -1788,6 +1788,14 @@ fn walkInstruction(
                 array_data[idx] = wr.expr.as.exprArg;
             }
 
+            // @check
+            // not working with
+            // const value_slice_float = []f32{42.0};
+            // const value_slice_float2: []f32 = .{42.0};
+            // rendering [][]f32
+            // the reason for that is it's initialized as a pointer
+            // in this case getting the last type index works fine
+            // but when it's not after a pointer it's thrown an error in js.
             const type_slot_index = self.types.items.len;
             try self.types.append(self.arena, .{ .Pointer = .{
                 .size = .Slice,

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -292,10 +292,27 @@ const DocData = struct {
             if (options.whitespace) |*ws| ws.indent_level += 1;
             while (it.next()) |kv| : (idx += 1) {
                 if (options.whitespace) |ws| try ws.outputIndent(w);
-                try w.print("\"{s}\": {d}", .{
-                    kv.key_ptr.*.sub_file_path,
-                    kv.value_ptr.*,
-                });
+                const builtin = @import("builtin");
+                if (builtin.target.os.tag == .windows) {
+                    try w.print("\"", .{});
+                    for (kv.key_ptr.*.sub_file_path) |c| {
+                        if (c == '\\') {
+                            try w.print("\\", .{});
+                            try w.print("\\", .{});
+                        } else {
+                            try w.print("{c}", .{c});
+                        }
+                    }
+                    try w.print("\"", .{});
+                    try w.print(": {d}", .{
+                        kv.value_ptr.*,
+                    });
+                } else {
+                    try w.print("\"{s}\": {d}", .{
+                        kv.key_ptr.*.sub_file_path,
+                        kv.value_ptr.*,
+                    });
+                }
                 if (idx != self.data.count() - 1) try w.writeByte(',');
                 try w.writeByte('\n');
             }

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -1242,10 +1242,6 @@ fn walkInstruction(
             };
         },
         .typeof_builtin => {
-            // @check: @TypeOf(T)
-            // right now it's only showing the T
-            // a way to solve it could be creating a .call
-            // another way is with a flag to handle it on Frontend
             const pl_node = data[inst_index].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Block, pl_node.payload_index);
             const body = file.zir.extra[extra.end..][extra.data.body_len - 1];
@@ -1257,7 +1253,13 @@ fn walkInstruction(
                 false,
             );
 
-            return operand;
+            const operand_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, operand.expr);
+
+            return DocData.WalkResult{
+                .typeRef = operand.typeRef,
+                .expr = .{ .typeOf = operand_index },
+            };
         },
         .type_info => {
             // @check

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -669,7 +669,7 @@ const DocData = struct {
             rhs: usize, // index in `exprs`
             // opKind
             // Identify the operator in js
-            // 0: add, 1: sub, 2: mul, 3: div, 4: mod, 5: rem, 6: rem_mod, 7: shl, 8: shr, 9: bitcast
+            // 0: add, 1: sub, 2: mul, 3: div, 4: mod, 5: rem, 6: rem_mod, 7: shl, 8: shr, 9: bitcast, 10: bit_or, 11: align_cast
             // Others binOp are not handled yet
             opKind: usize = 0,
             // flags to operations
@@ -994,6 +994,68 @@ fn walkInstruction(
             const rhs_index = self.exprs.items.len;
             try self.exprs.append(self.arena, rhs.expr);
             self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .opKind = 9 } };
+
+            return DocData.WalkResult{
+                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .expr = .{ .binOpIndex = binop_index },
+            };
+        },
+        .align_cast => {
+            const pl_node = data[inst_index].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
+
+            const binop_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
+
+            var lhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.lhs,
+                false,
+            );
+            var rhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.rhs,
+                false,
+            );
+
+            const lhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, lhs.expr);
+            const rhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, rhs.expr);
+            self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .opKind = 11 } };
+
+            return DocData.WalkResult{
+                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .expr = .{ .binOpIndex = binop_index },
+            };
+        },
+        .bit_or => {
+            const pl_node = data[inst_index].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
+
+            const binop_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
+
+            var lhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.lhs,
+                false,
+            );
+            var rhs: DocData.WalkResult = try self.walkRef(
+                file,
+                parent_scope,
+                extra.data.rhs,
+                false,
+            );
+
+            const lhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, lhs.expr);
+            const rhs_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, rhs.expr);
+            self.exprs.items[binop_index] = .{ .binOp = .{ .lhs = lhs_index, .rhs = rhs_index, .opKind = 10 } };
 
             return DocData.WalkResult{
                 .typeRef = .{ .type = @enumToInt(Ref.type_type) },


### PR DESCRIPTION
Working only when the slice is initialized with `_` or a known number representing the size.
I didn't found a way to get the sentinel in other cases, the `ptr_type` has a flag saying it has a sentinel but there's no reference for that sentinel in it's own structure like in some `array` initializers which I was able to grab from the last element of the array.
Following the zir generated there's a way to grab the sentinel before `ptr_type` but the `tags` like `str` or `int` were never called, I wasn't able to figure out how to get it from somewhere else or how to made they being called.

There are some minor changes in js to handle comptimeExprs.
The `anyopaque` (old [comptimeExpr]) has an [1] showing in from of itself.
```
Things I said above are not true anymore.
```
`Sentinel examples`
```zig
const string = "string";
const string_with_sentinel: [5:0]u8 = "string";
const array_string_with_sentinel_string: [2:"string"]u8 = .{ "string1", "string2" };
const array_string_with_sentinel_string_const: [2:"string"]u8 = .{ "string1", "string2" };
const array_string_with_sentinel_string_2 = [2:"string"]u8{ "string1", "string2" };

const slice_with_null_any_number: [3:42]usize = .{ 1, 2, 3 };
const slice_with_char_sentinel: [2:'a']u8 = .{ 'a', 'b' };

const slice_with_null_sentinel: [3:null]?usize = .{ 1, 2, 3 };
const array_type_sentinel_and_array_init_sent3 = [_:42]u8{ 1, 2, 3 };
const array_type_sentinel_and_array_init_sent2 = [3:42]u8{ 1, 2, 3 };

const ptr_array_char_with_sentinel_string = &[_:"string"]u8{ 'a', 'b' };
const ptr_array_char_with_sentinel_char = &[_:'a']u8{ 1, 2, 3 };

const Pointer = struct { ptr: usize };
const Sentinel = struct { val1: bool, val2: Pointer };
const slice_with_struct_sentinel = [1:Sentinel{ .val1 = false }]Sentinel{Sentinel{ .val1 = true, .val2 = Pointer{ .ptr = 42 } }}; 
const slice_with_struct_sentinel2 = [_:Sentinel{ .val1 = false }]Sentinel{Sentinel{ .val1 = true, .val2 = Pointer{ .ptr = 42 } }}; 

const slice_with_struct_sentinel_not_sized: [:Sentinel{ .val1 = false }]Sentinel = .{Sentinel{ .val1 = true, .val2 = Pointer{ .ptr = 42 } }};
const slice_with_struct_sentinel_not_sized2 = [:Sentinel{ .val1 = false }]Sentinel{Sentinel{ .val1 = true, .val2 = Pointer{ .ptr = 42 } }};
const slice_with_struct_sentinel_not_sized_undefined: [:Sentinel{ .val1 = false }]Sentinel = undefined;
const ptr_type_sentinel: [:0]u8 = undefined;
const ptr_type_sentinel_char: [:'z']u8 = undefined;

const array_many_const_sentinel: [*:42]u8 = undefined;
const array_many_const_sentinel_const: [*:42]const u8 = undefined;
const ptr_with_sentinel_string: [:"string"]const u8 = undefined;
const ptr_with_sentinel_int: [:42]u8 = "string";
const ptr_with_sentinel_int_const: [:42]const u8 = "string";
const array_with_sentinel_string: [:"string"]u8 = .{ "string1", "string2" };
const attay_with_sentinel_string_const = [:"string"]const u8{ "string1", "string2" };

```

The following code are partially working, `@TypeOf()` are not rendered yet, just rendering the `type`.
Structs now appear in fn decls.
`.typeOf_peer` has his own field which is `[]usize` meaning an array of exprs indexes.
It's possible to transform it in `.typeof` (which represents `.typeof` and `typeof_builtin`) but I think this should be discussed first because it's implies in change the behavior of both.

Added handling for pointer flags and fixed comptime at anytype params.
I still don't know how to grab the information needed to send to json.

Added support for pointer sentinels and extra info, like `align()`
Function decls now show all fn info generated by zir.

Fixed the `@as` node problem.

```zig
const Arg = struct {
    a: usize,
};

pub fn fun1(a: Arg) Arg {
    _ = a;
}

pub fn fun2(a: type) @TypeOf(type) {
    return a;
}

pub fn fun1(a: @TypeOf(u32, i16, u8)) @TypeOf(u32, i32, i16, u8) {
    _ = a;
}

pub fn fun2(a: @TypeOf(u32, u8)) @TypeOf(u32, i32) {
    _ = a;
}

pub fn fun1(a: *volatile u8) *volatile u8 {
    return a;
}
pub fn fun2(a: *allowzero u8) *allowzero u8 {
    return a;
}
pub fn fun3(a: *align(@alignOf(@TypeOf(u8))) u8) *align(@alignOf(@TypeOf(u8))) u8 {
    return a;
}
pub fn fun4(a: *addrspace(.global) u8) *addrspace(.global) u8 {
    return a;
}
pub fn fun5(a: anytype, comptime b: anytype) void {
    _ = a;
    _ = b;
}

fn fun1(a: ?usize) callconv(.Naked) !?usize {
    return a;
}
fn fun2(a: usize) callconv(.C) usize {
    return a;
}
fn fun3(a: usize) anyerror!usize {
    return a;
}
fn fun4(a: *usize) callconv(.C) anyerror!?*usize {
    return a;
}
fn fun5(a: u32) callconv(.C) error{SomethingHere}!u32 {
    return a;
}
pub extern fn funExternCallconvAnyerrorExtended(a: usize) callconv(.Naked) anyerror!usize;

// mul not implemented yet
fn derp() align(@sizeOf(usize) * 2) i32 {
    return 1234;
}
fn noop1() align(1) void {}
fn noop4() align(4) void {}
pub extern "wasi_snapshot_preview1" fn poll_oneoff(in: *const u8, out: *u8, nsubscriptions: usize, nevents: *usize) u8; // his bits flags says he have a calling convention
pub extern "wasi_snapshot_preview1" fn poll_oneoff2(in: *const u8, out: *u8, nsubscriptions: usize, nevents: *usize) callconv(.Stdlib) u8;
pub extern "wasi_snapshot_preview1" fn poll_oneoff3(in: *const u8, out: *u8, nsubscriptions: usize, nevents: *usize) align(1) callconv(.Stdlib) u8;

```

Added some binOp for a better printing.
The struct is simple and need some discussion on how to get a better one repeating less code.
I just made it work and I'm not thinking about correct the printing of nested expr tree with the current structure. (I can do it but only if I asked for because the goal here is just make work and refactor later).

```zig
fn derpAdd() align(@sizeOf(usize) + 2) void {}
fn derpAddWrap() align(@sizeOf(usize) +% 2) void {}
fn derpAddSat() align(@sizeOf(usize) +| 2) void {}

fn derpSub() align(@sizeOf(usize) - 2) void {}
fn derpSubWrap() align(@sizeOf(usize) -% 2) void {}
fn derpSubSat() align(@sizeOf(usize) -| 2) void {}

fn derpMul() align(@sizeOf(usize) * 2) void {}
fn derpMulWrap() align(@sizeOf(usize) *% 2) void {}
fn derpMulSat() align(@sizeOf(usize) *| 2) void {}

fn derpDivExact() align(@divExact(@sizeOf(usize), 2)) void {}
fn derpDivFloor() align(@divFloor(@sizeOf(usize), 2)) void {}
fn derpDivTrunc() align(@divTrunc(@sizeOf(usize), 2)) void {}

fn derpRem() align(@rem(@sizeOf(usize), 2)) void {}
fn derpMod() align(@mod(@sizeOf(usize), 2)) void {}

fn derpShl() align(@sizeOf(usize) << 2) void {}
fn derpShlExact() align(@shlExact(@sizeOf(usize), 2)) void {}
fn derpShlSat() align(@sizeOf(usize) <<| 2) void {}

fn derpShr() align(@sizeOf(usize) >> 2) void {}
fn derpShrExact() align(@shrExact(@sizeOf(usize), 2)) void {}

fn derpMoreComplexOperation() align(@mod(@divExact(@sizeOf(usize), 2), @shrExact((5 *% 20), 3) <<| 2)) void {}
const value = @mod(4, 7) -% ((((3 *| 4) << 2) >> 3) +| 1);

```