### PR TITLE
zig env: add support for line based output

### DIFF
--- a/src/introspect.zig
+++ b/src/introspect.zig
@@ -4,6 +4,7 @@ const mem = std.mem;
 const os = std.os;
 const fs = std.fs;
 const Compilation = @import("Compilation.zig");
+const build_options = @import("build_options");
 
 /// Returns the sub_path that worked, or `null` if none did.
 /// The path of the returned Directory is relative to `base`.
@@ -80,23 +81,17 @@ pub fn findZigLibDirFromSelfExe(
 
 /// Caller owns returned memory.
 pub fn resolveGlobalCacheDir(allocator: mem.Allocator) ![]u8 {
-    if (builtin.os.tag == .wasi) {
+    if (builtin.os.tag == .wasi)
         @compileError("on WASI the global cache dir must be resolved with preopens");
-    }
-    if (std.process.getEnvVarOwned(allocator, "ZIG_GLOBAL_CACHE_DIR")) |value| {
-        if (value.len > 0) {
-            return value;
-        } else {
-            allocator.free(value);
-        }
-    } else |_| {}
+
+    if (try EnvVar.ZIG_GLOBAL_CACHE_DIR.get(allocator)) |value| return value;
 
     const appname = "zig";
 
     if (builtin.os.tag != .windows) {
-        if (std.os.getenv("XDG_CACHE_HOME")) |cache_root| {
+        if (EnvVar.XDG_CACHE_HOME.getPosix()) |cache_root| {
             return fs.path.join(allocator, &[_][]const u8{ cache_root, appname });
-        } else if (std.os.getenv("HOME")) |home| {
+        } else if (EnvVar.HOME.getPosix()) |home| {
             return fs.path.join(allocator, &[_][]const u8{ home, ".cache", appname });
         }
     }
@@ -146,3 +141,42 @@ pub fn resolvePath(
 pub fn isUpDir(p: []const u8) bool {
     return mem.startsWith(u8, p, "..") and (p.len == 2 or p[2] == fs.path.sep);
 }
+
+/// Collects all the environment variables that Zig could possibly inspect, so
+/// that we can do reflection on this and print them with `zig env`.
+pub const EnvVar = enum {
+    ZIG_GLOBAL_CACHE_DIR,
+    ZIG_LOCAL_CACHE_DIR,
+    ZIG_LIB_DIR,
+    ZIG_LIBC,
+    ZIG_BUILD_RUNNER,
+    ZIG_VERBOSE_LINK,
+    ZIG_VERBOSE_CC,
+    ZIG_BTRFS_WORKAROUND,
+    CC,
+    NO_COLOR,
+    XDG_CACHE_HOME,
+    HOME,
+    /// https://github.com/ziglang/zig/issues/17585
+    INCLUDE,
+
+    pub fn isSet(comptime ev: EnvVar) bool {
+        return std.process.hasEnvVarConstant(@tagName(ev));
+    }
+
+    pub fn get(ev: EnvVar, arena: mem.Allocator) !?[]u8 {
+        // Env vars aren't used in the bootstrap stage.
+        if (build_options.only_c) return null;
+
+        if (std.process.getEnvVarOwned(arena, @tagName(ev))) |value| {
+            return value;
+        } else |err| switch (err) {
+            error.EnvironmentVariableNotFound => return null,
+            else => |e| return e,
+        }
+    }
+
+    pub fn getPosix(comptime ev: EnvVar) ?[:0]const u8 {
+        return std.os.getenvZ(@tagName(ev));
+    }
+};

--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -11,6 +11,7 @@ const is_haiku = builtin.target.os.tag == .haiku;
 const log = std.log.scoped(.libc_installation);
 
 const ZigWindowsSDK = @import("windows_sdk.zig").ZigWindowsSDK;
+const EnvVar = @import("introspect.zig").EnvVar;
 
 /// See the render function implementation for documentation of the fields.
 pub const LibCInstallation = struct {
@@ -694,7 +695,7 @@ fn appendCcExe(args: *std.ArrayList([]const u8), skip_cc_env_var: bool) !void {
         args.appendAssumeCapacity(default_cc_exe);
         return;
     }
-    const cc_env_var = std.os.getenvZ("CC") orelse {
+    const cc_env_var = EnvVar.CC.getPosix() orelse {
         args.appendAssumeCapacity(default_cc_exe);
         return;
     };

--- a/src/print_env.zig
+++ b/src/print_env.zig
@@ -1,62 +1,52 @@
 const std = @import("std");
-const mem = std.mem;
 const build_options = @import("build_options");
 const introspect = @import("introspect.zig");
 const Allocator = std.mem.Allocator;
 const fatal = @import("main.zig").fatal;
 
-const Env = struct {
-    name: []const u8,
-    value: []const u8,
-};
+pub fn cmdEnv(arena: Allocator, args: []const []const u8, stdout: std.fs.File.Writer) !void {
+    _ = args;
+    const self_exe_path = try introspect.findZigExePath(arena);
 
-pub fn cmdEnv(gpa: Allocator, args: []const []const u8, stdout: std.fs.File.Writer) !void {
-    const self_exe_path = try introspect.findZigExePath(gpa);
-    defer gpa.free(self_exe_path);
-
-    var zig_lib_directory = introspect.findZigLibDirFromSelfExe(gpa, self_exe_path) catch |err| {
+    var zig_lib_directory = introspect.findZigLibDirFromSelfExe(arena, self_exe_path) catch |err| {
         fatal("unable to find zig installation directory: {s}\n", .{@errorName(err)});
     };
-    defer gpa.free(zig_lib_directory.path.?);
     defer zig_lib_directory.handle.close();
 
-    const zig_std_dir = try std.fs.path.join(gpa, &[_][]const u8{ zig_lib_directory.path.?, "std" });
-    defer gpa.free(zig_std_dir);
+    const zig_std_dir = try std.fs.path.join(arena, &[_][]const u8{ zig_lib_directory.path.?, "std" });
 
-    const global_cache_dir = try introspect.resolveGlobalCacheDir(gpa);
-    defer gpa.free(global_cache_dir);
+    const global_cache_dir = try introspect.resolveGlobalCacheDir(arena);
 
     const info = try std.zig.system.NativeTargetInfo.detect(.{});
-    const triple = try info.target.zigTriple(gpa);
-    defer gpa.free(triple);
-
-    const envars: []Env = &[_]Env{
-        .{ .name = "zig_exe", .value = self_exe_path },
-        .{ .name = "lib_dir", .value = zig_lib_directory.path.? },
-        .{ .name = "std_dir", .value = zig_std_dir },
-        .{ .name = "global_cache_dir", .value = global_cache_dir },
-        .{ .name = "version", .value = build_options.version },
-        .{ .name = "target", .value = triple },
-    };
+    const triple = try info.target.zigTriple(arena);
 
     var bw = std.io.bufferedWriter(stdout);
     const w = bw.writer();
 
-    if (args.len > 0) {
-        for (args) |name| {
-            for (envars) |env| {
-                if (mem.eql(u8, name, env.name)) {
-                    try w.print("{s}\n", .{env.value});
-                }
-            }
+    try w.print(
+        \\zig_exe={s}
+        \\lib_dir={s}
+        \\std_dir={s}
+        \\global_cache_dir={s}
+        \\version={s}
+        \\target={s}
+        \\
+    , .{
+        self_exe_path,
+        zig_lib_directory.path.?,
+        zig_std_dir,
+        global_cache_dir,
+        build_options.version,
+        triple,
+    });
+
+    inline for (@typeInfo(introspect.EnvVar).Enum.fields) |field| {
+        if (try @field(introspect.EnvVar, field.name).get(arena)) |value| {
+            try w.print("{s}={s}\n", .{ field.name, value });
+        } else {
+            try w.print("{s}\n", .{field.name});
         }
-        try bw.flush();
-
-        return;
     }
 
-    for (envars) |env| {
-        try w.print("{[name]s}=\"{[value]s}\"\n", env);
-    }
     try bw.flush();
 }

--- a/src/resinator/preprocess.zig
+++ b/src/resinator/preprocess.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const cli = @import("cli.zig");
+const introspect = @import("../introspect.zig");
 
 pub const IncludeArgs = struct {
     clang_target: ?[]const u8 = null,
@@ -67,7 +68,7 @@ pub fn appendClangArgs(arena: Allocator, argv: *std.ArrayList([]const u8), optio
     }
 
     if (!options.ignore_include_env_var) {
-        const INCLUDE = std.process.getEnvVarOwned(arena, "INCLUDE") catch "";
+        const INCLUDE = (introspect.EnvVar.INCLUDE.get(arena) catch @panic("OOM")) orelse "";
 
         // TODO: Should this be platform-specific? How does windres/llvm-rc handle this (if at all)?
         var it = std.mem.tokenize(u8, INCLUDE, ";");


### PR DESCRIPTION
Currently it is not very convenient to extract a single environment variable from `zig env`.
An example using the shell: `zig env | jq -r .lib_dir`.

Update print_env.zig so that, when args is not empty, print each environment variable associated with an argument.
An updated example: `zig env lib_dir`.

Unrecognized environment variables are ignored.