### PR TITLE
translate-c: translate extern unknown-length arrays using @extern

### DIFF
--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -3948,4 +3948,12 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
             \\}
         });
     }
+
+    cases.add("extern array of unknown length",
+        \\extern int foo[];
+    , &[_][]const u8{
+        \\const foo: [*c]c_int = @extern([*c]c_int, .{
+        \\    .name = "foo",
+        \\});
+    });
 }


### PR DESCRIPTION
Resolves: #14743

Depends on #14860 to work properly, but won't regress anything if merged sooner.