### PR TITLE
failing C ABI test with double

### DIFF
--- a/test/c_abi/cfuncs.c
+++ b/test/c_abi/cfuncs.c
@@ -661,21 +661,6 @@ void c_multiple_struct_floats(FloatRect x, FloatRect y) {
     assert_or_panic(y.bottom == 15);
 }
 
-struct  C_C_D  {
-  char v1;
-  char v2;
-  double v3;
-};
-
-int c_C_C_D(struct C_C_D lv){
-  int err = 0;
-  if (lv.v1 != 88) err = 1;
-  if (lv.v2 != 39) err = 2;
-  if (lv.v3 != -2.125) err = 3;
-  return err;
-}
-
-
 bool c_ret_bool() {
     return 1;
 }
@@ -784,4 +769,67 @@ void c_ptr_size_float_struct(Vector2 vec) {
 }
 Vector2 c_ret_ptr_size_float_struct(void) {
     return (Vector2){3, 4};
+}
+
+/// Tests for Double + Char struct
+struct DC { double v1; char v2; };
+
+int c_assert_DC(struct DC lv){
+  if (lv.v1 != -0.25) return 1;
+  if (lv.v2 != 15) return 2;
+  return 0;
+}
+struct DC c_ret_DC(){
+    struct DC lv = { .v1 = -0.25, .v2 = 15 };
+    return lv;
+}
+int zig_assert_DC(struct DC);
+int c_send_DC(){
+    return zig_assert_DC(c_ret_DC());
+}
+struct DC zig_ret_DC();
+int c_assert_ret_DC(){
+    return c_assert_DC(zig_ret_DC());
+}
+
+/// Tests for Char + Float + Float struct
+struct CFF { char v1; float v2; float v3; };
+
+int c_assert_CFF(struct CFF lv){
+  if (lv.v1 != 39) return 1;
+  if (lv.v2 != 0.875) return 2;
+  if (lv.v3 != 1.0) return 3;
+  return 0;
+}
+struct CFF c_ret_CFF(){
+    struct CFF lv = { .v1 = 39, .v2 = 0.875, .v3 = 1.0 };
+    return lv;
+}
+int zig_assert_CFF(struct CFF);
+int c_send_CFF(){
+    return zig_assert_CFF(c_ret_CFF());
+}
+struct CFF zig_ret_CFF();
+int c_assert_ret_CFF(){
+    return c_assert_CFF(zig_ret_CFF());
+}
+
+struct PD { void* v1; double v2; };
+
+int c_assert_PD(struct PD lv){
+  if (lv.v1 != 0) return 1;
+  if (lv.v2 != 0.5) return 2;
+  return 0;
+}
+struct PD c_ret_PD(){
+    struct PD lv = { .v1 = 0, .v2 = 0.5 };
+    return lv;
+}
+int zig_assert_PD(struct PD);
+int c_send_PD(){
+    return zig_assert_PD(c_ret_PD());
+}
+struct PD zig_ret_PD();
+int c_assert_ret_PD(){
+    return c_assert_PD(zig_ret_PD());
 }

--- a/test/c_abi/cfuncs.c
+++ b/test/c_abi/cfuncs.c
@@ -661,6 +661,21 @@ void c_multiple_struct_floats(FloatRect x, FloatRect y) {
     assert_or_panic(y.bottom == 15);
 }
 
+struct  C_C_D  {
+  char v1;
+  char v2;
+  double v3;
+};
+
+int c_C_C_D(struct C_C_D lv){
+  int err = 0;
+  if (lv.v1 != 88) err = 1;
+  if (lv.v2 != 39) err = 2;
+  if (lv.v3 != -2.125) err = 3;
+  return err;
+}
+
+
 bool c_ret_bool() {
     return 1;
 }

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -1,3 +1,8 @@
+/// Tests for the C ABI.
+/// Those tests are passing back and forth struct and values across C ABI
+/// by combining Zig code here and it's mirror in cfunc.c
+/// To run the tests on a specific architecture:
+/// zig test -fno-stage1 -lc main.zig cfuncs.c -target mips-linux --test-cmd qemu-mips --test-cmd-bin
 const std = @import("std");
 const builtin = @import("builtin");
 const print = std.debug.print;
