### PR TITLE
std: eliminate pointless meta.assumeSentinel() usage

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -978,7 +978,7 @@ pub fn readElfDebugInfo(allocator: mem.Allocator, elf_file: File) !ModuleDebugIn
         for (shdrs) |*shdr| {
             if (shdr.sh_type == elf.SHT_NULL) continue;
 
-            const name = std.mem.span(std.meta.assumeSentinel(header_strings[shdr.sh_name..].ptr, 0));
+            const name = mem.sliceTo(header_strings[shdr.sh_name..], 0);
             if (mem.eql(u8, name, ".debug_info")) {
                 opt_debug_info = try chopSlice(mapped_mem, shdr.sh_offset, shdr.sh_size);
             } else if (mem.eql(u8, name, ".debug_abbrev")) {

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2968,14 +2968,14 @@ pub fn selfExePath(out_buffer: []u8) SelfExePathError![]u8 {
             var out_len: usize = out_buffer.len;
             try os.sysctl(&mib, out_buffer.ptr, &out_len, null, 0);
             // TODO could this slice from 0 to out_len instead?
-            return mem.sliceTo(std.meta.assumeSentinel(out_buffer.ptr, 0), 0);
+            return mem.sliceTo(out_buffer, 0);
         },
         .netbsd => {
             var mib = [4]c_int{ os.CTL.KERN, os.KERN.PROC_ARGS, -1, os.KERN.PROC_PATHNAME };
             var out_len: usize = out_buffer.len;
             try os.sysctl(&mib, out_buffer.ptr, &out_len, null, 0);
             // TODO could this slice from 0 to out_len instead?
-            return mem.sliceTo(std.meta.assumeSentinel(out_buffer.ptr, 0), 0);
+            return mem.sliceTo(out_buffer, 0);
         },
         .openbsd, .haiku => {
             // OpenBSD doesn't support getting the path of a running process, so try to guess it

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -103,10 +103,10 @@ pub const Address = extern union {
             .path = undefined,
         };
 
-        // this enables us to have the proper length of the socket in getOsSockLen
-        mem.set(u8, &sock_addr.path, 0);
+        // Add 1 to ensure a terminating 0 is present in the path array for maximum portability.
+        if (path.len + 1 > sock_addr.path.len) return error.NameTooLong;
 
-        if (path.len > sock_addr.path.len) return error.NameTooLong;
+        mem.set(u8, &sock_addr.path, 0);
         mem.copy(u8, &sock_addr.path, path);
 
         return Address{ .un = sock_addr };
@@ -179,9 +179,17 @@ pub const Address = extern union {
                     unreachable;
                 }
 
-                const path_len = std.mem.len(std.meta.assumeSentinel(&self.un.path, 0));
-                return @intCast(os.socklen_t, @sizeOf(os.sockaddr.un) - self.un.path.len + path_len);
+                // Using the full length of the structure here is more portable than returning
+                // the number of bytes actually used by the currently stored path.
+                // This also is correct regardless if we are passing a socket address to the kernel
+                // (e.g. in bind, connect, sendto) since we ensure the path is 0 terminated in
+                // initUnix() or if we are receiving a socket address from the kernel and must
+                // provide the full buffer size (e.g. getsockname, getpeername, recvfrom, accept).
+                //
+                // To access the path, std.mem.sliceTo(&address.un.path, 0) should be used.
+                return @intCast(os.socklen_t, @sizeOf(os.sockaddr.un));
             },
+
             else => unreachable,
         }
     }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1687,7 +1687,7 @@ fn dnsParseCallback(ctx: dpc_ctx, rr: u8, data: []const u8, packet: []const u8) 
             var tmp: [256]u8 = undefined;
             // Returns len of compressed name. strlen to get canon name.
             _ = try os.dn_expand(packet, data, &tmp);
