### PR TITLE
macho: Pass sections by pointer when slicing names

### DIFF
--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -653,7 +653,7 @@ pub const segment_command_64 = extern struct {
     nsects: u32 = 0,
     flags: u32 = 0,
 
-    pub fn segName(seg: segment_command_64) []const u8 {
+    pub fn segName(seg: *const segment_command_64) []const u8 {
         return parseName(&seg.segname);
     }
 };
@@ -772,11 +772,11 @@ pub const section_64 = extern struct {
     /// reserved
     reserved3: u32 = 0,
 
-    pub fn sectName(sect: section_64) []const u8 {
+    pub fn sectName(sect: *const section_64) []const u8 {
         return parseName(&sect.sectname);
     }
 
-    pub fn segName(sect: section_64) []const u8 {
+    pub fn segName(sect: *const section_64) []const u8 {
         return parseName(&sect.segname);
     }
 


### PR DESCRIPTION
Thought these were fishy in the debug(link) logs:
```
debug(link): putting section ' ,@"���' as an Atom
debug(link): putting section ' ,@"���' as an Atom
...
debug(link):  ,81��� => size: 0x18, alignment: 0x3
debug(link):  ,81��� => size: 0x980, alignment: 0x4
... etc.
```

Turns out, we were accidentally returning a pointer to a parameter - Stage 1 just happened to pass the parameter by reference.

One more stepping stone for #12111