### PR TITLE
cmake: add the ZIG_SKIP_STAGE3 option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -829,6 +829,12 @@ if(MSVC OR MINGW)
     target_link_libraries(zig2 LINK_PUBLIC version)
 endif()
 
+set(ZIG_SKIP_STAGE3 off CACHE BOOL "Skip building stage3 compiler")
+
+if(ZIG_SKIP_STAGE3)
+    return()
+endif()
+
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   set(ZIG_RELEASE_ARG "")
 elseif("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")


### PR DESCRIPTION
When testing changes to the Zig compiler, the stage3 compiler is probably not necessary.  Instead it will take more time and memory on an old PC.

Add the ZIG_SKIP_STAGE3 option to CMakeLists.txt.  When set to on, cmake will skip building the stage3 compiler.