### PR TITLE
self-hosted: cleanup codegen.Result

### DIFF
--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -24,7 +24,7 @@ const log = std.log.scoped(.codegen);
 const build_options = @import("build_options");
 
 const GenerateSymbolError = codegen.GenerateSymbolError;
-const FnResult = codegen.FnResult;
+const Result = codegen.Result;
 const DebugInfoOutput = codegen.DebugInfoOutput;
 
 const bits = @import("bits.zig");
@@ -349,7 +349,7 @@ pub fn generate(
     liveness: Liveness,
     code: *std.ArrayList(u8),
     debug_output: DebugInfoOutput,
-) GenerateSymbolError!FnResult {
+) GenerateSymbolError!Result {
     if (build_options.skip_non_native and builtin.cpu.arch != bin_file.options.target.cpu.arch) {
         @panic("Attempted to compile for architecture that was disabled by build configuration");
     }
@@ -392,8 +392,8 @@ pub fn generate(
     defer function.dbg_info_relocs.deinit(bin_file.allocator);
 
     var call_info = function.resolveCallingConventionValues(fn_type) catch |err| switch (err) {
-        error.CodegenFail => return FnResult{ .fail = function.err_msg.? },
-        error.OutOfRegisters => return FnResult{
+        error.CodegenFail => return Result{ .fail = function.err_msg.? },
+        error.OutOfRegisters => return Result{
             .fail = try ErrorMsg.create(bin_file.allocator, src_loc, "CodeGen ran out of registers. This is a bug in the Zig compiler.", .{}),
         },
         else => |e| return e,
@@ -406,8 +406,8 @@ pub fn generate(
     function.max_end_stack = call_info.stack_byte_count;
 
     function.gen() catch |err| switch (err) {
-        error.CodegenFail => return FnResult{ .fail = function.err_msg.? },
-        error.OutOfRegisters => return FnResult{
+        error.CodegenFail => return Result{ .fail = function.err_msg.? },
+        error.OutOfRegisters => return Result{
             .fail = try ErrorMsg.create(bin_file.allocator, src_loc, "CodeGen ran out of registers. This is a bug in the Zig compiler.", .{}),
         },
         else => |e| return e,
@@ -439,14 +439,14 @@ pub fn generate(
     defer emit.deinit();
 
     emit.emitMir() catch |err| switch (err) {
-        error.EmitFail => return FnResult{ .fail = emit.err_msg.? },
+        error.EmitFail => return Result{ .fail = emit.err_msg.? },
         else => |e| return e,
     };
 
     if (function.err_msg) |em| {
-        return FnResult{ .fail = em };
+        return Result{ .fail = em };
     } else {
-        return FnResult{ .appended = {} };
+        return Result{ .appended = {} };
     }
 }
 

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -446,7 +446,7 @@ pub fn generate(
     if (function.err_msg) |em| {
         return Result{ .fail = em };
     } else {
-        return Result{ .appended = {} };
+        return Result.ok;
     }
 }
 

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -23,7 +23,7 @@ const leb128 = std.leb;
 const log = std.log.scoped(.codegen);
 const build_options = @import("build_options");
 
-const FnResult = codegen.FnResult;
+const Result = codegen.Result;
 const GenerateSymbolError = codegen.GenerateSymbolError;
 const DebugInfoOutput = codegen.DebugInfoOutput;
 
@@ -356,7 +356,7 @@ pub fn generate(
     liveness: Liveness,
     code: *std.ArrayList(u8),
     debug_output: DebugInfoOutput,
-) GenerateSymbolError!FnResult {
+) GenerateSymbolError!Result {
     if (build_options.skip_non_native and builtin.cpu.arch != bin_file.options.target.cpu.arch) {
         @panic("Attempted to compile for architecture that was disabled by build configuration");
     }
@@ -399,8 +399,8 @@ pub fn generate(
     defer function.dbg_info_relocs.deinit(bin_file.allocator);
 
     var call_info = function.resolveCallingConventionValues(fn_type) catch |err| switch (err) {
-        error.CodegenFail => return FnResult{ .fail = function.err_msg.? },
-        error.OutOfRegisters => return FnResult{
+        error.CodegenFail => return Result{ .fail = function.err_msg.? },
+        error.OutOfRegisters => return Result{
             .fail = try ErrorMsg.create(bin_file.allocator, src_loc, "CodeGen ran out of registers. This is a bug in the Zig compiler.", .{}),
         },
         else => |e| return e,
@@ -413,8 +413,8 @@ pub fn generate(
     function.max_end_stack = call_info.stack_byte_count;
 
     function.gen() catch |err| switch (err) {
-        error.CodegenFail => return FnResult{ .fail = function.err_msg.? },
-        error.OutOfRegisters => return FnResult{
+        error.CodegenFail => return Result{ .fail = function.err_msg.? },
+        error.OutOfRegisters => return Result{
             .fail = try ErrorMsg.create(bin_file.allocator, src_loc, "CodeGen ran out of registers. This is a bug in the Zig compiler.", .{}),
         },
         else => |e| return e,
@@ -446,14 +446,14 @@ pub fn generate(
     defer emit.deinit();
 
     emit.emitMir() catch |err| switch (err) {
-        error.EmitFail => return FnResult{ .fail = emit.err_msg.? },
+        error.EmitFail => return Result{ .fail = emit.err_msg.? },
         else => |e| return e,
     };
 
     if (function.err_msg) |em| {
-        return FnResult{ .fail = em };
+        return Result{ .fail = em };
     } else {
-        return FnResult{ .appended = {} };
+        return Result{ .appended = {} };
     }
 }
 

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -453,7 +453,7 @@ pub fn generate(
     if (function.err_msg) |em| {
         return Result{ .fail = em };
     } else {
-        return Result{ .appended = {} };
+        return Result.ok;
     }
 }
 

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -22,7 +22,7 @@ const leb128 = std.leb;
 const log = std.log.scoped(.codegen);
 const build_options = @import("build_options");
 
-const FnResult = @import("../../codegen.zig").FnResult;
+const Result = @import("../../codegen.zig").Result;
 const GenerateSymbolError = @import("../../codegen.zig").GenerateSymbolError;
 const DebugInfoOutput = @import("../../codegen.zig").DebugInfoOutput;
 
@@ -225,7 +225,7 @@ pub fn generate(
     liveness: Liveness,
     code: *std.ArrayList(u8),
     debug_output: DebugInfoOutput,
-) GenerateSymbolError!FnResult {
+) GenerateSymbolError!Result {
     if (build_options.skip_non_native and builtin.cpu.arch != bin_file.options.target.cpu.arch) {
         @panic("Attempted to compile for architecture that was disabled by build configuration");
     }
@@ -268,8 +268,8 @@ pub fn generate(
     defer function.exitlude_jump_relocs.deinit(bin_file.allocator);
 
     var call_info = function.resolveCallingConventionValues(fn_type) catch |err| switch (err) {
-        error.CodegenFail => return FnResult{ .fail = function.err_msg.? },
-        error.OutOfRegisters => return FnResult{
+        error.CodegenFail => return Result{ .fail = function.err_msg.? },
+        error.OutOfRegisters => return Result{
             .fail = try ErrorMsg.create(bin_file.allocator, src_loc, "CodeGen ran out of registers. This is a bug in the Zig compiler.", .{}),
         },
         else => |e| return e,
@@ -282,8 +282,8 @@ pub fn generate(
     function.max_end_stack = call_info.stack_byte_count;
 
     function.gen() catch |err| switch (err) {
-        error.CodegenFail => return FnResult{ .fail = function.err_msg.? },
-        error.OutOfRegisters => return FnResult{
+        error.CodegenFail => return Result{ .fail = function.err_msg.? },
+        error.OutOfRegisters => return Result{
             .fail = try ErrorMsg.create(bin_file.allocator, src_loc, "CodeGen ran out of registers. This is a bug in the Zig compiler.", .{}),
         },
         else => |e| return e,
@@ -309,14 +309,14 @@ pub fn generate(
     defer emit.deinit();
 
     emit.emitMir() catch |err| switch (err) {
-        error.EmitFail => return FnResult{ .fail = emit.err_msg.? },
+        error.EmitFail => return Result{ .fail = emit.err_msg.? },
         else => |e| return e,
     };
 
     if (function.err_msg) |em| {
-        return FnResult{ .fail = em };
+        return Result{ .fail = em };
     } else {
-        return FnResult{ .appended = {} };
+        return Result{ .appended = {} };
     }
 }
 

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -316,7 +316,7 @@ pub fn generate(
     if (function.err_msg) |em| {
         return Result{ .fail = em };
     } else {
-        return Result{ .appended = {} };
+        return Result.ok;
     }
 }
 

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -20,7 +20,7 @@ const Emit = @import("Emit.zig");
 const Liveness = @import("../../Liveness.zig");
 const Type = @import("../../type.zig").Type;
 const GenerateSymbolError = @import("../../codegen.zig").GenerateSymbolError;
-const FnResult = @import("../../codegen.zig").FnResult;
+const Result = @import("../../codegen.zig").Result;
 const DebugInfoOutput = @import("../../codegen.zig").DebugInfoOutput;
 
 const build_options = @import("build_options");
@@ -265,7 +265,7 @@ pub fn generate(
     liveness: Liveness,
     code: *std.ArrayList(u8),
     debug_output: DebugInfoOutput,
-) GenerateSymbolError!FnResult {
+) GenerateSymbolError!Result {
     if (build_options.skip_non_native and builtin.cpu.arch != bin_file.options.target.cpu.arch) {
         @panic("Attempted to compile for architecture that was disabled by build configuration");
     }
@@ -310,8 +310,8 @@ pub fn generate(
     defer function.exitlude_jump_relocs.deinit(bin_file.allocator);
 
     var call_info = function.resolveCallingConventionValues(fn_type, .callee) catch |err| switch (err) {
-        error.CodegenFail => return FnResult{ .fail = function.err_msg.? },
-        error.OutOfRegisters => return FnResult{
+        error.CodegenFail => return Result{ .fail = function.err_msg.? },
+        error.OutOfRegisters => return Result{
             .fail = try ErrorMsg.create(bin_file.allocator, src_loc, "CodeGen ran out of registers. This is a bug in the Zig compiler.", .{}),
         },
         else => |e| return e,
@@ -324,8 +324,8 @@ pub fn generate(
     function.max_end_stack = call_info.stack_byte_count;
 
     function.gen() catch |err| switch (err) {
-        error.CodegenFail => return FnResult{ .fail = function.err_msg.? },
-        error.OutOfRegisters => return FnResult{
+        error.CodegenFail => return Result{ .fail = function.err_msg.? },
+        error.OutOfRegisters => return Result{
             .fail = try ErrorMsg.create(bin_file.allocator, src_loc, "CodeGen ran out of registers. This is a bug in the Zig compiler.", .{}),
         },
         else => |e| return e,
@@ -351,14 +351,14 @@ pub fn generate(
     defer emit.deinit();
 
     emit.emitMir() catch |err| switch (err) {
-        error.EmitFail => return FnResult{ .fail = emit.err_msg.? },
+        error.EmitFail => return Result{ .fail = emit.err_msg.? },
         else => |e| return e,
     };
 
     if (function.err_msg) |em| {
-        return FnResult{ .fail = em };
+        return Result{ .fail = em };
     } else {
-        return FnResult{ .appended = {} };
+        return Result{ .appended = {} };
     }
 }
 

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -358,7 +358,7 @@ pub fn generate(
     if (function.err_msg) |em| {
         return Result{ .fail = em };
     } else {
-        return Result{ .appended = {} };
+        return Result.ok;
     }
 }
 

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1187,7 +1187,7 @@ pub fn generate(
         else => |e| return e,
     };
 
-    return codegen.Result{ .appended = {} };
+    return codegen.Result.ok;
 }
 
 fn genFunc(func: *CodeGen) InnerError!void {

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -627,13 +627,6 @@ test "Wasm - buildOpcode" {
     try testing.expectEqual(@as(wasm.Opcode, .f64_reinterpret_i64), f64_reinterpret_i64);
 }
 
-pub const Result = union(enum) {
-    /// The codegen bytes have been appended to `Context.code`
-    appended: void,
-    /// The data is managed externally and are part of the `Result`
-    externally_managed: []const u8,
-};
-
 /// Hashmap to store generated `WValue` for each `Air.Inst.Ref`
 pub const ValueTable = std.AutoArrayHashMapUnmanaged(Air.Inst.Ref, WValue);
 
@@ -1171,7 +1164,7 @@ pub fn generate(
     liveness: Liveness,
     code: *std.ArrayList(u8),
     debug_output: codegen.DebugInfoOutput,
-) codegen.GenerateSymbolError!codegen.FnResult {
+) codegen.GenerateSymbolError!codegen.Result {
     _ = src_loc;
     var code_gen: CodeGen = .{
         .gpa = bin_file.allocator,
@@ -1190,11 +1183,11 @@ pub fn generate(
     defer code_gen.deinit();
 
     genFunc(&code_gen) catch |err| switch (err) {
-        error.CodegenFail => return codegen.FnResult{ .fail = code_gen.err_msg },
+        error.CodegenFail => return codegen.Result{ .fail = code_gen.err_msg },
         else => |e| return e,
     };
 
-    return codegen.FnResult{ .appended = {} };
+    return codegen.Result{ .appended = {} };
 }
 
 fn genFunc(func: *CodeGen) InnerError!void {

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -352,7 +352,7 @@ pub fn generate(
     if (function.err_msg) |em| {
         return Result{ .fail = em };
     } else {
-        return Result{ .appended = {} };
+        return Result.ok;
     }
 }
 

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -16,7 +16,7 @@ const Compilation = @import("../../Compilation.zig");
 const DebugInfoOutput = codegen.DebugInfoOutput;
 const DW = std.dwarf;
 const ErrorMsg = Module.ErrorMsg;
-const FnResult = codegen.FnResult;
+const Result = codegen.Result;
 const GenerateSymbolError = codegen.GenerateSymbolError;
 const Emit = @import("Emit.zig");
 const Liveness = @import("../../Liveness.zig");
@@ -257,7 +257,7 @@ pub fn generate(
     liveness: Liveness,
     code: *std.ArrayList(u8),
     debug_output: DebugInfoOutput,
-) GenerateSymbolError!FnResult {
+) GenerateSymbolError!Result {
     if (build_options.skip_non_native and builtin.cpu.arch != bin_file.options.target.cpu.arch) {
         @panic("Attempted to compile for architecture that was disabled by build configuration");
     }
@@ -305,8 +305,8 @@ pub fn generate(
     defer if (builtin.mode == .Debug) function.mir_to_air_map.deinit();
 
     var call_info = function.resolveCallingConventionValues(fn_type) catch |err| switch (err) {
-        error.CodegenFail => return FnResult{ .fail = function.err_msg.? },
-        error.OutOfRegisters => return FnResult{
+        error.CodegenFail => return Result{ .fail = function.err_msg.? },
+        error.OutOfRegisters => return Result{
             .fail = try ErrorMsg.create(bin_file.allocator, src_loc, "CodeGen ran out of registers. This is a bug in the Zig compiler.", .{}),
         },
         else => |e| return e,
@@ -319,8 +319,8 @@ pub fn generate(
     function.max_end_stack = call_info.stack_byte_count;
 
     function.gen() catch |err| switch (err) {
-        error.CodegenFail => return FnResult{ .fail = function.err_msg.? },
-        error.OutOfRegisters => return FnResult{
+        error.CodegenFail => return Result{ .fail = function.err_msg.? },
+        error.OutOfRegisters => return Result{
             .fail = try ErrorMsg.create(bin_file.allocator, src_loc, "CodeGen ran out of registers. This is a bug in the Zig compiler.", .{}),
         },
         else => |e| return e,
@@ -345,14 +345,14 @@ pub fn generate(
     };
     defer emit.deinit();
     emit.lowerMir() catch |err| switch (err) {
-        error.EmitFail => return FnResult{ .fail = emit.err_msg.? },
+        error.EmitFail => return Result{ .fail = emit.err_msg.? },
         else => |e| return e,
     };
 
     if (function.err_msg) |em| {
-        return FnResult{ .fail = em };
+        return Result{ .fail = em };
     } else {
-        return FnResult{ .appended = {} };
+        return Result{ .appended = {} };
     }
 }
 

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -22,8 +22,10 @@ const Value = @import("value.zig").Value;
 const Zir = @import("Zir.zig");
 
 pub const Result = union(enum) {
-    /// The `code` parameter passed to `generateSymbol` has the value appended.
-    appended: void,
+    /// The `code` parameter passed to `generateSymbol` has the value ok.
+    ok: void,
+
+    /// There was a codegen error.
     fail: *ErrorMsg,
 };
 
@@ -138,7 +140,7 @@ pub fn generateSymbol(
     if (typed_value.val.isUndefDeep()) {
         const abi_size = math.cast(usize, typed_value.ty.abiSize(target)) orelse return error.Overflow;
         try code.appendNTimes(0xaa, abi_size);
-        return Result{ .appended = {} };
+        return Result.ok;
     }
 
     switch (typed_value.ty.zigTypeTag()) {
@@ -169,7 +171,7 @@ pub fn generateSymbol(
                 128 => writeFloat(f128, typed_value.val.toFloat(f128), target, endian, try code.addManyAsArray(16)),
                 else => unreachable,
             }
-            return Result{ .appended = {} };
+            return Result.ok;
         },
         .Array => switch (typed_value.val.tag()) {
             .bytes => {
@@ -178,7 +180,7 @@ pub fn generateSymbol(
                 // The bytes payload already includes the sentinel, if any
                 try code.ensureUnusedCapacity(len);
                 code.appendSliceAssumeCapacity(bytes[0..len]);
-                return Result{ .appended = {} };
+                return Result.ok;
             },
             .str_lit => {
                 const str_lit = typed_value.val.castTag(.str_lit).?.data;
@@ -190,7 +192,7 @@ pub fn generateSymbol(
                     const byte = @intCast(u8, sent_val.toUnsignedInt(target));
                     code.appendAssumeCapacity(byte);
                 }
-                return Result{ .appended = {} };
+                return Result.ok;
             },
             .aggregate => {
                 const elem_vals = typed_value.val.castTag(.aggregate).?.data;
@@ -201,11 +203,11 @@ pub fn generateSymbol(
                         .ty = elem_ty,
                         .val = elem_val,
                     }, code, debug_output, reloc_info)) {
-                        .appended => {},
+                        .ok => {},
                         .fail => |em| return Result{ .fail = em },
                     }
                 }
-                return Result{ .appended = {} };
+                return Result.ok;
             },
             .repeated => {
                 const array = typed_value.val.castTag(.repeated).?.data;
@@ -219,7 +221,7 @@ pub fn generateSymbol(
                         .ty = elem_ty,
                         .val = array,
                     }, code, debug_output, reloc_info)) {
-                        .appended => {},
+                        .ok => {},
                         .fail => |em| return Result{ .fail = em },
                     }
                 }
@@ -229,12 +231,12 @@ pub fn generateSymbol(
                         .ty = elem_ty,
                         .val = sentinel_val,
                     }, code, debug_output, reloc_info)) {
-                        .appended => {},
+                        .ok => {},
                         .fail => |em| return Result{ .fail = em },
                     }
                 }
 
-                return Result{ .appended = {} };
+                return Result.ok;
             },
             .empty_array_sentinel => {
                 const elem_ty = typed_value.ty.childType();
@@ -243,10 +245,10 @@ pub fn generateSymbol(
                     .ty = elem_ty,
                     .val = sentinel_val,
                 }, code, debug_output, reloc_info)) {
-                    .appended => {},
+                    .ok => {},
                     .fail => |em| return Result{ .fail = em },
                 }
-                return Result{ .appended = {} };
+                return Result.ok;
             },
             else => return Result{
                 .fail = try ErrorMsg.create(
@@ -270,7 +272,7 @@ pub fn generateSymbol(
                     },
                     else => unreachable,
                 }
-                return Result{ .appended = {} };
+                return Result.ok;
             },
             .variable => {
                 const decl = typed_value.val.castTag(.variable).?.data.owner_decl;
@@ -290,7 +292,7 @@ pub fn generateSymbol(
                     .ty = slice_ptr_field_type,
                     .val = slice.ptr,
                 }, code, debug_output, reloc_info)) {
-                    .appended => {},
+                    .ok => {},
                     .fail => |em| return Result{ .fail = em },
                 }
 
@@ -299,11 +301,11 @@ pub fn generateSymbol(
                     .ty = Type.initTag(.usize),
                     .val = slice.len,
                 }, code, debug_output, reloc_info)) {
-                    .appended => {},
+                    .ok => {},
                     .fail => |em| return Result{ .fail = em },
                 }
 
-                return Result{ .appended = {} };
+                return Result.ok;
             },
             .field_ptr => {
                 const field_ptr = typed_value.val.castTag(.field_ptr).?.data;
@@ -350,10 +352,10 @@ pub fn generateSymbol(
                             .ty = typed_value.ty,
                             .val = container_ptr,
                         }, code, debug_output, reloc_info)) {
-                            .appended => {},
+                            .ok => {},
                             .fail => |em| return Result{ .fail = em },
                         }
-                        return Result{ .appended = {} };
+                        return Result.ok;
                     },
                     else => return Result{
                         .fail = try ErrorMsg.create(
@@ -406,7 +408,7 @@ pub fn generateSymbol(
                     .signed => @bitCast(u8, @intCast(i8, typed_value.val.toSignedInt(target))),
                 };
                 try code.append(x);
-                return Result{ .appended = {} };
+                return Result.ok;
             }
             if (info.bits > 64) {
                 var bigint_buffer: Value.BigIntSpace = undefined;
@@ -415,7 +417,7 @@ pub fn generateSymbol(
                 const start = code.items.len;
                 try code.resize(start + abi_size);
                 bigint.writeTwosComplement(code.items[start..][0..abi_size], endian);
-                return Result{ .appended = {} };
+                return Result.ok;
             }
             switch (info.signedness) {
                 .unsigned => {
@@ -443,7 +445,7 @@ pub fn generateSymbol(
                     }
                 },
             }
-            return Result{ .appended = {} };
+            return Result.ok;
         },
         .Enum => {
             var int_buffer: Value.Payload.U64 = undefined;
@@ -453,7 +455,7 @@ pub fn generateSymbol(
             if (info.bits <= 8) {
                 const x = @intCast(u8, int_val.toUnsignedInt(target));
                 try code.append(x);
-                return Result{ .appended = {} };
+                return Result.ok;
             }
             if (info.bits > 64) {
                 return Result{
@@ -491,12 +493,12 @@ pub fn generateSymbol(
                     }
                 },
             }
-            return Result{ .appended = {} };
+            return Result.ok;
         },
         .Bool => {
             const x: u8 = @boolToInt(typed_value.val.toBool());
             try code.append(x);
-            return Result{ .appended = {} };
+            return Result.ok;
         },
         .Struct => {
             if (typed_value.ty.containerLayout() == .Packed) {
@@ -521,9 +523,7 @@ pub fn generateSymbol(
                             .ty = field_ty,
                             .val = field_val,
                         }, &tmp_list, debug_output, reloc_info)) {
-                            .appended => {
-                                mem.copy(u8, code.items[current_pos..], tmp_list.items);
-                            },
+                            .ok => mem.copy(u8, code.items[current_pos..], tmp_list.items),
                             .fail => |em| return Result{ .fail = em },
                         }
                     } else {
@@ -532,7 +532,7 @@ pub fn generateSymbol(
                     bits += @intCast(u16, field_ty.bitSize(target));
                 }
 
-                return Result{ .appended = {} };
+                return Result.ok;
             }
 
             const struct_begin = code.items.len;
@@ -545,7 +545,7 @@ pub fn generateSymbol(
                     .ty = field_ty,
                     .val = field_val,
                 }, code, debug_output, reloc_info)) {
-                    .appended => {},
+                    .ok => {},
                     .fail => |em| return Result{ .fail = em },
                 }
                 const unpadded_field_end = code.items.len - struct_begin;
@@ -559,7 +559,7 @@ pub fn generateSymbol(
                 }
             }
 
-            return Result{ .appended = {} };
+            return Result.ok;
         },
         .Union => {
             const union_obj = typed_value.val.castTag(.@"union").?.data;
@@ -578,7 +578,7 @@ pub fn generateSymbol(
                     .ty = typed_value.ty.unionTagType().?,
                     .val = union_obj.tag,
                 }, code, debug_output, reloc_info)) {
-                    .appended => {},
+                    .ok => {},
                     .fail => |em| return Result{ .fail = em },
                 }
             }
@@ -595,7 +595,7 @@ pub fn generateSymbol(
                     .ty = field_ty,
                     .val = union_obj.val,
                 }, code, debug_output, reloc_info)) {
-                    .appended => {},
+                    .ok => {},
                     .fail => |em| return Result{ .fail = em },
                 }
 
@@ -610,12 +610,12 @@ pub fn generateSymbol(
                     .ty = union_ty.tag_ty,
                     .val = union_obj.tag,
                 }, code, debug_output, reloc_info)) {
-                    .appended => {},
+                    .ok => {},
                     .fail => |em| return Result{ .fail = em },
                 }
             }
 
-            return Result{ .appended = {} };
+            return Result.ok;
         },
         .Optional => {
             var opt_buf: Type.Payload.ElemType = undefined;
@@ -626,7 +626,7 @@ pub fn generateSymbol(
 
             if (!payload_type.hasRuntimeBits()) {
                 try code.writer().writeByteNTimes(@boolToInt(is_pl), abi_size);
-                return Result{ .appended = {} };
+                return Result.ok;
             }
 
             if (typed_value.ty.optionalReprIsPayload()) {
@@ -635,7 +635,7 @@ pub fn generateSymbol(
                         .ty = payload_type,
                         .val = payload.data,
                     }, code, debug_output, reloc_info)) {
-                        .appended => {},
+                        .ok => {},
                         .fail => |em| return Result{ .fail = em },
                     }
                 } else if (!typed_value.val.isNull()) {
@@ -643,14 +643,14 @@ pub fn generateSymbol(
                         .ty = payload_type,
                         .val = typed_value.val,
                     }, code, debug_output, reloc_info)) {
-                        .appended => {},
+                        .ok => {},
                         .fail => |em| return Result{ .fail = em },
                     }
                 } else {
                     try code.writer().writeByteNTimes(0, abi_size);
                 }
 
-                return Result{ .appended = {} };
+                return Result.ok;
             }
 
             const value = if (typed_value.val.castTag(.opt_payload)) |payload| payload.data else Value.initTag(.undef);
@@ -659,11 +659,11 @@ pub fn generateSymbol(
                 .ty = payload_type,
                 .val = value,
             }, code, debug_output, reloc_info)) {
-                .appended => {},
+                .ok => {},
                 .fail => |em| return Result{ .fail = em },
             }
 
-            return Result{ .appended = {} };
+            return Result.ok;
         },
         .ErrorUnion => {
             const error_ty = typed_value.ty.errorUnionSet();
@@ -688,7 +688,7 @@ pub fn generateSymbol(
                     .ty = error_ty,
                     .val = if (is_payload) Value.initTag(.zero) else typed_value.val,
                 }, code, debug_output, reloc_info)) {
-                    .appended => {},
+                    .ok => {},
                     .fail => |em| return Result{ .fail = em },
                 }
             }
@@ -701,7 +701,7 @@ pub fn generateSymbol(
                     .ty = payload_ty,
                     .val = payload_val,
                 }, code, debug_output, reloc_info)) {
-                    .appended => {},
+                    .ok => {},
                     .fail => |em| return Result{ .fail = em },
                 }
                 const unpadded_end = code.items.len - begin;
@@ -720,7 +720,7 @@ pub fn generateSymbol(
                     .ty = error_ty,
                     .val = if (is_payload) Value.initTag(.zero) else typed_value.val,
                 }, code, debug_output, reloc_info)) {
-                    .appended => {},
+                    .ok => {},
                     .fail => |em| return Result{ .fail = em },
                 }
                 const unpadded_end = code.items.len - begin;
