### PR TITLE
Sema: Revert sema.err to null if the Decl already has an error

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1925,6 +1925,7 @@ fn failWithOwnedErrorMsg(sema: *Sema, err_msg: *Module.ErrorMsg) CompileError {
     const gop = mod.failed_decls.getOrPutAssumeCapacity(sema.owner_decl_index);
     if (gop.found_existing) {
         // If there are multiple errors for the same Decl, prefer the first one added.
+        sema.err = null;
         err_msg.destroy(mod.gpa);
     } else {
         gop.value_ptr.* = err_msg;


### PR DESCRIPTION
Previously we would assign the error message to Sema and then never
clear it even when destroying the error message, which caused memory
corruption.