### PR TITLE
stage3 macos: enable -headerpad_max_install_names

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -532,6 +532,10 @@ fn addCmakeCfgOptionsToExe(
     exe: *std.build.LibExeObjStep,
     use_zig_libcxx: bool,
 ) !void {
+    if (exe.target.isDarwin()) {
+        // useful for package maintainers
+        exe.headerpad_max_install_names = true;
+    }
     exe.addObjectFile(fs.path.join(b.allocator, &[_][]const u8{
         cfg.cmake_binary_dir,
         "zigcpp",


### PR DESCRIPTION
This pads the install names area in final (stage3) zig executable on macos. The executable size grows by 4096 bytes, or roughly 0.002% .

closes #13388