### PR TITLE
translate_c: support inline assembly inside functions

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -286,6 +286,61 @@ pub const ChooseExpr = opaque {
     extern fn ZigClangChooseExpr_getChosenSubExpr(*const ChooseExpr) *const Expr;
 };
 
+pub const IdentifierInfo = opaque {};
+
+pub const GCCAsmStmt = opaque {
+    pub const getAsmString = ZigClangGCCAsmStmt_getAsmString;
+    extern fn ZigClangGCCAsmStmt_getAsmString(*const GCCAsmStmt) *const StringLiteral;
+
+    pub const isSimple = ZigClangGCCAsmStmt_isSimple;
+    extern fn ZigClangGCCAsmStmt_isSimple(*const GCCAsmStmt) bool;
+
+    pub const getNumOutputs = ZigClangGCCAsmStmt_getNumOutputs;
+    extern fn ZigClangGCCAsmStmt_getNumOutputs(*const GCCAsmStmt) c_uint;
+
+    pub const getOutputIdentifier = ZigClangGCCAsmStmt_getOutputIdentifier;
+    extern fn ZigClangGCCAsmStmt_getOutputIdentifier(*const GCCAsmStmt, c_uint) *const IdentifierInfo;
+
+    pub const getOutputName = ZigClangGCCAsmStmt_getOutputName;
+    extern fn ZigClangGCCAsmStmt_getOutputName(*const GCCAsmStmt, usize) StringRef;
+
+    pub const getOutputConstraint = ZigClangGCCAsmStmt_getOutputConstraint;
+    extern fn ZigClangGCCAsmStmt_getOutputConstraint(*const GCCAsmStmt, usize) StringRef;
+
+    pub const getOutputConstraintLiteral = ZigClangGCCAsmStmt_getOutputConstraintLiteral;
+    extern fn ZigClangGCCAsmStmt_getOutputConstraintLiteral(*const GCCAsmStmt, usize) *const StringLiteral;
+
+    pub const getOutputExpr = ZigClangGCCAsmStmt_getOutputExpr;
+    extern fn ZigClangGCCAsmStmt_getOutputExpr(*const GCCAsmStmt, usize) *const Expr;
+
+    pub const getNumInputs = ZigClangGCCAsmStmt_getNumInputs;
+    extern fn ZigClangGCCAsmStmt_getNumInputs(*const GCCAsmStmt) c_uint;
+
+    pub const getInputIdentifier = ZigClangGCCAsmStmt_getInputIdentifier;
+    extern fn ZigClangGCCAsmStmt_getInputIdentifier(*const GCCAsmStmt, usize) *const IdentifierInfo;
+
+    pub const getInputName = ZigClangGCCAsmStmt_getInputName;
+    extern fn ZigClangGCCAsmStmt_getInputName(*const GCCAsmStmt, usize) StringRef;
+
+    pub const getInputConstraint = ZigClangGCCAsmStmt_getInputConstraint;
+    extern fn ZigClangGCCAsmStmt_getInputConstraint(*const GCCAsmStmt, usize) StringRef;
+
+    pub const getInputConstraintLiteral = ZigClangGCCAsmStmt_getInputConstraintLiteral;
+    extern fn ZigClangGCCAsmStmt_getInputConstraintLiteral(*const GCCAsmStmt, usize) *const StringLiteral;
+
+    pub const getInputExpr = ZigClangGCCAsmStmt_getInputExpr;
+    extern fn ZigClangGCCAsmStmt_getInputExpr(*const GCCAsmStmt, usize) *const Expr;
+
+    pub const getNumClobbers = ZigClangGCCAsmStmt_getNumClobbers;
+    extern fn ZigClangGCCAsmStmt_getNumClobbers(*const GCCAsmStmt) c_uint;
+
+    pub const getClobberStringLiteral = ZigClangGCCAsmStmt_getClobberStringLiteral;
+    extern fn ZigClangGCCAsmStmt_getClobberStringLiteral(*const GCCAsmStmt, usize) *const StringLiteral;
+
+    pub const isAsmGoto = ZigClangGCCAsmStmt_isAsmGoto;
+    extern fn ZigClangGCCAsmStmt_isAsmGoto(*const GCCAsmStmt) bool;
+};
+
 pub const CompoundAssignOperator = opaque {
     pub const getType = ZigClangCompoundAssignOperator_getType;
     extern fn ZigClangCompoundAssignOperator_getType(*const CompoundAssignOperator) QualType;
@@ -876,7 +931,16 @@ pub const StringLiteral = opaque {
     extern fn ZigClangStringLiteral_getString_bytes_begin_size(*const StringLiteral, *usize) [*]const u8;
 };
 
-pub const StringRef = opaque {};
+pub const StringRef = extern struct {
+    ptr: [*]const u8,
+    len: c_uint,
+
+    pub fn toSlice(self: StringRef) ?[]const u8 {
+        if (self.len == 0)
+            return null;
+        return self.ptr[0..self.len];
+    }
+};
 
 pub const SwitchStmt = opaque {
     pub const getConditionVariableDeclStmt = ZigClangSwitchStmt_getConditionVariableDeclStmt;

--- a/src/clang.zig
+++ b/src/clang.zig
@@ -288,57 +288,53 @@ pub const ChooseExpr = opaque {
 
 pub const IdentifierInfo = opaque {};
 
+pub const AsmStmt = opaque {
+    pub const isSimple = ZigClangAsmStmt_isSimple;
+    extern fn ZigClangAsmStmt_isSimple(*const AsmStmt) bool;
+
+    pub const isVolatile = ZigClangAsmStmt_isVolatile;
+    extern fn ZigClangAsmStmt_isVolatile(*const AsmStmt) bool;
+
+    pub const getNumOutputs = ZigClangAsmStmt_getNumOutputs;
+    extern fn ZigClangAsmStmt_getNumOutputs(*const AsmStmt) c_uint;
+
+    pub const getOutputIdentifier = ZigClangAsmStmt_getOutputIdentifier;
+    extern fn ZigClangAsmStmt_getOutputIdentifier(*const AsmStmt, c_uint) *const IdentifierInfo;
+
+    pub const getOutputConstraint = ZigClangAsmStmt_getOutputConstraint;
+    extern fn ZigClangAsmStmt_getOutputConstraint(*const AsmStmt, usize) StringRef;
+
+    pub const getOutputConstraintLiteral = ZigClangAsmStmt_getOutputConstraintLiteral;
+    extern fn ZigClangAsmStmt_getOutputConstraintLiteral(*const AsmStmt, usize) *const StringLiteral;
+
+    pub const getOutputExpr = ZigClangAsmStmt_getOutputExpr;
+    extern fn ZigClangAsmStmt_getOutputExpr(*const AsmStmt, usize) *const Expr;
+
+    pub const getNumInputs = ZigClangAsmStmt_getNumInputs;
+    extern fn ZigClangAsmStmt_getNumInputs(*const AsmStmt) c_uint;
+
+    pub const getInputConstraint = ZigClangAsmStmt_getInputConstraint;
+    extern fn ZigClangAsmStmt_getInputConstraint(*const AsmStmt, usize) StringRef;
+
+    pub const getInputExpr = ZigClangAsmStmt_getInputExpr;
+    extern fn ZigClangAsmStmt_getInputExpr(*const AsmStmt, usize) *const Expr;
+
+    pub const getNumClobbers = ZigClangAsmStmt_getNumClobbers;
+    extern fn ZigClangAsmStmt_getNumClobbers(*const AsmStmt) c_uint;
+
+    pub const getClobber = ZigClangAsmStmt_getClobber;
+    extern fn ZigClangAsmStmt_getClobber(*const AsmStmt, usize) StringRef;
+};
+
 pub const GCCAsmStmt = opaque {
     pub const getAsmString = ZigClangGCCAsmStmt_getAsmString;
     extern fn ZigClangGCCAsmStmt_getAsmString(*const GCCAsmStmt) *const StringLiteral;
 
-    pub const isSimple = ZigClangGCCAsmStmt_isSimple;
-    extern fn ZigClangGCCAsmStmt_isSimple(*const GCCAsmStmt) bool;
-
-    pub const getNumOutputs = ZigClangGCCAsmStmt_getNumOutputs;
-    extern fn ZigClangGCCAsmStmt_getNumOutputs(*const GCCAsmStmt) c_uint;
-
-    pub const getOutputIdentifier = ZigClangGCCAsmStmt_getOutputIdentifier;
-    extern fn ZigClangGCCAsmStmt_getOutputIdentifier(*const GCCAsmStmt, c_uint) *const IdentifierInfo;
-
     pub const getOutputName = ZigClangGCCAsmStmt_getOutputName;
     extern fn ZigClangGCCAsmStmt_getOutputName(*const GCCAsmStmt, usize) StringRef;
 
-    pub const getOutputConstraint = ZigClangGCCAsmStmt_getOutputConstraint;
-    extern fn ZigClangGCCAsmStmt_getOutputConstraint(*const GCCAsmStmt, usize) StringRef;
-
-    pub const getOutputConstraintLiteral = ZigClangGCCAsmStmt_getOutputConstraintLiteral;
-    extern fn ZigClangGCCAsmStmt_getOutputConstraintLiteral(*const GCCAsmStmt, usize) *const StringLiteral;
-
-    pub const getOutputExpr = ZigClangGCCAsmStmt_getOutputExpr;
-    extern fn ZigClangGCCAsmStmt_getOutputExpr(*const GCCAsmStmt, usize) *const Expr;
-
-    pub const getNumInputs = ZigClangGCCAsmStmt_getNumInputs;
-    extern fn ZigClangGCCAsmStmt_getNumInputs(*const GCCAsmStmt) c_uint;
-
-    pub const getInputIdentifier = ZigClangGCCAsmStmt_getInputIdentifier;
-    extern fn ZigClangGCCAsmStmt_getInputIdentifier(*const GCCAsmStmt, usize) *const IdentifierInfo;
-
     pub const getInputName = ZigClangGCCAsmStmt_getInputName;
     extern fn ZigClangGCCAsmStmt_getInputName(*const GCCAsmStmt, usize) StringRef;
-
-    pub const getInputConstraint = ZigClangGCCAsmStmt_getInputConstraint;
-    extern fn ZigClangGCCAsmStmt_getInputConstraint(*const GCCAsmStmt, usize) StringRef;
-
-    pub const getInputConstraintLiteral = ZigClangGCCAsmStmt_getInputConstraintLiteral;
-    extern fn ZigClangGCCAsmStmt_getInputConstraintLiteral(*const GCCAsmStmt, usize) *const StringLiteral;
-
-    pub const getInputExpr = ZigClangGCCAsmStmt_getInputExpr;
-    extern fn ZigClangGCCAsmStmt_getInputExpr(*const GCCAsmStmt, usize) *const Expr;
-
-    pub const getNumClobbers = ZigClangGCCAsmStmt_getNumClobbers;
-    extern fn ZigClangGCCAsmStmt_getNumClobbers(*const GCCAsmStmt) c_uint;
-
-    pub const getClobberStringLiteral = ZigClangGCCAsmStmt_getClobberStringLiteral;
-    extern fn ZigClangGCCAsmStmt_getClobberStringLiteral(*const GCCAsmStmt, usize) *const StringLiteral;
-
-    pub const isAsmGoto = ZigClangGCCAsmStmt_isAsmGoto;
-    extern fn ZigClangGCCAsmStmt_isAsmGoto(*const GCCAsmStmt) bool;
 };
 
 pub const CompoundAssignOperator = opaque {
@@ -1234,7 +1230,7 @@ pub const TypeClass = enum(c_int) {
     ExtVector,
 };
 
-const StmtClass = enum(c_int) {
+pub const StmtClass = enum(c_int) {
     NoStmtClass,
     GCCAsmStmtClass,
     MSAsmStmtClass,

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -3044,56 +3044,62 @@ unsigned ZigClangCharacterLiteral_getValue(const struct ZigClangCharacterLiteral
 }
 
 
-const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getAsmString(const struct ZigClangGCCAsmStmt *self) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    return reinterpret_cast<const ZigClangStringLiteral *>(casted->getAsmString());
-}
-
-bool ZigClangGCCAsmStmt_isSimple(const struct ZigClangGCCAsmStmt *self) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+bool ZigClangAsmStmt_isSimple(const struct ZigClangAsmStmt *self) {
+    auto casted = reinterpret_cast<const clang::AsmStmt *>(self);
     return casted->isSimple();
 }
 
-unsigned ZigClangGCCAsmStmt_getNumOutputs(const struct ZigClangGCCAsmStmt *self) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+bool ZigClangAsmStmt_isVolatile(const struct ZigClangAsmStmt *self) {
+    auto casted = reinterpret_cast<const clang::AsmStmt *>(self);
+    return casted->isVolatile();
+}
+
+unsigned ZigClangAsmStmt_getNumOutputs(const struct ZigClangAsmStmt *self) {
+    auto casted = reinterpret_cast<const clang::AsmStmt *>(self);
     return casted->getNumOutputs();
 }
 
-const struct ZigClangIdentifierInfo *ZigClangGCCAsmStmt_getOutputIdentifier(const struct ZigClangGCCAsmStmt *self, unsigned i) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    return reinterpret_cast<const struct ZigClangIdentifierInfo *>(casted->getOutputIdentifier(i));
-}
-
-const struct ZigClangStringRef ZigClangGCCAsmStmt_getOutputName(const struct ZigClangGCCAsmStmt *self, unsigned i) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    auto temp = casted->getOutputName(i);
-    return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
-}
-//
-const struct ZigClangStringRef ZigClangGCCAsmStmt_getOutputConstraint(const struct ZigClangGCCAsmStmt *self, unsigned i) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+const struct ZigClangStringRef ZigClangAsmStmt_getOutputConstraint(const struct ZigClangAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::AsmStmt *>(self);
     auto temp = casted->getOutputConstraint(i);
     return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
 }
 
-const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getOutputConstraintLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    return reinterpret_cast<const struct ZigClangStringLiteral *>(casted->getOutputConstraintLiteral(i));
-}
-
-const struct ZigClangExpr *ZigClangGCCAsmStmt_getOutputExpr(const struct ZigClangGCCAsmStmt *self, unsigned i) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+const struct ZigClangExpr *ZigClangAsmStmt_getOutputExpr(const struct ZigClangAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::AsmStmt *>(self);
     return reinterpret_cast<const struct ZigClangExpr *>(casted->getOutputExpr(i));
 }
 
-unsigned ZigClangGCCAsmStmt_getNumInputs(const struct ZigClangGCCAsmStmt *self) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+unsigned ZigClangAsmStmt_getNumInputs(const struct ZigClangAsmStmt *self) {
+    auto casted = reinterpret_cast<const clang::AsmStmt *>(self);
     return casted->getNumInputs();
 }
 
-const struct ZigClangIdentifierInfo *ZigClangGCCAsmStmt_getInputIdentifier(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+const struct ZigClangStringRef ZigClangAsmStmt_getInputConstraint(const struct ZigClangAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::AsmStmt *>(self);
+    auto temp = casted->getInputConstraint(i);
+    return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
+}
+
+const struct ZigClangExpr *ZigClangAsmStmt_getInputExpr(const struct ZigClangAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::AsmStmt *>(self);
+    return reinterpret_cast<const struct ZigClangExpr *>(casted->getInputExpr(i));
+}
+
+unsigned ZigClangAsmStmt_getNumClobbers(const struct ZigClangAsmStmt *self) {
+    auto casted = reinterpret_cast<const clang::AsmStmt *>(self);
+    return casted->getNumClobbers();
+}
+
+const struct ZigClangStringRef ZigClangAsmStmt_getClobber(const struct ZigClangAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::AsmStmt *>(self);
+    auto temp = casted->getClobber(i);
+    return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
+}
+
+const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getAsmString(const struct ZigClangGCCAsmStmt *self) {
     auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    return reinterpret_cast<const struct ZigClangIdentifierInfo *>(casted->getInputIdentifier(i));
+    return reinterpret_cast<const ZigClangStringLiteral *>(casted->getAsmString());
 }
 
 const struct ZigClangStringRef ZigClangGCCAsmStmt_getInputName(const struct ZigClangGCCAsmStmt *self, unsigned i) {
@@ -3102,43 +3108,11 @@ const struct ZigClangStringRef ZigClangGCCAsmStmt_getInputName(const struct ZigC
     return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
 }
 
-const struct ZigClangStringRef ZigClangGCCAsmStmt_getInputConstraint(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+const struct ZigClangStringRef ZigClangGCCAsmStmt_getOutputName(const struct ZigClangGCCAsmStmt *self, unsigned i) {
     auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    auto temp = casted->getInputConstraint(i);
+    auto temp = casted->getOutputName(i);
     return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
 }
-
-const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getInputConstraintLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    return reinterpret_cast<const struct ZigClangStringLiteral *>(casted->getInputConstraintLiteral(i));
-}
-
-const struct ZigClangExpr *ZigClangGCCAsmStmt_getInputExpr(const struct ZigClangGCCAsmStmt *self, unsigned i) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    return reinterpret_cast<const struct ZigClangExpr *>(casted->getInputExpr(i));
-}
-
-unsigned ZigClangGCCAsmStmt_getNumClobbers(const struct ZigClangGCCAsmStmt *self) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    return casted->getNumClobbers();
-}
-
-const struct ZigClangStringRef ZigClangGCCAsmStmt_getClobber(const struct ZigClangGCCAsmStmt *self, unsigned i) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    auto temp = casted->getClobber(i);
-    return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
-}
-
-const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getClobberStringLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    return reinterpret_cast<const struct ZigClangStringLiteral *>(casted->getClobberStringLiteral(i));
-}
-
-const bool ZigClangGCCAsmStmt_isAsmGoto(const struct ZigClangGCCAsmStmt *self) {
-    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
-    return casted->isAsmGoto();
-}
-
 
 const struct ZigClangExpr *ZigClangChooseExpr_getChosenSubExpr(const struct ZigClangChooseExpr *self) {
     auto casted = reinterpret_cast<const clang::ChooseExpr *>(self);

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -3043,6 +3043,103 @@ unsigned ZigClangCharacterLiteral_getValue(const struct ZigClangCharacterLiteral
     return casted->getValue();
 }
 
+
+const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getAsmString(const struct ZigClangGCCAsmStmt *self) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return reinterpret_cast<const ZigClangStringLiteral *>(casted->getAsmString());
+}
+
+bool ZigClangGCCAsmStmt_isSimple(const struct ZigClangGCCAsmStmt *self) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return casted->isSimple();
+}
+
+unsigned ZigClangGCCAsmStmt_getNumOutputs(const struct ZigClangGCCAsmStmt *self) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return casted->getNumOutputs();
+}
+
+const struct ZigClangIdentifierInfo *ZigClangGCCAsmStmt_getOutputIdentifier(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return reinterpret_cast<const struct ZigClangIdentifierInfo *>(casted->getOutputIdentifier(i));
+}
+
+const struct ZigClangStringRef ZigClangGCCAsmStmt_getOutputName(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    auto temp = casted->getOutputName(i);
+    return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
+}
+//
+const struct ZigClangStringRef ZigClangGCCAsmStmt_getOutputConstraint(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    auto temp = casted->getOutputConstraint(i);
+    return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
+}
+
+const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getOutputConstraintLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return reinterpret_cast<const struct ZigClangStringLiteral *>(casted->getOutputConstraintLiteral(i));
+}
+
+const struct ZigClangExpr *ZigClangGCCAsmStmt_getOutputExpr(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return reinterpret_cast<const struct ZigClangExpr *>(casted->getOutputExpr(i));
+}
+
+unsigned ZigClangGCCAsmStmt_getNumInputs(const struct ZigClangGCCAsmStmt *self) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return casted->getNumInputs();
+}
+
+const struct ZigClangIdentifierInfo *ZigClangGCCAsmStmt_getInputIdentifier(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return reinterpret_cast<const struct ZigClangIdentifierInfo *>(casted->getInputIdentifier(i));
+}
+
+const struct ZigClangStringRef ZigClangGCCAsmStmt_getInputName(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    auto temp = casted->getInputName(i);
+    return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
+}
+
+const struct ZigClangStringRef ZigClangGCCAsmStmt_getInputConstraint(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    auto temp = casted->getInputConstraint(i);
+    return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
+}
+
+const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getInputConstraintLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return reinterpret_cast<const struct ZigClangStringLiteral *>(casted->getInputConstraintLiteral(i));
+}
+
+const struct ZigClangExpr *ZigClangGCCAsmStmt_getInputExpr(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return reinterpret_cast<const struct ZigClangExpr *>(casted->getInputExpr(i));
+}
+
+unsigned ZigClangGCCAsmStmt_getNumClobbers(const struct ZigClangGCCAsmStmt *self) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return casted->getNumClobbers();
+}
+
+const struct ZigClangStringRef ZigClangGCCAsmStmt_getClobber(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    auto temp = casted->getClobber(i);
+    return ZigClangStringRef{ temp.data(), static_cast<unsigned>(temp.size()) };
+}
+
+const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getClobberStringLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return reinterpret_cast<const struct ZigClangStringLiteral *>(casted->getClobberStringLiteral(i));
+}
+
+const bool ZigClangGCCAsmStmt_isAsmGoto(const struct ZigClangGCCAsmStmt *self) {
+    auto casted = reinterpret_cast<const clang::GCCAsmStmt *>(self);
+    return casted->isAsmGoto();
+}
+
+
 const struct ZigClangExpr *ZigClangChooseExpr_getChosenSubExpr(const struct ZigClangChooseExpr *self) {
     auto casted = reinterpret_cast<const clang::ChooseExpr *>(self);
     return reinterpret_cast<const ZigClangExpr *>(casted->getChosenSubExpr());

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -106,6 +106,8 @@ struct ZigClangCaseStmt;
 struct ZigClangCastExpr;
 struct ZigClangCharacterLiteral;
 struct ZigClangChooseExpr;
+struct ZigClangIdentifierInfo;
+struct ZigClangGCCAsmStmt;
 struct ZigClangCompoundAssignOperator;
 struct ZigClangCompoundStmt;
 struct ZigClangConditionalOperator;
@@ -161,7 +163,6 @@ struct ZigClangSourceRange;
 struct ZigClangStmt;
 struct ZigClangStmtExpr;
 struct ZigClangStringLiteral;
-struct ZigClangStringRef;
 struct ZigClangSwitchStmt;
 struct ZigClangTagDecl;
 struct ZigClangType;
@@ -176,6 +177,12 @@ struct ZigClangInitListExpr;
 
 typedef struct ZigClangStmt *const * ZigClangCompoundStmt_const_body_iterator;
 typedef struct ZigClangDecl *const * ZigClangDeclStmt_const_decl_iterator;
+
+// INFO: keep in sync with src/clang.zig:StringRef
+struct ZigClangStringRef {
+  const char *ptr;
+  unsigned len;
+};
 
 struct ZigClangRecordDecl_field_iterator {
     void *opaque;
@@ -1347,6 +1354,27 @@ ZIG_EXTERN_C const struct ZigClangFieldDecl *ZigClangCastExpr_getTargetFieldForT
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangCharacterLiteral_getBeginLoc(const struct ZigClangCharacterLiteral *);
 ZIG_EXTERN_C enum ZigClangCharacterLiteral_CharacterKind ZigClangCharacterLiteral_getKind(const struct ZigClangCharacterLiteral *);
 ZIG_EXTERN_C unsigned ZigClangCharacterLiteral_getValue(const struct ZigClangCharacterLiteral *);
+
+ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getAsmString(const struct ZigClangGCCAsmStmt *self);
+ZIG_EXTERN_C bool ZigClangGCCAsmStmt_isSimple(const struct ZigClangGCCAsmStmt *self);
+ZIG_EXTERN_C unsigned ZigClangGCCAsmStmt_getNumOutputs(const struct ZigClangGCCAsmStmt *self);
+ZIG_EXTERN_C const struct ZigClangIdentifierInfo *ZigClangGCCAsmStmt_getOutputIdentifier(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getOutputName(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getOutputConstraint(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getOutputConstraintLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangExpr *ZigClangGCCAsmStmt_getOutputExpr(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C unsigned ZigClangGCCAsmStmt_getNumInputs(const struct ZigClangGCCAsmStmt *self);
+ZIG_EXTERN_C const struct ZigClangIdentifierInfo *ZigClangGCCAsmStmt_getInputIdentifier(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getInputName(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getInputConstraint(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getInputConstraintLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangExpr *ZigClangGCCAsmStmt_getInputExpr(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C unsigned ZigClangGCCAsmStmt_getNumClobbers(const struct ZigClangGCCAsmStmt *self);
+ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getClobber(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getClobberStringLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i);
+
+ZIG_EXTERN_C const bool ZigClangGCCAsmStmt_isAsmGoto(const struct ZigClangGCCAsmStmt *self);
+
 
 ZIG_EXTERN_C const struct ZigClangExpr *ZigClangChooseExpr_getChosenSubExpr(const struct ZigClangChooseExpr *);
 

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -107,6 +107,7 @@ struct ZigClangCastExpr;
 struct ZigClangCharacterLiteral;
 struct ZigClangChooseExpr;
 struct ZigClangIdentifierInfo;
+struct ZigClangAsmStmt;
 struct ZigClangGCCAsmStmt;
 struct ZigClangCompoundAssignOperator;
 struct ZigClangCompoundStmt;
@@ -1355,25 +1356,23 @@ ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangCharacterLiteral_getBeginLoc(
 ZIG_EXTERN_C enum ZigClangCharacterLiteral_CharacterKind ZigClangCharacterLiteral_getKind(const struct ZigClangCharacterLiteral *);
 ZIG_EXTERN_C unsigned ZigClangCharacterLiteral_getValue(const struct ZigClangCharacterLiteral *);
 
-ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getAsmString(const struct ZigClangGCCAsmStmt *self);
-ZIG_EXTERN_C bool ZigClangGCCAsmStmt_isSimple(const struct ZigClangGCCAsmStmt *self);
-ZIG_EXTERN_C unsigned ZigClangGCCAsmStmt_getNumOutputs(const struct ZigClangGCCAsmStmt *self);
-ZIG_EXTERN_C const struct ZigClangIdentifierInfo *ZigClangGCCAsmStmt_getOutputIdentifier(const struct ZigClangGCCAsmStmt *self, unsigned i);
-ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getOutputName(const struct ZigClangGCCAsmStmt *self, unsigned i);
-ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getOutputConstraint(const struct ZigClangGCCAsmStmt *self, unsigned i);
-ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getOutputConstraintLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i);
-ZIG_EXTERN_C const struct ZigClangExpr *ZigClangGCCAsmStmt_getOutputExpr(const struct ZigClangGCCAsmStmt *self, unsigned i);
-ZIG_EXTERN_C unsigned ZigClangGCCAsmStmt_getNumInputs(const struct ZigClangGCCAsmStmt *self);
-ZIG_EXTERN_C const struct ZigClangIdentifierInfo *ZigClangGCCAsmStmt_getInputIdentifier(const struct ZigClangGCCAsmStmt *self, unsigned i);
-ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getInputName(const struct ZigClangGCCAsmStmt *self, unsigned i);
-ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getInputConstraint(const struct ZigClangGCCAsmStmt *self, unsigned i);
-ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getInputConstraintLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i);
-ZIG_EXTERN_C const struct ZigClangExpr *ZigClangGCCAsmStmt_getInputExpr(const struct ZigClangGCCAsmStmt *self, unsigned i);
-ZIG_EXTERN_C unsigned ZigClangGCCAsmStmt_getNumClobbers(const struct ZigClangGCCAsmStmt *self);
-ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getClobber(const struct ZigClangGCCAsmStmt *self, unsigned i);
-ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getClobberStringLiteral(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C bool ZigClangAsmStmt_isSimple(const struct ZigClangAsmStmt *self);
+ZIG_EXTERN_C bool ZigClangAsmStmt_isVolatile(const struct ZigClangAsmStmt *self);
+ZIG_EXTERN_C unsigned ZigClangAsmStmt_getNumOutputs(const struct ZigClangAsmStmt *self);
+ZIG_EXTERN_C const struct ZigClangIdentifierInfo *ZigClangAsmStmt_getOutputIdentifier(const struct ZigClangAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangStringRef ZigClangAsmStmt_getOutputConstraint(const struct ZigClangAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangExpr *ZigClangAsmStmt_getOutputExpr(const struct ZigClangAsmStmt *self, unsigned i);
+ZIG_EXTERN_C unsigned ZigClangAsmStmt_getNumInputs(const struct ZigClangAsmStmt *self);
+ZIG_EXTERN_C const struct ZigClangIdentifierInfo *ZigClangAsmStmt_getInputIdentifier(const struct ZigClangAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangStringRef ZigClangAsmStmt_getInputConstraint(const struct ZigClangAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangExpr *ZigClangAsmStmt_getInputExpr(const struct ZigClangAsmStmt *self, unsigned i);
+ZIG_EXTERN_C unsigned ZigClangAsmStmt_getNumClobbers(const struct ZigClangAsmStmt *self);
+ZIG_EXTERN_C const struct ZigClangStringRef ZigClangAsmStmt_getClobber(const struct ZigClangAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangAsmStmt_getClobberStringLiteral(const struct ZigClangAsmStmt *self, unsigned i);
 
-ZIG_EXTERN_C const bool ZigClangGCCAsmStmt_isAsmGoto(const struct ZigClangGCCAsmStmt *self);
+ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangGCCAsmStmt_getAsmString(const struct ZigClangGCCAsmStmt *self);
+ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getOutputName(const struct ZigClangGCCAsmStmt *self, unsigned i);
+ZIG_EXTERN_C const struct ZigClangStringRef ZigClangGCCAsmStmt_getInputName(const struct ZigClangGCCAsmStmt *self, unsigned i);
 
 
 ZIG_EXTERN_C const struct ZigClangExpr *ZigClangChooseExpr_getChosenSubExpr(const struct ZigClangChooseExpr *);


### PR DESCRIPTION
TODO:
- [x] outputs
- [ ] figure out how to translate constraints
- [x] volatile(should we follow the C semantics for volatile, or the zig semantics and add volatile when outputs are not present?)
- [ ] replace names in the assemble `%0` -> `%[arg0]`
- [ ] volatile support in asm_simple(?)
- [ ] support for MSAsmStmtClass
- [ ] cleanup