### PR TITLE
translate-c: Better support for division in macros

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -6232,7 +6232,7 @@ fn parseCMulExpr(c: *Context, m: *MacroCtx, scope: *Scope) ParseError!Node {
             .Slash => {
                 const lhs = try macroBoolToInt(c, node);
                 const rhs = try macroBoolToInt(c, try parseCCastExpr(c, m, scope));
-                node = try Tag.div.create(c.arena, .{ .lhs = lhs, .rhs = rhs });
+                node = try Tag.macro_arithmetic.create(c.arena, .{ .op = .div, .lhs = lhs, .rhs = rhs });
             },
             .Percent => {
                 const lhs = try macroBoolToInt(c, node);

--- a/test/behavior/translate_c_macros.h
+++ b/test/behavior/translate_c_macros.h
@@ -53,3 +53,6 @@ typedef _Bool uintptr_t;
 #define LARGE_INT 18446744073709550592
 
 #define EMBEDDED_TAB "hello	"
+
+#define DIVIDE_CONSTANT(version) (version / 1000)
+#define DIVIDE_ARGS(A, B) (A / B)

--- a/test/behavior/translate_c_macros.zig
+++ b/test/behavior/translate_c_macros.zig
@@ -147,3 +147,37 @@ test "string and char literals that are not UTF-8 encoded. Issue #12784" {
     try expectEqual(@as(u8, '\xA9'), latin1.UNPRINTABLE_CHAR);
     try expectEqualStrings("\xA9\xA9\xA9", latin1.UNPRINTABLE_STRING);
 }
+
+test "Macro that uses division operator. Issue #13162" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
+    try expectEqual(@as(c_int, 42), h.DIVIDE_CONSTANT(@as(c_int, 42_000)));
+    try expectEqual(@as(c_uint, 42), h.DIVIDE_CONSTANT(@as(c_uint, 42_000)));
+
+    try expectEqual(
+        @as(f64, 42.0),
+        h.DIVIDE_ARGS(
+            @as(f64, 42.0),
+            true,
+        ),
+    );
+    try expectEqual(
+        @as(c_int, 21),
+        h.DIVIDE_ARGS(
+            @as(i8, 42),
+            @as(i8, 2),
+        ),
+    );
+
+    try expectEqual(
+        @as(c_int, 21),
+        h.DIVIDE_ARGS(
+            @as(c_ushort, 42),
+            @as(c_ushort, 2),
+        ),
+    );
+}


### PR DESCRIPTION
Perform C-style arithmetic conversions on operands to division operator in macros

Closes #13162