### PR TITLE
Sema: fix empty slice pointer value

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -25152,7 +25152,7 @@ fn coerceExtra(
                             .ptr = if (dest_info.@"align" != 0)
                                 try Value.Tag.int_u64.create(sema.arena, dest_info.@"align")
                             else
-                                try inst_child_ty.lazyAbiAlignment(target, sema.arena),
+                                try dest_info.pointee_type.lazyAbiAlignment(target, sema.arena),
                             .len = Value.zero,
                         });
                         return sema.addConstant(dest_ty, slice_val);
@@ -30212,6 +30212,11 @@ fn resolveLazyValue(sema: *Sema, val: Value) CompileError!void {
             for (aggregate) |elem_val| {
                 try sema.resolveLazyValue(elem_val);
             }
+        },
+        .slice => {
+            const slice = val.castTag(.slice).?.data;
+            try sema.resolveLazyValue(slice.ptr);
+            return sema.resolveLazyValue(slice.len);
         },
         else => return,
     }

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1069,7 +1069,7 @@ pub const DeclGen = struct {
                     const extern_fn = val.castTag(.extern_fn).?.data;
                     try dg.renderDeclName(writer, extern_fn.owner_decl, 0);
                 },
-                .int_u64, .one => {
+                .int_u64, .one, .int_big_positive, .lazy_align, .lazy_size => {
                     try writer.writeAll("((");
                     try dg.renderType(writer, ty);
                     return writer.print("){x})", .{try dg.fmtIntLiteral(Type.usize, val, .Other)});

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3397,7 +3397,7 @@ pub const DeclGen = struct {
                     };
                     return dg.context.constStruct(&fields, fields.len, .False);
                 },
-                .int_u64, .one, .int_big_positive => {
+                .int_u64, .one, .int_big_positive, .lazy_align, .lazy_size => {
                     const llvm_usize = try dg.lowerType(Type.usize);
                     const llvm_int = llvm_usize.constInt(tv.val.toUnsignedInt(target), .False);
                     return llvm_int.constIntToPtr(try dg.lowerType(tv.ty));

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -723,10 +723,18 @@ test "slice with dereferenced value" {
 test "empty slice ptr is non null" {
     if (builtin.zig_backend == .stage2_aarch64 and builtin.os.tag == .macos) return error.SkipZigTest; // TODO
 
-    const empty_slice: []u8 = &[_]u8{};
-    const p: [*]u8 = empty_slice.ptr + 0;
-    const t = @ptrCast([*]i8, p);
-    try expect(@ptrToInt(t) == @ptrToInt(empty_slice.ptr));
+    {
+        const empty_slice: []u8 = &[_]u8{};
+        const p: [*]u8 = empty_slice.ptr + 0;
+        const t = @ptrCast([*]i8, p);
+        try expect(@ptrToInt(t) == @ptrToInt(empty_slice.ptr));
+    }
+    {
+        const empty_slice: []u8 = &.{};
+        const p: [*]u8 = empty_slice.ptr + 0;
+        const t = @ptrCast([*]i8, p);
+        try expect(@ptrToInt(t) == @ptrToInt(empty_slice.ptr));
+    }
 }
 
 test "slice decays to many pointer" {


### PR DESCRIPTION
While attempting to produce a non-zero alignment, we accidentally picked the one thing with a zero alignment instead.

Closes #15085