### PR TITLE
#12474: std.fs.Dir.makeOpenPath: optimize case, if path already exists

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1459,8 +1459,9 @@ pub const Dir = struct {
         try os.mkdiratW(self.fd, sub_path, default_new_dir_mode);
     }
 
-    /// Calls makeDir recursively to make an entire path. Returns success if the path
-    /// already exists and is a directory.
+    /// Calls makeDir iteratively to make an entire path
+    /// (i.e. creating any parent directories that do not exist).
+    /// Returns success if the path already exists and is a directory.
     /// This function is not atomic, and if it returns an error, the file system may
     /// have been modified regardless.
     pub fn makePath(self: Dir, sub_path: []const u8) !void {
@@ -1483,9 +1484,9 @@ pub const Dir = struct {
         }
     }
 
-    /// Calls makeOpenDirAccessMaskW recursively to make an entire path
-    /// (i.e. falling back if the parent directory does not exist). Opens the dir if the path
-    /// already exists and is a directory.
+    /// Calls makeOpenDirAccessMaskW iteratively to make an entire path
+    /// (i.e. creating any parent directories that do not exist).
+    /// Opens the dir if the path already exists and is a directory.
     /// This function is not atomic, and if it returns an error, the file system may
     /// have been modified regardless.
     fn makeOpenPathAccessMaskW(self: Dir, sub_path: []const u8, access_mask: u32, no_follow: bool) OpenError!Dir {

--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -1507,6 +1507,14 @@ pub fn ComponentIterator(comptime path_type: PathType, comptime T: type) type {
         /// For example, if the path is `/a/b/c` and the most recently returned component
         /// is `b`, then this will return the `c` component.
         pub fn next(self: *Self) ?Component {
+            const peek_result = self.peekNext() orelse return null;
+            self.start_index = peek_result.path.len - peek_result.name.len;
+            self.end_index = peek_result.path.len;
+            return peek_result;
+        }
+
+        /// Like `next`, but does not modify the iterator state.
+        pub fn peekNext(self: Self) ?Component {
             var start_index = self.end_index;
             while (start_index < self.path.len and path_type.isSep(T, self.path[start_index])) {
                 start_index += 1;
@@ -1516,11 +1524,9 @@ pub fn ComponentIterator(comptime path_type: PathType, comptime T: type) type {
                 end_index += 1;
             }
             if (start_index == end_index) return null;
-            self.start_index = start_index;
-            self.end_index = end_index;
             return .{
-                .name = self.path[self.start_index..self.end_index],
-                .path = self.path[0..self.end_index],
+                .name = self.path[start_index..end_index],
+                .path = self.path[0..end_index],
             };
         }
 
@@ -1529,6 +1535,14 @@ pub fn ComponentIterator(comptime path_type: PathType, comptime T: type) type {
         /// For example, if the path is `/a/b/c` and the most recently returned component
         /// is `b`, then this will return the `a` component.
         pub fn previous(self: *Self) ?Component {
+            const peek_result = self.peekPrevious() orelse return null;
+            self.start_index = peek_result.path.len - peek_result.name.len;
+            self.end_index = peek_result.path.len;
+            return peek_result;
+        }
+
+        /// Like `previous`, but does not modify the iterator state.
+        pub fn peekPrevious(self: Self) ?Component {
             var end_index = self.start_index;
             while (true) {
                 if (end_index == self.root_end_index) return null;
@@ -1542,11 +1556,9 @@ pub fn ComponentIterator(comptime path_type: PathType, comptime T: type) type {
                 start_index -= 1;
             }
             if (start_index == end_index) return null;
-            self.start_index = start_index;
-            self.end_index = end_index;
             return .{
-                .name = self.path[self.start_index..self.end_index],
-                .path = self.path[0..self.end_index],
+                .name = self.path[start_index..end_index],
+                .path = self.path[0..end_index],
             };
         }
     };

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -663,6 +663,18 @@ test "file operations on directories" {
     }.impl);
 }
 
+test "makeOpenPath parent dirs do not exist" {
+    var tmp_dir = tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var dir = try tmp_dir.dir.makeOpenPath("root_dir/parent_dir/some_dir", .{});
+    dir.close();
+
+    // double check that the full directory structure was created
+    var dir_verification = try tmp_dir.dir.openDir("root_dir/parent_dir/some_dir", .{});
+    dir_verification.close();
+}
+
 test "deleteDir" {
     try testWithAllSupportedPathTypes(struct {
         fn impl(ctx: *TestContext) !void {


### PR DESCRIPTION
Uses a single NtCreateFile syscall on windows, falling back if the parent directory does not exist.

Closes ziglang#12474. Thanks to @joedavis and @matu3ba.