### PR TITLE
x86: fix generating debug info for variables

### DIFF
--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -1259,7 +1259,7 @@ fn writeDeclDebugInfo(self: *Dwarf, file: *File, atom: *Atom, dbg_info_buf: []co
                     debug_info_sect.addr = dwarf_segment.vmaddr + new_offset - dwarf_segment.fileoff;
                 }
                 debug_info_sect.size = needed_size;
-                d_sym.debug_line_header_dirty = true;
+                d_sym.debug_info_header_dirty = true;
             }
             const file_pos = debug_info_sect.offset + atom.off;
             try pwriteDbgInfoNops(

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -102,7 +102,7 @@ pub const DeclState = struct {
     }
 
     pub fn addExprlocReloc(self: *DeclState, target: u32, offset: u32, is_ptr: bool) !void {
-        log.debug("{x}: target sym @{d}, via GOT {}", .{ offset, target, is_ptr });
+        log.debug("{x}: target sym %{d}, via GOT {}", .{ offset, target, is_ptr });
         try self.exprloc_relocs.append(self.gpa, .{
             .@"type" = if (is_ptr) .got_load else .direct_load,
             .target = target,
@@ -135,7 +135,7 @@ pub const DeclState = struct {
                 .@"type" = ty,
                 .offset = undefined,
             });
-            log.debug("@{d}: {}", .{ sym_index, ty.fmtDebug() });
+            log.debug("%{d}: {}", .{ sym_index, ty.fmtDebug() });
             try self.abbrev_resolver.putNoClobberContext(self.gpa, ty, sym_index, .{
                 .mod = self.mod,
             });
@@ -143,7 +143,7 @@ pub const DeclState = struct {
                 .mod = self.mod,
             }).?;
         };
-        log.debug("{x}: @{d} + 0", .{ offset, resolv });
+        log.debug("{x}: %{d} + 0", .{ offset, resolv });
         try self.abbrev_relocs.append(self.gpa, .{
             .target = resolv,
             .atom = atom,
@@ -1056,6 +1056,7 @@ pub fn commitDeclState(
                 break :blk false;
             };
             if (deferred) {
+                log.debug("resolving %{d} deferred until flush", .{target});
                 try self.global_abbrev_relocs.append(gpa, .{
                     .target = null,
                     .offset = reloc.offset,
@@ -1063,10 +1064,12 @@ pub fn commitDeclState(
                     .addend = reloc.addend,
                 });
             } else {
+                const value = symbol.atom.off + symbol.offset + reloc.addend;
+                log.debug("{x}: [() => {x}] (%{d}, '{}')", .{ reloc.offset, value, target, ty.fmtDebug() });
                 mem.writeInt(
                     u32,
                     dbg_info_buffer.items[reloc.offset..][0..@sizeOf(u32)],
-                    symbol.atom.off + symbol.offset + reloc.addend,
+                    value,
                     target_endian,
                 );
             }


### PR DESCRIPTION
Add handling for these additional `MCValue`s:
* `.immediate` - lower to `DW.OP.consts` or `DW.OP.constu` depending
  on signedness followed by popping off the DWARF stack with
  `DW.OP.stack_value`
* `.undef` - lower to `DW.OP.implicit_value`
* `.none` - lower to `DW.OP.lit0` followed by popping off the DWARF
  stack with `DW.OP.stack_value`

For any remaining unhandled case, we generate `DW.OP.nop` in order
not to mess up remaining DWARF info.

Also, update `__DWARF` sections before and after writing out `__LINKEDIT` sections in dSYM bundle for MachO.