### PR TITLE
debug info: resolve relative paths to source files into absolute paths

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -217,10 +217,6 @@ pub const Options = struct {
     /// (Darwin) remove dylibs that are unreachable by the entry point or exported symbols
     dead_strip_dylibs: bool = false,
 
-    /// (Windows) PDB source path prefix to instruct the linker how to resolve relative
-    /// paths when consolidating CodeView streams into a single PDB file.
-    pdb_source_path: ?[]const u8 = null,
-
     pub fn effectiveOutputMode(options: Options) std.builtin.OutputMode {
         return if (options.use_lld) .Obj else options.output_mode;
     }

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -171,10 +171,6 @@ pub fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
             });
             try argv.append(try allocPrint(arena, "-PDB:{s}", .{out_pdb}));
             try argv.append(try allocPrint(arena, "-PDBALTPATH:{s}", .{out_pdb}));
-
-            if (self.base.options.pdb_source_path) |path| {
-                try argv.append(try std.fmt.allocPrint(arena, "-PDBSOURCEPATH:{s}", .{path}));
-            }
         }
         if (self.base.options.lto) {
             switch (self.base.options.optimize_mode) {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1149,7 +1149,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
         }
 
         if (self.debug_line_header_dirty) {
-            try dw.writeDbgLineHeader(module);
+            try dw.writeDbgLineHeader();
             self.debug_line_header_dirty = false;
         }
     }

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -281,7 +281,7 @@ pub fn flushModule(self: *DebugSymbols, macho_file: *MachO) !void {
     }
 
     if (self.debug_line_header_dirty) {
-        try self.dwarf.writeDbgLineHeader(module);
+        try self.dwarf.writeDbgLineHeader();
         self.debug_line_header_dirty = false;
     }
 

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -2672,7 +2672,7 @@ pub fn flushModule(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Nod
             // as locations are always offsets relative to 'code' section.
             try dwarf.writeDbgInfoHeader(mod, 0, code_section_size);
             try dwarf.writeDbgAranges(0, code_section_size);
-            try dwarf.writeDbgLineHeader(mod);
+            try dwarf.writeDbgLineHeader();
         }
 
         var debug_bytes = std.ArrayList(u8).init(wasm.base.allocator);


### PR DESCRIPTION
This change brings back `stage1` behavior in that all debug info paths that are emitted in DWARF/PDB are always absolute. Note that the paths are resolved only when committing them into either a respective LLVM type (`llvm.DIFile`), or when emitting DWARF (as is the case with self-hosted backends).

This change will make stack traces and debugging experience more consistent in the sense that the presence of source lines in stack traces will not be dependent on the current working directory of the running process, making cases like https://github.com/ziglang/zig/issues/13831 non-existent (I am referring here to lack of source lines in submitted stack trace, not the actual linker bug which is unrelated).

Additional bonus is that we no longer need to mess with `lld-link`s output on Windows by including special PDB path manipulating flag, `-PDBSOURCEPATH` as all source paths are now absolute by design.

Finally, as generating valid debug info output is important but not critical, if a call to `std.os.realpath` fails for whatever reason, we simply fallback to relative paths readily available.

If we merge this, this patch will obsolete https://github.com/ziglang/zig/pull/13540

cc @Vexu 