### PR TITLE
std.http: add missing InvalidTrailers to ReadError

### DIFF
--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -501,7 +501,7 @@ pub const Response = struct {
         }
     }
 
-    pub const ReadError = TransferReadError || proto.HeadersParser.CheckCompleteHeadError || error{DecompressionFailure};
+    pub const ReadError = TransferReadError || proto.HeadersParser.CheckCompleteHeadError || error{ DecompressionFailure, InvalidTrailers };
 
     pub const Reader = std.io.Reader(*Response, ReadError, read);
 


### PR DESCRIPTION
Hi,

The following code has a build error.
```zig
const std = @import("std");

pub fn main() !void {
    var res: std.http.Server.Response = undefined;
    var buf: [16]u8 = undefined;
    _ = try res.read(&buf);
}
```

Here is the build error.
```
/Users/ryo/ws/zig/zig/build/stage3/lib/zig/std/http/Server.zig:535:93: error: expected type 'error{ConnectionResetByPeer,ConnectionTimedOut,DecompressionFailure,EndOfStream,HttpChunkInvalid,HttpHeadersExceededSizeLimit,OutOfMemory,UnexpectedReadFailure}', found type 'error{InvalidTrailers}'
                res.request.parse(res.request.parser.header_bytes.items) catch return error.InvalidTrailers;
```

This PR fixes this.

zig version is:
0.11.0-dev.2680+a1aa55ebe