### PR TITLE
wasm-linker: implement linking with WASI-libc

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -716,6 +716,7 @@ pub const File = struct {
         InvalidFeatureSet,
         InvalidFormat,
         InvalidIndex,
+        InvalidInitFunc,
         InvalidMagicByte,
         InvalidWasmVersion,
         LLDCrashed,

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -824,7 +824,9 @@ fn checkUndefinedSymbols(wasm: *const Wasm) !void {
             } else wasm.name;
             const import_name = if (undef.file) |file_index| name: {
                 const obj = wasm.objects.items[file_index];
-                const name_index = obj.findImport(symbol.tag.externalType(), symbol.index).name;
+                const name_index = if (symbol.tag == .function) name_index: {
+                    break :name_index obj.findImport(symbol.tag.externalType(), symbol.index).name;
+                } else symbol.name;
                 break :name obj.string_table.get(name_index);
             } else wasm.string_table.get(wasm.imports.get(undef).?.name);
             log.err("could not resolve undefined symbol '{s}'", .{import_name});

--- a/src/link/Wasm/types.zig
+++ b/src/link/Wasm/types.zig
@@ -129,6 +129,7 @@ pub const Segment = struct {
     /// file or binary. When `merge_segments` is true, this will return the
     /// short name. i.e. ".rodata". When false, it returns the entire name instead.
     pub fn outputName(self: Segment, merge_segments: bool) []const u8 {
+        if (std.mem.startsWith(u8, self.name, ".synthetic")) return ".synthetic"; // always merge
         if (!merge_segments) return self.name;
         if (std.mem.startsWith(u8, self.name, ".rodata.")) {
             return ".rodata";


### PR DESCRIPTION
This implements the remaining features left to allow the in-house linker to link with WASI-libc. This means we now support c constructors in the form of `__wasm_call_ctors` which will call each constructor based on its priority. It also creates symbols for `__heap_base` and `__heap_end` when any of the linked object files reference the symbol. Those symbols are then used to perform relocations so the runtime knows where the heap starts and ends. This is useful to know for allocators such as sbrk.
