### PR TITLE
stage2: Support modifiers in inline asm

### DIFF
--- a/test/behavior/asm.zig
+++ b/test/behavior/asm.zig
@@ -136,3 +136,16 @@ extern fn this_is_my_alias() i32;
 export fn derp() i32 {
     return 1234;
 }
+
+test "asm modifiers (AArch64)" {
+    if (builtin.target.cpu.arch != .aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
+
+    var x: u32 = 15;
+    const double = asm ("add %[ret:w], %[in:w], %[in:w]"
+        : [ret] "=r" (-> u32),
+        : [in] "r" (x),
+    );
+    try expect(double == 2 * x);
+}


### PR DESCRIPTION
These are supported using `%[ident:mod]` syntax.

This allows requesting, e.g., the "w" (32-bit) vs. "x" (64-bit) views of AArch64 registers.

See https://llvm.org/docs/LangRef.html#asm-template-argument-modifiers