### PR TITLE
build.zig: teach `--compress-debug-sections`

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -1474,6 +1474,8 @@ pub const LibExeObjStep = struct {
     major_only_filename: ?[]const u8,
     name_only_filename: ?[]const u8,
     strip: bool,
+    // keep in sync with src/link.zig:CompressDebugSections
+    compress_debug_sections: enum { none, zlib } = .none,
     lib_paths: ArrayList([]const u8),
     rpaths: ArrayList([]const u8),
     framework_dirs: ArrayList([]const u8),
@@ -2688,6 +2690,12 @@ pub const LibExeObjStep = struct {
         if (self.strip) {
             try zig_args.append("--strip");
         }
+
+        switch (self.compress_debug_sections) {
+            .none => {},
+            .zlib => try zig_args.append("--compress-debug-sections=zlib"),
+        }
+
         if (self.link_eh_frame_hdr) {
             try zig_args.append("--eh-frame-hdr");
         }


### PR DESCRIPTION
build.zig: teach `--compress-debug-sections`

Now that #11863 is landed, let's expose it to the zig programs that
build stuff via `build.zig`. "Benchmarks" with [turbonss](https://git.sr.ht/~motiejus/turbonss):

Built with:

    $ zig build -Dtarget=x86_64-linux-gnu.2.19 -Dcpu=x86_64_v3 -Drelease-small=true

*Debug, uncompressed*

    174K turbonss-analyze
    161K turbonss-getent
    1.2M turbonss-unix2db
    448K libnss_turbo.so.2.0.0

*Debug, compressed*

     78K turbonss-analyze
     86K turbonss-getent
    572K turbonss-unix2db
    190K libnss_turbo.so.2.0.0

*Stripped, for completeness*

     17K turbonss-analyze
     20K turbonss-getent
    197K turbonss-unix2db
     26K libnss_turbo.so.2.0.0

I am copying the struct, because that seems to be the precedent. E.g. enum `"link.zig".SystemLib` is copied in `lib/std/build.zig`, but not put to a place where both `lib/std/build.zig` and `src/link.zig` can reach. If you you think that's a bad idea, tell me where to put it and I can refactor it.