### PR TITLE
CI: test updating the wasm binary

### DIFF
--- a/ci/aarch64-linux-debug.sh
+++ b/ci/aarch64-linux-debug.sh
@@ -71,3 +71,30 @@ tidy --drop-empty-elements no -qe ../zig-cache/langref.html
 
 # Produce the experimental std lib documentation.
 stage3-debug/bin/zig test ../lib/std/std.zig -femit-docs -fno-emit-bin --zig-lib-dir ../lib
+
+# Ensure that updating the wasm binary from this commit will result in a viable build.
+stage3-debug/bin/zig build update-zig1
+
+rm -rf ../build-new
+mkdir ../build-new
+cd ../build-new
+
+export ZIG_GLOBAL_CACHE_DIR="$(pwd)/zig-global-cache"
+export ZIG_LOCAL_CACHE_DIR="$(pwd)/zig-local-cache"
+export CC="$ZIG cc -target $TARGET -mcpu=$MCPU"
+export CXX="$ZIG c++ -target $TARGET -mcpu=$MCPU"
+
+cmake .. \
+  -DCMAKE_PREFIX_PATH="$PREFIX" \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DZIG_TARGET_TRIPLE="$TARGET" \
+  -DZIG_TARGET_MCPU="$MCPU" \
+  -DZIG_STATIC=ON \
+  -GNinja
+
+unset CC
+unset CXX
+
+ninja install
+
+stage3/bin/zig test ../test/behavior.zig -I../test

--- a/ci/aarch64-linux-release.sh
+++ b/ci/aarch64-linux-release.sh
@@ -71,3 +71,30 @@ tidy --drop-empty-elements no -qe ../zig-cache/langref.html
 
 # Produce the experimental std lib documentation.
 stage3-release/bin/zig test ../lib/std/std.zig -femit-docs -fno-emit-bin --zig-lib-dir ../lib
+
+# Ensure that updating the wasm binary from this commit will result in a viable build.
+stage3-release/bin/zig build update-zig1
+
+rm -rf ../build-new
+mkdir ../build-new
+cd ../build-new
+
+export ZIG_GLOBAL_CACHE_DIR="$(pwd)/zig-global-cache"
+export ZIG_LOCAL_CACHE_DIR="$(pwd)/zig-local-cache"
+export CC="$ZIG cc -target $TARGET -mcpu=$MCPU"
+export CXX="$ZIG c++ -target $TARGET -mcpu=$MCPU"
+
+cmake .. \
+  -DCMAKE_PREFIX_PATH="$PREFIX" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DZIG_TARGET_TRIPLE="$TARGET" \
+  -DZIG_TARGET_MCPU="$MCPU" \
+  -DZIG_STATIC=ON \
+  -GNinja
+
+unset CC
+unset CXX
+
+ninja install
+
+stage3/bin/zig test ../test/behavior.zig -I../test

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -72,6 +72,7 @@ tidy --drop-empty-elements no -qe ../zig-cache/langref.html
 # Produce the experimental std lib documentation.
 stage3-release/bin/zig test ../lib/std/std.zig -femit-docs -fno-emit-bin --zig-lib-dir ../lib
 
+# Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3-release/bin/zig build \
   --prefix stage4-release \
   -Denable-llvm \
@@ -86,3 +87,30 @@ stage3-release/bin/zig build \
 echo "If the following command fails, it means nondeterminism has been"
 echo "introduced, making stage3 and stage4 no longer byte-for-byte identical."
 diff stage3-release/bin/zig stage4-release/bin/zig
+
+# Ensure that updating the wasm binary from this commit will result in a viable build.
+stage3-release/bin/zig build update-zig1
+
+rm -rf ../build-new
+mkdir ../build-new
+cd ../build-new
+
+export ZIG_GLOBAL_CACHE_DIR="$(pwd)/zig-global-cache"
+export ZIG_LOCAL_CACHE_DIR="$(pwd)/zig-local-cache"
+export CC="$ZIG cc -target $TARGET -mcpu=$MCPU"
+export CXX="$ZIG c++ -target $TARGET -mcpu=$MCPU"
+
+cmake .. \
+  -DCMAKE_PREFIX_PATH="$PREFIX" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DZIG_TARGET_TRIPLE="$TARGET" \
+  -DZIG_TARGET_MCPU="$MCPU" \
+  -DZIG_STATIC=ON \
+  -GNinja
+
+unset CC
+unset CXX
+
+ninja install
+
+stage3/bin/zig test ../test/behavior.zig -I../test


### PR DESCRIPTION
Make sure that no commit regresses the ability to upgrade our wasm binary. Otherwise, somebody in the future is going to have a Bad Day.