### PR TITLE
Return invalid argument in sendto instead of unreachable

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -5781,7 +5781,10 @@ pub fn sendmsg(
     }
 }
 
-pub const SendToError = SendMsgError;
+pub const SendToError = SendMsgError || error{
+    /// The destination address is not reachable by the bound address.
+    UnreachableAddress,
+};
 
 /// Transmit a message to another socket.
 ///
@@ -5858,7 +5861,7 @@ pub fn sendto(
                 .DESTADDRREQ => unreachable, // The socket is not connection-mode, and no peer address is set.
                 .FAULT => unreachable, // An invalid user space address was specified for an argument.
                 .INTR => continue,
-                .INVAL => unreachable, // Invalid argument passed.
+                .INVAL => return error.UnreachableAddress,
                 .ISCONN => unreachable, // connection-mode socket was connected already but a recipient was specified
                 .MSGSIZE => return error.MessageTooBig,
                 .NOBUFS => return error.SystemResources,


### PR DESCRIPTION
At least on Linux, the sendto command can cause the INVAL error with 'user-side' error. I.e. not a clear bug in the code, but simply the address being send to not being in the right ip address range. There is no definite way to check for this issue before hand, so it should probably not turn to an unreachable and crash.

The user still has to deal with the enum and could make it unreachable if that is required on their side.

Here is an example to show the issue:

```
const std = @import("std");
const os = std.os;
const net = std.net;

pub fn main() anyerror!void {
    const address_all = net.Address.initIp4([_]u8{ 0, 0, 0, 0 }, 4040);
    const address = net.Address.initIp4([_]u8{ 127, 0, 0, 1 }, 4040);

    const address_target_ok = net.Address.initIp4([_]u8{ 127, 0, 0, 42 }, 4040);
    const address_target_notok = net.Address.initIp4([_]u8{ 192, 168, 1, 1 }, 4040);

    const sock_flags = os.SOCK.DGRAM | os.SOCK.CLOEXEC | os.SOCK.NONBLOCK;

    const buf = "hello";
    {
        var fd_all = try os.socket(address_all.any.family, sock_flags, os.IPPROTO.UDP);
        defer os.closeSocket(fd_all);

        try os.bind(fd_all, &address_all.any, address_all.getOsSockLen());

        _ = try os.sendto(fd_all, buf, os.MSG.NOSIGNAL, &address_target_ok.any, address_target_ok.getOsSockLen());
        _ = try os.sendto(fd_all, buf, os.MSG.NOSIGNAL, &address_target_notok.any, address_target_notok.getOsSockLen());
    }

    {
        var fd = try os.socket(address.any.family, sock_flags, os.IPPROTO.UDP);
        defer os.closeSocket(fd);

        try os.bind(fd, &address.any, address.getOsSockLen());
        _ = try os.sendto(fd, buf, os.MSG.NOSIGNAL, &address_target_ok.any, address_target_ok.getOsSockLen());
        _ = try os.sendto(fd, buf, os.MSG.NOSIGNAL, &address_target_notok.any, address_target_notok.getOsSockLen()); // This last one get .INVAL
    }
}
```