### PR TITLE
llvm: fix missing global initializers in llvm module

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2633,6 +2633,8 @@ pub const DeclGen = struct {
                 if (variable.data.is_weak_linkage) llvm_global.setLinkage(.ExternalWeak);
             }
         } else {
+            // Ensure the llvm module remains valid even if we decide to not codegen an initializer.
+            llvm_global.setInitializer(llvm_type.getUndef());
             llvm_global.setLinkage(.Internal);
             llvm_global.setUnnamedAddr(.True);
         }

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -83,6 +83,7 @@ test {
     _ = @import("behavior/bugs/11213.zig");
     _ = @import("behavior/bugs/11816.zig");
     _ = @import("behavior/bugs/12003.zig");
+    _ = @import("behavior/bugs/12025.zig");
     _ = @import("behavior/bugs/12033.zig");
     _ = @import("behavior/bugs/12430.zig");
     _ = @import("behavior/bugs/12486.zig");

--- a/test/behavior/bugs/12025.zig
+++ b/test/behavior/bugs/12025.zig
@@ -1,0 +1,10 @@
+test {
+    comptime var st = .{
+        .foo = &1,
+        .bar = &2,
+    };
+
+    inline for (@typeInfo(@TypeOf(st)).Struct.fields) |field| {
+        _ = field;
+    }
+}

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -99,4 +99,5 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     //cases.add("tools/update_spirv_features.zig");
 
     cases.addBuildFile("test/standalone/issue_13030/build.zig", .{ .build_modes = true });
+    cases.addBuildFile("test/standalone/issue_12588/build.zig", .{});
 }

--- a/test/standalone/issue_12588/build.zig
+++ b/test/standalone/issue_12588/build.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+    const target = b.standardTargetOptions(.{});
+
+    const obj = b.addObject("main", "main.zig");
+    obj.setBuildMode(mode);
+    obj.setTarget(target);
+    obj.emit_llvm_ir = .emit;
+    obj.emit_llvm_bc = .emit;
+    obj.emit_bin = .no_emit;
+    b.default_step.dependOn(&obj.step);
+
+    const test_step = b.step("test", "Test the program");
+    test_step.dependOn(&obj.step);
+}

--- a/test/standalone/issue_12588/build.zig
+++ b/test/standalone/issue_12588/build.zig
@@ -8,8 +8,8 @@ pub fn build(b: *Builder) void {
     const obj = b.addObject("main", "main.zig");
     obj.setBuildMode(mode);
     obj.setTarget(target);
-    obj.emit_llvm_ir = .emit;
-    obj.emit_llvm_bc = .emit;
+    obj.emit_llvm_ir = .{ .emit_to = b.pathFromRoot("main.ll") };
+    obj.emit_llvm_bc = .{ .emit_to = b.pathFromRoot("main.bc") };
     obj.emit_bin = .no_emit;
     b.default_step.dependOn(&obj.step);
 

--- a/test/standalone/issue_12588/main.zig
+++ b/test/standalone/issue_12588/main.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+
+export fn strFromFloatHelp(float: f64) void {
+    var buf: [400]u8 = undefined;
+    _ = std.fmt.bufPrint(&buf, "{d}", .{float}) catch unreachable;
+}


### PR DESCRIPTION
Fixes #12025 and #12588 by emitting a dummy initializer to catch various cases where we don't want to codegen one.