### PR TITLE
Remove outdated TODO comment in lib/std/start.zig

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -361,7 +361,6 @@ fn wWinMainCRTStartup() callconv(std.os.windows.WINAPI) noreturn {
     std.os.windows.kernel32.ExitProcess(@bitCast(std.os.windows.UINT, result));
 }
 
-// TODO https://github.com/ziglang/zig/issues/265
 fn posixCallMainAndExit() noreturn {
     @setAlignStack(16);
 


### PR DESCRIPTION
Hi, I'm new to zig and I'm so fascinated with it that I just started looking for some quick issues to tackle as the first contribution for me.

- https://github.com/ziglang/zig/issues/3767 

I thought this issue should be a good start, soon realizing that apparently it is already resolved except that one outdated TODO comment remains there. In fact, grep gives me the following result:

```
❯ rg 'issues/265'
lib/std/start.zig
364:// TODO https://github.com/ziglang/zig/issues/265
```

And the function that follows this TODO comment, `posixCallMainAndExit`, seems to be already taking advantage of sentinel-terminated pointers (I suppose [this commit](https://github.com/ziglang/zig/commit/15d415e10b81a66fa3b887fb2a0c20bbcd614d94#diff-d6d2716d80bf9cc45a0051d3ffe1885c2e2af19165a7bb1a9f04c3a595ffffd2) is relevant). So I have concluded that this comment should be outdated.

Resolves #3767