### PR TITLE
Allocator integer overflow with `math.maxInt(usize)` fix.

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -316,13 +316,9 @@ const PageAllocator = struct {
         }
 
         const max_drop_len = alignment - @minimum(alignment, mem.page_size);
-        // Subtract with overflow due to possibility of operation causing a panic otherwise.
+        // Saturating subtraction due to possibility of operation causing a panic otherwise.
         // Result is clamped between 0 and std.math.maxInt(usize).
-        const sub_res = brk: {
-            var res: usize = undefined;
-            break :brk if (@subWithOverflow(usize, aligned_len, n, &res)) 0 else res;
-        };
-        const alloc_len = if (max_drop_len <= sub_res)
+        const alloc_len = if (max_drop_len <= aligned_len -| n)
             aligned_len
         else
             mem.alignForward(aligned_len + max_drop_len, mem.page_size);

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -316,7 +316,13 @@ const PageAllocator = struct {
         }
 
         const max_drop_len = alignment - @minimum(alignment, mem.page_size);
-        const alloc_len = if (max_drop_len <= aligned_len - n)
+        // Subtract with overflow due to possibility of operation causing a panic otherwise.
+        // Result is clamped between 0 and std.math.maxInt(usize).
+        const sub_res = brk: {
+            var res: usize = undefined;
+            break :brk if (@subWithOverflow(usize, aligned_len, n, &res)) 0 else res;
+        };
+        const alloc_len = if (max_drop_len <= sub_res)
             aligned_len
         else
             mem.alignForward(aligned_len + max_drop_len, mem.page_size);

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -317,7 +317,6 @@ const PageAllocator = struct {
 
         const max_drop_len = alignment - @minimum(alignment, mem.page_size);
         // Saturating subtraction due to possibility of operation causing a panic otherwise.
-        // Result is clamped between 0 and std.math.maxInt(usize).
         const alloc_len = if (max_drop_len <= aligned_len -| n)
             aligned_len
         else

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -971,6 +971,7 @@ test "large allocations" {
     const ptr3 = try allocator.alloc(u64, 62768);
     allocator.free(ptr3);
     allocator.free(ptr2);
+    try std.testing.expectError(error.OutOfMemory, allocator.alloc(u8, std.math.maxInt(usize))); // equivalent to std.testing.allocator
 }
 
 test "realloc" {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3196,7 +3196,10 @@ pub fn alignForward(addr: usize, alignment: usize) usize {
 /// Round an address up to the nearest aligned address
 /// The alignment must be a power of 2 and greater than 0.
 pub fn alignForwardGeneric(comptime T: type, addr: T, alignment: T) T {
-    return alignBackwardGeneric(T, addr + (alignment - 1), alignment);
+    var result: T = undefined;
+    // Add with overflow due to possibility of addr + alignment - 1 being larger than std.math.maxInt(T).
+    // result is clamped between 0 and std.math.maxInt(usize).
+    return alignBackwardGeneric(T, if (@addWithOverflow(T, addr, alignment - 1, &result)) std.math.maxInt(T) else result, alignment);
 }
 
 /// Force an evaluation of the expression; this tries to prevent

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3196,10 +3196,7 @@ pub fn alignForward(addr: usize, alignment: usize) usize {
 /// Round an address up to the nearest aligned address
 /// The alignment must be a power of 2 and greater than 0.
 pub fn alignForwardGeneric(comptime T: type, addr: T, alignment: T) T {
-    var result: T = undefined;
-    // Add with overflow due to possibility of addr + alignment - 1 being larger than std.math.maxInt(T).
-    // result is clamped between 0 and std.math.maxInt(usize).
-    return alignBackwardGeneric(T, if (@addWithOverflow(T, addr, alignment - 1, &result)) std.math.maxInt(T) else result, alignment);
+return alignBackwardGeneric(T, addr +| (alignment - 1), alignment);
 }
 
 /// Force an evaluation of the expression; this tries to prevent

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3196,7 +3196,8 @@ pub fn alignForward(addr: usize, alignment: usize) usize {
 /// Round an address up to the nearest aligned address
 /// The alignment must be a power of 2 and greater than 0.
 pub fn alignForwardGeneric(comptime T: type, addr: T, alignment: T) T {
-return alignBackwardGeneric(T, addr +| (alignment - 1), alignment);
+    // Saturating addition due to possibility of operation causing a panic otherwise.
+    return alignBackwardGeneric(T, addr +| (alignment - 1), alignment);
 }
 
 /// Force an evaluation of the expression; this tries to prevent

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4372,7 +4372,7 @@ pub fn mmap(
         .BADF => unreachable, // Always a race condition.
         .OVERFLOW => unreachable, // The number of pages used for length + offset would overflow.
         .NODEV => return error.MemoryMappingNotSupported,
-        .INVAL => unreachable, // Invalid parameters to mmap()
+        .INVAL => return error.OutOfMemory, // Invalid parameters to mmap()
         .NOMEM => return error.OutOfMemory,
         else => return unexpectedErrno(err),
     }


### PR DESCRIPTION
Fixed overflow panics that may occur when allocating if the size requested is too large.
My solution was clamping the results of two operations that could cause a panic with a value between 0 and `math.maxInt(T)`
Also added a line to an allocation test expecting an `OutOfMemory` error in general_purpose_allocator.zig. 

This fixes #12118 