### PR TITLE
CLI: more careful resolution of paths

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -41,9 +41,9 @@ pub fn build(b: *Builder) !void {
     docs_step.dependOn(&docgen_cmd.step);
 
     const test_cases = b.addTest("src/test.zig");
+    test_cases.main_pkg_path = ".";
     test_cases.stack_size = stack_size;
     test_cases.setBuildMode(mode);
-    test_cases.addPackagePath("test_cases", "test/cases.zig");
     test_cases.single_threaded = single_threaded;
 
     const fmt_build_zig = b.addFmt(&[_][]const u8{"build.zig"});

--- a/src/test.zig
+++ b/src/test.zig
@@ -60,7 +60,7 @@ test {
         ctx.addTestCasesFromDir(dir);
     }
 
-    try @import("test_cases").addCases(&ctx);
+    try @import("../test/cases.zig").addCases(&ctx);
 
     try ctx.run();
 }


### PR DESCRIPTION
In general, we prefer compiler code to use relative paths based on open directory handles because this is the most portable. However, sometimes absolute paths are used, and sometimes relative paths are used that go up a directory.

The recent improvements in 81d2135ca6ebd71b8c121a19957c8fbf7f87125b regressed the use case when an absolute path is used for the zig lib directory mixed with a relative path used for the root source file. This could happen when, for example, running the standard library tests, like this:

stage3/bin/zig test ../lib/std/std.zig

This happened because the zig lib dir was inferred to be an absolute directory based on the zig executable directory, while the root source file was detected as a relative path. There was no common prefix and so it was not determined that the std.zig file was inside the lib directory.

This commit adds a function for resolving paths that preserves relative path names while allowing absolute paths, and converting relative upwards paths (e.g. "../foo") to absolute paths. This restores the previous functionality while remaining compatible with systems such as WASI that cannot deal with absolute paths.