### PR TITLE
add CI test coverage for more target combinations

### DIFF
--- a/lib/compiler_rt/common.zig
+++ b/lib/compiler_rt/common.zig
@@ -6,7 +6,8 @@ pub const linkage: std.builtin.GlobalLinkage = if (builtin.is_test) .Internal el
 /// Determines the symbol's visibility to other objects.
 /// For WebAssembly this allows the symbol to be resolved to other modules, but will not
 /// export it to the host runtime.
-pub const visibility: std.builtin.SymbolVisibility = if (builtin.target.isWasm()) .hidden else .default;
+pub const visibility: std.builtin.SymbolVisibility =
+    if (builtin.target.isWasm() and linkage != .Internal) .hidden else .default;
 pub const want_aeabi = switch (builtin.abi) {
     .eabi,
     .eabihf,

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -679,8 +679,7 @@ pub fn addRunArtifact(b: *Build, exe: *CompileStep) *RunStep {
     run_step.addArtifactArg(exe);
 
     if (exe.kind == .@"test") {
-        run_step.stdio = .zig_test;
-        run_step.addArgs(&.{"--listen=-"});
+        run_step.enableTestRunnerMode();
     }
 
     if (exe.vcpkg_bin_path) |path| {

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -454,6 +454,10 @@ pub const ExecutableOptions = struct {
     optimize: std.builtin.Mode = .Debug,
     linkage: ?CompileStep.Linkage = null,
     max_rss: usize = 0,
+    link_libc: ?bool = null,
+    single_threaded: ?bool = null,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
 };
 
 pub fn addExecutable(b: *Build, options: ExecutableOptions) *CompileStep {
@@ -466,6 +470,10 @@ pub fn addExecutable(b: *Build, options: ExecutableOptions) *CompileStep {
         .kind = .exe,
         .linkage = options.linkage,
         .max_rss = options.max_rss,
+        .link_libc = options.link_libc,
+        .single_threaded = options.single_threaded,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
     });
 }
 
@@ -475,6 +483,10 @@ pub const ObjectOptions = struct {
     target: CrossTarget,
     optimize: std.builtin.Mode,
     max_rss: usize = 0,
+    link_libc: ?bool = null,
+    single_threaded: ?bool = null,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
 };
 
 pub fn addObject(b: *Build, options: ObjectOptions) *CompileStep {
@@ -485,6 +497,10 @@ pub fn addObject(b: *Build, options: ObjectOptions) *CompileStep {
         .optimize = options.optimize,
         .kind = .obj,
         .max_rss = options.max_rss,
+        .link_libc = options.link_libc,
+        .single_threaded = options.single_threaded,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
     });
 }
 
@@ -495,6 +511,10 @@ pub const SharedLibraryOptions = struct {
     target: CrossTarget,
     optimize: std.builtin.Mode,
     max_rss: usize = 0,
+    link_libc: ?bool = null,
+    single_threaded: ?bool = null,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
 };
 
 pub fn addSharedLibrary(b: *Build, options: SharedLibraryOptions) *CompileStep {
@@ -507,6 +527,10 @@ pub fn addSharedLibrary(b: *Build, options: SharedLibraryOptions) *CompileStep {
         .target = options.target,
         .optimize = options.optimize,
         .max_rss = options.max_rss,
+        .link_libc = options.link_libc,
+        .single_threaded = options.single_threaded,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
     });
 }
 
@@ -517,6 +541,10 @@ pub const StaticLibraryOptions = struct {
     optimize: std.builtin.Mode,
     version: ?std.builtin.Version = null,
     max_rss: usize = 0,
+    link_libc: ?bool = null,
+    single_threaded: ?bool = null,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
 };
 
 pub fn addStaticLibrary(b: *Build, options: StaticLibraryOptions) *CompileStep {
@@ -529,6 +557,10 @@ pub fn addStaticLibrary(b: *Build, options: StaticLibraryOptions) *CompileStep {
         .target = options.target,
         .optimize = options.optimize,
         .max_rss = options.max_rss,
+        .link_libc = options.link_libc,
+        .single_threaded = options.single_threaded,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
     });
 }
 
