### PR TITLE
std.http.Client.Response: Support any header

### DIFF
--- a/lib/std/http/Client/Response.zig
+++ b/lib/std/http/Client/Response.zig
@@ -213,7 +213,7 @@ test "header continuation" {
 
     try testing.expectError(
         error.HttpHeaderContinuationsUnsupported,
-        resp.parseHeaders(),
+        resp.parseHeaders(testing.allocator),
     );
 }
 
@@ -234,7 +234,7 @@ test "duplicate content length header" {
 
     try testing.expectError(
         error.HttpHeadersInvalid,
-        resp.parseHeaders(),
+        resp.parseHeaders(testing.allocator),
     );
 }
 


### PR DESCRIPTION
Add support for any headers in the http Client. For now only a few set of headers are supported.

### Tangential

Additionally, according to [RFC 2822, Section 2.2](https://datatracker.ietf.org/doc/html/rfc2822#section-2.2) (and common conception) the first line of an HTTP request is not a header. It is called a "status line" by [RFC 2616 Section 6.1](https://datatracker.ietf.org/doc/html/rfc2616#section-6.1).

```
HTTP/1.0 200 OK
```

It thus feels somewhat weird to me that we consider the status and the http version as headers, accessing them as if the http response somewhat looked like that.
```
Status: 200
Version: HTTP/1.0
```

Let me know if it's something we want to address in which case I can edit my PR to make that change as well. To me both status and version should be fields of the response rather than response's header field.