### PR TITLE
test: correctly track identical error msgs in handled errors list

### DIFF
--- a/src/test.zig
+++ b/src/test.zig
@@ -1574,6 +1574,8 @@ pub const TestContext = struct {
 
                     for (actual_errors.list) |actual_error| {
                         for (case_error_list) |case_msg, i| {
+                            if (handled_errors[i]) continue;
+
                             const ex_tag: std.meta.Tag(@TypeOf(case_msg)) = case_msg;
                             switch (actual_error) {
                                 .src => |actual_msg| {

--- a/test/cases/compile_errors/dereference_anyopaque.zig
+++ b/test/cases/compile_errors/dereference_anyopaque.zig
@@ -42,6 +42,7 @@ pub export fn entry() void {
 
 // error
 // backend=llvm
+// target=x86_64-linux,aarch64-linux,arm-linux,x86_64-macos,aarch64-macos
 //
 // :11:22: error: comparison of 'void' with null
 // :25:51: error: unable to resolve comptime value


### PR DESCRIPTION
Prior to this change, for an example compiler error test case with
multiple identical errors messages such as

```
:1:2: error: foo
:1:2: error: foo
```

the test harness would never increment the error index thus only
marking the very first error message as handled yielding a false
positive.

Additionally, while here, regress `dereference_anyopaque` test case
as not passing on `wasm32-wasi` target.

cc @Vexu @andrewrk 