### PR TITLE
std.mem.Allocator: allow shrink to fail

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -471,7 +471,7 @@ fn genToc(allocator: Allocator, tokenizer: *Tokenizer) !Toc {
                             },
                             Token.Id.Separator => {},
                             Token.Id.BracketClose => {
-                                try nodes.append(Node{ .SeeAlso = list.toOwnedSlice() });
+                                try nodes.append(Node{ .SeeAlso = try list.toOwnedSlice() });
                                 break;
                             },
                             else => return parseError(tokenizer, see_also_tok, "invalid see_also token", .{}),
@@ -610,7 +610,7 @@ fn genToc(allocator: Allocator, tokenizer: *Tokenizer) !Toc {
                             .source_token = source_token,
                             .just_check_syntax = just_check_syntax,
                             .mode = mode,
-                            .link_objects = link_objects.toOwnedSlice(),
+                            .link_objects = try link_objects.toOwnedSlice(),
                             .target_str = target_str,
                             .link_libc = link_libc,
                             .backend_stage1 = backend_stage1,
@@ -707,8 +707,8 @@ fn genToc(allocator: Allocator, tokenizer: *Tokenizer) !Toc {
     }
 
     return Toc{
-        .nodes = nodes.toOwnedSlice(),
-        .toc = toc_buf.toOwnedSlice(),
+        .nodes = try nodes.toOwnedSlice(),
+        .toc = try toc_buf.toOwnedSlice(),
         .urls = urls,
     };
 }
@@ -729,7 +729,7 @@ fn urlize(allocator: Allocator, input: []const u8) ![]u8 {
             else => {},
         }
     }
-    return buf.toOwnedSlice();
+    return try buf.toOwnedSlice();
 }
 
 fn escapeHtml(allocator: Allocator, input: []const u8) ![]u8 {
@@ -738,7 +738,7 @@ fn escapeHtml(allocator: Allocator, input: []const u8) ![]u8 {
 
     const out = buf.writer();
     try writeEscaped(out, input);
-    return buf.toOwnedSlice();
+    return try buf.toOwnedSlice();
 }
 
 fn writeEscaped(out: anytype, input: []const u8) !void {
@@ -854,7 +854,7 @@ fn termColor(allocator: Allocator, input: []const u8) ![]u8 {
             },
         }
     }
