### PR TITLE
llvm: mangle extern function names for Wasm target

### DIFF
--- a/test/link.zig
+++ b/test/link.zig
@@ -48,6 +48,11 @@ fn addWasmCases(cases: *tests.StandaloneContext) void {
         .use_emulation = true,
     });
 
+    cases.addBuildFile("test/link/wasm/extern-mangle/build.zig", .{
+        .build_modes = true,
+        .requires_stage2 = true,
+    });
+
     cases.addBuildFile("test/link/wasm/infer-features/build.zig", .{
         .requires_stage2 = true,
     });

--- a/test/link/wasm/extern-mangle/a.zig
+++ b/test/link/wasm/extern-mangle/a.zig
@@ -1,0 +1,1 @@
+pub extern "a" fn hello() i32;

--- a/test/link/wasm/extern-mangle/b.zig
+++ b/test/link/wasm/extern-mangle/b.zig
@@ -1,0 +1,1 @@
+pub extern "b" fn hello() i32;

--- a/test/link/wasm/extern-mangle/build.zig
+++ b/test/link/wasm/extern-mangle/build.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    const test_step = b.step("test", "Test");
+    test_step.dependOn(b.getInstallStep());
+
+    const lib = b.addSharedLibrary("lib", "lib.zig", .unversioned);
+    lib.setBuildMode(mode);
+    lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    lib.install();
+
+    const check_lib = lib.checkObject(.wasm);
+    check_lib.checkStart("Section import");
+    check_lib.checkNext("entries 2"); // a.hello & b.hello
+    check_lib.checkNext("module a");
+    check_lib.checkNext("name hello");
+    check_lib.checkNext("module b");
+    check_lib.checkNext("name hello");
+
+    test_step.dependOn(&check_lib.step);
+}

--- a/test/link/wasm/extern-mangle/lib.zig
+++ b/test/link/wasm/extern-mangle/lib.zig
@@ -1,0 +1,6 @@
+const a = @import("a.zig").hello;
+const b = @import("b.zig").hello;
+export fn foo() void {
+    _ = a();
+    _ = b();
+}


### PR DESCRIPTION
When Wasm extern functions contain the same name but have a different module name such as `extern "a"` vs `extern "b"` LLVM backend will currently resolve the two functions to the same symbol. By mangling the name of the symbol, we ensure the functions are resolved separately. We mangle the name by applying `<name>|<module>` where `module` is also known as the library name.

Closes #12880 

Sorry, this wasn't part of the 0.10.0 release, but this should at least make it available in 0.10.1