### PR TITLE
i386 ABI: Fix some sizes and alignments

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1761,7 +1761,7 @@ pub const Target = struct {
     }
 
     pub inline fn longDoubleIs(target: Target, comptime F: type) bool {
-        if (target.abi == .msvc) {
+        if (target.abi == .msvc or (target.abi == .android and target.cpu.arch == .i386)) {
             return F == f64;
         }
         return switch (F) {

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -53,6 +53,9 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     if (builtin.cpu.arch.isAARCH64() and builtin.zig_backend == .stage2_llvm) {
         cases.addBuildFile("test/c_abi/build.zig", .{});
     }
+    if (builtin.cpu.arch == .i386 and builtin.zig_backend == .stage2_llvm) {
+        cases.addBuildFile("test/c_abi/build.zig", .{});
+    }
     // C ABI tests only pass for the Wasm target when using stage2
     cases.addBuildFile("test/c_abi/build_wasm.zig", .{
         .requires_stage2 = true,


### PR DESCRIPTION
This makes the following changes for i386:

long long and unsigned long long have 4 byte alignment on non-Windows

f64 (double) has 4-byte alignment on non-Windows

long double is 80 bits and has 4 byte alignment on mingw

long double on android is 64 bits, not 80: https://www.uclibc.org/docs/psABI-i386.pdf

Fixes #12453
Fixes #12987