### PR TITLE
cbe: enough fixes to bootstrap a compiler with a working c backend

### DIFF
--- a/lib/include/zig.h
+++ b/lib/include/zig.h
@@ -279,24 +279,21 @@ zig_extern void *memset (void *, int, zig_usize);
     static inline zig_##Type zig_##operation##_##Type(zig_##Type lhs, zig_##RhsType rhs) { \
         return lhs operator rhs; \
     }
-#define zig_int_operators(w) \
-    zig_int_operator(u##w, u##w,       and,  &) \
-    zig_int_operator(i##w, i##w,       and,  &) \
-    zig_int_operator(u##w, u##w,        or,  |) \
-    zig_int_operator(i##w, i##w,        or,  |) \
-    zig_int_operator(u##w, u##w,       xor,  ^) \
-    zig_int_operator(i##w, i##w,       xor,  ^) \
-    zig_int_operator(u##w, u8,         shl, <<) \
-    zig_int_operator(i##w, u8,         shl, <<) \
-    zig_int_operator(u##w, u8,         shr, >>) \
-    zig_int_operator(u##w, u##w, div_floor,  /) \
-    zig_int_operator(u##w, u##w,       mod,  %)
-zig_int_operators(8)
-zig_int_operators(16)
-zig_int_operators(32)
-zig_int_operators(64)
-
+#define zig_int_basic_operator(Type, operation, operator) \
+    zig_int_operator(Type, Type, operation, operator)
+#define zig_int_shift_operator(Type, operation, operator) \
+    zig_int_operator(Type,   u8, operation, operator)
 #define zig_int_helpers(w) \
+    zig_int_basic_operator(u##w, and,  &) \
+    zig_int_basic_operator(i##w, and,  &) \
+    zig_int_basic_operator(u##w,  or,  |) \
+    zig_int_basic_operator(i##w,  or,  |) \
+    zig_int_basic_operator(u##w, xor,  ^) \
+    zig_int_basic_operator(i##w, xor,  ^) \
+    zig_int_shift_operator(u##w, shl, <<) \
+    zig_int_shift_operator(i##w, shl, <<) \
+    zig_int_shift_operator(u##w, shr, >>) \
+\
     static inline zig_i##w zig_shr_i##w(zig_i##w lhs, zig_u8 rhs) { \
         zig_i##w sign_mask = lhs < zig_as_i##w(0) ? -zig_as_i##w(1) : zig_as_i##w(0); \
         return ((lhs ^ sign_mask) >> rhs) ^ sign_mask; \
@@ -320,9 +317,13 @@ zig_int_operators(64)
             ? val | zig_minInt(i##w, bits) : val & zig_maxInt(i##w, bits); \
     } \
 \
+    zig_int_basic_operator(u##w, div_floor, /) \
+\
     static inline zig_i##w zig_div_floor_i##w(zig_i##w lhs, zig_i##w rhs) { \
         return lhs / rhs - (((lhs ^ rhs) & (lhs % rhs)) < zig_as_i##w(0)); \
     } \
+\
+    zig_int_basic_operator(u##w, mod, %) \
 \
     static inline zig_i##w zig_mod_i##w(zig_i##w lhs, zig_i##w rhs) { \
         zig_i##w rem = lhs % rhs; \

--- a/lib/include/zig.h
+++ b/lib/include/zig.h
@@ -66,9 +66,9 @@
 #endif
 
 #if defined(__cplusplus)
-#define zig_extern_c extern "C"
+#define zig_extern extern "C"
 #else
-#define zig_extern_c
+#define zig_extern extern
 #endif
 
 #if zig_has_builtin(debugtrap)
@@ -265,8 +265,8 @@ typedef  int64_t zig_i64;
 #define zig_compiler_rt_abbrev_f80  xf
 #define zig_compiler_rt_abbrev_f128 tf
 
-zig_extern_c void *memcpy (void *zig_restrict, void const *zig_restrict, zig_usize);
-zig_extern_c void *memset (void *, int, zig_usize);
+zig_extern void *memcpy (void *zig_restrict, void const *zig_restrict, zig_usize);
+zig_extern void *memset (void *, int, zig_usize);
 
 /* ==================== 8/16/32/64-bit Integer Routines ===================== */
 
@@ -345,7 +345,7 @@ static inline zig_bool zig_addo_u32(zig_u32 *res, zig_u32 lhs, zig_u32 rhs, zig_
 #endif
 }
 
-zig_extern_c zig_i32  __addosi4(zig_i32 lhs, zig_i32 rhs, zig_c_int *overflow);
+zig_extern zig_i32  __addosi4(zig_i32 lhs, zig_i32 rhs, zig_c_int *overflow);
 static inline zig_bool zig_addo_i32(zig_i32 *res, zig_i32 lhs, zig_i32 rhs, zig_u8 bits) {
 #if zig_has_builtin(add_overflow)
     zig_i32 full_res;
@@ -371,7 +371,7 @@ static inline zig_bool zig_addo_u64(zig_u64 *res, zig_u64 lhs, zig_u64 rhs, zig_
 #endif
 }
 
-zig_extern_c zig_i64  __addodi4(zig_i64 lhs, zig_i64 rhs, zig_c_int *overflow);
+zig_extern zig_i64  __addodi4(zig_i64 lhs, zig_i64 rhs, zig_c_int *overflow);
 static inline zig_bool zig_addo_i64(zig_i64 *res, zig_i64 lhs, zig_i64 rhs, zig_u8 bits) {
 #if zig_has_builtin(add_overflow)
     zig_i64 full_res;
@@ -441,7 +441,7 @@ static inline zig_bool zig_subo_u32(zig_u32 *res, zig_u32 lhs, zig_u32 rhs, zig_
 #endif
 }
 
-zig_extern_c zig_i32  __subosi4(zig_i32 lhs, zig_i32 rhs, zig_c_int *overflow);
+zig_extern zig_i32  __subosi4(zig_i32 lhs, zig_i32 rhs, zig_c_int *overflow);
 static inline zig_bool zig_subo_i32(zig_i32 *res, zig_i32 lhs, zig_i32 rhs, zig_u8 bits) {
 #if zig_has_builtin(sub_overflow)
     zig_i32 full_res;
@@ -467,7 +467,7 @@ static inline zig_bool zig_subo_u64(zig_u64 *res, zig_u64 lhs, zig_u64 rhs, zig_
 #endif
 }
 
-zig_extern_c zig_i64  __subodi4(zig_i64 lhs, zig_i64 rhs, zig_c_int *overflow);
+zig_extern zig_i64  __subodi4(zig_i64 lhs, zig_i64 rhs, zig_c_int *overflow);
 static inline zig_bool zig_subo_i64(zig_i64 *res, zig_i64 lhs, zig_i64 rhs, zig_u8 bits) {
 #if zig_has_builtin(sub_overflow)
     zig_i64 full_res;
@@ -537,7 +537,7 @@ static inline zig_bool zig_mulo_u32(zig_u32 *res, zig_u32 lhs, zig_u32 rhs, zig_
 #endif
 }
 
-zig_extern_c zig_i32  __mulosi4(zig_i32 lhs, zig_i32 rhs, zig_c_int *overflow);
+zig_extern zig_i32  __mulosi4(zig_i32 lhs, zig_i32 rhs, zig_c_int *overflow);
 static inline zig_bool zig_mulo_i32(zig_i32 *res, zig_i32 lhs, zig_i32 rhs, zig_u8 bits) {
 #if zig_has_builtin(mul_overflow)
     zig_i32 full_res;
@@ -563,7 +563,7 @@ static inline zig_bool zig_mulo_u64(zig_u64 *res, zig_u64 lhs, zig_u64 rhs, zig_
 #endif
 }
 
-zig_extern_c zig_i64  __mulodi4(zig_i64 lhs, zig_i64 rhs, zig_c_int *overflow);
+zig_extern zig_i64  __mulodi4(zig_i64 lhs, zig_i64 rhs, zig_c_int *overflow);
 static inline zig_bool zig_mulo_i64(zig_i64 *res, zig_i64 lhs, zig_i64 rhs, zig_u8 bits) {
 #if zig_has_builtin(mul_overflow)
     zig_i64 full_res;
@@ -1210,7 +1210,7 @@ static inline zig_bool zig_addo_u128(zig_u128 *res, zig_u128 lhs, zig_u128 rhs, 
 #endif
 }
 
-zig_extern_c zig_i128  __addoti4(zig_i128 lhs, zig_i128 rhs, zig_c_int *overflow);
+zig_extern zig_i128  __addoti4(zig_i128 lhs, zig_i128 rhs, zig_c_int *overflow);
 static inline zig_bool zig_addo_i128(zig_i128 *res, zig_i128 lhs, zig_i128 rhs, zig_u8 bits) {
 #if zig_has_builtin(add_overflow)
     zig_i128 full_res;
@@ -1236,7 +1236,7 @@ static inline zig_bool zig_subo_u128(zig_u128 *res, zig_u128 lhs, zig_u128 rhs, 
 #endif
 }
 
-zig_extern_c zig_i128  __suboti4(zig_i128 lhs, zig_i128 rhs, zig_c_int *overflow);
+zig_extern zig_i128  __suboti4(zig_i128 lhs, zig_i128 rhs, zig_c_int *overflow);
 static inline zig_bool zig_subo_i128(zig_i128 *res, zig_i128 lhs, zig_i128 rhs, zig_u8 bits) {
 #if zig_has_builtin(sub_overflow)
     zig_i128 full_res;
@@ -1262,7 +1262,7 @@ static inline zig_bool zig_mulo_u128(zig_u128 *res, zig_u128 lhs, zig_u128 rhs, 
 #endif
 }
 
-zig_extern_c zig_i128  __muloti4(zig_i128 lhs, zig_i128 rhs, zig_c_int *overflow);
+zig_extern zig_i128  __muloti4(zig_i128 lhs, zig_i128 rhs, zig_c_int *overflow);
 static inline zig_bool zig_mulo_i128(zig_i128 *res, zig_i128 lhs, zig_i128 rhs, zig_u8 bits) {
 #if zig_has_builtin(mul_overflow)
     zig_i128 full_res;
@@ -1552,7 +1552,7 @@ typedef long double zig_c_longdouble;
 #define zig_as_special_c_longdouble(sign, name, arg, repr) sign __builtin_##name##l(arg)
 
 #define zig_convert_builtin(ResType, operation, ArgType, version) \
-    zig_extern_c zig_##ResType zig_expand_concat(zig_expand_concat(zig_expand_concat(__##operation, \
+    zig_extern zig_##ResType zig_expand_concat(zig_expand_concat(zig_expand_concat(__##operation, \
         zig_compiler_rt_abbrev_##ArgType), zig_compiler_rt_abbrev_##ResType), version)(zig_##ArgType);
 zig_convert_builtin(f16,  trunc,  f32,  2)
 zig_convert_builtin(f16,  trunc,  f64,  2)
@@ -1585,7 +1585,7 @@ zig_convert_builtin(f128, extend, f80,  2)
     }
 
 #define zig_float_less_builtin_0(Type, operation) \
-    zig_extern_c zig_i8 zig_expand_concat(zig_expand_concat(__##operation, \
+    zig_extern zig_i8 zig_expand_concat(zig_expand_concat(__##operation, \
         zig_compiler_rt_abbrev_##Type), 2)(zig_##Type, zig_##Type); \
     static inline zig_i8 zig_##operation##_##Type(zig_##Type lhs, zig_##Type rhs) { \
         return (zig_i8)zig_expand_concat(zig_expand_concat(__##operation, zig_compiler_rt_abbrev_##Type), 2)(lhs, rhs); \
@@ -1603,7 +1603,7 @@ zig_convert_builtin(f128, extend, f80,  2)
     }
 
 #define zig_float_binary_builtin_0(Type, operation, operator) \
-    zig_extern_c zig_##Type zig_expand_concat(zig_expand_concat(__##operation, \
+    zig_extern zig_##Type zig_expand_concat(zig_expand_concat(__##operation, \
         zig_compiler_rt_abbrev_##Type), 3)(zig_##Type, zig_##Type); \
     static inline zig_##Type zig_##operation##_##Type(zig_##Type lhs, zig_##Type rhs) { \
         return zig_expand_concat(zig_expand_concat(__##operation, zig_compiler_rt_abbrev_##Type), 3)(lhs, rhs); \
@@ -1638,24 +1638,24 @@ zig_convert_builtin(f128, extend, f80,  2)
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_##Type)(Type, sub, -) \
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_##Type)(Type, mul, *) \
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_##Type)(Type, div, /) \
-    zig_extern_c zig_##Type zig_libc_name_##Type(sqrt)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(sin)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(cos)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(tan)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(exp)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(exp2)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(log)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(log2)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(log10)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(fabs)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(floor)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(ceil)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(round)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(trunc)(zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(fmod)(zig_##Type, zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(fmin)(zig_##Type, zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(fmax)(zig_##Type, zig_##Type); \
-    zig_extern_c zig_##Type zig_libc_name_##Type(fma)(zig_##Type, zig_##Type, zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(sqrt)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(sin)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(cos)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(tan)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(exp)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(exp2)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(log)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(log2)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(log10)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(fabs)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(floor)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(ceil)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(round)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(trunc)(zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(fmod)(zig_##Type, zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(fmin)(zig_##Type, zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(fmax)(zig_##Type, zig_##Type); \
+    zig_extern zig_##Type zig_libc_name_##Type(fma)(zig_##Type, zig_##Type, zig_##Type); \
 \
     static inline zig_##Type zig_div_trunc_##Type(zig_##Type lhs, zig_##Type rhs) { \
         return zig_libc_name_##Type(trunc)(zig_div_##Type(lhs, rhs)); \

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -2434,7 +2434,7 @@ fn genBody(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail, OutO
             .bool_or,  .bit_or  => try airBinOp(f, inst, "|",  "or",  .None),
             .xor                => try airBinOp(f, inst, "^",  "xor", .None),
             .shr, .shr_exact    => try airBinBuiltinCall(f, inst, "shr", .None),
-            .shl,               => try airBinBuiltinCall(f, inst, "shl", .None),
+            .shl,               => try airBinBuiltinCall(f, inst, "shlw", .Bits),
             .shl_exact          => try airBinOp(f, inst, "<<", "shl", .None),
             .not                => try airNot  (f, inst),
 

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -435,6 +435,7 @@ test "global union with single field is correctly initialized" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
 
     glbl = Foo1{
         .f = @typeInfo(Foo1).Union.fields[0].field_type{ .x = 123 },

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -435,7 +435,6 @@ test "global union with single field is correctly initialized" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
 
     glbl = Foo1{
         .f = @typeInfo(Foo1).Union.fields[0].field_type{ .x = 123 },

--- a/test/stage2/cbe.zig
+++ b/test/stage2/cbe.zig
@@ -951,7 +951,7 @@ pub fn addCases(ctx: *TestContext) !void {
     ctx.h("simple header", linux_x64,
         \\export fn start() void{}
     ,
-        \\zig_extern_c zig_void start(zig_void);
+        \\zig_extern zig_void start(zig_void);
         \\
     );
     ctx.h("header with single param function", linux_x64,
@@ -959,7 +959,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    _ = a;
         \\}
     ,
-        \\zig_extern_c zig_void start(zig_u8 const a0);
+        \\zig_extern zig_void start(zig_u8 const a0);
         \\
     );
     ctx.h("header with multiple param function", linux_x64,
@@ -967,25 +967,25 @@ pub fn addCases(ctx: *TestContext) !void {
         \\  _ = a; _ = b; _ = c;
         \\}
     ,
-        \\zig_extern_c zig_void start(zig_u8 const a0, zig_u8 const a1, zig_u8 const a2);
+        \\zig_extern zig_void start(zig_u8 const a0, zig_u8 const a1, zig_u8 const a2);
         \\
     );
     ctx.h("header with u32 param function", linux_x64,
         \\export fn start(a: u32) void{ _ = a; }
     ,
-        \\zig_extern_c zig_void start(zig_u32 const a0);
+        \\zig_extern zig_void start(zig_u32 const a0);
         \\
     );
     ctx.h("header with usize param function", linux_x64,
         \\export fn start(a: usize) void{ _ = a; }
     ,
-        \\zig_extern_c zig_void start(zig_usize const a0);
+        \\zig_extern zig_void start(zig_usize const a0);
         \\
     );
     ctx.h("header with bool param function", linux_x64,
         \\export fn start(a: bool) void{_ = a;}
     ,
-        \\zig_extern_c zig_void start(zig_bool const a0);
+        \\zig_extern zig_void start(zig_bool const a0);
         \\
     );
     ctx.h("header with noreturn function", linux_x64,
@@ -993,7 +993,7 @@ pub fn addCases(ctx: *TestContext) !void {
         \\    unreachable;
         \\}
     ,
-        \\zig_extern_c zig_noreturn start(zig_void);
+        \\zig_extern zig_noreturn start(zig_void);
         \\
     );
     ctx.h("header with multiple functions", linux_x64,
@@ -1001,15 +1001,15 @@ pub fn addCases(ctx: *TestContext) !void {
         \\export fn b() void{}
         \\export fn c() void{}
     ,
-        \\zig_extern_c zig_void a(zig_void);
-        \\zig_extern_c zig_void b(zig_void);
-        \\zig_extern_c zig_void c(zig_void);
+        \\zig_extern zig_void a(zig_void);
+        \\zig_extern zig_void b(zig_void);
+        \\zig_extern zig_void c(zig_void);
         \\
     );
     ctx.h("header with multiple includes", linux_x64,
         \\export fn start(a: u32, b: usize) void{ _ = a; _ = b; }
     ,
-        \\zig_extern_c zig_void start(zig_u32 const a0, zig_usize const a1);
+        \\zig_extern zig_void start(zig_u32 const a0, zig_usize const a1);
         \\
     );
 }


### PR DESCRIPTION
The bootstrapping steps I followed:
```sh
mkdir stage1
cp lib/include/zig.h stage1
zig build -p only-c -Donly-c -Dno-lib
cat only-c/bin/zig.c > stage1/zig1.c
# comment out first and last groups of imports from comptime block in lib/compiler_rt.zig
zig build-obj -ofmt=c lib/compiler_rt.zig -femit-bin=stage1/compiler_rt.c
clang -Istage1 -fbracket-depth=512 stage1/compiler_rt.c stage1/zig1.c -o stage1/zig1 -Wl,-z,stack-size=0x10000000
cat > stage1/options.zig <<DONE
pub const mem_leak_frames: u32 = 4;
pub const skip_non_native: bool = false;
pub const have_llvm: bool = false;
pub const llvm_has_m68k: bool = false;
pub const llvm_has_csky: bool = false;
pub const llvm_has_arc: bool = false;
pub const force_gpa: bool = false;
pub const only_c: bool = false;
pub const version: [:0]const u8 = "0.11.0-dev.stage1";
pub const semver: @import("std").SemanticVersion = .{
    .major = 0,
    .minor = 11,
    .patch = 0,
    .pre = "dev",
    .build = "stage1",
};
pub const enable_logging: bool = false;
pub const enable_link_snapshots: bool = false;
pub const enable_tracy: bool = false;
pub const enable_tracy_callstack: bool = false;
pub const enable_tracy_allocation: bool = false;
pub const value_tracing: bool = false;
pub const have_stage1: bool = false;
DONE
stage1/zig1 build-obj -lc src/main.zig -ofmt=c --name zig2 --zig-lib-dir lib --pkg-begin build_options stage1/options.zig --pkg-end
mv zig2.c stage1
clang -Istage1 -fbracket-depth=512 stage1/compiler_rt.c stage1/zig2.c -o stage1/zig2 -Wl,-z,stack-size=0x10000000
stage1/zig2 build-obj -lc src/main.zig -ofmt=c --name zig3 --zig-lib-dir lib --pkg-begin build_options stage1/options.zig --pkg-end
mv zig3.c stage1
clang -Istage1 -fbracket-depth=512 stage1/compiler_rt.c stage1/zig3.c -o stage1/zig3 -Wl,-z,stack-size=0x10000000
```
This produces functionally and sizewise but not bytewise identical zig2.c/zig3.c and zig2/zig3, which means that the bootstrapped C backend is working.  Crashes when loading from cache and when generating Dwarf debug info.