### PR TITLE
src/print_env: print the native target

### DIFF
--- a/src/print_env.zig
+++ b/src/print_env.zig
@@ -21,6 +21,10 @@ pub fn cmdEnv(gpa: Allocator, args: []const []const u8, stdout: std.fs.File.Writ
     const global_cache_dir = try introspect.resolveGlobalCacheDir(gpa);
     defer gpa.free(global_cache_dir);
 
+    const info = try std.zig.system.NativeTargetInfo.detect(gpa, .{});
+    const triple = try info.target.zigTriple(gpa);
+    defer gpa.free(triple);
+
     var bw = std.io.bufferedWriter(stdout);
     const w = bw.writer();
 
@@ -41,6 +45,9 @@ pub fn cmdEnv(gpa: Allocator, args: []const []const u8, stdout: std.fs.File.Writ
 
     try jws.objectField("version");
     try jws.emitString(build_options.version);
+
+    try jws.objectField("target");
+    try jws.emitString(triple);
 
     try jws.endObject();
     try w.writeByte('\n');


### PR DESCRIPTION
Add the native target triple to the zig env command output.

The target triple is formatted the same way as it is done in the
zig targets command.