### PR TITLE
introduce compile error for pointless discards

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -404,7 +404,6 @@ fn callFn(comptime f: anytype, args: anytype) switch (Impl) {
             }
 
             // pthreads don't support exit status, ignore value
-            _ = status;
             return default_value;
         },
         .ErrorUnion => |info| {

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -582,8 +582,6 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
             old_align: u29,
             ret_addr: usize,
         ) void {
-            _ = old_align;
-
             const entry = self.large_allocations.getEntry(@ptrToInt(old_mem.ptr)) orelse {
                 if (config.safety) {
                     @panic("Invalid free");

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -171,7 +171,6 @@ pub fn approxEqRel(comptime T: type, x: T, y: T, tolerance: T) bool {
 }
 
 pub fn approxEq(comptime T: type, x: T, y: T, tolerance: T) bool {
-    _ = T;
     _ = x;
     _ = y;
     _ = tolerance;

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -2506,7 +2506,6 @@ fn walkInstruction(
                         try self.srcLocInfo(file, sn, parent_src)
                     else
                         parent_src;
-                    _ = src_info;
 
                     const decls_len = if (small.has_decls_len) blk: {
                         const decls_len = file.zir.extra[extra_index];
@@ -2627,7 +2626,6 @@ fn walkInstruction(
                         extra_index += 1;
                         break :blk fields_len;
                     } else 0;
-                    _ = fields_len;
 
                     const decls_len = if (small.has_decls_len) blk: {
                         const decls_len = file.zir.extra[extra_index];
@@ -2759,7 +2757,6 @@ fn walkInstruction(
                         extra_index += 1;
                         break :blk fields_len;
                     } else 0;
-                    _ = fields_len;
 
                     const decls_len = if (small.has_decls_len) blk: {
                         const decls_len = file.zir.extra[extra_index];
@@ -2901,7 +2898,6 @@ fn walkInstruction(
                         extra_index += 1;
                         break :blk fields_len;
                     } else 0;
-                    _ = fields_len;
 
                     const decls_len = if (small.has_decls_len) blk: {
                         const decls_len = file.zir.extra[extra_index];

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -19670,8 +19670,6 @@ fn zirMemcpy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void
         if (try sema.resolveDefinedValue(block, src_src, src_ptr)) |src_ptr_val| {
             if (!src_ptr_val.isComptimeMutablePtr()) break :rs src_src;
             if (try sema.resolveDefinedValue(block, len_src, len)) |len_val| {
-                _ = dest_ptr_val;
-                _ = src_ptr_val;
                 _ = len_val;
                 return sema.fail(block, src, "TODO: Sema.zirMemcpy at comptime", .{});
             } else break :rs len_src;
@@ -19713,7 +19711,6 @@ fn zirMemset(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void
         if (!ptr_val.isComptimeMutablePtr()) break :rs dest_src;
         if (try sema.resolveDefinedValue(block, len_src, len)) |len_val| {
             if (try sema.resolveMaybeUndefVal(block, value_src, value)) |val| {
-                _ = ptr_val;
                 _ = len_val;
                 _ = val;
                 return sema.fail(block, src, "TODO: Sema.zirMemset at comptime", .{});
@@ -19941,7 +19938,6 @@ fn zirFuncFancy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
         if (val.tag() == .generic_poison) {
             break :blk FuncLinkSection{ .generic = {} };
         }
-        _ = val;
         return sema.fail(block, section_src, "TODO implement linksection on functions", .{});
     } else if (extra.data.bits.has_section_ref) blk: {
         const section_ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_index]);

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -2581,7 +2581,6 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    _ = inst;
     const result: MCValue = if (self.liveness.isUnused(inst))
         .dead
     else
@@ -3614,7 +3613,6 @@ fn airRetLoad(self: *Self, inst: Air.Inst.Index) !void {
     const ptr = try self.resolveInst(un_op);
     const ptr_ty = self.air.typeOf(un_op);
     const ret_ty = self.fn_type.fnReturnType();
-    _ = ret_ty;
 
     switch (self.ret_mcv) {
         .none => {},
@@ -5099,7 +5097,6 @@ fn lowerDeclRef(self: *Self, tv: TypedValue, decl_index: Module.Decl.Index) Inne
     } else {
         return self.fail("TODO codegen non-ELF const Decl pointer", .{});
     }
-    _ = tv;
 }
 
 fn lowerUnnamedConst(self: *Self, tv: TypedValue) InnerError!MCValue {

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -2111,7 +2111,6 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    _ = inst;
     const result: MCValue = if (self.liveness.isUnused(inst))
         .dead
     else
@@ -3353,7 +3352,6 @@ fn divFloat(
 ) InnerError!MCValue {
     _ = lhs_bind;
     _ = rhs_bind;
-    _ = lhs_ty;
     _ = rhs_ty;
     _ = maybe_inst;
 
@@ -3420,7 +3418,6 @@ fn divExact(
 ) InnerError!MCValue {
     _ = lhs_bind;
     _ = rhs_bind;
-    _ = lhs_ty;
     _ = rhs_ty;
     _ = maybe_inst;
 
@@ -3506,7 +3503,6 @@ fn modulo(
 ) InnerError!MCValue {
     _ = lhs_bind;
     _ = rhs_bind;
-    _ = lhs_ty;
     _ = rhs_ty;
     _ = maybe_inst;
 

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1316,7 +1316,6 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    _ = inst;
     const result: MCValue = if (self.liveness.isUnused(inst))
         .dead
     else
@@ -1598,7 +1597,6 @@ fn airStructFieldPtrIndex(self: *Self, inst: Air.Inst.Index, index: u8) !void {
     return self.structFieldPtr(ty_op.operand, ty_op.ty, index);
 }
 fn structFieldPtr(self: *Self, operand: Air.Inst.Ref, ty: Air.Inst.Ref, index: u32) !void {
-    _ = self;
     _ = operand;
     _ = ty;
     _ = index;
@@ -1615,7 +1613,6 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airFieldParentPtr(self: *Self, inst: Air.Inst.Index) !void {
-    _ = self;
     _ = inst;
     return self.fail("TODO implement codegen airFieldParentPtr", .{});
 }

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -2084,9 +2084,7 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airSwitch(self: *Self, inst: Air.Inst.Index) !void {
-    _ = self;
     _ = inst;
-
     return self.fail("TODO implement switch for {}", .{self.target.cpu.arch});
 }
 

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -1960,7 +1960,6 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airErrReturnTrace(self: *Self, inst: Air.Inst.Index) !void {
-    _ = inst;
     const result: MCValue = if (self.liveness.isUnused(inst))
         .dead
     else
@@ -6590,7 +6589,6 @@ fn airFloatToInt(self: *Self, inst: Air.Inst.Index) !void {
 fn airCmpxchg(self: *Self, inst: Air.Inst.Index) !void {
     const ty_pl = self.air.instructions.items(.data)[inst].ty_pl;
     const extra = self.air.extraData(Air.Block, ty_pl.payload);
-    _ = ty_pl;
     _ = extra;
     return self.fail("TODO implement x86 airCmpxchg", .{});
     // return self.finishAir(inst, result, .{ extra.ptr, extra.expected_value, extra.new_value });

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -622,7 +622,6 @@ pub fn updateDeclExports(
 ) !void {
     try self.seeDecl(decl_index);
     // we do all the things in flush
-    _ = self;
     _ = module;
     _ = exports;
 }

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -324,7 +324,6 @@ const Writer = struct {
     fn writeNoOp(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
         _ = w;
         _ = inst;
-        _ = s;
         // no-op, no argument to write
     }
 

--- a/test/behavior/bugs/11165.zig
+++ b/test/behavior/bugs/11165.zig
@@ -14,7 +14,6 @@ test "bytes" {
         .a = undefined,
         .c = "12345".*, // this caused problems
     };
-    _ = s_1;
 
     var u_2 = U{ .s = s_1 };
     _ = u_2;
@@ -35,7 +34,6 @@ test "aggregate" {
         .a = undefined,
         .c = c, // this caused problems
     };
-    _ = s_1;
 
     var u_2 = U{ .s = s_1 };
     _ = u_2;

--- a/test/behavior/type.zig
+++ b/test/behavior/type.zig
@@ -486,7 +486,6 @@ test "Type.Union from Type.Enum" {
             .decls = &.{},
         },
     });
-    _ = T;
     _ = @typeInfo(T).Union;
 }
 
@@ -505,7 +504,6 @@ test "Type.Union from regular enum" {
             .decls = &.{},
         },
     });
-    _ = T;
     _ = @typeInfo(T).Union;
 }
 

--- a/test/behavior/type_info.zig
+++ b/test/behavior/type_info.zig
@@ -425,12 +425,8 @@ fn generic2(comptime T: type, param: T, param2: u8) void {
     _ = param;
     _ = param2;
 }
-fn generic3(param: anytype) @TypeOf(param) {
-    _ = param;
-}
-fn generic4(comptime param: anytype) @TypeOf(param) {
-    _ = param;
-}
+fn generic3(param: anytype) @TypeOf(param) {}
+fn generic4(comptime param: anytype) @TypeOf(param) {}
 
 test "typeInfo with comptime parameter in struct fn def" {
     const S = struct {

--- a/test/cases/compile_errors/non-comptime-parameter-used-as-array-size.zig
+++ b/test/cases/compile_errors/non-comptime-parameter-used-as-array-size.zig
@@ -6,7 +6,6 @@ export fn entry() void {
 }
 
 fn makeLlamas(count: usize) [count]u8 {
-    _ = count;
 }
 
 // error

--- a/test/cases/compile_errors/pointless discard.zig
+++ b/test/cases/compile_errors/pointless discard.zig
@@ -1,0 +1,12 @@
+export fn foo() void {
+    var x: i32 = 1234;
+    x += 1;
+    _ = x;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:9: error: pointless discard of local variable
+// :3:5: note: used here

--- a/test/cases/type_of.0.zig
+++ b/test/cases/type_of.0.zig
@@ -1,6 +1,5 @@
 pub fn main() void {
     var x: usize = 0;
-    _ = x;
     const z = @TypeOf(x, @as(u128, 5));
     assert(z == u128);
 }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -116,10 +116,10 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub export fn foo() void {
         \\    while (true) if (true) {
         \\        var a: c_int = 1;
-        \\        _ = a;
+        \\        _ = @TypeOf(a);
         \\    } else {
         \\        var b: c_int = 2;
-        \\        _ = b;
+        \\        _ = @TypeOf(b);
         \\    };
         \\    if (true) if (true) {};
         \\}
@@ -192,7 +192,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\        .B = 0,
         \\        .C = 0,
         \\    };
-        \\    _ = a;
+        \\    _ = @TypeOf(a);
         \\    {
         \\        const struct_Foo_1 = extern struct {
         \\            A: c_int,
@@ -204,7 +204,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\            .B = 0,
         \\            .C = 0,
         \\        };
-        \\        _ = a_2;
+        \\        _ = @TypeOf(a_2);
         \\    }
         \\}
     });
@@ -233,24 +233,24 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\        B: c_int,
         \\        C: c_int,
         \\    };
-        \\    _ = union_unnamed_1;
+        \\    _ = @TypeOf(union_unnamed_1);
         \\    const Foo = union_unnamed_1;
         \\    var a: Foo = Foo{
         \\        .A = @as(c_int, 0),
         \\    };
-        \\    _ = a;
+        \\    _ = @TypeOf(a);
         \\    {
         \\        const union_unnamed_2 = extern union {
         \\            A: c_int,
         \\            B: c_int,
         \\            C: c_int,
         \\        };
-        \\        _ = union_unnamed_2;
+        \\        _ = @TypeOf(union_unnamed_2);
         \\        const Foo_1 = union_unnamed_2;
         \\        var a_2: Foo_1 = Foo_1{
         \\            .A = @as(c_int, 0),
         \\        };
-        \\        _ = a_2;
+        \\        _ = @TypeOf(a_2);
         \\    }
         \\}
     });
@@ -318,7 +318,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    const bar_1 = struct {
         \\        threadlocal var static: c_int = 2;
         \\    };
-        \\    _ = bar_1;
+        \\    _ = @TypeOf(bar_1);
         \\    return 0;
         \\}
     });
@@ -337,7 +337,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
         \\pub export fn bar() c_int {
         \\    var a: c_int = 2;
-        \\    _ = a;
+        \\    _ = @TypeOf(a);
         \\    return 0;
         \\}
         \\pub export fn baz() c_int {
@@ -352,7 +352,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     , &[_][]const u8{
         \\pub export fn main() void {
         \\    var a: c_int = @bitCast(c_int, @truncate(c_uint, @alignOf(c_int)));
-        \\    _ = a;
+        \\    _ = @TypeOf(a);
         \\}
     });
 
@@ -500,7 +500,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\#define bar(x) (&x, +3, 4 == 4, 5 * 6, baz(1, 2), 2 % 2, baz(1,2))
     , &[_][]const u8{
         \\pub const foo = blk: {
-        \\    _ = foo;
+        \\    _ = @TypeOf(foo);
         \\    break :blk bar;
         \\};
         ,
@@ -724,7 +724,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub export fn function(arg_opaque_1: ?*struct_opaque) void {
         \\    var opaque_1 = arg_opaque_1;
         \\    var cast: ?*struct_opaque_2 = @ptrCast(?*struct_opaque_2, opaque_1);
-        \\    _ = cast;
+        \\    _ = @TypeOf(cast);
         \\}
     });
 
@@ -761,7 +761,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
             \\pub export fn my_fn() align(128) void {}
             \\pub export fn other_fn() void {
             \\    var ARR: [16]u8 align(16) = undefined;
-            \\    _ = ARR;
+            \\    _ = @TypeOf(ARR);
             \\}
         });
     }
@@ -798,17 +798,17 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     , &[_][]const u8{
         \\pub export fn foo() void {
         \\    var a: c_int = undefined;
-        \\    _ = a;
+        \\    _ = @TypeOf(a);
         \\    var b: u8 = 123;
-        \\    _ = b;
+        \\    _ = @TypeOf(b);
         \\    const c: c_int = undefined;
-        \\    _ = c;
+        \\    _ = @TypeOf(c);
         \\    const d: c_uint = @bitCast(c_uint, @as(c_int, 440));
-        \\    _ = d;
+        \\    _ = @TypeOf(d);
         \\    var e: c_int = 10;
-        \\    _ = e;
+        \\    _ = @TypeOf(e);
         \\    var f: c_uint = 10;
-        \\    _ = f;
+        \\    _ = @TypeOf(f);
         \\}
     });
 
@@ -867,7 +867,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    const v2 = struct {
         \\        const static: [5:0]u8 = "2.2.2".*;
         \\    };
-        \\    _ = v2;
+        \\    _ = @TypeOf(v2);
         \\}
     });
 
