### PR TITLE
std.math.big.int: breaking API changes to prevent UAF

### DIFF
--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -166,7 +166,7 @@ test "big.int bitcount + sizeInBaseUpperBound" {
     try testing.expect(a.sizeInBaseUpperBound(2) >= 32);
     try testing.expect(a.sizeInBaseUpperBound(10) >= 10);
 
-    try a.shiftLeft(a, 5000);
+    try a.shiftLeft(&a, 5000);
     try testing.expect(a.bitCountAbs() == 5032);
     try testing.expect(a.sizeInBaseUpperBound(2) >= 5032);
     a.setSign(false);
@@ -486,7 +486,7 @@ test "big.int add single-single" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.add(a.toConst(), b.toConst());
+    try c.add(&a, &b);
 
     try testing.expect((try c.to(u32)) == 55);
 }
@@ -500,10 +500,10 @@ test "big.int add multi-single" {
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
 
-    try c.add(a.toConst(), b.toConst());
+    try c.add(&a, &b);
     try testing.expect((try c.to(DoubleLimb)) == maxInt(Limb) + 2);
 
-    try c.add(b.toConst(), a.toConst());
+    try c.add(&b, &a);
     try testing.expect((try c.to(DoubleLimb)) == maxInt(Limb) + 2);
 }
 
@@ -517,7 +517,7 @@ test "big.int add multi-multi" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.add(a.toConst(), b.toConst());
+    try c.add(&a, &b);
 
     try testing.expect((try c.to(u128)) == op1 + op2);
 }
@@ -530,7 +530,7 @@ test "big.int add zero-zero" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.add(a.toConst(), b.toConst());
+    try c.add(&a, &b);
 
     try testing.expect((try c.to(u32)) == 0);
 }
@@ -542,7 +542,7 @@ test "big.int add alias multi-limb nonzero-zero" {
     var b = try Managed.initSet(testing.allocator, 0);
     defer b.deinit();
 
-    try a.add(a.toConst(), b.toConst());
+    try a.add(&a, &b);
 
     try testing.expect((try a.to(u128)) == op1);
 }
@@ -560,16 +560,16 @@ test "big.int add sign" {
     var neg_two = try Managed.initSet(testing.allocator, -2);
     defer neg_two.deinit();
 
-    try a.add(one.toConst(), two.toConst());
+    try a.add(&one, &two);
     try testing.expect((try a.to(i32)) == 3);
 
-    try a.add(neg_one.toConst(), two.toConst());
+    try a.add(&neg_one, &two);
     try testing.expect((try a.to(i32)) == 1);
 
-    try a.add(one.toConst(), neg_two.toConst());
+    try a.add(&one, &neg_two);
     try testing.expect((try a.to(i32)) == -1);
 
-    try a.add(neg_one.toConst(), neg_two.toConst());
+    try a.add(&neg_one, &neg_two);
     try testing.expect((try a.to(i32)) == -3);
 }
 
@@ -579,7 +579,7 @@ test "big.int add scalar" {
 
     var b = try Managed.init(testing.allocator);
     defer b.deinit();
-    try b.addScalar(a.toConst(), 5);
+    try b.addScalar(&a, 5);
 
     try testing.expect((try b.to(u32)) == 55);
 }
@@ -591,7 +591,7 @@ test "big.int addWrap single-single, unsigned" {
     var b = try Managed.initSet(testing.allocator, 10);
     defer b.deinit();
 
-    const wrapped = try a.addWrap(a.toConst(), b.toConst(), .unsigned, 17);
+    const wrapped = try a.addWrap(&a, &b, .unsigned, 17);
 
     try testing.expect(wrapped);
     try testing.expect((try a.to(u17)) == 9);
@@ -604,7 +604,7 @@ test "big.int subWrap single-single, unsigned" {
     var b = try Managed.initSet(testing.allocator, maxInt(u17));
     defer b.deinit();
 
-    const wrapped = try a.subWrap(a.toConst(), b.toConst(), .unsigned, 17);
+    const wrapped = try a.subWrap(&a, &b, .unsigned, 17);
 
     try testing.expect(wrapped);
     try testing.expect((try a.to(u17)) == 1);
@@ -617,7 +617,7 @@ test "big.int addWrap multi-multi, unsigned, limb aligned" {
     var b = try Managed.initSet(testing.allocator, maxInt(DoubleLimb));
     defer b.deinit();
 
-    const wrapped = try a.addWrap(a.toConst(), b.toConst(), .unsigned, @bitSizeOf(DoubleLimb));
+    const wrapped = try a.addWrap(&a, &b, .unsigned, @bitSizeOf(DoubleLimb));
 
     try testing.expect(wrapped);
     try testing.expect((try a.to(DoubleLimb)) == maxInt(DoubleLimb) - 1);
@@ -630,7 +630,7 @@ test "big.int subWrap single-multi, unsigned, limb aligned" {
     var b = try Managed.initSet(testing.allocator, maxInt(DoubleLimb) + 100);
     defer b.deinit();
 
-    const wrapped = try a.subWrap(a.toConst(), b.toConst(), .unsigned, @bitSizeOf(DoubleLimb));
+    const wrapped = try a.subWrap(&a, &b, .unsigned, @bitSizeOf(DoubleLimb));
 
     try testing.expect(wrapped);
     try testing.expect((try a.to(DoubleLimb)) == maxInt(DoubleLimb) - 88);
@@ -643,7 +643,7 @@ test "big.int addWrap single-single, signed" {
     var b = try Managed.initSet(testing.allocator, 1 + 1 + maxInt(u21));
     defer b.deinit();
 
-    const wrapped = try a.addWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(i21));
+    const wrapped = try a.addWrap(&a, &b, .signed, @bitSizeOf(i21));
 
     try testing.expect(wrapped);
     try testing.expect((try a.to(i21)) == minInt(i21));
@@ -656,7 +656,7 @@ test "big.int subWrap single-single, signed" {
     var b = try Managed.initSet(testing.allocator, 1);
     defer b.deinit();
 
-    const wrapped = try a.subWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(i21));
+    const wrapped = try a.subWrap(&a, &b, .signed, @bitSizeOf(i21));
 
     try testing.expect(wrapped);
     try testing.expect((try a.to(i21)) == maxInt(i21));
@@ -669,7 +669,7 @@ test "big.int addWrap multi-multi, signed, limb aligned" {
     var b = try Managed.initSet(testing.allocator, maxInt(SignedDoubleLimb));
     defer b.deinit();
 
-    const wrapped = try a.addWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(SignedDoubleLimb));
+    const wrapped = try a.addWrap(&a, &b, .signed, @bitSizeOf(SignedDoubleLimb));
 
     try testing.expect(wrapped);
     try testing.expect((try a.to(SignedDoubleLimb)) == -2);
@@ -682,7 +682,7 @@ test "big.int subWrap single-multi, signed, limb aligned" {
     var b = try Managed.initSet(testing.allocator, 1);
     defer b.deinit();
 
-    const wrapped = try a.subWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(SignedDoubleLimb));
+    const wrapped = try a.subWrap(&a, &b, .signed, @bitSizeOf(SignedDoubleLimb));
 
     try testing.expect(wrapped);
     try testing.expect((try a.to(SignedDoubleLimb)) == maxInt(SignedDoubleLimb));
@@ -695,7 +695,7 @@ test "big.int addSat single-single, unsigned" {
     var b = try Managed.initSet(testing.allocator, 10);
     defer b.deinit();
 
-    try a.addSat(a.toConst(), b.toConst(), .unsigned, 17);
+    try a.addSat(&a, &b, .unsigned, 17);
 
     try testing.expect((try a.to(u17)) == maxInt(u17));
 }
@@ -707,7 +707,7 @@ test "big.int subSat single-single, unsigned" {
     var b = try Managed.initSet(testing.allocator, 4000);
     defer b.deinit();
 
-    try a.subSat(a.toConst(), b.toConst(), .unsigned, 17);
+    try a.subSat(&a, &b, .unsigned, 17);
 
     try testing.expect((try a.to(u17)) == 0);
 }
@@ -719,7 +719,7 @@ test "big.int addSat multi-multi, unsigned, limb aligned" {
     var b = try Managed.initSet(testing.allocator, maxInt(DoubleLimb));
     defer b.deinit();
 
-    try a.addSat(a.toConst(), b.toConst(), .unsigned, @bitSizeOf(DoubleLimb));
+    try a.addSat(&a, &b, .unsigned, @bitSizeOf(DoubleLimb));
 
     try testing.expect((try a.to(DoubleLimb)) == maxInt(DoubleLimb));
 }
@@ -731,7 +731,7 @@ test "big.int subSat single-multi, unsigned, limb aligned" {
     var b = try Managed.initSet(testing.allocator, maxInt(DoubleLimb) + 100);
     defer b.deinit();
 
-    try a.subSat(a.toConst(), b.toConst(), .unsigned, @bitSizeOf(DoubleLimb));
+    try a.subSat(&a, &b, .unsigned, @bitSizeOf(DoubleLimb));
 
     try testing.expect((try a.to(DoubleLimb)) == 0);
 }
@@ -743,7 +743,7 @@ test "big.int addSat single-single, signed" {
     var b = try Managed.initSet(testing.allocator, 1);
     defer b.deinit();
 
-    try a.addSat(a.toConst(), b.toConst(), .signed, @bitSizeOf(i14));
+    try a.addSat(&a, &b, .signed, @bitSizeOf(i14));
 
     try testing.expect((try a.to(i14)) == maxInt(i14));
 }
@@ -755,7 +755,7 @@ test "big.int subSat single-single, signed" {
     var b = try Managed.initSet(testing.allocator, 1);
     defer b.deinit();
 
-    try a.subSat(a.toConst(), b.toConst(), .signed, @bitSizeOf(i21));
+    try a.subSat(&a, &b, .signed, @bitSizeOf(i21));
 
     try testing.expect((try a.to(i21)) == minInt(i21));
 }
@@ -767,7 +767,7 @@ test "big.int addSat multi-multi, signed, limb aligned" {
     var b = try Managed.initSet(testing.allocator, maxInt(SignedDoubleLimb));
     defer b.deinit();
 
-    try a.addSat(a.toConst(), b.toConst(), .signed, @bitSizeOf(SignedDoubleLimb));
+    try a.addSat(&a, &b, .signed, @bitSizeOf(SignedDoubleLimb));
 
     try testing.expect((try a.to(SignedDoubleLimb)) == maxInt(SignedDoubleLimb));
 }
@@ -779,7 +779,7 @@ test "big.int subSat single-multi, signed, limb aligned" {
     var b = try Managed.initSet(testing.allocator, 1);
     defer b.deinit();
 
-    try a.subSat(a.toConst(), b.toConst(), .signed, @bitSizeOf(SignedDoubleLimb));
+    try a.subSat(&a, &b, .signed, @bitSizeOf(SignedDoubleLimb));
 
     try testing.expect((try a.to(SignedDoubleLimb)) == minInt(SignedDoubleLimb));
 }
@@ -792,7 +792,7 @@ test "big.int sub single-single" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.sub(a.toConst(), b.toConst());
+    try c.sub(&a, &b);
 
     try testing.expect((try c.to(u32)) == 45);
 }
@@ -805,7 +805,7 @@ test "big.int sub multi-single" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.sub(a.toConst(), b.toConst());
+    try c.sub(&a, &b);
 
     try testing.expect((try c.to(Limb)) == maxInt(Limb));
 }
@@ -821,7 +821,7 @@ test "big.int sub multi-multi" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.sub(a.toConst(), b.toConst());
+    try c.sub(&a, &b);
 
     try testing.expect((try c.to(u128)) == op1 - op2);
 }
@@ -834,7 +834,7 @@ test "big.int sub equal" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.sub(a.toConst(), b.toConst());
+    try c.sub(&a, &b);
 
     try testing.expect((try c.to(u32)) == 0);
 }
