### PR TITLE
Fixes #13893 - some standard library networking tests are failing on …

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2068,7 +2068,7 @@ pub fn loadWinsockExtensionFunction(comptime T: type, sock: ws2_32.SOCKET, guid:
         ws2_32.SIO_GET_EXTENSION_FUNCTION_POINTER,
         @ptrCast(*const anyopaque, &guid),
         @sizeOf(GUID),
-        @intToPtr(?*anyopaque, @ptrToInt(function)),
+        @intToPtr(?*anyopaque, @ptrToInt(&function)),
         @sizeOf(T),
         &num_bytes,
         null,


### PR DESCRIPTION
std/x was removed from std library, which has failed test that was observed by 13893, this MR fixes the function pointer issue in loadWinsockExtensionFunction, and adds related test.