### PR TITLE
cmake msvc: fixup compiler arg generation, as /O2 is incompatible with /RTC1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,8 +309,14 @@ set(EMBEDDED_SOFTFLOAT_SOURCES
 )
 add_library(embedded_softfloat STATIC ${EMBEDDED_SOFTFLOAT_SOURCES})
 if(MSVC)
+    set(SOFTFLOAT_CFLAGS "/w")
+
+    if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+        set(SOFTFLOAT_CFLAGS "${SOFTFLOAT_CFLAGS} /O2")
+    endif()
+
     set_target_properties(embedded_softfloat PROPERTIES
-        COMPILE_FLAGS "/w /O2"
+        COMPILE_FLAGS ${SOFTFLOAT_CFLAGS}
     )
 else()
     set_target_properties(embedded_softfloat PROPERTIES
@@ -871,7 +877,9 @@ else()
 endif()
 
 if(MSVC)
-  set(OPTIMIZED_C_FLAGS "/O2")
+  if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    set(OPTIMIZED_C_FLAGS "/O2")
+  endif()
 else(MSVC)
   set(OPTIMIZED_C_FLAGS "-std=c99 -O3")
 endif(MSVC)


### PR DESCRIPTION
When trying to make a debug build I was hitting "/O2' and '/RTC1' command-line options are incompatible". This change only adds `/O2` on MSVC when not building "Debug".

Build process:
```
mkdir build-debug
pushd build-debug
"c:\Program Files\CMake\bin\cmake.exe" .. -Thost=x64 -G "Visual Studio 16 2019" -A x64 -DCMAKE_PREFIX_PATH=e:\dev\llvm+clang+lld-14.0.6-x86_64-windows-msvc-debug-mtd -DCMAKE_BUILD_TYPE=Debug
msbuild -p:Configuration=Debug INSTALL.vcxproj
```