### PR TITLE
autodoc: only modify the DOM once to display the search results

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -3326,29 +3326,28 @@ var zigAnalysis;
     }
 
     if (matchedItems.length !== 0) {
-      resizeDomList(
-        domListSearchResults,
-        matchedItems.length,
-        '<li><a href="#"></a></li>'
-      );
-
       matchedItems.sort(function (a, b) {
         let cmp = operatorCompare(b.points, a.points);
         if (cmp != 0) return cmp;
         return operatorCompare(a.decl.name, b.decl.name);
       });
 
+      // Build up the list of search results
+      let matchedItemsHTML = "";
+
       for (let i = 0; i < matchedItems.length; i += 1) {
-        let liDom = domListSearchResults.children[i];
-        let aDom = liDom.children[0];
-        let match = matchedItems[i];
-        let lastPkgName = match.path.pkgNames[match.path.pkgNames.length - 1];
-        aDom.textContent = lastPkgName + "." + match.path.declNames.join(".");
-        aDom.setAttribute(
-          "href",
-          navLink(match.path.pkgNames, match.path.declNames)
-        );
+        const match = matchedItems[i];
+        const lastPkgName = match.path.pkgNames[match.path.pkgNames.length - 1];
+
+        const text = lastPkgName + "." + match.path.declNames.join(".");
+        const href = navLink(match.path.pkgNames, match.path.declNames);
+
+        matchedItemsHTML += `<li><a href="${href}">${text}</a></li>`;
       }
+
+      // Replace the search results using our newly constructed HTML string
+      domListSearchResults.innerHTML = matchedItemsHTML;
+
       renderSearchCursor();
 
       domSectSearchResults.classList.remove("hidden");


### PR DESCRIPTION
This changes how the documentation viewer creates search result items. By building up the HTML for the search results, and adding them to the DOM in one operation, it improves the performance when rendering many search results.

**Measurements:**
Starting from a freshly loaded page, and searching "a" (returning ~10,000 results) it takes ~70ms, versus ~1.9s previously.

**Old:**
![image](https://user-images.githubusercontent.com/2127629/183235971-0e0db34f-8388-4ed0-86f3-3f9724815056.png)

**New:**
![image](https://user-images.githubusercontent.com/2127629/183235985-ad275ff7-6266-48b2-8c9a-ac72fbe10ddd.png)

Unfortunately after this task, the browser recalculates styles and does a layout, taking another ~600ms or so. I'm still looking into what's causing that, but for now this is a small code change with a big improvement.