### PR TITLE
LLVM: fix lowering of untagged union types

### DIFF
--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -5,7 +5,6 @@ const mem = std.mem;
 const testing = std.testing;
 
 test "parse and render IPv6 addresses" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
     var buffer: [100]u8 = undefined;
@@ -68,7 +67,6 @@ test "invalid but parseable IPv6 scope ids" {
 }
 
 test "parse and render IPv4 addresses" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
     var buffer: [18]u8 = undefined;
@@ -93,7 +91,6 @@ test "parse and render IPv4 addresses" {
 }
 
 test "parse and render UNIX addresses" {
-    if (@import("builtin").zig_backend != .stage1) return error.SkipZigTest;
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
     if (!net.has_unix_sockets) return error.SkipZigTest;
 

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -1194,3 +1194,22 @@ test "union tag is set when initiated as a temporary value at runtime" {
     var b: u32 = 1;
     try (U{ .b = b }).doTheTest();
 }
+
+test "extern union most-aligned field is smaller" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
+    const U = extern union {
+        in6: extern struct {
+            family: u16,
+            port: u16,
+            flowinfo: u32,
+            addr: [20]u8,
+        },
+        un: [110]u8,
+    };
+    var a: ?U = .{ .un = [_]u8{0} ** 110 };
+    try expect(a != null);
+}


### PR DESCRIPTION
The LLVM backend was calculating the amount of padding solely based
on the payload size. However, in the case where there is no union
tag, this fails to take into account alignment.

Closes #11857