### PR TITLE
std: collect all options under one namespace

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1824,10 +1824,9 @@ pub const have_segfault_handling_support = switch (native_os) {
     .freebsd, .openbsd => @hasDecl(os.system, "ucontext_t"),
     else => false,
 };
-pub const enable_segfault_handler: bool = if (@hasDecl(root, "enable_segfault_handler"))
-    root.enable_segfault_handler
-else
-    runtime_safety and have_segfault_handling_support;
+
+const enable_segfault_handler = std.options.enable_segfault_handler;
+pub const default_enable_segfault_handler = runtime_safety and have_segfault_handling_support;
 
 pub fn maybeEnableSegfaultHandler() void {
     if (enable_segfault_handler) {

--- a/lib/std/event/batch.zig
+++ b/lib/std/event/batch.zig
@@ -17,7 +17,7 @@ pub fn Batch(
     comptime async_behavior: enum {
         /// Observe the value of `std.io.is_async` to decide whether `add`
         /// and `wait` will be async functions. Asserts that the jobs do not suspend when
-        /// `std.io.mode == .blocking`. This is a generally safe assumption, and the
+        /// `std.options.io_mode == .blocking`. This is a generally safe assumption, and the
         /// usual recommended option for this parameter.
         auto_async,
 

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2661,15 +2661,15 @@ pub fn cwd() Dir {
     if (builtin.os.tag == .windows) {
         return Dir{ .fd = os.windows.peb().ProcessParameters.CurrentDirectory.Handle };
     } else if (builtin.os.tag == .wasi) {
-        if (@hasDecl(root, "wasi_cwd")) {
-            return root.wasi_cwd();
-        } else {
-            // Expect the first preopen to be current working directory.
-            return .{ .fd = 3 };
-        }
+        return std.options.wasiCwd();
     } else {
         return Dir{ .fd = os.AT.FDCWD };
     }
+}
+
+pub fn defaultWasiCwd() Dir {
+    // Expect the first preopen to be current working directory.
+    return .{ .fd = 3 };
 }
 
 /// Opens a directory at the given path. The directory is a system resource that remains

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -21,7 +21,7 @@ pub const File = struct {
     /// blocking.
     capable_io_mode: io.ModeOverride = io.default_mode,
 
-    /// Furthermore, even when `std.io.mode` is async, it is still sometimes desirable
+    /// Furthermore, even when `std.options.io_mode` is async, it is still sometimes desirable
     /// to perform blocking I/O, although not by default. For example, when printing a
     /// stack trace to stderr. This field tracks both by acting as an overriding I/O mode.
     /// When not building in async I/O mode, the type only has the `.blocking` tag, making

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -19,14 +19,7 @@ pub const Mode = enum {
     evented,
 };
 
-/// The application's chosen I/O mode. This defaults to `Mode.blocking` but can be overridden
-/// by `root.event_loop`.
-pub const mode: Mode = if (@hasDecl(root, "io_mode"))
-    root.io_mode
-else if (@hasDecl(root, "event_loop"))
-    Mode.evented
-else
-    Mode.blocking;
+const mode = std.options.io_mode;
 pub const is_async = mode != .blocking;
 
 /// This is an enum value to use for I/O mode at runtime, since it takes up zero bytes at runtime,

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -525,7 +525,7 @@ const bad_main_ret = "expected return type of main to be 'void', '!void', 'noret
 // and we want fewer call frames in stack traces.
 inline fn initEventLoopAndCallMain() u8 {
     if (std.event.Loop.instance) |loop| {
-        if (!@hasDecl(root, "event_loop")) {
+        if (loop == std.event.Loop.default_instance) {
             loop.init() catch |err| {
                 std.log.err("{s}", .{@errorName(err)});
                 if (@errorReturnTrace()) |trace| {
@@ -554,7 +554,7 @@ inline fn initEventLoopAndCallMain() u8 {
 // because it is working around stage1 compiler bugs.
 inline fn initEventLoopAndCallWinMain() std.os.windows.INT {
     if (std.event.Loop.instance) |loop| {
-        if (!@hasDecl(root, "event_loop")) {
+        if (loop == std.event.Loop.default_instance) {
             loop.init() catch |err| {
                 std.log.err("{s}", .{@errorName(err)});
                 if (@errorReturnTrace()) |trace| {

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -94,10 +94,79 @@ pub const wasm = @import("wasm.zig");
 pub const zig = @import("zig.zig");
 pub const start = @import("start.zig");
 
+const root = @import("root");
+const options_override = if (@hasDecl(root, "std_options")) root.std_options else struct {};
+
+pub const options = struct {
+    pub const enable_segfault_handler: bool = if (@hasDecl(options_override, "enable_segfault_handler"))
+        options_override.enable_segfault_handler
+    else
+        debug.default_enable_segfault_handler;
+
+    /// Function used to implement std.fs.cwd for wasi.
+    pub const wasiCwd: fn () fs.Dir = if (@hasDecl(options_override, "wasiCwd"))
+        options_override.wasiCwd
+    else
+        fs.defaultWasiCwd;
+
+    /// The application's chosen I/O mode.
+    pub const io_mode: io.Mode = if (@hasDecl(options_override, "io_mode"))
+        options_override.io_mode
+    else if (@hasDecl(options_override, "event_loop"))
+        .evented
+    else
+        .blocking;
+
+    pub const event_loop: event.Loop.Instance = if (@hasDecl(options_override, "event_loop"))
+        options_override.event_loop
+    else
+        event.Loop.default_instance;
+
+    pub const event_loop_mode: event.Loop.Mode = if (@hasDecl(options_override, "event_loop_mode"))
+        options_override.event_loop_mode
+    else
+        event.Loop.default_mode;
+
+    /// The current log level.
+    pub const log_level: log.Level = if (@hasDecl(options_override, "log_level"))
+        options_override.log_level
+    else
+        log.default_level;
+
+    pub const log_scope_levels: []const log.ScopeLevel = if (@hasDecl(options_override, "log_scope_levels"))
+        options_override.log_scope_levels
+    else
+        &.{};
+
+    pub const logFn: fn (
+        comptime message_level: log.Level,
+        comptime scope: @TypeOf(.enum_literal),
+        comptime format: []const u8,
+        args: anytype,
+    ) void = if (@hasDecl(options_override, "logFn"))
+        options_override.logFn
+    else
+        log.defaultLog;
+
+    pub const cryptoRandomSeed: fn (buffer: []u8) void = if (@hasDecl(options_override, "cryptoRandomSeed"))
+        options_override.cryptoRandomSeed
+    else
+        @import("crypto/tlcsprng.zig").defaultRandomSeed;
+
+    pub const crypto_always_getrandom: bool = if (@hasDecl(options_override, "crypto_always_getrandom"))
+        options_override.crypto_always_getrandom
+    else
+        false;
+};
+
 // This forces the start.zig file to be imported, and the comptime logic inside that
 // file decides whether to export any appropriate start symbols, and call main.
 comptime {
     _ = start;
+
+    for (@typeInfo(options_override).Struct.decls) |decl| {
+        if (!@hasDecl(options, decl.name)) @compileError("no option named " ++ decl.name);
+    }
 }
 
 test {

--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -2,7 +2,10 @@ const std = @import("std");
 const io = std.io;
 const builtin = @import("builtin");
 
-pub const io_mode: io.Mode = builtin.test_io_mode;
+pub const std_options = struct {
+    pub const io_mode: io.Mode = builtin.test_io_mode;
+    pub const logFn = log;
+};
 
 var log_err_count: usize = 0;
 
@@ -45,7 +48,7 @@ pub fn main() void {
         if (!have_tty) {
             std.debug.print("{d}/{d} {s}... ", .{ i + 1, test_fn_list.len, test_fn.name });
         }
-        const result = if (test_fn.async_frame_size) |size| switch (io_mode) {
+        const result = if (test_fn.async_frame_size) |size| switch (std.options.io_mode) {
             .evented => blk: {
                 if (async_frame_buffer.len < size) {
                     std.heap.page_allocator.free(async_frame_buffer);

--- a/src/crash_report.zig
+++ b/src/crash_report.zig
@@ -13,12 +13,10 @@ const Decl = Module.Decl;
 
 pub const is_enabled = builtin.mode == .Debug;
 
-/// To use these crash report diagnostics, publish these symbols in your main file.
+/// To use these crash report diagnostics, publish this panic in your main file
+/// and add `pub const enable_segfault_handler = false;` to your `std_options`.
 /// You will also need to call initialize() on startup, preferably as the very first operation in your program.
-pub const root_decls = struct {
-    pub const panic = if (is_enabled) compilerPanic else std.builtin.default_panic;
-    pub const enable_segfault_handler = false;
-};
+pub const panic = if (is_enabled) compilerPanic else std.builtin.default_panic;
 
 /// Install signal handlers to identify crashes and report diagnostics.
 pub fn initialize() void {

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -509,8 +509,8 @@ test "ptrCast comptime known slice to C pointer" {
 test "ptrToInt on a generic function" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_aarch64 and builtin.os.tag != .linux) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64 and builtin.os.tag != .linux) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
     const S = struct {
         fn generic(i: anytype) @TypeOf(i) {

--- a/test/compare_output.zig
+++ b/test/compare_output.zig
@@ -440,11 +440,14 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
     cases.add("std.log per scope log level override",
         \\const std = @import("std");
         \\
-        \\pub const log_level: std.log.Level = .debug;
-        \\
-        \\pub const scope_levels = [_]std.log.ScopeLevel{
-        \\    .{ .scope = .a, .level = .warn },
-        \\    .{ .scope = .c, .level = .err },
+        \\pub const std_options = struct {
+        \\    pub const log_level: std.log.Level = .debug;
+        \\    
+        \\    pub const log_scope_levels = &[_]std.log.ScopeLevel{
+        \\        .{ .scope = .a, .level = .warn },
+        \\        .{ .scope = .c, .level = .err },
+        \\    };
+        \\    pub const logFn = log;
         \\};
         \\
         \\const loga = std.log.scoped(.a);
@@ -494,7 +497,10 @@ pub fn addCases(cases: *tests.CompareOutputContext) void {
     cases.add("std.heap.LoggingAllocator logs to std.log",
         \\const std = @import("std");
         \\
-        \\pub const log_level: std.log.Level = .debug;
+        \\pub const std_options = struct {
+        \\    pub const log_level: std.log.Level = .debug;
+        \\    pub const logFn = log;
+        \\};
         \\
         \\pub fn main() !void {
         \\    var allocator_buf: [10]u8 = undefined;

--- a/test/standalone/issue_7030/main.zig
+++ b/test/standalone/issue_7030/main.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+pub const std_options = struct {
+    pub const logFn = log;
+};
+
 pub fn log(
     comptime message_level: std.log.Level,
     comptime scope: @Type(.EnumLiteral),

--- a/test/standalone/issue_9693/main.zig
+++ b/test/standalone/issue_9693/main.zig
@@ -1,2 +1,4 @@
-pub const io_mode = .evented;
+pub const std_options = struct {
+    pub const io_mode = .evented;
+};
 pub fn main() void {}


### PR DESCRIPTION
Putting all of the options in one namespace makes it easier to find what can be tweaked and results in fewer magical declarations in the root file.