### PR TITLE
`std.Progress`: fix inaccurate line truncation and use optimal max terminal width

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -290,8 +290,7 @@ fn refreshWithHeldLock(self: *Progress) void {
     var end: usize = 0;
     if (self.columns_written > 0) {
         // restore the cursor position by moving the cursor
-        // `columns_written` cells to the left, then clear the rest of the
-        // line
+        // `columns_written` cells to the left, then clear the rest of the line
         if (self.supports_ansi_escape_codes) {
             end += (std.fmt.bufPrint(self.output_buffer_slice[end..], "\x1b[{d}D", .{self.columns_written}) catch unreachable).len;
             end += (std.fmt.bufPrint(self.output_buffer_slice[end..], "\x1b[0K", .{}) catch unreachable).len;
@@ -343,9 +342,8 @@ fn refreshWithHeldLock(self: *Progress) void {
         self.columns_written = 0;
     }
 
-    // from here on we will print printable characters.
-    // make sure the unprintable characters we printed don't affect when we truncate the line
-    // in `bufWrite`.
+    // from here on we will write printable characters. we also make sure the unprintable characters
+    // we possibly wrote previously don't affect whether we truncate the line in `bufWrite`.
     const unprintables = end;
     end = 0;
     self.output_buffer_slice = self.output_buffer[unprintables .. unprintables + self.max_width.?];

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -411,13 +411,65 @@ fn bufWrite(self: *Progress, end: *usize, comptime format: []const u8, args: any
     }
 }
 
-test "basic functionality" {
-    var disable = true;
-    if (disable) {
-        // This test is disabled because it uses time.sleep() and is therefore slow. It also
-        // prints bogus progress data to stderr.
+// By default these tests are disabled because they use time.sleep()
+// and are therefore slow. They also prints bogus progress data to stderr.
+const skip_tests = false;
+
+test "behavior on buffer overflow" {
+    if (skip_tests)
         return error.SkipZigTest;
+
+    var progress = Progress{};
+
+    const long_string = "A" ** 300;
+    var node = progress.start(long_string, 0);
+
+    const speed_factor = std.time.ns_per_s / 4;
+
+    std.time.sleep(speed_factor);
+    node.activate();
+    std.time.sleep(speed_factor);
+    node.end();
+}
+
+test "multiple tasks with long names" {
+    if (skip_tests)
+        return error.SkipZigTest;
+
+    const time = std.time;
+
+    var progress = Progress{};
+
+    const tasks = [_][]const u8{
+        "A" ** 99,
+        "A" ** 100,
+        "A" ** 101,
+        "A" ** 102,
+        "A" ** 103,
+    };
+
+    const speed_factor = time.ns_per_s / 6;
+
+    for (tasks) |task| {
+        var node = progress.start(task, 3);
+        time.sleep(speed_factor);
+        node.activate();
+
+        time.sleep(speed_factor);
+        node.completeOne();
+        time.sleep(speed_factor);
+        node.completeOne();
+        time.sleep(speed_factor);
+        node.completeOne();
+
+        node.end();
     }
+}
+
+test "basic functionality" {
+    if (skip_tests)
+        return error.SkipZigTest;
+
     var progress = Progress{};
     const root_node = progress.start("", 100);
     defer root_node.end();

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -249,7 +249,7 @@ fn getTerminalCursorColumn(self: Progress, file: std.fs.File) !u16 {
         var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
         if (windows.kernel32.GetConsoleScreenBufferInfo(file.handle, &info) != windows.TRUE)
             unreachable;
-        return info.dwCursorPosition.X;
+        return @intCast(u16, info.dwCursorPosition.X);
     } else {
         return error.Unsupported;
     }

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -348,6 +348,7 @@ fn refreshWithHeldLock(self: *Progress) void {
     // in `bufWrite`.
     const unprintables = end;
     end = 0;
+    std.debug.print("PROGRESS DEBUG: {d} {d}", .{ unprintables, self.max_width.? });
     self.output_buffer_slice = self.output_buffer[unprintables .. unprintables + self.max_width.?];
 
     if (!self.done) {

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -203,13 +203,7 @@ pub fn start(self: *Progress, name: []const u8, estimated_total_items: usize) *N
 }
 
 fn getTerminalWidth(self: Progress, file_handle: os.fd_t) !u16 {
-    if (builtin.os.tag == .windows) {
-        std.debug.assert(self.is_windows_terminal);
-        var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
-        if (windows.kernel32.GetConsoleScreenBufferInfo(file_handle, &info) != windows.TRUE)
-            return error.Unexpected;
-        return @intCast(u16, info.dwSize.X);
-    } else if (builtin.os.tag == .linux) {
+    if (builtin.os.tag == .linux) {
         // TODO: figure out how to get this working on FreeBSD, macOS etc. too.
         //       they too should have capabilities to figure out the cursor column.
         var winsize: os.linux.winsize = undefined;
@@ -217,6 +211,12 @@ fn getTerminalWidth(self: Progress, file_handle: os.fd_t) !u16 {
             .SUCCESS => return winsize.ws_col,
             else => return error.Unexpected,
         }
+    } else if (builtin.os.tag == .windows) {
+        std.debug.assert(self.is_windows_terminal);
+        var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
+        if (windows.kernel32.GetConsoleScreenBufferInfo(file_handle, &info) != windows.TRUE)
+            return error.Unexpected;
+        return @intCast(u16, info.dwSize.X);
     } else {
         return error.Unsupported;
     }

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -207,7 +207,7 @@ fn getTerminalWidth(self: Progress, file_handle: os.fd_t) !u16 {
         std.debug.assert(self.is_windows_terminal);
         var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
         if (windows.kernel32.GetConsoleScreenBufferInfo(file_handle, &info) != windows.TRUE)
-            unreachable;
+            return error.Unexpected;
         return @intCast(u16, info.dwSize.X);
     } else if (builtin.os.tag == .linux) {
         // TODO: figure out how to get this working on FreeBSD, macOS etc. too.
@@ -248,7 +248,7 @@ fn getTerminalCursorColumn(self: Progress, file: std.fs.File) !u16 {
         std.debug.assert(self.is_windows_terminal);
         var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
         if (windows.kernel32.GetConsoleScreenBufferInfo(file.handle, &info) != windows.TRUE)
-            unreachable;
+            return error.Unexpected;
         return @intCast(u16, info.dwCursorPosition.X);
     } else {
         return error.Unsupported;

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -186,7 +186,7 @@ pub fn start(self: *Progress, name: []const u8, estimated_total_items: usize) *N
     self.max_width = std.math.clamp(
         self.max_width.?,
         truncation_suffix.len, // make sure we can at least truncate
-        self.output_buffer.len,
+        self.output_buffer.len - 1,
     );
     self.root = Node{
         .context = self,
@@ -348,7 +348,6 @@ fn refreshWithHeldLock(self: *Progress) void {
     // in `bufWrite`.
     const unprintables = end;
     end = 0;
-    std.debug.print("PROGRESS DEBUG: {d} {d}", .{ unprintables, self.max_width.? });
     self.output_buffer_slice = self.output_buffer[unprintables .. unprintables + self.max_width.?];
 
     if (!self.done) {
@@ -429,11 +428,14 @@ fn bufWrite(self: *Progress, end: *usize, comptime format: []const u8, args: any
 
 // By default these tests are disabled because they use time.sleep()
 // and are therefore slow. They also prints bogus progress data to stderr.
-const skip_tests = false;
+const skip_tests = true;
 
 test "behavior on buffer overflow" {
     if (skip_tests)
         return error.SkipZigTest;
+
+    // move the cursor
+    std.debug.print("{s}", .{"A" ** 300});
 
     var progress = Progress{};
 

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -473,6 +473,28 @@ test "multiple tasks with long names" {
     }
 }
 
+test "very short max width" {
+    if (skip_tests)
+        return error.SkipZigTest;
+
+    var progress = Progress{ .max_width = 4 };
+
+    const task = "A" ** 300;
+
+    const speed_factor = time.ns_per_s / 2;
+
+    var node = progress.start(task, 3);
+    time.sleep(speed_factor);
+    node.activate();
+
+    time.sleep(speed_factor);
+    node.completeOne();
+    time.sleep(speed_factor);
+    node.completeOne();
+
+    node.end();
+}
+
 test "basic functionality" {
     if (skip_tests)
         return error.SkipZigTest;


### PR DESCRIPTION
I really had a lot of attempts at this and I think this might be the best one so far. I think there's still some things to improve but this is definitely a start.

Output now fits nicely on pretty much any terminal width (well, not if it's >256 though, but that limit can easily be bumped):
![image](https://user-images.githubusercontent.com/35064754/178334346-15f3e663-0684-4664-a0fc-85d1fc87e22e.png)

Here's another common issue that I think Andrew described in https://github.com/ziglang/zig/issues/12024#issuecomment-1176803566:

![image](https://user-images.githubusercontent.com/35064754/178335333-d8dcb3d4-eb7f-495e-9042-6d68b3ea6a25.png)

That issue seems to be fixed now; here's a compilation on a terminal with a very small width:

https://user-images.githubusercontent.com/35064754/178335637-3a187e07-9cc9-4cc5-9ac3-45bda66ebc95.mp4

It succeeds with nothing left on the terminal.

Closes #12024 