### PR TITLE
wasm-linker: Implement linker tests

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -481,8 +481,8 @@ pub fn build(b: *Builder) !void {
     ));
 
     toolchain_step.dependOn(tests.addCompareOutputTests(b, test_filter, modes));
-    toolchain_step.dependOn(tests.addStandaloneTests(b, test_filter, modes, skip_non_native, enable_macos_sdk, target));
-    toolchain_step.dependOn(tests.addLinkTests(b, test_filter, modes, enable_macos_sdk));
+    toolchain_step.dependOn(tests.addStandaloneTests(b, test_filter, modes, skip_non_native, enable_macos_sdk, target, omit_stage2));
+    toolchain_step.dependOn(tests.addLinkTests(b, test_filter, modes, enable_macos_sdk, omit_stage2));
     toolchain_step.dependOn(tests.addStackTraceTests(b, test_filter, modes));
     toolchain_step.dependOn(tests.addCliTests(b, test_filter, modes));
     toolchain_step.dependOn(tests.addAssembleAndLinkTests(b, test_filter, modes));

--- a/ci/azure/macos_script
+++ b/ci/azure/macos_script
@@ -76,7 +76,7 @@ release/bin/zig build test-run-translated-c -Denable-macos-sdk
 release/bin/zig build docs                  -Denable-macos-sdk
 release/bin/zig build test-fmt              -Denable-macos-sdk
 release/bin/zig build test-cases            -Denable-macos-sdk -Dsingle-threaded
-release/bin/zig build test-link             -Denable-macos-sdk
+release/bin/zig build test-link             -Denable-macos-sdk -Domit-stage2
 
 if [ "${BUILD_REASON}" != "PullRequest" ]; then
   mv ../LICENSE release/

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1624,6 +1624,7 @@ pub const LibExeObjStep = struct {
     want_lto: ?bool = null,
     use_stage1: ?bool = null,
     use_llvm: ?bool = null,
+    use_lld: ?bool = null,
     ofmt: ?std.Target.ObjectFormat = null,
 
     output_path_source: GeneratedFile,
@@ -2477,6 +2478,14 @@ pub const LibExeObjStep = struct {
                 try zig_args.append("-fLLVM");
             } else {
                 try zig_args.append("-fno-LLVM");
+            }
+        }
+
+        if (self.use_lld) |use_lld| {
+            if (use_lld) {
+                try zig_args.append("-fLLD");
+            } else {
+                try zig_args.append("-fno-LLD");
             }
         }
 