@@ -852,19 +852,19 @@ test "big.int sub sign" {
     var neg_two = try Managed.initSet(testing.allocator, -2);
     defer neg_two.deinit();
 
-    try a.sub(one.toConst(), two.toConst());
+    try a.sub(&one, &two);
     try testing.expect((try a.to(i32)) == -1);
 
-    try a.sub(neg_one.toConst(), two.toConst());
+    try a.sub(&neg_one, &two);
     try testing.expect((try a.to(i32)) == -3);
 
-    try a.sub(one.toConst(), neg_two.toConst());
+    try a.sub(&one, &neg_two);
     try testing.expect((try a.to(i32)) == 3);
 
-    try a.sub(neg_one.toConst(), neg_two.toConst());
+    try a.sub(&neg_one, &neg_two);
     try testing.expect((try a.to(i32)) == 1);
 
-    try a.sub(neg_two.toConst(), neg_one.toConst());
+    try a.sub(&neg_two, &neg_one);
     try testing.expect((try a.to(i32)) == -1);
 }
 
@@ -876,7 +876,7 @@ test "big.int mul single-single" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.mul(a.toConst(), b.toConst());
+    try c.mul(&a, &b);
 
     try testing.expect((try c.to(u64)) == 250);
 }
@@ -889,7 +889,7 @@ test "big.int mul multi-single" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.mul(a.toConst(), b.toConst());
+    try c.mul(&a, &b);
 
     try testing.expect((try c.to(DoubleLimb)) == 2 * maxInt(Limb));
 }
@@ -904,7 +904,7 @@ test "big.int mul multi-multi" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.mul(a.toConst(), b.toConst());
+    try c.mul(&a, &b);
 
     try testing.expect((try c.to(u256)) == op1 * op2);
 }
@@ -915,7 +915,7 @@ test "big.int mul alias r with a" {
     var b = try Managed.initSet(testing.allocator, 2);
     defer b.deinit();
 
-    try a.mul(a.toConst(), b.toConst());
+    try a.mul(&a, &b);
 
     try testing.expect((try a.to(DoubleLimb)) == 2 * maxInt(Limb));
 }
@@ -926,7 +926,7 @@ test "big.int mul alias r with b" {
     var b = try Managed.initSet(testing.allocator, 2);
     defer b.deinit();
 
-    try a.mul(b.toConst(), a.toConst());
+    try a.mul(&b, &a);
 
     try testing.expect((try a.to(DoubleLimb)) == 2 * maxInt(Limb));
 }
@@ -935,7 +935,7 @@ test "big.int mul alias r with a and b" {
     var a = try Managed.initSet(testing.allocator, maxInt(Limb));
     defer a.deinit();
 
-    try a.mul(a.toConst(), a.toConst());
+    try a.mul(&a, &a);
 
     try testing.expect((try a.to(DoubleLimb)) == maxInt(Limb) * maxInt(Limb));
 }
@@ -948,7 +948,7 @@ test "big.int mul a*0" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.mul(a.toConst(), b.toConst());
+    try c.mul(&a, &b);
 
     try testing.expect((try c.to(u32)) == 0);
 }
@@ -961,7 +961,7 @@ test "big.int mul 0*0" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.mul(a.toConst(), b.toConst());
+    try c.mul(&a, &b);
 
     try testing.expect((try c.to(u32)) == 0);
 }
@@ -981,8 +981,8 @@ test "big.int mul large" {
     }
     a.setMetadata(true, 50);
 
-    try b.mul(a.toConst(), a.toConst());
-    try c.sqr(a.toConst());
+    try b.mul(&a, &a);
+    try c.sqr(&a);
 
     try testing.expect(b.eq(c));
 }
@@ -995,7 +995,7 @@ test "big.int mulWrap single-single unsigned" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.mulWrap(a.toConst(), b.toConst(), .unsigned, 17);
+    try c.mulWrap(&a, &b, .unsigned, 17);
 
     try testing.expect((try c.to(u17)) == 59836);
 }
@@ -1008,7 +1008,7 @@ test "big.int mulWrap single-single signed" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.mulWrap(a.toConst(), b.toConst(), .signed, 17);
+    try c.mulWrap(&a, &b, .signed, 17);
 
     try testing.expect((try c.to(i17)) == -59836);
 }
@@ -1023,7 +1023,7 @@ test "big.int mulWrap multi-multi unsigned" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.mulWrap(a.toConst(), b.toConst(), .unsigned, 65);
+    try c.mulWrap(&a, &b, .unsigned, 65);
 
     try testing.expect((try c.to(u128)) == (op1 * op2) & ((1 << 65) - 1));
 }
