### PR TITLE
introduce std.io.poll

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -210,13 +210,7 @@ pub const ChildProcess = struct {
     ) !void {
         debug.assert(child.stdout_behavior == .Pipe);
         debug.assert(child.stderr_behavior == .Pipe);
-        if (builtin.os.tag == .haiku) {
-            const stdout_in = child.stdout.?.reader();
-            const stderr_in = child.stderr.?.reader();
-
-            try stdout_in.readAllArrayList(stdout, max_output_bytes);
-            try stderr_in.readAllArrayList(stderr, max_output_bytes);
-        } else if (builtin.os.tag == .windows) {
+        if (builtin.os.tag == .windows) {
             try collectOutputWindows(child, stdout, stderr, max_output_bytes);
         } else {
             try collectOutputPosix(child, stdout, stderr, max_output_bytes);

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -423,6 +423,7 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
             }
         } else struct {};
 
+        /// Returns true if there were leaks; false otherwise.
         pub fn deinit(self: *Self) bool {
             const leaks = if (config.safety) self.detectLeaks() else false;
             if (config.retain_metadata) {


### PR DESCRIPTION
## Motivation

I need the logic from `std.ChildProcess.collectOutput` for some other work I'm doing in #14647. This is my attempt to extract it into a reusable abstraction. In short summary, the usage looks like this:

```zig
    var poller = std.io.poll(gpa, enum { stdout, stderr }, .{
        .stdout = child.stdout.?,
        .stderr = child.stderr.?,
    });
    defer poller.deinit();

    while (!poller.done()) try poller.poll();
```

Each stream gets a `std.fifo.LinearFifo` which can be accessed by e.g. `poller.fifo(.stdout)`. You can do this inside the while loop, or you can just let it accumulate as I have done above.

## Testing

Here is the code I used to test this. Before merging this PR I will break it up into parent.zig and child.zig and move it to be a standalone test.

```
zig build-exe test.zig
./test
```

```zig
const std = @import("std");

pub fn main() !void {
    var general_purpose_allocator: std.heap.GeneralPurposeAllocator(.{}) = .{};
    defer if (general_purpose_allocator.deinit()) std.process.exit(1);
    const gpa = general_purpose_allocator.allocator();

    var arena_instance = std.heap.ArenaAllocator.init(gpa);
    defer arena_instance.deinit();
    const arena = arena_instance.allocator();

    const args = try std.process.argsAlloc(arena);

    if (args.len >= 2) {
        return childMain();
    } else {
        return parent(gpa, arena);
    }
}

fn parent(gpa: std.mem.Allocator, arena: std.mem.Allocator) !void {
    const self_exe_path = try std.fs.selfExePathAlloc(arena);
    var child = std.ChildProcess.init(&.{ self_exe_path, "child" }, gpa);

    child.stdin_behavior = .Pipe;
    child.stdout_behavior = .Pipe;
    child.stderr_behavior = .Pipe;

    try child.spawn();

    var poller = std.io.poll(gpa, enum { stdout, stderr }, .{
        .stdout = child.stdout.?,
        .stderr = child.stderr.?,
    });
    defer poller.deinit();

    try child.stdin.?.writeAll("the input");
    child.stdin.?.close(); // send EOF
    child.stdin = null;

    while (!poller.done()) try poller.poll();

    const term = try child.wait();
    switch (term) {
        .Exited => |code| {
            if (code != 0) @panic("bad child exit code");
        },
        else => @panic("child crash"),
    }

    const stdout = poller.fifo(.stdout).readableSlice(0);
    const stderr = poller.fifo(.stderr).readableSlice(0);

    for (0..10000) |i| {
        if (!std.mem.eql(u8, stderr[i * "Garbage".len ..][0.."Garbage".len], "Garbage")) {
            @panic("Garbage failure");
        }
        if (!std.mem.eql(u8, stdout[i * "Trash".len ..][0.."Trash".len], "Trash")) {
            @panic("Trash failure");
        }
    }
}

fn childMain() !void {
    const stdout = std.io.getStdOut();
    const stderr = std.io.getStdErr();
    const stdin = std.io.getStdIn();

    for (0..10000) |_| {
        try stderr.writeAll("Garbage");
        try stdout.writeAll("Trash");
    }

    var buf: [1000]u8 = undefined;
    const amt = try stdin.readAll(&buf);
    if (!std.mem.eql(u8, buf[0..amt], "the input")) {
        @panic("test failure");
    }
}
```

## Merge Checklist
 * [ ] Add the Windows implementation using overlapped I/O
 * [ ] Rework `std.ChildProcess.collectOutput` to use this abstraction. Most of that code can be deleted in theory, just need to add logic to limit to `max_output_bytes`.
 * [ ] Rework the above test file into a proper test case, probably a standalone one.