### PR TITLE
Indent multiline error messages properly

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -393,7 +393,8 @@ pub const AllErrors = struct {
             indent: usize,
         ) anyerror!void {
             const stderr = stderr_file.writer();
-            const counting_stderr = std.io.countingWriter(stderr).writer();
+            var counting_writer = std.io.countingWriter(stderr);
+            const counting_stderr = counting_writer.writer();
             switch (msg) {
                 .src => |src| {
                     try counting_stderr.writeByteNTimes(' ', indent);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -367,7 +367,7 @@ pub const AllErrors = struct {
             std.debug.getStderrMutex().lock();
             defer std.debug.getStderrMutex().unlock();
             const stderr = std.io.getStdErr();
-            return msg.renderToStdErrInner(ttyconf, stderr, "error:", .Red, 0) catch return;
+            return msg.renderToStdErrInner(ttyconf, stderr, "error", .Red, 0) catch return;
         }
 
         fn renderToStdErrInner(
@@ -390,12 +390,13 @@ pub const AllErrors = struct {
                     });
                     ttyconf.setColor(stderr, color);
                     try stderr.writeAll(kind);
+                    try stderr.writeAll(": ");
                     ttyconf.setColor(stderr, .Reset);
                     ttyconf.setColor(stderr, .Bold);
                     if (src.count == 1) {
-                        try stderr.print(" {s}\n", .{src.msg});
+                        try stderr.print("{s}\n", .{src.msg});
                     } else {
-                        try stderr.print(" {s}", .{src.msg});
+                        try stderr.print("{s}", .{src.msg});
                         ttyconf.setColor(stderr, .Dim);
                         try stderr.print(" ({d} times)\n", .{src.count});
                     }
@@ -414,24 +415,25 @@ pub const AllErrors = struct {
                         }
                     }
                     for (src.notes) |note| {
-                        try note.renderToStdErrInner(ttyconf, stderr_file, "note:", .Cyan, indent);
+                        try note.renderToStdErrInner(ttyconf, stderr_file, "note", .Cyan, indent);
                     }
                 },
                 .plain => |plain| {
                     ttyconf.setColor(stderr, color);
                     try stderr.writeByteNTimes(' ', indent);
                     try stderr.writeAll(kind);
+                    try stderr.writeAll(": ");
                     ttyconf.setColor(stderr, .Reset);
                     if (plain.count == 1) {
-                        try stderr.print(" {s}\n", .{plain.msg});
+                        try stderr.print("{s}\n", .{plain.msg});
                     } else {
-                        try stderr.print(" {s}", .{plain.msg});
+                        try stderr.print("{s}", .{plain.msg});
                         ttyconf.setColor(stderr, .Dim);
                         try stderr.print(" ({d} times)\n", .{plain.count});
                     }
                     ttyconf.setColor(stderr, .Reset);
                     for (plain.notes) |note| {
-                        try note.renderToStdErrInner(ttyconf, stderr_file, "error:", .Red, indent + 4);
+                        try note.renderToStdErrInner(ttyconf, stderr_file, "error", .Red, indent + 4);
                     }
                 },
             }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -381,18 +381,17 @@ pub const AllErrors = struct {
             std.debug.getStderrMutex().lock();
             defer std.debug.getStderrMutex().unlock();
             const stderr = std.io.getStdErr();
-            return msg.renderToStdErrInner(ttyconf, stderr, "error", .Red, 0) catch return;
+            return msg.renderToWriter(ttyconf, stderr.writer(), "error", .Red, 0) catch return;
         }
 
