### PR TITLE
autodoc: show binding in lowercase

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -633,7 +633,7 @@
         <div class="wrap">
           <section class="docs">
             <div style="position: relative">
-              <span id="searchPlaceholder"><kbd>S</kbd> to search, <kbd>?</kbd> for more options</span>
+              <span id="searchPlaceholder"><kbd>s</kbd> to search, <kbd>?</kbd> for more options</span>
               <input type="search" class="search" id="search" autocomplete="off" spellcheck="false" disabled>
             </div>
             <p id="status">Loading...</p>


### PR DESCRIPTION
`<S-s>` is not bound and shortcuts popup already use lowercase.