### PR TITLE
Resolve docs inconsistency with Overflow builtins

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -9804,8 +9804,8 @@ pub fn main() !void {
       {#header_close#}
       {#header_open|Builtin Overflow Functions#}
       <p>
-      These builtins return a {#link|Tuples#} containing wether there was an overflow
-      (as a {#syntax#}u1{#endsyntax#}) and the overflowed bits of the operation:
+      These builtins return a tuple containing whether there was an overflow
+      (as a {#syntax#}u1{#endsyntax#}) and the possibly overflowed bits of the operation:
       </p>
       <ul>
           <li>{#link|@addWithOverflow#}</li>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -9804,8 +9804,8 @@ pub fn main() !void {
       {#header_close#}
       {#header_open|Builtin Overflow Functions#}
       <p>
-      These builtins return a {#syntax#}bool{#endsyntax#} of whether or not overflow
-      occurred, as well as returning the overflowed bits:
+      These builtins return a {#link|Tuples#} containing wether there was an overflow
+      (as a {#syntax#}u1{#endsyntax#}) and the overflowed bits of the operation:
       </p>
       <ul>
           <li>{#link|@addWithOverflow#}</li>


### PR DESCRIPTION
In 41 (Undefined Behavior) . 5 (Integer Overflow) . 3 (Builtin Overflow Functions), it is stated that

> These builtins return a bool of whether or not overflow occurred, as well as returning the overflowed bits:
> * @addWithOverflow
> * @subWithOverflow
> * @mulWithOverflow
> * @shlWithOverflow

but in their definition says that it returns a `tuple`/`struct`.

Example;
`@addWithOverflow(a: anytype, b: anytype) struct { @TypeOf(a, b), u1 }`