### PR TITLE
x64: introduce Condition enum encapsulating EFLAGS condition codes

### DIFF
--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -275,42 +275,25 @@ pub const Inst = struct {
         call,
 
         /// ops flags:
-        ///     0b00 gte
-        ///     0b01 gt
-        ///     0b10 lt
-        ///     0b11 lte
-        cond_jmp_greater_less,
-        cond_set_byte_greater_less,
+        ///     unused
+        /// Notes:
+        ///  * uses `inst_cc` in Data.
+        cond_jmp,
 
         /// ops flags:
-        ///     0b00 above or equal
-        ///     0b01 above
-        ///     0b10 below
-        ///     0b11 below or equal
-        cond_jmp_above_below,
-        cond_set_byte_above_below,
-
-        /// ops flags:
-        ///     0bX0 ne
-        ///     0bX1 eq
-        cond_jmp_eq_ne,
-        cond_set_byte_eq_ne,
+        ///      0b00 reg1
+        /// Notes:
+        ///  * uses condition code (CC) stored as part of data
+        cond_set_byte,
 
         /// ops flags:
         ///     0b00 reg1, reg2,
         ///     0b01 reg1, word ptr  [reg2 + imm]
         ///     0b10 reg1, dword ptr [reg2 + imm]
         ///     0b11 reg1, qword ptr [reg2 + imm]
-        cond_mov_eq,
-        cond_mov_lt,
-        cond_mov_below,
-
-        /// ops flags:
-        ///     0b00 reg1 if OF = 1
-        ///     0b01 reg1 if OF = 0
-        ///     0b10 reg1 if CF = 1
-        ///     0b11 reg1 if CF = 0
-        cond_set_byte_overflow,
+        /// Notes:
+        ///  * uses condition code (CC) stored as part of data
+        cond_mov,
 
         /// ops flags:  form:
         ///       0b00   reg1
@@ -451,6 +434,16 @@ pub const Inst = struct {
         inst: Index,
         /// A 32-bit immediate value.
         imm: u32,
+        /// A condition code for use with EFLAGS register.
+        cc: bits.Condition,
+        /// Another instruction with condition code.
+        /// Used by `cond_jmp`.
+        inst_cc: struct {
+            /// Another instruction.
+            inst: Index,
+            /// A condition code for use with EFLAGS register.
+            cc: bits.Condition,
+        },
         /// An extern function.
         extern_fn: struct {
             /// Index of the containing atom.

--- a/src/arch/x86_64/bits.zig
+++ b/src/arch/x86_64/bits.zig
@@ -6,6 +6,135 @@ const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
 const DW = std.dwarf;
 
+/// EFLAGS condition codes
+pub const Condition = enum(u5) {
+    /// above
+    a,
+    /// above or equal
+    ae,
+    /// below
+    b,
+    /// below or equal
+    be,
+    /// carry
+    c,
+    /// equal
+    e,
+    /// greater
+    g,
+    /// greater or equal
+    ge,
+    /// less
+    l,
+    /// less or equal
+    le,
+    /// not above
+    na,
+    /// not above or equal
+    nae,
+    /// not below
+    nb,
+    /// not below or equal
+    nbe,
+    /// not carry
+    nc,
+    /// not equal
+    ne,
+    /// not greater
+    ng,
+    /// not greater or equal
+    nge,
+    /// not less
+    nl,
+    /// not less or equal
+    nle,
+    /// not overflow
+    no,
+    /// not parity
+    np,
+    /// not sign
+    ns,
+    /// not zero
+    nz,
+    /// overflow
+    o,
+    /// parity
+    p,
+    /// parity even
+    pe,
+    /// parity odd
+    po,
+    /// sign
+    s,
+    /// zero
+    z,
+
+    /// Converts a std.math.CompareOperator into a condition flag,
+    /// i.e. returns the condition that is true iff the result of the
+    /// comparison is true. Assumes signed comparison
+    pub fn fromCompareOperatorSigned(op: std.math.CompareOperator) Condition {
+        return switch (op) {
+            .gte => .ge,
+            .gt => .g,
+            .neq => .ne,
+            .lt => .l,
+            .lte => .le,
+            .eq => .e,
+        };
+    }
+
+    /// Converts a std.math.CompareOperator into a condition flag,
+    /// i.e. returns the condition that is true iff the result of the
+    /// comparison is true. Assumes unsigned comparison
+    pub fn fromCompareOperatorUnsigned(op: std.math.CompareOperator) Condition {
+        return switch (op) {
+            .gte => .ae,
+            .gt => .a,
+            .neq => .ne,
+            .lt => .b,
+            .lte => .be,
+            .eq => .e,
+        };
+    }
+
+    /// Returns the condition which is true iff the given condition is
+    /// false (if such a condition exists)
+    pub fn negate(cond: Condition) Condition {
+        return switch (cond) {
+            .a => .na,
+            .ae => .nae,
+            .b => .nb,
+            .be => .nbe,
+            .c => .nc,
+            .e => .ne,
+            .g => .ng,
+            .ge => .nge,
+            .l => .nl,
+            .le => .nle,
+            .na => .a,
+            .nae => .ae,
+            .nb => .b,
+            .nbe => .be,
+            .nc => .c,
+            .ne => .e,
+            .ng => .g,
+            .nge => .ge,
+            .nl => .l,
+            .nle => .le,
+            .no => .o,
+            .np => .p,
+            .ns => .s,
+            .nz => .z,
+            .o => .no,
+            .p => .np,
+            .pe => unreachable,
+            .po => unreachable,
+            .s => .ns,
+            .z => .nz,
+        };
+    }
+};
+
 // zig fmt: off
 
 /// Definitions of all of the general purpose x64 registers. The order is semantically meaningful.


### PR DESCRIPTION
Inspired by @joachimschmidt557's recent compare flags clean up in the ARM backend, x64 now also gets its very own `Condition` enum encapsulating all different possible EFLAGS condition codes (commonly abbreviated as `cc` in the manual). With this change, `CodeGen.zig` is now a lot cleaner and way more readable when it comes to handling of logical compare conditions.