### PR TITLE
llvm: fix missing unwind info (wrong uwtable attribute value)

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2572,7 +2572,7 @@ pub const DeclGen = struct {
         }
         dg.addFnAttr(llvm_fn, "nounwind");
         if (comp.unwind_tables) {
-            dg.addFnAttrString(llvm_fn, "uwtable", "sync");
+            dg.addFnAttrInt(llvm_fn, "uwtable", 2);
         }
         if (comp.bin_file.options.skip_linker_dependencies or
             comp.bin_file.options.no_builtin)

--- a/src/stage1/codegen.cpp
+++ b/src/stage1/codegen.cpp
@@ -223,7 +223,7 @@ static ZigLLVM_CallingConv get_llvm_cc(CodeGen *g, CallingConvention cc) {
 
 static void add_uwtable_attr(CodeGen *g, LLVMValueRef fn_val) {
     if (g->unwind_tables) {
-        addLLVMFnAttrStr(fn_val, "uwtable", "sync");
+        addLLVMFnAttrInt(fn_val, "uwtable", 2);
     }
 }
 


### PR DESCRIPTION
I noticed (https://github.com/ziglang/zig/pull/12740#issuecomment-1257112045) that after the LLVM 15 update, the exception record (unwind info) was missing from the COFF info.

This seems to be caused by an incorrect attribute value for `uwtable`. Based on https://llvm.org/docs/LangRef.html it, the options are (0: off, 1: sync, 2: async). 

I'm not familiar enough with the difference between the sync/async, but it seems like async was the default previously and has the most detailed unwind info.



