### PR TITLE
feat: prettify compile log output

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3002,7 +3002,7 @@ pub fn getAllErrorsAlloc(self: *Compilation) !AllErrors {
     };
 }
 
-pub fn getCompileLogOutput(self: *Compilation) []const u8 {
+pub fn getCompileLogText(self: Compilation) []const u8 {
     const module = self.bin_file.options.module orelse return &[0]u8{};
     return module.compile_log_text.items;
 }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5009,7 +5009,8 @@ fn zirCompileLog(
     const args = sema.code.refSlice(extra.end, extended.small);
 
     for (args) |arg_ref, i| {
-        if (i != 0) try writer.print(", ", .{});
+        // we rely on TypedValue's formatting to escape this in order for it to work
+        if (i != 0) try writer.writeByte('\x00');
 
         const arg = try sema.resolveInst(arg_ref);
         const arg_ty = sema.typeOf(arg);
@@ -5022,7 +5023,8 @@ fn zirCompileLog(
             try writer.print("@as({}, [runtime value])", .{arg_ty.fmt(sema.mod)});
         }
     }
-    try writer.print("\n", .{});
+    // we rely on TypedValue's formatting to escape this in order for it to work
+    try writer.writeByte('\n');
 
     const decl_index = if (sema.func) |some| some.owner_decl else sema.owner_decl_index;
     const gop = try sema.mod.compile_log_decls.getOrPut(sema.gpa, decl_index);


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/35064754/181906521-23dfd9ef-10a1-40f6-a9b5-b23a3d5239ca.png)

The "Compile Log Output" currently looks very plain and unconnected to the pretty messages before it with all the colors and stuff. The purpose of this PR is to make it look prettier and more connected to what's before it and it's also supposed to make the values easier to read if you have many values in a single line separated by commas.
Currently it kinda blends in with the `error: x...` stuff below that no one reads so that's not very good.

## After

![image](https://user-images.githubusercontent.com/35064754/181908107-91eb56d4-10b4-4367-bbfc-b060359782f9.png)

In addition to the previous one,
- It dims the dashes and the commas and makes the values bold.
- It uses cyan to make the compile log output stick out further. Currently cyan seems to be used only for `note: `s but I think the compile log output is similar. They're also notes that you wrote during comptime.
Another reason I think cyan makes sense is that `@compileError` is "worse" and it uses red and then `@compileLog` is not as bad and uses cyan, if you know what I mean.

This may not look complicated but it's significantly more complicated to do because color is not available in `Sema`. The way I do this is I concatenate the strings in `Sema` and use unprintable characters as terminators and then in `main` I `mem.split` `comp.getCompileLogText()` and add color. This is supposed to avoid using an unnecessarily complicated structure like a `ArrayListUnmanaged(ArrayListUnmanaged(u8))` or something.

In regards to distinguishing multiple values in one line, this is probably a lot better.