### PR TITLE
Support compiling for the android NDK

### DIFF
--- a/lib/compiler_rt/common.zig
+++ b/lib/compiler_rt/common.zig
@@ -9,6 +9,7 @@ pub const want_aeabi = switch (builtin.abi) {
     .musleabihf,
     .gnueabi,
     .gnueabihf,
+    .android,
     => switch (builtin.cpu.arch) {
         .arm, .armeb, .thumb, .thumbeb => true,
         else => false,

--- a/lib/compiler_rt/emutls.zig
+++ b/lib/compiler_rt/emutls.zig
@@ -18,7 +18,7 @@ const gcc_word = usize;
 pub const panic = common.panic;
 
 comptime {
-    if (builtin.abi.tag == .android or (builtin.link_libc and builtin.os.tag == .openbds)) {
+    if (builtin.link_libc and (builtin.abi == .android or builtin.os.tag == .openbsd)) {
         @export(__emutls_get_address, .{ .name = "__emutls_get_address", .linkage = common.linkage });
     }
 }

--- a/lib/compiler_rt/emutls.zig
+++ b/lib/compiler_rt/emutls.zig
@@ -18,7 +18,7 @@ const gcc_word = usize;
 pub const panic = common.panic;
 
 comptime {
-    if (builtin.link_libc and builtin.os.tag == .openbsd) {
+    if (builtin.abi.tag == .android or (builtin.link_libc and builtin.os.tag == .openbds)) {
         @export(__emutls_get_address, .{ .name = "__emutls_get_address", .linkage = common.linkage });
     }
 }

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -320,6 +320,9 @@ pub const pthread_rwlock_t = switch (native_abi) {
         size: [56]u8 align(@alignOf(usize)) = [_]u8{0} ** 56,
     },
 };
+pub usingnamespace if (native_abi == .android) struct {
+    pub const pthread_key_t = c_int;
+} else struct {};
 pub const sem_t = extern struct {
     __size: [__SIZEOF_SEM_T]u8 align(@alignOf(usize)),
 };


### PR DESCRIPTION
- Exports `__emutls_get_address` for android abi
- Defines `_pthread_key_t` on linux only for android abi
- Sets `want_eabi` to true for android abi