### PR TITLE
langref: fix unclosed and lonely tag

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -9412,7 +9412,9 @@ test "integer truncation" {
           <li>{#link|Enum Literals#}</li>
           <li>{#link|union#}</li>
       </ul>
+<p>
       {#syntax#}@Type{#endsyntax#} is not available for {#link|Functions#}.
+      </p>
       {#header_close#}
       {#header_open|@typeInfo#}
       <pre>{#syntax#}@typeInfo(comptime T: type) std.builtin.Type{#endsyntax#}</pre>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5588,6 +5588,7 @@ test "createFoo" {
       <p>
       To ensure that {#syntax#}deallocateFoo{#endsyntax#} is properly called
       when returning an error, you must add an {#syntax#}errdefer{#endsyntax#} outside of the block:
+      </p>
       {#code_begin|test|test_errdefer_block#}
 const std = @import("std");
 const Allocator = std.mem.Allocator;
@@ -9411,7 +9412,6 @@ test "integer truncation" {
           <li>{#link|Enum Literals#}</li>
           <li>{#link|union#}</li>
       </ul>
-      <p>
       {#syntax#}@Type{#endsyntax#} is not available for {#link|Functions#}.
       {#header_close#}
       {#header_open|@typeInfo#}


### PR DESCRIPTION
Previously the number of `<p>` and `</p>` where not the same.
Line 5588 has no closing tag and there is a lone tag on line 9414.