@@ -541,6 +573,10 @@ pub const TestOptions = struct {
     max_rss: usize = 0,
     filter: ?[]const u8 = null,
     test_runner: ?[]const u8 = null,
+    link_libc: ?bool = null,
+    single_threaded: ?bool = null,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
 };
 
 pub fn addTest(b: *Build, options: TestOptions) *CompileStep {
@@ -553,6 +589,10 @@ pub fn addTest(b: *Build, options: TestOptions) *CompileStep {
         .max_rss = options.max_rss,
         .filter = options.filter,
         .test_runner = options.test_runner,
+        .link_libc = options.link_libc,
+        .single_threaded = options.single_threaded,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
     });
 }
 

--- a/lib/std/Build/CompileStep.zig
+++ b/lib/std/Build/CompileStep.zig
@@ -63,7 +63,7 @@ emit_llvm_ir: EmitOption = .default,
 // so it is not an EmitOption for now.
 emit_h: bool = false,
 bundle_compiler_rt: ?bool = null,
-single_threaded: ?bool = null,
+single_threaded: ?bool,
 stack_protector: ?bool = null,
 disable_stack_probing: bool,
 disable_sanitize_c: bool,
@@ -101,8 +101,8 @@ link_objects: ArrayList(LinkObject),
 include_dirs: ArrayList(IncludeDir),
 c_macros: ArrayList([]const u8),
 installed_headers: ArrayList(*Step),
-is_linking_libc: bool = false,
-is_linking_libcpp: bool = false,
+is_linking_libc: bool,
+is_linking_libcpp: bool,
 vcpkg_bin_path: ?[]const u8 = null,
 
 /// This may be set in order to override the default install directory
@@ -207,8 +207,8 @@ force_undefined_symbols: std.StringHashMap(void),
 stack_size: ?u64 = null,
 
 want_lto: ?bool = null,
-use_llvm: ?bool = null,
-use_lld: ?bool = null,
+use_llvm: ?bool,
+use_lld: ?bool,
 
 /// This is an advanced setting that can change the intent of this CompileStep.
 /// If this slice has nonzero length, it means that this CompileStep exists to
