### PR TITLE
Use a slice for InstMap instead of std.HashMap

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3597,7 +3597,7 @@ pub fn mapOldZirToNew(
     defer new_decls.deinit();
 
     while (match_stack.popOrNull()) |match_item| {
-        try inst_map.put(gpa, match_item.old_inst, match_item.new_inst);
+        inst_map.putAssumeCapacity(match_item.old_inst, match_item.new_inst);
 
         // Maps name to extra index of decl sub item.
         var decl_map: std.StringHashMapUnmanaged(u32) = .{};
@@ -4975,7 +4975,7 @@ pub fn analyzeFnBody(mod: *Module, func: *Fn, arena: Allocator) SemaError!Air {
     const runtime_params_len = @intCast(u32, fn_ty_info.param_types.len);
     try inner_block.instructions.ensureTotalCapacityPrecise(gpa, runtime_params_len);
     try sema.air_instructions.ensureUnusedCapacity(gpa, fn_info.total_params_len * 2); // * 2 for the `addType`
-    try sema.inst_map.ensureUnusedCapacity(gpa, fn_info.total_params_len);
+    try sema.inst_map.ensureSpaceForInstructions(gpa, fn_info.param_body);
 
     var runtime_param_index: usize = 0;
     var total_param_index: usize = 0;


### PR DESCRIPTION
The `sema.inst_map` datastructure is very often accessed. All instructions that reference the result of other instructions does a lookup into this field. Because of this, a significant amount of time, is spent in `std.HashMap.get`.

This commit replaces the `HashMap` with a simpler data structure that simply uses the zir indexes to index into a slice for the result. See the data structure doc comment for more info.

Performance results:

```
> $(which time) -v perf stat -r 10 stage2-release/bin/zig build-exe \
      ../zig2/src/main.zig --pkg-begin build_options options.zig \
      --pkg-end -lc -fno-emit-bin

                master           new-inst-map
instructions  15,565,458,749   14,235,238,027   ~8.5% less
    branches   2,547,101,394    2,294,805,250   ~9.9% less
        time        2.40819s         2.25372s   ~6.4% less
                                               (~6.8% faster)
```

This might not be exactly how we want to do this. Someone might want to explore making `HashMap` faster (though it is hard to imagine it beating the performance of `map.items[key-map.start]`). Maybe this is a more general data structure (`IntIndexMap`) that we can put into the standard library.

I'll just put this PR here for discussion