### PR TITLE
Add std.math.degrees and std.math.radians

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -293,31 +293,31 @@ pub inline fn tan(value: anytype) @TypeOf(value) {
 }
 
 // Convert an angle in radians to degrees. T must be a float type.
-pub inline fn degrees(comptime T: type, angle_in_radians: T) T {
+pub fn radiansToDegrees(comptime T: type, angle_in_radians: T) T {
     if (@typeInfo(T) != .Float)
         @compileError("T must be a float type.");
     return angle_in_radians * 180.0 / pi;
 }
 
-test "degrees" {
-    try std.testing.expectApproxEqAbs(@as(f32, 0), degrees(f32, 0), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 90), degrees(f32, pi / 2.0), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, -45), degrees(f32, -pi / 4.0), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 180), degrees(f32, pi), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 360), degrees(f32, 2.0 * pi), 1e-6);
+test "radiansToDegrees" {
+    try std.testing.expectApproxEqAbs(@as(f32, 0), radiansToDegrees(f32, 0), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 90), radiansToDegrees(f32, pi / 2.0), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -45), radiansToDegrees(f32, -pi / 4.0), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 180), radiansToDegrees(f32, pi), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 360), radiansToDegrees(f32, 2.0 * pi), 1e-6);
 }
 
 // Convert an angle in degrees to radians. T must be a float type.
-pub inline fn radians(comptime T: type, angle_in_degrees: T) T {
+pub fn degreesToRadians(comptime T: type, angle_in_degrees: T) T {
     if (@typeInfo(T) != .Float)
         @compileError("T must be a float type.");
     return angle_in_degrees * pi / 180.0;
 }
 
-test "radians" {
-    try std.testing.expectApproxEqAbs(@as(f32, pi / 2.0), radians(f32, 90), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, -3 * pi / 2.0), radians(f32, -270), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 2 * pi), radians(f32, 360), 1e-6);
+test "degreesToRadians" {
+    try std.testing.expectApproxEqAbs(@as(f32, pi / 2.0), degreesToRadians(f32, 90), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -3 * pi / 2.0), degreesToRadians(f32, -270), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 2 * pi), degreesToRadians(f32, 360), 1e-6);
 }
 
 /// Base-e exponential function on a floating point number.

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -292,6 +292,34 @@ pub inline fn tan(value: anytype) @TypeOf(value) {
     return @tan(value);
 }
 
+// Convert an angle in radians to degrees. T must be a float type.
+pub inline fn degrees(comptime T: type, angle_in_radians: T) T {
+    if (@typeInfo(T) != .Float)
+        @compileError("T must be a float type.");
+    return angle_in_radians * 180.0/pi;
+}
+
+test "degrees" {
+    try std.testing.expectApproxEqAbs(@as(f32, 0), degrees(f32, 0), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 90), degrees(f32, pi/2.0), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -45), degrees(f32, -pi/4.0), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 180), degrees(f32, pi), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 360), degrees(f32, 2.0*pi), 1e-6);
+}
+
+// Convert an angle in degrees to radians. T must be a float type.
+pub inline fn radians(comptime T: type, angle_in_degrees: T) T {
+    if (@typeInfo(T) != .Float)
+        @compileError("T must be a float type.");
+    return angle_in_degrees * pi/180.0;
+}
+
+test "radians" {
+    try std.testing.expectApproxEqAbs(@as(f32, pi/2.0), radians(f32, 90), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -3*pi/2.0), radians(f32, -270), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 2*pi), radians(f32, 360), 1e-6);
+}
+
 /// Base-e exponential function on a floating point number.
 /// Uses a dedicated hardware instruction when available.
 /// This is the same as calling the builtin @exp

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -296,28 +296,28 @@ pub inline fn tan(value: anytype) @TypeOf(value) {
 pub inline fn degrees(comptime T: type, angle_in_radians: T) T {
     if (@typeInfo(T) != .Float)
         @compileError("T must be a float type.");
-    return angle_in_radians * 180.0/pi;
+    return angle_in_radians * 180.0 / pi;
 }
 
 test "degrees" {
     try std.testing.expectApproxEqAbs(@as(f32, 0), degrees(f32, 0), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 90), degrees(f32, pi/2.0), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, -45), degrees(f32, -pi/4.0), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 90), degrees(f32, pi / 2.0), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -45), degrees(f32, -pi / 4.0), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 180), degrees(f32, pi), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 360), degrees(f32, 2.0*pi), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 360), degrees(f32, 2.0 * pi), 1e-6);
 }
 
 // Convert an angle in degrees to radians. T must be a float type.
 pub inline fn radians(comptime T: type, angle_in_degrees: T) T {
     if (@typeInfo(T) != .Float)
         @compileError("T must be a float type.");
-    return angle_in_degrees * pi/180.0;
+    return angle_in_degrees * pi / 180.0;
 }
 
 test "radians" {
-    try std.testing.expectApproxEqAbs(@as(f32, pi/2.0), radians(f32, 90), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, -3*pi/2.0), radians(f32, -270), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 2*pi), radians(f32, 360), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, pi / 2.0), radians(f32, 90), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -3 * pi / 2.0), radians(f32, -270), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 2 * pi), radians(f32, 360), 1e-6);
 }
 
 /// Base-e exponential function on a floating point number.


### PR DESCRIPTION
Implements simple conversion functions for `degrees` and `radians`. 

A quick search brings up https://github.com/ziglang/zig/issues/9889 