### PR TITLE
Add -ferror-tracing and -fno-error-tracing compile options

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -906,7 +906,7 @@ pub fn standardOptimizeOption(self: *Build, options: StandardOptimizeOptionOptio
         return self.option(
             std.builtin.Mode,
             "optimize",
-            "prioritize performance, safety, or binary size (-O flag)",
+            "Prioritize performance, safety, or binary size (-O flag)",
         ) orelse .Debug;
     }
 }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1029,6 +1029,7 @@ pub const InitOptions = struct {
     /// This is for stage1 and should be deleted upon completion of self-hosting.
     color: Color = .auto,
     reference_trace: ?u32 = null,
+    error_tracing: ?bool = null,
     test_filter: ?[]const u8 = null,
     test_name_prefix: ?[]const u8 = null,
     test_runner_path: ?[]const u8 = null,
@@ -1715,8 +1716,9 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
 
         const error_return_tracing = !strip and switch (options.optimize_mode) {
             .Debug, .ReleaseSafe => (!options.target.isWasm() or options.target.os.tag == .emscripten) and
-                !options.target.cpu.arch.isBpf(),
-            .ReleaseFast, .ReleaseSmall => false,
+                !options.target.cpu.arch.isBpf() and (options.error_tracing orelse true),
+            .ReleaseFast, => options.error_tracing orelse false,
+            .ReleaseSmall => false,
         };
 
         // For resource management purposes.

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1717,7 +1717,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
         const error_return_tracing = !strip and switch (options.optimize_mode) {
             .Debug, .ReleaseSafe => (!options.target.isWasm() or options.target.os.tag == .emscripten) and
                 !options.target.cpu.arch.isBpf() and (options.error_tracing orelse true),
-            .ReleaseFast, => options.error_tracing orelse false,
+            .ReleaseFast => options.error_tracing orelse false,
             .ReleaseSmall => false,
         };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -432,6 +432,8 @@ const usage_build_generic =
     \\  -fno-Clang                Prevent using Clang as the C/C++ compilation backend
     \\  -freference-trace[=num]   How many lines of reference trace should be shown per compile error
     \\  -fno-reference-trace      Disable reference trace
+    \\  -ferror-tracing           Enable error tracing in ReleaseFast mode
+    \\  -fno-error-tracing        Disable error tracing in Debug and ReleaseSafe mode
     \\  -fsingle-threaded         Code assumes there is only one thread
     \\  -fno-single-threaded      Code may not assume there is only one thread
     \\  -fbuiltin                 Enable implicit builtin knowledge of functions
@@ -797,6 +799,7 @@ fn buildOutputType(
     var headerpad_max_install_names: bool = false;
     var dead_strip_dylibs: bool = false;
     var reference_trace: ?u32 = null;
+    var error_tracing: ?bool = null;
     var pdb_out_path: ?[]const u8 = null;
 
     // e.g. -m3dnow or -mno-outline-atomics. They correspond to std.Target llvm cpu feature names.
@@ -1218,6 +1221,10 @@ fn buildOutputType(
                         };
                     } else if (mem.eql(u8, arg, "-fno-reference-trace")) {
                         reference_trace = null;
+                    } else if (mem.eql(u8, arg, "-ferror-tracing")) {
+                        error_tracing = true;
+                    } else if (mem.eql(u8, arg, "-fno-error-tracing")) {
+                        error_tracing = false;
                     } else if (mem.eql(u8, arg, "-rdynamic")) {
                         rdynamic = true;
                     } else if (mem.eql(u8, arg, "-fsoname")) {
@@ -3136,6 +3143,7 @@ fn buildOutputType(
         .headerpad_max_install_names = headerpad_max_install_names,
         .dead_strip_dylibs = dead_strip_dylibs,
         .reference_trace = reference_trace,
+        .error_tracing = error_tracing,
         .pdb_out_path = pdb_out_path,
     }) catch |err| switch (err) {
         error.LibCUnavailable => {


### PR DESCRIPTION
Closes #691. Adds `-ferror-tracing` and `-fno-error-tracing` to the compile options. 

Specifying `-ferror-tracing` enables error tracing in ReleaseFast mode.
Specifying `-fno-error-tracing` disables error tracing in Debug and ReleaseSafe modes.
Error tracing remains permanently disabled in ReleaseSmall mode.

Example (ReleaseFast, `-ferror-tracing`): 
```
$ zig build-exe src/main.zig -ferror-tracing -OReleaseFast
$ ./main
error: AckAnotherError
/home/adam/base/src/main.zig:4:5: 0x2031a8 in main (main)
    return error.OhNoAnError;
    ^
/home/adam/base/src/main.zig:8:24: 0x2031b0 in main (main)
    return foo() catch return error.AckAnotherError;
                       ^
/home/adam/zig/lib/std/start.zig:616:37: 0x20316e in posixCallMainAndExit (main)
            const result = root.main() catch |err| {
```
Example (Debug, `-fno-error-tracing`):
```
$ zig build-exe src/main.zig -fno-error-tracing
$ ./main
error: AckAnotherError
```
