### PR TITLE
Compilation: strip debug info from ReleaseSmall by default

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -309,15 +309,15 @@ pub fn build(b: *Builder) !void {
                 .Debug => {},
                 .ReleaseFast => {
                     zig1_obj.addArg("-OReleaseFast");
-                    zig1_obj.addArg("--strip");
+                    zig1_obj.addArg("-fstrip");
                 },
                 .ReleaseSafe => {
                     zig1_obj.addArg("-OReleaseSafe");
-                    zig1_obj.addArg("--strip");
+                    zig1_obj.addArg("-fstrip");
                 },
                 .ReleaseSmall => {
                     zig1_obj.addArg("-OReleaseSmall");
-                    zig1_obj.addArg("--strip");
+                    zig1_obj.addArg("-fstrip");
                 },
             }
             if (single_threaded orelse false) {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -916,8 +916,8 @@ pub const InitOptions = struct {
     use_clang: ?bool = null,
     use_stage1: ?bool = null,
     single_threaded: ?bool = null,
+    strip: ?bool = null,
     rdynamic: bool = false,
-    strip: bool = false,
     function_sections: bool = false,
     no_builtin: bool = false,
     is_native_os: bool,
@@ -1422,7 +1422,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             break :blk buf.items[0 .. buf.items.len - 1 :0].ptr;
         } else null;
 
-        const strip = options.strip or !target_util.hasDebugInfo(options.target);
+        const strip = options.strip orelse !target_util.hasDebugInfo(options.target);
         const red_zone = options.want_red_zone orelse target_util.hasRedZone(options.target);
         const omit_frame_pointer = options.omit_frame_pointer orelse (options.optimize_mode != .Debug);
         const linker_optimization: u8 = options.linker_optimization orelse switch (options.optimize_mode) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -404,7 +404,8 @@ const usage_build_generic =
     \\  -fno-builtin              Disable implicit builtin knowledge of functions
     \\  -ffunction-sections       Places each function in a separate section
     \\  -fno-function-sections    All functions go into same section
-    \\  --strip                   Omit debug symbols
+    \\  -fstrip                   Omit debug symbols
+    \\  -fno-strip                Keep debug symbols
     \\  -ofmt=[mode]              Override target object format
     \\    elf                     Executable and Linking Format
     \\    c                       C source code
@@ -630,7 +631,7 @@ fn buildOutputType(
     var version: std.builtin.Version = .{ .major = 0, .minor = 0, .patch = 0 };
     var have_version = false;
     var compatibility_version: ?std.builtin.Version = null;
-    var strip = false;
+    var strip: ?bool = null;
     var function_sections = false;
     var no_builtin = false;
     var watch = false;
@@ -1296,8 +1297,10 @@ fn buildOutputType(
                     } else if (mem.eql(u8, arg, "--show-builtin")) {
                         show_builtin = true;
                         emit_bin = .no;
-                    } else if (mem.eql(u8, arg, "--strip")) {
+                    } else if (mem.eql(u8, arg, "-fstrip")) {
                         strip = true;
+                    } else if (mem.eql(u8, arg, "-fno-strip")) {
+                        strip = false;
                     } else if (mem.eql(u8, arg, "-fsingle-threaded")) {
                         single_threaded = true;
                     } else if (mem.eql(u8, arg, "-fno-single-threaded")) {
@@ -1432,7 +1435,6 @@ fn buildOutputType(
         .cc, .cpp => {
             emit_h = .no;
             soname = .no;
-            strip = false;
             ensure_libc_on_non_freestanding = true;
             ensure_libcpp_on_non_freestanding = arg_mode == .cpp;
             want_native_include_dirs = true;
@@ -2185,6 +2187,9 @@ fn buildOutputType(
             }
         },
     }
+
+    if (arg_mode == .build and optimize_mode == .ReleaseSmall and strip == null)
+        strip = true;
 
     if (arg_mode == .translate_c and c_source_files.items.len != 1) {
         fatal("translate-c expects exactly 1 source file (found {d})", .{c_source_files.items.len});

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -133,7 +133,7 @@ fn testGodboltApi(zig_exe: []const u8, dir_path: []const u8) anyerror!void {
         "--cache-dir",    dir_path,
         "--name",         "example",
         "-fno-emit-bin",  "-fno-emit-h",
-        "--strip",        "-OReleaseFast",
+        "-fstrip",        "-OReleaseFast",
         example_zig_path,
     });
 

--- a/test/link/wasm/archive/build.zig
+++ b/test/link/wasm/archive/build.zig
@@ -15,6 +15,7 @@ pub fn build(b: *Builder) void {
     lib.use_llvm = false;
     lib.use_stage1 = false;
     lib.use_lld = false;
+    lib.strip = false;
 
     const check = lib.checkObject(.wasm);
     check.checkStart("Section import");

--- a/test/link/wasm/bss/build.zig
+++ b/test/link/wasm/bss/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *Builder) void {
     lib.use_llvm = false;
     lib.use_stage1 = false;
     lib.use_lld = false;
+    lib.strip = false;
     // to make sure the bss segment is emitted, we must import memory
     lib.import_memory = true;
     lib.install();

--- a/test/link/wasm/segments/build.zig
+++ b/test/link/wasm/segments/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *Builder) void {
     lib.use_llvm = false;
     lib.use_stage1 = false;
     lib.use_lld = false;
+    lib.strip = false;
     lib.install();
 
     const check_lib = lib.checkObject(.wasm);

--- a/test/link/wasm/stack_pointer/build.zig
+++ b/test/link/wasm/stack_pointer/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *Builder) void {
     lib.use_llvm = false;
     lib.use_stage1 = false;
     lib.use_lld = false;
+    lib.strip = false;
     lib.stack_size = std.wasm.page_size * 2; // set an explicit stack size
     lib.install();
 

--- a/test/link/wasm/type/build.zig
+++ b/test/link/wasm/type/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *Builder) void {
     lib.use_llvm = false;
     lib.use_stage1 = false;
     lib.use_lld = false;
+    lib.strip = false;
     lib.install();
 
     const check_lib = lib.checkObject(.wasm);


### PR DESCRIPTION
Closes #6676
```
ali@linux ~/d/zig (o0)> build/zig2 build-exe z.zig -O ReleaseSmall
ali@linux ~/d/zig (o0)> ls -lha ./z ./z.o
-rwxr-xr-x 1 ali ali 8.5K Oct  4 17:52 ./z*
-rw-r--r-- 1 ali ali  12K Oct  4 17:52 ./z.o
ali@linux ~/d/zig (o0)> build/zig2 build-exe z.zig -O ReleaseSmall --strip
ali@linux ~/d/zig (o0)> ls -lha ./z ./z.o
-rwxr-xr-x 1 ali ali 8.5K Oct  4 17:52 ./z*
-rw-r--r-- 1 ali ali  12K Oct  4 17:52 ./z.o
ali@linux ~/d/zig (o0)> build/zig2 build-exe z.zig -O ReleaseSmall --no-strip
ali@linux ~/d/zig (o0)> ls -lha ./z ./z.o
-rwxr-xr-x 1 ali ali 426K Oct  4 17:53 ./z*
-rw-r--r-- 1 ali ali 729K Oct  4 17:53 ./z.o
ali@linux ~/d/zig (o0)> build/zig2 build-exe z.zig
ali@linux ~/d/zig (o0)> ls -lha ./z ./z.o
-rwxr-xr-x 1 ali ali 976K Oct  4 17:53 ./z*
-rw-r--r-- 1 ali ali 1.4M Oct  4 17:53 ./z.o
```