### PR TITLE
dwarf: reuse getDbgInfoAtom helper in all of Dwarf.zig

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2420,7 +2420,7 @@ pub fn updateFunc(self: *Elf, module: *Module, func: *Module.Fn, air: Air, liven
     const decl = module.declPtr(decl_index);
     self.freeUnnamedConsts(decl_index);
 
-    var decl_state: ?Dwarf.DeclState = if (self.dwarf) |*dw| try dw.initDeclState(module, decl) else null;
+    var decl_state: ?Dwarf.DeclState = if (self.dwarf) |*dw| try dw.initDeclState(module, decl_index) else null;
     defer if (decl_state) |*ds| ds.deinit();
 
     const res = if (decl_state) |*ds|
@@ -2443,7 +2443,7 @@ pub fn updateFunc(self: *Elf, module: *Module, func: *Module.Fn, air: Air, liven
         try self.dwarf.?.commitDeclState(
             &self.base,
             module,
-            decl,
+            decl_index,
             local_sym.st_value,
             local_sym.st_size,
             ds,
@@ -2483,7 +2483,7 @@ pub fn updateDecl(self: *Elf, module: *Module, decl_index: Module.Decl.Index) !v
     var code_buffer = std.ArrayList(u8).init(self.base.allocator);
     defer code_buffer.deinit();
 
-    var decl_state: ?Dwarf.DeclState = if (self.dwarf) |*dw| try dw.initDeclState(module, decl) else null;
+    var decl_state: ?Dwarf.DeclState = if (self.dwarf) |*dw| try dw.initDeclState(module, decl_index) else null;
     defer if (decl_state) |*ds| ds.deinit();
 
     // TODO implement .debug_info for global variables
@@ -2520,7 +2520,7 @@ pub fn updateDecl(self: *Elf, module: *Module, decl_index: Module.Decl.Index) !v
         try self.dwarf.?.commitDeclState(
             &self.base,
             module,
-            decl,
+            decl_index,
             local_sym.st_value,
             local_sym.st_size,
             ds,

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2190,7 +2190,7 @@ pub fn updateFunc(self: *MachO, module: *Module, func: *Module.Fn, air: Air, liv
     defer code_buffer.deinit();
 
     var decl_state = if (self.d_sym) |*d_sym|
-        try d_sym.dwarf.initDeclState(module, decl)
+        try d_sym.dwarf.initDeclState(module, decl_index)
     else
         null;
     defer if (decl_state) |*ds| ds.deinit();
@@ -2217,7 +2217,7 @@ pub fn updateFunc(self: *MachO, module: *Module, func: *Module.Fn, air: Air, liv
         try self.d_sym.?.dwarf.commitDeclState(
             &self.base,
             module,
-            decl,
+            decl_index,
             addr,
             decl.link.macho.size,
             ds,
@@ -2330,7 +2330,7 @@ pub fn updateDecl(self: *MachO, module: *Module, decl_index: Module.Decl.Index) 
     defer code_buffer.deinit();
 
     var decl_state: ?Dwarf.DeclState = if (self.d_sym) |*d_sym|
-        try d_sym.dwarf.initDeclState(module, decl)
+        try d_sym.dwarf.initDeclState(module, decl_index)
     else
         null;
     defer if (decl_state) |*ds| ds.deinit();
@@ -2368,7 +2368,7 @@ pub fn updateDecl(self: *MachO, module: *Module, decl_index: Module.Decl.Index) 
         try self.d_sym.?.dwarf.commitDeclState(
             &self.base,
             module,
-            decl,
+            decl_index,
             addr,
             decl.link.macho.size,
             ds,

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -885,7 +885,7 @@ pub fn updateFunc(wasm: *Wasm, mod: *Module, func: *Module.Fn, air: Air, livenes
 
     decl.link.wasm.clear();
 
-    var decl_state: ?Dwarf.DeclState = if (wasm.dwarf) |*dwarf| try dwarf.initDeclState(mod, decl) else null;
+    var decl_state: ?Dwarf.DeclState = if (wasm.dwarf) |*dwarf| try dwarf.initDeclState(mod, decl_index) else null;
     defer if (decl_state) |*ds| ds.deinit();
 
     var code_writer = std.ArrayList(u8).init(wasm.base.allocator);
@@ -913,7 +913,7 @@ pub fn updateFunc(wasm: *Wasm, mod: *Module, func: *Module.Fn, air: Air, livenes
         try dwarf.commitDeclState(
             &wasm.base,
             mod,
-            decl,
+            decl_index,
             // Actual value will be written after relocation.
             // For Wasm, this is the offset relative to the code section
             // which isn't known until flush().


### PR DESCRIPTION
We need to access it outside of `DeclState` too so why not reuse the helper anyway.