### PR TITLE
wasm: no longer use simplified `start.zig` logic

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -18,7 +18,6 @@ const start_sym_name = if (native_arch.isMIPS()) "__start" else "_start";
 // Until then, we have simplified logic here for self-hosted. TODO remove this once
 // self-hosted is capable enough to handle all of the real start.zig logic.
 pub const simplified_logic =
-    builtin.zig_backend == .stage2_wasm or
     (builtin.zig_backend == .stage2_x86_64 and (builtin.link_libc or builtin.os.tag == .plan9)) or
     builtin.zig_backend == .stage2_x86 or
     builtin.zig_backend == .stage2_aarch64 or
@@ -43,8 +42,6 @@ comptime {
                 if (!@hasDecl(root, "wWinMainCRTStartup") and !@hasDecl(root, "mainCRTStartup")) {
                     @export(wWinMainCRTStartup2, .{ .name = "wWinMainCRTStartup" });
                 }
-            } else if (builtin.os.tag == .wasi and @hasDecl(root, "main")) {
-                @export(wasiMain2, .{ .name = "_start" });
             } else if (builtin.os.tag == .opencl) {
                 if (@hasDecl(root, "main"))
                     @export(spirvMain2, .{ .name = "main" });
@@ -114,22 +111,6 @@ fn callMain2() noreturn {
     @setAlignStack(16);
     root.main();
     exit2(0);
-}
-
-fn wasiMain2() callconv(.C) noreturn {
-    switch (@typeInfo(@typeInfo(@TypeOf(root.main)).Fn.return_type.?)) {
-        .Void => {
-            root.main();
-            std.os.wasi.proc_exit(0);
-        },
-        .Int => |info| {
-            if (info.bits != 8 or info.signedness == .signed) {
-                @compileError(bad_main_ret);
-            }
-            std.os.wasi.proc_exit(root.main());
-        },
-        else => @compileError("Bad return type main"),
-    }
 }
 
 fn spirvMain2() callconv(.Kernel) void {

--- a/test/link/wasm/type/build.zig
+++ b/test/link/wasm/type/build.zig
@@ -26,10 +26,10 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
 
     const check_lib = lib.checkObject();
     check_lib.checkStart("Section type");
-    // only 2 entries, although we have 3 functions.
+    // only 3 entries, although we have more functions.
     // This is to test functions with the same function signature
     // have their types deduplicated.
-    check_lib.checkNext("entries 2");
+    check_lib.checkNext("entries 3");
     check_lib.checkNext("params 1");
     check_lib.checkNext("type i32");
     check_lib.checkNext("returns 1");


### PR DESCRIPTION
The Wasm backend now supports all features required to use the full `start.zig` logic, rather than the simplified version.
