### PR TITLE
Fix purely C/C++ compilations not using CacheMode.whole

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -780,7 +780,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
         // compiler state, the second clause here can be removed so that incremental
         // cache mode is used for LLVM backend too. We need some fuzz testing before
         // that can be enabled.
-        const cache_mode = if (use_llvm and !options.disable_lld_caching)
+        const cache_mode = if ((use_llvm or options.main_pkg == null) and !options.disable_lld_caching)
             CacheMode.whole
         else
             options.cache_mode;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1161,6 +1161,7 @@ fn buildOutputType(
                     } else if (mem.eql(u8, arg, "--debug-log")) {
                         if (!build_options.enable_logging) {
                             std.log.warn("Zig was compiled without logging enabled (-Dlog). --debug-log has no effect.", .{});
+                            _ = args_iter.nextOrFatal();
                         } else {
                             try log_scopes.append(gpa, args_iter.nextOrFatal());
                         }


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/15306.

In the case of no `main_pkg`, then `use_llvm` is false, which would cause the compilation to use the default caching mode (incremental). This was causing the cache to not be checked at all for the compilation.

Also fixed the argument to `--debug-log` being treated as a file argument when used with a release build. Discovered this one while testing this. This was causing the command to fail, instead of just printing a warning.