### PR TITLE
Use the new multi-sequence loop syntax

### DIFF
--- a/lib/std/Build/ConfigHeaderStep.zig
+++ b/lib/std/Build/ConfigHeaderStep.zig
@@ -349,9 +349,8 @@ fn render_blank(
     try output.appendSlice(include_guard_name);
     try output.appendSlice("\n");
 
-    const values = defines.values();
-    for (defines.keys(), 0..) |name, i| {
-        try renderValueC(output, name, values[i]);
+    for (defines.keys(), defines.values()) |name, value| {
+        try renderValueC(output, name, value);
     }
 
     try output.appendSlice("#endif /* ");

--- a/lib/std/array_hash_map.zig
+++ b/lib/std/array_hash_map.zig
@@ -715,8 +715,8 @@ pub fn ArrayHashMapUnmanaged(
                 const slice = self.entries.slice();
                 const hashes_array = slice.items(.hash);
                 const keys_array = slice.items(.key);
-                for (keys_array, 0..) |*item_key, i| {
-                    if (hashes_array[i] == h and checkedEql(ctx, key, item_key.*, i)) {
+                for (keys_array, hashes_array, 0..) |*item_key, item_hash, i| {
+                    if (item_hash == h and checkedEql(ctx, key, item_key.*, i)) {
                         return GetOrPutResult{
                             .key_ptr = item_key,
                             // workaround for #6974
@@ -946,8 +946,8 @@ pub fn ArrayHashMapUnmanaged(
                 const slice = self.entries.slice();
                 const hashes_array = slice.items(.hash);
                 const keys_array = slice.items(.key);
-                for (keys_array, 0..) |*item_key, i| {
-                    if (hashes_array[i] == h and checkedEql(ctx, key, item_key.*, i)) {
+                for (keys_array, hashes_array, 0..) |*item_key, item_hash, i| {
+                    if (item_hash == h and checkedEql(ctx, key, item_key.*, i)) {
                         return i;
                     }
                 }

--- a/lib/std/bit_set.zig
+++ b/lib/std/bit_set.zig
@@ -494,8 +494,8 @@ pub fn ArrayBitSet(comptime MaskIntType: type, comptime size: usize) type {
         /// Flips all bits in this bit set which are present
         /// in the toggles bit set.
         pub fn toggleSet(self: *Self, toggles: Self) void {
-            for (&self.masks, 0..) |*mask, i| {
-                mask.* ^= toggles.masks[i];
+            for (&self.masks, toggles.masks) |*mask, toggles_mask| {
+                mask.* ^= toggles_mask;
             }
         }
 
@@ -515,8 +515,8 @@ pub fn ArrayBitSet(comptime MaskIntType: type, comptime size: usize) type {
         /// result in the first one.  Bits in the result are
         /// set if the corresponding bits were set in either input.
         pub fn setUnion(self: *Self, other: Self) void {
-            for (&self.masks, 0..) |*mask, i| {
-                mask.* |= other.masks[i];
+            for (&self.masks, other.masks) |*mask, other_mask| {
+                mask.* |= other_mask;
             }
         }
 
@@ -524,8 +524,8 @@ pub fn ArrayBitSet(comptime MaskIntType: type, comptime size: usize) type {
         /// the result in the first one.  Bits in the result are
         /// set if the corresponding bits were set in both inputs.
         pub fn setIntersection(self: *Self, other: Self) void {
-            for (&self.masks, 0..) |*mask, i| {
-                mask.* &= other.masks[i];
+            for (&self.masks, other.masks) |*mask, other_mask| {
+                mask.* &= other_mask;
             }
         }
 
@@ -869,8 +869,8 @@ pub const DynamicBitSetUnmanaged = struct {
     pub fn toggleSet(self: *Self, toggles: Self) void {
         assert(toggles.bit_length == self.bit_length);
         const num_masks = numMasks(self.bit_length);
-        for (self.masks[0..num_masks], 0..) |*mask, i| {
-            mask.* ^= toggles.masks[i];
+        for (self.masks[0..num_masks], toggles.masks[0..num_masks]) |*mask, toggle_mask| {
+            mask.* ^= toggle_mask;
         }
     }
 
@@ -897,8 +897,8 @@ pub const DynamicBitSetUnmanaged = struct {
     pub fn setUnion(self: *Self, other: Self) void {
         assert(other.bit_length == self.bit_length);
         const num_masks = numMasks(self.bit_length);
-        for (self.masks[0..num_masks], 0..) |*mask, i| {
-            mask.* |= other.masks[i];
+        for (self.masks[0..num_masks], other.masks[0..num_masks]) |*mask, other_mask| {
+            mask.* |= other_mask;
         }
     }
 
@@ -909,8 +909,8 @@ pub const DynamicBitSetUnmanaged = struct {
     pub fn setIntersection(self: *Self, other: Self) void {
         assert(other.bit_length == self.bit_length);
         const num_masks = numMasks(self.bit_length);
-        for (self.masks[0..num_masks], 0..) |*mask, i| {
-            mask.* &= other.masks[i];
+        for (self.masks[0..num_masks], other.masks[0..num_masks]) |*mask, other_mask| {
+            mask.* &= other_mask;
         }
     }
 

--- a/lib/std/compress/deflate/deflate_fast.zig
+++ b/lib/std/compress/deflate/deflate_fast.zig
@@ -264,8 +264,8 @@ pub const DeflateFast = struct {
             var a = src[@intCast(usize, s)..@intCast(usize, s1)];
             b = b[0..a.len];
             // Extend the match to be as long as possible.
-            for (a, 0..) |_, i| {
-                if (a[i] != b[i]) {
+            for (a, b, 0..) |e, f, i| {
+                if (e != f) {
                     return @intCast(i32, i);
                 }
             }
@@ -285,8 +285,8 @@ pub const DeflateFast = struct {
             b = b[0..a.len];
         }
         a = a[0..b.len];
-        for (b, 0..) |_, i| {
-            if (a[i] != b[i]) {
+        for (a, b, 0..) |e, f, i| {
+            if (e != f) {
                 return @intCast(i32, i);
             }
         }
@@ -301,8 +301,8 @@ pub const DeflateFast = struct {
         // Continue looking for more matches in the current block.
         a = src[@intCast(usize, s + n)..@intCast(usize, s1)];
         b = src[0..a.len];
-        for (a, 0..) |_, i| {
-            if (a[i] != b[i]) {
+        for (a, b, 0..) |e, f, i| {
+            if (e != f) {
                 return @intCast(i32, i) + n;
             }
         }

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -2138,8 +2138,8 @@ pub fn ConfigurableTrace(comptime size: usize, comptime stack_frame_count: usize
                 ) catch return;
                 return;
             };
-            for (t.addrs[0..end], 0..) |frames_array, i| {
-                stderr.print("{s}:\n", .{t.notes[i]}) catch return;
+            for (t.addrs[0..end], t.notes[0..end]) |frames_array, frame_note| {
+                stderr.print("{s}:\n", .{frame_note}) catch return;
                 var frames_array_mutable = frames_array;
                 const frames = mem.sliceTo(frames_array_mutable[0..], 0);
                 const stack_trace: std.builtin.StackTrace = .{

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1280,8 +1280,8 @@ fn parsedEqual(a: anytype, b: @TypeOf(a)) bool {
             }
         },
         .Array => {
-            for (a, 0..) |e, i|
-                if (!parsedEqual(e, b[i])) return false;
+            for (a, b) |e, f|
+                if (!parsedEqual(e, f)) return false;
             return true;
         },
         .Struct => |info| {
@@ -1294,8 +1294,8 @@ fn parsedEqual(a: anytype, b: @TypeOf(a)) bool {
             .One => return parsedEqual(a.*, b.*),
             .Slice => {
                 if (a.len != b.len) return false;
-                for (a, 0..) |e, i|
-                    if (!parsedEqual(e, b[i])) return false;
+                for (a, b) |e, f|
+                    if (!parsedEqual(e, f)) return false;
                 return true;
             },
             .Many, .C => unreachable,
@@ -1518,8 +1518,8 @@ fn parseInternal(
             var r: T = undefined;
             var fields_seen = [_]bool{false} ** structInfo.fields.len;
             errdefer {
-                inline for (structInfo.fields, 0..) |field, i| {
-                    if (fields_seen[i] and !field.is_comptime) {
+                inline for (structInfo.fields, fields_seen) |field, seen| {
+                    if (seen and !field.is_comptime) {
                         parseFree(field.type, @field(r, field.name), options);
                     }
                 }
@@ -1584,8 +1584,8 @@ fn parseInternal(
                     else => return error.UnexpectedToken,
                 }
             }
-            inline for (structInfo.fields, 0..) |field, i| {
-                if (!fields_seen[i]) {
+            inline for (structInfo.fields, fields_seen) |field, seen| {
+                if (!seen) {
                     if (field.default_value) |default_ptr| {
                         if (!field.is_comptime) {
                             const default = @ptrCast(*align(1) const field.type, default_ptr).*;

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -611,8 +611,8 @@ test "lessThan" {
 pub fn eql(comptime T: type, a: []const T, b: []const T) bool {
     if (a.len != b.len) return false;
     if (a.ptr == b.ptr) return true;
-    for (a, 0..) |item, index| {
-        if (b[index] != item) return false;
+    for (a, b) |item_a, item_b| {
+        if (item_a != item_b) return false;
     }
     return true;
 }

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -672,8 +672,7 @@ fn expectEqualEnum(expected: anytype, actual: @TypeOf(expected)) !void {
         const expected_fields = @typeInfo(expected).Enum.fields;
         const actual_fields = @typeInfo(actual).Enum.fields;
         if (expected_fields.len != actual_fields.len) return error.FailedTest;
-        for (expected_fields, 0..) |expected_field, i| {
-            const actual_field = actual_fields[i];
+        for (expected_fields, actual_fields) |expected_field, actual_field| {
             try testing.expectEqual(expected_field.value, actual_field.value);
             try testing.expectEqualStrings(expected_field.name, actual_field.name);
         }
@@ -682,8 +681,7 @@ fn expectEqualEnum(expected: anytype, actual: @TypeOf(expected)) !void {
         const expected_decls = @typeInfo(expected).Enum.decls;
         const actual_decls = @typeInfo(actual).Enum.decls;
         if (expected_decls.len != actual_decls.len) return error.FailedTest;
-        for (expected_decls, 0..) |expected_decl, i| {
-            const actual_decl = actual_decls[i];
+        for (expected_decls, actual_decls) |expected_decl, actual_decl| {
             try testing.expectEqual(expected_decl.is_pub, actual_decl.is_pub);
             try testing.expectEqualStrings(expected_decl.name, actual_decl.name);
         }
@@ -870,8 +868,8 @@ pub fn eql(a: anytype, b: @TypeOf(a)) bool {
         },
         .Array => {
             if (a.len != b.len) return false;
-            for (a, 0..) |e, i|
-                if (!eql(e, b[i])) return false;
+            for (a, b) |e, f|
+                if (!eql(e, f)) return false;
             return true;
         },
         .Vector => |info| {

--- a/lib/std/pdb.zig
+++ b/lib/std/pdb.zig
@@ -922,8 +922,7 @@ const Msf = struct {
         }
 
         const streams = try allocator.alloc(MsfStream, stream_count);
-        for (streams, 0..) |*stream, i| {
-            const size = stream_sizes[i];
+        for (streams, stream_sizes) |*stream, size| {
             if (size == 0) {
                 stream.* = MsfStream{
                     .blocks = &[_]u32{},


### PR DESCRIPTION
I probably missed a lot of places, but I tried to stick to code that kind of made sense to me. Initially spotted this in mem.eql and the performance difference was significant (but it obviously depends on the two inputs).