### PR TITLE
autodoc: allow function descriptions expansion

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -266,6 +266,42 @@
         font-weight: bold;
       }
 
+      details[open] summary .sum-less {
+        display: none;
+      }
+
+      details[open] summary .sum-more {
+        display: block;
+      }
+
+      details summary .sum-more {
+        display: none;
+      }
+
+      details summary {
+        list-style-type: none;
+        position: relative;
+        pointer-events: none;
+      }
+
+      details summary::before {
+        content: "[+] ";
+        font-family: var(--mono);
+        color: var(--link-color);
+        position: sticky;
+        float: left;
+        top: 0px;
+        right: -16px;
+        z-index: 1;
+        margin-left: -2em;
+        pointer-events: all;
+        cursor: pointer;
+      }
+
+      details[open] summary::before {
+        content: "[-] ";
+      }
+
       .examples {
         list-style-type: none;
         margin: 0;

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -2466,9 +2466,19 @@ var zigAnalysis;
 
         let docs = getAstNode(decl.src).docs;
         if (docs != null) {
-          tdDesc.innerHTML = shortDescMarkdown(docs);
+          docs = docs.trim();
+          var short = shortDesc(docs);
+          if (short != docs) {
+            short = markdown(short);
+            var long = markdown(docs);
+            tdDesc.innerHTML = 
+            "<details><summary><div class=\"sum-less\">" + short + "</div>" + "<div class=\"sum-more\">" + long + "</div></summary></details>";
+          }
+          else {
+            tdDesc.innerHTML = markdown(short);
+          }
         } else {
-          tdDesc.textContent = "";
+          tdDesc.innerHTML = "<p><i>No documentation provided.</i><p>";
         }
       }
       domSectFns.classList.remove("hidden");
@@ -2897,7 +2907,7 @@ var zigAnalysis;
     });
   }
 
-  function shortDescMarkdown(docs) {
+  function shortDesc(docs){
     const trimmed_docs = docs.trim();
     let index = trimmed_docs.indexOf("\n\n");
     let cut = false;
@@ -2913,7 +2923,11 @@ var zigAnalysis;
 
     let slice = trimmed_docs.slice(0, index);
     if (cut) slice += "...";
-    return markdown(slice);
+    return slice;
+  }
+
+  function shortDescMarkdown(docs) {
+    return markdown(shortDesc(docs));
   }
 
   function markdown(input) {
@@ -3109,6 +3123,13 @@ var zigAnalysis;
         }
       }
       flushRun();
+
+      if (in_code) {
+        in_code = false;
+        parsing_code = false;
+        innerHTML += "</code>";
+        codetag = "";
+      }
 
       while (stack.length > 0) {
         const fmt = stack.pop();


### PR DESCRIPTION
This PR add dropdowns to function descriptions in the autodoc functions listing, allowing the user to see the full function description without leaving the page.

Also added _No documentation provided_ description for functions that aren't documented, as it makes the page layout more consistent.

Also fixed a bug in the markdown rendering code where half open code blocks weren't closed (that could happen if the text was sliced for the function description summary, or due to the source comment being malformed).

![firefox_1673373088](https://user-images.githubusercontent.com/11552304/211626660-dc4bebed-2dad-4ec4-86a5-e5a398111267.png)
