### PR TITLE
crypto.hmac: set the recommended key size to the block size

### DIFF
--- a/lib/std/crypto/hmac.zig
+++ b/lib/std/crypto/hmac.zig
@@ -18,7 +18,7 @@ pub fn Hmac(comptime Hash: type) type {
         const Self = @This();
         pub const mac_length = Hash.digest_length;
         pub const key_length_min = 0;
-        pub const key_length = 32; // recommended key length
+        pub const key_length = mac_length; // recommended key length
 
         o_key_pad: [Hash.block_length]u8,
         hash: Hash,


### PR DESCRIPTION
HMAC supports arbitrary key sizes, and there are no practical reasons to use more than 256 bit keys.

It still make sense to match the security level, though, especially since a distinction between the block size and the key size can be confusing.

Using `HMAC.key_size` instead of `HMAC.mac_size` caused our TLS implementation to compute wrong shared secrets when SHA-384 was used. So, fix it directly in `crypto.hmac` in order to prevent other misuses.