### PR TITLE
adds isTag function to std.meta

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -80,7 +80,7 @@ pub fn isTag(enum_or_union: anytype, comptime tag_name: []const u8) bool {
         // the field name doesn't match the supplied value.  Thus *at most* one
         // code block in this list of if statements should exist in generated
         // code, leading to the O(1) characteristics of this function.
-        if (std.mem.eql(u8, field.name, tag_name)) {
+        if (comptime std.mem.eql(u8, field.name, tag_name)) {
             unmatched = false;
 
             // NB: for unions, this uses the "tagged union coerces to enum"

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -63,7 +63,7 @@ test "std.meta.tagName" {
 /// union, and it should also be O(1) in the length of the comptime tag
 /// names.
 pub fn isTag(tagged_value: anytype, comptime tag_name: []const u8) bool {
-    const T = @TypeOf(enum_or_union);
+    const T = @TypeOf(tagged_value);
     const type_info = @typeInfo(T);
     const type_name = @typeName(T);
 

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -96,7 +96,7 @@ pub fn isTag(enum_or_union: anytype, comptime tag_name: []const u8) bool {
     unreachable;
 }
 
-test "isTag works with Enums" {
+test "std.meta.isTag for Enums" {
     const EnumType = enum { a, b };
     var a_type: EnumType = .a;
     var b_type: EnumType = .b;
@@ -107,7 +107,7 @@ test "isTag works with Enums" {
     try testing.expect(!isTag(b_type, "a"));
 }
 
-test "isTag works with Tagged Unions" {
+test "std.meta.isTag for Tagged Unions" {
     const TaggedUnionEnum = enum { int, flt };
 
     const TaggedUnionType = union(TaggedUnionEnum) {

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -67,7 +67,7 @@ pub fn isTag(enum_or_union: anytype, comptime tag_name: []const u8) bool {
     const type_info = @typeInfo(T);
     const type_name = @typeName(T);
 
-    // select the Enum type out of the type (in the case of the struct, extract it)
+    // select the Enum type out of the type (in the case of the tagged union, extract it)
     const E = if (.Enum == type_info) T else if (.Union == type_info) (if (type_info.Union.tag_type) |TT| TT else {
         @compileError("attempted to use isTag on the untagged union " ++ type_name);
     }) else {
@@ -76,15 +76,15 @@ pub fn isTag(enum_or_union: anytype, comptime tag_name: []const u8) bool {
 
     comptime var unmatched: bool = true;
     inline for (@typeInfo(E).Enum.fields) |field| {
-        // note that the next if statement is comptime, and is pruned if
-        // the field name doesn't match the supplied value.  *At most* one
-        // code block in this list of if statements should exist in
-        // generated code.
+        // note that the next if statement is comptime, and will be pruned if
+        // the field name doesn't match the supplied value.  Thus *at most* one
+        // code block in this list of if statements should exist in generated
+        // code, leading to the O(1) characteristics of this function.
         if (std.mem.eql(u8, field.name, tag_name)) {
             unmatched = false;
 
             // NB: for unions, this uses the "tagged union coerces to enum"
-            // feature.
+            // language feature.
             return @enumToInt(enum_or_union) == field.value;
         }
     }


### PR DESCRIPTION
This PR adds a runtime function called isTag to std.meta; This function returns a `bool` that reflects if the enum or tagged union corresponds to the tag name, which is a comptime string.  Although using the actual tag enum value is generally preferable, in some cases (such as FFI) easy access to the string representation is desirable.

As indicated in the documentation, this function runs in constant time, regardless of the size of the enum/union or the length of the string representations of the tag name.

I can also provide tests against the compile-time checks if desired.