### PR TITLE
fix ConfigurableTrace.dump OOB

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1999,7 +1999,7 @@ pub fn ConfigurableTrace(comptime size: usize, comptime stack_frame_count: usize
 
             const tty_config = detectTTYConfig();
             const stderr = io.getStdErr().writer();
-            const end = @maximum(t.index, size);
+            const end = @minimum(t.index, size);
             const debug_info = getSelfDebugInfo() catch |err| {
                 stderr.print(
                     "Unable to dump stack trace: Unable to open debug info: {s}\n",


### PR DESCRIPTION
The for-loop in dump() would index out of bounds if `t.index` is greater
than size, because `end` is the maximum of `t.index` and `size` rather than the
minimum.