### PR TITLE
AstGen: Pop error trace for `continue`

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -2071,6 +2071,11 @@ fn continueExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) 
                 if (break_tag == .break_inline) {
                     _ = try parent_gz.addUnNode(.check_comptime_control_flow, Zir.indexToRef(continue_block), node);
                 }
+
+                // As our last action before the continue, "pop" the error trace if needed
+                if (!gen_zir.force_comptime)
+                    _ = try parent_gz.addRestoreErrRetIndex(.{ .block = continue_block }, .always);
+
                 _ = try parent_gz.addBreak(break_tag, continue_block, .void_value);
                 return Zir.Inst.Ref.unreachable_value;
             },

--- a/test/stack_traces.zig
+++ b/test/stack_traces.zig
@@ -152,6 +152,57 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
     });
 
     cases.addCase(.{
+        .name = "continue in while loop",
+        .source = 
+        \\fn foo() !void {
+        \\    return error.UhOh;
+        \\}
+        \\
+        \\pub fn main() !void {
+        \\    var i: usize = 0;
+        \\    while (i < 3) : (i += 1) {
+        \\        foo() catch continue;
+        \\    }
+        \\    return error.UnrelatedError;
+        \\}
+        ,
+        .Debug = .{
+            .expect = 
+            \\error: UnrelatedError
+            \\source.zig:10:5: [address] in main (test)
+            \\    return error.UnrelatedError;
+            \\    ^
+            \\
+            ,
+        },
+        .ReleaseSafe = .{
+            .exclude_os = .{
+                .windows, // TODO
+                .linux, // defeated by aggressive inlining
+            },
+            .expect = 
+            \\error: UnrelatedError
+            \\source.zig:10:5: [address] in [function]
+            \\    return error.UnrelatedError;
+            \\    ^
+            \\
+            ,
+        },
+        .ReleaseFast = .{
+            .expect = 
+            \\error: UnrelatedError
+            \\
+            ,
+        },
+        .ReleaseSmall = .{
+            .expect = 
+            \\error: UnrelatedError
+            \\
+            ,
+        },
+    });
+
+    cases.addCase(.{
         .name = "try return + handled catch/if-else",
         .source = 
         \\fn foo() !void {


### PR DESCRIPTION
Thanks to @squeek502 for the bug report!

Resolves #13618.