### PR TITLE
docs: Clarify that `std.fs.path.resolve` doesn't resolve relative path to absolute path

### DIFF
--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -460,7 +460,7 @@ pub fn resolve(allocator: Allocator, paths: []const []const u8) ![]u8 {
 }
 
 /// This function is like a series of `cd` statements executed one after another.
-/// It resolves "." and "..".
+/// It resolves "." and "..", but will not convert relative path to absolute path, use std.fs.Dir.realpath instead.
 /// The result does not have a trailing path separator.
 /// Each drive has its own current working directory.
 /// Path separators are canonicalized to '\\' and drives are canonicalized to capital letters.
@@ -637,7 +637,7 @@ pub fn resolveWindows(allocator: Allocator, paths: []const []const u8) ![]u8 {
 }
 
 /// This function is like a series of `cd` statements executed one after another.
-/// It resolves "." and "..".
+/// It resolves "." and "..", but will not convert relative path to absolute path, use std.fs.Dir.realpath instead.
 /// The result does not have a trailing path separator.
 /// This function does not perform any syscalls. Executing this series of path
 /// lookups on the actual filesystem may produce different results due to


### PR DESCRIPTION
Since https://github.com/ziglang/zig/commit/d24aaf8847336e12b6571e13d57f6d112452d97d, `std.fs.path.resolve` doesn't make system calls anymore, thus made the function agnostic to actuall filesystem layout. As a result, relative path can no longer be resolved to absolute path (Not sure if they could before). Yet the behavior isn't specified in the documentation, causing https://github.com/ziglang/zig/issues/14010.

Related: https://github.com/ziglang/zig/issues/14010
