### PR TITLE
CBE: add support for integers larger than 128 bits (and apparently vectors too)

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -1674,6 +1674,7 @@ pub const Mutable = struct {
 
     /// If a is positive, this passes through to truncate.
     /// If a is negative, then r is set to positive with the bit pattern ~(a - 1).
+    /// r may alias a.
     ///
     /// Asserts `r` has enough storage to store the result.
     /// The upper bound is `calcTwosCompLimbCount(a.len)`.

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -1360,8 +1360,8 @@ typedef   signed __int128 zig_i128;
 
 #define zig_make_u128(hi, lo) ((zig_u128)(hi)<<64|(lo))
 #define zig_make_i128(hi, lo) ((zig_i128)zig_make_u128(hi, lo))
-#define zig_make_constant_u128(hi, lo) zig_make_u128(hi, lo)
-#define zig_make_constant_i128(hi, lo) zig_make_i128(hi, lo)
+#define zig_init_u128(hi, lo) zig_make_u128(hi, lo)
+#define zig_init_i128(hi, lo) zig_make_i128(hi, lo)
 #define zig_hi_u128(val) ((uint64_t)((val) >> 64))
 #define zig_lo_u128(val) ((uint64_t)((val) >>  0))
 #define zig_hi_i128(val) (( int64_t)((val) >> 64))
@@ -1391,11 +1391,11 @@ typedef struct { zig_align(16) int64_t hi; uint64_t lo; } zig_i128;
 #define zig_make_i128(hi, lo) ((zig_i128){ .h##i = (hi), .l##o = (lo) })
 
 #if _MSC_VER /* MSVC doesn't allow struct literals in constant expressions */
-#define zig_make_constant_u128(hi, lo) { .h##i = (hi), .l##o = (lo) }
-#define zig_make_constant_i128(hi, lo) { .h##i = (hi), .l##o = (lo) }
+#define zig_init_u128(hi, lo) { .h##i = (hi), .l##o = (lo) }
+#define zig_init_i128(hi, lo) { .h##i = (hi), .l##o = (lo) }
 #else /* But non-MSVC doesn't like the unprotected commas */
-#define zig_make_constant_u128(hi, lo) zig_make_u128(hi, lo)
-#define zig_make_constant_i128(hi, lo) zig_make_i128(hi, lo)
+#define zig_init_u128(hi, lo) zig_make_u128(hi, lo)
+#define zig_init_i128(hi, lo) zig_make_i128(hi, lo)
 #endif
 #define zig_hi_u128(val) ((val).hi)
 #define zig_lo_u128(val) ((val).lo)

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -1921,7 +1921,7 @@ static inline zig_i128 zig_bit_reverse_i128(zig_i128 val, uint8_t bits) {
 
 static inline uint16_t zig_int_bytes(uint16_t bits) {
     uint16_t bytes = (bits + CHAR_BIT - 1) / CHAR_BIT;
-    uint16_t alignment = 16;
+    uint16_t alignment = ZIG_TARGET_MAX_INT_ALIGNMENT;
     while (alignment / 2 >= bytes) alignment /= 2;
     return (bytes + alignment - 1) / alignment * alignment;
 }

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -612,12 +612,6 @@ static inline bool zig_addo_u32(uint32_t *res, uint32_t lhs, uint32_t rhs, uint8
 #endif
 }
 
-static inline void zig_vaddo_u32(uint8_t *ov, uint32_t *res, int n,
-    const uint32_t *lhs, const uint32_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_addo_u32(&res[i], lhs[i], rhs[i], bits);
-}
-
 zig_extern int32_t  __addosi4(int32_t lhs, int32_t rhs, int *overflow);
 static inline bool zig_addo_i32(int32_t *res, int32_t lhs, int32_t rhs, uint8_t bits) {
 #if zig_has_builtin(add_overflow) || defined(zig_gnuc)
@@ -632,12 +626,6 @@ static inline bool zig_addo_i32(int32_t *res, int32_t lhs, int32_t rhs, uint8_t 
     return overflow || full_res < zig_minInt_i(32, bits) || full_res > zig_maxInt_i(32, bits);
 }
 
-static inline void zig_vaddo_i32(uint8_t *ov, int32_t *res, int n,
-    const int32_t *lhs, const int32_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_addo_i32(&res[i], lhs[i], rhs[i], bits);
-}
-
 static inline bool zig_addo_u64(uint64_t *res, uint64_t lhs, uint64_t rhs, uint8_t bits) {
 #if zig_has_builtin(add_overflow) || defined(zig_gnuc)
     uint64_t full_res;
@@ -648,12 +636,6 @@ static inline bool zig_addo_u64(uint64_t *res, uint64_t lhs, uint64_t rhs, uint8
     *res = zig_addw_u64(lhs, rhs, bits);
     return *res < lhs;
 #endif
-}
-
-static inline void zig_vaddo_u64(uint8_t *ov, uint64_t *res, int n,
-    const uint64_t *lhs, const uint64_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_addo_u64(&res[i], lhs[i], rhs[i], bits);
 }
 
 zig_extern int64_t  __addodi4(int64_t lhs, int64_t rhs, int *overflow);
@@ -670,12 +652,6 @@ static inline bool zig_addo_i64(int64_t *res, int64_t lhs, int64_t rhs, uint8_t 
     return overflow || full_res < zig_minInt_i(64, bits) || full_res > zig_maxInt_i(64, bits);
 }
 
-static inline void zig_vaddo_i64(uint8_t *ov, int64_t *res, int n,
-    const int64_t *lhs, const int64_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_addo_i64(&res[i], lhs[i], rhs[i], bits);
-}
-
 static inline bool zig_addo_u8(uint8_t *res, uint8_t lhs, uint8_t rhs, uint8_t bits) {
 #if zig_has_builtin(add_overflow) || defined(zig_gnuc)
     uint8_t full_res;
@@ -688,12 +664,6 @@ static inline bool zig_addo_u8(uint8_t *res, uint8_t lhs, uint8_t rhs, uint8_t b
     *res = (uint8_t)full_res;
     return overflow;
 #endif
-}
-
-static inline void zig_vaddo_u8(uint8_t *ov, uint8_t *res, int n,
-    const uint8_t *lhs, const uint8_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_addo_u8(&res[i], lhs[i], rhs[i], bits);
 }
 
 static inline bool zig_addo_i8(int8_t *res, int8_t lhs, int8_t rhs, uint8_t bits) {
@@ -710,12 +680,6 @@ static inline bool zig_addo_i8(int8_t *res, int8_t lhs, int8_t rhs, uint8_t bits
 #endif
 }
 
-static inline void zig_vaddo_i8(uint8_t *ov, int8_t *res, int n,
-    const int8_t *lhs, const int8_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_addo_i8(&res[i], lhs[i], rhs[i], bits);
-}
-
 static inline bool zig_addo_u16(uint16_t *res, uint16_t lhs, uint16_t rhs, uint8_t bits) {
 #if zig_has_builtin(add_overflow) || defined(zig_gnuc)
     uint16_t full_res;
@@ -728,12 +692,6 @@ static inline bool zig_addo_u16(uint16_t *res, uint16_t lhs, uint16_t rhs, uint8
     *res = (uint16_t)full_res;
     return overflow;
 #endif
-}
-
-static inline void zig_vaddo_u16(uint8_t *ov, uint16_t *res, int n,
-    const uint16_t *lhs, const uint16_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_addo_u16(&res[i], lhs[i], rhs[i], bits);
 }
 
 static inline bool zig_addo_i16(int16_t *res, int16_t lhs, int16_t rhs, uint8_t bits) {
@@ -750,12 +708,6 @@ static inline bool zig_addo_i16(int16_t *res, int16_t lhs, int16_t rhs, uint8_t 
 #endif
 }
 
-static inline void zig_vaddo_i16(uint8_t *ov, int16_t *res, int n,
-    const int16_t *lhs, const int16_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_addo_i16(&res[i], lhs[i], rhs[i], bits);
-}
-
 static inline bool zig_subo_u32(uint32_t *res, uint32_t lhs, uint32_t rhs, uint8_t bits) {
 #if zig_has_builtin(sub_overflow) || defined(zig_gnuc)
     uint32_t full_res;
@@ -766,12 +718,6 @@ static inline bool zig_subo_u32(uint32_t *res, uint32_t lhs, uint32_t rhs, uint8
     *res = zig_subw_u32(lhs, rhs, bits);
     return *res > lhs;
 #endif
-}
-
-static inline void zig_vsubo_u32(uint8_t *ov, uint32_t *res, int n,
-    const uint32_t *lhs, const uint32_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_subo_u32(&res[i], lhs[i], rhs[i], bits);
 }
 
 zig_extern int32_t  __subosi4(int32_t lhs, int32_t rhs, int *overflow);
@@ -788,12 +734,6 @@ static inline bool zig_subo_i32(int32_t *res, int32_t lhs, int32_t rhs, uint8_t 
     return overflow || full_res < zig_minInt_i(32, bits) || full_res > zig_maxInt_i(32, bits);
 }
 
-static inline void zig_vsubo_i32(uint8_t *ov, int32_t *res, int n,
-    const int32_t *lhs, const int32_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_subo_i32(&res[i], lhs[i], rhs[i], bits);
-}
-
 static inline bool zig_subo_u64(uint64_t *res, uint64_t lhs, uint64_t rhs, uint8_t bits) {
 #if zig_has_builtin(sub_overflow) || defined(zig_gnuc)
     uint64_t full_res;
@@ -804,12 +744,6 @@ static inline bool zig_subo_u64(uint64_t *res, uint64_t lhs, uint64_t rhs, uint8
     *res = zig_subw_u64(lhs, rhs, bits);
     return *res > lhs;
 #endif
-}
-
-static inline void zig_vsubo_u64(uint8_t *ov, uint64_t *res, int n,
-    const uint64_t *lhs, const uint64_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_subo_u64(&res[i], lhs[i], rhs[i], bits);
 }
 
 zig_extern int64_t  __subodi4(int64_t lhs, int64_t rhs, int *overflow);
@@ -826,12 +760,6 @@ static inline bool zig_subo_i64(int64_t *res, int64_t lhs, int64_t rhs, uint8_t 
     return overflow || full_res < zig_minInt_i(64, bits) || full_res > zig_maxInt_i(64, bits);
 }
 
-static inline void zig_vsubo_i64(uint8_t *ov, int64_t *res, int n,
-    const int64_t *lhs, const int64_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_subo_i64(&res[i], lhs[i], rhs[i], bits);
-}
-
 static inline bool zig_subo_u8(uint8_t *res, uint8_t lhs, uint8_t rhs, uint8_t bits) {
 #if zig_has_builtin(sub_overflow) || defined(zig_gnuc)
     uint8_t full_res;
@@ -844,12 +772,6 @@ static inline bool zig_subo_u8(uint8_t *res, uint8_t lhs, uint8_t rhs, uint8_t b
     *res = (uint8_t)full_res;
     return overflow;
 #endif
-}
-
-static inline void zig_vsubo_u8(uint8_t *ov, uint8_t *res, int n,
-    const uint8_t *lhs, const uint8_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_subo_u8(&res[i], lhs[i], rhs[i], bits);
 }
 
 static inline bool zig_subo_i8(int8_t *res, int8_t lhs, int8_t rhs, uint8_t bits) {
@@ -866,13 +788,6 @@ static inline bool zig_subo_i8(int8_t *res, int8_t lhs, int8_t rhs, uint8_t bits
 #endif
 }
 
-static inline void zig_vsubo_i8(uint8_t *ov, int8_t *res, int n,
-    const int8_t *lhs, const int8_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_subo_i8(&res[i], lhs[i], rhs[i], bits);
-}
-
-
 static inline bool zig_subo_u16(uint16_t *res, uint16_t lhs, uint16_t rhs, uint8_t bits) {
 #if zig_has_builtin(sub_overflow) || defined(zig_gnuc)
     uint16_t full_res;
@@ -886,13 +801,6 @@ static inline bool zig_subo_u16(uint16_t *res, uint16_t lhs, uint16_t rhs, uint8
     return overflow;
 #endif
 }
-
-static inline void zig_vsubo_u16(uint8_t *ov, uint16_t *res, int n,
-    const uint16_t *lhs, const uint16_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_subo_u16(&res[i], lhs[i], rhs[i], bits);
-}
-
 
 static inline bool zig_subo_i16(int16_t *res, int16_t lhs, int16_t rhs, uint8_t bits) {
 #if zig_has_builtin(sub_overflow) || defined(zig_gnuc)
@@ -908,12 +816,6 @@ static inline bool zig_subo_i16(int16_t *res, int16_t lhs, int16_t rhs, uint8_t 
 #endif
 }
 
-static inline void zig_vsubo_i16(uint8_t *ov, int16_t *res, int n,
-    const int16_t *lhs, const int16_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_subo_i16(&res[i], lhs[i], rhs[i], bits);
-}
-
 static inline bool zig_mulo_u32(uint32_t *res, uint32_t lhs, uint32_t rhs, uint8_t bits) {
 #if zig_has_builtin(mul_overflow) || defined(zig_gnuc)
     uint32_t full_res;
@@ -924,12 +826,6 @@ static inline bool zig_mulo_u32(uint32_t *res, uint32_t lhs, uint32_t rhs, uint8
     *res = zig_mulw_u32(lhs, rhs, bits);
     return rhs != UINT32_C(0) && lhs > zig_maxInt_u(32, bits) / rhs;
 #endif
-}
-
-static inline void zig_vmulo_u32(uint8_t *ov, uint32_t *res, int n,
-    const uint32_t *lhs, const uint32_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_mulo_u32(&res[i], lhs[i], rhs[i], bits);
 }
 
 zig_extern int32_t  __mulosi4(int32_t lhs, int32_t rhs, int *overflow);
@@ -946,12 +842,6 @@ static inline bool zig_mulo_i32(int32_t *res, int32_t lhs, int32_t rhs, uint8_t 
     return overflow || full_res < zig_minInt_i(32, bits) || full_res > zig_maxInt_i(32, bits);
 }
 
-static inline void zig_vmulo_i32(uint8_t *ov, int32_t *res, int n,
-    const int32_t *lhs, const int32_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_mulo_i32(&res[i], lhs[i], rhs[i], bits);
-}
-
 static inline bool zig_mulo_u64(uint64_t *res, uint64_t lhs, uint64_t rhs, uint8_t bits) {
 #if zig_has_builtin(mul_overflow) || defined(zig_gnuc)
     uint64_t full_res;
@@ -962,12 +852,6 @@ static inline bool zig_mulo_u64(uint64_t *res, uint64_t lhs, uint64_t rhs, uint8
     *res = zig_mulw_u64(lhs, rhs, bits);
     return rhs != UINT64_C(0) && lhs > zig_maxInt_u(64, bits) / rhs;
 #endif
-}
-
-static inline void zig_vmulo_u64(uint8_t *ov, uint64_t *res, int n,
-    const uint64_t *lhs, const uint64_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_mulo_u64(&res[i], lhs[i], rhs[i], bits);
 }
 
 zig_extern int64_t  __mulodi4(int64_t lhs, int64_t rhs, int *overflow);
@@ -984,12 +868,6 @@ static inline bool zig_mulo_i64(int64_t *res, int64_t lhs, int64_t rhs, uint8_t 
     return overflow || full_res < zig_minInt_i(64, bits) || full_res > zig_maxInt_i(64, bits);
 }
 
-static inline void zig_vmulo_i64(uint8_t *ov, int64_t *res, int n,
-    const int64_t *lhs, const int64_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_mulo_i64(&res[i], lhs[i], rhs[i], bits);
-}
-
 static inline bool zig_mulo_u8(uint8_t *res, uint8_t lhs, uint8_t rhs, uint8_t bits) {
 #if zig_has_builtin(mul_overflow) || defined(zig_gnuc)
     uint8_t full_res;
@@ -1002,12 +880,6 @@ static inline bool zig_mulo_u8(uint8_t *res, uint8_t lhs, uint8_t rhs, uint8_t b
     *res = (uint8_t)full_res;
     return overflow;
 #endif
-}
-
-static inline void zig_vmulo_u8(uint8_t *ov, uint8_t *res, int n,
-    const uint8_t *lhs, const uint8_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_mulo_u8(&res[i], lhs[i], rhs[i], bits);
 }
 
 static inline bool zig_mulo_i8(int8_t *res, int8_t lhs, int8_t rhs, uint8_t bits) {
@@ -1024,12 +896,6 @@ static inline bool zig_mulo_i8(int8_t *res, int8_t lhs, int8_t rhs, uint8_t bits
 #endif
 }
 
-static inline void zig_vmulo_i8(uint8_t *ov, int8_t *res, int n,
-    const int8_t *lhs, const int8_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_mulo_i8(&res[i], lhs[i], rhs[i], bits);
-}
-
 static inline bool zig_mulo_u16(uint16_t *res, uint16_t lhs, uint16_t rhs, uint8_t bits) {
 #if zig_has_builtin(mul_overflow) || defined(zig_gnuc)
     uint16_t full_res;
@@ -1044,12 +910,6 @@ static inline bool zig_mulo_u16(uint16_t *res, uint16_t lhs, uint16_t rhs, uint8
 #endif
 }
 
-static inline void zig_vmulo_u16(uint8_t *ov, uint16_t *res, int n,
-    const uint16_t *lhs, const uint16_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_mulo_u16(&res[i], lhs[i], rhs[i], bits);
-}
-
 static inline bool zig_mulo_i16(int16_t *res, int16_t lhs, int16_t rhs, uint8_t bits) {
 #if zig_has_builtin(mul_overflow) || defined(zig_gnuc)
     int16_t full_res;
@@ -1062,12 +922,6 @@ static inline bool zig_mulo_i16(int16_t *res, int16_t lhs, int16_t rhs, uint8_t 
     *res = (int16_t)full_res;
     return overflow;
 #endif
-}
-
-static inline void zig_vmulo_i16(uint8_t *ov, int16_t *res, int n,
-    const int16_t *lhs, const int16_t *rhs, uint8_t bits)
-{
-    for (int i = 0; i < n; ++i) ov[i] = zig_mulo_i16(&res[i], lhs[i], rhs[i], bits);
 }
 
 #define zig_int_builtins(w) \
@@ -2090,6 +1944,446 @@ static inline int32_t zig_cmp_big(const void *lhs, const void *rhs, bool is_sign
     return 0;
 }
 
+static inline bool zig_addo_big(void *res, const void *lhs, const void *rhs, bool is_signed, uint16_t bits) {
+    uint8_t *res_bytes = res;
+    const uint8_t *lhs_bytes = lhs;
+    const uint8_t *rhs_bytes = rhs;
+    uint16_t byte_offset = 0;
+    uint16_t remaining_bytes = zig_int_bytes(bits);
+    uint16_t top_bits = remaining_bytes * 8 - bits;
+    bool overflow = false;
+
+#if zig_big_endian
+    byte_offset = remaining_bytes;
+#endif
+
+    while (remaining_bytes >= 128 / CHAR_BIT) {
+        uint16_t limb_bits = 128 - (remaining_bytes == 128 / CHAR_BIT ? top_bits : 0);
+
+#if zig_big_endian
+        byte_offset -= 128 / CHAR_BIT;
+#endif
+
+        if (remaining_bytes == 128 / CHAR_BIT && is_signed) {
+            zig_i128 res_limb;
+            zig_i128 tmp_limb;
+            zig_i128 lhs_limb;
+            zig_i128 rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_addo_i128(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_addo_i128(&res_limb, tmp_limb, zig_make_i128(INT64_C(0), overflow ? UINT64_C(1) : UINT64_C(0)), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        } else {
+            zig_u128 res_limb;
+            zig_u128 tmp_limb;
+            zig_u128 lhs_limb;
+            zig_u128 rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_addo_u128(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_addo_u128(&res_limb, tmp_limb, zig_make_u128(UINT64_C(0), overflow ? UINT64_C(1) : UINT64_C(0)), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        }
+
+        remaining_bytes -= 128 / CHAR_BIT;
+
+#if zig_little_endian
+        byte_offset += 128 / CHAR_BIT;
+#endif
+    }
+
+    while (remaining_bytes >= 64 / CHAR_BIT) {
+        uint16_t limb_bits = 64 - (remaining_bytes == 64 / CHAR_BIT ? top_bits : 0);
+
+#if zig_big_endian
+        byte_offset -= 64 / CHAR_BIT;
+#endif
+
+        if (remaining_bytes == 64 / CHAR_BIT && is_signed) {
+            int64_t res_limb;
+            int64_t tmp_limb;
+            int64_t lhs_limb;
+            int64_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_addo_i64(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_addo_i64(&res_limb, tmp_limb, overflow ? INT64_C(1) : INT64_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        } else {
+            uint64_t res_limb;
+            uint64_t tmp_limb;
+            uint64_t lhs_limb;
+            uint64_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_addo_u64(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_addo_u64(&res_limb, tmp_limb, overflow ? UINT64_C(1) : UINT64_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        }
+
+        remaining_bytes -= 64 / CHAR_BIT;
+
+#if zig_little_endian
+        byte_offset += 64 / CHAR_BIT;
+#endif
+    }
+
+    while (remaining_bytes >= 32 / CHAR_BIT) {
+        uint16_t limb_bits = 32 - (remaining_bytes == 32 / CHAR_BIT ? top_bits : 0);
+
+#if zig_big_endian
+        byte_offset -= 32 / CHAR_BIT;
+#endif
+
+        if (remaining_bytes == 32 / CHAR_BIT && is_signed) {
+            int32_t res_limb;
+            int32_t tmp_limb;
+            int32_t lhs_limb;
+            int32_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_addo_i32(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_addo_i32(&res_limb, tmp_limb, overflow ? INT32_C(1) : INT32_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        } else {
+            uint32_t res_limb;
+            uint32_t tmp_limb;
+            uint32_t lhs_limb;
+            uint32_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_addo_u32(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_addo_u32(&res_limb, tmp_limb, overflow ? UINT32_C(1) : UINT32_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        }
+
+        remaining_bytes -= 32 / CHAR_BIT;
+
+#if zig_little_endian
+        byte_offset += 32 / CHAR_BIT;
+#endif
+    }
+
+    while (remaining_bytes >= 16 / CHAR_BIT) {
+        uint16_t limb_bits = 16 - (remaining_bytes == 16 / CHAR_BIT ? top_bits : 0);
+
+#if zig_big_endian
+        byte_offset -= 16 / CHAR_BIT;
+#endif
+
+        if (remaining_bytes == 16 / CHAR_BIT && is_signed) {
+            int16_t res_limb;
+            int16_t tmp_limb;
+            int16_t lhs_limb;
+            int16_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_addo_i16(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_addo_i16(&res_limb, tmp_limb, overflow ? INT16_C(1) : INT16_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        } else {
+            uint16_t res_limb;
+            uint16_t tmp_limb;
+            uint16_t lhs_limb;
+            uint16_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_addo_u16(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_addo_u16(&res_limb, tmp_limb, overflow ? UINT16_C(1) : UINT16_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        }
+
+        remaining_bytes -= 16 / CHAR_BIT;
+
+#if zig_little_endian
+        byte_offset += 16 / CHAR_BIT;
+#endif
+    }
+
+    while (remaining_bytes >= 8 / CHAR_BIT) {
+        uint16_t limb_bits = 8 - (remaining_bytes == 8 / CHAR_BIT ? top_bits : 0);
+
+#if zig_big_endian
+        byte_offset -= 8 / CHAR_BIT;
+#endif
+
+        if (remaining_bytes == 8 / CHAR_BIT && is_signed) {
+            int8_t res_limb;
+            int8_t tmp_limb;
+            int8_t lhs_limb;
+            int8_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_addo_i8(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_addo_i8(&res_limb, tmp_limb, overflow ? INT8_C(1) : INT8_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        } else {
+            uint8_t res_limb;
+            uint8_t tmp_limb;
+            uint8_t lhs_limb;
+            uint8_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_addo_u8(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_addo_u8(&res_limb, tmp_limb, overflow ? UINT8_C(1) : UINT8_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        }
+
+        remaining_bytes -= 8 / CHAR_BIT;
+
+#if zig_little_endian
+        byte_offset += 8 / CHAR_BIT;
+#endif
+    }
+
+    return overflow;
+}
+
+static inline bool zig_subo_big(void *res, const void *lhs, const void *rhs, bool is_signed, uint16_t bits) {
+    uint8_t *res_bytes = res;
+    const uint8_t *lhs_bytes = lhs;
+    const uint8_t *rhs_bytes = rhs;
+    uint16_t byte_offset = 0;
+    uint16_t remaining_bytes = zig_int_bytes(bits);
+    uint16_t top_bits = remaining_bytes * 8 - bits;
+    bool overflow = false;
+
+#if zig_big_endian
+    byte_offset = remaining_bytes;
+#endif
+
+    while (remaining_bytes >= 128 / CHAR_BIT) {
+        uint16_t limb_bits = 128 - (remaining_bytes == 128 / CHAR_BIT ? top_bits : 0);
+
+#if zig_big_endian
+        byte_offset -= 128 / CHAR_BIT;
+#endif
+
+        if (remaining_bytes == 128 / CHAR_BIT && is_signed) {
+            zig_i128 res_limb;
+            zig_i128 tmp_limb;
+            zig_i128 lhs_limb;
+            zig_i128 rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_subo_i128(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_subo_i128(&res_limb, tmp_limb, zig_make_i128(INT64_C(0), overflow ? UINT64_C(1) : UINT64_C(0)), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        } else {
+            zig_u128 res_limb;
+            zig_u128 tmp_limb;
+            zig_u128 lhs_limb;
+            zig_u128 rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_subo_u128(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_subo_u128(&res_limb, tmp_limb, zig_make_u128(UINT64_C(0), overflow ? UINT64_C(1) : UINT64_C(0)), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        }
+
+        remaining_bytes -= 128 / CHAR_BIT;
+
+#if zig_little_endian
+        byte_offset += 128 / CHAR_BIT;
+#endif
+    }
+
+    while (remaining_bytes >= 64 / CHAR_BIT) {
+        uint16_t limb_bits = 64 - (remaining_bytes == 64 / CHAR_BIT ? top_bits : 0);
+
+#if zig_big_endian
+        byte_offset -= 64 / CHAR_BIT;
+#endif
+
+        if (remaining_bytes == 64 / CHAR_BIT && is_signed) {
+            int64_t res_limb;
+            int64_t tmp_limb;
+            int64_t lhs_limb;
+            int64_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_subo_i64(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_subo_i64(&res_limb, tmp_limb, overflow ? INT64_C(1) : INT64_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        } else {
+            uint64_t res_limb;
+            uint64_t tmp_limb;
+            uint64_t lhs_limb;
+            uint64_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_subo_u64(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_subo_u64(&res_limb, tmp_limb, overflow ? UINT64_C(1) : UINT64_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        }
+
+        remaining_bytes -= 64 / CHAR_BIT;
+
+#if zig_little_endian
+        byte_offset += 64 / CHAR_BIT;
+#endif
+    }
+
+    while (remaining_bytes >= 32 / CHAR_BIT) {
+        uint16_t limb_bits = 32 - (remaining_bytes == 32 / CHAR_BIT ? top_bits : 0);
+
+#if zig_big_endian
+        byte_offset -= 32 / CHAR_BIT;
+#endif
+
+        if (remaining_bytes == 32 / CHAR_BIT && is_signed) {
+            int32_t res_limb;
+            int32_t tmp_limb;
+            int32_t lhs_limb;
+            int32_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_subo_i32(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_subo_i32(&res_limb, tmp_limb, overflow ? INT32_C(1) : INT32_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        } else {
+            uint32_t res_limb;
+            uint32_t tmp_limb;
+            uint32_t lhs_limb;
+            uint32_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_subo_u32(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_subo_u32(&res_limb, tmp_limb, overflow ? UINT32_C(1) : UINT32_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        }
+
+        remaining_bytes -= 32 / CHAR_BIT;
+
+#if zig_little_endian
+        byte_offset += 32 / CHAR_BIT;
+#endif
+    }
+
+    while (remaining_bytes >= 16 / CHAR_BIT) {
+        uint16_t limb_bits = 16 - (remaining_bytes == 16 / CHAR_BIT ? top_bits : 0);
+
+#if zig_big_endian
+        byte_offset -= 16 / CHAR_BIT;
+#endif
+
+        if (remaining_bytes == 16 / CHAR_BIT && is_signed) {
+            int16_t res_limb;
+            int16_t tmp_limb;
+            int16_t lhs_limb;
+            int16_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_subo_i16(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_subo_i16(&res_limb, tmp_limb, overflow ? INT16_C(1) : INT16_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        } else {
+            uint16_t res_limb;
+            uint16_t tmp_limb;
+            uint16_t lhs_limb;
+            uint16_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_subo_u16(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_subo_u16(&res_limb, tmp_limb, overflow ? UINT16_C(1) : UINT16_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        }
+
+        remaining_bytes -= 16 / CHAR_BIT;
+
+#if zig_little_endian
+        byte_offset += 16 / CHAR_BIT;
+#endif
+    }
+
+    while (remaining_bytes >= 8 / CHAR_BIT) {
+        uint16_t limb_bits = 8 - (remaining_bytes == 8 / CHAR_BIT ? top_bits : 0);
+
+#if zig_big_endian
+        byte_offset -= 8 / CHAR_BIT;
+#endif
+
+        if (remaining_bytes == 8 / CHAR_BIT && is_signed) {
+            int8_t res_limb;
+            int8_t tmp_limb;
+            int8_t lhs_limb;
+            int8_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_subo_i8(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_subo_i8(&res_limb, tmp_limb, overflow ? INT8_C(1) : INT8_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        } else {
+            uint8_t res_limb;
+            uint8_t tmp_limb;
+            uint8_t lhs_limb;
+            uint8_t rhs_limb;
+            bool limb_overflow;
+
+            memcpy(&lhs_limb, &lhs_bytes[byte_offset], sizeof(lhs_limb));
+            memcpy(&rhs_limb, &rhs_bytes[byte_offset], sizeof(rhs_limb));
+            limb_overflow = zig_subo_u8(&tmp_limb, lhs_limb, rhs_limb, limb_bits);
+            overflow = limb_overflow ^ zig_subo_u8(&res_limb, tmp_limb, overflow ? UINT8_C(1) : UINT8_C(0), limb_bits);
+            memcpy(&res_bytes[byte_offset], &res_limb, sizeof(res_limb));
+        }
+
+        remaining_bytes -= 8 / CHAR_BIT;
+
+#if zig_little_endian
+        byte_offset += 8 / CHAR_BIT;
+#endif
+    }
+
+    return overflow;
+}
+
+static inline void zig_addw_big(void *res, const void *lhs, const void *rhs, bool is_signed, uint16_t bits) {
+    (void)zig_addo_big(res, lhs, rhs, is_signed, bits);
+}
+
+static inline void zig_subw_big(void *res, const void *lhs, const void *rhs, bool is_signed, uint16_t bits) {
+    (void)zig_subo_big(res, lhs, rhs, is_signed, bits);
+}
+
 static inline uint16_t zig_clz_big(const void *val, bool is_signed, uint16_t bits) {
     const uint8_t *val_bytes = val;
     uint16_t byte_offset = 0;
@@ -3091,80 +3385,6 @@ zig_msvc_atomics_128op(u128, max)
 #endif /* _M_IX86 */
 
 #endif /* _MSC_VER && (_M_IX86 || _M_X64) */
-
-/* ============================= Vector Support ============================= */
-
-#define zig_cmp_vec(operation, operator) \
-    static inline void zig_##operation##_vec(bool *result, const void *lhs, const void *rhs, uint32_t len, bool is_signed, uint16_t elem_bits) { \
-        uint32_t index = 0; \
-        const uint8_t *lhs_ptr = lhs; \
-        const uint8_t *rhs_ptr = rhs; \
-        uint16_t elem_bytes = zig_int_bytes(elem_bits); \
- \
-        while (index < len) { \
-            result[index] = zig_cmp_big(lhs_ptr, rhs_ptr, is_signed, elem_bits) operator 0; \
-            lhs_ptr += elem_bytes; \
-            rhs_ptr += elem_bytes; \
-            index += 1; \
-        } \
-    }
-zig_cmp_vec(eq, ==)
-zig_cmp_vec(ne, !=)
-zig_cmp_vec(lt, < )
-zig_cmp_vec(le, <=)
-zig_cmp_vec(gt, > )
-zig_cmp_vec(ge, >=)
-
-static inline void zig_clz_vec(void *result, const void *val, uint32_t len, bool is_signed, uint16_t elem_bits) {
-    uint32_t index = 0;
-    const uint8_t *val_ptr = val;
-    uint16_t elem_bytes = zig_int_bytes(elem_bits);
-
-    while (index < len) {
-        uint16_t lz = zig_clz_big(val_ptr, is_signed, elem_bits);
-        if (elem_bits <= 128) {
-            ((uint8_t *)result)[index] = (uint8_t)lz;
-        } else {
-            ((uint16_t *)result)[index] = lz;
-        }
-        val_ptr += elem_bytes;
-        index += 1;
-    }
-}
-
-static inline void zig_ctz_vec(void *result, const void *val, uint32_t len, bool is_signed, uint16_t elem_bits) {
-    uint32_t index = 0;
-    const uint8_t *val_ptr = val;
-    uint16_t elem_bytes = zig_int_bytes(elem_bits);
-
-    while (index < len) {
-        uint16_t tz = zig_ctz_big(val_ptr, is_signed, elem_bits);
-        if (elem_bits <= 128) {
-            ((uint8_t *)result)[index] = (uint8_t)tz;
-        } else {
-            ((uint16_t *)result)[index] = tz;
-        }
-        val_ptr += elem_bytes;
-        index += 1;
-    }
-}
-
-static inline void zig_popcount_vec(void *result, const void *val, uint32_t len, bool is_signed, uint16_t elem_bits) {
-    uint32_t index = 0;
-    const uint8_t *val_ptr = val;
-    uint16_t elem_bytes = zig_int_bytes(elem_bits);
-
-    while (index < len) {
-        uint16_t pc = zig_popcount_big(val_ptr, is_signed, elem_bits);
-        if (elem_bits <= 128) {
-            ((uint8_t *)result)[index] = (uint8_t)pc;
-        } else {
-            ((uint16_t *)result)[index] = pc;
-        }
-        val_ptr += elem_bytes;
-        index += 1;
-    }
-}
 
 /* ======================== Special Case Intrinsics ========================= */
 

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -1646,7 +1646,9 @@ static inline zig_u128 zig_wrap_u128(zig_u128 val, uint8_t bits) {
 }
 
 static inline zig_i128 zig_wrap_i128(zig_i128 val, uint8_t bits) {
-    return zig_make_i128(zig_wrap_i64(zig_hi_i128(val), bits - UINT8_C(64)), zig_lo_i128(val));
+    if (bits > UINT8_C(64)) return zig_make_i128(zig_wrap_i64(zig_hi_i128(val), bits - UINT8_C(64)), zig_lo_i128(val));
+    int64_t lo = zig_wrap_i64((int64_t)zig_lo_i128(val), bits);
+    return zig_make_i128(zig_shr_i64(lo, 63), (uint64_t)lo);
 }
 
 static inline zig_u128 zig_shlw_u128(zig_u128 lhs, uint8_t rhs, uint8_t bits) {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -17,12 +17,6 @@ const LazySrcLoc = Module.LazySrcLoc;
 const Air = @import("../Air.zig");
 const Liveness = @import("../Liveness.zig");
 
-const target_util = @import("../target.zig");
-const libcFloatPrefix = target_util.libcFloatPrefix;
-const libcFloatSuffix = target_util.libcFloatSuffix;
-const compilerRtFloatAbbrev = target_util.compilerRtFloatAbbrev;
-const compilerRtIntAbbrev = target_util.compilerRtIntAbbrev;
-
 const BigIntLimb = std.math.big.Limb;
 const BigInt = std.math.big.int;
 
@@ -3317,7 +3311,7 @@ fn airLoad(f: *Function, inst: Air.Inst.Index) !CValue {
         try writer.writeAll(", sizeof(");
         try f.renderType(writer, src_ty);
         try writer.writeAll("))");
-    } else if (ptr_info.host_size != 0) {
+    } else if (ptr_info.host_size > 0 and ptr_info.vector_index == .none) {
         var host_pl = Type.Payload.Bits{
             .base = .{ .tag = .int_unsigned },
             .data = ptr_info.host_size * 8,
@@ -3647,7 +3641,7 @@ fn airStore(f: *Function, inst: Air.Inst.Index) !CValue {
         if (src_val == .constant) {
             try freeLocal(f, inst, array_src.new_local, 0);
         }
-    } else if (ptr_info.host_size != 0) {
+    } else if (ptr_info.host_size > 0 and ptr_info.vector_index == .none) {
         const host_bits = ptr_info.host_size * 8;
         var host_pl = Type.Payload.Bits{ .base = .{ .tag = .int_unsigned }, .data = host_bits };
         const host_ty = Type.initPayload(&host_pl.base);

--- a/src/codegen/c/type.zig
+++ b/src/codegen/c/type.zig
@@ -651,6 +651,13 @@ pub const CType = extern union {
         });
     }
 
+    pub fn toSignedness(self: CType, s: std.builtin.Signedness) CType {
+        return switch (s) {
+            .unsigned => self.toUnsigned(),
+            .signed => self.toSigned(),
+        };
+    }
+
     pub fn getStandardDefineAbbrev(self: CType) ?[]const u8 {
         return switch (self.tag()) {
             .char => "CHAR",

--- a/src/codegen/c/type.zig
+++ b/src/codegen/c/type.zig
@@ -496,6 +496,296 @@ pub const CType = extern union {
         }
     };
 
+    pub fn toSigned(self: CType) CType {
+        return CType.initTag(switch (self.tag()) {
+            .char, .@"signed char", .@"unsigned char" => .@"signed char",
+            .short, .@"unsigned short" => .short,
+            .int, .@"unsigned int" => .int,
+            .long, .@"unsigned long" => .long,
+            .@"long long", .@"unsigned long long" => .@"long long",
+            .size_t, .ptrdiff_t => .ptrdiff_t,
+            .uint8_t, .int8_t => .int8_t,
+            .uint16_t, .int16_t => .int16_t,
+            .uint32_t, .int32_t => .int32_t,
+            .uint64_t, .int64_t => .int64_t,
+            .uintptr_t, .intptr_t => .intptr_t,
+            .zig_u128, .zig_i128 => .zig_i128,
+            .float,
+            .double,
+            .@"long double",
+            .zig_f16,
+            .zig_f32,
+            .zig_f80,
+            .zig_f128,
+            .zig_c_longdouble,
+            => |t| t,
+            else => unreachable,
+        });
+    }
+
+    pub fn toUnsigned(self: CType) CType {
+        return CType.initTag(switch (self.tag()) {
+            .char, .@"signed char", .@"unsigned char" => .@"unsigned char",
+            .short, .@"unsigned short" => .@"unsigned short",
+            .int, .@"unsigned int" => .@"unsigned int",
+            .long, .@"unsigned long" => .@"unsigned long",
+            .@"long long", .@"unsigned long long" => .@"unsigned long long",
+            .size_t, .ptrdiff_t => .size_t,
+            .uint8_t, .int8_t => .uint8_t,
+            .uint16_t, .int16_t => .uint16_t,
+            .uint32_t, .int32_t => .uint32_t,
+            .uint64_t, .int64_t => .uint64_t,
+            .uintptr_t, .intptr_t => .uintptr_t,
+            .zig_u128, .zig_i128 => .zig_u128,
+            else => unreachable,
+        });
+    }
+
+    pub fn getStandardDefineAbbrev(self: CType) ?[]const u8 {
+        return switch (self.tag()) {
+            .char => "CHAR",
+            .@"signed char" => "SCHAR",
+            .short => "SHRT",
+            .int => "INT",
+            .long => "LONG",
+            .@"long long" => "LLONG",
+            .@"unsigned char" => "UCHAR",
+            .@"unsigned short" => "USHRT",
+            .@"unsigned int" => "UINT",
+            .@"unsigned long" => "ULONG",
+            .@"unsigned long long" => "ULLONG",
+            .float => "FLT",
+            .double => "DBL",
+            .@"long double" => "LDBL",
+            .size_t => "SIZE",
+            .ptrdiff_t => "PTRDIFF",
+            .uint8_t => "UINT8",
+            .int8_t => "INT8",
+            .uint16_t => "UINT16",
+            .int16_t => "INT16",
+            .uint32_t => "UINT32",
+            .int32_t => "INT32",
+            .uint64_t => "UINT64",
+            .int64_t => "INT64",
+            .uintptr_t => "UINTPTR",
+            .intptr_t => "INTPTR",
+            else => null,
+        };
+    }
+
+    pub fn renderLiteralPrefix(self: CType, writer: anytype, kind: Kind) @TypeOf(writer).Error!void {
+        switch (self.tag()) {
+            .void => unreachable,
+            ._Bool,
+            .char,
+            .@"signed char",
+            .short,
+            .@"unsigned short",
+            .bool,
+            .size_t,
+            .ptrdiff_t,
+            .uintptr_t,
+            .intptr_t,
+            => |t| switch (kind) {
+                else => try writer.print("({s})", .{@tagName(t)}),
+                .global => {},
+            },
+            .int,
+            .long,
+            .@"long long",
+            .@"unsigned char",
+            .@"unsigned int",
+            .@"unsigned long",
+            .@"unsigned long long",
+            .float,
+            .double,
+            .@"long double",
+            => {},
+            .uint8_t,
+            .int8_t,
+            .uint16_t,
+            .int16_t,
+            .uint32_t,
+            .int32_t,
+            .uint64_t,
+            .int64_t,
+            => try writer.print("{s}_C(", .{self.getStandardDefineAbbrev().?}),
+            .zig_u128,
+            .zig_i128,
+            .zig_f16,
+            .zig_f32,
+            .zig_f64,
+            .zig_f80,
+            .zig_f128,
+            .zig_c_longdouble,
+            => |t| try writer.print("zig_{s}_{s}(", .{
+                switch (kind) {
+                    else => "make",
+                    .global => "init",
+                },
+                @tagName(t)["zig_".len..],
+            }),
+            .pointer,
+            .pointer_const,
+            .pointer_volatile,
+            .pointer_const_volatile,
+            => unreachable,
+            .array,
+            .vector,
+            => try writer.writeByte('{'),
+            .fwd_anon_struct,
+            .fwd_anon_union,
+            .fwd_struct,
+            .fwd_union,
+            .unnamed_struct,
+            .unnamed_union,
+            .packed_unnamed_struct,
+            .packed_unnamed_union,
+            .anon_struct,
+            .anon_union,
+            .@"struct",
+            .@"union",
+            .packed_struct,
+            .packed_union,
+            .function,
+            .varargs_function,
+            => unreachable,
+        }
+    }
+
+    pub fn renderLiteralSuffix(self: CType, writer: anytype) @TypeOf(writer).Error!void {
+        switch (self.tag()) {
+            .void => unreachable,
+            ._Bool => {},
+            .char,
+            .@"signed char",
+            .short,
+            .int,
+            => {},
+            .long => try writer.writeByte('l'),
+            .@"long long" => try writer.writeAll("ll"),
+            .@"unsigned char",
+            .@"unsigned short",
+            .@"unsigned int",
+            => try writer.writeByte('u'),
+            .@"unsigned long",
+            .size_t,
+            .uintptr_t,
+            => try writer.writeAll("ul"),
+            .@"unsigned long long" => try writer.writeAll("ull"),
+            .float => try writer.writeByte('f'),
+            .double => {},
+            .@"long double" => try writer.writeByte('l'),
+            .bool,
+            .ptrdiff_t,
+            .intptr_t,
+            => {},
+            .uint8_t,
+            .int8_t,
+            .uint16_t,
+            .int16_t,
+            .uint32_t,
+            .int32_t,
+            .uint64_t,
+            .int64_t,
+            .zig_u128,
+            .zig_i128,
+            .zig_f16,
+            .zig_f32,
+            .zig_f64,
+            .zig_f80,
+            .zig_f128,
+            .zig_c_longdouble,
+            => try writer.writeByte(')'),
+            .pointer,
+            .pointer_const,
+            .pointer_volatile,
+            .pointer_const_volatile,
+            => unreachable,
+            .array,
+            .vector,
+            => try writer.writeByte('}'),
+            .fwd_anon_struct,
+            .fwd_anon_union,
+            .fwd_struct,
+            .fwd_union,
+            .unnamed_struct,
+            .unnamed_union,
+            .packed_unnamed_struct,
+            .packed_unnamed_union,
+            .anon_struct,
+            .anon_union,
+            .@"struct",
+            .@"union",
+            .packed_struct,
+            .packed_union,
+            .function,
+            .varargs_function,
+            => unreachable,
+        }
+    }
+
+    pub fn byteSize(self: CType, store: Store.Set, target: Target) u64 {
+        return switch (self.tag()) {
+            .void => 0,
+            .char, .@"signed char", ._Bool, .@"unsigned char", .bool, .uint8_t, .int8_t => 1,
+            .short => target.c_type_byte_size(.short),
+            .int => target.c_type_byte_size(.int),
+            .long => target.c_type_byte_size(.long),
+            .@"long long" => target.c_type_byte_size(.longlong),
+            .@"unsigned short" => target.c_type_byte_size(.ushort),
+            .@"unsigned int" => target.c_type_byte_size(.uint),
+            .@"unsigned long" => target.c_type_byte_size(.ulong),
+            .@"unsigned long long" => target.c_type_byte_size(.ulonglong),
+            .float => target.c_type_byte_size(.float),
+            .double => target.c_type_byte_size(.double),
+            .@"long double" => target.c_type_byte_size(.longdouble),
+            .size_t,
+            .ptrdiff_t,
+            .uintptr_t,
+            .intptr_t,
+            .pointer,
+            .pointer_const,
+            .pointer_volatile,
+            .pointer_const_volatile,
+            => @divExact(target.cpu.arch.ptrBitWidth(), 8),
+            .uint16_t, .int16_t, .zig_f16 => 2,
+            .uint32_t, .int32_t, .zig_f32 => 4,
+            .uint64_t, .int64_t, .zig_f64 => 8,
+            .zig_u128, .zig_i128, .zig_f128 => 16,
+            .zig_f80 => if (target.c_type_bit_size(.longdouble) == 80)
+                target.c_type_byte_size(.longdouble)
+            else
+                16,
+            .zig_c_longdouble => target.c_type_byte_size(.longdouble),
+
+            .array,
+            .vector,
+            => {
+                const data = self.cast(Payload.Sequence).?.data;
+                return data.len * store.indexToCType(data.elem_type).byteSize(store, target);
+            },
+
+            .fwd_anon_struct,
+            .fwd_anon_union,
+            .fwd_struct,
+            .fwd_union,
+            .unnamed_struct,
+            .unnamed_union,
+            .packed_unnamed_struct,
+            .packed_unnamed_union,
+            .anon_struct,
+            .anon_union,
+            .@"struct",
+            .@"union",
+            .packed_struct,
+            .packed_union,
+            .function,
+            .varargs_function,
+            => unreachable,
+        };
+    }
+
     pub fn isPacked(self: CType) bool {
         return switch (self.tag()) {
             else => false,
@@ -787,26 +1077,26 @@ pub const CType = extern union {
             };
         }
 
-        fn tagFromIntInfo(signedness: std.builtin.Signedness, bits: u16) Tag {
-            return switch (bits) {
+        fn tagFromIntInfo(int_info: std.builtin.Type.Int) Tag {
+            return switch (int_info.bits) {
                 0 => .void,
-                1...8 => switch (signedness) {
+                1...8 => switch (int_info.signedness) {
                     .unsigned => .uint8_t,
                     .signed => .int8_t,
                 },
-                9...16 => switch (signedness) {
+                9...16 => switch (int_info.signedness) {
                     .unsigned => .uint16_t,
                     .signed => .int16_t,
                 },
-                17...32 => switch (signedness) {
+                17...32 => switch (int_info.signedness) {
                     .unsigned => .uint32_t,
                     .signed => .int32_t,
                 },
-                33...64 => switch (signedness) {
+                33...64 => switch (int_info.signedness) {
                     .unsigned => .uint64_t,
                     .signed => .int64_t,
                 },
-                65...128 => switch (signedness) {
+                65...128 => switch (int_info.signedness) {
                     .unsigned => .zig_u128,
                     .signed => .zig_i128,
                 },
@@ -945,31 +1235,27 @@ pub const CType = extern union {
                 .c_ulong => self.init(.@"unsigned long"),
                 .c_longlong => self.init(.@"long long"),
                 .c_ulonglong => self.init(.@"unsigned long long"),
-                else => {
-                    const info = ty.intInfo(target);
-                    const t = tagFromIntInfo(info.signedness, info.bits);
-                    switch (t) {
-                        .void => unreachable,
-                        else => self.init(t),
-                        .array => switch (kind) {
-                            .forward, .complete, .global => {
-                                const abi_size = ty.abiSize(target);
-                                const abi_align = ty.abiAlignment(target);
-                                self.storage = .{ .seq = .{ .base = .{ .tag = .array }, .data = .{
-                                    .len = @divExact(abi_size, abi_align),
-                                    .elem_type = tagFromIntInfo(
-                                        .unsigned,
-                                        @intCast(u16, abi_align * 8),
-                                    ).toIndex(),
-                                } } };
-                                self.value = .{ .cty = initPayload(&self.storage.seq) };
-                            },
-                            .forward_parameter,
-                            .parameter,
-                            => try self.initArrayParameter(ty, kind, lookup),
-                            .payload => unreachable,
+                else => switch (tagFromIntInfo(ty.intInfo(target))) {
+                    .void => unreachable,
+                    else => |t| self.init(t),
+                    .array => switch (kind) {
+                        .forward, .complete, .global => {
+                            const abi_size = ty.abiSize(target);
+                            const abi_align = ty.abiAlignment(target);
+                            self.storage = .{ .seq = .{ .base = .{ .tag = .array }, .data = .{
+                                .len = @divExact(abi_size, abi_align),
+                                .elem_type = tagFromIntInfo(.{
+                                    .signedness = .unsigned,
+                                    .bits = @intCast(u16, abi_align * 8),
+                                }).toIndex(),
+                            } } };
+                            self.value = .{ .cty = initPayload(&self.storage.seq) };
                         },
-                    }
+                        .forward_parameter,
+                        .parameter,
+                        => try self.initArrayParameter(ty, kind, lookup),
+                        .payload => unreachable,
+                    },
                 },
             } else switch (ty.zigTypeTag()) {
                 .Frame => unreachable,

--- a/src/codegen/c/type.zig
+++ b/src/codegen/c/type.zig
@@ -1465,7 +1465,7 @@ pub const CType = extern union {
                                 .base = .{ .tag = .int_unsigned },
                                 .data = info.host_size * 8,
                             };
-                            const pointee_ty = if (info.host_size > 0)
+                            const pointee_ty = if (info.host_size > 0 and info.vector_index == .none)
                                 Type.initPayload(&host_int_pl.base)
                             else
                                 info.pointee_type;

--- a/src/type.zig
+++ b/src/type.zig
@@ -4213,7 +4213,7 @@ pub const Type = extern union {
         };
     }
 
-    fn shallowElemType(child_ty: Type) Type {
+    pub fn shallowElemType(child_ty: Type) Type {
         return switch (child_ty.zigTypeTag()) {
             .Array, .Vector => child_ty.childType(),
             else => child_ty,

--- a/src/type.zig
+++ b/src/type.zig
@@ -4213,7 +4213,7 @@ pub const Type = extern union {
         };
     }
 
-    pub fn shallowElemType(child_ty: Type) Type {
+    fn shallowElemType(child_ty: Type) Type {
         return switch (child_ty.zigTypeTag()) {
             .Array, .Vector => child_ty.childType(),
             else => child_ty,

--- a/src/value.zig
+++ b/src/value.zig
@@ -3319,7 +3319,7 @@ pub const Value = extern union {
         }
     }
 
-    fn floatToValue(float: f128, arena: Allocator, dest_ty: Type, target: Target) !Value {
+    pub fn floatToValue(float: f128, arena: Allocator, dest_ty: Type, target: Target) !Value {
         switch (dest_ty.floatBits(target)) {
             16 => return Value.Tag.float_16.create(arena, @floatCast(f16, float)),
             32 => return Value.Tag.float_32.create(arena, @floatCast(f32, float)),

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -368,7 +368,6 @@ test "comptime @bitCast packed struct to int and back" {
 }
 
 test "comptime bitcast with fields following f80" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -34,7 +34,6 @@ test "@bitCast iX -> uX (8, 16, 128)" {
 
 test "@bitCast iX -> uX exotic integers" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
@@ -81,7 +80,6 @@ fn conv_uN(comptime N: usize, x: std.meta.Int(.unsigned, N)) std.meta.Int(.signe
 
 test "bitcast uX to bytes" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;

--- a/test/behavior/bitreverse.zig
+++ b/test/behavior/bitreverse.zig
@@ -96,7 +96,6 @@ fn vector8() !void {
 
 test "bitReverse vectors u8" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
@@ -115,7 +114,6 @@ fn vector16() !void {
 
 test "bitReverse vectors u16" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
@@ -134,7 +132,6 @@ fn vector24() !void {
 
 test "bitReverse vectors u24" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;

--- a/test/behavior/bugs/10147.zig
+++ b/test/behavior/bugs/10147.zig
@@ -6,7 +6,6 @@ test "test calling @clz on both vector and scalar inputs" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     var x: u32 = 0x1;

--- a/test/behavior/byteswap.zig
+++ b/test/behavior/byteswap.zig
@@ -62,7 +62,6 @@ fn vector8() !void {
 
 test "@byteSwap vectors u8" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
@@ -81,7 +80,6 @@ fn vector16() !void {
 
 test "@byteSwap vectors u16" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
@@ -100,7 +98,6 @@ fn vector24() !void {
 
 test "@byteSwap vectors u24" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -598,7 +598,6 @@ test "cast *[1][*]const u8 to [*]const ?[*]const u8" {
 
 test "vector casts" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -141,7 +141,6 @@ fn testSqrt() !void {
 
 test "@sqrt with vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -234,7 +233,6 @@ fn testSin() !void {
 
 test "@sin with vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -275,7 +273,6 @@ fn testCos() !void {
 
 test "@cos with vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -315,7 +312,6 @@ fn testExp() !void {
 
 test "@exp with vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -355,7 +351,6 @@ fn testExp2() !void {
 
 test "@exp2" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -409,7 +404,6 @@ test "@log with @vectors" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     {
@@ -447,7 +441,6 @@ test "@log2 with vectors" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     // https://github.com/ziglang/zig/issues/13681
     if (builtin.zig_backend == .stage2_llvm and
         builtin.cpu.arch == .aarch64 and
@@ -491,7 +484,6 @@ test "@log10 with vectors" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
 
     comptime try testLog10WithVectors();
     try testLog10WithVectors();
@@ -537,7 +529,6 @@ fn testFabs() !void {
 
 test "@fabs with vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -660,7 +651,6 @@ fn testFloor() !void {
 
 test "@floor with vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -754,7 +744,6 @@ fn testCeil() !void {
 
 test "@ceil with vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -848,7 +837,6 @@ fn testTrunc() !void {
 
 test "@trunc with vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -100,7 +100,6 @@ test "@clz vectors" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     try testClzVectors();
@@ -163,7 +162,6 @@ test "@ctz vectors" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .aarch64) {
@@ -1561,6 +1559,12 @@ test "signed zeros are represented properly" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+
+    if (builtin.os.tag == .windows and builtin.cpu.arch == .aarch64 and
+        builtin.zig_backend == .stage2_c)
+    {
+        return error.SkipZigTest;
+    }
 
     const S = struct {
         fn doTheTest() !void {

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -1526,7 +1526,6 @@ fn testNanEqNan(comptime F: type) !void {
 }
 
 test "vector comparison" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO

--- a/test/behavior/maximum_minimum.zig
+++ b/test/behavior/maximum_minimum.zig
@@ -25,7 +25,6 @@ test "@max" {
 test "@max on vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -75,7 +74,6 @@ test "@min for vectors" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     const S = struct {

--- a/test/behavior/muladd.zig
+++ b/test/behavior/muladd.zig
@@ -100,7 +100,6 @@ fn vector16() !void {
 }
 
 test "vector f16" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -124,7 +123,6 @@ fn vector32() !void {
 }
 
 test "vector f32" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -148,7 +146,6 @@ fn vector64() !void {
 }
 
 test "vector f64" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -171,7 +168,6 @@ fn vector80() !void {
 }
 
 test "vector f80" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -195,7 +191,6 @@ fn vector128() !void {
 }
 
 test "vector f128" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/muladd.zig
+++ b/test/behavior/muladd.zig
@@ -197,6 +197,13 @@ test "vector f128" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
+    if (builtin.os.tag == .windows and builtin.cpu.arch == .aarch64 and
+        builtin.zig_backend == .stage2_c)
+    {
+        // https://github.com/ziglang/zig/issues/13876
+        return error.SkipZigTest;
+    }
+
     comptime try vector128();
     try vector128();
 }

--- a/test/behavior/popcount.zig
+++ b/test/behavior/popcount.zig
@@ -67,7 +67,6 @@ fn testPopCountIntegers() !void {
 }
 
 test "@popCount vectors" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO

--- a/test/behavior/select.zig
+++ b/test/behavior/select.zig
@@ -4,7 +4,6 @@ const mem = std.mem;
 const expect = std.testing.expect;
 
 test "@select vectors" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -33,7 +32,6 @@ fn selectVectors() !void {
 }
 
 test "@select arrays" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/shuffle.zig
+++ b/test/behavior/shuffle.zig
@@ -69,7 +69,6 @@ test "@shuffle bool 2" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     if (builtin.zig_backend == .stage2_llvm) {
@@ -81,7 +80,7 @@ test "@shuffle bool 2" {
         fn doTheTest() !void {
             var x: @Vector(3, bool) = [3]bool{ false, true, false };
             var v: @Vector(2, bool) = [2]bool{ true, false };
-            const mask: @Vector(4, i32) = [4]i32{ 0, ~@as(i32, 1), 1, 2 };
+            const mask = [4]i32{ 0, ~@as(i32, 1), 1, 2 };
             var res = @shuffle(bool, x, v, mask);
             try expect(mem.eql(bool, &@as([4]bool, res), &[4]bool{ false, false, true, false }));
         }

--- a/test/behavior/shuffle.zig
+++ b/test/behavior/shuffle.zig
@@ -8,7 +8,6 @@ test "@shuffle int" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     const S = struct {
@@ -50,7 +49,6 @@ test "@shuffle bool 1" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     const S = struct {

--- a/test/behavior/truncate.zig
+++ b/test/behavior/truncate.zig
@@ -60,7 +60,6 @@ test "truncate on comptime integer" {
 }
 
 test "truncate on vectors" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -1118,7 +1118,6 @@ test "byte vector initialized in inline function" {
 }
 
 test "byte vector initialized in inline function" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -1233,7 +1232,6 @@ test "load packed vector element" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
 
     var x: @Vector(2, u15) = .{ 1, 4 };
     try expect((&x[0]).* == 1);
@@ -1246,7 +1244,6 @@ test "store packed vector element" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
 
     var v = @Vector(4, u1){ 1, 1, 1, 1 };
     try expectEqual(@Vector(4, u1){ 1, 1, 1, 1 }, v);

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -234,7 +234,6 @@ test "vector casts of sizes not divisible by 8" {
 }
 
 test "vector @splat" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -48,7 +48,6 @@ test "vector wrap operators" {
 
 test "vector bin compares with mem.eql" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -403,7 +402,6 @@ test "initialize vector which is a struct field" {
 
 test "vector comparison operators" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -91,7 +91,6 @@ test "vector int operators" {
 
 test "vector float operators" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -96,6 +96,13 @@ test "vector float operators" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
+    if (builtin.os.tag == .windows and builtin.cpu.arch == .aarch64 and
+        builtin.zig_backend == .stage2_c)
+    {
+        // https://github.com/ziglang/zig/issues/13876
+        return error.SkipZigTest;
+    }
+
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         const S = struct {
             fn doTheTest() !void {

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -804,7 +804,6 @@ test "vector @reduce comptime" {
 
 test "mask parameter of @shuffle is comptime scope" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -1212,7 +1211,6 @@ test "modRem with zero divisor" {
 
 test "array operands to shuffle are coerced to vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -25,7 +25,6 @@ test "implicit cast vector to array - bool" {
 
 test "vector wrap operators" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -116,7 +115,6 @@ test "vector float operators" {
 
 test "vector bit operators" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -442,7 +440,6 @@ test "vector comparison operators" {
 
 test "vector division operators" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -525,7 +522,6 @@ test "vector division operators" {
 
 test "vector bitwise not operator" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -557,7 +553,6 @@ test "vector bitwise not operator" {
 
 test "vector shift operators" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -651,7 +646,6 @@ test "vector shift operators" {
 
 test "vector reduce operation" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -707,7 +701,7 @@ test "vector reduce operation" {
 
             // LLVM 11 ERROR: Cannot select type
             // https://github.com/ziglang/zig/issues/7138
-            if (builtin.target.cpu.arch != .aarch64) {
+            if (builtin.zig_backend != .stage2_llvm or builtin.target.cpu.arch != .aarch64) {
                 try testReduce(.Min, [4]i64{ 1234567, -386, 0, 3 }, @as(i64, -386));
                 try testReduce(.Min, [4]u64{ 99, 9999, 9, 99999 }, @as(u64, 9));
             }
@@ -725,7 +719,7 @@ test "vector reduce operation" {
 
             // LLVM 11 ERROR: Cannot select type
             // https://github.com/ziglang/zig/issues/7138
-            if (builtin.target.cpu.arch != .aarch64) {
+            if (builtin.zig_backend != .stage2_llvm or builtin.target.cpu.arch != .aarch64) {
                 try testReduce(.Max, [4]i64{ 1234567, -386, 0, 3 }, @as(i64, 1234567));
                 try testReduce(.Max, [4]u64{ 99, 9999, 9, 99999 }, @as(u64, 99999));
             }
@@ -773,14 +767,14 @@ test "vector reduce operation" {
 
             // LLVM 11 ERROR: Cannot select type
             // https://github.com/ziglang/zig/issues/7138
-            if (false) {
-                try testReduce(.Min, [4]f16{ -1.9, 5.1, f16_nan, 100.0 }, f16_nan);
-                try testReduce(.Min, [4]f32{ -1.9, 5.1, f32_nan, 100.0 }, f32_nan);
-                try testReduce(.Min, [4]f64{ -1.9, 5.1, f64_nan, 100.0 }, f64_nan);
+            if (builtin.zig_backend != .stage2_llvm) {
+                try testReduce(.Min, [4]f16{ -1.9, 5.1, f16_nan, 100.0 }, @as(f16, -1.9));
+                try testReduce(.Min, [4]f32{ -1.9, 5.1, f32_nan, 100.0 }, @as(f32, -1.9));
+                try testReduce(.Min, [4]f64{ -1.9, 5.1, f64_nan, 100.0 }, @as(f64, -1.9));
 
-                try testReduce(.Max, [4]f16{ -1.9, 5.1, f16_nan, 100.0 }, f16_nan);
-                try testReduce(.Max, [4]f32{ -1.9, 5.1, f32_nan, 100.0 }, f32_nan);
-                try testReduce(.Max, [4]f64{ -1.9, 5.1, f64_nan, 100.0 }, f64_nan);
+                try testReduce(.Max, [4]f16{ -1.9, 5.1, f16_nan, 100.0 }, @as(f16, 100.0));
+                try testReduce(.Max, [4]f32{ -1.9, 5.1, f32_nan, 100.0 }, @as(f32, 100.0));
+                try testReduce(.Max, [4]f64{ -1.9, 5.1, f64_nan, 100.0 }, @as(f64, 100.0));
             }
 
             try testReduce(.Mul, [4]f16{ -1.9, 5.1, f16_nan, 100.0 }, f16_nan);
@@ -831,7 +825,6 @@ test "mask parameter of @shuffle is comptime scope" {
 
 test "saturating add" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -863,7 +856,6 @@ test "saturating add" {
 
 test "saturating subtraction" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -886,7 +878,6 @@ test "saturating subtraction" {
 
 test "saturating multiplication" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -913,7 +904,6 @@ test "saturating multiplication" {
 
 test "saturating shift-left" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -1047,7 +1037,6 @@ test "@mulWithOverflow" {
 }
 
 test "@shlWithOverflow" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -1202,7 +1191,6 @@ test "zero multiplicand" {
 
 test "@intCast to u0" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO


### PR DESCRIPTION
C backend improvements.
 * Add support for big integer literals.
 * Add support for big integer and vector (oops wrong type :eyes:) operations:
     * comparisons
     * clz
     * ctz
     * popcount
     * add
     * sub
 * Oops, add support for all of the other vector operations too.
 * Pass 99% (1553/1571) of behavior tests relative to the llvm backend.

Closes #8817