### PR TITLE
std.debug: add customPanicFn option to allow overriding the panicImpl

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -334,6 +334,10 @@ pub fn panicImpl(trace: ?*const std.builtin.StackTrace, first_trace_addr: ?usize
         resetSegfaultHandler();
     }
 
+    if (std.options.customPanicFn) |customPanicFn| {
+        customPanicFn(trace, first_trace_addr, msg);
+    }
+
     // Note there is similar logic in handleSegfaultPosix and handleSegfaultWindowsExtra.
     nosuspend switch (panic_stage) {
         0 => {

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -111,6 +111,11 @@ pub const options = struct {
     else
         debug.default_enable_segfault_handler;
 
+    pub const customPanicFn: ?*const fn (trace: ?*const builtin.StackTrace, first_trace_addr: ?usize, msg: []const u8) void = if (@hasDecl(options_override, "customPanicFn"))
+        &options_override.customPanicFn
+    else
+        null;
+
     /// Function used to implement std.fs.cwd for wasi.
     pub const wasiCwd: fn () fs.Dir = if (@hasDecl(options_override, "wasiCwd"))
         options_override.wasiCwd


### PR DESCRIPTION
For things like generating a minidump, generating crash reports, and others. There is already a way to override the exception handler, but if you want to catch all of the panics also then you'll need to override panicImpl