### PR TITLE
copy_file_range: use FICLONERANGE when possible

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2805,7 +2805,7 @@ fn copy_file(fd_in: os.fd_t, fd_out: os.fd_t) CopyFileRawError!void {
             // The kernel checks the u64 value `offset+count` for overflow, use
             // a 32 bit value so that the syscall won't return EINVAL except for
             // impossibly large files (> 2^64-1 - 2^32-1).
-            const amt = try os.copy_file_range(fd_in, offset, fd_out, offset, math.maxInt(u32), 0);
+            const amt = try os.copy_file_range(fd_in, offset, fd_out, offset, math.maxInt(u32));
             // Terminate when no data was copied
             if (amt == 0) break :cfr_loop;
             offset += amt;

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -1219,7 +1219,7 @@ pub const File = struct {
 
     pub fn copyRange(in: File, in_offset: u64, out: File, out_offset: u64, len: u64) CopyRangeError!u64 {
         const adjusted_len = math.cast(usize, len) orelse math.maxInt(usize);
-        const result = try os.copy_file_range(in.handle, in_offset, out.handle, out_offset, adjusted_len, 0);
+        const result = try os.copy_file_range(in.handle, in_offset, out.handle, out_offset, adjusted_len);
         return result;
     }
 

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -2760,6 +2760,13 @@ pub const DT = struct {
     pub const WHT = 14;
 };
 
+pub const FICLONERANGE_arg = extern struct {
+    src_fd: i64,
+    src_offset: u64,
+    src_length: u64,
+    dest_offset: u64,
+};
+
 pub const T = struct {
     pub const CGETS = if (is_mips) 0x540D else 0x5401;
     pub const CSETS = 0x5402;
@@ -2794,6 +2801,7 @@ pub const T = struct {
     pub const IOCGSERIAL = 0x541E;
     pub const IOCSSERIAL = 0x541F;
     pub const IOCPKT = 0x5420;
+    pub const FICLONERANGE = IOCTL.IOW(0x94, 13, FICLONERANGE_arg);
     pub const FIONBIO = 0x5421;
     pub const IOCNOTTY = 0x5422;
     pub const IOCSETD = 0x5423;


### PR DESCRIPTION
This is a follow-up from #12476: instead of adding a new abstraction to
clone files, start with `copy_file_range`. They use the same mechanism
in the kernel.

Benefits of FICLONERANGE vs `copy_file_range(2)`:
- O(1).
- CoW: so if files are not modified, it will not take additional space.

However, it is more restricted than copy_file_range: source and
destination must be on the same partition, and only some file systems
implement this. As of Linux 5.19 those are btrfs, cifs, nfs, ocfs2,
overlayfs and xfs[1].

Note: I removed `flags` from `copy_file_range` (that must be 0 as of writing). If we want to retain `flags`, this change shouldn't be as-is, and we probably need `os.clone_file_range`. If we add `clone_file_range`, should that function have fallbacks, like the `copy_file_range` does now?

[1]: https://elixir.bootlin.com/linux/v5.19/A/ident/remap_file_range