### PR TITLE
std.fs: split `Dir` into `IterableDir`

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -3245,7 +3245,7 @@ pub const LibExeObjStep = struct {
         const build_output_dir = mem.trimRight(u8, output_dir_nl, "\r\n");
 
         if (self.output_dir) |output_dir| {
-            var src_dir = try std.fs.cwd().openDir(build_output_dir, .{ .iterate = true });
+            var src_dir = try std.fs.cwd().openIterableDir(build_output_dir, .{});
             defer src_dir.close();
 
             // Create the output directory if it doesn't exist.
@@ -3265,7 +3265,7 @@ pub const LibExeObjStep = struct {
                     mem.eql(u8, entry.name, "zld.id") or
                     mem.eql(u8, entry.name, "lld.id")) continue;
 
-                _ = try src_dir.updateFile(entry.name, dest_dir, entry.name, .{});
+                _ = try src_dir.dir.updateFile(entry.name, dest_dir, entry.name, .{});
             }
         } else {
             self.output_dir = build_output_dir;
@@ -3480,7 +3480,7 @@ pub const InstallDirStep = struct {
         const self = @fieldParentPtr(InstallDirStep, "step", step);
         const dest_prefix = self.builder.getInstallPath(self.options.install_dir, self.options.install_subdir);
         const full_src_dir = self.builder.pathFromRoot(self.options.source_dir);
-        var src_dir = try std.fs.cwd().openDir(full_src_dir, .{ .iterate = true });
+        var src_dir = try std.fs.cwd().openIterableDir(full_src_dir, .{});
         defer src_dir.close();
         var it = try src_dir.walk(self.builder.allocator);
         next_entry: while (try it.next()) |entry| {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -308,7 +308,7 @@ pub fn fchmod(fd: fd_t, mode: mode_t) FChmodError!void {
         switch (system.getErrno(res)) {
             .SUCCESS => return,
             .INTR => continue,
-            .BADF => unreachable, // Can be reached if the fd refers to a directory opened without `OpenDirOptions{ .iterate = true }`
+            .BADF => unreachable, // Can be reached if the fd refers to a non-iterable directory.
 
             .FAULT => unreachable,
             .INVAL => unreachable,
@@ -349,7 +349,7 @@ pub fn fchown(fd: fd_t, owner: ?uid_t, group: ?gid_t) FChownError!void {
         switch (system.getErrno(res)) {
             .SUCCESS => return,
             .INTR => continue,
-            .BADF => unreachable, // Can be reached if the fd refers to a directory opened without `OpenDirOptions{ .iterate = true }`
+            .BADF => unreachable, // Can be reached if the fd refers to a non-iterable directory.
 
             .FAULT => unreachable,
             .INVAL => unreachable,

--- a/src/test.zig
+++ b/src/test.zig
@@ -1096,7 +1096,7 @@ pub const TestContext = struct {
         /// that if any errors occur the caller knows it happened during this file.
         current_file: *[]const u8,
     ) !void {
-        var it = try dir.walk(ctx.arena);
+        var it = try dir.intoIterable().walk(ctx.arena);
         var filenames = std.ArrayList([]const u8).init(ctx.arena);
 
         while (try it.next()) |entry| {

--- a/tools/process_headers.zig
+++ b/tools/process_headers.zig
@@ -381,14 +381,14 @@ pub fn main() !void {
             try dir_stack.append(target_include_dir);
 
             while (dir_stack.popOrNull()) |full_dir_name| {
-                var dir = std.fs.cwd().openDir(full_dir_name, .{ .iterate = true }) catch |err| switch (err) {
+                var iterable_dir = std.fs.cwd().openIterableDir(full_dir_name, .{}) catch |err| switch (err) {
                     error.FileNotFound => continue :search,
                     error.AccessDenied => continue :search,
                     else => return err,
                 };
-                defer dir.close();
+                defer iterable_dir.close();
 
-                var dir_it = dir.iterate();
+                var dir_it = iterable_dir.iterate();
 
                 while (try dir_it.next()) |entry| {
                     const full_path = try std.fs.path.join(allocator, &[_][]const u8{ full_dir_name, entry.name });

--- a/tools/update-license-headers.zig
+++ b/tools/update-license-headers.zig
@@ -14,9 +14,9 @@ pub fn main() !void {
 
     const args = try std.process.argsAlloc(arena);
     const path_to_walk = args[1];
-    const dir = try std.fs.cwd().openDir(path_to_walk, .{ .iterate = true });
+    const iterable_dir = try std.fs.cwd().openIterableDir(path_to_walk, .{});
 
-    var walker = try dir.walk(arena);
+    var walker = try iterable_dir.walk(arena);
     defer walker.deinit();
 
     var buffer: [500]u8 = undefined;
@@ -30,7 +30,7 @@ pub fn main() !void {
         node.activate();
         defer node.end();
 
-        const source = try dir.readFileAlloc(arena, entry.path, 20 * 1024 * 1024);
+        const source = try iterable_dir.dir.readFileAlloc(arena, entry.path, 20 * 1024 * 1024);
         if (!std.mem.startsWith(u8, source, expected_header)) {
             std.debug.print("no match: {s}\n", .{entry.path});
             continue;
@@ -42,6 +42,6 @@ pub fn main() !void {
         std.mem.copy(u8, new_source, new_header);
         std.mem.copy(u8, new_source[new_header.len..], truncated_source);
 
-        try dir.writeFile(entry.path, new_source);
+        try iterable_dir.dir.writeFile(entry.path, new_source);
     }
 }

--- a/tools/update-linux-headers.zig
+++ b/tools/update-linux-headers.zig
@@ -181,14 +181,14 @@ pub fn main() !void {
             try dir_stack.append(target_include_dir);
 
             while (dir_stack.popOrNull()) |full_dir_name| {
-                var dir = std.fs.cwd().openDir(full_dir_name, .{ .iterate = true }) catch |err| switch (err) {
+                var iterable_dir = std.fs.cwd().openIterableDir(full_dir_name, .{}) catch |err| switch (err) {
                     error.FileNotFound => continue :search,
                     error.AccessDenied => continue :search,
                     else => return err,
                 };
-                defer dir.close();
+                defer iterable_dir.close();
 
-                var dir_it = dir.iterate();
+                var dir_it = iterable_dir.iterate();
 
                 while (try dir_it.next()) |entry| {
                     const full_path = try std.fs.path.join(arena, &[_][]const u8{ full_dir_name, entry.name });

--- a/tools/update_glibc.zig
+++ b/tools/update_glibc.zig
@@ -41,7 +41,7 @@ pub fn main() !void {
 
     const dest_dir_path = try std.fmt.allocPrint(arena, "{s}/lib/libc/glibc", .{zig_src_path});
 
-    var dest_dir = fs.cwd().openDir(dest_dir_path, .{ .iterate = true }) catch |err| {
+    var dest_dir = fs.cwd().openIterableDir(dest_dir_path, .{}) catch |err| {
         fatal("unable to open destination directory '{s}': {s}", .{
             dest_dir_path, @errorName(err),
         });
@@ -63,14 +63,14 @@ pub fn main() !void {
                 if (mem.eql(u8, entry.path, p)) continue :walk;
             }
 
-            glibc_src_dir.copyFile(entry.path, dest_dir, entry.path, .{}) catch |err| {
+            glibc_src_dir.copyFile(entry.path, dest_dir.dir, entry.path, .{}) catch |err| {
                 log.warn("unable to copy '{s}/{s}' to '{s}/{s}': {s}", .{
                     glibc_src_path,  entry.path,
                     dest_dir_path,   entry.path,
                     @errorName(err),
                 });
                 if (err == error.FileNotFound) {
-                    try dest_dir.deleteFile(entry.path);
+                    try dest_dir.dir.deleteFile(entry.path);
                 }
             };
         }
@@ -79,7 +79,7 @@ pub fn main() !void {
     // Warn about duplicated files inside glibc/include/* that can be omitted
     // because they are already in generic-glibc/*.
 
-    var include_dir = dest_dir.openDir("include", .{ .iterate = true }) catch |err| {
+    var include_dir = dest_dir.dir.openIterableDir("include", .{}) catch |err| {
         fatal("unable to open directory '{s}/include': {s}", .{
             dest_dir_path, @errorName(err),
         });
@@ -116,7 +116,7 @@ pub fn main() !void {
                 generic_glibc_path, entry.path, @errorName(e),
             }),
         };
-        const glibc_include_contents = include_dir.readFileAlloc(
+        const glibc_include_contents = include_dir.dir.readFileAlloc(
             arena,
             entry.path,
             max_file_size,


### PR DESCRIPTION
`walk` and `iterate` are moved to a new type `IterableDir`. `Dir` receives a new `openIterableDir` function which returns an `IterableDir` and also an `intoIterable` function which converts the `Dir` into an `IterableDir` asserting that it was opened with `iterate = true`.

Closes #12007