### PR TITLE
fix: print targets

### DIFF
--- a/src/print_targets.zig
+++ b/src/print_targets.zig
@@ -99,8 +99,9 @@ pub fn cmdTargets(
         for (arch.allCpuModels()) |model| {
             try jws.objectField(model.name);
             try jws.beginArray();
-            for (arch.allFeaturesList(), 0..) |feature, i| {
-                if (model.features.isEnabled(@intCast(u8, i))) {
+            for (arch.allFeaturesList(), 0..) |feature, i_usize| {
+                const index = @intCast(Target.Cpu.Feature.Set.Index, i_usize);
+                if (model.features.isEnabled(index)) {
                     try jws.arrayElem();
                     try jws.emitString(feature.name);
                 }


### PR DESCRIPTION
Fix "zig targets" panic with integer cast truncated bits