### PR TITLE
UEFI: Querying memory map size with no allocation

### DIFF
--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -34,7 +34,7 @@ pub const BootServices = extern struct {
     freePages: std.meta.FnPtr(fn (memory: [*]align(4096) u8, pages: usize) callconv(.C) Status),
 
     /// Returns the current memory map.
-    getMemoryMap: std.meta.FnPtr(fn (mmap_size: *usize, mmap: [*]MemoryDescriptor, mapKey: *usize, descriptor_size: *usize, descriptor_version: *u32) callconv(.C) Status),
+    getMemoryMap: std.meta.FnPtr(fn (mmap_size: *usize, mmap: ?[*]MemoryDescriptor, mapKey: *usize, descriptor_size: *usize, descriptor_version: *u32) callconv(.C) Status),
 
     /// Allocates pool memory.
     allocatePool: std.meta.FnPtr(fn (pool_type: MemoryType, size: usize, buffer: *[*]align(8) u8) callconv(.C) Status),


### PR DESCRIPTION
This makes possible to query the memory map size from EFI firmware without making any allocation beforehand. This makes possible to be precise about the size of the allocation which will own a copy of the memory map from the UEFI application.