### PR TITLE
added an error for invalid pointer dereference

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -1170,7 +1170,7 @@ fn tokenizeAndPrintRaw(
             .tilde,
             => try writeEscaped(out, src[token.loc.start..token.loc.end]),
 
-            .invalid, .invalid_periodasterisks => return parseError(
+            .invalid, .invalid_periodasterisks, .invalid_asteriskperiod => return parseError(
                 docgen_tokenizer,
                 source_token,
                 "syntax error",

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -195,6 +195,9 @@ pub fn rootDecls(tree: Ast) []const Node.Index {
 pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
     const token_tags = tree.tokens.items(.tag);
     switch (parse_error.tag) {
+        .period_after_asterisk => {
+            return stream.writeAll("expected expression after '*', found '.'. Use '.*' to dereference pointers");
+        },
         .asterisk_after_ptr_deref => {
             // Note that the token will point at the `.*` but ideally the source
             // location would point to the `*` after the `.*`.
@@ -2836,6 +2839,7 @@ pub const Error = struct {
     } = .{ .none = {} },
 
     pub const Tag = enum {
+        period_after_asterisk,
         asterisk_after_ptr_deref,
         chained_comparison_operators,
         decl_between_fields,

--- a/lib/std/zig/Parse.zig
+++ b/lib/std/zig/Parse.zig
@@ -3438,6 +3438,17 @@ fn parseSuffixOp(p: *Parse, lhs: Node.Index) !Node.Index {
                 .rhs = undefined,
             },
         }),
+        .invalid_asteriskperiod => {
+            try p.warn(.period_after_asterisk);
+            return p.addNode(.{
+                .tag = .deref,
+                .main_token = p.nextToken(),
+                .data = .{
+                    .lhs = lhs,
+                    .rhs = undefined,
+                },
+            });
+        },
         .invalid_periodasterisks => {
             try p.warn(.asterisk_after_ptr_deref);
             return p.addNode(.{

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5938,6 +5938,17 @@ test "recovery: invalid global error set access" {
     });
 }
 
+test "recovery: invalid pointer dereference" {
+    try testError(
+        \\test "" {
+        \\  foo*.;
+        \\}
+    , &[_]Error{
+        .period_after_asterisk,
+        .expected_suffix_op,
+    });
+}
+
 test "recovery: invalid asterisk after pointer dereference" {
     try testError(
         \\test "" {

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -67,6 +67,7 @@ pub const Token = struct {
 
     pub const Tag = enum {
         invalid,
+        invalid_asteriskperiod,
         invalid_periodasterisks,
         identifier,
         string_literal,
@@ -203,6 +204,7 @@ pub const Token = struct {
                 .container_doc_comment,
                 => null,
 
+                .invalid_asteriskperiod => "*.",
                 .invalid_periodasterisks => ".**",
                 .bang => "!",
                 .pipe => "|",
@@ -622,6 +624,10 @@ pub const Tokenizer = struct {
                 },
 
                 .asterisk => switch (c) {
+                    '.' => {
+                        result.tag = .invalid_asteriskperiod;
+                        break;
+                    },
                     '=' => {
                         result.tag = .asterisk_equal;
                         self.index += 1;

--- a/src/autodoc/render_source.zig
+++ b/src/autodoc/render_source.zig
@@ -386,7 +386,7 @@ pub fn tokenizeAndPrintRaw(
             .tilde,
             => try writeEscaped(out, src[token.loc.start..token.loc.end]),
 
-            .invalid, .invalid_periodasterisks => return error.ParseError,
+            .invalid, .invalid_periodasterisks, .invalid_asteriskperiod => return error.ParseError,
         }
         index = token.loc.end;
     }


### PR DESCRIPTION
This error occurs when ```foo*.``` is typed instead of ```foo.*``` to dereference a pointer which is a common beginner error.

Sorry about the closed PR I tried fixing one thing and everything went wrong. This is also the first time I've ever made a PR to a large repo so there still might be problems with this one.