### PR TITLE
fix: resolve data race in std.Progress.maybeRefresh()

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -172,10 +172,10 @@ pub fn start(self: *Progress, name: []const u8, estimated_total_items: usize) *N
 /// Updates the terminal if enough time has passed since last update. Thread-safe.
 pub fn maybeRefresh(self: *Progress) void {
     if (self.timer) |*timer| {
-        const now = timer.read();
-        if (now < self.initial_delay_ns) return;
         if (!self.update_mutex.tryLock()) return;
         defer self.update_mutex.unlock();
+        const now = timer.read();
+        if (now < self.initial_delay_ns) return;
         // TODO I have observed this to happen sometimes. I think we need to follow Rust's
         // lead and guarantee monotonically increasing times in the std lib itself.
         if (now < self.prev_refresh_timestamp) return;


### PR DESCRIPTION
It seems we can simply lock the update mutex a little earlier.

Before:
```
~/Desktop/zig$ zig build -p stage3 -Dsanitize-thread --zig-lib-dir lib
~/Desktop/zig$ stage3/bin/zig run x.zig
AST Lowering [21] zig/number_literal.zig... LLVMSymbolizer: error reading file: No such file or directory
==================
WARNING: ThreadSanitizer: data race (pid=6670)
  Read of size 8 at 0x7ffd5dd43000 by thread T2:
    #0 memcpy <null> (zig+0x1ce7896)
```

After:
```
~/Desktop/zig$ zig build -p stage3 -Dsanitize-thread --zig-lib-dir lib
~/Desktop/zig$ stage3/bin/zig run x.zig
```

Fixes #13072