### PR TITLE
std.start: initialize Windows console output CP to UTF-8 on exe startup

### DIFF
--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -159,6 +159,11 @@ pub const options = struct {
         options_override.crypto_always_getrandom
     else
         false;
+
+    pub const windows_force_utf8_codepage: bool = if (@hasDecl(options_override, "windows_force_utf8_codepage"))
+        options_override.windows_force_utf8_codepage
+    else
+        true;
 };
 
 // This forces the start.zig file to be imported, and the comptime logic inside that


### PR DESCRIPTION
Windows treats console output outside the ASCII range as being part of its "codepage", which is very much *not* UTF-8 by default. This can be annoying when writing programs on Windows - you need to put `std.windows.kernel32.SetConsoleOutputCP` somewhere. Since all of `std` is based on UTF-8 output, it makes sense to do this automatically in most cases, so here we do it in `std.start`, but overrideable with a root option.

(I put the logic for this in its own function because I don't doubt there'll be similar weird things we end up having to do to make Windows act somewhat like a normal platform)