### PR TITLE
New command: zig pkg hash

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4205,7 +4205,7 @@ pub fn cmdPkg(gpa: Allocator, arena: Allocator, args: []const []const u8) !void 
 
     if (mem.eql(u8, command_arg, "-h") or mem.eql(u8, command_arg, "--help")) {
         const stdout = io.getStdOut().writer();
-        try stdout.writeAll(usage_fmt);
+        try stdout.writeAll(usage_pkg);
         return cleanExit();
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -4228,9 +4228,10 @@ pub fn cmdPkg(gpa: Allocator, arena: Allocator, args: []const []const u8) !void 
 
     const hash = blk: {
         const cwd_absolute_path = try cwd.realpathAlloc(gpa, ".");
-        var cwd_copy = try fs.openIterableDirAbsolute(cwd_absolute_path, .{});
+        defer gpa.free(cwd_absolute_path);
 
         // computePackageHash will close the directory after completion
+        var cwd_copy = try fs.openIterableDirAbsolute(cwd_absolute_path, .{});
         errdefer cwd_copy.dir.close();
 
         var thread_pool: ThreadPool = undefined;


### PR DESCRIPTION
This PR implements a new package command `zig pkg hash` which output the package hash the current directory.
Although not directly described as a command to be implemented in #14288 I found it useful to have this command when implementing other package manager stuff, and can see a good use case for including this for user pre/post validating of uploads/downloads of packages later on.

The command will check if either build.zig or build.zig.zon is present or the override flag "--allow-directory" before starting to hash to limit accidental trying to hash a large directory structure by using the command at the wrong place.

It uses a crude directory exclusions of the most common directories not part of a package as #14311 is not implemented yet.