### PR TITLE
Improve tagged union documentation

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3820,7 +3820,7 @@ test "simple union" {
       to use with {#link|switch#} expressions.
       Tagged unions coerce to their tag type: {#link|Type Coercion: unions and enums#}.
       </p>
-      {#code_begin|test|test_switch_tagged_union#}
+      {#code_begin|test|test_tagged_union#}
 const std = @import("std");
 const expect = std.testing.expect;
 
@@ -3846,14 +3846,6 @@ test "switch on tagged union" {
 test "get tag type" {
     try expect(std.meta.Tag(ComplexType) == ComplexTypeTag);
 }
-
-test "coerce to enum" {
-    const c1 = ComplexType{ .ok = 42 };
-    const c2 = ComplexType.not_ok;
-
-    try expect(c1 == .ok);
-    try expect(c2 == .not_ok);
-}
       {#code_end#}
       <p>In order to modify the payload of a tagged union in a switch expression,
       place a {#syntax#}*{#endsyntax#} before the variable name to make it a pointer:
@@ -3873,7 +3865,6 @@ const ComplexType = union(ComplexTypeTag) {
 
 test "modify tagged union in switch" {
     var c = ComplexType{ .ok = 42 };
-    try expect(@as(ComplexTypeTag, c) == ComplexTypeTag.ok);
 
     switch (c) {
         ComplexTypeTag.ok => |*value| value.* += 1,


### PR DESCRIPTION
closes #13870

I decided to remove the coercion test from this section, because that is also tested in both directions in the linked section specifically about union<->enum coercion.