### PR TITLE
Stage2 fixes

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -4265,10 +4265,13 @@ fn structDeclInner(
     // are in scope, so that field types, alignments, and default value expressions
     // can refer to decls within the struct itself.
     astgen.advanceSourceCursorToNode(node);
+    // If `node == 0` then this is the root struct and all the declarations should
+    // be relative to the beginning of the file.
+    const decl_line = if (node == 0) 0 else astgen.source_line;
     var block_scope: GenZir = .{
         .parent = &namespace.base,
         .decl_node_index = node,
-        .decl_line = astgen.source_line,
+        .decl_line = decl_line,
         .astgen = astgen,
         .force_comptime = true,
         .in_defer = false,
@@ -11764,7 +11767,6 @@ fn scanDecls(astgen: *AstGen, namespace: *Scope.Namespace, members: []const Ast.
             }
         }
 
-        // const index_name = try astgen.identAsString(index_token);
         var s = namespace.parent;
         while (true) switch (s.tag) {
             .local_val => {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5941,10 +5941,9 @@ fn analyzeCall(
                 undefined,
             ) catch |err| switch (err) {
                 error.NeededSourceLocation => {
-                    sema.inst_map.clearRetainingCapacity();
+                    _ = sema.inst_map.remove(inst);
                     const decl = sema.mod.declPtr(block.src_decl);
                     child_block.src_decl = block.src_decl;
-                    arg_i = 0;
                     try sema.analyzeInlineCallArg(
                         block,
                         &child_block,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -26139,11 +26139,12 @@ fn analyzeSlice(
     var array_ty = ptr_ptr_child_ty;
     var slice_ty = ptr_ptr_ty;
     var ptr_or_slice = ptr_ptr;
-    var elem_ty = ptr_ptr_child_ty.childType();
+    var elem_ty: Type = undefined;
     var ptr_sentinel: ?Value = null;
     switch (ptr_ptr_child_ty.zigTypeTag()) {
         .Array => {
             ptr_sentinel = ptr_ptr_child_ty.sentinel();
+            elem_ty = ptr_ptr_child_ty.childType();
         },
         .Pointer => switch (ptr_ptr_child_ty.ptrSize()) {
             .One => {

--- a/src/value.zig
+++ b/src/value.zig
@@ -2689,6 +2689,12 @@ pub const Value = extern union {
             // to have only one possible value itself.
             .the_only_possible_value => return val,
 
+            // pointer to integer casted to pointer of array
+            .int_u64, .int_i64 => {
+                assert(index == 0);
+                return val;
+            },
+
             else => unreachable,
         }
     }

--- a/test/behavior/generics.zig
+++ b/test/behavior/generics.zig
@@ -342,3 +342,18 @@ test "generic instantiation of tagged union with only one field" {
     try expect(S.foo(.{ .s = "a" }) == 1);
     try expect(S.foo(.{ .s = "ab" }) == 2);
 }
+
+test "nested generic function" {
+    const S = struct {
+        fn foo(comptime T: type, callback: *const fn (user_data: T) anyerror!void, data: T) anyerror!void {
+            try callback(data);
+        }
+        fn bar(a: u32) anyerror!void {
+            try expect(a == 123);
+        }
+
+        fn g(_: *const fn (anytype) void) void {}
+    };
+    try expect(@typeInfo(@TypeOf(S.g)).Fn.is_generic);
+    try S.foo(u32, S.bar, 123);
+}

--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -290,3 +290,14 @@ test "coerce tuple to tuple" {
     };
     try S.foo(.{123});
 }
+
+test "tuple type with void field" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+
+    const T = std.meta.Tuple(&[_]type{void});
+    const x = T{{}};
+    try expect(@TypeOf(x[0]) == void);
+}

--- a/test/cases/compile_errors/comptime_parameter_not_declared_as_such.zig
+++ b/test/cases/compile_errors/comptime_parameter_not_declared_as_such.zig
@@ -1,5 +1,6 @@
 fn f(_: anytype) void {}
-fn g(h: *const fn (anytype) void) void {
+const T = *const fn (anytype) void;
+fn g(h: T) void {
     h({});
 }
 pub export fn entry() void {
@@ -19,5 +20,5 @@ pub export fn entry1() void {
 // backend=stage2
 // target=native
 //
-// :2:6: error: parameter of type '*const fn(anytype) void' must be declared comptime
-// :9:34: error: parameter of type 'comptime_int' must be declared comptime
+// :3:6: error: parameter of type '*const fn(anytype) void' must be declared comptime
+// :10:34: error: parameter of type 'comptime_int' must be declared comptime

--- a/test/cases/compile_errors/error_in_typeof_param.zig
+++ b/test/cases/compile_errors/error_in_typeof_param.zig
@@ -1,0 +1,14 @@
+fn getSize() usize {
+    return 2;
+}
+pub fn expectEqual(expected: anytype, _: @TypeOf(expected)) !void {}
+pub export fn entry() void {
+    try expectEqual(2, getSize());
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :6:31: error: unable to resolve comptime value
+// :6:31: note: argument to parameter with comptime only type must be comptime known

--- a/test/cases/compile_errors/slice_of_non_array_type.zig
+++ b/test/cases/compile_errors/slice_of_non_array_type.zig
@@ -1,0 +1,9 @@
+comptime {
+    _ = 1[0..];
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:10: error: slice of non-array type 'comptime_int'


### PR DESCRIPTION
Ideally the nested function type thing would only apply to function types inside generic function types but that would require moving the param block inside the function type instruction.