### PR TITLE
Sema: defer stores to inferred allocs

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -3597,10 +3597,6 @@ fn airStore(f: *Function, inst: Air.Inst.Index) !CValue {
     const ptr_ty = f.air.typeOf(bin_op.lhs);
     const ptr_scalar_ty = ptr_ty.scalarType();
     const ptr_info = ptr_scalar_ty.ptrInfo().data;
-    if (!ptr_info.pointee_type.hasRuntimeBitsIgnoreComptime()) {
-        try reap(f, inst, &.{ bin_op.lhs, bin_op.rhs });
-        return .none;
-    }
 
     const ptr_val = try f.resolveInst(bin_op.lhs);
     const src_ty = f.air.typeOf(bin_op.rhs);
@@ -4461,9 +4457,7 @@ fn airBr(f: *Function, inst: Air.Inst.Index) !CValue {
 fn airBitcast(f: *Function, inst: Air.Inst.Index) !CValue {
     const ty_op = f.air.instructions.items(.data)[inst].ty_op;
     const dest_ty = f.air.typeOfIndex(inst);
-    // No IgnoreComptime until Sema stops giving us garbage Air.
-    // https://github.com/ziglang/zig/issues/13410
-    if (f.liveness.isUnused(inst) or !dest_ty.hasRuntimeBits()) {
+    if (f.liveness.isUnused(inst)) {
         try reap(f, inst, &.{ty_op.operand});
         return .none;
     }

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -8216,7 +8216,6 @@ pub const FuncGen = struct {
         const dest_ptr = try self.resolveInst(bin_op.lhs);
         const ptr_ty = self.air.typeOf(bin_op.lhs);
         const operand_ty = ptr_ty.childType();
-        if (!operand_ty.isFnOrHasRuntimeBitsIgnoreComptime()) return null;
 
         // TODO Sema should emit a different instruction when the store should
         // possibly do the safety 0xaa bytes for undefined.

--- a/test/behavior/if.zig
+++ b/test/behavior/if.zig
@@ -140,12 +140,6 @@ test "if-else expression with runtime condition result location is inferred opti
 }
 
 test "result location with inferred type ends up being pointer to comptime_int" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-
     var a: ?u32 = 1234;
     var b: u32 = 2000;
     var c = if (a) |d| blk: {

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -1540,3 +1540,19 @@ test "access the tag of a global tagged union" {
     };
     try expect(U.u == .a);
 }
+
+test "coerce enum literal to union in result loc" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+
+    const U = union(enum) {
+        a,
+        b: u8,
+
+        fn doTest(c: bool) !void {
+            var u = if (c) .a else @This(){ .b = 0 };
+            try expect(u == .a);
+        }
+    };
+    try U.doTest(true);
+    comptime try U.doTest(true);
+}


### PR DESCRIPTION
This lets us generate the store with knowledge of the type to be stored. Therefore, we can avoid generating garbage Air with stores through pointers to comptime-only types which backends cannot lower.

Closes #13410
Closes #15122

---
```
  %31 = alloc(*u32)
...
        %57 = bitcast(*comptime_int, %31)
        %58!= store(%57!, @Zir.Inst.Ref.zero)
```
=>
```
  %68 = constant(u32, 0)
...
  %31 = alloc(*u32)
...
       %54!= store(%31, %68!)
```
---
```
  %43 = constant(@TypeOf(.enum_literal), .a)
...
  %38 = alloc(*repro.U)
...
        %45 = bitcast(*@TypeOf(.enum_literal), %38)
        %46!= store(%45!, %43!)
```
=>
```
  %95 = constant(repro.U, .{ .a = {} })
...
  %38 = alloc(*repro.U)
...
        %44!= store(%38, %95!)
```