### PR TITLE
zig fmt: fix extra whitespace with multiline strings

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5500,6 +5500,35 @@ test "zig fmt: canonicalize symbols (keywords)" {
     );
 }
 
+test "zig fmt: no space before newline before multiline string" {
+    try testCanonical(
+        \\const S = struct {
+        \\    text: []const u8,
+        \\    comment: []const u8,
+        \\};
+        \\
+        \\test {
+        \\    const s1 = .{
+        \\        .text =
+        \\        \\hello
+        \\        \\world
+        \\        ,
+        \\        .comment = "test",
+        \\    };
+        \\    _ = s1;
+        \\    const s2 = .{
+        \\        .comment = "test",
+        \\        .text =
+        \\        \\hello
+        \\        \\world
+        \\        ,
+        \\    };
+        \\    _ = s2;
+        \\}
+        \\
+    );
+}
+
 // Normalize \xNN and \u{NN} escapes and unicode inside @"" escapes.
 test "zig fmt: canonicalize symbols (character escapes)" {
     try testTransform(

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1675,7 +1675,12 @@ fn renderStructInit(
 
         try renderToken(ais, tree, struct_init.ast.lbrace + 1, .none); // .
         try renderIdentifier(ais, tree, struct_init.ast.lbrace + 2, .space, .eagerly_unquote); // name
-        try renderToken(ais, tree, struct_init.ast.lbrace + 3, .space); // =
+        // Don't output a space after the = if expression is a multiline string,
+        // since then it will start on the next line.
+        const nodes = tree.nodes.items(.tag);
+        const expr = nodes[struct_init.ast.fields[0]];
+        var space_after_equal: Space = if (expr == .multiline_string_literal) .none else .space;
+        try renderToken(ais, tree, struct_init.ast.lbrace + 3, space_after_equal); // =
         try renderExpression(gpa, ais, tree, struct_init.ast.fields[0], .comma);
 
         for (struct_init.ast.fields[1..]) |field_init| {
@@ -1683,7 +1688,8 @@ fn renderStructInit(
             try renderExtraNewlineToken(ais, tree, init_token - 3);
             try renderToken(ais, tree, init_token - 3, .none); // .
             try renderIdentifier(ais, tree, init_token - 2, .space, .eagerly_unquote); // name
-            try renderToken(ais, tree, init_token - 1, .space); // =
+            space_after_equal = if (nodes[field_init] == .multiline_string_literal) .none else .space;
+            try renderToken(ais, tree, init_token - 1, space_after_equal); // =
             try renderExpression(gpa, ais, tree, field_init, .comma);
         }
 

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9859,7 +9859,7 @@ pub const FuncGen = struct {
             constraints: [:0]const u8,
         } = switch (target.cpu.arch) {
             .x86 => .{
-                .template = 
+                .template =
                 \\roll $$3,  %edi ; roll $$13, %edi
                 \\roll $$61, %edi ; roll $$51, %edi
                 \\xchgl %ebx,%ebx
@@ -9867,7 +9867,7 @@ pub const FuncGen = struct {
                 .constraints = "={edx},{eax},0,~{cc},~{memory}",
             },
             .x86_64 => .{
-                .template = 
+                .template =
                 \\rolq $$3,  %rdi ; rolq $$13, %rdi
                 \\rolq $$61, %rdi ; rolq $$51, %rdi
                 \\xchgq %rbx,%rbx
@@ -9875,7 +9875,7 @@ pub const FuncGen = struct {
                 .constraints = "={rdx},{rax},0,~{cc},~{memory}",
             },
             .aarch64, .aarch64_32, .aarch64_be => .{
-                .template = 
+                .template =
                 \\ror x12, x12, #3  ;  ror x12, x12, #13
                 \\ror x12, x12, #51 ;  ror x12, x12, #61
                 \\orr x10, x10, x10

--- a/test/stack_traces.zig
+++ b/test/stack_traces.zig
@@ -5,13 +5,13 @@ const tests = @import("tests.zig");
 pub fn addCases(cases: *tests.StackTracesContext) void {
     cases.addCase(.{
         .name = "return",
-        .source = 
+        .source =
         \\pub fn main() !void {
         \\    return error.TheSkyIsFalling;
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\source.zig:2:5: [address] in main (test)
             \\    return error.TheSkyIsFalling;
@@ -24,7 +24,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 .windows, // TODO
                 .linux, // defeated by aggressive inlining
             },
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\source.zig:2:5: [address] in [function]
             \\    return error.TheSkyIsFalling;
@@ -33,13 +33,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\
             ,
@@ -48,7 +48,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
 
     cases.addCase(.{
         .name = "try return",
-        .source = 
+        .source =
         \\fn foo() !void {
         \\    return error.TheSkyIsFalling;
         \\}
@@ -58,7 +58,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\source.zig:2:5: [address] in foo (test)
             \\    return error.TheSkyIsFalling;
@@ -73,7 +73,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             .exclude_os = .{
                 .windows, // TODO
             },
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\source.zig:2:5: [address] in [function]
             \\    return error.TheSkyIsFalling;
@@ -85,13 +85,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\
             ,
@@ -99,7 +99,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
     });
     cases.addCase(.{
         .name = "non-error return pops error trace",
-        .source = 
+        .source =
         \\fn bar() !void {
         \\    return error.UhOh;
         \\}
@@ -116,7 +116,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: UnrelatedError
             \\source.zig:13:5: [address] in main (test)
             \\    return error.UnrelatedError;
@@ -129,7 +129,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 .windows, // TODO
                 .linux, // defeated by aggressive inlining
             },
-            .expect = 
+            .expect =
             \\error: UnrelatedError
             \\source.zig:13:5: [address] in [function]
             \\    return error.UnrelatedError;
@@ -138,13 +138,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: UnrelatedError
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: UnrelatedError
             \\
             ,
@@ -153,7 +153,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
 
     cases.addCase(.{
         .name = "continue in while loop",
-        .source = 
+        .source =
         \\fn foo() !void {
         \\    return error.UhOh;
         \\}
@@ -167,7 +167,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: UnrelatedError
             \\source.zig:10:5: [address] in main (test)
             \\    return error.UnrelatedError;
@@ -180,7 +180,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 .windows, // TODO
                 .linux, // defeated by aggressive inlining
             },
-            .expect = 
+            .expect =
             \\error: UnrelatedError
             \\source.zig:10:5: [address] in [function]
             \\    return error.UnrelatedError;
@@ -189,13 +189,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: UnrelatedError
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: UnrelatedError
             \\
             ,
@@ -204,7 +204,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
 
     cases.addCase(.{
         .name = "try return + handled catch/if-else",
-        .source = 
+        .source =
         \\fn foo() !void {
         \\    return error.TheSkyIsFalling;
         \\}
@@ -218,7 +218,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\source.zig:2:5: [address] in foo (test)
             \\    return error.TheSkyIsFalling;
@@ -234,7 +234,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 .windows, // TODO
                 .linux, // defeated by aggressive inlining
             },
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\source.zig:2:5: [address] in [function]
             \\    return error.TheSkyIsFalling;
@@ -246,13 +246,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\
             ,
@@ -261,7 +261,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
 
     cases.addCase(.{
         .name = "break from inline loop pops error return trace",
-        .source = 
+        .source =
         \\fn foo() !void { return error.FooBar; }
         \\
         \\pub fn main() !void {
@@ -277,7 +277,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: BadTime
             \\source.zig:12:5: [address] in main (test)
             \\    return error.BadTime;
@@ -290,7 +290,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 .windows, // TODO
                 .linux, // defeated by aggressive inlining
             },
-            .expect = 
+            .expect =
             \\error: BadTime
             \\source.zig:12:5: [address] in [function]
             \\    return error.BadTime;
@@ -299,13 +299,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: BadTime
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: BadTime
             \\
             ,
@@ -314,7 +314,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
 
     cases.addCase(.{
         .name = "catch and re-throw error",
-        .source = 
+        .source =
         \\fn foo() !void {
         \\    return error.TheSkyIsFalling;
         \\}
@@ -324,7 +324,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\source.zig:2:5: [address] in foo (test)
             \\    return error.TheSkyIsFalling;
@@ -340,7 +340,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 .windows, // TODO
                 .linux, // defeated by aggressive inlining
             },
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\source.zig:2:5: [address] in [function]
             \\    return error.TheSkyIsFalling;
@@ -352,13 +352,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\
             ,
@@ -367,7 +367,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
 
     cases.addCase(.{
         .name = "errors stored in var do not contribute to error trace",
-        .source = 
+        .source =
         \\fn foo() !void {
         \\    return error.TheSkyIsFalling;
         \\}
@@ -382,7 +382,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: SomethingUnrelatedWentWrong
             \\source.zig:11:5: [address] in main (test)
             \\    return error.SomethingUnrelatedWentWrong;
@@ -395,7 +395,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 .windows, // TODO
                 .linux, // defeated by aggressive inlining
             },
-            .expect = 
+            .expect =
             \\error: SomethingUnrelatedWentWrong
             \\source.zig:11:5: [address] in [function]
             \\    return error.SomethingUnrelatedWentWrong;
@@ -404,13 +404,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: SomethingUnrelatedWentWrong
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: SomethingUnrelatedWentWrong
             \\
             ,
@@ -419,7 +419,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
 
     cases.addCase(.{
         .name = "error stored in const has trace preserved for duration of block",
-        .source = 
+        .source =
         \\fn foo() !void { return error.TheSkyIsFalling; }
         \\fn bar() !void { return error.InternalError; }
         \\fn baz() !void { return error.UnexpectedReality; }
@@ -446,7 +446,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: StillUnresolved
             \\source.zig:1:18: [address] in foo (test)
             \\fn foo() !void { return error.TheSkyIsFalling; }
@@ -465,7 +465,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
                 .windows, // TODO
                 .linux, // defeated by aggressive inlining
             },
-            .expect = 
+            .expect =
             \\error: StillUnresolved
             \\source.zig:1:18: [address] in [function]
             \\fn foo() !void { return error.TheSkyIsFalling; }
@@ -480,13 +480,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: StillUnresolved
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: StillUnresolved
             \\
             ,
@@ -495,7 +495,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
 
     cases.addCase(.{
         .name = "error passed to function has its trace preserved for duration of the call",
-        .source = 
+        .source =
         \\pub fn expectError(expected_error: anyerror, actual_error: anyerror!void) !void {
         \\    actual_error catch |err| {
         \\        if (err == expected_error) return {};
@@ -516,7 +516,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: TestExpectedError
             \\source.zig:9:18: [address] in foo (test)
             \\fn foo() !void { return error.Foo; }
@@ -534,7 +534,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             .exclude_os = .{
                 .windows, // TODO
             },
-            .expect = 
+            .expect =
             \\error: TestExpectedError
             \\source.zig:9:18: [address] in [function]
             \\fn foo() !void { return error.Foo; }
@@ -549,13 +549,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: TestExpectedError
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: TestExpectedError
             \\
             ,
@@ -564,7 +564,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
 
     cases.addCase(.{
         .name = "try return from within catch",
-        .source = 
+        .source =
         \\fn foo() !void {
         \\    return error.TheSkyIsFalling;
         \\}
@@ -580,7 +580,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\source.zig:2:5: [address] in foo (test)
             \\    return error.TheSkyIsFalling;
@@ -598,7 +598,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             .exclude_os = .{
                 .windows, // TODO
             },
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\source.zig:2:5: [address] in [function]
             \\    return error.TheSkyIsFalling;
@@ -613,13 +613,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\
             ,
@@ -628,7 +628,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
 
     cases.addCase(.{
         .name = "try return from within if-else",
-        .source = 
+        .source =
         \\fn foo() !void {
         \\    return error.TheSkyIsFalling;
         \\}
@@ -644,7 +644,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\source.zig:2:5: [address] in foo (test)
             \\    return error.TheSkyIsFalling;
@@ -662,7 +662,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             .exclude_os = .{
                 .windows, // TODO
             },
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\source.zig:2:5: [address] in [function]
             \\    return error.TheSkyIsFalling;
@@ -677,13 +677,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: AndMyCarIsOutOfGas
             \\
             ,
@@ -692,7 +692,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
 
     cases.addCase(.{
         .name = "try try return return",
-        .source = 
+        .source =
         \\fn foo() !void {
         \\    try bar();
         \\}
@@ -710,7 +710,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\source.zig:10:5: [address] in make_error (test)
             \\    return error.TheSkyIsFalling;
@@ -731,7 +731,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             .exclude_os = .{
                 .windows, // TODO
             },
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\source.zig:10:5: [address] in [function]
             \\    return error.TheSkyIsFalling;
@@ -749,13 +749,13 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             ,
         },
         .ReleaseFast = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\
             ,
         },
         .ReleaseSmall = .{
-            .expect = 
+            .expect =
             \\error: TheSkyIsFalling
             \\
             ,
@@ -768,7 +768,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
             .windows, // TODO intermittent failures
         },
         .name = "dumpCurrentStackTrace",
-        .source = 
+        .source =
         \\const std = @import("std");
         \\
         \\fn bar() void {
@@ -783,7 +783,7 @@ pub fn addCases(cases: *tests.StackTracesContext) void {
         \\}
         ,
         .Debug = .{
-            .expect = 
+            .expect =
             \\source.zig:7:8: [address] in foo (test)
             \\    bar();
             \\       ^


### PR DESCRIPTION
Fixes #13937