### PR TITLE
docs: remove confusion about align[For|Back]ward

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3252,13 +3252,13 @@ test "sliceAsBytes preserves pointer attributes" {
     try testing.expectEqual(in.alignment, out.alignment);
 }
 
-/// Round an address up to the nearest aligned address
+/// Round an address up to the next (or current) aligned address.
 /// The alignment must be a power of 2 and greater than 0.
 pub fn alignForward(addr: usize, alignment: usize) usize {
     return alignForwardGeneric(usize, addr, alignment);
 }
 
-/// Round an address up to the nearest aligned address
+/// Round an address up to the next (or current) aligned address.
 /// The alignment must be a power of 2 and greater than 0.
 pub fn alignForwardGeneric(comptime T: type, addr: T, alignment: T) T {
     return alignBackwardGeneric(T, addr + (alignment - 1), alignment);
@@ -3290,7 +3290,7 @@ test "alignForward" {
     try testing.expect(alignForward(17, 8) == 24);
 }
 
-/// Round an address up to the previous aligned address
+/// Round an address down to the previous (or current) aligned address.
 /// Unlike `alignBackward`, `alignment` can be any positive number, not just a power of 2.
 pub fn alignBackwardAnyAlign(i: usize, alignment: usize) usize {
     if (@popCount(usize, alignment) == 1)
@@ -3299,13 +3299,13 @@ pub fn alignBackwardAnyAlign(i: usize, alignment: usize) usize {
     return i - @mod(i, alignment);
 }
 
-/// Round an address up to the previous aligned address
+/// Round an address down to the previous (or current) aligned address.
 /// The alignment must be a power of 2 and greater than 0.
 pub fn alignBackward(addr: usize, alignment: usize) usize {
     return alignBackwardGeneric(usize, addr, alignment);
 }
 
-/// Round an address up to the previous aligned address
+/// Round an address down to the previous (or current) aligned address.
 /// The alignment must be a power of 2 and greater than 0.
 pub fn alignBackwardGeneric(comptime T: type, addr: T, alignment: T) T {
     assert(@popCount(T, alignment) == 1);


### PR DESCRIPTION
- `alignBackward` does round 'down', not 'up'
- removed 'nearest' in favor of 'next' as its more in line with 'previous'
- added '(or current)', because the input address will be the output address if its already aligned.
- added a period at the end of the lines I touched, because it is missing when the stdlib docs are generated