### PR TITLE
Do not use -fPIC when compiling a UEFI application

### DIFF
--- a/src/target.zig
+++ b/src/target.zig
@@ -204,7 +204,7 @@ pub fn requiresPIC(target: std.Target, linking_libc: bool) bool {
 /// This is not whether the target supports Position Independent Code, but whether the -fPIC
 /// C compiler argument is valid to Clang.
 pub fn supports_fpic(target: std.Target) bool {
-    return target.os.tag != .windows;
+    return target.os.tag != .windows and target.os.tag != .uefi;
 }
 
 pub fn isSingleThreaded(target: std.Target) bool {


### PR DESCRIPTION
Because UEFI applications are windows DLLs, `zig cc` correctly sets the target to <arch>-unknown-windows-msvc when compiling for UEFI. However, a UEFI application is not treated as a windows DLL when determining whether the target supports the -fPIC option.