### PR TITLE
wasi: add Preopens.findDir; update tests, docs

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1831,3 +1831,10 @@ test "delete a setAsCwd directory on Windows" {
     // Close the parent "tmp" so we don't leak the HANDLE.
     tmp.parent_dir.close();
 }
+
+// ensure the tests for fs/wasi.zig are run
+test {
+    if (builtin.os.tag == .wasi) {
+        _ = std.fs.wasi;
+    }
+}

--- a/lib/std/fs/wasi.zig
+++ b/lib/std/fs/wasi.zig
@@ -9,11 +9,15 @@ const Allocator = mem.Allocator;
 const wasi = std.os.wasi;
 const fd_t = wasi.fd_t;
 const prestat_t = wasi.prestat_t;
+const testing = std.testing;
 
 pub const Preopens = struct {
     // Indexed by file descriptor number.
     names: []const []const u8,
 
+    /// Looks for a given `name` (path) in the list of preopens.
+    /// Returns the corresponding file descriptor if an exact match is found.
+    /// Otherwise returns `null`.
     pub fn find(p: Preopens, name: []const u8) ?os.fd_t {
         for (p.names, 0..) |elem_name, i| {
             if (mem.eql(u8, elem_name, name)) {
@@ -21,6 +25,113 @@ pub const Preopens = struct {
             }
         }
         return null;
+    }
+
+    // A pair of <preopened dir, relative path to the given preopen>
+    const PreopenMatch = struct {
+        dir: std.fs.Dir,
+        relativePath: []const u8,
+    };
+
+    /// Looks for a given `full_path` in the list of preopens.
+    /// Returns a `std.fs.Dir` if the given `full_path` exists and can be opened.
+    /// If there are no preopened paths that match, it returns a `std.fs.Dir.OpenError`.
+    /// A preopened path matches if it is a prefix of the given `full_path`.
+    /// If multiple preopens match, then the longest match is returned.
+    /// e.g. if `/` and `/tmp` are preopened, and `full_path` is `/tmp/myfile.txt`,
+    /// `myfile.txt` is looked under the `/tmp` preopen and not under `/`.
+    pub fn findDir(p: Preopens, full_path: []const u8, flags: std.fs.Dir.OpenDirOptions) std.fs.Dir.OpenError!std.fs.Dir {
+        const m = findPreopenMatch(p, full_path) catch |err| {
+            return err;
+        };
+        return m.dir.openDirWasi(m.relativePath, flags);
+    }
+
+    fn findPreopenMatch(p: Preopens, full_path: []const u8) std.fs.Dir.OpenError!PreopenMatch {
+        if (p.names.len <= 2)
+            return std.fs.Dir.OpenError.BadPathName; // there are no preopens
+
+        var prefix: []const u8 = "";
+        var fd: usize = 0;
+        for (p.names, 0..) |preopen, i| {
+            if (i > 2 and wasiPathPrefixMatches(preopen, full_path)) {
+                if (preopen.len > prefix.len) {
+                    prefix = preopen;
+                    fd = i;
+                }
+            }
+        }
+
+        // still no match
+        if (fd == 0) {
+            return std.fs.Dir.OpenError.FileNotFound;
+        }
+        const d = std.fs.Dir{ .fd = @intCast(os.fd_t, fd) };
+        const rel = full_path[prefix.len + 1 .. full_path.len];
+        return PreopenMatch{ .dir = d, .relativePath = rel };
+    }
+
+    /// Matches when the given `prefix` is a prefix of `path`
+    fn wasiPathPrefixMatches(prefix: []const u8, path: []const u8) bool {
+        if (path[0] != '/' and prefix.len == 0)
+            return true;
+
+        if (path.len < prefix.len)
+            return false;
+
+        if (prefix.len == 1) {
+            return prefix[0] == path[0];
+        }
+
+        if (!std.mem.eql(u8, path[0..prefix.len], prefix)) {
+            return false;
+        }
+
+        return path.len == prefix.len or
+            path[prefix.len] == '/';
+    }
+
+    test "wasiPathPrefixMatches" {
+        try testing.expect(wasiPathPrefixMatches("/", "/foo"));
+        try testing.expect(wasiPathPrefixMatches("/testcases", "/testcases/test.txt"));
+        try testing.expect(wasiPathPrefixMatches("", "foo"));
+        try testing.expect(wasiPathPrefixMatches("foo", "foo"));
+        try testing.expect(wasiPathPrefixMatches("foo", "foo/bar"));
+        try testing.expect(!wasiPathPrefixMatches("bar", "foo/bar"));
+        try testing.expect(!wasiPathPrefixMatches("bar", "foo"));
+        try testing.expect(wasiPathPrefixMatches("foo", "foo/bar"));
+        try testing.expect(!wasiPathPrefixMatches("fooo", "foo"));
+        try testing.expect(!wasiPathPrefixMatches("foo", "fooo"));
+        try testing.expect(!wasiPathPrefixMatches("foo/bar", "foo"));
+        try testing.expect(!wasiPathPrefixMatches("bar/foo", "foo"));
+        try testing.expect(wasiPathPrefixMatches("/foo", "/foo"));
+        try testing.expect(wasiPathPrefixMatches("/foo", "/foo"));
+        try testing.expect(wasiPathPrefixMatches("/foo", "/foo/"));
+    }
+
+    test "Preopens.findPreopenMatch" {
+        if (builtin.os.tag != .wasi or builtin.link_libc) return error.SkipZigTest;
+
+        const wasi_preopens: Preopens = .{
+            .names = &.{
+                "stdin",
+                "stdout",
+                "stderr",
+                ".",
+                "/tmp",
+            },
+        };
+
+        const p1 = findPreopenMatch(wasi_preopens, "/blah") catch
+            @panic("unable to find matching preopen");
+        try testing.expect(p1.dir.fd == 3);
+        try testing.expect(std.mem.eql(u8, p1.relativePath, "/blah"));
+
+        const p2 = findPreopenMatch(wasi_preopens, "/tmp/blah") catch
+            @panic("unable to find matching preopen");
+
+        try testing.expect(p2.dir.fd == 4);
+        try testing.expect(std.mem.eql(u8, p2.relativePath, "/blah"));
     }
 };
 

--- a/lib/std/fs/wasi.zig
+++ b/lib/std/fs/wasi.zig
@@ -41,9 +41,7 @@ pub const Preopens = struct {
     /// e.g. if `/` and `/tmp` are preopened, and `full_path` is `/tmp/myfile.txt`,
     /// `myfile.txt` is looked under the `/tmp` preopen and not under `/`.
     pub fn findDir(p: Preopens, full_path: []const u8, flags: std.fs.Dir.OpenDirOptions) std.fs.Dir.OpenError!std.fs.Dir {
-        const m = findPreopenMatch(p, full_path) catch |err| {
-            return err;
-        };
+        const m = try findPreopenMatch(p, full_path);
         return m.dir.openDirWasi(m.relativePath, flags);
     }
 
@@ -66,7 +64,7 @@ pub const Preopens = struct {
         if (fd == 0) {
             return std.fs.Dir.OpenError.FileNotFound;
         }
-        const d = std.fs.Dir{ .fd = @intCast(os.fd_t, fd) };
+        const d = std.fs.Dir{ .fd = @intCast(os.fd_t) };
         const rel = full_path[prefix.len + 1 .. full_path.len];
         return PreopenMatch{ .dir = d, .relativePath = rel };
     }


### PR DESCRIPTION
Second attempt at #14661 :)

in Zig's WASI support:

>   `cwd()` always points at `fd=3`, i.e. the first given preopen. However, if multiple preopens are available, there is currently no predefined library function to look through all of them. 

The patch adds a new std lib function `Preopens.openDir(path)` that looks through all preopens and returns an open dir for the given path. 

- If no preopens are available or there is no match, then an error is returned
- if there is at least one preopen `p`, and it is a prefix of `path`, then the suffix `path[p.len..]` is looked under dir `p`
- if there are multiple preopens `p` that are prefix of `path` then the longest prefix is used


The current patch is configuring the test mode so that the following preopens are pre-configured:

```
  .  => /
/tmp => /tmp
```

I am opening this PR to rebase on `master` and discuss a different approach for testing (if applicable)

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
