### PR TITLE
stage2: add missing data to ZIR encoding of functions

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -73,7 +73,7 @@ fn setExtra(astgen: *AstGen, index: usize, extra: anytype) void {
             Zir.Inst.Call.Flags => @bitCast(u32, @field(extra, field.name)),
             Zir.Inst.BuiltinCall.Flags => @bitCast(u32, @field(extra, field.name)),
             Zir.Inst.SwitchBlock.Bits => @bitCast(u32, @field(extra, field.name)),
-            Zir.Inst.ExtendedFunc.Bits => @bitCast(u32, @field(extra, field.name)),
+            Zir.Inst.FuncFancy.Bits => @bitCast(u32, @field(extra, field.name)),
             else => @compileError("bad field type"),
         };
         i += 1;
@@ -1205,7 +1205,7 @@ fn fnProtoExpr(
         break :is_var_args false;
     };
 
-    const align_inst: Zir.Inst.Ref = if (fn_proto.ast.align_expr == 0) .none else inst: {
+    const align_ref: Zir.Inst.Ref = if (fn_proto.ast.align_expr == 0) .none else inst: {
         break :inst try expr(&block_scope, scope, align_rl, fn_proto.ast.align_expr);
     };
 
@@ -1232,19 +1232,24 @@ fn fnProtoExpr(
     if (is_inferred_error) {
         return astgen.failTok(maybe_bang, "function prototype may not have inferred error set", .{});
     }
-    var ret_gz = block_scope.makeSubBlock(scope);
-    defer ret_gz.unstack();
-    const ret_ty = try expr(&ret_gz, scope, coerced_type_rl, fn_proto.ast.return_type);
-    const ret_br = try ret_gz.addBreak(.break_inline, 0, ret_ty);
+    const ret_ty = try expr(&block_scope, scope, coerced_type_rl, fn_proto.ast.return_type);
 
     const result = try block_scope.addFunc(.{
         .src_node = fn_proto.ast.proto_node,
+
+        .cc_ref = cc,
+        .cc_gz = null,
+        .align_ref = align_ref,
+        .align_gz = null,
+        .ret_ref = ret_ty,
+        .ret_gz = null,
+        .section_ref = .none,
+        .section_gz = null,
+        .addrspace_ref = .none,
+        .addrspace_gz = null,
+
         .param_block = block_inst,
-        .ret_gz = &ret_gz,
-        .ret_br = ret_br,
         .body_gz = null,
-        .cc = cc,
-        .align_inst = align_inst,
         .lib_name = 0,
         .is_var_args = is_var_args,
         .is_inferred_error = false,
@@ -2282,7 +2287,7 @@ fn unusedResultExpr(gz: *GenZir, scope: *Scope, statement: Ast.Node.Index) Inner
             .field_val_named,
             .func,
             .func_inferred,
-            .func_extended,
+            .func_fancy,
             .int,
             .int_big,
             .float,
@@ -3395,9 +3400,8 @@ fn fnDecl(
 
     const doc_comment_index = try astgen.docCommentAsString(fn_proto.firstToken());
 
-    const has_section_or_addrspace = fn_proto.ast.section_expr != 0 or fn_proto.ast.addrspace_expr != 0;
-    // Alignment is passed in the func instruction in this case.
-    wip_members.nextDecl(is_pub, is_export, false, has_section_or_addrspace);
+    // align, linksection, and addrspace is passed in the func instruction in this case.
+    wip_members.nextDecl(is_pub, is_export, false, false);
 
     var params_scope = &fn_gz.base;
     const is_var_args = is_var_args: {
@@ -3483,17 +3487,49 @@ fn fnDecl(
     const maybe_bang = tree.firstToken(fn_proto.ast.return_type) - 1;
     const is_inferred_error = token_tags[maybe_bang] == .bang;
 
-    const align_inst: Zir.Inst.Ref = if (fn_proto.ast.align_expr == 0) .none else inst: {
-        break :inst try expr(&decl_gz, params_scope, align_rl, fn_proto.ast.align_expr);
-    };
-    const addrspace_inst: Zir.Inst.Ref = if (fn_proto.ast.addrspace_expr == 0) .none else inst: {
-        break :inst try expr(&decl_gz, params_scope, .{ .ty = .address_space_type }, fn_proto.ast.addrspace_expr);
-    };
-    const section_inst: Zir.Inst.Ref = if (fn_proto.ast.section_expr == 0) .none else inst: {
-        break :inst try comptimeExpr(&decl_gz, params_scope, .{ .ty = .const_slice_u8_type }, fn_proto.ast.section_expr);
+    // After creating the function ZIR instruction, it will need to update the break
+    // instructions inside the expression blocks for align, addrspace, cc, and ret_ty
+    // to use the function instruction as the "block" to break from.
+
+    var align_gz = decl_gz.makeSubBlock(params_scope);
+    defer align_gz.unstack();
+    const align_ref: Zir.Inst.Ref = if (fn_proto.ast.align_expr == 0) .none else inst: {
+        const inst = try expr(&decl_gz, params_scope, coerced_align_rl, fn_proto.ast.align_expr);
+        if (align_gz.instructionsSlice().len == 0) {
+            // In this case we will send a len=0 body which can be encoded more efficiently.
+            break :inst inst;
+        }
+        _ = try align_gz.addBreak(.break_inline, 0, inst);
+        break :inst inst;
     };
 
-    const cc: Zir.Inst.Ref = blk: {
+    var addrspace_gz = decl_gz.makeSubBlock(params_scope);
+    defer addrspace_gz.unstack();
+    const addrspace_ref: Zir.Inst.Ref = if (fn_proto.ast.addrspace_expr == 0) .none else inst: {
+        const inst = try expr(&decl_gz, params_scope, .{ .coerced_ty = .address_space_type }, fn_proto.ast.addrspace_expr);
+        if (addrspace_gz.instructionsSlice().len == 0) {
+            // In this case we will send a len=0 body which can be encoded more efficiently.
+            break :inst inst;
+        }
+        _ = try addrspace_gz.addBreak(.break_inline, 0, inst);
+        break :inst inst;
+    };
+
+    var section_gz = decl_gz.makeSubBlock(params_scope);
+    defer section_gz.unstack();
+    const section_ref: Zir.Inst.Ref = if (fn_proto.ast.section_expr == 0) .none else inst: {
+        const inst = try expr(&decl_gz, params_scope, .{ .coerced_ty = .const_slice_u8_type }, fn_proto.ast.section_expr);
+        if (section_gz.instructionsSlice().len == 0) {
+            // In this case we will send a len=0 body which can be encoded more efficiently.
+            break :inst inst;
+        }
+        _ = try section_gz.addBreak(.break_inline, 0, inst);
+        break :inst inst;
+    };
+
+    var cc_gz = decl_gz.makeSubBlock(params_scope);
+    defer cc_gz.unstack();
+    const cc_ref: Zir.Inst.Ref = blk: {
         if (fn_proto.ast.callconv_expr != 0) {
             if (has_inline_keyword) {
                 return astgen.failNode(
@@ -3502,12 +3538,18 @@ fn fnDecl(
                     .{},
                 );
             }
-            break :blk try expr(
+            const inst = try expr(
                 &decl_gz,
                 params_scope,
-                .{ .ty = .calling_convention_type },
+                .{ .coerced_ty = .calling_convention_type },
                 fn_proto.ast.callconv_expr,
             );
+            if (cc_gz.instructionsSlice().len == 0) {
+                // In this case we will send a len=0 body which can be encoded more efficiently.
+                break :blk inst;
+            }
+            _ = try cc_gz.addBreak(.break_inline, 0, inst);
+            break :blk inst;
         } else if (is_extern) {
             // note: https://github.com/ziglang/zig/issues/5269
             break :blk .calling_convention_c;
@@ -3520,8 +3562,18 @@ fn fnDecl(
 
     var ret_gz = decl_gz.makeSubBlock(params_scope);
     defer ret_gz.unstack();
-    const ret_ty = try expr(&ret_gz, params_scope, coerced_type_rl, fn_proto.ast.return_type);
-    const ret_br = try ret_gz.addBreak(.break_inline, 0, ret_ty);
+    const ret_ref: Zir.Inst.Ref = switch (nodePrimitive(tree, fn_proto.ast.return_type)) {
+        .none => inst: {
+            const inst = try expr(&ret_gz, params_scope, coerced_type_rl, fn_proto.ast.return_type);
+            if (ret_gz.instructionsSlice().len == 0) {
+                // In this case we will send a len=0 body which can be encoded more efficiently.
+                break :inst inst;
+            }
+            _ = try ret_gz.addBreak(.break_inline, 0, inst);
+            break :inst inst;
+        },
+        else => |p| p,
+    };
 
     const func_inst: Zir.Inst.Ref = if (body_node == 0) func: {
         if (!is_extern) {
@@ -3532,12 +3584,18 @@ fn fnDecl(
         }
         break :func try decl_gz.addFunc(.{
             .src_node = decl_node,
+            .cc_ref = cc_ref,
+            .cc_gz = &cc_gz,
+            .align_ref = align_ref,
+            .align_gz = &align_gz,
+            .ret_ref = ret_ref,
             .ret_gz = &ret_gz,
-            .ret_br = ret_br,
+            .section_ref = section_ref,
+            .section_gz = &section_gz,
+            .addrspace_ref = addrspace_ref,
+            .addrspace_gz = &addrspace_gz,
             .param_block = block_inst,
             .body_gz = null,
-            .cc = cc,
-            .align_inst = align_inst,
             .lib_name = lib_name,
             .is_var_args = is_var_args,
             .is_inferred_error = false,
@@ -3571,14 +3629,20 @@ fn fnDecl(
 
         break :func try decl_gz.addFunc(.{
             .src_node = decl_node,
+            .cc_ref = cc_ref,
+            .cc_gz = &cc_gz,
+            .align_ref = align_ref,
+            .align_gz = &align_gz,
+            .ret_ref = ret_ref,
+            .ret_gz = &ret_gz,
+            .section_ref = section_ref,
+            .section_gz = &section_gz,
+            .addrspace_ref = addrspace_ref,
+            .addrspace_gz = &addrspace_gz,
             .lbrace_line = lbrace_line,
             .lbrace_column = lbrace_column,
             .param_block = block_inst,
-            .ret_gz = &ret_gz,
-            .ret_br = ret_br,
             .body_gz = &fn_gz,
-            .cc = cc,
-            .align_inst = align_inst,
             .lib_name = lib_name,
             .is_var_args = is_var_args,
             .is_inferred_error = is_inferred_error,
@@ -3604,10 +3668,6 @@ fn fnDecl(
     wip_members.appendToDecl(fn_name_str_index);
     wip_members.appendToDecl(block_inst);
     wip_members.appendToDecl(doc_comment_index);
-    if (has_section_or_addrspace) {
-        wip_members.appendToDecl(@enumToInt(section_inst));
-        wip_members.appendToDecl(@enumToInt(addrspace_inst));
-    }
 }
 
 fn globalVarDecl(
@@ -4001,14 +4061,22 @@ fn testDecl(
 
     const func_inst = try decl_block.addFunc(.{
         .src_node = node,
+
+        .cc_ref = .none,
+        .cc_gz = null,
+        .align_ref = .none,
+        .align_gz = null,
+        .ret_ref = .void_type,
+        .ret_gz = null,
+        .section_ref = .none,
+        .section_gz = null,
+        .addrspace_ref = .none,
+        .addrspace_gz = null,
+
         .lbrace_line = lbrace_line,
         .lbrace_column = lbrace_column,
         .param_block = block_inst,
-        .ret_gz = null,
-        .ret_br = 0,
         .body_gz = &fn_block,
-        .cc = .none,
-        .align_inst = .none,
         .lib_name = 0,
         .is_var_args = false,
         .is_inferred_error = true,
@@ -8957,6 +9025,31 @@ fn nodeImpliesComptimeOnly(tree: *const Ast, start_node: Ast.Node.Index) bool {
     }
 }
 
+fn nodePrimitive(tree: *const Ast, start_node: Ast.Node.Index) Zir.Inst.Ref {
+    const node_tags = tree.nodes.items(.tag);
+    const node_datas = tree.nodes.items(.data);
+
+    var node = start_node;
+    while (true) {
+        switch (node_tags[node]) {
+            // Forward the question to the LHS sub-expression.
+            .grouped_expression => node = node_datas[node].lhs,
+
+            .identifier => {
+                const main_tokens = tree.nodes.items(.main_token);
+                const ident_bytes = tree.tokenSlice(main_tokens[node]);
+                if (primitives.get(ident_bytes)) |primitive| {
+                    return primitive;
+                } else {
+                    return .none;
+                }
+            },
+
+            else => return .none,
+        }
+    }
+}
+
 /// Applies `rl` semantics to `result`. Expressions which do not do their own handling of
 /// result locations must call this function on their result.
 /// As an example, if the `ResultLoc` is `ptr`, it will write the result to the pointer.
@@ -9952,17 +10045,34 @@ const GenZir = struct {
         gz.unstack();
     }
 
-    /// Supports `body_gz` stacked on `ret_gz` stacked on `gz`. Unstacks `body_gz` and `ret_gz`.
+    /// Must be called with the following stack set up:
+    ///  * gz (bottom)
+    ///  * align_gz
+    ///  * addrspace_gz
+    ///  * section_gz
+    ///  * cc_gz
+    ///  * ret_gz
+    ///  * body_gz (top)
+    /// Unstacks all of those except for `gz`.
     fn addFunc(gz: *GenZir, args: struct {
         src_node: Ast.Node.Index,
         lbrace_line: u32 = 0,
         lbrace_column: u32 = 0,
-        body_gz: ?*GenZir,
         param_block: Zir.Inst.Index,
+
+        align_gz: ?*GenZir,
+        addrspace_gz: ?*GenZir,
+        section_gz: ?*GenZir,
+        cc_gz: ?*GenZir,
         ret_gz: ?*GenZir,
-        ret_br: Zir.Inst.Index,
-        cc: Zir.Inst.Ref,
-        align_inst: Zir.Inst.Ref,
+        body_gz: ?*GenZir,
+
+        align_ref: Zir.Inst.Ref,
+        addrspace_ref: Zir.Inst.Ref,
+        section_ref: Zir.Inst.Ref,
+        cc_ref: Zir.Inst.Ref,
+        ret_ref: Zir.Inst.Ref,
+
         lib_name: u32,
         is_var_args: bool,
         is_inferred_error: bool,
@@ -9972,11 +10082,13 @@ const GenZir = struct {
         assert(args.src_node != 0);
         const astgen = gz.astgen;
         const gpa = astgen.gpa;
+        const ret_ref = if (args.ret_ref == .void_type) .none else args.ret_ref;
+        const new_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
 
         try astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
         var body: []Zir.Inst.Index = &[0]Zir.Inst.Index{};
-        var ret_ty: []Zir.Inst.Index = &[0]Zir.Inst.Index{};
+        var ret_body: []Zir.Inst.Index = &[0]Zir.Inst.Index{};
         var src_locs_buffer: [3]u32 = undefined;
         var src_locs: []u32 = src_locs_buffer[0..0];
         if (args.body_gz) |body_gz| {
@@ -10000,61 +10112,120 @@ const GenZir = struct {
 
             body = body_gz.instructionsSlice();
             if (args.ret_gz) |ret_gz|
-                ret_ty = ret_gz.instructionsSliceUpto(body_gz);
+                ret_body = ret_gz.instructionsSliceUpto(body_gz);
         } else {
             if (args.ret_gz) |ret_gz|
-                ret_ty = ret_gz.instructionsSlice();
+                ret_body = ret_gz.instructionsSlice();
         }
 
-        if (args.cc != .none or args.lib_name != 0 or
-            args.is_var_args or args.is_test or args.align_inst != .none or
-            args.is_extern)
+        if (args.cc_ref != .none or args.lib_name != 0 or
+            args.is_var_args or args.is_test or args.is_extern or
+            args.align_ref != .none or args.section_ref != .none or
+            args.addrspace_ref != .none)
         {
+            var align_body: []Zir.Inst.Index = &.{};
+            var addrspace_body: []Zir.Inst.Index = &.{};
+            var section_body: []Zir.Inst.Index = &.{};
+            var cc_body: []Zir.Inst.Index = &.{};
+            if (args.ret_gz != null) {
+                align_body = args.align_gz.?.instructionsSliceUpto(args.addrspace_gz.?);
+                addrspace_body = args.addrspace_gz.?.instructionsSliceUpto(args.section_gz.?);
+                section_body = args.section_gz.?.instructionsSliceUpto(args.cc_gz.?);
+                cc_body = args.cc_gz.?.instructionsSliceUpto(args.ret_gz.?);
+            }
+
             try astgen.extra.ensureUnusedCapacity(
                 gpa,
-                @typeInfo(Zir.Inst.ExtendedFunc).Struct.fields.len +
-                    ret_ty.len + body.len + src_locs.len +
-                    @boolToInt(args.lib_name != 0) +
-                    @boolToInt(args.align_inst != .none) +
-                    @boolToInt(args.cc != .none),
+                @typeInfo(Zir.Inst.FuncFancy).Struct.fields.len +
+                    fancyFnExprExtraLen(align_body, args.align_ref) +
+                    fancyFnExprExtraLen(addrspace_body, args.addrspace_ref) +
+                    fancyFnExprExtraLen(section_body, args.section_ref) +
+                    fancyFnExprExtraLen(cc_body, args.cc_ref) +
+                    fancyFnExprExtraLen(ret_body, ret_ref) +
+                    body.len + src_locs.len +
+                    @boolToInt(args.lib_name != 0),
             );
-            const payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.ExtendedFunc{
+            const payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.FuncFancy{
                 .param_block = args.param_block,
-                .ret_body_len = @intCast(u32, ret_ty.len),
                 .body_len = @intCast(u32, body.len),
                 .bits = .{
                     .is_var_args = args.is_var_args,
                     .is_inferred_error = args.is_inferred_error,
-                    .has_lib_name = args.lib_name != 0,
-                    .has_cc = args.cc != .none,
-                    .has_align = args.align_inst != .none,
                     .is_test = args.is_test,
                     .is_extern = args.is_extern,
+                    .has_lib_name = args.lib_name != 0,
+
+                    .has_align_ref = args.align_ref != .none,
+                    .has_addrspace_ref = args.addrspace_ref != .none,
+                    .has_section_ref = args.section_ref != .none,
+                    .has_cc_ref = args.cc_ref != .none,
+                    .has_ret_ty_ref = ret_ref != .none,
+
+                    .has_align_body = align_body.len != 0,
+                    .has_addrspace_body = addrspace_body.len != 0,
+                    .has_section_body = section_body.len != 0,
+                    .has_cc_body = cc_body.len != 0,
+                    .has_ret_ty_body = ret_body.len != 0,
                 },
             });
             if (args.lib_name != 0) {
                 astgen.extra.appendAssumeCapacity(args.lib_name);
             }
-            if (args.cc != .none) {
-                astgen.extra.appendAssumeCapacity(@enumToInt(args.cc));
+
+            const zir_datas = astgen.instructions.items(.data);
+            if (align_body.len != 0) {
+                astgen.extra.appendAssumeCapacity(@intCast(u32, align_body.len));
+                astgen.extra.appendSliceAssumeCapacity(align_body);
+                zir_datas[align_body[align_body.len - 1]].@"break".block_inst = new_index;
+            } else if (args.align_ref != .none) {
+                astgen.extra.appendAssumeCapacity(@enumToInt(args.align_ref));
             }
-            if (args.align_inst != .none) {
-                astgen.extra.appendAssumeCapacity(@enumToInt(args.align_inst));
+            if (addrspace_body.len != 0) {
+                astgen.extra.appendAssumeCapacity(@intCast(u32, addrspace_body.len));
+                astgen.extra.appendSliceAssumeCapacity(addrspace_body);
+                zir_datas[addrspace_body[addrspace_body.len - 1]].@"break".block_inst = new_index;
+            } else if (args.addrspace_ref != .none) {
+                astgen.extra.appendAssumeCapacity(@enumToInt(args.addrspace_ref));
             }
-            astgen.extra.appendSliceAssumeCapacity(ret_ty);
+            if (section_body.len != 0) {
+                astgen.extra.appendAssumeCapacity(@intCast(u32, section_body.len));
+                astgen.extra.appendSliceAssumeCapacity(section_body);
+                zir_datas[section_body[section_body.len - 1]].@"break".block_inst = new_index;
+            } else if (args.section_ref != .none) {
+                astgen.extra.appendAssumeCapacity(@enumToInt(args.section_ref));
+            }
+            if (cc_body.len != 0) {
+                astgen.extra.appendAssumeCapacity(@intCast(u32, cc_body.len));
+                astgen.extra.appendSliceAssumeCapacity(cc_body);
+                zir_datas[cc_body[cc_body.len - 1]].@"break".block_inst = new_index;
+            } else if (args.cc_ref != .none) {
+                astgen.extra.appendAssumeCapacity(@enumToInt(args.cc_ref));
+            }
+            if (ret_body.len != 0) {
+                astgen.extra.appendAssumeCapacity(@intCast(u32, ret_body.len));
+                astgen.extra.appendSliceAssumeCapacity(ret_body);
+                zir_datas[ret_body[ret_body.len - 1]].@"break".block_inst = new_index;
+            } else if (ret_ref != .none) {
+                astgen.extra.appendAssumeCapacity(@enumToInt(ret_ref));
+            }
+
             astgen.extra.appendSliceAssumeCapacity(body);
             astgen.extra.appendSliceAssumeCapacity(src_locs);
-            // order is important when unstacking
+
+            // Order is important when unstacking.
             if (args.body_gz) |body_gz| body_gz.unstack();
-            if (args.ret_gz) |ret_gz| ret_gz.unstack();
+            if (args.ret_gz != null) {
+                args.ret_gz.?.unstack();
+                args.cc_gz.?.unstack();
+                args.section_gz.?.unstack();
+                args.addrspace_gz.?.unstack();
+                args.align_gz.?.unstack();
+            }
+
             try gz.instructions.ensureUnusedCapacity(gpa, 1);
 
-            const new_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
-            if (args.ret_br != 0) {
-                astgen.instructions.items(.data)[args.ret_br].@"break".block_inst = new_index;
-            }
             astgen.instructions.appendAssumeCapacity(.{
-                .tag = .func_extended,
+                .tag = .func_fancy,
                 .data = .{ .pl_node = .{
                     .src_node = gz.nodeIndexToRelative(args.src_node),
                     .payload_index = payload_index,
@@ -10066,27 +10237,40 @@ const GenZir = struct {
             try astgen.extra.ensureUnusedCapacity(
                 gpa,
                 @typeInfo(Zir.Inst.Func).Struct.fields.len +
-                    ret_ty.len + body.len + src_locs.len,
+                    @maximum(ret_body.len, @boolToInt(ret_ref != .none)) +
+                    body.len + src_locs.len,
             );
+            const ret_body_len = if (ret_body.len != 0)
+                @intCast(u32, ret_body.len)
+            else
+                @boolToInt(ret_ref != .none);
 
             const payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.Func{
                 .param_block = args.param_block,
-                .ret_body_len = @intCast(u32, ret_ty.len),
+                .ret_body_len = ret_body_len,
                 .body_len = @intCast(u32, body.len),
             });
-            astgen.extra.appendSliceAssumeCapacity(ret_ty);
+            const zir_datas = astgen.instructions.items(.data);
+            if (ret_body.len != 0) {
+                astgen.extra.appendSliceAssumeCapacity(ret_body);
+                zir_datas[ret_body[ret_body.len - 1]].@"break".block_inst = new_index;
+            } else if (ret_ref != .none) {
+                astgen.extra.appendAssumeCapacity(@enumToInt(ret_ref));
+            }
             astgen.extra.appendSliceAssumeCapacity(body);
             astgen.extra.appendSliceAssumeCapacity(src_locs);
-            // order is important when unstacking
+
+            // Order is important when unstacking.
             if (args.body_gz) |body_gz| body_gz.unstack();
             if (args.ret_gz) |ret_gz| ret_gz.unstack();
+            if (args.cc_gz) |cc_gz| cc_gz.unstack();
+            if (args.section_gz) |section_gz| section_gz.unstack();
+            if (args.addrspace_gz) |addrspace_gz| addrspace_gz.unstack();
+            if (args.align_gz) |align_gz| align_gz.unstack();
+
             try gz.instructions.ensureUnusedCapacity(gpa, 1);
 
             const tag: Zir.Inst.Tag = if (args.is_inferred_error) .func_inferred else .func;
-            const new_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
-            if (args.ret_br != 0) {
-                astgen.instructions.items(.data)[args.ret_br].@"break".block_inst = new_index;
-            }
             astgen.instructions.appendAssumeCapacity(.{
                 .tag = tag,
                 .data = .{ .pl_node = .{
@@ -10097,6 +10281,12 @@ const GenZir = struct {
             gz.instructions.appendAssumeCapacity(new_index);
             return indexToRef(new_index);
         }
+    }
+
+    fn fancyFnExprExtraLen(body: []Zir.Inst.Index, ref: Zir.Inst.Ref) usize {
+        // In the case of non-empty body, there is one for the body length,
+        // and then one for each instruction.
+        return body.len + @boolToInt(ref != .none);
     }
 
     fn addVar(gz: *GenZir, args: struct {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1595,9 +1595,9 @@ pub const Fn = struct {
         switch (zir_tags[func.zir_body_inst]) {
             .func => return false,
             .func_inferred => return true,
-            .func_extended => {
+            .func_fancy => {
                 const inst_data = zir.instructions.items(.data)[func.zir_body_inst].pl_node;
-                const extra = zir.extraData(Zir.Inst.ExtendedFunc, inst_data.payload_index);
+                const extra = zir.extraData(Zir.Inst.FuncFancy, inst_data.payload_index);
                 return extra.data.bits.is_inferred_error;
             },
             else => unreachable,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6547,7 +6547,7 @@ fn zirFunc(
         inst,
         0,
         target_util.defaultAddressSpace(target, .function),
-        null,
+        FuncLinkSection.default,
         cc,
         ret_ty,
         false,
@@ -6660,15 +6660,26 @@ fn handleExternLibName(
     return sema.gpa.dupeZ(u8, lib_name);
 }
 
+const FuncLinkSection = union(enum) {
+    generic,
+    default,
+    explicit: [*:0]const u8,
+};
+
 fn funcCommon(
     sema: *Sema,
     block: *Block,
     src_node_offset: i32,
     func_inst: Zir.Inst.Index,
-    alignment: u32,
-    address_space: std.builtin.AddressSpace,
-    section: ?[*:0]const u8,
-    cc: std.builtin.CallingConvention,
+    /// null means generic poison
+    alignment: ?u32,
+    /// null means generic poison
+    address_space: ?std.builtin.AddressSpace,
+    /// outer null means generic poison; inner null means default link section
+    section: FuncLinkSection,
+    /// null means generic poison
+    cc: ?std.builtin.CallingConvention,
+    /// this might be Type.generic_poison
     bare_return_type: Type,
     var_args: bool,
     inferred_error_set: bool,
@@ -6679,7 +6690,11 @@ fn funcCommon(
 ) CompileError!Air.Inst.Ref {
     const ret_ty_src: LazySrcLoc = .{ .node_offset_fn_type_ret_ty = src_node_offset };
 
-    var is_generic = bare_return_type.tag() == .generic_poison;
+    var is_generic = bare_return_type.tag() == .generic_poison or
+        alignment == null or
+        address_space == null or
+        section == .generic or
+        cc == null;
     // Check for generic params.
     for (block.params.items) |param| {
         if (param.ty.tag() == .generic_poison) is_generic = true;
@@ -6700,25 +6715,28 @@ fn funcCommon(
     errdefer if (maybe_inferred_error_set_node) |node| sema.gpa.destroy(node);
     // Note: no need to errdefer since this will still be in its default state at the end of the function.
 
+    const target = sema.mod.getTarget();
     const fn_ty: Type = fn_ty: {
         // Hot path for some common function types.
         // TODO can we eliminate some of these Type tag values? seems unnecessarily complicated.
-        if (!is_generic and block.params.items.len == 0 and !var_args and
-            alignment == 0 and !inferred_error_set)
+        if (!is_generic and block.params.items.len == 0 and !var_args and !inferred_error_set and
+            alignment.? == 0 and
+            address_space.? == target_util.defaultAddressSpace(target, .function) and
+            section == .default)
         {
-            if (bare_return_type.zigTypeTag() == .NoReturn and cc == .Unspecified) {
+            if (bare_return_type.zigTypeTag() == .NoReturn and cc.? == .Unspecified) {
                 break :fn_ty Type.initTag(.fn_noreturn_no_args);
             }
 
-            if (bare_return_type.zigTypeTag() == .Void and cc == .Unspecified) {
+            if (bare_return_type.zigTypeTag() == .Void and cc.? == .Unspecified) {
                 break :fn_ty Type.initTag(.fn_void_no_args);
             }
 
-            if (bare_return_type.zigTypeTag() == .NoReturn and cc == .Naked) {
+            if (bare_return_type.zigTypeTag() == .NoReturn and cc.? == .Naked) {
                 break :fn_ty Type.initTag(.fn_naked_noreturn_no_args);
             }
 
-            if (bare_return_type.zigTypeTag() == .Void and cc == .C) {
+            if (bare_return_type.zigTypeTag() == .Void and cc.? == .C) {
                 break :fn_ty Type.initTag(.fn_ccc_void_no_args);
             }
         }
@@ -6764,21 +6782,33 @@ fn funcCommon(
             });
         };
 
+        // stage1 bug workaround
+        const cc_workaround = cc orelse undefined;
+        const align_workaround = alignment orelse @as(u32, undefined);
+
         break :fn_ty try Type.Tag.function.create(sema.arena, .{
             .param_types = param_types,
             .comptime_params = comptime_params.ptr,
             .return_type = return_type,
-            .cc = cc,
-            .alignment = alignment,
+            .cc = cc_workaround,
+            .cc_is_generic = cc == null,
+            .alignment = align_workaround,
+            .align_is_generic = alignment == null,
+            .section_is_generic = section == .generic,
+            .addrspace_is_generic = address_space == null,
             .is_var_args = var_args,
             .is_generic = is_generic,
         });
     };
 
     if (sema.owner_decl.owns_tv) {
-        sema.owner_decl.@"linksection" = section;
-        sema.owner_decl.@"align" = alignment;
-        sema.owner_decl.@"addrspace" = address_space;
+        switch (section) {
+            .generic => sema.owner_decl.@"linksection" = undefined,
+            .default => sema.owner_decl.@"linksection" = null,
+            .explicit => |s| sema.owner_decl.@"linksection" = s,
+        }
+        if (alignment) |a| sema.owner_decl.@"align" = a;
+        if (address_space) |a| sema.owner_decl.@"addrspace" = a;
     }
 
     if (is_extern) {
@@ -16780,13 +16810,16 @@ fn zirFuncFancy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
         break :blk lib_name;
     } else null;
 
-    const @"align": u32 = if (extra.data.bits.has_align_body) blk: {
+    const @"align": ?u32 = if (extra.data.bits.has_align_body) blk: {
         const body_len = sema.code.extra[extra_index];
         extra_index += 1;
         const body = sema.code.extra[extra_index..][0..body_len];
         extra_index += body.len;
 
         const val = try sema.resolveGenericBody(block, align_src, body, inst, Type.u16);
+        if (val.tag() == .generic_poison) {
+            break :blk null;
+        }
         const alignment = @intCast(u32, val.toUnsignedInt(target));
         if (alignment == target_util.defaultFunctionAlignment(target)) {
             break :blk 0;
@@ -16796,7 +16829,12 @@ fn zirFuncFancy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
     } else if (extra.data.bits.has_align_ref) blk: {
         const align_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);
         extra_index += 1;
-        const align_tv = try sema.resolveInstConst(block, align_src, align_ref);
+        const align_tv = sema.resolveInstConst(block, align_src, align_ref) catch |err| switch (err) {
+            error.GenericPoison => {
+                break :blk null;
+            },
+            else => |e| return e,
+        };
         const alignment = @intCast(u32, align_tv.val.toUnsignedInt(target));
         if (alignment == target_util.defaultFunctionAlignment(target)) {
             break :blk 0;
@@ -16805,7 +16843,7 @@ fn zirFuncFancy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
         }
     } else 0;
 
-    const @"addrspace": std.builtin.AddressSpace = if (extra.data.bits.has_addrspace_body) blk: {
+    const @"addrspace": ?std.builtin.AddressSpace = if (extra.data.bits.has_addrspace_body) blk: {
         const body_len = sema.code.extra[extra_index];
         extra_index += 1;
         const body = sema.code.extra[extra_index..][0..body_len];
@@ -16813,32 +16851,48 @@ fn zirFuncFancy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
 
         const addrspace_ty = try sema.getBuiltinType(block, addrspace_src, "AddressSpace");
         const val = try sema.resolveGenericBody(block, addrspace_src, body, inst, addrspace_ty);
+        if (val.tag() == .generic_poison) {
+            break :blk null;
+        }
         break :blk val.toEnum(std.builtin.AddressSpace);
     } else if (extra.data.bits.has_addrspace_ref) blk: {
         const addrspace_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);
         extra_index += 1;
-        const addrspace_tv = try sema.resolveInstConst(block, addrspace_src, addrspace_ref);
+        const addrspace_tv = sema.resolveInstConst(block, addrspace_src, addrspace_ref) catch |err| switch (err) {
+            error.GenericPoison => {
+                break :blk null;
+            },
+            else => |e| return e,
+        };
         break :blk addrspace_tv.val.toEnum(std.builtin.AddressSpace);
     } else target_util.defaultAddressSpace(target, .function);
 
-    const @"linksection": ?[*:0]const u8 = if (extra.data.bits.has_section_body) {
+    const @"linksection": FuncLinkSection = if (extra.data.bits.has_section_body) blk: {
         const body_len = sema.code.extra[extra_index];
         extra_index += 1;
         const body = sema.code.extra[extra_index..][0..body_len];
         extra_index += body.len;
 
         const val = try sema.resolveGenericBody(block, section_src, body, inst, Type.initTag(.const_slice_u8));
+        if (val.tag() == .generic_poison) {
+            break :blk FuncLinkSection{ .generic = {} };
+        }
         _ = val;
         return sema.fail(block, section_src, "TODO implement linksection on functions", .{});
-    } else if (extra.data.bits.has_section_ref) {
+    } else if (extra.data.bits.has_section_ref) blk: {
         const section_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);
         extra_index += 1;
-        const section_tv = try sema.resolveInstConst(block, section_src, section_ref);
+        const section_tv = sema.resolveInstConst(block, section_src, section_ref) catch |err| switch (err) {
+            error.GenericPoison => {
+                break :blk FuncLinkSection{ .generic = {} };
+            },
+            else => |e| return e,
+        };
         _ = section_tv;
         return sema.fail(block, section_src, "TODO implement linksection on functions", .{});
-    } else null;
+    } else FuncLinkSection{ .default = {} };
 
-    const cc: std.builtin.CallingConvention = if (extra.data.bits.has_cc_body) blk: {
+    const cc: ?std.builtin.CallingConvention = if (extra.data.bits.has_cc_body) blk: {
         const body_len = sema.code.extra[extra_index];
         extra_index += 1;
         const body = sema.code.extra[extra_index..][0..body_len];
@@ -16846,13 +16900,21 @@ fn zirFuncFancy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
 
         const cc_ty = try sema.getBuiltinType(block, addrspace_src, "CallingConvention");
         const val = try sema.resolveGenericBody(block, cc_src, body, inst, cc_ty);
+        if (val.tag() == .generic_poison) {
+            break :blk null;
+        }
         break :blk val.toEnum(std.builtin.CallingConvention);
     } else if (extra.data.bits.has_cc_ref) blk: {
         const cc_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);
         extra_index += 1;
-        const cc_tv = try sema.resolveInstConst(block, cc_src, cc_ref);
+        const cc_tv = sema.resolveInstConst(block, cc_src, cc_ref) catch |err| switch (err) {
+            error.GenericPoison => {
+                break :blk null;
+            },
+            else => |e| return e,
+        };
         break :blk cc_tv.val.toEnum(std.builtin.CallingConvention);
-    } else .Unspecified;
+    } else std.builtin.CallingConvention.Unspecified;
 
     const ret_ty: Type = if (extra.data.bits.has_ret_ty_body) blk: {
         const body_len = sema.code.extra[extra_index];

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -747,7 +747,7 @@ fn analyzeBodyInner(
             .field_call_bind              => try sema.zirFieldCallBind(block, inst),
             .func                         => try sema.zirFunc(block, inst, false),
             .func_inferred                => try sema.zirFunc(block, inst, true),
-            .func_extended                => try sema.zirFuncExtended(block, inst),
+            .func_fancy                   => try sema.zirFuncFancy(block, inst),
             .import                       => try sema.zirImport(block, inst),
             .indexable_ptr_len            => try sema.zirIndexablePtrLen(block, inst),
             .int                          => try sema.zirInt(block, inst),
@@ -5186,7 +5186,10 @@ fn analyzeCall(
         // on parameters, we must now do the same for the return type as we just did with
         // each of the parameters, resolving the return type and providing it to the child
         // `Sema` so that it can be used for the `ret_ptr` instruction.
-        const ret_ty_inst = try sema.resolveBody(&child_block, fn_info.ret_ty_body, module_fn.zir_body_inst);
+        const ret_ty_inst = if (fn_info.ret_ty_body.len != 0)
+            try sema.resolveBody(&child_block, fn_info.ret_ty_body, module_fn.zir_body_inst)
+        else
+            try sema.resolveInst(fn_info.ret_ty_ref);
         const ret_ty_src = func_src; // TODO better source location
         const bare_return_type = try sema.analyzeAsType(&child_block, ret_ty_src, ret_ty_inst);
         // Create a fresh inferred error set type for inline/comptime calls.
@@ -6497,9 +6500,34 @@ fn zirFunc(
 
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const extra = sema.code.extraData(Zir.Inst.Func, inst_data.payload_index);
+    const target = sema.mod.getTarget();
+    const ret_ty_src = inst_data.src(); // TODO better source location
+
     var extra_index = extra.end;
-    const ret_ty_body = sema.code.extra[extra_index..][0..extra.data.ret_body_len];
-    extra_index += ret_ty_body.len;
+
+    const ret_ty: Type = switch (extra.data.ret_body_len) {
+        0 => Type.void,
+        1 => blk: {
+            const ret_ty_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);
+            extra_index += 1;
+            if (sema.resolveType(block, ret_ty_src, ret_ty_ref)) |ret_ty| {
+                break :blk ret_ty;
+            } else |err| switch (err) {
+                error.GenericPoison => {
+                    break :blk Type.initTag(.generic_poison);
+                },
+                else => |e| return e,
+            }
+        },
+        else => blk: {
+            const ret_ty_body = sema.code.extra[extra_index..][0..extra.data.ret_body_len];
+            extra_index += ret_ty_body.len;
+
+            const ret_ty_val = try sema.resolveGenericBody(block, ret_ty_src, ret_ty_body, inst, Type.type);
+            var buffer: Value.ToTypeBuffer = undefined;
+            break :blk try ret_ty_val.toType(&buffer).copy(sema.arena);
+        },
+    };
 
     var src_locs: Zir.Inst.Func.SrcLocs = undefined;
     const has_body = extra.data.body_len != 0;
@@ -6517,9 +6545,11 @@ fn zirFunc(
         block,
         inst_data.src_node,
         inst,
-        ret_ty_body,
+        0,
+        target_util.defaultAddressSpace(target, .function),
+        null,
         cc,
-        Value.@"null",
+        ret_ty,
         false,
         inferred_error_set,
         false,
@@ -6527,6 +6557,44 @@ fn zirFunc(
         src_locs,
         null,
     );
+}
+
+// TODO this function and its callsites along with funcCommon need to be reworked
+// to handle when callconv, align, linksection, addrspace depend on comptime values
+// (thus triggering error.GenericPoison)
+fn resolveGenericBody(
+    sema: *Sema,
+    block: *Block,
+    src: LazySrcLoc,
+    body: []const Zir.Inst.Index,
+    func_inst: Zir.Inst.Index,
+    dest_ty: Type,
+) !Value {
+    assert(body.len != 0);
+
+    const err = err: {
+        // Make sure any nested param instructions don't clobber our work.
+        const prev_params = block.params;
+        block.params = .{};
+        defer {
+            block.params.deinit(sema.gpa);
+            block.params = prev_params;
+        }
+        const uncasted = sema.resolveBody(block, body, func_inst) catch |err| break :err err;
+        const result = sema.coerce(block, dest_ty, uncasted, src) catch |err| break :err err;
+        const val = sema.resolveConstValue(block, src, result) catch |err| break :err err;
+        return val;
+    };
+    switch (err) {
+        error.GenericPoison => {
+            if (dest_ty.tag() == .type) {
+                return Value.initTag(.generic_poison_type);
+            } else {
+                return Value.initTag(.generic_poison);
+            }
+        },
+        else => |e| return e,
+    }
 }
 
 /// Given a library name, examines if the library name should end up in
@@ -6597,9 +6665,11 @@ fn funcCommon(
     block: *Block,
     src_node_offset: i32,
     func_inst: Zir.Inst.Index,
-    ret_ty_body: []const Zir.Inst.Index,
+    alignment: u32,
+    address_space: std.builtin.AddressSpace,
+    section: ?[*:0]const u8,
     cc: std.builtin.CallingConvention,
-    align_val: Value,
+    bare_return_type: Type,
     var_args: bool,
     inferred_error_set: bool,
     is_extern: bool,
@@ -6609,42 +6679,11 @@ fn funcCommon(
 ) CompileError!Air.Inst.Ref {
     const ret_ty_src: LazySrcLoc = .{ .node_offset_fn_type_ret_ty = src_node_offset };
 
-    // The return type body might be a type expression that depends on generic parameters.
-    // In such case we need to use a generic_poison value for the return type and mark
-    // the function as generic.
-    var is_generic = false;
-    const bare_return_type: Type = ret_ty: {
-        if (ret_ty_body.len == 0) break :ret_ty Type.void;
-
-        const err = err: {
-            // Make sure any nested param instructions don't clobber our work.
-            const prev_params = block.params;
-            block.params = .{};
-            defer {
-                block.params.deinit(sema.gpa);
-                block.params = prev_params;
-            }
-            if (sema.resolveBody(block, ret_ty_body, func_inst)) |ret_ty_inst| {
-                if (sema.analyzeAsType(block, ret_ty_src, ret_ty_inst)) |ret_ty| {
-                    break :ret_ty ret_ty;
-                } else |err| break :err err;
-            } else |err| break :err err;
-            // Check for generic params.
-            for (block.params.items) |param| {
-                if (param.ty.tag() == .generic_poison) is_generic = true;
-            }
-        };
-        switch (err) {
-            error.GenericPoison => {
-                // The type is not available until the generic instantiation.
-                is_generic = true;
-                break :ret_ty Type.initTag(.generic_poison);
-            },
-            else => |e| return e,
-        }
-    };
-
-    const mod = sema.mod;
+    var is_generic = bare_return_type.tag() == .generic_poison;
+    // Check for generic params.
+    for (block.params.items) |param| {
+        if (param.ty.tag() == .generic_poison) is_generic = true;
+    }
 
     const new_func: *Module.Fn = new_func: {
         if (!has_body) break :new_func undefined;
@@ -6661,18 +6700,7 @@ fn funcCommon(
     errdefer if (maybe_inferred_error_set_node) |node| sema.gpa.destroy(node);
     // Note: no need to errdefer since this will still be in its default state at the end of the function.
 
-    const target = mod.getTarget();
-
     const fn_ty: Type = fn_ty: {
-        const alignment: u32 = if (align_val.tag() == .null_value) 0 else a: {
-            const alignment = @intCast(u32, align_val.toUnsignedInt(target));
-            if (alignment == target_util.defaultFunctionAlignment(target)) {
-                break :a 0;
-            } else {
-                break :a alignment;
-            }
-        };
-
         // Hot path for some common function types.
         // TODO can we eliminate some of these Type tag values? seems unnecessarily complicated.
         if (!is_generic and block.params.items.len == 0 and !var_args and
@@ -6746,6 +6774,12 @@ fn funcCommon(
             .is_generic = is_generic,
         });
     };
+
+    if (sema.owner_decl.owns_tv) {
+        sema.owner_decl.@"linksection" = section;
+        sema.owner_decl.@"align" = alignment;
+        sema.owner_decl.@"addrspace" = address_space;
+    }
 
     if (is_extern) {
         const new_extern_fn = try sema.gpa.create(Module.ExternFn);
@@ -16723,16 +16757,20 @@ fn zirVarExtended(
     return result;
 }
 
-fn zirFuncExtended(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
+fn zirFuncFancy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const tracy = trace(@src());
     defer tracy.end();
 
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src = inst_data.src();
-    const extra = sema.code.extraData(Zir.Inst.ExtendedFunc, inst_data.payload_index);
+    const extra = sema.code.extraData(Zir.Inst.FuncFancy, inst_data.payload_index);
+    const target = sema.mod.getTarget();
 
-    const cc_src: LazySrcLoc = .{ .node_offset_fn_type_cc = inst_data.src_node };
     const align_src: LazySrcLoc = src; // TODO add a LazySrcLoc that points at align
+    const addrspace_src: LazySrcLoc = src; // TODO add a LazySrcLoc that points at addrspace
+    const section_src: LazySrcLoc = src; // TODO add a LazySrcLoc that points at section
+    const cc_src: LazySrcLoc = .{ .node_offset_fn_type_cc = inst_data.src_node };
+    const ret_src: LazySrcLoc = src; // TODO add a LazySrcLoc that points at the return type
 
     var extra_index: usize = extra.end;
 
@@ -16742,22 +16780,103 @@ fn zirFuncExtended(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileErro
         break :blk lib_name;
     } else null;
 
-    const cc: std.builtin.CallingConvention = if (extra.data.bits.has_cc) blk: {
+    const @"align": u32 = if (extra.data.bits.has_align_body) blk: {
+        const body_len = sema.code.extra[extra_index];
+        extra_index += 1;
+        const body = sema.code.extra[extra_index..][0..body_len];
+        extra_index += body.len;
+
+        const val = try sema.resolveGenericBody(block, align_src, body, inst, Type.u16);
+        const alignment = @intCast(u32, val.toUnsignedInt(target));
+        if (alignment == target_util.defaultFunctionAlignment(target)) {
+            break :blk 0;
+        } else {
+            break :blk alignment;
+        }
+    } else if (extra.data.bits.has_align_ref) blk: {
+        const align_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);
+        extra_index += 1;
+        const align_tv = try sema.resolveInstConst(block, align_src, align_ref);
+        const alignment = @intCast(u32, align_tv.val.toUnsignedInt(target));
+        if (alignment == target_util.defaultFunctionAlignment(target)) {
+            break :blk 0;
+        } else {
+            break :blk alignment;
+        }
+    } else 0;
+
+    const @"addrspace": std.builtin.AddressSpace = if (extra.data.bits.has_addrspace_body) blk: {
+        const body_len = sema.code.extra[extra_index];
+        extra_index += 1;
+        const body = sema.code.extra[extra_index..][0..body_len];
+        extra_index += body.len;
+
+        const addrspace_ty = try sema.getBuiltinType(block, addrspace_src, "AddressSpace");
+        const val = try sema.resolveGenericBody(block, addrspace_src, body, inst, addrspace_ty);
+        break :blk val.toEnum(std.builtin.AddressSpace);
+    } else if (extra.data.bits.has_addrspace_ref) blk: {
+        const addrspace_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);
+        extra_index += 1;
+        const addrspace_tv = try sema.resolveInstConst(block, addrspace_src, addrspace_ref);
+        break :blk addrspace_tv.val.toEnum(std.builtin.AddressSpace);
+    } else target_util.defaultAddressSpace(target, .function);
+
+    const @"linksection": ?[*:0]const u8 = if (extra.data.bits.has_section_body) {
+        const body_len = sema.code.extra[extra_index];
+        extra_index += 1;
+        const body = sema.code.extra[extra_index..][0..body_len];
+        extra_index += body.len;
+
+        const val = try sema.resolveGenericBody(block, section_src, body, inst, Type.initTag(.const_slice_u8));
+        _ = val;
+        return sema.fail(block, section_src, "TODO implement linksection on functions", .{});
+    } else if (extra.data.bits.has_section_ref) {
+        const section_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);
+        extra_index += 1;
+        const section_tv = try sema.resolveInstConst(block, section_src, section_ref);
+        _ = section_tv;
+        return sema.fail(block, section_src, "TODO implement linksection on functions", .{});
+    } else null;
+
+    const cc: std.builtin.CallingConvention = if (extra.data.bits.has_cc_body) blk: {
+        const body_len = sema.code.extra[extra_index];
+        extra_index += 1;
+        const body = sema.code.extra[extra_index..][0..body_len];
+        extra_index += body.len;
+
+        const cc_ty = try sema.getBuiltinType(block, addrspace_src, "CallingConvention");
+        const val = try sema.resolveGenericBody(block, cc_src, body, inst, cc_ty);
+        break :blk val.toEnum(std.builtin.CallingConvention);
+    } else if (extra.data.bits.has_cc_ref) blk: {
         const cc_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);
         extra_index += 1;
         const cc_tv = try sema.resolveInstConst(block, cc_src, cc_ref);
         break :blk cc_tv.val.toEnum(std.builtin.CallingConvention);
     } else .Unspecified;
 
-    const align_val: Value = if (extra.data.bits.has_align) blk: {
-        const align_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);
+    const ret_ty: Type = if (extra.data.bits.has_ret_ty_body) blk: {
+        const body_len = sema.code.extra[extra_index];
         extra_index += 1;
-        const align_tv = try sema.resolveInstConst(block, align_src, align_ref);
-        break :blk align_tv.val;
-    } else Value.@"null";
+        const body = sema.code.extra[extra_index..][0..body_len];
+        extra_index += body.len;
 
-    const ret_ty_body = sema.code.extra[extra_index..][0..extra.data.ret_body_len];
-    extra_index += ret_ty_body.len;
+        const val = try sema.resolveGenericBody(block, ret_src, body, inst, Type.type);
+        var buffer: Value.ToTypeBuffer = undefined;
+        const ty = try val.toType(&buffer).copy(sema.arena);
+        break :blk ty;
+    } else if (extra.data.bits.has_ret_ty_ref) blk: {
+        const ret_ty_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);
+        extra_index += 1;
+        const ret_ty_tv = sema.resolveInstConst(block, ret_src, ret_ty_ref) catch |err| switch (err) {
+            error.GenericPoison => {
+                break :blk Type.initTag(.generic_poison);
+            },
+            else => |e| return e,
+        };
+        var buffer: Value.ToTypeBuffer = undefined;
+        const ty = try ret_ty_tv.val.toType(&buffer).copy(sema.arena);
+        break :blk ty;
+    } else Type.void;
 
     var src_locs: Zir.Inst.Func.SrcLocs = undefined;
     const has_body = extra.data.body_len != 0;
@@ -16774,9 +16893,11 @@ fn zirFuncExtended(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileErro
         block,
         inst_data.src_node,
         inst,
-        ret_ty_body,
+        @"align",
+        @"addrspace",
+        @"linksection",
         cc,
-        align_val,
+        ret_ty,
         is_var_args,
         is_inferred_error,
         is_extern,

--- a/src/type.zig
+++ b/src/type.zig
@@ -6120,6 +6120,10 @@ pub const Type = extern union {
                 cc: std.builtin.CallingConvention,
                 is_var_args: bool,
                 is_generic: bool,
+                align_is_generic: bool = false,
+                cc_is_generic: bool = false,
+                section_is_generic: bool = false,
+                addrspace_is_generic: bool = false,
 
                 pub fn paramIsComptime(self: @This(), i: usize) bool {
                     assert(i < self.param_types.len);


### PR DESCRIPTION
The main purpose of this commit is to prepare to implement support for
callconv(), align(), linksection(), and addrspace() annotations on
generic functions where the provided expression depends on comptime
parameters (making the function generic).

It's a rather involved change, so this commit only makes the necessary
changes to AstGen without regressing any behavior, and a follow-up
commit can finish the task by making the enhancements to Sema.

By my quick estimation, the new encoding for functions is a negligible
improvement - along the lines of 0.005% fewer total ZIR bytes on
average. Still, it's nice that this commit, while adding more
data into ZIR, actually ends up reducing the storage size thanks to a
slightly more sophisticated encoding.

Zir.Inst.ExtendedFunc is renamed to Zir.Inst.FuncFancy to eliminate
confusion about it being an extended instruction (it used to be but is
no longer). The encoding for this instruction is completely reworked.

The encoding for Zir.Inst.Func is also changed slightly - when the
return type body length is 1, then only a Zir.Inst.Ref is provided; not
a full body.

linksection() and addrspace() are now communicated via func_fancy ZIR
instruction rather than as part of the corresponding decl. This allows
their expressions to observe comptime parameters.

