### PR TITLE
macho: fix performance regression for x86_64 and -dead_strip

### DIFF
--- a/src/link/MachO/ZldAtom.zig
+++ b/src/link/MachO/ZldAtom.zig
@@ -181,6 +181,27 @@ const RelocContext = struct {
     base_offset: i32 = 0,
 };
 
+pub fn getRelocContext(zld: *Zld, atom_index: AtomIndex) RelocContext {
+    const atom = zld.getAtom(atom_index);
+    assert(atom.getFile() != null); // synthetic atoms do not have relocs
+
+    const object = zld.objects.items[atom.getFile().?];
+    if (object.getSourceSymbol(atom.sym_index)) |source_sym| {
+        const source_sect = object.getSourceSection(source_sym.n_sect - 1);
+        return .{
+            .base_addr = source_sect.addr,
+            .base_offset = @intCast(i32, source_sym.n_value - source_sect.addr),
+        };
+    }
+    const nbase = @intCast(u32, object.in_symtab.?.len);
+    const sect_id = @intCast(u16, atom.sym_index - nbase);
+    const source_sect = object.getSourceSection(sect_id);
+    return .{
+        .base_addr = source_sect.addr,
+        .base_offset = 0,
+    };
+}
+
 pub fn parseRelocTarget(
     zld: *Zld,
     atom_index: AtomIndex,
@@ -192,6 +213,52 @@ pub fn parseRelocTarget(
 
     if (rel.r_extern == 0) {
         const sect_id = @intCast(u8, rel.r_symbolnum - 1);
+        const ctx = getRelocContext(zld, atom_index);
+        const atom_code = getAtomCode(zld, atom_index);
+        const rel_offset = @intCast(u32, rel.r_address - ctx.base_offset);
+
+        const address_in_section = if (rel.r_pcrel == 0) blk: {
+            break :blk if (rel.r_length == 3)
+                mem.readIntLittle(i64, atom_code[rel_offset..][0..8])
+            else
+                mem.readIntLittle(i32, atom_code[rel_offset..][0..4]);
+        } else blk: {
+            const correction: u3 = switch (@intToEnum(macho.reloc_type_x86_64, rel.r_type)) {
+                .X86_64_RELOC_SIGNED => 0,
+                .X86_64_RELOC_SIGNED_1 => 1,
+                .X86_64_RELOC_SIGNED_2 => 2,
+                .X86_64_RELOC_SIGNED_4 => 4,
+                else => unreachable,
+            };
+            const addend = mem.readIntLittle(i32, atom_code[rel_offset..][0..4]);
+            const target_address = @intCast(i64, ctx.base_addr) + rel.r_address + 4 + correction + addend;
+            break :blk target_address;
+        };
+
+        // Find containing atom
+        const Predicate = struct {
+            addr: i64,
+
+            pub fn predicate(pred: @This(), other: i64) bool {
+                return if (other == -1) true else other > pred.addr;
+            }
+        };
+
+        if (object.source_section_index_lookup[sect_id] > -1) {
+            const first_sym_index = @intCast(usize, object.source_section_index_lookup[sect_id]);
+            const target_sym_index = @import("zld.zig").lsearch(i64, object.source_address_lookup[first_sym_index..], Predicate{
+                .addr = address_in_section,
+            });
+
+            if (target_sym_index > 0) {
+                return SymbolWithLoc{
+                    .sym_index = @intCast(u32, first_sym_index + target_sym_index - 1),
+                    .file = atom.file,
+                };
+            }
+        }
+
+        // Start of section is not contained anywhere, return synthetic atom.
         const sym_index = object.getSectionAliasSymbolIndex(sect_id);
         return SymbolWithLoc{ .sym_index = sym_index, .file = atom.file };
     }
@@ -405,28 +472,12 @@ pub fn resolveRelocs(
     const atom = zld.getAtom(atom_index);
     assert(atom.getFile() != null); // synthetic atoms do not have relocs
 
-    const object = zld.objects.items[atom.getFile().?];
-    const ctx: RelocContext = blk: {
-        if (object.getSourceSymbol(atom.sym_index)) |source_sym| {
-            const source_sect = object.getSourceSection(source_sym.n_sect - 1);
-            break :blk .{
-                .base_addr = source_sect.addr,
-                .base_offset = @intCast(i32, source_sym.n_value - source_sect.addr),
-            };
-        }
-        const nbase = @intCast(u32, object.in_symtab.?.len);
-        const sect_id = @intCast(u16, atom.sym_index - nbase);
-        const source_sect = object.getSourceSection(sect_id);
-        break :blk .{
-            .base_addr = source_sect.addr,
-            .base_offset = 0,
-        };
-    };
-
     log.debug("resolving relocations in ATOM(%{d}, '{s}')", .{
         atom.sym_index,
         zld.getSymbolName(atom.getSymbolWithLoc()),
     });
+
+    const ctx = getRelocContext(zld, atom_index);
 
     return switch (arch) {
         .aarch64 => resolveRelocsArm64(zld, atom_index, atom_code, atom_relocs, reverse_lookup, ctx),
@@ -744,8 +795,11 @@ fn resolveRelocsArm64(
                     mem.readIntLittle(i32, atom_code[rel_offset..][0..4]);
 
                 if (rel.r_extern == 0) {
-                    const target_sect_base_addr = object.getSourceSection(@intCast(u16, rel.r_symbolnum - 1)).addr;
-                    ptr_addend -= @intCast(i64, target_sect_base_addr);
+                    const base_addr = if (target.sym_index > object.source_address_lookup.len)
+                        @intCast(i64, object.getSourceSection(@intCast(u16, rel.r_symbolnum - 1)).addr)
+                    else
+                        object.source_address_lookup[target.sym_index];
+                    ptr_addend -= base_addr;
                 }
 
                 const result = blk: {
@@ -878,13 +932,12 @@ fn resolveRelocsX86(
                 var addend = mem.readIntLittle(i32, atom_code[rel_offset..][0..4]) + correction;
 
                 if (rel.r_extern == 0) {
-                    // Note for the future self: when r_extern == 0, we should subtract correction from the
-                    // addend.
-                    const target_sect_base_addr = object.getSourceSection(@intCast(u16, rel.r_symbolnum - 1)).addr;
-                    // We need to add base_offset, i.e., offset of this atom wrt to the source
-                    // section. Otherwise, the addend will over-/under-shoot.
-                    addend += @intCast(i32, @intCast(i64, context.base_addr + rel_offset + 4) -
-                        @intCast(i64, target_sect_base_addr) + context.base_offset);
+                    const base_addr = if (target.sym_index > object.source_address_lookup.len)
+                        @intCast(i64, object.getSourceSection(@intCast(u16, rel.r_symbolnum - 1)).addr)
+                    else
+                        object.source_address_lookup[target.sym_index];
+                    addend += @intCast(i32, @intCast(i64, context.base_addr) + rel.r_address + 4 -
+                        @intCast(i64, base_addr));
                 }
 
                 const adjusted_target_addr = @intCast(u64, @intCast(i64, target_addr) + addend);
@@ -902,8 +955,11 @@ fn resolveRelocsX86(
                     mem.readIntLittle(i32, atom_code[rel_offset..][0..4]);
 
                 if (rel.r_extern == 0) {
-                    const target_sect_base_addr = object.getSourceSection(@intCast(u16, rel.r_symbolnum - 1)).addr;
-                    addend -= @intCast(i64, target_sect_base_addr);
+                    const base_addr = if (target.sym_index > object.source_address_lookup.len)
+                        @intCast(i64, object.getSourceSection(@intCast(u16, rel.r_symbolnum - 1)).addr)
+                    else
+                        object.source_address_lookup[target.sym_index];
+                    addend -= base_addr;
                 }
 
                 const result = blk: {

--- a/src/link/MachO/dead_strip.zig
+++ b/src/link/MachO/dead_strip.zig
@@ -162,21 +162,6 @@ fn markLive(
         };
         const target_sym = zld.getSymbol(target);
 
-        if (rel.r_extern == 0) {
-            // We are pessimistic and mark all atoms within the target section as live.
-            // TODO: this can be improved by marking only the relevant atoms.
-            const sect_id = target_sym.n_sect;
-            const object = zld.objects.items[target.getFile().?];
-            for (object.atoms.items) |other_atom_index| {
-                const other_atom = zld.getAtom(other_atom_index);
-                const other_sym = zld.getSymbol(other_atom.getSymbolWithLoc());
-                if (other_sym.n_sect == sect_id) {
-                    markLive(zld, other_atom_index, alive, reverse_lookups);
-                }
-            }
-            continue;
-        }
-
         if (target_sym.undf()) continue;
         if (target.getFile() == null) {
             const target_sym_name = zld.getSymbolName(target);

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -966,10 +966,9 @@ pub const Zld = struct {
 
             const global_index = resolver.table.get(sym_name) orelse {
                 const gpa = self.gpa;
-                const name = try resolver.arena.dupe(u8, sym_name);
                 const global_index = @intCast(u32, self.globals.items.len);
                 try self.globals.append(gpa, sym_loc);
-                try resolver.table.putNoClobber(name, global_index);
+                try resolver.table.putNoClobber(sym_name, global_index);
                 if (sym.undf() and !sym.tentative()) {
                     try resolver.unresolved.putNoClobber(global_index, {});
                 }


### PR DESCRIPTION
Prior to this patch, we would unnecessarily spin in `markLive` routine when dead stripping due to inability to handle target atoms described by hard-coded offsets wrt to the source relocatable object file (i.e., `r_extern == 0` which normally occurs `X86_64_RELOC_UNSIGNED` and `X86_64_RELOC_SIGNED`). This is now fixed by caching sorted source symbols by address per object and finding the containing atom of this type of relocation, and marking it live.

With this patch, macOS users on `x86_64` can now experience comparable performance as `aarch64` users. Some numbers run against standalone `zld` linking `stage3`. The link time of `stage3` with dead stripping has now been reduced by 1 second making `zld` just 1.40x slower than `lld` and faster than `ld64`:

```
❯ hyperfine ./zld ./lld ./ld64 --warmup 5
Benchmark 1: ./zld
  Time (mean ± σ):      2.300 s ±  0.013 s    [User: 1.484 s, System: 0.797 s]
  Range (min … max):    2.284 s …  2.321 s    10 runs
 
Benchmark 2: ./lld
  Time (mean ± σ):      1.639 s ±  0.010 s    [User: 1.655 s, System: 0.624 s]
  Range (min … max):    1.627 s …  1.656 s    10 runs
 
Benchmark 3: ./ld64
  Time (mean ± σ):      2.682 s ±  0.060 s    [User: 3.638 s, System: 0.721 s]
  Range (min … max):    2.627 s …  2.802 s    10 runs
 
Summary
  './lld' ran
    1.40 ± 0.01 times faster than './zld'
    1.64 ± 0.04 times faster than './ld64'
```