### PR TITLE
ThreadPool: Make `join()` a no-op in single-threaded mode

### DIFF
--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -49,6 +49,10 @@ pub fn deinit(self: *ThreadPool) void {
 }
 
 fn join(self: *ThreadPool, spawned: usize) void {
+    if (builtin.single_threaded) {
+        return;
+    }
+
     {
         self.mutex.lock();
         defer self.mutex.unlock();


### PR DESCRIPTION
This comptime gate is needed to make sure that purely single-threaded programs don't generate calls to the std.Thread API.

WASI targets successfully build again with this change 🚀 