### PR TITLE
std.ascii: remove LUT and deprecations

### DIFF
--- a/lib/std/SemanticVersion.zig
+++ b/lib/std/SemanticVersion.zig
@@ -114,7 +114,7 @@ pub fn parse(text: []const u8) !Version {
             if (id.len == 0) return error.InvalidVersion;
 
             // Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-].
-            for (id) |c| if (!std.ascii.isAlNum(c) and c != '-') return error.InvalidVersion;
+            for (id) |c| if (!std.ascii.isAlphanumeric(c) and c != '-') return error.InvalidVersion;
 
             // Numeric identifiers MUST NOT include leading zeroes.
             const is_num = for (id) |c| {
@@ -133,7 +133,7 @@ pub fn parse(text: []const u8) !Version {
             if (id.len == 0) return error.InvalidVersion;
 
             // Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-].
-            for (id) |c| if (!std.ascii.isAlNum(c) and c != '-') return error.InvalidVersion;
+            for (id) |c| if (!std.ascii.isAlphanumeric(c) and c != '-') return error.InvalidVersion;
         }
     }
 

--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -200,9 +200,11 @@ test "ASCII character classes" {
 
     try testing.expect(!isControl('a'));
     try testing.expect(!isControl('z'));
+    try testing.expect(!isControl(' '));
     try testing.expect(isControl(control_code.nul));
     try testing.expect(isControl(control_code.ff));
     try testing.expect(isControl(control_code.us));
+    try testing.expect(isControl(control_code.del));
     try testing.expect(!isControl(0x80));
     try testing.expect(!isControl(0xff));
 
@@ -210,36 +212,53 @@ test "ASCII character classes" {
     try testing.expect(':' == toUpper(':'));
     try testing.expect('\xab' == toUpper('\xab'));
     try testing.expect(!isUpper('z'));
+    try testing.expect(!isUpper(0x80));
+    try testing.expect(!isUpper(0xff));
 
     try testing.expect('c' == toLower('C'));
     try testing.expect(':' == toLower(':'));
     try testing.expect('\xab' == toLower('\xab'));
     try testing.expect(!isLower('Z'));
+    try testing.expect(!isLower(0x80));
+    try testing.expect(!isLower(0xff));
 
     try testing.expect(isAlphanumeric('Z'));
     try testing.expect(isAlphanumeric('z'));
     try testing.expect(isAlphanumeric('5'));
-    try testing.expect(isAlphanumeric('5'));
+    try testing.expect(isAlphanumeric('a'));
     try testing.expect(!isAlphanumeric('!'));
+    try testing.expect(!isAlphanumeric(0x80));
+    try testing.expect(!isAlphanumeric(0xff));
 
     try testing.expect(!isAlphabetic('5'));
     try testing.expect(isAlphabetic('c'));
-    try testing.expect(!isAlphabetic('5'));
+    try testing.expect(!isAlphabetic('@'));
+    try testing.expect(isAlphabetic('Z'));
+    try testing.expect(!isAlphabetic(0x80));
+    try testing.expect(!isAlphabetic(0xff));
 
     try testing.expect(isWhitespace(' '));
     try testing.expect(isWhitespace('\t'));
     try testing.expect(isWhitespace('\r'));
     try testing.expect(isWhitespace('\n'));
+    try testing.expect(isWhitespace(control_code.ff));
     try testing.expect(!isWhitespace('.'));
+    try testing.expect(!isWhitespace(control_code.us));
+    try testing.expect(!isWhitespace(0x80));
+    try testing.expect(!isWhitespace(0xff));
 
     try testing.expect(!isHex('g'));
     try testing.expect(isHex('b'));
     try testing.expect(isHex('F'));
     try testing.expect(isHex('9'));
+    try testing.expect(!isHex(0x80));
+    try testing.expect(!isHex(0xff));
 
     try testing.expect(!isDigit('~'));
     try testing.expect(isDigit('0'));
     try testing.expect(isDigit('9'));
+    try testing.expect(!isDigit(0x80));
+    try testing.expect(!isDigit(0xff));
 
     try testing.expect(isPrint(' '));
     try testing.expect(isPrint('@'));

--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -91,7 +91,7 @@ pub const control_code = struct {
 /// Returns whether the character is alphanumeric: A-Z, a-z, or 0-9.
 pub fn isAlphanumeric(c: u8) bool {
     return switch (c) {
-        'A'...'Z', 'a'...'z', '0'...'9' => true,
+        '0'...'9', 'A'...'Z', 'a'...'z' => true,
         else => false,
     };
 }
@@ -167,7 +167,7 @@ pub fn isUpper(c: u8) bool {
 /// Returns whether the character is a hexadecimal digit: A-F, a-f, or 0-9.
 pub fn isHex(c: u8) bool {
     return switch (c) {
-        'A'...'F', 'a'...'f', '0'...'9' => true,
+        '0'...'9', 'A'...'F', 'a'...'f' => true,
         else => false,
     };
 }

--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -10,83 +10,10 @@
 
 const std = @import("std");
 
-// TODO: remove all decls marked as DEPRECATED after 0.10.0's release
-
 /// The C0 control codes of the ASCII encoding.
 ///
 /// See also: https://en.wikipedia.org/wiki/C0_and_C1_control_codes and `isControl`.
 pub const control_code = struct {
-    // DEPRECATED: use the lowercase variant
-    pub const NUL = 0x00;
-    // DEPRECATED: use the lowercase variant
-    pub const SOH = 0x01;
-    // DEPRECATED: use the lowercase variant
-    pub const STX = 0x02;
-    // DEPRECATED: use the lowercase variant
-    pub const ETX = 0x03;
-    // DEPRECATED: use the lowercase variant
-    pub const EOT = 0x04;
-    // DEPRECATED: use the lowercase variant
-    pub const ENQ = 0x05;
-    // DEPRECATED: use the lowercase variant
-    pub const ACK = 0x06;
-    // DEPRECATED: use the lowercase variant
-    pub const BEL = 0x07;
-    // DEPRECATED: use the lowercase variant
-    pub const BS = 0x08;
-    // DEPRECATED: use `ht`
-    pub const TAB = 0x09;
-    // DEPRECATED: use the lowercase variant
-    pub const LF = 0x0A;
-    // DEPRECATED: use the lowercase variant
-    pub const VT = 0x0B;
-    // DEPRECATED: use the lowercase variant
-    pub const FF = 0x0C;
-    // DEPRECATED: use the lowercase variant
-    pub const CR = 0x0D;
-    // DEPRECATED: use the lowercase variant
-    pub const SO = 0x0E;
-    // DEPRECATED: use the lowercase variant
-    pub const SI = 0x0F;
-    // DEPRECATED: use the lowercase variant
-    pub const DLE = 0x10;
-    // DEPRECATED: use the lowercase variant
-    pub const DC1 = 0x11;
-    // DEPRECATED: use the lowercase variant
-    pub const DC2 = 0x12;
-    // DEPRECATED: use the lowercase variant
-    pub const DC3 = 0x13;
-    // DEPRECATED: use the lowercase variant
-    pub const DC4 = 0x14;
-    // DEPRECATED: use the lowercase variant
-    pub const NAK = 0x15;
-    // DEPRECATED: use the lowercase variant
-    pub const SYN = 0x16;
-    // DEPRECATED: use the lowercase variant
-    pub const ETB = 0x17;
-    // DEPRECATED: use the lowercase variant
-    pub const CAN = 0x18;
-    // DEPRECATED: use the lowercase variant
-    pub const EM = 0x19;
-    // DEPRECATED: use the lowercase variant
-    pub const SUB = 0x1A;
-    // DEPRECATED: use the lowercase variant
-    pub const ESC = 0x1B;
-    // DEPRECATED: use the lowercase variant
-    pub const FS = 0x1C;
-    // DEPRECATED: use the lowercase variant
-    pub const GS = 0x1D;
-    // DEPRECATED: use the lowercase variant
-    pub const RS = 0x1E;
-    // DEPRECATED: use the lowercase variant
-    pub const US = 0x1F;
-    // DEPRECATED: use the lowercase variant
-    pub const DEL = 0x7F;
-    // DEPRECATED: use the lowercase variant
-    pub const XON = 0x11;
-    // DEPRECATED: use the lowercase variant
-    pub const XOFF = 0x13;
-
     /// Null.
     pub const nul = 0x00;
     /// Start of Heading.
@@ -298,19 +225,6 @@ fn inTable(c: u8, t: tIndex) bool {
     return (combinedTable[c] & (@as(u8, 1) << @enumToInt(t))) != 0;
 }
 
-/// DEPRECATED: use `isAlphanumeric`
-pub const isAlNum = isAlphanumeric;
-/// DEPRECATED: use `isAlphabetic`
-pub const isAlpha = isAlphabetic;
-/// DEPRECATED: use `isControl`
-pub const isCntrl = isControl;
-/// DEPRECATED: use `isWhitespace`.
-pub const isSpace = isWhitespace;
-/// DEPRECATED: use `whitespace`.
-pub const spaces = whitespace;
-/// DEPRECATED: use `isHex`.
-pub const isXDigit = isHex;
-
 /// Returns whether the character is alphanumeric.
 pub fn isAlphanumeric(c: u8) bool {
     return (combinedTable[c] & ((@as(u8, 1) << @enumToInt(tIndex.Alpha)) |
@@ -335,11 +249,6 @@ pub fn isDigit(c: u8) bool {
     return inTable(c, tIndex.Digit);
 }
 
-/// DEPRECATED: use `isPrint(c) and c != ' '` instead
-pub fn isGraph(c: u8) bool {
-    return inTable(c, tIndex.Graph);
-}
-
 /// Returns whether the character is a lowercased letter.
 pub fn isLower(c: u8) bool {
     return inTable(c, tIndex.Lower);
@@ -350,11 +259,6 @@ pub fn isLower(c: u8) bool {
 /// This is the same as `!isControl(c)`.
 pub fn isPrint(c: u8) bool {
     return inTable(c, tIndex.Graph) or c == ' ';
-}
-
-/// DEPRECATED: create your own function based on your needs and what you want to do.
-pub fn isPunct(c: u8) bool {
-    return inTable(c, tIndex.Punct);
 }
 
 /// Returns whether this character is included in `whitespace`.
@@ -390,11 +294,6 @@ pub fn isHex(c: u8) bool {
 /// Returns whether the character is a 7-bit ASCII character.
 pub fn isASCII(c: u8) bool {
     return c < 128;
-}
-
-/// DEPRECATED: use `c == ' ' or c == '\t'` or try `isWhitespace`
-pub fn isBlank(c: u8) bool {
-    return (c == ' ') or (c == '\x09');
 }
 
 /// Uppercases the character and returns it as-is if it's already uppercased or not a letter.
@@ -440,9 +339,9 @@ test "ascii character classes" {
     try testing.expect(isAlphanumeric('5'));
     try testing.expect(!isAlphanumeric('!'));
 
-    try testing.expect(!isAlpha('5'));
-    try testing.expect(isAlpha('c'));
-    try testing.expect(!isAlpha('5'));
+    try testing.expect(!isAlphabetic('5'));
+    try testing.expect(isAlphabetic('c'));
+    try testing.expect(!isAlphabetic('5'));
 
     try testing.expect(isWhitespace(' '));
     try testing.expect(isWhitespace('\t'));

--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -254,7 +254,7 @@ pub fn isLower(c: u8) bool {
     return inTable(c, tIndex.Lower);
 }
 
-/// Returns whether the character has some graphical representation and can be printed.
+/// Returns whether the character is printable and has some graphical representation.
 /// This also returns `true` for the space character.
 /// This is the same as `!isControl(c)`.
 pub fn isPrint(c: u8) bool {
@@ -286,7 +286,7 @@ pub fn isUpper(c: u8) bool {
     return inTable(c, tIndex.Upper);
 }
 
-/// Returns whether the character is a hexadecimal digit. This is case-insensitive.
+/// Returns whether the character is a hexadecimal digit. Case-insensitive.
 pub fn isHex(c: u8) bool {
     return inTable(c, tIndex.Hex);
 }
@@ -296,7 +296,7 @@ pub fn isASCII(c: u8) bool {
     return c < 128;
 }
 
-/// Uppercases the character and returns it as-is if it's already uppercased or not a letter.
+/// Uppercases the character and returns it as-is if already uppercase or not a letter.
 pub fn toUpper(c: u8) u8 {
     if (isLower(c)) {
         return c & 0b11011111;
@@ -305,7 +305,7 @@ pub fn toUpper(c: u8) u8 {
     }
 }
 
-/// Lowercases the character and returns it as-is if it's already lowercased or not a letter.
+/// Lowercases the character and returns it as-is if already lowercase or not a letter.
 pub fn toLower(c: u8) u8 {
     if (isUpper(c)) {
         return c | 0b00100000;
@@ -314,7 +314,7 @@ pub fn toLower(c: u8) u8 {
     }
 }
 
-test "ascii character classes" {
+test "ASCII character classes" {
     const testing = std.testing;
 
     try testing.expect(!isControl('a'));
@@ -440,7 +440,7 @@ pub fn startsWithIgnoreCase(haystack: []const u8, needle: []const u8) bool {
     return if (needle.len > haystack.len) false else eqlIgnoreCase(haystack[0..needle.len], needle);
 }
 
-test "ascii.startsWithIgnoreCase" {
+test "startsWithIgnoreCase" {
     try std.testing.expect(startsWithIgnoreCase("boB", "Bo"));
     try std.testing.expect(!startsWithIgnoreCase("Needle in hAyStAcK", "haystack"));
 }
@@ -449,7 +449,7 @@ pub fn endsWithIgnoreCase(haystack: []const u8, needle: []const u8) bool {
     return if (needle.len > haystack.len) false else eqlIgnoreCase(haystack[haystack.len - needle.len ..], needle);
 }
 
-test "ascii.endsWithIgnoreCase" {
+test "endsWithIgnoreCase" {
     try std.testing.expect(endsWithIgnoreCase("Needle in HaYsTaCk", "haystack"));
     try std.testing.expect(!endsWithIgnoreCase("BoB", "Bo"));
 }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2198,8 +2198,9 @@ test "slice" {
 }
 
 test "escape non-printable" {
-    try expectFmt("abc", "{s}", .{fmtSliceEscapeLower("abc")});
+    try expectFmt("abc 123", "{s}", .{fmtSliceEscapeLower("abc 123")});
     try expectFmt("ab\\xffc", "{s}", .{fmtSliceEscapeLower("ab\xffc")});
+    try expectFmt("abc 123", "{s}", .{fmtSliceEscapeUpper("abc 123")});
     try expectFmt("ab\\xFFc", "{s}", .{fmtSliceEscapeUpper("ab\xffc")});
 }
 

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1192,7 +1192,7 @@ pub fn isValidHostName(hostname: []const u8) bool {
     if (hostname.len >= 254) return false;
     if (!std.unicode.utf8ValidateSlice(hostname)) return false;
     for (hostname) |byte| {
-        if (byte >= 0x80 or byte == '.' or byte == '-' or std.ascii.isAlNum(byte)) {
+        if (!std.ascii.isASCII(byte) or byte == '.' or byte == '-' or std.ascii.isAlphanumeric(byte)) {
             continue;
         }
         return false;

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -1531,7 +1531,7 @@ const Parser = struct {
                     // without types we don't know if '&&' was intended as 'bitwise_and address_of', or a c-style logical_and
                     // The best the parser can do is recommend changing it to 'and' or ' & &'
                     try p.warnMsg(.{ .tag = .invalid_ampersand_ampersand, .token = oper_token });
-                } else if (std.ascii.isSpace(char_before) != std.ascii.isSpace(char_after)) {
+                } else if (std.ascii.isWhitespace(char_before) != std.ascii.isWhitespace(char_after)) {
                     try p.warnMsg(.{ .tag = .mismatched_binary_op_whitespace, .token = oper_token });
                 }
             }
@@ -1728,7 +1728,7 @@ const Parser = struct {
                     var sentinel: Node.Index = 0;
                     if (p.eatToken(.identifier)) |ident| {
                         const ident_slice = p.source[p.token_starts[ident]..p.token_starts[ident + 1]];
-                        if (!std.mem.eql(u8, std.mem.trimRight(u8, ident_slice, &std.ascii.spaces), "c")) {
+                        if (!std.mem.eql(u8, std.mem.trimRight(u8, ident_slice, &std.ascii.whitespace), "c")) {
                             p.tok_i -= 1;
                         }
                     } else if (p.eatToken(.colon)) |_| {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2648,7 +2648,7 @@ fn renderComments(ais: *Ais, tree: Ast, start: usize, end: usize) Error!bool {
         const newline = if (newline_index) |i| comment_start + i else null;
 
         const untrimmed_comment = tree.source[comment_start .. newline orelse tree.source.len];
-        const trimmed_comment = mem.trimRight(u8, untrimmed_comment, &std.ascii.spaces);
+        const trimmed_comment = mem.trimRight(u8, untrimmed_comment, &std.ascii.whitespace);
 
         // Don't leave any whitespace at the start of the file
         if (index != 0) {
@@ -2669,7 +2669,7 @@ fn renderComments(ais: *Ais, tree: Ast, start: usize, end: usize) Error!bool {
 
         index = 1 + (newline orelse end - 1);
 
-        const comment_content = mem.trimLeft(u8, trimmed_comment["//".len..], &std.ascii.spaces);
+        const comment_content = mem.trimLeft(u8, trimmed_comment["//".len..], &std.ascii.whitespace);
         if (ais.disabled_offset != null and mem.eql(u8, comment_content, "zig fmt: on")) {
             // Write the source for which formatting was disabled directly
             // to the underlying writer, fixing up invaild whitespace.
@@ -2716,7 +2716,7 @@ fn renderExtraNewlineToken(ais: *Ais, tree: Ast, token_index: Ast.TokenIndex) Er
     // non-whitespace character is encountered or two newlines have been found.
     var i = token_start - 1;
     var newlines: u2 = 0;
-    while (std.ascii.isSpace(tree.source[i])) : (i -= 1) {
+    while (std.ascii.isWhitespace(tree.source[i])) : (i -= 1) {
         if (tree.source[i] == '\n') newlines += 1;
         if (newlines == 2) return ais.insertNewline();
         if (i == prev_token_end) break;
@@ -2778,7 +2778,7 @@ fn tokenSliceForRender(tree: Ast, token_index: Ast.TokenIndex) []const u8 {
             ret.len -= 1;
         },
         .container_doc_comment, .doc_comment => {
-            ret = mem.trimRight(u8, ret, &std.ascii.spaces);
+            ret = mem.trimRight(u8, ret, &std.ascii.whitespace);
         },
         else => {},
     }

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -1232,7 +1232,7 @@ pub const Tokenizer = struct {
     fn getInvalidCharacterLength(self: *Tokenizer) u3 {
         const c0 = self.buffer[self.index];
         if (std.ascii.isASCII(c0)) {
-            if (std.ascii.isCntrl(c0)) {
+            if (std.ascii.isControl(c0)) {
                 // ascii control codes are never allowed
                 // (note that \n was checked before we got here)
                 return 1;

--- a/src/DepTokenizer.zig
+++ b/src/DepTokenizer.zig
@@ -866,7 +866,7 @@ test "error target - continuation expecting end-of-line" {
     );
     try depTokenizer("foo.o: \\ ",
         \\target = {foo.o}
-        \\ERROR: illegal char \x20 at position 8: continuation expecting end-of-line
+        \\ERROR: illegal char ' ' at position 8: continuation expecting end-of-line
     );
     try depTokenizer("foo.o: \\x",
         \\target = {foo.o}
@@ -1053,10 +1053,10 @@ fn printCharValues(out: anytype, bytes: []const u8) !void {
 }
 
 fn printUnderstandableChar(out: anytype, char: u8) !void {
-    if (!std.ascii.isPrint(char) or char == ' ') {
-        try out.print("\\x{X:0>2}", .{char});
+    if (std.ascii.isPrint(char)) {
+        try out.print("'{c}'", .{char});
     } else {
-        try out.print("'{c}'", .{printable_char_tab[char]});
+        try out.print("\\x{X:0>2}", .{char});
     }
 }
 

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -5738,7 +5738,7 @@ fn parseCNumLit(c: *Context, m: *MacroCtx) ParseError!Node {
                 if (mem.indexOfScalar(u8, lit_bytes, '.')) |dot_index| {
                     if (dot_index == 2) {
                         lit_bytes = try std.fmt.allocPrint(c.arena, "0x0{s}", .{lit_bytes[2..]});
-                    } else if (dot_index + 1 == lit_bytes.len or !std.ascii.isXDigit(lit_bytes[dot_index + 1])) {
+                    } else if (dot_index + 1 == lit_bytes.len or !std.ascii.isHex(lit_bytes[dot_index + 1])) {
                         // If the literal lacks a digit after the `.`, we need to
                         // add one since `0x1.p10` would be invalid syntax in Zig.
                         lit_bytes = try std.fmt.allocPrint(c.arena, "0x{s}0{s}", .{


### PR DESCRIPTION
I wrote this after #12448 got merged but decided to wait for 0.10.0 to be released before pulling it. Now I've decided to pull it a bit earlier since 0.10.0 is just about to be released, anyway (and in case someone else would accidentally start working on the same thing or something).

This should be merged **after** 0.10.0 and removes all deprecations, updates the codebase, does some other cleanups etc., and also removes the LUT (Look-Up Table): this was already discussed quite a bit in #11629 (see https://github.com/ziglang/zig/pull/11629#issuecomment-1213641429 etc.) and I've also discussed this with @topolarity in more detail after that, but basically the reason is that the LUT made us depend on cache performance. It also reduces binary size. See also the commit's description for more detail.

Removing both the deprecations and the LUT at the same time is a very convenient timing, by the way. It shouldn't make review that much harder, I hope.