### PR TITLE
Stage2: detect when initializer of const variable is comptime known

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -2063,9 +2063,8 @@ pub const Const = struct {
         // This is the inverse of calcDivLimbsBufferLen
         const available_len = (limbs.len / 3) - 2;
 
-        // TODO https://github.com/ziglang/zig/issues/11439
-        const biggest = comptime Const{
-            .limbs = &([1]Limb{math.maxInt(Limb)} ** available_len),
+        const biggest: Const = .{
+            .limbs = &([1]Limb{comptime math.maxInt(Limb)} ** available_len),
             .positive = false,
         };
         var buf: [biggest.sizeInBaseUpperBound(radix)]u8 = undefined;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3453,6 +3453,10 @@ fn validateStructInit(
                     }
                 }
                 if (lhs != field_ptr_air_ref) continue;
+                while (block_index > 0) : (block_index -= 1) {
+                    const block_inst = block.instructions.items[block_index - 1];
+                    if (air_tags[block_inst] != .dbg_stmt) break;
+                }
                 if (block_index > 0 and
                     field_ptr_air_inst == block.instructions.items[block_index - 1])
                 {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3340,7 +3340,9 @@ fn validateStructInit(
     const struct_ptr = try sema.resolveInst(struct_ptr_zir_ref);
     const struct_ty = sema.typeOf(struct_ptr).childType();
 
-    if (is_comptime or block.is_comptime) {
+    if ((is_comptime or block.is_comptime) and
+        (try sema.resolveDefinedValue(block, init_src, struct_ptr)) != null)
+    {
         // In this case the only thing we need to do is evaluate the implicit
         // store instructions for default field values, and report any missing fields.
         // Avoid the cost of the extra machinery for detecting a comptime struct init value.
@@ -3544,7 +3546,9 @@ fn zirValidateArrayInit(
         });
     }
 
-    if (is_comptime or block.is_comptime) {
+    if ((is_comptime or block.is_comptime) and
+        (try sema.resolveDefinedValue(block, init_src, array_ptr)) != null)
+    {
         // In this case the comptime machinery will have evaluated the store instructions
         // at comptime so we have almost nothing to do here. However, in case of a
         // sentinel-terminated array, the sentinel will not have been populated by

--- a/test/behavior/bugs/1741.zig
+++ b/test/behavior/bugs/1741.zig
@@ -2,9 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 test "fixed" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
     const x: f32 align(128) = 12.34;
     try std.testing.expect(@ptrToInt(&x) % 128 == 0);
 }


### PR DESCRIPTION
~~This PR makes it so that const variables produce a `decl_ref_const_init` value which behaves similarly to `decl_ref_mut` but also allows runtime stores if needed by converting the comptime pointer into a set of runtime instructions. The alloc and the instructions are placed in a `resolve_const_alloc` block replacing the hacky `make_ptr_const` which detects if any runtime instructions were emitted for the initializer and then either converts the original alloc into a runtime instruction or a comptime value.~~

~~The mechanism is quite complex but it's the simplest I could think of capable of solving more complex situations with nested structs/arrays producing chained `field_ptr`/`ptr_elem_ptr` instructions:~~
```zig
pub export fn entry() void {
    const T = struct { c: u8 };
    const S = struct { a: bool, b: [2]T };

    var foo = false;
    var bar: u8 = 1;
    const s: S = .{
        // .a = foo,
        .a = false,
        .b = [2]T{
            T{ .c = 1 },
            // T{ .c = bar },
            T{ .c = 3 },
        },
    };
    if (s.a) @compileError("bad");

    _ = foo;  _ = bar; _ = s;
}
```

~~This PR is currently a proof of concept since I'd like to get some comments on it before putting even more time into polishing it.~~

Closes #11439