### PR TITLE
std.debug: define error set in DebugInfo.lookupModuleDl

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1375,7 +1375,7 @@ pub const DebugInfo = struct {
         } = .{ .address = address };
         const CtxTy = @TypeOf(ctx);
 
-        if (os.dl_iterate_phdr(&ctx, anyerror, struct {
+        if (os.dl_iterate_phdr(&ctx, error{Found}, struct {
             fn callback(info: *os.dl_phdr_info, size: usize, context: *CtxTy) !void {
                 _ = size;
                 // The base address is too high
@@ -1403,7 +1403,6 @@ pub const DebugInfo = struct {
             return error.MissingDebugInfo;
         } else |err| switch (err) {
             error.Found => {},
-            else => return error.MissingDebugInfo,
         }
 
         if (self.address_map.get(ctx.base_address)) |obj_di| {


### PR DESCRIPTION
tracing down an `error: else prong required when switching on type 'anyerror'` error while using some `std.debug` functions and thought this might be a lead. generally better for the stdlib to not use `anyerror`