### PR TITLE
test/src/Cases: fix incorrect code to find zig_lib_directory

### DIFF
--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -1154,7 +1154,7 @@ fn runCases(self: *Cases, zig_exe_path: []const u8) !void {
     progress.terminal = null;
     defer root_node.end();
 
-    var zig_lib_directory = try introspect.findZigLibDir(self.gpa);
+    var zig_lib_directory = try introspect.findZigLibDirFromSelfExe(self.gpa, zig_exe_path);
     defer zig_lib_directory.handle.close();
     defer self.gpa.free(zig_lib_directory.path.?);
 


### PR DESCRIPTION
The runCases function incorrectly called the introspect.findZigLibDir function, causing a possible error, depending on the location of the local cache directory, since the current executable is check-case.

Use findZigLibDirFromSelfExe, passing the zig_exe_path argument.

The current CI scripts work correctly because ZIG_LOCAL_CACHE_DIR is set to "$(pwd)/zig-local-cache".

Fixes #15044