### PR TITLE
AEGIS MAC: add support for 128-bit tags

### DIFF
--- a/lib/std/crypto.zig
+++ b/lib/std/crypto.zig
@@ -41,7 +41,9 @@ pub const auth = struct {
     pub const siphash = @import("crypto/siphash.zig");
     pub const aegis = struct {
         pub const Aegis128LMac = @import("crypto/aegis.zig").Aegis128LMac;
+        pub const Aegis128LMac_128 = @import("crypto/aegis.zig").Aegis128LMac_128;
         pub const Aegis256Mac = @import("crypto/aegis.zig").Aegis256Mac;
+        pub const Aegis256Mac_128 = @import("crypto/aegis.zig").Aegis256Mac_128;
     };
     pub const cmac = @import("crypto/cmac.zig");
 };

--- a/lib/std/crypto/aegis.zig
+++ b/lib/std/crypto/aegis.zig
@@ -417,6 +417,20 @@ pub const Aegis128LMac = AegisMac(Aegis128L_256);
 /// - It has a large security margin against internal collisions.
 pub const Aegis256Mac = AegisMac(Aegis256_256);
 
+/// Aegis128L MAC with a 128-bit output.
+/// A MAC with a 128-bit output is not safe unless the number of messages
+/// authenticated with the same key remains small.
+/// After 2^48 messages, the probability of a collision is already ~ 2^-33.
+/// If unsure, use the  Aegis128LMac type, that has a 256 bit output.
+pub const Aegis128LMac_128 = AegisMac(Aegis128L);
+
+/// Aegis256 MAC with a 128-bit output.
+/// A MAC with a 128-bit output is not safe unless the number of messages
+/// authenticated with the same key remains small.
+/// After 2^48 messages, the probability of a collision is already ~ 2^-33.
+/// If unsure, use the  Aegis256Mac type, that has a 256 bit output.
+pub const Aegis256Mac_128 = AegisMac(Aegis256);
+
 fn AegisMac(comptime T: type) type {
     return struct {
         const Self = @This();


### PR DESCRIPTION
When used as a MAC, 256-bit tags are recommended.

But in interactive protocols, 128 bits may be acceptable.

We already implement both versions, so it doesn't take much to expose the relevant types.