### PR TITLE
Add [src] links to function decls in autodocs

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1858,6 +1858,7 @@ var zigAnalysis;
                 } else {
                   payloadHtml += escapeHtml(opts.fnDecl.name);
                 }
+                payloadHtml += renderSourceFileLink(opts.fnDecl);
                 payloadHtml += "</span>";
               }
             } else {


### PR DESCRIPTION
related issue: #12759

Hi! I was looking for a way to familiarize myself a bit more with Zig, and having previously poked with autodoc a bit a month or two ago, I figured I'd grab this quick one-liner to carry forward `[src]` links on function declaration docs pages.

Here's the result:

<img width="1582" alt="Screen Shot 2022-10-09 at 8 53 21 PM" src="https://user-images.githubusercontent.com/8205547/194787509-afb9a1bd-e876-4175-be56-716ed812accf.png">

<img width="1582" alt="Screen Shot 2022-10-09 at 8 53 44 PM" src="https://user-images.githubusercontent.com/8205547/194787514-610f9b08-1241-4241-a875-17833ae690b0.png">

Which links to this page:

<img width="1582" alt="Screen Shot 2022-10-09 at 8 53 32 PM" src="https://user-images.githubusercontent.com/8205547/194787523-925aac91-0243-474f-89a3-11543ed144ea.png">

---

I do have a couple questions concerning development on autodoc in general not specific to this PR, and happy to move these to issues/discussions if this isn't the appropriate spot for questions:

1. I'm struggling a bit to understand the development flow of `index.html` and `main.js`. From my reading of [the docs](https://github.com/ziglang/zig/wiki/How-to-contribute-to-Autodoc), I should be able to edit either of these files, run `zig build-obj -femit-docs <file>.zig`, and it should copy `lib/docs/{index.html,main.js}` to the newly created`docs/` folder. However, when I make edits to either of the two files then run that, it does not take my edits (it uses whatever is in the `master` branch). I read [the code](https://github.com/ziglang/zig/blob/7f508480f49b78817bf67579a8810d4499cbbc13/src/Autodoc.zig#L317-L321) and ran a quick strace, and I see that it's just doing a copy to a temporary file and renaming. I'm not sure why my edits aren't being applied to those files? Any advice there?

2. I see that there's a [section in the docs](https://github.com/ziglang/zig/wiki/How-to-contribute-to-Autodoc#editing-the-js-code) about writing type-annoted javascript, but it looks like that was [recently removed](https://github.com/ziglang/zig/pull/12173). Should that section of the docs be deleted?

Thanks!