### PR TITLE
`spawnWindows`: Fix PATH searching when cwd is absolute

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -1022,8 +1022,12 @@ pub const ChildProcess = struct {
                 };
 
                 // If the app name had path separators, that disallows PATH searching,
-                // and there's no need to search the PATH if the cwd path is absolute.
-                if (app_dirname_w != null or fs.path.isAbsoluteWindowsWTF16(cwd_path_w)) {
+                // and there's no need to search the PATH if the app name is absolute.
+                // We still search the path if the cwd is absolute because of the
+                // "cwd set in ChildProcess is in effect when choosing the executable path
+                // to match posix semantics" behavior--we don't want to skip searching
+                // the PATH just because we were trying to set the cwd of the child process.
+                if (app_dirname_w != null or app_name_is_absolute) {
                     return original_err;
                 }
 


### PR DESCRIPTION
Fixes a regression caused by https://github.com/ziglang/zig/pull/13983

From the added comment:

We still search the path if the cwd is absolute because of the "cwd set in ChildProcess is in effect when choosing the executable path to match posix semantics" behavior--we don't want to skip searching the PATH just because we were trying to set the cwd of the child process.

This is a straightforward bug fix. It will cause conflicts with #13993 but I'll resolve those once this is merged.