### PR TITLE
Avoid error trying to format broken symlinks

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4317,7 +4317,7 @@ fn fmtPathDir(
 
         if (is_dir and (mem.eql(u8, entry.name, "zig-cache") or mem.eql(u8, entry.name, "zig-out"))) continue;
 
-        if (is_dir or mem.endsWith(u8, entry.name, ".zig")) {
+        if (is_dir or entry.kind == .File and mem.endsWith(u8, entry.name, ".zig")) {
             const full_path = try fs.path.join(fmt.gpa, &[_][]const u8{ file_path, entry.name });
             defer fmt.gpa.free(full_path);
 


### PR DESCRIPTION
My specific use case is that my editor (emacs) creates temporary broken symlinks while editing a file (seems like a locking mechanism?) which causes `zig fmt` to error.  Some testing shows that formatting a non-broken symlink overwrites the symlink, which seems a bit unsafe, so I chose to just ignore symlinks completely.