### PR TITLE
AstGen: avoid access to capture defined in an inner scope from a continue expression

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -71,8 +71,8 @@ preallocated_new_func: ?*Module.Fn = null,
 /// TODO: after upgrading to use InternPool change the key here to be an
 /// InternPool value index.
 types_to_resolve: std.ArrayListUnmanaged(Air.Inst.Ref) = .{},
-/// These are lazily created runtime blocks from inline_block instructions.
-/// They are created when an inline_break passes through a runtime condition, because
+/// These are lazily created runtime blocks from block_inline instructions.
+/// They are created when an break_inline passes through a runtime condition, because
 /// Sema must convert comptime control flow to runtime control flow, which means
 /// breaking from a block.
 post_hoc_blocks: std.AutoHashMapUnmanaged(Air.Inst.Index, *LabeledBlock) = .{},
@@ -147,7 +147,7 @@ pub const Block = struct {
     /// for the one that will be the same for all Block instances.
     src_decl: Decl.Index,
     /// Non zero if a non-inline loop or a runtime conditional have been encountered.
-    /// Stores to to comptime variables are only allowed when var.runtime_index <= runtime_index.
+    /// Stores to comptime variables are only allowed when var.runtime_index <= runtime_index.
     runtime_index: Value.RuntimeIndex = .zero,
     inline_block: Zir.Inst.Index = 0,
 
@@ -1391,9 +1391,8 @@ fn analyzeBodyInner(
                     // If this block contains a function prototype, we need to reset the
                     // current list of parameters and restore it later.
                     // Note: this probably needs to be resolved in a more general manner.
-                    if (tags[inline_body[inline_body.len - 1]] == .repeat_inline) {
-                        child_block.inline_block = inline_body[0];
-                    } else child_block.inline_block = block.inline_block;
+                    child_block.inline_block =
+                        if (tags[inline_body[inline_body.len - 1]] == .repeat_inline) inline_body[0] else inst;
 
                     var label: Block.Label = .{
                         .zir_block = inst,

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -646,7 +646,6 @@ test "multiline string literal is null terminated" {
 }
 
 test "string escapes" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;

--- a/test/behavior/bit_shifting.zig
+++ b/test/behavior/bit_shifting.zig
@@ -62,7 +62,6 @@ fn ShardedTable(comptime Key: type, comptime mask_bit_count: comptime_int, compt
 
 test "sharded table" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     // realistic 16-way sharding

--- a/test/behavior/bugs/6456.zig
+++ b/test/behavior/bugs/6456.zig
@@ -11,7 +11,6 @@ const text =
 ;
 
 test "issue 6456" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/optional.zig
+++ b/test/behavior/optional.zig
@@ -429,7 +429,6 @@ test "alignment of wrapping an optional payload" {
 
 test "Optional slice size is optimized" {
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -483,7 +483,6 @@ test "pointer to constant decl preserves alignment" {
 test "ptrCast comptime known slice to C pointer" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
     const s: [:0]const u8 = "foo";

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -702,7 +702,6 @@ test "slice field ptr var" {
 test "global slice field access" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
     const S = struct {

--- a/test/behavior/translate_c_macros.zig
+++ b/test/behavior/translate_c_macros.zig
@@ -123,7 +123,6 @@ test "large integer macro" {
 test "string literal macro with embedded tab character" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
@@ -133,7 +132,6 @@ test "string literal macro with embedded tab character" {
 test "string and char literals that are not UTF-8 encoded. Issue #12784" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 

--- a/test/behavior/typename.zig
+++ b/test/behavior/typename.zig
@@ -18,7 +18,6 @@ test "anon fn param" {
         return error.SkipZigTest;
     }
 
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -50,7 +49,6 @@ test "anon field init" {
         return error.SkipZigTest;
     }
 
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -76,7 +74,6 @@ test "anon field init" {
 }
 
 test "basic" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -92,7 +89,6 @@ test "top level decl" {
         return error.SkipZigTest;
     }
 
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -142,7 +138,6 @@ const B = struct {
 };
 
 test "fn param" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -218,7 +213,6 @@ test "local variable" {
         return error.SkipZigTest;
     }
 
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -238,7 +232,6 @@ test "local variable" {
 
 test "comptime parameters not converted to anytype in function type" {
     if (builtin.zig_backend == .stage1) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -254,7 +247,6 @@ test "anon name strategy used in sub expression" {
         return error.SkipZigTest;
     }
 
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO


### PR DESCRIPTION
This PR fixes a Zir issue where a value defined in an inner scope is accessed from an outer scope.  This does not cause issues with most of the backends since they do not do any scope verification, and asm and LLVM IR are flat.  However, with the C backend, this triggers C compile errors since the a local gets defined in an inner C scope, and the C compiler actually checks for proper scoping.  This could also have been fixed by declaring all locals at the top of the function, but it seems reasonable for Zir to respect proper scoping.

 * Change the Zir generated by while expressions to respect scoping.
 * Fix Sema crash when not breaking to the outermost inline block, which was revealed by the previous change.
 * With these changes the C backend is passing 92% (1259/1374) of the behavior tests vs the LLVM backend.

As you can see in the following example, `%16` is now accessed from the same scope instead of from an outer scope.
```zig
export fn entry() void {
    var x: ?u8 = 42;
    while (x) |y| : (x = y) {}
}
```
```diff
# Source bytes:       79B
 # Tokens:             32 (184B)
 # AST Nodes:          15 (315B)
-# Total ZIR bytes:    696B
+# Total ZIR bytes:    700B
 # Instructions:       39 (351B)
 # String Table Bytes: 13B
-# Extra Data Items:   67 (268B)
+# Extra Data Items:   68 (272B)
 %0 = extended(struct_decl(parent, Auto, {
-  [59] export entry line(0) hash(498bcdbf8b9f8088648ef7130aa5a5b7): %1 = block_inline({
+  [60] export entry line(0) hash(498bcdbf8b9f8088648ef7130aa5a5b7): %1 = block_inline({
     %37 = func(ret_ty=@Zir.Inst.Ref.void_type, body={
       %2 = block({
         %3 = dbg_block_begin()
         %4 = dbg_stmt(2, 5)
         %5 = optional_type(@Zir.Inst.Ref.u8_type) node_offset:2:12 to :2:15
         %6 = alloc_mut(%5) node_offset:2:5 to :2:20
         %7 = int(42)
         %8 = store_node(%6, %7) node_offset:2:18 to :2:20
         %9 = dbg_var_ptr(%6, "x")
         %10 = loop({
           %15 = block({
             %11 = dbg_stmt(3, 12)
             %12 = load(%6) node_offset:3:12 to :3:13
             %13 = is_non_null(%12) node_offset:3:29 to :3:31
             %14 = condbr(%13, {
+              %19 = dbg_block_begin()
               %16 = optional_payload_unsafe(%12) node_offset:3:12 to :3:13
-              %23 = dbg_block_begin()
-              %24 = dbg_var_val(%16, "y")
-              %28 = dbg_block_end()
-              %25 = block({
-                %26 = restore_err_ret_index(%25, @Zir.Inst.Ref.none)
-                %27 = break(%25, @Zir.Inst.Ref.void_value)
-              }) node_offset:3:29 to :3:31
+              %20 = dbg_var_val(%16, "y")
+              %17 = block({
+                %24 = dbg_stmt(3, 29)
+                %25 = block({
+                  %26 = restore_err_ret_index(%25, @Zir.Inst.Ref.none)
+                  %27 = break(%25, @Zir.Inst.Ref.void_value)
+                }) node_offset:3:29 to :3:31
+                %28 = break(%17, @Zir.Inst.Ref.void_value)
+              }) node_offset:3:5 to :3:31
+              %21 = dbg_stmt(3, 22)
+              %23 = dbg_block_end()
+              %22 = store_node(%6, %16) node_offset:3:22 to :3:27
               %29 = break(%15, @Zir.Inst.Ref.void_value)
             }, {
               %30 = break(%10, @Zir.Inst.Ref.void_value)
             }) node_offset:3:5 to :3:31
           }) node_offset:3:5 to :3:31
-          %17 = dbg_block_begin()
-          %18 = dbg_var_val(%16, "y")
-          %19 = dbg_stmt(3, 22)
-          %21 = dbg_block_end()
-          %20 = store_node(%6, %16) node_offset:3:22 to :3:27
-          %22 = repeat() node_offset:3:5 to :3:31
+          %18 = repeat() node_offset:3:5 to :3:31
         }) node_offset:3:5 to :3:31
         %32 = dbg_block_end()
         %31 = ensure_result_used(%10) node_offset:3:5 to :3:31
         %33 = restore_err_ret_index(%2, @Zir.Inst.Ref.none)
         %34 = break(%2, @Zir.Inst.Ref.void_value)
       }) node_offset:1:24 to :1:25
       %35 = restore_err_ret_index(@Zir.Inst.Ref.none, @Zir.Inst.Ref.none)
       %36 = ret_tok(@Zir.Inst.Ref.void_value) token_offset:4:1 to :4:2
     }) (lbrace=1:24,rbrace=4:1) node_offset:1:1 to :1:10
     %38 = break_inline(%1, %37)
   }) node_offset:1:1 to :1:23
 }, {}, {})
```