### PR TITLE
Fix string type

### DIFF
--- a/lib/std/valgrind/callgrind.zig
+++ b/lib/std/valgrind/callgrind.zig
@@ -2,7 +2,7 @@ const std = @import("../std.zig");
 const valgrind = std.valgrind;
 
 pub const CallgrindClientRequest = enum(usize) {
-    DumpStats = valgrind.ToolBase("CT"),
+    DumpStats = valgrind.ToolBase("CT".*),
     ZeroStats,
     ToggleCollect,
     DumpStatsAt,


### PR DESCRIPTION
Fixes the error when using std.vallgrind.callgrind:
`error: expected type '[2]u8', found '*const [2:0]u8'`