### PR TITLE
[MachO] add -pagezero_size

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1744,6 +1744,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .native_darwin_sdk = options.native_darwin_sdk,
             .install_name = options.install_name,
             .entitlements = options.entitlements,
+            .pagezero_size = options.pagezero_size,
         });
         errdefer bin_file.destroy();
         comp.* = .{
@@ -2476,7 +2477,7 @@ fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifes
     man.hash.addListOfBytes(comp.bin_file.options.framework_dirs);
     man.hash.addListOfBytes(comp.bin_file.options.frameworks);
     try man.addOptionalFile(comp.bin_file.options.entitlements);
-    if (comp.bin_file.options.pagezero_size) |value| man.hash.add(value);
+    man.hash.addOptional(comp.bin_file.options.pagezero_size);
 
     // COFF specific stuff
     man.hash.addOptional(comp.bin_file.options.subsystem);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -903,6 +903,8 @@ pub const InitOptions = struct {
     install_name: ?[]const u8 = null,
     /// (Darwin) Path to entitlements file
     entitlements: ?[]const u8 = null,
+    /// (Darwin) size of the __PAGEZERO segment
+    pagezero_size: ?u64 = null,
 };
 
 fn addPackageTableToCacheHash(
@@ -2359,7 +2361,7 @@ fn prepareWholeEmitSubPath(arena: Allocator, opt_emit: ?EmitLoc) error{OutOfMemo
 /// to remind the programmer to update multiple related pieces of code that
 /// are in different locations. Bump this number when adding or deleting
 /// anything from the link cache manifest.
-pub const link_hash_implementation_version = 3;
+pub const link_hash_implementation_version = 4;
 
 fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifest) !void {
     const gpa = comp.gpa;
@@ -2369,7 +2371,7 @@ fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifes
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
-    comptime assert(link_hash_implementation_version == 3);
+    comptime assert(link_hash_implementation_version == 4);
 
     if (comp.bin_file.options.module) |mod| {
         const main_zig_file = try mod.main_pkg.root_src_directory.join(arena, &[_][]const u8{
@@ -2474,6 +2476,7 @@ fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifes
     man.hash.addListOfBytes(comp.bin_file.options.framework_dirs);
     man.hash.addListOfBytes(comp.bin_file.options.frameworks);
     try man.addOptionalFile(comp.bin_file.options.entitlements);
+    if (comp.bin_file.options.pagezero_size) |value| man.hash.add(value);
 
     // COFF specific stuff
     man.hash.addOptional(comp.bin_file.options.subsystem);

--- a/src/link.zig
+++ b/src/link.zig
@@ -187,6 +187,9 @@ pub const Options = struct {
     /// (Darwin) Path to entitlements file
     entitlements: ?[]const u8 = null,
 
+    /// (Darwin) size of the __PAGEZERO segment
+    pagezero_size: ?u64 = null,
+
     pub fn effectiveOutputMode(options: Options) std.builtin.OutputMode {
         return if (options.use_lld) .Obj else options.output_mode;
     }

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -969,7 +969,7 @@ fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Node) !
         man = comp.cache_parent.obtain();
         self.base.releaseLock();
 
-        comptime assert(Compilation.link_hash_implementation_version == 3);
+        comptime assert(Compilation.link_hash_implementation_version == 4);
 
         for (self.base.options.objects) |obj| {
             _ = try man.addFile(obj.path, null);

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1298,7 +1298,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
         // We are about to obtain this lock, so here we give other processes a chance first.
         self.base.releaseLock();
 
-        comptime assert(Compilation.link_hash_implementation_version == 3);
+        comptime assert(Compilation.link_hash_implementation_version == 4);
 
         try man.addOptionalFile(self.base.options.linker_script);
         try man.addOptionalFile(self.base.options.version_script);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -4377,7 +4377,7 @@ fn populateMissingMetadata(self: *MachO) !void {
     if (self.pagezero_segment_cmd_index == null) blk: {
         if (aligned_pagezero_vmsize == 0) break :blk;
         if (aligned_pagezero_vmsize != pagezero_vmsize) {
-            log.warn("requested __PAGEZERO size is not page aligned", .{});
+            log.warn("requested __PAGEZERO size (0x{x}) is not page aligned", .{pagezero_vmsize});
             log.warn("  rounding down to 0x{x}", .{aligned_pagezero_vmsize});
         }
         self.pagezero_segment_cmd_index = @intCast(u16, self.load_commands.items.len);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -929,6 +929,11 @@ pub fn flushModule(self: *MachO, comp: *Compilation, prog_node: *std.Progress.No
                     try argv.append(rpath);
                 }
 
+                if (self.base.options.pagezero_size) |pagezero_size| {
+                    try argv.append("-pagezero_size");
+                    try argv.append(try std.fmt.allocPrint(arena, "0x{x}", .{pagezero_size}));
+                }
+
                 try argv.appendSlice(positionals.items);
 
                 try argv.append("-o");

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -2274,7 +2274,7 @@ fn linkWithLLD(self: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) !
         // We are about to obtain this lock, so here we give other processes a chance first.
         self.base.releaseLock();
 
-        comptime assert(Compilation.link_hash_implementation_version == 3);
+        comptime assert(Compilation.link_hash_implementation_version == 4);
 
         for (self.base.options.objects) |obj| {
             _ = try man.addFile(obj.path, null);

--- a/src/main.zig
+++ b/src/main.zig
@@ -910,6 +910,13 @@ fn buildOutputType(
                         install_name = args_iter.next() orelse {
                             fatal("expected parameter after {s}", .{arg});
                         };
+                    } else if (mem.eql(u8, arg, "-pagezero_size")) {
+                        const next_arg = args_iter.next() orelse {
+                            fatal("expected parameter after {s}", .{arg});
+                        };
+                        pagezero_size = std.fmt.parseUnsigned(u64, next_arg, 0) catch |err| {
+                            fatal("unable to parse '{s}': {s}", .{ arg, @errorName(err) });
+                        };
                     } else if (mem.eql(u8, arg, "-T") or mem.eql(u8, arg, "--script")) {
                         linker_script = args_iter.next() orelse {
                             fatal("expected parameter after {s}", .{arg});


### PR DESCRIPTION
Pass `-pagezero_size` to the MachO linker. This is the final
"unsupported linker arg" that I could chase that CGo uses. After this
and #11874 we may be able to fail on an "unsupported linker arg" instead
of emiting a warning.

Test case:

    zig=/code/zig/build/zig
    CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 CC="$zig cc -target x86_64-macos" CXX="$zig c++ -target x86_64-macos" go build -a -ldflags "-s -w" cgo.go

I compiled a trivial CGo program and executed it on an amd64 Darwin
host.

To be honest, I am not entirely sure what this is doing. This feels
right after reading what this argument does in LLVM sources, but I am by
no means qualified to make MachO pull requests. Will take feedback.