### PR TITLE
Improve debuggability of programs built by the self hosted compiler

### DIFF
--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -142,6 +142,8 @@ pub fn main() !void {
                     return usageAndErr(builder, false, stderr_stream);
                 };
                 try debug_log_scopes.append(next_arg);
+            } else if (mem.eql(u8, arg, "--debug-compile-errors")) {
+                builder.debug_compile_errors = true;
             } else if (mem.eql(u8, arg, "--glibc-runtimes")) {
                 builder.glibc_runtimes_dir = nextArg(args, &arg_idx) orelse {
                     std.debug.print("Expected argument after --glibc-runtimes\n\n", .{});

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -72,6 +72,7 @@ pub const Builder = struct {
     pkg_config_pkg_list: ?(PkgConfigError![]const PkgConfigPkg) = null,
     args: ?[][]const u8 = null,
     debug_log_scopes: []const []const u8 = &.{},
+    debug_compile_errors: bool = false,
 
     /// Experimental. Use system Darling installation to run cross compiled macOS build artifacts.
     enable_darling: bool = false,
@@ -2684,6 +2685,10 @@ pub const LibExeObjStep = struct {
         for (builder.debug_log_scopes) |log_scope| {
             try zig_args.append("--debug-log");
             try zig_args.append(log_scope);
+        }
+
+        if (builder.debug_compile_errors) {
+            try zig_args.append("--debug-compile-errors");
         }
 
         if (builder.verbose_cimport) zig_args.append("--verbose-cimport") catch unreachable;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2189,10 +2189,16 @@ fn failWithOwnedErrorMsg(sema: *Sema, err_msg: *Module.ErrorMsg) CompileError {
     @setCold(true);
 
     if (crash_report.is_enabled and sema.mod.comp.debug_compile_errors) {
-        std.debug.print("compile error during Sema: {s}, src: {s}:{}\n", .{
+        const err_path = err_msg.src_loc.file_scope.fullPath(sema.mod.gpa) catch unreachable;
+        const err_source = err_msg.src_loc.file_scope.getSource(sema.mod.gpa) catch unreachable;
+        const err_span = err_msg.src_loc.span(sema.mod.gpa) catch unreachable;
+        const err_loc = std.zig.findLineColumn(err_source.bytes, err_span.main);
+        std.debug.print("compile error during Sema:\n{s}:{d}:{d}: error: {s}\n{s}\n\n", .{
+            err_path,
+            err_loc.line + 1,
+            err_loc.column + 1,
             err_msg.msg,
-            err_msg.src_loc.file_scope.sub_file_path,
-            err_msg.src_loc.lazy,
+            err_loc.source_line,
         });
         crash_report.compilerPanic("unexpected compile error occurred", null, null);
     }

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -6088,6 +6088,12 @@ pub const FuncGen = struct {
         const insert_block = self.builder.getInsertBlock();
         if (isByRef(operand_ty)) {
             _ = dib.insertDeclareAtEnd(operand, di_local_var, debug_loc, insert_block);
+        } else if (self.dg.module.comp.bin_file.options.optimize_mode == .Debug) {
+            const alignment = operand_ty.abiAlignment(self.dg.module.getTarget());
+            const alloca = self.buildAlloca(operand.typeOf(), alignment);
+            const store_inst = self.builder.buildStore(operand, alloca);
+            store_inst.setAlignment(alignment);
+            _ = dib.insertDeclareAtEnd(alloca, di_local_var, debug_loc, insert_block);
         } else {
             _ = dib.insertDbgValueIntrinsicAtEnd(operand, di_local_var, debug_loc, insert_block);
         }
@@ -8026,6 +8032,12 @@ pub const FuncGen = struct {
             const insert_block = self.builder.getInsertBlock();
             if (isByRef(inst_ty)) {
                 _ = dib.insertDeclareAtEnd(arg_val, di_local_var, debug_loc, insert_block);
+            } else if (self.dg.module.comp.bin_file.options.optimize_mode == .Debug) {
+                const alignment = inst_ty.abiAlignment(self.dg.module.getTarget());
+                const alloca = self.buildAlloca(arg_val.typeOf(), alignment);
+                const store_inst = self.builder.buildStore(arg_val, alloca);
+                store_inst.setAlignment(alignment);
+                _ = dib.insertDeclareAtEnd(alloca, di_local_var, debug_loc, insert_block);
             } else {
                 _ = dib.insertDbgValueIntrinsicAtEnd(arg_val, di_local_var, debug_loc, insert_block);
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -3778,6 +3778,7 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
         var override_local_cache_dir: ?[]const u8 = try optionalStringEnvVar(arena, "ZIG_LOCAL_CACHE_DIR");
         var child_argv = std.ArrayList([]const u8).init(arena);
         var reference_trace: ?u32 = null;
+        var debug_compile_errors = false;
 
         const argv_index_exe = child_argv.items.len;
         _ = try child_argv.addOne();
@@ -3839,6 +3840,9 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
                     } else if (mem.eql(u8, arg, "-fno-reference-trace")) {
                         try child_argv.append(arg);
                         reference_trace = null;
+                    } else if (mem.eql(u8, arg, "--debug-compile-errors")) {
+                        try child_argv.append(arg);
+                        debug_compile_errors = true;
                     }
                 }
                 try child_argv.append(arg);
@@ -3973,6 +3977,7 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
             .use_stage1 = use_stage1,
             .cache_mode = .whole,
             .reference_trace = reference_trace,
+            .debug_compile_errors = debug_compile_errors,
         }) catch |err| {
             fatal("unable to create compilation: {s}", .{@errorName(err)});
         };


### PR DESCRIPTION
`@llvm.dbg.value` is absolutely useless, adding a temporary alloca
to store the constant in will make it actually show up in debuggers.
The effect on performance should be minimal since there is only one
store and it the change is not applied to ReleaseSafe builds.

```zig
fn foo(a: u32, b: []const u8, c: bool, d: enum { yes, no }) void {
    _ = a; _ = b; _ = c; _ = d;
}
```
before:
```
Breakpoint 1, a.foo (a=<optimized out>, b=..., c=<optimized out>, d=<optimized out>) at a.zig:18
18          _ = d;
```
after:
```
Breakpoint 1, a.foo (a=1, b=..., c=false, d=yes) at a.zig:15
15          _ = a; _ = b; _ = c; _ = d;
(gdb) p b
$1 = {ptr = 0x20854f <a.main.anon_3888> "bar", len = 3}
```