### PR TITLE
llvm: fix lowering of non-byte-aligned field pointers

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3341,7 +3341,6 @@ fn doTheTest() !void {
       Zig allows the address to be taken of a non-byte-aligned field:
       </p>
       {#code_begin|test|pointer_to_non-byte_aligned_field#}
-      {#backend_stage1#}
 const std = @import("std");
 const expect = std.testing.expect;
 
@@ -3398,7 +3397,6 @@ fn bar(x: *const u3) u3 {
       Pointers to non-ABI-aligned fields share the same address as the other fields within their host integer:
       </p>
       {#code_begin|test|packed_struct_field_addrs#}
-      {#backend_stage1#}
 const std = @import("std");
 const expect = std.testing.expect;
 
@@ -3463,9 +3461,6 @@ test "overaligned pointer to packed struct" {
     try expect(ptr_to_b.* == 2);
 }
       {#code_end#}
-      <p>When this bug is fixed, the above test in the documentation will unexpectedly pass, which will
-      cause the test suite to fail, notifying the bug fixer to update these docs.
-      </p>
       <p>
       It's also possible to set alignment of struct fields:
       </p>

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3948,7 +3948,7 @@ pub const DeclGen = struct {
                                 }
                                 break :b b;
                             };
-                            const byte_offset = llvm_usize.constInt((prev_bits + 7) / 8, .False);
+                            const byte_offset = llvm_usize.constInt(prev_bits / 8, .False);
                             const field_addr = base_addr.constAdd(byte_offset);
                             bitcast_needed = false;
                             const final_llvm_ty = (try dg.lowerType(ptr_child_ty)).pointerType(0);


### PR DESCRIPTION
 * When a field starts at some bit offset within a byte you need to load starting from that byte and shift, not starting from the next byte, so a rounded-down divide is required here, not a rounded-up one.
 * Remove paragraph from doc that no longer relates to anything.

Closes #12363