### PR TITLE
macho+zld: write code signature padding before committing load commands

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -574,11 +574,12 @@ pub fn flushModule(self: *MachO, comp: *Compilation, prog_node: *std.Progress.No
         var codesig = CodeSignature.init(self.page_size);
         codesig.code_directory.ident = self.base.options.emit.?.sub_path;
         if (self.base.options.entitlements) |path| {
-            try codesig.addEntitlements(arena, path);
+            try codesig.addEntitlements(self.base.allocator, path);
         }
         try self.writeCodeSignaturePadding(&codesig);
         break :blk codesig;
     } else null;
+    defer if (codesig) |*csig| csig.deinit(self.base.allocator);
 
     // Write load commands
     var lc_buffer = std.ArrayList(u8).init(arena);

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -4115,11 +4115,12 @@ pub fn linkWithZld(macho_file: *MachO, comp: *Compilation, prog_node: *std.Progr
             var codesig = CodeSignature.init(page_size);
             codesig.code_directory.ident = fs.path.basename(full_out_path);
             if (options.entitlements) |path| {
-                try codesig.addEntitlements(arena, path);
+                try codesig.addEntitlements(zld.gpa, path);
             }
             try zld.writeCodeSignaturePadding(&codesig);
             break :blk codesig;
         } else null;
+        defer if (codesig) |*csig| csig.deinit(zld.gpa);
 
         // Write load commands
         var lc_buffer = std.ArrayList(u8).init(arena);

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -4100,6 +4100,27 @@ pub fn linkWithZld(macho_file: *MachO, comp: *Compilation, prog_node: *std.Progr
             }
         }
 
+        // Write code signature padding if required
+        const requires_codesig = blk: {
+            if (options.entitlements) |_| break :blk true;
+            if (cpu_arch == .aarch64 and (os_tag == .macos or abi == .simulator)) break :blk true;
+            break :blk false;
+        };
+        var codesig: ?CodeSignature = if (requires_codesig) blk: {
+            // Preallocate space for the code signature.
+            // We need to do this at this stage so that we have the load commands with proper values
+            // written out to the file.
+            // The most important here is to have the correct vm and filesize of the __LINKEDIT segment
+            // where the code signature goes into.
+            var codesig = CodeSignature.init(page_size);
+            codesig.code_directory.ident = fs.path.basename(full_out_path);
+            if (options.entitlements) |path| {
+                try codesig.addEntitlements(arena, path);
+            }
+            try zld.writeCodeSignaturePadding(&codesig);
+            break :blk codesig;
+        } else null;
+
         // Write load commands
         var lc_buffer = std.ArrayList(u8).init(arena);
         const lc_writer = lc_buffer.writer();
@@ -4142,29 +4163,11 @@ pub fn linkWithZld(macho_file: *MachO, comp: *Compilation, prog_node: *std.Progr
 
         try load_commands.writeLoadDylibLCs(zld.dylibs.items, zld.referenced_dylibs.keys(), lc_writer);
 
-        const requires_codesig = blk: {
-            if (options.entitlements) |_| break :blk true;
-            if (cpu_arch == .aarch64 and (os_tag == .macos or abi == .simulator)) break :blk true;
-            break :blk false;
-        };
         var codesig_cmd_offset: ?u32 = null;
-        var codesig: ?CodeSignature = if (requires_codesig) blk: {
-            // Preallocate space for the code signature.
-            // We need to do this at this stage so that we have the load commands with proper values
-            // written out to the file.
-            // The most important here is to have the correct vm and filesize of the __LINKEDIT segment
-            // where the code signature goes into.
-            var codesig = CodeSignature.init(page_size);
-            codesig.code_directory.ident = fs.path.basename(full_out_path);
-            if (options.entitlements) |path| {
-                try codesig.addEntitlements(gpa, path);
-            }
-            try zld.writeCodeSignaturePadding(&codesig);
+        if (requires_codesig) {
             codesig_cmd_offset = @sizeOf(macho.mach_header_64) + @intCast(u32, lc_buffer.items.len);
             try lc_writer.writeStruct(zld.codesig_cmd);
-            break :blk codesig;
-        } else null;
-        defer if (codesig) |*csig| csig.deinit(gpa);
+        }
 
         const ncmds = load_commands.calcNumOfLCs(lc_buffer.items);
         try zld.file.pwriteAll(lc_buffer.items, @sizeOf(macho.mach_header_64));

--- a/test/link.zig
+++ b/test/link.zig
@@ -165,6 +165,11 @@ fn addMachOCases(cases: *tests.StandaloneContext) void {
         .requires_symlinks = true,
     });
 
