### PR TITLE
langref: add missing ReleaseSmall when describing unreachable

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5463,7 +5463,8 @@ fn doAThing(str: []u8) !void {
       <p>
       Here we know for sure that "1234" will parse successfully. So we put the
       {#syntax#}unreachable{#endsyntax#} value on the right hand side. {#syntax#}unreachable{#endsyntax#} generates
-      a panic in Debug and ReleaseSafe modes and undefined behavior in ReleaseFast mode. So, while we're debugging the
+      a panic in {#link|Debug#} and {#link|ReleaseSafe#} modes and undefined behavior in
+      {#link|ReleaseFast#} and {#link|ReleaseSmall#} modes. So, while we're debugging the
       application, if there <em>was</em> a surprise error here, the application would crash
       appropriately.
       </p>
@@ -11882,7 +11883,7 @@ fn readU32Be() u32 {}
             Depending on the build mode, {#syntax#}unreachable{#endsyntax#} may emit a panic.
             <ul>
               <li>Emits a panic in {#syntax#}Debug{#endsyntax#} and {#syntax#}ReleaseSafe{#endsyntax#} mode, or when using <kbd>zig test</kbd>.</li>
-              <li>Does not emit a panic in {#syntax#}ReleaseFast{#endsyntax#} mode, unless <kbd>zig test</kbd> is being used.</li>
+              <li>Does not emit a panic in {#syntax#}ReleaseFast{#endsyntax#} and {#syntax#}ReleaseSmall{#endsyntax#} mode, unless <kbd>zig test</kbd> is being used.</li>
               <li>See also {#link|unreachable#}</li>
             </ul>
           </td>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -11883,7 +11883,7 @@ fn readU32Be() u32 {}
             Depending on the build mode, {#syntax#}unreachable{#endsyntax#} may emit a panic.
             <ul>
               <li>Emits a panic in {#syntax#}Debug{#endsyntax#} and {#syntax#}ReleaseSafe{#endsyntax#} mode, or when using <kbd>zig test</kbd>.</li>
-              <li>Does not emit a panic in {#syntax#}ReleaseFast{#endsyntax#} and {#syntax#}ReleaseSmall{#endsyntax#} mode, unless <kbd>zig test</kbd> is being used.</li>
+              <li>Does not emit a panic in {#syntax#}ReleaseFast{#endsyntax#} and {#syntax#}ReleaseSmall{#endsyntax#} mode.</li>
               <li>See also {#link|unreachable#}</li>
             </ul>
           </td>


### PR DESCRIPTION
Add a missing ReleaseSmall when describing unreachable in the try section and the unreachable entry in the Keyword Reference section.

Additionally, transform Debug, ReleaseSafe, ReleaseFast and ReleaseSmall into links in the try section.