### PR TITLE
cache: Fix LockViolation during C compilation paths

### DIFF
--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -233,7 +233,7 @@ pub const Lock = struct {
 
     pub fn release(lock: *Lock) void {
         if (builtin.os.tag == .windows) {
-            // Windows does not guarantee that locks are immediately unlocked when 
+            // Windows does not guarantee that locks are immediately unlocked when
             // the file handle is closed. See: LockFileEx documentation.
             lock.manifest_file.unlock();
         }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3596,6 +3596,7 @@ pub fn cImport(comp: *Compilation, c_src: []const u8) !CImportResult {
     const cimport_zig_basename = "cimport.zig";
 
     var man = comp.obtainCObjectCacheManifest();
+    man.want_shared_lock = false;
     defer man.deinit();
 
     const use_stage1 = build_options.have_stage1 and comp.bin_file.options.use_stage1;
@@ -3713,6 +3714,7 @@ pub fn cImport(comp: *Compilation, c_src: []const u8) !CImportResult {
     // possible we had a hit and the manifest is dirty, for example if the file mtime changed but
     // the contents were the same, we hit the cache but the manifest is dirty and we need to update
     // it to prevent doing a full file content comparison the next time around.
+    man.want_shared_lock = true;
     man.writeManifest() catch |err| {
         log.warn("failed to write cache manifest for C import: {s}", .{@errorName(err)});
     };
@@ -3887,6 +3889,7 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.P
     }
 
     var man = comp.obtainCObjectCacheManifest();
+    man.want_shared_lock = false;
     defer man.deinit();
 
     man.hash.add(comp.clang_preprocessor_mode);
@@ -4182,6 +4185,7 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.P
     // possible we had a hit and the manifest is dirty, for example if the file mtime changed but
     // the contents were the same, we hit the cache but the manifest is dirty and we need to update
     // it to prevent doing a full file content comparison the next time around.
+    man.want_shared_lock = true;
     man.writeManifest() catch |err| {
         log.warn("failed to write cache manifest when compiling '{s}': {s}", .{ c_object.src.src_path, @errorName(err) });
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -3454,6 +3454,7 @@ fn cmdTranslateC(comp: *Compilation, arena: Allocator, enable_cache: bool, stage
     const translated_zig_basename = try std.fmt.allocPrint(arena, "{s}.zig", .{comp.bin_file.options.root_name});
 
     var man: Cache.Manifest = comp.obtainCObjectCacheManifest();
+    man.want_shared_lock = false;
     defer if (enable_cache) man.deinit();
 
     man.hash.add(@as(u16, 0xb945)); // Random number to distinguish translate-c from compiling C objects


### PR DESCRIPTION
This fixes https://github.com/ziglang/zig/issues/12718.

### Summary
- C compilation flows didn't hold an exclusive lock on the cache manifest file when writing to it in all cases
- On windows, explicitly unlock the file lock before closing it

### Context

At first I though this was related to locks not being released, since the LockFileEx documenation mentions:

> If a process terminates with a portion of a file locked or closes a file that has outstanding locks, the locks are unlocked by the operating system. However, the time it takes for the operating system to unlock these locks depends upon available system resources. Therefore, it is recommended that your process explicitly unlock all files it has locked when it terminates. If this is not done, access to these files may be denied if the operating system has not yet unlocked them.

This seems like a case we should handle, so I added an explicit unlock on windows. However, examining the trace in procmon revealed the actual issue:

![zig_cache](https://user-images.githubusercontent.com/74892/202841539-976e3c81-83f7-44dc-9b5b-b8754489eadc.PNG)

On Windows, the file locks actually lock the range of the file (vs flock which is just advisory). The manifest write was failing because at that point the lock has been downgraded to shared (read only), and it actually blocks the attempted write. This revealed the actual bug which is that the manifest should have been locked exclusively until the manifest was written, and at that point it can be downgraded to shared.

The specific pattern to trigger this is outlined in #12718:

1. Complete a build where a cimport compiles succesfully. This creates the manifest file.
2. Change the c code so the cimport compile fails, and build again. The manifest is read but not written due to the failure.
3. Change the c code back, and recompile. This triggers the `LockViolation` as the manifest needs to be written, and we were only holding a shared lock.

