### PR TITLE
llvm: explicitly annotate alias with linkage

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1114,11 +1114,17 @@ pub const Object = struct {
                 if (self.llvm_module.getNamedGlobalAlias(exp_name_z.ptr, exp_name_z.len)) |alias| {
                     alias.setAliasee(llvm_global);
                 } else {
-                    _ = self.llvm_module.addAlias(
+                    const alias = self.llvm_module.addAlias(
                         llvm_global.typeOf(),
                         llvm_global,
                         exp_name_z,
                     );
+                    switch (exp.options.linkage) {
+                        .Internal => unreachable,
+                        .Strong => alias.setLinkage(.External),
+                        .Weak => alias.setLinkage(.WeakODR),
+                        .LinkOnce => alias.setLinkage(.LinkOnceODR),
+                    }
                 }
             }
         } else {

--- a/src/link.zig
+++ b/src/link.zig
@@ -798,9 +798,8 @@ pub const File = struct {
             } else {
                 try base.flushModule(comp, prog_node);
             }
-            break :blk try fs.path.join(arena, &.{
-                fs.path.dirname(full_out_path_z).?, base.intermediary_basename.?,
-            });
+            const dirname = fs.path.dirname(full_out_path_z) orelse ".";
+            break :blk try fs.path.join(arena, &.{ dirname, base.intermediary_basename.? });
         } else null;
 
         log.debug("module_obj_path={s}", .{if (module_obj_path) |s| s else "(null)"});

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -501,7 +501,8 @@ static LLVMValueRef make_fn_llvm_value(CodeGen *g, ZigFn *fn) {
 
         for (size_t i = 1; i < fn->export_list.length; i += 1) {
             GlobalExport *fn_export = &fn->export_list.items[i];
-            LLVMAddAlias(g->module, LLVMTypeOf(llvm_fn), llvm_fn, buf_ptr(&fn_export->name));
+            LLVMValueRef alias = LLVMAddAlias(g->module, LLVMTypeOf(llvm_fn), llvm_fn, buf_ptr(&fn_export->name));
+            LLVMSetLinkage(alias, to_llvm_linkage(fn_export->linkage, false));
         }
     }
 
@@ -9015,7 +9016,8 @@ static void do_code_gen(CodeGen *g) {
 
         for (size_t export_i = 1; export_i < var->export_list.length; export_i += 1) {
             GlobalExport *global_export = &var->export_list.items[export_i];
-            LLVMAddAlias(g->module, LLVMTypeOf(var->value_ref), var->value_ref, buf_ptr(&global_export->name));
+            LLVMValueRef alias = LLVMAddAlias(g->module, LLVMTypeOf(var->value_ref), var->value_ref, buf_ptr(&global_export->name));
+            LLVMSetLinkage(alias, to_llvm_linkage(global_export->linkage, false));
         }
     }
 

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -28,6 +28,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     }
     cases.addBuildFile("test/standalone/global_linkage/build.zig", .{});
     cases.addBuildFile("test/standalone/static_c_lib/build.zig", .{});
+    cases.addBuildFile("test/standalone/link_weak_reexports/build.zig", .{});
     cases.addBuildFile("test/standalone/link_interdependent_static_c_libs/build.zig", .{});
     cases.addBuildFile("test/standalone/link_static_lib_as_system_lib/build.zig", .{});
     cases.addBuildFile("test/standalone/link_common_symbols/build.zig", .{});

--- a/test/standalone/link_weak_reexports/a.zig
+++ b/test/standalone/link_weak_reexports/a.zig
@@ -1,0 +1,12 @@
+fn internal(x: i64) callconv(.C) i64 {
+    return x * x;
+}
+
+comptime {
+    @export(internal, .{ .name = "__pow", .linkage = .Weak });
+    @export(internal, .{ .name = "powq", .linkage = .Weak });
+}
+
+pub export fn div2(x: i64) i64 {
+    return @divExact(x, 2);
+}

--- a/test/standalone/link_weak_reexports/b.zig
+++ b/test/standalone/link_weak_reexports/b.zig
@@ -1,0 +1,3 @@
+pub export fn powq(x: i64) i64 {
+    return x * x;
+}

--- a/test/standalone/link_weak_reexports/build.zig
+++ b/test/standalone/link_weak_reexports/build.zig
@@ -1,0 +1,19 @@
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    const lib_a = b.addStaticLibrary("a", "a.zig");
+    lib_a.setBuildMode(mode);
+
+    const lib_b = b.addStaticLibrary("b", "b.zig");
+    lib_b.setBuildMode(mode);
+
+    const test_exe = b.addTest("main.zig");
+    test_exe.setBuildMode(mode);
+    test_exe.linkLibrary(lib_b);
+    test_exe.linkLibrary(lib_a);
+
+    const test_step = b.step("test", "Test it");
+    test_step.dependOn(&test_exe.step);
+}

--- a/test/standalone/link_weak_reexports/main.zig
+++ b/test/standalone/link_weak_reexports/main.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+const expect = std.testing.expect;
+
+extern fn powq(i64) i64;
+extern fn div2(i64) i64;
+
+test "call both imports" {
+    try expect(powq(2) == 4);
+    try expect(div2(4) == 2);
+}


### PR DESCRIPTION
Without explicitly applying the correct linkage attribute will
result in LLVM assuming the alias exported as strong/external. This is
particularly troublesome for static archives where we want to re-export
the same symbol under a different name but the same, weak linkage.
This can then cause weird behaviour when ordering of the static
archives with competing definition of the same symbol may lead to
either no error, or symbol collision error, depending on the linking
order.

A short example is provided in `test/standalone/link_weak_reexports`
where if `liba.a` exports `div2` with strong linkage, and exports
`__pow` with weak linkage, but also aliases `__pow` as `powq`, and
if `libb.a` exports `powq` as strong, then the final program that
  requires presence of both symbols `div2` and `powq` will correctly
  link if `liba.a` preceeds `libb.a` on the linker line, and lead to
  error if they are flipped.

Another issue with this is that we will never link the definition
from `libb.a` unless we drop `liba.a` altogether. We actually
have this very problem in Zig when trying to link musl and use
musl's implementation in favour of compiler-rt's. This is currently
not possible as we always order `libcompiler_rt.a` as first on
the linker line, while flipping the order so that `libc.a` comes
before `libcompiler_rt.a` leads to linker errors.