### PR TITLE
stage2: Fix AIR printing

### DIFF
--- a/src/value.zig
+++ b/src/value.zig
@@ -2664,6 +2664,26 @@ pub const Value = extern union {
         }
     }
 
+    /// Returns true if a Value is backed by a variable
+    pub fn isVariable(
+        val: Value,
+        mod: *Module,
+    ) bool {
+        return switch (val.tag()) {
+            .slice => val.castTag(.slice).?.data.ptr.isVariable(mod),
+            .comptime_field_ptr => val.castTag(.comptime_field_ptr).?.data.field_val.isVariable(mod),
+            .elem_ptr => val.castTag(.elem_ptr).?.data.array_ptr.isVariable(mod),
+            .field_ptr => val.castTag(.field_ptr).?.data.container_ptr.isVariable(mod),
+            .eu_payload_ptr => val.castTag(.eu_payload_ptr).?.data.container_ptr.isVariable(mod),
+            .opt_payload_ptr => val.castTag(.opt_payload_ptr).?.data.container_ptr.isVariable(mod),
+            .decl_ref => mod.declPtr(val.castTag(.decl_ref).?.data).val.isVariable(mod),
+            .decl_ref_mut => mod.declPtr(val.castTag(.decl_ref_mut).?.data.decl_index).val.isVariable(mod),
+
+            .variable => true,
+            else => false,
+        };
+    }
+
     // Asserts that the provided start/end are in-bounds.
     pub fn sliceArray(
         val: Value,


### PR DESCRIPTION
Packed structs never have comptime fields, and a slice might actually be backed by a variable, which we need to catch before iterating its elements.

Resolves #12293, cc @sin-ack who reported a similar issue on Discord