### PR TITLE
test harness: don't skip tests

### DIFF
--- a/test/tests.zig
+++ b/test/tests.zig
@@ -632,8 +632,9 @@ pub fn addPkgTests(
 
         if (test_target.backend) |backend| switch (backend) {
             .stage1 => if (skip_stage1) continue,
+            .stage2_llvm => {},
             else => if (skip_stage2) continue,
-        } else if (skip_stage2) continue;
+        };
 
         const want_this_mode = for (modes) |m| {
             if (m == test_target.mode) break true;


### PR DESCRIPTION
The meaning of this "skip_stage2" flag was intended to mean the
self-hosted backends, not the stage2 frontend. Sorry for the confusion.

closes #12541