### PR TITLE
stdlib: Support `std.log` at comptime, using `@compileError`

### DIFF
--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -120,6 +120,15 @@ pub fn log(
     comptime format: []const u8,
     args: anytype,
 ) void {
+    const is_comptime = b: {
+        // A cursed technique to detect whether we are running in a comptime context or not
+        var cond: bool = true;
+        break :b @TypeOf(if (cond) @as(u1, 1) else null) == u1;
+    };
+    if (is_comptime) {
+        return std.log.defaultLog(message_level, scope, format, args);
+    }
+
     if (@enumToInt(message_level) <= @enumToInt(std.log.Level.err)) {
         log_err_count += 1;
     }


### PR DESCRIPTION
This is a rudimentary (and arguably cursed) implementation of comptime logging. It works in stage 1 and stage 2.

I'm not sure we'll want to merge this, but it might be useful so I decided to open the PR just to get feedback.

```zig
test {
    const Foo = struct { a: u8, b: i32 };
    const data = Foo{ .a = 15, .b = -16 };
    comptime std.log.err(
        \\Error encountered!
        \\Data was: {}
        \\
        \\Have you tried turning it off and on again?
        , .{ data });
}
```

when compiled, this prints:
```
$ ./stage2/bin/zig test test.zig
lib/std/log.zig:183:9: error: Error encountered!
                              Data was: test.test_0.Foo{ .a = 15, .b = -16 }

                              Have you tried turning it off and on again?

lib/test_runner.zig:130:34: note: called from here
lib/std/log.zig:139:21: note: called from here
lib/std/log.zig:217:16: note: called from here
test.zig:6:25: note: called from here
```

You can only log one message, since this uses `@compileError`. AFAIK `@compileLog` currently has no way of printing a string if it's not a string literal. 

kudos to @r00ster91 for the idea