### PR TITLE
tools: fix update-linux-headers.zig and process_headers.zig

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -83,6 +83,10 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     // Ensure the development tools are buildable.
     cases.add("tools/gen_spirv_spec.zig");
     cases.add("tools/gen_stubs.zig");
+    cases.add("tools/generate_linux_syscalls.zig");
+    cases.add("tools/process_headers.zig");
+    cases.add("tools/update-license-headers.zig");
+    cases.add("tools/update-linux-headers.zig");
     cases.add("tools/update_clang_options.zig");
     cases.add("tools/update_cpu_features.zig");
     cases.add("tools/update_glibc.zig");

--- a/tools/process_headers.zig
+++ b/tools/process_headers.zig
@@ -267,8 +267,9 @@ const DestTarget = struct {
                 (@enumToInt(a.abi) *% @as(u32, 4082223418));
         }
 
-        pub fn eql(self: @This(), a: DestTarget, b: DestTarget) bool {
+        pub fn eql(self: @This(), a: DestTarget, b: DestTarget, b_index: usize) bool {
             _ = self;
+            _ = b_index;
             return a.arch.eql(b.arch) and
                 a.os == b.os and
                 a.abi == b.abi;

--- a/tools/update-linux-headers.zig
+++ b/tools/update-linux-headers.zig
@@ -106,8 +106,9 @@ const DestTarget = struct {
             return @truncate(u32, hasher.final());
         }
 
-        pub fn eql(self: @This(), a: DestTarget, b: DestTarget) bool {
+        pub fn eql(self: @This(), a: DestTarget, b: DestTarget, b_index: usize) bool {
             _ = self;
+            _ = b_index;
             return a.arch.eql(b.arch);
         }
     };


### PR DESCRIPTION
I tried to update merge_anal_dumps.zig, but it looks abandoned since 2019, so IMHO it's too much work (a lot has changed since then) for too little gain. If you want, I can remove this file and/or include this commits to #11740.

Signed-off-by: BratishkaErik <bratishkaerik@getgoogleoff.me>