### PR TITLE
AstGen: add ResultLoc.only_break to fix loop's then-scope result

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -5974,8 +5974,7 @@ fn whileExpr(
     if (dbg_var_name) |some| {
         try then_scope.addDbgVar(.dbg_var_val, some, dbg_var_inst);
     }
-    // rl == .discard may ignore some compile error.
-    const then_rl = .{ .only_break = ResultLoc.wrap(if (loop_scope.break_result_loc == .discard) .none else loop_scope.break_result_loc) };
+    const then_rl = .{ .only_break = ResultLoc.wrap(loop_scope.break_result_loc) };
     const then_result = try expr(&then_scope, then_sub_scope, then_rl, while_full.ast.then_expr);
     _ = try addEnsureResult(&then_scope, then_result, while_full.ast.then_expr);
 
@@ -6215,8 +6214,7 @@ fn forExpr(
         break :blk &index_scope.base;
     };
 
-    // rl == .discard may ignore some compile error.
-    const then_rl = .{ .only_break = ResultLoc.wrap(if (loop_scope.break_result_loc == .discard) .none else loop_scope.break_result_loc) };
+    const then_rl = .{ .only_break = ResultLoc.wrap(loop_scope.break_result_loc) };
     const then_result = try expr(&then_scope, then_sub_scope, then_rl, for_full.ast.then_expr);
     _ = try addEnsureResult(&then_scope, then_result, for_full.ast.then_expr);
 

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -87,6 +87,7 @@ test {
     _ = @import("behavior/bugs/12486.zig");
     _ = @import("behavior/bugs/12680.zig");
     _ = @import("behavior/bugs/12776.zig");
+    _ = @import("behavior/bugs/11816_12551_12555.zig");
     _ = @import("behavior/byteswap.zig");
     _ = @import("behavior/byval_arg_var.zig");
     _ = @import("behavior/call.zig");
@@ -161,7 +162,6 @@ test {
     _ = @import("behavior/void.zig");
     _ = @import("behavior/while.zig");
     _ = @import("behavior/widening.zig");
-    _ = @import("behavior/bugs/11816_12551_12555.zig");
 
     if (builtin.cpu.arch == .wasm32) {
         _ = @import("behavior/wasm.zig");

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -161,6 +161,7 @@ test {
     _ = @import("behavior/void.zig");
     _ = @import("behavior/while.zig");
     _ = @import("behavior/widening.zig");
+    _ = @import("behavior/bugs/11816_12551_12555.zig");
 
     if (builtin.cpu.arch == .wasm32) {
         _ = @import("behavior/wasm.zig");

--- a/test/behavior/bugs/11816_12551_12555.zig
+++ b/test/behavior/bugs/11816_12551_12555.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+
+test "issue11816" {
+    var x: u32 = 3;
+    const val: usize = while (true) switch (x) {
+        1 => break 2,
+        else => x -= 1,
+    }; // else unreachable; another bug?
+    try std.testing.expectEqual(@as(usize, 2), val);
+}
+
+test "issue12551_12555" {
+    try std.testing.expect(for ([1]u8{0}) |x| {
+        if (x == 0) break true;
+    } else false);
+}

--- a/test/cases/issue12455.zig
+++ b/test/cases/issue12455.zig
@@ -1,0 +1,13 @@
+test "issue12455" {
+    var a: u32 = 0;
+    while (true) switch (a) {
+        0 => 2,
+        1 => a = 0,
+        else => break,
+    };
+}
+
+// error
+// is_test=1
+//
+// :3:18: error: incompatible types: 'comptime_int' and 'void'

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -225,24 +225,6 @@ pub fn addCases(ctx: *TestContext) !void {
         });
     }
 
-    {
-        const case = ctx.obj("issue 12455 while with switch", .{});
-        // https://github.com/ziglang/zig/issues/12455
-        case.backend = .stage2;
-        case.addError(
-            \\pub export fn entry() void {
-            \\    var a: u32 = 0;
-            \\    while (true) switch (a) {
-            \\        0 => 2,
-            \\        1 => a = 0,
-            \\        else => break,
-            \\    };
-            \\}
-        , &[_][]const u8{
-            ":3:18: error: incompatible types: 'comptime_int' and 'void'",
-        });
-    }
-
     // TODO test this in stage2, but we won't even try in stage1
     //ctx.objErrStage1("inline fn calls itself indirectly",
     //    \\export fn foo() void {

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -225,6 +225,24 @@ pub fn addCases(ctx: *TestContext) !void {
         });
     }
 
+    {
+        const case = ctx.obj("issue 12455 while with switch", .{});
+        // https://github.com/ziglang/zig/issues/12455
+        case.backend = .stage2;
+        case.addError(
+            \\pub export fn entry() void {
+            \\    var a: u32 = 0;
+            \\    while (true) switch (a) {
+            \\        0 => 2,
+            \\        1 => a = 0,
+            \\        else => break,
+            \\    };
+            \\}
+        , &[_][]const u8{
+            ":3:18: error: incompatible types: 'comptime_int' and 'void'",
+        });
+    }
+
     // TODO test this in stage2, but we won't even try in stage1
     //ctx.objErrStage1("inline fn calls itself indirectly",
     //    \\export fn foo() void {


### PR DESCRIPTION
fix https://github.com/ziglang/zig/issues/12555 https://github.com/ziglang/zig/issues/12551 https://github.com/ziglang/zig/issues/12455

loop body is noreturn and only the `break` operands are the result values of loops. the new locType 'only_break' mean only effect break result,
otherwise it's work like 'none'.

ralate commit: https://github.com/ziglang/zig/commit/70894d5c2f

prev msg:
~while/for expr use func `markAsLoopBody` to set `rvalue_noresult` field for help func `rvalue` to skip store result in `then_scope`. and blockExpr default return void_value when block end_noreturn.~

~in this case, func `rvalue` add a `as_node` for `rl` if it is `ty` case, then got `as_node(rl, void_value)`cause the bug.~

~so need add `rvalue_noresult` case include `ty rl`~

PS: zig is great project.
