### PR TITLE
Dynamically link `libc++` if integrating with system LLVM

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -565,13 +565,17 @@ fn addCmakeCfgOptionsToExe(
         exe.linkLibCpp();
     } else {
         const need_cpp_includes = true;
+        const lib_suffix = switch (cfg.llvm_linkage) {
+            .static => exe.target.staticLibSuffix()[1..],
+            .dynamic => exe.target.dynamicLibSuffix()[1..],
+        };
 
         // System -lc++ must be used because in this code path we are attempting to link
         // against system-provided LLVM, Clang, LLD.
         if (exe.target.getOsTag() == .linux) {
-            // First we try to static link against gcc libstdc++. If that doesn't work,
-            // we fall back to -lc++ and cross our fingers.
-            addCxxKnownPath(b, cfg, exe, "libstdc++.a", "", need_cpp_includes) catch |err| switch (err) {
+            // First we try to link against gcc libstdc++. If that doesn't work, we fall
+            // back to -lc++ and cross our fingers.
+            addCxxKnownPath(b, cfg, exe, b.fmt("libstdc++.{s}", .{lib_suffix}), "", need_cpp_includes) catch |err| switch (err) {
                 error.RequiredLibraryNotFound => {
                     exe.linkSystemLibrary("c++");
                 },
@@ -579,11 +583,11 @@ fn addCmakeCfgOptionsToExe(
             };
             exe.linkSystemLibrary("unwind");
         } else if (exe.target.isFreeBSD()) {
-            try addCxxKnownPath(b, cfg, exe, "libc++.a", null, need_cpp_includes);
+            try addCxxKnownPath(b, cfg, exe, b.fmt("libc++.{s}", .{lib_suffix}), null, need_cpp_includes);
             exe.linkSystemLibrary("pthread");
         } else if (exe.target.getOsTag() == .openbsd) {
-            try addCxxKnownPath(b, cfg, exe, "libc++.a", null, need_cpp_includes);
-            try addCxxKnownPath(b, cfg, exe, "libc++abi.a", null, need_cpp_includes);
+            try addCxxKnownPath(b, cfg, exe, b.fmt("libc++.{s}", .{lib_suffix}), null, need_cpp_includes);
+            try addCxxKnownPath(b, cfg, exe, b.fmt("libc++abi.{s}", .{lib_suffix}), null, need_cpp_includes);
         } else if (exe.target.isDarwin()) {
             exe.linkSystemLibrary("c++");
         }

--- a/src/clang.zig
+++ b/src/clang.zig
@@ -1913,3 +1913,6 @@ extern fn ZigClangLoadFromCommandLine(
     errors_len: *usize,
     resources_path: [*:0]const u8,
 ) ?*ASTUnit;
+
+pub const isLLVMUsingSeparateLibcxx = ZigClangIsLLVMUsingSeparateLibcxx;
+extern fn ZigClangIsLLVMUsingSeparateLibcxx() bool;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1592,6 +1592,15 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
                     }
                 }
             }
+            for (self.base.options.objects) |obj| {
+                if (Compilation.classifyFileExt(obj.path) == .shared_library) {
+                    const lib_dir_path = std.fs.path.dirname(obj.path).?;
+                    if ((try rpath_table.fetchPut(lib_dir_path, {})) == null) {
+                        try argv.append("-rpath");
+                        try argv.append(lib_dir_path);
+                    }
+                }
+            }
         }
 
         for (self.base.options.lib_dirs) |lib_dir| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -174,6 +174,17 @@ pub fn main() anyerror!void {
     return mainArgs(gpa, arena, args);
 }
 
+/// Check that LLVM and Clang have been linked properly so that they are using the same
+/// libc++ and can safely share objects with pointers to static variables in libc++
+fn verifyLibcxxCorrectlyLinked() void {
+    if (build_options.have_llvm and ZigClangIsLLVMUsingSeparateLibcxx()) {
+        fatal(
+            \\Zig was built/linked incorrectly: LLVM and Clang have separate copies of libc++
+            \\       If you are dynamically linking LLVM, make sure you dynamically link libc++ too
+        , .{});
+    }
+}
+
 pub fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     if (args.len <= 1) {
         std.log.info("{s}", .{usage});
@@ -261,8 +272,12 @@ pub fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
         const stdout = io.getStdOut().writer();
         return @import("print_targets.zig").cmdTargets(arena, cmd_args, stdout, info.target);
     } else if (mem.eql(u8, cmd, "version")) {
-        return std.io.getStdOut().writeAll(build_options.version ++ "\n");
+        try std.io.getStdOut().writeAll(build_options.version ++ "\n");
+        // Check libc++ linkage to make sure Zig was built correctly, but only for "env" and "version"
+        // to avoid affecting the startup time for build-critical commands (check takes about ~10 μs)
+        return verifyLibcxxCorrectlyLinked();
     } else if (mem.eql(u8, cmd, "env")) {
+        verifyLibcxxCorrectlyLinked();
         return @import("print_env.zig").cmdEnv(arena, cmd_args, io.getStdOut().writer());
     } else if (mem.eql(u8, cmd, "zen")) {
         return io.getStdOut().writeAll(info_zen);
@@ -4480,6 +4495,8 @@ pub const info_zen =
     \\
     \\
 ;
+
+extern fn ZigClangIsLLVMUsingSeparateLibcxx() bool;
 
 extern "c" fn ZigClang_main(argc: c_int, argv: [*:null]?[*:0]u8) c_int;
 extern "c" fn ZigLlvmAr_main(argc: c_int, argv: [*:null]?[*:0]u8) c_int;

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -1418,4 +1418,5 @@ ZIG_EXTERN_C const struct ZigClangRecordDecl *ZigClangFieldDecl_getParent(const 
 ZIG_EXTERN_C unsigned ZigClangFieldDecl_getFieldIndex(const struct ZigClangFieldDecl *);
 
 ZIG_EXTERN_C const struct ZigClangAPSInt *ZigClangEnumConstantDecl_getInitVal(const struct ZigClangEnumConstantDecl *);
+ZIG_EXTERN_C bool ZigClangIsLLVMUsingSeparateLibcxx();
 #endif


### PR DESCRIPTION
If we are integrating with system LLVM, build.zig attempts to statically link `libc++`.

As a result, LLVM ends up with a separate "copy" of the library. This causes POSIX `std::error_code`s generated by LLVM and Clang always compare unequal, since they refer to (duplicated) static variables.

This PR changes libc++ to be linked dynamically and adds a runtime check to verify that LLVM and Clang are using a single instance of libc++. I believe this resolves https://github.com/ziglang/zig/issues/11168 (cc @mitchellh)

I might have missed some important build system details, so feel free to take this change over if needed.