-    return buf.toOwnedSlice();
+    return try buf.toOwnedSlice();
 }
 
 const builtin_types = [_][]const u8{

--- a/lib/std/array_hash_map.zig
+++ b/lib/std/array_hash_map.zig
@@ -1872,7 +1872,7 @@ const IndexHeader = struct {
         const len = @as(usize, 1) << @intCast(math.Log2Int(usize), new_bit_index);
         const index_size = hash_map.capacityIndexSize(new_bit_index);
         const nbytes = @sizeOf(IndexHeader) + index_size * len;
-        const bytes = try allocator.allocAdvanced(u8, @alignOf(IndexHeader), nbytes, .exact);
+        const bytes = try allocator.alignedAlloc(u8, @alignOf(IndexHeader), nbytes);
         @memset(bytes.ptr + @sizeOf(IndexHeader), 0xff, bytes.len - @sizeOf(IndexHeader));
         const result = @ptrCast(*IndexHeader, bytes.ptr);
         result.* = .{

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -47,6 +47,10 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
 
         pub const Slice = if (alignment) |a| ([]align(a) T) else []T;
 
+        pub fn SentinelSlice(comptime s: T) type {
+            return if (alignment) |a| ([:s]align(a) T) else [:s]T;
+        }
+
         /// Deinitialize with `deinit` or use `toOwnedSlice`.
         pub fn init(allocator: Allocator) Self {
             return Self{
@@ -92,18 +96,31 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
             return result;
         }
 
-        /// The caller owns the returned memory. Empties this ArrayList.
-        pub fn toOwnedSlice(self: *Self) Slice {
+        /// The caller owns the returned memory. Empties this ArrayList,
+        /// however its capacity may or may not be cleared and deinit() is
+        /// still required to clean up its memory.
+        pub fn toOwnedSlice(self: *Self) Allocator.Error!Slice {
             const allocator = self.allocator;
-            const result = allocator.shrink(self.allocatedSlice(), self.items.len);
-            self.* = init(allocator);
-            return result;
+
+            const old_memory = self.allocatedSlice();
+            if (allocator.resize(old_memory, self.items.len)) {
+                const result = self.items;
+                self.* = init(allocator);
+                return result;
+            }
+
+            const new_memory = try allocator.alignedAlloc(T, alignment, self.items.len);
+            mem.copy(T, new_memory, self.items);
+            @memset(@ptrCast([*]u8, self.items.ptr), undefined, self.items.len * @sizeOf(T));
+            self.items.len = 0;
+            return new_memory;
         }
 
         /// The caller owns the returned memory. Empties this ArrayList.
-        pub fn toOwnedSliceSentinel(self: *Self, comptime sentinel: T) Allocator.Error![:sentinel]T {
-            try self.append(sentinel);
-            const result = self.toOwnedSlice();
+        pub fn toOwnedSliceSentinel(self: *Self, comptime sentinel: T) Allocator.Error!SentinelSlice(sentinel) {
+            try self.ensureTotalCapacityPrecise(self.items.len + 1);
+            self.appendAssumeCapacity(sentinel);
+            const result = try self.toOwnedSlice();
             return result[0 .. result.len - 1 :sentinel];
         }
 
@@ -299,17 +316,30 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
         pub fn shrinkAndFree(self: *Self, new_len: usize) void {
             assert(new_len <= self.items.len);
 
-            if (@sizeOf(T) > 0) {
-                self.items = self.allocator.realloc(self.allocatedSlice(), new_len) catch |e| switch (e) {
-                    error.OutOfMemory => { // no problem, capacity is still correct then.
-                        self.items.len = new_len;
-                        return;
-                    },
-                };
-                self.capacity = new_len;
-            } else {
+            if (@sizeOf(T) == 0) {
                 self.items.len = new_len;
+                return;
             }
+
+            const old_memory = self.allocatedSlice();
+            if (self.allocator.resize(old_memory, new_len)) {
+                self.capacity = new_len;
+                self.items.len = new_len;
+                return;
+            }
+
+            const new_memory = self.allocator.alignedAlloc(T, alignment, new_len) catch |e| switch (e) {
+                error.OutOfMemory => {
+                    // No problem, capacity is still correct then.
+                    self.items.len = new_len;
+                    return;
+                },
+            };
+
+            mem.copy(T, new_memory, self.items);
+            self.allocator.free(old_memory);
+            self.items = new_memory;
+            self.capacity = new_memory.len;
         }
 
         /// Reduce length to `new_len`.
@@ -334,19 +364,20 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
         /// Modify the array so that it can hold at least `new_capacity` items.
         /// Invalidates pointers if additional memory is needed.
         pub fn ensureTotalCapacity(self: *Self, new_capacity: usize) Allocator.Error!void {
-            if (@sizeOf(T) > 0) {
-                if (self.capacity >= new_capacity) return;
-
-                var better_capacity = self.capacity;
-                while (true) {
-                    better_capacity +|= better_capacity / 2 + 8;
-                    if (better_capacity >= new_capacity) break;
-                }
-
-                return self.ensureTotalCapacityPrecise(better_capacity);
-            } else {
+            if (@sizeOf(T) == 0) {
                 self.capacity = math.maxInt(usize);
+                return;
             }
+
+            if (self.capacity >= new_capacity) return;
+
+            var better_capacity = self.capacity;
+            while (true) {
+                better_capacity +|= better_capacity / 2 + 8;
+                if (better_capacity >= new_capacity) break;
+            }
+
+            return self.ensureTotalCapacityPrecise(better_capacity);
         }
 
         /// Modify the array so that it can hold at least `new_capacity` items.
@@ -354,15 +385,27 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
         /// (but not guaranteed) to be equal to `new_capacity`.
         /// Invalidates pointers if additional memory is needed.
         pub fn ensureTotalCapacityPrecise(self: *Self, new_capacity: usize) Allocator.Error!void {
-            if (@sizeOf(T) > 0) {
-                if (self.capacity >= new_capacity) return;
+            if (@sizeOf(T) == 0) {
+                self.capacity = math.maxInt(usize);
+                return;
+            }
 
-                // TODO This can be optimized to avoid needlessly copying undefined memory.
-                const new_memory = try self.allocator.reallocAtLeast(self.allocatedSlice(), new_capacity);
+            if (self.capacity >= new_capacity) return;
+
+            // Here we avoid copying allocated but unused bytes by
+            // attempting a resize in place, and falling back to allocating
+            // a new buffer and doing our own copy. With a realloc() call,
+            // the allocator implementation would pointlessly copy our
+            // extra capacity.
+            const old_memory = self.allocatedSlice();
+            if (self.allocator.resize(old_memory, new_capacity)) {
+                self.capacity = new_capacity;
+            } else {
+                const new_memory = try self.allocator.alignedAlloc(T, alignment, new_capacity);
+                mem.copy(T, new_memory, self.items);
+                self.allocator.free(old_memory);
                 self.items.ptr = new_memory.ptr;
                 self.capacity = new_memory.len;
-            } else {
-                self.capacity = math.maxInt(usize);
             }
         }
 
@@ -381,8 +424,7 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
         /// Increase length by 1, returning pointer to the new item.
         /// The returned pointer becomes invalid when the list resized.
         pub fn addOne(self: *Self) Allocator.Error!*T {
-            const newlen = self.items.len + 1;
-            try self.ensureTotalCapacity(newlen);
+            try self.ensureTotalCapacity(self.items.len + 1);
             return self.addOneAssumeCapacity();
         }
 
@@ -392,7 +434,6 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
         /// **Does not** invalidate element pointers.
         pub fn addOneAssumeCapacity(self: *Self) *T {
             assert(self.items.len < self.capacity);
-
             self.items.len += 1;
             return &self.items[self.items.len - 1];
         }
@@ -490,6 +531,10 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
 
         pub const Slice = if (alignment) |a| ([]align(a) T) else []T;
 
+        pub fn SentinelSlice(comptime s: T) type {
+            return if (alignment) |a| ([:s]align(a) T) else [:s]T;
+        }
+
         /// Initialize with capacity to hold at least num elements.
         /// The resulting capacity is likely to be equal to `num`.
         /// Deinitialize with `deinit` or use `toOwnedSlice`.
@@ -511,17 +556,29 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
             return .{ .items = self.items, .capacity = self.capacity, .allocator = allocator };
         }
 
-        /// The caller owns the returned memory. ArrayList becomes empty.
-        pub fn toOwnedSlice(self: *Self, allocator: Allocator) Slice {
-            const result = allocator.shrink(self.allocatedSlice(), self.items.len);
-            self.* = Self{};
-            return result;
+        /// The caller owns the returned memory. Empties this ArrayList,
+        /// however its capacity may or may not be cleared and deinit() is
+        /// still required to clean up its memory.
+        pub fn toOwnedSlice(self: *Self, allocator: Allocator) Allocator.Error!Slice {
+            const old_memory = self.allocatedSlice();
+            if (allocator.resize(old_memory, self.items.len)) {
+                const result = self.items;
+                self.* = .{};
+                return result;
+            }
+
+            const new_memory = try allocator.alignedAlloc(T, alignment, self.items.len);
+            mem.copy(T, new_memory, self.items);
+            @memset(@ptrCast([*]u8, self.items.ptr), undefined, self.items.len * @sizeOf(T));
+            self.items.len = 0;
+            return new_memory;
         }
 
         /// The caller owns the returned memory. ArrayList becomes empty.
-        pub fn toOwnedSliceSentinel(self: *Self, allocator: Allocator, comptime sentinel: T) Allocator.Error![:sentinel]T {
-            try self.append(allocator, sentinel);
-            const result = self.toOwnedSlice(allocator);
+        pub fn toOwnedSliceSentinel(self: *Self, allocator: Allocator, comptime sentinel: T) Allocator.Error!SentinelSlice(sentinel) {
+            try self.ensureTotalCapacityPrecise(allocator, self.items.len + 1);
+            self.appendAssumeCapacity(sentinel);
+            const result = try self.toOwnedSlice(allocator);
             return result[0 .. result.len - 1 :sentinel];
         }
 
@@ -701,16 +758,34 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
         }
 
         /// Reduce allocated capacity to `new_len`.
+        /// May invalidate element pointers.
         pub fn shrinkAndFree(self: *Self, allocator: Allocator, new_len: usize) void {
             assert(new_len <= self.items.len);
 
-            self.items = allocator.realloc(self.allocatedSlice(), new_len) catch |e| switch (e) {
-                error.OutOfMemory => { // no problem, capacity is still correct then.
+            if (@sizeOf(T) == 0) {
+                self.items.len = new_len;
+                return;
+            }
+
+            const old_memory = self.allocatedSlice();
+            if (allocator.resize(old_memory, new_len)) {
+                self.capacity = new_len;
+                self.items.len = new_len;
+                return;
+            }
+
+            const new_memory = allocator.alignedAlloc(T, alignment, new_len) catch |e| switch (e) {
+                error.OutOfMemory => {
+                    // No problem, capacity is still correct then.
                     self.items.len = new_len;
                     return;
                 },
             };
-            self.capacity = new_len;
+
+            mem.copy(T, new_memory, self.items);
+            allocator.free(old_memory);
+            self.items = new_memory;
+            self.capacity = new_memory.len;
         }
 
         /// Reduce length to `new_len`.
@@ -752,11 +827,28 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
         /// (but not guaranteed) to be equal to `new_capacity`.
         /// Invalidates pointers if additional memory is needed.
         pub fn ensureTotalCapacityPrecise(self: *Self, allocator: Allocator, new_capacity: usize) Allocator.Error!void {
+            if (@sizeOf(T) == 0) {
+                self.capacity = math.maxInt(usize);
+                return;
+            }
+
             if (self.capacity >= new_capacity) return;
 
-            const new_memory = try allocator.reallocAtLeast(self.allocatedSlice(), new_capacity);
-            self.items.ptr = new_memory.ptr;
-            self.capacity = new_memory.len;
+            // Here we avoid copying allocated but unused bytes by
+            // attempting a resize in place, and falling back to allocating
+            // a new buffer and doing our own copy. With a realloc() call,
+            // the allocator implementation would pointlessly copy our
+            // extra capacity.
+            const old_memory = self.allocatedSlice();
+            if (allocator.resize(old_memory, new_capacity)) {
+                self.capacity = new_capacity;
+            } else {
+                const new_memory = try allocator.alignedAlloc(T, alignment, new_capacity);
+                mem.copy(T, new_memory, self.items);
+                allocator.free(old_memory);
+                self.items.ptr = new_memory.ptr;
+                self.capacity = new_memory.len;
+            }
         }
 
         /// Modify the array so that it can hold at least `additional_count` **more** items.

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -2934,7 +2934,7 @@ pub const LibExeObjStep = struct {
                     }
                 }
 
-                try zig_args.append(mcpu_buffer.toOwnedSlice());
+                try zig_args.append(try mcpu_buffer.toOwnedSlice());
             }
 
             if (self.target.dynamic_linker.get()) |dynamic_linker| {

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -421,8 +421,8 @@ pub const ChildProcess = struct {
 
         return ExecResult{
             .term = try child.wait(),
-            .stdout = stdout.toOwnedSlice(),
-            .stderr = stderr.toOwnedSlice(),
+            .stdout = try stdout.toOwnedSlice(),
+            .stderr = try stderr.toOwnedSlice(),
         };
     }
 
@@ -1270,7 +1270,7 @@ pub fn createWindowsEnvBlock(allocator: mem.Allocator, env_map: *const EnvMap) !
     i += 1;
     result[i] = 0;
     i += 1;
-    return allocator.shrink(result, i);
+    return try allocator.realloc(result, i);
 }
 
 pub fn createNullDelimitedEnvMap(arena: mem.Allocator, env_map: *const EnvMap) ![:null]?[*:0]u8 {

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1112,7 +1112,7 @@ fn readMachODebugInfo(allocator: mem.Allocator, macho_file: File) !ModuleDebugIn
     }
     assert(state == .oso_close);
 
-    const symbols = allocator.shrink(symbols_buf, symbol_index);
+    const symbols = try allocator.realloc(symbols_buf, symbol_index);
 
     // Even though lld emits symbols in ascending order, this debug code
     // should work for programs linked in any valid way.

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -954,11 +954,9 @@ pub const File = struct {
         };
 
         if (optional_sentinel) |sentinel| {
-            try array_list.append(sentinel);
-            const buf = array_list.toOwnedSlice();
-            return buf[0 .. buf.len - 1 :sentinel];
+            return try array_list.toOwnedSliceSentinel(sentinel);
         } else {
-            return array_list.toOwnedSlice();
+            return try array_list.toOwnedSlice();
         }
     }
 

--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -1155,7 +1155,7 @@ pub fn relativePosix(allocator: Allocator, from: []const u8, to: []const u8) ![]
         }
         if (to_rest.len == 0) {
             // shave off the trailing slash
-            return allocator.shrink(result, result_index - 1);
+            return allocator.realloc(result, result_index - 1);
         }
 
         mem.copy(u8, result[result_index..], to_rest);

--- a/lib/std/fs/wasi.zig
+++ b/lib/std/fs/wasi.zig
@@ -160,7 +160,7 @@ pub const PreopenList = struct {
         if (cwd_root) |root| assert(fs.path.isAbsolute(root));
 
         // Clear contents if we're being called again
-        for (self.toOwnedSlice()) |preopen| {
+        for (try self.toOwnedSlice()) |preopen| {
             switch (preopen.type) {
                 PreopenType.Dir => |path| self.buffer.allocator.free(path),
             }
@@ -263,8 +263,8 @@ pub const PreopenList = struct {
     }
 
     /// The caller owns the returned memory. ArrayList becomes empty.
-    pub fn toOwnedSlice(self: *Self) []Preopen {
-        return self.buffer.toOwnedSlice();
+    pub fn toOwnedSlice(self: *Self) ![]Preopen {
+        return try self.buffer.toOwnedSlice();
     }
 };
 

--- a/lib/std/io/reader.zig
+++ b/lib/std/io/reader.zig
@@ -176,11 +176,11 @@ pub fn Reader(
                 error.EndOfStream => if (array_list.items.len == 0) {
                     return null;
                 } else {
-                    return array_list.toOwnedSlice();
+                    return try array_list.toOwnedSlice();
                 },
                 else => |e| return e,
             };
-            return array_list.toOwnedSlice();
+            return try array_list.toOwnedSlice();
         }
 
         /// Reads from the stream until specified byte is found. If the buffer is not

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1668,12 +1668,10 @@ fn parseInternal(
 
                             if (ptrInfo.sentinel) |some| {
                                 const sentinel_value = @ptrCast(*align(1) const ptrInfo.child, some).*;
-                                try arraylist.append(sentinel_value);
-                                const output = arraylist.toOwnedSlice();
-                                return output[0 .. output.len - 1 :sentinel_value];
+                                return try arraylist.toOwnedSliceSentinel(sentinel_value);
                             }
 
-                            return arraylist.toOwnedSlice();
+                            return try arraylist.toOwnedSlice();
                         },
                         .String => |stringToken| {
                             if (ptrInfo.child != u8) return error.UnexpectedToken;

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -2376,6 +2376,34 @@ pub const Const = struct {
     pub fn eq(a: Const, b: Const) bool {
         return order(a, b) == .eq;
     }
+
+    pub fn clz(a: Const, bits: Limb) Limb {
+        // Limbs are stored in little-endian order but we need
+        // to iterate big-endian.
+        var total_limb_lz: Limb = 0;
+        var i: usize = a.limbs.len;
+        const bits_per_limb = @sizeOf(Limb) * 8;
+        while (i != 0) {
+            i -= 1;
+            const limb = a.limbs[i];
+            const this_limb_lz = @clz(limb);
+            total_limb_lz += this_limb_lz;
+            if (this_limb_lz != bits_per_limb) break;
+        }
+        const total_limb_bits = a.limbs.len * bits_per_limb;
+        return total_limb_lz + bits - total_limb_bits;
+    }
+
+    pub fn ctz(a: Const) Limb {
+        // Limbs are stored in little-endian order.
+        var result: Limb = 0;
+        for (a.limbs) |limb| {
+            const limb_tz = @ctz(limb);
+            result += limb_tz;
+            if (limb_tz != @sizeOf(Limb) * 8) break;
+        }
+        return result;
+    }
 };
 
 /// An arbitrary-precision big integer along with an allocator which manages the memory.

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -2148,7 +2148,7 @@ pub const Const = struct {
         const limbs = try allocator.alloc(Limb, calcToStringLimbsBufferLen(self.limbs.len, base));
         defer allocator.free(limbs);
 
-        return allocator.shrink(string, self.toString(string, base, case, limbs));
+        return allocator.realloc(string, self.toString(string, base, case, limbs));
     }
 
     /// Converts self to a string in the requested base.

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -8,167 +8,101 @@ const Allocator = @This();
 const builtin = @import("builtin");
 
 pub const Error = error{OutOfMemory};
+pub const Log2Align = math.Log2Int(usize);
 
 // The type erased pointer to the allocator implementation
 ptr: *anyopaque,
 vtable: *const VTable,
 
 pub const VTable = struct {
-    /// Attempt to allocate at least `len` bytes aligned to `ptr_align`.
+    /// Attempt to allocate exactly `len` bytes aligned to `1 << ptr_align`.
     ///
-    /// If `len_align` is `0`, then the length returned MUST be exactly `len` bytes,
-    /// otherwise, the length must be aligned to `len_align`.
-    ///
-    /// `len` must be greater than or equal to `len_align` and must be aligned by `len_align`.
-    ///
-    /// `ret_addr` is optionally provided as the first return address of the allocation call stack.
-    /// If the value is `0` it means no return address has been provided.
-    alloc: std.meta.FnPtr(fn (ptr: *anyopaque, len: usize, ptr_align: u29, len_align: u29, ret_addr: usize) Error![]u8),
+    /// `ret_addr` is optionally provided as the first return address of the
+    /// allocation call stack. If the value is `0` it means no return address
+    /// has been provided.
+    alloc: std.meta.FnPtr(fn (ctx: *anyopaque, len: usize, ptr_align: u8, ret_addr: usize) ?[*]u8),
 
-    /// Attempt to expand or shrink memory in place. `buf.len` must equal the most recent
-    /// length returned by `alloc` or `resize`. `buf_align` must equal the same value
-    /// that was passed as the `ptr_align` parameter to the original `alloc` call.
+    /// Attempt to expand or shrink memory in place. `buf.len` must equal the
+    /// length requested from the most recent successful call to `alloc` or
+    /// `resize`. `buf_align` must equal the same value that was passed as the
+    /// `ptr_align` parameter to the original `alloc` call.
     ///
-    /// `null` can only be returned if `new_len` is greater than `buf.len`.
-    /// If `buf` cannot be expanded to accomodate `new_len`, then the allocation MUST be
-    /// unmodified and `null` MUST be returned.
+    /// A result of `true` indicates the resize was successful and the
+    /// allocation now has the same address but a size of `new_len`. `false`
+    /// indicates the resize could not be completed without moving the
+    /// allocation to a different address.
     ///
-    /// If `len_align` is `0`, then the length returned MUST be exactly `len` bytes,
-    /// otherwise, the length must be aligned to `len_align`. Note that `len_align` does *not*
-    /// provide a way to modify the alignment of a pointer. Rather it provides an API for
-    /// accepting more bytes of memory from the allocator than requested.
+    /// `new_len` must be greater than zero.
     ///
-    /// `new_len` must be greater than zero, greater than or equal to `len_align` and must be aligned by `len_align`.
-    ///
-    /// `ret_addr` is optionally provided as the first return address of the allocation call stack.
-    /// If the value is `0` it means no return address has been provided.
-    resize: std.meta.FnPtr(fn (ptr: *anyopaque, buf: []u8, buf_align: u29, new_len: usize, len_align: u29, ret_addr: usize) ?usize),
+    /// `ret_addr` is optionally provided as the first return address of the
+    /// allocation call stack. If the value is `0` it means no return address
+    /// has been provided.
+    resize: std.meta.FnPtr(fn (ctx: *anyopaque, buf: []u8, buf_align: u8, new_len: usize, ret_addr: usize) bool),
 
-    /// Free and invalidate a buffer. `buf.len` must equal the most recent length returned by `alloc` or `resize`.
-    /// `buf_align` must equal the same value that was passed as the `ptr_align` parameter to the original `alloc` call.
+    /// Free and invalidate a buffer.
     ///
-    /// `ret_addr` is optionally provided as the first return address of the allocation call stack.
-    /// If the value is `0` it means no return address has been provided.
-    free: std.meta.FnPtr(fn (ptr: *anyopaque, buf: []u8, buf_align: u29, ret_addr: usize) void),
+    /// `buf.len` must equal the most recent length returned by `alloc` or
+    /// given to a successful `resize` call.
+    ///
+    /// `buf_align` must equal the same value that was passed as the
+    /// `ptr_align` parameter to the original `alloc` call.
+    ///
+    /// `ret_addr` is optionally provided as the first return address of the
+    /// allocation call stack. If the value is `0` it means no return address
+    /// has been provided.
+    free: std.meta.FnPtr(fn (ctx: *anyopaque, buf: []u8, buf_align: u8, ret_addr: usize) void),
 };
 
-pub fn init(
-    pointer: anytype,
-    comptime allocFn: fn (ptr: @TypeOf(pointer), len: usize, ptr_align: u29, len_align: u29, ret_addr: usize) Error![]u8,
-    comptime resizeFn: fn (ptr: @TypeOf(pointer), buf: []u8, buf_align: u29, new_len: usize, len_align: u29, ret_addr: usize) ?usize,
-    comptime freeFn: fn (ptr: @TypeOf(pointer), buf: []u8, buf_align: u29, ret_addr: usize) void,
-) Allocator {
-    const Ptr = @TypeOf(pointer);
-    const ptr_info = @typeInfo(Ptr);
-
-    assert(ptr_info == .Pointer); // Must be a pointer
-    assert(ptr_info.Pointer.size == .One); // Must be a single-item pointer
-
-    const alignment = ptr_info.Pointer.alignment;
-
-    const gen = struct {
-        fn allocImpl(ptr: *anyopaque, len: usize, ptr_align: u29, len_align: u29, ret_addr: usize) Error![]u8 {
-            const self = @ptrCast(Ptr, @alignCast(alignment, ptr));
-            return @call(.{ .modifier = .always_inline }, allocFn, .{ self, len, ptr_align, len_align, ret_addr });
-        }
-        fn resizeImpl(ptr: *anyopaque, buf: []u8, buf_align: u29, new_len: usize, len_align: u29, ret_addr: usize) ?usize {
-            assert(new_len != 0);
-            const self = @ptrCast(Ptr, @alignCast(alignment, ptr));
-            return @call(.{ .modifier = .always_inline }, resizeFn, .{ self, buf, buf_align, new_len, len_align, ret_addr });
-        }
-        fn freeImpl(ptr: *anyopaque, buf: []u8, buf_align: u29, ret_addr: usize) void {
-            const self = @ptrCast(Ptr, @alignCast(alignment, ptr));
-            @call(.{ .modifier = .always_inline }, freeFn, .{ self, buf, buf_align, ret_addr });
-        }
-
-        const vtable = VTable{
-            .alloc = allocImpl,
-            .resize = resizeImpl,
-            .free = freeImpl,
-        };
-    };
-
-    return .{
-        .ptr = pointer,
-        .vtable = &gen.vtable,
-    };
+pub fn noResize(
+    self: *anyopaque,
+    buf: []u8,
+    log2_buf_align: u8,
+    new_len: usize,
+    ret_addr: usize,
+) bool {
+    _ = self;
+    _ = buf;
+    _ = log2_buf_align;
+    _ = new_len;
+    _ = ret_addr;
+    return false;
 }
 
-/// Set resizeFn to `NoResize(AllocatorType).noResize` if in-place resize is not supported.
-pub fn NoResize(comptime AllocatorType: type) type {
-    return struct {
-        pub fn noResize(
-            self: *AllocatorType,
-            buf: []u8,
-            buf_align: u29,
-            new_len: usize,
-            len_align: u29,
-            ret_addr: usize,
-        ) ?usize {
-            _ = self;
-            _ = buf_align;
-            _ = len_align;
-            _ = ret_addr;
-            return if (new_len > buf.len) null else new_len;
-        }
-    };
+pub fn noFree(
+    self: *anyopaque,
+    buf: []u8,
+    log2_buf_align: u8,
+    ret_addr: usize,
+) void {
+    _ = self;
+    _ = buf;
+    _ = log2_buf_align;
+    _ = ret_addr;
 }
 
-/// Set freeFn to `NoOpFree(AllocatorType).noOpFree` if free is a no-op.
-pub fn NoOpFree(comptime AllocatorType: type) type {
-    return struct {
-        pub fn noOpFree(
-            self: *AllocatorType,
-            buf: []u8,
-            buf_align: u29,
-            ret_addr: usize,
-        ) void {
-            _ = self;
-            _ = buf;
-            _ = buf_align;
-            _ = ret_addr;
-        }
-    };
+/// This function is not intended to be called except from within the
+/// implementation of an Allocator
+pub inline fn rawAlloc(self: Allocator, len: usize, ptr_align: u8, ret_addr: usize) ?[*]u8 {
+    return self.vtable.alloc(self.ptr, len, ptr_align, ret_addr);
 }
 
-/// Set freeFn to `PanicFree(AllocatorType).panicFree` if free is not a supported operation.
-pub fn PanicFree(comptime AllocatorType: type) type {
-    return struct {
-        pub fn panicFree(
-            self: *AllocatorType,
-            buf: []u8,
-            buf_align: u29,
-            ret_addr: usize,
-        ) void {
-            _ = self;
-            _ = buf;
-            _ = buf_align;
-            _ = ret_addr;
-            @panic("free is not a supported operation for the allocator: " ++ @typeName(AllocatorType));
-        }
-    };
+/// This function is not intended to be called except from within the
+/// implementation of an Allocator
+pub inline fn rawResize(self: Allocator, buf: []u8, log2_buf_align: u8, new_len: usize, ret_addr: usize) bool {
+    return self.vtable.resize(self.ptr, buf, log2_buf_align, new_len, ret_addr);
 }
 
-/// This function is not intended to be called except from within the implementation of an Allocator
-pub inline fn rawAlloc(self: Allocator, len: usize, ptr_align: u29, len_align: u29, ret_addr: usize) Error![]u8 {
-    return self.vtable.alloc(self.ptr, len, ptr_align, len_align, ret_addr);
-}
-
-/// This function is not intended to be called except from within the implementation of an Allocator
-pub inline fn rawResize(self: Allocator, buf: []u8, buf_align: u29, new_len: usize, len_align: u29, ret_addr: usize) ?usize {
-    return self.vtable.resize(self.ptr, buf, buf_align, new_len, len_align, ret_addr);
-}
-
-/// This function is not intended to be called except from within the implementation of an Allocator
-pub inline fn rawFree(self: Allocator, buf: []u8, buf_align: u29, ret_addr: usize) void {
-    return self.vtable.free(self.ptr, buf, buf_align, ret_addr);
+/// This function is not intended to be called except from within the
+/// implementation of an Allocator
+pub inline fn rawFree(self: Allocator, buf: []u8, log2_buf_align: u8, ret_addr: usize) void {
+    return self.vtable.free(self.ptr, buf, log2_buf_align, ret_addr);
 }
 
 /// Returns a pointer to undefined memory.
 /// Call `destroy` with the result to free the memory.
 pub fn create(self: Allocator, comptime T: type) Error!*T {
-    if (@sizeOf(T) == 0) return @intToPtr(*T, std.math.maxInt(usize));
-    const slice = try self.allocAdvancedWithRetAddr(T, null, 1, .exact, @returnAddress());
+    if (@sizeOf(T) == 0) return @intToPtr(*T, math.maxInt(usize));
+    const slice = try self.allocAdvancedWithRetAddr(T, null, 1, @returnAddress());
     return &slice[0];
 }
 
@@ -179,7 +113,7 @@ pub fn destroy(self: Allocator, ptr: anytype) void {
     const T = info.child;
     if (@sizeOf(T) == 0) return;
     const non_const_ptr = @intToPtr([*]u8, @ptrToInt(ptr));
-    self.rawFree(non_const_ptr[0..@sizeOf(T)], info.alignment, @returnAddress());
+    self.rawFree(non_const_ptr[0..@sizeOf(T)], math.log2(info.alignment), @returnAddress());
 }
 
 /// Allocates an array of `n` items of type `T` and sets all the
@@ -191,7 +125,7 @@ pub fn destroy(self: Allocator, ptr: anytype) void {
 ///
 /// For allocating a single item, see `create`.
 pub fn alloc(self: Allocator, comptime T: type, n: usize) Error![]T {
-    return self.allocAdvancedWithRetAddr(T, null, n, .exact, @returnAddress());
+    return self.allocAdvancedWithRetAddr(T, null, n, @returnAddress());
 }
 
 pub fn allocWithOptions(
@@ -215,11 +149,11 @@ pub fn allocWithOptionsRetAddr(
     return_address: usize,
 ) Error!AllocWithOptionsPayload(Elem, optional_alignment, optional_sentinel) {
     if (optional_sentinel) |sentinel| {
-        const ptr = try self.allocAdvancedWithRetAddr(Elem, optional_alignment, n + 1, .exact, return_address);
+        const ptr = try self.allocAdvancedWithRetAddr(Elem, optional_alignment, n + 1, return_address);
         ptr[n] = sentinel;
         return ptr[0..n :sentinel];
     } else {
-        return self.allocAdvancedWithRetAddr(Elem, optional_alignment, n, .exact, return_address);
+        return self.allocAdvancedWithRetAddr(Elem, optional_alignment, n, return_address);
     }
 }
 
@@ -255,21 +189,8 @@ pub fn alignedAlloc(
     comptime alignment: ?u29,
     n: usize,
 ) Error![]align(alignment orelse @alignOf(T)) T {
-    return self.allocAdvancedWithRetAddr(T, alignment, n, .exact, @returnAddress());
+    return self.allocAdvancedWithRetAddr(T, alignment, n, @returnAddress());
 }
-
-pub fn allocAdvanced(
-    self: Allocator,
-    comptime T: type,
-    /// null means naturally aligned
-    comptime alignment: ?u29,
-    n: usize,
-    exact: Exact,
-) Error![]align(alignment orelse @alignOf(T)) T {
-    return self.allocAdvancedWithRetAddr(T, alignment, n, exact, @returnAddress());
-}
-
-pub const Exact = enum { exact, at_least };
 
 pub fn allocAdvancedWithRetAddr(
     self: Allocator,
@@ -277,209 +198,99 @@ pub fn allocAdvancedWithRetAddr(
     /// null means naturally aligned
     comptime alignment: ?u29,
     n: usize,
-    exact: Exact,
     return_address: usize,
 ) Error![]align(alignment orelse @alignOf(T)) T {
     const a = if (alignment) |a| blk: {
-        if (a == @alignOf(T)) return allocAdvancedWithRetAddr(self, T, null, n, exact, return_address);
+        if (a == @alignOf(T)) return allocAdvancedWithRetAddr(self, T, null, n, return_address);
         break :blk a;
     } else @alignOf(T);
 
+    // The Zig Allocator interface is not intended to solve allocations beyond
+    // the minimum OS page size. For these use cases, the caller must use OS
+    // APIs directly.
+    comptime assert(a <= mem.page_size);
+
     if (n == 0) {
-        const ptr = comptime std.mem.alignBackward(std.math.maxInt(usize), a);
+        const ptr = comptime std.mem.alignBackward(math.maxInt(usize), a);
         return @intToPtr([*]align(a) T, ptr)[0..0];
     }
 
     const byte_count = math.mul(usize, @sizeOf(T), n) catch return Error.OutOfMemory;
-    // TODO The `if (alignment == null)` blocks are workarounds for zig not being able to
-    // access certain type information about T without creating a circular dependency in async
-    // functions that heap-allocate their own frame with @Frame(func).
-    const size_of_T: usize = if (alignment == null) @divExact(byte_count, n) else @sizeOf(T);
-    const len_align: u29 = switch (exact) {
-        .exact => 0,
-        .at_least => math.cast(u29, size_of_T) orelse 0,
-    };
-    const byte_slice = try self.rawAlloc(byte_count, a, len_align, return_address);
-    switch (exact) {
-        .exact => assert(byte_slice.len == byte_count),
-        .at_least => assert(byte_slice.len >= byte_count),
-    }
+    const byte_ptr = self.rawAlloc(byte_count, log2a(a), return_address) orelse return Error.OutOfMemory;
     // TODO: https://github.com/ziglang/zig/issues/4298
-    @memset(byte_slice.ptr, undefined, byte_slice.len);
-    if (alignment == null) {
-        // This if block is a workaround (see comment above)
-        return @intToPtr([*]T, @ptrToInt(byte_slice.ptr))[0..@divExact(byte_slice.len, @sizeOf(T))];
-    } else {
-        return mem.bytesAsSlice(T, @alignCast(a, byte_slice));
-    }
+    @memset(byte_ptr, undefined, byte_count);
+    const byte_slice = byte_ptr[0..byte_count];
+    return mem.bytesAsSlice(T, @alignCast(a, byte_slice));
 }
 
-/// Increases or decreases the size of an allocation. It is guaranteed to not move the pointer.
-pub fn resize(self: Allocator, old_mem: anytype, new_n: usize) ?@TypeOf(old_mem) {
+/// Requests to modify the size of an allocation. It is guaranteed to not move
+/// the pointer, however the allocator implementation may refuse the resize
+/// request by returning `false`.
+pub fn resize(self: Allocator, old_mem: anytype, new_n: usize) bool {
     const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
     const T = Slice.child;
     if (new_n == 0) {
         self.free(old_mem);
-        return &[0]T{};
+        return true;
+    }
+    if (old_mem.len == 0) {
+        return false;
     }
     const old_byte_slice = mem.sliceAsBytes(old_mem);
-    const new_byte_count = math.mul(usize, @sizeOf(T), new_n) catch return null;
-    const rc = self.rawResize(old_byte_slice, Slice.alignment, new_byte_count, 0, @returnAddress()) orelse return null;
-    assert(rc == new_byte_count);
-    const new_byte_slice = old_byte_slice.ptr[0..new_byte_count];
-    return mem.bytesAsSlice(T, new_byte_slice);
+    // I would like to use saturating multiplication here, but LLVM cannot lower it
+    // on WebAssembly: https://github.com/ziglang/zig/issues/9660
+    //const new_byte_count = new_n *| @sizeOf(T);
+    const new_byte_count = math.mul(usize, @sizeOf(T), new_n) catch return false;
+    return self.rawResize(old_byte_slice, log2a(Slice.alignment), new_byte_count, @returnAddress());
 }
 
-/// This function requests a new byte size for an existing allocation,
-/// which can be larger, smaller, or the same size as the old memory
-/// allocation.
-/// This function is preferred over `shrink`, because it can fail, even
-/// when shrinking. This gives the allocator a chance to perform a
-/// cheap shrink operation if possible, or otherwise return OutOfMemory,
-/// indicating that the caller should keep their capacity, for example
-/// in `std.ArrayList.shrink`.
-/// If you need guaranteed success, call `shrink`.
+/// This function requests a new byte size for an existing allocation, which
+/// can be larger, smaller, or the same size as the old memory allocation.
 /// If `new_n` is 0, this is the same as `free` and it always succeeds.
 pub fn realloc(self: Allocator, old_mem: anytype, new_n: usize) t: {
     const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
     break :t Error![]align(Slice.alignment) Slice.child;
 } {
-    const old_alignment = @typeInfo(@TypeOf(old_mem)).Pointer.alignment;
-    return self.reallocAdvancedWithRetAddr(old_mem, old_alignment, new_n, .exact, @returnAddress());
+    return self.reallocAdvanced(old_mem, new_n, @returnAddress());
 }
 
-pub fn reallocAtLeast(self: Allocator, old_mem: anytype, new_n: usize) t: {
-    const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
-    break :t Error![]align(Slice.alignment) Slice.child;
-} {
-    const old_alignment = @typeInfo(@TypeOf(old_mem)).Pointer.alignment;
-    return self.reallocAdvancedWithRetAddr(old_mem, old_alignment, new_n, .at_least, @returnAddress());
-}
-
-/// This is the same as `realloc`, except caller may additionally request
-/// a new alignment, which can be larger, smaller, or the same as the old
-/// allocation.
 pub fn reallocAdvanced(
     self: Allocator,
     old_mem: anytype,
-    comptime new_alignment: u29,
     new_n: usize,
-    exact: Exact,
-) Error![]align(new_alignment) @typeInfo(@TypeOf(old_mem)).Pointer.child {
-    return self.reallocAdvancedWithRetAddr(old_mem, new_alignment, new_n, exact, @returnAddress());
-}
-
-pub fn reallocAdvancedWithRetAddr(
-    self: Allocator,
-    old_mem: anytype,
-    comptime new_alignment: u29,
-    new_n: usize,
-    exact: Exact,
     return_address: usize,
-) Error![]align(new_alignment) @typeInfo(@TypeOf(old_mem)).Pointer.child {
+) t: {
+    const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
+    break :t Error![]align(Slice.alignment) Slice.child;
+} {
     const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
     const T = Slice.child;
     if (old_mem.len == 0) {
-        return self.allocAdvancedWithRetAddr(T, new_alignment, new_n, exact, return_address);
+        return self.allocAdvancedWithRetAddr(T, Slice.alignment, new_n, return_address);
     }
     if (new_n == 0) {
         self.free(old_mem);
-        const ptr = comptime std.mem.alignBackward(std.math.maxInt(usize), new_alignment);
-        return @intToPtr([*]align(new_alignment) T, ptr)[0..0];
+        const ptr = comptime std.mem.alignBackward(math.maxInt(usize), Slice.alignment);
+        return @intToPtr([*]align(Slice.alignment) T, ptr)[0..0];
     }
 
     const old_byte_slice = mem.sliceAsBytes(old_mem);
     const byte_count = math.mul(usize, @sizeOf(T), new_n) catch return Error.OutOfMemory;
     // Note: can't set shrunk memory to undefined as memory shouldn't be modified on realloc failure
-    const len_align: u29 = switch (exact) {
-        .exact => 0,
-        .at_least => math.cast(u29, @as(usize, @sizeOf(T))) orelse 0,
-    };
-
-    if (mem.isAligned(@ptrToInt(old_byte_slice.ptr), new_alignment)) {
-        if (byte_count <= old_byte_slice.len) {
-            const shrunk_len = self.shrinkBytes(old_byte_slice, Slice.alignment, byte_count, len_align, return_address);
-            return mem.bytesAsSlice(T, @alignCast(new_alignment, old_byte_slice.ptr[0..shrunk_len]));
-        }
-
-        if (self.rawResize(old_byte_slice, Slice.alignment, byte_count, len_align, return_address)) |resized_len| {
-            // TODO: https://github.com/ziglang/zig/issues/4298
-            @memset(old_byte_slice.ptr + byte_count, undefined, resized_len - byte_count);
-            return mem.bytesAsSlice(T, @alignCast(new_alignment, old_byte_slice.ptr[0..resized_len]));
+    if (mem.isAligned(@ptrToInt(old_byte_slice.ptr), Slice.alignment)) {
+        if (self.rawResize(old_byte_slice, log2a(Slice.alignment), byte_count, return_address)) {
+            return mem.bytesAsSlice(T, @alignCast(Slice.alignment, old_byte_slice.ptr[0..byte_count]));
         }
     }
 
-    if (byte_count <= old_byte_slice.len and new_alignment <= Slice.alignment) {
+    const new_mem = self.rawAlloc(byte_count, log2a(Slice.alignment), return_address) orelse
         return error.OutOfMemory;
-    }
-
-    const new_mem = try self.rawAlloc(byte_count, new_alignment, len_align, return_address);
-    @memcpy(new_mem.ptr, old_byte_slice.ptr, math.min(byte_count, old_byte_slice.len));
+    @memcpy(new_mem, old_byte_slice.ptr, @min(byte_count, old_byte_slice.len));
     // TODO https://github.com/ziglang/zig/issues/4298
     @memset(old_byte_slice.ptr, undefined, old_byte_slice.len);
-    self.rawFree(old_byte_slice, Slice.alignment, return_address);
+    self.rawFree(old_byte_slice, log2a(Slice.alignment), return_address);
 
-    return mem.bytesAsSlice(T, @alignCast(new_alignment, new_mem));
-}
-
-/// Prefer calling realloc to shrink if you can tolerate failure, such as
-/// in an ArrayList data structure with a storage capacity.
-/// Shrink always succeeds, and `new_n` must be <= `old_mem.len`.
-/// Returned slice has same alignment as old_mem.
-/// Shrinking to 0 is the same as calling `free`.
-pub fn shrink(self: Allocator, old_mem: anytype, new_n: usize) t: {
-    const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
-    break :t []align(Slice.alignment) Slice.child;
-} {
-    const old_alignment = @typeInfo(@TypeOf(old_mem)).Pointer.alignment;
-    return self.alignedShrinkWithRetAddr(old_mem, old_alignment, new_n, @returnAddress());
-}
-
-/// This is the same as `shrink`, except caller may additionally request
-/// a new alignment, which must be smaller or the same as the old
-/// allocation.
-pub fn alignedShrink(
-    self: Allocator,
-    old_mem: anytype,
-    comptime new_alignment: u29,
-    new_n: usize,
-) []align(new_alignment) @typeInfo(@TypeOf(old_mem)).Pointer.child {
-    return self.alignedShrinkWithRetAddr(old_mem, new_alignment, new_n, @returnAddress());
-}
-
-/// This is the same as `alignedShrink`, except caller may additionally pass
-/// the return address of the first stack frame, which may be relevant for
-/// allocators which collect stack traces.
-pub fn alignedShrinkWithRetAddr(
-    self: Allocator,
-    old_mem: anytype,
-    comptime new_alignment: u29,
-    new_n: usize,
-    return_address: usize,
-) []align(new_alignment) @typeInfo(@TypeOf(old_mem)).Pointer.child {
-    const Slice = @typeInfo(@TypeOf(old_mem)).Pointer;
-    const T = Slice.child;
-
-    if (new_n == old_mem.len)
-        return old_mem;
-    if (new_n == 0) {
-        self.free(old_mem);
-        const ptr = comptime std.mem.alignBackward(std.math.maxInt(usize), new_alignment);
-        return @intToPtr([*]align(new_alignment) T, ptr)[0..0];
-    }
-
-    assert(new_n < old_mem.len);
-    assert(new_alignment <= Slice.alignment);
-
-    // Here we skip the overflow checking on the multiplication because
-    // new_n <= old_mem.len and the multiplication didn't overflow for that operation.
-    const byte_count = @sizeOf(T) * new_n;
-
-    const old_byte_slice = mem.sliceAsBytes(old_mem);
-    // TODO: https://github.com/ziglang/zig/issues/4298
-    @memset(old_byte_slice.ptr + byte_count, undefined, old_byte_slice.len - byte_count);
-    _ = self.shrinkBytes(old_byte_slice, Slice.alignment, byte_count, 0, return_address);
-    return old_mem[0..new_n];
+    return mem.bytesAsSlice(T, @alignCast(Slice.alignment, new_mem[0..byte_count]));
 }
 
 /// Free an array allocated with `alloc`. To free a single item,
@@ -492,7 +303,7 @@ pub fn free(self: Allocator, memory: anytype) void {
     const non_const_ptr = @intToPtr([*]u8, @ptrToInt(bytes.ptr));
     // TODO: https://github.com/ziglang/zig/issues/4298
     @memset(non_const_ptr, undefined, bytes_len);
-    self.rawFree(non_const_ptr[0..bytes_len], Slice.alignment, @returnAddress());
+    self.rawFree(non_const_ptr[0..bytes_len], log2a(Slice.alignment), @returnAddress());
 }
 
 /// Copies `m` to newly allocated memory. Caller owns the memory.
@@ -510,226 +321,16 @@ pub fn dupeZ(allocator: Allocator, comptime T: type, m: []const T) ![:0]T {
     return new_buf[0..m.len :0];
 }
 
-/// This function allows a runtime `alignment` value. Callers should generally prefer
-/// to call the `alloc*` functions.
-pub fn allocBytes(
-    self: Allocator,
-    /// Must be >= 1.
-    /// Must be a power of 2.
-    /// Returned slice's pointer will have this alignment.
-    alignment: u29,
-    byte_count: usize,
-    /// 0 indicates the length of the slice returned MUST match `byte_count` exactly
-    /// non-zero means the length of the returned slice must be aligned by `len_align`
-    /// `byte_count` must be aligned by `len_align`
-    len_align: u29,
-    return_address: usize,
-) Error![]u8 {
-    const new_mem = try self.rawAlloc(byte_count, alignment, len_align, return_address);
-    // TODO: https://github.com/ziglang/zig/issues/4298
-    @memset(new_mem.ptr, undefined, new_mem.len);
-    return new_mem;
-}
-
-test "allocBytes" {
-    const number_of_bytes: usize = 10;
-    var runtime_alignment: u29 = 2;
-
-    {
-        const new_mem = try std.testing.allocator.allocBytes(runtime_alignment, number_of_bytes, 0, @returnAddress());
-        defer std.testing.allocator.free(new_mem);
-
-        try std.testing.expectEqual(number_of_bytes, new_mem.len);
-        try std.testing.expect(mem.isAligned(@ptrToInt(new_mem.ptr), runtime_alignment));
+/// TODO replace callsites with `@log2` after this proposal is implemented:
+/// https://github.com/ziglang/zig/issues/13642
+inline fn log2a(x: anytype) switch (@typeInfo(@TypeOf(x))) {
+    .Int => math.Log2Int(@TypeOf(x)),
+    .ComptimeInt => comptime_int,
+    else => @compileError("int please"),
+} {
+    switch (@typeInfo(@TypeOf(x))) {
+        .Int => return math.log2_int(@TypeOf(x), x),
+        .ComptimeInt => return math.log2(x),
+        else => @compileError("bad"),
     }
-
-    runtime_alignment = 8;
-
-    {
-        const new_mem = try std.testing.allocator.allocBytes(runtime_alignment, number_of_bytes, 0, @returnAddress());
-        defer std.testing.allocator.free(new_mem);
-
-        try std.testing.expectEqual(number_of_bytes, new_mem.len);
-        try std.testing.expect(mem.isAligned(@ptrToInt(new_mem.ptr), runtime_alignment));
-    }
-}
-
-test "allocBytes non-zero len_align" {
-    const number_of_bytes: usize = 10;
-    var runtime_alignment: u29 = 1;
-    var len_align: u29 = 2;
-
-    {
-        const new_mem = try std.testing.allocator.allocBytes(runtime_alignment, number_of_bytes, len_align, @returnAddress());
-        defer std.testing.allocator.free(new_mem);
-
-        try std.testing.expect(new_mem.len >= number_of_bytes);
-        try std.testing.expect(new_mem.len % len_align == 0);
-        try std.testing.expect(mem.isAligned(@ptrToInt(new_mem.ptr), runtime_alignment));
-    }
-
-    runtime_alignment = 16;
-    len_align = 5;
-
-    {
-        const new_mem = try std.testing.allocator.allocBytes(runtime_alignment, number_of_bytes, len_align, @returnAddress());
-        defer std.testing.allocator.free(new_mem);
-
-        try std.testing.expect(new_mem.len >= number_of_bytes);
-        try std.testing.expect(new_mem.len % len_align == 0);
-        try std.testing.expect(mem.isAligned(@ptrToInt(new_mem.ptr), runtime_alignment));
-    }
-}
-
-/// Realloc is used to modify the size or alignment of an existing allocation,
-/// as well as to provide the allocator with an opportunity to move an allocation
-/// to a better location.
-/// The returned slice will have its pointer aligned at least to `new_alignment` bytes.
-///
-/// This function allows a runtime `alignment` value. Callers should generally prefer
-/// to call the `realloc*` functions.
-///
-/// If the size/alignment is greater than the previous allocation, and the requested new
-/// allocation could not be granted this function returns `error.OutOfMemory`.
-/// When the size/alignment is less than or equal to the previous allocation,
-/// this function returns `error.OutOfMemory` when the allocator decides the client
-/// would be better off keeping the extra alignment/size.
-/// Clients will call `resizeFn` when they require the allocator to track a new alignment/size,
-/// and so this function should only return success when the allocator considers
-/// the reallocation desirable from the allocator's perspective.
-///
-/// As an example, `std.ArrayList` tracks a "capacity", and therefore can handle
-/// reallocation failure, even when `new_n` <= `old_mem.len`. A `FixedBufferAllocator`
-/// would always return `error.OutOfMemory` for `reallocFn` when the size/alignment
-/// is less than or equal to the old allocation, because it cannot reclaim the memory,
-/// and thus the `std.ArrayList` would be better off retaining its capacity.
-pub fn reallocBytes(
-    self: Allocator,
-    /// Must be the same as what was returned from most recent call to `allocFn` or `resizeFn`.
-    /// If `old_mem.len == 0` then this is a new allocation and `new_byte_count` must be >= 1.
-    old_mem: []u8,
-    /// If `old_mem.len == 0` then this is `undefined`, otherwise:
-    /// Must be the same as what was passed to `allocFn`.
-    /// Must be >= 1.
-    /// Must be a power of 2.
-    old_alignment: u29,
-    /// If `new_byte_count` is 0 then this is a free and it is required that `old_mem.len != 0`.
-    new_byte_count: usize,
-    /// Must be >= 1.
-    /// Must be a power of 2.
-    /// Returned slice's pointer will have this alignment.
-    new_alignment: u29,
-    /// 0 indicates the length of the slice returned MUST match `new_byte_count` exactly
-    /// non-zero means the length of the returned slice must be aligned by `len_align`
-    /// `new_byte_count` must be aligned by `len_align`
-    len_align: u29,
-    return_address: usize,
-) Error![]u8 {
-    if (old_mem.len == 0) {
-        return self.allocBytes(new_alignment, new_byte_count, len_align, return_address);
-    }
-    if (new_byte_count == 0) {
-        // TODO https://github.com/ziglang/zig/issues/4298
-        @memset(old_mem.ptr, undefined, old_mem.len);
-        self.rawFree(old_mem, old_alignment, return_address);
-        return &[0]u8{};
-    }
-
-    if (mem.isAligned(@ptrToInt(old_mem.ptr), new_alignment)) {
-        if (new_byte_count <= old_mem.len) {
-            const shrunk_len = self.shrinkBytes(old_mem, old_alignment, new_byte_count, len_align, return_address);
-            return old_mem.ptr[0..shrunk_len];
-        }
-
-        if (self.rawResize(old_mem, old_alignment, new_byte_count, len_align, return_address)) |resized_len| {
-            assert(resized_len >= new_byte_count);
-            // TODO: https://github.com/ziglang/zig/issues/4298
-            @memset(old_mem.ptr + new_byte_count, undefined, resized_len - new_byte_count);
-            return old_mem.ptr[0..resized_len];
-        }
-    }
-
-    if (new_byte_count <= old_mem.len and new_alignment <= old_alignment) {
-        return error.OutOfMemory;
-    }
-
-    const new_mem = try self.rawAlloc(new_byte_count, new_alignment, len_align, return_address);
-    @memcpy(new_mem.ptr, old_mem.ptr, math.min(new_byte_count, old_mem.len));
-
-    // TODO https://github.com/ziglang/zig/issues/4298
-    @memset(old_mem.ptr, undefined, old_mem.len);
-    self.rawFree(old_mem, old_alignment, return_address);
-
-    return new_mem;
-}
-
-test "reallocBytes" {
-    var new_mem: []u8 = &.{};
-
-    var new_byte_count: usize = 16;
-    var runtime_alignment: u29 = 4;
-
-    // `new_mem.len == 0`, this is a new allocation
-    {
-        new_mem = try std.testing.allocator.reallocBytes(new_mem, undefined, new_byte_count, runtime_alignment, 0, @returnAddress());
-        try std.testing.expectEqual(new_byte_count, new_mem.len);
-        try std.testing.expect(mem.isAligned(@ptrToInt(new_mem.ptr), runtime_alignment));
-    }
-
-    // `new_byte_count < new_mem.len`, this is a shrink, alignment is unmodified
-    new_byte_count = 14;
-    {
-        new_mem = try std.testing.allocator.reallocBytes(new_mem, runtime_alignment, new_byte_count, runtime_alignment, 0, @returnAddress());
-        try std.testing.expectEqual(new_byte_count, new_mem.len);
-        try std.testing.expect(mem.isAligned(@ptrToInt(new_mem.ptr), runtime_alignment));
-    }
-
-    // `new_byte_count < new_mem.len`, this is a shrink, alignment is decreased from 4 to 2
-    runtime_alignment = 2;
-    new_byte_count = 12;
-    {
-        new_mem = try std.testing.allocator.reallocBytes(new_mem, 4, new_byte_count, runtime_alignment, 0, @returnAddress());
-        try std.testing.expectEqual(new_byte_count, new_mem.len);
-        try std.testing.expect(mem.isAligned(@ptrToInt(new_mem.ptr), runtime_alignment));
-    }
-
-    // `new_byte_count > new_mem.len`, this is a growth, alignment is increased from 2 to 8
-    runtime_alignment = 8;
-    new_byte_count = 32;
-    {
-        new_mem = try std.testing.allocator.reallocBytes(new_mem, 2, new_byte_count, runtime_alignment, 0, @returnAddress());
-        try std.testing.expectEqual(new_byte_count, new_mem.len);
-        try std.testing.expect(mem.isAligned(@ptrToInt(new_mem.ptr), runtime_alignment));
-    }
-
-    // `new_byte_count == 0`, this is a free
-    new_byte_count = 0;
-    {
-        new_mem = try std.testing.allocator.reallocBytes(new_mem, runtime_alignment, new_byte_count, runtime_alignment, 0, @returnAddress());
-        try std.testing.expectEqual(new_byte_count, new_mem.len);
-    }
-}
-
-/// Call `vtable.resize`, but caller guarantees that `new_len` <= `buf.len` meaning
-/// than a `null` return value should be impossible.
-/// This function allows a runtime `buf_align` value. Callers should generally prefer
-/// to call `shrink`.
-pub fn shrinkBytes(
-    self: Allocator,
-    /// Must be the same as what was returned from most recent call to `allocFn` or `resizeFn`.
-    buf: []u8,
-    /// Must be the same as what was passed to `allocFn`.
-    /// Must be >= 1.
-    /// Must be a power of 2.
-    buf_align: u29,
-    /// Must be >= 1.
-    new_len: usize,
-    /// 0 indicates the length of the slice returned MUST match `new_len` exactly
-    /// non-zero means the length of the returned slice must be aligned by `len_align`
-    /// `new_len` must be aligned by `len_align`
-    len_align: u29,
-    return_address: usize,
-) usize {
-    assert(new_len <= buf.len);
-    return self.rawResize(buf, buf_align, new_len, len_align, return_address) orelse unreachable;
 }

--- a/lib/std/meta/trailer_flags.zig
+++ b/lib/std/meta/trailer_flags.zig
@@ -144,7 +144,7 @@ test "TrailerFlags" {
         .b = true,
         .c = true,
     });
-    const slice = try testing.allocator.allocAdvanced(u8, 8, flags.sizeInBytes(), .exact);
+    const slice = try testing.allocator.alignedAlloc(u8, 8, flags.sizeInBytes());
     defer testing.allocator.free(slice);
 
     flags.set(slice.ptr, .b, false);

--- a/lib/std/multi_array_list.zig
+++ b/lib/std/multi_array_list.zig
@@ -288,11 +288,10 @@ pub fn MultiArrayList(comptime S: type) type {
             assert(new_len <= self.capacity);
             assert(new_len <= self.len);
 
-            const other_bytes = gpa.allocAdvanced(
+            const other_bytes = gpa.alignedAlloc(
                 u8,
                 @alignOf(S),
                 capacityInBytes(new_len),
-                .exact,
             ) catch {
                 const self_slice = self.slice();
                 inline for (fields) |field_info, i| {
@@ -360,11 +359,10 @@ pub fn MultiArrayList(comptime S: type) type {
         /// `new_capacity` must be greater or equal to `len`.
         pub fn setCapacity(self: *Self, gpa: Allocator, new_capacity: usize) !void {
             assert(new_capacity >= self.len);
-            const new_bytes = try gpa.allocAdvanced(
+            const new_bytes = try gpa.alignedAlloc(
                 u8,
                 @alignOf(S),
                 capacityInBytes(new_capacity),
-                .exact,
             );
             if (self.len == 0) {
                 gpa.free(self.allocatedBytes());

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -825,7 +825,7 @@ pub fn getAddressList(allocator: mem.Allocator, name: []const u8, port: u16) !*A
 
         result.addrs = try arena.alloc(Address, lookup_addrs.items.len);
         if (canon.items.len != 0) {
-            result.canon_name = canon.toOwnedSlice();
+            result.canon_name = try canon.toOwnedSlice();
         }
 
         for (lookup_addrs.items) |lookup_addr, i| {

--- a/lib/std/pdb.zig
+++ b/lib/std/pdb.zig
@@ -478,7 +478,7 @@ fn readSparseBitVector(stream: anytype, allocator: mem.Allocator) ![]u32 {
             if (bit_i == std.math.maxInt(u5)) break;
         }
     }
-    return list.toOwnedSlice();
+    return try list.toOwnedSlice();
 }
 
 pub const Pdb = struct {
@@ -615,8 +615,8 @@ pub const Pdb = struct {
                 return error.InvalidDebugInfo;
         }
 
-        self.modules = modules.toOwnedSlice();
-        self.sect_contribs = sect_contribs.toOwnedSlice();
+        self.modules = try modules.toOwnedSlice();
+        self.sect_contribs = try sect_contribs.toOwnedSlice();
     }
 
     pub fn parseInfoStream(self: *Pdb) !void {

--- a/lib/std/segmented_list.zig
+++ b/lib/std/segmented_list.zig
@@ -1,6 +1,7 @@
 const std = @import("std.zig");
 const assert = std.debug.assert;
 const testing = std.testing;
+const mem = std.mem;
 const Allocator = std.mem.Allocator;
 
 // Imagine that `fn at(self: *Self, index: usize) &T` is a customer asking for a box
@@ -177,24 +178,32 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
             return self.growCapacity(allocator, new_capacity);
         }
 
-        /// Only grows capacity, or retains current capacity
+        /// Only grows capacity, or retains current capacity.
         pub fn growCapacity(self: *Self, allocator: Allocator, new_capacity: usize) Allocator.Error!void {
             const new_cap_shelf_count = shelfCount(new_capacity);
             const old_shelf_count = @intCast(ShelfIndex, self.dynamic_segments.len);
-            if (new_cap_shelf_count > old_shelf_count) {
-                self.dynamic_segments = try allocator.realloc(self.dynamic_segments, new_cap_shelf_count);
-                var i = old_shelf_count;
-                errdefer {
-                    self.freeShelves(allocator, i, old_shelf_count);
-                    self.dynamic_segments = allocator.shrink(self.dynamic_segments, old_shelf_count);
-                }
-                while (i < new_cap_shelf_count) : (i += 1) {
-                    self.dynamic_segments[i] = (try allocator.alloc(T, shelfSize(i))).ptr;
-                }
+            if (new_cap_shelf_count <= old_shelf_count) return;
+
+            const new_dynamic_segments = try allocator.alloc([*]T, new_cap_shelf_count);
+            errdefer allocator.free(new_dynamic_segments);
+
+            var i: ShelfIndex = 0;
+            while (i < old_shelf_count) : (i += 1) {
+                new_dynamic_segments[i] = self.dynamic_segments[i];
             }
+            errdefer while (i > old_shelf_count) : (i -= 1) {
+                allocator.free(new_dynamic_segments[i][0..shelfSize(i)]);
+            };
+            while (i < new_cap_shelf_count) : (i += 1) {
+                new_dynamic_segments[i] = (try allocator.alloc(T, shelfSize(i))).ptr;
+            }
+
+            allocator.free(self.dynamic_segments);
+            self.dynamic_segments = new_dynamic_segments;
         }
 
-        /// Only shrinks capacity or retains current capacity
+        /// Only shrinks capacity or retains current capacity.
+        /// It may fail to reduce the capacity in which case the capacity will remain unchanged.
         pub fn shrinkCapacity(self: *Self, allocator: Allocator, new_capacity: usize) void {
             if (new_capacity <= prealloc_item_count) {
                 const len = @intCast(ShelfIndex, self.dynamic_segments.len);
@@ -207,12 +216,24 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
             const new_cap_shelf_count = shelfCount(new_capacity);
             const old_shelf_count = @intCast(ShelfIndex, self.dynamic_segments.len);
             assert(new_cap_shelf_count <= old_shelf_count);
-            if (new_cap_shelf_count == old_shelf_count) {
-                return;
-            }
+            if (new_cap_shelf_count == old_shelf_count) return;
 
+            // freeShelves() must be called before resizing the dynamic
+            // segments, but we don't know if resizing the dynamic segments
+            // will work until we try it. So we must allocate a fresh memory
+            // buffer in order to reduce capacity.
+            const new_dynamic_segments = allocator.alloc([*]T, new_cap_shelf_count) catch return;
             self.freeShelves(allocator, old_shelf_count, new_cap_shelf_count);
-            self.dynamic_segments = allocator.shrink(self.dynamic_segments, new_cap_shelf_count);
+            if (allocator.resize(self.dynamic_segments, new_cap_shelf_count)) {
+                // We didn't need the new memory allocation after all.
+                self.dynamic_segments = self.dynamic_segments[0..new_cap_shelf_count];
+                allocator.free(new_dynamic_segments);
+            } else {
+                // Good thing we allocated that new memory slice.
+                mem.copy([*]T, new_dynamic_segments, self.dynamic_segments[0..new_cap_shelf_count]);
+                allocator.free(self.dynamic_segments);
+                self.dynamic_segments = new_dynamic_segments;
+            }
         }
 
         pub fn shrink(self: *Self, new_len: usize) void {
@@ -227,10 +248,10 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
 
             var i = start;
             if (end <= prealloc_item_count) {
-                std.mem.copy(T, dest[i - start ..], self.prealloc_segment[i..end]);
+                mem.copy(T, dest[i - start ..], self.prealloc_segment[i..end]);
                 return;
             } else if (i < prealloc_item_count) {
-                std.mem.copy(T, dest[i - start ..], self.prealloc_segment[i..]);
+                mem.copy(T, dest[i - start ..], self.prealloc_segment[i..]);
                 i = prealloc_item_count;
             }
 
@@ -239,7 +260,7 @@ pub fn SegmentedList(comptime T: type, comptime prealloc_item_count: usize) type
                 const copy_start = boxIndex(i, shelf_index);
                 const copy_end = std.math.min(shelfSize(shelf_index), copy_start + end - i);
 
-                std.mem.copy(
+                mem.copy(
                     T,
                     dest[i - start ..],
                     self.dynamic_segments[shelf_index][copy_start..copy_end],
@@ -480,13 +501,13 @@ fn testSegmentedList(comptime prealloc: usize) !void {
             control[@intCast(usize, i)] = i + 1;
         }
 
-        std.mem.set(i32, dest[0..], 0);
+        mem.set(i32, dest[0..], 0);
         list.writeToSlice(dest[0..], 0);
-        try testing.expect(std.mem.eql(i32, control[0..], dest[0..]));
+        try testing.expect(mem.eql(i32, control[0..], dest[0..]));
 
-        std.mem.set(i32, dest[0..], 0);
+        mem.set(i32, dest[0..], 0);
         list.writeToSlice(dest[50..], 50);
-        try testing.expect(std.mem.eql(i32, control[50..], dest[50..]));
+        try testing.expect(mem.eql(i32, control[50..], dest[50..]));
     }
 
     try list.setCapacity(testing.allocator, 0);

--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -611,12 +611,7 @@ pub fn utf16leToUtf8AllocZ(allocator: mem.Allocator, utf16le: []const u16) ![:0]
         assert((utf8Encode(codepoint, result.items[out_index..]) catch unreachable) == utf8_len);
         out_index += utf8_len;
     }
-
-    const len = result.items.len;
-
-    try result.append(0);
-
-    return result.toOwnedSlice()[0..len :0];
+    return result.toOwnedSliceSentinel(0);
 }
 
 /// Asserts that the output buffer is big enough.
@@ -714,9 +709,7 @@ pub fn utf8ToUtf16LeWithNull(allocator: mem.Allocator, utf8: []const u8) ![:0]u1
         }
     }
 
-    const len = result.items.len;
-    try result.append(0);
-    return result.toOwnedSlice()[0..len :0];
+    return result.toOwnedSliceSentinel(0);
 }
 
 /// Returns index of next character. If exact fit, returned index equals output slice length.

--- a/lib/std/zig/parse.zig
+++ b/lib/std/zig/parse.zig
@@ -72,8 +72,8 @@ pub fn parse(gpa: Allocator, source: [:0]const u8) Allocator.Error!Ast {
         .source = source,
         .tokens = tokens.toOwnedSlice(),
         .nodes = parser.nodes.toOwnedSlice(),
-        .extra_data = parser.extra_data.toOwnedSlice(gpa),
-        .errors = parser.errors.toOwnedSlice(gpa),
+        .extra_data = try parser.extra_data.toOwnedSlice(gpa),
+        .errors = try parser.errors.toOwnedSlice(gpa),
     };
 }
 

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -199,8 +199,8 @@ pub fn generate(gpa: Allocator, tree: Ast) Allocator.Error!Zir {
 
     return Zir{
         .instructions = astgen.instructions.toOwnedSlice(),
-        .string_bytes = astgen.string_bytes.toOwnedSlice(gpa),
-        .extra = astgen.extra.toOwnedSlice(gpa),
+        .string_bytes = try astgen.string_bytes.toOwnedSlice(gpa),
+        .extra = try astgen.extra.toOwnedSlice(gpa),
     };
 }
 

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -146,46 +146,46 @@ pub fn generateZirData(self: *Autodoc) !void {
                     .c_ulonglong_type,
                     .c_longdouble_type,
                     => .{
-                        .Int = .{ .name = tmpbuf.toOwnedSlice() },
+                        .Int = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
                     .f16_type,
                     .f32_type,
                     .f64_type,
                     .f128_type,
                     => .{
-                        .Float = .{ .name = tmpbuf.toOwnedSlice() },
+                        .Float = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
                     .comptime_int_type => .{
-                        .ComptimeInt = .{ .name = tmpbuf.toOwnedSlice() },
+                        .ComptimeInt = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
                     .comptime_float_type => .{
-                        .ComptimeFloat = .{ .name = tmpbuf.toOwnedSlice() },
+                        .ComptimeFloat = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
 
                     .anyopaque_type => .{
-                        .ComptimeExpr = .{ .name = tmpbuf.toOwnedSlice() },
+                        .ComptimeExpr = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
                     .bool_type => .{
-                        .Bool = .{ .name = tmpbuf.toOwnedSlice() },
+                        .Bool = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
 
                     .noreturn_type => .{
-                        .NoReturn = .{ .name = tmpbuf.toOwnedSlice() },
+                        .NoReturn = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
                     .void_type => .{
-                        .Void = .{ .name = tmpbuf.toOwnedSlice() },
+                        .Void = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
                     .type_info_type => .{
-                        .ComptimeExpr = .{ .name = tmpbuf.toOwnedSlice() },
+                        .ComptimeExpr = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
                     .type_type => .{
-                        .Type = .{ .name = tmpbuf.toOwnedSlice() },
+                        .Type = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
                     .anyerror_type => .{
-                        .ErrorSet = .{ .name = tmpbuf.toOwnedSlice() },
+                        .ErrorSet = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
                     .calling_convention_inline, .calling_convention_c, .calling_convention_type => .{
-                        .EnumLiteral = .{ .name = tmpbuf.toOwnedSlice() },
+                        .EnumLiteral = .{ .name = try tmpbuf.toOwnedSlice() },
                     },
                 },
             );

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5052,7 +5052,7 @@ fn parseLldStderr(comp: *Compilation, comptime prefix: []const u8, stderr: []con
     while (lines.next()) |line| {
         if (mem.startsWith(u8, line, prefix ++ ":")) {
             if (current_err) |err| {
-                err.context_lines = context_lines.toOwnedSlice();
+                err.context_lines = try context_lines.toOwnedSlice();
             }
 
             var split = std.mem.split(u8, line, "error: ");
@@ -5078,7 +5078,7 @@ fn parseLldStderr(comp: *Compilation, comptime prefix: []const u8, stderr: []con
     }
 
     if (current_err) |err| {
-        err.context_lines = context_lines.toOwnedSlice();
+        err.context_lines = try context_lines.toOwnedSlice();
     }
 }
 

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -79,7 +79,7 @@ pub fn analyze(gpa: Allocator, air: Air) Allocator.Error!Liveness {
     return Liveness{
         .tomb_bits = a.tomb_bits,
         .special = a.special,
-        .extra = a.extra.toOwnedSlice(gpa),
+        .extra = try a.extra.toOwnedSlice(gpa),
     };
 }
 
@@ -594,7 +594,7 @@ pub fn getSwitchBr(l: Liveness, gpa: Allocator, inst: Air.Inst.Index, cases_len:
         deaths.appendAssumeCapacity(else_deaths);
     }
     return SwitchBrTable{
-        .deaths = deaths.toOwnedSlice(),
+        .deaths = try deaths.toOwnedSlice(),
     };
 }
 

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -53,12 +53,12 @@ local_zir_cache: Compilation.Directory,
 /// map of Decl indexes to details about them being exported.
 /// The Export memory is owned by the `export_owners` table; the slice itself
 /// is owned by this table. The slice is guaranteed to not be empty.
-decl_exports: std.AutoArrayHashMapUnmanaged(Decl.Index, []*Export) = .{},
+decl_exports: std.AutoArrayHashMapUnmanaged(Decl.Index, ArrayListUnmanaged(*Export)) = .{},
 /// This models the Decls that perform exports, so that `decl_exports` can be updated when a Decl
 /// is modified. Note that the key of this table is not the Decl being exported, but the Decl that
 /// is performing the export of another Decl.
 /// This table owns the Export memory.
-export_owners: std.AutoArrayHashMapUnmanaged(Decl.Index, []*Export) = .{},
+export_owners: std.AutoArrayHashMapUnmanaged(Decl.Index, ArrayListUnmanaged(*Export)) = .{},
 /// The set of all the Zig source files in the Module. We keep track of this in order
 /// to iterate over it and check which source files have been modified on the file system when
 /// an update is requested, as well as to cache `@import` results.
@@ -80,7 +80,7 @@ embed_table: std.StringHashMapUnmanaged(*EmbedFile) = .{},
 /// This table uses an optional index so that when a Decl is destroyed, the string literal
 /// is still reclaimable by a future Decl.
 string_literal_table: std.HashMapUnmanaged(StringLiteralContext.Key, Decl.OptionalIndex, StringLiteralContext, std.hash_map.default_max_load_percentage) = .{},
-string_literal_bytes: std.ArrayListUnmanaged(u8) = .{},
+string_literal_bytes: ArrayListUnmanaged(u8) = .{},
 
 /// The set of all the generic function instantiations. This is used so that when a generic
 /// function is called twice with the same comptime parameter arguments, both calls dispatch
@@ -163,7 +163,7 @@ test_functions: std.AutoArrayHashMapUnmanaged(Decl.Index, void) = .{},
 ///    multi-threaded contention on an atomic counter.
 allocated_decls: std.SegmentedList(Decl, 0) = .{},
 /// When a Decl object is freed from `allocated_decls`, it is pushed into this stack.
-decls_free_list: std.ArrayListUnmanaged(Decl.Index) = .{},
+decls_free_list: ArrayListUnmanaged(Decl.Index) = .{},
 
 global_assembly: std.AutoHashMapUnmanaged(Decl.Index, []u8) = .{},
 
@@ -173,7 +173,7 @@ reference_table: std.AutoHashMapUnmanaged(Decl.Index, struct {
 }) = .{},
 
 pub const StringLiteralContext = struct {
-    bytes: *std.ArrayListUnmanaged(u8),
+    bytes: *ArrayListUnmanaged(u8),
 
     pub const Key = struct {
         index: u32,
@@ -192,7 +192,7 @@ pub const StringLiteralContext = struct {
 };
 
 pub const StringLiteralAdapter = struct {
-    bytes: *std.ArrayListUnmanaged(u8),
+    bytes: *ArrayListUnmanaged(u8),
 
     pub fn eql(self: @This(), a_slice: []const u8, b: StringLiteralContext.Key) bool {
         const b_slice = self.bytes.items[b.index..][0..b.len];
@@ -1896,11 +1896,11 @@ pub const File = struct {
 
     /// Used by change detection algorithm, after astgen, contains the
     /// set of decls that existed in the previous ZIR but not in the new one.
-    deleted_decls: std.ArrayListUnmanaged(Decl.Index) = .{},
+    deleted_decls: ArrayListUnmanaged(Decl.Index) = .{},
     /// Used by change detection algorithm, after astgen, contains the
     /// set of decls that existed both in the previous ZIR and in the new one,
     /// but their source code has been modified.
-    outdated_decls: std.ArrayListUnmanaged(Decl.Index) = .{},
+    outdated_decls: ArrayListUnmanaged(Decl.Index) = .{},
 
     /// The most recent successful ZIR for this file, with no errors.
     /// This is only populated when a previously successful ZIR
@@ -3438,12 +3438,12 @@ pub fn deinit(mod: *Module) void {
 
     mod.compile_log_decls.deinit(gpa);
 
-    for (mod.decl_exports.values()) |export_list| {
-        gpa.free(export_list);
+    for (mod.decl_exports.values()) |*export_list| {
+        export_list.deinit(gpa);
     }
     mod.decl_exports.deinit(gpa);
 
-    for (mod.export_owners.values()) |value| {
+    for (mod.export_owners.values()) |*value| {
         freeExportList(gpa, value);
     }
     mod.export_owners.deinit(gpa);
@@ -3533,13 +3533,13 @@ pub fn declIsRoot(mod: *Module, decl_index: Decl.Index) bool {
     return decl_index == decl.src_namespace.getDeclIndex();
 }
 
-fn freeExportList(gpa: Allocator, export_list: []*Export) void {
-    for (export_list) |exp| {
+fn freeExportList(gpa: Allocator, export_list: *ArrayListUnmanaged(*Export)) void {
+    for (export_list.items) |exp| {
         gpa.free(exp.options.name);
         if (exp.options.section) |s| gpa.free(s);
         gpa.destroy(exp);
     }
-    gpa.free(export_list);
+    export_list.deinit(gpa);
 }
 
 const data_has_safety_tag = @sizeOf(Zir.Inst.Data) != 8;
@@ -3822,7 +3822,7 @@ pub fn astGenFile(mod: *Module, file: *File) !void {
                     .byte_abs = token_starts[parse_err.token] + extra_offset,
                 },
             },
-            .msg = msg.toOwnedSlice(),
+            .msg = try msg.toOwnedSlice(),
         };
         if (token_tags[parse_err.token + @boolToInt(parse_err.token_is_prev)] == .invalid) {
             const bad_off = @intCast(u32, file.tree.tokenSlice(parse_err.token + @boolToInt(parse_err.token_is_prev)).len);
@@ -3845,7 +3845,7 @@ pub fn astGenFile(mod: *Module, file: *File) !void {
                     .parent_decl_node = 0,
                     .lazy = .{ .token_abs = note.token },
                 },
-                .msg = msg.toOwnedSlice(),
+                .msg = try msg.toOwnedSlice(),
             };
         }
 
@@ -3981,7 +3981,7 @@ fn updateZirRefs(mod: *Module, file: *File, old_zir: Zir) !void {
     // Walk the Decl graph, updating ZIR indexes, strings, and populating
     // the deleted and outdated lists.
 
-    var decl_stack: std.ArrayListUnmanaged(Decl.Index) = .{};
+    var decl_stack: ArrayListUnmanaged(Decl.Index) = .{};
     defer decl_stack.deinit(gpa);
 
     const root_decl = file.root_decl.unwrap().?;
@@ -4146,7 +4146,7 @@ pub fn mapOldZirToNew(
         old_inst: Zir.Inst.Index,
         new_inst: Zir.Inst.Index,
     };
-    var match_stack: std.ArrayListUnmanaged(MatchedZirDecl) = .{};
+    var match_stack: ArrayListUnmanaged(MatchedZirDecl) = .{};
     defer match_stack.deinit(gpa);
 
     // Main struct inst is always the same
@@ -5488,12 +5488,12 @@ pub fn abortAnonDecl(mod: *Module, decl_index: Decl.Index) void {
 /// Delete all the Export objects that are caused by this Decl. Re-analysis of
 /// this Decl will cause them to be re-created (or not).
 fn deleteDeclExports(mod: *Module, decl_index: Decl.Index) void {
-    const kv = mod.export_owners.fetchSwapRemove(decl_index) orelse return;
+    var export_owners = (mod.export_owners.fetchSwapRemove(decl_index) orelse return).value;
 
-    for (kv.value) |exp| {
+    for (export_owners.items) |exp| {
         if (mod.decl_exports.getPtr(exp.exported_decl)) |value_ptr| {
             // Remove exports with owner_decl matching the regenerating decl.
-            const list = value_ptr.*;
+            const list = value_ptr.items;
             var i: usize = 0;
             var new_len = list.len;
             while (i < new_len) {
@@ -5504,7 +5504,7 @@ fn deleteDeclExports(mod: *Module, decl_index: Decl.Index) void {
                     i += 1;
                 }
             }
-            value_ptr.* = mod.gpa.shrink(list, new_len);
+            value_ptr.shrinkAndFree(mod.gpa, new_len);
             if (new_len == 0) {
                 assert(mod.decl_exports.swapRemove(exp.exported_decl));
             }
@@ -5527,7 +5527,7 @@ fn deleteDeclExports(mod: *Module, decl_index: Decl.Index) void {
         mod.gpa.free(exp.options.name);
         mod.gpa.destroy(exp);
     }
-    mod.gpa.free(kv.value);
+    export_owners.deinit(mod.gpa);
 }
 
 pub fn analyzeFnBody(mod: *Module, func: *Fn, arena: Allocator) SemaError!Air {
@@ -5745,8 +5745,8 @@ pub fn analyzeFnBody(mod: *Module, func: *Fn, arena: Allocator) SemaError!Air {
 
     return Air{
         .instructions = sema.air_instructions.toOwnedSlice(),
-        .extra = sema.air_extra.toOwnedSlice(gpa),
-        .values = sema.air_values.toOwnedSlice(gpa),
+        .extra = try sema.air_extra.toOwnedSlice(gpa),
+        .values = try sema.air_values.toOwnedSlice(gpa),
     };
 }
 
@@ -6415,7 +6415,7 @@ pub fn processExports(mod: *Module) !void {
     var it = mod.decl_exports.iterator();
     while (it.next()) |entry| {
         const exported_decl = entry.key_ptr.*;
-        const exports = entry.value_ptr.*;
+        const exports = entry.value_ptr.items;
         for (exports) |new_export| {
             const gop = try symbol_exports.getOrPut(gpa, new_export.options.name);
             if (gop.found_existing) {
@@ -6694,4 +6694,12 @@ pub fn addGlobalAssembly(mod: *Module, decl_index: Decl.Index, source: []const u
 
 pub fn wantDllExports(mod: Module) bool {
     return mod.comp.bin_file.options.dll_export_fns and mod.getTarget().os.tag == .windows;
+}
+
+pub fn getDeclExports(mod: Module, decl_index: Decl.Index) []const *Export {
+    if (mod.decl_exports.get(decl_index)) |l| {
+        return l.items;
+    } else {
+        return &[0]*Export{};
+    }
 }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -19299,6 +19299,7 @@ fn zirBitCount(
         .Int => {
             if (try sema.resolveMaybeUndefVal(operand)) |val| {
                 if (val.isUndef()) return sema.addConstUndef(result_scalar_ty);
+                try sema.resolveLazyValue(val);
                 return sema.addIntUnsigned(result_scalar_ty, comptimeOp(val, operand_ty, target));
             } else {
                 try sema.requireRuntimeBlock(block, src, operand_src);

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -531,7 +531,7 @@ pub fn generate(
 
     var mir = Mir{
         .instructions = function.mir_instructions.toOwnedSlice(),
-        .extra = function.mir_extra.toOwnedSlice(bin_file.allocator),
+        .extra = try function.mir_extra.toOwnedSlice(bin_file.allocator),
     };
     defer mir.deinit(bin_file.allocator);
 

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -328,7 +328,7 @@ pub fn generate(
 
     var mir = Mir{
         .instructions = function.mir_instructions.toOwnedSlice(),
-        .extra = function.mir_extra.toOwnedSlice(bin_file.allocator),
+        .extra = try function.mir_extra.toOwnedSlice(bin_file.allocator),
     };
     defer mir.deinit(bin_file.allocator);
 

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -291,7 +291,7 @@ pub fn generate(
 
     var mir = Mir{
         .instructions = function.mir_instructions.toOwnedSlice(),
-        .extra = function.mir_extra.toOwnedSlice(bin_file.allocator),
+        .extra = try function.mir_extra.toOwnedSlice(bin_file.allocator),
     };
     defer mir.deinit(bin_file.allocator);
 

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -330,7 +330,7 @@ pub fn generate(
 
     var mir = Mir{
         .instructions = function.mir_instructions.toOwnedSlice(),
-        .extra = function.mir_extra.toOwnedSlice(bin_file.allocator),
+        .extra = try function.mir_extra.toOwnedSlice(bin_file.allocator),
     };
     defer mir.deinit(bin_file.allocator);
 

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1064,8 +1064,8 @@ fn genFunctype(gpa: Allocator, cc: std.builtin.CallingConvention, params: []cons
     }
 
     return wasm.Type{
-        .params = temp_params.toOwnedSlice(),
-        .returns = returns.toOwnedSlice(),
+        .params = try temp_params.toOwnedSlice(),
+        .returns = try returns.toOwnedSlice(),
     };
 }
 
@@ -1176,7 +1176,7 @@ fn genFunc(func: *CodeGen) InnerError!void {
 
     var mir: Mir = .{
         .instructions = func.mir_instructions.toOwnedSlice(),
-        .extra = func.mir_extra.toOwnedSlice(func.gpa),
+        .extra = try func.mir_extra.toOwnedSlice(func.gpa),
     };
     defer mir.deinit(func.gpa);
 
@@ -1258,7 +1258,7 @@ fn resolveCallingConventionValues(func: *CodeGen, fn_ty: Type) InnerError!CallWV
         },
         else => return func.fail("calling convention '{s}' not supported for Wasm", .{@tagName(cc)}),
     }
-    result.args = args.toOwnedSlice();
+    result.args = try args.toOwnedSlice();
     return result;
 }
 

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -331,7 +331,7 @@ pub fn generate(
 
     var mir = Mir{
         .instructions = function.mir_instructions.toOwnedSlice(),
-        .extra = function.mir_extra.toOwnedSlice(bin_file.allocator),
+        .extra = try function.mir_extra.toOwnedSlice(bin_file.allocator),
     };
     defer mir.deinit(bin_file.allocator);
 

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1286,7 +1286,7 @@ pub const DeclGen = struct {
         }
         try bw.writeAll(");\n");
 
-        const rendered = buffer.toOwnedSlice();
+        const rendered = try buffer.toOwnedSlice();
         errdefer dg.typedefs.allocator.free(rendered);
         const name = rendered[name_begin..name_end];
 
@@ -1326,7 +1326,7 @@ pub const DeclGen = struct {
         const name_end = buffer.items.len;
         try bw.writeAll(";\n");
 
-        const rendered = buffer.toOwnedSlice();
+        const rendered = try buffer.toOwnedSlice();
         errdefer dg.typedefs.allocator.free(rendered);
         const name = rendered[name_begin..name_end];
 
@@ -1369,7 +1369,7 @@ pub const DeclGen = struct {
         buffer.appendSliceAssumeCapacity(buffer.items[name_begin..name_end]);
         buffer.appendSliceAssumeCapacity(";\n");
 
-        const rendered = buffer.toOwnedSlice();
+        const rendered = try buffer.toOwnedSlice();
         errdefer dg.typedefs.allocator.free(rendered);
         const name = rendered[name_begin..name_end];
 
@@ -1413,7 +1413,7 @@ pub const DeclGen = struct {
         }
         try buffer.appendSlice("};\n");
 
-        const rendered = buffer.toOwnedSlice();
+        const rendered = try buffer.toOwnedSlice();
         errdefer dg.typedefs.allocator.free(rendered);
 
         try dg.typedefs.ensureUnusedCapacity(1);
@@ -1448,7 +1448,7 @@ pub const DeclGen = struct {
         try buffer.writer().print("}} zig_T_{};\n", .{typeToCIdentifier(t, dg.module)});
         const name_end = buffer.items.len - ";\n".len;
 
-        const rendered = buffer.toOwnedSlice();
+        const rendered = try buffer.toOwnedSlice();
         errdefer dg.typedefs.allocator.free(rendered);
         const name = rendered[name_begin..name_end];
 
@@ -1510,7 +1510,7 @@ pub const DeclGen = struct {
         if (t.unionTagTypeSafety()) |_| try buffer.appendSlice(" } payload;\n");
         try buffer.appendSlice("};\n");
 
-        const rendered = buffer.toOwnedSlice();
+        const rendered = try buffer.toOwnedSlice();
         errdefer dg.typedefs.allocator.free(rendered);
 
         try dg.typedefs.ensureUnusedCapacity(1);
@@ -1553,7 +1553,7 @@ pub const DeclGen = struct {
         const name_end = buffer.items.len;
         try bw.writeAll(";\n");
 
-        const rendered = buffer.toOwnedSlice();
+        const rendered = try buffer.toOwnedSlice();
         errdefer dg.typedefs.allocator.free(rendered);
         const name = rendered[name_begin..name_end];
 
@@ -1586,7 +1586,7 @@ pub const DeclGen = struct {
         const c_len_val = Value.initPayload(&c_len_pl.base);
         try bw.print("[{}];\n", .{try dg.fmtIntLiteral(Type.usize, c_len_val)});
 
-        const rendered = buffer.toOwnedSlice();
+        const rendered = try buffer.toOwnedSlice();
         errdefer dg.typedefs.allocator.free(rendered);
         const name = rendered[name_begin..name_end];
 
@@ -1614,7 +1614,7 @@ pub const DeclGen = struct {
         const name_end = buffer.items.len;
         try bw.writeAll(";\n");
 
-        const rendered = buffer.toOwnedSlice();
+        const rendered = try buffer.toOwnedSlice();
         errdefer dg.typedefs.allocator.free(rendered);
         const name = rendered[name_begin..name_end];
 
@@ -1643,7 +1643,7 @@ pub const DeclGen = struct {
         const name_end = buffer.items.len;
         try buffer.appendSlice(";\n");
 
-        const rendered = buffer.toOwnedSlice();
+        const rendered = try buffer.toOwnedSlice();
         errdefer dg.typedefs.allocator.free(rendered);
         const name = rendered[name_begin..name_end];
 
@@ -2006,7 +2006,7 @@ pub const DeclGen = struct {
         _ = try airBreakpoint(bw);
         try buffer.appendSlice("}\n");
 
-        const rendered = buffer.toOwnedSlice();
+        const rendered = try buffer.toOwnedSlice();
         errdefer dg.typedefs.allocator.free(rendered);
         const name = rendered[name_begin..name_end];
 
@@ -2108,7 +2108,7 @@ pub const DeclGen = struct {
         dg.module.markDeclAlive(decl);
 
         if (dg.module.decl_exports.get(decl_index)) |exports| {
-            return writer.writeAll(exports[0].options.name);
+            return writer.writeAll(exports.items[0].options.name);
         } else if (decl.isExtern()) {
             return writer.writeAll(mem.sliceTo(decl.name, 0));
         } else {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -693,7 +693,7 @@ pub const Object = struct {
         for (mod.decl_exports.values()) |export_list, i| {
             const decl_index = export_keys[i];
             const llvm_global = object.decl_map.get(decl_index) orelse continue;
-            for (export_list) |exp| {
+            for (export_list.items) |exp| {
                 // Detect if the LLVM global has already been created as an extern. In such
                 // case, we need to replace all uses of it with this exported global.
                 // TODO update std.builtin.ExportOptions to have the name be a
@@ -1215,8 +1215,7 @@ pub const Object = struct {
             else => |e| return e,
         };
 
-        const decl_exports = module.decl_exports.get(decl_index) orelse &[0]*Module.Export{};
-        try o.updateDeclExports(module, decl_index, decl_exports);
+        try o.updateDeclExports(module, decl_index, module.getDeclExports(decl_index));
     }
 
     pub fn updateDecl(self: *Object, module: *Module, decl_index: Module.Decl.Index) !void {
@@ -1239,8 +1238,7 @@ pub const Object = struct {
             },
             else => |e| return e,
         };
-        const decl_exports = module.decl_exports.get(decl_index) orelse &[0]*Module.Export{};
-        try self.updateDeclExports(module, decl_index, decl_exports);
+        try self.updateDeclExports(module, decl_index, module.getDeclExports(decl_index));
     }
 
     /// TODO replace this with a call to `Module::getNamedValue`. This will require adding

--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -387,7 +387,7 @@ pub const LibCInstallation = struct {
                 else => return error.FileSystem,
             };
 
-            self.include_dir = result_buf.toOwnedSlice();
+            self.include_dir = try result_buf.toOwnedSlice();
             return;
         }
 
@@ -434,7 +434,7 @@ pub const LibCInstallation = struct {
                 else => return error.FileSystem,
             };
 
-            self.crt_dir = result_buf.toOwnedSlice();
+            self.crt_dir = try result_buf.toOwnedSlice();
             return;
         }
         return error.LibCRuntimeNotFound;
@@ -499,7 +499,7 @@ pub const LibCInstallation = struct {
                 else => return error.FileSystem,
             };
 
-            self.kernel32_lib_dir = result_buf.toOwnedSlice();
+            self.kernel32_lib_dir = try result_buf.toOwnedSlice();
             return;
         }
         return error.LibCKernel32LibNotFound;

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -938,9 +938,9 @@ pub fn updateFunc(self: *Coff, module: *Module, func: *Module.Fn, air: Air, live
 
     try self.updateDeclCode(decl_index, code, .FUNCTION);
 
-    // Since we updated the vaddr and the size, each corresponding export symbol also needs to be updated.
-    const decl_exports = module.decl_exports.get(decl_index) orelse &[0]*Module.Export{};
-    return self.updateDeclExports(module, decl_index, decl_exports);
+    // Since we updated the vaddr and the size, each corresponding export
+    // symbol also needs to be updated.
+    return self.updateDeclExports(module, decl_index, module.getDeclExports(decl_index));
 }
 
 pub fn lowerUnnamedConst(self: *Coff, tv: TypedValue, decl_index: Module.Decl.Index) !u32 {
@@ -1053,9 +1053,9 @@ pub fn updateDecl(self: *Coff, module: *Module, decl_index: Module.Decl.Index) !
 
     try self.updateDeclCode(decl_index, code, .NULL);
 
-    // Since we updated the vaddr and the size, each corresponding export symbol also needs to be updated.
-    const decl_exports = module.decl_exports.get(decl_index) orelse &[0]*Module.Export{};
-    return self.updateDeclExports(module, decl_index, decl_exports);
+    // Since we updated the vaddr and the size, each corresponding export
+    // symbol also needs to be updated.
+    return self.updateDeclExports(module, decl_index, module.getDeclExports(decl_index));
 }
 
 fn getDeclOutputSection(self: *Coff, decl: *Module.Decl) u16 {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2450,9 +2450,9 @@ pub fn updateFunc(self: *Elf, module: *Module, func: *Module.Fn, air: Air, liven
         );
     }
 
-    // Since we updated the vaddr and the size, each corresponding export symbol also needs to be updated.
-    const decl_exports = module.decl_exports.get(decl_index) orelse &[0]*Module.Export{};
-    return self.updateDeclExports(module, decl_index, decl_exports);
+    // Since we updated the vaddr and the size, each corresponding export
+    // symbol also needs to be updated.
+    return self.updateDeclExports(module, decl_index, module.getDeclExports(decl_index));
 }
 
 pub fn updateDecl(self: *Elf, module: *Module, decl_index: Module.Decl.Index) !void {
@@ -2527,9 +2527,9 @@ pub fn updateDecl(self: *Elf, module: *Module, decl_index: Module.Decl.Index) !v
         );
     }
 
-    // Since we updated the vaddr and the size, each corresponding export symbol also needs to be updated.
-    const decl_exports = module.decl_exports.get(decl_index) orelse &[0]*Module.Export{};
-    return self.updateDeclExports(module, decl_index, decl_exports);
+    // Since we updated the vaddr and the size, each corresponding export
+    // symbol also needs to be updated.
+    return self.updateDeclExports(module, decl_index, module.getDeclExports(decl_index));
 }
 
 pub fn lowerUnnamedConst(self: *Elf, typed_value: TypedValue, decl_index: Module.Decl.Index) !u32 {

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2225,8 +2225,7 @@ pub fn updateFunc(self: *MachO, module: *Module, func: *Module.Fn, air: Air, liv
 
     // Since we updated the vaddr and the size, each corresponding export symbol also
     // needs to be updated.
-    const decl_exports = module.decl_exports.get(decl_index) orelse &[0]*Module.Export{};
-    try self.updateDeclExports(module, decl_index, decl_exports);
+    try self.updateDeclExports(module, decl_index, module.getDeclExports(decl_index));
 }
 
 pub fn lowerUnnamedConst(self: *MachO, typed_value: TypedValue, decl_index: Module.Decl.Index) !u32 {
@@ -2377,8 +2376,7 @@ pub fn updateDecl(self: *MachO, module: *Module, decl_index: Module.Decl.Index) 
 
     // Since we updated the vaddr and the size, each corresponding export symbol also
     // needs to be updated.
-    const decl_exports = module.decl_exports.get(decl_index) orelse &[0]*Module.Export{};
-    try self.updateDeclExports(module, decl_index, decl_exports);
+    try self.updateDeclExports(module, decl_index, module.getDeclExports(decl_index));
 }
 
 fn getDeclOutputSection(self: *MachO, decl: *Module.Decl) u8 {

--- a/src/link/MachO/Trie.zig
+++ b/src/link/MachO/Trie.zig
@@ -165,7 +165,7 @@ pub const Node = struct {
                         break;
                     try label_buf.append(next);
                 }
-                break :blk label_buf.toOwnedSlice();
+                break :blk try label_buf.toOwnedSlice();
             };
 
             const seek_to = try leb.readULEB128(u64, reader);

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -3206,7 +3206,7 @@ fn linkWithLLD(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) !
                     const skip_export_non_fn = target.os.tag == .wasi and
                         wasm.base.options.wasi_exec_model == .command;
                     for (mod.decl_exports.values()) |exports| {
-                        for (exports) |exprt| {
+                        for (exports.items) |exprt| {
                             const exported_decl = mod.declPtr(exprt.exported_decl);
                             if (skip_export_non_fn and exported_decl.ty.zigTypeTag() != .Fn) {
                                 // skip exporting symbols when we're building a WASI command

--- a/src/link/Wasm/Object.zig
+++ b/src/link/Wasm/Object.zig
@@ -557,7 +557,7 @@ fn Parser(comptime ReaderType: type) type {
                 error.EndOfStream => {}, // finished parsing the file
                 else => |e| return e,
             }
-            parser.object.relocatable_data = relocatable_data.toOwnedSlice();
+            parser.object.relocatable_data = try relocatable_data.toOwnedSlice();
         }
 
         /// Based on the "features" custom section, parses it into a list of
@@ -742,7 +742,7 @@ fn Parser(comptime ReaderType: type) type {
                         log.debug("Found legacy indirect function table. Created symbol", .{});
                     }
 
-                    parser.object.symtable = symbols.toOwnedSlice();
+                    parser.object.symtable = try symbols.toOwnedSlice();
                 },
             }
         }

--- a/src/link/tapi/parse.zig
+++ b/src/link/tapi/parse.zig
@@ -262,7 +262,7 @@ pub const Tree = struct {
         }
 
         self.source = source;
-        self.tokens = tokens.toOwnedSlice();
+        self.tokens = try tokens.toOwnedSlice();
 
         var it = TokenIterator{ .buffer = self.tokens };
         var parser = Parser{

--- a/src/link/tapi/yaml.zig
+++ b/src/link/tapi/yaml.zig
@@ -193,7 +193,7 @@ pub const Value = union(ValueType) {
                 }
             }
 
-            return Value{ .list = out_list.toOwnedSlice() };
+            return Value{ .list = try out_list.toOwnedSlice() };
         } else if (node.cast(Node.Value)) |value| {
             const start = tree.tokens[value.start.?];
             const end = tree.tokens[value.end.?];

--- a/src/main.zig
+++ b/src/main.zig
@@ -4803,7 +4803,7 @@ pub const ClangArgIterator = struct {
                 };
                 self.root_args = args;
             }
-            const resp_arg_slice = resp_arg_list.toOwnedSlice();
+            const resp_arg_slice = try resp_arg_list.toOwnedSlice();
             self.next_index = 0;
             self.argv = resp_arg_slice;
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -338,7 +338,7 @@ const TestManifest = struct {
         while (try it.next()) |item| {
             try out.append(item);
         }
-        return out.toOwnedSlice();
+        return try out.toOwnedSlice();
     }
 
     fn getConfigForKeyAssertSingle(self: TestManifest, key: []const u8, comptime T: type) !T {
@@ -361,7 +361,7 @@ const TestManifest = struct {
         while (it.next()) |line| {
             try out.append(line);
         }
-        return out.toOwnedSlice();
+        return try out.toOwnedSlice();
     }
 
     fn ParseFn(comptime T: type) type {
@@ -1179,7 +1179,7 @@ pub const TestContext = struct {
                             if (output.items.len > 0) {
                                 try output.resize(output.items.len - 1);
                             }
-                            case.addCompareOutput(src, output.toOwnedSlice());
+                            case.addCompareOutput(src, try output.toOwnedSlice());
                         },
                         .cli => @panic("TODO cli tests"),
                     }

--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -788,7 +788,7 @@ pub fn render(gpa: Allocator, zig_is_stage1: bool, nodes: []const Node) !std.zig
         .source = try ctx.buf.toOwnedSliceSentinel(0),
         .tokens = ctx.tokens.toOwnedSlice(),
         .nodes = ctx.nodes.toOwnedSlice(),
-        .extra_data = ctx.extra_data.toOwnedSlice(gpa),
+        .extra_data = try ctx.extra_data.toOwnedSlice(gpa),
         .errors = &.{},
     };
 }

--- a/test/cases/compile_errors/dereference_anyopaque.zig
+++ b/test/cases/compile_errors/dereference_anyopaque.zig
@@ -47,9 +47,9 @@ pub export fn entry() void {
 // :11:22: error: comparison of 'void' with null
 // :25:51: error: values of type 'anyopaque' must be comptime-known, but operand value is runtime-known
 // :25:51: note: opaque type 'anyopaque' has undefined size
-// :25:51: error: values of type 'fn(*anyopaque, usize, u29, u29, usize) error{OutOfMemory}![]u8' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn(*anyopaque, usize, u29, u29, usize) error{OutOfMemory}![]u8' for a function pointer type
-// :25:51: error: values of type 'fn(*anyopaque, []u8, u29, usize, u29, usize) ?usize' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn(*anyopaque, []u8, u29, usize, u29, usize) ?usize' for a function pointer type
-// :25:51: error: values of type 'fn(*anyopaque, []u8, u29, usize) void' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn(*anyopaque, []u8, u29, usize) void' for a function pointer type
+// :25:51: error: values of type 'fn(*anyopaque, usize, u8, usize) ?[*]u8' must be comptime-known, but operand value is runtime-known
+// :25:51: note: use '*const fn(*anyopaque, usize, u8, usize) ?[*]u8' for a function pointer type
+// :25:51: error: values of type 'fn(*anyopaque, []u8, u8, usize, usize) bool' must be comptime-known, but operand value is runtime-known
+// :25:51: note: use '*const fn(*anyopaque, []u8, u8, usize, usize) bool' for a function pointer type
+// :25:51: error: values of type 'fn(*anyopaque, []u8, u8, usize) void' must be comptime-known, but operand value is runtime-known
+// :25:51: note: use '*const fn(*anyopaque, []u8, u8, usize) void' for a function pointer type

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -504,9 +504,10 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    const allocator = logging_allocator.allocator();
         \\
         \\    var a = try allocator.alloc(u8, 10);
-        \\    a = allocator.shrink(a, 5);
+        \\    try std.testing.expect(allocator.resize(a, 5));
+        \\    a = a[0..5];
         \\    try std.testing.expect(a.len == 5);
-        \\    try std.testing.expect(allocator.resize(a, 20) == null);
+        \\    try std.testing.expect(!allocator.resize(a, 20));
         \\    allocator.free(a);
         \\}
         \\
@@ -522,9 +523,9 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
         \\    nosuspend stdout.print(level_txt ++ prefix2 ++ format ++ "\n", args) catch return;
         \\}
     ,
-        \\debug: alloc - success - len: 10, ptr_align: 1, len_align: 0
-        \\debug: shrink - success - 10 to 5, len_align: 0, buf_align: 1
-        \\error: expand - failure - 5 to 20, len_align: 0, buf_align: 1
+        \\debug: alloc - success - len: 10, ptr_align: 0
+        \\debug: shrink - success - 10 to 5, buf_align: 0
+        \\error: expand - failure - 5 to 20, buf_align: 0
         \\debug: free - len: 5
         \\
     );

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -992,7 +992,7 @@ pub const StackTracesContext = struct {
                     }
                     try buf.appendSlice("\n");
                 }
-                break :got_result buf.toOwnedSlice();
+                break :got_result try buf.toOwnedSlice();
             };
 
             if (!mem.eql(u8, self.expect_output, got)) {


### PR DESCRIPTION
After going through and making these changes, I am convinced that this interface is an improvement. Particularly, it results in less copying of allocated but unused bytes in fundamental data structures such as ArrayList.

closes #13535

## How to upgrade for this change

 * `ArrayList.toOwnedSlice` - this function now possibly returns `error.OutOfMemory`. In all instances in the Zig codebase, the solution was as simple as adding `try` in front of the callsite. I expect this to be the case for third party projects as well.
 * `Allocator.shrink` - this function is no longer available. Instead, call `realloc` and handle the possible failure, or call `resize` and handle it refusing to shrink in place by returning `false`.