-        fn renderToStdErrInner(
+        pub fn renderToWriter(
             msg: Message,
             ttyconf: std.debug.TTY.Config,
-            stderr_file: std.fs.File,
+            stderr: anytype,
             kind: []const u8,
             color: std.debug.TTY.Color,
             indent: usize,
         ) anyerror!void {
-            const stderr = stderr_file.writer();
             var counting_writer = std.io.countingWriter(stderr);
             const counting_stderr = counting_writer.writer();
             switch (msg) {
@@ -435,7 +434,7 @@ pub const AllErrors = struct {
                         }
                     }
                     for (src.notes) |note| {
-                        try note.renderToStdErrInner(ttyconf, stderr_file, "note", .Cyan, indent);
+                        try note.renderToWriter(ttyconf, stderr, "note", .Cyan, indent);
                     }
                 },
                 .plain => |plain| {
@@ -453,7 +452,7 @@ pub const AllErrors = struct {
                     }
                     ttyconf.setColor(stderr, .Reset);
                     for (plain.notes) |note| {
-                        try note.renderToStdErrInner(ttyconf, stderr_file, "error", .Red, indent + 4);
+                        try note.renderToWriter(ttyconf, stderr, "error", .Red, indent + 4);
                     }
                 },
             }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -409,7 +409,7 @@ pub const AllErrors = struct {
                     try counting_stderr.writeAll(": ");
                     // This is the length of the part before the error message:
                     // e.g. "file.zig:4:5: error: "
-                    const prefix_len = counting_stderr.context.bytes_written;
+                    const prefix_len = @intCast(usize, counting_stderr.context.bytes_written);
                     ttyconf.setColor(stderr, .Reset);
                     ttyconf.setColor(stderr, .Bold);
                     if (src.count == 1) {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -138,43 +138,6 @@ pub fn addCases(ctx: *TestContext) !void {
         "tmp.zig:2:1: error: invalid character: '\\t'",
     });
 
-    // TODO: uncomment this in stage2
-    // {
-    //     const case = ctx.obj("multiline error messages", .{});
-    //     case.backend = .stage2;
-    //
-    //     case.addError(
-    //         \\comptime {
-    //         \\    @compileError("hello\nworld");
-    //         \\}
-    //     , &[_][]const u8{
-    //         \\tmp.zig:2:5: error: hello
-    //         \\                    world
-    //     });
-    //
-    //     case.addError(
-    //         \\comptime {
-    //         \\    @compileError(
-    //         \\        \\
-    //         \\        \\hello!
-    //         \\        \\I'm a multiline error message.
-    //         \\        \\I hope to be very useful!
-    //         \\        \\
-    //         \\        \\also I will leave this trailing newline here if you don't mind
-    //         \\        \\
-    //         \\    );
-    //         \\}
-    //     , &[_][]const u8{
-    //         \\tmp.zig:2:5: error:
-    //         \\                    hello!
-    //         \\                    I'm a multiline error message.
-    //         \\                    I hope to be very useful!
-    //         \\
-    //         \\                    also I will leave this trailing newline here if you don't mind
-    //         \\
-    //     });
-    // }
-
     // TODO test this in stage2, but we won't even try in stage1
     //ctx.objErrStage1("inline fn calls itself indirectly",
     //    \\export fn foo() void {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -138,6 +138,42 @@ pub fn addCases(ctx: *TestContext) !void {
         "tmp.zig:2:1: error: invalid character: '\\t'",
     });
 
+    {
+        const case = ctx.obj("multiline error messages", .{});
+        case.backend = .stage2;
+
+        case.addError(
+            \\comptime {
+            \\    @compileError("hello\nworld");
+            \\}
+        , &[_][]const u8{
+            \\tmp.zig:2:5: error: hello
+            \\                    world
+        });
+
+        case.addError(
+            \\comptime {
+            \\    @compileError(
+            \\        \\
+            \\        \\hello!
+            \\        \\I'm a multiline error message.
+            \\        \\I hope to be very useful!
+            \\        \\
+            \\        \\also I will leave this trailing newline here if you don't mind
+            \\        \\
+            \\    );
+            \\}
+        , &[_][]const u8{
+            \\tmp.zig:2:5: error:
+            \\                    hello!
+            \\                    I'm a multiline error message.
+            \\                    I hope to be very useful!
+            \\
+            \\                    also I will leave this trailing newline here if you don't mind
+            \\
+        });
+    }
+
     // TODO test this in stage2, but we won't even try in stage1
     //ctx.objErrStage1("inline fn calls itself indirectly",
     //    \\export fn foo() void {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -138,6 +138,42 @@ pub fn addCases(ctx: *TestContext) !void {
         "tmp.zig:2:1: error: invalid character: '\\t'",
     });
 
