### PR TITLE
std.leb128: Re-enable test for riscv64

### DIFF
--- a/lib/std/leb128.zig
+++ b/lib/std/leb128.zig
@@ -347,11 +347,6 @@ fn test_write_leb128(value: anytype) !void {
 }
 
 test "serialize unsigned LEB128" {
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .riscv64) {
-        // https://github.com/ziglang/zig/issues/12031
-        return error.SkipZigTest;
-    }
-
     const max_bits = 18;
 
     comptime var t = 0;
@@ -366,11 +361,6 @@ test "serialize unsigned LEB128" {
 }
 
 test "serialize signed LEB128" {
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .riscv64) {
-        // https://github.com/ziglang/zig/issues/12031
-        return error.SkipZigTest;
-    }
-
     // explicitly test i0 because starting `t` at 0
     // will break the while loop
     try test_write_leb128(@as(i0, 0));


### PR DESCRIPTION
This is a trivial patch to re-enable tests that were disabled due to a LLVM 14 regression. The regression has been fixed in LLVM 15.

You can reproduce with:
`stage3/bin/zig test ../lib/std/leb128.zig --zig-lib-dir ../lib -target riscv64-linux-none`

Closes #12031.