### PR TITLE
zig fmt: fix idempotency with newlines surrounding doc comment

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -4683,7 +4683,6 @@ pub const prctl_mm_map = extern struct {
 };
 
 pub const NETLINK = struct {
-
     /// Routing/device hook
     pub const ROUTE = 0;
 

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -4154,6 +4154,41 @@ test "zig fmt: container doc comments" {
     );
 }
 
+test "zig fmt: remove newlines surrounding doc comment" {
+    try testTransform(
+        \\
+        \\
+        \\
+        \\/// doc comment
+        \\
+        \\fn foo() void {}
+        \\
+    ,
+        \\/// doc comment
+        \\fn foo() void {}
+        \\
+    );
+}
+
+test "zig fmt: remove newlines surrounding doc comment within container decl" {
+    try testTransform(
+        \\const Foo = struct {
+        \\
+        \\
+        \\    /// doc comment
+        \\
+        \\    fn foo() void {}
+        \\};
+        \\
+    ,
+        \\const Foo = struct {
+        \\    /// doc comment
+        \\    fn foo() void {}
+        \\};
+        \\
+    );
+}
+
 test "zig fmt: anytype struct field" {
     try testError(
         \\pub const Pointer = struct {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2482,7 +2482,10 @@ fn renderDocComments(ais: *Ais, tree: Ast, end_token: Ast.TokenIndex) Error!void
     }
     const first_tok = tok;
     if (first_tok == end_token) return;
-    try renderExtraNewlineToken(ais, tree, first_tok);
+
+    if (tok != 0 and token_tags[first_tok - 1] != .l_brace) {
+        try renderExtraNewlineToken(ais, tree, first_tok);
+    }
 
     while (token_tags[tok] == .doc_comment) : (tok += 1) {
         try renderToken(ais, tree, tok, .newline);

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2483,8 +2483,15 @@ fn renderDocComments(ais: *Ais, tree: Ast, end_token: Ast.TokenIndex) Error!void
     const first_tok = tok;
     if (first_tok == end_token) return;
 
-    if (tok != 0 and token_tags[first_tok - 1] != .l_brace) {
-        try renderExtraNewlineToken(ais, tree, first_tok);
+    if (tok != 0) {
+        const prev_token_tag = token_tags[first_tok - 1];
+
+        // Prevent accidental use of `renderDocComments` for a function argument doc comment
+        assert(prev_token_tag != .l_paren);
+
+        if (prev_token_tag != .l_brace) {
+            try renderExtraNewlineToken(ais, tree, first_tok);
+        }
     }
 
     while (token_tags[tok] == .doc_comment) : (tok += 1) {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2483,7 +2483,7 @@ fn renderDocComments(ais: *Ais, tree: Ast, end_token: Ast.TokenIndex) Error!void
     const first_tok = tok;
     if (first_tok == end_token) return;
 
-    if (tok != 0) {
+    if (first_tok != 0) {
         const prev_token_tag = token_tags[first_tok - 1];
 
         // Prevent accidental use of `renderDocComments` for a function argument doc comment


### PR DESCRIPTION
This should fix #11802 

I'd be happy to hear any suggestions/improvements as I'm not really sure if this is the best way to go about it.