### PR TITLE
@mulCarryless() - add a builtin to llvm backend

### DIFF
--- a/src/Air.zig
+++ b/src/Air.zig
@@ -178,6 +178,11 @@ pub const Inst = struct {
         /// and if an overflow happens, ov is 1. Otherwise ov is 0.
         /// Uses the `ty_pl` field. Payload is `Bin`.
         shl_with_overflow,
+        /// Carryless multiplication. Both operands are guaranteed to be the same type,
+        /// Result type is the same as both operands.
+        /// Uses the `ty_pl` field. Payload is `MulCarryless`.
+        /// Uses the `ty` field.
+        mul_carryless,
         /// Allocates stack local memory.
         /// Uses the `ty` field.
         alloc,
@@ -897,6 +902,12 @@ pub const Shuffle = struct {
     mask_len: u32,
 };
 
+pub const MulCarryless = struct {
+    a: Inst.Ref,
+    b: Inst.Ref,
+    imm: Inst.Ref,
+};
+
 pub const VectorCmp = struct {
     lhs: Inst.Ref,
     rhs: Inst.Ref,
@@ -1222,7 +1233,11 @@ pub fn typeOfIndex(air: Air, inst: Air.Inst.Index) Type {
             const extra = air.extraData(Air.Bin, datas[inst].pl_op.payload).data;
             return air.typeOf(extra.lhs);
         },
-
+        .mul_carryless => {
+            // const extra = air.extraData(Air.MulCarryless, datas[inst].ty_pl.payload).data;
+            // return air.typeOf(extra.a);
+            return air.getRefType(datas[inst].ty_pl.ty);
+        },
         .@"try" => {
             const err_union_ty = air.typeOf(datas[inst].pl_op.operand);
             return err_union_ty.errorUnionPayload();

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -8250,7 +8250,15 @@ fn builtinCall(
             });
             return rvalue(gz, ri, result, node);
         },
-
+        .mul_carryless => {
+            const result = try gz.addExtendedPayload(.mul_carryless, Zir.Inst.MulCarryless{
+                .node = gz.nodeIndexToRelative(node),
+                .a = try expr(gz, scope, .{ .rl = .none }, params[0]),
+                .b = try expr(gz, scope, .{ .rl = .none }, params[1]),
+                .imm = try expr(gz, scope, .{ .rl = .none }, params[2]),
+            });
+            return rvalue(gz, ri, result, node);
+        },
         .atomic_load => {
             const result = try gz.addPlNode(.atomic_load, node, Zir.Inst.AtomicLoad{
                 // zig fmt: off

--- a/src/BuiltinFn.zig
+++ b/src/BuiltinFn.zig
@@ -66,6 +66,7 @@ pub const Tag = enum {
     wasm_memory_grow,
     mod,
     mul_with_overflow,
+    mul_carryless,
     panic,
     pop_count,
     prefetch,
@@ -609,6 +610,13 @@ pub const list = list: {
             .{
                 .tag = .mul_with_overflow,
                 .param_count = 4,
+            },
+        },
+        .{
+            "@mulCarryless",
+            .{
+                .tag = .mul_carryless,
+                .param_count = 3,
             },
         },
         .{

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -405,6 +405,13 @@ pub fn categorizeOperand(
             if (extra.b == operand_ref) return matchOperandSmallIndex(l, inst, 1, .none);
             return .none;
         },
+        .mul_carryless => {
+            const extra = air.extraData(Air.MulCarryless, air_datas[inst].ty_pl.payload).data;
+            if (extra.a == operand_ref) return matchOperandSmallIndex(l, inst, 0, .none);
+            if (extra.b == operand_ref) return matchOperandSmallIndex(l, inst, 1, .none);
+            if (extra.imm == operand_ref) return matchOperandSmallIndex(l, inst, 2, .none);
+            return .none;
+        },
         .reduce, .reduce_optimized => {
             const reduce = air_datas[inst].reduce;
             if (reduce.operand == operand_ref) return matchOperandSmallIndex(l, inst, 0, .none);
@@ -904,6 +911,11 @@ fn analyzeInst(
             const ty_pl = inst_datas[inst].ty_pl;
             const extra = a.air.extraData(Air.Bin, ty_pl.payload).data;
             return trackOperands(a, new_set, inst, main_tomb, .{ extra.lhs, extra.rhs, .none });
+        },
+        .mul_carryless => {
+            const ty_pl = inst_datas[inst].ty_pl;
+            const extra = a.air.extraData(Air.MulCarryless, ty_pl.payload).data;
+            return trackOperands(a, new_set, inst, main_tomb, .{ extra.a, extra.b, extra.imm });
         },
 
         .dbg_var_ptr,

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -1927,6 +1927,10 @@ pub const Inst = struct {
         /// `operand` is payload index to `OverflowArithmetic`.
         /// `small` is unused.
         mul_with_overflow,
+        /// Implements the `@mulCarryless` builtin.
+        /// `operand` is payload index to `MulCarryless`.
+        /// `small` is unused.
+        mul_carryless,
         /// Implements the `@shlWithOverflow` builtin.
         /// `operand` is payload index to `OverflowArithmetic`.
         /// `small` is unused.
@@ -3423,6 +3427,13 @@ pub const Inst = struct {
         lhs: Ref,
         rhs: Ref,
         ptr: Ref,
+    };
+
+    pub const MulCarryless = struct {
+        node: i32,
+        a: Ref,
+        b: Ref,
+        imm: Ref,
     };
 
     pub const Cmpxchg = struct {

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -709,6 +709,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .mul_with_overflow => try self.airMulWithOverflow(inst),
             .shl_with_overflow => try self.airShlWithOverflow(inst),
 
+            .mul_carryless => @panic("TODO"),
+
             .cmp_lt  => try self.airCmp(inst, .lt),
             .cmp_lte => try self.airCmp(inst, .lte),
             .cmp_eq  => try self.airCmp(inst, .eq),

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -619,6 +619,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .mul_with_overflow => try self.airMulWithOverflow(inst),
             .shl_with_overflow => try self.airShlWithOverflow(inst),
 
+            .mul_carryless => @panic("TODO"),
+
             .cmp_lt  => try self.airCmp(inst, .lt),
             .cmp_lte => try self.airCmp(inst, .lte),
             .cmp_eq  => try self.airCmp(inst, .eq),

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -524,6 +524,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .mul_with_overflow => try self.airMulWithOverflow(inst),
             .shl_with_overflow => try self.airShlWithOverflow(inst),
 
+            .mul_carryless => @panic("TODO"),
+
             .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
             .cmp_lt  => try self.airCmp(inst, .lt),

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -548,6 +548,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .mul_with_overflow => try self.airMulWithOverflow(inst),
             .shl_with_overflow => try self.airShlWithOverflow(inst),
 
+            .mul_carryless => @panic("TODO"),
+
             .div_float, .div_trunc, .div_floor, .div_exact => try self.airDiv(inst),
 
             .cmp_lt  => try self.airCmp(inst, .lt),

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1717,6 +1717,8 @@ fn genInst(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         .shl_with_overflow => func.airShlWithOverflow(inst),
         .mul_with_overflow => func.airMulWithOverflow(inst),
 
+        .mul_carryless => @panic("TODO"),
+
         .clz => func.airClz(inst),
         .ctz => func.airCtz(inst),
 

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -619,6 +619,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .mul_with_overflow => try self.airMulWithOverflow(inst),
             .shl_with_overflow => try self.airAddSubShlWithOverflow(inst),
 
+            .mul_carryless => @panic("TODO"),
+
             .div_float, .div_trunc, .div_floor, .div_exact => try self.airMulDivBinOp(inst),
 
             .cmp_lt  => try self.airCmp(inst, .lt),

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -2732,6 +2732,8 @@ fn genBodyInner(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail,
             .mul_with_overflow => try airOverflow(f, inst, "mul", .Bits),
             .shl_with_overflow => try airOverflow(f, inst, "shl", .Bits),
 
+            .mul_carryless => return f.fail("TODO: C backend: implement @mulCarryless()", .{}),
+
             .min => try airMinMax(f, inst, '<', "fmin"),
             .max => try airMinMax(f, inst, '>', "fmax"),
 

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -736,6 +736,15 @@ pub const Builder = opaque {
         Name: [*:0]const u8,
     ) *Value;
 
+    pub const buildMulcl = ZigLLVMBuildMulcl;
+    extern fn ZigLLVMBuildMulcl(
+        *Builder,
+        A: *Value,
+        B: *Value,
+        IMM: *Value,
+        Name: [*:0]const u8,
+    ) *Value;
+
     pub const buildPtrToInt = LLVMBuildPtrToInt;
     extern fn LLVMBuildPtrToInt(
         *Builder,

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -306,6 +306,7 @@ const Writer = struct {
             .shuffle => try w.writeShuffle(s, inst),
             .reduce, .reduce_optimized => try w.writeReduce(s, inst),
             .cmp_vector, .cmp_vector_optimized => try w.writeCmpVector(s, inst),
+            .mul_carryless => try w.writeMulCarryless(s, inst),
 
             .dbg_block_begin, .dbg_block_end => {},
         }
@@ -459,6 +460,20 @@ const Writer = struct {
         try w.writeOperand(s, inst, 1, extra.lhs);
         try s.writeAll(", ");
         try w.writeOperand(s, inst, 2, extra.rhs);
+    }
+
+    fn writeMulCarryless(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
+        const ty_pl = w.air.instructions.items(.data)[inst].ty_pl;
+        const extra = w.air.extraData(Air.MulCarryless, ty_pl.payload).data;
+
+        const ty = w.air.getRefType(ty_pl.ty);
+        try w.writeType(s, ty);
+        try s.writeAll(", ");
+        try w.writeOperand(s, inst, 1, extra.a);
+        try s.writeAll(", ");
+        try w.writeOperand(s, inst, 2, extra.b);
+        try s.writeAll(", ");
+        try w.writeOperand(s, inst, 3, extra.imm);
     }
 
     fn writeReduce(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -539,6 +539,7 @@ const Writer = struct {
             },
             .builtin_async_call => try self.writeBuiltinAsyncCall(stream, extended),
             .cmpxchg => try self.writeCmpxchg(stream, extended),
+            .mul_carryless => try self.writeMulCarryless(stream, extended),
         }
     }
 
@@ -1157,6 +1158,19 @@ const Writer = struct {
         try self.writeInstRef(stream, extra.rhs);
         try stream.writeAll(", ");
         try self.writeInstRef(stream, extra.ptr);
+        try stream.writeAll(")) ");
+        try self.writeSrc(stream, src);
+    }
+
+    fn writeMulCarryless(self: *Writer, stream: anytype, extended: Zir.Inst.Extended.InstData) !void {
+        const extra = self.code.extraData(Zir.Inst.MulCarryless, extended.operand).data;
+        const src = LazySrcLoc.nodeOffset(extra.node);
+
+        try self.writeInstRef(stream, extra.a);
+        try stream.writeAll(", ");
+        try self.writeInstRef(stream, extra.b);
+        try stream.writeAll(", ");
+        try self.writeInstRef(stream, extra.imm);
         try stream.writeAll(")) ");
         try self.writeSrc(stream, src);
     }

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -29,6 +29,7 @@
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/InlineAsm.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/IntrinsicsX86.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
@@ -553,6 +554,13 @@ LLVMValueRef ZigLLVMBuildUShlSat(LLVMBuilderRef B, LLVMValueRef LHS, LLVMValueRe
 
 LLVMValueRef LLVMBuildVectorSplat(LLVMBuilderRef B, unsigned elem_count, LLVMValueRef V, const char *Name) {
   return wrap(unwrap(B)->CreateVectorSplat(elem_count, unwrap(V), Name));
+}
+
+LLVMValueRef ZigLLVMBuildMulcl(LLVMBuilderRef B, LLVMValueRef LHS, LLVMValueRef RHS, LLVMValueRef IMM, const char *name) {
+    llvm::Value* values[3] = {unwrap(LHS), unwrap(RHS), unwrap(IMM)};
+
+    CallInst *call_inst = unwrap(B)->CreateIntrinsic(Intrinsic::X86Intrinsics::x86_pclmulqdq, llvm::None, values, nullptr, name);
+    return wrap(call_inst);
 }
 
 void ZigLLVMFnSetSubprogram(LLVMValueRef fn, ZigLLVMDISubprogram *subprogram) {

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -153,6 +153,7 @@ ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildUMulFixSat(LLVMBuilderRef B, LLVMValueRef 
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildUShlSat(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildSShlSat(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
 ZIG_EXTERN_C LLVMValueRef LLVMBuildVectorSplat(LLVMBuilderRef B, unsigned elem_count, LLVMValueRef V, const char *Name);
+ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMulcl(LLVMBuilderRef B, LLVMValueRef LHS, LLVMValueRef RHS, LLVMValueRef IMM, const char *name);
 
 
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildNSWShl(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS,

--- a/test/behavior/mul_carryless.zig
+++ b/test/behavior/mul_carryless.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const u64x2 = std.meta.Vector(2, u64);
+
+test "carryless mul" {
+    const S = struct {
+        fn doTheTest() !void {
+            const a = 0b10100010;
+            const b = 0b10010110;
+            const expected = @as(u64, 0b101100011101100);
+            const av: u64x2 = .{ a, 0 };
+            const bv: u64x2 = .{ b, 0 };
+            const r = @mulCarryless(av, bv, @as(u8, 0));
+            try std.testing.expectEqual(expected, r[0]);
+        }
+    };
+    try S.doTheTest();
+    // comptime try S.doTheTest();
+}


### PR DESCRIPTION
addresses #9631. 

only works with llvm backend/x86 so far. allows new 
test/behavior/mul_carryless.zig to pass with -Denable-llvm. doesn't do 
any backend/arch/cpu-feature testing yet.