### PR TITLE
Improve error messages for break type coercion

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -1274,7 +1274,7 @@ fn fnProtoExpr(
                 defer param_gz.unstack();
                 const param_type = try expr(&param_gz, scope, coerced_type_ri, param_type_node);
                 const param_inst_expected = @intCast(u32, astgen.instructions.len + 1);
-                _ = try param_gz.addBreak(.break_inline, param_inst_expected, param_type);
+                _ = try param_gz.addBreakWithSrcNode(.break_inline, param_inst_expected, param_type, param_type_node);
                 const main_tokens = tree.nodes.items(.main_token);
                 const name_token = param.name_token orelse main_tokens[param_type_node];
                 const tag: Zir.Inst.Tag = if (is_comptime) .param_comptime else .param;
@@ -1983,7 +1983,7 @@ fn breakExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) Inn
 
                 switch (block_gz.break_result_info.rl) {
                     .block_ptr => {
-                        const br = try parent_gz.addBreak(break_tag, block_inst, operand);
+                        const br = try parent_gz.addBreakWithSrcNode(break_tag, block_inst, operand, rhs);
                         try block_gz.labeled_breaks.append(astgen.gpa, .{ .br = br, .search = search_index });
                     },
                     .ptr => {
@@ -1995,7 +1995,7 @@ fn breakExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) Inn
                         _ = try parent_gz.addBreak(break_tag, block_inst, .void_value);
                     },
                     else => {
-                        _ = try parent_gz.addBreak(break_tag, block_inst, operand);
+                        _ = try parent_gz.addBreakWithSrcNode(break_tag, block_inst, operand, rhs);
                     },
                 }
                 return Zir.Inst.Ref.unreachable_value;
