### PR TITLE
stage2: change how defers are stored in Zir

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5700,7 +5700,6 @@ fn bar() !void {
         try quux();
     } else |err| switch (err) {
         error.FileNotFound => try hello(),
-        else => try another(),
     }
 }
 
@@ -5714,10 +5713,6 @@ fn quux() !void {
 
 fn hello() !void {
     try bang2();
-}
-
-fn another() !void {
-    try bang1();
 }
 
 fn bang1() !void {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1460,6 +1460,29 @@ fn analyzeBodyInner(
             //        break break_data.inst;
             //    }
             //},
+            .@"defer" => blk: {
+                const inst_data = sema.code.instructions.items(.data)[inst].@"defer";
+                const defer_body = sema.code.extra[inst_data.index..][0..inst_data.len];
+                const break_inst = sema.analyzeBodyInner(block, defer_body) catch |err| switch (err) {
+                    error.ComptimeBreak => sema.comptime_break_inst,
+                    else => |e| return e,
+                };
+                if (break_inst != defer_body[defer_body.len - 1]) break always_noreturn;
+                break :blk Air.Inst.Ref.void_value;
+            },
+            .defer_err_code => blk: {
+                const inst_data = sema.code.instructions.items(.data)[inst].defer_err_code;
+                const extra = sema.code.extraData(Zir.Inst.DeferErrCode, inst_data.payload_index).data;
+                const defer_body = sema.code.extra[extra.index..][0..extra.len];
+                const err_code = try sema.resolveInst(inst_data.err_code);
+                try sema.inst_map.put(sema.gpa, extra.remapped_err_code, err_code);
+                const break_inst = sema.analyzeBodyInner(block, defer_body) catch |err| switch (err) {
+                    error.ComptimeBreak => sema.comptime_break_inst,
+                    else => |e| return e,
+                };
+                if (break_inst != defer_body[defer_body.len - 1]) break always_noreturn;
+                break :blk Air.Inst.Ref.void_value;
+            },
         };
         if (sema.typeOf(air_inst).isNoReturn())
             break always_noreturn;
@@ -9324,11 +9347,6 @@ fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
                 }
 
                 if (special_prong == .@"else" and seen_errors.count() == operand_ty.errorSetNames().len) {
-
-                    // TODO re-enable if defer implementation is improved
-                    // https://github.com/ziglang/zig/issues/11798
-                    if (true) break :else_validation;
-
                     // In order to enable common patterns for generic code allow simple else bodies
                     // else => unreachable,
                     // else => return,
@@ -9345,6 +9363,12 @@ fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
                         .as_node,
                         .ret_node,
                         .@"unreachable",
+                        .@"defer",
+                        .defer_err_code,
+                        .err_union_code,
+                        .ret_err_value_code,
+                        .is_non_err,
+                        .condbr,
                         => {},
                         else => break,
                     } else break :else_validation;

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -992,6 +992,13 @@ pub const Inst = struct {
         /// closure_capture instruction ref.
         closure_get,
 
+        /// A defer statement.
+        /// Uses the `defer` union field.
+        @"defer",
+        /// An errdefer statement with a code.
+        /// Uses the `err_defer_code` union field.
+        defer_err_code,
+
         /// The ZIR instruction tag is one of the `Extended` ones.
         /// Uses the `extended` union field.
         extended,
@@ -1241,6 +1248,8 @@ pub const Inst = struct {
                 .try_ptr,
                 //.try_inline,
                 //.try_ptr_inline,
+                .@"defer",
+                .defer_err_code,
                 => false,
 
                 .@"break",
@@ -1308,6 +1317,8 @@ pub const Inst = struct {
                 .memcpy,
                 .memset,
                 .check_comptime_control_flow,
+                .@"defer",
+                .defer_err_code,
                 => true,
 
                 .param,
@@ -1815,6 +1826,9 @@ pub const Inst = struct {
 
                 .closure_capture = .un_tok,
                 .closure_get = .inst_node,
+
+                .@"defer" = .@"defer",
+                .defer_err_code = .defer_err_code,
 
                 .extended = .extended,
             });
@@ -2569,6 +2583,14 @@ pub const Inst = struct {
                 return zir.nullTerminatedString(self.str);
             }
         },
+        @"defer": struct {
+            index: u32,
+            len: u32,
+        },
+        defer_err_code: struct {
+            err_code: Ref,
+            payload_index: u32,
+        },
 
         // Make sure we don't accidentally add a field to make this union
         // bigger than expected. Note that in Debug builds, Zig is allowed
@@ -2605,6 +2627,8 @@ pub const Inst = struct {
             dbg_stmt,
             inst_node,
             str_op,
+            @"defer",
+            defer_err_code,
         };
     };
 
@@ -3542,6 +3566,12 @@ pub const Inst = struct {
         node: i32,
         line: u32,
         column: u32,
+    };
+
+    pub const DeferErrCode = struct {
+        remapped_err_code: Index,
+        index: u32,
+        len: u32,
     };
 };
 

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -447,6 +447,9 @@ const Writer = struct {
 
             .closure_get => try self.writeInstNode(stream, inst),
 
+            .@"defer" => try self.writeDefer(stream, inst),
+            .defer_err_code => try self.writeDeferErrCode(stream, inst),
+
             .extended => try self.writeExtended(stream, inst),
         }
     }
