### PR TITLE
libcxx: only pass -DHAVE___CXA_THREAD_ATEXIT_IMPL for glibc

### DIFF
--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -320,7 +320,7 @@ pub fn buildLibCXXABI(comp: *Compilation) !void {
             }
             try cflags.append("-D_LIBCXXABI_HAS_NO_THREADS");
             try cflags.append("-D_LIBCPP_HAS_NO_THREADS");
-        } else {
+        } else if (target.abi.isGnu()) {
             try cflags.append("-DHAVE___CXA_THREAD_ATEXIT_IMPL");
         }
 


### PR DESCRIPTION
This definition communicates to libcxxabi that the libc will provide the `__cxa_thread_atexit_impl` symbol. This is true for glibc but not true for other libcs, such as musl.

Fixes building zig with `-Dtracy`.