### PR TITLE
Make the Connection header follow conventions

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -907,10 +907,11 @@ pub fn request(client: *Client, uri: Uri, headers: Request.Headers, options: Req
         try h.appendSlice(@tagName(headers.version));
         try h.appendSlice("\r\nHost: ");
         try h.appendSlice(host);
-        try h.appendSlice(switch (headers.version) {
-            .@"HTTP/1.0" => "\r\nConnection: close\r\n\r\n",
-            .@"HTTP/1.1" => "\r\nConnection: keep-alive\r\n\r\n",
-        });
+        switch (headers.version) {
+            .@"HTTP/1.0" => try h.appendSlice("\r\nConnection: close\r\n\r\n"),
+            .@"HTTP/1.1" => try h.appendSlice("\r\nConnection: keep-alive\r\n\r\n"),
+            else => {},
+        }
         const header_bytes = h.slice();
         try req.connection.writeAll(header_bytes);
     }

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -907,8 +907,10 @@ pub fn request(client: *Client, uri: Uri, headers: Request.Headers, options: Req
         try h.appendSlice(@tagName(headers.version));
         try h.appendSlice("\r\nHost: ");
         try h.appendSlice(host);
-        try h.appendSlice("\r\nConnection: close\r\n\r\n");
-
+        try h.appendSlice(switch (headers.version) {
+            .@"HTTP/1.0" => "\r\nConnection: close\r\n\r\n",
+            .@"HTTP/1.1" => "\r\nConnection: keep-alive\r\n\r\n",
+        });
         const header_bytes = h.slice();
         try req.connection.writeAll(header_bytes);
     }

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -910,7 +910,6 @@ pub fn request(client: *Client, uri: Uri, headers: Request.Headers, options: Req
         switch (headers.version) {
             .@"HTTP/1.0" => try h.appendSlice("\r\nConnection: close\r\n\r\n"),
             .@"HTTP/1.1" => try h.appendSlice("\r\nConnection: keep-alive\r\n\r\n"),
-            else => {},
         }
         const header_bytes = h.slice();
         try req.connection.writeAll(header_bytes);


### PR DESCRIPTION
As per [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection#directives):

> #### `close`
>   Indicates that either the client or the server would like to close the connection. This is the default on HTTP/1.0 requests.
> 
> #### any comma-separated list of HTTP headers [Usually `keep-alive` only]
>   Indicates that the client would like to keep the connection open. Keeping a connection open is the default on HTTP/1.1 requests. The list of headers are the name of the header to be removed by the first non-transparent proxy or cache in-between: these headers define the connection between the emitter and the first entity, not the destination node. 