### PR TITLE
self-hosted: fix incorrect freeing of registers when tracked by non-allocating instructions such as bit_cast

### DIFF
--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -900,12 +900,25 @@ fn processDeath(self: *Self, inst: Air.Inst.Index) void {
     branch.inst_table.putAssumeCapacity(inst, .dead);
     switch (prev_value) {
         .register => |reg| {
-            self.register_manager.freeReg(reg);
+            // For some instructions such as bit_cast it is possible that we will track the same MCValue
+            // for two different instructions. In this case, if either instruction dies before another,
+            // we do not want to free the MCValue prematurely.
+            // TODO we can either do this or we should re-implement AIR instruction implementations for
+            // bit_cast, ptr_to_int, etc. to actually have those instructions assigned a new MCValue.
+            if (self.register_manager.getTrackedInst(reg)) |tracked_inst| {
+                if (inst == tracked_inst) {
+                    self.register_manager.freeReg(reg);
+                }
+            }
         },
         .register_c_flag,
         .register_v_flag,
         => |reg| {
-            self.register_manager.freeReg(reg);
+            if (self.register_manager.getTrackedInst(reg)) |tracked_inst| {
+                if (inst == tracked_inst) {
+                    self.register_manager.freeReg(reg);
+                }
+            }
             self.cpsr_flags_inst = null;
         },
         .cpsr_flags => {

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -4312,10 +4312,23 @@ fn processDeath(self: *Self, inst: Air.Inst.Index) void {
     log.debug("%{} death: {} -> .dead", .{ inst, prev_value });
     switch (prev_value) {
         .register => |reg| {
-            self.register_manager.freeReg(reg);
+            // For some instructions such as bit_cast it is possible that we will track the same MCValue
+            // for two different instructions. In this case, if either instruction dies before another,
+            // we do not want to free the MCValue prematurely.
+            // TODO we can either do this or we should re-implement AIR instruction implementations for
+            // bit_cast, ptr_to_int, etc. to actually have those instructions assigned a new MCValue.
+            if (self.register_manager.getTrackedInst(reg)) |tracked_inst| {
+                if (inst == tracked_inst) {
+                    self.register_manager.freeReg(reg);
+                }
+            }
         },
         .register_with_overflow => |rwo| {
-            self.register_manager.freeReg(rwo.reg);
+            if (self.register_manager.getTrackedInst(rwo.reg)) |tracked_inst| {
+                if (inst == tracked_inst) {
+                    self.register_manager.freeReg(rwo.reg);
+                }
+            }
             self.condition_flags_inst = null;
         },
         .condition_flags => {

--- a/src/register_manager.zig
+++ b/src/register_manager.zig
@@ -218,6 +218,8 @@ pub fn RegisterManager(
                 }
             }
 
+            log.debug("allocated registers {any} for insts {any}", .{ regs, insts });
+
             return regs;
         }
 
@@ -323,6 +325,15 @@ pub fn RegisterManager(
                     self.freeReg(reg);
                 }
             }
+        }
+
+        /// Returns tracked AIR instruction for the specified register if
+        /// one has been allocated and is tracking.
+        pub fn getTrackedInst(self: *Self, reg: Register) ?Air.Inst.Index {
+            const index = indexOfRegIntoTracked(reg) orelse return null;
+            log.debug("getTrackedInst for {}", .{reg});
+            if (self.isRegFree(reg)) return null;
+            return self.registers[index];
         }
 
         /// Allocates the specified register with the specified

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -180,6 +180,7 @@ test "void arrays" {
 }
 
 test "nested arrays of strings" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO

--- a/test/behavior/void.zig
+++ b/test/behavior/void.zig
@@ -19,6 +19,7 @@ test "compare void with void compile time known" {
 }
 
 test "iterate over a void slice" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     var j: usize = 0;

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -58,14 +58,14 @@ const test_targets = blk: {
             .link_libc = true,
             .backend = .stage2_c,
         },
-        //.{
-        //    .target = .{
-        //        .cpu_arch = .x86_64,
-        //        .os_tag = .linux,
-        //        .abi = .none,
-        //    },
-        //    .backend = .stage2_x86_64,
-        //},
+        .{
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .linux,
+                .abi = .none,
+            },
+            .backend = .stage2_x86_64,
+        },
         .{
             .target = .{
                 .cpu_arch = .aarch64,


### PR DESCRIPTION
See commits 994c9d6 through to 7c5c4c1.

Do not merge until @andrewrk's PR https://github.com/ziglang/zig/pull/14671 gets merged. I have opened this PR ahead of time to verify with the CI that I haven't regressed anything else.