### PR TITLE
Fix line endings of `huffman-text.input` and re-enable test on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 *.txt text eol=lf
 langref.html.in text eol=lf
 deps/SoftFloat-3e/*.txt text eol=crlf
+lib/std/compress/deflate/testdata/* binary
 
 deps/** linguist-vendored
 lib/include/** linguist-vendored

--- a/lib/std/compress/deflate/huffman_bit_writer.zig
+++ b/lib/std/compress/deflate/huffman_bit_writer.zig
@@ -848,11 +848,6 @@ test "writeBlockHuff" {
     // Tests huffman encoding against reference files to detect possible regressions.
     // If encoding/bit allocation changes you can regenerate these files
 
-    if (builtin.os.tag == .windows) {
-        // https://github.com/ziglang/zig/issues/13892
-        return error.SkipZigTest;
-    }
-
     try testBlockHuff(
         "huffman-null-max.input",
         "huffman-null-max.golden",


### PR DESCRIPTION
Closes #13892