### PR TITLE
PriorityQueue: use compareFn in update()

### DIFF
--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -219,7 +219,12 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
         }
 
         pub fn update(self: *Self, elem: T, new_elem: T) !void {
-            var update_index: usize = std.mem.indexOfScalar(T, self.items[0..self.len], elem) orelse return error.ElementNotFound;
+            const update_index = blk: {
+                for (self.items) |item, idx| {
+                    if (compareFn(self.context, item, elem).compare(.eq)) break :blk idx;
+                }
+                return error.ElementNotFound;
+            };
             const old_elem: T = self.items[update_index];
             self.items[update_index] = new_elem;
             switch (compareFn(self.context, new_elem, old_elem)) {


### PR DESCRIPTION
update() calls mem.indexOfScalar() which uses `==` for comparing items,
which fails when the operator is not supported.
As PirorityQueue needs a comparing function anyway we can use `.eq` results
to identify matching objects.

closes #9918