### PR TITLE
Call ensureResultUsed before comptime .call is evaluated.

### DIFF
--- a/test/cases/compile_errors/ignored_comptime_value.zig
+++ b/test/cases/compile_errors/ignored_comptime_value.zig
@@ -1,5 +1,17 @@
-export fn foo() void {
+export fn a() void {
     comptime 1;
+}
+export fn b() void {
+    comptime bar();
+}
+fn bar() u8 {
+    const u32_max = @import("std").math.maxInt(u32);
+
+    @setEvalBranchQuota(u32_max);
+    var x: u32 = 0;
+    while (x != u32_max) : (x +%= 1) {}
+
+    return 0;
 }
 
 // error
@@ -9,3 +21,6 @@ export fn foo() void {
 // :2:5: error: value of type 'comptime_int' ignored
 // :2:5: note: all non-void values must be used
 // :2:5: note: this error can be suppressed by assigning the value to '_'
+// :5:17: error: value of type 'u8' ignored
+// :5:17: note: all non-void values must be used
+// :5:17: note: this error can be suppressed by assigning the value to '_'


### PR DESCRIPTION
Check the return type of a comptime call prior to its evaluation.

Support all kinds of expressions may require big changes to data structure and sema.zig.

Fixes #12580