### PR TITLE
Fix linker segfault adding rpath to sharedlib

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1679,7 +1679,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
             }
             for (self.base.options.objects) |obj| {
                 if (Compilation.classifyFileExt(obj.path) == .shared_library) {
-                    const lib_dir_path = std.fs.path.dirname(obj.path).?;
+                    const lib_dir_path = std.fs.path.dirname(obj.path) orelse continue;
                     if ((try rpath_table.fetchPut(lib_dir_path, {})) == null) {
                         try argv.append("-rpath");
                         try argv.append(lib_dir_path);


### PR DESCRIPTION
If the shared library is a relative path, dirname will return null causing a segfault. In the case I debugged, the current directory was already in RPATH so just ignoring this case seems a reasonable fix. After this fix "make" and "make test" pass for mimalloc.

Closes #13766