### PR TITLE
stage2: Support initializing anonymous struct type

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -5432,6 +5432,24 @@ pub const Type = extern union {
         }
     }
 
+    pub fn structFieldDefaultValue(ty: Type, index: usize) Value {
+        switch (ty.tag()) {
+            .@"struct" => {
+                const struct_obj = ty.castTag(.@"struct").?.data;
+                return struct_obj.fields.values()[index].default_val;
+            },
+            .tuple => {
+                const tuple = ty.castTag(.tuple).?.data;
+                return tuple.values[index];
+            },
+            .anon_struct => {
+                const struct_obj = ty.castTag(.anon_struct).?.data;
+                return struct_obj.values[index];
+            },
+            else => unreachable,
+        }
+    }
+
     pub fn structFieldValueComptime(ty: Type, index: usize) ?Value {
         switch (ty.tag()) {
             .@"struct" => {

--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -221,20 +221,14 @@ test "fieldParentPtr of anon struct" {
 }
 
 test "offsetOf tuple" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
-
     var x: u32 = 0;
     const T = @TypeOf(.{ x, x });
-
     _ = @offsetOf(T, "1");
 }
 
 test "offsetOf anon struct" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
-
     var x: u32 = 0;
     const T = @TypeOf(.{ .foo = x, .bar = x });
-
     _ = @offsetOf(T, "bar");
 }
 

--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -197,3 +197,61 @@ test "initializing tuple with explicit type" {
     var a = T{ 0, 0 };
     _ = a;
 }
+
+test "initializing anon struct with explicit type" {
+    const T = @TypeOf(.{ .foo = @as(i32, 1), .bar = @as(i32, 2) });
+    var a = T{ .foo = 1, .bar = 2 };
+    _ = a;
+}
+
+test "fieldParentPtr of tuple" {
+    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
+
+    var x: u32 = 0;
+    const tuple = .{ x, x };
+    try testing.expect(&tuple == @fieldParentPtr(@TypeOf(tuple), "1", &tuple[1]));
+}
+
+test "fieldParentPtr of anon struct" {
+    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
+
+    var x: u32 = 0;
+    const anon_st = .{ .foo = x, .bar = x };
+    try testing.expect(&anon_st == @fieldParentPtr(@TypeOf(anon_st), "bar", &anon_st.bar));
+}
+
+test "offsetOf tuple" {
+    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
+
+    var x: u32 = 0;
+    const T = @TypeOf(.{ x, x });
+
+    _ = @offsetOf(T, "1");
+}
+
+test "offsetOf anon struct" {
+    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
+
+    var x: u32 = 0;
+    const T = @TypeOf(.{ .foo = x, .bar = x });
+
+    _ = @offsetOf(T, "bar");
+}
+
+test "initializing tuple with mixed comptime-runtime fields" {
+    if (true) return error.SkipZigTest; // TODO
+
+    var x: u32 = 15;
+    const T = @TypeOf(.{ @as(i32, -1234), @as(u32, 5678), x });
+    var a: T = .{ -1234, 5678, x + 1 };
+    _ = a;
+}
+
+test "initializing anon struct with mixed comptime-runtime fields" {
+    if (true) return error.SkipZigTest; // TODO
+
+    var x: u32 = 15;
+    const T = @TypeOf(.{ .foo = @as(i32, -1234), .bar = x });
+    var a: T = .{ .foo = -1234, .bar = x + 1 };
+    _ = a;
+}

--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -205,7 +205,10 @@ test "initializing anon struct with explicit type" {
 }
 
 test "fieldParentPtr of tuple" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     var x: u32 = 0;
     const tuple = .{ x, x };
@@ -213,7 +216,10 @@ test "fieldParentPtr of tuple" {
 }
 
 test "fieldParentPtr of anon struct" {
-    if (builtin.zig_backend != .stage1) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
 
     var x: u32 = 0;
     const anon_st = .{ .foo = x, .bar = x };

--- a/test/cases/compile_errors/offsetOf-bad_field_name.zig
+++ b/test/cases/compile_errors/offsetOf-bad_field_name.zig
@@ -9,5 +9,5 @@ export fn foo() usize {
 // backend=stage2
 // target=native
 //
-// :5:27: error: struct 'tmp.Foo' has no field 'a'
+// :5:27: error: no field named 'a' in struct 'tmp.Foo'
 // :1:13: note: struct declared here


### PR DESCRIPTION
Adds support for initializing `.anon_struct` types. Resolves #12030.

During this change, I noticed some loose ends still open from #11162, so I've added skipped behavior tests covering the missing functionality. I also filed  #12049 since we don't currently have a way to add skipped compile error tests (AFAIK)