### PR TITLE
stage2: add compile error for shlExact overflow

### DIFF
--- a/test/cases/compile_errors/shlExact_shifts_out_1_bits.zig
+++ b/test/cases/compile_errors/shlExact_shifts_out_1_bits.zig
@@ -4,7 +4,7 @@ comptime {
 }
 
 // error
-// backend=stage1
+// backend=llvm
 // target=native
 //
-// tmp.zig:2:15: error: operation caused overflow
+// :2:15: error: operation caused overflow


### PR DESCRIPTION
I couldn't figure out if I was running the test case, I don't think I was.

Completes part of #12366, doesn't add a similar check for `shrExact` or `divExact`. 