### PR TITLE
std.log: make current level be a function

### DIFF
--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -96,18 +96,20 @@ pub const Level = enum {
 };
 
 /// The default log level is based on build mode.
-pub const default_level: Level = switch (builtin.mode) {
-    .Debug => .debug,
-    .ReleaseSafe => .info,
-    .ReleaseFast, .ReleaseSmall => .err,
-};
+pub fn defaultLevel() Level {
+    return switch (builtin.mode) {
+        .Debug => .debug,
+        .ReleaseSafe => .info,
+        .ReleaseFast, .ReleaseSmall => .err,
+    };
+}
 
 /// The current log level. This is set to root.log_level if present, otherwise
 /// log.default_level.
-pub const level: Level = if (@hasDecl(root, "log_level"))
+pub const level: fn () Level = if (@hasDecl(root, "log_level"))
     root.log_level
 else
-    default_level;
+    defaultLevel;
 
 pub const ScopeLevel = struct {
     scope: @Type(.EnumLiteral),
@@ -129,7 +131,7 @@ fn log(
         inline for (scope_levels) |scope_level| {
             if (scope_level.scope == scope) break :blk scope_level.level;
         }
-        break :blk level;
+        break :blk level();
     };
 
     if (@enumToInt(message_level) <= @enumToInt(effective_log_level)) {

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -20,7 +20,10 @@ pub var failing_allocator_instance = FailingAllocator.init(base_allocator_instan
 pub var base_allocator_instance = std.heap.FixedBufferAllocator.init("");
 
 /// TODO https://github.com/ziglang/zig/issues/5738
-pub var log_level = std.log.Level.warn;
+pub var current_log_level: std.log.Level = .warn;
+pub fn log_level() std.log.Level {
+    return current_log_level;
+}
 
 /// This is available to any test that wants to execute Zig in a child process.
 /// It will be the same executable that is running `zig test`.

--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -53,7 +53,7 @@ pub fn main() void {
                 leaks += 1;
             }
         }
-        std.testing.log_level = .warn;
+        std.testing.current_log_level = .warn;
 
         var test_node = root_node.start(test_fn.name, 0);
         test_node.activate();
@@ -123,7 +123,7 @@ pub fn log(
     if (@enumToInt(message_level) <= @enumToInt(std.log.Level.err)) {
         log_err_count += 1;
     }
-    if (@enumToInt(message_level) <= @enumToInt(std.testing.log_level)) {
+    if (@enumToInt(message_level) <= @enumToInt(std.testing.current_log_level)) {
         std.debug.print(
             "[" ++ @tagName(scope) ++ "] (" ++ @tagName(message_level) ++ "): " ++ format ++ "\n",
             args,

--- a/src/main.zig
+++ b/src/main.zig
@@ -92,11 +92,13 @@ const debug_usage = normal_usage ++
 
 const usage = if (debug_extensions_enabled) debug_usage else normal_usage;
 
-pub const log_level: std.log.Level = switch (builtin.mode) {
-    .Debug => .debug,
-    .ReleaseSafe, .ReleaseFast => .info,
-    .ReleaseSmall => .err,
-};
+pub fn log_level() std.log.Level {
+    return switch (builtin.mode) {
+        .Debug => .debug,
+        .ReleaseSafe, .ReleaseFast => .info,
+        .ReleaseSmall => .err,
+    };
+}
 
 var log_scopes: std.ArrayListUnmanaged([]const u8) = .{};
 
@@ -109,7 +111,7 @@ pub fn log(
     // Hide debug messages unless:
     // * logging enabled with `-Dlog`.
     // * the --debug-log arg for the scope has been provided
-    if (@enumToInt(level) > @enumToInt(std.log.level) or
+    if (@enumToInt(level) > @enumToInt(std.log.level()) or
         @enumToInt(level) > @enumToInt(std.log.Level.info))
     {
         if (!build_options.enable_logging) return;

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -440,7 +440,9 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
     cases.add("std.log per scope log level override",
         \\const std = @import("std");
         \\
-        \\pub const log_level: std.log.Level = .debug;
+        \\pub fn log_level() std.log.Level {
+        \\    return .debug;
+        \\}
         \\
         \\pub const scope_levels = [_]std.log.ScopeLevel{
         \\    .{ .scope = .a, .level = .warn },
@@ -494,7 +496,9 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
     cases.add("std.heap.LoggingAllocator logs to std.log",
         \\const std = @import("std");
         \\
-        \\pub const log_level: std.log.Level = .debug;
+        \\pub fn log_level() std.log.Level {
+        \\    return .debug;
+        \\}
         \\
         \\pub fn main() !void {
         \\    var allocator_buf: [10]u8 = undefined;


### PR DESCRIPTION
From https://github.com/ziglang/zig/issues/2586#issuecomment-497327770
> Making it configurable at runtime would not be something the default thing would do but you could override the log function to achieve that behavior.

And from https://github.com/ziglang/zig/issues/2586#issuecomment-506546622
> You could also make default_level a function, which just returns a comptime value by default, or root can make it a function that returns a comptime or runtime value.

Overriding the `log` function isn't enough because level checking happens before that, so it'd make sense to expose that bit of logic for API users to change.

Overriding the current way `level` is set also isn't enough because that's set as a `const`. That leaves an overridable function to be done, as Marler suggested.

Here's an example of how this patch looks in practice:

```zig
var current_log_level: std.log.Level = .info; // default

pub fn log_level() std.log.Level {
    return current_log_level;
}

pub fn main() !void {
   // ...
   if (args.options.verbose) current_log_level = .debug;
   // ...
}
```