+    {
+        const case = ctx.obj("multiline error messages", .{});
+        case.backend = .stage2;
+
+        case.addError(
+            \\comptime {
+            \\    @compileError("hello\nworld");
+            \\}
+        , &[_][]const u8{
+            \\:2:5: error: hello
+            \\             world
+        });
+
+        case.addError(
+            \\comptime {
+            \\    @compileError(
+            \\        \\
+            \\        \\hello!
+            \\        \\I'm a multiline error message.
+            \\        \\I hope to be very useful!
+            \\        \\
+            \\        \\also I will leave this trailing newline here if you don't mind
+            \\        \\
+            \\    );
+            \\}
+        , &[_][]const u8{
+            \\:2:5: error: 
+            \\             hello!
+            \\             I'm a multiline error message.
+            \\             I hope to be very useful!
+            \\             
+            \\             also I will leave this trailing newline here if you don't mind
+            \\             
+        });
+    }
+
     // TODO test this in stage2, but we won't even try in stage1
     //ctx.objErrStage1("inline fn calls itself indirectly",
     //    \\export fn foo() void {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -138,41 +138,42 @@ pub fn addCases(ctx: *TestContext) !void {
         "tmp.zig:2:1: error: invalid character: '\\t'",
     });
 
-    {
-        const case = ctx.obj("multiline error messages", .{});
-        case.backend = .stage2;
-
-        case.addError(
-            \\comptime {
-            \\    @compileError("hello\nworld");
-            \\}
-        , &[_][]const u8{
-            \\tmp.zig:2:5: error: hello
-            \\                    world
-        });
-
-        case.addError(
-            \\comptime {
-            \\    @compileError(
-            \\        \\
-            \\        \\hello!
-            \\        \\I'm a multiline error message.
-            \\        \\I hope to be very useful!
-            \\        \\
-            \\        \\also I will leave this trailing newline here if you don't mind
-            \\        \\
-            \\    );
-            \\}
-        , &[_][]const u8{
-            \\tmp.zig:2:5: error:
-            \\                    hello!
-            \\                    I'm a multiline error message.
-            \\                    I hope to be very useful!
-            \\
-            \\                    also I will leave this trailing newline here if you don't mind
-            \\
-        });
-    }
+    // TODO: uncomment this in stage2
+    // {
+    //     const case = ctx.obj("multiline error messages", .{});
+    //     case.backend = .stage2;
+    //
+    //     case.addError(
+    //         \\comptime {
+    //         \\    @compileError("hello\nworld");
+    //         \\}
+    //     , &[_][]const u8{
+    //         \\tmp.zig:2:5: error: hello
+    //         \\                    world
+    //     });
+    //
+    //     case.addError(
+    //         \\comptime {
+    //         \\    @compileError(
+    //         \\        \\
+    //         \\        \\hello!
+    //         \\        \\I'm a multiline error message.
+    //         \\        \\I hope to be very useful!
+    //         \\        \\
+    //         \\        \\also I will leave this trailing newline here if you don't mind
+    //         \\        \\
+    //         \\    );
+    //         \\}
+    //     , &[_][]const u8{
+    //         \\tmp.zig:2:5: error:
+    //         \\                    hello!
+    //         \\                    I'm a multiline error message.
+    //         \\                    I hope to be very useful!
+    //         \\
+    //         \\                    also I will leave this trailing newline here if you don't mind
+    //         \\
+    //     });
+    // }
 
     // TODO test this in stage2, but we won't even try in stage1
     //ctx.objErrStage1("inline fn calls itself indirectly",


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/35064754/177806664-b19f3ad5-f318-4a9f-8019-240ae3cf329b.png)

## After

![image](https://user-images.githubusercontent.com/35064754/177806605-33d03a76-751d-4b82-8877-810b028931ac.png)

Now we can finally write long multiline error messages and they'll look nice!

While working on #12021 I thought it'd be really nice if we could actually make multiline error messages look nice so I worked on this. In hindsight, maybe the newline after the semicolon there wasn't really needed but that's besides the point of this PR.

One argument against this might be that error messages should be concise and you should never need more than one line but I think that's just not really a helpful rule.

I mainly did this so that *users* (i.e. `"this is bad"`) rather than lang devs (i.e. `"struct 'x.x' has no member named 'main'"`) could write longer error messages.
So if I as a lib dev for example like to give my users long helpful error messages because that's my style, why not allow me to write longer error messages that span more than one line?
Of course this was always possible but it always felt off when all lines after the first one weren't properly indented.
Originally I thought about only doing this for the messages of `@compileError` but ultimately that seemed even more complicated so this is doing it for every error message which means lang devs can use this feature for multiline error messages too, which is more consistent anyway.
