### PR TITLE
Correctly handle carriage return characters according to the spec

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -11551,7 +11551,8 @@ fn readU32Be() u32 {}
       </p>
       <p>
       Each LF may be immediately preceded by a single CR (byte value 0x0d, code point U+000d, {#syntax#}'\r'{#endsyntax#})
-      to form a Windows style line ending, but this is discouraged.
+      to form a Windows style line ending, but this is discouraged. Note that in mulitline strings, CRLF sequences will
+      be encoded as LF when compiled into a zig program.
       A CR in any other context is not allowed.
       </p>
       <p>

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -171,7 +171,7 @@ pub fn tokenSlice(tree: Ast, token_index: TokenIndex) []const u8 {
         .index = token_starts[token_index],
         .pending_invalid_token = null,
     };
-    const token = tokenizer.next();
+    const token = tokenizer.findTagAtCurrentIndex(token_tag);
     assert(token.tag == token_tag);
     return tree.source[token.loc.start..token.loc.end];
 }

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -406,6 +406,38 @@ pub const Tokenizer = struct {
         saw_at_sign,
     };
 
+    /// This is a workaround to the fact that the tokenizer can queue up
+    /// 'pending_invalid_token's when parsing literals, which means that we need
+    /// to scan from the start of the current line to find a matching tag - just
+    /// in case it was an invalid character generated during literal
+    /// tokenization. Ideally this processing of this would be pushed to the AST
+    /// parser or another later stage, both to give more useful error messages
+    /// with that extra context and in order to be able to remove this
+    /// workaround.
+    pub fn findTagAtCurrentIndex(self: *Tokenizer, tag: Token.Tag) Token {
+        if (tag == .invalid) {
+            const target_index = self.index;
+            var starting_index = target_index;
+            while (starting_index > 0) {
+                if (self.buffer[starting_index] == '\n') {
+                    break;
+                }
+                starting_index -= 1;
+            }
+
+            self.index = starting_index;
+            while (self.index <= target_index or self.pending_invalid_token != null) {
+                const result = self.next();
+                if (result.loc.start == target_index and result.tag == tag) {
+                    return result;
+                }
+            }
+            unreachable;
+        } else {
+            return self.next();
+        }
+    }
+
     pub fn next(self: *Tokenizer) Token {
         if (self.pending_invalid_token) |token| {
             self.pending_invalid_token = null;

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -467,7 +467,7 @@ pub const Tokenizer = struct {
                         }
                         break;
                     },
-                    ' ', '\n', '\t' => {
+                    ' ', '\n', '\t', '\r' => {
                         result.loc.start = self.index + 1;
                     },
                     '"' => {
@@ -585,18 +585,6 @@ pub const Tokenizer = struct {
                     '0'...'9' => {
                         state = .int;
                         result.tag = .number_literal;
-                    },
-                    '\r' => {
-                        // Carriage returns are *only* allowed just before a linefeed as part of a CRLF pair, otherwise
-                        // they constitute an illegal byte!
-                        if (self.index + 1 < self.buffer.len and self.buffer[self.index + 1] == '\n') {
-                            result.loc.start = self.index + 1;
-                        } else {
-                            result.tag = .invalid;
-                            result.loc.end = self.index;
-                            self.index += 1;
-                            return result;
-                        }
                     },
                     else => {
                         result.tag = .invalid;

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -925,7 +925,7 @@ pub const Tokenizer = struct {
                         self.index += 1;
                         break;
                     },
-                    '\t' => {},
+                    '\t', '\r' => {},
                     else => self.checkLiteralCharacter(),
                 },
 

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -10491,35 +10491,19 @@ fn strLitNodeAsString(astgen: *AstGen, node: Ast.Node.Index) !IndexSlice {
     var tok_i = start;
     {
         const slice = tree.tokenSlice(tok_i);
-        const line_bytes = slice[2 .. slice.len - 1];
-        const carriage_return_count = mem.count(u8, line_bytes, "\r");
-        if (carriage_return_count > 0) {
-            try string_bytes.ensureUnusedCapacity(gpa, line_bytes.len - carriage_return_count);
-            for (line_bytes) |line_byte| {
-                if (line_byte == '\r') continue;
-                string_bytes.appendAssumeCapacity(line_byte);
-            }
-        } else {
-            try string_bytes.appendSlice(gpa, line_bytes);
-        }
+        const carriage_return_ending: usize = if (slice[slice.len - 2] == '\r') 2 else 1;
+        const line_bytes = slice[2 .. slice.len - carriage_return_ending];
+        try string_bytes.appendSlice(gpa, line_bytes);
         tok_i += 1;
     }
     // Following lines: each line prepends a newline.
     while (tok_i <= end) : (tok_i += 1) {
         const slice = tree.tokenSlice(tok_i);
-        const line_bytes = slice[2 .. slice.len - 1];
-
-        const carriage_return_count = mem.count(u8, line_bytes, "\r");
-        try string_bytes.ensureUnusedCapacity(gpa, line_bytes.len - carriage_return_count + 1);
+        const carriage_return_ending: usize = if (slice[slice.len - 2] == '\r') 2 else 1;
+        const line_bytes = slice[2 .. slice.len - carriage_return_ending];
+        try string_bytes.ensureUnusedCapacity(gpa, line_bytes.len + 1);
         string_bytes.appendAssumeCapacity('\n');
-        if (carriage_return_count > 0) {
-            for (line_bytes) |line_byte| {
-                if (line_byte == '\r') continue;
-                string_bytes.appendAssumeCapacity(line_byte);
-            }
-        } else {
-            string_bytes.appendSliceAssumeCapacity(line_bytes);
-        }
+        string_bytes.appendSliceAssumeCapacity(line_bytes);
     }
     const len = string_bytes.items.len - str_index;
     try string_bytes.append(gpa, 0);

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -535,4 +535,13 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\debug: free - len: 5
         \\
     );
+
+    cases.add("valid carriage return example", "const io = @import(\"std\").io;\r\n" ++ // Testing CRLF line endings are valid
+        "\r\n" ++
+        "pub \r fn main() void {\r\n" ++ // Testing isolated carriage return as whitespace is valid
+        "    const stdout = io.getStdOut().writer();\r\n" ++
+        "    stdout.print(\\\\A Multiline\r\n" ++ // testing CRLF at end of multiline string line is valid and normalises to \n in the output
+        "                 \\\\String\r\n" ++
+        "                 , .{}) catch unreachable;\r\n" ++
+        "}\r\n", "A Multiline\nString");
 }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -175,6 +175,16 @@ pub fn addCases(ctx: *TestContext) !void {
     }
 
     {
+        const case = ctx.obj("isolated carriage return in multiline string literal", .{});
+        case.backend = .stage2;
+
+        case.addError("const foo = \\\\\test\r\r rogue carriage return\n;", &[_][]const u8{
+            ":1:19: error: expected ';' after declaration",
+            ":1:20: note: invalid byte: '\\r'",
+        });
+    }
+
+    {
         const case = ctx.obj("missing semicolon at EOF", .{});
         case.addError(
             \\const foo = 1


### PR DESCRIPTION
Taking guidance from: ziglang/zig-spec#38, carriage returns are now allowed preceding line-feeds when found in doc-comments or multiline strings. The CRLF is also only interpreted as a newline in this case. However - they are otherwise rejected when found in any other context except when used as plain whitespace.

This resolves #11414 and resolves #12674. It replaces #12692 which is a part of this PR.

Ideally the error reporting should be improved by #12449 sometime in the future, but I think I might take a look at that once this has been merged.