### PR TITLE
macho: fix incorrect representation of encodings count per page

### DIFF
--- a/src/link/MachO/UnwindInfo.zig
+++ b/src/link/MachO/UnwindInfo.zig
@@ -68,7 +68,7 @@ const Page = struct {
     start: RecordIndex,
     count: u16,
     page_encodings: [max_compact_encodings]RecordIndex = undefined,
-    page_encodings_count: u8 = 0,
+    page_encodings_count: u9 = 0,
 
     fn appendPageEncoding(page: *Page, record_id: RecordIndex) void {
         assert(page.page_encodings_count <= max_compact_encodings);
@@ -81,13 +81,13 @@ const Page = struct {
         info: *const UnwindInfo,
         enc: macho.compact_unwind_encoding_t,
     ) ?u8 {
-        comptime var index: u8 = 0;
+        comptime var index: u9 = 0;
         inline while (index < max_compact_encodings) : (index += 1) {
             if (index >= page.page_encodings_count) return null;
             const record_id = page.page_encodings[index];
             const record = info.records.items[record_id];
             if (record.compactUnwindEncoding == enc) {
-                return index;
+                return @intCast(u8, index);
             }
         }
         return null;


### PR DESCRIPTION
There can be a maximum of 256 compact encodings per page in compact unwind info, and we were using `u8` to represent the count which is insufficient. This commit bumps it to `u9`.

Fixes https://github.com/ziglang/zig/issues/14584