### PR TITLE
translate-c: Translate clang packed struct C into Zig extern struct with align(1)

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -470,6 +470,9 @@ pub const FieldDecl = opaque {
     pub const getAlignedAttribute = ZigClangFieldDecl_getAlignedAttribute;
     extern fn ZigClangFieldDecl_getAlignedAttribute(*const FieldDecl, *const ASTContext) c_uint;
 
+    pub const getPackedAttribute = ZigClangFieldDecl_getPackedAttribute;
+    extern fn ZigClangFieldDecl_getPackedAttribute(*const FieldDecl) bool;
+
     pub const isAnonymousStructOrUnion = ZigClangFieldDecl_isAnonymousStructOrUnion;
     extern fn ZigClangFieldDecl_isAnonymousStructOrUnion(*const FieldDecl) bool;
 
@@ -1014,6 +1017,9 @@ pub const VarDecl = opaque {
 
     pub const getAlignedAttribute = ZigClangVarDecl_getAlignedAttribute;
     extern fn ZigClangVarDecl_getAlignedAttribute(*const VarDecl, *const ASTContext) c_uint;
+
+    pub const getPackedAttribute = ZigClangVarDecl_getPackedAttribute;
+    extern fn ZigClangVarDecl_getPackedAttribute(*const VarDecl) bool;
 
     pub const getCleanupAttribute = ZigClangVarDecl_getCleanupAttribute;
     extern fn ZigClangVarDecl_getCleanupAttribute(*const VarDecl) ?*const FunctionDecl;

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -1941,10 +1941,7 @@ const char* ZigClangVarDecl_getSectionAttribute(const struct ZigClangVarDecl *se
 
 bool ZigClangRecordDecl_getPackedAttribute(const ZigClangRecordDecl *zig_record_decl) {
     const clang::RecordDecl *record_decl = reinterpret_cast<const clang::RecordDecl *>(zig_record_decl);
-    if (record_decl->getAttr<clang::PackedAttr>()) {
-      return true;
-    }
-  return false;
+    return record_decl->hasAttr<clang::PackedAttr>();
 }
 
 unsigned ZigClangVarDecl_getAlignedAttribute(const struct ZigClangVarDecl *self, const ZigClangASTContext* ctx) {
@@ -1983,6 +1980,16 @@ unsigned ZigClangFunctionDecl_getAlignedAttribute(const struct ZigClangFunctionD
     }
     // Zero means no explicit alignment factor was specified
     return 0;
+}
+
+bool ZigClangVarDecl_getPackedAttribute(const struct ZigClangVarDecl *self) {
+    auto casted_self = reinterpret_cast<const clang::VarDecl *>(self);
+    return casted_self->hasAttr<clang::PackedAttr>();
+}
+
+bool ZigClangFieldDecl_getPackedAttribute(const struct ZigClangFieldDecl *self) {
+    auto casted_self = reinterpret_cast<const clang::FieldDecl *>(self);
+    return casted_self->hasAttr<clang::PackedAttr>();
 }
 
 ZigClangQualType ZigClangParmVarDecl_getOriginalType(const struct ZigClangParmVarDecl *self) {

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -1101,6 +1101,8 @@ ZIG_EXTERN_C const struct ZigClangFunctionDecl *ZigClangVarDecl_getCleanupAttrib
 ZIG_EXTERN_C unsigned ZigClangVarDecl_getAlignedAttribute(const struct ZigClangVarDecl *self, const ZigClangASTContext* ctx);
 ZIG_EXTERN_C unsigned ZigClangFunctionDecl_getAlignedAttribute(const struct ZigClangFunctionDecl *self, const ZigClangASTContext* ctx);
 ZIG_EXTERN_C unsigned ZigClangFieldDecl_getAlignedAttribute(const struct ZigClangFieldDecl *self, const ZigClangASTContext* ctx);
+ZIG_EXTERN_C bool ZigClangVarDecl_getPackedAttribute(const struct ZigClangVarDecl *self);
+ZIG_EXTERN_C bool ZigClangFieldDecl_getPackedAttribute(const struct ZigClangFieldDecl *self);
 
 ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangFileScopeAsmDecl_getAsmString(const struct ZigClangFileScopeAsmDecl *self);
 

--- a/test/run_translated_c.zig
+++ b/test/run_translated_c.zig
@@ -250,20 +250,18 @@ pub fn addCases(cases: *tests.RunTranslatedCContext) void {
         \\}
     , "");
 
-    if (@import("builtin").zig_backend == .stage1) {
-        cases.add("struct initializer - packed",
-            \\#define _NO_CRT_STDIO_INLINE 1
-            \\#include <stdint.h>
-            \\#include <stdlib.h>
-            \\struct s {uint8_t x,y;
-            \\          uint32_t z;} __attribute__((packed)) s0 = {1, 2};
-            \\int main() {
-            \\  /* sizeof nor offsetof currently supported */
-            \\  if (((intptr_t)&s0.z - (intptr_t)&s0.x) != 2) abort();
-            \\  return 0;
-            \\}
-        , "");
-    }
+    cases.add("struct initializer - packed",
+        \\#define _NO_CRT_STDIO_INLINE 1
+        \\#include <stdint.h>
+        \\#include <stdlib.h>
+        \\struct s {uint8_t x,y;
+        \\          uint32_t z;} __attribute__((packed)) s0 = {1, 2};
+        \\int main() {
+        \\  /* sizeof nor offsetof currently supported */
+        \\  if (((intptr_t)&s0.z - (intptr_t)&s0.x) != 2) abort();
+        \\  return 0;
+        \\}
+    , "");
 
     cases.add("cast signed array index to unsigned",
         \\#include <stdlib.h>

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -728,22 +728,20 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     });
 
-    if (builtin.zig_backend == .stage1) {
-        cases.add("struct initializer - packed",
-            \\struct {int x,y,z;} __attribute__((packed)) s0 = {1, 2};
-        , &[_][]const u8{
-            \\const struct_unnamed_1 = packed struct {
-            \\    x: c_int,
-            \\    y: c_int,
-            \\    z: c_int,
-            \\};
-            \\pub export var s0: struct_unnamed_1 = struct_unnamed_1{
-            \\    .x = @as(c_int, 1),
-            \\    .y = @as(c_int, 2),
-            \\    .z = 0,
-            \\};
-        });
-    }
+    cases.add("struct initializer - packed",
+        \\struct {int x,y,z;} __attribute__((packed)) s0 = {1, 2};
+    , &[_][]const u8{
+        \\const struct_unnamed_1 = extern struct {
+        \\    x: c_int align(1),
+        \\    y: c_int align(1),
+        \\    z: c_int align(1),
+        \\};
+        \\pub export var s0: struct_unnamed_1 = struct_unnamed_1{
+        \\    .x = @as(c_int, 1),
+        \\    .y = @as(c_int, 2),
+        \\    .z = 0,
+        \\};
+    });
 
     // Test case temporarily disabled:
     // https://github.com/ziglang/zig/issues/12055


### PR DESCRIPTION
This is relevant to the fix and discussion in #12735 (and supersedes it).

@ifreund noticed that `align(1)` is missing from `translate-c` output. Hoewever that bug is present with both stage1 & stage2 and is technically independent from that other PR.

~~Until PR #12735 is applied (or some other fix to #12733), `packed struct` will only work with translate-c on stage1.~~

~~I'm hoping this will help work towards getting `packed struct` to support `extern` (but I don't really understand the details too much).~~

**EDIT**: Zig's notion of packed struct is an integer e C's notion of packed struct is essentially an `extern struct` with every field set to `align(1)` (as @ifreund already noticed below).

## Relevant Mismatch with Zig Language Spec (things changed)
Since the last stable release (0.9.1), there was a **change in the language spec** related to the alignment of packed structures.

The docs for Zig 0.9.1 read:
> Packed structs have 1-byte alignment.

So the old behavior of translate-c (not specifying any alignment) was possibly correct back then.

However the current docs read:

> Packed structs have the same alignment as their backing integer

So now `translate-c` definitely needs to specify `align(1)` for every field (unless the field has an explicitly specified alignment)

Unfortunately, the current implementation of `translate-c` does not reflect this.


**EDIT**: Also, packed structs are now interpreted simply as wrappers around integers (issue #10113). This means instead of translating `__attribute___(packed) struct` to be an `packed struct` it needs to be an `extern struct`

Running `translate-c` on the following code:

```c
struct foo {
    char a;
    int b;
} __attribute__((packed));

struct bar {
    char a;
    int b;
    short c;
    __attribute__((aligned(8))) long d;
} __attribute__((packed));
```

does not apply any alignment attributes to any fields except d.

<summary>
   <details>Currently generated (incorrect) code</details>
   Running `zig translate-c -fstage1 test.h` on the above code (need `-fstage1` becuase packed struct support is disabled on stage2).

    ```zig
    pub const struct_foo = packed struct {
        a: u8,
        b: c_int,
    };
    pub const struct_bar = packed struct {
        a: u8,
        b: c_int,
        c: c_short,
        d: c_long align(8),
    };
    ```

    Notice how the `align(1)` specifier is missing 😦
    **EDIT**: And these are `packed struct` instead of `extern struct`.
</summary>

### Justification for C behavior of `align(1)`
This comes from a careful reading of the GCC docs for type & variable attributes.

The final line of the documentation for `__attribute__ ((aligned))` [[on types]](https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html) says:

> When used on a struct, or struct member, the aligned attribute can only increase the alignment; **in order to decrease it, the packed attribute must be specified as well**

This implies that GCC uses the `packed` attribute for alignment purposes in addition to eliminating padding.

The documentation for `__attribute__((packed))` [[on types]](https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html), states that "This is equivalent to specifying the packed attribute on each of the members."

The key is resolving this indirection, and looking at the documentation for `__attribute__((packed))` [[on fields]](https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#Common-Variable-Attributes):

> The packed attribute specifies that a **structure member should have the smallest possible alignment** — one bit for a bit-field and one byte otherwise, unless a larger value is specified with the aligned attribute. The attribute does not apply to non-member objects.

(NOTE: Somewhat confusingly, field attributes are documented under "variables" in GCC...)

This means that a C structure with `__attribute__((packed)` is shorthand for `__attribute__((packed))` on each member, which is equivalent to Zig's `align(1)` on each of its members.

## Fixed Behavior
Sometimes __attribute__((packed)) is used only for alignment purposes.

In particular, it can be used as a semi-portable way to do unaligned stores

The `stdlib.h` headers do this on aarch64-macos.12.

The structures in the MacOS headers were being used chiefly for their alignment
properties, not for padding purposes (they only had one field).

After applying this change, the translated structures have align(1)
explicitly applied to all of their fields (unless explicitly overriden).
This makes Zig behavior for `tranlsate-c` consistent with clang/GCC.

~~Here is the newly produced (correct) output for the above example~~:

**EDIT**: Changed from `packed struct` to `extern struct`.

```zig
pub const struct_foo = extern struct {
    a: u8 align(1),
    b: c_int align(1),
};
pub const struct_bar = extern struct {
    a: u8 align(1),
    b: c_int align(1),
    c: c_short align(1),
    d: c_long align(8),
};
```

This is closely related with PR #12735 

**EDIT 1**: Updated to reflect need to change from `packed struct` to `extern struct` (see comment below).