### PR TITLE
Shema: improve source location in errors

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -10705,6 +10705,7 @@ fn zirShl(
 
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src = inst_data.src();
+    sema.src = src;
     const lhs_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
     const rhs_src: LazySrcLoc = .{ .node_offset_bin_rhs = inst_data.src_node };
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
@@ -10878,6 +10879,7 @@ fn zirShr(
 
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src = inst_data.src();
+    sema.src = src;
     const lhs_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
     const rhs_src: LazySrcLoc = .{ .node_offset_bin_rhs = inst_data.src_node };
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
@@ -11000,6 +11002,7 @@ fn zirBitwise(
 
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src: LazySrcLoc = .{ .node_offset_bin_op = inst_data.src_node };
+    sema.src = src;
     const lhs_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
     const rhs_src: LazySrcLoc = .{ .node_offset_bin_rhs = inst_data.src_node };
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
@@ -11633,6 +11636,7 @@ fn zirArithmetic(
 fn zirDiv(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src: LazySrcLoc = .{ .node_offset_bin_op = inst_data.src_node };
+    sema.src = src;
     const lhs_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
     const rhs_src: LazySrcLoc = .{ .node_offset_bin_rhs = inst_data.src_node };
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
@@ -11786,6 +11790,7 @@ fn zirDiv(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Ins
 fn zirDivExact(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src: LazySrcLoc = .{ .node_offset_bin_op = inst_data.src_node };
+    sema.src = src;
     const lhs_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
     const rhs_src: LazySrcLoc = .{ .node_offset_bin_rhs = inst_data.src_node };
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
@@ -11942,6 +11947,7 @@ fn zirDivExact(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
 fn zirDivFloor(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src: LazySrcLoc = .{ .node_offset_bin_op = inst_data.src_node };
+    sema.src = src;
     const lhs_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
     const rhs_src: LazySrcLoc = .{ .node_offset_bin_rhs = inst_data.src_node };
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
@@ -12053,6 +12059,7 @@ fn zirDivFloor(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
 fn zirDivTrunc(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src: LazySrcLoc = .{ .node_offset_bin_op = inst_data.src_node };
+    sema.src = src;
     const lhs_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
     const rhs_src: LazySrcLoc = .{ .node_offset_bin_rhs = inst_data.src_node };
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
@@ -12289,6 +12296,7 @@ fn airTag(block: *Block, is_int: bool, normal: Air.Inst.Tag, optimized: Air.Inst
 fn zirModRem(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src: LazySrcLoc = .{ .node_offset_bin_op = inst_data.src_node };
+    sema.src = src;
     const lhs_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
     const rhs_src: LazySrcLoc = .{ .node_offset_bin_rhs = inst_data.src_node };
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
@@ -12474,6 +12482,7 @@ fn intRemScalar(
 fn zirMod(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src: LazySrcLoc = .{ .node_offset_bin_op = inst_data.src_node };
+    sema.src = src;
     const lhs_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
     const rhs_src: LazySrcLoc = .{ .node_offset_bin_rhs = inst_data.src_node };
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
@@ -12576,6 +12585,7 @@ fn zirMod(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Ins
 fn zirRem(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const inst_data = sema.code.instructions.items(.data)[inst].pl_node;
     const src: LazySrcLoc = .{ .node_offset_bin_op = inst_data.src_node };
+    sema.src = src;
     const lhs_src: LazySrcLoc = .{ .node_offset_bin_lhs = inst_data.src_node };
     const rhs_src: LazySrcLoc = .{ .node_offset_bin_rhs = inst_data.src_node };
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;

--- a/test/cases/compile_errors/assign_to_constant_variable.zig
+++ b/test/cases/compile_errors/assign_to_constant_variable.zig
@@ -1,6 +1,74 @@
-export fn f() void {
-    const a = 3;
-    a = 4;
+export fn entry1() void {
+    const a = 1;
+    a = 1;
+}
+export fn entry2() void {
+    const a = 1;
+    a |= 1;
+}
+export fn entry3() void {
+    const a = 1;
+    a %= 1;
+}
+export fn entry4() void {
+    const a = 1;
+    a ^= 1;
+}
+export fn entry5() void {
+    const a = 1;
+    a += 1;
+}
+export fn entry6() void {
+    const a = 1;
+    a +%= 1;
+}
+export fn entry7() void {
+    const a = 1;
+    a +|= 1;
+}
+export fn entry8() void {
+    const a = 1;
+    a -= 1;
+}
+export fn entry9() void {
+    const a = 1;
+    a -%= 1;
+}
+export fn entry10() void {
+    const a = 1;
+    a -|= 1;
+}
+export fn entry11() void {
+    const a = 1;
+    a *= 1;
+}
+export fn entry12() void {
+    const a = 1;
+    a *%= 1;
+}
+export fn entry13() void {
+    const a = 1;
+    a *|= 1;
+}
+export fn entry14() void {
+    const a = 1;
+    a /= 1;
+}
+export fn entry15() void {
+    const a = 1;
+    a &= 1;
+}
+export fn entry16() void {
+    const a = 1;
+    a <<= 1;
+}
+export fn entry17() void {
+    const a = 1;
+    a <<|= 1;
+}
+export fn entry18() void {
+    const a = 1;
+    a >>= 1;
 }
 
 // error
@@ -8,3 +76,20 @@ export fn f() void {
 // target=native
 //
 // :3:9: error: cannot assign to constant
+// :7:7: error: cannot assign to constant
+// :11:7: error: cannot assign to constant
+// :15:7: error: cannot assign to constant
+// :19:7: error: cannot assign to constant
+// :23:7: error: cannot assign to constant
+// :27:7: error: cannot assign to constant
+// :31:7: error: cannot assign to constant
+// :35:7: error: cannot assign to constant
+// :39:7: error: cannot assign to constant
+// :43:7: error: cannot assign to constant
+// :47:7: error: cannot assign to constant
+// :51:7: error: cannot assign to constant
+// :55:7: error: cannot assign to constant
+// :59:7: error: cannot assign to constant
+// :63:7: error: cannot assign to constant
+// :67:7: error: cannot assign to constant
+// :71:7: error: cannot assign to constant


### PR DESCRIPTION
resolves #12793


All operators mentioned in the issue ( `^=` `&=` `|=`  `/=` `%=` `<<=` `<<|=` `>>=` ) are now having correct error location. 
For example:
```zig
main.zig:3:10: error: cannot assign to constant
    data ^= 1;
    ~~~~~^~~~
```