### PR TITLE
parser: detect mismatched/misleading indentation

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -378,6 +378,16 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
                 }),
             }
         },
+
+        .mismatched_indentation => {
+            return stream.writeAll("statement indentation mismatched with siblings");
+        },
+        .outdented_block => {
+            return stream.writeAll("block is outdented from surrounding block");
+        },
+        .previous_indentation => {
+            return stream.writeAll("previous indentation level set here");
+        },
     }
 }
 
@@ -2747,6 +2757,10 @@ pub const Error = struct {
         expected_var_const,
         wrong_equal_var_decl,
         var_const_decl,
+
+        mismatched_indentation,
+        outdented_block,
+        previous_indentation,
 
         zig_style_container,
         previous_field,

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -2438,7 +2438,7 @@ test "zig fmt: add comma on last switch prong" {
         \\    InitArg.None,
         \\    InitArg.Enum => { }
         \\}
-        \\ switch (self.init_arg_expr) {
+        \\switch (self.init_arg_expr) {
         \\     InitArg.Type => |t| { },
         \\     InitArg.None,
         \\     InitArg.Enum => { }//line comment
@@ -6053,6 +6053,115 @@ test "ampersand" {
     , &.{});
 }
 
+test "misleading indentation" {
+    try testError(
+        \\fn f() void {
+        \\    if (x)
+        \\        gotoFail();
+        \\        gotoFail();
+        \\}
+    , &[_]Error{
+        .mismatched_indentation,
+        .previous_indentation,
+    });
+    try testError(
+        \\fn f() void {
+        \\  ok();
+        \\no = 2;
+        \\}
+    , &[_]Error{
+        .mismatched_indentation,
+        .previous_indentation,
+    });
+    try testError(
+        \\fn f() void {
+        \\  ok();
+        \\    { no = 1; }
+        \\}
+    , &[_]Error{
+        .mismatched_indentation,
+        .previous_indentation,
+    });
+    try testError(
+        \\comptime {
+        \\    ok = 1;
+        \\     no = 2;
+        \\}
+    , &[_]Error{
+        .mismatched_indentation,
+        .previous_indentation,
+    });
+    try testError(
+        \\fn f() void {
+        \\    if (x) {
+        \\   no = 1;
+        \\    }
+        \\}
+    , &[_]Error{
+        .outdented_block,
+        .previous_indentation,
+    });
+    try testError(
+        \\fn f() void {
+        \\    {    {
+        \\       _ = 1;
+        \\    }    }
+        \\}
+    , &[_]Error{
+        .outdented_block,
+        .previous_indentation,
+    });
+    // Nested in a sub-container
+    try testError(
+        \\fn f() void {
+        \\    const T = struct {
+        \\        fn g() void {
+        \\            ok = 1;
+        \\           no = 2;
+        \\        }
+        \\    };
+        \\}
+    , &[_]Error{
+        .mismatched_indentation,
+        .previous_indentation,
+    });
+}
+
+test "acceptable indentation" {
+    // Same line as { do not define indentation level
+    try testNoError(
+        \\fn f() void { _ = 1; _ = 2; }
+    );
+    try testNoError(
+        \\fn f() void { _ = 1;
+        \\  _ = 2; _ = 3;
+        \\  { _ = 4; }
+        \\}
+    );
+    try testNoError(
+        \\fn f() void {
+        \\if (x) {
+        \\_ = 1;
+        \\}
+        \\}
+    );
+    // Container level decls do not matter
+    try testNoError(
+        \\const x = true;
+        \\ const y = false;
+    );
+    // Containers have independent indentation levels
+    try testNoError(
+        \\fn f() void {
+        \\    const T = struct {
+        \\        fn g() void {
+        \\ _ = 1;
+        \\        }
+        \\    };
+        \\}
+    );
+}
+
 const std = @import("std");
 const mem = std.mem;
 const print = std.debug.print;
@@ -6125,4 +6234,10 @@ fn testError(source: [:0]const u8, expected_errors: []const Error) !void {
     for (expected_errors) |expected, i| {
         try std.testing.expectEqual(expected, tree.errors[i].tag);
     }
+}
+
+fn testNoError(source: [:0]const u8) !void {
+    var fba = std.heap.FixedBufferAllocator.init(fixed_buffer_mem[0..]);
+    var b: bool = undefined;
+    _ = try testParse(source, fba.allocator(), &b);
 }

--- a/test/cases/compile_errors/mismatched_indentation.zig
+++ b/test/cases/compile_errors/mismatched_indentation.zig
@@ -1,0 +1,14 @@
+fn f() void {
+    var x = false;
+    if (x)
+        gotoFail();
+        gotoFail();
+}
+fn gotoFail() void {}
+
+// error
+// backend=stage2
+// target=native
+//
+// :5:9: error: statement indentation mismatched with siblings
+// :2:5: note: previous indentation level set here

--- a/test/cases/compile_errors/outdented_block.zig
+++ b/test/cases/compile_errors/outdented_block.zig
@@ -1,0 +1,10 @@
+	comptime {
+_ = "outdented";
+	}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:1: error: block is outdented from surrounding block
+// :1:2: note: previous indentation level set here


### PR DESCRIPTION
Closes #35. This is a follow-up to #13593, which explains some of the design choice rationale.

I added two compile error tests, one for each of the new kinds of error. If the errors were "recoverable" it could be done in one, but I need to study parse.zig more to understand how to make parse errors recoverable. Let me know if that's desirable.

I found a [TODO in parser_test.zig](https://github.com/ziglang/zig/blob/master/lib/std/zig/parser_test.zig#L5849-L5852) (added in 79f18763679a9eac7cb1ff7bd9ede063277b266b) which suggests that a fix to #35 should allow for a particular recoverable error scenario with closing curly braces. I don't 100% understand the expectation, so please let me know what it means if it is still a relevant blocker.