### PR TITLE
dwarf: add support for multiple source files

### DIFF
--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -2569,7 +2569,10 @@ fn addDIFile(self: *Dwarf, mod: *Module, decl_index: Module.Decl.Index) !u28 {
     if (!gop.found_existing) {
         switch (self.bin_file.tag) {
             .elf => self.bin_file.cast(File.Elf).?.debug_line_header_dirty = true,
-            .macho => self.bin_file.cast(File.MachO).?.d_sym.?.debug_line_header_dirty = true,
+            .macho => {
+                const d_sym = self.bin_file.cast(File.MachO).?.getDebugSymbols().?;
+                d_sym.markDirty(d_sym.debug_line_section_index.?);
+            },
             .wasm => {},
             else => unreachable,
         }

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -1166,7 +1166,7 @@ pub fn commitDeclState(
                 .macho => {
                     const d_sym = self.bin_file.cast(File.MachO).?.getDebugSymbols().?;
                     const sect_index = d_sym.debug_line_section_index.?;
-                    try d_sym.growSection(sect_index, needed_size);
+                    try d_sym.growSection(sect_index, needed_size, true);
                     const sect = d_sym.getSection(sect_index);
                     const file_pos = sect.offset + src_fn.off;
                     try pwriteDbgLineNops(
@@ -1414,7 +1414,7 @@ fn writeDeclDebugInfo(self: *Dwarf, atom: *Atom, dbg_info_buf: []const u8) !void
         .macho => {
             const d_sym = self.bin_file.cast(File.MachO).?.getDebugSymbols().?;
             const sect_index = d_sym.debug_info_section_index.?;
-            try d_sym.growSection(sect_index, needed_size);
+            try d_sym.growSection(sect_index, needed_size, true);
             const sect = d_sym.getSection(sect_index);
             const file_pos = sect.offset + atom.off;
             try pwriteDbgInfoNops(
@@ -1697,7 +1697,7 @@ pub fn writeDbgAbbrev(self: *Dwarf) !void {
         .macho => {
             const d_sym = self.bin_file.cast(File.MachO).?.getDebugSymbols().?;
             const sect_index = d_sym.debug_abbrev_section_index.?;
-            try d_sym.growSection(sect_index, needed_size);
+            try d_sym.growSection(sect_index, needed_size, false);
             const sect = d_sym.getSection(sect_index);
             const file_pos = sect.offset + abbrev_offset;
             try d_sym.file.pwriteAll(&abbrev_buf, file_pos);
@@ -2134,7 +2134,7 @@ pub fn writeDbgAranges(self: *Dwarf, addr: u64, size: u64) !void {
         .macho => {
             const d_sym = self.bin_file.cast(File.MachO).?.getDebugSymbols().?;
             const sect_index = d_sym.debug_aranges_section_index.?;
-            try d_sym.growSection(sect_index, needed_size);
+            try d_sym.growSection(sect_index, needed_size, false);
             const sect = d_sym.getSection(sect_index);
             const file_pos = sect.offset;
             try d_sym.file.pwriteAll(di_buf.items, file_pos);
@@ -2301,7 +2301,7 @@ pub fn writeDbgLineHeader(self: *Dwarf, module: *Module) !void {
                 const d_sym = self.bin_file.cast(File.MachO).?.getDebugSymbols().?;
                 const sect_index = d_sym.debug_line_section_index.?;
                 const needed_size = @intCast(u32, d_sym.getSection(sect_index).size + delta);
-                try d_sym.growSection(sect_index, needed_size);
+                try d_sym.growSection(sect_index, needed_size, true);
                 const file_pos = d_sym.getSection(sect_index).offset + src_fn.off;
 
                 const amt = try d_sym.file.preadAll(buffer, file_pos);

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -1151,7 +1151,7 @@ pub fn commitDeclState(
                 .elf => {
                     const elf_file = self.bin_file.cast(File.Elf).?;
                     const shdr_index = elf_file.debug_line_section_index.?;
-                    try elf_file.growNonAllocSection(shdr_index, needed_size, 1);
+                    try elf_file.growNonAllocSection(shdr_index, needed_size, 1, true);
                     const debug_line_sect = elf_file.sections.items[shdr_index];
                     const file_pos = debug_line_sect.sh_offset + src_fn.off;
                     try pwriteDbgLineNops(
@@ -1398,7 +1398,7 @@ fn writeDeclDebugInfo(self: *Dwarf, atom: *Atom, dbg_info_buf: []const u8) !void
         .elf => {
             const elf_file = self.bin_file.cast(File.Elf).?;
             const shdr_index = elf_file.debug_info_section_index.?;
-            try elf_file.growNonAllocSection(shdr_index, needed_size, 1);
+            try elf_file.growNonAllocSection(shdr_index, needed_size, 1, true);
             const debug_info_sect = elf_file.sections.items[shdr_index];
             const file_pos = debug_info_sect.sh_offset + atom.off;
             try pwriteDbgInfoNops(
@@ -1689,7 +1689,7 @@ pub fn writeDbgAbbrev(self: *Dwarf) !void {
         .elf => {
             const elf_file = self.bin_file.cast(File.Elf).?;
             const shdr_index = elf_file.debug_abbrev_section_index.?;
-            try elf_file.growNonAllocSection(shdr_index, needed_size, 1);
+            try elf_file.growNonAllocSection(shdr_index, needed_size, 1, false);
             const debug_abbrev_sect = elf_file.sections.items[shdr_index];
             const file_pos = debug_abbrev_sect.sh_offset + abbrev_offset;
             try elf_file.base.file.?.pwriteAll(&abbrev_buf, file_pos);
@@ -2126,7 +2126,7 @@ pub fn writeDbgAranges(self: *Dwarf, addr: u64, size: u64) !void {
         .elf => {
             const elf_file = self.bin_file.cast(File.Elf).?;
             const shdr_index = elf_file.debug_aranges_section_index.?;
-            try elf_file.growNonAllocSection(shdr_index, needed_size, 16);
+            try elf_file.growNonAllocSection(shdr_index, needed_size, 16, false);
             const debug_aranges_sect = elf_file.sections.items[shdr_index];
             const file_pos = debug_aranges_sect.sh_offset;
             try elf_file.base.file.?.pwriteAll(di_buf.items, file_pos);
@@ -2289,7 +2289,7 @@ pub fn writeDbgLineHeader(self: *Dwarf, module: *Module) !void {
                 const elf_file = self.bin_file.cast(File.Elf).?;
                 const shdr_index = elf_file.debug_line_section_index.?;
                 const needed_size = elf_file.sections.items[shdr_index].sh_size + delta;
-                try elf_file.growNonAllocSection(shdr_index, needed_size, 1);
+                try elf_file.growNonAllocSection(shdr_index, needed_size, 1, true);
                 const file_pos = elf_file.sections.items[shdr_index].sh_offset + src_fn.off;
 
                 const amt = try elf_file.base.file.?.preadAll(buffer, file_pos);

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -2309,7 +2309,13 @@ pub fn writeDbgLineHeader(self: *Dwarf, module: *Module) !void {
 
                 try d_sym.file.pwriteAll(buffer, file_pos + delta);
             },
-            .wasm => @panic("TODO grow section"),
+            .wasm => {
+                const wasm_file = self.bin_file.cast(File.Wasm).?;
+                const debug_line = &wasm_file.debug_line_atom.?.code;
+                mem.copy(u8, buffer, debug_line.items[src_fn.off..]);
+                try debug_line.resize(self.allocator, debug_line.items.len + delta);
+                mem.copy(u8, debug_line.items[src_fn.off + delta ..], buffer);
+            },
             else => unreachable,
         }
 

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -976,11 +976,7 @@ pub fn initDeclState(self: *Dwarf, mod: *Module, decl_index: Module.Decl.Index) 
             // Once we support more than one source file, this will have the ability to be more
             // than one possible value.
             const file_index = try self.addDIFile(mod, decl_index);
-            leb128.writeUnsignedFixed(
-                4,
-                dbg_line_buffer.addManyAsArrayAssumeCapacity(4),
-                file_index + 1,
-            );
+            leb128.writeUnsignedFixed(4, dbg_line_buffer.addManyAsArrayAssumeCapacity(4), file_index);
 
             // Emit a line for the begin curly with prologue_end=false. The codegen will
             // do the work of setting prologue_end=true and epilogue_begin=true.
@@ -2370,7 +2366,7 @@ pub fn writeDbgLineHeader(self: *Dwarf, module: *Module) !void {
         di_buf.appendSliceAssumeCapacity(file);
         di_buf.appendSliceAssumeCapacity(&[_]u8{
             0, // null byte for the relative path name
-            @intCast(u8, dir_index + 1), // directory_index
+            @intCast(u8, dir_index), // directory_index
             0, // mtime (TODO supply this)
             0, // file size bytes (TODO supply this)
         });
@@ -2596,7 +2592,7 @@ fn addDIFile(self: *Dwarf, mod: *Module, decl_index: Module.Decl.Index) !u28 {
             else => unreachable,
         }
     }
-    return @intCast(u28, gop.index);
+    return @intCast(u28, gop.index + 1);
 }
 
 fn genIncludeDirsAndFileNames(self: *Dwarf, arena: Allocator, module: *Module) !struct {
@@ -2626,7 +2622,7 @@ fn genIncludeDirsAndFileNames(self: *Dwarf, arena: Allocator, module: *Module) !
                 break :inner dir_path[comp_dir.len + 1 ..];
             } else dir_path;
             const dirs_gop = dirs.getOrPutAssumeCapacity(actual_dir_path);
-            break :blk @intCast(u28, dirs_gop.index);
+            break :blk @intCast(u28, dirs_gop.index + 1);
         };
 
         files_dir_indexes.appendAssumeCapacity(dir_index);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -347,7 +347,7 @@ pub fn openPath(allocator: Allocator, options: link.Options) !*MachO {
 
         self.d_sym = .{
             .allocator = allocator,
-            .dwarf = link.File.Dwarf.init(allocator, .macho, options.target),
+            .dwarf = link.File.Dwarf.init(allocator, &self.base, options.target),
             .file = d_sym_file,
             .page_size = self.page_size,
         };
@@ -449,7 +449,7 @@ pub fn flushModule(self: *MachO, comp: *Compilation, prog_node: *std.Progress.No
     const module = self.base.options.module orelse return error.LinkingWithoutZigSourceUnimplemented;
 
     if (self.d_sym) |*d_sym| {
-        try d_sym.dwarf.flushModule(&self.base, module);
+        try d_sym.dwarf.flushModule(module);
     }
 
     var libs = std.StringArrayHashMap(link.SystemLib).init(arena);
@@ -2213,7 +2213,6 @@ pub fn updateFunc(self: *MachO, module: *Module, func: *Module.Fn, air: Air, liv
 
     if (decl_state) |*ds| {
         try self.d_sym.?.dwarf.commitDeclState(
-            &self.base,
             module,
             decl_index,
             addr,
@@ -2364,7 +2363,6 @@ pub fn updateDecl(self: *MachO, module: *Module, decl_index: Module.Decl.Index) 
 
     if (decl_state) |*ds| {
         try self.d_sym.?.dwarf.commitDeclState(
-            &self.base,
             module,
             decl_index,
             addr,
@@ -2603,7 +2601,7 @@ fn updateDeclCode(self: *MachO, decl_index: Module.Decl.Index, code: []const u8)
 pub fn updateDeclLineNumber(self: *MachO, module: *Module, decl: *const Module.Decl) !void {
     _ = module;
     if (self.d_sym) |*d_sym| {
-        try d_sym.dwarf.updateDeclLineNumber(&self.base, decl);
+        try d_sym.dwarf.updateDeclLineNumber(decl);
     }
 }
 

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -4300,6 +4300,11 @@ pub fn getEntryPoint(self: MachO) error{MissingMainEntrypoint}!SymbolWithLoc {
     return global;
 }
 
+pub fn getDebugSymbols(self: *MachO) ?*DebugSymbols {
+    if (self.d_sym == null) return null;
+    return &self.d_sym.?;
+}
+
 pub fn findFirst(comptime T: type, haystack: []align(1) const T, start: usize, predicate: anytype) usize {
     if (!@hasDecl(@TypeOf(predicate), "predicate"))
         @compileError("Predicate is required to define fn predicate(@This(), T) bool");

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -213,7 +213,7 @@ pub fn flushModule(self: *DebugSymbols, macho_file: *MachO) !void {
     }
 
     if (self.debug_abbrev_section_dirty) {
-        try self.dwarf.writeDbgAbbrev(&macho_file.base);
+        try self.dwarf.writeDbgAbbrev();
         self.debug_abbrev_section_dirty = false;
     }
 
@@ -223,7 +223,7 @@ pub fn flushModule(self: *DebugSymbols, macho_file: *MachO) !void {
         const text_section = macho_file.sections.items(.header)[macho_file.text_section_index.?];
         const low_pc = text_section.addr;
         const high_pc = text_section.addr + text_section.size;
-        try self.dwarf.writeDbgInfoHeader(&macho_file.base, module, low_pc, high_pc);
+        try self.dwarf.writeDbgInfoHeader(module, low_pc, high_pc);
         self.debug_info_header_dirty = false;
     }
 
@@ -231,12 +231,12 @@ pub fn flushModule(self: *DebugSymbols, macho_file: *MachO) !void {
         // Currently only one compilation unit is supported, so the address range is simply
         // identical to the main program header virtual address and memory size.
         const text_section = macho_file.sections.items(.header)[macho_file.text_section_index.?];
-        try self.dwarf.writeDbgAranges(&macho_file.base, text_section.addr, text_section.size);
+        try self.dwarf.writeDbgAranges(text_section.addr, text_section.size);
         self.debug_aranges_section_dirty = false;
     }
 
     if (self.debug_line_header_dirty) {
-        try self.dwarf.writeDbgLineHeader(&macho_file.base, module);
+        try self.dwarf.writeDbgLineHeader(module);
         self.debug_line_header_dirty = false;
     }
 

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -202,7 +202,7 @@ fn detectAllocCollision(self: *DebugSymbols, start: u64, size: u64) ?u64 {
     return null;
 }
 
-pub fn findFreeSpace(self: *DebugSymbols, object_size: u64, min_alignment: u64) u64 {
+fn findFreeSpace(self: *DebugSymbols, object_size: u64, min_alignment: u64) u64 {
     const segment = self.getDwarfSegmentPtr();
     var offset: u64 = segment.fileoff;
     while (self.detectAllocCollision(offset, object_size)) |item_end| {
@@ -464,7 +464,7 @@ fn writeHeader(self: *DebugSymbols, macho_file: *MachO, ncmds: u32, sizeofcmds: 
     try self.file.pwriteAll(mem.asBytes(&header), 0);
 }
 
-pub fn allocatedSize(self: *DebugSymbols, start: u64) u64 {
+fn allocatedSize(self: *DebugSymbols, start: u64) u64 {
     const seg = self.getDwarfSegmentPtr();
     assert(start >= seg.fileoff);
     var min_pos: u64 = std.math.maxInt(u64);

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -180,6 +180,12 @@ pub fn markDirty(self: *DebugSymbols, sect_index: u8) void {
         self.debug_info_header_dirty = true;
     } else if (self.debug_line_section_index.? == sect_index) {
         self.debug_line_header_dirty = true;
+    } else if (self.debug_abbrev_section_index.? == sect_index) {
+        self.debug_abbrev_section_dirty = true;
+    } else if (self.debug_str_section_index.? == sect_index) {
+        self.debug_string_table_dirty = true;
+    } else if (self.debug_aranges_section_index.? == sect_index) {
+        self.debug_aranges_section_dirty = true;
     }
 }
 

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -171,6 +171,7 @@ pub fn growSection(self: *DebugSymbols, sect_index: u8, needed_size: u32) !void 
         if (amt != existing_size) return error.InputOutput;
         sect.offset = @intCast(u32, new_offset);
     }
+
     sect.size = needed_size;
     self.markDirty(sect_index);
 }


### PR DESCRIPTION
We now generate `include_directories` and `file_names` lists in `.debug_line` section which means we can finally debug the self-hosted native backend output across multiple Zig source files. In particular, we can finally debug output from running:

```
$ zig test behavior.zig -Itest -fno-LLVM --test-no-exec -femit-bin=test_bin
$ gdb test_bin
```

I have ensured that all 3 platforms Linux, macOS and Wasm benefit from the changes introduced in this PR. ~~Before merging it, I am thinking of adding some simple incremental DWARF test plugin to our incremental test harness. This is long overdue especially now that I have taken the time to refactor a lot of the DWARF linker code. For that reason, I will leave the PR in draft until I have a stab at the testing harness.~~ In order not to clutter this already pretty big PR further, I have decided to work on the test harness on the side next.

EDIT: some showcase (taken on macOS):

<img width="837" alt="Screenshot_2022-12-08_at_09 46 28" src="https://user-images.githubusercontent.com/1519747/206524453-1b7cc711-709e-492e-9830-93577c4ca9f6.png">
