### PR TITLE
autodoc: use js instead of details for collapsing descriptions

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -266,25 +266,23 @@
         font-weight: bold;
       }
 
-      details[open] summary .sum-less {
+      .expand[open] .sum-less {
         display: none;
       }
 
-      details[open] summary .sum-more {
+      .expand[open] .sum-more {
         display: block;
       }
 
-      details summary .sum-more {
+      .expand .sum-more {
         display: none;
       }
 
-      details summary {
-        list-style-type: none;
+      .expand {
         position: relative;
-        pointer-events: none;
       }
 
-      details summary::before {
+      .expand .button:before {
         content: "[+] ";
         font-family: var(--mono);
         color: var(--link-color);
@@ -298,7 +296,7 @@
         cursor: pointer;
       }
 
-      details[open] summary::before {
+      .expand[open] .button:before {
         content: "[-] ";
       }
 

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -2476,7 +2476,7 @@ var zigAnalysis;
             short = markdown(short);
             var long = markdown(docs);
             tdDesc.innerHTML = 
-            "<details ontoggle=\"scrollOnCollapse(event);\"><summary><div class=\"sum-less\">" + short + "</div>" + "<div class=\"sum-more\">" + long + "</div></summary></details>";
+            "<div class=\"expand\" ><span class=\"button\" onclick=\"toggleExpand(event)\"></span><div class=\"sum-less\">" + short + "</div>" + "<div class=\"sum-more\">" + long + "</div></details>";
           }
           else {
             tdDesc.innerHTML = markdown(short);
@@ -3718,12 +3718,11 @@ var zigAnalysis;
 
 })();
 
-function scrollOnCollapse(event) {
-  const details = event.target;
-  if (!details.open && details.getBoundingClientRect().top < 0) {
-    console.log("scrolling!")
-    details.parentElement.parentElement.scrollIntoView(true);
-  } else {
-    console.log("not scrolling!", details.open, details.top);
+function toggleExpand(event) {
+  const parent = event.target.parentElement;
+  parent.toggleAttribute("open");
+
+  if (!parent.open && parent.getBoundingClientRect().top < 0) {
+    parent.parentElement.parentElement.scrollIntoView(true);
   }
 }


### PR DESCRIPTION
This fixes various input problems related to the description being in the `<summary>` tag, which was not intended for that. Instead the solution uses a full js implementation to swap the short and long description using classes, which is okay because the documentations heavily rely on js to work in the first place.