### PR TITLE
Update Nvptx backend for Zig 0.10

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -833,6 +833,7 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace, ret_addr
             // Didn't have boot_services, just fallback to whatever.
             std.os.abort();
         },
+        .cuda => std.os.abort(),
         else => {
             const first_trace_addr = ret_addr orelse @returnAddress();
             std.debug.panicImpl(error_return_trace, first_trace_addr, msg);

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -500,9 +500,14 @@ pub fn abort() noreturn {
         @breakpoint();
         exit(1);
     }
+    if (builtin.os.tag == .cuda) {
+        @"llvm.trap"();
+    }
 
     system.abort();
 }
+
+extern fn @"llvm.trap"() noreturn;
 
 pub const RaiseError = UnexpectedError;
 

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -501,6 +501,7 @@ pub fn abort() noreturn {
         exit(1);
     }
     if (builtin.os.tag == .cuda) {
+        // TODO: introduce `@trap` instead of abusing https://github.com/ziglang/zig/issues/2291
         @"llvm.trap"();
     }
 

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -951,6 +951,13 @@ pub const Target = struct {
                 };
             }
 
+            pub fn isNvptx(arch: Arch) bool {
+                return switch (arch) {
+                    .nvptx, .nvptx64 => true,
+                    else => false,
+                };
+            }
+
             pub fn parseCpuModel(arch: Arch, cpu_name: []const u8) !*const Cpu.Model {
                 for (arch.allCpuModels()) |cpu| {
                     if (mem.eql(u8, cpu_name, cpu.name)) {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -720,6 +720,15 @@ pub const Decl = struct {
         var buffer = std.ArrayList(u8).init(mod.gpa);
         defer buffer.deinit();
         try decl.renderFullyQualifiedName(mod, buffer.writer());
+
+        // Sanitize the name for nvptx which is more restrictive.
+        if (mod.comp.bin_file.options.target.cpu.arch.isNvptx()) {
+            for (buffer.items) |*byte| switch (byte.*) {
+                '{', '}', '*', '[', ']', '(', ')', ',', ' ', '\'' => byte.* = '_',
+                else => {},
+            };
+        }
+
         return buffer.toOwnedSliceSentinel(0);
     }
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -21397,7 +21397,12 @@ fn validateExternType(
         },
         .Fn => {
             if (position != .other) return false;
-            return !Type.fnCallingConventionAllowsZigTypes(ty.fnCallingConvention());
+            return switch (ty.fnCallingConvention()) {
+                // For now we want to authorize PTX kernel to use zig objects, even if we end up exposing the ABI.
+                // The goal is to experiment with more integrated CPU/GPU code.
+                .PtxKernel => true,
+                else => !Type.fnCallingConventionAllowsZigTypes(ty.fnCallingConvention()),
+            };
         },
         .Enum => {
             var buf: Type.Payload.Bits = undefined;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -18202,12 +18202,6 @@ fn zirAddrSpaceCast(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.Inst
     else
         dest_ptr_ty;
 
-    if (try sema.resolveMaybeUndefVal(block, ptr_src, ptr)) |val| {
-        // Pointer value should compatible with both address spaces.
-        // TODO: Figure out why this generates an invalid bitcast.
-        return sema.addConstant(dest_ty, val);
-    }
-
     try sema.requireRuntimeBlock(block, src, ptr_src);
     // TODO: Address space cast safety?
 

--- a/src/link/NvPtx.zig
+++ b/src/link/NvPtx.zig
@@ -76,7 +76,15 @@ pub fn updateFunc(self: *NvPtx, module: *Module, func: *Module.Fn, air: Air, liv
 
 pub fn updateDecl(self: *NvPtx, module: *Module, decl_index: Module.Decl.Index) !void {
     if (!build_options.have_llvm) return;
+    const decl = module.declPtr(decl_index);
+    log.info("updating {s}", .{decl.name});
     return self.llvm_object.updateDecl(module, decl_index);
+    // const decl_index = func.owner_decl;
+    // const decl = module.declPtr(decl_index);
+
+    // try mod.decl_exports.ensureUnusedCapacity(gpa, 1);
+    // try mod.export_owners.ensureUnusedCapacity(gpa, 1);
+    // mod.decl_exports.getOrPutAssumeCapacity(exported_decl_index);
 }
 
 pub fn updateDeclExports(

--- a/src/target.zig
+++ b/src/target.zig
@@ -655,7 +655,7 @@ pub fn addrSpaceCastIsValid(
     const arch = target.cpu.arch;
     switch (arch) {
         .x86_64, .i386 => return arch.supportsAddressSpace(from) and arch.supportsAddressSpace(to),
-        .amdgcn => {
+        .nvptx64, .nvptx, .amdgcn => {
             const to_generic = arch.supportsAddressSpace(from) and to == .generic;
             const from_generic = arch.supportsAddressSpace(to) and from == .generic;
             return to_generic or from_generic;

--- a/src/target.zig
+++ b/src/target.zig
@@ -411,8 +411,13 @@ pub fn classifyCompilerRtLibName(target: std.Target, name: []const u8) CompilerR
 }
 
 pub fn hasDebugInfo(target: std.Target) bool {
-    _ = target;
-    return true;
+    return switch (target.cpu.arch) {
+        .nvptx, .nvptx64 => {
+            // TODO: not sure to test "ptx >= 7.5" with featureset
+            return std.Target.nvptx.featureSetHas(target.cpu.features, .ptx75);
+        },
+        else => true
+    };
 }
 
 pub fn defaultCompilerRtOptimizeMode(target: std.Target) std.builtin.Mode {

--- a/src/target.zig
+++ b/src/target.zig
@@ -411,13 +411,12 @@ pub fn classifyCompilerRtLibName(target: std.Target, name: []const u8) CompilerR
 }
 
 pub fn hasDebugInfo(target: std.Target) bool {
-    return switch (target.cpu.arch) {
-        .nvptx, .nvptx64 => {
-            // TODO: not sure to test "ptx >= 7.5" with featureset
-            return std.Target.nvptx.featureSetHas(target.cpu.features, .ptx75);
-        },
-        else => true
-    };
+    if (target.cpu.arch.isNvptx()) {
+        // TODO: not sure how to test "ptx >= 7.5" with featureset
+        return std.Target.nvptx.featureSetHas(target.cpu.features, .ptx75);
+    }
+
+    return true;
 }
 
 pub fn defaultCompilerRtOptimizeMode(target: std.Target) std.builtin.Mode {

--- a/test/cases.zig
+++ b/test/cases.zig
@@ -4,6 +4,5 @@ const TestContext = @import("../src/test.zig").TestContext;
 pub fn addCases(ctx: *TestContext) !void {
     try @import("compile_errors.zig").addCases(ctx);
     try @import("stage2/cbe.zig").addCases(ctx);
-    // https://github.com/ziglang/zig/issues/10968
-    //try @import("stage2/nvptx.zig").addCases(ctx);
+    try @import("stage2/nvptx.zig").addCases(ctx);
 }

--- a/test/stage2/nvptx.zig
+++ b/test/stage2/nvptx.zig
@@ -25,7 +25,7 @@ pub fn addCases(ctx: *TestContext) !void {
         case.compiles(
             \\fn threadIdX() u32 {
             \\    return asm ("mov.u32 \t%[r], %tid.x;"
-            \\       : [r] "=r" (-> utid),
+            \\       : [r] "=r" (-> u32),
             \\    );
             \\}
             \\
@@ -54,12 +54,12 @@ pub fn addCases(ctx: *TestContext) !void {
         case.compiles(
             \\fn threadIdX() u32 {
             \\    return asm ("mov.u32 \t%[r], %tid.x;"
-            \\       : [r] "=r" (-> utid),
+            \\       : [r] "=r" (-> u32),
             \\    );
             \\}
             \\
             \\ var _sdata: [1024]f32 addrspace(.shared) = undefined;
-            \\ pub export fn reduceSum(d_x: []const f32, out: *f32) callconv(ptx.Kernel) void {
+            \\ pub export fn reduceSum(d_x: []const f32, out: *f32) callconv(.PtxKernel) void {
             \\     var sdata = @addrSpaceCast(.generic, &_sdata);
             \\     const tid: u32 = threadIdX();
             \\     var sum = d_x[tid];
@@ -99,6 +99,8 @@ pub fn addPtx(
         .files = std.ArrayList(TestContext.File).init(ctx.cases.allocator),
         .link_libc = false,
         .backend = .llvm,
+        // Bug in Debug mode
+        .optimize_mode = .ReleaseSafe,
     }) catch @panic("out of memory");
     return &ctx.cases.items[ctx.cases.items.len - 1];
 }


### PR DESCRIPTION
Due to the progress on 0.10 a few things broke Nvptx backend.

Some of the changes I'm pushing here are outside of  `link/NvPtx.zig`, and are modifying  shared code.
Let me know if you can think of a better way to structure the changes. From least controversial to more controversial.

* link/NvPtx.zig -> I'm modifying in place the "Compilation" object. Now I restore the changes before returning. A bit hacky but it allows to reuse the rest of the LLVM backend code without modification there.

* Target.zig -> PTX only support debug information starting from PTX 7.5. Not sure how to test "ptx >= 7.5".
 
* Sema.zig -> allow to use Zig objects in exported .PtxKernel functions. This allow tight integration between CPU/GPU code and was approved by Andrew given that we can change it later if we realize it was a bad idea to expose the ABI like this. https://github.com/ziglang/zig/issues/10397#issuecomment-1000709733

* Module.zig -> sanitize the name of variables. This is required because the names can be like "io.fixed_buffer_stream.FixedBufferStream([]u8).writer" and don't match the C-like identifiers expected by PTX.

Tagging @Snektron who expressed interest in this workstream and @Vexu who kindly merge previous PR (#10189)

Thanks to the progress of self hosted, we can now generate debug information in the PTX files. Also the assembly syntax now works as documented, so it's simpler to use special ptx registers. And I can use the same zig binary for building the device and host code, so it's pretty exciting.

See https://github.com/gwenzek/cudaz/tree/e8895596009c689300fe7c7193fa2dbf7db07629 for user code using this Zig branch. 