### PR TITLE
Add block expression return type doc

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4041,7 +4041,22 @@ test "access variable after block scope" {
     x += 1;
 }
       {#code_end#}
-      <p>Blocks are expressions. When labeled, {#syntax#}break{#endsyntax#} can be used
+      <p>Blocks are expressions and by default they are a void literal:</p>
+      {#code_begin|test|test_block_void_literal#}
+const std = @import("std");
+const expect = std.testing.expect;
+
+test "evaluates to void" {
+
+    const x = {
+        var y: i32 = 123;
+        y += 1;
+    };
+    try expect(@TypeOf(x) == void);
+}
+      {#code_end#}
+
+      <p>When the block is labeled, {#syntax#}break{#endsyntax#} can be used
       to return a value from the block:
       </p>
       {#code_begin|test|test_labeled_break#}


### PR DESCRIPTION
Addresses #11112

Add doc on default return type for block expressions, with test case. I'm not sure it's the most appropriate test case (comparing void to void) but couldn't think of something better, if you have any ideas add them here and I'm happy to fix this up 👍 