### PR TITLE
Stage2 point to error location using spans

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -338,7 +338,7 @@ pub const AllErrors = struct {
             src_path: []const u8,
             line: u32,
             column: u32,
-            byte_offset: u32,
+            span: Module.SrcLoc.Span,
             /// Usually one, but incremented for redundant messages.
             count: u32 = 1,
             /// Does not include the trailing newline.
@@ -429,7 +429,10 @@ pub const AllErrors = struct {
                             try stderr.writeByte('\n');
                             try stderr.writeByteNTimes(' ', src.column);
                             ttyconf.setColor(stderr, .Green);
-                            try stderr.writeAll("^\n");
+                            try stderr.writeByte('^');
+                            // TODO basic unicode code point monospace width
+                            try stderr.writeByteNTimes('~', src.span.end - src.span.start - 1);
+                            try stderr.writeByte('\n');
                             ttyconf.setColor(stderr, .Reset);
                         }
                     }
@@ -469,7 +472,8 @@ pub const AllErrors = struct {
                         hasher.update(src.src_path);
                         std.hash.autoHash(&hasher, src.line);
                         std.hash.autoHash(&hasher, src.column);
-                        std.hash.autoHash(&hasher, src.byte_offset);
+                        std.hash.autoHash(&hasher, src.span.start);
+                        std.hash.autoHash(&hasher, src.span.end);
                     },
                     .plain => |plain| {
                         hasher.update(plain.msg);
@@ -488,7 +492,8 @@ pub const AllErrors = struct {
                                 mem.eql(u8, a_src.src_path, b_src.src_path) and
                                 a_src.line == b_src.line and
                                 a_src.column == b_src.column and
-                                a_src.byte_offset == b_src.byte_offset;
+                                a_src.span.start == b_src.span.start and
+                                a_src.span.end == b_src.span.end;
                         },
                         .plain => return false,
                     },
@@ -527,20 +532,20 @@ pub const AllErrors = struct {
             std.hash_map.default_max_load_percentage,
         ).init(allocator);
         const err_source = try module_err_msg.src_loc.file_scope.getSource(module.gpa);
