### PR TITLE
Sema: accept thumb and thumbeb with ARM calling conventions

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7161,7 +7161,7 @@ fn funcCommon(
                 else => @as([]const u8, "i386 and AArch64"),
             },
             .APCS, .AAPCS, .AAPCSVFP => switch (arch) {
-                .arm, .armeb, .aarch64, .aarch64_be, .aarch64_32 => null,
+                .arm, .armeb, .aarch64, .aarch64_be, .aarch64_32, .thumb, .thumbeb => null,
                 else => @as([]const u8, "ARM"),
             },
             .SysV, .Win64 => switch (arch) {


### PR DESCRIPTION
Commit 3014a0d5f1dcbcfdcec3852ffd54f3c589fe3e83 added calling convention validation, but left out thumb and thumbeb from the archs that can use the ARM-specific calling conventions. This plus a8a7f15106abef7c647d4de572a04b77ce048dd6 made compilation fail for thumb targets.