### PR TITLE
`ChildProcess.spawnWindows`: `PATH` search fixes + optimizations

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -997,6 +997,9 @@ pub const ChildProcess = struct {
                     }
                 }
 
+                // No need to search the PATH if the app path is absolute
+                if (fs.path.isAbsoluteWindowsWTF16(app_path_w)) return no_path_err;
+
                 // app_path_w has the cwd prepended to it if cwd is non-null, so when
                 // searching the PATH we should make sure we use the app_name verbatim.
                 var app_name_w_needs_free = false;


### PR DESCRIPTION
Note: This is probably best reviewed commit-by-commit, as they could each be a separate PR if I weren't making all the changes at one time.

---

If the command is specified as `something.exe`, the retry will now try:

```
C:\some\path\something.exe
C:\some\path\something.exe.COM
C:\some\path\something.exe.EXE
C:\some\path\something.exe.BAT
... etc ...
```

whereas before it would only try the versions with an added extension from `PATHEXT`, which would cause the retry to fail  on things that it should find.

---

Also, I reworked some stuff to drastically reduce the amount of allocations that occur in the `FileNotFound` recovery block when looking through `PATH`.

---

Finally, `CreateProcessW` can now return `error.InvalidExe` when appropriate, and `spawnWindows` has been made to handle it. When the initial `windowsCreateProcess` in `spawnWindows` fails with `error.InvalidExe`, it will now retry with the values from `PATHEXT` appended before searching the `PATH`.

This matches `cmd.exe` behavior. For example, if there is only a file named `mycommand` in the cwd but it is a Linux executable, then running the command `mycommand` will result in:

'mycommand' is not recognized as an internal or external command, operable program or batch file.

However, if there is *both* a `mycommand` (that is a Linux executable) and a `mycommand.exe` that is a valid Windows exe, then running the command `mycommand` will successfully run `mycommand.exe`.

---

Example that demonstrates the path search problem and shows the extent of the reduced allocations:

```zig
const std = @import("std");

pub fn main() !void {
    var diag_allocator = std.testing.FailingAllocator.init(std.heap.page_allocator, std.math.maxInt(usize));
    const allocator = diag_allocator.allocator();
    defer {
        std.debug.print("allocations: {}, allocated bytes: {}\n", .{ diag_allocator.allocations, diag_allocator.allocated_bytes });
    }

    // Note: passing env map doesn't change anything, the same behavior happens if
    //       env map isn't provided
    var env_map = try std.process.getEnvMap(allocator);
    defer env_map.deinit();

    var result = try std.ChildProcess.exec(.{
        .allocator = allocator,
        // this should be found in the system32 dir
        .argv = &[_][]const u8{"whoami.exe"},
        .env_map = &env_map,
    });
    defer allocator.free(result.stdout);
    defer allocator.free(result.stderr);

    std.debug.print("{}\n", .{result.term});
}
```

Before:

```
allocations: 819, allocated bytes: 66500
error: FileNotFound
C:\Users\Ryan\Programming\Zig\zig\lib\std\os\windows.zig:1600:32: 0x7ff7963d079b in CreateProcessW (winpath.exe.obj)
            .FILE_NOT_FOUND => return error.FileNotFound,
                               ^
C:\Users\Ryan\Programming\Zig\zig\lib\std\child_process.zig:1078:5: 0x7ff7963d0656 in windowsCreateProcess (winpath.exe.obj)
    return windows.CreateProcessW(
    ^
```

After:

```
child_process.ChildProcess.Term{ .Exited = 0 }
allocations: 129, allocated bytes: 18872
```

However, this is comparing the command not being found with it being found. For completeness, here's an apples-to-apples comparison for the number of allocations when the command is not found:

```
allocations: 127, allocated bytes: 17757
error: FileNotFound
C:\Users\Ryan\Programming\Zig\zig\lib\std\os\windows.zig:1600:32: 0x7ff6ab790ecb in CreateProcessW (winpath.exe.obj)
            .FILE_NOT_FOUND => return error.FileNotFound,
                               ^
```

Note also that the number/size of the allocations saved depends on the number of items within `PATH` and `PATHEXT`.