### PR TITLE
std.fs: improve error-handling for openDirW

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1820,7 +1820,7 @@ pub const Dir = struct {
         );
         switch (rc) {
             .SUCCESS => return result,
-            .OBJECT_NAME_INVALID => unreachable,
+            .OBJECT_NAME_INVALID => return error.NotDir,
             .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
             .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
             .NOT_A_DIRECTORY => return error.NotDir,


### PR DESCRIPTION
<details>
  <summary>Scenario where the bug manifests itself in a real use-case.</summary>

While adding a cmake dependency to `build.zig` with:

```zig
b.addSystemCommand(&[_][]const u8{ "cmake", "-DCMAKE_BUILD_TYPE=Release", ".", "-B", "build" });
```
 
 I've encountered `unreachable` which was caused by [this line](https://github.com/ziglang/zig/blame/03cdb4fb5853109e46bdc08d8a849a23780093ae/lib/std/fs.zig#L1793). It turns out my `%PATH%` had an incorrect entry: `:\Program Files\7-Zip` - notice no `C` at the start.

So what happens is that as part of `spawnWindows` Zig [searches through each `%PATH%` entry](https://github.com/ziglang/zig/blob/03cdb4fb5853109e46bdc08d8a849a23780093ae/lib/std/child_process.zig#L1043) to find an absolute path of `cmake` executable, and instead of skipping an invalid entry we panic on it.

</details>

You can repro the panic with this MRE:

```zig
var buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
var fba = std.heap.FixedBufferAllocator.init(&buffer);
const allocator = fba.allocator();
var broken_dir = try std.unicode.utf8ToUtf16LeWithNull(allocator, ":\\Program Files\\7-Zip");
_ = try std.fs.cwd().openDirW(broken_dir, .{}, true);
```

There's no info in [the original commit](https://github.com/ziglang/zig/blame/176bc53858053866e2a751e8d1e2a6a52871cff0/lib/std/fs.zig#L841) why it handles it as such, so I assume it's reasonable to treat the error as `error.NotDir` instead.