### PR TITLE
re-enable "signed zeros are represented properly" beahvior tests for f80 and c_longdouble

### DIFF
--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -1440,11 +1440,9 @@ test "signed zeros are represented properly" {
             try testOne(f16);
             try testOne(f32);
             try testOne(f64);
-            // TODO enable this
-            //try testOne(f80);
+            try testOne(f80);
             try testOne(f128);
-            // TODO enable this
-            //try testOne(c_longdouble);
+            try testOne(c_longdouble);
         }
 
         fn testOne(comptime T: type) !void {


### PR DESCRIPTION
works on my machine in various configurations, so re-enabling here for the CI run