@@ -846,6 +851,7 @@ const DC = extern struct { v1: f64, v2: u8 };
 test "DC: Zig passes to C" {
     if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     try expectOk(c_assert_DC(.{ .v1 = -0.25, .v2 = 15 }));
 }
 test "DC: Zig returns to C" {
@@ -854,6 +860,7 @@ test "DC: Zig returns to C" {
 test "DC: C passes to Zig" {
     if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     try expectOk(c_send_DC());
 }
 test "DC: C returns to Zig" {
@@ -881,18 +888,24 @@ const CFF = extern struct { v1: u8, v2: f32, v3: f32 };
 test "CFF: Zig passes to C" {
     if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     try expectOk(c_assert_CFF(.{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 }));
 }
 test "CFF: Zig returns to C" {
+    if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     try expectOk(c_assert_ret_CFF());
 }
 test "CFF: C passes to Zig" {
     if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
+
     try expectOk(c_send_CFF());
 }
 test "CFF: C returns to Zig" {
+    // segfault on aarch64 and mips
     if (builtin.target.cpu.arch == .aarch64) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     try expectEqual(c_ret_CFF(), .{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 });
 }
 pub extern fn c_assert_CFF(lv: CFF) c_int;
@@ -917,6 +930,7 @@ const PD = extern struct { v1: ?*anyopaque, v2: f64 };
 test "PD: Zig passes to C" {
     if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     try expectOk(c_assert_PD(.{ .v1 = null, .v2 = 0.5 }));
 }
 test "PD: Zig returns to C" {
@@ -926,6 +940,7 @@ test "PD: Zig returns to C" {
 test "PD: C passes to Zig" {
     if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     try expectOk(c_send_PD());
 }
 test "PD: C returns to Zig" {

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -853,10 +853,12 @@ test "DC: Zig passes to C" {
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     try expectOk(c_assert_DC(.{ .v1 = -0.25, .v2 = 15 }));
 }
 test "DC: Zig returns to C" {
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     try expectOk(c_assert_ret_DC());
 }
 test "DC: C passes to Zig" {
@@ -864,10 +866,12 @@ test "DC: C passes to Zig" {
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     try expectOk(c_send_DC());
 }
 test "DC: C returns to Zig" {
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     try expectEqual(c_ret_DC(), .{ .v1 = -0.25, .v2 = 15 });
 }
 
@@ -893,16 +897,19 @@ test "CFF: Zig passes to C" {
     if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     try expectOk(c_assert_CFF(.{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 }));
 }
 test "CFF: Zig returns to C" {
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     try expectOk(c_assert_ret_CFF());
 }
 test "CFF: C passes to Zig" {
     if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
 
     try expectOk(c_send_CFF());
 }
@@ -910,6 +917,7 @@ test "CFF: C returns to Zig" {
     // segfault on aarch64 and mips
     if (builtin.target.cpu.arch == .aarch64) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     try expectEqual(c_ret_CFF(), .{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 });
 }
 pub extern fn c_assert_CFF(lv: CFF) c_int;
@@ -935,20 +943,24 @@ test "PD: Zig passes to C" {
     if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     try expectOk(c_assert_PD(.{ .v1 = null, .v2 = 0.5 }));
 }
 test "PD: Zig returns to C" {
     if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     try expectOk(c_assert_ret_PD());
 }
 test "PD: C passes to Zig" {
     if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     try expectOk(c_send_PD());
 }
 test "PD: C returns to Zig" {
     if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     try expectEqual(c_ret_PD(), .{ .v1 = null, .v2 = 0.5 });
 }
 pub extern fn c_assert_PD(lv: PD) c_int;

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -840,28 +840,20 @@ pub inline fn expectOk(c_err: c_int) !void {
     }
 }
 
-pub inline fn expectFailX86(c_err: c_int) !void {
-    // AFAICT those tests are failing only on Mac, Linux x86_64.
-    if (comptime builtin.target.cpu.arch != .x86_64) return expectOk(c_err);
-    if (comptime builtin.target.os.tag == .windows) return expectOk(c_err);
-    if (c_err != 0) {
-        std.debug.print("ABI mismatch on field v{d}.\n", .{c_err});
-    } else {
-        std.debug.print("no ABI mismatch, test should be upgraded to expectOk.\n", .{});
-    }
-    return error.SkipZigTest;
-}
-
 /// Tests for Double + Char struct
 const DC = extern struct { v1: f64, v2: u8 };
 test "DC: Zig passes to C" {
-    try expectFailX86(c_assert_DC(.{ .v1 = -0.25, .v2 = 15 }));
+    if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows)
+        return error.SkipZigTest;
+    try expectOk(c_assert_DC(.{ .v1 = -0.25, .v2 = 15 }));
 }
 test "DC: Zig returns to C" {
     try expectOk(c_assert_ret_DC());
 }
 test "DC: C passes to Zig" {
-    try expectFailX86(c_send_DC());
+    if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows)
+        return error.SkipZigTest;
+    try expectOk(c_send_DC());
 }
 test "DC: C returns to Zig" {
     try expectEqual(c_ret_DC(), .{ .v1 = -0.25, .v2 = 15 });
@@ -886,13 +878,17 @@ pub export fn zig_ret_DC() DC {
 const CFF = extern struct { v1: u8, v2: f32, v3: f32 };
 
 test "CFF: Zig passes to C" {
-    try expectFailX86(c_assert_CFF(.{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 }));
+    if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
+        return error.SkipZigTest;
+    try expectOk(c_assert_CFF(.{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 }));
 }
 test "CFF: Zig returns to C" {
     try expectOk(c_assert_ret_CFF());
 }
 test "CFF: C passes to Zig" {
-    try expectFailX86(c_send_CFF());
+    if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
+        return error.SkipZigTest;
+    try expectOk(c_send_CFF());
 }
 test "CFF: C returns to Zig" {
     try expectEqual(c_ret_CFF(), .{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 });
@@ -917,13 +913,17 @@ pub export fn zig_ret_CFF() CFF {
 const PD = extern struct { v1: ?*anyopaque, v2: f64 };
 
 test "PD: Zig passes to C" {
-    try expectFailX86(c_assert_PD(.{ .v1 = null, .v2 = 0.5 }));
+    if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
+        return error.SkipZigTest;
+    try expectOk(c_assert_PD(.{ .v1 = null, .v2 = 0.5 }));
 }
 test "PD: Zig returns to C" {
     try expectOk(c_assert_ret_PD());
 }
 test "PD: C passes to Zig" {
-    try expectFailX86(c_send_PD());
+    if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
+        return error.SkipZigTest;
+    try expectOk(c_send_PD());
 }
 test "PD: C returns to Zig" {
     try expectEqual(c_ret_PD(), .{ .v1 = null, .v2 = 0.5 });

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -643,6 +643,13 @@ test "C ABI structs of floats as multiple parameters" {
     c_multiple_struct_floats(r1, r2);
 }
 
+const C_C_D = extern struct { v1: u8, v2: u8, v3: f64 };
+extern fn c_C_C_D(lv: C_C_D) c_int;
+
+test "C_C_D" {
+    try expect(c_C_C_D(.{ .v1 = 88, .v2 = 39, .v3 = -2.125 }) == 0);
+}
+
 export fn zig_ret_bool() bool {
     return true;
 }

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -852,18 +852,22 @@ test "DC: Zig passes to C" {
     if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     try expectOk(c_assert_DC(.{ .v1 = -0.25, .v2 = 15 }));
 }
 test "DC: Zig returns to C" {
+    if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     try expectOk(c_assert_ret_DC());
 }
 test "DC: C passes to Zig" {
     if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows)
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     try expectOk(c_send_DC());
 }
 test "DC: C returns to Zig" {
+    if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     try expectEqual(c_ret_DC(), .{ .v1 = -0.25, .v2 = 15 });
 }
 

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -1,8 +1,10 @@
-/// Tests for the C ABI.
-/// Those tests are passing back and forth struct and values across C ABI
-/// by combining Zig code here and it's mirror in cfunc.c
-/// To run the tests on a specific architecture:
-/// zig test -fno-stage1 -lc main.zig cfuncs.c -target mips-linux --test-cmd qemu-mips --test-cmd-bin
+//! Tests for the C ABI.
+//! Those tests are passing back and forth struct and values across C ABI
+//! by combining Zig code here and its mirror in cfunc.c
+//! To run all the tests on the tier 1 architecture you can use:
+//! zig build test-c-abi -fqemu
+//! To run the tests on a specific architecture:
+//! zig test -fno-stage1 -lc main.zig cfuncs.c -target mips-linux --test-cmd qemu-mips --test-cmd-bin
 const std = @import("std");
 const builtin = @import("builtin");
 const print = std.debug.print;

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const print = std.debug.print;
 const expect = std.testing.expect;
+const expectEqual = std.testing.expectEqual;
 const has_i128 = builtin.cpu.arch != .x86 and !builtin.cpu.arch.isARM() and
     !builtin.cpu.arch.isMIPS() and !builtin.cpu.arch.isPPC();
 
@@ -918,6 +919,7 @@ test "PD: Zig passes to C" {
     try expectOk(c_assert_PD(.{ .v1 = null, .v2 = 0.5 }));
 }
 test "PD: Zig returns to C" {
+    if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
     try expectOk(c_assert_ret_PD());
 }
 test "PD: C passes to Zig" {
@@ -926,6 +928,7 @@ test "PD: C passes to Zig" {
     try expectOk(c_send_PD());
 }
 test "PD: C returns to Zig" {
+    if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
     try expectEqual(c_ret_PD(), .{ .v1 = null, .v2 = 0.5 });
 }
 pub extern fn c_assert_PD(lv: PD) c_int;

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -892,6 +892,7 @@ test "CFF: C passes to Zig" {
     try expectOk(c_send_CFF());
 }
 test "CFF: C returns to Zig" {
+    if (builtin.target.cpu.arch == .aarch64) return error.SkipZigTest;
     try expectEqual(c_ret_CFF(), .{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 });
 }
 pub extern fn c_assert_CFF(lv: CFF) c_int;

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -854,11 +854,13 @@ test "DC: Zig passes to C" {
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectOk(c_assert_DC(.{ .v1 = -0.25, .v2 = 15 }));
 }
 test "DC: Zig returns to C" {
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectOk(c_assert_ret_DC());
 }
 test "DC: C passes to Zig" {
@@ -867,11 +869,13 @@ test "DC: C passes to Zig" {
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectOk(c_send_DC());
 }
 test "DC: C returns to Zig" {
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectEqual(c_ret_DC(), .{ .v1 = -0.25, .v2 = 15 });
 }
 
@@ -898,11 +902,13 @@ test "CFF: Zig passes to C" {
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectOk(c_assert_CFF(.{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 }));
 }
 test "CFF: Zig returns to C" {
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectOk(c_assert_ret_CFF());
 }
 test "CFF: C passes to Zig" {
@@ -910,6 +916,7 @@ test "CFF: C passes to Zig" {
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
 
     try expectOk(c_send_CFF());
 }
@@ -918,6 +925,7 @@ test "CFF: C returns to Zig" {
     if (builtin.target.cpu.arch == .aarch64) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectEqual(c_ret_CFF(), .{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 });
 }
 pub extern fn c_assert_CFF(lv: CFF) c_int;
@@ -944,11 +952,13 @@ test "PD: Zig passes to C" {
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectOk(c_assert_PD(.{ .v1 = null, .v2 = 0.5 }));
 }
 test "PD: Zig returns to C" {
     if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectOk(c_assert_ret_PD());
 }
 test "PD: C passes to Zig" {
@@ -956,11 +966,13 @@ test "PD: C passes to Zig" {
         return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectOk(c_send_PD());
 }
 test "PD: C returns to Zig" {
     if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectEqual(c_ret_PD(), .{ .v1 = null, .v2 = 0.5 });
 }
 pub extern fn c_assert_PD(lv: PD) c_int;


### PR DESCRIPTION
I think I found a failing C abi test for Zig.

I'm not using the latest build, and I'd like my approach to be confirmed first.

But if it holds, I can share a hundred of those from https://github.com/gwenzek/llvm-test-suite/

@topolarity which expressed interest for this area of work.