### PR TITLE
fix potential integer underflow in std.zig.Ast.fullCall

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -2189,9 +2189,9 @@ fn fullCall(tree: Ast, info: full.Call.Components) full.Call {
         .ast = info,
         .async_token = null,
     };
-    const maybe_async_token = tree.firstToken(info.fn_expr) - 1;
-    if (token_tags[maybe_async_token] == .keyword_async) {
-        result.async_token = maybe_async_token;
+    const first_token = tree.firstToken(info.fn_expr);
+    if (first_token != 0 and token_tags[first_token - 1] == .keyword_async) {
+        result.async_token = first_token - 1;
     }
     return result;
 }

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -214,6 +214,13 @@ test "zig fmt: top-level fields" {
     );
 }
 
+test "zig fmt: top-level tuple function call type" {
+    try testCanonical(
+        \\foo()
+        \\
+    );
+}
+
 test "zig fmt: C style containers" {
     try testError(
         \\struct Foo {


### PR DESCRIPTION
The following code will crash the zig compiler. (this is the entire file)
```zig
foo()
```