### PR TITLE
Add Random.weightedIndex function

### DIFF
--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -343,7 +343,7 @@ pub const Random = struct {
     ///
     /// This is useful for selecting an item from a slice where weights are not equal.
     /// `T` must be a numeric type capable of holding the sum of `proportions`.
-    pub fn dice(r: std.rand.Random, comptime T: type, proportions: []T) usize {
+    pub fn weightedIndex(r: std.rand.Random, comptime T: type, proportions: []T) usize {
         // This implementation works by summing the proportions and picking a random
         //  point in [0, sum).  We then loop over the proportions, accumulating
         //  until our accumulator is greater than the random point.
@@ -361,7 +361,7 @@ pub const Random = struct {
             // take care that imprecision doesn't lead to a value slightly greater than sum
             std.math.min(r.float(T) * sum, sum - std.math.epsilon(T))
         else
-            @compileError("dice does not support proportions of type " ++ @typeName(T));
+            @compileError("weightedIndex does not support proportions of type " ++ @typeName(T));
 
         std.debug.assert(point < sum);
 

--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -360,7 +360,8 @@ pub const Random = struct {
         else if (comptime std.meta.trait.isFloat(T))
             // take care that imprecision doesn't lead to a value slightly greater than sum
             std.math.min(r.float(T) * sum, sum - std.math.epsilon(T))
-        else @compileError("dice does not support proportions of type "++@typeName(T));
+        else
+            @compileError("dice does not support proportions of type " ++ @typeName(T));
 
         std.debug.assert(point < sum);
 

--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -337,6 +337,41 @@ pub const Random = struct {
             mem.swap(T, &buf[i], &buf[j]);
         }
     }
+
+    /// Randomly selects an index into `proportions`, where the likelihood of each
+    /// index is weighted by that proportion.
+    ///
+    /// This is useful for selecting an item from a slice where weights are not equal.
+    /// `T` must be a numeric type capable of holding the sum of `proportions`.
+    pub fn dice(r: std.rand.Random, comptime T: type, proportions: []T) usize {
+        // This implementation works by summing the proportions and picking a random
+        //  point in [0, sum).  We then loop over the proportions, accumulating
+        //  until our accumulator is greater than the random point.
+
+        var sum: T = 0;
+        for (proportions) |v| {
+            sum += v;
+        }
+
+        const point = if (comptime std.meta.trait.isSignedInt(T))
+            r.intRangeLessThan(T, 0, sum)
+        else if (comptime std.meta.trait.isUnsignedInt(T))
+            r.uintLessThan(T, sum)
+        else if (comptime std.meta.trait.isFloat(T))
+            // take care that imprecision doesn't lead to a value slightly greater than sum
+            std.math.min(r.float(T) * sum, sum - std.math.epsilon(T))
+        else @compileError("dice does not support proportions of type "++@typeName(T));
+
+        std.debug.assert(point < sum);
+
+        var accumulator: T = 0;
+        for (proportions) |p, index| {
+            accumulator += p;
+            if (point < accumulator) return index;
+        }
+
+        unreachable;
+    }
 };
 
 /// Convert a random integer 0 <= random_int <= maxValue(T),

--- a/lib/std/rand/test.zig
+++ b/lib/std/rand/test.zig
@@ -448,12 +448,12 @@ test "CSPRNG" {
 
 test "Random dice" {
     // Make sure dice works for various integers and floats
-    inline for (.{u64, i4, f32, f64}) |T| {
+    inline for (.{ u64, i4, f32, f64 }) |T| {
         var prng = DefaultPrng.init(0);
         const random = prng.random();
 
         var proportions = [_]T{ 2, 1, 1, 2 };
-        var counts    = [_]u64{ 0, 0, 0, 0};
+        var counts = [_]u64{ 0, 0, 0, 0 };
 
         const n_trials: u64 = 10_000;
         var i: usize = 0;
@@ -466,8 +466,8 @@ test "Random dice" {
         const approxEq = std.math.approxEq;
         // Define "roughly" to be within 10%
         const tolerance = n_trials / 10;
-        try expect(approxEq(counts[0],     counts[1] * 2, tolerance));
-        try expect(approxEq(counts[1],     counts[2],     tolerance));
-        try expect(approxEq(counts[3] * 2, counts[4],     tolerance));
+        try expect(approxEq(counts[0], counts[1] * 2, tolerance));
+        try expect(approxEq(counts[1], counts[2], tolerance));
+        try expect(approxEq(counts[3] * 2, counts[4], tolerance));
     }
 }

--- a/lib/std/rand/test.zig
+++ b/lib/std/rand/test.zig
@@ -446,8 +446,8 @@ test "CSPRNG" {
     try expect(a ^ b ^ c != 0);
 }
 
-test "Random dice" {
-    // Make sure dice works for various integers and floats
+test "Random weightedIndex" {
+    // Make sure weightedIndex works for various integers and floats
     inline for (.{ u64, i4, f32, f64 }) |T| {
         var prng = DefaultPrng.init(0);
         const random = prng.random();
@@ -458,7 +458,7 @@ test "Random dice" {
         const n_trials: u64 = 10_000;
         var i: usize = 0;
         while (i < n_trials) : (i += 1) {
-            const pick = random.dice(T, &proportions);
+            const pick = random.weightedIndex(T, &proportions);
             counts[pick] += 1;
         }
 

--- a/lib/std/rand/test.zig
+++ b/lib/std/rand/test.zig
@@ -466,8 +466,8 @@ test "Random dice" {
         const approxEq = std.math.approxEq;
         // Define "roughly" to be within 10%
         const tolerance = n_trials / 10;
-        try expect(approxEq(counts[0], counts[1] * 2, tolerance));
-        try expect(approxEq(counts[1], counts[2], tolerance));
-        try expect(approxEq(counts[3] * 2, counts[4], tolerance));
+        try expect(approxEq(T, counts[0], counts[1] * 2, tolerance));
+        try expect(approxEq(T, counts[1], counts[2], tolerance));
+        try expect(approxEq(T, counts[3] * 2, counts[4], tolerance));
     }
 }

--- a/lib/std/rand/test.zig
+++ b/lib/std/rand/test.zig
@@ -453,7 +453,7 @@ test "Random dice" {
         const random = prng.random();
 
         var proportions = [_]T{ 2, 1, 1, 2 };
-        var counts = [_]u64{ 0, 0, 0, 0 };
+        var counts = [_]f64{ 0, 0, 0, 0 };
 
         const n_trials: u64 = 10_000;
         var i: usize = 0;
@@ -463,11 +463,11 @@ test "Random dice" {
         }
 
         // We expect the first and last counts to be roughly 2x the second and third
-        const approxEq = std.math.approxEq;
+        const approxEqRel = std.math.approxEqRel;
         // Define "roughly" to be within 10%
-        const tolerance = n_trials / 10;
-        try expect(approxEq(T, counts[0], counts[1] * 2, tolerance));
-        try expect(approxEq(T, counts[1], counts[2], tolerance));
-        try expect(approxEq(T, counts[3] * 2, counts[4], tolerance));
+        const tolerance = 0.1;
+        try std.testing.expect(approxEqRel(f64, counts[0], counts[1] * 2, tolerance));
+        try std.testing.expect(approxEqRel(f64, counts[1], counts[2], tolerance));
+        try std.testing.expect(approxEqRel(f64, counts[2] * 2, counts[3], tolerance));
     }
 }


### PR DESCRIPTION
The ~~`dice`~~ `weightedIndex` function picks from a list of weighted indices.  This is useful in situations where the developer needs to select from a range of options which are not equally weighted; this is common in simulations or algorithms like Wave Function Collapse.

~~A note on naming: I went with `dice` because that's what the algorithm is called in the [D standard library](https://dlang.org/library/std/random/dice.html).  Other good options would be `weightedIndex` and `pickIndex`.~~

This implementation should work with all primitive numeric types.