### PR TITLE
tests: enable test_runner_module_imports standalone test

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -78,6 +78,10 @@ pub const build_cases = [_]BuildCase{
         .import = @import("standalone/test_runner_path/build.zig"),
     },
     .{
+        .build_root = "test/standalone/test_runner_module_imports",
+        .import = @import("standalone/test_runner_module_imports/build.zig"),
+    },
+    .{
         .build_root = "test/standalone/issue_13970",
         .import = @import("standalone/issue_13970/build.zig"),
     },

--- a/test/standalone/test_runner_module_imports/build.zig
+++ b/test/standalone/test_runner_module_imports/build.zig
@@ -16,4 +16,5 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&t.run().step);
+    b.default_step = test_step;
 }


### PR DESCRIPTION
This standalone test wasn't being run - not sure if there was a mistake when it was added, or it was disabled at some point, but it's passing.