### PR TITLE
sema: add compile error for coercing a slice to an anyopaque pointer

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -25093,6 +25093,13 @@ fn coerceExtra(
                     } };
                     break :pointer;
                 }
+                if (inst_ty.isSlice()) {
+                    in_memory_result = .{ .slice_to_anyopaque = .{
+                        .actual = inst_ty,
+                        .wanted = dest_ty,
+                    } };
+                    break :pointer;
+                }
                 return sema.coerceCompatiblePtrs(block, dest_ty, inst, inst_src);
             }
 
@@ -25603,6 +25610,7 @@ const InMemoryCoercionResult = union(enum) {
     ptr_bit_range: BitRange,
     ptr_alignment: IntPair,
     double_ptr_to_anyopaque: Pair,
+    slice_to_anyopaque: Pair,
 
     const Pair = struct {
         actual: Type,
@@ -25899,6 +25907,13 @@ const InMemoryCoercionResult = union(enum) {
                 try sema.errNote(block, src, msg, "cannot implicitly cast double pointer '{}' to anyopaque pointer '{}'", .{
                     pair.actual.fmt(sema.mod), pair.wanted.fmt(sema.mod),
                 });
+                break;
+            },
+            .slice_to_anyopaque => |pair| {
+                try sema.errNote(block, src, msg, "cannot implicitly cast slice '{}' to anyopaque pointer '{}'", .{
+                    pair.actual.fmt(sema.mod), pair.wanted.fmt(sema.mod),
+                });
+                try sema.errNote(block, src, msg, "consider using '.ptr'", .{});
                 break;
             },
         };

--- a/test/cases/compile_errors/slice_to_anyopaque_pointer.zig
+++ b/test/cases/compile_errors/slice_to_anyopaque_pointer.zig
@@ -1,0 +1,13 @@
+export fn entry() void {
+    const slice: []const u8 = "foo";
+    const x = @as(*const anyopaque, slice);
+    _ = x;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:37: error: expected type '*const anyopaque', found '[]const u8'
+// :3:37: note: cannot implicitly cast slice '[]const u8' to anyopaque pointer '*const anyopaque'
+// :3:37: note: consider using '.ptr'


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/14917. 

This change makes coercing a slice (directly, ie. without using `.ptr`) to an anyopaque pointer a compile error. Short discussion in Discord [here](https://discord.com/channels/605571803288698900/785499283368706060/1099927070466900008).

Instead of crashing there is now a compile error alerting the user that the coercion isn't possible:

```
src\main.zig:36:44: error: expected type '?*const anyopaque', found '[]const u8'
    _ = pocketmod.pocketmod_init(&pmodctx, mod_data, mod_data.len, 44100);
                                           ^~~~~~~~
C:\cygwin64\home\kcbanner\temp\zig-embeddir\zig-cache\o\d9a8c17a208fb48bf628a30a3cafa090\cimport.zig:79:62: note: parameter type declared here
pub extern fn pocketmod_init(c: [*c]pocketmod_context, data: ?*const anyopaque, size: c_int, rate: c_int) c_int;
```

If the coercion isn't nested in an optional (ie. `report_err = true`), then there are more detailed notes, and a hint to use `.ptr`:

```
src\reduction2.zig:3:31: error: expected type '*anyopaque', found '[]u8'
    const x = @as(*anyopaque, slice);
                              ^~~~~
src\reduction2.zig:3:31: note: cannot implicitly cast slice '[]u8' to anyopaque pointer '*anyopaque'
src\reduction2.zig:3:31: note: consider using '.ptr'
```