### PR TITLE
Update Linux syscall list for 5.19

### DIFF
--- a/lib/std/os/linux/syscalls.zig
+++ b/lib/std/os/linux/syscalls.zig
@@ -3485,6 +3485,7 @@ pub const RiscV64 = enum(usize) {
     landlock_create_ruleset = 444,
     landlock_add_rule = 445,
     landlock_restrict_self = 446,
+    memfd_secret = 447,
     process_mrelease = 448,
     futex_waitv = 449,
     set_mempolicy_home_node = 450,


### PR DESCRIPTION
New changes: memfd_secret implemented for RISC-V.