### PR TITLE
LLVM: implement signext/zeroext attributes

### DIFF
--- a/lib/compiler_rt/common.zig
+++ b/lib/compiler_rt/common.zig
@@ -68,7 +68,11 @@ pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace) nore
 /// need for extending them to wider fp types.
 /// TODO remove this; do this type selection in the language rather than
 /// here in compiler-rt.
-pub const F16T = if (builtin.cpu.arch.isAARCH64()) f16 else u16;
+pub const F16T = switch (builtin.cpu.arch) {
+    .aarch64, .aarch64_be, .aarch64_32 => f16,
+    .riscv64 => if (builtin.zig_backend == .stage1) u16 else f16,
+    else => u16,
+};
 
 pub fn wideMultiply(comptime Z: type, a: Z, b: Z, hi: *Z, lo: *Z) void {
     switch (Z) {

--- a/lib/std/math/float.zig
+++ b/lib/std/math/float.zig
@@ -3,19 +3,19 @@ const assert = std.debug.assert;
 const expect = std.testing.expect;
 
 /// Creates a raw "1.0" mantissa for floating point type T. Used to dedupe f80 logic.
-fn mantissaOne(comptime T: type) comptime_int {
+inline fn mantissaOne(comptime T: type) comptime_int {
     return if (@typeInfo(T).Float.bits == 80) 1 << floatFractionalBits(T) else 0;
 }
 
 /// Creates floating point type T from an unbiased exponent and raw mantissa.
-fn reconstructFloat(comptime T: type, exponent: comptime_int, mantissa: comptime_int) T {
+inline fn reconstructFloat(comptime T: type, exponent: comptime_int, mantissa: comptime_int) T {
     const TBits = std.meta.Int(.unsigned, @bitSizeOf(T));
     const biased_exponent = @as(TBits, exponent + floatExponentMax(T));
     return @bitCast(T, (biased_exponent << floatMantissaBits(T)) | @as(TBits, mantissa));
 }
 
 /// Returns the number of bits in the exponent of floating point type T.
-pub fn floatExponentBits(comptime T: type) comptime_int {
+pub inline fn floatExponentBits(comptime T: type) comptime_int {
     assert(@typeInfo(T) == .Float);
 
     return switch (@typeInfo(T).Float.bits) {
@@ -29,7 +29,7 @@ pub fn floatExponentBits(comptime T: type) comptime_int {
 }
 
 /// Returns the number of bits in the mantissa of floating point type T.
-pub fn floatMantissaBits(comptime T: type) comptime_int {
+pub inline fn floatMantissaBits(comptime T: type) comptime_int {
     assert(@typeInfo(T) == .Float);
 
     return switch (@typeInfo(T).Float.bits) {
@@ -43,7 +43,7 @@ pub fn floatMantissaBits(comptime T: type) comptime_int {
 }
 
 /// Returns the number of fractional bits in the mantissa of floating point type T.
-pub fn floatFractionalBits(comptime T: type) comptime_int {
+pub inline fn floatFractionalBits(comptime T: type) comptime_int {
     assert(@typeInfo(T) == .Float);
 
     // standard IEEE floats have an implicit 0.m or 1.m integer part
@@ -61,39 +61,39 @@ pub fn floatFractionalBits(comptime T: type) comptime_int {
 
 /// Returns the minimum exponent that can represent
 /// a normalised value in floating point type T.
-pub fn floatExponentMin(comptime T: type) comptime_int {
+pub inline fn floatExponentMin(comptime T: type) comptime_int {
     return -floatExponentMax(T) + 1;
 }
 
 /// Returns the maximum exponent that can represent
 /// a normalised value in floating point type T.
-pub fn floatExponentMax(comptime T: type) comptime_int {
+pub inline fn floatExponentMax(comptime T: type) comptime_int {
     return (1 << (floatExponentBits(T) - 1)) - 1;
 }
 
 /// Returns the smallest subnormal number representable in floating point type T.
-pub fn floatTrueMin(comptime T: type) T {
+pub inline fn floatTrueMin(comptime T: type) T {
     return reconstructFloat(T, floatExponentMin(T) - 1, 1);
 }
 
 /// Returns the smallest normal number representable in floating point type T.
-pub fn floatMin(comptime T: type) T {
+pub inline fn floatMin(comptime T: type) T {
     return reconstructFloat(T, floatExponentMin(T), mantissaOne(T));
 }
 
 /// Returns the largest normal number representable in floating point type T.
-pub fn floatMax(comptime T: type) T {
+pub inline fn floatMax(comptime T: type) T {
     const all1s_mantissa = (1 << floatMantissaBits(T)) - 1;
     return reconstructFloat(T, floatExponentMax(T), all1s_mantissa);
 }
 
 /// Returns the machine epsilon of floating point type T.
-pub fn floatEps(comptime T: type) T {
+pub inline fn floatEps(comptime T: type) T {
     return reconstructFloat(T, -floatFractionalBits(T), mantissaOne(T));
 }
 
 /// Returns the value inf for floating point type T.
-pub fn inf(comptime T: type) T {
+pub inline fn inf(comptime T: type) T {
     return reconstructFloat(T, floatExponentMax(T) + 1, mantissaOne(T));
 }
 

--- a/lib/std/math/float.zig
+++ b/lib/std/math/float.zig
@@ -9,14 +9,14 @@ inline fn mantissaOne(comptime T: type) comptime_int {
 
 /// Creates floating point type T from an unbiased exponent and raw mantissa.
 inline fn reconstructFloat(comptime T: type, exponent: comptime_int, mantissa: comptime_int) T {
-    const TBits = std.meta.Int(.unsigned, @bitSizeOf(T));
+    const TBits = @Type(.{ .Int = .{ .signedness = .unsigned, .bits = @bitSizeOf(T) } });
     const biased_exponent = @as(TBits, exponent + floatExponentMax(T));
     return @bitCast(T, (biased_exponent << floatMantissaBits(T)) | @as(TBits, mantissa));
 }
 
 /// Returns the number of bits in the exponent of floating point type T.
 pub inline fn floatExponentBits(comptime T: type) comptime_int {
-    assert(@typeInfo(T) == .Float);
+    comptime assert(@typeInfo(T) == .Float);
 
     return switch (@typeInfo(T).Float.bits) {
         16 => 5,
@@ -30,7 +30,7 @@ pub inline fn floatExponentBits(comptime T: type) comptime_int {
 
 /// Returns the number of bits in the mantissa of floating point type T.
 pub inline fn floatMantissaBits(comptime T: type) comptime_int {
-    assert(@typeInfo(T) == .Float);
+    comptime assert(@typeInfo(T) == .Float);
 
     return switch (@typeInfo(T).Float.bits) {
         16 => 10,
@@ -44,7 +44,7 @@ pub inline fn floatMantissaBits(comptime T: type) comptime_int {
 
 /// Returns the number of fractional bits in the mantissa of floating point type T.
 pub inline fn floatFractionalBits(comptime T: type) comptime_int {
-    assert(@typeInfo(T) == .Float);
+    comptime assert(@typeInfo(T) == .Float);
 
     // standard IEEE floats have an implicit 0.m or 1.m integer part
     // f80 is special and has an explicitly stored bit in the MSB
@@ -97,7 +97,7 @@ pub inline fn inf(comptime T: type) T {
     return reconstructFloat(T, floatExponentMax(T) + 1, mantissaOne(T));
 }
 
-test "std.math.float" {
+test "float bits" {
     inline for ([_]type{ f16, f32, f64, f80, f128, c_longdouble }) |T| {
         // (1 +) for the sign bit, since it is separate from the other bits
         const size = 1 + floatExponentBits(T) + floatMantissaBits(T);

--- a/lib/std/math/isinf.zig
+++ b/lib/std/math/isinf.zig
@@ -3,7 +3,7 @@ const math = std.math;
 const expect = std.testing.expect;
 
 /// Returns whether x is an infinity, ignoring sign.
-pub fn isInf(x: anytype) bool {
+pub inline fn isInf(x: anytype) bool {
     const T = @TypeOf(x);
     const TBits = std.meta.Int(.unsigned, @typeInfo(T).Float.bits);
     const remove_sign = ~@as(TBits, 0) >> 1;
@@ -11,12 +11,12 @@ pub fn isInf(x: anytype) bool {
 }
 
 /// Returns whether x is an infinity with a positive sign.
-pub fn isPositiveInf(x: anytype) bool {
+pub inline fn isPositiveInf(x: anytype) bool {
     return x == math.inf(@TypeOf(x));
 }
 
 /// Returns whether x is an infinity with a negative sign.
-pub fn isNegativeInf(x: anytype) bool {
+pub inline fn isNegativeInf(x: anytype) bool {
     return x == -math.inf(@TypeOf(x));
 }
 

--- a/src/type.zig
+++ b/src/type.zig
@@ -4439,6 +4439,16 @@ pub const Type = extern union {
         };
     }
 
+    /// Returns true for integers, enums, error sets, and packed structs.
+    /// If this function returns true, then intInfo() can be called on the type.
+    pub fn isAbiInt(ty: Type) bool {
+        return switch (ty.zigTypeTag()) {
+            .Int, .Enum, .ErrorSet => true,
+            .Struct => ty.containerLayout() == .Packed,
+            else => false,
+        };
+    }
+
     /// Asserts the type is an integer, enum, error set, or vector of one of them.
     pub fn intInfo(self: Type, target: Target) struct { signedness: std.builtin.Signedness, bits: u16 } {
         var ty = self;

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -1168,11 +1168,6 @@ test "remainder division" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .riscv64) {
-        // https://github.com/ziglang/zig/issues/12054
-        return error.SkipZigTest;
-    }
-
     comptime try remdiv(f16);
     comptime try remdiv(f32);
     comptime try remdiv(f64);
@@ -1203,11 +1198,6 @@ test "float remainder division using @rem" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .riscv64) {
-        // https://github.com/ziglang/zig/issues/12054
-        return error.SkipZigTest;
-    }
 
     comptime try frem(f16);
     comptime try frem(f32);
@@ -1250,11 +1240,6 @@ test "float modulo division using @mod" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .riscv64) {
-        // https://github.com/ziglang/zig/issues/12054
-        return error.SkipZigTest;
-    }
 
     comptime try fmod(f16);
     comptime try fmod(f32);
@@ -1431,11 +1416,6 @@ test "@ceil f80" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
 
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .riscv64) {
-        // https://github.com/ziglang/zig/issues/12054
-        return error.SkipZigTest;
-    }
-
     try testCeil(f80, 12.0);
     comptime try testCeil(f80, 12.0);
 }
@@ -1446,11 +1426,6 @@ test "@ceil f128" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .riscv64) {
-        // https://github.com/ziglang/zig/issues/12054
-        return error.SkipZigTest;
-    }
 
     try testCeil(f128, 12.0);
     comptime try testCeil(f128, 12.0);
@@ -1599,11 +1574,6 @@ test "NaN comparison" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .riscv64) {
-        // https://github.com/ziglang/zig/issues/12054
-        return error.SkipZigTest;
-    }
 
     try testNanEqNan(f16);
     try testNanEqNan(f32);


### PR DESCRIPTION
For calling convention ABI purposes, integer attributes and return
values need to have an LLVM attribute signext or zeroext added
sometimes. This commit implements that logic.

It also implements a proof-of-concept of moving the F16T type from
being a compiler_rt hack to being how the compiler lowers f16 in
functions that need to match certain calling conventions.

Closes #12054