### PR TITLE
coff: support allow_shlib_undefined with lld

### DIFF
--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -95,6 +95,7 @@ pub fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
         man.hash.add(self.base.options.tsaware);
         man.hash.add(self.base.options.nxcompat);
         man.hash.add(self.base.options.dynamicbase);
+        man.hash.addOptional(self.base.options.allow_shlib_undefined);
         // strip does not need to go into the linker hash because it is part of the hash namespace
         man.hash.addOptional(self.base.options.major_subsystem_version);
         man.hash.addOptional(self.base.options.minor_subsystem_version);
@@ -225,6 +226,11 @@ pub fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
         }
         if (!self.base.options.dynamicbase) {
             try argv.append("-dynamicbase:NO");
+        }
+        if (self.base.options.allow_shlib_undefined) |allow_shlib_undefined| {
+            if (allow_shlib_undefined) {
+                try argv.append("-FORCE:UNRESOLVED");
+            }
         }
 
         try argv.append(try allocPrint(arena, "-OUT:{s}", .{full_out_path}));


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/14718.

When `allow_shlib_undefined` is true, then `-FORCE:UNRESOLVED` is set on the `lld`command line.

Note that the [docs](https://learn.microsoft.com/en-us/cpp/build/reference/force-force-file-output?view=msvc-170) for `/FORCE:UNRESOLVED` don't explicitly state that this rule only applies to shared libraries. However, in order for linking to succeed, an import library (`.lib`) for the library specified in the `extern` definition still needs to be available to the linker. Because of this, the behavior should be consistent - only allow unresolved symbols when linking against shared libraries.

Example of this working:

```zig
const std = @import("std");

pub fn build(b: *std.Build) void {
    const target = b.standardTargetOptions(.{});
    const optimize = b.standardOptimizeOption(.{});

    const lib = b.addSharedLibrary(.{
        .name = "add-lib",
        .root_source_file = .{ .path = "src/lib.zig" },
        .target = target,
        .optimize = optimize,
    });

    lib.override_dest_dir = .bin;
    b.installArtifact(lib);

    const exe = b.addExecutable(.{
        .name = "unresolved",
        .root_source_file = .{ .path = "src/main.zig" },
        .target = target,
        .optimize = optimize,
    });

    // Just so the .lib will exist in zig-out/bin before the exe is built for the purposes of this example.
    // You wouldn't use linker_allow_shlib_undefined if you were also building `add-lib` here, you'd just link to it.
    exe.step.dependOn(&lib.step);

    // So the linker can find add-lib.lib
    exe.addLibraryPath("zig-out/bin");

    exe.linker_allow_shlib_undefined = true;
    b.installArtifact(exe);
}
```

main.zig
```zig
const std = @import("std");

extern "add-lib" fn add(a: i32, b: i32) i32;

pub fn main() !void {
    std.debug.print("add: {}\n", .{ add(5, 3) });
}
```

lib.zig
```zig
export fn add(a: i32, b: i32) i32 {
    return a + b;
}
```

Note that if the name of the library is omitted from the `extern` definition, then lld will emit a warning, but still link - the program will segfault when run (the linker doesn't know where the symbol comes from):

```
zig build-exe unresolved-test Debug native: error: warning(link): unexpected LLD stderr:
lld-link: warning: undefined symbol: add

Segmentation fault at address 0x7ff7478a0000
???:?:?: 0x7ff7478a0000 in ??? (???)
c:\cygwin64\home\kcbanner\kit\zig\build-stage3-debug\lib\zig\std\start.zig:396:41: 0x7ff7878a13aa in WinStartup (unresolved.exe.obj)
    std.debug.maybeEnableSegfaultHandler();
                                        ^
???:?:?: 0x0 in ??? (???)
```

I'm not sure what the behavior is here on other OSes, but the LLD warning should be enough to guide the user to their mistake.
