### PR TITLE
Autodoc: added some builtin tags and refactored some unary and binary operators

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1159,7 +1159,6 @@ var zigAnalysis;
 
             let payloadHtml = "@";
             switch (expr.builtin.name) {
-
               case "align_of": {
                 payloadHtml += "alignOf";
                 break;
@@ -1264,6 +1263,29 @@ var zigAnalysis;
                 payloadHtml += "frameSize";
                 break;
               }
+              case "ptr_to_int": {
+                payloadHtml += "ptrToInt";
+                break;
+              }
+              case "error_to_int": {
+                payloadHtml += "errorToInt";
+                break;
+              }
+              case "int_to_error": {
+                payloadHtml += "intToError";
+                break;
+              }
+              case "maximum": {
+                payloadHtml += "maximum";
+                break;
+              }
+              case "minimum": {
+                payloadHtml += "minimum";
+                break;
+              }
+              case "bit_not": {
+                return "~" + param;
+              }
               default: console.log("builtin function not handled yet or doesn't exist!");
             };
             return payloadHtml + "(" + param + ")";
@@ -1325,22 +1347,6 @@ var zigAnalysis;
                 payloadHtml += "hasField";
                 break;
               }
-              case "clz": {
-                payloadHtml += "clz";
-                break;
-              }
-              case "ctz": {
-                payloadHtml += "ctz";
-                break;
-              }
-              case "pop_count": {
-                payloadHtml += "popCount";
-                break;
-              }
-              case "byte_swap": {
-                payloadHtml += "byteSwap";
-                break;
-              }
               case "bit_reverse": {
                 payloadHtml += "bitReverse";
                 break;
@@ -1387,6 +1393,22 @@ var zigAnalysis;
               }
               case "vector_type" : {
                 payloadHtml +=  "Vector"; 
+                break;
+              }
+              case "reduce": {
+                payloadHtml +=  "reduce"; 
+                break;
+              }
+              case "splat": {
+                payloadHtml +=  "splat"; 
+                break;
+              }
+              case "offset_of": {
+                payloadHtml +=  "offsetOf"; 
+                break;
+              }
+              case "bit_offset_of": {
+                payloadHtml +=  "bitOffsetOf"; 
                 break;
               }
               default: console.log("builtin function not handled yet or doesn't exist!");
