### PR TITLE
emutls: avoid a panic cast causes pointer to be null

### DIFF
--- a/lib/compiler_rt/emutls.zig
+++ b/lib/compiler_rt/emutls.zig
@@ -182,13 +182,17 @@ const current_thread_storage = struct {
 
     /// Return casted thread specific value.
     fn getspecific() ?*ObjectArray {
-        return @ptrCast(
-            ?*ObjectArray,
-            @alignCast(
-                @alignOf(ObjectArray),
-                std.c.pthread_getspecific(current_thread_storage.key),
-            ),
-        );
+        if (std.c.pthread_getspecific(current_thread_storage.key)) |v| {
+            return @ptrCast(
+                ?*ObjectArray,
+                @alignCast(
+                    @alignOf(ObjectArray),
+                    v,
+                ),
+            );
+        } else {
+            return null;
+        }
     }
 
     /// Set casted thread specific value.


### PR DESCRIPTION
the `test.__emutls_get_address zeroed` is currently failing on OpenBSD.

```
Test [114/235] test.__emutls_get_address zeroed... thread 558531 panic: cast causes pointer to be null
compiler_rt/emutls.zig:189:42: 0x512ccb20748 in getspecific (test)
compiler_rt/emutls.zig:165:47: 0x512ccafe4d0 in getArray (test)
compiler_rt/emutls.zig:309:52: 0x512cca60d7f in getPointer (test)
compiler_rt/emutls.zig:28:30: 0x512cca3a244 in __emutls_get_address (test)
compiler_rt/emutls.zig:348:78: 0x512cca39f4f in test.__emutls_get_address zeroed (test)
/home/semarie/repos/ziglang/zig/lib/test_runner.zig:62:28: 0x512cca23560 in main (test)
        } else test_fn.func();
                           ^
/home/semarie/repos/ziglang/zig/lib/std/start.zig:568:22: 0x512cca24d88 in main (test)
            root.main();
                     ^
???:?:?: 0x512cca22d51 in ??? (???)
???:?:?: 0x0 in ??? (???)
error: the following test command crashed:
/home/semarie/repos/ziglang/zig/zig-cache/o/a7fd8945a015b5eb33a4d19249155233/test
error: test...
error: The following command exited with error code 1:
/home/semarie/repos/ziglang/zig/build/cmake/stage3/bin/zig test /home/semarie/repos/ziglang/zig/lib/compiler_rt.zig --test-name-prefix compiler-rt-native-Debug--multi-default  --cache-dir /home/semarie/repos/ziglang/zig/zig-cache --global-cache-dir /home/semarie/.cache/zig --name test -fno-single-threaded -I /home/semarie/repos/ziglang/zig/test --zig-lib-dir /home/semarie/repos/ziglang/zig/lib --enable-cache 
error: the following build command failed with exit code 1:
/home/semarie/repos/ziglang/zig/zig-cache/o/a1770ba974435a9bc0cea64f4e34ec4d/build /home/semarie/repos/ziglang/zig/build/cmake/stage3/bin/zig /home/semarie/repos/ziglang/zig /home/semarie/repos/ziglang/zig/zig-cache /home/semarie/.cache/zig test -Dskip-non-native
```

from the stacktrace, it is the cast in `getspecific()` which cause the problem, but I am really unsure why: `pthread_getspecific()` is expected to return an optional (here the panic occured when returned `null`), and `@ptrCast()` is also expected to be cope with the optional pointer (specially when cast to optional).

the PR workaround the problem by testing for `null` before casting, but I am unsure if it hides an underline problem or not.