### PR TITLE
build: add option to not build langref on install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,9 @@ message(STATUS "Configuring zig version ${RESOLVED_ZIG_VERSION}")
 set(ZIG_NO_LIB off CACHE BOOL
     "Disable copying lib/ files to install prefix during the build phase")
 
+set(ZIG_NO_LANGREF off CACHE BOOL
+    "Disable copying of langref to the install prefix during the build phase")
+
 set(ZIG_SKIP_INSTALL_LIB_FILES off CACHE BOOL "Deprecated. Use ZIG_NO_LIB")
 if(ZIG_SKIP_INSTALL_LIB_FILES)
   message(WARNING "ZIG_SKIP_INSTALL_LIB_FILES is deprecated. Use ZIG_NO_LIB instead.")
@@ -819,6 +822,11 @@ if(ZIG_NO_LIB)
 else()
   set(ZIG_NO_LIB_ARG "")
 endif()
+if(ZIG_NO_LANGREF)
+  set(ZIG_NO_LANGREF_ARG "-Dno-langref")
+else()
+  set(ZIG_NO_LANGREF_ARG "")
+endif()
 if(ZIG_SINGLE_THREADED)
   set(ZIG_SINGLE_THREADED_ARG "-fsingle-threaded")
 else()
@@ -843,6 +851,7 @@ set(ZIG_BUILD_ARGS
   ${ZIG_RELEASE_ARG}
   ${ZIG_STATIC_ARG}
   ${ZIG_NO_LIB_ARG}
+  ${ZIG_NO_LANGREF_ARG}
   ${ZIG_SINGLE_THREADED_ARG}
   ${ZIG_PIE_ARG}
   "-Dtarget=${ZIG_TARGET_TRIPLE}"

--- a/build.zig
+++ b/build.zig
@@ -36,6 +36,7 @@ pub fn build(b: *std.Build) !void {
         std.log.warn("-Dskip-install-lib-files is deprecated in favor of -Dno-lib", .{});
     }
     const skip_install_lib_files = b.option(bool, "no-lib", "skip copying of lib/ files and langref to installation prefix. Useful for development") orelse deprecated_skip_install_lib_files;
+    const skip_install_langref = b.option(bool, "no-langref", "skip copying of langref to the installation prefix") orelse skip_install_lib_files;
 
     const docgen_exe = b.addExecutable(.{
         .name = "docgen",
@@ -53,7 +54,7 @@ pub fn build(b: *std.Build) !void {
     docgen_cmd.addFileSourceArg(.{ .path = "doc/langref.html.in" });
     const langref_file = docgen_cmd.addOutputFileArg("langref.html");
     const install_langref = b.addInstallFileWithDir(langref_file, .prefix, "doc/langref.html");
-    if (!skip_install_lib_files) {
+    if (!skip_install_langref) {
         b.getInstallStep().dependOn(&install_langref.step);
     }
 


### PR DESCRIPTION
This is useful for packaging where you want the lib/ files but not langref in some completely non-standard location.

langref also prolongs the local install to access the stage 3 compiler without having to fish for hashes