### PR TITLE
std.fs: Fix Walker closing the initial directory when not fully iterated

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -889,8 +889,11 @@ pub const IterableDir = struct {
         }
 
         pub fn deinit(self: *Walker) void {
-            for (self.stack.items) |*item| {
-                item.iter.dir.close();
+            // Close any remaining directories except the initial one (which is always at index 0)
+            if (self.stack.items.len > 1) {
+                for (self.stack.items[1..]) |*item| {
+                    item.iter.dir.close();
+                }
             }
             self.stack.deinit();
             self.name_buffer.deinit();


### PR DESCRIPTION
This is a fix for a regression caused by https://github.com/ziglang/zig/commit/61c5d8f8f19d4321a492cb8a1adc4d221024f7d9

Closes #12209