### PR TITLE
Add ability to import dependencies from build.zig

### DIFF
--- a/src/Package.zig
+++ b/src/Package.zig
@@ -215,6 +215,7 @@ pub const build_zig_basename = "build.zig";
 
 pub fn fetchAndAddDependencies(
     pkg: *Package,
+    root_pkg: *Package,
     arena: Allocator,
     thread_pool: *ThreadPool,
     http_client: *std.http.Client,
@@ -295,7 +296,8 @@ pub fn fetchAndAddDependencies(
             all_modules,
         );
 
-        try pkg.fetchAndAddDependencies(
+        try sub_pkg.fetchAndAddDependencies(
+            root_pkg,
             arena,
             thread_pool,
             http_client,
@@ -309,7 +311,8 @@ pub fn fetchAndAddDependencies(
             all_modules,
         );
 
-        try add(pkg, gpa, fqn, sub_pkg);
+        try pkg.add(gpa, name, sub_pkg);
+        try root_pkg.add(gpa, fqn, sub_pkg);
 
         try dependencies_source.writer().print("    pub const {s} = @import(\"{}\");\n", .{
             std.zig.fmtId(fqn), std.zig.fmtEscapes(fqn),

--- a/src/main.zig
+++ b/src/main.zig
@@ -4228,6 +4228,10 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
                 .root_src_path = "build_runner.zig",
             };
 
+        var build_pkg: Package = .{
+            .root_src_directory = build_directory,
+            .root_src_path = build_zig_basename,
+        };
         if (!build_options.omit_pkg_fetching_code) {
             var http_client: std.http.Client = .{ .allocator = gpa };
             defer http_client.deinit();
@@ -4249,7 +4253,8 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
 
             // Here we borrow main package's table and will replace it with a fresh
             // one after this process completes.
-            main_pkg.fetchAndAddDependencies(
+            build_pkg.fetchAndAddDependencies(
+                &main_pkg,
                 arena,
                 &thread_pool,
                 &http_client,
@@ -4280,11 +4285,6 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
             mem.swap(Package.Table, &main_pkg.table, &deps_pkg.table);
             try main_pkg.add(gpa, "@dependencies", deps_pkg);
         }
-
-        var build_pkg: Package = .{
-            .root_src_directory = build_directory,
-            .root_src_path = build_zig_basename,
-        };
         try main_pkg.add(gpa, "@build", &build_pkg);
 
         const comp = Compilation.create(gpa, .{


### PR DESCRIPTION
Closes #14279

This PR adds the ability to import dependencies from build.zig. We now create a tree of dependencies with the build_pkg as root. This allows for recursive dependencies importing from their own dependencies as well.