### PR TITLE
Sema: error on ambiguous coercion of comptime float and ints

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -11211,7 +11211,7 @@ fn zirDiv(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Ins
         const rhs_val = maybe_rhs_val orelse unreachable;
         const rem = lhs_val.floatRem(rhs_val, resolved_type, sema.arena, target) catch unreachable;
         if (rem.compareWithZero(.neq)) {
-            return sema.fail(block, src, "ambiguous coercion of division operands '{s}' and '{s}'; division has non-zero reminder '{}'", .{
+            return sema.fail(block, src, "ambiguous coercion of division operands '{s}' and '{s}'; non-zero remainder '{}'", .{
                 @tagName(lhs_ty.tag()), @tagName(rhs_ty.tag()), rem.fmtValue(resolved_type, sema.mod),
             });
         }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -11202,18 +11202,17 @@ fn zirDiv(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Ins
     const maybe_lhs_val = try sema.resolveMaybeUndefValIntable(block, lhs_src, casted_lhs);
     const maybe_rhs_val = try sema.resolveMaybeUndefValIntable(block, rhs_src, casted_rhs);
 
-    if ((lhs_ty.tag() == .comptime_float and rhs_ty.tag() == .comptime_int) or
-        (lhs_ty.tag() == .comptime_int and rhs_ty.tag() == .comptime_float))
+    if ((lhs_ty.zigTypeTag() == .ComptimeFloat and rhs_ty.zigTypeTag() == .ComptimeInt) or
+        (lhs_ty.zigTypeTag() == .ComptimeInt and rhs_ty.zigTypeTag() == .ComptimeFloat))
     {
         // If it makes a difference whether we coerce to ints or floats before doing the division, error.
         // If lhs % rhs is 0, it doesn't matter.
-        var lhs_val = maybe_lhs_val orelse unreachable;
-        var rhs_val = maybe_rhs_val orelse unreachable;
-        var rem = lhs_val.floatRem(rhs_val, resolved_type, sema.arena, target) catch unreachable;
-        var float_rem = rem.toFloat(f32);
-        if (float_rem != 0.0) {
-            return sema.fail(block, src, "ambiguous coercion of division operands: '{s}' and '{s}': division has non-zero reminder: {d}", .{
-                @tagName(lhs_ty.tag()), @tagName(rhs_ty.tag()), float_rem,
+        const lhs_val = maybe_lhs_val orelse unreachable;
+        const rhs_val = maybe_rhs_val orelse unreachable;
+        const rem = lhs_val.floatRem(rhs_val, resolved_type, sema.arena, target) catch unreachable;
+        if (rem.compareWithZero(.neq)) {
+            return sema.fail(block, src, "ambiguous coercion of division operands '{s}' and '{s}'; division has non-zero reminder '{}'", .{
+                @tagName(lhs_ty.tag()), @tagName(rhs_ty.tag()), rem.fmtValue(resolved_type, sema.mod),
             });
         }
     }

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -194,8 +194,8 @@ fn testSin() !void {
         const eps = epsForType(ty);
         try expect(@sin(@as(ty, 0)) == 0);
         try expect(math.approxEqAbs(ty, @sin(@as(ty, std.math.pi)), 0, eps));
-        try expect(math.approxEqAbs(ty, @sin(@as(ty, std.math.pi / 2)), 1, eps));
-        try expect(math.approxEqAbs(ty, @sin(@as(ty, std.math.pi / 4)), 0.7071067811865475, eps));
+        try expect(math.approxEqAbs(ty, @sin(@as(ty, std.math.pi / 2.0)), 1, eps));
+        try expect(math.approxEqAbs(ty, @sin(@as(ty, std.math.pi / 4.0)), 0.7071067811865475, eps));
     }
 
     {
@@ -228,8 +228,8 @@ fn testCos() !void {
         const eps = epsForType(ty);
         try expect(@cos(@as(ty, 0)) == 1);
         try expect(math.approxEqAbs(ty, @cos(@as(ty, std.math.pi)), -1, eps));
-        try expect(math.approxEqAbs(ty, @cos(@as(ty, std.math.pi / 2)), 0, eps));
-        try expect(math.approxEqAbs(ty, @cos(@as(ty, std.math.pi / 4)), 0.7071067811865475, eps));
+        try expect(math.approxEqAbs(ty, @cos(@as(ty, std.math.pi / 2.0)), 0, eps));
+        try expect(math.approxEqAbs(ty, @cos(@as(ty, std.math.pi / 4.0)), 0.7071067811865475, eps));
     }
 
     {

--- a/test/cases/compile_errors/ambiguous_coercion_of_division_operands.zig
+++ b/test/cases/compile_errors/ambiguous_coercion_of_division_operands.zig
@@ -15,10 +15,9 @@ export fn entry4() void {
     _ = f;
 }
 
-
 // error
 // backend=stage2
 // target=native
 //
-// :2:23: error: ambiguous coercion of division operands 'comptime_float' and 'comptime_int'; division has non-zero reminder '4'
-// :6:21: error: ambiguous coercion of division operands 'comptime_int' and 'comptime_float'; division has non-zero reminder '4'
+// :2:23: error: ambiguous coercion of division operands 'comptime_float' and 'comptime_int'; non-zero remainder '4'
+// :6:21: error: ambiguous coercion of division operands 'comptime_int' and 'comptime_float'; non-zero remainder '4'

--- a/test/cases/compile_errors/ambiguous_coercion_of_division_operands.zig
+++ b/test/cases/compile_errors/ambiguous_coercion_of_division_operands.zig
@@ -1,0 +1,24 @@
+export fn entry1() void {
+    var f: f32 = 54.0 / 5;
+    _ = f;
+}
+export fn entry2() void {
+    var f: f32 = 54 / 5.0;
+    _ = f;
+}
+export fn entry3() void {
+    var f: f32 = 55.0 / 5;
+    _ = f;
+}
+export fn entry4() void {
+    var f: f32 = 55 / 5.0;
+    _ = f;
+}
+
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:23: error: ambiguous coercion of division operands 'comptime_float' and 'comptime_int'; division has non-zero reminder '4'
+// :6:21: error: ambiguous coercion of division operands 'comptime_int' and 'comptime_float'; division has non-zero reminder '4'


### PR DESCRIPTION
The following, from the documentation as of the time of writing, illustrates
the problem:

```zig
// Compile time coercion of float to int
test "implicit cast to comptime_int" {
    var f: f32 = 54.0 / 5;
    _ = f;
}
```

It is not clear how to unify the types of 54.0 and 5 to perform the
division. We can either

 - cast 54.0 to comptime_int resulting in @as(comptime_int, 10), which is
   casted to @as(f32, 10), or
 - cast 5 to comptime_float resulting in @as(comptime_float, 10.8), which
   is casted to @as(f32, 10.8)

Since the two resulting values are different, a compiler error is appropriate.

Fixes: #12364

---

I wasn't sure about exactly which types should be disallowed, so I only used the comptimes. 

Further, this also raises an error in the flipped case, which stage1 doesn't:

```zig
// Compile time coercion of float to int
test "implicit cast to comptime_int" {
    var g: f32 = 10 / 3.0;
    _ = g;
}
```
Running:
```bash
$ zig version
0.9.1
$ zig test 12364.zig
All 1 tests passed.
$ zig-out/bin/zig test 12364.zig
12364.zig:5:21: error: ambiguous coercion of the division operands: 'ComptimeInt' and 'ComptimeFloat'
    var g: f32 = 10 / 3.0;
                 ~~~^~~~~
```