### PR TITLE
fix error message importing file starting with module root path

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4367,7 +4367,7 @@ pub fn importFile(
     if (!mem.startsWith(u8, resolved_path, resolved_root_path) or
         // This prevents this check from triggering when the name of the
         // imported file starts with the root path's directory name.
-        mem.indexOfAny(u8, &.{resolved_path[resolved_root_path.len]}, "/\\") == null)
+        std.fs.path.isSep(resolved_path[resolved_root_path.len]))
     {
         return error.ImportOutsidePkgPath;
     }

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4364,7 +4364,11 @@ pub fn importFile(
     const resolved_root_path = try std.fs.path.resolve(gpa, &[_][]const u8{cur_pkg_dir_path});
     defer gpa.free(resolved_root_path);
 
-    if (!mem.startsWith(u8, resolved_path, resolved_root_path)) {
+    if (!mem.startsWith(u8, resolved_path, resolved_root_path) or
+        // This prevents this check from triggering when the name of the
+        // imported file starts with the root path's directory name.
+        mem.indexOfAny(u8, &.{resolved_path[resolved_root_path.len]}, "/\\") == null)
+    {
         return error.ImportOutsidePkgPath;
     }
     // +1 for the directory separator here.

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4367,7 +4367,7 @@ pub fn importFile(
     if (!mem.startsWith(u8, resolved_path, resolved_root_path) or
         // This prevents this check from triggering when the name of the
         // imported file starts with the root path's directory name.
-        std.fs.path.isSep(resolved_path[resolved_root_path.len]))
+        !std.fs.path.isSep(resolved_path[resolved_root_path.len]))
     {
         return error.ImportOutsidePkgPath;
     }


### PR DESCRIPTION
closes #9537

Note that, for some reason, I couldn't get this error to trigger. I have ensured that the check I changed triggers when it should, though. Not sure what's preventing it from erroring for me.