@@ -911,7 +911,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
             \\pub export fn bar() void {
             \\    var func_ptr: ?*anyopaque = @ptrCast(?*anyopaque, foo);
             \\    var typed_func_ptr: ?*const fn () callconv(.C) void = @intToPtr(?*const fn () callconv(.C) void, @intCast(c_ulong, @ptrToInt(func_ptr)));
-            \\    _ = typed_func_ptr;
+            \\    _ = @TypeOf(typed_func_ptr);
             \\}
         });
     }
@@ -1353,7 +1353,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     , &[_][]const u8{
         \\pub export fn foo() void {
         \\    var a: c_int = undefined;
-        \\    _ = a;
+        \\    _ = @TypeOf(a);
         \\}
     });
 
@@ -1524,23 +1524,23 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    var p: ?*anyopaque = undefined;
         \\    {
         \\        var to_char: [*c]u8 = @ptrCast([*c]u8, @alignCast(@import("std").meta.alignment([*c]u8), p));
-        \\        _ = to_char;
+        \\        _ = @TypeOf(to_char);
         \\        var to_short: [*c]c_short = @ptrCast([*c]c_short, @alignCast(@import("std").meta.alignment([*c]c_short), p));
-        \\        _ = to_short;
+        \\        _ = @TypeOf(to_short);
         \\        var to_int: [*c]c_int = @ptrCast([*c]c_int, @alignCast(@import("std").meta.alignment([*c]c_int), p));
-        \\        _ = to_int;
+        \\        _ = @TypeOf(to_int);
         \\        var to_longlong: [*c]c_longlong = @ptrCast([*c]c_longlong, @alignCast(@import("std").meta.alignment([*c]c_longlong), p));
-        \\        _ = to_longlong;
+        \\        _ = @TypeOf(to_longlong);
         \\    }
         \\    {
         \\        var to_char: [*c]u8 = @ptrCast([*c]u8, @alignCast(@import("std").meta.alignment([*c]u8), p));
-        \\        _ = to_char;
+        \\        _ = @TypeOf(to_char);
         \\        var to_short: [*c]c_short = @ptrCast([*c]c_short, @alignCast(@import("std").meta.alignment([*c]c_short), p));
-        \\        _ = to_short;
+        \\        _ = @TypeOf(to_short);
         \\        var to_int: [*c]c_int = @ptrCast([*c]c_int, @alignCast(@import("std").meta.alignment([*c]c_int), p));
-        \\        _ = to_int;
+        \\        _ = @TypeOf(to_int);
         \\        var to_longlong: [*c]c_longlong = @ptrCast([*c]c_longlong, @alignCast(@import("std").meta.alignment([*c]c_longlong), p));
-        \\        _ = to_longlong;
+        \\        _ = @TypeOf(to_longlong);
         \\    }
         \\}
     });
