### PR TITLE
stage2: Ensure f128 alignment matches c_longdouble alignment

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -2919,7 +2919,10 @@ pub const Type = extern union {
                     return AbiAlignmentAdvanced{ .scalar = abiAlignment(u80_ty, target) };
                 },
             },
-            .f128 => return AbiAlignmentAdvanced{ .scalar = 16 },
+            .f128 => switch (CType.longdouble.sizeInBits(target)) {
+                128 => return AbiAlignmentAdvanced{ .scalar = CType.longdouble.alignment(target) },
+                else => return AbiAlignmentAdvanced{ .scalar = 16 },
+            },
 
             // TODO revisit this when we have the concept of the error tag type
             .anyerror_void_error_union,


### PR DESCRIPTION
On platforms where `c_longdouble` is 128-bits, we probably want `f128` and `c_longdouble` to match.

I intended to make this change as part of #13257, but missed this piece.

Supersedes #13392.