### PR TITLE
Sema: fix coerce_result_ptr in case of inferred result type

### DIFF
--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -232,13 +232,13 @@ const Writer = struct {
             .validate_array_init_ty,
             .validate_struct_init_ty,
             .make_ptr_const,
+            .validate_deref,
             => try self.writeUnNode(stream, inst),
 
             .ref,
             .ret_tok,
             .ensure_err_payload_void,
             .closure_capture,
-            .validate_deref,
             => try self.writeUnTok(stream, inst),
 
             .bool_br_and,

--- a/src/value.zig
+++ b/src/value.zig
@@ -4935,7 +4935,16 @@ pub const Value = extern union {
                 /// peer type resolution. This is stored in a separate list so that
                 /// the items are contiguous in memory and thus can be passed to
                 /// `Module.resolvePeerTypes`.
-                stored_inst_list: std.ArrayListUnmanaged(Air.Inst.Ref) = .{},
+                prongs: std.MultiArrayList(struct {
+                    /// The dummy instruction used as a peer to resolve the type.
+                    /// Although this has a redundant type with placeholder, this is
+                    /// needed in addition because it may be a constant value, which
+                    /// affects peer type resolution.
+                    stored_inst: Air.Inst.Ref,
+                    /// The bitcast instruction used as a placeholder when the
+                    /// new result pointer type is not yet known.
+                    placeholder: Air.Inst.Index,
+                }) = .{},
                 /// 0 means ABI-aligned.
                 alignment: u32,
             },

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -570,10 +570,7 @@ test "type coercion of pointer to anon struct literal to pointer to array" {
 }
 
 test "array with comptime only element type" {
-    const a = [_]type{
-        u32,
-        i32,
-    };
+    const a = [_]type{ u32, i32 };
     try testing.expect(a[0] == u32);
     try testing.expect(a[1] == i32);
 }

--- a/test/behavior/if.zig
+++ b/test/behavior/if.zig
@@ -128,3 +128,15 @@ test "if peer expressions inferred optional type" {
     try expect(left.? == 98);
     try expect(right.? == 99);
 }
+
+test "if-else expression with runtime condition result location is inferred optional" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+
+    const A = struct { b: u64, c: u64 };
+    var d: bool = true;
+    const e = if (d) A{ .b = 15, .c = 30 } else null;
+    try expect(e != null);
+}

--- a/test/behavior/if.zig
+++ b/test/behavior/if.zig
@@ -140,3 +140,19 @@ test "if-else expression with runtime condition result location is inferred opti
     const e = if (d) A{ .b = 15, .c = 30 } else null;
     try expect(e != null);
 }
+
+test "result location with inferred type ends up being pointer to comptime_int" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+
+    var a: ?u32 = 1234;
+    var b: u32 = 2000;
+    var c = if (a) |d| blk: {
+        if (d < b) break :blk @as(u32, 1);
+        break :blk 0;
+    } else @as(u32, 0);
+    try expect(c == 1);
+}


### PR DESCRIPTION
Previously, the logic for analyzing coerce_result_ptr would generate
invalid bitcast instructions which did not include coercion logic, such
as optional wrapping, resulting in miscompilations.

Now, the logic of resolve_inferred_alloc goes back over all the
placeholders inserted by coerce_result_ptr, and replaces them with logic
doing the proper coercions.

Closes #12045

## Demo

```zig
fn doTheTest() !void {
    var cond: bool = true;
    const pc_range = if (cond) PcRange{
        .start = 15,
        .end = 30,
    } else null;
    assert(pc_range != null);
}

const PcRange = struct {
    start: u64,
    end: u64,
};
```

### Before the fix:

Each prong of the if expression incorrectly bitcasts the optional to a non-optional and then fails to account for the null bit at all.

