### PR TITLE
std.Build: enhancements to ConfigHeaderStep

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -598,13 +598,17 @@ pub fn addSystemCommand(self: *Build, argv: []const []const u8) *RunStep {
     return run_step;
 }
 
+/// Using the `values` provided, produces a C header file, possibly based on a
+/// template input file (e.g. config.h.in).
+/// When an input template file is provided, this function will fail the build
+/// when an option not found in the input file is provided in `values`, and
+/// when an option found in the input file is missing from `values`.
 pub fn addConfigHeader(
     b: *Build,
-    source: FileSource,
-    style: ConfigHeaderStep.Style,
+    options: ConfigHeaderStep.Options,
     values: anytype,
 ) *ConfigHeaderStep {
-    const config_header_step = ConfigHeaderStep.create(b, source, style);
+    const config_header_step = ConfigHeaderStep.create(b, options);
     config_header_step.addValues(values);
     return config_header_step;
 }

--- a/lib/std/Build/CompileStep.zig
+++ b/lib/std/Build/CompileStep.zig
@@ -442,10 +442,24 @@ pub fn installHeader(a: *CompileStep, src_path: []const u8, dest_rel_path: []con
     a.installed_headers.append(&install_file.step) catch @panic("OOM");
 }
 
-pub fn installConfigHeader(a: *CompileStep, config_header: *ConfigHeaderStep) void {
-    const install_file = a.builder.addInstallFileWithDir(config_header.getOutputSource(), .header, config_header.output_path);
-    a.builder.getInstallStep().dependOn(&install_file.step);
-    a.installed_headers.append(&install_file.step) catch unreachable;
+pub const InstallConfigHeaderOptions = struct {
+    install_dir: InstallDir = .header,
+    dest_rel_path: ?[]const u8 = null,
+};
+
+pub fn installConfigHeader(
+    cs: *CompileStep,
+    config_header: *ConfigHeaderStep,
+    options: InstallConfigHeaderOptions,
+) void {
+    const dest_rel_path = options.dest_rel_path orelse config_header.include_path;
+    const install_file = cs.builder.addInstallFileWithDir(
+        .{ .generated = &config_header.output_file },
+        options.install_dir,
+        dest_rel_path,
+    );
+    cs.builder.getInstallStep().dependOn(&install_file.step);
+    cs.installed_headers.append(&install_file.step) catch @panic("OOM");
 }
 
 pub fn installHeadersDirectory(
@@ -1628,8 +1642,9 @@ fn make(step: *Step) !void {
                 }
             },
             .config_header_step => |config_header| {
-                try zig_args.append("-I");
-                try zig_args.append(config_header.output_dir);
+                const full_file_path = config_header.output_file.path.?;
+                const header_dir_path = full_file_path[0 .. full_file_path.len - config_header.include_path.len];
+                try zig_args.appendSlice(&.{ "-I", header_dir_path });
             },
         }
     }

--- a/lib/std/Build/CompileStep.zig
+++ b/lib/std/Build/CompileStep.zig
@@ -442,6 +442,12 @@ pub fn installHeader(a: *CompileStep, src_path: []const u8, dest_rel_path: []con
     a.installed_headers.append(&install_file.step) catch @panic("OOM");
 }
 
