### PR TITLE
std.compress.xz: Avoid possible integer overflow in a few places

### DIFF
--- a/lib/std/compress/xz.zig
+++ b/lib/std/compress/xz.zig
@@ -118,7 +118,7 @@ pub fn Decompress(comptime ReaderType: type) type {
                 var hasher = std.compress.hashedReader(self.in_reader, Crc32.init());
                 const hashed_reader = hasher.reader();
 
-                const backward_size = (try hashed_reader.readIntLittle(u32) + 1) * 4;
+                const backward_size = (@as(u64, try hashed_reader.readIntLittle(u32)) + 1) * 4;
                 if (backward_size != index_size)
                     return error.CorruptInput;
 

--- a/lib/std/compress/xz/block.zig
+++ b/lib/std/compress/xz/block.zig
@@ -98,7 +98,7 @@ pub fn Decoder(comptime ReaderType: type) type {
                 var header_hasher = std.compress.hashedReader(block_reader, Crc32.init());
                 const header_reader = header_hasher.reader();
 
-                const header_size = try header_reader.readByte() * 4;
+                const header_size = @as(u64, try header_reader.readByte()) * 4;
                 if (header_size == 0)
                     return error.EndOfStreamWithNoError;
 
@@ -217,7 +217,7 @@ pub fn Decoder(comptime ReaderType: type) type {
                     if (status == 1)
                         try self.accum.reset(self.allocator);
 
-                    const size = try packed_reader.readIntBig(u16) + 1;
+                    const size = @as(u17, try packed_reader.readIntBig(u16)) + 1;
                     try self.accum.ensureUnusedCapacity(self.allocator, size);
 
                     var i: usize = 0;


### PR DESCRIPTION
Closes #14500

Note: The test cases here could definitely be improved by constructing a valid `xz` input that would otherwise trigger the overflows. That way, the test cases would actually be testing something in all release modes. 