-        const err_byte_offset = try module_err_msg.src_loc.byteOffset(module.gpa);
-        const err_loc = std.zig.findLineColumn(err_source.bytes, err_byte_offset);
+        const err_span = try module_err_msg.src_loc.span(module.gpa);
+        const err_loc = std.zig.findLineColumn(err_source.bytes, err_span.start);
 
         for (module_err_msg.notes) |module_note| {
             const source = try module_note.src_loc.file_scope.getSource(module.gpa);
-            const byte_offset = try module_note.src_loc.byteOffset(module.gpa);
-            const loc = std.zig.findLineColumn(source.bytes, byte_offset);
+            const span = try module_note.src_loc.span(module.gpa);
+            const loc = std.zig.findLineColumn(source.bytes, span.start);
             const file_path = try module_note.src_loc.file_scope.fullPath(allocator);
             const note = &notes_buf[note_i];
             note.* = .{
                 .src = .{
                     .src_path = file_path,
                     .msg = try allocator.dupe(u8, module_note.msg),
-                    .byte_offset = byte_offset,
+                    .span = span,
                     .line = @intCast(u32, loc.line),
                     .column = @intCast(u32, loc.column),
                     .source_line = if (err_loc.eql(loc)) null else try allocator.dupe(u8, loc.source_line),
@@ -566,7 +571,7 @@ pub const AllErrors = struct {
             .src = .{
                 .src_path = file_path,
                 .msg = try allocator.dupe(u8, module_err_msg.msg),
-                .byte_offset = err_byte_offset,
+                .span = err_span,
                 .line = @intCast(u32, err_loc.line),
                 .column = @intCast(u32, err_loc.column),
                 .notes = notes_buf[0..note_i],
@@ -593,16 +598,15 @@ pub const AllErrors = struct {
         while (item_i < items_len) : (item_i += 1) {
             const item = file.zir.extraData(Zir.Inst.CompileErrors.Item, extra_index);
             extra_index = item.end;
-            const err_byte_offset = blk: {
-                const token_starts = file.tree.tokens.items(.start);
+            const err_span = blk: {
                 if (item.data.node != 0) {
-                    const main_tokens = file.tree.nodes.items(.main_token);
-                    const main_token = main_tokens[item.data.node];
-                    break :blk token_starts[main_token];
+                    break :blk Module.SrcLoc.nodeToSpan(&file.tree, item.data.node);
                 }
-                break :blk token_starts[item.data.token] + item.data.byte_offset;
+                const token_starts = file.tree.tokens.items(.start);
+                const start = token_starts[item.data.token] + item.data.byte_offset;
+                break :blk Module.SrcLoc.Span{ .start = start, .end = start + 1 };
             };
-            const err_loc = std.zig.findLineColumn(file.source, err_byte_offset);
+            const err_loc = std.zig.findLineColumn(file.source, err_span.start);
 
             var notes: []Message = &[0]Message{};
             if (item.data.notes != 0) {
@@ -612,22 +616,21 @@ pub const AllErrors = struct {
                 for (notes) |*note, i| {
                     const note_item = file.zir.extraData(Zir.Inst.CompileErrors.Item, body[i]);
                     const msg = file.zir.nullTerminatedString(note_item.data.msg);
-                    const byte_offset = blk: {
-                        const token_starts = file.tree.tokens.items(.start);
+                    const span = blk: {
                         if (note_item.data.node != 0) {
-                            const main_tokens = file.tree.nodes.items(.main_token);
-                            const main_token = main_tokens[note_item.data.node];
-                            break :blk token_starts[main_token];
+                            break :blk Module.SrcLoc.nodeToSpan(&file.tree, note_item.data.node);
                         }
-                        break :blk token_starts[note_item.data.token] + note_item.data.byte_offset;
+                        const token_starts = file.tree.tokens.items(.start);
+                        const start = token_starts[note_item.data.token] + note_item.data.byte_offset;
+                        break :blk Module.SrcLoc.Span{ .start = start, .end = start + 1 };
                     };
-                    const loc = std.zig.findLineColumn(file.source, byte_offset);
+                    const loc = std.zig.findLineColumn(file.source, span.start);
 
                     note.* = .{
                         .src = .{
                             .src_path = try file.fullPath(arena),
                             .msg = try arena.dupe(u8, msg),
-                            .byte_offset = byte_offset,
+                            .span = span,
                             .line = @intCast(u32, loc.line),
                             .column = @intCast(u32, loc.column),
                             .notes = &.{}, // TODO rework this function to be recursive
@@ -642,7 +645,7 @@ pub const AllErrors = struct {
                 .src = .{
                     .src_path = try file.fullPath(arena),
                     .msg = try arena.dupe(u8, msg),
-                    .byte_offset = err_byte_offset,
+                    .span = err_span,
                     .line = @intCast(u32, err_loc.line),
                     .column = @intCast(u32, err_loc.column),
                     .notes = notes,
@@ -688,7 +691,7 @@ pub const AllErrors = struct {
                     .src_path = try arena.dupe(u8, src.src_path),
                     .line = src.line,
                     .column = src.column,
-                    .byte_offset = src.byte_offset,
+                    .span = src.span,
                     .source_line = if (src.source_line) |s| try arena.dupe(u8, s) else null,
                     .notes = try dupeList(src.notes, arena),
                 } },
@@ -2662,7 +2665,7 @@ pub fn getAllErrorsAlloc(self: *Compilation) !AllErrors {
                     .msg = try std.fmt.allocPrint(arena_allocator, "unable to build C object: {s}", .{
                         err_msg.msg,
                     }),
-                    .byte_offset = 0,
+                    .span = .{ .start = 0, .end = 1 },
                     .line = err_msg.line,
                     .column = err_msg.column,
                     .source_line = null, // TODO

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3403,7 +3403,7 @@ fn validateUnionInit(
 
             for (instrs[1..]) |inst| {
                 const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
-                const inst_src: LazySrcLoc = .{ .node_offset_back2tok = inst_data.src_node };
+                const inst_src: LazySrcLoc = .{ .node_offset_initializer = inst_data.src_node };
                 try sema.errNote(block, inst_src, msg, "additional initializer here", .{});
             }
             try sema.addDeclaredHereNote(msg, union_ty);
@@ -3421,7 +3421,7 @@ fn validateUnionInit(
 
     const field_ptr = instrs[0];
     const field_ptr_data = sema.code.instructions.items(.data)[field_ptr].pl_node;
-    const field_src: LazySrcLoc = .{ .node_offset_back2tok = field_ptr_data.src_node };
+    const field_src: LazySrcLoc = .{ .node_offset_initializer = field_ptr_data.src_node };
     const field_ptr_extra = sema.code.extraData(Zir.Inst.Field, field_ptr_data.payload_index).data;
     const field_name = sema.code.nullTerminatedString(field_ptr_extra.field_name_start);
     const field_index = try sema.unionFieldIndex(block, union_ty, field_name, field_src);
@@ -3523,7 +3523,7 @@ fn validateStructInit(
 
     for (instrs) |field_ptr| {
         const field_ptr_data = sema.code.instructions.items(.data)[field_ptr].pl_node;
-        const field_src: LazySrcLoc = .{ .node_offset_back2tok = field_ptr_data.src_node };
+        const field_src: LazySrcLoc = .{ .node_offset_initializer = field_ptr_data.src_node };
         const field_ptr_extra = sema.code.extraData(Zir.Inst.Field, field_ptr_data.payload_index).data;
         struct_ptr_zir_ref = field_ptr_extra.lhs;
         const field_name = sema.code.nullTerminatedString(field_ptr_extra.field_name_start);
@@ -3531,7 +3531,7 @@ fn validateStructInit(
         if (found_fields[field_index] != 0) {
             const other_field_ptr = found_fields[field_index];
             const other_field_ptr_data = sema.code.instructions.items(.data)[other_field_ptr].pl_node;
-            const other_field_src: LazySrcLoc = .{ .node_offset_back2tok = other_field_ptr_data.src_node };
+            const other_field_src: LazySrcLoc = .{ .node_offset_initializer = other_field_ptr_data.src_node };
             const msg = msg: {
                 const msg = try sema.errMsg(block, field_src, "duplicate field", .{});
                 errdefer msg.destroy(gpa);
@@ -3606,7 +3606,7 @@ fn validateStructInit(
     field: for (found_fields) |field_ptr, i| {
         if (field_ptr != 0) {
             const field_ptr_data = sema.code.instructions.items(.data)[field_ptr].pl_node;
-            const field_src: LazySrcLoc = .{ .node_offset_back2tok = field_ptr_data.src_node };
+            const field_src: LazySrcLoc = .{ .node_offset_initializer = field_ptr_data.src_node };
 
             // Determine whether the value stored to this pointer is comptime-known.
             const field_ty = struct_ty.structFieldType(i);
@@ -13999,14 +13999,14 @@ fn zirStructInit(
             extra_index = item.end;
 
             const field_type_data = zir_datas[item.data.field_type].pl_node;
-            const field_src: LazySrcLoc = .{ .node_offset_back2tok = field_type_data.src_node };
+            const field_src: LazySrcLoc = .{ .node_offset_initializer = field_type_data.src_node };
             const field_type_extra = sema.code.extraData(Zir.Inst.FieldType, field_type_data.payload_index).data;
             const field_name = sema.code.nullTerminatedString(field_type_extra.name_start);
             const field_index = try sema.structFieldIndex(block, resolved_ty, field_name, field_src);
             if (field_inits[field_index] != .none) {
                 const other_field_type = found_fields[field_index];
                 const other_field_type_data = zir_datas[other_field_type].pl_node;
-                const other_field_src: LazySrcLoc = .{ .node_offset_back2tok = other_field_type_data.src_node };
+                const other_field_src: LazySrcLoc = .{ .node_offset_initializer = other_field_type_data.src_node };
                 const msg = msg: {
                     const msg = try sema.errMsg(block, field_src, "duplicate field", .{});
                     errdefer msg.destroy(gpa);
@@ -14028,7 +14028,7 @@ fn zirStructInit(
         const item = sema.code.extraData(Zir.Inst.StructInit.Item, extra.end);
 
         const field_type_data = zir_datas[item.data.field_type].pl_node;
-        const field_src: LazySrcLoc = .{ .node_offset_back2tok = field_type_data.src_node };
+        const field_src: LazySrcLoc = .{ .node_offset_initializer = field_type_data.src_node };
         const field_type_extra = sema.code.extraData(Zir.Inst.FieldType, field_type_data.payload_index).data;
         const field_name = sema.code.nullTerminatedString(field_type_extra.name_start);
         const field_index = try sema.unionFieldIndex(block, resolved_ty, field_name, field_src);

--- a/src/main.zig
+++ b/src/main.zig
@@ -4381,7 +4381,7 @@ fn printErrsMsgToStdErr(
                     .msg = try std.fmt.allocPrint(arena, "invalid byte: '{'}'", .{
                         std.zig.fmtEscapes(tree.source[byte_offset..][0..1]),
                     }),
-                    .byte_offset = byte_offset,
+                    .span = .{ .start = byte_offset, .end = byte_offset + 1 },
                     .line = @intCast(u32, start_loc.line),
                     .column = @intCast(u32, start_loc.column) + bad_off,
                     .source_line = source_line,
@@ -4396,11 +4396,12 @@ fn printErrsMsgToStdErr(
             text_buf.items.len = 0;
             try tree.renderError(note, writer);
             const note_loc = tree.tokenLocation(0, note.token);
+            const byte_offset = @intCast(u32, note_loc.line_start);
             notes_buffer[notes_len] = .{
                 .src = .{
                     .src_path = path,
                     .msg = try arena.dupe(u8, text_buf.items),
-                    .byte_offset = @intCast(u32, note_loc.line_start),
+                    .span = .{ .start = byte_offset, .end = byte_offset + @intCast(u32, tree.tokenSlice(note.token).len) },
                     .line = @intCast(u32, note_loc.line),
                     .column = @intCast(u32, note_loc.column),
                     .source_line = tree.source[note_loc.line_start..note_loc.line_end],
@@ -4411,11 +4412,12 @@ fn printErrsMsgToStdErr(
         }
 
         const extra_offset = tree.errorOffset(parse_error);
+        const byte_offset = @intCast(u32, start_loc.line_start) + extra_offset;
         const message: Compilation.AllErrors.Message = .{
             .src = .{
                 .src_path = path,
                 .msg = text,
-                .byte_offset = @intCast(u32, start_loc.line_start) + extra_offset,
+                .span = .{ .start = byte_offset, .end = byte_offset + @intCast(u32, tree.tokenSlice(lok_token).len) },
                 .line = @intCast(u32, start_loc.line),
                 .column = @intCast(u32, start_loc.column) + extra_offset,
                 .source_line = source_line,

--- a/src/main.zig
+++ b/src/main.zig
@@ -4381,7 +4381,7 @@ fn printErrsMsgToStdErr(
                     .msg = try std.fmt.allocPrint(arena, "invalid byte: '{'}'", .{
                         std.zig.fmtEscapes(tree.source[byte_offset..][0..1]),
                     }),
-                    .span = .{ .start = byte_offset, .end = byte_offset + 1 },
+                    .span = .{ .start = byte_offset, .end = byte_offset + 1, .main = byte_offset },
                     .line = @intCast(u32, start_loc.line),
                     .column = @intCast(u32, start_loc.column) + bad_off,
                     .source_line = source_line,
@@ -4401,7 +4401,11 @@ fn printErrsMsgToStdErr(
                 .src = .{
                     .src_path = path,
                     .msg = try arena.dupe(u8, text_buf.items),
-                    .span = .{ .start = byte_offset, .end = byte_offset + @intCast(u32, tree.tokenSlice(note.token).len) },
+                    .span = .{
+                        .start = byte_offset,
+                        .end = byte_offset + @intCast(u32, tree.tokenSlice(note.token).len),
+                        .main = byte_offset,
+                    },
                     .line = @intCast(u32, note_loc.line),
                     .column = @intCast(u32, note_loc.column),
                     .source_line = tree.source[note_loc.line_start..note_loc.line_end],
@@ -4417,7 +4421,11 @@ fn printErrsMsgToStdErr(
             .src = .{
                 .src_path = path,
                 .msg = text,
-                .span = .{ .start = byte_offset, .end = byte_offset + @intCast(u32, tree.tokenSlice(lok_token).len) },
+                .span = .{
+                    .start = byte_offset,
+                    .end = byte_offset + @intCast(u32, tree.tokenSlice(lok_token).len),
+                    .main = byte_offset,
+                },
                 .line = @intCast(u32, start_loc.line),
                 .column = @intCast(u32, start_loc.column) + extra_offset,
                 .source_line = source_line,

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -2381,10 +2381,12 @@ const Writer = struct {
                 .parent_decl_node = self.parent_decl_node,
                 .lazy = src,
             };
-            const abs_byte_off = src_loc.byteOffset(self.gpa) catch unreachable;
-            const delta_line = std.zig.findLineColumn(tree.source, abs_byte_off);
-            try stream.print("{s}:{d}:{d}", .{
-                @tagName(src), delta_line.line + 1, delta_line.column + 1,
+            const src_span = src_loc.span(self.gpa) catch unreachable;
+            const start = std.zig.findLineColumn(tree.source, src_span.start);
+            const end = std.zig.findLineColumn(tree.source, src_span.end);
+            try stream.print("{s}:{d}:{d} to :{d}:{d}", .{
+                @tagName(src), start.line + 1, start.column + 1,
+                end.line + 1, end.column + 1,
             });
         }
     }

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -2386,7 +2386,7 @@ const Writer = struct {
             const end = std.zig.findLineColumn(tree.source, src_span.end);
             try stream.print("{s}:{d}:{d} to :{d}:{d}", .{
                 @tagName(src), start.line + 1, start.column + 1,
-                end.line + 1, end.column + 1,
+                end.line + 1,  end.column + 1,
             });
         }
     }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -174,6 +174,15 @@ pub fn addCases(ctx: *TestContext) !void {
         });
     }
 
+    {
+        const case = ctx.obj("missing semicolon at EOF", .{});
+        case.addError(
+            \\const foo = 1
+        , &[_][]const u8{
+            \\:1:14: error: expected ';' after declaration
+        });
+    }
+
     // TODO test this in stage2, but we won't even try in stage1
     //ctx.objErrStage1("inline fn calls itself indirectly",
     //    \\export fn foo() void {


### PR DESCRIPTION
```zig
comptime {
    var a: u8 = 255;
    var b: u8 = 255;
    _ = (a - 1) + (b - 1);
}
comptime {
    var a: u8 = 255;
    var b: u8 = 255;
    _ = (a - 1) +
        (b - 1);
}
comptime {
    var a: u8 = 255;
    var b: u8 = 255;
    _ = (a - 1)
        + (b - 1);
}
comptime {
    var a: u8 = 255;
    var b: u8 = 255;
    _ = (a - 1)
        +
        (b - 1);
}
```
```
$ zig2 test a.zig
a.zig:4:17: error: overflow of integer type 'u8' with value '508'
    _ = (a - 1) + (b - 1);
        ~~~~~~~~^~~~~~~~~
a.zig:9:17: error: overflow of integer type 'u8' with value '508'
    _ = (a - 1) +
        ~~~~~~~~^
a.zig:16:9: error: overflow of integer type 'u8' with value '508'
        + (b - 1);
        ^~~~~~~~~
a.zig:22:9: error: overflow of integer type 'u8' with value '508'
        +
        ^
```

~~I didn't edit compile error tests yet since this is likely to touch most of them and I want to wait for #12117/comments.~~

~~One enhancement I can think of would be to have the caret (and the column number at the start) point at the main token instead of the start (`+` in all the examples)~~ Done.