### PR TITLE
swap align and callconv in function typeName

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -1689,13 +1689,13 @@ pub const Type = extern union {
                         try writer.writeAll("...");
                     }
                     try writer.writeAll(") ");
+                    if (payload.alignment != 0) {
+                        try writer.print("align({d}) ", .{payload.alignment});
+                    }
                     if (payload.cc != .Unspecified) {
                         try writer.writeAll("callconv(.");
                         try writer.writeAll(@tagName(payload.cc));
                         try writer.writeAll(") ");
-                    }
-                    if (payload.alignment != 0) {
-                        try writer.print("align({d}) ", .{payload.alignment});
                     }
                     ty = payload.return_type;
                     continue;
@@ -2084,13 +2084,13 @@ pub const Type = extern union {
                     try writer.writeAll("...");
                 }
                 try writer.writeAll(") ");
+                if (fn_info.alignment != 0) {
+                    try writer.print("align({d}) ", .{fn_info.alignment});
+                }
                 if (fn_info.cc != .Unspecified) {
                     try writer.writeAll("callconv(.");
                     try writer.writeAll(@tagName(fn_info.cc));
                     try writer.writeAll(") ");
-                }
-                if (fn_info.alignment != 0) {
-                    try writer.print("align({d}) ", .{fn_info.alignment});
                 }
                 if (fn_info.return_type.tag() == .generic_poison) {
                     try writer.writeAll("anytype");

--- a/test/behavior/typename.zig
+++ b/test/behavior/typename.zig
@@ -80,11 +80,11 @@ test "basic" {
     try expectEqualStrings("fn(comptime u32) void", @typeName(fn (comptime u32) void));
     try expectEqualStrings("fn(noalias []u8) void", @typeName(fn (noalias []u8) void));
 
-    try expectEqualStrings("fn() align(2) void", @typeName(fn () align(2) void));
+    try expectEqualStrings("fn() align(32) void", @typeName(fn () align(32) void));
     try expectEqualStrings("fn() callconv(.C) void", @typeName(fn () callconv(.C) void));
-    try expectEqualStrings("fn() align(2) callconv(.C) void", @typeName(fn () align(2) callconv(.C) void));
-    try expectEqualStrings("fn(...) align(2) callconv(.C) void", @typeName(fn (...) align(2) callconv(.C) void));
-    try expectEqualStrings("fn(u32, ...) align(2) callconv(.C) void", @typeName(fn (u32, ...) align(2) callconv(.C) void));
+    try expectEqualStrings("fn() align(32) callconv(.C) void", @typeName(fn () align(32) callconv(.C) void));
+    try expectEqualStrings("fn(...) align(32) callconv(.C) void", @typeName(fn (...) align(32) callconv(.C) void));
+    try expectEqualStrings("fn(u32, ...) align(32) callconv(.C) void", @typeName(fn (u32, ...) align(32) callconv(.C) void));
 }
 
 test "top level decl" {

--- a/test/behavior/typename.zig
+++ b/test/behavior/typename.zig
@@ -69,9 +69,22 @@ test "basic" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
-    try expectEqualStrings(@typeName(i64), "i64");
-    try expectEqualStrings(@typeName(*usize), "*usize");
-    try expectEqualStrings(@typeName([]u8), "[]u8");
+    try expectEqualStrings("i64", @typeName(i64));
+    try expectEqualStrings("*usize", @typeName(*usize));
+    try expectEqualStrings("[]u8", @typeName([]u8));
+
+    try expectEqualStrings("fn() void", @typeName(fn () void));
+    try expectEqualStrings("fn(u32) void", @typeName(fn (u32) void));
+    try expectEqualStrings("fn(u32) void", @typeName(fn (a: u32) void));
+
+    try expectEqualStrings("fn(comptime u32) void", @typeName(fn (comptime u32) void));
+    try expectEqualStrings("fn(noalias []u8) void", @typeName(fn (noalias []u8) void));
+
+    try expectEqualStrings("fn() align(2) void", @typeName(fn () align(2) void));
+    try expectEqualStrings("fn() callconv(.C) void", @typeName(fn () callconv(.C) void));
+    try expectEqualStrings("fn() align(2) callconv(.C) void", @typeName(fn () align(2) callconv(.C) void));
+    try expectEqualStrings("fn(...) align(2) callconv(.C) void", @typeName(fn (...) align(2) callconv(.C) void));
+    try expectEqualStrings("fn(u32, ...) align(2) callconv(.C) void", @typeName(fn (u32, ...) align(2) callconv(.C) void));
 }
 
 test "top level decl" {


### PR DESCRIPTION
The zig grammar expects the alignment expression of a function prototype before the calling convention, but printing the type will show the calling convention first.

```zig
test {
    // this shouldn't fail
    try expectEqualStrings(
        @typeName(fn () align(2) callconv(.C) void),
        "fn() align(2) callconv(.C) void"
    );
}
```
Also, there is no space between `fn` and the parameter decls even though `zig fmt` will put a space there. Don't know if this is intentional or should also be changed.