### PR TITLE
std.debug.println()

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -93,6 +93,10 @@ pub fn print(comptime fmt: []const u8, args: anytype) void {
     nosuspend stderr.print(fmt, args) catch return;
 }
 
+pub fn println(comptime fmt: []const u8, args: anytype) void {
+    print(fmt ++ std.cstr.line_sep, args);
+}
+
 pub fn getStderrMutex() *std.Thread.Mutex {
     return &stderr_mutex;
 }


### PR DESCRIPTION
Hi,

In many cases, `std.debug.print()` is used with a new line.
So this PR implements `.println()`. Here is the usage:

```zig
const std = @import("std");

std.debug.println("hello, world", .{});
```

Many `print` + "\n" are found In [the document](https://ziglang.org/documentation/master/).

## Windows "\r\n"
All functions or methods or macro below uses `\r\n` in Windows.
* Python3 - print()
* Java - System.out.println()
* Node.js - console.log()
* Go - fmt.Println()
* Rust - println!

Here is my study:
https://github.com/nwtgck/println-study/actions/runs/4767810519/jobs/8476446974