@@ -1609,6 +1631,9 @@ var zigAnalysis;
           }
           case "float": {
               return "" + expr.float.toFixed(2);
+          }
+          case "float128": {
+              return "" + expr.float128.toFixed(2);
           }
           case "undefined": {
               return "undefined";

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1114,22 +1114,14 @@ var zigAnalysis;
             return exprName(sliceIndex, opts);
           }
           case "switchOp":{
-            let payloadHtml = "switch() {</br>";
-            for (let i = 0; i < expr.switchOp.cases.length; i++) {
-              const caseIndex = expr.switchOp.cases[i];
-              const item = zigAnalysis.exprs[caseIndex];
-              if (item['enumLiteral']) {
-                payloadHtml += "   " + " ." + exprName(item, opts) + " => {} " + "</br>";
-                continue;
-              }
-              payloadHtml += "    " + exprName(item, opts) + " => {} " + "</br>";
-            }
-              if (expr.switchOp.else_index !== 0) {
-                const else_index = expr.switchOp.else_index;
-                const item = zigAnalysis.exprs[else_index];
-                payloadHtml += "    " + "else" + " => {} " + "</br>";
-              }
-              payloadHtml += "}";
+            let condExpr = zigAnalysis.exprs[expr.switchOp.cond_index];
+            let node_name_ = expr.switchOp.node_name;
+            let file_name = expr.switchOp.file_name;
+            let line_start = expr.switchOp.line_start;
+            let payloadHtml = "";
+            let cond = exprName(condExpr, opts);
+            payloadHtml += "</br>" + "node_name: " + node_name_ + "</br>" + "file: " + file_name + "</br>" + "line_start: " + line_start + "</br>";
+            payloadHtml += "switch(" + cond + ") {...}";
             return payloadHtml;
           }
           case "switchIndex": {
@@ -1279,7 +1271,6 @@ var zigAnalysis;
           }
           case "builtinBinIndex" : {
             const builtinBinIndex = zigAnalysis.exprs[expr.builtinBinIndex];
-            console.log(expr)
             return exprName(builtinBinIndex, opts);
           }
           case "builtinBin": {
@@ -1287,8 +1278,6 @@ var zigAnalysis;
             const rhsOp = zigAnalysis.exprs[expr.builtinBin.rhs];
             let lhs = exprName(lhsOp, opts);
             let rhs = exprName(rhsOp, opts);
-
-            console.log(expr);
 
             let payloadHtml = "@";
             switch (expr.builtinBin.name) {
@@ -1356,6 +1345,50 @@ var zigAnalysis;
                 payloadHtml += "bitReverse";
                 break;
               }
+              case "div_exact": {
+                payloadHtml +=  "divExact"; 
+                break;
+              }
+              case "div_floor": {
+                payloadHtml +=  "divFloor"; 
+                break;
+              }
+              case "div_trunc": {
+                payloadHtml +=  "divTrunc"; 
+                break;
+              }
+              case "mod": {
+                payloadHtml +=  "mod"; 
+                break;
+              }
+              case "rem": {
+                payloadHtml +=  "rem"; 
+                break;
+              }
+              case "mod_rem": {
+                payloadHtml +=  "rem"; 
+                break;
+              }
+              case "shl_exact": {
+                payloadHtml +=  "shlExact"; 
+                break;
+              }
+              case "shr_exact": {
+                payloadHtml +=  "shrExact"; 
+                break;
+              }
+              case "bitcast" : {
+                payloadHtml +=  "bitCast"; 
+                break;
+              }
+              case "align_cast" : {
+                payloadHtml +=  "alignCast"; 
+                break;
+              }
+              case "vector_type" : {
+                payloadHtml +=  "Vector"; 
+                break;
+              }
               default: console.log("builtin function not handled yet or doesn't exist!");
             };
             return payloadHtml + "(" + lhs + ", " + rhs + ")";
@@ -1386,97 +1419,79 @@ var zigAnalysis;
             }
 
             let operator = "";
