### PR TITLE
Build: restore color support

### DIFF
--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -285,6 +285,7 @@ pub fn main() !void {
     var progress: std.Progress = .{ .dont_print_on_dumb = true };
     const main_progress_node = progress.start("", 0);
 
+    builder.ttyconf = ttyconf;
     builder.debug_log_scopes = debug_log_scopes.items;
     builder.resolveInstallPrefix(install_prefix, dir_list);
     {

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -220,9 +220,9 @@ pub fn dump(step: *Step) void {
     std.debug.getStderrMutex().lock();
     defer std.debug.getStderrMutex().unlock();
 
+    const ttyconf = step.owner.ttyconf;
     const stderr = std.io.getStdErr();
     const w = stderr.writer();
-    const tty_config = std.debug.detectTTYConfig(stderr);
     const debug_info = std.debug.getSelfDebugInfo() catch |err| {
         w.print("Unable to dump stack trace: Unable to open debug info: {s}\n", .{
             @errorName(err),
@@ -231,7 +231,7 @@ pub fn dump(step: *Step) void {
     };
     const ally = debug_info.allocator;
     w.print("name: '{s}'. creation stack trace:\n", .{step.name}) catch {};
-    std.debug.writeStackTrace(step.getStackTrace(), w, ally, debug_info, tty_config) catch |err| {
+    std.debug.writeStackTrace(step.getStackTrace(), w, ally, debug_info, ttyconf) catch |err| {
         stderr.writer().print("Unable to dump stack trace: {s}\n", .{@errorName(err)}) catch {};
         return;
     };


### PR DESCRIPTION
Commit 986a30e37 (integrate the build runner and the compiler server) removed the std.Build.color field, because build steps are no longer supposed to interact with stderr directly.

However this change have same issues:
  - The build system still use colors, in the dumpBadGetPathHelp function and std.Build.Step.dump method.  They create a new TTYConfig, ignoring the user preference.
  - A custom build step may still want to use colors. An example is ziglings. It uses a custom Run step, since it needs additional actions not supported by std.Build.RunStep, and it wants to use colors to improve user experience.

Add a new ttyconf field to std.Build, and, in the create function, initialize it using std.debug.detectTTYConfig.

Change lib/build_runner.zig to update the Build.ttyconf field, after the builder has been configured.

Rename the tty_config variable to ttyconf, for consistency.