### PR TITLE
crypto.25519.field: conditionally de-inline mul

### DIFF
--- a/lib/std/crypto/25519/field.zig
+++ b/lib/std/crypto/25519/field.zig
@@ -264,7 +264,7 @@ pub const Fe = struct {
     }
 
     /// Multiply two field elements
-    pub inline fn mul(a: Fe, b: Fe) Fe {
+    pub fn mul(a: Fe, b: Fe) Fe {
         var ax: [5]u128 = undefined;
         var bx: [5]u128 = undefined;
         var a19: [5]u128 = undefined;

--- a/lib/std/crypto/25519/field.zig
+++ b/lib/std/crypto/25519/field.zig
@@ -266,9 +266,9 @@ pub const Fe = struct {
 
     /// Multiply two field elements
     /// Inlining can result in large code generation, so do it conditionally.
-    pub fn mul(a: Fe, b: Fe) callconv(switch(builtin.mode) {
+    pub fn mul(a: Fe, b: Fe) callconv(switch (builtin.mode) {
         .ReleaseSafe, .ReleaseFast => .Inline,
-        .Debug, .ReleaseSmall => .Unspecified, 
+        .Debug, .ReleaseSmall => .Unspecified,
     }) Fe {
         var ax: [5]u128 = undefined;
         var bx: [5]u128 = undefined;

--- a/lib/std/crypto/25519/field.zig
+++ b/lib/std/crypto/25519/field.zig
@@ -7,6 +7,12 @@ const writeIntLittle = std.mem.writeIntLittle;
 const NonCanonicalError = crypto.errors.NonCanonicalError;
 const NotSquareError = crypto.errors.NotSquareError;
 
+// Inline conditionally, when it can result in large code generation.
+const bloaty_inline = switch (builtin.mode) {
+    .ReleaseSafe, .ReleaseFast => .Inline,
+    .Debug, .ReleaseSmall => .Unspecified,
+};
+
 pub const Fe = struct {
     limbs: [5]u64,
 
@@ -265,11 +271,7 @@ pub const Fe = struct {
     }
 
     /// Multiply two field elements
-    /// Inlining can result in large code generation, so do it conditionally.
-    pub fn mul(a: Fe, b: Fe) callconv(switch (builtin.mode) {
-        .ReleaseSafe, .ReleaseFast => .Inline,
-        .Debug, .ReleaseSmall => .Unspecified,
-    }) Fe {
+    pub fn mul(a: Fe, b: Fe) callconv(bloaty_inline) Fe {
         var ax: [5]u128 = undefined;
         var bx: [5]u128 = undefined;
         var a19: [5]u128 = undefined;

--- a/lib/std/crypto/25519/field.zig
+++ b/lib/std/crypto/25519/field.zig
@@ -1,10 +1,16 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const crypto = std.crypto;
 const readIntLittle = std.mem.readIntLittle;
 const writeIntLittle = std.mem.writeIntLittle;
 
 const NonCanonicalError = crypto.errors.NonCanonicalError;
 const NotSquareError = crypto.errors.NotSquareError;
+
+const modifier = switch (builtin.mode) {
+    .Debug, .ReleaseSafe, .ReleaseFast => .always_inline,
+    .ReleaseSmall => .auto,
+};
 
 pub const Fe = struct {
     limbs: [5]u64,
@@ -264,7 +270,11 @@ pub const Fe = struct {
     }
 
     /// Multiply two field elements
-    pub fn mul(a: Fe, b: Fe) Fe {
+    pub inline fn mul(a: Fe, b:Fe) Fe {
+        return @call(modifier, _mul, .{a, b});
+    }
+
+    pub fn _mul(a: Fe, b: Fe) Fe {
         var ax: [5]u128 = undefined;
         var bx: [5]u128 = undefined;
         var a19: [5]u128 = undefined;


### PR DESCRIPTION
This helps with binary size when using, for example, tls.Client:

Before (function size = 155200 bytes):
```console
$ zig build-exe goog.zig -Dcpu=baseline
$ readelf -a goog -W |grep Fe.invert
  1328: 000000000045b100 0x25e40 FUNC    LOCAL  DEFAULT    2 crypto.25519.field.Fe.invert
```
After (function size = 18088 bytes):
```console
$ zig build-exe goog.zig -Dcpu=baseline
$ readelf -a goog -W |grep Fe.invert
1329: 0000000000447fa0 18088 FUNC    LOCAL  DEFAULT    2 crypto.25519.field.Fe.invert
```
So, removes over 130kb from the function size.