### PR TITLE
std.crypto.ed25519 incremental signatures: hash the fallback noise

### DIFF
--- a/lib/std/crypto/25519/ed25519.zig
+++ b/lib/std/crypto/25519/ed25519.zig
@@ -318,6 +318,7 @@ pub const Ed25519 = struct {
             h.update(&scalar_and_prefix.prefix);
             var noise2: [noise_length]u8 = undefined;
             crypto.random.bytes(&noise2);
+            h.update(&noise2);
             if (noise) |*z| {
                 h.update(z);
             }


### PR DESCRIPTION
If the noise parameter was null, we didn't use any noise at all.

We unconditionally generated random noise (`noise2`) but didn't use it.

Spotted by @cryptocode, thanks!