### PR TITLE
glibc: allow linking against external libcrypt.

### DIFF
--- a/src/target.zig
+++ b/src/target.zig
@@ -372,8 +372,6 @@ pub fn is_libc_lib_name(target: std.Target, name: []const u8) bool {
             return true;
         if (eqlIgnoreCase(ignore_case, name, "pthread"))
             return true;
-        if (eqlIgnoreCase(ignore_case, name, "crypt"))
-            return true;
         if (eqlIgnoreCase(ignore_case, name, "util"))
             return true;
         if (eqlIgnoreCase(ignore_case, name, "xnet"))
@@ -381,6 +379,11 @@ pub fn is_libc_lib_name(target: std.Target, name: []const u8) bool {
         if (eqlIgnoreCase(ignore_case, name, "resolv"))
             return true;
         if (eqlIgnoreCase(ignore_case, name, "dl"))
+            return true;
+    }
+
+    if (target.abi.isMusl() or target.os.tag.isDarwin()) {
+        if (eqlIgnoreCase(ignore_case, name, "crypt"))
             return true;
     }
 


### PR DESCRIPTION
Support for the built-in libcrypt was removed in commit 6b7ddfba,
but the -lcrypt flag remained ignored, preventing linking against
external libcrypt.

Fixes #5990.

Signed-off-by: Piotr Sikora <piotr@aviatrix.com>