### PR TITLE
Sema: use `runtime_value` instead of creating allocs

### DIFF
--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -477,6 +477,6 @@ pub fn print(
         },
         .generic_poison_type => return writer.writeAll("(generic poison type)"),
         .generic_poison => return writer.writeAll("(generic poison)"),
-        .runtime_int => return writer.writeAll("[runtime value]"),
+        .runtime_value => return writer.writeAll("[runtime value]"),
     };
 }

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -5401,7 +5401,11 @@ fn lowerUnnamedConst(self: *Self, tv: TypedValue) InnerError!MCValue {
     }
 }
 
-fn genTypedValue(self: *Self, typed_value: TypedValue) InnerError!MCValue {
+fn genTypedValue(self: *Self, arg_tv: TypedValue) InnerError!MCValue {
+    var typed_value = arg_tv;
+    if (typed_value.val.castTag(.runtime_value)) |rt| {
+        typed_value.val = rt.data;
+    }
     log.debug("genTypedValue: ty = {}, val = {}", .{ typed_value.ty.fmtDebug(), typed_value.val.fmtDebug() });
     if (typed_value.val.isUndef())
         return MCValue{ .undef = {} };

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -6047,7 +6047,11 @@ fn lowerUnnamedConst(self: *Self, tv: TypedValue) InnerError!MCValue {
     }
 }
 
-fn genTypedValue(self: *Self, typed_value: TypedValue) InnerError!MCValue {
+fn genTypedValue(self: *Self, arg_tv: TypedValue) InnerError!MCValue {
+    var typed_value = arg_tv;
+    if (typed_value.val.castTag(.runtime_value)) |rt| {
+        typed_value.val = rt.data;
+    }
     log.debug("genTypedValue: ty = {}, val = {}", .{ typed_value.ty.fmtDebug(), typed_value.val.fmtDebug() });
     if (typed_value.val.isUndef())
         return MCValue{ .undef = {} };

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -2582,7 +2582,11 @@ fn toTwosComplement(value: anytype, bits: u7) std.meta.Int(.unsigned, @typeInfo(
     return @intCast(WantedT, result);
 }
 
-fn lowerConstant(func: *CodeGen, val: Value, ty: Type) InnerError!WValue {
+fn lowerConstant(func: *CodeGen, arg_val: Value, ty: Type) InnerError!WValue {
+    var val = arg_val;
+    if (val.castTag(.runtime_value)) |rt| {
+        val = rt.data;
+    }
     if (val.isUndefDeep()) return func.emitUndefined(ty);
     if (val.castTag(.decl_ref)) |decl_ref| {
         const decl_index = decl_ref.data;

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -6960,7 +6960,11 @@ fn lowerUnnamedConst(self: *Self, tv: TypedValue) InnerError!MCValue {
     }
 }
 
-fn genTypedValue(self: *Self, typed_value: TypedValue) InnerError!MCValue {
+fn genTypedValue(self: *Self, arg_tv: TypedValue) InnerError!MCValue {
+    var typed_value = arg_tv;
+    if (typed_value.val.castTag(.runtime_value)) |rt| {
+        typed_value.val = rt.data;
+    }
     log.debug("genTypedValue: ty = {}, val = {}", .{ typed_value.ty.fmtDebug(), typed_value.val.fmtDebug() });
     if (typed_value.val.isUndef())
         return MCValue{ .undef = {} };

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -149,13 +149,18 @@ fn writeFloat(comptime F: type, f: F, target: Target, endian: std.builtin.Endian
 pub fn generateSymbol(
     bin_file: *link.File,
     src_loc: Module.SrcLoc,
-    typed_value: TypedValue,
+    arg_tv: TypedValue,
     code: *std.ArrayList(u8),
     debug_output: DebugInfoOutput,
     reloc_info: RelocInfo,
 ) GenerateSymbolError!Result {
     const tracy = trace(@src());
     defer tracy.end();
+
+    var typed_value = arg_tv;
+    if (arg_tv.val.castTag(.runtime_value)) |rt| {
+        typed_value.val = rt.data;
+    }
 
     const target = bin_file.options.target;
     const endian = target.cpu.arch.endian();

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -555,9 +555,13 @@ pub const DeclGen = struct {
         dg: *DeclGen,
         writer: anytype,
         ty: Type,
-        val: Value,
+        arg_val: Value,
         location: ValueRenderLocation,
     ) error{ OutOfMemory, AnalysisFail }!void {
+        var val = arg_val;
+        if (val.castTag(.runtime_value)) |rt| {
+            val = rt.data;
+        }
         const target = dg.module.getTarget();
         if (val.isUndefDeep()) {
             switch (ty.zigTypeTag()) {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3187,7 +3187,11 @@ pub const DeclGen = struct {
         return llvm_elem_ty;
     }
 
-    fn lowerValue(dg: *DeclGen, tv: TypedValue) Error!*llvm.Value {
+    fn lowerValue(dg: *DeclGen, arg_tv: TypedValue) Error!*llvm.Value {
+        var tv = arg_tv;
+        if (tv.val.castTag(.runtime_value)) |rt| {
+            tv.val = rt.data;
+        }
         if (tv.val.isUndef()) {
             const llvm_type = try dg.lowerType(tv.ty);
             return llvm_type.getUndef();

--- a/test/behavior/bugs/13164.zig
+++ b/test/behavior/bugs/13164.zig
@@ -10,6 +10,7 @@ inline fn setLimits(min: ?u32, max: ?u32) !void {
 test {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
     var x: u32 = 42;
     try setLimits(x, null);

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -1135,3 +1135,40 @@ test "array of vectors is copied" {
     points2[0..points.len].* = points;
     try std.testing.expectEqual(points2[6], Vec3{ -345, -311, 381 });
 }
+
+test "byte vector initialized in inline function" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        inline fn boolx4(e0: bool, e1: bool, e2: bool, e3: bool) @Vector(4, bool) {
+            return .{ e0, e1, e2, e3 };
+        }
+
+        fn all(vb: @Vector(4, bool)) bool {
+            return @reduce(.And, vb);
+        }
+    };
+
+    try expect(S.all(S.boolx4(true, true, true, true)));
+}
+
+test "byte vector initialized in inline function" {
+    // TODO https://github.com/ziglang/zig/issues/13279
+    if (true) return error.SkipZigTest;
+
+    const S = struct {
+        fn boolx4(e0: bool, e1: bool, e2: bool, e3: bool) @Vector(4, bool) {
+            return .{ e0, e1, e2, e3 };
+        }
+
+        fn all(vb: @Vector(4, bool)) bool {
+            return @reduce(.And, vb);
+        }
+    };
+
+    try expect(S.all(S.boolx4(true, true, true, true)));
+}


### PR DESCRIPTION
Makes the inline version of #13279 pass