### PR TITLE
Build.zig_exe: make it sentinel-aware

### DIFF
--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -1008,13 +1008,13 @@ fn usageAndErr(builder: *std.Build, already_ran_build: bool, out_stream: anytype
     process.exit(1);
 }
 
-fn nextArg(args: [][]const u8, idx: *usize) ?[]const u8 {
+fn nextArg(args: [][:0]const u8, idx: *usize) ?[:0]const u8 {
     if (idx.* >= args.len) return null;
     defer idx.* += 1;
     return args[idx.*];
 }
 
-fn argsRest(args: [][]const u8, idx: usize) ?[][]const u8 {
+fn argsRest(args: [][:0]const u8, idx: usize) ?[][:0]const u8 {
     if (idx >= args.len) return null;
     return args[idx..];
 }

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -60,7 +60,7 @@ verbose_cimport: bool,
 verbose_llvm_cpu_features: bool,
 reference_trace: ?u32 = null,
 invalid_user_input: bool,
-zig_exe: []const u8,
+zig_exe: [:0]const u8,
 default_step: *Step,
 env_map: *EnvMap,
 top_level_steps: std.StringArrayHashMapUnmanaged(*TopLevelStep),
@@ -184,7 +184,7 @@ pub const DirList = struct {
 
 pub fn create(
     allocator: Allocator,
-    zig_exe: []const u8,
+    zig_exe: [:0]const u8,
     build_root: Cache.Directory,
     cache_root: Cache.Directory,
     global_cache_root: Cache.Directory,


### PR DESCRIPTION
This is useful for tests that want to `execve` zig directly. The string is already null-terminated, so this will just expose it as such, removing an extra allocation from the test.

Will be used in #14462