```
# Begin Function AIR: test2.doTheTest:
# Total AIR+Liveness bytes: 1.0390625KiB
# AIR Instructions:         68 (612B)
# AIR Extra Data:           40 (160B)
# AIR Values Bytes:         15 (120B)
# Liveness tomb_bits:       40B
# Liveness Extra Data:      3 (12B)
# Liveness special table:   1 (8B)
  %4 = const_ty(*bool)
  %7 = const_ty((inferred_alloc_const))
  %13 = const_ty(*const type)
  %14 = constant(*const type, test2.PcRange)
  %15 = constant(type, test2.PcRange)
  %16 = const_ty(test2.PcRange)
  %18 = const_ty(*test2.PcRange)
  %20 = const_ty(*u64)
  %22 = constant(comptime_int, 15)
  %23 = constant(u64, 15)
  %25 = const_ty(*u64)
  %27 = constant(comptime_int, 30)
  %28 = constant(u64, 30)
  %31 = const_ty(test2.PcRange)
  %32 = constant(test2.PcRange, .{.start = 15, .end = 30})
  %33 = const_ty(test2.PcRange)
  %38 = const_ty(*@TypeOf(null))
  %42 = const_ty(?test2.PcRange)
  %43 = const_ty(*const ?test2.PcRange)
  %45 = const_ty(*const ?test2.PcRange)
  %48 = const_ty(*const fn(bool) void)
  %49 = constant(*const fn(bool) void, (function 'assert'))
  %50 = const_ty(fn(bool) void)
  %51 = constant(fn(bool) void, (function 'assert'))
  %53 = const_ty(?test2.PcRange)
  %58 = const_ty(@typeInfo(@typeInfo(@TypeOf(test2.doTheTest)).Fn.return_type.?).ErrorUnion.error_set!void)
  %59 = constant(@typeInfo(@typeInfo(@TypeOf(test2.doTheTest)).Fn.return_type.?).ErrorUnion.error_set!void, {})
  %61 = const_ty(*const type)
  %62 = constant(*const type, builtin.builtin)
  %63 = constant(type, builtin.builtin)
  %64 = const_ty(*const type)
  %65 = constant(*const type, builtin.StackTrace)
  %66 = constant(type, builtin.StackTrace)
  %67 = const_ty(builtin.StackTrace)

  %0!= dbg_block_begin()
  %1!= dbg_stmt(2:5)
  %2 = alloc(*bool)
  %3!= store(%2, @Zir.Inst.Ref.bool_true)
  %5!= dbg_var_ptr(%2, cond)
  %6!= dbg_stmt(3:5)
  %8 = alloc(*const ?test2.PcRange)
  %9!= block(void, {
    %10!= dbg_stmt(3:26)
    %11 = load(bool, %2!)
    %41!= cond_br(%11!, {
      %12!= dbg_block_begin()
      %19 = bitcast(*test2.PcRange, %8)
      %34!= store(%19!, %32!)
      %35!= br(%9, @Zir.Inst.Ref.void_value)
    }, {
      %32!
      %36!= dbg_block_begin()
      %37!= dbg_block_end()
      %39!= bitcast(*@TypeOf(null), %8)
      %40!= br(%9, @Zir.Inst.Ref.void_value)
    })
  })
  %44 = bitcast(*const ?test2.PcRange, %8!)
  %46!= dbg_var_ptr(%44, pc_range)
  %47!= dbg_stmt(7:5)
  %52!= dbg_stmt(7:11)
  %54 = load(?test2.PcRange, %44!)
  %55 = is_non_null(%54!)
  %56!= dbg_block_end()
  %57!= call(%51!, [%55!])
  %60!= ret(%59!)
# End Function AIR: test2.doTheTest

```

### After the fix:

Equivalent logic - in fact, shared logic - when the local's type is provided.

```
# Begin Function AIR: test2.doTheTest:
# Total AIR+Liveness bytes: 1.22265625KiB
# AIR Instructions:         84 (756B)
# AIR Extra Data:           44 (176B)
# AIR Values Bytes:         17 (136B)
# Liveness tomb_bits:       48B
# Liveness Extra Data:      4 (16B)
# Liveness special table:   1 (8B)
  %4 = const_ty(*bool)
  %7 = const_ty((inferred_alloc_const))
  %13 = const_ty(*const type)
  %14 = constant(*const type, test2.PcRange)
  %15 = constant(type, test2.PcRange)
  %16 = const_ty(test2.PcRange)
  %18 = const_ty(*test2.PcRange)
  %20 = const_ty(*u64)
  %22 = constant(comptime_int, 15)
  %23 = constant(u64, 15)
  %25 = const_ty(*u64)
  %27 = constant(comptime_int, 30)
  %28 = constant(u64, 30)
  %31 = const_ty(test2.PcRange)
  %32 = constant(test2.PcRange, .{.start = 15, .end = 30})
  %33 = const_ty(test2.PcRange)
  %38 = const_ty(*@TypeOf(null))
  %42 = const_ty(?test2.PcRange)
  %44 = const_ty(test2.PcRange)
  %46 = const_ty(?test2.PcRange)
  %48 = const_ty(*const test2.PcRange)
  %50 = const_ty(*test2.PcRange)
  %54 = const_ty(?test2.PcRange)
  %55 = constant(?test2.PcRange, null)
  %56 = const_ty(?test2.PcRange)
  %57 = constant(?test2.PcRange, null)
  %59 = const_ty(*const ?test2.PcRange)
  %61 = const_ty(*const ?test2.PcRange)
  %64 = const_ty(*const fn(bool) void)
  %65 = constant(*const fn(bool) void, (function 'assert'))
  %66 = const_ty(fn(bool) void)
  %67 = constant(fn(bool) void, (function 'assert'))
  %69 = const_ty(?test2.PcRange)
  %74 = const_ty(@typeInfo(@typeInfo(@TypeOf(test2.doTheTest)).Fn.return_type.?).ErrorUnion.error_set!void)
  %75 = constant(@typeInfo(@typeInfo(@TypeOf(test2.doTheTest)).Fn.return_type.?).ErrorUnion.error_set!void, {})
  %77 = const_ty(*const type)
  %78 = constant(*const type, builtin.builtin)
  %79 = constant(type, builtin.builtin)
  %80 = const_ty(*const type)
  %81 = constant(*const type, builtin.StackTrace)
  %82 = constant(type, builtin.StackTrace)
  %83 = const_ty(builtin.StackTrace)

  %0!= dbg_block_begin()
  %1!= dbg_stmt(2:5)
  %2 = alloc(*bool)
  %3!= store(%2, @Zir.Inst.Ref.bool_true)
  %5!= dbg_var_ptr(%2, cond)
  %6!= dbg_stmt(3:5)
  %8 = alloc(*const ?test2.PcRange)
  %9!= block(void, {
    %10!= dbg_stmt(3:26)
    %11 = load(bool, %2!)
    %41!= cond_br(%11!, {
      %57!
      %12!= dbg_block_begin()
      %19 = block(*test2.PcRange, {
        %49 = optional_payload_ptr_set(*const test2.PcRange, %8)
        %51 = bitcast(*test2.PcRange, %49!)
        %52!= br(%19, %51!)
      })
      %34!= store(%19!, %32!)
      %35!= br(%9, @Zir.Inst.Ref.void_value)
    }, {
      %32!
      %36!= dbg_block_begin()
      %37!= dbg_block_end()
      %39!= store(%8, %57!)
      %40!= br(%9, @Zir.Inst.Ref.void_value)
    })
  })
  %60 = bitcast(*const ?test2.PcRange, %8!)
  %62!= dbg_var_ptr(%60, pc_range)
  %63!= dbg_stmt(7:5)
  %68!= dbg_stmt(7:11)
  %70 = load(?test2.PcRange, %60!)
  %71 = is_non_null(%70!)
  %72!= dbg_block_end()
  %73!= call(%67!, [%71!])
  %76!= ret(%75!)
# End Function AIR: test2.doTheTest
```

