### PR TITLE
WebAssembly-only fast allocator

### DIFF
--- a/lib/std/heap/PageAllocator.zig
+++ b/lib/std/heap/PageAllocator.zig
@@ -1,0 +1,110 @@
+const std = @import("../std.zig");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+const mem = std.mem;
+const os = std.os;
+const maxInt = std.math.maxInt;
+const assert = std.debug.assert;
+
+pub const vtable = Allocator.VTable{
+    .alloc = alloc,
+    .resize = resize,
+    .free = free,
+};
+
+fn alloc(_: *anyopaque, n: usize, log2_align: u8, ra: usize) ?[*]u8 {
+    _ = ra;
+    _ = log2_align;
+    assert(n > 0);
+    if (n > maxInt(usize) - (mem.page_size - 1)) return null;
+    const aligned_len = mem.alignForward(n, mem.page_size);
+
+    if (builtin.os.tag == .windows) {
+        const w = os.windows;
+        const addr = w.VirtualAlloc(
+            null,
+            aligned_len,
+            w.MEM_COMMIT | w.MEM_RESERVE,
+            w.PAGE_READWRITE,
+        ) catch return null;
+        return @ptrCast([*]align(mem.page_size) u8, @alignCast(mem.page_size, addr));
+    }
+
+    const hint = @atomicLoad(@TypeOf(std.heap.next_mmap_addr_hint), &std.heap.next_mmap_addr_hint, .Unordered);
+    const slice = os.mmap(
+        hint,
+        aligned_len,
+        os.PROT.READ | os.PROT.WRITE,
+        os.MAP.PRIVATE | os.MAP.ANONYMOUS,
+        -1,
+        0,
+    ) catch return null;
+    assert(mem.isAligned(@ptrToInt(slice.ptr), mem.page_size));
+    const new_hint = @alignCast(mem.page_size, slice.ptr + aligned_len);
+    _ = @cmpxchgStrong(@TypeOf(std.heap.next_mmap_addr_hint), &std.heap.next_mmap_addr_hint, hint, new_hint, .Monotonic, .Monotonic);
+    return slice.ptr;
+}
+
+fn resize(
+    _: *anyopaque,
+    buf_unaligned: []u8,
+    log2_buf_align: u8,
+    new_size: usize,
+    return_address: usize,
+) bool {
+    _ = log2_buf_align;
+    _ = return_address;
+    const new_size_aligned = mem.alignForward(new_size, mem.page_size);
+
+    if (builtin.os.tag == .windows) {
+        const w = os.windows;
+        if (new_size <= buf_unaligned.len) {
+            const base_addr = @ptrToInt(buf_unaligned.ptr);
+            const old_addr_end = base_addr + buf_unaligned.len;
+            const new_addr_end = mem.alignForward(base_addr + new_size, mem.page_size);
+            if (old_addr_end > new_addr_end) {
+                // For shrinking that is not releasing, we will only
+                // decommit the pages not needed anymore.
+                w.VirtualFree(
+                    @intToPtr(*anyopaque, new_addr_end),
+                    old_addr_end - new_addr_end,
+                    w.MEM_DECOMMIT,
+                );
+            }
+            return true;
+        }
+        const old_size_aligned = mem.alignForward(buf_unaligned.len, mem.page_size);
+        if (new_size_aligned <= old_size_aligned) {
+            return true;
+        }
+        return false;
+    }
+
+    const buf_aligned_len = mem.alignForward(buf_unaligned.len, mem.page_size);
+    if (new_size_aligned == buf_aligned_len)
+        return true;
+
+    if (new_size_aligned < buf_aligned_len) {
+        const ptr = @alignCast(mem.page_size, buf_unaligned.ptr + new_size_aligned);
+        // TODO: if the next_mmap_addr_hint is within the unmapped range, update it
+        os.munmap(ptr[0 .. buf_aligned_len - new_size_aligned]);
+        return true;
+    }
+
+    // TODO: call mremap
+    // TODO: if the next_mmap_addr_hint is within the remapped range, update it
+    return false;
+}
+
+fn free(_: *anyopaque, slice: []u8, log2_buf_align: u8, return_address: usize) void {
+    _ = log2_buf_align;
+    _ = return_address;
+
+    if (builtin.os.tag == .windows) {
+        os.windows.VirtualFree(slice.ptr, 0, os.windows.MEM_RELEASE);
+    } else {
+        const buf_aligned_len = mem.alignForward(slice.len, mem.page_size);
+        const ptr = @alignCast(mem.page_size, slice.ptr);
+        os.munmap(ptr[0..buf_aligned_len]);
+    }
+}

