### PR TITLE
Correct error path when creating new Decls

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -5641,7 +5641,7 @@ pub fn peekNextDeclIndex(mod: *const Module) Decl.Index {
     if (mod.decls_free_list.items.len != 0) {
         return mod.decls_free_list.items[mod.decls_free_list.items.len - 1];
     } else {
-        return @intToEnum(Decl.Index, mod.allocated_decls.len - 1);
+        return @intToEnum(Decl.Index, mod.allocated_decls.len);
     }
 }
 


### PR DESCRIPTION
This PR fixes multiple memory issues when creating new Decl's if errors occur.

---
```zig
// taken from Sema.zig line 20172
const new_decl_index = try sema.mod.allocateNewDecl(...); // doesn't initialize name
errdefer sema.mod.destroyDecl(new_decl_index); // destroy the decl's name
const new_decl = sema.mod.declPtr(new_decl_index);
new_decl.name = try sema.gpa.dupeZ(u8, options.name); // free on uninitialized memory on error
```
---
```zig
// taken from Sema.zig line 2345
const name = try sema.gpa.dupeZ(u8, mem.sliceTo(sema.mod.declPtr(block.src_decl).name, 0));
errdefer sema.gpa.free(name); // deallocates name on error
try mod.initNewAnonDecl(new_decl_index, ..., name); // takes ownership of name and double free's on error
return new_decl_index;
```
---