### PR TITLE
add BoundedArrayAligned

### DIFF
--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -9,6 +9,7 @@ pub const AutoArrayHashMapUnmanaged = array_hash_map.AutoArrayHashMapUnmanaged;
 pub const AutoHashMap = hash_map.AutoHashMap;
 pub const AutoHashMapUnmanaged = hash_map.AutoHashMapUnmanaged;
 pub const BoundedArray = @import("bounded_array.zig").BoundedArray;
+pub const BoundedArrayAligned = @import("bounded_array.zig").BoundedArrayAligned;
 pub const Build = @import("Build.zig");
 pub const BufMap = @import("buf_map.zig").BufMap;
 pub const BufSet = @import("buf_set.zig").BufSet;


### PR DESCRIPTION
This is useful for creating byte buffers of actually-different-things.
Copied the argument order from `Allocator.alignedAlloc`

I noted that `ArrayListAligned` is going out of it's way to not set the
alignment at comptime when it is not specified. However, I was not able
to do that the same way here, and good people on IRC, @ifreund in
particular (thanks!) assured me that


```zig
[N]T align(@alignOf(T))
```

is equivalent to

```zig
[N]T
```