### PR TITLE
separate different library directory types

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2549,7 +2549,7 @@ fn buildOutputType(
             framework_dirs.appendAssumeCapacity(framework_dir);
         }
 
-        for (paths.lib_dirs.items) |lib_dir| {
+        for (paths.extra_lib_dirs.items) |lib_dir| {
             try lib_dirs.append(lib_dir);
         }
         for (paths.rpaths.items) |rpath| {


### PR DESCRIPTION
fashionably late follow-up to #10621 which was reverted by #11265 without me noticing.

Separates non system library directories into `extra_lib_dirs` which is added to the rpath.