-            const canon_name = mem.sliceTo(std.meta.assumeSentinel(&tmp, 0), 0);
+            const canon_name = mem.sliceTo(&tmp, 0);
             if (isValidHostName(canon_name)) {
                 ctx.canon.items.len = 0;
                 try ctx.canon.appendSlice(canon_name);

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2006,7 +2006,7 @@ pub fn sliceToPrefixedFileW(s: []const u8) !PathSpace {
 }
 
 fn getFullPathNameW(path: [*:0]const u16, out: []u16) !usize {
-    const result = kernel32.GetFullPathNameW(path, @intCast(u32, out.len), std.meta.assumeSentinel(out.ptr, 0), null);
+    const result = kernel32.GetFullPathNameW(path, @intCast(u32, out.len), out.ptr, null);
     if (result == 0) {
         switch (kernel32.GetLastError()) {
             else => |err| return unexpectedError(err),

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -223,7 +223,7 @@ pub extern "kernel32" fn GetFinalPathNameByHandleW(
 pub extern "kernel32" fn GetFullPathNameW(
     lpFileName: [*:0]const u16,
     nBufferLength: u32,
-    lpBuffer: ?[*:0]u16,
+    lpBuffer: [*]u16,
     lpFilePart: ?*?[*:0]u16,
 ) callconv(@import("std").os.windows.WINAPI) u32;
 

--- a/lib/std/pdb.zig
+++ b/lib/std/pdb.zig
@@ -671,7 +671,7 @@ pub const Pdb = struct {
                 const name_index = try reader.readIntLittle(u32);
                 if (name_offset > name_bytes.len)
                     return error.InvalidDebugInfo;
-                const name = mem.sliceTo(std.meta.assumeSentinel(name_bytes.ptr + name_offset, 0), 0);
+                const name = mem.sliceTo(name_bytes[name_offset..], 0);
                 if (mem.eql(u8, name, "/names")) {
                     break :str_tab_index name_index;
                 }

--- a/lib/std/zig/system/NativeTargetInfo.zig
+++ b/lib/std/zig/system/NativeTargetInfo.zig
@@ -533,8 +533,7 @@ fn glibcVerFromSoFile(file: fs.File) !std.builtin.Version {
                 @alignCast(@alignOf(elf.Elf64_Shdr), &sh_buf[sh_buf_i]),
             );
             const sh_name_off = elfInt(is_64, need_bswap, sh32.sh_name, sh64.sh_name);
-            // TODO this pointer cast should not be necessary
-            const sh_name = mem.sliceTo(std.meta.assumeSentinel(shstrtab[sh_name_off..].ptr, 0), 0);
+            const sh_name = mem.sliceTo(shstrtab[sh_name_off..], 0);
             if (mem.eql(u8, sh_name, ".dynstr")) {
                 break :find_dyn_str .{
                     .offset = elfInt(is_64, need_bswap, sh32.sh_offset, sh64.sh_offset),
@@ -789,8 +788,7 @@ pub fn abiAndDynamicLinkerFromFile(
                     @alignCast(@alignOf(elf.Elf64_Shdr), &sh_buf[sh_buf_i]),
                 );
                 const sh_name_off = elfInt(is_64, need_bswap, sh32.sh_name, sh64.sh_name);
-                // TODO this pointer cast should not be necessary
-                const sh_name = mem.sliceTo(std.meta.assumeSentinel(shstrtab[sh_name_off..].ptr, 0), 0);
+                const sh_name = mem.sliceTo(shstrtab[sh_name_off..], 0);
                 if (mem.eql(u8, sh_name, ".dynstr")) {
                     break :find_dyn_str .{
                         .offset = elfInt(is_64, need_bswap, sh32.sh_offset, sh64.sh_offset),
@@ -812,7 +810,7 @@ pub fn abiAndDynamicLinkerFromFile(
                 const strtab_read_len = try preadMin(file, &strtab_buf, rpoff_file, strtab_len);
                 const strtab = strtab_buf[0..strtab_read_len];
 
-                const rpath_list = mem.sliceTo(std.meta.assumeSentinel(strtab.ptr, 0), 0);
+                const rpath_list = mem.sliceTo(strtab, 0);
                 var it = mem.tokenize(u8, rpath_list, ":");
                 while (it.next()) |rpath| {
                     if (glibcVerFromRPath(rpath)) |ver| {


### PR DESCRIPTION
This fixes a bug in std.net caused during the introduction of meta.assumeSentinel due to the unfortunate semantics of mem.span()

This leaves only 3 remaining uses of meta.assumeSentinel() in the standard library, each of which could be a simple @ptrCast([*:0]T, foo) instead. I think this function should likely be removed.

See also #14383, #14417