### PR TITLE
std.json: check output and source lengths in `std.json`

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1625,9 +1625,10 @@ fn parseInternal(
                     if (arrayInfo.child != u8) return error.UnexpectedToken;
                     var r: T = undefined;
                     const source_slice = stringToken.slice(tokens.slice, tokens.i - 1);
+                    if (r.len != stringToken.decodedLength()) return error.LengthMismatch;
                     switch (stringToken.escapes) {
-                        .None => if (r.len == source_slice.len) mem.copy(u8, &r, source_slice) else return error.LengthMismatch,
-                        .Some => if (r.len == stringToken.decodedLength()) try unescapeValidString(&r, source_slice) else return error.LengthMismatch,
+                        .None => mem.copy(u8, &r, source_slice),
+                        .Some => try unescapeValidString(&r, source_slice),
                     }
                     return r;
                 },

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1680,8 +1680,8 @@ fn parseInternal(
                             const output = try allocator.alloc(u8, len + @boolToInt(ptrInfo.sentinel != null));
                             errdefer allocator.free(output);
                             switch (stringToken.escapes) {
-                                .None => if (output.len == source_slice.len) mem.copy(u8, output, source_slice) else return error.LengthMismatch,
-                                .Some => if (output.len == len) try unescapeValidString(output, source_slice) else return error.LengthMismatch,
+                                .None => mem.copy(u8, output, source_slice),
+                                .Some => try unescapeValidString(output, source_slice),
                             }
 
                             if (ptrInfo.sentinel) |some| {
@@ -1990,7 +1990,7 @@ pub const Parser = struct {
             .Some => {
                 const output = try allocator.alloc(u8, s.decodedLength());
                 errdefer allocator.free(output);
-                if (output.len == s.decodedLength()) try unescapeValidString(output, slice) else return error.LengthMismatch;
+                try unescapeValidString(output, slice);
                 return Value{ .String = output };
             },
         }

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -2238,10 +2238,10 @@ test "parse into struct with no fields" {
     try testing.expectEqual(T{}, try parse(T, &ts, ParseOptions{}));
 }
 
-test "parse into struct with insufficient space" {
+test "parse into struct where destination and source lengths mismatch" {
     const T = struct {a: [2]u8};
     var ts = TokenStream.init("{\"a\": \"bbb\"}");
-    try testing.expectError(error.InsufficientSpace, parse(T, &ts, ParseOptions{}));
+    try testing.expectError(error.LengthMismatch, parse(T, &ts, ParseOptions{}));
 }
 
 test "parse into struct with misc fields" {

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -2239,7 +2239,7 @@ test "parse into struct with no fields" {
 }
 
 test "parse into struct where destination and source lengths mismatch" {
-    const T = struct {a: [2]u8};
+    const T = struct { a: [2]u8 };
     var ts = TokenStream.init("{\"a\": \"bbb\"}");
     try testing.expectError(error.LengthMismatch, parse(T, &ts, ParseOptions{}));
 }

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -2238,6 +2238,12 @@ test "parse into struct with no fields" {
     try testing.expectEqual(T{}, try parse(T, &ts, ParseOptions{}));
 }
 
+test "parse into struct with insufficient space" {
+    const T = struct {a: [2]u8};
+    var ts = TokenStream.init("{\"a\": \"bbb\"}");
+    try testing.expectError(error.InsufficientSpace, parse(T, &ts, ParseOptions{}));
+}
+
 test "parse into struct with misc fields" {
     @setEvalBranchQuota(10000);
     const options = ParseOptions{ .allocator = testing.allocator };


### PR DESCRIPTION
In `std.json` check the output and source lengths before doing `mem.copy`.