### PR TITLE
x86_64: remove extra whitespace

### DIFF
--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -1593,41 +1593,41 @@ inline fn getOpCode(tag: Tag, enc: Encoding, is_one_byte: bool) OpCode {
             .jnae      => if (is_one_byte) OpCode.init(&.{0x72}) else OpCode.init(&.{0x0f,0x82}),
 
             .jnb,
-            .jnc, 
+            .jnc,
             .jae       => if (is_one_byte) OpCode.init(&.{0x73}) else OpCode.init(&.{0x0f,0x83}),
 
-            .je, 
+            .je,
             .jz        => if (is_one_byte) OpCode.init(&.{0x74}) else OpCode.init(&.{0x0f,0x84}),
 
-            .jne, 
+            .jne,
             .jnz       => if (is_one_byte) OpCode.init(&.{0x75}) else OpCode.init(&.{0x0f,0x85}),
 
-            .jna, 
+            .jna,
             .jbe       => if (is_one_byte) OpCode.init(&.{0x76}) else OpCode.init(&.{0x0f,0x86}),
 
-            .jnbe, 
+            .jnbe,
             .ja        => if (is_one_byte) OpCode.init(&.{0x77}) else OpCode.init(&.{0x0f,0x87}),
 
             .js        => if (is_one_byte) OpCode.init(&.{0x78}) else OpCode.init(&.{0x0f,0x88}),
 
             .jns       => if (is_one_byte) OpCode.init(&.{0x79}) else OpCode.init(&.{0x0f,0x89}),
 
-            .jpe, 
+            .jpe,
             .jp        => if (is_one_byte) OpCode.init(&.{0x7a}) else OpCode.init(&.{0x0f,0x8a}),
 
-            .jpo, 
+            .jpo,
             .jnp       => if (is_one_byte) OpCode.init(&.{0x7b}) else OpCode.init(&.{0x0f,0x8b}),
 
-            .jnge, 
+            .jnge,
             .jl        => if (is_one_byte) OpCode.init(&.{0x7c}) else OpCode.init(&.{0x0f,0x8c}),
 
-            .jge, 
+            .jge,
             .jnl       => if (is_one_byte) OpCode.init(&.{0x7d}) else OpCode.init(&.{0x0f,0x8d}),
 
-            .jle, 
+            .jle,
             .jng       => if (is_one_byte) OpCode.init(&.{0x7e}) else OpCode.init(&.{0x0f,0x8e}),
 
-            .jg, 
+            .jg,
             .jnle      => if (is_one_byte) OpCode.init(&.{0x7f}) else OpCode.init(&.{0x0f,0x8f}),
 
             else       => unreachable,
@@ -1667,10 +1667,10 @@ inline fn getOpCode(tag: Tag, enc: Encoding, is_one_byte: bool) OpCode {
             .setp,
             .setpe      =>                  OpCode.init(&.{0x0f,0x9a}),
 
-            .setnp, 
+            .setnp,
             .setpo      =>                  OpCode.init(&.{0x0f,0x9b}),
 
-            .setl, 
+            .setl,
             .setnge     =>                  OpCode.init(&.{0x0f,0x9c}),
 
             .setnl,
@@ -1778,7 +1778,7 @@ inline fn getOpCode(tag: Tag, enc: Encoding, is_one_byte: bool) OpCode {
             .cmovbe,
             .cmovna,  =>                  OpCode.init(&.{0x0f,0x46}),
 
-            .cmove, 
+            .cmove,
             .cmovz,   =>                  OpCode.init(&.{0x0f,0x44}),
 
             .cmovg,
@@ -1840,7 +1840,7 @@ inline fn getOpCode(tag: Tag, enc: Encoding, is_one_byte: bool) OpCode {
             else => unreachable,
         },
         .vm => return switch (tag) {
-            .vmovsd, 
+            .vmovsd,
             .vmovss   => OpCode.init(&.{0x10}),
             .vucomisd,
             .vucomiss => OpCode.init(&.{0x2e}),


### PR DESCRIPTION
Remove extra whitespace at the end of a line in Emit.zig, in regions where zig fmt is off.