### PR TITLE
Adds the ability to generate files with RunStep

### DIFF
--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -52,7 +52,7 @@ pub const StdIoAction = union(enum) {
 pub const OutputFile = struct {
     file: std.build.GeneratedFile,
     name: []u8,
-    format: std.meta.FnPtr(fn (std.mem.Allocator, string: []const u8) std.mem.Allocator.Error![]u8),
+    format: *const fn (std.mem.Allocator, string: []const u8) std.mem.Allocator.Error![]u8,
 };
 
 pub const Arg = union(enum) {

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -102,4 +102,6 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/issue_13030/build.zig", .{ .build_modes = true });
     cases.addBuildFile("test/standalone/emit_asm_and_bin/build.zig", .{});
     cases.addBuildFile("test/standalone/issue_12588/build.zig", .{});
+
+    cases.addBuildFile("test/standalone/addOutArgument/build.zig", .{});
 }

--- a/test/standalone/addOutArgument/build.zig
+++ b/test/standalone/addOutArgument/build.zig
@@ -14,4 +14,7 @@ pub fn build(b: *std.build.Builder) void {
     runner_verify.addFileSourceArg(out_file_source);
 
     b.getInstallStep().dependOn(&runner_verify.step);
+
+    const test_step = b.step("test", "Does the same as the install step.");
+    test_step.dependOn(&runner_verify.step);
 }

--- a/test/standalone/addOutArgument/build.zig
+++ b/test/standalone/addOutArgument/build.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    const touch_exe = b.addExecutable("touch-file", "touch-file.zig");
+    const verify_exe = b.addExecutable("verify-file", "verify-file.zig");
+
+    const runner_touch = touch_exe.run();
+    const out_file_source = runner_touch.addOutArgument("{s}", "testfile.txt");
+
+    const runner_verify = verify_exe.run();
+
+    // the addFileSourceArg must automatically create a dependency
+    // on the `runner_touch` step.
+    runner_verify.addFileSourceArg(out_file_source);
+
+    b.getInstallStep().dependOn(&runner_verify.step);
+}

--- a/test/standalone/addOutArgument/touch-file.zig
+++ b/test/standalone/addOutArgument/touch-file.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+
+pub fn main() !void {
+    var argv_iter = try std.process.ArgIterator.initWithAllocator(std.heap.page_allocator);
+    defer argv_iter.deinit();
+
+    _ = argv_iter.next() orelse @panic("missing arg[0]");
+
+    const argv1 = argv_iter.next() orelse @panic("missing arg[1]");
+
+    var file = try std.fs.createFileAbsolute(argv1, .{});
+    defer file.close();
+
+    try file.writeAll("<-- content -->");
+}

--- a/test/standalone/addOutArgument/verify-file.zig
+++ b/test/standalone/addOutArgument/verify-file.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+
+pub fn main() !void {
+    var argv_iter = try std.process.ArgIterator.initWithAllocator(std.heap.page_allocator);
+    defer argv_iter.deinit();
+
+    _ = argv_iter.next() orelse @panic("missing arg[0]");
+
+    const argv1 = argv_iter.next() orelse @panic("missing arg[1]");
+
+    var file = try std.fs.openFileAbsolute(argv1, .{});
+    defer file.close();
+
+    const expected = "<-- content -->";
+    var actual: [expected.len]u8 = undefined;
+
+    try file.reader().readNoEof(&actual);
+
+    if (!std.mem.eql(u8, expected, &actual))
+        @panic("file contents not equal");
+}


### PR DESCRIPTION
This PR implements the ability to declare output paths in a `RunStep`, so we can easily depend on files generated in the build process without having to care about a temporary folder.

Usage example:
```zig
const std = @import("std");

pub fn build(b: *std.build.Builder) void {
    const generator = b.addSystemCommand(&.{"touch"});

    const source = generator.addOutArgument("", "magic.txt");

    const echo_step = b.addSystemCommand(&.{"file"});
    echo_step.addFileSourceArg(source);

    b.getInstallStep().dependOn(&echo_step.step);
}
```

which outputs on my machine:

```
/tmp/bb0c8215/zig-cache/o/56231f620411a8a2cec07ee46fc5b184/magic.txt: empty
```

so the `touch` command is executed implicitly before the `file` command via the `FileSource` dependency.

Right now, there is no test for this, where could i add one?

cc @andrewrk, as you requested this feature