### PR TITLE
fix: fix cross compile to ARM926EJ-S is Broken (closes #15281)

### DIFF
--- a/lib/std/target/arm.zig
+++ b/lib/std/target/arm.zig
@@ -1861,7 +1861,7 @@ pub const cpu = struct {
         .name = "arm926ej_s",
         .llvm_name = "arm926ej-s",
         .features = featureSet(&[_]Feature{
-            .v5te,
+            .v5tej,
         }),
     };
     pub const arm940t = CpuModel{


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15936231/232001208-be05d26a-cee5-45c4-9a2e-e18f32641aa0.png)

arm926ej_s arch should be ARMv5TEJ according to wikipedia, and in our company, we have this chip, the readelf below shows what is the native executable attributes should be look like:

<img width="198" alt="75f7251fac33fdc61c674c867a98dc1" src="https://user-images.githubusercontent.com/15936231/232366335-8dc74a28-ff6d-423b-aefc-b257a7c68f32.png">

but when we use zig to crosscompile using `zig cc -o x main.c --target=arm-linux-gnueabi -mcpu=arm926ej_s` the result of readelf's Tag_CPU_arch is v5TE

I don't know this change is enough though, please let me know if I need change something else.

PS: i didn't test this myself because I cant compile zig_bootstrap due to ziglang/zig-bootstrap#148, this change is suggested by @nekopsykose in https://github.com/ziglang/zig/issues/15281#issuecomment-1509886354


closes #15281 
