### PR TITLE
`std.testing`: make the caret indicator line more helpful

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -542,7 +542,7 @@ fn printIndicatorLine(source: []const u8, indicator_index: usize) void {
     if (indicator_index >= source.len)
         print("^ (end of string)\n", .{})
     else
-        print("^ ('\\u{{{x}}}')\n", .{source[indicator_index]});
+        print("^ ('\\x{x:0>2}')\n", .{source[indicator_index]});
 }
 
 fn printWithVisibleNewlines(source: []const u8) void {

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -542,7 +542,7 @@ fn printIndicatorLine(source: []const u8, indicator_index: usize) void {
     if (indicator_index >= source.len)
         print("^ (end of string)\n", .{})
     else
-        print("^ ({d})\n", .{source[indicator_index]});
+        print("^ ('\\u{{{x}}}')\n", .{source[indicator_index]});
 }
 
 fn printWithVisibleNewlines(source: []const u8) void {

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -539,7 +539,10 @@ fn printIndicatorLine(source: []const u8, indicator_index: usize) void {
         while (i < indicator_index) : (i += 1)
             print(" ", .{});
     }
-    print("^\n", .{});
+    if (indicator_index >= source.len)
+        print("^ (end of string)\n", .{})
+    else
+        print("^ ({d})\n", .{source[indicator_index]});
 }
 
 fn printWithVisibleNewlines(source: []const u8) void {


### PR DESCRIPTION
Same as #11766 but without the messed up history (thanks git).