### PR TITLE
fix(std.build.RunStep.addArgs): ignore empty arguments

### DIFF
--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -347,7 +347,7 @@ pub const Builder = struct {
 
     /// Initializes a RunStep with argv, which must at least have the path to the
     /// executable. More command line arguments can be added with `addArg`,
-    /// `addArgs`, and `addArtifactArg`.
+    /// `addArgs`, and `addArtifactArg`. Ignores empty arguments.
     /// Be careful using this function, as it introduces a system dependency.
     /// To run an executable built with zig build, see `LibExeObjStep.run`.
     pub fn addSystemCommand(self: *Builder, argv: []const []const u8) *RunStep {

--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -84,9 +84,11 @@ pub fn addArg(self: *RunStep, arg: []const u8) void {
     self.argv.append(Arg{ .bytes = self.builder.dupe(arg) }) catch unreachable;
 }
 
+/// Ignores empty arguments.
 pub fn addArgs(self: *RunStep, args: []const []const u8) void {
     for (args) |arg| {
-        self.addArg(arg);
+        if (arg.len != 0)
+            self.addArg(arg);
     }
 }
 


### PR DESCRIPTION
A primary use case for this is that I can easily conditionally not add an argument. This demonstrates roughly what I want to do in my build.zig (not actually with `zig`):
```zig
    b.getInstallStep().dependOn(
        &b.addSystemCommand(
            &[_][]const u8{
                "zig",
                "build-exe",
                "x.zig",
                if (exe.build_mode == .Debug) "" else "-Drelease-fast",
            },
        ).step,
    );
```
This currently results in this:
```
error: unrecognized file extension of parameter ''
The following command exited with error code 1 (expected 0):
```
While this looks somewhat readable, I've had cases where the error was quite confusing. I would expect an empty argument to not do or add anything, which is now the case, so the above works as expected.

While we could also use optionals for this, I think it's easier to just assign meaning to empty strings.

As an alternative to this PR I tried to play around with `++` concatenation and stuff in my code to not add the argument at all but it was incredibly cumbersome and I hit a compiler bug and stuff too, so I think this will just make it a lot nicer.