### PR TITLE
feat(std.fmt): reject more invalid type specifiers 

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7228,7 +7228,7 @@ pub fn print(self: *Writer, arg0: []const u8, arg1: i32) !void {
       <p>
       And now, what happens if we give too many arguments to {#syntax#}print{#endsyntax#}?
       </p>
-      {#code_begin|test_err|Unused argument in 'here is a string: '{s}' here is a number: {}#}
+      {#code_begin|test_err|unused argument in 'here is a string: '{s}' here is a number: {}#}
 const print = @import("std").debug.print;
 
 const a_number: i32 = 1234;

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -83,7 +83,7 @@ pub fn format(
     const ArgsType = @TypeOf(args);
     const args_type_info = @typeInfo(ArgsType);
     if (args_type_info != .Struct) {
-        @compileError("Expected tuple or struct argument, found " ++ @typeName(ArgsType));
+        @compileError("expected tuple or struct argument, found " ++ @typeName(ArgsType));
     }
 
     const fields_info = args_type_info.Struct.fields;
@@ -127,7 +127,7 @@ pub fn format(
         if (i >= fmt.len) break;
 
         if (fmt[i] == '}') {
-            @compileError("Missing opening {");
+            @compileError("missing opening {");
         }
 
         // Get past the {
@@ -140,7 +140,7 @@ pub fn format(
         const fmt_end = i;
 
         if (i >= fmt.len) {
-            @compileError("Missing closing }");
+            @compileError("missing closing }");
         }
 
         // Get past the }
@@ -152,7 +152,7 @@ pub fn format(
             .none => null,
             .number => |pos| pos,
             .named => |arg_name| meta.fieldIndex(ArgsType, arg_name) orelse
-                @compileError("No argument with name '" ++ arg_name ++ "'"),
+                @compileError("no argument with name '" ++ arg_name ++ "'"),
         };
 
         const width = switch (placeholder.width) {
@@ -160,8 +160,8 @@ pub fn format(
             .number => |v| v,
             .named => |arg_name| blk: {
                 const arg_i = comptime meta.fieldIndex(ArgsType, arg_name) orelse
-                    @compileError("No argument with name '" ++ arg_name ++ "'");
-                _ = comptime arg_state.nextArg(arg_i) orelse @compileError("Too few arguments");
+                    @compileError("no argument with name '" ++ arg_name ++ "'");
+                _ = comptime arg_state.nextArg(arg_i) orelse @compileError("too few arguments");
                 break :blk @field(args, arg_name);
             },
         };
@@ -171,14 +171,14 @@ pub fn format(
             .number => |v| v,
             .named => |arg_name| blk: {
                 const arg_i = comptime meta.fieldIndex(ArgsType, arg_name) orelse
-                    @compileError("No argument with name '" ++ arg_name ++ "'");
-                _ = comptime arg_state.nextArg(arg_i) orelse @compileError("Too few arguments");
+                    @compileError("no argument with name '" ++ arg_name ++ "'");
+                _ = comptime arg_state.nextArg(arg_i) orelse @compileError("too few arguments");
                 break :blk @field(args, arg_name);
             },
         };
 
         const arg_to_print = comptime arg_state.nextArg(arg_pos) orelse
-            @compileError("Too few arguments");
+            @compileError("too few arguments");
 
         try formatType(
             @field(args, fields_info[arg_to_print].name),
@@ -198,7 +198,7 @@ pub fn format(
         const missing_count = arg_state.args_len - @popCount(ArgSetType, arg_state.used_args);
         switch (missing_count) {
             0 => unreachable,
-            1 => @compileError("Unused argument in '" ++ fmt ++ "'"),
+            1 => @compileError("unused argument in '" ++ fmt ++ "'"),
             else => @compileError((comptime comptimePrint("{d}", .{missing_count})) ++ " unused arguments in '" ++ fmt ++ "'"),
         }
     }
@@ -217,7 +217,7 @@ fn parsePlaceholder(comptime str: anytype) Placeholder {
     // Skip the colon, if present
     if (comptime parser.char()) |ch| {
         if (ch != ':') {
-            @compileError("Expected : or }, found '" ++ [1]u8{ch} ++ "'");
+            @compileError("expected : or }, found '" ++ [1]u8{ch} ++ "'");
         }
     }
 
@@ -252,7 +252,7 @@ fn parsePlaceholder(comptime str: anytype) Placeholder {
     // Skip the dot, if present
     if (comptime parser.char()) |ch| {
         if (ch != '.') {
-            @compileError("Expected . or }, found '" ++ [1]u8{ch} ++ "'");
+            @compileError("expected . or }, found '" ++ [1]u8{ch} ++ "'");
         }
     }
 
@@ -261,7 +261,7 @@ fn parsePlaceholder(comptime str: anytype) Placeholder {
         @compileError(@errorName(err));
 
     if (comptime parser.char()) |ch| {
-        @compileError("Extraneous trailing character '" ++ [1]u8{ch} ++ "'");
+        @compileError("extraneous trailing character '" ++ [1]u8{ch} ++ "'");
     }
 
     return Placeholder{
@@ -423,7 +423,7 @@ pub fn formatAddress(value: anytype, options: FormatOptions, writer: anytype) @T
         else => {},
     }
 
-    @compileError("Cannot format non-pointer type " ++ @typeName(T) ++ " with * specifier");
+    @compileError("cannot format non-pointer type " ++ @typeName(T) ++ " with * specifier");
 }
 
 // This ANY const is a workaround for: https://github.com/ziglang/zig/issues/7948
@@ -608,7 +608,7 @@ pub fn formatType(
                         }
                         return;
                     }
-                    @compileError("Unknown format string: '" ++ actual_fmt ++ "' for type '" ++ @typeName(T) ++ "'");
+                    @compileError("unknown format string: '" ++ actual_fmt ++ "' for type '" ++ @typeName(T) ++ "'");
                 },
                 .Enum, .Union, .Struct => {
                     return formatType(value.*, actual_fmt, options, writer, max_depth);
@@ -630,7 +630,7 @@ pub fn formatType(
                         else => {},
                     }
                 }
-                @compileError("Unknown format string: '" ++ actual_fmt ++ "' for type '" ++ @typeName(T) ++ "'");
+                @compileError("unknown format string: '" ++ actual_fmt ++ "' for type '" ++ @typeName(T) ++ "'");
             },
             .Slice => {
                 if (actual_fmt.len == 0)
@@ -701,7 +701,7 @@ pub fn formatType(
             return formatBuf(buffer, options, writer);
         },
         .Null => return formatBuf("null", options, writer),
-        else => @compileError("Unable to format type '" ++ @typeName(T) ++ "'"),
+        else => @compileError("unable to format type '" ++ @typeName(T) ++ "'"),
     }
 }
 
@@ -747,13 +747,13 @@ pub fn formatIntValue(
         if (@typeInfo(@TypeOf(int_value)).Int.bits <= 8) {
             return formatAsciiChar(@as(u8, int_value), options, writer);
         } else {
-            @compileError("Cannot print integer that is larger than 8 bits as an ASCII character");
+            @compileError("cannot print integer that is larger than 8 bits as an ASCII character");
         }
     } else if (comptime std.mem.eql(u8, fmt, "u")) {
         if (@typeInfo(@TypeOf(int_value)).Int.bits <= 21) {
             return formatUnicodeCodepoint(@as(u21, int_value), options, writer);
         } else {
-            @compileError("Cannot print integer that is larger than 21 bits as an UTF-8 sequence");
+            @compileError("cannot print integer that is larger than 21 bits as an UTF-8 sequence");
         }
     } else if (comptime std.mem.eql(u8, fmt, "b")) {
         radix = 2;
@@ -768,7 +768,7 @@ pub fn formatIntValue(
         radix = 8;
         case = .lower;
     } else {
-        @compileError("Unsupported format string '" ++ fmt ++ "' for type '" ++ @typeName(@TypeOf(value)) ++ "'");
+        @compileError("unsupported format string '" ++ fmt ++ "' for type '" ++ @typeName(@TypeOf(value)) ++ "'");
     }
 
     return formatInt(int_value, radix, case, options, writer);
@@ -797,7 +797,7 @@ fn formatFloatValue(
             error.NoSpaceLeft => unreachable,
         };
     } else {
-        @compileError("Unsupported format string '" ++ fmt ++ "' for type '" ++ @typeName(@TypeOf(value)) ++ "'");
+        @compileError("unsupported format string '" ++ fmt ++ "' for type '" ++ @typeName(@TypeOf(value)) ++ "'");
     }
 
     return formatBuf(buf_stream.getWritten(), options, writer);
@@ -959,7 +959,7 @@ pub fn fmtIntSizeBin(value: u64) std.fmt.Formatter(formatSizeBin) {
 
 fn checkTextFmt(comptime fmt: []const u8) void {
     if (fmt.len != 1)
-        @compileError("Unsupported format string '" ++ fmt ++ "' when formatting text");
+        @compileError("unsupported format string '" ++ fmt ++ "' when formatting text");
     switch (fmt[0]) {
         'x' => @compileError("specifier 'x' has been deprecated, wrap your argument in std.fmt.fmtSliceHexLower instead"),
         'X' => @compileError("specifier 'X' has been deprecated, wrap your argument in std.fmt.fmtSliceHexUpper instead"),
@@ -2377,7 +2377,7 @@ test "custom" {
             } else if (comptime std.mem.eql(u8, fmt, "d")) {
                 return std.fmt.format(writer, "{d:.3}x{d:.3}", .{ self.x, self.y });
             } else {
-                @compileError("Unknown format character: '" ++ fmt ++ "'");
+                @compileError("unknown format character: '" ++ fmt ++ "'");
             }
         }
     };
@@ -2585,7 +2585,7 @@ test "formatType max_depth" {
             if (fmt.len == 0) {
                 return std.fmt.format(writer, "({d:.3},{d:.3})", .{ self.x, self.y });
             } else {
-                @compileError("Unknown format string: '" ++ fmt ++ "'");
+                @compileError("unknown format string: '" ++ fmt ++ "'");
             }
         }
     };

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2173,7 +2173,7 @@ fn coerceResultPtr(
             },
             else => {
                 if (std.debug.runtime_safety) {
-                    std.debug.panic("unexpected AIR tag for coerce_result_ptr: {s}", .{
+                    std.debug.panic("unexpected AIR tag for coerce_result_ptr: {}", .{
                         air_tags[trash_inst],
                     });
                 } else {

--- a/src/arch/sparc64/bits.zig
+++ b/src/arch/sparc64/bits.zig
@@ -1582,8 +1582,8 @@ test "Serialize formats" {
     for (testcases) |case| {
         const actual = case.inst.toU32();
         testing.expectEqual(case.expected, actual) catch |err| {
-            std.debug.print("error: {x}\n", .{err});
-            std.debug.print("case: {x}\n", .{case});
+            std.debug.print("error: {}\n", .{err});
+            std.debug.print("case: {}\n", .{case});
             return err;
         };
     }

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1773,7 +1773,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallOptions.
         } else if (func_val.castTag(.decl_ref)) |decl_ref| {
             break :blk module.declPtr(decl_ref.data);
         }
-        return self.fail("Expected a function, but instead found type '{s}'", .{func_val.tag()});
+        return self.fail("Expected a function, but instead found type '{}'", .{func_val.tag()});
     };
 
     const sret = if (first_param_sret) blk: {
@@ -2365,7 +2365,7 @@ fn lowerConstant(self: *Self, val: Value, ty: Type) InnerError!WValue {
             },
             .int_u64, .one => return WValue{ .imm32 = @intCast(u32, val.toUnsignedInt(target)) },
             .zero, .null_value => return WValue{ .imm32 = 0 },
-            else => return self.fail("Wasm TODO: lowerConstant for other const pointer tag {s}", .{val.tag()}),
+            else => return self.fail("Wasm TODO: lowerConstant for other const pointer tag {}", .{val.tag()}),
         },
         .Enum => {
             if (val.castTag(.enum_field_index)) |field_index| {
@@ -2421,7 +2421,7 @@ fn lowerConstant(self: *Self, val: Value, ty: Type) InnerError!WValue {
             const is_pl = val.tag() == .opt_payload;
             return WValue{ .imm32 = if (is_pl) @as(u32, 1) else 0 };
         },
-        else => |zig_type| return self.fail("Wasm TODO: LowerConstant for zigTypeTag {s}", .{zig_type}),
+        else => |zig_type| return self.fail("Wasm TODO: LowerConstant for zigTypeTag {}", .{zig_type}),
     }
 }
 

--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -202,7 +202,7 @@ pub fn lowerMir(emit: *Emit) InnerError!void {
             .pop_regs => try emit.mirPushPopRegisterList(.pop, inst),
 
             else => {
-                return emit.fail("Implement MIR->Emit lowering for x86_64 for pseudo-inst: {s}", .{tag});
+                return emit.fail("Implement MIR->Emit lowering for x86_64 for pseudo-inst: {}", .{tag});
             },
         }
     }

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -246,7 +246,7 @@ pub fn parseRelocs(self: *Atom, relocs: []const macho.relocation_info, context: 
                             else => {
                                 log.err("unexpected relocation type after ARM64_RELOC_ADDEND", .{});
                                 log.err("  expected ARM64_RELOC_PAGE21 or ARM64_RELOC_PAGEOFF12", .{});
-                                log.err("  found {s}", .{next});
+                                log.err("  found {}", .{next});
                                 return error.UnexpectedRelocationType;
                             },
                         }
@@ -285,7 +285,7 @@ pub fn parseRelocs(self: *Atom, relocs: []const macho.relocation_info, context: 
                     else => {
                         log.err("unexpected relocation type after ARM64_RELOC_ADDEND", .{});
                         log.err("  expected ARM64_RELOC_UNSIGNED", .{});
-                        log.err("  found {s}", .{@intToEnum(macho.reloc_type_arm64, relocs[i + 1].r_type)});
+                        log.err("  found {}", .{@intToEnum(macho.reloc_type_arm64, relocs[i + 1].r_type)});
                         return error.UnexpectedRelocationType;
                     },
                 },
@@ -294,7 +294,7 @@ pub fn parseRelocs(self: *Atom, relocs: []const macho.relocation_info, context: 
                     else => {
                         log.err("unexpected relocation type after X86_64_RELOC_ADDEND", .{});
                         log.err("  expected X86_64_RELOC_UNSIGNED", .{});
-                        log.err("  found {s}", .{@intToEnum(macho.reloc_type_x86_64, relocs[i + 1].r_type)});
+                        log.err("  found {}", .{@intToEnum(macho.reloc_type_x86_64, relocs[i + 1].r_type)});
                         return error.UnexpectedRelocationType;
                     },
                 },

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -167,7 +167,7 @@ pub fn parse(
     const this_arch: std.Target.Cpu.Arch = try fat.decodeArch(self.header.?.cputype, true);
 
     if (this_arch != cpu_arch) {
-        log.err("mismatched cpu architecture: expected {s}, found {s}", .{ cpu_arch, this_arch });
+        log.err("mismatched cpu architecture: expected {}, found {}", .{ cpu_arch, this_arch });
         return error.MismatchedCpuArchitecture;
     }
 
@@ -208,7 +208,7 @@ fn readLoadCommands(
                 }
             },
             else => {
-                log.debug("Unknown load command detected: 0x{x}.", .{cmd.cmd()});
+                log.debug("Unknown load command detected: 0x{x}.", .{@enumToInt(cmd.cmd())});
             },
         }
         self.load_commands.appendAssumeCapacity(cmd);

--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -110,7 +110,7 @@ pub fn parse(self: *Object, allocator: Allocator, cpu_arch: std.Target.Cpu.Arch)
         },
     };
     if (this_arch != cpu_arch) {
-        log.err("mismatched cpu architecture: expected {s}, found {s}", .{ cpu_arch, this_arch });
+        log.err("mismatched cpu architecture: expected {}, found {}", .{ cpu_arch, this_arch });
         return error.MismatchedCpuArchitecture;
     }
 
@@ -171,7 +171,7 @@ pub fn parse(self: *Object, allocator: Allocator, cpu_arch: std.Target.Cpu.Arch)
                 cmd.linkedit_data.dataoff += file_offset;
             },
             else => {
-                log.debug("Unknown load command detected: 0x{x}.", .{cmd.cmd()});
+                log.debug("Unknown load command detected: 0x{x}.", .{@enumToInt(cmd.cmd())});
             },
         }
         self.load_commands.appendAssumeCapacity(cmd);

--- a/src/link/MachO/fat.zig
+++ b/src/link/MachO/fat.zig
@@ -46,7 +46,7 @@ pub fn getLibraryOffset(reader: anytype, cpu_arch: std.Target.Cpu.Arch) !u64 {
             return fat_arch.offset;
         }
     } else {
-        log.err("Could not find matching cpu architecture in fat library: expected {s}", .{cpu_arch});
+        log.err("Could not find matching cpu architecture in fat library: expected {}", .{cpu_arch});
         return error.MismatchedCpuArchitecture;
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -4076,12 +4076,12 @@ pub fn cmdFmt(gpa: Allocator, arena: Allocator, args: []const []const u8) !void 
 
         const stdin = io.getStdIn();
         const source_code = readSourceFileToEndAlloc(gpa, &stdin, null) catch |err| {
-            fatal("unable to read stdin: {s}", .{err});
+            fatal("unable to read stdin: {}", .{err});
         };
         defer gpa.free(source_code);
 
         var tree = std.zig.parse(gpa, source_code) catch |err| {
-            fatal("error parsing stdin: {s}", .{err});
+            fatal("error parsing stdin: {}", .{err});
         };
         defer tree.deinit(gpa);
 
@@ -5011,7 +5011,7 @@ pub fn cmdAstCheck(
     } else {
         const stdin = io.getStdIn();
         const source = readSourceFileToEndAlloc(arena, &stdin, null) catch |err| {
-            fatal("unable to read stdin: {s}", .{err});
+            fatal("unable to read stdin: {}", .{err});
         };
         file.sub_file_path = "<stdin>";
         file.source = source;

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -551,7 +551,7 @@ const Writer = struct {
     fn writeElemTypeIndex(self: *Writer, stream: anytype, inst: Zir.Inst.Index) !void {
         const inst_data = self.code.instructions.items(.data)[inst].bin;
         try self.writeInstRef(stream, inst_data.lhs);
-        try stream.print(", {d})", .{inst_data.rhs});
+        try stream.print(", {d})", .{@enumToInt(inst_data.rhs)});
     }
 
     fn writeUnNode(

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -3279,7 +3279,7 @@ fn transConstantExpr(c: *Context, scope: *Scope, expr: *const clang.Expr, used: 
             return maybeSuppressResult(c, scope, used, as_node);
         },
         else => |kind| {
-            return fail(c, error.UnsupportedTranslation, expr.getBeginLoc(), "unsupported constant expression kind '{s}'", .{kind});
+            return fail(c, error.UnsupportedTranslation, expr.getBeginLoc(), "unsupported constant expression kind '{}'", .{kind});
         },
     }
 }


### PR DESCRIPTION
This makes it so that if you try to do `std.debug.print("{x:10}", .{.hello})`, it errors because
trying to format an enum literal as hexadecimal makes no sense. Currently it compiles as-is.
Basically what you're supposed to do instead is, in that case, `"{:10}"` or `"{any:10}"`.
The ":10" part to align the thing of course still works.

This is supposed to catch mistakes like `"{b:10}", .{true}` where maybe the user assumed
"b" means "boolean" but it means "binary". Or maybe they assumed it would print `1` or whatever? It's ambiguous.
It just doesn't seem right to accept `"{u:10}", .{null}` (which currently prints as "null") when something like `"{s:10}", .{5}` isn't accepted either.
Silently ignoring such invalid specifiers can give the user the wrong expectations so we should explicitly reject such invalid specifiers to make sure what's printed actually matches the user's expectations.

During review of the initial iteration of the PR, slightly improving the style of the compile errors here and there happened to become a part of this PR because it seemed convenient. This has been discussed with Vexu. Please review by commit.