### PR TITLE
delete `--prominent-compile-errors` from cli help output

### DIFF
--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -949,7 +949,6 @@ fn usage(builder: *std.Build, already_ran_build: bool, out_stream: anytype) !voi
         \\  -l, --list-steps             Print available steps
         \\  --verbose                    Print commands before executing them
         \\  --color [auto|off|on]        Enable or disable colored error messages
-        \\  --prominent-compile-errors   Output compile errors formatted for a human to read
         \\  -fsummary                    Print the build summary, even on success
         \\  -fno-summary                 Omit the build summary, even on failure
         \\  -j<N>                        Limit concurrent jobs (default is to use all CPU cores)

--- a/src/main.zig
+++ b/src/main.zig
@@ -4260,7 +4260,6 @@ pub const usage_build =
     \\   --global-cache-dir [path]     Override path to global Zig cache directory
     \\   --zig-lib-dir [arg]           Override path to Zig lib directory
     \\   --build-runner [file]         Override path to build runner
-    \\   --prominent-compile-errors    Output compile errors formatted for a human to read
     \\   -h, --help                    Print this help and exit
     \\
 ;


### PR DESCRIPTION
This removes the remnant mentions of the `--prominent-compile-errors` flag from the cli help output. The flag is unavailable since merge of #14647.