### PR TITLE
LLVM: fix canElideLoad behavior with loops

### DIFF
--- a/ci/linux/build-x86_64-debug.sh
+++ b/ci/linux/build-x86_64-debug.sh
@@ -51,9 +51,7 @@ stage3-debug/bin/zig fmt --check .. \
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
 stage3-debug/bin/zig build -Dtarget=arm-linux-musleabihf
 
-# building docs disabled due to:
-# https://github.com/ziglang/zig/issues/13546
-stage3-debug/bin/zig build test \
+stage3-debug/bin/zig build test docs \
   -fqemu \
   -fwasmtime \
   -Dstatic-llvm \
@@ -61,10 +59,8 @@ stage3-debug/bin/zig build test \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$(pwd)/../lib"
 
-# langref disabled due to:
-# https://github.com/ziglang/zig/issues/13546
-## Look for HTML errors.
-#tidy --drop-empty-elements no -qe ../zig-cache/langref.html
+# Look for HTML errors.
+tidy --drop-empty-elements no -qe ../zig-cache/langref.html
 
 # Produce the experimental std lib documentation.
 stage3-debug/bin/zig test ../lib/std/std.zig -femit-docs -fno-emit-bin --zig-lib-dir ../lib

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -8136,7 +8136,10 @@ pub const FuncGen = struct {
                 .write, .noret, .complex => return false,
                 .tomb => return true,
             }
-        } else unreachable;
+        }
+        // The only way to get here is to hit the end of a loop instruction
+        // (implicit repeat).
+        return false;
     }
 
     fn airLoad(fg: *FuncGen, body_tail: []const Air.Inst.Index) !?*llvm.Value {

--- a/test/behavior/while.zig
+++ b/test/behavior/while.zig
@@ -343,3 +343,24 @@ test "else continue outer while" {
         } else continue;
     }
 }
+
+test "try terminating an infinite loop" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
+    // Test coverage for https://github.com/ziglang/zig/issues/13546
+    const Foo = struct {
+        trash: i32,
+
+        fn bar() anyerror!@This() {
+            return .{ .trash = 1234 };
+        }
+    };
+    var t = true;
+    errdefer t = false;
+    try expect(while (true) {
+        if (t) break t;
+        _ = try Foo.bar();
+    } else unreachable);
+}


### PR DESCRIPTION
closes #13546