### PR TITLE
remove stage1 workaround for big int set

### DIFF
--- a/lib/std/math/big.zig
+++ b/lib/std/math/big.zig
@@ -13,7 +13,6 @@ pub const Log2Limb = std.math.Log2Int(Limb);
 
 comptime {
     assert(std.math.floorPowerOfTwo(usize, limb_info.bits) == limb_info.bits);
-    assert(limb_info.bits <= 64); // u128 set is unsupported
     assert(limb_info.signedness == .unsigned);
 }
 

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -30,7 +30,7 @@ pub fn calcLimbLen(scalar: anytype) usize {
     }
 
     const w_value = std.math.absCast(scalar);
-    return @divFloor(@intCast(Limb, math.log2(w_value)), limb_bits) + 1;
+    return @intCast(usize, @divFloor(@intCast(Limb, math.log2(w_value)), limb_bits) + 1);
 }
 
 pub fn calcToStringLimbsBufferLen(a_len: usize, base: u8) usize {
@@ -238,10 +238,7 @@ pub const Mutable = struct {
                     var i: usize = 0;
                     while (true) : (i += 1) {
                         self.limbs[i] = @truncate(Limb, w_value);
-
-                        // TODO: shift == 64 at compile-time fails. Fails on u128 limbs.
-                        w_value >>= limb_bits / 2;
-                        w_value >>= limb_bits / 2;
+                        w_value >>= limb_bits;
 
                         if (w_value == 0) break;
                     }
@@ -258,9 +255,7 @@ pub const Mutable = struct {
                     comptime var i = 0;
                     inline while (true) : (i += 1) {
                         self.limbs[i] = w_value & mask;
-
-                        w_value >>= limb_bits / 2;
-                        w_value >>= limb_bits / 2;
+                        w_value >>= limb_bits;
 
                         if (w_value == 0) break;
                     }


### PR DESCRIPTION
Underlying fix should have been https://github.com/ziglang/zig/commit/d7b029995c8ac678598de39aa106076dca232902.

u128 limb sizes are still not fully tested as we are missing compiler-rt support (__divei4, __modei4 on x86_64). Should be no zig blockers so the assertion has been removed.