### PR TITLE
stage2 llvm: fix handling of pointer fields in packed structs

### DIFF
--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -421,16 +421,17 @@ test "load pointer from packed struct" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
-    const Symbol = struct {
+    const A = struct {
         index: u16,
     };
-    const Relocation = packed struct {
-        symbol: *Symbol,
-        a: u32,
+    const B = packed struct {
+        x: *A,
+        y: u32,
     };
-    var a: []Relocation = &.{};
-    for (a) |rela| {
-        var b = rela.symbol.index;
-        _ = b;
+    var a: A = .{ .index = 123 };
+    var b_list: []B = &.{.{ .x = &a, .y = 99 }};
+    for (b_list) |b| {
+        var i = b.x.index;
+        try expect(i == 123);
     }
 }

--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -413,3 +413,24 @@ test "byte-aligned field pointer offsets" {
     try S.doTheTest();
     comptime try S.doTheTest();
 }
+
+test "load pointer from packed struct" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+
+    const Symbol = struct {
+        index: u16,
+    };
+    const Relocation = packed struct {
+        symbol: *Symbol,
+        a: u32,
+    };
+    var a: []Relocation = &.{};
+    for (a) |rela| {
+        var b = rela.symbol.index;
+        _ = b;
+    }
+}


### PR DESCRIPTION
This makes [Aro](https://github.com/Vexu/arocc) pass all tests with #11798 worked around and  #11867 applied.