### PR TITLE
stage2: comptime @bitCast packed struct bug fix 

### DIFF
--- a/src/value.zig
+++ b/src/value.zig
@@ -1283,11 +1283,11 @@ pub const Value = extern union {
             const field_val = field_vals[i];
             const field_bigint_const = switch (field.ty.zigTypeTag()) {
                 .Float => switch (field.ty.floatBits(target)) {
-                    16 => bitcastFloatToBigInt(f16, val.toFloat(f16), &field_buf),
-                    32 => bitcastFloatToBigInt(f32, val.toFloat(f32), &field_buf),
-                    64 => bitcastFloatToBigInt(f64, val.toFloat(f64), &field_buf),
-                    80 => bitcastFloatToBigInt(f80, val.toFloat(f80), &field_buf),
-                    128 => bitcastFloatToBigInt(f128, val.toFloat(f128), &field_buf),
+                    16 => bitcastFloatToBigInt(f16, field_val.toFloat(f16), &field_buf),
+                    32 => bitcastFloatToBigInt(f32, field_val.toFloat(f32), &field_buf),
+                    64 => bitcastFloatToBigInt(f64, field_val.toFloat(f64), &field_buf),
+                    80 => bitcastFloatToBigInt(f80, field_val.toFloat(f80), &field_buf),
+                    128 => bitcastFloatToBigInt(f128, field_val.toFloat(f128), &field_buf),
                     else => unreachable,
                 },
                 .Int, .Bool => field_val.toBigInt(&field_space, target),

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -264,3 +264,38 @@ test "triple level result location with bitcast sandwich passed as tuple element
     };
     try S.foo(.{@as(f64, @bitCast(f32, @as(u32, 0x414570A4)))});
 }
+
+test "@bitCast packed struct of floats" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+
+    const Foo = packed struct {
+        a: f16 = 0,
+        b: f32 = 1,
+        c: f64 = 2,
+        d: f128 = 3,
+    };
+
+    const Foo2 = packed struct {
+        a: f16 = 0,
+        b: f32 = 1,
+        c: f64 = 2,
+        d: f128 = 3,
+    };
+
+    const S = struct {
+        fn doTheTest() !void {
+            var foo = Foo{};
+            var v = @bitCast(Foo2, foo);
+            try expect(v.a == foo.a);
+            try expect(v.b == foo.b);
+            try expect(v.c == foo.c);
+            try expect(v.d == foo.d);
+        }
+    };
+    try S.doTheTest();
+    comptime try S.doTheTest();
+}

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -264,38 +264,3 @@ test "triple level result location with bitcast sandwich passed as tuple element
     };
     try S.foo(.{@as(f64, @bitCast(f32, @as(u32, 0x414570A4)))});
 }
-
-test "@bitCast packed struct of floats" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-
-    const Foo = packed struct {
-        a: f16 = 0,
-        b: f32 = 1,
-        c: f64 = 2,
-        d: f128 = 3,
-    };
-
-    const Foo2 = packed struct {
-        a: f16 = 0,
-        b: f32 = 1,
-        c: f64 = 2,
-        d: f128 = 3,
-    };
-
-    const S = struct {
-        fn doTheTest() !void {
-            var foo = Foo{};
-            var v = @bitCast(Foo2, foo);
-            try expect(v.a == foo.a);
-            try expect(v.b == foo.b);
-            try expect(v.c == foo.c);
-            try expect(v.d == foo.d);
-        }
-    };
-    try S.doTheTest();
-    comptime try S.doTheTest();
-}


### PR DESCRIPTION
Stage 2 will panic when attempting to `@bitCast` a packed struct that has a float field in comptime. The problem was that when iterating over the struct's fields in `packedStructToInt`, `val.toFloat` was used instead of `field_val.toFloat`.

There is also a test case included in this PR.