### PR TITLE
stage2: fix -femit-asm

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -99,4 +99,5 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     //cases.add("tools/update_spirv_features.zig");
 
     cases.addBuildFile("test/standalone/issue_13030/build.zig", .{ .build_modes = true });
+    cases.addBuildFile("test/standalone/emit_asm_and_bin/build.zig", .{});
 }

--- a/test/standalone/emit_asm_and_bin/build.zig
+++ b/test/standalone/emit_asm_and_bin/build.zig
@@ -1,0 +1,11 @@
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    const main = b.addTest("main.zig");
+    main.setBuildMode(b.standardReleaseOptions());
+    main.emit_asm = .{ .emit_to = b.pathFromRoot("main.s") };
+    main.emit_bin = .{ .emit_to = b.pathFromRoot("main") };
+
+    const test_step = b.step("test", "Run test");
+    test_step.dependOn(&main.step);
+}

--- a/test/standalone/emit_asm_and_bin/main.zig
+++ b/test/standalone/emit_asm_and_bin/main.zig
@@ -1,0 +1,1 @@
+pub fn main() void {}


### PR DESCRIPTION
I tried finding a better solution, but emitting is just too stateful in llvm, so I ended up just copying the logic from stage1.  For reference, if you ask clang for both outputs, then it emits the asm file first and then assembles that with the integrated or system assembler.

Fixes #12800