### PR TITLE
Fix "chdir smoke test" path comparison on Windows

### DIFF
--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -64,7 +64,14 @@ test "chdir smoke test" {
 
         var new_cwd_buf: [fs.MAX_PATH_BYTES]u8 = undefined;
         const new_cwd = try os.getcwd(new_cwd_buf[0..]);
-        try expect(mem.eql(u8, tmp_dir_path, new_cwd));
+
+        // On Windows, fs.path.resolve returns an uppercase drive letter, but the drive letter returned by getcwd may be lowercase
+        var resolved_cwd_buf: [fs.MAX_PATH_BYTES]u8 = undefined;
+        var resolved_cwd = path: {
+            var allocator = std.heap.FixedBufferAllocator.init(&resolved_cwd_buf);
+            break :path try fs.path.resolve(allocator.allocator(), &[_][]const u8{new_cwd});
+        };
+        try expect(mem.eql(u8, tmp_dir_path, resolved_cwd));
 
         // Restore cwd because process may have other tests that do not tolerate chdir.
         tmp_dir.close();


### PR DESCRIPTION
This test was failing for me, and the cause was my cwd had a lowercase drive letter:

Repro steps:
1. `cd c:\cygwin64\home\kcbanner\kit\zig\zig-test-tmp`
2. `zig build test-std -Dtest-filter="chdir smoke test"`
3. `try expect(mem.eql(u8, tmp_dir_path, new_cwd));` comparison fails

It ends up comparing `C:\cygwin64\home\kcbanner\kit\zig\zig-test-tmp` to `c:\cygwin64\home\kcbanner\kit\zig\zig-test-tmp`. 

Fixed by resolving the cwd as well to normalize the drive letter. 