@@ -1786,11 +1786,11 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    var arr: [10]u8 = [1]u8{
         \\        1,
         \\    } ++ [1]u8{0} ** 9;
-        \\    _ = arr;
+        \\    _ = @TypeOf(arr);
         \\    var arr1: [10][*c]u8 = [1][*c]u8{
         \\        null,
         \\    } ++ [1][*c]u8{null} ** 9;
-        \\    _ = arr1;
+        \\    _ = @TypeOf(arr1);
         \\}
     });
 
@@ -2038,16 +2038,16 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub var c: c_int = 4;
         \\pub export fn foo(arg_c_1: u8) void {
         \\    var c_1 = arg_c_1;
-        \\    _ = c_1;
+        \\    _ = @TypeOf(c_1);
         \\    var a_2: c_int = undefined;
         \\    var b_3: u8 = 123;
         \\    b_3 = @bitCast(u8, @truncate(i8, a_2));
         \\    {
         \\        var d: c_int = 5;
-        \\        _ = d;
+        \\        _ = @TypeOf(d);
         \\    }
         \\    var d: c_uint = @bitCast(c_uint, @as(c_int, 440));
-        \\    _ = d;
+        \\    _ = @TypeOf(d);
         \\}
     });
 
@@ -2146,7 +2146,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    {
         \\        var i: c_int = 2;
         \\        var b: c_int = 4;
-        \\        _ = b;
+        \\        _ = @TypeOf(b);
         \\        while ((i + @as(c_int, 2)) != 0) : (i = 2) {
         \\            var a: c_int = 2;
         \\            _ = blk: {
@@ -2159,7 +2159,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\        }
         \\    }
         \\    var i: u8 = 2;
-        \\    _ = i;
+        \\    _ = @TypeOf(i);
         \\}
     });
 
