### PR TITLE
std.os.linux: Allow the usage of dynamic PMUs

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -5172,7 +5172,9 @@ pub const rtnl_link_stats64 = extern struct {
 
 pub const perf_event_attr = extern struct {
     /// Major type: hardware/software/tracepoint/etc.
-    type: PERF.TYPE = undefined,
+    /// Either a static PMU type defined in PERF.COUNT, or a dynamic PMU type
+    /// which can be queried from /sys/bus/event_source/devices/*/type.
+    type: u32 = 0,
     /// Size of the attr structure, for fwd/bwd compat.
     size: u32 = @sizeOf(perf_event_attr),
     /// Type specific configuration information.


### PR DESCRIPTION
The perf_event_attr struct largely mirrors the upstream one[0], with one distinct change - the 'type' field is an enum value of PERF.TYPE, instead of a u32, which prevents the usage of dynamic PMUs.

With dynamic PMUs[1], the type value is queried from /sys/bus/event_source/devices/*/type and can obviously go outside the range of the enum definition.

By leaving the field type be u32 like in the upstream headers, allows both the usage of the predefined static types (via @enumToInt(PERF.TYPE.HARDWARE), for example) and whatever value you get from sysfs. This is already the case with the 'config' field being u64 and the PERF.COUNT struct. 

[0] - https://elixir.bootlin.com/linux/v5.19-rc1/source/include/uapi/linux/perf_event.h#L340
[1] - https://man7.org/linux/man-pages/man2/perf_event_open.2.html (ctrl+f "dynamic PMU")