### PR TITLE
Improve 'slice of single-item pointer' error message

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -29322,7 +29322,7 @@ fn analyzeSlice(
                                 block,
                                 src,
                                 msg,
-                                "perhaps you want to coerce using '@as(*[1]{}, ptr)'?",
+                                "single-item pointer can be coerced to array using '@as(*[1]{}, ptr)'",
                                 .{ptr_ptr_child_ty.childType().fmt(mod)},
                             );
                             break :msg msg;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -29301,7 +29301,9 @@ fn analyzeSlice(
                         const start_val = try sema.resolveDefinedValue(block, start_src, uncasted_start) orelse {
                             break :emit_note false;
                         };
-                        const start = start_val.toUnsignedInt(sema.mod.getTarget());
+                        const start = try start_val.getUnsignedIntAdvanced(sema.mod.getTarget(), sema) orelse {
+                            break :emit_note false;
+                        };
                         const end = end: {
                             if (uncasted_end_opt == .none) {
                                 break :end 1;
@@ -29309,7 +29311,9 @@ fn analyzeSlice(
                                 const end_val = try sema.resolveDefinedValue(block, end_src, uncasted_end_opt) orelse {
                                     break :emit_note false;
                                 };
-                                break :end end_val.toUnsignedInt(sema.mod.getTarget());
+                                break :end try end_val.getUnsignedIntAdvanced(sema.mod.getTarget(), sema) orelse {
+                                    break :emit_note false;
+                                };
                             }
                         };
                         break :emit_note (start == 0) and (end == 1);

--- a/test/cases/compile_errors/slicing_single-item_pointer_with_len_1.zig
+++ b/test/cases/compile_errors/slicing_single-item_pointer_with_len_1.zig
@@ -1,0 +1,11 @@
+export fn entry(ptr: *i32) void {
+    const slice = ptr[0..];
+    _ = slice;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:22: error: slice of single-item pointer
+// :2:22: note: single-item pointer can be coerced to array using '@as(*[1]i32, ptr)'


### PR DESCRIPTION
Offer a correct explicit coercion syntax to help the user avoid other footgunnable workarounds when they encounter this error.

Arguably, there's no need for this if we allowed explicit coercion using slice syntax [0..] or similar (also see https://github.com/ziglang/zig/issues/8197 and https://github.com/ziglang/zig/issues/3156) but this provides immediate value to users today per the status quo.