### PR TITLE
Fix (nearly) all stage2 crashes when testing stdlib

### DIFF
--- a/ci/zinc/linux_test.sh
+++ b/ci/zinc/linux_test.sh
@@ -59,6 +59,7 @@ stage2/bin/zig build -Dtarget=arm-linux-musleabihf # test building self-hosted f
 # * https://github.com/ziglang/zig/issues/11367 (and corresponding workaround in compiler source)
 # * https://github.com/ziglang/zig/pull/11492#issuecomment-1112871321
 stage2/bin/zig build test-behavior -fqemu -fwasmtime
+stage2/bin/zig test lib/std/std.zig --zig-lib-dir lib
 
 $ZIG build test-behavior         -fqemu -fwasmtime -Domit-stage2
 $ZIG build test-compiler-rt      -fqemu -fwasmtime

--- a/lib/std/bit_set.zig
+++ b/lib/std/bit_set.zig
@@ -1330,6 +1330,7 @@ fn testStaticBitSet(comptime Set: type) !void {
 }
 
 test "IntegerBitSet" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     try testStaticBitSet(IntegerBitSet(0));
     try testStaticBitSet(IntegerBitSet(1));
     try testStaticBitSet(IntegerBitSet(2));
@@ -1341,6 +1342,7 @@ test "IntegerBitSet" {
 }
 
 test "ArrayBitSet" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     if (@import("builtin").cpu.arch == .aarch64) {
         // https://github.com/ziglang/zig/issues/9879
         return error.SkipZigTest;
@@ -1355,6 +1357,7 @@ test "ArrayBitSet" {
 }
 
 test "DynamicBitSetUnmanaged" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     const allocator = std.testing.allocator;
     var a = try DynamicBitSetUnmanaged.initEmpty(allocator, 300);
     try testing.expectEqual(@as(usize, 0), a.count());
@@ -1395,6 +1398,7 @@ test "DynamicBitSetUnmanaged" {
 }
 
 test "DynamicBitSet" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     const allocator = std.testing.allocator;
     var a = try DynamicBitSet.initEmpty(allocator, 300);
     try testing.expectEqual(@as(usize, 0), a.count());

--- a/lib/std/compress.zig
+++ b/lib/std/compress.zig
@@ -5,7 +5,6 @@ pub const gzip = @import("compress/gzip.zig");
 pub const zlib = @import("compress/zlib.zig");
 
 test {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     _ = deflate;
     _ = gzip;
     _ = zlib;

--- a/lib/std/compress/deflate/compressor.zig
+++ b/lib/std/compress/deflate/compressor.zig
@@ -254,7 +254,10 @@ pub fn Compressor(comptime WriterType: anytype) type {
 
         // Inner writer wrapped in a HuffmanBitWriter
         hm_bw: hm_bw.HuffmanBitWriter(WriterType) = undefined,
-        bulk_hasher: fn ([]u8, []u32) u32,
+        bulk_hasher: if (@import("builtin").zig_backend == .stage1)
+            fn ([]u8, []u32) u32
+        else
+            *const fn ([]u8, []u32) u32,
 
         sync: bool, // requesting flush
         best_speed_enc: *fast.DeflateFast, // Encoder for best_speed

--- a/lib/std/compress/deflate/compressor_test.zig
+++ b/lib/std/compress/deflate/compressor_test.zig
@@ -179,7 +179,6 @@ test "deflate/inflate" {
 }
 
 test "very long sparse chunk" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     // A SparseReader returns a stream consisting of 0s ending with 65,536 (1<<16) 1s.
     // This tests missing hash references in a very large input.
     const SparseReader = struct {
@@ -377,7 +376,6 @@ test "compressor dictionary" {
 // Update the hash for best_speed only if d.index < d.maxInsertIndex
 // See https://golang.org/issue/2508
 test "Go non-regression test for 2508" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     var comp = try compressor(
         testing.allocator,
         io.null_writer,

--- a/lib/std/compress/deflate/compressor_test.zig
+++ b/lib/std/compress/deflate/compressor_test.zig
@@ -122,11 +122,8 @@ fn testToFromWithLevelAndLimit(level: deflate.Compression, input: []const u8, li
         try expect(compressed.items.len <= limit);
     }
 
-    var decomp = try decompressor(
-        testing.allocator,
-        io.fixedBufferStream(compressed.items).reader(),
-        null,
-    );
+    var fib = io.fixedBufferStream(compressed.items);
+    var decomp = try decompressor(testing.allocator, fib.reader(), null);
     defer decomp.deinit();
 
     var decompressed = try testing.allocator.alloc(u8, input.len);
@@ -136,7 +133,9 @@ fn testToFromWithLevelAndLimit(level: deflate.Compression, input: []const u8, li
     try expect(read == input.len);
     try expect(mem.eql(u8, input, decompressed));
 
-    try testSync(level, input);
+    if (builtin.zig_backend == .stage1) {
+        try testSync(level, input);
+    }
 }
 
 fn testToFromWithLimit(input: []const u8, limit: [11]u32) !void {
@@ -180,6 +179,7 @@ test "deflate/inflate" {
 }
 
 test "very long sparse chunk" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     // A SparseReader returns a stream consisting of 0s ending with 65,536 (1<<16) 1s.
     // This tests missing hash references in a very large input.
     const SparseReader = struct {
@@ -377,6 +377,7 @@ test "compressor dictionary" {
 // Update the hash for best_speed only if d.index < d.maxInsertIndex
 // See https://golang.org/issue/2508
 test "Go non-regression test for 2508" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     var comp = try compressor(
         testing.allocator,
         io.null_writer,
@@ -475,21 +476,16 @@ test "inflate reset" {
         try comp.close();
     }
 
-    var decomp = try decompressor(
-        testing.allocator,
-        io.fixedBufferStream(compressed_strings[0].items).reader(),
-        null,
-    );
+    var fib = io.fixedBufferStream(compressed_strings[0].items);
+    var decomp = try decompressor(testing.allocator, fib.reader(), null);
     defer decomp.deinit();
 
     var decompressed_0: []u8 = try decomp.reader()
         .readAllAlloc(testing.allocator, math.maxInt(usize));
     defer testing.allocator.free(decompressed_0);
 
-    try decomp.reset(
-        io.fixedBufferStream(compressed_strings[1].items).reader(),
-        null,
-    );
+    fib = io.fixedBufferStream(compressed_strings[1].items);
+    try decomp.reset(fib.reader(), null);
 
     var decompressed_1: []u8 = try decomp.reader()
         .readAllAlloc(testing.allocator, math.maxInt(usize));
@@ -530,21 +526,16 @@ test "inflate reset dictionary" {
         try comp.close();
     }
 
-    var decomp = try decompressor(
-        testing.allocator,
-        io.fixedBufferStream(compressed_strings[0].items).reader(),
-        dict,
-    );
+    var fib = io.fixedBufferStream(compressed_strings[0].items);
+    var decomp = try decompressor(testing.allocator, fib.reader(), dict);
     defer decomp.deinit();
 
     var decompressed_0: []u8 = try decomp.reader()
         .readAllAlloc(testing.allocator, math.maxInt(usize));
     defer testing.allocator.free(decompressed_0);
 
-    try decomp.reset(
-        io.fixedBufferStream(compressed_strings[1].items).reader(),
-        dict,
-    );
+    fib = io.fixedBufferStream(compressed_strings[1].items);
+    try decomp.reset(fib.reader(), dict);
 
     var decompressed_1: []u8 = try decomp.reader()
         .readAllAlloc(testing.allocator, math.maxInt(usize));

--- a/lib/std/compress/deflate/deflate_fast_test.zig
+++ b/lib/std/compress/deflate/deflate_fast_test.zig
@@ -78,11 +78,8 @@ test "best speed" {
                 var decompressed = try testing.allocator.alloc(u8, want.items.len);
                 defer testing.allocator.free(decompressed);
 
-                var decomp = try inflate.decompressor(
-                    testing.allocator,
-                    io.fixedBufferStream(compressed.items).reader(),
-                    null,
-                );
+                var fib = io.fixedBufferStream(compressed.items);
+                var decomp = try inflate.decompressor(testing.allocator, fib.reader(), null);
                 defer decomp.deinit();
 
                 var read = try decomp.reader().readAll(decompressed);
@@ -122,13 +119,13 @@ test "best speed max match offset" {
                 //	zeros1 is between 0 and 30 zeros.
                 // The difference between the two abc's will be offset, which
                 // is max_match_offset plus or minus a small adjustment.
-                var src_len: usize = @intCast(usize, offset + abc.len + @intCast(i32, extra));
+                var src_len: usize = @intCast(usize, offset + @as(i32, abc.len) + @intCast(i32, extra));
                 var src = try testing.allocator.alloc(u8, src_len);
                 defer testing.allocator.free(src);
 
                 mem.copy(u8, src, abc);
                 if (!do_match_before) {
-                    var src_offset: usize = @intCast(usize, offset - xyz.len);
+                    var src_offset: usize = @intCast(usize, offset - @as(i32, xyz.len));
                     mem.copy(u8, src[src_offset..], xyz);
                 }
                 var src_offset: usize = @intCast(usize, offset);
@@ -149,11 +146,8 @@ test "best speed max match offset" {
                 var decompressed = try testing.allocator.alloc(u8, src.len);
                 defer testing.allocator.free(decompressed);
 
-                var decomp = try inflate.decompressor(
-                    testing.allocator,
-                    io.fixedBufferStream(compressed.items).reader(),
-                    null,
-                );
+                var fib = io.fixedBufferStream(compressed.items);
+                var decomp = try inflate.decompressor(testing.allocator, fib.reader(), null);
                 defer decomp.deinit();
                 var read = try decomp.reader().readAll(decompressed);
                 _ = decomp.close();

--- a/lib/std/crypto/argon2.zig
+++ b/lib/std/crypto/argon2.zig
@@ -897,6 +897,7 @@ test "kdf" {
 }
 
 test "phc format hasher" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     const allocator = std.testing.allocator;
     const password = "testpass";
 
@@ -912,6 +913,7 @@ test "phc format hasher" {
 }
 
 test "password hash and password verify" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     const allocator = std.testing.allocator;
     const password = "testpass";
 

--- a/lib/std/crypto/bcrypt.zig
+++ b/lib/std/crypto/bcrypt.zig
@@ -802,6 +802,7 @@ test "bcrypt crypt format" {
 }
 
 test "bcrypt phc format" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     const hash_options = HashOptions{
         .params = .{ .rounds_log = 5 },
         .encoding = .phc,

--- a/lib/std/crypto/phc_encoding.zig
+++ b/lib/std/crypto/phc_encoding.zig
@@ -260,6 +260,7 @@ fn kvSplit(str: []const u8) !struct { key: []const u8, value: []const u8 } {
 }
 
 test "phc format - encoding/decoding" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     const Input = struct {
         str: []const u8,
         HashResult: type,

--- a/lib/std/crypto/scrypt.zig
+++ b/lib/std/crypto/scrypt.zig
@@ -683,6 +683,7 @@ test "unix-scrypt" {
 }
 
 test "crypt format" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     const str = "$7$C6..../....SodiumChloride$kBGj9fHznVYFQMEn/qDCfrDevf9YDtcDdKvEqHJLV8D";
     const params = try crypt_format.deserialize(crypt_format.HashResult(32), str);
     var buf: [str.len]u8 = undefined;

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2111,7 +2111,6 @@ test "slice" {
 }
 
 test "escape non-printable" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
     try expectFmt("abc", "{s}", .{fmtSliceEscapeLower("abc")});
     try expectFmt("ab\\xffc", "{s}", .{fmtSliceEscapeLower("ab\xffc")});
     try expectFmt("ab\\xFFc", "{s}", .{fmtSliceEscapeUpper("ab\xffc")});
@@ -2148,7 +2147,6 @@ test "cstr" {
 }
 
 test "filesize" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
     try expectFmt("file size: 42B\n", "file size: {}\n", .{fmtIntSizeDec(42)});
     try expectFmt("file size: 42B\n", "file size: {}\n", .{fmtIntSizeBin(42)});
     try expectFmt("file size: 63MB\n", "file size: {}\n", .{fmtIntSizeDec(63 * 1000 * 1000)});
@@ -2448,7 +2446,6 @@ test "struct.zero-size" {
 }
 
 test "bytes.hex" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
     const some_bytes = "\xCA\xFE\xBA\xBE";
     try expectFmt("lowercase: cafebabe\n", "lowercase: {x}\n", .{fmtSliceHexLower(some_bytes)});
     try expectFmt("uppercase: CAFEBABE\n", "uppercase: {X}\n", .{fmtSliceHexUpper(some_bytes)});
@@ -2480,7 +2477,6 @@ pub fn hexToBytes(out: []u8, input: []const u8) ![]u8 {
 }
 
 test "hexToBytes" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
     var buf: [32]u8 = undefined;
     try expectFmt("90" ** 32, "{s}", .{fmtSliceHexUpper(try hexToBytes(&buf, "90" ** 32))});
     try expectFmt("ABCD", "{s}", .{fmtSliceHexUpper(try hexToBytes(&buf, "ABCD"))});

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2225,6 +2225,7 @@ test "float.scientific.precision" {
 }
 
 test "float.special" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     try expectFmt("f64: nan", "f64: {}", .{math.nan_f64});
     // negative nan is not defined by IEE 754,
     // and ARM thus normalizes it to positive nan
@@ -2236,6 +2237,7 @@ test "float.special" {
 }
 
 test "float.hexadecimal.special" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     try expectFmt("f64: nan", "f64: {x}", .{math.nan_f64});
     // negative nan is not defined by IEE 754,
     // and ARM thus normalizes it to positive nan

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2190,18 +2190,22 @@ test "enum" {
 }
 
 test "non-exhaustive enum" {
+    if (builtin.zig_backend == .stage1) {
+        // stage1 fails to return fully qualified namespaces.
+        return error.SkipZigTest;
+    }
     const Enum = enum(u16) {
         One = 0x000f,
         Two = 0xbeef,
         _,
     };
-    try expectFmt("enum: Enum.One\n", "enum: {}\n", .{Enum.One});
-    try expectFmt("enum: Enum.Two\n", "enum: {}\n", .{Enum.Two});
-    try expectFmt("enum: Enum(4660)\n", "enum: {}\n", .{@intToEnum(Enum, 0x1234)});
-    try expectFmt("enum: Enum.One\n", "enum: {x}\n", .{Enum.One});
-    try expectFmt("enum: Enum.Two\n", "enum: {x}\n", .{Enum.Two});
-    try expectFmt("enum: Enum.Two\n", "enum: {X}\n", .{Enum.Two});
-    try expectFmt("enum: Enum(1234)\n", "enum: {x}\n", .{@intToEnum(Enum, 0x1234)});
+    try expectFmt("enum: fmt.test.non-exhaustive enum.Enum.One\n", "enum: {}\n", .{Enum.One});
+    try expectFmt("enum: fmt.test.non-exhaustive enum.Enum.Two\n", "enum: {}\n", .{Enum.Two});
+    try expectFmt("enum: fmt.test.non-exhaustive enum.Enum(4660)\n", "enum: {}\n", .{@intToEnum(Enum, 0x1234)});
+    try expectFmt("enum: fmt.test.non-exhaustive enum.Enum.One\n", "enum: {x}\n", .{Enum.One});
+    try expectFmt("enum: fmt.test.non-exhaustive enum.Enum.Two\n", "enum: {x}\n", .{Enum.Two});
+    try expectFmt("enum: fmt.test.non-exhaustive enum.Enum.Two\n", "enum: {X}\n", .{Enum.Two});
+    try expectFmt("enum: fmt.test.non-exhaustive enum.Enum(1234)\n", "enum: {x}\n", .{@intToEnum(Enum, 0x1234)});
 }
 
 test "float.scientific" {
@@ -2357,6 +2361,10 @@ test "custom" {
 }
 
 test "struct" {
+    if (builtin.zig_backend == .stage1) {
+        // stage1 fails to return fully qualified namespaces.
+        return error.SkipZigTest;
+    }
     const S = struct {
         a: u32,
         b: anyerror,
@@ -2367,7 +2375,7 @@ test "struct" {
         .b = error.Unused,
     };
 
-    try expectFmt("S{ .a = 456, .b = error.Unused }", "{}", .{inst});
+    try expectFmt("fmt.test.struct.S{ .a = 456, .b = error.Unused }", "{}", .{inst});
     // Tuples
     try expectFmt("{ }", "{}", .{.{}});
     try expectFmt("{ -1 }", "{}", .{.{-1}});
@@ -2375,6 +2383,10 @@ test "struct" {
 }
 
 test "union" {
+    if (builtin.zig_backend == .stage1) {
+        // stage1 fails to return fully qualified namespaces.
+        return error.SkipZigTest;
+    }
     const TU = union(enum) {
         float: f32,
         int: u32,
@@ -2394,17 +2406,21 @@ test "union" {
     const uu_inst = UU{ .int = 456 };
     const eu_inst = EU{ .float = 321.123 };
 
-    try expectFmt("TU{ .int = 123 }", "{}", .{tu_inst});
+    try expectFmt("fmt.test.union.TU{ .int = 123 }", "{}", .{tu_inst});
 
     var buf: [100]u8 = undefined;
     const uu_result = try bufPrint(buf[0..], "{}", .{uu_inst});
-    try std.testing.expect(mem.eql(u8, uu_result[0..3], "UU@"));
+    try std.testing.expect(mem.eql(u8, uu_result[0..18], "fmt.test.union.UU@"));
 
     const eu_result = try bufPrint(buf[0..], "{}", .{eu_inst});
-    try std.testing.expect(mem.eql(u8, eu_result[0..3], "EU@"));
+    try std.testing.expect(mem.eql(u8, eu_result[0..18], "fmt.test.union.EU@"));
 }
 
 test "enum" {
+    if (builtin.zig_backend == .stage1) {
+        // stage1 fails to return fully qualified namespaces.
+        return error.SkipZigTest;
+    }
     const E = enum {
         One,
         Two,
@@ -2413,10 +2429,14 @@ test "enum" {
 
     const inst = E.Two;
 
-    try expectFmt("E.Two", "{}", .{inst});
+    try expectFmt("fmt.test.enum.E.Two", "{}", .{inst});
 }
 
 test "struct.self-referential" {
+    if (builtin.zig_backend == .stage1) {
+        // stage1 fails to return fully qualified namespaces.
+        return error.SkipZigTest;
+    }
     const S = struct {
         const SelfType = @This();
         a: ?*SelfType,
@@ -2427,10 +2447,14 @@ test "struct.self-referential" {
     };
     inst.a = &inst;
 
-    try expectFmt("S{ .a = S{ .a = S{ .a = S{ ... } } } }", "{}", .{inst});
+    try expectFmt("fmt.test.struct.self-referential.S{ .a = fmt.test.struct.self-referential.S{ .a = fmt.test.struct.self-referential.S{ .a = fmt.test.struct.self-referential.S{ ... } } } }", "{}", .{inst});
 }
 
 test "struct.zero-size" {
+    if (builtin.zig_backend == .stage1) {
+        // stage1 fails to return fully qualified namespaces.
+        return error.SkipZigTest;
+    }
     const A = struct {
         fn foo() void {}
     };
@@ -2442,7 +2466,7 @@ test "struct.zero-size" {
     const a = A{};
     const b = B{ .a = a, .c = 0 };
 
-    try expectFmt("B{ .a = A{ }, .c = 0 }", "{}", .{b});
+    try expectFmt("fmt.test.struct.zero-size.B{ .a = fmt.test.struct.zero-size.A{ }, .c = 0 }", "{}", .{b});
 }
 
 test "bytes.hex" {
@@ -2508,6 +2532,10 @@ test "formatFloatValue with comptime_float" {
 }
 
 test "formatType max_depth" {
+    if (builtin.zig_backend == .stage1) {
+        // stage1 fails to return fully qualified namespaces.
+        return error.SkipZigTest;
+    }
     const Vec2 = struct {
         const SelfType = @This();
         x: f32,
@@ -2558,19 +2586,19 @@ test "formatType max_depth" {
     var buf: [1000]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     try formatType(inst, "", FormatOptions{}, fbs.writer(), 0);
-    try std.testing.expect(mem.eql(u8, fbs.getWritten(), "S{ ... }"));
+    try std.testing.expect(mem.eql(u8, fbs.getWritten(), "fmt.test.formatType max_depth.S{ ... }"));
 
     fbs.reset();
     try formatType(inst, "", FormatOptions{}, fbs.writer(), 1);
-    try std.testing.expect(mem.eql(u8, fbs.getWritten(), "S{ .a = S{ ... }, .tu = TU{ ... }, .e = E.Two, .vec = (10.200,2.220) }"));
+    try std.testing.expect(mem.eql(u8, fbs.getWritten(), "fmt.test.formatType max_depth.S{ .a = fmt.test.formatType max_depth.S{ ... }, .tu = fmt.test.formatType max_depth.TU{ ... }, .e = fmt.test.formatType max_depth.E.Two, .vec = (10.200,2.220) }"));
 
     fbs.reset();
     try formatType(inst, "", FormatOptions{}, fbs.writer(), 2);
-    try std.testing.expect(mem.eql(u8, fbs.getWritten(), "S{ .a = S{ .a = S{ ... }, .tu = TU{ ... }, .e = E.Two, .vec = (10.200,2.220) }, .tu = TU{ .ptr = TU{ ... } }, .e = E.Two, .vec = (10.200,2.220) }"));
+    try std.testing.expect(mem.eql(u8, fbs.getWritten(), "fmt.test.formatType max_depth.S{ .a = fmt.test.formatType max_depth.S{ .a = fmt.test.formatType max_depth.S{ ... }, .tu = fmt.test.formatType max_depth.TU{ ... }, .e = fmt.test.formatType max_depth.E.Two, .vec = (10.200,2.220) }, .tu = fmt.test.formatType max_depth.TU{ .ptr = fmt.test.formatType max_depth.TU{ ... } }, .e = fmt.test.formatType max_depth.E.Two, .vec = (10.200,2.220) }"));
 
     fbs.reset();
     try formatType(inst, "", FormatOptions{}, fbs.writer(), 3);
-    try std.testing.expect(mem.eql(u8, fbs.getWritten(), "S{ .a = S{ .a = S{ .a = S{ ... }, .tu = TU{ ... }, .e = E.Two, .vec = (10.200,2.220) }, .tu = TU{ .ptr = TU{ ... } }, .e = E.Two, .vec = (10.200,2.220) }, .tu = TU{ .ptr = TU{ .ptr = TU{ ... } } }, .e = E.Two, .vec = (10.200,2.220) }"));
+    try std.testing.expect(mem.eql(u8, fbs.getWritten(), "fmt.test.formatType max_depth.S{ .a = fmt.test.formatType max_depth.S{ .a = fmt.test.formatType max_depth.S{ .a = fmt.test.formatType max_depth.S{ ... }, .tu = fmt.test.formatType max_depth.TU{ ... }, .e = fmt.test.formatType max_depth.E.Two, .vec = (10.200,2.220) }, .tu = fmt.test.formatType max_depth.TU{ .ptr = fmt.test.formatType max_depth.TU{ ... } }, .e = fmt.test.formatType max_depth.E.Two, .vec = (10.200,2.220) }, .tu = fmt.test.formatType max_depth.TU{ .ptr = fmt.test.formatType max_depth.TU{ .ptr = fmt.test.formatType max_depth.TU{ ... } } }, .e = fmt.test.formatType max_depth.E.Two, .vec = (10.200,2.220) }"));
 }
 
 test "positional" {

--- a/lib/std/io/stream_source.zig
+++ b/lib/std/io/stream_source.zig
@@ -114,7 +114,6 @@ test "StreamSource (mutable buffer)" {
 }
 
 test "StreamSource (const buffer)" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     const buffer: [64]u8 = "Hello, World!".* ++ ([1]u8{0xAA} ** 51);
     var source = StreamSource{ .const_buffer = std.io.fixedBufferStream(&buffer) };
 

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1355,7 +1355,6 @@ pub const Value = union(enum) {
 };
 
 test "Value.jsonStringify" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     {
         var buffer: [10]u8 = undefined;
         var fbs = std.io.fixedBufferStream(&buffer);

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1355,6 +1355,7 @@ pub const Value = union(enum) {
 };
 
 test "Value.jsonStringify" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     {
         var buffer: [10]u8 = undefined;
         var fbs = std.io.fixedBufferStream(&buffer);

--- a/lib/std/math/copysign.zig
+++ b/lib/std/math/copysign.zig
@@ -13,6 +13,7 @@ pub fn copysign(magnitude: anytype, sign: @TypeOf(magnitude)) @TypeOf(magnitude)
 }
 
 test "math.copysign" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         try expect(copysign(@as(T, 1.0), @as(T, 1.0)) == 1.0);
         try expect(copysign(@as(T, 2.0), @as(T, -2.0)) == -2.0);

--- a/lib/std/math/signbit.zig
+++ b/lib/std/math/signbit.zig
@@ -10,6 +10,7 @@ pub fn signbit(x: anytype) bool {
 }
 
 test "math.signbit" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         try expect(!signbit(@as(T, 0.0)));
         try expect(!signbit(@as(T, 1.0)));

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2080,6 +2080,7 @@ fn testReadIntImpl() !void {
 }
 
 test "writeIntSlice" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     try testWriteIntImpl();
     comptime try testWriteIntImpl();
 }

--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -2154,7 +2154,6 @@ test "timeout (after a number of completions)" {
 }
 
 test "timeout_remove" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     if (builtin.os.tag != .linux) return error.SkipZigTest;
 
     var ring = IO_Uring.init(2, 0) catch |err| switch (err) {
@@ -2951,7 +2950,6 @@ test "provide_buffers: read" {
 }
 
 test "remove_buffers" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     if (builtin.os.tag != .linux) return error.SkipZigTest;
 
     var ring = IO_Uring.init(1, 0) catch |err| switch (err) {

--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -2154,6 +2154,7 @@ test "timeout (after a number of completions)" {
 }
 
 test "timeout_remove" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     if (builtin.os.tag != .linux) return error.SkipZigTest;
 
     var ring = IO_Uring.init(2, 0) catch |err| switch (err) {
@@ -2950,6 +2951,7 @@ test "provide_buffers: read" {
 }
 
 test "remove_buffers" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     if (builtin.os.tag != .linux) return error.SkipZigTest;
 
     var ring = IO_Uring.init(1, 0) catch |err| switch (err) {

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -286,6 +286,7 @@ const PQlt = PriorityQueue(u32, void, lessThan);
 const PQgt = PriorityQueue(u32, void, greaterThan);
 
 test "std.PriorityQueue: add and remove min heap" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQlt.init(testing.allocator, {});
     defer queue.deinit();
 
@@ -304,6 +305,7 @@ test "std.PriorityQueue: add and remove min heap" {
 }
 
 test "std.PriorityQueue: add and remove same min heap" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQlt.init(testing.allocator, {});
     defer queue.deinit();
 
@@ -353,6 +355,7 @@ test "std.PriorityQueue: peek" {
 }
 
 test "std.PriorityQueue: sift up with odd indices" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQlt.init(testing.allocator, {});
     defer queue.deinit();
     const items = [_]u32{ 15, 7, 21, 14, 13, 22, 12, 6, 7, 25, 5, 24, 11, 16, 15, 24, 2, 1 };
@@ -367,6 +370,7 @@ test "std.PriorityQueue: sift up with odd indices" {
 }
 
 test "std.PriorityQueue: addSlice" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQlt.init(testing.allocator, {});
     defer queue.deinit();
     const items = [_]u32{ 15, 7, 21, 14, 13, 22, 12, 6, 7, 25, 5, 24, 11, 16, 15, 24, 2, 1 };
@@ -412,6 +416,7 @@ test "std.PriorityQueue: fromOwnedSlice" {
 }
 
 test "std.PriorityQueue: add and remove max heap" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQgt.init(testing.allocator, {});
     defer queue.deinit();
 
@@ -430,6 +435,7 @@ test "std.PriorityQueue: add and remove max heap" {
 }
 
 test "std.PriorityQueue: add and remove same max heap" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQgt.init(testing.allocator, {});
     defer queue.deinit();
 
@@ -470,6 +476,7 @@ test "std.PriorityQueue: iterator" {
 }
 
 test "std.PriorityQueue: remove at index" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQlt.init(testing.allocator, {});
     defer queue.deinit();
 
@@ -505,6 +512,7 @@ test "std.PriorityQueue: iterator while empty" {
 }
 
 test "std.PriorityQueue: shrinkAndFree" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQlt.init(testing.allocator, {});
     defer queue.deinit();
 
@@ -528,6 +536,7 @@ test "std.PriorityQueue: shrinkAndFree" {
 }
 
 test "std.PriorityQueue: update min heap" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQlt.init(testing.allocator, {});
     defer queue.deinit();
 
@@ -543,6 +552,7 @@ test "std.PriorityQueue: update min heap" {
 }
 
 test "std.PriorityQueue: update same min heap" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQlt.init(testing.allocator, {});
     defer queue.deinit();
 
@@ -559,6 +569,7 @@ test "std.PriorityQueue: update same min heap" {
 }
 
 test "std.PriorityQueue: update max heap" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQgt.init(testing.allocator, {});
     defer queue.deinit();
 
@@ -574,6 +585,7 @@ test "std.PriorityQueue: update max heap" {
 }
 
 test "std.PriorityQueue: update same max heap" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQgt.init(testing.allocator, {});
     defer queue.deinit();
 
@@ -590,6 +602,7 @@ test "std.PriorityQueue: update same max heap" {
 }
 
 test "std.PriorityQueue: siftUp in remove" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     var queue = PQlt.init(testing.allocator, {});
     defer queue.deinit();
 
@@ -610,6 +623,7 @@ fn contextLessThan(context: []const u32, a: usize, b: usize) Order {
 const CPQlt = PriorityQueue(usize, []const u32, contextLessThan);
 
 test "std.PriorityQueue: add and remove min heap with contextful comparator" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     const context = [_]u32{ 5, 3, 4, 2, 2, 8, 0 };
 
     var queue = CPQlt.init(testing.allocator, context[0..]);

--- a/lib/std/tz.zig
+++ b/lib/std/tz.zig
@@ -214,6 +214,7 @@ pub const Tz = struct {
 };
 
 test "slim" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     const data = @embedFile("tz/asia_tokyo.tzif");
     var in_stream = std.io.fixedBufferStream(data);
 
@@ -227,6 +228,7 @@ test "slim" {
 }
 
 test "fat" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     const data = @embedFile("tz/antarctica_davis.tzif");
     var in_stream = std.io.fixedBufferStream(data);
 
@@ -239,6 +241,7 @@ test "fat" {
 }
 
 test "legacy" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest; // TODO
     // Taken from Slackware 8.0, from 2001
     const data = @embedFile("tz/europe_vatican.tzif");
     var in_stream = std.io.fixedBufferStream(data);

--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -804,7 +804,6 @@ pub fn fmtUtf16le(utf16le: []const u16) std.fmt.Formatter(formatUtf16le) {
 }
 
 test "fmtUtf16le" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     const expectFmt = std.testing.expectFmt;
     try expectFmt("", "{}", .{fmtUtf16le(utf8ToUtf16LeStringLiteral(""))});
     try expectFmt("foo", "{}", .{fmtUtf16le(utf8ToUtf16LeStringLiteral("foo"))});

--- a/lib/std/x.zig
+++ b/lib/std/x.zig
@@ -13,7 +13,6 @@ pub const net = struct {
 };
 
 test {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     inline for (.{ os, net }) |module| {
         std.testing.refAllDecls(module);
     }

--- a/lib/std/x/os/io.zig
+++ b/lib/std/x/os/io.zig
@@ -117,6 +117,7 @@ pub const Reactor = struct {
 };
 
 test "reactor/linux: drive async tcp client/listener pair" {
+    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     if (native_os.tag != .linux) return error.SkipZigTest;
 
     const ip = std.x.net.ip;

--- a/lib/std/x/os/net.zig
+++ b/lib/std/x/os/net.zig
@@ -381,7 +381,7 @@ pub const IPv6 = extern struct {
             });
         }
 
-        const zero_span = span: {
+        const zero_span: struct { from: usize, to: usize } = span: {
             var i: usize = 0;
             while (i < self.octets.len) : (i += 2) {
                 if (self.octets[i] == 0 and self.octets[i + 1] == 0) break;

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -2753,7 +2753,10 @@ fn varDecl(
                 const result_loc: ResultLoc = if (type_node != 0) .{
                     .ty = try typeExpr(gz, scope, type_node),
                 } else .none;
+                const prev_anon_name_strategy = gz.anon_name_strategy;
+                gz.anon_name_strategy = .dbg_var;
                 const init_inst = try reachableExpr(gz, scope, result_loc, var_decl.ast.init_node, node);
+                gz.anon_name_strategy = prev_anon_name_strategy;
 
                 try gz.addDbgVar(.dbg_var_val, ident_name, init_inst);
 
@@ -2777,6 +2780,7 @@ fn varDecl(
             var init_scope = gz.makeSubBlock(scope);
             // we may add more instructions to gz before stacking init_scope
             init_scope.instructions_top = GenZir.unstacked_top;
+            init_scope.anon_name_strategy = .dbg_var;
             defer init_scope.unstack();
 
             var resolve_inferred_alloc: Zir.Inst.Ref = .none;
@@ -2956,7 +2960,10 @@ fn varDecl(
                 resolve_inferred_alloc = alloc;
                 break :a .{ .alloc = alloc, .result_loc = .{ .inferred_ptr = alloc } };
             };
+            const prev_anon_name_strategy = gz.anon_name_strategy;
+            gz.anon_name_strategy = .dbg_var;
             _ = try reachableExprComptime(gz, scope, var_data.result_loc, var_decl.ast.init_node, node, is_comptime);
+            gz.anon_name_strategy = prev_anon_name_strategy;
             if (resolve_inferred_alloc != .none) {
                 _ = try gz.addUnNode(.resolve_inferred_alloc, resolve_inferred_alloc, node);
             }

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3790,9 +3790,12 @@ pub fn ensureFuncBodyAnalyzed(mod: *Module, func: *Fn) SemaError!void {
             defer liveness.deinit(gpa);
 
             if (builtin.mode == .Debug and mod.comp.verbose_air) {
-                std.debug.print("# Begin Function AIR: {s}:\n", .{decl.name});
+                const fqn = try decl.getFullyQualifiedName(mod);
+                defer mod.gpa.free(fqn);
+
+                std.debug.print("# Begin Function AIR: {s}:\n", .{fqn});
                 @import("print_air.zig").dump(mod, air, liveness);
-                std.debug.print("# End Function AIR: {s}\n\n", .{decl.name});
+                std.debug.print("# End Function AIR: {s}\n\n", .{fqn});
             }
 
             mod.comp.bin_file.updateFunc(mod, func, air, liveness) catch |err| switch (err) {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -19702,7 +19702,8 @@ fn coerce(
                     // pointer to tuple to slice
                     if (inst_ty.isSinglePointer() and
                         inst_ty.childType().isTuple() and
-                        !dest_info.mutable and dest_info.size == .Slice)
+                        (!dest_info.mutable or inst_ty.ptrIsMutable() or inst_ty.childType().tupleFields().types.len == 0) and
+                        dest_info.size == .Slice)
                     {
                         return sema.coerceTupleToSlicePtrs(block, dest_ty, dest_ty_src, inst, inst_src);
                     }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4967,6 +4967,8 @@ fn lookupInNamespace(
             var it = check_ns.usingnamespace_set.iterator();
             while (it.next()) |entry| {
                 const sub_usingnamespace_decl_index = entry.key_ptr.*;
+                // Skip the decl we're currently analysing.
+                if (sub_usingnamespace_decl_index == sema.owner_decl_index) continue;
                 const sub_usingnamespace_decl = mod.declPtr(sub_usingnamespace_decl_index);
                 const sub_is_pub = entry.value_ptr.*;
                 if (!sub_is_pub and src_file != sub_usingnamespace_decl.getFileScope()) {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -23328,7 +23328,17 @@ pub fn resolveTypeFully(
             const child_ty = try sema.resolveTypeFields(block, src, ty.childType());
             return resolveTypeFully(sema, block, src, child_ty);
         },
-        .Struct => return resolveStructFully(sema, block, src, ty),
+        .Struct => switch (ty.tag()) {
+            .@"struct" => return resolveStructFully(sema, block, src, ty),
+            .tuple, .anon_struct => {
+                const tuple = ty.tupleFields();
+
+                for (tuple.types) |field_ty| {
+                    try sema.resolveTypeFully(block, src, field_ty);
+                }
+            },
+            else => {},
+        },
         .Union => return resolveUnionFully(sema, block, src, ty),
         .Array => return resolveTypeFully(sema, block, src, ty.childType()),
         .Optional => {
@@ -23363,7 +23373,7 @@ fn resolveStructFully(
     try resolveStructLayout(sema, block, src, ty);
 
     const resolved_ty = try sema.resolveTypeFields(block, src, ty);
-    const payload = resolved_ty.castTag(.@"struct") orelse return;
+    const payload = resolved_ty.castTag(.@"struct").?;
     const struct_obj = payload.data;
 
     switch (struct_obj.status) {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -13757,10 +13757,10 @@ fn zirStructInit(
         const field_type_extra = sema.code.extraData(Zir.Inst.FieldType, field_type_data.payload_index).data;
         const field_name = sema.code.nullTerminatedString(field_type_extra.name_start);
         const field_index = try sema.unionFieldIndex(block, resolved_ty, field_name, field_src);
+        const tag_val = try Value.Tag.enum_field_index.create(sema.arena, field_index);
 
         const init_inst = try sema.resolveInst(item.data.init);
         if (try sema.resolveMaybeUndefVal(block, field_src, init_inst)) |val| {
-            const tag_val = try Value.Tag.enum_field_index.create(sema.arena, field_index);
             return sema.addConstantMaybeRef(
                 block,
                 src,
@@ -13779,6 +13779,8 @@ fn zirStructInit(
             const alloc = try block.addTy(.alloc, alloc_ty);
             const field_ptr = try sema.unionFieldPtr(block, field_src, alloc, field_name, field_src, resolved_ty);
             try sema.storePtr(block, src, field_ptr, init_inst);
+            const new_tag = try sema.addConstant(resolved_ty.unionTagTypeHypothetical(), tag_val);
+            _ = try block.addBinOp(.set_union_tag, alloc, new_tag);
             return alloc;
         }
 

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -3156,6 +3156,8 @@ pub const Inst = struct {
         /// Create an anonymous name for this declaration.
         /// Like this: "ParentDeclName_struct_69"
         anon,
+        /// Use the name specified in the next `dbg_var_{val,ptr}` instruction.
+        dbg_var,
     };
 
     /// Trailing:

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -2277,7 +2277,7 @@ fn airOptionalPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
 fn errUnionErr(self: *Self, error_union_mcv: MCValue, error_union_ty: Type) !MCValue {
     const err_ty = error_union_ty.errorUnionSet();
     const payload_ty = error_union_ty.errorUnionPayload();
-    if (err_ty.errorSetCardinality() == .zero) {
+    if (err_ty.errorSetIsEmpty()) {
         return MCValue{ .immediate = 0 };
     }
     if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
@@ -2311,7 +2311,7 @@ fn airUnwrapErrErr(self: *Self, inst: Air.Inst.Index) !void {
 fn errUnionPayload(self: *Self, error_union_mcv: MCValue, error_union_ty: Type) !MCValue {
     const err_ty = error_union_ty.errorUnionSet();
     const payload_ty = error_union_ty.errorUnionPayload();
-    if (err_ty.errorSetCardinality() == .zero) {
+    if (err_ty.errorSetIsEmpty()) {
         return error_union_mcv;
     }
     if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
@@ -3590,7 +3590,7 @@ fn isErr(self: *Self, ty: Type, operand: MCValue) !MCValue {
     const error_type = ty.errorUnionSet();
     const payload_type = ty.errorUnionPayload();
 
-    if (error_type.errorSetCardinality() == .zero) {
+    if (error_type.errorSetIsEmpty()) {
         return MCValue{ .immediate = 0 }; // always false
     }
 
@@ -4686,11 +4686,6 @@ fn genTypedValue(self: *Self, typed_value: TypedValue) InnerError!MCValue {
         .ErrorUnion => {
             const error_type = typed_value.ty.errorUnionSet();
             const payload_type = typed_value.ty.errorUnionPayload();
-
-            if (error_type.errorSetCardinality() == .zero) {
-                const payload_val = typed_value.val.castTag(.eu_payload).?.data;
-                return self.genTypedValue(.{ .ty = payload_type, .val = payload_val });
-            }
 
             const is_pl = typed_value.val.errorUnionIsPayload();
 

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -1773,7 +1773,7 @@ fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {
 fn errUnionErr(self: *Self, error_union_mcv: MCValue, error_union_ty: Type) !MCValue {
     const err_ty = error_union_ty.errorUnionSet();
     const payload_ty = error_union_ty.errorUnionPayload();
-    if (err_ty.errorSetCardinality() == .zero) {
+    if (err_ty.errorSetIsEmpty()) {
         return MCValue{ .immediate = 0 };
     }
     if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
@@ -1810,7 +1810,7 @@ fn airUnwrapErrErr(self: *Self, inst: Air.Inst.Index) !void {
 fn errUnionPayload(self: *Self, error_union_mcv: MCValue, error_union_ty: Type) !MCValue {
     const err_ty = error_union_ty.errorUnionSet();
     const payload_ty = error_union_ty.errorUnionPayload();
-    if (err_ty.errorSetCardinality() == .zero) {
+    if (err_ty.errorSetIsEmpty()) {
         return error_union_mcv;
     }
     if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
@@ -3922,7 +3922,7 @@ fn isErr(self: *Self, ty: Type, operand: MCValue) !MCValue {
     const error_type = ty.errorUnionSet();
     const error_int_type = Type.initTag(.u16);
 
-    if (error_type.errorSetCardinality() == .zero) {
+    if (error_type.errorSetIsEmpty()) {
         return MCValue{ .immediate = 0 }; // always false
     }
 
@@ -5368,12 +5368,6 @@ fn genTypedValue(self: *Self, typed_value: TypedValue) InnerError!MCValue {
         .ErrorUnion => {
             const error_type = typed_value.ty.errorUnionSet();
             const payload_type = typed_value.ty.errorUnionPayload();
-
-            if (error_type.errorSetCardinality() == .zero) {
-                const payload_val = typed_value.val.castTag(.eu_payload).?.data;
-                return self.genTypedValue(.{ .ty = payload_type, .val = payload_val });
-            }
-
             const is_pl = typed_value.val.errorUnionIsPayload();
 
             if (!payload_type.hasRuntimeBitsIgnoreComptime()) {

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1377,11 +1377,7 @@ fn isByRef(ty: Type, target: std.Target) bool {
         .Int => return ty.intInfo(target).bits > 64,
         .Float => return ty.floatBits(target) > 64,
         .ErrorUnion => {
-            const err_ty = ty.errorUnionSet();
             const pl_ty = ty.errorUnionPayload();
-            if (err_ty.errorSetCardinality() == .zero) {
-                return isByRef(pl_ty, target);
-            }
             if (!pl_ty.hasRuntimeBitsIgnoreComptime()) {
                 return false;
             }
@@ -1816,11 +1812,7 @@ fn airStore(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
 fn store(self: *Self, lhs: WValue, rhs: WValue, ty: Type, offset: u32) InnerError!void {
     switch (ty.zigTypeTag()) {
         .ErrorUnion => {
-            const err_ty = ty.errorUnionSet();
             const pl_ty = ty.errorUnionPayload();
-            if (err_ty.errorSetCardinality() == .zero) {
-                return self.store(lhs, rhs, pl_ty, 0);
-            }
             if (!pl_ty.hasRuntimeBitsIgnoreComptime()) {
                 return self.store(lhs, rhs, Type.anyerror, 0);
             }
@@ -2353,10 +2345,6 @@ fn lowerConstant(self: *Self, val: Value, ty: Type) InnerError!WValue {
         },
         .ErrorUnion => {
             const error_type = ty.errorUnionSet();
-            if (error_type.errorSetCardinality() == .zero) {
-                const pl_val = if (val.castTag(.eu_payload)) |pl| pl.data else Value.initTag(.undef);
-                return self.lowerConstant(pl_val, ty.errorUnionPayload());
-            }
             const is_pl = val.errorUnionIsPayload();
             const err_val = if (!is_pl) val else Value.initTag(.zero);
             return self.lowerConstant(err_val, error_type);
@@ -2925,7 +2913,7 @@ fn airIsErr(self: *Self, inst: Air.Inst.Index, opcode: wasm.Opcode) InnerError!W
     const err_union_ty = self.air.typeOf(un_op);
     const pl_ty = err_union_ty.errorUnionPayload();
 
-    if (err_union_ty.errorUnionSet().errorSetCardinality() == .zero) {
+    if (err_union_ty.errorUnionSet().errorSetIsEmpty()) {
         switch (opcode) {
             .i32_ne => return WValue{ .imm32 = 0 },
             .i32_eq => return WValue{ .imm32 = 1 },
@@ -2958,10 +2946,6 @@ fn airUnwrapErrUnionPayload(self: *Self, inst: Air.Inst.Index, op_is_ptr: bool) 
     const err_ty = if (op_is_ptr) op_ty.childType() else op_ty;
     const payload_ty = err_ty.errorUnionPayload();
 
-    if (err_ty.errorUnionSet().errorSetCardinality() == .zero) {
-        return operand;
-    }
-
     if (!payload_ty.hasRuntimeBitsIgnoreComptime()) return WValue{ .none = {} };
 
     const pl_offset = @intCast(u32, errUnionPayloadOffset(payload_ty, self.target));
@@ -2980,7 +2964,7 @@ fn airUnwrapErrUnionError(self: *Self, inst: Air.Inst.Index, op_is_ptr: bool) In
     const err_ty = if (op_is_ptr) op_ty.childType() else op_ty;
     const payload_ty = err_ty.errorUnionPayload();
 
-    if (err_ty.errorUnionSet().errorSetCardinality() == .zero) {
+    if (err_ty.errorUnionSet().errorSetIsEmpty()) {
         return WValue{ .imm32 = 0 };
     }
 
@@ -2997,10 +2981,6 @@ fn airWrapErrUnionPayload(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
     const ty_op = self.air.instructions.items(.data)[inst].ty_op;
     const operand = try self.resolveInst(ty_op.operand);
     const err_ty = self.air.typeOfIndex(inst);
-
-    if (err_ty.errorUnionSet().errorSetCardinality() == .zero) {
-        return operand;
-    }
 
     const pl_ty = self.air.typeOf(ty_op.operand);
     if (!pl_ty.hasRuntimeBitsIgnoreComptime()) {
@@ -4656,29 +4636,27 @@ fn lowerTry(
         return self.fail("TODO: lowerTry for pointers", .{});
     }
 
-    if (err_union_ty.errorUnionSet().errorSetCardinality() == .zero) {
-        return err_union;
-    }
-
     const pl_ty = err_union_ty.errorUnionPayload();
     const pl_has_bits = pl_ty.hasRuntimeBitsIgnoreComptime();
 
-    // Block we can jump out of when error is not set
-    try self.startBlock(.block, wasm.block_empty);
+    if (!err_union_ty.errorUnionSet().errorSetIsEmpty()) {
+        // Block we can jump out of when error is not set
+        try self.startBlock(.block, wasm.block_empty);
 
-    // check if the error tag is set for the error union.
-    try self.emitWValue(err_union);
-    if (pl_has_bits) {
-        const err_offset = @intCast(u32, errUnionErrorOffset(pl_ty, self.target));
-        try self.addMemArg(.i32_load16_u, .{
-            .offset = err_union.offset() + err_offset,
-            .alignment = Type.anyerror.abiAlignment(self.target),
-        });
+        // check if the error tag is set for the error union.
+        try self.emitWValue(err_union);
+        if (pl_has_bits) {
+            const err_offset = @intCast(u32, errUnionErrorOffset(pl_ty, self.target));
+            try self.addMemArg(.i32_load16_u, .{
+                .offset = err_union.offset() + err_offset,
+                .alignment = Type.anyerror.abiAlignment(self.target),
+            });
+        }
+        try self.addTag(.i32_eqz);
+        try self.addLabel(.br_if, 0); // jump out of block when error is '0'
+        try self.genBody(body);
+        try self.endBlock();
     }
-    try self.addTag(.i32_eqz);
-    try self.addLabel(.br_if, 0); // jump out of block when error is '0'
-    try self.genBody(body);
-    try self.endBlock();
 
     // if we reach here it means error was not set, and we want the payload
     if (!pl_has_bits) {

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -705,15 +705,6 @@ pub fn generateSymbol(
         .ErrorUnion => {
             const error_ty = typed_value.ty.errorUnionSet();
             const payload_ty = typed_value.ty.errorUnionPayload();
-
-            if (error_ty.errorSetCardinality() == .zero) {
-                const payload_val = typed_value.val.castTag(.eu_payload).?.data;
-                return generateSymbol(bin_file, src_loc, .{
-                    .ty = payload_ty,
-                    .val = payload_val,
-                }, code, debug_output, reloc_info);
-            }
-
             const is_payload = typed_value.val.errorUnionIsPayload();
 
             if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1571,22 +1571,6 @@ pub const Object = struct {
             },
             .ErrorUnion => {
                 const payload_ty = ty.errorUnionPayload();
-                switch (ty.errorUnionSet().errorSetCardinality()) {
-                    .zero => {
-                        const payload_di_ty = try o.lowerDebugType(payload_ty, .full);
-                        // The recursive call to `lowerDebugType` means we can't use `gop` anymore.
-                        try o.di_type_map.putContext(gpa, ty, AnnotatedDITypePtr.initFull(payload_di_ty), .{ .mod = o.module });
-                        return payload_di_ty;
-                    },
-                    .one => {
-                        if (payload_ty.isNoReturn()) {
-                            const di_type = dib.createBasicType("void", 0, DW.ATE.signed);
-                            gop.value_ptr.* = AnnotatedDITypePtr.initFull(di_type);
-                            return di_type;
-                        }
-                    },
-                    .many => {},
-                }
                 if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
                     const err_set_di_ty = try o.lowerDebugType(Type.anyerror, .full);
                     // The recursive call to `lowerDebugType` means we can't use `gop` anymore.
@@ -2554,15 +2538,6 @@ pub const DeclGen = struct {
             },
             .ErrorUnion => {
                 const payload_ty = t.errorUnionPayload();
-                switch (t.errorUnionSet().errorSetCardinality()) {
-                    .zero => return dg.lowerType(payload_ty),
-                    .one => {
-                        if (payload_ty.isNoReturn()) {
-                            return dg.context.voidType();
-                        }
-                    },
-                    .many => {},
-                }
                 if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
                     return try dg.lowerType(Type.anyerror);
                 }
@@ -3222,10 +3197,6 @@ pub const DeclGen = struct {
             },
             .ErrorUnion => {
                 const payload_type = tv.ty.errorUnionPayload();
-                if (tv.ty.errorUnionSet().errorSetCardinality() == .zero) {
-                    const payload_val = tv.val.castTag(.eu_payload).?.data;
-                    return dg.lowerValue(.{ .ty = payload_type, .val = payload_val });
-                }
                 const is_pl = tv.val.errorUnionIsPayload();
 
                 if (!payload_type.hasRuntimeBitsIgnoreComptime()) {
@@ -4795,40 +4766,37 @@ pub const FuncGen = struct {
     }
 
     fn lowerTry(fg: *FuncGen, err_union: *const llvm.Value, body: []const Air.Inst.Index, err_union_ty: Type, operand_is_ptr: bool, result_ty: Type) !?*const llvm.Value {
-        if (err_union_ty.errorUnionSet().errorSetCardinality() == .zero) {
-            // If the error set has no fields, then the payload and the error
-            // union are the same value.
-            return err_union;
-        }
-
         const payload_ty = err_union_ty.errorUnionPayload();
         const payload_has_bits = payload_ty.hasRuntimeBitsIgnoreComptime();
         const target = fg.dg.module.getTarget();
-        const is_err = err: {
-            const err_set_ty = try fg.dg.lowerType(Type.anyerror);
-            const zero = err_set_ty.constNull();
-            if (!payload_has_bits) {
-                const loaded = if (operand_is_ptr) fg.builder.buildLoad(err_union, "") else err_union;
+
+        if (!err_union_ty.errorUnionSet().errorSetIsEmpty()) {
+            const is_err = err: {
+                const err_set_ty = try fg.dg.lowerType(Type.anyerror);
+                const zero = err_set_ty.constNull();
+                if (!payload_has_bits) {
+                    const loaded = if (operand_is_ptr) fg.builder.buildLoad(err_union, "") else err_union;
+                    break :err fg.builder.buildICmp(.NE, loaded, zero, "");
+                }
+                const err_field_index = errUnionErrorOffset(payload_ty, target);
+                if (operand_is_ptr or isByRef(err_union_ty)) {
+                    const err_field_ptr = fg.builder.buildStructGEP(err_union, err_field_index, "");
+                    const loaded = fg.builder.buildLoad(err_field_ptr, "");
+                    break :err fg.builder.buildICmp(.NE, loaded, zero, "");
+                }
+                const loaded = fg.builder.buildExtractValue(err_union, err_field_index, "");
                 break :err fg.builder.buildICmp(.NE, loaded, zero, "");
-            }
-            const err_field_index = errUnionErrorOffset(payload_ty, target);
-            if (operand_is_ptr or isByRef(err_union_ty)) {
-                const err_field_ptr = fg.builder.buildStructGEP(err_union, err_field_index, "");
-                const loaded = fg.builder.buildLoad(err_field_ptr, "");
-                break :err fg.builder.buildICmp(.NE, loaded, zero, "");
-            }
-            const loaded = fg.builder.buildExtractValue(err_union, err_field_index, "");
-            break :err fg.builder.buildICmp(.NE, loaded, zero, "");
-        };
+            };
 
-        const return_block = fg.context.appendBasicBlock(fg.llvm_func, "TryRet");
-        const continue_block = fg.context.appendBasicBlock(fg.llvm_func, "TryCont");
-        _ = fg.builder.buildCondBr(is_err, return_block, continue_block);
+            const return_block = fg.context.appendBasicBlock(fg.llvm_func, "TryRet");
+            const continue_block = fg.context.appendBasicBlock(fg.llvm_func, "TryCont");
+            _ = fg.builder.buildCondBr(is_err, return_block, continue_block);
 
-        fg.builder.positionBuilderAtEnd(return_block);
-        try fg.genBody(body);
+            fg.builder.positionBuilderAtEnd(return_block);
+            try fg.genBody(body);
 
-        fg.builder.positionBuilderAtEnd(continue_block);
+            fg.builder.positionBuilderAtEnd(continue_block);
+        }
         if (!payload_has_bits) {
             if (!operand_is_ptr) return null;
 
@@ -5665,7 +5633,7 @@ pub const FuncGen = struct {
         const err_set_ty = try self.dg.lowerType(Type.initTag(.anyerror));
         const zero = err_set_ty.constNull();
 
-        if (err_union_ty.errorUnionSet().errorSetCardinality() == .zero) {
+        if (err_union_ty.errorUnionSet().errorSetIsEmpty()) {
             const llvm_i1 = self.context.intType(1);
             switch (op) {
                 .EQ => return llvm_i1.constInt(1, .False), // 0 == 0
@@ -5788,13 +5756,6 @@ pub const FuncGen = struct {
 
         const ty_op = self.air.instructions.items(.data)[inst].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
-        const operand_ty = self.air.typeOf(ty_op.operand);
-        const error_union_ty = if (operand_is_ptr) operand_ty.childType() else operand_ty;
-        if (error_union_ty.errorUnionSet().errorSetCardinality() == .zero) {
-            // If the error set has no fields, then the payload and the error
-            // union are the same value.
-            return operand;
-        }
         const result_ty = self.air.typeOfIndex(inst);
         const payload_ty = if (operand_is_ptr) result_ty.childType() else result_ty;
         const target = self.dg.module.getTarget();
@@ -5825,7 +5786,7 @@ pub const FuncGen = struct {
         const operand = try self.resolveInst(ty_op.operand);
         const operand_ty = self.air.typeOf(ty_op.operand);
         const err_union_ty = if (operand_is_ptr) operand_ty.childType() else operand_ty;
-        if (err_union_ty.errorUnionSet().errorSetCardinality() == .zero) {
+        if (err_union_ty.errorUnionSet().errorSetIsEmpty()) {
             const err_llvm_ty = try self.dg.lowerType(Type.anyerror);
             if (operand_is_ptr) {
                 return self.builder.buildBitCast(operand, err_llvm_ty.pointerType(0), "");
@@ -5856,10 +5817,6 @@ pub const FuncGen = struct {
         const operand = try self.resolveInst(ty_op.operand);
         const error_union_ty = self.air.typeOf(ty_op.operand).childType();
 
-        if (error_union_ty.errorUnionSet().errorSetCardinality() == .zero) {
-            // TODO: write undefined bytes through the pointer here
-            return operand;
-        }
         const payload_ty = error_union_ty.errorUnionPayload();
         const non_error_val = try self.dg.lowerValue(.{ .ty = Type.anyerror, .val = Value.zero });
         if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
@@ -5938,9 +5895,6 @@ pub const FuncGen = struct {
         const ty_op = self.air.instructions.items(.data)[inst].ty_op;
         const inst_ty = self.air.typeOfIndex(inst);
         const operand = try self.resolveInst(ty_op.operand);
-        if (inst_ty.errorUnionSet().errorSetCardinality() == .zero) {
-            return operand;
-        }
         const payload_ty = self.air.typeOf(ty_op.operand);
         if (!payload_ty.hasRuntimeBitsIgnoreComptime()) {
             return operand;

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -390,6 +390,9 @@ pub const Module = opaque {
 
     pub const setModuleInlineAsm2 = LLVMSetModuleInlineAsm2;
     extern fn LLVMSetModuleInlineAsm2(M: *const Module, Asm: [*]const u8, Len: usize) void;
+
+    pub const printModuleToFile = LLVMPrintModuleToFile;
+    extern fn LLVMPrintModuleToFile(M: *const Module, Filename: [*:0]const u8, ErrorMessage: *[*:0]const u8) Bool;
 };
 
 pub const lookupIntrinsicID = LLVMLookupIntrinsicID;

--- a/src/value.zig
+++ b/src/value.zig
@@ -1062,6 +1062,7 @@ pub const Value = extern union {
         sema_kit: ?Module.WipAnalysis,
     ) Module.CompileError!BigIntConst {
         switch (val.tag()) {
+            .null_value,
             .zero,
             .bool_false,
             .the_only_possible_value, // i0, u0

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -1086,3 +1086,26 @@ test "inline call of function with a switch inside the return statement" {
     };
     try expect(S.foo(1) == 1);
 }
+
+test "namespace lookup ignores decl causing the lookup" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        fn Mixin(comptime T: type) type {
+            return struct {
+                fn foo() void {
+                    const set = std.EnumSet(T.E).init(undefined);
+                    _ = set;
+                }
+            };
+        }
+
+        const E = enum { a, b };
+        usingnamespace Mixin(@This());
+    };
+    _ = S.foo();
+}

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1426,6 +1426,7 @@ test "coerce undefined single-item pointer of array to error union of slice" {
 }
 
 test "pointer to empty struct literal to mutable slice" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     var x: []i32 = &.{};
     try expect(x.len == 0);
 }

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -453,65 +453,6 @@ test "optional error set is the same size as error set" {
     comptime try expect(S.returnsOptErrSet() == null);
 }
 
-test "optional error set with only one error is the same size as bool" {
-    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-
-    const E = error{only};
-    comptime try expect(@sizeOf(?E) == @sizeOf(bool));
-    comptime try expect(@alignOf(?E) == @alignOf(bool));
-    const S = struct {
-        fn gimmeNull() ?E {
-            return null;
-        }
-        fn gimmeErr() ?E {
-            return error.only;
-        }
-    };
-    try expect(S.gimmeNull() == null);
-    try expect(error.only == S.gimmeErr().?);
-    comptime try expect(S.gimmeNull() == null);
-    comptime try expect(error.only == S.gimmeErr().?);
-}
-
-test "optional empty error set" {
-    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-
-    comptime try expect(@sizeOf(error{}!void) == @sizeOf(void));
-    comptime try expect(@alignOf(error{}!void) == @alignOf(void));
-
-    var x: ?error{} = undefined;
-    if (x != null) {
-        @compileError("test failed");
-    }
-}
-
-test "empty error set plus zero-bit payload" {
-    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-
-    comptime try expect(@sizeOf(error{}!void) == @sizeOf(void));
-    comptime try expect(@alignOf(error{}!void) == @alignOf(void));
-
-    var x: error{}!void = undefined;
-    if (x) |payload| {
-        if (payload != {}) {
-            @compileError("test failed");
-        }
-    } else |_| {
-        @compileError("test failed");
-    }
-    const S = struct {
-        fn empty() error{}!void {}
-        fn inferred() !void {
-            return empty();
-        }
-    };
-    try S.inferred();
-}
-
 test "nested catch" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/typename.zig
+++ b/test/behavior/typename.zig
@@ -137,43 +137,8 @@ const A_Enum = enum {
 
 fn regular() void {}
 
-test "fn body decl" {
-    if (builtin.zig_backend == .stage1) {
-        // stage1 fails to return fully qualified namespaces.
-        return error.SkipZigTest;
-    }
-
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-
-    try B.doTest();
-}
-
 const B = struct {
-    fn doTest() !void {
-        const B_Struct = struct {};
-        const B_Union = union {
-            unused: u8,
-        };
-        const B_Enum = enum {
-            unused,
-        };
-
-        try expectEqualStringsIgnoreDigits(
-            "behavior.typename.B.doTest__struct_0",
-            @typeName(B_Struct),
-        );
-        try expectEqualStringsIgnoreDigits(
-            "behavior.typename.B.doTest__union_0",
-            @typeName(B_Union),
-        );
-        try expectEqualStringsIgnoreDigits(
-            "behavior.typename.B.doTest__enum_0",
-            @typeName(B_Enum),
-        );
-    }
+    fn doTest() !void {}
 };
 
 test "fn param" {
@@ -245,4 +210,28 @@ pub fn expectEqualStringsIgnoreDigits(expected: []const u8, actual: []const u8) 
         }
     }
     return expectEqualStrings(expected, actual_buf[0..actual_i]);
+}
+
+test "local variable" {
+    if (builtin.zig_backend == .stage1) {
+        // stage1 fails to return fully qualified namespaces.
+        return error.SkipZigTest;
+    }
+
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+
+    const Foo = struct { a: u32 };
+    const Bar = union { a: u32 };
+    const Baz = enum { a, b };
+    const Qux = enum { a, b };
+    const Quux = enum { a, b };
+
+    try expectEqualStrings("behavior.typename.test.local variable.Foo", @typeName(Foo));
+    try expectEqualStrings("behavior.typename.test.local variable.Bar", @typeName(Bar));
+    try expectEqualStrings("behavior.typename.test.local variable.Baz", @typeName(Baz));
+    try expectEqualStrings("behavior.typename.test.local variable.Qux", @typeName(Qux));
+    try expectEqualStrings("behavior.typename.test.local variable.Quux", @typeName(Quux));
 }

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -1183,3 +1183,21 @@ test "comptime equality of extern unions with same tag" {
     const b = S.U{ .a = 1234 };
     try expect(S.foo(a) == S.foo(b));
 }
+
+test "union tag is set when initiated as a temporary value at runtime" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
+    const U = union(enum) {
+        a,
+        b: u32,
+        c,
+
+        fn doTheTest(u: @This()) !void {
+            try expect(u == .b);
+        }
+    };
+    var b: u32 = 1;
+    try (U{ .b = b }).doTheTest();
+}


### PR DESCRIPTION
After this passing all std tests will "only" require a bunch of miscompilation fixes, implementing async, and packed struct related adjustments.
Probably worth noting that removing stage2 function pointer handling from the compress related structs seems to cause #10886.

Should I disable the 40 failing tests and add `test-std` to the CI?