### PR TITLE
llvm: fix bug lowering aggregate_init with a byref sentinel

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -4311,13 +4311,17 @@ pub const FuncGen = struct {
         const gop = try self.func_inst_table.getOrPut(self.dg.gpa, inst);
         if (gop.found_existing) return gop.value_ptr.*;
 
-        const val = self.air.value(inst).?;
-        const ty = self.air.typeOf(inst);
-        const llvm_val = try self.dg.lowerValue(.{ .ty = ty, .val = val });
-        if (!isByRef(ty)) {
-            gop.value_ptr.* = llvm_val;
-            return llvm_val;
-        }
+        const llvm_val = try self.resolveValue(.{
+            .ty = self.air.typeOf(inst),
+            .val = self.air.value(inst).?,
+        });
+        gop.value_ptr.* = llvm_val;
+        return llvm_val;
+    }
+
+    fn resolveValue(self: *FuncGen, tv: TypedValue) !*llvm.Value {
+        const llvm_val = try self.dg.lowerValue(tv);
+        if (!isByRef(tv.ty)) return llvm_val;
 
         // We have an LLVM value but we need to create a global constant and
         // set the value as its initializer, and then return a pointer to the global.
@@ -4327,15 +4331,13 @@ pub const FuncGen = struct {
         global.setLinkage(.Private);
         global.setGlobalConstant(.True);
         global.setUnnamedAddr(.True);
-        global.setAlignment(ty.abiAlignment(target));
+        global.setAlignment(tv.ty.abiAlignment(target));
         // Because of LLVM limitations for lowering certain types such as unions,
         // the type of global constants might not match the type it is supposed to
         // be, and so we must bitcast the pointer at the usage sites.
-        const wanted_llvm_ty = try self.dg.lowerType(ty);
+        const wanted_llvm_ty = try self.dg.lowerType(tv.ty);
         const wanted_llvm_ptr_ty = wanted_llvm_ty.pointerType(0);
-        const casted_ptr = global.constBitCast(wanted_llvm_ptr_ty);
-        gop.value_ptr.* = casted_ptr;
-        return casted_ptr;
+        return global.constBitCast(wanted_llvm_ptr_ty);
     }
 
     fn genBody(self: *FuncGen, body: []const Air.Inst.Index) Error!void {
@@ -8852,7 +8854,7 @@ pub const FuncGen = struct {
                         llvm_usize.constInt(@intCast(c_uint, array_info.len), .False),
                     };
                     const elem_ptr = self.builder.buildInBoundsGEP(llvm_result_ty, alloca_inst, &indices, indices.len, "");
-                    const llvm_elem = try self.dg.lowerValue(.{
+                    const llvm_elem = try self.resolveValue(.{
                         .ty = array_info.elem_type,
                         .val = sent_val,
                     });

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -98,6 +98,7 @@ test {
     _ = @import("behavior/bugs/12911.zig");
     _ = @import("behavior/bugs/12928.zig");
     _ = @import("behavior/bugs/12945.zig");
+    _ = @import("behavior/bugs/12972.zig");
     _ = @import("behavior/bugs/12984.zig");
     _ = @import("behavior/byteswap.zig");
     _ = @import("behavior/byval_arg_var.zig");

--- a/test/behavior/bugs/12972.zig
+++ b/test/behavior/bugs/12972.zig
@@ -1,0 +1,17 @@
+const builtin = @import("builtin");
+
+pub fn f(_: [:null]const ?u8) void {}
+
+test {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+
+    const c: u8 = 42;
+    f(&[_:null]?u8{c});
+    f(&.{c});
+
+    var v: u8 = 42;
+    f(&[_:null]?u8{v});
+    f(&.{v});
+}


### PR DESCRIPTION
I tried auditing the other calls to `lowerValue`, and it seems like they all use types which can't (at least currently) be byval.
However, I'm not sure if they should also call `resolveValue` anyway for consistency/future-proofing.

Closes #12972