### PR TITLE
`fs.Dir.deleteTree`: Optimize for non-deeply-nested directories

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -811,6 +811,17 @@ pub const IterableDir = struct {
     };
 
     pub fn iterate(self: IterableDir) Iterator {
+        return self.iterateImpl(true);
+    }
+
+    /// Like `iterate`, but will not reset the directory cursor before the first
+    /// iteration. This should only be used in cases where it is known that the
+    /// `IterableDir` has not had its cursor modified yet (e.g. it was just opened).
+    pub fn iterateAssumeFirstIteration(self: IterableDir) Iterator {
+        return self.iterateImpl(false);
+    }
+
+    fn iterateImpl(self: IterableDir, first_iter_start_value: bool) Iterator {
         switch (builtin.os.tag) {
             .macos,
             .ios,
@@ -825,20 +836,20 @@ pub const IterableDir = struct {
                 .index = 0,
                 .end_index = 0,
                 .buf = undefined,
-                .first_iter = true,
+                .first_iter = first_iter_start_value,
             },
             .linux, .haiku => return Iterator{
                 .dir = self.dir,
                 .index = 0,
                 .end_index = 0,
                 .buf = undefined,
-                .first_iter = true,
+                .first_iter = first_iter_start_value,
             },
             .windows => return Iterator{
                 .dir = self.dir,
                 .index = 0,
                 .end_index = 0,
-                .first_iter = true,
+                .first_iter = first_iter_start_value,
                 .buf = undefined,
                 .name_data = undefined,
             },

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2187,6 +2187,7 @@ pub const Dir = struct {
                         } else |err| switch (err) {
                             error.FileNotFound => break :handle_entry,
 
+                            // Impossible because we do not pass any path separators.
                             error.NotDir => unreachable,
 
                             error.IsDir => {
@@ -2268,8 +2269,6 @@ pub const Dir = struct {
                         } else |err| switch (err) {
                             error.FileNotFound => return,
 
-                            error.NotDir => unreachable,
-
                             error.IsDir => {
                                 treat_as_dir = true;
                                 continue :handle_entry;
@@ -2281,6 +2280,7 @@ pub const Dir = struct {
                             error.NameTooLong,
                             error.SystemResources,
                             error.ReadOnlyFileSystem,
+                            error.NotDir,
                             error.FileSystem,
                             error.FileBusy,
                             error.BadPathName,

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -490,6 +490,12 @@ pub const IterableDir = struct {
                     };
                 }
             }
+
+            pub fn reset(self: *Self) void {
+                self.index = 0;
+                self.end_index = 0;
+                self.first_iter = true;
+            }
         },
         .haiku => struct {
             dir: Dir,
@@ -577,6 +583,12 @@ pub const IterableDir = struct {
                     };
                 }
             }
+
+            pub fn reset(self: *Self) void {
+                self.index = 0;
+                self.end_index = 0;
+                self.first_iter = true;
+            }
         },
         .linux => struct {
             dir: Dir,
@@ -655,6 +667,12 @@ pub const IterableDir = struct {
                     };
                 }
             }
+
+            pub fn reset(self: *Self) void {
+                self.index = 0;
+                self.end_index = 0;
+                self.first_iter = true;
+            }
         },
         .windows => struct {
             dir: Dir,
@@ -726,6 +744,12 @@ pub const IterableDir = struct {
                         .kind = kind,
                     };
                 }
+            }
+
+            pub fn reset(self: *Self) void {
+                self.index = 0;
+                self.end_index = 0;
+                self.first_iter = true;
             }
         },
         .wasi => struct {
@@ -805,6 +829,12 @@ pub const IterableDir = struct {
                         .kind = entry_kind,
                     };
                 }
