### PR TITLE
math.big.int: remove stale comments

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -935,9 +935,6 @@ pub const Mutable = struct {
     /// The upper bound for r limb count is `b.limbs.len`.
     /// The upper bound for q limb count is given by `a.limbs`.
     ///
-    /// If `allocator` is provided, it will be used for temporary storage to improve
-    /// multiplication performance. `error.OutOfMemory` is handled with a fallback algorithm.
-    ///
     /// `limbs_buffer` is used for temporary storage. The amount required is given by `calcDivLimbsBufferLen`.
     pub fn divFloor(
         q: *Mutable,
@@ -1064,9 +1061,6 @@ pub const Mutable = struct {
     /// Asserts there is enough memory to store q and r.
     /// The upper bound for r limb count is `b.limbs.len`.
     /// The upper bound for q limb count is given by `a.limbs.len`.
-    ///
-    /// If `allocator` is provided, it will be used for temporary storage to improve
-    /// multiplication performance. `error.OutOfMemory` is handled with a fallback algorithm.
     ///
     /// `limbs_buffer` is used for temporary storage. The amount required is given by `calcDivLimbsBufferLen`.
     pub fn divTrunc(


### PR DESCRIPTION
This pull request removes the optional allocator argument from functions `divFloor` and `divTrunc`. As a result, the comments related to accepting an optional `allocator` are no longer applicable. The support for accepting an optional allocator was removed in #10017.