### PR TITLE
More ABI size and alignment fixes

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1808,20 +1808,23 @@ pub const Target = struct {
             // 1. Different machine code instruction when loading into SIMD register.
             // 2. The C ABI wants 16 for extern structs.
             // 3. 16-byte cmpxchg needs 16-byte alignment.
-            // Same logic for riscv64, powerpc64, mips64, sparc64.
+            // Same logic for powerpc64, mips64, sparc64.
             .x86_64,
-            .riscv64,
             .powerpc64,
             .powerpc64le,
             .mips64,
             .mips64el,
             .sparc64,
-            => 8,
+            => return switch (target.ofmt) {
+                .c => 16,
+                else => 8,
+            },
 
             // Even LLVMABIAlignmentOfType(i128) agrees on these targets.
             .aarch64,
             .aarch64_be,
             .aarch64_32,
+            .riscv64,
             .bpfel,
             .bpfeb,
             .nvptx,

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1806,9 +1806,9 @@ pub const Target = struct {
                 else => 4,
             },
 
-            // For x86_64, LLVMABIAlignmentOfType(i128) reports 8. However I think 16
-            // is a better number for two reasons:
-            // 1. Better machine code when loading into SIMD register.
+            // For these, LLVMABIAlignmentOfType(i128) reports 8. Note that 16
+            // is a relevant number in three cases:
+            // 1. Different machine code instruction when loading into SIMD register.
             // 2. The C ABI wants 16 for extern structs.
             // 3. 16-byte cmpxchg needs 16-byte alignment.
             // Same logic for riscv64, powerpc64, mips64, sparc64.
@@ -1819,6 +1819,7 @@ pub const Target = struct {
             .mips64,
             .mips64el,
             .sparc64,
+            => 8,
 
             // Even LLVMABIAlignmentOfType(i128) agrees on these targets.
             .aarch64,

--- a/lib/std/zig/system/NativeTargetInfo.zig
+++ b/lib/std/zig/system/NativeTargetInfo.zig
@@ -276,6 +276,7 @@ fn detectAbiAndDynamicLinker(
     };
     var ld_info_list_buffer: [all_abis.len]LdInfo = undefined;
     var ld_info_list_len: usize = 0;
+    const ofmt = cross_target.ofmt orelse Target.ObjectFormat.default(os.tag, cpu.arch);
 
     for (all_abis) |abi| {
         // This may be a nonsensical parameter. We detect this with error.UnknownDynamicLinkerPath and
@@ -284,6 +285,7 @@ fn detectAbiAndDynamicLinker(
             .cpu = cpu,
             .os = os,
             .abi = abi,
+            .ofmt = ofmt,
         };
         const ld = target.standardDynamicLinkerPath();
         if (ld.get() == null) continue;
@@ -346,6 +348,7 @@ fn detectAbiAndDynamicLinker(
                 .cpu = cpu,
                 .os = os_adjusted,
                 .abi = cross_target.abi orelse found_ld_info.abi,
+                .ofmt = cross_target.ofmt orelse Target.ObjectFormat.default(os_adjusted.tag, cpu.arch),
             },
             .dynamic_linker = if (cross_target.dynamic_linker.get() == null)
                 DynamicLinker.init(found_ld_path)
@@ -539,6 +542,7 @@ pub fn abiAndDynamicLinkerFromFile(
             .cpu = cpu,
             .os = os,
             .abi = cross_target.abi orelse Target.Abi.default(cpu.arch, os),
+            .ofmt = cross_target.ofmt orelse Target.ObjectFormat.default(os.tag, cpu.arch),
         },
         .dynamic_linker = cross_target.dynamic_linker,
     };
@@ -829,6 +833,7 @@ fn defaultAbiAndDynamicLinker(cpu: Target.Cpu, os: Target.Os, cross_target: Cros
         .cpu = cpu,
         .os = os,
         .abi = cross_target.abi orelse Target.Abi.default(cpu.arch, os),
+        .ofmt = cross_target.ofmt orelse Target.ObjectFormat.default(os.tag, cpu.arch),
     };
     return NativeTargetInfo{
         .target = target,

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -935,12 +935,32 @@ pub const Struct = struct {
         /// If true then `default_val` is the comptime field value.
         is_comptime: bool,
 
-        /// Returns the field alignment, assuming the struct is not packed.
-        pub fn normalAlignment(field: Field, target: Target) u32 {
-            if (field.abi_align == 0) {
-                return field.ty.abiAlignment(target);
-            } else {
+        /// Returns the field alignment. If the struct is packed, returns 0.
+        pub fn alignment(
+            field: Field,
+            target: Target,
+            layout: std.builtin.Type.ContainerLayout,
+        ) u32 {
+            if (field.abi_align != 0) {
+                assert(layout != .Packed);
                 return field.abi_align;
+            }
+
+            switch (layout) {
+                .Packed => return 0,
+                .Auto => return field.ty.abiAlignment(target),
+                .Extern => {
+                    // This logic is duplicated in Type.abiAlignmentAdvanced.
+                    const ty_abi_align = field.ty.abiAlignment(target);
+
+                    if (field.ty.isAbiInt() and field.ty.intInfo(target).bits >= 128) {
+                        // The C ABI requires 128 bit integer fields of structs
+                        // to be 16-bytes aligned.
+                        return @maximum(ty_abi_align, 16);
+                    }
+
+                    return ty_abi_align;
+                },
             }
         }
     };

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -14380,10 +14380,7 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
                     else
                         field.default_val;
                     const default_val_ptr = try sema.optRefValue(block, src, field.ty, opt_default_val);
-                    const alignment = switch (layout) {
-                        .Auto, .Extern => field.normalAlignment(target),
-                        .Packed => 0,
-                    };
+                    const alignment = field.alignment(target, layout);
 
                     struct_field_fields.* = .{
                         // name: []const u8,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -20654,7 +20654,7 @@ fn panicWithMsg(
     const arena = sema.arena;
 
     const this_feature_is_implemented_in_the_backend =
-        mod.comp.bin_file.options.object_format == .c or
+        mod.comp.bin_file.options.target.ofmt == .c or
         mod.comp.bin_file.options.use_llvm;
     if (!this_feature_is_implemented_in_the_backend) {
         // TODO implement this feature in all the backends and then delete this branch

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2500,7 +2500,7 @@ pub const DeclGen = struct {
 
     fn lowerType(dg: *DeclGen, t: Type) Allocator.Error!*const llvm.Type {
         const llvm_ty = try lowerTypeInner(dg, t);
-        if (std.debug.runtime_safety) check: {
+        if (std.debug.runtime_safety and false) check: {
             if (t.zigTypeTag() == .Opaque) break :check;
             if (!t.hasRuntimeBits()) break :check;
             if (!llvm_ty.isSized().toBool()) break :check;

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1841,6 +1841,7 @@ pub const Object = struct {
                 }
 
                 const fields = ty.structFields();
+                const layout = ty.containerLayout();
 
                 var di_fields: std.ArrayListUnmanaged(*llvm.DIType) = .{};
                 defer di_fields.deinit(gpa);
@@ -1854,7 +1855,7 @@ pub const Object = struct {
                     if (field.is_comptime or !field.ty.hasRuntimeBitsIgnoreComptime()) continue;
 
                     const field_size = field.ty.abiSize(target);
-                    const field_align = field.normalAlignment(target);
+                    const field_align = field.alignment(target, layout);
                     const field_offset = std.mem.alignForwardGeneric(u64, offset, field_align);
                     offset = field_offset + field_size;
 
@@ -2499,7 +2500,7 @@ pub const DeclGen = struct {
 
     fn lowerType(dg: *DeclGen, t: Type) Allocator.Error!*const llvm.Type {
         const llvm_ty = try lowerTypeInner(dg, t);
-        if (std.debug.runtime_safety and false) check: {
+        if (std.debug.runtime_safety) check: {
             if (t.zigTypeTag() == .Opaque) break :check;
             if (!t.hasRuntimeBits()) break :check;
             if (!llvm_ty.isSized().toBool()) break :check;
@@ -2757,7 +2758,7 @@ pub const DeclGen = struct {
                 for (struct_obj.fields.values()) |field| {
                     if (field.is_comptime or !field.ty.hasRuntimeBitsIgnoreComptime()) continue;
 
-                    const field_align = field.normalAlignment(target);
+                    const field_align = field.alignment(target, struct_obj.layout);
                     const field_ty_align = field.ty.abiAlignment(target);
                     any_underaligned_fields = any_underaligned_fields or
                         field_align < field_ty_align;
@@ -3433,7 +3434,7 @@ pub const DeclGen = struct {
                 for (struct_obj.fields.values()) |field, i| {
                     if (field.is_comptime or !field.ty.hasRuntimeBitsIgnoreComptime()) continue;
 
-                    const field_align = field.normalAlignment(target);
+                    const field_align = field.alignment(target, struct_obj.layout);
                     big_align = @maximum(big_align, field_align);
                     const prev_offset = offset;
                     offset = std.mem.alignForwardGeneric(u64, offset, field_align);
@@ -9376,13 +9377,14 @@ fn llvmFieldIndex(
         }
         return null;
     }
-    assert(ty.containerLayout() != .Packed);
+    const layout = ty.containerLayout();
+    assert(layout != .Packed);
 
     var llvm_field_index: c_uint = 0;
     for (ty.structFields().values()) |field, i| {
         if (field.is_comptime or !field.ty.hasRuntimeBitsIgnoreComptime()) continue;
 
-        const field_align = field.normalAlignment(target);
+        const field_align = field.alignment(target, layout);
         big_align = @maximum(big_align, field_align);
         const prev_offset = offset;
         offset = std.mem.alignForwardGeneric(u64, offset, field_align);

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -273,7 +273,7 @@ pub const Object = struct {
         var di_compile_unit: ?*llvm.DICompileUnit = null;
 
         if (!options.strip) {
-            switch (options.object_format) {
+            switch (options.target.ofmt) {
                 .coff => llvm_module.addModuleCodeViewFlag(),
                 else => llvm_module.addModuleDebugInfoFlag(),
             }

--- a/src/link.zig
+++ b/src/link.zig
@@ -72,7 +72,6 @@ pub const Options = struct {
     target: std.Target,
     output_mode: std.builtin.OutputMode,
     link_mode: std.builtin.LinkMode,
-    object_format: std.Target.ObjectFormat,
     optimize_mode: std.builtin.Mode,
     machine_code_model: std.builtin.CodeModel,
     root_name: [:0]const u8,
@@ -273,13 +272,13 @@ pub const File = struct {
     /// rewriting it. A malicious file is detected as incremental link failure
     /// and does not cause Illegal Behavior. This operation is not atomic.
     pub fn openPath(allocator: Allocator, options: Options) !*File {
-        if (options.object_format == .macho) {
+        if (options.target.ofmt == .macho) {
             return &(try MachO.openPath(allocator, options)).base;
         }
 
         const use_stage1 = build_options.is_stage1 and options.use_stage1;
         if (use_stage1 or options.emit == null) {
-            return switch (options.object_format) {
+            return switch (options.target.ofmt) {
                 .coff => &(try Coff.createEmpty(allocator, options)).base,
                 .elf => &(try Elf.createEmpty(allocator, options)).base,
                 .macho => unreachable,
@@ -298,7 +297,7 @@ pub const File = struct {
             if (options.module == null) {
                 // No point in opening a file, we would not write anything to it.
                 // Initialize with empty.
-                return switch (options.object_format) {
+                return switch (options.target.ofmt) {
                     .coff => &(try Coff.createEmpty(allocator, options)).base,
                     .elf => &(try Elf.createEmpty(allocator, options)).base,
                     .macho => unreachable,
@@ -314,12 +313,12 @@ pub const File = struct {
             // Open a temporary object file, not the final output file because we
             // want to link with LLD.
             break :blk try std.fmt.allocPrint(allocator, "{s}{s}", .{
-                emit.sub_path, options.object_format.fileExt(options.target.cpu.arch),
+                emit.sub_path, options.target.ofmt.fileExt(options.target.cpu.arch),
             });
         } else emit.sub_path;
         errdefer if (use_lld) allocator.free(sub_path);
 
-        const file: *File = switch (options.object_format) {
+        const file: *File = switch (options.target.ofmt) {
             .coff => &(try Coff.openPath(allocator, sub_path, options)).base,
             .elf => &(try Elf.openPath(allocator, sub_path, options)).base,
             .macho => unreachable,

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -48,7 +48,7 @@ const DeclBlock = struct {
 };
 
 pub fn openPath(gpa: Allocator, sub_path: []const u8, options: link.Options) !*C {
-    assert(options.object_format == .c);
+    assert(options.target.ofmt == .c);
 
     if (options.use_llvm) return error.LLVMHasNoCBackend;
     if (options.use_lld) return error.LLDHasNoCBackend;

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -128,7 +128,7 @@ pub const TextBlock = struct {
 pub const SrcFn = void;
 
 pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Options) !*Coff {
-    assert(options.object_format == .coff);
+    assert(options.target.ofmt == .coff);
 
     if (build_options.have_llvm and options.use_llvm) {
         return createEmpty(allocator, options);

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -249,7 +249,7 @@ pub const Export = struct {
 };
 
 pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Options) !*Elf {
-    assert(options.object_format == .elf);
+    assert(options.target.ofmt == .elf);
 
     if (build_options.have_llvm and options.use_llvm) {
         return createEmpty(allocator, options);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -270,7 +270,7 @@ pub const Export = struct {
 };
 
 pub fn openPath(allocator: Allocator, options: link.Options) !*MachO {
-    assert(options.object_format == .macho);
+    assert(options.target.ofmt == .macho);
 
     const use_stage1 = build_options.is_stage1 and options.use_stage1;
     if (use_stage1 or options.emit == null) {
@@ -289,7 +289,7 @@ pub fn openPath(allocator: Allocator, options: link.Options) !*MachO {
         // we also want to put the intermediary object file in the cache while the
         // main emit directory is the cwd.
         self.base.intermediary_basename = try std.fmt.allocPrint(allocator, "{s}{s}", .{
-            emit.sub_path, options.object_format.fileExt(options.target.cpu.arch),
+            emit.sub_path, options.target.ofmt.fileExt(options.target.cpu.arch),
         });
     }
 

--- a/src/link/NvPtx.zig
+++ b/src/link/NvPtx.zig
@@ -57,7 +57,7 @@ pub fn createEmpty(gpa: Allocator, options: link.Options) !*NvPtx {
 pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Options) !*NvPtx {
     if (!build_options.have_llvm) @panic("nvptx target requires a zig compiler with llvm enabled.");
     if (!options.use_llvm) return error.PtxArchNotSupported;
-    assert(options.object_format == .nvptx);
+    assert(options.target.ofmt == .nvptx);
 
     const nvptx = try createEmpty(allocator, options);
     log.info("Opening .ptx target file {s}", .{sub_path});

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -657,7 +657,7 @@ pub const base_tag = .plan9;
 pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Options) !*Plan9 {
     if (options.use_llvm)
         return error.LLVMBackendDoesNotSupportPlan9;
-    assert(options.object_format == .plan9);
+    assert(options.target.ofmt == .plan9);
 
     const self = try createEmpty(allocator, options);
     errdefer self.base.destroy();

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -99,7 +99,7 @@ pub fn createEmpty(gpa: Allocator, options: link.Options) !*SpirV {
 }
 
 pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Options) !*SpirV {
-    assert(options.object_format == .spirv);
+    assert(options.target.ofmt == .spirv);
 
     if (options.use_llvm) return error.LLVM_BackendIsTODO_ForSpirV; // TODO: LLVM Doesn't support SpirV at all.
     if (options.use_lld) return error.LLD_LinkingIsTODO_ForSpirV; // TODO: LLD Doesn't support SpirV at all.

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -282,7 +282,7 @@ pub const StringTable = struct {
 };
 
 pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Options) !*Wasm {
-    assert(options.object_format == .wasm);
+    assert(options.target.ofmt == .wasm);
 
     if (build_options.have_llvm and options.use_llvm) {
         return createEmpty(allocator, options);

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -10082,6 +10082,7 @@ Buf *codegen_generate_builtin_source(CodeGen *g) {
         "    .cpu = cpu,\n"
         "    .os = os,\n"
         "    .abi = abi,\n"
+        "    .ofmt = object_format,\n"
         "};\n"
     );
 

--- a/src/type.zig
+++ b/src/type.zig
@@ -2374,6 +2374,18 @@ pub const Type = extern union {
             .error_union,
             .error_set,
             .error_set_merged,
+            .anyframe_T,
+            .optional_single_mut_pointer,
+            .optional_single_const_pointer,
+            .single_const_pointer,
+            .single_mut_pointer,
+            .many_const_pointer,
+            .many_mut_pointer,
+            .c_const_pointer,
+            .c_mut_pointer,
+            .const_slice,
+            .mut_slice,
+            .pointer,
             => return true,
 
             // These are false because they are comptime-only types.
@@ -2398,30 +2410,6 @@ pub const Type = extern union {
             .fn_naked_noreturn_no_args,
             .fn_ccc_void_no_args,
             => return false,
-
-            // These types have more than one possible value, so the result is the same as
-            // asking whether they are comptime-only types.
-            .anyframe_T,
-            .optional_single_mut_pointer,
-            .optional_single_const_pointer,
-            .single_const_pointer,
-            .single_mut_pointer,
-            .many_const_pointer,
-            .many_mut_pointer,
-            .c_const_pointer,
-            .c_mut_pointer,
-            .const_slice,
-            .mut_slice,
-            .pointer,
-            => {
-                if (ignore_comptime_only) {
-                    return true;
-                } else if (sema_kit) |sk| {
-                    return !(try sk.sema.typeRequiresComptime(sk.block, sk.src, ty));
-                } else {
-                    return !comptimeOnly(ty);
-                }
-            },
 
             .optional => {
                 var buf: Payload.ElemType = undefined;

--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -143,6 +143,19 @@ test "alignment and size of structs with 128-bit fields" {
         .riscv64,
         .sparc64,
         .x86_64,
+        => .{
+            .a_align = 8,
+            .a_size = 16,
+
+            .b_align = 16,
+            .b_size = 32,
+
+            .u128_align = 8,
+            .u128_size = 16,
+            .u129_align = 8,
+            .u129_size = 24,
+        },
+
         .aarch64,
         .aarch64_be,
         .aarch64_32,
@@ -166,17 +179,17 @@ test "alignment and size of structs with 128-bit fields" {
         else => return error.SkipZigTest,
     };
     comptime {
-        std.debug.assert(@alignOf(A) == expected.a_align);
-        std.debug.assert(@sizeOf(A) == expected.a_size);
+        assert(@alignOf(A) == expected.a_align);
+        assert(@sizeOf(A) == expected.a_size);
 
-        std.debug.assert(@alignOf(B) == expected.b_align);
-        std.debug.assert(@sizeOf(B) == expected.b_size);
+        assert(@alignOf(B) == expected.b_align);
+        assert(@sizeOf(B) == expected.b_size);
 
-        std.debug.assert(@alignOf(u128) == expected.u128_align);
-        std.debug.assert(@sizeOf(u128) == expected.u128_size);
+        assert(@alignOf(u128) == expected.u128_align);
+        assert(@sizeOf(u128) == expected.u128_size);
 
-        std.debug.assert(@alignOf(u129) == expected.u129_align);
-        std.debug.assert(@sizeOf(u129) == expected.u129_size);
+        assert(@alignOf(u129) == expected.u129_align);
+        assert(@sizeOf(u129) == expected.u129_size);
     }
 }
 

--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -100,8 +100,8 @@ test "alignment and size of structs with 128-bit fields" {
             .a_align = 8,
             .a_size = 16,
 
-            .b_align = 8,
-            .b_size = 24,
+            .b_align = 16,
+            .b_size = 32,
 
             .u128_align = 8,
             .u128_size = 16,
@@ -114,8 +114,8 @@ test "alignment and size of structs with 128-bit fields" {
                 .a_align = 8,
                 .a_size = 16,
 
-                .b_align = 8,
-                .b_size = 24,
+                .b_align = 16,
+                .b_size = 32,
 
                 .u128_align = 8,
                 .u128_size = 16,
@@ -126,8 +126,8 @@ test "alignment and size of structs with 128-bit fields" {
                 .a_align = 4,
                 .a_size = 16,
 
-                .b_align = 4,
-                .b_size = 20,
+                .b_align = 16,
+                .b_size = 32,
 
                 .u128_align = 4,
                 .u128_size = 16,
@@ -140,25 +140,39 @@ test "alignment and size of structs with 128-bit fields" {
         .mips64el,
         .powerpc64,
         .powerpc64le,
-        .riscv64,
         .sparc64,
         .x86_64,
-        => .{
-            .a_align = 8,
-            .a_size = 16,
+        => switch (builtin.object_format) {
+            .c => .{
+                .a_align = 16,
+                .a_size = 16,
 
-            .b_align = 16,
-            .b_size = 32,
+                .b_align = 16,
+                .b_size = 32,
 
-            .u128_align = 8,
-            .u128_size = 16,
-            .u129_align = 8,
-            .u129_size = 24,
+                .u128_align = 16,
+                .u128_size = 16,
+                .u129_align = 16,
+                .u129_size = 32,
+            },
+            else => .{
+                .a_align = 8,
+                .a_size = 16,
+
+                .b_align = 16,
+                .b_size = 32,
+
+                .u128_align = 8,
+                .u128_size = 16,
+                .u129_align = 8,
+                .u129_size = 24,
+            },
         },
 
         .aarch64,
         .aarch64_be,
         .aarch64_32,
+        .riscv64,
         .bpfel,
         .bpfeb,
         .nvptx,


### PR DESCRIPTION
Continuation of #12127. After this branch, there are no more instances of disagreements between LLVM ABI size and Zig ABI size when building stage3. However, it did not solve #11450.

The remaining ABI size mismatches that happen during behavior tests are:

```
error(codegen): when lowering behavior.ptrcast.testReinterpretExternStructAsExternStruct.S2, Zig ABI size = 6 but LLVM ABI size = 8
error(codegen): when lowering behavior.ptrcast.test.lower reinterpreted comptime field ptr (with under-aligned fields).S, Zig ABI size = 6 but LLVM ABI size = 8
error(codegen): when lowering builtin.Type.Fn.Param, Zig ABI size = 2 but LLVM ABI size = 3
error(codegen): when lowering [2]builtin.Type.Fn.Param, Zig ABI size = 4 but LLVM ABI size = 6
```