### PR TITLE
std: reenable vectorized code with the C backend

### DIFF
--- a/lib/std/crypto/blake3.zig
+++ b/lib/std/crypto/blake3.zig
@@ -200,7 +200,7 @@ const CompressGeneric = struct {
     }
 };
 
-const compress = if (builtin.cpu.arch == .x86_64 and builtin.zig_backend != .stage2_c)
+const compress = if (builtin.cpu.arch == .x86_64)
     CompressVectorized.compress
 else
     CompressGeneric.compress;

--- a/lib/std/crypto/gimli.zig
+++ b/lib/std/crypto/gimli.zig
@@ -152,7 +152,7 @@ pub const State = struct {
         self.endianSwap();
     }
 
-    pub const permute = if (builtin.cpu.arch == .x86_64 and builtin.zig_backend != .stage2_c) impl: {
+    pub const permute = if (builtin.cpu.arch == .x86_64) impl: {
         break :impl permute_vectorized;
     } else if (builtin.mode == .ReleaseSmall) impl: {
         break :impl permute_small;

--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -719,11 +719,7 @@ pub const Target = struct {
 
                 /// Adds the specified feature set but not its dependencies.
                 pub fn addFeatureSet(set: *Set, other_set: Set) void {
-                    if (builtin.zig_backend == .stage2_c) {
-                        for (&set.ints, 0..) |*int, i| int.* |= other_set.ints[i];
-                    } else {
-                        set.ints = @as(@Vector(usize_count, usize), set.ints) | @as(@Vector(usize_count, usize), other_set.ints);
-                    }
+                    set.ints = @as(@Vector(usize_count, usize), set.ints) | @as(@Vector(usize_count, usize), other_set.ints);
                 }
 
                 /// Removes the specified feature but not its dependents.
@@ -735,11 +731,7 @@ pub const Target = struct {
 
                 /// Removes the specified feature but not its dependents.
                 pub fn removeFeatureSet(set: *Set, other_set: Set) void {
-                    if (builtin.zig_backend == .stage2_c) {
-                        for (&set.ints, 0..) |*int, i| int.* &= ~other_set.ints[i];
-                    } else {
-                        set.ints = @as(@Vector(usize_count, usize), set.ints) & ~@as(@Vector(usize_count, usize), other_set.ints);
-                    }
+                    set.ints = @as(@Vector(usize_count, usize), set.ints) & ~@as(@Vector(usize_count, usize), other_set.ints);
                 }
 
                 pub fn populateDependencies(set: *Set, all_features_list: []const Cpu.Feature) void {


### PR DESCRIPTION
Now that the C backend can codegen vectors, lets reenable them in the standard library.