### PR TITLE
check output and source lengths

### DIFF
--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -2238,6 +2238,12 @@ test "parse into struct with no fields" {
     try testing.expectEqual(T{}, try parse(T, &ts, ParseOptions{}));
 }
 
+test "parse into struct with insufficient space" {
+    const T = struct {a: [2]u8};
+    var ts = TokenStream.init("{\"a\": \"bbb\"}");
+    try testing.expectError(error.InsufficientSpace, parse(T, &ts, ParseOptions{}));
+}
+
 test "parse into struct with misc fields" {
     @setEvalBranchQuota(10000);
     const options = ParseOptions{ .allocator = testing.allocator };


### PR DESCRIPTION
Check the output and source lengths before doing `mem.copy`