### PR TITLE
Implemented integer popcount codegen on x86_64 backend

### DIFF
--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -394,6 +394,9 @@ pub const Inst = struct {
         /// pop registers
         /// Uses `payload` field with `SaveRegisterList` as payload.
         pop_regs,
+
+        // popcount
+        popcnt,
     };
     /// The position of an MIR instruction within the `Mir` instructions array.
     pub const Index = u32;

--- a/test/behavior/popcount.zig
+++ b/test/behavior/popcount.zig
@@ -4,7 +4,6 @@ const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 
 test "@popCount integers" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO


### PR DESCRIPTION
This PR implements codegen for integer popcount (up to u64) on the self hosted x86_64 backend. 