### PR TITLE
fix bug and simplify std.crypto.tls.Client.limitVecs

### DIFF
--- a/lib/std/crypto/tls/Client.zig
+++ b/lib/std/crypto/tls/Client.zig
@@ -1330,18 +1330,15 @@ const VecPut = struct {
 
 /// Limit iovecs to a specific byte size.
 fn limitVecs(iovecs: []std.os.iovec, len: usize) []std.os.iovec {
-    var vec_i: usize = 0;
     var bytes_left: usize = len;
-    while (true) {
-        if (bytes_left >= iovecs[vec_i].iov_len) {
-            bytes_left -= iovecs[vec_i].iov_len;
-            vec_i += 1;
-            if (vec_i == iovecs.len or bytes_left == 0) return iovecs[0..vec_i];
-            continue;
+    for (iovecs, 0..) |*iovec, vec_i| {
+        if (bytes_left <= iovec.iov_len) {
+            iovec.iov_len = bytes_left;
+            return iovecs[0 .. vec_i + 1];
         }
-        iovecs[vec_i].iov_len = bytes_left;
-        return iovecs[0..vec_i];
+        bytes_left -= iovec.iov_len;
     }
+    return iovecs;
 }
 
 /// The priority order here is chosen based on what crypto algorithms Zig has


### PR DESCRIPTION
Looks like the current implementation of `limitVecs` doesn't match its description.  Here's a program that demonstrates the bug:

```zig
const std = @import("std");

fn getCapacity(vecs: []const std.os.iovec) usize {
    var total: usize = 0;
    for (vecs) |vec| {
        total += vec.iov_len;
    }
    return total;
}

pub fn main() !void {
    var bad_case = [_]std.os.iovec{ .{ .iov_len = 3, .iov_base = undefined } };
    var vecs_current = limitVecsCurrent(&bad_case, 1);
    std.log.info("capacity={}", .{getCapacity(vecs_current)});
    var vecs_new = limitVecsCurrent(&bad_case, 1);
    std.log.info("capacity={}", .{getCapacity(vecs_new)});
}

fn limitVecsCurrent(iovecs: []std.os.iovec, len: usize) []std.os.iovec {
    var vec_i: usize = 0;
    var bytes_left: usize = len;
    while (true) {
        if (bytes_left >= iovecs[vec_i].iov_len) {
            bytes_left -= iovecs[vec_i].iov_len;
            vec_i += 1;
            if (vec_i == iovecs.len or bytes_left == 0) return iovecs[0..vec_i];
            continue;
        }
        iovecs[vec_i].iov_len = bytes_left;
        return iovecs[0..vec_i];
    }
}

fn limitVecsNew(iovecs: []std.os.iovec, len: usize) []std.os.iovec {
    var bytes_left: usize = len;
    for (iovecs, 0..) |*iovec, vec_i| {
        if (bytes_left <= iovec.iov_len) {
            iovec.iov_len = bytes_left;
            return iovecs[0 .. vec_i + 1];
        }
        bytes_left -= iovec.iov_len;
    }
    return iovecs;
}

```

This program will print:
```
info: capacity=0
info: capacity=1
```

Both capacities should be 1, but the current implementation has an "off by one" bug where it returns a slice in some cases but erroneously excludes the last iovec.