### PR TITLE
Add support for -undefined error

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2073,6 +2073,8 @@ fn buildOutputType(
                     }
                     if (mem.eql(u8, "dynamic_lookup", linker_args.items[i])) {
                         linker_allow_shlib_undefined = true;
+                    } else if (mem.eql(u8, "error", linker_args.items[i])) {
+                        linker_allow_shlib_undefined = false;
                     } else {
                         fatal("unsupported -undefined option '{s}'", .{linker_args.items[i]});
                     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1703,6 +1703,8 @@ fn buildOutputType(
                     .undefined => {
                         if (mem.eql(u8, "dynamic_lookup", it.only_arg)) {
                             linker_allow_shlib_undefined = true;
+                        } else if (mem.eql(u8, "error", it.only_arg)) {
+                            linker_allow_shlib_undefined = false;
                         } else {
                             fatal("unsupported -undefined option '{s}'", .{it.only_arg});
                         }


### PR DESCRIPTION
Adds support for `-undefined error` in addition to `-undefined dynamic_lookup` added in #13991. 

`error` is the default behavior: fail of an undefined symbol is referenced. An explicit `-undefined error` is useful to reverse a previous `-undefined dynamic_lookup` on the command line (e.g.., in some set of base flags that are being appended to).

Fixes #14046
