### PR TITLE
tls: send post-quantum secure keyshare

### DIFF
--- a/lib/std/crypto/tls.zig
+++ b/lib/std/crypto/tls.zig
@@ -215,6 +215,10 @@ pub const NamedGroup = enum(u16) {
     ffdhe6144 = 0x0103,
     ffdhe8192 = 0x0104,
 
+    // Hybrid post-quantum key agreements
+    x25519_kyber512d00 = 0xFE30,
+    x25519_kyber768d00 = 0xFE31,
+
     _,
 };
 

--- a/lib/std/crypto/tls/Client.zig
+++ b/lib/std/crypto/tls/Client.zig
@@ -158,6 +158,7 @@ pub fn init(stream: anytype, ca_bundle: Certificate.Bundle, host: []const u8) In
         // Only possible to happen if the private key is all zeroes.
         error.IdentityElement => return error.InsufficientEntropy,
     };
+    const kyber768_kp = crypto.kem.kyber_d00.Kyber768.KeyPair.create(null) catch {};
 
     const extensions_payload =
         tls.extension(.supported_versions, [_]u8{
@@ -175,6 +176,7 @@ pub fn init(stream: anytype, ca_bundle: Certificate.Bundle, host: []const u8) In
         .rsa_pkcs1_sha512,
         .ed25519,
     })) ++ tls.extension(.supported_groups, enum_array(tls.NamedGroup, &.{
+        .x25519_kyber768d00,
         .secp256r1,
         .x25519,
     })) ++ tls.extension(
@@ -182,7 +184,9 @@ pub fn init(stream: anytype, ca_bundle: Certificate.Bundle, host: []const u8) In
         array(1, int2(@enumToInt(tls.NamedGroup.x25519)) ++
             array(1, x25519_kp.public_key) ++
             int2(@enumToInt(tls.NamedGroup.secp256r1)) ++
-            array(1, secp256r1_kp.public_key.toUncompressedSec1())),
+            array(1, secp256r1_kp.public_key.toUncompressedSec1()) ++
+            int2(@enumToInt(tls.NamedGroup.x25519_kyber768d00)) ++
+            array(1, x25519_kp.public_key ++ kyber768_kp.public_key.toBytes())),
     ) ++
         int2(@enumToInt(tls.ExtensionType.server_name)) ++
         int2(host_len + 5) ++ // byte length of this extension payload
@@ -274,7 +278,7 @@ pub fn init(stream: anytype, ca_bundle: Certificate.Bundle, host: []const u8) In
                 const extensions_size = hsd.decode(u16);
                 var all_extd = try hsd.sub(extensions_size);
                 var supported_version: u16 = 0;
