### PR TITLE
std.math.big.int: Initialize limbs in addWrap

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -489,6 +489,7 @@ pub const Mutable = struct {
             if (msl < req_limbs) {
                 r.limbs[msl] = 1;
                 r.len = req_limbs;
+                mem.set(Limb, r.limbs[msl + 1 .. req_limbs], 0);
             } else {
                 carry_truncated = true;
             }


### PR DESCRIPTION
When a `big.Int.Mutable` had more than two limbs, it was possible for this function to change the `len` field without zeroing limbs in the active range. These uninitialized limbs would then be used in `truncate()` and could cause invalid results.

Thanks to @matu3ba for investigating and finding the source of the bug!

This allowed me to uncomment the disabled `popCount` tests. I added a new test specific to `bitNotWrap`, but since the simplest check is to compare against large integer types (u256+) I skipped backends that don't support them yet.

Closes #13571