### PR TITLE
langref: incorrect use of the term "enum variant" in enums.zig

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3584,7 +3584,7 @@ const Type = enum {
     not_ok,
 };
 
-// Declare a specific instance of the enum.
+// Declare a specific enum element.
 const c = Type.ok;
 
 // If you want access to the ordinal value of an enum, you

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3584,7 +3584,7 @@ const Type = enum {
     not_ok,
 };
 
-// Declare a specific enum element.
+// Declare a specific enum field.
 const c = Type.ok;
 
 // If you want access to the ordinal value of an enum, you

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3633,13 +3633,13 @@ test "enum method" {
     try expect(!p.isClubs());
 }
 
-// An enum variant of different types can be switched upon.
+// An enum can be switched upon.
 const Foo = enum {
     string,
     number,
     none,
 };
-test "enum variant switch" {
+test "enum switch" {
     const p = Foo.number;
     const what_is_it = switch (p) {
         Foo.string => "this is a string",

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3584,7 +3584,7 @@ const Type = enum {
     not_ok,
 };
 
-// Declare a specific instance of the enum variant.
+// Declare a specific instance of the enum.
 const c = Type.ok;
 
 // If you want access to the ordinal value of an enum, you


### PR DESCRIPTION
Closes #13838 