### PR TITLE
stage2 LLVM: Use non-packed struct for unions and arrays

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2689,7 +2689,7 @@ pub const DeclGen = struct {
                         llvm_aligned_field_ty,
                         dg.context.intType(8).arrayType(padding_len),
                     };
-                    break :t dg.context.structType(&fields, fields.len, .True);
+                    break :t dg.context.structType(&fields, fields.len, .False);
                 };
 
                 if (layout.tag_size == 0) {
@@ -3002,7 +3002,7 @@ pub const DeclGen = struct {
                         return dg.context.constStruct(
                             llvm_elems.ptr,
                             @intCast(c_uint, llvm_elems.len),
-                            .True,
+                            .False,
                         );
                     } else {
                         const llvm_elem_ty = try dg.lowerType(elem_ty);
@@ -3039,7 +3039,7 @@ pub const DeclGen = struct {
                         return dg.context.constStruct(
                             llvm_elems.ptr,
                             @intCast(c_uint, llvm_elems.len),
-                            .True,
+                            .False,
                         );
                     } else {
                         const llvm_elem_ty = try dg.lowerType(elem_ty);
@@ -3056,7 +3056,7 @@ pub const DeclGen = struct {
                     const llvm_elems: [1]*const llvm.Value = .{sentinel};
                     const need_unnamed = dg.isUnnamedType(elem_ty, llvm_elems[0]);
                     if (need_unnamed) {
-                        return dg.context.constStruct(&llvm_elems, llvm_elems.len, .True);
+                        return dg.context.constStruct(&llvm_elems, llvm_elems.len, .False);
                     } else {
                         const llvm_elem_ty = try dg.lowerType(elem_ty);
                         return llvm_elem_ty.constArray(&llvm_elems, llvm_elems.len);
@@ -3343,7 +3343,7 @@ pub const DeclGen = struct {
                     const fields: [2]*const llvm.Value = .{
                         field, dg.context.intType(8).arrayType(padding_len).getUndef(),
                     };
-                    break :p dg.context.constStruct(&fields, fields.len, .True);
+                    break :p dg.context.constStruct(&fields, fields.len, .False);
                 };
 
                 if (layout.tag_size == 0) {


### PR DESCRIPTION
Resolves #12086

Consider this lowered union type:
```llvm
%Value = type { <{ i64, [8 x i8] }>, i1, [7 x i8] } ; 24 bytes, align(1)
%ErrorUnion = type { %Value, i16 } ; 26 bytes, align(2)
```

Stage 2 incorrectly assumes that LLVM's `sizeof(%Value)` is 32 bytes, but it's actually 26 because the alignment of Value was "deleted" by the use of a packed struct. Stage 2 can then end up generating a 32-byte `memcpy` that exceeds the bounds of the corresponding `alloca`.

AFAICT, there are two ways to go about fixing this:
   1. Make sure our LLVM type lowering never depends on the LLVM type being correctly aligned, OR
   2. Make sure that we keep the alignment of LLVM types in sync with the Zig types they represent

This PR takes approach (2), mostly for simplicity. AFAICT, we don't need a packed struct to achieve the desired layout, since an appended `[N]u8` always acts as contiguous padding. So this simply changes the type to use a non-packed struct.

Along the way, I noticed that arrays were also using packed structs. I could be wrong here, but this seems incorrect since array elements should be self-aligned.