### PR TITLE
Module: fix early exit conditions during compilation

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4310,10 +4310,9 @@ pub fn ensureFuncBodyAnalyzed(mod: *Module, func: *Fn) SemaError!void {
                 comp.emit_llvm_bc == null);
 
             const dump_air = builtin.mode == .Debug and comp.verbose_air;
+            const dump_llvm_ir = builtin.mode == .Debug and comp.verbose_llvm_ir;
 
-            if (no_bin_file and !dump_air) {
-                return;
-            }
+            if (no_bin_file and !dump_air and !dump_llvm_ir) return;
 
             log.debug("analyze liveness of {s}", .{decl.name});
             var liveness = try Liveness.analyze(gpa, air);
@@ -4328,9 +4327,7 @@ pub fn ensureFuncBodyAnalyzed(mod: *Module, func: *Fn) SemaError!void {
                 std.debug.print("# End Function AIR: {s}\n\n", .{fqn});
             }
 
-            if (no_bin_file) {
-                return;
-            }
+            if (no_bin_file and !dump_llvm_ir) return;
 
             comp.bin_file.updateFunc(mod, func, air, liveness) catch |err| switch (err) {
                 error.OutOfMemory => return error.OutOfMemory,
@@ -6475,7 +6472,14 @@ pub fn populateTestFunctions(mod: *Module) !void {
 pub fn linkerUpdateDecl(mod: *Module, decl_index: Decl.Index) !void {
     const comp = mod.comp;
 
-    if (comp.bin_file.options.emit == null) return;
+    const no_bin_file = (comp.bin_file.options.emit == null and
+        comp.emit_asm == null and
+        comp.emit_llvm_ir == null and
+        comp.emit_llvm_bc == null);
+
+    const dump_llvm_ir = builtin.mode == .Debug and comp.verbose_llvm_ir;
+
+    if (no_bin_file and !dump_llvm_ir) return;
 
     const decl = mod.declPtr(decl_index);
 

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -103,4 +103,5 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
 
     cases.addBuildFile("test/standalone/issue_13030/build.zig", .{ .build_modes = true });
     cases.addBuildFile("test/standalone/emit_asm_and_bin/build.zig", .{});
+    cases.addBuildFile("test/standalone/issue_12588/build.zig", .{});
 }

--- a/test/standalone/issue_12588/build.zig
+++ b/test/standalone/issue_12588/build.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+    const target = b.standardTargetOptions(.{});
+
+    const obj = b.addObject("main", "main.zig");
+    obj.setBuildMode(mode);
+    obj.setTarget(target);
+    obj.emit_llvm_ir = .{ .emit_to = b.pathFromRoot("main.ll") };
+    obj.emit_llvm_bc = .{ .emit_to = b.pathFromRoot("main.bc") };
+    obj.emit_bin = .no_emit;
+    b.default_step.dependOn(&obj.step);
+
+    const test_step = b.step("test", "Test the program");
+    test_step.dependOn(&obj.step);
+}

--- a/test/standalone/issue_12588/main.zig
+++ b/test/standalone/issue_12588/main.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+
+export fn strFromFloatHelp(float: f64) void {
+    var buf: [400]u8 = undefined;
+    _ = std.fmt.bufPrint(&buf, "{d}", .{float}) catch unreachable;
+}


### PR DESCRIPTION
 * `--verbose-llvm-ir` should trigger analysis and codegen
 * `-femit-asm` etc should trigger codegen even with `-fno-emit-bin`

Closes #12588