### PR TITLE
fix bug: fix incorrect structure definition

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -4004,7 +4004,7 @@ pub const io_uring_probe = extern struct {
     ops_len: u8,
 
     resv: u16,
-    resv2: u32[3],
+    resv2: [3]u32,
 
     // Followed by up to `ops_len` io_uring_probe_op structures
 };
@@ -4022,7 +4022,7 @@ pub const io_uring_restriction = extern struct {
         sqe_flags: u8,
     },
     resv: u8,
-    resv2: u32[3],
+    resv2: [3]u32,
 };
 
 /// io_uring_restriction->opcode values


### PR DESCRIPTION
fix incorrect structure definition of `io_uring_probe` and `io_uring_restriction`. 

Change `u32[3]` to `[3]u32`. And according to [liburing](https://github.com/axboe/liburing/blob/4fed79510a189cc7997f6d04855ebf7fb66cc323/src/include/liburing/io_uring.h#L599-L605) the definition of `io_uring_probe` should have a c pointor to `io_uring_probe_op`.

In `liburing`:
```c
struct io_uring_probe {
	__u8 last_op;	/* last opcode supported */
	__u8 ops_len;	/* length of ops[] array below */
	__u16 resv;
	__u32 resv2[3];
	struct io_uring_probe_op ops[];
};
```