### PR TITLE
autodocs: improve first-line descriptions

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -2835,16 +2835,20 @@ var zigAnalysis;
 
   function shortDescMarkdown(docs) {
     const trimmed_docs = docs.trim();
-    let index = trimmed_docs.indexOf(".");
-    if (index < 0) {
-      index = trimmed_docs.indexOf("\n");
-      if (index < 0) {
-        index = trimmed_docs.length;
-      }
-    } else {
-      index += 1; // include the period
+    let index = trimmed_docs.indexOf("\n\n");
+    let cut = false;
+
+    if (index < 0 || index > 80) {
+        if (trimmed_docs.length > 80) {
+            index = 80;
+            cut = true;
+        } else {
+            index = trimmed_docs.length;
+        }
     }
-    const slice = trimmed_docs.slice(0, index);
+
+    let slice = trimmed_docs.slice(0, index);
+    if (cut) slice += "...";
     return markdown(slice);
   }
 


### PR DESCRIPTION
This change stops autodoc from cutting off doc comments at the first full stop for a short description, and instead will cut off doc comments at first paragraph, or after 80 characters, whichever is sooner.

This prevents short summaries of multiple sentences from being cut early, and prevents examples without a second paragraph from creating noise.