### PR TITLE
autodoc: Fix border color around field docs in light mode

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -290,7 +290,7 @@
       }
 
       .fieldDocs {
-        border: 1px solid #2A2A2A;
+        border: 1px solid #F5F5F5;
         border-top: 0px;
         padding: 1px 1em;
       }
@@ -413,6 +413,9 @@
 
         .docs pre {
           background-color:#2A2A2A;
+        }
+        .fieldDocs {
+          border-color:#2A2A2A;
         }
         #listNav {
           background-color: #333;


### PR DESCRIPTION
Follow up to https://github.com/ziglang/zig/pull/12305

Before:
![lightmode0](https://user-images.githubusercontent.com/2389051/185725249-58ba87b7-079e-4cdb-b259-47976b2ca1ba.png)

After:
![lightmode1](https://user-images.githubusercontent.com/2389051/185725253-3ddc684c-c82c-4c75-80dc-cc677604e48f.png)

