### PR TITLE
Fix another LockViolation case on Windows

### DIFF
--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -830,6 +830,8 @@ pub const Manifest = struct {
     /// If `want_shared_lock` is true, this function automatically downgrades the
     /// lock from exclusive to shared.
     pub fn writeManifest(self: *Manifest) !void {
+        assert(self.have_exclusive_lock);
+
         const manifest_file = self.manifest_file.?;
         if (self.manifest_dirty) {
             self.manifest_dirty = false;

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -1035,7 +1035,7 @@ test "cache file and then recall it" {
             try testing.expect(try ch.hit());
             digest2 = ch.final();
 
-            try ch.writeManifest();
+            try testing.expectEqual(false, ch.have_exclusive_lock);
         }
 
         try testing.expectEqual(digest1, digest2);

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -1163,7 +1163,7 @@ test "no file inputs" {
 
         try testing.expect(try man.hit());
         digest2 = man.final();
-        try man.writeManifest();
+        try testing.expectEqual(false, man.have_exclusive_lock);
     }
 
     try testing.expectEqual(digest1, digest2);
@@ -1226,7 +1226,7 @@ test "Manifest with files added after initial hash work" {
             try testing.expect(try ch.hit());
             digest2 = ch.final();
 
-            try ch.writeManifest();
+            try testing.expectEqual(false, ch.have_exclusive_lock);
         }
         try testing.expect(mem.eql(u8, &digest1, &digest2));
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3663,13 +3663,15 @@ pub fn cImport(comp: *Compilation, c_src: []const u8) !CImportResult {
         break :digest digest;
     } else man.final();
 
-    // Write the updated manifest. This is a no-op if the manifest is not dirty. Note that it is
-    // possible we had a hit and the manifest is dirty, for example if the file mtime changed but
-    // the contents were the same, we hit the cache but the manifest is dirty and we need to update
-    // it to prevent doing a full file content comparison the next time around.
-    man.writeManifest() catch |err| {
-        log.warn("failed to write cache manifest for C import: {s}", .{@errorName(err)});
-    };
+    if (man.have_exclusive_lock) {
+        // Write the updated manifest. This is a no-op if the manifest is not dirty. Note that it is
+        // possible we had a hit and the manifest is dirty, for example if the file mtime changed but
+        // the contents were the same, we hit the cache but the manifest is dirty and we need to update
+        // it to prevent doing a full file content comparison the next time around.
+        man.writeManifest() catch |err| {
+            log.warn("failed to write cache manifest for C import: {s}", .{@errorName(err)});
+        };
+    }
 
     const out_zig_path = try comp.local_cache_directory.join(comp.gpa, &[_][]const u8{
         "o", &digest, cimport_zig_basename,

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4132,13 +4132,15 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.P
         break :blk digest;
     };
 
-    // Write the updated manifest. This is a no-op if the manifest is not dirty. Note that it is
-    // possible we had a hit and the manifest is dirty, for example if the file mtime changed but
-    // the contents were the same, we hit the cache but the manifest is dirty and we need to update
-    // it to prevent doing a full file content comparison the next time around.
-    man.writeManifest() catch |err| {
-        log.warn("failed to write cache manifest when compiling '{s}': {s}", .{ c_object.src.src_path, @errorName(err) });
-    };
+    if (man.have_exclusive_lock) {
+        // Write the updated manifest. This is a no-op if the manifest is not dirty. Note that it is
+        // possible we had a hit and the manifest is dirty, for example if the file mtime changed but
+        // the contents were the same, we hit the cache but the manifest is dirty and we need to update
+        // it to prevent doing a full file content comparison the next time around.
+        man.writeManifest() catch |err| {
+            log.warn("failed to write cache manifest when compiling '{s}': {s}", .{ c_object.src.src_path, @errorName(err) });
+        };
+    }
 
     const o_basename = try std.fmt.allocPrint(arena, "{s}{s}", .{ o_basename_noext, o_ext });
 


### PR DESCRIPTION
https://github.com/ziglang/zig/pull/13864 reverted some changes which were causing breakage if the same c file was compiled twice as part of the same compilation. This PR makes the fixes as suggested by this comment there: https://github.com/ziglang/zig/pull/13864#issuecomment-1345368976 

Changes:
- Add an assert that an exclusive lock is help to `writeManifest`, to catch this error when it happens.
- Only call `writeManifest` if an exclusive lock is held.
- Update tests to assert that a cache hit results in holding a shared lock, instead of writing the manifest

Reproduction steps for the `LockViolation`:

```
// build.zig
const std = @import("std");
const Builder = std.build.Builder;

pub fn build(b: *Builder) void {
    const target = b.standardTargetOptions(.{});
    const mode = b.standardReleaseOptions();

    const exe = b.addExecutable("template", null);
    exe.addCSourceFile("main.c", &.{});
    exe.linkLibC();
    exe.setTarget(target);
    exe.setBuildMode(mode);
    exe.install();
}
```

```
// main.c
#include <stdio.h>

int main(void)
{
    int x = 12;
    x = (x % 2 == 0) ? x / 2 : 3 * x + 1;

    // Uncomment to cause compilation failure
    //x = (x % 2 == 0) ? x = x / 2 : x = 3 * x + 1;
    return 0;
}
```

1. `zig build`. This compiles normally.
2. Uncomment the failing line in `main.c`
3. `zig build`. This compile fails due to the C compilation error.
4. Re-comment the failing line in `main.c`
5. `zig build`. This compiles successfully, but triggers the `LockViolation`.

Trace: 
![lock_violation_1](https://user-images.githubusercontent.com/74892/210272885-be0b5a56-25b5-4b62-bba8-f6b7e9c7f217.PNG)

