### PR TITLE
compiler_rt: test clzsi2 with zero on CPUs where possible

### DIFF
--- a/lib/compiler_rt/clzsi2_test.zig
+++ b/lib/compiler_rt/clzsi2_test.zig
@@ -281,7 +281,8 @@ test "clzsi2" {
     try test__clzsi2(0xFE000000, 0);
     try test__clzsi2(0xFF000000, 0);
     // arm and thumb1 assume input a != 0
-    //try test__clzsi2(0x00000000, 32);
+    if (!builtin.cpu.arch.isARM() and !builtin.cpu.arch.isThumb())
+        try test__clzsi2(0x00000000, 32);
     try test__clzsi2(0x00000001, 31);
     try test__clzsi2(0x00000002, 30);
     try test__clzsi2(0x00000004, 29);


### PR DESCRIPTION
On arm and thumb `test__clzsi2(0x00000000, 32)` crashes pretty badly:
```
Test [1/10] test.clzsi2... FAIL (TestExpectedEqual)
thread 50405 panic: reached unreachable code
Panicked during a panic. Aborting.
qemu: uncaught target signal 6 (Aborted) - core dumped
error: the following test command crashed:
```
We could still run this on the other CPUs.