### PR TITLE
sema: fix memory corruption caused by resolveStructLayout

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -30369,14 +30369,7 @@ fn resolveStructLayout(sema: *Sema, ty: Type) CompileError!void {
         }
 
         if (struct_obj.layout == .Auto and sema.mod.backendSupportsFeature(.field_reordering)) {
-            const optimized_order = blk: {
-                const decl = sema.mod.declPtr(struct_obj.owner_decl);
-                var decl_arena = decl.value_arena.?.promote(sema.mod.gpa);
-                defer decl.value_arena.?.* = decl_arena.state;
-                const decl_arena_allocator = decl_arena.allocator();
-
-                break :blk try decl_arena_allocator.alloc(u32, struct_obj.fields.count());
-            };
+            const optimized_order = try sema.perm_arena.alloc(u32, struct_obj.fields.count());
 
             for (struct_obj.fields.values(), 0..) |field, i| {
                 optimized_order[i] = if (field.ty.hasRuntimeBits())

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -30369,7 +30369,16 @@ fn resolveStructLayout(sema: *Sema, ty: Type) CompileError!void {
         }
 
         if (struct_obj.layout == .Auto and sema.mod.backendSupportsFeature(.field_reordering)) {
-            const optimized_order = try sema.perm_arena.alloc(u32, struct_obj.fields.count());
+            const optimized_order = if (struct_obj.owner_decl == sema.owner_decl_index)
+                try sema.perm_arena.alloc(u32, struct_obj.fields.count())
+            else blk: {
+                const decl = sema.mod.declPtr(struct_obj.owner_decl);
+                var decl_arena = decl.value_arena.?.promote(sema.mod.gpa);
+                defer decl.value_arena.?.* = decl_arena.state;
+                const decl_arena_allocator = decl_arena.allocator();
+
+                break :blk try decl_arena_allocator.alloc(u32, struct_obj.fields.count());
+            };
 
             for (struct_obj.fields.values(), 0..) |field, i| {
                 optimized_order[i] = if (field.ty.hasRuntimeBits())

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -1060,7 +1060,7 @@ pub fn getDeclVAddr(
         .offset = reloc_info.offset,
         .addend = reloc_info.addend,
     });
-    return undefined;
+    return 0;
 }
 
 pub fn getDeclBlock(self: *const Plan9, index: DeclBlock.Index) DeclBlock {


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/15219.

The reported crash was a panic due to incorrect alignment. Upon inspection, the misaligned pointer (`hash_map` metadata pointer) had a value of `0x02`.

The story of how 0x02 ends up there is as follows:

```
[0x0]   zig!weak.memset.default._alloca + 0xd4   
[0x1]   zig!allocAdvancedWithRetAddr__anon_51974 + 0x261   
[0x2]   zig!alloc__anon_6263 + 0x56   
[0x3]   zig!resolveStructLayout + 0xbbf   
[0x4]   zig!resolveTypeLayout + 0xa3   
[0x5]   zig!typeAbiSize + 0x54   
[0x6]   zig!intFitsInType + 0x650   
[0x7]   zig!coerceExtra + 0x67b4   
[0x8]   zig!coerce + 0x6e   
[0x9]   zig!semaStructFields + 0x5241  < analyzing `S`
```

In order to determine the value of the `.lazy_size` payload of `size`, the struct layout has to be resolved. The problem is that `resolveStructLayout` is promoting the decl's `value_arena`, but since we're still inside the call to `semaStructFields`, all the allocations that have happened in that function so far are on it's local `arena_allocator` and the state hasn't yet been written back to the decl.

When the `decl_arena` is promoted from the stale `decl.value_arena` state, the allocation for `optimized_order` ends up overlapping the same memory as `wip_captures.scope.captures.metadata`. Specifically, the write of `0x02` into `optimized_order[2]`.

So, by the time finalize happens the pointer contains garbage and the deinit crashes.

I'm not that familiar with sema, but I think this is the correct fix - use the `perm_arena` from the `sema` instance (which exists back on the stack of `semaStructFields`.


