### PR TITLE
Add stack trace capturing to `FailingAllocator` and use it to improve `checkAllAllocationFailures`

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -26,6 +26,27 @@ pub const runtime_safety = switch (builtin.mode) {
     .ReleaseFast, .ReleaseSmall => false,
 };
 
+pub const sys_can_stack_trace = switch (builtin.cpu.arch) {
+    // Observed to go into an infinite loop.
+    // TODO: Make this work.
+    .mips,
+    .mipsel,
+    => false,
+
+    // `@returnAddress()` in LLVM 10 gives
+    // "Non-Emscripten WebAssembly hasn't implemented __builtin_return_address".
+    .wasm32,
+    .wasm64,
+    => builtin.os.tag == .emscripten,
+
+    // `@returnAddress()` is unsupported in LLVM 13.
+    .bpfel,
+    .bpfeb,
+    => false,
+
+    else => true,
+};
+
 pub const LineInfo = struct {
     line: u64,
     column: u64,

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -105,28 +105,8 @@ const StackTrace = std.builtin.StackTrace;
 /// Integer type for pointing to slots in a small allocation
 const SlotIndex = std.meta.Int(.unsigned, math.log2(page_size) + 1);
 
-const sys_can_stack_trace = switch (builtin.cpu.arch) {
-    // Observed to go into an infinite loop.
-    // TODO: Make this work.
-    .mips,
-    .mipsel,
-    => false,
-
-    // `@returnAddress()` in LLVM 10 gives
-    // "Non-Emscripten WebAssembly hasn't implemented __builtin_return_address".
-    .wasm32,
-    .wasm64,
-    => builtin.os.tag == .emscripten,
-
-    // `@returnAddress()` is unsupported in LLVM 13.
-    .bpfel,
-    .bpfeb,
-    => false,
-
-    else => true,
-};
 const default_test_stack_trace_frames: usize = if (builtin.is_test) 8 else 4;
-const default_sys_stack_trace_frames: usize = if (sys_can_stack_trace) default_test_stack_trace_frames else 0;
+const default_sys_stack_trace_frames: usize = if (std.debug.sys_can_stack_trace) default_test_stack_trace_frames else 0;
 const default_stack_trace_frames: usize = switch (builtin.mode) {
     .Debug => default_sys_stack_trace_frames,
     else => 0,

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -650,7 +650,7 @@ pub fn checkAllAllocationFailures(backing_allocator: std.mem.Allocator, comptime
             error.OutOfMemory => {
                 if (failing_allocator_inst.allocated_bytes != failing_allocator_inst.freed_bytes) {
                     print(
-                        "\nfail_index: {d}/{d}\nallocated bytes: {d}\nfreed bytes: {d}\nallocations: {d}\ndeallocations: {d}\n",
+                        "\nfail_index: {d}/{d}\nallocated bytes: {d}\nfreed bytes: {d}\nallocations: {d}\ndeallocations: {d}\nallocation that was made to fail: {s}",
                         .{
                             fail_index,
                             needed_alloc_count,
@@ -658,6 +658,7 @@ pub fn checkAllAllocationFailures(backing_allocator: std.mem.Allocator, comptime
                             failing_allocator_inst.freed_bytes,
                             failing_allocator_inst.allocations,
                             failing_allocator_inst.deallocations,
+                            failing_allocator_inst.getStackTrace(),
                         },
                     );
                     return error.MemoryLeakDetected;

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -534,18 +534,27 @@ test {
 ///
 /// Any relevant state shared between runs of `test_fn` *must* be reset within `test_fn`.
 ///
-/// Expects that the `test_fn` has a deterministic number of memory allocations
-/// (an error will be returned if non-deterministic allocations are detected).
-///
 /// The strategy employed is to:
 /// - Run the test function once to get the total number of allocations.
 /// - Then, iterate and run the function X more times, incrementing
 ///   the failing index each iteration (where X is the total number of
 ///   allocations determined previously)
 ///
+/// Expects that `test_fn` has a deterministic number of memory allocations:
+/// - If an allocation was made to fail during a run of `test_fn`, but `test_fn`
+///   didn't return `error.OutOfMemory`, then `error.SwallowedOutOfMemoryError`
+///   is returned from `checkAllAllocationFailures`. You may want to ignore this
+///   depending on whether or not the code you're testing includes some strategies
+///   for recovering from `error.OutOfMemory`.
+/// - If a run of `test_fn` with an expected allocation failure executes without
+///   an allocation failure being induced, then `error.NondeterministicMemoryUsage`
+///   is returned. This error means that there are allocation points that won't be
+///   tested by the strategy this function employs (that is, there are sometimes more
+///   points of allocation than the initial run of `test_fn` detects).
+///
 /// ---
 ///
-/// Here's an example of using a simple test case that will cause a leak when the
+/// Here's an example using a simple test case that will cause a leak when the
 /// allocation of `bar` fails (but will pass normally):
 ///
 /// ```zig
@@ -645,7 +654,11 @@ pub fn checkAllAllocationFailures(backing_allocator: std.mem.Allocator, comptime
         args.@"0" = failing_allocator_inst.allocator();
 
         if (@call(.{}, test_fn, args)) |_| {
-            return error.NondeterministicMemoryUsage;
+            if (failing_allocator_inst.has_induced_failure) {
+                return error.SwallowedOutOfMemoryError;
+            } else {
+                return error.NondeterministicMemoryUsage;
+            }
         } else |err| switch (err) {
             error.OutOfMemory => {
                 if (failing_allocator_inst.allocated_bytes != failing_allocator_inst.freed_bytes) {

--- a/lib/std/testing/failing_allocator.zig
+++ b/lib/std/testing/failing_allocator.zig
@@ -56,13 +56,15 @@ pub const FailingAllocator = struct {
         return_address: usize,
     ) error{OutOfMemory}![]u8 {
         if (self.index == self.fail_index) {
-            mem.set(usize, &self.stack_addresses, 0);
-            var stack_trace = std.builtin.StackTrace{
-                .instruction_addresses = &self.stack_addresses,
-                .index = 0,
-            };
-            std.debug.captureStackTrace(return_address, &stack_trace);
-            self.has_induced_failure = true;
+            if (!self.has_induced_failure) {
+                mem.set(usize, &self.stack_addresses, 0);
+                var stack_trace = std.builtin.StackTrace{
+                    .instruction_addresses = &self.stack_addresses,
+                    .index = 0,
+                };
+                std.debug.captureStackTrace(return_address, &stack_trace);
+                self.has_induced_failure = true;
+            }
             return error.OutOfMemory;
         }
         const result = try self.internal_allocator.rawAlloc(len, ptr_align, len_align, return_address);

--- a/lib/std/testing/failing_allocator.zig
+++ b/lib/std/testing/failing_allocator.zig
@@ -19,8 +19,10 @@ pub const FailingAllocator = struct {
     freed_bytes: usize,
     allocations: usize,
     deallocations: usize,
-    stack_addresses: [16]usize,
+    stack_addresses: [num_stack_frames]usize,
     has_induced_failure: bool,
+
+    const num_stack_frames = if (std.debug.sys_can_stack_trace) 16 else 0;
 
     /// `fail_index` is the number of successful allocations you can
     /// expect from this allocator. The next allocation will fail.


### PR DESCRIPTION
There are two parts to this:

---

Adds stack trace capturing to `std.testing.FailingAllocator` and makes `std.testing.checkAllAllocationFailures` print the stack trace of the induced allocation failure when memory leaks are detected (very helpful for debugging)

---

`checkAllAllocationFailures`: add possibility of SwallowedOutOfMemoryError (split from NondeterministicMemoryUsage)

Inducing failure but not getting OutOfMemory back is not as much of a problem as never inducing failure when it was expected to be induced, so treating them differently and allowing them to be handled differently by the caller is useful.

For example, the current implementation of `std.HashMapUnmanaged.getOrPutContextAdapted` always tries to grow and then recovers from OutOfMemory by attempting a lookup of an existing key. If `getOrPutContextAdapted` is used (i.e. from `std.BufMap.putMove`) with `checkAllAllocationFailures`, then we'd have previously triggered `error.NondeterministicMemoryUsage`, but the real cause is that `OutOfMemory` is being recovered from and so the error is being swallowed. The new error allows us to both understand what's happening easier and to catch it and ignore it if we're okay with the code we're testing handling `error.OutOfMemory` without always bubbling it up.