### PR TITLE
stage2: better codegen for byte-aligned packed struct fields

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -18678,8 +18678,6 @@ fn structFieldPtrByIndex(
 
     const target = sema.mod.getTarget();
 
-    // TODO handle when the struct pointer is overaligned, we should return a potentially
-    // over-aligned field pointer too.
     if (struct_obj.layout == .Packed) {
         comptime assert(Type.packed_struct_layout_version == 2);
 
@@ -18699,6 +18697,27 @@ fn structFieldPtrByIndex(
         if (struct_ptr_ty_info.host_size != 0) {
             ptr_ty_data.host_size = struct_ptr_ty_info.host_size;
             ptr_ty_data.bit_offset += struct_ptr_ty_info.bit_offset;
+        }
+
+        const parent_align = if (struct_ptr_ty_info.@"align" != 0)
+            struct_ptr_ty_info.@"align"
+        else
+            struct_ptr_ty_info.pointee_type.abiAlignment(target);
+        ptr_ty_data.@"align" = parent_align;
+
+        // If the field happens to be byte-aligned, simplify the pointer type.
+        // The pointee type bit size must match its ABI byte size so that loads and stores
+        // do not interfere with the surrounding packed bits.
+        if (parent_align != 0 and ptr_ty_data.bit_offset % 8 == 0) {
+            const byte_offset = ptr_ty_data.bit_offset / 8;
+            const elem_size_bytes = ptr_ty_data.pointee_type.abiSize(target);
+            const elem_size_bits = ptr_ty_data.pointee_type.bitSize(target);
+            if (elem_size_bytes * 8 == elem_size_bits) {
+                const new_align = @as(u32, 1) << @intCast(u5, @ctz(u64, byte_offset | parent_align));
+                ptr_ty_data.bit_offset = 0;
+                ptr_ty_data.host_size = 0;
+                ptr_ty_data.@"align" = new_align;
+            }
         }
     } else {
         ptr_ty_data.@"align" = field.abi_align;

--- a/src/type.zig
+++ b/src/type.zig
@@ -5597,17 +5597,18 @@ pub const Type = extern union {
         comptime assert(Type.packed_struct_layout_version == 2);
 
         var bit_offset: u16 = undefined;
+        var elem_size_bits: u16 = undefined;
         var running_bits: u16 = 0;
         for (struct_obj.fields.values()) |f, i| {
             if (!f.ty.hasRuntimeBits()) continue;
 
+            const field_bits = @intCast(u16, f.ty.bitSize(target));
             if (i == field_index) {
                 bit_offset = running_bits;
+                elem_size_bits = field_bits;
             }
-            running_bits += @intCast(u16, f.ty.bitSize(target));
+            running_bits += field_bits;
         }
-        const host_size = (running_bits + 7) / 8;
-        _ = host_size; // TODO big-endian
         const byte_offset = bit_offset / 8;
         return byte_offset;
     }

--- a/src/type.zig
+++ b/src/type.zig
@@ -5591,6 +5591,27 @@ pub const Type = extern union {
         }
     }
 
+    pub fn packedStructFieldByteOffset(ty: Type, field_index: usize, target: Target) u32 {
+        const struct_obj = ty.castTag(.@"struct").?.data;
+        assert(struct_obj.layout == .Packed);
+        comptime assert(Type.packed_struct_layout_version == 2);
+
+        var bit_offset: u16 = undefined;
+        var running_bits: u16 = 0;
+        for (struct_obj.fields.values()) |f, i| {
+            if (!f.ty.hasRuntimeBits()) continue;
+
+            if (i == field_index) {
+                bit_offset = running_bits;
+            }
+            running_bits += @intCast(u16, f.ty.bitSize(target));
+        }
+        const host_size = (running_bits + 7) / 8;
+        _ = host_size; // TODO big-endian
+        const byte_offset = bit_offset / 8;
+        return byte_offset;
+    }
+
     pub const FieldOffset = struct {
         field: usize,
         offset: u64,


### PR DESCRIPTION
* Sema: handle overaligned packed struct field pointers
* LLVM: handle byte-aligned packed struct field pointers

We do not attempt this with big-endian targets yet because of nested
structs and floats. I need to double-check the desired behavior for big endian
targets before adding the necessary complications to this code. This will not
cause miscompilations; it only means the field pointer uses bit masking when it
might not be strictly necessary.

I intended to include the fix to behavior test 1120 in here as well but I ran out of time for today and I wanted to give these two commits a CI run while I sleep.