-            // binOp.kind is described at Autodoc.zig
-            // Expr section in BinOp struct
-            switch (expr.binOp.opKind) {
-              case 0: {
+
+            switch (expr.binOp.name) {
+              case "add": {
                 operator += "+";
                 break;
               }
-              case 1: {
+              case "addwrap": {
+                operator += "+%";
+                break;
+              }
+              case "add_sat": {
+                operator += "+|";
+                break;
+              }
+              case "sub": {
                 operator += "-";
                 break;
               }
-              case 2: {
+              case "subwrap": {
+                operator += "-%";
+                break;
+              }
+              case "sub_sat": {
+                operator += "-|";
+                break;
+              }
+              case "mul": {
                 operator += "*";
                 break;
               }
-              case 3: {
-                if (!expr.binOp.extact && !expr.binOp.floor && !expr.binOp.trunv) {
-                  operator += "/";
-                  break;
-                }
-                let print_div = "";
-                if (expr.binOp.exact) {
-                  print_div = "@divExact(";
-                }
-                if (expr.binOp.floor) {
-                  print_div = "@divFloor(";
-                }
-                if (expr.binOp.trunc) {
-                  print_div = "@divTrunc(";
-                }
-                return print_div + print_lhs + ", " + print_rhs + ")";
+              case "mulwrap": {
+                operator += "*%";
+                break;
               }
-              case 4: {
-                return "@mod(" + print_lhs + ", " + print_rhs + ")";
+              case "mul_sat": {
+                operator += "*|";
+                break;
               }
-              case 5: {
-                return "@rem(" + print_lhs + ", " + print_rhs + ")";
+              case "div": {
+                operator += "/";
+                break;
               }
-              case 6: {
-                // rem_mod
-                return "@rem(" + print_lhs + ", " + print_rhs + ")";
-              }
-              case 7: {
-                if (expr.binOp.exact) {
-                  let print_shl = "@shlExact(";
-                  return print_shl + print_lhs + ", " + print_rhs + ")";
-                }
+              case "shl": {
                 operator += "<<";
                 break;
               }
-              case 8: {
-                if (expr.binOp.exact) {
-                  let print_shr = "@shrExact(";
-                  return print_shr + print_lhs + ", " + print_rhs + ")";
-                }
+              case "shl_sat": {
+                operator += "<<|";
+                break;
+              }
+              case "shr": {
                 operator += ">>";
                 break;
               }
-              case 9 : {
-                return "@bitCast(" + print_lhs + ", " + print_rhs + ")";
-              }
-              case 10 : {
+              case "bit_or" : {
                 operator += "|";
                 break;
               }
-              case 11 : {
-                return "@alignCast(" + print_lhs + ", " + print_rhs + ")";
-              }
-              case 12 : {
+              case "bit_and" : {
                 operator += "&";
                 break;
               }
-              case 13 : {
+              case "array_cat" : {
                 operator += "++";
                 break;
               }
-              case 14 : {
+              case "array_mul" : {
                 operator += "**";
                 break;
               }
-              case 15 : {
-                return "@Vector(" + print_lhs + ", " + print_rhs + ")";
-              }
               default: console.log("operator not handled yet or doesn't exist!");
             };
-            if (expr.binOp.wrap) {
-              operator += "%";
-            }
-            if (expr.binOp.sat) {
-              operator += "|";
-            }
+
             return print_lhs + " " + operator + " " + print_rhs;
 
           }
@@ -1966,8 +1981,6 @@ var zigAnalysis;
                                       payloadHtml += '<span class="tok-kw">' + escapeHtml(name) + '</span>';
                                   } else if ("binOpIndex" in value) {
                                     payloadHtml += exprName(value, opts);
-                                    console.log(value);
-                                    console.log(payloadHtml);
                                   }else if ("comptimeExpr" in value) {
                                       let comptimeExpr = zigAnalysis.comptimeExprs[value.comptimeExpr].code;
                                       if (opts.wantHtml) {
@@ -1998,7 +2011,6 @@ var zigAnalysis;
                     }
 
                       if (fnObj.is_inferred_error) {
-                         console.log(fnObj)
                           payloadHtml += "!";
                       }
                       if (fnObj.ret != null) {

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -1196,7 +1196,25 @@ fn walkInstruction(
         },
 
         // @check array_cat and array_mul
-        .add, .addwrap, .add_sat, .sub, .subwrap, .sub_sat, .mul, .mulwrap, .mul_sat, .div, .shl, .shl_sat, .shr, .bit_or, .bit_and => {
+        .add,
+        .addwrap,
+        .add_sat,
+        .sub,
+        .subwrap,
+        .sub_sat,
+        .mul,
+        .mulwrap,
+        .mul_sat,
+        .div,
+        .shl,
+        .shl_sat,
+        .shr,
+        .bit_or,
+        .bit_and,
+        // @check still not working when applied in std
+        // .array_cat,
+        // .array_mul,
+        => {
             const pl_node = data[inst_index].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
 


### PR DESCRIPTION
The code for binary operators are much more clean now and easy to maintain.
I think I add all builtin functions related with unary and binary operatos, the ones that are missing need to handle their structures maybe it's better to discuss about and see if worth handling them now, there are some which are considered as `un_node` field but takes 2 arguments.
They are:
`clz`
`ctz`
`pop_count`
`byte_swap`
`bit_reverse`

I changed the `switch_block` to print some relevant information. Now I need to figure out how to get the line of the switch case because what I can get from ast is the relative line of the parent.
By doing that there are a easy way to generate links to github because the `file` structure already has the file name with path.

I add `float128` too and get stuck in `int_big`.
