### PR TITLE
std.IndexedSet.iterator: allow iteration on const EnumSet

### DIFF
--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -878,7 +878,7 @@ pub fn IndexedSet(comptime I: type, comptime Ext: fn (type) type) type {
         /// index order.  Modifications to the set during iteration
         /// may or may not be observed by the iterator, but will
         /// not invalidate it.
-        pub fn iterator(self: *Self) Iterator {
+        pub fn iterator(self: Self) Iterator {
             return .{ .inner = self.bits.iterator(.{}) };
         }
 
@@ -968,6 +968,9 @@ test "pure EnumSet fns" {
     try testing.expect(full.differenceWith(empty).eql(full));
     try testing.expect(full.differenceWith(red).eql(black));
     try testing.expect(full.differenceWith(black).eql(red));
+
+    // ensure iterator can be called on const EnumSet
+    _ = red.iterator();
 }
 
 /// A map from keys to values, using an index lookup.  Uses a

--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -878,7 +878,7 @@ pub fn IndexedSet(comptime I: type, comptime Ext: fn (type) type) type {
         /// index order.  Modifications to the set during iteration
         /// may or may not be observed by the iterator, but will
         /// not invalidate it.
-        pub fn iterator(self: Self) Iterator {
+        pub fn iterator(self: *const Self) Iterator {
             return .{ .inner = self.bits.iterator(.{}) };
         }
 
@@ -968,9 +968,24 @@ test "pure EnumSet fns" {
     try testing.expect(full.differenceWith(empty).eql(full));
     try testing.expect(full.differenceWith(red).eql(black));
     try testing.expect(full.differenceWith(black).eql(red));
+}
 
-    // ensure iterator can be called on const EnumSet
-    _ = red.iterator();
+test "std.enums.EnumSet const iterator" {
+    const Direction = enum { up, down, left, right };
+    const diag_move = init: {
+        var move = EnumSet(Direction).initEmpty();
+        move.insert(.right);
+        move.insert(.up);
+        break :init move;
+    };
+
+    var result = EnumSet(Direction).initEmpty();
+    var it = diag.iterator();
+    while (it.next()) |dir| {
+        result.insert(dir);
+    }
+
+    try testing.expect(result.eql(diag));
 }
 
 /// A map from keys to values, using an index lookup.  Uses a

--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -980,12 +980,12 @@ test "std.enums.EnumSet const iterator" {
     };
 
     var result = EnumSet(Direction).initEmpty();
-    var it = diag.iterator();
+    var it = diag_move.iterator();
     while (it.next()) |dir| {
         result.insert(dir);
     }
 
-    try testing.expect(result.eql(diag));
+    try testing.expect(result.eql(diag_move));
 }
 
 /// A map from keys to values, using an index lookup.  Uses a


### PR DESCRIPTION
**Context**

| Zig Version | 0.11.0-dev.618+096d3efae |
|-| - |

I am new to Zig, but not to C / C++. I am trying to to learn Zig via Advent of Code, and on day 9 came across this situation, I expected to work.  Very possible this is a beginner mistake, but also wanted to [do my part](https://github.com/ziglang/zig/blob/master/.github/CONTRIBUTING.md#start-a-project-using-zig) and file an issue.

**Reference Code**

```zig
const std = @import("std");
const EnumSet = std.EnumSet;

test "EnumSet const iteration" {
    const Direction = enum { up, down, left, right };

    const diag = diag: {
        var move: EnumSet(Direction) = .{};
        move.insert(.right);
        move.insert(.up);
        break :diag move;
    };

    _ = diag.iterator();
    //  ^ expected to be able to iterate a const EnumSet
}
```

**Expected Behavior**
I expected the code to compile and run, since I didn't see any reason why (or how?) an EnumSet iteration could mutate `diag`.

**Actual Behavior**
The code fails to compile with the following error:

```
src/main.zig:14:13: error: expected type '*enums.IndexedSet(enums.EnumIndexer(main.test.EnumSet const iteration.Direction),(function 'EnumSetExt'))', found '*const enums.IndexedSet(enums.EnumIndexer(main.test.EnumSet const iteration.Direction),(function 'EnumSetExt'))'
    _ = diag.iterator();
        ~~~~^~~~~~~~~
src/main.zig:14:13: note: cast discards const qualifier
/Users/steven/bin/lib/std/enums.zig:432:31: note: parameter type declared here
        pub fn iterator(self: *Self) Iterator {
```

I believe this change makes sense for EnumSet, but I couldn't really determine if this change also makes sense for all other users of `IndexedSet`.  I think simply by-value make the most sense but also `*const Self` would solve my issue as well.

Other related Issues / PRs:
https://github.com/ziglang/zig/pull/13014
https://github.com/ziglang/zig/pull/12995