@@ -1036,7 +1036,7 @@ test "big.int mulWrap multi-multi signed" {
 
     var c = try Managed.init(testing.allocator);
     defer c.deinit();
-    try c.mulWrap(a.toConst(), b.toConst(), .signed, @bitSizeOf(SignedDoubleLimb));
+    try c.mulWrap(&a, &b, .signed, @bitSizeOf(SignedDoubleLimb));
 
     try testing.expect((try c.to(SignedDoubleLimb)) == minInt(SignedDoubleLimb) + 2);
 }
@@ -1058,9 +1058,9 @@ test "big.int mulWrap large" {
 
     const testbits = @bitSizeOf(Limb) * 64 + 45;
 
-    try b.mulWrap(a.toConst(), a.toConst(), .signed, testbits);
-    try c.sqr(a.toConst());
-    try c.truncate(c.toConst(), .signed, testbits);
+    try b.mulWrap(&a, &a, .signed, testbits);
+    try c.sqr(&a);
+    try c.truncate(&c, .signed, testbits);
 
     try testing.expect(b.eq(c));
 }
@@ -1075,7 +1075,7 @@ test "big.int div single-half no rem" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u32)) == 10);
     try testing.expect((try r.to(u32)) == 0);
@@ -1091,7 +1091,7 @@ test "big.int div single-half with rem" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u32)) == 9);
     try testing.expect((try r.to(u32)) == 4);
@@ -1108,7 +1108,7 @@ test "big.int div single-single no rem" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u32)) == 131072);
     try testing.expect((try r.to(u32)) == 0);
@@ -1124,7 +1124,7 @@ test "big.int div single-single with rem" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u64)) == 131072);
     try testing.expect((try r.to(u64)) == 8589934592);
@@ -1143,7 +1143,7 @@ test "big.int div multi-single no rem" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u64)) == op1 / op2);
     try testing.expect((try r.to(u64)) == 0);
@@ -1162,7 +1162,7 @@ test "big.int div multi-single with rem" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u64)) == op1 / op2);
     try testing.expect((try r.to(u64)) == 3);
@@ -1181,7 +1181,7 @@ test "big.int div multi>2-single" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u128)) == op1 / op2);
     try testing.expect((try r.to(u32)) == 0x3e4e);
@@ -1197,7 +1197,7 @@ test "big.int div single-single q < r" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u64)) == 0);
     try testing.expect((try r.to(u64)) == 0x0078f432);
@@ -1213,7 +1213,7 @@ test "big.int div single-single q == r" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u64)) == 1);
     try testing.expect((try r.to(u64)) == 0);
@@ -1225,7 +1225,7 @@ test "big.int div q=0 alias" {
     var b = try Managed.initSet(testing.allocator, 10);
     defer b.deinit();
 
-    try Managed.divTrunc(&a, &b, a.toConst(), b.toConst());
+    try Managed.divTrunc(&a, &b, &a, &b);
 
     try testing.expect((try a.to(u64)) == 0);
     try testing.expect((try b.to(u64)) == 3);
@@ -1243,7 +1243,7 @@ test "big.int div multi-multi q < r" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u128)) == 0);
     try testing.expect((try r.to(u128)) == op1);
@@ -1262,7 +1262,7 @@ test "big.int div trunc single-single +/+" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     // n = q * d + r
     // 5 = 1 * 3 + 2
@@ -1286,7 +1286,7 @@ test "big.int div trunc single-single -/+" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     //  n = q *  d + r
     // -5 = 1 * -3 - 2
@@ -1310,7 +1310,7 @@ test "big.int div trunc single-single +/-" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     // n =  q *  d + r
     // 5 = -1 * -3 + 2
@@ -1334,7 +1334,7 @@ test "big.int div trunc single-single -/-" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     //  n = q *  d + r
     // -5 = 1 * -3 - 2
@@ -1361,7 +1361,7 @@ test "big.int divFloor #10932" {
     var mod = try Managed.init(testing.allocator);
     defer mod.deinit();
 
-    try res.divFloor(&mod, a.toConst(), b.toConst());
+    try res.divFloor(&mod, &a, &b);
 
     const ress = try res.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(ress);
@@ -1385,7 +1385,7 @@ test "big.int divFloor #11166" {
     var mod = try Managed.init(testing.allocator);
     defer mod.deinit();
 
-    try res.divFloor(&mod, a.toConst(), b.toConst());
+    try res.divFloor(&mod, &a, &b);
 
     const ress = try res.toString(testing.allocator, 10, .lower);
     defer testing.allocator.free(ress);
@@ -1409,7 +1409,7 @@ test "big.int gcd #10932" {
     try a.setString(10, "3000000000000000000000000000000000000000000000000000000000000000000000001461501637330902918203684832716283019655932542975000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
     try b.setString(10, "10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200001001500000000000000000100000000040000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000003000000000000000000000000000000000000000000000000000058715661000000000000000000000000000000000000023553252000000000180000000000000000000000000000000000000000000000000250000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001005000002000000000000000000000000000000000000000021000000001000000000000000000000000100000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000200000000000000000000004000000000000000000000000000000000000000000000301000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
 
-    try res.gcd(a, b);
+    try res.gcd(&a, &b);
 
     const ress = try res.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(ress);
@@ -1429,7 +1429,7 @@ test "big.int bitAnd #10932" {
     try a.setString(10, "154954885951624787839743960731760616696");
     try b.setString(10, "55000000000915215865915724129619485917228346934191537590366734850266784978214506142389798064826139649163838075568111457203909393174933092857416500785632012953993352521899237655507306575657169267399324107627651067352600878339870446048204062696260567762088867991835386857942106708741836433444432529637331429212430394179472179237695833247299409249810963487516399177133175950185719220422442438098353430605822151595560743492661038899294517012784306863064670126197566982968906306814338148792888550378533207318063660581924736840687332023636827401670268933229183389040490792300121030647791095178823932734160000000000000000000000000000000000000555555550000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
 
-    try res.bitAnd(a, b);
+    try res.bitAnd(&a, &b);
 
     try testing.expect((try res.to(i32)) == 0);
 }
@@ -1447,7 +1447,7 @@ test "big.int div floor single-single +/+" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divFloor(&q, &r, a.toConst(), b.toConst());
+    try Managed.divFloor(&q, &r, &a, &b);
 
     //  n =  q *  d + r
     //  5 =  1 *  3 + 2
@@ -1471,7 +1471,7 @@ test "big.int div floor single-single -/+" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divFloor(&q, &r, a.toConst(), b.toConst());
+    try Managed.divFloor(&q, &r, &a, &b);
 
     //  n =  q *  d + r
     // -5 = -2 *  3 + 1
@@ -1495,7 +1495,7 @@ test "big.int div floor single-single +/-" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divFloor(&q, &r, a.toConst(), b.toConst());
+    try Managed.divFloor(&q, &r, &a, &b);
 
     //  n =  q *  d + r
     //  5 = -2 * -3 - 1
@@ -1519,7 +1519,7 @@ test "big.int div floor single-single -/-" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divFloor(&q, &r, a.toConst(), b.toConst());
+    try Managed.divFloor(&q, &r, &a, &b);
 
     //  n =  q *  d + r
     // -5 =  2 * -3 + 1
@@ -1543,7 +1543,7 @@ test "big.int div floor no remainder negative quotient" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divFloor(&q, &r, a.toConst(), b.toConst());
+    try Managed.divFloor(&q, &r, &a, &b);
 
     try testing.expect((try q.to(i32)) == -0x80000000);
     try testing.expect((try r.to(i32)) == 0);
@@ -1562,7 +1562,7 @@ test "big.int div floor negative close to zero" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divFloor(&q, &r, a.toConst(), b.toConst());
+    try Managed.divFloor(&q, &r, &a, &b);
 
     try testing.expect((try q.to(i32)) == -1);
     try testing.expect((try r.to(i32)) == 10);
@@ -1581,7 +1581,7 @@ test "big.int div floor positive close to zero" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divFloor(&q, &r, a.toConst(), b.toConst());
+    try Managed.divFloor(&q, &r, &a, &b);
 
     try testing.expect((try q.to(i32)) == 0);
     try testing.expect((try r.to(i32)) == 10);
@@ -1597,7 +1597,7 @@ test "big.int div multi-multi with rem" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u128)) == 0xe38f38e39161aaabd03f0f1b);
     try testing.expect((try r.to(u128)) == 0x28de0acacd806823638);
@@ -1613,7 +1613,7 @@ test "big.int div multi-multi no rem" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u128)) == 0xe38f38e39161aaabd03f0f1b);
     try testing.expect((try r.to(u128)) == 0);
