### PR TITLE
Sema: avoid breaking hash contract when instantiating generic functions

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6828,7 +6828,7 @@ fn instantiateGenericCall(
     // don't find out until after generating a monomorphed function whether the parameter
     // type ended up being a "must-be-comptime-known" type.
     var hasher = std.hash.Wyhash.init(0);
-    std.hash.autoHash(&hasher, @ptrToInt(module_fn));
+    std.hash.autoHash(&hasher, module_fn.owner_decl);
 
     const generic_args = try sema.arena.alloc(GenericCallAdapter.Arg, func_ty_info.param_types.len);
     {
@@ -6871,7 +6871,7 @@ fn instantiateGenericCall(
                     },
                     else => |e| return e,
                 };
-                arg_val.hash(arg_ty, &hasher, mod);
+                arg_val.hashUncoerced(arg_ty, &hasher, mod);
                 if (is_anytype) {
                     arg_ty.hashWithHasher(&hasher, mod);
                     generic_args[i] = .{


### PR DESCRIPTION
 * Add `tagName` to `Value` which behaves like `@tagName`.
 * Add `hashUncoerced` to `Value` as an alternative to hash when we want to produce the same hash for values that can coerce to each other.
 * Hash `owner_decl` instead of `module_fn` in `Sema.instantiateGenericCall` since `Module.Decl.Index` is not affected by ASLR like `*Module.Fn` was, and also because `GenericCallAdapter.eql` was already doing this.
 * Use `Value.hashUncoerced` in `Sema.instantiateGenericCall` because `GenericCallAdapter.eql` uses `Value.eqlAdvanced` to compare args, which ignores coersions.
 * Add revealed missing cases to `Value.eqlAdvanced`.

Without these changes, we were breaking the hash contract for `monomorphed_funcs`, and were generating different hashes for values that compared equal.  This resulted in a 0.2% chance when compiling self-hosted of producing a different output, which depended on fingerprint collisions of hashes that were affected by ASLR.  Normally, the different hashes would have resulted in equal checks being skipped, but in the case of a fingerprint collision, the truth would be revealed and the compiler's behavior would diverge.