### PR TITLE
Fix #12655: zig fmt remove trailing comma at the end of assembly clobber

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -26,7 +26,7 @@ test "zig fmt: remove trailing comma at the end of assembly clobber" {
         \\    );
         \\}
         \\
-        ,
+    ,
         \\fn foo() void {
         \\    asm volatile (""
         \\        : [_] "" (-> type),

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -16,6 +16,28 @@ test "zig fmt: preserves clobbers in inline asm with stray comma" {
     );
 }
 
+test "zig fmt: remove trailing comma at the end of assembly clobber" {
+    try testTransform(
+        \\fn foo() void {
+        \\    asm volatile (""
+        \\        : [_] "" (-> type),
+        \\        :
+        \\        : "clobber1", "clobber2",
+        \\    );
+        \\}
+        \\
+        ,
+        \\fn foo() void {
+        \\    asm volatile (""
+        \\        : [_] "" (-> type),
+        \\        :
+        \\        : "clobber1", "clobber2"
+        \\    );
+        \\}
+        \\
+    );
+}
+
 test "zig fmt: respect line breaks in struct field value declaration" {
     try testCanonical(
         \\const Foo = struct {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2114,9 +2114,19 @@ fn renderAsm(
                 return renderToken(ais, tree, tok_i + 1, space);
             },
             .comma => {
-                try renderToken(ais, tree, tok_i, .none);
-                try renderToken(ais, tree, tok_i + 1, .space);
-                tok_i += 2;
+                switch (token_tags[tok_i + 2]) {
+                    .r_paren => {
+                        ais.setIndentDelta(indent_delta);
+                        ais.popIndent();
+                        try renderToken(ais, tree, tok_i, .newline);
+                        return renderToken(ais, tree, tok_i + 2, space);
+                    },
+                    else => {
+                        try renderToken(ais, tree, tok_i, .none);
+                        try renderToken(ais, tree, tok_i + 1, .space);
+                        tok_i += 2;
+                    },
+                }
             },
             else => unreachable,
         }


### PR DESCRIPTION
Fix #12655 
It will remove the trailing comma at the end of inline assembly clobber.
For example, before format:
```zig
fn foo() void {
    asm volatile (""
        : [_] "" (-> type),
        :
        : "clobber"
    );
    asm volatile (""
        :
        : [_] "" (type),
        : "clobber",
    );
}
```

After format:
```zig
fn foo() void {
    asm volatile (""
        : [_] "" (-> type),
        :
        : "clobber"
    );
    asm volatile (""
        :
        : [_] "" (type),
        : "clobber"
    );
}
```