### PR TITLE
dwarf: dedup generation of dwarf info for func args and vars in Dwarf module

### DIFF
--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -195,32 +195,28 @@ const DbgInfoReloc = struct {
         };
 
         switch (function.debug_output) {
-            .dwarf => |dw| {
-                switch (reloc.mcv) {
-                    .register => |reg| {
-                        try dw.genArgDbgInfo(reloc.name, reloc.ty, atom, .{
-                            .register = reg.dwarfLocOp(),
-                        });
-                    },
+            .dwarf => |dw| switch (reloc.mcv) {
+                .register => |reg| try dw.genArgDbgInfo(reloc.name, reloc.ty, atom, .{
+                    .register = reg.dwarfLocOp(),
+                }),
 
-                    .stack_offset,
-                    .stack_argument_offset,
-                    => |offset| {
-                        const adjusted_offset = switch (reloc.mcv) {
-                            .stack_offset => -@intCast(i32, offset),
-                            .stack_argument_offset => @intCast(i32, function.saved_regs_stack_space + offset),
-                            else => unreachable,
-                        };
-                        try dw.genArgDbgInfo(reloc.name, reloc.ty, atom, .{
-                            .stack = .{
-                                .fp_register = Register.x29.dwarfLocOpDeref(),
-                                .offset = adjusted_offset,
-                            },
-                        });
-                    },
+                .stack_offset,
+                .stack_argument_offset,
+                => |offset| {
+                    const adjusted_offset = switch (reloc.mcv) {
+                        .stack_offset => -@intCast(i32, offset),
+                        .stack_argument_offset => @intCast(i32, function.saved_regs_stack_space + offset),
+                        else => unreachable,
+                    };
+                    try dw.genArgDbgInfo(reloc.name, reloc.ty, atom, .{
+                        .stack = .{
+                            .fp_register = Register.x29.dwarfLocOpDeref(),
+                            .offset = adjusted_offset,
+                        },
+                    });
+                },
 
-                    else => unreachable, // not a possible argument
-                }
+                else => unreachable, // not a possible argument
             },
             .plan9 => {},
             .none => {},

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -184,15 +184,8 @@ const DbgInfoReloc = struct {
             else => unreachable,
         }
     }
-
     fn genArgDbgInfo(reloc: DbgInfoReloc, function: Self) error{OutOfMemory}!void {
-        const mod = function.bin_file.options.module.?;
-        const fn_owner_decl = mod.declPtr(function.mod_fn.owner_decl);
-        const atom = switch (function.bin_file.tag) {
-            .elf => &fn_owner_decl.link.elf.dbg_info_atom,
-            .macho => &fn_owner_decl.link.macho.dbg_info_atom,
-            else => unreachable,
-        };
+        const atom = function.getDbgInfoAtomPtr();
 
         switch (function.debug_output) {
             .dwarf => |dw| switch (reloc.mcv) {
@@ -230,6 +223,7 @@ const DbgInfoReloc = struct {
             .dbg_var_val => reloc.ty,
             else => unreachable,
         };
+        // const atom= function.getDbgInfoAtomPtr();
 
         switch (function.debug_output) {
             .dwarf => |dw| {
@@ -367,6 +361,17 @@ const DbgInfoReloc = struct {
         }
     }
 };
+
+fn getDbgInfoAtomPtr(self: Self) *link.File.Dwarf.Atom {
+    const mod = self.bin_file.options.module.?;
+    const fn_owner_decl = mod.declPtr(self.mod_fn.owner_decl);
+    const atom = switch (self.bin_file.tag) {
+        .elf => &fn_owner_decl.link.elf.dbg_info_atom,
+        .macho => &fn_owner_decl.link.macho.dbg_info_atom,
+        else => unreachable,
+    };
+    return atom;
+}
 
 const Branch = struct {
     inst_table: std.AutoArrayHashMapUnmanaged(Air.Inst.Index, MCValue) = .{},

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -245,15 +245,8 @@ const DbgInfoReloc = struct {
                             },
                         };
                     },
-                    .memory => |address| .{ .memory = .{
-                        .address = address,
-                        .is_ptr = is_ptr,
-                    } },
-                    .linker_load => |linker_load| .{ .memory = .{
-                        .address = 0,
-                        .is_ptr = is_ptr,
-                        .linker_load = linker_load,
-                    } },
+                    .memory => |address| .{ .memory = address },
+                    .linker_load => |linker_load| .{ .linker_load = linker_load },
                     .immediate => |x| .{ .immediate = x },
                     .undef => .undef,
                     .none => .none,
@@ -262,7 +255,7 @@ const DbgInfoReloc = struct {
                         break :blk .nop;
                     },
                 };
-                try dw.genVarDbgInfo(reloc.name, reloc.ty, atom, loc);
+                try dw.genVarDbgInfo(reloc.name, reloc.ty, atom, is_ptr, loc);
             },
             .plan9 => {},
             .none => {},

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -4033,7 +4033,6 @@ fn genArgDbgInfo(self: Self, inst: Air.Inst.Index, arg_index: u32) error{OutOfMe
     const mcv = self.args[arg_index];
     const ty = self.air.instructions.items(.data)[inst].ty;
     const name = self.mod_fn.getParamName(self.bin_file.options.module.?, arg_index);
-    const atom = self.getDbgInfoAtom();
 
     switch (self.debug_output) {
         .dwarf => |dw| {
@@ -4055,22 +4054,11 @@ fn genArgDbgInfo(self: Self, inst: Air.Inst.Index, arg_index: u32) error{OutOfMe
                 else => unreachable, // not a possible argument
 
             };
-            try dw.genArgDbgInfo(name, ty, atom, loc);
+            try dw.genArgDbgInfo(name, ty, self.bin_file.tag, self.mod_fn.owner_decl, loc);
         },
         .plan9 => {},
         .none => {},
     }
-}
-
-fn getDbgInfoAtom(self: Self) *link.File.Dwarf.Atom {
-    const mod = self.bin_file.options.module.?;
-    const fn_owner_decl = mod.declPtr(self.mod_fn.owner_decl);
-    const atom = switch (self.bin_file.tag) {
-        .elf => &fn_owner_decl.link.elf.dbg_info_atom,
-        .macho => &fn_owner_decl.link.macho.dbg_info_atom,
-        else => unreachable,
-    };
-    return atom;
 }
 
 fn airArg(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -772,28 +772,6 @@ fn ensureProcessDeathCapacity(self: *Self, additional_count: usize) !void {
     try table.ensureUnusedCapacity(self.gpa, additional_count);
 }
 
-/// Adds a Type to the .debug_info at the current position. The bytes will be populated later,
-/// after codegen for this symbol is done.
-fn addDbgInfoTypeReloc(self: *Self, ty: Type) !void {
-    switch (self.debug_output) {
-        .dwarf => |dw| {
-            assert(ty.hasRuntimeBits());
-            const dbg_info = &dw.dbg_info;
-            const index = dbg_info.items.len;
-            try dbg_info.resize(index + 4); // DW.AT.type,  DW.FORM.ref4
-            const mod = self.bin_file.options.module.?;
-            const atom = switch (self.bin_file.tag) {
-                .elf => &mod.declPtr(self.mod_fn.owner_decl).link.elf.dbg_info_atom,
-                .macho => unreachable,
-                else => unreachable,
-            };
-            try dw.addTypeRelocGlobal(atom, ty, @intCast(u32, index));
-        },
-        .plan9 => {},
-        .none => {},
-    }
-}
-
 fn allocMem(self: *Self, inst: Air.Inst.Index, abi_size: u32, abi_align: u32) !u32 {
     if (abi_align > self.stack_align)
         self.stack_align = abi_align;
@@ -1627,36 +1605,25 @@ fn airFieldParentPtr(self: *Self, inst: Air.Inst.Index) !void {
 fn genArgDbgInfo(self: *Self, inst: Air.Inst.Index, mcv: MCValue, arg_index: u32) !void {
     const ty = self.air.instructions.items(.data)[inst].ty;
     const name = self.mod_fn.getParamName(self.bin_file.options.module.?, arg_index);
-    const name_with_null = name.ptr[0 .. name.len + 1];
 
-    switch (mcv) {
-        .register => |reg| {
-            switch (self.debug_output) {
-                .dwarf => |dw| {
-                    const dbg_info = &dw.dbg_info;
-                    try dbg_info.ensureUnusedCapacity(3);
-                    dbg_info.appendAssumeCapacity(@enumToInt(link.File.Dwarf.AbbrevKind.parameter));
-                    dbg_info.appendSliceAssumeCapacity(&[2]u8{ // DW.AT.location, DW.FORM.exprloc
-                        1, // ULEB128 dwarf expression length
-                        reg.dwarfLocOp(),
-                    });
-                    try dbg_info.ensureUnusedCapacity(5 + name_with_null.len);
-                    try self.addDbgInfoTypeReloc(ty); // DW.AT.type,  DW.FORM.ref4
-                    dbg_info.appendSliceAssumeCapacity(name_with_null); // DW.AT.name, DW.FORM.string
-                },
-                .plan9 => {},
-                .none => {},
-            }
+    const mod = self.bin_file.options.module.?;
+    const fn_owner_decl = mod.declPtr(self.mod_fn.owner_decl);
+    const atom = switch (self.bin_file.tag) {
+        .elf => &fn_owner_decl.link.elf.dbg_info_atom,
+        .macho => &fn_owner_decl.link.macho.dbg_info_atom,
+        else => unreachable,
+    };
+
+    switch (self.debug_output) {
+        .dwarf => |dw| switch (mcv) {
+            .register => |reg| try dw.genArgDbgInfo(name, ty, atom, .{
+                .register = reg.dwarfLocOp(),
+            }),
+            .stack_offset => {},
+            else => {},
         },
-        .stack_offset => |offset| {
-            _ = offset;
-            switch (self.debug_output) {
-                .dwarf => {},
-                .plan9 => {},
-                .none => {},
-            }
-        },
-        else => {},
+        .plan9 => {},
+        .none => {},
     }
 }
 

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1605,30 +1605,22 @@ fn airFieldParentPtr(self: *Self, inst: Air.Inst.Index) !void {
 fn genArgDbgInfo(self: Self, inst: Air.Inst.Index, mcv: MCValue, arg_index: u32) !void {
     const ty = self.air.instructions.items(.data)[inst].ty;
     const name = self.mod_fn.getParamName(self.bin_file.options.module.?, arg_index);
-    const atom = self.getDbgIntoAtomPtr();
 
     switch (self.debug_output) {
         .dwarf => |dw| switch (mcv) {
-            .register => |reg| try dw.genArgDbgInfo(name, ty, atom, .{
-                .register = reg.dwarfLocOp(),
-            }),
+            .register => |reg| try dw.genArgDbgInfo(
+                name,
+                ty,
+                self.bin_file.tag,
+                self.mod_fn.owner_decl,
+                .{ .register = reg.dwarfLocOp() },
+            ),
             .stack_offset => {},
             else => {},
         },
         .plan9 => {},
         .none => {},
     }
-}
-
-fn getDbgIntoAtomPtr(self: Self) *link.File.Dwarf.Atom {
-    const mod = self.bin_file.options.module.?;
-    const fn_owner_decl = mod.declPtr(self.mod_fn.owner_decl);
-    const atom = switch (self.bin_file.tag) {
-        .elf => &fn_owner_decl.link.elf.dbg_info_atom,
-        .macho => &fn_owner_decl.link.macho.dbg_info_atom,
-        else => unreachable,
-    };
-    return atom;
 }
 
 fn airArg(self: *Self, inst: Air.Inst.Index) !void {

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -3255,27 +3255,20 @@ fn finishAir(self: *Self, inst: Air.Inst.Index, result: MCValue, operands: [Live
 fn genArgDbgInfo(self: Self, inst: Air.Inst.Index, mcv: MCValue, arg_index: u32) !void {
     const ty = self.air.instructions.items(.data)[inst].ty;
     const name = self.mod_fn.getParamName(self.bin_file.options.module.?, arg_index);
-    const atom = self.getDbgInfoAtomPtr();
 
     switch (self.debug_output) {
         .dwarf => |dw| switch (mcv) {
-            .register => |reg| try dw.genArgDbgInfo(name, ty, atom, .{
-                .register = reg.dwarfLocOp(),
-            }),
+            .register => |reg| try dw.genArgDbgInfo(
+                name,
+                ty,
+                self.bin_file.tag,
+                self.mod_fn.owner_decl,
+                .{ .register = reg.dwarfLocOp() },
+            ),
             else => {},
         },
         else => {},
     }
-}
-
-fn getDbgInfoAtomPtr(self: Self) *link.File.Dwarf.Atom {
-    const mod = self.bin_file.options.module.?;
-    const fn_owner_decl = mod.declPtr(self.mod_fn.owner_decl);
-    const atom = switch (self.bin_file.tag) {
-        .elf => &fn_owner_decl.link.elf.dbg_info_atom,
-        else => unreachable,
-    };
-    return atom;
 }
 
 // TODO replace this to call to extern memcpy

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -2460,26 +2460,6 @@ fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {
 
 // Common helper functions
 
-/// Adds a Type to the .debug_info at the current position. The bytes will be populated later,
-/// after codegen for this symbol is done.
-fn addDbgInfoTypeReloc(self: *Self, ty: Type) !void {
-    switch (self.debug_output) {
-        .dwarf => |dw| {
-            assert(ty.hasRuntimeBits());
-            const dbg_info = &dw.dbg_info;
-            const index = dbg_info.items.len;
-            try dbg_info.resize(index + 4); // DW.AT.type,  DW.FORM.ref4
-            const mod = self.bin_file.options.module.?;
-            const atom = switch (self.bin_file.tag) {
-                .elf => &mod.declPtr(self.mod_fn.owner_decl).link.elf.dbg_info_atom,
-                else => unreachable,
-            };
-            try dw.addTypeRelocGlobal(atom, ty, @intCast(u32, index));
-        },
-        else => {},
-    }
-}
-
 fn addInst(self: *Self, inst: Mir.Inst) error{OutOfMemory}!Mir.Inst.Index {
     const gpa = self.gpa;
     try self.mir_instructions.ensureUnusedCapacity(gpa, 1);
@@ -3272,38 +3252,30 @@ fn finishAir(self: *Self, inst: Air.Inst.Index, result: MCValue, operands: [Live
     self.finishAirBookkeeping();
 }
 
-fn genArgDbgInfo(self: *Self, inst: Air.Inst.Index, mcv: MCValue, arg_index: u32) !void {
+fn genArgDbgInfo(self: Self, inst: Air.Inst.Index, mcv: MCValue, arg_index: u32) !void {
     const ty = self.air.instructions.items(.data)[inst].ty;
     const name = self.mod_fn.getParamName(self.bin_file.options.module.?, arg_index);
-    const name_with_null = name.ptr[0 .. name.len + 1];
+    const atom = self.getDbgInfoAtomPtr();
 
-    switch (mcv) {
-        .register => |reg| {
-            switch (self.debug_output) {
-                .dwarf => |dw| {
-                    const dbg_info = &dw.dbg_info;
-                    try dbg_info.ensureUnusedCapacity(3);
-                    dbg_info.appendAssumeCapacity(@enumToInt(link.File.Dwarf.AbbrevKind.parameter));
-                    dbg_info.appendSliceAssumeCapacity(&[2]u8{ // DW.AT.location, DW.FORM.exprloc
-                        1, // ULEB128 dwarf expression length
-                        reg.dwarfLocOp(),
-                    });
-                    try dbg_info.ensureUnusedCapacity(5 + name_with_null.len);
-                    try self.addDbgInfoTypeReloc(ty); // DW.AT.type,  DW.FORM.ref4
-                    dbg_info.appendSliceAssumeCapacity(name_with_null); // DW.AT.name, DW.FORM.string
-                },
-                else => {},
-            }
-        },
-        .stack_offset => |offset| {
-            _ = offset;
-            switch (self.debug_output) {
-                .dwarf => {},
-                else => {},
-            }
+    switch (self.debug_output) {
+        .dwarf => |dw| switch (mcv) {
+            .register => |reg| try dw.genArgDbgInfo(name, ty, atom, .{
+                .register = reg.dwarfLocOp(),
+            }),
+            else => {},
         },
         else => {},
     }
+}
+
+fn getDbgInfoAtomPtr(self: Self) *link.File.Dwarf.Atom {
+    const mod = self.bin_file.options.module.?;
+    const fn_owner_decl = mod.declPtr(self.mod_fn.owner_decl);
+    const atom = switch (self.bin_file.tag) {
+        .elf => &fn_owner_decl.link.elf.dbg_info_atom,
+        else => unreachable,
+    };
+    return atom;
 }
 
 // TODO replace this to call to extern memcpy

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1291,23 +1291,6 @@ fn firstParamSRet(cc: std.builtin.CallingConvention, return_type: Type, target: 
     }
 }
 
-/// For a given `Type`, add debug information to .debug_info at the current position.
-/// The actual bytes will be written to the position after relocation.
-fn addDbgInfoTypeReloc(func: *CodeGen, ty: Type) !void {
-    switch (func.debug_output) {
-        .dwarf => |dwarf| {
-            assert(ty.hasRuntimeBitsIgnoreComptime());
-            const dbg_info = &dwarf.dbg_info;
-            const index = dbg_info.items.len;
-            try dbg_info.resize(index + 4);
-            const atom = &func.decl.link.wasm.dbg_info_atom;
-            try dwarf.addTypeRelocGlobal(atom, ty, @intCast(u32, index));
-        },
-        .plan9 => unreachable,
-        .none => {},
-    }
-}
-
 /// Lowers a Zig type and its value based on a given calling convention to ensure
 /// it matches the ABI.
 fn lowerArg(func: *CodeGen, cc: std.builtin.CallingConvention, ty: Type, value: WValue) !void {
@@ -2358,29 +2341,21 @@ fn airArg(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         .dwarf => |dwarf| {
             // TODO: Get the original arg index rather than wasm arg index
             const name = func.mod_fn.getParamName(func.bin_file.base.options.module.?, arg_index);
-            const leb_size = link.File.Wasm.getULEB128Size(arg.local.value);
-            const dbg_info = &dwarf.dbg_info;
-            try dbg_info.ensureUnusedCapacity(3 + leb_size + 5 + name.len + 1);
-            // wasm locations are encoded as follow:
-            // DW_OP_WASM_location wasm-op
-            // where wasm-op is defined as
-            // wasm-op := wasm-local | wasm-global | wasm-operand_stack
-            // where each argument is encoded as
-            // <opcode> i:uleb128
-            dbg_info.appendSliceAssumeCapacity(&.{
-                @enumToInt(link.File.Dwarf.AbbrevKind.parameter),
-                std.dwarf.OP.WASM_location,
-                std.dwarf.OP.WASM_local,
+            const atom = func.getDbgInfoAtom();
+            try dwarf.genArgDbgInfo(name, arg_ty, atom, .{
+                .wasm_local = arg.local.value,
             });
-            leb.writeULEB128(dbg_info.writer(), arg.local.value) catch unreachable;
-            try func.addDbgInfoTypeReloc(arg_ty);
-            dbg_info.appendSliceAssumeCapacity(name);
-            dbg_info.appendAssumeCapacity(0);
         },
         else => {},
     }
 
     func.finishAir(inst, arg, &.{});
+}
+
+fn getDbgInfoAtom(func: CodeGen) *link.File.Dwarf.Atom {
+    const mod = func.bin_file.base.options.module.?;
+    const fn_owner_decl = mod.declPtr(func.mod_fn.owner_decl);
+    return &fn_owner_decl.link.wasm.dbg_info_atom;
 }
 
 fn airBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
@@ -5345,38 +5320,22 @@ fn airDbgVar(func: *CodeGen, inst: Air.Inst.Index, is_ptr: bool) !void {
     const pl_op = func.air.instructions.items(.data)[inst].pl_op;
     const ty = func.air.typeOf(pl_op.operand);
     const operand = try func.resolveInst(pl_op.operand);
-    const op_ty = if (is_ptr) ty.childType() else ty;
 
-    log.debug("airDbgVar: %{d}: {}, {}", .{ inst, op_ty.fmtDebug(), operand });
+    log.debug("airDbgVar: %{d}: {}, {}", .{ inst, ty.fmtDebug(), operand });
 
     const name = func.air.nullTerminatedString(pl_op.payload);
     log.debug(" var name = ({s})", .{name});
 
-    const dbg_info = &func.debug_output.dwarf.dbg_info;
-    try dbg_info.append(@enumToInt(link.File.Dwarf.AbbrevKind.variable));
-    switch (operand) {
-        .local => |local| {
-            const leb_size = link.File.Wasm.getULEB128Size(local.value);
-            try dbg_info.ensureUnusedCapacity(2 + leb_size);
-            // wasm locals are encoded as follow:
-            // DW_OP_WASM_location wasm-op
-            // where wasm-op is defined as
-            // wasm-op := wasm-local | wasm-global | wasm-operand_stack
-            // where wasm-local is encoded as
-            // wasm-local := 0x00 i:uleb128
-            dbg_info.appendSliceAssumeCapacity(&.{
-                std.dwarf.OP.WASM_location,
-                std.dwarf.OP.WASM_local,
-            });
-            leb.writeULEB128(dbg_info.writer(), local.value) catch unreachable;
+    const atom = func.getDbgInfoAtom();
+    const loc: link.File.Dwarf.DeclState.VarArgDbgInfoLoc = switch (operand) {
+        .local => |local| .{ .wasm_local = local.value },
+        else => blk: {
+            log.debug("TODO generate debug info for {}", .{operand});
+            break :blk .nop;
         },
-        else => {}, // TODO
-    }
+    };
+    try func.debug_output.dwarf.genVarDbgInfo(name, ty, atom, is_ptr, loc);
 
-    try dbg_info.ensureUnusedCapacity(5 + name.len + 1);
-    try func.addDbgInfoTypeReloc(op_ty);
-    dbg_info.appendSliceAssumeCapacity(name);
-    dbg_info.appendAssumeCapacity(0);
     func.finishAir(inst, .none, &.{});
 }
 

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -5327,7 +5327,7 @@ fn airDbgVar(func: *CodeGen, inst: Air.Inst.Index, is_ptr: bool) !void {
     log.debug(" var name = ({s})", .{name});
 
     const atom = func.getDbgInfoAtom();
-    const loc: link.File.Dwarf.DeclState.VarArgDbgInfoLoc = switch (operand) {
+    const loc: link.File.Dwarf.DeclState.DbgInfoLoc = switch (operand) {
         .local => |local| .{ .wasm_local = local.value },
         else => blk: {
             log.debug("TODO generate debug info for {}", .{operand});

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -3827,21 +3827,18 @@ fn genArgDbgInfo(self: Self, ty: Type, name: [:0]const u8, mcv: MCValue) !void {
     };
 
     switch (self.debug_output) {
-        .dwarf => |dw| {
-            switch (mcv) {
-                .register => |reg| try dw.genArgDbgInfo(name, ty, atom, .{
-                    .register = reg.dwarfLocOp(),
-                }),
+        .dwarf => |dw| switch (mcv) {
+            .register => |reg| try dw.genArgDbgInfo(name, ty, atom, .{
+                .register = reg.dwarfLocOp(),
+            }),
+            .stack_offset => |off| try dw.genArgDbgInfo(name, ty, atom, .{
+                .stack = .{
+                    .fp_register = Register.rbp.dwarfLocOpDeref(), // TODO handle -fomit-frame-pointer
+                    .offset = -off,
+                },
+            }),
 
-                .stack_offset => |off| try dw.genArgDbgInfo(name, ty, atom, .{
-                    .stack = .{
-                        .fp_register = Register.rbp.dwarfLocOpDeref(), // TODO handle -fomit-frame-pointer
-                        .offset = -off,
-                    },
-                }),
-
-                else => unreachable, // not a valid function parameter
-            }
+            else => unreachable, // not a valid function parameter
         },
         .plan9 => {},
         .none => {},

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -4448,11 +4448,7 @@ fn airDbgVar(self: *Self, inst: Air.Inst.Index) !void {
     const name = self.air.nullTerminatedString(pl_op.payload);
 
     const tag = self.air.instructions.items(.tag)[inst];
-    switch (tag) {
-        .dbg_var_ptr => try self.genVarDbgInfo(tag, ty.childType(), mcv, name),
-        .dbg_var_val => try self.genVarDbgInfo(tag, ty, mcv, name),
-        else => unreachable,
-    }
+    try self.genVarDbgInfo(tag, ty, mcv, name);
 
     return self.finishAir(inst, .dead, .{ operand, .none, .none });
 }

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -3862,15 +3862,8 @@ fn genVarDbgInfo(
                     .fp_register = Register.rbp.dwarfLocOpDeref(),
                     .offset = -off,
                 } },
-                .memory => |address| .{ .memory = .{
-                    .address = address,
-                    .is_ptr = is_ptr,
-                } },
-                .linker_load => |linker_load| .{ .memory = .{
-                    .address = 0,
-                    .is_ptr = is_ptr,
-                    .linker_load = linker_load,
-                } },
+                .memory => |address| .{ .memory = address },
+                .linker_load => |linker_load| .{ .linker_load = linker_load },
                 .immediate => |x| .{ .immediate = x },
                 .undef => .undef,
                 .none => .none,
@@ -3879,7 +3872,7 @@ fn genVarDbgInfo(
                     break :blk .nop;
                 },
             };
-            try dw.genVarDbgInfo(name, ty, atom, loc);
+            try dw.genVarDbgInfo(name, ty, atom, is_ptr, loc);
         },
         .plan9 => {},
         .none => {},

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -128,11 +128,8 @@ pub const MCValue = union(enum) {
     /// The value is in memory at a hard-coded address.
     /// If the type is a pointer, it means the pointer address is at this memory location.
     memory: u64,
-    /// The value is in memory but requires a linker relocation fixup:
-    /// * got - the value is referenced indirectly via GOT entry index (the linker emits a got-type reloc)
-    /// * direct - the value is referenced directly via symbol index index (the linker emits a displacement reloc)
-    /// * import - the value is referenced indirectly via import entry index (the linker emits an import-type reloc)
-    linker_load: struct { type: enum { got, direct, import }, sym_index: u32 },
+    /// The value is in memory but requires a linker relocation fixup.
+    linker_load: codegen.LinkerLoad,
     /// The value is one of the stack variables.
     /// If the type is a pointer, it means the pointer address is in the stack at this offset.
     stack_offset: i32,
@@ -3865,12 +3862,15 @@ fn genVarDbgInfo(
                     .fp_register = Register.rbp.dwarfLocOpDeref(),
                     .offset = -off,
                 } },
-                .memory => |address| .{
-                    .memory = .{
-                        .address = address,
-                        .is_ptr = is_ptr,
-                    },
-                },
+                .memory => |address| .{ .memory = .{
+                    .address = address,
+                    .is_ptr = is_ptr,
+                } },
+                .linker_load => |linker_load| .{ .memory = .{
+                    .address = 0,
+                    .is_ptr = is_ptr,
+                    .linker_load = linker_load,
+                } },
                 .immediate => |x| .{ .immediate = x },
                 .undef => .undef,
                 .none => .none,

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -68,6 +68,19 @@ pub const DebugInfoOutput = union(enum) {
     none,
 };
 
+/// Helper struct to denote that the value is in memory but requires a linker relocation fixup:
+/// * got - the value is referenced indirectly via GOT entry index (the linker emits a got-type reloc)
+/// * direct - the value is referenced directly via symbol index index (the linker emits a displacement reloc)
+/// * import - the value is referenced indirectly via import entry index (the linker emits an import-type reloc)
+pub const LinkerLoad = struct {
+    type: enum {
+        got,
+        direct,
+        import,
+    },
+    sym_index: u32,
+};
+
 pub fn generateFunction(
     bin_file: *link.File,
     src_loc: Module.SrcLoc,

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -16,6 +16,7 @@ const DW = std.dwarf;
 const File = link.File;
 const LinkBlock = File.LinkBlock;
 const LinkFn = File.LinkFn;
+const LinkerLoad = @import("../codegen.zig").LinkerLoad;
 const Module = @import("../Module.zig");
 const Value = @import("../value.zig").Value;
 const Type = @import("../type.zig").Type;
@@ -616,10 +617,7 @@ pub const DeclState = struct {
         memory: struct {
             address: u64,
             is_ptr: bool,
-            linker_load: ?struct {
-                type: enum { got, direct, import },
-                sym_index: u32,
-            } = null,
+            linker_load: ?LinkerLoad = null,
         },
         immediate: u64,
         undef,


### PR DESCRIPTION
I think it's high time we move all DWARF specific stuff such as opcodes and exprloc emitting to `Dwarf.zig` module and expose higher level helpers for use by any codegen that wants to emit DWARF debug info.

cc @joachimschmidt557, @Luukdegram, @koachan 