### PR TITLE
Sema: detect duplicate enum tag values

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -18230,9 +18230,9 @@ fn zirReify(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstData, in
                 .mod = mod,
             });
 
-            var i: usize = 0;
-            while (i < fields_len) : (i += 1) {
-                const elem_val = try fields_val.elemValue(sema.mod, sema.arena, i);
+            var field_i: usize = 0;
+            while (field_i < fields_len) : (field_i += 1) {
+                const elem_val = try fields_val.elemValue(sema.mod, sema.arena, field_i);
                 const field_struct_val: []const Value = elem_val.castTag(.aggregate).?.data;
                 // TODO use reflection instead of magic numbers here
                 // name: []const u8
@@ -18255,17 +18255,31 @@ fn zirReify(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstData, in
                     });
                 }
 
-                const gop = enum_obj.fields.getOrPutAssumeCapacity(field_name);
-                if (gop.found_existing) {
-                    // TODO: better source location
-                    return sema.fail(block, src, "duplicate enum tag {s}", .{field_name});
+                const gop_field = enum_obj.fields.getOrPutAssumeCapacity(field_name);
+                if (gop_field.found_existing) {
+                    const msg = msg: {
+                        const msg = try sema.errMsg(block, src, "duplicate enum field '{s}'", .{field_name});
+                        errdefer msg.destroy(gpa);
+                        try sema.errNote(block, src, msg, "other field here", .{});
+                        break :msg msg;
+                    };
+                    return sema.failWithOwnedErrorMsg(msg);
                 }
 
                 const copied_tag_val = try value_val.copy(new_decl_arena_allocator);
-                enum_obj.values.putAssumeCapacityNoClobberContext(copied_tag_val, {}, .{
+                const gop_val = enum_obj.values.getOrPutAssumeCapacityContext(copied_tag_val, .{
                     .ty = enum_obj.tag_ty,
                     .mod = mod,
                 });
+                if (gop_val.found_existing) {
+                    const msg = msg: {
+                        const msg = try sema.errMsg(block, src, "enum tag value {} already taken", .{value_val.fmtValue(Type.comptime_int, mod)});
+                        errdefer msg.destroy(gpa);
+                        try sema.errNote(block, src, msg, "other enum tag value here", .{});
+                        break :msg msg;
+                    };
+                    return sema.failWithOwnedErrorMsg(msg);
+                }
             }
 
             try new_decl.finalizeNewArena(&new_decl_arena);

--- a/test/cases/compile_errors/reify_enum_with_duplicate_field.zig
+++ b/test/cases/compile_errors/reify_enum_with_duplicate_field.zig
@@ -1,0 +1,21 @@
+export fn entry() void {
+    _ = @Type(.{
+        .Enum = .{
+            .layout = .Auto,
+            .tag_type = u32,
+            .fields = &.{
+                .{ .name = "A", .value = 0 },
+                .{ .name = "A", .value = 1 },
+            },
+            .decls = &.{},
+            .is_exhaustive = false,
+        },
+    });
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:9: error: duplicate enum field 'A'
+// :2:9: note: other field here

--- a/test/cases/compile_errors/reify_enum_with_duplicate_tag_value.zig
+++ b/test/cases/compile_errors/reify_enum_with_duplicate_tag_value.zig
@@ -1,0 +1,21 @@
+export fn entry() void {
+    _ = @Type(.{
+        .Enum = .{
+            .layout = .Auto,
+            .tag_type = u32,
+            .fields = &.{
+                .{ .name = "A", .value = 10 },
+                .{ .name = "B", .value = 10 },
+            },
+            .decls = &.{},
+            .is_exhaustive = false,
+        },
+    });
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:9: error: enum tag value 10 already taken
+// :2:9: note: other enum tag value here


### PR DESCRIPTION
Fixes #13728
Fixes #13606

I also tried to add some source locations, but I'm not sure about those. For example:
Before:
```
y.zig:9:15: error: duplicate enum tag A
    const x = @Type(std.builtin.Type{
              ^~~~~
```
After:
```
y.zig:9:15: error: duplicate enum field 'A'
    const x = @Type(std.builtin.Type{
              ^~~~~
y.zig:9:15: note: other field here
```
Is this actually an improvement? Also, it doesn't show the same source line again below the note (maybe it's ok?). But I'm not sure how else we would improve the source location because are we supposed to point at the exact line where the value or field name is specified (e.g. `        .{ .name = "A", .value = 10 },`)? If not, the way I did it might be close to what's desired.

And looking at e.g. `test/cases/compile_errors/reify_type_for_tagged_union_with_extra_enum_field.zig`, it seems to similarly only really point at `@Type`, rather than pointing to specific values given to `@Type`.