### PR TITLE
Two more examples of possible syntax when dealing with errors

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5465,7 +5465,7 @@ fn doAThing(str: []u8) void {
          // do things
          break :blk 13;
      };
-    _ = number; // ...
+    _ = number; // number is now initialized
 }
       {#code_end#}
       {#header_close#}
@@ -5538,7 +5538,6 @@ fn doADifferentThing(str: []u8) void {
         doSomethingWithNumber(number);
     } else |_| {
         // do as you'd like
-        unreachable;
     }
 }
       {#end_syntax_block#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5461,10 +5461,10 @@ fn doAThing(str: []u8) void {
 const parseU64 = @import("error_union_parsing_u64.zig").parseU64;
 
 fn doAThing(str: []u8) void {
-     const number = parseU64(str, 10) catch blk: {
-         // do things
-         break :blk 13;
-     };
+    const number = parseU64(str, 10) catch blk: {
+        // do things
+        break :blk 13;
+    };
     _ = number; // number is now initialized
 }
       {#code_end#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5452,6 +5452,22 @@ fn doAThing(str: []u8) void {
           a default value of 13. The type of the right hand side of the binary {#syntax#}catch{#endsyntax#} operator must
               match the unwrapped error union type, or be of type {#syntax#}noreturn{#endsyntax#}.
       </p>
+     <p>
+      If you want to provide a default value with
+      {#syntax#}catch{#endsyntax#} after performing some logic, you
+      can combine {#syntax#}catch{#endsyntax#} with named {#link|Blocks#}:
+      </p>
+      {#code_begin|syntax|handle_error_with_catch_block.zig#}
+const parseU64 = @import("error_union_parsing_u64.zig").parseU64;
+
+fn doAThing(str: []u8) void {
+     const number = parseU64(str, 10) catch blk: {
+         // do things
+         break :blk 13;
+     };
+    _ = number; // ...
+}
+      {#code_end#}
       {#header_close#}
       {#header_open|try#}
       <p>Let's say you wanted to return the error if you got one, otherwise continue with the
@@ -5508,6 +5524,21 @@ fn doAThing(str: []u8) void {
         },
         // we promise that InvalidChar won't happen (or crash in debug mode if it does)
         error.InvalidChar => unreachable,
+    }
+}
+      {#end_syntax_block#}
+      <p>
+      You must use the variable capture syntax. If you don't need the
+      variable, you can capture with {#syntax#}_{#endsyntax#} and avoid the
+      {#syntax#}switch{#endsyntax#}.
+      </p>
+      {#syntax_block|zig|handle_no_error_scenarios.zig#}
+fn doADifferentThing(str: []u8) void {
+    if (parseU64(str, 10)) |number| {
+        doSomethingWithNumber(number);
+    } else |_| {
+        // do as you'd like
+        unreachable;
     }
 }
       {#end_syntax_block#}


### PR DESCRIPTION
As I've been messing around I tried some things that I expected to work but didn't:

```
if (maybeAnError()) |goodVal| {
  // happy path
} else {
  // oops this syntax doesn't work
}
```

So I wanted to add a docs example showing how to have an else without `switch` since whatever the case the parser does expect you to capture a variable.

Also added an example of using a named block for setting a value from a catch block. Yes this is strictly redundant but I didn't immediately think/guess correctly how to use a block with a catch.

Note to self: build the docs with `zig build docs`.