### PR TITLE
translate-c: Allow translating packed C structs iff ABI-sized

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -148,6 +148,9 @@ pub const APSInt = opaque {
 pub const ASTContext = opaque {
     pub const getPointerType = ZigClangASTContext_getPointerType;
     extern fn ZigClangASTContext_getPointerType(*const ASTContext, T: QualType) QualType;
+
+    pub const getTargetInfo = ZigClangASTContext_getTargetInfo;
+    extern fn ZigClangASTContext_getTargetInfo(*const ASTContext) *const TargetInfo;
 };
 
 pub const ASTUnit = opaque {
@@ -194,6 +197,12 @@ pub const ASTRecordLayout = opaque {
 
     pub const getAlignment = ZigClangASTRecordLayout_getAlignment;
     extern fn ZigClangASTRecordLayout_getAlignment(*const ASTRecordLayout) i64;
+
+    pub const getSize = ZigClangASTRecordLayout_getSize;
+    extern fn ZigClangASTRecordLayout_getSize(*const ASTRecordLayout) i64;
+
+    pub const getDataSize = ZigClangASTRecordLayout_getSize;
+    extern fn ZigClangASTRecordLayout_getDataSize(*const ASTRecordLayout) i64;
 };
 
 pub const AttributedType = opaque {
@@ -893,6 +902,11 @@ pub const SwitchStmt = opaque {
 pub const TagDecl = opaque {
     pub const isThisDeclarationADefinition = ZigClangTagDecl_isThisDeclarationADefinition;
     extern fn ZigClangTagDecl_isThisDeclarationADefinition(*const TagDecl) bool;
+};
+
+pub const TargetInfo = opaque {
+    pub const getMaxPointerWidth = ZigClangTargetInfo_getMaxPointerWidth;
+    extern fn ZigClangTargetInfo_getMaxPointerWidth(*const TargetInfo) u64;
 };
 
 pub const Type = opaque {

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -25,6 +25,7 @@
 #include <clang/AST/Attr.h>
 #include <clang/AST/Expr.h>
 #include <clang/AST/RecordLayout.h>
+#include <clang/Basic/TargetInfo.h>
 
 #if __GNUC__ >= 8
 #pragma GCC diagnostic pop
@@ -1832,12 +1833,21 @@ const char* ZigClangSourceManager_getCharacterData(const ZigClangSourceManager *
     return reinterpret_cast<const clang::SourceManager *>(self)->getCharacterData(bitcast(SL));
 }
 
-ZigClangQualType ZigClangASTContext_getPointerType(const ZigClangASTContext* self, ZigClangQualType T) {
+ZigClangQualType ZigClangASTContext_getPointerType(const ZigClangASTContext *self, ZigClangQualType T) {
     return bitcast(reinterpret_cast<const clang::ASTContext *>(self)->getPointerType(bitcast(T)));
 }
+const ZigClangTargetInfo *ZigClangASTContext_getTargetInfo(const ZigClangASTContext* self) {
+    const clang::ASTContext *ctx = reinterpret_cast<const clang::ASTContext *>(self);
+    return reinterpret_cast<const ZigClangTargetInfo *>(&ctx->getTargetInfo());
+}
 
+// TODO: UNUSED??
 unsigned ZigClangASTContext_getTypeAlign(const ZigClangASTContext* self, ZigClangQualType T) {
     return reinterpret_cast<const clang::ASTContext *>(self)->getTypeAlign(bitcast(T));
+}
+
+uint64_t ZigClangTargetInfo_getMaxPointerWidth(const ZigClangTargetInfo *self) {
+    return reinterpret_cast<const clang::TargetInfo *>(self)->getMaxPointerWidth();
 }
 
 ZigClangASTContext *ZigClangASTUnit_getASTContext(ZigClangASTUnit *self) {
@@ -2908,6 +2918,16 @@ uint64_t ZigClangASTRecordLayout_getFieldOffset(const struct ZigClangASTRecordLa
 int64_t ZigClangASTRecordLayout_getAlignment(const struct ZigClangASTRecordLayout *self) {
     auto casted_self = reinterpret_cast<const clang::ASTRecordLayout *>(self);
     return casted_self->getAlignment().getQuantity();
+}
+
+int64_t ZigClangASTRecordLayout_getSize(const struct ZigClangASTRecordLayout *self) {
+    auto casted_self = reinterpret_cast<const clang::ASTRecordLayout *>(self);
+    return casted_self->getSize().getQuantity();
+}
+
+int64_t ZigClangASTRecordLayout_getDataSize(const struct ZigClangASTRecordLayout *self) {
+    auto casted_self = reinterpret_cast<const clang::ASTRecordLayout *>(self);
+    return casted_self->getDataSize().getQuantity();
 }
 
 bool ZigClangIntegerLiteral_EvaluateAsInt(const struct ZigClangIntegerLiteral *self, struct ZigClangExprEvalResult *result, const struct ZigClangASTContext *ctx) {

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -164,6 +164,7 @@ struct ZigClangStringLiteral;
 struct ZigClangStringRef;
 struct ZigClangSwitchStmt;
 struct ZigClangTagDecl;
+struct ZigClangTargetInfo;
 struct ZigClangType;
 struct ZigClangTypedefNameDecl;
 struct ZigClangTypedefType;
@@ -1049,6 +1050,7 @@ ZIG_EXTERN_C const char* ZigClangSourceManager_getCharacterData(const struct Zig
         struct ZigClangSourceLocation SL);
 
 ZIG_EXTERN_C struct ZigClangQualType ZigClangASTContext_getPointerType(const struct ZigClangASTContext*, struct ZigClangQualType T);
+ZIG_EXTERN_C const struct ZigClangTargetInfo* ZigClangASTContext_getTargetInfo(const struct ZigClangASTContext*);
 
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangLexer_getLocForEndOfToken(struct ZigClangSourceLocation,
         const ZigClangSourceManager *, const ZigClangASTUnit *);
@@ -1076,6 +1078,8 @@ ZIG_EXTERN_C const struct ZigClangRecordDecl *ZigClangRecordType_getDecl(const s
 ZIG_EXTERN_C const struct ZigClangEnumDecl *ZigClangEnumType_getDecl(const struct ZigClangEnumType *record_ty);
 
 ZIG_EXTERN_C bool ZigClangTagDecl_isThisDeclarationADefinition(const struct ZigClangTagDecl *);
+
+ZIG_EXTERN_C uint64_t ZigClangTargetInfo_getMaxPointerWidth(const struct ZigClangTargetInfo *);
 
 ZIG_EXTERN_C const struct ZigClangTagDecl *ZigClangRecordDecl_getCanonicalDecl(const struct ZigClangRecordDecl *record_decl);
 ZIG_EXTERN_C const struct ZigClangTagDecl *ZigClangEnumDecl_getCanonicalDecl(const struct ZigClangEnumDecl *);
@@ -1106,6 +1110,8 @@ ZIG_EXTERN_C const struct ZigClangASTRecordLayout *ZigClangRecordDecl_getASTReco
 
 ZIG_EXTERN_C uint64_t ZigClangASTRecordLayout_getFieldOffset(const struct ZigClangASTRecordLayout *, unsigned);
 ZIG_EXTERN_C int64_t ZigClangASTRecordLayout_getAlignment(const struct ZigClangASTRecordLayout *);
+ZIG_EXTERN_C int64_t ZigClangASTRecordLayout_getSize(const struct ZigClangASTRecordLayout *);
+ZIG_EXTERN_C int64_t ZigClangASTRecordLayout_getDataSize(const struct ZigClangASTRecordLayout *);
 
 ZIG_EXTERN_C struct ZigClangQualType ZigClangFunctionDecl_getType(const struct ZigClangFunctionDecl *);
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangFunctionDecl_getLocation(const struct ZigClangFunctionDecl *);


### PR DESCRIPTION
This relaxes the restriction added in c7884af063791211544c6595a4900bbfcd5d96b6

It fixes issue #12733

Right now, the compiler only considered packed structs to be
C compatible (extern) if the structs are "ABI sized".

See also b83c037f9ffd7a4285de41c95827615fcbdbbf2f for details on
the extern restrictions on `packed struct`

This is an issue on all platforms, but is of particular
importance on aarch64-macos (see my other issue for details)

Previously a type like

```c
struct example {
    int val;
} __attribute__((__packed__));
```

would fail to translate and turn into

```zig
pub const example = @compileError("cannot translate packed record union");
```

This fixes this issue for ABI-sized struct, making the translate-c
rules consistent with the regular compiler.

However, we still keep the restriction on structs that are not "ABI-sized"

So
```c
struct example {
    long a, b, c
} __attribute__((__packed__));
```

will still fail with the appropriate error (in the sense it will emit `@compileError`)

### Implementation details

For the purposes of translate-c, a packed struct is considered
"ABI-sized" when sizeof(target_struct) <= sizeof(void*)

Unfortunately, right now the translate-c `*Context` structure (on the Zig side)
doesn't directly have any information on the target we're translating into.

However, clang has this target information, and keeps it  in clang::ASTContext.
I added a helper function to extract the `clang::TargetInfo` from this,
then query the pointer size.

This is potentially controversial, since it technically makes the
output target-dependent.
The decision of whether to accept/reject a packed struct varies depending
on the target's pointer size.

Howevee, the translator already asks for (integer) field offsets elsewhere,
so I'm pretty sure target info already impacts translation.

We also add getSize() and getDataSize() functions to *clang.RecordDecl.
These return padded and unpadded sizes respectively.
For a packed struct, they should be the same.

The overall effect is 4 more functions added to `zig_clang.cpp` used to
extract target info & query sizes.

### Overall Effect on M1 Macs
As I mentioned in the issue, `aarch64-macos.12` uses (ABI-sized) packed structs in `stdlib.h`. Even an empty file fails to compile without support. This makes resolving the underlying problem (#12733) crucial.

After fixing the bug (and applying #12730 ), I can get `build test-run-translated-c` to finally work!

Before, it just gave a nasty error:
````
/Users/nicholas/.cache/zig/o/d0183770046c7c4914f3676ac67443fd/source.zig:560:39: error: use of undeclared identifier 'struct__OSUnalignedU16'
    return _OSSwapInt16(@intToPtr([*c]struct__OSUnalignedU16, @intCast(usize, @ptrToInt(_base)) +% _offset).*.__val);
                                      ^~~~~~~~~~~~~~~~~~~~~~
/Users/nicholas/.cache/zig/o/d0183770046c7c4914f3676ac67443fd/source.zig:565:39: error: use of undeclared identifier 'struct__OSUnalignedU32'
    return _OSSwapInt32(@intToPtr([*c]struct__OSUnalignedU32, @intCast(usize, @ptrToInt(_base)) +% _offset).*.__val);
                                      ^~~~~~~~~~~~~~~~~~~~~~
````

Anyways, combining these two PRs seems to fix the most serious stage3 compiler and tranlsate-c bugs that I've been encountering on my M1 Mac. 


In addition to fixing `test-run-translated-c`, it also fixes my own libraries. In particular the test suite of [zig-mpack](https://github.com/Techcable/zig-mpack) finally passes!

With stage3, most of the remaining issues in my main codebase seem to be bugs with my project that stage1 didn't catch. For example, I had two conflicting definitions of `const debug = .....`. It was defined twice in my root module.

Hopefully these fixes mean I can *finally* get back to doing real programming with stage3 and Zig as my backend. Big thanks of course to @Vexu and the whole Zig team 🎉 

## Remaining (possible) questions
- Do I need to add test coverage for this new functionality?
   - Usually this is required, however this is really more of a fix for existing (broken) tests than a new one
   - I really don't understand why we only support certain `packed struct` in stage3. Ideally wouldn't we support all of them?
- Is there a cleaner way to do this without querying clang so much?

Please note, I have homework due (that I've been dodging) so I may not be super responsive (maybe just amend the PR?)  