### PR TITLE
fix build for the Android NDK

### DIFF
--- a/lib/compiler_rt/emutls.zig
+++ b/lib/compiler_rt/emutls.zig
@@ -86,12 +86,10 @@ const ObjectArray = struct {
     /// create a new ObjectArray with n slots. must call deinit() to deallocate.
     pub fn init(n: usize) *ObjectArray {
         var array = simple_allocator.alloc(ObjectArray);
-        errdefer simple_allocator.free(array);
 
         array.* = ObjectArray{
             .slots = simple_allocator.allocSlice(?ObjectPointer, n),
         };
-        errdefer simple_allocator.free(array.slots);
 
         for (array.slots) |*object| {
             object.* = null;


### PR DESCRIPTION
Zig had temporarily regressed in building for the Android NDK due to an uncatched error in `compiler_rt/emutls.zig` and due to the recent aa39644 commit, which caused `c.zig` to export `pthread_key_t` even though `c/linux.zig` exports it on Android.
These errors were not catched because building for the Android NDK isn't tested in the CI.
This pull request just fixes the aforementioned errors.
