### PR TITLE
stage2: allow comptime expressions for inline asm

### DIFF
--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -1883,6 +1883,11 @@ pub const Inst = struct {
         ///  * 0bX0000000_00000000 - is volatile
         /// `operand` is payload index to `Asm`.
         @"asm",
+        /// Same as `asm` except the assembly template is not a string literal but a comptime
+        /// expression.
+        /// The `asm_source` field of the Asm is not a null-terminated string
+        /// but instead a Ref.
+        asm_expr,
         /// Log compile time variables and emit an error message.
         /// `operand` is payload index to `NodeMultiOp`.
         /// `small` is `operands_len`.


### PR DESCRIPTION
It is not yet determined whether the Zig language will land on text-based string concatenation for inline assembly, as Zig 0.9.1 allows, and as this commit allows, or whether it will introduce a new assembly syntax more integrated with the rest of the language. Until this decision is made, this commit relaxes the restriction which was preventing inline assembly expressions from using comptime expressions for the assembly source code.