### PR TITLE
 stage2: ensure builtin packages are always available

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1494,30 +1494,13 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
                 );
                 errdefer test_pkg.destroy(gpa);
 
-                try test_pkg.add(gpa, "builtin", builtin_pkg);
-                try test_pkg.add(gpa, "root", test_pkg);
-                try test_pkg.add(gpa, "std", std_pkg);
-
                 break :root_pkg test_pkg;
             } else main_pkg;
             errdefer if (options.is_test) root_pkg.destroy(gpa);
 
-            var other_pkg_iter = main_pkg.table.valueIterator();
-            while (other_pkg_iter.next()) |pkg| {
-                try pkg.*.add(gpa, "builtin", builtin_pkg);
-                try pkg.*.add(gpa, "std", std_pkg);
-            }
-
             try main_pkg.addAndAdopt(gpa, "builtin", builtin_pkg);
             try main_pkg.add(gpa, "root", root_pkg);
             try main_pkg.addAndAdopt(gpa, "std", std_pkg);
-
-            try std_pkg.add(gpa, "builtin", builtin_pkg);
-            try std_pkg.add(gpa, "root", root_pkg);
-            try std_pkg.add(gpa, "std", std_pkg);
-
-            try builtin_pkg.add(gpa, "std", std_pkg);
-            try builtin_pkg.add(gpa, "builtin", builtin_pkg);
 
             const main_pkg_in_std = m: {
                 const std_path = try std.fs.path.resolve(arena, &[_][]const u8{

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4673,6 +4673,15 @@ pub fn importFile(
     cur_file: *File,
     import_string: []const u8,
 ) !ImportFileResult {
+    if (std.mem.eql(u8, import_string, "std")) {
+        return mod.importPkg(mod.main_pkg.table.get("std").?);
+    }
+    if (std.mem.eql(u8, import_string, "builtin")) {
+        return mod.importPkg(mod.main_pkg.table.get("builtin").?);
+    }
+    if (std.mem.eql(u8, import_string, "root")) {
+        return mod.importPkg(mod.root_pkg);
+    }
     if (cur_file.pkg.table.get(import_string)) |pkg| {
         return mod.importPkg(pkg);
     }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4674,10 +4674,6 @@ fn zirCImport(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileEr
         error.OutOfMemory => return error.OutOfMemory,
         else => unreachable, // we pass null for root_src_dir_path
     };
-    const std_pkg = mod.main_pkg.table.get("std").?;
-    const builtin_pkg = mod.main_pkg.table.get("builtin").?;
-    try c_import_pkg.add(sema.gpa, "builtin", builtin_pkg);
-    try c_import_pkg.add(sema.gpa, "std", std_pkg);
 
     const result = mod.importPkg(c_import_pkg) catch |err|
         return sema.fail(&child_block, src, "C import failed: {s}", .{@errorName(err)});

--- a/src/main.zig
+++ b/src/main.zig
@@ -858,6 +858,12 @@ fn buildOutputType(
                         ) catch |err| {
                             fatal("Failed to add package at path {s}: {s}", .{ pkg_path.?, @errorName(err) });
                         };
+
+                        if (mem.eql(u8, pkg_name.?, "std") or mem.eql(u8, pkg_name.?, "root") or mem.eql(u8, pkg_name.?, "builtin")) {
+                            fatal("unable to add package '{s}' -> '{s}': conflicts with builtin package", .{ pkg_name.?, pkg_path.? });
+                        } else if (cur_pkg.table.get(pkg_name.?)) |prev| {
+                            fatal("unable to add package '{s}' -> '{s}': already exists as '{s}", .{ pkg_name.?, pkg_path.?, prev.root_src_path });
+                        }
                         try cur_pkg.addAndAdopt(gpa, pkg_name.?, new_cur_pkg);
                         cur_pkg = new_cur_pkg;
                     } else if (mem.eql(u8, arg, "--pkg-end")) {


### PR DESCRIPTION
after a certain package depth, it appears access to the `'std'` package is lost. with this fix building [nektro/aquila](https://github.com/nektro/aquila) reaches a new error

```
[nix-shell:~/other/dev/aquila]$ ~/other/dev/zig/zig-out/bin/zig build --prominent-compile-errors -fno-stage1
/home/meg/other/dev/aquila/.zigmod/deps/git/github.com/nektro/zig-zorm/src/sqlite3.zig:1:21: error: unable to open 'std': PackageNotFound
const std = @import("std");
                    ^
aquila...The step exited with error code 1
error: the build command failed with exit code 1

[nix-shell:~/other/dev/aquila]$ ~/other/dev/zig/zig-out/bin/zig build --prominent-compile-errors -fno-stage1
Semantic Analysis [2456] ensureTotalCapacityPrecise... thread 78535 panic: integer overflow
/home/meg/other/dev/zig/lib/std/mem.zig:3045:54: 0x2dd642a in std.mem.alignForwardGeneric (zig)
    return alignBackwardGeneric(T, addr + (alignment - 1), alignment);
                                                     ^
/home/meg/other/dev/zig/src/codegen/llvm.zig:2651:57: 0x30e8575 in codegen.llvm.DeclGen.lowerType (zig)
                    offset = std.mem.alignForwardGeneric(u64, offset, field_align);
                                                        ^
/home/meg/other/dev/zig/src/codegen/llvm.zig:2376:43: 0x30df435 in codegen.llvm.DeclGen.resolveGlobalDecl (zig)
        const llvm_type = try dg.lowerType(decl.ty);
                                          ^
/home/meg/other/dev/zig/src/codegen/llvm.zig:3740:39: 0x30ef167 in codegen.llvm.DeclGen.lowerDeclRefValue (zig)
            try self.resolveGlobalDecl(decl_index);
                                      ^
....
```