### PR TITLE
std.fs.path: add stem()

### DIFF
--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -1319,3 +1319,40 @@ test "extension" {
     try testExtension("/foo/bar/bam/a.b.c", ".c");
     try testExtension("/foo/bar/bam/a.b.c/", ".c");
 }
+
+/// Returns the last component of this path without its extension (if any):
+/// - "hello/world/lib.tar.gz" ⇒ "lib.tar"
+/// - "hello/world/lib.tar"    ⇒ "lib"
+/// - "hello/world/lib"        ⇒ "lib"
+pub fn stem(path: []const u8) []const u8 {
+    const filename = basename(path);
+    const index = mem.lastIndexOfScalar(u8, filename, '.') orelse return filename[0..];
+    if (index == 0) return path;
+    return filename[0..index];
+}
+
+fn testStem(path: []const u8, expected: []const u8) !void {
+    try testing.expectEqualStrings(expected, stem(path));
+}
+
+test "stem" {
+    try testStem("hello/world/lib.tar.gz", "lib.tar");
+    try testStem("hello/world/lib.tar", "lib");
+    try testStem("hello/world/lib", "lib");
+    try testStem("hello/lib/", "lib");
+    try testStem("hello...", "hello..");
+    try testStem("hello.", "hello");
+    try testStem("/hello.", "hello");
+    try testStem(".gitignore", ".gitignore");
+    try testStem(".image.png", ".image");
+    try testStem("file.ext", "file");
+    try testStem("file.ext.", "file.ext");
+    try testStem("a.b.c", "a.b");
+    try testStem("a.b.c/", "a.b");
+    try testStem(".a", ".a");
+    try testStem("///", "");
+    try testStem("..", ".");
+    try testStem(".", ".");
+    try testStem(" ", " ");
+    try testStem("", "");
+}

--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -1257,14 +1257,14 @@ fn testRelativeWindows(from: []const u8, to: []const u8, expected_output: []cons
 /// Files that end with `.`, or that start with `.` and have no other `.` in their name,
 /// are considered to have no extension.
 /// Examples:
-/// - `"main.zig"`     ⇒ `".zig"`
-/// - `"src/main.zig"` ⇒ `".zig"`
-/// - `".gitignore"`   ⇒ `""`
-/// - `".image.png"`   ⇒ `".png"`
-/// - `"keep."`        ⇒ `"."`
-/// - `"src.keep.me"`  ⇒ `".me"`
+/// - `"main.zig"`      ⇒ `".zig"`
+/// - `"src/main.zig"`  ⇒ `".zig"`
+/// - `".gitignore"`    ⇒ `""`
+/// - `".image.png"`    ⇒ `".png"`
+/// - `"keep."`         ⇒ `"."`
+/// - `"src.keep.me"`   ⇒ `".me"`
 /// - `"/src/keep.me"`  ⇒ `".me"`
-/// - `"/src/keep.me/"`  ⇒ `".me"`
+/// - `"/src/keep.me/"` ⇒ `".me"`
 /// The returned slice is guaranteed to have its pointer within the start and end
 /// pointer address range of `path`, even if it is length zero.
 pub fn extension(path: []const u8) []const u8 {
@@ -1275,7 +1275,7 @@ pub fn extension(path: []const u8) []const u8 {
 }
 
 fn testExtension(path: []const u8, expected: []const u8) !void {
-    try std.testing.expectEqualStrings(expected, extension(path));
+    try testing.expectEqualStrings(expected, extension(path));
 }
 
 test "extension" {


### PR DESCRIPTION
This adds a function to `std.fs.path` returning the stem of the given path. I think this is a worthwhile addition in the long term. It's a pretty common function for a standard library. And I hope there isn't already some other really easy way to do this. I don't think there is.

I needed this today when I wanted to append a file name and change its file extension, like this:
```zig
                thisDir() ++ "/" ++ stem(path) ++ ".ext",
```

See here for how other standard libraries do this:
* https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.stem
* https://crystal-lang.org/api/1.6.0/Path.html#stem%3AString-instance-method
* https://doc.rust-lang.org/std/path/struct.Path.html#method.file_stem

This also kind of goes in hand with the already existing `std.fs.path.extension()` above this.
