### PR TITLE
CMake: Improve usage of `llvm-config` (esp. for consistent static/shared linking)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,9 @@ endif()
 message(STATUS "Configuring zig version ${ZIG_VERSION}")
 
 set(ZIG_STATIC off CACHE BOOL "Attempt to build a static zig executable (not compatible with glibc)")
+set(ZIG_SHARED_LLVM off CACHE BOOL "Prefer linking against shared LLVM libraries")
 set(ZIG_STATIC_LLVM off CACHE BOOL "Prefer linking against static LLVM libraries")
 set(ZIG_STATIC_ZLIB off CACHE BOOL "Prefer linking against static zlib")
-set(ZIG_PREFER_CLANG_CPP_DYLIB off CACHE BOOL "Try to link against -lclang-cpp")
 set(ZIG_USE_CCACHE off CACHE BOOL "Use ccache if available")
 
 if(CCACHE_PROGRAM AND ZIG_USE_CCACHE)
@@ -78,6 +78,10 @@ endif()
 if(ZIG_STATIC)
     set(ZIG_STATIC_LLVM ON)
     set(ZIG_STATIC_ZLIB ON)
+endif()
+
+if (ZIG_SHARED_LLVM AND ZIG_STATIC_LLVM)
+    message(SEND_ERROR "-DZIG_SHARED_LLVM and -DZIG_STATIC_LLVM cannot both be enabled simultaneously")
 endif()
 
 string(REGEX REPLACE "\\\\" "\\\\\\\\" ZIG_LIBC_LIB_DIR_ESCAPED "${ZIG_LIBC_LIB_DIR}")

--- a/build.zig
+++ b/build.zig
@@ -660,6 +660,7 @@ fn addCMakeLibraryList(exe: *std.build.LibExeObjStep, list: []const u8) void {
 }
 
 const CMakeConfig = struct {
+    llvm_linkage: std.build.LibExeObjStep.Linkage,
     cmake_binary_dir: []const u8,
     cmake_prefix_path: []const u8,
     cxx_compiler: []const u8,
@@ -698,6 +699,7 @@ fn findAndParseConfigH(b: *Builder, config_h_path_option: ?[]const u8) ?CMakeCon
     };
 
     var ctx: CMakeConfig = .{
+        .llvm_linkage = undefined,
         .cmake_binary_dir = undefined,
         .cmake_prefix_path = undefined,
         .cxx_compiler = undefined,
@@ -741,6 +743,7 @@ fn findAndParseConfigH(b: *Builder, config_h_path_option: ?[]const u8) ?CMakeCon
             .prefix = "#define ZIG_DIA_GUIDS_LIB ",
             .field = "dia_guids_lib",
         },
+        // .prefix = ZIG_LLVM_LINK_MODE parsed manually below
     };
 
     var lines_it = mem.tokenize(u8, config_h_text, "\r\n");
@@ -752,6 +755,12 @@ fn findAndParseConfigH(b: *Builder, config_h_path_option: ?[]const u8) ?CMakeCon
                 const quoted = it.next().?; // the stuff inside the quote
                 @field(ctx, mapping.field) = toNativePathSep(b, quoted);
             }
+        }
+        if (mem.startsWith(u8, line, "#define ZIG_LLVM_LINK_MODE ")) {
+            var it = mem.split(u8, line, "\"");
+            _ = it.next().?; // skip the stuff before the quote
+            const quoted = it.next().?; // the stuff inside the quote
+            ctx.llvm_linkage = if (mem.eql(u8, quoted, "shared")) .dynamic else .static;
         }
     }
     return ctx;

--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -9,7 +9,9 @@
 
 find_path(CLANG_INCLUDE_DIRS NAMES clang/Frontend/ASTUnit.h
   HINTS ${LLVM_INCLUDE_DIRS}
-  NO_DEFAULT_PATH # Only look for clang next to LLVM
+  # Only look for Clang next to LLVM or in { CMAKE_PREFIX_PATH, CMAKE_LIBRARY_PATH, CMAKE_FRAMEWORK_PATH }
+  NO_SYSTEM_ENVIRONMENT_PATH
+  NO_CMAKE_SYSTEM_PATH
 )
 
 if(${LLVM_LINK_MODE} STREQUAL "shared")
