### PR TITLE
Sema: Prevent coercion from tuple pointer to mutable slice

### DIFF
--- a/lib/std/fs/wasi.zig
+++ b/lib/std/fs/wasi.zig
@@ -201,7 +201,7 @@ pub const PreopenList = struct {
             // If we were provided a CWD root to resolve against, we try to treat Preopen dirs as
             // POSIX paths, relative to "/" or `cwd_root` depending on whether they start with "."
             const path = if (cwd_root) |cwd| blk: {
-                const resolve_paths: [][]const u8 = if (raw_path[0] == '.') &.{ cwd, raw_path } else &.{ "/", raw_path };
+                const resolve_paths: []const []const u8 = if (raw_path[0] == '.') &.{ cwd, raw_path } else &.{ "/", raw_path };
                 break :blk fs.path.resolve(self.buffer.allocator, resolve_paths) catch |err| switch (err) {
                     error.CurrentWorkingDirectoryUnlinked => unreachable, // root is absolute, so CWD not queried
                     else => |e| return e,

--- a/lib/std/x/net/bpf.zig
+++ b/lib/std/x/net/bpf.zig
@@ -691,14 +691,14 @@ test "tcpdump filter" {
     );
 }
 
-fn expectPass(data: anytype, filter: []Insn) !void {
+fn expectPass(data: anytype, filter: []const Insn) !void {
     try expectEqual(
         @as(u32, 0),
         try simulate(mem.asBytes(data), filter, .Big),
     );
 }
 
-fn expectFail(expected_error: anyerror, data: anytype, filter: []Insn) !void {
+fn expectFail(expected_error: anyerror, data: anytype, filter: []const Insn) !void {
     try expectError(
         expected_error,
         simulate(mem.asBytes(data), filter, native_endian),

--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -410,7 +410,7 @@ test "load pointer from packed struct" {
         y: u32,
     };
     var a: A = .{ .index = 123 };
-    var b_list: []B = &.{.{ .x = &a, .y = 99 }};
+    var b_list: []const B = &.{.{ .x = &a, .y = 99 }};
     for (b_list) |b| {
         var i = b.x.index;
         try expect(i == 123);

--- a/test/cases/compile_errors/stage2/tuple_ptr_to_mut_slice.zig
+++ b/test/cases/compile_errors/stage2/tuple_ptr_to_mut_slice.zig
@@ -1,0 +1,32 @@
+export fn entry1() void {
+    var a = .{ 1, 2, 3 };
+    _ = @as([]u8, &a);
+}
+export fn entry2() void {
+    var a = .{ @as(u8, 1), @as(u8, 2), @as(u8, 3) };
+    _ = @as([]u8, &a);
+}
+
+// runtime values
+var vals = [_]u7{ 4, 5, 6 };
+export fn entry3() void {
+    var a = .{ vals[0], vals[1], vals[2] };
+    _ = @as([]u8, &a);
+}
+export fn entry4() void {
+    var a = .{ @as(u8, vals[0]), @as(u8, vals[1]), @as(u8, vals[2]) };
+    _ = @as([]u8, &a);
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:19: error: cannot cast pointer to tuple to '[]u8'
+// :3:19: note: pointers to tuples can only coerce to constant pointers
+// :7:19: error: cannot cast pointer to tuple to '[]u8'
+// :7:19: note: pointers to tuples can only coerce to constant pointers
+// :14:19: error: cannot cast pointer to tuple to '[]u8'
+// :14:19: note: pointers to tuples can only coerce to constant pointers
+// :18:19: error: cannot cast pointer to tuple to '[]u8'
+// :18:19: note: pointers to tuples can only coerce to constant pointers


### PR DESCRIPTION
Closes #12821.
~~Also adds quick fix for seeming misuse of `pointerDecl`, should be audited at some point. This is just so that the CI passes.~~
Note: stage1 still does this.
Co-authored-by: topolarity [topolarity@tapscott.me](mailto:topolarity@tapscott.me)