### PR TITLE
std.math bound big.int.Managed::sqr() allocation more tightly

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -2960,7 +2960,7 @@ pub const Managed = struct {
 
     /// r = a * a
     pub fn sqr(rma: *Managed, a: *const Managed) !void {
-        const needed_limbs = 2 * a.limbs.len + 1;
+        const needed_limbs = 2 * a.len() + 1;
 
         if (rma.limbs.ptr == a.limbs.ptr) {
             var m = try Managed.initCapacity(rma.allocator, needed_limbs);


### PR DESCRIPTION
Running this kind of calculation (adapted from iguanaTLS) resulted in OOM errors
```
    // encrypted = signature ^ key.exponent MOD key.modulus
    while (curr_exponent.toConst().orderAgainstScalar(0) == .gt) {
        if (curr_exponent.isOdd()) {
            try result.mul(&result, &curr_base);
            try llmod(&result, modulus);
        }
        try curr_base.sqr(&curr_base);
        try llmod(&curr_base, modulus);
        try curr_exponent.shiftRight(&curr_exponent, 1);
    }
```
Bounding the allocation size of the result of sqr() to twice the used size (instead of twice the allocated size) avoids this issue.

Other similar functions in this file do allocation sizing based on `Managed::len()`. I think all allocation in this file should be done like this, but this is this is the most likely place it goes wrong.