### PR TITLE
add wasm-simd support for suggestVectorSizeForCpu

### DIFF
--- a/lib/std/simd.zig
+++ b/lib/std/simd.zig
@@ -43,6 +43,8 @@ pub fn suggestVectorSizeForCpu(comptime T: type, comptime cpu: std.Target.Cpu) ?
             //       for multiple processing, but I don't know what's optimal here, if using
             //       the 2048 bits or using just 64 per vector or something in between
             if (std.Target.sparc.featureSetHasAny(cpu.features, .{ .vis, .vis2, .vis3 })) break :blk 64;
+        } else if (cpu.arch.isWasm()) {
+            if (std.Target.wasm.featureSetHas(cpu.features, .simd128)) break :blk 128;
         }
         return null;
     };


### PR DESCRIPTION
std.simd.suggestVectorSizeForCpu didn't support Wasm SIMD
This PR adds Wasm SIMD support.

```shell
$ zig version
0.11.0-dev.1987+a2c6ecd6d
$ cat wasm-simd.zig 
const std = @import("std");

pub fn main() !void {
    const wasm_simd_model = std.Target.wasm.cpu.bleeding_edge;
    const wasm_simd_cpu = comptime std.Target.Cpu.Model.toCpu(&wasm_simd_model, std.Target.Cpu.Arch.wasm32);

    std.debug.print("vector size for u8(wasm) {?}\n", .{std.simd.suggestVectorSizeForCpu(u8, wasm_simd_cpu)});
}
$ zig run wasm-simd.zig 
vector size for u8(wasm) null
$ zig run --zig-lib-dir ~/ghq/github.com/ziglang/zig/lib wasm-simd.zig 
vector size for u8(wasm) 16
```