### PR TITLE
`[]T` pointer confusion in docs.

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2629,7 +2629,7 @@ test "Conversion between vectors, arrays, and slices" {
             </li>
         </ul>
         <ul>
-            <li>{#syntax#}[]T{#endsyntax#} - pointer to runtime-known number of items.
+            <li>{#syntax#}[]T{#endsyntax#} - is a slice (a fat pointer, which contains a pointer of type [*]T and a length).
             <ul>
                 <li>Supports index syntax: {#syntax#}slice[i]{#endsyntax#}</li>
                 <li>Supports slice syntax: {#syntax#}slice[start..end]{#endsyntax#}</li>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2629,7 +2629,7 @@ test "Conversion between vectors, arrays, and slices" {
             </li>
         </ul>
         <ul>
-            <li>{#syntax#}[]T{#endsyntax#} - is a slice (a fat pointer, which contains a pointer of type [*]T and a length).
+            <li>{#syntax#}[]T{#endsyntax#} - is a slice (a fat pointer, which contains a pointer of type {#syntax#}[*]T{#endsyntax#} and a length).
             <ul>
                 <li>Supports index syntax: {#syntax#}slice[i]{#endsyntax#}</li>
                 <li>Supports slice syntax: {#syntax#}slice[start..end]{#endsyntax#}</li>


### PR DESCRIPTION
saying `[]T` is a pointer is confusing because zig docs say there are two types of pointers (`*T` and `[*]T`). It is more clear to say that `[]T` is a slice type which contains a `[*]T` pointer and a length.