### PR TITLE
cmake: remove incompatible c flags for MSVC 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -842,9 +842,7 @@ else()
 endif()
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-    if(MSVC)
-        set(EXE_CFLAGS "${EXE_CFLAGS} /w")
-    else()
+    if(NOT MSVC)
         set(EXE_CFLAGS "${EXE_CFLAGS} -Werror -Wall")
         # fallthrough support was added in GCC 7.0
         if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,11 +308,7 @@ set(EMBEDDED_SOFTFLOAT_SOURCES
     "${CMAKE_SOURCE_DIR}/deps/SoftFloat-3e/source/ui64_to_extF80M.c"
 )
 add_library(embedded_softfloat STATIC ${EMBEDDED_SOFTFLOAT_SOURCES})
-if(MSVC)
-    set_target_properties(embedded_softfloat PROPERTIES
-        COMPILE_FLAGS "/w /O2"
-    )
-else()
+if(NOT MSVC)
     set_target_properties(embedded_softfloat PROPERTIES
         COMPILE_FLAGS "-std=c99 -O3"
     )
@@ -870,11 +866,9 @@ else()
     endif()
 endif()
 
-if(MSVC)
-  set(OPTIMIZED_C_FLAGS "/O2")
-else(MSVC)
+if(NOT MSVC)
   set(OPTIMIZED_C_FLAGS "-std=c99 -O3")
-endif(MSVC)
+endif()
 
 set(EXE_LDFLAGS " ")
 if(MSVC)


### PR DESCRIPTION
When building Zig0 with msvc you get an error that /O2 and /RTL1 are incompatible. C Flags for the project for msvc are set in cmake/c_flag_overrides.cmake