### PR TITLE
Implement some more environment functions for WASI.

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -110,25 +110,31 @@ pub fn getSelfDebugInfo() !*DebugInfo {
 }
 
 pub fn detectTTYConfig(file: std.fs.File) TTY.Config {
-    if (process.hasEnvVarConstant("ZIG_DEBUG_COLOR")) {
-        return .escape_codes;
-    } else if (process.hasEnvVarConstant("NO_COLOR")) {
+    if (builtin.os.tag == .wasi) {
+        // Per https://github.com/WebAssembly/WASI/issues/162 ANSI codes
+        // aren't currently supported.
         return .no_color;
     } else {
-        if (file.supportsAnsiEscapeCodes()) {
+        if (process.hasEnvVarConstant("ZIG_DEBUG_COLOR")) {
             return .escape_codes;
-        } else if (native_os == .windows and file.isTty()) {
-            var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
-            if (windows.kernel32.GetConsoleScreenBufferInfo(file.handle, &info) != windows.TRUE) {
-                // TODO: Should this return an error instead?
+        } else if (process.hasEnvVarConstant("NO_COLOR")) {
+            return .no_color;
+        } else {
+            if (file.supportsAnsiEscapeCodes()) {
+                return .escape_codes;
+            } else if (native_os == .windows and file.isTty()) {
+                var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
+                if (windows.kernel32.GetConsoleScreenBufferInfo(file.handle, &info) != windows.TRUE) {
+                    // TODO: Should this return an error instead?
+                    return .no_color;
+                }
+                return .{ .windows_api = .{
+                    .handle = file.handle,
+                    .reset_attributes = info.wAttributes,
+                } };
+            } else {
                 return .no_color;
             }
-            return .{ .windows_api = .{
-                .handle = file.handle,
-                .reset_attributes = info.wAttributes,
-            } };
-        } else {
-            return .no_color;
         }
     }
 }

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -372,10 +372,8 @@ pub fn getEnvVarOwned(allocator: Allocator, key: []const u8) GetEnvVarOwnedError
     } else if (builtin.os.tag == .wasi and !builtin.link_libc) {
         var envmap = getEnvMap(allocator) catch return error.OutOfMemory;
         defer envmap.deinit();
-        const val = envmap.getPtr(key) orelse return error.EnvironmentVariableNotFound;
-        const result = try allocator.alloc(u8, val.len);
-        mem.copy(u8, result, val.*);
-        return result;
+        const val = envmap.get(key) orelse return error.EnvironmentVariableNotFound;
+        return allocator.dupe(u8, val);
     } else {
         const result = os.getenv(key) orelse return error.EnvironmentVariableNotFound;
         return allocator.dupe(u8, result);

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -384,6 +384,8 @@ pub fn hasEnvVarConstant(comptime key: []const u8) bool {
     if (builtin.os.tag == .windows) {
         const key_w = comptime std.unicode.utf8ToUtf16LeStringLiteral(key);
         return std.os.getenvW(key_w) != null;
+    } else if (builtin.os.tag == .wasi and !builtin.link_libc) {
+        @compileError("hasEnvVarConstant is not supported for WASI without libc");
     } else {
         return os.getenv(key) != null;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -852,7 +852,7 @@ fn buildOutputType(
     // if it exists, default the color setting to .off
     // explicit --color arguments will still override this setting.
     // Disable color on WASI per https://github.com/WebAssembly/WASI/issues/162
-    color = if (builtin.os.tag == .wasi || std.process.hasEnvVarConstant("NO_COLOR")) .off else .auto;
+    color = if (builtin.os.tag == .wasi or std.process.hasEnvVarConstant("NO_COLOR")) .off else .auto;
 
     switch (arg_mode) {
         .build, .translate_c, .zig_test, .run => {

--- a/src/main.zig
+++ b/src/main.zig
@@ -672,8 +672,8 @@ fn buildOutputType(
     var no_builtin = false;
     var watch = false;
     var debug_compile_errors = false;
-    var verbose_link = (builtin.os.tag == .wasi and !builtin.link_libc) and std.process.hasEnvVarConstant("ZIG_VERBOSE_LINK");
-    var verbose_cc = (builtin.os.tag == .wasi and !builtin.link_libc) and std.process.hasEnvVarConstant("ZIG_VERBOSE_CC");
+    var verbose_link = (builtin.os.tag != .wasi or builtin.link_libc) and std.process.hasEnvVarConstant("ZIG_VERBOSE_LINK");
+    var verbose_cc = (builtin.os.tag != .wasi or builtin.link_libc) and std.process.hasEnvVarConstant("ZIG_VERBOSE_CC");
     var verbose_air = false;
     var verbose_llvm_ir = false;
     var verbose_cimport = false;

--- a/src/main.zig
+++ b/src/main.zig
@@ -672,8 +672,8 @@ fn buildOutputType(
     var no_builtin = false;
     var watch = false;
     var debug_compile_errors = false;
-    var verbose_link = std.process.hasEnvVarConstant("ZIG_VERBOSE_LINK");
-    var verbose_cc = std.process.hasEnvVarConstant("ZIG_VERBOSE_CC");
+    var verbose_link = (builtin.os.tag == .wasi and !builtin.link_libc) and std.process.hasEnvVarConstant("ZIG_VERBOSE_LINK");
+    var verbose_cc = (builtin.os.tag == .wasi and !builtin.link_libc) and std.process.hasEnvVarConstant("ZIG_VERBOSE_CC");
     var verbose_air = false;
     var verbose_llvm_ir = false;
     var verbose_cimport = false;
@@ -851,7 +851,8 @@ fn buildOutputType(
     // before arg parsing, check for the NO_COLOR environment variable
     // if it exists, default the color setting to .off
     // explicit --color arguments will still override this setting.
-    color = if (std.process.hasEnvVarConstant("NO_COLOR")) .off else .auto;
+    // Disable color on WASI per https://github.com/WebAssembly/WASI/issues/162
+    color = if (builtin.os.tag == .wasi || std.process.hasEnvVarConstant("NO_COLOR")) .off else .auto;
 
     switch (arg_mode) {
         .build, .translate_c, .zig_test, .run => {

--- a/src/main.zig
+++ b/src/main.zig
@@ -629,6 +629,10 @@ const Emit = union(enum) {
 };
 
 fn optionalStringEnvVar(arena: Allocator, name: []const u8) !?[]const u8 {
+    // Env vars aren't used in the bootstrap stage.
+    if (build_options.only_c) {
+        return null;
+    }
     if (std.process.getEnvVarOwned(arena, name)) |value| {
         return value;
     } else |err| switch (err) {


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/14135

Due to the limitations of the functionality that WASI currently exposes, this isn't great from a performance perspective, but it probably doesn't matter that much and it's definitely better than just returning EnvVar not found.