### PR TITLE
value: account for undef value for ptr in slice in hashUncoerced

### DIFF
--- a/src/value.zig
+++ b/src/value.zig
@@ -2573,7 +2573,12 @@ pub const Value = extern union {
             },
             .Float, .ComptimeFloat => std.hash.autoHash(hasher, @bitCast(u128, val.toFloat(f128))),
             .Bool, .Int, .ComptimeInt, .Pointer, .Fn => switch (val.tag()) {
-                .slice => val.castTag(.slice).?.data.ptr.hashPtr(hasher, mod.getTarget()),
+                .slice => {
+                    const slice = val.castTag(.slice).?.data;
+                    var ptr_buf: Type.SlicePtrFieldTypeBuffer = undefined;
+                    const ptr_ty = ty.slicePtrFieldType(&ptr_buf);
+                    slice.ptr.hashUncoerced(ptr_ty, hasher, mod);
+                },
                 else => val.hashPtr(hasher, mod.getTarget()),
             },
             .Array, .Vector => {


### PR DESCRIPTION
This patch fixes #13615 for me. I have based it on what we do in `fn hash(...)`, however, I wasn't sure if we should also hash the slices length given that we are doing partial hashes as this is `fn hashUncoerced(...)` so I would definitely appreciate a thorough review.

cc @jacobly0