### PR TITLE
correct the definition of sigprocmask in std.os and std.os.linux

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -5661,8 +5661,8 @@ pub fn sigaction(sig: u6, noalias act: ?*const Sigaction, noalias oact: ?*Sigact
 }
 
 /// Sets the thread signal mask.
-pub fn sigprocmask(flags: u32, noalias set: ?*const sigset_t, noalias oldset: ?*sigset_t) void {
-    switch (errno(system.sigprocmask(flags, set, oldset))) {
+pub fn sigprocmask(how: i32, noalias set: ?*const sigset_t, noalias oldset: ?*sigset_t) void {
+    switch (errno(system.sigprocmask(how, set, oldset))) {
         .SUCCESS => return,
         .FAULT => unreachable,
         .INVAL => unreachable,

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1161,8 +1161,8 @@ pub fn gettid() pid_t {
     return @bitCast(pid_t, @truncate(u32, syscall0(.gettid)));
 }
 
-pub fn sigprocmask(flags: u32, noalias set: ?*const sigset_t, noalias oldset: ?*sigset_t) usize {
-    return syscall4(.rt_sigprocmask, flags, @ptrToInt(set), @ptrToInt(oldset), NSIG / 8);
+pub fn sigprocmask(how: i32, noalias set: ?*const sigset_t, noalias oldset: ?*sigset_t) usize {
+    return syscall4(.rt_sigprocmask, @bitCast(usize, @as(isize, how)), @ptrToInt(set), @ptrToInt(oldset), NSIG / 8);
 }
 
 pub fn sigaction(sig: u6, noalias act: ?*const Sigaction, noalias oact: ?*Sigaction) usize {


### PR DESCRIPTION
this makes the "how" argument (formerly "flags", but it's not really a flags argument) of std.os.sigprocmask and std.os.linux.sigprocmask match the function signature posix and the linux kernel header prototypes specify, and fixes #13234, #14861.