### PR TITLE
feat: flake.nix

### DIFF
--- a/contrib/flake.lock
+++ b/contrib/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1658937758,
+        "narHash": "sha256-FxQB/tWX15Faq3GBM+qTfVzd9qJqy/3CEgBp2zpHeNc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8f73de28e63988da02426ebb17209e3ae07f103b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  } @ inputs:
+    inputs.utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [self.overlays.default];
+      };
+    in {
+      packages.default = pkgs.zig-master;
+    })
+    // {
+      overlays.default = final: prev: {
+        zig-master = prev.zig.overrideAttrs (attrs: {
+          version = "master";
+          src = ../.;
+
+          nativeBuildInputs = with prev; [
+            cmake
+            llvmPackages_14.llvm.dev
+          ];
+          buildInputs = with prev;
+            [
+              libxml2
+              zlib
+            ]
+            ++ (with llvmPackages_14; [
+              libclang
+              lld
+              llvm
+            ]);
+
+          cmakeFlags =
+            attrs.cmakeFlags
+            ++ [
+              "-DZIG_STATIC_ZLIB=ON"
+            ];
+        });
+      };
+    };
+}


### PR DESCRIPTION
For those that use Nix(OS). There are versioned derivations in nixpkgs, but I like to live on the edge. And the only way to _not_ have to have a source hash (which renders any HEAD-based derivation completely useless) is by referencing the source tree directly (instead of, e.g., fetchFromGitHub). So... voila.