### PR TITLE
tapi: sync with upstream

### DIFF
--- a/src/link/tapi/parse/test.zig
+++ b/src/link/tapi/parse/test.zig
@@ -1,8 +1,10 @@
 const std = @import("std");
 const mem = std.mem;
 const testing = std.testing;
-const Tree = @import("../parse.zig").Tree;
-const Node = @import("../parse.zig").Node;
+const parse = @import("../parse.zig");
+
+const Node = parse.Node;
+const Tree = parse.Tree;
 
 test "explicit doc" {
     const source =

--- a/src/link/tapi/yaml.zig
+++ b/src/link/tapi/yaml.zig
@@ -511,6 +511,81 @@ test "simple map untyped" {
     try testing.expectEqual(map.get("a").?.int, 0);
 }
 
+test "simple map untyped with a list of maps" {
+    const source =
+        \\a: 0
+        \\b: 
+        \\  - foo: 1
+        \\    bar: 2
+        \\  - foo: 3
+        \\    bar: 4
+        \\c: 1
+    ;
+
+    var yaml = try Yaml.load(testing.allocator, source);
+    defer yaml.deinit();
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+    try testing.expect(map.contains("a"));
+    try testing.expect(map.contains("b"));
+    try testing.expect(map.contains("c"));
+    try testing.expectEqual(map.get("a").?.int, 0);
+    try testing.expectEqual(map.get("c").?.int, 1);
+    try testing.expectEqual(map.get("b").?.list[0].map.get("foo").?.int, 1);
+    try testing.expectEqual(map.get("b").?.list[0].map.get("bar").?.int, 2);
+    try testing.expectEqual(map.get("b").?.list[1].map.get("foo").?.int, 3);
+    try testing.expectEqual(map.get("b").?.list[1].map.get("bar").?.int, 4);
+}
+
+test "simple map untyped with a list of maps. no indent" {
+    const source =
+        \\b: 
+        \\- foo: 1
+        \\c: 1
+    ;
+
+    var yaml = try Yaml.load(testing.allocator, source);
+    defer yaml.deinit();
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+    try testing.expect(map.contains("b"));
+    try testing.expect(map.contains("c"));
+    try testing.expectEqual(map.get("c").?.int, 1);
+    try testing.expectEqual(map.get("b").?.list[0].map.get("foo").?.int, 1);
+}
+
+test "simple map untyped with a list of maps. no indent 2" {
+    const source =
+        \\a: 0
+        \\b:
+        \\- foo: 1
+        \\  bar: 2
+        \\- foo: 3
+        \\  bar: 4
+        \\c: 1
+    ;
+
+    var yaml = try Yaml.load(testing.allocator, source);
+    defer yaml.deinit();
+
+    try testing.expectEqual(yaml.docs.items.len, 1);
+
+    const map = yaml.docs.items[0].map;
+    try testing.expect(map.contains("a"));
+    try testing.expect(map.contains("b"));
+    try testing.expect(map.contains("c"));
+    try testing.expectEqual(map.get("a").?.int, 0);
+    try testing.expectEqual(map.get("c").?.int, 1);
+    try testing.expectEqual(map.get("b").?.list[0].map.get("foo").?.int, 1);
+    try testing.expectEqual(map.get("b").?.list[0].map.get("bar").?.int, 2);
+    try testing.expectEqual(map.get("b").?.list[1].map.get("foo").?.int, 3);
+    try testing.expectEqual(map.get("b").?.list[1].map.get("bar").?.int, 4);
+}
+
 test "simple map typed" {
     const source =
         \\a: 0


### PR DESCRIPTION
gitrev kubkon/zig-yaml 8cf8dc3bb901fac8189f441392fc0989ad14cf71

Calculate line and col info indexed by token index. We can then
re-use this info to track current column number (aka indentation
level) of each "key:value" pair (map) or "- element" (list).
This significantly cleans up the code, and leads naturally to
handling of unindented lists in tbd files.

Fixes #11718