### PR TITLE
std.fs: Split `Iterator.next` on Linux and WASI to allow for handling platform-specific errors

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -241,6 +241,11 @@ test "Dir.Iterator but dir is deleted during iteration" {
     // Now, when we try to iterate, the next call should return null immediately.
     const entry = try iterator.next();
     try std.testing.expect(entry == null);
+
+    // On Linux, we can opt-in to receiving a more specific error by calling `nextLinux`
+    if (builtin.os.tag == .linux) {
+        try std.testing.expectError(error.DirNotFound, iterator.nextLinux());
+    }
 }
 
 fn entryEql(lhs: IterableDir.Entry, rhs: IterableDir.Entry) bool {


### PR DESCRIPTION
Follow up to #12226, implements the compromise detailed in https://github.com/ziglang/zig/issues/12211#issuecomment-1196011590