### PR TITLE
Fix caret location of `@panic` and `@errorReturnTrace()` when using tabs

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1128,7 +1128,10 @@ fn printLineFromFileAnyOs(out_stream: anytype, line_info: LineInfo) !void {
 
         for (slice) |byte| {
             if (line == line_info.line) {
-                try out_stream.writeByte(byte);
+                switch (byte) {
+                    '\t' => try out_stream.writeByte(' '),
+                    else => try out_stream.writeByte(byte),
+                }
                 if (byte == '\n') {
                     return;
                 }


### PR DESCRIPTION
Fixes #13020 by replacing tabs with spaces when printing a line.

The examples from #13020 now produce the expected behaviour:

`@panic`:
```
thread 28938 panic: 
/home/mint/Desktop/test.zig:2:2: 0x20b5f3 in main (test)
 @panic("");
 ^
 ```
 `@errorReturnTrace()`:
 ```
 error: Trace: 
[...]
/home/mint/Desktop/test.zig:4:6: 0x20d759 in someFunction (test)
 _ = try std.math.mul(u32, std.math.maxInt(u32), 2);
     ^
```

I would have added a test case for this, but that's impossible because the CI runs `zig fmt --check` on behaviour tests.