### PR TITLE
remove memset calls when setting to undefined in unsafe modes

### DIFF
--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -5976,6 +5976,7 @@ fn airAtomicStore(self: *Self, inst: Air.Inst.Index, order: std.builtin.AtomicOr
 }
 
 fn airMemset(self: *Self, inst: Air.Inst.Index) !void {
+    // TODO: remove @memset(ptr, undefined, size) calls
     _ = inst;
     return self.fail("TODO implement airMemset for {}", .{self.target.cpu.arch});
 }

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -5922,6 +5922,7 @@ fn airAtomicStore(self: *Self, inst: Air.Inst.Index, order: std.builtin.AtomicOr
 }
 
 fn airMemset(self: *Self, inst: Air.Inst.Index) !void {
+    // TODO: remove @memset(ptr, undefined, size) calls
     _ = inst;
     return self.fail("TODO implement airMemset for {}", .{self.target.cpu.arch});
 }

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -2416,6 +2416,7 @@ fn airAtomicStore(self: *Self, inst: Air.Inst.Index, order: std.builtin.AtomicOr
 }
 
 fn airMemset(self: *Self, inst: Air.Inst.Index) !void {
+    // TODO: remove @memset(ptr, undefined, size) calls
     _ = inst;
     return self.fail("TODO implement airMemset for {}", .{self.target.cpu.arch});
 }

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -1765,6 +1765,7 @@ fn airLoop(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airMemset(self: *Self, inst: Air.Inst.Index) !void {
+    // TODO: remove @memset(ptr, undefined, size) calls
     const pl_op = self.air.instructions.items(.data)[inst].pl_op;
     const extra = self.air.extraData(Air.Bin, pl_op.payload);
 

--- a/test/cases/compile_errors/memset_undefined.zig
+++ b/test/cases/compile_errors/memset_undefined.zig
@@ -1,0 +1,17 @@
+export fn foo() void {
+    var x: u32 = 10;
+    const ptr: *volatile u32 = &x;
+    @memset(@ptrCast([*]volatile u8, ptr), undefined, 4);
+}
+
+export fn bar() void {
+    var x: u32 = 10;
+    const y: u32 = undefined;
+    const ptr: *volatile u32 = &x;
+    @memset(@ptrCast([*]volatile u8, ptr), y, 4);
+}
+
+// error
+//
+// :4:5: error: storing an undefined value to a volatile pointer is not allowed
+// :11:5: error: storing an undefined value to a volatile pointer is not allowed


### PR DESCRIPTION
I'm not too familiar with the codegen pipeline yet, so I'm not sure if this should (can?) be moved further up into AstGen. 

closes #14094