### PR TITLE
mem: add splitBackwards

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1702,23 +1702,32 @@ pub fn split(comptime T: type, buffer: []const T, delimiter: []const T) SplitIte
 
 test "split" {
     var it = split(u8, "abc|def||ghi", "|");
-    try testing.expect(eql(u8, it.next().?, "abc"));
-    try testing.expect(eql(u8, it.next().?, "def"));
-    try testing.expect(eql(u8, it.next().?, ""));
-    try testing.expect(eql(u8, it.next().?, "ghi"));
+    try testing.expectEqualSlices(u8, it.rest(), "abc|def||ghi");
+    try testing.expectEqualSlices(u8, it.next().?, "abc");
+
+    try testing.expectEqualSlices(u8, it.rest(), "def||ghi");
+    try testing.expectEqualSlices(u8, it.next().?, "def");
+
+    try testing.expectEqualSlices(u8, it.rest(), "|ghi");
+    try testing.expectEqualSlices(u8, it.next().?, "");
+
+    try testing.expectEqualSlices(u8, it.rest(), "ghi");
+    try testing.expectEqualSlices(u8, it.next().?, "ghi");
+
+    try testing.expectEqualSlices(u8, it.rest(), "");
     try testing.expect(it.next() == null);
 
     it = split(u8, "", "|");
-    try testing.expect(eql(u8, it.next().?, ""));
+    try testing.expectEqualSlices(u8, it.next().?, "");
     try testing.expect(it.next() == null);
 
     it = split(u8, "|", "|");
-    try testing.expect(eql(u8, it.next().?, ""));
-    try testing.expect(eql(u8, it.next().?, ""));
+    try testing.expectEqualSlices(u8, it.next().?, "");
+    try testing.expectEqualSlices(u8, it.next().?, "");
     try testing.expect(it.next() == null);
 
     it = split(u8, "hello", " ");
-    try testing.expect(eql(u8, it.next().?, "hello"));
+    try testing.expectEqualSlices(u8, it.next().?, "hello");
     try testing.expect(it.next() == null);
 
     var it16 = split(
@@ -1726,17 +1735,18 @@ test "split" {
         std.unicode.utf8ToUtf16LeStringLiteral("hello"),
         std.unicode.utf8ToUtf16LeStringLiteral(" "),
     );
-    try testing.expect(eql(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("hello")));
+    try testing.expectEqualSlices(u16, it16.next().?, std.unicode.utf8ToUtf16LeStringLiteral("hello"));
     try testing.expect(it16.next() == null);
 }
 
 test "split (multibyte)" {
     var it = split(u8, "a, b ,, c, d, e", ", ");
-    try testing.expect(eql(u8, it.next().?, "a"));
-    try testing.expect(eql(u8, it.next().?, "b ,"));
-    try testing.expect(eql(u8, it.next().?, "c"));
-    try testing.expect(eql(u8, it.next().?, "d"));
-    try testing.expect(eql(u8, it.next().?, "e"));
+    try testing.expectEqualSlices(u8, it.next().?, "a");
+    try testing.expectEqualSlices(u8, it.rest(), "b ,, c, d, e");
+    try testing.expectEqualSlices(u8, it.next().?, "b ,");
+    try testing.expectEqualSlices(u8, it.next().?, "c");
+    try testing.expectEqualSlices(u8, it.next().?, "d");
+    try testing.expectEqualSlices(u8, it.next().?, "e");
     try testing.expect(it.next() == null);
 
     var it16 = split(


### PR DESCRIPTION
Over the last couple of weeks weeks I needed to iterate over a
collection backwards at least twice. Do we want to have this in stdlib?
If yes, click "Merge" and start using today! Free shipping and returns
(before 1.0).

Why is this useful?
-------------------

I need this for building an error wrapper: errors are added in the
wrapper from "lowest" level to "highest" level, and then printed in
reverse order. Imagine `UpdateUsers` call, which needs to return
`error.InvalidInput` and a wrappable error context. In Go we would add a
context to the error when returning it:

    // if update_user fails, add context on which user we are operating
    if err := update_user(user); err != nil {
        return fmt.Errorf("user id=%d: %w", user.id, err)
    }

Since Zig cannot pass anything else than u16 with an error (#2647), I
will pass a `err_ctx: *Err`, to the callers, where they can, besides
returning an error, augment it with auxiliary data. `Err` is a
preallocated array that can add zero-byte-separated strings. For a
concrete example, imagine such a call graph:

    update_user(User, *Err) error{InvalidInput}!<...>
      validate_user([]const u8, *Err) error{InvalidInput}!<...>

Where `validate_user` would like, besides only the error, signal the
invalid field. And `update_user`, besides the error, would signal the
offending user id.

We also don't want the low-level functions to know in which context they
are operating to construct a meaningful error message: if validation
fails, they append their "context" to the buffer. To translate/augment
the Go example above:

    pub fn validate_user(err_ctx: *Err, user: User) error{InvalidInput}!void {
        const name = user.name;
        if (!ascii.isAlpha(user.name)) {
            err_ctx.print("name '{s}' must be ascii-letters only", .{user.name});
            return error.InvalidInput;
        }
        <...>
    }

    // update_user validates each user and does something with it.
    pub fn update_user(err_ctx: *Err, user: User) error{InvalidInput}!void {
        // validate the user before updating it
        validate_user(user) catch {
            err_ctx.print("user id={d}", .{user.id});
            return error.InvalidInput;
        };
        <...>
    }

Then the top-level function (in my case, CLI) will read the buffer
backwards (splitting on `"\x00"`) and print:

    user id=123: name 'Žvangalas' must be ascii-letters only

To read that buffer backwards, dear readers of this commit message, I
need `mem.splitBackwards`.

This PR has 2 commits:

1. refactor `split` tests to use `assertEqualSlices`.
2. refactor `split` tests to use `rest()` occasionally.
3. add `splitBackwards` with similar tests to `split`.