### PR TITLE
Update wasi-libc to 8b7148f69ae241a2749b3defe4606da8143b72e0

### DIFF
--- a/lib/libc/wasi/libc-bottom-half/cloudlibc/src/libc/dirent/readdir.c
+++ b/lib/libc/wasi/libc-bottom-half/cloudlibc/src/libc/dirent/readdir.c
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 #include <assert.h>
 #include <wasi/api.h>
@@ -77,10 +80,36 @@ struct dirent *readdir(DIR *dirp) {
     GROW(dirp->dirent, dirp->dirent_size,
          offsetof(struct dirent, d_name) + entry.d_namlen + 1);
     struct dirent *dirent = dirp->dirent;
-    dirent->d_ino = entry.d_ino;
     dirent->d_type = entry.d_type;
     memcpy(dirent->d_name, name, entry.d_namlen);
     dirent->d_name[entry.d_namlen] = '\0';
+
+    // `fd_readdir` implementations may set the inode field to zero if the
+    // the inode number is unknown. In that case, do an `fstatat` to get the
+    // inode number.
+    off_t d_ino = entry.d_ino;
+    unsigned char d_type = entry.d_type;
+    if (d_ino == 0 && strcmp(dirent->d_name, "..") != 0) {
+      struct stat statbuf;
+      if (fstatat(dirp->fd, dirent->d_name, &statbuf, AT_SYMLINK_NOFOLLOW) != 0) {
+	if (errno == ENOENT) {
+	  // The file disappeared before we could read it, so skip it.
+	  dirp->buffer_processed += entry_size;
+	  continue;
+	}
+        return NULL;
+      }
+
+      // Fill in the inode.
+      d_ino = statbuf.st_ino;
+
+      // In case someone raced with us and replaced the object with this name
+      // with another of a different type, update the type too.
+      d_type = __wasilibc_iftodt(statbuf.st_mode & S_IFMT);
+    }
+    dirent->d_ino = d_ino;
+    dirent->d_type = d_type;
+
     dirp->cookie = entry.d_next;
     dirp->buffer_processed += entry_size;
     return dirent;

--- a/src/target.zig
+++ b/src/target.zig
@@ -328,8 +328,8 @@ pub fn supportsStackProbing(target: std.Target) bool {
 }
 
 pub fn supportsStackProtector(target: std.Target) bool {
-    // TODO: investigate whether stack-protector works on wasm
-    return !target.isWasm();
+    _ = target;
+    return true;
 }
 
 pub fn libcProvidesStackProtector(target: std.Target) bool {

--- a/src/wasi_libc.zig
+++ b/src/wasi_libc.zig
@@ -551,6 +551,7 @@ const libc_top_half_src_files = [_][]const u8{
     "wasi/libc-top-half/musl/src/fcntl/creat.c",
     "wasi/libc-top-half/musl/src/dirent/alphasort.c",
     "wasi/libc-top-half/musl/src/dirent/versionsort.c",
+    "wasi/libc-top-half/musl/src/env/__stack_chk_fail.c",
     "wasi/libc-top-half/musl/src/env/clearenv.c",
     "wasi/libc-top-half/musl/src/env/getenv.c",
     "wasi/libc-top-half/musl/src/env/putenv.c",


### PR DESCRIPTION
This fixes a bug when `fd_readdir()` doesn't set inode numbers.

It also finally adds `-fstack-protector` support.

See:
https://github.com/WebAssembly/wasi-libc/pull/345
https://github.com/WebAssembly/wasi-libc/pull/352
https://github.com/WebAssembly/wasi-libc/pull/351