### PR TITLE
std.childprocess: rename exec to run + all related code

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -642,7 +642,7 @@ fn addCxxKnownPath(
 ) !void {
     if (!std.process.can_spawn)
         return error.RequiredLibraryNotFound;
-    const path_padded = try b.exec(&[_][]const u8{
+    const path_padded = try b.run(&[_][]const u8{
         ctx.cxx_compiler,
         b.fmt("-print-file-name={s}", .{objname}),
     });

--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -1378,7 +1378,7 @@ fn genHtml(
                         try shell_out.print("\n", .{});
 
                         if (expected_outcome == .BuildFail) {
-                            const result = try ChildProcess.exec(.{
+                            const result = try ChildProcess.run(.{
                                 .allocator = allocator,
                                 .argv = build_args.items,
                                 .env_map = &env_map,
@@ -1405,7 +1405,7 @@ fn genHtml(
                             try shell_out.writeAll(colored_stderr);
                             break :code_block;
                         }
-                        const exec_result = exec(allocator, &env_map, build_args.items) catch
+                        const exec_result = run(allocator, &env_map, build_args.items) catch
                             return parseError(tokenizer, code.source_token, "example failed to compile", .{});
 
                         if (code.verbose_cimport) {
@@ -1438,7 +1438,7 @@ fn genHtml(
                         var exited_with_signal = false;
 
                         const result = if (expected_outcome == ExpectedOutcome.Fail) blk: {
-                            const result = try ChildProcess.exec(.{
+                            const result = try ChildProcess.run(.{
                                 .allocator = allocator,
                                 .argv = run_args,
                                 .env_map = &env_map,
@@ -1458,7 +1458,7 @@ fn genHtml(
                             }
                             break :blk result;
                         } else blk: {
-                            break :blk exec(allocator, &env_map, run_args) catch return parseError(tokenizer, code.source_token, "example crashed", .{});
+                            break :blk run(allocator, &env_map, run_args) catch return parseError(tokenizer, code.source_token, "example crashed", .{});
                         };
 
                         const escaped_stderr = try escapeHtml(allocator, result.stderr);
@@ -1519,7 +1519,7 @@ fn genHtml(
                                 },
                             }
                         }
-                        const result = exec(allocator, &env_map, test_args.items) catch
+                        const result = run(allocator, &env_map, test_args.items) catch
                             return parseError(tokenizer, code.source_token, "test failed", .{});
                         const escaped_stderr = try escapeHtml(allocator, result.stderr);
                         const escaped_stdout = try escapeHtml(allocator, result.stdout);
@@ -1553,7 +1553,7 @@ fn genHtml(
                             try test_args.append("-fstage1");
                             try shell_out.print("-fstage1", .{});
                         }
-                        const result = try ChildProcess.exec(.{
+                        const result = try ChildProcess.run(.{
                             .allocator = allocator,
                             .argv = test_args.items,
                             .env_map = &env_map,
@@ -1609,7 +1609,7 @@ fn genHtml(
                             },
                         }
 
-                        const result = try ChildProcess.exec(.{
+                        const result = try ChildProcess.run(.{
                             .allocator = allocator,
                             .argv = test_args.items,
                             .env_map = &env_map,
@@ -1678,7 +1678,7 @@ fn genHtml(
                         }
 
                         if (maybe_error_match) |error_match| {
-                            const result = try ChildProcess.exec(.{
+                            const result = try ChildProcess.run(.{
                                 .allocator = allocator,
                                 .argv = build_args.items,
                                 .env_map = &env_map,
@@ -1709,7 +1709,7 @@ fn genHtml(
                             const colored_stderr = try termColor(allocator, escaped_stderr);
                             try shell_out.print("\n{s} ", .{colored_stderr});
                         } else {
-                            _ = exec(allocator, &env_map, build_args.items) catch return parseError(tokenizer, code.source_token, "example failed to compile", .{});
+                            _ = run(allocator, &env_map, build_args.items) catch return parseError(tokenizer, code.source_token, "example failed to compile", .{});
                         }
                         try shell_out.writeAll("\n");
                     },
@@ -1756,7 +1756,7 @@ fn genHtml(
                                 },
                             }
                         }
-                        const result = exec(allocator, &env_map, test_args.items) catch return parseError(tokenizer, code.source_token, "test failed", .{});
+                        const result = run(allocator, &env_map, test_args.items) catch return parseError(tokenizer, code.source_token, "test failed", .{});
                         const escaped_stderr = try escapeHtml(allocator, result.stderr);
                         const escaped_stdout = try escapeHtml(allocator, result.stdout);
                         try shell_out.print("\n{s}{s}\n", .{ escaped_stderr, escaped_stdout });
@@ -1771,8 +1771,8 @@ fn genHtml(
     }
 }
 
-fn exec(allocator: Allocator, env_map: *process.EnvMap, args: []const []const u8) !ChildProcess.ExecResult {
-    const result = try ChildProcess.exec(.{
+fn run(allocator: Allocator, env_map: *process.EnvMap, args: []const []const u8) !ChildProcess.RunResult {
+    const result = try ChildProcess.run(.{
         .allocator = allocator,
         .argv = args,
         .env_map = env_map,
@@ -1796,7 +1796,7 @@ fn exec(allocator: Allocator, env_map: *process.EnvMap, args: []const []const u8
 }
 
 fn getBuiltinCode(allocator: Allocator, env_map: *process.EnvMap, zig_exe: []const u8) ![]const u8 {
-    const result = try exec(allocator, env_map, &[_][]const u8{ zig_exe, "build-obj", "--show-builtin" });
+    const result = try run(allocator, env_map, &[_][]const u8{ zig_exe, "build-obj", "--show-builtin" });
     return result.stdout;
 }
 

--- a/lib/std/build.zig
+++ b/lib/std/build.zig
@@ -99,7 +99,7 @@ pub const Builder = struct {
     /// Information about the native target. Computed before build() is invoked.
     host: NativeTargetInfo,
 
-    pub const ExecError = error{
+    pub const RunError = error{
         ReadFailure,
         ExitCodeFailure,
         ProcessTerminated,
@@ -1181,7 +1181,7 @@ pub const Builder = struct {
         argv: []const []const u8,
         out_code: *u8,
         stderr_behavior: std.ChildProcess.StdIo,
-    ) ExecError![]u8 {
+    ) RunError![]u8 {
         assert(argv.len != 0);
 
         if (!std.process.can_spawn)
@@ -1217,7 +1217,7 @@ pub const Builder = struct {
         }
     }
 
-    pub fn execFromStep(self: *Builder, argv: []const []const u8, src_step: ?*Step) ![]u8 {
+    pub fn runFromStep(self: *Builder, argv: []const []const u8, src_step: ?*Step) ![]u8 {
         assert(argv.len != 0);
 
         if (self.verbose) {
@@ -1266,8 +1266,8 @@ pub const Builder = struct {
         };
     }
 
-    pub fn exec(self: *Builder, argv: []const []const u8) ![]u8 {
-        return self.execFromStep(argv, null);
+    pub fn run(self: *Builder, argv: []const []const u8) ![]u8 {
+        return self.runFromStep(argv, null);
     }
 
     pub fn addSearchPrefix(self: *Builder, search_prefix: []const u8) void {

--- a/lib/std/build/InstallRawStep.zig
+++ b/lib/std/build/InstallRawStep.zig
@@ -98,7 +98,7 @@ fn make(step: *Step) !void {
     };
 
     try argv_list.appendSlice(&.{ full_src_path, full_dest_path });
-    _ = try self.builder.execFromStep(argv_list.items, &self.step);
+    _ = try self.builder.runFromStep(argv_list.items, &self.step);
 }
 
 test {

--- a/lib/std/build/LibExeObjStep.zig
+++ b/lib/std/build/LibExeObjStep.zig
@@ -17,7 +17,7 @@ const NativeTargetInfo = std.zig.system.NativeTargetInfo;
 const FileSource = std.build.FileSource;
 const PkgConfigPkg = Builder.PkgConfigPkg;
 const PkgConfigError = Builder.PkgConfigError;
-const ExecError = Builder.ExecError;
+const RunError = Builder.RunError;
 const Pkg = std.build.Pkg;
 const VcpkgRoot = std.build.VcpkgRoot;
 const InstallDir = std.build.InstallDir;
@@ -1875,7 +1875,7 @@ fn make(step: *Step) !void {
         try zig_args.append(try std.mem.concat(builder.allocator, u8, &[_][]const u8{ "@", args_file }));
     }
 
-    const output_dir_nl = try builder.execFromStep(zig_args.items, &self.step);
+    const output_dir_nl = try builder.runFromStep(zig_args.items, &self.step);
     const build_output_dir = mem.trimRight(u8, output_dir_nl, "\r\n");
 
     if (self.output_dir) |output_dir| {
@@ -1991,7 +1991,7 @@ pub fn doAtomicSymLinks(allocator: Allocator, output_path: []const u8, filename_
     };
 }
 
-fn execPkgConfigList(self: *Builder, out_code: *u8) (PkgConfigError || ExecError)![]const PkgConfigPkg {
+fn execPkgConfigList(self: *Builder, out_code: *u8) (PkgConfigError || RunError)![]const PkgConfigPkg {
     const stdout = try self.execAllowFail(&[_][]const u8{ "pkg-config", "--list-all" }, out_code, .Ignore);
     var list = ArrayList(PkgConfigPkg).init(self.allocator);
     errdefer list.deinit();

--- a/lib/std/build/RunStep.zig
+++ b/lib/std/build/RunStep.zig
@@ -11,7 +11,7 @@ const process = std.process;
 const ArrayList = std.ArrayList;
 const EnvMap = process.EnvMap;
 const Allocator = mem.Allocator;
-const ExecError = build.Builder.ExecError;
+const RunError = build.Builder.RunError;
 
 const max_stdout_size = 1 * 1024 * 1024; // 1 MiB
 
@@ -210,7 +210,7 @@ pub fn runCommand(
         const cmd = try std.mem.join(builder.allocator, " ", argv);
         std.debug.print("the following command cannot be executed ({s} does not support spawning a child process):\n{s}", .{ @tagName(builtin.os.tag), cmd });
         builder.allocator.free(cmd);
-        return ExecError.ExecNotSupported;
+        return RunError.ExecNotSupported;
     }
 
     var child = std.ChildProcess.init(argv, builder.allocator);

--- a/lib/std/build/TranslateCStep.zig
+++ b/lib/std/build/TranslateCStep.zig
@@ -94,7 +94,7 @@ fn make(step: *Step) !void {
 
     try argv_list.append(self.source.getPath(self.builder));
 
-    const output_path_nl = try self.builder.execFromStep(argv_list.items, &self.step);
+    const output_path_nl = try self.builder.runFromStep(argv_list.items, &self.step);
     const output_path = mem.trimRight(u8, output_path_nl, "\r\n");
 
     self.out_basename = fs.path.basename(output_path);

--- a/lib/std/zig/system/darwin.zig
+++ b/lib/std/zig/system/darwin.zig
@@ -13,7 +13,7 @@ pub const macos = @import("darwin/macos.zig");
 /// https://github.com/Homebrew/brew/blob/e119bdc571dcb000305411bc1e26678b132afb98/Library/Homebrew/brew.sh#L630
 pub fn isDarwinSDKInstalled(allocator: Allocator) bool {
     const argv = &[_][]const u8{ "/usr/bin/xcode-select", "--print-path" };
-    const result = std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv }) catch return false;
+    const result = std.ChildProcess.run(.{ .allocator = allocator, .argv = argv }) catch return false;
     defer {
         allocator.free(result.stderr);
         allocator.free(result.stdout);
@@ -40,7 +40,7 @@ pub fn getDarwinSDK(allocator: Allocator, target: Target) ?DarwinSDK {
     };
     const path = path: {
         const argv = &[_][]const u8{ "/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-path" };
-        const result = std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv }) catch return null;
+        const result = std.ChildProcess.run(.{ .allocator = allocator, .argv = argv }) catch return null;
         defer {
             allocator.free(result.stderr);
             allocator.free(result.stdout);
@@ -55,7 +55,7 @@ pub fn getDarwinSDK(allocator: Allocator, target: Target) ?DarwinSDK {
     };
     const version = version: {
         const argv = &[_][]const u8{ "/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-version" };
-        const result = std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv }) catch return null;
+        const result = std.ChildProcess.run(.{ .allocator = allocator, .argv = argv }) catch return null;
         defer {
             allocator.free(result.stderr);
             allocator.free(result.stdout);

--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -261,7 +261,7 @@ pub const LibCInstallation = struct {
             dev_null,
         });
 
-        const exec_res = std.ChildProcess.exec(.{
+        const run_res = std.ChildProcess.run(.{
             .allocator = allocator,
             .argv = argv.items,
             .max_output_bytes = 1024 * 1024,
@@ -279,21 +279,21 @@ pub const LibCInstallation = struct {
             },
         };
         defer {
-            allocator.free(exec_res.stdout);
-            allocator.free(exec_res.stderr);
+            allocator.free(run_res.stdout);
+            allocator.free(run_res.stderr);
         }
-        switch (exec_res.term) {
+        switch (run_res.term) {
             .Exited => |code| if (code != 0) {
-                printVerboseInvocation(argv.items, null, args.verbose, exec_res.stderr);
+                printVerboseInvocation(argv.items, null, args.verbose, run_res.stderr);
                 return error.CCompilerExitCode;
             },
             else => {
-                printVerboseInvocation(argv.items, null, args.verbose, exec_res.stderr);
+                printVerboseInvocation(argv.items, null, args.verbose, run_res.stderr);
                 return error.CCompilerCrashed;
             },
         }
 
-        var it = std.mem.tokenize(u8, exec_res.stderr, "\n\r");
+        var it = std.mem.tokenize(u8, run_res.stderr, "\n\r");
         var search_paths = std.ArrayList([]const u8).init(allocator);
         defer search_paths.deinit();
         while (it.next()) |line| {
@@ -584,7 +584,7 @@ fn ccPrintFileName(args: CCPrintFileNameOptions) ![:0]u8 {
     try appendCcExe(&argv, skip_cc_env_var);
     try argv.append(arg1);
 
-    const exec_res = std.ChildProcess.exec(.{
+    const run_res = std.ChildProcess.run(.{
         .allocator = allocator,
         .argv = argv.items,
         .max_output_bytes = 1024 * 1024,
@@ -599,21 +599,21 @@ fn ccPrintFileName(args: CCPrintFileNameOptions) ![:0]u8 {
         else => return error.UnableToSpawnCCompiler,
     };
     defer {
-        allocator.free(exec_res.stdout);
-        allocator.free(exec_res.stderr);
+        allocator.free(run_res.stdout);
+        allocator.free(run_res.stderr);
     }
-    switch (exec_res.term) {
+    switch (run_res.term) {
         .Exited => |code| if (code != 0) {
-            printVerboseInvocation(argv.items, args.search_basename, args.verbose, exec_res.stderr);
+            printVerboseInvocation(argv.items, args.search_basename, args.verbose, run_res.stderr);
             return error.CCompilerExitCode;
         },
         else => {
-            printVerboseInvocation(argv.items, args.search_basename, args.verbose, exec_res.stderr);
+            printVerboseInvocation(argv.items, args.search_basename, args.verbose, run_res.stderr);
             return error.CCompilerCrashed;
         },
     }
 
-    var it = std.mem.tokenize(u8, exec_res.stdout, "\n\r");
+    var it = std.mem.tokenize(u8, run_res.stdout, "\n\r");
     const line = it.next() orelse return error.LibCRuntimeNotFound;
     // When this command fails, it returns exit code 0 and duplicates the input file name.
     // So we detect failure by checking if the output matches exactly the input.

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -64,9 +64,9 @@ fn printCmd(cwd: []const u8, argv: []const []const u8) void {
     std.debug.print("\n", .{});
 }
 
-fn exec(cwd: []const u8, expect_0: bool, argv: []const []const u8) !ChildProcess.ExecResult {
+fn run(cwd: []const u8, expect_0: bool, argv: []const []const u8) !ChildProcess.RunResult {
     const max_output_size = 100 * 1024;
-    const result = ChildProcess.exec(.{
+    const result = ChildProcess.run(.{
         .allocator = a,
         .argv = argv,
         .cwd = cwd,
@@ -96,14 +96,14 @@ fn exec(cwd: []const u8, expect_0: bool, argv: []const []const u8) !ChildProcess
 }
 
 fn testZigInitLib(zig_exe: []const u8, dir_path: []const u8) !void {
-    _ = try exec(dir_path, true, &[_][]const u8{ zig_exe, "init-lib" });
-    const test_result = try exec(dir_path, true, &[_][]const u8{ zig_exe, "build", "test" });
+    _ = try run(dir_path, true, &[_][]const u8{ zig_exe, "init-lib" });
+    const test_result = try run(dir_path, true, &[_][]const u8{ zig_exe, "build", "test" });
     try testing.expectStringEndsWith(test_result.stderr, "All 1 tests passed.\n");
 }
 
 fn testZigInitExe(zig_exe: []const u8, dir_path: []const u8) !void {
-    _ = try exec(dir_path, true, &[_][]const u8{ zig_exe, "init-exe" });
-    const run_result = try exec(dir_path, true, &[_][]const u8{ zig_exe, "build", "run" });
+    _ = try run(dir_path, true, &[_][]const u8{ zig_exe, "init-exe" });
+    const run_result = try run(dir_path, true, &[_][]const u8{ zig_exe, "build", "run" });
     try testing.expectEqualStrings("All your codebase are belong to us.\n", run_result.stderr);
     try testing.expectEqualStrings("Run `zig build test` to run the tests.\n", run_result.stdout);
 }
@@ -140,7 +140,7 @@ fn testGodboltApi(zig_exe: []const u8, dir_path: []const u8) anyerror!void {
     const emit_asm_arg = try std.fmt.allocPrint(a, "-femit-asm={s}", .{example_s_path});
     try args.append(emit_asm_arg);
 
-    _ = try exec(dir_path, true, args.items);
+    _ = try run(dir_path, true, args.items);
 
     const out_asm = try std.fs.cwd().readFileAlloc(a, example_s_path, std.math.maxInt(usize));
     try testing.expect(std.mem.indexOf(u8, out_asm, "square:") != null);
@@ -149,25 +149,25 @@ fn testGodboltApi(zig_exe: []const u8, dir_path: []const u8) anyerror!void {
 }
 
 fn testMissingOutputPath(zig_exe: []const u8, dir_path: []const u8) !void {
-    _ = try exec(dir_path, true, &[_][]const u8{ zig_exe, "init-exe" });
+    _ = try run(dir_path, true, &[_][]const u8{ zig_exe, "init-exe" });
     const output_path = try fs.path.join(a, &[_][]const u8{ "does", "not", "exist", "foo.exe" });
     const output_arg = try std.fmt.allocPrint(a, "-femit-bin={s}", .{output_path});
     const source_path = try fs.path.join(a, &[_][]const u8{ "src", "main.zig" });
-    const result = try exec(dir_path, false, &[_][]const u8{ zig_exe, "build-exe", source_path, output_arg });
+    const result = try run(dir_path, false, &[_][]const u8{ zig_exe, "build-exe", source_path, output_arg });
     const s = std.fs.path.sep_str;
     const expected: []const u8 = "error: unable to open output directory 'does" ++ s ++ "not" ++ s ++ "exist': FileNotFound\n";
     try testing.expectEqualStrings(expected, result.stderr);
 }
 
 fn testZigFmt(zig_exe: []const u8, dir_path: []const u8) !void {
-    _ = try exec(dir_path, true, &[_][]const u8{ zig_exe, "init-exe" });
+    _ = try run(dir_path, true, &[_][]const u8{ zig_exe, "init-exe" });
 
     const unformatted_code = "    // no reason for indent";
 
     const fmt1_zig_path = try fs.path.join(a, &[_][]const u8{ dir_path, "fmt1.zig" });
     try fs.cwd().writeFile(fmt1_zig_path, unformatted_code);
 
-    const run_result1 = try exec(dir_path, true, &[_][]const u8{ zig_exe, "fmt", fmt1_zig_path });
+    const run_result1 = try run(dir_path, true, &[_][]const u8{ zig_exe, "fmt", fmt1_zig_path });
     // stderr should be file path + \n
     try testing.expect(std.mem.startsWith(u8, run_result1.stdout, fmt1_zig_path));
     try testing.expect(run_result1.stdout.len == fmt1_zig_path.len + 1 and run_result1.stdout[run_result1.stdout.len - 1] == '\n');
@@ -175,12 +175,12 @@ fn testZigFmt(zig_exe: []const u8, dir_path: []const u8) !void {
     const fmt2_zig_path = try fs.path.join(a, &[_][]const u8{ dir_path, "fmt2.zig" });
     try fs.cwd().writeFile(fmt2_zig_path, unformatted_code);
 
-    const run_result2 = try exec(dir_path, true, &[_][]const u8{ zig_exe, "fmt", dir_path });
+    const run_result2 = try run(dir_path, true, &[_][]const u8{ zig_exe, "fmt", dir_path });
     // running it on the dir, only the new file should be changed
     try testing.expect(std.mem.startsWith(u8, run_result2.stdout, fmt2_zig_path));
     try testing.expect(run_result2.stdout.len == fmt2_zig_path.len + 1 and run_result2.stdout[run_result2.stdout.len - 1] == '\n');
 
-    const run_result3 = try exec(dir_path, true, &[_][]const u8{ zig_exe, "fmt", dir_path });
+    const run_result3 = try run(dir_path, true, &[_][]const u8{ zig_exe, "fmt", dir_path });
     // both files have been formatted, nothing should change now
     try testing.expect(run_result3.stdout.len == 0);
 
@@ -189,7 +189,7 @@ fn testZigFmt(zig_exe: []const u8, dir_path: []const u8) !void {
     var unformatted_code_utf16 = "\xff\xfe \x00 \x00 \x00 \x00/\x00/\x00 \x00n\x00o\x00 \x00r\x00e\x00a\x00s\x00o\x00n\x00";
     try fs.cwd().writeFile(fmt4_zig_path, unformatted_code_utf16);
 
-    const run_result4 = try exec(dir_path, true, &[_][]const u8{ zig_exe, "fmt", dir_path });
+    const run_result4 = try run(dir_path, true, &[_][]const u8{ zig_exe, "fmt", dir_path });
     try testing.expect(std.mem.startsWith(u8, run_result4.stdout, fmt4_zig_path));
     try testing.expect(run_result4.stdout.len == fmt4_zig_path.len + 1 and run_result4.stdout[run_result4.stdout.len - 1] == '\n');
 }

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -11,7 +11,7 @@ const ArrayList = std.ArrayList;
 const Mode = std.builtin.Mode;
 const LibExeObjStep = build.LibExeObjStep;
 const Allocator = mem.Allocator;
-const ExecError = build.Builder.ExecError;
+const RunError = build.Builder.RunError;
 
 // Cases
 const compare_output = @import("compare_output.zig");
@@ -875,7 +875,7 @@ pub const StackTracesContext = struct {
                 const cmd = try std.mem.join(b.allocator, " ", args.items);
                 std.debug.print("the following command cannot be executed ({s} does not support spawning a child process):\n{s}", .{ @tagName(builtin.os.tag), cmd });
                 b.allocator.free(cmd);
-                return ExecError.ExecNotSupported;
+                return RunError.ExecNotSupported;
             }
 
             var child = std.ChildProcess.init(args.items, b.allocator);

--- a/tools/generate_linux_syscalls.zig
+++ b/tools/generate_linux_syscalls.zig
@@ -232,7 +232,7 @@ pub fn main() !void {
             "arch/arm64/include/uapi/asm/unistd.h",
         };
 
-        const child_result = try std.ChildProcess.exec(.{
+        const child_result = try std.ChildProcess.run(.{
             .allocator = allocator,
             .argv = &child_args,
             .cwd = linux_path,
@@ -294,7 +294,7 @@ pub fn main() !void {
             "arch/riscv/include/uapi/asm/unistd.h",
         };
 
-        const child_result = try std.ChildProcess.exec(.{
+        const child_result = try std.ChildProcess.run(.{
             .allocator = allocator,
             .argv = &child_args,
             .cwd = linux_path,

--- a/tools/update_clang_options.zig
+++ b/tools/update_clang_options.zig
@@ -585,7 +585,7 @@ pub fn main() anyerror!void {
         try std.fmt.allocPrint(allocator, "-I={s}/clang/include/clang/Driver", .{llvm_src_root}),
     };
 
-    const child_result = try std.ChildProcess.exec(.{
+    const child_result = try std.ChildProcess.run(.{
         .allocator = allocator,
         .argv = &child_args,
         .max_output_bytes = 100 * 1024 * 1024,

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -951,7 +951,7 @@ fn processOneTarget(job: Job) anyerror!void {
         }),
     };
 
-    const child_result = try std.ChildProcess.exec(.{
+    const child_result = try std.ChildProcess.run(.{
         .allocator = arena,
         .argv = &child_args,
         .max_output_bytes = 400 * 1024 * 1024,


### PR DESCRIPTION
Justification: exec, execv etc are unix concepts and portable version
should be called differently.

Do no touch non-Zig code. Adjust error names as well, if associated.
Closes #5853.