### PR TITLE
`os.windows.OpenFile`: Add `USER_MAPPED_FILE` as a possible error

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -134,6 +134,7 @@ pub fn OpenFile(sub_path_w: []const u16, options: OpenFileOptions) OpenError!HAN
         .OBJECT_NAME_COLLISION => return error.PathAlreadyExists,
         .FILE_IS_A_DIRECTORY => return error.IsDir,
         .NOT_A_DIRECTORY => return error.NotDir,
+        .USER_MAPPED_FILE => return error.AccessDenied,
         .INVALID_HANDLE => unreachable,
         else => return unexpectedStatus(rc),
     }


### PR DESCRIPTION
Ran into this when using a program that uses `CreateFileMapping` and then from Zig trying to call `std.fs.Dir.createFile` with the mapped file's path. More info can be found here:

https://stackoverflow.com/questions/41844842/when-error-1224-error-user-mapped-file-occurs

Before:

```
error.Unexpected NTSTATUS=0xc0000243
C:\Users\Ryan\Programming\Zig\zig\lib\std\os\windows.zig:138:40: 0x7ff74e957466 in OpenFile (test.exe.obj)
        else => return unexpectedStatus(rc),
                                       ^
```

After:

```
FAIL (AccessDenied)
C:\Users\Ryan\Programming\Zig\zig\lib\std\os\windows.zig:137:30: 0x7ff7f5b776ea in OpenFile (test.exe.obj)
        .USER_MAPPED_FILE => return error.AccessDenied,
                             ^
```