### PR TITLE
std.Build.RunStep: fix captureStdOut function return type

### DIFF
--- a/lib/std/Build/RunStep.zig
+++ b/lib/std/Build/RunStep.zig
@@ -304,7 +304,7 @@ pub fn captureStdErr(self: *RunStep) std.Build.FileSource {
     return .{ .generated = &output.generated_file };
 }
 
-pub fn captureStdOut(self: *RunStep) *std.Build.GeneratedFile {
+pub fn captureStdOut(self: *RunStep) std.Build.FileSource {
     assert(self.stdio != .inherit);
 
     if (self.captured_stdout) |output| return .{ .generated = &output.generated_file };


### PR DESCRIPTION
The return type of the captureStdOut function is incorrect. Replace *std.Build.GeneratedFile with std.Build.FileSource.