### PR TITLE
Fix generating COFF debug info on -gnu

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4474,7 +4474,11 @@ pub fn addCCArgs(
 
     if (!comp.bin_file.options.strip) {
         switch (target.ofmt) {
-            .coff => try argv.append("-gcodeview"),
+            .coff => {
+                // -g is required here because -gcodeview doesn't trigger debug info
+                // generation, it only changes the type of information generated.
+                try argv.appendSlice(&.{ "-g", "-gcodeview" });
+            },
             .elf, .macho => try argv.append("-gdwarf-4"),
             else => try argv.append("-g"),
         }


### PR DESCRIPTION
The issue with just passing `-gcodeview` is that it's not part of the `OPT_g_Group` in `clang/Driver/Options.td`, so it doesn't trigger debug info to be generated.

```
  // Clang.cpp#4124

  if (const Arg *A = Args.getLastArg(options::OPT_g_Group)) {
    DebugInfoKind = codegenoptions::DebugInfoConstructor;
```


Passing only `-g` is sufficient on MSVC, as there is logic in `Clang.cpp` which enables codeview if that is the default for the toolchain. Since the default for -gnu is not codeview, we have to pass `-gcodeview` in that case.

```
  // Clang.cpp#4169

  // If the user asked for debug info but did not explicitly specify -gcodeview
  // or -gdwarf, ask the toolchain for the default format.
  if (!EmitCodeView && !EmitDwarf &&
      DebugInfoKind != codegenoptions::NoDebugInfo) {
    switch (TC.getDefaultDebugFormat()) {
    case codegenoptions::DIF_CodeView:
      EmitCodeView = true;
      break;
    case codegenoptions::DIF_DWARF:
      EmitDwarf = true;
      break;
    }
  }
```

Combined with https://github.com/ziglang/zig/pull/15348, C stack traces will be functional on Windows.