### PR TITLE
Cache: resolve symlinks when manipulating file names

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1022,7 +1022,7 @@ fn addPackageTableToCacheHash(
     pkg_table: Package.Table,
     seen_table: *std.AutoHashMap(*Package, void),
     hash_type: union(enum) { path_bytes, files: *Cache.Manifest },
-) (error{OutOfMemory} || std.os.GetCwdError)!void {
+) (error{OutOfMemory} || std.os.RealPathError)!void {
     const allocator = arena.allocator();
 
     const packages = try allocator.alloc(Package.Table.KV, pkg_table.count());


### PR DESCRIPTION
Imagine someone (hey there, nice to meet you!) pointing `ZIG_LIB_DIR` to a relative directory from different directories. For example, Bazel prepares a "sandbox environment" (3 of those below) and sets up symlink farms akin to this:

    sandbox/1: lib -> ../lib
    sandbox/2: lib -> ../lib
    sandbox/3: lib -> ../lib

Then goes on to compiling our C file with a command like this:

    ZIG_LIB_DIR=lib path/to/zig cc <...>

All would be good, except that two instances of `zig cc` executed in `sandbox/1` and `sandbox/2` respectively do not share the zig cache, even though they are both pointed to the same lib directory. Badness ensures, we have thousands and thousands of `libc++.a` files in our cache directory, and CPU doing the same work over and over again.

Problem is in how the lib files are resolved and normalized: we do not follow the symlinks. Let's follow the symlinks! We have two options here:

1. Do not make paths absolute and put them as-is to the repository cache. This feels like a robust-enough approach, because `zig_lib_dir` is part of all the cache keys anyway. I couldn't find a funtion that normalizes a relative path in stdlib though, and wasn't sure I did think about all the cases.
2. Be paranoic, like me in this PR, and resolve the symlinks. That's more work (an extra syscall for every file), but has a lower chance of messing up somewhere else.

Fixes #13050