### PR TITLE
std.os: Fix `std.os.chdir` for WASI

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -379,28 +379,13 @@ pub const TmpIterableDir = struct {
     }
 };
 
-fn getCwdOrWasiPreopen() std.fs.Dir {
-    if (builtin.os.tag == .wasi and !builtin.link_libc) {
-        var preopens = std.fs.wasi.PreopenList.init(allocator);
-        defer preopens.deinit();
-        preopens.populate(null) catch
-            @panic("unable to make tmp dir for testing: unable to populate preopens");
-        const preopen = preopens.find(std.fs.wasi.PreopenType{ .Dir = "." }) orelse
-            @panic("unable to make tmp dir for testing: didn't find '.' in the preopens");
-
-        return std.fs.Dir{ .fd = preopen.fd };
-    } else {
-        return std.fs.cwd();
-    }
-}
-
 pub fn tmpDir(opts: std.fs.Dir.OpenDirOptions) TmpDir {
     var random_bytes: [TmpDir.random_bytes_count]u8 = undefined;
     std.crypto.random.bytes(&random_bytes);
     var sub_path: [TmpDir.sub_path_len]u8 = undefined;
     _ = std.fs.base64_encoder.encode(&sub_path, &random_bytes);
 
-    var cwd = getCwdOrWasiPreopen();
+    var cwd = std.fs.cwd();
     var cache_dir = cwd.makeOpenPath("zig-cache", .{}) catch
         @panic("unable to make tmp dir for testing: unable to make and open zig-cache dir");
     defer cache_dir.close();
@@ -422,7 +407,7 @@ pub fn tmpIterableDir(opts: std.fs.Dir.OpenDirOptions) TmpIterableDir {
     var sub_path: [TmpIterableDir.sub_path_len]u8 = undefined;
     _ = std.fs.base64_encoder.encode(&sub_path, &random_bytes);
 
-    var cwd = getCwdOrWasiPreopen();
+    var cwd = std.fs.cwd();
     var cache_dir = cwd.makeOpenPath("zig-cache", .{}) catch
         @panic("unable to make tmp dir for testing: unable to make and open zig-cache dir");
     defer cache_dir.close();


### PR DESCRIPTION
Test coverage was lacking for chdir() on WASI, allowing this to regress.

This change makes os.chdir() compile again, and improves the test logic to use our standard CWD support for WASI.

Resolves #13644. Thanks to @codefromthecrypt for the bug report 🙂 