### PR TITLE
autodoc: better short description algorithm

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -2639,14 +2639,23 @@ var zigAnalysis;
         });
     }
 
-    
+
     function shortDescMarkdown(docs) {
-        let parts = docs.trim().split("\n");
-        let firstLine = parts[0];
-        return markdown(firstLine);
+        const trimmed_docs = docs.trim();
+        let index = trimmed_docs.indexOf('.');
+        if (index < 0) {
+            index = trimmed_docs.indexOf('\n');
+            if (index < 0) {
+                index = trimmed_docs.length;
+            }
+        } else {
+            index += 1; // include the period
+        }
+        const slice = trimmed_docs.slice(0, index);
+        return markdown(slice);
     }
 
-    
+
     function markdown(input) {
         const raw_lines = input.split('\n'); // zig allows no '\r', so we don't need to split on CR
         


### PR DESCRIPTION
Just a small thing I found I could do.

# Before

![image](https://user-images.githubusercontent.com/35064754/181622620-ef9a3e38-b2b7-4f24-b246-5057803bea92.png)

# After

![image](https://user-images.githubusercontent.com/35064754/181622632-1213ff82-754f-45b7-ba77-7ce3a90defff.png)
