### PR TITLE
Add support for --no-entry linker flag.

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -769,6 +769,7 @@ pub const InitOptions = struct {
     linker_nxcompat: bool = false,
     linker_dynamicbase: bool = false,
     linker_optimization: ?u8 = null,
+    linker_no_entry: bool = false,
     major_subsystem_version: ?u32 = null,
     minor_subsystem_version: ?u32 = null,
     clang_passthrough_mode: bool = false,
@@ -1559,6 +1560,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
         const bin_file = try link.File.openPath(gpa, .{
             .emit = bin_file_emit,
             .implib_emit = implib_emit,
+            .no_entry = options.linker_no_entry,
             .root_name = root_name,
             .module = module,
             .target = options.target,
@@ -2348,6 +2350,7 @@ fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifes
     man.hash.add(comp.bin_file.options.z_noexecstack);
     man.hash.add(comp.bin_file.options.z_now);
     man.hash.add(comp.bin_file.options.z_relro);
+    man.hash.add(comp.bin_file.options.no_entry);
     man.hash.add(comp.bin_file.options.hash_style);
     man.hash.add(comp.bin_file.options.include_compiler_rt);
     if (comp.bin_file.options.link_libc) {

--- a/src/link.zig
+++ b/src/link.zig
@@ -86,6 +86,7 @@ pub const Options = struct {
     program_code_size_hint: u64 = 256 * 1024,
     entry_addr: ?u64 = null,
     entry: ?[]const u8,
+    no_entry: bool,
     stack_size_override: ?u64,
     image_base_override: ?u64,
     cache_mode: CacheMode,

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -2458,6 +2458,8 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) !
         if (self.base.options.entry) |entry| {
             try argv.append("--entry");
             try argv.append(entry);
+        } else if (self.base.options.no_entry){
+            try argv.append("--no-entry");
         }
 
         if (self.base.options.output_mode == .Exe) {

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -2458,7 +2458,7 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) !
         if (self.base.options.entry) |entry| {
             try argv.append("--entry");
             try argv.append(entry);
-        } else if (self.base.options.no_entry){
+        } else if (self.base.options.no_entry) {
             try argv.append("--no-entry");
         }
 


### PR DESCRIPTION
This flag is only valid for wasm targets.
Usage:
zig cc main.c -target wasm32-freestanding-none -o binary.wasm -Wl,--no-entry

Fixes #11045