### PR TITLE
wasi: fixes os.isatty on type mismatch

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3158,7 +3158,7 @@ pub fn isatty(handle: fd_t) bool {
     if (builtin.os.tag == .wasi) {
         var statbuf: fdstat_t = undefined;
         const err = system.fd_fdstat_get(handle, &statbuf);
-        if (@enumToInt(err) != 0) {
+        if (err != .SUCCESS) {
             // errno = err;
             return false;
         }

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3158,7 +3158,7 @@ pub fn isatty(handle: fd_t) bool {
     if (builtin.os.tag == .wasi) {
         var statbuf: fdstat_t = undefined;
         const err = system.fd_fdstat_get(handle, &statbuf);
-        if (err != 0) {
+        if (@enumToInt(err) != 0) {
             // errno = err;
             return false;
         }

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -1065,3 +1065,11 @@ test "timerfd" {
     try os.timerfd_settime(tfd, 0, &sit, null);
     try expectEqual(try os.poll(&fds, 5), 0);
 }
+
+test "isatty" {
+    var tmp = tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile("foo", .{});
+    try expectEqual(os.isatty(file.handle), false);
+}


### PR DESCRIPTION
isatty hasn't been tested explicitly, and there was a compilation error for WASI target.

```
lib/std/os.zig:3161:17: error: incompatible types: 'os.wasi.errno_t' and 'comptime_int'
        if (err != 0) {
            ~~~~^~~~
```

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>