### PR TITLE
Sema: avoid panic on callconv(.C) generic return type

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -8782,7 +8782,7 @@ fn funcCommon(
             };
             return sema.failWithOwnedErrorMsg(msg);
         }
-        if (!Type.fnCallingConventionAllowsZigTypes(cc_resolved) and !try sema.validateExternType(return_type, .ret_ty)) {
+        if (!ret_poison and !Type.fnCallingConventionAllowsZigTypes(cc_resolved) and !try sema.validateExternType(return_type, .ret_ty)) {
             const msg = msg: {
                 const msg = try sema.errMsg(block, ret_ty_src, "return type '{}' not allowed in function with calling convention '{s}'", .{
                     return_type.fmt(sema.mod), @tagName(cc_resolved),

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -141,6 +141,7 @@ test {
     _ = @import("behavior/bugs/13664.zig");
     _ = @import("behavior/bugs/13714.zig");
     _ = @import("behavior/bugs/13785.zig");
+    _ = @import("behavior/bugs/14854.zig");
     _ = @import("behavior/byteswap.zig");
     _ = @import("behavior/byval_arg_var.zig");
     _ = @import("behavior/call.zig");

--- a/test/behavior/bugs/14854.zig
+++ b/test/behavior/bugs/14854.zig
@@ -1,0 +1,13 @@
+const testing = @import("std").testing;
+
+test {
+    try testing.expect(getGeneric(u8, getU8) == 123);
+}
+
+fn getU8() callconv(.C) u8 {
+    return 123;
+}
+
+fn getGeneric(comptime T: type, supplier: fn () callconv(.C) T) T {
+    return supplier();
+}


### PR DESCRIPTION
Fixes #14854