### PR TITLE
Autodoc: some builtin functions and implemented merge_error_set and array_cat/mul tags

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1092,7 +1092,6 @@ var zigAnalysis;
             let payloadHtml = "";
             const lhsExpr = zigAnalysis.exprs[expr.slice.lhs];
             const startExpr = zigAnalysis.exprs[expr.slice.start];
-            console.log(expr)
             let decl = exprName(lhsExpr);
             let start = exprName(startExpr);
             let end = "";
@@ -1119,8 +1118,6 @@ var zigAnalysis;
             for (let i = 0; i < expr.switchOp.cases.length; i++) {
               const caseIndex = expr.switchOp.cases[i];
               const item = zigAnalysis.exprs[caseIndex];
-              console.log(caseIndex);
-              console.log(item);
               if (item['enumLiteral']) {
                 payloadHtml += "   " + " ." + exprName(item, opts) + " => {} " + "</br>";
                 continue;
@@ -1130,7 +1127,6 @@ var zigAnalysis;
               if (expr.switchOp.else_index !== 0) {
                 const else_index = expr.switchOp.else_index;
                 const item = zigAnalysis.exprs[else_index];
-                console.log(item);
                 payloadHtml += "    " + "else" + " => {} " + "</br>";
               }
               payloadHtml += "}";

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1086,7 +1086,33 @@ var zigAnalysis;
             return literal;
           }
           case "void": {
-            return "VOID WIP";
+            return "void";
+          }
+          case "slice":{
+            let payloadHtml = "";
+            const lhsExpr = zigAnalysis.exprs[expr.slice.lhs];
+            const startExpr = zigAnalysis.exprs[expr.slice.start];
+            console.log(expr)
+            let decl = exprName(lhsExpr);
+            let start = exprName(startExpr);
+            let end = "";
+            let sentinel = "";
+            if (expr.slice['end']) {
+              const endExpr = zigAnalysis.exprs[expr.slice.end];
+              let end_ = exprName(endExpr);
+              end += end_;
+            }
+            if (expr.slice['sentinel']) {
+              const sentinelExpr = zigAnalysis.exprs[expr.slice.sentinel];
+              let sentinel_ = exprName(sentinelExpr);
+              sentinel += " :" + sentinel_;
+            }
+            payloadHtml += decl + "["+ start + ".." + end + sentinel + "]";
+            return payloadHtml;
+          }
+          case "sliceIndex": {
+            const sliceIndex = zigAnalysis.exprs[expr.sliceIndex];
+            return exprName(sliceIndex, opts);
           }
           case "switchOp":{
             let payloadHtml = "switch() {</br>";
@@ -1257,6 +1283,7 @@ var zigAnalysis;
           }
           case "builtinBinIndex" : {
             const builtinBinIndex = zigAnalysis.exprs[expr.builtinBinIndex];
+            console.log(expr)
             return exprName(builtinBinIndex, opts);
           }
           case "builtinBin": {
@@ -1264,6 +1291,8 @@ var zigAnalysis;
             const rhsOp = zigAnalysis.exprs[expr.builtinBin.rhs];
             let lhs = exprName(lhsOp, opts);
             let rhs = exprName(rhsOp, opts);
+
+            console.log(expr);
 
             let payloadHtml = "@";
             switch (expr.builtinBin.name) {
@@ -1309,6 +1338,26 @@ var zigAnalysis;
               }
               case "has_field": {
                 payloadHtml += "hasField";
+                break;
+              }
+              case "clz": {
+                payloadHtml += "clz";
+                break;
+              }
+              case "ctz": {
+                payloadHtml += "ctz";
+                break;
+              }
+              case "pop_count": {
+                payloadHtml += "popCount";
+                break;
+              }
+              case "byte_swap": {
+                payloadHtml += "byteSwap";
+                break;
+              }
+              case "bit_reverse": {
+                payloadHtml += "bitReverse";
                 break;
               }
               default: console.log("builtin function not handled yet or doesn't exist!");

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1093,16 +1093,16 @@ var zigAnalysis;
               console.log(caseIndex);
               console.log(item);
               if (item['enumLiteral']) {
-                payloadHtml += "   " + " ." + exprName(item, opts) + " = " + "</br>";
+                payloadHtml += "   " + " ." + exprName(item, opts) + " => {} " + "</br>";
                 continue;
               }
-              payloadHtml += "    " + exprName(item, opts) + " = " + "</br>";
+              payloadHtml += "    " + exprName(item, opts) + " => {} " + "</br>";
             }
               if (expr.switchOp.else_index !== 0) {
                 const else_index = expr.switchOp.else_index;
                 const item = zigAnalysis.exprs[else_index];
                 console.log(item);
-                payloadHtml += "    " + "else" + " = " + "</br>";
+                payloadHtml += "    " + "else" + " => {} " + "</br>";
               }
               payloadHtml += "}";
             return payloadHtml;
@@ -1240,6 +1240,13 @@ var zigAnalysis;
             return print_lhs + " " + operator + " " + print_rhs;
 
           }
