### PR TITLE
Add support for .field_ptr in elemValueAdvanced

### DIFF
--- a/src/value.zig
+++ b/src/value.zig
@@ -3002,6 +3002,15 @@ pub const Value = extern union {
                 const data = val.castTag(.elem_ptr).?.data;
                 return data.array_ptr.elemValueAdvanced(mod, index + data.index, arena, buffer);
             },
+            .field_ptr => {
+                const data = val.castTag(.field_ptr).?.data;
+                if (data.container_ptr.pointerDecl()) |decl_index| {
+                    const container_decl = mod.declPtr(decl_index);
+                    const field_type = data.container_ty.structFieldType(data.field_index);
+                    const field_val = container_decl.val.fieldValue(field_type, data.field_index);
+                    return field_val.elemValueAdvanced(mod, index, arena, buffer);
+                } else unreachable;
+            },
 
             // The child type of arrays which have only one possible value need
             // to have only one possible value itself.

--- a/test/cases/comptime_aggregate_print.zig
+++ b/test/cases/comptime_aggregate_print.zig
@@ -1,0 +1,32 @@
+const UnionContainer = union {
+    buf: [2]i32,
+};
+
+fn getUnionSlice() []i32 {
+    var c = UnionContainer{ .buf = .{ 1, 2 } };
+    return c.buf[0..2];
+}
+
+const StructContainer = struct {
+    buf: [2]i32,
+};
+
+fn getStructSlice() []i32 {
+    var c = StructContainer{ .buf = .{ 3, 4 } };
+    return c.buf[0..2];
+}
+
+comptime {
+    @compileLog(getUnionSlice());
+    @compileLog(getStructSlice());
+}
+
+pub fn main() !void {}
+
+// error
+//
+// :20:5: error: found compile log statement
+//
+// Compile Log Output:
+// @as([]i32, .{ 1, 2 })
+// @as([]i32, .{ 3, 4 })


### PR DESCRIPTION
Fixed https://github.com/ziglang/zig/issues/15255.

This fixes a crash when `@compileLog` is passed a slice backed by an aggregate field at comptime.

I'm not sure if this behavior (return a slice backed by a function-scoped variable at comptime) is intended to be supported, but it does work now that the crash is fixed.