### PR TITLE
compiler_rt: Update Windows ABI for float<->int conversion routines

### DIFF
--- a/lib/compiler_rt/common.zig
+++ b/lib/compiler_rt/common.zig
@@ -17,6 +17,10 @@ pub const want_aeabi = switch (builtin.abi) {
 };
 pub const want_ppc_abi = builtin.cpu.arch.isPPC() or builtin.cpu.arch.isPPC64();
 
+// Libcalls that involve u128 on Windows x86-64 are expected by LLVM to use the
+// calling convention of @Vector(2, u64), rather than what's standard.
+pub const want_windows_v2u64_abi = builtin.os.tag == .windows and builtin.cpu.arch == .x86_64;
+
 /// This governs whether to use these symbol names for f16/f32 conversions
 /// rather than the standard names:
 /// * __gnu_f2h_ieee

--- a/lib/compiler_rt/fixdfti.zig
+++ b/lib/compiler_rt/fixdfti.zig
@@ -1,26 +1,23 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    const fixdfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __fixdfti_windows_x86_64;
-    } else __fixdfti;
-
-    @export(fixdfti_fn, .{ .name = "__fixdfti", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__fixdfti_windows_x86_64, .{ .name = "__fixdfti", .linkage = common.linkage });
+    } else {
+        @export(__fixdfti, .{ .name = "__fixdfti", .linkage = common.linkage });
+    }
 }
 
 pub fn __fixdfti(a: f64) callconv(.C) i128 {
     return floatToInt(i128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __fixdfti_windows_x86_64(a: f64) callconv(.C) v128 {
-    return @bitCast(v128, floatToInt(i128, a));
+fn __fixdfti_windows_x86_64(a: f64) callconv(.C) v2u64 {
+    return @bitCast(v2u64, floatToInt(i128, a));
 }

--- a/lib/compiler_rt/fixdfti.zig
+++ b/lib/compiler_rt/fixdfti.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixdfti, .{ .name = "__fixdfti", .linkage = common.linkage });
+    const fixdfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __fixdfti_windows_x86_64;
+    } else __fixdfti;
+
+    @export(fixdfti_fn, .{ .name = "__fixdfti", .linkage = common.linkage });
 }
 
 pub fn __fixdfti(a: f64) callconv(.C) i128 {
     return floatToInt(i128, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __fixdfti_windows_x86_64(a: f64) callconv(.C) v128 {
+    return @bitCast(v128, floatToInt(i128, a));
 }

--- a/lib/compiler_rt/fixhfti.zig
+++ b/lib/compiler_rt/fixhfti.zig
@@ -1,26 +1,23 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    const fixhfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __fixhfti_windows_x86_64;
-    } else __fixhfti;
-
-    @export(fixhfti_fn, .{ .name = "__fixhfti", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__fixhfti_windows_x86_64, .{ .name = "__fixhfti", .linkage = common.linkage });
+    } else {
+        @export(__fixhfti, .{ .name = "__fixhfti", .linkage = common.linkage });
+    }
 }
 
 pub fn __fixhfti(a: f16) callconv(.C) i128 {
     return floatToInt(i128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __fixhfti_windows_x86_64(a: f16) callconv(.C) v128 {
-    return @bitCast(v128, floatToInt(i128, a));
+fn __fixhfti_windows_x86_64(a: f16) callconv(.C) v2u64 {
+    return @bitCast(v2u64, floatToInt(i128, a));
 }

--- a/lib/compiler_rt/fixhfti.zig
+++ b/lib/compiler_rt/fixhfti.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixhfti, .{ .name = "__fixhfti", .linkage = common.linkage });
+    const fixhfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __fixhfti_windows_x86_64;
+    } else __fixhfti;
+
+    @export(fixhfti_fn, .{ .name = "__fixhfti", .linkage = common.linkage });
 }
 
