### PR TITLE
stage2: Fix corrupted Type when de-referencing field pointer

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -21614,10 +21614,10 @@ fn beginComptimePtrLoad(
                 deref.ty_without_well_defined_layout = field_ptr.container_ty;
             }
 
-            const tv = &(deref.pointee orelse {
+            const tv = deref.pointee orelse {
                 deref.pointee = null;
                 break :blk deref;
-            });
+            };
             const coerce_in_mem_ok =
                 (try sema.coerceInMemoryAllowed(block, field_ptr.container_ty, tv.ty, false, target, src, src)) == .ok or
                 (try sema.coerceInMemoryAllowed(block, tv.ty, field_ptr.container_ty, false, target, src, src)) == .ok;

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -82,6 +82,7 @@ test {
     _ = @import("behavior/bugs/11179.zig");
     _ = @import("behavior/bugs/11181.zig");
     _ = @import("behavior/bugs/11213.zig");
+    _ = @import("behavior/bugs/12003.zig");
     _ = @import("behavior/byteswap.zig");
     _ = @import("behavior/byval_arg_var.zig");
     _ = @import("behavior/call.zig");

--- a/test/behavior/bugs/12003.zig
+++ b/test/behavior/bugs/12003.zig
@@ -1,0 +1,7 @@
+test {
+    comptime {
+        const tuple_with_ptrs = .{ &0, &0 };
+        const field_ptr = (&tuple_with_ptrs.@"0");
+        _ = field_ptr.*;
+    }
+}


### PR DESCRIPTION
Closes #12003

The Type in the TypedValue was being overwritten by the `field_ty` before the call to `fieldValue`.