### PR TITLE
Fix buffer overflow in fmt when DAZ is set

### DIFF
--- a/lib/std/fmt/errol.zig
+++ b/lib/std/fmt/errol.zig
@@ -169,7 +169,8 @@ fn errolSlow(val: f64, buffer: []u8) FloatDecimal {
 
     // digit generation
     var buf_index: usize = 0;
-    while (true) {
+    const bound = buffer.len - 1;
+    while (buf_index < bound) {
         var hdig = @floatToInt(u8, @floor(high.val));
         if ((high.val == @intToFloat(f64, hdig)) and (high.off < 0)) hdig -= 1;
 


### PR DESCRIPTION
I noticed a program was segfaulting when formatting a number, which seemed weird. It only happens when you enable DAZ (denormals are zero) because errolSlow tries to use floating point math to format the number. If the number is a denormal this math will not work as expected, and the digit generating loop will run over the end of the buffer.

Issue demo: https://godbolt.org/z/Tn37a4d6K