### PR TITLE
Make `x and false` and `x or true` comptime-known

### DIFF
--- a/src/stage1/all_types.hpp
+++ b/src/stage1/all_types.hpp
@@ -2922,6 +2922,7 @@ struct Stage1ZirInstPhi {
     Stage1ZirInst base;
 
     size_t incoming_count;
+    bool merge_comptime;
     Stage1ZirBasicBlock **incoming_blocks;
     Stage1ZirInst **incoming_values;
     ResultLocPeerParent *peer_parent;


### PR DESCRIPTION
Allows code like this to compile:
```zig
const std = @import("std");

var i: usize = 0;
fn foo() bool {
    const stdout = std.io.getStdOut().writer();
    stdout.print("i = {}\n", .{i}) catch unreachable;
    return true;
}

pub fn main() void {
    if (false and foo()) { // This works already today
        @compileError("Condition should be comptime-false");
    }
    i += 1;
    if (foo() and false) { // PR allows this condition to be comptime-known
        @compileError("Condition should be comptime-false");
    }
}
```
outputs:
```console
$ ./build/stage3/bin/zig run test.zig
i = 1
```

Note that side effects are still respected, but the result can be comptime-known despite them. This is the same way we handle, e.g. `x * 0` and `0 * x`.

Closes #6768.