### PR TITLE
Clarify blocks being statements in doco

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4034,7 +4034,7 @@ test "access variable after block scope" {
     x += 1;
 }
       {#code_end#}
-      <p>Blocks are expressions. When labeled, {#syntax#}break{#endsyntax#} can be used
+      <p>Blocks are statements, not expressions. When labeled, {#syntax#}break{#endsyntax#} can be used
       to return a value from the block:
       </p>
       {#code_begin|test|test_labeled_break#}


### PR DESCRIPTION
As decided here: https://github.com/ziglang/zig/issues/9758#issuecomment-977127631

example of expression/statement disparity:

```
const lol: u8 = if (args.len == 2)
    3
  else v: {
    std.debug.print("logging info", .{...});
    break :v 5;
};
```