### PR TITLE
std.os.windows: Change HKEY to *opaque {}

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2868,10 +2868,7 @@ pub const PROV_RSA_FULL = 1;
 
 pub const REGSAM = ACCESS_MASK;
 pub const ACCESS_MASK = DWORD;
-pub const HKEY = *HKEY__;
-pub const HKEY__ = extern struct {
-    unused: c_int,
-};
+pub const HKEY = *opaque {};
 pub const LSTATUS = LONG;
 
 pub const FILE_NOTIFY_INFORMATION = extern struct {


### PR DESCRIPTION
The definition of HKEY__ as a struct with an unused int field is only the case in the Windows headers when `STRICT` is defined. From https://learn.microsoft.com/en-us/windows/win32/winprog/enabling-strict:

> When STRICT is defined, data type definitions change as follows:
>
> -  Specific handle types are defined to be mutually exclusive; for example, you will not be able to pass an HWND where an HDC type argument is required. Without STRICT, all handles are defined as HANDLE, so the compiler does not prevent you from using one type of handle where another type is expected.

Zig's `opaque {}` already gives this benefit to us, so the usage of a struct with an unused field is unnecessary, and it was causing HKEY to have an alignment of 4, which is a problem because there are HKEY constants like HKEY_LOCAL_MACHINE (0x80000002) that are not 4-byte aligned. Without this change, the compiler would not allow something like HKEY_LOCAL_MACHINE to be defined since it enforces pointer alignment.

Note also that `HWND`, `HMODULE`, `HDC`, etc already use `*opaque {}`; `HKEY` was the odd-one-out.