### PR TITLE
Add framework paths from NIX_CFLAGS_COMPILE

### DIFF
--- a/lib/std/zig/system/NativePaths.zig
+++ b/lib/std/zig/system/NativePaths.zig
@@ -40,6 +40,12 @@ pub fn detect(allocator: Allocator, native_info: NativeTargetInfo) !NativePaths 
                     break;
                 };
                 try self.addIncludeDir(include_path);
+            } else if (mem.eql(u8, word, "-iframework")) {
+                const framework_path = it.next() orelse {
+                    try self.addWarning("Expected argument after -iframework in NIX_CFLAGS_COMPILE");
+                    break;
+                };
+                try self.addFrameworkDir(framework_path);
             } else {
                 if (mem.startsWith(u8, word, "-frandom-seed=")) {
                     continue;


### PR DESCRIPTION
On MacOS, if we're using Nix to supply the frameworks Zig should add the frameworks paths. 

Instead we currently emit warning logs (which are a bit [noisy](https://gist.github.com/MarcoPolo/b52f6f79caefd8362bcc031c5c6b82a6)). And then potentially fail to build. Users can workaround this by manually parsing the `NIX_CFLAGS_COMPILE` and adding framework paths manually (basically what this PR does), but it would be great if we did the correct thing here.