### PR TITLE
std.Build.RunStep: fix default caching logic

### DIFF
--- a/lib/std/Build/RunStep.zig
+++ b/lib/std/Build/RunStep.zig
@@ -188,6 +188,10 @@ fn stdIoActionToBehavior(action: StdIoAction) std.ChildProcess.StdIo {
 }
 
 fn needOutputCheck(self: RunStep) bool {
+    switch (self.condition) {
+        .always => return false,
+        .output_outdated => {},
+    }
     if (self.extra_file_dependencies.len > 0) return true;
 
     for (self.argv.items) |arg| switch (arg) {
@@ -195,10 +199,7 @@ fn needOutputCheck(self: RunStep) bool {
         else => continue,
     };
 
-    return switch (self.condition) {
-        .always => false,
-        .output_outdated => true,
-    };
+    return false;
 }
 
 fn make(step: *Step) !void {


### PR DESCRIPTION
RunStep is supposed to auto-detect whether the intend is for side-effects or for producing an output file. The auto-detection logic was incorrect, and this commit fixes it.

I tested this manually locally. Automated testing will require a more significant investment in the test harness, which I will work on in a future enhancement.

closes #14666