### PR TITLE
stdlib: make linux.PERF.TYPE non-exhaustive

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -5498,6 +5498,7 @@ pub const PERF = struct {
         RAW,
         BREAKPOINT,
         MAX,
+        _,
     };
 
     pub const COUNT = struct {


### PR DESCRIPTION
perf_event_attr.type needs to take a runtime defined value to enable
dynamic PMU:s, such as kprobe and uprobe. This value can exceed
predefined values defined in the linux headers.

reference: perf_event_open(2) man page