+pub fn installConfigHeader(a: *CompileStep, config_header: *ConfigHeaderStep) void {
+    const install_file = a.builder.addInstallFileWithDir(config_header.getOutputSource(), .header, config_header.output_path);
+    a.builder.getInstallStep().dependOn(&install_file.step);
+    a.installed_headers.append(&install_file.step) catch unreachable;
+}
+
 pub fn installHeadersDirectory(
     a: *CompileStep,
     src_dir_path: []const u8,

--- a/lib/std/Build/ConfigHeaderStep.zig
+++ b/lib/std/Build/ConfigHeaderStep.zig
@@ -11,6 +11,8 @@ pub const Style = enum {
     /// The configure format supported by CMake. It uses `@@FOO@@` and
     /// `#cmakedefine` for template substitution.
     cmake,
+    /// Generate a c header from scratch with the values passed.
+    generated,
 };
 
 pub const Value = union(enum) {
@@ -27,9 +29,12 @@ builder: *std.Build,
 source: std.Build.FileSource,
 style: Style,
 values: std.StringHashMap(Value),
+gen_keys: std.ArrayList([]const u8),
+gen_values: std.ArrayList(Value),
 max_bytes: usize = 2 * 1024 * 1024,
 output_dir: []const u8,
-output_basename: []const u8,
+output_path: []const u8,
+output_gen: std.build.GeneratedFile,
 
 pub fn create(builder: *std.Build, source: std.Build.FileSource, style: Style) *ConfigHeaderStep {
     const self = builder.allocator.create(ConfigHeaderStep) catch @panic("OOM");
@@ -40,19 +45,34 @@ pub fn create(builder: *std.Build, source: std.Build.FileSource, style: Style) *
         .source = source,
         .style = style,
         .values = std.StringHashMap(Value).init(builder.allocator),
+        .gen_keys = std.ArrayList([]const u8).init(builder.allocator),
+        .gen_values = std.ArrayList(Value).init(builder.allocator),
         .output_dir = undefined,
-        .output_basename = "config.h",
+        .output_path = "config.h",
+        .output_gen = std.build.GeneratedFile{ .step = &self.step },
     };
+
     switch (source) {
         .path => |p| {
-            const basename = std.fs.path.basename(p);
-            if (std.mem.endsWith(u8, basename, ".h.in")) {
-                self.output_basename = basename[0 .. basename.len - 3];
+            self.output_path = p;
+
+            switch (style) {
+                .autoconf, .cmake => {
+                    if (std.mem.endsWith(u8, p, ".h.in")) {
+                        self.output_path = p[0 .. p.len - 3];
+                    }
+                },
+                else => {},
             }
         },
         else => {},
     }
+
     return self;
+}
+
+pub fn getOutputSource(self: *ConfigHeaderStep) std.build.FileSource {
+    return std.build.FileSource{ .generated = &self.output_gen };
 }
 
 pub fn addValues(self: *ConfigHeaderStep, values: anytype) void {
@@ -61,43 +81,36 @@ pub fn addValues(self: *ConfigHeaderStep, values: anytype) void {
 
 fn addValuesInner(self: *ConfigHeaderStep, values: anytype) !void {
     inline for (@typeInfo(@TypeOf(values)).Struct.fields) |field| {
-        try putValue(self, field.name, field.type, @field(values, field.name));
+        const val = try getValue(self, field.type, @field(values, field.name));
+        switch (self.style) {
+            .generated => {
+                try self.gen_keys.append(field.name);
+                try self.gen_values.append(val);
+            },
+            else => try self.values.put(field.name, val),
+        }
     }
 }
 
-fn putValue(self: *ConfigHeaderStep, field_name: []const u8, comptime T: type, v: T) !void {
+fn getValue(self: *ConfigHeaderStep, comptime T: type, v: T) !Value {
     switch (@typeInfo(T)) {
-        .Null => {
-            try self.values.put(field_name, .undef);
-        },
-        .Void => {
-            try self.values.put(field_name, .defined);
-        },
-        .Bool => {
-            try self.values.put(field_name, .{ .boolean = v });
-        },
-        .Int => {
-            try self.values.put(field_name, .{ .int = v });
-        },
-        .ComptimeInt => {
-            try self.values.put(field_name, .{ .int = v });
-        },
-        .EnumLiteral => {
-            try self.values.put(field_name, .{ .ident = @tagName(v) });
-        },
+        .Null => return .undef,
+        .Void => return .defined,
+        .Bool => return .{ .boolean = v },
+        .Int, .ComptimeInt => return .{ .int = v },
+        .EnumLiteral => return .{ .ident = @tagName(v) },
         .Optional => {
             if (v) |x| {
-                return putValue(self, field_name, @TypeOf(x), x);
+                return getValue(self, @TypeOf(x), x);
             } else {
-                try self.values.put(field_name, .undef);
+                return .undef;
             }
         },
         .Pointer => |ptr| {
             switch (@typeInfo(ptr.child)) {
                 .Array => |array| {
                     if (ptr.size == .One and array.child == u8) {
-                        try self.values.put(field_name, .{ .string = v });
-                        return;
+                        return .{ .string = v };
                     }
                 },
                 else => {},
@@ -113,7 +126,10 @@ fn make(step: *Step) !void {
     const self = @fieldParentPtr(ConfigHeaderStep, "step", step);
     const gpa = self.builder.allocator;
     const src_path = self.source.getPath(self.builder);
-    const contents = try std.fs.cwd().readFileAlloc(gpa, src_path, self.max_bytes);
+    const contents = switch (self.style) {
+        .generated => src_path,
+        else => try std.fs.cwd().readFileAlloc(gpa, src_path, self.max_bytes),
+    };
 
     // The cache is used here not really as a way to speed things up - because writing
     // the data to a file would probably be very fast - but as a way to find a canonical
@@ -146,8 +162,21 @@ fn make(step: *Step) !void {
     self.output_dir = try std.fs.path.join(gpa, &[_][]const u8{
         self.builder.cache_root, "o", &hash_basename,
     });
-    var dir = std.fs.cwd().makeOpenPath(self.output_dir, .{}) catch |err| {
-        std.debug.print("unable to make path {s}: {s}\n", .{ self.output_dir, @errorName(err) });
+
+    // If output_path has directory parts, deal with them.  Example:
+    // output_dir is zig-cache/o/HASH
+    // output_path is libavutil/avconfig.h
+    // We want to open directory zig-cache/o/HASH/libavutil/
+    // but keep output_dir as zig-cache/o/HASH for -I include
+    var outdir = self.output_dir;
+    var outpath = self.output_path;
+    if (std.fs.path.dirname(self.output_path)) |d| {
+        outdir = try std.fs.path.join(gpa, &[_][]const u8{ self.output_dir, d });
+        outpath = std.fs.path.basename(self.output_path);
+    }
+
+    var dir = std.fs.cwd().makeOpenPath(outdir, .{}) catch |err| {
+        std.debug.print("unable to make path {s}: {s}\n", .{ outdir, @errorName(err) });
         return err;
     };
     defer dir.close();
@@ -164,9 +193,12 @@ fn make(step: *Step) !void {
     switch (self.style) {
         .autoconf => try render_autoconf(contents, &output, &values_copy, src_path),
         .cmake => try render_cmake(contents, &output, &values_copy, src_path),
+        .generated => try render_generated(gpa, &output, &self.gen_keys, &self.gen_values, self.source.getDisplayName()),
     }
 
-    try dir.writeFile(self.output_basename, output.items);
+    try dir.writeFile(outpath, output.items);
+
+    self.output_gen.path = try std.fs.path.join(gpa, &[_][]const u8{ self.output_dir, self.output_path });
 }
 
 fn render_autoconf(
@@ -296,4 +328,32 @@ fn renderValue(output: *std.ArrayList(u8), name: []const u8, value: Value) !void
             try output.writer().print("#define {s} \"{}\"\n", .{ name, std.zig.fmtEscapes(string) });
         },
     }
+}
+
+fn render_generated(
+    gpa: std.mem.Allocator,
+    output: *std.ArrayList(u8),
+    keys: *std.ArrayList([]const u8),
+    values: *std.ArrayList(Value),
+    src_path: []const u8,
+) !void {
+    var include_guard = try gpa.dupe(u8, src_path);
+    defer gpa.free(include_guard);
+
+    for (include_guard) |*ch| {
+        if (ch.* == '.' or std.fs.path.isSep(ch.*)) {
+            ch.* = '_';
+        } else {
+            ch.* = std.ascii.toUpper(ch.*);
+        }
+    }
+
+    try output.writer().print("#ifndef {s}\n", .{include_guard});
+    try output.writer().print("#define {s}\n", .{include_guard});
+
+    for (keys.items) |k, i| {
+        try renderValue(output, k, values.items[i]);
+    }
+
+    try output.writer().print("#endif /* {s} */\n", .{include_guard});
 }

--- a/lib/std/Build/TranslateCStep.zig
+++ b/lib/std/Build/TranslateCStep.zig
@@ -15,7 +15,6 @@ builder: *std.Build,
 source: std.Build.FileSource,
 include_dirs: std.ArrayList([]const u8),
 c_macros: std.ArrayList([]const u8),
-output_dir: ?[]const u8,
 out_basename: []const u8,
 target: CrossTarget,
 optimize: std.builtin.OptimizeMode,
@@ -36,7 +35,6 @@ pub fn create(builder: *std.Build, options: Options) *TranslateCStep {
         .source = source,
         .include_dirs = std.ArrayList([]const u8).init(builder.allocator),
         .c_macros = std.ArrayList([]const u8).init(builder.allocator),
-        .output_dir = null,
         .out_basename = undefined,
         .target = options.target,
         .optimize = options.optimize,
@@ -122,15 +120,10 @@ fn make(step: *Step) !void {
     const output_path = mem.trimRight(u8, output_path_nl, "\r\n");
 
     self.out_basename = fs.path.basename(output_path);
-    if (self.output_dir) |output_dir| {
-        const full_dest = try fs.path.join(self.builder.allocator, &[_][]const u8{ output_dir, self.out_basename });
-        try self.builder.updateFile(output_path, full_dest);
-    } else {
-        self.output_dir = fs.path.dirname(output_path).?;
-    }
+    const output_dir = fs.path.dirname(output_path).?;
 
     self.output_file.path = try fs.path.join(
         self.builder.allocator,
-        &[_][]const u8{ self.output_dir.?, self.out_basename },
+        &[_][]const u8{ output_dir, self.out_basename },
     );
 }


### PR DESCRIPTION
This is a fork of #14382 with my own take on the problem.

Breaking API change to std.Build.addConfigHeader. It now uses an options
struct.

Introduce std.Build.CompileStep.installConfigHeader which also accepts
an options struct. This is used to add a generated config file into the
set of installed header files for a particular compilation artifact.

std.Build.ConfigHeaderStep now additionally supports a "blank" style
where a header is generated from scratch. It no longer exposes
`output_dir`. Instead it exposes a FileSource via `output_file`.
It now additionally accepts an `include_path` option which affects the
include path of CompileStep when using the `#include` directive, as well
as affecting the default installation subdirectory for header
installation purposes.

The hash used for the directory to store the generated config file now
includes the contents of the generated file. This fixes possible race
conditions when generating multiple header files simultaneously.

The values hash table is now an array hash map, to preserve order for
the "blank" use case.

I also took the opportunity to remove output_dir from TranslateCStep and
WriteFileStep. This is technically a breaking change, but it was always
naughty to access these fields.

[example usage](https://github.com/andrewrk/ffmpeg/commit/066c1faa068a210a51728b039d6cae8c580533bc)