### PR TITLE
std.process.Child: remove pid and handle, add id

### DIFF
--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -9,6 +9,7 @@ const assert = std.debug.assert;
 const testing = std.testing;
 const child_process = @import("child_process.zig");
 
+pub const Child = child_process.ChildProcess;
 pub const abort = os.abort;
 pub const exit = os.exit;
 pub const changeCurDir = os.chdir;

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -12,6 +12,7 @@ pub const BoundedArray = @import("bounded_array.zig").BoundedArray;
 pub const Build = @import("Build.zig");
 pub const BufMap = @import("buf_map.zig").BufMap;
 pub const BufSet = @import("buf_set.zig").BufSet;
+/// Deprecated: use `process.Child`.
 pub const ChildProcess = @import("child_process.zig").ChildProcess;
 pub const ComptimeStringMap = @import("comptime_string_map.zig").ComptimeStringMap;
 pub const DynLib = @import("dynamic_library.zig").DynLib;


### PR DESCRIPTION
Previously, this API had pid, to be used on POSIX systems, and handle, to be used on Windows.

This commit unifies the API, defining an Id type that is either the pid or the HANDLE depending on the target OS.

This commit also prepares for the future by allowing one to import via `std.process.Child` which is the fully qualified namespace that I intend to migrate to in the future.