### PR TITLE
ci: bump macOS image on Github Actions to macos-11

### DIFF
--- a/ci/azure/pipelines.yml
+++ b/ci/azure/pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: BuildMacOS
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-11'
   timeoutInMinutes: 360
   steps:
   - task: DownloadSecureFile@1
@@ -12,7 +12,7 @@ jobs:
     displayName: 'Build and test'
 - job: BuildMacOS_arm64
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-11'
   timeoutInMinutes: 180
   steps:
   - task: DownloadSecureFile@1


### PR DESCRIPTION
The currently used image is getting deprecated and every user is advised
to switch to either macos-11 or macos-12. The link to upstream
issue/notification:

https://github.com/actions/virtual-environments/issues/5583