### PR TITLE
Fix windows 11 arch detection and cache download

### DIFF
--- a/ci/x86_64-windows-debug.ps1
+++ b/ci/x86_64-windows-debug.ps1
@@ -1,4 +1,9 @@
-$TARGET = "$($Env:ARCH)-windows-gnu"
+$ARCHITECTURE = switch ([Environment]::Is64BitOperatingSystem) {
+    $true { "x86_64"; break }
+    $false { "x86"; break }
+}
+
+$TARGET = "$ARCHITECTURE-windows-gnu"
 $ZIG_LLVM_CLANG_LLD_NAME = "zig+llvm+lld+clang-$TARGET-0.11.0-dev.1869+df4cfc2ec"
 $MCPU = "baseline"
 $ZIG_LLVM_CLANG_LLD_URL = "https://ziglang.org/deps/$ZIG_LLVM_CLANG_LLD_NAME.zip"
@@ -6,12 +11,14 @@ $PREFIX_PATH = "$(Get-Location)\$ZIG_LLVM_CLANG_LLD_NAME"
 $ZIG = "$PREFIX_PATH\bin\zig.exe"
 $ZIG_LIB_DIR = "$(Get-Location)\lib"
 
-Write-Output "Downloading $ZIG_LLVM_CLANG_LLD_URL"
-Invoke-WebRequest -Uri "$ZIG_LLVM_CLANG_LLD_URL" -OutFile "$ZIG_LLVM_CLANG_LLD_NAME.zip"
+if (-not(Test-Path -Path "$ZIG_LLVM_CLANG_LLD_NAME.zip" -PathType Leaf)) {
+    Write-Output "Downloading $ZIG_LLVM_CLANG_LLD_URL"
+    Invoke-WebRequest -Uri "$ZIG_LLVM_CLANG_LLD_URL" -OutFile "$ZIG_LLVM_CLANG_LLD_NAME.zip"
 
-Write-Output "Extracting..."
-Add-Type -AssemblyName System.IO.Compression.FileSystem ;
-[System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/$ZIG_LLVM_CLANG_LLD_NAME.zip", "$PWD")
+    Write-Output "Extracting..."
+    Add-Type -AssemblyName System.IO.Compression.FileSystem ;
+    [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/$ZIG_LLVM_CLANG_LLD_NAME.zip", "$PWD")
+}
 
 function CheckLastExitCode {
     if (!$?) {

--- a/ci/x86_64-windows-debug.ps1
+++ b/ci/x86_64-windows-debug.ps1
@@ -15,10 +15,11 @@ if (-not(Test-Path -Path "$ZIG_LLVM_CLANG_LLD_NAME.zip" -PathType Leaf)) {
     Write-Output "Downloading $ZIG_LLVM_CLANG_LLD_URL"
     Invoke-WebRequest -Uri "$ZIG_LLVM_CLANG_LLD_URL" -OutFile "$ZIG_LLVM_CLANG_LLD_NAME.zip"
 
-    Write-Output "Extracting..."
-    Add-Type -AssemblyName System.IO.Compression.FileSystem ;
-    [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/$ZIG_LLVM_CLANG_LLD_NAME.zip", "$PWD")
 }
+
+Write-Output "Extracting..."
+Add-Type -AssemblyName System.IO.Compression.FileSystem ;
+[System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/$ZIG_LLVM_CLANG_LLD_NAME.zip", "$PWD")
 
 function CheckLastExitCode {
     if (!$?) {


### PR DESCRIPTION
The continuous integration script do not detect windows architecture under Windows 11 PowerShell
correctly.  This change fixes that along with downloading the zip containing zig, LLVM, and friends
only when necessary. It will use downloaded zip file rather than retrieving it again.

This is a quick fix and do not take care of checking checksum largely because
I don't know where to get the checksum from. If there was a checksum location
then the script can validate and download again if that fails.