### PR TITLE
windows: replace GetPhysicallyInstalledSystemMemory with ntdll

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -4476,6 +4476,34 @@ pub const MODULEENTRY32 = extern struct {
     szExePath: [MAX_PATH]CHAR,
 };
 
+pub const SYSTEM_INFORMATION_CLASS = enum(c_int) {
+    SystemBasicInformation = 0,
+    SystemPerformanceInformation = 2,
+    SystemTimeOfDayInformation = 3,
+    SystemProcessInformation = 5,
+    SystemProcessorPerformanceInformation = 8,
+    SystemInterruptInformation = 23,
+    SystemExceptionInformation = 33,
+    SystemRegistryQuotaInformation = 37,
+    SystemLookasideInformation = 45,
+    SystemCodeIntegrityInformation = 103,
+    SystemPolicyInformation = 134,
+};
+
+pub const SYSTEM_BASIC_INFORMATION = extern struct {
+    Reserved: ULONG,
+    TimerResolution: ULONG,
+    PageSize: ULONG,
+    NumberOfPhysicalPages: ULONG,
+    LowestPhysicalPageNumber: ULONG,
+    HighestPhysicalPageNumber: ULONG,
+    AllocationGranularity: ULONG,
+    MinimumUserModeAddress: ULONG_PTR,
+    MaximumUserModeAddress: ULONG_PTR,
+    ActiveProcessorsAffinityMask: KAFFINITY,
+    NumberOfProcessors: UCHAR,
+};
+
 pub const THREADINFOCLASS = enum(c_int) {
     ThreadBasicInformation,
     ThreadTimes,

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -31,6 +31,7 @@ const UNWIND_HISTORY_TABLE = windows.UNWIND_HISTORY_TABLE;
 const RUNTIME_FUNCTION = windows.RUNTIME_FUNCTION;
 const KNONVOLATILE_CONTEXT_POINTERS = windows.KNONVOLATILE_CONTEXT_POINTERS;
 const EXCEPTION_ROUTINE = windows.EXCEPTION_ROUTINE;
+const SYSTEM_INFORMATION_CLASS = windows.SYSTEM_INFORMATION_CLASS;
 const THREADINFOCLASS = windows.THREADINFOCLASS;
 const PROCESSINFOCLASS = windows.PROCESSINFOCLASS;
 const LPVOID = windows.LPVOID;
@@ -51,6 +52,14 @@ pub extern "ntdll" fn NtQueryInformationThread(
     ThreadInformationLength: ULONG,
     ReturnLength: ?*ULONG,
 ) callconv(WINAPI) NTSTATUS;
+
+pub extern "ntdll" fn NtQuerySystemInformation(
+    SystemInformationClass: SYSTEM_INFORMATION_CLASS,
+    SystemInformation: PVOID,
+    SystemInformationLength: ULONG,
+    ReturnLength: ?*ULONG,
+) callconv(WINAPI) NTSTATUS;
+
 pub extern "ntdll" fn NtSetInformationThread(
     ThreadHandle: HANDLE,
     ThreadInformationClass: THREADINFOCLASS,


### PR DESCRIPTION
On Windows, there are two kinds of total physical memory. One obtained by `GetPhysicallyInstalledSystemMemory` which represends the real physical memory values retreived from the SMBIOS physical memory tables. While this value is the total actual memory installed in the system, it does not represent the max total memory that the system can have. Parts of the system memory are hardware reserved. It's also worth noting that `GetPhysicallyInstalledSystemMemory` can be a bit expensive compared to the total - reserved as it parses the SMBIOS tables until it finds the memory table (16) which i believe requires allocation.

In Linux, `std/process.zig` uses `/proc/meminfo` MemTotal. In the man page of proc, it states that: 
```
MemTotal %lu
                 Total usable RAM (i.e., physical RAM minus a few reserved bits and the kernel binary code).
```
Therefore the equivalent of `GetPhysicallyInstalledSystemMemory` on linux would be like calling `dmidecode` or also retreiving the system specs from SMBIOS. 

The other value for system memory which is represented in [MEMORYSTATUSEX](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex)'s ullTotalPhys field. This field represents the total memory of the system minus the hardware reserved (Windows' Resource Monitor show the breakdown of the values). 

`ullTotalPhys` can be obtained in ntdll using the number of physical pages * the page size. 
This can be verified by running both. Here is a gist for both: [kernel32](https://gist.github.com/xEgoist/b91d8dcc71e288f8937ff41d4e5e0e40), and [ntdll](https://gist.github.com/xEgoist/ddb6f6c577d87963b07a6023d10bc9fa). Both should match according to my tests, but feel free to test.

-----

Note: If the intended behavior is to grab the total physical memory **including** the reserved space, or if it does not matter to use the current function, please feel free to close this PR. I also already have my ntdll version of `GetPhysicallyInstalledSystemMemory` [here](https://gist.github.com/xEgoist/49a68b8d292dc3fe2e284204a171b607) if it's more desired as well :) 
