### PR TITLE
stage2: fix C ABI for bool

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -10277,6 +10277,7 @@ fn ccAbiPromoteInt(
         else => {},
     }
     const int_info = switch (ty.zigTypeTag()) {
+        .Bool => Type.@"u1".intInfo(target),
         .Int, .Enum, .ErrorSet => ty.intInfo(target),
         else => return null,
     };


### PR DESCRIPTION
Before this change, if I take a debug zig dynamically linked to release llvm 15.0.1 compiled with release stage3 zig, and run `build-obj` on this program:
```zig
export fn f() void {}
```
I get the following output:
```
LLVM Emit Object... 
function definition may only have a distinct !dbg attachment
ptr @f

thread 27187 panic: LLVM module verification failed
codegen/llvm.zig:773:17: 0x90c2eb in flushModule (zig)
link/Elf.zig:960:47: 0x922c7c in flushModule (zig)
link/Elf.zig:1250:29: 0x91763b in linkWithLLD (zig)
link/Elf.zig:946:32: 0x908378 in flush (zig)
/home/jacob/Source/zig/src/link.zig:655:68: 0x905795 in flush (zig)
            .elf => return @fieldParentPtr(Elf, "base", base).flush(comp, prog_node),
                                                                   ^
/home/jacob/Source/zig/src/Compilation.zig:2440:24: 0xa75943 in flush (zig)
    comp.bin_file.flush(comp, prog_node) catch |err| switch (err) {
                       ^
/home/jacob/Source/zig/src/Compilation.zig:2421:23: 0xa77dfb in update (zig)
        try comp.flush(main_progress_node);
                      ^
/home/jacob/Source/zig/src/main.zig:3376:20: 0xaa2776 in updateModule (zig)
    try comp.update();
                   ^
/home/jacob/Source/zig/src/main.zig:3061:17: 0x822c1f in buildOutputType (zig)
    updateModule(gpa, comp, hook) catch |err| switch (err) {
                ^
/home/jacob/Source/zig/src/main.zig:234:31: 0x7fc4d8 in mainArgs (zig)
        return buildOutputType(gpa, arena, args, .{ .build = .Obj });
                              ^
/home/jacob/Source/zig/src/main.zig:174:20: 0x7fba00 in main (zig)
    return mainArgs(gpa, arena, args);
                   ^
/home/jacob/Source/zig/lib/std/start.zig:578:37: 0x7fdf31 in main (zig)
            const result = root.main() catch |err| {
                                    ^
Aborted
```
This is due to a miscompilation of the debug zig executable which causes `is_local_to_unit` to be incorrectly passed to `ZigLLVMCreateFunction`, which propagates into `DISubprogram::toSPFlags` in the release llvm shared library, which then misbehaves and returns the wrong value, which results in zig producing a corrupted llvm module.