### PR TITLE
zig fmt: add option --indent

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -60,6 +60,10 @@ pub fn render(tree: Ast, gpa: mem.Allocator) RenderError![]u8 {
     return buffer.toOwnedSlice();
 }
 
+pub fn setRenderIndentDelta(indent_delta: usize) void {
+    return @import("./render.zig").setIndentDelta(indent_delta);
+}
+
 pub fn renderToArrayList(tree: Ast, buffer: *std.ArrayList(u8)) RenderError!void {
     return @import("./render.zig").renderTree(buffer, tree);
 }

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -7,12 +7,16 @@ const Ast = std.zig.Ast;
 const Token = std.zig.Token;
 const primitives = std.zig.primitives;
 
-const indent_delta = 4;
+var indent_delta: usize = 4;
 const asm_indent_delta = 2;
 
 pub const Error = Ast.RenderError;
 
 const Ais = AutoIndentingStream(std.ArrayList(u8).Writer);
+
+pub fn setIndentDelta(new_indent_delta: usize) void {
+    indent_delta = new_indent_delta;
+}
 
 pub fn renderTree(buffer: *std.ArrayList(u8), tree: Ast) Error!void {
     assert(tree.errors.len == 0); // Cannot render an invalid tree.

--- a/src/main.zig
+++ b/src/main.zig
@@ -4170,6 +4170,7 @@ pub fn cmdFmt(gpa: Allocator, arena: Allocator, args: []const []const u8) !void 
     defer input_files.deinit();
     var excluded_files = ArrayList([]const u8).init(gpa);
     defer excluded_files.deinit();
+    var indent: usize = 0;
 
     {
         var i: usize = 0;
@@ -4202,6 +4203,12 @@ pub fn cmdFmt(gpa: Allocator, arena: Allocator, args: []const []const u8) !void 
                     i += 1;
                     const next_arg = args[i];
                     try excluded_files.append(next_arg);
+                } else if (mem.eql(u8, arg, "--indent")) {
+                    i += 1;
+                    const next_arg = args[i];
+                    indent = std.fmt.parseInt(usize, next_arg, 10) catch {
+                        fatal("expected [number] after --indent, found '{s}'", .{next_arg});
+                    };
                 } else {
                     fatal("unrecognized parameter: '{s}'", .{arg});
                 }
@@ -4209,6 +4216,10 @@ pub fn cmdFmt(gpa: Allocator, arena: Allocator, args: []const []const u8) !void 
                 try input_files.append(arg);
             }
         }
+    }
+
+    if (indent != 0) {
+        std.zig.Ast.setRenderIndentDelta(indent);
     }
 
     if (stdin_flag) {


### PR DESCRIPTION
Hi,

I'm new to zig, a consistent code-style comes with a little bit configurability will be very helpful, `zig fmt` may need an option `--indent` to allow user can specify different tab-width like prettier does [Tab Width](https://prettier.io/docs/en/options.html#tab-width)

Please point out any of my wrong