@@ -2396,27 +2396,27 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     , &[_][]const u8{
         \\pub export fn escapes() [*c]const u8 {
         \\    var a: u8 = '\'';
-        \\    _ = a;
+        \\    _ = @TypeOf(a);
         \\    var b: u8 = '\\';
-        \\    _ = b;
+        \\    _ = @TypeOf(b);
         \\    var c: u8 = '\x07';
-        \\    _ = c;
+        \\    _ = @TypeOf(c);
         \\    var d: u8 = '\x08';
-        \\    _ = d;
+        \\    _ = @TypeOf(d);
         \\    var e: u8 = '\x0c';
-        \\    _ = e;
+        \\    _ = @TypeOf(e);
         \\    var f: u8 = '\n';
-        \\    _ = f;
+        \\    _ = @TypeOf(f);
         \\    var g: u8 = '\r';
-        \\    _ = g;
+        \\    _ = @TypeOf(g);
         \\    var h: u8 = '\t';
-        \\    _ = h;
+        \\    _ = @TypeOf(h);
         \\    var i: u8 = '\x0b';
-        \\    _ = i;
+        \\    _ = @TypeOf(i);
         \\    var j: u8 = '\x00';
-        \\    _ = j;
+        \\    _ = @TypeOf(j);
         \\    var k: u8 = '"';
-        \\    _ = k;
+        \\    _ = @TypeOf(k);
         \\    return "'\\\x07\x08\x0c\n\r\t\x0b\x00\"";
         \\}
     });
