### PR TITLE
std.heap.ArenaAllocator: make State.promote more safe

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -97,7 +97,7 @@ const CAllocator = struct {
     }
 
     fn alloc(
-        _: *anyopaque,
+        _: Allocator.ImplPtr,
         len: usize,
         alignment: u29,
         len_align: u29,
@@ -123,7 +123,7 @@ const CAllocator = struct {
     }
 
     fn resize(
-        _: *anyopaque,
+        _: Allocator.ImplPtr,
         buf: []u8,
         buf_align: u29,
         new_len: usize,
@@ -145,7 +145,7 @@ const CAllocator = struct {
     }
 
     fn free(
-        _: *anyopaque,
+        _: Allocator.ImplPtr,
         buf: []u8,
         buf_align: u29,
         return_address: usize,
@@ -185,7 +185,7 @@ const raw_c_allocator_vtable = Allocator.VTable{
 };
 
 fn rawCAlloc(
-    _: *anyopaque,
+    _: Allocator.ImplPtr,
     len: usize,
     ptr_align: u29,
     len_align: u29,
@@ -199,7 +199,7 @@ fn rawCAlloc(
 }
 
 fn rawCResize(
-    _: *anyopaque,
+    _: Allocator.ImplPtr,
     buf: []u8,
     old_align: u29,
     new_len: usize,
@@ -215,7 +215,7 @@ fn rawCResize(
 }
 
 fn rawCFree(
-    _: *anyopaque,
+    _: Allocator.ImplPtr,
     buf: []u8,
     old_align: u29,
     ret_addr: usize,
@@ -257,7 +257,7 @@ const PageAllocator = struct {
         .free = free,
     };
 
-    fn alloc(_: *anyopaque, n: usize, alignment: u29, len_align: u29, ra: usize) error{OutOfMemory}![]u8 {
+    fn alloc(_: Allocator.ImplPtr, n: usize, alignment: u29, len_align: u29, ra: usize) error{OutOfMemory}![]u8 {
         _ = ra;
         assert(n > 0);
         if (n > maxInt(usize) - (mem.page_size - 1)) {
@@ -358,7 +358,7 @@ const PageAllocator = struct {
     }
 
     fn resize(
-        _: *anyopaque,
+        _: Allocator.ImplPtr,
         buf_unaligned: []u8,
         buf_align: u29,
         new_size: usize,
@@ -409,7 +409,7 @@ const PageAllocator = struct {
         return null;
     }
 
-    fn free(_: *anyopaque, buf_unaligned: []u8, buf_align: u29, return_address: usize) void {
+    fn free(_: Allocator.ImplPtr, buf_unaligned: []u8, buf_align: u29, return_address: usize) void {
         _ = buf_align;
         _ = return_address;
 
@@ -521,7 +521,7 @@ const WasmPageAllocator = struct {
         return mem.alignForward(memsize, mem.page_size) / mem.page_size;
     }
 
-    fn alloc(_: *anyopaque, len: usize, alignment: u29, len_align: u29, ra: usize) error{OutOfMemory}![]u8 {
+    fn alloc(_: Allocator.ImplPtr, len: usize, alignment: u29, len_align: u29, ra: usize) error{OutOfMemory}![]u8 {
         _ = ra;
         if (len > maxInt(usize) - (mem.page_size - 1)) {
             return error.OutOfMemory;
@@ -579,7 +579,7 @@ const WasmPageAllocator = struct {
     }
 
     fn resize(
-        _: *anyopaque,
+        _: Allocator.ImplPtr,
         buf: []u8,
         buf_align: u29,
         new_len: usize,
@@ -600,7 +600,7 @@ const WasmPageAllocator = struct {
     }
 
     fn free(
-        _: *anyopaque,
+        _: Allocator.ImplPtr,
         buf: []u8,
         buf_align: u29,
         return_address: usize,

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -151,11 +151,11 @@ const fail_allocator = Allocator{
 
 const failAllocator_vtable = Allocator.VTable{
     .alloc = failAllocatorAlloc,
-    .resize = Allocator.NoResize(anyopaque).noResize,
-    .free = Allocator.NoOpFree(anyopaque).noOpFree,
+    .resize = Allocator.NoResize(null).noResize,
+    .free = Allocator.NoOpFree(null).noOpFree,
 };
 
-fn failAllocatorAlloc(_: *anyopaque, n: usize, alignment: u29, len_align: u29, ra: usize) Allocator.Error![]u8 {
+fn failAllocatorAlloc(_: Allocator.ImplPtr, n: usize, alignment: u29, len_align: u29, ra: usize) Allocator.Error![]u8 {
     _ = n;
     _ = alignment;
     _ = len_align;

--- a/lib/std/os/uefi/pool_allocator.zig
+++ b/lib/std/os/uefi/pool_allocator.zig
@@ -32,7 +32,7 @@ const UefiPoolAllocator = struct {
     }
 
     fn alloc(
-        _: *anyopaque,
+        _: Allocator.ImplPtr,
         len: usize,
         ptr_align: u29,
         len_align: u29,
@@ -52,7 +52,7 @@ const UefiPoolAllocator = struct {
     }
 
     fn resize(
-        _: *anyopaque,
+        _: Allocator.ImplPtr,
         buf: []u8,
         buf_align: u29,
         new_len: usize,
@@ -66,7 +66,7 @@ const UefiPoolAllocator = struct {
     }
 
     fn free(
-        _: *anyopaque,
+        _: Allocator.ImplPtr,
         buf: []u8,
         buf_align: u29,
         ret_addr: usize,
@@ -103,7 +103,7 @@ const raw_pool_allocator_table = Allocator.VTable{
 };
 
 fn uefi_alloc(
-    _: *anyopaque,
+    _: Allocator.ImplPtr,
     len: usize,
     ptr_align: u29,
     len_align: u29,
@@ -124,7 +124,7 @@ fn uefi_alloc(
 }
 
 fn uefi_resize(
-    _: *anyopaque,
+    _: Allocator.ImplPtr,
     buf: []u8,
     old_align: u29,
     new_len: usize,
@@ -142,7 +142,7 @@ fn uefi_resize(
 }
 
 fn uefi_free(
-    _: *anyopaque,
+    _: Allocator.ImplPtr,
     buf: []u8,
     buf_align: u29,
     ret_addr: usize,

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -5519,9 +5519,7 @@ pub fn analyzeFnBody(mod: *Module, func: *Fn, arena: Allocator) SemaError!Air {
     const decl = mod.declPtr(decl_index);
 
     // Use the Decl's arena for captured values.
-    var decl_arena = decl.value_arena.?.promote(gpa);
-    defer decl.value_arena.?.* = decl_arena.state;
-    const decl_arena_allocator = decl_arena.allocator();
+    const decl_arena_allocator = decl.value_arena.?.promote(gpa).allocator();
 
     var sema: Sema = .{
         .mod = mod,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2709,9 +2709,7 @@ fn zirEnumDecl(
     const decl_val = try sema.analyzeDeclVal(block, src, new_decl_index);
     done = true;
 
-    var decl_arena = new_decl.value_arena.?.promote(gpa);
-    defer new_decl.value_arena.?.* = decl_arena.state;
-    const decl_arena_allocator = decl_arena.allocator();
+    const decl_arena_allocator = new_decl.value_arena.?.promote(gpa).allocator();
 
     extra_index = try mod.scanNamespace(&enum_obj.namespace, extra_index, decls_len, new_decl);
 
@@ -25710,7 +25708,10 @@ const ComptimePtrMutationKit = struct {
 
     fn beginArena(self: *ComptimePtrMutationKit, mod: *Module) Allocator {
         const decl = mod.declPtr(self.decl_ref_mut.decl_index);
-        self.decl_arena = decl.value_arena.?.promote(mod.gpa);
+        self.decl_arena = .{
+            .child_allocator = mod.gpa,
+            .state = decl.value_arena.?.*,
+        };
         return self.decl_arena.allocator();
     }
 
@@ -29116,9 +29117,7 @@ fn semaBackingIntType(mod: *Module, struct_obj: *Module.Struct) CompileError!voi
 
     const decl_index = struct_obj.owner_decl;
     const decl = mod.declPtr(decl_index);
-    var decl_arena = decl.value_arena.?.promote(gpa);
-    defer decl.value_arena.?.* = decl_arena.state;
-    const decl_arena_allocator = decl_arena.allocator();
+    const decl_arena_allocator = decl.value_arena.?.promote(gpa).allocator();
 
     const zir = struct_obj.namespace.file_scope.zir;
     const extended = zir.instructions.items(.data)[struct_obj.zir_index].extended;
@@ -29555,9 +29554,7 @@ fn semaStructFields(mod: *Module, struct_obj: *Module.Struct) CompileError!void 
     }
 
     const decl = mod.declPtr(decl_index);
-    var decl_arena = decl.value_arena.?.promote(gpa);
-    defer decl.value_arena.?.* = decl_arena.state;
-    const decl_arena_allocator = decl_arena.allocator();
+    const decl_arena_allocator = decl.value_arena.?.promote(gpa).allocator();
 
     var analysis_arena = std.heap.ArenaAllocator.init(gpa);
     defer analysis_arena.deinit();
@@ -29852,10 +29849,7 @@ fn semaUnionFields(mod: *Module, union_obj: *Module.Union) CompileError!void {
     extra_index += body.len;
 
     const decl = mod.declPtr(decl_index);
-
-    var decl_arena = decl.value_arena.?.promote(gpa);
-    defer decl.value_arena.?.* = decl_arena.state;
-    const decl_arena_allocator = decl_arena.allocator();
+    const decl_arena_allocator = decl.value_arena.?.promote(gpa).allocator();
 
     var analysis_arena = std.heap.ArenaAllocator.init(gpa);
     defer analysis_arena.deinit();

--- a/test/cases/compile_errors/dereference_anyopaque.zig
+++ b/test/cases/compile_errors/dereference_anyopaque.zig
@@ -1,55 +1,20 @@
-const std = @import("std");
-
-const Error = error{Something};
-
-fn next() Error!void {
-    return;
-}
-
-fn parse(comptime T: type, allocator: std.mem.Allocator) !void {
-    parseFree(T, undefined, allocator);
-    _ = (try next()) != null;
-}
-
-fn parseFree(comptime T: type, value: T, allocator: std.mem.Allocator) void {
-    switch (@typeInfo(T)) {
-        .Struct => |structInfo| {
-            inline for (structInfo.fields) |field| {
-                if (!field.is_comptime)
-                    parseFree(field.field_type, undefined, allocator);
-            }
-        },
-        .Pointer => |ptrInfo| {
-            switch (ptrInfo.size) {
-                .One => {
-                    parseFree(ptrInfo.child, value.*, allocator);
-                },
-                .Slice => {
-                    for (value) |v|
-                        parseFree(ptrInfo.child, v, allocator);
-                },
-                else => unreachable,
-            }
-        },
-        else => unreachable,
-    }
-}
-
 pub export fn entry() void {
-    const allocator = std.testing.failing_allocator;
-    _ = parse(std.StringArrayHashMap(bool), allocator) catch return;
+    inline for (&[_]type{
+        u8,
+        u16,
+        struct {},
+        anyopaque,
+    }) |T| deref(T);
+}
+
+fn deref(comptime T: type) void {
+    var runtime: *T = undefined;
+    _ = runtime.*;
 }
 
 // error
 // target=native
 // backend=llvm
 //
-// :11:22: error: comparison of 'void' with null
-// :25:51: error: values of type 'anyopaque' must be comptime-known, but operand value is runtime-known
-// :25:51: note: opaque type 'anyopaque' has undefined size
-// :25:51: error: values of type 'fn(*anyopaque, usize, u29, u29, usize) error{OutOfMemory}![]u8' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn(*anyopaque, usize, u29, u29, usize) error{OutOfMemory}![]u8' for a function pointer type
-// :25:51: error: values of type 'fn(*anyopaque, []u8, u29, usize, u29, usize) ?usize' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn(*anyopaque, []u8, u29, usize, u29, usize) ?usize' for a function pointer type
-// :25:51: error: values of type 'fn(*anyopaque, []u8, u29, usize) void' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn(*anyopaque, []u8, u29, usize) void' for a function pointer type
+// :12:16: error: values of type 'anyopaque' must be comptime-known, but operand value is runtime-known
+// :12:16: note: opaque type 'anyopaque' has undefined size


### PR DESCRIPTION
Previously, std.heap.ArenaAllocator.State.promote required the user to manually copy the arena state back to the original pointer when done with it. The original state also couldn't be used elsewhere until it was copied back. This was a clear footgun, as it's a very easy detail to miss and forgetting to do it would likely cause strange memory corruption issues which could be hard to track down. Now, promote returns a new structure containing a pointer to the original state, and this pointer is mutated whenever an operation is performed through its allocator, removing this footgun.

To have a nice API, the returned Promoted struct can be referenced only through const pointers, since the struct itself never needs to be mutated. This allows the direct usage 'state.promote().allocator()' to work safely. However, previously, the std.mem.Allocator API didn't allow a way to do this without resorting to hacks like @ptrToInt, as the type-erased pointer was stored internally as a *anyopaque. Therefore, the definition of Allocator has also been modified to allow storing const pointers through a union. This required a few changes to std, but nothing should be hugely breaking.