### PR TITLE
compiler_rt: update memcpy to copy usizes at a time

### DIFF
--- a/lib/compiler_rt/memcpy.zig
+++ b/lib/compiler_rt/memcpy.zig
@@ -7,18 +7,33 @@ comptime {
 
 pub fn memcpy(noalias dest: ?[*]u8, noalias src: ?[*]const u8, len: usize) callconv(.C) ?[*]u8 {
     @setRuntimeSafety(false);
+    if (len == 0) return dest;
 
-    if (len != 0) {
-        var d = dest.?;
-        var s = src.?;
-        var n = len;
-        while (true) {
-            d[0] = s[0];
-            n -= 1;
-            if (n == 0) break;
-            d += 1;
-            s += 1;
-        }
+    var d = dest.?;
+    var s = src.?;
+    const wsize = @sizeOf(usize);
+    const off = len % wsize;
+
+    // align comparison to usize
+    var n = off;
+    while (true) {
+        if (n == 0) break;
+        d[0] = s[0];
+        n -= 1;
+        d += 1;
+        s += 1;
+    }
+
+    // compare whole words at a time rather than single bytes
+    var dw = @ptrCast([*]usize, @alignCast(@alignOf(usize), d));
+    var sw = @ptrCast([*]const usize, @alignCast(@alignOf(usize), s));
+    n = (len - off) / 8;
+    while (true) {
+        if (n == 0) break;
+        dw[0] = sw[0];
+        n -= 1;
+        dw += 1;
+        sw += 1;
     }
 
     return dest;


### PR DESCRIPTION
cc @mikdusan noticed this improving stage2 compilation performance of stage3 by slightly more than 2x on macOS when using our own implementation

> libSystem.memcpy: 299.05 seconds
> memcpy.zig: 996.01 seconds
> memcpy_usize.zig: 443.22 seconds
