### PR TITLE
behavior: add test for #8277

### DIFF
--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -74,6 +74,7 @@ test {
     _ = @import("behavior/bugs/7047.zig");
     _ = @import("behavior/bugs/7187.zig");
     _ = @import("behavior/bugs/7325.zig");
+    _ = @import("behavior/bugs/8277.zig");
     _ = @import("behavior/bugs/8646.zig");
     _ = @import("behavior/bugs/9584.zig");
     _ = @import("behavior/bugs/10138.zig");

--- a/test/behavior/bugs/8277.zig
+++ b/test/behavior/bugs/8277.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+test "@sizeOf reified union zero-size payload fields" {
+    comptime {
+        try std.testing.expect(0 == @sizeOf(@Type(@typeInfo(union {}))));
+        try std.testing.expect(0 == @sizeOf(@Type(@typeInfo(union { a: void }))));
+        if (builtin.mode == .Debug or builtin.mode == .ReleaseSafe) {
+            try std.testing.expect(1 == @sizeOf(@Type(@typeInfo(union { a: void, b: void }))));
+            try std.testing.expect(1 == @sizeOf(@Type(@typeInfo(union { a: void, b: void, c: void }))));
+        } else {
+            try std.testing.expect(0 == @sizeOf(@Type(@typeInfo(union { a: void, b: void }))));
+            try std.testing.expect(0 == @sizeOf(@Type(@typeInfo(union { a: void, b: void, c: void }))));
+        }
+    }
+}


### PR DESCRIPTION
Test `@sizeOf` reified unions with zero-size payload fields.

closes #8277