### PR TITLE
std.os.windows.advapi32: add RegOpenKeyExA and RegQueryValueExA

### DIFF
--- a/lib/std/os/windows/advapi32.zig
+++ b/lib/std/os/windows/advapi32.zig
@@ -4,11 +4,20 @@ const BOOL = windows.BOOL;
 const DWORD = windows.DWORD;
 const HKEY = windows.HKEY;
 const BYTE = windows.BYTE;
+const LPCSTR = windows.LPCSTR;
 const LPCWSTR = windows.LPCWSTR;
 const LSTATUS = windows.LSTATUS;
 const REGSAM = windows.REGSAM;
 const ULONG = windows.ULONG;
 const WINAPI = windows.WINAPI;
+
+pub extern "advapi32" fn RegOpenKeyExA(
+    hKey: HKEY,
+    lpSubKey: LPCSTR,
+    ulOptions: DWORD,
+    samDesired: REGSAM,
+    phkResult: *HKEY,
+) callconv(WINAPI) LSTATUS;
 
 pub extern "advapi32" fn RegOpenKeyExW(
     hKey: HKEY,
@@ -16,6 +25,15 @@ pub extern "advapi32" fn RegOpenKeyExW(
     ulOptions: DWORD,
     samDesired: REGSAM,
     phkResult: *HKEY,
+) callconv(WINAPI) LSTATUS;
+
+pub extern "advapi32" fn RegQueryValueExA(
+    hKey: HKEY,
+    lpValueName: LPCSTR,
+    lpReserved: *DWORD,
+    lpType: *DWORD,
+    lpData: *BYTE,
+    lpcbData: *DWORD,
 ) callconv(WINAPI) LSTATUS;
 
 pub extern "advapi32" fn RegQueryValueExW(


### PR DESCRIPTION
Noticed these were missing while starting work on #6363. Might find more bindings to add in the coming days/weeks...

Question: `RegOpenKeyExW` is [duplicated in `std.os.windows.kernel32`](https://github.com/ziglang/zig/blob/master/lib/std/os/windows/kernel32.zig#L453-L459), so should it be deleted there, or should `RegOpenKeyExA` be added? (The C prototypes in `winreg.h` have `WINADVAPI`, so `advapi32` is probably the better place for these over `kernel32`)