+            }
+
+            pub fn reset(self: *Self) void {
+                self.index = 0;
+                self.end_index = 0;
+                self.cookie = os.wasi.DIRCOOKIE_START;
             }
         },
         else => @compileError("unimplemented"),

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -301,7 +301,7 @@ pub const IterableDir = struct {
         .macos, .ios, .freebsd, .netbsd, .dragonfly, .openbsd, .solaris => struct {
             dir: Dir,
             seek: i64,
-            buf: [8192]u8, // TODO align(@alignOf(os.system.dirent)),
+            buf: [1024]u8, // TODO align(@alignOf(os.system.dirent)),
             index: usize,
             end_index: usize,
             first_iter: bool,
@@ -499,7 +499,7 @@ pub const IterableDir = struct {
         },
         .haiku => struct {
             dir: Dir,
-            buf: [8192]u8, // TODO align(@alignOf(os.dirent64)),
+            buf: [1024]u8, // TODO align(@alignOf(os.dirent64)),
             index: usize,
             end_index: usize,
             first_iter: bool,
@@ -594,7 +594,7 @@ pub const IterableDir = struct {
             dir: Dir,
             // The if guard is solely there to prevent compile errors from missing `linux.dirent64`
             // definition when compiling for other OSes. It doesn't do anything when compiling for Linux.
-            buf: [8192]u8 align(if (builtin.os.tag != .linux) 1 else @alignOf(linux.dirent64)),
+            buf: [1024]u8 align(if (builtin.os.tag != .linux) 1 else @alignOf(linux.dirent64)),
             index: usize,
             end_index: usize,
             first_iter: bool,
@@ -676,7 +676,7 @@ pub const IterableDir = struct {
         },
         .windows => struct {
             dir: Dir,
-            buf: [8192]u8 align(@alignOf(os.windows.FILE_BOTH_DIR_INFORMATION)),
+            buf: [1024]u8 align(@alignOf(os.windows.FILE_BOTH_DIR_INFORMATION)),
             index: usize,
             end_index: usize,
             first_iter: bool,
@@ -754,7 +754,7 @@ pub const IterableDir = struct {
         },
         .wasi => struct {
             dir: Dir,
-            buf: [8192]u8, // TODO align(@alignOf(os.wasi.dirent_t)),
+            buf: [1024]u8, // TODO align(@alignOf(os.wasi.dirent_t)),
             cookie: u64,
             index: usize,
             end_index: usize,

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2178,7 +2178,7 @@ pub const Dir = struct {
                             });
                             continue :process_stack;
                         } else |_| {
-                            try top.iter.dir.deleteTreeFallback(entry.name, entry.kind);
+                            try top.iter.dir.deleteTreeMinStackSizeWithKindHint(entry.name, entry.kind);
                             break :handle_entry;
                         }
                     } else {
@@ -2225,9 +2225,13 @@ pub const Dir = struct {
         }
     }
 
-    /// Fallback version of deleteTree that is less efficient but works on arbitrarily
-    /// nested directories without needing recursion or allocation.
-    fn deleteTreeFallback(self: Dir, sub_path: []const u8, kind_hint: File.Kind) DeleteTreeError!void {
+    /// Like `deleteTree`, but only keeps one `Iterator` active at a time to minimize the function's stack size.
+    /// This is slower than `deleteTree` but uses less stack space.
+    pub fn deleteTreeMinStackSize(self: Dir, sub_path: []const u8) DeleteTreeError!void {
+        return self.deleteTreeMinStackWithKindHint(sub_path, .File);
+    }
+
+    fn deleteTreeMinStackSizeWithKindHint(self: Dir, sub_path: []const u8, kind_hint: File.Kind) DeleteTreeError!void {
         start_over: while (true) {
             var iterable_dir = iterable_dir: {
                 var treat_as_dir = kind_hint == .Directory;

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -219,6 +219,42 @@ test "Dir.Iterator twice" {
     }
 }
 
+test "Dir.Iterator reset" {
+    var tmp_dir = tmpIterableDir(.{});
+    defer tmp_dir.cleanup();
+
+    // First, create a couple of entries to iterate over.
+    const file = try tmp_dir.iterable_dir.dir.createFile("some_file", .{});
+    file.close();
+
+    try tmp_dir.iterable_dir.dir.makeDir("some_dir");
+
+    var arena = ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    // Create iterator.
+    var iter = tmp_dir.iterable_dir.iterate();
+
+    var i: u8 = 0;
+    while (i < 2) : (i += 1) {
+        var entries = std.ArrayList(IterableDir.Entry).init(allocator);
+
+        while (try iter.next()) |entry| {
+            // We cannot just store `entry` as on Windows, we're re-using the name buffer
+            // which means we'll actually share the `name` pointer between entries!
+            const name = try allocator.dupe(u8, entry.name);
+            try entries.append(.{ .name = name, .kind = entry.kind });
+        }
+
+        try testing.expect(entries.items.len == 2); // note that the Iterator skips '.' and '..'
+        try testing.expect(contains(&entries, .{ .name = "some_file", .kind = .File }));
+        try testing.expect(contains(&entries, .{ .name = "some_dir", .kind = .Directory }));
+
+        iter.reset();
+    }
+}
+
 test "Dir.Iterator but dir is deleted during iteration" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
From @andrewrk in https://github.com/ziglang/zig/pull/13070#issuecomment-1268046310:

> I'd like to fully exhaust the non-recursive, non-heap-allocating implementation options before resorting to this. Could you try a version that uses a fixed-size stack buffer (and resorts to redundant syscall operations in the case that the buffer is exhausted)?
>
> I think we should have only one implementation in the standard library. Hopefully it can accomplish all the characteristics we want:
>
> - Equivalent or better perf of rm -rf.
> - No possibility of stack overflow due to "user input" of a deeply nested file system tree
> - No allocator parameter required.


This PR implements this suggestion and (I think) accomplishes everything in the list. It is just as fast as the recursive implementation in #13070 for directories that stay within the fixed-size stack buffer, and only slows down (temporarily) for directories that exceed that level of nesting.

See #13048 for more context. Benchmarking is done with the [same folder structure mentioned here](https://github.com/ziglang/zig/issues/13048#issuecomment-1265224210):

> tested with the folder that resulted from `npx create-react-app my-app`; 41209 files, 344MiB

Linux benchmarks:

```
$ hyperfine "./rm-fast my-app-copy" "./rm-master my-app-copy" --prepare="cp -r my-app my-app-copy" --warmup 1 --runs 20
Benchmark #1: ./rm-fast my-app-copy
  Time (mean ± σ):     382.7 ms ±   7.8 ms    [User: 13.6 ms, System: 358.9 ms]
  Range (min … max):   372.2 ms … 395.9 ms    20 runs
 
Benchmark #2: ./rm-master my-app-copy
  Time (mean ± σ):     701.2 ms ±  28.3 ms    [User: 36.8 ms, System: 646.2 ms]
  Range (min … max):   673.4 ms … 799.4 ms    20 runs
 
Summary
  './rm-fast my-app-copy' ran
    1.83 ± 0.08 times faster than './rm-master my-app-copy'
```

(note: the test directory's nesting level stays within the fixed-size buffer)

Benchmarks against the recursive version from #13070 and `rm -rf`:

```
$ hyperfine "./rm-recursive my-app-copy" "./rm-fast my-app-copy" "rm -rf my-app-copy" --prepare="cp -r my-app my-app-copy" --warmup 1 --runs 20
Benchmark #1: ./rm-recursive my-app-copy
  Time (mean ± σ):     389.1 ms ±  12.9 ms    [User: 19.5 ms, System: 360.2 ms]
  Range (min … max):   370.5 ms … 430.6 ms    20 runs
 
Benchmark #2: ./rm-fast my-app-copy
  Time (mean ± σ):     392.6 ms ±  17.0 ms    [User: 17.4 ms, System: 359.5 ms]
  Range (min … max):   373.0 ms … 444.8 ms    20 runs
 
Benchmark #3: rm -rf my-app-copy
  Time (mean ± σ):     423.9 ms ±  35.4 ms    [User: 17.5 ms, System: 379.4 ms]
  Range (min … max):   391.6 ms … 518.9 ms    20 runs
 
Summary
  './rm-recursive my-app-copy' ran
    1.01 ± 0.05 times faster than './rm-fast my-app-copy'
    1.09 ± 0.10 times faster than 'rm -rf my-app-copy'
```

`strace` is identical to the recursive verison as long as the nesting stays within the fixed-size buffer:

```
$ strace -c ./rm-fast my-app-copy
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 80.38    0.435533          10     41210         1 unlinkat
  8.21    0.044482           4      9744           getdents64
  7.89    0.042770           8      4863           close
  3.51    0.019030           3      4863           openat
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           prlimit64
------ ----------- ----------- --------- --------- ----------------
100.00    0.541815                 60683         1 total
```

And the syscall count doesn't increase too much if the fallback is only needed for a few things. The directory I'm testing with has 10 nested directories max; here's the `strace -c` after setting `deleteTree`'s `BoundedArray` size to 8:

```
$ strace -c ./rm-fast my-app-copy
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 80.95    0.456681          11     41210         1 unlinkat
  8.05    0.045412           4      9754           getdents64
  7.56    0.042634           8      4873           close
  3.44    0.019404           3      4873           openat
  0.00    0.000000           0         4           rt_sigaction
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           prlimit64
------ ----------- ----------- --------- --------- ----------------
100.00    0.564131                 60717         1 total
```

and here it is with the `BoundedArray` size set to 4:

```
$ strace -c ./rm-fast my-app-copy
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 79.64    0.463573          11     41210         1 unlinkat
  9.61    0.055929           4     12428           getdents64
  6.02    0.035049           4      7548           close
  4.74    0.027564           3      7548           openat
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           prlimit64
------ ----------- ----------- --------- --------- ----------------
100.00    0.582115                 68737         1 total
```

---

This also includes some optimizations for what is now the fallback implementation of `deleteTree`, in that it eliminates some redundant `deleteFile` calls from the implementation while not changing its functionality (see https://github.com/ziglang/zig/issues/13048#issuecomment-1265287034 and the commit message in the list below for more info). This leads to a decent reduction in syscalls but a pretty insignificant decrease in wallclock time.

Before:
```
$ strace -c ./rm-master my-app-copy
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 47.82    0.580480           8     65368     24159 unlinkat
 33.35    0.404906          13     29036           getdents64
  7.55    0.091704           3     24159           close
  6.73    0.081669           3     24159           openat
  4.55    0.055245           2     24159           lseek
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           prlimit64
------ ----------- ----------- --------- --------- ----------------
100.00    1.214004                166884     24159 total
```
After:
```
$ strace -c ./rm-updated my-app-copy
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 45.90    0.496441          12     41210         1 unlinkat
 37.58    0.406455          13     29036           getdents64
  8.60    0.093017           3     24159           close
  7.93    0.085720           3     24159           openat
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           prlimit64
------ ----------- ----------- --------- --------- ----------------
100.00    1.081633                118567         1 total
```

(note also that the `lseek` syscalls are also gone; this is via the introduction of `IterableDir.iterateAssumeFirstIteration` which the new `deleteFile` implementation also takes advantage of)

Benchmark results:

```
$ hyperfine "./rm-master my-app-copy" "./rm-updated my-app-copy" --prepare="cp -r my-app my-app-copy" --warmup 1 --runs 20
Benchmark #1: ./rm-master my-app-copy
  Time (mean ± σ):     695.0 ms ±  11.9 ms    [User: 28.7 ms, System: 654.1 ms]
  Range (min … max):   678.5 ms … 718.0 ms    20 runs
 
Benchmark #2: ./rm-updated my-app-copy
  Time (mean ± σ):     683.6 ms ±  28.2 ms    [User: 26.1 ms, System: 639.1 ms]
  Range (min … max):   662.6 ms … 793.6 ms    20 runs
 
Summary
  './rm-updated my-app-copy' ran
    1.02 ± 0.05 times faster than './rm-master my-app-copy'
```

---

This also adds `IterableDir.Iterator.reset` which was helpful here to allow for resetting the iterator without needing to store the `IterableDir` in order to re-create a new iterator.

---

Closes #13048 if merged.