### PR TITLE
mingw: add _vscprintf from upstream

### DIFF
--- a/lib/libc/mingw/lib-common/msvcrt.def.in
+++ b/lib/libc/mingw/lib-common/msvcrt.def.in
@@ -1111,7 +1111,7 @@ _vprintf_l
 _vprintf_p
 _vprintf_p_l
 _vprintf_s_l
-F_NON_I386(_vscprintf) ; i386 _vscprintf replaced by emu
+_vscprintf
 _vscprintf_l
 _vscprintf_p_l
 _vscwprintf

--- a/lib/libc/mingw/stdio/_vscprintf.c
+++ b/lib/libc/mingw/stdio/_vscprintf.c
@@ -1,0 +1,86 @@
+/**
+ * This file has no copyright assigned and is placed in the Public Domain.
+ * This file is part of the mingw-w64 runtime package.
+ * No warranty is given; refer to the file DISCLAIMER.PD within this package.
+ */
+#include <windows.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+/* emulation of _vscprintf() via _vsnprintf() */
+static int __cdecl emu_vscprintf(const char * __restrict__ format, va_list arglist)
+{
+    char *buffer, *new_buffer;
+    size_t size;
+    int ret = -1;
+
+    /* if format is a null pointer, _vscprintf() returns -1 and sets errno to EINVAL */
+    if (!format) {
+        _set_errno(EINVAL);
+        return -1;
+    }
+
+    /* size for _vsnprintf() must be non-zero and buffer must have place for terminating null character */
+    size = strlen(format) * 2 + 1;
+    buffer = malloc(size);
+
+    if (!buffer) {
+        _set_errno(ENOMEM);
+        return -1;
+    }
+
+    /* if the number of characters to write is greater than size, _vsnprintf() returns -1 */
+    while (size < SIZE_MAX/2 && (ret = _vsnprintf(buffer, size, format, arglist)) < 0) {
+        /* in this case try with larger buffer */
+        size *= 2;
+        new_buffer = realloc(buffer, size);
+        if (!new_buffer)
+            break;
+        buffer = new_buffer;
+    }
+
+    free(buffer);
+
+    if (ret < 0) {
+        _set_errno(ENOMEM);
+        return -1;
+    }
+
+    return ret;
+}
+
+#ifndef __LIBMSVCRT_OS__
+
+int (__cdecl *__MINGW_IMP_SYMBOL(_vscprintf))(const char * __restrict__, va_list) = emu_vscprintf;
+
+#else
+
+#include <msvcrt.h>
+
+static int __cdecl init_vscprintf(const char * __restrict__ format, va_list arglist);
+
+int (__cdecl *__MINGW_IMP_SYMBOL(_vscprintf))(const char * __restrict__, va_list) = init_vscprintf;
+
+static int __cdecl init_vscprintf(const char * __restrict__ format, va_list arglist)
+{
+    HMODULE msvcrt = __mingw_get_msvcrt_handle();
+    int (__cdecl *func)(const char * __restrict__, va_list) = NULL;
+
+    if (msvcrt)
+        func = (int (__cdecl *)(const char * __restrict__, va_list))GetProcAddress(msvcrt, "_vscprintf");
+
+    if (!func)
+        func = emu_vscprintf;
+
+    return (__MINGW_IMP_SYMBOL(_vscprintf) = func)(format, arglist);
+}
+
+#endif
+
+int __cdecl _vscprintf(const char * __restrict__ format, va_list arglist)
+{
+    return __MINGW_IMP_SYMBOL(_vscprintf)(format, arglist);
+}

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -543,6 +543,7 @@ const msvcrt_common_src = [_][]const u8{
     "stdio" ++ path.sep_str ++ "acrt_iob_func.c",
     "stdio" ++ path.sep_str ++ "snprintf_alias.c",
     "stdio" ++ path.sep_str ++ "vsnprintf_alias.c",
+    "stdio" ++ path.sep_str ++ "_vscprintf.c",
     "misc" ++ path.sep_str ++ "_configthreadlocale.c",
     "misc" ++ path.sep_str ++ "_get_current_locale.c",
     "misc" ++ path.sep_str ++ "invalid_parameter_handler.c",


### PR DESCRIPTION
This allows x86 to build again: https://github.com/ziglang/zig/issues/13733

I pulled in `_vscprintf.c` file from the mingw64 repo, and exported the symbol. The history of that file in that repo has more info on why it needs to exist. I'm not sure what the `_vscprintf replaced by emu` comment referred to, as the commit adding that didn't add an emulated version. I may be missing some context here.

That being said, the test suite run with an x86-windows-gnu zig immediately segfaults so there may be more problems to address with x86:

```
LLVM Emit Object... Segmentation fault at address 0x3c
???:?:?: 0x76ca1708 in ??? (???)
???:?:?: 0x76ca174a in ??? (???)
C:\cygwin64\home\kcbanner\kit\zig\lib\std\Progress.zig:229:21: 0xdbd5d3 in refreshWithHeldLock (zig.exe.obj)
                info.wAttributes,
                    ^
C:\cygwin64\home\kcbanner\kit\zig\lib\std\Progress.zig:117:45: 0xc67e84 in end (zig.exe.obj)
            self.context.refreshWithHeldLock();
                                            ^
C:\cygwin64\home\kcbanner\kit\zig\src\Compilation.zig:2398:33: 0xca2fca in update (zig.exe.obj)
    defer main_progress_node.end();
                                ^
C:\cygwin64\home\kcbanner\kit\zig\src\Compilation.zig:5424:31: 0xdb7a6f in buildOutputFromZig (zig.exe.obj)
    try sub_compilation.update();
                              ^
C:\cygwin64\home\kcbanner\kit\zig\src\Compilation.zig:3420:22: 0xdba5cd in processOneJob (zig.exe.obj)
                &comp.libc_static_lib,
                     ^
C:\cygwin64\home\kcbanner\kit\zig\src\Compilation.zig:3092:30: 0xca5a4f in performAllTheWork (zig.exe.obj)
            try processOneJob(comp, work_item);
                             ^
C:\cygwin64\home\kcbanner\kit\zig\src\Compilation.zig:2401:31: 0xca1a24 in update (zig.exe.obj)
    try comp.performAllTheWork(main_progress_node);
                              ^
C:\cygwin64\home\kcbanner\kit\zig\src\main.zig:3376:20: 0xccef77 in updateModule (zig.exe.obj)
    try comp.update();
                   ^
C:\cygwin64\home\kcbanner\kit\zig\src\main.zig:3991:21: 0xbe9234 in cmdBuild (zig.exe.obj)
        updateModule(gpa, comp, .none) catch |err| switch (err) {
                    ^
C:\cygwin64\home\kcbanner\kit\zig\src\main.zig:261:24: 0xbbe13f in mainArgs (zig.exe.obj)
        return cmdBuild(gpa, arena, cmd_args);
                       ^
C:\cygwin64\home\kcbanner\kit\zig\src\stage1.zig:56:24: 0xd2ed6c in main (zig.exe.obj)
        stage2.mainArgs(gpa, arena, args) catch unreachable;
```