### PR TITLE
Fix `checkAllAllocationFailures` being too strict when checking arg types

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -626,10 +626,6 @@ pub fn checkAllAllocationFailures(backing_allocator: std.mem.Allocator, comptime
     // the failing allocator in field @"0" before each @call)
     var args: ArgsTuple = undefined;
     inline for (@typeInfo(@TypeOf(extra_args)).Struct.fields) |field, i| {
-        const expected_type = fn_args_fields[i + 1].field_type;
-        if (expected_type != field.field_type) {
-            @compileError("Unexpected type for extra argument at index " ++ (comptime std.fmt.comptimePrint("{d}", .{i})) ++ ": expected " ++ @typeName(expected_type) ++ ", found " ++ @typeName(field.field_type));
-        }
         const arg_i_str = comptime str: {
             var str_buf: [100]u8 = undefined;
             const args_i = i + 1;


### PR DESCRIPTION
Before, this would fail to compile:

```zig
fn testFn(alloc: std.mem.Allocator, arr: []const u8) !void {
    _ = alloc;
    _ = arr;
}

test "checkAll" {
    var arr = [_]u8{ 1, 2, 3 };
    try std.testing.checkAllAllocationFailures(std.testing.allocator, testFn, .{arr[0..]});
}
```

with the error `error: Unexpected type for extra argument at index 0: expected []const u8, found *[3]u8`

By removing this strict equality check, we allow the type checking to be done during the `@field(args, arg_i_str) = @field(extra_args, field.name);` instead, which then allows for things like type coercion to work, but still will give a compile error if the types are incorrect. So, after this change, the above succeeds (because `*[3]u8` can be coerced to `[]const u8`).

The new compile error when providing an incorrect type that can't be coerced looks like this:

```
zig/lib/std/testing.zig:639:35: error: expected type '[]const u8', found '*[3]u32'
        @field(args, arg_i_str) = @field(extra_args, field.name);
                                  ^
```