### PR TITLE
two package hash breaking enhancements

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -179,7 +179,7 @@ pub const File = struct {
         lock_nonblocking: bool = false,
 
         /// For POSIX systems this is the file system mode the file will
-        /// be created with.
+        /// be created with. On other systems this is always 0.
         mode: Mode = default_mode,
 
         /// Setting this to `.blocking` prevents `O.NONBLOCK` from being passed even
@@ -307,6 +307,7 @@ pub const File = struct {
         /// is unique to each filesystem.
         inode: INode,
         size: u64,
+        /// This is available on POSIX systems and is always 0 otherwise.
         mode: Mode,
         kind: Kind,
 

--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -1,6 +1,18 @@
 pub const Options = struct {
     /// Number of directory levels to skip when extracting files.
     strip_components: u32 = 0,
+    /// How to handle the "mode" property of files from within the tar file.
+    mode_mode: ModeMode = .executable_bit_only,
+
+    const ModeMode = enum {
+        /// The mode from the tar file is completely ignored. Files are created
+        /// with the default mode when creating files.
+        ignore,
+        /// The mode from the tar file is inspected for the owner executable bit
+        /// only. This bit is copied to the group and other executable bits.
+        /// Other bits of the mode are left as the default when creating files.
+        executable_bit_only,
+    };
 };
 
 pub const Header = struct {
@@ -72,6 +84,17 @@ pub const Header = struct {
 };
 
 pub fn pipeToFileSystem(dir: std.fs.Dir, reader: anytype, options: Options) !void {
+    switch (options.mode_mode) {
+        .ignore => {},
+        .executable_bit_only => {
+            // This code does not look at the mode bits yet. To implement this feature,
+            // the implementation must be adjusted to look at the mode, and check the
+            // user executable bit, then call fchmod on newly created files when
+            // the executable bit is supposed to be set.
+            // It also needs to properly deal with ACLs on Windows.
+            @panic("TODO: unimplemented: tar ModeMode.executable_bit_only");
+        },
+    }
     var file_name_buffer: [255]u8 = undefined;
     var buffer: [512 * 8]u8 = undefined;
     var start: usize = 0;


### PR DESCRIPTION
This enhances Zig to use [multihash](https://multiformats.io/multihash/) for the hash field in package manifests, closing #14284.

Additionally, it adds the executable bit and file paths to package hashes, closing #14308.

Unfortunately, due to the Windows equivalent of executable permissions being a bit tricky, there is follow-up work to be done.

What is done in this commit is the hash modifications. At the fetch layer, executable bits inside packages are ignored. In the hash
computation layer, executable bit is implemented for POSIX but not yet for Windows. This means that the hash will not break again in the future for packages that do not have any executable files, but it will break for packages that do.

Or, perhaps, I could make the decision that zig packages will unconditionally erase the executable bit from all files in a package. This would potentially be useful for packages that want to be distributed via mechanisms that do not contain this metadata. It would also be simpler to implement, since it is already implemented, and there is nothing further to be done.

[what the new hash field looks like](https://github.com/andrewrk/libgroove/commit/c6ca2772af19599f729b6334ee751a6627d3a299)