### PR TITLE
fix RegQueryValueExW api

### DIFF
--- a/lib/std/os/windows/advapi32.zig
+++ b/lib/std/os/windows/advapi32.zig
@@ -21,10 +21,10 @@ pub extern "advapi32" fn RegOpenKeyExW(
 pub extern "advapi32" fn RegQueryValueExW(
     hKey: HKEY,
     lpValueName: LPCWSTR,
-    lpReserved: *DWORD,
-    lpType: *DWORD,
-    lpData: *BYTE,
-    lpcbData: *DWORD,
+    lpReserved: ?*DWORD,
+    lpType: ?*DWORD,
+    lpData: ?*BYTE,
+    lpcbData: ?*DWORD,
 ) callconv(WINAPI) LSTATUS;
 
 // RtlGenRandom is known as SystemFunction036 under advapi32


### PR DESCRIPTION
The current api of `RegQueryValueExW` doesn't seem to allow to have null values as `lpReserved`, `lpType`, `lpData` and `lpcbData`. It however should by looking at the [win32 docs](https://learn.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regqueryvalueexw):

![image](https://user-images.githubusercontent.com/25441359/221175097-8700b819-dc6c-4ff5-9f9d-5460a960847a.png)
![image](https://user-images.githubusercontent.com/25441359/221175179-86081f05-47a6-46e3-b74c-f25d8ca95a64.png)
