### PR TITLE
lib/init-exe: fixes the dependencies of the compile step in the build.zig templates

### DIFF
--- a/lib/init-exe/build.zig
+++ b/lib/init-exe/build.zig
@@ -58,10 +58,11 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const exe_tests_run = b.addRunArtifact(exe_tests);
 
     // Similar to creating the run step earlier, this exposes a `test` step to
     // the `zig build --help` menu, providing a way for the user to request
     // running the unit tests.
     const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&exe_tests.step);
+    test_step.dependOn(&exe_tests_run.step);
 }

--- a/lib/init-exe/build.zig
+++ b/lib/init-exe/build.zig
@@ -32,7 +32,7 @@ pub fn build(b: *std.Build) void {
     // This *creates* a RunStep in the build graph, to be executed when another
     // step is evaluated that depends on it. The next line below will establish
     // such a dependency.
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
 
     // By making the run step depend on the install step, it will be run from the
     // installation directory rather than directly from within the cache directory.

--- a/lib/init-lib/build.zig
+++ b/lib/init-lib/build.zig
@@ -35,10 +35,11 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const main_tests_run = b.addRunArtifact(main_tests);
 
     // This creates a build step. It will be visible in the `zig build --help` menu,
     // and can be selected like this: `zig build test`
     // This will evaluate the `test` step rather than the default, which is "install".
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+    test_step.dependOn(&main_tests_run.step);
 }

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -676,7 +676,6 @@ pub fn addCliTests(b: *std.Build) *Step {
 
         const run_test = b.addSystemCommand(&.{ b.zig_exe, "build", "test" });
         run_test.cwd = tmp_path;
-        run_test.is_test_command = true;
         run_test.setName("zig build test");
         run_test.expectStdOutEqual("");
         run_test.step.dependOn(&init_lib.step);
@@ -711,7 +710,6 @@ pub fn addCliTests(b: *std.Build) *Step {
 
         const run_test = b.addSystemCommand(&.{ b.zig_exe, "build", "test" });
         run_test.cwd = tmp_path;
-        run_test.is_test_command = true;
         run_test.setName("zig build test");
         run_test.expectStdOutEqual("");
         run_test.step.dependOn(&init_exe.step);

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -676,6 +676,7 @@ pub fn addCliTests(b: *std.Build) *Step {
 
         const run_test = b.addSystemCommand(&.{ b.zig_exe, "build", "test" });
         run_test.cwd = tmp_path;
+        run_test.is_test_command = true;
         run_test.setName("zig build test");
         run_test.expectStdOutEqual("");
         run_test.step.dependOn(&init_lib.step);
@@ -710,6 +711,7 @@ pub fn addCliTests(b: *std.Build) *Step {
 
         const run_test = b.addSystemCommand(&.{ b.zig_exe, "build", "test" });
         run_test.cwd = tmp_path;
+        run_test.is_test_command = true;
         run_test.setName("zig build test");
         run_test.expectStdOutEqual("");
         run_test.step.dependOn(&init_exe.step);


### PR DESCRIPTION
fixes this: https://github.com/ziglang/zig/issues/15009
replaces this: https://github.com/ziglang/zig/pull/15064
replaces this: https://github.com/ziglang/zig/pull/15078
