### PR TITLE
translate-c: Don't add self-defined macros to global name table

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -9,6 +9,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     if (builtin.zig_backend == .stage1) { // https://github.com/ziglang/zig/issues/6025
         cases.add("test/standalone/issue_9693/main.zig");
     }
+    cases.add("test/standalone/issue_12471/main.zig");
     cases.add("test/standalone/guess_number/main.zig");
     cases.add("test/standalone/main_return_error/error_u8.zig");
     cases.add("test/standalone/main_return_error/error_u8_non_zero.zig");

--- a/test/standalone/issue_12471/main.zig
+++ b/test/standalone/issue_12471/main.zig
@@ -1,0 +1,12 @@
+const c = @cImport({
+    @cDefine("FOO", "FOO");
+    @cDefine("BAR", "FOO");
+
+    @cDefine("BAZ", "QUX");
+    @cDefine("QUX", "QUX");
+});
+
+pub fn main() u8 {
+    _ = c;
+    return 0;
+}


### PR DESCRIPTION
A self-defined macro is one of the form `#define FOO FOO`

Those types of macros have never been translated; this change will cause
any macros which refer to them to be translated as `@compileError` instead
of referring to a non-existent identifier.

Closes #12471