### PR TITLE
`std.log`: deduplicate `switch`

### DIFF
--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -85,12 +85,7 @@ pub const Level = enum {
     debug,
 
     /// Returns a string literal of the given level in full text form.
-    pub fn asText(comptime self: Level) switch (self) {
-        .err => @TypeOf("error"),
-        .warn => @TypeOf("warning"),
-        .info => @TypeOf("info"),
-        .debug => @TypeOf("debug"),
-    } {
+    pub fn asText(comptime self: Level) []const u8 {
         return switch (self) {
             .err => "error",
             .warn => "warning",


### PR DESCRIPTION
Instead of having a distinct type for every string length, we can generalize it using `[]const u8` to return a string of any length.