### PR TITLE
mingw: stop using K&R-style function definitions

### DIFF
--- a/lib/libc/mingw/misc/strtoimax.c
+++ b/lib/libc/mingw/misc/strtoimax.c
@@ -31,10 +31,7 @@
 #define valid(n, b)	((n) >= 0 && (n) < (b))
 
 intmax_t
-strtoimax(nptr, endptr, base)
-	register const char * __restrict__	nptr;
-	char ** __restrict__			endptr;
-	register int				base;
+strtoimax(const char * __restrict__ nptr, char ** __restrict__ endptr, int base)
 	{
 	register uintmax_t	accum;	/* accumulates converted value */
 	register int		n;	/* numeral from digit character */

--- a/lib/libc/mingw/misc/strtoumax.c
+++ b/lib/libc/mingw/misc/strtoumax.c
@@ -31,10 +31,7 @@
 #define valid(n, b)	((n) >= 0 && (n) < (b))
 
 uintmax_t
-strtoumax(nptr, endptr, base)
-	register const char * __restrict__	nptr;
-	char ** __restrict__			endptr;
-	register int				base;
+strtoumax(const char * __restrict__ nptr, char ** __restrict__ endptr, int base)
 	{
 	register uintmax_t	accum;	/* accumulates converted value */
 	register uintmax_t	next;	/* for computing next value of accum */

--- a/lib/libc/mingw/misc/wcstoimax.c
+++ b/lib/libc/mingw/misc/wcstoimax.c
@@ -33,10 +33,7 @@
 #define valid(n, b)	((n) >= 0 && (n) < (b))
 
 intmax_t
-wcstoimax(nptr, endptr, base)
-	register const wchar_t * __restrict__	nptr;
-	wchar_t ** __restrict__				endptr;
-	register int					base;
+wcstoimax(const wchar_t * __restrict__ nptr, wchar_t ** __restrict__ endptr, int base)
 	{
 	register uintmax_t	accum;	/* accumulates converted value */
 	register int		n;	/* numeral from digit character */

--- a/lib/libc/mingw/misc/wcstoumax.c
+++ b/lib/libc/mingw/misc/wcstoumax.c
@@ -33,10 +33,7 @@
 #define valid(n, b)	((n) >= 0 && (n) < (b))
 
 uintmax_t
-wcstoumax(nptr, endptr, base)
-	register const wchar_t * __restrict__	nptr;
-	wchar_t ** __restrict__				endptr;
-	register int					base;
+wcstoumax(const wchar_t * __restrict__ nptr, wchar_t ** __restrict__ endptr, int base)
 	{
 	register uintmax_t	accum;	/* accumulates converted value */
 	register uintmax_t	next;	/* for computing next value of accum */


### PR DESCRIPTION
this patch is from upstream, to fix `-Wdeprecated-non-prototypes` issues.

K&R-style has apparently been deprecated since even C89, and C2x will be repurposing the syntax space. this warning triggers when the change would affect the meaning of the code.

Closes #13384.