### PR TITLE
parser: detect mismatched/misleading indentation

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -375,6 +375,16 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
                 }),
             }
         },
+
+        .mismatched_indentation => {
+            return stream.writeAll("statement indentation mismatched with siblings");
+        },
+        .outdented_block => {
+            return stream.writeAll("block is outdented from surrounding block");
+        },
+        .previous_indentation => {
+            return stream.writeAll("previous indentation level set here");
+        },
     }
 }
 
@@ -2608,6 +2618,9 @@ pub const Error = struct {
         c_style_container,
         expected_var_const,
         wrong_equal_var_decl,
+        mismatched_indentation,
+        outdented_block,
+        previous_indentation,
 
         zig_style_container,
         previous_field,

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -39,6 +39,7 @@ pub fn parse(gpa: Allocator, source: [:0]const u8) Allocator.Error!Ast {
         .extra_data = .{},
         .scratch = .{},
         .tok_i = 0,
+        .current_block_indent_defining_token = 0,
     };
     defer parser.errors.deinit(gpa);
     defer parser.nodes.deinit(gpa);
@@ -90,6 +91,7 @@ const Parser = struct {
     nodes: Ast.NodeList,
     extra_data: std.ArrayListUnmanaged(Node.Index),
     scratch: std.ArrayListUnmanaged(Node.Index),
+    current_block_indent_defining_token: TokenIndex,
 
     const SmallSpan = union(enum) {
         zero_or_one: Node.Index,
@@ -245,6 +247,8 @@ const Parser = struct {
     ///      /
     /// TopLevelComptime <- KEYWORD_comptime Block
     fn parseContainerMembers(p: *Parser) !Members {
+        p.current_block_indent_defining_token = 0;
+
         const scratch_top = p.scratch.items.len;
         defer p.scratch.shrinkRetainingCapacity(scratch_top);
 
@@ -2018,15 +2022,64 @@ const Parser = struct {
     /// Block <- LBRACE Statement* RBRACE
     fn parseBlock(p: *Parser) !Node.Index {
         const lbrace = p.eatToken(.l_brace) orelse return null_node;
+
         const scratch_top = p.scratch.items.len;
         defer p.scratch.shrinkRetainingCapacity(scratch_top);
+
+        const parent_block_tok = p.current_block_indent_defining_token;
+        defer p.current_block_indent_defining_token = parent_block_tok;
+        const parent_indent = p.tokenColumn(parent_block_tok);
+
+        var prev_tok = lbrace;
+        var sibling: ?struct { indent: u32, tok: TokenIndex } = null;
         while (true) {
             if (p.token_tags[p.tok_i] == .r_brace) break;
+
+            // In the case that this statement opens a block (if, while, comptime, etc.),
+            // track the first token so the error message points to the offending position.
+            const stmt_tok = p.tok_i;
+            p.current_block_indent_defining_token = stmt_tok;
+
             const statement = try p.expectStatementRecoverable();
             if (statement == 0) break;
+
+            if (!p.tokensOnSameLine(prev_tok, stmt_tok)) {
+                const col = p.tokenColumn(stmt_tok);
+                if (sibling) |sib| {
+                    // Indentation mismatched with siblings
+                    if (col != sib.indent) {
+                        try p.warnMsg(.{
+                            .tag = .mismatched_indentation,
+                            .token = stmt_tok,
+                        });
+                        try p.warnMsg(.{
+                            .tag = .previous_indentation,
+                            .is_note = true,
+                            .token = sib.tok,
+                        });
+                    }
+                } else if (col < parent_indent) {
+                    // New block outdented from parent
+                    try p.warnMsg(.{
+                        .tag = .outdented_block,
+                        .token = stmt_tok,
+                    });
+                    try p.warnMsg(.{
+                        .tag = .previous_indentation,
+                        .is_note = true,
+                        .token = parent_block_tok,
+                    });
+                } else {
+                    // First statement on a new line defines the sibling indent level
+                    sibling = .{ .indent = p.tokenColumn(stmt_tok), .tok = stmt_tok };
+                }
+            }
+            prev_tok = stmt_tok;
+
             try p.scratch.append(p.gpa, statement);
         }
         _ = try p.expectToken(.r_brace);
+
         const semicolon = (p.token_tags[p.tok_i - 2] == .semicolon);
         const statements = p.scratch.items[scratch_top..];
         switch (statements.len) {
@@ -3754,6 +3807,17 @@ const Parser = struct {
 
     fn tokensOnSameLine(p: *Parser, token1: TokenIndex, token2: TokenIndex) bool {
         return std.mem.indexOfScalar(u8, p.source[p.token_starts[token1]..p.token_starts[token2]], '\n') == null;
+    }
+
+    fn tokenColumn(p: *Parser, token: TokenIndex) u32 {
+        var i = p.token_starts[token];
+        while (i > 0) : (i -= 1) {
+            if (p.source[i] == '\n') {
+                i += 1;
+                break;
+            }
+        }
+        return p.token_starts[token] - i;
     }
 
     fn eatToken(p: *Parser, tag: Token.Tag) ?TokenIndex {


### PR DESCRIPTION
Fixes #35

> If any line in a block has indentation, then all lines in the block must have the same indentation.
>
> Additionally, the indentation level of a block must be greater than or equal to indentation level of the parent block.

In the spirit of alerting the author to ambiguities or mistakes instead of presumptively fixing it, I added this to the parsing phase. This is similar to how mismatched whitespace around binary operators causes a parse error instead of being reformatted.

## Notes

The original issue is light on details, but my interpretation is that potential programmer mistakes arise from sequences of statements, not container decls. So I made this indentation error totally independent **per container**. Blocks are only considered relative to its container; a sub-container and its contents may be out-dented relative to its parent.

If it is better to have statements in nested containers require monotonic indentation, that is an easy fix, just let me know!

This feature also ignores decls and fields, since that is not likely a source of ambiguity/bugs.

This adds one new field to `Parser`.