### PR TITLE
compiler_rt: restructure compiler_rt.zig according to README.md

### DIFF
--- a/lib/compiler_rt.zig
+++ b/lib/compiler_rt.zig
@@ -3,64 +3,35 @@ const builtin = @import("builtin");
 pub const panic = @import("compiler_rt/common.zig").panic;
 
 comptime {
-    _ = @import("compiler_rt/addf3.zig");
-    _ = @import("compiler_rt/addhf3.zig");
-    _ = @import("compiler_rt/addsf3.zig");
-    _ = @import("compiler_rt/adddf3.zig");
-    _ = @import("compiler_rt/addtf3.zig");
-    _ = @import("compiler_rt/addxf3.zig");
+    // Integer routines
+    _ = @import("compiler_rt/count0bits.zig");
+    _ = @import("compiler_rt/parity.zig");
+    _ = @import("compiler_rt/popcount.zig");
+    _ = @import("compiler_rt/bswap.zig");
+    _ = @import("compiler_rt/cmp.zig");
 
-    _ = @import("compiler_rt/subhf3.zig");
-    _ = @import("compiler_rt/subsf3.zig");
-    _ = @import("compiler_rt/subdf3.zig");
-    _ = @import("compiler_rt/subtf3.zig");
-    _ = @import("compiler_rt/subxf3.zig");
+    _ = @import("compiler_rt/shift.zig");
+    _ = @import("compiler_rt/negXi2.zig");
+    _ = @import("compiler_rt/int.zig");
+    _ = @import("compiler_rt/muldi3.zig");
+    _ = @import("compiler_rt/multi3.zig");
+    _ = @import("compiler_rt/divti3.zig");
+    _ = @import("compiler_rt/udivti3.zig");
+    _ = @import("compiler_rt/modti3.zig");
+    _ = @import("compiler_rt/umodti3.zig");
 
-    _ = @import("compiler_rt/mulf3.zig");
-    _ = @import("compiler_rt/mulhf3.zig");
-    _ = @import("compiler_rt/mulsf3.zig");
-    _ = @import("compiler_rt/muldf3.zig");
-    _ = @import("compiler_rt/multf3.zig");
-    _ = @import("compiler_rt/mulxf3.zig");
+    _ = @import("compiler_rt/absv.zig");
+    _ = @import("compiler_rt/absvsi2.zig");
+    _ = @import("compiler_rt/absvdi2.zig");
+    _ = @import("compiler_rt/absvti2.zig");
+    _ = @import("compiler_rt/negv.zig");
 
-    _ = @import("compiler_rt/powiXf2.zig");
-    _ = @import("compiler_rt/mulc3.zig");
-    _ = @import("compiler_rt/mulhc3.zig");
-    _ = @import("compiler_rt/mulsc3.zig");
-    _ = @import("compiler_rt/muldc3.zig");
-    _ = @import("compiler_rt/mulxc3.zig");
-    _ = @import("compiler_rt/multc3.zig");
+    _ = @import("compiler_rt/addo.zig");
+    _ = @import("compiler_rt/subo.zig");
+    _ = @import("compiler_rt/mulo.zig");
 
-    _ = @import("compiler_rt/divc3.zig");
-    _ = @import("compiler_rt/divhc3.zig");
-    _ = @import("compiler_rt/divsc3.zig");
-    _ = @import("compiler_rt/divdc3.zig");
-    _ = @import("compiler_rt/divxc3.zig");
-    _ = @import("compiler_rt/divtc3.zig");
-
-    _ = @import("compiler_rt/neghf2.zig");
-    _ = @import("compiler_rt/negsf2.zig");
-    _ = @import("compiler_rt/negdf2.zig");
-    _ = @import("compiler_rt/negtf2.zig");
-    _ = @import("compiler_rt/negxf2.zig");
-
-    _ = @import("compiler_rt/comparef.zig");
-    _ = @import("compiler_rt/cmphf2.zig");
-    _ = @import("compiler_rt/cmpsf2.zig");
-    _ = @import("compiler_rt/cmpdf2.zig");
-    _ = @import("compiler_rt/cmptf2.zig");
-    _ = @import("compiler_rt/cmpxf2.zig");
-    _ = @import("compiler_rt/gehf2.zig");
-    _ = @import("compiler_rt/gesf2.zig");
-    _ = @import("compiler_rt/gedf2.zig");
-    _ = @import("compiler_rt/gexf2.zig");
-    _ = @import("compiler_rt/getf2.zig");
-    _ = @import("compiler_rt/unordhf2.zig");
-    _ = @import("compiler_rt/unordsf2.zig");
-    _ = @import("compiler_rt/unorddf2.zig");
-    _ = @import("compiler_rt/unordxf2.zig");
-    _ = @import("compiler_rt/unordtf2.zig");
-
+    // Float routines
+    // conversion
     _ = @import("compiler_rt/extendf.zig");
     _ = @import("compiler_rt/extendhfsf2.zig");
     _ = @import("compiler_rt/extendhfdf2.zig");
@@ -84,70 +55,6 @@ comptime {
     _ = @import("compiler_rt/trunctfsf2.zig");
     _ = @import("compiler_rt/trunctfdf2.zig");
     _ = @import("compiler_rt/trunctfxf2.zig");
-
-    _ = @import("compiler_rt/divhf3.zig");
-    _ = @import("compiler_rt/divsf3.zig");
-    _ = @import("compiler_rt/divdf3.zig");
-    _ = @import("compiler_rt/divxf3.zig");
-    _ = @import("compiler_rt/divtf3.zig");
-    _ = @import("compiler_rt/sin.zig");
-    _ = @import("compiler_rt/cos.zig");
-    _ = @import("compiler_rt/sincos.zig");
-    _ = @import("compiler_rt/ceil.zig");
-    _ = @import("compiler_rt/exp.zig");
-    _ = @import("compiler_rt/exp2.zig");
-    _ = @import("compiler_rt/fabs.zig");
-    _ = @import("compiler_rt/floor.zig");
-    _ = @import("compiler_rt/fma.zig");
-    _ = @import("compiler_rt/fmax.zig");
-    _ = @import("compiler_rt/fmin.zig");
-    _ = @import("compiler_rt/fmod.zig");
-    _ = @import("compiler_rt/log.zig");
-    _ = @import("compiler_rt/log10.zig");
-    _ = @import("compiler_rt/log2.zig");
-    _ = @import("compiler_rt/round.zig");
-    _ = @import("compiler_rt/sqrt.zig");
-    _ = @import("compiler_rt/tan.zig");
-    _ = @import("compiler_rt/trunc.zig");
-    _ = @import("compiler_rt/divti3.zig");
-    _ = @import("compiler_rt/modti3.zig");
-    _ = @import("compiler_rt/multi3.zig");
-    _ = @import("compiler_rt/udivti3.zig");
-    _ = @import("compiler_rt/udivmodei4.zig");
-    _ = @import("compiler_rt/udivmodti4.zig");
-    _ = @import("compiler_rt/umodti3.zig");
-
-    _ = @import("compiler_rt/int_to_float.zig");
-    _ = @import("compiler_rt/floatsihf.zig");
-    _ = @import("compiler_rt/floatsisf.zig");
-    _ = @import("compiler_rt/floatsidf.zig");
-    _ = @import("compiler_rt/floatsitf.zig");
-    _ = @import("compiler_rt/floatsixf.zig");
-    _ = @import("compiler_rt/floatdihf.zig");
-    _ = @import("compiler_rt/floatdisf.zig");
-    _ = @import("compiler_rt/floatdidf.zig");
-    _ = @import("compiler_rt/floatditf.zig");
-    _ = @import("compiler_rt/floatdixf.zig");
-    _ = @import("compiler_rt/floattihf.zig");
-    _ = @import("compiler_rt/floattisf.zig");
-    _ = @import("compiler_rt/floattidf.zig");
-    _ = @import("compiler_rt/floattitf.zig");
-    _ = @import("compiler_rt/floattixf.zig");
-    _ = @import("compiler_rt/floatundihf.zig");
-    _ = @import("compiler_rt/floatundisf.zig");
-    _ = @import("compiler_rt/floatundidf.zig");
-    _ = @import("compiler_rt/floatunditf.zig");
-    _ = @import("compiler_rt/floatundixf.zig");
-    _ = @import("compiler_rt/floatunsihf.zig");
-    _ = @import("compiler_rt/floatunsisf.zig");
-    _ = @import("compiler_rt/floatunsidf.zig");
-    _ = @import("compiler_rt/floatunsitf.zig");
-    _ = @import("compiler_rt/floatunsixf.zig");
-    _ = @import("compiler_rt/floatuntihf.zig");
-    _ = @import("compiler_rt/floatuntisf.zig");
-    _ = @import("compiler_rt/floatuntidf.zig");
-    _ = @import("compiler_rt/floatuntitf.zig");
-    _ = @import("compiler_rt/floatuntixf.zig");
 
     _ = @import("compiler_rt/float_to_int.zig");
     _ = @import("compiler_rt/fixhfsi.zig");
@@ -181,28 +88,131 @@ comptime {
     _ = @import("compiler_rt/fixunsxfdi.zig");
     _ = @import("compiler_rt/fixunsxfti.zig");
 
-    _ = @import("compiler_rt/count0bits.zig");
-    _ = @import("compiler_rt/parity.zig");
-    _ = @import("compiler_rt/popcount.zig");
-    _ = @import("compiler_rt/bswap.zig");
-    _ = @import("compiler_rt/int.zig");
-    _ = @import("compiler_rt/shift.zig");
+    _ = @import("compiler_rt/int_to_float.zig");
+    _ = @import("compiler_rt/floatsihf.zig");
+    _ = @import("compiler_rt/floatsisf.zig");
+    _ = @import("compiler_rt/floatsidf.zig");
+    _ = @import("compiler_rt/floatsitf.zig");
+    _ = @import("compiler_rt/floatsixf.zig");
+    _ = @import("compiler_rt/floatdihf.zig");
+    _ = @import("compiler_rt/floatdisf.zig");
+    _ = @import("compiler_rt/floatdidf.zig");
+    _ = @import("compiler_rt/floatditf.zig");
+    _ = @import("compiler_rt/floatdixf.zig");
+    _ = @import("compiler_rt/floattihf.zig");
+    _ = @import("compiler_rt/floattisf.zig");
+    _ = @import("compiler_rt/floattidf.zig");
+    _ = @import("compiler_rt/floattitf.zig");
+    _ = @import("compiler_rt/floattixf.zig");
+    _ = @import("compiler_rt/floatundihf.zig");
+    _ = @import("compiler_rt/floatundisf.zig");
+    _ = @import("compiler_rt/floatundidf.zig");
+    _ = @import("compiler_rt/floatunditf.zig");
+    _ = @import("compiler_rt/floatundixf.zig");
+    _ = @import("compiler_rt/floatunsihf.zig");
+    _ = @import("compiler_rt/floatunsisf.zig");
+    _ = @import("compiler_rt/floatunsidf.zig");
+    _ = @import("compiler_rt/floatunsitf.zig");
+    _ = @import("compiler_rt/floatunsixf.zig");
+    _ = @import("compiler_rt/floatuntihf.zig");
+    _ = @import("compiler_rt/floatuntisf.zig");
+    _ = @import("compiler_rt/floatuntidf.zig");
+    _ = @import("compiler_rt/floatuntitf.zig");
+    _ = @import("compiler_rt/floatuntixf.zig");
 
-    _ = @import("compiler_rt/negXi2.zig");
+    // comparison
+    _ = @import("compiler_rt/comparef.zig");
+    _ = @import("compiler_rt/cmphf2.zig");
+    _ = @import("compiler_rt/cmpsf2.zig");
+    _ = @import("compiler_rt/cmpdf2.zig");
+    _ = @import("compiler_rt/cmptf2.zig");
+    _ = @import("compiler_rt/cmpxf2.zig");
+    _ = @import("compiler_rt/unordhf2.zig");
+    _ = @import("compiler_rt/unordsf2.zig");
+    _ = @import("compiler_rt/unorddf2.zig");
+    _ = @import("compiler_rt/unordxf2.zig");
+    _ = @import("compiler_rt/unordtf2.zig");
+    _ = @import("compiler_rt/gehf2.zig");
+    _ = @import("compiler_rt/gesf2.zig");
+    _ = @import("compiler_rt/gedf2.zig");
+    _ = @import("compiler_rt/gexf2.zig");
+    _ = @import("compiler_rt/getf2.zig");
 
-    _ = @import("compiler_rt/muldi3.zig");
+    // arithmetic
+    _ = @import("compiler_rt/addf3.zig");
+    _ = @import("compiler_rt/addhf3.zig");
+    _ = @import("compiler_rt/addsf3.zig");
+    _ = @import("compiler_rt/adddf3.zig");
+    _ = @import("compiler_rt/addtf3.zig");
+    _ = @import("compiler_rt/addxf3.zig");
 
-    _ = @import("compiler_rt/absv.zig");
-    _ = @import("compiler_rt/absvsi2.zig");
-    _ = @import("compiler_rt/absvdi2.zig");
-    _ = @import("compiler_rt/absvti2.zig");
+    _ = @import("compiler_rt/subhf3.zig");
+    _ = @import("compiler_rt/subsf3.zig");
+    _ = @import("compiler_rt/subdf3.zig");
+    _ = @import("compiler_rt/subtf3.zig");
+    _ = @import("compiler_rt/subxf3.zig");
 
-    _ = @import("compiler_rt/negv.zig");
-    _ = @import("compiler_rt/addo.zig");
-    _ = @import("compiler_rt/subo.zig");
-    _ = @import("compiler_rt/mulo.zig");
-    _ = @import("compiler_rt/cmp.zig");
+    _ = @import("compiler_rt/mulf3.zig");
+    _ = @import("compiler_rt/mulhf3.zig");
+    _ = @import("compiler_rt/mulsf3.zig");
+    _ = @import("compiler_rt/muldf3.zig");
+    _ = @import("compiler_rt/multf3.zig");
+    _ = @import("compiler_rt/mulxf3.zig");
 
+    _ = @import("compiler_rt/divhf3.zig");
+    _ = @import("compiler_rt/divsf3.zig");
+    _ = @import("compiler_rt/divdf3.zig");
+    _ = @import("compiler_rt/divxf3.zig");
+    _ = @import("compiler_rt/divtf3.zig");
+
+    _ = @import("compiler_rt/neghf2.zig");
+    _ = @import("compiler_rt/negsf2.zig");
+    _ = @import("compiler_rt/negdf2.zig");
+    _ = @import("compiler_rt/negtf2.zig");
+    _ = @import("compiler_rt/negxf2.zig");
+
+    // other
+    _ = @import("compiler_rt/powiXf2.zig");
+    _ = @import("compiler_rt/mulc3.zig");
+    _ = @import("compiler_rt/mulhc3.zig");
+    _ = @import("compiler_rt/mulsc3.zig");
+    _ = @import("compiler_rt/muldc3.zig");
+    _ = @import("compiler_rt/mulxc3.zig");
+    _ = @import("compiler_rt/multc3.zig");
+
+    _ = @import("compiler_rt/divc3.zig");
+    _ = @import("compiler_rt/divhc3.zig");
+    _ = @import("compiler_rt/divsc3.zig");
+    _ = @import("compiler_rt/divdc3.zig");
+    _ = @import("compiler_rt/divxc3.zig");
+    _ = @import("compiler_rt/divtc3.zig");
+
+    // Math routines. Alphabetically sorted.
+    _ = @import("compiler_rt/ceil.zig");
+    _ = @import("compiler_rt/cos.zig");
+    _ = @import("compiler_rt/exp.zig");
+    _ = @import("compiler_rt/exp2.zig");
+    _ = @import("compiler_rt/fabs.zig");
+    _ = @import("compiler_rt/floor.zig");
+    _ = @import("compiler_rt/fma.zig");
+    _ = @import("compiler_rt/fmax.zig");
+    _ = @import("compiler_rt/fmin.zig");
+    _ = @import("compiler_rt/fmod.zig");
+    _ = @import("compiler_rt/log.zig");
+    _ = @import("compiler_rt/log10.zig");
+    _ = @import("compiler_rt/log2.zig");
+    _ = @import("compiler_rt/round.zig");
+    _ = @import("compiler_rt/sin.zig");
+    _ = @import("compiler_rt/sincos.zig");
+    _ = @import("compiler_rt/sqrt.zig");
+    _ = @import("compiler_rt/tan.zig");
+    _ = @import("compiler_rt/trunc.zig");
+
+    // BigInt. Alphabetically sorted.
+    _ = @import("compiler_rt/udivmodei4.zig");
+    _ = @import("compiler_rt/udivmodti4.zig");
+
+    // extra
     _ = @import("compiler_rt/os_version_check.zig");
     _ = @import("compiler_rt/emutls.zig");
     _ = @import("compiler_rt/arm.zig");

--- a/lib/compiler_rt/README.md
+++ b/lib/compiler_rt/README.md
@@ -327,7 +327,7 @@ Integer and Float Operations
 | ✓ | __negdf2           | f64  | ∅    | f64  | ..                             |
 | ✓ | __negtf2           | f128 | ∅    | f128 | ..                             |
 | ✓ | __negxf2           | f80  | ∅    | f80  | ..                             |
-|   |                    |      |      |      | **Floating point raised to integer power** |
+|   |                    |      |      |      | **Other** |
 | ✓ | __powihf2          | f16  | i32  | f16  | `a ^ b`                        |
 | ✓ | __powisf2          | f32  | i32  | f32  | ..                             |
 | ✓ | __powidf2          | f64  | i32  | f64  | ..                             |


### PR DESCRIPTION
Justifications
- compiler_rt base routines are almost finished, so make 1:1 mapping of code and documentation.
- Make adjustments to code + documentation simpler to prevent technical or documentation debt.