### PR TITLE
zig fmt: Add a `reset indentation` directive

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5639,6 +5639,72 @@ test "zig fmt: no space before newline before multiline string" {
     );
 }
 
+test "zig fmt: reset indentation" {
+    try testCanonical(
+        \\pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
+        \\    if (alignment) |a| {
+        \\        if (a == @alignOf(T)) {
+        \\            return ArrayListAligned(T, null);
+        \\        }
+        \\    }
+        \\    return struct {
+        \\        // zig fmt: reset indentation
+        \\
+        \\const Self = @This();
+        \\
+        \\items: Slice,
+        \\capacity: usize,
+        \\allocator: Allocator,
+        \\
+        \\pub const Slice = if (alignment) |a| ([]align(a) T) else []T;
+        \\
+        \\pub fn init(allocator: Allocator) Self {
+        \\    return Self{
+        \\        .items = &[_]T{},
+        \\        .capacity = 0,
+        \\        .allocator = allocator,
+        \\    };
+        \\}
+        \\    };
+        \\}
+        \\
+    );
+}
+
+test "zig fmt: reset indentation twice" {
+    try testCanonical(
+        \\pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
+        \\    if (alignment) |a| {
+        \\        if (a == @alignOf(T)) {
+        \\            return ArrayListAligned(T, null);
+        \\        }
+        \\    }
+        \\    return struct {
+        \\        // zig fmt: reset indentation
+        \\
+        \\const Self = @This();
+        \\
+        \\items: Slice,
+        \\capacity: usize,
+        \\allocator: Allocator,
+        \\
+        \\pub const Slice = if (alignment) |a| ([]align(a) T) else []T;
+        \\
+        \\pub fn init(allocator: Allocator) Self {
+        \\    // This has no effect:
+        \\    // zig fmt: reset indentation
+        \\    return Self{
+        \\        .items = &[_]T{},
+        \\        .capacity = 0,
+        \\        .allocator = allocator,
+        \\    };
+        \\}
+        \\    };
+        \\}
+        \\
+    );
+}
+
 // Normalize \xNN and \u{NN} escapes and unicode inside @"" escapes.
 test "zig fmt: canonicalize symbols (character escapes)" {
     try testTransform(


### PR DESCRIPTION
I mentioned this to Andrew a few weeks ago and he didn't seem immediately horrified :)

The motivation is that a lot of https://github.com/tigerbeetledb/tigerbeetle/ code is parameterized by comptime config to allow eg simulating network/disk. This means that most modules are wrapped in a function so almost the entire codebase is indented an extra 8 spaces.

Eg https://github.com/tigerbeetledb/tigerbeetle/blob/main/src/lsm/tree.zig#L73-L89 looks something like:

``` zig
pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_name: [:0]const u8) type {
    return struct {
        const Tree = @This();

        pub fn init(
            allocator: mem.Allocator,
            node_pool: *NodePool,
            grid: *Grid,
            options: Options,
        ) !Tree {
            assert(grid.superblock.opened);
            ...
```

We'd like to be able to write this instead:

``` zig
pub fn TreeType(comptime TreeTable: type, comptime Storage: type, comptime tree_name: [:0]const u8) type {
    return struct {
        // zig fmt: reset indentation

const Tree = @This();

pub fn init(
    allocator: mem.Allocator,
    node_pool: *NodePool,
    grid: *Grid,
    options: Options,
) !Tree {
    assert(grid.superblock.opened);
    ...
}

// (reset ends here, at the end of the block)
    };
}
```

After the comment the indentation is reset to 0. Once the current indentation level is popped, we return to the previous indentation level.