--- a/lib/std/heap/WasmAllocator.zig
+++ b/lib/std/heap/WasmAllocator.zig
@@ -1,0 +1,222 @@
+//! This is intended to be merged into GeneralPurposeAllocator at some point.
+
+const std = @import("../std.zig");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+const mem = std.mem;
+const assert = std.debug.assert;
+const wasm = std.wasm;
+const math = std.math;
+
+comptime {
+    if (!builtin.target.isWasm()) {
+        @compileError("WasmPageAllocator is only available for wasm32 arch");
+    }
+}
+
+pub const vtable = Allocator.VTable{
+    .alloc = alloc,
+    .resize = resize,
+    .free = free,
+};
+
+pub const Error = Allocator.Error;
+
+const max_usize = math.maxInt(usize);
+const bigpage_size = 512 * 1024;
+const pages_per_bigpage = bigpage_size / wasm.page_size;
+const bigpage_count = max_usize / bigpage_size;
+
+//// This has a length of 1024 usizes.
+//var bigpages_used = [1]usize{0} ** (bigpage_count / @bitSizeOf(usize));
+
+/// We have a small size class for all sizes up to 512kb.
+const size_class_count = math.log2(bigpage_size);
+
+const FreeList = struct {
+    /// Each element is the address of a freed pointer.
+    ptr: [*]usize,
+    len: usize,
+    cap: usize,
+
+    const init: FreeList = .{
+        .ptr = undefined,
+        .len = 0,
+        .cap = 0,
+    };
+};
+
+var next_addrs = [1]usize{0} ** size_class_count;
+var frees = [1]FreeList{FreeList.init} ** size_class_count;
+var bigpage_free_list: FreeList = .{
+    .ptr = &bigpage_free_buf,
+    .len = 0,
+    .cap = bigpage_free_buf.len,
+};
+var bigpage_free_buf: [16]usize = undefined;
+
+fn alloc(ctx: *anyopaque, len: usize, alignment: u29, len_align: u29, ra: usize) Error![]u8 {
+    _ = ctx;
+    _ = len_align;
+    _ = ra;
+    const slot_size = math.ceilPowerOfTwoAssert(usize, @max(len, alignment));
+    const class = math.log2(slot_size);
+    if (class < size_class_count) {
+        const addr = a: {
+            const free_list = &frees[class];
+            if (free_list.len > 0) {
+                free_list.len -= 1;
+                break :a free_list.ptr[free_list.len];
+            }
+
+            // Ensure unused capacity in the corresponding free list.
+            // This prevents memory allocation within free().
+            if (free_list.len >= free_list.cap) {
+                const old_bigpage_count = free_list.cap / bigpage_size;
+                if (bigpage_free_list.cap - bigpage_free_list.len < old_bigpage_count) {
+                    return error.OutOfMemory;
+                }
+                const new_bigpage_count = old_bigpage_count + 1;
+                const addr = try allocBigPages(new_bigpage_count);
+                const new_ptr = @intToPtr([*]usize, addr);
+                const old_ptr = free_list.ptr;
+                @memcpy(
+                    @ptrCast([*]u8, new_ptr),
+                    @ptrCast([*]u8, old_ptr),
+                    @sizeOf(usize) * free_list.len,
+                );
+                free_list.ptr = new_ptr;
+                free_list.cap = new_bigpage_count * (bigpage_size / @sizeOf(usize));
+
+                var i: usize = 0;
+                while (i < old_bigpage_count) : (i += 1) {
+                    bigpage_free_list.ptr[bigpage_free_list.len] = @ptrToInt(old_ptr) +
+                        i * bigpage_size;
+                    bigpage_free_list.len += 1;
+                }
+            }
+
+            const next_addr = next_addrs[class];
+            if (next_addr % bigpage_size == 0) {
+                //std.debug.print("alloc big page len={d} class={d} slot_size={d}\n", .{
+                //    len, class, slot_size,
+                //});
+                const addr = try allocBigPages(1);
+                next_addrs[class] = addr + slot_size;
+                break :a addr;
+            } else {
+                //std.debug.print("easy! len={d} class={d} slot_size={d}\n", .{
+                //    len, class, slot_size,
+                //});
+                next_addrs[class] = next_addr + slot_size;
+                break :a next_addr;
+            }
+        };
+        return @intToPtr([*]u8, addr)[0..len];
+    } else {
+        std.debug.panic("big alloc: len={d} align={d} slot_size={d} class={d}", .{
+            len, alignment, slot_size, class,
+        });
+    }
+}
+
+fn resize(
+    ctx: *anyopaque,
+    buf: []u8,
+    buf_align: u29,
+    new_len: usize,
+    len_align: u29,
+    return_address: usize,
+) ?usize {
+    _ = ctx;
+    _ = buf_align;
+    _ = return_address;
+    _ = len_align;
+    _ = new_len;
+    _ = buf;
+    @panic("handle resize");
+}
+
+fn free(
+    ctx: *anyopaque,
+    buf: []u8,
+    buf_align: u29,
+    return_address: usize,
+) void {
+    _ = ctx;
+    _ = return_address;
+    const class_size = @max(buf.len, buf_align);
+    const class = math.log2(class_size);
+    if (class < size_class_count) {
+        const free_list = &frees[class];
+        assert(free_list.len < free_list.cap);
+        free_list.ptr[free_list.len] = @ptrToInt(buf.ptr);
+        free_list.len += 1;
+    } else {
+        std.debug.panic("big free: len={d} align={d}", .{
+            buf.len, buf_align,
+        });
+    }
+}
+
+inline fn allocBigPages(n: usize) !usize {
+    if (n == 1 and bigpage_free_list.len > 0) {
+        bigpage_free_list.len -= 1;
+        return bigpage_free_list.ptr[bigpage_free_list.len];
+    }
+    const page_index = @wasmMemoryGrow(0, n * pages_per_bigpage);
+    if (page_index <= 0)
+        return error.OutOfMemory;
+    return @intCast(u32, page_index) * wasm.page_size;
+}
+
+const test_ally = Allocator{
+    .ptr = undefined,
+    .vtable = &vtable,
+};
+
+test "small allocations - free in same order" {
+    var list: [513]*u64 = undefined;
+
+    var i: usize = 0;
+    while (i < 513) : (i += 1) {
+        const ptr = try test_ally.create(u64);
+        list[i] = ptr;
+    }
+
+    for (list) |ptr| {
+        test_ally.destroy(ptr);
+    }
+}
+
+test "small allocations - free in reverse order" {
+    var list: [513]*u64 = undefined;
+
+    var i: usize = 0;
+    while (i < 513) : (i += 1) {
+        const ptr = try test_ally.create(u64);
+        list[i] = ptr;
+    }
+
+    i = list.len;
+    while (i > 0) {
+        i -= 1;
+        const ptr = list[i];
+        test_ally.destroy(ptr);
+    }
+}
+
+test "large allocations" {
+    std.debug.print("alloc ptr1\n", .{});
+    const ptr1 = try test_ally.alloc(u64, 42768);
+    std.debug.print("alloc ptr2\n", .{});
+    const ptr2 = try test_ally.alloc(u64, 52768);
+    std.debug.print("free ptr1\n", .{});
+    test_ally.free(ptr1);
+    std.debug.print("alloc ptr3\n", .{});
+    const ptr3 = try test_ally.alloc(u64, 62768);
+    std.debug.print("free ptr3\n", .{});
+    test_ally.free(ptr3);
+    std.debug.print("free ptr2\n", .{});
+    test_ally.free(ptr2);
+}

