### PR TITLE
link: make GOT (and other synthetic sections) handling common across linkers

### DIFF
--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -4290,6 +4290,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
             if (self.bin_file.cast(link.File.Elf)) |elf_file| {
                 const atom_index = try elf_file.getOrCreateAtomForDecl(func.owner_decl);
                 const atom = elf_file.getAtom(atom_index);
+                _ = try atom.getOrCreateOffsetTableEntry(elf_file);
                 const got_addr = @intCast(u32, atom.getOffsetTableAddress(elf_file));
                 try self.genSetReg(Type.initTag(.usize), .x30, .{ .memory = got_addr });
             } else if (self.bin_file.cast(link.File.MachO)) |macho_file| {

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -4270,6 +4270,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
             if (self.bin_file.cast(link.File.Elf)) |elf_file| {
                 const atom_index = try elf_file.getOrCreateAtomForDecl(func.owner_decl);
                 const atom = elf_file.getAtom(atom_index);
+                _ = try atom.getOrCreateOffsetTableEntry(elf_file);
                 const got_addr = @intCast(u32, atom.getOffsetTableAddress(elf_file));
                 try self.genSetReg(Type.initTag(.usize), .lr, .{ .memory = got_addr });
             } else if (self.bin_file.cast(link.File.MachO)) |_| {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1734,6 +1734,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
                 const func = func_payload.data;
                 const atom_index = try elf_file.getOrCreateAtomForDecl(func.owner_decl);
                 const atom = elf_file.getAtom(atom_index);
+                _ = try atom.getOrCreateOffsetTableEntry(elf_file);
                 const got_addr = @intCast(u32, atom.getOffsetTableAddress(elf_file));
                 try self.genSetReg(Type.initTag(.usize), .ra, .{ .memory = got_addr });
                 _ = try self.addInst(.{

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -1254,6 +1254,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
                 const got_addr = if (self.bin_file.cast(link.File.Elf)) |elf_file| blk: {
                     const atom_index = try elf_file.getOrCreateAtomForDecl(func.owner_decl);
                     const atom = elf_file.getAtom(atom_index);
+                    _ = try atom.getOrCreateOffsetTableEntry(elf_file);
                     break :blk @intCast(u32, atom.getOffsetTableAddress(elf_file));
                 } else unreachable;
 

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -5624,7 +5624,9 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
 
             if (self.bin_file.cast(link.File.Elf)) |elf_file| {
                 const atom_index = try elf_file.getOrCreateAtomForDecl(func.owner_decl);
-                const got_addr = elf_file.getAtom(atom_index).getOffsetTableAddress(elf_file);
+                const atom = elf_file.getAtom(atom_index);
+                _ = try atom.getOrCreateOffsetTableEntry(elf_file);
+                const got_addr = atom.getOffsetTableAddress(elf_file);
                 try self.asmMemory(.call, Memory.sib(.qword, .{
                     .base = .ds,
                     .disp = @intCast(i32, got_addr),
@@ -5853,7 +5855,9 @@ fn airCmpLtErrorsLen(self: *Self, inst: Air.Inst.Index) !void {
             .{ .kind = .const_data, .ty = Type.anyerror },
             4, // dword alignment
         );
-        const got_addr = elf_file.getAtom(atom_index).getOffsetTableAddress(elf_file);
+        const atom = elf_file.getAtom(atom_index);
+        _ = try atom.getOrCreateOffsetTableEntry(elf_file);
+        const got_addr = atom.getOffsetTableAddress(elf_file);
         try self.asmRegisterMemory(.mov, addr_reg.to64(), Memory.sib(.qword, .{
             .base = .ds,
             .disp = @intCast(i32, got_addr),
@@ -8230,7 +8234,9 @@ fn airErrorName(self: *Self, inst: Air.Inst.Index) !void {
             .{ .kind = .const_data, .ty = Type.anyerror },
             4, // dword alignment
         );
-        const got_addr = elf_file.getAtom(atom_index).getOffsetTableAddress(elf_file);
+        const atom = elf_file.getAtom(atom_index);
+        _ = try atom.getOrCreateOffsetTableEntry(elf_file);
+        const got_addr = atom.getOffsetTableAddress(elf_file);
         try self.asmRegisterMemory(.mov, addr_reg.to64(), Memory.sib(.qword, .{
             .base = .ds,
             .disp = @intCast(i32, got_addr),

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -7578,7 +7578,7 @@ fn genSetReg(self: *Self, ty: Type, reg: Register, mcv: MCValue) InnerError!void
             const atom_index = try self.getSymbolIndexForDecl(self.mod_fn.owner_decl);
             if (self.bin_file.cast(link.File.MachO)) |_| {
                 _ = try self.addInst(.{
-                    .tag = .mov_linker,
+                    .tag = .lea_linker,
                     .ops = .tlv_reloc,
                     .data = .{ .payload = try self.addExtra(Mir.LeaRegisterReloc{
                         .reg = @enumToInt(Register.rdi),

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1006,6 +1006,7 @@ fn genDeclRef(
     if (bin_file.cast(link.File.Elf)) |elf_file| {
         const atom_index = try elf_file.getOrCreateAtomForDecl(decl_index);
         const atom = elf_file.getAtom(atom_index);
+        _ = try atom.getOrCreateOffsetTableEntry(elf_file);
         return GenResult.mcv(.{ .memory = atom.getOffsetTableAddress(elf_file) });
     } else if (bin_file.cast(link.File.MachO)) |macho_file| {
         const atom_index = try macho_file.getOrCreateAtomForDecl(decl_index);

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -697,6 +697,7 @@ fn addGotEntry(self: *Coff, target: SymbolWithLoc) !void {
     const got_index = try self.got_table.allocateEntry(self.base.allocator, target);
     try self.writeOffsetTableEntry(got_index);
     self.got_table_count_dirty = true;
+    self.markRelocsDirtyByTarget(target);
 }
 
 pub fn createAtom(self: *Coff) !Atom.Index {
@@ -1341,6 +1342,7 @@ fn updateDeclCode(self: *Coff, decl_index: Module.Decl.Index, code: []u8, comple
                 log.debug("  (updating GOT entry)", .{});
                 const got_entry_index = self.got_table.lookup.get(.{ .sym_index = sym_index }).?;
                 try self.writeOffsetTableEntry(got_entry_index);
+                self.markRelocsDirtyByTarget(.{ .sym_index = sym_index });
             }
         } else if (code_len < atom.size) {
             self.shrinkAtom(atom_index, code_len);

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -492,8 +492,8 @@ fn growSection(self: *Coff, sect_id: u32, needed_size: u32) !void {
 
     const sect_vm_capacity = self.allocatedVirtualSize(header.virtual_address);
     if (needed_size > sect_vm_capacity) {
-        try self.growSectionVirtualMemory(sect_id, needed_size);
         self.markRelocsDirtyByAddress(header.virtual_address + needed_size);
+        try self.growSectionVirtualMemory(sect_id, needed_size);
     }
 
     header.virtual_size = @max(header.virtual_size, needed_size);

--- a/src/link/Coff/Relocation.zig
+++ b/src/link/Coff/Relocation.zig
@@ -73,7 +73,8 @@ pub fn getTargetAddress(self: Relocation, coff_file: *const Coff) ?u32 {
 
 /// Returns true if and only if the reloc is dirty AND the target address is available.
 pub fn isResolvable(self: Relocation, coff_file: *Coff) bool {
-    _ = self.getTargetAddress(coff_file) orelse return false;
+    const addr = self.getTargetAddress(coff_file) orelse return false;
+    if (addr == 0) return false;
     return self.dirty;
 }
 

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -63,6 +63,88 @@ const Section = struct {
     free_list: std.ArrayListUnmanaged(Atom.Index) = .{},
 };
 
+const SectionTable = struct {
+    entries: std.ArrayListUnmanaged(SymIndex) = .{},
+    free_list: std.ArrayListUnmanaged(Index) = .{},
+    lookup: std.AutoHashMapUnmanaged(SymIndex, Index) = .{},
+
+    const SymIndex = u32;
+    const Index = u32;
+
+    pub fn deinit(st: *ST, allocator: Allocator) void {
+        st.entries.deinit(allocator);
+        st.free_list.deinit(allocator);
+        st.lookup.deinit(allocator);
+    }
+
+    pub fn allocateEntry(st: *ST, allocator: Allocator, target: SymIndex) !Index {
+        try st.entries.ensureUnusedCapacity(allocator, 1);
+        const index = blk: {
+            if (st.free_list.popOrNull()) |index| {
+                log.debug("  (reusing entry index {d})", .{index});
+                break :blk index;
+            } else {
+                log.debug("  (allocating entry at index {d})", .{st.entries.items.len});
+                const index = @intCast(u32, st.entries.items.len);
+                _ = st.entries.addOneAssumeCapacity();
+                break :blk index;
+            }
+        };
+        st.entries.items[index] = target;
+        try st.lookup.putNoClobber(allocator, target, index);
+        return index;
+    }
+
+    pub fn freeEntry(st: *ST, allocator: Allocator, target: SymIndex) void {
+        const index = st.lookup.get(target) orelse return;
+        st.free_list.append(allocator, index) catch {};
+        st.entries.items[index] = 0;
+        _ = st.lookup.remove(target);
+    }
+
+    const FormatContext = struct {
+        ctx: *Elf,
+        st: *const ST,
+    };
+
+    fn fmt(
+        ctx: FormatContext,
+        comptime unused_format_string: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) @TypeOf(writer).Error!void {
+        _ = options;
+        comptime assert(unused_format_string.len == 0);
+
+        const base_addr = ctx.ctx.program_headers.items[ctx.ctx.phdr_got_index.?].p_vaddr;
+        const target = ctx.ctx.base.options.target;
+        const ptr_bits = target.cpu.arch.ptrBitWidth();
+        const ptr_bytes: u64 = @divExact(ptr_bits, 8);
+
+        try writer.writeAll("SectionTable:\n");
+        for (ctx.st.entries.items, 0..) |entry, i| {
+            try writer.print("  {d}@{x} => local(%{d})\n", .{ i, base_addr + i * ptr_bytes, entry });
+        }
+    }
+
+    fn format(st: ST, comptime unused_format_string: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
+        _ = st;
+        _ = unused_format_string;
+        _ = options;
+        _ = writer;
+        @compileError("do not format SectionTable directly; use st.fmtDebug()");
+    }
+
+    pub fn fmtDebug(st: ST, ctx: *Elf) std.fmt.Formatter(fmt) {
+        return .{ .data = .{
+            .ctx = ctx,
+            .st = st,
+        } };
+    }
+
+    const ST = @This();
+};
+
 const LazySymbolMetadata = struct {
     text_atom: ?Atom.Index = null,
     rodata_atom: ?Atom.Index = null,
@@ -148,17 +230,13 @@ global_symbols: std.ArrayListUnmanaged(elf.Elf64_Sym) = .{},
 
 local_symbol_free_list: std.ArrayListUnmanaged(u32) = .{},
 global_symbol_free_list: std.ArrayListUnmanaged(u32) = .{},
-offset_table_free_list: std.ArrayListUnmanaged(u32) = .{},
 
-/// Same order as in the file. The value is the absolute vaddr value.
-/// If the vaddr of the executable program header changes, the entire
-/// offset table needs to be rewritten.
-offset_table: std.ArrayListUnmanaged(u64) = .{},
+got_table: SectionTable = .{},
 
 phdr_table_dirty: bool = false,
 shdr_table_dirty: bool = false,
 shstrtab_dirty: bool = false,
-offset_table_count_dirty: bool = false,
+got_table_count_dirty: bool = false,
 
 debug_strtab_dirty: bool = false,
 debug_abbrev_section_dirty: bool = false,
@@ -329,8 +407,7 @@ pub fn deinit(self: *Elf) void {
     self.global_symbols.deinit(gpa);
     self.global_symbol_free_list.deinit(gpa);
     self.local_symbol_free_list.deinit(gpa);
-    self.offset_table_free_list.deinit(gpa);
-    self.offset_table.deinit(gpa);
+    self.got_table.deinit(gpa);
 
     {
         var it = self.decls.iterator();
@@ -1289,6 +1366,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
     assert(!self.shdr_table_dirty);
     assert(!self.shstrtab_dirty);
     assert(!self.debug_strtab_dirty);
+    assert(!self.got_table_count_dirty);
 }
 
 fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !void {
@@ -2168,7 +2246,7 @@ fn freeAtom(self: *Elf, atom_index: Atom.Index) void {
     _ = self.atom_by_index_table.remove(local_sym_index);
     self.getAtomPtr(atom_index).local_sym_index = 0;
 
-    self.offset_table_free_list.append(self.base.allocator, atom.offset_table_index) catch {};
+    self.got_table.freeEntry(gpa, local_sym_index);
 }
 
 fn shrinkAtom(self: *Elf, atom_index: Atom.Index, new_block_size: u64) void {
@@ -2191,11 +2269,9 @@ pub fn createAtom(self: *Elf) !Atom.Index {
     const atom_index = @intCast(Atom.Index, self.atoms.items.len);
     const atom = try self.atoms.addOne(gpa);
     const local_sym_index = try self.allocateLocalSymbol();
-    const offset_table_index = try self.allocateGotOffset();
     try self.atom_by_index_table.putNoClobber(gpa, local_sym_index, atom_index);
     atom.* = .{
         .local_sym_index = local_sym_index,
-        .offset_table_index = offset_table_index,
         .prev_index = null,
         .next_index = null,
     };
@@ -2352,26 +2428,6 @@ pub fn allocateLocalSymbol(self: *Elf) !u32 {
     return index;
 }
 
-pub fn allocateGotOffset(self: *Elf) !u32 {
-    try self.offset_table.ensureUnusedCapacity(self.base.allocator, 1);
-
-    const index = blk: {
-        if (self.offset_table_free_list.popOrNull()) |index| {
-            log.debug("  (reusing GOT offset at index {d})", .{index});
-            break :blk index;
-        } else {
-            log.debug("  (allocating GOT offset at index {d})", .{self.offset_table.items.len});
-            const index = @intCast(u32, self.offset_table.items.len);
-            _ = self.offset_table.addOneAssumeCapacity();
-            self.offset_table_count_dirty = true;
-            break :blk index;
-        }
-    };
-
-    self.offset_table.items[index] = 0;
-    return index;
-}
-
 fn freeUnnamedConsts(self: *Elf, decl_index: Module.Decl.Index) void {
     const unnamed_consts = self.unnamed_const_atoms.getPtr(decl_index) orelse return;
     for (unnamed_consts.items) |atom| {
@@ -2465,6 +2521,7 @@ fn updateDeclCode(self: *Elf, decl_index: Module.Decl.Index, code: []const u8, s
     const decl_metadata = self.decls.get(decl_index).?;
     const atom_index = decl_metadata.atom;
     const atom = self.getAtom(atom_index);
+    const local_sym_index = atom.getSymbolIndex().?;
 
     const shdr_index = decl_metadata.shdr;
     if (atom.getSymbol(self).st_size != 0 and self.base.child_pid == null) {
@@ -2485,8 +2542,9 @@ fn updateDeclCode(self: *Elf, decl_index: Module.Decl.Index, code: []const u8, s
                 local_sym.st_value = vaddr;
 
                 log.debug("  (writing new offset table entry)", .{});
-                self.offset_table.items[atom.offset_table_index] = vaddr;
-                try self.writeOffsetTableEntry(atom.offset_table_index);
+                const got_entry_index = self.got_table.lookup.get(local_sym_index).?;
+                self.got_table.entries.items[got_entry_index] = local_sym_index;
+                try self.writeOffsetTableEntry(got_entry_index);
             }
         } else if (code.len < local_sym.st_size) {
             self.shrinkAtom(atom_index, code.len);
@@ -2494,7 +2552,7 @@ fn updateDeclCode(self: *Elf, decl_index: Module.Decl.Index, code: []const u8, s
         local_sym.st_size = code.len;
 
         // TODO this write could be avoided if no fields of the symbol were changed.
-        try self.writeSymbol(atom.getSymbolIndex().?);
+        try self.writeSymbol(local_sym_index);
     } else {
         const local_sym = atom.getSymbolPtr(self);
         local_sym.* = .{
@@ -2509,12 +2567,12 @@ fn updateDeclCode(self: *Elf, decl_index: Module.Decl.Index, code: []const u8, s
         errdefer self.freeAtom(atom_index);
         log.debug("allocated text block for {s} at 0x{x}", .{ decl_name, vaddr });
 
-        self.offset_table.items[atom.offset_table_index] = vaddr;
         local_sym.st_value = vaddr;
         local_sym.st_size = code.len;
 
-        try self.writeSymbol(atom.getSymbolIndex().?);
-        try self.writeOffsetTableEntry(atom.offset_table_index);
+        try self.writeSymbol(local_sym_index);
+        const got_entry_index = try atom.getOrCreateOffsetTableEntry(self);
+        try self.writeOffsetTableEntry(got_entry_index);
     }
 
     const local_sym = atom.getSymbolPtr(self);
@@ -2755,12 +2813,12 @@ fn updateLazySymbolAtom(
     errdefer self.freeAtom(atom_index);
     log.debug("allocated text block for {s} at 0x{x}", .{ name, vaddr });
 
-    self.offset_table.items[atom.offset_table_index] = vaddr;
     local_sym.st_value = vaddr;
     local_sym.st_size = code.len;
 
     try self.writeSymbol(local_sym_index);
-    try self.writeOffsetTableEntry(atom.offset_table_index);
+    const got_entry_index = try atom.getOrCreateOffsetTableEntry(self);
+    try self.writeOffsetTableEntry(got_entry_index);
 
     const section_offset = vaddr - self.program_headers.items[phdr_index].p_vaddr;
     const file_offset = self.sections.items(.shdr)[shdr_index].sh_offset + section_offset;
@@ -2991,30 +3049,32 @@ fn writeSectHeader(self: *Elf, index: usize) !void {
 
 fn writeOffsetTableEntry(self: *Elf, index: usize) !void {
     const entry_size: u16 = self.archPtrWidthBytes();
-    if (self.offset_table_count_dirty) {
-        const needed_size = self.offset_table.items.len * entry_size;
+    if (self.got_table_count_dirty) {
+        const needed_size = self.got_table.entries.items.len * entry_size;
         try self.growAllocSection(self.got_section_index.?, needed_size);
-        self.offset_table_count_dirty = false;
+        self.got_table_count_dirty = false;
     }
     const endian = self.base.options.target.cpu.arch.endian();
     const shdr = &self.sections.items(.shdr)[self.got_section_index.?];
     const off = shdr.sh_offset + @as(u64, entry_size) * index;
     const phdr = &self.program_headers.items[self.phdr_got_index.?];
     const vaddr = phdr.p_vaddr + @as(u64, entry_size) * index;
+    const got_entry = self.got_table.entries.items[index];
+    const got_value = self.getSymbol(got_entry).st_value;
     switch (entry_size) {
         2 => {
             var buf: [2]u8 = undefined;
-            mem.writeInt(u16, &buf, @intCast(u16, self.offset_table.items[index]), endian);
+            mem.writeInt(u16, &buf, @intCast(u16, got_value), endian);
             try self.base.file.?.pwriteAll(&buf, off);
         },
         4 => {
             var buf: [4]u8 = undefined;
-            mem.writeInt(u32, &buf, @intCast(u32, self.offset_table.items[index]), endian);
+            mem.writeInt(u32, &buf, @intCast(u32, got_value), endian);
             try self.base.file.?.pwriteAll(&buf, off);
         },
         8 => {
             var buf: [8]u8 = undefined;
-            mem.writeInt(u64, &buf, self.offset_table.items[index], endian);
+            mem.writeInt(u64, &buf, got_value, endian);
             try self.base.file.?.pwriteAll(&buf, off);
 
             if (self.base.child_pid) |pid| {

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1801,6 +1801,7 @@ fn addGotEntry(self: *MachO, target: SymbolWithLoc) !void {
     const got_index = try self.got_table.allocateEntry(self.base.allocator, target);
     try self.writeOffsetTableEntry(got_index);
     self.got_table_count_dirty = true;
+    self.markRelocsDirtyByTarget(target);
 }
 
 fn addStubEntry(self: *MachO, target: SymbolWithLoc) !void {
@@ -1808,6 +1809,7 @@ fn addStubEntry(self: *MachO, target: SymbolWithLoc) !void {
     const stub_index = try self.stub_table.allocateEntry(self.base.allocator, target);
     try self.writeStubTableEntry(stub_index);
     self.stub_table_count_dirty = true;
+    self.markRelocsDirtyByTarget(target);
 }
 
 pub fn updateFunc(self: *MachO, module: *Module, func: *Module.Fn, air: Air, liveness: Liveness) !void {
@@ -2294,6 +2296,7 @@ fn updateDeclCode(self: *MachO, decl_index: Module.Decl.Index, code: []u8) !u64 
                 log.debug("  (updating GOT entry)", .{});
                 const got_atom_index = self.got_table.lookup.get(.{ .sym_index = sym_index }).?;
                 try self.writeOffsetTableEntry(got_atom_index);
+                self.markRelocsDirtyByTarget(.{ .sym_index = sym_index });
             }
         } else if (code_len < atom.size) {
             self.shrinkAtom(atom_index, code_len);

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -158,21 +158,6 @@ pub fn addBinding(macho_file: *MachO, atom_index: Index, binding: Binding) !void
     try gop.value_ptr.append(gpa, binding);
 }
 
-pub fn addLazyBinding(macho_file: *MachO, atom_index: Index, binding: Binding) !void {
-    const gpa = macho_file.base.allocator;
-    const atom = macho_file.getAtom(atom_index);
-    log.debug("  (adding lazy binding to symbol {s} at offset 0x{x} in %{?d})", .{
-        macho_file.getSymbolName(binding.target),
-        binding.offset,
-        atom.getSymbolIndex(),
-    });
-    const gop = try macho_file.lazy_bindings.getOrPut(gpa, atom_index);
-    if (!gop.found_existing) {
-        gop.value_ptr.* = .{};
-    }
-    try gop.value_ptr.append(gpa, binding);
-}
-
 pub fn resolveRelocations(
     macho_file: *MachO,
     atom_index: Index,
@@ -193,6 +178,4 @@ pub fn freeRelocations(macho_file: *MachO, atom_index: Index) void {
     if (removed_rebases) |*rebases| rebases.value.deinit(gpa);
     var removed_bindings = macho_file.bindings.fetchOrderedRemove(atom_index);
     if (removed_bindings) |*bindings| bindings.value.deinit(gpa);
-    var removed_lazy_bindings = macho_file.lazy_bindings.fetchOrderedRemove(atom_index);
-    if (removed_lazy_bindings) |*lazy_bindings| lazy_bindings.value.deinit(gpa);
 }

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -230,7 +230,7 @@ pub fn flushModule(self: *DebugSymbols, macho_file: *MachO) !void {
             .got_load => blk: {
                 const got_index = macho_file.got_table.lookup.get(.{ .sym_index = reloc.target }).?;
                 const got_entry = macho_file.got_table.entries.items[got_index];
-                break :blk got_entry.getSymbol(macho_file);
+                break :blk macho_file.getSymbol(got_entry);
             },
         };
         if (sym.n_value == reloc.prev_vaddr) continue;
@@ -240,7 +240,7 @@ pub fn flushModule(self: *DebugSymbols, macho_file: *MachO) !void {
             .got_load => blk: {
                 const got_index = macho_file.got_table.lookup.get(.{ .sym_index = reloc.target }).?;
                 const got_entry = macho_file.got_table.entries.items[got_index];
-                break :blk got_entry.getName(macho_file);
+                break :blk macho_file.getSymbolName(got_entry);
             },
         };
         const sect = &self.sections.items[self.debug_info_section_index.?];

--- a/src/link/MachO/eh_frame.zig
+++ b/src/link/MachO/eh_frame.zig
@@ -9,6 +9,7 @@ const log = std.log.scoped(.eh_frame);
 const Allocator = mem.Allocator;
 const AtomIndex = @import("zld.zig").AtomIndex;
 const Atom = @import("ZldAtom.zig");
+const Relocation = @import("Relocation.zig");
 const SymbolWithLoc = @import("zld.zig").SymbolWithLoc;
 const UnwindInfo = @import("UnwindInfo.zig");
 const Zld = @import("zld.zig").Zld;
@@ -368,7 +369,7 @@ pub fn EhFrameRecord(comptime is_mutable: bool) type {
                                 const target_addr = try Atom.getRelocTargetAddress(zld, target, true, false);
                                 const addend = mem.readIntLittle(i32, rec.data[rel_offset..][0..4]);
                                 const adjusted_target_addr = @intCast(u64, @intCast(i64, target_addr) + addend);
-                                const disp = try Atom.calcPcRelativeDisplacementX86(source_addr, adjusted_target_addr, 0);
+                                const disp = try Relocation.calcPcRelativeDisplacementX86(source_addr, adjusted_target_addr, 0);
                                 mem.writeIntLittle(i32, rec.data[rel_offset..][0..4], disp);
                             },
                             else => unreachable,

--- a/src/link/MachO/stubs.zig
+++ b/src/link/MachO/stubs.zig
@@ -1,0 +1,161 @@
+const std = @import("std");
+const aarch64 = @import("../../arch/aarch64/bits.zig");
+
+const Relocation = @import("Relocation.zig");
+
+pub inline fn calcStubHelperPreambleSize(cpu_arch: std.Target.Cpu.Arch) u5 {
+    return switch (cpu_arch) {
+        .x86_64 => 15,
+        .aarch64 => 6 * @sizeOf(u32),
+        else => unreachable, // unhandled architecture type
+    };
+}
+
+pub inline fn calcStubHelperEntrySize(cpu_arch: std.Target.Cpu.Arch) u4 {
+    return switch (cpu_arch) {
+        .x86_64 => 10,
+        .aarch64 => 3 * @sizeOf(u32),
+        else => unreachable, // unhandled architecture type
+    };
+}
+
+pub inline fn calcStubEntrySize(cpu_arch: std.Target.Cpu.Arch) u4 {
+    return switch (cpu_arch) {
+        .x86_64 => 6,
+        .aarch64 => 3 * @sizeOf(u32),
+        else => unreachable, // unhandled architecture type
+    };
+}
+
+pub inline fn calcStubOffsetInStubHelper(cpu_arch: std.Target.Cpu.Arch) u4 {
+    return switch (cpu_arch) {
+        .x86_64 => 1,
+        .aarch64 => 2 * @sizeOf(u32),
+        else => unreachable,
+    };
+}
+
+pub fn writeStubHelperPreambleCode(args: struct {
+    cpu_arch: std.Target.Cpu.Arch,
+    source_addr: u64,
+    dyld_private_addr: u64,
+    dyld_stub_binder_got_addr: u64,
+}, writer: anytype) !void {
+    switch (args.cpu_arch) {
+        .x86_64 => {
+            try writer.writeAll(&.{ 0x4c, 0x8d, 0x1d });
+            {
+                const disp = try Relocation.calcPcRelativeDisplacementX86(
+                    args.source_addr + 3,
+                    args.dyld_private_addr,
+                    0,
+                );
+                try writer.writeIntLittle(i32, disp);
+            }
+            try writer.writeAll(&.{ 0x41, 0x53, 0xff, 0x25 });
+            {
+                const disp = try Relocation.calcPcRelativeDisplacementX86(
+                    args.source_addr + 11,
+                    args.dyld_stub_binder_got_addr,
+                    0,
+                );
+                try writer.writeIntLittle(i32, disp);
+            }
+        },
+        .aarch64 => {
+            {
+                const pages = Relocation.calcNumberOfPages(args.source_addr, args.dyld_private_addr);
+                try writer.writeIntLittle(u32, aarch64.Instruction.adrp(.x17, pages).toU32());
+            }
+            {
+                const off = try Relocation.calcPageOffset(args.dyld_private_addr, .arithmetic);
+                try writer.writeIntLittle(u32, aarch64.Instruction.add(.x17, .x17, off, false).toU32());
+            }
+            try writer.writeIntLittle(u32, aarch64.Instruction.stp(
+                .x16,
+                .x17,
+                aarch64.Register.sp,
+                aarch64.Instruction.LoadStorePairOffset.pre_index(-16),
+            ).toU32());
+            {
+                const pages = Relocation.calcNumberOfPages(args.source_addr + 12, args.dyld_stub_binder_got_addr);
+                try writer.writeIntLittle(u32, aarch64.Instruction.adrp(.x16, pages).toU32());
+            }
+            {
+                const off = try Relocation.calcPageOffset(args.dyld_stub_binder_got_addr, .load_store_64);
+                try writer.writeIntLittle(u32, aarch64.Instruction.ldr(
+                    .x16,
+                    .x16,
+                    aarch64.Instruction.LoadStoreOffset.imm(off),
+                ).toU32());
+            }
+            try writer.writeIntLittle(u32, aarch64.Instruction.br(.x16).toU32());
+        },
+        else => unreachable,
+    }
+}
+
+pub fn writeStubHelperCode(args: struct {
+    cpu_arch: std.Target.Cpu.Arch,
+    source_addr: u64,
+    target_addr: u64,
+}, writer: anytype) !void {
+    switch (args.cpu_arch) {
+        .x86_64 => {
+            try writer.writeAll(&.{ 0x68, 0x0, 0x0, 0x0, 0x0, 0xe9 });
+            {
+                const disp = try Relocation.calcPcRelativeDisplacementX86(args.source_addr + 6, args.target_addr, 0);
+                try writer.writeIntLittle(i32, disp);
+            }
+        },
+        .aarch64 => {
+            const stub_size: u4 = 3 * @sizeOf(u32);
+            const literal = blk: {
+                const div_res = try std.math.divExact(u64, stub_size - @sizeOf(u32), 4);
+                break :blk std.math.cast(u18, div_res) orelse return error.Overflow;
+            };
+            try writer.writeIntLittle(u32, aarch64.Instruction.ldrLiteral(
+                .w16,
+                literal,
+            ).toU32());
+            {
+                const disp = try Relocation.calcPcRelativeDisplacementArm64(args.source_addr + 4, args.target_addr);
+                try writer.writeIntLittle(u32, aarch64.Instruction.b(disp).toU32());
+            }
+            try writer.writeAll(&.{ 0x0, 0x0, 0x0, 0x0 });
+        },
+        else => unreachable,
+    }
+}
+
+pub fn writeStubCode(args: struct {
+    cpu_arch: std.Target.Cpu.Arch,
+    source_addr: u64,
+    target_addr: u64,
+}, writer: anytype) !void {
+    switch (args.cpu_arch) {
+        .x86_64 => {
+            try writer.writeAll(&.{ 0xff, 0x25 });
+            {
+                const disp = try Relocation.calcPcRelativeDisplacementX86(args.source_addr + 2, args.target_addr, 0);
+                try writer.writeIntLittle(i32, disp);
+            }
+        },
+        .aarch64 => {
+            {
+                const pages = Relocation.calcNumberOfPages(args.source_addr, args.target_addr);
+                try writer.writeIntLittle(u32, aarch64.Instruction.adrp(.x16, pages).toU32());
+            }
+            {
+                const off = try Relocation.calcPageOffset(args.target_addr, .load_store_64);
+                try writer.writeIntLittle(u32, aarch64.Instruction.ldr(
+                    .x16,
+                    .x16,
+                    aarch64.Instruction.LoadStoreOffset.imm(off),
+                ).toU32());
+            }
+            try writer.writeIntLittle(u32, aarch64.Instruction.br(.x16).toU32());
+        },
+        else => unreachable,
+    }
+}

--- a/src/link/table_section.zig
+++ b/src/link/table_section.zig
@@ -47,7 +47,7 @@ pub fn TableSection(comptime Entry: type) type {
         ) !void {
             _ = options;
             comptime assert(unused_format_string.len == 0);
-            try writer.writeAll("SectionTable:\n");
+            try writer.writeAll("TableSection:\n");
             for (self.entries.items, 0..) |entry, i| {
                 try writer.print("  {d} => {}\n", .{ i, entry });
             }

--- a/src/link/table_section.zig
+++ b/src/link/table_section.zig
@@ -1,0 +1,65 @@
+pub fn TableSection(comptime Entry: type) type {
+    return struct {
+        entries: std.ArrayListUnmanaged(Entry) = .{},
+        free_list: std.ArrayListUnmanaged(Index) = .{},
+        lookup: std.AutoHashMapUnmanaged(Entry, Index) = .{},
+
+        pub fn deinit(self: *Self, allocator: Allocator) void {
+            self.entries.deinit(allocator);
+            self.free_list.deinit(allocator);
+            self.lookup.deinit(allocator);
+        }
+
+        pub fn allocateEntry(self: *Self, allocator: Allocator, entry: Entry) Allocator.Error!Index {
+            try self.entries.ensureUnusedCapacity(allocator, 1);
+            const index = blk: {
+                if (self.free_list.popOrNull()) |index| {
+                    log.debug("  (reusing entry index {d})", .{index});
+                    break :blk index;
+                } else {
+                    log.debug("  (allocating entry at index {d})", .{self.entries.items.len});
+                    const index = @intCast(u32, self.entries.items.len);
+                    _ = self.entries.addOneAssumeCapacity();
+                    break :blk index;
+                }
+            };
+            self.entries.items[index] = entry;
+            try self.lookup.putNoClobber(allocator, entry, index);
+            return index;
+        }
+
+        pub fn freeEntry(self: *Self, allocator: Allocator, entry: Entry) void {
+            const index = self.lookup.get(entry) orelse return;
+            self.free_list.append(allocator, index) catch {};
+            self.entries.items[index] = undefined;
+            _ = self.lookup.remove(entry);
+        }
+
+        pub fn count(self: Self) usize {
+            return self.entries.items.len;
+        }
+
+        pub fn format(
+            self: Self,
+            comptime unused_format_string: []const u8,
+            options: std.fmt.FormatOptions,
+            writer: anytype,
+        ) !void {
+            _ = options;
+            comptime assert(unused_format_string.len == 0);
+            try writer.writeAll("SectionTable:\n");
+            for (self.entries.items, 0..) |entry, i| {
+                try writer.print("  {d} => {}\n", .{ i, entry });
+            }
+        }
+
+        const Self = @This();
+        pub const Index = u32;
+    };
+}
+
+const std = @import("std");
+const assert = std.debug.assert;
+const log = std.log.scoped(.link);
+
+const Allocator = std.mem.Allocator;


### PR DESCRIPTION
Additionally for ELF we no longer waste a GOT entry index for atoms that do not require it. For MachO and Coff, we no longer use atoms to represent GOT section which will reduce memory usage. There are still caveats such as dirtying one GOT cell will trigger an update of the entire GOT table, however this can be optimised out as we go quite easily.

Finally, I have redone handling of threadlocals in MachO such that they no longer get a GOT cell, and they get their own helper for lowering into memory much like `updateLazySymbolAtom` and `updateDecl`.