### PR TITLE
Sema: `analyzeInlineCallArg` needs a block for the arg and the param

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -5940,7 +5940,9 @@ pub fn argSrc(
     gpa: Allocator,
     decl: *Decl,
     arg_i: usize,
+    bound_arg_src: ?LazySrcLoc,
 ) LazySrcLoc {
+    if (arg_i == 0 and bound_arg_src != null) return bound_arg_src.?;
     @setCold(true);
     const tree = decl.getFileScope().getTree(gpa) catch |err| {
         // In this case we emit a warning + a less precise source location.

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -183,6 +183,30 @@ pub fn addCases(ctx: *TestContext) !void {
         });
     }
 
+    {
+        const case = ctx.obj("argument causes error ", .{});
+        case.backend = .stage2;
+
+        case.addSourceFile("b.zig",
+            \\pub const ElfDynLib = struct {
+            \\    pub fn lookup(self: *ElfDynLib, comptime T: type) ?T {
+            \\        _ = self;
+            \\        return undefined;
+            \\    }
+            \\};
+        );
+
+        case.addError(
+            \\pub export fn entry() void {
+            \\    var lib: @import("b.zig").ElfDynLib = undefined;
+            \\    _ = lib.lookup(fn () void);
+            \\}
+        , &[_][]const u8{
+            ":3:12: error: unable to resolve comptime value",
+            ":3:12: note: argument to function being called at comptime must be comptime known",
+        });
+    }
+
     // TODO test this in stage2, but we won't even try in stage1
     //ctx.objErrStage1("inline fn calls itself indirectly",
     //    \\export fn foo() void {


### PR DESCRIPTION
Closes #12221
Closes #12224