### PR TITLE
wasm: uses main instead of main2 for test runner

### DIFF
--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -11,7 +11,7 @@ var log_err_count: usize = 0;
 
 pub fn main() void {
     if (builtin.zig_backend != .stage1 and
-        (builtin.zig_backend != .stage2_llvm or builtin.cpu.arch == .wasm32) and
+        builtin.zig_backend != .stage2_llvm and
         builtin.zig_backend != .stage2_c)
     {
         return main2() catch @panic("test failure");


### PR DESCRIPTION
This will allow users to have more informative outputs when they run in-Wasm unit tests:


### Before

```
$ zig test -target wasm32-wasi --test-cmd wasmtime --test-cmd run --test-cmd-bin --zig-lib-dir ../ziglang/lib test.zig
0 passed; 0 skipped; 2 failed.
test failureError: failed to run main module `/XXX/zig-cache/o/22440a85b93b9bbbacf5235da2ee1591/test.wasm`

Caused by:
    0: failed to invoke command default
    1: error while executing at wasm backtrace:
           0:  0x2ab - <unknown>!os.abort
           1:  0x17e - <unknown>!builtin.default_panic
           2:  0x819 - <unknown>!test_runner.main
           3:  0x79d - <unknown>!_start
       note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information
    2: wasm trap: wasm `unreachable` instruction executed
error: the following test command failed with exit code 134:
wasmtime run /XXX/zig-cache/o/22440a85b93b9bbbacf5235da2ee1591/test.wasm
```
### After

```
$ zig test -target wasm32-wasi --test-cmd wasmtime --test-cmd run --test-cmd-bin --zig-lib-dir ../ziglang/lib test.zig
1/2 test.testing my function... FAIL (TestUnexpectedResult)
2/2 test.testing my variables... FAIL (TestUnexpectedResult)
0 passed; 0 skipped; 2 failed.
error: the following test command failed with exit code 1:
wasmtime run /XXk/zig-cache/o/22440a85b93b9bbbacf5235da2ee1591/test.wasm
```