### PR TITLE
bitcast packed unions to integers

### DIFF
--- a/src/value.zig
+++ b/src/value.zig
@@ -1442,9 +1442,6 @@ pub const Value = extern union {
                 .Auto => unreachable, // Sema is supposed to have emitted a compile error already
                 .Extern => unreachable, // Handled in non-packed writeToMemory
                 .Packed => {
-                    if (ty.unionTagType() == null)
-                        @panic("TODO implement writeToPackedMemory for tagged unions");
-
                     const field_index = ty.unionTagFieldIndex(val.unionTag(), mod);
                     const field_type = ty.unionFields().values()[field_index.?].ty;
                     const field_val = val.fieldValue(field_type, field_index.?);

--- a/test/behavior/comptime_memory.zig
+++ b/test/behavior/comptime_memory.zig
@@ -394,3 +394,21 @@ test "accessing reinterpreted memory of parent object" {
         try testing.expect(b == expected);
     }
 }
+
+test "bitcast packed union to integer" {
+    const U = packed union {
+        x: u1,
+        y: u2,
+    };
+
+    comptime {
+        const a = U{ .x = 1 };
+        const b = U{ .y = 2 };
+        const cast_a = @bitCast(u2, a);
+        const cast_b = @bitCast(u2, b);
+
+        // truncated because the upper bit is garbage memory that we don't care about
+        try testing.expectEqual(@as(u1, 1), @truncate(u1, cast_a));
+        try testing.expectEqual(@as(u2, 2), cast_b);
+    }
+}


### PR DESCRIPTION
This was put together to enable some code written for [MicroZig](https://github.com/ZigEmbeddedGroup/microzig).

Question: Do tagless unions have some sort of hidden tag for safety checks?