### PR TITLE
std/crypto/{25519,pcurves}: make the scalar field order public

### DIFF
--- a/lib/std/crypto/pcurves/p256/scalar.zig
+++ b/lib/std/crypto/pcurves/p256/scalar.zig
@@ -24,6 +24,9 @@ const Fe = Field(.{
     .encoded_length = encoded_length,
 });
 
+/// The scalar field order.
+pub const field_order = Fe.field_order;
+
 /// Reject a scalar whose encoding is not canonical.
 pub fn rejectNonCanonical(s: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!void {
     return Fe.rejectNonCanonical(s, endian);
@@ -61,7 +64,7 @@ pub fn neg(s: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!Co
 
 /// Return (a-b) (mod L)
 pub fn sub(a: CompressedScalar, b: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!CompressedScalar {
-    return (try Scalar.fromBytes(a, endian)).sub(try Scalar.fromBytes(b.endian)).toBytes(endian);
+    return (try Scalar.fromBytes(a, endian)).sub(try Scalar.fromBytes(b, endian)).toBytes(endian);
 }
 
 /// Return a random scalar

--- a/lib/std/crypto/pcurves/p384/scalar.zig
+++ b/lib/std/crypto/pcurves/p384/scalar.zig
@@ -24,6 +24,9 @@ const Fe = Field(.{
     .encoded_length = encoded_length,
 });
 
+/// The scalar field order.
+pub const field_order = Fe.field_order;
+
 /// Reject a scalar whose encoding is not canonical.
 pub fn rejectNonCanonical(s: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!void {
     return Fe.rejectNonCanonical(s, endian);
@@ -56,7 +59,7 @@ pub fn neg(s: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!Co
 
 /// Return (a-b) (mod L)
 pub fn sub(a: CompressedScalar, b: CompressedScalar, endian: std.builtin.Endian) NonCanonicalError!CompressedScalar {
-    return (try Scalar.fromBytes(a, endian)).sub(try Scalar.fromBytes(b.endian)).toBytes(endian);
+    return (try Scalar.fromBytes(a, endian)).sub(try Scalar.fromBytes(b, endian)).toBytes(endian);
 }
 
 /// Return a random scalar


### PR DESCRIPTION
For 25519, it's very likely that applications would ever need the serialized representation. Expose the value as an integer as in other curves. Rename the internal representation from `field_size` to `field_order` for consistency.

Also fix a common typo in `scalar.sub()`.