### PR TITLE
std.enums.EnumFieldStruct: add explicit cast for default_value

### DIFF
--- a/lib/compiler_rt/emutls.zig
+++ b/lib/compiler_rt/emutls.zig
@@ -296,7 +296,7 @@ const emutls_control = extern struct {
             .size = @sizeOf(T),
             .alignment = @alignOf(T),
             .object = .{ .index = 0 },
-            .default_value = @ptrCast(?*anyopaque, default_value),
+            .default_value = @ptrCast(?*const anyopaque, default_value),
         };
     }
 


### PR DESCRIPTION
This is needed if the field type happens to be a pointer/slice, addresses #12957.