### PR TITLE
self-hosted: remove allocateDeclIndexes from the linker API

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -5324,7 +5324,7 @@ pub fn deleteUnusedDecl(mod: *Module, decl_index: Decl.Index) void {
     // Until then, we did call `allocateDeclIndexes` on this anonymous Decl and so we
     // must call `freeDecl` in the linker backend now.
     switch (mod.comp.bin_file.tag) {
-        .c => {}, // this linker backend has already migrated to the new API
+        .macho, .c => {}, // this linker backend has already migrated to the new API
         else => if (decl.has_tv) {
             if (decl.ty.isFnOrHasRuntimeBits()) {
                 mod.comp.bin_file.freeDecl(decl_index);

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -5328,6 +5328,7 @@ pub fn deleteUnusedDecl(mod: *Module, decl_index: Decl.Index) void {
         .elf,
         .macho,
         .c,
+        .wasm,
         => {}, // this linker backend has already migrated to the new API
 
         else => if (decl.has_tv) {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -5324,7 +5324,12 @@ pub fn deleteUnusedDecl(mod: *Module, decl_index: Decl.Index) void {
     // Until then, we did call `allocateDeclIndexes` on this anonymous Decl and so we
     // must call `freeDecl` in the linker backend now.
     switch (mod.comp.bin_file.tag) {
-        .elf, .macho, .c => {}, // this linker backend has already migrated to the new API
+        .coff,
+        .elf,
+        .macho,
+        .c,
+        => {}, // this linker backend has already migrated to the new API
+
         else => if (decl.has_tv) {
             if (decl.ty.isFnOrHasRuntimeBits()) {
                 mod.comp.bin_file.freeDecl(decl_index);

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -5324,7 +5324,7 @@ pub fn deleteUnusedDecl(mod: *Module, decl_index: Decl.Index) void {
     // Until then, we did call `allocateDeclIndexes` on this anonymous Decl and so we
     // must call `freeDecl` in the linker backend now.
     switch (mod.comp.bin_file.tag) {
-        .macho, .c => {}, // this linker backend has already migrated to the new API
+        .elf, .macho, .c => {}, // this linker backend has already migrated to the new API
         else => if (decl.has_tv) {
             if (decl.ty.isFnOrHasRuntimeBits()) {
                 mod.comp.bin_file.freeDecl(decl_index);

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4585,7 +4585,6 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
                 // We don't fully codegen the decl until later, but we do need to reserve a global
                 // offset table index for it. This allows us to codegen decls out of dependency
                 // order, increasing how many computations can be done in parallel.
-                try mod.comp.bin_file.allocateDeclIndexes(decl_index);
                 try mod.comp.work_queue.writeItem(.{ .codegen_func = func });
                 if (type_changed and mod.emit_h != null) {
                     try mod.comp.work_queue.writeItem(.{ .emit_h_decl = decl_index });
@@ -4697,7 +4696,6 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
         // codegen backend wants full access to the Decl Type.
         try sema.resolveTypeFully(decl.ty);
 
-        try mod.comp.bin_file.allocateDeclIndexes(decl_index);
         try mod.comp.work_queue.writeItem(.{ .codegen_decl = decl_index });
 
         if (type_changed and mod.emit_h != null) {
@@ -5315,29 +5313,6 @@ pub fn deleteUnusedDecl(mod: *Module, decl_index: Decl.Index) void {
     const decl = mod.declPtr(decl_index);
     log.debug("deleteUnusedDecl {d} ({s})", .{ decl_index, decl.name });
 
-    // TODO: remove `allocateDeclIndexes` and make the API that the linker backends
-    // are required to notice the first time `updateDecl` happens and keep track
-    // of it themselves. However they can rely on getting a `freeDecl` call if any
-    // `updateDecl` or `updateFunc` calls happen. This will allow us to avoid any call
-    // into the linker backend here, since the linker backend will never have been told
-    // about the Decl in the first place.
-    // Until then, we did call `allocateDeclIndexes` on this anonymous Decl and so we
-    // must call `freeDecl` in the linker backend now.
-    switch (mod.comp.bin_file.tag) {
-        .coff,
-        .elf,
-        .macho,
-        .c,
-        .wasm,
-        => {}, // this linker backend has already migrated to the new API
-
-        else => if (decl.has_tv) {
-            if (decl.ty.isFnOrHasRuntimeBits()) {
-                mod.comp.bin_file.freeDecl(decl_index);
-            }
-        },
-    }
-
     assert(!mod.declIsRoot(decl_index));
     assert(decl.src_namespace.anon_decls.swapRemove(decl_index));
 
@@ -5822,7 +5797,6 @@ pub fn initNewAnonDecl(
     // the Decl will be garbage collected by the `codegen_decl` task instead of sent
     // to the linker.
     if (typed_value.ty.isFnOrHasRuntimeBits()) {
-        try mod.comp.bin_file.allocateDeclIndexes(new_decl_index);
         try mod.comp.anon_work_queue.writeItem(.{ .codegen_decl = new_decl_index });
     }
 }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7510,7 +7510,6 @@ fn resolveGenericInstantiationType(
     // Queue up a `codegen_func` work item for the new Fn. The `comptime_args` field
     // will be populated, ensuring it will have `analyzeBody` called with the ZIR
     // parameters mapped appropriately.
-    try mod.comp.bin_file.allocateDeclIndexes(new_decl_index);
     try mod.comp.work_queue.writeItem(.{ .codegen_func = new_func });
     return new_func;
 }

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -4307,12 +4307,8 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
             const fn_owner_decl = mod.declPtr(func.owner_decl);
 
             if (self.bin_file.cast(link.File.Elf)) |elf_file| {
-                const ptr_bits = self.target.cpu.arch.ptrBitWidth();
-                const ptr_bytes: u64 = @divExact(ptr_bits, 8);
-                const got_addr = blk: {
-                    const got = &elf_file.program_headers.items[elf_file.phdr_got_index.?];
-                    break :blk @intCast(u32, got.p_vaddr + fn_owner_decl.link.elf.offset_table_index * ptr_bytes);
-                };
+                try fn_owner_decl.link.elf.ensureInitialized(elf_file);
+                const got_addr = @intCast(u32, fn_owner_decl.link.elf.getOffsetTableAddress(elf_file));
                 try self.genSetReg(Type.initTag(.usize), .x30, .{ .memory = got_addr });
             } else if (self.bin_file.cast(link.File.MachO)) |macho_file| {
                 try fn_owner_decl.link.macho.ensureInitialized(macho_file);
@@ -6125,20 +6121,15 @@ fn lowerDeclRef(self: *Self, tv: TypedValue, decl_index: Module.Decl.Index) Inne
     mod.markDeclAlive(decl);
 
     if (self.bin_file.cast(link.File.Elf)) |elf_file| {
-        const got = &elf_file.program_headers.items[elf_file.phdr_got_index.?];
-        const got_addr = got.p_vaddr + decl.link.elf.offset_table_index * ptr_bytes;
-        return MCValue{ .memory = got_addr };
+        try decl.link.elf.ensureInitialized(elf_file);
+        return MCValue{ .memory = decl.link.elf.getOffsetTableAddress(elf_file) };
     } else if (self.bin_file.cast(link.File.MachO)) |macho_file| {
-        // Because MachO is PIE-always-on, we defer memory address resolution until
-        // the linker has enough info to perform relocations.
         try decl.link.macho.ensureInitialized(macho_file);
         return MCValue{ .linker_load = .{
             .type = .got,
             .sym_index = decl.link.macho.getSymbolIndex().?,
         } };
     } else if (self.bin_file.cast(link.File.Coff)) |_| {
-        // Because COFF is PIE-always-on, we defer memory address resolution until
-        // the linker has enough info to perform relocations.
         assert(decl.link.coff.sym_index != 0);
         return MCValue{ .linker_load = .{
             .type = .got,

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -2120,22 +2120,28 @@ fn airCall(func: *CodeGen, inst: Air.Inst.Index, modifier: std.builtin.CallModif
         const module = func.bin_file.base.options.module.?;
 
         if (func_val.castTag(.function)) |function| {
-            break :blk module.declPtr(function.data.owner_decl);
+            const decl = module.declPtr(function.data.owner_decl);
+            try decl.link.wasm.ensureInitialized(func.bin_file);
+            break :blk decl;
         } else if (func_val.castTag(.extern_fn)) |extern_fn| {
             const ext_decl = module.declPtr(extern_fn.data.owner_decl);
             const ext_info = ext_decl.ty.fnInfo();
             var func_type = try genFunctype(func.gpa, ext_info.cc, ext_info.param_types, ext_info.return_type, func.target);
             defer func_type.deinit(func.gpa);
+            const atom = &ext_decl.link.wasm;
+            try atom.ensureInitialized(func.bin_file);
             ext_decl.fn_link.wasm.type_index = try func.bin_file.putOrGetFuncType(func_type);
             try func.bin_file.addOrUpdateImport(
                 mem.sliceTo(ext_decl.name, 0),
-                ext_decl.link.wasm.sym_index,
+                atom.getSymbolIndex().?,
                 ext_decl.getExternFn().?.lib_name,
                 ext_decl.fn_link.wasm.type_index,
             );
             break :blk ext_decl;
         } else if (func_val.castTag(.decl_ref)) |decl_ref| {
-            break :blk module.declPtr(decl_ref.data);
+            const decl = module.declPtr(decl_ref.data);
+            try decl.link.wasm.ensureInitialized(func.bin_file);
+            break :blk decl;
         }
         return func.fail("Expected a function, but instead found type '{}'", .{func_val.tag()});
     };
@@ -2752,6 +2758,7 @@ fn lowerDeclRefValue(func: *CodeGen, tv: TypedValue, decl_index: Module.Decl.Ind
     }
 
     module.markDeclAlive(decl);
+    try decl.link.wasm.ensureInitialized(func.bin_file);
 
     const target_sym_index = decl.link.wasm.sym_index;
     if (decl.ty.zigTypeTag() == .Fn) {

--- a/src/link.zig
+++ b/src/link.zig
@@ -617,7 +617,7 @@ pub const File = struct {
         switch (base.tag) {
             .coff => return @fieldParentPtr(Coff, "base", base).allocateDeclIndexes(decl_index),
             .elf => return @fieldParentPtr(Elf, "base", base).allocateDeclIndexes(decl_index),
-            .macho => return @fieldParentPtr(MachO, "base", base).allocateDeclIndexes(decl_index),
+            .macho => {}, // no-op
             .wasm => return @fieldParentPtr(Wasm, "base", base).allocateDeclIndexes(decl_index),
             .plan9 => return @fieldParentPtr(Plan9, "base", base).allocateDeclIndexes(decl_index),
             .c, .spirv, .nvptx => {},
@@ -911,6 +911,8 @@ pub const File = struct {
     /// The linker is passed information about the containing atom, `parent_atom_index`, and offset within it's
     /// memory buffer, `offset`, so that it can make a note of potential relocation sites, should the
     /// `Decl`'s address was not yet resolved, or the containing atom gets moved in virtual memory.
+    /// May be called before or after updateFunc/updateDecl therefore it is up to the linker to allocate
+    /// the block/atom.
     pub fn getDeclVAddr(base: *File, decl_index: Module.Decl.Index, reloc_info: RelocInfo) !u64 {
         if (build_options.only_c) unreachable;
         switch (base.tag) {

--- a/src/link.zig
+++ b/src/link.zig
@@ -615,12 +615,16 @@ pub const File = struct {
             return;
         }
         switch (base.tag) {
-            .coff => return @fieldParentPtr(Coff, "base", base).allocateDeclIndexes(decl_index),
-            .elf => {}, // no-op
-            .macho => {}, // no-op
             .wasm => return @fieldParentPtr(Wasm, "base", base).allocateDeclIndexes(decl_index),
             .plan9 => return @fieldParentPtr(Plan9, "base", base).allocateDeclIndexes(decl_index),
-            .c, .spirv, .nvptx => {},
+
+            .coff,
+            .elf,
+            .macho,
+            .c,
+            .spirv,
+            .nvptx,
+            => {},
         }
     }
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -615,7 +615,6 @@ pub const File = struct {
             return;
         }
         switch (base.tag) {
-            .wasm => return @fieldParentPtr(Wasm, "base", base).allocateDeclIndexes(decl_index),
             .plan9 => return @fieldParentPtr(Plan9, "base", base).allocateDeclIndexes(decl_index),
 
             .coff,
@@ -624,6 +623,7 @@ pub const File = struct {
             .c,
             .spirv,
             .nvptx,
+            .wasm,
             => {},
         }
     }

--- a/src/link.zig
+++ b/src/link.zig
@@ -616,7 +616,7 @@ pub const File = struct {
         }
         switch (base.tag) {
             .coff => return @fieldParentPtr(Coff, "base", base).allocateDeclIndexes(decl_index),
-            .elf => return @fieldParentPtr(Elf, "base", base).allocateDeclIndexes(decl_index),
+            .elf => {}, // no-op
             .macho => {}, // no-op
             .wasm => return @fieldParentPtr(Wasm, "base", base).allocateDeclIndexes(decl_index),
             .plan9 => return @fieldParentPtr(Plan9, "base", base).allocateDeclIndexes(decl_index),

--- a/src/link.zig
+++ b/src/link.zig
@@ -533,8 +533,7 @@ pub const File = struct {
         }
     }
 
-    /// May be called before or after updateDeclExports but must be called
-    /// after allocateDeclIndexes for any given Decl.
+    /// May be called before or after updateDeclExports for any given Decl.
     pub fn updateDecl(base: *File, module: *Module, decl_index: Module.Decl.Index) UpdateDeclError!void {
         const decl = module.declPtr(decl_index);
         log.debug("updateDecl {*} ({s}), type={}", .{ decl, decl.name, decl.ty.fmtDebug() });
@@ -557,8 +556,7 @@ pub const File = struct {
         }
     }
 
-    /// May be called before or after updateDeclExports but must be called
-    /// after allocateDeclIndexes for any given Decl.
+    /// May be called before or after updateDeclExports for any given Decl.
     pub fn updateFunc(base: *File, module: *Module, func: *Module.Fn, air: Air, liveness: Liveness) UpdateDeclError!void {
         const owner_decl = module.declPtr(func.owner_decl);
         log.debug("updateFunc {*} ({s}), type={}", .{
@@ -599,32 +597,6 @@ pub const File = struct {
             .wasm => return @fieldParentPtr(Wasm, "base", base).updateDeclLineNumber(module, decl),
             .plan9 => return @fieldParentPtr(Plan9, "base", base).updateDeclLineNumber(module, decl),
             .spirv, .nvptx => {},
-        }
-    }
-
-    /// Must be called before any call to updateDecl or updateDeclExports for
-    /// any given Decl.
-    /// TODO we're transitioning to deleting this function and instead having
-    /// each linker backend notice the first time updateDecl or updateFunc is called, or
-    /// a callee referenced from AIR.
-    pub fn allocateDeclIndexes(base: *File, decl_index: Module.Decl.Index) error{OutOfMemory}!void {
-        const decl = base.options.module.?.declPtr(decl_index);
-        log.debug("allocateDeclIndexes {*} ({s})", .{ decl, decl.name });
-        if (build_options.only_c) {
-            assert(base.tag == .c);
-            return;
-        }
-        switch (base.tag) {
-            .plan9 => return @fieldParentPtr(Plan9, "base", base).allocateDeclIndexes(decl_index),
-
-            .coff,
-            .elf,
-            .macho,
-            .c,
-            .spirv,
-            .nvptx,
-            .wasm,
-            => {},
         }
     }
 
@@ -878,8 +850,7 @@ pub const File = struct {
         AnalysisFail,
     };
 
-    /// May be called before or after updateDecl, but must be called after
-    /// allocateDeclIndexes for any given Decl.
+    /// May be called before or after updateDecl for any given Decl.
     pub fn updateDeclExports(
         base: *File,
         module: *Module,

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -1,6 +1,8 @@
 const Atom = @This();
 
 const std = @import("std");
+const assert = std.debug.assert;
+const elf = std.elf;
 
 const Dwarf = @import("../Dwarf.zig");
 const Elf = @import("../Elf.zig");
@@ -12,8 +14,10 @@ const Elf = @import("../Elf.zig");
 /// If this field is 0, it means the codegen size = 0 and there is no symbol or
 /// offset table entry.
 local_sym_index: u32,
+
 /// This field is undefined for symbols with size = 0.
 offset_table_index: u32,
+
 /// Points to the previous and next neighbors, based on the `text_offset`.
 /// This can be used to find, for example, the capacity of this `TextBlock`.
 prev: ?*Atom,
@@ -29,13 +33,49 @@ pub const empty = Atom{
     .dbg_info_atom = undefined,
 };
 
+pub fn ensureInitialized(self: *Atom, elf_file: *Elf) !void {
+    if (self.getSymbolIndex() != null) return; // Already initialized
+    self.local_sym_index = try elf_file.allocateLocalSymbol();
+    self.offset_table_index = try elf_file.allocateGotOffset();
+    try elf_file.atom_by_index_table.putNoClobber(elf_file.base.allocator, self.local_sym_index, self);
+}
+
+pub fn getSymbolIndex(self: Atom) ?u32 {
+    if (self.local_sym_index == 0) return null;
+    return self.local_sym_index;
+}
+
+pub fn getSymbol(self: Atom, elf_file: *Elf) elf.Elf64_Sym {
+    const sym_index = self.getSymbolIndex().?;
+    return elf_file.local_symbols.items[sym_index];
+}
+
+pub fn getSymbolPtr(self: Atom, elf_file: *Elf) *elf.Elf64_Sym {
+    const sym_index = self.getSymbolIndex().?;
+    return &elf_file.local_symbols.items[sym_index];
+}
+
+pub fn getName(self: Atom, elf_file: *Elf) []const u8 {
+    const sym = self.getSymbol();
+    return elf_file.getString(sym.st_name);
+}
+
+pub fn getOffsetTableAddress(self: Atom, elf_file: *Elf) u64 {
+    assert(self.getSymbolIndex() != null);
+    const target = elf_file.base.options.target;
+    const ptr_bits = target.cpu.arch.ptrBitWidth();
+    const ptr_bytes: u64 = @divExact(ptr_bits, 8);
+    const got = elf_file.program_headers.items[elf_file.phdr_got_index.?];
+    return got.p_vaddr + self.offset_table_index * ptr_bytes;
+}
+
 /// Returns how much room there is to grow in virtual address space.
 /// File offset relocation happens transparently, so it is not included in
 /// this calculation.
-pub fn capacity(self: Atom, elf_file: Elf) u64 {
-    const self_sym = elf_file.local_symbols.items[self.local_sym_index];
+pub fn capacity(self: Atom, elf_file: *Elf) u64 {
+    const self_sym = self.getSymbol(elf_file);
     if (self.next) |next| {
-        const next_sym = elf_file.local_symbols.items[next.local_sym_index];
+        const next_sym = next.getSymbol(elf_file);
         return next_sym.st_value - self_sym.st_value;
     } else {
         // We are the last block. The capacity is limited only by virtual address space.
@@ -43,11 +83,11 @@ pub fn capacity(self: Atom, elf_file: Elf) u64 {
     }
 }
 
-pub fn freeListEligible(self: Atom, elf_file: Elf) bool {
+pub fn freeListEligible(self: Atom, elf_file: *Elf) bool {
     // No need to keep a free list node for the last block.
     const next = self.next orelse return false;
-    const self_sym = elf_file.local_symbols.items[self.local_sym_index];
-    const next_sym = elf_file.local_symbols.items[next.local_sym_index];
+    const self_sym = self.getSymbol(elf_file);
+    const next_sym = next.getSymbol(elf_file);
     const cap = next_sym.st_value - self_sym.st_value;
     const ideal_cap = Elf.padToIdeal(self_sym.st_size);
     if (cap <= ideal_cap) return false;

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -1,0 +1,56 @@
+const Atom = @This();
+
+const std = @import("std");
+
+const Dwarf = @import("../Dwarf.zig");
+const Elf = @import("../Elf.zig");
+
+/// Each decl always gets a local symbol with the fully qualified name.
+/// The vaddr and size are found here directly.
+/// The file offset is found by computing the vaddr offset from the section vaddr
+/// the symbol references, and adding that to the file offset of the section.
+/// If this field is 0, it means the codegen size = 0 and there is no symbol or
+/// offset table entry.
+local_sym_index: u32,
+/// This field is undefined for symbols with size = 0.
+offset_table_index: u32,
+/// Points to the previous and next neighbors, based on the `text_offset`.
+/// This can be used to find, for example, the capacity of this `TextBlock`.
+prev: ?*Atom,
+next: ?*Atom,
+
+dbg_info_atom: Dwarf.Atom,
+
+pub const empty = Atom{
+    .local_sym_index = 0,
+    .offset_table_index = undefined,
+    .prev = null,
+    .next = null,
+    .dbg_info_atom = undefined,
+};
+
+/// Returns how much room there is to grow in virtual address space.
+/// File offset relocation happens transparently, so it is not included in
+/// this calculation.
+pub fn capacity(self: Atom, elf_file: Elf) u64 {
+    const self_sym = elf_file.local_symbols.items[self.local_sym_index];
+    if (self.next) |next| {
+        const next_sym = elf_file.local_symbols.items[next.local_sym_index];
+        return next_sym.st_value - self_sym.st_value;
+    } else {
+        // We are the last block. The capacity is limited only by virtual address space.
+        return std.math.maxInt(u32) - self_sym.st_value;
+    }
+}
+
+pub fn freeListEligible(self: Atom, elf_file: Elf) bool {
+    // No need to keep a free list node for the last block.
+    const next = self.next orelse return false;
+    const self_sym = elf_file.local_symbols.items[self.local_sym_index];
+    const next_sym = elf_file.local_symbols.items[next.local_sym_index];
+    const cap = next_sym.st_value - self_sym.st_value;
+    const ideal_cap = Elf.padToIdeal(self_sym.st_size);
+    if (cap <= ideal_cap) return false;
+    const surplus = cap - ideal_cap;
+    return surplus >= Elf.min_text_capacity;
+}

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2472,14 +2472,15 @@ pub fn updateDeclExports(
 
     const decl = module.declPtr(decl_index);
     const atom = &decl.link.macho;
-    try atom.ensureInitialized(self);
+
+    if (atom.getSymbolIndex() == null) return;
 
     const gop = try self.decls.getOrPut(gpa, decl_index);
     if (!gop.found_existing) {
-        gop.value_ptr.* = null;
+        gop.value_ptr.* = self.getDeclOutputSection(decl);
     }
 
-    const decl_sym = decl.link.macho.getSymbol(self);
+    const decl_sym = atom.getSymbol(self);
 
     for (exports) |exp| {
         const exp_name = try std.fmt.allocPrint(gpa, "_{s}", .{exp.options.name});

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1811,6 +1811,8 @@ pub fn deinit(self: *MachO) void {
 fn freeAtom(self: *MachO, atom: *Atom) void {
     log.debug("freeAtom {*}", .{atom});
 
+    const gpa = self.base.allocator;
+
     // Remove any relocs and base relocs associated with this Atom
     self.freeRelocationsForAtom(atom);
 
@@ -1850,7 +1852,7 @@ fn freeAtom(self: *MachO, atom: *Atom) void {
         if (!already_have_free_list_node and prev.freeListEligible(self)) {
             // The free list is heuristics, it doesn't have to be perfect, so we can ignore
             // the OOM here.
-            free_list.append(self.base.allocator, prev) catch {};
+            free_list.append(gpa, prev) catch {};
         }
     } else {
         atom.prev = null;
@@ -1861,6 +1863,33 @@ fn freeAtom(self: *MachO, atom: *Atom) void {
     } else {
         atom.next = null;
     }
+
+    // Appending to free lists is allowed to fail because the free lists are heuristics based anyway.
+    const sym_index = atom.getSymbolIndex().?;
+
+    self.locals_free_list.append(gpa, sym_index) catch {};
+
+    // Try freeing GOT atom if this decl had one
+    const got_target = SymbolWithLoc{ .sym_index = sym_index, .file = null };
+    if (self.got_entries_table.get(got_target)) |got_index| {
+        self.got_entries_free_list.append(gpa, @intCast(u32, got_index)) catch {};
+        self.got_entries.items[got_index] = .{
+            .target = .{ .sym_index = 0, .file = null },
+            .sym_index = 0,
+        };
+        _ = self.got_entries_table.remove(got_target);
+
+        if (self.d_sym) |*d_sym| {
+            d_sym.swapRemoveRelocs(sym_index);
+        }
+
+        log.debug("  adding GOT index {d} to free list (target local@{d})", .{ got_index, sym_index });
+    }
+
+    self.locals.items[sym_index].n_type = 0;
+    _ = self.atom_by_index_table.remove(sym_index);
+    log.debug("  adding local symbol index {d} to free list", .{sym_index});
+    atom.sym_index = 0;
 
     if (self.d_sym) |*d_sym| {
         d_sym.dwarf.freeAtom(&atom.dbg_info_atom);
@@ -1883,7 +1912,7 @@ fn growAtom(self: *MachO, atom: *Atom, new_atom_size: u64, alignment: u64) !u64 
     return self.allocateAtom(atom, new_atom_size, alignment);
 }
 
-fn allocateSymbol(self: *MachO) !u32 {
+pub fn allocateSymbol(self: *MachO) !u32 {
     try self.locals.ensureUnusedCapacity(self.base.allocator, 1);
 
     const index = blk: {
@@ -1975,16 +2004,6 @@ pub fn allocateStubEntry(self: *MachO, target: SymbolWithLoc) !u32 {
     return index;
 }
 
-pub fn allocateDeclIndexes(self: *MachO, decl_index: Module.Decl.Index) !void {
-    if (self.llvm_object) |_| return;
-    const decl = self.base.options.module.?.declPtr(decl_index);
-    if (decl.link.macho.sym_index != 0) return;
-
-    decl.link.macho.sym_index = try self.allocateSymbol();
-    try self.atom_by_index_table.putNoClobber(self.base.allocator, decl.link.macho.sym_index, &decl.link.macho);
-    try self.decls.putNoClobber(self.base.allocator, decl_index, null);
-}
-
 pub fn updateFunc(self: *MachO, module: *Module, func: *Module.Fn, air: Air, liveness: Liveness) !void {
     if (build_options.skip_non_native and builtin.object_format != .macho) {
         @panic("Attempted to compile for object format that was disabled by build configuration");
@@ -1997,8 +2016,15 @@ pub fn updateFunc(self: *MachO, module: *Module, func: *Module.Fn, air: Air, liv
 
     const decl_index = func.owner_decl;
     const decl = module.declPtr(decl_index);
-    self.freeUnnamedConsts(decl_index);
-    self.freeRelocationsForAtom(&decl.link.macho);
+    const atom = &decl.link.macho;
+    try atom.ensureInitialized(self);
+    const gop = try self.decls.getOrPut(self.base.allocator, decl_index);
+    if (gop.found_existing) {
+        self.freeUnnamedConsts(decl_index);
+        self.freeRelocationsForAtom(atom);
+    } else {
+        gop.value_ptr.* = null;
+    }
 
     var code_buffer = std.ArrayList(u8).init(self.base.allocator);
     defer code_buffer.deinit();
@@ -2136,7 +2162,14 @@ pub fn updateDecl(self: *MachO, module: *Module, decl_index: Module.Decl.Index) 
         }
     }
 
-    self.freeRelocationsForAtom(&decl.link.macho);
+    const atom = &decl.link.macho;
+    try atom.ensureInitialized(self);
+    const gop = try self.decls.getOrPut(self.base.allocator, decl_index);
+    if (gop.found_existing) {
+        self.freeRelocationsForAtom(atom);
+    } else {
+        gop.value_ptr.* = null;
+    }
 
     var code_buffer = std.ArrayList(u8).init(self.base.allocator);
     defer code_buffer.deinit();
@@ -2337,12 +2370,12 @@ fn updateDeclCode(self: *MachO, decl_index: Module.Decl.Index, code: []const u8)
     const decl = mod.declPtr(decl_index);
 
     const required_alignment = decl.getAlignment(self.base.options.target);
-    assert(decl.link.macho.sym_index != 0); // Caller forgot to call allocateDeclIndexes()
 
     const sym_name = try decl.getFullyQualifiedName(mod);
     defer self.base.allocator.free(sym_name);
 
     const atom = &decl.link.macho;
+    const sym_index = atom.getSymbolIndex().?; // Atom was not initialized
     const decl_ptr = self.decls.getPtr(decl_index).?;
     if (decl_ptr.* == null) {
         decl_ptr.* = self.getDeclOutputSection(decl);
@@ -2368,7 +2401,7 @@ fn updateDeclCode(self: *MachO, decl_index: Module.Decl.Index, code: []const u8)
             if (vaddr != sym.n_value) {
                 sym.n_value = vaddr;
                 log.debug("  (updating GOT entry)", .{});
-                const got_target = SymbolWithLoc{ .sym_index = atom.sym_index, .file = null };
+                const got_target = SymbolWithLoc{ .sym_index = sym_index, .file = null };
                 const got_atom = self.getGotAtomForSymbol(got_target).?;
                 self.markRelocsDirtyByTarget(got_target);
                 try self.writePtrWidthAtom(got_atom);
@@ -2399,10 +2432,10 @@ fn updateDeclCode(self: *MachO, decl_index: Module.Decl.Index, code: []const u8)
         atom.size = code_len;
         sym.n_value = vaddr;
 
-        const got_target = SymbolWithLoc{ .sym_index = atom.sym_index, .file = null };
+        const got_target = SymbolWithLoc{ .sym_index = sym_index, .file = null };
         const got_index = try self.allocateGotEntry(got_target);
         const got_atom = try self.createGotAtom(got_target);
-        self.got_entries.items[got_index].sym_index = got_atom.sym_index;
+        self.got_entries.items[got_index].sym_index = got_atom.getSymbolIndex().?;
         try self.writePtrWidthAtom(got_atom);
     }
 
@@ -2438,7 +2471,14 @@ pub fn updateDeclExports(
     const gpa = self.base.allocator;
 
     const decl = module.declPtr(decl_index);
-    if (decl.link.macho.sym_index == 0) return;
+    const atom = &decl.link.macho;
+    try atom.ensureInitialized(self);
+
+    const gop = try self.decls.getOrPut(gpa, decl_index);
+    if (!gop.found_existing) {
+        gop.value_ptr.* = null;
+    }
+
     const decl_sym = decl.link.macho.getSymbol(self);
 
     for (exports) |exp| {
@@ -2573,11 +2613,6 @@ fn freeUnnamedConsts(self: *MachO, decl_index: Module.Decl.Index) void {
     const unnamed_consts = self.unnamed_const_atoms.getPtr(decl_index) orelse return;
     for (unnamed_consts.items) |atom| {
         self.freeAtom(atom);
-        self.locals_free_list.append(gpa, atom.sym_index) catch {};
-        self.locals.items[atom.sym_index].n_type = 0;
-        _ = self.atom_by_index_table.remove(atom.sym_index);
-        log.debug("  adding local symbol index {d} to free list", .{atom.sym_index});
-        atom.sym_index = 0;
     }
     unnamed_consts.clearAndFree(gpa);
 }
@@ -2591,39 +2626,11 @@ pub fn freeDecl(self: *MachO, decl_index: Module.Decl.Index) void {
 
     log.debug("freeDecl {*}", .{decl});
 
-    const kv = self.decls.fetchSwapRemove(decl_index);
-    if (kv.?.value) |_| {
-        self.freeAtom(&decl.link.macho);
-        self.freeUnnamedConsts(decl_index);
-    }
-
-    // Appending to free lists is allowed to fail because the free lists are heuristics based anyway.
-    const gpa = self.base.allocator;
-    const sym_index = decl.link.macho.sym_index;
-    if (sym_index != 0) {
-        self.locals_free_list.append(gpa, sym_index) catch {};
-
-        // Try freeing GOT atom if this decl had one
-        const got_target = SymbolWithLoc{ .sym_index = sym_index, .file = null };
-        if (self.got_entries_table.get(got_target)) |got_index| {
-            self.got_entries_free_list.append(gpa, @intCast(u32, got_index)) catch {};
-            self.got_entries.items[got_index] = .{
-                .target = .{ .sym_index = 0, .file = null },
-                .sym_index = 0,
-            };
-            _ = self.got_entries_table.remove(got_target);
-
-            if (self.d_sym) |*d_sym| {
-                d_sym.swapRemoveRelocs(sym_index);
-            }
-
-            log.debug("  adding GOT index {d} to free list (target local@{d})", .{ got_index, sym_index });
+    if (self.decls.fetchSwapRemove(decl_index)) |kv| {
+        if (kv.value) |_| {
+            self.freeAtom(&decl.link.macho);
+            self.freeUnnamedConsts(decl_index);
         }
-
-        self.locals.items[sym_index].n_type = 0;
-        _ = self.atom_by_index_table.remove(sym_index);
-        log.debug("  adding local symbol index {d} to free list", .{sym_index});
-        decl.link.macho.sym_index = 0;
     }
 
     if (self.d_sym) |*d_sym| {
@@ -2636,7 +2643,9 @@ pub fn getDeclVAddr(self: *MachO, decl_index: Module.Decl.Index, reloc_info: Fil
     const decl = mod.declPtr(decl_index);
 
     assert(self.llvm_object == null);
-    assert(decl.link.macho.sym_index != 0);
+
+    try decl.link.macho.ensureInitialized(self);
+    const sym_index = decl.link.macho.getSymbolIndex().?;
 
     const atom = self.getAtomForSymbol(.{ .sym_index = reloc_info.parent_atom_index, .file = null }).?;
     try atom.addRelocation(self, .{
@@ -2645,7 +2654,7 @@ pub fn getDeclVAddr(self: *MachO, decl_index: Module.Decl.Index, reloc_info: Fil
             .x86_64 => @enumToInt(macho.reloc_type_x86_64.X86_64_RELOC_UNSIGNED),
             else => unreachable,
         },
-        .target = .{ .sym_index = decl.link.macho.sym_index, .file = null },
+        .target = .{ .sym_index = sym_index, .file = null },
         .offset = @intCast(u32, reloc_info.offset),
         .addend = reloc_info.addend,
         .pcrel = false,
@@ -3179,7 +3188,7 @@ fn collectRebaseData(self: *MachO, rebase: *Rebase) !void {
     const slice = self.sections.slice();
 
     for (self.rebases.keys()) |atom, i| {
-        log.debug("  ATOM(%{d}, '{s}')", .{ atom.sym_index, atom.getName(self) });
+        log.debug("  ATOM(%{?d}, '{s}')", .{ atom.getSymbolIndex(), atom.getName(self) });
 
         const sym = atom.getSymbol(self);
         const segment_index = slice.items(.segment_index)[sym.n_sect - 1];
@@ -3208,7 +3217,7 @@ fn collectBindData(self: *MachO, bind: anytype, raw_bindings: anytype) !void {
     const slice = self.sections.slice();
 
     for (raw_bindings.keys()) |atom, i| {
-        log.debug("  ATOM(%{d}, '{s}')", .{ atom.sym_index, atom.getName(self) });
+        log.debug("  ATOM(%{?d}, '{s}')", .{ atom.getSymbolIndex(), atom.getName(self) });
 
         const sym = atom.getSymbol(self);
         const segment_index = slice.items(.segment_index)[sym.n_sect - 1];
@@ -4277,8 +4286,8 @@ pub fn logAtoms(self: *MachO) void {
 pub fn logAtom(self: *MachO, atom: *const Atom) void {
     const sym = atom.getSymbol(self);
     const sym_name = atom.getName(self);
-    log.debug("  ATOM(%{d}, '{s}') @ {x} (sizeof({x}), alignof({x})) in object({?d}) in sect({d})", .{
-        atom.sym_index,
+    log.debug("  ATOM(%{?d}, '{s}') @ {x} (sizeof({x}), alignof({x})) in object({?d}) in sect({d})", .{
+        atom.getSymbolIndex(),
         sym_name,
         sym.n_value,
         atom.size,

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -424,7 +424,7 @@ fn updateFinish(self: *Plan9, decl: *Module.Decl) !void {
     // write the internal linker metadata
     decl.link.plan9.type = sym_t;
     // write the symbol
-    // we already have the got index because that got allocated in allocateDeclIndexes
+    // we already have the got index
     const sym: aout.Sym = .{
         .value = undefined, // the value of stuff gets filled in in flushModule
         .type = decl.link.plan9.type,
@@ -737,7 +737,7 @@ fn addDeclExports(
 
 pub fn freeDecl(self: *Plan9, decl_index: Module.Decl.Index) void {
     // TODO audit the lifetimes of decls table entries. It's possible to get
-    // allocateDeclIndexes and then freeDecl without any updateDecl in between.
+    // freeDecl without any updateDecl in between.
     // However that is planned to change, see the TODO comment in Module.zig
     // in the deleteUnusedDecl function.
     const mod = self.base.options.module.?;
@@ -959,11 +959,6 @@ pub fn writeSyms(self: *Plan9, buf: *std.ArrayList(u8)) !void {
     }
 }
 
-/// this will be removed, moved to updateFinish
-pub fn allocateDeclIndexes(self: *Plan9, decl_index: Module.Decl.Index) !void {
-    _ = self;
-    _ = decl_index;
-}
 /// Must be called only after a successful call to `updateDecl`.
 pub fn updateDeclLineNumber(self: *Plan9, mod: *Module, decl: *const Module.Decl) !void {
     _ = self;

--- a/src/link/Wasm/Atom.zig
+++ b/src/link/Wasm/Atom.zig
@@ -95,6 +95,17 @@ pub fn symbolLoc(atom: Atom) Wasm.SymbolLoc {
     return .{ .file = atom.file, .index = atom.sym_index };
 }
 
+pub fn ensureInitialized(atom: *Atom, wasm_bin: *Wasm) !void {
+    if (atom.getSymbolIndex() != null) return; // already initialized
+    atom.sym_index = try wasm_bin.allocateSymbol();
+    try wasm_bin.symbol_atom.putNoClobber(wasm_bin.base.allocator, atom.symbolLoc(), atom);
+}
+
+pub fn getSymbolIndex(atom: Atom) ?u32 {
+    if (atom.sym_index == 0) return null;
+    return atom.sym_index;
+}
+
 /// Returns the virtual address of the `Atom`. This is the address starting
 /// from the first entry within a section.
 pub fn getVA(atom: Atom, wasm: *const Wasm, symbol: *const Symbol) u32 {


### PR DESCRIPTION
TODO:
- [x] ELF backend
- [x] MachO backend
- [x] COFF backend
- [x] Wasm backend
- [x] Plan9 backend

After this is done, I will move ownership of `Atom`/`TextBlock`/`DeclBlock` from `Module` into the backends, and instead, the `Module` will be handed out an index by the respective backend. Just to be clear, I will work on this in a separate patch.