### PR TITLE
std.os.uefi: fix shift in pool allocator (again)

### DIFF
--- a/lib/std/os/uefi/pool_allocator.zig
+++ b/lib/std/os/uefi/pool_allocator.zig
@@ -22,7 +22,7 @@ const UefiPoolAllocator = struct {
 
         assert(len > 0);
 
-        const ptr_align = @as(usize, 1) << @truncate(Allocator.Log2Align, log2_ptr_align);
+        const ptr_align = @as(usize, 1) << @intCast(Allocator.Log2Align, log2_ptr_align);
 
         const metadata_len = mem.alignForward(@sizeOf(usize), ptr_align);
 

--- a/lib/std/os/uefi/pool_allocator.zig
+++ b/lib/std/os/uefi/pool_allocator.zig
@@ -22,7 +22,7 @@ const UefiPoolAllocator = struct {
 
         assert(len > 0);
 
-        const ptr_align = @as(usize, 1) << @as(Allocator.Log2Align, log2_ptr_align);
+        const ptr_align = @as(usize, 1) << @truncate(Allocator.Log2Align, log2_ptr_align);
 
         const metadata_len = mem.alignForward(@sizeOf(usize), ptr_align);
 


### PR DESCRIPTION
god why do we need 2 damn pull requests just to get uefi pool allocator properly working on the new allocator update on 0.11.0