### PR TITLE
Skip linker tests requiring symlinks on Windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -88,7 +88,7 @@ pub fn build(b: *Builder) !void {
         "Whether LLVM has the experimental target arc enabled",
     ) orelse false;
     const enable_macos_sdk = b.option(bool, "enable-macos-sdk", "Run tests requiring presence of macOS SDK and frameworks") orelse false;
-    const enable_symlinks_windows = b.option(bool, "enable-symlinks-windows", "Enable using symlinks on Windows. If this is not set, hardlinks are used.") orelse false;
+    const enable_symlinks_windows = b.option(bool, "enable-symlinks-windows", "Run tests requiring presence of symlinks on Windows") orelse false;
     const config_h_path_option = b.option([]const u8, "config_h", "Path to the generated config.h");
 
     if (!skip_install_lib_files) {

--- a/build.zig
+++ b/build.zig
@@ -88,6 +88,7 @@ pub fn build(b: *Builder) !void {
         "Whether LLVM has the experimental target arc enabled",
     ) orelse false;
     const enable_macos_sdk = b.option(bool, "enable-macos-sdk", "Run tests requiring presence of macOS SDK and frameworks") orelse false;
+    const enable_symlinks_windows = b.option(bool, "enable-symlinks-windows", "Enable using symlinks on Windows. If this is not set, hardlinks are used.") orelse false;
     const config_h_path_option = b.option([]const u8, "config_h", "Path to the generated config.h");
 
     if (!skip_install_lib_files) {
@@ -519,9 +520,10 @@ pub fn build(b: *Builder) !void {
         b.enable_rosetta,
         b.enable_wasmtime,
         b.enable_wine,
+        enable_symlinks_windows,
     ));
     test_step.dependOn(tests.addCAbiTests(b, skip_non_native));
-    test_step.dependOn(tests.addLinkTests(b, test_filter, modes, enable_macos_sdk, skip_stage2_tests));
+    test_step.dependOn(tests.addLinkTests(b, test_filter, modes, enable_macos_sdk, skip_stage2_tests, enable_symlinks_windows));
     test_step.dependOn(tests.addStackTraceTests(b, test_filter, modes));
     test_step.dependOn(tests.addCliTests(b, test_filter, modes));
     test_step.dependOn(tests.addAssembleAndLinkTests(b, test_filter, modes));

--- a/ci/windows/build.ps1
+++ b/ci/windows/build.ps1
@@ -49,7 +49,8 @@ Write-Output " zig build test docs..."
 & "$ZIGINSTALLDIR\bin\zig.exe" build test docs `
     --search-prefix "$ZIGPREFIXPATH" `
     -Dstatic-llvm `
-    -Dskip-non-native
+    -Dskip-non-native `
+    -Denable-symlinks-windows
 CheckLastExitCode
 
 # Produce the experimental std lib documentation.

--- a/test/link.zig
+++ b/test/link.zig
@@ -120,7 +120,7 @@ fn addMachOCases(cases: *tests.StandaloneContext) void {
         .build_modes = true,
         .requires_macos_sdk = true,
         .requires_symlinks = true,
-   });
+    });
 
     cases.addBuildFile("test/link/macho/linksection/build.zig", .{
         .build_modes = true,

--- a/test/link.zig
+++ b/test/link.zig
@@ -82,83 +82,102 @@ fn addMachOCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/link/macho/bugs/13056/build.zig", .{
         .build_modes = true,
         .requires_macos_sdk = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/bugs/13457/build.zig", .{
         .build_modes = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/dead_strip/build.zig", .{
         .build_modes = false,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/dead_strip_dylibs/build.zig", .{
         .build_modes = true,
         .requires_macos_sdk = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/dylib/build.zig", .{
         .build_modes = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/empty/build.zig", .{
         .build_modes = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/entry/build.zig", .{
         .build_modes = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/headerpad/build.zig", .{
         .build_modes = true,
         .requires_macos_sdk = true,
-    });
+        .requires_symlinks = true,
+   });
 
     cases.addBuildFile("test/link/macho/linksection/build.zig", .{
         .build_modes = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/needed_framework/build.zig", .{
         .build_modes = true,
         .requires_macos_sdk = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/needed_library/build.zig", .{
         .build_modes = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/objc/build.zig", .{
         .build_modes = true,
         .requires_macos_sdk = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/objcpp/build.zig", .{
         .build_modes = true,
         .requires_macos_sdk = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/pagezero/build.zig", .{
         .build_modes = false,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/search_strategy/build.zig", .{
         .build_modes = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/stack_size/build.zig", .{
         .build_modes = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/tls/build.zig", .{
         .build_modes = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/weak_library/build.zig", .{
         .build_modes = true,
+        .requires_symlinks = true,
     });
 
     cases.addBuildFile("test/link/macho/weak_framework/build.zig", .{
         .build_modes = true,
         .requires_macos_sdk = true,
+        .requires_symlinks = true,
     });
 }


### PR DESCRIPTION
Symlinks aren't available on Windows unless developer mode is enabled, or the user has a certain permission.

Running test-link before this change would result in this:

```
error: AccessDenied
C:\cygwin64\home\kcbanner\kit\zig\build-stage3-debug\lib\zig\std\os\windows.zig:220:32: 0x7ff765cd841f in DeviceIoControl (build.exe.obj)
        .PRIVILEGE_NOT_HELD => return error.AccessDenied,
                               ^
C:\cygwin64\home\kcbanner\kit\zig\build-stage3-debug\lib\zig\std\os\windows.zig:741:9: 0x7ff765cbaa6d in CreateSymbolicLink (build.exe.obj)
    _ = try DeviceIoControl(symlink_handle, FSCTL_SET_REPARSE_POINT, buffer[0..buf_len], null);
        ^
C:\cygwin64\home\kcbanner\kit\zig\build-stage3-debug\lib\zig\std\fs.zig:1997:9: 0x7ff765cba207 in symLinkW (build.exe.obj)
        return os.windows.CreateSymbolicLink(self.fd, sym_link_path_w, target_path_w, flags.is_directory);
        ^
C:\cygwin64\home\kcbanner\kit\zig\build-stage3-debug\lib\zig\std\fs.zig:1957:13: 0x7ff765cba194 in symLink (build.exe.obj)
            return self.symLinkW(target_path_w.span(), sym_link_path_w.span(), flags);
            ^
C:\cygwin64\home\kcbanner\kit\zig\build-stage3-debug\lib\zig\std\fs.zig:96:17: 0x7ff765cbabce in atomicSymLink (build.exe.obj)
        else => return err, // TODO zig should know this set does not include PathAlreadyExists
                ^
C:\cygwin64\home\kcbanner\kit\zig\build-stage3-debug\lib\zig\std\build.zig:3690:9: 0x7ff765cbbf22 in doAtomicSymLinks (build.exe.obj)
```

This adds `requires_symlink` and sets it for the linker tests that use symlinks (just macho currently).

I was trying to find a way to use `skip_non_native` through to the test cases to skip these automatically. However, the way the linker tests are setup in this case have a test step that depends on an `addSharedLibrary` step - and that `addSharedLibrary` step is what crashes, not the test itself.