### PR TITLE
translate-c: promote large integer macros to unsigned long long if necessary

### DIFF
--- a/lib/std/zig/c_translation.zig
+++ b/lib/std/zig/c_translation.zig
@@ -268,7 +268,7 @@ test "sizeof" {
 pub const CIntLiteralRadix = enum { decimal, octal, hexadecimal };
 
 fn PromoteIntLiteralReturnType(comptime SuffixType: type, comptime number: comptime_int, comptime radix: CIntLiteralRadix) type {
-    const signed_decimal = [_]type{ c_int, c_long, c_longlong };
+    const signed_decimal = [_]type{ c_int, c_long, c_longlong, c_ulonglong };
     const signed_oct_hex = [_]type{ c_int, c_uint, c_long, c_ulong, c_longlong, c_ulonglong };
     const unsigned = [_]type{ c_uint, c_ulong, c_ulonglong };
 

--- a/test/behavior/translate_c_macros.h
+++ b/test/behavior/translate_c_macros.h
@@ -48,3 +48,5 @@ typedef _Bool uintptr_t;
 
 #define CAST_TO_BOOL(X) (_Bool)(X)
 #define CAST_TO_UINTPTR(X) (uintptr_t)(X)
+
+#define LARGE_INT 18446744073709550592

--- a/test/behavior/translate_c_macros.zig
+++ b/test/behavior/translate_c_macros.zig
@@ -113,3 +113,7 @@ test "cast functions" {
     try expectEqual(true, h.CAST_TO_BOOL(S.foo));
     try expect(h.CAST_TO_UINTPTR(S.foo) != 0);
 }
+
+test "large integer macro" {
+    try expectEqual(@as(c_ulonglong, 18446744073709550592), h.LARGE_INT);
+}


### PR DESCRIPTION
Closes #10793

Co-authored-by: Veikka Tuominen <git@vexu.eu>