### PR TITLE
compiler-rt: import memcmp.zig instead of importing cmp.zig twice

### DIFF
--- a/lib/compiler_rt.zig
+++ b/lib/compiler_rt.zig
@@ -212,6 +212,6 @@ comptime {
     _ = @import("compiler_rt/memcpy.zig");
     _ = @import("compiler_rt/memset.zig");
     _ = @import("compiler_rt/memmove.zig");
-    _ = @import("compiler_rt/cmp.zig");
+    _ = @import("compiler_rt/memcmp.zig");
     _ = @import("compiler_rt/bcmp.zig");
 }


### PR DESCRIPTION
`cmp.zig` was accidently being referenced twice, rather than importing `memcmp.zig`.
