### PR TITLE
make `fmt.formatAsciiChar` respect `options` parameter

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2726,6 +2726,9 @@ test "padding" {
     try expectFmt("==crêpe===", "{s:=^10}", .{"crêpe"});
     try expectFmt("=====crêpe", "{s:=>10}", .{"crêpe"});
     try expectFmt("crêpe=====", "{s:=<10}", .{"crêpe"});
+    try expectFmt("====a", "{c:=>5}", .{'a'});
+    try expectFmt("==a==", "{c:=^5}", .{'a'});
+    try expectFmt("a====", "{c:=<5}", .{'a'});
 }
 
 test "decimal float padding" {

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1004,8 +1004,7 @@ pub fn formatAsciiChar(
     options: FormatOptions,
     writer: anytype,
 ) !void {
-    _ = options;
-    return writer.writeAll(@as(*const [1]u8, &c));
+    return formatBuf(@as(*const [1]u8, &c), options, writer);
 }
 
 pub fn formatUnicodeCodepoint(


### PR DESCRIPTION
currently being ignored by `_ = options;`
thanks to Chuck in Zig discord