### PR TITLE
macho+zld: skip atomless synthetic globals in dead_strip

### DIFF
--- a/src/link/MachO/dead_strip.zig
+++ b/src/link/MachO/dead_strip.zig
@@ -58,7 +58,8 @@ fn collectRoots(zld: *Zld, roots: *AtomTable) !void {
                 const sym = zld.getSymbol(global);
                 if (sym.undf()) continue;
 
-                const object = zld.objects.items[global.getFile().?];
+                const file = global.getFile() orelse continue; // synthetic globals are atomless
+                const object = zld.objects.items[file];
                 const atom_index = object.getAtomIndexForSymbol(global.sym_index).?; // panic here means fatal error
                 _ = try roots.getOrPut(atom_index);
 


### PR DESCRIPTION
They are implicitly marked live.

Fixes #13831 