-                var shared_key: [32]u8 = undefined;
+                var shared_key: []const u8 = undefined;
                 var have_shared_key = false;
                 while (!all_extd.eof()) {
                     try all_extd.ensure(2 + 2);
@@ -295,14 +299,29 @@ pub fn init(stream: anytype, ca_bundle: Certificate.Bundle, host: []const u8) In
                             const key_size = extd.decode(u16);
                             try extd.ensure(key_size);
                             switch (named_group) {
-                                .x25519 => {
-                                    if (key_size != 32) return error.TlsIllegalParameter;
-                                    const server_pub_key = extd.array(32);
+                                .x25519_kyber768d00 => {
+                                    const xksl = crypto.dh.X25519.public_length;
+                                    const hksl = xksl + crypto.kem.kyber_d00.Kyber768.ciphertext_length;
+                                    if (key_size != hksl)
+                                        return error.TlsIllegalParameter;
+                                    const server_ks = extd.array(hksl);
 
-                                    shared_key = crypto.dh.X25519.scalarmult(
+                                    shared_key = &((crypto.dh.X25519.scalarmult(
+                                        x25519_kp.secret_key,
+                                        server_ks[0..xksl].*,
+                                    ) catch return error.TlsDecryptFailure) ++ (kyber768_kp.secret_key.decaps(
+                                        server_ks[xksl..hksl],
+                                    ) catch return error.TlsDecryptFailure));
+                                },
+                                .x25519 => {
+                                    const ksl = crypto.dh.X25519.public_length;
+                                    if (key_size != ksl) return error.TlsIllegalParameter;
+                                    const server_pub_key = extd.array(ksl);
+
+                                    shared_key = &(crypto.dh.X25519.scalarmult(
                                         x25519_kp.secret_key,
                                         server_pub_key.*,
-                                    ) catch return error.TlsDecryptFailure;
+                                    ) catch return error.TlsDecryptFailure);
                                 },
                                 .secp256r1 => {
                                     const server_pub_key = extd.slice(key_size);
@@ -314,7 +333,7 @@ pub fn init(stream: anytype, ca_bundle: Certificate.Bundle, host: []const u8) In
                                     const mul = pk.p.mulPublic(secp256r1_kp.secret_key.bytes, .Big) catch {
                                         return error.TlsDecryptFailure;
                                     };
-                                    shared_key = mul.affineCoordinates().x.toBytes(.Big);
+                                    shared_key = &mul.affineCoordinates().x.toBytes(.Big);
                                 },
                                 else => {
                                     return error.TlsIllegalParameter;
@@ -358,7 +377,7 @@ pub fn init(stream: anytype, ca_bundle: Certificate.Bundle, host: []const u8) In
                         const early_secret = P.Hkdf.extract(&[1]u8{0}, &zeroes);
                         const empty_hash = tls.emptyHash(P.Hash);
                         const hs_derived_secret = hkdfExpandLabel(P.Hkdf, early_secret, "derived", &empty_hash, P.Hash.digest_length);
-                        p.handshake_secret = P.Hkdf.extract(&hs_derived_secret, &shared_key);
+                        p.handshake_secret = P.Hkdf.extract(&hs_derived_secret, shared_key);
                         const ap_derived_secret = hkdfExpandLabel(P.Hkdf, p.handshake_secret, "derived", &empty_hash, P.Hash.digest_length);
                         p.master_secret = P.Hkdf.extract(&ap_derived_secret, &zeroes);
                         const client_secret = hkdfExpandLabel(P.Hkdf, p.handshake_secret, "c hs traffic", &hello_hash, P.Hash.digest_length);


### PR DESCRIPTION
Sends post-quantum secure hybrid key share X25519+Kyber768Draft00, deployed by [Cloudflare](https://blog.cloudflare.com/post-quantum-for-all/).

A few notes:

1. The method of hybridisation is as per this [IETF TLS WG draft](https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design) version -06.
2. Kyber will probably change before final standardisation by NIST. When it does, we'll use a new TLS codepoint and update. The current version is [v3.02](https://pq-crystals.org/kyber/data/kyber-specification-round3-20210804.pdf) of the specification and version -00 of [this I-D](https://datatracker.ietf.org/doc/draft-cfrg-schwabe-kyber/).
3. The only other big deployment of post-quantum kex is CECPQ2 ([ref1](https://blog.cloudflare.com/the-tls-post-quantum-experiment/), [ref2](https://www.chromium.org/cecpq2/)) by Google, but [they'll move to Kyber](https://mailarchive.ietf.org/arch/browse/cfrg/). It is not clear though whether they'll adopt a preliminary version such as this one.
4. Zig already generates and sends two key shares: P-256 and X25519. We generate a Kyber768 on top of that and reuse the X25519 share to make the hybrid. Kyber768 is fast — faster than X25519 — even with the currently unoptimised implementation:
   ```
           x25519:      33753 exchanges/s
      kyber768d00:      49095 encaps/s
      kyber768d00:      62798 decaps/s
      kyber768d00:      43287 keygen/s
   ```
5. Kyber's keyshare is bigger: 1184 bytes for the client keyshare and 1088 bytes for the server keyshare. This will typically split the ClientHello into two TCP segments. The standards allow this, but it might well be that some middle boxes don't expect this.

To test

```zig
const std = @import("std");

pub fn main() !void {
    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
    defer arena.deinit();

    const hdrs = std.http.Client.Request.Headers{};
    const opts = std.http.Client.Request.Options{};
    var buf: [1000]u8 = undefined;
    const uri = try std.Uri.parse("https://cloudflare.com/cdn-cgi/trace");
    var client = std.http.Client{
        .allocator= arena.allocator(),
    };
    var req = try client.request(uri, hdrs, opts);
    try req.finish();
    const read = try req.readAll(&buf);
    const stdout = std.io.getStdOut().writer();
    try stdout.print("{s}\n", .{buf[0..read]});
}
```

Output:

```
fl=555f40
h=cloudflare.com
ip=[snip]
ts=1678868428.064
visit_scheme=https
uag=zig (std.http)
colo=AMS
sliver=none
http=http/1.1
loc=NL
tls=TLSv1.3
sni=plaintext
warp=off
gateway=off
rbi=off
kex=X25519Kyber768Draft00
```