### PR TITLE
Get panic messages from builtin instead of creating anon decls

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -869,6 +869,26 @@ pub noinline fn returnError(st: *StackTrace) void {
     addErrRetTraceAddr(st, @returnAddress());
 }
 
+pub const panic_messages = struct {
+    pub const unreach = "reached unreachable code";
+    pub const unwrap_null = "attempt to use null value";
+    pub const cast_to_null = "cast causes pointer to be null";
+    pub const incorrect_alignment = "incorrect alignment";
+    pub const invalid_error_code = "invalid error code";
+    pub const cast_truncated_data = "integer cast truncated bits";
+    pub const negative_to_unsigned = "attempt to cast negative value to unsigned integer";
+    pub const integer_overflow = "integer overflow";
+    pub const shl_overflow = "left shift overflowed bits";
+    pub const shr_overflow = "right shift overflowed bits";
+    pub const divide_by_zero = "division by zero";
+    pub const exact_division_remainder = "exact division produced remainder";
+    pub const inactive_union_field = "access of inactive union field";
+    pub const integer_part_out_of_bounds = "integer part of floating point value out of bounds";
+    pub const corrupt_switch = "switch on corrupt value";
+    pub const shift_rhs_too_big = "shift amount is greater than the type size";
+    pub const invalid_enum_value = "invalid enum value";
+};
+
 pub inline fn addErrRetTraceAddr(st: *StackTrace, addr: usize) void {
     if (st.index < st.instruction_addresses.len)
         st.instruction_addresses[st.index] = addr;


### PR DESCRIPTION
The TODO comment in safetyPanic mentions introducing the concept of reference-counted decls. That sounds like Zig current semantics for normal declarations. By placing the panic messages in builtin there is no need for another concept in the compiler.