### PR TITLE
introduce a "try" ZIR and AIR instruction

### DIFF
--- a/src/Air.zig
+++ b/src/Air.zig
@@ -320,6 +320,20 @@ pub const Inst = struct {
         /// Result type is always noreturn; no instructions in a block follow this one.
         /// Uses the `pl_op` field. Operand is the condition. Payload is `SwitchBr`.
         switch_br,
+        /// Given an operand which is an error union, splits control flow. In
+        /// case of error, control flow goes into the block that is part of this
+        /// instruction, which is guaranteed to end with a return instruction
+        /// and never breaks out of the block.
+        /// In the case of non-error, control flow proceeds to the next instruction
+        /// after the `try`, with the result of this instruction being the unwrapped
+        /// payload value, as if `unwrap_errunion_payload` was executed on the operand.
+        /// Uses the `pl_op` field. Payload is `Try`.
+        @"try",
+        /// Same as `try` except the operand is a pointer to an error union, and the
+        /// result is a pointer to the payload. Result is as if `unwrap_errunion_payload_ptr`
+        /// was executed on the operand.
+        /// Uses the `ty_pl` field. Payload is `TryPtr`.
+        try_ptr,
         /// A comptime-known value. Uses the `ty_pl` field, payload is index of
         /// `values` array.
         constant,
@@ -780,6 +794,19 @@ pub const SwitchBr = struct {
     };
 };
 
+/// This data is stored inside extra. Trailing:
+/// 0. body: Inst.Index // for each body_len
+pub const Try = struct {
+    body_len: u32,
+};
+
+/// This data is stored inside extra. Trailing:
+/// 0. body: Inst.Index // for each body_len
+pub const TryPtr = struct {
+    ptr: Inst.Ref,
+    body_len: u32,
+};
+
 pub const StructField = struct {
     /// Whether this is a pointer or byval is determined by the AIR tag.
     struct_operand: Inst.Ref,
@@ -1028,6 +1055,7 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .popcount,
         .byte_swap,
         .bit_reverse,
+        .try_ptr,
         => return air.getRefType(datas[inst].ty_op.ty),
 
         .loop,
@@ -1101,6 +1129,11 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .select => {
             const extra = air.extraData(Air.Bin, datas[inst].pl_op.payload).data;
             return air.typeOf(extra.lhs);
+        },
+
+        .@"try" => {
+            const err_union_ty = air.typeOf(datas[inst].pl_op.operand);
+            return err_union_ty.errorUnionPayload();
         },
     }
 }

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -1018,6 +1018,7 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .shl_with_overflow,
         .ptr_add,
         .ptr_sub,
+        .try_ptr,
         => return air.getRefType(datas[inst].ty_pl.ty),
 
         .not,
@@ -1055,7 +1056,6 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
         .popcount,
         .byte_swap,
         .bit_reverse,
-        .try_ptr,
         => return air.getRefType(datas[inst].ty_op.ty),
 
         .loop,

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -4896,7 +4896,8 @@ fn tryExpr(
     _ = try else_scope.addUnNode(.ret_node, err_code, node);
 
     try else_scope.setTryBody(try_inst, operand);
-    return indexToRef(try_inst);
+    const result = indexToRef(try_inst);
+    return rvalue(parent_gz, rl, result, node);
 }
 
 fn orelseCatchExpr(

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1324,10 +1324,66 @@ fn analyzeBodyInner(
             },
             .@"try" => blk: {
                 if (!block.is_comptime) break :blk try sema.zirTry(block, inst);
-                @panic("TODO");
+                const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
+                const src = inst_data.src();
+                const operand_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
+                const extra = sema.code.extraData(Zir.Inst.Try, inst_data.payload_index);
+                const inline_body = sema.code.extra[extra.end..][0..extra.data.body_len];
+                const operand = try sema.resolveInst(extra.data.operand);
+                const operand_ty = sema.typeOf(operand);
+                const is_ptr = operand_ty.zigTypeTag() == .Pointer;
+                const err_union = if (is_ptr)
+                    try sema.analyzeLoad(block, src, operand, operand_src)
+                else
+                    operand;
+                const is_non_err = try sema.analyzeIsNonErr(block, operand_src, err_union);
+                const is_non_err_tv = try sema.resolveInstConst(block, operand_src, is_non_err);
+                if (is_non_err_tv.val.toBool()) {
+                    if (is_ptr) {
+                        break :blk try sema.analyzeErrUnionPayloadPtr(block, src, operand, false, false);
+                    } else {
+                        const err_union_ty = sema.typeOf(err_union);
+                        break :blk try sema.analyzeErrUnionPayload(block, src, err_union_ty, operand, operand_src, false);
+                    }
+                }
+                const break_data = (try sema.analyzeBodyBreak(block, inline_body)) orelse
+                    break always_noreturn;
+                if (inst == break_data.block_inst) {
+                    break :blk try sema.resolveInst(break_data.operand);
+                } else {
+                    break break_data.inst;
+                }
             },
-            .try_inline => {
-                @panic("TODO");
+            .try_inline => blk: {
+                const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
+                const src = inst_data.src();
+                const operand_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
+                const extra = sema.code.extraData(Zir.Inst.Try, inst_data.payload_index);
+                const inline_body = sema.code.extra[extra.end..][0..extra.data.body_len];
+                const operand = try sema.resolveInst(extra.data.operand);
+                const operand_ty = sema.typeOf(operand);
+                const is_ptr = operand_ty.zigTypeTag() == .Pointer;
+                const err_union = if (is_ptr)
+                    try sema.analyzeLoad(block, src, operand, operand_src)
+                else
+                    operand;
+                const is_non_err = try sema.analyzeIsNonErr(block, operand_src, err_union);
+                const is_non_err_tv = try sema.resolveInstConst(block, operand_src, is_non_err);
+                if (is_non_err_tv.val.toBool()) {
+                    if (is_ptr) {
+                        break :blk try sema.analyzeErrUnionPayloadPtr(block, src, operand, false, false);
+                    } else {
+                        const err_union_ty = sema.typeOf(err_union);
+                        break :blk try sema.analyzeErrUnionPayload(block, src, err_union_ty, operand, operand_src, false);
+                    }
+                }
+                const break_data = (try sema.analyzeBodyBreak(block, inline_body)) orelse
+                    break always_noreturn;
+                if (inst == break_data.block_inst) {
+                    break :blk try sema.resolveInst(break_data.operand);
+                } else {
+                    break break_data.inst;
+                }
             },
         };
         if (sema.typeOf(air_inst).isNoReturn())

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1323,28 +1323,18 @@ fn analyzeBodyInner(
                 }
             },
             .@"try" => blk: {
-                if (!block.is_comptime) break :blk try sema.zirTry(block, inst);
+                if (!block.is_comptime) break :blk try sema.zirTry(block, inst, false);
                 const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
                 const src = inst_data.src();
                 const operand_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
                 const extra = sema.code.extraData(Zir.Inst.Try, inst_data.payload_index);
                 const inline_body = sema.code.extra[extra.end..][0..extra.data.body_len];
-                const operand = try sema.resolveInst(extra.data.operand);
-                const operand_ty = sema.typeOf(operand);
-                const is_ptr = operand_ty.zigTypeTag() == .Pointer;
-                const err_union = if (is_ptr)
-                    try sema.analyzeLoad(block, src, operand, operand_src)
-                else
-                    operand;
+                const err_union = try sema.resolveInst(extra.data.operand);
                 const is_non_err = try sema.analyzeIsNonErr(block, operand_src, err_union);
                 const is_non_err_tv = try sema.resolveInstConst(block, operand_src, is_non_err);
                 if (is_non_err_tv.val.toBool()) {
-                    if (is_ptr) {
-                        break :blk try sema.analyzeErrUnionPayloadPtr(block, src, operand, false, false);
-                    } else {
-                        const err_union_ty = sema.typeOf(err_union);
-                        break :blk try sema.analyzeErrUnionPayload(block, src, err_union_ty, operand, operand_src, false);
-                    }
+                    const err_union_ty = sema.typeOf(err_union);
+                    break :blk try sema.analyzeErrUnionPayload(block, src, err_union_ty, err_union, operand_src, false);
                 }
                 const break_data = (try sema.analyzeBodyBreak(block, inline_body)) orelse
                     break always_noreturn;
@@ -1354,28 +1344,50 @@ fn analyzeBodyInner(
                     break break_data.inst;
                 }
             },