-fn __fixhfti(a: f16) callconv(.C) i128 {
+pub fn __fixhfti(a: f16) callconv(.C) i128 {
     return floatToInt(i128, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __fixhfti_windows_x86_64(a: f16) callconv(.C) v128 {
+    return @bitCast(v128, floatToInt(i128, a));
 }

--- a/lib/compiler_rt/fixsfti.zig
+++ b/lib/compiler_rt/fixsfti.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixsfti, .{ .name = "__fixsfti", .linkage = common.linkage });
+    const fixsfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __fixsfti_windows_x86_64;
+    } else __fixsfti;
+
+    @export(fixsfti_fn, .{ .name = "__fixsfti", .linkage = common.linkage });
 }
 
 pub fn __fixsfti(a: f32) callconv(.C) i128 {
     return floatToInt(i128, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __fixsfti_windows_x86_64(a: f32) callconv(.C) v128 {
+    return @bitCast(v128, floatToInt(i128, a));
 }

--- a/lib/compiler_rt/fixsfti.zig
+++ b/lib/compiler_rt/fixsfti.zig
@@ -1,26 +1,23 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    const fixsfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __fixsfti_windows_x86_64;
-    } else __fixsfti;
-
-    @export(fixsfti_fn, .{ .name = "__fixsfti", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__fixsfti_windows_x86_64, .{ .name = "__fixsfti", .linkage = common.linkage });
+    } else {
+        @export(__fixsfti, .{ .name = "__fixsfti", .linkage = common.linkage });
+    }
 }
 
 pub fn __fixsfti(a: f32) callconv(.C) i128 {
     return floatToInt(i128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __fixsfti_windows_x86_64(a: f32) callconv(.C) v128 {
-    return @bitCast(v128, floatToInt(i128, a));
+fn __fixsfti_windows_x86_64(a: f32) callconv(.C) v2u64 {
+    return @bitCast(v2u64, floatToInt(i128, a));
 }

--- a/lib/compiler_rt/fixtfti.zig
+++ b/lib/compiler_rt/fixtfti.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixtfti, .{ .name = "__fixtfti", .linkage = common.linkage });
+    const fixtfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __fixtfti_windows_x86_64;
+    } else __fixtfti;
+
+    @export(fixtfti_fn, .{ .name = "__fixtfti", .linkage = common.linkage });
 }
 
 pub fn __fixtfti(a: f128) callconv(.C) i128 {
     return floatToInt(i128, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __fixtfti_windows_x86_64(a: f128) callconv(.C) v128 {
+    return @bitCast(v128, floatToInt(i128, a));
 }

--- a/lib/compiler_rt/fixtfti.zig
+++ b/lib/compiler_rt/fixtfti.zig
@@ -1,26 +1,23 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    const fixtfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __fixtfti_windows_x86_64;
-    } else __fixtfti;
-
-    @export(fixtfti_fn, .{ .name = "__fixtfti", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__fixtfti_windows_x86_64, .{ .name = "__fixtfti", .linkage = common.linkage });
+    } else {
+        @export(__fixtfti, .{ .name = "__fixtfti", .linkage = common.linkage });
+    }
 }
 
 pub fn __fixtfti(a: f128) callconv(.C) i128 {
     return floatToInt(i128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __fixtfti_windows_x86_64(a: f128) callconv(.C) v128 {
-    return @bitCast(v128, floatToInt(i128, a));
+fn __fixtfti_windows_x86_64(a: f128) callconv(.C) v2u64 {
+    return @bitCast(v2u64, floatToInt(i128, a));
 }

--- a/lib/compiler_rt/fixunsdfti.zig
+++ b/lib/compiler_rt/fixunsdfti.zig
@@ -1,26 +1,23 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    const fixunsdfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __fixunsdfti_windows_x86_64;
-    } else __fixunsdfti;
-
-    @export(fixunsdfti_fn, .{ .name = "__fixunsdfti", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__fixunsdfti_windows_x86_64, .{ .name = "__fixunsdfti", .linkage = common.linkage });
+    } else {
+        @export(__fixunsdfti, .{ .name = "__fixunsdfti", .linkage = common.linkage });
+    }
 }
 
 pub fn __fixunsdfti(a: f64) callconv(.C) u128 {
     return floatToInt(u128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __fixunsdfti_windows_x86_64(a: f64) callconv(.C) v128 {
-    return @bitCast(v128, floatToInt(u128, a));
+fn __fixunsdfti_windows_x86_64(a: f64) callconv(.C) v2u64 {
+    return @bitCast(v2u64, floatToInt(u128, a));
 }

--- a/lib/compiler_rt/fixunsdfti.zig
+++ b/lib/compiler_rt/fixunsdfti.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixunsdfti, .{ .name = "__fixunsdfti", .linkage = common.linkage });
+    const fixunsdfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __fixunsdfti_windows_x86_64;
+    } else __fixunsdfti;
+
+    @export(fixunsdfti_fn, .{ .name = "__fixunsdfti", .linkage = common.linkage });
 }
 
 pub fn __fixunsdfti(a: f64) callconv(.C) u128 {
     return floatToInt(u128, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __fixunsdfti_windows_x86_64(a: f64) callconv(.C) v128 {
+    return @bitCast(v128, floatToInt(u128, a));
 }

--- a/lib/compiler_rt/fixunshfti.zig
+++ b/lib/compiler_rt/fixunshfti.zig
@@ -1,26 +1,23 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    const fixunshfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __fixunshfti_windows_x86_64;
-    } else __fixunshfti;
-
-    @export(fixunshfti_fn, .{ .name = "__fixunshfti", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__fixunshfti_windows_x86_64, .{ .name = "__fixunshfti", .linkage = common.linkage });
+    } else {
+        @export(__fixunshfti, .{ .name = "__fixunshfti", .linkage = common.linkage });
+    }
 }
 
 pub fn __fixunshfti(a: f16) callconv(.C) u128 {
     return floatToInt(u128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
+const v2u64 = @import("std").meta.Vector(2, u64);
 
-fn __fixunshfti_windows_x86_64(a: f16) callconv(.C) v128 {
-    return @bitCast(v128, floatToInt(u128, a));
+fn __fixunshfti_windows_x86_64(a: f16) callconv(.C) v2u64 {
+    return @bitCast(v2u64, floatToInt(u128, a));
 }

--- a/lib/compiler_rt/fixunshfti.zig
+++ b/lib/compiler_rt/fixunshfti.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixunshfti, .{ .name = "__fixunshfti", .linkage = common.linkage });
+    const fixunshfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __fixunshfti_windows_x86_64;
+    } else __fixunshfti;
+
+    @export(fixunshfti_fn, .{ .name = "__fixunshfti", .linkage = common.linkage });
 }
 
 pub fn __fixunshfti(a: f16) callconv(.C) u128 {
     return floatToInt(u128, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __fixunshfti_windows_x86_64(a: f16) callconv(.C) v128 {
+    return @bitCast(v128, floatToInt(u128, a));
 }

--- a/lib/compiler_rt/fixunssfti.zig
+++ b/lib/compiler_rt/fixunssfti.zig
@@ -1,26 +1,23 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    const fixunssfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __fixunssfti_windows_x86_64;
-    } else __fixunssfti;
-
-    @export(fixunssfti_fn, .{ .name = "__fixunssfti", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__fixunssfti_windows_x86_64, .{ .name = "__fixunssfti", .linkage = common.linkage });
+    } else {
+        @export(__fixunssfti, .{ .name = "__fixunssfti", .linkage = common.linkage });
+    }
 }
 
 pub fn __fixunssfti(a: f32) callconv(.C) u128 {
     return floatToInt(u128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __fixunssfti_windows_x86_64(a: f32) callconv(.C) v128 {
-    return @bitCast(v128, floatToInt(u128, a));
+fn __fixunssfti_windows_x86_64(a: f32) callconv(.C) v2u64 {
+    return @bitCast(v2u64, floatToInt(u128, a));
 }

--- a/lib/compiler_rt/fixunssfti.zig
+++ b/lib/compiler_rt/fixunssfti.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixunssfti, .{ .name = "__fixunssfti", .linkage = common.linkage });
+    const fixunssfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __fixunssfti_windows_x86_64;
+    } else __fixunssfti;
+
+    @export(fixunssfti_fn, .{ .name = "__fixunssfti", .linkage = common.linkage });
 }
 
 pub fn __fixunssfti(a: f32) callconv(.C) u128 {
     return floatToInt(u128, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __fixunssfti_windows_x86_64(a: f32) callconv(.C) v128 {
+    return @bitCast(v128, floatToInt(u128, a));
 }

--- a/lib/compiler_rt/fixunstfti.zig
+++ b/lib/compiler_rt/fixunstfti.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixunstfti, .{ .name = "__fixunstfti", .linkage = common.linkage });
+    const fixunstfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __fixunstfti_windows_x86_64;
+    } else __fixunstfti;
+
+    @export(fixunstfti_fn, .{ .name = "__fixunstfti", .linkage = common.linkage });
 }
 
 pub fn __fixunstfti(a: f128) callconv(.C) u128 {
     return floatToInt(u128, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __fixunstfti_windows_x86_64(a: f128) callconv(.C) v128 {
+    return @bitCast(v128, floatToInt(u128, a));
 }

--- a/lib/compiler_rt/fixunstfti.zig
+++ b/lib/compiler_rt/fixunstfti.zig
@@ -1,26 +1,23 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    const fixunstfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __fixunstfti_windows_x86_64;
-    } else __fixunstfti;
-
-    @export(fixunstfti_fn, .{ .name = "__fixunstfti", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__fixunstfti_windows_x86_64, .{ .name = "__fixunstfti", .linkage = common.linkage });
+    } else {
+        @export(__fixunstfti, .{ .name = "__fixunstfti", .linkage = common.linkage });
+    }
 }
 
 pub fn __fixunstfti(a: f128) callconv(.C) u128 {
     return floatToInt(u128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __fixunstfti_windows_x86_64(a: f128) callconv(.C) v128 {
-    return @bitCast(v128, floatToInt(u128, a));
+fn __fixunstfti_windows_x86_64(a: f128) callconv(.C) v2u64 {
+    return @bitCast(v2u64, floatToInt(u128, a));
 }

--- a/lib/compiler_rt/fixunsxfti.zig
+++ b/lib/compiler_rt/fixunsxfti.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixunsxfti, .{ .name = "__fixunsxfti", .linkage = common.linkage });
+    const fixunsxfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __fixunsxfti_windows_x86_64;
+    } else __fixunsxfti;
+
+    @export(fixunsxfti_fn, .{ .name = "__fixunsxfti", .linkage = common.linkage });
 }
 
 pub fn __fixunsxfti(a: f80) callconv(.C) u128 {
     return floatToInt(u128, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __fixunsxfti_windows_x86_64(a: f80) callconv(.C) v128 {
+    return @bitCast(v128, floatToInt(u128, a));
 }

--- a/lib/compiler_rt/fixunsxfti.zig
+++ b/lib/compiler_rt/fixunsxfti.zig
@@ -1,26 +1,23 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    const fixunsxfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __fixunsxfti_windows_x86_64;
-    } else __fixunsxfti;
-
-    @export(fixunsxfti_fn, .{ .name = "__fixunsxfti", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__fixunsxfti_windows_x86_64, .{ .name = "__fixunsxfti", .linkage = common.linkage });
+    } else {
+        @export(__fixunsxfti, .{ .name = "__fixunsxfti", .linkage = common.linkage });
+    }
 }
 
 pub fn __fixunsxfti(a: f80) callconv(.C) u128 {
     return floatToInt(u128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __fixunsxfti_windows_x86_64(a: f80) callconv(.C) v128 {
-    return @bitCast(v128, floatToInt(u128, a));
+fn __fixunsxfti_windows_x86_64(a: f80) callconv(.C) v2u64 {
+    return @bitCast(v2u64, floatToInt(u128, a));
 }

--- a/lib/compiler_rt/fixxfti.zig
+++ b/lib/compiler_rt/fixxfti.zig
@@ -1,26 +1,23 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    const fixxfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __fixxfti_windows_x86_64;
-    } else __fixxfti;
-
-    @export(fixxfti_fn, .{ .name = "__fixxfti", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__fixxfti_windows_x86_64, .{ .name = "__fixxfti", .linkage = common.linkage });
+    } else {
+        @export(__fixxfti, .{ .name = "__fixxfti", .linkage = common.linkage });
+    }
 }
 
 pub fn __fixxfti(a: f80) callconv(.C) i128 {
     return floatToInt(i128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __fixxfti_windows_x86_64(a: f80) callconv(.C) v128 {
-    return @bitCast(v128, floatToInt(i128, a));
+fn __fixxfti_windows_x86_64(a: f80) callconv(.C) v2u64 {
+    return @bitCast(v2u64, floatToInt(i128, a));
 }

--- a/lib/compiler_rt/fixxfti.zig
+++ b/lib/compiler_rt/fixxfti.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const floatToInt = @import("./float_to_int.zig").floatToInt;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixxfti, .{ .name = "__fixxfti", .linkage = common.linkage });
+    const fixxfti_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __fixxfti_windows_x86_64;
+    } else __fixxfti;
+
+    @export(fixxfti_fn, .{ .name = "__fixxfti", .linkage = common.linkage });
 }
 
-fn __fixxfti(a: f80) callconv(.C) i128 {
+pub fn __fixxfti(a: f80) callconv(.C) i128 {
     return floatToInt(i128, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __fixxfti_windows_x86_64(a: f80) callconv(.C) v128 {
+    return @bitCast(v128, floatToInt(i128, a));
 }

--- a/lib/compiler_rt/floattidf.zig
+++ b/lib/compiler_rt/floattidf.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__floattidf, .{ .name = "__floattidf", .linkage = common.linkage });
+    const floattidf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __floattidf_windows_x86_64;
+    } else __floattidf;
+
+    @export(floattidf_fn, .{ .name = "__floattidf", .linkage = common.linkage });
 }
 
 pub fn __floattidf(a: i128) callconv(.C) f64 {
     return intToFloat(f64, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __floattidf_windows_x86_64(a: v128) callconv(.C) f64 {
+    return intToFloat(f64, @bitCast(i128, a));
 }

--- a/lib/compiler_rt/floattidf.zig
+++ b/lib/compiler_rt/floattidf.zig
@@ -1,26 +1,21 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    const floattidf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __floattidf_windows_x86_64;
-    } else __floattidf;
-
-    @export(floattidf_fn, .{ .name = "__floattidf", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__floattidf_windows_x86_64, .{ .name = "__floattidf", .linkage = common.linkage });
+    } else {
+        @export(__floattidf, .{ .name = "__floattidf", .linkage = common.linkage });
+    }
 }
 
 pub fn __floattidf(a: i128) callconv(.C) f64 {
     return intToFloat(f64, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
-
-fn __floattidf_windows_x86_64(a: v128) callconv(.C) f64 {
+fn __floattidf_windows_x86_64(a: @Vector(2, u64)) callconv(.C) f64 {
     return intToFloat(f64, @bitCast(i128, a));
 }

--- a/lib/compiler_rt/floattihf.zig
+++ b/lib/compiler_rt/floattihf.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__floattihf, .{ .name = "__floattihf", .linkage = common.linkage });
+    const floattihf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __floattihf_windows_x86_64;
+    } else __floattihf;
+
+    @export(floattihf_fn, .{ .name = "__floattihf", .linkage = common.linkage });
 }
 
-fn __floattihf(a: i128) callconv(.C) f16 {
+pub fn __floattihf(a: i128) callconv(.C) f16 {
     return intToFloat(f16, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __floattihf_windows_x86_64(a: v128) callconv(.C) f16 {
+    return intToFloat(f16, @bitCast(i128, a));
 }

--- a/lib/compiler_rt/floattihf.zig
+++ b/lib/compiler_rt/floattihf.zig
@@ -1,26 +1,21 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    const floattihf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __floattihf_windows_x86_64;
-    } else __floattihf;
-
-    @export(floattihf_fn, .{ .name = "__floattihf", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__floattihf_windows_x86_64, .{ .name = "__floattihf", .linkage = common.linkage });
+    } else {
+        @export(__floattihf, .{ .name = "__floattihf", .linkage = common.linkage });
+    }
 }
 
 pub fn __floattihf(a: i128) callconv(.C) f16 {
     return intToFloat(f16, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
-
-fn __floattihf_windows_x86_64(a: v128) callconv(.C) f16 {
+fn __floattihf_windows_x86_64(a: @Vector(2, u64)) callconv(.C) f16 {
     return intToFloat(f16, @bitCast(i128, a));
 }

--- a/lib/compiler_rt/floattisf.zig
+++ b/lib/compiler_rt/floattisf.zig
@@ -1,26 +1,21 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    const floattisf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __floattisf_windows_x86_64;
-    } else __floattisf;
-
-    @export(floattisf_fn, .{ .name = "__floattisf", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__floattisf_windows_x86_64, .{ .name = "__floattisf", .linkage = common.linkage });
+    } else {
+        @export(__floattisf, .{ .name = "__floattisf", .linkage = common.linkage });
+    }
 }
 
 pub fn __floattisf(a: i128) callconv(.C) f32 {
     return intToFloat(f32, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
-
-fn __floattisf_windows_x86_64(a: v128) callconv(.C) f32 {
+fn __floattisf_windows_x86_64(a: @Vector(2, u64)) callconv(.C) f32 {
     return intToFloat(f32, @bitCast(i128, a));
 }

--- a/lib/compiler_rt/floattisf.zig
+++ b/lib/compiler_rt/floattisf.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__floattisf, .{ .name = "__floattisf", .linkage = common.linkage });
+    const floattisf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __floattisf_windows_x86_64;
+    } else __floattisf;
+
+    @export(floattisf_fn, .{ .name = "__floattisf", .linkage = common.linkage });
 }
 
 pub fn __floattisf(a: i128) callconv(.C) f32 {
     return intToFloat(f32, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __floattisf_windows_x86_64(a: v128) callconv(.C) f32 {
+    return intToFloat(f32, @bitCast(i128, a));
 }

--- a/lib/compiler_rt/floattitf.zig
+++ b/lib/compiler_rt/floattitf.zig
@@ -1,26 +1,21 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    const floattitf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __floattitf_windows_x86_64;
-    } else __floattitf;
-
-    @export(floattitf_fn, .{ .name = "__floattitf", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__floattitf_windows_x86_64, .{ .name = "__floattitf", .linkage = common.linkage });
+    } else {
+        @export(__floattitf, .{ .name = "__floattitf", .linkage = common.linkage });
+    }
 }
 
 pub fn __floattitf(a: i128) callconv(.C) f128 {
     return intToFloat(f128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
-
-fn __floattitf_windows_x86_64(a: v128) callconv(.C) f128 {
+fn __floattitf_windows_x86_64(a: @Vector(2, u64)) callconv(.C) f128 {
     return intToFloat(f128, @bitCast(i128, a));
 }

--- a/lib/compiler_rt/floattitf.zig
+++ b/lib/compiler_rt/floattitf.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__floattitf, .{ .name = "__floattitf", .linkage = common.linkage });
+    const floattitf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __floattitf_windows_x86_64;
+    } else __floattitf;
+
+    @export(floattitf_fn, .{ .name = "__floattitf", .linkage = common.linkage });
 }
 
 pub fn __floattitf(a: i128) callconv(.C) f128 {
     return intToFloat(f128, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __floattitf_windows_x86_64(a: v128) callconv(.C) f128 {
+    return intToFloat(f128, @bitCast(i128, a));
 }

--- a/lib/compiler_rt/floattixf.zig
+++ b/lib/compiler_rt/floattixf.zig
@@ -1,26 +1,21 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    const floattixf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __floattixf_windows_x86_64;
-    } else __floattixf;
-
-    @export(floattixf_fn, .{ .name = "__floattixf", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__floattixf_windows_x86_64, .{ .name = "__floattixf", .linkage = common.linkage });
+    } else {
+        @export(__floattixf, .{ .name = "__floattixf", .linkage = common.linkage });
+    }
 }
 
 pub fn __floattixf(a: i128) callconv(.C) f80 {
     return intToFloat(f80, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
-
-fn __floattixf_windows_x86_64(a: v128) callconv(.C) f80 {
+fn __floattixf_windows_x86_64(a: @Vector(2, u64)) callconv(.C) f80 {
     return intToFloat(f80, @bitCast(i128, a));
 }

--- a/lib/compiler_rt/floattixf.zig
+++ b/lib/compiler_rt/floattixf.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__floattixf, .{ .name = "__floattixf", .linkage = common.linkage });
+    const floattixf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __floattixf_windows_x86_64;
+    } else __floattixf;
+
+    @export(floattixf_fn, .{ .name = "__floattixf", .linkage = common.linkage });
 }
 
-fn __floattixf(a: i128) callconv(.C) f80 {
+pub fn __floattixf(a: i128) callconv(.C) f80 {
     return intToFloat(f80, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __floattixf_windows_x86_64(a: v128) callconv(.C) f80 {
+    return intToFloat(f80, @bitCast(i128, a));
 }

--- a/lib/compiler_rt/floatuntidf.zig
+++ b/lib/compiler_rt/floatuntidf.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__floatuntidf, .{ .name = "__floatuntidf", .linkage = common.linkage });
+    const floatuntidf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __floatuntidf_windows_x86_64;
+    } else __floatuntidf;
+
+    @export(floatuntidf_fn, .{ .name = "__floatuntidf", .linkage = common.linkage });
 }
 
 pub fn __floatuntidf(a: u128) callconv(.C) f64 {
     return intToFloat(f64, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __floatuntidf_windows_x86_64(a: v128) callconv(.C) f64 {
+    return intToFloat(f64, @bitCast(u128, a));
 }

--- a/lib/compiler_rt/floatuntidf.zig
+++ b/lib/compiler_rt/floatuntidf.zig
@@ -1,26 +1,21 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    const floatuntidf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __floatuntidf_windows_x86_64;
-    } else __floatuntidf;
-
-    @export(floatuntidf_fn, .{ .name = "__floatuntidf", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__floatuntidf_windows_x86_64, .{ .name = "__floatuntidf", .linkage = common.linkage });
+    } else {
+        @export(__floatuntidf, .{ .name = "__floatuntidf", .linkage = common.linkage });
+    }
 }
 
 pub fn __floatuntidf(a: u128) callconv(.C) f64 {
     return intToFloat(f64, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
-
-fn __floatuntidf_windows_x86_64(a: v128) callconv(.C) f64 {
+fn __floatuntidf_windows_x86_64(a: @Vector(2, u64)) callconv(.C) f64 {
     return intToFloat(f64, @bitCast(u128, a));
 }

--- a/lib/compiler_rt/floatuntihf.zig
+++ b/lib/compiler_rt/floatuntihf.zig
@@ -1,26 +1,21 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    const floatuntihf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __floatuntihf_windows_x86_64;
-    } else __floatuntihf;
-
-    @export(floatuntihf_fn, .{ .name = "__floatuntihf", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__floatuntihf_windows_x86_64, .{ .name = "__floatuntihf", .linkage = common.linkage });
+    } else {
+        @export(__floatuntihf, .{ .name = "__floatuntihf", .linkage = common.linkage });
+    }
 }
 
 pub fn __floatuntihf(a: u128) callconv(.C) f16 {
     return intToFloat(f16, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
-
-fn __floatuntihf_windows_x86_64(a: v128) callconv(.C) f16 {
+fn __floatuntihf_windows_x86_64(a: @Vector(2, u64)) callconv(.C) f16 {
     return intToFloat(f16, @bitCast(u128, a));
 }

--- a/lib/compiler_rt/floatuntihf.zig
+++ b/lib/compiler_rt/floatuntihf.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__floatuntihf, .{ .name = "__floatuntihf", .linkage = common.linkage });
+    const floatuntihf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __floatuntihf_windows_x86_64;
+    } else __floatuntihf;
+
+    @export(floatuntihf_fn, .{ .name = "__floatuntihf", .linkage = common.linkage });
 }
 
-fn __floatuntihf(a: u128) callconv(.C) f16 {
+pub fn __floatuntihf(a: u128) callconv(.C) f16 {
     return intToFloat(f16, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __floatuntihf_windows_x86_64(a: v128) callconv(.C) f16 {
+    return intToFloat(f16, @bitCast(u128, a));
 }

--- a/lib/compiler_rt/floatuntisf.zig
+++ b/lib/compiler_rt/floatuntisf.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__floatuntisf, .{ .name = "__floatuntisf", .linkage = common.linkage });
+    const floatuntisf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __floatuntisf_windows_x86_64;
+    } else __floatuntisf;
+
+    @export(floatuntisf_fn, .{ .name = "__floatuntisf", .linkage = common.linkage });
 }
 
 pub fn __floatuntisf(a: u128) callconv(.C) f32 {
     return intToFloat(f32, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __floatuntisf_windows_x86_64(a: v128) callconv(.C) f32 {
+    return intToFloat(f32, @bitCast(u128, a));
 }

--- a/lib/compiler_rt/floatuntisf.zig
+++ b/lib/compiler_rt/floatuntisf.zig
@@ -1,26 +1,21 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    const floatuntisf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __floatuntisf_windows_x86_64;
-    } else __floatuntisf;
-
-    @export(floatuntisf_fn, .{ .name = "__floatuntisf", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__floatuntisf_windows_x86_64, .{ .name = "__floatuntisf", .linkage = common.linkage });
+    } else {
+        @export(__floatuntisf, .{ .name = "__floatuntisf", .linkage = common.linkage });
+    }
 }
 
 pub fn __floatuntisf(a: u128) callconv(.C) f32 {
     return intToFloat(f32, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
-
-fn __floatuntisf_windows_x86_64(a: v128) callconv(.C) f32 {
+fn __floatuntisf_windows_x86_64(a: @Vector(2, u64)) callconv(.C) f32 {
     return intToFloat(f32, @bitCast(u128, a));
 }

--- a/lib/compiler_rt/floatuntitf.zig
+++ b/lib/compiler_rt/floatuntitf.zig
@@ -1,5 +1,4 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
@@ -8,21 +7,17 @@ pub const panic = common.panic;
 comptime {
     const symbol_name = if (common.want_ppc_abi) "__floatuntikf" else "__floatuntitf";
 
-    const floatuntitf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __floatuntitf_windows_x86_64;
-    } else __floatuntitf;
-
-    @export(floatuntitf_fn, .{ .name = symbol_name, .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__floatuntitf_windows_x86_64, .{ .name = symbol_name, .linkage = common.linkage });
+    } else {
+        @export(__floatuntitf, .{ .name = symbol_name, .linkage = common.linkage });
+    }
 }
 
 pub fn __floatuntitf(a: u128) callconv(.C) f128 {
     return intToFloat(f128, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
-
-fn __floatuntitf_windows_x86_64(a: v128) callconv(.C) f128 {
+fn __floatuntitf_windows_x86_64(a: @Vector(2, u64)) callconv(.C) f128 {
     return intToFloat(f128, @bitCast(u128, a));
 }

--- a/lib/compiler_rt/floatuntitf.zig
+++ b/lib/compiler_rt/floatuntitf.zig
@@ -1,20 +1,28 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__floatuntikf, .{ .name = "__floatuntikf", .linkage = common.linkage });
-    } else {
-        @export(__floatuntitf, .{ .name = "__floatuntitf", .linkage = common.linkage });
-    }
+    const symbol_name = if (common.want_ppc_abi) "__floatuntikf" else "__floatuntitf";
+
+    const floatuntitf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __floatuntitf_windows_x86_64;
+    } else __floatuntitf;
+
+    @export(floatuntitf_fn, .{ .name = symbol_name, .linkage = common.linkage });
 }
 
 pub fn __floatuntitf(a: u128) callconv(.C) f128 {
     return intToFloat(f128, a);
 }
 
-fn __floatuntikf(a: u128) callconv(.C) f128 {
-    return intToFloat(f128, a);
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __floatuntitf_windows_x86_64(a: v128) callconv(.C) f128 {
+    return intToFloat(f128, @bitCast(u128, a));
 }

--- a/lib/compiler_rt/floatuntixf.zig
+++ b/lib/compiler_rt/floatuntixf.zig
@@ -1,12 +1,26 @@
+const builtin = @import("builtin");
+const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    @export(__floatuntixf, .{ .name = "__floatuntixf", .linkage = common.linkage });
+    const floatuntixf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
+        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
+        // that LLVM expects compiler-rt to have.
+        break :b __floatuntixf_windows_x86_64;
+    } else __floatuntixf;
+
+    @export(floatuntixf_fn, .{ .name = "__floatuntixf", .linkage = common.linkage });
 }
 
 pub fn __floatuntixf(a: u128) callconv(.C) f80 {
     return intToFloat(f80, a);
+}
+
+const v128 = @import("std").meta.Vector(2, u64);
+
+fn __floatuntixf_windows_x86_64(a: v128) callconv(.C) f80 {
+    return intToFloat(f80, @bitCast(u128, a));
 }

--- a/lib/compiler_rt/floatuntixf.zig
+++ b/lib/compiler_rt/floatuntixf.zig
@@ -1,26 +1,21 @@
 const builtin = @import("builtin");
-const arch = builtin.cpu.arch;
 const common = @import("./common.zig");
 const intToFloat = @import("./int_to_float.zig").intToFloat;
 
 pub const panic = common.panic;
 
 comptime {
-    const floatuntixf_fn = if (builtin.os.tag == .windows and arch == .x86_64) b: {
-        // The "ti" functions must use Vector(2, u64) return types to adhere to the ABI
-        // that LLVM expects compiler-rt to have.
-        break :b __floatuntixf_windows_x86_64;
-    } else __floatuntixf;
-
-    @export(floatuntixf_fn, .{ .name = "__floatuntixf", .linkage = common.linkage });
+    if (common.want_windows_v2u64_abi) {
+        @export(__floatuntixf_windows_x86_64, .{ .name = "__floatuntixf", .linkage = common.linkage });
+    } else {
+        @export(__floatuntixf, .{ .name = "__floatuntixf", .linkage = common.linkage });
+    }
 }
 
 pub fn __floatuntixf(a: u128) callconv(.C) f80 {
     return intToFloat(f80, a);
 }
 
-const v128 = @import("std").meta.Vector(2, u64);
-
-fn __floatuntixf_windows_x86_64(a: v128) callconv(.C) f80 {
+fn __floatuntixf_windows_x86_64(a: @Vector(2, u64)) callconv(.C) f80 {
     return intToFloat(f80, @bitCast(u128, a));
 }

--- a/lib/compiler_rt/udivmodti4.zig
+++ b/lib/compiler_rt/udivmodti4.zig
@@ -1,24 +1,13 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const udivmod = @import("udivmod.zig").udivmod;
-const arch = builtin.cpu.arch;
 const common = @import("common.zig");
 
 pub const panic = common.panic;
 
 comptime {
-    if (builtin.os.tag == .windows) {
-        switch (arch) {
-            .i386 => {
-                @export(__udivmodti4, .{ .name = "__udivmodti4", .linkage = common.linkage });
-            },
-            .x86_64 => {
-                // The "ti" functions must use Vector(2, u64) parameter types to adhere to the ABI
-                // that LLVM expects compiler-rt to have.
-                @export(__udivmodti4_windows_x86_64, .{ .name = "__udivmodti4", .linkage = common.linkage });
-            },
-            else => {},
-        }
+    if (common.want_windows_v2u64_abi) {
+        @export(__udivmodti4_windows_x86_64, .{ .name = "__udivmodti4", .linkage = common.linkage });
     } else {
         @export(__udivmodti4, .{ .name = "__udivmodti4", .linkage = common.linkage });
     }
@@ -28,10 +17,10 @@ pub fn __udivmodti4(a: u128, b: u128, maybe_rem: ?*u128) callconv(.C) u128 {
     return udivmod(u128, a, b, maybe_rem);
 }
 
-const v128 = std.meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __udivmodti4_windows_x86_64(a: v128, b: v128, maybe_rem: ?*u128) callconv(.C) v128 {
-    return @bitCast(v128, udivmod(u128, @bitCast(u128, a), @bitCast(u128, b), maybe_rem));
+fn __udivmodti4_windows_x86_64(a: v2u64, b: v2u64, maybe_rem: ?*u128) callconv(.C) v2u64 {
+    return @bitCast(v2u64, udivmod(u128, @bitCast(u128, a), @bitCast(u128, b), maybe_rem));
 }
 
 test {

--- a/lib/compiler_rt/udivti3.zig
+++ b/lib/compiler_rt/udivti3.zig
@@ -1,27 +1,13 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const udivmod = @import("udivmod.zig").udivmod;
-const arch = builtin.cpu.arch;
 const common = @import("common.zig");
 
 pub const panic = common.panic;
 
 comptime {
-    if (builtin.os.tag == .windows) {
-        switch (arch) {
-            .i386 => {
-                @export(__udivti3, .{ .name = "__udivti3", .linkage = common.linkage });
-            },
-            .x86_64 => {
-                // The "ti" functions must use Vector(2, u64) parameter types to adhere to the ABI
-                // that LLVM expects compiler-rt to have.
-                @export(__udivti3_windows_x86_64, .{ .name = "__udivti3", .linkage = common.linkage });
-            },
-            else => {},
-        }
-        if (arch.isAARCH64()) {
-            @export(__udivti3, .{ .name = "__udivti3", .linkage = common.linkage });
-        }
+    if (common.want_windows_v2u64_abi) {
+        @export(__udivti3_windows_x86_64, .{ .name = "__udivti3", .linkage = common.linkage });
     } else {
         @export(__udivti3, .{ .name = "__udivti3", .linkage = common.linkage });
     }
@@ -31,8 +17,8 @@ pub fn __udivti3(a: u128, b: u128) callconv(.C) u128 {
     return udivmod(u128, a, b, null);
 }
 
-const v128 = std.meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __udivti3_windows_x86_64(a: v128, b: v128) callconv(.C) v128 {
-    return @bitCast(v128, udivmod(u128, @bitCast(u128, a), @bitCast(u128, b), null));
+fn __udivti3_windows_x86_64(a: v2u64, b: v2u64) callconv(.C) v2u64 {
+    return @bitCast(v2u64, udivmod(u128, @bitCast(u128, a), @bitCast(u128, b), null));
 }

--- a/lib/compiler_rt/umodti3.zig
+++ b/lib/compiler_rt/umodti3.zig
@@ -1,27 +1,13 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const udivmod = @import("udivmod.zig").udivmod;
-const arch = builtin.cpu.arch;
 const common = @import("common.zig");
 
 pub const panic = common.panic;
 
 comptime {
-    if (builtin.os.tag == .windows) {
-        switch (arch) {
-            .i386 => {
-                @export(__umodti3, .{ .name = "__umodti3", .linkage = common.linkage });
-            },
-            .x86_64 => {
-                // The "ti" functions must use Vector(2, u64) parameter types to adhere to the ABI
-                // that LLVM expects compiler-rt to have.
-                @export(__umodti3_windows_x86_64, .{ .name = "__umodti3", .linkage = common.linkage });
-            },
-            else => {},
-        }
-        if (arch.isAARCH64()) {
-            @export(__umodti3, .{ .name = "__umodti3", .linkage = common.linkage });
-        }
+    if (common.want_windows_v2u64_abi) {
+        @export(__umodti3_windows_x86_64, .{ .name = "__umodti3", .linkage = common.linkage });
     } else {
         @export(__umodti3, .{ .name = "__umodti3", .linkage = common.linkage });
     }
@@ -33,10 +19,10 @@ pub fn __umodti3(a: u128, b: u128) callconv(.C) u128 {
     return r;
 }
 
-const v128 = std.meta.Vector(2, u64);
+const v2u64 = @Vector(2, u64);
 
-fn __umodti3_windows_x86_64(a: v128, b: v128) callconv(.C) v128 {
+fn __umodti3_windows_x86_64(a: v2u64, b: v2u64) callconv(.C) v2u64 {
     var r: u128 = undefined;
     _ = udivmod(u128, @bitCast(u128, a), @bitCast(u128, b), &r);
-    return @bitCast(v128, r);
+    return @bitCast(v2u64, r);
 }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2284,10 +2284,6 @@ test "float.hexadecimal.precision" {
 }
 
 test "float.decimal" {
-    if (builtin.zig_backend == .stage1 and builtin.os.tag == .windows) {
-        // https://github.com/ziglang/zig/issues/12063
-        return error.SkipZigTest;
-    }
     try expectFmt("f64: 152314000000000000000000000000", "f64: {d}", .{@as(f64, 1.52314e+29)});
     try expectFmt("f32: 0", "f32: {d}", .{@as(f32, 0.0)});
     try expectFmt("f32: 0", "f32: {d:.0}", .{@as(f32, 0.0)});
@@ -2311,10 +2307,6 @@ test "float.decimal" {
 }
 
 test "float.libc.sanity" {
-    if (builtin.zig_backend == .stage1 and builtin.os.tag == .windows) {
-        // https://github.com/ziglang/zig/issues/12063
-        return error.SkipZigTest;
-    }
     try expectFmt("f64: 0.00001", "f64: {d:.5}", .{@as(f64, @bitCast(f32, @as(u32, 916964781)))});
     try expectFmt("f64: 0.00001", "f64: {d:.5}", .{@as(f64, @bitCast(f32, @as(u32, 925353389)))});
     try expectFmt("f64: 0.10000", "f64: {d:.5}", .{@as(f64, @bitCast(f32, @as(u32, 1036831278)))});

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -101,18 +101,20 @@ test "vector float operators" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
-    const S = struct {
-        fn doTheTest() !void {
-            var v: @Vector(4, f32) = [4]f32{ 10, 20, 30, 40 };
-            var x: @Vector(4, f32) = [4]f32{ 1, 2, 3, 4 };
-            try expect(mem.eql(f32, &@as([4]f32, v + x), &[4]f32{ 11, 22, 33, 44 }));
-            try expect(mem.eql(f32, &@as([4]f32, v - x), &[4]f32{ 9, 18, 27, 36 }));
-            try expect(mem.eql(f32, &@as([4]f32, v * x), &[4]f32{ 10, 40, 90, 160 }));
-            try expect(mem.eql(f32, &@as([4]f32, -x), &[4]f32{ -1, -2, -3, -4 }));
-        }
-    };
-    try S.doTheTest();
-    comptime try S.doTheTest();
+    inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
+        const S = struct {
+            fn doTheTest() !void {
+                var v: @Vector(4, T) = [4]T{ 10, 20, 30, 40 };
+                var x: @Vector(4, T) = [4]T{ 1, 2, 3, 4 };
+                try expect(mem.eql(T, &@as([4]T, v + x), &[4]T{ 11, 22, 33, 44 }));
+                try expect(mem.eql(T, &@as([4]T, v - x), &[4]T{ 9, 18, 27, 36 }));
+                try expect(mem.eql(T, &@as([4]T, v * x), &[4]T{ 10, 40, 90, 160 }));
+                try expect(mem.eql(T, &@as([4]T, -x), &[4]T{ -1, -2, -3, -4 }));
+            }
+        };
+        try S.doTheTest();
+        comptime try S.doTheTest();
+    }
 }
 
 test "vector bit operators" {


### PR DESCRIPTION
Resolves #12063

Starting with LLVM 14, the Libcalls to these functions are now lowered using a `Vector(2, u64)` instead of the standard ABI for i128 integers on Windows, so our compiler-rt implementation needs to be updated to expose the same ABI

Relevant LLVM revision: https://reviews.llvm.org/D110413