### PR TITLE
Correct the init function to use initLocked() for initializing std.event.Lock.

### DIFF
--- a/lib/std/event/group.zig
+++ b/lib/std/event/group.zig
@@ -35,7 +35,7 @@ pub fn Group(comptime ReturnType: type) type {
             return Self{
                 .frame_stack = Stack.init(),
                 .alloc_stack = AllocStack.init(),
-                .lock = Lock.init(),
+                .lock = Lock.initLocked(),
                 .allocator = allocator,
             };
         }

--- a/lib/std/event/group.zig
+++ b/lib/std/event/group.zig
@@ -35,7 +35,7 @@ pub fn Group(comptime ReturnType: type) type {
             return Self{
                 .frame_stack = Stack.init(),
                 .alloc_stack = AllocStack.init(),
-                .lock = Lock.initLocked(),
+                .lock = .{},
                 .allocator = allocator,
             };
         }

--- a/lib/std/event/locked.zig
+++ b/lib/std/event/locked.zig
@@ -22,7 +22,7 @@ pub fn Locked(comptime T: type) type {
 
         pub fn init(data: T) Self {
             return Self{
-                .lock = Lock.init(),
+                .lock = .{},
                 .private_data = data,
             };
         }


### PR DESCRIPTION
#### Fixes issue #11924 
#### init funcion used init() to initialize a std.event.Lock. std.event.Lock does not have init() function. Corrected to initLocked(). 