### PR TITLE
Relative cache dir and build prefix

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -413,8 +413,15 @@ pub fn resolveInstallPrefix(self: *Build, install_prefix: ?[]const u8, dir_list:
         self.install_prefix = install_prefix orelse "/usr";
         self.install_path = self.pathJoin(&.{ dest_dir, self.install_prefix });
     } else {
-        self.install_prefix = install_prefix orelse
-            (self.build_root.join(self.allocator, &.{"zig-out"}) catch @panic("unhandled error"));
+        if (install_prefix) |path| {
+            if (fs.path.isAbsolute(path))
+                self.install_prefix = path
+            else
+                // Allow a relative path to have the same behavior as zig-out.
+                self.install_prefix = self.build_root.join(self.allocator, &.{path}) catch
+                    @panic("unhandled error");
+        } else self.install_prefix = self.build_root.join(self.allocator, &.{"zig-out"}) catch
+            @panic("unhandled error");
         self.install_path = self.install_prefix;
     }
 


### PR DESCRIPTION
The purpose of this changeset is to allow the user to override the default `zig-cache` and `zig-out` directories.

The next step is to add the `ZIG_INSTALL_DIR` environment  variable, so that both `zig-cache` and `zig-out` can be overridden using environment variables.  I'm not sure if this is the correct way, however.

Some issues:

  - I used `var zig_cache = &@as([]const u8, "zig_cache")` to store a string literal in a mutable variable, but I'm not sure if there is a better way.
  - `zig fmt` have `zig-cache` and `zig-out` hard coded, so that these directories are ignored.
  Using a custom cache directory, `zig fmt` may modify the cache entries.
  - Some user may depending on the current behavior for relative `--cache-dir` and `--prefix`.
    However in this case it possible to do (like in the `ci` scripts):
    `export ZIG_LOCAL_CACHE_DIR="$(pwd)/zig-local-cache"`
  
    By the way, `shellharden` suggests to use `$PWD` instead of `$(pwd)`.