### PR TITLE
[linker] ignore --sort-common

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1607,6 +1607,10 @@ fn buildOutputType(
                                         build_id = true;
                                         warn("ignoring build-id style argument: '{s}'", .{value});
                                         continue;
+                                    } else if (mem.eql(u8, key, "--sort-common")) {
+                                        // this ignores --sort=common=<anything>; ignoring plain --sort-common
+                                        // is done below.
+                                        continue;
                                     }
                                     try linker_args.append(key);
                                     try linker_args.append(value);
@@ -1619,6 +1623,9 @@ fn buildOutputType(
                                 needed = true;
                             } else if (mem.eql(u8, linker_arg, "-no-pie")) {
                                 want_pie = false;
+                            } else if (mem.eql(u8, linker_arg, "--sort-common")) {
+                                // from ld.lld(1): --sort-common is ignored for GNU compatibility,
+                                // this ignores plain --sort-common
                             } else if (mem.eql(u8, linker_arg, "--whole-archive") or
                                 mem.eql(u8, linker_arg, "-whole-archive"))
                             {


### PR DESCRIPTION
From ld.lld(1):

     --sort-common
             This option is ignored for GNU compatibility.

Refs https://github.com/zigchroot/zig-chroot/issues/1