### PR TITLE
remove --enable-cache option; std.Build.CompileStep: remove output_dir

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -325,7 +325,6 @@ const Code = struct {
     link_objects: []const []const u8,
     target_str: ?[]const u8,
     link_libc: bool,
-    backend_stage1: bool,
     link_mode: ?std.builtin.LinkMode,
     disable_cache: bool,
     verbose_cimport: bool,
@@ -596,7 +595,6 @@ fn genToc(allocator: Allocator, tokenizer: *Tokenizer) !Toc {
                     var link_mode: ?std.builtin.LinkMode = null;
                     var disable_cache = false;
                     var verbose_cimport = false;
-                    var backend_stage1 = false;
                     var additional_options = std.ArrayList([]const u8).init(allocator);
                     defer additional_options.deinit();
 
@@ -631,8 +629,6 @@ fn genToc(allocator: Allocator, tokenizer: *Tokenizer) !Toc {
                             link_libc = true;
                         } else if (mem.eql(u8, end_tag_name, "link_mode_dynamic")) {
                             link_mode = .Dynamic;
-                        } else if (mem.eql(u8, end_tag_name, "backend_stage1")) {
-                            backend_stage1 = true;
                         } else if (mem.eql(u8, end_tag_name, "additonal_option")) {
                             _ = try eatToken(tokenizer, Token.Id.Separator);
                             const option = try eatToken(tokenizer, Token.Id.TagContent);
@@ -660,7 +656,6 @@ fn genToc(allocator: Allocator, tokenizer: *Tokenizer) !Toc {
                             .link_objects = try link_objects.toOwnedSlice(),
                             .target_str = target_str,
                             .link_libc = link_libc,
-                            .backend_stage1 = backend_stage1,
                             .link_mode = link_mode,
                             .disable_cache = disable_cache,
                             .verbose_cimport = verbose_cimport,
@@ -1380,10 +1375,10 @@ fn genHtml(
                         var build_args = std.ArrayList([]const u8).init(allocator);
                         defer build_args.deinit();
                         try build_args.appendSlice(&[_][]const u8{
-                            zig_exe,          "build-exe",
-                            "--name",         code.name,
-                            "--color",        "on",
-                            "--enable-cache", tmp_source_file_name,
+                            zig_exe,       "build-exe",
+                            "--name",      code.name,
+                            "--color",     "on",
+                            name_plus_ext,
                         });
                         if (opt_zig_lib_dir) |zig_lib_dir| {
                             try build_args.appendSlice(&.{ "--zig-lib-dir", zig_lib_dir });
@@ -1400,20 +1395,12 @@ fn genHtml(
                         }
                         for (code.link_objects) |link_object| {
                             const name_with_ext = try std.fmt.allocPrint(allocator, "{s}{s}", .{ link_object, obj_ext });
-                            const full_path_object = try fs.path.join(
-                                allocator,
-                                &[_][]const u8{ tmp_dir_name, name_with_ext },
-                            );
-                            try build_args.append(full_path_object);
+                            try build_args.append(name_with_ext);
                             try shell_out.print("{s} ", .{name_with_ext});
                         }
                         if (code.link_libc) {
                             try build_args.append("-lc");
                             try shell_out.print("-lc ", .{});
-                        }
-                        if (code.backend_stage1) {
-                            try build_args.append("-fstage1");
-                            try shell_out.print("-fstage1", .{});
                         }
                         const target = try std.zig.CrossTarget.parse(.{
                             .arch_os_abi = code.target_str orelse "native",
@@ -1461,7 +1448,7 @@ fn genHtml(
                             try shell_out.writeAll(colored_stderr);
                             break :code_block;
                         }
-                        const exec_result = exec(allocator, &env_map, build_args.items) catch
+                        const exec_result = exec(allocator, &env_map, tmp_dir_name, build_args.items) catch
                             return parseError(tokenizer, code.source_token, "example failed to compile", .{});
 
                         if (code.verbose_cimport) {
@@ -1480,14 +1467,9 @@ fn genHtml(
                             }
                         }
 
-                        const path_to_exe_dir = mem.trim(u8, exec_result.stdout, " \r\n");
-                        const path_to_exe_basename = try std.fmt.allocPrint(allocator, "{s}{s}", .{
+                        const path_to_exe = try std.fmt.allocPrint(allocator, "./{s}{s}", .{
                             code.name,
                             target.exeFileExt(),
-                        });
-                        const path_to_exe = try fs.path.join(allocator, &[_][]const u8{
-                            path_to_exe_dir,
-                            path_to_exe_basename,
                         });
                         const run_args = &[_][]const u8{path_to_exe};
 
@@ -1498,6 +1480,7 @@ fn genHtml(
                                 .allocator = allocator,
                                 .argv = run_args,
                                 .env_map = &env_map,
+                                .cwd = tmp_dir_name,
                                 .max_output_bytes = max_doc_file_size,
                             });
                             switch (result.term) {
@@ -1514,7 +1497,7 @@ fn genHtml(
                             }
                             break :blk result;
                         } else blk: {
-                            break :blk exec(allocator, &env_map, run_args) catch return parseError(tokenizer, code.source_token, "example crashed", .{});
+                            break :blk exec(allocator, &env_map, tmp_dir_name, run_args) catch return parseError(tokenizer, code.source_token, "example crashed", .{});
                         };
 
                         const escaped_stderr = try escapeHtml(allocator, result.stderr);
@@ -1555,10 +1538,6 @@ fn genHtml(
                             try test_args.append("-lc");
                             try shell_out.print("-lc ", .{});
                         }
-                        if (code.backend_stage1) {
-                            try test_args.append("-fstage1");
-                            try shell_out.print("-fstage1", .{});
-                        }
                         if (code.target_str) |triple| {
                             try test_args.appendSlice(&[_][]const u8{ "-target", triple });
                             try shell_out.print("-target {s} ", .{triple});
@@ -1579,7 +1558,7 @@ fn genHtml(
                                 },
                             }
                         }
-                        const result = exec(allocator, &env_map, test_args.items) catch
+                        const result = exec(allocator, &env_map, null, test_args.items) catch
                             return parseError(tokenizer, code.source_token, "test failed", .{});
                         const escaped_stderr = try escapeHtml(allocator, result.stderr);
                         const escaped_stdout = try escapeHtml(allocator, result.stdout);
@@ -1609,10 +1588,6 @@ fn genHtml(
                         if (code.link_libc) {
                             try test_args.append("-lc");
                             try shell_out.print("-lc ", .{});
-                        }
-                        if (code.backend_stage1) {
-                            try test_args.append("-fstage1");
-                            try shell_out.print("-fstage1", .{});
                         }
                         const result = try ChildProcess.exec(.{
                             .allocator = allocator,
@@ -1778,7 +1753,7 @@ fn genHtml(
                             const colored_stderr = try termColor(allocator, escaped_stderr);
                             try shell_out.print("\n{s} ", .{colored_stderr});
                         } else {
-                            _ = exec(allocator, &env_map, build_args.items) catch return parseError(tokenizer, code.source_token, "example failed to compile", .{});
+                            _ = exec(allocator, &env_map, null, build_args.items) catch return parseError(tokenizer, code.source_token, "example failed to compile", .{});
                         }
                         try shell_out.writeAll("\n");
                     },
@@ -1831,7 +1806,7 @@ fn genHtml(
                             try test_args.append(option);
                             try shell_out.print("{s} ", .{option});
                         }
-                        const result = exec(allocator, &env_map, test_args.items) catch return parseError(tokenizer, code.source_token, "test failed", .{});
+                        const result = exec(allocator, &env_map, null, test_args.items) catch return parseError(tokenizer, code.source_token, "test failed", .{});
                         const escaped_stderr = try escapeHtml(allocator, result.stderr);
                         const escaped_stdout = try escapeHtml(allocator, result.stdout);
                         try shell_out.print("\n{s}{s}\n", .{ escaped_stderr, escaped_stdout });
@@ -1846,11 +1821,17 @@ fn genHtml(
     }
 }
 
-fn exec(allocator: Allocator, env_map: *process.EnvMap, args: []const []const u8) !ChildProcess.ExecResult {
+fn exec(
+    allocator: Allocator,
+    env_map: *process.EnvMap,
+    cwd: ?[]const u8,
+    args: []const []const u8,
+) !ChildProcess.ExecResult {
     const result = try ChildProcess.exec(.{
         .allocator = allocator,
         .argv = args,
         .env_map = env_map,
+        .cwd = cwd,
         .max_output_bytes = max_doc_file_size,
     });
     switch (result.term) {
@@ -1877,12 +1858,12 @@ fn getBuiltinCode(
     opt_zig_lib_dir: ?[]const u8,
 ) ![]const u8 {
     if (opt_zig_lib_dir) |zig_lib_dir| {
-        const result = try exec(allocator, env_map, &.{
+        const result = try exec(allocator, env_map, null, &.{
             zig_exe, "build-obj", "--show-builtin", "--zig-lib-dir", zig_lib_dir,
         });
         return result.stdout;
     } else {
-        const result = try exec(allocator, env_map, &.{
+        const result = try exec(allocator, env_map, null, &.{
             zig_exe, "build-obj", "--show-builtin",
         });
         return result.stdout;

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -539,6 +539,8 @@ pub const TestOptions = struct {
     optimize: std.builtin.Mode = .Debug,
     version: ?std.builtin.Version = null,
     max_rss: usize = 0,
+    filter: ?[]const u8 = null,
+    test_runner: ?[]const u8 = null,
 };
 
 pub fn addTest(b: *Build, options: TestOptions) *CompileStep {
@@ -549,6 +551,8 @@ pub fn addTest(b: *Build, options: TestOptions) *CompileStep {
         .target = options.target,
         .optimize = options.optimize,
         .max_rss = options.max_rss,
+        .filter = options.filter,
+        .test_runner = options.test_runner,
     });
 }
 

--- a/lib/std/Build/CompileStep.zig
+++ b/lib/std/Build/CompileStep.zig
@@ -1864,7 +1864,6 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         });
     }
 
-    try zig_args.append("--enable-cache");
     try zig_args.append("--listen=-");
 
     // Windows has an argument length limit of 32,766 characters, macOS 262,144 and Linux

--- a/lib/std/Build/TranslateCStep.zig
+++ b/lib/std/Build/TranslateCStep.zig
@@ -100,7 +100,6 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     try argv_list.append("translate-c");
     try argv_list.append("-lc");
 
-    try argv_list.append("--enable-cache");
     try argv_list.append("--listen=-");
 
     if (!self.target.isNative()) {

--- a/test/standalone/issue_13970/build.zig
+++ b/test/standalone/issue_13970/build.zig
@@ -6,16 +6,16 @@ pub fn build(b: *std.Build) void {
 
     const test1 = b.addTest(.{
         .root_source_file = .{ .path = "test_root/empty.zig" },
+        .test_runner = "src/main.zig",
     });
     const test2 = b.addTest(.{
         .root_source_file = .{ .path = "src/empty.zig" },
+        .test_runner = "src/main.zig",
     });
     const test3 = b.addTest(.{
         .root_source_file = .{ .path = "empty.zig" },
+        .test_runner = "src/main.zig",
     });
-    test1.setTestRunner("src/main.zig");
-    test2.setTestRunner("src/main.zig");
-    test3.setTestRunner("src/main.zig");
 
     test_step.dependOn(&b.addRunArtifact(test1).step);
     test_step.dependOn(&b.addRunArtifact(test2).step);

--- a/test/standalone/test_runner_module_imports/build.zig
+++ b/test/standalone/test_runner_module_imports/build.zig
@@ -3,8 +3,8 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const t = b.addTest(.{
         .root_source_file = .{ .path = "src/main.zig" },
+        .test_runner = "test_runner/main.zig",
     });
-    t.setTestRunner("test_runner/main.zig");
 
     const module1 = b.createModule(.{ .source_file = .{ .path = "module1/main.zig" } });
     const module2 = b.createModule(.{

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -977,11 +977,11 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
             .optimize = test_target.optimize_mode,
             .target = test_target.target,
             .max_rss = max_rss,
+            .filter = options.test_filter,
         });
         const single_threaded_txt = if (test_target.single_threaded) "single" else "multi";
         const backend_txt = if (test_target.backend) |backend| @tagName(backend) else "default";
         these_tests.single_threaded = test_target.single_threaded;
-        these_tests.setFilter(options.test_filter);
         if (test_target.link_libc) {
             these_tests.linkSystemLibrary("c");
         }
@@ -1037,10 +1037,15 @@ pub fn addCAbiTests(b: *std.Build, skip_non_native: bool, skip_release: bool) *S
                 continue;
             }
 
+            const triple_prefix = c_abi_target.zigTriple(b.allocator) catch @panic("OOM");
+
             const test_step = b.addTest(.{
                 .root_source_file = .{ .path = "test/c_abi/main.zig" },
                 .optimize = optimize_mode,
                 .target = c_abi_target,
+                .name = b.fmt("test-c-abi-{s}-{s}", .{
+                    triple_prefix, @tagName(optimize_mode),
+                }),
             });
             if (c_abi_target.abi != null and c_abi_target.abi.?.isMusl()) {
                 // TODO NativeTargetInfo insists on dynamically linking musl
@@ -1056,11 +1061,6 @@ pub fn addCAbiTests(b: *std.Build, skip_non_native: bool, skip_release: bool) *S
             if (c_abi_target.isWindows()) {
                 test_step.want_lto = false;
             }
-
-            const triple_prefix = c_abi_target.zigTriple(b.allocator) catch @panic("OOM");
-            test_step.setName(b.fmt("test-c-abi-{s}-{s} ", .{
-                triple_prefix, @tagName(optimize_mode),
-            }));
 
             const run = b.addRunArtifact(test_step);
             run.skip_foreign_checks = true;


### PR DESCRIPTION
std.Build.CompileStep: remove output_dir

Build scripts must instead use the FileSource abstraction rather than
telling the compiler directly where to output files.

CLI: remove --enable-cache option

This use case is now handled instead by the --listen option.

closes #14951
closes #15025
closes #15072

