### PR TITLE
std.target.riscv: fix baseline_rv32 missing feature "32bit"

### DIFF
--- a/lib/std/target/riscv.zig
+++ b/lib/std/target/riscv.zig
@@ -748,6 +748,7 @@ pub const cpu = struct {
         .name = "baseline_rv32",
         .llvm_name = null,
         .features = featureSet(&[_]Feature{
+            .@"32bit",
             .a,
             .c,
             .d,

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -866,7 +866,7 @@ const llvm_targets = [_]LlvmTarget{
             .{
                 .llvm_name = null,
                 .zig_name = "baseline_rv32",
-                .features = &.{ "a", "c", "d", "f", "m" },
+                .features = &.{ "32bit", "a", "c", "d", "f", "m" },
             },
             .{
                 .llvm_name = null,


### PR DESCRIPTION
Fix #15301