### PR TITLE
Revamp the ed25519 API

### DIFF
--- a/lib/std/crypto/25519/ed25519.zig
+++ b/lib/std/crypto/25519/ed25519.zig
@@ -16,27 +16,227 @@ const WeakPublicKeyError = crypto.errors.WeakPublicKeyError;
 /// Ed25519 (EdDSA) signatures.
 pub const Ed25519 = struct {
     /// The underlying elliptic curve.
-    pub const Curve = @import("edwards25519.zig").Edwards25519;
-    /// Length (in bytes) of a seed required to create a key pair.
-    pub const seed_length = 32;
-    /// Length (in bytes) of a compressed secret key.
-    pub const secret_length = 64;
-    /// Length (in bytes) of a compressed public key.
-    pub const public_length = 32;
-    /// Length (in bytes) of a signature.
-    pub const signature_length = 64;
+    pub const Curve = std.crypto.ecc.Edwards25519;
+
     /// Length (in bytes) of optional random bytes, for non-deterministic signatures.
     pub const noise_length = 32;
 
     const CompressedScalar = Curve.scalar.CompressedScalar;
     const Scalar = Curve.scalar.Scalar;
 
+    /// An Ed25519 secret key.
+    pub const SecretKey = struct {
+        /// Length (in bytes) of a raw secret key.
+        pub const encoded_length = 64;
+
+        bytes: [encoded_length]u8,
+
+        /// Return the seed used to generate this secret key.
+        pub fn seed(self: SecretKey) [KeyPair.seed_length]u8 {
+            return self.bytes[0..KeyPair.seed_length].*;
+        }
+
+        /// Return the raw public key bytes corresponding to this secret key.
+        pub fn publicKeyBytes(self: SecretKey) [PublicKey.encoded_length]u8 {
+            return self.bytes[KeyPair.seed_length..].*;
+        }
+
+        /// Create a secret key from raw bytes.
+        pub fn fromBytes(bytes: [encoded_length]u8) !SecretKey {
+            return SecretKey{ .bytes = bytes };
+        }
+
+        /// Return the secret key as raw bytes.
+        pub fn toBytes(sk: SecretKey) [encoded_length]u8 {
+            return sk.bytes;
+        }
+
+        // Return the clamped secret scalar and prefix for this secret key
+        fn scalarAndPrefix(self: SecretKey) struct { scalar: CompressedScalar, prefix: [32]u8 } {
+            var az: [Sha512.digest_length]u8 = undefined;
+            var h = Sha512.init(.{});
+            h.update(&self.seed());
+            h.final(&az);
+
+            var s = az[0..32].*;
+            Curve.scalar.clamp(&s);
+
+            return .{ .scalar = s, .prefix = az[32..].* };
+        }
+    };
+
+    /// A Signer is used to incrementally compute a signature.
+    /// It can be obtained from a `KeyPair`, using the `signer()` function.
+    pub const Signer = struct {
+        h: Sha512,
+        scalar: CompressedScalar,
+        nonce: CompressedScalar,
+        r_bytes: [Curve.encoded_length]u8,
+
+        fn init(scalar: CompressedScalar, nonce: CompressedScalar, public_key: PublicKey) (IdentityElementError || KeyMismatchError || NonCanonicalError || WeakPublicKeyError)!Signer {
+            const r = try Curve.basePoint.mul(nonce);
+            const r_bytes = r.toBytes();
+
+            var t: [64]u8 = undefined;
+            mem.copy(u8, t[0..32], &r_bytes);
+            mem.copy(u8, t[32..], &public_key.bytes);
+            var h = Sha512.init(.{});
+            h.update(&t);
+
+            return Signer{ .h = h, .scalar = scalar, .nonce = nonce, .r_bytes = r_bytes };
+        }
+
+        /// Add new data to the message being signed.
+        pub fn update(self: *Signer, data: []const u8) void {
+            self.h.update(data);
+        }
+
+        /// Compute a signature over the entire message.
+        pub fn finalize(self: *Signer) Signature {
+            var hram64: [Sha512.digest_length]u8 = undefined;
+            self.h.final(&hram64);
+            const hram = Curve.scalar.reduce64(hram64);
+
+            const s = Curve.scalar.mulAdd(hram, self.scalar, self.nonce);
+
+            return Signature{ .r = self.r_bytes, .s = s };
+        }
+    };
+
+    /// An Ed25519 public key.
+    pub const PublicKey = struct {
+        /// Length (in bytes) of a raw public key.
+        pub const encoded_length = 32;
+
+        bytes: [encoded_length]u8,
+
+        /// Create a public key from raw bytes.
+        pub fn fromBytes(bytes: [encoded_length]u8) !PublicKey {
+            try Curve.rejectNonCanonical(bytes);
+            return PublicKey{ .bytes = bytes };
+        }
+
+        /// Convert a public key to raw bytes.
+        pub fn toBytes(pk: PublicKey) [encoded_length]u8 {
+            return pk.bytes;
+        }
+
+        fn signWithNonce(public_key: PublicKey, msg: []const u8, scalar: CompressedScalar, nonce: CompressedScalar) (IdentityElementError || NonCanonicalError || KeyMismatchError || WeakPublicKeyError)!Signature {
+            var st = try Signer.init(scalar, nonce, public_key);
+            st.update(msg);
+            return st.finalize();
+        }
+
+        fn computeNonceAndSign(public_key: PublicKey, msg: []const u8, noise: ?[noise_length]u8, scalar: CompressedScalar, prefix: []const u8) (IdentityElementError || NonCanonicalError || KeyMismatchError || WeakPublicKeyError)!Signature {
+            var h = Sha512.init(.{});
+            if (noise) |*z| {
+                h.update(z);
+            }
+            h.update(prefix);
+            h.update(msg);
+            var nonce64: [64]u8 = undefined;
+            h.final(&nonce64);
+
+            const nonce = Curve.scalar.reduce64(nonce64);
+
+            return public_key.signWithNonce(msg, scalar, nonce);
+        }
+    };
+
+    /// A Verifier is used to incrementally verify a signature.
+    /// It can be obtained from a `Signature`, using the `verifier()` function.
+    pub const Verifier = struct {
+        h: Sha512,
+        s: CompressedScalar,
+        a: Curve,
+        expected_r: Curve,
+
+        fn init(sig: Signature, public_key: PublicKey) !Verifier {
+            const r = sig.r;
+            const s = sig.s;
+            try Curve.scalar.rejectNonCanonical(s);
+            const a = try Curve.fromBytes(public_key.bytes);
+            try a.rejectIdentity();
+            try Curve.rejectNonCanonical(r);
+            const expected_r = try Curve.fromBytes(r);
+            try expected_r.rejectIdentity();
+
+            var h = Sha512.init(.{});
+            h.update(&r);
+            h.update(&public_key.bytes);
+
+            return Verifier{ .h = h, .s = s, .a = a, .expected_r = expected_r };
+        }
+
+        /// Add new content to the message to be verified.
+        pub fn update(self: *Verifier, msg: []const u8) void {
+            self.h.update(msg);
+        }
+
+        /// Verify that the signature is valid for the entire message.
+        pub fn verify(self: *Verifier) (SignatureVerificationError || WeakPublicKeyError || IdentityElementError)!void {
+            var hram64: [Sha512.digest_length]u8 = undefined;
+            self.h.final(&hram64);
+            const hram = Curve.scalar.reduce64(hram64);
+
+            const sb_ah = try Curve.basePoint.mulDoubleBasePublic(self.s, self.a.neg(), hram);
+            if (self.expected_r.sub(sb_ah).clearCofactor().rejectIdentity()) |_| {
+                return error.SignatureVerificationFailed;
+            } else |_| {}
+        }
+    };
+
+    /// An Ed25519 signature.
+    pub const Signature = struct {
+        /// Length (in bytes) of a raw signature.
+        pub const encoded_length = Curve.encoded_length + @sizeOf(CompressedScalar);
+
+        /// The R component of an EdDSA signature.
+        r: [Curve.encoded_length]u8,
+        /// The S component of an EdDSA signature.
+        s: CompressedScalar,
+
+        /// Return the raw signature (r, s) in little-endian format.
+        pub fn toBytes(self: Signature) [encoded_length]u8 {
+            var bytes: [encoded_length]u8 = undefined;
+            mem.copy(u8, bytes[0 .. encoded_length / 2], &self.r);
+            mem.copy(u8, bytes[encoded_length / 2 ..], &self.s);
+            return bytes;
+        }
+
+        /// Create a signature from a raw encoding of (r, s).
+        /// EdDSA always assumes little-endian.
+        pub fn fromBytes(bytes: [encoded_length]u8) Signature {
+            return Signature{
+                .r = bytes[0 .. encoded_length / 2].*,
+                .s = bytes[encoded_length / 2 ..].*,
+            };
+        }
+
+        /// Create a Verifier for incremental verification of a signature.
+        pub fn verifier(self: Signature, public_key: PublicKey) !Verifier {
+            return Verifier.init(self, public_key);
+        }
+
+        /// Verify the signature against a message and public key.
+        /// Return IdentityElement or NonCanonical if the public key or signature are not in the expected range,
+        /// or SignatureVerificationError if the signature is invalid for the given message and key.
+        pub fn verify(self: Signature, msg: []const u8, public_key: PublicKey) (IdentityElementError || NonCanonicalError || SignatureVerificationError || EncodingError || WeakPublicKeyError)!void {
+            var st = try Verifier.init(self, public_key);
+            st.update(msg);
+            return st.verify();
+        }
+    };
+
     /// An Ed25519 key pair.
     pub const KeyPair = struct {
+        /// Length (in bytes) of a seed required to create a key pair.
+        pub const seed_length = noise_length;
+
         /// Public part.
-        public_key: [public_length]u8,
-        /// Secret part. What we expose as a secret key is, under the hood, the concatenation of the seed and the public key.
-        secret_key: [secret_length]u8,
+        public_key: PublicKey,
+        /// Secret scalar.
+        secret_key: SecretKey,
 
         /// Derive a key pair from an optional secret seed.
         ///
@@ -56,120 +256,101 @@ pub const Ed25519 = struct {
             var h = Sha512.init(.{});
             h.update(&ss);
             h.final(&az);
-            const p = Curve.basePoint.clampedMul(az[0..32].*) catch return error.IdentityElement;
-            var sk: [secret_length]u8 = undefined;
-            mem.copy(u8, &sk, &ss);
-            const pk = p.toBytes();
-            mem.copy(u8, sk[seed_length..], &pk);
-
-            return KeyPair{ .public_key = pk, .secret_key = sk };
+            const pk_p = Curve.basePoint.clampedMul(az[0..32].*) catch return error.IdentityElement;
+            const pk_bytes = pk_p.toBytes();
+            var sk_bytes: [SecretKey.encoded_length]u8 = undefined;
+            mem.copy(u8, &sk_bytes, &ss);
+            mem.copy(u8, sk_bytes[seed_length..], &pk_bytes);
+            return KeyPair{
+                .public_key = PublicKey.fromBytes(pk_bytes) catch unreachable,
+                .secret_key = try SecretKey.fromBytes(sk_bytes),
+            };
         }
 
         /// Create a KeyPair from a secret key.
-        pub fn fromSecretKey(secret_key: [secret_length]u8) KeyPair {
+        pub fn fromSecretKey(secret_key: SecretKey) IdentityElementError!KeyPair {
+            const pk_p = try Curve.fromBytes(secret_key.publicKeyBytes());
+
+            // It is critical for EdDSA to use the correct public key.
+            // In order to enforce this, a SecretKey implicitly includes a copy of the public key.
+            // In Debug mode, we can still afford checking that the public key is correct for extra safety.
+            if (std.builtin.mode == .Debug) {
+                const recomputed_kp = try create(secret_key[0..seed_length].*);
+                debug.assert(recomputed_kp.public_key.p.toBytes() == pk_p.toBytes());
+            }
             return KeyPair{
+                .public_key = PublicKey{ .p = pk_p },
                 .secret_key = secret_key,
-                .public_key = secret_key[seed_length..].*,
             };
+        }
+
+        /// Sign a message using the key pair.
+        /// The noise can be null in order to create deterministic signatures.
+        /// If deterministic signatures are not required, the noise should be randomly generated instead.
+        /// This helps defend against fault attacks.
+        pub fn sign(key_pair: KeyPair, msg: []const u8, noise: ?[noise_length]u8) (IdentityElementError || NonCanonicalError || KeyMismatchError || WeakPublicKeyError)!Signature {
+            if (!mem.eql(u8, &key_pair.secret_key.publicKeyBytes(), &key_pair.public_key.toBytes())) {
+                return error.KeyMismatch;
+            }
+            const scalar_and_prefix = key_pair.secret_key.scalarAndPrefix();
+            return key_pair.public_key.computeNonceAndSign(
+                msg,
+                noise,
+                scalar_and_prefix.scalar,
+                &scalar_and_prefix.prefix,
+            );
+        }
+
+        /// Create a Signer, that can be used for incremental signing.
+        /// Note that the signature is not deterministic.
+        /// The noise parameter, if set, should be something unique for each message,
+        /// such as a random nonce, or a counter.
+        pub fn signer(key_pair: KeyPair, noise: ?[noise_length]u8) !Signer {
+            if (!mem.eql(u8, &key_pair.secret_key.publicKeyBytes(), &key_pair.public_key.toBytes())) {
+                return error.KeyMismatch;
+            }
+            const scalar_and_prefix = key_pair.secret_key.scalarAndPrefix();
+            var h = Sha512.init(.{});
+            h.update(&scalar_and_prefix.prefix);
+            var noise2: [noise_length]u8 = undefined;
+            crypto.random.bytes(&noise2);
+            if (noise) |*z| {
+                h.update(z);
+            }
+            var nonce64: [64]u8 = undefined;
+            h.final(&nonce64);
+            const nonce = Curve.scalar.reduce64(nonce64);
+
+            return Signer.init(scalar_and_prefix.scalar, nonce, key_pair.public_key);
         }
     };
 
-    /// Sign a message using a key pair, and optional random noise.
-    /// Having noise creates non-standard, non-deterministic signatures,
-    /// but has been proven to increase resilience against fault attacks.
-    pub fn sign(msg: []const u8, key_pair: KeyPair, noise: ?[noise_length]u8) (IdentityElementError || WeakPublicKeyError || KeyMismatchError)![signature_length]u8 {
-        const seed = key_pair.secret_key[0..seed_length];
-        const public_key = key_pair.secret_key[seed_length..];
-        if (!mem.eql(u8, public_key, &key_pair.public_key)) {
-            return error.KeyMismatch;
-        }
-        var az: [Sha512.digest_length]u8 = undefined;
-        var h = Sha512.init(.{});
-        h.update(seed);
-        h.final(&az);
-
-        h = Sha512.init(.{});
-        if (noise) |*z| {
-            h.update(z);
-        }
-        h.update(az[32..]);
-        h.update(msg);
-        var nonce64: [64]u8 = undefined;
-        h.final(&nonce64);
-        const nonce = Curve.scalar.reduce64(nonce64);
-        const r = try Curve.basePoint.mul(nonce);
-
-        var sig: [signature_length]u8 = undefined;
-        mem.copy(u8, sig[0..32], &r.toBytes());
-        mem.copy(u8, sig[32..], public_key);
-        h = Sha512.init(.{});
-        h.update(&sig);
-        h.update(msg);
-        var hram64: [Sha512.digest_length]u8 = undefined;
-        h.final(&hram64);
-        const hram = Curve.scalar.reduce64(hram64);
-
-        var x = az[0..32];
-        Curve.scalar.clamp(x);
-        const s = Curve.scalar.mulAdd(hram, x.*, nonce);
-        mem.copy(u8, sig[32..], s[0..]);
-        return sig;
-    }
-
-    /// Verify an Ed25519 signature given a message and a public key.
-    /// Returns error.SignatureVerificationFailed is the signature verification failed.
-    pub fn verify(sig: [signature_length]u8, msg: []const u8, public_key: [public_length]u8) (SignatureVerificationError || WeakPublicKeyError || EncodingError || NonCanonicalError || IdentityElementError)!void {
-        const r = sig[0..32];
-        const s = sig[32..64];
-        try Curve.scalar.rejectNonCanonical(s.*);
-        try Curve.rejectNonCanonical(public_key);
-        const a = try Curve.fromBytes(public_key);
-        try a.rejectIdentity();
-        try Curve.rejectNonCanonical(r.*);
-        const expected_r = try Curve.fromBytes(r.*);
-        try expected_r.rejectIdentity();
-
-        var h = Sha512.init(.{});
-        h.update(r);
-        h.update(&public_key);
-        h.update(msg);
-        var hram64: [Sha512.digest_length]u8 = undefined;
-        h.final(&hram64);
-        const hram = Curve.scalar.reduce64(hram64);
-
-        const sb_ah = try Curve.basePoint.mulDoubleBasePublic(s.*, a.neg(), hram);
-        if (expected_r.sub(sb_ah).clearCofactor().rejectIdentity()) |_| {
-            return error.SignatureVerificationFailed;
-        } else |_| {}
-    }
-
     /// A (signature, message, public_key) tuple for batch verification
     pub const BatchElement = struct {
-        sig: [signature_length]u8,
+        sig: Signature,
         msg: []const u8,
-        public_key: [public_length]u8,
+        public_key: PublicKey,
     };
 
     /// Verify several signatures in a single operation, much faster than verifying signatures one-by-one
     pub fn verifyBatch(comptime count: usize, signature_batch: [count]BatchElement) (SignatureVerificationError || IdentityElementError || WeakPublicKeyError || EncodingError || NonCanonicalError)!void {
-        var r_batch: [count][32]u8 = undefined;
-        var s_batch: [count][32]u8 = undefined;
+        var r_batch: [count]CompressedScalar = undefined;
+        var s_batch: [count]CompressedScalar = undefined;
         var a_batch: [count]Curve = undefined;
         var expected_r_batch: [count]Curve = undefined;
 
         for (signature_batch) |signature, i| {
-            const r = signature.sig[0..32];
-            const s = signature.sig[32..64];
-            try Curve.scalar.rejectNonCanonical(s.*);
-            try Curve.rejectNonCanonical(signature.public_key);
-            const a = try Curve.fromBytes(signature.public_key);
+            const r = signature.sig.r;
+            const s = signature.sig.s;
+            try Curve.scalar.rejectNonCanonical(s);
+            const a = try Curve.fromBytes(signature.public_key.bytes);
             try a.rejectIdentity();
-            try Curve.rejectNonCanonical(r.*);
-            const expected_r = try Curve.fromBytes(r.*);
+            try Curve.rejectNonCanonical(r);
+            const expected_r = try Curve.fromBytes(r);
             try expected_r.rejectIdentity();
             expected_r_batch[i] = expected_r;
-            r_batch[i] = r.*;
-            s_batch[i] = s.*;
+            r_batch[i] = r;
+            s_batch[i] = s;
             a_batch[i] = a;
         }
 
@@ -177,7 +358,7 @@ pub const Ed25519 = struct {
         for (signature_batch) |signature, i| {
             var h = Sha512.init(.{});
             h.update(&r_batch[i]);
-            h.update(&signature.public_key);
+            h.update(&signature.public_key.bytes);
             h.update(signature.msg);
             var hram64: [Sha512.digest_length]u8 = undefined;
             h.final(&hram64);
@@ -220,19 +401,22 @@ pub const Ed25519 = struct {
         pub const BlindSecretKey = struct {
             prefix: [64]u8,
             blind_scalar: CompressedScalar,
-            blind_public_key: CompressedScalar,
+            blind_public_key: PublicKey,
         };
+
+        /// A blind public key.
+        pub const BlindPublicKey = PublicKey;
 
         /// A blind key pair.
         pub const BlindKeyPair = struct {
-            blind_public_key: [public_length]u8,
+            blind_public_key: BlindPublicKey,
             blind_secret_key: BlindSecretKey,
         };
 
         /// Blind an existing key pair with a blinding seed and a context.
         pub fn blind(key_pair: Ed25519.KeyPair, blind_seed: [blind_seed_length]u8, ctx: []const u8) !BlindKeyPair {
             var h: [Sha512.digest_length]u8 = undefined;
-            Sha512.hash(key_pair.secret_key[0..32], &h, .{});
+            Sha512.hash(&key_pair.secret_key.seed(), &h, .{});
             Curve.scalar.clamp(h[0..32]);
             const scalar = Curve.scalar.reduce(h[0..32].*);
 
@@ -240,7 +424,7 @@ pub const Ed25519 = struct {
             const blind_factor = Curve.scalar.reduce(blind_h[0..32].*);
 
             const blind_scalar = Curve.scalar.mul(scalar, blind_factor);
-            const blind_public_key = (Curve.basePoint.mul(blind_scalar) catch return error.IdentityElement).toBytes();
+            const blind_public_key = try PublicKey.fromBytes((Curve.basePoint.mul(blind_scalar) catch return error.IdentityElement).toBytes());
 
             var prefix: [64]u8 = undefined;
             mem.copy(u8, prefix[0..32], h[32..64]);
@@ -258,42 +442,22 @@ pub const Ed25519 = struct {
         }
 
         /// Recover a public key from a blind version of it.
-        pub fn unblindPublicKey(blind_public_key: [public_length]u8, blind_seed: [blind_seed_length]u8, ctx: []const u8) ![public_length]u8 {
+        pub fn unblindPublicKey(blind_public_key: BlindPublicKey, blind_seed: [blind_seed_length]u8, ctx: []const u8) !PublicKey {
             const blind_h = blindCtx(blind_seed, ctx);
             const inv_blind_factor = Scalar.fromBytes(blind_h[0..32].*).invert().toBytes();
-            const public_key = try (try Curve.fromBytes(blind_public_key)).mul(inv_blind_factor);
-            return public_key.toBytes();
+            const pk_p = try (try Curve.fromBytes(blind_public_key.bytes)).mul(inv_blind_factor);
+            return PublicKey.fromBytes(pk_p.toBytes());
         }
 
         /// Sign a message using a blind key pair, and optional random noise.
         /// Having noise creates non-standard, non-deterministic signatures,
         /// but has been proven to increase resilience against fault attacks.
-        pub fn sign(msg: []const u8, key_pair: BlindKeyPair, noise: ?[noise_length]u8) ![signature_length]u8 {
-            var h = Sha512.init(.{});
-            if (noise) |*z| {
-                h.update(z);
-            }
-            h.update(&key_pair.blind_secret_key.prefix);
-            h.update(msg);
-            var nonce64: [64]u8 = undefined;
-            h.final(&nonce64);
+        pub fn sign(msg: []const u8, key_pair: BlindKeyPair, noise: ?[noise_length]u8) !Signature {
+            const scalar = key_pair.blind_secret_key.blind_scalar;
+            const prefix = key_pair.blind_secret_key.prefix;
 
-            const nonce = Curve.scalar.reduce64(nonce64);
-            const r = try Curve.basePoint.mul(nonce);
-
-            var sig: [signature_length]u8 = undefined;
-            mem.copy(u8, sig[0..32], &r.toBytes());
-            mem.copy(u8, sig[32..], &key_pair.blind_public_key);
-            h = Sha512.init(.{});
-            h.update(&sig);
-            h.update(msg);
-            var hram64: [Sha512.digest_length]u8 = undefined;
-            h.final(&hram64);
-            const hram = Curve.scalar.reduce64(hram64);
-
-            const s = Curve.scalar.mulAdd(hram, key_pair.blind_secret_key.blind_scalar, nonce);
-            mem.copy(u8, sig[32..], s[0..]);
-            return sig;
+            return (try PublicKey.fromBytes(key_pair.blind_public_key.bytes))
+                .computeNonceAndSign(msg, noise, scalar, &prefix);
         }
 
         /// Compute a blind context from a blinding seed and a context.
@@ -314,8 +478,8 @@ test "ed25519 key pair creation" {
     _ = try fmt.hexToBytes(seed[0..], "8052030376d47112be7f73ed7a019293dd12ad910b654455798b4667d73de166");
     const key_pair = try Ed25519.KeyPair.create(seed);
     var buf: [256]u8 = undefined;
-    try std.testing.expectEqualStrings(try std.fmt.bufPrint(&buf, "{s}", .{std.fmt.fmtSliceHexUpper(&key_pair.secret_key)}), "8052030376D47112BE7F73ED7A019293DD12AD910B654455798B4667D73DE1662D6F7455D97B4A3A10D7293909D1A4F2058CB9A370E43FA8154BB280DB839083");
-    try std.testing.expectEqualStrings(try std.fmt.bufPrint(&buf, "{s}", .{std.fmt.fmtSliceHexUpper(&key_pair.public_key)}), "2D6F7455D97B4A3A10D7293909D1A4F2058CB9A370E43FA8154BB280DB839083");
+    try std.testing.expectEqualStrings(try std.fmt.bufPrint(&buf, "{s}", .{std.fmt.fmtSliceHexUpper(&key_pair.secret_key.toBytes())}), "8052030376D47112BE7F73ED7A019293DD12AD910B654455798B4667D73DE1662D6F7455D97B4A3A10D7293909D1A4F2058CB9A370E43FA8154BB280DB839083");
+    try std.testing.expectEqualStrings(try std.fmt.bufPrint(&buf, "{s}", .{std.fmt.fmtSliceHexUpper(&key_pair.public_key.toBytes())}), "2D6F7455D97B4A3A10D7293909D1A4F2058CB9A370E43FA8154BB280DB839083");
 }
 
 test "ed25519 signature" {
@@ -323,11 +487,11 @@ test "ed25519 signature" {
     _ = try fmt.hexToBytes(seed[0..], "8052030376d47112be7f73ed7a019293dd12ad910b654455798b4667d73de166");
     const key_pair = try Ed25519.KeyPair.create(seed);
 
-    const sig = try Ed25519.sign("test", key_pair, null);
+    const sig = try key_pair.sign("test", null);
     var buf: [128]u8 = undefined;
-    try std.testing.expectEqualStrings(try std.fmt.bufPrint(&buf, "{s}", .{std.fmt.fmtSliceHexUpper(&sig)}), "10A442B4A80CC4225B154F43BEF28D2472CA80221951262EB8E0DF9091575E2687CC486E77263C3418C757522D54F84B0359236ABBBD4ACD20DC297FDCA66808");
-    try Ed25519.verify(sig, "test", key_pair.public_key);
-    try std.testing.expectError(error.SignatureVerificationFailed, Ed25519.verify(sig, "TEST", key_pair.public_key));
+    try std.testing.expectEqualStrings(try std.fmt.bufPrint(&buf, "{s}", .{std.fmt.fmtSliceHexUpper(&sig.toBytes())}), "10A442B4A80CC4225B154F43BEF28D2472CA80221951262EB8E0DF9091575E2687CC486E77263C3418C757522D54F84B0359236ABBBD4ACD20DC297FDCA66808");
+    try sig.verify("test", key_pair.public_key);
+    try std.testing.expectError(error.SignatureVerificationFailed, sig.verify("TEST", key_pair.public_key));
 }
 
 test "ed25519 batch verification" {
@@ -338,8 +502,8 @@ test "ed25519 batch verification" {
         var msg2: [32]u8 = undefined;
         crypto.random.bytes(&msg1);
         crypto.random.bytes(&msg2);
-        const sig1 = try Ed25519.sign(&msg1, key_pair, null);
-        const sig2 = try Ed25519.sign(&msg2, key_pair, null);
+        const sig1 = try key_pair.sign(&msg1, null);
+        const sig2 = try key_pair.sign(&msg2, null);
         var signature_batch = [_]Ed25519.BatchElement{
             Ed25519.BatchElement{
                 .sig = sig1,
@@ -355,9 +519,7 @@ test "ed25519 batch verification" {
         try Ed25519.verifyBatch(2, signature_batch);
 
         signature_batch[1].sig = sig1;
-        // TODO https://github.com/ziglang/zig/issues/12240
-        const sig_len = signature_batch.len;
-        try std.testing.expectError(error.SignatureVerificationFailed, Ed25519.verifyBatch(sig_len, signature_batch));
+        try std.testing.expectError(error.SignatureVerificationFailed, Ed25519.verifyBatch(signature_batch.len, signature_batch));
     }
 }
 
@@ -446,14 +608,19 @@ test "ed25519 test vectors" {
     for (entries) |entry| {
         var msg: [entry.msg_hex.len / 2]u8 = undefined;
         _ = try fmt.hexToBytes(&msg, entry.msg_hex);
-        var public_key: [32]u8 = undefined;
-        _ = try fmt.hexToBytes(&public_key, entry.public_key_hex);
-        var sig: [64]u8 = undefined;
-        _ = try fmt.hexToBytes(&sig, entry.sig_hex);
+        var public_key_bytes: [32]u8 = undefined;
+        _ = try fmt.hexToBytes(&public_key_bytes, entry.public_key_hex);
+        const public_key = Ed25519.PublicKey.fromBytes(public_key_bytes) catch |err| {
+            try std.testing.expectEqual(entry.expected.?, err);
+            continue;
+        };
+        var sig_bytes: [64]u8 = undefined;
+        _ = try fmt.hexToBytes(&sig_bytes, entry.sig_hex);
+        const sig = Ed25519.Signature.fromBytes(sig_bytes);
         if (entry.expected) |error_type| {
-            try std.testing.expectError(error_type, Ed25519.verify(sig, &msg, public_key));
+            try std.testing.expectError(error_type, sig.verify(&msg, public_key));
         } else {
-            try Ed25519.verify(sig, &msg, public_key);
+            try sig.verify(&msg, public_key);
         }
     }
 }
@@ -474,9 +641,25 @@ test "ed25519 with blind keys" {
     // Sign a message and check that it can be verified with the blind public key
     const msg = "test";
     const sig = try BlindKeySignatures.sign(msg, blind_kp, null);
-    try Ed25519.verify(sig, msg, blind_kp.blind_public_key);
+    try sig.verify(msg, blind_kp.blind_public_key);
 
     // Unblind the public key
     const pk = try BlindKeySignatures.unblindPublicKey(blind_kp.blind_public_key, blind, "ctx");
-    try std.testing.expectEqualSlices(u8, &pk, &kp.public_key);
+    try std.testing.expectEqualSlices(u8, &pk.toBytes(), &kp.public_key.toBytes());
+}
+
+test "ed25519 signatures with streaming" {
+    const kp = try Ed25519.KeyPair.create(null);
+
+    var signer = try kp.signer(null);
+    signer.update("mes");
+    signer.update("sage");
+    const sig = signer.finalize();
+
+    try sig.verify("message", kp.public_key);
+
+    var verifier = try sig.verifier(kp.public_key);
+    verifier.update("mess");
+    verifier.update("age");
+    try verifier.verify();
 }

--- a/lib/std/crypto/25519/x25519.zig
+++ b/lib/std/crypto/25519/x25519.zig
@@ -44,9 +44,9 @@ pub const X25519 = struct {
 
         /// Create a key pair from an Ed25519 key pair
         pub fn fromEd25519(ed25519_key_pair: crypto.sign.Ed25519.KeyPair) (IdentityElementError || EncodingError)!KeyPair {
-            const seed = ed25519_key_pair.secret_key[0..32];
+            const seed = ed25519_key_pair.secret_key.seed();
             var az: [Sha512.digest_length]u8 = undefined;
-            Sha512.hash(seed, &az, .{});
+            Sha512.hash(&seed, &az, .{});
             var sk = az[0..32].*;
             Curve.scalar.clamp(&sk);
             const pk = try publicKeyFromEd25519(ed25519_key_pair.public_key);
@@ -64,8 +64,8 @@ pub const X25519 = struct {
     }
 
     /// Compute the X25519 equivalent to an Ed25519 public eky.
-    pub fn publicKeyFromEd25519(ed25519_public_key: [crypto.sign.Ed25519.public_length]u8) (IdentityElementError || EncodingError)![public_length]u8 {
-        const pk_ed = try crypto.ecc.Edwards25519.fromBytes(ed25519_public_key);
+    pub fn publicKeyFromEd25519(ed25519_public_key: crypto.sign.Ed25519.PublicKey) (IdentityElementError || EncodingError)![public_length]u8 {
+        const pk_ed = try crypto.ecc.Edwards25519.fromBytes(ed25519_public_key.bytes);
         const pk = try Curve.fromEdwards25519(pk_ed);
         return pk.toBytes();
     }


### PR DESCRIPTION
This is a breaking API change, to make the ed25519 API similiar to the one used for ECDSA, and for future signature systems.

The ed25519 API was difficult to extend. In particular, adding multiple encodings for keys would have been ugly.

Instead of raw bytes, keys are now represented as `PublicKey` and `SecretKey` types, and signatures as the `Signature` type.

This is consistent with the ECDSA API, and, overall, makes everything much cleaner.

Signature creation and non-batch verification also got a little bit faster with the removal of an unneeded serialization.

Blind key signatures now directly reuse the regular signature code instead of duplicating it just to use a different way to compute the prefix.

In addition, support for incremental signatures has been added. Very large messages can now be signed and verified without requiring much memory.

This is something that was requested before, but was blocked by the previous API.