### PR TITLE
Compilation: revert asking for exclusive locks on cache hits

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3540,7 +3540,6 @@ pub fn cImport(comp: *Compilation, c_src: []const u8) !CImportResult {
     const cimport_zig_basename = "cimport.zig";
 
     var man = comp.obtainCObjectCacheManifest();
-    man.want_shared_lock = false;
     defer man.deinit();
 
     man.hash.add(@as(u16, 0xb945)); // Random number to distinguish translate-c from compiling C objects
@@ -3654,7 +3653,6 @@ pub fn cImport(comp: *Compilation, c_src: []const u8) !CImportResult {
     // possible we had a hit and the manifest is dirty, for example if the file mtime changed but
     // the contents were the same, we hit the cache but the manifest is dirty and we need to update
     // it to prevent doing a full file content comparison the next time around.
-    man.want_shared_lock = true;
     man.writeManifest() catch |err| {
         log.warn("failed to write cache manifest for C import: {s}", .{@errorName(err)});
     };
@@ -3829,7 +3827,6 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.P
     }
 
     var man = comp.obtainCObjectCacheManifest();
-    man.want_shared_lock = false;
     defer man.deinit();
 
     man.hash.add(comp.clang_preprocessor_mode);
@@ -4125,7 +4122,6 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.P
     // possible we had a hit and the manifest is dirty, for example if the file mtime changed but
     // the contents were the same, we hit the cache but the manifest is dirty and we need to update
     // it to prevent doing a full file content comparison the next time around.
-    man.want_shared_lock = true;
     man.writeManifest() catch |err| {
         log.warn("failed to write cache manifest when compiling '{s}': {s}", .{ c_object.src.src_path, @errorName(err) });
     };


### PR DESCRIPTION
We definitely want a shared lock on a cache hit. Without this, we get a deadlock when Zig is asked to compile the same C source file multiple times as part of the same compilation.

This is a partial revert of 8ccb9a6ad327a4d7fbc321b33d4aa66a27a1f5ee.

cc @kcbanner