### PR TITLE
macho: implement pruning of unused segments and sections

### DIFF
--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -912,6 +912,9 @@ pub const relocation_info = packed struct {
 pub const LC_REQ_DYLD = 0x80000000;
 
 pub const LC = enum(u32) {
+    /// No load command - invalid
+    NONE = 0x0,
+
     /// segment of this file to be mapped
     SEGMENT = 0x1,
 

--- a/src/link/MachO/CodeSignature.zig
+++ b/src/link/MachO/CodeSignature.zig
@@ -250,7 +250,8 @@ pub fn addEntitlements(self: *CodeSignature, allocator: Allocator, path: []const
 
 pub const WriteOpts = struct {
     file: fs.File,
-    text_segment: macho.segment_command_64,
+    exec_seg_base: u64,
+    exec_seg_limit: u64,
     code_sig_cmd: macho.linkedit_data_command,
     output_mode: std.builtin.OutputMode,
 };
@@ -270,8 +271,8 @@ pub fn writeAdhocSignature(
     var blobs = std.ArrayList(Blob).init(allocator);
     defer blobs.deinit();
 
-    self.code_directory.inner.execSegBase = opts.text_segment.fileoff;
-    self.code_directory.inner.execSegLimit = opts.text_segment.filesize;
+    self.code_directory.inner.execSegBase = opts.exec_seg_base;
+    self.code_directory.inner.execSegLimit = opts.exec_seg_limit;
     self.code_directory.inner.execSegFlags = if (opts.output_mode == .Exe) macho.CS_EXECSEG_MAIN_BINARY else 0;
     const file_size = opts.code_sig_cmd.dataoff;
     self.code_directory.inner.codeLimit = file_size;


### PR DESCRIPTION
This is a prelude to a more elaborate work which will implement
`-dead_strip` flag - garbage collection of unreachable atoms. Here,
when sorting sections, we also check that the section is actually
populated with some atoms, and if not, we exclude it from the final
linked image. This can happen when we do not import any symbols
from dynamic libraries in which case we will not be populating
the stubs sections or the GOT table, implying we can skip allocating
those sections. Furthermore, we also make a check that a segment
is actually occupied too, with the exception of `__TEXT` segment
which is non-optional given that it wraps the header and load commands
and thus is required by the `dyld` to perform dynamic linking, and
`__PAGEZERO` which is generally non-optional when the linked image
is an executable. For any other segment, if its section count is
zero, we mark it as dead and skip allocating it and generating
a load command for it.

This commit also includes some minor improvements to the linker such
as refactoring of the segment allocating codepaths, skipping
`__PAGEZERO` generation for dylibs, and skipping generation of zero-sized
atoms for special symbols such as `__mh_execute_header` and `___dso_handle`.
These special symbols are only allocated local and global symbol pair
and their VM addresses is set to the start of the `__TEXT` segment,
but no `Atom` is created, as it's not necessary given that they never
carry any machine code.

Finally, we now always force-link against `libSystem` which turns out
to be required for `dyld` to properly handle `LC_MAIN` load command
on older macOS versions such as 10.15.7.