### PR TITLE
Port some stage1 test cases to stage2

### DIFF
--- a/test/cases/compile_errors/undefined_as_field_type_is_rejected.zig
+++ b/test/cases/compile_errors/undefined_as_field_type_is_rejected.zig
@@ -7,7 +7,7 @@ export fn entry1() void {
 }
 
 // error
-// backend=stage1
+// backend=stage2
 // target=native
 //
-// tmp.zig:2:8: error: use of undefined value here causes undefined behavior
+// :2:8: error: use of undefined value here causes undefined behavior

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -136,4 +136,51 @@ pub fn addCases(ctx: *Cases) !void {
             \\const dummy = 0;
         );
     }
+
+    {
+        const case = ctx.obj("wrong same named struct", .{});
+
+        case.addError(
+            \\const a = @import("a.zig");
+            \\const b = @import("b.zig");
+            \\
+            \\export fn entry() void {
+            \\    var a1: a.Foo = undefined;
+            \\    bar(&a1);
+            \\}
+            \\
+            \\fn bar(_: *b.Foo) void {}
+        , &[_][]const u8{
+            ":6:9: error: expected type '*b.Foo', found '*a.Foo'",
+            ":6:9: note: pointer type child 'a.Foo' cannot cast into pointer type child 'b.Foo'",
+            ":1:17: note: struct declared here",
+            ":1:17: note: struct declared here",
+            ":9:11: note: parameter type declared here",
+        });
+
+        case.addSourceFile("a.zig",
+            \\pub const Foo = struct {
+            \\    x: i32,
+            \\};
+        );
+
+        case.addSourceFile("b.zig",
+            \\pub const Foo = struct {
+            \\    z: f64,
+            \\};
+        );
+    }
+
+    {
+        const case = ctx.obj("non-printable invalid character", .{});
+
+        case.addError("\xff\xfe" ++
+            \\export fn foo() bool {
+            \\    return true;
+            \\}
+        , &[_][]const u8{
+            ":1:1: error: expected type expression, found 'invalid bytes'",
+            ":1:1: note: invalid byte: '\\xff'",
+        });
+    }
 }


### PR DESCRIPTION
There are now very few stage1 cases remaining:
* `cases/compile_errors/stage1/obj/*` currently don't work correctly on stage2. There are 6 of these, and most of them are probably fairly simple to fix.
* `cases/compile_errors/async/*` and all remaining `safety/*` depend on async; see #6025.

Resolves: #14849