### PR TITLE
Enables cross-referencing of files in WriteFileStep

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1285,6 +1285,7 @@ pub fn addInstallFileWithDir(
     }
     const install_step = self.allocator.create(InstallFileStep) catch @panic("OOM");
     install_step.* = InstallFileStep.init(self, source.dupe(self), install_dir, dest_rel_path);
+    source.addStepDependencies(&install_step.step);
     return install_step;
 }
 

--- a/lib/std/Build/WriteFileStep.zig
+++ b/lib/std/Build/WriteFileStep.zig
@@ -164,7 +164,7 @@ fn make(step: *Step) !void {
     for (wf.files.items) |file| {
         const basename = fs.path.basename(file.sub_path);
         if (fs.path.dirname(file.sub_path)) |dirname| {
-            var dir = try wf.builder.cache_root.handle.makeOpenPath(dirname, .{});
+            var dir = try cache_dir.makeOpenPath(dirname, .{});
             defer dir.close();
             try writeFile(wf, dir, file.contents, basename);
         } else {


### PR DESCRIPTION
Also fixes bug in add InstallFileWithDir.

This PR allows one to use a `WriteFileStep` to write several related files:

```zig
write_step.addCopyFile("data/embed_1.bin", …);
write_step.addCopyFile("data/embed_2.bin", …);
write_step.add("bundle.zig",
    \\pub const embed1 = @embedFile("data/embed_1.bin");
    \\pub const embed2 = @embedFile("data/embed_2.bin");
);
```