### PR TITLE
macho: parse weak imports in tbd descriptors

### DIFF
--- a/src/link/tapi.zig
+++ b/src/link/tapi.zig
@@ -26,6 +26,7 @@ pub const TbdV3 = struct {
         allowable_clients: ?[]const []const u8,
         re_exports: ?[]const []const u8,
         symbols: ?[]const []const u8,
+        weak_symbols: ?[]const []const u8,
         objc_classes: ?[]const []const u8,
         objc_ivars: ?[]const []const u8,
         objc_eh_types: ?[]const []const u8,
@@ -53,6 +54,7 @@ pub const TbdV4 = struct {
     exports: ?[]const struct {
         targets: []const []const u8,
         symbols: ?[]const []const u8,
+        weak_symbols: ?[]const []const u8,
         objc_classes: ?[]const []const u8,
         objc_ivars: ?[]const []const u8,
         objc_eh_types: ?[]const []const u8,
@@ -60,6 +62,7 @@ pub const TbdV4 = struct {
     reexports: ?[]const struct {
         targets: []const []const u8,
         symbols: ?[]const []const u8,
+        weak_symbols: ?[]const []const u8,
         objc_classes: ?[]const []const u8,
         objc_ivars: ?[]const []const u8,
         objc_eh_types: ?[]const []const u8,

--- a/test/link.zig
+++ b/test/link.zig
@@ -79,6 +79,11 @@ fn addWasmCases(cases: *tests.StandaloneContext) void {
 }
 
 fn addMachOCases(cases: *tests.StandaloneContext) void {
+    cases.addBuildFile("test/link/macho/bugs/13056/build.zig", .{
+        .build_modes = true,
+        .requires_macos_sdk = true,
+    });
+
     cases.addBuildFile("test/link/macho/bugs/13457/build.zig", .{
         .build_modes = true,
     });

--- a/test/link/macho/bugs/13056/build.zig
+++ b/test/link/macho/bugs/13056/build.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    const target: std.zig.CrossTarget = .{ .os_tag = .macos };
+    const target_info = std.zig.system.NativeTargetInfo.detect(target) catch unreachable;
+    const sdk = std.zig.system.darwin.getDarwinSDK(b.allocator, target_info.target) orelse
+        @panic("macOS SDK is required to run the test");
+
+    const test_step = b.step("test", "Test the program");
+
+    const exe = b.addExecutable("test", null);
+    b.default_step.dependOn(&exe.step);
+    exe.addIncludePath(std.fs.path.join(b.allocator, &.{ sdk.path, "/usr/include" }) catch unreachable);
+    exe.addIncludePath(std.fs.path.join(b.allocator, &.{ sdk.path, "/usr/include/c++/v1" }) catch unreachable);
+    exe.addCSourceFile("test.cpp", &.{
+        "-nostdlib++",
+        "-nostdinc++",
+    });
+    exe.addObjectFile(std.fs.path.join(b.allocator, &.{ sdk.path, "/usr/lib/libc++.tbd" }) catch unreachable);
+    exe.setBuildMode(mode);
+
+    const run_cmd = exe.run();
+    run_cmd.expectStdErrEqual("x: 5\n");
+
+    test_step.dependOn(&run_cmd.step);
+}

--- a/test/link/macho/bugs/13056/test.cpp
+++ b/test/link/macho/bugs/13056/test.cpp
@@ -1,0 +1,10 @@
+// test.cpp
+#include <new>
+#include <cstdio>
+
+int main() {
+    int *x = new int;
+    *x = 5;
+    fprintf(stderr, "x: %d\n", *x);
+    delete x;
+}


### PR DESCRIPTION
However, we will treat them as standard imports rather than refs to weak imports until I investigate more how it actually works underneath.

Fixes #13056 

cc @topolarity 

```
$ cat test.cpp                                                                                             
// test.cpp
#include <new>
#include <cstdio>

int main() {
    int *x = new int;
    *x = 5;
    fprintf(stderr, "x: %d\n", *x);
    delete x;
}

$ ../../zig/build/stage3/bin/zig c++ test.cpp $(xcrun --show-sdk-path)/usr/lib/libc++.tbd -nostdlib++ -nostdinc++ -I $(xcrun --show-sdk-path)/usr/include -I $(xcrun --show-sdk-path)/usr/include/c++/v1

$ ./a.out                                                                                                                                                                                               
x: 5
```

I have also added a linker test to this effect.