### PR TITLE
Roughly track the last token in each AST node

### DIFF
--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -2,13 +2,15 @@ const std = @import("std.zig");
 const tokenizer = @import("zig/tokenizer.zig");
 const fmt = @import("zig/fmt.zig");
 const assert = std.debug.assert;
+const parse_mod = @import("zig/parse.zig");
 
 pub const Token = tokenizer.Token;
 pub const Tokenizer = tokenizer.Tokenizer;
 pub const fmtId = fmt.fmtId;
 pub const fmtEscapes = fmt.fmtEscapes;
 pub const isValidId = fmt.isValidId;
-pub const parse = @import("zig/parse.zig").parse;
+pub const parse = parse_mod.parse;
+pub const parseWithOptions = parse_mod.parseWithOptions;
 pub const string_literal = @import("zig/string_literal.zig");
 pub const number_literal = @import("zig/number_literal.zig");
 pub const primitives = @import("zig/primitives.zig");

--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -788,6 +788,7 @@ pub fn render(gpa: Allocator, nodes: []const Node) !std.zig.Ast {
         .tokens = ctx.tokens.toOwnedSlice(),
         .nodes = ctx.nodes.toOwnedSlice(),
         .extra_data = try ctx.extra_data.toOwnedSlice(gpa),
+        .node_ends = null,
         .errors = &.{},
     };
 }


### PR DESCRIPTION
This is important for tools like LSP servers, because we can't properly reconstruct the extents of an AST node just from its structure. Take the following example:

```zig
fn foo() void {
    var bar = 10;
    if (ba
}
```

If the cursor is positioned after the `if (ba`, zls will *not* autocomplete `bar`. This is because `Ast.lastToken` tries to find the end of the function by traversing the children, so it never includes the final `}`, meaning zls doesn't think that the cursor is inside `foo`.

To remedy this, I've added an parser option that will record the last token of ast nodes as well as the first. Optional so that we don't take a performance&memory hit when we don't need to track this data.

I've been using a forked zig with this based on `0.10.0` along with a patched zls for the past couple months, and it works fine.

---

Here is an example that you can run to see what I'm talking about:

```zig
const std = @import("std");

pub fn main() !void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    const alloc = gpa.allocator();
    const my_src =
        \\pub fn foo() void {
        \\var bar = 10;
        \\    if (b
        \\}
    ;

    const my_ast = try std.zig.parse(alloc, my_src);

    // Find the 'foo' fn_decl node
    const decls = my_ast.rootDecls();
    std.debug.assert(decls.len == 1);
    const foo_decl = decls[0];

    // Find the last token for this fn_decl node
    const last_tok_ix = my_ast.lastToken(foo_decl);
    const last_tok_offset = my_ast.tokens.items(.start)[last_tok_ix];

    // Print the offset of the last token
    try std.io.getStdOut().writer().print(
        "Source is {} bytes long, last tok in foo is {}\n",
        .{ my_src.len, last_tok_offset },
    );
}
```

This prints:
```
Source is 45 bytes long, last tok in foo is 32
```

It thinks the last token of the function decl `foo` starts at 32, but the source is 45 bytes long. With correct tracking of AST extents, this should show 44 instead.