### PR TITLE
uefi: Delete unneeded alignment and use default 4K

### DIFF
--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -383,7 +383,6 @@ pub fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
                 "-OPT:REF",
                 "-SAFESEH:NO",
                 "-MERGE:.rdata=.data",
-                "-ALIGN:32",
                 "-NODEFAULTLIB",
                 "-SECTION:.xdata,D",
             }),


### PR DESCRIPTION
Closes #7484.

Right now for UEFI targets an alignment of 32 is being used for no reason other than support a rare bytecode. As this is far from the standard case, removing this alignment and using the default one, as most toolchains do, should be the desired behavior.