### PR TITLE
std: add peek function to std.json.TokenStream

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -415,7 +415,6 @@ pub const StreamingParser = struct {
                     }
 
                     _ = p.stack.pop();
-                    p.state = .ValueBegin;
                     p.after_string_state = State.fromAggregateContainerType(last_type);
 
                     switch (p.stack.len) {
@@ -438,7 +437,6 @@ pub const StreamingParser = struct {
                     }
 
                     _ = p.stack.pop();
-                    p.state = .ValueBegin;
                     p.after_string_state = State.fromAggregateContainerType(last_type);
 
                     switch (p.stack.len) {

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -221,7 +221,7 @@ pub const StreamingParser = struct {
     pub fn reset(p: *StreamingParser) void {
         p.state = .TopLevelBegin;
         p.count = 0;
-        // Set before ever read in main transition function
+        // Set before every read in main transition function
         p.after_string_state = undefined;
         p.after_value_state = .ValueEnd; // handle end of values normally
         p.stack.init();


### PR DESCRIPTION
First time contributing, hope this PR is up to your standards.

Similarly to #11925, this `peek` implementation technically does modify the internal `i` counter to speed up subsequent `peek` calls, but it shouldn't have any other impact. This is useful because `next` has been refactored to invoke `peek` internally, so the common case of invoking `peek` followed by `next` will still be fast. If this approach is not ok, then I can refactor `peek` so that subsequent calls repeat the same work.

One thing I'm very uncertain about is the change in the `stackUsed` method (only used in tests), particularly the contribution of `token1`/`token2` to the stack size. My understanding is that the `StreamingParser`'s stack is only used to keep track of opening/closing brackets, and `token2` is only ever populated with the token immediately after a number, which implies "If token2 is not null, then token1 is a number". With that in mind, should we not validate if `token1` and `token2` are brackets/braces rather than just checking for not null?

Closes #12463. 