### PR TITLE
llvm/bpf: disable llvm builtins for bpf target

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2719,6 +2719,9 @@ pub const DeclGen = struct {
         if (comp.bin_file.options.llvm_cpu_features) |s| {
             llvm_fn.addFunctionAttr("target-features", s);
         }
+        if (comp.getTarget().cpu.arch.isBpf()) {
+            llvm_fn.addFunctionAttr("no-builtins", "");
+        }
     }
 
     fn resolveGlobalDecl(dg: *DeclGen, decl_index: Module.Decl.Index) Error!*llvm.Value {


### PR DESCRIPTION
As bpf program has no global section for constant values (especially strings), so use llvm's builtins (like memcpy, memset, etc) will lead to compilation failure (something like this: A call to built-in function 'memcpy' is not supported.)