### PR TITLE
std.http.Client: default to lazy root cert scanning

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4098,7 +4098,6 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
         if (!build_options.omit_pkg_fetching_code) {
             var http_client: std.http.Client = .{ .allocator = gpa };
             defer http_client.deinit();
-            try http_client.rescanRootCertificates();
 
             // Here we provide an import to the build runner that allows using reflection to find
             // all of the dependencies. Without this, there would be no way to use `@import` to


### PR DESCRIPTION
After this change, the system will be inspected for root certificates only upon the first https request that actually occurs. This makes the compiler no longer do SSL certificate scanning when running `zig build` if no network requests are made.