### PR TITLE
std.os: Add DeviceBusy as a possible write error

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1007,6 +1007,7 @@ pub const WriteError = error{
     FileTooBig,
     InputOutput,
     NoSpaceLeft,
+    DeviceBusy,
 
     /// In WASI, this error may occur when the file descriptor does
     /// not hold the required rights to write to it.
@@ -1105,6 +1106,7 @@ pub fn write(fd: fd_t, bytes: []const u8) WriteError!usize {
             .PERM => return error.AccessDenied,
             .PIPE => return error.BrokenPipe,
             .CONNRESET => return error.ConnectionResetByPeer,
+            .BUSY => return error.DeviceBusy,
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -1174,6 +1176,7 @@ pub fn writev(fd: fd_t, iov: []const iovec_const) WriteError!usize {
             .PERM => return error.AccessDenied,
             .PIPE => return error.BrokenPipe,
             .CONNRESET => return error.ConnectionResetByPeer,
+            .BUSY => return error.DeviceBusy,
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -1270,6 +1273,7 @@ pub fn pwrite(fd: fd_t, bytes: []const u8, offset: u64) PWriteError!usize {
             .NXIO => return error.Unseekable,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
+            .BUSY => return error.DeviceBusy,
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -1359,6 +1363,7 @@ pub fn pwritev(fd: fd_t, iov: []const iovec_const, offset: u64) PWriteError!usiz
             .NXIO => return error.Unseekable,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
+            .BUSY => return error.DeviceBusy,
             else => |err| return unexpectedErrno(err),
         }
     }

--- a/src/link.zig
+++ b/src/link.zig
@@ -460,6 +460,7 @@ pub const File = struct {
         CurrentWorkingDirectoryUnlinked,
         LockViolation,
         NetNameDeleted,
+        DeviceBusy,
     };
 
     /// Called from within the CodeGen to lower a local variable instantion as an unnamed


### PR DESCRIPTION
In Linux when writing to various files in the virtual file system, for example /sys/fs/cgroup, if you write an invalid value to a file you'll get errno 16.

This change allows for these specific cases to be caught instead of being lumped together in `error.UnexpectedError`.

In a shell:
```
echo 3G > memory.memsw.limit_in_bytes
bash: echo: write error: Device or resource busy
```

Before this change:
```
unexpected errno: 16
/home/shadeops/opt/zig-master-llvm15/lib/zig/std/debug.zig:561:19: 0x22b9a7 in writeCurrentStackTrace__anon_6009 (write)
    while (it.next()) |return_address| {
                  ^
/home/shadeops/opt/zig-master-llvm15/lib/zig/std/debug.zig:157:80: 0x20cf63 in dumpCurrentStackTrace (write)
        writeCurrentStackTrace(stderr, debug_info, detectTTYConfig(io.getStdErr()), start_addr) catch |err| {
                                                                               ^
/home/shadeops/opt/zig-master-llvm15/lib/zig/std/os.zig:5463:40: 0x20ee7e in unexpectedErrno (write)
        std.debug.dumpCurrentStackTrace(null);
                                       ^
/home/shadeops/opt/zig-master-llvm15/lib/zig/std/os.zig:1362:49: 0x20be84 in pwritev (write)
            else => |err| return unexpectedErrno(err),
                                                ^
```

After this change:
```
error: DeviceBusy
/home/shadeops/opt/zig-master-llvm15/lib/zig/std/os.zig:1366:22: 0x20c272 in pwritev (write)
            .BUSY => return error.DeviceBusy,
```
