### PR TITLE
link: move macOS kernel inode cache invalidation to MachO linker

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -418,26 +418,7 @@ pub const File = struct {
             .Exe => {},
         }
         switch (base.tag) {
-            .macho => if (base.file) |f| {
-                if (build_options.only_c) unreachable;
-                if (comptime builtin.target.isDarwin() and builtin.target.cpu.arch == .aarch64) {
-                    if (base.options.target.cpu.arch == .aarch64) {
-                        // XNU starting with Big Sur running on arm64 is caching inodes of running binaries.
-                        // Any change to the binary will effectively invalidate the kernel's cache
-                        // resulting in a SIGKILL on each subsequent run. Since when doing incremental
-                        // linking we're modifying a binary in-place, this will end up with the kernel
-                        // killing it on every subsequent run. To circumvent it, we will copy the file
-                        // into a new inode, remove the original file, and rename the copy to match
-                        // the original file. This is super messy, but there doesn't seem any other
-                        // way to please the XNU.
-                        const emit = base.options.emit orelse return;
-                        try emit.directory.handle.copyFile(emit.sub_path, emit.directory.handle, emit.sub_path, .{});
-                    }
-                }
-                f.close();
-                base.file = null;
-            },
-            .coff, .elf, .plan9, .wasm => if (base.file) |f| {
+            .coff, .elf, .macho, .plan9, .wasm => if (base.file) |f| {
                 if (build_options.only_c) unreachable;
                 if (base.intermediary_basename != null) {
                     // The file we have open is not the final file that we want to

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -60,6 +60,17 @@ pub const SearchStrategy = enum {
     dylibs_first,
 };
 
+/// Mode of operation of the linker.
+pub const Mode = enum {
+    /// Incremental mode will preallocate segments/sections and is compatible with
+    /// watch and HCS modes of operation.
+    incremental,
+    /// Zld mode will link relocatables in a traditional, one-shot
+    /// fashion (default for LLVM backend). It acts as a drop-in replacement for
+    /// LLD.
+    zld,
+};
+
 const Section = struct {
     header: macho.section_64,
     segment_index: u8,
@@ -98,10 +109,7 @@ d_sym: ?DebugSymbols = null,
 /// For x86_64 that's 4KB, whereas for aarch64, that's 16KB.
 page_size: u16,
 
-/// Mode of operation: incremental - will preallocate segments/sections and is compatible with
-/// watch and HCS modes of operation; one_shot - will link relocatables in a traditional, one-shot
-/// fashion (default for LLVM backend).
-mode: enum { incremental, one_shot },
+mode: Mode,
 
 dyld_info_cmd: macho.dyld_info_command = .{},
 symtab_cmd: macho.symtab_command = .{},
@@ -314,33 +322,42 @@ pub const default_headerpad_size: u32 = 0x1000;
 pub fn openPath(allocator: Allocator, options: link.Options) !*MachO {
     assert(options.target.ofmt == .macho);
 
-    if (options.emit == null or options.module == null) {
+    if (options.emit == null) {
         return createEmpty(allocator, options);
     }
 
     const emit = options.emit.?;
-    const self = try createEmpty(allocator, options);
-    errdefer {
-        self.base.file = null;
-        self.base.destroy();
-    }
+    const mode: Mode = mode: {
+        if (options.use_llvm or options.module == null or options.cache_mode == .whole)
+            break :mode .zld;
+        break :mode .incremental;
+    };
+    const sub_path = if (mode == .zld) blk: {
+        if (options.module == null) {
+            // No point in opening a file, we would not write anything to it.
+            // Initialize with empty.
+            return createEmpty(allocator, options);
+        }
+        // Open a temporary object file, not the final output file because we
+        // want to link with LLD.
+        break :blk try std.fmt.allocPrint(allocator, "{s}{s}", .{
+            emit.sub_path, options.target.ofmt.fileExt(options.target.cpu.arch),
+        });
+    } else emit.sub_path;
+    errdefer if (mode == .zld) allocator.free(sub_path);
 
-    if (build_options.have_llvm and options.use_llvm and options.module != null) {
+    const self = try createEmpty(allocator, options);
+    errdefer self.base.destroy();
+
+    if (mode == .zld) {
         // TODO this intermediary_basename isn't enough; in the case of `zig build-exe`,
         // we also want to put the intermediary object file in the cache while the
         // main emit directory is the cwd.
-        self.base.intermediary_basename = try std.fmt.allocPrint(allocator, "{s}{s}", .{
-            emit.sub_path, options.target.ofmt.fileExt(options.target.cpu.arch),
-        });
+        self.base.intermediary_basename = sub_path;
+        return self;
     }
 
-    if (self.base.intermediary_basename != null) switch (options.output_mode) {
-        .Obj => return self,
-        .Lib => if (options.link_mode == .Static) return self,
-        else => {},
-    };
-
-    const file = try emit.directory.handle.createFile(emit.sub_path, .{
+    const file = try emit.directory.handle.createFile(sub_path, .{
         .truncate = false,
         .read = true,
         .mode = link.determineMode(options),
@@ -348,23 +365,21 @@ pub fn openPath(allocator: Allocator, options: link.Options) !*MachO {
     errdefer file.close();
     self.base.file = file;
 
-    if (self.mode == .one_shot) return self;
-
     if (!options.strip and options.module != null) {
         // Create dSYM bundle.
-        log.debug("creating {s}.dSYM bundle", .{emit.sub_path});
+        log.debug("creating {s}.dSYM bundle", .{sub_path});
 
         const d_sym_path = try fmt.allocPrint(
             allocator,
             "{s}.dSYM" ++ fs.path.sep_str ++ "Contents" ++ fs.path.sep_str ++ "Resources" ++ fs.path.sep_str ++ "DWARF",
-            .{emit.sub_path},
+            .{sub_path},
         );
         defer allocator.free(d_sym_path);
 
         var d_sym_bundle = try emit.directory.handle.makeOpenPath(d_sym_path, .{});
         defer d_sym_bundle.close();
 
-        const d_sym_file = try d_sym_bundle.createFile(emit.sub_path, .{
+        const d_sym_file = try d_sym_bundle.createFile(sub_path, .{
             .truncate = false,
             .read = true,
         });
@@ -413,7 +428,7 @@ pub fn createEmpty(gpa: Allocator, options: link.Options) !*MachO {
         },
         .page_size = page_size,
         .mode = if (use_llvm or options.module == null or options.cache_mode == .whole)
-            .one_shot
+            .zld
         else
             .incremental,
     };
@@ -447,7 +462,7 @@ pub fn flush(self: *MachO, comp: *Compilation, prog_node: *std.Progress.Node) li
     }
 
     switch (self.mode) {
-        .one_shot => return zld.linkWithZld(self, comp, prog_node),
+        .zld => return zld.linkWithZld(self, comp, prog_node),
         .incremental => return self.flushModule(comp, prog_node),
     }
 }

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -3665,16 +3665,17 @@ pub fn linkWithZld(macho_file: *MachO, comp: *Compilation, prog_node: *std.Progr
     } else {
         const page_size = macho_file.page_size;
         const sub_path = options.emit.?.sub_path;
-        if (macho_file.base.file == null) {
-            macho_file.base.file = try directory.handle.createFile(sub_path, .{
-                .truncate = true,
-                .read = true,
-                .mode = link.determineMode(options.*),
-            });
-        }
+
+        const file = try directory.handle.createFile(sub_path, .{
+            .truncate = true,
+            .read = true,
+            .mode = link.determineMode(options.*),
+        });
+        defer file.close();
+
         var zld = Zld{
             .gpa = gpa,
-            .file = macho_file.base.file.?,
+            .file = file,
             .page_size = macho_file.page_size,
             .options = options,
         };

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -4172,6 +4172,7 @@ pub fn linkWithZld(macho_file: *MachO, comp: *Compilation, prog_node: *std.Progr
 
         if (codesig) |*csig| {
             try zld.writeCodeSignature(comp, csig); // code signing always comes last
+            try MachO.invalidateKernelCache(directory.handle, zld.options.emit.?.sub_path);
         }
     }
 


### PR DESCRIPTION
Since #14647 landed in master, I started experiencing build failures on an M1 mac where it looked as if the output directory handle was getting closed before we could invalidate the kernel cache by moving the final binary in-place. The code responsible for this so far resided in `link.makeExecutable` but now I am of the opinion that it really is part of the MachO linker only. I have thus moved it and as expected it solved the problems for me.

For the record, here's an example error trace before this change:

```zig
zig build-exe zdb Debug native: error: thread 6148693 panic: reached unreachable code                                                                                                                                                                                                                                                                                  
/Users/kubkon/dev/zig/build/stage3/lib/zig/std/os.zig:1725:22: 0x10449d813 in openatZ (zig)                                                                                                                                                                                                                                     
            .BADF => unreachable,                                                                                                                                                                                                                                                                                               
                     ^                                                                                                                                                                                                                                                                                                          
/Users/kubkon/dev/zig/build/stage3/lib/zig/std/fs.zig:1179:32: 0x10426dc7f in openFileZ (zig)                                                                                                                                                                                                                                   
            try os.openatZ(self.fd, sub_path, os_flags, 0);                                                                                                                                                                                                                                                                     
                               ^                                                                                                                                                                                                                                                                                                
/Users/kubkon/dev/zig/build/stage3/lib/zig/std/fs.zig:1113:30: 0x1040e0e2b in openFile (zig)                                                                                                                                                                                                                                    
        return self.openFileZ(&path_c, flags);                                                                                                                                                                                                                                                                                  
                             ^                                                                                                                                                                                                                                                                                                  
/Users/kubkon/dev/zig/build/stage3/lib/zig/std/fs.zig:2563:46: 0x1041a1ffb in copyFile (zig)                                                                                                                                                                                                                                    
        var in_file = try source_dir.openFile(source_path, .{});                                                                                                                                                                                                                                                                
                                             ^                                                                                                                                                                                                                                                                                  
/Users/kubkon/dev/zig/src/link.zig:436:102: 0x1041ef463 in makeExecutable (zig)                                                                                                                                                                                                                                                 
                        try emit.directory.handle.copyFile(emit.sub_path, emit.directory.handle, emit.sub_path, .{});                                                                                                                                                                                                           
                                                                                                     ^                                                                                                                                                                                                                          
/Users/kubkon/dev/zig/src/Compilation.zig:2469:40: 0x1041ef007 in makeBinFileExecutable (zig)                                                                                                                                                                                                                                   
    return self.bin_file.makeExecutable();                                                                                                                                                                                                                                                                                      
                                       ^                                                                                                                                                                                                                                                                                        
/Users/kubkon/dev/zig/src/main.zig:3498:47: 0x104214c5f in serve (zig)                                                                                                                                                                                                                                                          
                try comp.makeBinFileExecutable();                                                                                                                                                                                                                                                                               
                                              ^                                                                                                                                                                                                                                                                                 
/Users/kubkon/dev/zig/src/main.zig:3298:31: 0x1040bbb5f in buildOutputType (zig)                                                                                                                                                                                                                                                
                test_exec_args.items,                                                                                                                                                                                                                                                                                           
                              ^                                                                                                                                                                                                                                                                                                 
/Users/kubkon/dev/zig/src/main.zig:267:31: 0x10408f357 in mainArgs (zig)                                                                                                                                                                                                                                                        
        return buildOutputType(gpa, arena, args, .{ .build = .Exe });                                                                                                                                                                                                                                                           
                              ^                                                                                                                                                                                                                                                                                                 
/Users/kubkon/dev/zig/src/main.zig:211:20: 0x10408eaf7 in main (zig)                                                                                                                                                                                                                                                            
    return mainArgs(gpa, arena, args);                                                                                                                                                                                                                                                                                          
                   ^                                                                                                                                                                                                                                                                                                            
/Users/kubkon/dev/zig/build/stage3/lib/zig/std/start.zig:617:37: 0x104090f13 in main (zig)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x1aa0c3e4f in ??? (???)
???:?:?: 0xde3affffffffffff in ??? (???)

zig build-exe zdb Debug native: error: the following command terminated unexpectedly:
/Users/kubkon/dev/zig/build/stage4/bin/zig build-exe /Users/kubkon/dev/zdb/src/main.zig /Users/kubkon/dev/zdb/src/macos/mach_excUser.c /Users/kubkon/dev/zdb/src/macos/mach_excServer.c --cache-dir /Users/kubkon/dev/zdb/zig-cache --global-cache-dir /Users/kubkon/.cache/zig --name zdb --entitlements resources/Info.plist --mod build_options::/Users/kubkon/dev/zdb/zig-cache/options/Dfs55J_0mL3vKEcBg-fTHWsoD5DNKkw-_hN_otKnahHPKdjb9j_UGtbDK13-7MR5 --deps build_options -I /Users/kubkon/dev/zdb/src --enable-cache --listen=- 
Build Summary: 1/4 steps succeeded; 1 failed (disable with -fno-summary)
install transitive failure
└─ install zdb transitive failure
   └─ zig build-exe zdb Debug native failure
      └─ options success
error: the following build command failed with exit code 1:
/Users/kubkon/dev/zdb/zig-cache/o/d0d7fd31f9d3811bc176313047d275c4/build /Users/kubkon/dev/zig/build/stage4/bin/zig /Users/kubkon/dev/zdb /Users/kubkon/dev/zdb/zig-cache /Users/kubkon/.cache/zig
```