### PR TITLE
Sema: resolve lazy align in zirReify for union fields

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -18232,7 +18232,7 @@ fn zirReify(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstData, in
                 var buffer: Value.ToTypeBuffer = undefined;
                 gop.value_ptr.* = .{
                     .ty = try field_type_val.toType(&buffer).copy(new_decl_arena_allocator),
-                    .abi_align = @intCast(u32, alignment_val.toUnsignedInt(target)),
+                    .abi_align = @intCast(u32, (try alignment_val.getUnsignedIntAdvanced(target, sema.kit(block, src))).?),
                 };
             }
 

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -111,6 +111,7 @@ test {
     _ = @import("behavior/bugs/13159.zig");
     _ = @import("behavior/bugs/13171.zig");
     _ = @import("behavior/bugs/13285.zig");
+    _ = @import("behavior/bugs/13435.zig");
     _ = @import("behavior/byteswap.zig");
     _ = @import("behavior/byval_arg_var.zig");
     _ = @import("behavior/call.zig");

--- a/test/behavior/bugs/13435.zig
+++ b/test/behavior/bugs/13435.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+
+fn CreateUnion(comptime T: type) type {
+    return @Type(.{
+        .Union = .{
+            .layout = .Auto,
+            .tag_type = null,
+            .fields = &[_]std.builtin.Type.UnionField{
+                .{
+                    .name = "field",
+                    .field_type = T,
+                    .alignment = @alignOf(T),
+                },
+            },
+            .decls = &[_]std.builtin.Type.Declaration{},
+        },
+    });
+}
+
+test {
+    _ = CreateUnion(struct {});
+}


### PR DESCRIPTION
This commit mirrors 930f904aaa7d591d86a8c3216526711be95fcc17. This is my first time contributing to the stage2 compiler, so let me know if I'm misunderstanding anything.

Closes #13435