### PR TITLE
stage2: fix size of c_longdouble for Wasm target

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -6592,6 +6592,8 @@ pub const CType = enum {
                         .powerpcle,
                         .powerpc64,
                         .powerpc64le,
+                        .wasm32,
+                        .wasm64,
                         => return 128,
 
                         else => return 64,
@@ -6640,6 +6642,8 @@ pub const CType = enum {
                         .powerpcle,
                         .powerpc64,
                         .powerpc64le,
+                        .wasm32,
+                        .wasm64,
                         => return 128,
 
                         else => return 64,

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1430,6 +1430,7 @@ test "coerce between pointers of compatible differently-named floats" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     if (builtin.os.tag == .windows) {
         // https://github.com/ziglang/zig/issues/12396

--- a/test/c_abi/cfuncs.c
+++ b/test/c_abi/cfuncs.c
@@ -33,6 +33,7 @@ void zig_five_integers(int32_t, int32_t, int32_t, int32_t, int32_t);
 
 void zig_f32(float);
 void zig_f64(double);
+void zig_longdouble(long double);
 void zig_five_floats(float, float, float, float, float);
 
 bool zig_ret_bool();
@@ -157,6 +158,7 @@ void run_c_tests(void) {
 
     zig_f32(12.34f);
     zig_f64(56.78);
+    zig_longdouble(12.34l);
     zig_five_floats(1.0f, 2.0f, 3.0f, 4.0f, 5.0f);
 
     zig_ptr((void*)0xdeadbeefL);
@@ -269,6 +271,10 @@ void c_f32(float x) {
 
 void c_f64(double x) {
     assert_or_panic(x == 56.78);
+}
+
+void c_long_double(long double x) {
+    assert_or_panic(x == 12.34l);
 }
 
 void c_ptr(void *x) {

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -89,6 +89,7 @@ export fn zig_struct_u128(a: U128) void {
 
 extern fn c_f32(f32) void;
 extern fn c_f64(f64) void;
+extern fn c_long_double(c_longdouble) void;
 
 // On windows x64, the first 4 are passed via registers, others on the stack.
 extern fn c_five_floats(f32, f32, f32, f32, f32) void;
@@ -105,6 +106,7 @@ test "C ABI floats" {
     c_f32(12.34);
     c_f64(56.78);
     c_five_floats(1.0, 2.0, 3.0, 4.0, 5.0);
+    c_long_double(12.34);
 }
 
 export fn zig_f32(x: f32) void {
@@ -112,6 +114,9 @@ export fn zig_f32(x: f32) void {
 }
 export fn zig_f64(x: f64) void {
     expect(x == 56.78) catch @panic("test failure: zig_f64");
+}
+export fn zig_longdouble(x: c_longdouble) void {
+    expect(x == 12.34) catch @panic("test failure: zig_longdouble");
 }
 
 extern fn c_ptr(*anyopaque) void;

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const print = std.debug.print;
 const expect = std.testing.expect;
 
@@ -106,6 +107,10 @@ test "C ABI floats" {
     c_f32(12.34);
     c_f64(56.78);
     c_five_floats(1.0, 2.0, 3.0, 4.0, 5.0);
+}
+
+test "C ABI long double" {
+    if (!builtin.cpu.arch.isWasm()) return error.SkipZigTest;
     c_long_double(12.34);
 }
 
@@ -116,6 +121,7 @@ export fn zig_f64(x: f64) void {
     expect(x == 56.78) catch @panic("test failure: zig_f64");
 }
 export fn zig_longdouble(x: c_longdouble) void {
+    if (!builtin.cpu.arch.isWasm()) return; // waiting for #1481
     expect(x == 12.34) catch @panic("test failure: zig_longdouble");
 }
 


### PR DESCRIPTION
According to https://github.com/WebAssembly/tool-conventions/blob/main/BasicCABI.md the size of c's long double is 16 bytes for Wasm, rather than 8 bytes we previously used in the compiler. This ensures we not only pass the correct values but also create the correct function signature needed to pass the Wasm validator. e.i. When passing a `c_longdouble` to a function, we pass it as 2 separate `f64`'s.

This essentially fixes a bug where the compiler-rt function `roundl` was generating an incorrect function signature and causing a miscompilation when targeting Wasm.

This also adds an additional test case in c_abi tests.
