### PR TITLE
wasm-linker: feature compatibility validation

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -696,6 +696,7 @@ pub const File = struct {
         GlobalTypeMismatch,
         InvalidCharacter,
         InvalidEntryKind,
+        InvalidFeatureSet,
         InvalidFormat,
         InvalidIndex,
         InvalidMagicByte,

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -651,7 +651,12 @@ fn resolveSymbolsInArchives(wasm: *Wasm) !void {
     }
 }
 
-fn validateFeatures(wasm: *const Wasm, arena: Allocator) !void {
+fn validateFeatures(
+    wasm: *const Wasm,
+    arena: Allocator,
+    to_emit: *[@typeInfo(std.Target.wasm.Feature).Enum.fields.len]bool,
+    emit_features_count: *u32,
+) !void {
     const cpu_features = wasm.base.options.target.cpu.features;
     const infer = cpu_features.isEmpty(); // when the user did not define any features, we infer them from linked objects.
     var allowed = std.AutoHashMap(std.Target.wasm.Feature, void).init(arena);
@@ -754,6 +759,13 @@ fn validateFeatures(wasm: *const Wasm, arena: Allocator) !void {
 
     if (!valid_feature_set) {
         return error.InvalidFeatureSet;
+    }
+
+    if (allowed.count() > 0) {
+        emit_features_count.* = allowed.count();
+        for (to_emit) |*feature_enabled, feature_index| {
+            feature_enabled.* = allowed.contains(@intToEnum(std.Target.wasm.Feature, feature_index));
+        }
     }
 }
 
@@ -2264,7 +2276,9 @@ pub fn flushModule(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Nod
         try wasm.resolveSymbolsInObject(@intCast(u16, object_index));
     }
 
-    try wasm.validateFeatures(arena);
+    var emit_features_count: u32 = 0;
+    var enabled_features: [@typeInfo(std.Target.wasm.Feature).Enum.fields.len]bool = undefined;
+    try wasm.validateFeatures(arena, &enabled_features, &emit_features_count);
     try wasm.resolveSymbolsInArchives();
     try wasm.checkUndefinedSymbols();
 
@@ -2710,6 +2724,9 @@ pub fn flushModule(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Nod
         }
 
         try emitProducerSection(&binary_bytes);
+        if (emit_features_count > 0) {
+            try emitFeaturesSection(&binary_bytes, &enabled_features, emit_features_count);
+        }
     }
 
     // Only when writing all sections executed properly we write the magic
@@ -2792,6 +2809,32 @@ fn emitProducerSection(binary_bytes: *std.ArrayList(u8)) !void {
 
             try leb.writeULEB128(writer, @intCast(u32, version.len));
             try writer.writeAll(version);
+        }
+    }
+
+    try writeCustomSectionHeader(
+        binary_bytes.items,
+        header_offset,
+        @intCast(u32, binary_bytes.items.len - header_offset - 6),
+    );
+}
+
+fn emitFeaturesSection(binary_bytes: *std.ArrayList(u8), enabled_features: []const bool, features_count: u32) !void {
+    const header_offset = try reserveCustomSectionHeader(binary_bytes);
+
+    const writer = binary_bytes.writer();
+    const target_features = "target_features";
+    try leb.writeULEB128(writer, @intCast(u32, target_features.len));
+    try writer.writeAll(target_features);
+
+    try leb.writeULEB128(writer, features_count);
+    for (enabled_features) |enabled, feature_index| {
+        if (enabled) {
+            const feature: types.Feature = .{ .prefix = .used, .tag = @intToEnum(types.Feature.Tag, feature_index) };
+            try leb.writeULEB128(writer, @enumToInt(feature.prefix));
+            const string = feature.toString();
+            try leb.writeULEB128(writer, @intCast(u32, string.len));
+            try writer.writeAll(string);
         }
     }
 

--- a/src/link/Wasm/types.zig
+++ b/src/link/Wasm/types.zig
@@ -203,6 +203,24 @@ pub const Feature = struct {
         pub fn fromCpuFeature(feature: std.Target.wasm.Feature) Tag {
             return @intToEnum(Tag, @enumToInt(feature));
         }
+
+        pub fn toString(tag: Tag) []const u8 {
+            return switch (tag) {
+                .atomics => "atomics",
+                .bulk_memory => "bulk-memory",
+                .exception_handling => "exception-handling",
+                .extended_const => "extended-const",
+                .multivalue => "multivalue",
+                .mutable_globals => "mutable-globals",
+                .nontrapping_fptoint => "nontrapping-fptoint",
+                .reference_types => "reference-types",
+                .relaxed_simd => "relaxed-simd",
+                .sign_ext => "sign-ext",
+                .simd128 => "simd128",
+                .tail_call => "tail-call",
+                .shared_mem => "shared-mem",
+            };
+        }
     };
 
     pub const Prefix = enum(u8) {
@@ -211,28 +229,10 @@ pub const Feature = struct {
         required = '=',
     };
 
-    pub fn toString(feature: Feature) []const u8 {
-        return switch (feature.tag) {
-            .atomics => "atomics",
-            .bulk_memory => "bulk-memory",
-            .exception_handling => "exception-handling",
-            .extended_const => "extended-const",
-            .multivalue => "multivalue",
-            .mutable_globals => "mutable-globals",
-            .nontrapping_fptoint => "nontrapping-fptoint",
-            .reference_types => "reference-types",
-            .relaxed_simd => "relaxed-simd",
-            .sign_ext => "sign-ext",
-            .simd128 => "simd128",
-            .tail_call => "tail-call",
-            .shared_mem => "shared-mem",
-        };
-    }
-
     pub fn format(feature: Feature, comptime fmt: []const u8, opt: std.fmt.FormatOptions, writer: anytype) !void {
         _ = opt;
         _ = fmt;
-        try writer.print("{c} {s}", .{ feature.prefix, feature.toString() });
+        try writer.print("{c} {s}", .{ feature.prefix, feature.tag.toString() });
     }
 };
 

--- a/src/link/Wasm/types.zig
+++ b/src/link/Wasm/types.zig
@@ -183,7 +183,27 @@ pub const Feature = struct {
     /// Type of the feature, must be unique in the sequence of features.
     tag: Tag,
 
-    pub const Tag = std.Target.wasm.Feature;
+    /// Unlike `std.Target.wasm.Feature` this also contains linker-features such as shared-mem
+    pub const Tag = enum {
+        atomics,
+        bulk_memory,
+        exception_handling,
+        extended_const,
+        multivalue,
+        mutable_globals,
+        nontrapping_fptoint,
+        reference_types,
+        relaxed_simd,
+        sign_ext,
+        simd128,
+        tail_call,
+        shared_mem,
+
+        /// From a given cpu feature, returns its linker feature
+        pub fn fromCpuFeature(feature: std.Target.wasm.Feature) Tag {
+            return @intToEnum(Tag, @enumToInt(feature));
+        }
+    };
 
     pub const Prefix = enum(u8) {
         used = '+',
@@ -205,6 +225,7 @@ pub const Feature = struct {
             .sign_ext => "sign-ext",
             .simd128 => "simd128",
             .tail_call => "tail-call",
+            .shared_mem => "shared-mem",
         };
     }
 
@@ -228,4 +249,5 @@ pub const known_features = std.ComptimeStringMap(Feature.Tag, .{
     .{ "sign-ext", .sign_ext },
     .{ "simd128", .simd128 },
     .{ "tail-call", .tail_call },
+    .{ "shared-mem", .shared_mem },
 });

--- a/src/link/Wasm/types.zig
+++ b/src/link/Wasm/types.zig
@@ -183,18 +183,7 @@ pub const Feature = struct {
     /// Type of the feature, must be unique in the sequence of features.
     tag: Tag,
 
-    pub const Tag = enum {
-        atomics,
-        bulk_memory,
-        exception_handling,
-        multivalue,
-        mutable_globals,
-        nontrapping_fptoint,
-        sign_ext,
-        simd128,
-        tail_call,
-        shared_mem,
-    };
+    pub const Tag = std.Target.wasm.Feature;
 
     pub const Prefix = enum(u8) {
         used = '+',
@@ -204,13 +193,18 @@ pub const Feature = struct {
 
     pub fn toString(feature: Feature) []const u8 {
         return switch (feature.tag) {
+            .atomics => "atomics",
             .bulk_memory => "bulk-memory",
             .exception_handling => "exception-handling",
+            .extended_const => "extended-const",
+            .multivalue => "multivalue",
             .mutable_globals => "mutable-globals",
             .nontrapping_fptoint => "nontrapping-fptoint",
+            .reference_types => "reference-types",
+            .relaxed_simd => "relaxed-simd",
             .sign_ext => "sign-ext",
+            .simd128 => "simd128",
             .tail_call => "tail-call",
-            else => @tagName(feature),
         };
     }
 
@@ -225,11 +219,13 @@ pub const known_features = std.ComptimeStringMap(Feature.Tag, .{
     .{ "atomics", .atomics },
     .{ "bulk-memory", .bulk_memory },
     .{ "exception-handling", .exception_handling },
+    .{ "extended-const", .extended_const },
     .{ "multivalue", .multivalue },
     .{ "mutable-globals", .mutable_globals },
     .{ "nontrapping-fptoint", .nontrapping_fptoint },
+    .{ "reference-types", .reference_types },
+    .{ "relaxed-simd", .relaxed_simd },
     .{ "sign-ext", .sign_ext },
     .{ "simd128", .simd128 },
     .{ "tail-call", .tail_call },
-    .{ "shared-mem", .shared_mem },
 });

--- a/test/link.zig
+++ b/test/link.zig
@@ -33,6 +33,10 @@ fn addWasmCases(cases: *tests.StandaloneContext) void {
         .requires_stage2 = true,
     });
 
+    cases.addBuildFile("test/link/wasm/basic-features/build.zig", .{
+        .requires_stage2 = true,
+    });
+
     cases.addBuildFile("test/link/wasm/bss/build.zig", .{
         .build_modes = false,
         .requires_stage2 = true,
@@ -42,6 +46,10 @@ fn addWasmCases(cases: *tests.StandaloneContext) void {
         .build_modes = true,
         .requires_stage2 = true,
         .use_emulation = true,
+    });
+
+    cases.addBuildFile("test/link/wasm/infer-features/build.zig", .{
+        .requires_stage2 = true,
     });
 
     cases.addBuildFile("test/link/wasm/producers/build.zig", .{

--- a/test/link/wasm/basic-features/build.zig
+++ b/test/link/wasm/basic-features/build.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    // Library with explicitly set cpu features
+    const lib = b.addSharedLibrary("lib", "main.zig", .unversioned);
+    lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    lib.target.cpu_model = .{ .explicit = &std.Target.wasm.cpu.mvp };
+    lib.target.cpu_features_add.addFeature(0); // index 0 == atomics (see std.Target.wasm.Features)
+    lib.setBuildMode(mode);
+    lib.use_llvm = false;
+    lib.use_lld = false;
+
+    // Verify the result contains the features explicitly set on the target for the library.
+    const check = lib.checkObject(.wasm);
+    check.checkStart("name target_features");
+    check.checkNext("features 1");
+    check.checkNext("+ atomics");
+
+    const test_step = b.step("test", "Run linker test");
+    test_step.dependOn(&check.step);
+}

--- a/test/link/wasm/basic-features/main.zig
+++ b/test/link/wasm/basic-features/main.zig
@@ -1,0 +1,1 @@
+export fn foo() void {}

--- a/test/link/wasm/infer-features/build.zig
+++ b/test/link/wasm/infer-features/build.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    // Wasm Object file which we will use to infer the features from
+    const c_obj = b.addObject("c_obj", null);
+    c_obj.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    c_obj.target.cpu_model = .{ .explicit = &std.Target.wasm.cpu.bleeding_edge };
+    c_obj.addCSourceFile("foo.c", &.{});
+    c_obj.setBuildMode(mode);
+
+    // Wasm library that doesn't have any features specified. This will
+    // infer its featureset from other linked object files.
+    const lib = b.addSharedLibrary("lib", "main.zig", .unversioned);
+    lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    lib.target.cpu_model = .{ .explicit = &std.Target.wasm.cpu.mvp };
+    lib.setBuildMode(mode);
+    lib.use_llvm = false;
+    lib.use_lld = false;
+    lib.addObject(c_obj);
+
+    // Verify the result contains the features from the C Object file.
+    const check = lib.checkObject(.wasm);
+    check.checkStart("name target_features");
+    check.checkNext("features 7");
+    check.checkNext("+ atomics");
+    check.checkNext("+ bulk-memory");
+    check.checkNext("+ mutable-globals");
+    check.checkNext("+ nontrapping-fptoint");
+    check.checkNext("+ sign-ext");
+    check.checkNext("+ simd128");
+    check.checkNext("+ tail-call");
+
+    const test_step = b.step("test", "Run linker test");
+    test_step.dependOn(&check.step);
+}

--- a/test/link/wasm/infer-features/foo.c
+++ b/test/link/wasm/infer-features/foo.c
@@ -1,0 +1,3 @@
+int foo() {
+  return 5;
+}

--- a/test/link/wasm/infer-features/main.zig
+++ b/test/link/wasm/infer-features/main.zig
@@ -1,0 +1,1 @@
+extern fn foo() c_int;


### PR DESCRIPTION
Wasm object files and binaries can contain an optional section called the `target_features` section. This section describes features that are used, required, or disallowed. This PR implements the validation of each linked object file and its features to ensure the generated binary is compatible. For example, when object A uses the feature 'atomics' but object B disallows the feature 'atomics' it's a linker error. Only when the user has specified features or any of the linked object files do, will we emit this section. As it's optional, it's omitted when providing the `-fstrip` flag. When the user did not specify any features, we instead infer them from any of the linked object files. For the curious reader, more information can be found at: https://github.com/WebAssembly/tool-conventions/blob/main/Linking.md#target-features-section
