### PR TITLE
stage2: make --color on affect progress bar too

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2356,7 +2356,16 @@ pub fn update(comp: *Compilation) !void {
     var progress: std.Progress = .{ .dont_print_on_dumb = true };
     const main_progress_node = progress.start("", 0);
     defer main_progress_node.end();
-    if (comp.color == .off) progress.terminal = null;
+    switch (comp.color) {
+        .off => {
+            progress.terminal = null;
+        },
+        .on => {
+            progress.terminal = std.io.getStdErr();
+            progress.supports_ansi_escape_codes = true;
+        },
+        .auto => {},
+    }
 
     try comp.performAllTheWork(main_progress_node);
 


### PR DESCRIPTION
Before, --color on would affect colored compile error printing but not affect terminal progress bar printing. It was intended for this option to affect both; now it does.

This causes a failure when building the language reference, which contains code for parsing terminal output and rendering HTML. Now it must be expanded to handle 'K' and 'D' codes to simulate a terminal cursor moving, and the CI will fail until that capability is added in a later commit of this branch.

I extracted this change from #13560 so that the idea is not lost but we can solve this issue separately.