@@ -21,14 +23,18 @@ if(${LLVM_LINK_MODE} STREQUAL "shared")
       clang-cpp
     NAMES_PER_DIR
     HINTS "${LLVM_LIBDIRS}"
-    NO_DEFAULT_PATH # Only look for Clang next to LLVM
+    # Only look for Clang next to LLVM or in { CMAKE_PREFIX_PATH, CMAKE_LIBRARY_PATH, CMAKE_FRAMEWORK_PATH }
+    NO_SYSTEM_ENVIRONMENT_PATH
+    NO_CMAKE_SYSTEM_PATH
   )
 else()
   macro(FIND_AND_ADD_CLANG_LIB _libname_)
     string(TOUPPER ${_libname_} _prettylibname_)
     find_library(CLANG_${_prettylibname_}_LIB NAMES ${_libname_} NAMES_PER_DIR
       HINTS "${LLVM_LIBDIRS}"
-      NO_DEFAULT_PATH # Only look for Clang next to LLVM
+      # Only look for Clang next to LLVM or in { CMAKE_PREFIX_PATH, CMAKE_LIBRARY_PATH, CMAKE_FRAMEWORK_PATH }
+      NO_SYSTEM_ENVIRONMENT_PATH
+      NO_CMAKE_SYSTEM_PATH
     )
     if(CLANG_${_prettylibname_}_LIB)
       set(CLANG_LIBRARIES ${CLANG_LIBRARIES} ${CLANG_${_prettylibname_}_LIB})

--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -7,7 +7,6 @@
 # CLANG_LIBRARIES
 # CLANG_LIBDIRS
 