-            .try_inline => blk: {
+            //.try_inline => blk: {
+            //    const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
+            //    const src = inst_data.src();
+            //    const operand_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
+            //    const extra = sema.code.extraData(Zir.Inst.Try, inst_data.payload_index);
+            //    const inline_body = sema.code.extra[extra.end..][0..extra.data.body_len];
+            //    const operand = try sema.resolveInst(extra.data.operand);
+            //    const operand_ty = sema.typeOf(operand);
+            //    const is_ptr = operand_ty.zigTypeTag() == .Pointer;
+            //    const err_union = if (is_ptr)
+            //        try sema.analyzeLoad(block, src, operand, operand_src)
+            //    else
+            //        operand;
+            //    const is_non_err = try sema.analyzeIsNonErr(block, operand_src, err_union);
+            //    const is_non_err_tv = try sema.resolveInstConst(block, operand_src, is_non_err);
+            //    if (is_non_err_tv.val.toBool()) {
+            //        if (is_ptr) {
+            //            break :blk try sema.analyzeErrUnionPayloadPtr(block, src, operand, false, false);
+            //        } else {
+            //            const err_union_ty = sema.typeOf(err_union);
+            //            break :blk try sema.analyzeErrUnionPayload(block, src, err_union_ty, operand, operand_src, false);
+            //        }
+            //    }
+            //    const break_data = (try sema.analyzeBodyBreak(block, inline_body)) orelse
+            //        break always_noreturn;
+            //    if (inst == break_data.block_inst) {
+            //        break :blk try sema.resolveInst(break_data.operand);
+            //    } else {
+            //        break break_data.inst;
+            //    }
+            //},
+            .try_ptr => blk: {
+                if (!block.is_comptime) break :blk try sema.zirTry(block, inst, true);
                 const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
                 const src = inst_data.src();
                 const operand_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
                 const extra = sema.code.extraData(Zir.Inst.Try, inst_data.payload_index);
                 const inline_body = sema.code.extra[extra.end..][0..extra.data.body_len];
                 const operand = try sema.resolveInst(extra.data.operand);
-                const operand_ty = sema.typeOf(operand);
-                const is_ptr = operand_ty.zigTypeTag() == .Pointer;
-                const err_union = if (is_ptr)
-                    try sema.analyzeLoad(block, src, operand, operand_src)
-                else
-                    operand;
+                const err_union = try sema.analyzeLoad(block, src, operand, operand_src);
                 const is_non_err = try sema.analyzeIsNonErr(block, operand_src, err_union);
                 const is_non_err_tv = try sema.resolveInstConst(block, operand_src, is_non_err);
                 if (is_non_err_tv.val.toBool()) {
-                    if (is_ptr) {
-                        break :blk try sema.analyzeErrUnionPayloadPtr(block, src, operand, false, false);
-                    } else {
-                        const err_union_ty = sema.typeOf(err_union);
-                        break :blk try sema.analyzeErrUnionPayload(block, src, err_union_ty, operand, operand_src, false);
-                    }
+                    break :blk try sema.analyzeErrUnionPayloadPtr(block, src, operand, false, false);
                 }
                 const break_data = (try sema.analyzeBodyBreak(block, inline_body)) orelse
                     break always_noreturn;
@@ -1385,6 +1397,27 @@ fn analyzeBodyInner(
                     break break_data.inst;
                 }
             },
+            //.try_ptr_inline => blk: {
+            //    const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
+            //    const src = inst_data.src();
+            //    const operand_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
+            //    const extra = sema.code.extraData(Zir.Inst.Try, inst_data.payload_index);
+            //    const inline_body = sema.code.extra[extra.end..][0..extra.data.body_len];
+            //    const operand = try sema.resolveInst(extra.data.operand);
+            //    const err_union = try sema.analyzeLoad(block, src, operand, operand_src);
+            //    const is_non_err = try sema.analyzeIsNonErr(block, operand_src, err_union);
+            //    const is_non_err_tv = try sema.resolveInstConst(block, operand_src, is_non_err);
+            //    if (is_non_err_tv.val.toBool()) {
+            //        break :blk try sema.analyzeErrUnionPayloadPtr(block, src, operand, false, false);
+            //    }
+            //    const break_data = (try sema.analyzeBodyBreak(block, inline_body)) orelse
+            //        break always_noreturn;
+            //    if (inst == break_data.block_inst) {
+            //        break :blk try sema.resolveInst(break_data.operand);
+            //    } else {
+            //        break break_data.inst;
+            //    }
+            //},
         };
         if (sema.typeOf(air_inst).isNoReturn())
             break always_noreturn;
