### PR TITLE
autodoc: Removed BoundFn from indexTypeKinds in main.js

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -2660,7 +2660,6 @@ var zigAnalysis;
       "Enum",
       "Union",
       "Fn",
-      "BoundFn",
       "Opaque",
       "Frame",
       "AnyFrame",


### PR DESCRIPTION
Removes error that blocks rendering of autodoc documentation.