### PR TITLE
netbsd: use versioned __msync13 from libc

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -90,6 +90,8 @@ pub usingnamespace switch (builtin.os.tag) {
         pub extern "c" fn stat(noalias path: [*:0]const u8, noalias buf: *c.Stat) c_int;
 
         pub extern "c" fn alarm(seconds: c_uint) c_uint;
+
+        pub extern "c" fn msync(addr: *align(page_size) const anyopaque, len: usize, flags: c_int) c_int;
     },
 };
 
@@ -145,7 +147,6 @@ pub extern "c" fn write(fd: c.fd_t, buf: [*]const u8, nbyte: usize) isize;
 pub extern "c" fn pwrite(fd: c.fd_t, buf: [*]const u8, nbyte: usize, offset: c.off_t) isize;
 pub extern "c" fn mmap(addr: ?*align(page_size) anyopaque, len: usize, prot: c_uint, flags: c_uint, fd: c.fd_t, offset: c.off_t) *anyopaque;
 pub extern "c" fn munmap(addr: *align(page_size) const anyopaque, len: usize) c_int;
-pub extern "c" fn msync(addr: *align(page_size) const anyopaque, len: usize, flags: c_int) c_int;
 pub extern "c" fn mprotect(addr: *align(page_size) anyopaque, len: usize, prot: c_uint) c_int;
 pub extern "c" fn link(oldpath: [*:0]const u8, newpath: [*:0]const u8, flags: c_int) c_int;
 pub extern "c" fn linkat(oldfd: c.fd_t, oldpath: [*:0]const u8, newfd: c.fd_t, newpath: [*:0]const u8, flags: c_int) c_int;

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -59,6 +59,9 @@ pub const sched_yield = __libc_thr_yield;
 
 pub extern "c" fn posix_memalign(memptr: *?*anyopaque, alignment: usize, size: usize) c_int;
 
+pub extern "c" fn __msync13(addr: *align(std.mem.page_size) const anyopaque, len: usize, flags: c_int) c_int;
+pub const msync = __msync13;
+
 pub const pthread_mutex_t = extern struct {
     magic: u32 = 0x33330003,
     errorcheck: padded_pthread_spin_t = 0,


### PR DESCRIPTION
The system linker shows warning when `msync` is linked instead of `__msync13`:

  "warning: reference to compatibility msync(); include <sys/mman.h> for correct reference"

closes #14422