### PR TITLE
std.ChildProcess: correct fn getUserInfo pkg in setUserName

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -122,7 +122,7 @@ pub const ChildProcess = struct {
     }
 
     pub fn setUserName(self: *ChildProcess, name: []const u8) !void {
-        const user_info = try os.getUserInfo(name);
+        const user_info = try std.process.getUserInfo(name);
         self.uid = user_info.uid;
         self.gid = user_info.gid;
     }


### PR DESCRIPTION
17b0166e moved getUserInfo from std.os to std.process but ChildProcess.setUserName never updated the pkg name.