### PR TITLE
Fixes #14574 - Panic on NoSpaceLeft when formatting duration as we have a fixed buffer

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1503,6 +1503,7 @@ fn formatDuration(data: FormatDurationData, comptime fmt: []const u8, options: s
 
     // worst case: "-XXXyXXwXXdXXhXXmXX.XXXs".len = 24
     var buf: [24]u8 = undefined;
+    errdefer @panic("buffer overflow while formatting duration");
     var fbs = std.io.fixedBufferStream(&buf);
     var buf_writer = fbs.writer();
     if (data.negative) {

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1505,7 +1505,7 @@ fn formatDuration(data: FormatDurationData, comptime fmt: []const u8, options: s
     var buf: [24]u8 = undefined;
 
     return tryFormatDuration(data, &buf, options, writer) catch |err| switch (err) {
-        error.NoSpaceLeft => unreachable
+        error.NoSpaceLeft => unreachable,
     };
 }
 

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1503,7 +1503,6 @@ fn formatDuration(data: FormatDurationData, comptime fmt: []const u8, options: s
 
     // worst case: "-XXXyXXwXXdXXhXXmXX.XXXs".len = 24
     var buf: [24]u8 = undefined;
-    errdefer @panic("buffer overflow while formatting duration");
     var fbs = std.io.fixedBufferStream(&buf);
     var buf_writer = fbs.writer();
     if (data.negative) {

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1503,8 +1503,16 @@ fn formatDuration(data: FormatDurationData, comptime fmt: []const u8, options: s
 
     // worst case: "-XXXyXXwXXdXXhXXmXX.XXXs".len = 24
     var buf: [24]u8 = undefined;
-    var fbs = std.io.fixedBufferStream(&buf);
+
+    return tryFormatDuration(data, &buf, options, writer) catch |err| switch (err) {
+        error.NoSpaceLeft => unreachable
+    };
+}
+
+fn tryFormatDuration(data: FormatDurationData, buffer_ptr: []u8, options: std.fmt.FormatOptions, writer: anytype) !void {
+    var fbs = std.io.fixedBufferStream(buffer_ptr);
     var buf_writer = fbs.writer();
+
     if (data.negative) {
         try buf_writer.writeByte('-');
     }


### PR DESCRIPTION
Panic on error when formatting duration. Allows this to compile:
```zig
const std = @import("std");

pub fn main() !void {
    try std.io.null_writer.print("{}", .{std.fmt.fmtDuration(100)});
}
```
Thus fixes #14574.

All standard library tests pass when running `zig build test-std -Dskip-release -Dskip-non-native`.