### PR TITLE
Sema: automatically optimize order of struct fields

### DIFF
--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -954,7 +954,7 @@ pub const IO_Uring = struct {
     pub fn register_files_update(self: *IO_Uring, offset: u32, fds: []const os.fd_t) !void {
         assert(self.fd >= 0);
 
-        const FilesUpdate = struct {
+        const FilesUpdate = extern struct {
             offset: u32,
             resv: u32,
             fds: u64 align(8),

--- a/src/type.zig
+++ b/src/type.zig
@@ -5741,10 +5741,14 @@ pub const Type = extern union {
         target: Target,
 
         pub fn next(it: *StructOffsetIterator) ?FieldOffset {
-            const i = it.field;
+            var i = it.field;
             if (it.struct_obj.fields.count() <= i)
                 return null;
 
+            if (it.struct_obj.optimized_order) |some| {
+                i = some[i];
+                if (i == Module.Struct.omitted_field) return null;
+            }
             const field = it.struct_obj.fields.values()[i];
             it.field += 1;
 

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1555,3 +1555,21 @@ test "optional generic function label struct field" {
     };
     try expect((Options{}).isFoo.?(u8) == 123);
 }
+
+test "struct fields get automatically reordered" {
+    if (builtin.zig_backend != .stage2_llvm) return error.SkipZigTest; // TODO
+
+    const S1 = struct {
+        a: u32,
+        b: u32,
+        c: bool,
+        d: bool,
+    };
+    const S2 = struct {
+        a: u32,
+        b: bool,
+        c: u32,
+        d: bool,
+    };
+    try expect(@sizeOf(S1) == @sizeOf(S2));
+}


### PR DESCRIPTION
This is a simple starting version of the optimization described in #168 where the fields are just sorted by order of descending alignment.