### PR TITLE
improve header searchlist handling in build, main

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -3119,7 +3119,7 @@ pub const LibExeObjStep = struct {
             try zig_args.append(builder.pathJoin(&.{
                 search_prefix, "lib",
             }));
-            try zig_args.append("-isystem");
+            try zig_args.append("-I");
             try zig_args.append(builder.pathJoin(&.{
                 search_prefix, "include",
             }));


### PR DESCRIPTION
build.zig:
- use `-I` instead of `-isystem` for `b.addSearchPrefix()`

main.zig:
- silently ignore superfluous search dirs
- warn when a dir is added to multiple searchlists
- consolidate "expected paramter after {s}" fatal error messages
- rename command-line switch `-dirafter` → `-idirafter`

closes #12888