### PR TITLE
std.http.Server - fix closing connection on subsequent keep-alive requests

### DIFF
--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -465,7 +465,7 @@ pub const Response = struct {
         try res.request.parse(res.request.parser.header_bytes.items);
 
         const res_connection = res.headers.getFirstValue("connection");
-        const res_keepalive = res_connection != null and !std.ascii.eqlIgnoreCase("close", res_connection.?);
+        const res_keepalive = res_connection == null or !std.ascii.eqlIgnoreCase("close", res_connection.?);
 
         const req_connection = res.request.headers.getFirstValue("connection");
         const req_keepalive = req_connection != null and !std.ascii.eqlIgnoreCase("close", req_connection.?);


### PR DESCRIPTION
This patch fixes a small but subtle bug (??) that prevents keep-alive connections from actually staying open between requests with the examples. 


Reasoning:
- In Response.do() .. there is logic to default the response connection to keep-alive if not specifically set in the headers (lines 393-395) 
- However, in Response.wait() ... if the response header isn't set yet, then the existing AND logic on line 468 will mean that response connection defaults to 'close' instead.
 
This then ends up setting res.connection.conn.closing = true (line 475), which in turn will close the connection on the next  call to Response.reset()

Using the example threaded handler with the while loop , it will process the 1st response correctly, then detect the closing == true condition, break the while loop, and terminate the thread.  

End result is that even though the headers on both req and res are showing correct keep-alive behaviour in the browser tools ... its actually spawning a new thread for each keep alive request, handling 1 request, then closing :(

I know that std.http.Server isnt meant to be a production web server or anything ... but the problem is that the examples are not necessarily looping the way they look like they should, which maybe gives incorrect feedback on whether or not the reset() calls are working or not.

Tested this by manually  by adding hacks to force connection.conn.closing after res.wait()
See example hacks here :
https://gist.github.com/zigster64/955298295f43c6d50975d48cfd389614

Performance wise, there is a measurable speed up when the keep alive is working properly.  Can now expect sub-millisecond responses to requests on a busy page.