### PR TITLE
ReadLine & Peek

### DIFF
--- a/lib/std/compress/deflate/compressor_test.zig
+++ b/lib/std/compress/deflate/compressor_test.zig
@@ -188,7 +188,7 @@ test "very long sparse chunk" {
         const Self = @This();
         const Error = error{};
 
-        pub const Reader = io.Reader(*Self, Error, read);
+        pub const Reader = io.Reader(*Self, Error, read, peek);
 
         pub fn reader(self: *Self) Reader {
             return .{ .context = self };
@@ -214,6 +214,28 @@ test "very long sparse chunk" {
                 }
             }
             s.cur = cur;
+            return n;
+        }
+
+        fn peek(s: *Self, b: []u8) Error!usize {
+            var n: usize = 0; // amount read
+
+            if (s.cur >= s.l) {
+                return 0;
+            }
+            n = b.len;
+            var cur = s.cur + n;
+            if (cur > s.l) {
+                n -= cur - s.l;
+                cur = s.l;
+            }
+            for (b[0..n]) |_, i| {
+                if (s.cur + i >= s.l -| (1 << 16)) {
+                    b[i] = 1;
+                } else {
+                    b[i] = 0;
+                }
+            }
             return n;
         }
     };

--- a/lib/std/compress/deflate/decompressor.zig
+++ b/lib/std/compress/deflate/decompressor.zig
@@ -306,7 +306,7 @@ pub fn Decompressor(comptime ReaderType: type) type {
             error{EndOfStream} ||
             InflateError ||
             Allocator.Error;
-        pub const Reader = io.Reader(*Self, Error, read);
+        pub const Reader = io.Reader(*Self, Error, read, null);
 
         allocator: Allocator,
 

--- a/lib/std/compress/zlib.zig
+++ b/lib/std/compress/zlib.zig
@@ -15,7 +15,7 @@ pub fn ZlibStream(comptime ReaderType: type) type {
         pub const Error = ReaderType.Error ||
             deflate.Decompressor(ReaderType).Error ||
             error{ WrongChecksum, Unsupported };
-        pub const Reader = io.Reader(*Self, Error, read);
+        pub const Reader = io.Reader(*Self, Error, read, null);
 
         allocator: mem.Allocator,
         inflater: deflate.Decompressor(ReaderType),

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -39,7 +39,7 @@ pub fn LinearFifo(
         count: usize,
 
         const Self = @This();
-        pub const Reader = std.io.Reader(*Self, error{}, readFn);
+        pub const Reader = std.io.Reader(*Self, error{}, readFn, peekFn);
         pub const Writer = std.io.Writer(*Self, error{OutOfMemory}, appendWrite);
 
         // Type of Self argument for slice operations.
@@ -225,6 +225,10 @@ pub fn LinearFifo(
         /// The purpose of this function existing is to match `std.io.Reader` API.
         fn readFn(self: *Self, dest: []u8) error{}!usize {
             return self.read(dest);
+        }
+
+        fn peekFn(self: *Self, dest: []u8) error{}!usize {
+            return self.peek(dest);
         }
 
         pub fn reader(self: *Self) Reader {

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -204,7 +204,7 @@ pub fn LinearFifo(
             self.discard(1);
             return c;
         }
-        
+
         /// Peek the next item from the fifo
         pub fn peekItemNext(self: *Self) ?T {
             if (self.count == 0) return null;
@@ -228,11 +228,11 @@ pub fn LinearFifo(
 
             return dst.len - dst_left.len;
         }
-        
+
         pub fn peek(self: *Self, dst: []T) usize {
             var dst_left = dst;
 
-            var off : usize = 0;
+            var off: usize = 0;
             while (dst_left.len > 0) {
                 const slice = self.readableSlice(off);
                 if (slice.len == 0) break;

--- a/lib/std/io/bit_reader.zig
+++ b/lib/std/io/bit_reader.zig
@@ -14,7 +14,7 @@ pub fn BitReader(comptime endian: std.builtin.Endian, comptime ReaderType: type)
         bit_count: u3,
 
         pub const Error = ReaderType.Error;
-        pub const Reader = io.Reader(*Self, Error, read);
+        pub const Reader = io.Reader(*Self, Error, read, null);
 
         const Self = @This();
         const u8_bit_count = @bitSizeOf(u8);

--- a/lib/std/io/buffered_reader.zig
+++ b/lib/std/io/buffered_reader.zig
@@ -14,49 +14,46 @@ pub fn BufferedReader(comptime buffer_size: usize, comptime ReaderType: type) ty
         const Self = @This();
         const FifoType = std.fifo.LinearFifo(u8, std.fifo.LinearFifoBufferType{ .Static = buffer_size });
 
-        fn read(s: *Self, b: []u8) Error!usize {
-            var n: usize = 0; // amount read
-
-            if (s.cur >= s.l) {
-                return 0;
-            }
-            n = b.len;
-            var cur = s.cur + n;
-            if (cur > s.l) {
-                n -= cur - s.l;
-                cur = s.l;
-            }
-            for (b[0..n]) |_, i| {
-                if (s.cur + i >= s.l -| (1 << 16)) {
-                    b[i] = 1;
-                } else {
-                    b[i] = 0;
+        pub fn read(self: *Self, dest: []u8) Error!usize {
+            var dest_index: usize = 0;
+            while (dest_index < dest.len) {
+                const written = self.fifo.read(dest[dest_index..]);
+                if (written == 0) {
+                    // fifo empty, fill it
+                    const writable = self.fifo.writableSlice(0);
+                    assert(writable.len > 0);
+                    const n = try self.unbuffered_reader.read(writable);
+                    if (n == 0) {
+                        // reading from the unbuffered stream returned nothing
+                        // so we have nothing left to read.
+                        return dest_index;
+                    }
+                    self.fifo.update(n);
                 }
+                dest_index += written;
             }
-            s.cur = cur;
-            return n;
+            return dest.len;
         }
 
-        fn peek(s: *Self, b: []u8) Error!usize {
-            var n: usize = 0; // amount read
-
-            if (s.cur >= s.l) {
-                return 0;
-            }
-            n = b.len;
-            var cur = s.cur + n;
-            if (cur > s.l) {
-                n -= cur - s.l;
-                cur = s.l;
-            }
-            for (b[0..n]) |_, i| {
-                if (s.cur + i >= s.l -| (1 << 16)) {
-                    b[i] = 1;
-                } else {
-                    b[i] = 0;
+        fn peek(self: *Self, dest: []u8) Error!usize {
+            var dest_index: usize = 0;
+            while (dest_index < dest.len) {
+                const written = self.fifo.peek(dest[dest_index..]);
+                if (written == 0) {
+                    // fifo empty, fill it
+                    const writable = self.fifo.writableSlice(0);
+                    assert(writable.len > 0);
+                    const n = try self.unbuffered_reader.peek(writable);
+                    if (n == 0) {
+                        // reading from the unbuffered stream returned nothing
+                        // so we have nothing left to read.
+                        return dest_index;
+                    }
+                    self.fifo.update(n);
                 }
+                dest_index += written;
             }
-            return n;
+            return dest.len;
         }
 
         pub fn reader(self: *Self) Reader {
@@ -76,7 +73,7 @@ test "io.BufferedReader" {
 
         const Error = error{NoError};
         const Self = @This();
-        const Reader = io.Reader(*Self, Error, read);
+        const Reader = io.Reader(*Self, Error, read, null);
 
         fn init(str: []const u8) Self {
             return Self{

--- a/lib/std/io/counting_reader.zig
+++ b/lib/std/io/counting_reader.zig
@@ -9,11 +9,16 @@ pub fn CountingReader(comptime ReaderType: anytype) type {
         bytes_read: u64 = 0,
 
         pub const Error = ReaderType.Error;
-        pub const Reader = io.Reader(*@This(), Error, read);
+        pub const Reader = io.Reader(*@This(), Error, read, peek);
 
         pub fn read(self: *@This(), buf: []u8) Error!usize {
             const amt = try self.child_reader.read(buf);
             self.bytes_read += amt;
+            return amt;
+        }
+
+        pub fn peek(self: *@This(), buf: []u8) Error!usize {
+            const amt = try self.child_reader.read(buf);
             return amt;
         }
 

--- a/lib/std/io/fixed_buffer_stream.zig
+++ b/lib/std/io/fixed_buffer_stream.zig
@@ -17,7 +17,7 @@ pub fn FixedBufferStream(comptime Buffer: type) type {
         pub const SeekError = error{};
         pub const GetSeekPosError = error{};
 
-        pub const Reader = io.Reader(*Self, ReadError, read);
+        pub const Reader = io.Reader(*Self, ReadError, read, peek);
         pub const Writer = io.Writer(*Self, WriteError, write);
 
         pub const SeekableStream = io.SeekableStream(
@@ -50,6 +50,15 @@ pub fn FixedBufferStream(comptime Buffer: type) type {
 
             mem.copy(u8, dest[0..size], self.buffer[self.pos..end]);
             self.pos = end;
+
+            return size;
+        }
+
+        pub fn peek(self: *Self, dest: []u8) ReadError!usize {
+            const size = std.math.min(dest.len, self.buffer.len - self.pos);
+            const end = self.pos + size;
+
+            mem.copy(u8, dest[0..size], self.buffer[self.pos..end]);
 
             return size;
         }

--- a/lib/std/io/limited_reader.zig
+++ b/lib/std/io/limited_reader.zig
@@ -9,7 +9,7 @@ pub fn LimitedReader(comptime ReaderType: type) type {
         bytes_left: u64,
 
         pub const Error = ReaderType.Error;
-        pub const Reader = io.Reader(*Self, Error, read);
+        pub const Reader = io.Reader(*Self, Error, read, peek);
 
         const Self = @This();
 
@@ -17,6 +17,12 @@ pub fn LimitedReader(comptime ReaderType: type) type {
             const max_read = std.math.min(self.bytes_left, dest.len);
             const n = try self.inner_reader.read(dest[0..max_read]);
             self.bytes_left -= n;
+            return n;
+        }
+
+        pub fn peek(self: *Self, dest: []u8) Error!usize {
+            const max_read = std.math.min(self.bytes_left, dest.len);
+            const n = try self.inner_reader.read(dest[0..max_read]);
             return n;
         }
 

--- a/lib/std/io/peek_stream.zig
+++ b/lib/std/io/peek_stream.zig
@@ -15,7 +15,7 @@ pub fn PeekStream(
         fifo: FifoType,
 
         pub const Error = ReaderType.Error;
-        pub const Reader = io.Reader(*Self, Error, read);
+        pub const Reader = io.Reader(*Self, Error, read, null);
 
         const Self = @This();
         const FifoType = std.fifo.LinearFifo(u8, buffer_type);

--- a/lib/std/io/stream_source.zig
+++ b/lib/std/io/stream_source.zig
@@ -25,7 +25,7 @@ pub const StreamSource = union(enum) {
     pub const SeekError = io.FixedBufferStream([]u8).SeekError || (if (has_file) std.fs.File.SeekError else error{});
     pub const GetSeekPosError = io.FixedBufferStream([]u8).GetSeekPosError || (if (has_file) std.fs.File.GetSeekPosError else error{});
 
-    pub const Reader = io.Reader(*StreamSource, ReadError, read);
+    pub const Reader = io.Reader(*StreamSource, ReadError, read, peek);
     pub const Writer = io.Writer(*StreamSource, WriteError, write);
     pub const SeekableStream = io.SeekableStream(
         *StreamSource,
@@ -42,6 +42,14 @@ pub const StreamSource = union(enum) {
             .buffer => |*x| return x.read(dest),
             .const_buffer => |*x| return x.read(dest),
             .file => |x| if (!has_file) unreachable else return x.read(dest),
+        }
+    }
+
+    pub fn peek(self: *StreamSource, dest: []u8) ReadError!usize {
+        switch (self.*) {
+            .buffer => |*x| return x.peek(dest),
+            .const_buffer => |*x| return x.peek(dest),
+            .file => |x| if (!has_file) unreachable else return x.peek(dest),
         }
     }
 

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1636,7 +1636,7 @@ pub const Stream = struct {
     pub const ReadError = os.ReadError;
     pub const WriteError = os.WriteError;
 
-    pub const Reader = io.Reader(Stream, ReadError, read);
+    pub const Reader = io.Reader(Stream, ReadError, read, null);
     pub const Writer = io.Writer(Stream, WriteError, write);
 
     pub fn reader(self: Stream) Reader {

--- a/lib/std/os/uefi/protocols/file_protocol.zig
+++ b/lib/std/os/uefi/protocols/file_protocol.zig
@@ -24,7 +24,7 @@ pub const FileProtocol = extern struct {
     pub const WriteError = error{WriteError};
 
     pub const SeekableStream = io.SeekableStream(*const FileProtocol, SeekError, GetSeekPosError, seekTo, seekBy, getPos, getEndPos);
-    pub const Reader = io.Reader(*const FileProtocol, ReadError, readFn);
+    pub const Reader = io.Reader(*const FileProtocol, ReadError, readFn, null);
     pub const Writer = io.Writer(*const FileProtocol, WriteError, writeFn);
 
     pub fn seekableStream(self: *FileProtocol) SeekableStream {

--- a/lib/std/pdb.zig
+++ b/lib/std/pdb.zig
@@ -1092,7 +1092,7 @@ const MsfStream = struct {
         return block * self.block_size + offset;
     }
 
-    pub fn reader(self: *MsfStream) std.io.Reader(*MsfStream, Error, read) {
+    pub fn reader(self: *MsfStream) std.io.Reader(*MsfStream, Error, read, null) {
         return .{ .context = self };
     }
 };

--- a/lib/std/x/net/tcp.zig
+++ b/lib/std/x/net/tcp.zig
@@ -116,7 +116,7 @@ pub const Client = struct {
     }
 
     /// Wrap `tcp.Client` into `std.io.Reader`.
-    pub fn reader(self: Client, flags: u32) io.Reader(Client.Reader, ErrorSetOf(Client.Reader.read), Client.Reader.read) {
+    pub fn reader(self: Client, flags: u32) io.Reader(Client.Reader, ErrorSetOf(Client.Reader.read), Client.Reader.read, Client.Reader.peek) {
         return .{ .context = .{ .client = self, .flags = flags } };
     }
 

--- a/lib/std/x/net/tcp.zig
+++ b/lib/std/x/net/tcp.zig
@@ -64,6 +64,11 @@ pub const Client = struct {
         pub fn read(self: Client.Reader, buffer: []u8) !usize {
             return self.client.read(buffer, self.flags);
         }
+
+        /// Implements `peekFn` for `std.io.Reader`.
+        pub fn peek(self: Client.Reader, buffer: []u8) !usize {
+            return self.client.peek(buffer, self.flags);
+        }
     };
 
     /// Implements `std.io.Writer`.
@@ -129,6 +134,12 @@ pub const Client = struct {
     /// specified. It returns the number of bytes read into the buffer provided.
     pub fn read(self: Client, buf: []u8, flags: u32) !usize {
         return self.socket.read(buf, flags);
+    }
+
+    /// Read data from the socket into the buffer provided with a set of flags
+    /// specified. It returns the number of bytes read into the buffer provided.
+    pub fn peek(self: Client, buf: []u8, flags: u32) !usize {
+        return self.socket.peek(buf, flags);
     }
 
     /// Write a buffer of data provided to the socket with a set of flags specified.

--- a/lib/std/x/os/socket_posix.zig
+++ b/lib/std/x/os/socket_posix.zig
@@ -62,7 +62,7 @@ pub fn Mixin(comptime Socket: type) type {
         pub fn read(self: Socket, buf: []u8, flags: u32) !usize {
             return os.recv(self.fd, buf, flags);
         }
-        
+
         /// Peek data from the socket into the buffer provided with a set of flags
         /// specified. It returns the number of bytes read into the buffer provided.
         pub fn peek(self: Socket, buf: []u8, flags: u32) !usize {

--- a/lib/std/x/os/socket_posix.zig
+++ b/lib/std/x/os/socket_posix.zig
@@ -62,6 +62,12 @@ pub fn Mixin(comptime Socket: type) type {
         pub fn read(self: Socket, buf: []u8, flags: u32) !usize {
             return os.recv(self.fd, buf, flags);
         }
+        
+        /// Peek data from the socket into the buffer provided with a set of flags
+        /// specified. It returns the number of bytes read into the buffer provided.
+        pub fn peek(self: Socket, buf: []u8, flags: u32) !usize {
+            return os.recv(self.fd, buf, flags | os.MSG.PEEK);
+        }
 
         /// Write a buffer of data provided to the socket with a set of flags specified.
         /// It returns the number of bytes that are written to the socket.


### PR DESCRIPTION
I'd like to introduce a new method `readLine` and `readLineAlloc` (suggestions on a name would be appreciated) to the Reader interface. These functions help fulfill the outlined changes suggested in #6754 and #3822 for platform-agnostic line reading. These functions will treat a variety of cases of CR, LF, VT and FF as valid line terminators and consume all that happen at the end of a line. 

However... to implement these, the reader must be able to look forward and attempt to read the next character without committing to consuming that data. This is where Reader introduces an optional function on construction `peekFn`. For the most part, this change allows reading buffer data ahead of time without committing to consuming it. This was necessary for CR+LF and other edge case line termination formats. 

In addition, I then created `peek` equivalents of `readByte, readStruct, readInt, readIntBig, readIntLittle ...`

If a Reader does not have Peek defined, the peek functions `peek` `peekAll` return 0 and `peekNoEof` and functions that rely on it return `error.EndOfStream`. 
If a Reader does not have Peek defined, then the functions`readLine` and `readLineAlloc` return then upon finding one endline character.

This is just a draft for now, but I'd be willing to discuss and make changes. 

I'll be testing the new peek() functions and the readLine() alongside making sure I haven't broken test cases where peek is ignored. This will however force a change in the API for those who instantiate Reader() directly or extend upon it.

Additionally:
- [x] FIFO Queues now have `peekItemNext()` to grab the next available item 
- [x] Buffered Readers now have `peek` functionality
- [x] GZip streams have `peek` functionality
- [ ] ZLib streams have `peek` functionality
- [x] File streams have `peek` functionality
- [ ] BitReader streams have `peek` functionality
- [x] CountingReader streams have `peek` functionality
- [x] FixedBufferStream has `peek` functionality
- [x] LimitedReader streams have `peek` functionality
- [x] StreamSource have `peek` functionality enabled
- [x] x.net.tcp has `peek` functionality #7194
- [ ] Get Rid of PeekStream #4501
- [ ] UEFI Peek()

Tests:
- [x] FIFO Queue peekItemNext() test
- [ ] Buffered Reader peek() test (I think I made an error with this)
- [ ] GZip peek() test
- [ ] ZLib peek() test
- [ ] File peek() test
- [ ] BitReader peek() test
- [ ] CountingReader peek() test
- [ ] FixedBufferStream peek() test
- [ ] LimitedReader peek() test
- [ ] StreamSource peek() test
- [ ] x.net.tcp peek() test
- [ ] readLine() test
- [ ] readLineAlloc() test