### PR TITLE
child_process: split spawn into fork/exec

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -670,6 +670,7 @@ pub const ChildProcess = struct {
             forkChildErrReport(self.err_pipe_write, err);
         }
 
+        /// Performs setup in the child process, i.e. std pipes, cwd, gid, uid.
         pub fn setup(self: Forked) !void {
             try setUpChildIo(self.child.stdin_behavior, self.stdin_pipe[0], os.STDIN_FILENO, self.dev_null_fd);
             try setUpChildIo(self.child.stdout_behavior, self.stdout_pipe[1], os.STDOUT_FILENO, self.dev_null_fd);
@@ -711,12 +712,13 @@ pub const ChildProcess = struct {
         }
     };
 
-    /// fork off the child process.  Calling fork is equivalent to spawn except it will return
+    /// fork off the child process.  Returns `null` for the current process and `Forked` for
+    /// the child process.  Calling fork is equivalent to spawn except it will return
     /// in the child process before calling setup/exec.  This provides an opportunity for the
     /// caller to perform additional setup in the child process before calling setup/exec.
     ///
     /// This API does not support resource cleanup in the child process after fork returns.
-    /// The caller is only mean to perform setup and then call exec or exit afterwards.
+    /// The caller is only meant to perform setup and then call exec or exit afterwards.
     ///
     /// Note there are limitations on what can be done in the child process after fork returns.
     /// For example, calling malloc from libc may cause deadlock.

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -37,6 +37,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     if (builtin.os.tag != .windows) {
         // https://github.com/ziglang/zig/issues/12419
         cases.addBuildFile("test/standalone/issue_11595/build.zig", .{});
+        cases.addBuildFile("test/standalone/child_process_setup/build.zig", .{});
     }
     if (builtin.os.tag != .wasi) {
         cases.addBuildFile("test/standalone/load_dynamic_library/build.zig", .{});

--- a/test/standalone/child_process_setup/build.zig
+++ b/test/standalone/child_process_setup/build.zig
@@ -2,10 +2,8 @@ const std = @import("std");
 
 pub fn build(b: *std.build.Builder) void {
     const target = b.standardTargetOptions(.{});
-    const mode = b.standardReleaseOptions();
     const exe = b.addExecutable("child_process_setup", "main.zig");
     exe.setTarget(target);
-    exe.setBuildMode(mode);
     const run = exe.run();
     run.stdout_action = .{
         .expect_exact = "child process waiting for pipe to close...\n" ++

--- a/test/standalone/child_process_setup/build.zig
+++ b/test/standalone/child_process_setup/build.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    const target = b.standardTargetOptions(.{});
+    const mode = b.standardReleaseOptions();
+    const exe = b.addExecutable("child_process_setup", "main.zig");
+    exe.setTarget(target);
+    exe.setBuildMode(mode);
+    const run = exe.run();
+    run.stdout_action = .{
+        .expect_exact = "child process waiting for pipe to close...\n" ++
+            "pipe closed\n",
+    };
+    run.step.dependOn(&exe.step);
+    const test_step = b.step("test", "Run the app");
+    // TODO: implement ChildProcess.fork on darwin
+    if (target.isDarwin())
+        return;
+    test_step.dependOn(&run.step);
+}

--- a/test/standalone/child_process_setup/main.zig
+++ b/test/standalone/child_process_setup/main.zig
@@ -1,0 +1,81 @@
+const builtin = @import("builtin");
+const std = @import("std");
+const os = std.os;
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer if (gpa.deinit()) @panic("leaks");
+    const al = gpa.allocator();
+
+    const args = try std.process.argsAlloc(al);
+    defer al.free(args);
+
+    if (args.len <= 1) {
+        try parentMain(al);
+    } else {
+        try childMain(args);
+    }
+}
+
+fn parentMain(al: std.mem.Allocator) !void {
+    // mimic a real use case for child process setup, setting up a
+    // pipe that needs to be closed in the child process
+    const act = os.Sigaction{
+        .handler = .{ .handler = os.SIG.IGN },
+        .mask = os.empty_sigset,
+        .flags = os.SA.SIGINFO,
+    };
+    try os.sigaction(os.SIG.PIPE, &act, null);
+    const pipe = try os.pipe();
+
+    const self_exe = try std.fs.selfExePathAlloc(al);
+    defer al.free(self_exe);
+    var read_pipe_str_buf: [30]u8 = undefined;
+    const read_pipe_str = try std.fmt.bufPrint(&read_pipe_str_buf, "{d}", .{pipe[0]});
+    var child = std.ChildProcess.init(&[_][]const u8{
+        self_exe,
+        read_pipe_str,
+    }, al);
+    if (try child.fork()) |forked| {
+        // This statement is the purpose of this test. It demonstrates that
+        // the ChildProcess API supports extra setup in the child process.
+        //
+        // In this case we close the write end of the pipe in the child process so that
+        // when the parent process closes it, the read end of the pipe will also close,
+        // otherwise, the pipe would stay open since the child process has a reference
+        // to the write end of the pipe.
+        os.close(pipe[1]);
+
+        forked.setup() catch |err| forked.reportError(err);
+        forked.reportError(forked.exec());
+    }
+
+    const len = try os.write(pipe[1], "hello");
+    std.debug.assert(len == 5);
+    os.close(pipe[1]);
+
+    const term = try child.wait();
+    switch (term) {
+        .Exited => |code| if (code != 0) @panic("non-zero exit code from child"),
+        else => @panic("abnormal child process termination"),
+    }
+}
+
+fn childMain(args: []const []const u8) !void {
+    const pipe_fd_str = args[1];
+    const pipe_fd = try std.fmt.parseInt(os.fd_t, pipe_fd_str, 10);
+    var buf: [5]u8 = undefined;
+    {
+        const len = try os.read(pipe_fd, &buf);
+        std.debug.assert(len == 5);
+        std.debug.assert(std.mem.eql(u8, &buf, "hello"));
+    }
+    {
+        // if the write end of the pipe wasn't closed then we'll just wait
+        // here forever
+        try std.io.getStdOut().writer().writeAll("child process waiting for pipe to close...\n");
+        const len = try os.read(pipe_fd, &buf);
+        try std.io.getStdOut().writer().writeAll("pipe closed\n");
+        std.debug.assert(len == 0);
+    }
+}


### PR DESCRIPTION
This is a proposed enhancement to the `ChildProcess` API.  In addition to `spawn`, this PR adds the `fork` function to `ChildProcess` which returns an instance of `Forked` which provides the `setup` and `exec` functions to finish spawning the child process.  This allows applications to utilize the functionality that `ChildProcess` provides without giving up the flexibility to perform custom setup code in the child process when needed.

Note that another variation I considered for this was to add one or more callbacks to `ChildProcess` that could be executed in the child process.  A callback design would be equivalent to what I've done here, except instead of adding a Context/Callback in the std library (the "Forked" context and setup/exec "callbacks"), the application would create their own Context/Callback(s).  By doing this in the std library instead, it only needs to be done once rather than once per use of the API.