### PR TITLE
CBE: fix more behavior tests

### DIFF
--- a/lib/zig.h
+++ b/lib/zig.h
@@ -5,6 +5,7 @@
 #endif
 #include <float.h>
 #include <limits.h>
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -78,6 +78,32 @@ typedef char bool;
 #define zig_cold
 #endif
 
+#if zig_has_attribute(flatten)
+#define zig_maybe_flatten __attribute__((flatten))
+#else
+#define zig_maybe_flatten
+#endif
+
+#if zig_has_attribute(noinline)
+#define zig_never_inline __attribute__((noinline)) zig_maybe_flatten
+#elif defined(_MSC_VER)
+#define zig_never_inline __declspec(noinline) zig_maybe_flatten
+#else
+#define zig_never_inline zig_never_inline_unavailable
+#endif
+
+#if zig_has_attribute(not_tail_called)
+#define zig_never_tail __attribute__((not_tail_called)) zig_never_inline
+#else
+#define zig_never_tail zig_never_tail_unavailable
+#endif
+
+#if zig_has_attribute(always_inline)
+#define zig_always_tail __attribute__((musttail))
+#else
+#define zig_always_tail zig_always_tail_unavailable
+#endif
+
 #if __STDC_VERSION__ >= 199901L
 #define zig_restrict restrict
 #elif defined(__GNUC__)

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -6876,17 +6876,16 @@ fn airCVaStart(f: *Function, inst: Air.Inst.Index) !CValue {
 
     const inst_ty = f.air.typeOfIndex(inst);
     const fn_cty = try f.typeToCType(f.object.dg.decl.?.ty, .complete);
-
     const param_len = fn_cty.castTag(.varargs_function).?.data.param_types.len;
-    if (param_len == 0)
-        return f.fail("CBE: C requires at least one runtime argument for varargs functions", .{});
 
     const writer = f.object.writer();
     const local = try f.allocLocal(inst, inst_ty);
     try writer.writeAll("va_start(*(va_list *)&");
     try f.writeCValue(writer, local, .Other);
-    try writer.writeAll(", ");
-    try f.writeCValue(writer, .{ .arg = param_len - 1 }, .FunctionArgument);
+    if (param_len > 0) {
+        try writer.writeAll(", ");
+        try f.writeCValue(writer, .{ .arg = param_len - 1 }, .FunctionArgument);
+    }
     try writer.writeAll(");\n");
     return local;
 }

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -247,8 +247,8 @@ pub fn flushModule(self: *C, comp: *Compilation, prog_node: *std.Progress.Node) 
 
     const abi_define = abiDefine(comp);
 
-    // Covers defines, zig.h, ctypes, asm, lazy fwd, lazy code.
-    try f.all_buffers.ensureUnusedCapacity(gpa, 6);
+    // Covers defines, zig.h, ctypes, asm, lazy fwd.
+    try f.all_buffers.ensureUnusedCapacity(gpa, 5);
 
     if (abi_define) |buf| f.appendBufAssumeCapacity(buf);
     f.appendBufAssumeCapacity(zig_h);
@@ -263,8 +263,8 @@ pub fn flushModule(self: *C, comp: *Compilation, prog_node: *std.Progress.Node) 
         f.appendBufAssumeCapacity(asm_buf.items);
     }
 
-    const lazy_indices = f.all_buffers.items.len;
-    f.all_buffers.items.len += 2;
+    const lazy_index = f.all_buffers.items.len;
+    f.all_buffers.items.len += 1;
 
     try self.flushErrDecls(&f.lazy_db);
 
@@ -297,6 +297,7 @@ pub fn flushModule(self: *C, comp: *Compilation, prog_node: *std.Progress.Node) 
 
     {
         // We need to flush lazy ctypes after flushing all decls but before flushing any decl ctypes.
+        // This ensures that every lazy CType.Index exactly matches the global CType.Index.
         assert(f.ctypes.count() == 0);
         try self.flushCTypes(&f, .none, f.lazy_db.ctypes);
 
@@ -305,30 +306,22 @@ pub fn flushModule(self: *C, comp: *Compilation, prog_node: *std.Progress.Node) 
             try self.flushCTypes(&f, entry.key_ptr.toOptional(), entry.value_ptr.ctypes);
     }
 
