### PR TITLE
std.os: handle EPERM errno for bind

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3469,7 +3469,7 @@ pub fn bind(sock: socket_t, addr: *const sockaddr, len: socklen_t) BindError!voi
         const rc = system.bind(sock, addr, len);
         switch (errno(rc)) {
             .SUCCESS => return,
-            .ACCES => return error.AccessDenied,
+            .ACCES, .PERM => return error.AccessDenied,
             .ADDRINUSE => return error.AddressInUse,
             .BADF => unreachable, // always a race condition if this error is returned
             .INVAL => unreachable, // invalid parameters


### PR DESCRIPTION
Handle the EPERM error in the os.bind function, which can happen when binding AF_NETLINK sockets as non-root on Linux.

Return `error.AccessDenied` instead of `error.PermissionDenied`, as this seems to be the more common return convention for EPERM in os.zig.