### PR TITLE
Implement EmulatableRunStep for linker tests

### DIFF
--- a/ci/zinc/linux_test.sh
+++ b/ci/zinc/linux_test.sh
@@ -67,6 +67,7 @@ $STAGE1_ZIG build test-cli              -fqemu -fwasmtime
 $STAGE1_ZIG build test-run-translated-c -fqemu -fwasmtime
 $STAGE1_ZIG build docs                  -fqemu -fwasmtime
 $STAGE1_ZIG build test-cases            -fqemu -fwasmtime
+$STAGE1_ZIG build test-link             -fqemu -fwasmtime
 
 # Produce the experimental std lib documentation.
 mkdir -p "$RELEASE_STAGING/docs/std"

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -26,7 +26,7 @@ pub const CheckFileStep = @import("build/CheckFileStep.zig");
 pub const CheckObjectStep = @import("build/CheckObjectStep.zig");
 pub const InstallRawStep = @import("build/InstallRawStep.zig");
 pub const OptionsStep = @import("build/OptionsStep.zig");
-pub const RunCompareStep = @import("build/RunCompareStep.zig");
+pub const EmulatableRunStep = @import("build/EmulatableRunStep.zig");
 
 pub const Builder = struct {
     install_tls: TopLevelStep,
@@ -3605,7 +3605,7 @@ pub const Step = struct {
         translate_c,
         write_file,
         run,
-        run_and_compare,
+        emulatable_run,
         check_file,
         check_object,
         install_raw,

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1891,6 +1891,21 @@ pub const LibExeObjStep = struct {
         return run_step;
     }
 
+    /// Creates an `EmulatableRunStep` with an executable built with `addExecutable`.
+    /// Allows running foreign binaries through emulation platforms such as Qemu or Rosetta.
+    /// When a binary cannot be ran through emulation or the option is disabled, a warning
+    /// will be printed and the binary will *NOT* be ran.
+    pub fn runEmulatable(exe: *LibExeObjStep) *EmulatableRunStep {
+        assert(exe.kind == .exe or exe.kind == .text_exe);
+
+        const run_step = EmulatableRunStep.create(exe.builder.fmt("run {s}", .{exe.step.name}), exe);
+        if (exe.vcpkg_bin_path) |path| {
+            run_step.addPathDir(path);
+        }
+
+        return run_step;
+    }
+
     pub fn checkObject(self: *LibExeObjStep, obj_format: std.Target.ObjectFormat) *CheckObjectStep {
         return CheckObjectStep.create(self.builder, self.getOutputSource(), obj_format);
     }

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -26,6 +26,7 @@ pub const CheckFileStep = @import("build/CheckFileStep.zig");
 pub const CheckObjectStep = @import("build/CheckObjectStep.zig");
 pub const InstallRawStep = @import("build/InstallRawStep.zig");
 pub const OptionsStep = @import("build/OptionsStep.zig");
+pub const RunCompareStep = @import("build/RunCompareStep.zig");
 
 pub const Builder = struct {
     install_tls: TopLevelStep,
@@ -3604,6 +3605,7 @@ pub const Step = struct {
         translate_c,
         write_file,
         run,
+        run_and_compare,
         check_file,
         check_object,
         install_raw,

--- a/lib/std/build/CheckObjectStep.zig
+++ b/lib/std/build/CheckObjectStep.zig
@@ -12,7 +12,7 @@ const CheckObjectStep = @This();
 const Allocator = mem.Allocator;
 const Builder = build.Builder;
 const Step = build.Step;
-const RunCompareStep = build.RunCompareStep;
+const EmulatableRunStep = build.EmulatableRunStep;
 
 pub const base_id = .check_obj;
 
@@ -40,12 +40,12 @@ pub fn create(builder: *Builder, source: build.FileSource, obj_format: std.Targe
 
 /// Runs and (optionally) compares the output of a binary.
 /// Asserts `self` was generated from an executable step.
-pub fn runAndCompare(self: *CheckObjectStep) *RunCompareStep {
+pub fn runAndCompare(self: *CheckObjectStep) *EmulatableRunStep {
     const dependencies_len = self.step.dependencies.items.len;
     assert(dependencies_len > 0);
     const exe_step = self.step.dependencies.items[dependencies_len - 1];
     const exe = exe_step.cast(std.build.LibExeObjStep).?;
-    return RunCompareStep.create(self.builder, "RunCompare", exe);
+    return EmulatableRunStep.create(self.builder, "EmulatableRun", exe);
 }
 
 /// There two types of actions currently suported:

--- a/lib/std/build/CheckObjectStep.zig
+++ b/lib/std/build/CheckObjectStep.zig
@@ -12,6 +12,7 @@ const CheckObjectStep = @This();
 const Allocator = mem.Allocator;
 const Builder = build.Builder;
 const Step = build.Step;
+const RunCompareStep = build.RunCompareStep;
 
 pub const base_id = .check_obj;
 
@@ -35,6 +36,16 @@ pub fn create(builder: *Builder, source: build.FileSource, obj_format: std.Targe
     };
     self.source.addStepDependencies(&self.step);
     return self;
+}
+
+/// Runs and (optionally) compares the output of a binary.
+/// Asserts `self` was generated from an executable step.
+pub fn runAndCompare(self: *CheckObjectStep) *RunCompareStep {
+    const dependencies_len = self.step.dependencies.items.len;
+    assert(dependencies_len > 0);
+    const exe_step = self.step.dependencies.items[dependencies_len - 1];
+    const exe = exe_step.cast(std.build.LibExeObjStep).?;
+    return RunCompareStep.create(self.builder, "RunCompare", exe);
 }
 
 /// There two types of actions currently suported:

--- a/lib/std/build/EmulatableRunStep.zig
+++ b/lib/std/build/EmulatableRunStep.zig
@@ -56,7 +56,12 @@ pub const StdIoAction = union(enum) {
 pub fn create(builder: *Builder, name: []const u8, artifact: *LibExeObjStep) *EmulatableRunStep {
     std.debug.assert(artifact.kind == .exe or artifact.kind == .test_exe);
     const self = builder.allocator.create(EmulatableRunStep) catch unreachable;
-    const hide_warnings = builder.option(bool, "hide-foreign-warnings", "Hide the warning when a foreign binary which is incompatible is skipped") orelse false;
+
+    const option_name = "hide-foreign-warnings";
+    const hide_warnings = if (builder.available_options_map.get(option_name) == null) warn: {
+        break :warn builder.option(bool, option_name, "Hide the warning when a foreign binary which is incompatible is skipped") orelse false;
+    } else false;
+
     self.* = .{
         .builder = builder,
         .step = Step.init(.emulatable_run, name, builder.allocator, make),

--- a/lib/std/build/RunCompareStep.zig
+++ b/lib/std/build/RunCompareStep.zig
@@ -1,0 +1,147 @@
+//! Unlike `RunStep` this step will provide emulation, when enabled, to run foreign binaries.
+//! When a binary is foreign, but emulation for the target is disabled, the specified binary
+//! will not be run and therefore also not validated against its output.
+//! This step can be useful when wishing to run a built binary on multiple platforms,
+//! without having to verify if it's possible to be ran against.
+
+const std = @import("../std.zig");
+const build = std.build;
+const Step = std.build.Step;
+const Builder = std.build.Builder;
+const LibExeObjStep = std.build.LibExeObjStep;
+
+const fs = std.fs;
+const process = std.process;
+const EnvMap = process.EnvMap;
+
+const RunCompareStep = @This();
+
+pub const step_id = .run_and_compare;
+
+step: Step,
+builder: *Builder,
+
+/// The artifact (executable) to be run by this step
+exe: *LibExeObjStep,
+
+/// Set this to `null` to ignore the exit code for the purpose of determining a successful execution
+expected_exit_code: ?u8 = 0,
+
+/// Override this field to modify the environment
+env_map: ?*EnvMap,
+
+pub fn create(builder: *Builder, name: []const u8, artifact: *LibExeObjStep) *RunCompareStep {
+    std.debug.assert(artifact.kind == .exe or artifact.kind == .test_exe);
+    const self = builder.allocator.create(RunCompareStep) catch unreachable;
+    self.* = .{
+        .builder = builder,
+        .step = Step.init(.run_and_compare, name, builder.allocator, make),
+        .exe = artifact,
+        .env_map = null,
+    };
+    self.step.dependOn(&artifact.step);
+
+    return self;
+}
+
+fn make(step: *Step) !void {
+    const self = @fieldParentPtr(RunCompareStep, "step", step);
+    const host_info = self.builder.host;
+    const cwd = self.builder.build_root;
+    _ = cwd;
+    std.debug.print("Make called!\n", .{});
+
+    var argv_list = std.ArrayList([]const u8).init(self.builder.allocator);
+    _ = argv_list;
+
+    const need_cross_glibc = self.exe.target.isGnuLibC() and self.exe.is_linking_libc;
+    switch (host_info.getExternalExecutor(self.exe.target_info, .{
+        .qemu_fixes_dl = need_cross_glibc and self.builder.glibc_runtimes_dir != null,
+        .link_libc = self.exe.is_linking_libc,
+    })) {
+        .native => {},
+        .rosetta => if (!self.builder.enable_rosetta) return,
+        .wine => |bin_name| if (self.builder.enable_wine) {
+            try argv_list.append(bin_name);
+        } else return,
+        .qemu => |bin_name| if (self.builder.enable_qemu) {
+            const glibc_dir_arg = if (need_cross_glibc)
+                self.builder.glibc_runtimes_dir orelse return
+            else
+                null;
+            try argv_list.append(bin_name);
+            if (glibc_dir_arg) |dir| {
+                // TODO look into making this a call to `linuxTriple`. This
+                // needs the directory to be called "i686" rather than
+                // "i386" which is why we do it manually here.
+                const fmt_str = "{s}" ++ fs.path.sep_str ++ "{s}-{s}-{s}";
+                const cpu_arch = self.exe.target.getCpuArch();
+                const os_tag = self.exe.target.getOsTag();
+                const abi = self.exe.target.getAbi();
+                const cpu_arch_name: []const u8 = if (cpu_arch == .i386)
+                    "i686"
+                else
+                    @tagName(cpu_arch);
+                const full_dir = try std.fmt.allocPrint(self.builder.allocator, fmt_str, .{
+                    dir, cpu_arch_name, @tagName(os_tag), @tagName(abi),
+                });
+
+                try argv_list.append("-L");
+                try argv_list.append(full_dir);
+            }
+        } else return,
+        .darling => |bin_name| if (self.builder.enable_darling) {
+            try argv_list.append(bin_name);
+        } else return,
+        .wasmtime => |bin_name| if (self.builder.enable_wasmtime) {
+            try argv_list.append(bin_name);
+            try argv_list.append("--dir=.");
+        } else return,
+        else => return, // on any failures we skip
+    }
+
+    if (self.exe.target.isWindows()) {
+        // On Windows we don't have rpaths so we have to add .dll search paths to PATH
+        self.addPathForDynLibs(self.exe);
+    }
+
+    const executable_path = self.exe.installed_path orelse self.exe.getOutputSource().getPath(self.builder);
+    try argv_list.append(executable_path);
+}
+
+fn addPathForDynLibs(self: *RunCompareStep, artifact: *LibExeObjStep) void {
+    for (artifact.link_objects.items) |link_object| {
+        switch (link_object) {
+            .other_step => |other| {
+                if (other.target.isWindows() and other.isDynamicLibrary()) {
+                    self.addPathDir(fs.path.dirname(other.getOutputSource().getPath(self.builder)).?);
+                    self.addPathForDynLibs(other);
+                }
+            },
+            else => {},
+        }
+    }
+}
+
+pub fn addPathDir(self: *RunCompareStep, search_path: []const u8) void {
+    const env_map = self.getEnvMap();
+
+    const key = "PATH";
+    var prev_path = env_map.get(key);
+
+    if (prev_path) |pp| {
+        const new_path = self.builder.fmt("{s}" ++ [1]u8{fs.path.delimiter} ++ "{s}", .{ pp, search_path });
+        env_map.put(key, new_path) catch unreachable;
+    } else {
+        env_map.put(key, self.builder.dupePath(search_path)) catch unreachable;
+    }
+}
+
+pub fn getEnvMap(self: *RunCompareStep) *EnvMap {
+    return self.env_map orelse {
+        const env_map = self.builder.allocator.create(EnvMap) catch unreachable;
+        env_map.* = process.getEnvMap(self.builder.allocator) catch unreachable;
+        self.env_map = env_map;
+        return env_map;
+    };
+}

--- a/test/link.zig
+++ b/test/link.zig
@@ -47,69 +47,67 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
         .requires_stage2 = true,
     });
 
-    if (builtin.os.tag == .macos) {
-        cases.addBuildFile("test/link/macho/entry/build.zig", .{
-            .build_modes = true,
-        });
+    cases.addBuildFile("test/link/macho/entry/build.zig", .{
+        .build_modes = true,
+    });
 
-        cases.addBuildFile("test/link/macho/pagezero/build.zig", .{
-            .build_modes = false,
-        });
+    cases.addBuildFile("test/link/macho/pagezero/build.zig", .{
+        .build_modes = false,
+    });
 
-        cases.addBuildFile("test/link/macho/dylib/build.zig", .{
-            .build_modes = true,
-        });
+    cases.addBuildFile("test/link/macho/dylib/build.zig", .{
+        .build_modes = true,
+    });
 
-        cases.addBuildFile("test/link/macho/dead_strip/build.zig", .{
-            .build_modes = false,
-        });
+    cases.addBuildFile("test/link/macho/dead_strip/build.zig", .{
+        .build_modes = false,
+    });
 
-        cases.addBuildFile("test/link/macho/dead_strip_dylibs/build.zig", .{
-            .build_modes = true,
-            .requires_macos_sdk = true,
-        });
+    cases.addBuildFile("test/link/macho/dead_strip_dylibs/build.zig", .{
+        .build_modes = true,
+        .requires_macos_sdk = true,
+    });
 
-        cases.addBuildFile("test/link/macho/needed_library/build.zig", .{
-            .build_modes = true,
-        });
+    cases.addBuildFile("test/link/macho/needed_library/build.zig", .{
+        .build_modes = true,
+    });
 
-        cases.addBuildFile("test/link/macho/weak_library/build.zig", .{
-            .build_modes = true,
-        });
+    cases.addBuildFile("test/link/macho/weak_library/build.zig", .{
+        .build_modes = true,
+    });
 
-        cases.addBuildFile("test/link/macho/needed_framework/build.zig", .{
-            .build_modes = true,
-            .requires_macos_sdk = true,
-        });
+    cases.addBuildFile("test/link/macho/needed_framework/build.zig", .{
+        .build_modes = true,
+        .requires_macos_sdk = true,
+    });
 
-        cases.addBuildFile("test/link/macho/weak_framework/build.zig", .{
-            .build_modes = true,
-            .requires_macos_sdk = true,
-        });
+    cases.addBuildFile("test/link/macho/weak_framework/build.zig", .{
+        .build_modes = true,
+        .requires_macos_sdk = true,
+    });
 
-        // Try to build and run an Objective-C executable.
-        cases.addBuildFile("test/link/macho/objc/build.zig", .{
-            .build_modes = true,
-            .requires_macos_sdk = true,
-        });
+    // Try to build and run an Objective-C executable.
+    cases.addBuildFile("test/link/macho/objc/build.zig", .{
+        .build_modes = true,
+        .requires_macos_sdk = true,
+    });
 
-        // Try to build and run an Objective-C++ executable.
-        cases.addBuildFile("test/link/macho/objcpp/build.zig", .{
-            .build_modes = true,
-            .requires_macos_sdk = true,
-        });
+    // Try to build and run an Objective-C++ executable.
+    cases.addBuildFile("test/link/macho/objcpp/build.zig", .{
+        .build_modes = true,
+        .requires_macos_sdk = true,
+    });
 
-        cases.addBuildFile("test/link/macho/stack_size/build.zig", .{
-            .build_modes = true,
-        });
+    cases.addBuildFile("test/link/macho/stack_size/build.zig", .{
+        .build_modes = true,
+    });
 
-        cases.addBuildFile("test/link/macho/search_strategy/build.zig", .{
-            .build_modes = true,
-        });
+    cases.addBuildFile("test/link/macho/search_strategy/build.zig", .{
+        .build_modes = true,
+    });
 
-        cases.addBuildFile("test/link/macho/headerpad/build.zig", .{
-            .build_modes = true,
-            .requires_macos_sdk = true,
-        });
-    }
+    cases.addBuildFile("test/link/macho/headerpad/build.zig", .{
+        .build_modes = true,
+        .requires_macos_sdk = true,
+    });
 }

--- a/test/link/macho/dead_strip/build.zig
+++ b/test/link/macho/dead_strip/build.zig
@@ -16,9 +16,7 @@ pub fn build(b: *Builder) void {
         check.checkInSymtab();
         check.checkNext("{*} (__TEXT,__text) external _iAmUnused");
 
-        test_step.dependOn(&check.step);
-
-        const run_cmd = exe.run();
+        const run_cmd = check.runAndCompare();
         run_cmd.expectStdOutEqual("Hello!\n");
         test_step.dependOn(&run_cmd.step);
     }
@@ -32,9 +30,7 @@ pub fn build(b: *Builder) void {
         check.checkInSymtab();
         check.checkNotPresent("{*} (__TEXT,__text) external _iAmUnused");
 
-        test_step.dependOn(&check.step);
-
-        const run_cmd = exe.run();
+        const run_cmd = check.runAndCompare();
         run_cmd.expectStdOutEqual("Hello!\n");
         test_step.dependOn(&run_cmd.step);
     }

--- a/test/link/macho/entry/build.zig
+++ b/test/link/macho/entry/build.zig
@@ -8,6 +8,7 @@ pub fn build(b: *Builder) void {
     test_step.dependOn(b.getInstallStep());
 
     const exe = b.addExecutable("main", null);
+    exe.setTarget(.{ .os_tag = .macos });
     exe.setBuildMode(mode);
     exe.addCSourceFile("main.c", &.{});
     exe.linkLibC();
@@ -26,9 +27,7 @@ pub fn build(b: *Builder) void {
 
     check_exe.checkComputeCompare("vmaddr entryoff +", .{ .op = .eq, .value = .{ .variable = "n_value" } });
 
-    test_step.dependOn(&check_exe.step);
-
-    const run = exe.run();
+    const run = check_exe.runAndCompare();
     run.expectStdOutEqual("42");
     test_step.dependOn(&run.step);
 }

--- a/test/link/macho/objc/build.zig
+++ b/test/link/macho/objc/build.zig
@@ -7,7 +7,6 @@ pub fn build(b: *Builder) void {
     const test_step = b.step("test", "Test the program");
 
     const exe = b.addExecutable("test", null);
-    b.default_step.dependOn(&exe.step);
     exe.addIncludePath(".");
     exe.addCSourceFile("Foo.m", &[0][]const u8{});
     exe.addCSourceFile("test.m", &[0][]const u8{});
@@ -17,6 +16,6 @@ pub fn build(b: *Builder) void {
     // populate paths to the sysroot here.
     exe.linkFramework("Foundation");
 
-    const run_cmd = exe.run();
+    const run_cmd = std.build.EmulatableRunStep.create(b, "run", exe);
     test_step.dependOn(&run_cmd.step);
 }

--- a/test/link/macho/pagezero/build.zig
+++ b/test/link/macho/pagezero/build.zig
@@ -9,6 +9,7 @@ pub fn build(b: *Builder) void {
 
     {
         const exe = b.addExecutable("pagezero", null);
+        exe.setTarget(.{ .os_tag = .macos });
         exe.setBuildMode(mode);
         exe.addCSourceFile("main.c", &.{});
         exe.linkLibC();
@@ -28,6 +29,7 @@ pub fn build(b: *Builder) void {
 
     {
         const exe = b.addExecutable("no_pagezero", null);
+        exe.setTarget(.{ .os_tag = .macos });
         exe.setBuildMode(mode);
         exe.addCSourceFile("main.c", &.{});
         exe.linkLibC();

--- a/test/link/macho/stack_size/build.zig
+++ b/test/link/macho/stack_size/build.zig
@@ -8,6 +8,7 @@ pub fn build(b: *Builder) void {
     test_step.dependOn(b.getInstallStep());
 
     const exe = b.addExecutable("main", null);
+    exe.setTarget(.{ .os_tag = .macos });
     exe.setBuildMode(mode);
     exe.addCSourceFile("main.c", &.{});
     exe.linkLibC();
@@ -17,8 +18,6 @@ pub fn build(b: *Builder) void {
     check_exe.checkStart("cmd MAIN");
     check_exe.checkNext("stacksize 100000000");
 
-    test_step.dependOn(&check_exe.step);
-
-    const run = exe.run();
+    const run = check_exe.runAndCompare();
     test_step.dependOn(&run.step);
 }


### PR DESCRIPTION
Implements a new step that can run and compare the output for foreign binaries that will be run through emulation when enabled (or directly on the host when non-foreign binary). When disabled, it will skip running the binary and produce a warning instead. Said warning can be hidden by either setting the option manually in `build.zig` on the step, or passing `-Dhide-foreign-warnings`. This option is automatically added when creating the step.

The main goal of this step is to help us test the various linkers and we want to run it for multiple targets. This is especially useful when cross-compiling for ELF and MachO as they support more than a single architecture. For this reason, a handy function was appended to `CheckObjectStep` called `runAndCompare` that will automatically create this step and provide the artifact that was used for the original step. 

This PR does not yet update all the current linker tests to use this new step.