### PR TITLE
Linux: Add `IN_MASK_CREATE` and corresponding error handling in `inotify_add_watch`

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4244,6 +4244,7 @@ pub const INotifyAddWatchError = error{
     SystemResources,
     UserResourceLimitReached,
     NotDir,
+    WatchAlreadyExists,
 } || UnexpectedError;
 
 /// add a watch to an initialized inotify instance
@@ -4266,6 +4267,7 @@ pub fn inotify_add_watchZ(inotify_fd: i32, pathname: [*:0]const u8, mask: u32) I
         .NOMEM => return error.SystemResources,
         .NOSPC => return error.UserResourceLimitReached,
         .NOTDIR => return error.NotDir,
+        .EXIST => return error.WatchAlreadyExists,
         else => |err| return unexpectedErrno(err),
     }
 }

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -2976,6 +2976,7 @@ pub const IN = struct {
     pub const ONLYDIR = 0x01000000;
     pub const DONT_FOLLOW = 0x02000000;
     pub const EXCL_UNLINK = 0x04000000;
+    pub const MASK_CREATE = 0x10000000;
     pub const MASK_ADD = 0x20000000;
 
     pub const ISDIR = 0x40000000;


### PR DESCRIPTION
From https://man7.org/linux/man-pages/man7/inotify.7.html

> **IN_MASK_CREATE** (since Linux 4.18)
>
> Watch pathname only if it does not already have a watch associated with it; the error EEXIST results if pathname is already being watched.