### PR TITLE
trivial: use a named struct in Compilation.create()

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2757,7 +2757,7 @@ fn buildOutputType(
 
     gimmeMoreOfThoseSweetSweetFileDescriptors();
 
-    const comp = Compilation.create(gpa, .{
+    const comp = Compilation.create(gpa, Compilation.InitOptions{
         .zig_lib_directory = zig_lib_directory,
         .local_cache_directory = local_cache_directory,
         .global_cache_directory = global_cache_directory,


### PR DESCRIPTION
My dev tools are not as sophisticated to automatically resolve the
struct in question, but having a named one will certainly aid
visibility and `git grep`.

Background: it looks like a nuisance; however, I have added a number of linker flags to `src/main.zig` and friends already, and this one is always confusing to find the struct for.