### PR TITLE
macho: implement support for bundles

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -185,9 +185,6 @@ astgen_wait_group: WaitGroup = .{},
 /// TODO: Remove this when Stage2 becomes the default compiler as it will already have this information.
 export_symbol_names: std.ArrayListUnmanaged([]const u8) = .{},
 
-bundle: bool = false,
-bundle_loader: ?[]const u8 = null,
-
 pub const default_stack_protector_buffer_size = 4;
 pub const SemaError = Module.SemaError;
 
@@ -1039,7 +1036,9 @@ pub const InitOptions = struct {
     /// (Darwin) remove dylibs that are unreachable by the entry point or exported symbols
     dead_strip_dylibs: bool = false,
     libcxx_abi_version: libcxx.AbiVersion = libcxx.AbiVersion.default,
+    /// (Darwin) Produce a bundle
     bundle: bool = false,
+    /// (Darwin) Executable that will be loading the bundle output file being linked
     bundle_loader: ?[]const u8 = null,
 };
 
@@ -1941,8 +1940,6 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .debug_compiler_runtime_libs = options.debug_compiler_runtime_libs,
             .debug_compile_errors = options.debug_compile_errors,
             .libcxx_abi_version = options.libcxx_abi_version,
-            .bundle = options.bundle,
-            .bundle_loader = options.bundle_loader,
         };
         break :comp comp;
     };

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -185,6 +185,9 @@ astgen_wait_group: WaitGroup = .{},
 /// TODO: Remove this when Stage2 becomes the default compiler as it will already have this information.
 export_symbol_names: std.ArrayListUnmanaged([]const u8) = .{},
 
+bundle: bool = false,
+bundle_loader: ?[]const u8 = null,
+
 pub const default_stack_protector_buffer_size = 4;
 pub const SemaError = Module.SemaError;
 
@@ -1036,6 +1039,8 @@ pub const InitOptions = struct {
     /// (Darwin) remove dylibs that are unreachable by the entry point or exported symbols
     dead_strip_dylibs: bool = false,
     libcxx_abi_version: libcxx.AbiVersion = libcxx.AbiVersion.default,
+    bundle: bool = false,
+    bundle_loader: ?[]const u8 = null,
 };
 
 fn addPackageTableToCacheHash(
@@ -1883,6 +1888,8 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .headerpad_max_install_names = options.headerpad_max_install_names,
             .dead_strip_dylibs = options.dead_strip_dylibs,
             .force_undefined_symbols = .{},
+            .bundle = options.bundle,
+            .bundle_loader = options.bundle_loader,
         });
         errdefer bin_file.destroy();
         comp.* = .{
@@ -1934,6 +1941,8 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .debug_compiler_runtime_libs = options.debug_compiler_runtime_libs,
             .debug_compile_errors = options.debug_compile_errors,
             .libcxx_abi_version = options.libcxx_abi_version,
+            .bundle = options.bundle,
+            .bundle_loader = options.bundle_loader,
         };
         break :comp comp;
     };

--- a/src/link.zig
+++ b/src/link.zig
@@ -217,6 +217,9 @@ pub const Options = struct {
     /// (Darwin) remove dylibs that are unreachable by the entry point or exported symbols
     dead_strip_dylibs: bool = false,
 
+    bundle: bool = false,
+    bundle_loader: ?[]const u8 = null,
+
     pub fn effectiveOutputMode(options: Options) std.builtin.OutputMode {
         return if (options.use_lld) .Obj else options.output_mode;
     }

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -18,6 +18,7 @@ const MachO = @import("../MachO.zig");
 
 id: ?Id = null,
 weak: bool = false,
+is_bundle_loader: bool = false,
 
 /// Parsed symbol table represented as hash map of symbols'
 /// names. We can and should defer creating *Symbols until
@@ -140,7 +141,7 @@ pub fn parseFromBinary(
 
     const header = try reader.readStruct(macho.mach_header_64);
 
-    if (header.filetype != macho.MH_DYLIB) {
+    if (!self.is_bundle_loader and header.filetype != macho.MH_DYLIB) {
         log.debug("invalid filetype: expected 0x{x}, found 0x{x}", .{ macho.MH_DYLIB, header.filetype });
         return error.NotDylib;
     }


### PR DESCRIPTION
MachO linker now handles `-bundle` and `-bundle_loader <executable>` parameters similar to how `ld` does it.

There is no test case for this proof of concept just yet but I am planning to prepare one.

@kubkon what do you think?