### PR TITLE
Conditionally export f80 and f128 compiler_rt symbols

### DIFF
--- a/lib/compiler_rt/addtf3.zig
+++ b/lib/compiler_rt/addtf3.zig
@@ -4,12 +4,14 @@ const addf3 = @import("./addf3.zig").addf3;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__addkf3, .{ .name = "__addkf3", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_add, .{ .name = "_Qp_add", .linkage = common.linkage });
-    } else {
-        @export(__addtf3, .{ .name = "__addtf3", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__addkf3, .{ .name = "__addkf3", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_add, .{ .name = "_Qp_add", .linkage = common.linkage });
+        } else {
+            @export(__addtf3, .{ .name = "__addtf3", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/addxf3.zig
+++ b/lib/compiler_rt/addxf3.zig
@@ -4,7 +4,9 @@ const addf3 = @import("./addf3.zig").addf3;
 pub const panic = common.panic;
 
 comptime {
-    @export(__addxf3, .{ .name = "__addxf3", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__addxf3, .{ .name = "__addxf3", .linkage = common.linkage });
+    }
 }
 
 pub fn __addxf3(a: f80, b: f80) callconv(.C) f80 {

--- a/lib/compiler_rt/ceil.zig
+++ b/lib/compiler_rt/ceil.zig
@@ -17,10 +17,12 @@ comptime {
     @export(__ceilh, .{ .name = "__ceilh", .linkage = common.linkage });
     @export(ceilf, .{ .name = "ceilf", .linkage = common.linkage });
     @export(ceil, .{ .name = "ceil", .linkage = common.linkage });
-    @export(__ceilx, .{ .name = "__ceilx", .linkage = common.linkage });
-    const ceilq_sym_name = if (common.want_ppc_abi) "ceilf128" else "ceilq";
-    @export(ceilq, .{ .name = ceilq_sym_name, .linkage = common.linkage });
-    @export(ceill, .{ .name = "ceill", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__ceilx, .{ .name = "__ceilx", .linkage = common.linkage });
+        const ceilq_sym_name = if (common.want_ppc_abi) "ceilf128" else "ceilq";
+        @export(ceilq, .{ .name = ceilq_sym_name, .linkage = common.linkage });
+        @export(ceill, .{ .name = "ceill", .linkage = common.linkage });
+    }
 }
 
 pub fn __ceilh(x: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/cmptf2.zig
+++ b/lib/compiler_rt/cmptf2.zig
@@ -6,25 +6,27 @@ const comparef = @import("./comparef.zig");
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__eqkf2, .{ .name = "__eqkf2", .linkage = common.linkage });
-        @export(__nekf2, .{ .name = "__nekf2", .linkage = common.linkage });
-        @export(__ltkf2, .{ .name = "__ltkf2", .linkage = common.linkage });
-        @export(__lekf2, .{ .name = "__lekf2", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_cmp, .{ .name = "_Qp_cmp", .linkage = common.linkage });
-        @export(_Qp_feq, .{ .name = "_Qp_feq", .linkage = common.linkage });
-        @export(_Qp_fne, .{ .name = "_Qp_fne", .linkage = common.linkage });
-        @export(_Qp_flt, .{ .name = "_Qp_flt", .linkage = common.linkage });
-        @export(_Qp_fle, .{ .name = "_Qp_fle", .linkage = common.linkage });
-        @export(_Qp_fgt, .{ .name = "_Qp_fgt", .linkage = common.linkage });
-        @export(_Qp_fge, .{ .name = "_Qp_fge", .linkage = common.linkage });
-    } else {
-        @export(__eqtf2, .{ .name = "__eqtf2", .linkage = common.linkage });
-        @export(__netf2, .{ .name = "__netf2", .linkage = common.linkage });
-        @export(__letf2, .{ .name = "__letf2", .linkage = common.linkage });
-        @export(__cmptf2, .{ .name = "__cmptf2", .linkage = common.linkage });
-        @export(__lttf2, .{ .name = "__lttf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__eqkf2, .{ .name = "__eqkf2", .linkage = common.linkage });
+            @export(__nekf2, .{ .name = "__nekf2", .linkage = common.linkage });
+            @export(__ltkf2, .{ .name = "__ltkf2", .linkage = common.linkage });
+            @export(__lekf2, .{ .name = "__lekf2", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_cmp, .{ .name = "_Qp_cmp", .linkage = common.linkage });
+            @export(_Qp_feq, .{ .name = "_Qp_feq", .linkage = common.linkage });
+            @export(_Qp_fne, .{ .name = "_Qp_fne", .linkage = common.linkage });
+            @export(_Qp_flt, .{ .name = "_Qp_flt", .linkage = common.linkage });
+            @export(_Qp_fle, .{ .name = "_Qp_fle", .linkage = common.linkage });
+            @export(_Qp_fgt, .{ .name = "_Qp_fgt", .linkage = common.linkage });
+            @export(_Qp_fge, .{ .name = "_Qp_fge", .linkage = common.linkage });
+        } else {
+            @export(__eqtf2, .{ .name = "__eqtf2", .linkage = common.linkage });
+            @export(__netf2, .{ .name = "__netf2", .linkage = common.linkage });
+            @export(__letf2, .{ .name = "__letf2", .linkage = common.linkage });
+            @export(__cmptf2, .{ .name = "__cmptf2", .linkage = common.linkage });
+            @export(__lttf2, .{ .name = "__lttf2", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/cmpxf2.zig
+++ b/lib/compiler_rt/cmpxf2.zig
@@ -6,11 +6,13 @@ const comparef = @import("./comparef.zig");
 pub const panic = common.panic;
 
 comptime {
-    @export(__eqxf2, .{ .name = "__eqxf2", .linkage = common.linkage });
-    @export(__nexf2, .{ .name = "__nexf2", .linkage = common.linkage });
-    @export(__lexf2, .{ .name = "__lexf2", .linkage = common.linkage });
-    @export(__cmpxf2, .{ .name = "__cmpxf2", .linkage = common.linkage });
-    @export(__ltxf2, .{ .name = "__ltxf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__eqxf2, .{ .name = "__eqxf2", .linkage = common.linkage });
+        @export(__nexf2, .{ .name = "__nexf2", .linkage = common.linkage });
+        @export(__lexf2, .{ .name = "__lexf2", .linkage = common.linkage });
+        @export(__cmpxf2, .{ .name = "__cmpxf2", .linkage = common.linkage });
+        @export(__ltxf2, .{ .name = "__ltxf2", .linkage = common.linkage });
+    }
 }
 
 /// "These functions calculate a <=> b. That is, if a is less than b, they return -1;

--- a/lib/compiler_rt/cos.zig
+++ b/lib/compiler_rt/cos.zig
@@ -15,10 +15,12 @@ comptime {
     @export(__cosh, .{ .name = "__cosh", .linkage = common.linkage });
     @export(cosf, .{ .name = "cosf", .linkage = common.linkage });
     @export(cos, .{ .name = "cos", .linkage = common.linkage });
-    @export(__cosx, .{ .name = "__cosx", .linkage = common.linkage });
-    const cosq_sym_name = if (common.want_ppc_abi) "cosf128" else "cosq";
-    @export(cosq, .{ .name = cosq_sym_name, .linkage = common.linkage });
-    @export(cosl, .{ .name = "cosl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__cosx, .{ .name = "__cosx", .linkage = common.linkage });
+        const cosq_sym_name = if (common.want_ppc_abi) "cosf128" else "cosq";
+        @export(cosq, .{ .name = cosq_sym_name, .linkage = common.linkage });
+        @export(cosl, .{ .name = "cosl", .linkage = common.linkage });
+    }
 }
 
 pub fn __cosh(a: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/divtf3.zig
+++ b/lib/compiler_rt/divtf3.zig
@@ -8,12 +8,14 @@ const wideMultiply = common.wideMultiply;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__divkf3, .{ .name = "__divkf3", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_div, .{ .name = "_Qp_div", .linkage = common.linkage });
-    } else {
-        @export(__divtf3, .{ .name = "__divtf3", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__divkf3, .{ .name = "__divkf3", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_div, .{ .name = "_Qp_div", .linkage = common.linkage });
+        } else {
+            @export(__divtf3, .{ .name = "__divtf3", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/divxf3.zig
+++ b/lib/compiler_rt/divxf3.zig
@@ -9,7 +9,9 @@ const wideMultiply = common.wideMultiply;
 pub const panic = common.panic;
 
 comptime {
-    @export(__divxf3, .{ .name = "__divxf3", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__divxf3, .{ .name = "__divxf3", .linkage = common.linkage });
+    }
 }
 
 pub fn __divxf3(a: f80, b: f80) callconv(.C) f80 {

--- a/lib/compiler_rt/exp.zig
+++ b/lib/compiler_rt/exp.zig
@@ -17,10 +17,12 @@ comptime {
     @export(__exph, .{ .name = "__exph", .linkage = common.linkage });
     @export(expf, .{ .name = "expf", .linkage = common.linkage });
     @export(exp, .{ .name = "exp", .linkage = common.linkage });
-    @export(__expx, .{ .name = "__expx", .linkage = common.linkage });
-    const expq_sym_name = if (common.want_ppc_abi) "expf128" else "expq";
-    @export(expq, .{ .name = expq_sym_name, .linkage = common.linkage });
-    @export(expl, .{ .name = "expl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__expx, .{ .name = "__expx", .linkage = common.linkage });
+        const expq_sym_name = if (common.want_ppc_abi) "expf128" else "expq";
+        @export(expq, .{ .name = expq_sym_name, .linkage = common.linkage });
+        @export(expl, .{ .name = "expl", .linkage = common.linkage });
+    }
 }
 
 pub fn __exph(a: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/exp2.zig
+++ b/lib/compiler_rt/exp2.zig
@@ -17,10 +17,12 @@ comptime {
     @export(__exp2h, .{ .name = "__exp2h", .linkage = common.linkage });
     @export(exp2f, .{ .name = "exp2f", .linkage = common.linkage });
     @export(exp2, .{ .name = "exp2", .linkage = common.linkage });
-    @export(__exp2x, .{ .name = "__exp2x", .linkage = common.linkage });
-    const exp2q_sym_name = if (common.want_ppc_abi) "exp2f128" else "exp2q";
-    @export(exp2q, .{ .name = exp2q_sym_name, .linkage = common.linkage });
-    @export(exp2l, .{ .name = "exp2l", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__exp2x, .{ .name = "__exp2x", .linkage = common.linkage });
+        const exp2q_sym_name = if (common.want_ppc_abi) "exp2f128" else "exp2q";
+        @export(exp2q, .{ .name = exp2q_sym_name, .linkage = common.linkage });
+        @export(exp2l, .{ .name = "exp2l", .linkage = common.linkage });
+    }
 }
 
 pub fn __exp2h(x: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/extenddftf2.zig
+++ b/lib/compiler_rt/extenddftf2.zig
@@ -4,12 +4,14 @@ const extendf = @import("./extendf.zig").extendf;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__extenddfkf2, .{ .name = "__extenddfkf2", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_dtoq, .{ .name = "_Qp_dtoq", .linkage = common.linkage });
-    } else {
-        @export(__extenddftf2, .{ .name = "__extenddftf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__extenddfkf2, .{ .name = "__extenddfkf2", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_dtoq, .{ .name = "_Qp_dtoq", .linkage = common.linkage });
+        } else {
+            @export(__extenddftf2, .{ .name = "__extenddftf2", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/extenddfxf2.zig
+++ b/lib/compiler_rt/extenddfxf2.zig
@@ -4,7 +4,9 @@ const extend_f80 = @import("./extendf.zig").extend_f80;
 pub const panic = common.panic;
 
 comptime {
-    @export(__extenddfxf2, .{ .name = "__extenddfxf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__extenddfxf2, .{ .name = "__extenddfxf2", .linkage = common.linkage });
+    }
 }
 
 fn __extenddfxf2(a: f64) callconv(.C) f80 {

--- a/lib/compiler_rt/extendhftf2.zig
+++ b/lib/compiler_rt/extendhftf2.zig
@@ -4,7 +4,9 @@ const extendf = @import("./extendf.zig").extendf;
 pub const panic = common.panic;
 
 comptime {
-    @export(__extendhftf2, .{ .name = "__extendhftf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__extendhftf2, .{ .name = "__extendhftf2", .linkage = common.linkage });
+    }
 }
 
 pub fn __extendhftf2(a: common.F16T) callconv(.C) f128 {

--- a/lib/compiler_rt/extendhfxf2.zig
+++ b/lib/compiler_rt/extendhfxf2.zig
@@ -4,7 +4,9 @@ const extend_f80 = @import("./extendf.zig").extend_f80;
 pub const panic = common.panic;
 
 comptime {
-    @export(__extendhfxf2, .{ .name = "__extendhfxf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__extendhfxf2, .{ .name = "__extendhfxf2", .linkage = common.linkage });
+    }
 }
 
 fn __extendhfxf2(a: common.F16T) callconv(.C) f80 {

--- a/lib/compiler_rt/extendsftf2.zig
+++ b/lib/compiler_rt/extendsftf2.zig
@@ -4,12 +4,14 @@ const extendf = @import("./extendf.zig").extendf;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__extendsfkf2, .{ .name = "__extendsfkf2", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_stoq, .{ .name = "_Qp_stoq", .linkage = common.linkage });
-    } else {
-        @export(__extendsftf2, .{ .name = "__extendsftf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__extendsfkf2, .{ .name = "__extendsfkf2", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_stoq, .{ .name = "_Qp_stoq", .linkage = common.linkage });
+        } else {
+            @export(__extendsftf2, .{ .name = "__extendsftf2", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/extendsfxf2.zig
+++ b/lib/compiler_rt/extendsfxf2.zig
@@ -4,7 +4,9 @@ const extend_f80 = @import("./extendf.zig").extend_f80;
 pub const panic = common.panic;
 
 comptime {
-    @export(__extendsfxf2, .{ .name = "__extendsfxf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__extendsfxf2, .{ .name = "__extendsfxf2", .linkage = common.linkage });
+    }
 }
 
 fn __extendsfxf2(a: f32) callconv(.C) f80 {

--- a/lib/compiler_rt/extendxftf2.zig
+++ b/lib/compiler_rt/extendxftf2.zig
@@ -4,7 +4,9 @@ const common = @import("./common.zig");
 pub const panic = common.panic;
 
 comptime {
-    @export(__extendxftf2, .{ .name = "__extendxftf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__extendxftf2, .{ .name = "__extendxftf2", .linkage = common.linkage });
+    }
 }
 
 fn __extendxftf2(a: f80) callconv(.C) f128 {

--- a/lib/compiler_rt/fabs.zig
+++ b/lib/compiler_rt/fabs.zig
@@ -9,10 +9,12 @@ comptime {
     @export(__fabsh, .{ .name = "__fabsh", .linkage = common.linkage });
     @export(fabsf, .{ .name = "fabsf", .linkage = common.linkage });
     @export(fabs, .{ .name = "fabs", .linkage = common.linkage });
-    @export(__fabsx, .{ .name = "__fabsx", .linkage = common.linkage });
-    const fabsq_sym_name = if (common.want_ppc_abi) "fabsf128" else "fabsq";
-    @export(fabsq, .{ .name = fabsq_sym_name, .linkage = common.linkage });
-    @export(fabsl, .{ .name = "fabsl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__fabsx, .{ .name = "__fabsx", .linkage = common.linkage });
+        const fabsq_sym_name = if (common.want_ppc_abi) "fabsf128" else "fabsq";
+        @export(fabsq, .{ .name = fabsq_sym_name, .linkage = common.linkage });
+        @export(fabsl, .{ .name = "fabsl", .linkage = common.linkage });
+    }
 }
 
 pub fn __fabsh(a: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/fixtfdi.zig
+++ b/lib/compiler_rt/fixtfdi.zig
@@ -4,12 +4,14 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__fixkfdi, .{ .name = "__fixkfdi", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_qtox, .{ .name = "_Qp_qtox", .linkage = common.linkage });
-    } else {
-        @export(__fixtfdi, .{ .name = "__fixtfdi", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__fixkfdi, .{ .name = "__fixkfdi", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_qtox, .{ .name = "_Qp_qtox", .linkage = common.linkage });
+        } else {
+            @export(__fixtfdi, .{ .name = "__fixtfdi", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/fixtfsi.zig
+++ b/lib/compiler_rt/fixtfsi.zig
@@ -4,12 +4,14 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__fixkfsi, .{ .name = "__fixkfsi", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_qtoi, .{ .name = "_Qp_qtoi", .linkage = common.linkage });
-    } else {
-        @export(__fixtfsi, .{ .name = "__fixtfsi", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__fixkfsi, .{ .name = "__fixkfsi", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_qtoi, .{ .name = "_Qp_qtoi", .linkage = common.linkage });
+        } else {
+            @export(__fixtfsi, .{ .name = "__fixtfsi", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/fixtfti.zig
+++ b/lib/compiler_rt/fixtfti.zig
@@ -5,10 +5,12 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_windows_v2u64_abi) {
-        @export(__fixtfti_windows_x86_64, .{ .name = "__fixtfti", .linkage = common.linkage });
-    } else {
-        @export(__fixtfti, .{ .name = "__fixtfti", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_windows_v2u64_abi) {
+            @export(__fixtfti_windows_x86_64, .{ .name = "__fixtfti", .linkage = common.linkage });
+        } else {
+            @export(__fixtfti, .{ .name = "__fixtfti", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/fixunstfdi.zig
+++ b/lib/compiler_rt/fixunstfdi.zig
@@ -4,12 +4,14 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__fixunskfdi, .{ .name = "__fixunskfdi", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_qtoux, .{ .name = "_Qp_qtoux", .linkage = common.linkage });
-    } else {
-        @export(__fixunstfdi, .{ .name = "__fixunstfdi", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__fixunskfdi, .{ .name = "__fixunskfdi", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_qtoux, .{ .name = "_Qp_qtoux", .linkage = common.linkage });
+        } else {
+            @export(__fixunstfdi, .{ .name = "__fixunstfdi", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/fixunstfsi.zig
+++ b/lib/compiler_rt/fixunstfsi.zig
@@ -4,12 +4,14 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__fixunskfsi, .{ .name = "__fixunskfsi", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_qtoui, .{ .name = "_Qp_qtoui", .linkage = common.linkage });
-    } else {
-        @export(__fixunstfsi, .{ .name = "__fixunstfsi", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__fixunskfsi, .{ .name = "__fixunskfsi", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_qtoui, .{ .name = "_Qp_qtoui", .linkage = common.linkage });
+        } else {
+            @export(__fixunstfsi, .{ .name = "__fixunstfsi", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/fixunstfti.zig
+++ b/lib/compiler_rt/fixunstfti.zig
@@ -5,10 +5,12 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_windows_v2u64_abi) {
-        @export(__fixunstfti_windows_x86_64, .{ .name = "__fixunstfti", .linkage = common.linkage });
-    } else {
-        @export(__fixunstfti, .{ .name = "__fixunstfti", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_windows_v2u64_abi) {
+            @export(__fixunstfti_windows_x86_64, .{ .name = "__fixunstfti", .linkage = common.linkage });
+        } else {
+            @export(__fixunstfti, .{ .name = "__fixunstfti", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/fixunsxfdi.zig
+++ b/lib/compiler_rt/fixunsxfdi.zig
@@ -4,7 +4,9 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixunsxfdi, .{ .name = "__fixunsxfdi", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__fixunsxfdi, .{ .name = "__fixunsxfdi", .linkage = common.linkage });
+    }
 }
 
 fn __fixunsxfdi(a: f80) callconv(.C) u64 {

--- a/lib/compiler_rt/fixunsxfsi.zig
+++ b/lib/compiler_rt/fixunsxfsi.zig
@@ -4,7 +4,9 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixunsxfsi, .{ .name = "__fixunsxfsi", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__fixunsxfsi, .{ .name = "__fixunsxfsi", .linkage = common.linkage });
+    }
 }
 
 fn __fixunsxfsi(a: f80) callconv(.C) u32 {

--- a/lib/compiler_rt/fixunsxfti.zig
+++ b/lib/compiler_rt/fixunsxfti.zig
@@ -5,10 +5,12 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_windows_v2u64_abi) {
-        @export(__fixunsxfti_windows_x86_64, .{ .name = "__fixunsxfti", .linkage = common.linkage });
-    } else {
-        @export(__fixunsxfti, .{ .name = "__fixunsxfti", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_windows_v2u64_abi) {
+            @export(__fixunsxfti_windows_x86_64, .{ .name = "__fixunsxfti", .linkage = common.linkage });
+        } else {
+            @export(__fixunsxfti, .{ .name = "__fixunsxfti", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/fixxfdi.zig
+++ b/lib/compiler_rt/fixxfdi.zig
@@ -4,7 +4,9 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixxfdi, .{ .name = "__fixxfdi", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__fixxfdi, .{ .name = "__fixxfdi", .linkage = common.linkage });
+    }
 }
 
 fn __fixxfdi(a: f80) callconv(.C) i64 {

--- a/lib/compiler_rt/fixxfsi.zig
+++ b/lib/compiler_rt/fixxfsi.zig
@@ -4,7 +4,9 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    @export(__fixxfsi, .{ .name = "__fixxfsi", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__fixxfsi, .{ .name = "__fixxfsi", .linkage = common.linkage });
+    }
 }
 
 fn __fixxfsi(a: f80) callconv(.C) i32 {

--- a/lib/compiler_rt/fixxfti.zig
+++ b/lib/compiler_rt/fixxfti.zig
@@ -5,10 +5,12 @@ const floatToInt = @import("./float_to_int.zig").floatToInt;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_windows_v2u64_abi) {
-        @export(__fixxfti_windows_x86_64, .{ .name = "__fixxfti", .linkage = common.linkage });
-    } else {
-        @export(__fixxfti, .{ .name = "__fixxfti", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_windows_v2u64_abi) {
+            @export(__fixxfti_windows_x86_64, .{ .name = "__fixxfti", .linkage = common.linkage });
+        } else {
+            @export(__fixxfti, .{ .name = "__fixxfti", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/floatditf.zig
+++ b/lib/compiler_rt/floatditf.zig
@@ -4,12 +4,14 @@ const intToFloat = @import("./int_to_float.zig").intToFloat;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__floatdikf, .{ .name = "__floatdikf", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_xtoq, .{ .name = "_Qp_xtoq", .linkage = common.linkage });
-    } else {
-        @export(__floatditf, .{ .name = "__floatditf", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__floatdikf, .{ .name = "__floatdikf", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_xtoq, .{ .name = "_Qp_xtoq", .linkage = common.linkage });
+        } else {
+            @export(__floatditf, .{ .name = "__floatditf", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/floatdixf.zig
+++ b/lib/compiler_rt/floatdixf.zig
@@ -4,7 +4,9 @@ const intToFloat = @import("./int_to_float.zig").intToFloat;
 pub const panic = common.panic;
 
 comptime {
-    @export(__floatdixf, .{ .name = "__floatdixf", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__floatdixf, .{ .name = "__floatdixf", .linkage = common.linkage });
+    }
 }
 
 fn __floatdixf(a: i64) callconv(.C) f80 {

--- a/lib/compiler_rt/floatsitf.zig
+++ b/lib/compiler_rt/floatsitf.zig
@@ -4,12 +4,14 @@ const intToFloat = @import("./int_to_float.zig").intToFloat;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__floatsikf, .{ .name = "__floatsikf", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_itoq, .{ .name = "_Qp_itoq", .linkage = common.linkage });
-    } else {
-        @export(__floatsitf, .{ .name = "__floatsitf", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__floatsikf, .{ .name = "__floatsikf", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_itoq, .{ .name = "_Qp_itoq", .linkage = common.linkage });
+        } else {
+            @export(__floatsitf, .{ .name = "__floatsitf", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/floatsixf.zig
+++ b/lib/compiler_rt/floatsixf.zig
@@ -4,7 +4,9 @@ const intToFloat = @import("./int_to_float.zig").intToFloat;
 pub const panic = common.panic;
 
 comptime {
-    @export(__floatsixf, .{ .name = "__floatsixf", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__floatsixf, .{ .name = "__floatsixf", .linkage = common.linkage });
+    }
 }
 
 fn __floatsixf(a: i32) callconv(.C) f80 {

--- a/lib/compiler_rt/floattixf.zig
+++ b/lib/compiler_rt/floattixf.zig
@@ -5,10 +5,12 @@ const intToFloat = @import("./int_to_float.zig").intToFloat;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_windows_v2u64_abi) {
-        @export(__floattixf_windows_x86_64, .{ .name = "__floattixf", .linkage = common.linkage });
-    } else {
-        @export(__floattixf, .{ .name = "__floattixf", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_windows_v2u64_abi) {
+            @export(__floattixf_windows_x86_64, .{ .name = "__floattixf", .linkage = common.linkage });
+        } else {
+            @export(__floattixf, .{ .name = "__floattixf", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/floatunditf.zig
+++ b/lib/compiler_rt/floatunditf.zig
@@ -4,12 +4,14 @@ const intToFloat = @import("./int_to_float.zig").intToFloat;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__floatundikf, .{ .name = "__floatundikf", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_uxtoq, .{ .name = "_Qp_uxtoq", .linkage = common.linkage });
-    } else {
-        @export(__floatunditf, .{ .name = "__floatunditf", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__floatundikf, .{ .name = "__floatundikf", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_uxtoq, .{ .name = "_Qp_uxtoq", .linkage = common.linkage });
+        } else {
+            @export(__floatunditf, .{ .name = "__floatunditf", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/floatundixf.zig
+++ b/lib/compiler_rt/floatundixf.zig
@@ -4,7 +4,9 @@ const intToFloat = @import("./int_to_float.zig").intToFloat;
 pub const panic = common.panic;
 
 comptime {
-    @export(__floatundixf, .{ .name = "__floatundixf", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__floatundixf, .{ .name = "__floatundixf", .linkage = common.linkage });
+    }
 }
 
 fn __floatundixf(a: u64) callconv(.C) f80 {

--- a/lib/compiler_rt/floatunsitf.zig
+++ b/lib/compiler_rt/floatunsitf.zig
@@ -4,12 +4,14 @@ const intToFloat = @import("./int_to_float.zig").intToFloat;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__floatunsikf, .{ .name = "__floatunsikf", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_uitoq, .{ .name = "_Qp_uitoq", .linkage = common.linkage });
-    } else {
-        @export(__floatunsitf, .{ .name = "__floatunsitf", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__floatunsikf, .{ .name = "__floatunsikf", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_uitoq, .{ .name = "_Qp_uitoq", .linkage = common.linkage });
+        } else {
+            @export(__floatunsitf, .{ .name = "__floatunsitf", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/floatunsixf.zig
+++ b/lib/compiler_rt/floatunsixf.zig
@@ -4,7 +4,9 @@ const intToFloat = @import("./int_to_float.zig").intToFloat;
 pub const panic = common.panic;
 
 comptime {
-    @export(__floatunsixf, .{ .name = "__floatunsixf", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__floatunsixf, .{ .name = "__floatunsixf", .linkage = common.linkage });
+    }
 }
 
 fn __floatunsixf(a: u32) callconv(.C) f80 {

--- a/lib/compiler_rt/floatuntitf.zig
+++ b/lib/compiler_rt/floatuntitf.zig
@@ -5,12 +5,14 @@ const intToFloat = @import("./int_to_float.zig").intToFloat;
 pub const panic = common.panic;
 
 comptime {
-    const symbol_name = if (common.want_ppc_abi) "__floatuntikf" else "__floatuntitf";
+    if (common.should_emit_f80_or_f128) {
+        const symbol_name = if (common.want_ppc_abi) "__floatuntikf" else "__floatuntitf";
 
-    if (common.want_windows_v2u64_abi) {
-        @export(__floatuntitf_windows_x86_64, .{ .name = symbol_name, .linkage = common.linkage });
-    } else {
-        @export(__floatuntitf, .{ .name = symbol_name, .linkage = common.linkage });
+        if (common.want_windows_v2u64_abi) {
+            @export(__floatuntitf_windows_x86_64, .{ .name = symbol_name, .linkage = common.linkage });
+        } else {
+            @export(__floatuntitf, .{ .name = symbol_name, .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/floatuntixf.zig
+++ b/lib/compiler_rt/floatuntixf.zig
@@ -5,10 +5,12 @@ const intToFloat = @import("./int_to_float.zig").intToFloat;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_windows_v2u64_abi) {
-        @export(__floatuntixf_windows_x86_64, .{ .name = "__floatuntixf", .linkage = common.linkage });
-    } else {
-        @export(__floatuntixf, .{ .name = "__floatuntixf", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_windows_v2u64_abi) {
+            @export(__floatuntixf_windows_x86_64, .{ .name = "__floatuntixf", .linkage = common.linkage });
+        } else {
+            @export(__floatuntixf, .{ .name = "__floatuntixf", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/floor.zig
+++ b/lib/compiler_rt/floor.zig
@@ -17,10 +17,12 @@ comptime {
     @export(__floorh, .{ .name = "__floorh", .linkage = common.linkage });
     @export(floorf, .{ .name = "floorf", .linkage = common.linkage });
     @export(floor, .{ .name = "floor", .linkage = common.linkage });
-    @export(__floorx, .{ .name = "__floorx", .linkage = common.linkage });
-    const floorq_sym_name = if (common.want_ppc_abi) "floorf128" else "floorq";
-    @export(floorq, .{ .name = floorq_sym_name, .linkage = common.linkage });
-    @export(floorl, .{ .name = "floorl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__floorx, .{ .name = "__floorx", .linkage = common.linkage });
+        const floorq_sym_name = if (common.want_ppc_abi) "floorf128" else "floorq";
+        @export(floorq, .{ .name = floorq_sym_name, .linkage = common.linkage });
+        @export(floorl, .{ .name = "floorl", .linkage = common.linkage });
+    }
 }
 
 pub fn __floorh(x: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/fma.zig
+++ b/lib/compiler_rt/fma.zig
@@ -18,10 +18,12 @@ comptime {
     @export(__fmah, .{ .name = "__fmah", .linkage = common.linkage });
     @export(fmaf, .{ .name = "fmaf", .linkage = common.linkage });
     @export(fma, .{ .name = "fma", .linkage = common.linkage });
-    @export(__fmax, .{ .name = "__fmax", .linkage = common.linkage });
-    const fmaq_sym_name = if (common.want_ppc_abi) "fmaf128" else "fmaq";
-    @export(fmaq, .{ .name = fmaq_sym_name, .linkage = common.linkage });
-    @export(fmal, .{ .name = "fmal", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__fmax, .{ .name = "__fmax", .linkage = common.linkage });
+        const fmaq_sym_name = if (common.want_ppc_abi) "fmaf128" else "fmaq";
+        @export(fmaq, .{ .name = fmaq_sym_name, .linkage = common.linkage });
+        @export(fmal, .{ .name = "fmal", .linkage = common.linkage });
+    }
 }
 
 pub fn __fmah(x: f16, y: f16, z: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/fmax.zig
+++ b/lib/compiler_rt/fmax.zig
@@ -10,10 +10,12 @@ comptime {
     @export(__fmaxh, .{ .name = "__fmaxh", .linkage = common.linkage });
     @export(fmaxf, .{ .name = "fmaxf", .linkage = common.linkage });
     @export(fmax, .{ .name = "fmax", .linkage = common.linkage });
-    @export(__fmaxx, .{ .name = "__fmaxx", .linkage = common.linkage });
-    const fmaxq_sym_name = if (common.want_ppc_abi) "fmaxf128" else "fmaxq";
-    @export(fmaxq, .{ .name = fmaxq_sym_name, .linkage = common.linkage });
-    @export(fmaxl, .{ .name = "fmaxl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__fmaxx, .{ .name = "__fmaxx", .linkage = common.linkage });
+        const fmaxq_sym_name = if (common.want_ppc_abi) "fmaxf128" else "fmaxq";
+        @export(fmaxq, .{ .name = fmaxq_sym_name, .linkage = common.linkage });
+        @export(fmaxl, .{ .name = "fmaxl", .linkage = common.linkage });
+    }
 }
 
 pub fn __fmaxh(x: f16, y: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/fmin.zig
+++ b/lib/compiler_rt/fmin.zig
@@ -10,10 +10,12 @@ comptime {
     @export(__fminh, .{ .name = "__fminh", .linkage = common.linkage });
     @export(fminf, .{ .name = "fminf", .linkage = common.linkage });
     @export(fmin, .{ .name = "fmin", .linkage = common.linkage });
-    @export(__fminx, .{ .name = "__fminx", .linkage = common.linkage });
-    const fminq_sym_name = if (common.want_ppc_abi) "fminf128" else "fminq";
-    @export(fminq, .{ .name = fminq_sym_name, .linkage = common.linkage });
-    @export(fminl, .{ .name = "fminl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__fminx, .{ .name = "__fminx", .linkage = common.linkage });
+        const fminq_sym_name = if (common.want_ppc_abi) "fminf128" else "fminq";
+        @export(fminq, .{ .name = fminq_sym_name, .linkage = common.linkage });
+        @export(fminl, .{ .name = "fminl", .linkage = common.linkage });
+    }
 }
 
 pub fn __fminh(x: f16, y: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/fmod.zig
+++ b/lib/compiler_rt/fmod.zig
@@ -12,10 +12,12 @@ comptime {
     @export(__fmodh, .{ .name = "__fmodh", .linkage = common.linkage });
     @export(fmodf, .{ .name = "fmodf", .linkage = common.linkage });
     @export(fmod, .{ .name = "fmod", .linkage = common.linkage });
-    @export(__fmodx, .{ .name = "__fmodx", .linkage = common.linkage });
-    const fmodq_sym_name = if (common.want_ppc_abi) "fmodf128" else "fmodq";
-    @export(fmodq, .{ .name = fmodq_sym_name, .linkage = common.linkage });
-    @export(fmodl, .{ .name = "fmodl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__fmodx, .{ .name = "__fmodx", .linkage = common.linkage });
+        const fmodq_sym_name = if (common.want_ppc_abi) "fmodf128" else "fmodq";
+        @export(fmodq, .{ .name = fmodq_sym_name, .linkage = common.linkage });
+        @export(fmodl, .{ .name = "fmodl", .linkage = common.linkage });
+    }
 }
 
 pub fn __fmodh(x: f16, y: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/getf2.zig
+++ b/lib/compiler_rt/getf2.zig
@@ -6,15 +6,17 @@ const comparef = @import("./comparef.zig");
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__gekf2, .{ .name = "__gekf2", .linkage = common.linkage });
-        @export(__gtkf2, .{ .name = "__gtkf2", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        // These exports are handled in cmptf2.zig because gt and ge on sparc
-        // are based on calling _Qp_cmp.
-    } else {
-        @export(__getf2, .{ .name = "__getf2", .linkage = common.linkage });
-        @export(__gttf2, .{ .name = "__gttf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__gekf2, .{ .name = "__gekf2", .linkage = common.linkage });
+            @export(__gtkf2, .{ .name = "__gtkf2", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            // These exports are handled in cmptf2.zig because gt and ge on sparc
+            // are based on calling _Qp_cmp.
+        } else {
+            @export(__getf2, .{ .name = "__getf2", .linkage = common.linkage });
+            @export(__gttf2, .{ .name = "__gttf2", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/gexf2.zig
+++ b/lib/compiler_rt/gexf2.zig
@@ -4,8 +4,10 @@ const comparef = @import("./comparef.zig");
 pub const panic = common.panic;
 
 comptime {
-    @export(__gexf2, .{ .name = "__gexf2", .linkage = common.linkage });
-    @export(__gtxf2, .{ .name = "__gtxf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__gexf2, .{ .name = "__gexf2", .linkage = common.linkage });
+        @export(__gtxf2, .{ .name = "__gtxf2", .linkage = common.linkage });
+    }
 }
 
 fn __gexf2(a: f80, b: f80) callconv(.C) i32 {

--- a/lib/compiler_rt/log.zig
+++ b/lib/compiler_rt/log.zig
@@ -17,10 +17,12 @@ comptime {
     @export(__logh, .{ .name = "__logh", .linkage = common.linkage });
     @export(logf, .{ .name = "logf", .linkage = common.linkage });
     @export(log, .{ .name = "log", .linkage = common.linkage });
-    @export(__logx, .{ .name = "__logx", .linkage = common.linkage });
-    const logq_sym_name = if (common.want_ppc_abi) "logf128" else "logq";
-    @export(logq, .{ .name = logq_sym_name, .linkage = common.linkage });
-    @export(logl, .{ .name = "logl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__logx, .{ .name = "__logx", .linkage = common.linkage });
+        const logq_sym_name = if (common.want_ppc_abi) "logf128" else "logq";
+        @export(logq, .{ .name = logq_sym_name, .linkage = common.linkage });
+        @export(logl, .{ .name = "logl", .linkage = common.linkage });
+    }
 }
 
 pub fn __logh(a: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/log10.zig
+++ b/lib/compiler_rt/log10.zig
@@ -18,10 +18,12 @@ comptime {
     @export(__log10h, .{ .name = "__log10h", .linkage = common.linkage });
     @export(log10f, .{ .name = "log10f", .linkage = common.linkage });
     @export(log10, .{ .name = "log10", .linkage = common.linkage });
-    @export(__log10x, .{ .name = "__log10x", .linkage = common.linkage });
-    const log10q_sym_name = if (common.want_ppc_abi) "log10f128" else "log10q";
-    @export(log10q, .{ .name = log10q_sym_name, .linkage = common.linkage });
-    @export(log10l, .{ .name = "log10l", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__log10x, .{ .name = "__log10x", .linkage = common.linkage });
+        const log10q_sym_name = if (common.want_ppc_abi) "log10f128" else "log10q";
+        @export(log10q, .{ .name = log10q_sym_name, .linkage = common.linkage });
+        @export(log10l, .{ .name = "log10l", .linkage = common.linkage });
+    }
 }
 
 pub fn __log10h(a: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/log2.zig
+++ b/lib/compiler_rt/log2.zig
@@ -18,10 +18,12 @@ comptime {
     @export(__log2h, .{ .name = "__log2h", .linkage = common.linkage });
     @export(log2f, .{ .name = "log2f", .linkage = common.linkage });
     @export(log2, .{ .name = "log2", .linkage = common.linkage });
-    @export(__log2x, .{ .name = "__log2x", .linkage = common.linkage });
-    const log2q_sym_name = if (common.want_ppc_abi) "log2f128" else "log2q";
-    @export(log2q, .{ .name = log2q_sym_name, .linkage = common.linkage });
-    @export(log2l, .{ .name = "log2l", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__log2x, .{ .name = "__log2x", .linkage = common.linkage });
+        const log2q_sym_name = if (common.want_ppc_abi) "log2f128" else "log2q";
+        @export(log2q, .{ .name = log2q_sym_name, .linkage = common.linkage });
+        @export(log2l, .{ .name = "log2l", .linkage = common.linkage });
+    }
 }
 
 pub fn __log2h(a: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/multf3.zig
+++ b/lib/compiler_rt/multf3.zig
@@ -4,12 +4,14 @@ const mulf3 = @import("./mulf3.zig").mulf3;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__mulkf3, .{ .name = "__mulkf3", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_mul, .{ .name = "_Qp_mul", .linkage = common.linkage });
-    } else {
-        @export(__multf3, .{ .name = "__multf3", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__mulkf3, .{ .name = "__mulkf3", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_mul, .{ .name = "_Qp_mul", .linkage = common.linkage });
+        } else {
+            @export(__multf3, .{ .name = "__multf3", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/mulxf3.zig
+++ b/lib/compiler_rt/mulxf3.zig
@@ -4,7 +4,9 @@ const mulf3 = @import("./mulf3.zig").mulf3;
 pub const panic = common.panic;
 
 comptime {
-    @export(__mulxf3, .{ .name = "__mulxf3", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__mulxf3, .{ .name = "__mulxf3", .linkage = common.linkage });
+    }
 }
 
 pub fn __mulxf3(a: f80, b: f80) callconv(.C) f80 {

--- a/lib/compiler_rt/negtf2.zig
+++ b/lib/compiler_rt/negtf2.zig
@@ -3,7 +3,9 @@ const common = @import("./common.zig");
 pub const panic = common.panic;
 
 comptime {
-    @export(__negtf2, .{ .name = "__negtf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__negtf2, .{ .name = "__negtf2", .linkage = common.linkage });
+    }
 }
 
 fn __negtf2(a: f128) callconv(.C) f128 {

--- a/lib/compiler_rt/negxf2.zig
+++ b/lib/compiler_rt/negxf2.zig
@@ -3,7 +3,9 @@ const common = @import("./common.zig");
 pub const panic = common.panic;
 
 comptime {
-    @export(__negxf2, .{ .name = "__negxf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__negxf2, .{ .name = "__negxf2", .linkage = common.linkage });
+    }
 }
 
 fn __negxf2(a: f80) callconv(.C) f80 {

--- a/lib/compiler_rt/round.zig
+++ b/lib/compiler_rt/round.zig
@@ -17,10 +17,12 @@ comptime {
     @export(__roundh, .{ .name = "__roundh", .linkage = common.linkage });
     @export(roundf, .{ .name = "roundf", .linkage = common.linkage });
     @export(round, .{ .name = "round", .linkage = common.linkage });
-    @export(__roundx, .{ .name = "__roundx", .linkage = common.linkage });
-    const roundq_sym_name = if (common.want_ppc_abi) "roundf128" else "roundq";
-    @export(roundq, .{ .name = roundq_sym_name, .linkage = common.linkage });
-    @export(roundl, .{ .name = "roundl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__roundx, .{ .name = "__roundx", .linkage = common.linkage });
+        const roundq_sym_name = if (common.want_ppc_abi) "roundf128" else "roundq";
+        @export(roundq, .{ .name = roundq_sym_name, .linkage = common.linkage });
+        @export(roundl, .{ .name = "roundl", .linkage = common.linkage });
+    }
 }
 
 pub fn __roundh(x: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/sin.zig
+++ b/lib/compiler_rt/sin.zig
@@ -21,10 +21,12 @@ comptime {
     @export(__sinh, .{ .name = "__sinh", .linkage = common.linkage });
     @export(sinf, .{ .name = "sinf", .linkage = common.linkage });
     @export(sin, .{ .name = "sin", .linkage = common.linkage });
-    @export(__sinx, .{ .name = "__sinx", .linkage = common.linkage });
-    const sinq_sym_name = if (common.want_ppc_abi) "sinf128" else "sinq";
-    @export(sinq, .{ .name = sinq_sym_name, .linkage = common.linkage });
-    @export(sinl, .{ .name = "sinl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__sinx, .{ .name = "__sinx", .linkage = common.linkage });
+        const sinq_sym_name = if (common.want_ppc_abi) "sinf128" else "sinq";
+        @export(sinq, .{ .name = sinq_sym_name, .linkage = common.linkage });
+        @export(sinl, .{ .name = "sinl", .linkage = common.linkage });
+    }
 }
 
 pub fn __sinh(x: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/sincos.zig
+++ b/lib/compiler_rt/sincos.zig
@@ -13,10 +13,12 @@ comptime {
     @export(__sincosh, .{ .name = "__sincosh", .linkage = common.linkage });
     @export(sincosf, .{ .name = "sincosf", .linkage = common.linkage });
     @export(sincos, .{ .name = "sincos", .linkage = common.linkage });
-    @export(__sincosx, .{ .name = "__sincosx", .linkage = common.linkage });
-    const sincosq_sym_name = if (common.want_ppc_abi) "sincosf128" else "sincosq";
-    @export(sincosq, .{ .name = sincosq_sym_name, .linkage = common.linkage });
-    @export(sincosl, .{ .name = "sincosl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__sincosx, .{ .name = "__sincosx", .linkage = common.linkage });
+        const sincosq_sym_name = if (common.want_ppc_abi) "sincosf128" else "sincosq";
+        @export(sincosq, .{ .name = sincosq_sym_name, .linkage = common.linkage });
+        @export(sincosl, .{ .name = "sincosl", .linkage = common.linkage });
+    }
 }
 
 pub fn __sincosh(x: f16, r_sin: *f16, r_cos: *f16) callconv(.C) void {

--- a/lib/compiler_rt/sqrt.zig
+++ b/lib/compiler_rt/sqrt.zig
@@ -10,10 +10,12 @@ comptime {
     @export(__sqrth, .{ .name = "__sqrth", .linkage = common.linkage });
     @export(sqrtf, .{ .name = "sqrtf", .linkage = common.linkage });
     @export(sqrt, .{ .name = "sqrt", .linkage = common.linkage });
-    @export(__sqrtx, .{ .name = "__sqrtx", .linkage = common.linkage });
-    const sqrtq_sym_name = if (common.want_ppc_abi) "sqrtf128" else "sqrtq";
-    @export(sqrtq, .{ .name = sqrtq_sym_name, .linkage = common.linkage });
-    @export(sqrtl, .{ .name = "sqrtl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__sqrtx, .{ .name = "__sqrtx", .linkage = common.linkage });
+        const sqrtq_sym_name = if (common.want_ppc_abi) "sqrtf128" else "sqrtq";
+        @export(sqrtq, .{ .name = sqrtq_sym_name, .linkage = common.linkage });
+        @export(sqrtl, .{ .name = "sqrtl", .linkage = common.linkage });
+    }
 }
 
 pub fn __sqrth(x: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/subtf3.zig
+++ b/lib/compiler_rt/subtf3.zig
@@ -3,12 +3,14 @@ const common = @import("./common.zig");
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__subkf3, .{ .name = "__subkf3", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_sub, .{ .name = "_Qp_sub", .linkage = common.linkage });
-    } else {
-        @export(__subtf3, .{ .name = "__subtf3", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__subkf3, .{ .name = "__subkf3", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_sub, .{ .name = "_Qp_sub", .linkage = common.linkage });
+        } else {
+            @export(__subtf3, .{ .name = "__subtf3", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/subxf3.zig
+++ b/lib/compiler_rt/subxf3.zig
@@ -4,7 +4,9 @@ const common = @import("./common.zig");
 pub const panic = common.panic;
 
 comptime {
-    @export(__subxf3, .{ .name = "__subxf3", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__subxf3, .{ .name = "__subxf3", .linkage = common.linkage });
+    }
 }
 
 fn __subxf3(a: f80, b: f80) callconv(.C) f80 {

--- a/lib/compiler_rt/tan.zig
+++ b/lib/compiler_rt/tan.zig
@@ -23,10 +23,12 @@ comptime {
     @export(__tanh, .{ .name = "__tanh", .linkage = common.linkage });
     @export(tanf, .{ .name = "tanf", .linkage = common.linkage });
     @export(tan, .{ .name = "tan", .linkage = common.linkage });
-    @export(__tanx, .{ .name = "__tanx", .linkage = common.linkage });
-    const tanq_sym_name = if (common.want_ppc_abi) "tanf128" else "tanq";
-    @export(tanq, .{ .name = tanq_sym_name, .linkage = common.linkage });
-    @export(tanl, .{ .name = "tanl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__tanx, .{ .name = "__tanx", .linkage = common.linkage });
+        const tanq_sym_name = if (common.want_ppc_abi) "tanf128" else "tanq";
+        @export(tanq, .{ .name = tanq_sym_name, .linkage = common.linkage });
+        @export(tanl, .{ .name = "tanl", .linkage = common.linkage });
+    }
 }
 
 pub fn __tanh(x: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/trunc.zig
+++ b/lib/compiler_rt/trunc.zig
@@ -17,10 +17,12 @@ comptime {
     @export(__trunch, .{ .name = "__trunch", .linkage = common.linkage });
     @export(truncf, .{ .name = "truncf", .linkage = common.linkage });
     @export(trunc, .{ .name = "trunc", .linkage = common.linkage });
-    @export(__truncx, .{ .name = "__truncx", .linkage = common.linkage });
-    const truncq_sym_name = if (common.want_ppc_abi) "truncf128" else "truncq";
-    @export(truncq, .{ .name = truncq_sym_name, .linkage = common.linkage });
-    @export(truncl, .{ .name = "truncl", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__truncx, .{ .name = "__truncx", .linkage = common.linkage });
+        const truncq_sym_name = if (common.want_ppc_abi) "truncf128" else "truncq";
+        @export(truncq, .{ .name = truncq_sym_name, .linkage = common.linkage });
+        @export(truncl, .{ .name = "truncl", .linkage = common.linkage });
+    }
 }
 
 pub fn __trunch(x: f16) callconv(.C) f16 {

--- a/lib/compiler_rt/trunctfdf2.zig
+++ b/lib/compiler_rt/trunctfdf2.zig
@@ -4,12 +4,14 @@ const truncf = @import("./truncf.zig").truncf;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__trunckfdf2, .{ .name = "__trunckfdf2", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_qtod, .{ .name = "_Qp_qtod", .linkage = common.linkage });
-    } else {
-        @export(__trunctfdf2, .{ .name = "__trunctfdf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__trunckfdf2, .{ .name = "__trunckfdf2", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_qtod, .{ .name = "_Qp_qtod", .linkage = common.linkage });
+        } else {
+            @export(__trunctfdf2, .{ .name = "__trunctfdf2", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/trunctfhf2.zig
+++ b/lib/compiler_rt/trunctfhf2.zig
@@ -4,7 +4,9 @@ const truncf = @import("./truncf.zig").truncf;
 pub const panic = common.panic;
 
 comptime {
-    @export(__trunctfhf2, .{ .name = "__trunctfhf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__trunctfhf2, .{ .name = "__trunctfhf2", .linkage = common.linkage });
+    }
 }
 
 pub fn __trunctfhf2(a: f128) callconv(.C) common.F16T {

--- a/lib/compiler_rt/trunctfsf2.zig
+++ b/lib/compiler_rt/trunctfsf2.zig
@@ -4,12 +4,14 @@ const truncf = @import("./truncf.zig").truncf;
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__trunckfsf2, .{ .name = "__trunckfsf2", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        @export(_Qp_qtos, .{ .name = "_Qp_qtos", .linkage = common.linkage });
-    } else {
-        @export(__trunctfsf2, .{ .name = "__trunctfsf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__trunckfsf2, .{ .name = "__trunckfsf2", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            @export(_Qp_qtos, .{ .name = "_Qp_qtos", .linkage = common.linkage });
+        } else {
+            @export(__trunctfsf2, .{ .name = "__trunctfsf2", .linkage = common.linkage });
+        }
     }
 }
 

--- a/lib/compiler_rt/trunctfxf2.zig
+++ b/lib/compiler_rt/trunctfxf2.zig
@@ -5,7 +5,9 @@ const trunc_f80 = @import("./truncf.zig").trunc_f80;
 pub const panic = common.panic;
 
 comptime {
-    @export(__trunctfxf2, .{ .name = "__trunctfxf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__trunctfxf2, .{ .name = "__trunctfxf2", .linkage = common.linkage });
+    }
 }
 
 pub fn __trunctfxf2(a: f128) callconv(.C) f80 {

--- a/lib/compiler_rt/truncxfdf2.zig
+++ b/lib/compiler_rt/truncxfdf2.zig
@@ -4,7 +4,9 @@ const trunc_f80 = @import("./truncf.zig").trunc_f80;
 pub const panic = common.panic;
 
 comptime {
-    @export(__truncxfdf2, .{ .name = "__truncxfdf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__truncxfdf2, .{ .name = "__truncxfdf2", .linkage = common.linkage });
+    }
 }
 
 fn __truncxfdf2(a: f80) callconv(.C) f64 {

--- a/lib/compiler_rt/truncxfhf2.zig
+++ b/lib/compiler_rt/truncxfhf2.zig
@@ -4,7 +4,9 @@ const trunc_f80 = @import("./truncf.zig").trunc_f80;
 pub const panic = common.panic;
 
 comptime {
-    @export(__truncxfhf2, .{ .name = "__truncxfhf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__truncxfhf2, .{ .name = "__truncxfhf2", .linkage = common.linkage });
+    }
 }
 
 fn __truncxfhf2(a: f80) callconv(.C) common.F16T {

--- a/lib/compiler_rt/truncxfsf2.zig
+++ b/lib/compiler_rt/truncxfsf2.zig
@@ -4,7 +4,9 @@ const trunc_f80 = @import("./truncf.zig").trunc_f80;
 pub const panic = common.panic;
 
 comptime {
-    @export(__truncxfsf2, .{ .name = "__truncxfsf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        @export(__truncxfsf2, .{ .name = "__truncxfsf2", .linkage = common.linkage });
+    }
 }
 
 fn __truncxfsf2(a: f80) callconv(.C) f32 {

--- a/lib/compiler_rt/unordtf2.zig
+++ b/lib/compiler_rt/unordtf2.zig
@@ -4,13 +4,15 @@ const comparef = @import("./comparef.zig");
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
-        @export(__unordkf2, .{ .name = "__unordkf2", .linkage = common.linkage });
-    } else if (common.want_sparc_abi) {
-        // These exports are handled in cmptf2.zig because unordered comparisons
-        // are based on calling _Qp_cmp.
-    } else {
-        @export(__unordtf2, .{ .name = "__unordtf2", .linkage = common.linkage });
+    if (common.should_emit_f80_or_f128) {
+        if (common.want_ppc_abi) {
+            @export(__unordkf2, .{ .name = "__unordkf2", .linkage = common.linkage });
+        } else if (common.want_sparc_abi) {
+            // These exports are handled in cmptf2.zig because unordered comparisons
+            // are based on calling _Qp_cmp.
+        } else {
+            @export(__unordtf2, .{ .name = "__unordtf2", .linkage = common.linkage });
+        }
     }
 }
 


### PR DESCRIPTION
Fix for #10847
F80 and F128 code is crashing LLVM when targetting soft float. Compiler RT symbols are then conditionally exported, not exporting them when the backend used is LLVM and the target is not using the FPU for, at the moment, x86_64 and aarch64.