### PR TITLE
std.Thread.Futex.PosixImpl.Address.from: fix `alignment` type

### DIFF
--- a/lib/std/Thread/Futex.zig
+++ b/lib/std/Thread/Futex.zig
@@ -721,7 +721,7 @@ const PosixImpl = struct {
             // then cut off the zero bits from the alignment to get the unique address.
             const addr = @ptrToInt(ptr);
             assert(addr & (alignment - 1) == 0);
-            return addr >> @ctz(alignment);
+            return addr >> @ctz(@as(usize, alignment));
         }
     };
 


### PR DESCRIPTION
Fixes #13673

I found the correct type by [blaming](https://github.com/ziglang/zig/commit/62ff8871ed9c8c4e46d8acd1d227ed3fb802be7f#diff-efdc8ea1c18493314ed01d0dc85d35564a2f5282f15c1f66db91822861d704a1L724-R724).