### PR TITLE
std.mem.zeroes: Zero sized structs with uninitialized members

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -425,7 +425,7 @@ test "zeroes" {
     comptime var comptime_union = zeroes(C_union);
     try testing.expectEqual(@as(u8, 0), comptime_union.a);
 
-    // https://github.com/ziglang/zig/pull/12246
+    // Ensure zero sized struct with fields is initialized correctly.
     _ = zeroes(struct { handle: void });
 }
 

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -267,7 +267,7 @@ pub fn zeroes(comptime T: type) T {
             return null;
         },
         .Struct => |struct_info| {
-            if (@sizeOf(T) == 0) return T{};
+            if (@sizeOf(T) == 0) return undefined;
             if (struct_info.layout == .Extern) {
                 var item: T = undefined;
                 set(u8, asBytes(&item), 0);

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -424,6 +424,9 @@ test "zeroes" {
 
     comptime var comptime_union = zeroes(C_union);
     try testing.expectEqual(@as(u8, 0), comptime_union.a);
+
+    // https://github.com/ziglang/zig/pull/12246
+    _ = zeroes(struct { handle: void });
 }
 
 /// Initializes all fields of the struct with their default value, or zero values if no default value is present.


### PR DESCRIPTION
`std.mem.zeroes(struct{handle: void})` Failed with the following error before:
```
/nix/store/l6v4359wc9xrxxmvvp3rynsb5s3d78xf-zig-0.9.1/lib/zig/std/mem.zig:270:42: error: missing field: 'handle'
            if (@sizeOf(T) == 0) return T{};
                                         ^
```