### PR TITLE
wasi-libc: define BULK_MEMORY_THRESHOLD for the bulk_memory feature

### DIFF
--- a/src/wasi_libc.zig
+++ b/src/wasi_libc.zig
@@ -277,6 +277,8 @@ fn addCCArgs(
 
         "-iwithsysroot",
         try comp.zig_lib_directory.join(arena, &[_][]const u8{ "libc", "include", triple }),
+
+        "-DBULK_MEMORY_THRESHOLD=32",
     });
 }
 


### PR DESCRIPTION
When the bulk_memory feature is enabled, wasi-libc will only use it if the number of bytes is >= `BULK_MEMORY_THRESHOLD`.

Set it to `32` as in the original `wasi-libc` Makefile.