### PR TITLE
http.Client: don't prematurely check transfer_{encoding,compression}

### DIFF
--- a/lib/std/http/Client/Response.zig
+++ b/lib/std/http/Client/Response.zig
@@ -74,8 +74,6 @@ pub const Headers = struct {
                 if (headers.content_length != null) return error.HttpHeadersInvalid;
                 headers.content_length = try std.fmt.parseInt(u64, header_value, 10);
             } else if (std.ascii.eqlIgnoreCase(header_name, "transfer-encoding")) {
-                if (headers.transfer_encoding != null or headers.transfer_compression != null) return error.HttpHeadersInvalid;
-
                 // Transfer-Encoding: second, first
                 // Transfer-Encoding: deflate, chunked
                 var iter = std.mem.splitBackwards(u8, header_value, ",");
@@ -84,8 +82,10 @@ pub const Headers = struct {
                     const trimmed = std.mem.trim(u8, first, " ");
 
                     if (std.meta.stringToEnum(http.TransferEncoding, trimmed)) |te| {
+                        if (headers.transfer_encoding != null) return error.HttpHeadersInvalid;
                         headers.transfer_encoding = te;
                     } else if (std.meta.stringToEnum(http.ContentEncoding, trimmed)) |ce| {
+                        if (headers.transfer_compression != null) return error.HttpHeadersInvalid;
                         headers.transfer_compression = ce;
                     } else {
                         return error.HttpTransferEncodingUnsupported;


### PR DESCRIPTION
Common headers in a response are:

    Content-Encoding: gzip
    Transfer-Encoding: chunked

We used to return `HttpHeadersInvalid` if a `Transfer-Encoding` header was received while the compression was already set.

However, Transfer-Encoding may not include compression. We should only return an error if we are setting a value that was already set.

Fixes compatibility with a bunch of websites.