### PR TITLE
Revert test workarounds for aarch64-windows

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -31,8 +31,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/shared_library/build.zig", .{});
     cases.addBuildFile("test/standalone/mix_o_files/build.zig", .{});
     cases.addBuildFile("test/standalone/mix_c_files/build.zig", .{
-        // https://github.com/ziglang/zig/issues/13738
-        .build_modes = !(builtin.os.tag == .windows and builtin.cpu.arch == .aarch64),
+        .build_modes = true,
         .cross_targets = true,
     });
     cases.addBuildFile("test/standalone/global_linkage/build.zig", .{});

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -64,8 +64,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     }
 
     cases.addBuildFile("test/standalone/c_compiler/build.zig", .{
-        // https://github.com/ziglang/zig/issues/13738
-        .build_modes = !(builtin.os.tag == .windows and builtin.cpu.arch == .aarch64),
+        .build_modes = true,
         .cross_targets = true,
     });
 


### PR DESCRIPTION
These are fixed by #13854.