### PR TITLE
stage2: remove `--verbose-mir` from help menu

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -510,7 +510,6 @@ const usage_build_generic =
     \\  --verbose-link               Display linker invocations
     \\  --verbose-cc                 Display C compiler invocations
     \\  --verbose-air                Enable compiler debug output for Zig AIR
-    \\  --verbose-mir                Enable compiler debug output for Zig MIR
     \\  --verbose-llvm-ir            Enable compiler debug output for LLVM IR
     \\  --verbose-cimport            Enable compiler debug output for C imports
     \\  --verbose-llvm-cpu-features  Enable compiler debug output for LLVM CPU features


### PR DESCRIPTION
handler removed in https://github.com/ziglang/zig/commit/5f97652da8881773b823a0730e5791816668528a