### PR TITLE
llvm: fix lowering of runtime refs to comptime-only decls

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -4082,7 +4082,7 @@ pub const DeclGen = struct {
         }
 
         const is_fn_body = decl.ty.zigTypeTag() == .Fn;
-        if (!is_fn_body and !decl.ty.hasRuntimeBitsIgnoreComptime()) {
+        if (!is_fn_body and !decl.ty.hasRuntimeBits()) {
             return self.lowerPtrToVoid(tv.ty);
         }
 

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -83,6 +83,7 @@ test {
     _ = @import("behavior/bugs/11213.zig");
     _ = @import("behavior/bugs/11816.zig");
     _ = @import("behavior/bugs/12003.zig");
+    _ = @import("behavior/bugs/12025.zig");
     _ = @import("behavior/bugs/12033.zig");
     _ = @import("behavior/bugs/12430.zig");
     _ = @import("behavior/bugs/12486.zig");

--- a/test/behavior/bugs/12025.zig
+++ b/test/behavior/bugs/12025.zig
@@ -1,0 +1,10 @@
+test {
+    comptime var st = .{
+        .foo = &1,
+        .bar = &2,
+    };
+
+    inline for (@typeInfo(@TypeOf(st)).Struct.fields) |field| {
+        _ = field;
+    }
+}


### PR DESCRIPTION
When we want a runtime pointer to a zero-bit value we use an undef pointer, but what if we want a runtime pointer to a comptime-only value? Normally, if `T` is a comptime-only type such as `*const comptime_int`, then `*const T` would also be a comptime-only type, so anything referencing a comptime-only value is usually also comptime-only, and therefore not emitted to the executable.

However, what if instead we have a `*const anyopaque` pointing to a comptime-only value?  Certainly, `*const anyopaque` is a runtime type, and so we need some runtime value to store, even when it happens to be pointing to a comptime-only value.  In this case we want to do the same thing as we do when pointing to a zero-bit value, so we use `hasRuntimeBits` to handle both cases instead of ignoring comptime.

Closes #12025