### PR TITLE
Cache.zig: add missing errdefer

### DIFF
--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -222,6 +222,7 @@ pub const Manifest = struct {
 
         try self.files.ensureUnusedCapacity(self.cache.gpa, 1);
         const resolved_path = try fs.path.resolve(self.cache.gpa, &[_][]const u8{file_path});
+        errdefer self.cache.gpa.free(resolved_path);
 
         const idx = self.files.items.len;
         self.files.addOneAssumeCapacity().* = .{


### PR DESCRIPTION
This was meant to be fixed in #13051, but that PR was closed; so I am porting the fix in isolation here.