### PR TITLE
Send langref.html to zig-out/share/doc instead of zig-cache

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -39,7 +39,7 @@ pub fn build(b: *Builder) !void {
     const rel_zig_exe = try fs.path.relative(b.allocator, b.build_root, b.zig_exe);
     const langref_out_path = fs.path.join(
         b.allocator,
-        &[_][]const u8{ b.cache_root, "langref.html" },
+        &[_][]const u8{ b.install_prefix, "share", "doc", "langref.html" },
     ) catch unreachable;
     const docgen_cmd = docgen_exe.run();
     docgen_cmd.addArgs(&[_][]const u8{

--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const io = std.io;
 const fs = std.fs;
+const path = fs.path;
 const process = std.process;
 const ChildProcess = std.ChildProcess;
 const Progress = std.Progress;
@@ -48,6 +49,7 @@ pub fn main() !void {
     var in_file = try fs.cwd().openFile(in_file_name, .{ .mode = .read_only });
     defer in_file.close();
 
+    if (path.dirname(out_file_name)) |dirname| try fs.cwd().makePath(dirname);
     var out_file = try fs.cwd().createFile(out_file_name, .{});
     defer out_file.close();
 


### PR DESCRIPTION
After the discussion here: https://github.com/ziglang/zig/issues/13863

I think sending final build output to `zig-cache` is very confusing and counter-intuitive. I asked in `#zig:matrix.org` where people thought would be the most logical place to send it, and someone suggested this place, because `zig-out` is the install prefix; stuff that goes in `zig-out/bin` is stuff that, in a distribution package, would get installed to `/usr/bin`. Likewise, the language reference in packaged versions of zig (on their system and mine at least)  is installed to `/usr/share/doc`.