### PR TITLE
[elf linker] add --sort-section

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -989,6 +989,7 @@ pub const InitOptions = struct {
     linker_optimization: ?u8 = null,
     linker_compress_debug_sections: ?link.CompressDebugSections = null,
     linker_module_definition_file: ?[]const u8 = null,
+    linker_sort_section: ?link.SortSection = null,
     major_subsystem_version: ?u32 = null,
     minor_subsystem_version: ?u32 = null,
     clang_passthrough_mode: bool = false,
@@ -1853,6 +1854,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .bind_global_refs_locally = options.linker_bind_global_refs_locally orelse false,
             .compress_debug_sections = options.linker_compress_debug_sections orelse .none,
             .module_definition_file = options.linker_module_definition_file,
+            .sort_section = options.linker_sort_section,
             .import_memory = options.linker_import_memory orelse false,
             .import_symbols = options.linker_import_symbols,
             .import_table = options.linker_import_table,
@@ -2684,6 +2686,7 @@ fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifes
     man.hash.add(comp.bin_file.options.hash_style);
     man.hash.add(comp.bin_file.options.compress_debug_sections);
     man.hash.add(comp.bin_file.options.include_compiler_rt);
+    man.hash.addOptional(comp.bin_file.options.sort_section);
     if (comp.bin_file.options.link_libc) {
         man.hash.add(comp.bin_file.options.libc_installation != null);
         if (comp.bin_file.options.libc_installation) |libc_installation| {

--- a/src/link.zig
+++ b/src/link.zig
@@ -25,6 +25,8 @@ pub const SystemLib = struct {
     weak: bool = false,
 };
 
+pub const SortSection = enum { name, alignment };
+
 pub const CacheMode = enum { incremental, whole };
 
 pub fn hashAddSystemLibs(
@@ -159,6 +161,7 @@ pub const Options = struct {
     disable_lld_caching: bool,
     is_test: bool,
     hash_style: HashStyle,
+    sort_section: ?SortSection,
     major_subsystem_version: ?u32,
     minor_subsystem_version: ?u32,
     gc_sections: ?bool = null,

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1324,6 +1324,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
         man.hash.addOptionalBytes(self.base.options.entry);
         man.hash.addOptional(self.base.options.image_base_override);
         man.hash.add(gc_sections);
+        man.hash.addOptional(self.base.options.sort_section);
         man.hash.add(self.base.options.eh_frame_hdr);
         man.hash.add(self.base.options.emit_relocs);
         man.hash.add(self.base.options.rdynamic);
@@ -1486,6 +1487,11 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
         if (self.base.options.linker_script) |linker_script| {
             try argv.append("-T");
             try argv.append(linker_script);
+        }
+
+        if (self.base.options.sort_section) |how| {
+            const arg = try std.fmt.allocPrint(arena, "--sort-section={s}", .{@tagName(how)});
+            try argv.append(arg);
         }
 
         if (gc_sections) {


### PR DESCRIPTION
Tested by: created a "hello world" C file and compiled with:

    zig cc -v main.c -Wl,--sort-section=name -o main

... and verified the `--sort-section=name` is passed to ld.lld.

Refs https://github.com/zigchroot/zig-chroot/issues/1