### PR TITLE
Exposes build.zig from std.build for experimentation

### DIFF
--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -9,6 +9,8 @@ const process = std.process;
 const ArrayList = std.ArrayList;
 const File = std.fs.File;
 
+pub const @"build.zig" = root;
+
 pub fn main() !void {
     // Here we use an ArenaAllocator backed by a DirectAllocator because a build is a short-lived,
     // one shot program. We don't need to waste time freeing memory and finding places to squish

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -28,6 +28,13 @@ pub const InstallRawStep = @import("build/InstallRawStep.zig");
 pub const OptionsStep = @import("build/OptionsStep.zig");
 pub const EmulatableRunStep = @import("build/EmulatableRunStep.zig");
 
+const root_file = @import("root");
+
+pub const build_script = if (@hasDecl(root_file, "build.zig"))
+    root_file.@"build.zig"
+else
+    @compileError("Access to build.zig is only available in a 'zig build' invocation!");
+
 pub const Builder = struct {
     install_tls: TopLevelStep,
     uninstall_tls: TopLevelStep,


### PR DESCRIPTION
Exposes `std.build.build_script` in the build runner, to allow access to build.zig from build.zig dependencies.