### PR TITLE
LLVM: Place functions on AVR in flash addrspace

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -17328,11 +17328,11 @@ fn zirPtrType(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air
         break :blk abi_align;
     } else 0;
 
-    const address_space = if (inst_data.flags.has_addrspace) blk: {
+    const address_space: std.builtin.AddressSpace = if (inst_data.flags.has_addrspace) blk: {
         const ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_i]);
         extra_i += 1;
         break :blk try sema.analyzeAddressSpace(block, addrspace_src, ref, .pointer);
-    } else .generic;
+    } else if (elem_ty.zigTypeTag() == .Fn and target.cpu.arch == .avr) .flash else .generic;
 
     const bit_offset = if (inst_data.flags.has_bit_range) blk: {
         const ref = @intToEnum(Zir.Inst.Ref, sema.code.extra[extra_i]);

--- a/src/target.zig
+++ b/src/target.zig
@@ -644,8 +644,9 @@ pub fn defaultAddressSpace(
         function,
     },
 ) AddressSpace {
-    _ = target;
-    _ = context;
+    // The default address space for functions on AVR is .flash to produce
+    // correct fixups into progmem.
+    if (context == .function and target.cpu.arch == .avr) return .flash;
     return .generic;
 }
 


### PR DESCRIPTION
On AVR, functions need to be placed in the flash address space in order to generate correct fixups for function pointers (`R_AVR_16_PM` for fixups for flash addresses vs `R_AVR_16` for data fixups).

Fixes #14733.