### PR TITLE
langref: move paragraph inside the p element

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10656,9 +10656,11 @@ const c = @cImport({
       {#header_close#}
 
       {#header_open|C Translation CLI#}
+      <p>
       Zig's C translation capability is available as a CLI tool via <kbd>zig translate-c</kbd>.
       It requires a single filename as an argument. It may also take a set of optional flags that are
       forwarded to clang. It writes the translated file to stdout.
+      </p>
       {#header_open|Command line flags#}
       <ul>
         <li>


### PR DESCRIPTION
In the "C Translation CLI" section, move the paragraph inside the p element.

The current HTML is valid, but, as an example, a paragraph outside a p element is not handled correctly by the browser Inspect tool.