### PR TITLE
stage2: lower each struct field type, align, init separately

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -916,13 +916,14 @@ pub const Struct = struct {
     /// one possible value.
     known_non_opv: bool,
     requires_comptime: PropertyBoolean = .unknown,
+    have_field_inits: bool = false,
 
     pub const Fields = std.StringArrayHashMapUnmanaged(Field);
 
     /// The `Type` and `Value` memory is owned by the arena of the Struct's owner_decl.
     pub const Field = struct {
         /// Uses `noreturn` to indicate `anytype`.
-        /// undefined until `status` is `have_field_types` or `have_layout`.
+        /// undefined until `status` is >= `have_field_types`.
         ty: Type,
         /// Uses `unreachable_value` to indicate no default.
         default_val: Value,

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1358,3 +1358,17 @@ test "store to comptime field" {
         s.a.a = 1;
     }
 }
+
+test "struct field init value is size of the struct" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+
+    const namespace = struct {
+        const S = extern struct {
+            size: u8 = @sizeOf(S),
+            blah: u16,
+        };
+    };
+    var s: namespace.S = .{ .blah = 1234 };
+    try expect(s.size == 4);
+}


### PR DESCRIPTION
Previously, struct types, alignment values, and initialization
expressions were all lowered into the same ZIR body, which caused false
positive "depends on itself" errors when the initialization expression
depended on the size of the struct.

This also uses ResultLoc.coerced_ty for struct field alignment and
initialization values. The resulting ZIR encoding ends up being roughly
the same, neither smaller nor larger than previously.

Closes #12029

cc @kristoff-it - this affects ZIR encoding for autodocs