### PR TITLE
Partial workaround for #1923, isolating error return traces between individual tests

### DIFF
--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -96,6 +96,13 @@ pub fn main() void {
                 test_node.end();
             },
         }
+        // Workaround issue #1923 by clearing error stack traces between tests
+        //
+        // This is not a true fix, but helps isolate errors to the tests where they
+        // originate instead of confusing them all together
+        if (@errorReturnTrace()) |trace| {
+            trace.index = 0;
+        }
     }
     root_node.end();
     if (ok_count == test_fn_list.len) {


### PR DESCRIPTION
Essentially #1923 means "caught" errors still show up in error return traces.
The correct fix would require the compiler to fix this, but that could affect performance.

For now, simply workaround this issue by clearing the return traces
between tests.

This means that "caught" errors in one test will not show up in the
error traces of other tests.

Consider the following code:
```zig
const std = @import("std");
const testing = std.testing;
 
export fn add(a: i32, b: i32) i32 {
    return a + b;
}
 
test "expect error" {
    const func = struct {
        fn oom() !void {
            return error.OutOfMemory;
        }
    };
    try testing.expectError(error.OutOfMemory, func.oom());
}
 
test "basic add functionality" {
    try testing.expect(add(3, 7) == 11);
}
```

Here is the behavior before this change:
<img width="907" alt="image" src="https://user-images.githubusercontent.com/4615889/184504044-64ebfdda-2765-4587-a1b7-5794d96ca318.png">

Here is the behavior afterwards:
<img width="972" alt="image" src="https://user-images.githubusercontent.com/4615889/184504058-3119fab1-6cde-4c06-9105-07260e2a3944.png">

**EDIT**: Also thanks for @squeek502 for identifying the correct workaround