### PR TITLE
Remove `std.os.windows.QueryInformationFile` (a wrapper of `NtQueryInformationFile`)

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1218,23 +1218,6 @@ test "GetFinalPathNameByHandle" {
     _ = try GetFinalPathNameByHandle(handle, .{ .volume_name = .Dos }, buffer[0..required_len_in_u16]);
 }
 
-pub const QueryInformationFileError = error{Unexpected};
-
-pub fn QueryInformationFile(
-    handle: HANDLE,
-    info_class: FILE_INFORMATION_CLASS,
-    out_buffer: []u8,
-) QueryInformationFileError!void {
-    var io: IO_STATUS_BLOCK = undefined;
-    const len_bytes = std.math.cast(u32, out_buffer.len) orelse unreachable;
-    const rc = ntdll.NtQueryInformationFile(handle, &io, out_buffer.ptr, len_bytes, info_class);
-    switch (rc) {
-        .SUCCESS => {},
-        .INVALID_PARAMETER => unreachable,
-        else => return unexpectedStatus(rc),
-    }
-}
-
 pub const GetFileSizeError = error{Unexpected};
 
 pub fn GetFileSizeEx(hFile: HANDLE) GetFileSizeError!u64 {


### PR DESCRIPTION
This function is unused, it doesn't provide much over a direct call to `NtQueryInformationFile`, and the current implementation contains a few footguns:

- The current wrapper treats all possible errors as unexpected, even likely ones like `BUFFER_OVERFLOW` (which is returned if the size of the out_buffer is too small to contain all the variable-length members of the requested info, which the user may not actually care about, see https://github.com/ziglang/zig/pull/14841/commits/6d74c0d1b41b52bca3d66092a48660f2ee4ae4f8)
- Each caller may need to handle errors differently, different errors might be possible depending on the `FILE_INFORMATION_CLASS`, etc, and making a wrapper that handles all of those different use-cases nicely seems like it'd be more trouble than it's worth (`FILE_INFORMATION_CLASS` has 76 different possible values)

If a wrapper for `NtQueryInformationFile` is wanted, then it should probably have wrapper functions per-use-case, like how `QueryObjectName` wraps `NtQueryObject` for the `ObjectNameInformation` class:

https://github.com/ziglang/zig/blob/e3cf9d165081533524927cebf8a92ac6fee097f2/lib/std/os/windows.zig#L1015-L1042