### PR TITLE
enable debugging infrastructure when using C backend

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -868,8 +868,7 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace, ret_addr
 
     // For backends that cannot handle the language features depended on by the
     // default panic handler, we have a simpler panic handler:
-    if (builtin.zig_backend == .stage2_c or
-        builtin.zig_backend == .stage2_wasm or
+    if (builtin.zig_backend == .stage2_wasm or
         builtin.zig_backend == .stage2_arm or
         builtin.zig_backend == .stage2_aarch64 or
         builtin.zig_backend == .stage2_x86_64 or

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1360,13 +1360,7 @@ pub const DebugInfo = struct {
     }
 
     pub fn getModuleForAddress(self: *DebugInfo, address: usize) !*ModuleDebugInfo {
-        if (builtin.zig_backend == .stage2_c) {
-            return @as(error{
-                InvalidDebugInfo,
-                MissingDebugInfo,
-                UnsupportedBackend,
-            }, error.UnsupportedBackend);
-        } else if (comptime builtin.target.isDarwin()) {
+        if (comptime builtin.target.isDarwin()) {
             return self.lookupModuleDyld(address);
         } else if (native_os == .windows) {
             return self.lookupModuleWin32(address);
@@ -1380,9 +1374,7 @@ pub const DebugInfo = struct {
     }
 
     pub fn getModuleNameForAddress(self: *DebugInfo, address: usize) ?[]const u8 {
-        if (builtin.zig_backend == .stage2_c) {
-            return null;
-        } else if (comptime builtin.target.isDarwin()) {
+        if (comptime builtin.target.isDarwin()) {
             return null;
         } else if (native_os == .windows) {
             return self.lookupModuleNameWin32(address);
@@ -2191,8 +2183,6 @@ pub fn dumpStackPointerAddr(prefix: []const u8) void {
 }
 
 test "manage resources correctly" {
-    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // error.UnsupportedBackend
-
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
     if (builtin.os.tag == .windows and builtin.cpu.arch == .x86_64) {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -5371,8 +5371,10 @@ pub fn dl_iterate_phdr(
 ) Error!void {
     const Context = @TypeOf(context);
 
-    if (builtin.object_format != .elf)
-        @compileError("dl_iterate_phdr is not available for this target");
+    switch (builtin.object_format) {
+        .elf, .c => {},
+        else => @compileError("dl_iterate_phdr is not available for this target"),
+    }
 
     if (builtin.link_libc) {
         switch (system.dl_iterate_phdr(struct {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -6629,7 +6629,8 @@ pub fn backendSupportsFeature(mod: Module, feature: Feature) bool {
             mod.comp.bin_file.options.use_llvm,
         .panic_unwrap_error => mod.comp.bin_file.options.target.ofmt == .c or
             mod.comp.bin_file.options.use_llvm,
-        .safety_check_formatted => mod.comp.bin_file.options.use_llvm,
+        .safety_check_formatted => mod.comp.bin_file.options.target.ofmt == .c or
+            mod.comp.bin_file.options.use_llvm,
         .error_return_trace => mod.comp.bin_file.options.use_llvm,
         .is_named_enum_value => mod.comp.bin_file.options.use_llvm,
         .error_set_has_value => mod.comp.bin_file.options.use_llvm or mod.comp.bin_file.options.target.isWasm(),


### PR DESCRIPTION
Thanks to @jacobly0's recent enhancements to the C backend, this stuff works now.

Example code:

```zig
pub fn main() !void {
    foo();
}

fn foo() void {
    @panic("crash");
}
```

With these changes, I was able to get the following output:


```
$ stage4/bin/zig run test.zig -ofmt=c -lc
thread 2170091 panic: crash
/home/andy/.cache/zig/o/94655884186a733d45f84ff29e3268a1/test.c:3808:2: 0x20e3f6 in test_foo__148 (/home/andy/.cache/zig/o/94655884186a733d45f84ff29e3268a1/test.c)
 builtin_default_panic__192((anon__148_39){(uint8_t const *)((uint8_t const *)&test_foo__anon_2586__2586), (uintptr_t)5ul}, ((struct StackTrace__991 *)NULL), (anon__148_43){ .payload = (uintptr_t)0xaaaaaaaaaaaaaaaaul, .is_null = true });
 ^
/home/andy/.cache/zig/o/94655884186a733d45f84ff29e3268a1/test.c:3513:2: 0x20e308 in test_main__147 (/home/andy/.cache/zig/o/94655884186a733d45f84ff29e3268a1/test.c)
 test_foo__148();
 ^
/home/andy/.cache/zig/o/94655884186a733d45f84ff29e3268a1/test.c:3743:8: 0x20daf7 in main (/home/andy/.cache/zig/o/94655884186a733d45f84ff29e3268a1/test.c)
 (void)test_main__147();
       ^
???:?:?: 0x7f4f90ccf24d in ??? (???)
???:?:?: 0x0 in ??? (???)
???:?:?: 0x686361632e2f7963 in ??? (???)
Aborted (core dumped)
```

However, without `-lc` I get this:

```
$ stage4/bin/zig run test.zig -ofmt=c
error(compilation): clang failed with stderr: /home/andy/.cache/zig/o/7f613643629e5d7da6f22572739e6a20/test.c:35749:63: error: use of undeclared identifier '_DYNAMIC'

/home/andy/.cache/zig/o/7f613643629e5d7da6f22572739e6a20/test.c:1:1: error: unable to build C object: clang exited with code 1
```

So that will need to be solved before this is merged. Reduction:

```zig
const std = @import("std");

pub fn main() !void {
    var x = get_DYNAMIC();
    _ = x;
}

pub fn get_DYNAMIC() ?[*]i32 {
    return @extern([*]i32, .{ .name = "_DYNAMIC", .linkage = .Weak });
}
```

```
$ stage4/bin/zig run test.zig  -ofmt=c
error(compilation): clang failed with stderr: /home/andy/.cache/zig/o/066858da9004c77a5fa0f6bbdbb578dc/test.c:5109:33: error: use of undeclared identifier '_DYNAMIC'
/home/andy/.cache/zig/o/066858da9004c77a5fa0f6bbdbb578dc/test.c:38133:63: error: use of undeclared identifier '_DYNAMIC'
```
