### PR TITLE
compiler: enable caching for -femit-h

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1524,6 +1524,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
         cache.hash.add(options.machine_code_model);
         cache.hash.addOptionalEmitLoc(options.emit_bin);
         cache.hash.addOptionalEmitLoc(options.emit_implib);
+        cache.hash.addOptionalEmitLoc(options.emit_h);
         cache.hash.addBytes(options.root_name);
         if (options.target.os.tag == .wasi) cache.hash.add(wasi_exec_model);
         // TODO audit this and make sure everything is in it

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -484,7 +484,7 @@ pub fn flushEmitH(module: *Module) !void {
         }
     }
 
-    const directory = emit_h.loc.directory orelse module.comp.local_cache_directory;
+    const directory = emit_h.loc.directory orelse module.zig_cache_artifact_directory;
     const file = try directory.handle.createFile(emit_h.loc.basename, .{
         // We set the end position explicitly below; by not truncating the file, we possibly
         // make it easier on the file system by doing 1 reallocation instead of two.


### PR DESCRIPTION
As documented in #14416, when using `zig build-lib -femit-h` with caching enabled, if the generated header file is removed, it will not be generated again, unless the library source code is modified.

For consistent builds with `zig build`, assume that the file generated by -femit using the default path is an artificact, and update src/main.zig to enable caching.

Update the flushEmitH function in src/link/C.zig to use the zig_cache_artifact_directory instead of the incorrect local_cache_directory.

Updates #14416