### PR TITLE
linker: fail the compilation if there were linker errors

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -51,6 +51,7 @@ whole_cache_manifest: ?*Cache.Manifest = null,
 whole_cache_manifest_mutex: std.Thread.Mutex = .{},
 
 link_error_flags: link.File.ErrorFlags = .{},
+lld_errors: std.ArrayListUnmanaged(LldError) = .{},
 
 work_queue: std.fifo.LinearFifo(Job, .Dynamic),
 anon_work_queue: std.fifo.LinearFifo(Job, .Dynamic),
@@ -332,6 +333,21 @@ pub const MiscError = struct {
             children.deinit(gpa);
         }
         misc_err.* = undefined;
+    }
+};
+
+pub const LldError = struct {
+    /// Allocated with gpa.
+    msg: []const u8,
+    context_lines: []const []const u8 = &.{},
+
+    pub fn deinit(self: *LldError, gpa: Allocator) void {
+        for (self.context_lines) |line| {
+            gpa.free(line);
+        }
+
+        gpa.free(self.context_lines);
+        gpa.free(self.msg);
     }
 };
 
@@ -2166,6 +2182,11 @@ pub fn destroy(self: *Compilation) void {
     }
     self.failed_c_objects.deinit(gpa);
 
+    for (self.lld_errors.items) |*lld_error| {
+        lld_error.deinit(gpa);
+    }
+    self.lld_errors.deinit(gpa);
+
     self.clearMiscFailures();
 
     self.cache_parent.manifest_dir.close();
@@ -2465,6 +2486,10 @@ pub fn update(comp: *Compilation) !void {
             try comp.flush(main_progress_node);
         }
 
+        if (comp.totalErrorCount() != 0) {
+            return;
+        }
+
         // Failure here only means an unnecessary cache miss.
         man.writeManifest() catch |err| {
             log.warn("failed to write cache manifest: {s}", .{@errorName(err)});
@@ -2494,7 +2519,7 @@ fn flush(comp: *Compilation, prog_node: *std.Progress.Node) !void {
     // This is needed before reading the error flags.
     comp.bin_file.flush(comp, prog_node) catch |err| switch (err) {
         error.FlushFailure => {}, // error reported through link_error_flags
-        error.LLDReportedFailure => {}, // error reported through log.err
+        error.LLDReportedFailure => {}, // error reported via lockAndParseLldStderr
         else => |e| return e,
     };
     comp.link_error_flags = comp.bin_file.errorFlags();
@@ -2727,7 +2752,7 @@ pub fn makeBinFileWritable(self: *Compilation) !void {
 /// This function is temporally single-threaded.
 pub fn totalErrorCount(self: *Compilation) usize {
     var total: usize = self.failed_c_objects.count() + self.misc_failures.count() +
-        @boolToInt(self.alloc_failure_occurred);
+        @boolToInt(self.alloc_failure_occurred) + self.lld_errors.items.len;
 
     if (self.bin_file.options.module) |module| {
         total += module.failed_exports.count();
@@ -2814,6 +2839,21 @@ pub fn getAllErrorsAlloc(self: *Compilation) !AllErrors {
                 },
             });
         }
+    }
+    for (self.lld_errors.items) |lld_error| {
+        const notes = try arena_allocator.alloc(AllErrors.Message, lld_error.context_lines.len);
+        for (lld_error.context_lines) |context_line, i| {
+            notes[i] = .{ .plain = .{
+                .msg = try arena_allocator.dupe(u8, context_line),
+            } };
+        }
+
+        try errors.append(.{
+            .plain = .{
+                .msg = try arena_allocator.dupe(u8, lld_error.msg),
+                .notes = notes,
+            },
+        });
     }
     for (self.misc_failures.values()) |*value| {
         try AllErrors.addPlainWithChildren(&arena, &errors, value.msg, value.children);
@@ -4987,6 +5027,49 @@ pub fn lockAndSetMiscFailure(
     defer comp.mutex.unlock();
 
     return setMiscFailure(comp, tag, format, args);
+}
+
+fn parseLddStderr(comp: *Compilation, comptime prefix: []const u8, stderr: []const u8) Allocator.Error!void {
+    var context_lines = std.ArrayList([]const u8).init(comp.gpa);
+    defer context_lines.deinit();
+
+    var current_err: ?*LldError = null;
+    var lines = mem.split(u8, stderr, std.cstr.line_sep);
+    while (lines.next()) |line| {
+        if (mem.startsWith(u8, line, prefix ++ ":")) {
+            if (current_err) |err| {
+                err.context_lines = context_lines.toOwnedSlice();
+            }
+
+            const duped_msg = try comp.gpa.dupe(u8, line);
+            errdefer comp.gpa.free(duped_msg);
+
+            current_err = try comp.lld_errors.addOne(comp.gpa);
+            current_err.?.* = .{ .msg = duped_msg };
+        } else if (current_err != null) {
+            const context_prefix = ">>> ";
+            var trimmed = mem.trimRight(u8, line, &std.ascii.whitespace);
+            if (mem.startsWith(u8, trimmed, context_prefix)) {
+                trimmed = trimmed[context_prefix.len..];
+            }
+
+            if (trimmed.len > 0) {
+                const duped_line = try comp.gpa.dupe(u8, trimmed);
+                try context_lines.append(duped_line);
+            }
+        }
+    }
+
+    if (current_err) |err| {
+        err.context_lines = context_lines.toOwnedSlice();
+    }
+}
+
+pub fn lockAndParseLldStderr(comp: *Compilation, comptime prefix: []const u8, stderr: []const u8) void {
+    comp.mutex.lock();
+    defer comp.mutex.unlock();
+
+    comp.parseLddStderr(prefix, stderr) catch comp.setAllocFailure();
 }
 
 pub fn dump_argv(argv: []const []const u8) void {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5044,7 +5044,7 @@ fn parseLldStderr(comp: *Compilation, comptime prefix: []const u8, stderr: []con
             var split = std.mem.split(u8, line, "error: ");
             _ = split.first();
 
-            const duped_msg = try std.fmt.allocPrint(comp.gpa, "{s}: {s}", .{ prefix, split.rest() });            
+            const duped_msg = try std.fmt.allocPrint(comp.gpa, "{s}: {s}", .{ prefix, split.rest() });
             errdefer comp.gpa.free(duped_msg);
 
             current_err = try comp.lld_errors.addOne(comp.gpa);


### PR DESCRIPTION
This fixes https://github.com/ziglang/zig/issues/13432 and https://github.com/ziglang/zig/issues/13235

There was no check for linker errors after flushing, which meant that if the link failed the build would continue, trying to copy the non-existent artifact, and also write the manifest as if it had succeeded.

I added `Compilation.lockAndParseLldStderr` to consume the stderr result of the lld call, and accumulate it in `lld_errors`. These errors are then surfaced via the same mechanism the other compilation errors are.