### PR TITLE
std.crypto.aegis: support 256-bit tags

### DIFF
--- a/lib/std/crypto.zig
+++ b/lib/std/crypto.zig
@@ -4,7 +4,9 @@ const root = @import("root");
 pub const aead = struct {
     pub const aegis = struct {
         pub const Aegis128L = @import("crypto/aegis.zig").Aegis128L;
+        pub const Aegis128L_256 = @import("crypto/aegis.zig").Aegis128L_256;
         pub const Aegis256 = @import("crypto/aegis.zig").Aegis256;
+        pub const Aegis256_256 = @import("crypto/aegis.zig").Aegis256_256;
     };
 
     pub const aes_gcm = struct {


### PR DESCRIPTION
The latest (`cfrg-aegis-aead-02`) revision of the draft allows AEGIS to output 256-bit authentication tags.

The computational overhead is negligible. However, with a 256-bit tag, finding a collision becomes impractical even when the key and associated data can be chosen by an adversary.