### PR TITLE
Add missing adddf3

### DIFF
--- a/lib/compiler_rt.zig
+++ b/lib/compiler_rt.zig
@@ -4,6 +4,7 @@ comptime {
     _ = @import("compiler_rt/atomics.zig");
 
     _ = @import("compiler_rt/addf3.zig");
+    _ = @import("compiler_rt/adddf3.zig");
     _ = @import("compiler_rt/addsf3.zig");
     _ = @import("compiler_rt/addtf3.zig");
     _ = @import("compiler_rt/addxf3.zig");


### PR DESCRIPTION
Looks like a file got missed in https://github.com/ziglang/zig/pull/11847.

```zig
LLD Link... ld.lld: error: undefined symbol: __aeabi_dadd
>>> referenced by errol.zig:366 (/home/usr/projects/zig/build/lib/zig/std/fmt/errol.zig:366)
```