### PR TITLE
Sema: @extern fixes

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -107,6 +107,7 @@ pub fn addCases(cases: *tests.StandaloneContext) void {
     cases.addBuildFile("test/standalone/emit_asm_and_bin/build.zig", .{});
     cases.addBuildFile("test/standalone/issue_12588/build.zig", .{});
     cases.addBuildFile("test/standalone/embed_generated_file/build.zig", .{});
+    cases.addBuildFile("test/standalone/extern/build.zig", .{});
 
     cases.addBuildFile("test/standalone/dep_diamond/build.zig", .{});
     cases.addBuildFile("test/standalone/dep_triangle/build.zig", .{});

--- a/test/standalone/extern/build.zig
+++ b/test/standalone/extern/build.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const optimize = b.standardOptimizeOption(.{});
+
+    const obj = b.addObject(.{
+        .name = "exports",
+        .root_source_file = .{ .path = "exports.zig" },
+        .target = .{},
+        .optimize = optimize,
+    });
+    const main = b.addTest(.{
+        .root_source_file = .{ .path = "main.zig" },
+        .optimize = optimize,
+    });
+    main.addObject(obj);
+
+    const test_step = b.step("test", "Test it");
+    test_step.dependOn(&main.step);
+}

--- a/test/standalone/extern/exports.zig
+++ b/test/standalone/extern/exports.zig
@@ -1,0 +1,12 @@
+var hidden: u32 = 0;
+export fn updateHidden(val: u32) void {
+    hidden = val;
+}
+export fn getHidden() u32 {
+    return hidden;
+}
+
+const T = extern struct { x: u32 };
+
+export var mut_val: f64 = 1.23;
+export const const_val: T = .{ .x = 42 };

--- a/test/standalone/extern/main.zig
+++ b/test/standalone/extern/main.zig
@@ -1,0 +1,21 @@
+const assert = @import("std").debug.assert;
+
+const updateHidden = @extern(*const fn (u32) callconv(.C) void, .{ .name = "updateHidden" });
+const getHidden = @extern(*const fn () callconv(.C) u32, .{ .name = "getHidden" });
+
+const T = extern struct { x: u32 };
+
+test {
+    var mut_val_ptr = @extern(*f64, .{ .name = "mut_val" });
+    var const_val_ptr = @extern(*const T, .{ .name = "const_val" });
+
+    assert(getHidden() == 0);
+    updateHidden(123);
+    assert(getHidden() == 123);
+
+    assert(mut_val_ptr.* == 1.23);
+    mut_val_ptr.* = 10.0;
+    assert(mut_val_ptr.* == 10.0);
+
+    assert(const_val_ptr.x == 42);
+}


### PR DESCRIPTION
* There was an edge case where the arena could be destroyed twice on error: once from the arena itself and once from the decl destruction.

* The type of the created decl was incorrect (it should have been the pointer child type), but it's not required anyway, so it's now just initialized to anyopaque (which more accurately reflects what's actually at that memory, since e.g. [*]T may correspond to nothing).

* A runtime bitcast of the pointer was performed, meaning `@extern` didn't work at comptime. This is unnecessary: the decl_ref can just be initialized with the correct pointer type.