### PR TITLE
wasm: implement more runtime safety checks

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -6626,7 +6626,7 @@ pub fn backendSupportsFeature(mod: Module, feature: Feature) bool {
         .safety_check_formatted => mod.comp.bin_file.options.use_llvm,
         .error_return_trace => mod.comp.bin_file.options.use_llvm,
         .is_named_enum_value => mod.comp.bin_file.options.use_llvm,
-        .error_set_has_value => mod.comp.bin_file.options.use_llvm,
+        .error_set_has_value => mod.comp.bin_file.options.use_llvm or mod.comp.bin_file.options.target.isWasm(),
         .field_reordering => mod.comp.bin_file.options.use_llvm,
     };
 }

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3338,9 +3338,13 @@ fn airCmpVector(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 fn airCmpLtErrorsLen(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const un_op = func.air.instructions.items(.data)[inst].un_op;
     const operand = try func.resolveInst(un_op);
+    const sym_index = try func.bin_file.getGlobalSymbol("__zig_lt_errors_len", null);
 
-    _ = operand;
-    return func.fail("TODO implement airCmpLtErrorsLen for wasm", .{});
+    try func.emitWValue(operand);
+    try func.addLabel(.call, sym_index);
+    const result = try func.allocLocal(Type.bool);
+    try func.addLabel(.local_set, result.local.value);
+    return func.finishAir(inst, result, &.{un_op});
 }
 
 fn airBr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -401,7 +401,6 @@ test "expected [*c]const u8, found [*:0]const u8" {
 }
 
 test "explicit cast from integer to error type" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO


### PR DESCRIPTION
Implements the air instructions `error_set_has_value` and `cmp_lt_errors_len`, which are runtime safety checks emitted during `@errorToInt` and `@errCast`