### PR TITLE
zig fmt: fix file ending in a multi line comment

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -186,6 +186,15 @@ test "zig fmt: file ends in comment" {
     );
 }
 
+test "zig fmt: file ends in multi line comment" {
+    try testTransform(
+        \\     \\foobar
+    ,
+        \\\\foobar
+        \\
+    );
+}
+
 test "zig fmt: file ends in comment after var decl" {
     try testTransform(
         \\const x = 42;

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2759,8 +2759,7 @@ fn tokenSliceForRender(tree: Ast, token_index: Ast.TokenIndex) []const u8 {
     var ret = tree.tokenSlice(token_index);
     switch (tree.tokens.items(.tag)[token_index]) {
         .multiline_string_literal_line => {
-            assert(ret[ret.len - 1] == '\n');
-            ret.len -= 1;
+            if (ret[ret.len - 1] == '\n') ret.len -= 1;
         },
         .container_doc_comment, .doc_comment => {
             ret = mem.trimRight(u8, ret, &std.ascii.whitespace);


### PR DESCRIPTION
running `zig fmt` on a file that ends with a multi line comment without a line break afterwards would previously trip an assertion or produce malformed output.