-    {
-        f.all_buffers.items[lazy_indices + 0] = .{
-            .iov_base = if (f.lazy_db.fwd_decl.items.len > 0) f.lazy_db.fwd_decl.items.ptr else "",
-            .iov_len = f.lazy_db.fwd_decl.items.len,
-        };
-        f.file_size += f.lazy_db.fwd_decl.items.len;
-
-        f.all_buffers.items[lazy_indices + 1] = .{
-            .iov_base = if (f.lazy_db.code.items.len > 0) f.lazy_db.code.items.ptr else "",
-            .iov_len = f.lazy_db.code.items.len,
-        };
-        f.file_size += f.lazy_db.code.items.len;
-    }
-
     f.all_buffers.items[ctypes_index] = .{
         .iov_base = if (f.ctypes_buf.items.len > 0) f.ctypes_buf.items.ptr else "",
         .iov_len = f.ctypes_buf.items.len,
     };
     f.file_size += f.ctypes_buf.items.len;
 
+    f.all_buffers.items[lazy_index] = .{
+        .iov_base = if (f.lazy_db.fwd_decl.items.len > 0) f.lazy_db.fwd_decl.items.ptr else "",
+        .iov_len = f.lazy_db.fwd_decl.items.len,
+    };
+    f.file_size += f.lazy_db.fwd_decl.items.len;
+
     // Now the code.
-    try f.all_buffers.ensureUnusedCapacity(gpa, decl_values.len);
-    for (decl_values) |decl|
-        f.appendBufAssumeCapacity(decl.code.items);
+    try f.all_buffers.ensureUnusedCapacity(gpa, 1 + decl_values.len);
+    f.appendBufAssumeCapacity(f.lazy_db.code.items);
+    for (decl_values) |decl| f.appendBufAssumeCapacity(decl.code.items);
 
     const file = self.base.file.?;
     try file.setEndPos(f.file_size);

