### PR TITLE
zig-cache: support windows drive + fwd-slash paths

### DIFF
--- a/src/DepTokenizer.zig
+++ b/src/DepTokenizer.zig
@@ -82,7 +82,7 @@ pub fn next(self: *Tokenizer) ?Token {
                     // silently ignore null target
                     self.state = .lhs;
                 },
-                '\\' => {
+                '/', '\\' => {
                     self.state = .target_colon_reverse_solidus;
                     self.index += 1;
                 },
@@ -706,7 +706,7 @@ test "windows mixed prereqs" {
     );
 }
 
-test "funky targets" {
+test "windows funky targets" {
     try depTokenizer(
         \\C:\Users\anon\foo.o:
         \\C:\Users\anon\foo\ .o:
@@ -725,6 +725,16 @@ test "funky targets" {
         \\target = {C:\Users\anon\#foo.o}
         \\target = {C:\Users\anon\$foo.o}
         \\target = {C:\Users\anon\     foo.o}
+    );
+}
+
+test "windows drive and forward slashes" {
+    try depTokenizer(
+        \\C:/msys64/what/zig-cache\tmp\48ac4d78dd531abd-cxa_thread_atexit.obj: \
+        \\  C:/msys64/opt/zig3/lib/zig/libc/mingw/crt/cxa_thread_atexit.c
+    ,
+        \\target = {C:/msys64/what/zig-cache\tmp\48ac4d78dd531abd-cxa_thread_atexit.obj}
+        \\prereq = {C:/msys64/opt/zig3/lib/zig/libc/mingw/crt/cxa_thread_atexit.c}
     );
 }
 


### PR DESCRIPTION
closes #13539

This patch comes as a result of seeing various instances of invalid pathnames of various libc dependencies on windows. 

This kind of path hinted at the underlying issue. Note trailing `:` as **part** of pathname!
```
/msys64/what/zig-cache\tmp\48ac4d78dd531abd-cxa_thread_atexit.obj:
```

And it was obtained via DepTokenizer from a `.d` dependency file such as:
```
C:/msys64/what/zig-cache\tmp\48ac4d78dd531abd-cxa_thread_atexit.obj: \
  C:/msys64/opt/zig3/lib/zig/libc/mingw/crt/cxa_thread_atexit.c
```

- the first token should be a `.target` and all the way up to last `:` before EOL
- instead `.target` was parsed as `C` and `.prereq` was `/msys64/what/zig-cache\tmp\48ac4d78dd531abd-cxa_thread_atexit.obj:`

The solve is to allow `DRIVE:/PATH` just as `DRIVE:\PATH` is allowed; this correctly parses `.target` token in its entirety.

A new test was added for coverage.