### PR TITLE
netbsd: add mcontext_t for aarch64

### DIFF
--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -1061,17 +1061,37 @@ pub const sigset_t = extern struct {
 
 pub const empty_sigset = sigset_t{ .__bits = [_]u32{0} ** SIG.WORDS };
 
-// XXX x86_64 specific
-pub const mcontext_t = extern struct {
-    gregs: [26]u64,
-    mc_tlsbase: u64,
-    fpregs: [512]u8 align(8),
+pub const mcontext_t = switch (builtin.cpu.arch) {
+    .aarch64 => extern struct {
+        gregs: [35]u64,
+        fregs: [528]u8 align(16),
+        spare: [8]u64,
+    },
+    .x86_64 => extern struct {
+        gregs: [26]u64,
+        mc_tlsbase: u64,
+        fpregs: [512]u8 align(8),
+    },
+    else => struct {},
 };
 
-pub const REG = struct {
-    pub const RBP = 12;
-    pub const RIP = 21;
-    pub const RSP = 24;
+pub const REG = switch (builtin.cpu.arch) {
+    .aarch64 => struct {
+        pub const FP = 29;
+        pub const SP = 31;
+        pub const PC = 32;
+    },
+    .arm => struct {
+        pub const FP = 11;
+        pub const SP = 13;
+        pub const PC = 15;
+    },
+    .x86_64 => struct {
+        pub const RBP = 12;
+        pub const RIP = 21;
+        pub const RSP = 24;
+    },
+    else => struct {},
 };
 
 pub const ucontext_t = extern struct {

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1985,11 +1985,13 @@ fn handleSegfaultPosix(sig: i32, info: *const os.siginfo_t, ctx_ptr: ?*const any
             const ctx = @ptrCast(*const os.ucontext_t, @alignCast(@alignOf(os.ucontext_t), ctx_ptr));
             const ip = switch (native_os) {
                 .macos => @intCast(usize, ctx.mcontext.ss.pc),
+                .netbsd => @intCast(usize, ctx.mcontext.gregs[os.REG.PC]),
                 else => @intCast(usize, ctx.mcontext.pc),
             };
             // x29 is the ABI-designated frame pointer
             const bp = switch (native_os) {
                 .macos => @intCast(usize, ctx.mcontext.ss.fp),
+                .netbsd => @intCast(usize, ctx.mcontext.gregs[os.REG.FP]),
                 else => @intCast(usize, ctx.mcontext.regs[29]),
             };
             dumpStackTraceFromBase(bp, ip);

--- a/src/crash_report.zig
+++ b/src/crash_report.zig
@@ -237,11 +237,13 @@ fn handleSegfaultPosix(sig: i32, info: *const os.siginfo_t, ctx_ptr: ?*const any
             const ctx = @ptrCast(*const os.ucontext_t, @alignCast(@alignOf(os.ucontext_t), ctx_ptr));
             const ip = switch (native_os) {
                 .macos => @intCast(usize, ctx.mcontext.ss.pc),
+                .netbsd => @intCast(usize, ctx.mcontext.gregs[os.REG.PC]),
                 else => @intCast(usize, ctx.mcontext.pc),
             };
             // x29 is the ABI-designated frame pointer
             const bp = switch (native_os) {
                 .macos => @intCast(usize, ctx.mcontext.ss.fp),
+                .netbsd => @intCast(usize, ctx.mcontext.gregs[os.REG.FP]),
                 else => @intCast(usize, ctx.mcontext.regs[29]),
             };
             break :ctx StackContext{ .exception = .{ .bp = bp, .ip = ip } };


### PR DESCRIPTION
- test `lib/std/std.zig` passes
- stack traces work