### PR TITLE
behavior: disable tests that trigger an llvm 15 bug and assertion

### DIFF
--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -334,6 +334,11 @@ test "comptime @bitCast packed struct to int and back" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
+    if (comptime builtin.zig_backend == .stage2_llvm and builtin.cpu.arch.endian() == .Big) {
+        // https://github.com/ziglang/zig/issues/13782
+        return error.SkipZigTest;
+    }
+
     const S = packed struct {
         void: void = {},
         uint: u8 = 13,

--- a/test/behavior/bugs/12169.zig
+++ b/test/behavior/bugs/12169.zig
@@ -7,6 +7,12 @@ test {
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+
+    if (comptime builtin.zig_backend == .stage2_llvm and builtin.cpu.arch.endian() == .Big) {
+        // https://github.com/ziglang/zig/issues/13782
+        return error.SkipZigTest;
+    }
+
     const a = @Vector(2, bool){ true, true };
     const b = @Vector(1, bool){true};
     try std.testing.expect(@reduce(.And, a));


### PR DESCRIPTION
```
LLVM Emit Object... zig: llvm/include/llvm/ADT/APInt.h:840: void llvm::APInt::lshrInPlace(unsigned int): Assertion `ShiftAmt <= BitWidth && "Invalid shift amount"' failed.
Aborted
```

Tracked by #13782