### PR TITLE
std: add error.LockViolation to windows.WriteFile

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -953,6 +953,10 @@ pub const WriteError = error{
     OperationAborted,
     NotOpenForWriting,
 
+    /// The process cannot access the file because another process has locked
+    /// a portion of the file. Windows-only.
+    LockViolation,
+
     /// This error occurs when no global event loop is configured,
     /// and reading from the file descriptor would block.
     WouldBlock,

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -517,6 +517,9 @@ pub const WriteFileError = error{
     OperationAborted,
     BrokenPipe,
     NotOpenForWriting,
+    /// The process cannot access the file because another process has locked
+    /// a portion of the file.
+    LockViolation,
     Unexpected,
 };
 
@@ -597,6 +600,7 @@ pub fn WriteFile(
                 .IO_PENDING => unreachable,
                 .BROKEN_PIPE => return error.BrokenPipe,
                 .INVALID_HANDLE => return error.NotOpenForWriting,
+                .LOCK_VIOLATION => return error.LockViolation,
                 else => |err| return unexpectedError(err),
             }
         }

--- a/src/link.zig
+++ b/src/link.zig
@@ -435,6 +435,7 @@ pub const File = struct {
         EmitFail,
         NameTooLong,
         CurrentWorkingDirectoryUnlinked,
+        LockViolation,
     };
 
     /// Called from within the CodeGen to lower a local variable instantion as an unnamed

--- a/src/main.zig
+++ b/src/main.zig
@@ -4227,6 +4227,7 @@ const FmtError = error{
     NotOpenForWriting,
     UnsupportedEncoding,
     ConnectionResetByPeer,
+    LockViolation,
 } || fs.File.OpenError;
 
 fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool, dir: fs.Dir, sub_path: []const u8) FmtError!void {


### PR DESCRIPTION
I encountered this error today when testing the self-hosted compiler on
Windows.