### PR TITLE
std: remove meta.assumeSentinel

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -3028,7 +3028,7 @@ pub fn selfExePath(out_buffer: []u8) SelfExePathError![]u8 {
 /// The result is UTF16LE-encoded.
 pub fn selfExePathW() [:0]const u16 {
     const image_path_name = &os.windows.peb().ProcessParameters.ImagePathName;
-    return mem.sliceTo(std.meta.assumeSentinel(image_path_name.Buffer, 0), 0);
+    return image_path_name.Buffer[0 .. image_path_name.Length / 2 :0];
 }
 
 /// `selfExeDirPath` except allocates the result on the heap.

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -332,41 +332,7 @@ pub fn Sentinel(comptime T: type, comptime sentinel_val: Elem(T)) type {
     @compileError("Unable to derive a sentinel pointer type from " ++ @typeName(T));
 }
 
-/// Takes a Slice or Many Pointer and returns it with the Type modified to have the given sentinel value.
-/// This function assumes the caller has verified the memory contains the sentinel value.
-pub fn assumeSentinel(p: anytype, comptime sentinel_val: Elem(@TypeOf(p))) Sentinel(@TypeOf(p), sentinel_val) {
-    const T = @TypeOf(p);
-    const ReturnType = Sentinel(T, sentinel_val);
-    switch (@typeInfo(T)) {
-        .Pointer => |info| switch (info.size) {
-            .Slice, .Many, .One => return @ptrCast(ReturnType, p),
-            .C => {},
-        },
-        .Optional => |info| switch (@typeInfo(info.child)) {
-            .Pointer => |ptr_info| switch (ptr_info.size) {
-                .Many => return @ptrCast(ReturnType, p),
-                else => {},
-            },
-            else => {},
-        },
-        else => {},
-    }
-    @compileError("Unable to derive a sentinel pointer type from " ++ @typeName(T));
-}
-
-test "std.meta.assumeSentinel" {
-    try testing.expect([*:0]u8 == @TypeOf(assumeSentinel(@as([*]u8, undefined), 0)));
-    try testing.expect([:0]u8 == @TypeOf(assumeSentinel(@as([]u8, undefined), 0)));
-    try testing.expect([*:0]const u8 == @TypeOf(assumeSentinel(@as([*]const u8, undefined), 0)));
-    try testing.expect([:0]const u8 == @TypeOf(assumeSentinel(@as([]const u8, undefined), 0)));
-    try testing.expect([*:0]u16 == @TypeOf(assumeSentinel(@as([*]u16, undefined), 0)));
-    try testing.expect([:0]const u16 == @TypeOf(assumeSentinel(@as([]const u16, undefined), 0)));
-    try testing.expect([*:3]u8 == @TypeOf(assumeSentinel(@as([*:1]u8, undefined), 3)));
-    try testing.expect([:null]?[*]u8 == @TypeOf(assumeSentinel(@as([]?[*]u8, undefined), null)));
-    try testing.expect([*:null]?[*]u8 == @TypeOf(assumeSentinel(@as([*]?[*]u8, undefined), null)));
-    try testing.expect(*[10:0]u8 == @TypeOf(assumeSentinel(@as(*[10]u8, undefined), 0)));
-    try testing.expect(?[*:0]u8 == @TypeOf(assumeSentinel(@as(?[*]u8, undefined), 0)));
-}
+const assumeSentinel = @compileError("This function has been removed, consider using std.mem.sliceTo() or if needed a @ptrCast()");
 
 pub fn containerLayout(comptime T: type) Type.ContainerLayout {
     return switch (@typeInfo(T)) {

--- a/lib/std/os/linux/vdso.zig
+++ b/lib/std/os/linux/vdso.zig
@@ -68,7 +68,7 @@ pub fn lookup(vername: []const u8, name: []const u8) usize {
         if (0 == (@as(u32, 1) << @intCast(u5, syms[i].st_info & 0xf) & OK_TYPES)) continue;
         if (0 == (@as(u32, 1) << @intCast(u5, syms[i].st_info >> 4) & OK_BINDS)) continue;
         if (0 == syms[i].st_shndx) continue;
-        const sym_name = std.meta.assumeSentinel(strings + syms[i].st_name, 0);
+        const sym_name = @ptrCast([*:0]u8, strings + syms[i].st_name);
         if (!mem.eql(u8, name, mem.sliceTo(sym_name, 0))) continue;
         if (maybe_versym) |versym| {
             if (!checkver(maybe_verdef.?, versym[i], vername, strings))
@@ -91,6 +91,6 @@ fn checkver(def_arg: *elf.Verdef, vsym_arg: i32, vername: []const u8, strings: [
         def = @intToPtr(*elf.Verdef, @ptrToInt(def) + def.vd_next);
     }
     const aux = @intToPtr(*elf.Verdaux, @ptrToInt(def) + def.vd_aux);
-    const vda_name = std.meta.assumeSentinel(strings + aux.vda_name, 0);
+    const vda_name = @ptrCast([*:0]u8, strings + aux.vda_name);
     return mem.eql(u8, vername, mem.sliceTo(vda_name, 0));
 }


### PR DESCRIPTION
All but 3 callsites of this function in the standard library and compiler were unnecessary and were removed in faf2fd18.

In this commit, the remaining 3 callsites are removed. One of them turned out to also be unnecessary and has been replaced by slicing directly with the length..

The 2 remaining callsites were in the very pointer-math heavy std/os/linux/vdso.zig code which should perhaps be refactored to better utilize slices. These 2 callsites are replaced with a plain @ptrCast([*:0]u8, ptr) though could likely use std.mem.sliceTo() if the surrounding code was refactored.