### PR TITLE
run 2 tests that previously failed due to an old LLVM 14 regression

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -316,12 +316,6 @@ pub fn zeroes(comptime T: type) T {
 }
 
 test "zeroes" {
-    if (builtin.zig_backend == .stage2_llvm) {
-        // Regressed in LLVM 14:
-        // https://github.com/llvm/llvm-project/issues/55522
-        return error.SkipZigTest;
-    }
-
     const C_struct = extern struct {
         x: u32,
         y: u32,

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -227,7 +227,7 @@ pub fn set(comptime T: type, dest: []T, value: T) void {
 /// interfacing with a C API where this practice is more common and relied upon. If you are performing code review and see this
 /// function used, examine closely - it may be a code smell.
 /// Zero initializes the type.
-/// This can be used to zero initialize a any type for which it makes sense. Structs will be initialized recursively.
+/// This can be used to zero initialize any type for which it makes sense. Structs will be initialized recursively.
 pub fn zeroes(comptime T: type) T {
     switch (@typeInfo(T)) {
         .ComptimeInt, .Int, .ComptimeFloat, .Float => {
@@ -255,7 +255,7 @@ pub fn zeroes(comptime T: type) T {
                 var structure: T = undefined;
                 inline for (struct_info.fields) |field| {
                     if (!field.is_comptime) {
-                        @field(structure, field.name) = zeroes(@TypeOf(@field(structure, field.name)));
+                        @field(structure, field.name) = zeroes(field.type);
                     }
                 }
                 return structure;
@@ -459,7 +459,7 @@ pub fn zeroInit(comptime T: type, init: anytype) T {
                                     @field(value, field.name) = std.mem.zeroInit(field.type, .{});
                                 },
                                 else => {
-                                    @field(value, field.name) = std.mem.zeroes(@TypeOf(@field(value, field.name)));
+                                    @field(value, field.name) = std.mem.zeroes(field.type);
                                 },
                             }
                         }

--- a/lib/std/simd.zig
+++ b/lib/std/simd.zig
@@ -421,12 +421,6 @@ test "vector prefix scan" {
         return error.SkipZigTest;
     }
 
-    if (builtin.zig_backend == .stage2_llvm) {
-        // Regressed in LLVM 14:
-        // https://github.com/llvm/llvm-project/issues/55522
-        return error.SkipZigTest;
-    }
-
     const int_base = @Vector(4, i32){ 11, 23, 9, -21 };
     const float_base = @Vector(4, f32){ 2, 0.5, -10, 6.54321 };
     const bool_base = @Vector(4, bool){ true, false, true, false };


### PR DESCRIPTION
These should now pass, and they did for me locally.