### PR TITLE
macos: add /usr/local/* paths conditional on macOS major version

### DIFF
--- a/lib/std/zig/system/NativePaths.zig
+++ b/lib/std/zig/system/NativePaths.zig
@@ -84,13 +84,14 @@ pub fn detect(allocator: Allocator, native_info: NativeTargetInfo) !NativePaths 
 
     if (comptime builtin.target.isDarwin()) {
         try self.addIncludeDir("/usr/include");
-        try self.addIncludeDir("/usr/local/include");
-
         try self.addLibDir("/usr/lib");
-        try self.addLibDir("/usr/local/lib");
-
-        try self.addFrameworkDir("/Library/Frameworks");
         try self.addFrameworkDir("/System/Library/Frameworks");
+
+        if (builtin.target.os.version_range.semver.min.major < 11) {
+            try self.addIncludeDir("/usr/local/include");
+            try self.addLibDir("/usr/local/lib");
+            try self.addFrameworkDir("/Library/Frameworks");
+        }
 
         return self;
     }


### PR DESCRIPTION
`/usr/local/include`, `/usr/local/lib` and `/Library/Frameworks`
have been deprecated since approximately macOS 11, and so to avoid
redundant and misinformed warning messages generated by the linker,
add those dirs only when natively targeting macOS 10.x.x or below.

cc @andrewrk 