### PR TITLE
`Dir.openDirAccessMaskW`: Add ACCESS_DENIED as a possible error

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1794,6 +1794,9 @@ pub const Dir = struct {
             .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
             .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
             .NOT_A_DIRECTORY => return error.NotDir,
+            // This can happen if the directory has 'List folder contents' permission set to 'Deny'
+            // and the directory is trying to be opened for iteration.
+            .ACCESS_DENIED => return error.AccessDenied,
             .INVALID_PARAMETER => unreachable,
             else => return w.unexpectedStatus(rc),
         }


### PR DESCRIPTION
Can occur when trying to open a directory for iteration but the 'List folder contents' permission of the directory is set to 'Deny'.

This was found because it was being triggered during PATH searching in ChildProcess.spawnWindows if a PATH entry did not have 'List folder contents' permission, so this fixes that as well (note: the behavior on hitting this during PATH searching is to treat it as the directory not existing and therefore it will fail to find any executables in a directory in the PATH without 'List folder contents' permission; this matches Windows `cmd.exe` behavior which also fails to find commands in directories that do not have 'List folder contents' permission).