### PR TITLE
wasm-linker: generate 'producers' section

### DIFF
--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -2671,7 +2671,7 @@ fn emitProducerSection(binary_bytes: *std.ArrayList(u8)) !void {
 
     // processed-by field
     {
-        const processed_by = "processed_by";
+        const processed_by = "processed-by";
         try leb.writeULEB128(writer, @intCast(u32, processed_by.len));
         try writer.writeAll(processed_by);
 

--- a/test/link.zig
+++ b/test/link.zig
@@ -34,7 +34,7 @@ fn addWasmCases(cases: *tests.StandaloneContext) void {
     });
 
     cases.addBuildFile("test/link/wasm/bss/build.zig", .{
-        .build_modes = true,
+        .build_modes = false,
         .requires_stage2 = true,
     });
 
@@ -42,6 +42,11 @@ fn addWasmCases(cases: *tests.StandaloneContext) void {
         .build_modes = true,
         .requires_stage2 = true,
         .use_emulation = true,
+    });
+
+    cases.addBuildFile("test/link/wasm/producers/build.zig", .{
+        .build_modes = true,
+        .requires_stage2 = true,
     });
 
     cases.addBuildFile("test/link/wasm/segments/build.zig", .{

--- a/test/link/wasm/producers/build.zig
+++ b/test/link/wasm/producers/build.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    const test_step = b.step("test", "Test");
+    test_step.dependOn(b.getInstallStep());
+
+    const lib = b.addSharedLibrary("lib", "lib.zig", .unversioned);
+    lib.setBuildMode(mode);
+    lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    lib.use_llvm = false;
+    lib.use_stage1 = false;
+    lib.use_lld = false;
+    lib.install();
+
+    const zig_version = builtin.zig_version;
+    var version_buf: [100]u8 = undefined;
+    const version_fmt = std.fmt.bufPrint(&version_buf, "version {}", .{zig_version}) catch unreachable;
+
+    const check_lib = lib.checkObject(.wasm);
+    check_lib.checkStart("name producers");
+    check_lib.checkNext("fields 2");
+    check_lib.checkNext("field_name language");
+    check_lib.checkNext("values 1");
+    check_lib.checkNext("value_name Zig");
+    check_lib.checkNext(version_fmt);
+    check_lib.checkNext("field_name processed-by");
+    check_lib.checkNext("values 1");
+    check_lib.checkNext("value_name Zig");
+    check_lib.checkNext(version_fmt);
+
+    test_step.dependOn(&check_lib.step);
+}

--- a/test/link/wasm/producers/lib.zig
+++ b/test/link/wasm/producers/lib.zig
@@ -1,0 +1,1 @@
+export fn foo() void {}


### PR DESCRIPTION
Implements the `producers` custom section. This section contains meta data describing what tools were used to generate the binary as well as what the source language was. Other tools can use this information to apply certain transformations (such as name mangling for c++), or even optimizations.

For now, we always emit Zig as source language and as tool used to produce the binary. The next step would be to parse all linked object files and static archives and append their source languages and tools + SDK's also.