@@ -732,7 +732,7 @@ pub fn generateSymbol(
                 }
             }
 
-            return Result{ .appended = {} };
+            return Result.ok;
         },
         .ErrorSet => {
             switch (typed_value.val.tag()) {
@@ -745,7 +745,7 @@ pub fn generateSymbol(
                     try code.writer().writeByteNTimes(0, @intCast(usize, Type.anyerror.abiSize(target)));
                 },
             }
-            return Result{ .appended = {} };
+            return Result.ok;
         },
         .Vector => switch (typed_value.val.tag()) {
             .bytes => {
@@ -753,7 +753,7 @@ pub fn generateSymbol(
                 const len = @intCast(usize, typed_value.ty.arrayLen());
                 try code.ensureUnusedCapacity(len);
                 code.appendSliceAssumeCapacity(bytes[0..len]);
-                return Result{ .appended = {} };
+                return Result.ok;
             },
             .aggregate => {
                 const elem_vals = typed_value.val.castTag(.aggregate).?.data;
@@ -764,11 +764,11 @@ pub fn generateSymbol(
                         .ty = elem_ty,
                         .val = elem_val,
                     }, code, debug_output, reloc_info)) {
-                        .appended => {},
+                        .ok => {},
                         .fail => |em| return Result{ .fail = em },
                     }
                 }
