### PR TITLE
fix more parsing underflows found while fuzzing

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -618,7 +618,7 @@ pub fn firstToken(tree: Ast, node: Node.Index) TokenIndex {
         .tagged_union_enum_tag_trailing,
         => {
             const main_token = main_tokens[n];
-            switch (token_tags[main_token - 1]) {
+            switch (token_tags[main_token -| 1]) {
                 .keyword_packed, .keyword_extern => end_offset += 1,
                 else => {},
             }

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -228,6 +228,23 @@ test "zig fmt: top-level enum missing 'const name ='" {
     , &[_]Error{.expected_token});
 }
 
+test "zig fmt: top-level container missing 'const name ='" {
+    // somehow testCanonical() causes these to be interpreted as
+    // .container_field which safely leads to std.Ast.zig firstToken() on L562.
+    // but zls and zig interpret as .container_decl (i think) and both crash
+    // on L621. this can be observed by placing either of the following
+    // contents in a file and running `zig test` on that file or opening that
+    // file with zls.
+    try testCanonical(
+        \\union {}
+        \\
+    );
+    try testCanonical(
+        \\struct {}
+        \\
+    );
+}
+
 test "zig fmt: top-level bare asterisk+identifier" {
     try testCanonical(
         \\*x


### PR DESCRIPTION
this patch allows these inputs to successfully parse and adds tests for them:
* `struct {}` or `union {}` - std.zig.Ast.firstToken()#L621

this is a draft because the added test doesn't work.  i don't know where to put the tests or how to change them so that they will lead to the same outcome as zig or zls.  here is my what i mean (copied from comment in test added by this pr).

> somehow testCanonical() causes these to be interpreted as
.container_field which safely leads to std.Ast.zig firstToken() on L562.
but zls and zig interpret as .container_decl (i think) and both crash
on L621. this can be observed by placing either of these
contents in a file and running `zig test` on that file or opening that
file with zls.