### PR TITLE
Move std.crypto.config options to std.options

### DIFF
--- a/lib/std/crypto.zig
+++ b/lib/std/crypto.zig
@@ -185,30 +185,26 @@ pub const errors = @import("crypto/errors.zig");
 pub const tls = @import("crypto/tls.zig");
 pub const Certificate = @import("crypto/Certificate.zig");
 
-/// Global configuration of cryptographic implementations in the standard library.
-pub const config = struct {
-    /// Side-channels mitigations.
-    pub const SideChannelsMitigations = enum {
-        /// No additional side-channel mitigations are applied.
-        /// This is the fastest mode.
-        none,
-        /// The `basic` mode protects against most practical attacks, provided that the
-        /// application or implements proper defenses against brute-force attacks.
-        /// It offers a good balance between performance and security.
-        basic,
-        /// The `medium` mode offers increased resilience against side-channel attacks,
-        /// making most attacks unpractical even on shared/low latency environements.
-        /// This is the default mode.
-        medium,
-        /// The `full` mode offers the highest level of protection against side-channel attacks.
-        /// Note that this doesn't cover all possible attacks (especially power analysis or
-        /// thread-local attacks such as cachebleed), and that the performance impact is significant.
-        full,
-    };
-
-    /// This is a global configuration that applies to all cryptographic implementations.
-    pub const side_channels_mitigations: SideChannelsMitigations = if (@hasDecl(root, "side_channels_mitigations")) root.side_channels_mitigations else .medium;
+/// Side-channels mitigations.
+pub const SideChannelsMitigations = enum {
+    /// No additional side-channel mitigations are applied.
+    /// This is the fastest mode.
+    none,
+    /// The `basic` mode protects against most practical attacks, provided that the
+    /// application or implements proper defenses against brute-force attacks.
+    /// It offers a good balance between performance and security.
+    basic,
+    /// The `medium` mode offers increased resilience against side-channel attacks,
+    /// making most attacks unpractical even on shared/low latency environements.
+    /// This is the default mode.
+    medium,
+    /// The `full` mode offers the highest level of protection against side-channel attacks.
+    /// Note that this doesn't cover all possible attacks (especially power analysis or
+    /// thread-local attacks such as cachebleed), and that the performance impact is significant.
+    full,
 };
+
+pub const default_side_channels_mitigations = .medium;
 
 test {
     _ = aead.aegis.Aegis128L;

--- a/lib/std/crypto/aes/soft.zig
+++ b/lib/std/crypto/aes/soft.zig
@@ -4,7 +4,7 @@ const mem = std.mem;
 
 const BlockVec = [4]u32;
 
-const side_channels_mitigations = std.crypto.config.side_channels_mitigations;
+const side_channels_mitigations = std.options.side_channels_mitigations;
 
 /// A single AES block.
 pub const Block = struct {

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -190,6 +190,11 @@ pub const options = struct {
         options_override.http_connection_pool_size
     else
         http.Client.default_connection_pool_size;
+
+    pub const side_channels_mitigations: crypto.SideChannelsMitigations = if (@hasDecl(options_override, "side_channels_mitigations"))
+        options_override.side_channels_mitigations
+    else
+        crypto.default_side_channels_mitigations;
 };
 
 // This forces the start.zig file to be imported, and the comptime logic inside that


### PR DESCRIPTION
Options have been moved to a single namespace.

Thank you Andrew for the reminder!