### PR TITLE
parser: remove c_void -> anyopaque rewrite

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -106,29 +106,6 @@ test "zig fmt: rewrite callconv(.Inline) to the inline keyword" {
     );
 }
 
-// TODO Remove this after zig 0.10.0 is released.
-test "zig fmt: rewrite c_void to anyopaque" {
-    try testTransform(
-        \\const Foo = struct {
-        \\    c_void: *c_void,
-        \\};
-        \\
-        \\fn foo(a: ?*c_void) !*c_void {
-        \\    return a orelse unreachable;
-        \\}
-        \\
-    ,
-        \\const Foo = struct {
-        \\    c_void: *anyopaque,
-        \\};
-        \\
-        \\fn foo(a: ?*anyopaque) !*anyopaque {
-        \\    return a orelse unreachable;
-        \\}
-        \\
-    );
-}
-
 test "zig fmt: simple top level comptime block" {
     try testCanonical(
         \\// line comment

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -207,18 +207,9 @@ fn renderExpression(gpa: Allocator, ais: *Ais, tree: Ast, node: Ast.Node.Index, 
     const node_tags = tree.nodes.items(.tag);
     const datas = tree.nodes.items(.data);
     switch (node_tags[node]) {
-        // TODO remove this c_void -> anyopaque rewrite after the 0.10.0 release.
-        // Also get rid of renderSpace() as it will no longer be necessary.
         .identifier => {
             const token_index = main_tokens[node];
-
-            const lexeme = tokenSliceForRender(tree, token_index);
-            if (mem.eql(u8, lexeme, "c_void")) {
-                try ais.writer().writeAll("anyopaque");
-                return renderSpace(ais, tree, token_index, lexeme.len, space);
-            } else {
-                return renderIdentifier(ais, tree, token_index, space, .preserve_when_shadowing);
-            }
+            return renderIdentifier(ais, tree, token_index, space, .preserve_when_shadowing);
         },
 
         .number_literal,


### PR DESCRIPTION
TODO comments said to remove this

re: the second change: I'm slightly unsure here what was meant by "get rid of renderSpace()"; I guessed at the intent and it looks sensible to me but I would like someone more knowledgeable to confirm.