### PR TITLE
Properly handle --name with folder separators

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -941,6 +941,8 @@ fn buildOutputType(
                         };
                     } else if (mem.eql(u8, arg, "--name")) {
                         provided_name = args_iter.nextOrFatal();
+                        if (!mem.eql(u8, provided_name.?, fs.path.basename(provided_name.?)))
+                            fatal("invalid package name '{s}': cannot contain folder separators", .{provided_name.?});
                     } else if (mem.eql(u8, arg, "-rpath")) {
                         try rpath_list.append(args_iter.nextOrFatal());
                     } else if (mem.eql(u8, arg, "--library-directory") or mem.eql(u8, arg, "-L")) {


### PR DESCRIPTION
For #10501. Basic use case:
```
# (in build/)
stage3/bin/zig build-exe --name hello/a <source file>
```
Outputs to `hello/a`, or if `hello` doesn't exist, fails with `error: unable to open output directory 'hello': FileNotFound`