### PR TITLE
std.os: Allow write functions to return INVAL errors

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -658,6 +658,7 @@ pub const Request = struct {
         MissingEndCertificateMarker,
         InvalidPadding,
         EndOfStream,
+        InvalidArgument,
     };
 
     pub fn read(req: *Request, buffer: []u8) ReadError!usize {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1037,6 +1037,7 @@ pub const WriteError = error{
     InputOutput,
     NoSpaceLeft,
     DeviceBusy,
+    InvalidArgument,
 
     /// In WASI, this error may occur when the file descriptor does
     /// not hold the required rights to write to it.
@@ -1123,7 +1124,7 @@ pub fn write(fd: fd_t, bytes: []const u8) WriteError!usize {
         switch (errno(rc)) {
             .SUCCESS => return @intCast(usize, rc),
             .INTR => continue,
-            .INVAL => unreachable,
+            .INVAL => return error.InvalidArgument,
             .FAULT => unreachable,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForWriting, // can be a race condition.
@@ -1193,7 +1194,7 @@ pub fn writev(fd: fd_t, iov: []const iovec_const) WriteError!usize {
         switch (errno(rc)) {
             .SUCCESS => return @intCast(usize, rc),
             .INTR => continue,
-            .INVAL => unreachable,
+            .INVAL => return error.InvalidArgument,
             .FAULT => unreachable,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForWriting, // Can be a race condition.
@@ -1288,7 +1289,7 @@ pub fn pwrite(fd: fd_t, bytes: []const u8, offset: u64) PWriteError!usize {
         switch (errno(rc)) {
             .SUCCESS => return @intCast(usize, rc),
             .INTR => continue,
-            .INVAL => unreachable,
+            .INVAL => return error.InvalidArgument,
             .FAULT => unreachable,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForWriting, // Can be a race condition.
@@ -1378,7 +1379,7 @@ pub fn pwritev(fd: fd_t, iov: []const iovec_const, offset: u64) PWriteError!usiz
         switch (errno(rc)) {
             .SUCCESS => return @intCast(usize, rc),
             .INTR => continue,
-            .INVAL => unreachable,
+            .INVAL => return error.InvalidArgument,
             .FAULT => unreachable,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForWriting, // Can be a race condition.

--- a/src/link.zig
+++ b/src/link.zig
@@ -461,6 +461,7 @@ pub const File = struct {
         LockViolation,
         NetNameDeleted,
         DeviceBusy,
+        InvalidArgument,
     };
 
     /// Called from within the CodeGen to lower a local variable instantion as an unnamed

--- a/src/main.zig
+++ b/src/main.zig
@@ -4622,6 +4622,7 @@ const FmtError = error{
     ConnectionResetByPeer,
     LockViolation,
     NetNameDeleted,
+    InvalidArgument,
 } || fs.File.OpenError;
 
 fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool, dir: fs.Dir, sub_path: []const u8) FmtError!void {


### PR DESCRIPTION
In Linux when interacting with the virtual file system when writing in invalid value to a file the OS will return errno 22 (INVAL).

Instead of triggering an unreachable, this change now returns a newly introduced `error.InvalidArgument`.

An example of where this can occur is with Cgroups, if you write a value to memory.memsw.limit_in_bytes that is smaller than memory.limit_in_bytes this will return an Invalid Argument.

Bash:
```
echo 1G > memory.memsw.limit_in_bytes
bash: echo: write error: Invalid argument
```
With this PR:
```
zig build run -- ./mem

Setting /sys/fs/cgroup/memory/ginkgo/ginkgo_135496/memory.memsw.limit_in_bytes to 1G
error: InvalidArgument
```

Other notes:
The reason that std.http.Client's ReadError list was updated despite this being added to the list of write errors is due to `fn readAdvanced(..)` calling `req.client.request` which contains a write call.