### PR TITLE
Using `comptime level.asText()` in log example

### DIFF
--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -38,7 +38,7 @@
 //!             return,
 //!     } ++ "): ";
 //!
-//!     const prefix = "[" ++ level.asText() ++ "] " ++ scope_prefix;
+//!     const prefix = "[" ++ comptime level.asText() ++ "] " ++ scope_prefix;
 //!
 //!     // Print the message to stderr, silently ignoring any errors
 //!     std.debug.getStderrMutex().lock();


### PR DESCRIPTION
Some recent change makes slice concatenation runtime (merge #12368), so the example needs to be explicitly made comptime.