### PR TITLE
Revert "Add [src] links to function decls in autodocs"

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1858,7 +1858,6 @@ var zigAnalysis;
                 } else {
                   payloadHtml += escapeHtml(opts.fnDecl.name);
                 }
-                payloadHtml += renderSourceFileLink(opts.fnDecl);
                 payloadHtml += "</span>";
               }
             } else {


### PR DESCRIPTION
Reverts ziglang/zig#13120

In reference to: https://github.com/ziglang/zig/issues/12759#issuecomment-1285803577

I was able to confirm that removing this line causes the behavior described in the comment above to go away.

Digging in a bit more, the DOM structure of the nodes on the individual function page are pretty different than the DOM nodes of the page that lists all the functions in a package. Might take a bit of work to get the two in sync (or perhaps it's not so bad), but in the meantime, probably best just to revert this bad PR and deploy.