### PR TITLE
debug: replace RtlCaptureStackBackTrace (which was spuriously failing) with a new implementation which uses RtlVirtualUnwind instead

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -571,7 +571,7 @@ pub fn writeCurrentStackTrace(
 pub fn walkStackWindows(addresses: []usize) usize {
     if (builtin.cpu.arch == .i386) {
         // RtlVirtualUnwind doesn't exist on x86
-        return windows.ntdll.RtlCaptureStackBackTrace(windows.UNW_FLAG_NHANDLER, addresses.len, @ptrCast(**anyopaque, addresses.ptr), null);
+        return windows.ntdll.RtlCaptureStackBackTrace(0, addresses.len, @ptrCast(**anyopaque, addresses.ptr), null);
     }
 
     var context: windows.CONTEXT = std.mem.zeroes(windows.CONTEXT);
@@ -586,7 +586,7 @@ pub fn walkStackWindows(addresses: []usize) usize {
         if (windows.kernel32.RtlLookupFunctionEntry(current_regs.ip, &image_base, &history_table)) |runtime_function| {
             var handler_data: ?*anyopaque = null;
             var establisher_frame: u64 = undefined;
-            _ = windows.kernel32.RtlVirtualUnwind(0, image_base, current_regs.ip, runtime_function, &context, &handler_data, &establisher_frame, null);
+            _ = windows.kernel32.RtlVirtualUnwind(windows.UNW_FLAG_NHANDLER, image_base, current_regs.ip, runtime_function, &context, &handler_data, &establisher_frame, null);
         } else {
             // leaf function
             context.setIp(@intToPtr(*u64, current_regs.sp).*);

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -569,7 +569,7 @@ pub fn writeCurrentStackTrace(
 }
 
 pub fn walkStackWindows(addresses: []usize) usize {
-    if (builtin.cpu.arch == .i386) {
+    if (builtin.cpu.arch == .x86) {
         // RtlVirtualUnwind doesn't exist on x86
         return windows.ntdll.RtlCaptureStackBackTrace(0, addresses.len, @ptrCast(**anyopaque, addresses.ptr), null);
     }

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -588,15 +588,7 @@ pub noinline fn walkStackWindows(addresses: []usize) usize {
         if (windows.ntdll.RtlLookupFunctionEntry(current_regs.ip, &image_base, &history_table)) |runtime_function| {
             var handler_data: ?*anyopaque = null;
             var establisher_frame: u64 = undefined;
-            _ = windows.ntdll.RtlVirtualUnwind(
-                windows.UNW_FLAG_NHANDLER,
-                image_base,
-                current_regs.ip,
-                runtime_function,
-                &context,
-                &handler_data,
-                &establisher_frame,
-                null);
+            _ = windows.ntdll.RtlVirtualUnwind(windows.UNW_FLAG_NHANDLER, image_base, current_regs.ip, runtime_function, &context, &handler_data, &establisher_frame, null);
         } else {
             // leaf function
             context.setIp(@intToPtr(*u64, current_regs.sp).*);

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -3361,12 +3361,12 @@ pub usingnamespace switch (native_arch) {
         pub const RUNTIME_FUNCTION = extern struct {
             BeginAddress: DWORD,
             EndAddress: DWORD,
-            UnwindData: DWORD
+            UnwindData: DWORD,
         };
 
         pub const KNONVOLATILE_CONTEXT_POINTERS = extern struct {
             FloatingContext: [16]?*M128A,
-            IntegerContext: [16]?*ULONG64
+            IntegerContext: [16]?*ULONG64,
         };
     },
     .aarch64 => struct {
@@ -3451,7 +3451,7 @@ pub usingnamespace switch (native_arch) {
             BeginAddress: DWORD,
             DUMMYUNIONNAME: extern union {
                 UnwindData: DWORD,
-                DUMMYSTRUCTNAME: packed  struct {
+                DUMMYSTRUCTNAME: packed struct {
                     Flag: u2,
                     FunctionLength: u11,
                     RegF: u3,
@@ -3459,8 +3459,8 @@ pub usingnamespace switch (native_arch) {
                     H: u1,
                     CR: u2,
                     FrameSize: u9,
-                }
-            }
+                },
+            },
         };
 
         pub const KNONVOLATILE_CONTEXT_POINTERS = extern struct {
@@ -3474,7 +3474,7 @@ pub usingnamespace switch (native_arch) {
             X26: ?*DWORD64,
             X27: ?*DWORD64,
             X28: ?*DWORD64,
-            Fp :?*DWORD64,
+            Fp: ?*DWORD64,
             Lr: ?*DWORD64,
             D8: ?*DWORD64,
             D9: ?*DWORD64,
@@ -3483,7 +3483,7 @@ pub usingnamespace switch (native_arch) {
             D12: ?*DWORD64,
             D13: ?*DWORD64,
             D14: ?*DWORD64,
-            D15: ?*DWORD64
+            D15: ?*DWORD64,
         };
     },
     else => struct {},
@@ -3501,13 +3501,13 @@ pub const EXCEPTION_ROUTINE = *const fn (
     ExceptionRecord: ?*EXCEPTION_RECORD,
     EstablisherFrame: PVOID,
     ContextRecord: *(Self.CONTEXT),
-    DispatcherContext: PVOID
+    DispatcherContext: PVOID,
 ) callconv(WINAPI) EXCEPTION_DISPOSITION;
 
 pub const UNWIND_HISTORY_TABLE_SIZE = 12;
 pub const UNWIND_HISTORY_TABLE_ENTRY = extern struct {
     ImageBase: ULONG64,
-    FunctionEntry: *Self.RUNTIME_FUNCTION
+    FunctionEntry: *Self.RUNTIME_FUNCTION,
 };
 
 pub const UNWIND_HISTORY_TABLE = extern struct {
@@ -3518,7 +3518,7 @@ pub const UNWIND_HISTORY_TABLE = extern struct {
     Once: BYTE,
     LowAddress: ULONG64,
     HighAddress: ULONG64,
-    Entry: [UNWIND_HISTORY_TABLE_SIZE]UNWIND_HISTORY_TABLE_ENTRY
+    Entry: [UNWIND_HISTORY_TABLE_SIZE]UNWIND_HISTORY_TABLE_ENTRY,
 };
 
 pub const UNW_FLAG_NHANDLER = 0x0;
@@ -3576,7 +3576,7 @@ pub const TEB = extern struct {
 
 pub const EXCEPTION_REGISTRATION_RECORD = struct {
     Next: ?*EXCEPTION_REGISTRATION_RECORD,
-    Handler: ?*EXCEPTION_DISPOSITION
+    Handler: ?*EXCEPTION_DISPOSITION,
 };
 
 pub const NT_TIB = extern struct {
@@ -3584,10 +3584,7 @@ pub const NT_TIB = extern struct {
     StackBase: PVOID,
     StackLimit: PVOID,
     SubSystemTib: PVOID,
-    DUMMYUNIONNAME: extern union {
-        FiberData: PVOID,
-        Version: DWORD
-    },
+    DUMMYUNIONNAME: extern union { FiberData: PVOID, Version: DWORD },
     ArbitraryUserPointer: PVOID,
     Self: ?*@This(),
 };

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -3447,7 +3447,7 @@ pub usingnamespace switch (native_arch) {
             }
         };
 
-        pub const RUNTIME_FUNCTION = struct {
+        pub const RUNTIME_FUNCTION = extern struct {
             BeginAddress: DWORD,
             DUMMYUNIONNAME: extern union {
                 UnwindData: DWORD,
@@ -3574,7 +3574,7 @@ pub const TEB = extern struct {
     TlsExpansionSlots: PVOID,
 };
 
-pub const EXCEPTION_REGISTRATION_RECORD = struct {
+pub const EXCEPTION_REGISTRATION_RECORD = extern struct {
     Next: ?*EXCEPTION_REGISTRATION_RECORD,
     Handler: ?*EXCEPTION_DISPOSITION,
 };

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2152,7 +2152,6 @@ pub const LONG = i32;
 pub const ULONG64 = u64;
 pub const ULONGLONG = u64;
 pub const LONGLONG = i64;
-pub const ULONG64 = u64;
 pub const HLOCAL = HANDLE;
 pub const LANGID = c_ushort;
 

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -3526,11 +3526,6 @@ pub const UNW_FLAG_EHANDLER = 0x1;
 pub const UNW_FLAG_UHANDLER = 0x2;
 pub const UNW_FLAG_CHAININFO = 0x4;
 
-pub const VECTORED_EXCEPTION_HANDLER = switch (builtin.zig_backend) {
-    .stage1 => fn (ExceptionInfo: *EXCEPTION_POINTERS) callconv(WINAPI) c_long,
-    else => *const fn (ExceptionInfo: *EXCEPTION_POINTERS) callconv(WINAPI) c_long,
-};
-
 pub const OBJECT_ATTRIBUTES = extern struct {
     Length: ULONG,
     RootDirectory: ?HANDLE,

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -31,6 +31,8 @@ pub const winmm = @import("windows/winmm.zig");
 
 pub const self_process_handle = @intToPtr(HANDLE, maxInt(usize));
 
+const Self = @This();
+
 pub const OpenError = error{
     IsDir,
     NotDir,
@@ -2150,6 +2152,7 @@ pub const LONG = i32;
 pub const ULONG64 = u64;
 pub const ULONGLONG = u64;
 pub const LONGLONG = i64;
+pub const ULONG64 = u64;
 pub const HLOCAL = HANDLE;
 pub const LANGID = c_ushort;
 
@@ -3272,7 +3275,7 @@ pub usingnamespace switch (native_arch) {
         };
 
         pub const CONTEXT = extern struct {
-            P1Home: DWORD64,
+            P1Home: DWORD64 align(16),
             P2Home: DWORD64,
             P3Home: DWORD64,
             P4Home: DWORD64,
@@ -3342,9 +3345,28 @@ pub usingnamespace switch (native_arch) {
             LastExceptionToRip: DWORD64,
             LastExceptionFromRip: DWORD64,
 
-            pub fn getRegs(ctx: *const CONTEXT) struct { bp: usize, ip: usize } {
-                return .{ .bp = ctx.Rbp, .ip = ctx.Rip };
+            pub fn getRegs(ctx: *const CONTEXT) struct { bp: usize, ip: usize, sp: usize } {
+                return .{ .bp = ctx.Rbp, .ip = ctx.Rip, .sp = ctx.Rsp };
             }
+
+            pub fn setIp(ctx: *CONTEXT, ip: usize) void {
+                ctx.Rip = ip;
+            }
+
+            pub fn setSp(ctx: *CONTEXT, sp: usize) void {
+                ctx.Rsp = sp;
+            }
+        };
+
+        pub const RUNTIME_FUNCTION = extern struct {
+            BeginAddress: DWORD,
+            EndAddress: DWORD,
+            UnwindData: DWORD
+        };
+
+        pub const KNONVOLATILE_CONTEXT_POINTERS = extern struct {
+            FloatingContext: [16]?*M128A,
+            IntegerContext: [16]?*ULONG64
         };
     },
     .aarch64 => struct {
@@ -3360,7 +3382,7 @@ pub usingnamespace switch (native_arch) {
         };
 
         pub const CONTEXT = extern struct {
-            ContextFlags: ULONG,
+            ContextFlags: ULONG align(16),
             Cpsr: ULONG,
             DUMMYUNIONNAME: extern union {
                 DUMMYSTRUCTNAME: extern struct {
@@ -3408,12 +3430,60 @@ pub usingnamespace switch (native_arch) {
             Wcr: [2]DWORD,
             Wvr: [2]DWORD64,
 
-            pub fn getRegs(ctx: *const CONTEXT) struct { bp: usize, ip: usize } {
+            pub fn getRegs(ctx: *const CONTEXT) struct { bp: usize, ip: usize, sp: usize } {
                 return .{
                     .bp = ctx.DUMMYUNIONNAME.DUMMYSTRUCTNAME.Fp,
                     .ip = ctx.Pc,
+                    .sp = ctx.Sp,
                 };
             }
+
+            pub fn setIp(ctx: *CONTEXT, ip: usize) void {
+                ctx.Pc = ip;
+            }
+
+            pub fn setSp(ctx: *CONTEXT, sp: usize) void {
+                ctx.Sp = sp;
+            }
+        };
+
+        pub const RUNTIME_FUNCTION = struct {
+            BeginAddress: DWORD,
+            DUMMYUNIONNAME: extern union {
+                UnwindData: DWORD,
+                DUMMYSTRUCTNAME: packed  struct {
+                    Flag: u2,
+                    FunctionLength: u11,
+                    RegF: u3,
+                    RegI: u4,
+                    H: u1,
+                    CR: u2,
+                    FrameSize: u9,
+                }
+            }
+        };
+
+        pub const KNONVOLATILE_CONTEXT_POINTERS = extern struct {
+            X19: ?*DWORD64,
+            X20: ?*DWORD64,
+            X21: ?*DWORD64,
+            X22: ?*DWORD64,
+            X23: ?*DWORD64,
+            X24: ?*DWORD64,
+            X25: ?*DWORD64,
+            X26: ?*DWORD64,
+            X27: ?*DWORD64,
+            X28: ?*DWORD64,
+            Fp :?*DWORD64,
+            Lr: ?*DWORD64,
+            D8: ?*DWORD64,
+            D9: ?*DWORD64,
+            D10: ?*DWORD64,
+            D11: ?*DWORD64,
+            D12: ?*DWORD64,
+            D13: ?*DWORD64,
+            D14: ?*DWORD64,
+            D15: ?*DWORD64
         };
     },
     else => struct {},
@@ -3425,6 +3495,41 @@ pub const EXCEPTION_POINTERS = extern struct {
 };
 
 pub const VECTORED_EXCEPTION_HANDLER = *const fn (ExceptionInfo: *EXCEPTION_POINTERS) callconv(WINAPI) c_long;
+
+pub const EXCEPTION_DISPOSITION = i32;
+pub const EXCEPTION_ROUTINE = *const fn (
+    ExceptionRecord: ?*EXCEPTION_RECORD,
+    EstablisherFrame: PVOID,
+    ContextRecord: *(Self.CONTEXT),
+    DispatcherContext: PVOID
+) callconv(WINAPI) EXCEPTION_DISPOSITION;
+
+pub const UNWIND_HISTORY_TABLE_SIZE = 12;
+pub const UNWIND_HISTORY_TABLE_ENTRY = extern struct {
+    ImageBase: ULONG64,
+    FunctionEntry: *Self.RUNTIME_FUNCTION
+};
+
+pub const UNWIND_HISTORY_TABLE = extern struct {
+    Count: ULONG,
+    LocalHint: BYTE,
+    GlobalHint: BYTE,
+    Search: BYTE,
+    Once: BYTE,
+    LowAddress: ULONG64,
+    HighAddress: ULONG64,
+    Entry: [UNWIND_HISTORY_TABLE_SIZE]UNWIND_HISTORY_TABLE_ENTRY
+};
+
+pub const UNW_FLAG_NHANDLER = 0x0;
+pub const UNW_FLAG_EHANDLER = 0x1;
+pub const UNW_FLAG_UHANDLER = 0x2;
+pub const UNW_FLAG_CHAININFO = 0x4;
+
+pub const VECTORED_EXCEPTION_HANDLER = switch (builtin.zig_backend) {
+    .stage1 => fn (ExceptionInfo: *EXCEPTION_POINTERS) callconv(WINAPI) c_long,
+    else => *const fn (ExceptionInfo: *EXCEPTION_POINTERS) callconv(WINAPI) c_long,
+};
 
 pub const OBJECT_ATTRIBUTES = extern struct {
     Length: ULONG,

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -3574,6 +3574,24 @@ pub const TEB = extern struct {
     TlsExpansionSlots: PVOID,
 };
 
+pub const EXCEPTION_REGISTRATION_RECORD = struct {
+    Next: ?*EXCEPTION_REGISTRATION_RECORD,
+    Handler: ?*EXCEPTION_DISPOSITION
+};
+
+pub const NT_TIB = extern struct {
+    ExceptionList: ?*EXCEPTION_REGISTRATION_RECORD,
+    StackBase: PVOID,
+    StackLimit: PVOID,
+    SubSystemTib: PVOID,
+    DUMMYUNIONNAME: extern union {
+        FiberData: PVOID,
+        Version: DWORD
+    },
+    ArbitraryUserPointer: PVOID,
+    Self: ?*@This(),
+};
+
 /// Process Environment Block
 /// Microsoft documentation of this is incomplete, the fields here are taken from various resources including:
 ///  - https://github.com/wine-mirror/wine/blob/1aff1e6a370ee8c0213a0fd4b220d121da8527aa/include/winternl.h#L269

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -5,8 +5,10 @@ const BOOL = windows.BOOL;
 const BOOLEAN = windows.BOOLEAN;
 const CONDITION_VARIABLE = windows.CONDITION_VARIABLE;
 const CONSOLE_SCREEN_BUFFER_INFO = windows.CONSOLE_SCREEN_BUFFER_INFO;
+const CONTEXT = windows.CONTEXT;
 const COORD = windows.COORD;
 const DWORD = windows.DWORD;
+const DWORD64 = windows.DWORD64;
 const FILE_INFO_BY_HANDLE_CLASS = windows.FILE_INFO_BY_HANDLE_CLASS;
 const HANDLE = windows.HANDLE;
 const HMODULE = windows.HMODULE;
@@ -60,6 +62,10 @@ const INIT_ONCE_FN = windows.INIT_ONCE_FN;
 const PMEMORY_BASIC_INFORMATION = windows.PMEMORY_BASIC_INFORMATION;
 const REGSAM = windows.REGSAM;
 const LSTATUS = windows.LSTATUS;
+const UNWIND_HISTORY_TABLE = windows.UNWIND_HISTORY_TABLE;
+const RUNTIME_FUNCTION = windows.RUNTIME_FUNCTION;
+const KNONVOLATILE_CONTEXT_POINTERS = windows.KNONVOLATILE_CONTEXT_POINTERS;
+const EXCEPTION_ROUTINE = windows.EXCEPTION_ROUTINE;
 
 pub extern "kernel32" fn AddVectoredExceptionHandler(First: c_ulong, Handler: ?VECTORED_EXCEPTION_HANDLER) callconv(WINAPI) ?*anyopaque;
 pub extern "kernel32" fn RemoveVectoredExceptionHandler(Handle: HANDLE) callconv(WINAPI) c_ulong;
@@ -291,6 +297,25 @@ pub extern "kernel32" fn ReadFile(
 ) callconv(WINAPI) BOOL;
 
 pub extern "kernel32" fn RemoveDirectoryW(lpPathName: [*:0]const u16) callconv(WINAPI) BOOL;
+
+pub extern "kernel32" fn RtlCaptureContext(ContextRecord: *CONTEXT) callconv(WINAPI) void;
+
+pub extern "kernel32" fn RtlLookupFunctionEntry(
+    ControlPc: DWORD64,
+    ImageBase: *DWORD64,
+    HistoryTable: *UNWIND_HISTORY_TABLE
+) callconv(WINAPI) ?*RUNTIME_FUNCTION;
+
+pub extern "kernel32" fn RtlVirtualUnwind(
+    HandlerType: DWORD,
+    ImageBase: DWORD64,
+    ControlPc: DWORD64,
+    FunctionEntry: *RUNTIME_FUNCTION,
+    ContextRecord: *CONTEXT,
+    HandlerData: *?PVOID,
+    EstablisherFrame: *DWORD64,
+    ContextPointers: ?*KNONVOLATILE_CONTEXT_POINTERS,
+) callconv(WINAPI) *EXCEPTION_ROUTINE;
 
 pub extern "kernel32" fn SetConsoleTextAttribute(hConsoleOutput: HANDLE, wAttributes: WORD) callconv(WINAPI) BOOL;
 

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -303,7 +303,7 @@ pub extern "kernel32" fn RtlCaptureContext(ContextRecord: *CONTEXT) callconv(WIN
 pub extern "kernel32" fn RtlLookupFunctionEntry(
     ControlPc: DWORD64,
     ImageBase: *DWORD64,
-    HistoryTable: *UNWIND_HISTORY_TABLE
+    HistoryTable: *UNWIND_HISTORY_TABLE,
 ) callconv(WINAPI) ?*RUNTIME_FUNCTION;
 
 pub extern "kernel32" fn RtlVirtualUnwind(

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -3,6 +3,7 @@ const windows = std.os.windows;
 
 const BOOL = windows.BOOL;
 const DWORD = windows.DWORD;
+const DWORD64 = windows.DWORD64;
 const ULONG = windows.ULONG;
 const WINAPI = windows.WINAPI;
 const NTSTATUS = windows.NTSTATUS;
@@ -24,6 +25,11 @@ const SIZE_T = windows.SIZE_T;
 const CURDIR = windows.CURDIR;
 const PCWSTR = windows.PCWSTR;
 const RTL_QUERY_REGISTRY_TABLE = windows.RTL_QUERY_REGISTRY_TABLE;
+const CONTEXT = windows.CONTEXT;
+const UNWIND_HISTORY_TABLE = windows.UNWIND_HISTORY_TABLE;
+const RUNTIME_FUNCTION = windows.RUNTIME_FUNCTION;
+const KNONVOLATILE_CONTEXT_POINTERS = windows.KNONVOLATILE_CONTEXT_POINTERS;
+const EXCEPTION_ROUTINE = windows.EXCEPTION_ROUTINE;
 
 pub const THREADINFOCLASS = enum(c_int) {
     ThreadBasicInformation,
@@ -99,6 +105,22 @@ pub extern "ntdll" fn RtlCaptureStackBackTrace(
     BackTrace: **anyopaque,
     BackTraceHash: ?*DWORD,
 ) callconv(WINAPI) WORD;
+pub extern "ntdll" fn RtlCaptureContext(ContextRecord: *CONTEXT) callconv(WINAPI) void;
+pub extern "ntdll" fn RtlLookupFunctionEntry(
+    ControlPc: DWORD64,
+    ImageBase: *DWORD64,
+    HistoryTable: *UNWIND_HISTORY_TABLE,
+) callconv(WINAPI) ?*RUNTIME_FUNCTION;
+pub extern "ntdll" fn RtlVirtualUnwind(
+    HandlerType: DWORD,
+    ImageBase: DWORD64,
+    ControlPc: DWORD64,
+    FunctionEntry: *RUNTIME_FUNCTION,
+    ContextRecord: *CONTEXT,
+    HandlerData: *?PVOID,
+    EstablisherFrame: *DWORD64,
+    ContextPointers: ?*KNONVOLATILE_CONTEXT_POINTERS,
+) callconv(WINAPI) *EXCEPTION_ROUTINE;
 pub extern "ntdll" fn NtQueryInformationFile(
     FileHandle: HANDLE,
     IoStatusBlock: *IO_STATUS_BLOCK,


### PR DESCRIPTION
This PR implements `std.debug.walkStackWindows` as a replacement for `RtlCaptureStackBackTrace`. 

### Context

As part of debugging #12703 I was investigating why stack traces weren't appearing, and realized a simple test program that just panicked would not always print the stack trace.

Note that I'm using `zig2` here as I can't build stage3 due to #12703.

Example program:
```
fn bar() void {
    @panic("test");
}

fn foo() void {
    bar();
}

pub fn main() void {
    foo();
}
```

```
>zig2 build-exe panic.zig -target native-windows-msvc

>panic.exe
thread 24112 panic: test

>panic.exe
thread 6572 panic: test
c:\cygwin64\home\kcbanner\temp\zig_panic\panic.zig:2:5: 0x7ff7c6e31d7f in bar (panic.exe.obj)
    @panic("test");
    ^
c:\cygwin64\home\kcbanner\temp\zig_panic\panic.zig:6:8: 0x7ff7c6e315ce in foo (panic.exe.obj)
    bar();
       ^
c:\cygwin64\home\kcbanner\temp\zig_panic\panic.zig:10:8: 0x7ff7c6e3128e in main (panic.exe.obj)
    foo();
       ^
C:\cygwin64\home\kcbanner\kit\zig\lib\std\start.zig:345:41: 0x7ff7c6e31247 in WinStartup (panic.exe.obj)
    std.debug.maybeEnableSegfaultHandler();
                                        ^
???:?:?: 0x7ffac2397033 in ??? (???)
???:?:?: 0x7ffac2ce2650 in ??? (???)

>panic.exe
thread 3864 panic: test

>panic.exe
thread 19984 panic: test
```

The reason for this is that `RtlCaptureStackBackTrace` spuriously returns 0. I couldn't determine the root cause of the spurious failures, but it seemed that others had run into this (https://developercommunity.visualstudio.com/t/capturestackbacktrace-randomly-fails-after-initial/1383213) and had gotten around it by unwinding the stack via the `RtlLookupFunctionEntry`/`RtlVirtualUnwind` calls. 

I referenced these docs for the unwind process:
- https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64?view=msvc-170#unwind-procedure
- http://www.nynaeve.net/?p=101

Supporting changes:
- added `RtlCaptureContext`, `RtlLookupFunctionEntry`, `RtlVirtualUnwind` and supporting types
- fix alignment of `CONTEXT` structs to match winnt.h as required by `RtlCaptureContext` (`fxsave` instr)
  - If a `CONTEXT` was put onto the stack and happened to not be aligned to 16, then the `fxsave` instruction would cause an access violation
- windows aarch64: fix __chkstk being defined twice if libc is not linked on msvc
  - I'm not familiar with this system, but I was hitting this compile error with `-target aarch64-windows-msvc`

### Testing

I'm unsure how to test on windows aarch64. I don't have the hardware - and while the code compiles against `-target aarch64-windows-msvc`, I can't be sure it functions. It seems like qemu for windows doesn't support the same userspace emulation as linux for running aarch64 binaries.

When running `zig2 build test -Dskip-release`, I get failures such as:

```
compiler [51/1153] compile_error_in_inline_fn_call_fixed (stage2, aarch64-macos) [2/2] update [2... error.Unexpected NTSTATUS=0xc0000056
c:\cygwin64\home\kcbanner\kit\zig\lib\std\debug.zig:608:31: 0x7ff77d15ff6f in writeCurrentStackTraceWindows__anon_57536 (test.exe.obj)
    const n = walkStackWindows(addr_buf[0..]);
                              ^
c:\cygwin64\home\kcbanner\kit\zig\lib\std\debug.zig:552:45: 0x7ff77d15fe8d in writeCurrentStackTrace__anon_57535 (test.exe.obj)
        return writeCurrentStackTraceWindows(out_stream, debug_info, tty_config, start_addr);
                                            ^
```

However, these also seem present on master, just with the old stack trace function. This seems like #12420?

I've made my best efforts to follow the style/contributing guidelines and but please let me know if I've missed something as this is my first PR here. I'm also happy to defer this until I can figure out #12703 and properly run the tests.