### PR TITLE
Keep Decl objects of failed generic instantiations for error reporting purposes

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -367,7 +367,7 @@ pub const WipCaptureScope = struct {
     gpa: Allocator,
     perm_arena: Allocator,
 
-    pub fn init(gpa: Allocator, perm_arena: Allocator, parent: ?*CaptureScope) !@This() {
+    pub fn init(gpa: Allocator, perm_arena: Allocator, parent: ?*CaptureScope) Allocator.Error!WipCaptureScope {
         const scope = try perm_arena.create(CaptureScope);
         scope.* = .{ .parent = parent };
         return @This(){
@@ -4837,7 +4837,7 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
 }
 
 /// Returns the depender's index of the dependee.
-pub fn declareDeclDependency(mod: *Module, depender_index: Decl.Index, dependee_index: Decl.Index) !void {
+pub fn declareDeclDependency(mod: *Module, depender_index: Decl.Index, dependee_index: Decl.Index) Allocator.Error!void {
     if (depender_index == dependee_index) return;
 
     const depender = mod.declPtr(depender_index);

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4571,17 +4571,8 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
 
     // We need the memory for the Type to go into the arena for the Decl
     var decl_arena = std.heap.ArenaAllocator.init(gpa);
+    errdefer decl_arena.deinit();
     const decl_arena_allocator = decl_arena.allocator();
-
-    const decl_arena_state = blk: {
-        errdefer decl_arena.deinit();
-        const s = try decl_arena_allocator.create(std.heap.ArenaAllocator.State);
-        break :blk s;
-    };
-    defer {
-        decl_arena_state.* = decl_arena.state;
-        decl.value_arena = decl_arena_state;
-    }
 
     var analysis_arena = std.heap.ArenaAllocator.init(gpa);
     defer analysis_arena.deinit();
@@ -4651,6 +4642,8 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
     // not the struct itself.
     try sema.resolveTypeLayout(&block_scope, ty_src, decl_tv.ty);
 
+    const decl_arena_state = try decl_arena_allocator.create(std.heap.ArenaAllocator.State);
+
     if (decl.is_usingnamespace) {
         if (!decl_tv.ty.eql(Type.type, mod)) {
             return sema.fail(&block_scope, ty_src, "expected type, found {}", .{
@@ -4669,6 +4662,8 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
         decl.@"linksection" = null;
         decl.has_tv = true;
         decl.owns_tv = false;
+        decl_arena_state.* = decl_arena.state;
+        decl.value_arena = decl_arena_state;
         decl.analysis = .complete;
         decl.generation = mod.generation;
 
@@ -4697,6 +4692,8 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
             // linksection, align, and addrspace were already set by Sema
             decl.has_tv = true;
             decl.owns_tv = owns_tv;
+            decl_arena_state.* = decl_arena.state;
+            decl.value_arena = decl_arena_state;
             decl.analysis = .complete;
             decl.generation = mod.generation;
 
@@ -4805,6 +4802,8 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
         };
     };
     decl.has_tv = true;
+    decl_arena_state.* = decl_arena.state;
+    decl.value_arena = decl_arena_state;
     decl.analysis = .complete;
     decl.generation = mod.generation;
 

--- a/test/cases/compile_errors/generic_function_instantiation_inherits_parent_branch_quota.zig
+++ b/test/cases/compile_errors/generic_function_instantiation_inherits_parent_branch_quota.zig
@@ -1,0 +1,30 @@
+pub export fn entry1() void {
+    @setEvalBranchQuota(1001);
+    // Return type evaluation should inherit both the
+    // parent's branch quota and count meaning
+    // at least 2002 backwards branches are required.
+    comptime var i = 0;
+    inline while (i < 1000) : (i += 1) {}
+    _ = simple(10);
+}
+pub export fn entry2() void {
+    @setEvalBranchQuota(2001);
+    comptime var i = 0;
+    inline while (i < 1000) : (i += 1) {}
+    _ = simple(10);
+}
+fn simple(comptime n: usize) Type(n) {
+    return n;
+}
+fn Type(comptime n: usize) type {
+    if (n <= 1) return usize;
+    return Type(n - 1);
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :21:16: error: evaluation exceeded 1001 backwards branches
+// :21:16: note: use @setEvalBranchQuota() to raise the branch limit from 1001
+// :16:34: note: called from here

--- a/test/cases/compile_errors/generic_instantiation_failure.zig
+++ b/test/cases/compile_errors/generic_instantiation_failure.zig
@@ -1,0 +1,27 @@
+fn List(comptime Head: type, comptime Tail: type) type {
+    return union {
+        const Self = @This();
+        head: Head,
+        tail: Tail,
+
+        fn AppendReturnType(comptime item: anytype) type {
+            return List(Head, List(@TypeOf(item), void));
+        }
+    };
+}
+
+fn makeList(item: anytype) List(@TypeOf(item), void) {
+    return List(@TypeOf(item), void){ .head = item };
+}
+
+pub export fn entry() void {
+    @TypeOf(makeList(42)).AppendReturnType(64);
+}
+
+// error
+// backend=llvm
+// target=native
+//
+// :18:43: error: value of type 'type' ignored
+// :18:43: note: all non-void values must be used
+// :18:43: note: this error can be suppressed by assigning the value to '_'

--- a/test/cases/compile_errors/generic_instantiation_failure_container_level.zig
+++ b/test/cases/compile_errors/generic_instantiation_failure_container_level.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+const Version = std.SemanticVersion;
+const print = @import("std").debug.print;
+
+fn readVersion() Version {
+    const version_file = "foo";
+    const len = std.mem.indexOfAny(u8, version_file, " \n") orelse version_file.len;
+    const version_string = version_file[0..len];
+    return Version.parse(version_string) catch unreachable;
+}
+
+const version: Version = readVersion();
+pub export fn entry() void {
+    print("Version {}.{}.{}+{?s}\n", .{ version.major, version.minor, version.patch, version.build });
+}
+
+// error
+// backend=llvm
+// target=native
+//
+// :9:48: error: caught unexpected error 'InvalidVersion'
+// :12:37: note: called from here

--- a/test/cases/compile_errors/generic_instantiation_failure_container_level.zig
+++ b/test/cases/compile_errors/generic_instantiation_failure_container_level.zig
@@ -18,5 +18,5 @@ pub export fn entry() void {
 // backend=llvm
 // target=native
 //
-// :9:48: error: caught unexpected error 'InvalidVersion'
+// :9:48: error: reached unreachable code
 // :12:37: note: called from here

--- a/test/cases/compile_errors/generic_instantiation_failure_in_generic_function_return_type.zig
+++ b/test/cases/compile_errors/generic_instantiation_failure_in_generic_function_return_type.zig
@@ -1,0 +1,14 @@
+const std = @import("std");
+
+pub export fn entry() void {
+    var ohnoes: *usize = undefined;
+    _ = sliceAsBytes(ohnoes);
+}
+fn sliceAsBytes(slice: anytype) std.meta.trait.isPtrTo(.Array)(@TypeOf(slice)) {}
+
+
+// error
+// backend=llvm
+// target=native
+//
+// :7:63: error: expected type 'type', found 'bool'


### PR DESCRIPTION
This is a similar strategy as #13017, but tweaked in the following ways:

  * It is a bit less invasive in the sense that it does not extract a
    large chunk of code into a new function.
  * It does mostly the same removal of `errdefer`, however it leaves in
    the removal of the decl from the `monomorphed_funcs` table in the
    case of an error.
  * The changes to Decl memory handling are now done the same in Sema as
    they are in Module.

Some of the memory allocation failures in Sema are not handled properly.
Instead of pretending with `try`, the code now acknowledges this fact by
using `@panic`.

I have a long term plan for how to fix these, which is to migrate
everything over to InternPool. Then we can do the "ensure capacity"
pattern for all memory allocations needed by generic instantiation.

I'm not sure why the compile error doesn't match exactly in the
generic_instantiation_failure_container_level test case, but in my
opinion this logic should be in AstGen anyway, not Sema.

