### PR TITLE
Fix #12091: Error message with TERM=dumb is missing info

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -429,25 +429,23 @@ pub const AllErrors = struct {
                         try stderr.print(" ({d} times)\n", .{src.count});
                     }
                     ttyconf.setColor(stderr, .Reset);
-                    if (ttyconf != .no_color) {
-                        if (src.source_line) |line| {
-                            for (line) |b| switch (b) {
-                                '\t' => try stderr.writeByte(' '),
-                                else => try stderr.writeByte(b),
-                            };
-                            try stderr.writeByte('\n');
-                            // TODO basic unicode code point monospace width
-                            const before_caret = src.span.main - src.span.start;
-                            // -1 since span.main includes the caret
-                            const after_caret = src.span.end - src.span.main -| 1;
-                            try stderr.writeByteNTimes(' ', src.column - before_caret);
-                            ttyconf.setColor(stderr, .Green);
-                            try stderr.writeByteNTimes('~', before_caret);
-                            try stderr.writeByte('^');
-                            try stderr.writeByteNTimes('~', after_caret);
-                            try stderr.writeByte('\n');
-                            ttyconf.setColor(stderr, .Reset);
-                        }
+                    if (src.source_line) |line| {
+                        for (line) |b| switch (b) {
+                            '\t' => try stderr.writeByte(' '),
+                            else => try stderr.writeByte(b),
+                        };
+                        try stderr.writeByte('\n');
+                        // TODO basic unicode code point monospace width
+                        const before_caret = src.span.main - src.span.start;
+                        // -1 since span.main includes the caret
+                        const after_caret = src.span.end - src.span.main -| 1;
+                        try stderr.writeByteNTimes(' ', src.column - before_caret);
+                        ttyconf.setColor(stderr, .Green);
+                        try stderr.writeByteNTimes('~', before_caret);
+                        try stderr.writeByte('^');
+                        try stderr.writeByteNTimes('~', after_caret);
+                        try stderr.writeByte('\n');
+                        ttyconf.setColor(stderr, .Reset);
                     }
                     for (src.notes) |note| {
                         try note.renderToWriter(ttyconf, stderr, "note", .Cyan, indent);

--- a/src/test.zig
+++ b/src/test.zig
@@ -1662,6 +1662,7 @@ pub const TestContext = struct {
                                         var msg: Compilation.AllErrors.Message = actual_error;
                                         msg.src.src_path = case_msg.src.src_path;
                                         msg.src.notes = &.{};
+                                        msg.src.source_line = null;
                                         var fib = std.io.fixedBufferStream(&buf);
                                         try msg.renderToWriter(.no_color, fib.writer(), "error", .Red, 0);
                                         var it = std.mem.split(u8, fib.getWritten(), "error: ");


### PR DESCRIPTION
Probably at some point after the if statement was added, ttyconf.setColor was refactored to internally be a noop if ttyconf == .no_color, so this whole condition is now unnecessary, as far as I can tell.