### PR TITLE
introduce std.debug.Trace and use it to debug a LazySrcLoc in stage2 that is set to a bogus value

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -131,6 +131,7 @@ pub fn build(b: *Builder) !void {
     const link_libc = b.option(bool, "force-link-libc", "Force self-hosted compiler to link libc") orelse enable_llvm;
     const strip = b.option(bool, "strip", "Omit debug information") orelse false;
     const use_zig0 = b.option(bool, "zig0", "Bootstrap using zig0") orelse false;
+    const value_tracing = b.option(bool, "value-tracing", "Enable extra state tracking to help troubleshoot bugs in the compiler (using the std.debug.Trace API)") orelse false;
 
     const mem_leak_frames: u32 = b.option(u32, "mem-leak-frames", "How many stack frames to print when a memory leak occurs. Tests get 2x this amount.") orelse blk: {
         if (strip) break :blk @as(u32, 0);
@@ -353,6 +354,7 @@ pub fn build(b: *Builder) !void {
     exe_options.addOption(bool, "enable_tracy", tracy != null);
     exe_options.addOption(bool, "enable_tracy_callstack", tracy_callstack);
     exe_options.addOption(bool, "enable_tracy_allocation", tracy_allocation);
+    exe_options.addOption(bool, "value_tracing", value_tracing);
     exe_options.addOption(bool, "is_stage1", is_stage1);
     exe_options.addOption(bool, "omit_stage2", omit_stage2);
     if (tracy) |tracy_path| {
@@ -402,6 +404,7 @@ pub fn build(b: *Builder) !void {
     test_cases_options.addOption(bool, "enable_rosetta", b.enable_rosetta);
     test_cases_options.addOption(bool, "enable_darling", b.enable_darling);
     test_cases_options.addOption(u32, "mem_leak_frames", mem_leak_frames * 2);
+    test_cases_options.addOption(bool, "value_tracing", value_tracing);
     test_cases_options.addOption(?[]const u8, "glibc_runtimes_dir", b.glibc_runtimes_dir);
     test_cases_options.addOption([:0]const u8, "version", try b.allocator.dupeZ(u8, version));
     test_cases_options.addOption(std.SemanticVersion, "semver", semver);

--- a/ci/azure/build.zig
+++ b/ci/azure/build.zig
@@ -99,6 +99,7 @@ pub fn build(b: *Builder) !void {
     const force_gpa = b.option(bool, "force-gpa", "Force the compiler to use GeneralPurposeAllocator") orelse false;
     const link_libc = b.option(bool, "force-link-libc", "Force self-hosted compiler to link libc") orelse enable_llvm;
     const strip = b.option(bool, "strip", "Omit debug information") orelse false;
+    const value_tracing = b.option(bool, "value-tracing", "Enable extra state tracking to help troubleshoot bugs in the compiler (using the std.debug.Trace API)") orelse false;
 
     const mem_leak_frames: u32 = b.option(u32, "mem-leak-frames", "How many stack frames to print when a memory leak occurs. Tests get 2x this amount.") orelse blk: {
         if (strip) break :blk @as(u32, 0);
@@ -303,6 +304,7 @@ pub fn build(b: *Builder) !void {
     exe_options.addOption(bool, "enable_tracy", tracy != null);
     exe_options.addOption(bool, "enable_tracy_callstack", tracy_callstack);
     exe_options.addOption(bool, "enable_tracy_allocation", tracy_allocation);
+    exe_options.addOption(bool, "value_tracing", value_tracing);
     exe_options.addOption(bool, "is_stage1", is_stage1);
     exe_options.addOption(bool, "omit_stage2", omit_stage2);
     if (tracy) |tracy_path| {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -338,6 +338,8 @@ pub const AllErrors = struct {
             line: u32,
             column: u32,
             byte_offset: u32,
+            /// Usually one, but incremented for redundant messages.
+            count: u32 = 1,
             /// Does not include the trailing newline.
             source_line: ?[]const u8,
             notes: []Message = &.{},
@@ -345,7 +347,20 @@ pub const AllErrors = struct {
         plain: struct {
             msg: []const u8,
             notes: []Message = &.{},
+            /// Usually one, but incremented for redundant messages.
+            count: u32 = 1,
         },
+
+        pub fn incrementCount(msg: *Message) void {
+            switch (msg.*) {
+                .src => |*src| {
+                    src.count += 1;
+                },
+                .plain => |*plain| {
+                    plain.count += 1;
+                },
+            }
+        }
 
         pub fn renderToStdErr(msg: Message, ttyconf: std.debug.TTY.Config) void {
             std.debug.getStderrMutex().lock();
@@ -376,7 +391,13 @@ pub const AllErrors = struct {
                     try stderr.writeAll(kind);
                     ttyconf.setColor(stderr, .Reset);
                     ttyconf.setColor(stderr, .Bold);
-                    try stderr.print(" {s}\n", .{src.msg});
+                    if (src.count == 1) {
+                        try stderr.print(" {s}\n", .{src.msg});
+                    } else {
+                        try stderr.print(" {s}", .{src.msg});
+                        ttyconf.setColor(stderr, .Dim);
+                        try stderr.print(" ({d} times)\n", .{src.count});
+                    }
                     ttyconf.setColor(stderr, .Reset);
                     if (ttyconf != .no_color) {
                         if (src.source_line) |line| {
@@ -400,7 +421,13 @@ pub const AllErrors = struct {
                     try stderr.writeByteNTimes(' ', indent);
                     try stderr.writeAll(kind);
                     ttyconf.setColor(stderr, .Reset);
-                    try stderr.print(" {s}\n", .{plain.msg});
+                    if (plain.count == 1) {
+                        try stderr.print(" {s}\n", .{plain.msg});
+                    } else {
+                        try stderr.print(" {s}", .{plain.msg});
+                        ttyconf.setColor(stderr, .Dim);
+                        try stderr.print(" ({d} times)\n", .{plain.count});
+                    }
                     ttyconf.setColor(stderr, .Reset);
                     for (plain.notes) |note| {
                         try note.renderToStdErrInner(ttyconf, stderr_file, "error:", .Red, indent + 4);
@@ -408,6 +435,50 @@ pub const AllErrors = struct {
                 },
             }
         }
+
+        pub const HashContext = struct {
+            pub fn hash(ctx: HashContext, key: *Message) u64 {
+                _ = ctx;
+                var hasher = std.hash.Wyhash.init(0);
+
+                switch (key.*) {
+                    .src => |src| {
+                        hasher.update(src.msg);
+                        hasher.update(src.src_path);
+                        std.hash.autoHash(&hasher, src.line);
+                        std.hash.autoHash(&hasher, src.column);
+                        std.hash.autoHash(&hasher, src.byte_offset);
+                    },
+                    .plain => |plain| {
+                        hasher.update(plain.msg);
+                    },
+                }
+
+                return hasher.final();
+            }
+
+            pub fn eql(ctx: HashContext, a: *Message, b: *Message) bool {
+                _ = ctx;
+                switch (a.*) {
+                    .src => |a_src| switch (b.*) {
+                        .src => |b_src| {
+                            return mem.eql(u8, a_src.msg, b_src.msg) and
+                                mem.eql(u8, a_src.src_path, b_src.src_path) and
+                                a_src.line == b_src.line and
+                                a_src.column == b_src.column and
+                                a_src.byte_offset == b_src.byte_offset;
+                        },
+                        .plain => return false,
+                    },
+                    .plain => |a_plain| switch (b.*) {
+                        .src => return false,
+                        .plain => |b_plain| {
+                            return mem.eql(u8, a_plain.msg, b_plain.msg);
+                        },
+                    },
+                }
+            }
+        };
     };
 
     pub fn deinit(self: *AllErrors, gpa: Allocator) void {
@@ -421,13 +492,25 @@ pub const AllErrors = struct {
         module_err_msg: Module.ErrorMsg,
     ) !void {
         const allocator = arena.allocator();
-        const notes = try allocator.alloc(Message, module_err_msg.notes.len);
-        for (notes) |*note, i| {
-            const module_note = module_err_msg.notes[i];
+
+        const notes_buf = try allocator.alloc(Message, module_err_msg.notes.len);
+        var note_i: usize = 0;
+
+        // De-duplicate error notes. The main use case in mind for this is
+        // too many "note: called from here" notes when eval branch quota is reached.
+        var seen_notes = std.HashMap(
+            *Message,
+            void,
+            Message.HashContext,
+            std.hash_map.default_max_load_percentage,
+        ).init(allocator);
+
+        for (module_err_msg.notes) |module_note| {
             const source = try module_note.src_loc.file_scope.getSource(module.gpa);
             const byte_offset = try module_note.src_loc.byteOffset(module.gpa);
             const loc = std.zig.findLineColumn(source.bytes, byte_offset);
             const file_path = try module_note.src_loc.file_scope.fullPath(allocator);
+            const note = &notes_buf[note_i];
             note.* = .{
                 .src = .{
                     .src_path = file_path,
@@ -438,6 +521,12 @@ pub const AllErrors = struct {
                     .source_line = try allocator.dupe(u8, loc.source_line),
                 },
             };
+            const gop = try seen_notes.getOrPut(note);
+            if (gop.found_existing) {
+                gop.key_ptr.*.incrementCount();
+            } else {
+                note_i += 1;
+            }
         }
         if (module_err_msg.src_loc.lazy == .entire_file) {
             try errors.append(.{
@@ -458,7 +547,7 @@ pub const AllErrors = struct {
                 .byte_offset = byte_offset,
                 .line = @intCast(u32, loc.line),
                 .column = @intCast(u32, loc.column),
-                .notes = notes,
+                .notes = notes_buf[0..note_i],
                 .source_line = try allocator.dupe(u8, loc.source_line),
             },
         });

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -2529,11 +2529,9 @@ pub const SrcLoc = struct {
 /// where in semantic analysis the value got set.
 const TracedOffset = struct {
     x: i32,
-    trace: Trace = trace_init,
+    trace: std.debug.Trace = .{},
 
-    const want_tracing = builtin.mode == .Debug;
-    const trace_init = if (want_tracing) std.debug.Trace(1, 3){} else {};
-    const Trace = @TypeOf(trace_init);
+    const want_tracing = std.debug.Trace.enabled;
 };
 
 /// Resolving a source location into a byte offset may require doing work

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -2531,7 +2531,7 @@ const TracedOffset = struct {
     x: i32,
     trace: std.debug.Trace = .{},
 
-    const want_tracing = std.debug.Trace.enabled;
+    const want_tracing = build_options.value_tracing;
 };
 
 /// Resolving a source location into a byte offset may require doing work

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -18061,7 +18061,6 @@ fn safetyPanic(
 fn emitBackwardBranch(sema: *Sema, block: *Block, src: LazySrcLoc) !void {
     sema.branch_count += 1;
     if (sema.branch_count > sema.branch_quota) {
-        // TODO show the "called from here" stack
         return sema.fail(block, src, "evaluation exceeded {d} backwards branches", .{sema.branch_quota});
     }
 }

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2427,7 +2427,7 @@ pub const Inst = struct {
             operand: Ref,
 
             pub fn src(self: @This()) LazySrcLoc {
-                return .{ .node_offset = self.src_node };
+                return LazySrcLoc.nodeOffset(self.src_node);
             }
         },
         /// Used for unary operators, with a token source location.
@@ -2450,7 +2450,7 @@ pub const Inst = struct {
             payload_index: u32,
 
             pub fn src(self: @This()) LazySrcLoc {
-                return .{ .node_offset = self.src_node };
+                return LazySrcLoc.nodeOffset(self.src_node);
             }
         },
         pl_tok: struct {
@@ -2526,7 +2526,7 @@ pub const Inst = struct {
             bit_count: u16,
 
             pub fn src(self: @This()) LazySrcLoc {
-                return .{ .node_offset = self.src_node };
+                return LazySrcLoc.nodeOffset(self.src_node);
             }
         },
         bool_br: struct {
@@ -2545,7 +2545,7 @@ pub const Inst = struct {
             force_comptime: bool,
 
             pub fn src(self: @This()) LazySrcLoc {
-                return .{ .node_offset = self.src_node };
+                return LazySrcLoc.nodeOffset(self.src_node);
             }
         },
         @"break": struct {
@@ -2566,7 +2566,7 @@ pub const Inst = struct {
             inst: Index,
 
             pub fn src(self: @This()) LazySrcLoc {
-                return .{ .node_offset = self.src_node };
+                return LazySrcLoc.nodeOffset(self.src_node);
             }
         },
         str_op: struct {

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -622,7 +622,7 @@ pub fn deinit(self: *Self) void {
 
 /// Sets `err_msg` on `CodeGen` and returns `error.CodegenFail` which is caught in link/Wasm.zig
 fn fail(self: *Self, comptime fmt: []const u8, args: anytype) InnerError {
-    const src: LazySrcLoc = .{ .node_offset = 0 };
+    const src = LazySrcLoc.nodeOffset(0);
     const src_loc = src.toSrcLoc(self.decl);
     self.err_msg = try Module.ErrorMsg.create(self.gpa, src_loc, fmt, args);
     return error.CodegenFail;

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -363,7 +363,7 @@ pub const DeclGen = struct {
 
     fn fail(dg: *DeclGen, comptime format: []const u8, args: anytype) error{ AnalysisFail, OutOfMemory } {
         @setCold(true);
-        const src: LazySrcLoc = .{ .node_offset = 0 };
+        const src = LazySrcLoc.nodeOffset(0);
         const src_loc = src.toSrcLoc(dg.decl);
         dg.error_msg = try Module.ErrorMsg.create(dg.module.gpa, src_loc, format, args);
         return error.AnalysisFail;

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2163,7 +2163,7 @@ pub const DeclGen = struct {
     fn todo(self: *DeclGen, comptime format: []const u8, args: anytype) Error {
         @setCold(true);
         assert(self.err_msg == null);
-        const src_loc = @as(LazySrcLoc, .{ .node_offset = 0 }).toSrcLoc(self.decl);
+        const src_loc = LazySrcLoc.nodeOffset(0).toSrcLoc(self.decl);
         self.err_msg = try Module.ErrorMsg.create(self.gpa, src_loc, "TODO (LLVM): " ++ format, args);
         return error.CodegenFail;
     }

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -184,7 +184,7 @@ pub const DeclGen = struct {
 
     fn fail(self: *DeclGen, comptime format: []const u8, args: anytype) Error {
         @setCold(true);
-        const src: LazySrcLoc = .{ .node_offset = 0 };
+        const src = LazySrcLoc.nodeOffset(0);
         const src_loc = src.toSrcLoc(self.decl);
         assert(self.error_msg == null);
         self.error_msg = try Module.ErrorMsg.create(self.module.gpa, src_loc, format, args);
@@ -193,7 +193,7 @@ pub const DeclGen = struct {
 
     fn todo(self: *DeclGen, comptime format: []const u8, args: anytype) Error {
         @setCold(true);
-        const src: LazySrcLoc = .{ .node_offset = 0 };
+        const src = LazySrcLoc.nodeOffset(0);
         const src_loc = src.toSrcLoc(self.decl);
         assert(self.error_msg == null);
         self.error_msg = try Module.ErrorMsg.create(self.module.gpa, src_loc, "TODO (SPIR-V): " ++ format, args);

--- a/src/config.zig.in
+++ b/src/config.zig.in
@@ -8,6 +8,7 @@ pub const semver = @import("std").SemanticVersion.parse(version) catch unreachab
 pub const enable_logging: bool = @ZIG_ENABLE_LOGGING_BOOL@;
 pub const enable_link_snapshots: bool = false;
 pub const enable_tracy = false;
+pub const value_tracing = false;
 pub const is_stage1 = true;
 pub const skip_non_native = false;
 pub const omit_stage2: bool = @ZIG_OMIT_STAGE2_BOOL@;

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -497,7 +497,7 @@ const Writer = struct {
             .wasm_memory_size,
             => {
                 const inst_data = self.code.extraData(Zir.Inst.UnNode, extended.operand).data;
-                const src: LazySrcLoc = .{ .node_offset = inst_data.node };
+                const src = LazySrcLoc.nodeOffset(inst_data.node);
                 try self.writeInstRef(stream, inst_data.operand);
                 try stream.writeAll(")) ");
                 try self.writeSrc(stream, src);
@@ -510,7 +510,7 @@ const Writer = struct {
             .prefetch,
             => {
                 const inst_data = self.code.extraData(Zir.Inst.BinNode, extended.operand).data;
-                const src: LazySrcLoc = .{ .node_offset = inst_data.node };
+                const src = LazySrcLoc.nodeOffset(inst_data.node);
                 try self.writeInstRef(stream, inst_data.lhs);
                 try stream.writeAll(", ");
                 try self.writeInstRef(stream, inst_data.rhs);
@@ -520,7 +520,7 @@ const Writer = struct {
 
             .field_call_bind_named => {
                 const extra = self.code.extraData(Zir.Inst.FieldNamedNode, extended.operand).data;
-                const src: LazySrcLoc = .{ .node_offset = extra.node };
+                const src = LazySrcLoc.nodeOffset(extra.node);
                 try self.writeInstRef(stream, extra.lhs);
                 try stream.writeAll(", ");
                 try self.writeInstRef(stream, extra.field_name);
@@ -531,7 +531,7 @@ const Writer = struct {
     }
 
     fn writeExtNode(self: *Writer, stream: anytype, extended: Zir.Inst.Extended.InstData) !void {
-        const src: LazySrcLoc = .{ .node_offset = @bitCast(i32, extended.operand) };
+        const src = LazySrcLoc.nodeOffset(@bitCast(i32, extended.operand));
         try stream.writeAll(")) ");
         try self.writeSrc(stream, src);
     }
@@ -1050,7 +1050,7 @@ const Writer = struct {
 
     fn writeNodeMultiOp(self: *Writer, stream: anytype, extended: Zir.Inst.Extended.InstData) !void {
         const extra = self.code.extraData(Zir.Inst.NodeMultiOp, extended.operand);
-        const src: LazySrcLoc = .{ .node_offset = extra.data.src_node };
+        const src = LazySrcLoc.nodeOffset(extra.data.src_node);
         const operands = self.code.refSlice(extra.end, extended.small);
 
         for (operands) |operand, i| {
@@ -1074,7 +1074,7 @@ const Writer = struct {
 
     fn writeAsm(self: *Writer, stream: anytype, extended: Zir.Inst.Extended.InstData) !void {
         const extra = self.code.extraData(Zir.Inst.Asm, extended.operand);
-        const src: LazySrcLoc = .{ .node_offset = extra.data.src_node };
+        const src = LazySrcLoc.nodeOffset(extra.data.src_node);
         const outputs_len = @truncate(u5, extended.small);
         const inputs_len = @truncate(u5, extended.small >> 5);
         const clobbers_len = @truncate(u5, extended.small >> 10);
@@ -1145,7 +1145,7 @@ const Writer = struct {
 
     fn writeOverflowArithmetic(self: *Writer, stream: anytype, extended: Zir.Inst.Extended.InstData) !void {
         const extra = self.code.extraData(Zir.Inst.OverflowArithmetic, extended.operand).data;
-        const src: LazySrcLoc = .{ .node_offset = extra.node };
+        const src = LazySrcLoc.nodeOffset(extra.node);
 
         try self.writeInstRef(stream, extra.lhs);
         try stream.writeAll(", ");
@@ -1898,7 +1898,7 @@ const Writer = struct {
         inst: Zir.Inst.Index,
     ) (@TypeOf(stream).Error || error{OutOfMemory})!void {
         const src_node = self.code.instructions.items(.data)[inst].node;
-        const src: LazySrcLoc = .{ .node_offset = src_node };
+        const src = LazySrcLoc.nodeOffset(src_node);
         try stream.writeAll(") ");
         try self.writeSrc(stream, src);
     }
@@ -2117,7 +2117,7 @@ const Writer = struct {
     fn writeAllocExtended(self: *Writer, stream: anytype, extended: Zir.Inst.Extended.InstData) !void {
         const extra = self.code.extraData(Zir.Inst.AllocExtended, extended.operand);
         const small = @bitCast(Zir.Inst.AllocExtended.Small, extended.small);
-        const src: LazySrcLoc = .{ .node_offset = extra.data.src_node };
+        const src = LazySrcLoc.nodeOffset(extra.data.src_node);
 
         var extra_index: usize = extra.end;
         const type_inst: Zir.Inst.Ref = if (!small.has_type) .none else blk: {
@@ -2351,7 +2351,7 @@ const Writer = struct {
 
     fn writeSrcNode(self: *Writer, stream: anytype, src_node: ?i32) !void {
         const node_offset = src_node orelse return;
-        const src: LazySrcLoc = .{ .node_offset = node_offset };
+        const src = LazySrcLoc.nodeOffset(node_offset);
         try stream.writeAll(" ");
         return self.writeSrc(stream, src);
     }

--- a/test/cases/recursive_inline_function.1.zig
+++ b/test/cases/recursive_inline_function.1.zig
@@ -14,3 +14,6 @@ inline fn fibonacci(n: usize) usize {
 // error
 //
 // :11:21: error: evaluation exceeded 1000 backwards branches
+// :11:40: note: called from here (6 times)
+// :11:21: note: called from here (495 times)
+// :5:24: note: called from here

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -233,30 +233,6 @@ pub fn addCases(ctx: *TestContext) !void {
             \\}
         , "");
     }
-    // This will make a pretty deep call stack, so this test can only be enabled
-    // on hosts where Zig's linking strategy can honor the 16 MiB (default) we
-    // link the self-hosted compiler with.
-    const host_supports_custom_stack_size = @import("builtin").target.os.tag == .linux;
-    if (host_supports_custom_stack_size) {
-        var case = ctx.exeFromCompiledC("@setEvalBranchQuota", .{});
-
-        // TODO when adding result location support to function calls, revisit this test
-        // case. It can go back to what it was before, with `y` being comptime known.
-        // Because the ret_ptr will passed in with the inline fn call, and there will
-        // only be 1 store to it, and it will be comptime known.
-        case.addCompareOutput(
-            \\pub export fn main() i32 {
-            \\    @setEvalBranchQuota(1001);
-            \\    const y = rec(1001);
-            \\    return y - 1;
-            \\}
-            \\
-            \\inline fn rec(n: i32) i32 {
-            \\    if (n <= 1) return n;
-            \\    return rec(n - 1);
-            \\}
-        , "");
-    }
     {
         var case = ctx.exeFromCompiledC("control flow", .{});
 


### PR DESCRIPTION
The actual fix here is:

```diff
-        try sema.emitBackwardBranch(&child_block, call_src);
+        try sema.emitBackwardBranch(block, call_src);
```

Here is some output from using std.debug.Trace on the LazySrcLoc that helped me track down where the problem was:

```
[nix-shell:~/dev/zig/build-release]$ stage2/bin/zig test test3.zig 
init:
/home/andy/dev/zig/src/Zir.zig:2441:45: 0x31b8ba5 in Zir.struct:2432:18.src (zig)
                return LazySrcLoc.nodeOffset(self.src_node);
                                            ^
/home/andy/dev/zig/src/Sema.zig:5030:35: 0x339fde6 in Sema.zirCall (zig)
    const call_src = inst_data.src();
                                  ^
/home/andy/dev/zig/src/Sema.zig:712:62: 0x322dbe7 in Sema.analyzeBodyInner (zig)
            .call                         => try sema.zirCall(block, inst),
                                                             ^
thread 18654 panic: index out of bounds
/home/andy/dev/zig/src/Module.zig:2115:46: 0x2f76876 in Module.SrcLoc.byteOffset (zig)
                const tok_index = main_tokens[node];
                                             ^
/home/andy/dev/zig/src/Compilation.zig:451:66: 0x2f705f6 in Compilation.AllErrors.add (zig)
        const byte_offset = try module_err_msg.src_loc.byteOffset(module.gpa);
                                                                 ^
/home/andy/dev/zig/src/Compilation.zig:2568:38: 0x2dd1aa3 in Compilation.getAllErrorsAlloc (zig)
                    try AllErrors.add(module, &arena, &errors, entry.value_ptr.*.*);
                                     ^
/home/andy/dev/zig/src/main.zig:3121:44: 0x2d3bf6a in updateModule (zig)
    var errors = try comp.getAllErrorsAlloc();
                                           ^
/home/andy/dev/zig/src/main.zig:2808:17: 0x2d04a59 in buildOutputType (zig)
    updateModule(gpa, comp, hook) catch |err| switch (err) {
                ^
/home/andy/dev/zig/src/main.zig:225:31: 0x2cea926 in mainArgs (zig)
        return buildOutputType(gpa, arena, args, .zig_test);
                              ^
/home/andy/dev/zig/src/main.zig:174:20: 0x2ce9974 in main (zig)
    return mainArgs(gpa, arena, args);
                   ^
/home/andy/dev/zig/lib/std/start.zig:581:37: 0x31d5bf7 in std.start.callMain (zig)
            const result = root.main() catch |err| {
                                    ^
/home/andy/dev/zig/lib/std/start.zig:515:12: 0x2cec3c7 in std.start.callMainWithArgs (zig)
    return @call(.{ .modifier = .always_inline }, callMain, .{});
           ^
/home/andy/dev/zig/lib/std/start.zig:480:12: 0x2cec172 in std.start.main (zig)
    return @call(.{ .modifier = .always_inline }, callMainWithArgs, .{ @intCast(usize, c_argc), c_argv, envp });
           ^
Aborted (core dumped)
```

This pinpointed where the bad LazySrcLoc was created:

```
/home/andy/dev/zig/src/Sema.zig:5030:35: 0x339fde6 in Sema.zirCall (zig)
    const call_src = inst_data.src();
                                  ^
```

So then it was a simple matter of noticing where it got sent into a compile error, which was at the call to `emitBackwardBranch`. This was due to the return type of the function having function bodies in it, so solving the compile error was a matter of making them function pointers instead.