### PR TITLE
Sema: allow method calls on optional pointers

### DIFF
--- a/test/behavior/fn.zig
+++ b/test/behavior/fn.zig
@@ -455,6 +455,23 @@ test "method call with optional and error union first param" {
     try s.errUnion();
 }
 
+test "method call with optional pointer first param" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        x: i32 = 1234,
+
+        fn method(s: ?*@This()) !void {
+            try expect(s.?.x == 1234);
+        }
+    };
+    var s: S = .{};
+    try s.method();
+    const s_ptr = &s;
+    try s_ptr.method();
+}
+
 test "using @ptrCast on function pointers" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO


### PR DESCRIPTION
Currently, it is possible to use the method call syntax `obj.method(...)` when `method`'s first parameter is the same as `obj`'s type (`T`), a pointer (`*T` or `[*c]T`), optional (`?T`), or error union (`Error!T`). This change adds support for `?*T`.

This is particularly useful for bindings to libraries where deallocation functions (e.g. `free`, `unref`) allow null to be passed as the object: a mechanical translation using `[*c]T` would work with the previous method syntax, but would no longer work when manually refined to `?*T`.