### PR TITLE
std: add jsonStringify to ArrayList, StringHashMap and StringArrayHashMap

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -4,6 +4,7 @@ const assert = debug.assert;
 const testing = std.testing;
 const mem = std.mem;
 const math = std.math;
+const json = std.json;
 const Allocator = mem.Allocator;
 
 /// A contiguous, growable list of items in memory.
@@ -443,6 +444,14 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
         pub fn unusedCapacitySlice(self: Self) Slice {
             return self.allocatedSlice()[self.items.len..];
         }
+
+        pub fn jsonStringify(
+            self: Self,
+            options: json.StringifyOptions,
+            out_stream: anytype,
+        ) @TypeOf(out_stream).Error!void {
+            return json.stringify(self.items, options, out_stream);
+        }
     };
 }
 
@@ -829,6 +838,14 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
         /// modification of `self.items.len`.
         pub fn unusedCapacitySlice(self: Self) Slice {
             return self.allocatedSlice()[self.items.len..];
+        }
+
+        pub fn jsonStringify(
+            self: Self,
+            options: json.StringifyOptions,
+            out_stream: anytype,
+        ) @TypeOf(out_stream).Error!void {
+            return json.stringify(self.items, options, out_stream);
         }
     };
 }

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -6,6 +6,7 @@ const debug = std.debug;
 const math = std.math;
 const mem = std.mem;
 const meta = std.meta;
+const json = std.json;
 const trait = meta.trait;
 const Allocator = mem.Allocator;
 const Wyhash = std.hash.Wyhash;
@@ -672,6 +673,14 @@ pub fn HashMap(
         ) Allocator.Error!HashMap(K, V, @TypeOf(new_ctx), max_load_percentage) {
             var other = try self.unmanaged.cloneContext(new_allocator, new_ctx);
             return other.promoteContext(new_allocator, new_ctx);
+        }
+
+        pub fn jsonStringify(
+            self: Self,
+            options: json.StringifyOptions,
+            out_stream: anytype,
+        ) @TypeOf(out_stream).Error!void {
+            return self.unmanaged.jsonStringify(options, out_stream);
         }
     };
 }
@@ -1486,6 +1495,52 @@ pub fn HashMapUnmanaged(
             }
 
             return other;
+        }
+
+        pub fn jsonStringify(
+            self: Self,
+            options: json.StringifyOptions,
+            out_stream: anytype,
+        ) @TypeOf(out_stream).Error!void {
+            if (K != []const u8) {
+                @compileError("jsonStringify is only supported if the Key (" ++
+                    @typeName(K) ++
+                    ") is []const u8 because JSON Object keys are always strings." ++
+                    "Consider writing your own jsonStringify function");
+            }
+
+            try out_stream.writeByte('{');
+            var field_output = false;
+            var child_options = options;
+            if (child_options.whitespace) |*child_whitespace| {
+                child_whitespace.indent_level += 1;
+            }
+            var it = self.iterator();
+            while (it.next()) |entry| {
+                if (!field_output) {
+                    field_output = true;
+                } else {
+                    try out_stream.writeByte(',');
+                }
+                if (child_options.whitespace) |child_whitespace| {
+                    try child_whitespace.outputIndent(out_stream);
+                }
+
+                try json.stringify(entry.key_ptr.*, options, out_stream);
+                try out_stream.writeByte(':');
+                if (child_options.whitespace) |child_whitespace| {
+                    if (child_whitespace.separator) {
+                        try out_stream.writeByte(' ');
+                    }
+                }
+                try json.stringify(entry.value_ptr.*, child_options, out_stream);
+            }
+            if (field_output) {
+                if (options.whitespace) |whitespace| {
+                    try whitespace.outputIndent(out_stream);
+                }
+            }
+            try out_stream.writeByte('}');
         }
 
         fn grow(self: *Self, allocator: Allocator, new_capacity: Size, ctx: Context) Allocator.Error!void {

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1198,41 +1198,8 @@ pub const Value = union(enum) {
             .Float => |inner| try stringify(inner, options, out_stream),
             .NumberString => |inner| try out_stream.writeAll(inner),
             .String => |inner| try stringify(inner, options, out_stream),
-            .Array => |inner| try stringify(inner.items, options, out_stream),
-            .Object => |inner| {
-                try out_stream.writeByte('{');
-                var field_output = false;
-                var child_options = options;
-                if (child_options.whitespace) |*child_whitespace| {
-                    child_whitespace.indent_level += 1;
-                }
-                var it = inner.iterator();
-                while (it.next()) |entry| {
-                    if (!field_output) {
-                        field_output = true;
-                    } else {
-                        try out_stream.writeByte(',');
-                    }
-                    if (child_options.whitespace) |child_whitespace| {
-                        try child_whitespace.outputIndent(out_stream);
-                    }
-
-                    try stringify(entry.key_ptr.*, options, out_stream);
-                    try out_stream.writeByte(':');
-                    if (child_options.whitespace) |child_whitespace| {
-                        if (child_whitespace.separator) {
-                            try out_stream.writeByte(' ');
-                        }
-                    }
-                    try stringify(entry.value_ptr.*, child_options, out_stream);
-                }
-                if (field_output) {
-                    if (options.whitespace) |whitespace| {
-                        try whitespace.outputIndent(out_stream);
-                    }
-                }
-                try out_stream.writeByte('}');
-            },
+            .Array => |inner| try stringify(inner, options, out_stream),
+            .Object => |inner| try stringify(inner, options, out_stream),
         }
     }
 


### PR DESCRIPTION
This PR adds `jsonStringify` functions to `ArrayList`, `StringHashMap` and their variants so that they can be more easily converted into JSON strings. The status quo exposes the user to unexpected results because you either get their internal structure in json format or compiler errors when calling `std.json.stringify` on them which is unnecessary because these types seamlessly map into JSON Arrays or Objects and are already being used for that purpose by [std.json.Value](https://github.com/ziglang/zig/blob/4521456f66122c6348ef6980ae1eecdb94f4f110/lib/std/json.zig#L1179).

As an example, not having to write a `jsonStringify` function just because you are using an `ArrayList` in a deeply nested struct or being able to representing a map to arrays of objects as a `StringHashMap(ArrayList(MyStruct))` can be very useful. 

---

Unfortunately one issue `StringHashMap` face is when they encounter non utf-8 encoded bytes in their keys because they can't be correctly stringified. Right now `std.json.stringify` would fall back to encoding them as a JSON array which results in invalid JSON.

```zig
try std.json.stringify("\xff \xfa", .{}, stdout); // prints [255,32,250]

var map = std.StringHashMap(u32).init(allocator);
try map.put("\xff", 42);
try std.json.stringify(map, .{}, stdout);// prints {[255]:42}
```