### PR TITLE
Zig Usage Command

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -188,7 +188,7 @@ fn verifyLibcxxCorrectlyLinked() void {
 pub fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     if (args.len <= 1) {
         std.log.info("{s}", .{usage});
-        fatal("expected command argument", .{});
+        return;
     }
 
     if (std.process.can_execv and std.os.getenvZ("ZIG_IS_DETECTING_LIBC_PATHS") != null) {


### PR DESCRIPTION
Currently running 
```
zig
```
Returns usage + an error. 

Proposal here would be to just return usage, as a user the first command I will run is the `zig` command to get information about the possible commands preferably without an error. 