### PR TITLE
Draft: Have Reader/Writer be a runtime instead of comptime interface

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -270,11 +270,11 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
             @compileError("The Writer interface is only defined for ArrayList(u8) " ++
                 "but the given type is ArrayList(" ++ @typeName(T) ++ ")")
         else
-            std.io.Writer(*Self, error{OutOfMemory}, appendWrite);
+            std.io.Writer(error{OutOfMemory});
 
         /// Initializes a Writer which will append to the list.
         pub fn writer(self: *Self) Writer {
-            return .{ .context = self };
+            return Writer.init(self, appendWrite);
         }
 
         /// Same as `append` except it returns the number of bytes written, which is always the same
@@ -687,25 +687,6 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
             self: *Self,
             allocator: Allocator,
         };
-
-        pub const Writer = if (T != u8)
-            @compileError("The Writer interface is only defined for ArrayList(u8) " ++
-                "but the given type is ArrayList(" ++ @typeName(T) ++ ")")
-        else
-            std.io.Writer(WriterContext, error{OutOfMemory}, appendWrite);
-
-        /// Initializes a Writer which will append to the list.
-        pub fn writer(self: *Self, allocator: Allocator) Writer {
-            return .{ .context = .{ .self = self, .allocator = allocator } };
-        }
-
-        /// Same as `append` except it returns the number of bytes written, which is always the same
-        /// as `m.len`. The purpose of this function existing is to match `std.io.Writer` API.
-        /// Invalidates pointers if additional memory is needed.
-        fn appendWrite(context: WriterContext, m: []const u8) Allocator.Error!usize {
-            try context.self.appendSlice(context.allocator, m);
-            return m.len;
-        }
 
         /// Append a value to the list `n` times.
         /// Allocates more memory as necessary.

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -162,10 +162,13 @@ pub const BufferedAtomicFile = @import("io/buffered_atomic_file.zig").BufferedAt
 pub const StreamSource = @import("io/stream_source.zig").StreamSource;
 
 /// A Writer that doesn't write to anything.
-pub const null_writer = @as(NullWriter, .{ .context = {} });
+pub const null_writer = NullWriter{
+    .context = undefined,
+    .writeFn = dummyWrite,
+};
 
-const NullWriter = Writer(void, error{}, dummyWrite);
-fn dummyWrite(context: void, data: []const u8) error{}!usize {
+const NullWriter = Writer(error{});
+fn dummyWrite(context: *anyopaque, data: []const u8) error{}!usize {
     _ = context;
     return data.len;
 }

--- a/lib/std/io/buffered_writer.zig
+++ b/lib/std/io/buffered_writer.zig
@@ -10,7 +10,7 @@ pub fn BufferedWriter(comptime buffer_size: usize, comptime WriterType: type) ty
         end: usize = 0,
 
         pub const Error = WriterType.Error;
-        pub const Writer = io.Writer(*Self, Error, write);
+        pub const Writer = io.Writer(Error);
 
         const Self = @This();
 
@@ -20,7 +20,7 @@ pub fn BufferedWriter(comptime buffer_size: usize, comptime WriterType: type) ty
         }
 
         pub fn writer(self: *Self) Writer {
-            return .{ .context = self };
+            return Writer.init(self, write);
         }
 
         pub fn write(self: *Self, bytes: []const u8) Error!usize {

--- a/lib/std/io/counting_reader.zig
+++ b/lib/std/io/counting_reader.zig
@@ -9,7 +9,7 @@ pub fn CountingReader(comptime ReaderType: anytype) type {
         bytes_read: u64 = 0,
 
         pub const Error = ReaderType.Error;
-        pub const Reader = io.Reader(*@This(), Error, read);
+        pub const Reader = io.Reader(Error);
 
         pub fn read(self: *@This(), buf: []u8) Error!usize {
             const amt = try self.child_reader.read(buf);
@@ -18,7 +18,7 @@ pub fn CountingReader(comptime ReaderType: anytype) type {
         }
 
         pub fn reader(self: *@This()) Reader {
-            return .{ .context = self };
+            return Reader.init(self, read);
         }
     };
 }

--- a/lib/std/io/counting_writer.zig
+++ b/lib/std/io/counting_writer.zig
@@ -9,7 +9,7 @@ pub fn CountingWriter(comptime WriterType: type) type {
         child_stream: WriterType,
 
         pub const Error = WriterType.Error;
-        pub const Writer = io.Writer(*Self, Error, write);
+        pub const Writer = io.Writer(Error);
 
         const Self = @This();
 
@@ -20,7 +20,7 @@ pub fn CountingWriter(comptime WriterType: type) type {
         }
 
         pub fn writer(self: *Self) Writer {
-            return .{ .context = self };
+            return Writer.init(self, write);
         }
     };
 }