--- a/src/target.zig
+++ b/src/target.zig
@@ -723,6 +723,7 @@ pub fn supportsFunctionAlignment(target: std.Target) bool {
 pub fn supportsTailCall(target: std.Target, backend: std.builtin.CompilerBackend) bool {
     switch (backend) {
         .stage1, .stage2_llvm => return @import("codegen/llvm.zig").supportsTailCall(target),
+        .stage2_c => return true,
         else => return false,
     }
 }

--- a/test/behavior/field_parent_ptr.zig
+++ b/test/behavior/field_parent_ptr.zig
@@ -48,7 +48,6 @@ fn testParentFieldPtrFirst(a: *const bool) !void {
 test "@fieldParentPtr untagged union" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     try testFieldParentPtrUnion(&bar.c);
@@ -75,7 +74,6 @@ fn testFieldParentPtrUnion(c: *const i32) !void {
 test "@fieldParentPtr tagged union" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     try testFieldParentPtrTaggedUnion(&bar_tagged.c);
@@ -102,7 +100,6 @@ fn testFieldParentPtrTaggedUnion(c: *const i32) !void {
 test "@fieldParentPtr extern union" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     try testFieldParentPtrExternUnion(&bar_extern.c);

--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -603,7 +603,6 @@ test "packed struct initialized in bitcast" {
 test "pointer to container level packed struct field" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -507,7 +507,6 @@ test "ptrCast comptime known slice to C pointer" {
 }
 
 test "ptrToInt on a generic function" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO

--- a/test/behavior/var_args.zig
+++ b/test/behavior/var_args.zig
@@ -96,10 +96,9 @@ fn doNothingWithFirstArg(args: anytype) void {
 test "simple variadic function" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.cpu.arch == .aarch64 and builtin.os.tag != .macos and builtin.zig_backend == .stage2_llvm) {
+    if (builtin.cpu.arch == .aarch64 and builtin.os.tag != .macos) {
         // https://github.com/ziglang/zig/issues/14096
         return error.SkipZigTest;
     }
@@ -124,8 +123,10 @@ test "simple variadic function" {
         }
     };
 
-    try std.testing.expectEqual(@as(c_int, 0), S.simple(@as(c_int, 0)));
-    try std.testing.expectEqual(@as(c_int, 1024), S.simple(@as(c_int, 1024)));
+    if (builtin.zig_backend != .stage2_c) { // C doesn't support varargs without a preceding runtime arg.
+        try std.testing.expectEqual(@as(c_int, 0), S.simple(@as(c_int, 0)));
+        try std.testing.expectEqual(@as(c_int, 1024), S.simple(@as(c_int, 1024)));
+    }
     try std.testing.expectEqual(@as(c_int, 0), S.add(0));
     try std.testing.expectEqual(@as(c_int, 1), S.add(1, @as(c_int, 1)));
     try std.testing.expectEqual(@as(c_int, 3), S.add(2, @as(c_int, 1), @as(c_int, 2)));
@@ -134,10 +135,9 @@ test "simple variadic function" {
 test "variadic functions" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.cpu.arch == .aarch64 and builtin.os.tag != .macos and builtin.zig_backend == .stage2_llvm) {
+    if (builtin.cpu.arch == .aarch64 and builtin.os.tag != .macos) {
         // https://github.com/ziglang/zig/issues/14096
         return error.SkipZigTest;
     }
@@ -178,10 +178,9 @@ test "variadic functions" {
 test "copy VaList" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.cpu.arch == .aarch64 and builtin.os.tag != .macos and builtin.zig_backend == .stage2_llvm) {
+    if (builtin.cpu.arch == .aarch64 and builtin.os.tag != .macos) {
         // https://github.com/ziglang/zig/issues/14096
         return error.SkipZigTest;
     }

--- a/test/behavior/var_args.zig
+++ b/test/behavior/var_args.zig
@@ -111,6 +111,12 @@ test "simple variadic function" {
             return @cVaArg(&ap, c_int);
         }
 
+        fn compatible(_: c_int, ...) callconv(.C) c_int {
+            var ap = @cVaStart();
+            defer @cVaEnd(&ap);
+            return @cVaArg(&ap, c_int);
+        }
+
         fn add(count: c_int, ...) callconv(.C) c_int {
             var ap = @cVaStart();
             defer @cVaEnd(&ap);
@@ -123,10 +129,13 @@ test "simple variadic function" {
         }
     };
 
-    if (builtin.zig_backend != .stage2_c) { // C doesn't support varargs without a preceding runtime arg.
+    if (builtin.zig_backend != .stage2_c) {
+        // pre C23 doesn't support varargs without a preceding runtime arg.
         try std.testing.expectEqual(@as(c_int, 0), S.simple(@as(c_int, 0)));
         try std.testing.expectEqual(@as(c_int, 1024), S.simple(@as(c_int, 1024)));
     }
+    try std.testing.expectEqual(@as(c_int, 0), S.compatible(undefined, @as(c_int, 0)));
+    try std.testing.expectEqual(@as(c_int, 1024), S.compatible(undefined, @as(c_int, 1024)));
     try std.testing.expectEqual(@as(c_int, 0), S.add(0));
     try std.testing.expectEqual(@as(c_int, 1), S.add(1, @as(c_int, 1)));
     try std.testing.expectEqual(@as(c_int, 3), S.add(2, @as(c_int, 1), @as(c_int, 2)));


### PR DESCRIPTION
 * `@fieldParentPtr` of a union
 * pointers to generic functions
 * c varargs
 * partial call attribute support

95% (1493/1569) on linux vs the llvm backend