### PR TITLE
coff: fix reading COFF header offset

### DIFF
--- a/lib/std/coff.zig
+++ b/lib/std/coff.zig
@@ -831,7 +831,7 @@ pub const Coff = struct {
         var stream = std.io.fixedBufferStream(self.data);
         const reader = stream.reader();
         try stream.seekTo(pe_pointer_offset);
-        const coff_header_offset = try reader.readByte();
+        const coff_header_offset = try reader.readIntLittle(u32);
         try stream.seekTo(coff_header_offset);
         var buf: [4]u8 = undefined;
         try reader.readNoEof(&buf);


### PR DESCRIPTION
I was quite confused when some executables were seemingly missing the COFF header magic number. It turns out that the `0x3C` COFF header offset was being read as a byte and not a `u32`, causing the header to sometimes be read incorrectly.

I'm also working with COFF for a project, so I added some missing constants I needed. 