### PR TITLE
Linker: -z<arg> should be equivalent to -z <arg>

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1955,12 +1955,15 @@ fn buildOutputType(
                     linker_compress_debug_sections = std.meta.stringToEnum(link.CompressDebugSections, arg1) orelse {
                         fatal("expected [none|zlib] after --compress-debug-sections, found '{s}'", .{arg1});
                     };
-                } else if (mem.eql(u8, arg, "-z")) {
-                    i += 1;
-                    if (i >= linker_args.items.len) {
-                        fatal("expected linker extension flag after '{s}'", .{arg});
+                } else if (mem.startsWith(u8, arg, "-z")) {
+                    var z_arg = mem.trimLeft(u8, arg, "-z");
+                    if (z_arg.len == 0) {
+                        i += 1;
+                        if (i >= linker_args.items.len) {
+                            fatal("expected linker extension flag after '{s}'", .{arg});
+                        }
+                        z_arg = linker_args.items[i];
                     }
-                    const z_arg = linker_args.items[i];
                     if (mem.eql(u8, z_arg, "nodelete")) {
                         linker_z_nodelete = true;
                     } else if (mem.eql(u8, z_arg, "notext")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1956,7 +1956,7 @@ fn buildOutputType(
                         fatal("expected [none|zlib] after --compress-debug-sections, found '{s}'", .{arg1});
                     };
                 } else if (mem.startsWith(u8, arg, "-z")) {
-                    var z_arg = mem.trimLeft(u8, arg, "-z");
+                    var z_arg = arg[2..];
                     if (z_arg.len == 0) {
                         i += 1;
                         if (i >= linker_args.items.len) {


### PR DESCRIPTION
`lld` accepts both syntaxes, but we were rejecting (and, before 3f7e9ff597a3514bb1c4f1900027c40682ac9f13, ignoring) the former.

In particular, `cargo-zigbuild` was broken since Rust unconditionally [adds](https://github.com/rust-lang/rust/blame/7aa413d59206fd511137728df3d9e0fd377429bd/compiler/rustc_codegen_ssa/src/back/linker.rs#L761) `-znoexecstack` (not `-z noexecstack`) on non-Windows platforms.