### PR TITLE
std.testing: Reference all declarations with `refAllDecls` and `refAllDeclsRecursive`

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -727,7 +727,7 @@ pub fn checkAllAllocationFailures(backing_allocator: std.mem.Allocator, comptime
 pub fn refAllDecls(comptime T: type) void {
     if (!builtin.is_test) return;
     inline for (comptime std.meta.declarations(T)) |decl| {
-        if (decl.is_pub) _ = @field(T, decl.name);
+        _ = @field(T, decl.name);
     }
 }
 
@@ -735,14 +735,12 @@ pub fn refAllDecls(comptime T: type) void {
 /// For deep types, you may use `@setEvalBranchQuota`
 pub fn refAllDeclsRecursive(comptime T: type) void {
     inline for (comptime std.meta.declarations(T)) |decl| {
-        if (decl.is_pub) {
-            if (@TypeOf(@field(T, decl.name)) == type) {
-                switch (@typeInfo(@field(T, decl.name))) {
-                    .Struct, .Enum, .Union, .Opaque => refAllDeclsRecursive(@field(T, decl.name)),
-                    else => {},
-                }
+        if (@TypeOf(@field(T, decl.name)) == type) {
+            switch (@typeInfo(@field(T, decl.name))) {
+                .Struct, .Enum, .Union, .Opaque => refAllDeclsRecursive(@field(T, decl.name)),
+                else => {},
             }
-            _ = @field(T, decl.name);
         }
+        _ = @field(T, decl.name);
     }
 }


### PR DESCRIPTION
Fixes #12838.

With this PR, `std.testing.refAllDecls` and `std.testing.refAllDeclsRecursive` will allow the semantic analyzer to look at all declarations regardless their visibility (private or `pub`).

The motivation for this PR is as follows.

- As written in #12838, given that these two functions reside in the `testing` module, it would make much more sense to also reference private declarations.
- This makes the behavior of these functions align with [what the official doc shows](https://ziglang.org/documentation/master/#toc-Nested-Container-Tests).
