### PR TITLE
crypto.core.aes: process 6 block in parallel instead of 8 on aarch64

### DIFF
--- a/lib/std/crypto/aes/aesni.zig
+++ b/lib/std/crypto/aes/aesni.zig
@@ -101,8 +101,8 @@ pub const Block = struct {
             &cpu.sandybridge, &cpu.ivybridge => 8,
             &cpu.haswell, &cpu.broadwell => 7,
             &cpu.cannonlake, &cpu.skylake, &cpu.skylake_avx512 => 4,
-            &cpu.icelake_client, &cpu.icelake_server => 6,
-            &cpu.znver1, &cpu.znver2 => 8,
+            &cpu.icelake_client, &cpu.icelake_server, &cpu.tigerlake, &cpu.rocketlake, &cpu.alderlake => 6,
+            &cpu.znver1, &cpu.znver2, &cpu.znver3 => 8,
             else => 8,
         };
 

--- a/lib/std/crypto/aes/armcrypto.zig
+++ b/lib/std/crypto/aes/armcrypto.zig
@@ -109,7 +109,7 @@ pub const Block = struct {
     /// Perform operations on multiple blocks in parallel.
     pub const parallel = struct {
         /// The recommended number of AES encryption/decryption to perform in parallel for the chosen implementation.
-        pub const optimal_parallel_blocks = 8;
+        pub const optimal_parallel_blocks = 6;
 
         /// Encrypt multiple blocks in parallel, each their own round key.
         pub inline fn encryptParallel(comptime count: usize, blocks: [count]Block, round_keys: [count]Block) [count]Block {


### PR DESCRIPTION
At least on Apple Silicon, this is slightly faster than 8 blocks.