### PR TITLE
fix std.Build.OptionsStep

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1737,7 +1737,7 @@ pub fn makeTempPath(b: *Build) []const u8 {
     const rand_int = std.crypto.random.int(u64);
     const tmp_dir_sub_path = "tmp" ++ fs.path.sep_str ++ hex64(rand_int);
     const result_path = b.cache_root.join(b.allocator, &.{tmp_dir_sub_path}) catch @panic("OOM");
-    fs.cwd().makePath(result_path) catch |err| {
+    b.cache_root.handle.makePath(tmp_dir_sub_path) catch |err| {
         std.debug.print("unable to make tmp path '{s}': {s}\n", .{
             result_path, @errorName(err),
         });
@@ -1747,7 +1747,7 @@ pub fn makeTempPath(b: *Build) []const u8 {
 
 /// There are a few copies of this function in miscellaneous places. Would be nice to find
 /// a home for them.
-fn hex64(x: u64) [16]u8 {
+pub fn hex64(x: u64) [16]u8 {
     const hex_charset = "0123456789abcdef";
     var result: [16]u8 = undefined;
     var i: usize = 0;

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -213,6 +213,11 @@ pub const build_cases = [_]BuildCase{
         .build_root = "test/standalone/issue_13030",
         .import = @import("standalone/issue_13030/build.zig"),
     },
+    // TODO restore this test
+    //.{
+    //    .build_root = "test/standalone/options",
+    //    .import = @import("standalone/options/build.zig"),
+    //},
 };
 
 const std = @import("std");

--- a/test/standalone/options/build.zig
+++ b/test/standalone/options/build.zig
@@ -1,13 +1,10 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
-    const target = b.standardTargetOptions(.{});
-    const optimize = b.standardOptimizeOption(.{});
-
     const main = b.addTest(.{
         .root_source_file = .{ .path = "src/main.zig" },
-        .target = target,
-        .optimize = optimize,
+        .target = .{},
+        .optimize = .Debug,
     });
 
     const options = b.addOptions();


### PR DESCRIPTION
 * use the same hash function as the rest of the steps
 * fix race condition due to a macOS oddity.
 * fix race condition due to file truncation (rename into place instead)
 * integrate with marking Step.result_cached. check if the file already exists with fs.access before doing anything else.
 * use a directory so that the file basename can be "options.zig" instead of a hash digest.
 * better error reporting in case of file system failures.

Fixes #15006