### PR TITLE
Sema: implement AVR address spaces

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -174,6 +174,14 @@ pub const AddressSpace = enum {
     param,
     shared,
     local,
+
+    // AVR address spaces.
+    flash,
+    flash1,
+    flash2,
+    flash3,
+    flash4,
+    flash5,
 };
 
 /// This data structure is used by the Zig language code generation and

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -1186,6 +1186,8 @@ pub const Target = struct {
                     .fs, .gs, .ss => arch == .x86_64 or arch == .x86,
                     .global, .constant, .local, .shared => is_gpu,
                     .param => is_nvptx,
+                    // TODO this should also check how many flash banks the cpu has
+                    .flash, .flash1, .flash2, .flash3, .flash4, .flash5 => arch == .avr,
                 };
             }
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -31892,6 +31892,8 @@ pub fn analyzeAddressSpace(
         .param => is_nv,
         .global, .shared, .local => is_gpu,
         .constant => is_gpu and (ctx == .constant),
+        // TODO this should also check how many flash banks the cpu has
+        .flash, .flash1, .flash2, .flash3, .flash4, .flash5 => arch == .avr,
     };
 
     if (!supported) {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -10237,6 +10237,16 @@ fn toLlvmAddressSpace(address_space: std.builtin.AddressSpace, target: std.Targe
             .local => llvm.address_space.amdgpu.private,
             else => unreachable,
         },
+        .avr => switch (address_space) {
+            .generic => llvm.address_space.default,
+            .flash => llvm.address_space.avr.flash,
+            .flash1 => llvm.address_space.avr.flash1,
+            .flash2 => llvm.address_space.avr.flash2,
+            .flash3 => llvm.address_space.avr.flash3,
+            .flash4 => llvm.address_space.avr.flash4,
+            .flash5 => llvm.address_space.avr.flash5,
+            else => unreachable,
+        },
         else => switch (address_space) {
             .generic => llvm.address_space.default,
             else => unreachable,

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -1527,8 +1527,12 @@ pub const address_space = struct {
 
     // See llvm/lib/Target/AVR/AVR.h
     pub const avr = struct {
-        pub const data_memory: c_uint = 0;
-        pub const program_memory: c_uint = 1;
+        pub const flash: c_uint = 1;
+        pub const flash1: c_uint = 2;
+        pub const flash2: c_uint = 3;
+        pub const flash3: c_uint = 4;
+        pub const flash4: c_uint = 5;
+        pub const flash5: c_uint = 6;
     };
 
     // See llvm/lib/Target/NVPTX/NVPTX.h

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -548,7 +548,7 @@ pub const DeclGen = struct {
             .gs, .fs, .ss => unreachable,
             .shared => .Workgroup,
             .local => .Private,
-            .global, .param, .constant => unreachable,
+            .global, .param, .constant, .flash, .flash1, .flash2, .flash3, .flash4, .flash5 => unreachable,
         };
     }
 


### PR DESCRIPTION
I didn't test this on real hardware yet, but after looking at the LLVM IR it seems to be working.

```zig
var a: u16 addrspace(.data) = 11;
var b: u16 addrspace(.program) = 22;
var c: u16 addrspace(.data) = 0;

pub export fn _start1() callconv(.C) noreturn {
    c = a + b;
    while (true) {}
}
```
compiles to:
```llvm
@foo.a = internal unnamed_addr global i16 11, align 1
@foo.b = internal unnamed_addr addrspace(1) global i16 22, align 1
@foo.c = internal unnamed_addr global i16 0, align 1

; Function Attrs: minsize noredzone noreturn nounwind optsize
define dso_local void @_start1() addrspace(0) #0 {
Entry:
  %0 = load i16, ptr @foo.a, align 1
  %1 = load i16, ptr addrspace(1) @foo.b, align 1
  %2 = add nuw i16 %0, %1
  store i16 %2, ptr @foo.c, align 1
  br label %Loop

Loop:                                             ; preds = %Loop, %Entry
  br label %Loop
}
```