### PR TITLE
autodocs: improve error set rendering

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1768,11 +1768,15 @@ var zigAnalysis;
             let errSetObj = typeObj;
             if (errSetObj.fields == null) {
               return '<span class="tok-type">anyerror</span>';
+            } else if (errSetObj.fields.length == 0) {
+              return "error{}";
+            } else if (errSetObj.fields.length == 1) {
+              return "error{" + errSetObj.fields[0].name + "}";
             } else {
               // throw "TODO";
-              let html = "error{" + errSetObj.fields[0].name;
+              let html = "error{ " + errSetObj.fields[0].name;
               for (let i = 1; i < errSetObj.fields.length; i++) html += ", " + errSetObj.fields[i].name;
-              html += "}";
+              html += " }";
               return html;
             }
           }


### PR DESCRIPTION
This change allows autodoc to render empty error sets (this previously caused a runtime error), and to correctly render multi-item error sets in the same style as `zig fmt`. 

Before:
- empty `[crashes]`
- single `error{Foo}`
- multi `error{Foo, Bar}`

After:
- empty `error{}`
- single `error{Foo}`
- multi `error{ Foo, Bar }`