### PR TITLE
langref: add section numbers

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -300,6 +300,40 @@
           color: #fff;
         }
       }
+
+      @media all {
+        main {
+          counter-reset: section-2;
+        }
+        h2 {
+          counter-reset: section-3;
+        }
+        h2::before {
+          counter-increment: section-2;
+          content: counter(section-2) ". ";
+          font-weight: normal;
+        }
+        h3 {
+          counter-reset: section-4;
+        }
+        h3::before {
+          counter-increment: section-3;
+          content: counter(section-2) "." counter(section-3) ". ";
+          font-weight: normal;
+        }
+        h4::before {
+          counter-increment: section-4;
+          content: counter(section-2) "." counter(section-3) "." counter(section-4) ". ";
+          font-weight: normal;
+        }
+        #zig-version::before {
+          content: "";
+        }
+        #table-of-contents::before {
+          content: "";
+        }
+      }
+    }
     </style>
 </head>
 <body>


### PR DESCRIPTION
When reading a document with nested sections, it is not easy to discover the depth of the current section.

Add support for nested section numbers, from the h2 to the h4 heading, in the format "lv1. ", "lv1.lv2. ", "lv1.lv2.lv3. ".  The "Zig Version" and "Table of Content" sections are excluded.

The section numbers are implemented in CSS, with the CSS rules declared inside a @media rule.  Currently the @media rule targets all media.