### PR TITLE
compiler_rt: __divmodti4 for libgcc symbol compatibility

### DIFF
--- a/lib/compiler_rt/README.md
+++ b/lib/compiler_rt/README.md
@@ -114,7 +114,7 @@ Integer and Float Operations
 | ✓ | __udivmodti4       | u128 | u128 | u128 | ..                             |
 | ✓ | __divmodsi4        | i32  | i32  | i32  | `a / b, rem.* = a % b`         |
 | ✓ | __divmoddi4        | i64  | i64  | i64  | ..                             |
-| ✗ | __divmodti4        | i128 | i128 | i128 | .. [^libgcc_compat]            |
+| ✓ | __divmodti4        | i128 | i128 | i128 | .. [^libgcc_compat]            |
 |   |                    |      |      |      | **Integer Arithmetic with Trapping Overflow**|
 | ✓ | __absvsi2          | i32  | i32  | i32  | abs(a)                         |
 | ✓ | __absvdi2          | i64  | i64  | i64  | ..                             |

--- a/tools/gen_stubs.zig
+++ b/tools/gen_stubs.zig
@@ -664,6 +664,7 @@ const blacklisted_symbols = [_][]const u8{
     "__divkf3",
     "__divmoddi4",
     "__divmodsi4",
+    "__divmodti4",
     "__divsf3",
     "__divsi3",
     "__divtf3",


### PR DESCRIPTION
- Copy and adjust __divmodsi4 tests for __divmoddi4 and __divmodti4.
- Assuming d = a/b does not overflow (MIN/-1) or uses div by 0, then tmp = (d * b) = (a/b * b) = a does not overflow. => Remove wraparound for remainder in applicable routines.