### PR TITLE
std: add expectEqualDeep

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -763,7 +763,7 @@ pub fn expectEqualDeep(expected: anytype, actual: @TypeOf(expected)) !void {
 
         .Vector => |info| {
             if (info.len != @typeInfo(@TypeOf(actual)).Vector.len) {
-                std.debug.print("Vector len not the same, expected {*}, found {*}\n", .{ info.len, @typeInfo(@TypeOf(actual)).Vector.len });
+                std.debug.print("Vector len not the same, expected {d}, found {d}\n", .{ info.len, @typeInfo(@TypeOf(actual)).Vector.len });
                 return error.TestExpectedEqual;
             }
             var i: usize = 0;

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -670,6 +670,16 @@ pub fn expectStringEndsWith(actual: []const u8, expected_ends_with: []const u8) 
     return error.TestExpectedEndsWith;
 }
 
+/// This function is intended to be used only in tests. When the two values are not
+/// deeply equal, prints diagnostics to stderr to show exactly how they are not equal,
+/// then returns a test failure error.
+/// `actual` is casted to the type of `expected`.
+///
+/// Deeply equal is defined as follows:
+/// Primitive types are deeply equal if they are equal using  `==` operator.
+/// Struct values are deeply equal if their corresponding fields are deeply equal.
+/// Container types(like Array/Slice/Vector) deeply equal when their corresponding elements are deeply equal.
+/// Pointer values are deeply equal if values they point to are deeply equal.
 pub fn expectEqualDeep(expected: anytype, actual: @TypeOf(expected)) !void {
     switch (@typeInfo(@TypeOf(actual))) {
         .NoReturn,

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -796,17 +796,11 @@ pub fn expectEqualDeep(expected: anytype, actual: @TypeOf(expected)) !void {
             try expectEqual(expectedTag, actualTag);
 
             // we only reach this loop if the tags are equal
-            inline for (std.meta.fields(@TypeOf(actual))) |fld| {
-                if (std.mem.eql(u8, fld.name, @tagName(actualTag))) {
-                    try expectEqualDeep(@field(expected, fld.name), @field(actual, fld.name));
-                    return;
+            switch (expected) {
+                inline else => |val, tag| {
+                    try expectEqualDeep(val, @field(actual, @tagName(tag)));
                 }
             }
-
-            // we iterate over *all* union fields
-            // => we should never get here as the loop above is
-            //    including all possible values.
-            unreachable;
         },
 
         .Optional => {

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -916,17 +916,6 @@ test "expectEqualDeep composite type" {
     }
 }
 
-test "expectEqualDeep bad case" {
-    try expectError(error.TestExpectedEqual, expectEqualDeep(1, 2));
-    try expectError(error.TestExpectedEqual, expectEqualDeep("abc", "abd"));
-    const TestStruct = struct { s: []const u8 };
-    try expectError(error.TestExpectedEqual, expectEqualDeep(TestStruct{ .s = "abc" }, TestStruct{ .s = "abd" }));
-    try expectError(error.TestExpectedEqual, expectEqualDeep([_][]const u8{ "a", "b", "c" }, [_][]const u8{ "a", "a", "c" }));
-
-    // vector
-    try expectError(error.TestExpectedEqual, expectEqualDeep(@splat(4, @as(u32, 3)), @splat(4, @as(u32, 4))));
-}
-
 fn printIndicatorLine(source: []const u8, indicator_index: usize) void {
     const line_begin_index = if (std.mem.lastIndexOfScalar(u8, source[0..indicator_index], '\n')) |line_begin|
         line_begin + 1


### PR DESCRIPTION
Close #12451

Deeply equal is defined as follows:
- Primitive types are deeply equal if they are equal using  `==` operator.
- Struct values are deeply equal if their corresponding fields are deeply equal.
- Container types(like Array/Slice/Vector) deeply equal when their corresponding elements are deeply equal.
- Pointer values are deeply equal if values they point to are deeply equal.
