### PR TITLE
Zld: Report archive file with cpu arch mismatch

### DIFF
--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -1065,7 +1065,13 @@ pub const Zld = struct {
                 assert(offsets.items.len > 0);
 
                 const object_id = @intCast(u16, self.objects.items.len);
-                const object = try archive.parseObject(gpa, cpu_arch, offsets.items[0]);
+                const object = archive.parseObject(gpa, cpu_arch, offsets.items[0]) catch |e| switch (e) {
+                    error.MismatchedCpuArchitecture => {
+                        log.err("CPU architecture mismatch found in {s}", .{archive.name});
+                        return e;
+                    },
+                    else => return e,
+                };
                 try self.objects.append(gpa, object);
                 try self.resolveSymbolsInObject(object_id, resolver);
 


### PR DESCRIPTION
This is just a simple/hacky feature to report the source of a linking error. I found this helpful in fixing-up some of my libs when recently switching from an x86_64 to aarch64 device, so thought it might be useful to others a well before zld has a fully featured error reporting system.