### PR TITLE
Fix building with Clang 16

### DIFF
--- a/src/stage1/parse_f128.c
+++ b/src/stage1/parse_f128.c
@@ -983,14 +983,14 @@ static int isspace(int c)
     return c == ' ' || (unsigned)c-'\t' < 5;
 }
 
-static inline float128_t makeInf128() {
+static inline float128_t makeInf128(void) {
     union ldshape ux;
     ux.i2.hi = 0x7fff000000000000UL;
     ux.i2.lo = 0x0UL;
     return ux.f;
 }
 
-static inline float128_t makeNaN128() {
+static inline float128_t makeNaN128(void) {
     uint64_t rand = 0UL;
     union ldshape ux;
     ux.i2.hi = 0x7fff000000000000UL | (rand & 0xffffffffffffUL);


### PR DESCRIPTION
Before:
```c
[ 81%] Built target embedded_softfloat
[ 85%] Built target zigcpp
Consolidate compiler generated dependencies of target opt_c_util
[ 85%] Building C object CMakeFiles/opt_c_util.dir/src/stage1/parse_f128.c.o
/home/bratishkaerik/zig-upstream/src/stage1/parse_f128.c:986:36: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
static inline float128_t makeInf128() {
                                   ^
                                    void
/home/bratishkaerik/zig-upstream/src/stage1/parse_f128.c:993:36: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
static inline float128_t makeNaN128() {
                                   ^
                                    void
2 errors generated.
gmake[2]: *** [CMakeFiles/opt_c_util.dir/build.make:76: CMakeFiles/opt_c_util.dir/src/stage1/parse_f128.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:147: CMakeFiles/opt_c_util.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```
Related:
https://archives.gentoo.org/gentoo-dev/message/dd9f2d3082b8b6f8dfbccb0639e6e240