### PR TITLE
Sema: Fixed segfault arising from @TypeOf bug with packed struct field alignments

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -17682,6 +17682,10 @@ fn reifyStruct(
         }
         const abi_align = @intCast(u29, (try alignment_val.getUnsignedIntAdvanced(target, sema.kit(block, src))).?);
 
+        if (layout == .Packed and abi_align != 0) {
+            return sema.fail(block, src, "alignment in a packed struct field must be set to 0", .{});
+        }
+
         const field_name = try name_val.toAllocatedBytes(
             Type.initTag(.const_slice_u8),
             new_decl_arena_allocator,

--- a/test/cases/compile_errors/packed_struct_field_alignment_unavailable_for_reify_type.zig
+++ b/test/cases/compile_errors/packed_struct_field_alignment_unavailable_for_reify_type.zig
@@ -1,0 +1,11 @@
+export fn entry() void {
+    _ = @Type(.{ .Struct = .{ .layout = .Packed, .fields = &.{
+        .{ .name = "one", .field_type = u4, .default_value = null, .is_comptime = false, .alignment = 2 },
+    }, .decls = &.{}, .is_tuple = false } });
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:9: error: alignment in a packed struct field must be set to 0


### PR DESCRIPTION
Fixes #13028.

Added a check to see if the alignment in each field is set to 0.
Now `@typeInfo` does not produce a segfault if the alignment is set to anything other than 0.