### PR TITLE
Add error for bad cast from `*T` to `*[n]T`

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -24855,6 +24855,7 @@ fn coerceExtra(
                 const array_ty = dest_info.pointee_type;
                 if (array_ty.zigTypeTag() != .Array) break :single_item;
                 const array_elem_ty = array_ty.childType();
+                if (array_ty.arrayLen() != 1) break :single_item;
                 const dest_is_mut = dest_info.mutable;
                 switch (try sema.coerceInMemoryAllowed(block, array_elem_ty, ptr_elem_ty, dest_is_mut, target, dest_ty_src, inst_src)) {
                     .ok => {},

--- a/test/cases/compile_errors/attempted_implicit_cast_from_T_to_long_array_ptr.zig
+++ b/test/cases/compile_errors/attempted_implicit_cast_from_T_to_long_array_ptr.zig
@@ -1,0 +1,18 @@
+export fn entry0(single: *u32) void {
+    _ = @as(*const [0]u32, single);
+}
+export fn entry1(single: *u32) void {
+    _ = @as(*const [1]u32, single);
+}
+export fn entry2(single: *u32) void {
+    _ = @as(*const [2]u32, single);
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:28: error: expected type '*const [0]u32', found '*u32'
+// :2:28: note: pointer type child 'u32' cannot cast into pointer type child '[0]u32'
+// :8:28: error: expected type '*const [2]u32', found '*u32'
+// :8:28: note: pointer type child 'u32' cannot cast into pointer type child '[2]u32'


### PR DESCRIPTION
Casting `*T` to `*[1]T` should still work, but every other length will now be a compiler error instead of a potential OOB access.