### PR TITLE
coff: specify default base path for relative source paths in pdb

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1016,6 +1016,9 @@ pub const InitOptions = struct {
     /// (Darwin) remove dylibs that are unreachable by the entry point or exported symbols
     dead_strip_dylibs: bool = false,
     libcxx_abi_version: libcxx.AbiVersion = libcxx.AbiVersion.default,
+    /// (Windows) PDB source path prefix to instruct the linker how to resolve relative
+    /// paths when consolidating CodeView streams into a single PDB file.
+    pdb_source_path: ?[]const u8 = null,
 };
 
 fn addPackageTableToCacheHash(
@@ -1719,6 +1722,27 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             };
         };
 
+        const pdb_source_path: ?[]const u8 = options.pdb_source_path orelse blk: {
+            if (builtin.target.os.tag == .windows) {
+                // PDB requires all file paths to be fully resolved, and it is really the
+                // linker's responsibility to canonicalize any path extracted from the CodeView
+                // in the object file. However, LLD-link has some very questionable defaults, and
+                // in particular, it purposely bakes in path separator of the host system it was
+                // built on rather than the targets, or just throw an error. Thankfully, they have
+                // left a backdoor we can use via -PDBSOURCEPATH.
+                const mod = module orelse break :blk null;
+                var buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+                const resolved_path = if (mod.main_pkg.root_src_directory.path) |base_path| p: {
+                    if (std.fs.path.isAbsolute(base_path)) break :blk base_path;
+                    const resolved_path = std.os.realpath(base_path, &buffer) catch break :blk null;
+                    const pos = std.mem.lastIndexOfLinear(u8, resolved_path, base_path) orelse resolved_path.len;
+                    break :p resolved_path[0..pos];
+                } else std.os.realpath(".", &buffer) catch break :blk null;
+                break :blk try arena.dupe(u8, resolved_path);
+            }
+            break :blk null;
+        };
+
         const implib_emit: ?link.Emit = blk: {
             const emit_implib = options.emit_implib orelse break :blk null;
 
@@ -1865,6 +1889,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .headerpad_max_install_names = options.headerpad_max_install_names,
             .dead_strip_dylibs = options.dead_strip_dylibs,
             .force_undefined_symbols = .{},
+            .pdb_source_path = pdb_source_path,
         });
         errdefer bin_file.destroy();
         comp.* = .{

--- a/src/link.zig
+++ b/src/link.zig
@@ -218,6 +218,10 @@ pub const Options = struct {
     /// (Darwin) remove dylibs that are unreachable by the entry point or exported symbols
     dead_strip_dylibs: bool = false,
 
+    /// (Windows) PDB source path prefix to instruct the linker how to resolve relative
+    /// paths when consolidating CodeView streams into a single PDB file.
+    pdb_source_path: ?[]const u8 = null,
+
     pub fn effectiveOutputMode(options: Options) std.builtin.OutputMode {
         return if (options.use_lld) .Obj else options.output_mode;
     }

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -181,6 +181,10 @@ pub fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
         try argv.append("-NOLOGO");
         if (!self.base.options.strip) {
             try argv.append("-DEBUG");
+
+            if (self.base.options.pdb_source_path) |path| {
+                try argv.append(try std.fmt.allocPrint(arena, "-PDBSOURCEPATH:{s}", .{path}));
+            }
         }
         if (self.base.options.lto) {
             switch (self.base.options.optimize_mode) {

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -962,7 +962,7 @@ pub const StackTracesContext = struct {
                         pos = marks[i] + delim.len;
                     }
                     // locate source basename
-                    pos = mem.lastIndexOfAny(u8, line[0..marks[0]], "\\/") orelse {
+                    pos = mem.lastIndexOfScalar(u8, line[0..marks[0]], fs.path.sep) orelse {
                         // unexpected pattern: emit raw line and cont
                         try buf.appendSlice(line);
                         try buf.appendSlice("\n");


### PR DESCRIPTION
This commit fixes inconsistent paths in stack trace printouts on Windows. Namely, we no longer have this situation:

```zig
pub fn main() void {
    gonnaFail();
}

fn gonnaFail() void {
    unreachable;
}
```

#### Current behavior:

```
$ main.exe
thread 17744 panic: reached unreachable code
C:/Users/kubkon/dev/examples/stack-traces/main.zig:6:5: 0x7ff6409a126f in gonnaFail (main.exe.obj)
    unreachable;
    ^
C:/Users/kubkon/dev/examples/stack-traces/main.zig:2:14: 0x7ff6409a123e in main (main.exe.obj)
    gonnaFail();
             ^
C:\Users\kubkon\dev\zig\stage3\lib\zig\std\start.zig:345:41: 0x7ff6409a12ca in WinStartup (main.exe.obj)
    }
                                        ^
Unable to dump stack trace: FileNotFound
```

#### With this patch:

```
$ main.exe
thread 17744 panic: reached unreachable code
C:\Users\kubkon\dev\examples\stack-traces\main.zig:6:5: 0x7ff6409a126f in gonnaFail (main.exe.obj)
    unreachable;
    ^
C:\Users\kubkon\dev\examples\stack-traces\main.zig:2:14: 0x7ff6409a123e in main (main.exe.obj)
    gonnaFail();
             ^
C:\Users\kubkon\dev\zig\stage3\lib\zig\std\start.zig:345:41: 0x7ff6409a12ca in WinStartup (main.exe.obj)
    }
                                        ^
Unable to dump stack trace: FileNotFound
```

The reason this happens is that PDB requires all file paths to be fully resolved, and it is really the linker's responsibility to canonicalize any path extracted from the CodeView in the object file. However, `LLD-link` has some very questionable defaults, and in particular, it purposely bakes in path separator of the host system it was built on rather the target's (to be honest, even throwing an error in such case would be better than a default like that IMHO). And so, because we built the Win devkit on a Linux host, `LLD-link` has POSIX-style separators baked in, and hence resolves relative paths such as `.\main.zig` into `C:/something/main.zig`.

Thankfully, they have left a backdoor we can use via `-PDBSOURCEPATH` flag.

From `LLD-link`'s help:

```
/pdbsourcepath:<value>  Base path used to make relative source file path absolute in PDB
```

If we are building a Zig module, we will provide a PDB source path prefix (if necessary) which overwrites path canonicalization in `LLD-link`. For context, code responsible for this in `LLD`: [lld/COFF/PDB.cpp#L243](https://github.com/llvm/llvm-project/blob/ac31781759889226711b801c3833fea280fdb7aa/lld/COFF/PDB.cpp#L243).

I would also like to point out the reason we didn't see this happen in stage1 is because in stage1 we always embedded fully resolved paths (with the exception when we are targeting MachO). Now that in stage3 we are including relative and absolute paths, this problem has surfaced.

Finally, with this commit we can revert half of https://github.com/ziglang/zig/pull/12368/commits/f2d30b3a6857a23a8c92c2f948e38df69a8df54e as the path separator is now consistent with the platform we are running the binary on.