-#TODO: FIXME
 find_path(CLANG_INCLUDE_DIRS NAMES clang/Frontend/ASTUnit.h
   HINTS ${LLVM_INCLUDE_DIRS}
   NO_DEFAULT_PATH # Only look for clang next to LLVM

--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -7,53 +7,29 @@
 # CLANG_LIBRARIES
 # CLANG_LIBDIRS
 
+#TODO: FIXME
 find_path(CLANG_INCLUDE_DIRS NAMES clang/Frontend/ASTUnit.h
-  PATHS
-    /usr/lib/llvm/14/include
-    /usr/lib/llvm-14/include
-    /usr/lib/llvm-14.0/include
-    /usr/local/llvm140/include
-    /usr/local/llvm14/include
-    /usr/local/opt/llvm@14/include
-    /opt/homebrew/opt/llvm@14/include
-    /mingw64/include
+  HINTS ${LLVM_INCLUDE_DIRS}
+  NO_DEFAULT_PATH # Only look for clang next to LLVM
 )
 
-if(ZIG_PREFER_CLANG_CPP_DYLIB)
+if(${LLVM_LINK_MODE} STREQUAL "shared")
   find_library(CLANG_LIBRARIES
     NAMES
+      libclang-cpp.so.14
       clang-cpp-14.0
       clang-cpp140
       clang-cpp
     NAMES_PER_DIR
-    PATHS
-      ${CLANG_LIBDIRS}
-      /usr/lib/llvm/14/lib
-      /usr/lib/llvm/14/lib64
-      /usr/lib/llvm-14/lib
-      /usr/local/llvm140/lib
-      /usr/local/llvm14/lib
-      /usr/local/opt/llvm@14/lib
-      /opt/homebrew/opt/llvm@14/lib
+    HINTS "${LLVM_LIBDIRS}"
+    NO_DEFAULT_PATH # Only look for Clang next to LLVM
   )
-endif()
-
-if(NOT CLANG_LIBRARIES)
+else()
   macro(FIND_AND_ADD_CLANG_LIB _libname_)
     string(TOUPPER ${_libname_} _prettylibname_)
     find_library(CLANG_${_prettylibname_}_LIB NAMES ${_libname_} NAMES_PER_DIR
-      PATHS
-        ${CLANG_LIBDIRS}
-        /usr/lib/llvm/14/lib
-        /usr/lib/llvm-14/lib
-        /usr/lib/llvm-14.0/lib
-        /usr/local/llvm140/lib
-        /usr/local/llvm14/lib
-        /usr/local/opt/llvm@14/lib
-        /opt/homebrew/opt/llvm@14/lib
-        /mingw64/lib
-        /c/msys64/mingw64/lib
-        c:\\msys64\\mingw64\\lib
+      HINTS "${LLVM_LIBDIRS}"
+      NO_DEFAULT_PATH # Only look for Clang next to LLVM
     )
     if(CLANG_${_prettylibname_}_LIB)
       set(CLANG_LIBRARIES ${CLANG_LIBRARIES} ${CLANG_${_prettylibname_}_LIB})

--- a/cmake/Findlld.cmake
+++ b/cmake/Findlld.cmake
@@ -8,12 +8,22 @@
 
 find_path(LLD_INCLUDE_DIRS NAMES lld/Common/Driver.h
     HINTS ${LLVM_INCLUDE_DIRS}
-    NO_DEFAULT_PATH # Only look for LLD next to LLVM
-)
+    PATHS
+        /usr/lib/llvm-14/include
+        /usr/local/llvm140/include
+        /usr/local/llvm14/include
+        /usr/local/opt/llvm@14/include
+        /opt/homebrew/opt/llvm@14/include
+        /mingw64/include)
 
 find_library(LLD_LIBRARY NAMES lld-14.0 lld140 lld NAMES_PER_DIR
     HINTS ${LLVM_LIBDIRS}
-    NO_DEFAULT_PATH # Only look for LLD next to LLVM
+    PATHS
+        /usr/lib/llvm-14/lib
+        /usr/local/llvm140/lib
+        /usr/local/llvm14/lib
+        /usr/local/opt/llvm@14/lib
+        /opt/homebrew/opt/llvm@14/lib
 )
 if(EXISTS ${LLD_LIBRARY})
     set(LLD_LIBRARIES ${LLD_LIBRARY})
@@ -22,8 +32,16 @@ else()
         string(TOUPPER ${_libname_} _prettylibname_)
         find_library(LLD_${_prettylibname_}_LIB NAMES ${_libname_} NAMES_PER_DIR
             HINTS ${LLVM_LIBDIRS}
-            NO_DEFAULT_PATH # Only look for LLD next to LLVM
-        )
+            PATHS
+                ${LLD_LIBDIRS}
+                /usr/lib/llvm-14/lib
+                /usr/local/llvm140/lib
+                /usr/local/llvm14/lib
+                /usr/local/opt/llvm@14/lib
+                /opt/homebrew/opt/llvm@14/lib
+                /mingw64/lib
+                /c/msys64/mingw64/lib
+                c:/msys64/mingw64/lib)
         if(LLD_${_prettylibname_}_LIB)
             set(LLD_LIBRARIES ${LLD_LIBRARIES} ${LLD_${_prettylibname_}_LIB})
         endif()

