### PR TITLE
stage2: llvm - Implement C ABI when targetting wasm32

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -484,7 +484,20 @@ pub fn build(b: *Builder) !void {
     ));
 
     toolchain_step.dependOn(tests.addCompareOutputTests(b, test_filter, modes));
-    toolchain_step.dependOn(tests.addStandaloneTests(b, test_filter, modes, skip_non_native, enable_macos_sdk, target, omit_stage2));
+    toolchain_step.dependOn(tests.addStandaloneTests(
+        b,
+        test_filter,
+        modes,
+        skip_non_native,
+        enable_macos_sdk,
+        target,
+        omit_stage2,
+        b.enable_darling,
+        b.enable_qemu,
+        b.enable_rosetta,
+        b.enable_wasmtime,
+        b.enable_wine,
+    ));
     toolchain_step.dependOn(tests.addLinkTests(b, test_filter, modes, enable_macos_sdk, omit_stage2));
     toolchain_step.dependOn(tests.addStackTraceTests(b, test_filter, modes));
     toolchain_step.dependOn(tests.addCliTests(b, test_filter, modes));

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1674,7 +1674,7 @@ fn airRet(self: *Self, inst: Air.Inst.Index) InnerError!WValue {
                 try self.emitWValue(operand);
                 const opcode = buildOpcode(.{
                     .op = .load,
-                    .width = @intCast(u8, scalar_type.abiSize(self.target)),
+                    .width = @intCast(u8, scalar_type.abiSize(self.target) * 8),
                     .signedness = if (scalar_type.isSignedInt()) .signed else .unsigned,
                     .valtype1 = typeToValtype(scalar_type, self.target),
                 });

--- a/src/arch/wasm/abi.zig
+++ b/src/arch/wasm/abi.zig
@@ -48,38 +48,20 @@ pub fn classifyType(ty: Type, target: Target) [2]Class {
         },
         .Bool => return direct,
         .Array => return memory,
-        // .ErrorUnion => {
-        //     const has_tag = ty.errorUnionSet().hasRuntimeBitsIgnoreComptime();
-        //     const has_pl = ty.errorUnionPayload().hasRuntimeBitsIgnoreComptime();
-        //     if (!has_pl) return direct;
-        //     if (!has_tag) {
-        //         return classifyType(ty.errorUnionPayload(), target);
-        //     }
-        //     return memory;
-        // },
         .Optional => {
             std.debug.assert(ty.isPtrLikeOptional());
             return direct;
-            // var buf: Type.Payload.ElemType = undefined;
-            // const pl_has_bits = ty.optionalChild(&buf).hasRuntimeBitsIgnoreComptime();
-            // if (!pl_has_bits) return direct;
-            // return memory;
         },
         .Pointer => {
-            // // Slices act like struct and will be passed by reference
-            // if (ty.isSlice()) return memory;
+            std.debug.assert(!ty.isSlice());
             return direct;
         },
         .Union => {
             const layout = ty.unionGetLayout(target);
             std.debug.assert(layout.tag_size == 0);
-            // if (layout.payload_size == 0 and layout.tag_size != 0) {
-            //     return classifyType(ty.unionTagType().?, target);
-            // }
             if (ty.unionFields().count() > 1) return memory;
             return classifyType(ty.unionFields().values()[0].ty, target);
         },
-        // .AnyFrame, .Frame => return direct,
         .ErrorUnion,
         .Frame,
         .AnyFrame,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -22,6 +22,7 @@ const Type = @import("../type.zig").Type;
 const LazySrcLoc = Module.LazySrcLoc;
 const CType = @import("../type.zig").CType;
 const x86_64_abi = @import("../arch/x86_64/abi.zig");
+const wasm_c_abi = @import("../arch/wasm/abi.zig");
 
 const Error = error{ OutOfMemory, CodegenFail };
 
@@ -9093,6 +9094,10 @@ fn firstParamSRet(fn_info: Type.Payload.Function.Data, target: std.Target) bool 
                 .windows => return x86_64_abi.classifyWindows(fn_info.return_type, target) == .memory,
                 else => return x86_64_abi.classifySystemV(fn_info.return_type, target)[0] == .memory,
             },
+            .wasm32 => {
+                const classes = wasm_c_abi.classifyType(fn_info.return_type, target);
+                return classes[0] == .indirect;
+            },
             else => return false, // TODO investigate C ABI for other architectures
         },
         else => return false,
@@ -9196,6 +9201,20 @@ fn lowerFnRetTy(dg: *DeclGen, fn_info: Type.Payload.Function.Data) !*const llvm.
                         }
                         return dg.context.structType(&llvm_types_buffer, llvm_types_index, .False);
                     },
+                },
+                .wasm32 => {
+                    if (is_scalar) {
+                        return dg.lowerType(fn_info.return_type);
+                    }
+                    const classes = wasm_c_abi.classifyType(fn_info.return_type, target);
+                    if (classes[0] == .indirect or classes[0] == .none) {
+                        return dg.context.voidType();
+                    }
+
+                    assert(classes[0] == .direct and classes[1] == .none);
+                    const scalar_type = wasm_c_abi.scalarType(fn_info.return_type, target);
+                    const abi_size = scalar_type.abiSize(target);
+                    return dg.context.intType(@intCast(c_uint, abi_size * 8));
                 },
                 // TODO investigate C ABI for other architectures
                 else => return dg.lowerType(fn_info.return_type),
@@ -9371,6 +9390,18 @@ const ParamTypeIterator = struct {
                             it.zig_index += 1;
                             return .multiple_llvm_ints;
                         },
