### PR TITLE
translate-c: Escape non-ASCII characters that appear in macros

### DIFF
--- a/test/behavior/translate_c_macros.zig
+++ b/test/behavior/translate_c_macros.zig
@@ -5,6 +5,7 @@ const expectEqual = std.testing.expectEqual;
 const expectEqualStrings = std.testing.expectEqualStrings;
 
 const h = @cImport(@cInclude("behavior/translate_c_macros.h"));
+const latin1 = @cImport(@cInclude("behavior/translate_c_macros_not_utf8.h"));
 
 test "casting to void with a macro" {
     h.IGNORE_ME_1(42);
@@ -133,4 +134,15 @@ test "string literal macro with embedded tab character" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     try expectEqualStrings("hello\t", h.EMBEDDED_TAB);
+}
+
+test "string and char literals that are not UTF-8 encoded. Issue #12784" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
+    try expectEqual(@as(u8, '\xA9'), latin1.UNPRINTABLE_CHAR);
+    try expectEqualStrings("\xA9\xA9\xA9", latin1.UNPRINTABLE_STRING);
 }

--- a/test/behavior/translate_c_macros_not_utf8.h
+++ b/test/behavior/translate_c_macros_not_utf8.h
@@ -1,0 +1,5 @@
+// Note: This file is encoded with ISO/IEC 8859-1 (latin1), not UTF-8.
+// Do not change the encoding
+
+#define UNPRINTABLE_STRING "©©©"
+#define UNPRINTABLE_CHAR '©'


### PR DESCRIPTION
Macro definitions are simply a slice of bytes, which may not be UTF-8 encoded. If they are not UTF-8 encoded, escape non-printable and non-ASCII characters as `\xNN`.

Fixes #12784