### PR TITLE
stage2: fix @sizeOf() for vector types.

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -3254,7 +3254,7 @@ pub const Type = extern union {
 
             .array_u8 => return AbiSizeAdvanced{ .scalar = ty.castTag(.array_u8).?.data },
             .array_u8_sentinel_0 => return AbiSizeAdvanced{ .scalar = ty.castTag(.array_u8_sentinel_0).?.data + 1 },
-            .array, .vector => {
+            .array => {
                 const payload = ty.cast(Payload.Array).?.data;
                 switch (try payload.elem_type.abiSizeAdvanced(target, strat)) {
                     .scalar => |elem_size| return AbiSizeAdvanced{ .scalar = payload.len * elem_size },
@@ -3265,6 +3265,7 @@ pub const Type = extern union {
                     },
                 }
             },
+            .vector => return AbiSizeAdvanced{ .scalar = abiAlignment(ty, target) },
             .array_sentinel => {
                 const payload = ty.castTag(.array_sentinel).?.data;
                 switch (try payload.elem_type.abiSizeAdvanced(target, strat)) {

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -1076,6 +1076,90 @@ test "alignment of vectors" {
     try expect(@alignOf(@Vector(2, u1)) == 1);
     try expect(@alignOf(@Vector(1, u1)) == 1);
     try expect(@alignOf(@Vector(2, u16)) == 4);
+
+    try expect(@alignOf(@Vector(7, i8)) == 8);
+    try expect(@alignOf(@Vector(8, i8)) == 8);
+    try expect(@alignOf(@Vector(9, i8)) == 16);
+
+    const specialcase_16_bytes = switch (builtin.target.cpu.arch) {
+        .arm, .armeb, .thumb, .thumbeb => true,
+        else => false,
+    };
+
+    try expect(@alignOf(@Vector(15, i8)) == 16);
+    if (specialcase_16_bytes) {
+        if (builtin.zig_backend == .stage1) {
+            try expect(@alignOf(@Vector(16, i8)) == 8);
+        } else {
+            // TODO
+            // https://github.com/ziglang/zig/issues/12137
+        }
+    } else {
+        try expect(@alignOf(@Vector(16, i8)) == 16);
+    }
+    try expect(@alignOf(@Vector(17, i8)) == 32);
+
+    try expect(@alignOf(@Vector(31, i8)) == 32);
+    try expect(@alignOf(@Vector(32, i8)) == 32);
+    try expect(@alignOf(@Vector(33, i8)) == 64);
+
+    try expect(@alignOf(@Vector(3, u16)) == 8);
+    try expect(@alignOf(@Vector(3, u64)) == 32);
+    try expect(@alignOf(@Vector(1, *u8)) == @sizeOf(*u8) * 1);
+    try expect(@alignOf(@Vector(2, *u8)) == @sizeOf(*u8) * 2);
+    try expect(@alignOf(@Vector(3, *u8)) == @sizeOf(*u8) * 4);
+
+    try expect(@alignOf(@Vector(3, f32)) == 16);
+    if (specialcase_16_bytes) {
+        if (builtin.zig_backend == .stage1) {
+            try expect(@alignOf(@Vector(4, f32)) == 8);
+        } else {
+            // TODO
+            // https://github.com/ziglang/zig/issues/12137
+        }
+    } else {
+        try expect(@alignOf(@Vector(4, f32)) == 16);
+    }
+    try expect(@alignOf(@Vector(5, f32)) == 32);
+
+    try expect(@alignOf(@Vector(8, bool)) == 1);
+    try expect(@alignOf(@Vector(8, u1)) == 1);
+    try expect(@alignOf(@Vector(9, u1)) == 2);
+    try expect(@alignOf(@Vector(32, u1)) == 4);
+    try expect(@alignOf(@Vector(33, u1)) == 8);
+}
+
+test "size of vectors" {
+    try expect(@sizeOf(@Vector(2, u8)) == 2);
+    try expect(@sizeOf(@Vector(2, u1)) == 1);
+    try expect(@sizeOf(@Vector(1, u1)) == 1);
+    try expect(@sizeOf(@Vector(2, u16)) == 4);
+
+    try expect(@sizeOf(@Vector(7, i8)) == 8);
+    try expect(@sizeOf(@Vector(8, i8)) == 8);
+    try expect(@sizeOf(@Vector(9, i8)) == 16);
+    try expect(@sizeOf(@Vector(15, i8)) == 16);
+    try expect(@sizeOf(@Vector(16, i8)) == 16);
+    try expect(@sizeOf(@Vector(17, i8)) == 32);
+    try expect(@sizeOf(@Vector(31, i8)) == 32);
+    try expect(@sizeOf(@Vector(32, i8)) == 32);
+    try expect(@sizeOf(@Vector(33, i8)) == 64);
+
+    try expect(@sizeOf(@Vector(3, u16)) == 8);
+    try expect(@sizeOf(@Vector(3, u64)) == 32);
+    try expect(@sizeOf(@Vector(1, *u8)) == @sizeOf(*u8) * 1);
+    try expect(@sizeOf(@Vector(2, *u8)) == @sizeOf(*u8) * 2);
+    try expect(@sizeOf(@Vector(3, *u8)) == @sizeOf(*u8) * 4);
+
+    try expect(@sizeOf(@Vector(3, f32)) == 16);
+    try expect(@sizeOf(@Vector(4, f32)) == 16);
+    try expect(@sizeOf(@Vector(5, f32)) == 32);
+
+    try expect(@sizeOf(@Vector(8, bool)) == 1);
+    try expect(@sizeOf(@Vector(8, u1)) == 1);
+    try expect(@sizeOf(@Vector(9, u1)) == 2);
+    try expect(@sizeOf(@Vector(32, u1)) == 4);
+    try expect(@sizeOf(@Vector(33, u1)) == 8);
 }
 
 test "loading the second vector from a slice of vectors" {


### PR DESCRIPTION

stage1 does
```c++
        entry->abi_size = LLVMABISizeOfType(g->target_data_ref, example_vector_llvm_type);
        entry->abi_align = LLVMABIAlignmentOfType(g->target_data_ref, example_vector_llvm_type);
```

but looks like it's actually pretty direct, same as alignment. (next power-of-2)
maybe some architectures are different? 


follow-up of https://github.com/ziglang/zig/commit/095e24e537fcb6a702b992d946d1ca73d6f608b3

closes #12026