### PR TITLE
haiku update for futex thread

### DIFF
--- a/lib/std/Thread/Futex.zig
+++ b/lib/std/Thread/Futex.zig
@@ -73,6 +73,8 @@ else if (builtin.os.tag == .openbsd)
     OpenbsdImpl
 else if (builtin.os.tag == .dragonfly)
     DragonflyImpl
+else if (builtin.os.tag == .haiku)
+    SingleThreadedImpl
 else if (std.Thread.use_pthreads)
     PosixImpl
 else

--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -27,6 +27,10 @@ pub extern "c" fn _kern_read_stat(fd: c_int, path_ptr: [*]u8, traverse_link: boo
 
 pub extern "c" fn _kern_get_current_team() i32;
 
+pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
+
+pub const dl_iterate_phdr_callback = fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int;
+
 pub const sem_t = extern struct {
     type: i32,
     u: extern union {

--- a/src/target.zig
+++ b/src/target.zig
@@ -540,6 +540,8 @@ pub fn libcFullLinkFlags(target: std.Target) []const []const u8 {
             "-lroot",
             "-lpthread",
             "-lc",
+            "-lbsd",
+            "-lnetwork",
         },
         else => switch (target.abi) {
             .android => &[_][]const u8{


### PR DESCRIPTION
hello,

the following patch sets updates threading to use the SingleThreadImpl on haiku to prevent an error as shown below from occurring when trying to run zig build.

```
> mkdir helloworld

> cd helloworld

> zig init-exe
info: Created build.zig
info: Created src/main.zig
info: Next, try `zig build --help` or `zig build run`

> zig build run
/boot/home/src/git/zig/lib/std/Thread/Futex.zig:726:40: error: expected integer or vector, found 'comptime_int'
            return addr >> @ctz(usize, alignment);
                                       ^~~~~~~~~

> zig version
0.10.0-dev.3659+e5e6eb983

> uname -a
Haiku shredder 1 hrev56350 Aug 12 2022 06:04:04 x86_64 x86_64 Haiku
```

note that this patchsets also include

* linking the _bsd_ and _network_ libs when building on haiku (preliminary socket support) 
* expose dl_iterate_phdr (added to haiku as of [hrev56227)](https://git.haiku-os.org/haiku/log/?qt=range&q=hrev56226..hrev56227)