### PR TITLE
std.fs.MAX_NAME_BYTES: fix accessing `MAXNAMLEN`

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -57,7 +57,7 @@ pub const MAX_NAME_BYTES = switch (builtin.os.tag) {
     .linux, .macos, .ios, .freebsd, .dragonfly => os.NAME_MAX,
     // Haiku's NAME_MAX includes the null terminator, so subtract one.
     .haiku => os.NAME_MAX - 1,
-    .netbsd, .openbsd, .solaris => os.MAXNAMLEN,
+    .netbsd, .openbsd, .solaris => os.system.MAXNAMLEN,
     // Each UTF-16LE character may be expanded to 3 UTF-8 bytes.
     // If it would require 4 UTF-8 bytes, then there would be a surrogate
     // pair in the UTF-16LE, and we (over)account 3 bytes for it that way.


### PR DESCRIPTION
Fixes #13680