### PR TITLE
Fixes to linux/bpf/btf.zig

### DIFF
--- a/lib/std/os/linux/bpf/btf.zig
+++ b/lib/std/os/linux/bpf/btf.zig
@@ -1,12 +1,12 @@
 const std = @import("../../../std.zig");
 
-const magic = 0xeb9f;
-const version = 1;
+pub const magic = 0xeb9f;
+pub const version = 1;
 
 pub const ext = @import("btf_ext.zig");
 
 /// All offsets are in bytes relative to the end of this header
-pub const Header = packed struct {
+pub const Header = extern struct {
     magic: u16,
     version: u8,
     flags: u8,
@@ -34,15 +34,15 @@ pub const max_name_offset = 0xffffff;
 /// Max number of struct/union/enum member of func args
 pub const max_vlen = 0xffff;
 
-pub const Type = packed struct {
+pub const Type = extern struct {
     name_off: u32,
-    info: packed struct {
+    info: packed struct(u32) {
         /// number of struct's members
         vlen: u16,
 
         unused_1: u8,
         kind: Kind,
-        unused_2: u3,
+        unused_2: u2,
 
         /// used by Struct, Union, and Fwd
         kind_flag: bool,
@@ -53,31 +53,35 @@ pub const Type = packed struct {
     ///
     /// type is used by Ptr, Typedef, Volatile, Const, Restrict, Func,
     /// FuncProto, and Var. It is a type_id referring to another type
-    size_type: union { size: u32, typ: u32 },
+    size_type: extern union { size: u32, typ: u32 },
 };
 
 /// For some kinds, Type is immediately followed by extra data
-pub const Kind = enum(u4) {
+pub const Kind = enum(u5) {
     unknown,
     int,
     ptr,
     array,
-    structure,
-    kind_union,
-    enumeration,
+    @"struct",
+    @"union",
+    @"enum",
     fwd,
     typedef,
-    kind_volatile,
-    constant,
+    @"volatile",
+    @"const",
     restrict,
     func,
-    funcProto,
-    variable,
-    dataSec,
+    func_proto,
+    @"var",
+    datasec,
+    float,
+    decl_tag,
+    type_tag,
+    enum64,
 };
 
-/// Int kind is followed by this struct
-pub const IntInfo = packed struct {
+/// int kind is followed by this struct
+pub const IntInfo = packed struct(u32) {
     bits: u8,
     unused: u8,
     offset: u8,
@@ -92,36 +96,43 @@ test "IntInfo is 32 bits" {
     try std.testing.expectEqual(@bitSizeOf(IntInfo), 32);
 }
 
-/// Enum kind is followed by this struct
-pub const Enum = packed struct {
+/// enum kind is followed by this struct
+pub const Enum = extern struct {
     name_off: u32,
     val: i32,
 };
 
-/// Array kind is followd by this struct
-pub const Array = packed struct {
+/// enum64 kind is followed by this struct
+pub const Enum64 = extern struct {
+    name_off: u32,
+    val_lo32: i32,
+    val_hi32: i32,
+};
+
+/// array kind is followd by this struct
+pub const Array = extern struct {
     typ: u32,
     index_type: u32,
     nelems: u32,
 };
 
-/// Struct and Union kinds are followed by multiple Member structs. The exact
+/// struct and union kinds are followed by multiple Member structs. The exact
 /// number is stored in vlen
-pub const Member = packed struct {
+pub const Member = extern struct {
     name_off: u32,
     typ: u32,
 
     /// if the kind_flag is set, offset contains both member bitfield size and
     /// bit offset, the bitfield size is set for bitfield members. If the type
     /// info kind_flag is not set, the offset contains only bit offset
-    offset: packed struct {
+    offset: packed struct(u32) {
         bit: u24,
         bitfield_size: u8,
     },
 };
 
-/// FuncProto is followed by multiple Params, the exact number is stored in vlen
-pub const Param = packed struct {
+/// func_proto is followed by multiple Params, the exact number is stored in vlen
+pub const Param = extern struct {
     name_off: u32,
     typ: u32,
 };
@@ -138,16 +149,26 @@ pub const FuncLinkage = enum {
     external,
 };
 
-/// Var kind is followd by a single Var struct to describe additional
+/// var kind is followd by a single Var struct to describe additional
 /// information related to the variable such as its linkage
-pub const Var = packed struct {
+pub const Var = extern struct {
     linkage: u32,
 };
 
-/// Datasec kind is followed by multible VarSecInfo to describe all Var kind
+/// datasec kind is followed by multible VarSecInfo to describe all Var kind
 /// types it contains along with it's in-section offset as well as size.
-pub const VarSecInfo = packed struct {
+pub const VarSecInfo = extern struct {
     typ: u32,
     offset: u32,
     size: u32,
+};
+
+// decl_tag kind is followed by a single DeclTag struct to describe
+// additional information related to the tag applied location.
+// If component_idx == -1, the tag is applied to a struct, union,
+// variable or function. Otherwise, it is applied to a struct/union
+// member or a func argument, and component_idx indicates which member
+// or argument (0 ... vlen-1).
+pub const DeclTag = extern struct {
+    component_idx: u32,
 };


### PR DESCRIPTION
- the meaning of packed structs changed in zig 0.10. adjust accordingly. Use "extern struct" for the cases that directly map to C structs.

- Add new type info kinds, like enum64 and DeclTag

- change the Type enum to use the canonical names from libbpf. This is more predictable when comparing with external BPF documentation (than invented synonyms that need to be guessed)

cc @mattnite 