### PR TITLE
Don't initialize thread-local storage for single-threaded builds

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -437,20 +437,22 @@ fn posixCallMainAndExit() callconv(.C) noreturn {
             std.os.linux.pie.relocate(phdrs);
         }
 
-        // ARMv6 targets (and earlier) have no support for TLS in hardware.
-        // FIXME: Elide the check for targets >= ARMv7 when the target feature API
-        // becomes less verbose (and more usable).
-        if (comptime native_arch.isARM()) {
-            if (at_hwcap & std.os.linux.HWCAP.TLS == 0) {
-                // FIXME: Make __aeabi_read_tp call the kernel helper kuser_get_tls
-                // For the time being use a simple abort instead of a @panic call to
-                // keep the binary bloat under control.
-                std.os.abort();
+        if (!builtin.single_threaded) {
+            // ARMv6 targets (and earlier) have no support for TLS in hardware.
+            // FIXME: Elide the check for targets >= ARMv7 when the target feature API
+            // becomes less verbose (and more usable).
+            if (comptime native_arch.isARM()) {
+                if (at_hwcap & std.os.linux.HWCAP.TLS == 0) {
+                    // FIXME: Make __aeabi_read_tp call the kernel helper kuser_get_tls
+                    // For the time being use a simple abort instead of a @panic call to
+                    // keep the binary bloat under control.
+                    std.os.abort();
+                }
             }
-        }
 
-        // Initialize the TLS area.
-        std.os.linux.tls.initStaticTLS(phdrs);
+            // Initialize the TLS area.
+            std.os.linux.tls.initStaticTLS(phdrs);
+        }
 
         // The way Linux executables represent stack size is via the PT_GNU_STACK
         // program header. However the kernel does not recognize it; it always gives 8 MiB.


### PR DESCRIPTION
Being able to disable the TLS initialization has two benefits:

 * Most importantly it will make it possible to build Zig programs for Linux platforms that lack hardware TLS support (e.g. old ARM)
 * It shaves off a bunch of bytes* for single-threaded programs that don't need TLS, which I assume is most of them not counting Dragonfly BSD and its strange syscall requirements. 

(*4608 bytes to 944 for an empty no-op program on x86-64)

~~Currently the draft simply adds an option to not initialize the TLS area. If one goes ahead and uses `threadlocal` variables anyway the program will likely crash on runtime, which is not that great.~~

Ideally the compiler would know if TLS variables are used anywhere and only add the TLS init stuff when actually needed (#2432); this option may be useful until we get there.