### PR TITLE
std: CheckObject - correctly depend on its own step when creating an EmulatableRunStep

### DIFF
--- a/lib/std/build/CheckObjectStep.zig
+++ b/lib/std/build/CheckObjectStep.zig
@@ -45,7 +45,9 @@ pub fn runAndCompare(self: *CheckObjectStep) *EmulatableRunStep {
     assert(dependencies_len > 0);
     const exe_step = self.step.dependencies.items[dependencies_len - 1];
     const exe = exe_step.cast(std.build.LibExeObjStep).?;
-    return EmulatableRunStep.create(self.builder, "EmulatableRun", exe);
+    const emulatable_step = EmulatableRunStep.create(self.builder, "EmulatableRun", exe);
+    emulatable_step.step.dependOn(&self.step);
+    return emulatable_step;
 }
 
 /// There two types of actions currently suported:

--- a/test/link/macho/dead_strip/build.zig
+++ b/test/link/macho/dead_strip/build.zig
@@ -16,7 +16,6 @@ pub fn build(b: *Builder) void {
         const check = exe.checkObject(.macho);
         check.checkInSymtab();
         check.checkNext("{*} (__TEXT,__text) external _iAmUnused");
-        test_step.dependOn(&check.step);
 
         const run_cmd = check.runAndCompare();
         run_cmd.expectStdOutEqual("Hello!\n");
@@ -31,7 +30,6 @@ pub fn build(b: *Builder) void {
         const check = exe.checkObject(.macho);
         check.checkInSymtab();
         check.checkNotPresent("{*} (__TEXT,__text) external _iAmUnused");
-        test_step.dependOn(&check.step);
 
         const run_cmd = check.runAndCompare();
         run_cmd.expectStdOutEqual("Hello!\n");

--- a/test/link/macho/dylib/build.zig
+++ b/test/link/macho/dylib/build.zig
@@ -40,8 +40,6 @@ pub fn build(b: *Builder) void {
     check_exe.checkNext("current version 10000");
     check_exe.checkNext("compatibility version 10000");
 
-    test_step.dependOn(&check_exe.step);
-
     check_exe.checkStart("cmd RPATH");
     check_exe.checkNext(std.fmt.allocPrint(b.allocator, "path {s}", .{b.pathFromRoot("zig-out/lib")}) catch unreachable);
 

--- a/test/link/macho/entry/build.zig
+++ b/test/link/macho/entry/build.zig
@@ -26,7 +26,6 @@ pub fn build(b: *Builder) void {
     check_exe.checkNext("{n_value} (__TEXT,__text) external _non_main");
 
     check_exe.checkComputeCompare("vmaddr entryoff +", .{ .op = .eq, .value = .{ .variable = "n_value" } });
-    test_step.dependOn(&check_exe.step);
 
     const run = check_exe.runAndCompare();
     run.expectStdOutEqual("42");

--- a/test/link/macho/needed_library/build.zig
+++ b/test/link/macho/needed_library/build.zig
@@ -31,7 +31,6 @@ pub fn build(b: *Builder) void {
     const check = exe.checkObject(.macho);
     check.checkStart("cmd LOAD_DYLIB");
     check.checkNext("name @rpath/liba.dylib");
-    test_step.dependOn(&check.step);
 
     const run_cmd = check.runAndCompare();
     test_step.dependOn(&run_cmd.step);

--- a/test/link/macho/search_strategy/build.zig
+++ b/test/link/macho/search_strategy/build.zig
@@ -17,7 +17,6 @@ pub fn build(b: *Builder) void {
         const check = exe.checkObject(.macho);
         check.checkStart("cmd LOAD_DYLIB");
         check.checkNext("name @rpath/liba.dylib");
-        test_step.dependOn(&check.step);
 
         const run = check.runAndCompare();
         run.cwd = b.pathFromRoot(".");

--- a/test/link/macho/stack_size/build.zig
+++ b/test/link/macho/stack_size/build.zig
@@ -18,7 +18,6 @@ pub fn build(b: *Builder) void {
     const check_exe = exe.checkObject(.macho);
     check_exe.checkStart("cmd MAIN");
     check_exe.checkNext("stacksize 100000000");
-    test_step.dependOn(&check_exe.step);
 
     const run = check_exe.runAndCompare();
     test_step.dependOn(&run.step);

--- a/test/link/macho/weak_library/build.zig
+++ b/test/link/macho/weak_library/build.zig
@@ -33,8 +33,6 @@ pub fn build(b: *Builder) void {
     check.checkNext("(undefined) weak external _a (from liba)");
     check.checkNext("(undefined) weak external _asStr (from liba)");
 
-    test_step.dependOn(&check.step);
-
     const run_cmd = check.runAndCompare();
     run_cmd.expectStdOutEqual("42 42");
     test_step.dependOn(&run_cmd.step);


### PR DESCRIPTION
When creating an `EmulatableRunStep`, it now correctly depends on its own step rather than only the executable that was created. This means we do not need to add extra `dependOn` statements on both the emulatable step as well as the check object step. Thanks to @jacobly0 for finding this bug.