-                return Result{ .appended = {} };
+                return Result.ok;
             },
             .repeated => {
                 const array = typed_value.val.castTag(.repeated).?.data;
@@ -781,11 +781,11 @@ pub fn generateSymbol(
                         .ty = elem_ty,
                         .val = array,
                     }, code, debug_output, reloc_info)) {
-                        .appended => {},
+                        .ok => {},
                         .fail => |em| return Result{ .fail = em },
                     }
                 }
-                return Result{ .appended = {} };
+                return Result.ok;
             },
             .str_lit => {
                 const str_lit = typed_value.val.castTag(.str_lit).?.data;
@@ -793,7 +793,7 @@ pub fn generateSymbol(
                 const bytes = mod.string_literal_bytes.items[str_lit.index..][0..str_lit.len];
                 try code.ensureUnusedCapacity(str_lit.len);
                 code.appendSliceAssumeCapacity(bytes);
-                return Result{ .appended = {} };
+                return Result.ok;
             },
             else => unreachable,
         },
@@ -834,7 +834,7 @@ fn lowerDeclRef(
             .ty = slice_ptr_field_type,
             .val = typed_value.val,
         }, code, debug_output, reloc_info)) {
-            .appended => {},
+            .ok => {},
             .fail => |em| return Result{ .fail = em },
         }
 
