### PR TITLE
fix Nvptx backend outputing files at the top level of zig-cache

### DIFF
--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -193,7 +193,7 @@ pub fn binNameAlloc(allocator: std.mem.Allocator, options: BinNameOptions) error
                 target.libPrefix(), root_name,
             }),
         },
-        .nvptx => return std.fmt.allocPrint(allocator, "{s}", .{root_name}),
+        .nvptx => return std.fmt.allocPrint(allocator, "{s}.ptx", .{root_name}),
         .dxcontainer => @panic("TODO what's the file extension for these?"),
     }
 }


### PR DESCRIPTION
Something changed in the builder a bit before 0.10.0, and Nvptx.zig is currently outputing files directly at the top level of zig-cache.

This change make it outputs .ptx files inside zig-cache/o/<hash>/

Could we merge this for 0.10.1 ?