### PR TITLE
add const to msghdr_const iov and control pointers

### DIFF
--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -266,13 +266,13 @@ pub const msghdr_const = extern struct {
     msg_namelen: socklen_t,
 
     /// scatter/gather array
-    msg_iov: [*]iovec_const,
+    msg_iov: [*]const iovec_const,
 
     /// # elements in msg_iov
     msg_iovlen: i32,
 
     /// ancillary data
-    msg_control: ?*anyopaque,
+    msg_control: ?*const anyopaque,
 
     /// ancillary data buffer len
     msg_controllen: socklen_t,

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -279,13 +279,13 @@ pub const msghdr_const = extern struct {
     msg_namelen: socklen_t,
 
     /// scatter/gather array
-    msg_iov: [*]iovec_const,
+    msg_iov: [*]const iovec_const,
 
     /// # elements in msg_iov
     msg_iovlen: c_uint,
 
     /// ancillary data
-    msg_control: ?*anyopaque,
+    msg_control: ?*const anyopaque,
 
     /// ancillary data buffer len
     msg_controllen: socklen_t,

--- a/lib/std/c/solaris.zig
+++ b/lib/std/c/solaris.zig
@@ -202,11 +202,11 @@ pub const msghdr_const = extern struct {
     /// size of address
     msg_namelen: socklen_t,
     /// scatter/gather array
-    msg_iov: [*]iovec_const,
+    msg_iov: [*]const iovec_const,
     /// # elements in msg_iov
     msg_iovlen: i32,
     /// ancillary data
-    msg_control: ?*anyopaque,
+    msg_control: ?*const anyopaque,
     /// ancillary data buffer len
     msg_controllen: socklen_t,
     /// flags on received message

--- a/lib/std/os/linux/arm-eabi.zig
+++ b/lib/std/os/linux/arm-eabi.zig
@@ -253,9 +253,9 @@ pub const msghdr = extern struct {
 pub const msghdr_const = extern struct {
     name: ?*const sockaddr,
     namelen: socklen_t,
-    iov: [*]iovec_const,
+    iov: [*]const iovec_const,
     iovlen: i32,
-    control: ?*anyopaque,
+    control: ?*const anyopaque,
     controllen: socklen_t,
     flags: i32,
 };

--- a/lib/std/os/linux/arm64.zig
+++ b/lib/std/os/linux/arm64.zig
@@ -209,10 +209,10 @@ pub const msghdr = extern struct {
 pub const msghdr_const = extern struct {
     name: ?*const sockaddr,
     namelen: socklen_t,
-    iov: [*]iovec_const,
+    iov: [*]const iovec_const,
     iovlen: i32,
     __pad1: i32 = 0,
-    control: ?*anyopaque,
+    control: ?*const anyopaque,
     controllen: socklen_t,
     __pad2: socklen_t = 0,
     flags: i32,

--- a/lib/std/os/linux/i386.zig
+++ b/lib/std/os/linux/i386.zig
@@ -228,9 +228,9 @@ pub const msghdr = extern struct {
 pub const msghdr_const = extern struct {
     name: ?*const sockaddr,
     namelen: socklen_t,
-    iov: [*]iovec_const,
+    iov: [*]const iovec_const,
     iovlen: i32,
-    control: ?*anyopaque,
+    control: ?*const anyopaque,
     controllen: socklen_t,
     flags: i32,
 };

--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -2033,7 +2033,7 @@ test "sendmsg/recvmsg" {
     defer os.close(client);
 
     const buffer_send = [_]u8{42} ** 128;
-    var iovecs_send = [_]os.iovec_const{
+    const iovecs_send = [_]os.iovec_const{
         os.iovec_const{ .iov_base = &buffer_send, .iov_len = buffer_send.len },
     };
     const msg_send = os.msghdr_const{

--- a/lib/std/os/linux/mips.zig
+++ b/lib/std/os/linux/mips.zig
@@ -304,9 +304,9 @@ pub const msghdr = extern struct {
 pub const msghdr_const = extern struct {
     name: ?*const sockaddr,
     namelen: socklen_t,
-    iov: [*]iovec_const,
+    iov: [*]const iovec_const,
     iovlen: i32,
-    control: ?*anyopaque,
+    control: ?*const anyopaque,
     controllen: socklen_t,
     flags: i32,
 };

--- a/lib/std/os/linux/powerpc.zig
+++ b/lib/std/os/linux/powerpc.zig
@@ -234,9 +234,9 @@ pub const msghdr = extern struct {
 pub const msghdr_const = extern struct {
     name: ?*const sockaddr,
     namelen: socklen_t,
-    iov: [*]iovec_const,
+    iov: [*]const iovec_const,
     iovlen: usize,
-    control: ?*anyopaque,
+    control: ?*const anyopaque,
     controllen: socklen_t,
     flags: i32,
 };

--- a/lib/std/os/linux/powerpc64.zig
+++ b/lib/std/os/linux/powerpc64.zig
@@ -235,9 +235,9 @@ pub const msghdr = extern struct {
 pub const msghdr_const = extern struct {
     name: ?*const sockaddr,
     namelen: socklen_t,
-    iov: [*]iovec_const,
+    iov: [*]const iovec_const,
     iovlen: usize,
-    control: ?*anyopaque,
+    control: ?*const anyopaque,
     controllen: usize,
     flags: i32,
 };

--- a/lib/std/os/linux/riscv64.zig
+++ b/lib/std/os/linux/riscv64.zig
@@ -199,10 +199,10 @@ pub const msghdr = extern struct {
 pub const msghdr_const = extern struct {
     name: ?*const sockaddr,
     namelen: socklen_t,
-    iov: [*]iovec_const,
+    iov: [*]const iovec_const,
     iovlen: i32,
     __pad1: i32 = 0,
-    control: ?*anyopaque,
+    control: ?*const anyopaque,
     controllen: socklen_t,
     __pad2: socklen_t = 0,
     flags: i32,

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -285,9 +285,9 @@ pub const msghdr = extern struct {
 pub const msghdr_const = extern struct {
     name: ?*const sockaddr,
     namelen: socklen_t,
-    iov: [*]iovec_const,
+    iov: [*]const iovec_const,
     iovlen: u64,
-    control: ?*anyopaque,
+    control: ?*const anyopaque,
     controllen: u64,
     flags: i32,
 };

--- a/lib/std/os/linux/x86_64.zig
+++ b/lib/std/os/linux/x86_64.zig
@@ -256,10 +256,10 @@ pub const msghdr = extern struct {
 pub const msghdr_const = extern struct {
     name: ?*const sockaddr,
     namelen: socklen_t,
-    iov: [*]iovec_const,
+    iov: [*]const iovec_const,
     iovlen: i32,
     __pad1: i32 = 0,
-    control: ?*anyopaque,
+    control: ?*const anyopaque,
     controllen: socklen_t,
     __pad2: socklen_t = 0,
     flags: i32,

--- a/lib/std/os/windows/ws2_32.zig
+++ b/lib/std/os/windows/ws2_32.zig
@@ -1143,7 +1143,7 @@ pub const msghdr_const = WSAMSG_const;
 pub const WSAMSG_const = extern struct {
     name: *const sockaddr,
     namelen: INT,
-    lpBuffers: [*]WSABUF,
+    lpBuffers: [*]const WSABUF,
     dwBufferCount: DWORD,
     Control: WSABUF,
     dwFlags: DWORD,


### PR DESCRIPTION
alongside the typical `msghdr` struct, Zig has added a `msghdr_const`
type that can be used with `sendmsg` which allows const data to
be provided.  I believe that data pointed to by the `iov` and `control`
fields in `msghdr` are also left unmodified, in which case they can
be marked `const`.