### PR TITLE
Windows: Fix output when .pdb file is not found during stack trace

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -842,7 +842,10 @@ fn readCoffDebugInfo(allocator: mem.Allocator, coff_file: File) !ModuleDebugInfo
         defer allocator.free(path);
 
         di.debug_data = PdbOrDwarf{ .pdb = undefined };
-        di.debug_data.pdb = try pdb.Pdb.init(allocator, path);
+        di.debug_data.pdb = pdb.Pdb.init(allocator, path) catch |err| switch (err) {
+            error.FileNotFound, error.IsDir => return error.MissingDebugInfo,
+            else => return err,
+        };
         try di.debug_data.pdb.parseInfoStream();
         try di.debug_data.pdb.parseDbiStream();
 


### PR DESCRIPTION
This `pdb.Pdb.init` call can return `error.FileNotFound`, which was previously resulting in:

    Unable to print stack trace: FileNotFound

which also aborts the stack trace printing (so any deeper stack traces are not printed).

It makes more sense to treat it as `MissingDebugInfo` which then gets printed as:

    ???:?:?: 0x7fffa8817033 in ??? (???)

and allows the stack trace to continue printing.

Note: locally, the error.FileNotFound was being triggered for me when looking for kernel32.pdb and ntdll.pdb

---

Test code:

```zig
const std = @import("std");

test "trace" {
    std.debug.dumpCurrentStackTrace(@returnAddress());
}

```

Before:

```
Test [1/1] test "trace"... C:\Users\Ryan\Programming\Zig\zig\lib\test_runner.zig:79:28: 0x7ff7f4feb064 in root).main (test.obj)
        } else test_fn.func();
                           ^
C:\Users\Ryan\Programming\Zig\zig\lib\std\start.zig:571:22: 0x7ff7f4fc29ee in td.start.callMain (test.obj)
            root.main();
                     ^
C:\Users\Ryan\Programming\Zig\zig\lib\std\start.zig:349:65: 0x7ff7f4fc2227 in td.start.WinStartup (test.obj)
    std.os.windows.kernel32.ExitProcess(initEventLoopAndCallMain());
                                                                ^
Unable to dump stack trace: FileNotFound
All 1 tests passed.
```

After:

```
Test [1/1] test "trace"... C:\Users\Ryan\Programming\Zig\zig\lib\test_runner.zig:79:28: 0x7ff7af1ab0d4 in root).main (test.obj)
        } else test_fn.func();
                           ^
C:\Users\Ryan\Programming\Zig\zig\lib\std\start.zig:571:22: 0x7ff7af1829ee in td.start.callMain (test.obj)
            root.main();
                     ^
C:\Users\Ryan\Programming\Zig\zig\lib\std\start.zig:349:65: 0x7ff7af182227 in td.start.WinStartup (test.obj)
    std.os.windows.kernel32.ExitProcess(initEventLoopAndCallMain());
                                                                ^
???:?:?: 0x7fffa8817033 in ??? (???)
???:?:?: 0x7fffaa4e2650 in ??? (???)
All 1 tests passed.
```