### PR TITLE
Add SetConsoleMode to windows.kernel32

### DIFF
--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -165,6 +165,7 @@ pub extern "kernel32" fn GetCommandLineA() callconv(WINAPI) LPSTR;
 pub extern "kernel32" fn GetCommandLineW() callconv(WINAPI) LPWSTR;
 
 pub extern "kernel32" fn GetConsoleMode(in_hConsoleHandle: HANDLE, out_lpMode: *DWORD) callconv(WINAPI) BOOL;
+pub extern "kernel32" fn SetConsoleMode(in_hConsoleHandle: HANDLE, in_dwMode: DWORD) callconv(WINAPI) BOOL;
 
 pub extern "kernel32" fn GetConsoleOutputCP() callconv(WINAPI) UINT;
 


### PR DESCRIPTION
Hi,

I've read that `windows.kernel32`'s functions are "lazily added" to `stdlib`.

I would like to use `SetConsoleMode` in my project.
I have already patched `stdlib` in my local machine and looks like it works.