### PR TITLE
wasm-linker: refactor virtual addresses

### DIFF
--- a/src/link/Wasm/Object.zig
+++ b/src/link/Wasm/Object.zig
@@ -270,6 +270,7 @@ fn checkLegacyIndirectFunctionTable(object: *Object) !?Symbol {
         .name = table_import.name,
         .tag = .table,
         .index = 0,
+        .virtual_address = undefined,
     };
     table_symbol.setFlag(.WASM_SYM_UNDEFINED);
     table_symbol.setFlag(.WASM_SYM_NO_STRIP);
@@ -758,6 +759,7 @@ fn Parser(comptime ReaderType: type) type {
                 .tag = tag,
                 .name = undefined,
                 .index = undefined,
+                .virtual_address = undefined,
             };
 
             switch (tag) {

--- a/src/link/Wasm/Symbol.zig
+++ b/src/link/Wasm/Symbol.zig
@@ -20,6 +20,9 @@ name: u32,
 index: u32,
 /// Represents the kind of the symbol, such as a function or global.
 tag: Tag,
+/// Contains the virtual address of the symbol, relative to the start of its section.
+/// This differs from the offset of an `Atom` which is relative to the start of a segment.
+virtual_address: u32,
 
 pub const Tag = enum {
     function,


### PR DESCRIPTION
For data symbols, we will now store their virtual address. This means we do no longer have to calculate it each time a relocation asks for the address. 

This now also allows us directly store the virtual address of synthetic symbols without having to create an atom for them. This means we also don't need to have a "synthetic" segment any longer and do not emit the synthetic symbols such as __heap_end and __heap_base into the final binary.

This is a prerequisite for the implementation of shared memory and TLS I'm about to upstream.