### PR TITLE
Enable IPv4 mapped address conversion in linux version getAddressList

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -741,7 +741,7 @@ pub fn tcpConnectToAddress(address: Address) TcpConnectToAddressError!Stream {
     return Stream{ .handle = sockfd };
 }
 
-const GetAddressListError = std.mem.Allocator.Error || std.fs.File.OpenError || std.fs.File.ReadError || std.os.SocketError || std.os.BindError || error{
+const GetAddressListError = std.mem.Allocator.Error || std.fs.File.OpenError || std.fs.File.ReadError || std.os.SocketError || std.os.BindError || std.os.SetSockOptError || error{
     // TODO: break this up into error sets from the various underlying functions
 
     TemporaryNameServerFailure,


### PR DESCRIPTION
It seems like the original code of setsockopt is not effective because i catch the EINVAL branch when uncomment this code, it should call setsockopt before the bind call.

This should fixes #14900.