### PR TITLE
stage2: wasm-linker - Place decls in the correct segment and order segments

### DIFF
--- a/src/link/Wasm/types.zig
+++ b/src/link/Wasm/types.zig
@@ -125,14 +125,15 @@ pub const Segment = struct {
     /// Bitfield containing flags for a segment
     flags: u32,
 
+    /// Returns the name as how it will be output into the final object
+    /// file or binary. When `merge_segments` is true, this will return the
+    /// short name. i.e. ".rodata". When false, it returns the entire name instead.
     pub fn outputName(self: Segment, merge_segments: bool) []const u8 {
         if (!merge_segments) return self.name;
         if (std.mem.startsWith(u8, self.name, ".rodata.")) {
             return ".rodata";
         } else if (std.mem.startsWith(u8, self.name, ".text.")) {
             return ".text";
-        } else if (std.mem.startsWith(u8, self.name, ".rodata.")) {
-            return ".rodata";
         } else if (std.mem.startsWith(u8, self.name, ".data.")) {
             return ".data";
         } else if (std.mem.startsWith(u8, self.name, ".bss.")) {


### PR DESCRIPTION
Previously, all decls would be placed within the 'rodata' segment regardless of constness. With this change, we correctly put them into segments such as 'data' and 'bss'. The linker now also orders the segments in such a way to always place the bss segment last, which allows us to completely omit this segment in the case where the memory is exported and not imported from the runtime. This allows smaller binaries as the runtime itself will zero-initialize the memory for us.