### PR TITLE
std: fix definition of SIG_IGN, SIG_DFL, etc.

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -814,10 +814,10 @@ pub const sigset_t = u32;
 pub const empty_sigset: sigset_t = 0;
 
 pub const SIG = struct {
-    pub const ERR = @intToPtr(?Sigaction.sigaction_fn, maxInt(usize));
-    pub const DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
-    pub const IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
-    pub const HOLD = @intToPtr(?Sigaction.sigaction_fn, 5);
+    pub const ERR = @intToPtr(?Sigaction.handler_fn, maxInt(usize));
+    pub const DFL = @intToPtr(?Sigaction.handler_fn, 0);
+    pub const IGN = @intToPtr(?Sigaction.handler_fn, 1);
+    pub const HOLD = @intToPtr(?Sigaction.handler_fn, 5);
 
     /// block specified signal set
     pub const _BLOCK = 1;

--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -609,9 +609,9 @@ pub const S = struct {
 pub const BADSIG = SIG.ERR;
 
 pub const SIG = struct {
-    pub const DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
-    pub const IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
-    pub const ERR = @intToPtr(?Sigaction.sigaction_fn, maxInt(usize));
+    pub const DFL = @intToPtr(?Sigaction.handler_fn, 0);
+    pub const IGN = @intToPtr(?Sigaction.handler_fn, 1);
+    pub const ERR = @intToPtr(?Sigaction.handler_fn, maxInt(usize));
 
     pub const BLOCK = 1;
     pub const UNBLOCK = 2;

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -670,9 +670,9 @@ pub const SIG = struct {
     pub const UNBLOCK = 2;
     pub const SETMASK = 3;
 
-    pub const DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
-    pub const IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
-    pub const ERR = @intToPtr(?Sigaction.sigaction_fn, maxInt(usize));
+    pub const DFL = @intToPtr(?Sigaction.handler_fn, 0);
+    pub const IGN = @intToPtr(?Sigaction.handler_fn, 1);
+    pub const ERR = @intToPtr(?Sigaction.handler_fn, maxInt(usize));
 
     pub const WORDS = 4;
     pub const MAXSIG = 128;

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -910,9 +910,9 @@ pub const winsize = extern struct {
 const NSIG = 32;
 
 pub const SIG = struct {
-    pub const DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
-    pub const IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
-    pub const ERR = @intToPtr(?Sigaction.sigaction_fn, maxInt(usize));
+    pub const DFL = @intToPtr(?Sigaction.handler_fn, 0);
+    pub const IGN = @intToPtr(?Sigaction.handler_fn, 1);
+    pub const ERR = @intToPtr(?Sigaction.handler_fn, maxInt(usize));
 
     pub const WORDS = 4;
     pub const MAXSIG = 128;

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -982,11 +982,11 @@ pub const winsize = extern struct {
 const NSIG = 33;
 
 pub const SIG = struct {
-    pub const DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
-    pub const IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
-    pub const ERR = @intToPtr(?Sigaction.sigaction_fn, maxInt(usize));
-    pub const CATCH = @intToPtr(?Sigaction.sigaction_fn, 2);
-    pub const HOLD = @intToPtr(?Sigaction.sigaction_fn, 3);
+    pub const DFL = @intToPtr(?Sigaction.handler_fn, 0);
+    pub const IGN = @intToPtr(?Sigaction.handler_fn, 1);
+    pub const ERR = @intToPtr(?Sigaction.handler_fn, maxInt(usize));
+    pub const CATCH = @intToPtr(?Sigaction.handler_fn, 2);
+    pub const HOLD = @intToPtr(?Sigaction.handler_fn, 3);
 
     pub const HUP = 1;
     pub const INT = 2;

--- a/lib/std/c/solaris.zig
+++ b/lib/std/c/solaris.zig
@@ -879,10 +879,10 @@ pub const winsize = extern struct {
 const NSIG = 75;
 
 pub const SIG = struct {
-    pub const DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
-    pub const ERR = @intToPtr(?Sigaction.sigaction_fn, maxInt(usize));
-    pub const IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
-    pub const HOLD = @intToPtr(?Sigaction.sigaction_fn, 2);
+    pub const DFL = @intToPtr(?Sigaction.handler_fn, 0);
+    pub const ERR = @intToPtr(?Sigaction.handler_fn, maxInt(usize));
+    pub const IGN = @intToPtr(?Sigaction.handler_fn, 1);
+    pub const HOLD = @intToPtr(?Sigaction.handler_fn, 2);
 
     pub const WORDS = 4;
     pub const MAXSIG = 75;

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1787,7 +1787,7 @@ fn resetSegfaultHandler() void {
         return;
     }
     var act = os.Sigaction{
-        .handler = .{ .sigaction = os.SIG.DFL },
+        .handler = .{ .handler = os.SIG.DFL },
         .mask = os.empty_sigset,
         .flags = 0,
     };

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -476,9 +476,8 @@ pub fn abort() noreturn {
         // Install default handler so that the tkill below will terminate.
         const sigact = Sigaction{
             .handler = .{ .sigaction = SIG.DFL },
-            .mask = undefined,
-            .flags = undefined,
-            .restorer = undefined,
+            .mask = empty_sigset,
+            .flags = 0,
         };
         sigaction(SIG.ABRT, &sigact, null) catch |err| switch (err) {
             error.OperationNotSupported => unreachable,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -475,7 +475,7 @@ pub fn abort() noreturn {
 
         // Install default handler so that the tkill below will terminate.
         const sigact = Sigaction{
-            .handler = .{ .sigaction = SIG.DFL },
+            .handler = .{ .handler = SIG.DFL },
             .mask = empty_sigset,
             .flags = 0,
         };

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1945,9 +1945,9 @@ pub const SIG = if (is_mips) struct {
     pub const SYS = 31;
     pub const UNUSED = SIG.SYS;
 
-    pub const ERR = @intToPtr(?Sigaction.sigaction_fn, maxInt(usize));
-    pub const DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
-    pub const IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
+    pub const ERR = @intToPtr(?Sigaction.handler_fn, maxInt(usize));
+    pub const DFL = @intToPtr(?Sigaction.handler_fn, 0);
+    pub const IGN = @intToPtr(?Sigaction.handler_fn, 1);
 } else if (is_sparc) struct {
     pub const BLOCK = 1;
     pub const UNBLOCK = 2;
@@ -1989,9 +1989,9 @@ pub const SIG = if (is_mips) struct {
     pub const PWR = LOST;
     pub const IO = SIG.POLL;
 
-    pub const ERR = @intToPtr(?Sigaction.sigaction_fn, maxInt(usize));
-    pub const DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
-    pub const IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
+    pub const ERR = @intToPtr(?Sigaction.handler_fn, maxInt(usize));
+    pub const DFL = @intToPtr(?Sigaction.handler_fn, 0);
+    pub const IGN = @intToPtr(?Sigaction.handler_fn, 1);
 } else struct {
     pub const BLOCK = 0;
     pub const UNBLOCK = 1;
@@ -2032,9 +2032,9 @@ pub const SIG = if (is_mips) struct {
     pub const SYS = 31;
     pub const UNUSED = SIG.SYS;
 
-    pub const ERR = @intToPtr(?Sigaction.sigaction_fn, maxInt(usize));
-    pub const DFL = @intToPtr(?Sigaction.sigaction_fn, 0);
-    pub const IGN = @intToPtr(?Sigaction.sigaction_fn, 1);
+    pub const ERR = @intToPtr(?Sigaction.handler_fn, maxInt(usize));
+    pub const DFL = @intToPtr(?Sigaction.handler_fn, 0);
+    pub const IGN = @intToPtr(?Sigaction.handler_fn, 1);
 };
 
 pub const kernel_rwf = u32;

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -785,7 +785,7 @@ test "sigaction" {
     try testing.expect(signal_test_failed == false);
     // Check if the handler has been correctly reset to SIG_DFL
     try os.sigaction(os.SIG.USR1, null, &old_sa);
-    try testing.expectEqual(os.SIG.DFL, old_sa.handler.sigaction);
+    try testing.expectEqual(os.SIG.DFL, old_sa.handler.handler);
 }
 
 test "dup & dup2" {


### PR DESCRIPTION
POSIX specifies that the sa_handler field of the sigaction struct may
be set to SIG_IGN or SIG_DFL. However, the current constants in the
standard library use the function pointer signature corresponding to
the sa_sigaction field instead.

This may not cause issues in practice because the fields usually occupy
the same memory in a union, but this isn't required by POSIX and there
may be systems we do not yet support that do this differently.

Fixing this also makes the Zig interface less confusing to use after
reading the man page.

I've also included a commit fixing one case where we pass undefined memory to the kernel :/