+                    },
+                    .wasm32 => {
+                        it.zig_index += 1;
+                        it.llvm_index += 1;
+                        if (is_scalar) {
+                            return .byval;
+                        }
+                        const classes = wasm_c_abi.classifyType(ty, it.target);
+                        if (classes[0] == .indirect) {
+                            return .byref;
+                        }
+                        return .abi_sized_int;
                     },
                     // TODO investigate C ABI for other architectures
                     else => {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9094,10 +9094,7 @@ fn firstParamSRet(fn_info: Type.Payload.Function.Data, target: std.Target) bool 
                 .windows => return x86_64_abi.classifyWindows(fn_info.return_type, target) == .memory,
                 else => return x86_64_abi.classifySystemV(fn_info.return_type, target)[0] == .memory,
             },
-            .wasm32 => {
-                const classes = wasm_c_abi.classifyType(fn_info.return_type, target);
-                return classes[0] == .indirect;
-            },
+            .wasm32 => return wasm_c_abi.classifyType(fn_info.return_type, target)[0] == .indirect,
             else => return false, // TODO investigate C ABI for other architectures
         },
         else => return false,

--- a/test/stage1/c_abi/build_wasm.zig
+++ b/test/stage1/c_abi/build_wasm.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const rel_opts = b.standardReleaseOptions();
+    const target: std.zig.CrossTarget = .{ .cpu_arch = .wasm32, .os_tag = .wasi };
+    b.use_stage1 = false;
+
+    const c_obj = b.addObject("cfuncs", null);
+    c_obj.addCSourceFile("cfuncs.c", &[_][]const u8{"-std=c99"});
+    c_obj.setBuildMode(rel_opts);
+    c_obj.linkSystemLibrary("c");
+    c_obj.setTarget(target);
+
+    const main = b.addTest("main.zig");
+    main.setBuildMode(rel_opts);
+    main.addObject(c_obj);
+    main.setTarget(target);
+
+    const test_step = b.step("test", "Test the program");
+    test_step.dependOn(&main.step);
+
+    b.default_step.dependOn(test_step);
+}

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -41,6 +41,12 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     if (builtin.cpu.arch == .x86_64) {
         cases.addBuildFile("test/stage1/c_abi/build.zig", .{});
     }
+    // C ABI tests only pass for the Wasm target when using stage2
+    cases.addBuildFile("test/stage1/c_abi/build_wasm.zig", .{
+        .requires_stage2 = true,
+        .use_emulation = true,
+    });
+
     cases.addBuildFile("test/standalone/c_compiler/build.zig", .{
         .build_modes = true,
         .cross_targets = true,

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -463,6 +463,11 @@ pub fn addStandaloneTests(
     enable_macos_sdk: bool,
     target: std.zig.CrossTarget,
     omit_stage2: bool,
+    enable_darling: bool,
+    enable_qemu: bool,
+    enable_rosetta: bool,
+    enable_wasmtime: bool,
+    enable_wine: bool,
 ) *build.Step {
     const cases = b.allocator.create(StandaloneContext) catch unreachable;
     cases.* = StandaloneContext{
@@ -475,6 +480,11 @@ pub fn addStandaloneTests(
         .enable_macos_sdk = enable_macos_sdk,
         .target = target,
         .omit_stage2 = omit_stage2,
+        .enable_darling = enable_darling,
+        .enable_qemu = enable_qemu,
+        .enable_rosetta = enable_rosetta,
+        .enable_wasmtime = enable_wasmtime,
+        .enable_wine = enable_wine,
     };
 
     standalone.addCases(cases);
@@ -962,6 +972,11 @@ pub const StandaloneContext = struct {
     enable_macos_sdk: bool,
     target: std.zig.CrossTarget,
     omit_stage2: bool,
+    enable_darling: bool = false,
+    enable_qemu: bool = false,
+    enable_rosetta: bool = false,
+    enable_wasmtime: bool = false,
+    enable_wine: bool = false,
 
     pub fn addC(self: *StandaloneContext, root_src: []const u8) void {
         self.addAllArgs(root_src, true);
@@ -976,6 +991,7 @@ pub const StandaloneContext = struct {
         cross_targets: bool = false,
         requires_macos_sdk: bool = false,
         requires_stage2: bool = false,
+        use_emulation: bool = false,
     }) void {
         const b = self.b;
 
@@ -1005,6 +1021,24 @@ pub const StandaloneContext = struct {
             const target_triple = self.target.zigTriple(b.allocator) catch unreachable;
             const target_arg = fmt.allocPrint(b.allocator, "-Dtarget={s}", .{target_triple}) catch unreachable;
             zig_args.append(target_arg) catch unreachable;
+        }
+
+        if (features.use_emulation) {
+            if (self.enable_darling) {
+                zig_args.append("-fdarling") catch unreachable;
+            }
+            if (self.enable_qemu) {
+                zig_args.append("-fqemu") catch unreachable;
+            }
+            if (self.enable_rosetta) {
+                zig_args.append("-frosetta") catch unreachable;
+            }
+            if (self.enable_wasmtime) {
+                zig_args.append("-fwasmtime") catch unreachable;
+            }
+            if (self.enable_wine) {
+                zig_args.append("-fwine") catch unreachable;
+            }
         }
 
         const modes = if (features.build_modes) self.modes else &[1]Mode{.Debug};


### PR DESCRIPTION
This utilizes the same logic as what the Wasm backend uses, similar to what was done for x86_64. All the C ABI tests are now passing and are enabled for Wasm specifically when stage2 is enabled.
