### PR TITLE
autodoc: Add borders to field docs to make it clear which field they are associated with

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -284,6 +284,16 @@
         overflow-x: hidden;
       }
 
+      .fieldHasDocs {
+        margin-bottom: 0;
+      }
+
+      .fieldDocs {
+        border: 1px solid #2A2A2A;
+        border-top: 0px;
+        padding: 1px 1em;
+      }
+
       /* help dialog */
       .help-modal {
         display: flex;

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -618,15 +618,18 @@ var zigAnalysis;
         for (let i = 0; i < fields.length; i += 1) {
             let field = fields[i];
             let fieldNode = zigAnalysis.astNodes[field];
+            let docs = fieldNode.docs;
             if (fieldNode.docs == null) {
                 continue;
             }
+            let docsNonEmpty = docs !== "";
             let divDom = domListParams.children[domIndex];
             domIndex += 1;
 
 
             let value = typeObj.params[i];
-            let html = '<pre>' + escapeHtml((fieldNode.name)) + ": ";
+            let preClass = docsNonEmpty ? ' class="fieldHasDocs"' : "";
+            let html = '<pre' + preClass + '>' + escapeHtml((fieldNode.name)) + ": ";
             if (isVarArgs && i === typeObj.params.length - 1) {
                 html += '...';
             } else {
@@ -636,9 +639,8 @@ var zigAnalysis;
 
             html += ',</pre>';
 
-            let docs = fieldNode.docs;
-            if (docs != null) {
-                html += markdown(docs);
+            if (docsNonEmpty) {
+                html += '<div class="fieldDocs">' + markdown(docs) + '</div>';
             }
             divDom.innerHTML = html;
         }
@@ -2270,8 +2272,11 @@ var zigAnalysis;
                 let fieldNode = zigAnalysis.astNodes[containerNode.fields[i]];
                 let divDom = domListFields.children[i];
                 let fieldName = (fieldNode.name);
+                let docs = fieldNode.docs;
+                let docsNonEmpty = docs != null && docs !== "";
+                let extraPreClass = docsNonEmpty ? " fieldHasDocs" : "";
 
-                let html = '<div class="mobile-scroll-container"><pre class="scroll-item">' + escapeHtml(fieldName);
+                let html = '<div class="mobile-scroll-container"><pre class="scroll-item' + extraPreClass + '">' + escapeHtml(fieldName);
 
                 if (container.kind === typeKinds.Enum) {
                     html += ' = <span class="tok-number">' + fieldName + '</span>';
@@ -2289,9 +2294,8 @@ var zigAnalysis;
 
                 html += ',</pre></div>';
 
-                let docs = fieldNode.docs;
-                if (docs != null) {
-                    html += markdown(docs);
+                if (docsNonEmpty) {
+                    html += '<div class="fieldDocs">' + markdown(docs) + '</div>';
                 }
                 divDom.innerHTML = html;
             }


### PR DESCRIPTION
As discussed in Discord.

Before:
![autodoc-before](https://user-images.githubusercontent.com/2389051/182004428-7d9f6252-d126-49fb-8181-229edbe2f621.png)

After:
![autodoc-after](https://user-images.githubusercontent.com/2389051/182004433-29efa7b2-10ca-4c86-97a1-d173f6e8cd13.png)

