### PR TITLE
stage2: Include `catch` expressions in error return trace

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -425,6 +425,9 @@ fn callFn(comptime f: anytype, args: anytype) switch (Impl) {
             @call(.auto, f, args) catch |err| {
                 std.debug.print("error: {s}\n", .{@errorName(err)});
                 if (@errorReturnTrace()) |trace| {
+                    if (builtin.zig_backend != .stage1)
+                        trace.index -= 1; // exclude this error-handling block
+
                     std.debug.dumpStackTrace(trace.*);
                 }
             };

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -532,6 +532,9 @@ inline fn initEventLoopAndCallMain() u8 {
             loop.init() catch |err| {
                 std.log.err("{s}", .{@errorName(err)});
                 if (@errorReturnTrace()) |trace| {
+                    if (builtin.zig_backend != .stage1)
+                        trace.index -= 1; // exclude this error-handling block
+
                     std.debug.dumpStackTrace(trace.*);
                 }
                 return 1;
@@ -561,6 +564,9 @@ inline fn initEventLoopAndCallWinMain() std.os.windows.INT {
             loop.init() catch |err| {
                 std.log.err("{s}", .{@errorName(err)});
                 if (@errorReturnTrace()) |trace| {
+                    if (builtin.zig_backend != .stage1)
+                        trace.index -= 1; // exclude this error-handling block
+
                     std.debug.dumpStackTrace(trace.*);
                 }
                 return 1;
@@ -617,6 +623,9 @@ pub fn callMain() u8 {
             const result = root.main() catch |err| {
                 std.log.err("{s}", .{@errorName(err)});
                 if (@errorReturnTrace()) |trace| {
+                    if (builtin.zig_backend != .stage1)
+                        trace.index -= 1; // exclude this error-handling block
+
                     std.debug.dumpStackTrace(trace.*);
                 }
                 return 1;

--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -78,6 +78,9 @@ pub fn main() void {
                 fail_count += 1;
                 progress.log("FAIL ({s})\n", .{@errorName(err)});
                 if (@errorReturnTrace()) |trace| {
+                    if (builtin.zig_backend != .stage1)
+                        trace.index -= 1; // exclude this error-handling block
+
                     std.debug.dumpStackTrace(trace.*);
                 }
                 test_node.end();

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2638,6 +2638,7 @@ pub const Inst = struct {
         },
         save_err_ret_index: struct {
             operand: Ref, // If error type (or .none), save new trace index
+            emit_ret_trace_entry: bool, // Add this location to the error trace
         },
         restore_err_ret_index: struct {
             block: Ref, // If restored, the index is from this block's entrypoint

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -2306,7 +2306,7 @@ const Writer = struct {
         const inst_data = self.code.instructions.items(.data)[inst].save_err_ret_index;
 
         try self.writeInstRef(stream, inst_data.operand);
-        try stream.writeAll(")");
+        try stream.print(", emit_ret_trace_entry={})", .{inst_data.emit_ret_trace_entry});
     }
 
     fn writeRestoreErrRetIndex(self: *Writer, stream: anytype, inst: Zir.Inst.Index) !void {

--- a/test/stack_traces.zig
+++ b/test/stack_traces.zig
@@ -329,6 +329,9 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             \\source.zig:2:5: [address] in foo (test)
             \\    return error.TheSkyIsFalling;
             \\    ^
+            \\source.zig:6:18: [address] in main (test)
+            \\    return foo() catch error.AndMyCarIsOutOfGas;
+            \\                 ^
             \\source.zig:6:5: [address] in main (test)
             \\    return foo() catch error.AndMyCarIsOutOfGas;
             \\    ^
@@ -345,6 +348,9 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             \\source.zig:2:5: [address] in [function]
             \\    return error.TheSkyIsFalling;
             \\    ^
+            \\source.zig:6:18: [address] in [function]
+            \\    return foo() catch error.AndMyCarIsOutOfGas;
+            \\                 ^
             \\source.zig:6:5: [address] in [function]
             \\    return foo() catch error.AndMyCarIsOutOfGas;
             \\    ^
@@ -585,6 +591,9 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             \\source.zig:2:5: [address] in foo (test)
             \\    return error.TheSkyIsFalling;
             \\    ^
+            \\source.zig:10:11: [address] in main (test)
+            \\    foo() catch { // error trace should include foo()
+            \\          ^
             \\source.zig:6:5: [address] in bar (test)
             \\    return error.AndMyCarIsOutOfGas;
             \\    ^
@@ -603,6 +612,9 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             \\source.zig:2:5: [address] in [function]
             \\    return error.TheSkyIsFalling;
             \\    ^
+            \\source.zig:10:11: [address] in [function]
+            \\    foo() catch { // error trace should include foo()
+            \\          ^
             \\source.zig:6:5: [address] in [function]
             \\    return error.AndMyCarIsOutOfGas;
             \\    ^
@@ -649,6 +661,9 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             \\source.zig:2:5: [address] in foo (test)
             \\    return error.TheSkyIsFalling;
             \\    ^
+            \\source.zig:10:23: [address] in main (test)
+            \\    if (foo()) |_| {} else |_| { // error trace should include foo()
+            \\                      ^
             \\source.zig:6:5: [address] in bar (test)
             \\    return error.AndMyCarIsOutOfGas;
             \\    ^
@@ -667,6 +682,9 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             \\source.zig:2:5: [address] in [function]
             \\    return error.TheSkyIsFalling;
             \\    ^
+            \\source.zig:10:23: [address] in [function]
+            \\    if (foo()) |_| {} else |_| { // error trace should include foo()
+            \\                      ^
             \\source.zig:6:5: [address] in [function]
             \\    return error.AndMyCarIsOutOfGas;
             \\    ^


### PR DESCRIPTION
Follow-up to #12837. Wanted to separate this one out since it's a change to UX.

The idea is to make it easier to track errors that flow through a catch block:

```zig
fn foo() !void { return error.BigIssue; }
fn bar() !void { return error.AnotherProblem; }
fn baz() !void {
    return bar();
}
test {
    foo() catch {
        try baz();
    };
}
```

```console
./test_err9.zig:1:18: 0x2117c8 in foo (test)
fn foo() !void { return error.BigIssue; }
                 ^
./test_err9.zig:7:11: 0x211918 in test_0 (test)
    foo() catch {
          ^
./test_err9.zig:2:18: 0x2118e8 in bar (test)
fn bar() !void { return error.AnotherProblem; }
                 ^
./test_err9.zig:4:5: 0x2118ce in baz (test)
    return bar();
    ^
./test_err9.zig:8:9: 0x211934 in test_0 (test)
        try baz();
        ^
```

This trace makes it clear that an error arrived in `test_0` and then was handled unsuccessfully.

Any `if (foo()) |non_err| { ... } else |err| { ... }` expressions are also included in the return trace.

Dependent on #12837 , only the last commit is specific to this PR.
