### PR TITLE
autodoc: fix highlighted line in light mode

### DIFF
--- a/src/autodoc/render_source.zig
+++ b/src/autodoc/render_source.zig
@@ -85,9 +85,9 @@ pub fn genHtml(
         \\        display: inline-block;
         \\      }
         \\      .line:target {
-        \\        border-top: 1px solid #444;
-        \\        border-bottom: 1px solid #444;
-        \\        background: #333;
+        \\        border-top: 1px solid #ccc;
+        \\        border-bottom: 1px solid #ccc;
+        \\        background: #fafafa;
         \\      }
         \\
         \\      @media (prefers-color-scheme: dark) {
@@ -99,6 +99,11 @@ pub fn genHtml(
         \\            color: #ccc;
         \\            background: #222;
         \\            border: unset;
+        \\        }
+        \\        .line:target {
+        \\            border-top: 1px solid #444;
+        \\            border-bottom: 1px solid #444;
+        \\            background: #333;
         \\        }
         \\        .tok-kw {
         \\            color: #eee;


### PR DESCRIPTION
sorry that i forgot light theme in previous PR 
![image](https://user-images.githubusercontent.com/63465728/188307505-ea92b7a7-b8c6-444c-b9bc-3ef2302c6fd3.png)
colors are taken from [*Documentation*](https://ziglang.org/documentation/master/) page