### PR TITLE
llvm: fix use after free with pointers to optional slices

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1773,7 +1773,7 @@ pub const Object = struct {
                 if (ty.optionalReprIsPayload()) {
                     const ptr_di_ty = try o.lowerDebugType(child_ty, resolve);
                     // The recursive call to `lowerDebugType` means we can't use `gop` anymore.
-                    try o.di_type_map.putContext(gpa, ty, AnnotatedDITypePtr.initFull(ptr_di_ty), .{ .mod = o.module });
+                    try o.di_type_map.putContext(gpa, ty, AnnotatedDITypePtr.init(ptr_di_ty, resolve), .{ .mod = o.module });
                     return ptr_di_ty;
                 }
 

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -747,3 +747,18 @@ test "slice decays to many pointer" {
     const p: [*:0]const u8 = buf[0..7 :0];
     try expectEqualStrings(buf[0..7], std.mem.span(p));
 }
+
+test "write through pointer to optional slice arg" {
+    const S = struct {
+        fn bar(foo: *?[]const u8) !void {
+            foo.* = try baz();
+        }
+
+        fn baz() ![]const u8 {
+            return "ok";
+        }
+    };
+    var foo: ?[]const u8 = null;
+    try S.bar(&foo);
+    try expectEqualStrings(foo.?, "ok");
+}

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -749,6 +749,11 @@ test "slice decays to many pointer" {
 }
 
 test "write through pointer to optional slice arg" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     const S = struct {
         fn bar(foo: *?[]const u8) !void {
             foo.* = try baz();


### PR DESCRIPTION
I would love to add a test for this, but since this is a memory bug they are super flaky and don't reliably reproduce the issue.

Closes #14715
Closes #14783