### PR TITLE
coff: handle multiple DLLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -583,6 +583,7 @@ set(ZIG_STAGE2_SOURCES
     "${CMAKE_SOURCE_DIR}/src/link/C.zig"
     "${CMAKE_SOURCE_DIR}/src/link/Coff.zig"
     "${CMAKE_SOURCE_DIR}/src/link/Coff/Atom.zig"
+    "${CMAKE_SOURCE_DIR}/src/link/Coff/ImportTable.zig"
     "${CMAKE_SOURCE_DIR}/src/link/Coff/Object.zig"
     "${CMAKE_SOURCE_DIR}/src/link/Coff/lld.zig"
     "${CMAKE_SOURCE_DIR}/src/link/Elf.zig"

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -6121,7 +6121,7 @@ fn callIntrinsic(
     args: []const WValue,
 ) InnerError!WValue {
     assert(param_types.len == args.len);
-    const symbol_index = func.bin_file.base.getGlobalSymbol(name) catch |err| {
+    const symbol_index = func.bin_file.base.getGlobalSymbol(name, null) catch |err| {
         return func.fail("Could not find or create global symbol '{s}'", .{@errorName(err)});
     };
 

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -5317,16 +5317,10 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
             } else unreachable;
         } else if (func_value.castTag(.extern_fn)) |func_payload| {
             const extern_fn = func_payload.data;
-            const decl_name = mod.declPtr(extern_fn.owner_decl).name;
-            if (extern_fn.lib_name) |lib_name| {
-                log.debug("TODO enforce that '{s}' is expected in '{s}' library", .{
-                    decl_name,
-                    lib_name,
-                });
-            }
-
+            const decl_name = mem.sliceTo(mod.declPtr(extern_fn.owner_decl).name, 0);
+            const lib_name = mem.sliceTo(extern_fn.lib_name, 0);
             if (self.bin_file.cast(link.File.Coff)) |coff_file| {
-                const sym_index = try coff_file.getGlobalSymbol(mem.sliceTo(decl_name, 0));
+                const sym_index = try coff_file.getGlobalSymbol(decl_name, lib_name);
                 try self.genSetReg(Type.initTag(.usize), .rax, .{
                     .linker_load = .{
                         .type = .import,
@@ -5335,7 +5329,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
                 });
                 try self.asmRegister(.call, .rax);
             } else if (self.bin_file.cast(link.File.MachO)) |macho_file| {
-                const sym_index = try macho_file.getGlobalSymbol(mem.sliceTo(decl_name, 0));
+                const sym_index = try macho_file.getGlobalSymbol(decl_name, lib_name);
                 const atom = try macho_file.getOrCreateAtomForDecl(self.mod_fn.owner_decl);
                 const atom_index = macho_file.getAtom(atom).getSymbolIndex().?;
                 _ = try self.addInst(.{

--- a/src/link.zig
+++ b/src/link.zig
@@ -504,18 +504,20 @@ pub const File = struct {
     /// Called from within CodeGen to retrieve the symbol index of a global symbol.
     /// If no symbol exists yet with this name, a new undefined global symbol will
     /// be created. This symbol may get resolved once all relocatables are (re-)linked.
-    pub fn getGlobalSymbol(base: *File, name: []const u8) UpdateDeclError!u32 {
+    /// Optionally, it is possible to specify where to expect the symbol defined if it
+    /// is an import.
+    pub fn getGlobalSymbol(base: *File, name: []const u8, lib_name: ?[]const u8) UpdateDeclError!u32 {
         if (build_options.only_c) @compileError("unreachable");
-        log.debug("getGlobalSymbol '{s}'", .{name});
+        log.debug("getGlobalSymbol '{s}' (expected in '{?s}')", .{ name, lib_name });
         switch (base.tag) {
             // zig fmt: off
-            .coff  => return @fieldParentPtr(Coff, "base", base).getGlobalSymbol(name),
+            .coff  => return @fieldParentPtr(Coff, "base", base).getGlobalSymbol(name, lib_name),
             .elf   => unreachable,
-            .macho => return @fieldParentPtr(MachO, "base", base).getGlobalSymbol(name),
+            .macho => return @fieldParentPtr(MachO, "base", base).getGlobalSymbol(name, lib_name),
             .plan9 => unreachable,
             .spirv => unreachable,
             .c     => unreachable,
-            .wasm  => return @fieldParentPtr(Wasm,  "base", base).getGlobalSymbol(name),
+            .wasm  => return @fieldParentPtr(Wasm,  "base", base).getGlobalSymbol(name, lib_name),
             .nvptx => unreachable,
             // zig fmt: on
         }

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1451,6 +1451,8 @@ pub fn flushModule(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
         self.error_flags.no_entry_point_found = false;
         try self.writeHeader();
     }
+
+    assert(!self.imports_count_dirty);
 }
 
 pub fn getDeclVAddr(self: *Coff, decl_index: Module.Decl.Index, reloc_info: link.File.RelocInfo) !u64 {

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1526,7 +1526,8 @@ pub fn getDeclVAddr(self: *Coff, decl_index: Module.Decl.Index, reloc_info: link
     return 0;
 }
 
-pub fn getGlobalSymbol(self: *Coff, name: []const u8) !u32 {
+pub fn getGlobalSymbol(self: *Coff, name: []const u8, lib_name: ?[]const u8) !u32 {
+    _ = lib_name;
     const gop = try self.getOrPutGlobalPtr(name);
     const global_index = self.getGlobalIndex(name).?;
 

--- a/src/link/Coff/ImportTable.zig
+++ b/src/link/Coff/ImportTable.zig
@@ -1,0 +1,133 @@
+//! Represents an import table in the .idata section where each contained pointer
+//! is to a symbol from the same DLL.
+//!
+//! The layout of .idata section is as follows:
+//!
+//! --- ADDR1 : IAT (all import tables concatenated together)
+//!     ptr
+//!     ptr
+//!     0 sentinel
+//!     ptr
+//!     0 sentinel
+//! --- ADDR2: headers
+//!     ImportDirectoryEntry header
+//!     ImportDirectoryEntry header
+//!     sentinel
+//! --- ADDR2: lookup tables
+//!     Lookup table
+//!     0 sentinel
+//!     Lookup table
+//!     0 sentinel
+//! --- ADDR3: name hint tables
+//!     hint-symname
+//!     hint-symname
+//! --- ADDR4: DLL names
+//!     DLL#1 name
+//!     DLL#2 name
+//! --- END
+
+entries: std.ArrayListUnmanaged(SymbolWithLoc) = .{},
+free_list: std.ArrayListUnmanaged(u32) = .{},
+lookup: std.AutoHashMapUnmanaged(SymbolWithLoc, u32) = .{},
+
+pub fn deinit(itab: *ImportTable, allocator: Allocator) void {
+    itab.entries.deinit(allocator);
+    itab.free_list.deinit(allocator);
+    itab.lookup.deinit(allocator);
+}
+
+/// Size of the import table does not include the sentinel.
+pub fn size(itab: ImportTable) u32 {
+    return @intCast(u32, itab.entries.items.len) * @sizeOf(u64);
+}
+
+pub fn addImport(itab: *ImportTable, allocator: Allocator, target: SymbolWithLoc) !ImportIndex {
+    try itab.entries.ensureUnusedCapacity(allocator, 1);
+    const index: u32 = blk: {
+        if (itab.free_list.popOrNull()) |index| {
+            log.debug("  (reusing import entry index {d})", .{index});
+            break :blk index;
+        } else {
+            log.debug("  (allocating import entry at index {d})", .{itab.entries.items.len});
+            const index = @intCast(u32, itab.entries.items.len);
+            _ = itab.entries.addOneAssumeCapacity();
+            break :blk index;
+        }
+    };
+    itab.entries.items[index] = target;
+    try itab.lookup.putNoClobber(allocator, target, index);
+    return index;
+}
+
+const Context = struct {
+    coff_file: *const Coff,
+    /// Index of this ImportTable in a global list of all tables.
+    /// This is required in order to calculate the base vaddr of this ImportTable.
+    index: usize,
+    /// Offset into the string interning table of the DLL this ImportTable corresponds to.
+    name_off: u32,
+};
+
+fn getBaseAddress(ctx: Context) u32 {
+    const header = ctx.coff_file.sections.items(.header)[ctx.coff_file.idata_section_index.?];
+    var addr = header.virtual_address;
+    for (ctx.coff_file.import_tables.values(), 0..) |other_itab, i| {
+        if (ctx.index == i) break;
+        addr += @intCast(u32, other_itab.entries.items.len * @sizeOf(u64)) + 8;
+    }
+    return addr;
+}
+
+pub fn getImportAddress(itab: *const ImportTable, target: SymbolWithLoc, ctx: Context) ?u32 {
+    const index = itab.lookup.get(target) orelse return null;
+    const base_vaddr = getBaseAddress(ctx);
+    return base_vaddr + index * @sizeOf(u64);
+}
+
+const FormatContext = struct {
+    itab: ImportTable,
+    ctx: Context,
+};
+
+fn fmt(
+    fmt_ctx: FormatContext,
+    comptime unused_format_string: []const u8,
+    options: std.fmt.FormatOptions,
+    writer: anytype,
+) @TypeOf(writer).Error!void {
+    _ = options;
+    comptime assert(unused_format_string.len == 0);
+    const lib_name = fmt_ctx.ctx.coff_file.temp_strtab.getAssumeExists(fmt_ctx.ctx.name_off);
+    const base_vaddr = getBaseAddress(fmt_ctx.ctx);
+    try writer.print("IAT({s}.dll) @{x}:", .{ lib_name, base_vaddr });
+    for (fmt_ctx.itab.entries.items, 0..) |entry, i| {
+        try writer.print("\n  {d}@{?x} => {s}", .{
+            i,
+            fmt_ctx.itab.getImportAddress(entry, fmt_ctx.ctx),
+            fmt_ctx.ctx.coff_file.getSymbolName(entry),
+        });
+    }
+}
+
+fn format(itab: ImportTable, comptime unused_format_string: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
+    _ = itab;
+    _ = unused_format_string;
+    _ = options;
+    _ = writer;
+    @compileError("do not format ImportTable directly; use itab.fmtDebug()");
+}
+
+pub fn fmtDebug(itab: ImportTable, ctx: Context) std.fmt.Formatter(fmt) {
+    return .{ .data = .{ .itab = itab, .ctx = ctx } };
+}
+
+const ImportIndex = u32;
+const ImportTable = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const log = std.log.scoped(.link);
+
+const Allocator = std.mem.Allocator;
+const Coff = @import("../Coff.zig");
+const SymbolWithLoc = Coff.SymbolWithLoc;

--- a/src/link/Coff/Relocation.zig
+++ b/src/link/Coff/Relocation.zig
@@ -61,8 +61,13 @@ pub fn getTargetAddress(self: Relocation, coff_file: *const Coff) ?u32 {
 
         .import, .import_page, .import_pageoff => {
             const sym = coff_file.getSymbol(self.target);
-            const itab = coff_file.import_tables.get(sym.value) orelse return null;
-            return itab.getImportAddress(coff_file, self.target);
+            const index = coff_file.import_tables.getIndex(sym.value) orelse return null;
+            const itab = coff_file.import_tables.values()[index];
+            return itab.getImportAddress(self.target, .{
+                .coff_file = coff_file,
+                .index = index,
+                .name_off = sym.value,
+            });
         },
     }
 }

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -3202,7 +3202,8 @@ fn insertSection(self: *MachO, segment_index: u8, header: macho.section_64) !u8 
     return insertion_index;
 }
 
-pub fn getGlobalSymbol(self: *MachO, name: []const u8) !u32 {
+pub fn getGlobalSymbol(self: *MachO, name: []const u8, lib_name: ?[]const u8) !u32 {
+    _ = lib_name;
     const gpa = self.base.allocator;
 
     const sym_name = try std.fmt.allocPrint(gpa, "_{s}", .{name});

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -1573,7 +1573,8 @@ pub fn lowerUnnamedConst(wasm: *Wasm, tv: TypedValue, decl_index: Module.Decl.In
 /// such as an exported or imported symbol.
 /// If the symbol does not yet exist, creates a new one symbol instead
 /// and then returns the index to it.
-pub fn getGlobalSymbol(wasm: *Wasm, name: []const u8) !u32 {
+pub fn getGlobalSymbol(wasm: *Wasm, name: []const u8, lib_name: ?[]const u8) !u32 {
+    _ = lib_name;
     const name_index = try wasm.string_table.put(wasm.base.allocator, name);
     const gop = try wasm.globals.getOrPut(wasm.base.allocator, name_index);
     if (gop.found_existing) {

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -112,7 +112,6 @@ const test_targets = blk: {
                 .os_tag = .windows,
                 .abi = .gnu,
             },
-            .single_threaded = true, // https://github.com/ziglang/zig/issues/15075
             .backend = .stage2_x86_64,
         },
 


### PR DESCRIPTION
Fixes #15075

The cool thing about Zig's handling of `extern`s (aka `extern "ntdll" fn SomeFunc(...)`) is that we can declaratively specify what DLLs we want to link against and what symbols link from there without having access to the said DLLs. Of course, if we make a mistake in naming the right DLL, we get a loader rather than a linker error, but I still find it amazing that we are able to do this.