### PR TITLE
copy_file_range: fix zigification of TXTBSY

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -6255,7 +6255,7 @@ pub const CopyFileRangeError = error{
     NoSpaceLeft,
     Unseekable,
     PermissionDenied,
-    FileBusy,
+    SwapFile,
 } || PReadError || PWriteError || UnexpectedError;
 
 var has_copy_file_range_syscall = std.atomic.Atomic(bool).init(true);
@@ -6309,7 +6309,7 @@ pub fn copy_file_range(fd_in: fd_t, off_in: u64, fd_out: fd_t, off_out: u64, len
             .NOSPC => return error.NoSpaceLeft,
             .OVERFLOW => return error.Unseekable,
             .PERM => return error.PermissionDenied,
-            .TXTBSY => return error.FileBusy,
+            .TXTBSY => return error.SwapFile,
             // these may not be regular files, try fallback
             .INVAL => {},
             // support for cross-filesystem copy added in Linux 5.3, use fallback

--- a/src/link.zig
+++ b/src/link.zig
@@ -418,7 +418,7 @@ pub const File = struct {
         NoSpaceLeft,
         Unseekable,
         PermissionDenied,
-        FileBusy,
+        SwapFile,
         SystemResources,
         OperationAborted,
         BrokenPipe,


### PR DESCRIPTION
From `copy_file_range(2)` errors:

    ETXTBSY
           Either fd_in or fd_out refers to an active swap file.

Same error will be used in the upcoming `ioctl_ficlonerange(2)`:

    ETXTBSY
           One of the files is a swap file.  Swap files cannot share storage.