### PR TITLE
wasm: correctly handle optional slices

### DIFF
--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1706,9 +1706,11 @@ fn isByRef(ty: Type, target: std.Target) bool {
             return true;
         },
         .Optional => {
-            if (ty.optionalReprIsPayload()) return false;
+            if (ty.isPtrLikeOptional()) return false;
             var buf: Type.Payload.ElemType = undefined;
-            return ty.optionalChild(&buf).hasRuntimeBitsIgnoreComptime();
+            const pl_type = ty.optionalChild(&buf);
+            if (pl_type.zigTypeTag() == .ErrorSet) return false;
+            return pl_type.hasRuntimeBitsIgnoreComptime();
         },
         .Pointer => {
             // Slices act like struct and will be passed by reference
@@ -3869,14 +3871,17 @@ fn airIsNull(func: *CodeGen, inst: Air.Inst.Index, opcode: wasm.Opcode, op_kind:
 /// NOTE: Leaves the result on the stack
 fn isNull(func: *CodeGen, operand: WValue, optional_ty: Type, opcode: wasm.Opcode) InnerError!WValue {
     try func.emitWValue(operand);
+    var buf: Type.Payload.ElemType = undefined;
+    const payload_ty = optional_ty.optionalChild(&buf);
     if (!optional_ty.optionalReprIsPayload()) {
-        var buf: Type.Payload.ElemType = undefined;
-        const payload_ty = optional_ty.optionalChild(&buf);
         // When payload is zero-bits, we can treat operand as a value, rather than
         // a pointer to the stack value
         if (payload_ty.hasRuntimeBitsIgnoreComptime()) {
             try func.addMemArg(.i32_load8_u, .{ .offset = operand.offset(), .alignment = 1 });
         }
+    } else if (payload_ty.isSlice()) {
+        // move the ptr on top of the stack
+        _ = try func.load(operand, Type.usize, 0);
     }
 
     // Compare the null value with '0'

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3880,8 +3880,11 @@ fn isNull(func: *CodeGen, operand: WValue, optional_ty: Type, opcode: wasm.Opcod
             try func.addMemArg(.i32_load8_u, .{ .offset = operand.offset(), .alignment = 1 });
         }
     } else if (payload_ty.isSlice()) {
-        // move the ptr on top of the stack
-        _ = try func.load(operand, Type.usize, 0);
+        switch (func.arch()) {
+            .wasm32 => try func.addMemArg(.i32_load, .{ .offset = operand.offset(), .alignment = 4 }),
+            .wasm64 => try func.addMemArg(.i64_load, .{ .offset = operand.offset(), .alignment = 8 }),
+            else => unreachable,
+        }
     }
 
     // Compare the null value with '0'

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1179,7 +1179,6 @@ fn peerTypeEmptyArrayAndSlice(a: bool, slice: []const u8) []const u8 {
 test "implicitly cast from [N]T to ?[]const T" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     try expect(mem.eql(u8, castToOptionalSlice().?, "hi"));
@@ -1264,7 +1263,6 @@ test "cast from array reference to fn: runtime fn ptr" {
 test "*const [N]null u8 to ?[]const u8" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     const S = struct {
@@ -1413,7 +1411,6 @@ test "cast i8 fn call peers to i32 result" {
 test "cast compatible optional types" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     var a: ?[:0]const u8 = null;

--- a/test/behavior/optional.zig
+++ b/test/behavior/optional.zig
@@ -439,7 +439,6 @@ test "Optional slice size is optimized" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     try expect(@sizeOf(?[]u8) == @sizeOf([]u8));
@@ -479,7 +478,6 @@ test "cast slice to const slice nested in error union and optional" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const S = struct {
         fn inner() !?[]u8 {


### PR DESCRIPTION
The following code snippet would previously fail when using the native webassembly backend.
```zig
fn foo() ?[]const u8 {
    return null;
}

fn bar() ?[]const u8 {
    return foo();
}

comptime {
    _ = bar;
}
```
Running `stage4/bin/zig build-obj example.zig -target wasm32-freestanding` would produce:
```
thread 19645 panic: reached unreachable code
/home/techatrix/zig/src/arch/wasm/CodeGen.zig:282:25: 0x1b38a09 in buildOpcode (zig)
                else => unreachable,
                        ^
/home/techatrix/zig/src/arch/wasm/CodeGen.zig:2430:27: 0x1b44658 in load (zig)
        .width = abi_size * 8,
                          ^
/home/techatrix/zig/src/arch/wasm/CodeGen.zig:2381:47: 0x1a202a0 in airLoad (zig)
            const stack_loaded = try func.load(operand, ty, 0);
...
```

If I'm not mistaken the issue was that `?[]const u8` should be passed as a reference just like `[]const u8`. I've also updated the null check to account for optional slices.
@Luukdegram seeing as you are the main contributor to this backend: did i do this correctly?
