### PR TITLE
zig fmt: omit extra whitespace after last comment before EOF

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -18,6 +18,19 @@ test "zig fmt: transform old for loop syntax to new" {
     );
 }
 
+test "zig fmt: remove extra whitespace at start and end of file with comment between" {
+    try testTransform(
+        \\
+        \\
+        \\// hello
+        \\
+        \\
+    ,
+        \\// hello
+        \\
+    );
+}
+
 test "zig fmt: tuple struct" {
     try testCanonical(
         \\const T = struct {
@@ -511,17 +524,6 @@ test "zig fmt: remove empty lines at start/end of block" {
         \\    if (foo) {
         \\        foo();
         \\    }
-        \\}
-        \\
-    );
-}
-
-test "zig fmt: allow empty line before commment at start of block" {
-    try testCanonical(
-        \\test {
-        \\
-        \\    // foo
-        \\    const x = 42;
         \\}
         \\
     );

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2512,7 +2512,7 @@ const Space = enum {
     /// In either case, a newline will be inserted afterwards.
     semicolon,
     /// Skip rendering whitespace and comments. If this is used, the caller
-    /// *must* handle handle whitespace and comments manually.
+    /// *must* handle whitespace and comments manually.
     skip,
 };
 
@@ -2702,7 +2702,7 @@ fn renderIdentifierContents(writer: anytype, bytes: []const u8) !void {
                 }
             },
             0x00...('\\' - 1), ('\\' + 1)...0x7f => {
-                const buf = [1]u8{@intCast(u8, byte)};
+                const buf = [1]u8{byte};
                 try std.fmt.format(writer, "{}", .{std.zig.fmtEscapes(&buf)});
                 pos += 1;
             },
@@ -2782,7 +2782,7 @@ fn renderComments(ais: *Ais, tree: Ast, start: usize, end: usize) Error!bool {
         const comment_content = mem.trimLeft(u8, trimmed_comment["//".len..], &std.ascii.whitespace);
         if (ais.disabled_offset != null and mem.eql(u8, comment_content, "zig fmt: on")) {
             // Write the source for which formatting was disabled directly
-            // to the underlying writer, fixing up invaild whitespace.
+            // to the underlying writer, fixing up invalid whitespace.
             const disabled_source = tree.source[ais.disabled_offset.?..comment_start];
             try writeFixingWhitespace(ais.underlying_writer, disabled_source);
             // Write with the canonical single space.
@@ -2799,7 +2799,10 @@ fn renderComments(ais: *Ais, tree: Ast, start: usize, end: usize) Error!bool {
     }
 
     if (index != start and mem.containsAtLeast(u8, tree.source[index - 1 .. end], 2, "\n")) {
-        try ais.insertNewline();
+        // Don't leave any whitespace at the end of the file
+        if (end != tree.source.len) {
+            try ais.insertNewline();
+        }
     }
 
     return index != start;


### PR DESCRIPTION
Status quo canonical:
```zig
  1 test {}
  2
  3 //
  4
```
Now:
```zig
  1 test {}
  2
  3 //
```

