### PR TITLE
CI: more aggressively check zig1 bootstrapping

### DIFF
--- a/ci/aarch64-linux-debug.sh
+++ b/ci/aarch64-linux-debug.sh
@@ -98,3 +98,9 @@ unset CXX
 ninja install
 
 stage3/bin/zig test ../test/behavior.zig -I../test
+stage3/bin/zig build -p stage4 \
+  -Dstatic-llvm \
+  -Dtarget=native-native-musl \
+  --search-prefix "$PREFIX" \
+  --zig-lib-dir "$(pwd)/../lib"
+stage4/bin/zig test ../test/behavior.zig -I../test

--- a/ci/aarch64-linux-release.sh
+++ b/ci/aarch64-linux-release.sh
@@ -98,3 +98,9 @@ unset CXX
 ninja install
 
 stage3/bin/zig test ../test/behavior.zig -I../test
+stage3/bin/zig build -p stage4 \
+  -Dstatic-llvm \
+  -Dtarget=native-native-musl \
+  --search-prefix "$PREFIX" \
+  --zig-lib-dir "$(pwd)/../lib"
+stage4/bin/zig test ../test/behavior.zig -I../test

--- a/ci/x86_64-linux-debug.sh
+++ b/ci/x86_64-linux-debug.sh
@@ -97,3 +97,9 @@ unset CXX
 ninja install
 
 stage3/bin/zig test ../test/behavior.zig -I../test
+stage3/bin/zig build -p stage4 \
+  -Dstatic-llvm \
+  -Dtarget=native-native-musl \
+  --search-prefix "$PREFIX" \
+  --zig-lib-dir "$(pwd)/../lib"
+stage4/bin/zig test ../test/behavior.zig -I../test

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -114,3 +114,9 @@ unset CXX
 ninja install
 
 stage3/bin/zig test ../test/behavior.zig -I../test
+stage3/bin/zig build -p stage4 \
+  -Dstatic-llvm \
+  -Dtarget=native-native-musl \
+  --search-prefix "$PREFIX" \
+  --zig-lib-dir "$(pwd)/../lib"
+stage4/bin/zig test ../test/behavior.zig -I../test


### PR DESCRIPTION
This would have caught the problem we are seeing in #14799.