### PR TITLE
lib/init-exe, lib/init-lib: ensure tests runs again

### DIFF
--- a/lib/init-exe/build.zig
+++ b/lib/init-exe/build.zig
@@ -59,9 +59,12 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    // A RunStep must be added to run the unit tests.
+    const run_test = b.addRunArtifact(exe_tests);
+
     // Similar to creating the run step earlier, this exposes a `test` step to
     // the `zig build --help` menu, providing a way for the user to request
     // running the unit tests.
     const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&exe_tests.step);
+    test_step.dependOn(&run_test.step);
 }

--- a/lib/init-lib/build.zig
+++ b/lib/init-lib/build.zig
@@ -30,15 +30,18 @@ pub fn build(b: *std.Build) void {
     lib.install();
 
     // Creates a step for unit testing.
-    const main_tests = b.addTest(.{
+    const lib_tests = b.addTest(.{
         .root_source_file = .{ .path = "src/main.zig" },
         .target = target,
         .optimize = optimize,
     });
 
+    // A RunStep must be added to run the unit tests.
+    const run_test = b.addRunArtifact(lib_tests);
+
     // This creates a build step. It will be visible in the `zig build --help` menu,
     // and can be selected like this: `zig build test`
     // This will evaluate the `test` step rather than the default, which is "install".
-    const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_test.step);
 }

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -663,7 +663,6 @@ pub fn addCliTests(b: *std.Build) *Step {
     const s = std.fs.path.sep_str;
 
     {
-
         // Test `zig init-lib`.
         const tmp_path = b.makeTempPath();
         const init_lib = b.addSystemCommand(&.{ b.zig_exe, "init-lib" });


### PR DESCRIPTION
After commit ede5dcffe (make the build runner and test runner talk to each other), the std.Build.addTest function no longer runs tests, but the build.zig files in init-exe and init-lib where not updated.

Rename main_tests to lib_tests in init-lib, for consistency with the exe_tests variable in init-exe.

Add a RunStep to exe_tests and lib_tests.

Remove an empty line in the addCliTests function in tests/tests.zig.

Closes #15009