@@ -1629,7 +1629,7 @@ test "big.int div multi-multi (2 branch)" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u128)) == 0x10000000000000000);
     try testing.expect((try r.to(u128)) == 0x44444443444444431111111111111111);
@@ -1645,7 +1645,7 @@ test "big.int div multi-multi (3.1/3.3 branch)" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u128)) == 0xfffffffffffffffffff);
     try testing.expect((try r.to(u256)) == 0x1111111111111111111110b12222222222222222282);
@@ -1661,7 +1661,7 @@ test "big.int div multi-single zero-limb trailing" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     var expected = try Managed.initSet(testing.allocator, 0x6000000000000000000000000000000000000000000000000);
     defer expected.deinit();
@@ -1679,7 +1679,7 @@ test "big.int div multi-multi zero-limb trailing (with rem)" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u128)) == 0x10000000000000000);
 
@@ -1698,7 +1698,7 @@ test "big.int div multi-multi zero-limb trailing (with rem) and dividend zero-li
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     try testing.expect((try q.to(u128)) == 0x1);
 
@@ -1717,7 +1717,7 @@ test "big.int div multi-multi zero-limb trailing (with rem) and dividend zero-li
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     const qs = try q.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(qs);
@@ -1741,7 +1741,7 @@ test "big.int div multi-multi fuzz case #1" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     const qs = try q.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(qs);
@@ -1765,7 +1765,7 @@ test "big.int div multi-multi fuzz case #2" {
     defer q.deinit();
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
-    try Managed.divTrunc(&q, &r, a.toConst(), b.toConst());
+    try Managed.divTrunc(&q, &r, &a, &b);
 
     const qs = try q.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(qs);
@@ -1780,7 +1780,7 @@ test "big.int truncate single unsigned" {
     var a = try Managed.initSet(testing.allocator, maxInt(u47));
     defer a.deinit();
 
-    try a.truncate(a.toConst(), .unsigned, 17);
+    try a.truncate(&a, .unsigned, 17);
 
     try testing.expect((try a.to(u17)) == maxInt(u17));
 }
@@ -1789,7 +1789,7 @@ test "big.int truncate single signed" {
     var a = try Managed.initSet(testing.allocator, 0x1_0000);
     defer a.deinit();
 
-    try a.truncate(a.toConst(), .signed, 17);
+    try a.truncate(&a, .signed, 17);
 
     try testing.expect((try a.to(i17)) == minInt(i17));
 }
@@ -1798,7 +1798,7 @@ test "big.int truncate multi to single unsigned" {
     var a = try Managed.initSet(testing.allocator, (maxInt(Limb) + 1) | 0x1234_5678_9ABC_DEF0);
     defer a.deinit();
 
-    try a.truncate(a.toConst(), .unsigned, 27);
+    try a.truncate(&a, .unsigned, 27);
 
     try testing.expect((try a.to(u27)) == 0x2BC_DEF0);
 }
@@ -1807,7 +1807,7 @@ test "big.int truncate multi to single signed" {
     var a = try Managed.initSet(testing.allocator, maxInt(Limb) << 10);
     defer a.deinit();
 
-    try a.truncate(a.toConst(), .signed, @bitSizeOf(i11));
+    try a.truncate(&a, .signed, @bitSizeOf(i11));
 
     try testing.expect((try a.to(i11)) == minInt(i11));
 }
@@ -1819,7 +1819,7 @@ test "big.int truncate multi to multi unsigned" {
     var a = try Managed.initSet(testing.allocator, maxInt(SignedDoubleLimb));
     defer a.deinit();
 
-    try a.truncate(a.toConst(), .unsigned, bits - 1);
+    try a.truncate(&a, .unsigned, bits - 1);
 
     try testing.expect((try a.to(Int)) == maxInt(Int));
 }
@@ -1828,7 +1828,7 @@ test "big.int truncate multi to multi signed" {
     var a = try Managed.initSet(testing.allocator, 3 << @bitSizeOf(Limb));
     defer a.deinit();
 
-    try a.truncate(a.toConst(), .signed, @bitSizeOf(Limb) + 1);
+    try a.truncate(&a, .signed, @bitSizeOf(Limb) + 1);
 
     try testing.expect((try a.to(std.meta.Int(.signed, @bitSizeOf(Limb) + 1))) == -1 << @bitSizeOf(Limb));
 }
@@ -1837,7 +1837,7 @@ test "big.int truncate negative multi to single" {
     var a = try Managed.initSet(testing.allocator, -@as(SignedDoubleLimb, maxInt(Limb) + 1));
     defer a.deinit();
 
-    try a.truncate(a.toConst(), .signed, @bitSizeOf(i17));
+    try a.truncate(&a, .signed, @bitSizeOf(i17));
 
     try testing.expect((try a.to(i17)) == 0);
 }
@@ -1845,11 +1845,11 @@ test "big.int truncate negative multi to single" {
 test "big.int truncate multi unsigned many" {
     var a = try Managed.initSet(testing.allocator, 1);
     defer a.deinit();
-    try a.shiftLeft(a, 1023);
+    try a.shiftLeft(&a, 1023);
 
     var b = try Managed.init(testing.allocator);
     defer b.deinit();
-    try b.truncate(a.toConst(), .signed, @bitSizeOf(i1));
+    try b.truncate(&a, .signed, @bitSizeOf(i1));
 
     try testing.expect((try b.to(i1)) == 0);
 }
@@ -1858,7 +1858,7 @@ test "big.int saturate single signed positive" {
     var a = try Managed.initSet(testing.allocator, 0xBBBB_BBBB);
     defer a.deinit();
 
-    try a.saturate(a.toConst(), .signed, 17);
+    try a.saturate(&a, .signed, 17);
 
     try testing.expect((try a.to(i17)) == maxInt(i17));
 }
@@ -1867,7 +1867,7 @@ test "big.int saturate single signed negative" {
     var a = try Managed.initSet(testing.allocator, -1_234_567);
     defer a.deinit();
 
-    try a.saturate(a.toConst(), .signed, 17);
+    try a.saturate(&a, .signed, 17);
 
     try testing.expect((try a.to(i17)) == minInt(i17));
 }
@@ -1876,7 +1876,7 @@ test "big.int saturate single signed" {
     var a = try Managed.initSet(testing.allocator, maxInt(i17) - 1);
     defer a.deinit();
 
-    try a.saturate(a.toConst(), .signed, 17);
+    try a.saturate(&a, .signed, 17);
 
     try testing.expect((try a.to(i17)) == maxInt(i17) - 1);
 }
@@ -1885,7 +1885,7 @@ test "big.int saturate multi signed" {
     var a = try Managed.initSet(testing.allocator, maxInt(Limb) << @bitSizeOf(SignedDoubleLimb));
     defer a.deinit();
 
-    try a.saturate(a.toConst(), .signed, @bitSizeOf(SignedDoubleLimb));
+    try a.saturate(&a, .signed, @bitSizeOf(SignedDoubleLimb));
 
     try testing.expect((try a.to(SignedDoubleLimb)) == maxInt(SignedDoubleLimb));
 }
@@ -1894,7 +1894,7 @@ test "big.int saturate single unsigned" {
     var a = try Managed.initSet(testing.allocator, 0xFEFE_FEFE);
     defer a.deinit();
 
-    try a.saturate(a.toConst(), .unsigned, 23);
+    try a.saturate(&a, .unsigned, 23);
 
     try testing.expect((try a.to(u23)) == maxInt(u23));
 }
@@ -1903,7 +1903,7 @@ test "big.int saturate multi unsigned zero" {
     var a = try Managed.initSet(testing.allocator, -1);
     defer a.deinit();
 
-    try a.saturate(a.toConst(), .unsigned, @bitSizeOf(DoubleLimb));
+    try a.saturate(&a, .unsigned, @bitSizeOf(DoubleLimb));
 
     try testing.expect(a.eqZero());
 }
@@ -1912,7 +1912,7 @@ test "big.int saturate multi unsigned" {
     var a = try Managed.initSet(testing.allocator, maxInt(Limb) << @bitSizeOf(DoubleLimb));
     defer a.deinit();
 
-    try a.saturate(a.toConst(), .unsigned, @bitSizeOf(DoubleLimb));
+    try a.saturate(&a, .unsigned, @bitSizeOf(DoubleLimb));
 
     try testing.expect((try a.to(DoubleLimb)) == maxInt(DoubleLimb));
 }
@@ -1920,7 +1920,7 @@ test "big.int saturate multi unsigned" {
 test "big.int shift-right single" {
     var a = try Managed.initSet(testing.allocator, 0xffff0000);
     defer a.deinit();
-    try a.shiftRight(a, 16);
+    try a.shiftRight(&a, 16);
 
     try testing.expect((try a.to(u32)) == 0xffff);
 }
@@ -1928,21 +1928,21 @@ test "big.int shift-right single" {
 test "big.int shift-right multi" {
     var a = try Managed.initSet(testing.allocator, 0xffff0000eeee1111dddd2222cccc3333);
     defer a.deinit();
-    try a.shiftRight(a, 67);
+    try a.shiftRight(&a, 67);
 
     try testing.expect((try a.to(u64)) == 0x1fffe0001dddc222);
 
     try a.set(0xffff0000eeee1111dddd2222cccc3333);
-    try a.shiftRight(a, 63);
-    try a.shiftRight(a, 63);
-    try a.shiftRight(a, 2);
+    try a.shiftRight(&a, 63);
+    try a.shiftRight(&a, 63);
+    try a.shiftRight(&a, 2);
     try testing.expect(a.eqZero());
 }
 
 test "big.int shift-left single" {
     var a = try Managed.initSet(testing.allocator, 0xffff);
     defer a.deinit();
-    try a.shiftLeft(a, 16);
+    try a.shiftLeft(&a, 16);
 
     try testing.expect((try a.to(u64)) == 0xffff0000);
 }
@@ -1950,7 +1950,7 @@ test "big.int shift-left single" {
 test "big.int shift-left multi" {
     var a = try Managed.initSet(testing.allocator, 0x1fffe0001dddc222);
     defer a.deinit();
-    try a.shiftLeft(a, 67);
+    try a.shiftLeft(&a, 67);
 
     try testing.expect((try a.to(u128)) == 0xffff0000eeee11100000000000000000);
 }
@@ -1961,12 +1961,12 @@ test "big.int shift-right negative" {
 
     var arg = try Managed.initSet(testing.allocator, -20);
     defer arg.deinit();
-    try a.shiftRight(arg, 2);
+    try a.shiftRight(&arg, 2);
     try testing.expect((try a.to(i32)) == -20 >> 2);
 
     var arg2 = try Managed.initSet(testing.allocator, -5);
     defer arg2.deinit();
-    try a.shiftRight(arg2, 10);
+    try a.shiftRight(&arg2, 10);
     try testing.expect((try a.to(i32)) == -5 >> 10);
 }
 
@@ -1976,14 +1976,14 @@ test "big.int shift-left negative" {
 
     var arg = try Managed.initSet(testing.allocator, -10);
     defer arg.deinit();
-    try a.shiftRight(arg, 1232);
+    try a.shiftRight(&arg, 1232);
     try testing.expect((try a.to(i32)) == -10 >> 1232);
 }
 
 test "big.int sat shift-left simple unsigned" {
     var a = try Managed.initSet(testing.allocator, 0xffff);
     defer a.deinit();
-    try a.shiftLeftSat(a, 16, .unsigned, 21);
+    try a.shiftLeftSat(&a, 16, .unsigned, 21);
 
     try testing.expect((try a.to(u64)) == 0x1fffff);
 }
@@ -1991,7 +1991,7 @@ test "big.int sat shift-left simple unsigned" {
 test "big.int sat shift-left simple unsigned no sat" {
     var a = try Managed.initSet(testing.allocator, 1);
     defer a.deinit();
-    try a.shiftLeftSat(a, 16, .unsigned, 21);
+    try a.shiftLeftSat(&a, 16, .unsigned, 21);
 
     try testing.expect((try a.to(u64)) == 0x10000);
 }
@@ -1999,7 +1999,7 @@ test "big.int sat shift-left simple unsigned no sat" {
 test "big.int sat shift-left multi unsigned" {
     var a = try Managed.initSet(testing.allocator, 16);
     defer a.deinit();
-    try a.shiftLeftSat(a, @bitSizeOf(DoubleLimb) - 3, .unsigned, @bitSizeOf(DoubleLimb) - 1);
+    try a.shiftLeftSat(&a, @bitSizeOf(DoubleLimb) - 3, .unsigned, @bitSizeOf(DoubleLimb) - 1);
 
     try testing.expect((try a.to(DoubleLimb)) == maxInt(DoubleLimb) >> 1);
 }
@@ -2007,7 +2007,7 @@ test "big.int sat shift-left multi unsigned" {
 test "big.int sat shift-left unsigned shift > bitcount" {
     var a = try Managed.initSet(testing.allocator, 1);
     defer a.deinit();
-    try a.shiftLeftSat(a, 10, .unsigned, 10);
+    try a.shiftLeftSat(&a, 10, .unsigned, 10);
 
     try testing.expect((try a.to(u10)) == maxInt(u10));
 }
@@ -2015,7 +2015,7 @@ test "big.int sat shift-left unsigned shift > bitcount" {
 test "big.int sat shift-left unsigned zero" {
     var a = try Managed.initSet(testing.allocator, 0);
     defer a.deinit();
-    try a.shiftLeftSat(a, 1, .unsigned, 0);
+    try a.shiftLeftSat(&a, 1, .unsigned, 0);
 
     try testing.expect((try a.to(u64)) == 0);
 }
@@ -2023,7 +2023,7 @@ test "big.int sat shift-left unsigned zero" {
 test "big.int sat shift-left unsigned negative" {
     var a = try Managed.initSet(testing.allocator, -100);
     defer a.deinit();
-    try a.shiftLeftSat(a, 0, .unsigned, 0);
+    try a.shiftLeftSat(&a, 0, .unsigned, 0);
 
     try testing.expect((try a.to(u64)) == 0);
 }
@@ -2031,7 +2031,7 @@ test "big.int sat shift-left unsigned negative" {
 test "big.int sat shift-left signed simple negative" {
     var a = try Managed.initSet(testing.allocator, -100);
     defer a.deinit();
-    try a.shiftLeftSat(a, 3, .signed, 10);
+    try a.shiftLeftSat(&a, 3, .signed, 10);
 
     try testing.expect((try a.to(i10)) == minInt(i10));
 }
@@ -2039,7 +2039,7 @@ test "big.int sat shift-left signed simple negative" {
 test "big.int sat shift-left signed simple positive" {
     var a = try Managed.initSet(testing.allocator, 100);
     defer a.deinit();
-    try a.shiftLeftSat(a, 3, .signed, 10);
+    try a.shiftLeftSat(&a, 3, .signed, 10);
 
     try testing.expect((try a.to(i10)) == maxInt(i10));
 }
@@ -2050,7 +2050,7 @@ test "big.int sat shift-left signed multi positive" {
 
     var a = try Managed.initSet(testing.allocator, x);
     defer a.deinit();
-    try a.shiftLeftSat(a, shift, .signed, @bitSizeOf(SignedDoubleLimb));
+    try a.shiftLeftSat(&a, shift, .signed, @bitSizeOf(SignedDoubleLimb));
 
     try testing.expect((try a.to(SignedDoubleLimb)) == @as(SignedDoubleLimb, x) <<| shift);
 }
@@ -2061,7 +2061,7 @@ test "big.int sat shift-left signed multi negative" {
 
     var a = try Managed.initSet(testing.allocator, x);
     defer a.deinit();
-    try a.shiftLeftSat(a, shift, .signed, @bitSizeOf(SignedDoubleLimb));
+    try a.shiftLeftSat(&a, shift, .signed, @bitSizeOf(SignedDoubleLimb));
 
     try testing.expect((try a.to(SignedDoubleLimb)) == @as(SignedDoubleLimb, x) <<| shift);
 }
@@ -2070,7 +2070,7 @@ test "big.int bitNotWrap unsigned simple" {
     var a = try Managed.initSet(testing.allocator, 123);
     defer a.deinit();
 
-    try a.bitNotWrap(a, .unsigned, 10);
+    try a.bitNotWrap(&a, .unsigned, 10);
 
     try testing.expect((try a.to(u10)) == ~@as(u10, 123));
 }
@@ -2079,7 +2079,7 @@ test "big.int bitNotWrap unsigned multi" {
     var a = try Managed.initSet(testing.allocator, 0);
     defer a.deinit();
 
-    try a.bitNotWrap(a, .unsigned, @bitSizeOf(DoubleLimb));
+    try a.bitNotWrap(&a, .unsigned, @bitSizeOf(DoubleLimb));
 
     try testing.expect((try a.to(DoubleLimb)) == maxInt(DoubleLimb));
 }
@@ -2088,7 +2088,7 @@ test "big.int bitNotWrap signed simple" {
     var a = try Managed.initSet(testing.allocator, -456);
     defer a.deinit();
 
-    try a.bitNotWrap(a, .signed, 11);
+    try a.bitNotWrap(&a, .signed, 11);
 
     try testing.expect((try a.to(i11)) == ~@as(i11, -456));
 }
@@ -2097,7 +2097,7 @@ test "big.int bitNotWrap signed multi" {
     var a = try Managed.initSet(testing.allocator, 0);
     defer a.deinit();
 
-    try a.bitNotWrap(a, .signed, @bitSizeOf(SignedDoubleLimb));
+    try a.bitNotWrap(&a, .signed, @bitSizeOf(SignedDoubleLimb));
 
     try testing.expect((try a.to(SignedDoubleLimb)) == -1);
 }
@@ -2108,7 +2108,7 @@ test "big.int bitwise and simple" {
     var b = try Managed.initSet(testing.allocator, 0xeeeeeeee22222222);
     defer b.deinit();
 
-    try a.bitAnd(a, b);
+    try a.bitAnd(&a, &b);
 
     try testing.expect((try a.to(u64)) == 0xeeeeeeee00000000);
 }
@@ -2119,7 +2119,7 @@ test "big.int bitwise and multi-limb" {
     var b = try Managed.initSet(testing.allocator, maxInt(Limb));
     defer b.deinit();
 
-    try a.bitAnd(a, b);
+    try a.bitAnd(&a, &b);
 
     try testing.expect((try a.to(u128)) == 0);
 }
@@ -2130,7 +2130,7 @@ test "big.int bitwise and negative-positive simple" {
     var b = try Managed.initSet(testing.allocator, 0xeeeeeeee22222222);
     defer b.deinit();
 
-    try a.bitAnd(a, b);
+    try a.bitAnd(&a, &b);
 
     try testing.expect((try a.to(u64)) == 0x22222222);
 }
@@ -2141,7 +2141,7 @@ test "big.int bitwise and negative-positive multi-limb" {
     var b = try Managed.initSet(testing.allocator, maxInt(Limb));
     defer b.deinit();
 
-    try a.bitAnd(a, b);
+    try a.bitAnd(&a, &b);
 
     try testing.expect(a.eqZero());
 }
@@ -2152,7 +2152,7 @@ test "big.int bitwise and positive-negative simple" {
     var b = try Managed.initSet(testing.allocator, -0xeeeeeeee22222222);
     defer b.deinit();
 
-    try a.bitAnd(a, b);
+    try a.bitAnd(&a, &b);
 
     try testing.expect((try a.to(u64)) == 0x1111111111111110);
 }
@@ -2163,7 +2163,7 @@ test "big.int bitwise and positive-negative multi-limb" {
     var b = try Managed.initSet(testing.allocator, -maxInt(Limb) - 1);
     defer b.deinit();
 
-    try a.bitAnd(a, b);
+    try a.bitAnd(&a, &b);
 
     try testing.expect(a.eqZero());
 }
@@ -2174,7 +2174,7 @@ test "big.int bitwise and negative-negative simple" {
     var b = try Managed.initSet(testing.allocator, -0xeeeeeeee22222222);
     defer b.deinit();
 
-    try a.bitAnd(a, b);
+    try a.bitAnd(&a, &b);
 
     try testing.expect((try a.to(i128)) == -0xffffffff33333332);
 }
@@ -2185,7 +2185,7 @@ test "big.int bitwise and negative-negative multi-limb" {
     var b = try Managed.initSet(testing.allocator, -maxInt(Limb) - 2);
     defer b.deinit();
 
-    try a.bitAnd(a, b);
+    try a.bitAnd(&a, &b);
 
     try testing.expect((try a.to(i128)) == -maxInt(Limb) * 2 - 2);
 }
@@ -2196,7 +2196,7 @@ test "big.int bitwise and negative overflow" {
     var b = try Managed.initSet(testing.allocator, -2);
     defer b.deinit();
 
-    try a.bitAnd(a, b);
+    try a.bitAnd(&a, &b);
 
     try testing.expect((try a.to(SignedDoubleLimb)) == -maxInt(Limb) - 1);
 }
@@ -2207,7 +2207,7 @@ test "big.int bitwise xor simple" {
     var b = try Managed.initSet(testing.allocator, 0xeeeeeeee22222222);
     defer b.deinit();
 
-    try a.bitXor(a, b);
+    try a.bitXor(&a, &b);
 
     try testing.expect((try a.to(u64)) == 0x1111111133333333);
 }
@@ -2218,7 +2218,7 @@ test "big.int bitwise xor multi-limb" {
     var b = try Managed.initSet(testing.allocator, maxInt(Limb));
     defer b.deinit();
 
-    try a.bitXor(a, b);
+    try a.bitXor(&a, &b);
 
     try testing.expect((try a.to(DoubleLimb)) == (maxInt(Limb) + 1) ^ maxInt(Limb));
 }
@@ -2229,7 +2229,7 @@ test "big.int bitwise xor single negative simple" {
     var b = try Managed.initSet(testing.allocator, -0x45fd3acef9191fad);
     defer b.deinit();
 
-    try a.bitXor(a, b);
+    try a.bitXor(&a, &b);
 
     try testing.expect((try a.to(i64)) == -0x2efed94fcb932ef9);
 }
@@ -2240,7 +2240,7 @@ test "big.int bitwise xor single negative zero" {
     var b = try Managed.initSet(testing.allocator, -0);
     defer b.deinit();
 
-    try a.bitXor(a, b);
+    try a.bitXor(&a, &b);
 
     try testing.expect(a.eqZero());
 }
@@ -2251,7 +2251,7 @@ test "big.int bitwise xor single negative multi-limb" {
     var b = try Managed.initSet(testing.allocator, 0xf2194e7d1c855272a997fcde16f6d5a8);
     defer b.deinit();
 
-    try a.bitXor(a, b);
+    try a.bitXor(&a, &b);
 
     try testing.expect((try a.to(i128)) == -0x6a50889abd8834a24db1f19650d3999a);
 }
@@ -2262,7 +2262,7 @@ test "big.int bitwise xor single negative overflow" {
     var b = try Managed.initSet(testing.allocator, -1);
     defer b.deinit();
 
-    try a.bitXor(a, b);
+    try a.bitXor(&a, &b);
 
     try testing.expect((try a.to(SignedDoubleLimb)) == -(maxInt(Limb) + 1));
 }
@@ -2273,7 +2273,7 @@ test "big.int bitwise xor double negative simple" {
     var b = try Managed.initSet(testing.allocator, -0x4dd4fa576f3046ac);
     defer b.deinit();
 
-    try a.bitXor(a, b);
+    try a.bitXor(&a, &b);
 
     try testing.expect((try a.to(u64)) == 0xc39c47081a6eb759);
 }
@@ -2284,7 +2284,7 @@ test "big.int bitwise xor double negative multi-limb" {
     var b = try Managed.initSet(testing.allocator, -0xcb07736a7b62289c78d967c3985eebeb);
     defer b.deinit();
 
-    try a.bitXor(a, b);
+    try a.bitXor(&a, &b);
 
     try testing.expect((try a.to(u128)) == 0xa3492ec28e62c410dff92bf0549bf771);
 }
@@ -2295,7 +2295,7 @@ test "big.int bitwise or simple" {
     var b = try Managed.initSet(testing.allocator, 0xeeeeeeee22222222);
     defer b.deinit();
 
-    try a.bitOr(a, b);
+    try a.bitOr(&a, &b);
 
     try testing.expect((try a.to(u64)) == 0xffffffff33333333);
 }
@@ -2306,7 +2306,7 @@ test "big.int bitwise or multi-limb" {
     var b = try Managed.initSet(testing.allocator, maxInt(Limb));
     defer b.deinit();
 
-    try a.bitOr(a, b);
+    try a.bitOr(&a, &b);
 
     // TODO: big.int.cpp or is wrong on multi-limb.
     try testing.expect((try a.to(DoubleLimb)) == (maxInt(Limb) + 1) + maxInt(Limb));
@@ -2318,7 +2318,7 @@ test "big.int bitwise or negative-positive simple" {
     var b = try Managed.initSet(testing.allocator, 0xeeeeeeee22222222);
     defer b.deinit();
 
-    try a.bitOr(a, b);
+    try a.bitOr(&a, &b);
 
     try testing.expect((try a.to(i64)) == -0x1111111111111111);
 }
@@ -2329,7 +2329,7 @@ test "big.int bitwise or negative-positive multi-limb" {
     var b = try Managed.initSet(testing.allocator, 1);
     defer b.deinit();
 
-    try a.bitOr(a, b);
+    try a.bitOr(&a, &b);
 
     try testing.expect((try a.to(SignedDoubleLimb)) == -maxInt(Limb));
 }
@@ -2340,7 +2340,7 @@ test "big.int bitwise or positive-negative simple" {
     var b = try Managed.initSet(testing.allocator, -0xeeeeeeee22222222);
     defer b.deinit();
 
-    try a.bitOr(a, b);
+    try a.bitOr(&a, &b);
 
     try testing.expect((try a.to(i64)) == -0x22222221);
 }
@@ -2351,7 +2351,7 @@ test "big.int bitwise or positive-negative multi-limb" {
     var b = try Managed.initSet(testing.allocator, -1);
     defer b.deinit();
 
-    try a.bitOr(a, b);
+    try a.bitOr(&a, &b);
 
     try testing.expect((try a.to(SignedDoubleLimb)) == -1);
 }
@@ -2362,7 +2362,7 @@ test "big.int bitwise or negative-negative simple" {
     var b = try Managed.initSet(testing.allocator, -0xeeeeeeee22222222);
     defer b.deinit();
 
-    try a.bitOr(a, b);
+    try a.bitOr(&a, &b);
 
     try testing.expect((try a.to(i128)) == -0xeeeeeeee00000001);
 }
@@ -2373,7 +2373,7 @@ test "big.int bitwise or negative-negative multi-limb" {
     var b = try Managed.initSet(testing.allocator, -maxInt(Limb));
     defer b.deinit();
 
-    try a.bitOr(a, b);
+    try a.bitOr(&a, &b);
 
     try testing.expect((try a.to(SignedDoubleLimb)) == -maxInt(Limb));
 }
@@ -2384,7 +2384,7 @@ test "big.int var args" {
 
     var b = try Managed.initSet(testing.allocator, 6);
     defer b.deinit();
-    try a.add(a.toConst(), b.toConst());
+    try a.add(&a, &b);
     try testing.expect((try a.to(u64)) == 11);
 
     var c = try Managed.initSet(testing.allocator, 11);
@@ -2404,7 +2404,7 @@ test "big.int gcd non-one small" {
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
 
-    try r.gcd(a, b);
+    try r.gcd(&a, &b);
 
     try testing.expect((try r.to(u32)) == 1);
 }
@@ -2417,7 +2417,7 @@ test "big.int gcd non-one small" {
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
 
-    try r.gcd(a, b);
+    try r.gcd(&a, &b);
 
     try testing.expect((try r.to(u32)) == 38);
 }
@@ -2430,7 +2430,7 @@ test "big.int gcd non-one large" {
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
 
-    try r.gcd(a, b);
+    try r.gcd(&a, &b);
 
     try testing.expect((try r.to(u32)) == 4369);
 }
@@ -2443,7 +2443,7 @@ test "big.int gcd large multi-limb result" {
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
 
-    try r.gcd(a, b);
+    try r.gcd(&a, &b);
 
     const answer = (try r.to(u256));
     try testing.expect(answer == 0xf000000ff00000fff0000ffff000fffff00ffffff1);
@@ -2457,7 +2457,7 @@ test "big.int gcd one large" {
     var r = try Managed.init(testing.allocator);
     defer r.deinit();
 
-    try r.gcd(a, b);
+    try r.gcd(&a, &b);
 
     try testing.expect((try r.to(u64)) == 1);
 }
@@ -2488,10 +2488,10 @@ test "big.int pow" {
         var a = try Managed.initSet(testing.allocator, -3);
         defer a.deinit();
 
-        try a.pow(a.toConst(), 3);
+        try a.pow(&a, 3);
         try testing.expectEqual(@as(i32, -27), try a.to(i32));
 
-        try a.pow(a.toConst(), 4);
+        try a.pow(&a, 4);
         try testing.expectEqual(@as(i32, 531441), try a.to(i32));
     }
     {
@@ -2502,9 +2502,9 @@ test "big.int pow" {
         defer y.deinit();
 
         // y and a are not aliased
-        try y.pow(a.toConst(), 123);
+        try y.pow(&a, 123);
         // y and a are aliased
-        try a.pow(a.toConst(), 123);
+        try a.pow(&a, 123);
 
         try testing.expect(a.eq(y));
 
@@ -2522,18 +2522,18 @@ test "big.int pow" {
         var a = try Managed.initSet(testing.allocator, 0);
         defer a.deinit();
 
-        try a.pow(a.toConst(), 100);
+        try a.pow(&a, 100);
         try testing.expectEqual(@as(i32, 0), try a.to(i32));
 
         try a.set(1);
-        try a.pow(a.toConst(), 0);
+        try a.pow(&a, 0);
         try testing.expectEqual(@as(i32, 1), try a.to(i32));
-        try a.pow(a.toConst(), 100);
+        try a.pow(&a, 100);
         try testing.expectEqual(@as(i32, 1), try a.to(i32));
         try a.set(-1);
-        try a.pow(a.toConst(), 15);
+        try a.pow(&a, 15);
         try testing.expectEqual(@as(i32, -1), try a.to(i32));
-        try a.pow(a.toConst(), 16);
+        try a.pow(&a, 16);
         try testing.expectEqual(@as(i32, 1), try a.to(i32));
     }
 }
@@ -2547,7 +2547,7 @@ test "big.int regression test for 1 limb overflow with alias" {
     defer b.deinit();
 
     try a.ensureAddCapacity(a.toConst(), b.toConst());
-    try a.add(a.toConst(), b.toConst());
+    try a.add(&a, &b);
 
     try testing.expect(a.toConst().orderAgainstScalar(19740274219868223167) == .eq);
 }
@@ -2561,7 +2561,7 @@ test "big.int regression test for realloc with alias" {
     defer b.deinit();
 
     try a.ensureAddCapacity(a.toConst(), b.toConst());
-    try a.add(a.toConst(), b.toConst());
+    try a.add(&a, &b);
 
     try testing.expect(a.toConst().orderAgainstScalar(14691098406862188148944207245954912110548093601382197697835) == .eq);
 }
@@ -2572,7 +2572,7 @@ test "big int popcount" {
     var b = try Managed.initSet(testing.allocator, -1);
     defer b.deinit();
 
-    try a.popCount(b.toConst(), 16);
+    try a.popCount(&b, 16);
 
     try testing.expect(a.toConst().orderAgainstScalar(16) == .eq);
 }

--- a/lib/std/math/big/rational.zig
+++ b/lib/std/math/big/rational.zig
@@ -102,20 +102,23 @@ pub const Rational = struct {
             try self.p.setString(10, str[0..i]);
 
             const base = IntConst{ .limbs = &[_]Limb{10}, .positive = true };
+            var local_buf: [@sizeOf(Limb) * Int.default_capacity]u8 align(@alignOf(Limb)) = undefined;
+            var fba = std.heap.FixedBufferAllocator.init(&local_buf);
+            const base_managed = try base.toManaged(fba.allocator());
 
             var j: usize = start;
             while (j < str.len - i - 1) : (j += 1) {
                 try self.p.ensureMulCapacity(self.p.toConst(), base);
-                try self.p.mul(self.p.toConst(), base);
+                try self.p.mul(&self.p, &base_managed);
             }
 
             try self.q.setString(10, str[i + 1 ..]);
-            try self.p.add(self.p.toConst(), self.q.toConst());
+            try self.p.add(&self.p, &self.q);
 
             try self.q.set(1);
             var k: usize = i + 1;
             while (k < str.len) : (k += 1) {
-                try self.q.mul(self.q.toConst(), base);
+                try self.q.mul(&self.q, &base_managed);
             }
 
             try self.reduce();
@@ -172,9 +175,9 @@ pub const Rational = struct {
 
         try self.q.set(1);
         if (shift >= 0) {
-            try self.q.shiftLeft(self.q, @intCast(usize, shift));
+            try self.q.shiftLeft(&self.q, @intCast(usize, shift));
         } else {
-            try self.p.shiftLeft(self.p, @intCast(usize, -shift));
+            try self.p.shiftLeft(&self.p, @intCast(usize, -shift));
         }
 
         try self.reduce();
@@ -215,9 +218,9 @@ pub const Rational = struct {
 
         const shift = msize2 - exp;
         if (shift >= 0) {
-            try a2.shiftLeft(a2, @intCast(usize, shift));
+            try a2.shiftLeft(&a2, @intCast(usize, shift));
         } else {
-            try b2.shiftLeft(b2, @intCast(usize, -shift));
+            try b2.shiftLeft(&b2, @intCast(usize, -shift));
         }
 
         // 2. compute quotient and remainder
@@ -228,7 +231,7 @@ pub const Rational = struct {
         var r = try Int.init(self.p.allocator);
         defer r.deinit();
 
-        try Int.divTrunc(&q, &r, a2.toConst(), b2.toConst());
+        try Int.divTrunc(&q, &r, &a2, &b2);
 
         var mantissa = extractLowBits(q, BitReprType);
         var have_rem = r.len() > 0;
@@ -350,8 +353,8 @@ pub const Rational = struct {
         var p = try Int.init(b.p.allocator);
         defer p.deinit();
 
-        try q.mul(a.p.toConst(), b.q.toConst());
-        try p.mul(b.p.toConst(), a.q.toConst());
+        try q.mul(&a.p, &b.q);
+        try p.mul(&b.p, &a.q);
 
         return if (is_abs) q.orderAbs(p) else q.order(p);
     }
@@ -376,11 +379,11 @@ pub const Rational = struct {
             r.deinit();
         };
 
-        try r.p.mul(a.p.toConst(), b.q.toConst());
-        try r.q.mul(b.p.toConst(), a.q.toConst());
-        try r.p.add(r.p.toConst(), r.q.toConst());
+        try r.p.mul(&a.p, &b.q);
+        try r.q.mul(&b.p, &a.q);
+        try r.p.add(&r.p, &r.q);
 
-        try r.q.mul(a.q.toConst(), b.q.toConst());
+        try r.q.mul(&a.q, &b.q);
         try r.reduce();
     }
 
@@ -404,11 +407,11 @@ pub const Rational = struct {
             r.deinit();
         };
 
-        try r.p.mul(a.p.toConst(), b.q.toConst());
-        try r.q.mul(b.p.toConst(), a.q.toConst());
-        try r.p.sub(r.p.toConst(), r.q.toConst());
+        try r.p.mul(&a.p, &b.q);
+        try r.q.mul(&b.p, &a.q);
+        try r.p.sub(&r.p, &r.q);
 
-        try r.q.mul(a.q.toConst(), b.q.toConst());
+        try r.q.mul(&a.q, &b.q);
         try r.reduce();
     }
 
@@ -418,8 +421,8 @@ pub const Rational = struct {
     ///
     /// Returns an error if memory could not be allocated.
     pub fn mul(r: *Rational, a: Rational, b: Rational) !void {
-        try r.p.mul(a.p.toConst(), b.p.toConst());
-        try r.q.mul(a.q.toConst(), b.q.toConst());
+        try r.p.mul(&a.p, &b.p);
+        try r.q.mul(&a.q, &b.q);
         try r.reduce();
     }
 
@@ -433,8 +436,8 @@ pub const Rational = struct {
             @panic("division by zero");
         }
 
-        try r.p.mul(a.p.toConst(), b.q.toConst());
-        try r.q.mul(b.p.toConst(), a.q.toConst());
+        try r.p.mul(&a.p, &b.q);
+        try r.q.mul(&b.p, &a.q);
         try r.reduce();
     }
 
@@ -450,7 +453,7 @@ pub const Rational = struct {
 
         const sign = r.p.isPositive();
         r.p.abs();
-        try a.gcd(r.p, r.q);
+        try a.gcd(&r.p, &r.q);
         r.p.setSign(sign);
 
         const one = IntConst{ .limbs = &[_]Limb{1}, .positive = true };
@@ -460,8 +463,8 @@ pub const Rational = struct {
 
             // TODO: divexact would be useful here
             // TODO: don't copy r.q for div
-            try Int.divTrunc(&r.p, &unused, r.p.toConst(), a.toConst());
-            try Int.divTrunc(&r.q, &unused, r.q.toConst(), a.toConst());
+            try Int.divTrunc(&r.p, &unused, &r.p, &a);
+            try Int.divTrunc(&r.q, &unused, &r.q, &a);
         }
     }
 };
@@ -573,7 +576,6 @@ test "big.rational setFloatString" {
 }
 
 test "big.rational toFloat" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     var a = try Rational.init(testing.allocator);
     defer a.deinit();
 
@@ -587,7 +589,6 @@ test "big.rational toFloat" {
 }
 
 test "big.rational set/to Float round-trip" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     var a = try Rational.init(testing.allocator);
     defer a.deinit();
     var prng = std.rand.DefaultPrng.init(0x5EED);

--- a/src/RangeSet.zig
+++ b/src/RangeSet.zig
@@ -85,7 +85,7 @@ pub fn spans(self: *RangeSet, first: Value, last: Value, ty: Type) !bool {
 
         // prev.last + 1 == cur.first
         try counter.copy(prev.last.toBigInt(&space, target));
-        try counter.addScalar(counter.toConst(), 1);
+        try counter.addScalar(&counter, 1);
 
         const cur_start_int = cur.first.toBigInt(&space, target);
         if (!cur_start_int.eq(counter.toConst())) {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -22706,9 +22706,9 @@ fn cmpNumeric(
                     else => {},
                 }
                 if (lhs_is_signed) {
-                    try bigint.addScalar(bigint.toConst(), -1);
+                    try bigint.addScalar(&bigint, -1);
                 } else {
-                    try bigint.addScalar(bigint.toConst(), 1);
+                    try bigint.addScalar(&bigint, 1);
                 }
             }
             lhs_bits = bigint.toConst().bitCountTwosComp();
@@ -22752,9 +22752,9 @@ fn cmpNumeric(
                     else => {},
                 }
                 if (rhs_is_signed) {
-                    try bigint.addScalar(bigint.toConst(), -1);
+                    try bigint.addScalar(&bigint, -1);
                 } else {
-                    try bigint.addScalar(bigint.toConst(), 1);
+                    try bigint.addScalar(&bigint, 1);
                 }
             }
             rhs_bits = bigint.toConst().bitCountTwosComp();


### PR DESCRIPTION
Many of the Managed methods accepted by-val parameters which could
reference Limb slices that became invalid memory after any
ensureCapacity calls. Now, Managed methods accept `*const Managed`
parameters so that if the function allows aliasing and the
ensure-capacity call resizes the Limb slice, it also affects the
aliased parameters, avoiding use-after-free bugs.

This is a breaking change that reduces the requirement for callsites to
manually make the ensure-capacity changes prior to calling many of the
Managed methods.

Closes #11897