### PR TITLE
Fix #14063

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -29743,6 +29743,18 @@ pub fn resolveTypeLayout(sema: *Sema, ty: Type) CompileError!void {
             const payload_ty = ty.errorUnionPayload();
             return sema.resolveTypeLayout(payload_ty);
         },
+        .Fn => {
+            const info = ty.fnInfo();
+            if (info.is_generic) {
+                // Resolving of generic function types is defeerred to when
+                // the function is instantiated.
+                return;
+            }
+            for (info.param_types) |param_ty| {
+                try sema.resolveTypeLayout(param_ty);
+            }
+            try sema.resolveTypeLayout(info.return_type);
+        },
         else => {},
     }
 }

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1419,3 +1419,16 @@ test "struct field has a pointer to an aligned version of itself" {
 
     try expect(&e == e.next);
 }
+
+test "struct only referenced from optional parameter/return" {
+    const S = struct {
+        fn f(_: ?struct { x: u8 }) void {}
+        fn g() ?struct { x: u8 } {
+            return null;
+        }
+    };
+
+    const fp: *const anyopaque = &S.f;
+    const gp: *const anyopaque = &S.g;
+    try expect(fp != gp);
+}


### PR DESCRIPTION
 * Fix missing struct layout for llvm backend.

~~I'm not 100% convinced that this won't prevent valid code from compiling, but it passes behavior tests and I can't come up with anything.~~  After noticing how similar this code was to `resolveTypeFully`, I copied over the style from that function and am much more convinced of the correctness of this change.

Closes #14063