### PR TITLE
stage2: implement `noinline fn`

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -1274,6 +1274,7 @@ fn fnProtoExpr(
         .is_inferred_error = false,
         .is_test = false,
         .is_extern = false,
+        .is_noinline = false,
         .noalias_bits = noalias_bits,
     });
 
@@ -3389,7 +3390,6 @@ fn fnDecl(
     };
     defer fn_gz.unstack();
 
-    // TODO: support noinline
     const is_pub = fn_proto.visib_token != null;
     const is_export = blk: {
         const maybe_export_token = fn_proto.extern_export_inline_token orelse break :blk false;
@@ -3402,6 +3402,10 @@ fn fnDecl(
     const has_inline_keyword = blk: {
         const maybe_inline_token = fn_proto.extern_export_inline_token orelse break :blk false;
         break :blk token_tags[maybe_inline_token] == .keyword_inline;
+    };
+    const is_noinline = blk: {
+        const maybe_noinline_token = fn_proto.extern_export_inline_token orelse break :blk false;
+        break :blk token_tags[maybe_noinline_token] == .keyword_noinline;
     };
 
     const doc_comment_index = try astgen.docCommentAsString(fn_proto.firstToken());
@@ -3610,6 +3614,7 @@ fn fnDecl(
             .is_inferred_error = false,
             .is_test = false,
             .is_extern = true,
+            .is_noinline = is_noinline,
             .noalias_bits = noalias_bits,
         });
     } else func: {
@@ -3658,6 +3663,7 @@ fn fnDecl(
             .is_inferred_error = is_inferred_error,
             .is_test = false,
             .is_extern = false,
+            .is_noinline = is_noinline,
             .noalias_bits = noalias_bits,
         });
     };
@@ -4093,6 +4099,7 @@ fn testDecl(
         .is_inferred_error = true,
         .is_test = true,
         .is_extern = false,
+        .is_noinline = false,
         .noalias_bits = 0,
     });
 
