### PR TITLE
std: Handle field struct defaults in std.mem.zeroInit

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -446,30 +446,32 @@ pub fn zeroInit(comptime T: type, init: anytype) T {
                     var value: T = undefined;
 
                     inline for (struct_info.fields) |field, i| {
-                        if (!field.is_comptime) {
-                            if (init_info.is_tuple and init_info.fields.len > i) {
-                                @field(value, struct_info.fields[i].name) = @field(init, init_info.fields[i].name);
-                            } else if (@hasField(@TypeOf(init), field.name)) {
-                                switch (@typeInfo(field.type)) {
-                                    .Struct => {
-                                        @field(value, field.name) = zeroInit(field.type, @field(init, field.name));
-                                    },
-                                    else => {
-                                        @field(value, field.name) = @field(init, field.name);
-                                    },
-                                }
-                            } else if (field.default_value) |default_value_ptr| {
-                                const default_value = @ptrCast(*align(1) const field.type, default_value_ptr).*;
-                                @field(value, field.name) = default_value;
-                            } else {
-                                switch (@typeInfo(field.type)) {
-                                    .Struct => {
-                                        @field(value, field.name) = std.mem.zeroInit(field.type, .{});
-                                    },
-                                    else => {
-                                        @field(value, field.name) = std.mem.zeroes(@TypeOf(@field(value, field.name)));
-                                    },
-                                }
+                        if (field.is_comptime) {
+                            continue;
+                        }
+
+                        if (init_info.is_tuple and init_info.fields.len > i) {
+                            @field(value, field.name) = @field(init, init_info.fields[i].name);
+                        } else if (@hasField(@TypeOf(init), field.name)) {
+                            switch (@typeInfo(field.type)) {
+                                .Struct => {
+                                    @field(value, field.name) = zeroInit(field.type, @field(init, field.name));
+                                },
+                                else => {
+                                    @field(value, field.name) = @field(init, field.name);
+                                },
+                            }
+                        } else if (field.default_value) |default_value_ptr| {
+                            const default_value = @ptrCast(*align(1) const field.type, default_value_ptr).*;
+                            @field(value, field.name) = default_value;
+                        } else {
+                            switch (@typeInfo(field.type)) {
+                                .Struct => {
+                                    @field(value, field.name) = std.mem.zeroInit(field.type, .{});
+                                },
+                                else => {
+                                    @field(value, field.name) = std.mem.zeroes(@TypeOf(@field(value, field.name)));
+                                },
                             }
                         }
                     }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -456,7 +456,7 @@ pub fn zeroInit(comptime T: type, init: anytype) T {
                                     },
                                     else => {
                                         @field(value, field.name) = @field(init, field.name);
-                                    }
+                                    },
                                 }
                             } else if (field.default_value) |default_value_ptr| {
                                 const default_value = @ptrCast(*align(1) const field.type, default_value_ptr).*;
@@ -468,7 +468,7 @@ pub fn zeroInit(comptime T: type, init: anytype) T {
                                     },
                                     else => {
                                         @field(value, field.name) = std.mem.zeroes(@TypeOf(@field(value, field.name)));
-                                    }
+                                    },
                                 }
                             }
                         }
@@ -558,7 +558,7 @@ test "zeroInit" {
     const baz1 = zeroInit(Baz, .{});
     try testing.expectEqual(Baz{}, baz1);
 
-    const baz2 = zeroInit(Baz, .{.foo = "zab"});
+    const baz2 = zeroInit(Baz, .{ .foo = "zab" });
     try testing.expectEqualSlices(u8, "zab", baz2.foo);
 
     const NestedBaz = struct {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -431,36 +431,46 @@ pub fn zeroInit(comptime T: type, init: anytype) T {
         .Struct => |struct_info| {
             switch (@typeInfo(Init)) {
                 .Struct => |init_info| {
-                    var value = std.mem.zeroes(T);
-
-                    inline for (struct_info.fields) |field| {
-                        if (field.default_value) |default_value_ptr| {
-                            const default_value = @ptrCast(*align(1) const field.type, default_value_ptr).*;
-                            @field(value, field.name) = default_value;
-                        } else if (@typeInfo(field.type) == .Struct) {
-                            @field(value, field.name) = zeroInit(field.type, .{});
-                        }
-                    }
-
                     if (init_info.is_tuple) {
-                        inline for (init_info.fields) |field, i| {
-                            @field(value, struct_info.fields[i].name) = @field(init, field.name);
+                        if (init_info.fields.len > struct_info.fields.len) {
+                            @compileError("Tuple initializer has more elments than there are fields in `" ++ @typeName(T) ++ "`");
                         }
-                        return value;
+                    } else {
+                        inline for (init_info.fields) |field| {
+                            if (!@hasField(T, field.name)) {
+                                @compileError("Encountered an initializer for `" ++ field.name ++ "`, but it is not a field of " ++ @typeName(T));
+                            }
+                        }
                     }
 
-                    inline for (init_info.fields) |field| {
-                        if (!@hasField(T, field.name)) {
-                            @compileError("Encountered an initializer for `" ++ field.name ++ "`, but it is not a field of " ++ @typeName(T));
-                        }
+                    var value: T = undefined;
 
-                        switch (@typeInfo(field.type)) {
-                            .Struct => {
-                                @field(value, field.name) = zeroInit(field.type, @field(init, field.name));
-                            },
-                            else => {
-                                @field(value, field.name) = @field(init, field.name);
-                            },
+                    inline for (struct_info.fields) |field, i| {
+                        if (!field.is_comptime) {
+                            if (init_info.is_tuple and init_info.fields.len > i) {
+                                @field(value, struct_info.fields[i].name) = @field(init, init_info.fields[i].name);
+                            } else if (@hasField(@TypeOf(init), field.name)) {
+                                switch (@typeInfo(field.type)) {
+                                    .Struct => {
+                                        @field(value, field.name) = zeroInit(field.type, @field(init, field.name));
+                                    },
+                                    else => {
+                                        @field(value, field.name) = @field(init, field.name);
+                                    }
+                                }
+                            } else if (field.default_value) |default_value_ptr| {
+                                const default_value = @ptrCast(*align(1) const field.type, default_value_ptr).*;
+                                @field(value, field.name) = default_value;
+                            } else {
+                                switch (@typeInfo(field.type)) {
+                                    .Struct => {
+                                        @field(value, field.name) = std.mem.zeroInit(field.type, .{});
+                                    },
+                                    else => {
+                                        @field(value, field.name) = std.mem.zeroes(@TypeOf(@field(value, field.name)));
+                                    }
+                                }
+                            }
                         }
                     }
 


### PR DESCRIPTION
Fixes #14115

First commit is the minimum change to fix.

Second commit changes the implementation to initialize each field of the struct exactly once.