### PR TITLE
windows: add support for native virtual terminal

### DIFF
--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -320,6 +320,8 @@ pub extern "kernel32" fn RtlVirtualUnwind(
     ContextPointers: ?*KNONVOLATILE_CONTEXT_POINTERS,
 ) callconv(WINAPI) *EXCEPTION_ROUTINE;
 
+pub extern "kernel32" fn SetConsoleMode(in_hConsoleHandle: HANDLE, in_Mode: DWORD) callconv(WINAPI) BOOL;
+
 pub extern "kernel32" fn SetConsoleTextAttribute(hConsoleOutput: HANDLE, wAttributes: WORD) callconv(WINAPI) BOOL;
 
 pub extern "kernel32" fn SetConsoleCtrlHandler(


### PR DESCRIPTION
Unfortunately I'm unable to test that, when `ENABLE_VIRTUAL_TERMINAL_PROCESSING` is available, the Windows console supports all the escape codes used by the compiler and standard library.

From https://web.archive.org/web/20230000000000*/https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences, the official documentation was only added in 2022.