### PR TITLE
change uefi packed structs to new integer backed syntax

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -50,7 +50,9 @@ comptime {
 test {
     _ = darwin;
     _ = linux;
-    _ = uefi;
+    if (builtin.os.tag == .uefi) {
+        _ = uefi;
+    }
     _ = wasi;
     _ = windows;
     _ = posix_spawn;

--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -35,7 +35,7 @@ pub const Ipv6Address = extern struct {
     address: [16]u8,
 };
 
-/// GUIDs must be align(8)
+/// GUIDs are align(8) unless otherwise specified.
 pub const Guid = extern struct {
     time_low: u32,
     time_mid: u16,
@@ -149,4 +149,9 @@ test "GUID formatting" {
     defer std.testing.allocator.free(str);
 
     try std.testing.expect(std.mem.eql(u8, str, "32cb3c89-8080-427c-ba13-5049873bc287"));
+}
+
+test {
+    _ = tables;
+    _ = protocols;
 }

--- a/lib/std/os/uefi/protocols.zig
+++ b/lib/std/os/uefi/protocols.zig
@@ -44,7 +44,7 @@ pub const hii = @import("protocols/hii.zig");
 pub usingnamespace @import("protocols/hii_database_protocol.zig");
 pub usingnamespace @import("protocols/hii_popup_protocol.zig");
 
-comptime {
+test {
     @setEvalBranchQuota(2000);
     @import("std").testing.refAllDeclsRecursive(@This());
 }

--- a/lib/std/os/uefi/protocols.zig
+++ b/lib/std/os/uefi/protocols.zig
@@ -43,3 +43,8 @@ pub usingnamespace @import("protocols/udp6_protocol.zig");
 pub const hii = @import("protocols/hii.zig");
 pub usingnamespace @import("protocols/hii_database_protocol.zig");
 pub usingnamespace @import("protocols/hii_popup_protocol.zig");
+
+comptime {
+    @setEvalBranchQuota(2000);
+    @import("std").testing.refAllDeclsRecursive(@This());
+}

--- a/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
+++ b/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
@@ -31,6 +31,12 @@ pub const AbsolutePointerProtocol = extern struct {
     };
 };
 
+pub const AbsolutePointerModeAttributes = packed struct(u32) {
+    supports_alt_active: bool,
+    supports_pressure_as_z: bool,
+    _pad: u30 = 0,
+};
+
 pub const AbsolutePointerMode = extern struct {
     absolute_min_x: u64,
     absolute_min_y: u64,
@@ -38,20 +44,18 @@ pub const AbsolutePointerMode = extern struct {
     absolute_max_x: u64,
     absolute_max_y: u64,
     absolute_max_z: u64,
-    attributes: packed struct {
-        supports_alt_active: bool,
-        supports_pressure_as_z: bool,
-        _pad: u30 = 0,
-    },
+    attributes: AbsolutePointerModeAttributes,
+};
+
+pub const AbsolutePointerStateActiveButtons = packed struct(u32) {
+    touch_active: bool,
+    alt_active: bool,
+    _pad: u30 = 0,
 };
 
 pub const AbsolutePointerState = extern struct {
     current_x: u64,
     current_y: u64,
     current_z: u64,
-    active_buttons: packed struct {
-        touch_active: bool,
-        alt_active: bool,
-        _pad: u30 = 0,
-    },
+    active_buttons: AbsolutePointerStateActiveButtons,
 };

--- a/lib/std/os/uefi/protocols/device_path_protocol.zig
+++ b/lib/std/os/uefi/protocols/device_path_protocol.zig
@@ -4,10 +4,13 @@ const uefi = std.os.uefi;
 const Allocator = mem.Allocator;
 const Guid = uefi.Guid;
 
-pub const DevicePathProtocol = packed struct {
+// All Device Path Nodes are byte-packed and may appear on any byte boundary.
+// All code references to device path nodes must assume all fields are unaligned.
+
+pub const DevicePathProtocol = extern struct {
     type: DevicePathType,
     subtype: u8,
-    length: u16,
+    length: u16 align(1),
 
     pub const guid align(8) = Guid{
         .time_low = 0x09576e91,
@@ -38,7 +41,7 @@ pub const DevicePathProtocol = packed struct {
     }
 
     /// Creates a file device path from the existing device path and a file path.
-    pub fn create_file_device_path(self: *DevicePathProtocol, allocator: Allocator, path: [:0]const u16) !*DevicePathProtocol {
+    pub fn create_file_device_path(self: *DevicePathProtocol, allocator: Allocator, path: [:0]align(1) const u16) !*DevicePathProtocol {
         var path_size = self.size();
 
         // 2 * (path.len + 1) for the path and its null terminator, which are u16s
@@ -56,7 +59,7 @@ pub const DevicePathProtocol = packed struct {
         new.length = @sizeOf(MediaDevicePath.FilePathDevicePath) + 2 * (@intCast(u16, path.len) + 1);
 
         // The same as new.getPath(), but not const as we're filling it in.
-        var ptr = @ptrCast([*:0]u16, @alignCast(2, @ptrCast([*]u8, new)) + @sizeOf(MediaDevicePath.FilePathDevicePath));
+        var ptr = @ptrCast([*:0]align(1) u16, @ptrCast([*]u8, new) + @sizeOf(MediaDevicePath.FilePathDevicePath));
 
         for (path) |s, i|
             ptr[i] = s;
@@ -108,6 +111,15 @@ pub const DevicePathProtocol = packed struct {
     }
 };
 
+comptime {
+    std.debug.assert(4 == @sizeOf(DevicePathProtocol));
+    std.debug.assert(1 == @alignOf(DevicePathProtocol));
+
+    std.debug.assert(0 == @offsetOf(DevicePathProtocol, "type"));
+    std.debug.assert(1 == @offsetOf(DevicePathProtocol, "subtype"));
+    std.debug.assert(2 == @offsetOf(DevicePathProtocol, "length"));
+}
+
 pub const DevicePath = union(DevicePathType) {
     Hardware: HardwareDevicePath,
     Acpi: AcpiDevicePath,
@@ -145,51 +157,115 @@ pub const HardwareDevicePath = union(Subtype) {
         _,
     };
 
-    pub const PciDevicePath = packed struct {
+    pub const PciDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
+        length: u16 align(1),
         function: u8,
         device: u8,
     };
 
-    pub const PcCardDevicePath = packed struct {
+    comptime {
+        std.debug.assert(6 == @sizeOf(PciDevicePath));
+        std.debug.assert(1 == @alignOf(PciDevicePath));
+
+        std.debug.assert(0 == @offsetOf(PciDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(PciDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(PciDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(PciDevicePath, "function"));
+        std.debug.assert(5 == @offsetOf(PciDevicePath, "device"));
+    }
+
+    pub const PcCardDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
+        length: u16 align(1),
         function_number: u8,
     };
 
-    pub const MemoryMappedDevicePath = packed struct {
+    comptime {
+        std.debug.assert(5 == @sizeOf(PcCardDevicePath));
+        std.debug.assert(1 == @alignOf(PcCardDevicePath));
+
+        std.debug.assert(0 == @offsetOf(PcCardDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(PcCardDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(PcCardDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(PcCardDevicePath, "function_number"));
+    }
+
+    pub const MemoryMappedDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        memory_type: u32,
-        start_address: u64,
-        end_address: u64,
+        length: u16 align(1),
+        memory_type: u32 align(1),
+        start_address: u64 align(1),
+        end_address: u64 align(1),
     };
 
-    pub const VendorDevicePath = packed struct {
+    comptime {
+        std.debug.assert(24 == @sizeOf(MemoryMappedDevicePath));
+        std.debug.assert(1 == @alignOf(MemoryMappedDevicePath));
+
+        std.debug.assert(0 == @offsetOf(MemoryMappedDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(MemoryMappedDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(MemoryMappedDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(MemoryMappedDevicePath, "memory_type"));
+        std.debug.assert(8 == @offsetOf(MemoryMappedDevicePath, "start_address"));
+        std.debug.assert(16 == @offsetOf(MemoryMappedDevicePath, "end_address"));
+    }
+
+    pub const VendorDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        vendor_guid: Guid,
+        length: u16 align(1),
+        vendor_guid: Guid align(1),
     };
 
-    pub const ControllerDevicePath = packed struct {
+    comptime {
+        std.debug.assert(20 == @sizeOf(VendorDevicePath));
+        std.debug.assert(1 == @alignOf(VendorDevicePath));
+
+        std.debug.assert(0 == @offsetOf(VendorDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(VendorDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(VendorDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(VendorDevicePath, "vendor_guid"));
+    }
+
+    pub const ControllerDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        controller_number: u32,
+        length: u16 align(1),
+        controller_number: u32 align(1),
     };
 
-    pub const BmcDevicePath = packed struct {
+    comptime {
+        std.debug.assert(8 == @sizeOf(ControllerDevicePath));
+        std.debug.assert(1 == @alignOf(ControllerDevicePath));
+
+        std.debug.assert(0 == @offsetOf(ControllerDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(ControllerDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(ControllerDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(ControllerDevicePath, "controller_number"));
+    }
+
+    pub const BmcDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
+        length: u16 align(1),
         interface_type: u8,
-        base_address: usize,
+        base_address: u64 align(1),
     };
+
+    comptime {
+        std.debug.assert(13 == @sizeOf(BmcDevicePath));
+        std.debug.assert(1 == @alignOf(BmcDevicePath));
+
+        std.debug.assert(0 == @offsetOf(BmcDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(BmcDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(BmcDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(BmcDevicePath, "interface_type"));
+        std.debug.assert(5 == @offsetOf(BmcDevicePath, "base_address"));
+    }
 };
 
 pub const AcpiDevicePath = union(Subtype) {
@@ -204,37 +280,71 @@ pub const AcpiDevicePath = union(Subtype) {
         _,
     };
 
-    pub const BaseAcpiDevicePath = packed struct {
+    pub const BaseAcpiDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        hid: u32,
-        uid: u32,
+        length: u16 align(1),
+        hid: u32 align(1),
+        uid: u32 align(1),
     };
 
-    pub const ExpandedAcpiDevicePath = packed struct {
+    comptime {
+        std.debug.assert(12 == @sizeOf(BaseAcpiDevicePath));
+        std.debug.assert(1 == @alignOf(BaseAcpiDevicePath));
+
+        std.debug.assert(0 == @offsetOf(BaseAcpiDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(BaseAcpiDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(BaseAcpiDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(BaseAcpiDevicePath, "hid"));
+        std.debug.assert(8 == @offsetOf(BaseAcpiDevicePath, "uid"));
+    }
+
+    pub const ExpandedAcpiDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        hid: u32,
-        uid: u32,
-        cid: u32,
+        length: u16 align(1),
+        hid: u32 align(1),
+        uid: u32 align(1),
+        cid: u32 align(1),
         // variable length u16[*:0] strings
         // hid_str, uid_str, cid_str
     };
 
-    pub const AdrDevicePath = packed struct {
+    comptime {
+        std.debug.assert(16 == @sizeOf(ExpandedAcpiDevicePath));
+        std.debug.assert(1 == @alignOf(ExpandedAcpiDevicePath));
+
+        std.debug.assert(0 == @offsetOf(ExpandedAcpiDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(ExpandedAcpiDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(ExpandedAcpiDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(ExpandedAcpiDevicePath, "hid"));
+        std.debug.assert(8 == @offsetOf(ExpandedAcpiDevicePath, "uid"));
+        std.debug.assert(12 == @offsetOf(ExpandedAcpiDevicePath, "cid"));
+    }
+
+    pub const AdrDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        adr: u32,
+        length: u16 align(1),
+        adr: u32 align(1),
+
         // multiple adr entries can optionally follow
-        pub fn adrs(self: *const AdrDevicePath) []const u32 {
+        pub fn adrs(self: *const AdrDevicePath) []align(1) const u32 {
             // self.length is a minimum of 8 with one adr which is size 4.
             var entries = (self.length - 4) / @sizeOf(u32);
-            return @ptrCast([*]const u32, &self.adr)[0..entries];
+            return @ptrCast([*]align(1) const u32, &self.adr)[0..entries];
         }
     };
+
+    comptime {
+        std.debug.assert(8 == @sizeOf(AdrDevicePath));
+        std.debug.assert(1 == @alignOf(AdrDevicePath));
+
+        std.debug.assert(0 == @offsetOf(AdrDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(AdrDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(AdrDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(AdrDevicePath, "adr"));
+    }
 };
 
 pub const MessagingDevicePath = union(Subtype) {
@@ -279,7 +389,7 @@ pub const MessagingDevicePath = union(Subtype) {
         _,
     };
 
-    pub const AtapiDevicePath = packed struct {
+    pub const AtapiDevicePath = extern struct {
         const Role = enum(u8) {
             Master = 0,
             Slave = 1,
@@ -292,111 +402,249 @@ pub const MessagingDevicePath = union(Subtype) {
 
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
+        length: u16 align(1),
         primary_secondary: Rank,
         slave_master: Role,
-        logical_unit_number: u16,
+        logical_unit_number: u16 align(1),
     };
 
-    pub const ScsiDevicePath = packed struct {
+    comptime {
+        std.debug.assert(8 == @sizeOf(AtapiDevicePath));
+        std.debug.assert(1 == @alignOf(AtapiDevicePath));
+
+        std.debug.assert(0 == @offsetOf(AtapiDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(AtapiDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(AtapiDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(AtapiDevicePath, "primary_secondary"));
+        std.debug.assert(5 == @offsetOf(AtapiDevicePath, "slave_master"));
+        std.debug.assert(6 == @offsetOf(AtapiDevicePath, "logical_unit_number"));
+    }
+
+    pub const ScsiDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        target_id: u16,
-        logical_unit_number: u16,
+        length: u16 align(1),
+        target_id: u16 align(1),
+        logical_unit_number: u16 align(1),
     };
 
-    pub const FibreChannelDevicePath = packed struct {
+    comptime {
+        std.debug.assert(8 == @sizeOf(ScsiDevicePath));
+        std.debug.assert(1 == @alignOf(ScsiDevicePath));
+
+        std.debug.assert(0 == @offsetOf(ScsiDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(ScsiDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(ScsiDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(ScsiDevicePath, "target_id"));
+        std.debug.assert(6 == @offsetOf(ScsiDevicePath, "logical_unit_number"));
+    }
+
+    pub const FibreChannelDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        reserved: u32,
-        world_wide_name: u64,
-        logical_unit_number: u64,
+        length: u16 align(1),
+        reserved: u32 align(1),
+        world_wide_name: u64 align(1),
+        logical_unit_number: u64 align(1),
     };
 
-    pub const FibreChannelExDevicePath = packed struct {
+    comptime {
+        std.debug.assert(24 == @sizeOf(FibreChannelDevicePath));
+        std.debug.assert(1 == @alignOf(FibreChannelDevicePath));
+
+        std.debug.assert(0 == @offsetOf(FibreChannelDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(FibreChannelDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(FibreChannelDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(FibreChannelDevicePath, "reserved"));
+        std.debug.assert(8 == @offsetOf(FibreChannelDevicePath, "world_wide_name"));
+        std.debug.assert(16 == @offsetOf(FibreChannelDevicePath, "logical_unit_number"));
+    }
+
+    pub const FibreChannelExDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        reserved: u32,
-        world_wide_name: [8]u8,
-        logical_unit_number: [8]u8,
+        length: u16 align(1),
+        reserved: u32 align(1),
+        world_wide_name: u64 align(1),
+        logical_unit_number: u64 align(1),
     };
 
-    pub const F1394DevicePath = packed struct {
+    comptime {
+        std.debug.assert(24 == @sizeOf(FibreChannelExDevicePath));
+        std.debug.assert(1 == @alignOf(FibreChannelExDevicePath));
+
+        std.debug.assert(0 == @offsetOf(FibreChannelExDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(FibreChannelExDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(FibreChannelExDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(FibreChannelExDevicePath, "reserved"));
+        std.debug.assert(8 == @offsetOf(FibreChannelExDevicePath, "world_wide_name"));
+        std.debug.assert(16 == @offsetOf(FibreChannelExDevicePath, "logical_unit_number"));
+    }
+
+    pub const F1394DevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        reserved: u32,
-        guid: u64,
+        length: u16 align(1),
+        reserved: u32 align(1),
+        guid: u64 align(1),
     };
 
-    pub const UsbDevicePath = packed struct {
+    comptime {
+        std.debug.assert(16 == @sizeOf(F1394DevicePath));
+        std.debug.assert(1 == @alignOf(F1394DevicePath));
+
+        std.debug.assert(0 == @offsetOf(F1394DevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(F1394DevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(F1394DevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(F1394DevicePath, "reserved"));
+        std.debug.assert(8 == @offsetOf(F1394DevicePath, "guid"));
+    }
+
+    pub const UsbDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
+        length: u16 align(1),
         parent_port_number: u8,
         interface_number: u8,
     };
 
-    pub const SataDevicePath = packed struct {
+    comptime {
+        std.debug.assert(6 == @sizeOf(UsbDevicePath));
+        std.debug.assert(1 == @alignOf(UsbDevicePath));
+
+        std.debug.assert(0 == @offsetOf(UsbDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(UsbDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(UsbDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(UsbDevicePath, "parent_port_number"));
+        std.debug.assert(5 == @offsetOf(UsbDevicePath, "interface_number"));
+    }
+
+    pub const SataDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        hba_port_number: u16,
-        port_multiplier_port_number: u16,
-        logical_unit_number: u16,
+        length: u16 align(1),
+        hba_port_number: u16 align(1),
+        port_multiplier_port_number: u16 align(1),
+        logical_unit_number: u16 align(1),
     };
 
-    pub const UsbWwidDevicePath = packed struct {
+    comptime {
+        std.debug.assert(10 == @sizeOf(SataDevicePath));
+        std.debug.assert(1 == @alignOf(SataDevicePath));
+
+        std.debug.assert(0 == @offsetOf(SataDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(SataDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(SataDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(SataDevicePath, "hba_port_number"));
+        std.debug.assert(6 == @offsetOf(SataDevicePath, "port_multiplier_port_number"));
+        std.debug.assert(8 == @offsetOf(SataDevicePath, "logical_unit_number"));
+    }
+
+    pub const UsbWwidDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        interface_number: u16,
-        device_vendor_id: u16,
-        device_product_id: u16,
+        length: u16 align(1),
+        interface_number: u16 align(1),
+        device_vendor_id: u16 align(1),
+        device_product_id: u16 align(1),
 
-        pub fn serial_number(self: *const UsbWwidDevicePath) []const u16 {
+        pub fn serial_number(self: *const UsbWwidDevicePath) []align(1) const u16 {
             var serial_len = (self.length - @sizeOf(UsbWwidDevicePath)) / @sizeOf(u16);
-            return @ptrCast([*]u16, @ptrCast([*]u8, self) + @sizeOf(UsbWwidDevicePath))[0..serial_len];
+            return @ptrCast([*]align(1) const u16, @ptrCast([*]const u8, self) + @sizeOf(UsbWwidDevicePath))[0..serial_len];
         }
     };
 
-    pub const DeviceLogicalUnitDevicePath = packed struct {
+    comptime {
+        std.debug.assert(10 == @sizeOf(UsbWwidDevicePath));
+        std.debug.assert(1 == @alignOf(UsbWwidDevicePath));
+
+        std.debug.assert(0 == @offsetOf(UsbWwidDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(UsbWwidDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(UsbWwidDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(UsbWwidDevicePath, "interface_number"));
+        std.debug.assert(6 == @offsetOf(UsbWwidDevicePath, "device_vendor_id"));
+        std.debug.assert(8 == @offsetOf(UsbWwidDevicePath, "device_product_id"));
+    }
+
+    pub const DeviceLogicalUnitDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
+        length: u16 align(1),
         lun: u8,
     };
 
-    pub const UsbClassDevicePath = packed struct {
+    comptime {
+        std.debug.assert(5 == @sizeOf(DeviceLogicalUnitDevicePath));
+        std.debug.assert(1 == @alignOf(DeviceLogicalUnitDevicePath));
+
+        std.debug.assert(0 == @offsetOf(DeviceLogicalUnitDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(DeviceLogicalUnitDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(DeviceLogicalUnitDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(DeviceLogicalUnitDevicePath, "lun"));
+    }
+
+    pub const UsbClassDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        vendor_id: u16,
-        product_id: u16,
+        length: u16 align(1),
+        vendor_id: u16 align(1),
+        product_id: u16 align(1),
         device_class: u8,
         device_subclass: u8,
         device_protocol: u8,
     };
 
-    pub const I2oDevicePath = packed struct {
+    comptime {
+        std.debug.assert(11 == @sizeOf(UsbClassDevicePath));
+        std.debug.assert(1 == @alignOf(UsbClassDevicePath));
+
+        std.debug.assert(0 == @offsetOf(UsbClassDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(UsbClassDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(UsbClassDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(UsbClassDevicePath, "vendor_id"));
+        std.debug.assert(6 == @offsetOf(UsbClassDevicePath, "product_id"));
+        std.debug.assert(8 == @offsetOf(UsbClassDevicePath, "device_class"));
+        std.debug.assert(9 == @offsetOf(UsbClassDevicePath, "device_subclass"));
+        std.debug.assert(10 == @offsetOf(UsbClassDevicePath, "device_protocol"));
+    }
+
+    pub const I2oDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        tid: u32,
+        length: u16 align(1),
+        tid: u32 align(1),
     };
 
-    pub const MacAddressDevicePath = packed struct {
+    comptime {
+        std.debug.assert(8 == @sizeOf(I2oDevicePath));
+        std.debug.assert(1 == @alignOf(I2oDevicePath));
+
+        std.debug.assert(0 == @offsetOf(I2oDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(I2oDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(I2oDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(I2oDevicePath, "tid"));
+    }
+
+    pub const MacAddressDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
+        length: u16 align(1),
         mac_address: uefi.MacAddress,
         if_type: u8,
     };
 
-    pub const Ipv4DevicePath = packed struct {
+    comptime {
+        std.debug.assert(37 == @sizeOf(MacAddressDevicePath));
+        std.debug.assert(1 == @alignOf(MacAddressDevicePath));
+
+        std.debug.assert(0 == @offsetOf(MacAddressDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(MacAddressDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(MacAddressDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(MacAddressDevicePath, "mac_address"));
+        std.debug.assert(36 == @offsetOf(MacAddressDevicePath, "if_type"));
+    }
+
+    pub const Ipv4DevicePath = extern struct {
         pub const IpType = enum(u8) {
             Dhcp = 0,
             Static = 1,
@@ -404,18 +652,35 @@ pub const MessagingDevicePath = union(Subtype) {
 
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        local_ip_address: uefi.Ipv4Address,
-        remote_ip_address: uefi.Ipv4Address,
-        local_port: u16,
-        remote_port: u16,
-        network_protocol: u16,
+        length: u16 align(1),
+        local_ip_address: uefi.Ipv4Address align(1),
+        remote_ip_address: uefi.Ipv4Address align(1),
+        local_port: u16 align(1),
+        remote_port: u16 align(1),
+        network_protocol: u16 align(1),
         static_ip_address: IpType,
-        gateway_ip_address: u32,
-        subnet_mask: u32,
+        gateway_ip_address: u32 align(1),
+        subnet_mask: u32 align(1),
     };
 
-    pub const Ipv6DevicePath = packed struct {
+    comptime {
+        std.debug.assert(27 == @sizeOf(Ipv4DevicePath));
+        std.debug.assert(1 == @alignOf(Ipv4DevicePath));
+
+        std.debug.assert(0 == @offsetOf(Ipv4DevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(Ipv4DevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(Ipv4DevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(Ipv4DevicePath, "local_ip_address"));
+        std.debug.assert(8 == @offsetOf(Ipv4DevicePath, "remote_ip_address"));
+        std.debug.assert(12 == @offsetOf(Ipv4DevicePath, "local_port"));
+        std.debug.assert(14 == @offsetOf(Ipv4DevicePath, "remote_port"));
+        std.debug.assert(16 == @offsetOf(Ipv4DevicePath, "network_protocol"));
+        std.debug.assert(18 == @offsetOf(Ipv4DevicePath, "static_ip_address"));
+        std.debug.assert(19 == @offsetOf(Ipv4DevicePath, "gateway_ip_address"));
+        std.debug.assert(23 == @offsetOf(Ipv4DevicePath, "subnet_mask"));
+    }
+
+    pub const Ipv6DevicePath = extern struct {
         pub const Origin = enum(u8) {
             Manual = 0,
             AssignedStateless = 1,
@@ -424,26 +689,53 @@ pub const MessagingDevicePath = union(Subtype) {
 
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
+        length: u16 align(1),
         local_ip_address: uefi.Ipv6Address,
         remote_ip_address: uefi.Ipv6Address,
-        local_port: u16,
-        remote_port: u16,
-        protocol: u16,
+        local_port: u16 align(1),
+        remote_port: u16 align(1),
+        protocol: u16 align(1),
         ip_address_origin: Origin,
         prefix_length: u8,
         gateway_ip_address: uefi.Ipv6Address,
     };
 
-    pub const VlanDevicePath = packed struct {
+    comptime {
+        std.debug.assert(60 == @sizeOf(Ipv6DevicePath));
+        std.debug.assert(1 == @alignOf(Ipv6DevicePath));
+
+        std.debug.assert(0 == @offsetOf(Ipv6DevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(Ipv6DevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(Ipv6DevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(Ipv6DevicePath, "local_ip_address"));
+        std.debug.assert(20 == @offsetOf(Ipv6DevicePath, "remote_ip_address"));
+        std.debug.assert(36 == @offsetOf(Ipv6DevicePath, "local_port"));
+        std.debug.assert(38 == @offsetOf(Ipv6DevicePath, "remote_port"));
+        std.debug.assert(40 == @offsetOf(Ipv6DevicePath, "protocol"));
+        std.debug.assert(42 == @offsetOf(Ipv6DevicePath, "ip_address_origin"));
+        std.debug.assert(43 == @offsetOf(Ipv6DevicePath, "prefix_length"));
+        std.debug.assert(44 == @offsetOf(Ipv6DevicePath, "gateway_ip_address"));
+    }
+
+    pub const VlanDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        vlan_id: u16,
+        length: u16 align(1),
+        vlan_id: u16 align(1),
     };
 
-    pub const InfiniBandDevicePath = packed struct {
-        pub const ResourceFlags = packed struct {
+    comptime {
+        std.debug.assert(6 == @sizeOf(VlanDevicePath));
+        std.debug.assert(1 == @alignOf(VlanDevicePath));
+
+        std.debug.assert(0 == @offsetOf(VlanDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(VlanDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(VlanDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(VlanDevicePath, "vlan_id"));
+    }
+
+    pub const InfiniBandDevicePath = extern struct {
+        pub const ResourceFlags = packed struct(u32) {
             pub const ControllerType = enum(u1) {
                 Ioc = 0,
                 Service = 1,
@@ -461,15 +753,29 @@ pub const MessagingDevicePath = union(Subtype) {
 
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        resource_flags: ResourceFlags,
+        length: u16 align(1),
+        resource_flags: ResourceFlags align(1),
         port_gid: [16]u8,
-        service_id: u64,
-        target_port_id: u64,
-        device_id: u64,
+        service_id: u64 align(1),
+        target_port_id: u64 align(1),
+        device_id: u64 align(1),
     };
 
-    pub const UartDevicePath = packed struct {
+    comptime {
+        std.debug.assert(48 == @sizeOf(InfiniBandDevicePath));
+        std.debug.assert(1 == @alignOf(InfiniBandDevicePath));
+
+        std.debug.assert(0 == @offsetOf(InfiniBandDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(InfiniBandDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(InfiniBandDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(InfiniBandDevicePath, "resource_flags"));
+        std.debug.assert(8 == @offsetOf(InfiniBandDevicePath, "port_gid"));
+        std.debug.assert(24 == @offsetOf(InfiniBandDevicePath, "service_id"));
+        std.debug.assert(32 == @offsetOf(InfiniBandDevicePath, "target_port_id"));
+        std.debug.assert(40 == @offsetOf(InfiniBandDevicePath, "device_id"));
+    }
+
+    pub const UartDevicePath = extern struct {
         pub const Parity = enum(u8) {
             Default = 0,
             None = 1,
@@ -490,20 +796,44 @@ pub const MessagingDevicePath = union(Subtype) {
 
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        reserved: u16,
-        baud_rate: u32,
+        length: u16 align(1),
+        reserved: u32 align(1),
+        baud_rate: u64 align(1),
         data_bits: u8,
         parity: Parity,
         stop_bits: StopBits,
     };
 
-    pub const VendorDefinedDevicePath = packed struct {
+    comptime {
+        std.debug.assert(19 == @sizeOf(UartDevicePath));
+        std.debug.assert(1 == @alignOf(UartDevicePath));
+
+        std.debug.assert(0 == @offsetOf(UartDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(UartDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(UartDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(UartDevicePath, "reserved"));
+        std.debug.assert(8 == @offsetOf(UartDevicePath, "baud_rate"));
+        std.debug.assert(16 == @offsetOf(UartDevicePath, "data_bits"));
+        std.debug.assert(17 == @offsetOf(UartDevicePath, "parity"));
+        std.debug.assert(18 == @offsetOf(UartDevicePath, "stop_bits"));
+    }
+
+    pub const VendorDefinedDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        vendor_guid: Guid,
+        length: u16 align(1),
+        vendor_guid: Guid align(1),
     };
+
+    comptime {
+        std.debug.assert(20 == @sizeOf(VendorDefinedDevicePath));
+        std.debug.assert(1 == @alignOf(VendorDefinedDevicePath));
+
+        std.debug.assert(0 == @offsetOf(VendorDefinedDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(VendorDefinedDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(VendorDefinedDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(VendorDefinedDevicePath, "vendor_guid"));
+    }
 };
 
 pub const MediaDevicePath = union(Subtype) {
@@ -530,7 +860,7 @@ pub const MediaDevicePath = union(Subtype) {
         _,
     };
 
-    pub const HardDriveDevicePath = packed struct {
+    pub const HardDriveDevicePath = extern struct {
         pub const Format = enum(u8) {
             LegacyMbr = 0x01,
             GuidPartitionTable = 0x02,
@@ -545,81 +875,181 @@ pub const MediaDevicePath = union(Subtype) {
 
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        partition_number: u32,
-        partition_start: u64,
-        partition_size: u64,
+        length: u16 align(1),
+        partition_number: u32 align(1),
+        partition_start: u64 align(1),
+        partition_size: u64 align(1),
         partition_signature: [16]u8,
         partition_format: Format,
         signature_type: SignatureType,
     };
 
-    pub const CdromDevicePath = packed struct {
+    comptime {
+        std.debug.assert(42 == @sizeOf(HardDriveDevicePath));
+        std.debug.assert(1 == @alignOf(HardDriveDevicePath));
+
+        std.debug.assert(0 == @offsetOf(HardDriveDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(HardDriveDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(HardDriveDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(HardDriveDevicePath, "partition_number"));
+        std.debug.assert(8 == @offsetOf(HardDriveDevicePath, "partition_start"));
+        std.debug.assert(16 == @offsetOf(HardDriveDevicePath, "partition_size"));
+        std.debug.assert(24 == @offsetOf(HardDriveDevicePath, "partition_signature"));
+        std.debug.assert(40 == @offsetOf(HardDriveDevicePath, "partition_format"));
+        std.debug.assert(41 == @offsetOf(HardDriveDevicePath, "signature_type"));
+    }
+
+    pub const CdromDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        boot_entry: u32,
-        partition_start: u64,
-        partition_size: u64,
+        length: u16 align(1),
+        boot_entry: u32 align(1),
+        partition_start: u64 align(1),
+        partition_size: u64 align(1),
     };
 
-    pub const VendorDevicePath = packed struct {
+    comptime {
+        std.debug.assert(24 == @sizeOf(CdromDevicePath));
+        std.debug.assert(1 == @alignOf(CdromDevicePath));
+
+        std.debug.assert(0 == @offsetOf(CdromDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(CdromDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(CdromDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(CdromDevicePath, "boot_entry"));
+        std.debug.assert(8 == @offsetOf(CdromDevicePath, "partition_start"));
+        std.debug.assert(16 == @offsetOf(CdromDevicePath, "partition_size"));
+    }
+
+    pub const VendorDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        guid: Guid,
-        // vendor-defined variable data
+        length: u16 align(1),
+        guid: Guid align(1),
     };
 
-    pub const FilePathDevicePath = packed struct {
+    comptime {
+        std.debug.assert(20 == @sizeOf(VendorDevicePath));
+        std.debug.assert(1 == @alignOf(VendorDevicePath));
+
+        std.debug.assert(0 == @offsetOf(VendorDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(VendorDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(VendorDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(VendorDevicePath, "guid"));
+    }
+
+    pub const FilePathDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
+        length: u16 align(1),
 
-        pub fn getPath(self: *const FilePathDevicePath) [*:0]const u16 {
-            return @ptrCast([*:0]const u16, @alignCast(2, @ptrCast([*]const u8, self)) + @sizeOf(FilePathDevicePath));
+        pub fn getPath(self: *const FilePathDevicePath) [*:0]align(1) const u16 {
+            return @ptrCast([*:0]align(1) const u16, @ptrCast([*]const u8, self) + @sizeOf(FilePathDevicePath));
         }
     };
 
-    pub const MediaProtocolDevicePath = packed struct {
+    comptime {
+        std.debug.assert(4 == @sizeOf(FilePathDevicePath));
+        std.debug.assert(1 == @alignOf(FilePathDevicePath));
+
+        std.debug.assert(0 == @offsetOf(FilePathDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(FilePathDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(FilePathDevicePath, "length"));
+    }
+
+    pub const MediaProtocolDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        guid: Guid,
+        length: u16 align(1),
+        guid: Guid align(1),
     };
 
-    pub const PiwgFirmwareFileDevicePath = packed struct {
+    comptime {
+        std.debug.assert(20 == @sizeOf(MediaProtocolDevicePath));
+        std.debug.assert(1 == @alignOf(MediaProtocolDevicePath));
+
+        std.debug.assert(0 == @offsetOf(MediaProtocolDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(MediaProtocolDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(MediaProtocolDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(MediaProtocolDevicePath, "guid"));
+    }
+
+    pub const PiwgFirmwareFileDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        fv_filename: Guid,
+        length: u16 align(1),
+        fv_filename: Guid align(1),
     };
 
-    pub const PiwgFirmwareVolumeDevicePath = packed struct {
+    comptime {
+        std.debug.assert(20 == @sizeOf(PiwgFirmwareFileDevicePath));
+        std.debug.assert(1 == @alignOf(PiwgFirmwareFileDevicePath));
+
+        std.debug.assert(0 == @offsetOf(PiwgFirmwareFileDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(PiwgFirmwareFileDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(PiwgFirmwareFileDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(PiwgFirmwareFileDevicePath, "fv_filename"));
+    }
+
+    pub const PiwgFirmwareVolumeDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        fv_name: Guid,
+        length: u16 align(1),
+        fv_name: Guid align(1),
     };
 
-    pub const RelativeOffsetRangeDevicePath = packed struct {
+    comptime {
+        std.debug.assert(20 == @sizeOf(PiwgFirmwareVolumeDevicePath));
+        std.debug.assert(1 == @alignOf(PiwgFirmwareVolumeDevicePath));
+
+        std.debug.assert(0 == @offsetOf(PiwgFirmwareVolumeDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(PiwgFirmwareVolumeDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(PiwgFirmwareVolumeDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(PiwgFirmwareVolumeDevicePath, "fv_name"));
+    }
+
+    pub const RelativeOffsetRangeDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        reserved: u32,
-        start: u64,
-        end: u64,
+        length: u16 align(1),
+        reserved: u32 align(1),
+        start: u64 align(1),
+        end: u64 align(1),
     };
 
-    pub const RamDiskDevicePath = packed struct {
+    comptime {
+        std.debug.assert(24 == @sizeOf(RelativeOffsetRangeDevicePath));
+        std.debug.assert(1 == @alignOf(RelativeOffsetRangeDevicePath));
+
+        std.debug.assert(0 == @offsetOf(RelativeOffsetRangeDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(RelativeOffsetRangeDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(RelativeOffsetRangeDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(RelativeOffsetRangeDevicePath, "reserved"));
+        std.debug.assert(8 == @offsetOf(RelativeOffsetRangeDevicePath, "start"));
+        std.debug.assert(16 == @offsetOf(RelativeOffsetRangeDevicePath, "end"));
+    }
+
+    pub const RamDiskDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        start: u64,
-        end: u64,
-        disk_type: Guid,
-        instance: u16,
+        length: u16 align(1),
+        start: u64 align(1),
+        end: u64 align(1),
+        disk_type: Guid align(1),
+        instance: u16 align(1),
     };
+
+    comptime {
+        std.debug.assert(38 == @sizeOf(RamDiskDevicePath));
+        std.debug.assert(1 == @alignOf(RamDiskDevicePath));
+
+        std.debug.assert(0 == @offsetOf(RamDiskDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(RamDiskDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(RamDiskDevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(RamDiskDevicePath, "start"));
+        std.debug.assert(12 == @offsetOf(RamDiskDevicePath, "end"));
+        std.debug.assert(20 == @offsetOf(RamDiskDevicePath, "disk_type"));
+        std.debug.assert(36 == @offsetOf(RamDiskDevicePath, "instance"));
+    }
 };
 
 pub const BiosBootSpecificationDevicePath = union(Subtype) {
@@ -630,17 +1060,28 @@ pub const BiosBootSpecificationDevicePath = union(Subtype) {
         _,
     };
 
-    pub const BBS101DevicePath = packed struct {
+    pub const BBS101DevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
-        device_type: u16,
-        status_flag: u16,
+        length: u16 align(1),
+        device_type: u16 align(1),
+        status_flag: u16 align(1),
 
         pub fn getDescription(self: *const BBS101DevicePath) [*:0]const u8 {
             return @ptrCast([*:0]const u8, self) + @sizeOf(BBS101DevicePath);
         }
     };
+
+    comptime {
+        std.debug.assert(8 == @sizeOf(BBS101DevicePath));
+        std.debug.assert(1 == @alignOf(BBS101DevicePath));
+
+        std.debug.assert(0 == @offsetOf(BBS101DevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(BBS101DevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(BBS101DevicePath, "length"));
+        std.debug.assert(4 == @offsetOf(BBS101DevicePath, "device_type"));
+        std.debug.assert(6 == @offsetOf(BBS101DevicePath, "status_flag"));
+    }
 };
 
 pub const EndDevicePath = union(Subtype) {
@@ -653,15 +1094,33 @@ pub const EndDevicePath = union(Subtype) {
         _,
     };
 
-    pub const EndEntireDevicePath = packed struct {
+    pub const EndEntireDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
+        length: u16 align(1),
     };
 
-    pub const EndThisInstanceDevicePath = packed struct {
+    comptime {
+        std.debug.assert(4 == @sizeOf(EndEntireDevicePath));
+        std.debug.assert(1 == @alignOf(EndEntireDevicePath));
+
+        std.debug.assert(0 == @offsetOf(EndEntireDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(EndEntireDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(EndEntireDevicePath, "length"));
+    }
+
+    pub const EndThisInstanceDevicePath = extern struct {
         type: DevicePathType,
         subtype: Subtype,
-        length: u16,
+        length: u16 align(1),
     };
+
+    comptime {
+        std.debug.assert(4 == @sizeOf(EndEntireDevicePath));
+        std.debug.assert(1 == @alignOf(EndEntireDevicePath));
+
+        std.debug.assert(0 == @offsetOf(EndEntireDevicePath, "type"));
+        std.debug.assert(1 == @offsetOf(EndEntireDevicePath, "subtype"));
+        std.debug.assert(2 == @offsetOf(EndEntireDevicePath, "length"));
+    }
 };

--- a/lib/std/os/uefi/protocols/edid_override_protocol.zig
+++ b/lib/std/os/uefi/protocols/edid_override_protocol.zig
@@ -6,19 +6,17 @@ const Status = uefi.Status;
 
 /// Override EDID information
 pub const EdidOverrideProtocol = extern struct {
-    _get_edid: std.meta.FnPtr(fn (*const EdidOverrideProtocol, Handle, *u32, *usize, *?[*]u8) callconv(.C) Status),
+    _get_edid: std.meta.FnPtr(fn (*const EdidOverrideProtocol, Handle, *EdidOverrideProtocolAttributes, *usize, *?[*]u8) callconv(.C) Status),
 
     /// Returns policy information and potentially a replacement EDID for the specified video output device.
     pub fn getEdid(
         self: *const EdidOverrideProtocol,
         handle: Handle,
-        /// The align(4) here should really be part of the EdidOverrideProtocolAttributes type.
-        /// TODO remove this workaround when packed(u32) structs are implemented.
-        attributes: *align(4) EdidOverrideProtocolAttributes,
+        attributes: *EdidOverrideProtocolAttributes,
         edid_size: *usize,
         edid: *?[*]u8,
     ) Status {
-        return self._get_edid(self, handle, @ptrCast(*u32, attributes), edid_size, edid);
+        return self._get_edid(self, handle, attributes, edid_size, edid);
     }
 
     pub const guid align(8) = Guid{
@@ -31,7 +29,7 @@ pub const EdidOverrideProtocol = extern struct {
     };
 };
 
-pub const EdidOverrideProtocolAttributes = packed struct {
+pub const EdidOverrideProtocolAttributes = packed struct(u32) {
     dont_override: bool,
     enable_hot_plug: bool,
     _pad: u30 = 0,

--- a/lib/std/os/uefi/protocols/hii.zig
+++ b/lib/std/os/uefi/protocols/hii.zig
@@ -4,7 +4,7 @@ const Guid = uefi.Guid;
 pub const HIIHandle = *opaque {};
 
 /// The header found at the start of each package.
-pub const HIIPackageHeader = packed struct {
+pub const HIIPackageHeader = packed struct(u32) {
     length: u24,
     type: u8,
 
@@ -43,23 +43,27 @@ pub const HIISimplifiedFontPackage = extern struct {
     }
 };
 
+pub const NarrowGlyphAttributes = packed struct(u8) {
+    non_spacing: bool,
+    wide: bool,
+    _pad: u6 = 0,
+};
+
 pub const NarrowGlyph = extern struct {
     unicode_weight: u16,
-    attributes: packed struct {
-        non_spacing: bool,
-        wide: bool,
-        _pad: u6 = 0,
-    },
+    attributes: NarrowGlyphAttributes,
     glyph_col_1: [19]u8,
+};
+
+pub const WideGlyphAttributes = packed struct(u8) {
+    non_spacing: bool,
+    wide: bool,
+    _pad: u6 = 0,
 };
 
 pub const WideGlyph = extern struct {
     unicode_weight: u16,
-    attributes: packed struct {
-        non_spacing: bool,
-        wide: bool,
-        _pad: u6,
-    },
+    attributes: WideGlyphAttributes,
     glyph_col_1: [19]u8,
     glyph_col_2: [19]u8,
     _pad: [3]u8 = [_]u8{0} ** 3,

--- a/lib/std/os/uefi/protocols/simple_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_network_protocol.zig
@@ -121,7 +121,7 @@ pub const SimpleNetworkMode = extern struct {
     media_present: bool,
 };
 
-pub const SimpleNetworkReceiveFilter = packed struct {
+pub const SimpleNetworkReceiveFilter = packed struct(u32) {
     receive_unicast: bool,
     receive_multicast: bool,
     receive_broadcast: bool,
@@ -165,7 +165,7 @@ pub const NetworkStatistics = extern struct {
     tx_retry_frames: u64,
 };
 
-pub const SimpleNetworkInterruptStatus = packed struct {
+pub const SimpleNetworkInterruptStatus = packed struct(u32) {
     receive_interrupt: bool,
     transmit_interrupt: bool,
     command_interrupt: bool,

--- a/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
@@ -53,29 +53,33 @@ pub const KeyData = extern struct {
     key_state: KeyState = undefined,
 };
 
+pub const KeyShiftState = packed struct(u32) {
+    right_shift_pressed: bool,
+    left_shift_pressed: bool,
+    right_control_pressed: bool,
+    left_control_pressed: bool,
+    right_alt_pressed: bool,
+    left_alt_pressed: bool,
+    right_logo_pressed: bool,
+    left_logo_pressed: bool,
+    menu_key_pressed: bool,
+    sys_req_pressed: bool,
+    _pad: u21 = 0,
+    shift_state_valid: bool,
+};
+
+pub const KeyToggleState = packed struct(u8) {
+    scroll_lock_active: bool,
+    num_lock_active: bool,
+    caps_lock_active: bool,
+    _pad: u3 = 0,
+    key_state_exposed: bool,
+    toggle_state_valid: bool,
+};
+
 pub const KeyState = extern struct {
-    key_shift_state: packed struct {
-        right_shift_pressed: bool,
-        left_shift_pressed: bool,
-        right_control_pressed: bool,
-        left_control_pressed: bool,
-        right_alt_pressed: bool,
-        left_alt_pressed: bool,
-        right_logo_pressed: bool,
-        left_logo_pressed: bool,
-        menu_key_pressed: bool,
-        sys_req_pressed: bool,
-        _pad: u21 = 0,
-        shift_state_valid: bool,
-    },
-    key_toggle_state: packed struct {
-        scroll_lock_active: bool,
-        num_lock_active: bool,
-        caps_lock_active: bool,
-        _pad: u3 = 0,
-        key_state_exposed: bool,
-        toggle_state_valid: bool,
-    },
+    key_shift_state: KeyShiftState,
+    key_toggle_state: KeyToggleState,
 };
 
 pub const InputKey = extern struct {

--- a/lib/std/os/uefi/tables.zig
+++ b/lib/std/os/uefi/tables.zig
@@ -3,3 +3,7 @@ pub usingnamespace @import("tables/runtime_services.zig");
 pub usingnamespace @import("tables/configuration_table.zig");
 pub usingnamespace @import("tables/system_table.zig");
 pub usingnamespace @import("tables/table_header.zig");
+
+comptime {
+    @import("std").testing.refAllDeclsRecursive(@This());
+}

--- a/lib/std/os/uefi/tables.zig
+++ b/lib/std/os/uefi/tables.zig
@@ -4,6 +4,6 @@ pub usingnamespace @import("tables/configuration_table.zig");
 pub usingnamespace @import("tables/system_table.zig");
 pub usingnamespace @import("tables/table_header.zig");
 
-comptime {
+test {
     @import("std").testing.refAllDeclsRecursive(@This());
 }

--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -219,33 +219,32 @@ pub const MemoryType = enum(u32) {
     _,
 };
 
+pub const MemoryDescriptorAttribute = packed struct(u64) {
+    uc: bool,
+    wc: bool,
+    wt: bool,
+    wb: bool,
+    uce: bool,
+    _pad1: u7 = 0,
+    wp: bool,
+    rp: bool,
+    xp: bool,
+    nv: bool,
+    more_reliable: bool,
+    ro: bool,
+    sp: bool,
+    cpu_crypto: bool,
+    _pad2: u43 = 0,
+    memory_runtime: bool,
+};
+
 pub const MemoryDescriptor = extern struct {
     type: MemoryType,
     padding: u32,
     physical_start: u64,
     virtual_start: u64,
     number_of_pages: usize,
-    attribute: packed struct {
-        uc: bool,
-        wc: bool,
-        wt: bool,
-        wb: bool,
-        uce: bool,
-        _pad1: u3,
-        _pad2: u4,
-        wp: bool,
-        rp: bool,
-        xp: bool,
-        nv: bool,
-        more_reliable: bool,
-        ro: bool,
-        sp: bool,
-        cpu_crypto: bool,
-        _pad3: u4,
-        _pad4: u32,
-        _pad5: u7,
-        memory_runtime: bool,
-    },
+    attribute: MemoryDescriptorAttribute,
 };
 
 pub const LocateSearchType = enum(u32) {
@@ -254,14 +253,14 @@ pub const LocateSearchType = enum(u32) {
     ByProtocol,
 };
 
-pub const OpenProtocolAttributes = packed struct {
+pub const OpenProtocolAttributes = packed struct(u32) {
     by_handle_protocol: bool = false,
     get_protocol: bool = false,
     test_protocol: bool = false,
     by_child_controller: bool = false,
     by_driver: bool = false,
     exclusive: bool = false,
-    _pad: u26 = 0,
+    reserved: u26 = 0,
 };
 
 pub const ProtocolInformationEntry = extern struct {

--- a/lib/std/os/uefi/tables/runtime_services.zig
+++ b/lib/std/os/uefi/tables/runtime_services.zig
@@ -78,7 +78,7 @@ pub const CapsuleHeader = extern struct {
 
 pub const UefiCapsuleBlockDescriptor = extern struct {
     length: u64,
-    address: union {
+    address: extern union {
         dataBlock: EfiPhysicalAddress,
         continuationPointer: EfiPhysicalAddress,
     },


### PR DESCRIPTION
* device_path_protocol now uses extern structs with align(1) fields because
the transition to integer backed packed struct broke alignment

* added comptime asserts that device_path_protocol structs do not violate
alignment and size specifications