@@ -2363,6 +2366,26 @@ const Writer = struct {
     fn writeDbgStmt(self: *Writer, stream: anytype, inst: Zir.Inst.Index) !void {
         const inst_data = self.code.instructions.items(.data)[inst].dbg_stmt;
         try stream.print("{d}, {d})", .{ inst_data.line + 1, inst_data.column + 1 });
+    }
+
+    fn writeDefer(self: *Writer, stream: anytype, inst: Zir.Inst.Index) !void {
+        const inst_data = self.code.instructions.items(.data)[inst].@"defer";
+        const body = self.code.extra[inst_data.index..][0..inst_data.len];
+        try self.writeBracedBody(stream, body);
+        try stream.writeByte(')');
+    }
+
+    fn writeDeferErrCode(self: *Writer, stream: anytype, inst: Zir.Inst.Index) !void {
+        const inst_data = self.code.instructions.items(.data)[inst].defer_err_code;
+        const extra = self.code.extraData(Zir.Inst.DeferErrCode, inst_data.payload_index).data;
+
+        try self.writeInstRef(stream, Zir.indexToRef(extra.remapped_err_code));
+        try stream.writeAll(" = ");
+        try self.writeInstRef(stream, inst_data.err_code);
+        try stream.writeAll(", ");
+        const body = self.code.extra[extra.index..][0..extra.len];
+        try self.writeBracedBody(stream, body);
+        try stream.writeByte(')');
     }
 
     fn writeInstRef(self: *Writer, stream: anytype, ref: Zir.Inst.Ref) !void {

--- a/test/behavior/defer.zig
+++ b/test/behavior/defer.zig
@@ -127,3 +127,20 @@ test "errdefer with payload" {
     try S.doTheTest();
     comptime try S.doTheTest();
 }
+
+test "simple else prong doesn't emit an error for unreachable else prong" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+
+    const S = struct {
+        fn foo() error{Foo}!void {
+            return error.Foo;
+        }
+    };
+    var a: u32 = 0;
+    defer a += 1;
+    S.foo() catch |err| switch (err) {
+        error.Foo => a += 1,
+        else => |e| return e,
+    };
+    try expect(a == 1);
+}

--- a/test/cases/compile_errors/return_from_defer_expression.zig
+++ b/test/cases/compile_errors/return_from_defer_expression.zig
@@ -19,3 +19,4 @@ export fn entry() usize { return @sizeOf(@TypeOf(testTrickyDefer)); }
 // target=native
 //
 // :4:11: error: 'try' not allowed inside defer expression
+// :4:5: note: defer expression here

--- a/test/cases/compile_errors/uncreachable_else_prong_err_set.zig
+++ b/test/cases/compile_errors/uncreachable_else_prong_err_set.zig
@@ -1,0 +1,25 @@
+pub export fn complex() void {
+    var a: error{ Foo, Bar } = error.Foo;
+    switch (a) {
+        error.Foo => unreachable,
+        error.Bar => unreachable,
+        else => {
+            @compileError("<something complex here>");
+        },
+    }
+}
+
+pub export fn simple() void {
+    var a: error{ Foo, Bar } = error.Foo;
+    switch (a) {
+        error.Foo => unreachable,
+        error.Bar => unreachable,
+        else => |e| return e,
+    }
+}
+
+// error
+// backend=llvm
+// target=native
+//
+// :6:14: error: unreachable else prong; all cases already handled

--- a/test/cases/returns_in_try.zig
+++ b/test/cases/returns_in_try.zig
@@ -13,4 +13,6 @@ pub fn b() !void {
 // error
 //
 // :7:11: error: 'try' not allowed inside defer expression
+// :7:5: note: defer expression here
 // :10:11: error: cannot return from defer expression
+// :10:5: note: defer expression here


### PR DESCRIPTION
Storing defers this way has the benefits that the defer doesn't get multiple times in AstGen, it takes up less space, and it Sema aware of defers allowing for 'unreachable else prong' on error sets in generic code.

The disadvantage is that it is a bit more complex and errdefers with now emit a placeholder instruction (but those are rare).

```
Sema.zig before:
  Total ZIR bytes:    3.7794370651245117MiB
  Instructions:       238996 (2.051319122314453MiB)
  String Table Bytes: 89.2802734375KiB
  Extra Data Items:   430144 (1.640869140625MiB)
Sema.zig after:
  Total ZIR bytes:    3.3344192504882812MiB
  Instructions:       211829 (1.8181428909301758MiB)
  String Table Bytes: 89.2802734375KiB
  Extra Data Items:   374611 (1.4290275573730469MiB)
```