### PR TITLE
fix ChildProcess crash when PATH is empty.

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1814,7 +1814,7 @@ pub fn execvpeZ_expandArg0(
     var path_buf: [MAX_PATH_BYTES]u8 = undefined;
     var it = mem.tokenize(u8, PATH, ":");
     var seen_eacces = false;
-    var err: ExecveError = undefined;
+    var err: ExecveError = error.FileNotFound;
 
     // In case of expanding arg0 we must put it back if we return with an error.
     const prev_arg0 = child_argv[0];


### PR DESCRIPTION
by making the initial value for the variable `err` in the function `execvpeZ_expandArg0` of the file os.zig equal to `error.FileNotFound`. Closes #12816.

Explanation: The `execvpeZ_expandArg0` function was returning an undefined `err` because it never went into the while loop right after (because the PATH was empty) which I guess was causing the `invalid error code`. I fixed it by just making the `err` variable initially equal to `error.FileNotFound`. `error.FileNotFound` is returned for a PATH that is not empty where a command or executable could not be found.