### PR TITLE
Optionally Remove SIGPIPE errors on Linux when using std.net -- Allow std.net.StreamServer.accept to return error.WouldBlock

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1671,8 +1671,8 @@ pub const Stream = struct {
         if (std.io.is_async) {
             return std.event.Loop.instance.?.write(self.handle, buffer, false);
         } else {
-            if(builtin.os.tag == .linux)
-                return os.send(@bitCast(socket_t, self.handle), buffer, os.linux.MSG.NOSIGNAL)
+            if (builtin.os.tag == .linux)
+                return os.send(@bitCast(os.socket_t, self.handle), buffer, os.linux.MSG.NOSIGNAL)
             else {
                 return os.write(self.handle, buffer);
             }
@@ -1817,6 +1817,9 @@ pub const StreamServer = struct {
         NetworkSubsystemFailed,
 
         OperationNotSupported,
+
+        /// Occurs when timeout happens on a blocking socket
+        WouldBlock,
     } || os.UnexpectedError;
 
     pub const Connection = struct {
@@ -1843,7 +1846,6 @@ pub const StreamServer = struct {
                 .address = accepted_addr,
             };
         } else |err| switch (err) {
-            error.WouldBlock => unreachable,
             else => |e| return e,
         }
     }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1671,7 +1671,11 @@ pub const Stream = struct {
         if (std.io.is_async) {
             return std.event.Loop.instance.?.write(self.handle, buffer, false);
         } else {
-            return os.write(self.handle, buffer);
+            if(builtin.os.tag == .linux)
+                return os.send(@bitCast(socket_t, self.handle), buffer, os.linux.MSG.NOSIGNAL)
+            else {
+                return os.write(self.handle, buffer);
+            }
         }
     }
 

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1685,7 +1685,12 @@ pub const Stream = struct {
                         error.MessageTooBig => error.Unexpected,
                         error.NetworkSubsystemFailed => error.Unexpected,
                         error.NetworkUnreachable => error.Unexpected,
-                        else => e,
+                        error.AccessDenied => error.AccessDenied,
+                        error.BrokenPipe => error.BrokenPipe,
+                        error.ConnectionResetByPeer => error.ConnectionResetByPeer,
+                        error.SystemResources => error.SystemResources,
+                        error.Unexpected => error.Unexpected,
+                        error.WouldBlock => error.WouldBlock,
                     };
                 };
             } else {

--- a/lib/std/x/os/socket.zig
+++ b/lib/std/x/os/socket.zig
@@ -330,7 +330,7 @@ pub const Socket = struct {
     /// Enclose a socket abstraction over an existing socket file descriptor.
     pub fn from(fd: os.socket_t) Socket {
         var s = Socket{ .fd = fd };
-        s.setRaiseSIGPIPE(s.raise_sigpipe);
+        s.setRaiseSIGPIPE(s.raise_sigpipe) catch unreachable;
         return s;
     }
 

--- a/lib/std/x/os/socket.zig
+++ b/lib/std/x/os/socket.zig
@@ -307,6 +307,12 @@ pub const Socket = struct {
     /// The underlying handle of a socket.
     fd: os.socket_t,
 
+    // Whether or not the socket should raise SIGPIPE errors on platforms
+    // that support SIGPIPE. Default is changed to being false, as this
+    // option generates API compatibility between operating systems such as
+    // Linux, which does generate SIGPIPE, and Windows, which does not.
+    raise_sigpipe: bool = false,
+
     /// Enclose a socket abstraction over an existing socket file descriptor.
     pub fn from(fd: os.socket_t) Socket {
         return Socket{ .fd = fd };

--- a/lib/std/x/os/socket_posix.zig
+++ b/lib/std/x/os/socket_posix.zig
@@ -66,7 +66,13 @@ pub fn Mixin(comptime Socket: type) type {
         /// Write a buffer of data provided to the socket with a set of flags specified.
         /// It returns the number of bytes that are written to the socket.
         pub fn write(self: Socket, buf: []const u8, flags: u32) !usize {
-            return os.send(self.fd, buf, flags);
+            var flags_ = flags;
+
+            if(builtin.os.tag == .linux) {
+                flags_ |= os.linux.MSG.NOSIGNAL;
+            }
+
+            return os.send(self.fd, buf, flags_);
         }
 
         /// Writes multiple I/O vectors with a prepended message header to the socket

--- a/lib/std/x/os/socket_posix.zig
+++ b/lib/std/x/os/socket_posix.zig
@@ -69,7 +69,7 @@ pub fn Mixin(comptime Socket: type) type {
         pub fn write(self: Socket, buf: []const u8, flags: u32) !usize {
             var flags_ = flags;
 
-            if (builtin.os.tag == .linux) {
+            if (builtin.os.tag == .linux and !self.raise_sigpipe) {
                 flags_ |= os.linux.MSG.NOSIGNAL;
             }
 

--- a/lib/std/x/os/socket_posix.zig
+++ b/lib/std/x/os/socket_posix.zig
@@ -13,7 +13,9 @@ pub fn Mixin(comptime Socket: type) type {
             const set = std.EnumSet(Socket.InitFlags).init(flags);
             if (set.contains(.close_on_exec)) raw_flags |= os.SOCK.CLOEXEC;
             if (set.contains(.nonblocking)) raw_flags |= os.SOCK.NONBLOCK;
-            return Socket{ .fd = try os.socket(domain, raw_flags, protocol) };
+            var s = Socket{ .fd = try os.socket(domain, raw_flags, protocol) };
+            try s.setRaiseSIGPIPE(s.raise_sigpipe);
+            return s;
         }
 
         /// Closes the socket.

--- a/lib/std/x/os/socket_posix.zig
+++ b/lib/std/x/os/socket_posix.zig
@@ -1,4 +1,5 @@
 const std = @import("../../std.zig");
+const builtin = @import("builtin");
 
 const os = std.os;
 const mem = std.mem;
@@ -68,7 +69,7 @@ pub fn Mixin(comptime Socket: type) type {
         pub fn write(self: Socket, buf: []const u8, flags: u32) !usize {
             var flags_ = flags;
 
-            if(builtin.os.tag == .linux) {
+            if (builtin.os.tag == .linux) {
                 flags_ |= os.linux.MSG.NOSIGNAL;
             }
 


### PR DESCRIPTION
This PR fixes #5614 
Linux defaults to causing a SIGPIPE issue when a connection is broken. For Terminal / Shell applications, this is fine, however it kills network applications, which becomes a problem. Instead, Linux has MSG_NOSIGNAL for sockets which will return EPIPE instead of SIGPIPE, which does not result in a crash and is an error that can be handled by the application. This is an optional flag for sockets, but makes the API between OS's consistent. It doesn't change anything else about SIGPIPE generation. This replaces the default flags for Linux in std.net and std.x.net to use MSG_NOSIGNAL. It also creates a method setRaiseSIGPIPE() which sets the flag and for Mac & FreeBSD sets the socket to not raise a SIGPIPE. 

This PR also fixes #7142
When a timeout is set on a socket, the socket may return error.WouldBlock if nothing is detected by the specified timeout. std.net.StreamServer.accept() mishandles this and assigns error.WouldBlock to be unreachable, yet every other error is passed. This commit fixes this by adding error.WouldBlock to the error union and removing this code.