### PR TITLE
stage1: remove deadcode ast_print

### DIFF
--- a/src/stage1/parser.hpp
+++ b/src/stage1/parser.hpp
@@ -14,8 +14,6 @@
 
 AstNode * ast_parse(Buf *buf, ZigType *owner, ErrColor err_color);
 
-void ast_print(AstNode *node, int indent);
-
 void ast_visit_node_children(AstNode *node, void (*visit)(AstNode **, void *context), void *context);
 
 Buf *node_identifier_buf(AstNode *node);


### PR DESCRIPTION
Fixes: 2a990d696 ("stage1: rework tokenizer to match stage2")
Fixes: b6354ddd5 ("move AST rendering code to separate file")

Signed-off-by: Wei Fu <fuweid89@gmail.com>