### PR TITLE
std: Expose Int parameter in std.PackedInt[Array,Slice]

### DIFF
--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -286,6 +286,9 @@ pub fn PackedIntSliceEndian(comptime Int: type, comptime endian: Endian) type {
         bit_offset: u3,
         len: usize,
 
+        /// The integer type of the packed slice.
+        pub const Child = Int;
+
         /// Calculates the number of bytes required to store a desired count
         /// of `Int`s.
         pub fn bytesRequired(int_count: usize) usize {

--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -208,6 +208,9 @@ pub fn PackedIntArrayEndian(comptime Int: type, comptime endian: Endian, comptim
         /// The number of elements in the packed array.
         comptime len: usize = int_count,
 
+        /// The integer type of the packed array.
+        pub const Child = Int;
+
         /// Initialize a packed array using an unpacked array
         /// or, more likely, an array literal.
         pub fn init(ints: [int_count]Int) Self {


### PR DESCRIPTION
I have some code that needs to deserialize into a `std.PackedIntArray` and a `std.PackedIntSlice`, but that's currently not possible to do when you only have the type returned by either functions (at least, I can't see any obvious way to do so).

Just exposing the `Int` parameter is enough to let me deserialize properly though. I'd be able to write something like this:

```zig
// Assume Value is some std.PackedIntArray...

fn visitSeq(allocator: ?std.mem.Allocator, seq: anytype) !Value {
    var array = Value.initAllTo(0);

    if (array.len == 0) {
        return array;
    }

    var i: usize = 0;
    while (i < array.len) : (i += 1) {
        if (try seq.nextElement(allocator, Value.Child)) |value| { // can't call this without PR.
            array.set(i, value);
        } else {
            // End of sequence was reached early.
            return error.InvalidLength;
        }
    }

    // Expected end of sequence, but found an element.
    if ((try seq.nextElement(allocator, Value.Child)) != null) { // can't call this without PR.
        return error.InvalidLength;
    }

    return array;
}
```

P.S. I don't mind changing `Child` to something else if you'd prefer. idk what the convention is anymore.