### PR TITLE
Fix segfault in getaddrinfo

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -322,7 +322,9 @@ pub extern "c" fn getaddrinfo(
     noalias node: ?[*:0]const u8,
     noalias service: ?[*:0]const u8,
     noalias hints: ?*const c.addrinfo,
-    noalias res: **c.addrinfo,
+    /// On Linux, `res` will not be modified on error and `freeaddrinfo` will
+    /// potentially crash if you pass it an undefined pointer
+    noalias res: *?*c.addrinfo,
 ) c.EAI;
 
 pub extern "c" fn freeaddrinfo(res: *c.addrinfo) void;

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -764,7 +764,7 @@ pub fn getAddressList(allocator: mem.Allocator, name: []const u8, port: u16) !*A
             .addrlen = 0,
             .next = null,
         };
-        var res: *os.addrinfo = undefined;
+        var res: ?*os.addrinfo = null;
         const rc = sys.getaddrinfo(name_c.ptr, port_c.ptr, &hints, &res);
         if (builtin.target.os.tag == .windows) switch (@intToEnum(os.windows.ws2_32.WinsockError, @intCast(u16, rc))) {
             @intToEnum(os.windows.ws2_32.WinsockError, 0) => {},
@@ -794,11 +794,11 @@ pub fn getAddressList(allocator: mem.Allocator, name: []const u8, port: u16) !*A
             },
             else => unreachable,
         }
-        defer sys.freeaddrinfo(res);
+        defer if (res != null) sys.freeaddrinfo(res.?);
 
         const addr_count = blk: {
             var count: usize = 0;
-            var it: ?*os.addrinfo = res;
+            var it = res;
             while (it) |info| : (it = info.next) {
                 if (info.addr != null) {
                     count += 1;
@@ -808,7 +808,7 @@ pub fn getAddressList(allocator: mem.Allocator, name: []const u8, port: u16) !*A
         };
         result.addrs = try arena.alloc(Address, addr_count);
 
-        var it: ?*os.addrinfo = res;
+        var it = res;
         var i: usize = 0;
         while (it) |info| : (it = info.next) {
             const addr = info.addr orelse continue;


### PR DESCRIPTION
The following snippet segfaults on Linux when `host` points to a domain that can't be resolved:
```zig
test "segfault" {
    const std = @import("std");
    var host = "hellooooooooooooooo.1.2.3.4.5.6.67.com";
    var addrinfo: *std.c.addrinfo = undefined;
    _ = std.c.getaddrinfo(
        host,
        null,
        null,
        &addrinfo,
    );
    defer std.c.freeaddrinfo(addrinfo);
}
```
<img width="760" alt="image" src="https://user-images.githubusercontent.com/709451/211180937-fd41bc52-6fb0-4131-ab6f-93af5277c27c.png">

> Stop reason: signal SIGSEGV: invalid address (fault address: 0x0)
