### PR TITLE
mark deprecated assumeSentinel as pub

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -332,7 +332,7 @@ pub fn Sentinel(comptime T: type, comptime sentinel_val: Elem(T)) type {
     @compileError("Unable to derive a sentinel pointer type from " ++ @typeName(T));
 }
 
-const assumeSentinel = @compileError("This function has been removed, consider using std.mem.sliceTo() or if needed a @ptrCast()");
+pub const assumeSentinel = @compileError("This function has been removed, consider using std.mem.sliceTo() or if needed a @ptrCast()");
 
 pub fn containerLayout(comptime T: type) Type.ContainerLayout {
     return switch (@typeInfo(T)) {


### PR DESCRIPTION
assumeSentinel was removed and replaced with a compileError, but it's not pub, so the error message indicates it's private rather than providing the compileError message.