--- a/cmake/Findlld.cmake
+++ b/cmake/Findlld.cmake
@@ -7,21 +7,13 @@
 # LLD_LIBRARIES
 
 find_path(LLD_INCLUDE_DIRS NAMES lld/Common/Driver.h
-    PATHS
-        /usr/lib/llvm-14/include
-        /usr/local/llvm140/include
-        /usr/local/llvm14/include
-        /usr/local/opt/llvm@14/include
-        /opt/homebrew/opt/llvm@14/include
-        /mingw64/include)
+    HINTS ${LLVM_INCLUDE_DIRS}
+    NO_DEFAULT_PATH # Only look for LLD next to LLVM
+)
 
 find_library(LLD_LIBRARY NAMES lld-14.0 lld140 lld NAMES_PER_DIR
-    PATHS
-        /usr/lib/llvm-14/lib
-        /usr/local/llvm140/lib
-        /usr/local/llvm14/lib
-        /usr/local/opt/llvm@14/lib
-        /opt/homebrew/opt/llvm@14/lib
+    HINTS ${LLVM_LIBDIRS}
+    NO_DEFAULT_PATH # Only look for LLD next to LLVM
 )
 if(EXISTS ${LLD_LIBRARY})
     set(LLD_LIBRARIES ${LLD_LIBRARY})
@@ -29,18 +21,11 @@ else()
     macro(FIND_AND_ADD_LLD_LIB _libname_)
         string(TOUPPER ${_libname_} _prettylibname_)
         find_library(LLD_${_prettylibname_}_LIB NAMES ${_libname_} NAMES_PER_DIR
-            PATHS
-                ${LLD_LIBDIRS}
-                /usr/lib/llvm-14/lib
-                /usr/local/llvm140/lib
-                /usr/local/llvm14/lib
-                /usr/local/opt/llvm@14/lib
-                /opt/homebrew/opt/llvm@14/lib
-                /mingw64/lib
-                /c/msys64/mingw64/lib
-                c:/msys64/mingw64/lib)
-            if(LLD_${_prettylibname_}_LIB)
-                set(LLD_LIBRARIES ${LLD_LIBRARIES} ${LLD_${_prettylibname_}_LIB})
+            HINTS ${LLVM_LIBDIRS}
+            NO_DEFAULT_PATH # Only look for LLD next to LLVM
+        )
+        if(LLD_${_prettylibname_}_LIB)
+            set(LLD_LIBRARIES ${LLD_LIBRARIES} ${LLD_${_prettylibname_}_LIB})
         endif()
     endmacro(FIND_AND_ADD_LLD_LIB)
 

--- a/src/stage1/config.h.in
+++ b/src/stage1/config.h.in
@@ -16,6 +16,7 @@
 
 // Used by build.zig for communicating build information to self hosted build.
 #define ZIG_CMAKE_BINARY_DIR "@CMAKE_BINARY_DIR@"
+#define ZIG_LLVM_LINK_MODE "@LLVM_LINK_MODE@"
 #define ZIG_CMAKE_PREFIX_PATH "@CMAKE_PREFIX_PATH@"
 #define ZIG_CXX_COMPILER "@CMAKE_CXX_COMPILER@"
 #define ZIG_LLD_INCLUDE_PATH "@LLD_INCLUDE_DIRS@"


### PR DESCRIPTION
This commit reworks the LLVM/Clang/LLD discovery process for CMake.

`llvm-config` really wraps **two** sets of libraries that exist in parallel in an installation: shared and static. Building LLVM according to the wiki gives you only static libs. However, building with `-DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON` means that your LLVM/Clang installation with have *both* sets of libraries (which is usually the case for system-provided LLVM/Clang).

In that case, llvm-config reports entirely different libraries and dependencies for `--link-static` versus `--link-shared`

This include several changes to handle this better:
  1. Search for `llvm-config` from most preferred directory to least, skipping any candidate that is the wrong version or doesn't support the requested link mode ("static" or "shared")
  2. `-DZIG_PREFER_CLANG_CPP_DYLIB` has been renamed to `-DZIG_SHARED_LLVM`, to better align with `-DZIG_STATIC_LLVM`.
  3. Only search for Clang in the same directory where LLVM was located (or `CMAKE_LIBRARY_PATH`)
  4. Use `llvm-config` to find include directories
  5. LLVM's link mode is forwarded to Clang, so that they are each linked either statically or dynamically
  6. Use "--link-static" when querying "--system-libs" from llvm-config, so that this will include libz and other dependencies for statically linking LLD