@@ -287,6 +287,10 @@ pub const Options = struct {
     max_rss: usize = 0,
     filter: ?[]const u8 = null,
     test_runner: ?[]const u8 = null,
+    link_libc: ?bool = null,
+    single_threaded: ?bool = null,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
 };
 
 pub const Kind = enum {
@@ -412,6 +416,12 @@ pub fn create(owner: *std.Build, options: Options) *CompileStep {
         .output_dirname_source = GeneratedFile{ .step = &self.step },
 
         .target_info = target_info,
+
+        .is_linking_libc = options.link_libc orelse false,
+        .is_linking_libcpp = false,
+        .single_threaded = options.single_threaded,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
     };
 
     if (self.kind == .lib) {

--- a/lib/std/Build/RunStep.zig
+++ b/lib/std/Build/RunStep.zig
@@ -140,6 +140,11 @@ pub fn setName(self: *RunStep, name: []const u8) void {
     self.rename_step_with_output_arg = false;
 }
 
+pub fn enableTestRunnerMode(rs: *RunStep) void {
+    rs.stdio = .zig_test;
+    rs.addArgs(&.{"--listen=-"});
+}
+
 pub fn addArtifactArg(self: *RunStep, artifact: *CompileStep) void {
     self.argv.append(Arg{ .artifact = artifact }) catch @panic("OOM");
     self.step.dependOn(&artifact.step);

--- a/lib/std/zig/Server.zig
+++ b/lib/std/zig/Server.zig
@@ -104,11 +104,9 @@ pub fn receiveMessage(s: *Server) !InMessage.Header {
         const buf = fifo.readableSlice(0);
         assert(fifo.readableLength() == buf.len);
         if (buf.len >= @sizeOf(Header)) {
-            const header = @ptrCast(*align(1) const Header, buf[0..@sizeOf(Header)]);
             // workaround for https://github.com/ziglang/zig/issues/14904
-            const bytes_len = bswap_and_workaround_u32(&header.bytes_len);
-            // workaround for https://github.com/ziglang/zig/issues/14904
-            const tag = bswap_and_workaround_tag(&header.tag);
+            const bytes_len = bswap_and_workaround_u32(buf[4..][0..4]);
+            const tag = bswap_and_workaround_tag(buf[0..][0..4]);
 
             if (buf.len - @sizeOf(Header) >= bytes_len) {
                 fifo.discard(@sizeOf(Header));
@@ -281,14 +279,12 @@ fn bswap_u32_array(slice: []u32) void {
 }
 
 /// workaround for https://github.com/ziglang/zig/issues/14904
-fn bswap_and_workaround_u32(x: *align(1) const u32) u32 {
-    const bytes_ptr = @ptrCast(*const [4]u8, x);
+fn bswap_and_workaround_u32(bytes_ptr: *const [4]u8) u32 {
     return std.mem.readIntLittle(u32, bytes_ptr);
 }
 
 /// workaround for https://github.com/ziglang/zig/issues/14904
-fn bswap_and_workaround_tag(x: *align(1) const InMessage.Tag) InMessage.Tag {
-    const bytes_ptr = @ptrCast(*const [4]u8, x);
+fn bswap_and_workaround_tag(bytes_ptr: *const [4]u8) InMessage.Tag {
     const int = std.mem.readIntLittle(u32, bytes_ptr);
     return @intToEnum(InMessage.Tag, int);
 }

--- a/test/behavior/atomics.zig
+++ b/test/behavior/atomics.zig
@@ -209,6 +209,12 @@ test "atomicrmw with floats" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
+    if (builtin.zig_backend == .stage2_c) {
+        // TODO: test.c:34929:7: error: address argument to atomic operation must be a pointer to integer or pointer ('zig_f32 *' (aka 'float *') invalid
+        // when compiling with -std=c99 -pedantic
+        return error.SkipZigTest;
+    }
+
     if ((builtin.zig_backend == .stage2_llvm or builtin.zig_backend == .stage2_c) and
         builtin.cpu.arch == .aarch64)
     {

--- a/test/behavior/bugs/12680.zig
+++ b/test/behavior/bugs/12680.zig
@@ -11,6 +11,10 @@ test "export a function twice" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
+        // TODO: test.c: error: aliases are not supported on darwin
+        return error.SkipZigTest;
+    }
 
     // If it exports the function correctly, `test_func` and `testFunc` will points to the same address.
     try expectEqual(test_func(), other_file.testFunc());

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1313,6 +1313,11 @@ test "cast f16 to wider types" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
+
     const S = struct {
         fn doTheTest() !void {
             var x: f16 = 1234.0;
@@ -1336,6 +1341,11 @@ test "cast f128 to narrower types" {
         builtin.zig_backend == .stage2_c)
     {
         // https://github.com/ziglang/zig/issues/13876
+        return error.SkipZigTest;
+    }
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
         return error.SkipZigTest;
     }
 
@@ -1426,6 +1436,11 @@ test "coerce between pointers of compatible differently-named floats" {
 
     if (builtin.os.tag == .windows) {
         // https://github.com/ziglang/zig/issues/12396
+        return error.SkipZigTest;
+    }
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
         return error.SkipZigTest;
     }
 

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1313,7 +1313,12 @@ test "cast f16 to wider types" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
+
+    if (builtin.os.tag == .windows and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
         // TODO: test is failing
         return error.SkipZigTest;
     }
@@ -1344,7 +1349,7 @@ test "cast f128 to narrower types" {
         return error.SkipZigTest;
     }
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -542,6 +542,11 @@ test "another, possibly redundant, @fabs test" {
         return error.SkipZigTest;
     }
 
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
+
     try testFabsLegacy(f128, 12.0);
     comptime try testFabsLegacy(f128, 12.0);
     try testFabsLegacy(f64, 12.0);
@@ -583,6 +588,11 @@ test "a third @fabs test, surely there should not be three fabs tests" {
         builtin.zig_backend == .stage2_c)
     {
         // https://github.com/ziglang/zig/issues/13876
+        return error.SkipZigTest;
+    }
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
         return error.SkipZigTest;
     }
 
@@ -687,6 +697,11 @@ test "@floor f128" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
 
     try testFloorLegacy(f128, 12.0);
     comptime try testFloorLegacy(f128, 12.0);
@@ -874,6 +889,11 @@ test "@trunc f128" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
+
     try testTruncLegacy(f128, 12.0);
     comptime try testTruncLegacy(f128, 12.0);
 }
@@ -989,6 +1009,11 @@ test "negation f128" {
         builtin.zig_backend == .stage2_c)
     {
         // https://github.com/ziglang/zig/issues/13876
+        return error.SkipZigTest;
+    }
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
         return error.SkipZigTest;
     }
 

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -542,7 +542,7 @@ test "another, possibly redundant, @fabs test" {
         return error.SkipZigTest;
     }
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }
@@ -591,7 +591,7 @@ test "a third @fabs test, surely there should not be three fabs tests" {
         return error.SkipZigTest;
     }
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }
@@ -698,7 +698,7 @@ test "@floor f128" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }
@@ -792,6 +792,11 @@ test "@ceil f128" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .x86_64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
 
     try testCeilLegacy(f128, 12.0);
     comptime try testCeilLegacy(f128, 12.0);
@@ -889,7 +894,7 @@ test "@trunc f128" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }
@@ -1012,7 +1017,7 @@ test "negation f128" {
         return error.SkipZigTest;
     }
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }
@@ -1059,6 +1064,11 @@ test "comptime fixed-width float zero divided by zero produces NaN" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .x86_64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
 
     inline for (.{ f16, f32, f64, f80, f128 }) |F| {
         try expect(math.isNan(@as(F, 0) / @as(F, 0)));

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -622,6 +622,11 @@ test "f128" {
         return error.SkipZigTest;
     }
 
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
+
     try test_f128();
     comptime try test_f128();
 }
@@ -1299,6 +1304,11 @@ test "remainder division" {
         return error.SkipZigTest;
     }
 
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
+
     comptime try remdiv(f16);
     comptime try remdiv(f32);
     comptime try remdiv(f64);
@@ -1445,6 +1455,11 @@ test "@round f128" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
+
     try testRound(f128, 12.0);
     comptime try testRound(f128, 12.0);
 }
