### PR TITLE
don't tokenize an invalid string literal

### DIFF
--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -739,6 +739,7 @@ pub const Tokenizer = struct {
                     },
                     0 => {
                         if (self.index == self.buffer.len) {
+                            result.tag = .invalid;
                             break;
                         } else {
                             self.checkLiteralCharacter();
@@ -1326,7 +1327,7 @@ test "newline in string literal" {
     try testTokenize(
         \\"
         \\"
-    , &.{ .invalid, .string_literal });
+    , &.{ .invalid, .invalid });
 }
 
 test "code point literal with unicode escapes" {


### PR DESCRIPTION
formatting the following file would previously fail:
```zig
@"
```

```
thread 35824 panic: reached unreachable code
/opt/zig/0.11.0-dev.1580+a5b34a61a/files/lib/std/debug.zig:281:14: 0x3318cc in assert (zls)
    if (!ok) unreachable; // assertion failure
             ^
/opt/zig/0.11.0-dev.1580+a5b34a61a/files/lib/std/zig/render.zig:2453:18: 0x655e01 in renderIdentifier (zls)
    assert(lexeme.len >= 3);
                 ^
/opt/zig/0.11.0-dev.1580+a5b34a61a/files/lib/std/zig/render.zig:210:36: 0x64f961 in renderExpression (zls)
            return renderIdentifier(ais, tree, token_index, space, .preserve_when_shadowing);
                                   ^
/opt/zig/0.11.0-dev.1580+a5b34a61a/files/lib/std/zig/render.zig:2343:32: 0x6cf270 in renderExpressionComma (zls)
        return renderExpression(gpa, ais, tree, node, space);
                               ^
/opt/zig/0.11.0-dev.1580+a5b34a61a/files/lib/std/zig/render.zig:1203:67: 0x658a80 in renderContainerField (zls)
            return renderExpressionComma(gpa, ais, tree, field.ast.type_expr, space); // type
                                                                  ^
/opt/zig/0.11.0-dev.1580+a5b34a61a/files/lib/std/zig/render.zig:183:85: 0x6009a1 in renderMember (zls)
        => return renderContainerField(gpa, ais, tree, tree.fullContainerField(decl).?, is_tuple, space),
                                                                                    ^
/opt/zig/0.11.0-dev.1580+a5b34a61a/files/lib/std/zig/render.zig:51:45: 0x5b3e0d in renderMembers (zls)
    try renderMember(gpa, ais, tree, members[0], is_tuple, .newline);
                                            ^
/opt/zig/0.11.0-dev.1580+a5b34a61a/files/lib/std/zig/render.zig:33:66: 0x541364 in renderTree (zls)
    try renderMembers(buffer.allocator, ais, tree, tree.rootDecls());
                                                                 ^
/opt/zig/0.11.0-dev.1580+a5b34a61a/files/lib/std/zig/Ast.zig:119:46: 0x4d296f in renderToArrayList (zls)
    return @import("./render.zig").renderTree(buffer, tree);
                                             ^
/opt/zig/0.11.0-dev.1580+a5b34a61a/files/lib/std/zig/Ast.zig:114:31: 0x455f0d in render (zls)
    try tree.renderToArrayList(&buffer);
                              ^
```