### PR TITLE
std.fs.File.readToEndAlloc: extend explanation of max_bytes

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -927,6 +927,12 @@ pub const File = struct {
     /// Reads all the bytes from the current position to the end of the file.
     /// On success, caller owns returned buffer.
     /// If the file is larger than `max_bytes`, returns `error.FileTooBig`.
+    /// `max_bytes` is not "number of bytes to read", but a maximum.
+    ///
+    /// Note:
+    /// It's imperative to choose a reasonable value for `max_bytes`. The least desirable value to
+    /// use is `std.math.maxInt(usize)`, as it will read until there is no more memory left, and should
+    /// only be used for prototyping.
     pub fn readToEndAlloc(self: File, allocator: mem.Allocator, max_bytes: usize) ![]u8 {
         return self.readToEndAllocOptions(allocator, max_bytes, null, @alignOf(u8), null);
     }


### PR DESCRIPTION
We had a long discussion about this here: https://discord.com/channels/605571803288698900/1063644143647199322

It seems there are two current problems with the documentation that this PR intends to resolve:

1. People misinterpret "max_bytes" (as shown in our discussion)
2. It is not clear how to simply read in a whole file without care for memory usage.

At first I thought a separate function would be good for this, but we all agreed that it goes against Zig's ethos of properly written programs, and instead, the documentation should be supplemented to explain how it can be done and **why it should be avoided in majority of cases**.