### PR TITLE
Detect noreturn in block statements

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -1967,6 +1967,9 @@ fn blockExpr(
     }
 
     try blockExprStmts(gz, scope, statements);
+    if (gz.endsWithNoReturn()) {
+        return Zir.Inst.Ref.unreachable_value;
+    }
     return rvalue(gz, rl, .void_value, block_node);
 }
 

--- a/test/cases/compile_errors/stage2/noreturn_in_block.zig
+++ b/test/cases/compile_errors/stage2/noreturn_in_block.zig
@@ -1,0 +1,34 @@
+export fn entry1() void {
+    {
+        return;
+    }
+    return;
+}
+
+export fn entry2() void {
+    outer: {
+        {
+            break :outer;
+        }
+        return;
+    }
+}
+
+export fn entry3() void {
+    while (true) {
+        {
+            break;
+        }
+        return;
+    }
+}
+
+// error
+// target=native
+//
+// :5:5: error: unreachable code
+// :2:5: note: control flow is diverted here
+// :13:9: error: unreachable code
+// :10:9: note: control flow is diverted here
+// :22:9: error: unreachable code
+// :19:9: note: control flow is diverted here


### PR DESCRIPTION
In #11744 I (incorrectly) stated that `break` should be handled differently than the other "noreturn" instructions in blocks, which led me to introduce an unnecessary `endsWithBreak()` check. However, this is in fact not the case because in unlabeled blocks `break` *is* a noreturn value. The exception is labeled breaks (e.g. `break :blk`), but labeled blocks are handled in a different code path than unlabeled blocks, and this change applies only to the latter. This means the correct solution is actually much simpler than the one in #11744.

Consider the following cases:

Case 1:

```zig
pub fn main() void {
    {
        return;
    }
    return;
}
```

`return` in the unlabeled block causes the block to be marked as "noreturn", so the second `return` statement is correctly marked unreachable.

Case 2:

```zig
pub fn main() void {
    outer: {
        {
            break :outer;
        }
        return;
    }
}
```

The `break` inside the inner unlabeled block is considered a "noreturn" instruction, so the inner block is marked "noreturn" and the `return` statement is correctly marked unreachable.

Case 3:

```zig
pub fn main() void {
    while (true) {
        {
            break;
        }
        return;
    }
}
```

Same as case 2.

Now let's consider labeled block statements:

Case 4:

```zig
pub fn main() void {
    a: {
        b: {
            break :a;
        }
        return;
    }
}
```

The `break` inside the inner block is handled in the labeled block codepath so this PR does not affect this case; however, this *already* fails to compile due to the unused `b:` block label.

Case 5:

```zig
pub fn main() void {
    a: {
        break :a;
    }
    return;
}
```

The `break` inside the labeled block is not affected by this change since it is in a labeled block, so in this case the block is *not* marked as "noreturn" (which is correct).

Pinging @andrewrk per the conversation in #11744. What do you think of this approach? Are there any cases I missed?

Closes #11686.