### PR TITLE
langref: remove extra curly bracket in the CSS

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -333,7 +333,6 @@
           content: "";
         }
       }
-    }
     </style>
 </head>
 <body>


### PR DESCRIPTION
In commit 3542dbf0ea5 (langref: add section numbers) I accidentally added an extra closing curly bracket at the end of the style element.

Sorry for not validating the HTML file before creating the PR.