### PR TITLE
stage2: pass anon name strategy to reify

### DIFF
--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -1220,7 +1220,6 @@ fn walkInstruction(
         .trunc,
         .round,
         .tag_name,
-        .reify,
         .type_name,
         .frame_type,
         .frame_size,
@@ -2605,6 +2604,7 @@ fn walkInstruction(
                 },
                 .error_to_int,
                 .int_to_error,
+                .reify,
                 => {
                     const extra = file.zir.extraData(Zir.Inst.UnNode, extended.operand).data;
                     const bin_index = self.exprs.items.len;

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -839,8 +839,6 @@ pub const Inst = struct {
         round,
         /// Implement builtin `@tagName`. Uses `un_node`.
         tag_name,
-        /// Implement builtin `@Type`. Uses `un_node`.
-        reify,
         /// Implement builtin `@typeName`. Uses `un_node`.
         type_name,
         /// Implement builtin `@Frame`. Uses `un_node`.
@@ -1197,7 +1195,6 @@ pub const Inst = struct {
                 .trunc,
                 .round,
                 .tag_name,
-                .reify,
                 .type_name,
                 .frame_type,
                 .frame_size,
@@ -1484,7 +1481,6 @@ pub const Inst = struct {
                 .trunc,
                 .round,
                 .tag_name,
-                .reify,
                 .type_name,
                 .frame_type,
                 .frame_size,
@@ -1759,7 +1755,6 @@ pub const Inst = struct {
                 .trunc = .un_node,
                 .round = .un_node,
                 .tag_name = .un_node,
-                .reify = .un_node,
                 .type_name = .un_node,
                 .frame_type = .un_node,
                 .frame_size = .un_node,
@@ -1980,6 +1975,10 @@ pub const Inst = struct {
         /// Implement builtin `@intToError`.
         /// `operand` is payload index to `UnNode`.
         int_to_error,
+        /// Implement builtin `@Type`.
+        /// `operand` is payload index to `UnNode`.
+        /// `small` contains `NameStrategy
+        reify,
 
         pub const InstData = struct {
             opcode: Extended,

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -214,7 +214,6 @@ const Writer = struct {
             .trunc,
             .round,
             .tag_name,
-            .reify,
             .type_name,
             .frame_type,
             .frame_size,
@@ -500,6 +499,7 @@ const Writer = struct {
             .wasm_memory_size,
             .error_to_int,
             .int_to_error,
+            .reify,
             => {
                 const inst_data = self.code.extraData(Zir.Inst.UnNode, extended.operand).data;
                 const src = LazySrcLoc.nodeOffset(inst_data.node);

--- a/test/cases/compile_errors/reify_type_for_tagged_union_with_extra_union_field.zig
+++ b/test/cases/compile_errors/reify_type_for_tagged_union_with_extra_union_field.zig
@@ -1,0 +1,35 @@
+const Tag = @Type(.{
+    .Enum = .{
+        .layout = .Auto,
+        .tag_type = u1,
+        .fields = &.{
+            .{ .name = "signed", .value = 0 },
+            .{ .name = "unsigned", .value = 1 },
+        },
+        .decls = &.{},
+        .is_exhaustive = true,
+    },
+});
+const Tagged = @Type(.{
+    .Union = .{
+        .layout = .Auto,
+        .tag_type = Tag,
+        .fields = &.{
+            .{ .name = "signed", .field_type = i32, .alignment = @alignOf(i32) },
+            .{ .name = "unsigned", .field_type = u32, .alignment = @alignOf(u32) },
+            .{ .name = "arst", .field_type = f32, .alignment = @alignOf(f32) },
+        },
+        .decls = &.{},
+    },
+});
+export fn entry() void {
+    var tagged = Tagged{ .signed = -1 };
+    tagged = .{ .unsigned = 1 };
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :13:16: error: no field named 'arst' in enum 'tmp.Tag'
+// :1:13: note: enum declared here


### PR DESCRIPTION
This avoids the issue in #12358 (and generally results in nicer names for reified types) but doesn't prevent it happening somewhere else.