+    cases.addBuildFile("test/link/macho/strict_validation/build.zig", .{
+        .build_modes = true,
+        .requires_symlinks = true,
+    });
+
     cases.addBuildFile("test/link/macho/tls/build.zig", .{
         .build_modes = true,
         .requires_symlinks = true,

--- a/test/link/macho/strict_validation/build.zig
+++ b/test/link/macho/strict_validation/build.zig
@@ -1,0 +1,100 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Builder = std.build.Builder;
+const LibExeObjectStep = std.build.LibExeObjStep;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+    const target: std.zig.CrossTarget = .{ .os_tag = .macos };
+
+    const test_step = b.step("test", "Test");
+    test_step.dependOn(b.getInstallStep());
+
+    const exe = b.addExecutable("main", "main.zig");
+    exe.setBuildMode(mode);
+    exe.setTarget(target);
+    exe.linkLibC();
+
+    const check_exe = exe.checkObject(.macho);
+
+    check_exe.checkStart("cmd SEGMENT_64");
+    check_exe.checkNext("segname __LINKEDIT");
+    check_exe.checkNext("fileoff {fileoff}");
+    check_exe.checkNext("filesz {filesz}");
+
+    check_exe.checkStart("cmd DYLD_INFO_ONLY");
+    check_exe.checkNext("rebaseoff {rebaseoff}");
+    check_exe.checkNext("rebasesize {rebasesize}");
+    check_exe.checkNext("bindoff {bindoff}");
+    check_exe.checkNext("bindsize {bindsize}");
+    check_exe.checkNext("lazybindoff {lazybindoff}");
+    check_exe.checkNext("lazybindsize {lazybindsize}");
+    check_exe.checkNext("exportoff {exportoff}");
+    check_exe.checkNext("exportsize {exportsize}");
+
+    check_exe.checkStart("cmd SYMTAB");
+    check_exe.checkNext("symoff {symoff}");
+    check_exe.checkNext("stroff {stroff}");
+    check_exe.checkNext("strsize {strsize}");
+
+    check_exe.checkStart("cmd DYSYMTAB");
+    check_exe.checkNext("indirectsymoff {dysymoff}");
+
+    switch (builtin.cpu.arch) {
+        .aarch64 => {
+            check_exe.checkStart("cmd CODE_SIGNATURE");
+            check_exe.checkNext("dataoff {codesigoff}");
+            check_exe.checkNext("datasize {codesigsize}");
+        },
+        .x86_64 => {},
+        else => unreachable,
+    }
+
+    // Next check: DYLD_INFO_ONLY subsections are in order: rebase < bind < lazy < export
+    check_exe.checkComputeCompare("rebaseoff ", .{ .op = .lt, .value = .{ .variable = "bindoff" } });
+    check_exe.checkComputeCompare("bindoff", .{ .op = .lt, .value = .{ .variable = "lazybindoff" } });
+    check_exe.checkComputeCompare("lazybindoff", .{ .op = .lt, .value = .{ .variable = "exportoff" } });
+
+    // Next check: DYLD_INFO_ONLY subsections do not overlap
+    check_exe.checkComputeCompare("rebaseoff rebasesize +", .{ .op = .lte, .value = .{ .variable = "bindoff" } });
+    check_exe.checkComputeCompare("bindoff bindsize +", .{ .op = .lte, .value = .{ .variable = "lazybindoff" } });
+    check_exe.checkComputeCompare("lazybindoff lazybindsize +", .{ .op = .lte, .value = .{ .variable = "exportoff" } });
+
+    // Next check: we maintain order: symtab < dysymtab < strtab
+    check_exe.checkComputeCompare("symoff", .{ .op = .lt, .value = .{ .variable = "dysymoff" } });
+    check_exe.checkComputeCompare("dysymoff", .{ .op = .lt, .value = .{ .variable = "stroff" } });
+
+    // Next check: all LINKEDIT sections apart from CODE_SIGNATURE are 8-bytes aligned
+    check_exe.checkComputeCompare("rebaseoff 8 %", .{ .op = .eq, .value = .{ .literal = 0 } });
+    check_exe.checkComputeCompare("bindoff 8 %", .{ .op = .eq, .value = .{ .literal = 0 } });
+    check_exe.checkComputeCompare("lazybindoff 8 %", .{ .op = .eq, .value = .{ .literal = 0 } });
+    check_exe.checkComputeCompare("exportoff 8 %", .{ .op = .eq, .value = .{ .literal = 0 } });
+    check_exe.checkComputeCompare("symoff 8 %", .{ .op = .eq, .value = .{ .literal = 0 } });
+    check_exe.checkComputeCompare("stroff 8 %", .{ .op = .eq, .value = .{ .literal = 0 } });
+    check_exe.checkComputeCompare("dysymoff 8 %", .{ .op = .eq, .value = .{ .literal = 0 } });
+
+    switch (builtin.cpu.arch) {
+        .aarch64 => {
+            // Next check: LINKEDIT segment does not extend beyond, or does not include, CODE_SIGNATURE data
+            check_exe.checkComputeCompare("fileoff filesz codesigoff codesigsize + - -", .{
+                .op = .eq,
+                .value = .{ .literal = 0 },
+            });
+
+            // Next check: CODE_SIGNATURE data offset is 16-bytes aligned
+            check_exe.checkComputeCompare("codesigoff 16 %", .{ .op = .eq, .value = .{ .literal = 0 } });
+        },
+        .x86_64 => {
+            // Next check: LINKEDIT segment does not extend beyond, or does not include, strtab data
+            check_exe.checkComputeCompare("fileoff filesz stroff strsize + - -", .{
+                .op = .eq,
+                .value = .{ .literal = 0 },
+            });
+        },
+        else => unreachable,
+    }
+
+    const run = check_exe.runAndCompare();
+    run.expectStdOutEqual("Hello!\n");
+    test_step.dependOn(&run.step);
+}

--- a/test/link/macho/strict_validation/main.zig
+++ b/test/link/macho/strict_validation/main.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+    try stdout.writeAll("Hello!\n");
+}


### PR DESCRIPTION
Otherwise, we were prematurely committing `__LINKEDIT` segment LC with outdated size (i.e., without code signature being taken into account). This would scaffold into strict validation failures by Apple tooling.

Add MachO strict validation smoke test to avoid this type of regression in the future.

Fixes #14045 