### PR TITLE
`std.log`: give friendly error to freestanding users

### DIFF
--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -156,11 +156,11 @@ pub fn defaultLog(
     comptime format: []const u8,
     args: anytype,
 ) void {
-    if (builtin.os.tag == .freestanding) {
-        // On freestanding one must provide a log function; we do not have
-        // any I/O configured.
-        return;
-    }
+    if (builtin.os.tag == .freestanding)
+        @compileError(
+            \\freestanding targets do not have I/O configured;
+            \\please provide at least an empty `log` function declaration
+        );
 
     const level_txt = comptime message_level.asText();
     const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";

--- a/test/standalone/issue_7030/main.zig
+++ b/test/standalone/issue_7030/main.zig
@@ -1,5 +1,17 @@
 const std = @import("std");
 
+pub fn log(
+    comptime message_level: std.log.Level,
+    comptime scope: @Type(.EnumLiteral),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    _ = message_level;
+    _ = scope;
+    _ = format;
+    _ = args;
+}
+
 pub fn main() anyerror!void {
     std.log.info("All your codebase are belong to us.", .{});
 }


### PR DESCRIPTION
@InKryption and I came to the conclusion that it'd be much nicer if instead of doing nothing `std.log.debug` etc. gave an error if you use it on a freestanding target with no top level `log` function available.
The reason this `builtin.os.tag == .freestanding` branch was added is #6252 where the issue was that when they tried to use the GPA, it would also semantically analyze `std.log`'s stuff which in turn would cause errors because most likely you did not implement any of that I/O stuff. Of course it is silly to require the user to implement all that I/O stuff when you just want to allocate.

However I think that if you choose to use the GPA, an allocator that can log messages, you should accept that you will also have to deal with the burden of some of the GPA's functionality not being implemented, so with this change you will be required to at least provide an empty top level function declaration like this in order for your code to compile again:

```zig
pub fn log(
    comptime message_level: std.log.Level,
    comptime scope: @Type(.EnumLiteral),
    comptime format: []const u8,
    args: anytype,
) void {
    _ = message_level;
    _ = scope;
    _ = format;
    _ = args;
}
```

An added benefit is that it's much harder to miss the safety messages from the allocator ([like andrew said](https://github.com/ziglang/zig/issues/6252#issuecomment-687354380)).

It's just incredibly confusing when you try to use `std.log.debug` on say `wasm32-freestanding` and it somehow compiles (while `_ = std.io.getStdOut().write("hello") catch unreachable;` doesn't due to a missing `os` implementation) and then when you execute it it doesn't do anything.