### PR TITLE
zig cc: emit to a.out if outpath is unspecified

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2613,7 +2613,7 @@ fn buildOutputType(
             }
         },
         .yes_a_out => Compilation.EmitLoc{
-            .directory = null,
+            .directory = .{ .path = null, .handle = fs.cwd() },
             .basename = a_out_basename,
         },
     };


### PR DESCRIPTION
If `-o` is not specified for `zig cc` for linking, it should emit the `a.out` (or equivalent) to the current directory. So then this:

    $ zig cc test.c

Should result in `./a.out`.

If directory is omitted from `Compilation.EmitLoc`, it will default to the cache directory later in the compilation chain, which will result in `a.out` missing in the current directory.

If we specify the directory to `Compilation.EmitLoc`, it will be handled, allegedly, correctly.

Fixes #12858