### PR TITLE
wasi-libc: use __heap_end if available

### DIFF
--- a/lib/libc/wasi/emmalloc/emmalloc.c
+++ b/lib/libc/wasi/emmalloc/emmalloc.c
@@ -56,6 +56,7 @@
 
 // Defind by the linker to have the address of the start of the heap.
 extern unsigned char __heap_base;
+extern unsigned char __heap_end __attribute__((__weak__));
 
 // Behavior of right shifting a signed integer is compiler implementation defined.
 static_assert((((int32_t)0x80000000U) >> 31) == -1, "This malloc implementation requires that right-shifting a signed integer produces a sign-extending (arithmetic) shift!");
@@ -545,7 +546,10 @@ static bool claim_more_memory(size_t numBytes)
     // If this is the first time we're called, see if we can use
     // the initial heap memory set up by wasm-ld.
     if (!listOfAllRegions) {
-      unsigned char *heap_end = sbrk(0);
+      unsigned char *heap_end = &__heap_end;
+      if (heap_end == NULL)
+        heap_end = sbrk(0);
+
       if (numBytes <= (size_t)(heap_end - &__heap_base)) {
         startPtr = &__heap_base;
         endPtr = heap_end;


### PR DESCRIPTION
The symbol was introduced in LLD 15.0.7, as a way to know how much memory can be allocated:

https://github.com/llvm/llvm-project/commit/1095870e8ceddc5371f446f4e7c3473f89a461cd 

https://github.com/WebAssembly/wasi-libc/pull/377