### PR TITLE
compiler_rt: make README visually nice and improve explanations

### DIFF
--- a/lib/compiler_rt/README.md
+++ b/lib/compiler_rt/README.md
@@ -27,482 +27,545 @@ then statically linked and therefore is a transparent dependency for the
 programmer.
 For details see `../compiler_rt.zig`.
 
-The routines in this folder are listed below.
-Routines are annotated as `type source routine // description`, with `routine`
-being the name used in aforementioned `compiler_rt.zig`.
-`dev` means deviating from compiler_rt, `port` ported, `source` is the
-information source for the implementation, `none` means unimplemented.
-Some examples for the naming convention are:
-- dev source name_routine, name_routine2 various implementations for performance, simplicity etc
-- port llvm compiler-rt library routines from [LLVM](http://compiler-rt.llvm.org/)
-   * LLVM emits library calls to compiler-rt, if the hardware lacks functionality
-- port musl libc routines from [musl](https://musl.libc.org/)
-If the library or information source is uncommon, use the entry `other` for `source`.
-Please do not break the search by inserting entries in another format than `impl space source`.
-
 Bugs should be solved by trying to duplicate the bug upstream, if possible.
  * If the bug exists upstream, get it fixed upstream and port the fix downstream to Zig.
  * If the bug only exists in Zig, use the corresponding C code and debug
    both implementations side by side to figure out what is wrong.
 
-## Integer library routines
+Routines with status are given below. Sources were besides
+"The Art of Computer Programming" by Donald E. Knuth, "HackersDelight" by Henry S. Warren,
+"Bit Twiddling Hacks" collected by Sean Eron Anderson, "Berkeley SoftFloat" by John R. Hauser,
+LLVM "compiler-rt" as it was MIT-licensed, "musl libc" and thoughts + work of contributors.
 
-#### Integer Bit operations
+The compiler-rt routines have not yet been audited.
+See https://github.com/ziglang/zig/issues/1504.
 
-- dev HackersDelight __clzsi2        // count leading zeros
-- dev HackersDelight __clzdi2        // count leading zeros
-- dev HackersDelight __clzti2        // count leading zeros
-- dev HackersDelight __ctzsi2        // count trailing zeros
-- dev HackersDelight __ctzdi2        // count trailing zeros
-- dev HackersDelight __ctzti2        // count trailing zeros
-- dev __ctzsi2 __ffssi2              // find least significant 1 bit
-- dev __ctzsi2 __ffsdi2              // find least significant 1 bit
-- dev __ctzsi2 __ffsti2              // find least significant 1 bit
-- dev BitTwiddlingHacks __paritysi2  // bit parity
-- dev BitTwiddlingHacks __paritydi2  // bit parity
-- dev BitTwiddlingHacks __parityti2  // bit parity
-- dev TAOCP __popcountsi2            // bit population
-- dev TAOCP __popcountdi2            // bit population
-- dev TAOCP __popcountti2            // bit population
-- dev other __bswapsi2               // a byteswapped
-- dev other __bswapdi2               // a byteswapped
-- dev other __bswapti2               // a byteswapped
+From left to right the columns mean 1. if the routine is implemented (✗ or ✓),
+2. the name, 3. input (`a`), 4. input (`b`), 5. return value,
+6. an explanation of the functionality, .. to repeat the comment from the
+column a row above and/or additional return values.
+Some routines have more extensive comments supplemented with a reference text.
 
-#### Integer Comparison
+Integer and Float Operations
 
-- port llvm __cmpsi2        // a,b: i32, (a<b)-> 0, (a==b) -> 1, (a>b) -> 2
-- port llvm __cmpdi2        // a,b: i64
-- port llvm __cmpti2        // a,b: i128
-- port llvm __ucmpsi2       // a,b: u32, (a<b)-> 0, (a==b) -> 1, (a>b) -> 2
-- port llvm __ucmpdi2       // a,b: u64
-- port llvm __ucmpti2       // a,b: u128
+| Done   | Name          | a    | b    | Out  | Comment                        |
+| ------ | ------------- | ---- | ---- | ---- | ------------------------------ |
+|   |                    |      |      |      | **Integer Bit Operations**     |
+| ✓ | __clzsi2           | u32  | ∅    | i32  | count leading zeroes           |
+| ✓ | __clzdi2           | u64  | ∅    | i32  | count leading zeroes           |
+| ✓ | __clzti2           | u128 | ∅    | i32  | count trailing zeros           |
+| ✓ | __ctzsi2           | u32  | ∅    | i32  | count trailing zeros           |
+| ✓ | __ctzdi2           | u64  | ∅    | i32  | count trailing zeros           |
+| ✓ | __ctzti2           | u128 | ∅    | i32  | count leading zeroes           |
+| ✓ | __ffssi2           | u32  | ∅    | i32  | count leading zeroes           |
+| ✓ | __ffsdi2           | u64  | ∅    | i32  | count leading zeroes           |
+| ✓ | __ffsti2           | u128 | ∅    | i32  | count leading zeroes           |
+| ✓ | __paritysi2        | u32  | ∅    | i32  | find least significant 1 bit   |
+| ✓ | __paritydi2        | u64  | ∅    | i32  | find least significant 1 bit   |
+| ✓ | __parityti2        | u128 | ∅    | i32  | find least significant 1 bit   |
+| ✓ | __popcountsi2      | u32  | ∅    | i32  | bit population                 |
+| ✓ | __popcountdi2      | u64  | ∅    | i32  | bit population                 |
+| ✓ | __popcountti2      | u128 | ∅    | i32  | bit population                 |
+| ✓ | __bswapsi2         | u32  | ∅    | i32  | bit parity                     |
+| ✓ | __bswapdi2         | u64  | ∅    | i32  | bit parity                     |
+| ✓ | __bswapti2         | u128 | ∅    | i32  | bit parity                     |
+|   |                    |      |      |      | **Integer Comparison**         |
+| ✓ | __cmpsi2           | i32  | i32  | i32  | `(a<b) -> 0, (a==b) -> 1, (a>b) -> 2` |
+| ✓ | __cmpdi2           | i64  | i64  | i32  | ..                             |
+| ✓ | __cmpti2           | i128 | i128 | i32  | ..                             |
+| ✓ | __ucmpsi2          | i32  | i32  | i32  | `(a<b) -> 0, (a==b) -> 1, (a>b) -> 2` |
+| ✓ | __ucmpdi2          | i64  | i64  | i32  | ..                             |
+| ✓ | __ucmpti2          | i128 | i128 | i32  | ..                             |
+|   |                    |      |      |      | **Integer Arithmetic**         |
+| ✗ | __ashlsi3          | i32  | i32  | i32  | `a << b` [^unused_rl78]        |
+| ✓ | __ashldi3          | i64  | i32  | i64  | ..                             |
+| ✓ | __ashlti3          | i128 | i32  | i128 | ..                             |
+| ✓ | __aeabi_llsl       | i32  | i32  | i32  | .. ARM                         |
+| ✗ | __ashrsi3          | i32  | i32  | i32  | `a >> b` arithmetic (sign fill) [^unused_rl78] |
+| ✓ | __ashrdi3          | i64  | i32  | i64  | ..                             |
+| ✓ | __ashrti3          | i128 | i32  | i128 | ..                             |
+| ✓ | __aeabi_lasr       | i64  | i32  | i64  | .. ARM                         |
+| ✗ | __lshrsi3          | i32  | i32  | i32  | `a >> b` logical (zero fill) [^unused_rl78] |
+| ✓ | __lshrdi3          | i64  | i32  | i64  | ..                             |
+| ✓ | __lshrti3          | i128 | i32  | i128 | ..                             |
+| ✓ | __aeabi_llsr       | i64  | i32  | i64  | .. ARM                         |
+| ✓ | __negsi2           | i32  | i32  | i32  | `-a` [^libgcc_compat]          |
+| ✓ | __negdi2           | i64  | i64  | i64  | ..                             |
+| ✓ | __negti2           | i128 | i128 | i128 | ..                             |
+| ✓ | __mulsi3           | i32  | i32  | i32  | `a * b`                        |
+| ✓ | __muldi3           | i64  | i64  | i64  | ..                             |
+| ✓ | __multi3           | i128 | i128 | i128 | ..                             |
+| ✓ | __divsi3           | i32  | i32  | i32  | `a / b`                        |
+| ✓ | __divdi3           | i64  | i64  | i64  | ..                             |
+| ✓ | __divti3           | i128 | i128 | i128 | ..                             |
+| ✓ | __aeabi_idiv       | i32  | i32  | i32  | .. ARM                         |
+| ✓ | __udivsi3          | u32  | u32  | u32  | `a / b`                        |
+| ✓ | __udivdi3          | u64  | u64  | u64  | ..                             |
+| ✓ | __udivti3          | u128 | u128 | u128 | ..                             |
+| ✓ | __aeabi_uidiv      | i32  | i32  | i32  | .. ARM                         |
+| ✓ | __modsi3           | i32  | i32  | i32  | `a % b`                        |
+| ✓ | __moddi3           | i64  | i64  | i64  | ..                             |
+| ✓ | __modti3           | i128 | i128 | i128 | ..                             |
+| ✓ | __umodsi3          | u32  | u32  | u32  | `a % b`                        |
+| ✓ | __umoddi3          | u64  | u64  | u64  | ..                             |
+| ✓ | __umodti3          | u128 | u128 | u128 | ..                             |
+| ✓ | __udivmodsi4       | u32  | u32  | u32  | `a / b, rem.* = a % b`         |
+| ✓ | __udivmoddi4       | u64  | u64  | u64  | ..                             |
+| ✓ | __udivmodti4       | u128 | u128 | u128 | ..                             |
+| ✓ | __divmodsi4        | i32  | i32  | i32  | `a / b, rem.* = a % b`         |
+| ✓ | __divmoddi4        | i64  | i64  | i64  | ..                             |
+| ✗ | __divmodti4        | i128 | i128 | i128 | .. [^libgcc_compat]            |
+|   |                    |      |      |      | **Integer Arithmetic with Trapping Overflow**|
+| ✓ | __absvsi2          | i32  | i32  | i32  | abs(a)                         |
+| ✓ | __absvdi2          | i64  | i64  | i64  | ..                             |
+| ✓ | __absvti2          | i128 | i128 | i128 | ..                             |
+| ✓ | __negvsi2          | i32  | i32  | i32  | `-a` [^libgcc_compat]          |
+| ✓ | __negvdi2          | i64  | i64  | i64  | ..                             |
+| ✓ | __negvti2          | i128 | i128 | i128 | ..                             |
+| ✗ | __addvsi3          | i32  | i32  | i32  | `a + b`                        |
+| ✗ | __addvdi3          | i64  | i64  | i64  | ..                             |
+| ✗ | __addvti3          | i128 | i128 | i128 | ..                             |
+| ✗ | __subvsi3          | i32  | i32  | i32  | `a - b`                        |
+| ✗ | __subvdi3          | i64  | i64  | i64  | ..                             |
+| ✗ | __subvti3          | i128 | i128 | i128 | ..                             |
+| ✗ | __mulvsi3          | i32  | i32  | i32  | `a * b`                        |
+| ✗ | __mulvdi3          | i64  | i64  | i64  | ..                             |
+| ✗ | __mulvti3          | i128 | i128 | i128 | ..                             |
+|   |                    |      |      |      | **Integer Arithmetic which Return on Overflow** [^noptr_faster] |
+| ✓ | __addosi4          | i32  | i32  | i32  | `a + b`, overflow->ov.*=1 else 0 [^perf_addition] |
+| ✓ | __addodi4          | i64  | i64  | i64  | ..                             |
+| ✓ | __addoti4          | i128 | i128 | i128 | ..                             |
+| ✓ | __subosi4          | i32  | i32  | i32  | `a - b`, overflow->ov.*=1 else 0 [^perf_addition] |
+| ✓ | __subodi4          | i64  | i64  | i64  | ..                             |
+| ✓ | __suboti4          | i128 | i128 | i128 | ..                             |
+| ✓ | __mulosi4          | i32  | i32  | i32  | `a * b`, overflow->ov.*=1 else 0 |
+| ✓ | __mulodi4          | i64  | i64  | i64  | ..                             |
+| ✓ | __muloti4          | i128 | i128 | i128 | ..                             |
+|   |                    |      |      |      | **Float Conversion**           |
+| ✓ | __extendsfdf2      | f32  | ∅    | f64  | ..                             |
+| ✓ | __extendsftf2      | f32  | ∅    | f128 | ..                             |
+| ✓ | __extendsfxf2      | f32  | ∅    | f80  | ..                             |
+| ✓ | __extenddftf2      | f64  | ∅    | f128 | ..                             |
+| ✓ | __extenddfxf2      | f64  | ∅    | f80  | ..                             |
+| ✓ | __truncsfhf2       | f32  | ∅    | f16  | rounding towards zero          |
+| ✓ | __truncdfhf2       | f64  | ∅    | f16  | ..                             |
+| ✓ | __truncdfsf2       | f64  | ∅    | f32  | ..                             |
+| ✓ | __trunctfhf2       | f128 | ∅    | f16  | ..                             |
+| ✓ | __trunctfsf2       | f128 | ∅    | f32  | ..                             |
+| ✓ | __trunctfdf2       | f128 | ∅    | f64  | ..                             |
+| ✓ | __trunctfxf2       | f128 | ∅    | f80  | ..                             |
+| ✓ | __truncxfhf2       | f80  | ∅    | f16  | ..                             |
+| ✓ | __truncxfsf2       | f80  | ∅    | f32  | ..                             |
+| ✓ | __truncxfdf2       | f80  | ∅    | f64  | ..                             |
+| ✓ | __aeabi_f2h        | f32  | ∅    | f16  | .. ARM                         |
+| ✓ | __gnu_f2h_ieee     | f32  | ∅    | f16  | ..GNU naming convention        |
+| ✓ | __aeabi_d2h        | f64  | ∅    | f16  | .. ARM                         |
+| ✓ | __aeabi_d2f        | f64  | ∅    | f32  | .. ARM                         |
+| ✓ | __trunckfsf2       | f128 | ∅    | f32  | .. PPC                         |
+| ✓ | _Qp_qtos           |*f128 | ∅    | f32  | .. SPARC                       |
+| ✓ | __trunckfdf2       | f128 | ∅    | f64  | .. PPC                         |
+| ✓ | _Qp_qtod           |*f128 | ∅    | f64  | .. SPARC                       |
+| ✓ | __fixhfsi          | f16  | ∅    | i32  | rounding towards zero          |
+| ✓ | __fixsfsi          | f32  | ∅    | i32  | ..                             |
+| ✓ | __fixdfsi          | f64  | ∅    | i32  | ..                             |
+| ✓ | __fixtfsi          | f128 | ∅    | i32  | ..                             |
+| ✓ | __fixxfsi          | f80  | ∅    | i32  | ..                             |
+| ✓ | __fixhfdi          | f16  | ∅    | i64  | ..                             |
+| ✓ | __fixsfdi          | f32  | ∅    | i64  | ..                             |
+| ✓ | __fixdfdi          | f64  | ∅    | i64  | ..                             |
+| ✓ | __fixtfdi          | f128 | ∅    | i64  | ..                             |
+| ✓ | __fixxfdi          | f80  | ∅    | i64  | ..                             |
+| ✓ | __fixhfti          | f16  | ∅    | i128 | ..                             |
+| ✓ | __fixsfti          | f32  | ∅    | i128 | ..                             |
+| ✓ | __fixdfti          | f64  | ∅    | i128 | ..                             |
+| ✓ | __fixtfti          | f128 | ∅    | i128 | ..                             |
+| ✓ | __fixxfti          | f80  | ∅    | i128 | ..                             |
+| ✓ | __fixunshfsi       | f16  | ∅    | u32  | rounding towards zero. negative values become 0. |
+| ✓ | __fixunssfsi       | f32  | ∅    | u32  | ..                             |
+| ✓ | __fixunsdfsi       | f64  | ∅    | u32  | ..                             |
+| ✓ | __fixunstfsi       | f128 | ∅    | u32  | ..                             |
+| ✓ | __fixunsxfsi       | f80  | ∅    | u32  | ..                             |
+| ✓ | __fixunshfdi       | f16  | ∅    | u64  | ..                             |
+| ✓ | __fixunssfdi       | f32  | ∅    | u64  | ..                             |
+| ✓ | __fixunsdfdi       | f64  | ∅    | u64  | ..                             |
+| ✓ | __fixunstfdi       | f128 | ∅    | u64  | ..                             |
+| ✓ | __fixunsxfdi       | f80  | ∅    | u64  | ..                             |
+| ✓ | __fixunshfti       | f16  | ∅    | u128 | ..                             |
+| ✓ | __fixunssfti       | f32  | ∅    | u128 | ..                             |
+| ✓ | __fixunsdfti       | f64  | ∅    | u128 | ..                             |
+| ✓ | __fixunstfti       | f128 | ∅    | u128 | ..                             |
+| ✓ | __fixunsxfti       | f80  | ∅    | u128 | ..                             |
+| ✓ | __floatsihf        | i32  | ∅    | f16  | int_to_float conversions       |
+| ✓ | __floatsisf        | i32  | ∅    | f32  | ..                             |
+| ✓ | __floatsidf        | i32  | ∅    | f64  | ..                             |
+| ✓ | __floatsitf        | i32  | ∅    | f128 | ..                             |
+| ✓ | __floatsixf        | i32  | ∅    | f80  | ..                             |
+| ✓ | __floatdisf        | i64  | ∅    | f32  | ..                             |
+| ✓ | __floatdidf        | i64  | ∅    | f64  | ..                             |
+| ✓ | __floatditf        | i64  | ∅    | f128 | ..                             |
+| ✓ | __floatdixf        | i64  | ∅    | f80  | ..                             |
+| ✓ | __floattihf        | i128 | ∅    | f16  | ..                             |
+| ✓ | __floattisf        | i128 | ∅    | f32  | ..                             |
+| ✓ | __floattidf        | i128 | ∅    | f64  | ..                             |
+| ✓ | __floattitf        | i128 | ∅    | f128 | ..                             |
+| ✓ | __floattixf        | i128 | ∅    | f80  | ..                             |
+| ✓ | __floatunsihf      | u32  | ∅    | f16  | uint_to_float conversions      |
+| ✓ | __floatunsisf      | u32  | ∅    | f32  | ..                             |
+| ✓ | __floatunsidf      | u32  | ∅    | f64  | ..                             |
+| ✓ | __floatunsitf      | u32  | ∅    | f128 | ..                             |
+| ✓ | __floatunsixf      | u32  | ∅    | f80  | ..                             |
+| ✓ | __floatundihf      | u64  | ∅    | f16  | ..                             |
+| ✓ | __floatundisf      | u64  | ∅    | f32  | ..                             |
+| ✓ | __floatundidf      | u64  | ∅    | f64  | ..                             |
+| ✓ | __floatunditf      | u64  | ∅    | f128 | ..                             |
+| ✓ | __floatundixf      | u64  | ∅    | f80  | ..                             |
+| ✓ | __floatuntihf      | u128 | ∅    | f16  | ..                             |
+| ✓ | __floatuntisf      | u128 | ∅    | f32  | ..                             |
+| ✓ | __floatuntidf      | u128 | ∅    | f64  | ..                             |
+| ✓ | __floatuntitf      | u128 | ∅    | f128 | ..                             |
+| ✓ | __floatuntixf      | u128 | ∅    | f80  | ..                             |
+|   |                    |      |      |      | **Float Comparison**           |
+| ✓ | __cmphf2           | f16  | f16  | i32  | `(a<b)->-1, (a==b)->0, (a>b)->1, Nan->1` |
+| ✓ | __cmpsf2           | f32  | f32  | i32  | exported from __lesf2, __ledf2, __letf2 (below) |
+| ✓ | __cmpdf2           | f64  | f64  | i32  | But: if NaN is a possibility, use another routine. |
+| ✓ | __cmptf2           | f128 | f128 | i32  | ..                             |
+| ✓ | __cmpxf2           | f80  | f80  | i32  | ..                             |
+| ✓ | _Qp_cmp            |*f128 |*f128 | i32  | .. SPARC                       |
+| ✓ | __unordhf2         | f16  | f16  | i32  | `(a==+-NaN or b==+-NaN) -> !=0, else -> 0` |
+| ✓ | __unordsf2         | f32  | f32  | i32  | ..                             |
+| ✓ | __unorddf2         | f64  | f64  | i32  | Note: only reliable for (input!=NaN) |
+| ✓ | __unordtf2         | f128 | f128 | i32  | ..                             |
+| ✓ | __unordxf2         | f80  | f80  | i32  | ..                             |
+| ✓ | __aeabi_fcmpun     | f32  | f32  | i32  | .. ARM                         |
+| ✓ | __aeabi_dcmpun     | f32  | f32  | i32  | .. ARM                         |
+| ✓ | __unordkf2         | f128 | f128 | i32  | .. PPC                         |
+| ✓ | __eqhf2            | f16  | f16  | i32  | `(a!=NaN) and (b!=Nan) and (a==b) -> output=0` |
+| ✓ | __eqsf2            | f32  | f32  | i32  | ..                                             |
+| ✓ | __eqdf2            | f64  | f64  | i32  | ..                             |
+| ✓ | __eqtf2            | f128 | f128 | i32  | ..                             |
+| ✓ | __eqxf2            | f80  | f80  | i32  | ..                             |
+| ✓ | __aeabi_fcmpeq     | f32  | f32  | i32  | .. ARM                         |
+| ✓ | __aeabi_dcmpeq     | f32  | f32  | i32  | .. ARM                         |
+| ✓ | __eqkf2            | f128 | f128 | i32  | .. PPC                         |
+| ✓ | _Qp_feq            |*f128 |*f128 | bool | .. SPARC                       |
+| ✓ | __nehf2            | f16  | f16  | i32  | `(a==NaN) or (b==Nan) or (a!=b) -> output!=0` |
+| ✓ | __nesf2            | f32  | f32  | i32  | Note: __eqXf2 and __neXf2 have same return value |
+| ✓ | __nedf2            | f64  | f64  | i32  | ..                             |
+| ✓ | __netf2            | f128 | f128 | i32  | ..                             |
+| ✓ | __nexf2            | f80  | f80  | i32  | ..                             |
+| ✓ | __nekf2            | f128 | f128 | i32  | .. PPC                         |
+| ✓ | _Qp_fne            |*f128 |*f128 | bool | .. SPARC                       |
+| ✓ | __gehf2            | f16  | f16  | i32  | `(a!=Nan) and (b!=Nan) and (a>=b) -> output>=0` |
+| ✓ | __gesf2            | f32  | f32  | i32  | ..                             |
+| ✓ | __gedf2            | f64  | f64  | i32  | ..                             |
+| ✓ | __getf2            | f128 | f128 | i32  | ..                             |
+| ✓ | __gexf2            | f80  | f80  | i32  | ..                             |
+| ✓ | __gekf2            | f128 | f128 | i32  | .. PPC                         |
+| ✓ | _Qp_fge            |*f128 |*f128 | bool | .. SPARC                       |
+| ✓ | __lthf2            | f16  | f16  | i32  | `(a!=Nan) and (b!=Nan) and (a<b) -> output<0` |
+| ✓ | __ltsf2            | f32  | f32  | i32  | ..                             |
+| ✓ | __ltdf2            | f64  | f64  | i32  | ..                             |
+| ✓ | __lttf2            | f128 | f128 | i32  | ..                             |
+| ✓ | __ltxf2            | f80  | f80  | i32  | ..                             |
+| ✓ | __ltkf2            | f128 | f128 | i32  | .. PPC                         |
+| ✓ | __aeabi_fcmplt     | f32  | f32  | i32  | .. ARM                         |
+| ✓ | __aeabi_dcmplt     | f32  | f32  | i32  | .. ARM                         |
+| ✓ | _Qp_flt            |*f128 |*f128 | bool | .. SPARC                       |
+| ✓ | __lehf2            | f16  | f16  | i32  | `(a!=Nan) and (b!=Nan) and (a<=b) -> output<=0` |
+| ✓ | __lesf2            | f32  | f32  | i32  | ..                             |
+| ✓ | __ledf2            | f64  | f64  | i32  | ..                             |
+| ✓ | __letf2            | f128 | f128 | i32  | ..                             |
+| ✓ | __lexf2            | f80  | f80  | i32  | ..                             |
+| ✓ | __aeabi_fcmple     | f32  | f32  | i32  | .. ARM                         |
+| ✓ | __aeabi_dcmple     | f32  | f32  | i32  | .. ARM                         |
+| ✓ | __lekf2            | f128 | f128 | i32  | .. PPC                         |
+| ✓ | _Qp_fle            |*f128 |*f128 | bool | .. SPARC                       |
+| ✓ | __gthf2            | f16  | f16  | i32  | `(a!=Nan) and (b!=Nan) and (a>b) -> output>0` |
+| ✓ | __gtsf2            | f32  | f32  | i32  | ..                             |
+| ✓ | __gtdf2            | f64  | f64  | i32  | ..                             |
+| ✓ | __gttf2            | f128 | f128 | i32  | ..                             |
+| ✓ | __gtxf2            | f80  | f80  | i32  | ..                             |
+| ✓ | __gtkf2            | f128 | f128 | i32  | .. PPC                         |
+| ✓ | _Qp_fgt            |*f128 |*f128 | bool | .. SPARC                       |
+|   |                    |      |      |      | **Float Arithmetic**           |
+| ✓ | __addhf3           | f32  | f32  | f32  | `a + b`                        |
+| ✓ | __addsf3           | f32  | f32  | f32  | ..                             |
+| ✓ | __adddf3           | f64  | f64  | f64  | ..                             |
+| ✓ | __addtf3           | f128 | f128 | f128 | ..                             |
+| ✓ | __addxf3           | f80  | f80  | f80  | ..                             |
+| ✓ | __aeabi_fadd       | f32  | f32  | f32  | .. ARM                         |
+| ✓ | __aeabi_dadd       | f64  | f64  | f64  | .. ARM                         |
+| ✓ | __addkf3           | f128 | f128 | f128 | .. PPC                         |
+| ✓ | _Qp_add            |*f128 |*f128 | void | .. SPARC args *c,*a,*b c=a+b   |
+| ✓ | __subhf3           | f32  | f32  | f32  | `a - b`                        |
+| ✓ | __subsf3           | f32  | f32  | f32  | ..                             |
+| ✓ | __subdf3           | f64  | f64  | f64  | ..                             |
+| ✓ | __subtf3           | f128 | f128 | f128 | ..                             |
+| ✓ | __subxf3           | f80  | f80  | f80  | ..                             |
+| ✓ | __aeabi_fsub       | f32  | f32  | f32  | .. ARM                         |
+| ✓ | __aeabi_dsub       | f64  | f64  | f64  | .. ARM                         |
+| ✓ | __subkf3           | f128 | f128 | f128 | .. PPC                         |
+| ✓ | _Qp_sub            |*f128 |*f128 | void | .. SPARC args *c,*a,*b c=a-b   |
+| ✓ | __mulhf3           | f32  | f32  | f32  | `a * b`                        |
+| ✓ | __mulsf3           | f32  | f32  | f32  | ..                             |
+| ✓ | __muldf3           | f64  | f64  | f64  | ..                             |
+| ✓ | __multf3           | f128 | f128 | f128 | ..                             |
+| ✓ | __mulxf3           | f80  | f80  | f80  | ..                             |
+| ✓ | __aeabi_fmul       | f32  | f32  | f32  | .. ARM                         |
+| ✓ | __aeabi_dmul       | f64  | f64  | f64  | .. ARM                         |
+| ✓ | __mulkf3           | f128 | f128 | f128 | .. PPC                         |
+| ✓ | _Qp_mul            |*f128 |*f128 | void | .. SPARC args *c,*a,*b c=a*b   |
+| ✓ | __divsf3           | f32  | f32  | f32  | `a / b`                        |
+| ✓ | __divdf3           | f64  | f64  | f64  | ..                             |
+| ✓ | __divtf3           | f128 | f128 | f128 | ..                             |
+| ✓ | __divxf3           | f80  | f80  | f80  | ..                             |
+| ✓ | __aeabi_fdiv       | f32  | f32  | f32  | .. ARM                         |
+| ✓ | __aeabi_ddiv       | f64  | f64  | f64  | .. ARM                         |
+| ✓ | __divkf3           | f128 | f128 | f128 | .. PPC                         |
+| ✓ | _Qp_div            |*f128 |*f128 | void | .. SPARC args *c,*a,*b c=a*b   |
+| ✓ | __negsf2           | f32  | ∅    | f32[^unused_rl78] | -a (can be lowered directly to a xor) |
+| ✓ | __negdf2           | f64  | ∅    | f64  | ..                             |
+| ✓ | __negtf2           | f128 | ∅    | f128 | ..                             |
+| ✓ | __negxf2           | f80  | ∅    | f80  | ..                             |
+|   |                    |      |      |      | **Floating point raised to integer power** |
+| ✗ | __powihf2          | f16  | f16  | f16  | `a ^ b`                        |
+| ✗ | __powisf2          | f32  | f32  | f32  | ..                             |
+| ✗ | __powidf2          | f64  | f64  | f64  | ..                             |
+| ✗ | __powitf2          | f128 | f128 | f128 | ..                             |
+| ✗ | __powixf2          | f80  | f80  | f80  | ..                             |
+| ✓ | __mulhc3           | all4 | f16  | f16  | `(a+ib) * (c+id)`              |
+| ✓ | __mulsc3           | all4 | f32  | f32  | ..                             |
+| ✓ | __muldc3           | all4 | f64  | f64  | ..                             |
+| ✓ | __multc3           | all4 | f128 | f128 | ..                             |
+| ✓ | __mulxc3           | all4 | f80  | f80  | ..                             |
+| ✓ | __divhc3           | all4 | f16  | f16  | `(a+ib) / (c+id)`              |
+| ✓ | __divsc3           | all4 | f32  | f32  | ..                             |
+| ✓ | __divdc3           | all4 | f64  | f64  | ..                             |
+| ✓ | __divtc3           | all4 | f128 | f128 | ..                             |
+| ✓ | __divxc3           | all4 | f80  | f80  | ..                             |
 
-#### Integer Arithmetic
+[^unused_rl78]: Unused in LLVM, but used for example by rl78.
+[^libgcc_compat]: Unused in backends and for symbol-level compatibility with libgcc.
+[^noptr_faster]: Operations without pointer and without C struct semantics lead to better optimizations.
+[^perf_addition]: Has better performance than standard method due to 2s complement semantics.
+Not provided by LLVM and libgcc.
 
-- none none __ashlsi3       // a,b: i32, a << b unused in llvm, TODO (e.g. used by rl78)
-- port llvm __ashldi3       // a,b: u64
-- port llvm __ashlti3       // a,b: u128
-- none none __ashrsi3       // a,b: i32, a >> b  arithmetic (sign fill) TODO (e.g. used by rl78)
-- port llvm __ashrdi3       // ..
-- port llvm __ashrti3       //
-- none none __lshrsi3       // a,b: i32, a >> b  logical    (zero fill) TODO (e.g. used by rl78)
-- port llvm __lshrdi3       //
-- port llvm __lshrti3       //
-- port llvm __negdi2        // a: i32,  -a, symbol-level compatibility with libgcc
-- port llvm __negti2        //              unnecessary: unused in backends
-- port llvm __mulsi3        // a,b: i32, a * b
-- port llvm __muldi3        //
-- port llvm __multi3        //
-- port llvm __divsi3        // a,b: i32, a / b
-- port llvm __divdi3        //
-- port llvm __divti3        //
-- port llvm __udivsi3       // a,b: u32, a / b
-- port llvm __udivdi3       //
-- port llvm __udivti3       //
-- port llvm __modsi3        // a,b: i32, a % b
-- port llvm __moddi3        //
-- port llvm __modti3        //
-- port llvm __umodsi3       // a,b: u32, a % b
-- port llvm __umoddi3       //
-- port llvm __umodti3       //
-- port llvm __udivmoddi4    // a,b: u32, a / b, rem.* = a % b  unsigned
-- port llvm __udivmodti4    //
-- port llvm __udivmodsi4    //
-- port llvm __divmodsi4     // a,b: i32, a / b, rem.* = a % b  signed, ARM
-- port llvm __divmoddi4     //
-
-#### Integer Arithmetic with trapping overflow
-
-- dev BitTwiddlingHacks __absvsi2  // abs(a)
-- dev BitTwiddlingHacks __absvdi2  // abs(a)
-- dev BitTwiddlingHacks __absvti2  // abs(a)
-- port llvm __negvsi2              // -a symbol-level compatibility: libgcc
-- port llvm __negvdi2              // -a unnecessary: unused in backends
-- port llvm __negvti2              // -a
-- TODO upstreaming __addvsi3..__mulvti3 after testing panics works
-- dev HackersDelight __addvsi3     // a + b
-- dev HackersDelight __addvdi3     //
-- dev HackersDelight __addvti3     //
-- dev HackersDelight __subvsi3     // a - b
-- dev HackersDelight __subvdi3     //
-- dev HackersDelight __subvti3     //
-- dev HackersDelight __mulvsi3     // a * b
-- dev HackersDelight __mulvdi3     //
-- dev HackersDelight __mulvti3     //
-
-#### Integer Arithmetic which returns if overflow (would be faster without pointer)
-
-- dev HackersDelight __addosi4     // a + b, overflow->ov.*=1 else 0
-- dev HackersDelight __addodi4     // (completeness + performance, llvm does not use them)
-- dev HackersDelight __addoti4     //
-- dev HackersDelight __subosi4     // a - b, overflow->ov.*=1 else 0
-- dev HackersDelight __subodi4     // (completeness + performance, llvm does not use them)
-- dev HackersDelight __suboti4     //
-- dev HackersDelight __mulosi4     // a * b, overflow->ov.*=1 else 0
-- dev HackersDelight __mulodi4     // (required by llvm)
-- dev HackersDelight __muloti4     //
-
-## Float library routines
-
-TODO: review source of implementation
-
-#### Float Conversion
-
-- dev  other __extendsfdf2   // a: f32 -> f64, TODO: missing tests
-- dev  other __extendsftf2   // a: f32 -> f128
-- dev   llvm __extendsfxf2   // a: f32 -> f80, TODO: missing tests
-- dev  other __extenddftf2   // a: f64 -> f128
-- dev   llvm __extenddfxf2   // a: f64 -> f80
-- dev  other __truncdfsf2    // a: f64 -> f32, rounding towards zero
-- dev  other __trunctfdf2    // a: f128-> f64
-- dev  other __trunctfsf2    // a: f128-> f32
-- dev   llvm __truncxfsf2    // a: f80 -> f32, TODO: missing tests
-- dev   llvm __truncxfdf2    // a: f80 -> f64, TODO: missing tests
-
-- dev  unclear __fixsfsi     // a: f32 -> i32, rounding towards zero
-- dev  unclear __fixdfsi     // a: f64 -> i32
-- dev  unclear __fixtfsi     // a: f128-> i32
-- dev  unclear __fixxfsi     // a: f80 -> i32, TODO: missing tests
-- dev  unclear __fixsfdi     // a: f32 -> i64, rounding towards zero
-- dev  unclear __fixdfdi     // ..
-- dev  unclear __fixtfdi     //
-- dev  unclear __fixxfdi     // TODO: missing tests
-- dev  unclear __fixsfti     // a: f32 -> i128, rounding towards zero
-- dev  unclear __fixdfti     // ..
-- dev  unclear __fixtfdi     //
-- dev  unclear __fixxfti     // TODO: missing tests
-
-- dev unclear __fixunssfsi   // a: f32 -> u32, rounding towards zero. negative values become 0.
-- dev unclear __fixunsdfsi   // ..
-- dev unclear __fixunstfsi   //
-- dev unclear __fixunsxfsi   // TODO: missing tests
-- dev unclear __fixunssfdi   // a: f32 -> u64, rounding towards zero. negative values become 0.
-- dev unclear __fixunsdfdi   //
-- dev unclear __fixunstfdi   //
-- dev unclear __fixunsxfdi   // TODO: missing tests
-- dev unclear __fixunssfti   // a: f32 -> u128, rounding towards zero. negative values become 0.
-- dev unclear __fixunsdfti   //
-- dev unclear __fixunstfdi   //
-- dev unclear __fixunsxfti   // TODO: some more tests needed for base coverage
-
-- dev unclear __floatsisf    // a: i32 -> f32
-- dev unclear __floatsidf    // a: i32 -> f64, TODO: missing tests
-- dev unclear __floatsitf    // ..
-- dev unclear __floatsixf    // TODO: missing tests
-- dev unclear __floatdisf    // a: i64 -> f32
-- dev unclear __floatdidf    //
-- dev unclear __floatditf    //
-- dev unclear __floatdixf    // TODO: missing tests
-- dev unclear __floattisf    // a: i128-> f32
-- dev unclear __floattidf    //
-- dev unclear __floattitf    //
-- dev unclear __floattixf    // TODO: missing tests
-
-- dev unclear __floatunsisf  // a: u32 -> f32
-- dev unclear __floatunsidf  // TODO: missing tests
-- dev unclear __floatunsitf  //
-- dev unclear __floatunsixf  // TODO: missing tests
-- dev unclear __floatundisf  // a: u64 -> f32
-- dev unclear __floatundidf  //
-- dev unclear __floatunditf  //
-- dev unclear __floatundixf  // TODO: missing tests
-- dev unclear __floatuntisf  // a: u128-> f32
-- dev unclear __floatuntidf  //
-- dev unclear __floatuntitf  //
-- dev unclear __floatuntixf  // TODO: missing tests
-
-#### Float Comparison
-
-- dev other __cmpsf2       // a,b:f32, (a<b)->-1,(a==b)->0,(a>b)->1,Nan->1
-- dev other __cmpdf2       // exported from __lesf2, __ledf2, __letf2 (below)
-- dev other __cmptf2       // But: if NaN is a possibility, use another routine.
-- dev other __unordsf2     // a,b:f32, (a==+-NaN or b==+-NaN) -> !=0, else -> 0
-- dev other __unorddf2     // __only reliable for (input!=NaN)__
-- dev other __unordtf2     // TODO: missing tests
-- dev other __eqsf2        // (a!=NaN) and (b!=Nan) and (a==b) -> output=0
-- dev other __eqdf2        //
-- dev other __eqtf2        //
-- dev other __nesf2        // (a==NaN) or (b==Nan) or (a!=b) -> output!=0
-- dev other __nedf2        //
-- dev other __netf2        // __eqtf2 and __netf2 have same return value -> tested with __eqsf2
-- dev other __gesf2        // (a!=Nan) and (b!=Nan) and (a>=b) -> output>=0
-- dev other __gedf2        //
-- dev other __getf2        // TODO: missing tests
-- dev other __ltsf2        // (a!=Nan) and (b!=Nan) and (a<b) -> output<0
-- dev other __ltdf2        //
-- dev other __lttf2        // TODO: missing tests
-- dev other __lesf2        // (a!=Nan) and (b!=Nan) and (a<=b) -> output<=0
-- dev other __ledf2        //
-- dev other __letf2        // TODO: missing tests
-- dev other __gtsf2        // (a!=Nan) and (b!=Nan) and (a>b) -> output>0
-- dev other __gtdf2        //
-- dev other __gttf2        // TODO: missing tests
-
-#### Float Arithmetic
-
-- dev unclear __addsf3       // a + b f32, TODO: missing tests
-- dev unclear __adddf3       // a + b f64, TODO: missing tests
-- dev unclear __addtf3       // a + b f128
-- dev unclear __addxf3       // a + b f80
-- dev unclear __aeabi_fadd   // a + b f64 ARM: AAPCS
-- dev unclear __aeabi_dadd   // a + b f64 ARM: AAPCS
-- dev unclear __subsf3       // a - b, TODO: missing tests
-- dev unclear __subdf3       // a - b, TODO: missing tests
-- dev unclear __subtf3       // a - b
-- dev unclear __subxf3       // a - b f80, TODO: missing tests
-- dev unclear __aeabi_fsub   // a - b f64 ARM: AAPCS
-- dev unclear __aeabi_dsub   // a - b f64 ARM: AAPCS
-- dev unclear __mulsf3       // a * b, TODO: missing tests
-- dev unclear __muldf3       // a * b, TODO: missing tests
-- dev unclear __multf3       // a * b
-- dev unclear __mulxf3       // a * b
-- dev unclear __divsf3       // a / b, TODO: review tests
-- dev unclear __divdf3       // a / b, TODO: review tests
-- dev unclear __divtf3       // a / b
-- dev unclear __divxf3       // a / b
-- dev unclear __negsf2       // -a symbol-level compatibility: libgcc uses this for the rl78
-- dev unclear __negdf2       // -a unnecessary: can be lowered directly to a xor
-- dev unclear __negtf2       // -a, TODO: missing tests
-- dev unclear __negxf2       // -a, TODO: missing tests
-
-#### Floating point raised to integer power
-- dev unclear __powisf2  // a ^ b, TODO
-- dev unclear __powidf2  //
-- dev unclear __powitf2  //
-- dev unclear __powixf2  //
-- dev unclear __mulsc3   // (a+ib) * (c+id)
-- dev unclear __muldc3   //
-- dev unclear __multc3   //
-- dev unclear __mulxc3   //
-- dev unclear __divsc3   // (a+ib) * / (c+id)
-- dev unclear __divdc3   //
-- dev unclear __divtc3   //
-- dev unclear __divxc3   //
-
-## Decimal float library routines
+Decimal float library routines
 
 BID means Binary Integer Decimal encoding, DPD means Densely Packed Decimal encoding.
 BID should be only chosen for binary data, DPD for decimal data (ASCII, Unicode etc).
-If possible, use BCD instead of DPD to represent numbers not accurately representable
-in binary like the number 0.2.
+For example the number 0.2 is not accurately representable in binary data.
 
-All routines are TODO.
+| Done   | Name          | a           | b         | Out       | Comment                      |
+| ------ | ------------- | ---------   | --------- | --------- | ---------------------------- |
+|   |                    |             |           |           | **Decimal Float Conversion** |
+| ✗ | __dpd_extendsddd2  |     dec32   | ∅         |     dec64 | conversion                   |
+| ✗ | __bid_extendsddd2  |     dec32   | ∅         |     dec64 | ..                           |
+| ✗ | __dpd_extendsdtd2  |     dec32   | ∅         |     dec128| ..                           |
+| ✗ | __bid_extendsdtd2  |     dec32   | ∅         |     dec128| ..                           |
+| ✗ | __dpd_extendddtd2  |     dec64   | ∅         |     dec128| ..                           |
+| ✗ | __bid_extendddtd2  |     dec64   | ∅         |     dec128| ..                           |
+| ✗ | __dpd_truncddsd2   |     dec64   | ∅         |     dec32 | ..                           |
+| ✗ | __bid_truncddsd2   |     dec64   | ∅         |     dec32 | ..                           |
+| ✗ | __dpd_trunctdsd2   |     dec128  | ∅         |     dec32 | ..                           |
+| ✗ | __bid_trunctdsd2   |     dec128  | ∅         |     dec32 | ..                           |
+| ✗ | __dpd_trunctddd2   |     dec128  | ∅         |     dec64 | ..                           |
+| ✗ | __bid_trunctddd2   |     dec128  | ∅         |     dec64 | ..                           |
+| ✗ | __dpd_extendsfdd   |     float   | ∅         |     dec64 | ..                           |
+| ✗ | __bid_extendsfdd   |     float   | ∅         |     dec64 | ..                           |
+| ✗ | __dpd_extendsftd   |     float   | ∅         |     dec128| ..                           |
+| ✗ | __bid_extendsftd   |     float   | ∅         |     dec128| ..                           |
+| ✗ | __dpd_extenddftd   |     double  | ∅         |     dec128| ..                           |
+| ✗ | __bid_extenddftd   |     double  | ∅         |     dec128| ..                           |
+| ✗ | __dpd_extendxftd   |long double  | ∅         |     dec128| ..                           |
+| ✗ | __bid_extendxftd   |long double  | ∅         |     dec128| ..                           |
+| ✗ | __dpd_truncdfsd    |     double  | ∅         |     dec32 | ..                           |
+| ✗ | __bid_truncdfsd    |     double  | ∅         |     dec32 | ..                           |
+| ✗ | __dpd_truncxfsd    |long double  | ∅         |     dec32 | ..                           |
+| ✗ | __bid_truncxfsd    |long double  | ∅         |     dec32 | ..                           |
+| ✗ | __dpd_trunctfsd    |long double  | ∅         |     dec32 | ..                           |
+| ✗ | __bid_trunctfsd    |long double  | ∅         |     dec32 | ..                           |
+| ✗ | __dpd_truncxfdd    |long double  | ∅         |     dec64 | ..                           |
+| ✗ | __bid_truncxfdd    |long double  | ∅         |     dec64 | ..                           |
+| ✗ | __dpd_trunctfdd    |long double  | ∅         |     dec64 | ..                           |
+| ✗ | __bid_trunctfdd    |long double  | ∅         |     dec64 | ..                           |
+| ✗ | __dpd_truncddsf    |     dec64   | ∅         |     float | ..                           |
+| ✗ | __bid_truncddsf    |     dec64   | ∅         |     float | ..                           |
+| ✗ | __dpd_trunctdsf    |     dec128  | ∅         |     float | ..                           |
+| ✗ | __bid_trunctdsf    |     dec128  | ∅         |     float | ..                           |
+| ✗ | __dpd_extendsddf   |     dec32   | ∅         |     double| ..                           |
+| ✗ | __bid_extendsddf   |     dec32   | ∅         |     double| ..                           |
+| ✗ | __dpd_trunctddf    |     dec128  | ∅         |     double| ..                           |
+| ✗ | __bid_trunctddf    |     dec128  | ∅         |     double| ..                           |
+| ✗ | __dpd_extendsdxf   |     dec32   | ∅         |long double| ..                           |
+| ✗ | __bid_extendsdxf   |     dec32   | ∅         |long double| ..                           |
+| ✗ | __dpd_extendddxf   |     dec64   | ∅         |long double| ..                           |
+| ✗ | __bid_extendddxf   |     dec64   | ∅         |long double| ..                           |
+| ✗ | __dpd_trunctdxf    |     dec128  | ∅         |long double| ..                           |
+| ✗ | __bid_trunctdxf    |     dec128  | ∅         |long double| ..                           |
+| ✗ | __dpd_extendsdtf   |     dec32   | ∅         |long double| ..                           |
+| ✗ | __bid_extendsdtf   |     dec32   | ∅         |long double| ..                           |
+| ✗ | __dpd_extendddtf   |     dec64   | ∅         |long double| ..                           |
+| ✗ | __bid_extendddtf   |     dec64   | ∅         |long double| ..                           |
+| ✗ | __dpd_extendsfsd   |     float   | ∅         |     dec32 | same size conversions        |
+| ✗ | __bid_extendsfsd   |     float   | ∅         |     dec32 | ..                           |
+| ✗ | __dpd_extenddfdd   |     double  | ∅         |     dec64 | ..                           |
+| ✗ | __bid_extenddfdd   |     double  | ∅         |     dec64 | ..                           |
+| ✗ | __dpd_extendtftd   |long double  | ∅         |     dec128| ..                           |
+| ✗ | __bid_extendtftd   |long double  | ∅         |     dec128| ..                           |
+| ✗ | __dpd_truncsdsf    |     dec32   | ∅         |     float | ..                           |
+| ✗ | __bid_truncsdsf    |     dec32   | ∅         |     float | ..                           |
+| ✗ | __dpd_truncdddf    |     dec64   | ∅         |     float | conversion                   |
+| ✗ | __bid_truncdddf    |     dec64   | ∅         |     float | ..                           |
+| ✗ | __dpd_trunctdtf    |     dec128  | ∅         |long double| ..                           |
+| ✗ | __bid_trunctdtf    |     dec128  | ∅         |long double| ..                           |
+| ✗ | __dpd_fixsdsi      |     dec32   | ∅         |     int   | ..                           |
+| ✗ | __bid_fixsdsi      |     dec32   | ∅         |     int   | ..                           |
+| ✗ | __dpd_fixddsi      |     dec64   | ∅         |     int   | ..                           |
+| ✗ | __bid_fixddsi      |     dec64   | ∅         |     int   | ..                           |
+| ✗ | __dpd_fixtdsi      |     dec128  | ∅         |     int   | ..                           |
+| ✗ | __bid_fixtdsi      |     dec128  | ∅         |     int   | ..                           |
+| ✗ | __dpd_fixsddi      |     dec32   | ∅         |     long  | ..                           |
+| ✗ | __bid_fixsddi      |     dec32   | ∅         |     long  | ..                           |
+| ✗ | __dpd_fixdddi      |     dec64   | ∅         |     long  | ..                           |
+| ✗ | __bid_fixdddi      |     dec64   | ∅         |     long  | ..                           |
+| ✗ | __dpd_fixtddi      |     dec128  | ∅         |     long  | ..                           |
+| ✗ | __bid_fixtddi      |     dec128  | ∅         |     long  | ..                           |
+| ✗ | __dpd_fixunssdsi   |     dec32   | ∅         |unsigned int | .. All negative values become zero. |
+| ✗ | __bid_fixunssdsi   |     dec32   | ∅         |unsigned int | ..                         |
+| ✗ | __dpd_fixunsddsi   |     dec64   | ∅         |unsigned int | ..                         |
+| ✗ | __bid_fixunsddsi   |     dec64   | ∅         |unsigned int | ..                         |
+| ✗ | __dpd_fixunstdsi   |     dec128  | ∅         |unsigned int | ..                         |
+| ✗ | __bid_fixunstdsi   |     dec128  | ∅         |unsigned int | ..                         |
+| ✗ | __dpd_fixunssddi   |     dec32   | ∅         |unsigned long| ..                         |
+| ✗ | __bid_fixunssddi   |     dec32   | ∅         |unsigned long| ..                         |
+| ✗ | __dpd_fixunsdddi   |     dec64   | ∅         |unsigned long| ..                         |
+| ✗ | __bid_fixunsdddi   |     dec64   | ∅         |unsigned long| ..                         |
+| ✗ | __dpd_fixunstddi   |     dec128  | ∅         |unsigned long| ..                         |
+| ✗ | __bid_fixunstddi   |     dec128  | ∅         |unsigned long| ..                         |
+| ✗ | __dpd_floatsisd    |     int     | ∅         |     dec32   | ..                         |
+| ✗ | __bid_floatsisd    |     int     | ∅         |     dec32   | ..                         |
+| ✗ | __dpd_floatsidd    |     int     | ∅         |     dec64   | ..                         |
+| ✗ | __bid_floatsidd    |     int     | ∅         |     dec64   | ..                         |
+| ✗ | __dpd_floatsitd    |     int     | ∅         |     dec128  | ..                         |
+| ✗ | __bid_floatsitd    |     int     | ∅         |     dec128  | ..                         |
+| ✗ | __dpd_floatdisd    |     long    | ∅         |     dec32   | ..                         |
+| ✗ | __bid_floatdisd    |     long    | ∅         |     dec32   | ..                         |
+| ✗ | __dpd_floatdidd    |     long    | ∅         |     dec64   | ..                         |
+| ✗ | __bid_floatdidd    |     long    | ∅         |     dec64   | ..                         |
+| ✗ | __dpd_floatditd    |     long    | ∅         |     dec128  | ..                         |
+| ✗ | __bid_floatditd    |     long    | ∅         |     dec128  | ..                         |
+| ✗ | __dpd_floatunssisd | unsigned int| ∅         |     dec32   | ..                         |
+| ✗ | __bid_floatunssisd | unsigned int| ∅         |     dec32   | ..                         |
+| ✗ | __dpd_floatunssidd | unsigned int| ∅         |     dec64   | ..                         |
+| ✗ | __bid_floatunssidd | unsigned int| ∅         |     dec64   | ..                         |
+| ✗ | __dpd_floatunssitd | unsigned int| ∅         |     dec128  | ..                         |
+| ✗ | __bid_floatunssitd | unsigned int| ∅         |     dec128  | ..                         |
+| ✗ | __dpd_floatunsdisd |unsigned long| ∅         |     dec32   | ..                         |
+| ✗ | __bid_floatunsdisd |unsigned long| ∅         |     dec32   | ..                         |
+| ✗ | __dpd_floatunsdidd |unsigned long| ∅         |     dec64   | ..                         |
+| ✗ | __bid_floatunsdidd |unsigned long| ∅         |     dec64   | ..                         |
+| ✗ | __dpd_floatunsditd |unsigned long| ∅         |     dec128  | ..                         |
+| ✗ | __bid_floatunsditd |unsigned long| ∅         |     dec128  | ..                         |
+|   |                |        |        |        | **Decimal Float Comparison**                            |
+| ✗ | __dpd_unordsd2 | dec32  | dec32  | c_int  | `a +-NaN or a +-NaN -> 1(nonzero), else -> 0`           |
+| ✗ | __bid_unordsd2 | dec32  | dec32  | c_int  | ..                                                      |
+| ✗ | __dpd_unorddd2 | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __bid_unorddd2 | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __dpd_unordtd2 | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __bid_unordtd2 | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __dpd_eqsd2    | dec32  | dec32  | c_int  |`a!=+-NaN and b!=+-Nan and a==b -> 0, else -> 1(nonzero)`|
+| ✗ | __bid_eqsd2    | dec32  | dec32  | c_int  | ..                                                      |
+| ✗ | __dpd_eqdd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __bid_eqdd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __dpd_eqtd2    | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __bid_eqtd2    | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __dpd_nesd2    | dec32  | dec32  | c_int  | `a==+-NaN or b==+-NaN or a!=b -> 1(nonzero), else -> 0` |
+| ✗ | __bid_nesd2    | dec32  | dec32  | c_int  | ..                                                      |
+| ✗ | __dpd_nedd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __bid_nedd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __dpd_netd2    | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __bid_netd2    | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __dpd_gesd2    | dec32  | dec32  | c_int  | `a!=+-NaN and b!=+-NaN and a>=b -> >=0, else -> <0`     |
+| ✗ | __bid_gesd2    | dec32  | dec32  | c_int  | ..                                                      |
+| ✗ | __dpd_gedd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __bid_gedd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __dpd_getd2    | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __bid_getd2    | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __dpd_ltsd2    | dec32  | dec32  | c_int  | `a!=+-NaN and b!=+-NaN and a<b -> <0, else -> >=0`      |
+| ✗ | __bid_ltsd2    | dec32  | dec32  | c_int  | ..                                                      |
+| ✗ | __dpd_ltdd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __bid_ltdd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __dpd_lttd2    | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __bid_lttd2    | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __dpd_lesd2    | dec32  | dec32  | c_int  | `a!=+-NaN and b!=+-NaN and a<=b -> <=0, else -> >=0`    |
+| ✗ | __bid_lesd2    | dec32  | dec32  | c_int  | ..                                                      |
+| ✗ | __dpd_ledd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __bid_ledd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __dpd_letd2    | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __bid_letd2    | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __dpd_gtsd2    | dec32  | dec32  | c_int  | `a!=+-NaN and b!=+-NaN and a>b -> >0, else -> <=0`      |
+| ✗ | __bid_gtsd2    | dec32  | dec32  | c_int  | ..                                                      |
+| ✗ | __dpd_gtdd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __bid_gtdd2    | dec64  | dec64  | c_int  | ..                                                      |
+| ✗ | __dpd_gttd2    | dec128 | dec128 | c_int  | ..                                                      |
+| ✗ | __bid_gttd2    | dec128 | dec128 | c_int  | ..                                                      |
+|   |                |        |        |        | **Decimal Float Arithmetic**[^options] |
+| ✗ | __dpd_addsd3   | dec32  | dec32  | dec32  |`a + b`|
+| ✗ | __bid_addsd3   | dec32  | dec32  | dec32  | ..    |
+| ✗ | __dpd_adddd3   | dec64  | dec64  | dec64  | ..    |
+| ✗ | __bid_adddd3   | dec64  | dec64  | dec64  | ..    |
+| ✗ | __dpd_addtd3   | dec128 | dec128 | dec128 | ..    |
+| ✗ | __bid_addtd3   | dec128 | dec128 | dec128 | ..    |
+| ✗ | __dpd_subsd3   | dec32  | dec32  | dec32  |`a - b`|
+| ✗ | __bid_subsd3   | dec32  | dec32  | dec32  | ..    |
+| ✗ | __dpd_subdd3   | dec64  | dec64  | dec64  | ..    |
+| ✗ | __bid_subdd3   | dec64  | dec64  | dec64  | ..    |
+| ✗ | __dpd_subtd3   | dec128 | dec128 | dec128 | ..    |
+| ✗ | __bid_subtd3   | dec128 | dec128 | dec128 | ..    |
+| ✗ | __dpd_mulsd3   | dec32  | dec32  | dec32  |`a * b`|
+| ✗ | __bid_mulsd3   | dec32  | dec32  | dec32  | ..    |
+| ✗ | __dpd_muldd3   | dec64  | dec64  | dec64  | ..    |
+| ✗ | __bid_muldd3   | dec64  | dec64  | dec64  | ..    |
+| ✗ | __dpd_multd3   | dec128 | dec128 | dec128 | ..    |
+| ✗ | __bid_multd3   | dec128 | dec128 | dec128 | ..    |
+| ✗ | __dpd_divsd3   | dec32  | dec32  | dec32  |`a / b`|
+| ✗ | __bid_divsd3   | dec32  | dec32  | dec32  | ..    |
+| ✗ | __dpd_divdd3   | dec64  | dec64  | dec64  | ..    |
+| ✗ | __bid_divdd3   | dec64  | dec64  | dec64  | ..    |
+| ✗ | __dpd_divtd3   | dec128 | dec128 | dec128 | ..    |
+| ✗ | __bid_divtd3   | dec128 | dec128 | dec128 | ..    |
+| ✗ | __dpd_negsd2   | dec32  | dec32  | dec32  | `-a`  |
+| ✗ | __bid_negsd2   | dec32  | dec32  | dec32  | ..    |
+| ✗ | __dpd_negdd2   | dec64  | dec64  | dec64  | ..    |
+| ✗ | __bid_negdd2   | dec64  | dec64  | dec64  | ..    |
+| ✗ | __dpd_negtd2   | dec128 | dec128 | dec128 | ..    |
+| ✗ | __bid_negtd2   | dec128 | dec128 | dec128 | ..    |
 
-#### Decimal float Conversion
+[^options]: These numbers include options with routines for +-0 and +-Nan.
 
-- __dpd_extendsddd2  //       dec32->dec64
-- __bid_extendsddd2  //       dec32->dec64
-- __dpd_extendsdtd2  //       dec32->dec128
-- __bid_extendsdtd2  //       dec32->dec128
-- __dpd_extendddtd2  //       dec64->dec128
-- __bid_extendddtd2  //       dec64->dec128
-- __dpd_truncddsd2   //       dec64->dec32
-- __bid_truncddsd2   //       dec64->dec32
-- __dpd_trunctdsd2   //      dec128->dec32
-- __bid_trunctdsd2   //      dec128->dec32
-- __dpd_trunctddd2   //      dec128->dec64
-- __bid_trunctddd2   //      dec128->dec64
+Fixed-point fractional library routines
 
-- __dpd_extendsfdd   //       float->dec64
-- __bid_extendsfdd   //       float->dec64
-- __dpd_extendsftd   //       float->dec128
-- __bid_extendsftd   //       float->dec128
-- __dpd_extenddftd   //      double->dec128
-- __bid_extenddftd   //      double->dec128
-- __dpd_extendxftd   // long double->dec128
-- __bid_extendxftd   // long double->dec128
-- __dpd_truncdfsd    //      double->dec32
-- __bid_truncdfsd    //      double->dec32
-- __dpd_truncxfsd    // long double->dec32
-- __bid_truncxfsd    // long double->dec32
-- __dpd_trunctfsd    // long double->dec32
-- __bid_trunctfsd    // long double->dec32
-- __dpd_truncxfdd    // long double->dec64
-- __bid_truncxfdd    // long double->dec64
-- __dpd_trunctfdd    // long double->dec64
-- __bid_trunctfdd    // long double->dec64
+TODO brief explanation + implementation
 
-- __dpd_truncddsf    //      dec64->float
-- __bid_truncddsf    //      dec64->float
-- __dpd_trunctdsf    //     dec128->float
-- __bid_trunctdsf    //     dec128->float
-- __dpd_extendsddf   //      dec32->double
-- __bid_extendsddf   //      dec32->double
-- __dpd_trunctddf    //     dec128->double
-- __bid_trunctddf    //     dec128->double
-- __dpd_extendsdxf   //      dec32->long double
-- __bid_extendsdxf   //      dec32->long double
-- __dpd_extendddxf   //      dec64->long double
-- __bid_extendddxf   //      dec64->long double
-- __dpd_trunctdxf    //     dec128->long double
-- __bid_trunctdxf    //     dec128->long double
-- __dpd_extendsdtf   //      dec32->long double
-- __bid_extendsdtf   //      dec32->long double
-- __dpd_extendddtf   //      dec64->long double
-- __bid_extendddtf   //      dec64->long double
+| Done   | Name          | a           | b         | Out       | Comment                    |
+| ------ | ------------- | ---------   | --------- | --------- | -------------------------- |
+|        |               |             |           |           | **Fixed-Point Fractional** |
 
-Same size conversion:
-- __dpd_extendsfsd   //      float->dec32
-- __bid_extendsfsd   //      float->dec32
-- __dpd_extenddfdd   //     double->dec64
-- __bid_extenddfdd   //     double->dec64
-- __dpd_extendtftd   //long double->dec128
-- __bid_extendtftd   //long double->dec128
-- __dpd_truncsdsf    //      dec32->float
-- __bid_truncsdsf    //      dec32->float
-- __dpd_truncdddf    //      dec64->float
-- __bid_truncdddf    //      dec64->float
-- __dpd_trunctdtf    //     dec128->long double
-- __bid_trunctdtf    //     dec128->long double
+Further content:
+- aarch64 outline atomics
+- atomics
+- msvc things like _alldiv, _aulldiv, _allrem
+- clear cache
+- tls emulation
+- math routines (cos, sin, tan, ceil, floor, exp, exp2, fabs, log, log10, log2, sincos, sqrt)
+- bcmp
+- ieee float routines (fma, fmax, fmin, fmod, fabs, float rounding, )
+- arm routines (memory routines + memclr [setting to 0], divmod routines and stubs for unwind_cpp)
+- memory routines (memcmp, memcpy, memset, memmove)
+- objective-c __isPlatformVersionAtLeast check
+- stack probe routines
 
-- __dpd_fixsdsi      //      dec32->int
-- __bid_fixsdsi      //      dec32->int
-- __dpd_fixddsi      //      dec64->int
-- __bid_fixddsi      //      dec64->int
-- __dpd_fixtdsi      //     dec128->int
-- __bid_fixtdsi      //     dec128->int
+Future work
 
-- __dpd_fixsddi      //      dec32->long
-- __bid_fixsddi      //      dec32->long
-- __dpd_fixdddi      //      dec64->long
-- __bid_fixdddi      //      dec64->long
-- __dpd_fixtddi      //     dec128->long
-- __bid_fixtddi      //     dec128->long
-
-- __dpd_fixunssdsi   //   dec32->unsigned int, All negative values become zero.
-- __bid_fixunssdsi   //   dec32->unsigned int
-- __dpd_fixunsddsi   //   dec64->unsigned int
-- __bid_fixunsddsi   //   dec64->unsigned int
-- __dpd_fixunstdsi   //  dec128->unsigned int
-- __bid_fixunstdsi   //  dec128->unsigned int
-
-- __dpd_fixunssddi   //   dec32->unsigned long, All negative values become zero.
-- __bid_fixunssddi   //   dec32->unsigned long
-- __dpd_fixunsdddi   //   dec64->unsigned long
-- __bid_fixunsdddi   //   dec64->unsigned long
-- __dpd_fixunstddi   //  dec128->unsigned long
-- __bid_fixunstddi   //  dec128->unsigned long
-
-- __dpd_floatsisd    //     int->dec32
-- __bid_floatsisd    //     int->dec32
-- __dpd_floatsidd    //     int->dec64
-- __bid_floatsidd    //     int->dec64
-- __dpd_floatsitd    //     int->dec128
-- __bid_floatsitd    //     int->dec128
-
-- __dpd_floatdisd    //    long->dec32
-- __bid_floatdisd    //    long->dec32
-- __dpd_floatdidd    //    long->dec64
-- __bid_floatdidd    //    long->dec64
-- __dpd_floatditd    //    long->dec128
-- __bid_floatditd    //    long->dec128
-
-- __dpd_floatunssisd  //  unsigned int->dec32
-- __bid_floatunssisd  //  unsigned int->dec32
-- __dpd_floatunssidd  //  unsigned int->dec64
-- __bid_floatunssidd  //  unsigned int->dec64
-- __dpd_floatunssitd  //  unsigned int->dec128
-- __bid_floatunssitd  //  unsigned int->dec128
-
-- __dpd_floatunsdisd  // unsigned long->dec32
-- __bid_floatunsdisd  // unsigned long->dec32
-- __dpd_floatunsdidd  // unsigned long->dec64
-- __bid_floatunsdidd  // unsigned long->dec64
-- __dpd_floatunsditd  // unsigned long->dec128
-- __bid_floatunsditd  // unsigned long->dec128
-
-#### Decimal float Comparison
-
-All decimal float comparison routines return c_int.
-
-- __dpd_unordsd2  // a,b: dec32, a +-NaN or a +-NaN -> 1(nonzero), else -> 0
-- __bid_unordsd2  // a,b: dec32
-- __dpd_unorddd2  // a,b: dec64
-- __bid_unorddd2  // a,b: dec64
-- __dpd_unordtd2  // a,b: dec128
-- __bid_unordtd2  // a,b: dec128
-
-- __dpd_eqsd2  // a,b: dec32, a!=+-NaN and b!=+-Nan and a==b -> 0, else -> 1(nonzero)
-- __bid_eqsd2  // a,b: dec32
-- __dpd_eqdd2  // a,b: dec64
-- __bid_eqdd2  // a,b: dec64
-- __dpd_eqtd2  // a,b: dec128
-- __bid_eqtd2  // a,b: dec128
-
-- __dpd_nesd2  // a,b: dec32, a==+-NaN or b==+-NaN or a!=b -> 1(nonzero), else -> 0
-- __bid_nesd2  // a,b: dec32
-- __dpd_nedd2  // a,b: dec64
-- __bid_nedd2  // a,b: dec64
-- __dpd_netd2  // a,b: dec128
-- __bid_netd2  // a,b: dec128
-
-- __dpd_gesd2  // a,b: dec32, a!=+-NaN and b!=+-NaN and a>=b -> >=0, else -> <0
-- __bid_gesd2  // a,b: dec32
-- __dpd_gedd2  // a,b: dec64
-- __bid_gedd2  // a,b: dec64
-- __dpd_getd2  // a,b: dec128
-- __bid_getd2  // a,b: dec128
-
-- __dpd_ltsd2  // a,b: dec32, a!=+-NaN and b!=+-NaN and a<b -> <0, else -> >=0
-- __bid_ltsd2  // a,b: dec32
-- __dpd_ltdd2  // a,b: dec64
-- __bid_ltdd2  // a,b: dec64
-- __dpd_lttd2  // a,b: dec128
-- __bid_lttd2  // a,b: dec128
-
-- __dpd_lesd2  // a,b: dec32, a!=+-NaN and b!=+-NaN and a<=b -> <=0, else -> >=0
-- __bid_lesd2  // a,b: dec32
-- __dpd_ledd2  // a,b: dec64
-- __bid_ledd2  // a,b: dec64
-- __dpd_letd2  // a,b: dec128
-- __bid_letd2  // a,b: dec128
-
-- __dpd_gtsd2  // a,b: dec32, a!=+-NaN and b!=+-NaN and a>b -> >0, else -> <=0
-- __bid_gtsd2  // a,b: dec32
-- __dpd_gtdd2  // a,b: dec64
-- __bid_gtdd2  // a,b: dec64
-- __dpd_gttd2  // a,b: dec128
-- __bid_gttd2  // a,b: dec128
-
-#### Decimal float Arithmetic
-
-These numbers include options with routines for +-0 and +-Nan.
-
-- __dpd_addsd3  // a,b: dec32 -> dec32,  a + b
-- __bid_addsd3  // a,b: dec32 -> dec32
-- __dpd_adddd3  // a,b: dec64 -> dec64
-- __bid_adddd3  // a,b: dec64 -> dec64
-- __dpd_addtd3  // a,b: dec128-> dec128
-- __bid_addtd3  // a,b: dec128-> dec128
-- __dpd_subsd3  // a,b: dec32,  a - b
-- __bid_subsd3  // a,b: dec32 -> dec32
-- __dpd_subdd3  // a,b: dec64 ..
-- __bid_subdd3  // a,b: dec64
-- __dpd_subtd3  // a,b: dec128
-- __bid_subtd3  // a,b: dec128
-- __dpd_mulsd3  // a,b: dec32,  a * b
-- __bid_mulsd3  // a,b: dec32 -> dec32
-- __dpd_muldd3  // a,b: dec64 ..
-- __bid_muldd3  // a,b: dec64
-- __dpd_multd3  // a,b: dec128
-- __bid_multd3  // a,b: dec128
-- __dpd_divsd3  // a,b: dec32,  a / b
-- __bid_divsd3  // a,b: dec32 -> dec32
-- __dpd_divdd3  // a,b: dec64 ..
-- __bid_divdd3  // a,b: dec64
-- __dpd_divtd3  // a,b: dec128
-- __bid_divtd3  // a,b: dec128
-- __dpd_negsd2  // a,b: dec32, -a
-- __bid_negsd2  // a,b: dec32 -> dec32
-- __dpd_negdd2  // a,b: dec64 ..
-- __bid_negdd2  // a,b: dec64
-- __dpd_negtd2  // a,b: dec128
-- __bid_negtd2  // a,b: dec128
-
-## Fixed-point fractional library routines
-
-TODO
-
-Too unclear for work items:
-- Miscellaneous routines => unclear, if supported (cache control and stack functions)
-- Zig-specific language runtime features, for example "Arbitrary length integer library routines"
+Arbitrary length integer library routines


### PR DESCRIPTION
This commit makes the text more dense with sources, noes the outstanding audit and adds an explanation of the table before converting everything to markdown tables.

For the status a checkmark or cross in utf8 encoding are used and the input and output sizes of all operations are given inclusive comments for understanding of the routines.

This should document all compiler_rt integer and float routines, but does not include a documentation of existing ieee floating and math routines.