### PR TITLE
autodoc: show compileErrors correctly

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -866,7 +866,7 @@ var zigAnalysis;
       }
       case "compileError": {
         let compileError = expr.compileError;
-        return "@compileError(" + exprName(zigAnalysis.exprs[compileError]) + ")";
+        return "@compileError(" + exprName(zigAnalysis.exprs[compileError], opts) + ")";
       }
       case "enumLiteral": {
         let literal = expr.enumLiteral;

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -866,7 +866,7 @@ var zigAnalysis;
       }
       case "compileError": {
         let compileError = expr.compileError;
-        return compileError;
+        return "@compileError(" + exprName(zigAnalysis.exprs[compileError]) + ")";
       }
       case "enumLiteral": {
         let literal = expr.enumLiteral;

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -632,7 +632,7 @@ const DocData = struct {
         sizeOf: usize, // index in `exprs`
         bitSizeOf: usize, // index in `exprs`
         enumToInt: usize, // index in `exprs`
-        compileError: []const u8,
+        compileError: usize, //index in `exprs`
         errorSets: usize,
         string: []const u8, // direct value
         sliceIndex: usize,
@@ -1027,13 +1027,11 @@ fn walkInstruction(
                 false,
             );
 
+            const operand_index = self.exprs.items.len;
+            try self.exprs.append(self.arena, operand.expr);
+
             return DocData.WalkResult{
-                .expr = .{
-                    .compileError = switch (operand.expr) {
-                        .string => |s| s,
-                        else => "TODO: non-string @compileError arguments",
-                    },
-                },
+                .expr = .{ .compileError = operand_index },
             };
         },
         .enum_literal => {


### PR DESCRIPTION
Changes the way compileError keeps its argument, and the way it renders in the frontend.