### PR TITLE
std.os.uefi: fix shift in pool allocator

### DIFF
--- a/lib/std/os/uefi/pool_allocator.zig
+++ b/lib/std/os/uefi/pool_allocator.zig
@@ -22,7 +22,7 @@ const UefiPoolAllocator = struct {
 
         assert(len > 0);
 
-        const ptr_align = 1 << log2_ptr_align;
+        const ptr_align = @as(usize, 1) << @as(Allocator.Log2Align, log2_ptr_align);
 
         const metadata_len = mem.alignForward(@sizeOf(usize), ptr_align);
 


### PR DESCRIPTION
Needed a fixed integer type on the LHS and the RHS to be of the right width.