### PR TITLE
Fix missing pthread_key_t definition on linux

### DIFF
--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -320,9 +320,7 @@ pub const pthread_rwlock_t = switch (native_abi) {
         size: [56]u8 align(@alignOf(usize)) = [_]u8{0} ** 56,
     },
 };
-pub usingnamespace if (native_abi == .android) struct {
-    pub const pthread_key_t = c_int;
-} else struct {};
+pub const pthread_key_t = c_uint;
 pub const sem_t = extern struct {
     __size: [__SIZEOF_SEM_T]u8 align(@alignOf(usize)),
 };


### PR DESCRIPTION
* pthread_key_t should also be available for non-android platforms
* Also change the type to c_uint because Linux pthreadtypes.h typedefs it as "unsigned int"

Partially addresses #13950