### PR TITLE
HTTP client and server send "0\r\n\r\n" when chunked encoding

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -856,7 +856,7 @@ pub const Request = struct {
     /// Finish the body of a request. This notifies the server that you have no more data to send.
     pub fn finish(req: *Request) !void {
         switch (req.headers.transfer_encoding) {
-            .chunked => req.connection.data.conn.writeAll("0\r\n") catch |err| {
+            .chunked => req.connection.data.conn.writeAll("0\r\n\r\n") catch |err| {
                 req.client.last_error = .{ .write = err };
                 return error.WriteFailed;
             },

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -517,7 +517,7 @@ pub const Response = struct {
     /// Finish the body of a request. This notifies the server that you have no more data to send.
     pub fn finish(res: *Response) !void {
         switch (res.headers.transfer_encoding) {
-            .chunked => try res.connection.writeAll("0\r\n"),
+            .chunked => try res.connection.writeAll("0\r\n\r\n"),
             .content_length => |len| if (len != 0) return error.MessageNotCompleted,
             .none => {},
         }


### PR DESCRIPTION
Hi,

Thank you so much for wonderful project! I fixed the HTTP server when chunked encoding.

## Current problem

Here is `server.zig`
```zig
const std = @import("std");

pub fn main() !void {
    var server = std.http.Server.init(std.heap.page_allocator, .{ .reuse_address = true });
    defer server.deinit();

    try server.listen(try std.net.Address.parseIp("127.0.0.1", 8080));

    while (true) {
        const res = try server.accept(.{ .dynamic = 8192 });

        const thread = try std.Thread.spawn(.{}, handler, .{res});
        thread.detach();
    }
}

fn handler(res: *std.http.Server.Response) !void {
    defer res.reset();

    try res.wait();
    std.debug.print("requested: {}\n", .{res.request});
    // chunked transfer
    res.headers.transfer_encoding = .chunked;
    res.headers.connection = res.request.headers.connection;
    try res.do();
    _ = try res.write("Hello, World!\n");
    try res.finish();
}
```

```bash
zig run server.zig
```

Here is a client but error occurred.
```console
$ curl localhost:8080
Hello, World!
curl: (18) transfer closed with outstanding read data remaining
```

This PR fixes the problem.

## Reference
```txt
HTTP/1.1 200 OK
Content-Type: text/plain
Transfer-Encoding: chunked

7\r\n
Mozilla\r\n
11\r\n
Developer Network\r\n
0\r\n
\r\n
```
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding#chunked_encoding


```
chunked-body   = *chunk
                 last-chunk
                 trailer-part
                 CRLF  // <- This PR adds this one

last-chunk     = 1*("0") [ chunk-ext ] CRLF
```
https://datatracker.ietf.org/doc/html/rfc7230#section-4.1