### PR TITLE
std.debug: handle some possible errors and resolve low-hanging TODOs

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -210,8 +210,11 @@ fn refreshWithHeldLock(self: *Progress) void {
             std.debug.assert(self.is_windows_terminal);
 
             var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
-            if (windows.kernel32.GetConsoleScreenBufferInfo(file.handle, &info) != windows.TRUE)
-                unreachable;
+            if (windows.kernel32.GetConsoleScreenBufferInfo(file.handle, &info) != windows.TRUE) {
+                // stop trying to write to this file
+                self.terminal = null;
+                break :winapi;
+            }
 
             var cursor_pos = windows.COORD{
                 .X = info.dwCursorPosition.X - @intCast(windows.SHORT, self.columns_written),
@@ -231,7 +234,7 @@ fn refreshWithHeldLock(self: *Progress) void {
                 cursor_pos,
                 &written,
             ) != windows.TRUE) {
-                // Stop trying to write to this file.
+                // stop trying to write to this file
                 self.terminal = null;
                 break :winapi;
             }
@@ -241,10 +244,16 @@ fn refreshWithHeldLock(self: *Progress) void {
                 fill_chars,
                 cursor_pos,
                 &written,
-            ) != windows.TRUE) unreachable;
-
-            if (windows.kernel32.SetConsoleCursorPosition(file.handle, cursor_pos) != windows.TRUE)
-                unreachable;
+            ) != windows.TRUE) {
+                // stop trying to write to this file
+                self.terminal = null;
+                break :winapi;
+            }
+            if (windows.kernel32.SetConsoleCursorPosition(file.handle, cursor_pos) != windows.TRUE) {
+                // stop trying to write to this file
+                self.terminal = null;
+                break :winapi;
+            }
         } else {
             // we are in a "dumb" terminal like in acme or writing to a file
             self.output_buffer[end] = '\n';
@@ -288,7 +297,7 @@ fn refreshWithHeldLock(self: *Progress) void {
     }
 
     _ = file.write(self.output_buffer[0..end]) catch {
-        // Stop trying to write to this file once it errors.
+        // stop trying to write to this file
         self.terminal = null;
     };
     if (self.timer) |*timer| {

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -761,14 +761,12 @@ fn printLineInfo(
     }
 }
 
-// TODO use this
 pub const OpenSelfDebugInfoError = error{
     MissingDebugInfo,
-    OutOfMemory,
     UnsupportedOperatingSystem,
 };
 
-pub fn openSelfDebugInfo(allocator: mem.Allocator) anyerror!DebugInfo {
+pub fn openSelfDebugInfo(allocator: mem.Allocator) OpenSelfDebugInfoError!DebugInfo {
     nosuspend {
         if (builtin.strip_debug_info)
             return error.MissingDebugInfo;
@@ -785,7 +783,7 @@ pub fn openSelfDebugInfo(allocator: mem.Allocator) anyerror!DebugInfo {
             .windows,
             .solaris,
             => return DebugInfo.init(allocator),
-            else => return error.UnsupportedDebugInfo,
+            else => return error.UnsupportedOperatingSystem,
         }
     }
 }

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -384,14 +384,6 @@ pub fn panicImpl(trace: ?*const std.builtin.StackTrace, first_trace_addr: ?usize
     os.abort();
 }
 
-const RED = "\x1b[31;1m";
-const GREEN = "\x1b[32;1m";
-const CYAN = "\x1b[36;1m";
-const WHITE = "\x1b[37;1m";
-const BOLD = "\x1b[1m";
-const DIM = "\x1b[2m";
-const RESET = "\x1b[0m";
-
 pub fn writeStackTrace(
     stack_trace: std.builtin.StackTrace,
     out_stream: anytype,
@@ -615,13 +607,13 @@ pub const TTY = struct {
                 .no_color => return,
                 .escape_codes => {
                     const color_string = switch (color) {
-                        .Red => RED,
-                        .Green => GREEN,
-                        .Cyan => CYAN,
-                        .White => WHITE,
-                        .Dim => DIM,
-                        .Bold => BOLD,
-                        .Reset => RESET,
+                        .Red => "\x1b[31;1m",
+                        .Green => "\x1b[32;1m",
+                        .Cyan => "\x1b[36;1m",
+                        .White => "\x1b[37;1m",
+                        .Bold => "\x1b[1m",
+                        .Dim => "\x1b[2m",
+                        .Reset => "\x1b[0m",
                     };
                     try out_stream.writeAll(color_string);
                 },

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -387,9 +387,9 @@ fn SliceDiffer(comptime T: type) type {
             for (self.expected) |value, i| {
                 var full_index = self.start_index + i;
                 const diff = if (i < self.actual.len) !std.meta.eql(self.actual[i], value) else true;
-                if (diff) self.ttyconf.setColor(writer, .Red);
+                if (diff) try self.ttyconf.setColor(writer, .Red);
                 try writer.print("[{}]: {any}\n", .{ full_index, value });
-                if (diff) self.ttyconf.setColor(writer, .Reset);
+                if (diff) try self.ttyconf.setColor(writer, .Reset);
             }
         }
     };
@@ -427,9 +427,9 @@ const BytesDiffer = struct {
     }
 
     fn writeByteDiff(self: BytesDiffer, writer: anytype, comptime fmt: []const u8, byte: u8, diff: bool) !void {
-        if (diff) self.ttyconf.setColor(writer, .Red);
+        if (diff) try self.ttyconf.setColor(writer, .Red);
         try writer.print(fmt, .{byte});
-        if (diff) self.ttyconf.setColor(writer, .Reset);
+        if (diff) try self.ttyconf.setColor(writer, .Reset);
     }
 
     const ChunkIterator = struct {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -428,29 +428,29 @@ pub const AllErrors = struct {
             switch (msg) {
                 .src => |src| {
                     try counting_stderr.writeByteNTimes(' ', indent);
-                    ttyconf.setColor(stderr, .Bold);
+                    try ttyconf.setColor(stderr, .Bold);
                     try counting_stderr.print("{s}:{d}:{d}: ", .{
                         src.src_path,
                         src.line + 1,
                         src.column + 1,
                     });
-                    ttyconf.setColor(stderr, color);
+                    try ttyconf.setColor(stderr, color);
                     try counting_stderr.writeAll(kind);
                     try counting_stderr.writeAll(": ");
                     // This is the length of the part before the error message:
                     // e.g. "file.zig:4:5: error: "
                     const prefix_len = @intCast(usize, counting_stderr.context.bytes_written);
-                    ttyconf.setColor(stderr, .Reset);
-                    ttyconf.setColor(stderr, .Bold);
+                    try ttyconf.setColor(stderr, .Reset);
+                    try ttyconf.setColor(stderr, .Bold);
                     if (src.count == 1) {
                         try src.writeMsg(stderr, prefix_len);
                         try stderr.writeByte('\n');
                     } else {
                         try src.writeMsg(stderr, prefix_len);
-                        ttyconf.setColor(stderr, .Dim);
+                        try ttyconf.setColor(stderr, .Dim);
                         try stderr.print(" ({d} times)\n", .{src.count});
                     }
-                    ttyconf.setColor(stderr, .Reset);
+                    try ttyconf.setColor(stderr, .Reset);
                     if (src.source_line) |line| {
                         for (line) |b| switch (b) {
                             '\t' => try stderr.writeByte(' '),
@@ -462,19 +462,19 @@ pub const AllErrors = struct {
                         // -1 since span.main includes the caret
                         const after_caret = src.span.end - src.span.main -| 1;
                         try stderr.writeByteNTimes(' ', src.column - before_caret);
-                        ttyconf.setColor(stderr, .Green);
+                        try ttyconf.setColor(stderr, .Green);
                         try stderr.writeByteNTimes('~', before_caret);
                         try stderr.writeByte('^');
                         try stderr.writeByteNTimes('~', after_caret);
                         try stderr.writeByte('\n');
-                        ttyconf.setColor(stderr, .Reset);
+                        try ttyconf.setColor(stderr, .Reset);
                     }
                     for (src.notes) |note| {
                         try note.renderToWriter(ttyconf, stderr, "note", .Cyan, indent);
                     }
                     if (src.reference_trace.len != 0) {
-                        ttyconf.setColor(stderr, .Reset);
-                        ttyconf.setColor(stderr, .Dim);
+                        try ttyconf.setColor(stderr, .Reset);
+                        try ttyconf.setColor(stderr, .Dim);
                         try stderr.print("referenced by:\n", .{});
                         for (src.reference_trace) |reference| {
                             switch (reference) {
@@ -498,23 +498,23 @@ pub const AllErrors = struct {
                             }
                         }
                         try stderr.writeByte('\n');
-                        ttyconf.setColor(stderr, .Reset);
+                        try ttyconf.setColor(stderr, .Reset);
                     }
                 },
                 .plain => |plain| {
-                    ttyconf.setColor(stderr, color);
+                    try ttyconf.setColor(stderr, color);
                     try stderr.writeByteNTimes(' ', indent);
                     try stderr.writeAll(kind);
                     try stderr.writeAll(": ");
-                    ttyconf.setColor(stderr, .Reset);
+                    try ttyconf.setColor(stderr, .Reset);
                     if (plain.count == 1) {
                         try stderr.print("{s}\n", .{plain.msg});
                     } else {
                         try stderr.print("{s}", .{plain.msg});
-                        ttyconf.setColor(stderr, .Dim);
+                        try ttyconf.setColor(stderr, .Dim);
                         try stderr.print(" ({d} times)\n", .{plain.count});
                     }
-                    ttyconf.setColor(stderr, .Reset);
+                    try ttyconf.setColor(stderr, .Reset);
                     for (plain.notes) |note| {
                         try note.renderToWriter(ttyconf, stderr, "note", .Cyan, indent + 4);
                     }


### PR DESCRIPTION
`ttyconf.setColor(stderr, .Dim)` just like `stderr.print("{s}", .{plain.msg})` can fail, so I don't see why we wouldn't handle the former just like the latter. It's an edge case. You can always still ignore the error in your specific case if you want to.
Apart from that it solves a bunch of related TODOs and it also removes a bunch of `unreachable`s in `std.Progress` which is supposed to be non-fallible because now I'm confident these `unreachable`s can be reached since the user can modify the `std.Progress.terminal` field. It can probably fail anyway. Better safe than sorry.