### PR TITLE
stdlib: fix selectSymbol function pointers

### DIFF
--- a/lib/std/os/windows/user32.zig
+++ b/lib/std/os/windows/user32.zig
@@ -28,7 +28,7 @@ const POINT = windows.POINT;
 const HCURSOR = windows.HCURSOR;
 const HBRUSH = windows.HBRUSH;
 
-fn selectSymbol(comptime function_static: anytype, function_dynamic: @TypeOf(function_static), comptime os: std.Target.Os.WindowsVersion) @TypeOf(function_static) {
+fn selectSymbol(comptime function_static: anytype, function_dynamic: *const @TypeOf(function_static), comptime os: std.Target.Os.WindowsVersion) *const @TypeOf(function_static) {
     comptime {
         const sym_ok = builtin.os.isAtLeast(.windows, os);
         if (sym_ok == true) return function_static;


### PR DESCRIPTION
Fixes error with function pointers.

Code:
```zig
_ = try std.os.windows.user32.messageBoxW(null, std.unicode.utf8ToUtf16LeStringLiteral("hello"), std.unicode.utf8ToUtf16LeStringLiteral("world"), 0);
```

Before:
```
.local/zig/ver/zig-linux-x86_64-0.11.0-dev.1268+0e66df209/lib/std/os/windows/user32.zig:1585:48: error: unable to resolve comptime value
    const function = selectSymbol(MessageBoxW, pfnMessageBoxW, .win2k);
                                               ^~~~~~~~~~~~~~
.local/zig/ver/zig-linux-x86_64-0.11.0-dev.1268+0e66df209/lib/std/os/windows/user32.zig:1585:48: note: argument to parameter with comptime-only type must be comptime-known
.local/zig/ver/zig-linux-x86_64-0.11.0-dev.1268+0e66df209/lib/std/os/windows/user32.zig:31:139: note: expression is evaluated at comptime because the generic function was instantiated with a comptime-only return type
fn selectSymbol(comptime function_static: anytype, function_dynamic: @TypeOf(function_static), comptime os: std.Target.Os.WindowsVersion) @TypeOf(function_static) {

                  ^~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    messageBoxW: .local/zig/ver/zig-linux-x86_64-0.11.0-dev.1268+0e66df209/lib/std/os/windows/user32.zig:1585:22
    main: main.zig:4:30
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```

After:
```
No error produced.
```

Thanks to @Luukdegram.