### PR TITLE
sema: Rework Decl.value_arena to fix another memory corruption issue

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -411,6 +411,43 @@ pub const WipCaptureScope = struct {
     }
 };
 
+const ValueArena = struct {
+    state: std.heap.ArenaAllocator.State,
+    state_acquired: ?*std.heap.ArenaAllocator.State = null,
+
+    /// If non-zero, then an ArenaAllocator has been promoted from `state`,
+    /// and `state_acquired` points to its state field.
+    ref_count: usize = 0,
+
+    /// Returns an allocator backed by either promoting `state`, or by the existing ArenaAllocator
+    /// that has already promoted `state`. `out_arena_allocator` provides storage for the initial promotion,
+    /// and must live until the matching call to release()
+    pub fn acquire(self: *ValueArena, child_allocator: Allocator, out_arena_allocator: *std.heap.ArenaAllocator) Allocator {
+        defer self.ref_count += 1;
+
+        if (self.state_acquired) |state_acquired| {
+            const arena_allocator = @fieldParentPtr(
+                std.heap.ArenaAllocator,
+                "state",
+                state_acquired,
+            );
+            return arena_allocator.allocator();
+        }
+
+        out_arena_allocator.* = self.state.promote(child_allocator);
+        self.state_acquired = &out_arena_allocator.state;
+        return out_arena_allocator.allocator();
+    }
+
+    pub fn release(self: *ValueArena) void {
+        self.ref_count -= 1;
+        if (self.ref_count == 0) {
+            self.state = self.state_acquired.?.*;
+            self.state_acquired = null;
+        }
+    }
+};
+
 pub const Decl = struct {
     /// Allocated with Module's allocator; outlives the ZIR code.
     name: [*:0]const u8,
@@ -429,7 +466,7 @@ pub const Decl = struct {
     @"addrspace": std.builtin.AddressSpace,
     /// The memory for ty, val, align, linksection, and captures.
     /// If this is `null` then there is no memory management needed.
-    value_arena: ?*std.heap.ArenaAllocator.State = null,
+    value_arena: ?*ValueArena = null,
     /// The direct parent namespace of the Decl.
     /// Reference to externally owned memory.
     /// In the case of the Decl corresponding to a file, this is
@@ -607,7 +644,7 @@ pub const Decl = struct {
             variable.deinit(gpa);
             gpa.destroy(variable);
         }
-        if (decl.value_arena) |arena_state| {
+        if (decl.value_arena) |value_arena| {
             if (decl.owns_tv) {
                 if (decl.val.castTag(.str_lit)) |str_lit| {
                     mod.string_literal_table.getPtrContext(str_lit.data, .{
@@ -615,7 +652,8 @@ pub const Decl = struct {
                     }).?.* = .none;
                 }
             }
-            arena_state.promote(gpa).deinit();
+            assert(value_arena.ref_count == 0);
+            value_arena.state.promote(gpa).deinit();
             decl.value_arena = null;
             decl.has_tv = false;
             decl.owns_tv = false;
@@ -624,9 +662,9 @@ pub const Decl = struct {
 
     pub fn finalizeNewArena(decl: *Decl, arena: *std.heap.ArenaAllocator) !void {
         assert(decl.value_arena == null);
-        const arena_state = try arena.allocator().create(std.heap.ArenaAllocator.State);
-        arena_state.* = arena.state;
-        decl.value_arena = arena_state;
+        const value_arena = try arena.allocator().create(ValueArena);
+        value_arena.* = .{ .state = arena.state };
+        decl.value_arena = value_arena;
     }
 
     /// This name is relative to the containing namespace of the decl.
@@ -4538,14 +4576,15 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
     var decl_arena = std.heap.ArenaAllocator.init(gpa);
     const decl_arena_allocator = decl_arena.allocator();
 
-    const decl_arena_state = blk: {
+    const decl_value_arena = blk: {
         errdefer decl_arena.deinit();
-        const s = try decl_arena_allocator.create(std.heap.ArenaAllocator.State);
+        const s = try decl_arena_allocator.create(ValueArena);
+        s.* = .{ .state = undefined };
         break :blk s;
     };
     defer {
-        decl_arena_state.* = decl_arena.state;
-        decl.value_arena = decl_arena_state;
+        decl_value_arena.state = decl_arena.state;
+        decl.value_arena = decl_value_arena;
     }
 
     var analysis_arena = std.heap.ArenaAllocator.init(gpa);
@@ -5493,9 +5532,9 @@ pub fn analyzeFnBody(mod: *Module, func: *Fn, arena: Allocator) SemaError!Air {
     const decl = mod.declPtr(decl_index);
 
     // Use the Decl's arena for captured values.
-    var decl_arena = decl.value_arena.?.promote(gpa);
-    defer decl.value_arena.?.* = decl_arena.state;
-    const decl_arena_allocator = decl_arena.allocator();
+    var decl_arena: std.heap.ArenaAllocator = undefined;
+    const decl_arena_allocator = decl.value_arena.?.acquire(gpa, &decl_arena);
+    defer decl.value_arena.?.release();
 
     var sema: Sema = .{
         .mod = mod,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2858,7 +2858,7 @@ fn zirEnumDecl(
 
     var decl_arena: std.heap.ArenaAllocator = undefined;
     const decl_arena_allocator = new_decl.value_arena.?.acquire(gpa, &decl_arena);
-    defer new_decl.value_arena.?.release();
+    defer new_decl.value_arena.?.release(&decl_arena);
 
     extra_index = try mod.scanNamespace(&enum_obj.namespace, extra_index, decls_len, new_decl);
 
@@ -27004,7 +27004,7 @@ const ComptimePtrMutationKit = struct {
 
     fn finishArena(self: *ComptimePtrMutationKit, mod: *Module) void {
         const decl = mod.declPtr(self.decl_ref_mut.decl_index);
-        decl.value_arena.?.release();
+        decl.value_arena.?.release(&self.decl_arena);
         self.decl_arena = undefined;
     }
 };
@@ -30655,7 +30655,7 @@ fn resolveStructLayout(sema: *Sema, ty: Type) CompileError!void {
                 const decl = sema.mod.declPtr(struct_obj.owner_decl);
                 var decl_arena: std.heap.ArenaAllocator = undefined;
                 const decl_arena_allocator = decl.value_arena.?.acquire(sema.mod.gpa, &decl_arena);
-                defer decl.value_arena.?.release();
+                defer decl.value_arena.?.release(&decl_arena);
                 break :blk try decl_arena_allocator.alloc(u32, struct_obj.fields.count());
             };
 
@@ -30701,7 +30701,7 @@ fn semaBackingIntType(mod: *Module, struct_obj: *Module.Struct) CompileError!voi
     const decl = mod.declPtr(decl_index);
     var decl_arena: std.heap.ArenaAllocator = undefined;
     const decl_arena_allocator = decl.value_arena.?.acquire(gpa, &decl_arena);
-    defer decl.value_arena.?.release();
+    defer decl.value_arena.?.release(&decl_arena);
 
     const zir = struct_obj.namespace.file_scope.zir;
     const extended = zir.instructions.items(.data)[struct_obj.zir_index].extended;
@@ -31395,7 +31395,7 @@ fn semaStructFields(mod: *Module, struct_obj: *Module.Struct) CompileError!void 
     const decl = mod.declPtr(decl_index);
     var decl_arena: std.heap.ArenaAllocator = undefined;
     const decl_arena_allocator = decl.value_arena.?.acquire(gpa, &decl_arena);
-    defer decl.value_arena.?.release();
+    defer decl.value_arena.?.release(&decl_arena);
 
     var analysis_arena = std.heap.ArenaAllocator.init(gpa);
     defer analysis_arena.deinit();
@@ -31735,7 +31735,7 @@ fn semaUnionFields(mod: *Module, union_obj: *Module.Union) CompileError!void {
     const decl = mod.declPtr(decl_index);
     var decl_arena: std.heap.ArenaAllocator = undefined;
     const decl_arena_allocator = decl.value_arena.?.acquire(gpa, &decl_arena);
-    defer decl.value_arena.?.release();
+    defer decl.value_arena.?.release(&decl_arena);
 
     var analysis_arena = std.heap.ArenaAllocator.init(gpa);
     defer analysis_arena.deinit();

--- a/test/cases/decl_value_arena.zig
+++ b/test/cases/decl_value_arena.zig
@@ -1,0 +1,21 @@
+pub const Protocols: struct {
+	list: *const fn(*Connection) void = undefined,
+	handShake: type = struct {
+		const stepStart: u8 = 0;
+	},
+} = .{};
+
+pub const Connection = struct {
+	streamBuffer: [0]u8 = undefined,
+	__lastReceivedPackets: [0]u8 = undefined,
+
+	handShakeState: u8 = Protocols.handShake.stepStart,
+};
+
+pub fn main() void {
+	var conn: Connection = undefined;
+	_ = conn;
+}
+
+// run
+//


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/15150.

This fixes a bug where resolveStructLayout was promoting from stale value_arena state which was then overwritten when another ArenaAllocator higher in the call stack saved its state back. This resulted in the memory for struct_obj.optmized_order overlapping existing allocations.

My initial fix in c7067ef wasn't sufficient, as it only checked if the struct being resolved had the same owner as the current sema instance. However, it's possible for resolveStructLayout to be called when the sema instance has a different owner, but the struct decl's value_arena is currently in use higher up in the callstack.

This change introduces ValueArena, which holds the arena state as well as tracks if an arena has already been promoted from it. This allows callers to use the value_arena storage without needing to be aware of another user of this same storage higher up in the call stack.

Question for reviewers: Is that test case enough - or should it include more context / reference the bug issue?

An example of a callstack that exhibited the original bug (from the linked issue):

```
zig.exe;;7FF7F224A614;2CDA614
zig.exe;allocAdvancedWithRetAddr__anon_52271();7FF7EF8B9201;349201
zig.exe;alloc__anon_6268();7FF7EF6FD1A6;18D1A6
zig.exe;resolveStructLayout();7FF7EFBBAEE0;64AEE0  < struct_obj.owner_decl != sema.owner_decl_index, so it promotes from struct_obj, but this state is already "acquired" by analyzeFnBody above
zig.exe;resolveStructFully();7FF7EFBE2DB1;672DB1
zig.exe;resolveTypeFully();7FF7EF9A0088;430088
zig.exe;resolveTypeFully();7FF7EF99FF9A;42FF9A
zig.exe;resolveTypeFully();7FF7EF9A0677;430677
zig.exe;resolveTypeFully();7FF7EF99FF9A;42FF9A
zig.exe;resolveStructFully();7FF7EFBE2FC7;672FC7
zig.exe;resolveTypeFully();7FF7EF9A0088;430088
zig.exe;semaDecl();7FF7EF995C9F;425C9F             < new Sema instance created
zig.exe;ensureDeclAnalyzed();7FF7EF7C9F86;259F86
zig.exe;ensureDeclAnalyzed();7FF7F048D8B3;F1D8B3
zig.exe;analyzeDeclRef();7FF7EFF5178F;9E178F
zig.exe;analyzeDeclVal();7FF7F0454CCC;EE4CCC
zig.exe;zirDeclVal();7FF7EFE675A2;8F75A2
zig.exe;analyzeBodyInner();7FF7EFBA3B0C;633B0C
zig.exe;analyzeBodyBreak();7FF7EF996F11;426F11
zig.exe;resolveBody();7FF7F043F65D;ECF65D
zig.exe;semaStructFields();7FF7F04F3B11;F83B11
zig.exe;resolveTypeFieldsStruct();7FF7EFF3BCD7;9CBCD7
zig.exe;resolveTypeFields();7FF7EFBCA349;65A349
zig.exe;validateRunTimeType();7FF7F04E2CBD;F72CBD
zig.exe;validateVarType();7FF7F042AF58;EBAF58
zig.exe;zirAllocMut();7FF7EFE50FB6;8E0FB6
zig.exe;analyzeBodyInner();7FF7EFBA1DD2;631DD2
zig.exe;resolveBlockBody();7FF7F0488145;F18145
zig.exe;zirBlock();7FF7EFF2C514;9BC514
zig.exe;analyzeBodyInner();7FF7EFBB84C8;6484C8
zig.exe;analyzeBody();7FF7EFE073EF;8973EF
zig.exe;analyzeFnBody();7FF7EFB89F9D;619F9D
zig.exe;ensureFuncBodyAnalyzed();7FF7EF975C96;405C96
zig.exe;ensureFuncBodyAnalyzed();7FF7F0513E4A;FA3E4A
zig.exe;resolveInferredErrorSet();7FF7EFF66050;9F6050
zig.exe;analyzeIsNonErrComptimeOnly();7FF7EFF28F10;9B8F10
zig.exe;analyzeIsNonErr();7FF7F04639CB;EF39CB
zig.exe;zirIsNonErr();7FF7EFE7297B;90297B
zig.exe;analyzeBodyInner();7FF7EFBA599E;63599E
zig.exe;resolveBlockBody();7FF7F0488145;F18145
zig.exe;zirBlock();7FF7EFF2C514;9BC514
zig.exe;analyzeBodyInner();7FF7EFBB84C8;6484C8
zig.exe;resolveBlockBody();7FF7F0488145;F18145
zig.exe;zirBlock();7FF7EFF2C514;9BC514
zig.exe;analyzeBodyInner();7FF7EFBB84C8;6484C8
zig.exe;resolveBlockBody();7FF7F0488145;F18145
zig.exe;zirSwitchBlock();7FF7EFE82F91;912F91
zig.exe;analyzeBodyInner();7FF7EFBA6E12;636E12
zig.exe;resolveBlockBody();7FF7F0488145;F18145
zig.exe;zirBlock();7FF7EFF2C514;9BC514
zig.exe;analyzeBodyInner();7FF7EFBB84C8;6484C8
zig.exe;analyzeBody();7FF7EFE073EF;8973EF
zig.exe;analyzeCall();7FF7F044A94D;EDA94D
zig.exe;zirBuiltinCall();7FF7EFEC387D;95387D
zig.exe;analyzeBodyInner();7FF7EFBAA262;63A262
zig.exe;resolveBlockBody();7FF7F0488145;F18145
zig.exe;zirBlock();7FF7EFF2C514;9BC514
zig.exe;analyzeBodyInner();7FF7EFBB84C8;6484C8
zig.exe;analyzeBody();7FF7EFE073EF;8973EF
zig.exe;analyzeCall();7FF7F044A94D;EDA94D
zig.exe;zirCall();7FF7EFE62F1F;8F2F1F
zig.exe;analyzeBodyInner();7FF7EFBA3151;633151
zig.exe;analyzeBodyBreak();7FF7EF996F11;426F11
zig.exe;resolveBody();7FF7F043F65D;ECF65D
zig.exe;zirCall();7FF7EFE62A6D;8F2A6D
zig.exe;analyzeBodyInner();7FF7EFBA3151;633151
zig.exe;resolveBlockBody();7FF7F0488145;F18145
zig.exe;zirBlock();7FF7EFF2C514;9BC514
zig.exe;analyzeBodyInner();7FF7EFBB84C8;6484C8
zig.exe;analyzeBody();7FF7EFE073EF;8973EF
zig.exe;analyzeFnBody();7FF7EFB89F9D;619F9D       < state first promoted here
zig.exe;ensureFuncBodyAnalyzed();7FF7EF975C96;405C96
zig.exe;processOneJob();7FF7EF973C2E;403C2E
zig.exe;performAllTheWork();7FF7EF824905;2B4905
zig.exe;update();7FF7EF820DB5;2B0DB5
zig.exe;updateModule();7FF7EF84EB22;2DEB22
zig.exe;buildOutputType();7FF7EF6C8499;158499
zig.exe;mainArgs();7FF7EF69C246;12C246
zig.exe;main();7FF7EF69BDEF;12BDEF
zig.exe;main();7FF7EF69DC22;12DC22
zig.exe;;7FF7F151AF06;1FAAF06
zig.exe;;7FF7F151AF6C;1FAAF6C
kernel32.dll;;7FFB45507604;17604
ntdll.dll;;7FFB45BE26A1;526A1
```