### PR TITLE
Upstream macOS hot-code swapping PoC

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -152,6 +152,7 @@ pub fn build(b: *std.Build) !void {
     if (only_install_lib_files)
         return;
 
+    const entitlements = b.option([]const u8, "entitlements", "Path to entitlements file for hot-code swapping without sudo on macOS");
     const tracy = b.option([]const u8, "tracy", "Enable Tracy integration. Supply path to Tracy source");
     const tracy_callstack = b.option(bool, "tracy-callstack", "Include callstack information with Tracy data. Does nothing if -Dtracy is not provided") orelse (tracy != null);
     const tracy_allocation = b.option(bool, "tracy-allocation", "Include allocation information with Tracy data. Does nothing if -Dtracy is not provided") orelse (tracy != null);
@@ -173,6 +174,7 @@ pub fn build(b: *std.Build) !void {
     exe.pie = pie;
     exe.sanitize_thread = sanitize_thread;
     exe.build_id = b.option(bool, "build-id", "Include a build id note") orelse false;
+    exe.entitlements = entitlements;
     exe.install();
 
     const compile_step = b.step("compile", "Build the self-hosted compiler");

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -3316,7 +3316,7 @@ pub fn getKernError(err: kern_return_t) KernE {
 
 pub fn unexpectedKernError(err: KernE) std.os.UnexpectedError {
     if (std.os.unexpected_error_tracing) {
-        std.debug.print("unexpected errno: {d}\n", .{@enumToInt(err)});
+        std.debug.print("unexpected error: {d}\n", .{@enumToInt(err)});
         std.debug.dumpCurrentStackTrace(null);
     }
     return error.Unexpected;

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -3033,16 +3033,18 @@ pub const caddr_t = ?[*]u8;
 
 pub extern "c" fn ptrace(request: c_int, pid: pid_t, addr: caddr_t, data: c_int) c_int;
 
-pub const POSIX_SPAWN_RESETIDS = 0x0001;
-pub const POSIX_SPAWN_SETPGROUP = 0x0002;
-pub const POSIX_SPAWN_SETSIGDEF = 0x0004;
-pub const POSIX_SPAWN_SETSIGMASK = 0x0008;
-pub const POSIX_SPAWN_SETEXEC = 0x0040;
-pub const POSIX_SPAWN_START_SUSPENDED = 0x0080;
-pub const _POSIX_SPAWN_DISABLE_ASLR = 0x0100;
-pub const POSIX_SPAWN_SETSID = 0x0400;
-pub const _POSIX_SPAWN_RESLIDE = 0x0800;
-pub const POSIX_SPAWN_CLOEXEC_DEFAULT = 0x4000;
+pub const POSIX_SPAWN = struct {
+    pub const RESETIDS = 0x0001;
+    pub const SETPGROUP = 0x0002;
+    pub const SETSIGDEF = 0x0004;
+    pub const SETSIGMASK = 0x0008;
+    pub const SETEXEC = 0x0040;
+    pub const START_SUSPENDED = 0x0080;
+    pub const DISABLE_ASLR = 0x0100;
+    pub const SETSID = 0x0400;
+    pub const RESLIDE = 0x0800;
+    pub const CLOEXEC_DEFAULT = 0x4000;
+};
 
 pub const posix_spawnattr_t = *opaque {};
 pub const posix_spawn_file_actions_t = *opaque {};

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -203,47 +203,6 @@ pub extern "c" fn mach_timebase_info(tinfo: ?*mach_timebase_info_data) kern_retu
 pub extern "c" fn malloc_size(?*const anyopaque) usize;
 pub extern "c" fn posix_memalign(memptr: *?*anyopaque, alignment: usize, size: usize) c_int;
 
-pub const posix_spawnattr_t = *opaque {};
-pub const posix_spawn_file_actions_t = *opaque {};
-pub extern "c" fn posix_spawnattr_init(attr: *posix_spawnattr_t) c_int;
-pub extern "c" fn posix_spawnattr_destroy(attr: *posix_spawnattr_t) c_int;
-pub extern "c" fn posix_spawnattr_setflags(attr: *posix_spawnattr_t, flags: c_short) c_int;
-pub extern "c" fn posix_spawnattr_getflags(attr: *const posix_spawnattr_t, flags: *c_short) c_int;
-pub extern "c" fn posix_spawn_file_actions_init(actions: *posix_spawn_file_actions_t) c_int;
-pub extern "c" fn posix_spawn_file_actions_destroy(actions: *posix_spawn_file_actions_t) c_int;
-pub extern "c" fn posix_spawn_file_actions_addclose(actions: *posix_spawn_file_actions_t, filedes: fd_t) c_int;
-pub extern "c" fn posix_spawn_file_actions_addopen(
-    actions: *posix_spawn_file_actions_t,
-    filedes: fd_t,
-    path: [*:0]const u8,
-    oflag: c_int,
-    mode: mode_t,
-) c_int;
-pub extern "c" fn posix_spawn_file_actions_adddup2(
-    actions: *posix_spawn_file_actions_t,
-    filedes: fd_t,
-    newfiledes: fd_t,
-) c_int;
-pub extern "c" fn posix_spawn_file_actions_addinherit_np(actions: *posix_spawn_file_actions_t, filedes: fd_t) c_int;
-pub extern "c" fn posix_spawn_file_actions_addchdir_np(actions: *posix_spawn_file_actions_t, path: [*:0]const u8) c_int;
-pub extern "c" fn posix_spawn_file_actions_addfchdir_np(actions: *posix_spawn_file_actions_t, filedes: fd_t) c_int;
-pub extern "c" fn posix_spawn(
-    pid: *pid_t,
-    path: [*:0]const u8,
-    actions: ?*const posix_spawn_file_actions_t,
-    attr: ?*const posix_spawnattr_t,
-    argv: [*:null]?[*:0]const u8,
-    env: [*:null]?[*:0]const u8,
-) c_int;
-pub extern "c" fn posix_spawnp(
-    pid: *pid_t,
-    path: [*:0]const u8,
-    actions: ?*const posix_spawn_file_actions_t,
-    attr: ?*const posix_spawnattr_t,
-    argv: [*:null]?[*:0]const u8,
-    env: [*:null]?[*:0]const u8,
-) c_int;
-
 pub extern "c" fn kevent64(
     kq: c_int,
     changelist: [*]const kevent64_s,
@@ -2176,18 +2135,6 @@ pub const E = enum(u16) {
     _,
 };
 
-pub fn getKernError(err: kern_return_t) KernE {
-    return @intToEnum(KernE, @truncate(u32, @intCast(usize, err)));
-}
-
-pub fn unexpectedKernError(err: KernE) std.os.UnexpectedError {
-    if (std.os.unexpected_error_tracing) {
-        std.debug.print("unexpected errno: {d}\n", .{@enumToInt(err)});
-        std.debug.dumpCurrentStackTrace(null);
-    }
-    return error.Unexpected;
-}
-
 /// Kernel return values
 pub const KernE = enum(u32) {
     SUCCESS = 0,
@@ -3063,6 +3010,29 @@ pub const CPUFAMILY = enum(u32) {
     _,
 };
 
+pub const PT = struct {
+    pub const TRACE_ME = 0;
+    pub const READ_I = 1;
+    pub const READ_D = 2;
+    pub const READ_U = 3;
+    pub const WRITE_I = 4;
+    pub const WRITE_D = 5;
+    pub const WRITE_U = 6;
+    pub const CONTINUE = 7;
+    pub const KILL = 8;
+    pub const STEP = 9;
+    pub const DETACH = 11;
+    pub const SIGEXC = 12;
+    pub const THUPDATE = 13;
+    pub const ATTACHEXC = 14;
+    pub const FORCEQUOTA = 30;
+    pub const DENY_ATTACH = 31;
+};
+
+pub const caddr_t = ?[*]u8;
+
+pub extern "c" fn ptrace(request: c_int, pid: pid_t, addr: caddr_t, data: c_int) c_int;
+
 pub const POSIX_SPAWN_RESETIDS = 0x0001;
 pub const POSIX_SPAWN_SETPGROUP = 0x0002;
 pub const POSIX_SPAWN_SETSIGDEF = 0x0004;
@@ -3074,26 +3044,283 @@ pub const POSIX_SPAWN_SETSID = 0x0400;
 pub const _POSIX_SPAWN_RESLIDE = 0x0800;
 pub const POSIX_SPAWN_CLOEXEC_DEFAULT = 0x4000;
 
-pub const PT_TRACE_ME = 0;
-pub const PT_READ_I = 1;
-pub const PT_READ_D = 2;
-pub const PT_READ_U = 3;
-pub const PT_WRITE_I = 4;
-pub const PT_WRITE_D = 5;
-pub const PT_WRITE_U = 6;
-pub const PT_CONTINUE = 7;
-pub const PT_KILL = 8;
-pub const PT_STEP = 9;
-pub const PT_DETACH = 11;
-pub const PT_SIGEXC = 12;
-pub const PT_THUPDATE = 13;
-pub const PT_ATTACHEXC = 14;
-pub const PT_FORCEQUOTA = 30;
-pub const PT_DENY_ATTACH = 31;
+pub const posix_spawnattr_t = *opaque {};
+pub const posix_spawn_file_actions_t = *opaque {};
+pub extern "c" fn posix_spawnattr_init(attr: *posix_spawnattr_t) c_int;
+pub extern "c" fn posix_spawnattr_destroy(attr: *posix_spawnattr_t) c_int;
+pub extern "c" fn posix_spawnattr_setflags(attr: *posix_spawnattr_t, flags: c_short) c_int;
+pub extern "c" fn posix_spawnattr_getflags(attr: *const posix_spawnattr_t, flags: *c_short) c_int;
+pub extern "c" fn posix_spawn_file_actions_init(actions: *posix_spawn_file_actions_t) c_int;
+pub extern "c" fn posix_spawn_file_actions_destroy(actions: *posix_spawn_file_actions_t) c_int;
+pub extern "c" fn posix_spawn_file_actions_addclose(actions: *posix_spawn_file_actions_t, filedes: fd_t) c_int;
+pub extern "c" fn posix_spawn_file_actions_addopen(
+    actions: *posix_spawn_file_actions_t,
+    filedes: fd_t,
+    path: [*:0]const u8,
+    oflag: c_int,
+    mode: mode_t,
+) c_int;
+pub extern "c" fn posix_spawn_file_actions_adddup2(
+    actions: *posix_spawn_file_actions_t,
+    filedes: fd_t,
+    newfiledes: fd_t,
+) c_int;
+pub extern "c" fn posix_spawn_file_actions_addinherit_np(actions: *posix_spawn_file_actions_t, filedes: fd_t) c_int;
+pub extern "c" fn posix_spawn_file_actions_addchdir_np(actions: *posix_spawn_file_actions_t, path: [*:0]const u8) c_int;
+pub extern "c" fn posix_spawn_file_actions_addfchdir_np(actions: *posix_spawn_file_actions_t, filedes: fd_t) c_int;
+pub extern "c" fn posix_spawn(
+    pid: *pid_t,
+    path: [*:0]const u8,
+    actions: ?*const posix_spawn_file_actions_t,
+    attr: ?*const posix_spawnattr_t,
+    argv: [*:null]?[*:0]const u8,
+    env: [*:null]?[*:0]const u8,
+) c_int;
+pub extern "c" fn posix_spawnp(
+    pid: *pid_t,
+    path: [*:0]const u8,
+    actions: ?*const posix_spawn_file_actions_t,
+    attr: ?*const posix_spawnattr_t,
+    argv: [*:null]?[*:0]const u8,
+    env: [*:null]?[*:0]const u8,
+) c_int;
 
-pub const caddr_t = ?[*]u8;
+pub const PosixSpawn = struct {
+    const errno = std.os.errno;
+    const unexpectedErrno = std.os.unexpectedErrno;
 
-pub extern "c" fn ptrace(request: c_int, pid: pid_t, addr: caddr_t, data: c_int) c_int;
+    pub const Error = error{
+        SystemResources,
+        InvalidFileDescriptor,
+        NameTooLong,
+        TooBig,
+        PermissionDenied,
+        InputOutput,
+        FileSystem,
+        FileNotFound,
+        InvalidExe,
+        NotDir,
+        FileBusy,
+        /// Returned when the child fails to execute either in the pre-exec() initialization step, or
+        /// when exec(3) is invoked.
+        ChildExecFailed,
+    } || std.os.UnexpectedError;
+
+    pub const Attr = struct {
+        attr: posix_spawnattr_t,
+
+        pub fn init() Error!Attr {
+            var attr: posix_spawnattr_t = undefined;
+            switch (errno(posix_spawnattr_init(&attr))) {
+                .SUCCESS => return Attr{ .attr = attr },
+                .NOMEM => return error.SystemResources,
+                .INVAL => unreachable,
+                else => |err| return unexpectedErrno(err),
+            }
+        }
+
+        pub fn deinit(self: *Attr) void {
+            defer self.* = undefined;
+            switch (errno(posix_spawnattr_destroy(&self.attr))) {
+                .SUCCESS => return,
+                .INVAL => unreachable, // Invalid parameters.
+                else => unreachable,
+            }
+        }
+
+        pub fn get(self: Attr) Error!u16 {
+            var flags: c_short = undefined;
+            switch (errno(posix_spawnattr_getflags(&self.attr, &flags))) {
+                .SUCCESS => return @bitCast(u16, flags),
+                .INVAL => unreachable,
+                else => |err| return unexpectedErrno(err),
+            }
+        }
+
+        pub fn set(self: *Attr, flags: u16) Error!void {
+            switch (errno(posix_spawnattr_setflags(&self.attr, @bitCast(c_short, flags)))) {
+                .SUCCESS => return,
+                .INVAL => unreachable,
+                else => |err| return unexpectedErrno(err),
+            }
+        }
+    };
+
+    pub const Actions = struct {
+        actions: posix_spawn_file_actions_t,
+
+        pub fn init() Error!Actions {
+            var actions: posix_spawn_file_actions_t = undefined;
+            switch (errno(posix_spawn_file_actions_init(&actions))) {
+                .SUCCESS => return Actions{ .actions = actions },
+                .NOMEM => return error.SystemResources,
+                .INVAL => unreachable,
+                else => |err| return unexpectedErrno(err),
+            }
+        }
+
+        pub fn deinit(self: *Actions) void {
+            defer self.* = undefined;
+            switch (errno(posix_spawn_file_actions_destroy(&self.actions))) {
+                .SUCCESS => return,
+                .INVAL => unreachable, // Invalid parameters.
+                else => unreachable,
+            }
+        }
+
+        pub fn open(self: *Actions, fd: fd_t, path: []const u8, flags: u32, mode: mode_t) Error!void {
+            const posix_path = try std.os.toPosixPath(path);
+            return self.openZ(fd, &posix_path, flags, mode);
+        }
+
+        pub fn openZ(self: *Actions, fd: fd_t, path: [*:0]const u8, flags: u32, mode: mode_t) Error!void {
+            switch (errno(posix_spawn_file_actions_addopen(&self.actions, fd, path, @bitCast(c_int, flags), mode))) {
+                .SUCCESS => return,
+                .BADF => return error.InvalidFileDescriptor,
+                .NOMEM => return error.SystemResources,
+                .NAMETOOLONG => return error.NameTooLong,
+                .INVAL => unreachable, // the value of file actions is invalid
+                else => |err| return unexpectedErrno(err),
+            }
+        }
+
+        pub fn close(self: *Actions, fd: fd_t) Error!void {
+            switch (errno(posix_spawn_file_actions_addclose(&self.actions, fd))) {
+                .SUCCESS => return,
+                .BADF => return error.InvalidFileDescriptor,
+                .NOMEM => return error.SystemResources,
+                .INVAL => unreachable, // the value of file actions is invalid
+                .NAMETOOLONG => unreachable,
+                else => |err| return unexpectedErrno(err),
+            }
+        }
+
+        pub fn dup2(self: *Actions, fd: fd_t, newfd: fd_t) Error!void {
+            switch (errno(posix_spawn_file_actions_adddup2(&self.actions, fd, newfd))) {
+                .SUCCESS => return,
+                .BADF => return error.InvalidFileDescriptor,
+                .NOMEM => return error.SystemResources,
+                .INVAL => unreachable, // the value of file actions is invalid
+                .NAMETOOLONG => unreachable,
+                else => |err| return unexpectedErrno(err),
+            }
+        }
+
+        pub fn inherit(self: *Actions, fd: fd_t) Error!void {
+            switch (errno(posix_spawn_file_actions_addinherit_np(&self.actions, fd))) {
+                .SUCCESS => return,
+                .BADF => return error.InvalidFileDescriptor,
+                .NOMEM => return error.SystemResources,
+                .INVAL => unreachable, // the value of file actions is invalid
+                .NAMETOOLONG => unreachable,
+                else => |err| return unexpectedErrno(err),
+            }
+        }
+
+        pub fn chdir(self: *Actions, path: []const u8) Error!void {
+            const posix_path = try std.os.toPosixPath(path);
+            return self.chdirZ(&posix_path);
+        }
+
+        pub fn chdirZ(self: *Actions, path: [*:0]const u8) Error!void {
+            switch (errno(posix_spawn_file_actions_addchdir_np(&self.actions, path))) {
+                .SUCCESS => return,
+                .NOMEM => return error.SystemResources,
+                .NAMETOOLONG => return error.NameTooLong,
+                .BADF => unreachable,
+                .INVAL => unreachable, // the value of file actions is invalid
+                else => |err| return unexpectedErrno(err),
+            }
+        }
+
+        pub fn fchdir(self: *Actions, fd: fd_t) Error!void {
+            switch (errno(posix_spawn_file_actions_addfchdir_np(&self.actions, fd))) {
+                .SUCCESS => return,
+                .BADF => return error.InvalidFileDescriptor,
+                .NOMEM => return error.SystemResources,
+                .INVAL => unreachable, // the value of file actions is invalid
+                .NAMETOOLONG => unreachable,
+                else => |err| return unexpectedErrno(err),
+            }
+        }
+    };
+
+    pub fn spawn(
+        path: []const u8,
+        actions: ?Actions,
+        attr: ?Attr,
+        argv: [*:null]?[*:0]const u8,
+        envp: [*:null]?[*:0]const u8,
+    ) Error!pid_t {
+        const posix_path = try std.os.toPosixPath(path);
+        return spawnZ(&posix_path, actions, attr, argv, envp);
+    }
+
+    pub fn spawnZ(
+        path: [*:0]const u8,
+        actions: ?Actions,
+        attr: ?Attr,
+        argv: [*:null]?[*:0]const u8,
+        envp: [*:null]?[*:0]const u8,
+    ) Error!pid_t {
+        var pid: pid_t = undefined;
+        switch (errno(posix_spawn(
+            &pid,
+            path,
+            if (actions) |a| &a.actions else null,
+            if (attr) |a| &a.attr else null,
+            argv,
+            envp,
+        ))) {
+            .SUCCESS => return pid,
+            .@"2BIG" => return error.TooBig,
+            .NOMEM => return error.SystemResources,
+            .BADF => return error.InvalidFileDescriptor,
+            .ACCES => return error.PermissionDenied,
+            .IO => return error.InputOutput,
+            .LOOP => return error.FileSystem,
+            .NAMETOOLONG => return error.NameTooLong,
+            .NOENT => return error.FileNotFound,
+            .NOEXEC => return error.InvalidExe,
+            .NOTDIR => return error.NotDir,
+            .TXTBSY => return error.FileBusy,
+            .BADARCH => return error.InvalidExe,
+            .BADEXEC => return error.InvalidExe,
+            .FAULT => unreachable,
+            .INVAL => unreachable,
+            else => |err| return unexpectedErrno(err),
+        }
+    }
+
+    pub fn waitpid(pid: pid_t, flags: u32) Error!std.os.WaitPidResult {
+        var status: c_int = undefined;
+        while (true) {
+            const rc = waitpid(pid, &status, @intCast(c_int, flags));
+            switch (errno(rc)) {
+                .SUCCESS => return std.os.WaitPidResult{
+                    .pid = @intCast(pid_t, rc),
+                    .status = @bitCast(u32, status),
+                },
+                .INTR => continue,
+                .CHILD => return error.ChildExecFailed,
+                .INVAL => unreachable, // Invalid flags.
+                else => unreachable,
+            }
+        }
+    }
+};
+
+pub fn getKernError(err: kern_return_t) KernE {
+    return @intToEnum(KernE, @truncate(u32, @intCast(usize, err)));
+}
+
+pub fn unexpectedKernError(err: KernE) std.os.UnexpectedError {
+    if (std.os.unexpected_error_tracing) {
+        std.debug.print("unexpected errno: {d}\n", .{@enumToInt(err)});
+        std.debug.dumpCurrentStackTrace(null);
+    }
+    return error.Unexpected;
+}
 
 pub const MachError = error{
     /// Not enough permissions held to perform the requested kernel

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -656,6 +656,10 @@ pub const segment_command_64 = extern struct {
     pub fn segName(seg: *const segment_command_64) []const u8 {
         return parseName(&seg.segname);
     }
+
+    pub fn isWriteable(seg: segment_command_64) bool {
+        return seg.initprot & PROT.WRITE != 0;
+    }
 };
 
 pub const PROT = struct {

--- a/src/link.zig
+++ b/src/link.zig
@@ -397,9 +397,10 @@ pub const File = struct {
                             if (macho.mach_task == null) {
                                 if (std.os.darwin.machTaskForPid(pid)) |task| {
                                     macho.mach_task = task;
-                                    std.os.ptrace(std.os.darwin.PT.ATTACHEXC, pid, 0, 0) catch |err| {
-                                        log.warn("ptrace failure: {s}", .{@errorName(err)});
-                                    };
+                                    // TODO enable ones we register for exceptions
+                                    // std.os.ptrace(std.os.darwin.PT.ATTACHEXC, pid, 0, 0) catch |err| {
+                                    //     log.warn("ptrace failure: {s}", .{@errorName(err)});
+                                    // };
                                 } else |err| {
                                     log.warn("failed to acquire Mach task for child process: {s}", .{@errorName(err)});
                                 }
@@ -443,9 +444,11 @@ pub const File = struct {
                         .linux => std.os.ptrace(std.os.linux.PTRACE.DETACH, pid, 0, 0) catch |err| {
                             log.warn("ptrace failure: {s}", .{@errorName(err)});
                         },
-                        .macos => std.os.ptrace(std.os.darwin.PT.KILL, pid, 0, 0) catch |err| {
-                            log.warn("ptrace failure: {s}", .{@errorName(err)});
-                        },
+                        .macos => {},
+                        // TODO see comment above in makeWritable
+                        // .macos => std.os.ptrace(std.os.darwin.PT.DETACH, pid, 0, 0) catch |err| {
+                        //     log.warn("ptrace failure: {s}", .{@errorName(err)});
+                        // },
                         else => return error.HotSwapUnavailableOnHostOperatingSystem,
                     }
                 }

--- a/src/link.zig
+++ b/src/link.zig
@@ -389,11 +389,8 @@ pub const File = struct {
                     try emit.directory.handle.copyFile(emit.sub_path, emit.directory.handle, tmp_sub_path, .{});
                     try emit.directory.handle.rename(tmp_sub_path, emit.sub_path);
                     switch (builtin.os.tag) {
-                        .linux => {
-                            switch (std.os.errno(std.os.linux.ptrace(std.os.linux.PTRACE.ATTACH, pid, 0, 0, 0))) {
-                                .SUCCESS => {},
-                                else => |errno| log.warn("ptrace failure: {s}", .{@tagName(errno)}),
-                            }
+                        .linux => std.os.ptrace(std.os.linux.PTRACE.ATTACH, pid, 0, 0) catch |err| {
+                            log.warn("ptrace failure: {s}", .{@errorName(err)});
                         },
                         else => return error.HotSwapUnavailableOnHostOperatingSystem,
                     }
@@ -430,11 +427,8 @@ pub const File = struct {
 
                 if (base.child_pid) |pid| {
                     switch (builtin.os.tag) {
-                        .linux => {
-                            switch (std.os.errno(std.os.linux.ptrace(std.os.linux.PTRACE.DETACH, pid, 0, 0, 0))) {
-                                .SUCCESS => {},
-                                else => |errno| log.warn("ptrace failure: {s}", .{@tagName(errno)}),
-                            }
+                        .linux => std.os.ptrace(std.os.linux.PTRACE.DETACH, pid, 0, 0) catch |err| {
+                            log.warn("ptrace failure: {s}", .{@errorName(err)});
                         },
                         else => return error.HotSwapUnavailableOnHostOperatingSystem,
                     }

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -610,7 +610,7 @@ pub fn flushModule(self: *MachO, comp: *Compilation, prog_node: *std.Progress.No
 
         var code = std.ArrayList(u8).init(self.base.allocator);
         defer code.deinit();
-        try code.resize(atom.size);
+        try code.resize(math.cast(usize, atom.size) orelse return error.Overflow);
 
         const amt = try self.base.file.?.preadAll(code.items, file_offset);
         if (amt != code.items.len) return error.InputOutput;

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -3811,6 +3811,28 @@ pub fn allocatedVirtualSize(self: *MachO, start: u64) u64 {
     return min_pos - start;
 }
 
+pub fn ptraceAttach(self: *MachO, pid: std.os.pid_t) !void {
+    const mach_task = try std.os.darwin.machTaskForPid(pid);
+    log.debug("Mach task for pid {d}: {any}", .{ pid, mach_task });
+    self.mach_task = mach_task;
+
+    // TODO start exception handler in another thread
+
+    // TODO enable ones we register for exceptions
+    // try std.os.ptrace(std.os.darwin.PT.ATTACHEXC, pid, 0, 0);
+}
+
+pub fn ptraceDetach(self: *MachO, pid: std.os.pid_t) !void {
+    _ = pid;
+
+    // TODO stop exception handler
+
+    // TODO see comment in ptraceAttach
+    // try std.os.ptrace(std.os.darwin.PT.DETACH, pid, 0, 0);
+
+    self.mach_task = null;
+}
+
 pub fn makeStaticString(bytes: []const u8) [16]u8 {
     var buf = [_]u8{0} ** 16;
     assert(bytes.len <= buf.len);

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -183,19 +183,11 @@ pub fn addLazyBinding(macho_file: *MachO, atom_index: Index, binding: Binding) !
     try gop.value_ptr.append(gpa, binding);
 }
 
-pub fn resolveRelocations(macho_file: *MachO, atom_index: Index) !void {
-    const atom = macho_file.getAtom(atom_index);
-    const relocs = macho_file.relocs.get(atom_index) orelse return;
-    const source_sym = atom.getSymbol(macho_file);
-    const source_section = macho_file.sections.get(source_sym.n_sect - 1).header;
-    const file_offset = source_section.offset + source_sym.n_value - source_section.addr;
-
-    log.debug("relocating '{s}'", .{atom.getName(macho_file)});
-
-    for (relocs.items) |*reloc| {
+pub fn resolveRelocations(macho_file: *MachO, atom_index: Index, relocs: []Relocation, code: []u8) !void {
+    log.debug("relocating '{s}'", .{macho_file.getAtom(atom_index).getName(macho_file)});
+    for (relocs) |*reloc| {
         if (!reloc.dirty) continue;
-
-        try reloc.resolve(macho_file, atom_index, file_offset);
+        try reloc.resolve(macho_file, atom_index, code);
         reloc.dirty = false;
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -3320,21 +3320,20 @@ fn buildOutputType(
 
             try server.listen(.{ .in = ip4_addr });
 
-            while (true) {
-                const conn = try server.accept();
-                defer conn.stream.close();
+            const conn = try server.accept();
+            defer conn.stream.close();
 
-                try serve(
-                    comp,
-                    .{ .handle = conn.stream.handle },
-                    .{ .handle = conn.stream.handle },
-                    test_exec_args.items,
-                    self_exe_path,
-                    arg_mode,
-                    all_args,
-                    runtime_args_start,
-                );
-            }
+            try serve(
+                comp,
+                .{ .handle = conn.stream.handle },
+                .{ .handle = conn.stream.handle },
+                test_exec_args.items,
+                self_exe_path,
+                arg_mode,
+                all_args,
+                runtime_args_start,
+            );
+            return cleanExit();
         },
     }
 
@@ -3465,9 +3464,7 @@ fn serve(
         const hdr = try server.receiveMessage();
 
         switch (hdr.tag) {
-            .exit => {
-                return cleanExit();
-            },
+            .exit => return,
             .update => {
                 assert(main_progress_node.recently_updated_child == null);
                 tracy.frameMark();

--- a/src/main.zig
+++ b/src/main.zig
@@ -3852,11 +3852,15 @@ fn runOrTestHotSwap(
     switch (builtin.target.os.tag) {
         .macos, .ios, .tvos, .watchos => {
             const PosixSpawn = std.os.darwin.PosixSpawn;
+
             var attr = try PosixSpawn.Attr.init();
             defer attr.deinit();
-            const flags: u16 = std.os.darwin.POSIX_SPAWN_SETSIGDEF |
-                std.os.darwin.POSIX_SPAWN_SETSIGMASK |
-                std.os.darwin._POSIX_SPAWN_DISABLE_ASLR;
+
+            // ASLR is probably a good default for better debugging experience/programming
+            // with hot-code updates in mind. However, we can also make it work with ASLR on.
+            const flags: u16 = std.os.darwin.POSIX_SPAWN.SETSIGDEF |
+                std.os.darwin.POSIX_SPAWN.SETSIGMASK |
+                std.os.darwin.POSIX_SPAWN.DISABLE_ASLR;
             try attr.set(flags);
 
             var arena_allocator = std.heap.ArenaAllocator.init(gpa);


### PR DESCRIPTION
Depends on #14935 

Upstreams updated but still minimal PoC of hot-code swapping on macOS with the incremental MachO linker. In order to play with it without any `sudo` malarkey, it's required to build the compiler with the right entitlements: those for the debugger. At least for the time being, we won't do it by default as it elevates Zig to superpowers, so to try it out, you need to rebuild with `-Dentitlements=Info.plist` flag.