### PR TITLE
GPA: return true when deinit is successful

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -16,6 +16,7 @@ pub const LogToWriterAllocator = @import("heap/log_to_writer_allocator.zig").Log
 pub const logToWriterAllocator = @import("heap/log_to_writer_allocator.zig").logToWriterAllocator;
 pub const ArenaAllocator = @import("heap/arena_allocator.zig").ArenaAllocator;
 pub const GeneralPurposeAllocator = @import("heap/general_purpose_allocator.zig").GeneralPurposeAllocator;
+pub const GPADeinitResult = @import("heap/general_purpose_allocator.zig").DeinitResult;
 
 const Allocator = mem.Allocator;
 

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -423,7 +423,7 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
             }
             self.large_allocations.deinit(self.backing_allocator);
             self.* = undefined;
-            return leaks;
+            return !leaks;
         }
 
         fn collectStackTrace(first_trace_addr: usize, addresses: *[stack_n]usize) void {
@@ -922,7 +922,7 @@ const test_config = Config{};
 
 test "small allocations - free in same order" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     var list = std.ArrayList(*u64).init(std.testing.allocator);
@@ -941,7 +941,7 @@ test "small allocations - free in same order" {
 
 test "small allocations - free in reverse order" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     var list = std.ArrayList(*u64).init(std.testing.allocator);
@@ -960,7 +960,7 @@ test "small allocations - free in reverse order" {
 
 test "large allocations" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     const ptr1 = try allocator.alloc(u64, 42768);
@@ -973,7 +973,7 @@ test "large allocations" {
 
 test "realloc" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     var slice = try allocator.alignedAlloc(u8, @alignOf(u32), 1);
@@ -995,7 +995,7 @@ test "realloc" {
 
 test "shrink" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     var slice = try allocator.alloc(u8, 20);
@@ -1018,7 +1018,7 @@ test "shrink" {
 
 test "large object - grow" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     var slice1 = try allocator.alloc(u8, page_size * 2 - 20);
@@ -1036,7 +1036,7 @@ test "large object - grow" {
 
 test "realloc small object to large object" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     var slice = try allocator.alloc(u8, 70);
@@ -1053,7 +1053,7 @@ test "realloc small object to large object" {
 
 test "shrink large object to large object" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     var slice = try allocator.alloc(u8, page_size * 2 + 50);
@@ -1076,7 +1076,7 @@ test "shrink large object to large object" {
 
 test "shrink large object to large object with larger alignment" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     var debug_buffer: [1000]u8 = undefined;
@@ -1112,7 +1112,7 @@ test "shrink large object to large object with larger alignment" {
 
 test "realloc large object to small object" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     var slice = try allocator.alloc(u8, page_size * 2 + 50);
@@ -1130,7 +1130,7 @@ test "overrideable mutexes" {
         .backing_allocator = std.testing.allocator,
         .mutex = std.Thread.Mutex{},
     };
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     const ptr = try allocator.create(i32);
@@ -1139,7 +1139,7 @@ test "overrideable mutexes" {
 
 test "non-page-allocator backing allocator" {
     var gpa = GeneralPurposeAllocator(.{}){ .backing_allocator = std.testing.allocator };
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     const ptr = try allocator.create(i32);
@@ -1148,7 +1148,7 @@ test "non-page-allocator backing allocator" {
 
 test "realloc large object to larger alignment" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     var debug_buffer: [1000]u8 = undefined;
@@ -1190,7 +1190,7 @@ test "realloc large object to larger alignment" {
 test "large object shrinks to small but allocation fails during shrink" {
     var failing_allocator = std.testing.FailingAllocator.init(std.heap.page_allocator, 3);
     var gpa = GeneralPurposeAllocator(.{}){ .backing_allocator = failing_allocator.allocator() };
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     var slice = try allocator.alloc(u8, page_size * 2 + 50);
@@ -1207,7 +1207,7 @@ test "large object shrinks to small but allocation fails during shrink" {
 
 test "objects of size 1024 and 2048" {
     var gpa = GeneralPurposeAllocator(test_config){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     const slice = try allocator.alloc(u8, 1025);
@@ -1219,7 +1219,7 @@ test "objects of size 1024 and 2048" {
 
 test "setting a memory cap" {
     var gpa = GeneralPurposeAllocator(.{ .enable_memory_limit = true }){};
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     gpa.setRequestedMemoryLimit(1010);
@@ -1246,11 +1246,11 @@ test "setting a memory cap" {
 test "double frees" {
     // use a GPA to back a GPA to check for leaks of the latter's metadata
     var backing_gpa = GeneralPurposeAllocator(.{ .safety = true }){};
-    defer std.testing.expect(!backing_gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(backing_gpa.deinit()) catch @panic("leak");
 
     const GPA = GeneralPurposeAllocator(.{ .safety = true, .never_unmap = true, .retain_metadata = true });
     var gpa = GPA{ .backing_allocator = backing_gpa.allocator() };
-    defer std.testing.expect(!gpa.deinit()) catch @panic("leak");
+    defer std.testing.expect(gpa.deinit()) catch @panic("leak");
     const allocator = gpa.allocator();
 
     // detect a small allocation double free, even though bucket is emptied

--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -32,7 +32,7 @@ pub fn main() void {
     for (test_fn_list) |test_fn, i| {
         std.testing.allocator_instance = .{};
         defer {
-            if (!std.testing.allocator_instance.deinit()) {
+            if (std.testing.allocator_instance.deinit() == std.heap.GPADeinitResult.leaking) {
                 leaks += 1;
             }
         }

--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -32,7 +32,7 @@ pub fn main() void {
     for (test_fn_list) |test_fn, i| {
         std.testing.allocator_instance = .{};
         defer {
-            if (std.testing.allocator_instance.deinit()) {
+            if (!std.testing.allocator_instance.deinit()) {
                 leaks += 1;
             }
         }


### PR DESCRIPTION
- gpa should return true when `deinit` is successful. Returning false when successful is counterintuitive and confusing.