### PR TITLE
Sema: allow comptime mutation of multiple array elements

### DIFF
--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -48,16 +48,23 @@ fn getArrayLen(a: []const u32) usize {
 test "array concat with undefined" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
-    {
-        var array = "hello".* ++ @as([5]u8, undefined);
-        array[5..10].* = "world".*;
-        try std.testing.expect(std.mem.eql(u8, &array, "helloworld"));
-    }
-    {
-        var array = @as([5]u8, undefined) ++ "world".*;
-        array[0..5].* = "hello".*;
-        try std.testing.expect(std.mem.eql(u8, &array, "helloworld"));
-    }
+    const S = struct {
+        fn doTheTest() !void {
+            {
+                var array = "hello".* ++ @as([5]u8, undefined);
+                array[5..10].* = "world".*;
+                try std.testing.expect(std.mem.eql(u8, &array, "helloworld"));
+            }
+            {
+                var array = @as([5]u8, undefined) ++ "world".*;
+                array[0..5].* = "hello".*;
+                try std.testing.expect(std.mem.eql(u8, &array, "helloworld"));
+            }
+        }
+    };
+
+    try S.doTheTest();
+    comptime try S.doTheTest();
 }
 
 test "array concat with tuple" {

--- a/test/behavior/comptime_memory.zig
+++ b/test/behavior/comptime_memory.zig
@@ -412,3 +412,11 @@ test "bitcast packed union to integer" {
         try testing.expectEqual(@as(u2, 2), cast_b);
     }
 }
+
+test "mutate entire slice at comptime" {
+    comptime {
+        var buf: [3]u8 = undefined;
+        const x: [2]u8 = .{ 1, 2 }; // Avoid RLS
+        buf[1..3].* = x;
+    }
+}


### PR DESCRIPTION
See the added test case for an example of what this fixes.

Previously, if you had a pointer to multiple array elements and tried to write to it at comptime, it was incorrectly treated as a pointer to one specific array value, leading to an assertion down the line. If we try to mutate a value at an elem_ptr larger than the element type, we need to perform a modification to multiple array elements.

This solution isn't ideal, since it will result in storePtrVal serializing the whole array, modifying the relevant parts, and storing it back. Ideally, it would only take the required elements. However, this change would have been more complex, and this is a fairly rare operation (nobody ever ran into the bug before after all), so it doesn't matter all that much.

Resolves: #8304
Resolves: #10211
Resolves: #13336