### PR TITLE
langref: add missing dot at the end of the paragraph

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10869,7 +10869,7 @@ test "variadic function" {
 }
       {#code_end#}
       <p>
-        Variadic functions can be implemented using {#link|@cVaStart#}, {#link|@cVaEnd#}, {#link|@cVaArg#} and {#link|@cVaCopy#}
+        Variadic functions can be implemented using {#link|@cVaStart#}, {#link|@cVaEnd#}, {#link|@cVaArg#} and {#link|@cVaCopy#}.
       </p>
       {#code_begin|test|test_defining_variadic_function#}
 const std = @import("std");


### PR DESCRIPTION
In the "C Variadic Functions" section, add a missing dot at the end of the paragraph before the test_defining_variadic_function.zig example.