### PR TITLE
autodoc: better No Results Found page and other improvements

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -169,8 +169,8 @@
         width: 100%;
         margin-bottom: 0.8rem;
         padding: 0.5rem;
-        font-size: 1rem;
         font-family: var(--ui);
+        font-size: 1rem;
         color: var(--tx-color);
         background-color: var(--search-bg-color);
         border-top: 0;
@@ -339,8 +339,8 @@
       kbd {
         display: inline-block;
         padding: 0.3em 0.2em;
-        font-size: 1.2em;
-        font-size: var(--mono);
+        font-family: var(--mono);
+        font-size: 1em;
         line-height: 0.8em;
         vertical-align: middle;
         color: #000;

--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -612,7 +612,7 @@
           </div>
         </nav>
       </div>
-      <div class="flex-right">
+      <div id="docs" class="flex-right">
         <div class="wrap">
           <section class="docs">
             <div style="position: relative">

--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -722,11 +722,13 @@
         <div class="modal">
           <h1>Keyboard Shortcuts</h1>
           <dl><dt><kbd>?</kbd></dt><dd>Show this help modal</dd></dl>
-          <dl><dt><kbd>Esc</kbd></dt><dd>Clear focus; close this modal</dd></dl>
           <dl><dt><kbd>s</kbd></dt><dd>Focus the search field</dd></dl>
-          <dl><dt><kbd>↑</kbd></dt><dd>Move up in search results</dd></dl>
-          <dl><dt><kbd>↓</kbd></dt><dd>Move down in search results</dd></dl>
-          <dl><dt><kbd>⏎</kbd></dt><dd>Go to active search result</dd></dl>
+          <div style="margin-left: 1em">
+            <dl><dt><kbd>↑</kbd></dt><dd>Move up in search results</dd></dl>
+            <dl><dt><kbd>↓</kbd></dt><dd>Move down in search results</dd></dl>
+            <dl><dt><kbd>⏎</kbd></dt><dd>Go to active search result</dd></dl>
+          </div>
+          <dl><dt><kbd>Esc</kbd></dt><dd>Clear focus; close this modal</dd></dl>
         </div>
       </div>
     </div>

--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -654,7 +654,13 @@
             </div>
             <div id="sectSearchNoResults" class="hidden">
               <h2>No Results Found</h2>
-              <p>Press escape to exit search and then '?' to see more options.</p>
+              <p>Here are some things you can try:</p>
+              <ul>
+                <li>Check out the <a id="langRefLink">Language Reference</a> for the language itself.</li>
+                <li>Check out the <a href="https://ziglang.org/learn/">Learn page</a> for other helpful resources for learning Zig.</li>
+                <li>Use your search engine.</li>
+              </ul>
+              <p>Press <kbd>?</kbd> to see keyboard shortcuts and <kbd>Esc</kbd> to return.</p>
             </div>
             <div id="sectFields" class="hidden">
               <h2>Fields</h2>

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -41,7 +41,7 @@ var zigAnalysis;
   const domSearch = document.getElementById("search");
   const domSectSearchResults = document.getElementById("sectSearchResults");
   const domSectSearchAllResultsLink = document.getElementById("sectSearchAllResultsLink");
-
+  const domDocs = document.getElementById("docs");
   const domListSearchResults = document.getElementById("listSearchResults");
   const domSectSearchNoResults = document.getElementById("sectSearchNoResults");
   const domSectInfo = document.getElementById("sectInfo");
@@ -3262,9 +3262,9 @@ var zigAnalysis;
         break;
       case "s":
         if (domHelpModal.classList.contains("hidden")) {
-          // TODO: scroll the page to the very top
           domSearch.focus();
           domSearch.select();
+          domDocs.scrollTo(0, 0);
           ev.preventDefault();
           ev.stopPropagation();
           startAsyncSearch();

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -51,6 +51,7 @@ var zigAnalysis;
   const domHdrName = document.getElementById("hdrName");
   const domHelpModal = document.getElementById("helpModal");
   const domSearchPlaceholder = document.getElementById("searchPlaceholder");
+  const domLangRefLink = document.getElementById("langRefLink");
 
   let searchTimer = null;
   let searchTrimResults = true;
@@ -160,6 +161,13 @@ var zigAnalysis;
   window.addEventListener("hashchange", onHashChange, false);
   window.addEventListener("keydown", onWindowKeyDown, false);
   onHashChange();
+
+  let langRefVersion = zigAnalysis.params.zigVersion;
+  if (!/^\d+\.\d+\.\d+$/.test(langRefVersion)) {
+    // the version is probably not released yet
+    langRefVersion = "master";
+  }
+  domLangRefLink.href = `https://ziglang.org/documentation/${langRefVersion}/`;
 
   function renderTitle() {
     let list = curNav.pkgNames.concat(curNav.declNames);

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -3148,6 +3148,7 @@ var zigAnalysis;
     domSearch.blur();
   }
 
+  // hide the modal if it's visible or return to the previous result page and unfocus the search
   function onEscape(ev) {
     if (!domHelpModal.classList.contains("hidden")) {
       domHelpModal.classList.add("hidden");

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -3148,6 +3148,22 @@ var zigAnalysis;
     domSearch.blur();
   }
 
+  function onEscape(ev) {
+    if (!domHelpModal.classList.contains("hidden")) {
+      domHelpModal.classList.add("hidden");
+      ev.preventDefault();
+      ev.stopPropagation();
+    } else {
+      domSearch.value = "";
+      domSearch.blur();
+      domSearchPlaceholder.classList.remove("hidden");
+      curSearchIndex = -1;
+      ev.preventDefault();
+      ev.stopPropagation();
+      startSearch();
+    }
+  }
+
   function onSearchKeyDown(ev) {
     switch (getKeyString(ev)) {
       case "Enter":
@@ -3164,13 +3180,8 @@ var zigAnalysis;
         ev.stopPropagation();
         return;
       case "Esc":
-        domSearch.value = "";
-        domSearch.blur();
-        curSearchIndex = -1;
-        ev.preventDefault();
-        ev.stopPropagation();
-        startSearch();
-        return;
+        onEscape(ev);
+        return
       case "Up":
         moveSearchCursor(-1);
         ev.preventDefault();
@@ -3245,18 +3256,17 @@ var zigAnalysis;
   function onWindowKeyDown(ev) {
     switch (getKeyString(ev)) {
       case "Esc":
-        if (!domHelpModal.classList.contains("hidden")) {
-          domHelpModal.classList.add("hidden");
-          ev.preventDefault();
-          ev.stopPropagation();
-        }
+        onEscape(ev);
         break;
       case "s":
-        domSearch.focus();
-        domSearch.select();
-        ev.preventDefault();
-        ev.stopPropagation();
-        startAsyncSearch();
+        if (domHelpModal.classList.contains("hidden")) {
+          // TODO: scroll the page to the very top
+          domSearch.focus();
+          domSearch.select();
+          ev.preventDefault();
+          ev.stopPropagation();
+          startAsyncSearch();
+        }
         break;
       case "?":
         ev.preventDefault();
@@ -3273,6 +3283,7 @@ var zigAnalysis;
     domHelpModal.style.top =
       window.innerHeight / 2 - domHelpModal.clientHeight / 2 + "px";
     domHelpModal.focus();
+    domSearch.blur();
   }
 
   function clearAsyncSearch() {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -3189,6 +3189,7 @@ var zigAnalysis;
         ev.stopPropagation();
         return;
       case "Down":
+        // TODO: make the page scroll down if the search cursor is out of the screen
         moveSearchCursor(1);
         ev.preventDefault();
         ev.stopPropagation();

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -117,10 +117,10 @@ var zigAnalysis;
   });
   domSectSearchAllResultsLink.addEventListener('click', onClickSearchShowAllResults, false);
   function onClickSearchShowAllResults(ev) {
-      ev.preventDefault();
-      ev.stopPropagation();
-      searchTrimResults = false;
-      onHashChange();
+    ev.preventDefault();
+    ev.stopPropagation();
+    searchTrimResults = false;
+    onHashChange();
   }
 
   domPrivDeclsBox.addEventListener(
@@ -3309,7 +3309,7 @@ var zigAnalysis;
     list.sort();
     return list;
   }
-  
+
   function renderSearch() {
     let matchedItems = [];
     let ignoreCase = curNavSearch.toLowerCase() === curNavSearch;
@@ -3398,13 +3398,13 @@ var zigAnalysis;
         const text = lastPkgName + "." + match.path.declNames.join(".");
         const href = navLink(match.path.pkgNames, match.path.declNames);
 
-        matchedItemsHTML += "<li><a href=\""+ href +"\">"+ text + "</a></li>";
+        matchedItemsHTML += "<li><a href=\"" + href + "\">" + text + "</a></li>";
       }
 
       // Replace the search results using our newly constructed HTML string
       domListSearchResults.innerHTML = matchedItemsHTML;
       if (searchTrimmed) {
-          domSectSearchAllResultsLink.classList.remove("hidden");
+        domSectSearchAllResultsLink.classList.remove("hidden");
       }
       renderSearchCursor();
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35064754/184531674-577186c3-ee8e-4f39-b36f-389ae4e82af1.png)

For reference, here is Rust's page when you have no results: https://doc.rust-lang.org/std/collections/struct.HashSet.html?search=wdqqdw
As you can see, it offers you to make a search with DDG.
Even as mainly a DDG user myself, I think this is a little bit opinionated so I didn't add any explicit search engine link to search with. There are [other search engines](https://github.com/r00ster91/shifting#search_engines) too.

---

![image](https://user-images.githubusercontent.com/35064754/184531664-23ee85eb-0c88-4660-ac9e-fe966c431f05.png)

This indentation you can see is supposed to be a visual clue that those shortcuts are only available when having pressed <kbd>S</kbd> (or the search field is active).