### PR TITLE
Sema: elide safety of modulus and remainder division sometimes

### DIFF
--- a/test/cases/safety/modrem by zero.zig
+++ b/test/cases/safety/modrem by zero.zig
@@ -2,18 +2,18 @@ const std = @import("std");
 
 pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace) noreturn {
     _ = stack_trace;
-    if (std.mem.eql(u8, message, "remainder division by zero or negative value")) {
+    if (std.mem.eql(u8, message, "division by zero")) {
         std.process.exit(0);
     }
     std.process.exit(1);
 }
 pub fn main() !void {
-    const x = div0(999, -1);
+    const x = div0(999, 0);
     _ = x;
     return error.TestFailed;
 }
-fn div0(a: i32, b: i32) i32 {
-    return @rem(a, b);
+fn div0(a: u32, b: u32) u32 {
+    return a / b;
 }
 // run
 // backend=llvm

--- a/test/cases/safety/modulus by zero.zig
+++ b/test/cases/safety/modulus by zero.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace) noreturn {
+    _ = stack_trace;
+    if (std.mem.eql(u8, message, "division by zero")) {
+        std.process.exit(0);
+    }
+    std.process.exit(1);
+}
+pub fn main() !void {
+    const x = mod0(999, 0);
+    _ = x;
+    return error.TestFailed;
+}
+fn mod0(a: i32, b: i32) i32 {
+    return @mod(a, b);
+}
+// run
+// backend=llvm
+// target=native

--- a/test/cases/safety/remainder division by zero.zig
+++ b/test/cases/safety/remainder division by zero.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace) noreturn {
+    _ = stack_trace;
+    if (std.mem.eql(u8, message, "division by zero")) {
+        std.process.exit(0);
+    }
+    std.process.exit(1);
+}
+pub fn main() !void {
+    const x = rem0(999, 0);
+    _ = x;
+    return error.TestFailed;
+}
+fn rem0(a: i32, b: i32) i32 {
+    return @rem(a, b);
+}
+// run
+// backend=llvm
+// target=native


### PR DESCRIPTION
Piggybacking on 40f8f0134f5da9baaefd0fdab529d5585fa46199, remainder
division, modulus, and `%` syntax no longer emit safety checks for a
comptime-known denominator.