### PR TITLE
@export() with linksection option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -159,7 +159,7 @@ pub fn build(b: *Builder) !void {
     exe.setTarget(target);
 
     const compile_step = b.step("compile", "Build the self-hosted compiler");
-    compile_step.dependOn(&exe.install_step.?.step);
+    compile_step.dependOn(&exe.step);
 
     if (!skip_stage2_tests) {
         test_step.dependOn(&exe.step);

--- a/build.zig
+++ b/build.zig
@@ -159,7 +159,7 @@ pub fn build(b: *Builder) !void {
     exe.setTarget(target);
 
     const compile_step = b.step("compile", "Build the self-hosted compiler");
-    compile_step.dependOn(&exe.step);
+    compile_step.dependOn(&exe.install_step.?.step);
 
     if (!skip_stage2_tests) {
         test_step.dependOn(&exe.step);

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -20300,8 +20300,13 @@ fn resolveExportOptions(
     const linkage_val = try sema.resolveConstValue(block, linkage_src, linkage_operand, "linkage of exported value must be comptime-known");
     const linkage = linkage_val.toEnum(std.builtin.GlobalLinkage);
 
-    const section = try sema.fieldVal(block, src, options, "section", section_src);
-    const section_val = try sema.resolveConstValue(block, section_src, section, "linksection of exported value must be comptime-known");
+    const section_operand = try sema.fieldVal(block, src, options, "section", section_src);
+    const section_opt_val = try sema.resolveConstValue(block, section_src, section_operand, "linksection of exported value must be comptime-known");
+    const section_ty = Type.initTag(.const_slice_u8);
+    const section = if (section_opt_val.optionalValue()) |section_val|
+        try section_val.toAllocatedBytes(section_ty, sema.arena, sema.mod)
+    else
+        null;
 
     const visibility_operand = try sema.fieldVal(block, src, options, "visibility", visibility_src);
     const visibility_val = try sema.resolveConstValue(block, visibility_src, visibility_operand, "visibility of exported value must be comptime-known");
@@ -20317,14 +20322,10 @@ fn resolveExportOptions(
         });
     }
 
-    if (!section_val.isNull()) {
-        return sema.fail(block, section_src, "TODO: implement exporting with linksection", .{});
-    }
-
     return std.builtin.ExportOptions{
         .name = name,
         .linkage = linkage,
-        .section = null, // TODO
+        .section = section,
         .visibility = visibility,
     };
 }


### PR DESCRIPTION
I did not find many tests under the `test/` directory wrt `linksection` if anyone has directions on how they want this tested I'm definitely willing to put in the work breaking ground on some testing facilities.

In addition to the section name I changed the `compile` step to depend on stage3's install step. This way when building zig using cmake (I'm linking to LLVM because I'm primarily testing this on embedded targets) it'll be under `zig-out`, instead of having to find it in the build cache.