### PR TITLE
std.testing: add `refAllDeclsRecursive` function

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -689,3 +689,19 @@ pub fn refAllDecls(comptime T: type) void {
         if (decl.is_pub) _ = @field(T, decl.name);
     }
 }
+
+/// Given a type, and Recursively reference all the declarations inside, so that the semantic analyzer sees them.
+/// For deep types, you may use `@setEvalBranchQuota`
+pub fn refAllDeclsRecursive(comptime T: type) void {
+    inline for (comptime std.meta.declarations(T)) |decl| {
+        if (decl.is_pub) {
+            if (@TypeOf(@field(T, decl.name)) == type) {
+                switch (@typeInfo(@field(T, decl.name))) {
+                    .Struct, .Enum, .Union, .Opaque => refAllDeclsRecursive(@field(T, decl.name)),
+                    else => {},
+                }
+            }
+            _ = @field(T, decl.name);
+        }
+    }
+}


### PR DESCRIPTION
### difference with `refAllDecls`
```zig
const Struct = struct {
    pub const test_constant = @compileLog("referenced - 0");

    pub const InternalStruct = struct {
        pub const internal_constant = @compileLog("referenced - 1");
    };
};
```
**`refAllDecls()`:**
```zig
test "normal" {
    std.testing.refAllDecls(Struct);
}
```
```sh
| *"referenced - 0"
```


**`refAllDeclsRecursive()`:**
```zig
test "recursive" {
    std.testing.refAllDeclsRecursive(Struct);
}
```
```sh
| *"referenced - 0"
| *"referenced - 1"
```

we used the same approach in **Mach ([1](https://github.com/hexops/mach-freetype/blob/9b8b9796d9a22f2a05e701da0cbcdcf4ae8fcccb/src/utils.zig#L23-L36), [2](https://github.com/hexops/mach/blob/f8f4dcf55fc0b7365abfa66304e1f781b5f4eb42/sysaudio/soundio/main.zig#L16-L29))**
which were very helpful and found many errors