### PR TITLE
Add compile error for runtime parameter in function returning a comptime only type.

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -20,7 +20,7 @@ pub const Tokenizer = tokenizer.Tokenizer;
 /// If linking gnu libc (glibc), the `ok` value will be true if the target
 /// version is greater than or equal to `glibc_version`.
 /// If linking a libc other than these, returns `false`.
-pub fn versionCheck(glibc_version: std.builtin.Version) type {
+pub fn versionCheck(comptime glibc_version: std.builtin.Version) type {
     return struct {
         pub const ok = blk: {
             if (!builtin.link_libc) break :blk false;

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -406,7 +406,7 @@ pub const Header = struct {
     }
 };
 
-pub fn ProgramHeaderIterator(ParseSource: anytype) type {
+pub fn ProgramHeaderIterator(comptime ParseSource: anytype) type {
     return struct {
         elf_header: Header,
         parse_source: ParseSource,
@@ -456,7 +456,7 @@ pub fn ProgramHeaderIterator(ParseSource: anytype) type {
     };
 }
 
-pub fn SectionHeaderIterator(ParseSource: anytype) type {
+pub fn SectionHeaderIterator(comptime ParseSource: anytype) type {
     return struct {
         elf_header: Header,
         parse_source: ParseSource,

--- a/lib/std/io/bit_reader.zig
+++ b/lib/std/io/bit_reader.zig
@@ -7,7 +7,7 @@ const meta = std.meta;
 const math = std.math;
 
 /// Creates a stream which allows for reading bit fields from another stream
-pub fn BitReader(endian: std.builtin.Endian, comptime ReaderType: type) type {
+pub fn BitReader(comptime endian: std.builtin.Endian, comptime ReaderType: type) type {
     return struct {
         forward_reader: ReaderType,
         bit_buffer: u7,

--- a/lib/std/io/bit_writer.zig
+++ b/lib/std/io/bit_writer.zig
@@ -7,7 +7,7 @@ const meta = std.meta;
 const math = std.math;
 
 /// Creates a stream which allows for writing bit fields to another stream
-pub fn BitWriter(endian: std.builtin.Endian, comptime WriterType: type) type {
+pub fn BitWriter(comptime endian: std.builtin.Endian, comptime WriterType: type) type {
     return struct {
         forward_writer: WriterType,
         bit_buffer: u8,

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -764,7 +764,7 @@ const TagPayloadType = TagPayload;
 
 ///Given a tagged union type, and an enum, return the type of the union
 /// field corresponding to the enum tag.
-pub fn TagPayload(comptime U: type, tag: Tag(U)) type {
+pub fn TagPayload(comptime U: type, comptime tag: Tag(U)) type {
     comptime debug.assert(trait.is(.Union)(U));
 
     const info = @typeInfo(U).Union;

--- a/lib/std/multi_array_list.zig
+++ b/lib/std/multi_array_list.zig
@@ -459,7 +459,7 @@ pub fn MultiArrayList(comptime S: type) type {
             return self.bytes[0..capacityInBytes(self.capacity)];
         }
 
-        fn FieldType(field: Field) type {
+        fn FieldType(comptime field: Field) type {
             return meta.fieldInfo(S, field).field_type;
         }
 

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -745,7 +745,7 @@ fn setAttribute(attr: Attribute) void {
     _ = attr;
 }
 
-fn Setter(attr: Attribute) type {
+fn Setter(comptime attr: Attribute) type {
     return struct {
         fn set() void {
             setAttribute(attr);

--- a/test/cases/compile_errors/explain_why_fn_is_called_at_comptime.zig
+++ b/test/cases/compile_errors/explain_why_fn_is_called_at_comptime.zig
@@ -4,12 +4,12 @@ const S = struct {
 };
 fn bar() void {}
 
-fn foo(a: u8) S {
-    return .{ .fnPtr = bar, .a = a };
+fn foo(comptime a: *u8) S {
+    return .{ .fnPtr = bar, .a = a.* };
 }
 pub export fn entry() void {
     var a: u8 = 1;
-    _ = foo(a);
+    _ = foo(&a);
 }
 
 // error
@@ -18,6 +18,6 @@ pub export fn entry() void {
 //
 // :12:13: error: unable to resolve comptime value
 // :12:13: note: argument to function being called at comptime must be comptime known
-// :7:15: note: function is being called at comptime because it returns a comptime only type 'tmp.S'
+// :7:25: note: function is being called at comptime because it returns a comptime only type 'tmp.S'
 // :2:12: note: struct requires comptime because of this field
 // :2:12: note: use '*const fn() void' for a function pointer type

--- a/test/cases/compile_errors/non_comptime_param_in_comptime_function.zig
+++ b/test/cases/compile_errors/non_comptime_param_in_comptime_function.zig
@@ -1,0 +1,36 @@
+fn F(val: anytype) type {
+    _ = val;
+    return struct {};
+}
+export fn entry() void {
+    _ = F(void{});
+}
+const S = struct {
+    foo: fn () void,
+};
+fn bar(_: u32) S {
+    return undefined;
+}
+export fn entry1() void {
+    _ = bar();
+}
+// prioritize other return type errors
+fn foo(a: u32) callconv(.C) comptime_int {
+    return a;
+}
+export fn entry2() void {
+    _ = foo(1);
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :1:20: error: function with comptime only return type 'type' requires all parameters to be comptime
+// :1:20: note: types are not available at runtime
+// :1:6: note: param 'val' is required to be comptime
+// :11:16: error: function with comptime only return type 'tmp.S' requires all parameters to be comptime
+// :9:10: note: struct requires comptime because of this field
+// :9:10: note: use '*const fn() void' for a function pointer type
+// :11:8: note: param is required to be comptime
+// :18:29: error: return type 'comptime_int' not allowed in function with calling convention 'C'


### PR DESCRIPTION
Closes #12333

This PR implements a compile error for when a function which return type is comptime only takes a parameter which might be a runtime parameter.