### PR TITLE
compiler_rt: re-enable divxf3 test on windows/llvm

### DIFF
--- a/lib/compiler_rt/divxf3.zig
+++ b/lib/compiler_rt/divxf3.zig
@@ -206,7 +206,5 @@ pub fn __divxf3(a: f80, b: f80) callconv(.C) f80 {
 }
 
 test {
-    if (builtin.zig_backend == .stage2_llvm and builtin.os.tag == .windows) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/12603
-
     _ = @import("divxf3_test.zig");
 }


### PR DESCRIPTION
I went to check what was wrong here, but the test is now passing on windows.

Closes https://github.com/ziglang/zig/issues/12603