### PR TITLE
style: add missing comma

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4812,7 +4812,7 @@ pub fn generateBuiltinZigSource(comp: *Compilation, allocator: Allocator) Alloca
     );
 
     switch (target.os.getVersionRange()) {
-        .none => try buffer.appendSlice(" .none = {} }\n"),
+        .none => try buffer.appendSlice(" .none = {} },\n"),
         .semver => |semver| try buffer.writer().print(
             \\ .semver = .{{
             \\        .min = .{{


### PR DESCRIPTION
This is really minor but the issue this fixes is that if you copy-paste the following output of `--show-builtin` into your `build.zig` for example then the formatter will format
```zig
pub const os = std.Target.Os{
    .tag = .freestanding,
    .version_range = .{ .none = {} }
};
```
to
```zig
pub const os = std.Target.Os{ .tag = .freestanding, .version_range = .{ .none = {} } };
```
which doesn't match the output.
With this comma, the output of `--show-builtin` will stay the way it is after a `zig fmt`.