### PR TITLE
Sema: error on signed integer division

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -11262,7 +11262,7 @@ fn zirDiv(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Ins
     }
 
     const air_tag = if (is_int) blk: {
-        if (lhs_ty.isSignedInt() != rhs_ty.isSignedInt()) {
+        if (lhs_ty.isSignedInt() or rhs_ty.isSignedInt()) {
             return sema.fail(block, src, "division with '{s}' and '{s}': signed integers must use @divTrunc, @divFloor, or @divExact", .{ @tagName(lhs_ty.tag()), @tagName(rhs_ty.tag()) });
         }
         break :blk Air.Inst.Tag.div_trunc;

--- a/test/cases/compile_errors/signed_integer_division.zig
+++ b/test/cases/compile_errors/signed_integer_division.zig
@@ -1,0 +1,9 @@
+export fn foo(a: i32, b: i32) i32 {
+    return a / b;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:14: error: division with 'i32' and 'i32': signed integers must use @divTrunc, @divFloor, or @divExact

--- a/test/cases/compile_errors/stage1/obj/signed_integer_division.zig
+++ b/test/cases/compile_errors/stage1/obj/signed_integer_division.zig
@@ -1,9 +1,0 @@
-export fn foo(a: i32, b: i32) i32 {
-    return a / b;
-}
-
-// error
-// backend=stage1
-// target=native
-//
-// tmp.zig:2:14: error: division with 'i32' and 'i32': signed integers must use @divTrunc, @divFloor, or @divExact


### PR DESCRIPTION
stage1 error reads

error: division with 'i32' and 'comptime_int': signed integers must use @divTrunc, @divFloor, or @divExact

Fixes: #12339

---

Trying to compile the example in #12339 

```zig
const std = @import("std");

pub fn main() void {
    var v1: i32 = -49;
    var v2: i32 = v1/2;
    std.log.info("Result: {}", .{v2});
}
```
we now get
```bash
$ stage2/bin/zig test 12339.zig
12339.zig:5:21: error: division with 'i32' and 'comptime_int': signed integers must use @divTrunc, @divFloor, or @divExact
    var v2: i32 = v1/2;
                  ~~^~
```