### PR TITLE
stage2: fix branches on undefined values

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4430,6 +4430,8 @@ pub fn semaFile(mod: *Module, file: *File) SemaError!void {
     new_decl.has_linksection_or_addrspace = false;
     new_decl.ty = ty_ty;
     new_decl.val = struct_val;
+    new_decl.@"align" = 0;
+    new_decl.@"linksection" = null;
     new_decl.has_tv = true;
     new_decl.owns_tv = true;
     new_decl.alive = true; // This Decl corresponds to a File and is therefore always alive.

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2335,6 +2335,7 @@ pub const Object = struct {
         const stack_trace_decl = builtin_namespace.decls
             .getKeyAdapted(stack_trace_str, Module.DeclAdapter{ .mod = mod }).?;
 
+        mod.ensureDeclAnalyzed(stack_trace_decl) catch unreachable;
         return mod.declPtr(stack_trace_decl).val.toType(undefined);
     }
 };

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2332,10 +2332,13 @@ pub const Object = struct {
         // buffer is only used for int_type, `builtin` is a struct.
         const builtin_ty = mod.declPtr(builtin_decl).val.toType(undefined);
         const builtin_namespace = builtin_ty.getNamespace().?;
-        const stack_trace_decl = builtin_namespace.decls
+        const stack_trace_decl_index = builtin_namespace.decls
             .getKeyAdapted(stack_trace_str, Module.DeclAdapter{ .mod = mod }).?;
+        const stack_trace_decl = mod.declPtr(stack_trace_decl_index);
 
-        return mod.declPtr(stack_trace_decl).val.toType(undefined);
+        // Sema should have ensured that StackTrace was analyzed.
+        assert(stack_trace_decl.has_tv);
+        return stack_trace_decl.val.toType(undefined);
     }
 };
 

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2335,7 +2335,6 @@ pub const Object = struct {
         const stack_trace_decl = builtin_namespace.decls
             .getKeyAdapted(stack_trace_str, Module.DeclAdapter{ .mod = mod }).?;
 
-        mod.ensureDeclAnalyzed(stack_trace_decl) catch unreachable;
         return mod.declPtr(stack_trace_decl).val.toType(undefined);
     }
 };

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -97,4 +97,6 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     // Disabled due to tripping LLVM 13 assertion:
     // https://github.com/ziglang/zig/issues/12015
     //cases.add("tools/update_spirv_features.zig");
+
+    cases.addBuildFile("test/standalone/issue_13030/build.zig", .{ .build_modes = true });
 }

--- a/test/standalone/issue_13030/build.zig
+++ b/test/standalone/issue_13030/build.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Builder = std.build.Builder;
+const CrossTarget = std.zig.CrossTarget;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+    const target = b.standardTargetOptions(.{});
+
+    const obj = b.addObject("main", "main.zig");
+    obj.setBuildMode(mode);
+
+    obj.setTarget(target);
+    b.default_step.dependOn(&obj.step);
+
+    const test_step = b.step("test", "Test the program");
+    test_step.dependOn(&obj.step);
+}

--- a/test/standalone/issue_13030/main.zig
+++ b/test/standalone/issue_13030/main.zig
@@ -1,7 +1,7 @@
-fn b(comptime T: type) ?@import("std").meta.FnPtr(fn () error{}!T) {
+fn b(comptime T: type) ?*const fn () error{}!T {
     return null;
 }
 
-export fn c() void {
+export fn entry() void {
     _ = b(void);
 }

--- a/test/standalone/issue_13030/main.zig
+++ b/test/standalone/issue_13030/main.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+fn a() error{}!void {}
+fn b() std.meta.FnPtr(fn () error{}!void) {
+    return &a;
+}
+export fn c() void {
+    _ = b();
+}

--- a/test/standalone/issue_13030/main.zig
+++ b/test/standalone/issue_13030/main.zig
@@ -1,8 +1,7 @@
-const std = @import("std");
-fn a() error{}!void {}
-fn b() std.meta.FnPtr(fn () error{}!void) {
-    return &a;
+fn b(comptime T: type) ?@import("std").meta.FnPtr(fn () error{}!T) {
+    return null;
 }
+
 export fn c() void {
-    _ = b();
+    _ = b(void);
 }


### PR DESCRIPTION
Fixes #13030 and #12933, but does not address https://github.com/ziglang/zig/issues/12933#issuecomment-1255658710, which I cannot reproduce locally.

~~I do not have much experience with stage2 internals yet, so if a reviewer could confirm that `ensureDeclAnalyzed` can be called from this context, since there are currently no other calls to it in `llvm.zig`.~~  A subsequent error makes it clear that this was, indeed, the wrong approach, so I worked out another solution that makes much more sense.