### PR TITLE
Added os check for std.fs.setAsCwd() to work on Windows

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1561,6 +1561,14 @@ pub const Dir = struct {
         if (builtin.os.tag == .wasi) {
             @compileError("changing cwd is not currently possible in WASI");
         }
+        if (builtin.os.tag == .windows) {
+            var dir_path_buffer: [os.windows.PATH_MAX_WIDE]u16 = undefined;
+            var dir_path = try os.windows.GetFinalPathNameByHandle(self.fd, .{}, &dir_path_buffer);
+            if (builtin.link_libc) {
+                return os.chdirW(dir_path);
+            }
+            return os.windows.SetCurrentDirectory(dir_path);
+        }
         try os.fchdir(self.fd);
     }
 


### PR DESCRIPTION
closes #12970 

Due to the unavailability of `fchdir` in Windows, a call for setting the CWD needs to either call `chdirW` or `SetCurrentDirectory` with the path string (`[]const u16`). Unfortunately, Windows does not offer any functions for setting the current working directory via handle/fd, which is what `setAsCwd()` uses.

Since we are dealing with a Handle in Windows, a call for `GetFinalPathNameByHandle` is necessary for getting the file path first in order to call `SetCurrentDirectory`.

Another option is to have this condition inside `fchdir` instead. 

This was tested using the following code: 
```zig
    const dir = try std.fs.cwd().openDir("C:\\", .{}); 
    try dir.setAsCwd(); 
    var buffer: [1024]u8 = undefined; 
    const cwd = std.fs.cwd(); 
    std.debug.print("@@@{s}@@@\n",.{try cwd.realpath(".",&buffer)});
```
which prints: `@@@C:\@@@`