### PR TITLE
stage2: sparc64: Small refactorings and stack pointer accounting fixes

### DIFF
--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -1891,7 +1891,7 @@ fn binOpImmediate(
                 .is_imm = true,
                 .rd = dest_reg,
                 .rs1 = lhs_reg,
-                .rs2_or_imm = .{ .imm = @intCast(i13, rhs.immediate) },
+                .rs2_or_imm = .{ .imm = @intCast(u12, rhs.immediate) },
             },
         },
         .sllx => .{
@@ -1907,7 +1907,7 @@ fn binOpImmediate(
             .arithmetic_2op = .{
                 .is_imm = true,
                 .rs1 = lhs_reg,
-                .rs2_or_imm = .{ .imm = @intCast(i13, rhs.immediate) },
+                .rs2_or_imm = .{ .imm = @intCast(u12, rhs.immediate) },
             },
         },
         else => unreachable,

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -407,7 +407,7 @@ fn gen(self: *Self) !void {
         }
 
         // Backpatch stack offset
-        const total_stack_size = self.max_end_stack + abi.stack_reserved_area; // TODO + self.saved_regs_stack_space;
+        const total_stack_size = self.max_end_stack + abi.stack_reserved_area;
         const stack_size = mem.alignForwardGeneric(u32, total_stack_size, self.stack_align);
         if (math.cast(i13, stack_size)) |size| {
             self.mir_instructions.set(save_inst, .{

--- a/src/arch/sparc64/Emit.zig
+++ b/src/arch/sparc64/Emit.zig
@@ -121,6 +121,10 @@ pub fn emitMir(
             .subcc => try emit.mirArithmetic3Op(inst),
 
             .tcc => try emit.mirTrap(inst),
+
+            .cmp => try emit.mirArithmetic2Op(inst),
+
+            .mov => try emit.mirArithmetic2Op(inst),
         }
     }
 }
@@ -179,12 +183,16 @@ fn mirArithmetic2Op(emit: *Emit, inst: Mir.Inst.Index) !void {
         const imm = data.rs2_or_imm.imm;
         switch (tag) {
             .@"return" => try emit.writeInstruction(Instruction.@"return"(i13, rs1, imm)),
+            .cmp => try emit.writeInstruction(Instruction.subcc(i13, rs1, imm, .g0)),
+            .mov => try emit.writeInstruction(Instruction.@"or"(i13, .g0, imm, rs1)),
             else => unreachable,
         }
     } else {
         const rs2 = data.rs2_or_imm.rs2;
         switch (tag) {
             .@"return" => try emit.writeInstruction(Instruction.@"return"(Register, rs1, rs2)),
+            .cmp => try emit.writeInstruction(Instruction.subcc(Register, rs1, rs2, .g0)),
+            .mov => try emit.writeInstruction(Instruction.@"or"(Register, .g0, rs2, rs1)),
             else => unreachable,
         }
     }

--- a/src/arch/sparc64/Mir.zig
+++ b/src/arch/sparc64/Mir.zig
@@ -125,9 +125,23 @@ pub const Inst = struct {
         /// This uses the trap field.
         tcc,
 
-        // TODO add synthetic instructions
-        // TODO add cmp synthetic instruction to avoid wasting a register when
-        // comparing with subcc
+        // SPARCv9 synthetic instructions
+        // Note that the instructions that is added here are only those that
+        // will simplify backend development. Synthetic instructions that is
+        // only used to provide syntactic sugar in, e.g. inline assembly should
+        // be deconstructed inside the parser instead.
+        // See also: G.3 Synthetic Instructions
+        // TODO add more synthetic instructions
+
+        /// Comparison
+        /// This uses the arithmetic_2op field.
+        cmp, // cmp rs1, rs2/imm -> subcc rs1, rs2/imm, %g0
+
+        /// Copy register/immediate contents to another register
+        /// This uses the arithmetic_2op field, with rs1
+        /// being the *destination* register.
+        // TODO is it okay to abuse rs1 in this way?
+        mov, // mov rs2/imm, rs1 -> or %g0, rs2/imm, rs1
     };
 
     /// The position of an MIR instruction within the `Mir` instructions array.

--- a/src/arch/sparc64/abi.zig
+++ b/src/arch/sparc64/abi.zig
@@ -3,17 +3,17 @@ const bits = @import("bits.zig");
 const Register = bits.Register;
 const RegisterManagerFn = @import("../../register_manager.zig").RegisterManager;
 
-// SPARCv9 stack constants.
+// SPARCv9 SysV ABI stack constants.
 // See: Registers and the Stack Frame, page 3P-8, SCD 2.4.1.
 
-// On SPARCv9, %sp points to top of stack + stack bias,
-// and %fp points to top of previous frame + stack bias.
+// The ABI specifies that %sp points to top of stack - stack bias,
+// and %fp points to top of previous frame - stack bias.
 pub const stack_bias = 2047;
 
-// The first 176 bytes of the stack is reserved for register saving purposes.
-// SPARCv9 requires to reserve space in the stack for the first six arguments,
-// even though they are usually passed in registers.
-pub const stack_save_area = 176;
+// The first 128 bytes of the stack is reserved for register saving purposes.
+// The ABI also requires to reserve space in the stack for the first six
+// outgoing arguments, even though they are usually passed in registers.
+pub const stack_reserved_area = 128 + 48;
 
 // There are no callee-preserved registers since the windowing
 // mechanism already takes care of them.


### PR DESCRIPTION
- Add `cmp` and `mov` synthetic instructions for convenience
- Account for stack bias and reserved area when generating pointers to stack offsets