### PR TITLE
Wildcard certs should only validate one level of sub domain

### DIFF
--- a/lib/std/crypto/Certificate.zig
+++ b/lib/std/crypto/Certificate.zig
@@ -275,7 +275,7 @@ pub const Parsed = struct {
     // Check hostname according to RFC2818 specification:
     //
     // If more than one identity of a given type is present in
-    // the certificate (e.g., more than one dNSName name, a match in any one
+    // the certificate (e.g., more than one DNSName name, a match in any one
     // of the set is considered acceptable.) Names may contain the wildcard
     // character * which is considered to match any single domain name
     // component or component fragment. E.g., *.a.com matches foo.a.com but
@@ -283,14 +283,6 @@ pub const Parsed = struct {
     fn checkHostName(host_name: []const u8, dns_name: []const u8) bool {
         if (mem.eql(u8, dns_name, host_name)) {
             return true; // exact match
-        }
-
-        // In the case of the wildcard not being
-        // in the subdomain.
-        if (mem.indexOf(u8, dns_name, "*")) |idx| {
-            if (idx > 0) {
-                return mem.eql(u8, host_name[0..idx], dns_name[0..idx]);
-            }
         }
 
         var it_host = std.mem.split(u8, host_name, ".");
@@ -323,7 +315,7 @@ test "Parsed.checkHostName" {
     try expectEqual(true, Parsed.checkHostName("ziglang.org", "ziglang.org"));
     try expectEqual(true, Parsed.checkHostName("bar.ziglang.org", "*.ziglang.org"));
     try expectEqual(false, Parsed.checkHostName("foo.bar.ziglang.org", "*.ziglang.org"));
-    try expectEqual(true, Parsed.checkHostName("ziglang.org", "zig*.org"));
+    try expectEqual(false, Parsed.checkHostName("ziglang.org", "zig*.org"));
     try expectEqual(false, Parsed.checkHostName("lang.org", "zig*.org"));
 }
 

--- a/lib/std/crypto/Certificate.zig
+++ b/lib/std/crypto/Certificate.zig
@@ -285,6 +285,14 @@ pub const Parsed = struct {
             return true; // exact match
         }
 
+        // In the case of the wildcard not being
+        // in the subdomain.
+        if (mem.indexOf(u8, dns_name, "*")) |idx| {
+            if (idx > 0) {
+                return mem.eql(u8, host_name[0..idx], dns_name[0..idx]);
+            }
+        }
+
         var it_host = std.mem.split(u8, host_name, ".");
         var it_dns = std.mem.split(u8, dns_name, ".");
 
@@ -309,12 +317,13 @@ pub const Parsed = struct {
     }
 };
 
-test "Parsed checkHostName" {
+test "Parsed.checkHostName" {
     const expectEqual = std.testing.expectEqual;
 
     try expectEqual(true, Parsed.checkHostName("ziglang.org", "ziglang.org"));
     try expectEqual(true, Parsed.checkHostName("bar.ziglang.org", "*.ziglang.org"));
     try expectEqual(false, Parsed.checkHostName("foo.bar.ziglang.org", "*.ziglang.org"));
+    try expectEqual(true, Parsed.checkHostName("ziglang.org", "zig*.org"));
     try expectEqual(false, Parsed.checkHostName("lang.org", "zig*.org"));
 }
 

--- a/lib/std/crypto/Certificate.zig
+++ b/lib/std/crypto/Certificate.zig
@@ -304,7 +304,7 @@ pub const Parsed = struct {
                 break host == null and dns == null;
             }
 
-            // If not a wildcard and they dont 
+            // If not a wildcard and they dont
             // match then there is no match.
             if (mem.eql(u8, dns.?, "*") == false and mem.eql(u8, dns.?, host.?) == false) {
                 return false;

--- a/lib/std/crypto/Certificate.zig
+++ b/lib/std/crypto/Certificate.zig
@@ -272,28 +272,51 @@ pub const Parsed = struct {
         return error.CertificateHostMismatch;
     }
 
+    // Check hostname according to RFC2818 specification:
+    //
+    // If more than one identity of a given type is present in
+    // the certificate (e.g., more than one dNSName name, a match in any one
+    // of the set is considered acceptable.) Names may contain the wildcard
+    // character * which is considered to match any single domain name
+    // component or component fragment. E.g., *.a.com matches foo.a.com but
+    // not bar.foo.a.com. f*.com matches foo.com but not bar.com.
     fn checkHostName(host_name: []const u8, dns_name: []const u8) bool {
         if (mem.eql(u8, dns_name, host_name)) {
             return true; // exact match
         }
 
-        if (mem.startsWith(u8, dns_name, "*.")) {
-            // wildcard certificate, matches any subdomain
-            // TODO: I think wildcards are not supposed to match any prefix but
-            // only match exactly one subdomain.
-            if (mem.endsWith(u8, host_name, dns_name[1..])) {
-                // The host_name has a subdomain, but the important part matches.
-                return true;
-            }
-            if (mem.eql(u8, dns_name[2..], host_name)) {
-                // The host_name has no subdomain and matches exactly.
-                return true;
-            }
-        }
+        var it_host = std.mem.split(u8, host_name, ".");
+        var it_dns = std.mem.split(u8, dns_name, ".");
 
-        return false;
+        const len_match = while (true) {
+            const host = it_host.next();
+            const dns = it_dns.next();
+
+            if (host == null or dns == null) {
+                break host == null and dns == null;
+            }
+
+            // If not a wildcard and they dont 
+            // match then there is no match.
+            if (mem.eql(u8, dns.?, "*") == false and mem.eql(u8, dns.?, host.?) == false) {
+                return false;
+            }
+        };
+
+        // If the components are not the same
+        // length then there is no match.
+        return len_match;
     }
 };
+
+test "Parsed checkHostName" {
+    const expectEqual = std.testing.expectEqual;
+
+    try expectEqual(true, Parsed.checkHostName("ziglang.org", "ziglang.org"));
+    try expectEqual(true, Parsed.checkHostName("bar.ziglang.org", "*.ziglang.org"));
+    try expectEqual(false, Parsed.checkHostName("foo.bar.ziglang.org", "*.ziglang.org"));
+    try expectEqual(false, Parsed.checkHostName("lang.org", "zig*.org"));
+}
 
 pub fn parse(cert: Certificate) !Parsed {
     const cert_bytes = cert.buffer;


### PR DESCRIPTION
Closes #14177

The following testcase was included in the RFC spec, but not explicitly mentioned in the issue. I went ahead and implemented it.
> f*.com matches foo.com but not bar.com

Do we want to expand this to cases like `zig*ng.org` matching `ziglang.org`? I could not find any reference to it in the spec, but I imagine the above quote implying that `zig*ng.org` would need to pass as well.