### PR TITLE
linker: remove `-z noexecstack` option

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -762,7 +762,6 @@ pub const InitOptions = struct {
     linker_z_notext: bool = false,
     linker_z_defs: bool = false,
     linker_z_origin: bool = false,
-    linker_z_noexecstack: bool = false,
     linker_z_now: bool = true,
     linker_z_relro: bool = true,
     linker_z_nocopyreloc: bool = false,
@@ -1602,7 +1601,6 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .z_defs = options.linker_z_defs,
             .z_origin = options.linker_z_origin,
             .z_nocopyreloc = options.linker_z_nocopyreloc,
-            .z_noexecstack = options.linker_z_noexecstack,
             .z_now = options.linker_z_now,
             .z_relro = options.linker_z_relro,
             .tsaware = options.linker_tsaware,
@@ -2350,7 +2348,6 @@ fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifes
     man.hash.add(comp.bin_file.options.z_defs);
     man.hash.add(comp.bin_file.options.z_origin);
     man.hash.add(comp.bin_file.options.z_nocopyreloc);
-    man.hash.add(comp.bin_file.options.z_noexecstack);
     man.hash.add(comp.bin_file.options.z_now);
     man.hash.add(comp.bin_file.options.z_relro);
     man.hash.add(comp.bin_file.options.hash_style);

--- a/src/link.zig
+++ b/src/link.zig
@@ -113,7 +113,6 @@ pub const Options = struct {
     z_defs: bool,
     z_origin: bool,
     z_nocopyreloc: bool,
-    z_noexecstack: bool,
     z_now: bool,
     z_relro: bool,
     tsaware: bool,

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1333,7 +1333,6 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
         man.hash.add(self.base.options.z_defs);
         man.hash.add(self.base.options.z_origin);
         man.hash.add(self.base.options.z_nocopyreloc);
-        man.hash.add(self.base.options.z_noexecstack);
         man.hash.add(self.base.options.z_now);
         man.hash.add(self.base.options.z_relro);
         man.hash.add(self.base.options.hash_style);
@@ -1511,10 +1510,6 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
         if (self.base.options.z_nocopyreloc) {
             try argv.append("-z");
             try argv.append("nocopyreloc");
-        }
-        if (self.base.options.z_noexecstack) {
-            try argv.append("-z");
-            try argv.append("noexecstack");
         }
         if (self.base.options.z_now) {
             // LLD defaults to -zlazy

--- a/src/main.zig
+++ b/src/main.zig
@@ -433,7 +433,6 @@ const usage_build_generic =
     \\    defs                         Force a fatal error if any undefined symbols remain
     \\    origin                       Indicate that the object must have its origin processed
     \\    nocopyreloc                  Disable the creation of copy relocations
-    \\    noexecstack                  Indicate that the object requires an executable stack
     \\    now                          (default) Force all relocations to be processed on load
     \\    lazy                         Don't force all relocations to be processed on load
     \\    relro                        (default) Force all relocations to be read-only after processing
@@ -656,7 +655,6 @@ fn buildOutputType(
     var linker_z_notext = false;
     var linker_z_defs = false;
     var linker_z_origin = false;
-    var linker_z_noexecstack = false;
     var linker_z_now = true;
     var linker_z_relro = true;
     var linker_tsaware = false;
@@ -1207,8 +1205,6 @@ fn buildOutputType(
                             linker_z_defs = true;
                         } else if (mem.eql(u8, z_arg, "origin")) {
                             linker_z_origin = true;
-                        } else if (mem.eql(u8, z_arg, "noexecstack")) {
-                            linker_z_noexecstack = true;
                         } else if (mem.eql(u8, z_arg, "now")) {
                             linker_z_now = true;
                         } else if (mem.eql(u8, z_arg, "lazy")) {
@@ -1694,7 +1690,7 @@ fn buildOutputType(
                     } else if (mem.eql(u8, z_arg, "origin")) {
                         linker_z_origin = true;
                     } else if (mem.eql(u8, z_arg, "noexecstack")) {
-                        linker_z_noexecstack = true;
+                        // noexecstack is the default when linking with LLD
                     } else if (mem.eql(u8, z_arg, "now")) {
                         linker_z_now = true;
                     } else if (mem.eql(u8, z_arg, "lazy")) {
@@ -2719,7 +2715,6 @@ fn buildOutputType(
         .linker_z_notext = linker_z_notext,
         .linker_z_defs = linker_z_defs,
         .linker_z_origin = linker_z_origin,
-        .linker_z_noexecstack = linker_z_noexecstack,
         .linker_z_now = linker_z_now,
         .linker_z_relro = linker_z_relro,
         .linker_tsaware = linker_tsaware,


### PR DESCRIPTION
Note that the current documentation for the `-z noexecstack` is
incorrect. This indicates that an object *does not* require an
executable stack.

This is actually the default of LLD, and there has never been a way to
override this default by passing `-z execstack` to LLD.

This commit removes the redundant `-z noexecstack` option from
zig build-exe/build-lib/build-obj and ignores the option if passed
to zig cc for compatibility.

As far as I can tell, there is no reason for code to require an
executable stack. This option only exists because the stack was
originally executable by default and some programs came to depend
on that behavior. Instead, mprotect(2) may be used to make memory
pages executable.