### PR TITLE
codegen: fix taking the address of a field in a zero-bit struct

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -5131,7 +5131,9 @@ fn structFieldPtr(f: *Function, inst: Air.Inst.Index, struct_ptr_ty: Type, struc
         .begin, .end => {
             try writer.writeByte('(');
             try f.writeCValue(writer, struct_ptr, .Other);
-            try writer.print(")[{}]", .{@boolToInt(field_loc == .end)});
+            try writer.print(")[{}]", .{
+                @boolToInt(field_loc == .end and struct_ty.hasRuntimeBitsIgnoreComptime()),
+            });
         },
         .field => |field| if (extra_name != .none) {
             try f.writeCValueDerefMember(writer, struct_ptr, extra_name);

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -653,7 +653,7 @@ pub const DeclGen = struct {
                     }
                     try writer.print("{ }", .{fmtIdent(field_info.name)});
                 } else {
-                    try dg.renderParentPtr(writer, field_ptr.container_ptr, field_info.ty);
+                    try dg.renderParentPtr(writer, field_ptr.container_ptr, container_ptr_ty);
                 }
             },
             .elem_ptr => {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -4125,7 +4125,7 @@ pub const DeclGen = struct {
             else => unreachable,
         };
         if (bitcast_needed) {
-            return llvm_ptr.constBitCast((try dg.lowerType(ptr_child_ty)).pointerType(0));
+            return llvm_ptr.constBitCast((try dg.lowerPtrElemTy(ptr_child_ty)).pointerType(0));
         } else {
             return llvm_ptr;
         }

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -4033,16 +4033,24 @@ pub const DeclGen = struct {
                             const final_llvm_ty = (try dg.lowerType(ptr_child_ty)).pointerType(0);
                             break :blk field_addr.constIntToPtr(final_llvm_ty);
                         }
-                        bitcast_needed = !field_ty.eql(ptr_child_ty, dg.module);
 
                         var ty_buf: Type.Payload.Pointer = undefined;
-                        const llvm_field_index = llvmFieldIndex(parent_ty, field_index, target, &ty_buf).?;
-                        const indices: [2]*llvm.Value = .{
-                            llvm_u32.constInt(0, .False),
-                            llvm_u32.constInt(llvm_field_index, .False),
-                        };
+
                         const parent_llvm_ty = try dg.lowerType(parent_ty);
-                        break :blk parent_llvm_ty.constInBoundsGEP(parent_llvm_ptr, &indices, indices.len);
+                        if (llvmFieldIndex(parent_ty, field_index, target, &ty_buf)) |llvm_field_index| {
+                            bitcast_needed = !field_ty.eql(ptr_child_ty, dg.module);
+                            const indices: [2]*llvm.Value = .{
+                                llvm_u32.constInt(0, .False),
+                                llvm_u32.constInt(llvm_field_index, .False),
+                            };
+                            break :blk parent_llvm_ty.constInBoundsGEP(parent_llvm_ptr, &indices, indices.len);
+                        } else {
+                            bitcast_needed = !parent_ty.eql(ptr_child_ty, dg.module);
+                            const indices: [1]*llvm.Value = .{
+                                llvm_u32.constInt(1, .False),
+                            };
+                            break :blk parent_llvm_ty.constInBoundsGEP(parent_llvm_ptr, &indices, indices.len);
+                        }
                     },
                     .Pointer => {
                         assert(parent_ty.isSlice());

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2969,7 +2969,7 @@ pub const DeclGen = struct {
 
                 comptime assert(struct_layout_version == 2);
                 var offset: u64 = 0;
-                var big_align: u32 = 0;
+                var big_align: u32 = 1;
                 var any_underaligned_fields = false;
 
                 for (struct_obj.fields.values()) |field| {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -4046,9 +4046,8 @@ pub const DeclGen = struct {
                             break :blk parent_llvm_ty.constInBoundsGEP(parent_llvm_ptr, &indices, indices.len);
                         } else {
                             bitcast_needed = !parent_ty.eql(ptr_child_ty, dg.module);
-                            const indices: [1]*llvm.Value = .{
-                                llvm_u32.constInt(1, .False),
-                            };
+                            const llvm_index = llvm_u32.constInt(@boolToInt(parent_ty.hasRuntimeBitsIgnoreComptime()), .False);
+                            const indices: [1]*llvm.Value = .{llvm_index};
                             break :blk parent_llvm_ty.constInBoundsGEP(parent_llvm_ptr, &indices, indices.len);
                         }
                     },
@@ -9774,8 +9773,8 @@ pub const FuncGen = struct {
                         // end of the struct. Treat our struct pointer as an array of two and get
                         // the index to the element at index `1` to get a pointer to the end of
                         // the struct.
-                        const llvm_usize = try self.dg.lowerType(Type.usize);
-                        const llvm_index = llvm_usize.constInt(1, .False);
+                        const llvm_u32 = self.dg.context.intType(32);
+                        const llvm_index = llvm_u32.constInt(@boolToInt(struct_ty.hasRuntimeBitsIgnoreComptime()), .False);
                         const indices: [1]*llvm.Value = .{llvm_index};
                         return self.builder.buildInBoundsGEP(struct_llvm_ty, struct_ptr, &indices, indices.len, "");
                     }

--- a/src/value.zig
+++ b/src/value.zig
@@ -2915,8 +2915,16 @@ pub const Value = extern union {
             .field_ptr => val.castTag(.field_ptr).?.data.container_ptr.isVariable(mod),
             .eu_payload_ptr => val.castTag(.eu_payload_ptr).?.data.container_ptr.isVariable(mod),
             .opt_payload_ptr => val.castTag(.opt_payload_ptr).?.data.container_ptr.isVariable(mod),
-            .decl_ref => mod.declPtr(val.castTag(.decl_ref).?.data).val.isVariable(mod),
-            .decl_ref_mut => mod.declPtr(val.castTag(.decl_ref_mut).?.data.decl_index).val.isVariable(mod),
+            .decl_ref => {
+                const decl = mod.declPtr(val.castTag(.decl_ref).?.data);
+                assert(decl.has_tv);
+                return decl.val.isVariable(mod);
+            },
+            .decl_ref_mut => {
+                const decl = mod.declPtr(val.castTag(.decl_ref_mut).?.data.decl_index);
+                assert(decl.has_tv);
+                return decl.val.isVariable(mod);
+            },
 
             .variable => true,
             else => false,

--- a/test/behavior/bugs/3742.zig
+++ b/test/behavior/bugs/3742.zig
@@ -39,5 +39,7 @@ test "fixed" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_llvm and
+        builtin.cpu.arch == .aarch64 and builtin.os.tag == .windows) return error.SkipZigTest;
     ArgSerializer.serializeCommand(GET.init("banana"));
 }


### PR DESCRIPTION
This a second attempt at #13992.

 * Handle a `null` return from `llvmFieldIndex`.
 * Fix getting a pointer to the end of a zero-bit struct in the llvm and c backends.
 * Add a behavior test to test these code paths.
 * Reword this test name, which incorrectly described how pointers to zero-bit fields behave, and instead describe the actual test.
 * Fix incorrect type being passed to `renderParentPtr` in the C backend.
 * Disable uncovered test failure on aarch64-windows to verify it's the only remaining issue.