### PR TITLE
wasi: add Preopens.findDir, update tests to preopen `/tmp'

### DIFF
--- a/lib/std/Build/CompileStep.zig
+++ b/lib/std/Build/CompileStep.zig
@@ -1555,7 +1555,9 @@ fn make(step: *Step) !void {
                     try zig_args.append("--test-cmd");
                     try zig_args.append(bin_name);
                     try zig_args.append("--test-cmd");
-                    try zig_args.append("--dir=.");
+                    try zig_args.append("--mapdir=/::.");
+                    try zig_args.append("--test-cmd");
+                    try zig_args.append("--mapdir=/tmp::/tmp");
                     try zig_args.append("--test-cmd-bin");
                 } else {
                     try zig_args.append("--test-no-exec");

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -13,6 +13,11 @@ const File = std.fs.File;
 const tmpDir = testing.tmpDir;
 const tmpIterableDir = testing.tmpIterableDir;
 
+// ensure tests for fs/wasi.zig are run
+comptime {
+    _ = std.fs.wasi;
+}
+
 test "Dir.readLink" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();

--- a/lib/std/fs/wasi.zig
+++ b/lib/std/fs/wasi.zig
@@ -9,6 +9,7 @@ const Allocator = mem.Allocator;
 const wasi = std.os.wasi;
 const fd_t = wasi.fd_t;
 const prestat_t = wasi.prestat_t;
+const testing = std.testing;
 
 pub const Preopens = struct {
     // Indexed by file descriptor number.
@@ -21,6 +22,30 @@ pub const Preopens = struct {
             }
         }
         return null;
+    }
+
+    pub fn findDir(p: Preopens, full_path: []const u8, flags: std.fs.Dir.OpenDirOptions) std.fs.Dir.OpenError!std.fs.Dir {
+        if (p.names.len <= 2)
+            return std.fs.Dir.OpenError.BadPathName; // there are no preopens
+
+        var prefix: []const u8 = "";
+        var fd: usize = 0;
+        for (p.names) |preopen, i| {
+            if (i > 2 and wasiPathPrefixMatches(preopen, full_path)) {
+                if (preopen.len > prefix.len) {
+                    prefix = preopen;
+                    fd = i;
+                }
+            }
+        }
+
+        // still no match
+        if (fd == 0) {
+            return std.fs.Dir.OpenError.FileNotFound;
+        }
+        const d = std.fs.Dir{ .fd = @intCast(os.fd_t, fd) };
+        const rel = full_path[prefix.len + 1 .. full_path.len];
+        return d.openDirWasi(rel, flags);
     }
 };
 
@@ -53,4 +78,87 @@ pub fn preopensAlloc(gpa: Allocator) Allocator.Error!Preopens {
         }
         names.appendAssumeCapacity(name);
     }
+}
+
+fn wasiPathPrefixMatches(prefix: []const u8, path: []const u8) bool {
+    if (path[0] != '/' and prefix.len == 0)
+        return true;
+
+    if (path.len < prefix.len)
+        return false;
+
+    if (prefix.len == 1) {
+        return prefix[0] == path[0];
+    }
+
+    if (!std.mem.eql(u8, path[0..prefix.len], prefix)) {
+        return false;
+    }
+
+    return path.len == prefix.len or
+        path[prefix.len] == '/';
+}
+
+test "preopens" {
+    if (builtin.os.tag != .wasi) return error.SkipZigTest;
+
+    // lifted from `testing`
+    const random_bytes_count = 12;
+    const buf_size = 256;
+    const path = "/tmp";
+    const tmp_file_name = "file.txt";
+    const nonsense = "nonsense";
+
+    var random_bytes: [random_bytes_count]u8 = undefined;
+    var buf: [buf_size]u8 = undefined;
+
+    std.crypto.random.bytes(&random_bytes);
+    const sub_path = std.fs.base64_encoder.encode(&buf, &random_bytes);
+
+    // find all preopens
+    const allocator = std.heap.page_allocator;
+    var wasi_preopens = try std.fs.wasi.preopensAlloc(allocator);
+
+    // look for the exact "/tmp" preopen match
+    const fd = std.fs.wasi.Preopens.find(wasi_preopens, path) orelse unreachable;
+    const base_dir = std.fs.Dir{ .fd = fd };
+
+    var tmp_path = base_dir.makeOpenPath(sub_path, .{}) catch
+        @panic("unable to make tmp dir for testing: /tmp/<rand-path>");
+
+    defer tmp_path.close();
+    defer tmp_path.deleteTree(sub_path) catch {};
+
+    // create a file under /tmp/<rand>/file.txt with contents "nonsense"
+    try tmp_path.writeFile(tmp_file_name, nonsense);
+
+    // now look for the file as a single path
+    var tmp_dir_path_buf: [buf_size]u8 = undefined;
+    const tmp_dir_path = try std.fmt.bufPrint(&tmp_dir_path_buf, "{s}/{s}", .{ path, sub_path });
+
+    // find "/tmp/<rand>" using `findDir()`
+    const tmp_file_dir = try wasi_preopens.findDir(tmp_dir_path, .{});
+
+    const text = try tmp_file_dir.readFile(tmp_file_name, &buf);
+
+    // ensure the file contents match "nonsense"
+    try testing.expect(std.mem.eql(u8, nonsense, text));
+}
+
+test "wasiPathPrefixMatches" {
+    try testing.expect(wasiPathPrefixMatches("/", "/foo"));
+    try testing.expect(wasiPathPrefixMatches("/testcases", "/testcases/test.txt"));
+    try testing.expect(wasiPathPrefixMatches("", "foo"));
+    try testing.expect(wasiPathPrefixMatches("foo", "foo"));
+    try testing.expect(wasiPathPrefixMatches("foo", "foo/bar"));
+    try testing.expect(!wasiPathPrefixMatches("bar", "foo/bar"));
+    try testing.expect(!wasiPathPrefixMatches("bar", "foo"));
+    try testing.expect(wasiPathPrefixMatches("foo", "foo/bar"));
+    try testing.expect(!wasiPathPrefixMatches("fooo", "foo"));
+    try testing.expect(!wasiPathPrefixMatches("foo", "fooo"));
+    try testing.expect(!wasiPathPrefixMatches("foo/bar", "foo"));
+    try testing.expect(!wasiPathPrefixMatches("bar/foo", "foo"));
+    try testing.expect(wasiPathPrefixMatches("/foo", "/foo"));
+    try testing.expect(wasiPathPrefixMatches("/foo", "/foo"));
+    try testing.expect(wasiPathPrefixMatches("/foo", "/foo/"));
 }

--- a/lib/std/fs/wasi.zig
+++ b/lib/std/fs/wasi.zig
@@ -100,7 +100,7 @@ fn wasiPathPrefixMatches(prefix: []const u8, path: []const u8) bool {
 }
 
 test "preopens" {
-    if (builtin.os.tag != .wasi) return error.SkipZigTest;
+    if (builtin.os.tag != .wasi or builtin.link_libc) return error.SkipZigTest;
 
     // lifted from `testing`
     const random_bytes_count = 12;


### PR DESCRIPTION
While working on Wazero, we learned that Zig's behavior is for `cwd()` to always point at `fd=3`, i.e. the first given preopen. However, if multiple preopens are available, there is currently no predefined library function to look through all of them. 

For instance, consider the case when `/` and `/tmp` are both preopened, and `/` resolves to `a`, and `/tmp` resolves to `b`.

If you just naively invoke `std.fs.openIterableDir("/tmp/blah.txt", .{})` the file `blah.txt` will be looked under `a/tmp/blah.txt` instead of, `b/blah.txt`


Since `wasi-libc` seems to be doing [a prefix search where the longest match wins](https://github.com/WebAssembly/wasi-libc/blob/a02298043ff551ce1157bc2ee7ab74c3bffe7144/libc-bottom-half/sources/preopens.c#L189-L192), we'd like to propose an API to look up an absolute path through all the available preopens. 

In order to exercise the new code path I am also modifying the test launcher so that `/tmp` is mounted at `/tmp`.

This is also my first contribution and I am a Zig n00b so pardon my naivety here :)

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
