### PR TITLE
wasi: remove unnecessary breakpoint() in abort

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -550,7 +550,6 @@ pub fn abort() noreturn {
         exit(0); // TODO choose appropriate exit code
     }
     if (builtin.os.tag == .wasi) {
-        @breakpoint();
         exit(1);
     }
     if (builtin.os.tag == .cuda) {


### PR DESCRIPTION
This was introduced in https://github.com/ziglang/zig/commit/b37acc4d6870a090c3501d81d3f647bc30220e4b as a workaround, but it shouldn't be needed anymore (all the runtimes should be able to handle exit(1) properly, and the `unreachable` is in any way inserted _after_  proc_exit). This makes the code aligned with other platforms. 