@@ -847,11 +847,11 @@ fn lowerDeclRef(
             .ty = Type.usize,
             .val = Value.initPayload(&slice_len.base),
         }, code, debug_output, reloc_info)) {
-            .appended => {},
+            .ok => {},
             .fail => |em| return Result{ .fail = em },
         }
 
-        return Result{ .appended = {} };
+        return Result.ok;
     }
 
     const ptr_width = target.cpu.arch.ptrBitWidth();
@@ -859,7 +859,7 @@ fn lowerDeclRef(
     const is_fn_body = decl.ty.zigTypeTag() == .Fn;
     if (!is_fn_body and !decl.ty.hasRuntimeBits()) {
         try code.writer().writeByteNTimes(0xaa, @divExact(ptr_width, 8));
-        return Result{ .appended = {} };
+        return Result.ok;
     }
 
     module.markDeclAlive(decl);
@@ -877,7 +877,7 @@ fn lowerDeclRef(
         else => unreachable,
     }
 
-    return Result{ .appended = {} };
+    return Result.ok;
 }
 
 pub fn errUnionPayloadOffset(payload_ty: Type, target: std.Target) u64 {

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -981,7 +981,6 @@ pub fn lowerUnnamedConst(self: *Coff, tv: TypedValue, decl_index: Module.Decl.In
         .parent_atom_index = atom.sym_index,
     });
     const code = switch (res) {
-        .externally_managed => |x| x,
         .appended => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
@@ -1042,7 +1041,6 @@ pub fn updateDecl(self: *Coff, module: *Module, decl_index: Module.Decl.Index) !
         .parent_atom_index = decl.link.coff.sym_index,
     });
     const code = switch (res) {
-        .externally_managed => |x| x,
         .appended => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -928,7 +928,7 @@ pub fn updateFunc(self: *Coff, module: *Module, func: *Module.Fn, air: Air, live
         .none,
     );
     const code = switch (res) {
-        .appended => code_buffer.items,
+        .ok => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try module.failed_decls.put(module.gpa, decl_index, em);
@@ -981,7 +981,7 @@ pub fn lowerUnnamedConst(self: *Coff, tv: TypedValue, decl_index: Module.Decl.In
         .parent_atom_index = atom.sym_index,
     });
     const code = switch (res) {
-        .appended => code_buffer.items,
+        .ok => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try mod.failed_decls.put(mod.gpa, decl_index, em);
@@ -1041,7 +1041,7 @@ pub fn updateDecl(self: *Coff, module: *Module, decl_index: Module.Decl.Index) !
         .parent_atom_index = decl.link.coff.sym_index,
     });
     const code = switch (res) {
-        .appended => code_buffer.items,
+        .ok => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try module.failed_decls.put(module.gpa, decl_index, em);

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2553,7 +2553,6 @@ pub fn updateDecl(self: *Elf, module: *Module, decl_index: Module.Decl.Index) !v
         });
 
     const code = switch (res) {
-        .externally_managed => |x| x,
         .appended => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
@@ -2618,7 +2617,6 @@ pub fn lowerUnnamedConst(self: *Elf, typed_value: TypedValue, decl_index: Module
         .parent_atom_index = atom.local_sym_index,
     });
     const code = switch (res) {
-        .externally_managed => |x| x,
         .appended => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2479,7 +2479,7 @@ pub fn updateFunc(self: *Elf, module: *Module, func: *Module.Fn, air: Air, liven
         try codegen.generateFunction(&self.base, decl.srcLoc(), func, air, liveness, &code_buffer, .none);
 
     const code = switch (res) {
-        .appended => code_buffer.items,
+        .ok => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try module.failed_decls.put(module.gpa, decl_index, em);
@@ -2553,7 +2553,7 @@ pub fn updateDecl(self: *Elf, module: *Module, decl_index: Module.Decl.Index) !v
         });
 
     const code = switch (res) {
-        .appended => code_buffer.items,
+        .ok => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try module.failed_decls.put(module.gpa, decl_index, em);
@@ -2617,7 +2617,7 @@ pub fn lowerUnnamedConst(self: *Elf, typed_value: TypedValue, decl_index: Module
         .parent_atom_index = atom.local_sym_index,
     });
     const code = switch (res) {
-        .appended => code_buffer.items,
+        .ok => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try mod.failed_decls.put(mod.gpa, decl_index, em);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2017,7 +2017,7 @@ pub fn updateFunc(self: *MachO, module: *Module, func: *Module.Fn, air: Air, liv
         try codegen.generateFunction(&self.base, decl.srcLoc(), func, air, liveness, &code_buffer, .none);
 
     const code = switch (res) {
-        .appended => code_buffer.items,
+        .ok => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try module.failed_decls.put(module.gpa, decl_index, em);
@@ -2082,7 +2082,7 @@ pub fn lowerUnnamedConst(self: *MachO, typed_value: TypedValue, decl_index: Modu
         .parent_atom_index = atom.sym_index,
     });
     const code = switch (res) {
-        .appended => code_buffer.items,
+        .ok => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try module.failed_decls.put(module.gpa, decl_index, em);
@@ -2166,7 +2166,7 @@ pub fn updateDecl(self: *MachO, module: *Module, decl_index: Module.Decl.Index) 
         });
 
     const code = switch (res) {
-        .appended => code_buffer.items,
+        .ok => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try module.failed_decls.put(module.gpa, decl_index, em);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2082,7 +2082,6 @@ pub fn lowerUnnamedConst(self: *MachO, typed_value: TypedValue, decl_index: Modu
         .parent_atom_index = atom.sym_index,
     });
     const code = switch (res) {
-        .externally_managed => |x| x,
         .appended => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
@@ -2167,7 +2166,6 @@ pub fn updateDecl(self: *MachO, module: *Module, decl_index: Module.Decl.Index) 
         });
 
     const code = switch (res) {
-        .externally_managed => |x| x,
         .appended => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -299,7 +299,7 @@ pub fn updateFunc(self: *Plan9, module: *Module, func: *Module.Fn, air: Air, liv
         },
     );
     const code = switch (res) {
-        .appended => try code_buffer.toOwnedSlice(),
+        .ok => try code_buffer.toOwnedSlice(),
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try module.failed_decls.put(module.gpa, decl_index, em);
@@ -358,7 +358,7 @@ pub fn lowerUnnamedConst(self: *Plan9, tv: TypedValue, decl_index: Module.Decl.I
         .parent_atom_index = @enumToInt(decl_index),
     });
     const code = switch (res) {
-        .appended => code_buffer.items,
+        .ok => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try mod.failed_decls.put(mod.gpa, decl_index, em);
@@ -402,7 +402,7 @@ pub fn updateDecl(self: *Plan9, module: *Module, decl_index: Module.Decl.Index) 
         .parent_atom_index = @enumToInt(decl_index),
     });
     const code = switch (res) {
-        .appended => code_buffer.items,
+        .ok => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try module.failed_decls.put(module.gpa, decl_index, em);

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -358,7 +358,6 @@ pub fn lowerUnnamedConst(self: *Plan9, tv: TypedValue, decl_index: Module.Decl.I
         .parent_atom_index = @enumToInt(decl_index),
     });
     const code = switch (res) {
-        .externally_managed => |x| x,
         .appended => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
@@ -403,7 +402,6 @@ pub fn updateDecl(self: *Plan9, module: *Module, decl_index: Module.Decl.Index) 
         .parent_atom_index = @enumToInt(decl_index),
     });
     const code = switch (res) {
-        .externally_managed => |x| x,
         .appended => code_buffer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -1046,7 +1046,7 @@ pub fn updateFunc(wasm: *Wasm, mod: *Module, func: *Module.Fn, air: Air, livenes
     );
 
     const code = switch (result) {
-        .appended => code_writer.items,
+        .ok => code_writer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try mod.failed_decls.put(mod.gpa, decl_index, em);
@@ -1113,7 +1113,7 @@ pub fn updateDecl(wasm: *Wasm, mod: *Module, decl_index: Module.Decl.Index) !voi
     );
 
     const code = switch (res) {
-        .appended => code_writer.items,
+        .ok => code_writer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try mod.failed_decls.put(mod.gpa, decl_index, em);
@@ -1249,7 +1249,7 @@ pub fn lowerUnnamedConst(wasm: *Wasm, tv: TypedValue, decl_index: Module.Decl.In
         },
     );
     const code = switch (result) {
-        .appended => value_bytes.items,
+        .ok => value_bytes.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try mod.failed_decls.put(mod.gpa, decl_index, em);

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -1113,7 +1113,6 @@ pub fn updateDecl(wasm: *Wasm, mod: *Module, decl_index: Module.Decl.Index) !voi
     );
 
     const code = switch (res) {
-        .externally_managed => |x| x,
         .appended => code_writer.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;
@@ -1250,7 +1249,6 @@ pub fn lowerUnnamedConst(wasm: *Wasm, tv: TypedValue, decl_index: Module.Decl.In
         },
     );
     const code = switch (result) {
-        .externally_managed => |x| x,
         .appended => value_bytes.items,
         .fail => |em| {
             decl.analysis = .codegen_failure;


### PR DESCRIPTION
* remove unused `externally_managed` prong for Decls' code - even if we did find a use for it, we would need to redesign it to account for relocations applied by the linker, i.e., make it mutable one way or another
* rename `Result.appended` to `Result.ok` as we do not really care how the linker/codegen handled it