@@ -10170,6 +10177,7 @@ const GenZir = struct {
         is_inferred_error: bool,
         is_test: bool,
         is_extern: bool,
+        is_noinline: bool,
     }) !Zir.Inst.Ref {
         assert(args.src_node != 0);
         const astgen = gz.astgen;
@@ -10211,10 +10219,9 @@ const GenZir = struct {
         }
         const body_len = astgen.countBodyLenAfterFixups(body);
 
-        if (args.cc_ref != .none or args.lib_name != 0 or
-            args.is_var_args or args.is_test or args.is_extern or
-            args.align_ref != .none or args.section_ref != .none or
-            args.addrspace_ref != .none or args.noalias_bits != 0)
+        if (args.cc_ref != .none or args.lib_name != 0 or args.is_var_args or args.is_test or
+            args.is_extern or args.align_ref != .none or args.section_ref != .none or
+            args.addrspace_ref != .none or args.noalias_bits != 0 or args.is_noinline)
         {
             var align_body: []Zir.Inst.Index = &.{};
             var addrspace_body: []Zir.Inst.Index = &.{};
@@ -10247,6 +10254,7 @@ const GenZir = struct {
                     .is_inferred_error = args.is_inferred_error,
                     .is_test = args.is_test,
                     .is_extern = args.is_extern,
+                    .is_noinline = args.is_noinline,
                     .has_lib_name = args.lib_name != 0,
                     .has_any_noalias = args.noalias_bits != 0,
 

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1488,7 +1488,7 @@ pub const Fn = struct {
     branch_quota: u32,
     state: Analysis,
     is_cold: bool = false,
-    is_noinline: bool = false,
+    is_noinline: bool,
     calls_or_awaits_errorable_fn: bool = false,
 
     /// Any inferred error sets that this function owns, both its own inferred error set and

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7557,7 +7557,7 @@ fn funcCommon(
         }
 
         if (cc_workaround == .Inline and is_noinline) {
-            return sema.fail(block, cc_src, "callconv(.Inline) and noinline are incompatible together", .{});
+            return sema.fail(block, cc_src, "'noinline' function cannot have callconv 'Inline'", .{});
         }
 
         break :fn_ty try Type.Tag.function.create(sema.arena, .{

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2731,6 +2731,7 @@ pub const Inst = struct {
             is_inferred_error: bool,
             is_test: bool,
             is_extern: bool,
+            is_noinline: bool,
             has_align_ref: bool,
             has_align_body: bool,
             has_addrspace_ref: bool,
@@ -2743,7 +2744,7 @@ pub const Inst = struct {
             has_ret_ty_body: bool,
             has_lib_name: bool,
             has_any_noalias: bool,
-            _: u16 = undefined,
+            _: u15 = undefined,
         };
     };
 

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -699,6 +699,12 @@ pub const Object = struct {
             DeclGen.removeFnAttr(llvm_func, "cold");
         }
 
+        if (func.is_noinline) {
+            dg.addFnAttr(llvm_func, "noinline");
+        } else {
+            DeclGen.removeFnAttr(llvm_func, "noinline");
+        }
+
         // Remove all the basic blocks of a function in order to start over, generating
         // LLVM IR from an empty function body.
         while (llvm_func.getFirstBasicBlock()) |bb| {

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -1983,6 +1983,7 @@ const Writer = struct {
             inferred_error_set,
             false,
             false,
+            false,
 
             .none,
             &.{},
@@ -2090,6 +2091,7 @@ const Writer = struct {
             extra.data.bits.is_inferred_error,
             extra.data.bits.is_var_args,
             extra.data.bits.is_extern,
+            extra.data.bits.is_noinline,
             align_ref,
             align_body,
             addrspace_ref,
@@ -2249,6 +2251,7 @@ const Writer = struct {
         inferred_error_set: bool,
         var_args: bool,
         is_extern: bool,
+        is_noinline: bool,
         align_ref: Zir.Inst.Ref,
         align_body: []const Zir.Inst.Index,
         addrspace_ref: Zir.Inst.Ref,
@@ -2272,6 +2275,7 @@ const Writer = struct {
         try self.writeFlag(stream, "vargs, ", var_args);
         try self.writeFlag(stream, "extern, ", is_extern);
         try self.writeFlag(stream, "inferror, ", inferred_error_set);
+        try self.writeFlag(stream, "noinline, ", is_noinline);
 
         if (noalias_bits != 0) {
             try stream.print("noalias=0b{b}, ", .{noalias_bits});

--- a/test/cases/compile_errors/noinline_fn_cc_inline.zig
+++ b/test/cases/compile_errors/noinline_fn_cc_inline.zig
@@ -1,0 +1,12 @@
+const cc = .Inline;
+noinline fn foo() callconv(cc) void {}
+
+comptime {
+    _ = foo;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:28: error: 'noinline' function cannot have callconv 'Inline'


### PR DESCRIPTION
Fixes #11767

```zig
test {
    foo();
}

noinline fn foo() void {
    //
}
```

```
[meg@nixos:~/dev/zig]$ ./zig-out/bin/zig ast-check -t test.zig 
# Source bytes:       55B
# Tokens:             16 (104B)
# AST Nodes:          9 (237B)
# Total ZIR bytes:    398B
# Instructions:       15 (135B)
# String Table Bytes: 7B
# Extra Data Items:   48 (192B)
%0 = extended(struct_decl(parent, Auto, {
  test line(0) hash(53b4e586ab7c73d53a2fda7c58ad19aa): %1 = block_inline({
    %9 = func_fancy(test, inferror, body={
      %2 = dbg_block_begin())
      %3 = dbg_stmt(2, 5)
      %4 = decl_val("foo") token_offset:2:5 to :2:8
      %5 = dbg_stmt(2, 8)
      %7 = dbg_block_end())
      %6 = call(nodiscard .auto, %4, []) node_offset:2:5 to :2:10
      %8 = ret_tok(@Zir.Inst.Ref.void_value) token_offset:3:1 to :3:2
    }) (lbrace=1:6,rbrace=3:1) node_offset:1:1 to :1:5
    %10 = break_inline(%1, %9)
  }) node_offset:1:1 to :1:5
  [40] foo line(4) hash(f3339e121db838fc9d98c7412345a9c5): %11 = block_inline({
    %13 = func_fancy(noinline, body={
      %12 = ret_tok(@Zir.Inst.Ref.void_value) token_offset:7:1 to :7:2
    }) (lbrace=1:24,rbrace=3:1) node_offset:5:1 to :5:12
    %14 = break_inline(%11, %13)
  }) node_offset:5:1 to :5:23
}, {}, {})
```

```ll
<snip>

; Function Attrs: noinline nounwind
define internal fastcc void @test.foo() unnamed_addr #0 !dbg !4183 {
Entry:
  ret void
}

<snip>
```

Full `.ll` log: https://clbin.com/ztvi5