### PR TITLE
std.zig.system.NativeTargetInfo: improve glibc version and dynamic linker detection

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -1210,7 +1210,7 @@ fn genHtml(
     var env_map = try process.getEnvMap(allocator);
     try env_map.put("ZIG_DEBUG_COLOR", "1");
 
-    const host = try std.zig.system.NativeTargetInfo.detect(allocator, .{});
+    const host = try std.zig.system.NativeTargetInfo.detect(.{});
     const builtin_code = try getBuiltinCode(allocator, &env_map, zig_exe);
 
     for (toc.nodes) |node| {
@@ -1474,7 +1474,6 @@ fn genHtml(
                                 .arch_os_abi = triple,
                             });
                             const target_info = try std.zig.system.NativeTargetInfo.detect(
-                                allocator,
                                 cross_target,
                             );
                             switch (host.getExternalExecutor(target_info, .{

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -171,7 +171,7 @@ pub const Builder = struct {
         const env_map = try allocator.create(EnvMap);
         env_map.* = try process.getEnvMap(allocator);
 
-        const host = try NativeTargetInfo.detect(allocator, .{});
+        const host = try NativeTargetInfo.detect(.{});
 
         const self = try allocator.create(Builder);
         self.* = Builder{
@@ -1798,7 +1798,7 @@ pub const LibExeObjStep = struct {
     }
 
     fn computeOutFileNames(self: *LibExeObjStep) void {
-        self.target_info = NativeTargetInfo.detect(self.builder.allocator, self.target) catch
+        self.target_info = NativeTargetInfo.detect(self.target) catch
             unreachable;
 
         const target = self.target_info.target;

--- a/lib/std/build/EmulatableRunStep.zig
+++ b/lib/std/build/EmulatableRunStep.zig
@@ -158,7 +158,7 @@ fn warnAboutForeignBinaries(step: *EmulatableRunStep) void {
 
     const host_name = builder.host.target.zigTriple(builder.allocator) catch unreachable;
     const foreign_name = artifact.target.zigTriple(builder.allocator) catch unreachable;
-    const target_info = std.zig.system.NativeTargetInfo.detect(builder.allocator, artifact.target) catch unreachable;
+    const target_info = std.zig.system.NativeTargetInfo.detect(artifact.target) catch unreachable;
     const need_cross_glibc = artifact.target.isGnuLibC() and artifact.is_linking_libc;
     switch (builder.host.getExternalExecutor(target_info, .{
         .qemu_fixes_dl = need_cross_glibc and builder.glibc_runtimes_dir != null,

--- a/lib/std/zig/system/NativeTargetInfo.zig
+++ b/lib/std/zig/system/NativeTargetInfo.zig
@@ -552,14 +552,14 @@ fn glibcVerFromSoFile(file: fs.File) !std.builtin.Version {
     // and furthermore, that the system-installed glibc is at minimum that version.
 
     // Empirically, glibc 2.34 libc.so .dynstr section is 32441 bytes on my system.
-    // Here I use this value plus some headroom. This makes it only need
+    // Here I use double this value plus some headroom. This makes it only need
     // a single read syscall here.
-    var buf: [40000]u8 = undefined;
+    var buf: [80000]u8 = undefined;
     if (buf.len < dynstr.size) return error.InvalidGnuLibCVersion;
 
     const dynstr_size = @intCast(usize, dynstr.size);
     const dynstr_bytes = buf[0..dynstr_size];
-    _ = try preadMin(file, dynstr_bytes, dynstr.offset, dynstr_size);
+    _ = try preadMin(file, dynstr_bytes, dynstr.offset, dynstr_bytes.len);
     var it = mem.split(u8, dynstr_bytes, &.{0});
     var max_ver: std.builtin.Version = .{ .major = 2, .minor = 2, .patch = 5 };
     while (it.next()) |s| {

--- a/lib/std/zig/system/NativeTargetInfo.zig
+++ b/lib/std/zig/system/NativeTargetInfo.zig
@@ -485,8 +485,9 @@ fn glibcVerFromSoFile(file: fs.File) !std.builtin.Version {
     var buf: [40000]u8 = undefined;
     if (buf.len < dynstr.size) return error.InvalidGnuLibCVersion;
 
-    const dynstr_bytes = buf[0..dynstr.size];
-    _ = try preadMin(file, dynstr_bytes, dynstr.offset, dynstr.size);
+    const dynstr_size = @intCast(usize, dynstr.size);
+    const dynstr_bytes = buf[0..dynstr_size];
+    _ = try preadMin(file, dynstr_bytes, dynstr.offset, dynstr_size);
     var it = mem.split(u8, dynstr_bytes, &.{0});
     var max_ver: std.builtin.Version = .{ .major = 2, .minor = 2, .patch = 5 };
     while (it.next()) |s| {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3870,7 +3870,7 @@ pub const DeclGen = struct {
                                 var b: usize = 0;
                                 for (parent_ty.structFields().values()[0..field_index]) |field| {
                                     if (field.is_comptime or !field.ty.hasRuntimeBitsIgnoreComptime()) continue;
-                                    b += field.ty.bitSize(target);
+                                    b += @intCast(usize, field.ty.bitSize(target));
                                 }
                                 break :b b;
                             };

--- a/src/test.zig
+++ b/src/test.zig
@@ -1211,7 +1211,7 @@ pub const TestContext = struct {
     }
 
     fn run(self: *TestContext) !void {
-        const host = try std.zig.system.NativeTargetInfo.detect(self.gpa, .{});
+        const host = try std.zig.system.NativeTargetInfo.detect(.{});
 
         var progress = std.Progress{};
         const root_node = progress.start("compiler", self.cases.items.len);
@@ -1300,7 +1300,7 @@ pub const TestContext = struct {
         global_cache_directory: Compilation.Directory,
         host: std.zig.system.NativeTargetInfo,
     ) !void {
-        const target_info = try std.zig.system.NativeTargetInfo.detect(allocator, case.target);
+        const target_info = try std.zig.system.NativeTargetInfo.detect(case.target);
         const target = target_info.target;
 
         var arena_allocator = std.heap.ArenaAllocator.init(allocator);


### PR DESCRIPTION
Previously, this code would fail to detect glibc version because it
relied on libc.so.6 being a symlink which revealed the answer. On modern
distro versions, this is no longer the case.

This new strategy finds the path to libc.so.6 from `/usr/bin/env`, then
inspects the `.dynstr` section of libc.so.6, looking for symbols that
start with "GLIBC_2.". It then parses those as semantic versions and
takes the maximum value as the system-native glibc version.

-----

Before, native glibc and dynamic linker detection attempted to use the
executable's own binary if it was dynamically linked to answer both the
C ABI question and the dynamic linker question. However, this could be
problematic on a system that uses a RUNPATH for the compiler binary,
locking it to an older glibc version, while system binaries such as
/usr/bin/env use a newer glibc version. The problem is that libc.so.6
glibc version will match that of the system while the dynamic linker
will match that of the compiler binary. Executables with these versions
mismatching will fail to run.

Therefore, this pull request changes the logic to be the same regardless of
whether the compiler binary is dynamically or statically linked. It
inspects `/usr/bin/env` as an ELF file to find the answer to these
questions, or if there is a shebang line, then it chases the referenced
file recursively. If that does not provide the answer, then the function
falls back to defaults.

This pull request also solves a TODO to remove an Allocator parameter to the
detect() function.

-----

closes #6469
closes #12567

@Vexu can you check if this solves #11137 for you?