```llvm
; Function Attrs: nounwind
define internal fastcc i16 @test2.doTheTest(%builtin.StackTrace* nonnull %0) unnamed_addr #0 !dbg !42 {
Entry:
  %1 = alloca { %test2.PcRange, i1 }, align 8
  %2 = alloca i1, align 1
  store i1 true, i1* %2, align 1, !dbg !72
  call void @llvm.dbg.declare(metadata i1* %2, metadata !58, metadata !DIExpression()), !dbg !72
  %3 = load i1, i1* %2, align 1, !dbg !73
  br i1 %3, label %Then, label %Else, !dbg !73

Then:                                             ; preds = %Entry
  %4 = getelementptr inbounds { %test2.PcRange, i1 }, { %test2.PcRange, i1 }* %1, i32 0, i32 1, !dbg !73
  store i1 true, i1* %4, align 1, !dbg !73
  %5 = getelementptr inbounds { %test2.PcRange, i1 }, { %test2.PcRange, i1 }* %1, i32 0, i32 0, !dbg !73
  br label %Block, !dbg !73

Else:                                             ; preds = %Entry
  store { %test2.PcRange, i1 } { %test2.PcRange undef, i1 false }, { %test2.PcRange, i1 }* %1, align 8, !dbg !73
  br label %Block1, !dbg !73

Block:                                            ; preds = %Then
  %6 = phi %test2.PcRange* [ %5, %Then ], !dbg !73
  store %test2.PcRange { i64 15, i64 30 }, %test2.PcRange* %6, align 8, !dbg !73
  br label %Block1, !dbg !73

Block1:                                           ; preds = %Else, %Block
  call void @llvm.dbg.declare(metadata { %test2.PcRange, i1 }* %1, metadata !62, metadata !DIExpression()), !dbg !74
  %7 = load { %test2.PcRange, i1 }, { %test2.PcRange, i1 }* %1, align 8, !dbg !75
  %8 = extractvalue { %test2.PcRange, i1 } %7, 1, !dbg !75
  call fastcc void @debug.assert(i1 %8), !dbg !75
  ret i16 0, !dbg !75
}

; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
declare void @llvm.dbg.declare(metadata %0, metadata %1, metadata %2) #1

; Function Attrs: nounwind
define internal fastcc void @debug.assert(i1 %0) unnamed_addr #0 !dbg !76 {
Entry:
  call void @llvm.dbg.value(metadata i1 %0, metadata !81, metadata !DIExpression()), !dbg !83
  %1 = xor i1 %0, true, !dbg !84
  br i1 %1, label %Then, label %Else, !dbg !84

Then:                                             ; preds = %Entry
  call fastcc void @test2.panic(i8* getelementptr inbounds ([24 x i8], [24 x i8]* @debug.assert__anon_320, i32 0, i32 0), i64 24, %builtin.StackTrace* null), !dbg !84
  unreachable, !dbg !84

Else:                                             ; preds = %Entry
  br label %Block, !dbg !84

Block:                                            ; preds = %Else
  ret void, !dbg !84
}
```
