### PR TITLE
langref: improve the test_fn_reflection.zig doctest

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5241,11 +5241,15 @@ test "fn type inference" {
       {#header_close#}
       {#header_open|Function Reflection#}
       {#code_begin|test|test_fn_reflection#}
-const expect = @import("std").testing.expect;
+const std = @import("std");
+const math = std.math;
+const testing = std.testing;
 
 test "fn reflection" {
-    try expect(@typeInfo(@TypeOf(expect)).Fn.args[0].arg_type.? == bool);
-    try expect(@typeInfo(@TypeOf(expect)).Fn.is_var_args == false);
+    try testing.expect(@typeInfo(@TypeOf(testing.expect)).Fn.args[0].arg_type.? == bool);
+    try testing.expect(@typeInfo(@TypeOf(testing.tmpDir)).Fn.return_type.? == testing.TmpDir);
+
+    try testing.expect(@typeInfo(@TypeOf(math.Log2Int)).Fn.is_generic);
 }
       {#code_end#}
       {#header_close#}


### PR DESCRIPTION
Currently, the test_fn_reflection.zig doctest has an example of .Fn.is_var_args.  This example can confuse the reader, since there is no documentation about variadic functions and is_var_args is mainly used in the compiler.

Remove the example with .Fn.is_var_args and add instead examples with .Fn.return_type and .Fn.is_generic.