### PR TITLE
[elf] main.zig: add -z nocopyreloc

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -697,6 +697,7 @@ fn buildOutputType(
     var linker_print_gc_sections: bool = false;
     var linker_print_icf_sections: bool = false;
     var linker_print_map: bool = false;
+    var linker_z_nocopyreloc = false;
     var linker_z_nodelete = false;
     var linker_z_notext = false;
     var linker_z_defs = false;
@@ -1261,6 +1262,8 @@ fn buildOutputType(
                             linker_z_defs = true;
                         } else if (mem.eql(u8, z_arg, "origin")) {
                             linker_z_origin = true;
+                        } else if (mem.eql(u8, z_arg, "nocopyreloc")) {
+                            linker_z_nocopyreloc = true;
                         } else if (mem.eql(u8, z_arg, "now")) {
                             linker_z_now = true;
                         } else if (mem.eql(u8, z_arg, "lazy")) {
@@ -1824,6 +1827,8 @@ fn buildOutputType(
                         linker_z_defs = true;
                     } else if (mem.eql(u8, z_arg, "origin")) {
                         linker_z_origin = true;
+                    } else if (mem.eql(u8, z_arg, "nocopyreloc")) {
+                        linker_z_nocopyreloc = true;
                     } else if (mem.eql(u8, z_arg, "noexecstack")) {
                         // noexecstack is the default when linking with LLD
                     } else if (mem.eql(u8, z_arg, "now")) {
@@ -2893,6 +2898,7 @@ fn buildOutputType(
         .linker_print_map = linker_print_map,
         .linker_global_base = linker_global_base,
         .linker_export_symbol_names = linker_export_symbol_names.items,
+        .linker_z_nocopyreloc = linker_z_nocopyreloc,
         .linker_z_nodelete = linker_z_nodelete,
         .linker_z_notext = linker_z_notext,
         .linker_z_defs = linker_z_defs,


### PR DESCRIPTION
I did not fully wire it up in main.zig when I originally implemented `-z nocopyreloc` in #11679 (440f5249f1a). Finish it.

If we strictly follow the rules, we should bump the cache version, since the field was technically added only now. But since nobody complained thus far, I don't think many users care that much about it and we can omit it.