### PR TITLE
ChildProcess: fix false positives in windowsCreateProcessSupportsExtension

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -1357,6 +1357,7 @@ fn windowsCreateProcess(app_name: [*:0]u16, cmd_line: [*:0]u16, envp_ptr: ?[*]u1
 
 /// Case-insenstive UTF-16 lookup
 fn windowsCreateProcessSupportsExtension(ext: []const u16) bool {
+    if (ext.len != 4) return false;
     const State = enum {
         start,
         dot,
@@ -1411,6 +1412,11 @@ fn windowsCreateProcessSupportsExtension(ext: []const u16) bool {
         },
     };
     return false;
+}
+
+test "windowsCreateProcessSupportsExtension" {
+    try std.testing.expect(windowsCreateProcessSupportsExtension(&[_]u16{ '.', 'e', 'X', 'e' }));
+    try std.testing.expect(!windowsCreateProcessSupportsExtension(&[_]u16{ '.', 'e', 'X', 'e', 'c' }));
 }
 
 /// Caller must dealloc.


### PR DESCRIPTION
Previously, the implementation would essentially check `startsWith` instead of `eql` (e.g. it would return true for `.exec` because it erroneously 'matched' `.exe`).

This bug had no real negative effects, the `windowsCreateProcessSupportsExtension` function is just used as an optimization to avoid evaluating extensions that we know we will fail to execute.

Follow up to #13993