### PR TITLE
std.json: Fix parsing of large numbers

### DIFF
--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -2046,6 +2046,11 @@ test "parse" {
     try testing.expectEqual(@as([3]u8, "foo".*), try parse([3]u8, &ts, ParseOptions{}));
     ts = TokenStream.init("[]");
     try testing.expectEqual(@as([0]u8, undefined), try parse([0]u8, &ts, ParseOptions{}));
+
+    ts = TokenStream.init("\"12345678901234567890\"");
+    try testing.expectEqual(@as(u64, 12345678901234567890), try parse(u64, &ts, ParseOptions{}));
+    ts = TokenStream.init("\"123.456\"");
+    try testing.expectEqual(@as(f64, 123.456), try parse(f64, &ts, ParseOptions{}));
 }
 
 test "parse into enum" {


### PR DESCRIPTION
Numbers greater than about 2^53 are encoded as strings in JSON, looking like `{ "12345678901234567890" }` instead of `{ 12345678901234567890 }`. `std.json.parseInternal` previously errored out because of this. It now tolerates integers wrapped in quotes. I've written a simple test case for this.

This has the side effect that `std.json.parse` will also accept small integers wrapped in quotes, though I think this is acceptable.