@@ -13032,15 +13065,18 @@ fn zirCondbr(
     return always_noreturn;
 }
 
-fn zirTry(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileError!Zir.Inst.Ref {
+fn zirTry(
+    sema: *Sema,
+    parent_block: *Block,
+    inst: Zir.Inst.Index,
+    is_ptr: bool,
+) CompileError!Zir.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src = inst_data.src();
     const operand_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
     const extra = sema.code.extraData(Zir.Inst.Try, inst_data.payload_index);
     const body = sema.code.extra[extra.end..][0..extra.data.body_len];
     const operand = try sema.resolveInst(extra.data.operand);
-    const operand_ty = sema.typeOf(operand);
-    const is_ptr = operand_ty.zigTypeTag() == .Pointer;
     const err_union = if (is_ptr)
         try sema.analyzeLoad(parent_block, src, operand, operand_src)
     else
@@ -13073,6 +13109,7 @@ fn zirTry(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileError!
     _ = try sema.analyzeBodyInner(&sub_block, body);
 
     if (is_ptr) {
+        const operand_ty = sema.typeOf(operand);
         const ptr_info = operand_ty.ptrInfo().data;
         const res_ty = try Type.ptr(sema.arena, sema.mod, .{
             .pointee_type = err_union_ty.errorUnionPayload(),

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -12983,7 +12983,8 @@ fn zirTry(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileError!
     const extra = sema.code.extraData(Zir.Inst.Try, inst_data.payload_index);
     const body = sema.code.extra[extra.end..][0..extra.data.body_len];
     const operand = try sema.resolveInst(extra.data.operand);
-    const is_ptr = sema.typeOf(operand).zigTypeTag() == .Pointer;
+    const operand_ty = sema.typeOf(operand);
+    const is_ptr = operand_ty.zigTypeTag() == .Pointer;
     const err_union = if (is_ptr)
         try sema.analyzeLoad(parent_block, src, operand, operand_src)
     else
@@ -13008,9 +13009,52 @@ fn zirTry(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileError!
         // no breaks from the body possible, and that the body is noreturn.
         return sema.resolveBody(parent_block, body, inst);
     }
-    _ = body;
-    _ = is_non_err;
-    @panic("TODO");
+
+    var sub_block = parent_block.makeSubBlock();
+    defer sub_block.instructions.deinit(sema.gpa);
+
+    // This body is guaranteed to end with noreturn and has no breaks.
+    _ = try sema.analyzeBodyInner(&sub_block, body);
+
+    if (is_ptr) {
+        const ptr_info = operand_ty.ptrInfo().data;
+        const res_ty = try Type.ptr(sema.arena, sema.mod, .{
+            .pointee_type = err_union_ty.errorUnionPayload(),
+            .@"addrspace" = ptr_info.@"addrspace",
+            .mutable = ptr_info.mutable,
+            .@"allowzero" = ptr_info.@"allowzero",
+            .@"volatile" = ptr_info.@"volatile",
+        });
+        const res_ty_ref = try sema.addType(res_ty);
+        try sema.air_extra.ensureUnusedCapacity(sema.gpa, @typeInfo(Air.Try).Struct.fields.len +
+            sub_block.instructions.items.len);
+        const try_inst = try parent_block.addInst(.{
+            .tag = .try_ptr,
+            .data = .{ .ty_pl = .{
+                .ty = res_ty_ref,
+                .payload = sema.addExtraAssumeCapacity(Air.TryPtr{
+                    .ptr = operand,
+                    .body_len = @intCast(u32, sub_block.instructions.items.len),
+                }),
+            } },
+        });
+        sema.air_extra.appendSliceAssumeCapacity(sub_block.instructions.items);
+        return try_inst;
+    }
+
+    try sema.air_extra.ensureUnusedCapacity(sema.gpa, @typeInfo(Air.Try).Struct.fields.len +
+        sub_block.instructions.items.len);
+    const try_inst = try parent_block.addInst(.{
+        .tag = .@"try",
+        .data = .{ .pl_op = .{
+            .operand = operand,
+            .payload = sema.addExtraAssumeCapacity(Air.Try{
+                .body_len = @intCast(u32, sub_block.instructions.items.len),
+            }),
+        } },
+    });
+    sema.air_extra.appendSliceAssumeCapacity(sub_block.instructions.items);
+    return try_inst;
 }
 
 // A `break` statement is inside a runtime condition, but trying to

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1322,6 +1322,13 @@ fn analyzeBodyInner(
                     break break_data.inst;
                 }
             },
+            .@"try" => blk: {
+                if (!block.is_comptime) break :blk try sema.zirTry(block, inst);
+                @panic("TODO");
+            },
+            .try_inline => {
+                @panic("TODO");
+            },
         };
         if (sema.typeOf(air_inst).isNoReturn())
             break always_noreturn;
@@ -6415,32 +6422,43 @@ fn zirErrUnionPayload(
     const src = inst_data.src();
     const operand = try sema.resolveInst(inst_data.operand);
     const operand_src = src;
-    const operand_ty = sema.typeOf(operand);
-    if (operand_ty.zigTypeTag() != .ErrorUnion) {
+    const err_union_ty = sema.typeOf(operand);
+    if (err_union_ty.zigTypeTag() != .ErrorUnion) {
         return sema.fail(block, operand_src, "expected error union type, found '{}'", .{
-            operand_ty.fmt(sema.mod),
+            err_union_ty.fmt(sema.mod),
         });
     }
+    return sema.analyzeErrUnionPayload(block, src, err_union_ty, operand, operand_src, safety_check);
+}
 
-    const result_ty = operand_ty.errorUnionPayload();
-    if (try sema.resolveDefinedValue(block, src, operand)) |val| {
+fn analyzeErrUnionPayload(
+    sema: *Sema,
+    block: *Block,
+    src: LazySrcLoc,
+    err_union_ty: Type,
+    operand: Zir.Inst.Ref,
+    operand_src: LazySrcLoc,
+    safety_check: bool,
+) CompileError!Air.Inst.Ref {
+    const payload_ty = err_union_ty.errorUnionPayload();
+    if (try sema.resolveDefinedValue(block, operand_src, operand)) |val| {
         if (val.getError()) |name| {
             return sema.fail(block, src, "caught unexpected error '{s}'", .{name});
         }
         const data = val.castTag(.eu_payload).?.data;
-        return sema.addConstant(result_ty, data);
+        return sema.addConstant(payload_ty, data);
     }
 
     try sema.requireRuntimeBlock(block, src);
 
     // If the error set has no fields then no safety check is needed.
     if (safety_check and block.wantSafety() and
-        operand_ty.errorUnionSet().errorSetCardinality() != .zero)
+        err_union_ty.errorUnionSet().errorSetCardinality() != .zero)
     {
         try sema.panicUnwrapError(block, src, operand, .unwrap_errunion_err, .is_non_err);
     }
 
-    return block.addTyOp(.unwrap_errunion_payload, result_ty, operand);
+    return block.addTyOp(.unwrap_errunion_payload, payload_ty, operand);
 }
 
 /// Pointer in, pointer out.
@@ -12956,6 +12974,43 @@ fn zirCondbr(
     sema.air_extra.appendSliceAssumeCapacity(true_instructions);
     sema.air_extra.appendSliceAssumeCapacity(sub_block.instructions.items);
     return always_noreturn;
+}
+
+fn zirTry(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileError!Zir.Inst.Ref {
+    const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
+    const src = inst_data.src();
+    const operand_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
+    const extra = sema.code.extraData(Zir.Inst.Try, inst_data.payload_index);
+    const body = sema.code.extra[extra.end..][0..extra.data.body_len];
+    const operand = try sema.resolveInst(extra.data.operand);
+    const is_ptr = sema.typeOf(operand).zigTypeTag() == .Pointer;
+    const err_union = if (is_ptr)
+        try sema.analyzeLoad(parent_block, src, operand, operand_src)
+    else
+        operand;
+    const err_union_ty = sema.typeOf(err_union);
+    if (err_union_ty.zigTypeTag() != .ErrorUnion) {
+        return sema.fail(parent_block, operand_src, "expected error union type, found '{}'", .{
+            err_union_ty.fmt(sema.mod),
+        });
+    }
+    const is_non_err = try sema.analyzeIsNonErr(parent_block, operand_src, err_union);
+
+    if (try sema.resolveDefinedValue(parent_block, operand_src, is_non_err)) |is_non_err_val| {
+        if (is_non_err_val.toBool()) {
+            if (is_ptr) {
+                return sema.analyzeErrUnionPayloadPtr(parent_block, src, operand, false, false);
+            } else {
+                return sema.analyzeErrUnionPayload(parent_block, src, err_union_ty, operand, operand_src, false);
+            }
+        }
+        // We can analyze the body directly in the parent block because we know there are
+        // no breaks from the body possible, and that the body is noreturn.
+        return sema.resolveBody(parent_block, body, inst);
+    }
+    _ = body;
+    _ = is_non_err;
+    @panic("TODO");
 }
 
 // A `break` statement is inside a runtime condition, but trying to

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -328,10 +328,14 @@ pub const Inst = struct {
         /// payload value, as if `err_union_payload_unsafe` was executed on the operand.
         /// Uses the `pl_node` union field. Payload is `Try`.
         @"try",
-        /// Same as `try` except the operand is coerced to a comptime value, and
-        /// only the taken branch is analyzed. The block must terminate with an "inline"
-        /// variant of a noreturn instruction.
-        try_inline,
+        ///// Same as `try` except the operand is coerced to a comptime value, and
+        ///// only the taken branch is analyzed. The block must terminate with an "inline"
+        ///// variant of a noreturn instruction.
+        //try_inline,
+        /// Same as `try` except the operand is a pointer and the result is a pointer.
+        try_ptr,
+        ///// Same as `try_inline` except the operand is a pointer and the result is a pointer.
+        //try_ptr_inline,
         /// An error set type definition. Contains a list of field names.
         /// Uses the `pl_node` union field. Payload is `ErrorSetDecl`.
         error_set_decl,
@@ -1245,7 +1249,9 @@ pub const Inst = struct {
                 .ret_ptr,
                 .ret_type,
                 .@"try",
-                .try_inline,
+                .try_ptr,
+                //.try_inline,
+                //.try_ptr_inline,
                 => false,
 
                 .@"break",
@@ -1525,7 +1531,9 @@ pub const Inst = struct {
                 .repeat_inline,
                 .panic,
                 .@"try",
-                .try_inline,
+                .try_ptr,
+                //.try_inline,
+                //.try_ptr_inline,
                 => false,
 
                 .extended => switch (data.extended.opcode) {
@@ -1587,7 +1595,9 @@ pub const Inst = struct {
                 .condbr = .pl_node,
                 .condbr_inline = .pl_node,
                 .@"try" = .pl_node,
-                .try_inline = .pl_node,
+                .try_ptr = .pl_node,
+                //.try_inline = .pl_node,
+                //.try_ptr_inline = .pl_node,
                 .error_set_decl = .pl_node,
                 .error_set_decl_anon = .pl_node,
                 .error_set_decl_func = .pl_node,
@@ -3766,7 +3776,7 @@ fn findDeclsInner(
             try zir.findDeclsBody(list, then_body);
             try zir.findDeclsBody(list, else_body);
         },
-        .@"try", .try_inline => {
+        .@"try", .try_ptr => {
             const inst_data = datas[inst].pl_node;
             const extra = zir.extraData(Inst.Try, inst_data.payload_index);
             const body = zir.extra[extra.end..][0..extra.data.body_len];

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -665,6 +665,9 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .prefetch        => try self.airPrefetch(inst),
             .mul_add         => try self.airMulAdd(inst),
 
+            .@"try"          => @panic("TODO"),
+            .try_ptr         => @panic("TODO"),
+
             .dbg_var_ptr,
             .dbg_var_val,
             => try self.airDbgVar(inst),

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -677,6 +677,9 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .prefetch        => try self.airPrefetch(inst),
             .mul_add         => try self.airMulAdd(inst),
 
+            .@"try"          => @panic("TODO"),
+            .try_ptr         => @panic("TODO"),
+
             .dbg_var_ptr,
             .dbg_var_val,
             => try self.airDbgVar(inst),

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -677,8 +677,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .prefetch        => try self.airPrefetch(inst),
             .mul_add         => try self.airMulAdd(inst),
 
-            .@"try"          => @panic("TODO"),
-            .try_ptr         => @panic("TODO"),
+            .@"try"          => try self.airTry(inst),
+            .try_ptr         => try self.airTryPtr(inst),
 
             .dbg_var_ptr,
             .dbg_var_val,
@@ -1837,8 +1837,8 @@ fn airUnwrapErrPayload(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const error_union_ty = self.air.typeOf(ty_op.operand);
-        const mcv = try self.resolveInst(ty_op.operand);
-        break :result try self.errUnionPayload(mcv, error_union_ty);
+        const error_union = try self.resolveInst(ty_op.operand);
+        break :result try self.errUnionPayload(error_union, error_union_ty);
     };
     return self.finishAir(inst, result, .{ ty_op.operand, .none, .none });
 }
@@ -3705,6 +3705,42 @@ fn airDbgVar(self: *Self, inst: Air.Inst.Index) !void {
     return self.finishAir(inst, .dead, .{ operand, .none, .none });
 }
 
+/// Given a boolean condition, emit a jump that is taken when that
+/// condition is false.
+fn condBr(self: *Self, condition: MCValue) !Mir.Inst.Index {
+    const condition_code: Condition = switch (condition) {
+        .cpsr_flags => |cond| cond.negate(),
+        else => blk: {
+            const reg = switch (condition) {
+                .register => |r| r,
+                else => try self.copyToTmpRegister(Type.bool, condition),
+            };
+
+            try self.spillCompareFlagsIfOccupied();
+
+            // cmp reg, 1
+            // bne ...
+            _ = try self.addInst(.{
+                .tag = .cmp,
+                .cond = .al,
+                .data = .{ .rr_op = .{
+                    .rd = .r0,
+                    .rn = reg,
+                    .op = Instruction.Operand.imm(1, 0),
+                } },
+            });
+
+            break :blk .ne;
+        },
+    };
+
+    return try self.addInst(.{
+        .tag = .b,
+        .cond = condition_code,
+        .data = .{ .inst = undefined }, // populated later through performReloc
+    });
+}
+
 fn airCondBr(self: *Self, inst: Air.Inst.Index) !void {
     const pl_op = self.air.instructions.items(.data)[inst].pl_op;
     const cond_inst = try self.resolveInst(pl_op.operand);
@@ -3713,39 +3749,7 @@ fn airCondBr(self: *Self, inst: Air.Inst.Index) !void {
     const else_body = self.air.extra[extra.end + then_body.len ..][0..extra.data.else_body_len];
     const liveness_condbr = self.liveness.getCondBr(inst);
 
-    const reloc: Mir.Inst.Index = reloc: {
-        const condition: Condition = switch (cond_inst) {
-            .cpsr_flags => |cond| cond.negate(),
-            else => blk: {
-                const reg = switch (cond_inst) {
-                    .register => |r| r,
-                    else => try self.copyToTmpRegister(Type.bool, cond_inst),
-                };
-
-                try self.spillCompareFlagsIfOccupied();
-
-                // cmp reg, 1
-                // bne ...
-                _ = try self.addInst(.{
-                    .tag = .cmp,
-                    .cond = .al,
-                    .data = .{ .rr_op = .{
-                        .rd = .r0,
-                        .rn = reg,
-                        .op = Instruction.Operand.imm(1, 0),
-                    } },
-                });
-
-                break :blk .ne;
-            },
-        };
-
-        break :reloc try self.addInst(.{
-            .tag = .b,
-            .cond = condition,
-            .data = .{ .inst = undefined }, // populated later through performReloc
-        });
-    };
+    const reloc: Mir.Inst.Index = try self.condBr(cond_inst);
 
     // If the condition dies here in this condbr instruction, process
     // that death now instead of later as this has an effect on
@@ -4157,13 +4161,8 @@ fn airSwitch(self: *Self, inst: Air.Inst.Index) !void {
                 .lhs = condition,
                 .rhs = item,
             } };
-            const cmp_result = try self.cmp(operands, condition_ty, .neq);
-
-            relocs[0] = try self.addInst(.{
-                .tag = .b,
-                .cond = cmp_result.cpsr_flags,
-                .data = .{ .inst = undefined }, // populated later through performReloc
-            });
+            const cmp_result = try self.cmp(operands, condition_ty, .eq);
+            relocs[0] = try self.condBr(cmp_result);
         } else {
             return self.fail("TODO switch with multiple items", .{});
         }
@@ -5146,6 +5145,33 @@ fn airMulAdd(self: *Self, inst: Air.Inst.Index) !void {
         return self.fail("TODO implement airMulAdd for arm", .{});
     };
     return self.finishAir(inst, result, .{ extra.lhs, extra.rhs, pl_op.operand });
+}
+
+fn airTry(self: *Self, inst: Air.Inst.Index) !void {
+    const pl_op = self.air.instructions.items(.data)[inst].pl_op;
+    const extra = self.air.extraData(Air.Try, pl_op.payload);
+    const body = self.air.extra[extra.end..][0..extra.data.body_len];
+    const result: MCValue = result: {
+        const error_union_ty = self.air.typeOf(pl_op.operand);
+        const error_union = try self.resolveInst(pl_op.operand);
+        const is_err_result = try self.isErr(error_union_ty, error_union);
+        const reloc = try self.condBr(is_err_result);
+
+        try self.genBody(body);
+
+        try self.performReloc(reloc);
+        break :result try self.errUnionPayload(error_union, error_union_ty);
+    };
+    return self.finishAir(inst, result, .{ pl_op.operand, .none, .none });
+}
+
+fn airTryPtr(self: *Self, inst: Air.Inst.Index) !void {
+    const ty_pl = self.air.instructions.items(.data)[inst].ty_pl;
+    const extra = self.air.extraData(Air.TryPtr, ty_pl.payload);
+    const body = self.air.extra[extra.end..][0..extra.data.body_len];
+    _ = body;
+    return self.fail("TODO implement airTryPtr for arm", .{});
+    // return self.finishAir(inst, result, .{ extra.data.ptr, .none, .none });
 }
 
 fn resolveInst(self: *Self, inst: Air.Inst.Ref) InnerError!MCValue {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -604,6 +604,9 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .prefetch        => try self.airPrefetch(inst),
             .mul_add         => try self.airMulAdd(inst),
 
+            .@"try"          => @panic("TODO"),
+            .try_ptr         => @panic("TODO"),
+
             .dbg_var_ptr,
             .dbg_var_val,
             => try self.airDbgVar(inst),

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -604,6 +604,9 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .prefetch        => @panic("TODO try self.airPrefetch(inst)"),
             .mul_add         => @panic("TODO try self.airMulAdd(inst)"),
 
+            .@"try"          => @panic("TODO try self.airTry(inst)"),
+            .try_ptr         => @panic("TODO try self.airTryPtr(inst)"),
+
             .dbg_var_ptr,
             .dbg_var_val,
             => try self.airDbgVar(inst),

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1490,6 +1490,9 @@ fn genInst(self: *Self, inst: Air.Inst.Index) !WValue {
         .int_to_float => self.airIntToFloat(inst),
         .get_union_tag => self.airGetUnionTag(inst),
 
+        .@"try" => @panic("TODO"),
+        .try_ptr => @panic("TODO"),
+
         // TODO
         .dbg_inline_begin,
         .dbg_inline_end,

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1490,8 +1490,8 @@ fn genInst(self: *Self, inst: Air.Inst.Index) !WValue {
         .int_to_float => self.airIntToFloat(inst),
         .get_union_tag => self.airGetUnionTag(inst),
 
-        .@"try" => @panic("TODO"),
-        .try_ptr => @panic("TODO"),
+        .@"try" => self.airTry(inst),
+        .try_ptr => self.airTryPtr(inst),
 
         // TODO
         .dbg_inline_begin,
@@ -4625,4 +4625,69 @@ fn airDbgStmt(self: *Self, inst: Air.Inst.Index) !WValue {
         }),
     } });
     return WValue{ .none = {} };
+}
+
+fn airTry(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
+    const pl_op = self.air.instructions.items(.data)[inst].pl_op;
+    const err_union = try self.resolveInst(pl_op.operand);
+    const extra = self.air.extraData(Air.Try, pl_op.payload);
+    const body = self.air.extra[extra.end..][0..extra.data.body_len];
+    const err_union_ty = self.air.typeOf(pl_op.operand);
+    return lowerTry(self, err_union, body, err_union_ty, false);
+}
+
+fn airTryPtr(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
+    const ty_pl = self.air.instructions.items(.data)[inst].ty_pl;
+    const extra = self.air.extraData(Air.TryPtr, ty_pl.payload);
+    const err_union_ptr = try self.resolveInst(extra.data.ptr);
+    const body = self.air.extra[extra.end..][0..extra.data.body_len];
+    const err_union_ty = self.air.typeOf(extra.data.ptr).childType();
+    return lowerTry(self, err_union_ptr, body, err_union_ty, true);
+}
+
+fn lowerTry(
+    self: *Self,
+    err_union: WValue,
+    body: []const Air.Inst.Index,
+    err_union_ty: Type,
+    operand_is_ptr: bool,
+) InnerError!WValue {
+    if (operand_is_ptr) {
+        return self.fail("TODO: lowerTry for pointers", .{});
+    }
+
+    if (err_union_ty.errorUnionSet().errorSetCardinality() == .zero) {
+        return err_union;
+    }
+
+    const pl_ty = err_union_ty.errorUnionPayload();
+    const pl_has_bits = pl_ty.hasRuntimeBitsIgnoreComptime();
+
+    // Block we can jump out of when error is not set
+    try self.startBlock(.block, wasm.block_empty);
+
+    // check if the error tag is set for the error union.
+    try self.emitWValue(err_union);
+    if (pl_has_bits) {
+        const err_offset = @intCast(u32, errUnionErrorOffset(pl_ty, self.target));
+        try self.addMemArg(.i32_load16_u, .{
+            .offset = err_union.offset() + err_offset,
+            .alignment = Type.anyerror.abiAlignment(self.target),
+        });
+    }
+    try self.addTag(.i32_eqz);
+    try self.addLabel(.br_if, 0); // jump out of block when error is '0'
+    try self.genBody(body);
+    try self.endBlock();
+
+    // if we reach here it means error was not set, and we want the payload
+    if (!pl_has_bits) {
+        return WValue{ .none = {} };
+    }
+
+    const pl_offset = @intCast(u32, errUnionPayloadOffset(pl_ty, self.target));
+    if (isByRef(pl_ty, self.target)) {
+        return buildPointerOffset(self, err_union, pl_offset, .new);
+    }
+    return self.load(err_union, pl_ty, pl_offset);
 }

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -681,6 +681,9 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .prefetch        => try self.airPrefetch(inst),
             .mul_add         => try self.airMulAdd(inst),
 
+            .@"try"          => @panic("TODO"),
+            .try_ptr         => @panic("TODO"),
+
             .dbg_var_ptr,
             .dbg_var_val,
             => try self.airDbgVar(inst),

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1875,6 +1875,9 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .union_init       => try airUnionInit(f, inst),
             .prefetch         => try airPrefetch(f, inst),
 
+            .@"try" => @panic("TODO"),
+            .try_ptr => @panic("TODO"),
+
             .dbg_var_ptr,
             .dbg_var_val,
             => try airDbgVar(f, inst),

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -4040,6 +4040,8 @@ pub const FuncGen = struct {
                 .ret_addr       => try self.airRetAddr(inst),
                 .frame_addr     => try self.airFrameAddress(inst),
                 .cond_br        => try self.airCondBr(inst),
+                .@"try"         => try self.airTry(inst),
+                .try_ptr        => try self.airTryPtr(inst),
                 .intcast        => try self.airIntCast(inst),
                 .trunc          => try self.airTrunc(inst),
                 .fptrunc        => try self.airFptrunc(inst),
@@ -4729,6 +4731,75 @@ pub const FuncGen = struct {
 
         // No need to reset the insert cursor since this instruction is noreturn.
         return null;
+    }
+
+    fn airTry(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {
+        const pl_op = self.air.instructions.items(.data)[inst].pl_op;
+        const err_union = try self.resolveInst(pl_op.operand);
+        const extra = self.air.extraData(Air.Try, pl_op.payload);
+        const body = self.air.extra[extra.end..][0..extra.data.body_len];
+        const err_union_ty = self.air.typeOf(pl_op.operand);
+        const result_ty = self.air.typeOfIndex(inst);
+        return lowerTry(self, err_union, body, err_union_ty, false, result_ty);
+    }
+
+    fn airTryPtr(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {
+        const ty_pl = self.air.instructions.items(.data)[inst].ty_pl;
+        const extra = self.air.extraData(Air.TryPtr, ty_pl.payload);
+        const err_union_ptr = try self.resolveInst(extra.data.ptr);
+        const body = self.air.extra[extra.end..][0..extra.data.body_len];
+        const err_union_ty = self.air.typeOf(extra.data.ptr).childType();
+        const result_ty = self.air.typeOfIndex(inst);
+        return lowerTry(self, err_union_ptr, body, err_union_ty, true, result_ty);
+    }
+
+    fn lowerTry(fg: *FuncGen, err_union: *const llvm.Value, body: []const Air.Inst.Index, err_union_ty: Type, operand_is_ptr: bool, result_ty: Type) !?*const llvm.Value {
+        if (err_union_ty.errorUnionSet().errorSetCardinality() == .zero) {
+            // If the error set has no fields, then the payload and the error
+            // union are the same value.
+            return err_union;
+        }
+
+        const payload_ty = err_union_ty.errorUnionPayload();
+        const payload_has_bits = payload_ty.hasRuntimeBitsIgnoreComptime();
+        const target = fg.dg.module.getTarget();
+        const is_err = err: {
+            const err_set_ty = try fg.dg.lowerType(Type.anyerror);
+            const zero = err_set_ty.constNull();
+            if (!payload_has_bits) {
+                const loaded = if (operand_is_ptr) fg.builder.buildLoad(err_union, "") else err_union;
+                break :err fg.builder.buildICmp(.NE, loaded, zero, "");
+            }
+            const err_field_index = errUnionErrorOffset(payload_ty, target);
+            if (operand_is_ptr or isByRef(err_union_ty)) {
+                const err_field_ptr = fg.builder.buildStructGEP(err_union, err_field_index, "");
+                const loaded = fg.builder.buildLoad(err_field_ptr, "");
+                break :err fg.builder.buildICmp(.NE, loaded, zero, "");
+            }
+            const loaded = fg.builder.buildExtractValue(err_union, err_field_index, "");
+            break :err fg.builder.buildICmp(.NE, loaded, zero, "");
+        };
+
+        const return_block = fg.context.appendBasicBlock(fg.llvm_func, "TryRet");
+        const continue_block = fg.context.appendBasicBlock(fg.llvm_func, "TryCont");
+        _ = fg.builder.buildCondBr(is_err, return_block, continue_block);
+
+        fg.builder.positionBuilderAtEnd(return_block);
+        try fg.genBody(body);
+
+        fg.builder.positionBuilderAtEnd(continue_block);
+        if (!payload_has_bits) {
+            if (!operand_is_ptr) return null;
+
+            // TODO once we update to LLVM 14 this bitcast won't be necessary.
+            const res_ptr_ty = try fg.dg.lowerType(result_ty);
+            return fg.builder.buildBitCast(err_union, res_ptr_ty, "");
+        }
+        const offset = errUnionPayloadOffset(payload_ty, target);
+        if (operand_is_ptr or isByRef(payload_ty)) {
+            return fg.builder.buildStructGEP(err_union, offset, "");
+        }
+        return fg.builder.buildExtractValue(err_union, offset, "");
     }
 
     fn airSwitchBr(self: *FuncGen, inst: Air.Inst.Index) !?*const llvm.Value {
@@ -5673,15 +5744,14 @@ pub const FuncGen = struct {
         const operand = try self.resolveInst(ty_op.operand);
         const operand_ty = self.air.typeOf(ty_op.operand);
         const error_union_ty = if (operand_is_ptr) operand_ty.childType() else operand_ty;
-        // If the error set has no fields, then the payload and the error
-        // union are the same value.
         if (error_union_ty.errorUnionSet().errorSetCardinality() == .zero) {
+            // If the error set has no fields, then the payload and the error
+            // union are the same value.
             return operand;
         }
         const result_ty = self.air.typeOfIndex(inst);
         const payload_ty = if (operand_is_ptr) result_ty.childType() else result_ty;
         const target = self.dg.module.getTarget();
-        const offset = errUnionPayloadOffset(payload_ty, target);
 
         if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
             if (!operand_is_ptr) return null;
@@ -5690,6 +5760,7 @@ pub const FuncGen = struct {
             const res_ptr_ty = try self.dg.lowerType(result_ty);
             return self.builder.buildBitCast(operand, res_ptr_ty, "");
         }
+        const offset = errUnionPayloadOffset(payload_ty, target);
         if (operand_is_ptr or isByRef(payload_ty)) {
             return self.builder.buildStructGEP(operand, offset, "");
         }

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -381,7 +381,7 @@ const Writer = struct {
             => try self.writeCondBr(stream, inst),
 
             .@"try",
-            .try_inline,
+            .try_ptr,
             => try self.writeTry(stream, inst),
 
             .error_set_decl => try self.writeErrorSetDecl(stream, inst, .parent),


### PR DESCRIPTION
Implements #11772.

## Merge Checklist:

 * [x] implement support in the backends
   - [x] x86_64
   - [x] wasm
   - [x] aarch64
   - [x] arm
   - [ ] ~riscv64~ not covered by CI tests
   - [ ] ~sparc64~ not covered by CI tests
   - [x] C
 * [x] Sema: avoid emitting unused is_non_error AIR instruction

## Analysis

Note: master branch at time of writing is e498fb155051f548071da1a13098b8793f527275.

It did *not* close the bloat gap (#11498). File size stats after this change:

```
self-hosted binary size, LLVM backend, -Drelease, -Dstrip, LLVM disabled:
  master:
    stage3: 8370744 bytes
    stage2: 6963432 bytes
  this branch:
    stage3: 8343144 bytes
    stage2: 6939800 bytes

```

So it seems that this branch produces a slightly smaller executable (a delta of 25 KB) in both cases, but did not change the relative size difference.

However it did have a small improvement on how long it took to build in release mode with LLVM:

```
building self-hosted, LLVM backend, -Drelease, -Dstrip, LLVM disabled:
  master: 
    stage1 build stage2: 3m28.3s
    stage2 build stage3: 3m16.4s
    stage3 build stage3: 3m14.4s
  this branch:
    stage1 build stage2: 3m27.8s
    stage2 build stage3: 3m10.6s
    stage3 build stage3: 3m07.7s
```

Here's the measurement that should probably be used to decide whether this patch is overall an improvement:

```
building self-hosted, LLVM backend, debug mode, LLVM disabled:
  master: 
    stage1 build stage2: 0m34.3s
    stage2 build stage3: 0m33.1s
    stage3 build stage3: error: AccessDenied
  this branch:
    stage1 build stage2: 0m30.7s
    stage2 build stage3: 0m31.4s
    stage3 build stage3: error: AccessDenied
```

I keep getting `error: AccessDenied` intermittently when running stage3 and I have not diagnosed it yet. This is tracked in  #11450. It's unfortunate here because the stage3 measurement is what we are most interested in.

Here's the same measurement but with `-Denable-llvm` which apparently does not trip the "access denied" error:

```
building self-hosted, LLVM backend, debug mode, -Denable-llvm
  master: 
    stage1 build stage2: 0m51.0s
    stage2 build stage3: 0m45.9s
    stage3 build stage3: 0m43.7s
  this branch:
    stage1 build stage2: 0m50.8s
    stage2 build stage3: 0m44.5s
    stage3 build stage3: 0m42.4s
```

Finally, let's look at perf of debug builds:

```
building self-hosted using debug mode, LLVM backend, debug mode, LLVM disabled:
  master:
    stage2 build stage3: 1m16.9s
    stage3 build stage3: 1m15.0s
  this branch:
    stage2 build stage3: 1m16.3s
    stage3 build stage3: 1m13.8s
```

Looking at the optimized LLVM IR, did `buildOutputType` get the desired cleanup pattern?

:x: no

## Conclusion

Overall, this seems to have had a small, but noticeable impact. Given that it produces better runtime code for a common zig syntax in debug builds, I am inclined to press forward with this change.