### PR TITLE
Implement `@shuffle`, fix vector element accesses for WASM backend

### DIFF
--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -4749,7 +4749,7 @@ fn airShuffle(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         } ++ [1]u32{undefined} ** 4;
 
         var lanes = std.mem.asBytes(operands[1..]);
-        for (0..mask_len) |index| {
+        for (0..@intCast(usize, mask_len)) |index| {
             var buf: Value.ElemValueBuffer = undefined;
             const mask_elem = mask.elemValueBuffer(module, index, &buf).toSignedInt(func.target);
             const base_index = if (mask_elem >= 0)
@@ -4757,8 +4757,8 @@ fn airShuffle(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
             else
                 16 + @intCast(u8, @intCast(i64, elem_size) * ~mask_elem);
 
-            for (0..elem_size) |byte_offset| {
-                lanes[index * elem_size + byte_offset] = base_index + @intCast(u8, byte_offset);
+            for (0..@intCast(usize, elem_size)) |byte_offset| {
+                lanes[index * @intCast(usize, elem_size) + byte_offset] = base_index + @intCast(u8, byte_offset);
             }
         }
 

--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -486,7 +486,9 @@ fn emitSimd(emit: *Emit, inst: Mir.Inst.Index) !void {
             const mem_arg = emit.mir.extraData(Mir.MemArg, extra_index + 1).data;
             try encodeMemArg(mem_arg, writer);
         },
-        .v128_const => {
+        .v128_const,
+        .i8x16_shuffle,
+        => {
             const simd_value = emit.mir.extra[extra_index + 1 ..][0..4];
             try writer.writeAll(std.mem.asBytes(simd_value));
         },

--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -492,6 +492,23 @@ fn emitSimd(emit: *Emit, inst: Mir.Inst.Index) !void {
             const simd_value = emit.mir.extra[extra_index + 1 ..][0..4];
             try writer.writeAll(std.mem.asBytes(simd_value));
         },
+        .i8x16_extract_lane_s,
+        .i8x16_extract_lane_u,
+        .i8x16_replace_lane,
+        .i16x8_extract_lane_s,
+        .i16x8_extract_lane_u,
+        .i16x8_replace_lane,
+        .i32x4_extract_lane,
+        .i32x4_replace_lane,
+        .i64x2_extract_lane,
+        .i64x2_replace_lane,
+        .f32x4_extract_lane,
+        .f32x4_replace_lane,
+        .f64x2_extract_lane,
+        .f64x2_replace_lane,
+        => {
+            try writer.writeByte(@intCast(u8, emit.mir.extra[extra_index + 1]));
+        },
         .i8x16_splat,
         .i16x8_splat,
         .i32x4_splat,

--- a/test/behavior/shuffle.zig
+++ b/test/behavior/shuffle.zig
@@ -4,7 +4,6 @@ const mem = std.mem;
 const expect = std.testing.expect;
 
 test "@shuffle int" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -807,7 +807,6 @@ test "vector @reduce comptime" {
 }
 
 test "mask parameter of @shuffle is comptime scope" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO


### PR DESCRIPTION
Thanks @jacobly0 for all the help with this :)

- `@shuffle` works
- Vector element accesses (mutable and constant) work (again)

cc @Luukdegram 