### PR TITLE
translate-c: fix codegen when C source has variables named the same as mangling prefixes

### DIFF
--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -3962,4 +3962,159 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
     , &[_][]const u8{
         \\pub const foo: [3:0]u8 = "bar";
     });
+
+    cases.add("worst-case assign from mangle prefix",
+        \\void foo() {
+        \\    int n, tmp = 1;
+        \\    if (n = tmp) {}
+        \\}
+    , &[_][]const u8{
+        \\pub export fn foo() void {
+        \\    var n: c_int = undefined;
+        \\    var tmp: c_int = 1;
+        \\    if ((blk: {
+        \\        const tmp_1 = tmp;
+        \\        n = tmp_1;
+        \\        break :blk tmp_1;
+        \\    }) != 0) {}
+        \\}
+    });
+
+    cases.add("worst-case assign to mangle prefix",
+        \\void foo() {
+        \\    int tmp, n = 1;
+        \\    if (tmp = n) {}
+        \\}
+    , &[_][]const u8{
+        \\pub export fn foo() void {
+        \\    var tmp: c_int = undefined;
+        \\    var n: c_int = 1;
+        \\    if ((blk: {
+        \\        const tmp_1 = n;
+        \\        tmp = tmp_1;
+        \\        break :blk tmp_1;
+        \\    }) != 0) {}
+        \\}
+    });
+
+    cases.add("worst-case precrement mangle prefix",
+        \\void foo() {
+        \\    int n, ref = 1;
+        \\    if (n = ++ref) {}
+        \\}
+    , &[_][]const u8{
+        \\pub export fn foo() void {
+        \\    var n: c_int = undefined;
+        \\    var ref: c_int = 1;
+        \\    if ((blk: {
+        \\        const tmp = blk_1: {
+        \\            const ref_2 = &ref;
+        \\            ref_2.* += 1;
+        \\            break :blk_1 ref_2.*;
+        \\        };
+        \\        n = tmp;
+        \\        break :blk tmp;
+        \\    }) != 0) {}
+        \\}
+    });
+
+    cases.add("worst-case postcrement mangle prefix",
+        \\void foo() {
+        \\    int n, ref = 1;
+        \\    if (n = ref++) {}
+        \\}
+    , &[_][]const u8{
+        \\pub export fn foo() void {
+        \\    var n: c_int = undefined;
+        \\    var ref: c_int = 1;
+        \\    if ((blk: {
+        \\        const tmp = blk_1: {
+        \\            const ref_2 = &ref;
+        \\            const tmp_3 = ref_2.*;
+        \\            ref_2.* += 1;
+        \\            break :blk_1 tmp_3;
+        \\        };
+        \\        n = tmp;
+        \\        break :blk tmp;
+        \\    }) != 0) {}
+        \\}
+    });
+
+    cases.add("worst-case compound assign from mangle prefix",
+        \\void foo() {
+        \\    int n, ref = 1;
+        \\    if (n += ref) {}
+        \\}
+    , &[_][]const u8{
+        \\pub export fn foo() void {
+        \\    var n: c_int = undefined;
+        \\    var ref: c_int = 1;
+        \\    if ((blk: {
+        \\        const ref_1 = &n;
+        \\        ref_1.* += ref;
+        \\        break :blk ref_1.*;
+        \\    }) != 0) {}
+        \\}
+    });
+
+    cases.add("worst-case compound assign to mangle prefix",
+        \\void foo() {
+        \\    int ref, n = 1;
+        \\    if (ref += n) {}
+        \\}
+    , &[_][]const u8{
+        \\pub export fn foo() void {
+        \\    var ref: c_int = undefined;
+        \\    var n: c_int = 1;
+        \\    if ((blk: {
+        \\        const ref_1 = &ref;
+        \\        ref_1.* += n;
+        \\        break :blk ref_1.*;
+        \\    }) != 0) {}
+        \\}
+    });
+
+    cases.add("binary conditional operator where condition is the mangle prefix",
+        \\void foo() {
+        \\    int f = 1;
+        \\    int n, cond_temp = 1;
+        \\    if (n = (cond_temp)?:(f)) {}
+        \\}
+    , &[_][]const u8{
+        \\pub export fn foo() void {
+        \\    var f: c_int = 1;
+        \\    var n: c_int = undefined;
+        \\    var cond_temp: c_int = 1;
+        \\    if ((blk: {
+        \\        const tmp = blk_1: {
+        \\            const cond_temp_2 = cond_temp;
+        \\            break :blk_1 if (cond_temp_2 != 0) cond_temp_2 else f;
+        \\        };
+        \\        n = tmp;
+        \\        break :blk tmp;
+        \\    }) != 0) {}
+        \\}
+    });
+
+    cases.add("binary conditional operator where false_expr is the mangle prefix",
+        \\void foo() {
+        \\    int cond_temp = 1;
+        \\    int n, f = 1;
+        \\    if (n = (f)?:(cond_temp)) {}
+        \\}
+    , &[_][]const u8{
+        \\pub export fn foo() void {
+        \\    var cond_temp: c_int = 1;
+        \\    var n: c_int = undefined;
+        \\    var f: c_int = 1;
+        \\    if ((blk: {
+        \\        const tmp = blk_1: {
+        \\            const cond_temp_2 = f;
+        \\            break :blk_1 if (cond_temp_2 != 0) cond_temp_2 else cond_temp;
+        \\        };
+        \\        n = tmp;
+        \\        break :blk tmp;
+        \\    }) != 0) {}
+        \\}
+    });
 }


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/15411.

If the C code had variables that were named the same as the prefixes used for name mangling, such as `tmp`, `ref`, or `cond_temp`, then the codegen would generate incorrect code in some cases. This was because these aliases were immediately visible to sub-expressions that actually needed to use the original name.

Example:

```
void test_transCreateNodeAssign() {
    int n, tmp = 1;
    if (n = tmp) {}
}

// Translated to:

pub export fn test_transCreateNodeAssign() void {
    var n: c_int = undefined;
    var tmp: c_int = 1;
    _ = @TypeOf(tmp);
    if ((blk: {
        const tmp_1 = tmp_1;
        n = tmp_1;
        break :blk tmp_1;
    }) != 0) {}
}
```

Note the incorrect assignment `const tmp_1 = tmp_1;`, which should be `const tmp_1 = tmp;`

Another example:

```
int test_transBinaryConditionalOperator_inverse() {
    int cond_temp = 1;
    int n, f = 1;
    if (n = (f)?:(cond_temp)) {}
}

// Translates to:

pub export fn test_transBinaryConditionalOperator() c_int {
    var cond_temp: c_int = 1;
    _ = @TypeOf(cond_temp);
    var n: c_int = undefined;
    var f: c_int = 1;
    if ((blk: {
        const tmp = blk_1: {
            const cond_temp_2 = f;
            break :blk_1 if (cond_temp_2 != 0) cond_temp_2 else cond_temp_2;
        };
        n = tmp;
        break :blk tmp;
    }) != 0) {}
}
```

The `break :blk_1 if (cond_temp_2 != 0) cond_temp_2 else cond_temp_2;` statement should end with `else cond_temp;`.

I introduced the concept of reserving aliases without enabling them. An alias that isn't enabled isn't visible to expression translation, but is still reserved so that sub-expressions generate aliases that don't overlap.

Added test cases to cover the cases that would break before this change.