### PR TITLE
std.Target.ObjectFormat: specify dxcontainer file ext

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -626,7 +626,7 @@ pub const Target = struct {
                 .raw => ".bin",
                 .plan9 => plan9Ext(cpu_arch),
                 .nvptx => ".ptx",
-                .dxcontainer => @panic("TODO what's the extension for these?"),
+                .dxcontainer => ".dxil",
             };
         }
 


### PR DESCRIPTION
Earlier in https://github.com/ziglang/zig/blob/cf822c6ddd7e56b248ab217d38907aad38935b2f/lib/std/zig.zig#L198 I saw we already specify a file extension there so at least for now this is probably better than before. It's probably the same file extension as there.