### PR TITLE
autodoc: fix markdown list rendering

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -3319,13 +3319,15 @@ const NAV_MODES = {
         } else if (line.text.startsWith("#")) {
           line.type = "h1";
           line.text = line.text.substr(1);
-        } else if (line.text.startsWith("-")) {
+        } else if (line.text.match(/^-[ \t]+.*$/)) {
+          // line starts with a hyphen, followed by spaces or tabs
+          const match = line.text.match(/^-[ \t]+/);
           line.type = "ul";
-          line.text = line.text.substr(1);
-        } else if (line.text.match(/^\d+\..*$/)) {
-          // if line starts with {number}{dot}
-          const match = line.text.match(/(\d+)\./);
-          line.type = "ul";
+          line.text = line.text.substr(match[0].length);
+        } else if (line.text.match(/^\d+\.[ \t]+.*$/)) {
+          // line starts with {number}{dot}{spaces or tabs}
+          const match = line.text.match(/(\d+)\.[ \t]+/);
+          line.type = "ol";
           line.text = line.text.substr(match[0].length);
           line.ordered_number = Number(match[1].length);
         } else if (line.text == "```") {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -3538,7 +3538,7 @@ const NAV_MODES = {
         case "ul":
         case "ol":
           if (
-            !previousLineIs("ul", line_no) ||
+            !previousLineIs(line.type, line_no) ||
             getPreviousLineIndent(line_no) < line.indent
           ) {
             html += "<" + line.type + ">\n";
@@ -3547,7 +3547,7 @@ const NAV_MODES = {
           html += "<li>" + markdownInlines(line.text) + "</li>\n";
 
           if (
-            !nextLineIs("ul", line_no) ||
+            !nextLineIs(line.type, line_no) ||
             getNextLineIndent(line_no) < line.indent
           ) {
             html += "</" + line.type + ">\n";


### PR DESCRIPTION
Both [original Markdown](https://daringfireball.net/projects/markdown/syntax#list) and [CommonMark](https://spec.commonmark.org/current/#lists) require at least one space or tab between the list marker and any following content.  Following this allows starting a line with a negative number or one with a decimal point.

I am unaware of the history but for some reason ordered lists are rendered as unordered.  The second patch adds support for `<ol>` rendering.