### PR TITLE
enable tests on emutls implementation even if not used on all platforms

### DIFF
--- a/lib/compiler_rt/emutls.zig
+++ b/lib/compiler_rt/emutls.zig
@@ -323,7 +323,7 @@ const emutls_control = extern struct {
 };
 
 test "simple_allocator" {
-    if (!builtin.link_libc or builtin.os.tag != .openbsd) return error.SkipZigTest;
+    if (!builtin.link_libc) return error.SkipZigTest;
 
     var data1: *[64]u8 = simple_allocator.alloc([64]u8);
     defer simple_allocator.free(data1);
@@ -339,7 +339,7 @@ test "simple_allocator" {
 }
 
 test "__emutls_get_address zeroed" {
-    if (!builtin.link_libc or builtin.os.tag != .openbsd) return error.SkipZigTest;
+    if (!builtin.link_libc) return error.SkipZigTest;
 
     var ctl = emutls_control.init(usize, null);
     try expect(ctl.object.index == 0);
@@ -360,7 +360,7 @@ test "__emutls_get_address zeroed" {
 }
 
 test "__emutls_get_address with default_value" {
-    if (!builtin.link_libc or builtin.os.tag != .openbsd) return error.SkipZigTest;
+    if (!builtin.link_libc) return error.SkipZigTest;
 
     const value: usize = 5678; // default value
     var ctl = emutls_control.init(usize, &value);
@@ -380,7 +380,7 @@ test "__emutls_get_address with default_value" {
 }
 
 test "test default_value with differents sizes" {
-    if (!builtin.link_libc or builtin.os.tag != .openbsd) return error.SkipZigTest;
+    if (!builtin.link_libc) return error.SkipZigTest;
 
     const testType = struct {
         fn _testType(comptime T: type, value: T) !void {

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -548,6 +548,8 @@ comptime {
     std.debug.assert(@alignOf(kinfo_file) == @sizeOf(u64));
 }
 
+pub const pthread_key_t = c_int;
+
 pub const CTL = struct {
     pub const KERN = 1;
     pub const DEBUG = 5;

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -364,3 +364,5 @@ pub const dirent64 = struct {
     d_type: u8,
     d_name: [256]u8,
 };
+
+pub const pthread_key_t = c_uint;


### PR DESCRIPTION
it should avoid untested commits which break OpenBSD.