+          case "errorSets": {
+            const errUnionObj = zigAnalysis.types[expr.errorSets];
+            let lhs = exprName(errUnionObj.lhs, opts);
+            let rhs = exprName(errUnionObj.rhs, opts);
+            return lhs + " || " + rhs;
+
+          }
           case "errorUnion": {
             const errUnionObj = zigAnalysis.types[expr.errorUnion];
             let lhs = exprName(errUnionObj.lhs, opts);
@@ -1280,6 +1287,11 @@ var zigAnalysis;
             payloadHtml += ")";
             return payloadHtml;
 
+          }
+          case "alignOf": {
+            const alignRefArg = zigAnalysis.exprs[expr.alignOf];
+            let payloadHtml = "@alignOf(" + exprName(alignRefArg, {wantHtml: true, wantLink:true}) + ")";
+            return payloadHtml;
           }
           case "typeOf": {
             const typeRefArg = zigAnalysis.exprs[expr.typeOf];
@@ -1634,6 +1646,18 @@ var zigAnalysis;
                                   if (isVarArgs && i === fnObj.params.length - 1) {
                                       payloadHtml += '...';
                                   }
+                                  else if ("alignOf" in value) {
+                                    if (opts.wantHtml) {
+                                      payloadHtml += '<a href="">';
+                                      payloadHtml +=
+                                        '<span class="tok-kw" style="color:lightblue;">'
+                                        + exprName(value, opts) + '</span>';
+                                      payloadHtml += '</a>';
+                                    } else {
+                                      payloadHtml += exprName(value, opts);
+                                    }
+
+                                  }
                                   else if ("typeOf" in value) {
                                     if (opts.wantHtml) {
                                       payloadHtml += '<a href="">';
@@ -1728,6 +1752,7 @@ var zigAnalysis;
                     }
 
                       if (fnObj.is_inferred_error) {
+                         console.log(fnObj)
                           payloadHtml += "!";
                       }
                       if (fnObj.ret != null) {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1062,6 +1062,36 @@ var zigAnalysis;
     function exprName(expr, opts) {
         switch (Object.keys(expr)[0]) {
           default: throw "oh no";
+          case "enumLiteral": {
+            let literal = expr.enumLiteral;
+            return literal;
+          }
+          case "switchOp":{
+            let payloadHtml = "switch() {</br>";
+            for (let i = 0; i < expr.switchOp.cases.length; i++) {
+              const caseIndex = expr.switchOp.cases[i];
+              const item = zigAnalysis.exprs[caseIndex];
+              console.log(caseIndex);
+              console.log(item);
+              if (item['enumLiteral']) {
+                payloadHtml += "   " + " ." + exprName(item, opts) + " = " + "</br>";
+                continue;
+              }
+              payloadHtml += "    " + exprName(item, opts) + " = " + "</br>";
+            }
+              if (expr.switchOp.else_index !== 0) {
+                const else_index = expr.switchOp.else_index;
+                const item = zigAnalysis.exprs[else_index];
+                console.log(item);
+                payloadHtml += "    " + "else" + " = " + "</br>";
+              }
+              payloadHtml += "}";
+            return payloadHtml;
+          }
+          case "switchIndex": {
+            const switchIndex = zigAnalysis.exprs[expr.switchIndex];
+            return exprName(switchIndex, opts);
+          }
           case "fieldRef" : {
             // const fieldRef = zigAnalysis.decls[expr.fieldRef.index];
             // const struct_name = zigAnalysis.decls[expr.struct[0].val.typeRef.refPath[0].declRef].name;

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1085,6 +1085,9 @@ var zigAnalysis;
             let literal = expr.enumLiteral;
             return literal;
           }
+          case "void": {
+            return "VOID WIP";
+          }
           case "switchOp":{
             let payloadHtml = "switch() {</br>";
             for (let i = 0; i < expr.switchOp.cases.length; i++) {
@@ -1115,13 +1118,12 @@ var zigAnalysis;
             // const fieldRef = zigAnalysis.decls[expr.fieldRef.index];
             // const struct_name = zigAnalysis.decls[expr.struct[0].val.typeRef.refPath[0].declRef].name;
             console.log(expr)
-            console.log(fieldRef)
+            // console.log(fieldRef)
             // return "@enumToInt(" + exprName(enumToInt, opts) + ")";
             // return exprName(fieldRef,opts);
             return "WIP"
           }
           case "enumToInt" : {
-            console.log(expr);
             const enumToInt = zigAnalysis.exprs[expr.enumToInt];
             return "@enumToInt(" + exprName(enumToInt, opts) + ")";
           }
@@ -1132,6 +1134,187 @@ var zigAnalysis;
           case "sizeOf" : {
             const sizeOf = zigAnalysis.exprs[expr.sizeOf];
             return "@sizeOf(" + exprName(sizeOf, opts) + ")";
+          }
+          case "builtinIndex" : {
+            const builtinIndex = zigAnalysis.exprs[expr.builtinIndex];
+            return exprName(builtinIndex, opts);
+          }
+          case "builtin": {
+            const param_expr = zigAnalysis.exprs[expr.builtin.param];
+            let param = exprName(param_expr, opts);
+
+            let payloadHtml = "@";
+            switch (expr.builtin.name) {
+
+              case "align_of": {
+                payloadHtml += "alignOf";
+                break;
+              }
+              case "bool_to_int": {
+                payloadHtml += "boolToInt";
+                break;
+              }
+              case "embed_file": {
+                payloadHtml += "embedFile";
+                break;
+              }
+              case "error_name": {
+                payloadHtml += "errorName";
+                break;
+              }
+              case "panic": {
+                payloadHtml += "panic";
+                break;
+              }
+              case "set_cold": {
+                payloadHtml += "setCold";
+                break;
+              }
+              case "set_runtime_safety": {
+                payloadHtml += "setRuntimeSafety";
+                break;
+              }
+              case "sqrt": {
+                payloadHtml += "sqrt";
+                break;
+              }
+              case "sin": {
+                payloadHtml += "sin";
+                break;
+              }
+              case "cos": {
+                payloadHtml += "cos";
+                break;
+              }
+              case "tan": {
+                payloadHtml += "tan";
+                break;
+              }
+              case "exp": {
+                payloadHtml += "exp";
+                break;
+              }
+              case "exp2": {
+                payloadHtml += "exp2";
+                break;
+              }
+              case "log": {
+                payloadHtml += "log";
+                break;
+              }
+              case "log2": {
+                payloadHtml += "log2";
+                break;
+              }
+              case "log10": {
+                payloadHtml += "log10";
+                break;
+              }
+              case "fabs": {
+                payloadHtml += "fabs";
+                break;
+              }
+              case "floor": {
+                payloadHtml += "floor";
+                break;
+              }
+              case "ceil": {
+                payloadHtml += "ceil";
+                break;
+              }
+              case "trunc": {
+                payloadHtml += "trunc";
+                break;
+              }
+              case "round": {
+                payloadHtml += "round";
+                break;
+              }
+              case "tag_name": {
+                payloadHtml += "tagName";
+                break;
+              }
+              case "reify": {
+                payloadHtml += "Type";
+                break;
+              }
+              case "type_name": {
+                payloadHtml += "typeName";
+                break;
+              }
+              case "frame_type": {
+                payloadHtml += "Frame";
+                break;
+              }
+              case "frame_size": {
+                payloadHtml += "frameSize";
+                break;
+              }
+              default: console.log("builtin function not handled yet or doesn't exist!");
+            };
+            return payloadHtml + "(" + param + ")";
+
+          }
+          case "builtinBinIndex" : {
+            const builtinBinIndex = zigAnalysis.exprs[expr.builtinBinIndex];
+            return exprName(builtinBinIndex, opts);
+          }
+          case "builtinBin": {
+            const lhsOp = zigAnalysis.exprs[expr.builtinBin.lhs];
+            const rhsOp = zigAnalysis.exprs[expr.builtinBin.rhs];
+            let lhs = exprName(lhsOp, opts);
+            let rhs = exprName(rhsOp, opts);
+
+            let payloadHtml = "@";
+            switch (expr.builtinBin.name) {
+              case "float_to_int": {
+                payloadHtml += "floatToInt";
+                break;
+              }
+              case "int_to_float": {
+                payloadHtml += "intToFloat";
+                break;
+              }
+              case "int_to_ptr": {
+                payloadHtml += "intToPtr";
+                break;
+              }
+              case "int_to_enum": {
+                payloadHtml += "intToEnum";
+                break;
+              }
+              case "float_cast": {
+                payloadHtml += "floatCast";
+                break;
+              }
+              case "int_cast": {
+                payloadHtml += "intCast";
+                break;
+              }
+              case "ptr_cast": {
+                payloadHtml += "ptrCast";
+                break;
+              }
+              case "truncate": {
+                payloadHtml += "truncate";
+                break;
+              }
+              case "align_cast": {
+                payloadHtml += "alignCast";
+                break;
+              }
+              case "has_decl": {
+                payloadHtml += "hasDecl";
+                break;
+              }
+              case "has_field": {
+                payloadHtml += "hasField";
+                break;
+              }
+              default: console.log("builtin function not handled yet or doesn't exist!");
+            };
+            return payloadHtml + "(" + lhs + ", " + rhs + ")";
+
           }
           case "binOpIndex" : {
             const binOpIndex = zigAnalysis.exprs[expr.binOpIndex];
@@ -1145,9 +1328,6 @@ var zigAnalysis;
 
             let print_lhs = "";
             let print_rhs = "";
-
-            console.log(lhsOp)
-            console.log(rhsOp)
 
             if (lhsOp['binOpIndex']) {
               print_lhs = "(" + lhs + ")";
@@ -1228,6 +1408,21 @@ var zigAnalysis;
               }
               case 11 : {
                 return "@alignCast(" + print_lhs + ", " + print_rhs + ")";
+              }
+              case 12 : {
+                operator += "&";
+                break;
+              }
+              case 13 : {
+                operator += "++";
+                break;
+              }
+              case 14 : {
+                operator += "**";
+                break;
+              }
+              case 15 : {
+                return "@Vector(" + print_lhs + ", " + print_rhs + ")";
               }
               default: console.log("operator not handled yet or doesn't exist!");
             };
@@ -1723,7 +1918,11 @@ var zigAnalysis;
                                         linkFnNameDecl: opts.linkFnNameDecl,
                                       });
                                       payloadHtml += '<span class="tok-kw">' + escapeHtml(name) + '</span>';
-                                  } else if ("comptimeExpr" in value) {
+                                  } else if ("binOpIndex" in value) {
+                                    payloadHtml += exprName(value, opts);
+                                    console.log(value);
+                                    console.log(payloadHtml);
+                                  }else if ("comptimeExpr" in value) {
                                       let comptimeExpr = zigAnalysis.comptimeExprs[value.comptimeExpr].code;
                                       if (opts.wantHtml) {
                                         payloadHtml += '<span class="tok-kw">' + comptimeExpr + '</span>';

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -1151,7 +1151,7 @@ fn walkInstruction(
             self.exprs.items[slice_index] = .{ .slice = .{ .lhs = lhs_index, .start = start_index } };
 
             return DocData.WalkResult{
-                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .typeRef = self.decls.items[lhs.expr.declRef].value.typeRef,
                 .expr = .{ .sliceIndex = slice_index },
             };
         },
@@ -1190,7 +1190,7 @@ fn walkInstruction(
             self.exprs.items[slice_index] = .{ .slice = .{ .lhs = lhs_index, .start = start_index, .end = end_index } };
 
             return DocData.WalkResult{
-                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .typeRef = self.decls.items[lhs.expr.declRef].value.typeRef,
                 .expr = .{ .sliceIndex = slice_index },
             };
         },
@@ -1237,7 +1237,7 @@ fn walkInstruction(
             self.exprs.items[slice_index] = .{ .slice = .{ .lhs = lhs_index, .start = start_index, .end = end_index, .sentinel = sentinel_index } };
 
             return DocData.WalkResult{
-                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
+                .typeRef = self.decls.items[lhs.expr.declRef].value.typeRef,
                 .expr = .{ .sliceIndex = slice_index },
             };
         },


### PR DESCRIPTION
Some unary and binary builtin functions are now implemented, there are much more to implement.
The structure to implement them it's better and cleaner, than binOp, delivering all the work to js.

Tag `merge_error_sets` are now implemented and apparently it's working and it's generating all the information
needed to show it in frontend.

The tags `array_cat` and `array_mul` are working in examples cases but it's get broken running in std.
So it's commented in the pr.

The next candidates tags I'm thinking in working on are:
`slice_start`
`slice_end`
`slice_sentinel`
`switch_block` I already started this one but it's get complicated 
`func_fancy`

And refactoring the `binOp` to match the struct of `builtinBin`.

All this implementations are not fully tested. Said that maybe there are some unexpected behaviors right now
if someone find some and send some snippet of code I can work on and try to solve.

```zig
fn funBitAnd(_: anytype) align(10 & 2) void {}

// working -- but there's a problem in align() when we have a nested expr it show the last node
const AStruct = struct {
    a: *align(@alignOf(AStruct)) AStruct,
};

// // `merge_error_sets`
// // @check in std if it's really working
const A = error{One};
const B = error{Two};
const C = error{Three};
const D = error{Four};
const E = A || B || C || D;

const AEnum = enum { a, b };
const float_to_int = @floatToInt(u8, 42.42); // not working as expected
const int_to_float = @intToFloat(f32, 42);
const int_to_ptr = @intToPtr(*i32, 0);
const int_to_enum = @intToEnum(AEnum, 1);
const float_cast: f32 = @floatCast(f32, 3.1415);
const int_cast: i32 = @floatCast(i32, 3.1415);
const ptr_cast = @ptrCast(?*anyopaque, 0xbeef);
const truncate = @truncate(u8, 42424242);
const ptr: *void = undefined;
const align_cast = @alignCast(2, ptr);
const has_decl = @hasDecl(i32, "hi");
const has_field = @hasField(@TypeOf(i32), "hi");

const align_of = @alignOf([*]u8);
const bool_to_int = @boolToInt(true);
const embed_file = @embedFile("foo.zig");
const error_name = @errorName(error{ERROR});
const panic = @panic("panic");
const sqrt = @sqrt(42);
const sin = @sin(1);
const cos = @cos(1);
const tan = @tan(1);
const exp = @exp(2);
const exp2 = @exp2(2);
const log = @log(2);
const log2 = @log2(2);
const log10 = @log10(2);
const fabs = @fabs(@as(f16, -2.5));
const floor = @floor(@as(f16, 2.1));
const ceil = @ceil(@as(f16, 2.1));
const trunc = @trunc(@as(f16, 2.1));
const x = 14.0;
const y = x + 0.4;
const round = @round(y);
const tag_name: []const u8 = @tagName(AEnum.a); // WIP: fieldRef
const reify = @Type(u8);
const type_name = @typeName(u8);

const vector: @Vector(4, i32) = [4]i32{ 111, 222, 333, 444 };
fn divExact(a: @Vector(4, i32), b: @Vector(4, i32)) @Vector(4, i32) {
    return @divExact(a, b);
}

const slice = []u8{ 1, 2, 3 }; // still have the behavior of rendering [][]u8
const slice_start = slice[0..];
const slice_end = slice[0..2];
const slice_end_sentinel = slice[0..2 :0];


// "TODO: handle `{s}` in tryResolveDeclPath.type\nInfo: {}
// when running in std 
const array_cat = "array1" ++ "array2";
const array_mul = "=" ** 2;
const array_a = .{ 1, 2, 3 };
const array_b = .{ 4, 5, 6 };
const array_cat_a_b = array_a ++ array_b;
const array_mul_array_cat_a_b = (array_a ++ array_b) ** 42;

```

### Proposal

Considering my new approach of implementing `builtin functions` if that's make some sense I have a proposal.
In builtin functions and operands we can unify everything in 2 big groups unary operations and binary operations.

The big advantage is the simplicity because they share the same behavior in autodocs and it's much more simple to
maintain.

as an example I have the implementation of the builtin functions I did today.

```zig
        // builtin functions
        .align_of,
        .bool_to_int,
        .embed_file,
        .error_name,
        .panic,
        .set_cold, // @check
        .set_runtime_safety, // @check
        .sqrt,
        .sin,
        .cos,
        .tan,
        .exp,
        .exp2,
        .log,
        .log2,
        .log10,
        .fabs,
        .floor,
        .ceil,
        .trunc,
        .round,
        .tag_name,
        .reify,
        .type_name,
        .frame_type,
        .frame_size,
        => {
            const un_node = data[inst_index].un_node;
            const bin_index = self.exprs.items.len;
            try self.exprs.append(self.arena, .{ .builtin = .{ .param = 0 } });
            const param = try self.walkRef(file, parent_scope, un_node.operand, false);

            const param_index = self.exprs.items.len;
            try self.exprs.append(self.arena, param.expr);

            self.exprs.items[bin_index] = .{ .builtin = .{ .name = @tagName(tags[inst_index]), .param = param_index } };

            return DocData.WalkResult{
                .typeRef = param.typeRef,
                .expr = .{ .builtinIndex = bin_index },
            };
        },
        // @check
        // .clz, .ctz, .pop_count, .byte_swap, .bit_reverse
        .float_to_int, .int_to_float, .int_to_ptr, .int_to_enum, .float_cast, .int_cast, .ptr_cast, .truncate, .align_cast, .has_decl, .has_field => {
            const pl_node = data[inst_index].pl_node;
            const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);

            const binop_index = self.exprs.items.len;
            try self.exprs.append(self.arena, .{ .builtinBin = .{ .lhs = 0, .rhs = 0 } });

            var lhs: DocData.WalkResult = try self.walkRef(
                file,
                parent_scope,
                extra.data.lhs,
                false,
            );
            var rhs: DocData.WalkResult = try self.walkRef(
                file,
                parent_scope,
                extra.data.rhs,
                false,
            );

            const lhs_index = self.exprs.items.len;
            try self.exprs.append(self.arena, lhs.expr);
            const rhs_index = self.exprs.items.len;
            try self.exprs.append(self.arena, rhs.expr);
            self.exprs.items[binop_index] = .{ .builtinBin = .{ .name = @tagName(tags[inst_index]), .lhs = lhs_index, .rhs = rhs_index } };

            return DocData.WalkResult{
                .typeRef = .{ .type = @enumToInt(Ref.type_type) },
                .expr = .{ .builtinBinIndex = binop_index },
            };
        },
```

The biggest advantage is everything live at same place being more clean and it unlock more advantages like we can already put all the instructions related with the category and send them to js and even there we can choose handle with an error ou just handle with the default case of the switch statement.

This unlock a easy way for new contributors because they don't have to handle with `Autodoc.zig` or `Zir.zig` it's just look what are not implemented yet in the frontend or autodoc and then they can search in source code some examples if needed.