### PR TITLE
Sema: allow ptr field access on pointer-to-array

### DIFF
--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -677,3 +677,13 @@ test "array of array agregate init" {
     var b = [1][10]u32{a} ** 2;
     try std.testing.expect(b[1][1] == 11);
 }
+
+test "pointer to array has ptr field" {
+    const arr: *const [5]u32 = &.{ 10, 20, 30, 40, 50 };
+    try std.testing.expect(arr.ptr == @as([*]const u32, arr));
+    try std.testing.expect(arr.ptr[0] == 10);
+    try std.testing.expect(arr.ptr[1] == 20);
+    try std.testing.expect(arr.ptr[2] == 30);
+    try std.testing.expect(arr.ptr[3] == 40);
+    try std.testing.expect(arr.ptr[4] == 50);
+}

--- a/test/cases/compile_errors/len_access_on_array_many_ptr.zig
+++ b/test/cases/compile_errors/len_access_on_array_many_ptr.zig
@@ -1,0 +1,10 @@
+export fn foo() void {
+    const x: [*][5]u8 = undefined;
+    _ = x.len;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:10: error: type '[*][5]u8' does not support field access


### PR DESCRIPTION
Also remove an incorrect piece of logic which allowed fetching the 'len' property on non-single-ptrs (e.g. many-ptrs) and add a corresponding compile error test case.

Resolves: #4765