### PR TITLE
libstd: fix off-by-one error in def of ProcSym in pdb.zig

### DIFF
--- a/test/stack_traces.zig
+++ b/test/stack_traces.zig
@@ -3,11 +3,6 @@ const os = std.os;
 const tests = @import("tests.zig");
 
 pub fn addCases(cases: *tests.StackTracesContext) void {
-    if (@import("builtin").os.tag == .windows) {
-        // https://github.com/ziglang/zig/issues/12422
-        return;
-    }
-
     cases.addCase(.{
         .name = "return",
         .source = 
@@ -178,7 +173,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
     cases.addCase(.{
         .exclude_os = .{
             .openbsd, // integer overflow
-            .windows,
+            .windows, // TODO intermittent failures
         },
         .name = "dumpCurrentStackTrace",
         .source = 


### PR DESCRIPTION
Fixes: #12422 

Make sure `ProcSym` includes a single element byte-array which delimits the start of the symbol's name as part of its definition. This makes the code more elegant in that accessing the name is equivalent to taking the address of this one element array.

Prior to this fix, `ProcSym` was defined as `packed struct` and reported size of `35`. After it was changed to `extern struct` in https://github.com/ziglang/zig/commit/b95942744c7ded279f5695ed20fdbbc806323cba the size reported is rounded to `36` (which is correct). However, according to https://github.com/microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L3722 `ProcSym` should include a one-element byte array which delimits the start of the symbol name which brings the size of  `ProcSym` to `36` without padding.