### PR TITLE
Close more old stage1 issues

### DIFF
--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -91,11 +91,19 @@ test {
     _ = @import("behavior/bugs/11213.zig");
     _ = @import("behavior/bugs/11787.zig");
     _ = @import("behavior/bugs/11816.zig");
+    _ = @import("behavior/bugs/11995.zig");
+    _ = @import("behavior/bugs/12000.zig");
     _ = @import("behavior/bugs/12003.zig");
     _ = @import("behavior/bugs/12025.zig");
     _ = @import("behavior/bugs/12033.zig");
     _ = @import("behavior/bugs/12043.zig");
+    _ = @import("behavior/bugs/12051.zig");
+    _ = @import("behavior/bugs/12092.zig");
+    _ = @import("behavior/bugs/12119.zig");
+    _ = @import("behavior/bugs/12142.zig");
+    _ = @import("behavior/bugs/12169.zig");
     _ = @import("behavior/bugs/12430.zig");
+    _ = @import("behavior/bugs/12450.zig");
     _ = @import("behavior/bugs/12486.zig");
     _ = @import("behavior/bugs/12488.zig");
     _ = @import("behavior/bugs/12498.zig");
@@ -122,6 +130,7 @@ test {
     _ = @import("behavior/bugs/13068.zig");
     _ = @import("behavior/bugs/13069.zig");
     _ = @import("behavior/bugs/13112.zig");
+    _ = @import("behavior/bugs/13113.zig");
     _ = @import("behavior/bugs/13128.zig");
     _ = @import("behavior/bugs/13159.zig");
     _ = @import("behavior/bugs/13164.zig");

--- a/test/behavior/bugs/11995.zig
+++ b/test/behavior/bugs/11995.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const testing = std.testing;
+const builtin = @import("builtin");
+
+fn wuffs_base__make_io_buffer(arg_data: wuffs_base__slice_u8, arg_meta: *wuffs_base__io_buffer_meta) callconv(.C) void {
+    arg_data.ptr[0] = 'w';
+    arg_meta.closed = false;
+}
+const wuffs_base__io_buffer_meta = extern struct {
+    wi: usize,
+    ri: usize,
+    pos: u64,
+    closed: bool,
+};
+const wuffs_base__slice_u8 = extern struct {
+    ptr: [*c]u8,
+    len: usize,
+};
+test {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    var string: [5]u8 = "hello".*;
+    const arg_data = wuffs_base__slice_u8{ .ptr = @ptrCast([*c]u8, &string), .len = string.len };
+    var arg_meta = wuffs_base__io_buffer_meta{ .wi = 1, .ri = 2, .pos = 3, .closed = true };
+    wuffs_base__make_io_buffer(arg_data, &arg_meta);
+    try std.testing.expectEqualStrings("wello", arg_data.ptr[0..arg_data.len]);
+    try std.testing.expectEqual(@as(usize, 1), arg_meta.wi);
+    try std.testing.expectEqual(@as(usize, 2), arg_meta.ri);
+    try std.testing.expectEqual(@as(u64, 3), arg_meta.pos);
+    try std.testing.expect(!arg_meta.closed);
+}

--- a/test/behavior/bugs/12000.zig
+++ b/test/behavior/bugs/12000.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const T = struct {
+    next: @TypeOf(null, @as(*const T, undefined)),
+};
+
+test {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    var t: T = .{ .next = null };
+    try std.testing.expect(t.next == null);
+}

--- a/test/behavior/bugs/12051.zig
+++ b/test/behavior/bugs/12051.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+test {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    const x = X{};
+    try std.testing.expectEqual(@as(u16, 0), x.y.a);
+    try std.testing.expectEqual(false, x.y.b);
+    try std.testing.expectEqual(Z{ .a = 0 }, x.y.c);
+    try std.testing.expectEqual(Z{ .a = 0 }, x.y.d);
+}
+
+const X = struct {
+    y: Y = Y.init(),
+};
+
+const Y = struct {
+    a: u16,
+    b: bool,
+    c: Z,
+    d: Z,
+
+    fn init() Y {
+        return .{
+            .a = 0,
+            .b = false,
+            .c = @bitCast(Z, @as(u32, 0)),
+            .d = @bitCast(Z, @as(u32, 0)),
+        };
+    }
+};
+
+const Z = packed struct {
+    a: u32,
+};

--- a/test/behavior/bugs/12092.zig
+++ b/test/behavior/bugs/12092.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const Foo = struct {
+    a: Bar,
+};
+
+const Bar = struct {
+    b: u32,
+};
+
+fn takeFoo(foo: *const Foo) !void {
+    try std.testing.expectEqual(@as(u32, 24), foo.a.b);
+}
+
+test {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    var baz: u32 = 24;
+    try takeFoo(&.{
+        .a = .{
+            .b = baz,
+        },
+    });
+}

--- a/test/behavior/bugs/12119.zig
+++ b/test/behavior/bugs/12119.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const u8x32 = @Vector(32, u8);
+const u32x8 = @Vector(8, u32);
+
+test {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    const zerox32: u8x32 = [_]u8{0} ** 32;
+    const bigsum: u32x8 = @bitCast(u32x8, zerox32);
+    try std.testing.expectEqual(0, @reduce(.Add, bigsum));
+}

--- a/test/behavior/bugs/12142.zig
+++ b/test/behavior/bugs/12142.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const Holder = struct {
+    array: []const u8,
+};
+
+const Test = struct {
+    holders: []const Holder,
+};
+
+const Letter = enum(u8) {
+    A = 0x41,
+    B,
+};
+
+fn letter(e: Letter) u8 {
+    return @enumToInt(e);
+}
+
+test {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    const test_struct = Test{
+        .holders = &.{
+            Holder{
+                .array = &.{
+                    letter(.A),
+                },
+            },
+        },
+    };
+    try std.testing.expectEqualStrings("A", test_struct.holders[0].array);
+}

--- a/test/behavior/bugs/12169.zig
+++ b/test/behavior/bugs/12169.zig
@@ -1,0 +1,14 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+test {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    const a = @Vector(2, bool){ true, true };
+    const b = @Vector(1, bool){true};
+    try std.testing.expect(@reduce(.And, a));
+    try std.testing.expect(@reduce(.And, b));
+}

--- a/test/behavior/bugs/12450.zig
+++ b/test/behavior/bugs/12450.zig
@@ -1,0 +1,21 @@
+const expect = @import("std").testing.expect;
+const builtin = @import("builtin");
+
+const Foo = packed struct {
+    a: i32,
+    b: u8,
+};
+
+var buffer: [256]u8 = undefined;
+
+test {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    var f1: *align(16) Foo = @alignCast(16, @ptrCast(*align(1) Foo, &buffer[0]));
+    try expect(@typeInfo(@TypeOf(f1)).Pointer.alignment == 16);
+    try expect(@ptrToInt(f1) == @ptrToInt(&f1.a));
+    try expect(@typeInfo(@TypeOf(&f1.a)).Pointer.alignment == 16);
+}

--- a/test/behavior/bugs/13113.zig
+++ b/test/behavior/bugs/13113.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const Foo = extern struct {
+    a: u8 align(1),
+    b: u16 align(1),
+};
+
+test {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    const foo = Foo{
+        .a = 1,
+        .b = 2,
+    };
+    try std.testing.expectEqual(1, foo.a);
+    try std.testing.expectEqual(2, foo.b);
+}

--- a/test/cases/compile_errors/implicit_cast_const_array_to_mutable_slice.zig
+++ b/test/cases/compile_errors/implicit_cast_const_array_to_mutable_slice.zig
@@ -13,6 +13,11 @@ export fn entry2() void {
     const many: [*]u8 = str;
     _ = many;
 }
+export fn entry3() void {
+    const lang: []const u8 = "lang";
+    const targets: [1][]const u8 = [_][]u8{lang};
+    _ = targets;
+}
 
 // error
 // backend=stage2
@@ -24,3 +29,5 @@ export fn entry2() void {
 // :8:27: note: cast discards const qualifier
 // :13:25: error: expected type '[*]u8', found '*const [0:0]u8'
 // :13:25: note: cast discards const qualifier
+// :18:44: error: expected type '[]u8', found '[]const u8'
+// :18:44: note: cast discards const qualifier

--- a/test/cases/compile_errors/invalid_store_to_comptime_field.zig
+++ b/test/cases/compile_errors/invalid_store_to_comptime_field.zig
@@ -61,6 +61,11 @@ pub export fn entry6() void {
     };
     _ = State.init(false);
 }
+pub export fn entry7() void {
+    const list1 = .{ "sss", 1, 2, 3 };
+    const list2 = @TypeOf(list1){ .@"0" = "xxx", .@"1" = 4, .@"2" = 5, .@"3" = 6 };
+    _ = list2;
+}
 
 // error
 // target=native
@@ -73,4 +78,5 @@ pub export fn entry6() void {
 // :25:29: note: default value set here
 // :41:16: error: value stored in comptime field does not match the default value of the field
 // :45:12: error: value stored in comptime field does not match the default value of the field
+// :66:43: error: value stored in comptime field does not match the default value of the field
 // :59:35: error: value stored in comptime field does not match the default value of the field

--- a/test/cases/compile_errors/invalid_struct_field.zig
+++ b/test/cases/compile_errors/invalid_struct_field.zig
@@ -1,14 +1,21 @@
-const A = struct { x : i32, };
+const A = struct { x: i32 };
 export fn f() void {
-    var a : A = undefined;
+    var a: A = undefined;
     a.foo = 1;
     const y = a.bar;
     _ = y;
 }
 export fn g() void {
-    var a : A = undefined;
+    var a: A = undefined;
     const y = a.bar;
     _ = y;
+}
+export fn e() void {
+    const B = struct {
+        fn f() void {}
+    };
+    const b: B = undefined;
+    @import("std").debug.print("{}{}", .{ b.f, b.f });
 }
 
 // error
@@ -18,4 +25,5 @@ export fn g() void {
 // :4:7: error: no field named 'foo' in struct 'tmp.A'
 // :1:11: note: struct declared here
 // :10:17: error: no field named 'bar' in struct 'tmp.A'
-
+// :18:45: error: no field named 'f' in struct 'tmp.e.B'
+// :14:15: note: struct declared here


### PR DESCRIPTION
# How can I help closing old stage1 issues?

The current policy is that before an old stage1 issue can be closed, test coverage for it has to be added.

1. Go to https://github.com/ziglang/zig/issues?q=is%3Aopen+is%3Aissue+label%3Astage1

2. Close your eyes and click on an issue

3. Determine whether the code in the issue is supposed to compile-error or simply pass.
* If the code from the issue is supposed to just pass, maybe clean it up a bit and put the code in `test/behavior/bugs/github_issue_number.zig` and then reference that file in `test/behavior.zig` at the right spot (there's an order). Use `zig test x.zig` to check locally if it does actually pass.
  [Example](https://github.com/ziglang/zig/blob/master/test/behavior/bugs/12486.zig) and [its reference in test/behavior.zig](https://github.com/ziglang/zig/blob/88b49ed00d6d2efb5b523ab15cbf8ffb37383c56/test/behavior.zig#L99)
* If it's supposed to compile-error, create an explicitly-named file for how the code is supposed to compile-error in `test/cases/compile_errors/`. You can check the code locally with `zig test x.zig` to check what errors you get and copy-paste them into the file at the end as comments like in the other compile error case files.
  [Example](https://github.com/ziglang/zig/blob/master/test/cases/compile_errors/array_access_of_non_array.zig)

4. In your commits' description you can list all issues you provided test coverage for like `Closes #1` each on a separate line, like in the commits of this PR.