### PR TITLE
std.build: support for generated c headers

### DIFF
--- a/lib/std/Build/CompileStep.zig
+++ b/lib/std/Build/CompileStep.zig
@@ -442,6 +442,12 @@ pub fn installHeader(a: *CompileStep, src_path: []const u8, dest_rel_path: []con
     a.installed_headers.append(&install_file.step) catch @panic("OOM");
 }
 
+pub fn installConfigHeader(a: *LibExeObjStep, config_header: *ConfigHeaderStep) void {
+    const install_file = a.builder.addInstallFileWithDir(config_header.getOutputSource(), .header, config_header.output_path);
+    a.builder.getInstallStep().dependOn(&install_file.step);
+    a.installed_headers.append(&install_file.step) catch unreachable;
+}
+
 pub fn installHeadersDirectory(
     a: *CompileStep,
     src_dir_path: []const u8,

--- a/lib/std/Build/CompileStep.zig
+++ b/lib/std/Build/CompileStep.zig
@@ -442,7 +442,7 @@ pub fn installHeader(a: *CompileStep, src_path: []const u8, dest_rel_path: []con
     a.installed_headers.append(&install_file.step) catch @panic("OOM");
 }
 
-pub fn installConfigHeader(a: *LibExeObjStep, config_header: *ConfigHeaderStep) void {
+pub fn installConfigHeader(a: *CompileStep, config_header: *ConfigHeaderStep) void {
     const install_file = a.builder.addInstallFileWithDir(config_header.getOutputSource(), .header, config_header.output_path);
     a.builder.getInstallStep().dependOn(&install_file.step);
     a.installed_headers.append(&install_file.step) catch unreachable;


### PR DESCRIPTION
Add ability to generate a c header file from scratch, and then both compile with it and install it if needed.

Example:
```zig
    const avconfig_h = b.addConfigHeader(.{ .path = "libavutil/avconfig.h" }, .generated, .{
        .AV_HAVE_BIGENDIAN = 0, // TODO: detect based on target
        .AV_HAVE_FAST_UNALIGNED = 1, // TODO: detect based on target
    });

    lib.addConfigHeader(avconfig_h);

    lib.installConfigHeader(avconfig_h);
```