### PR TITLE
`fs.Dir.deleteTree`: Fix DirNotEmpty condition

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -2210,7 +2210,7 @@ pub const Dir = struct {
             var need_to_retry: bool = false;
             parent_dir.deleteDir(name) catch |err| switch (err) {
                 error.FileNotFound => {},
-                error.DirNotEmpty => need_to_retry = false,
+                error.DirNotEmpty => need_to_retry = true,
                 else => |e| return e,
             };
 


### PR DESCRIPTION
`deleteTree` needs to retry once the directory is reported to be not empty. Otherwise, `need_to_retry` is always going to be false thus making the retry a dead code.