### PR TITLE
AstGen: store void_value to ptr when else body is empty

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -5608,7 +5608,11 @@ fn ifExpr(
         };
     } else .{
         .src = if_full.ast.then_expr,
-        .result = .none,
+        .result = switch (rl) {
+            // Explicitly store void to ptr result loc if there is no else branch
+            .ptr, .block_ptr => try rvalue(&else_scope, rl, .void_value, node),
+            else => .none,
+        },
     };
 
     const break_tag: Zir.Inst.Tag = if (parent_gz.force_comptime) .break_inline else .@"break";

--- a/test/cases/compile_errors/missing_else_clause.zig
+++ b/test/cases/compile_errors/missing_else_clause.zig
@@ -6,11 +6,32 @@ fn g(b: bool) void {
     const y = if (b) h: { break :h @as(i32, 1); };
     _ = y;
 }
-export fn entry() void { f(true); g(true); }
-
+fn h() void {
+    // https://github.com/ziglang/zig/issues/12743
+    const T = struct { oh_no: *u32 };
+    var x: T = if (false) {};
+    _ = x;
+}
+fn k(b: bool) void {
+    // block_ptr case
+    const T = struct { oh_no: u32 };
+    var x = if (b) blk: {
+        break :blk if (false) T{ .oh_no = 2 };
+    } else T{ .oh_no = 1 };
+    _ = x;
+}
+export fn entry() void {
+    f(true);
+    g(true);
+    h();
+    k(true);
+}
 // error
 // backend=stage2
 // target=native
 //
 // :2:21: error: incompatible types: 'i32' and 'void'
 // :6:15: error: incompatible types: 'i32' and 'void'
+// :12:16: error: expected type 'tmp.h.T', found 'void'
+// :11:15: note: struct declared here
+// :18:9: error: incompatible types: 'void' and 'tmp.k.T'


### PR DESCRIPTION
fix https://github.com/ziglang/zig/issues/12743

if not have else body, should be store void_value to the pointer explicitly.
