### PR TITLE
std.crypto.hash.sha3: add TurboSHAKE

### DIFF
--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -27,6 +27,8 @@ const hashes = [_]Crypto{
     Crypto{ .ty = crypto.hash.sha3.Sha3_512, .name = "sha3-512" },
     Crypto{ .ty = crypto.hash.sha3.Shake128, .name = "shake-128" },
     Crypto{ .ty = crypto.hash.sha3.Shake256, .name = "shake-256" },
+    Crypto{ .ty = crypto.hash.sha3.TurboShake128(null), .name = "turboshake-128" },
+    Crypto{ .ty = crypto.hash.sha3.TurboShake256(null), .name = "turboshake-256" },
     Crypto{ .ty = crypto.hash.Gimli, .name = "gimli-hash" },
     Crypto{ .ty = crypto.hash.blake2.Blake2s256, .name = "blake2s" },
     Crypto{ .ty = crypto.hash.blake2.Blake2b512, .name = "blake2b" },

--- a/lib/std/crypto/keccak_p.zig
+++ b/lib/std/crypto/keccak_p.zig
@@ -175,12 +175,12 @@ pub fn KeccakF(comptime f: u11) type {
         /// Apply a (possibly) reduced-round permutation to the state.
         pub fn permuteR(self: *Self, comptime rounds: u5) void {
             var i = RC.len - rounds;
-            while (i < rounds - rounds % 3) : (i += 3) {
+            while (i < RC.len - RC.len % 3) : (i += 3) {
                 self.round(RC[i]);
                 self.round(RC[i + 1]);
                 self.round(RC[i + 2]);
             }
-            while (i < rounds) : (i += 1) {
+            while (i < RC.len) : (i += 1) {
                 self.round(RC[i]);
             }
         }


### PR DESCRIPTION
TurboSHAKE is a round-reduced version of SHAKE which is being standardized by CFRG.

It offers the same practical security as SHA3 and SHAKE. Its security builds up on the scrutiny that Keccak has received since its publication.

Unlike SHA3 (but not unlike SHAKE), the output can be of any size.

TurboSHAKE also offers higher performance - It is nearly twice as fast as SHAKE.

```
         sha3-256:        571 MiB/s
         sha3-512:        316 MiB/s
        shake-128:        723 MiB/s
   turboshake-128:       1334 MiB/s
```

Why it matters: TurboSHAKE is the fastest secure hash function we'll have in Zig when compiling for the `baseline` CPU.

Since we already had SHAKE, TurboSHAKE is a trivial addition, and it will immediately benefit from the further optimizations we'll do to Keccak.