### PR TITLE
Add signed integer repr documentation

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1521,7 +1521,8 @@ fn divide(a: i32, b: i32) i32 {
       Zig supports arbitrary bit-width integers, referenced by using
       an identifier of <code>i</code> or <code>u</code> followed by digits. For example, the identifier
       {#syntax#}i7{#endsyntax#} refers to a signed 7-bit integer. The maximum allowed bit-width of an
-      integer type is {#syntax#}65535{#endsyntax#}.
+      integer type is {#syntax#}65535{#endsyntax#}. For signed integer types, Zig uses a
+      <a href="https://en.wikipedia.org/wiki/Two's_complement">two's complement</a> representation.
       </p>
       {#see_also|Wrapping Operations#}
       {#header_close#}


### PR DESCRIPTION
Addresses #11103

This add's a small note detailing the two's compliment representation of signed integers. 

I'm a Zig newbie but hoping to help out in the docs before digging deeper. Couldn't get the docs to build by running `zig run doc/docgen.zig` with 
```
zig git:master
❯ zig version
0.10.0-dev.3504+85a3f9b05
```
Any existing documentation for building the docs? if not, I can add some if you can tell me what I'm obviously doing wrong here 👍 