### PR TITLE
Add std.c.umask.

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -173,6 +173,7 @@ pub extern "c" fn readlink(noalias path: [*:0]const u8, noalias buf: [*]u8, bufs
 pub extern "c" fn readlinkat(dirfd: c.fd_t, noalias path: [*:0]const u8, noalias buf: [*]u8, bufsize: usize) isize;
 pub extern "c" fn fchmod(fd: c.fd_t, mode: c.mode_t) c_int;
 pub extern "c" fn fchown(fd: c.fd_t, owner: c.uid_t, group: c.gid_t) c_int;
+pub extern "c" fn umask(mode: c.mode_t) c.mode_t;
 
 pub extern "c" fn rmdir(path: [*:0]const u8) c_int;
 pub extern "c" fn getenv(name: [*:0]const u8) ?[*:0]u8;


### PR DESCRIPTION
Hello. I just needed `umask` to create unix sockets with the right permissions so I added a simple line in `std.c`.

Is this okay? Should I add something else?