### PR TITLE
Windows: Explicitly pass PDB paths to lld-link

### DIFF
--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -181,6 +181,13 @@ pub fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
         try argv.append("-NOLOGO");
         if (!self.base.options.strip) {
             try argv.append("-DEBUG");
+
+            const out_ext = std.fs.path.extension(full_out_path);
+            const out_pdb = try allocPrint(arena, "{s}.pdb", .{
+                full_out_path[0 .. full_out_path.len - out_ext.len],
+            });
+            try argv.append(try allocPrint(arena, "-PDB:{s}", .{out_pdb}));
+            try argv.append(try allocPrint(arena, "-PDBALTPATH:{s}", .{out_pdb}));
         }
         if (self.base.options.lto) {
             switch (self.base.options.optimize_mode) {


### PR DESCRIPTION
On Windows, lld-link resolves PDB output paths using `/` and embeds the result in the final executable, which breaks some native tooling like WPR/WPA. This commit overrides the default behavior of lld-link by explicitly setting the output PDB filename and binary-embedded path so that it uses `\`. PDBs are still generated in the same location as before: adjacent to the output file.

Not 100% sure if this is appropriate to fix in zig or if it's an upstream issue so feel free to close, I took a stab at it since #12492 seemed to imply lld-link is poorly behaved wrt path separators and it's preventing me from benchmarking some zig programs without hex editing them to fix up PDB paths.