### PR TITLE
std: implement os.mprotect on Windows

### DIFF
--- a/lib/std/c/windows.zig
+++ b/lib/std/c/windows.zig
@@ -94,6 +94,18 @@ pub const SEEK = struct {
     pub const END = 2;
 };
 
+/// Basic memory protection flags
+pub const PROT = struct {
+    /// page can not be accessed
+    pub const NONE = 0x0;
+    /// page can be read
+    pub const READ = 0x1;
+    /// page can be written
+    pub const WRITE = 0x2;
+    /// page can be executed
+    pub const EXEC = 0x4;
+};
+
 pub const E = enum(u16) {
     /// No error occurred.
     SUCCESS = 0,

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1499,6 +1499,22 @@ pub fn VirtualFree(lpAddress: ?LPVOID, dwSize: usize, dwFreeType: DWORD) void {
     assert(kernel32.VirtualFree(lpAddress, dwSize, dwFreeType) != 0);
 }
 
+pub const VirtualProtectError = error{
+    InvalidAddress,
+    Unexpected,
+};
+
+pub fn VirtualProtect(lpAddress: ?LPVOID, dwSize: SIZE_T, flNewProtect: DWORD, lpflOldProtect: *DWORD) VirtualProtectError!void {
+    // ntdll takes an extra level of indirection here
+    var addr = lpAddress;
+    var size = dwSize;
+    switch (ntdll.NtProtectVirtualMemory(self_process_handle, &addr, &size, flNewProtect, lpflOldProtect)) {
+        .SUCCESS => {},
+        .INVALID_ADDRESS => return error.InvalidAddress,
+        else => |st| return unexpectedStatus(st),
+    }
+}
+
 pub const VirtualQueryError = error{Unexpected};
 
 pub fn VirtualQuery(lpAddress: ?LPVOID, lpBuffer: PMEMORY_BASIC_INFORMATION, dwLength: SIZE_T) VirtualQueryError!SIZE_T {

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -291,3 +291,11 @@ pub extern "ntdll" fn RtlQueryRegistryValues(
     Context: ?*anyopaque,
     Environment: ?*anyopaque,
 ) callconv(WINAPI) NTSTATUS;
+
+pub extern "ntdll" fn NtProtectVirtualMemory(
+    ProcessHandle: HANDLE,
+    BaseAddress: *PVOID,
+    NumberOfBytesToProtect: *ULONG,
+    NewAccessProtection: ULONG,
+    OldAccessProtection: *ULONG,
+) callconv(WINAPI) NTSTATUS;


### PR DESCRIPTION
Recently discussed on Discord in zig-help, exactly what it says on the tin. I don't have a Windows machine on hand to confirm it works, but the logic is pretty simple and it compiles fine.

(Who designed the `VirtualProtect` API?! The protection constants are insane)