### PR TITLE
fix: change ordering of prep provide buffers args

### DIFF
--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -897,13 +897,13 @@ pub const IO_Uring = struct {
         self: *IO_Uring,
         user_data: u64,
         buffers: [*]u8,
-        buffers_count: usize,
         buffer_size: usize,
+        buffers_count: usize,
         group_id: usize,
         buffer_id: usize,
     ) !*linux.io_uring_sqe {
         const sqe = try self.get_sqe();
-        io_uring_prep_provide_buffers(sqe, buffers, buffers_count, buffer_size, group_id, buffer_id);
+        io_uring_prep_provide_buffers(sqe, buffers, buffer_size, buffers_count, group_id, buffer_id);
         sqe.user_data = user_data;
         return sqe;
     }
@@ -1576,8 +1576,8 @@ pub fn io_uring_prep_linkat(
 pub fn io_uring_prep_provide_buffers(
     sqe: *linux.io_uring_sqe,
     buffers: [*]u8,
-    num: usize,
     buffer_len: usize,
+    num: usize,
     group_id: usize,
     buffer_id: usize,
 ) void {
@@ -2892,7 +2892,7 @@ test "provide_buffers: read" {
     // Provide 4 buffers
 
     {
-        const sqe = try ring.provide_buffers(0xcccccccc, @ptrCast([*]u8, &buffers), buffers.len, buffer_len, group_id, buffer_id);
+        const sqe = try ring.provide_buffers(0xcccccccc, @ptrCast([*]u8, &buffers), buffer_len, buffers.len, group_id, buffer_id);
         try testing.expectEqual(linux.IORING_OP.PROVIDE_BUFFERS, sqe.opcode);
         try testing.expectEqual(@as(i32, buffers.len), sqe.fd);
         try testing.expectEqual(@as(u32, buffers[0].len), sqe.len);
@@ -2965,7 +2965,7 @@ test "provide_buffers: read" {
     const reprovided_buffer_id = 2;
 
     {
-        _ = try ring.provide_buffers(0xabababab, @ptrCast([*]u8, &buffers[reprovided_buffer_id]), 1, buffer_len, group_id, reprovided_buffer_id);
+        _ = try ring.provide_buffers(0xabababab, @ptrCast([*]u8, &buffers[reprovided_buffer_id]), buffer_len, 1, group_id, reprovided_buffer_id);
         try testing.expectEqual(@as(u32, 1), try ring.submit());
 
         const cqe = try ring.copy_cqe();
@@ -3024,7 +3024,7 @@ test "remove_buffers" {
     // Provide 4 buffers
 
     {
-        _ = try ring.provide_buffers(0xcccccccc, @ptrCast([*]u8, &buffers), buffers.len, buffer_len, group_id, buffer_id);
+        _ = try ring.provide_buffers(0xcccccccc, @ptrCast([*]u8, &buffers), buffer_len, buffers.len, group_id, buffer_id);
         try testing.expectEqual(@as(u32, 1), try ring.submit());
 
         const cqe = try ring.copy_cqe();
@@ -3113,7 +3113,7 @@ test "provide_buffers: accept/connect/send/recv" {
     // Provide 4 buffers
 
     {
-        const sqe = try ring.provide_buffers(0xcccccccc, @ptrCast([*]u8, &buffers), buffers.len, buffer_len, group_id, buffer_id);
+        const sqe = try ring.provide_buffers(0xcccccccc, @ptrCast([*]u8, &buffers), buffer_len, buffers.len, group_id, buffer_id);
         try testing.expectEqual(linux.IORING_OP.PROVIDE_BUFFERS, sqe.opcode);
         try testing.expectEqual(@as(i32, buffers.len), sqe.fd);
         try testing.expectEqual(@as(u32, buffer_len), sqe.len);
@@ -3207,7 +3207,7 @@ test "provide_buffers: accept/connect/send/recv" {
     const reprovided_buffer_id = 2;
 
     {
-        _ = try ring.provide_buffers(0xabababab, @ptrCast([*]u8, &buffers[reprovided_buffer_id]), 1, buffer_len, group_id, reprovided_buffer_id);
+        _ = try ring.provide_buffers(0xabababab, @ptrCast([*]u8, &buffers[reprovided_buffer_id]), buffer_len, 1, group_id, reprovided_buffer_id);
         try testing.expectEqual(@as(u32, 1), try ring.submit());
 
         const cqe = try ring.copy_cqe();


### PR DESCRIPTION
This is just a nit, but I noticed while digging around in the [man page of io_uring_prep_provide_buffers](https://man7.org/linux/man-pages/man3/io_uring_prep_provide_buffers.3.html) that `len` comes before `nr` in the parameters list, but in `io_uring.zig` it's the opposite (`buffers_count` comes before `buffer_size`). the `provide_buffers()` fn also follows the original ordering, but the followup call to `io_uring_prep_provide_buffers` swapped these args around.

This is just a small PR to change that ordering, just to maintain consistency with [liburing](https://github.com/axboe/liburing/blob/0ce8a73fd588a2e9f7ff53184bffecf6dbf15857/src/include/liburing.h#L897-L899).

If there was some context I was missing from before or if this change is unnecessary, feel free to close it :)