### PR TITLE
Fix all std lib tests being run for any file within the std package

### DIFF
--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -853,7 +853,7 @@ fn walkInstruction(
             var path = str_tok.get(file.zir);
 
             const maybe_other_package: ?*Package = blk: {
-                if (self.module.main_pkg_in_std and std.mem.eql(u8, path, "std")) {
+                if (self.module.main_pkg_is_std and std.mem.eql(u8, path, "std")) {
                     path = "root";
                     break :blk self.module.main_pkg;
                 } else {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1588,10 +1588,10 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             try main_pkg.add(gpa, "root", root_pkg);
             try main_pkg.addAndAdopt(gpa, "std", std_pkg);
 
-            const main_pkg_in_std = m: {
+            const main_pkg_is_std = m: {
                 const std_path = try std.fs.path.resolve(arena, &[_][]const u8{
                     std_pkg.root_src_directory.path orelse ".",
-                    std.fs.path.dirname(std_pkg.root_src_path) orelse ".",
+                    std_pkg.root_src_path,
                 });
                 defer arena.free(std_path);
                 const main_path = try std.fs.path.resolve(arena, &[_][]const u8{
@@ -1599,7 +1599,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
                     main_pkg.root_src_path,
                 });
                 defer arena.free(main_path);
-                break :m mem.startsWith(u8, main_path, std_path);
+                break :m mem.eql(u8, main_path, std_path);
             };
 
             // Pre-open the directory handles for cached ZIR code so that it does not need
@@ -1638,7 +1638,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
                 .gpa = gpa,
                 .comp = comp,
                 .main_pkg = main_pkg,
-                .main_pkg_in_std = main_pkg_in_std,
+                .main_pkg_is_std = main_pkg_is_std,
                 .root_pkg = root_pkg,
                 .zig_cache_artifact_directory = zig_cache_artifact_directory,
                 .global_zir_cache = global_zir_cache,

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -142,7 +142,7 @@ job_queued_update_builtin_zig: bool = true,
 /// This makes it so that we can run `zig test` on the standard library.
 /// Otherwise, the logic for scanning test decls skips all of them because
 /// `main_pkg != std_pkg`.
-main_pkg_in_std: bool,
+main_pkg_is_std: bool,
 
 compile_log_text: ArrayListUnmanaged(u8) = .{},
 
@@ -5171,7 +5171,7 @@ fn scanDecl(iter: *ScanDeclIter, decl_sub_index: usize, flags: u4) Allocator.Err
                 // the test name filter.
                 if (!comp.bin_file.options.is_test) break :blk false;
                 if (decl_pkg != mod.main_pkg) {
-                    if (!mod.main_pkg_in_std) break :blk false;
+                    if (!mod.main_pkg_is_std) break :blk false;
                     const std_pkg = mod.main_pkg.table.get("std").?;
                     if (std_pkg != decl_pkg) break :blk false;
                 }
@@ -5182,7 +5182,7 @@ fn scanDecl(iter: *ScanDeclIter, decl_sub_index: usize, flags: u4) Allocator.Err
                 if (!is_named_test) break :blk false;
                 if (!comp.bin_file.options.is_test) break :blk false;
                 if (decl_pkg != mod.main_pkg) {
-                    if (!mod.main_pkg_in_std) break :blk false;
+                    if (!mod.main_pkg_is_std) break :blk false;
                     const std_pkg = mod.main_pkg.table.get("std").?;
                     if (std_pkg != decl_pkg) break :blk false;
                 }


### PR DESCRIPTION
Before this commit:

```
$ zig test lib/std/fs/test.zig --main-pkg-path lib/std --zig-lib-dir lib
2170 passed; 37 skipped; 0 failed.
```

After this commit:

```
$ zig test lib/std/fs/test.zig --main-pkg-path lib/std --zig-lib-dir lib
All 45 tests passed.
```

This matches stage1 behavior:

```
$ zig test -fstage1 lib/std/fs/test.zig --main-pkg-path lib/std --zig-lib-dir lib
All 45 tests passed.
```

All tests are still run if `zig test` is run directly on `lib/std/std.zig`:

```
$ zig test lib/std/std.zig --main-pkg-path lib/std --zig-lib-dir lib
2170 passed; 37 skipped; 0 failed.
```

`zig build test-std` is unaffected by this change.

Closes #12926

---

Prior relevant commits for context:
- 3b60ab4872355f0b9a9c7d0794ca8b548ab99412
- ec95e00e28cb23f37dc097f71afd7090e947a1cd