### PR TITLE
CMake: Use `NAMES_PER_DIR` in all lookups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(ZIG_VERSION "" CACHE STRING "Override Zig version string. Default is to find
 
 if("${ZIG_VERSION}" STREQUAL "")
     set(ZIG_VERSION "${ZIG_VERSION_MAJOR}.${ZIG_VERSION_MINOR}.${ZIG_VERSION_PATCH}")
-    find_program(GIT_EXE NAMES git)
+    find_program(GIT_EXE NAMES git NAMES_PER_DIR)
     if(GIT_EXE)
         execute_process(
             COMMAND ${GIT_EXE} -C ${CMAKE_SOURCE_DIR} describe --match *.*.* --tags
@@ -110,13 +110,13 @@ find_package(lld 14)
 
 if(ZIG_STATIC_ZLIB)
     list(REMOVE_ITEM LLVM_LIBRARIES "-lz")
-    find_library(ZLIB NAMES libz.a libzlibstatic.a z zlib libz)
+    find_library(ZLIB NAMES libz.a libzlibstatic.a z zlib libz NAMES_PER_DIR)
     list(APPEND LLVM_LIBRARIES "${ZLIB}")
 endif()
 
 if(APPLE AND ZIG_STATIC)
     list(REMOVE_ITEM LLVM_LIBRARIES "-lcurses")
-    find_library(CURSES NAMES libcurses.a libncurses.a
+    find_library(CURSES NAMES libcurses.a libncurses.a NAMES_PER_DIR
       PATHS
         /usr/local/opt/ncurses/lib
         /opt/homebrew/opt/ncurses/lib)

--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -25,6 +25,7 @@ if(ZIG_PREFER_CLANG_CPP_DYLIB)
       clang-cpp-14.0
       clang-cpp140
       clang-cpp
+    NAMES_PER_DIR
     PATHS
       ${CLANG_LIBDIRS}
       /usr/lib/llvm/14/lib
@@ -40,7 +41,7 @@ endif()
 if(NOT CLANG_LIBRARIES)
   macro(FIND_AND_ADD_CLANG_LIB _libname_)
     string(TOUPPER ${_libname_} _prettylibname_)
-    find_library(CLANG_${_prettylibname_}_LIB NAMES ${_libname_}
+    find_library(CLANG_${_prettylibname_}_LIB NAMES ${_libname_} NAMES_PER_DIR
       PATHS
         ${CLANG_LIBDIRS}
         /usr/lib/llvm/14/lib

--- a/cmake/Findlld.cmake
+++ b/cmake/Findlld.cmake
@@ -15,7 +15,7 @@ find_path(LLD_INCLUDE_DIRS NAMES lld/Common/Driver.h
         /opt/homebrew/opt/llvm@14/include
         /mingw64/include)
 
-find_library(LLD_LIBRARY NAMES lld-14.0 lld140 lld
+find_library(LLD_LIBRARY NAMES lld-14.0 lld140 lld NAMES_PER_DIR
     PATHS
         /usr/lib/llvm-14/lib
         /usr/local/llvm140/lib
@@ -28,7 +28,7 @@ if(EXISTS ${LLD_LIBRARY})
 else()
     macro(FIND_AND_ADD_LLD_LIB _libname_)
         string(TOUPPER ${_libname_} _prettylibname_)
-        find_library(LLD_${_prettylibname_}_LIB NAMES ${_libname_}
+        find_library(LLD_${_prettylibname_}_LIB NAMES ${_libname_} NAMES_PER_DIR
             PATHS
                 ${LLD_LIBDIRS}
                 /usr/lib/llvm-14/lib

--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -27,6 +27,7 @@ if(ZIG_PREFER_CLANG_CPP_DYLIB)
       LLVM-14
       LLVM-140
       LLVM
+    NAMES_PER_DIR
     PATHS
       ${LLVM_LIBDIRS}
       /usr/lib/llvm/14/lib
@@ -40,7 +41,7 @@ if(ZIG_PREFER_CLANG_CPP_DYLIB)
   )
 
   find_program(LLVM_CONFIG_EXE
-      NAMES llvm-config-14 llvm-config-14.0 llvm-config140 llvm-config14 llvm-config
+      NAMES llvm-config-14 llvm-config-14.0 llvm-config140 llvm-config14 llvm-config NAMES_PER_DIR
       PATHS
           "/mingw64/bin"
           "/c/msys64/mingw64/bin"
@@ -71,7 +72,7 @@ if(ZIG_PREFER_CLANG_CPP_DYLIB)
   endif()
 elseif(ZIG_USE_LLVM_CONFIG)
   find_program(LLVM_CONFIG_EXE
-      NAMES llvm-config-14 llvm-config-14.0 llvm-config140 llvm-config14 llvm-config
+      NAMES llvm-config-14 llvm-config-14.0 llvm-config140 llvm-config14 llvm-config NAMES_PER_DIR
       PATHS
           "/mingw64/bin"
           "/c/msys64/mingw64/bin"
@@ -173,7 +174,7 @@ elseif(ZIG_USE_LLVM_CONFIG)
   set(LLVM_LIBRARIES ${LLVM_LIBRARIES} ${LLVM_SYSTEM_LIBS})
 
   if(NOT LLVM_LIBRARIES)
-    find_library(LLVM_LIBRARIES NAMES LLVM LLVM-14 LLVM-14.0)
+    find_library(LLVM_LIBRARIES NAMES LLVM LLVM-14 LLVM-14.0 NAMES_PER_DIR)
   endif()
 
   link_directories("${CMAKE_PREFIX_PATH}/lib")
@@ -184,7 +185,7 @@ else()
 
   macro(FIND_AND_ADD_LLVM_LIB _libname_)
     string(TOUPPER ${_libname_} _prettylibname_)
-    find_library(LLVM_${_prettylibname_}_LIB NAMES ${_libname_} PATHS ${LLVM_LIBDIRS})
+    find_library(LLVM_${_prettylibname_}_LIB NAMES ${_libname_} NAMES_PER_DIR PATHS ${LLVM_LIBDIRS})
     set(LLVM_LIBRARIES ${LLVM_LIBRARIES} ${LLVM_${_prettylibname_}_LIB})
   endmacro(FIND_AND_ADD_LLVM_LIB)
 


### PR DESCRIPTION
CMake has a surprising default behavior where looking up a library by multiple names gives the name order higher priority than the directory search order. This change add `NAMES_PER_DIR` to request the more sensible behavior: directory search order has higher priority than name order.

Previously, system-provided "llvm-config-14" would always be chosen over "llvm-config" in CMAKE_PREFIX_PATH.

Now, any matching name found in CMAKE_PREFIX_PATH wins over system-provided tools/libraries.