### PR TITLE
zig build system: add LibExeObjStep.installLibraryHeaders

### DIFF
--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -220,6 +220,11 @@ pub fn main() !void {
                 return usageAndErr(builder, true, stderr_stream);
             },
             error.UncleanExit => process.exit(1),
+            // This error is intended to indicate that the step has already
+            // logged an error message and so printing the error return trace
+            // here would be unwanted extra information, unless the user opts
+            // into it with a debug flag.
+            error.StepFailed => process.exit(1),
             else => return err,
         }
     };

--- a/lib/std/build/InstallFileStep.zig
+++ b/lib/std/build/InstallFileStep.zig
@@ -13,6 +13,9 @@ builder: *Builder,
 source: FileSource,
 dir: InstallDir,
 dest_rel_path: []const u8,
+/// This is used by the build system when a file being installed comes from one
+/// package but is being installed by another.
+override_source_builder: ?*Builder = null,
 
 pub fn init(
     builder: *Builder,
@@ -32,7 +35,8 @@ pub fn init(
 
 fn make(step: *Step) !void {
     const self = @fieldParentPtr(InstallFileStep, "step", step);
+    const src_builder = self.override_source_builder orelse self.builder;
+    const full_src_path = self.source.getPath(src_builder);
     const full_dest_path = self.builder.getInstallPath(self.dir, self.dest_rel_path);
-    const full_src_path = self.source.getPath(self.builder);
     try self.builder.updateFile(full_src_path, full_dest_path);
 }


### PR DESCRIPTION
This function is needed when a library exposes one of its own library dependency's headers as part of its own public API.

Also, improve error message when a file system error occurs during install file step.

Real world motivation: https://github.com/andrewrk/libgroove/commit/9566fce65b822c57f052e749820a38e739ab0ea9