### PR TITLE
build: avoid zig's libc++ on *-windows-msvc

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -574,8 +574,11 @@ fn addCmakeCfgOptionsToExe(
                 };
                 exe.linkSystemLibrary("unwind");
             },
-            .ios, .macos, .watchos, .tvos, .windows => {
+            .ios, .macos, .watchos, .tvos => {
                 exe.linkLibCpp();
+            },
+            .windows => {
+                if (exe.target.getAbi() != .msvc) exe.linkLibCpp();
             },
             .freebsd => {
                 if (static) {


### PR DESCRIPTION
https://github.com/ziglang/zig/commit/741445ce298df5136553802f2681ca8dc5ad596f started linking zig's libcpp on windows, but `libcxxabi` can't build under msvc.

Fixes: https://github.com/ziglang/zig/issues/11777
Related: https://github.com/ziglang/zig/issues/5312