### PR TITLE
`std.compress`: Improve tests, remove reliance on openDirAbsolute

### DIFF
--- a/lib/std/compress/deflate/bits_utils.zig
+++ b/lib/std/compress/deflate/bits_utils.zig
@@ -8,7 +8,6 @@ pub fn bitReverse(comptime T: type, value: T, N: usize) T {
 
 test "bitReverse" {
     const std = @import("std");
-    const expect = std.testing.expect;
 
     const ReverseBitsTest = struct {
         in: u16,
@@ -29,6 +28,6 @@ test "bitReverse" {
 
     for (reverse_bits_tests) |h| {
         var v = bitReverse(u16, h.in, h.bit_count);
-        try expect(v == h.out);
+        try std.testing.expectEqual(h.out, v);
     }
 }

--- a/lib/std/compress/deflate/compressor.zig
+++ b/lib/std/compress/deflate/compressor.zig
@@ -1079,7 +1079,7 @@ test "deflate" {
         try comp.close();
         comp.deinit();
 
-        try expect(mem.eql(u8, output.items, dt.out));
+        try testing.expectEqualSlices(u8, dt.out, output.items);
     }
 }
 
@@ -1104,7 +1104,7 @@ test "bulkHash4" {
             _ = bulkHash4(y, dst);
             for (dst) |got, i| {
                 var want = hash4(y[i..]);
-                try expect(got == want);
+                try testing.expectEqual(want, got);
             }
         }
     }

--- a/lib/std/compress/deflate/compressor_test.zig
+++ b/lib/std/compress/deflate/compressor_test.zig
@@ -62,8 +62,8 @@ fn testSync(level: deflate.Compression, input: []const u8) !void {
             defer testing.allocator.free(decompressed);
 
             var read = try decomp.reader().readAll(decompressed); // read at least half
-            try expect(read == half_len);
-            try expect(mem.eql(u8, input[0..half], decompressed));
+            try testing.expectEqual(half_len, read);
+            try testing.expectEqualSlices(u8, input[0..half], decompressed);
         }
 
         // Write last half of the input and close()
@@ -79,13 +79,13 @@ fn testSync(level: deflate.Compression, input: []const u8) !void {
             defer testing.allocator.free(decompressed);
 
             var read = try decomp.reader().readAll(decompressed);
-            try expect(read == half_len);
-            try expect(mem.eql(u8, input[half..], decompressed));
+            try testing.expectEqual(half_len, read);
+            try testing.expectEqualSlices(u8, input[half..], decompressed);
 
             // Extra read
             var final: [10]u8 = undefined;
             read = try decomp.reader().readAll(&final);
-            try expect(read == 0); // expect ended stream to return 0 bytes
+            try testing.expectEqual(@as(usize, 0), read); // expect ended stream to return 0 bytes
 
             _ = decomp.close();
         }
@@ -105,7 +105,7 @@ fn testSync(level: deflate.Compression, input: []const u8) !void {
     _ = try decomp.reader().readAll(decompressed);
     _ = decomp.close();
 
-    try expect(mem.eql(u8, input, decompressed));
+    try testing.expectEqualSlices(u8, input, decompressed);
 }
 
 fn testToFromWithLevelAndLimit(level: deflate.Compression, input: []const u8, limit: u32) !void {
@@ -130,8 +130,8 @@ fn testToFromWithLevelAndLimit(level: deflate.Compression, input: []const u8, li
     defer testing.allocator.free(decompressed);
 
     var read: usize = try decomp.reader().readAll(decompressed);
-    try expect(read == input.len);
-    try expect(mem.eql(u8, input, decompressed));
+    try testing.expectEqual(input.len, read);
+    try testing.expectEqualSlices(u8, input, decompressed);
 
     if (false) {
         // TODO: this test has regressed
@@ -237,7 +237,7 @@ test "very long sparse chunk" {
         read = try reader.read(&buf);
         written += try writer.write(buf[0..read]);
     }
-    try expect(written == 0x23e8);
+    try testing.expectEqual(@as(usize, 0x23e8), written);
 }
 
 test "compressor reset" {
@@ -287,7 +287,7 @@ fn testWriterReset(level: deflate.Compression, dict: ?[]const u8) !void {
     try filler.writeData(&comp);
     try comp.close();
 
-    try expect(mem.eql(u8, buf1.items, buf2.items));
+    try testing.expectEqualSlices(u8, buf1.items, buf2.items);
 }
 
 test "decompressor dictionary" {
@@ -327,7 +327,7 @@ test "decompressor dictionary" {
     defer decomp.deinit();
 
     _ = try decomp.reader().readAll(decompressed);
-    try expect(mem.eql(u8, decompressed, "hello again world"));
+    try testing.expectEqualSlices(u8, "hello again world", decompressed);
 }
 
 test "compressor dictionary" {
@@ -371,7 +371,7 @@ test "compressor dictionary" {
     try comp_d.writer().writeAll(text);
     try comp_d.close();
 
-    try expect(mem.eql(u8, compressed_nd.readableSlice(0), compressed_d.items));
+    try testing.expectEqualSlices(u8, compressed_d.items, compressed_nd.readableSlice(0));
 }
 
 // Update the hash for best_speed only if d.index < d.maxInsertIndex
@@ -394,18 +394,12 @@ test "Go non-regression test for 2508" {
 }
 
 test "deflate/inflate string" {
-    // Skip wasi because it does not support std.fs.openDirAbsolute()
-    if (builtin.os.tag == .wasi) return error.SkipZigTest;
-
-    const current_dir = try std.fs.openDirAbsolute(std.fs.path.dirname(@src().file).?, .{});
-    const testdata_dir = try current_dir.openDir("testdata", .{});
-
     const StringTest = struct {
         filename: []const u8,
         limit: [11]u32,
     };
 
-    var deflate_inflate_string_tests = [_]StringTest{
+    const deflate_inflate_string_tests = [_]StringTest{
         .{
             .filename = "compress-e.txt",
             .limit = [11]u32{
@@ -440,12 +434,8 @@ test "deflate/inflate string" {
         },
     };
 
-    for (deflate_inflate_string_tests) |t| {
-        const golden_file = try testdata_dir.openFile(t.filename, .{});
-        defer golden_file.close();
-        var golden = try golden_file.reader().readAllAlloc(testing.allocator, math.maxInt(usize));
-        defer testing.allocator.free(golden);
-
+    inline for (deflate_inflate_string_tests) |t| {
+        var golden = @embedFile("testdata/" ++ t.filename);
         try testToFromWithLimit(golden, t.limit);
     }
 }
@@ -492,11 +482,8 @@ test "inflate reset" {
 
     _ = decomp.close();
 
-    try expect(strings[0].len == decompressed_0.len);
-    try expect(strings[1].len == decompressed_1.len);
-
-    try expect(mem.eql(u8, strings[0], decompressed_0));
-    try expect(mem.eql(u8, strings[1], decompressed_1));
+    try testing.expectEqualSlices(u8, strings[0], decompressed_0);
+    try testing.expectEqualSlices(u8, strings[1], decompressed_1);
 }
 
 test "inflate reset dictionary" {
@@ -542,9 +529,6 @@ test "inflate reset dictionary" {
 
     _ = decomp.close();
 
-    try expect(strings[0].len == decompressed_0.len);
-    try expect(strings[1].len == decompressed_1.len);
-
-    try expect(mem.eql(u8, strings[0], decompressed_0));
-    try expect(mem.eql(u8, strings[1], decompressed_1));
+    try testing.expectEqualSlices(u8, strings[0], decompressed_0);
+    try testing.expectEqualSlices(u8, strings[1], decompressed_1);
 }

--- a/lib/std/compress/deflate/decompressor.zig
+++ b/lib/std/compress/deflate/decompressor.zig
@@ -895,7 +895,6 @@ pub fn Decompressor(comptime ReaderType: type) type {
 }
 
 // tests
-const expect = std.testing.expect;
 const expectError = std.testing.expectError;
 const io = std.io;
 const testing = std.testing;
@@ -928,7 +927,7 @@ test "truncated input" {
 
         var output = [1]u8{0} ** 12;
         try expectError(error.UnexpectedEndOfStream, zr.readAll(&output));
-        try expect(mem.eql(u8, output[0..t.output.len], t.output));
+        try testing.expectEqualSlices(u8, t.output, output[0..t.output.len]);
     }
 }
 
@@ -1026,8 +1025,8 @@ test "inflate A Tale of Two Cities (1859) intro" {
 
     var got: [700]u8 = undefined;
     var got_len = try decomp.reader().read(&got);
-    try expect(got_len == 616);
-    try expect(mem.eql(u8, got[0..expected.len], expected));
+    try testing.expectEqual(@as(usize, 616), got_len);
+    try testing.expectEqualSlices(u8, expected, got[0..expected.len]);
 }
 
 test "lengths overflow" {

--- a/lib/std/compress/deflate/deflate_fast.zig
+++ b/lib/std/compress/deflate/deflate_fast.zig
@@ -354,7 +354,7 @@ pub const DeflateFast = struct {
 };
 
 test "best speed match 1/3" {
-    const expect = std.testing.expect;
+    const expectEqual = std.testing.expectEqual;
 
     {
         var previous = [_]u8{ 0, 0, 0, 1, 2 };
@@ -367,7 +367,7 @@ test "best speed match 1/3" {
         };
         var current = [_]u8{ 3, 4, 5, 0, 1, 2, 3, 4, 5 };
         var got: i32 = e.matchLen(3, -3, &current);
-        try expect(got == 6);
+        try expectEqual(@as(i32, 6), got);
     }
     {
         var previous = [_]u8{ 0, 0, 0, 1, 2 };
@@ -380,7 +380,7 @@ test "best speed match 1/3" {
         };
         var current = [_]u8{ 2, 4, 5, 0, 1, 2, 3, 4, 5 };
         var got: i32 = e.matchLen(3, -3, &current);
-        try expect(got == 3);
+        try expectEqual(@as(i32, 3), got);
     }
     {
         var previous = [_]u8{ 0, 0, 0, 1, 1 };
@@ -393,7 +393,7 @@ test "best speed match 1/3" {
         };
         var current = [_]u8{ 3, 4, 5, 0, 1, 2, 3, 4, 5 };
         var got: i32 = e.matchLen(3, -3, &current);
-        try expect(got == 2);
+        try expectEqual(@as(i32, 2), got);
     }
     {
         var previous = [_]u8{ 0, 0, 0, 1, 2 };
@@ -406,7 +406,7 @@ test "best speed match 1/3" {
         };
         var current = [_]u8{ 2, 2, 2, 2, 1, 2, 3, 4, 5 };
         var got: i32 = e.matchLen(0, -1, &current);
-        try expect(got == 4);
+        try expectEqual(@as(i32, 4), got);
     }
     {
         var previous = [_]u8{ 0, 0, 0, 1, 2, 3, 4, 5, 2, 2 };
@@ -419,7 +419,7 @@ test "best speed match 1/3" {
         };
         var current = [_]u8{ 2, 2, 2, 2, 1, 2, 3, 4, 5 };
         var got: i32 = e.matchLen(4, -7, &current);
-        try expect(got == 5);
+        try expectEqual(@as(i32, 5), got);
     }
     {
         var previous = [_]u8{ 9, 9, 9, 9, 9 };
@@ -432,7 +432,7 @@ test "best speed match 1/3" {
         };
         var current = [_]u8{ 2, 2, 2, 2, 1, 2, 3, 4, 5 };
         var got: i32 = e.matchLen(0, -1, &current);
-        try expect(got == 0);
+        try expectEqual(@as(i32, 0), got);
     }
     {
         var previous = [_]u8{ 9, 9, 9, 9, 9 };
@@ -445,12 +445,12 @@ test "best speed match 1/3" {
         };
         var current = [_]u8{ 9, 2, 2, 2, 1, 2, 3, 4, 5 };
         var got: i32 = e.matchLen(1, 0, &current);
-        try expect(got == 0);
+        try expectEqual(@as(i32, 0), got);
     }
 }
 
 test "best speed match 2/3" {
-    const expect = std.testing.expect;
+    const expectEqual = std.testing.expectEqual;
 
     {
         var previous = [_]u8{};
@@ -463,7 +463,7 @@ test "best speed match 2/3" {
         };
         var current = [_]u8{ 9, 2, 2, 2, 1, 2, 3, 4, 5 };
         var got: i32 = e.matchLen(1, -5, &current);
-        try expect(got == 0);
+        try expectEqual(@as(i32, 0), got);
     }
     {
         var previous = [_]u8{};
@@ -476,7 +476,7 @@ test "best speed match 2/3" {
         };
         var current = [_]u8{ 9, 2, 2, 2, 1, 2, 3, 4, 5 };
         var got: i32 = e.matchLen(1, -1, &current);
-        try expect(got == 0);
+        try expectEqual(@as(i32, 0), got);
     }
     {
         var previous = [_]u8{};
@@ -489,7 +489,7 @@ test "best speed match 2/3" {
         };
         var current = [_]u8{ 2, 2, 2, 2, 1, 2, 3, 4, 5 };
         var got: i32 = e.matchLen(1, 0, &current);
-        try expect(got == 3);
+        try expectEqual(@as(i32, 3), got);
     }
     {
         var previous = [_]u8{ 3, 4, 5 };
@@ -502,13 +502,13 @@ test "best speed match 2/3" {
         };
         var current = [_]u8{ 3, 4, 5 };
         var got: i32 = e.matchLen(0, -3, &current);
-        try expect(got == 3);
+        try expectEqual(@as(i32, 3), got);
     }
 }
 
 test "best speed match 2/2" {
     const testing = std.testing;
-    const expect = testing.expect;
+    const expectEqual = testing.expectEqual;
 
     const Case = struct {
         previous: u32,
@@ -580,7 +580,7 @@ test "best speed match 2/2" {
             .cur = 0,
         };
         var got: i32 = e.matchLen(c.s, c.t, current);
-        try expect(got == c.expected);
+        try expectEqual(@as(i32, c.expected), got);
     }
 }
 
@@ -623,16 +623,16 @@ test "best speed shift offsets" {
     tokens_count = 0;
     enc.encode(&tokens, &tokens_count, &test_data);
     var got = tokens_count;
-    try expect(want_first_tokens == got);
+    try testing.expectEqual(want_first_tokens, got);
 
     // Verify we are about to wrap.
-    try expect(enc.cur == buffer_reset);
+    try testing.expectEqual(@as(i32, buffer_reset), enc.cur);
 
     // Part 2 should match clean state as well even if wrapped.
     tokens_count = 0;
     enc.encode(&tokens, &tokens_count, &test_data);
     got = tokens_count;
-    try expect(want_second_tokens == got);
+    try testing.expectEqual(want_second_tokens, got);
 
     // Verify that we wrapped.
     try expect(enc.cur < buffer_reset);
@@ -645,13 +645,12 @@ test "best speed shift offsets" {
     tokens_count = 0;
     enc.encode(&tokens, &tokens_count, &test_data);
     got = tokens_count;
-    try expect(want_first_tokens == got);
+    try testing.expectEqual(want_first_tokens, got);
 }
 
 test "best speed reset" {
     // test that encoding is consistent across a warparound of the table offset.
     // See https://github.com/golang/go/issues/34121
-    const expect = std.testing.expect;
     const fmt = std.fmt;
     const testing = std.testing;
 
@@ -716,6 +715,6 @@ test "best speed reset" {
         try comp.close();
 
         // output must match at wraparound
-        try expect(mem.eql(u8, got.items, want.items));
+        try testing.expectEqualSlices(u8, want.items, got.items);
     }
 }

--- a/lib/std/compress/deflate/deflate_fast_test.zig
+++ b/lib/std/compress/deflate/deflate_fast_test.zig
@@ -85,8 +85,8 @@ test "best speed" {
                 var read = try decomp.reader().readAll(decompressed);
                 _ = decomp.close();
 
-                try expect(read == want.items.len);
-                try expect(mem.eql(u8, want.items, decompressed));
+                try testing.expectEqual(want.items.len, read);
+                try testing.expectEqualSlices(u8, want.items, decompressed);
             }
         }
     }
@@ -152,8 +152,8 @@ test "best speed max match offset" {
                 var read = try decomp.reader().readAll(decompressed);
                 _ = decomp.close();
 
-                try expect(read == src.len);
-                try expect(mem.eql(u8, decompressed, src));
+                try testing.expectEqual(src.len, read);
+                try testing.expectEqualSlices(u8, src, decompressed);
             }
         }
     }

--- a/lib/std/compress/deflate/dict_decoder.zig
+++ b/lib/std/compress/deflate/dict_decoder.zig
@@ -206,7 +206,6 @@ pub const DictDecoder = struct {
 
 test "dictionary decoder" {
     const ArrayList = std.ArrayList;
-    const expect = std.testing.expect;
     const testing = std.testing;
 
     const abc = "ABC\n";
@@ -416,5 +415,5 @@ test "dictionary decoder" {
     _ = try want.write(want_list.items[want_list.items.len - dd.histSize() ..][0..10]);
 
     _ = try got.write(dd.readFlush());
-    try expect(mem.eql(u8, got_list.items, want_list.items));
+    try testing.expectEqualSlices(u8, want_list.items, got_list.items);
 }

--- a/lib/std/compress/deflate/huffman_bit_writer.zig
+++ b/lib/std/compress/deflate/huffman_bit_writer.zig
@@ -121,7 +121,7 @@ pub fn HuffmanBitWriter(comptime WriterType: type) type {
             self.nbytes = 0;
         }
 
-        fn write(self: *Self, b: []u8) Error!void {
+        fn write(self: *Self, b: []const u8) Error!void {
             if (self.err) {
                 return;
             }
@@ -155,7 +155,7 @@ pub fn HuffmanBitWriter(comptime WriterType: type) type {
             }
         }
 
-        pub fn writeBytes(self: *Self, bytes: []u8) Error!void {
+        pub fn writeBytes(self: *Self, bytes: []const u8) Error!void {
             if (self.err) {
                 return;
             }
@@ -323,7 +323,7 @@ pub fn HuffmanBitWriter(comptime WriterType: type) type {
         // storedSizeFits calculates the stored size, including header.
         // The function returns the size in bits and whether the block
         // fits inside a single block.
-        fn storedSizeFits(in: ?[]u8) StoredSize {
+        fn storedSizeFits(in: ?[]const u8) StoredSize {
             if (in == null) {
                 return .{ .size = 0, .storable = false };
             }
@@ -453,7 +453,7 @@ pub fn HuffmanBitWriter(comptime WriterType: type) type {
             self: *Self,
             tokens: []const token.Token,
             eof: bool,
-            input: ?[]u8,
+            input: ?[]const u8,
         ) Error!void {
             if (self.err) {
                 return;
@@ -546,7 +546,7 @@ pub fn HuffmanBitWriter(comptime WriterType: type) type {
             self: *Self,
             tokens: []const token.Token,
             eof: bool,
-            input: ?[]u8,
+            input: ?[]const u8,
         ) Error!void {
             if (self.err) {
                 return;
@@ -685,7 +685,7 @@ pub fn HuffmanBitWriter(comptime WriterType: type) type {
 
         // Encodes a block of bytes as either Huffman encoded literals or uncompressed bytes
         // if the results only gains very little from compression.
-        pub fn writeBlockHuff(self: *Self, eof: bool, input: []u8) Error!void {
+        pub fn writeBlockHuff(self: *Self, eof: bool, input: []const u8) Error!void {
             if (self.err) {
                 return;
             }
@@ -828,7 +828,7 @@ pub fn huffmanBitWriter(allocator: Allocator, writer: anytype) !HuffmanBitWriter
 // histogram accumulates a histogram of b in h.
 //
 // h.len must be >= 256, and h's elements must be all zeroes.
-fn histogram(b: []u8, h: *[]u16) void {
+fn histogram(b: []const u8, h: *[]u16) void {
     var lh = h.*[0..256];
     for (b) |t| {
         lh[t] += 1;
@@ -891,21 +891,9 @@ test "writeBlockHuff" {
     );
 }
 
-fn testBlockHuff(in_name: []const u8, want_name: []const u8) !void {
-    // Skip wasi because it does not support std.fs.openDirAbsolute()
-    if (builtin.os.tag == .wasi) return error.SkipZigTest;
-
-    const current_dir = try std.fs.openDirAbsolute(std.fs.path.dirname(@src().file).?, .{});
-    const testdata_dir = try current_dir.openDir("testdata", .{});
-    const in_file = try testdata_dir.openFile(in_name, .{});
-    defer in_file.close();
-    const want_file = try testdata_dir.openFile(want_name, .{});
-    defer want_file.close();
-
-    var in = try in_file.reader().readAllAlloc(testing.allocator, math.maxInt(usize));
-    defer testing.allocator.free(in);
-    var want = try want_file.reader().readAllAlloc(testing.allocator, math.maxInt(usize));
-    defer testing.allocator.free(want);
+fn testBlockHuff(comptime in_name: []const u8, comptime want_name: []const u8) !void {
+    const in: []const u8 = @embedFile("testdata/" ++ in_name);
+    const want: []const u8 = @embedFile("testdata/" ++ want_name);
 
     var buf = ArrayList(u8).init(testing.allocator);
     defer buf.deinit();
@@ -914,7 +902,7 @@ fn testBlockHuff(in_name: []const u8, want_name: []const u8) !void {
     try bw.writeBlockHuff(false, in);
     try bw.flush();
 
-    try expect(mem.eql(u8, buf.items, want));
+    try std.testing.expectEqualSlices(u8, want, buf.items);
 
     // Test if the writer produces the same output after reset.
     var buf_after_reset = ArrayList(u8).init(testing.allocator);
@@ -925,8 +913,8 @@ fn testBlockHuff(in_name: []const u8, want_name: []const u8) !void {
     try bw.writeBlockHuff(false, in);
     try bw.flush();
 
-    try expect(mem.eql(u8, buf_after_reset.items, buf.items));
-    try expect(mem.eql(u8, buf_after_reset.items, want));
+    try std.testing.expectEqualSlices(u8, buf.items, buf_after_reset.items);
+    try std.testing.expectEqualSlices(u8, want, buf_after_reset.items);
 
     try testWriterEOF(.write_huffman_block, &[0]token.Token{}, in);
 }
@@ -1617,38 +1605,18 @@ test "writeBlockDynamic" {
 
 // testBlock tests a block against its references,
 // or regenerate the references, if "-update" flag is set.
-fn testBlock(comptime ht: HuffTest, ttype: TestType) !void {
-    // Skip wasi because it does not support std.fs.openDirAbsolute()
-    if (builtin.os.tag == .wasi) return error.SkipZigTest;
-
-    var want_name: []u8 = undefined;
-    var want_name_no_input: []u8 = undefined;
-    var input: []u8 = undefined;
-    var want: []u8 = undefined;
-    var want_ni: []u8 = undefined; // want no input: what we expect when input is empty
-
-    const current_dir = try std.fs.openDirAbsolute(std.fs.path.dirname(@src().file).?, .{});
-    const testdata_dir = try current_dir.openDir("testdata", .{});
-
-    var want_name_type = if (ht.want.len == 0) .{} else .{ttype.to_s()};
-    want_name = try fmt.allocPrint(testing.allocator, ht.want, want_name_type);
-    defer testing.allocator.free(want_name);
-
-    if (!mem.eql(u8, ht.input, "")) {
-        const in_file = try testdata_dir.openFile(ht.input, .{});
-        input = try in_file.reader().readAllAlloc(testing.allocator, math.maxInt(usize));
-        defer testing.allocator.free(input);
-
-        const want_file = try testdata_dir.openFile(want_name, .{});
-        want = try want_file.reader().readAllAlloc(testing.allocator, math.maxInt(usize));
-        defer testing.allocator.free(want);
+fn testBlock(comptime ht: HuffTest, comptime ttype: TestType) !void {
+    if (ht.input.len != 0 and ht.want.len != 0) {
+        const want_name = comptime fmt.comptimePrint(ht.want, .{ttype.to_s()});
+        const input = @embedFile("testdata/" ++ ht.input);
+        const want = @embedFile("testdata/" ++ want_name);
 
         var buf = ArrayList(u8).init(testing.allocator);
         var bw = try huffmanBitWriter(testing.allocator, buf.writer());
         try writeToType(ttype, &bw, ht.tokens, input);
 
         var got = buf.items;
-        try expect(mem.eql(u8, got, want)); // expect writeBlock to yield expected result
+        try testing.expectEqualSlices(u8, want, got); // expect writeBlock to yield expected result
 
         // Test if the writer produces the same output after reset.
         buf.deinit();
@@ -1661,16 +1629,12 @@ fn testBlock(comptime ht: HuffTest, ttype: TestType) !void {
         try writeToType(ttype, &bw, ht.tokens, input);
         try bw.flush();
         got = buf.items;
-        try expect(mem.eql(u8, got, want)); // expect writeBlock to yield expected result
+        try testing.expectEqualSlices(u8, want, got); // expect writeBlock to yield expected result
         try testWriterEOF(.write_block, ht.tokens, input);
     }
 
-    want_name_no_input = try fmt.allocPrint(testing.allocator, ht.want_no_input, .{ttype.to_s()});
-    defer testing.allocator.free(want_name_no_input);
-
-    const want_no_input_file = try testdata_dir.openFile(want_name_no_input, .{});
-    want_ni = try want_no_input_file.reader().readAllAlloc(testing.allocator, math.maxInt(usize));
-    defer testing.allocator.free(want_ni);
+    const want_name_no_input = comptime fmt.comptimePrint(ht.want_no_input, .{ttype.to_s()});
+    const want_ni = @embedFile("testdata/" ++ want_name_no_input);
 
     var buf = ArrayList(u8).init(testing.allocator);
     var bw = try huffmanBitWriter(testing.allocator, buf.writer());
@@ -1678,7 +1642,7 @@ fn testBlock(comptime ht: HuffTest, ttype: TestType) !void {
     try writeToType(ttype, &bw, ht.tokens, null);
 
     var got = buf.items;
-    try expect(mem.eql(u8, got, want_ni)); // expect writeBlock to yield expected result
+    try testing.expectEqualSlices(u8, want_ni, got); // expect writeBlock to yield expected result
     try expect(got[0] & 1 != 1); // expect no EOF
 
     // Test if the writer produces the same output after reset.
@@ -1693,11 +1657,11 @@ fn testBlock(comptime ht: HuffTest, ttype: TestType) !void {
     try bw.flush();
     got = buf.items;
 
-    try expect(mem.eql(u8, got, want_ni)); // expect writeBlock to yield expected result
+    try testing.expectEqualSlices(u8, want_ni, got); // expect writeBlock to yield expected result
     try testWriterEOF(.write_block, ht.tokens, &[0]u8{});
 }
 
-fn writeToType(ttype: TestType, bw: anytype, tok: []const token.Token, input: ?[]u8) !void {
+fn writeToType(ttype: TestType, bw: anytype, tok: []const token.Token, input: ?[]const u8) !void {
     switch (ttype) {
         .write_block => try bw.writeBlock(tok, false, input),
         .write_dyn_block => try bw.writeBlockDynamic(tok, false, input),
@@ -1707,7 +1671,7 @@ fn writeToType(ttype: TestType, bw: anytype, tok: []const token.Token, input: ?[
 }
 
 // Tests if the written block contains an EOF marker.
-fn testWriterEOF(ttype: TestType, ht_tokens: []const token.Token, input: []u8) !void {
+fn testWriterEOF(ttype: TestType, ht_tokens: []const token.Token, input: []const u8) !void {
     var buf = ArrayList(u8).init(testing.allocator);
     defer buf.deinit();
     var bw = try huffmanBitWriter(testing.allocator, buf.writer());

--- a/lib/std/compress/deflate/huffman_code.zig
+++ b/lib/std/compress/deflate/huffman_code.zig
@@ -386,39 +386,39 @@ test "generate a Huffman code from an array of frequencies" {
     defer enc.deinit();
     enc.generate(freqs[0..], 7);
 
-    try testing.expect(enc.bitLength(freqs[0..]) == 141);
+    try testing.expectEqual(@as(u32, 141), enc.bitLength(freqs[0..]));
 
-    try testing.expect(enc.codes[0].len == 3);
-    try testing.expect(enc.codes[1].len == 6);
-    try testing.expect(enc.codes[2].len == 6);
-    try testing.expect(enc.codes[3].len == 5);
-    try testing.expect(enc.codes[4].len == 3);
-    try testing.expect(enc.codes[5].len == 2);
-    try testing.expect(enc.codes[6].len == 2);
-    try testing.expect(enc.codes[7].len == 6);
-    try testing.expect(enc.codes[8].len == 0);
-    try testing.expect(enc.codes[9].len == 0);
-    try testing.expect(enc.codes[10].len == 0);
-    try testing.expect(enc.codes[11].len == 0);
-    try testing.expect(enc.codes[12].len == 0);
-    try testing.expect(enc.codes[13].len == 0);
-    try testing.expect(enc.codes[14].len == 0);
-    try testing.expect(enc.codes[15].len == 0);
-    try testing.expect(enc.codes[16].len == 6);
-    try testing.expect(enc.codes[17].len == 5);
-    try testing.expect(enc.codes[18].len == 3);
+    try testing.expectEqual(@as(usize, 3), enc.codes[0].len);
+    try testing.expectEqual(@as(usize, 6), enc.codes[1].len);
+    try testing.expectEqual(@as(usize, 6), enc.codes[2].len);
+    try testing.expectEqual(@as(usize, 5), enc.codes[3].len);
+    try testing.expectEqual(@as(usize, 3), enc.codes[4].len);
+    try testing.expectEqual(@as(usize, 2), enc.codes[5].len);
+    try testing.expectEqual(@as(usize, 2), enc.codes[6].len);
+    try testing.expectEqual(@as(usize, 6), enc.codes[7].len);
+    try testing.expectEqual(@as(usize, 0), enc.codes[8].len);
+    try testing.expectEqual(@as(usize, 0), enc.codes[9].len);
+    try testing.expectEqual(@as(usize, 0), enc.codes[10].len);
+    try testing.expectEqual(@as(usize, 0), enc.codes[11].len);
+    try testing.expectEqual(@as(usize, 0), enc.codes[12].len);
+    try testing.expectEqual(@as(usize, 0), enc.codes[13].len);
+    try testing.expectEqual(@as(usize, 0), enc.codes[14].len);
+    try testing.expectEqual(@as(usize, 0), enc.codes[15].len);
+    try testing.expectEqual(@as(usize, 6), enc.codes[16].len);
+    try testing.expectEqual(@as(usize, 5), enc.codes[17].len);
+    try testing.expectEqual(@as(usize, 3), enc.codes[18].len);
 
-    try testing.expect(enc.codes[5].code == 0x0);
-    try testing.expect(enc.codes[6].code == 0x2);
-    try testing.expect(enc.codes[0].code == 0x1);
-    try testing.expect(enc.codes[4].code == 0x5);
-    try testing.expect(enc.codes[18].code == 0x3);
-    try testing.expect(enc.codes[3].code == 0x7);
-    try testing.expect(enc.codes[17].code == 0x17);
-    try testing.expect(enc.codes[1].code == 0x0f);
-    try testing.expect(enc.codes[2].code == 0x2f);
-    try testing.expect(enc.codes[7].code == 0x1f);
-    try testing.expect(enc.codes[16].code == 0x3f);
+    try testing.expectEqual(@as(u16, 0x0), enc.codes[5].code);
+    try testing.expectEqual(@as(u16, 0x2), enc.codes[6].code);
+    try testing.expectEqual(@as(u16, 0x1), enc.codes[0].code);
+    try testing.expectEqual(@as(u16, 0x5), enc.codes[4].code);
+    try testing.expectEqual(@as(u16, 0x3), enc.codes[18].code);
+    try testing.expectEqual(@as(u16, 0x7), enc.codes[3].code);
+    try testing.expectEqual(@as(u16, 0x17), enc.codes[17].code);
+    try testing.expectEqual(@as(u16, 0x0f), enc.codes[1].code);
+    try testing.expectEqual(@as(u16, 0x2f), enc.codes[2].code);
+    try testing.expectEqual(@as(u16, 0x1f), enc.codes[7].code);
+    try testing.expectEqual(@as(u16, 0x3f), enc.codes[16].code);
 }
 
 test "generate a Huffman code for the fixed litteral table specific to Deflate" {

--- a/lib/std/compress/deflate/token.zig
+++ b/lib/std/compress/deflate/token.zig
@@ -99,6 +99,5 @@ pub fn offsetCode(off: u32) u32 {
 
 test {
     const std = @import("std");
-    const expect = std.testing.expect;
-    try expect(matchToken(555, 555) == 3_401_581_099);
+    try std.testing.expectEqual(@as(Token, 3_401_581_099), matchToken(555, 555));
 }

--- a/lib/std/compress/gzip.zig
+++ b/lib/std/compress/gzip.zig
@@ -163,7 +163,7 @@ fn testReader(data: []const u8, comptime expected: []const u8) !void {
     defer testing.allocator.free(buf);
 
     // Check against the reference
-    try testing.expectEqualSlices(u8, buf, expected);
+    try testing.expectEqualSlices(u8, expected, buf);
 }
 
 // All the test cases are obtained by compressing the RFC1952 text

--- a/lib/std/compress/zlib.zig
+++ b/lib/std/compress/zlib.zig
@@ -99,7 +99,7 @@ fn testReader(data: []const u8, expected: []const u8) !void {
     defer testing.allocator.free(buf);
 
     // Check against the reference
-    try testing.expectEqualSlices(u8, buf, expected);
+    try testing.expectEqualSlices(u8, expected, buf);
 }
 
 // All the test cases are obtained by compressing the RFC1951 text


### PR DESCRIPTION
- Previously, some of the compress tests used `@src()` in combination with `dirname` and `openDirAbsolute` to read test files at runtime, which both excludes platforms that `openDirAbsolute` is not implemented for (WASI) and platforms that `SourceLocation.file` is not absolute (this was true for me locally on Windows and @mikdusan said they ran into it on BSDs). Instead of converting the tests to use `fs.cwd().openDir`, they have been converted to use `@embedFile` to avoid any potential problems with the runtime cwd.
- In order to use `@embedFile`, some of the `[]u8` parameters needed to be changed to `[]const u8`; none of them needed to be non-const anyway
- The tests now use `expectEqual` and `expectEqualSlices` where appropriate for better diagnostics