### PR TITLE
CI: increase stage3 test coverage

### DIFF
--- a/lib/std/hash/auto_hash.zig
+++ b/lib/std/hash/auto_hash.zig
@@ -375,6 +375,12 @@ test "testHash struct" {
 }
 
 test "testHash union" {
+    const builtin = @import("builtin");
+    if (builtin.zig_backend == .stage2_llvm and builtin.mode == .ReleaseSafe) {
+        // https://github.com/ziglang/zig/issues/12178
+        return error.SkipZigTest;
+    }
+
     const Foo = union(enum) {
         A: u32,
         B: bool,

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -38,7 +38,7 @@ pub fn main() !void {
         testMissingOutputPath,
         testZigFmt,
     };
-    for (test_fns) |testFn| {
+    inline for (test_fns) |testFn| {
         try fs.cwd().deleteTree(dir_path);
         try fs.cwd().makeDir(dir_path);
         try testFn(zig_exe, dir_path);

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -494,8 +494,10 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\
         \\pub fn main() !void {
         \\    var allocator_buf: [10]u8 = undefined;
-        \\    var fixedBufferAllocator = std.mem.validationWrap(std.heap.FixedBufferAllocator.init(&allocator_buf));
-        \\    const allocator = std.heap.loggingAllocator(fixedBufferAllocator.allocator()).allocator();
+        \\    var fba = std.heap.FixedBufferAllocator.init(&allocator_buf);
+        \\    var fba_wrapped = std.mem.validationWrap(fba);
+        \\    var logging_allocator = std.heap.loggingAllocator(fba_wrapped.allocator());
+        \\    const allocator = logging_allocator.allocator();
         \\
         \\    var a = try allocator.alloc(u8, 10);
         \\    a = allocator.shrink(a, 5);


### PR DESCRIPTION
 * Use a debug build of stage3 instead of a debug build of stage2 for
   our self-hosted compiler test coverage.
 * Move coverage from stage1 to stage3 for:
   - building self-hosted without LLVM
   - building self-hosted for 32-bit arm
   - test-compiler-rt
   - test-behavior
   - test-std
     - caveat: release mode is skipped because I observed a problem
       locally.
   - test-compare-output
   - test-asm-link
   - test-fmt