@@ -1487,6 +1502,11 @@ test "NaN comparison" {
         builtin.cpu.arch == .aarch64)
     {
         // https://github.com/ziglang/zig/issues/13876
+        return error.SkipZigTest;
+    }
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
         return error.SkipZigTest;
     }
 
@@ -1562,6 +1582,12 @@ test "signed zeros are represented properly" {
     if (builtin.os.tag == .windows and builtin.cpu.arch == .aarch64 and
         builtin.zig_backend == .stage2_c)
     {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
         return error.SkipZigTest;
     }
 

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -622,7 +622,7 @@ test "f128" {
         return error.SkipZigTest;
     }
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }
@@ -1304,7 +1304,7 @@ test "remainder division" {
         return error.SkipZigTest;
     }
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }
@@ -1339,6 +1339,11 @@ test "float remainder division using @rem" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .x86_64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
 
     comptime try frem(f16);
     comptime try frem(f32);
@@ -1381,6 +1386,11 @@ test "float modulo division using @mod" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .x86_64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
 
     comptime try fmod(f16);
     comptime try fmod(f32);
@@ -1455,7 +1465,7 @@ test "@round f128" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }
@@ -1505,7 +1515,7 @@ test "NaN comparison" {
         return error.SkipZigTest;
     }
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }

