### PR TITLE
On std.os.sendfile, return error rather than unreachable on brokenPipe condition

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -6028,7 +6028,7 @@ pub fn sendfile(
                     .BADF => unreachable, // Always a race condition.
                     .FAULT => unreachable, // Segmentation fault.
                     .OVERFLOW => unreachable, // We avoid passing too large of a `count`.
-                    .NOTCONN => unreachable, // `out_fd` is an unconnected socket.
+                    .NOTCONN => return error.BrokenPipe, // `out_fd` is an unconnected socket
 
                     .INVAL, .NOSYS => {
                         // EINVAL could be any of the following situations:
@@ -6096,7 +6096,7 @@ pub fn sendfile(
 
                     .BADF => unreachable, // Always a race condition.
                     .FAULT => unreachable, // Segmentation fault.
-                    .NOTCONN => unreachable, // `out_fd` is an unconnected socket.
+                    .NOTCONN => return error.BrokenPipe, // `out_fd` is an unconnected socket
 
                     .INVAL, .OPNOTSUPP, .NOTSOCK, .NOSYS => {
                         // EINVAL could be any of the following situations:
@@ -6178,7 +6178,7 @@ pub fn sendfile(
                     .BADF => unreachable, // Always a race condition.
                     .FAULT => unreachable, // Segmentation fault.
                     .INVAL => unreachable,
-                    .NOTCONN => unreachable, // `out_fd` is an unconnected socket.
+                    .NOTCONN => return error.BrokenPipe, // `out_fd` is an unconnected socket
 
                     .OPNOTSUPP, .NOTSOCK, .NOSYS => break :sf,
 
@@ -6472,7 +6472,7 @@ pub fn recvfrom(
                 .BADF => unreachable, // always a race condition
                 .FAULT => unreachable,
                 .INVAL => unreachable,
-                .NOTCONN => unreachable,
+                .NOTCONN => return error.SocketNotConnected,
                 .NOTSOCK => unreachable,
                 .INTR => continue,
                 .AGAIN => return error.WouldBlock,


### PR DESCRIPTION
Problem :  

Having a simple loop that does this -
sock = accept()
.. do stuff
std.os.sendfile(sock, ...)

It is possible for accept() to return a valid socket fd, but the socket can disconnect before the sendfile starts or completes.
Current handling of this in std.os is to call unreachable ... which in turns kills the server app.

Other code in the same file handles the .NOTCONN condition by returning a SocketNotConnected (for Recv errors) or BrokenPipe (for write errors where the connection dies)

This patch changes the handling of the .NOTCONN condition on std.os.sendfile() to return error.BrokenPipe rather than doing a panic / unreachable.

Testing:

Naiive test - run an app that does the simple loop, and hammer it with a flood of requests. Observe that it panics shortly into the flood.

Rebuild the app using a modified std lib (from this patch), and repeat the test. Observe that the app correctly reports 'error BrokenPipe', and continues processing requests correctly.

Difficult to create an automated test for this. 