### PR TITLE
Don't assume dynamic linking is required when there are any system libs defined

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1298,8 +1298,6 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
                 break :dl true;
             }
             const any_dyn_libs: bool = x: {
-                if (options.system_lib_names.len != 0)
-                    break :x true;
                 for (options.link_objects) |obj| {
                     switch (classifyFileExt(obj.path)) {
                         .shared_library => break :x true,


### PR DESCRIPTION
On a musl system containing both a static libc and other static system libs, this assumption breaks attempts to produce a static executable.

Example:

```zig
const std = @import("std");

pub fn build(b: *std.build.Builder) void {
    const target = b.standardTargetOptions(.{});
    const optimize = b.standardOptimizeOption(.{});

    const exe = b.addExecutable(.{
        .name = "foo",
        .target = target,
        .optimize = optimize,
        // .linkage = .static,
    });
    exe.addCSourceFiles(&.{
        "example.c",
    }, &.{
        "-Wall",
    });
    exe.linkLibC();
    exe.linkSystemLibrary("crypto");
    exe.linkSystemLibrary("curl");
    exe.linkSystemLibrary("ssl");
    exe.linkSystemLibrary("z");
    exe.install();
}
```

The `example.c` source file is the one found at
https://curl.se/libcurl/c/simple.html. The system has libcrypto.a, libcurl.a, libssl.a and libz.a, all without dynamic counterparts. The above builds correctly but produces a dynamic executable.

Uncommenting the `.linkage` line in `build.zig` to force a static binary produces the following error:

```
/usr/bin/zig build-exe -cflags -Wall -- /home/jeremy/curl-test/example.c -lcrypto -lcurl -lssl -lz -lc --cache-dir /home/jeremy/curl-test/zig-cache --global-cache-dir /home/jeremy/.cache/zig --name foo -static --enable-cache
error: unable to create compilation: UnableToStaticLink
```

Rebuilding zig with this check removed allows the build and link to succeed, producing a static binary.