### PR TITLE
translate-c: Fix types on assign expression bool

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -4519,7 +4519,10 @@ fn transCreateNodeAssign(
     defer block_scope.deinit();
 
     const tmp = try block_scope.makeMangledName(c, "tmp");
-    const rhs_node = try transExpr(c, &block_scope.base, rhs, .used);
+    var rhs_node = try transExpr(c, &block_scope.base, rhs, .used);
+    if (!exprIsBooleanType(lhs) and isBoolRes(rhs_node)) {
+        rhs_node = try Tag.bool_to_int.create(c.arena, rhs_node);
+    }
     const tmp_decl = try Tag.var_simple.create(c.arena, .{ .name = tmp, .init = rhs_node });
     try block_scope.statements.append(tmp_decl);
 

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -3900,4 +3900,20 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub const ZERO = @as(c_int, 0);
         \\pub const WORLD = @as(c_int, 0o0000123);
     });
+
+    cases.add("Assign expression from bool to int",
+        \\void foo(void) {
+        \\    int a;
+        \\    if (a = 1 > 0) {}
+        \\}
+    , &[_][]const u8{
+        \\pub export fn foo() void {
+        \\    var a: c_int = undefined;
+        \\    if ((blk: {
+        \\        const tmp = @boolToInt(@as(c_int, 1) > @as(c_int, 0));
+        \\        a = tmp;
+        \\        break :blk tmp;
+        \\    }) != 0) {}
+        \\}
+    });
 }


### PR DESCRIPTION
Fixes #14387 

Just seems like an earlier block needed copying down into the expression version:

https://github.com/ziglang/zig/blob/4c116841840bfa7f0068bef23984dd832da8a54d/src/translate_c.zig#L4504-L4507