### PR TITLE
llvm: emit metadata for exported global variables

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2555,7 +2555,7 @@ pub const DeclGen = struct {
                 );
 
                 try dg.object.di_map.put(dg.gpa, dg.decl, di_global.getVariable().toNode());
-                global.attachMetaData(di_global);
+                if (!is_internal_linkage) global.attachMetaData(di_global);
             }
         }
     }

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2544,7 +2544,7 @@ pub const DeclGen = struct {
 
                 const line_number = decl.src_line + 1;
                 const is_internal_linkage = !dg.module.decl_exports.contains(decl_index);
-                const di_global = dib.createGlobalVariable(
+                const di_global = dib.createGlobalVariableExpression(
                     di_file.toScope(),
                     decl.name,
                     global.getValueName(),
@@ -2554,7 +2554,8 @@ pub const DeclGen = struct {
                     is_internal_linkage,
                 );
 
-                try dg.object.di_map.put(dg.gpa, dg.decl, di_global.toNode());
+                try dg.object.di_map.put(dg.gpa, dg.decl, di_global.getVariable().toNode());
+                global.attachMetaData(di_global);
             }
         }
     }

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -256,6 +256,9 @@ pub const Value = opaque {
 
     pub const addByValAttr = ZigLLVMAddByValAttr;
     extern fn ZigLLVMAddByValAttr(Fn: *Value, ArgNo: c_uint, type: *Type) void;
+
+    pub const attachMetaData = ZigLLVMAttachMetaData;
+    extern fn ZigLLVMAttachMetaData(GlobalVar: *Value, DIG: *DIGlobalVariableExpression) void;
 };
 
 pub const Type = opaque {
@@ -1582,6 +1585,7 @@ pub const address_space = struct {
 pub const DIEnumerator = opaque {};
 pub const DILocalVariable = opaque {};
 pub const DILocation = opaque {};
+pub const DIGlobalExpression = opaque {};
 
 pub const DIGlobalVariable = opaque {
     pub const toNode = ZigLLVMGlobalVariableToNode;
@@ -1589,6 +1593,13 @@ pub const DIGlobalVariable = opaque {
 
     pub const replaceLinkageName = ZigLLVMGlobalVariableReplaceLinkageName;
     extern fn ZigLLVMGlobalVariableReplaceLinkageName(global_variable: *DIGlobalVariable, linkage_name: *MDString) void;
+};
+pub const DIGlobalVariableExpression = opaque {
+    pub const getVariable = ZigLLVMGlobalGetVariable;
+    extern fn ZigLLVMGlobalGetVariable(global_variable: *DIGlobalVariableExpression) *DIGlobalVariable;
+
+    pub const getExpression = ZigLLVMGlobalGetExpression;
+    extern fn ZigLLVMGlobalGetExpression(global_variable: *DIGlobalVariableExpression) *DIGlobalExpression;
 };
 pub const DIType = opaque {
     pub const toScope = ZigLLVMTypeToScope;
@@ -1797,8 +1808,8 @@ pub const DIBuilder = opaque {
         flags: c_uint,
     ) *DILocalVariable;
 
-    pub const createGlobalVariable = ZigLLVMCreateGlobalVariable;
-    extern fn ZigLLVMCreateGlobalVariable(
+    pub const createGlobalVariableExpression = ZigLLVMCreateGlobalVariableExpression;
+    extern fn ZigLLVMCreateGlobalVariableExpression(
         dib: *DIBuilder,
         scope: *DIScope,
         name: [*:0]const u8,
@@ -1807,7 +1818,7 @@ pub const DIBuilder = opaque {
         line_no: c_uint,
         di_type: *DIType,
         is_local_to_unit: bool,
-    ) *DIGlobalVariable;
+    ) *DIGlobalVariableExpression;
 
     pub const createParameterVariable = ZigLLVMCreateParameterVariable;
     extern fn ZigLLVMCreateParameterVariable(

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -874,19 +874,18 @@ ZigLLVMDILocalVariable *ZigLLVMCreateAutoVariable(ZigLLVMDIBuilder *dbuilder,
     return reinterpret_cast<ZigLLVMDILocalVariable*>(result);
 }
 
-ZigLLVMDIGlobalVariable *ZigLLVMCreateGlobalVariable(ZigLLVMDIBuilder *dbuilder,
+ZigLLVMDIGlobalVariableExpression *ZigLLVMCreateGlobalVariableExpression(ZigLLVMDIBuilder *dbuilder,
     ZigLLVMDIScope *scope, const char *name, const char *linkage_name, ZigLLVMDIFile *file,
     unsigned line_no, ZigLLVMDIType *di_type, bool is_local_to_unit)
 {
-    DIGlobalVariableExpression *result = reinterpret_cast<DIBuilder*>(dbuilder)->createGlobalVariableExpression(
+    return reinterpret_cast<ZigLLVMDIGlobalVariableExpression*>(reinterpret_cast<DIBuilder*>(dbuilder)->createGlobalVariableExpression(
         reinterpret_cast<DIScope*>(scope),
         name,
         linkage_name,
         reinterpret_cast<DIFile*>(file),
         line_no,
         reinterpret_cast<DIType*>(di_type),
-        is_local_to_unit);
-    return reinterpret_cast<ZigLLVMDIGlobalVariable*>(result->getVariable());
+        is_local_to_unit));
 }
 
 ZigLLVMDILocalVariable *ZigLLVMCreateParameterVariable(ZigLLVMDIBuilder *dbuilder,
@@ -1450,6 +1449,18 @@ LLVMValueRef ZigLLVMBuildFPMulReduce(LLVMBuilderRef B, LLVMValueRef Acc, LLVMVal
 
 void ZigLLVMTakeName(LLVMValueRef new_owner, LLVMValueRef victim) {
     unwrap(new_owner)->takeName(unwrap(victim));
+}
+
+ZigLLVMDIGlobalVariable* ZigLLVMGlobalGetVariable(ZigLLVMDIGlobalVariableExpression *global_variable_expression) {
+	return reinterpret_cast<ZigLLVMDIGlobalVariable*>(reinterpret_cast<DIGlobalVariableExpression*>(global_variable_expression)->getVariable());
+}
+
+ZigLLVMDIGlobalExpression* ZigLLVMGlobalGetExpression(ZigLLVMDIGlobalVariableExpression *global_variable_expression) {
+	return reinterpret_cast<ZigLLVMDIGlobalExpression*>(reinterpret_cast<DIGlobalVariableExpression*>(global_variable_expression)->getExpression());
+}
+
+void ZigLLVMAttachMetaData(LLVMValueRef Val, ZigLLVMDIGlobalVariableExpression *global_variable_expression) {
+	unwrap<GlobalVariable>(Val)->addDebugInfo(reinterpret_cast<DIGlobalVariableExpression*>(global_variable_expression));
 }
 
 static_assert((Triple::ArchType)ZigLLVM_UnknownArch == Triple::UnknownArch, "");

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -34,7 +34,9 @@ struct ZigLLVMDILexicalBlock;
 struct ZigLLVMDISubprogram;
 struct ZigLLVMDISubroutineType;
 struct ZigLLVMDILocalVariable;
+struct ZigLLVMDIGlobalVariableExpression;
 struct ZigLLVMDIGlobalVariable;
+struct ZigLLVMDIGlobalExpression;
 struct ZigLLVMDILocation;
 struct ZigLLVMDIEnumerator;
 struct ZigLLVMInsertionPoint;
@@ -271,7 +273,7 @@ ZIG_EXTERN_C struct ZigLLVMDILocalVariable *ZigLLVMCreateAutoVariable(struct Zig
         struct ZigLLVMDIScope *scope, const char *name, struct ZigLLVMDIFile *file, unsigned line_no,
         struct ZigLLVMDIType *type, bool always_preserve, unsigned flags);
 
-ZIG_EXTERN_C struct ZigLLVMDIGlobalVariable *ZigLLVMCreateGlobalVariable(struct ZigLLVMDIBuilder *dbuilder,
+ZIG_EXTERN_C struct ZigLLVMDIGlobalVariableExpression *ZigLLVMCreateGlobalVariableExpression(struct ZigLLVMDIBuilder *dbuilder,
     struct ZigLLVMDIScope *scope, const char *name, const char *linkage_name, struct ZigLLVMDIFile *file,
     unsigned line_no, struct ZigLLVMDIType *di_type, bool is_local_to_unit);
 
@@ -333,6 +335,10 @@ ZIG_EXTERN_C void ZigLLVMAddFunctionElemTypeAttr(LLVMValueRef fn_ref, size_t arg
 ZIG_EXTERN_C void ZigLLVMAddFunctionAttrCold(LLVMValueRef fn);
 
 ZIG_EXTERN_C void ZigLLVMParseCommandLineOptions(size_t argc, const char *const *argv);
+
+ZIG_EXTERN_C ZigLLVMDIGlobalVariable* ZigLLVMGlobalGetVariable(ZigLLVMDIGlobalVariableExpression *global_variable_expression);
+ZIG_EXTERN_C ZigLLVMDIGlobalExpression* ZigLLVMGlobalGetExpression(ZigLLVMDIGlobalVariableExpression *global_variable_expression);
+ZIG_EXTERN_C void ZigLLVMAttachMetaData(LLVMValueRef Val, ZigLLVMDIGlobalVariableExpression *global_variable_expression);
 
 
 // synchronize with llvm/include/ADT/Triple.h::ArchType


### PR DESCRIPTION
One use case is to genearte BTF information from global variable's metadata.