### PR TITLE
Sema: `evalutate` → `evaluate` in error message

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -20401,7 +20401,7 @@ fn requireFunctionBlock(sema: *Sema, block: *Block, src: LazySrcLoc) !void {
 fn requireRuntimeBlock(sema: *Sema, block: *Block, src: LazySrcLoc, runtime_src: ?LazySrcLoc) !void {
     if (block.is_comptime) {
         const msg = msg: {
-            const msg = try sema.errMsg(block, src, "unable to evalutate comptime expression", .{});
+            const msg = try sema.errMsg(block, src, "unable to evaluate comptime expression", .{});
             errdefer msg.destroy(sema.gpa);
 
             if (runtime_src) |some| {

--- a/test/cases/compile_errors/asm_at_compile_time.zig
+++ b/test/cases/compile_errors/asm_at_compile_time.zig
@@ -14,5 +14,5 @@ fn doSomeAsm() void {
 // backend=llvm
 // target=native
 //
-// :6:5: error: unable to evalutate comptime expression
+// :6:5: error: unable to evaluate comptime expression
 // :2:14: note: called from here


### PR DESCRIPTION
Typo fix.