--- a/lib/std/heap/WasmAllocator.zig
+++ b/lib/std/heap/WasmAllocator.zig
@@ -117,10 +117,10 @@ fn resize(
         }
     } else {
         const old_bigpages_needed = bigPagesNeeded(old_actual_len);
-        const old_big_slot_size = math.ceilPowerOfTwoAssert(usize, old_bigpages_needed);
+        const old_big_slot_pages = math.ceilPowerOfTwoAssert(usize, old_bigpages_needed);
         const new_bigpages_needed = bigPagesNeeded(new_actual_len);
-        const new_big_slot_size = math.ceilPowerOfTwo(usize, new_bigpages_needed) catch return null;
-        if (old_big_slot_size == new_big_slot_size) return new_len;
+        const new_big_slot_pages = math.ceilPowerOfTwo(usize, new_bigpages_needed) catch return null;
+        if (old_big_slot_pages == new_big_slot_pages) return new_len;
         if (new_actual_len >= old_actual_len) return null;
 
         const new_small_slot_size = math.ceilPowerOfTwoAssert(usize, new_actual_len);
@@ -129,7 +129,7 @@ fn resize(
             // TODO: push the big allocation into the free list
             _ = new_small_class;
         } else {
-            const new_big_class = math.log2(new_big_slot_size);
+            const new_big_class = math.log2(new_big_slot_pages);
             // TODO: push the upper area into the free list
             _ = new_big_class;
         }

--- a/lib/std/heap/WasmPageAllocator.zig
+++ b/lib/std/heap/WasmPageAllocator.zig
@@ -102,7 +102,8 @@ fn nPages(memsize: usize) usize {
     return mem.alignForward(memsize, mem.page_size) / mem.page_size;
 }
 
-fn alloc(_: *anyopaque, len: usize, log2_align: u8, ra: usize) ?[*]u8 {
+fn alloc(ctx: *anyopaque, len: usize, log2_align: u8, ra: usize) ?[*]u8 {
+    _ = ctx;
     _ = ra;
     if (len > maxInt(usize) - (mem.page_size - 1)) return null;
     const page_count = nPages(len);
@@ -159,12 +160,13 @@ fn freePages(start: usize, end: usize) void {
 }
 
 fn resize(
-    _: *anyopaque,
+    ctx: *anyopaque,
     buf: []u8,
     log2_buf_align: u8,
     new_len: usize,
     return_address: usize,
 ) bool {
+    _ = ctx;
     _ = log2_buf_align;
     _ = return_address;
     const aligned_len = mem.alignForward(buf.len, mem.page_size);
@@ -179,11 +181,12 @@ fn resize(
 }
 
 fn free(
-    _: *anyopaque,
+    ctx: *anyopaque,
     buf: []u8,
     log2_buf_align: u8,
     return_address: usize,
 ) void {
+    _ = ctx;
     _ = log2_buf_align;
     _ = return_address;
     const aligned_len = mem.alignForward(buf.len, mem.page_size);

--- a/lib/std/heap/WasmPageAllocator.zig
+++ b/lib/std/heap/WasmPageAllocator.zig
@@ -1,0 +1,193 @@
+const std = @import("../std.zig");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+const mem = std.mem;
+const maxInt = std.math.maxInt;
+const assert = std.debug.assert;
+
+comptime {
+    if (!builtin.target.isWasm()) {
+        @compileError("WasmPageAllocator is only available for wasm32 arch");
+    }
+}
+
+pub const vtable = Allocator.VTable{
+    .alloc = alloc,
+    .resize = resize,
+    .free = free,
+};
+
+const PageStatus = enum(u1) {
+    used = 0,
+    free = 1,
+
+    pub const none_free: u8 = 0;
+};
+
+const FreeBlock = struct {
+    data: []u128,
+
+    const Io = std.packed_int_array.PackedIntIo(u1, .Little);
+
+    fn totalPages(self: FreeBlock) usize {
+        return self.data.len * 128;
+    }
+
+    fn isInitialized(self: FreeBlock) bool {
+        return self.data.len > 0;
+    }
+
+    fn getBit(self: FreeBlock, idx: usize) PageStatus {
+        const bit_offset = 0;
+        return @intToEnum(PageStatus, Io.get(mem.sliceAsBytes(self.data), idx, bit_offset));
+    }
+
+    fn setBits(self: FreeBlock, start_idx: usize, len: usize, val: PageStatus) void {
+        const bit_offset = 0;
+        var i: usize = 0;
+        while (i < len) : (i += 1) {
+            Io.set(mem.sliceAsBytes(self.data), start_idx + i, bit_offset, @enumToInt(val));
+        }
+    }
+
+    // Use '0xFFFFFFFF' as a _missing_ sentinel
+    // This saves ~50 bytes compared to returning a nullable
+
+    // We can guarantee that conventional memory never gets this big,
+    // and wasm32 would not be able to address this memory (32 GB > usize).
+
+    // Revisit if this is settled: https://github.com/ziglang/zig/issues/3806
+    const not_found = maxInt(usize);
+
+    fn useRecycled(self: FreeBlock, num_pages: usize, log2_align: u8) usize {
+        @setCold(true);
+        for (self.data) |segment, i| {
+            const spills_into_next = @bitCast(i128, segment) < 0;
+            const has_enough_bits = @popCount(segment) >= num_pages;
+
+            if (!spills_into_next and !has_enough_bits) continue;
+
+            var j: usize = i * 128;
+            while (j < (i + 1) * 128) : (j += 1) {
+                var count: usize = 0;
+                while (j + count < self.totalPages() and self.getBit(j + count) == .free) {
+                    count += 1;
+                    const addr = j * mem.page_size;
+                    if (count >= num_pages and mem.isAlignedLog2(addr, log2_align)) {
+                        self.setBits(j, num_pages, .used);
+                        return j;
+                    }
+                }
+                j += count;
+            }
+        }
+        return not_found;
+    }
+
+    fn recycle(self: FreeBlock, start_idx: usize, len: usize) void {
+        self.setBits(start_idx, len, .free);
+    }
+};
+
+var _conventional_data = [_]u128{0} ** 16;
+// Marking `conventional` as const saves ~40 bytes
+const conventional = FreeBlock{ .data = &_conventional_data };
+var extended = FreeBlock{ .data = &[_]u128{} };
+
+fn extendedOffset() usize {
+    return conventional.totalPages();
+}
+
+fn nPages(memsize: usize) usize {
+    return mem.alignForward(memsize, mem.page_size) / mem.page_size;
+}
+
+fn alloc(_: *anyopaque, len: usize, log2_align: u8, ra: usize) ?[*]u8 {
+    _ = ra;
+    if (len > maxInt(usize) - (mem.page_size - 1)) return null;
+    const page_count = nPages(len);
+    const page_idx = allocPages(page_count, log2_align) catch return null;
+    return @intToPtr([*]u8, page_idx * mem.page_size);
+}
+
+fn allocPages(page_count: usize, log2_align: u8) !usize {
+    {
+        const idx = conventional.useRecycled(page_count, log2_align);
+        if (idx != FreeBlock.not_found) {
+            return idx;
+        }
+    }
+
+    const idx = extended.useRecycled(page_count, log2_align);
+    if (idx != FreeBlock.not_found) {
+        return idx + extendedOffset();
+    }
+
+    const next_page_idx = @wasmMemorySize(0);
+    const next_page_addr = next_page_idx * mem.page_size;
+    const aligned_addr = mem.alignForwardLog2(next_page_addr, log2_align);
+    const drop_page_count = @divExact(aligned_addr - next_page_addr, mem.page_size);
+    const result = @wasmMemoryGrow(0, @intCast(u32, drop_page_count + page_count));
+    if (result <= 0)
+        return error.OutOfMemory;
+    assert(result == next_page_idx);
+    const aligned_page_idx = next_page_idx + drop_page_count;
+    if (drop_page_count > 0) {
+        freePages(next_page_idx, aligned_page_idx);
+    }
+    return @intCast(usize, aligned_page_idx);
+}
+
+fn freePages(start: usize, end: usize) void {
+    if (start < extendedOffset()) {
+        conventional.recycle(start, @min(extendedOffset(), end) - start);
+    }
+    if (end > extendedOffset()) {
+        var new_end = end;
+        if (!extended.isInitialized()) {
+            // Steal the last page from the memory currently being recycled
+            // TODO: would it be better if we use the first page instead?
+            new_end -= 1;
+
+            extended.data = @intToPtr([*]u128, new_end * mem.page_size)[0 .. mem.page_size / @sizeOf(u128)];
+            // Since this is the first page being freed and we consume it, assume *nothing* is free.
+            mem.set(u128, extended.data, PageStatus.none_free);
+        }
+        const clamped_start = @max(extendedOffset(), start);
+        extended.recycle(clamped_start - extendedOffset(), new_end - clamped_start);
+    }
+}
+
+fn resize(
+    _: *anyopaque,
+    buf: []u8,
+    log2_buf_align: u8,
+    new_len: usize,
+    return_address: usize,
+) bool {
+    _ = log2_buf_align;
+    _ = return_address;
+    const aligned_len = mem.alignForward(buf.len, mem.page_size);
+    if (new_len > aligned_len) return false;
+    const current_n = nPages(aligned_len);
+    const new_n = nPages(new_len);
+    if (new_n != current_n) {
+        const base = nPages(@ptrToInt(buf.ptr));
+        freePages(base + new_n, base + current_n);
+    }
+    return true;
+}
+
+fn free(
+    _: *anyopaque,
+    buf: []u8,
+    log2_buf_align: u8,
+    return_address: usize,
+) void {
+    _ = log2_buf_align;
+    _ = return_address;
+    const aligned_len = mem.alignForward(buf.len, mem.page_size);
+    const current_n = nPages(aligned_len);
+    const base = nPages(@ptrToInt(buf.ptr));
+    freePages(base, base + current_n);
+}


### PR DESCRIPTION
This is a 160-line Allocator implementation that is simpler, faster, and more memory-efficient than GeneralPurposeAllocator. It similarly buckets allocations into size classes, however, unlike GPA, it additionally uses free lists, and does not track any metadata. The only extra information stored within each allocation is an intrusive free list node, so that the allocation can be added to the free list without possibility of failure. This allocator has zero external fragmentation, but a high amount of internal fragmentation. Large allocations are never split into multiple smaller allocations, and smaller allocations are never joined into a single larger allocation.

It is WebAssembly-only because it depends on single-threaded access to global variables to keep track of allocator state, it directly calls the `@wasmMemoryGrow` intrinsic, and it never gives memory back to the OS.

I think this strategy could be appropriate in general when the following options are enabled:
 * `-fsingle-threaded`
 * `-OReleaseSmall`
 * The OS has an API equivalent to `sbrk` for obtaining heap memory.