### PR TITLE
translate-c: support brace-enclosed string initializers (c++20 9.4.2.1)

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -460,6 +460,9 @@ pub const Expr = opaque {
 
     pub const evaluateAsConstantExpr = ZigClangExpr_EvaluateAsConstantExpr;
     extern fn ZigClangExpr_EvaluateAsConstantExpr(*const Expr, *ExprEvalResult, Expr_ConstantExprKind, *const ASTContext) bool;
+
+    pub const castToStringLiteral = ZigClangExpr_castToStringLiteral;
+    extern fn ZigClangExpr_castToStringLiteral(*const Expr) ?*const StringLiteral;
 };
 
 pub const FieldDecl = opaque {
@@ -1052,6 +1055,12 @@ pub const InitListExpr = opaque {
 
     pub const getArrayFiller = ZigClangInitListExpr_getArrayFiller;
     extern fn ZigClangInitListExpr_getArrayFiller(*const InitListExpr) *const Expr;
+
+    pub const hasArrayFiller = ZigClangInitListExpr_hasArrayFiller;
+    extern fn ZigClangInitListExpr_hasArrayFiller(*const InitListExpr) bool;
+
+    pub const isStringLiteralInit = ZigClangInitListExpr_isStringLiteralInit;
+    extern fn ZigClangInitListExpr_isStringLiteralInit(*const InitListExpr) bool;
 
     pub const getNumInits = ZigClangInitListExpr_getNumInits;
     extern fn ZigClangInitListExpr_getNumInits(*const InitListExpr) c_uint;

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -2382,6 +2382,12 @@ bool ZigClangExpr_EvaluateAsConstantExpr(const ZigClangExpr *self, ZigClangExprE
     return true;
 }
 
+const ZigClangStringLiteral *ZigClangExpr_castToStringLiteral(const struct ZigClangExpr *self) {
+    auto casted_self = reinterpret_cast<const clang::Expr *>(self);
+    auto cast = clang::dyn_cast<const clang::StringLiteral>(casted_self);
+    return reinterpret_cast<const ZigClangStringLiteral *>(cast);
+}
+
 const ZigClangExpr *ZigClangInitListExpr_getInit(const ZigClangInitListExpr *self, unsigned i) {
     auto casted = reinterpret_cast<const clang::InitListExpr *>(self);
     const clang::Expr *result = casted->getInit(i);
@@ -2392,6 +2398,16 @@ const ZigClangExpr *ZigClangInitListExpr_getArrayFiller(const ZigClangInitListEx
     auto casted = reinterpret_cast<const clang::InitListExpr *>(self);
     const clang::Expr *result = casted->getArrayFiller();
     return reinterpret_cast<const ZigClangExpr *>(result);
+}
+
+bool ZigClangInitListExpr_hasArrayFiller(const ZigClangInitListExpr *self) {
+    auto casted = reinterpret_cast<const clang::InitListExpr *>(self);
+    return casted->hasArrayFiller();
+}
+
+bool ZigClangInitListExpr_isStringLiteralInit(const ZigClangInitListExpr *self) {
+    auto casted = reinterpret_cast<const clang::InitListExpr *>(self);
+    return casted->isStringLiteralInit();
 }
 
 const ZigClangFieldDecl *ZigClangInitListExpr_getInitializedFieldInUnion(const ZigClangInitListExpr *self) {

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -1220,9 +1220,12 @@ ZIG_EXTERN_C bool ZigClangExpr_EvaluateAsFloat(const struct ZigClangExpr *self,
         ZigClangAPFloat **result, const struct ZigClangASTContext *ctx);
 ZIG_EXTERN_C bool ZigClangExpr_EvaluateAsConstantExpr(const struct ZigClangExpr *,
         struct ZigClangExprEvalResult *, ZigClangExpr_ConstantExprKind, const struct ZigClangASTContext *);
+ZIG_EXTERN_C const struct ZigClangStringLiteral *ZigClangExpr_castToStringLiteral(const struct ZigClangExpr *self);
 
 ZIG_EXTERN_C const ZigClangExpr *ZigClangInitListExpr_getInit(const ZigClangInitListExpr *, unsigned);
 ZIG_EXTERN_C const ZigClangExpr *ZigClangInitListExpr_getArrayFiller(const ZigClangInitListExpr *);
+ZIG_EXTERN_C bool ZigClangInitListExpr_hasArrayFiller(const ZigClangInitListExpr *);
+ZIG_EXTERN_C bool ZigClangInitListExpr_isStringLiteralInit(const ZigClangInitListExpr *);
 ZIG_EXTERN_C unsigned ZigClangInitListExpr_getNumInits(const ZigClangInitListExpr *);
 ZIG_EXTERN_C const ZigClangFieldDecl *ZigClangInitListExpr_getInitializedFieldInUnion(const ZigClangInitListExpr *self);
 

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -3956,4 +3956,10 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    .name = "foo",
         \\});
     });
+
+    cases.add("string array initializer",
+        \\static const char foo[] = {"bar"};
+    , &[_][]const u8{
+        \\pub const foo: [3:0]u8 = "bar";
+    });
 }


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/11481.

This PR adds support for this kind of array initialization: `static const char foo[] = {"bar"};`. This fixes a crash where the code assumed that an an array filler always existed.

Context:
- https://eel.is/c++draft/dcl.init.string
- https://clang.llvm.org/doxygen/_2home_2buildbot_2as-worker-4_2publish-doxygen-docs_2llvm-project_2clang_2lib_2StaticAnalyzer_2Core_2RegionStore_8cpp-example.html#a66