### PR TITLE
astgen: fill result location with `void` if no other value

### DIFF
--- a/test/cases/compile_errors/break_void_result_location.zig
+++ b/test/cases/compile_errors/break_void_result_location.zig
@@ -1,0 +1,32 @@
+export fn f1() void {
+    const x: usize = for ("hello") |_| {};
+    _ = x;
+}
+export fn f2() void {
+    const x: usize = for ("hello") |_| {
+        break;
+    };
+    _ = x;
+}
+export fn f3() void {
+    var t: bool = true;
+    const x: usize = while (t) {
+        break;
+    };
+    _ = x;
+}
+export fn f4() void {
+    const x: usize = blk: {
+        break :blk;
+    };
+    _ = x;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:22: error: expected type 'usize', found 'void'
+// :7:9: error: expected type 'usize', found 'void'
+// :14:9: error: expected type 'usize', found 'void'
+// :18:1: error: expected type 'usize', found 'void'


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/14686.

After this commit we essentially treat `break` and `break :blk` as `break {}` and `break :blk {}` respectively, to ensure that the result gets type checked. Also, there is a special case for `for` loop without any `break`s so that this gets type checked as well (on master `for (0..10) |_| { }` can be assigned to anything):

```zig
var foo: void = for (0..10) |_| { };
_ = foo;
```

Another approach could be to make it a compile error to use `break` without a value when the for/while/block is used as an expression. I'm not sure what's the preferred approach so I went with the first idea, but I'm happy to do either (or something else entirely).



