### PR TITLE
CI: override cache folders on aarch64-windows

### DIFF
--- a/ci/aarch64-windows.ps1
+++ b/ci/aarch64-windows.ps1
@@ -36,6 +36,12 @@ Remove-Item -Path 'build-release' -Recurse -Force -ErrorAction Ignore
 New-Item -Path 'build-release' -ItemType Directory
 Set-Location -Path 'build-release'
 
+# Override the cache directories because they won't actually help other CI runs
+# which will be testing alternate versions of zig, and ultimately would just
+# fill up space on the hard drive for no reason.
+$Env:ZIG_GLOBAL_CACHE_DIR="$(Get-Location)\zig-global-cache"
+$Env:ZIG_LOCAL_CACHE_DIR="$(Get-Location)\zig-local-cache"
+
 # CMake gives a syntax error when file paths with backward slashes are used.
 # Here, we use forward slashes only to work around this.
 & cmake .. `


### PR DESCRIPTION
This matches the scripts we use for our other self-hosted runners.