### PR TITLE
Add comment warning against using `page_allocator` with `GeneralPurposeAllocator`

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -222,6 +222,8 @@ fn rawCFree(
 
 /// This allocator makes a syscall directly for every allocation and free.
 /// Thread-safe and lock-free.
+///
+/// Using `page_allocator` with `GeneralPurposeAllocator` outside of WebAssembly is not recommended, as it causes detrimental performance issues in long-running programs.
 pub const page_allocator = if (builtin.target.isWasm())
     Allocator{
         .ptr = undefined,


### PR DESCRIPTION
`std.heap.page_allocator` + `GeneralPurposeAllocator` is a performance footgun

Relevant: https://github.com/zigtools/zls/issues/1128

`GeneralPurposeAllocator`, overall, is kind of a performance footgun. But especially when combined with `page_allocator`. In early versions of Bun it was something like a 3x performance improvement to parsing when switching from `GeneralPurposeAllocator` to `std.heap.c_allocator`

