### PR TITLE
debug: re-enable resource management test on x86_64 windows

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -2060,11 +2060,6 @@ pub fn dumpStackPointerAddr(prefix: []const u8) void {
 test "manage resources correctly" {
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
-    if (builtin.os.tag == .windows and builtin.cpu.arch == .x86_64) {
-        // https://github.com/ziglang/zig/issues/13963
-        return error.SkipZigTest;
-    }
-
     const writer = std.io.null_writer;
     var di = try openSelfDebugInfo(testing.allocator);
     defer di.deinit();


### PR DESCRIPTION
I believe the leaks here were fixed by https://github.com/ziglang/zig/pull/14247

Fixes https://github.com/ziglang/zig/issues/13963