### PR TITLE
lib: add panic test runner

### DIFF
--- a/lib/panic_runner.zig
+++ b/lib/panic_runner.zig
@@ -1,0 +1,284 @@
+//! Panic test runner
+//! Control starts itself as Runner as childprocess as
+//! [test_runner_exe_path, test_nr, msg_pipe handle].
+//! Runner writes
+//! [passed, skipped, failed, panic_type]
+//! into msg_pipe to TC.
+//! TODO: clarify, if a timeout should be offered as available opt-in functionality.
+
+// TODO async signal safety => reads can fail
+// or be interrupted
+const std = @import("std");
+const io = std.io;
+const builtin = @import("builtin");
+const os = std.os;
+const ChildProcess = std.ChildProcess;
+const child_process = std.child_process;
+const pipe_rd = child_process.pipe_rd;
+const pipe_wr = child_process.pipe_wr;
+
+const Global = struct {
+    const max_panic_msg_size = 4096;
+    // used by runner
+    msg_pipe: os.fd_t,
+    buf_panic_msg: [Global.max_panic_msg_size]u8,
+    buf_panic_msg_fill: usize,
+
+    // used by controller and runner
+    is_runner_panic: bool,
+    passed: usize,
+    skipped: usize,
+    failed: usize,
+};
+var global = Global{
+    .msg_pipe = undefined,
+    .is_runner_panic = false,
+    .passed = 0,
+    .skipped = 0,
+    .failed = 0,
+    .buf_panic_msg = [_]u8{0} ** Global.max_panic_msg_size,
+    .buf_panic_msg_fill = 0,
+};
+
+const PanicT = enum(u8) {
+    nopanic,
+    expected_panic,
+    unexpected_panic,
+};
+
+/// This function is only working correctly inside test blocks. It writes an
+/// expected panic message to a global buffer only available in panic_testrunner.zig,
+/// which is compared by the Runner in the panic handler once it is called.
+/// TODO: This has workaround semantics for an always called missing exit handler
+/// or set of functions to assert that the panic is always called.
+/// This would include catching all signals (SIGSEV etc), but may not be desired
+/// by the user, since user may rely on signaling for runtime behavior of tests.
+pub fn writeExpectedPanicMsg(panic_msg: []const u8) void {
+    // do bounds checks for first and last element manually, but omit the others.
+    std.debug.assert(panic_msg.len < global.buf_panic_msg.len);
+    std.debug.assert(panic_msg.len > 0);
+    global.buf_panic_msg[0] = panic_msg[0];
+    @memcpy(@ptrCast([*]u8, &global.buf_panic_msg[0]), panic_msg.ptr, panic_msg.len);
+    global.buf_panic_msg_fill = panic_msg.len;
+}
+
+// Overwritten panic routine
+// TODO: synchronization etc
+pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
+    @setCold(true);
+    _ = stack_trace;
+    if (global.is_runner_panic) {
+        var msg_pipe_file = std.fs.File{
+            .handle = global.msg_pipe,
+        };
+
+        const msg_wr = msg_pipe_file.writer();
+        // [passed, skipped, failed, nopanic|panic|expected_panic]
+        msg_wr.writeIntNative(usize, global.passed) catch unreachable;
+        msg_wr.writeIntNative(usize, global.skipped) catch unreachable;
+        msg_wr.writeIntNative(usize, global.failed) catch unreachable;
+
+        if (std.mem.eql(u8, message, global.buf_panic_msg[0..global.buf_panic_msg_fill])) {
+            std.debug.print("execpted panic\n", .{});
+            msg_wr.writeByte(@intCast(u8, @enumToInt(PanicT.expected_panic))) catch unreachable;
+            msg_pipe_file.close(); // workaround process.exit
+            std.process.exit(0);
+        } else {
+            std.debug.print("unexecpted panic\n", .{});
+            msg_wr.writeByte(@intCast(u8, @enumToInt(PanicT.unexpected_panic))) catch unreachable;
+            msg_pipe_file.close(); // workaround process.exit
+            std.debug.panic("{s}", .{message});
+        }
+    }
+    std.debug.panic("{s}", .{message});
+    switch (builtin.os.tag) {
+        .freestanding, .other, .amdhsa, .amdpal => while (true) {},
+        else => std.os.abort(),
+    }
+}
+
+const State = enum {
+    Control,
+    Worker,
+};
+
+const Cli = struct {
+    state: State,
+    test_nr: u64,
+    test_runner_exe_path: []u8,
+};
+
+// path_to_testbinary, test number(u32), string(*anyopaque = 64bit)
+var buffer: [std.fs.MAX_PATH_BYTES + 30]u8 = undefined;
+var FixedBufferAlloc = std.heap.FixedBufferAllocator.init(buffer[0..]);
+var fixed_alloc = FixedBufferAlloc.allocator();
+
+fn processArgs(static_alloc: std.mem.Allocator) Cli {
+    const args = std.process.argsAlloc(static_alloc) catch {
+        @panic("Too many bytes passed over the CLI to Test Runner/Control.");
+    };
+    var cli = Cli{
+        .state = undefined,
+        .test_nr = undefined,
+        .test_runner_exe_path = undefined,
+    };
+    if (args.len == 3) {
+        // disable inheritance asap
+        global.msg_pipe = std.os.stringToHandle(args[2]) catch unreachable;
+        os.disableInheritance(global.msg_pipe) catch unreachable;
+        global.is_runner_panic = true;
+
+        cli.state = .Worker;
+        cli.test_nr = std.fmt.parseUnsigned(u64, args[1], 10) catch unreachable;
+        std.debug.print("test worker (exe_path test_nr handle: ", .{});
+        std.debug.print("{s} {s} {s}\n", .{ args[0], args[1], args[2] });
+    } else {
+        cli.state = .Control;
+        cli.test_nr = 0;
+        std.debug.print("test control: {s}\n", .{args[0]});
+    }
+    cli.test_runner_exe_path = args[0];
+    return cli;
+}
+
+// args: path_to_testbinary, [test_nr pipe_worker_to_ctrl]
+pub fn main() !void {
+    var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+    defer std.debug.assert(!general_purpose_allocator.deinit());
+    const gpa = general_purpose_allocator.allocator();
+
+    var cli = processArgs(fixed_alloc);
+    switch (cli.state) {
+        .Control => {
+            // pipe Worker => Controller
+            var buf_handle: [os.handleCharSize]u8 = comptime [_]u8{0} ** os.handleCharSize;
+            var buf_tests_done: [10]u8 = [_]u8{0} ** 10;
+            var tests_done: usize = 0;
+            const tests_todo = builtin.test_functions.len;
+
+            while (tests_done < tests_todo) {
+                var pipe = try child_process.portablePipe();
+                defer os.close(pipe[pipe_rd]);
+                const handle_s = os.handleToString(pipe[pipe_wr], &buf_handle) catch unreachable;
+                const tests_done_s = std.fmt.bufPrint(&buf_tests_done, "{d}", .{tests_done}) catch unreachable;
+                var child_proc = ChildProcess.init(
+                    &.{ cli.test_runner_exe_path, tests_done_s, handle_s },
+                    gpa,
+                );
+
+                {
+                    // close pipe end asap before it leaks anywhere
+                    defer os.close(pipe[pipe_wr]);
+                    try os.enableInheritance(pipe[pipe_wr]);
+
+                    try child_proc.spawn();
+                }
+                const ret_term = try child_proc.wait();
+                std.debug.print("ret_term: {any}\n", .{ret_term.Exited});
+                if (ret_term.Exited != @enumToInt(ChildProcess.Term.Exited)) {
+                    @panic("TODO: handle printing message for exit reason.");
+                }
+                if (ret_term.Exited != 0) {
+                    @panic("TODO: handle printing message for non-0 return code.");
+                }
+
+                var file = std.fs.File{
+                    .handle = pipe[pipe_rd],
+                };
+                const file_rd = file.reader();
+                const ret_passed = try file_rd.readIntNative(usize);
+                std.debug.print("ctrl passed: {d}\n", .{ret_passed});
+                const ret_skipped = try file_rd.readIntNative(usize);
+                std.debug.print("ctrl skipped: {d}\n", .{ret_skipped});
+                const ret_failed = try file_rd.readIntNative(usize);
+                std.debug.print("ctrl fail: {d}\n", .{ret_failed});
+                global.passed += ret_passed;
+                global.skipped += ret_skipped;
+                global.failed += ret_failed;
+                tests_done += ret_passed + ret_skipped + ret_failed;
+
+                const ret_panic_u = try file_rd.readByte();
+                const panic_t = @intToEnum(PanicT, ret_panic_u);
+                switch (panic_t) {
+                    .nopanic => {
+                        // tests must be finished or this is in an error
+                        break;
+                    },
+                    .expected_panic => {
+                        // sum numbers + restart on new test fn
+                        global.passed += 1;
+                        tests_done += 1;
+                        continue;
+                    },
+                    .unexpected_panic => {
+                        // clean exit with writing total count status
+                        // error message has been already written by child process
+                        const stderr = std.io.getStdErr();
+                        stderr.writeAll("FAIL: unexpected panic: ") catch {};
+                        writeInt(stderr, global.passed) catch {};
+                        stderr.writeAll(" passed; ") catch {};
+                        writeInt(stderr, global.skipped) catch {};
+                        stderr.writeAll(" skipped; ") catch {};
+                        writeInt(stderr, global.failed) catch {};
+                        stderr.writeAll(" failed.\n") catch {};
+                        std.process.exit(1);
+                    },
+                }
+            }
+            const stderr = std.io.getStdErr();
+            stderr.writeAll("SUCCESS: ") catch {};
+            writeInt(stderr, global.passed) catch {};
+            stderr.writeAll(" passed; ") catch {};
+            writeInt(stderr, global.skipped) catch {};
+            stderr.writeAll(" skipped; ") catch {};
+            writeInt(stderr, global.failed) catch {};
+            stderr.writeAll(" failed.\n") catch {};
+            std.process.exit(0);
+        },
+        .Worker => {
+            // state is global, so that panic function has access to it.
+            global.passed = 0;
+            global.skipped = 0;
+            global.failed = 0;
+
+            for (builtin.test_functions[cli.test_nr..]) |test_fn| {
+                test_fn.func() catch |err| {
+                    if (err != error.SkipZigTest) {
+                        global.failed += 1;
+                    } else {
+                        global.skipped += 1;
+                    }
+                };
+                global.passed += 1;
+            }
+
+            var msg_pipe_file = std.fs.File{
+                .handle = global.msg_pipe,
+            };
+            defer msg_pipe_file.close();
+            const msg_wr = msg_pipe_file.writer();
+            // [passed, skipped, failed, panic?, message_len, optional_message]
+            try msg_wr.writeIntNative(usize, global.passed);
+            try msg_wr.writeIntNative(usize, global.skipped);
+            try msg_wr.writeIntNative(usize, global.failed);
+            try msg_wr.writeByte(@intCast(u8, @boolToInt(false)));
+            try msg_wr.writeIntNative(usize, 0);
+        },
+    }
+}
+
+fn writeInt(stderr: std.fs.File, int: usize) anyerror!void {
+    const base = 10;
+    var buf: [100]u8 = undefined;
+    var a: usize = int;
+    var index: usize = buf.len;
+    while (true) {
+        const digit = a % base;
+        index -= 1;
+        buf[index] = std.fmt.digitToChar(@intCast(u8, digit), .lower);
+        a /= base;
+        if (a == 0) break;
+    }
+    const slice = buf[index..];
+    try stderr.writeAll(slice);
+}

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -640,7 +640,7 @@ pub const ChildProcess = struct {
     fn spawnWindows(self: *ChildProcess) SpawnError!void {
         const saAttr = windows.SECURITY_ATTRIBUTES{
             .nLength = @sizeOf(windows.SECURITY_ATTRIBUTES),
-            .bInheritHandle = windows.TRUE,
+            .bInheritHandle = windows.FALSE,
             .lpSecurityDescriptor = null,
         };
 
@@ -691,11 +691,24 @@ pub const ChildProcess = struct {
             windowsDestroyPipe(g_hChildStd_IN_Rd, g_hChildStd_IN_Wr);
         };
 
+        var tmp_hChildStd_Rd: windows.HANDLE = undefined;
+        var tmp_hChildStd_Wr: windows.HANDLE = undefined;
         var g_hChildStd_OUT_Rd: ?windows.HANDLE = null;
         var g_hChildStd_OUT_Wr: ?windows.HANDLE = null;
         switch (self.stdout_behavior) {
             StdIo.Pipe => {
-                try windowsMakeAsyncPipe(&g_hChildStd_OUT_Rd, &g_hChildStd_OUT_Wr, &saAttr);
+                try windowsMakeAsyncPipe(
+                    &tmp_hChildStd_Rd,
+                    &tmp_hChildStd_Wr,
+                    &saAttr,
+                );
+                errdefer {
+                    os.close(tmp_hChildStd_Rd);
+                    os.close(tmp_hChildStd_Wr);
+                }
+                try windows.SetHandleInformation(tmp_hChildStd_Wr, windows.HANDLE_FLAG_INHERIT, 1);
+                g_hChildStd_OUT_Rd = tmp_hChildStd_Rd;
+                g_hChildStd_OUT_Wr = tmp_hChildStd_Wr;
             },
             StdIo.Ignore => {
                 g_hChildStd_OUT_Wr = nul_handle;
@@ -715,7 +728,18 @@ pub const ChildProcess = struct {
         var g_hChildStd_ERR_Wr: ?windows.HANDLE = null;
         switch (self.stderr_behavior) {
             StdIo.Pipe => {
-                try windowsMakeAsyncPipe(&g_hChildStd_ERR_Rd, &g_hChildStd_ERR_Wr, &saAttr);
+                try windowsMakeAsyncPipe(
+                    &tmp_hChildStd_Rd,
+                    &tmp_hChildStd_Wr,
+                    &saAttr,
+                );
+                errdefer {
+                    os.close(tmp_hChildStd_Rd);
+                    os.close(tmp_hChildStd_Wr);
+                }
+                try windows.SetHandleInformation(tmp_hChildStd_Wr, windows.HANDLE_FLAG_INHERIT, 1);
+                g_hChildStd_ERR_Rd = tmp_hChildStd_Rd;
+                g_hChildStd_ERR_Wr = tmp_hChildStd_Wr;
             },
             StdIo.Ignore => {
                 g_hChildStd_ERR_Wr = nul_handle;
@@ -912,6 +936,28 @@ pub const ChildProcess = struct {
         }
     }
 };
+
+/// Pipe read side
+pub const pipe_rd = 0;
+/// Pipe write side
+pub const pipe_wr = 1;
+const PortPipeT = if (builtin.os.tag == .windows) [2]windows.HANDLE else [2]os.fd_t;
+
+/// Portable pipe creation with disabled inheritance
+pub inline fn portablePipe() !PortPipeT {
+    var pipe_new: PortPipeT = undefined;
+    if (builtin.os.tag == .windows) {
+        const saAttr = windows.SECURITY_ATTRIBUTES{
+            .nLength = @sizeOf(windows.SECURITY_ATTRIBUTES),
+            .bInheritHandle = windows.FALSE,
+            .lpSecurityDescriptor = null,
+        };
+        try windowsMakeAsyncPipe(&pipe_new[pipe_rd], &pipe_new[pipe_wr], &saAttr);
+    } else {
+        pipe_new = try os.pipe2(@as(u32, os.O.CLOEXEC));
+    }
+    return pipe_new;
+}
 
 /// Expects `app_buf` to contain exactly the app name, and `dir_buf` to contain exactly the dir path.
 /// After return, `app_buf` will always contain exactly the app name and `dir_buf` will always contain exactly the dir path.
@@ -1143,30 +1189,25 @@ fn windowsCreateProcessPathExt(
 }
 
 fn windowsCreateProcess(app_name: [*:0]u16, cmd_line: [*:0]u16, envp_ptr: ?[*]u16, cwd_ptr: ?[*:0]u16, lpStartupInfo: *windows.STARTUPINFOW, lpProcessInformation: *windows.PROCESS_INFORMATION) !void {
-    // TODO the docs for environment pointer say:
-    // > A pointer to the environment block for the new process. If this parameter
-    // > is NULL, the new process uses the environment of the calling process.
-    // > ...
-    // > An environment block can contain either Unicode or ANSI characters. If
-    // > the environment block pointed to by lpEnvironment contains Unicode
-    // > characters, be sure that dwCreationFlags includes CREATE_UNICODE_ENVIRONMENT.
-    // > If this parameter is NULL and the environment block of the parent process
-    // > contains Unicode characters, you must also ensure that dwCreationFlags
-    // > includes CREATE_UNICODE_ENVIRONMENT.
-    // This seems to imply that we have to somehow know whether our process parent passed
-    // CREATE_UNICODE_ENVIRONMENT if we want to pass NULL for the environment parameter.
-    // Since we do not know this information that would imply that we must not pass NULL
-    // for the parameter.
-    // However this would imply that programs compiled with -DUNICODE could not pass
-    // environment variables to programs that were not, which seems unlikely.
-    // More investigation is needed.
+    // See https://stackoverflow.com/a/4207169/9306292
+    // One can manually write in unicode even if one doesn't compile in unicode
+    // (-DUNICODE).
+    // Thus CREATE_UNICODE_ENVIRONMENT, according to how one constructed the
+    // environment block, is necessary, since CreateProcessA and CreateProcessW may
+    // work with either Ansi or Unicode.
+    // * The environment variables can still be inherited from parent process,
+    //   if set to NULL
+    // * The OS can for an unspecified environment block not figure out,
+    //   if it is Unicode or ANSI.
+    // * Applications may break without specification of the environment variable
+    //   due to inability of Windows to check (+translate) the character encodings.
     return windows.CreateProcessW(
         app_name,
         cmd_line,
         null,
         null,
         windows.TRUE,
-        windows.CREATE_UNICODE_ENVIRONMENT,
+        @enumToInt(windows.PROCESS_CREATION_FLAGS.CREATE_UNICODE_ENVIRONMENT),
         @ptrCast(?*anyopaque, envp_ptr),
         cwd_ptr,
         lpStartupInfo,
@@ -1283,14 +1324,22 @@ fn windowsMakePipeIn(rd: *?windows.HANDLE, wr: *?windows.HANDLE, sattr: *const w
     var wr_h: windows.HANDLE = undefined;
     try windows.CreatePipe(&rd_h, &wr_h, sattr);
     errdefer windowsDestroyPipe(rd_h, wr_h);
-    try windows.SetHandleInformation(wr_h, windows.HANDLE_FLAG_INHERIT, 0);
+    try windows.SetHandleInformation(rd_h, windows.HANDLE_FLAG_INHERIT, 1);
     rd.* = rd_h;
     wr.* = wr_h;
 }
 
 var pipe_name_counter = std.atomic.Atomic(u32).init(1);
 
-fn windowsMakeAsyncPipe(rd: *?windows.HANDLE, wr: *?windows.HANDLE, sattr: *const windows.SECURITY_ATTRIBUTES) !void {
+/// To enable/disable inheritance parent and child process, use
+/// os.enableInheritance() and os.disableInheritance() on the handle.
+/// convention: sattr uses bInheritHandle = windows.FALSE and only used pipe end
+/// is enabled.
+pub fn windowsMakeAsyncPipe(
+    rd: *windows.HANDLE,
+    wr: *windows.HANDLE,
+    sattr: *const windows.SECURITY_ATTRIBUTES,
+) !void {
     var tmp_bufw: [128]u16 = undefined;
 
     // Anonymous pipes are built upon Named pipes.
@@ -1343,9 +1392,6 @@ fn windowsMakeAsyncPipe(rd: *?windows.HANDLE, wr: *?windows.HANDLE, sattr: *cons
             else => |err| return windows.unexpectedError(err),
         }
     }
-    errdefer os.close(write_handle);
-
-    try windows.SetHandleInformation(read_handle, windows.HANDLE_FLAG_INHERIT, 0);
 
     rd.* = read_handle;
     wr.* = write_handle;

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -223,6 +223,8 @@ pub extern "kernel32" fn GetFullPathNameW(
     lpFilePart: ?*?[*:0]u16,
 ) callconv(@import("std").os.windows.WINAPI) u32;
 
+pub extern "kernel32" fn GetHandleInformation(hObject: HANDLE, dwFlags: *DWORD) callconv(WINAPI) BOOL;
+
 pub extern "kernel32" fn GetOverlappedResult(hFile: HANDLE, lpOverlapped: *OVERLAPPED, lpNumberOfBytesTransferred: *DWORD, bWait: BOOL) callconv(WINAPI) BOOL;
 
 pub extern "kernel32" fn GetProcessHeap() callconv(WINAPI) ?HANDLE;

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -55,6 +55,7 @@ pub const base64 = @import("base64.zig");
 pub const bit_set = @import("bit_set.zig");
 pub const builtin = @import("builtin.zig");
 pub const c = @import("c.zig");
+pub const child_process = @import("child_process.zig");
 pub const coff = @import("coff.zig");
 pub const compress = @import("compress.zig");
 pub const crypto = @import("crypto.zig");

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -917,10 +917,10 @@ test "expectEqualDeep composite type" {
 }
 
 // TODO: test blocks can observe their own index fn argument.
-// Do not leaks implementation details from the test runner into libstd.
+// Do not leak implementation details from the test runner into libstd.
 // `test_fns_i` is index into builtin.test_functions set by test runner.
-const TestFn_iT = if (!builtin.is_test) u32 else void;
-threadlocal var test_fns_i: TestFn_iT = if (!builtin.is_test) 0 else void;
+const TestFn_iT = if (builtin.is_test) usize else void;
+pub threadlocal var test_fns_i: TestFn_iT = if (builtin.is_test) 0 else {};
 
 /// Send expected panic message to server from test runner, spawns itself as a
 /// child process with the test number, tells the server pid and process group

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -916,6 +916,26 @@ test "expectEqualDeep composite type" {
     }
 }
 
+// TODO: test blocks can observe their own index fn argument.
+// Do not leaks implementation details from the test runner into libstd.
+// `test_fns_i` is index into builtin.test_functions set by test runner.
+const TestFn_iT = if (!builtin.is_test) u32 else void;
+threadlocal var test_fns_i: TestFn_iT = if (!builtin.is_test) 0 else void;
+
+/// Send expected panic message to server from test runner, spawns itself as a
+/// child process with the test number, tells the server pid and process group
+/// of child and waits for the child process. The child process executes exactly
+/// one test block up to panic or returns with error code 1.
+/// If another expected panic message has been received by the server for the
+/// same test block, then the test is marked as error.InvalidPanicMsg and the
+/// child of the test runner thread is terminated via pid and process group,
+///
+/// In case no server is desired, the to be run test block is provided as cli
+/// argument.
+pub fn expectPanic(msg: []const u8) !void {
+    _ = msg;
+}
+
 fn printIndicatorLine(source: []const u8, indicator_index: usize) void {
     const line_begin_index = if (std.mem.lastIndexOfScalar(u8, source[0..indicator_index], '\n')) |line_begin|
         line_begin + 1

--- a/lib/std/zig/Server.zig
+++ b/lib/std/zig/Server.zig
@@ -42,7 +42,7 @@ pub const Message = struct {
     ///   - 0 means not async
     /// * expected_panic_msg: [tests_len]u32,
     ///   - null-terminated string_bytes index
-    ///   - 0 means does not expect pani
+    ///   - 0 means does not expect panic
     /// * string_bytes: [string_bytes_len]u8,
     pub const TestMetadata = extern struct {
         string_bytes_len: u32,

--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -146,6 +146,7 @@ fn mainTerminal() void {
 
     var leaks: usize = 0;
     for (test_fn_list, 0..) |test_fn, i| {
+        std.testing.test_fns_i = i;
         std.testing.allocator_instance = .{};
         defer {
             if (std.testing.allocator_instance.deinit() == .leak) {

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -137,6 +137,10 @@ pub const build_cases = [_]BuildCase{
         .build_root = "test/standalone/install_raw_hex",
         .import = @import("standalone/install_raw_hex/build.zig"),
     },
+    .{
+        .build_root = "test/standalone/childprocess_extrapipe",
+        .import = @import("standalone/childprocess_extrapipe/build.zig"),
+    },
     // TODO take away EmitOption.emit_to option and make it give a FileSource
     //.{
     //    .build_root = "test/standalone/emit_asm_and_bin",

--- a/test/standalone/childprocess_extrapipe/build.zig
+++ b/test/standalone/childprocess_extrapipe/build.zig
@@ -17,7 +17,8 @@ pub fn build(b: *Builder) void {
         .target = target,
         .optimize = optimize,
     });
-    const run_cmd = parent.run();
+    const run_cmd = b.addRunArtifact(parent);
+    run_cmd.expectExitCode(0);
     run_cmd.addArtifactArg(child);
 
     const test_step = b.step("test", "Test it");

--- a/test/standalone/childprocess_extrapipe/build.zig
+++ b/test/standalone/childprocess_extrapipe/build.zig
@@ -1,0 +1,25 @@
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const child = b.addExecutable(.{
+        .name = "child",
+        .root_source_file = .{ .path = "child.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const parent = b.addExecutable(.{
+        .name = "parent",
+        .root_source_file = .{ .path = "parent.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    const run_cmd = parent.run();
+    run_cmd.addArtifactArg(child);
+
+    const test_step = b.step("test", "Test it");
+    test_step.dependOn(&run_cmd.step);
+}

--- a/test/standalone/childprocess_extrapipe/child.zig
+++ b/test/standalone/childprocess_extrapipe/child.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const windows = std.os.windows;
+pub fn main() !void {
+    var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+    defer if (general_purpose_allocator.deinit()) @panic("found memory leaks");
+    const gpa = general_purpose_allocator.allocator();
+
+    var it = try std.process.argsWithAllocator(gpa);
+    defer it.deinit();
+    _ = it.next() orelse unreachable; // skip binary name
+    const s_handle = it.next() orelse unreachable;
+    var file_handle = try std.os.stringToHandle(s_handle);
+    defer std.os.close(file_handle);
+
+    // child inherited the handle, so inheritance must be enabled
+    const is_inheritable = try std.os.isInheritable(file_handle);
+    std.debug.assert(is_inheritable);
+
+    try std.os.disableInheritance(file_handle);
+    var file_in = std.fs.File{ .handle = file_handle }; // read side of pipe
+    const file_in_reader = file_in.reader();
+    const message = try file_in_reader.readUntilDelimiterAlloc(gpa, '\x17', 20_000);
+    defer gpa.free(message);
+    try std.testing.expectEqualSlices(u8, message, "test123");
+}

--- a/test/standalone/childprocess_extrapipe/parent.zig
+++ b/test/standalone/childprocess_extrapipe/parent.zig
@@ -1,0 +1,50 @@
+const builtin = @import("builtin");
+const std = @import("std");
+const ChildProcess = std.ChildProcess;
+const math = std.math;
+const windows = std.os.windows;
+const os = std.os;
+const testing = std.testing;
+const child_process = std.child_process;
+const pipe_rd = child_process.pipe_rd;
+const pipe_wr = child_process.pipe_wr;
+
+pub fn main() !void {
+    var gpa_state = std.heap.GeneralPurposeAllocator(.{}){};
+    defer if (gpa_state.deinit()) @panic("found memory leaks");
+    const gpa = gpa_state.allocator();
+
+    var it = try std.process.argsWithAllocator(gpa);
+    defer it.deinit();
+    _ = it.next() orelse unreachable; // skip binary name
+    const child_path = it.next() orelse unreachable;
+
+    var pipe = try child_process.portablePipe();
+    defer os.close(pipe[pipe_wr]);
+    var child_proc: ChildProcess = undefined;
+    // spawn block ensures read end of pipe always closed + shortly closed after spawn().
+    {
+        defer os.close(pipe[pipe_rd]);
+
+        var buf: [os.handleCharSize]u8 = comptime [_]u8{0} ** os.handleCharSize;
+        const s_handle = os.handleToString(pipe[pipe_rd], &buf) catch unreachable;
+        child_proc = ChildProcess.init(
+            &.{ child_path, s_handle },
+            gpa,
+        );
+
+        // less time to leak read end of pipe => better
+        try os.enableInheritance(pipe[pipe_rd]);
+        try child_proc.spawn();
+    }
+
+    // check that inheritance was disabled for the handle the whole time
+    const is_inheritable = try os.isInheritable(pipe[pipe_wr]);
+    std.debug.assert(!is_inheritable);
+
+    var file_out = std.fs.File{ .handle = pipe[pipe_wr] };
+    const file_out_writer = file_out.writer();
+    try file_out_writer.writeAll("test123\x17"); // ETB = \x17
+    const ret_val = try child_proc.wait();
+    try testing.expectEqual(ret_val, .{ .Exited = 0 });
+}


### PR DESCRIPTION
Panic test runner starts itself as child process with the test function
index representing a test block. The custom panic handler compares a
global previously written string.  If the panic message is expected, the
success count is increased and the next test block is run. On failure
the parent process prints collected results, before it terminates.

This means, that only one @panic is possible within a test block and that
no follow-up code after the @panic in the test block can be run.

Depends on #14152.
Closes #1356.