### PR TITLE
Test harness improvements

### DIFF
--- a/test/cases/llvm/nested_blocks.zig
+++ b/test/cases/llvm/nested_blocks.zig
@@ -19,6 +19,6 @@ pub fn main() void {
 }
 
 // run
-// backend=stage2, llvm
+// backend=stage2,llvm
 // target=x86_64-linux,x86_64-macos
 //

--- a/test/cases/recursive_inline_function.0.zig
+++ b/test/cases/recursive_inline_function.0.zig
@@ -9,4 +9,5 @@ inline fn fibonacci(n: usize) usize {
 }
 
 // run
+// target=x86_64-linux,arm-linux,x86_64-macos,wasm32-wasi
 //


### PR DESCRIPTION
Prior to this change, if there was an unknown value specified in the test manifest, or even a typo, we would silently skip this test case combo. Now, we throw a hard error instead.

I've also disabled `recursive_inline_function` test on `aarch64` due to a crash (happens on my M1 MBP) that is to be investigated.