### PR TITLE
Sema: ensure resolveTypeFields is called for optional and error union types

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -16128,9 +16128,10 @@ fn fieldType(
     field_src: LazySrcLoc,
     ty_src: LazySrcLoc,
 ) CompileError!Air.Inst.Ref {
-    const resolved_ty = try sema.resolveTypeFields(block, ty_src, aggregate_ty);
-    var cur_ty = resolved_ty;
+    var cur_ty = aggregate_ty;
     while (true) {
+        const resolved_ty = try sema.resolveTypeFields(block, ty_src, cur_ty);
+        cur_ty = resolved_ty;
         switch (cur_ty.zigTypeTag()) {
             .Struct => {
                 if (cur_ty.isAnonStruct()) {

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -85,6 +85,7 @@ test {
     _ = @import("behavior/bugs/12003.zig");
     _ = @import("behavior/bugs/12033.zig");
     _ = @import("behavior/bugs/12430.zig");
+    _ = @import("behavior/bugs/12486.zig");
     _ = @import("behavior/byteswap.zig");
     _ = @import("behavior/byval_arg_var.zig");
     _ = @import("behavior/call.zig");

--- a/test/behavior/bugs/12486.zig
+++ b/test/behavior/bugs/12486.zig
@@ -1,13 +1,17 @@
+const SomeEnum = union(enum) {
+    EnumVariant: u8,
+};
+
+const SomeStruct = struct {
+    struct_field: u8,
+};
+
 const OptEnum = struct {
     opt_enum: ?SomeEnum,
 };
 
 const ErrEnum = struct {
     err_enum: anyerror!SomeEnum,
-};
-
-const SomeEnum = union(enum) {
-    EnumVariant: u8,
 };
 
 const OptStruct = struct {
@@ -18,11 +22,7 @@ const ErrStruct = struct {
     err_struct: anyerror!SomeStruct,
 };
 
-const SomeStruct = struct {
-    struct_field: u8,
-};
-
-pub fn main() void {
+test {
     _ = OptEnum{
         .opt_enum = .{
             .EnumVariant = 1,
@@ -47,5 +47,3 @@ pub fn main() void {
         },
     };
 }
-
-// run

--- a/test/cases/coercion-to-unused-union-and-struct.zig
+++ b/test/cases/coercion-to-unused-union-and-struct.zig
@@ -1,0 +1,51 @@
+const OptEnum = struct {
+    opt_enum: ?SomeEnum,
+};
+
+const ErrEnum = struct {
+    err_enum: anyerror!SomeEnum,
+};
+
+const SomeEnum = union(enum) {
+    EnumVariant: u8,
+};
+
+const OptStruct = struct {
+    opt_struct: ?SomeStruct,
+};
+
+const ErrStruct = struct {
+    err_struct: anyerror!SomeStruct,
+};
+
+const SomeStruct = struct {
+    struct_field: u8,
+};
+
+pub fn main() void {
+    _ = OptEnum{
+        .opt_enum = .{
+            .EnumVariant = 1,
+        },
+    };
+
+    _ = ErrEnum{
+        .err_enum = .{
+            .EnumVariant = 1,
+        },
+    };
+
+    _ = OptStruct{
+        .opt_struct = .{
+            .struct_field = 1,
+        },
+    };
+
+    _ = ErrStruct{
+        .err_struct = .{
+            .struct_field = 1,
+        },
+    };
+}
+
+// run


### PR DESCRIPTION
We call `sema.resolveTypeFields` in order to get the fields of structs
and unions inserted into their data structures. If it isn't called, it
can happen that the fields of a type is queried before those fields are
inserted into (for instance) `Module.Union.fields`, which would result in
a wrong 'no field named' error.

Fixes: #12486