### PR TITLE
add ability to pass force-undefined-symbols to the linker

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -175,6 +175,12 @@ pub const Options = struct {
     lib_dirs: []const []const u8,
     rpath_list: []const []const u8,
 
+    /// List of symbols forced as undefined in the symbol table
+    /// thus forcing their resolution by the linker.
+    /// Corresponds to `-u <symbol>` for ELF and `/include:<symbol>` for COFF/PE.
+    /// TODO add handling for MachO.
+    force_undefined_symbols: std.StringArrayHashMapUnmanaged(void),
+
     version: ?std.builtin.Version,
     compatibility_version: ?std.builtin.Version,
     libc_installation: ?*const LibCInstallation,

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1133,6 +1133,10 @@ fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Node) !
             }
         }
 
+        for (self.base.options.force_undefined_symbols.keys()) |symbol| {
+            try argv.append(try allocPrint(arena, "-INCLUDE:{s}", .{symbol}));
+        }
+
         if (is_dyn_lib) {
             try argv.append("-DLL");
         }

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1448,6 +1448,11 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
             try argv.append(entry);
         }
 
+        for (self.base.options.force_undefined_symbols.keys()) |symbol| {
+            try argv.append("-u");
+            try argv.append(symbol);
+        }
+
         switch (self.base.options.hash_style) {
             .gnu => try argv.append("--hash-style=gnu"),
             .sysv => try argv.append("--hash-style=sysv"),

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -93,12 +93,6 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile) !void {
                     "-D_WIN32_WINNT=0x0f00",
                     "-D__MSVCRT_VERSION__=0x700",
                 });
-                if (std.mem.eql(u8, dep, "tlssup.c") and comp.bin_file.options.lto) {
-                    // LLD will incorrectly drop the `_tls_index` symbol. Here we work
-                    // around it by not using LTO for this one file.
-                    // https://github.com/ziglang/zig/issues/8531
-                    try args.append("-fno-lto");
-                }
                 c_source_files[i] = .{
                     .src_path = try comp.zig_lib_directory.join(arena, &[_][]const u8{
                         "libc", "mingw", "crt", dep,


### PR DESCRIPTION
This commit enables `-u <symbol>` for ELF and `-include:<symbol>` for COFF linkers for use internally. This means we do not expose these flags to the users just yet, however, we make use of them internally whenever required. One such use case is forcing inclusion of `_tls_index` when linking for Windows with mingw and LTO and dead code stripping enabled. This ensures we add `_tls_index` to the symbol resolver as an undefined symbol and force the linker to include an atom that provides it marking it a dead-code-stripping root - meaning it will not be garbage collected by the linker no matter what.

This is my proposed alternative to #8674 which doesn't rely on scanning input source files by name when compiling mingw and putting in the cache. Instead, we tell the linker to force-include `_tls_index` whenever we link against mingw libc.

Closes #8531

@andrewrk I've also had a look at your reported C++ problems in presence of LTO but I couldn't repro it locally so unless we get a report that it's still the case, I have now enabled LTO by default on Windows for Release builds, and I am marking #8531 for closing.

cc @xxxbxxx 