--- a/test/behavior/muladd.zig
+++ b/test/behavior/muladd.zig
@@ -75,6 +75,11 @@ test "@mulAdd f128" {
         return error.SkipZigTest;
     }
 
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
+
     comptime try testMulAdd128();
     try testMulAdd128();
 }
@@ -200,6 +205,11 @@ test "vector f128" {
         builtin.zig_backend == .stage2_c)
     {
         // https://github.com/ziglang/zig/issues/13876
+        return error.SkipZigTest;
+    }
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
         return error.SkipZigTest;
     }
 

--- a/test/behavior/muladd.zig
+++ b/test/behavior/muladd.zig
@@ -75,7 +75,7 @@ test "@mulAdd f128" {
         return error.SkipZigTest;
     }
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -103,6 +103,11 @@ test "vector float operators" {
         return error.SkipZigTest;
     }
 
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
+
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         const S = struct {
             fn doTheTest() !void {

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -103,7 +103,7 @@ test "vector float operators" {
         return error.SkipZigTest;
     }
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }

--- a/test/behavior/widening.zig
+++ b/test/behavior/widening.zig
@@ -50,6 +50,11 @@ test "float widening" {
         return error.SkipZigTest;
     }
 
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
+        return error.SkipZigTest;
+    }
+
     var a: f16 = 12.34;
     var b: f32 = a;
     var c: f64 = b;
@@ -74,6 +79,11 @@ test "float widening f16 to f128" {
         builtin.zig_backend == .stage2_c)
     {
         // https://github.com/ziglang/zig/issues/13876
+        return error.SkipZigTest;
+    }
+
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+        // TODO: test is failing
         return error.SkipZigTest;
     }
 

--- a/test/behavior/widening.zig
+++ b/test/behavior/widening.zig
@@ -50,7 +50,7 @@ test "float widening" {
         return error.SkipZigTest;
     }
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }
@@ -82,7 +82,7 @@ test "float widening f16 to f128" {
         return error.SkipZigTest;
     }
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
         // TODO: test is failing
         return error.SkipZigTest;
     }

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -942,6 +942,15 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
         if (test_target.use_llvm == false and mem.eql(u8, options.name, "compiler-rt"))
             continue;
 
+        // TODO get compiler-rt tests passing for wasm32-wasi
+        // currently causes "LLVM ERROR: Unable to expand fixed point multiplication."
+        if (test_target.target.getCpuArch() == .wasm32 and
+            test_target.target.getOsTag() == .wasi and
+            mem.eql(u8, options.name, "compiler-rt"))
+        {
+            continue;
+        }
+
         // TODO get universal-libc tests passing for self-hosted backends.
         if (test_target.use_llvm == false and mem.eql(u8, options.name, "universal-libc"))
             continue;
@@ -949,6 +958,13 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
         // TODO get std lib tests passing for self-hosted backends.
         if (test_target.use_llvm == false and mem.eql(u8, options.name, "std"))
             continue;
