### PR TITLE
emutls: add const to default_value field

### DIFF
--- a/lib/compiler_rt/emutls.zig
+++ b/lib/compiler_rt/emutls.zig
@@ -141,7 +141,7 @@ const ObjectArray = struct {
 
             if (control.default_value) |value| {
                 // default value: copy the content to newly allocated object.
-                @memcpy(data, @ptrCast([*]u8, value), size);
+                @memcpy(data, @ptrCast([*]const u8, value), size);
             } else {
                 // no default: return zeroed memory.
                 @memset(data, 0, size);
@@ -236,7 +236,7 @@ const emutls_control = extern struct {
     },
 
     // null or non-zero initial value for the object
-    default_value: ?*anyopaque,
+    default_value: ?*const anyopaque,
 
     // global Mutex used to serialize control.index initialization.
     var mutex: std.c.pthread_mutex_t = std.c.PTHREAD_MUTEX_INITIALIZER;
@@ -291,7 +291,7 @@ const emutls_control = extern struct {
     }
 
     /// Simple helper for testing purpose.
-    pub fn init(comptime T: type, default_value: ?*T) emutls_control {
+    pub fn init(comptime T: type, default_value: ?*const T) emutls_control {
         return emutls_control{
             .size = @sizeOf(T),
             .alignment = @alignOf(T),
@@ -362,7 +362,7 @@ test "__emutls_get_address zeroed" {
 test "__emutls_get_address with default_value" {
     if (!builtin.link_libc or builtin.os.tag != .openbsd) return error.SkipZigTest;
 
-    var value: usize = 5678; // default value
+    const value: usize = 5678; // default value
     var ctl = emutls_control.init(usize, &value);
     try expect(ctl.object.index == 0);
 
@@ -384,8 +384,7 @@ test "test default_value with differents sizes" {
 
     const testType = struct {
         fn _testType(comptime T: type, value: T) !void {
-            var def: T = value;
-            var ctl = emutls_control.init(T, &def);
+            var ctl = emutls_control.init(T, &value);
             var x = ctl.get_typed_pointer(T);
             try expect(x.* == value);
         }


### PR DESCRIPTION
Commit f14cc75 accidentally added a const when grepping for assignments to `std.builtin.Type.StructField.default_value`, however when looking into it further, I noticed that even though this default_value field is emitted into the `.data` section, the value it points to is actually emitted into the `.rodata` section, so it seems correct to use const here.

Fixes https://github.com/ziglang/zig/pull/12975#issuecomment-1279956048