### PR TITLE
elf+macho: use explicit alignment on Decl if specified

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5800,6 +5800,7 @@ fn instantiateGenericCall(
         }
 
         new_decl.val = try Value.Tag.function.create(new_decl_arena_allocator, new_func);
+        new_decl.@"align" = 0;
         new_decl.has_tv = true;
         new_decl.owns_tv = true;
         new_decl.analysis = .complete;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2300,7 +2300,7 @@ fn updateDeclCode(self: *Elf, decl_index: Module.Decl.Index, code: []const u8, s
     defer self.base.allocator.free(decl_name);
 
     log.debug("updateDeclCode {s}{*}", .{ decl_name, decl });
-    const required_alignment = decl.ty.abiAlignment(self.base.options.target);
+    const required_alignment = decl.getAlignment(self.base.options.target);
 
     const decl_ptr = self.decls.getPtr(decl_index).?;
     if (decl_ptr.* == null) {

--- a/test/behavior/bugs/1741.zig
+++ b/test/behavior/bugs/1741.zig
@@ -5,7 +5,6 @@ test "fixed" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
     const x: f32 align(128) = 12.34;
     try std.testing.expect(@ptrToInt(&x) % 128 == 0);


### PR DESCRIPTION
Now the linkers call `decl.getAlignment(target)` instead of `decl.ty.abiAlignment(target)` to get the explicit alignment if specified (for example via `var x align(2) = ...`).

After changing the callsites I noticed that one code path in Sema wasn't setting the `Decl`'s explicit alignment to `0` (for those out of the loop, alignment of `0` means unspecified, use ABI alignment instead), and instead left it as `undefined` which would then incorrectly be picked up as specified explicit alignment of `0xaaaaaaaa` which is obviously incorrect. The code path in Sema I mention is in `instantiateGenericCall`, but I'm wondering if my patch to Sema is indeed fixing the issue or rather just the symptom, so would appreciate your input here @andrewrk.