@@ -3745,7 +3745,7 @@ fn fnDecl(
                 defer param_gz.unstack();
                 const param_type = try expr(&param_gz, params_scope, coerced_type_ri, param_type_node);
                 const param_inst_expected = @intCast(u32, astgen.instructions.len + 1);
-                _ = try param_gz.addBreak(.break_inline, param_inst_expected, param_type);
+                _ = try param_gz.addBreakWithSrcNode(.break_inline, param_inst_expected, param_type, param_type_node);
 
                 const main_tokens = tree.nodes.items(.main_token);
                 const name_token = param.name_token orelse main_tokens[param_type_node];
@@ -4105,7 +4105,7 @@ fn globalVarDecl(
     };
     // We do this at the end so that the instruction index marks the end
     // range of a top level declaration.
-    _ = try block_scope.addBreak(.break_inline, block_inst, var_inst);
+    _ = try block_scope.addBreakWithSrcNode(.break_inline, block_inst, var_inst, node);
     try block_scope.setBlockBody(block_inst);
 
     {
@@ -5447,7 +5447,9 @@ fn orelseCatchExpr(
         condbr,
         cond,
         then_result,
+        node,
         else_result,
+        rhs,
         block,
         block,
         break_tag,
@@ -5466,7 +5468,9 @@ fn finishThenElseBlock(
     condbr: Zir.Inst.Index,
     cond: Zir.Inst.Ref,
     then_result: Zir.Inst.Ref,
+    then_src_node: Ast.Node.Index,
     else_result: Zir.Inst.Ref,
+    else_src_node: Ast.Node.Index,
     main_block: Zir.Inst.Index,
     then_break_block: Zir.Inst.Index,
     break_tag: Zir.Inst.Tag,
@@ -5489,11 +5493,11 @@ fn finishThenElseBlock(
             return indexToRef(main_block);
         },
         .break_operand => {
-            const then_break = if (!then_no_return) try then_scope.makeBreak(break_tag, then_break_block, then_result) else 0;
+            const then_break = if (!then_no_return) try then_scope.makeBreakWithSrcNode(break_tag, then_break_block, then_result, then_src_node) else 0;
             const else_break = if (else_result == .none)
                 try else_scope.makeBreak(break_tag, main_block, .void_value)
             else if (!else_no_return)
-                try else_scope.makeBreak(break_tag, main_block, else_result)
+                try else_scope.makeBreakWithSrcNode(break_tag, main_block, else_result, else_src_node)
             else
                 0;
 
@@ -5674,7 +5678,7 @@ fn boolBinOp(
     defer rhs_scope.unstack();
     const rhs = try expr(&rhs_scope, &rhs_scope.base, bool_ri, node_datas[node].rhs);
     if (!gz.refIsNoReturn(rhs)) {
-        _ = try rhs_scope.addBreak(.break_inline, bool_br, rhs);
+        _ = try rhs_scope.addBreakWithSrcNode(.break_inline, bool_br, rhs, node_datas[node].rhs);
     }
     try rhs_scope.setBoolBrBody(bool_br);
 
@@ -5749,6 +5753,7 @@ fn ifExpr(
     var payload_val_scope: Scope.LocalVal = undefined;
 
     try then_scope.addDbgBlockBegin();
+    const then_node = if_full.ast.then_expr;
     const then_sub_scope = s: {
         if (if_full.error_token != null) {
             if (if_full.payload_token) |payload_token| {
@@ -5756,7 +5761,7 @@ fn ifExpr(
                     .err_union_payload_unsafe_ptr
                 else
                     .err_union_payload_unsafe;
-                const payload_inst = try then_scope.addUnNode(tag, cond.inst, if_full.ast.then_expr);
+                const payload_inst = try then_scope.addUnNode(tag, cond.inst, then_node);
                 const token_name_index = payload_token + @boolToInt(payload_is_ref);
                 const ident_name = try astgen.identAsString(token_name_index);
                 const token_name_str = tree.tokenSlice(token_name_index);
@@ -5786,7 +5791,7 @@ fn ifExpr(
             const ident_bytes = tree.tokenSlice(ident_token);
             if (mem.eql(u8, "_", ident_bytes))
                 break :s &then_scope.base;
-            const payload_inst = try then_scope.addUnNode(tag, cond.inst, if_full.ast.then_expr);
+            const payload_inst = try then_scope.addUnNode(tag, cond.inst, then_node);
             const ident_name = try astgen.identAsString(ident_token);
             try astgen.detectLocalShadowing(&then_scope.base, ident_name, ident_token, ident_bytes, .capture);
             payload_val_scope = .{
@@ -5804,7 +5809,7 @@ fn ifExpr(
         }
     };
 
-    const then_result = try expr(&then_scope, then_sub_scope, block_scope.break_result_info, if_full.ast.then_expr);
+    const then_result = try expr(&then_scope, then_sub_scope, block_scope.break_result_info, then_node);
     if (!then_scope.endsWithNoReturn()) {
         block_scope.break_count += 1;
     }
@@ -5869,7 +5874,7 @@ fn ifExpr(
             .result = e,
         };
     } else .{
-        .src = if_full.ast.then_expr,
+        .src = then_node,
         .result = switch (ri.rl) {
             // Explicitly store void to ptr result loc if there is no else branch
             .ptr, .block_ptr => try rvalue(&else_scope, ri, .void_value, node),
@@ -5888,7 +5893,9 @@ fn ifExpr(
         condbr,
         cond.bool_bit,
         then_result,
+        then_node,
         else_info.result,
+        else_info.src,
         block,
         block,
         break_tag,
@@ -6176,6 +6183,7 @@ fn whileExpr(
     then_scope.instructions_top = then_scope.instructions.items.len;
 
     try then_scope.addDbgBlockBegin();
+    const then_node = while_full.ast.then_expr;
     if (payload_inst != 0) try then_scope.instructions.append(astgen.gpa, payload_inst);
     if (dbg_var_name) |name| try then_scope.addDbgVar(.dbg_var_val, name, dbg_var_inst);
     try then_scope.instructions.append(astgen.gpa, continue_block);
@@ -6189,7 +6197,7 @@ fn whileExpr(
     try then_scope.addDbgBlockEnd();
 
     continue_scope.instructions_top = continue_scope.instructions.items.len;
-    _ = try unusedResultExpr(&continue_scope, &continue_scope.base, while_full.ast.then_expr);
+    _ = try unusedResultExpr(&continue_scope, &continue_scope.base, then_node);
     try checkUsed(parent_gz, &then_scope.base, then_sub_scope);
     const break_tag: Zir.Inst.Tag = if (is_inline) .break_inline else .@"break";
     if (!continue_scope.endsWithNoReturn()) {
@@ -6252,7 +6260,7 @@ fn whileExpr(
             .result = else_result,
         };
     } else .{
-        .src = while_full.ast.then_expr,
+        .src = then_node,
         .result = .none,
     };
 
@@ -6271,7 +6279,9 @@ fn whileExpr(
         condbr,
         cond.bool_bit,
         .void_value,
+        then_node,
         else_info.result,
+        else_info.src,
         loop_block,
         cond_block,
         break_tag,
@@ -6459,6 +6469,7 @@ fn forExpr(
         });
     }
 
+    var then_node = for_full.ast.then_expr;
     var then_scope = parent_gz.makeSubBlock(&cond_scope.base);
     defer then_scope.unstack();
 
@@ -6526,8 +6537,8 @@ fn forExpr(
         break :blk capture_sub_scope;
     };
 
-    const then_result = try expr(&then_scope, then_sub_scope, .{ .rl = .none }, for_full.ast.then_expr);
-    _ = try addEnsureResult(&then_scope, then_result, for_full.ast.then_expr);
+    const then_result = try expr(&then_scope, then_sub_scope, .{ .rl = .none }, then_node);
+    _ = try addEnsureResult(&then_scope, then_result, then_node);
 
     try checkUsed(parent_gz, &then_scope.base, then_sub_scope);
     try then_scope.addDbgBlockEnd();
@@ -6558,7 +6569,7 @@ fn forExpr(
             .result = else_result,
         };
     } else .{
-        .src = for_full.ast.then_expr,
+        .src = then_node,
         .result = .none,
     };
 
@@ -6578,7 +6589,9 @@ fn forExpr(
         condbr,
         cond,
         then_result,
+        then_node,
         else_info.result,
+        else_info.src,
         loop_block,
         cond_block,
         break_tag,
@@ -6937,12 +6950,13 @@ fn switchExpr(
             if (dbg_var_tag_name) |some| {
                 try case_scope.addDbgVar(.dbg_var_val, some, dbg_var_tag_inst);
             }
-            const case_result = try expr(&case_scope, sub_scope, block_scope.break_result_info, case.ast.target_expr);
+            const target_expr_node = case.ast.target_expr;
+            const case_result = try expr(&case_scope, sub_scope, block_scope.break_result_info, target_expr_node);
             try checkUsed(parent_gz, &case_scope.base, sub_scope);
             try case_scope.addDbgBlockEnd();
             if (!parent_gz.refIsNoReturn(case_result)) {
                 block_scope.break_count += 1;
-                _ = try case_scope.addBreak(.@"break", switch_block, case_result);
+                _ = try case_scope.addBreakWithSrcNode(.@"break", switch_block, case_result, target_expr_node);
             }
 
             const case_slice = case_scope.instructionsSlice();
@@ -7045,10 +7059,12 @@ fn switchExpr(
             .break_void => {
                 assert(!strat.elide_store_to_block_ptr_instructions);
                 const last_inst = payloads.items[end_index - 1];
-                if (zir_tags[last_inst] == .@"break" and
-                    zir_datas[last_inst].@"break".block_inst == switch_block)
-                {
-                    zir_datas[last_inst].@"break".operand = .void_value;
+                if (zir_tags[last_inst] == .@"break") {
+                    const inst_data = zir_datas[last_inst].@"break";
+                    const block_inst = astgen.extra.items[inst_data.payload_index];
+                    if (block_inst == switch_block) {
+                        zir_datas[last_inst].@"break".operand = .void_value;
+                    }
                 }
             },
         }
@@ -8839,7 +8855,7 @@ fn callExpr(
         // `call_inst` is reused to provide the param type.
         arg_block.rl_ty_inst = call_inst;
         const arg_ref = try expr(&arg_block, &arg_block.base, .{ .rl = .{ .coerced_ty = call_inst }, .ctx = .fn_arg }, param_node);
-        _ = try arg_block.addBreak(.break_inline, call_index, arg_ref);
+        _ = try arg_block.addBreakWithSrcNode(.break_inline, call_index, arg_ref, param_node);
 
         const body = arg_block.instructionsSlice();
         try astgen.scratch.ensureUnusedCapacity(astgen.gpa, countBodyLenAfterFixups(astgen, body));
@@ -11242,35 +11258,40 @@ const GenZir = struct {
             if (align_body.len != 0) {
                 astgen.extra.appendAssumeCapacity(countBodyLenAfterFixups(astgen, align_body));
                 astgen.appendBodyWithFixups(align_body);
-                zir_datas[align_body[align_body.len - 1]].@"break".block_inst = new_index;
+                const inst_data = zir_datas[align_body[align_body.len - 1]].@"break";
+                astgen.extra.items[inst_data.payload_index] = new_index;
             } else if (args.align_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@enumToInt(args.align_ref));
             }
             if (addrspace_body.len != 0) {
                 astgen.extra.appendAssumeCapacity(countBodyLenAfterFixups(astgen, addrspace_body));
                 astgen.appendBodyWithFixups(addrspace_body);
-                zir_datas[addrspace_body[addrspace_body.len - 1]].@"break".block_inst = new_index;
+                const inst_data = zir_datas[addrspace_body[addrspace_body.len - 1]].@"break";
+                astgen.extra.items[inst_data.payload_index] = new_index;
             } else if (args.addrspace_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@enumToInt(args.addrspace_ref));
             }
             if (section_body.len != 0) {
                 astgen.extra.appendAssumeCapacity(countBodyLenAfterFixups(astgen, section_body));
                 astgen.appendBodyWithFixups(section_body);
-                zir_datas[section_body[section_body.len - 1]].@"break".block_inst = new_index;
+                const inst_data = zir_datas[section_body[section_body.len - 1]].@"break";
+                astgen.extra.items[inst_data.payload_index] = new_index;
             } else if (args.section_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@enumToInt(args.section_ref));
             }
             if (cc_body.len != 0) {
                 astgen.extra.appendAssumeCapacity(countBodyLenAfterFixups(astgen, cc_body));
                 astgen.appendBodyWithFixups(cc_body);
-                zir_datas[cc_body[cc_body.len - 1]].@"break".block_inst = new_index;
+                const inst_data = zir_datas[cc_body[cc_body.len - 1]].@"break";
+                astgen.extra.items[inst_data.payload_index] = new_index;
             } else if (args.cc_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@enumToInt(args.cc_ref));
             }
             if (ret_body.len != 0) {
                 astgen.extra.appendAssumeCapacity(countBodyLenAfterFixups(astgen, ret_body));
                 astgen.appendBodyWithFixups(ret_body);
-                zir_datas[ret_body[ret_body.len - 1]].@"break".block_inst = new_index;
+                const inst_data = zir_datas[ret_body[ret_body.len - 1]].@"break";
+                astgen.extra.items[inst_data.payload_index] = new_index;
             } else if (ret_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@enumToInt(ret_ref));
             }
@@ -11324,7 +11345,9 @@ const GenZir = struct {
             const zir_datas = astgen.instructions.items(.data);
             if (ret_body.len != 0) {
                 astgen.appendBodyWithFixups(ret_body);
-                zir_datas[ret_body[ret_body.len - 1]].@"break".block_inst = new_index;
+
+                const inst_data = zir_datas[ret_body[ret_body.len - 1]].@"break";
+                astgen.extra.items[inst_data.payload_index] = new_index;
             } else if (ret_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@enumToInt(ret_ref));
             }
@@ -11770,30 +11793,104 @@ const GenZir = struct {
     fn addBreak(
         gz: *GenZir,
         tag: Zir.Inst.Tag,
-        break_block: Zir.Inst.Index,
+        block_inst: Zir.Inst.Index,
         operand: Zir.Inst.Ref,
     ) !Zir.Inst.Index {
-        return gz.addAsIndex(.{
+        const gpa = gz.astgen.gpa;
+        try gz.instructions.ensureUnusedCapacity(gpa, 1);
+        try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
+
+        const extra: Zir.Inst.Break = .{
+            .block_inst = block_inst,
+            .operand_src_node = Zir.Inst.Break.no_src_node,
+        };
+        const payload_index = try gz.astgen.addExtra(extra);
+        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .@"break" = .{
-                .block_inst = break_block,
                 .operand = operand,
+                .payload_index = payload_index,
             } },
         });
+        gz.instructions.appendAssumeCapacity(new_index);
+        return new_index;
     }
 
     fn makeBreak(
         gz: *GenZir,
         tag: Zir.Inst.Tag,
-        break_block: Zir.Inst.Index,
+        block_inst: Zir.Inst.Index,
         operand: Zir.Inst.Ref,
     ) !Zir.Inst.Index {
+        const gpa = gz.astgen.gpa;
+        try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
+
+        const extra: Zir.Inst.Break = .{
+            .block_inst = block_inst,
+            .operand_src_node = Zir.Inst.Break.no_src_node,
+        };
+        const payload_index = try gz.astgen.addExtra(extra);
         const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
-        try gz.astgen.instructions.append(gz.astgen.gpa, .{
+        gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .@"break" = .{
-                .block_inst = break_block,
                 .operand = operand,
+                .payload_index = payload_index,
+            } },
+        });
+        return new_index;
+    }
+
+    fn addBreakWithSrcNode(
+        gz: *GenZir,
+        tag: Zir.Inst.Tag,
+        block_inst: Zir.Inst.Index,
+        operand: Zir.Inst.Ref,
+        operand_src_node: Ast.Node.Index,
+    ) !Zir.Inst.Index {
+        const gpa = gz.astgen.gpa;
+        try gz.instructions.ensureUnusedCapacity(gpa, 1);
+        try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
+
+        const extra: Zir.Inst.Break = .{
+            .block_inst = block_inst,
+            .operand_src_node = gz.nodeIndexToRelative(operand_src_node),
+        };
+        const payload_index = try gz.astgen.addExtra(extra);
+        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        gz.astgen.instructions.appendAssumeCapacity(.{
+            .tag = tag,
+            .data = .{ .@"break" = .{
+                .operand = operand,
+                .payload_index = payload_index,
+            } },
+        });
+        gz.instructions.appendAssumeCapacity(new_index);
+        return new_index;
+    }
+
+    fn makeBreakWithSrcNode(
+        gz: *GenZir,
+        tag: Zir.Inst.Tag,
+        block_inst: Zir.Inst.Index,
+        operand: Zir.Inst.Ref,
+        operand_src_node: Ast.Node.Index,
+    ) !Zir.Inst.Index {
+        const gpa = gz.astgen.gpa;
+        try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
+
+        const extra: Zir.Inst.Break = .{
+            .block_inst = block_inst,
+            .operand_src_node = gz.nodeIndexToRelative(operand_src_node),
+        };
+        const payload_index = try gz.astgen.addExtra(extra);
+        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        gz.astgen.instructions.appendAssumeCapacity(.{
+            .tag = tag,
+            .data = .{ .@"break" = .{
+                .operand = operand,
+                .payload_index = payload_index,
             } },
         });
         return new_index;

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -6002,7 +6002,7 @@ pub const PeerTypeCandidateSrc = union(enum) {
     none: void,
     /// When we want to know the the src of candidate i, look up at
     /// index i in this slice
-    override: []LazySrcLoc,
+    override: []?LazySrcLoc,
     /// resolvePeerTypes originates from a @TypeOf(...) call
     typeof_builtin_call_node_offset: i32,
 

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2599,8 +2599,8 @@ pub const Inst = struct {
             }
         },
         @"break": struct {
-            block_inst: Index,
             operand: Ref,
+            payload_index: u32,
         },
         switch_capture: struct {
             switch_inst: Index,
@@ -2684,6 +2684,13 @@ pub const Inst = struct {
             save_err_ret_index,
             restore_err_ret_index,
         };
+    };
+
+    pub const Break = struct {
+        pub const no_src_node = std.math.maxInt(i32);
+
+        block_inst: Index,
+        operand_src_node: i32,
     };
 
     /// Trailing:

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -2320,8 +2320,9 @@ const Writer = struct {
 
     fn writeBreak(self: *Writer, stream: anytype, inst: Zir.Inst.Index) !void {
         const inst_data = self.code.instructions.items(.data)[inst].@"break";
+        const extra = self.code.extraData(Zir.Inst.Break, inst_data.payload_index).data;
 
-        try self.writeInstIndex(stream, inst_data.block_inst);
+        try self.writeInstIndex(stream, extra.block_inst);
         try stream.writeAll(", ");
         try self.writeInstRef(stream, inst_data.operand);
         try stream.writeAll(")");

--- a/test/cases/compile_errors/incompatible sub-byte fields.zig
+++ b/test/cases/compile_errors/incompatible sub-byte fields.zig
@@ -25,3 +25,5 @@ export fn entry() void {
 // target=native
 //
 // :14:17: error: incompatible types: '*align(1:0:1) u2' and '*align(2:8:2) u2'
+// :15:14: note: type '*align(1:0:1) u2' here
+// :16:14: note: type '*align(2:8:2) u2' here

--- a/test/cases/compile_errors/missing_else_clause.zig
+++ b/test/cases/compile_errors/missing_else_clause.zig
@@ -31,7 +31,9 @@ export fn entry() void {
 // target=native
 //
 // :2:21: error: incompatible types: 'i32' and 'void'
+// :6:25: note: type 'i32' here
 // :6:15: error: incompatible types: 'i32' and 'void'
+// :2:31: note: type 'i32' here
 // :12:16: error: expected type 'tmp.h.T', found 'void'
 // :11:15: note: struct declared here
 // :18:9: error: incompatible types: 'void' and 'tmp.k.T'

--- a/test/cases/compile_errors/missing_result_type_for_phi_node.zig
+++ b/test/cases/compile_errors/missing_result_type_for_phi_node.zig
@@ -10,3 +10,5 @@ export fn entry() void {
 // target=native
 //
 // :5:11: error: incompatible types: 'void' and 'comptime_int'
+// :5:11: note: type 'void' here
+// :5:17: note: type 'comptime_int' here

--- a/test/cases/compile_errors/unused_value_in_switch_in_loop.zig
+++ b/test/cases/compile_errors/unused_value_in_switch_in_loop.zig
@@ -12,3 +12,5 @@ export fn entry() void {
 // target=native
 //
 // :3:18: error: incompatible types: 'comptime_int' and 'void'
+// :4:14: note: type 'comptime_int' here
+// :5:16: note: type 'void' here


### PR DESCRIPTION
I wanted to experiment a bit and improve these error messages but I have no idea if this is the right way to go about it. If it's not, I'm happy to do it differently if I can get a nudge in the right direction, otherwise feel free to just close the PR :smile:

This turns `@"break"` data from a nice, self-containted 8 byte struct into something more like a `pl_node` with extra data. I haven't measured the performance impact since I wanted some feedback if this overall approach before investing too much time.

Examples of the improved error messages:

#### While loops

```zig
var x: bool = true;
const b = while (x) {
    break 1;
} else "asdf";
_ = b;
```

Before:

```zig
fails.zig:85:15: error: incompatible types: 'comptime_int' and '*const [4:0]u8'
    const b = for (a) |_| {
```

After:

```zig
fails.zig:7:15: error: incompatible types: 'comptime_int' and '*const [4:0]u8'
    const b = while (x) {
              ^~~~~
fails.zig:8:15: note: type 'comptime_int' here
        break 1;
              ^
fails.zig:9:12: note: type '*const [4:0]u8' here
    } else "asdf";
```

### Some more examples

#### For loops

<details>

```zig
const a = [_]u8{ 1, 2, 3 };
const b = for (a) |_| {
    break 1;
} else "a";
_ = b;
```

Before:

```zig
fails.zig:35:15: error: incompatible types: 'comptime_int' and '*const [1:0]u8'
    const b = for (a) |_| {
              ^~~
```

After:

```zig
fails.zig:35:15: error: incompatible types: 'comptime_int' and '*const [1:0]u8'
    const b = for (a) |_| {
              ^~~
fails.zig:36:15: note: type 'comptime_int' here
        break 1;
              ^
fails.zig:37:12: note: type '*const [1:0]u8' here
    } else "a";
```
</details>

#### Switch

<details>

```zig
var a: usize = 1;
const b = switch (a) {
    1 => false,
    2 => true,
    3 => "a",
    else => 2,
};
_ = b;
```

Before:

```zig
fails.zig:120:15: error: incompatible types: 'bool' and '*const [1:0]u8'
    const b = switch (a) {
              ^~~~~~
```

After:

```zig
fails.zig:120:15: error: incompatible types: 'bool' and '*const [1:0]u8'
    const b = switch (a) {
              ^~~~~~
fails.zig:121:14: note: type 'bool' here
        1 => false,
             ^~~~~
fails.zig:123:14: note: type '*const [1:0]u8' here
        3 => "a",
             ^~~
```
</details>

Some cases can still be improved, for instace the notorious `incompatible types: 'foo' and 'void'` with the missing else-branch on `for` and `while` loops. Here's what it looks like now:

<details>

```zig
var a: bool = true;
const b = while (a) {
    break 1;
};
_ = b;
```

Before:

```zig
fails.zig:14:15: error: incompatible types: 'comptime_int' and 'void'
    const b = while (a) {
```

After:

```zig
fails.zig:14:15: error: incompatible types: 'comptime_int' and 'void'
    const b = while (a) {
              ^~~~~
fails.zig:15:15: note: type 'comptime_int' here
        break 1;`
```
</details>


Loops with labeled blocks in the `else` statement are also not as good as they could be, it would be better if the error pointed at the `break` instruction.

<details>

```zig
const a = [_]u8{ 1, 2, 3 };
const b = for (a) |_| {
    break 1;
} else blk: {
    break :blk "asdf";
};
_ = b;
```

Before:

```zig
fails.zig:85:15: error: incompatible types: 'comptime_int' and '*const [4:0]u8'
    const b = for (a) |_| {
              ^~~
```

After:

```zig
fails.zig:85:15: error: incompatible types: 'comptime_int' and '*const [4:0]u8'
    const b = for (a) |_| {
              ^~~
fails.zig:86:15: note: type 'comptime_int' here
        break 1;
              ^
fails.zig:87:17: note: type '*const [4:0]u8' here
    } else blk: {
           ~~~~~^
```
</details>