### PR TITLE
stage2: no condition on system libs to link native libc

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -508,7 +508,7 @@ pub const ChildProcess = struct {
                 // it, that's the error code returned by the child process.
                 _ = std.os.poll(&fd, 0) catch unreachable;
 
-                // According to eventfd(2) the descriptro is readable if the counter
+                // According to eventfd(2) the descriptor is readable if the counter
                 // has a value greater than 0
                 if ((fd[0].revents & std.os.POLL.IN) != 0) {
                     const err_int = try readIntFd(err_pipe[0]);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1238,7 +1238,6 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             options.target,
             options.is_native_abi,
             link_libc,
-            options.system_lib_names.len != 0 or options.frameworks.count() != 0,
             options.libc_installation,
             options.native_darwin_sdk != null,
         );
@@ -4522,7 +4521,6 @@ fn detectLibCIncludeDirs(
     target: Target,
     is_native_abi: bool,
     link_libc: bool,
-    link_system_libs: bool,
     libc_installation: ?*const LibCInstallation,
     has_macos_sdk: bool,
 ) !LibCDirs {
@@ -4539,7 +4537,7 @@ fn detectLibCIncludeDirs(
 
     // If linking system libraries and targeting the native abi, default to
     // using the system libc installation.
-    if (link_system_libs and is_native_abi and !target.isMinGW()) {
+    if (is_native_abi and !target.isMinGW()) {
         if (target.isDarwin()) {
             return if (has_macos_sdk)
                 // For Darwin/macOS, we are all set with getDarwinSDK found earlier.

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -719,17 +719,16 @@ pub fn buildSharedObjects(comp: *Compilation) !void {
                 .lt => continue,
                 .gt => {
                     // TODO Expose via compile error mechanism instead of log.
-                    log.err("invalid target glibc version: {}", .{target_version});
+                    log.warn("invalid target glibc version: {}", .{target_version});
                     return error.InvalidTargetGLibCVersion;
                 },
             }
-        } else {
+        } else blk: {
             const latest_index = metadata.all_versions.len - 1;
-            // TODO Expose via compile error mechanism instead of log.
-            log.err("zig does not yet provide glibc version {}, the max provided version is {}", .{
+            log.warn("zig cannot build new glibc version {}; providing instead {}", .{
                 target_version, metadata.all_versions[latest_index],
             });
-            return error.InvalidTargetGLibCVersion;
+            break :blk latest_index;
         };
 
         {


### PR DESCRIPTION
Before, Zig tried to use its own libc files (e.g. glibc) when there were no system libs being linked. This prevented building against native glibc on systems that have newer glibc than the ones Zig provides.

Closes #12797