### PR TITLE
type: print comptime on fn type params

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -2042,6 +2042,9 @@ pub const Type = extern union {
                 try writer.writeAll("fn(");
                 for (fn_info.param_types) |param_ty, i| {
                     if (i != 0) try writer.writeAll(", ");
+                    if (fn_info.paramIsComptime(i)) {
+                        try writer.writeAll("comptime ");
+                    }
                     if (std.math.cast(u5, i)) |index| if (@truncate(u1, fn_info.noalias_bits >> index) != 0) {
                         try writer.writeAll("noalias ");
                     };

--- a/test/behavior/typename.zig
+++ b/test/behavior/typename.zig
@@ -122,7 +122,7 @@ test "top level decl" {
     );
     // generic fn
     try expectEqualStrings(
-        "fn(type) type",
+        "fn(comptime type) type",
         @typeName(@TypeOf(TypeFromFn)),
     );
 }
@@ -244,5 +244,5 @@ test "comptime parameters not converted to anytype in function type" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     const T = fn (fn (type) void, void) void;
-    try expectEqualStrings("fn(fn(type) void, void) void", @typeName(T));
+    try expectEqualStrings("fn(comptime fn(comptime type) void, void) void", @typeName(T));
 }

--- a/test/cases/compile_errors/comptime_param_coersion.zig
+++ b/test/cases/compile_errors/comptime_param_coersion.zig
@@ -1,0 +1,20 @@
+pub export fn entry() void {
+    comptime var x: fn (comptime i32, comptime i32) void = undefined;
+    x = bar;
+}
+pub export fn entry1() void {
+    comptime var x: fn (i32, i32) void = undefined;
+    x = foo;
+}
+
+fn foo(comptime _: i32, comptime _: i32) void {}
+fn bar(comptime _: i32, _: i32) void {}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:9: error: expected type 'fn(comptime i32, comptime i32) void', found 'fn(comptime i32, i32) void'
+// :3:9: note: non-comptime parameter 1 cannot cast into a comptime parameter
+// :7:9: error: expected type 'fn(i32, i32) void', found 'fn(comptime i32, comptime i32) void'
+// :7:9: note: generic function cannot cast into a non-generic function


### PR DESCRIPTION
Given the source
```zig
fn f(_: i32, comptime _: i32) void {}

test {
    _ = @as(*const fn (i32, i32) void, f);
}
```
this turns the compile error from
```
repro.zig:4:40: error: expected type '*const fn(i32, i32) void', found '*const fn(i32, i32) void'
    _ = @as(*const fn (i32, i32) void, f);
                                       ^
repro.zig:4:40: note: pointer type child 'fn(i32, i32) void' cannot cast into pointer type child 'fn(i32, i32) void'
repro.zig:4:40: note: generic function cannot cast into a non-generic function
```
into
```
repro.zig:4:40: error: expected type '*const fn(i32, i32) void', found '*const fn(i32, comptime i32) void'
    _ = @as(*const fn (i32, i32) void, f);
                                       ^
repro.zig:4:40: note: pointer type child 'fn(i32, comptime i32) void' cannot cast into pointer type child 'fn(i32, i32) void'
repro.zig:4:40: note: generic function cannot cast into a non-generic function
```
which avoids the confusing message `error: expected type 'x', found 'x'`.