### PR TITLE
stage2 astgen: Use `rl` semantics for `@Type`

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -7676,7 +7676,8 @@ fn builtinCall(
                 } },
             });
             gz.instructions.appendAssumeCapacity(new_index);
-            return indexToRef(new_index);
+            const result = indexToRef(new_index);
+            return rvalue(gz, rl, result, node);
         },
         .panic => {
             try emitDbgNode(gz, node);

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -84,6 +84,7 @@ test {
     _ = @import("behavior/bugs/11213.zig");
     _ = @import("behavior/bugs/12003.zig");
     _ = @import("behavior/bugs/12033.zig");
+    _ = @import("behavior/bugs/12430.zig");
     _ = @import("behavior/byteswap.zig");
     _ = @import("behavior/byval_arg_var.zig");
     _ = @import("behavior/call.zig");

--- a/test/behavior/bugs/12430.zig
+++ b/test/behavior/bugs/12430.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+
+test {
+    const T = comptime b: {
+        break :b @Type(.{ .Int = .{
+            .signedness = .unsigned,
+            .bits = 8,
+        } });
+    };
+    try std.testing.expect(T == u8);
+}


### PR DESCRIPTION
Super smol fix.

Resolves #12430.