### PR TITLE
Remove incorrect assertion in readMachODebugInfo panicking during panic

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1110,7 +1110,12 @@ fn readMachODebugInfo(allocator: mem.Allocator, macho_file: File) !ModuleDebugIn
             else => {},
         }
     }
-    assert(state == .oso_close);
+
+    switch (state) {
+        .init => return error.MissingDebugInfo,
+        .oso_close => {},
+        else => return error.InvalidDebugInfo,
+    }
 
     const symbols = try allocator.realloc(symbols_buf, symbol_index);
 


### PR DESCRIPTION
This fixes a class of bugs on macOS where a segfault happening in a loaded dylib with no debug info would cause a panic in the panic handler instead of simply noting that the dylib has no valid debug info via `error.MissingDebugInfo`. An example could be code linking some system dylib and causing some routine to segfault on say invalid pointer value, which should normally cause Zig to print an incomplete stack trace anchored at the currently loaded image and backtrace all the way back to the Zig binary with valid debug info. Currently, in a situation like this we would trigger a panic within a panic.