### PR TITLE
stage2: Fix panic when printing AIR for tuple/anon struct types

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -5372,6 +5372,18 @@ pub const Type = extern union {
         }
     }
 
+    pub fn structFieldName(ty: Type, field_index: usize) []const u8 {
+        switch (ty.tag()) {
+            .@"struct" => {
+                const struct_obj = ty.castTag(.@"struct").?.data;
+                assert(struct_obj.haveFieldTypes());
+                return struct_obj.fields.keys()[field_index];
+            },
+            .anon_struct => return ty.castTag(.anon_struct).?.data.names[field_index],
+            else => unreachable,
+        }
+    }
+
     pub fn structFieldCount(ty: Type) usize {
         switch (ty.tag()) {
             .@"struct" => {


### PR DESCRIPTION
With these changes, it's now possible to print the AIR (`--verbose-air`) for:

```zig
test {
    const anon_st = .{ .foo = 1, .bar = 2 };
    _ = &anon_st.bar;

    const anon_t = .{ 1, 2 };
    _ = &anon_t.@"0";

    const str: []const u8 = &[_]u8{ 1, 2, 3 };
    _ = &str.len;
}
```

This also changes it so that comptime fields are always printed, for both structs and tuples.

The printing of slices could use some improvement still, but this is a step in the right direction.