+
+        // TODO get std lib tests passing for the C backend
+        if (test_target.target.ofmt == std.Target.ObjectFormat.c and
+            mem.eql(u8, options.name, "std"))
+        {
+            continue;
+        }
 
         const want_this_mode = for (options.optimize_modes) |m| {
             if (m == test_target.optimize_mode) break true;

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -22,12 +22,12 @@ pub const CompareOutputContext = @import("src/CompareOutput.zig");
 pub const StackTracesContext = @import("src/StackTrace.zig");
 
 const TestTarget = struct {
-    target: CrossTarget = @as(CrossTarget, .{}),
+    target: CrossTarget = .{},
     optimize_mode: std.builtin.OptimizeMode = .Debug,
-    link_libc: bool = false,
-    single_threaded: bool = false,
-    disable_native: bool = false,
-    backend: ?std.builtin.CompilerBackend = null,
+    link_libc: ?bool = null,
+    single_threaded: ?bool = null,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
 };
 
 const test_targets = blk: {
@@ -43,13 +43,47 @@ const test_targets = blk: {
         .{
             .single_threaded = true,
         },
+        .{
+            .optimize_mode = .ReleaseFast,
+        },
+        .{
+            .link_libc = true,
+            .optimize_mode = .ReleaseFast,
+        },
+        .{
+            .optimize_mode = .ReleaseFast,
+            .single_threaded = true,
+        },
+
+        .{
+            .optimize_mode = .ReleaseSafe,
+        },
+        .{
+            .link_libc = true,
+            .optimize_mode = .ReleaseSafe,
+        },
+        .{
+            .optimize_mode = .ReleaseSafe,
+            .single_threaded = true,
+        },
+
+        .{
+            .optimize_mode = .ReleaseSmall,
+        },
+        .{
+            .link_libc = true,
+            .optimize_mode = .ReleaseSmall,
+        },
+        .{
+            .optimize_mode = .ReleaseSmall,
+            .single_threaded = true,
+        },
 
         .{
             .target = .{
                 .ofmt = .c,
             },
             .link_libc = true,
-            .backend = .stage2_c,
         },
         .{
             .target = .{
@@ -57,22 +91,24 @@ const test_targets = blk: {
                 .os_tag = .linux,
                 .abi = .none,
             },
-            .backend = .stage2_x86_64,
+            .use_llvm = false,
+            .use_lld = false,
         },
         .{
             .target = .{
                 .cpu_arch = .aarch64,
                 .os_tag = .linux,
             },
-            .backend = .stage2_aarch64,
+            .use_llvm = false,
+            .use_lld = false,
         },
         .{
             .target = .{
                 .cpu_arch = .wasm32,
                 .os_tag = .wasi,
             },
-            .single_threaded = true,
-            .backend = .stage2_wasm,
+            .use_llvm = false,
+            .use_lld = false,
         },
         // https://github.com/ziglang/zig/issues/13623
         //.{
@@ -80,7 +116,8 @@ const test_targets = blk: {
         //        .cpu_arch = .arm,
         //        .os_tag = .linux,
         //    },
-        //    .backend = .stage2_arm,
+        //    .use_llvm = false,
+        //    .use_lld = false,
         //},
         // https://github.com/ziglang/zig/issues/13623
         //.{
@@ -88,7 +125,8 @@ const test_targets = blk: {
         //        .arch_os_abi = "arm-linux-none",
         //        .cpu_features = "generic+v8a",
         //    }) catch unreachable,
-        //    .backend = .stage2_arm,
+        //    .use_llvm = false,
+        //    .use_lld = false,
         //},
         .{
             .target = .{
@@ -96,7 +134,8 @@ const test_targets = blk: {
                 .os_tag = .macos,
                 .abi = .none,
             },
-            .backend = .stage2_aarch64,
+            .use_llvm = false,
+            .use_lld = false,
         },
         .{
             .target = .{
@@ -104,7 +143,8 @@ const test_targets = blk: {
                 .os_tag = .macos,
                 .abi = .none,
             },
-            .backend = .stage2_x86_64,
+            .use_llvm = false,
+            .use_lld = false,
         },
         .{
             .target = .{
@@ -112,7 +152,8 @@ const test_targets = blk: {
                 .os_tag = .windows,
                 .abi = .gnu,
             },
-            .backend = .stage2_x86_64,
+            .use_llvm = false,
+            .use_lld = false,
         },
 
         .{
@@ -121,7 +162,6 @@ const test_targets = blk: {
                 .os_tag = .wasi,
             },
             .link_libc = false,
-            .single_threaded = true,
         },
         .{
             .target = .{
@@ -129,7 +169,6 @@ const test_targets = blk: {
                 .os_tag = .wasi,
             },
             .link_libc = true,
-            .single_threaded = true,
         },
 
         .{
@@ -412,43 +451,6 @@ const test_targets = blk: {
                 .abi = .gnu,
             },
             .link_libc = true,
-        },
-
-        // Do the release tests last because they take a long time
-        .{
-            .optimize_mode = .ReleaseFast,
-        },
-        .{
-            .link_libc = true,
-            .optimize_mode = .ReleaseFast,
-        },
-        .{
-            .optimize_mode = .ReleaseFast,
-            .single_threaded = true,
-        },
-
-        .{
-            .optimize_mode = .ReleaseSafe,
-        },
-        .{
-            .link_libc = true,
-            .optimize_mode = .ReleaseSafe,
-        },
-        .{
-            .optimize_mode = .ReleaseSafe,
-            .single_threaded = true,
-        },
-
-        .{
-            .optimize_mode = .ReleaseSmall,
-        },
-        .{
-            .link_libc = true,
-            .optimize_mode = .ReleaseSmall,
-        },
-        .{
-            .optimize_mode = .ReleaseSmall,
-            .single_threaded = true,
         },
     };
 };
@@ -913,8 +915,6 @@ const ModuleTestOptions = struct {
     skip_non_native: bool,
     skip_cross_glibc: bool,
     skip_libc: bool,
-    skip_stage1: bool,
-    skip_stage2: bool,
     max_rss: usize = 0,
 };
 
@@ -922,49 +922,41 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
     const step = b.step(b.fmt("test-{s}", .{options.name}), options.desc);
 
     for (test_targets) |test_target| {
-        if (options.skip_non_native and !test_target.target.isNative())
+        const is_native = test_target.target.isNative() or
+            (test_target.target.getOsTag() == builtin.os.tag and
+            test_target.target.getCpuArch() == builtin.cpu.arch);
+
+        if (options.skip_non_native and !is_native)
             continue;
 
-        if (options.skip_cross_glibc and test_target.target.isGnuLibC() and test_target.link_libc)
+        if (options.skip_cross_glibc and test_target.target.isGnuLibC() and test_target.link_libc == true)
             continue;
 
-        if (options.skip_libc and test_target.link_libc)
+        if (options.skip_libc and test_target.link_libc == true)
             continue;
 
-        if (test_target.link_libc and test_target.target.getOs().requiresLibC()) {
-            // This would be a redundant test.
-            continue;
-        }
-
-        if (options.skip_single_threaded and test_target.single_threaded)
+        if (options.skip_single_threaded and test_target.single_threaded == true)
             continue;
 
-        if (test_target.disable_native and
-            test_target.target.getOsTag() == builtin.os.tag and
-            test_target.target.getCpuArch() == builtin.cpu.arch)
-        {
+        // TODO get compiler-rt tests passing for self-hosted backends.
+        if (test_target.use_llvm == false and mem.eql(u8, options.name, "compiler-rt"))
             continue;
-        }
 
-        if (test_target.backend) |backend| switch (backend) {
-            .stage1 => if (options.skip_stage1) continue,
-            .stage2_llvm => {},
-            else => if (options.skip_stage2) continue,
-        };
+        // TODO get universal-libc tests passing for self-hosted backends.
+        if (test_target.use_llvm == false and mem.eql(u8, options.name, "universal-libc"))
+            continue;
+
+        // TODO get std lib tests passing for self-hosted backends.
+        if (test_target.use_llvm == false and mem.eql(u8, options.name, "std"))
+            continue;
 
         const want_this_mode = for (options.optimize_modes) |m| {
             if (m == test_target.optimize_mode) break true;
         } else false;
         if (!want_this_mode) continue;
 
-        const libc_prefix = if (test_target.target.getOs().requiresLibC())
-            ""
-        else if (test_target.link_libc)
-            "c"
-        else
-            "bare";
-
-        const triple_prefix = test_target.target.zigTriple(b.allocator) catch @panic("OOM");
+        const libc_suffix = if (test_target.link_libc == true) "-libc" else "";
+        const triple_txt = test_target.target.zigTriple(b.allocator) catch @panic("OOM");
 
         // wasm32-wasi builds need more RAM, idk why
         const max_rss = if (test_target.target.getOs().tag == .wasi)
@@ -978,42 +970,33 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
             .target = test_target.target,
             .max_rss = max_rss,
             .filter = options.test_filter,
+            .link_libc = test_target.link_libc,
+            .single_threaded = test_target.single_threaded,
+            .use_llvm = test_target.use_llvm,
+            .use_lld = test_target.use_lld,
         });
-        const single_threaded_txt = if (test_target.single_threaded) "single" else "multi";
-        const backend_txt = if (test_target.backend) |backend| @tagName(backend) else "default";
-        these_tests.single_threaded = test_target.single_threaded;
-        if (test_target.link_libc) {
-            these_tests.linkSystemLibrary("c");
-        }
+        const single_threaded_suffix = if (test_target.single_threaded == true) "-single" else "";
+        const backend_suffix = if (test_target.use_llvm == true)
+            "-llvm"
+        else if (test_target.target.ofmt == std.Target.ObjectFormat.c)
+            "-cbe"
+        else if (test_target.use_llvm == false)
+            "-selfhosted"
+        else
+            "";
+
         these_tests.overrideZigLibDir("lib");
         these_tests.addIncludePath("test");
-        if (test_target.backend) |backend| switch (backend) {
-            .stage1 => {
-                @panic("stage1 testing requested");
-            },
-            .stage2_llvm => {
-                these_tests.use_llvm = true;
-            },
-            .stage2_c => {
-                these_tests.use_llvm = false;
-            },
-            else => {
-                these_tests.use_llvm = false;
-                // TODO: force self-hosted linkers to avoid LLD creeping in
-                // until the auto-select mechanism deems them worthy
-                these_tests.use_lld = false;
-            },
-        };
 
         const run = b.addRunArtifact(these_tests);
         run.skip_foreign_checks = true;
-        run.setName(b.fmt("run test {s}-{s}-{s}-{s}-{s}-{s}", .{
+        run.setName(b.fmt("run test {s}-{s}-{s}{s}{s}{s}", .{
             options.name,
-            triple_prefix,
+            triple_txt,
             @tagName(test_target.optimize_mode),
-            libc_prefix,
-            single_threaded_txt,
-            backend_txt,
+            libc_suffix,
+            single_threaded_suffix,
+            backend_suffix,
         }));
 
         step.dependOn(&run.step);

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1030,11 +1030,14 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
                     "-std=c99",
                     "-pedantic",
                     "-Werror",
-                    // TODO stop violating these pedantic errors
+                    // TODO stop violating these pedantic errors. spotted on linux
                     "-Wno-address-of-packed-member",
                     "-Wno-gnu-folding-constant",
                     "-Wno-incompatible-pointer-types",
                     "-Wno-overlength-strings",
+                    // TODO stop violating these pedantic errors. spotted on darwin
+                    "-Wno-dollar-in-identifier-extension",
+                    "-Wno-absolute-value",
                 },
             });
             compile_c.addIncludePath("lib"); // for zig.h

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -942,6 +942,14 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
         if (test_target.use_llvm == false and mem.eql(u8, options.name, "compiler-rt"))
             continue;
 
+        // TODO get the x86_64 self-hosted backend tests passing on Windows
+        if (test_target.target.getCpuArch() == .x86_64 and
+            test_target.target.getOsTag() == .windows and
+            test_target.use_llvm == false)
+        {
+            continue;
+        }
+
         // TODO get compiler-rt tests passing for wasm32-wasi
         // currently causes "LLVM ERROR: Unable to expand fixed point multiplication."
         if (test_target.target.getCpuArch() == .wasm32 and


### PR DESCRIPTION
* avoid skipping native tests
* actually run the C backend tests

With this I was able to make the C backend tests integrate cleanly with the build runner:

```
├─ run test behavior-native-Debug-libc-cbe 1567 passed 101 skipped 15ms MaxRSS:18M
│  └─ zig build-exe behavior-native-Debug-libc-cbe Debug native success 11s MaxRSS:647M
│     └─ zig test Debug native success 24s MaxRSS:181M
```