### PR TITLE
Sema: allow field access instructions to be emitted at comptime

### DIFF
--- a/lib/std/crypto/25519/ed25519.zig
+++ b/lib/std/crypto/25519/ed25519.zig
@@ -622,7 +622,7 @@ test "ed25519 test vectors" {
         },
     };
     for (entries) |entry| {
-        var msg: [64 / 2]u8 = undefined;
+        var msg: [entry.msg_hex.len / 2]u8 = undefined;
         _ = try fmt.hexToBytes(&msg, entry.msg_hex);
         var public_key_bytes: [32]u8 = undefined;
         _ = try fmt.hexToBytes(&public_key_bytes, entry.public_key_hex);

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -99,7 +99,7 @@ test "parse and render UNIX addresses" {
     const fmt_addr = std.fmt.bufPrint(buffer[0..], "{}", .{addr}) catch unreachable;
     try std.testing.expectEqualSlices(u8, "/tmp/testpath", fmt_addr);
 
-    const too_long = [_]u8{'a'} ** 200;
+    const too_long = [_]u8{'a'} ** (addr.un.path.len + 1);
     try testing.expectError(error.NameTooLong, net.Address.initUnix(too_long[0..]));
 }
 

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -365,6 +365,7 @@ const Writer = struct {
 
             .block,
             .block_comptime,
+            .block_comptime_defer_error,
             .block_inline,
             .suspend_block,
             .loop,

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -1409,12 +1409,30 @@ test "continue in inline for inside a comptime switch" {
 test "length of global array is determinable at comptime" {
     const S = struct {
         var bytes: [1024]u8 = undefined;
-
-        fn foo() !void {
-            try std.testing.expect(bytes.len == 1024);
-        }
     };
-    comptime try S.foo();
+    try std.testing.expect(comptime S.bytes.len == 1024);
+}
+
+test "length of array in global struct is determinable at comptime" {
+    const S = struct {
+        var g: struct { bytes: [1024]u8 } = undefined;
+    };
+    try std.testing.expect(comptime S.g.bytes.len == 1024);
+}
+
+test "length of array in global tuple is determinable at comptime" {
+    const S = struct {
+        var g: struct { [1024]u8 } = undefined;
+    };
+    try std.testing.expect(comptime S.g[0].len == 1024);
+    try std.testing.expect(comptime S.g.@"0".len == 1024);
+}
+
+test "length of array in global union is determinable at comptime" {
+    const S = struct {
+        var g: union { bytes: [1024]u8 } = undefined;
+    };
+    try std.testing.expect(comptime S.g.bytes.len == 1024);
 }
 
 test "continue nested inline for loop" {


### PR DESCRIPTION
Related to 34e4b07. This makes `struct.arr.len` succeed at comptime.

Resolves: #15280