### PR TITLE
llvm: fix null pointer use when lowering pointer to final zero-width field of a comptime value

### DIFF
--- a/lib/std/rand/Xoroshiro128.zig
+++ b/lib/std/rand/Xoroshiro128.zig
@@ -20,7 +20,7 @@ pub fn random(self: *Xoroshiro128) Random {
     return Random.init(self, fill);
 }
 
-fn next(self: *Xoroshiro128) u64 {
+pub fn next(self: *Xoroshiro128) u64 {
     const s0 = self.s[0];
     var s1 = self.s[1];
     const r = s0 +% s1;
@@ -33,7 +33,7 @@ fn next(self: *Xoroshiro128) u64 {
 }
 
 // Skip 2^64 places ahead in the sequence
-fn jump(self: *Xoroshiro128) void {
+pub fn jump(self: *Xoroshiro128) void {
     var s0: u64 = 0;
     var s1: u64 = 0;
 

--- a/lib/std/rand/Xoshiro256.zig
+++ b/lib/std/rand/Xoshiro256.zig
@@ -22,7 +22,7 @@ pub fn random(self: *Xoshiro256) Random {
     return Random.init(self, fill);
 }
 
-fn next(self: *Xoshiro256) u64 {
+pub fn next(self: *Xoshiro256) u64 {
     const r = math.rotl(u64, self.s[0] +% self.s[3], 23) +% self.s[0];
 
     const t = self.s[1] << 17;
@@ -40,7 +40,7 @@ fn next(self: *Xoshiro256) u64 {
 }
 
 // Skip 2^128 places ahead in the sequence
-fn jump(self: *Xoshiro256) void {
+pub fn jump(self: *Xoshiro256) void {
     var s: u256 = 0;
 
     var table: u256 = 0x39abdc4529b1661ca9582618e03fc9aad5a61266f0c9392c180ec6d33cfd0aba;

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -4033,16 +4033,24 @@ pub const DeclGen = struct {
                             const final_llvm_ty = (try dg.lowerType(ptr_child_ty)).pointerType(0);
                             break :blk field_addr.constIntToPtr(final_llvm_ty);
                         }
-                        bitcast_needed = !field_ty.eql(ptr_child_ty, dg.module);
 
                         var ty_buf: Type.Payload.Pointer = undefined;
-                        const llvm_field_index = llvmFieldIndex(parent_ty, field_index, target, &ty_buf).?;
-                        const indices: [2]*llvm.Value = .{
-                            llvm_u32.constInt(0, .False),
-                            llvm_u32.constInt(llvm_field_index, .False),
-                        };
+
                         const parent_llvm_ty = try dg.lowerType(parent_ty);
-                        break :blk parent_llvm_ty.constInBoundsGEP(parent_llvm_ptr, &indices, indices.len);
+                        if (llvmFieldIndex(parent_ty, field_index, target, &ty_buf)) |llvm_field_index| {
+                            bitcast_needed = !field_ty.eql(ptr_child_ty, dg.module);
+                            const indices: [2]*llvm.Value = .{
+                                llvm_u32.constInt(0, .False),
+                                llvm_u32.constInt(llvm_field_index, .False),
+                            };
+                            break :blk parent_llvm_ty.constInBoundsGEP(parent_llvm_ptr, &indices, indices.len);
+                        } else {
+                            bitcast_needed = !parent_ty.eql(ptr_child_ty, dg.module);
+                            const indices: [1]*llvm.Value = .{
+                                llvm_u32.constInt(1, .False),
+                            };
+                            break :blk parent_llvm_ty.constInBoundsGEP(parent_llvm_ptr, &indices, indices.len);
+                        }
                     },
                     .Pointer => {
                         assert(parent_ty.isSlice());


### PR DESCRIPTION
 * Handle a `null` return from `llvmFieldIndex`.
 * Add a behavior test to test this code path.
 * Reword this test name, which incorrectly described how pointers to zero-bit fields behave, and instead describe the actual test.
 * Add `pub` to some rand functions.

These were all of the issues encountered while trying to test a new data structure.