### PR TITLE
std.http.Client: support transfer-encoding: chunked

### DIFF
--- a/lib/std/crypto/tls/Client.zig
+++ b/lib/std/crypto/tls/Client.zig
@@ -1207,6 +1207,7 @@ const VecPut = struct {
     /// Returns the amount actually put which is always equal to bytes.len
     /// unless the vectors ran out of space.
     fn put(vp: *VecPut, bytes: []const u8) usize {
+        if (vp.idx >= vp.iovecs.len) return 0;
         var bytes_i: usize = 0;
         while (true) {
             const v = vp.iovecs[vp.idx];

--- a/lib/std/http.zig
+++ b/lib/std/http.zig
@@ -246,6 +246,13 @@ pub const Status = enum(u10) {
     }
 };
 
+pub const TransferEncoding = enum {
+    chunked,
+    compress,
+    deflate,
+    gzip,
+};
+
 const std = @import("std.zig");
 
 test {


### PR DESCRIPTION
With this, I have successfully downloaded https://github.com/ziglang/zig/archive/refs/tags/0.10.0.tar.gz!


closes #14204

In order to add tests for this I need to implement an HTTP server in the standard library (#910) so that's probably the next thing I'll do.

Test drive script:

```zig
const std = @import("std");
const http = std.http;

pub fn main() !void {
    var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
    const arena = arena_instance.allocator();
    const gpa = arena;

    const args = try std.process.argsAlloc(arena);

    var client: http.Client = .{
        .allocator = gpa,
    };
    try client.ca_bundle.rescan(gpa);
    defer client.deinit(gpa);

    const url = try std.Url.parse(args[1]);
    var req = try client.request(url, .{}, .{});

    const stdout = if (args.len >= 3)
        try std.fs.cwd().createFile(args[2], .{})
    else
        std.io.getStdOut();

    var bw = std.io.bufferedWriter(stdout.writer());
    const w = bw.writer();

    var total: usize = 0;
    var buf: [5000]u8 = undefined;
    while (true) {
        const amt = try req.readAll(&buf);
        total += amt;
        if (amt == 0) break;
        std.debug.print("got {d} bytes (total {d})\n", .{ amt, total });
        try w.writeAll(buf[0..amt]);
    }

    try bw.flush();
}
```