### PR TITLE
std: stop using LinearFifo in BufferedReader

### DIFF
--- a/lib/std/io/buffered_reader.zig
+++ b/lib/std/io/buffered_reader.zig
@@ -49,7 +49,7 @@ pub fn bufferedReader(underlying_stream: anytype) BufferedReader(4096, @TypeOf(u
     return .{ .unbuffered_reader = underlying_stream };
 }
 
-test "io.BufferedReader" {
+test "io.BufferedReader OneByte" {
     const OneByteReadReader = struct {
         str: []const u8,
         curr: usize,
@@ -87,4 +87,103 @@ test "io.BufferedReader" {
     const res = try stream.readAllAlloc(testing.allocator, str.len + 1);
     defer testing.allocator.free(res);
     try testing.expectEqualSlices(u8, str, res);
+}
+
+fn smallBufferedReader(underlying_stream: anytype) BufferedReader(8, @TypeOf(underlying_stream)) {
+    return .{ .unbuffered_reader = underlying_stream };
+}
+test "io.BufferedReader Block" {
+    const BlockReader = struct {
+        block: []const u8,
+        reads_allowed: usize,
+        curr_read: usize,
+
+        const Error = error{NoError};
+        const Self = @This();
+        const Reader = io.Reader(*Self, Error, read);
+
+        fn init(block: []const u8, reads_allowed: usize) Self {
+            return Self{
+                .block = block,
+                .reads_allowed = reads_allowed,
+                .curr_read = 0,
+            };
+        }
+
+        fn read(self: *Self, dest: []u8) Error!usize {
+            if (self.curr_read >= self.reads_allowed) {
+                return 0;
+            }
+            std.debug.assert(dest.len >= self.block.len);
+            std.mem.copy(u8, dest, self.block);
+
+            self.curr_read += 1;
+            return self.block.len;
+        }
+
+        fn reader(self: *Self) Reader {
+            return .{ .context = self };
+        }
+    };
+
+    const block = "0123";
+
+    // len out == block
+    {
+        var block_reader = BlockReader.init(block, 2);
+        var test_buf_reader = BufferedReader(4, BlockReader){ .unbuffered_reader = block_reader };
+        var out_buf: [4]u8 = undefined;
+        _ = try test_buf_reader.read(&out_buf);
+        try testing.expectEqualSlices(u8, &out_buf, block);
+        _ = try test_buf_reader.read(&out_buf);
+        try testing.expectEqualSlices(u8, &out_buf, block);
+        try testing.expectEqual(try test_buf_reader.read(&out_buf), 0);
+    }
+
+    // len out < block
+    {
+        var block_reader = BlockReader.init(block, 2);
+        var test_buf_reader = BufferedReader(4, BlockReader){ .unbuffered_reader = block_reader };
+        var out_buf: [3]u8 = undefined;
+        _ = try test_buf_reader.read(&out_buf);
+        try testing.expectEqualSlices(u8, &out_buf, "012");
+        _ = try test_buf_reader.read(&out_buf);
+        try testing.expectEqualSlices(u8, &out_buf, "301");
+        const n = try test_buf_reader.read(&out_buf);
+        try testing.expectEqualSlices(u8, out_buf[0..n], "23");
+        try testing.expectEqual(try test_buf_reader.read(&out_buf), 0);
+    }
+
+    // len out > block
+    {
+        var block_reader = BlockReader.init(block, 2);
+        var test_buf_reader = BufferedReader(4, BlockReader){ .unbuffered_reader = block_reader };
+        var out_buf: [5]u8 = undefined;
+        _ = try test_buf_reader.read(&out_buf);
+        try testing.expectEqualSlices(u8, &out_buf, "01230");
+        const n = try test_buf_reader.read(&out_buf);
+        try testing.expectEqualSlices(u8, out_buf[0..n], "123");
+        try testing.expectEqual(try test_buf_reader.read(&out_buf), 0);
+    }
+
+    // len out == 0
+    {
+        var block_reader = BlockReader.init(block, 2);
+        var test_buf_reader = BufferedReader(4, BlockReader){ .unbuffered_reader = block_reader };
+        var out_buf: [0]u8 = undefined;
+        _ = try test_buf_reader.read(&out_buf);
+        try testing.expectEqualSlices(u8, &out_buf, "");
+    }
+
+    // len bufreader buf > block
+    {
+        var block_reader = BlockReader.init(block, 2);
+        var test_buf_reader = BufferedReader(5, BlockReader){ .unbuffered_reader = block_reader };
+        var out_buf: [4]u8 = undefined;
+        _ = try test_buf_reader.read(&out_buf);
+        try testing.expectEqualSlices(u8, &out_buf, block);
+        _ = try test_buf_reader.read(&out_buf);
+        try testing.expectEqualSlices(u8, &out_buf, block);
+        try testing.expectEqual(try test_buf_reader.read(&out_buf), 0);
+    }
 }


### PR DESCRIPTION
See also commit 7287c7482a2c694c7c7f56b9f7c1744a7ae7905f where LinearFifo is removed from BufferedWriter

Basically, LinearFifo does extra work v. copying bytes and increasing an offset.

---

### Context:

I wrote a clone of [runiq](https://github.com/whitfin/runiq), [zuniq](https://github.com/hwchen/zuniq), and was surprised `zuniq` was slower by quite a bit. On my test data set, runiq's read + filter + write had about the same time as just zuniq's read.

Just to give a broad idea of the speedup, here's some timings of before/after. (`patched` is the version run against the changes in this PR). I'm running ubuntu 20.04 on amd64 (ryzen).

```
zuniq on  main [+1] > just bench scratch/test-data.txt
zig build install -Drelease-fast -p zig-out
zig build install -Drelease-fast -p zig-out/patched --zig-lib-dir ~/zigdev/zig/lib
hyperfine --warmup 10 'zig-out/bin/zuniq scratch/test-data.txt' 'zig-out/patched/bin/zuniq scratch/test-data.txt' 'runiq scratch/test-data.txt'
Benchmark 1: zig-out/bin/zuniq scratch/test-data.txt
  Time (mean ± σ):     185.1 ms ±   4.2 ms    [User: 168.1 ms, System: 16.8 ms]
  Range (min … max):   179.1 ms … 191.6 ms    16 runs
 
Benchmark 2: zig-out/patched/bin/zuniq scratch/test-data.txt
  Time (mean ± σ):      84.7 ms ±   3.4 ms    [User: 66.6 ms, System: 17.9 ms]
  Range (min … max):    80.2 ms …  93.0 ms    36 runs
 
Benchmark 3: runiq scratch/test-data.txt
  Time (mean ± σ):     134.1 ms ±   3.9 ms    [User: 75.6 ms, System: 58.2 ms]
  Range (min … max):   126.1 ms … 140.9 ms    21 runs
 
Summary
  'zig-out/patched/bin/zuniq scratch/test-data.txt' ran
    1.58 ± 0.08 times faster than 'runiq scratch/test-data.txt'
    2.18 ± 0.10 times faster than 'zig-out/bin/zuniq scratch/test-data.txt'

zuniq on  main [+1] > ./zig-out/bin/zuniq scratch/test-data.txt| wc -l
522478
zuniq on  main [+1] > ./zig-out/patched/bin/zuniq scratch/test-data.txt| wc -l
522478
zuniq on  main [+1] > runiq scratch/test-data.txt| wc -l 
522478
```

---

### Todo

I've taken a shortcut in testing just as a sanity check: I used the latest nightly and ran `zig test --zig-lib-dir lib  --main-pkg-path lib/std lib/std/io/buffered_reader.zig`.

If this change is desirable, I'll take the time to:
- [x] Set up my zig dev environment properly to run the tests
- [x] Add some more tests, as I didn't check edge cases (which the LinearFifo may have tested)
- [x] Write a benchmark as in https://github.com/ziglang/zig/pull/10668

edit: I've started work on cleaning this up, see the list above.

### ref
https://github.com/ziglang/zig/issues/10637#issuecomment-1022036688, noting that it might be desirable to remove the LinearFifo from BufferedReader since it had been done for BufferedWriter.