### PR TITLE
fix x86_64 C ABI

### DIFF
--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -851,8 +851,6 @@ pub inline fn expectOk(c_err: c_int) !void {
 /// Tests for Double + Char struct
 const DC = extern struct { v1: f64, v2: u8 };
 test "DC: Zig passes to C" {
-    if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows)
-        return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
@@ -866,8 +864,6 @@ test "DC: Zig returns to C" {
     try expectOk(c_assert_ret_DC());
 }
 test "DC: C passes to Zig" {
-    if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows)
-        return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -896,8 +896,7 @@ pub export fn zig_ret_DC() DC {
 const CFF = extern struct { v1: u8, v2: f32, v3: f32 };
 
 test "CFF: Zig passes to C" {
-    if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
-        return error.SkipZigTest;
+    if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
@@ -910,8 +909,7 @@ test "CFF: Zig returns to C" {
     try expectOk(c_assert_ret_CFF());
 }
 test "CFF: C passes to Zig" {
-    if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
-        return error.SkipZigTest;
+    if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
@@ -946,8 +944,7 @@ pub export fn zig_ret_CFF() CFF {
 const PD = extern struct { v1: ?*anyopaque, v2: f64 };
 
 test "PD: Zig passes to C" {
-    if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
-        return error.SkipZigTest;
+    if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
@@ -960,8 +957,7 @@ test "PD: Zig returns to C" {
     try expectOk(c_assert_ret_PD());
 }
 test "PD: C passes to Zig" {
-    if (builtin.target.cpu.arch.isX86() and builtin.target.os.tag != .windows)
-        return error.SkipZigTest;
+    if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;


### PR DESCRIPTION
follow up on https://github.com/ziglang/zig/pull/13376

(note I originally copy pasted the wrong part of the IR...)

For the `C_C_D = extern struct { v1: i8, v2: i8, v3: f64 }` struct
Clang generates the following IR:

```
; Function Attrs: noinline nounwind optnone uwtable
define dso_local i32 @assert_C_C_D(i64 %0, double %1) #0 !dbg !10 {
  %3 = alloca %struct.C_C_D, align 8
  %4 = alloca i32, align 4
  %5 = getelementptr inbounds { i64, double }, ptr %3, i32 0, i32 0
  store i64 %0, ptr %5, align 8
  %6 = getelementptr inbounds { i64, double }, ptr %3, i32 0, i32 1
  store double %1, ptr %6, align 8
```

Zig:

```
%struct.C_C_D = type { i8, i8, [6 x i8], double }

; Function Attrs: nounwind
define dso_local i32 @zig_assert_C_C_D(i64 %0, i64 %1) #0 !dbg !32 {
Entry:
  %2 = alloca i32, align 4
  %3 = alloca %example.C_C_D, align 8
  %4 = getelementptr inbounds { i64, i64 }, ptr %3, i32 0, i32 0
  store i64 %0, ptr %4, align 8
  %5 = getelementptr inbounds { i64, i64 }, ptr %3, i32 0, i32 1
  store i64 %1, ptr %5, align 8

}
```

The main difference is that the Clang reads the arguments with a `load {i64, double}` which reads from an integer register and a float register, while Zig reads with `load {i64, i64}` which reads from two integer registers.

I was first looking into the `classifySystemV` but I came under the impression the logic there was correct.
But @Vexu pointed me to the llvm backend where the codegen for function call is using `.multiple_llvm_ints` and `.multiple_llvm_ints` to handle complex struct.
Which doesn't work for struct with mixed floats and ints.
This PR replaces those enums by `multiple_llvm_types` and  in `ParamTypeIterator` instead of returning the size of the types we directly return a pointer to the corresponding LLVM type (which we need just after anyway).

With this PR I can run the 9420 tests in https://github.com/gwenzek/llvm-test-suite/ on x86_64-linux. 
The tests suite only has relatively small structs with up to 3 fields, I think we could increase it by generating larger ones.

@Vexu @topolarity for review.