@@ -2612,7 +2612,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub export fn foo() c_int {
         \\    return blk: {
         \\        var a: c_int = 1;
-        \\        _ = a;
+        \\        _ = @TypeOf(a);
         \\        break :blk a;
         \\    };
         \\}
@@ -2716,7 +2716,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\int bar(void) { return 0; }
     , &[_][]const u8{
         \\pub inline fn CALL(arg: anytype) @TypeOf(bar()) {
-        \\    _ = arg;
+        \\    _ = @TypeOf(arg);
         \\    return bar();
         \\}
     });
@@ -2775,14 +2775,14 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub export fn foo() void {
         \\    if (true) {
         \\        var a: c_int = 2;
-        \\        _ = a;
+        \\        _ = @TypeOf(a);
         \\    }
         \\    if ((blk: {
         \\        _ = @as(c_int, 2);
         \\        break :blk @as(c_int, 5);
         \\    }) != 0) {
         \\        var a: c_int = 2;
-        \\        _ = a;
+        \\        _ = @TypeOf(a);
         \\    }
         \\}
     });
@@ -3285,7 +3285,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\#define a 2
     , &[_][]const u8{
         \\pub inline fn FOO(bar: anytype) @TypeOf(baz(@import("std").zig.c_translation.cast(?*anyopaque, baz))) {
-        \\    _ = bar;
+        \\    _ = @TypeOf(bar);
         \\    return baz(@import("std").zig.c_translation.cast(?*anyopaque, baz));
         \\}
         ,
@@ -3425,7 +3425,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     , &[_][]const u8{
         \\pub export fn foo(arg_a: [*c]c_int) void {
         \\    var a = arg_a;
-        \\    _ = a;
+        \\    _ = @TypeOf(a);
         \\}
         \\pub export fn bar(arg_a: [*c]const c_int) void {
         \\    var a = arg_a;
@@ -3785,12 +3785,12 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub export fn bar(arg_x: c_int, arg_y: c_int) c_int {
         \\    var x = arg_x;
         \\    var y = arg_y;
-        \\    _ = y;
+        \\    _ = @TypeOf(y);
         \\    return x;
         \\}
         ,
         \\pub inline fn FOO(A: anytype, B: anytype) @TypeOf(A) {
-        \\    _ = B;
+        \\    _ = @TypeOf(B);
         \\    return A;
         \\}
     });


### PR DESCRIPTION
Example:

```zig
test {
    var x: i32 = 1234;
    x += 1;
    _ = x;
}
```

```
test.zig:4:9: error: pointless discard of local variable
    _ = x;
        ^
test.zig:3:5: note: used here
    x += 1;
    ^
```

Related: #12803

----

 * Needs a compile error test added
 * I'm not sure why but this seemed to expose a latent bug:

```
thread 559744 panic: reached unreachable code
/home/andy/Downloads/zig/lib/std/debug.zig:281:14: 0xad82d8 in std.debug.assert (zig2)
    if (!ok) unreachable; // assertion failure
             ^
/home/andy/Downloads/zig/src/type.zig:2508:23: 0xf71d26 in type.Type.hasRuntimeBitsAdvanced (zig2)
                assert(union_obj.haveFieldTypes());
                      ^
/home/andy/Downloads/zig/src/type.zig:3041:62: 0xd41d42 in type.Type.abiAlignmentAdvanced (zig2)
                    if (!(try field.ty.hasRuntimeBitsAdvanced(false, sema_kit))) continue;
                                                             ^
/home/andy/Downloads/zig/src/type.zig:2800:44: 0x153ae9f in type.Type.lazyAbiAlignment (zig2)
        switch (try ty.abiAlignmentAdvanced(target, .{ .lazy = arena })) {
                                           ^
/home/andy/Downloads/zig/src/Sema.zig:14080:55: 0x12c6de8 in Sema.zirTypeInfo (zig2)
                try info.pointee_type.lazyAbiAlignment(target, sema.arena);
                                                      ^
/home/andy/Downloads/zig/src/Sema.zig:799:66: 0x112121b in Sema.analyzeBodyInner (zig2)
            .type_info                    => try sema.zirTypeInfo(block, inst),
                                                                 ^
/home/andy/Downloads/zig/src/Sema.zig:609:30: 0x111144a in Sema.analyzeBody (zig2)
    _ = sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                             ^
/home/andy/Downloads/zig/src/Sema.zig:6057:33: 0x151521f in Sema.analyzeCall (zig2)
                sema.analyzeBody(&child_block, fn_info.body) catch |err| switch (err) {
                                ^
/home/andy/Downloads/zig/src/Sema.zig:5595:28: 0x129f560 in Sema.zirCall (zig2)
    return sema.analyzeCall(block, func, func_src, call_src, modifier, ensure_result_used, resolved_args, bound_arg_src);
                           ^
/home/andy/Downloads/zig/src/Sema.zig:725:62: 0x111d60d in Sema.analyzeBodyInner (zig2)
            .call                         => try sema.zirCall(block, inst),
                                                             ^
/home/andy/Downloads/zig/src/Sema.zig:4850:34: 0x1536bea in Sema.resolveBlockBody (zig2)
        if (sema.analyzeBodyInner(child_block, body)) |_| {
                                 ^
/home/andy/Downloads/zig/src/Sema.zig:4833:33: 0x13382fc in Sema.zirBlock (zig2)
    return sema.resolveBlockBody(parent_block, src, &child_block, body, inst, &label.merges);
                                ^
/home/andy/Downloads/zig/src/Sema.zig:1239:69: 0x112a8f4 in Sema.analyzeBodyInner (zig2)
                if (!block.is_comptime) break :blk try sema.zirBlock(block, inst);
                                                                    ^
/home/andy/Downloads/zig/src/Sema.zig:609:30: 0x111144a in Sema.analyzeBody (zig2)
    _ = sema.analyzeBodyInner(block, body) catch |err| switch (err) {
                             ^
/home/andy/Downloads/zig/src/Module.zig:5570:21: 0xf419dd in Module.analyzeFnBody (zig2)
    sema.analyzeBody(&inner_block, fn_info.body) catch |err| switch (err) {
                    ^
/home/andy/Downloads/zig/src/Module.zig:4271:40: 0xf22b70 in Module.ensureFuncBodyAnalyzed (zig2)
            var air = mod.analyzeFnBody(func, sema_arena) catch |err| switch (err) {
                                       ^
/home/andy/Downloads/zig/src/Compilation.zig:2982:42: 0xc69c3a in Compilation.processOneJob (zig2)
            module.ensureFuncBodyAnalyzed(func) catch |err| switch (err) {
                                         ^
/home/andy/Downloads/zig/src/Compilation.zig:2920:30: 0xc58c47 in Compilation.performAllTheWork (zig2)
            try processOneJob(comp, work_item);
                             ^
/home/andy/Downloads/zig/src/Compilation.zig:2260:31: 0xc5155d in Compilation.update (zig2)
    try comp.performAllTheWork(main_progress_node);
                              ^
/home/andy/Downloads/zig/src/main.zig:3360:20: 0xbe0c6f in main.updateModule (zig2)
    try comp.update();
                   ^
/home/andy/Downloads/zig/src/main.zig:3034:17: 0xb38bbc in main.buildOutputType (zig2)
    updateModule(gpa, comp, hook) catch |err| switch (err) {
                ^
/home/andy/Downloads/zig/src/main.zig:230:31: 0xae51d7 in main.mainArgs (zig2)
        return buildOutputType(gpa, arena, args, .{ .build = .Exe });
                              ^
/home/andy/Downloads/zig/src/stage1.zig:48:24: 0xae4be9 in main (zig2)
        stage2.mainArgs(gpa, arena, args) catch unreachable;
                       ^
```

Happens when doing the standard cmake build for me.