### PR TITLE
std.os.uefi: fix some mistakes

### DIFF
--- a/lib/std/os/uefi/protocols/managed_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/managed_network_protocol.zig
@@ -15,7 +15,7 @@ pub const ManagedNetworkProtocol = extern struct {
     _transmit: std.meta.FnPtr(fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) callconv(.C) Status),
     _receive: std.meta.FnPtr(fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) callconv(.C) Status),
     _cancel: std.meta.FnPtr(fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkCompletionToken) callconv(.C) Status),
-    _poll: std.meta.FnPtr(fn (*const ManagedNetworkProtocol) callconv(.C) usize),
+    _poll: std.meta.FnPtr(fn (*const ManagedNetworkProtocol) callconv(.C) Status),
 
     /// Returns the operational parameters for the current MNP child driver.
     /// May also support returning the underlying SNP driver mode data.

--- a/lib/std/os/uefi/protocols/managed_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/managed_network_protocol.zig
@@ -31,8 +31,7 @@ pub const ManagedNetworkProtocol = extern struct {
     /// Translates an IP multicast address to a hardware (MAC) multicast address.
     /// This function may be unsupported in some MNP implementations.
     pub fn mcastIpToMac(self: *const ManagedNetworkProtocol, ipv6flag: bool, ipaddress: *const anyopaque, mac_address: *MacAddress) Status {
-        _ = mac_address;
-        return self._mcast_ip_to_mac(self, ipv6flag, ipaddress);
+        return self._mcast_ip_to_mac(self, ipv6flag, ipaddress, mac_address);
     }
 
     /// Enables and disables receive filters for multicast address.

--- a/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
@@ -10,7 +10,7 @@ pub const SimpleTextInputExProtocol = extern struct {
     _read_key_stroke_ex: std.meta.FnPtr(fn (*const SimpleTextInputExProtocol, *KeyData) callconv(.C) Status),
     wait_for_key_ex: Event,
     _set_state: std.meta.FnPtr(fn (*const SimpleTextInputExProtocol, *const u8) callconv(.C) Status),
-    _register_key_notify: std.meta.FnPtr(fn (*const SimpleTextInputExProtocol, *const KeyData, fn (*const KeyData) callconv(.C) usize, **anyopaque) callconv(.C) Status),
+    _register_key_notify: std.meta.FnPtr(fn (*const SimpleTextInputExProtocol, *const KeyData, std.meta.FnPtr(fn (*const KeyData) callconv(.C) usize), **anyopaque) callconv(.C) Status),
     _unregister_key_notify: std.meta.FnPtr(fn (*const SimpleTextInputExProtocol, *const anyopaque) callconv(.C) Status),
 
     /// Resets the input device hardware.
@@ -29,7 +29,7 @@ pub const SimpleTextInputExProtocol = extern struct {
     }
 
     /// Register a notification function for a particular keystroke for the input device.
-    pub fn registerKeyNotify(self: *const SimpleTextInputExProtocol, key_data: *const KeyData, notify: fn (*const KeyData) callconv(.C) usize, handle: **anyopaque) Status {
+    pub fn registerKeyNotify(self: *const SimpleTextInputExProtocol, key_data: *const KeyData, notify: std.meta.FnPtr(fn (*const KeyData) callconv(.C) usize), handle: **anyopaque) Status {
         return self._register_key_notify(self, key_data, notify, handle);
     }
 

--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -191,7 +191,7 @@ pub const BootServices = extern struct {
     pub const tpl_high_level: usize = 31;
 };
 
-pub const EfiEventNotify = fn (event: Event, ctx: *anyopaque) callconv(.C) void;
+pub const EfiEventNotify = std.meta.FnPtr(fn (event: Event, ctx: *anyopaque) callconv(.C) void);
 
 pub const TimerDelay = enum(u32) {
     TimerCancel,


### PR DESCRIPTION
This is an attempt to make `std.os.uefi` work with self-hosted (stage2); it is currently broken.

With this PR, the following now works:
```zig
const std = @import("std");

pub fn main() void {
    std.testing.refAllDeclsRecursive(std.os.uefi);
}
```
```
$ zig run x.zig --zig-lib-dir lib
$
```

However, it doesn't work with stage1:
```
$ zig run x.zig --zig-lib-dir lib -fstage1
./lib/std/os/uefi/protocols/simple_text_output_protocol.zig:7:38: error: struct 'std.os.uefi.protocols.simple_text_output_protocol.SimpleTextOutputProtocol' depends on itself
pub const SimpleTextOutputProtocol = extern struct {
                                     ^
./lib/std/os/uefi/tables/system_table.zig:27:5: note: while checking this field
    con_out: ?*SimpleTextOutputProtocol,
    ^
./lib/std/os/uefi/protocols/loaded_image_protocol.zig:10:33: error: struct 'std.os.uefi.protocols.loaded_image_protocol.LoadedImageProtocol' depends on itself
pub const LoadedImageProtocol = extern struct {
                                ^
```
This error only happens with the old compiler. I can't really figure out why. It only started happening after I added `std.meta.FnPtr`.
So I came here to get some feedback: is it fine to drop stage1 support for `std.os.uefi`? If so, we could also just use `*const Fn` directly instead of `std.meta.FnPtr(Fn)` where `std.meta.FnPtr` is supposed to serve for compatibility with both stage1 and stage2.

Also, the reason I changed all these `packed struct`s to `extern struct`s is because some of them were containing arrays and as we all know `packed struct`s can no longer have them so I thought that maybe these should all be `extern struct`s anyway so I just changed them all.
This might be wrong, which is why I'm asking for feedback or reviews.

CC @fifty-six