### PR TITLE
float related C ABI fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -439,7 +439,7 @@ pub fn build(b: *Builder) !void {
         b.enable_wine,
         enable_symlinks_windows,
     ));
-    test_step.dependOn(tests.addCAbiTests(b, skip_non_native));
+    test_step.dependOn(tests.addCAbiTests(b, skip_non_native, skip_release));
     test_step.dependOn(tests.addLinkTests(b, test_filter, modes, enable_macos_sdk, skip_stage2_tests, enable_symlinks_windows));
     test_step.dependOn(tests.addStackTraceTests(b, test_filter, modes));
     test_step.dependOn(tests.addCliTests(b, test_filter, modes));

--- a/src/arch/x86_64/abi.zig
+++ b/src/arch/x86_64/abi.zig
@@ -5,7 +5,19 @@ const assert = std.debug.assert;
 const Register = @import("bits.zig").Register;
 const RegisterManagerFn = @import("../../register_manager.zig").RegisterManager;
 
-pub const Class = enum { integer, sse, sseup, x87, x87up, complex_x87, memory, none, win_i128 };
+pub const Class = enum {
+    integer,
+    sse,
+    sseup,
+    x87,
+    x87up,
+    complex_x87,
+    memory,
+    none,
+    win_i128,
+    float,
+    float_combine,
+};
 
 pub fn classifyWindows(ty: Type, target: Target) Class {
     // https://docs.microsoft.com/en-gb/cpp/build/x64-calling-convention?view=vs-2017
@@ -121,7 +133,11 @@ pub fn classifySystemV(ty: Type, target: Target, ctx: Context) [8]Class {
                 }
                 return result;
             },
