### PR TITLE
std: add fchmodat

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -171,7 +171,9 @@ pub extern "c" fn dup(fd: c.fd_t) c_int;
 pub extern "c" fn dup2(old_fd: c.fd_t, new_fd: c.fd_t) c_int;
 pub extern "c" fn readlink(noalias path: [*:0]const u8, noalias buf: [*]u8, bufsize: usize) isize;
 pub extern "c" fn readlinkat(dirfd: c.fd_t, noalias path: [*:0]const u8, noalias buf: [*]u8, bufsize: usize) isize;
+pub extern "c" fn chmod(path: [*:0]const u8, mode: c.mode_t) c_int;
 pub extern "c" fn fchmod(fd: c.fd_t, mode: c.mode_t) c_int;
+pub extern "c" fn fchmodat(fd: c.fd_t, path: [*:0]const u8, mode: c.mode_t, flags: c_uint) c_int;
 pub extern "c" fn fchown(fd: c.fd_t, owner: c.uid_t, group: c.gid_t) c_int;
 pub extern "c" fn umask(mode: c.mode_t) c.mode_t;
 

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -11,6 +11,11 @@ const math = std.math;
 
 const is_darwin = builtin.os.tag.isDarwin();
 
+pub const has_executable_bit = switch (builtin.os.tag) {
+    .windows, .wasi => false,
+    else => true,
+};
+
 pub const path = @import("fs/path.zig");
 pub const File = @import("fs/file.zig").File;
 pub const wasi = @import("fs/wasi.zig");

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -769,12 +769,30 @@ pub fn fchmod(fd: i32, mode: mode_t) usize {
     return syscall2(.fchmod, @bitCast(usize, @as(isize, fd)), mode);
 }
 
+pub fn chmod(path: [*:0]const u8, mode: mode_t) usize {
+    if (@hasField(SYS, "chmod")) {
+        return syscall2(.chmod, @ptrToInt(path), mode);
+    } else {
+        return syscall4(
+            .fchmodat,
+            @bitCast(usize, @as(isize, AT.FDCWD)),
+            @ptrToInt(path),
+            mode,
+            0,
+        );
+    }
+}
+
 pub fn fchown(fd: i32, owner: uid_t, group: gid_t) usize {
     if (@hasField(SYS, "fchown32")) {
         return syscall3(.fchown32, @bitCast(usize, @as(isize, fd)), owner, group);
     } else {
         return syscall3(.fchown, @bitCast(usize, @as(isize, fd)), owner, group);
     }
+}
+
+pub fn fchmodat(fd: i32, path: [*:0]const u8, mode: mode_t, flags: u32) usize {
+    return syscall4(.fchmodat, @bitCast(usize, @as(isize, fd)), @ptrToInt(path), mode, flags);
 }
 
 /// Can only be called on 32 bit systems. For 64 bit see `lseek`.


### PR DESCRIPTION
Also add `std.fs.has_executable_bit` for doing conditional compilation.

This adds the linux syscalls for chmod and fchmodat, as well as the extern libc function declarations.

Only `fchmodat` is added to `std.os`, and it is not yet added to std.fs.