### PR TITLE
Sema: ignore comptime params in partial func type check

### DIFF
--- a/test/behavior/typename.zig
+++ b/test/behavior/typename.zig
@@ -235,3 +235,14 @@ test "local variable" {
     try expectEqualStrings("behavior.typename.test.local variable.Qux", @typeName(Qux));
     try expectEqualStrings("behavior.typename.test.local variable.Quux", @typeName(Quux));
 }
+
+test "comptime parameters not converted to anytype in function type" {
+    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+
+    const T = fn (fn (type) void, void) void;
+    try expectEqualStrings("fn(fn(type) void, void) void", @typeName(T));
+}

--- a/test/cases/compile_errors/export_function_with_comptime_parameter.zig
+++ b/test/cases/compile_errors/export_function_with_comptime_parameter.zig
@@ -6,4 +6,4 @@ export fn foo(comptime x: anytype, y: i32) i32{
 // backend=stage2
 // target=native
 //
-// :1:15: error: generic parameters not allowed in function with calling convention 'C'
+// :1:15: error: comptime parameters not allowed in function with calling convention 'C'

--- a/test/cases/compile_errors/extern_function_with_comptime_parameter.zig
+++ b/test/cases/compile_errors/extern_function_with_comptime_parameter.zig
@@ -12,9 +12,6 @@ comptime { _ = entry2; }
 // backend=stage2
 // target=native
 //
-// :5:12: error: extern function cannot be generic
-// :5:30: note: function is generic because of this parameter
-// :6:12: error: extern function cannot be generic
-// :6:30: note: function is generic because of this parameter
-// :1:8: error: extern function cannot be generic
-// :1:15: note: function is generic because of this parameter
+// :1:15: error: comptime parameters not allowed in function with calling convention 'C'
+// :5:30: error: comptime parameters not allowed in function with calling convention 'C'
+// :6:30: error: generic parameters not allowed in function with calling convention 'C'


### PR DESCRIPTION
This fixes a bug exposed by cd1833044ab7505bc101c85f59889bd3ea3fac80 a function type would be converted to generic_poison even after instantiated due to containing comptime only types.

This could also be fixed by just checking `is_generic_instantiation` this way also provides better type names.

Closes #12625

With this ci.ziglang.org should pass again (or at least get further).