--- a/lib/std/io/fixed_buffer_stream.zig
+++ b/lib/std/io/fixed_buffer_stream.zig
@@ -17,8 +17,8 @@ pub fn FixedBufferStream(comptime Buffer: type) type {
         pub const SeekError = error{};
         pub const GetSeekPosError = error{};
 
-        pub const Reader = io.Reader(*Self, ReadError, read);
-        pub const Writer = io.Writer(*Self, WriteError, write);
+        pub const Reader = io.Reader(ReadError);
+        pub const Writer = io.Writer(WriteError);
 
         pub const SeekableStream = io.SeekableStream(
             *Self,
@@ -33,11 +33,11 @@ pub fn FixedBufferStream(comptime Buffer: type) type {
         const Self = @This();
 
         pub fn reader(self: *Self) Reader {
-            return .{ .context = self };
+            return Reader.init(self, read);
         }
 
         pub fn writer(self: *Self) Writer {
-            return .{ .context = self };
+            return Writer.init(self, write);
         }
 
         pub fn seekableStream(self: *Self) SeekableStream {

--- a/lib/std/io/limited_reader.zig
+++ b/lib/std/io/limited_reader.zig
@@ -9,7 +9,7 @@ pub fn LimitedReader(comptime ReaderType: type) type {
         bytes_left: u64,
 
         pub const Error = ReaderType.Error;
-        pub const Reader = io.Reader(*Self, Error, read);
+        pub const Reader = io.Reader(Error);
 
         const Self = @This();
 
@@ -21,7 +21,7 @@ pub fn LimitedReader(comptime ReaderType: type) type {
         }
 
         pub fn reader(self: *Self) Reader {
-            return .{ .context = self };
+            return Reader.init(self, read);
         }
     };
 }

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2932,7 +2932,7 @@ fn AutoIndentingStream(comptime UnderlyingWriter: type) type {
     return struct {
         const Self = @This();
         pub const WriteError = UnderlyingWriter.Error;
-        pub const Writer = std.io.Writer(*Self, WriteError, write);
+        pub const Writer = std.io.Writer(WriteError);
 
         underlying_writer: UnderlyingWriter,
 
@@ -2955,7 +2955,7 @@ fn AutoIndentingStream(comptime UnderlyingWriter: type) type {
         indent_next_line: usize = 0,
 
         pub fn writer(self: *Self) Writer {
-            return .{ .context = self };
+            return Writer.init(self, write);
         }
 
         pub fn write(self: *Self, bytes: []const u8) WriteError!usize {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -439,7 +439,7 @@ pub const AllErrors = struct {
                     try counting_stderr.writeAll(": ");
                     // This is the length of the part before the error message:
                     // e.g. "file.zig:4:5: error: "
-                    const prefix_len = @intCast(usize, counting_stderr.context.bytes_written);
+                    const prefix_len = @intCast(usize, counting_writer.bytes_written);
                     ttyconf.setColor(stderr, .Reset);
                     ttyconf.setColor(stderr, .Bold);
                     if (src.count == 1) {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -6695,7 +6695,7 @@ fn IndentWriter(comptime UnderlyingWriter: type) type {
     return struct {
         const Self = @This();
         pub const Error = UnderlyingWriter.Error;
-        pub const Writer = std.io.Writer(*Self, Error, write);
+        pub const Writer = std.io.Writer(Error);
 
         pub const indent_delta = 1;
 
@@ -6704,7 +6704,7 @@ fn IndentWriter(comptime UnderlyingWriter: type) type {
         current_line_empty: bool = true,
 
         pub fn writer(self: *Self) Writer {
-            return .{ .context = self };
+            return Writer.init(self, write);
         }
 
         pub fn write(self: *Self, bytes: []const u8) Error!usize {

--- a/src/link/MachO/Archive.zig
+++ b/src/link/MachO/Archive.zig
@@ -189,7 +189,7 @@ pub fn parseObject(
     offset: u32,
 ) !Object {
     const reader = self.file.reader();
-    try reader.context.seekTo(self.fat_offset + offset);
+    try self.file.seekTo(self.fat_offset + offset);
 
     const object_header = try reader.readStruct(ar_hdr);
 

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -122,7 +122,7 @@ pub const Zld = struct {
         const cpu_arch = self.options.target.cpu.arch;
         const reader = file.reader();
         const fat_offset = try fat.getLibraryOffset(reader, cpu_arch);
-        try reader.context.seekTo(fat_offset);
+        try file.seekTo(fat_offset);
 
         var archive = Archive{
             .name = name,

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -2098,7 +2098,12 @@ fn populateErrorNameTable(wasm: *Wasm) !void {
         const offset = @intCast(u32, atom.code.items.len);
         // first we create the data for the slice of the name
         try atom.code.appendNTimes(wasm.base.allocator, 0, 4); // ptr to name, will be relocated
-        try atom.code.writer(wasm.base.allocator).writeIntLittle(u32, len - 1);
+        {
+            var managed = atom.code.toManaged(wasm.base.allocator);
+            defer atom.code = managed.moveToUnmanaged();
+            try managed.writer().writeIntLittle(u32, len - 1);
+        }
+
         // create relocation to the error name
         try atom.relocs.append(wasm.base.allocator, .{
             .index = names_symbol_index,


### PR DESCRIPTION
Current version of Reader and Writer takes 3 comptime arguments to specify the type. A Context, Error and read/write function. The drawbacks to this approuch are:

- No Reader/Writer types are actually the same. A FixedBufferReader.Reader is no the same as a File.Reader
  - This means you have to take `anytype` everywhere and every different reader/writer will generate a copy of the function taking them.
- Type names are very long, as they include the arguments in the names. This is made even worse by the fact that readers and writers tend to be composed. This affects:
  - Error messages. They can become very hard to read and understand
  - C backend. Type names become incredibly long, which is one of the contributing factors to why the output is big

This commit changes Reader and Writer to be more like Allocator. They are now a pointer + a function pointer to the function that implementions the read/write. This reduces the arguments taken by Reader and Writer from 3 to 1, which is the error set. We cannot eliminate this. Benifits:

- Now, at least some Reader/Writer types can be the same. When they share the same error set, they will be the same type.
  - We could also add some functionality to promote a Reader/Writer to use a super set of its own error set. For example, we could have (this is vaporware):
    ```zig
    const a: Reader(error{}) = ...;
    const b: Reader(error{A}) = ...;
    const readers = &[_]Reader(anyerror){
        a.promote(anyerror),
        b.promote(anyerror),
    };
    ```

- Type names are a lot shorter and nesting Readers and Writers will not produce names that include the child reader/writer.
  - Error messages are better:
    ```zig
    const std = @import("std");

    fn a(b: usize) void {
        _ = b;
    }

    test {
        var counting_writer = std.io.countingWriter(std.io.null_writer);
        // Before: expected type 'usize', found 'io.writer.Writer(*io.counting_writer.CountingWriter(io.writer.Writer(void,error{},(function 'dummyWrite'))),error{},(function 'write'))'
        // After:  expected type 'usize', found 'io.writer.Writer(error{})'
        a(counting_writer.writer());
    }
    ```

  - C backend produces less code:
    ```
      108.368.735 zig2.after.c
      117.846.808 zig2.before.c
    ```

Drawbacks:
* You can no longer access the inner writer through `writer.context`
  * Seemed a bit like an anti pattern though. You should probably take the concrete reader/writer if you need to access its state
* You can no longer obtain a `Writer` for `ArrayListUnmanaged(u8)`. You need to get a managed `ArrayList`, get the `Writer`, write what you want and then move the result back with `moveToUnmanaged`.
      
I've done the work of getting the compiler compiling but many tests probably wont. I wanna know if this is something that would make sense