### PR TITLE
langref, tools: rename --single-threaded to -fsingle-threaded

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -9604,7 +9604,7 @@ pub fn build(b: *std.Build) void {
       {#header_close#}
 
       {#header_open|Single Threaded Builds#}
-      <p>Zig has a compile option <kbd>--single-threaded</kbd> which has the following effects:</p>
+      <p>Zig has a compile option <kbd>-fsingle-threaded</kbd> which has the following effects:</p>
       <ul>
         <li>All {#link|Thread Local Variables#} are treated as regular {#link|Container Level Variables#}.</li>
         <li>The overhead of {#link|Async Functions#} becomes equivalent to function call overhead.</li>

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -1306,7 +1306,7 @@ fn usageAndExit(file: fs.File, arg0: []const u8, code: u8) noreturn {
         \\
         \\Updates lib/std/target/<target>.zig from llvm/lib/Target/<Target>/<Target>.td .
         \\
-        \\On a less beefy system, or when debugging, compile with --single-threaded.
+        \\On a less beefy system, or when debugging, compile with -fsingle-threaded.
         \\
     , .{arg0}) catch std.process.exit(1);
     std.process.exit(code);


### PR DESCRIPTION
Commit 40f5e5dfc60e removed the `--single-threaded` option, but didn't update all mentions of it.

```console
$ zig version
0.11.0-dev.1568+c9b957c93
$ zig build-exe --help | grep single
  -fsingle-threaded         Code assumes there is only one thread
  -fno-single-threaded      Code may not assume there is only one thread
$ zig build-exe --single-threaded foo.zig
error: unrecognized parameter: '--single-threaded'
```