### PR TITLE
std: Replace use of stage1 function pointers

### DIFF
--- a/lib/std/base64.zig
+++ b/lib/std/base64.zig
@@ -9,10 +9,7 @@ pub const Error = error{
     NoSpaceLeft,
 };
 
-const decoderWithIgnoreProto = switch (@import("builtin").zig_backend) {
-    .stage1 => fn (ignore: []const u8) Base64DecoderWithIgnore,
-    else => *const fn (ignore: []const u8) Base64DecoderWithIgnore,
-};
+const decoderWithIgnoreProto = std.meta.FnPtr(fn (ignore: []const u8) Base64DecoderWithIgnore);
 
 /// Base64 codecs
 pub const Codecs = struct {

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -3593,10 +3593,7 @@ pub const Step = struct {
     loop_flag: bool,
     done_flag: bool,
 
-    const MakeFn = switch (builtin.zig_backend) {
-        .stage1 => fn (self: *Step) anyerror!void,
-        else => *const fn (self: *Step) anyerror!void,
-    };
+    const MakeFn = std.meta.FnPtr(fn (self: *Step) anyerror!void);
 
     pub const Id = enum {
         top_level,

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -736,14 +736,8 @@ pub const CompilerBackend = enum(u64) {
 /// therefore must be kept in sync with the compiler implementation.
 pub const TestFn = struct {
     name: []const u8,
-    func: testFnProto,
+    func: std.meta.FnPtr(fn () anyerror!void),
     async_frame_size: ?usize,
-};
-
-/// stage1 is *wrong*. It is not yet updated to support the new function type semantics.
-const testFnProto = switch (builtin.zig_backend) {
-    .stage1 => fn () anyerror!void, // wrong!
-    else => *const fn () anyerror!void,
 };
 
 /// This function type is used by the Zig language code generation and

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -241,11 +241,8 @@ pub extern "c" fn utimes(path: [*:0]const u8, times: *[2]c.timeval) c_int;
 pub extern "c" fn utimensat(dirfd: c.fd_t, pathname: [*:0]const u8, times: *[2]c.timespec, flags: u32) c_int;
 pub extern "c" fn futimens(fd: c.fd_t, times: *const [2]c.timespec) c_int;
 
+const PThreadStartFn = std.meta.FnPtr(fn (?*anyopaque) callconv(.C) ?*anyopaque);
 pub extern "c" fn pthread_create(noalias newthread: *pthread_t, noalias attr: ?*const c.pthread_attr_t, start_routine: PThreadStartFn, noalias arg: ?*anyopaque) c.E;
-const PThreadStartFn = if (builtin.zig_backend == .stage1)
-    fn (?*anyopaque) callconv(.C) ?*anyopaque
-else
-    *const fn (?*anyopaque) callconv(.C) ?*anyopaque;
 pub extern "c" fn pthread_attr_init(attr: *c.pthread_attr_t) c.E;
 pub extern "c" fn pthread_attr_setstack(attr: *c.pthread_attr_t, stackaddr: *anyopaque, stacksize: usize) c.E;
 pub extern "c" fn pthread_attr_setstacksize(attr: *c.pthread_attr_t, stacksize: usize) c.E;
@@ -254,20 +251,14 @@ pub extern "c" fn pthread_attr_destroy(attr: *c.pthread_attr_t) c.E;
 pub extern "c" fn pthread_self() pthread_t;
 pub extern "c" fn pthread_join(thread: pthread_t, arg_return: ?*?*anyopaque) c.E;
 pub extern "c" fn pthread_detach(thread: pthread_t) c.E;
+const PThreadForkFn = std.meta.FnPtr(fn () callconv(.C) void);
 pub extern "c" fn pthread_atfork(
     prepare: ?PThreadForkFn,
     parent: ?PThreadForkFn,
     child: ?PThreadForkFn,
 ) c_int;
-const PThreadForkFn = if (builtin.zig_backend == .stage1)
-    fn () callconv(.C) void
-else
-    *const fn () callconv(.C) void;
+const PThreadKeyCreateFn = std.meta.FnPtr(fn (value: *anyopaque) callconv(.C) void);
 pub extern "c" fn pthread_key_create(key: *c.pthread_key_t, destructor: ?PThreadKeyCreateFn) c.E;
-const PThreadKeyCreateFn = if (builtin.zig_backend == .stage1)
-    fn (value: *anyopaque) callconv(.C) void
-else
-    *const fn (value: *anyopaque) callconv(.C) void;
 pub extern "c" fn pthread_key_delete(key: c.pthread_key_t) c.E;
 pub extern "c" fn pthread_getspecific(key: c.pthread_key_t) ?*anyopaque;
 pub extern "c" fn pthread_setspecific(key: c.pthread_key_t, value: ?*anyopaque) c_int;

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -918,14 +918,8 @@ pub const siginfo_t = extern struct {
 
 /// Renamed from `sigaction` to `Sigaction` to avoid conflict with function name.
 pub const Sigaction = extern struct {
-    pub const handler_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int) callconv(.C) void,
-        else => *const fn (c_int) callconv(.C) void,
-    };
-    pub const sigaction_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-        else => *const fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-    };
+    pub const handler_fn = std.meta.FnPtr(fn (c_int) callconv(.C) void);
+    pub const sigaction_fn = std.meta.FnPtr(fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void);
 
     handler: extern union {
         handler: ?handler_fn,

--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -13,10 +13,7 @@ pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;
 pub extern "c" fn pipe2(fds: *[2]fd_t, flags: u32) c_int;
 
-pub const dl_iterate_phdr_callback = switch (builtin.zig_backend) {
-    .stage1 => fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-    else => *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-};
+pub const dl_iterate_phdr_callback = std.meta.FnPtr(fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int);
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 
 pub extern "c" fn lwp_gettid() c_int;
@@ -683,14 +680,8 @@ pub const empty_sigset = sigset_t{ .__bits = [_]c_uint{0} ** _SIG_WORDS };
 pub const sig_atomic_t = c_int;
 
 pub const Sigaction = extern struct {
-    pub const handler_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int) callconv(.C) void,
-        else => *const fn (c_int) callconv(.C) void,
-    };
-    pub const sigaction_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-        else => *const fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-    };
+    pub const handler_fn = std.meta.FnPtr(fn (c_int) callconv(.C) void);
+    pub const sigaction_fn = std.meta.FnPtr(fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void);
 
     /// signal handler
     handler: extern union {

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -37,10 +37,7 @@ pub extern "c" fn sendfile(
     flags: u32,
 ) c_int;
 
-pub const dl_iterate_phdr_callback = switch (builtin.zig_backend) {
-    .stage1 => fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-    else => *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-};
+pub const dl_iterate_phdr_callback = std.meta.FnPtr(fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int);
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 
 pub const pthread_mutex_t = extern struct {
@@ -1200,14 +1197,8 @@ const NSIG = 32;
 
 /// Renamed from `sigaction` to `Sigaction` to avoid conflict with the syscall.
 pub const Sigaction = extern struct {
-    pub const handler_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int) callconv(.C) void,
-        else => *const fn (c_int) callconv(.C) void,
-    };
-    pub const sigaction_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-        else => *const fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-    };
+    pub const handler_fn = std.meta.FnPtr(fn (c_int) callconv(.C) void);
+    pub const sigaction_fn = std.meta.FnPtr(fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void);
 
     /// signal handler
     handler: extern union {

--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -738,10 +738,7 @@ const NSIG = 32;
 
 /// Renamed from `sigaction` to `Sigaction` to avoid conflict with the syscall.
 pub const Sigaction = extern struct {
-    pub const handler_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (i32) callconv(.C) void,
-        else => *const fn (i32) callconv(.C) void,
-    };
+    pub const handler_fn = std.meta.FnPtr(fn (i32) callconv(.C) void);
 
     /// signal handler
     __sigaction_u: extern union {

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -263,10 +263,7 @@ pub extern "c" fn inotify_rm_watch(fd: fd_t, wd: c_int) c_int;
 /// See std.elf for constants for this
 pub extern "c" fn getauxval(__type: c_ulong) c_ulong;
 
-pub const dl_iterate_phdr_callback = switch (builtin.zig_backend) {
-    .stage1 => fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-    else => *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-};
+pub const dl_iterate_phdr_callback = std.meta.FnPtr(fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int);
 
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -9,10 +9,7 @@ const rusage = std.c.rusage;
 extern "c" fn __errno() *c_int;
 pub const _errno = __errno;
 
-pub const dl_iterate_phdr_callback = switch (builtin.zig_backend) {
-    .stage1 => fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-    else => *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-};
+pub const dl_iterate_phdr_callback = std.meta.FnPtr(fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int);
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 
 pub extern "c" fn _lwp_self() lwpid_t;
@@ -974,14 +971,8 @@ pub const SIG = struct {
 
 /// Renamed from `sigaction` to `Sigaction` to avoid conflict with the syscall.
 pub const Sigaction = extern struct {
-    pub const handler_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int) callconv(.C) void,
-        else => *const fn (c_int) callconv(.C) void,
-    };
-    pub const sigaction_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-        else => *const fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-    };
+    pub const handler_fn = std.meta.FnPtr(fn (c_int) callconv(.C) void);
+    pub const sigaction_fn = std.meta.FnPtr(fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void);
 
     /// signal handler
     handler: extern union {

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -7,10 +7,7 @@ const iovec_const = std.os.iovec_const;
 extern "c" fn __errno() *c_int;
 pub const _errno = __errno;
 
-pub const dl_iterate_phdr_callback = switch (builtin.zig_backend) {
-    .stage1 => fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-    else => *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-};
+pub const dl_iterate_phdr_callback = std.meta.FnPtr(fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int);
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 
 pub extern "c" fn arc4random_buf(buf: [*]u8, len: usize) void;
@@ -1029,14 +1026,8 @@ pub const SIG = struct {
 
 /// Renamed from `sigaction` to `Sigaction` to avoid conflict with the syscall.
 pub const Sigaction = extern struct {
-    pub const handler_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int) callconv(.C) void,
-        else => *const fn (c_int) callconv(.C) void,
-    };
-    pub const sigaction_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-        else => *const fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-    };
+    pub const handler_fn = std.meta.FnPtr(fn (c_int) callconv(.C) void);
+    pub const sigaction_fn = std.meta.FnPtr(fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void);
 
     /// signal handler
     handler: extern union {

--- a/lib/std/c/solaris.zig
+++ b/lib/std/c/solaris.zig
@@ -8,10 +8,7 @@ const timezone = std.c.timezone;
 extern "c" fn ___errno() *c_int;
 pub const _errno = ___errno;
 
-pub const dl_iterate_phdr_callback = switch (builtin.zig_backend) {
-    .stage1 => fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-    else => *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int,
-};
+pub const dl_iterate_phdr_callback = std.meta.FnPtr(fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int);
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 
 pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) usize;
@@ -955,14 +952,8 @@ pub const SIG = struct {
 
 /// Renamed from `sigaction` to `Sigaction` to avoid conflict with the syscall.
 pub const Sigaction = extern struct {
-    pub const handler_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int) callconv(.C) void,
-        else => *const fn (c_int) callconv(.C) void,
-    };
-    pub const sigaction_fn = switch (builtin.zig_backend) {
-        .stage1 => fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-        else => *const fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void,
-    };
+    pub const handler_fn = std.meta.FnPtr(fn (c_int) callconv(.C) void);
+    pub const sigaction_fn = std.meta.FnPtr(fn (c_int, *const siginfo_t, ?*const anyopaque) callconv(.C) void);
 
     /// signal options
     flags: c_uint,

--- a/lib/std/compress/deflate/compressor.zig
+++ b/lib/std/compress/deflate/compressor.zig
@@ -254,10 +254,7 @@ pub fn Compressor(comptime WriterType: anytype) type {
 
         // Inner writer wrapped in a HuffmanBitWriter
         hm_bw: hm_bw.HuffmanBitWriter(WriterType) = undefined,
-        bulk_hasher: if (@import("builtin").zig_backend == .stage1)
-            fn ([]u8, []u32) u32
-        else
-            *const fn ([]u8, []u32) u32,
+        bulk_hasher: std.meta.FnPtr(fn ([]u8, []u32) u32),
 
         sync: bool, // requesting flush
         best_speed_enc: *fast.DeflateFast, // Encoder for best_speed

--- a/lib/std/compress/deflate/decompressor.zig
+++ b/lib/std/compress/deflate/decompressor.zig
@@ -334,10 +334,7 @@ pub fn Decompressor(comptime ReaderType: type) type {
 
         // Next step in the decompression,
         // and decompression state.
-        step: if (@import("builtin").zig_backend == .stage1)
-            fn (*Self) Error!void
-        else
-            *const fn (*Self) Error!void,
+        step: std.meta.FnPtr(fn (*Self) Error!void),
         step_state: DecompressorState,
         final: bool,
         err: ?Error,

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2173,18 +2173,18 @@ test "escape non-printable" {
 }
 
 test "pointer" {
-    if (builtin.zig_backend == .stage1) return error.SkipZigTest;
     {
         const value = @intToPtr(*align(1) i32, 0xdeadbeef);
         try expectFmt("pointer: i32@deadbeef\n", "pointer: {}\n", .{value});
         try expectFmt("pointer: i32@deadbeef\n", "pointer: {*}\n", .{value});
     }
+    const FnPtr = if (builtin.zig_backend == .stage1) fn () void else *align(1) const fn () void;
     {
-        const value = @intToPtr(*align(1) const fn () void, 0xdeadbeef);
+        const value = @intToPtr(FnPtr, 0xdeadbeef);
         try expectFmt("pointer: fn() void@deadbeef\n", "pointer: {}\n", .{value});
     }
     {
-        const value = @intToPtr(*align(1) const fn () void, 0xdeadbeef);
+        const value = @intToPtr(FnPtr, 0xdeadbeef);
         try expectFmt("pointer: fn() void@deadbeef\n", "pointer: {}\n", .{value});
     }
 }

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -23,10 +23,7 @@ pub const VTable = struct {
     ///
     /// `ret_addr` is optionally provided as the first return address of the allocation call stack.
     /// If the value is `0` it means no return address has been provided.
-    alloc: switch (builtin.zig_backend) {
-        .stage1 => allocProto, // temporary workaround until we replace stage1 with stage2
-        else => *const allocProto,
-    },
+    alloc: std.meta.FnPtr(fn (ptr: *anyopaque, len: usize, ptr_align: u29, len_align: u29, ret_addr: usize) Error![]u8),
 
     /// Attempt to expand or shrink memory in place. `buf.len` must equal the most recent
     /// length returned by `alloc` or `resize`. `buf_align` must equal the same value
@@ -45,25 +42,15 @@ pub const VTable = struct {
     ///
     /// `ret_addr` is optionally provided as the first return address of the allocation call stack.
     /// If the value is `0` it means no return address has been provided.
-    resize: switch (builtin.zig_backend) {
-        .stage1 => resizeProto, // temporary workaround until we replace stage1 with stage2
-        else => *const resizeProto,
-    },
+    resize: std.meta.FnPtr(fn (ptr: *anyopaque, buf: []u8, buf_align: u29, new_len: usize, len_align: u29, ret_addr: usize) ?usize),
 
     /// Free and invalidate a buffer. `buf.len` must equal the most recent length returned by `alloc` or `resize`.
     /// `buf_align` must equal the same value that was passed as the `ptr_align` parameter to the original `alloc` call.
     ///
     /// `ret_addr` is optionally provided as the first return address of the allocation call stack.
     /// If the value is `0` it means no return address has been provided.
-    free: switch (builtin.zig_backend) {
-        .stage1 => freeProto, // temporary workaround until we replace stage1 with stage2
-        else => *const freeProto,
-    },
+    free: std.meta.FnPtr(fn (ptr: *anyopaque, buf: []u8, buf_align: u29, ret_addr: usize) void),
 };
-
-const allocProto = fn (ptr: *anyopaque, len: usize, ptr_align: u29, len_align: u29, ret_addr: usize) Error![]u8;
-const resizeProto = fn (ptr: *anyopaque, buf: []u8, buf_align: u29, new_len: usize, len_align: u29, ret_addr: usize) ?usize;
-const freeProto = fn (ptr: *anyopaque, buf: []u8, buf_align: u29, ret_addr: usize) void;
 
 pub fn init(
     pointer: anytype,

--- a/lib/std/os/linux/arm-eabi.zig
+++ b/lib/std/os/linux/arm-eabi.zig
@@ -98,19 +98,10 @@ pub fn syscall6(
     );
 }
 
+const CloneFn = std.meta.FnPtr(fn (arg: usize) callconv(.C) u8);
+
 /// This matches the libc clone function.
-pub extern fn clone(
-    func: switch (@import("builtin").zig_backend) {
-        .stage1 => fn (arg: usize) callconv(.C) u8,
-        else => *const fn (arg: usize) callconv(.C) u8,
-    },
-    stack: usize,
-    flags: u32,
-    arg: usize,
-    ptid: *i32,
-    tls: usize,
-    ctid: *i32,
-) usize;
+pub extern fn clone(func: CloneFn, stack: usize, flags: u32, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;
 
 pub fn restore() callconv(.Naked) void {
     return asm volatile ("svc #0"

--- a/lib/std/os/linux/arm64.zig
+++ b/lib/std/os/linux/arm64.zig
@@ -98,10 +98,7 @@ pub fn syscall6(
     );
 }
 
-const CloneFn = switch (@import("builtin").zig_backend) {
-    .stage1 => fn (arg: usize) callconv(.C) u8,
-    else => *const fn (arg: usize) callconv(.C) u8,
-};
+const CloneFn = std.meta.FnPtr(fn (arg: usize) callconv(.C) u8);
 
 /// This matches the libc clone function.
 pub extern fn clone(func: CloneFn, stack: usize, flags: u32, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;

--- a/lib/std/os/linux/i386.zig
+++ b/lib/std/os/linux/i386.zig
@@ -118,10 +118,7 @@ pub fn socketcall(call: usize, args: [*]usize) usize {
     );
 }
 
-const CloneFn = switch (@import("builtin").zig_backend) {
-    .stage1 => fn (arg: usize) callconv(.C) u8,
-    else => *const fn (arg: usize) callconv(.C) u8,
-};
+const CloneFn = std.meta.FnPtr(fn (arg: usize) callconv(.C) u8);
 
 /// This matches the libc clone function.
 pub extern fn clone(func: CloneFn, stack: usize, flags: u32, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;

--- a/lib/std/os/linux/mips.zig
+++ b/lib/std/os/linux/mips.zig
@@ -190,10 +190,7 @@ pub fn syscall7(
     );
 }
 
-const CloneFn = switch (@import("builtin").zig_backend) {
-    .stage1 => fn (arg: usize) callconv(.C) u8,
-    else => *const fn (arg: usize) callconv(.C) u8,
-};
+const CloneFn = std.meta.FnPtr(fn (arg: usize) callconv(.C) u8);
 
 /// This matches the libc clone function.
 pub extern fn clone(func: CloneFn, stack: usize, flags: u32, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;

--- a/lib/std/os/linux/powerpc.zig
+++ b/lib/std/os/linux/powerpc.zig
@@ -126,10 +126,7 @@ pub fn syscall6(
     );
 }
 
-const CloneFn = switch (@import("builtin").zig_backend) {
-    .stage1 => fn (arg: usize) callconv(.C) u8,
-    else => *const fn (arg: usize) callconv(.C) u8,
-};
+const CloneFn = std.meta.FnPtr(fn (arg: usize) callconv(.C) u8);
 
 /// This matches the libc clone function.
 pub extern fn clone(func: CloneFn, stack: usize, flags: usize, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;

--- a/lib/std/os/linux/powerpc64.zig
+++ b/lib/std/os/linux/powerpc64.zig
@@ -126,10 +126,7 @@ pub fn syscall6(
     );
 }
 
-const CloneFn = switch (@import("builtin").zig_backend) {
-    .stage1 => fn (arg: usize) callconv(.C) u8,
-    else => *const fn (arg: usize) callconv(.C) u8,
-};
+const CloneFn = std.meta.FnPtr(fn (arg: usize) callconv(.C) u8);
 
 /// This matches the libc clone function.
 pub extern fn clone(func: CloneFn, stack: usize, flags: usize, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;

--- a/lib/std/os/linux/riscv64.zig
+++ b/lib/std/os/linux/riscv64.zig
@@ -95,10 +95,7 @@ pub fn syscall6(
     );
 }
 
-const CloneFn = switch (@import("builtin").zig_backend) {
-    .stage1 => fn (arg: usize) callconv(.C) u8,
-    else => *const fn (arg: usize) callconv(.C) u8,
-};
+const CloneFn = std.meta.FnPtr(fn (arg: usize) callconv(.C) u8);
 
 pub extern fn clone(func: CloneFn, stack: usize, flags: u32, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;
 

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -178,10 +178,7 @@ pub fn syscall6(
     );
 }
 
-const CloneFn = switch (@import("builtin").zig_backend) {
-    .stage1 => fn (arg: usize) callconv(.C) u8,
-    else => *const fn (arg: usize) callconv(.C) u8,
-};
+const CloneFn = std.meta.FnPtr(fn (arg: usize) callconv(.C) u8);
 
 /// This matches the libc clone function.
 pub extern fn clone(func: CloneFn, stack: usize, flags: usize, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;

--- a/lib/std/os/linux/x86_64.zig
+++ b/lib/std/os/linux/x86_64.zig
@@ -100,13 +100,10 @@ pub fn syscall6(
     );
 }
 
+const CloneFn = std.meta.FnPtr(fn (arg: usize) callconv(.C) u8);
+
 /// This matches the libc clone function.
 pub extern fn clone(func: CloneFn, stack: usize, flags: usize, arg: usize, ptid: *i32, tls: usize, ctid: *i32) usize;
-
-const CloneFn = switch (@import("builtin").zig_backend) {
-    .stage1 => fn (arg: usize) callconv(.C) u8,
-    else => *const fn (arg: usize) callconv(.C) u8,
-};
 
 pub const restore = restore_rt;
 

--- a/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
+++ b/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
@@ -1,12 +1,13 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 
 /// Protocol for touchscreens
 pub const AbsolutePointerProtocol = extern struct {
-    _reset: fn (*const AbsolutePointerProtocol, bool) callconv(.C) Status,
-    _get_state: fn (*const AbsolutePointerProtocol, *AbsolutePointerState) callconv(.C) Status,
+    _reset: std.meta.FnPtr(fn (*const AbsolutePointerProtocol, bool) callconv(.C) Status),
+    _get_state: std.meta.FnPtr(fn (*const AbsolutePointerProtocol, *AbsolutePointerState) callconv(.C) Status),
     wait_for_input: Event,
     mode: *AbsolutePointerMode,
 

--- a/lib/std/os/uefi/protocols/block_io_protocol.zig
+++ b/lib/std/os/uefi/protocols/block_io_protocol.zig
@@ -44,10 +44,10 @@ pub const BlockIoProtocol = extern struct {
     revision: u64,
     media: *EfiBlockMedia,
 
-    _reset: fn (*BlockIoProtocol, extended_verification: bool) callconv(.C) Status,
-    _read_blocks: fn (*BlockIoProtocol, media_id: u32, lba: u64, buffer_size: usize, buf: [*]u8) callconv(.C) Status,
-    _write_blocks: fn (*BlockIoProtocol, media_id: u32, lba: u64, buffer_size: usize, buf: [*]u8) callconv(.C) Status,
-    _flush_blocks: fn (*BlockIoProtocol) callconv(.C) Status,
+    _reset: std.meta.FnPtr(fn (*BlockIoProtocol, extended_verification: bool) callconv(.C) Status),
+    _read_blocks: std.meta.FnPtr(fn (*BlockIoProtocol, media_id: u32, lba: u64, buffer_size: usize, buf: [*]u8) callconv(.C) Status),
+    _write_blocks: std.meta.FnPtr(fn (*BlockIoProtocol, media_id: u32, lba: u64, buffer_size: usize, buf: [*]u8) callconv(.C) Status),
+    _flush_blocks: std.meta.FnPtr(fn (*BlockIoProtocol) callconv(.C) Status),
 
     /// Resets the block device hardware.
     pub fn reset(self: *Self, extended_verification: bool) Status {

--- a/lib/std/os/uefi/protocols/edid_override_protocol.zig
+++ b/lib/std/os/uefi/protocols/edid_override_protocol.zig
@@ -1,11 +1,12 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Handle = uefi.Handle;
 const Status = uefi.Status;
 
 /// Override EDID information
 pub const EdidOverrideProtocol = extern struct {
-    _get_edid: fn (*const EdidOverrideProtocol, Handle, *u32, *usize, *?[*]u8) callconv(.C) Status,
+    _get_edid: std.meta.FnPtr(fn (*const EdidOverrideProtocol, Handle, *u32, *usize, *?[*]u8) callconv(.C) Status),
 
     /// Returns policy information and potentially a replacement EDID for the specified video output device.
     pub fn getEdid(

--- a/lib/std/os/uefi/protocols/file_protocol.zig
+++ b/lib/std/os/uefi/protocols/file_protocol.zig
@@ -7,16 +7,16 @@ const Status = uefi.Status;
 
 pub const FileProtocol = extern struct {
     revision: u64,
-    _open: fn (*const FileProtocol, **const FileProtocol, [*:0]const u16, u64, u64) callconv(.C) Status,
-    _close: fn (*const FileProtocol) callconv(.C) Status,
-    _delete: fn (*const FileProtocol) callconv(.C) Status,
-    _read: fn (*const FileProtocol, *usize, [*]u8) callconv(.C) Status,
-    _write: fn (*const FileProtocol, *usize, [*]const u8) callconv(.C) Status,
-    _get_position: fn (*const FileProtocol, *u64) callconv(.C) Status,
-    _set_position: fn (*const FileProtocol, u64) callconv(.C) Status,
-    _get_info: fn (*const FileProtocol, *align(8) const Guid, *const usize, [*]u8) callconv(.C) Status,
-    _set_info: fn (*const FileProtocol, *align(8) const Guid, usize, [*]const u8) callconv(.C) Status,
-    _flush: fn (*const FileProtocol) callconv(.C) Status,
+    _open: std.meta.FnPtr(fn (*const FileProtocol, **const FileProtocol, [*:0]const u16, u64, u64) callconv(.C) Status),
+    _close: std.meta.FnPtr(fn (*const FileProtocol) callconv(.C) Status),
+    _delete: std.meta.FnPtr(fn (*const FileProtocol) callconv(.C) Status),
+    _read: std.meta.FnPtr(fn (*const FileProtocol, *usize, [*]u8) callconv(.C) Status),
+    _write: std.meta.FnPtr(fn (*const FileProtocol, *usize, [*]const u8) callconv(.C) Status),
+    _get_position: std.meta.FnPtr(fn (*const FileProtocol, *u64) callconv(.C) Status),
+    _set_position: std.meta.FnPtr(fn (*const FileProtocol, u64) callconv(.C) Status),
+    _get_info: std.meta.FnPtr(fn (*const FileProtocol, *align(8) const Guid, *const usize, [*]u8) callconv(.C) Status),
+    _set_info: std.meta.FnPtr(fn (*const FileProtocol, *align(8) const Guid, usize, [*]const u8) callconv(.C) Status),
+    _flush: std.meta.FnPtr(fn (*const FileProtocol) callconv(.C) Status),
 
     pub const SeekError = error{SeekError};
     pub const GetSeekPosError = error{GetSeekPosError};

--- a/lib/std/os/uefi/protocols/graphics_output_protocol.zig
+++ b/lib/std/os/uefi/protocols/graphics_output_protocol.zig
@@ -1,12 +1,13 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 
 /// Graphics output
 pub const GraphicsOutputProtocol = extern struct {
-    _query_mode: fn (*const GraphicsOutputProtocol, u32, *usize, **GraphicsOutputModeInformation) callconv(.C) Status,
-    _set_mode: fn (*const GraphicsOutputProtocol, u32) callconv(.C) Status,
-    _blt: fn (*const GraphicsOutputProtocol, ?[*]GraphicsOutputBltPixel, GraphicsOutputBltOperation, usize, usize, usize, usize, usize, usize, usize) callconv(.C) Status,
+    _query_mode: std.meta.FnPtr(fn (*const GraphicsOutputProtocol, u32, *usize, **GraphicsOutputModeInformation) callconv(.C) Status),
+    _set_mode: std.meta.FnPtr(fn (*const GraphicsOutputProtocol, u32) callconv(.C) Status),
+    _blt: std.meta.FnPtr(fn (*const GraphicsOutputProtocol, ?[*]GraphicsOutputBltPixel, GraphicsOutputBltOperation, usize, usize, usize, usize, usize, usize, usize) callconv(.C) Status),
     mode: *GraphicsOutputProtocolMode,
 
     /// Returns information for an available graphics mode that the graphics device and the set of active video output devices supports.

--- a/lib/std/os/uefi/protocols/hii_database_protocol.zig
+++ b/lib/std/os/uefi/protocols/hii_database_protocol.zig
@@ -1,4 +1,5 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 const hii = uefi.protocols.hii;
@@ -6,10 +7,10 @@ const hii = uefi.protocols.hii;
 /// Database manager for HII-related data structures.
 pub const HIIDatabaseProtocol = extern struct {
     _new_package_list: Status, // TODO
-    _remove_package_list: fn (*const HIIDatabaseProtocol, hii.HIIHandle) callconv(.C) Status,
-    _update_package_list: fn (*const HIIDatabaseProtocol, hii.HIIHandle, *const hii.HIIPackageList) callconv(.C) Status,
-    _list_package_lists: fn (*const HIIDatabaseProtocol, u8, ?*const Guid, *usize, [*]hii.HIIHandle) callconv(.C) Status,
-    _export_package_lists: fn (*const HIIDatabaseProtocol, ?hii.HIIHandle, *usize, *hii.HIIPackageList) callconv(.C) Status,
+    _remove_package_list: std.meta.FnPtr(fn (*const HIIDatabaseProtocol, hii.HIIHandle) callconv(.C) Status),
+    _update_package_list: std.meta.FnPtr(fn (*const HIIDatabaseProtocol, hii.HIIHandle, *const hii.HIIPackageList) callconv(.C) Status),
+    _list_package_lists: std.meta.FnPtr(fn (*const HIIDatabaseProtocol, u8, ?*const Guid, *usize, [*]hii.HIIHandle) callconv(.C) Status),
+    _export_package_lists: std.meta.FnPtr(fn (*const HIIDatabaseProtocol, ?hii.HIIHandle, *usize, *hii.HIIPackageList) callconv(.C) Status),
     _register_package_notify: Status, // TODO
     _unregister_package_notify: Status, // TODO
     _find_keyboard_layouts: Status, // TODO

--- a/lib/std/os/uefi/protocols/hii_popup_protocol.zig
+++ b/lib/std/os/uefi/protocols/hii_popup_protocol.zig
@@ -1,4 +1,5 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 const hii = uefi.protocols.hii;
@@ -6,7 +7,7 @@ const hii = uefi.protocols.hii;
 /// Display a popup window
 pub const HIIPopupProtocol = extern struct {
     revision: u64,
-    _create_popup: fn (*const HIIPopupProtocol, HIIPopupStyle, HIIPopupType, hii.HIIHandle, u16, ?*HIIPopupSelection) callconv(.C) Status,
+    _create_popup: std.meta.FnPtr(fn (*const HIIPopupProtocol, HIIPopupStyle, HIIPopupType, hii.HIIHandle, u16, ?*HIIPopupSelection) callconv(.C) Status),
 
     /// Displays a popup window.
     pub fn createPopup(self: *const HIIPopupProtocol, style: HIIPopupStyle, popup_type: HIIPopupType, handle: hii.HIIHandle, msg: u16, user_selection: ?*HIIPopupSelection) Status {

--- a/lib/std/os/uefi/protocols/ip6_config_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_config_protocol.zig
@@ -1,13 +1,14 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;
 const Status = uefi.Status;
 
 pub const Ip6ConfigProtocol = extern struct {
-    _set_data: fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, usize, *const anyopaque) callconv(.C) Status,
-    _get_data: fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, *usize, ?*const anyopaque) callconv(.C) Status,
-    _register_data_notify: fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) callconv(.C) Status,
-    _unregister_data_notify: fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) callconv(.C) Status,
+    _set_data: std.meta.FnPtr(fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, usize, *const anyopaque) callconv(.C) Status),
+    _get_data: std.meta.FnPtr(fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, *usize, ?*const anyopaque) callconv(.C) Status),
+    _register_data_notify: std.meta.FnPtr(fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) callconv(.C) Status),
+    _unregister_data_notify: std.meta.FnPtr(fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) callconv(.C) Status),
 
     pub fn setData(self: *const Ip6ConfigProtocol, data_type: Ip6ConfigDataType, data_size: usize, data: *const anyopaque) Status {
         return self._set_data(self, data_type, data_size, data);

--- a/lib/std/os/uefi/protocols/ip6_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_protocol.zig
@@ -1,4 +1,5 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;
 const Status = uefi.Status;
@@ -7,15 +8,15 @@ const ManagedNetworkConfigData = uefi.protocols.ManagedNetworkConfigData;
 const SimpleNetworkMode = uefi.protocols.SimpleNetworkMode;
 
 pub const Ip6Protocol = extern struct {
-    _get_mode_data: fn (*const Ip6Protocol, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(.C) Status,
-    _configure: fn (*const Ip6Protocol, ?*const Ip6ConfigData) callconv(.C) Status,
-    _groups: fn (*const Ip6Protocol, bool, ?*const Ip6Address) callconv(.C) Status,
-    _routes: fn (*const Ip6Protocol, bool, ?*const Ip6Address, u8, ?*const Ip6Address) callconv(.C) Status,
-    _neighbors: fn (*const Ip6Protocol, bool, *const Ip6Address, ?*const MacAddress, u32, bool) callconv(.C) Status,
-    _transmit: fn (*const Ip6Protocol, *Ip6CompletionToken) callconv(.C) Status,
-    _receive: fn (*const Ip6Protocol, *Ip6CompletionToken) callconv(.C) Status,
-    _cancel: fn (*const Ip6Protocol, ?*Ip6CompletionToken) callconv(.C) Status,
-    _poll: fn (*const Ip6Protocol) callconv(.C) Status,
+    _get_mode_data: std.meta.FnPtr(fn (*const Ip6Protocol, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(.C) Status),
+    _configure: std.meta.FnPtr(fn (*const Ip6Protocol, ?*const Ip6ConfigData) callconv(.C) Status),
+    _groups: std.meta.FnPtr(fn (*const Ip6Protocol, bool, ?*const Ip6Address) callconv(.C) Status),
+    _routes: std.meta.FnPtr(fn (*const Ip6Protocol, bool, ?*const Ip6Address, u8, ?*const Ip6Address) callconv(.C) Status),
+    _neighbors: std.meta.FnPtr(fn (*const Ip6Protocol, bool, *const Ip6Address, ?*const MacAddress, u32, bool) callconv(.C) Status),
+    _transmit: std.meta.FnPtr(fn (*const Ip6Protocol, *Ip6CompletionToken) callconv(.C) Status),
+    _receive: std.meta.FnPtr(fn (*const Ip6Protocol, *Ip6CompletionToken) callconv(.C) Status),
+    _cancel: std.meta.FnPtr(fn (*const Ip6Protocol, ?*Ip6CompletionToken) callconv(.C) Status),
+    _poll: std.meta.FnPtr(fn (*const Ip6Protocol) callconv(.C) Status),
 
     /// Gets the current operational settings for this instance of the EFI IPv6 Protocol driver.
     pub fn getModeData(self: *const Ip6Protocol, ip6_mode_data: ?*Ip6ModeData, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) Status {

--- a/lib/std/os/uefi/protocols/ip6_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_service_binding_protocol.zig
@@ -1,11 +1,12 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 
 pub const Ip6ServiceBindingProtocol = extern struct {
-    _create_child: fn (*const Ip6ServiceBindingProtocol, *?Handle) callconv(.C) Status,
-    _destroy_child: fn (*const Ip6ServiceBindingProtocol, Handle) callconv(.C) Status,
+    _create_child: std.meta.FnPtr(fn (*const Ip6ServiceBindingProtocol, *?Handle) callconv(.C) Status),
+    _destroy_child: std.meta.FnPtr(fn (*const Ip6ServiceBindingProtocol, Handle) callconv(.C) Status),
 
     pub fn createChild(self: *const Ip6ServiceBindingProtocol, handle: *?Handle) Status {
         return self._create_child(self, handle);

--- a/lib/std/os/uefi/protocols/loaded_image_protocol.zig
+++ b/lib/std/os/uefi/protocols/loaded_image_protocol.zig
@@ -1,4 +1,5 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Handle = uefi.Handle;
 const Status = uefi.Status;
@@ -19,7 +20,7 @@ pub const LoadedImageProtocol = extern struct {
     image_size: u64,
     image_code_type: MemoryType,
     image_data_type: MemoryType,
-    _unload: fn (*const LoadedImageProtocol, Handle) callconv(.C) Status,
+    _unload: std.meta.FnPtr(fn (*const LoadedImageProtocol, Handle) callconv(.C) Status),
 
     /// Unloads an image from memory.
     pub fn unload(self: *const LoadedImageProtocol, handle: Handle) Status {

--- a/lib/std/os/uefi/protocols/managed_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/managed_network_protocol.zig
@@ -1,4 +1,5 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;
 const Status = uefi.Status;
@@ -7,14 +8,14 @@ const SimpleNetworkMode = uefi.protocols.SimpleNetworkMode;
 const MacAddress = uefi.protocols.MacAddress;
 
 pub const ManagedNetworkProtocol = extern struct {
-    _get_mode_data: fn (*const ManagedNetworkProtocol, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(.C) Status,
-    _configure: fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkConfigData) callconv(.C) Status,
-    _mcast_ip_to_mac: fn (*const ManagedNetworkProtocol, bool, *const anyopaque, *MacAddress) callconv(.C) Status,
-    _groups: fn (*const ManagedNetworkProtocol, bool, ?*const MacAddress) callconv(.C) Status,
-    _transmit: fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) callconv(.C) Status,
-    _receive: fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) callconv(.C) Status,
-    _cancel: fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkCompletionToken) callconv(.C) Status,
-    _poll: fn (*const ManagedNetworkProtocol) callconv(.C) usize,
+    _get_mode_data: std.meta.FnPtr(fn (*const ManagedNetworkProtocol, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(.C) Status),
+    _configure: std.meta.FnPtr(fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkConfigData) callconv(.C) Status),
+    _mcast_ip_to_mac: std.meta.FnPtr(fn (*const ManagedNetworkProtocol, bool, *const anyopaque, *MacAddress) callconv(.C) Status),
+    _groups: std.meta.FnPtr(fn (*const ManagedNetworkProtocol, bool, ?*const MacAddress) callconv(.C) Status),
+    _transmit: std.meta.FnPtr(fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) callconv(.C) Status),
+    _receive: std.meta.FnPtr(fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) callconv(.C) Status),
+    _cancel: std.meta.FnPtr(fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkCompletionToken) callconv(.C) Status),
+    _poll: std.meta.FnPtr(fn (*const ManagedNetworkProtocol) callconv(.C) usize),
 
     /// Returns the operational parameters for the current MNP child driver.
     /// May also support returning the underlying SNP driver mode data.

--- a/lib/std/os/uefi/protocols/managed_network_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/managed_network_service_binding_protocol.zig
@@ -1,11 +1,12 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 
 pub const ManagedNetworkServiceBindingProtocol = extern struct {
-    _create_child: fn (*const ManagedNetworkServiceBindingProtocol, *?Handle) callconv(.C) Status,
-    _destroy_child: fn (*const ManagedNetworkServiceBindingProtocol, Handle) callconv(.C) Status,
+    _create_child: std.meta.FnPtr(fn (*const ManagedNetworkServiceBindingProtocol, *?Handle) callconv(.C) Status),
+    _destroy_child: std.meta.FnPtr(fn (*const ManagedNetworkServiceBindingProtocol, Handle) callconv(.C) Status),
 
     pub fn createChild(self: *const ManagedNetworkServiceBindingProtocol, handle: *?Handle) Status {
         return self._create_child(self, handle);

--- a/lib/std/os/uefi/protocols/rng_protocol.zig
+++ b/lib/std/os/uefi/protocols/rng_protocol.zig
@@ -1,11 +1,12 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 
 /// Random Number Generator protocol
 pub const RNGProtocol = extern struct {
-    _get_info: fn (*const RNGProtocol, *usize, [*]align(8) Guid) callconv(.C) Status,
-    _get_rng: fn (*const RNGProtocol, ?*align(8) const Guid, usize, [*]u8) callconv(.C) Status,
+    _get_info: std.meta.FnPtr(fn (*const RNGProtocol, *usize, [*]align(8) Guid) callconv(.C) Status),
+    _get_rng: std.meta.FnPtr(fn (*const RNGProtocol, ?*align(8) const Guid, usize, [*]u8) callconv(.C) Status),
 
     /// Returns information about the random number generation implementation.
     pub fn getInfo(self: *const RNGProtocol, list_size: *usize, list: [*]align(8) Guid) Status {

--- a/lib/std/os/uefi/protocols/simple_file_system_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_file_system_protocol.zig
@@ -1,11 +1,12 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const FileProtocol = uefi.protocols.FileProtocol;
 const Status = uefi.Status;
 
 pub const SimpleFileSystemProtocol = extern struct {
     revision: u64,
-    _open_volume: fn (*const SimpleFileSystemProtocol, **const FileProtocol) callconv(.C) Status,
+    _open_volume: std.meta.FnPtr(fn (*const SimpleFileSystemProtocol, **const FileProtocol) callconv(.C) Status),
 
     pub fn openVolume(self: *const SimpleFileSystemProtocol, root: **const FileProtocol) Status {
         return self._open_volume(self, root);

--- a/lib/std/os/uefi/protocols/simple_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_network_protocol.zig
@@ -1,23 +1,24 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 
 pub const SimpleNetworkProtocol = extern struct {
     revision: u64,
-    _start: fn (*const SimpleNetworkProtocol) callconv(.C) Status,
-    _stop: fn (*const SimpleNetworkProtocol) callconv(.C) Status,
-    _initialize: fn (*const SimpleNetworkProtocol, usize, usize) callconv(.C) Status,
-    _reset: fn (*const SimpleNetworkProtocol, bool) callconv(.C) Status,
-    _shutdown: fn (*const SimpleNetworkProtocol) callconv(.C) Status,
-    _receive_filters: fn (*const SimpleNetworkProtocol, SimpleNetworkReceiveFilter, SimpleNetworkReceiveFilter, bool, usize, ?[*]const MacAddress) callconv(.C) Status,
-    _station_address: fn (*const SimpleNetworkProtocol, bool, ?*const MacAddress) callconv(.C) Status,
-    _statistics: fn (*const SimpleNetworkProtocol, bool, ?*usize, ?*NetworkStatistics) callconv(.C) Status,
-    _mcast_ip_to_mac: fn (*const SimpleNetworkProtocol, bool, *const anyopaque, *MacAddress) callconv(.C) Status,
-    _nvdata: fn (*const SimpleNetworkProtocol, bool, usize, usize, [*]u8) callconv(.C) Status,
-    _get_status: fn (*const SimpleNetworkProtocol, *SimpleNetworkInterruptStatus, ?*?[*]u8) callconv(.C) Status,
-    _transmit: fn (*const SimpleNetworkProtocol, usize, usize, [*]const u8, ?*const MacAddress, ?*const MacAddress, ?*const u16) callconv(.C) Status,
-    _receive: fn (*const SimpleNetworkProtocol, ?*usize, *usize, [*]u8, ?*MacAddress, ?*MacAddress, ?*u16) callconv(.C) Status,
+    _start: std.meta.FnPtr(fn (*const SimpleNetworkProtocol) callconv(.C) Status),
+    _stop: std.meta.FnPtr(fn (*const SimpleNetworkProtocol) callconv(.C) Status),
+    _initialize: std.meta.FnPtr(fn (*const SimpleNetworkProtocol, usize, usize) callconv(.C) Status),
+    _reset: std.meta.FnPtr(fn (*const SimpleNetworkProtocol, bool) callconv(.C) Status),
+    _shutdown: std.meta.FnPtr(fn (*const SimpleNetworkProtocol) callconv(.C) Status),
+    _receive_filters: std.meta.FnPtr(fn (*const SimpleNetworkProtocol, SimpleNetworkReceiveFilter, SimpleNetworkReceiveFilter, bool, usize, ?[*]const MacAddress) callconv(.C) Status),
+    _station_address: std.meta.FnPtr(fn (*const SimpleNetworkProtocol, bool, ?*const MacAddress) callconv(.C) Status),
+    _statistics: std.meta.FnPtr(fn (*const SimpleNetworkProtocol, bool, ?*usize, ?*NetworkStatistics) callconv(.C) Status),
+    _mcast_ip_to_mac: std.meta.FnPtr(fn (*const SimpleNetworkProtocol, bool, *const anyopaque, *MacAddress) callconv(.C) Status),
+    _nvdata: std.meta.FnPtr(fn (*const SimpleNetworkProtocol, bool, usize, usize, [*]u8) callconv(.C) Status),
+    _get_status: std.meta.FnPtr(fn (*const SimpleNetworkProtocol, *SimpleNetworkInterruptStatus, ?*?[*]u8) callconv(.C) Status),
+    _transmit: std.meta.FnPtr(fn (*const SimpleNetworkProtocol, usize, usize, [*]const u8, ?*const MacAddress, ?*const MacAddress, ?*const u16) callconv(.C) Status),
+    _receive: std.meta.FnPtr(fn (*const SimpleNetworkProtocol, ?*usize, *usize, [*]u8, ?*MacAddress, ?*MacAddress, ?*u16) callconv(.C) Status),
     wait_for_packet: Event,
     mode: *SimpleNetworkMode,
 

--- a/lib/std/os/uefi/protocols/simple_pointer_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_pointer_protocol.zig
@@ -1,12 +1,13 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 
 /// Protocol for mice
 pub const SimplePointerProtocol = struct {
-    _reset: fn (*const SimplePointerProtocol, bool) callconv(.C) Status,
-    _get_state: fn (*const SimplePointerProtocol, *SimplePointerState) callconv(.C) Status,
+    _reset: std.meta.FnPtr(fn (*const SimplePointerProtocol, bool) callconv(.C) Status),
+    _get_state: std.meta.FnPtr(fn (*const SimplePointerProtocol, *SimplePointerState) callconv(.C) Status),
     wait_for_input: Event,
     mode: *SimplePointerMode,
 

--- a/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
@@ -1,16 +1,17 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 
 /// Character input devices, e.g. Keyboard
 pub const SimpleTextInputExProtocol = extern struct {
-    _reset: fn (*const SimpleTextInputExProtocol, bool) callconv(.C) Status,
-    _read_key_stroke_ex: fn (*const SimpleTextInputExProtocol, *KeyData) callconv(.C) Status,
+    _reset: std.meta.FnPtr(fn (*const SimpleTextInputExProtocol, bool) callconv(.C) Status),
+    _read_key_stroke_ex: std.meta.FnPtr(fn (*const SimpleTextInputExProtocol, *KeyData) callconv(.C) Status),
     wait_for_key_ex: Event,
-    _set_state: fn (*const SimpleTextInputExProtocol, *const u8) callconv(.C) Status,
-    _register_key_notify: fn (*const SimpleTextInputExProtocol, *const KeyData, fn (*const KeyData) callconv(.C) usize, **anyopaque) callconv(.C) Status,
-    _unregister_key_notify: fn (*const SimpleTextInputExProtocol, *const anyopaque) callconv(.C) Status,
+    _set_state: std.meta.FnPtr(fn (*const SimpleTextInputExProtocol, *const u8) callconv(.C) Status),
+    _register_key_notify: std.meta.FnPtr(fn (*const SimpleTextInputExProtocol, *const KeyData, fn (*const KeyData) callconv(.C) usize, **anyopaque) callconv(.C) Status),
+    _unregister_key_notify: std.meta.FnPtr(fn (*const SimpleTextInputExProtocol, *const anyopaque) callconv(.C) Status),
 
     /// Resets the input device hardware.
     pub fn reset(self: *const SimpleTextInputExProtocol, verify: bool) Status {

--- a/lib/std/os/uefi/protocols/simple_text_input_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_input_protocol.zig
@@ -1,4 +1,5 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const InputKey = uefi.protocols.InputKey;
@@ -6,8 +7,8 @@ const Status = uefi.Status;
 
 /// Character input devices, e.g. Keyboard
 pub const SimpleTextInputProtocol = extern struct {
-    _reset: fn (*const SimpleTextInputProtocol, bool) callconv(.C) Status,
-    _read_key_stroke: fn (*const SimpleTextInputProtocol, *InputKey) callconv(.C) Status,
+    _reset: std.meta.FnPtr(fn (*const SimpleTextInputProtocol, bool) callconv(.C) Status),
+    _read_key_stroke: std.meta.FnPtr(fn (*const SimpleTextInputProtocol, *InputKey) callconv(.C) Status),
     wait_for_key: Event,
 
     /// Resets the input device hardware.

--- a/lib/std/os/uefi/protocols/simple_text_output_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_output_protocol.zig
@@ -1,18 +1,19 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 
 /// Character output devices
 pub const SimpleTextOutputProtocol = extern struct {
-    _reset: fn (*const SimpleTextOutputProtocol, bool) callconv(.C) Status,
-    _output_string: fn (*const SimpleTextOutputProtocol, [*:0]const u16) callconv(.C) Status,
-    _test_string: fn (*const SimpleTextOutputProtocol, [*:0]const u16) callconv(.C) Status,
-    _query_mode: fn (*const SimpleTextOutputProtocol, usize, *usize, *usize) callconv(.C) Status,
-    _set_mode: fn (*const SimpleTextOutputProtocol, usize) callconv(.C) Status,
-    _set_attribute: fn (*const SimpleTextOutputProtocol, usize) callconv(.C) Status,
-    _clear_screen: fn (*const SimpleTextOutputProtocol) callconv(.C) Status,
-    _set_cursor_position: fn (*const SimpleTextOutputProtocol, usize, usize) callconv(.C) Status,
-    _enable_cursor: fn (*const SimpleTextOutputProtocol, bool) callconv(.C) Status,
+    _reset: std.meta.FnPtr(fn (*const SimpleTextOutputProtocol, bool) callconv(.C) Status),
+    _output_string: std.meta.FnPtr(fn (*const SimpleTextOutputProtocol, [*:0]const u16) callconv(.C) Status),
+    _test_string: std.meta.FnPtr(fn (*const SimpleTextOutputProtocol, [*:0]const u16) callconv(.C) Status),
+    _query_mode: std.meta.FnPtr(fn (*const SimpleTextOutputProtocol, usize, *usize, *usize) callconv(.C) Status),
+    _set_mode: std.meta.FnPtr(fn (*const SimpleTextOutputProtocol, usize) callconv(.C) Status),
+    _set_attribute: std.meta.FnPtr(fn (*const SimpleTextOutputProtocol, usize) callconv(.C) Status),
+    _clear_screen: std.meta.FnPtr(fn (*const SimpleTextOutputProtocol) callconv(.C) Status),
+    _set_cursor_position: std.meta.FnPtr(fn (*const SimpleTextOutputProtocol, usize, usize) callconv(.C) Status),
+    _enable_cursor: std.meta.FnPtr(fn (*const SimpleTextOutputProtocol, bool) callconv(.C) Status),
     mode: *SimpleTextOutputMode,
 
     /// Resets the text output device hardware.

--- a/lib/std/os/uefi/protocols/udp6_protocol.zig
+++ b/lib/std/os/uefi/protocols/udp6_protocol.zig
@@ -1,4 +1,5 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;
 const Status = uefi.Status;
@@ -9,13 +10,13 @@ const ManagedNetworkConfigData = uefi.protocols.ManagedNetworkConfigData;
 const SimpleNetworkMode = uefi.protocols.SimpleNetworkMode;
 
 pub const Udp6Protocol = extern struct {
-    _get_mode_data: fn (*const Udp6Protocol, ?*Udp6ConfigData, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(.C) Status,
-    _configure: fn (*const Udp6Protocol, ?*const Udp6ConfigData) callconv(.C) Status,
-    _groups: fn (*const Udp6Protocol, bool, ?*const Ip6Address) callconv(.C) Status,
-    _transmit: fn (*const Udp6Protocol, *Udp6CompletionToken) callconv(.C) Status,
-    _receive: fn (*const Udp6Protocol, *Udp6CompletionToken) callconv(.C) Status,
-    _cancel: fn (*const Udp6Protocol, ?*Udp6CompletionToken) callconv(.C) Status,
-    _poll: fn (*const Udp6Protocol) callconv(.C) Status,
+    _get_mode_data: std.meta.FnPtr(fn (*const Udp6Protocol, ?*Udp6ConfigData, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(.C) Status),
+    _configure: std.meta.FnPtr(fn (*const Udp6Protocol, ?*const Udp6ConfigData) callconv(.C) Status),
+    _groups: std.meta.FnPtr(fn (*const Udp6Protocol, bool, ?*const Ip6Address) callconv(.C) Status),
+    _transmit: std.meta.FnPtr(fn (*const Udp6Protocol, *Udp6CompletionToken) callconv(.C) Status),
+    _receive: std.meta.FnPtr(fn (*const Udp6Protocol, *Udp6CompletionToken) callconv(.C) Status),
+    _cancel: std.meta.FnPtr(fn (*const Udp6Protocol, ?*Udp6CompletionToken) callconv(.C) Status),
+    _poll: std.meta.FnPtr(fn (*const Udp6Protocol) callconv(.C) Status),
 
     pub fn getModeData(self: *const Udp6Protocol, udp6_config_data: ?*Udp6ConfigData, ip6_mode_data: ?*Ip6ModeData, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) Status {
         return self._get_mode_data(self, udp6_config_data, ip6_mode_data, mnp_config_data, snp_mode_data);

--- a/lib/std/os/uefi/protocols/udp6_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/udp6_service_binding_protocol.zig
@@ -1,11 +1,12 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 
 pub const Udp6ServiceBindingProtocol = extern struct {
-    _create_child: fn (*const Udp6ServiceBindingProtocol, *?Handle) callconv(.C) Status,
-    _destroy_child: fn (*const Udp6ServiceBindingProtocol, Handle) callconv(.C) Status,
+    _create_child: std.meta.FnPtr(fn (*const Udp6ServiceBindingProtocol, *?Handle) callconv(.C) Status),
+    _destroy_child: std.meta.FnPtr(fn (*const Udp6ServiceBindingProtocol, Handle) callconv(.C) Status),
 
     pub fn createChild(self: *const Udp6ServiceBindingProtocol, handle: *?Handle) Status {
         return self._create_child(self, handle);

--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -1,4 +1,5 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const Handle = uefi.Handle;
@@ -21,138 +22,138 @@ pub const BootServices = extern struct {
     hdr: TableHeader,
 
     /// Raises a task's priority level and returns its previous level.
-    raiseTpl: fn (new_tpl: usize) callconv(.C) usize,
+    raiseTpl: std.meta.FnPtr(fn (new_tpl: usize) callconv(.C) usize),
 
     /// Restores a task's priority level to its previous value.
-    restoreTpl: fn (old_tpl: usize) callconv(.C) void,
+    restoreTpl: std.meta.FnPtr(fn (old_tpl: usize) callconv(.C) void),
 
     /// Allocates memory pages from the system.
-    allocatePages: fn (alloc_type: AllocateType, mem_type: MemoryType, pages: usize, memory: *[*]align(4096) u8) callconv(.C) Status,
+    allocatePages: std.meta.FnPtr(fn (alloc_type: AllocateType, mem_type: MemoryType, pages: usize, memory: *[*]align(4096) u8) callconv(.C) Status),
 
     /// Frees memory pages.
-    freePages: fn (memory: [*]align(4096) u8, pages: usize) callconv(.C) Status,
+    freePages: std.meta.FnPtr(fn (memory: [*]align(4096) u8, pages: usize) callconv(.C) Status),
 
     /// Returns the current memory map.
-    getMemoryMap: fn (mmap_size: *usize, mmap: [*]MemoryDescriptor, mapKey: *usize, descriptor_size: *usize, descriptor_version: *u32) callconv(.C) Status,
+    getMemoryMap: std.meta.FnPtr(fn (mmap_size: *usize, mmap: [*]MemoryDescriptor, mapKey: *usize, descriptor_size: *usize, descriptor_version: *u32) callconv(.C) Status),
 
     /// Allocates pool memory.
-    allocatePool: fn (pool_type: MemoryType, size: usize, buffer: *[*]align(8) u8) callconv(.C) Status,
+    allocatePool: std.meta.FnPtr(fn (pool_type: MemoryType, size: usize, buffer: *[*]align(8) u8) callconv(.C) Status),
 
     /// Returns pool memory to the system.
-    freePool: fn (buffer: [*]align(8) u8) callconv(.C) Status,
+    freePool: std.meta.FnPtr(fn (buffer: [*]align(8) u8) callconv(.C) Status),
 
     /// Creates an event.
-    createEvent: fn (type: u32, notify_tpl: usize, notify_func: ?fn (Event, ?*anyopaque) callconv(.C) void, notifyCtx: ?*const anyopaque, event: *Event) callconv(.C) Status,
+    createEvent: std.meta.FnPtr(fn (type: u32, notify_tpl: usize, notify_func: ?std.meta.FnPtr(fn (Event, ?*anyopaque) callconv(.C) void), notifyCtx: ?*const anyopaque, event: *Event) callconv(.C) Status),
 
     /// Sets the type of timer and the trigger time for a timer event.
-    setTimer: fn (event: Event, type: TimerDelay, triggerTime: u64) callconv(.C) Status,
+    setTimer: std.meta.FnPtr(fn (event: Event, type: TimerDelay, triggerTime: u64) callconv(.C) Status),
 
     /// Stops execution until an event is signaled.
-    waitForEvent: fn (event_len: usize, events: [*]const Event, index: *usize) callconv(.C) Status,
+    waitForEvent: std.meta.FnPtr(fn (event_len: usize, events: [*]const Event, index: *usize) callconv(.C) Status),
 
     /// Signals an event.
-    signalEvent: fn (event: Event) callconv(.C) Status,
+    signalEvent: std.meta.FnPtr(fn (event: Event) callconv(.C) Status),
 
     /// Closes an event.
-    closeEvent: fn (event: Event) callconv(.C) Status,
+    closeEvent: std.meta.FnPtr(fn (event: Event) callconv(.C) Status),
 
     /// Checks whether an event is in the signaled state.
-    checkEvent: fn (event: Event) callconv(.C) Status,
+    checkEvent: std.meta.FnPtr(fn (event: Event) callconv(.C) Status),
 
     /// Installs a protocol interface on a device handle. If the handle does not exist, it is created
     /// and added to the list of handles in the system. installMultipleProtocolInterfaces()
     /// performs more error checking than installProtocolInterface(), so its use is recommended over this.
-    installProtocolInterface: fn (handle: Handle, protocol: *align(8) const Guid, interface_type: EfiInterfaceType, interface: *anyopaque) callconv(.C) Status,
+    installProtocolInterface: std.meta.FnPtr(fn (handle: Handle, protocol: *align(8) const Guid, interface_type: EfiInterfaceType, interface: *anyopaque) callconv(.C) Status),
 
     /// Reinstalls a protocol interface on a device handle
-    reinstallProtocolInterface: fn (handle: Handle, protocol: *align(8) const Guid, old_interface: *anyopaque, new_interface: *anyopaque) callconv(.C) Status,
+    reinstallProtocolInterface: std.meta.FnPtr(fn (handle: Handle, protocol: *align(8) const Guid, old_interface: *anyopaque, new_interface: *anyopaque) callconv(.C) Status),
 
     /// Removes a protocol interface from a device handle. Usage of
     /// uninstallMultipleProtocolInterfaces is recommended over this.
-    uninstallProtocolInterface: fn (handle: Handle, protocol: *align(8) const Guid, interface: *anyopaque) callconv(.C) Status,
+    uninstallProtocolInterface: std.meta.FnPtr(fn (handle: Handle, protocol: *align(8) const Guid, interface: *anyopaque) callconv(.C) Status),
 
     /// Queries a handle to determine if it supports a specified protocol.
-    handleProtocol: fn (handle: Handle, protocol: *align(8) const Guid, interface: *?*anyopaque) callconv(.C) Status,
+    handleProtocol: std.meta.FnPtr(fn (handle: Handle, protocol: *align(8) const Guid, interface: *?*anyopaque) callconv(.C) Status),
 
     reserved: *anyopaque,
 
     /// Creates an event that is to be signaled whenever an interface is installed for a specified protocol.
-    registerProtocolNotify: fn (protocol: *align(8) const Guid, event: Event, registration: **anyopaque) callconv(.C) Status,
+    registerProtocolNotify: std.meta.FnPtr(fn (protocol: *align(8) const Guid, event: Event, registration: **anyopaque) callconv(.C) Status),
 
     /// Returns an array of handles that support a specified protocol.
-    locateHandle: fn (search_type: LocateSearchType, protocol: ?*align(8) const Guid, search_key: ?*const anyopaque, bufferSize: *usize, buffer: [*]Handle) callconv(.C) Status,
+    locateHandle: std.meta.FnPtr(fn (search_type: LocateSearchType, protocol: ?*align(8) const Guid, search_key: ?*const anyopaque, bufferSize: *usize, buffer: [*]Handle) callconv(.C) Status),
 
     /// Locates the handle to a device on the device path that supports the specified protocol
-    locateDevicePath: fn (protocols: *align(8) const Guid, device_path: **const DevicePathProtocol, device: *?Handle) callconv(.C) Status,
+    locateDevicePath: std.meta.FnPtr(fn (protocols: *align(8) const Guid, device_path: **const DevicePathProtocol, device: *?Handle) callconv(.C) Status),
 
     /// Adds, updates, or removes a configuration table entry from the EFI System Table.
-    installConfigurationTable: fn (guid: *align(8) const Guid, table: ?*anyopaque) callconv(.C) Status,
+    installConfigurationTable: std.meta.FnPtr(fn (guid: *align(8) const Guid, table: ?*anyopaque) callconv(.C) Status),
 
     /// Loads an EFI image into memory.
-    loadImage: fn (boot_policy: bool, parent_image_handle: Handle, device_path: ?*const DevicePathProtocol, source_buffer: ?[*]const u8, source_size: usize, imageHandle: *?Handle) callconv(.C) Status,
+    loadImage: std.meta.FnPtr(fn (boot_policy: bool, parent_image_handle: Handle, device_path: ?*const DevicePathProtocol, source_buffer: ?[*]const u8, source_size: usize, imageHandle: *?Handle) callconv(.C) Status),
 
     /// Transfers control to a loaded image's entry point.
-    startImage: fn (image_handle: Handle, exit_data_size: ?*usize, exit_data: ?*[*]u16) callconv(.C) Status,
+    startImage: std.meta.FnPtr(fn (image_handle: Handle, exit_data_size: ?*usize, exit_data: ?*[*]u16) callconv(.C) Status),
 
     /// Terminates a loaded EFI image and returns control to boot services.
-    exit: fn (image_handle: Handle, exit_status: Status, exit_data_size: usize, exit_data: ?*const anyopaque) callconv(.C) Status,
+    exit: std.meta.FnPtr(fn (image_handle: Handle, exit_status: Status, exit_data_size: usize, exit_data: ?*const anyopaque) callconv(.C) Status),
 
     /// Unloads an image.
-    unloadImage: fn (image_handle: Handle) callconv(.C) Status,
+    unloadImage: std.meta.FnPtr(fn (image_handle: Handle) callconv(.C) Status),
 
     /// Terminates all boot services.
-    exitBootServices: fn (image_handle: Handle, map_key: usize) callconv(.C) Status,
+    exitBootServices: std.meta.FnPtr(fn (image_handle: Handle, map_key: usize) callconv(.C) Status),
 
     /// Returns a monotonically increasing count for the platform.
-    getNextMonotonicCount: fn (count: *u64) callconv(.C) Status,
+    getNextMonotonicCount: std.meta.FnPtr(fn (count: *u64) callconv(.C) Status),
 
     /// Induces a fine-grained stall.
-    stall: fn (microseconds: usize) callconv(.C) Status,
+    stall: std.meta.FnPtr(fn (microseconds: usize) callconv(.C) Status),
 
     /// Sets the system's watchdog timer.
-    setWatchdogTimer: fn (timeout: usize, watchdogCode: u64, data_size: usize, watchdog_data: ?[*]const u16) callconv(.C) Status,
+    setWatchdogTimer: std.meta.FnPtr(fn (timeout: usize, watchdogCode: u64, data_size: usize, watchdog_data: ?[*]const u16) callconv(.C) Status),
 
     /// Connects one or more drives to a controller.
-    connectController: fn (controller_handle: Handle, driver_image_handle: ?Handle, remaining_device_path: ?*DevicePathProtocol, recursive: bool) callconv(.C) Status,
+    connectController: std.meta.FnPtr(fn (controller_handle: Handle, driver_image_handle: ?Handle, remaining_device_path: ?*DevicePathProtocol, recursive: bool) callconv(.C) Status),
 
     // Disconnects one or more drivers from a controller
-    disconnectController: fn (controller_handle: Handle, driver_image_handle: ?Handle, child_handle: ?Handle) callconv(.C) Status,
+    disconnectController: std.meta.FnPtr(fn (controller_handle: Handle, driver_image_handle: ?Handle, child_handle: ?Handle) callconv(.C) Status),
 
     /// Queries a handle to determine if it supports a specified protocol.
-    openProtocol: fn (handle: Handle, protocol: *align(8) const Guid, interface: *?*anyopaque, agent_handle: ?Handle, controller_handle: ?Handle, attributes: OpenProtocolAttributes) callconv(.C) Status,
+    openProtocol: std.meta.FnPtr(fn (handle: Handle, protocol: *align(8) const Guid, interface: *?*anyopaque, agent_handle: ?Handle, controller_handle: ?Handle, attributes: OpenProtocolAttributes) callconv(.C) Status),
 
     /// Closes a protocol on a handle that was opened using openProtocol().
-    closeProtocol: fn (handle: Handle, protocol: *align(8) const Guid, agentHandle: Handle, controller_handle: ?Handle) callconv(.C) Status,
+    closeProtocol: std.meta.FnPtr(fn (handle: Handle, protocol: *align(8) const Guid, agentHandle: Handle, controller_handle: ?Handle) callconv(.C) Status),
 
     /// Retrieves the list of agents that currently have a protocol interface opened.
-    openProtocolInformation: fn (handle: Handle, protocol: *align(8) const Guid, entry_buffer: *[*]ProtocolInformationEntry, entry_count: *usize) callconv(.C) Status,
+    openProtocolInformation: std.meta.FnPtr(fn (handle: Handle, protocol: *align(8) const Guid, entry_buffer: *[*]ProtocolInformationEntry, entry_count: *usize) callconv(.C) Status),
 
     /// Retrieves the list of protocol interface GUIDs that are installed on a handle in a buffer allocated from pool.
-    protocolsPerHandle: fn (handle: Handle, protocol_buffer: *[*]*align(8) const Guid, protocol_buffer_count: *usize) callconv(.C) Status,
+    protocolsPerHandle: std.meta.FnPtr(fn (handle: Handle, protocol_buffer: *[*]*align(8) const Guid, protocol_buffer_count: *usize) callconv(.C) Status),
 
     /// Returns an array of handles that support the requested protocol in a buffer allocated from pool.
-    locateHandleBuffer: fn (search_type: LocateSearchType, protocol: ?*align(8) const Guid, search_key: ?*const anyopaque, num_handles: *usize, buffer: *[*]Handle) callconv(.C) Status,
+    locateHandleBuffer: std.meta.FnPtr(fn (search_type: LocateSearchType, protocol: ?*align(8) const Guid, search_key: ?*const anyopaque, num_handles: *usize, buffer: *[*]Handle) callconv(.C) Status),
 
     /// Returns the first protocol instance that matches the given protocol.
-    locateProtocol: fn (protocol: *align(8) const Guid, registration: ?*const anyopaque, interface: *?*anyopaque) callconv(.C) Status,
+    locateProtocol: std.meta.FnPtr(fn (protocol: *align(8) const Guid, registration: ?*const anyopaque, interface: *?*anyopaque) callconv(.C) Status),
 
     /// Installs one or more protocol interfaces into the boot services environment
-    installMultipleProtocolInterfaces: fn (handle: *Handle, ...) callconv(.C) Status,
+    installMultipleProtocolInterfaces: std.meta.FnPtr(fn (handle: *Handle, ...) callconv(.C) Status),
 
     /// Removes one or more protocol interfaces into the boot services environment
-    uninstallMultipleProtocolInterfaces: fn (handle: *Handle, ...) callconv(.C) Status,
+    uninstallMultipleProtocolInterfaces: std.meta.FnPtr(fn (handle: *Handle, ...) callconv(.C) Status),
 
     /// Computes and returns a 32-bit CRC for a data buffer.
-    calculateCrc32: fn (data: [*]const u8, data_size: usize, *u32) callconv(.C) Status,
+    calculateCrc32: std.meta.FnPtr(fn (data: [*]const u8, data_size: usize, *u32) callconv(.C) Status),
 
     /// Copies the contents of one buffer to another buffer
-    copyMem: fn (dest: [*]u8, src: [*]const u8, len: usize) callconv(.C) void,
+    copyMem: std.meta.FnPtr(fn (dest: [*]u8, src: [*]const u8, len: usize) callconv(.C) void),
 
     /// Fills a buffer with a specified value
-    setMem: fn (buffer: [*]u8, size: usize, value: u8) callconv(.C) void,
+    setMem: std.meta.FnPtr(fn (buffer: [*]u8, size: usize, value: u8) callconv(.C) void),
 
     /// Creates an event in a group.
-    createEventEx: fn (type: u32, notify_tpl: usize, notify_func: EfiEventNotify, notify_ctx: *const anyopaque, event_group: *align(8) const Guid, event: *Event) callconv(.C) Status,
+    createEventEx: std.meta.FnPtr(fn (type: u32, notify_tpl: usize, notify_func: EfiEventNotify, notify_ctx: *const anyopaque, event_group: *align(8) const Guid, event: *Event) callconv(.C) Status),
 
     /// Opens a protocol with a structure as the loaded image for a UEFI application
     pub fn openProtocolSt(self: *BootServices, comptime protocol: type, handle: Handle) !*protocol {

--- a/lib/std/os/uefi/tables/runtime_services.zig
+++ b/lib/std/os/uefi/tables/runtime_services.zig
@@ -1,4 +1,5 @@
-const uefi = @import("std").os.uefi;
+const std = @import("std");
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const TableHeader = uefi.tables.TableHeader;
 const Time = uefi.Time;
@@ -18,50 +19,50 @@ pub const RuntimeServices = extern struct {
     hdr: TableHeader,
 
     /// Returns the current time and date information, and the time-keeping capabilities of the hardware platform.
-    getTime: fn (time: *uefi.Time, capabilities: ?*TimeCapabilities) callconv(.C) Status,
+    getTime: std.meta.FnPtr(fn (time: *uefi.Time, capabilities: ?*TimeCapabilities) callconv(.C) Status),
 
     /// Sets the current local time and date information
-    setTime: fn (time: *uefi.Time) callconv(.C) Status,
+    setTime: std.meta.FnPtr(fn (time: *uefi.Time) callconv(.C) Status),
 
     /// Returns the current wakeup alarm clock setting
-    getWakeupTime: fn (enabled: *bool, pending: *bool, time: *uefi.Time) callconv(.C) Status,
+    getWakeupTime: std.meta.FnPtr(fn (enabled: *bool, pending: *bool, time: *uefi.Time) callconv(.C) Status),
 
     /// Sets the system wakeup alarm clock time
-    setWakeupTime: fn (enable: *bool, time: ?*uefi.Time) callconv(.C) Status,
+    setWakeupTime: std.meta.FnPtr(fn (enable: *bool, time: ?*uefi.Time) callconv(.C) Status),
 
     /// Changes the runtime addressing mode of EFI firmware from physical to virtual.
-    setVirtualAddressMap: fn (mmap_size: usize, descriptor_size: usize, descriptor_version: u32, virtual_map: [*]MemoryDescriptor) callconv(.C) Status,
+    setVirtualAddressMap: std.meta.FnPtr(fn (mmap_size: usize, descriptor_size: usize, descriptor_version: u32, virtual_map: [*]MemoryDescriptor) callconv(.C) Status),
 
     /// Determines the new virtual address that is to be used on subsequent memory accesses.
-    convertPointer: fn (debug_disposition: usize, address: **anyopaque) callconv(.C) Status,
+    convertPointer: std.meta.FnPtr(fn (debug_disposition: usize, address: **anyopaque) callconv(.C) Status),
 
     /// Returns the value of a variable.
-    getVariable: fn (var_name: [*:0]const u16, vendor_guid: *align(8) const Guid, attributes: ?*u32, data_size: *usize, data: ?*anyopaque) callconv(.C) Status,
+    getVariable: std.meta.FnPtr(fn (var_name: [*:0]const u16, vendor_guid: *align(8) const Guid, attributes: ?*u32, data_size: *usize, data: ?*anyopaque) callconv(.C) Status),
 
     /// Enumerates the current variable names.
-    getNextVariableName: fn (var_name_size: *usize, var_name: [*:0]u16, vendor_guid: *align(8) Guid) callconv(.C) Status,
+    getNextVariableName: std.meta.FnPtr(fn (var_name_size: *usize, var_name: [*:0]u16, vendor_guid: *align(8) Guid) callconv(.C) Status),
 
     /// Sets the value of a variable.
-    setVariable: fn (var_name: [*:0]const u16, vendor_guid: *align(8) const Guid, attributes: u32, data_size: usize, data: *anyopaque) callconv(.C) Status,
+    setVariable: std.meta.FnPtr(fn (var_name: [*:0]const u16, vendor_guid: *align(8) const Guid, attributes: u32, data_size: usize, data: *anyopaque) callconv(.C) Status),
 
     /// Return the next high 32 bits of the platform's monotonic counter
-    getNextHighMonotonicCount: fn (high_count: *u32) callconv(.C) Status,
+    getNextHighMonotonicCount: std.meta.FnPtr(fn (high_count: *u32) callconv(.C) Status),
 
     /// Resets the entire platform.
-    resetSystem: fn (reset_type: ResetType, reset_status: Status, data_size: usize, reset_data: ?*const anyopaque) callconv(.C) noreturn,
+    resetSystem: std.meta.FnPtr(fn (reset_type: ResetType, reset_status: Status, data_size: usize, reset_data: ?*const anyopaque) callconv(.C) noreturn),
 
     /// Passes capsules to the firmware with both virtual and physical mapping.
     /// Depending on the intended consumption, the firmware may process the capsule immediately.
     /// If the payload should persist across a system reset, the reset value returned from
     /// `queryCapsuleCapabilities` must be passed into resetSystem and will cause the capsule
     /// to be processed by the firmware as part of the reset process.
-    updateCapsule: fn (capsule_header_array: **CapsuleHeader, capsule_count: usize, scatter_gather_list: EfiPhysicalAddress) callconv(.C) Status,
+    updateCapsule: std.meta.FnPtr(fn (capsule_header_array: **CapsuleHeader, capsule_count: usize, scatter_gather_list: EfiPhysicalAddress) callconv(.C) Status),
 
     /// Returns if the capsule can be supported via `updateCapsule`
-    queryCapsuleCapabilities: fn (capsule_header_array: **CapsuleHeader, capsule_count: usize, maximum_capsule_size: *usize, resetType: ResetType) callconv(.C) Status,
+    queryCapsuleCapabilities: std.meta.FnPtr(fn (capsule_header_array: **CapsuleHeader, capsule_count: usize, maximum_capsule_size: *usize, resetType: ResetType) callconv(.C) Status),
 
     /// Returns information about the EFI variables
-    queryVariableInfo: fn (attributes: *u32, maximum_variable_storage_size: *u64, remaining_variable_storage_size: *u64, maximum_variable_size: *u64) callconv(.C) Status,
+    queryVariableInfo: std.meta.FnPtr(fn (attributes: *u32, maximum_variable_storage_size: *u64, remaining_variable_storage_size: *u64, maximum_variable_size: *u64) callconv(.C) Status),
 
     pub const signature: u64 = 0x56524553544e5552;
 };

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2689,10 +2689,7 @@ pub const MEM_RESERVE_PLACEHOLDERS = 0x2;
 pub const MEM_DECOMMIT = 0x4000;
 pub const MEM_RELEASE = 0x8000;
 
-pub const PTHREAD_START_ROUTINE = switch (builtin.zig_backend) {
-    .stage1 => fn (LPVOID) callconv(.C) DWORD,
-    else => *const fn (LPVOID) callconv(.C) DWORD,
-};
+pub const PTHREAD_START_ROUTINE = std.meta.FnPtr(fn (LPVOID) callconv(.C) DWORD);
 pub const LPTHREAD_START_ROUTINE = PTHREAD_START_ROUTINE;
 
 pub const WIN32_FIND_DATAW = extern struct {
@@ -2865,10 +2862,7 @@ pub const IMAGE_TLS_DIRECTORY = extern struct {
 pub const IMAGE_TLS_DIRECTORY64 = IMAGE_TLS_DIRECTORY;
 pub const IMAGE_TLS_DIRECTORY32 = IMAGE_TLS_DIRECTORY;
 
-pub const PIMAGE_TLS_CALLBACK = switch (builtin.zig_backend) {
-    .stage1 => ?fn (PVOID, DWORD, PVOID) callconv(.C) void,
-    else => ?*const fn (PVOID, DWORD, PVOID) callconv(.C) void,
-};
+pub const PIMAGE_TLS_CALLBACK = ?std.meta.FnPtr(fn (PVOID, DWORD, PVOID) callconv(.C) void);
 
 pub const PROV_RSA_FULL = 1;
 
@@ -2894,10 +2888,7 @@ pub const FILE_ACTION_MODIFIED = 0x00000003;
 pub const FILE_ACTION_RENAMED_OLD_NAME = 0x00000004;
 pub const FILE_ACTION_RENAMED_NEW_NAME = 0x00000005;
 
-pub const LPOVERLAPPED_COMPLETION_ROUTINE = switch (builtin.zig_backend) {
-    .stage1 => ?fn (DWORD, DWORD, *OVERLAPPED) callconv(.C) void,
-    else => ?*const fn (DWORD, DWORD, *OVERLAPPED) callconv(.C) void,
-};
+pub const LPOVERLAPPED_COMPLETION_ROUTINE = ?std.meta.FnPtr(fn (DWORD, DWORD, *OVERLAPPED) callconv(.C) void);
 
 pub const FILE_NOTIFY_CHANGE_CREATION = 64;
 pub const FILE_NOTIFY_CHANGE_SIZE = 8;
@@ -2950,10 +2941,7 @@ pub const RTL_CRITICAL_SECTION = extern struct {
 pub const CRITICAL_SECTION = RTL_CRITICAL_SECTION;
 pub const INIT_ONCE = RTL_RUN_ONCE;
 pub const INIT_ONCE_STATIC_INIT = RTL_RUN_ONCE_INIT;
-pub const INIT_ONCE_FN = switch (builtin.zig_backend) {
-    .stage1 => fn (InitOnce: *INIT_ONCE, Parameter: ?*anyopaque, Context: ?*anyopaque) callconv(.C) BOOL,
-    else => *const fn (InitOnce: *INIT_ONCE, Parameter: ?*anyopaque, Context: ?*anyopaque) callconv(.C) BOOL,
-};
+pub const INIT_ONCE_FN = std.meta.FnPtr(fn (InitOnce: *INIT_ONCE, Parameter: ?*anyopaque, Context: ?*anyopaque) callconv(.C) BOOL);
 
 pub const RTL_RUN_ONCE = extern struct {
     Ptr: ?*anyopaque,
@@ -3238,10 +3226,7 @@ pub const EXCEPTION_POINTERS = extern struct {
     ContextRecord: *std.os.windows.CONTEXT,
 };
 
-pub const VECTORED_EXCEPTION_HANDLER = switch (builtin.zig_backend) {
-    .stage1 => fn (ExceptionInfo: *EXCEPTION_POINTERS) callconv(WINAPI) c_long,
-    else => *const fn (ExceptionInfo: *EXCEPTION_POINTERS) callconv(WINAPI) c_long,
-};
+pub const VECTORED_EXCEPTION_HANDLER = std.meta.FnPtr(fn (ExceptionInfo: *EXCEPTION_POINTERS) callconv(WINAPI) c_long);
 
 pub const OBJECT_ATTRIBUTES = extern struct {
     Length: ULONG,
@@ -3517,10 +3502,7 @@ pub const RTL_DRIVE_LETTER_CURDIR = extern struct {
     DosPath: UNICODE_STRING,
 };
 
-pub const PPS_POST_PROCESS_INIT_ROUTINE = switch (builtin.zig_backend) {
-    .stage1 => ?fn () callconv(.C) void,
-    else => ?*const fn () callconv(.C) void,
-};
+pub const PPS_POST_PROCESS_INIT_ROUTINE = ?std.meta.FnPtr(fn () callconv(.C) void);
 
 pub const FILE_BOTH_DIR_INFORMATION = extern struct {
     NextEntryOffset: ULONG,
@@ -3540,10 +3522,7 @@ pub const FILE_BOTH_DIR_INFORMATION = extern struct {
 };
 pub const FILE_BOTH_DIRECTORY_INFORMATION = FILE_BOTH_DIR_INFORMATION;
 
-pub const IO_APC_ROUTINE = switch (builtin.zig_backend) {
-    .stage1 => fn (PVOID, *IO_STATUS_BLOCK, ULONG) callconv(.C) void,
-    else => *const fn (PVOID, *IO_STATUS_BLOCK, ULONG) callconv(.C) void,
-};
+pub const IO_APC_ROUTINE = std.meta.FnPtr(fn (PVOID, *IO_STATUS_BLOCK, ULONG) callconv(.C) void);
 
 pub const CURDIR = extern struct {
     DosPath: UNICODE_STRING,
@@ -3615,14 +3594,8 @@ pub const ENUM_PAGE_FILE_INFORMATION = extern struct {
     PeakUsage: SIZE_T,
 };
 
-pub const PENUM_PAGE_FILE_CALLBACKW = switch (builtin.zig_backend) {
-    .stage1 => ?fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCWSTR) callconv(.C) BOOL,
-    else => ?*const fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCWSTR) callconv(.C) BOOL,
-};
-pub const PENUM_PAGE_FILE_CALLBACKA = switch (builtin.zig_backend) {
-    .stage1 => ?fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCSTR) callconv(.C) BOOL,
-    else => ?*const fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCSTR) callconv(.C) BOOL,
-};
+pub const PENUM_PAGE_FILE_CALLBACKW = ?std.meta.FnPtr(fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCWSTR) callconv(.C) BOOL);
+pub const PENUM_PAGE_FILE_CALLBACKA = ?std.meta.FnPtr(fn (?LPVOID, *ENUM_PAGE_FILE_INFORMATION, LPCSTR) callconv(.C) BOOL);
 
 pub const PSAPI_WS_WATCH_INFORMATION_EX = extern struct {
     BasicInfo: PSAPI_WS_WATCH_INFORMATION,
@@ -3722,7 +3695,4 @@ pub const CTRL_CLOSE_EVENT: DWORD = 2;
 pub const CTRL_LOGOFF_EVENT: DWORD = 5;
 pub const CTRL_SHUTDOWN_EVENT: DWORD = 6;
 
-pub const HANDLER_ROUTINE = switch (builtin.zig_backend) {
-    .stage1 => fn (dwCtrlType: DWORD) callconv(.C) BOOL,
-    else => *const fn (dwCtrlType: DWORD) callconv(.C) BOOL,
-};
+pub const HANDLER_ROUTINE = std.meta.FnPtr(fn (dwCtrlType: DWORD) callconv(.C) BOOL);

--- a/lib/std/os/windows/user32.zig
+++ b/lib/std/os/windows/user32.zig
@@ -39,7 +39,7 @@ fn selectSymbol(comptime function_static: anytype, function_dynamic: @TypeOf(fun
 
 // === Messages ===
 
-pub const WNDPROC = fn (hwnd: HWND, uMsg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(WINAPI) LRESULT;
+pub const WNDPROC = std.meta.FnPtr(fn (hwnd: HWND, uMsg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(WINAPI) LRESULT);
 
 pub const MSG = extern struct {
     hWnd: ?HWND,
@@ -1056,7 +1056,7 @@ pub fn getMessageA(lpMsg: *MSG, hWnd: ?HWND, wMsgFilterMin: u32, wMsgFilterMax: 
 }
 
 pub extern "user32" fn GetMessageW(lpMsg: *MSG, hWnd: ?HWND, wMsgFilterMin: UINT, wMsgFilterMax: UINT) callconv(WINAPI) BOOL;
-pub var pfnGetMessageW: @TypeOf(GetMessageW) = undefined;
+pub var pfnGetMessageW: std.meta.FnPtr(@TypeOf(GetMessageW)) = undefined;
 pub fn getMessageW(lpMsg: *MSG, hWnd: ?HWND, wMsgFilterMin: u32, wMsgFilterMax: u32) !void {
     const function = selectSymbol(GetMessageW, pfnGetMessageW, .win2k);
 
@@ -1087,7 +1087,7 @@ pub fn peekMessageA(lpMsg: *MSG, hWnd: ?HWND, wMsgFilterMin: u32, wMsgFilterMax:
 }
 
 pub extern "user32" fn PeekMessageW(lpMsg: *MSG, hWnd: ?HWND, wMsgFilterMin: UINT, wMsgFilterMax: UINT, wRemoveMsg: UINT) callconv(WINAPI) BOOL;
-pub var pfnPeekMessageW: @TypeOf(PeekMessageW) = undefined;
+pub var pfnPeekMessageW: std.meta.FnPtr(@TypeOf(PeekMessageW)) = undefined;
 pub fn peekMessageW(lpMsg: *MSG, hWnd: ?HWND, wMsgFilterMin: u32, wMsgFilterMax: u32, wRemoveMsg: u32) !bool {
     const function = selectSymbol(PeekMessageW, pfnPeekMessageW, .win2k);
 
@@ -1112,7 +1112,7 @@ pub fn dispatchMessageA(lpMsg: *const MSG) LRESULT {
 }
 
 pub extern "user32" fn DispatchMessageW(lpMsg: *const MSG) callconv(WINAPI) LRESULT;
-pub var pfnDispatchMessageW: @TypeOf(DispatchMessageW) = undefined;
+pub var pfnDispatchMessageW: std.meta.FnPtr(@TypeOf(DispatchMessageW)) = undefined;
 pub fn dispatchMessageW(lpMsg: *const MSG) LRESULT {
     const function = selectSymbol(DispatchMessageW, pfnDispatchMessageW, .win2k);
     return function(lpMsg);
@@ -1129,7 +1129,7 @@ pub fn defWindowProcA(hWnd: HWND, Msg: UINT, wParam: WPARAM, lParam: LPARAM) LRE
 }
 
 pub extern "user32" fn DefWindowProcW(hWnd: HWND, Msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(WINAPI) LRESULT;
-pub var pfnDefWindowProcW: @TypeOf(DefWindowProcW) = undefined;
+pub var pfnDefWindowProcW: std.meta.FnPtr(@TypeOf(DefWindowProcW)) = undefined;
 pub fn defWindowProcW(hWnd: HWND, Msg: UINT, wParam: WPARAM, lParam: LPARAM) LRESULT {
     const function = selectSymbol(DefWindowProcW, pfnDefWindowProcW, .win2k);
     return function(hWnd, Msg, wParam, lParam);
@@ -1191,7 +1191,7 @@ pub fn registerClassExA(window_class: *const WNDCLASSEXA) !ATOM {
 }
 
 pub extern "user32" fn RegisterClassExW(*const WNDCLASSEXW) callconv(WINAPI) ATOM;
-pub var pfnRegisterClassExW: @TypeOf(RegisterClassExW) = undefined;
+pub var pfnRegisterClassExW: std.meta.FnPtr(@TypeOf(RegisterClassExW)) = undefined;
 pub fn registerClassExW(window_class: *const WNDCLASSEXW) !ATOM {
     const function = selectSymbol(RegisterClassExW, pfnRegisterClassExW, .win2k);
     const atom = function(window_class);
@@ -1215,7 +1215,7 @@ pub fn unregisterClassA(lpClassName: [*:0]const u8, hInstance: HINSTANCE) !void 
 }
 
 pub extern "user32" fn UnregisterClassW(lpClassName: [*:0]const u16, hInstance: HINSTANCE) callconv(WINAPI) BOOL;
-pub var pfnUnregisterClassW: @TypeOf(UnregisterClassW) = undefined;
+pub var pfnUnregisterClassW: std.meta.FnPtr(@TypeOf(UnregisterClassW)) = undefined;
 pub fn unregisterClassW(lpClassName: [*:0]const u16, hInstance: HINSTANCE) !void {
     const function = selectSymbol(UnregisterClassW, pfnUnregisterClassW, .win2k);
     if (function(lpClassName, hInstance) == 0) {
@@ -1292,7 +1292,7 @@ pub fn createWindowExA(dwExStyle: u32, lpClassName: [*:0]const u8, lpWindowName:
 }
 
 pub extern "user32" fn CreateWindowExW(dwExStyle: DWORD, lpClassName: [*:0]const u16, lpWindowName: [*:0]const u16, dwStyle: DWORD, X: i32, Y: i32, nWidth: i32, nHeight: i32, hWindParent: ?HWND, hMenu: ?HMENU, hInstance: HINSTANCE, lpParam: ?LPVOID) callconv(WINAPI) ?HWND;
-pub var pfnCreateWindowExW: @TypeOf(CreateWindowExW) = undefined;
+pub var pfnCreateWindowExW: std.meta.FnPtr(@TypeOf(CreateWindowExW)) = undefined;
 pub fn createWindowExW(dwExStyle: u32, lpClassName: [*:0]const u16, lpWindowName: [*:0]const u16, dwStyle: u32, X: i32, Y: i32, nWidth: i32, nHeight: i32, hWindParent: ?HWND, hMenu: ?HMENU, hInstance: HINSTANCE, lpParam: ?*anyopaque) !HWND {
     const function = selectSymbol(CreateWindowExW, pfnCreateWindowExW, .win2k);
     const window = function(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWindParent, hMenu, hInstance, lpParam);
@@ -1382,7 +1382,7 @@ pub fn getWindowLongA(hWnd: HWND, nIndex: i32) !i32 {
 }
 
 pub extern "user32" fn GetWindowLongW(hWnd: HWND, nIndex: i32) callconv(WINAPI) LONG;
-pub var pfnGetWindowLongW: @TypeOf(GetWindowLongW) = undefined;
+pub var pfnGetWindowLongW: std.meta.FnPtr(@TypeOf(GetWindowLongW)) = undefined;
 pub fn getWindowLongW(hWnd: HWND, nIndex: i32) !i32 {
     const function = selectSymbol(GetWindowLongW, pfnGetWindowLongW, .win2k);
 
@@ -1415,7 +1415,7 @@ pub fn getWindowLongPtrA(hWnd: HWND, nIndex: i32) !isize {
 }
 
 pub extern "user32" fn GetWindowLongPtrW(hWnd: HWND, nIndex: i32) callconv(WINAPI) LONG_PTR;
-pub var pfnGetWindowLongPtrW: @TypeOf(GetWindowLongPtrW) = undefined;
+pub var pfnGetWindowLongPtrW: std.meta.FnPtr(@TypeOf(GetWindowLongPtrW)) = undefined;
 pub fn getWindowLongPtrW(hWnd: HWND, nIndex: i32) !isize {
     if (@sizeOf(LONG_PTR) == 4) return getWindowLongW(hWnd, nIndex);
     const function = selectSymbol(GetWindowLongPtrW, pfnGetWindowLongPtrW, .win2k);
@@ -1449,7 +1449,7 @@ pub fn setWindowLongA(hWnd: HWND, nIndex: i32, dwNewLong: i32) !i32 {
 }
 
 pub extern "user32" fn SetWindowLongW(hWnd: HWND, nIndex: i32, dwNewLong: LONG) callconv(WINAPI) LONG;
-pub var pfnSetWindowLongW: @TypeOf(SetWindowLongW) = undefined;
+pub var pfnSetWindowLongW: std.meta.FnPtr(@TypeOf(SetWindowLongW)) = undefined;
 pub fn setWindowLongW(hWnd: HWND, nIndex: i32, dwNewLong: i32) !i32 {
     const function = selectSymbol(SetWindowLongW, pfnSetWindowLongW, .win2k);
 
@@ -1484,7 +1484,7 @@ pub fn setWindowLongPtrA(hWnd: HWND, nIndex: i32, dwNewLong: isize) !isize {
 }
 
 pub extern "user32" fn SetWindowLongPtrW(hWnd: HWND, nIndex: i32, dwNewLong: LONG_PTR) callconv(WINAPI) LONG_PTR;
-pub var pfnSetWindowLongPtrW: @TypeOf(SetWindowLongPtrW) = undefined;
+pub var pfnSetWindowLongPtrW: std.meta.FnPtr(@TypeOf(SetWindowLongPtrW)) = undefined;
 pub fn setWindowLongPtrW(hWnd: HWND, nIndex: i32, dwNewLong: isize) !isize {
     if (@sizeOf(LONG_PTR) == 4) return setWindowLongW(hWnd, nIndex, dwNewLong);
     const function = selectSymbol(SetWindowLongPtrW, pfnSetWindowLongPtrW, .win2k);
@@ -1580,7 +1580,7 @@ pub fn messageBoxA(hWnd: ?HWND, lpText: [*:0]const u8, lpCaption: [*:0]const u8,
 }
 
 pub extern "user32" fn MessageBoxW(hWnd: ?HWND, lpText: [*:0]const u16, lpCaption: ?[*:0]const u16, uType: UINT) callconv(WINAPI) i32;
-pub var pfnMessageBoxW: @TypeOf(MessageBoxW) = undefined;
+pub var pfnMessageBoxW: std.meta.FnPtr(@TypeOf(MessageBoxW)) = undefined;
 pub fn messageBoxW(hWnd: ?HWND, lpText: [*:0]const u16, lpCaption: [*:0]const u16, uType: u32) !i32 {
     const function = selectSymbol(MessageBoxW, pfnMessageBoxW, .win2k);
     const value = function(hWnd, lpText, lpCaption, uType);

--- a/lib/std/os/windows/ws2_32.zig
+++ b/lib/std/os/windows/ws2_32.zig
@@ -942,7 +942,7 @@ pub const UDP_NOCHECKSUM = 1;
 pub const UDP_CHECKSUM_COVERAGE = 20;
 pub const GAI_STRERROR_BUFFER_SIZE = 1024;
 
-pub const LPCONDITIONPROC = fn (
+pub const LPCONDITIONPROC = std.meta.FnPtr(fn (
     lpCallerId: *WSABUF,
     lpCallerData: *WSABUF,
     lpSQOS: *QOS,
@@ -951,14 +951,14 @@ pub const LPCONDITIONPROC = fn (
     lpCalleeData: *WSABUF,
     g: *u32,
     dwCallbackData: usize,
-) callconv(WINAPI) i32;
+) callconv(WINAPI) i32);
 
-pub const LPWSAOVERLAPPED_COMPLETION_ROUTINE = fn (
+pub const LPWSAOVERLAPPED_COMPLETION_ROUTINE = std.meta.FnPtr(fn (
     dwError: u32,
     cbTransferred: u32,
     lpOverlapped: *OVERLAPPED,
     dwFlags: u32,
-) callconv(WINAPI) void;
+) callconv(WINAPI) void);
 
 pub const FLOWSPEC = extern struct {
     TokenRate: u32,
@@ -1173,7 +1173,7 @@ pub const TRANSMIT_FILE_BUFFERS = extern struct {
     TailLength: u32,
 };
 
-pub const LPFN_TRANSMITFILE = fn (
+pub const LPFN_TRANSMITFILE = std.meta.FnPtr(fn (
     hSocket: SOCKET,
     hFile: HANDLE,
     nNumberOfBytesToWrite: u32,
@@ -1181,9 +1181,9 @@ pub const LPFN_TRANSMITFILE = fn (
     lpOverlapped: ?*OVERLAPPED,
     lpTransmitBuffers: ?*TRANSMIT_FILE_BUFFERS,
     dwReserved: u32,
-) callconv(WINAPI) BOOL;
+) callconv(WINAPI) BOOL);
 
-pub const LPFN_ACCEPTEX = fn (
+pub const LPFN_ACCEPTEX = std.meta.FnPtr(fn (
     sListenSocket: SOCKET,
     sAcceptSocket: SOCKET,
     lpOutputBuffer: *anyopaque,
@@ -1192,9 +1192,9 @@ pub const LPFN_ACCEPTEX = fn (
     dwRemoteAddressLength: u32,
     lpdwBytesReceived: *u32,
     lpOverlapped: *OVERLAPPED,
-) callconv(WINAPI) BOOL;
+) callconv(WINAPI) BOOL);
 
-pub const LPFN_GETACCEPTEXSOCKADDRS = fn (
+pub const LPFN_GETACCEPTEXSOCKADDRS = std.meta.FnPtr(fn (
     lpOutputBuffer: *anyopaque,
     dwReceiveDataLength: u32,
     dwLocalAddressLength: u32,
@@ -1203,29 +1203,29 @@ pub const LPFN_GETACCEPTEXSOCKADDRS = fn (
     LocalSockaddrLength: *i32,
     RemoteSockaddr: **sockaddr,
     RemoteSockaddrLength: *i32,
-) callconv(WINAPI) void;
+) callconv(WINAPI) void);
 
-pub const LPFN_WSASENDMSG = fn (
+pub const LPFN_WSASENDMSG = std.meta.FnPtr(fn (
     s: SOCKET,
     lpMsg: *const std.x.os.Socket.Message,
     dwFlags: u32,
     lpNumberOfBytesSent: ?*u32,
     lpOverlapped: ?*OVERLAPPED,
     lpCompletionRoutine: ?LPWSAOVERLAPPED_COMPLETION_ROUTINE,
-) callconv(WINAPI) i32;
+) callconv(WINAPI) i32);
 
-pub const LPFN_WSARECVMSG = fn (
+pub const LPFN_WSARECVMSG = std.meta.FnPtr(fn (
     s: SOCKET,
     lpMsg: *std.x.os.Socket.Message,
     lpdwNumberOfBytesRecv: ?*u32,
     lpOverlapped: ?*OVERLAPPED,
     lpCompletionRoutine: ?LPWSAOVERLAPPED_COMPLETION_ROUTINE,
-) callconv(WINAPI) i32;
+) callconv(WINAPI) i32);
 
-pub const LPSERVICE_CALLBACK_PROC = fn (
+pub const LPSERVICE_CALLBACK_PROC = std.meta.FnPtr(fn (
     lParam: LPARAM,
     hAsyncTaskHandle: HANDLE,
-) callconv(WINAPI) void;
+) callconv(WINAPI) void);
 
 pub const SERVICE_ASYNC_INFO = extern struct {
     lpServiceCallbackProc: LPSERVICE_CALLBACK_PROC,
@@ -1233,11 +1233,11 @@ pub const SERVICE_ASYNC_INFO = extern struct {
     hAsyncTaskHandle: HANDLE,
 };
 
-pub const LPLOOKUPSERVICE_COMPLETION_ROUTINE = fn (
+pub const LPLOOKUPSERVICE_COMPLETION_ROUTINE = std.meta.FnPtr(fn (
     dwError: u32,
     dwBytes: u32,
     lpOverlapped: *OVERLAPPED,
-) callconv(WINAPI) void;
+) callconv(WINAPI) void);
 
 pub const fd_set = extern struct {
     fd_count: u32,

--- a/lib/std/rand.zig
+++ b/lib/std/rand.zig
@@ -30,10 +30,7 @@ pub const RomuTrio = @import("rand/RomuTrio.zig");
 
 pub const Random = struct {
     ptr: *anyopaque,
-    fillFn: if (builtin.zig_backend == .stage1)
-        fn (ptr: *anyopaque, buf: []u8) void
-    else
-        *const fn (ptr: *anyopaque, buf: []u8) void,
+    fillFn: std.meta.FnPtr(fn (ptr: *anyopaque, buf: []u8) void),
 
     pub fn init(pointer: anytype, comptime fillFn: fn (ptr: @TypeOf(pointer), buf: []u8) void) Random {
         const Ptr = @TypeOf(pointer);

--- a/lib/std/zig/c_translation.zig
+++ b/lib/std/zig/c_translation.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const testing = std.testing;
 const math = std.math;
 const mem = std.mem;
@@ -8,7 +9,7 @@ pub fn cast(comptime DestType: type, target: anytype) DestType {
     // this function should behave like transCCast in translate-c, except it's for macros
     const SourceType = @TypeOf(target);
     switch (@typeInfo(DestType)) {
-        .Fn => if (@import("builtin").zig_backend == .stage1)
+        .Fn => if (builtin.zig_backend == .stage1)
             return castToPtr(DestType, SourceType, target)
         else
             return castToPtr(*const DestType, SourceType, target),
@@ -17,7 +18,7 @@ pub fn cast(comptime DestType: type, target: anytype) DestType {
             if (@typeInfo(dest_opt.child) == .Pointer) {
                 return castToPtr(DestType, SourceType, target);
             } else if (@typeInfo(dest_opt.child) == .Fn) {
-                if (@import("builtin").zig_backend == .stage1)
+                if (builtin.zig_backend == .stage1)
                     return castToPtr(DestType, SourceType, target)
                 else
                     return castToPtr(?*const dest_opt.child, SourceType, target);
@@ -137,10 +138,7 @@ test "cast" {
     try testing.expect(cast(?*anyopaque, -1) == @intToPtr(?*anyopaque, @bitCast(usize, @as(isize, -1))));
     try testing.expect(cast(?*anyopaque, foo) == @intToPtr(?*anyopaque, @bitCast(usize, @as(isize, -1))));
 
-    const FnPtr = if (@import("builtin").zig_backend == .stage1)
-        ?fn (*anyopaque) void
-    else
-        ?*align(1) const fn (*anyopaque) void;
+    const FnPtr = ?if (builtin.zig_backend == .stage1) fn (*anyopaque) void else *align(1) const fn (*anyopaque) void;
     try testing.expect(cast(FnPtr, 0) == @intToPtr(FnPtr, @as(usize, 0)));
     try testing.expect(cast(FnPtr, foo) == @intToPtr(FnPtr, @bitCast(usize, @as(isize, -1))));
 }
@@ -151,7 +149,7 @@ pub fn sizeof(target: anytype) usize {
     switch (@typeInfo(T)) {
         .Float, .Int, .Struct, .Union, .Array, .Bool, .Vector => return @sizeOf(T),
         .Fn => {
-            if (@import("builtin").zig_backend == .stage1) {
+            if (builtin.zig_backend == .stage1) {
                 // sizeof(main) returns 1, sizeof(&main) returns pointer size.
                 // We cannot distinguish those types in Zig, so use pointer size.
                 return @sizeOf(T);
@@ -254,7 +252,7 @@ test "sizeof" {
     try testing.expect(sizeof(*const *const [4:0]u8) == ptr_size);
     try testing.expect(sizeof(*const [4]u8) == ptr_size);
 
-    if (@import("builtin").zig_backend == .stage1) {
+    if (builtin.zig_backend == .stage1) {
         try testing.expect(sizeof(sizeof) == @sizeOf(@TypeOf(sizeof)));
     } else if (false) { // TODO
         try testing.expect(sizeof(&sizeof) == @sizeOf(@TypeOf(&sizeof)));


### PR DESCRIPTION
Many parts of `std` still use stage1-style function pointers. This PR removes all instances of this, replacing them with the use of `std.meta.FnPtr`. Additionally, manually-written `if` statements have been replaced with `FnPtr` for clarity, conciseness, and to be guarantee detection and removal when stage1 support is removed from `std`.

I'll give this another check over before it's ready to merge.