### PR TITLE
Better Autodoc Src File Links

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1857,8 +1857,10 @@ var zigAnalysis;
                     "</a>";
                 } else {
                   payloadHtml += escapeHtml(opts.fnDecl.name);
+                  payloadHtml = "<a target=\"_blank\" href=\"" +
+                    sourceFileLink(opts.fnDecl) + "\">" +
+                    escapeHtml(opts.fnDecl.name) + "</a>";
                 }
-                payloadHtml += renderSourceFileLink(opts.fnDecl);
                 payloadHtml += "</span>";
               }
             } else {
@@ -2326,12 +2328,12 @@ var zigAnalysis;
       }
     }
   }
-  function renderSourceFileLink(decl) {
-    let srcNode = getAstNode(decl.src);
 
-    return "<a style=\"float: right;\" href=\"" +
-      sourceFileUrlTemplate.replace("{{file}}",
-        zigAnalysis.files[srcNode.file]).replace("{{line}}", srcNode.line + 1) + "\">[src]</a>";
+  function sourceFileLink(decl) {
+      const srcNode = getAstNode(decl.src);
+      return sourceFileUrlTemplate.
+          replace("{{file}}", zigAnalysis.files[srcNode.file]).
+          replace("{{line}}", srcNode.line + 1);
   }
 
   function renderContainer(container) {
@@ -2458,7 +2460,8 @@ var zigAnalysis;
           fnDecl: decl,
           linkFnNameDecl: navLinkDecl(decl.name),
         });
-        tdFnSrc.innerHTML = renderSourceFileLink(decl);
+        tdFnSrc.innerHTML = "<a style=\"float: right;\" target=\"_blank\" href=\"" +
+          sourceFileLink(decl) + "\">[src]</a>";
 
         let docs = getAstNode(decl.src).docs;
         if (docs != null) {


### PR DESCRIPTION
related issue: https://github.com/ziglang/zig/issues/12759

This PR makes a couple changes, open to feedback!

1. Fixes the broken "double-links" that were introduced in https://github.com/ziglang/zig/pull/13120 (see also https://github.com/ziglang/zig/pull/13237, which we should close if this is merged)
2. Adds links to source code directly in to the function name rather than a separate `[src]` button on the right side of the page. I chose this because when you have a long function declaration, the `[src]` link takes up precious real estate, so hopefully this avoid some cases where you might get a `...` on your function declaration, which obscures the info I'm looking for.
3. Opens source links in new tabs (this is a better experience IMO)

Here is a page of the list of functions in a package (`[src]` links still exist, and the link on the function name is to the autodocs page for that function):

![image](https://user-images.githubusercontent.com/8205547/197803648-d1ec25ab-1c70-4d12-8ae3-a5122937db7c.png)

And here is the function declaration page, with the link to the src on the function name itself:

![image](https://user-images.githubusercontent.com/8205547/197804704-5a7c7a30-41ba-4e1d-a7b2-80ce3c8c36e7.png)