### PR TITLE
tests: add `-Dskip-cross-glibc` option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -81,6 +81,7 @@ pub fn build(b: *std.Build) !void {
     const skip_release_fast = b.option(bool, "skip-release-fast", "Main test suite skips release-fast builds") orelse skip_release;
     const skip_release_safe = b.option(bool, "skip-release-safe", "Main test suite skips release-safe builds") orelse skip_release;
     const skip_non_native = b.option(bool, "skip-non-native", "Main test suite skips non-native builds") orelse false;
+    const skip_cross_glibc = b.option(bool, "skip-cross-glibc", "Main test suite skips builds that require cross glibc") orelse false;
     const skip_libc = b.option(bool, "skip-libc", "Main test suite skips tests that link libc") orelse false;
     const skip_single_threaded = b.option(bool, "skip-single-threaded", "Main test suite skips tests that are single-threaded") orelse false;
     const skip_stage1 = b.option(bool, "skip-stage1", "Main test suite skips stage1 compile error tests") orelse false;
@@ -351,6 +352,7 @@ pub fn build(b: *std.Build) !void {
     test_cases_options.addOption(bool, "enable_logging", enable_logging);
     test_cases_options.addOption(bool, "enable_link_snapshots", enable_link_snapshots);
     test_cases_options.addOption(bool, "skip_non_native", skip_non_native);
+    test_cases_options.addOption(bool, "skip_cross_glibc", skip_cross_glibc);
     test_cases_options.addOption(bool, "skip_stage1", skip_stage1);
     test_cases_options.addOption(bool, "have_llvm", enable_llvm);
     test_cases_options.addOption(bool, "llvm_has_m68k", llvm_has_m68k);
@@ -415,6 +417,7 @@ pub fn build(b: *std.Build) !void {
         .optimize_modes = optimization_modes,
         .skip_single_threaded = skip_single_threaded,
         .skip_non_native = skip_non_native,
+        .skip_cross_glibc = skip_cross_glibc,
         .skip_libc = skip_libc,
         .skip_stage1 = skip_stage1,
         .skip_stage2 = skip_stage2_tests,
@@ -429,6 +432,7 @@ pub fn build(b: *std.Build) !void {
         .optimize_modes = optimization_modes,
         .skip_single_threaded = true,
         .skip_non_native = skip_non_native,
+        .skip_cross_glibc = skip_cross_glibc,
         .skip_libc = true,
         .skip_stage1 = skip_stage1,
         .skip_stage2 = true, // TODO get all these passing
@@ -442,6 +446,7 @@ pub fn build(b: *std.Build) !void {
         .optimize_modes = optimization_modes,
         .skip_single_threaded = true,
         .skip_non_native = skip_non_native,
+        .skip_cross_glibc = skip_cross_glibc,
         .skip_libc = true,
         .skip_stage1 = skip_stage1,
         .skip_stage2 = true, // TODO get all these passing
@@ -473,6 +478,7 @@ pub fn build(b: *std.Build) !void {
         .optimize_modes = optimization_modes,
         .skip_single_threaded = skip_single_threaded,
         .skip_non_native = skip_non_native,
+        .skip_cross_glibc = skip_cross_glibc,
         .skip_libc = skip_libc,
         .skip_stage1 = skip_stage1,
         .skip_stage2 = true, // TODO get all these passing

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -910,6 +910,7 @@ const ModuleTestOptions = struct {
     optimize_modes: []const OptimizeMode,
     skip_single_threaded: bool,
     skip_non_native: bool,
+    skip_cross_glibc: bool,
     skip_libc: bool,
     skip_stage1: bool,
     skip_stage2: bool,
@@ -921,6 +922,9 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
 
     for (test_targets) |test_target| {
         if (options.skip_non_native and !test_target.target.isNative())
+            continue;
+
+        if (options.skip_cross_glibc and test_target.target.isGnuLibC() and test_target.link_libc)
             continue;
 
         if (options.skip_libc and test_target.link_libc)


### PR DESCRIPTION
It is reasonable to pass `-Dskip-non-native` when unable to run foreign binaries, however there is no option for being able to run foreign static binaries but unable to run foreign dynamic binaries.  This can occur when qemu is installed but not cross glibc.