### PR TITLE
DynLib.lookup: cast the pointer to the correct alignment

### DIFF
--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -348,7 +348,7 @@ pub const WindowsDynLib = struct {
 
     pub fn lookup(self: *WindowsDynLib, comptime T: type, name: [:0]const u8) ?T {
         if (windows.kernel32.GetProcAddress(self.dll, name.ptr)) |addr| {
-            return @ptrCast(T, addr);
+            return @ptrCast(T, @alignCast(@alignOf(@typeInfo(T).Pointer.child), addr));
         } else {
             return null;
         }
@@ -382,7 +382,7 @@ pub const DlDynlib = struct {
         // dlsym (and other dl-functions) secretly take shadow parameter - return address on stack
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66826
         if (@call(.never_tail, system.dlsym, .{ self.handle, name.ptr })) |symbol| {
-            return @ptrCast(T, symbol);
+            return @ptrCast(T, @alignCast(@alignOf(@typeInfo(T).Pointer.child), symbol));
         } else {
             return null;
         }

--- a/test/standalone/load_dynamic_library/build.zig
+++ b/test/standalone/load_dynamic_library/build.zig
@@ -8,12 +8,7 @@ pub fn build(b: *std.Build) void {
     const optimize: std.builtin.OptimizeMode = .Debug;
     const target: std.zig.CrossTarget = .{};
 
-    const ok = (builtin.os.tag != .wasi and
-        // https://github.com/ziglang/zig/issues/13550
-        (builtin.os.tag != .macos or builtin.cpu.arch != .aarch64) and
-        // https://github.com/ziglang/zig/issues/13686
-        (builtin.os.tag != .windows or builtin.cpu.arch != .aarch64));
-    if (!ok) return;
+    if (builtin.os.tag == .wasi) return;
 
     const lib = b.addSharedLibrary(.{
         .name = "add",


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/15043, https://github.com/ziglang/zig/issues/13200, https://github.com/ziglang/zig/issues/13550, https://github.com/ziglang/zig/issues/13686.