--- a/lib/std/build/CheckObjectStep.zig
+++ b/lib/std/build/CheckObjectStep.zig
@@ -753,7 +753,7 @@ const WasmDumper = struct {
     }
 
     fn parseDumpLimits(reader: anytype, writer: anytype) !void {
-        const flags = try std.leb.readULEB128(u1, reader);
+        const flags = try std.leb.readULEB128(u8, reader);
         const min = try std.leb.readULEB128(u32, reader);
 
         try writer.print("min {d}\n", .{min});

--- a/src/link.zig
+++ b/src/link.zig
@@ -348,7 +348,7 @@ pub const File = struct {
 
     pub fn makeWritable(base: *File) !void {
         switch (base.tag) {
-            .coff, .elf, .macho, .plan9 => {
+            .coff, .elf, .macho, .plan9, .wasm => {
                 if (base.file != null) return;
                 const emit = base.options.emit orelse return;
                 base.file = try emit.directory.handle.createFile(emit.sub_path, .{
@@ -357,7 +357,7 @@ pub const File = struct {
                     .mode = determineMode(base.options),
                 });
             },
-            .c, .wasm, .spirv, .nvptx => {},
+            .c, .spirv, .nvptx => {},
         }
     }
 
@@ -391,7 +391,7 @@ pub const File = struct {
                     base.file = null;
                 }
             },
-            .coff, .elf, .plan9 => if (base.file) |f| {
+            .coff, .elf, .plan9, .wasm => if (base.file) |f| {
                 if (base.intermediary_basename != null) {
                     // The file we have open is not the final file that we want to
                     // make executable, so we don't have to close it.
@@ -400,7 +400,7 @@ pub const File = struct {
                 f.close();
                 base.file = null;
             },
-            .c, .wasm, .spirv, .nvptx => {},
+            .c, .spirv, .nvptx => {},
         }
     }
 

--- a/test/link.zig
+++ b/test/link.zig
@@ -31,6 +31,18 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
         .build_modes = true,
     });
 
+    cases.addBuildFile("test/link/wasm/segments/build.zig", .{
+        .build_modes = true,
+    });
+
+    cases.addBuildFile("test/link/wasm/stack_pointer/build.zig", .{
+        .build_modes = true,
+    });
+
+    cases.addBuildFile("test/link/wasm/bss/build.zig", .{
+        .build_modes = true,
+    });
+
     if (builtin.os.tag == .macos) {
         cases.addBuildFile("test/link/macho/entry/build.zig", .{
             .build_modes = true,

--- a/test/link.zig
+++ b/test/link.zig
@@ -29,18 +29,22 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
 
     cases.addBuildFile("test/link/wasm/type/build.zig", .{
         .build_modes = true,
+        .requires_stage2 = true,
     });
 
     cases.addBuildFile("test/link/wasm/segments/build.zig", .{
         .build_modes = true,
+        .requires_stage2 = true,
     });
 
     cases.addBuildFile("test/link/wasm/stack_pointer/build.zig", .{
         .build_modes = true,
+        .requires_stage2 = true,
     });
 
     cases.addBuildFile("test/link/wasm/bss/build.zig", .{
         .build_modes = true,
+        .requires_stage2 = true,
     });
 
     if (builtin.os.tag == .macos) {

--- a/test/link.zig
+++ b/test/link.zig
@@ -27,6 +27,10 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
         .build_modes = true,
     });
 
+    cases.addBuildFile("test/link/wasm/type/build.zig", .{
+        .build_modes = true,
+    });
+
     if (builtin.os.tag == .macos) {
         cases.addBuildFile("test/link/macho/entry/build.zig", .{
             .build_modes = true,

--- a/test/link/wasm/bss/build.zig
+++ b/test/link/wasm/bss/build.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    const test_step = b.step("test", "Test");
+    test_step.dependOn(b.getInstallStep());
+
+    const lib = b.addSharedLibrary("lib", "lib.zig", .unversioned);
+    lib.setBuildMode(mode);
+    lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    lib.use_llvm = false;
+    lib.use_stage1 = false;
+    lib.use_lld = false;
+    // to make sure the bss segment is emitted, we must import memory
+    lib.import_memory = true;
+    lib.install();
+
+    const check_lib = lib.checkObject(.wasm);
+
+    // since we import memory, make sure it exists with the correct naming
+    check_lib.checkStart("Section import");
+    check_lib.checkNext("entries 1");
+    check_lib.checkNext("module env"); // default module name is "env"
+    check_lib.checkNext("name memory"); // as per linker specification
+
+    // since we are importing memory, ensure it's not exported
+    check_lib.checkStart("Section export");
+    check_lib.checkNext("entries 1"); // we're exporting function 'foo' so only 1 entry
+
+    // validate the name of the stack pointer
+    check_lib.checkStart("Section custom");
+    check_lib.checkNext("type data_segment");
+    check_lib.checkNext("names 2");
+    check_lib.checkNext("index 0");
+    check_lib.checkNext("name .rodata");
+    check_lib.checkNext("index 1"); // bss section always last
+    check_lib.checkNext("name .bss");
+    test_step.dependOn(&check_lib.step);
+}

--- a/test/link/wasm/bss/lib.zig
+++ b/test/link/wasm/bss/lib.zig
@@ -1,0 +1,5 @@
+pub var bss: u32 = undefined;
+
+export fn foo() void {
+    _ = bss;
+}

--- a/test/link/wasm/segments/build.zig
+++ b/test/link/wasm/segments/build.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    const test_step = b.step("test", "Test");
+    test_step.dependOn(b.getInstallStep());
+
+    const lib = b.addSharedLibrary("lib", "lib.zig", .unversioned);
+    lib.setBuildMode(mode);
+    lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    lib.use_llvm = false;
+    lib.use_stage1 = false;
+    lib.use_lld = false;
+    lib.install();
+
+    const check_lib = lib.checkObject(.wasm);
+    check_lib.checkStart("Section data");
+    check_lib.checkNext("entries 2"); // rodata & data, no bss because we're exporting memory
+
+    check_lib.checkStart("Section custom");
+    check_lib.checkStart("name name"); // names custom section
+    check_lib.checkStart("type data_segment");
+    check_lib.checkNext("names 2");
+    check_lib.checkNext("index 0");
+    check_lib.checkNext("name .rodata");
+    check_lib.checkNext("index 1");
+    check_lib.checkNext("name .data");
+    test_step.dependOn(&check_lib.step);
+}

--- a/test/link/wasm/segments/lib.zig
+++ b/test/link/wasm/segments/lib.zig
@@ -1,0 +1,9 @@
+pub const rodata: u32 = 5;
+pub var data: u32 = 10;
+pub var bss: u32 = undefined;
+
+export fn foo() void {
+    _ = rodata;
+    _ = data;
+    _ = bss;
+}

--- a/test/link/wasm/stack_pointer/build.zig
+++ b/test/link/wasm/stack_pointer/build.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    const test_step = b.step("test", "Test");
+    test_step.dependOn(b.getInstallStep());
+
+    const lib = b.addSharedLibrary("lib", "lib.zig", .unversioned);
+    lib.setBuildMode(mode);
+    lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    lib.use_llvm = false;
+    lib.use_stage1 = false;
+    lib.use_lld = false;
+    lib.stack_size = std.wasm.page_size * 2; // set an explicit stack size
+    lib.install();
+
+    const check_lib = lib.checkObject(.wasm);
+
+    // ensure global exists and its initial value is equal to explitic stack size
+    check_lib.checkStart("Section global");
+    check_lib.checkNext("entries 1");
+    check_lib.checkNext("type i32"); // on wasm32 the stack pointer must be i32
+    check_lib.checkNext("mutable true"); // must be able to mutate the stack pointer
+    check_lib.checkNext("i32.const {stack_pointer}");
+    check_lib.checkComputeCompare("stack_pointer", .{ .op = .eq, .value = .{ .literal = lib.stack_size.? } });
+
+    // validate memory section starts after virtual stack
+    check_lib.checkNext("Section data");
+    check_lib.checkNext("i32.const {data_start}");
+    check_lib.checkComputeCompare("data_start", .{ .op = .eq, .value = .{ .variable = "stack_pointer" } });
+
+    // validate the name of the stack pointer
+    check_lib.checkStart("Section custom");
+    check_lib.checkNext("type global");
+    check_lib.checkNext("names 1");
+    check_lib.checkNext("index 0");
+    check_lib.checkNext("name __stack_pointer");
+    test_step.dependOn(&check_lib.step);
+}

--- a/test/link/wasm/stack_pointer/lib.zig
+++ b/test/link/wasm/stack_pointer/lib.zig
@@ -1,0 +1,1 @@
+export fn foo() void {}

--- a/test/link/wasm/type/build.zig
+++ b/test/link/wasm/type/build.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    const test_step = b.step("test", "Test");
+    test_step.dependOn(b.getInstallStep());
+
+    const lib = b.addSharedLibrary("lib", "lib.zig", .unversioned);
+    lib.setBuildMode(mode);
+    lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    lib.use_llvm = false;
+    lib.use_stage1 = false;
+    lib.use_lld = false;
+    lib.install();
+
+    const check_lib = lib.checkObject(.wasm);
+    check_lib.checkStart("Section type");
+    // only 2 entries, although we have 3 functions.
+    // This is to test functions with the same function signature
+    // have their types deduplicated.
+    check_lib.checkNext("entries 2");
+    check_lib.checkNext("params 1");
+    check_lib.checkNext("type i32");
+    check_lib.checkNext("returns 1");
+    check_lib.checkNext("type i64");
+    check_lib.checkNext("params 0");
+    check_lib.checkNext("returns 0");
+
+    test_step.dependOn(&check_lib.step);
+}

--- a/test/link/wasm/type/lib.zig
+++ b/test/link/wasm/type/lib.zig
@@ -1,0 +1,10 @@
+export fn foo(x: u32) u64 {
+    return bar(x);
+}
+
+fn bar(x: u32) u64 {
+    y();
+    return x;
+}
+
+fn y() void {}

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -462,6 +462,7 @@ pub fn addStandaloneTests(
     skip_non_native: bool,
     enable_macos_sdk: bool,
     target: std.zig.CrossTarget,
+    omit_stage2: bool,
 ) *build.Step {
     const cases = b.allocator.create(StandaloneContext) catch unreachable;
     cases.* = StandaloneContext{
@@ -473,6 +474,7 @@ pub fn addStandaloneTests(
         .skip_non_native = skip_non_native,
         .enable_macos_sdk = enable_macos_sdk,
         .target = target,
+        .omit_stage2 = omit_stage2,
     };
 
     standalone.addCases(cases);
@@ -485,6 +487,7 @@ pub fn addLinkTests(
     test_filter: ?[]const u8,
     modes: []const Mode,
     enable_macos_sdk: bool,
+    omit_stage2: bool,
 ) *build.Step {
     const cases = b.allocator.create(StandaloneContext) catch unreachable;
     cases.* = StandaloneContext{
@@ -496,6 +499,7 @@ pub fn addLinkTests(
         .skip_non_native = true,
         .enable_macos_sdk = enable_macos_sdk,
         .target = .{},
+        .omit_stage2 = omit_stage2,
     };
     link.addCases(cases);
     return cases.step;
@@ -957,6 +961,7 @@ pub const StandaloneContext = struct {
     skip_non_native: bool,
     enable_macos_sdk: bool,
     target: std.zig.CrossTarget,
+    omit_stage2: bool,
 
     pub fn addC(self: *StandaloneContext, root_src: []const u8) void {
         self.addAllArgs(root_src, true);
@@ -970,10 +975,12 @@ pub const StandaloneContext = struct {
         build_modes: bool = false,
         cross_targets: bool = false,
         requires_macos_sdk: bool = false,
+        requires_stage2: bool = false,
     }) void {
         const b = self.b;
 
         if (features.requires_macos_sdk and !self.enable_macos_sdk) return;
+        if (features.requires_stage2 and self.omit_stage2) return;
 
         const annotated_case_name = b.fmt("build {s}", .{build_file});
         if (self.test_filter) |filter| {


### PR DESCRIPTION
Implements the linker-tests framework for the self-hosted wasm linker.
This includes a few test cases, as well as small fixes within the self-hosted linker that were caught during the implementation of the tests.

Note: This adds the `-fno-LLD` and `-fLDD` options to `build.zig` to make sure the self-hosted linker is used, rather than wasm-ld when running the tests.