-            32, 64 => {
+            32 => {
+                result[0] = .float;
+                return result;
+            },
+            64 => {
                 result[0] = .sse;
                 return result;
             },
@@ -252,6 +268,9 @@ pub fn classifySystemV(ty: Type, target: Target, ctx: Context) [8]Class {
                     combine: {
                         // "If both classes are equal, this is the resulting class."
                         if (result[result_i] == field_class[0]) {
+                            if (result[result_i] == .float) {
+                                result[result_i] = .float_combine;
+                            }
                             break :combine;
                         }
 

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -10478,6 +10478,14 @@ fn lowerFnRetTy(dg: *DeclGen, fn_info: Type.Payload.Function.Data) !*llvm.Type {
                                     llvm_types_buffer[llvm_types_index] = dg.context.doubleType();
                                     llvm_types_index += 1;
                                 },
+                                .float => {
+                                    llvm_types_buffer[llvm_types_index] = dg.context.floatType();
+                                    llvm_types_index += 1;
+                                },
+                                .float_combine => {
+                                    llvm_types_buffer[llvm_types_index] = dg.context.floatType().vectorType(2);
+                                    llvm_types_index += 1;
+                                },
                                 .x87 => {
                                     if (llvm_types_index != 0 or classes[2] != .none) {
                                         return dg.context.voidType();
@@ -10692,6 +10700,14 @@ const ParamTypeIterator = struct {
                                     },
                                     .sse, .sseup => {
                                         llvm_types_buffer[llvm_types_index] = dg.context.doubleType();
+                                        llvm_types_index += 1;
+                                    },
+                                    .float => {
+                                        llvm_types_buffer[llvm_types_index] = dg.context.floatType();
+                                        llvm_types_index += 1;
+                                    },
+                                    .float_combine => {
+                                        llvm_types_buffer[llvm_types_index] = dg.context.floatType().vectorType(2);
                                         llvm_types_index += 1;
                                     },
                                     .x87 => {

--- a/test/c_abi/cfuncs.c
+++ b/test/c_abi/cfuncs.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-void zig_panic();
+void zig_panic(void);
 
 static void assert_or_panic(bool ok) {
     if (!ok) {
@@ -58,6 +58,54 @@ static void assert_or_panic(bool ok) {
 
 #ifdef __riscv
 #  define ZIG_NO_COMPLEX
+#endif
+
+#ifdef __x86_64__
+#define ZIG_NO_RAW_F16
+#endif
+
+#ifdef __i386__
+#define ZIG_NO_RAW_F16
+#endif
+
+#ifdef __mips__
+#define ZIG_NO_RAW_F16
+#endif
+
+#ifdef __riscv
+#define ZIG_NO_RAW_F16
+#endif
+
+#ifdef __wasm__
+#define ZIG_NO_RAW_F16
+#endif
+
+#ifdef __powerpc__
+#define ZIG_NO_RAW_F16
+#endif
+
+#ifdef __aarch64__
+#define ZIG_NO_F128
+#endif
+
+#ifdef __arm__
+#define ZIG_NO_F128
+#endif
+
+#ifdef __mips__
+#define ZIG_NO_F128
+#endif
+
+#ifdef __riscv
+#define ZIG_NO_F128
+#endif
+
+#ifdef __powerpc__
+#define ZIG_NO_F128
+#endif
+
+#ifdef __APPLE__
+#define ZIG_NO_F128
 #endif
 
 #ifndef ZIG_NO_I128
@@ -884,3 +932,56 @@ void c_func_ptr_byval(void *a, void *b, struct ByVal in, unsigned long c, void *
     assert_or_panic((intptr_t)d == 4);
     assert_or_panic(e == 5);
 }
+
+#ifndef ZIG_NO_RAW_F16
+__fp16 c_f16(__fp16 a) {
+    assert_or_panic(a == 12);
+    return 34;
+}
+#endif
+
+typedef struct {
+    __fp16 a;
+} f16_struct;
+f16_struct c_f16_struct(f16_struct a) {
+    assert_or_panic(a.a == 12);
+    return (f16_struct){34};
+}
+
+#if defined __x86_64__ || defined __i386__
+typedef long double f80;
+f80 c_f80(f80 a) {
+    assert_or_panic((double)a == 12.34);
+    return 56.78;
+}
+typedef struct {
+    f80 a;
+} f80_struct;
+f80_struct c_f80_struct(f80_struct a) {
+    assert_or_panic((double)a.a == 12.34);
+    return (f80_struct){56.78};
+}
+typedef struct {
+    f80 a;
+    int b;
+} f80_extra_struct;
+f80_extra_struct c_f80_extra_struct(f80_extra_struct a) {
+    assert_or_panic((double)a.a == 12.34);
+    assert_or_panic(a.b == 42);
+    return (f80_extra_struct){56.78, 24};
+}
+#endif
+
+#ifndef ZIG_NO_F128
+__float128 c_f128(__float128 a) {
+    assert_or_panic((double)a == 12.34);
+    return 56.78;
+}
+typedef struct {
+    __float128 a;
+} f128_struct;
+f128_struct c_f128_struct(f128_struct a) {
+    assert_or_panic((double)a.a == 12.34);
+    return (f128_struct){56.78};
+}
+#endif

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -937,7 +937,6 @@ test "CFF: Zig returns to C" {
     try expectOk(c_assert_ret_CFF());
 }
 test "CFF: C passes to Zig" {
-    if (builtin.cpu.arch == .x86_64 and builtin.mode != .Debug) return error.SkipZigTest;
     if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isRISCV() and builtin.mode != .Debug) return error.SkipZigTest;
     if (builtin.cpu.arch == .aarch64 and builtin.mode != .Debug) return error.SkipZigTest;
@@ -948,7 +947,6 @@ test "CFF: C passes to Zig" {
     try expectOk(c_send_CFF());
 }
 test "CFF: C returns to Zig" {
-    if (builtin.cpu.arch == .x86_64 and builtin.mode != .Debug) return error.SkipZigTest;
     if (builtin.cpu.arch == .x86 and builtin.mode != .Debug) return error.SkipZigTest;
     if (builtin.cpu.arch == .aarch64 and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isRISCV() and builtin.mode != .Debug) return error.SkipZigTest;

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -4,7 +4,7 @@
 //! To run all the tests on the tier 1 architecture you can use:
 //! zig build test-c-abi -fqemu
 //! To run the tests on a specific architecture:
-//! zig test -fno-stage1 -lc main.zig cfuncs.c -target mips-linux --test-cmd qemu-mips --test-cmd-bin
+//! zig test -lc main.zig cfuncs.c -target mips-linux --test-cmd qemu-mips --test-cmd-bin
 const std = @import("std");
 const builtin = @import("builtin");
 const print = std.debug.print;
@@ -764,6 +764,7 @@ extern fn c_float_array_struct(FloatArrayStruct) void;
 extern fn c_ret_float_array_struct() FloatArrayStruct;
 
 test "Float array like struct" {
+    if (builtin.cpu.arch == .x86 and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
 
@@ -824,7 +825,9 @@ extern fn c_big_vec(BigVec) void;
 extern fn c_ret_big_vec() BigVec;
 
 test "big simd vector" {
+    if (comptime builtin.cpu.arch.isMIPS() and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
+    if (builtin.cpu.arch == .x86_64 and builtin.os.tag == .macos and builtin.mode != .Debug) return error.SkipZigTest;
 
     c_big_vec(.{ 1, 2, 3, 4, 5, 6, 7, 8 });
 
@@ -875,6 +878,8 @@ test "DC: Zig passes to C" {
     try expectOk(c_assert_DC(.{ .v1 = -0.25, .v2 = 15 }));
 }
 test "DC: Zig returns to C" {
+    if (builtin.cpu.arch == .x86 and builtin.mode != .Debug) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS() and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
@@ -888,6 +893,8 @@ test "DC: C passes to Zig" {
     try expectOk(c_send_DC());
 }
 test "DC: C returns to Zig" {
+    if (builtin.cpu.arch == .x86 and builtin.mode != .Debug) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS() and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
@@ -920,13 +927,17 @@ test "CFF: Zig passes to C" {
     try expectOk(c_assert_CFF(.{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 }));
 }
 test "CFF: Zig returns to C" {
+    if (builtin.cpu.arch == .x86 and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectOk(c_assert_ret_CFF());
 }
 test "CFF: C passes to Zig" {
+    if (builtin.cpu.arch == .x86_64 and builtin.mode != .Debug) return error.SkipZigTest;
     if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isRISCV() and builtin.mode != .Debug) return error.SkipZigTest;
+    if (builtin.cpu.arch == .aarch64 and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
@@ -934,6 +945,10 @@ test "CFF: C passes to Zig" {
     try expectOk(c_send_CFF());
 }
 test "CFF: C returns to Zig" {
+    if (builtin.cpu.arch == .x86_64 and builtin.mode != .Debug) return error.SkipZigTest;
+    if (builtin.cpu.arch == .x86 and builtin.mode != .Debug) return error.SkipZigTest;
+    if (builtin.cpu.arch == .aarch64 and builtin.mode != .Debug) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isRISCV() and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
@@ -967,6 +982,7 @@ test "PD: Zig passes to C" {
 }
 test "PD: Zig returns to C" {
     if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS() and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectOk(c_assert_ret_PD());
@@ -980,6 +996,7 @@ test "PD: C passes to Zig" {
 }
 test "PD: C returns to Zig" {
     if (builtin.target.cpu.arch == .x86) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS() and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
     try expectEqual(c_ret_PD(), .{ .v1 = null, .v2 = 0.5 });
@@ -1014,6 +1031,7 @@ extern fn c_modify_by_ref_param(ByRef) ByRef;
 
 test "C function modifies by ref param" {
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
+    if (builtin.cpu.arch == .x86_64 and builtin.os.tag == .windows and builtin.mode != .Debug) return error.SkipZigTest;
 
     const res = c_modify_by_ref_param(.{ .val = 1, .arr = undefined });
     try expect(res.val == 42);
@@ -1034,6 +1052,8 @@ const ByVal = extern struct {
 
 extern fn c_func_ptr_byval(*anyopaque, *anyopaque, ByVal, c_ulong, *anyopaque, c_ulong) void;
 test "C function that takes byval struct called via function pointer" {
+    if (builtin.cpu.arch == .x86 and builtin.mode != .Debug) return error.SkipZigTest;
+    if (comptime builtin.cpu.arch.isMIPS() and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
 
     var fn_ptr = &c_func_ptr_byval;


### PR DESCRIPTION
Trying to match what clang outputs while keeping the classification system similar to the documentation is somewhat difficult. I don't know how it'll be with the self-hosted backend but maybe it'd be better to just do our own thing?