### PR TITLE
windows: detect ANSI support in more terminals

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -226,6 +226,13 @@ pub const File = struct {
     /// Test whether ANSI escape codes will be treated as such.
     pub fn supportsAnsiEscapeCodes(self: File) bool {
         if (builtin.os.tag == .windows) {
+            if (!os.isatty(self.handle)) return false;
+
+            var console_mode: os.windows.DWORD = 0;
+            if (os.windows.kernel32.GetConsoleMode(self.handle, &console_mode) != 0) {
+                if (console_mode & os.windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0) return true;
+            }
+
             return os.isCygwinPty(self.handle);
         }
         if (builtin.os.tag == .wasi) {

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -3151,6 +3151,8 @@ pub const CONSOLE_SCREEN_BUFFER_INFO = extern struct {
     dwMaximumWindowSize: COORD,
 };
 
+pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4;
+
 pub const FOREGROUND_BLUE = 1;
 pub const FOREGROUND_GREEN = 2;
 pub const FOREGROUND_RED = 4;


### PR DESCRIPTION
Checks if the underlying console supports ANSI escape sequences.

Resolves an issue where bold text would render as completely white in Windows Terminal, which was unreadable on a light background.