### PR TITLE
autodoc: Implemented struct_init_empty for walkInstruction 

### DIFF
--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -2200,17 +2200,10 @@ fn walkInstruction(
                 false,
             );
 
-            _ = operand;
-
-            // WIP
-
-            printWithContext(
-                file,
-                inst_index,
-                "TODO: implement `{s}` for walkInstruction\n\n",
-                .{@tagName(tags[inst_index])},
-            );
-            return self.cteTodo(@tagName(tags[inst_index]));
+            return DocData.WalkResult{
+                .typeRef = operand.expr,
+                .expr = .{ .@"struct" = &.{} },
+            };
         },
         .struct_init_anon => {
             const pl_node = data[inst_index].pl_node;
@@ -2537,6 +2530,7 @@ fn walkInstruction(
                         const var_init_ref = @intToEnum(Ref, file.zir.extra[extra_index]);
                         const var_init = try self.walkRef(file, parent_scope, parent_src, var_init_ref, need_type);
                         value.expr = var_init.expr;
+                        value.typeRef = var_init.typeRef;
                     }
 
                     return value;


### PR DESCRIPTION
fixed variable type in the cases like
```
var x = Z{};
```