### PR TITLE
Sema: make `InferredErrorSet` deterministic

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1578,7 +1578,7 @@ pub const Fn = struct {
         errors: ErrorSet.NameMap = .{},
 
         /// Other inferred error sets which this inferred error set should include.
-        inferred_error_sets: std.AutoHashMapUnmanaged(*InferredErrorSet, void) = .{},
+        inferred_error_sets: std.AutoArrayHashMapUnmanaged(*InferredErrorSet, void) = .{},
 
         /// Whether the function returned anyerror. This is true if either of
         /// the dependent functions returns anyerror.

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -27509,9 +27509,7 @@ fn analyzeIsNonErrComptimeOnly(
                 // Try to avoid resolving inferred error set if possible.
                 if (ies.errors.count() != 0) break :blk;
                 if (ies.is_anyerror) break :blk;
-                var it = ies.inferred_error_sets.keyIterator();
-                while (it.next()) |other_error_set_ptr| {
-                    const other_ies: *Module.Fn.InferredErrorSet = other_error_set_ptr.*;
+                for (ies.inferred_error_sets.keys()) |other_ies| {
                     if (ies == other_ies) continue;
                     try sema.resolveInferredErrorSet(block, src, other_ies);
                     if (other_ies.is_anyerror) {
@@ -29432,9 +29430,7 @@ fn resolveInferredErrorSet(
 
     ies.is_resolved = true;
 
-    var it = ies.inferred_error_sets.keyIterator();
-    while (it.next()) |other_error_set_ptr| {
-        const other_ies: *Module.Fn.InferredErrorSet = other_error_set_ptr.*;
+    for (ies.inferred_error_sets.keys()) |other_ies| {
         if (ies == other_ies) continue;
         try sema.resolveInferredErrorSet(block, src, other_ies);
 


### PR DESCRIPTION
Empirically, this `AutoHashMapUnmanaged` &rightarrow; `AutoArrayHashMapUnmanaged` change fixes all non-determinism in `ReleaseFast` build artifacts.

```sh
  1732720 4927ca68d53191842ffa265204c1782b1dcb18aa80955faa04342464b17371aeb63594e0316a59d0cafd23cba9f8f948a9c5834d9006cc79d8dd2e3393b436b8  build/zig1
 57433840 9d88d1b4c33864f668a6497b8c0655d64fd06a6c80cd055a8d699f4bc2912914c140a14285182e726d9af49d296bd26971f63ffb005ac5bd398be7a5ba1cbf6b  build/zig2
 11641624 b00c4af28c71d1e8b757e6e0dab3f35173f26db62c6916ede91364d00507b8abf1ce5d18a88e3c9dccffc2133f41d641fa4feba6ef832a76bb95997e63298e20  build/stage3/bin/zig
 61163904 063d7dde32a9f0f141cff60359039fedc75bcee52b16507c91656e43bff774c0e028c564302ae73fa9bedf4c20cc792a2d91235e980a5d073b49b28b2580be18  det1/bin/zig
 61163904 063d7dde32a9f0f141cff60359039fedc75bcee52b16507c91656e43bff774c0e028c564302ae73fa9bedf4c20cc792a2d91235e980a5d073b49b28b2580be18  det2/bin/zig
 61163904 063d7dde32a9f0f141cff60359039fedc75bcee52b16507c91656e43bff774c0e028c564302ae73fa9bedf4c20cc792a2d91235e980a5d073b49b28b2580be18  det3/bin/zig
```

Closes #12183