### PR TITLE
elf+macho: append null to DWARF strtab to avoid overlapping sects

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -756,10 +756,11 @@ pub fn populateMissingMetadata(self: *Elf) !void {
         try self.writeSymbol(0);
     }
 
-    if (self.dwarf) |dw| {
+    if (self.dwarf) |*dw| {
         if (self.debug_str_section_index == null) {
             self.debug_str_section_index = @intCast(u16, self.sections.items.len);
             assert(dw.strtab.items.len == 0);
+            try dw.strtab.append(self.base.allocator, 0);
             try self.sections.append(self.base.allocator, .{
                 .sh_name = try self.makeString(".debug_str"),
                 .sh_type = elf.SHT_PROGBITS,

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -83,6 +83,7 @@ pub fn populateMissingMetadata(self: *DebugSymbols) !void {
 
     if (self.debug_str_section_index == null) {
         assert(self.dwarf.strtab.items.len == 0);
+        try self.dwarf.strtab.append(self.allocator, 0);
         self.debug_str_section_index = try self.allocateSection(
             "__debug_str",
             @intCast(u32, self.dwarf.strtab.items.len),


### PR DESCRIPTION
Otherwise, we were risking having strtab zero-sized and overlap with another section.