### PR TITLE
stage2: implement exporting using field access

### DIFF
--- a/test/behavior/export.zig
+++ b/test/behavior/export.zig
@@ -55,3 +55,16 @@ test "exporting with internal linkage" {
     };
     S.foo();
 }
+
+test "exporting using field access" {
+    const S = struct {
+        const Inner = struct {
+            const x: u32 = 5;
+        };
+        comptime {
+            @export(Inner.x, .{ .name = "foo", .linkage = .Internal });
+        }
+    };
+
+    _ = S.Inner.x;
+}


### PR DESCRIPTION
Implements exporting namespaced declarations. e.g. `@export(a.b, .{...});`

closes #12532 
