### PR TITLE
Sema: allow dereferencing ill-defined pointers to zero-bit types at comptime

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4712,6 +4712,11 @@ fn zirValidateDeref(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileErr
         .Slice => return sema.fail(block, src, "index syntax required for slice type '{}'", .{operand_ty.fmt(sema.mod)}),
     }
 
+    if ((try sema.typeHasOnePossibleValue(operand_ty.childType())) != null) {
+        // No need to validate the actual pointer value, we don't need it!
+        return;
+    }
+
     const elem_ty = operand_ty.elemType2();
     if (try sema.resolveMaybeUndefVal(operand)) |val| {
         if (val.isUndef()) {

--- a/test/behavior/comptime_memory.zig
+++ b/test/behavior/comptime_memory.zig
@@ -420,3 +420,11 @@ test "mutate entire slice at comptime" {
         buf[1..3].* = x;
     }
 }
+
+test "dereference undefined pointer to zero-bit type" {
+    const p0: *void = undefined;
+    try testing.expectEqual({}, p0.*);
+
+    const p1: *[0]u32 = undefined;
+    try testing.expect(p1.*.len == 0);
+}


### PR DESCRIPTION
It doesn't matter if a pointer to a zero-bit (i.e. OPV) type is undefined or runtime-known; we still know the result of the dereference at comptime. Code may use this, for instance, when allocating zero-bit types: `@as(*void, undefined)` is entirely reasonable to use at runtime, since we know the pointer will never be accessed, thus it should be valid at comptime too.