### PR TITLE
[all linkers] fail hard on unsupported flags

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1343,7 +1343,7 @@ fn buildOutputType(
                         } else if (mem.startsWith(u8, z_arg, "max-page-size=")) {
                             linker_z_max_page_size = parseIntSuffix(z_arg, "max-page-size=".len);
                         } else {
-                            warn("unsupported linker extension flag: -z {s}", .{z_arg});
+                            fatal("unsupported linker extension flag: -z {s}", .{z_arg});
                         }
                     } else if (mem.eql(u8, arg, "--import-memory")) {
                         linker_import_memory = true;
@@ -1961,7 +1961,7 @@ fn buildOutputType(
                     } else if (mem.startsWith(u8, z_arg, "max-page-size=")) {
                         linker_z_max_page_size = parseIntSuffix(z_arg, "max-page-size=".len);
                     } else {
-                        warn("unsupported linker extension flag: -z {s}", .{z_arg});
+                        fatal("unsupported linker extension flag: -z {s}", .{z_arg});
                     }
                 } else if (mem.eql(u8, arg, "--major-image-version")) {
                     i += 1;
@@ -2186,7 +2186,7 @@ fn buildOutputType(
 
                     have_version = true;
                 } else {
-                    warn("unsupported linker arg: {s}", .{arg});
+                    fatal("unsupported linker arg: {s}", .{arg});
                 }
             }
 


### PR DESCRIPTION
Currently `zig cc`, when confronted with a linker argument it does
not understand, skips the flag and emits a warning.

This has been causing headaches for people that build third-party
software (including me). Zig seemingly builds and links the final
executable, only to segfault when running it. Emiting a warning and
"successfully" compiling a binary breaks autoconf assumptions.
See https://github.com/zigchroot/zig-chroot/issues/1 for a recent
painful example.

If there are linker warnings when compiling software, the first thing we
have to do is add support for ones linker is complaining, and only then
go file issues. If zig "successfully" (i.e. status code = 0) compiles a
binary, there is instead a tendency to blaim "zig doing something
weird". (I am guilty of this.) In my experience, adding the unsupported
arguments has been quite easy; see #11679, #11875, #11874 for recent
examples.

With the "soft prerequisites" below I was able to build all of
the CGo programs that I am encountering at $dayjob.

Harder prerequisites — some production code in my dayjob will cease to build unless we merge this first:
- https://github.com/ziglang/zig/pull/11863

Soft prerequisites — some things I've observed in other issues/PRs:
- https://github.com/ziglang/zig/pull/11614
- https://github.com/ziglang/zig/pull/11906
- https://github.com/ziglang/zig/pull/11912
- https://github.com/ziglang/zig/pull/11913
- https://github.com/ziglang/zig/pull/11914
- https://github.com/ziglang/zig/pull/11915
- https://github.com/ziglang/zig/pull/11916
- https://github.com/ziglang/zig/pull/11917

Andrew's comment in favor of failing early instead of emitting a warning: https://github.com/zigchroot/zig-chroot/issues/1#issuecomment-1054710190 . (NOTE: the repo no longer exists, I would be grateful if someone has a copy of the comment.)