### PR TITLE
stage2: implement `--build-id` styles

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -165,8 +165,11 @@ pub fn build(b: *std.Build) !void {
     exe.strip = strip;
     exe.pie = pie;
     exe.sanitize_thread = sanitize_thread;
-    exe.build_id = b.option(bool, "build-id", "Include a build id note") orelse false;
     exe.entitlements = entitlements;
+
+    if (b.option([]const u8, "build-id", "Include a build id note")) |build_id|
+        exe.build_id = try std.Build.CompileStep.BuildId.parse(b.allocator, build_id);
+
     b.installArtifact(exe);
 
     test_step.dependOn(&exe.step);

--- a/build.zig
+++ b/build.zig
@@ -167,8 +167,11 @@ pub fn build(b: *std.Build) !void {
     exe.sanitize_thread = sanitize_thread;
     exe.entitlements = entitlements;
 
-    if (b.option([]const u8, "build-id", "Include a build id note")) |build_id|
-        exe.build_id = try std.Build.CompileStep.BuildId.parse(b.allocator, build_id);
+    exe.build_id = b.option(
+        std.Build.Step.Compile.BuildId,
+        "build-id",
+        "Request creation of '.note.gnu.build-id' section",
+    );
 
     b.installArtifact(exe);
 

--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -235,6 +235,10 @@ pub const HashHelper = struct {
                     .none => {},
                 }
             },
+            std.Build.Step.Compile.BuildId => switch (x) {
+                .none, .fast, .uuid, .sha1, .md5 => hh.add(std.meta.activeTag(x)),
+                .hexstring => |hex_string| hh.addBytes(hex_string.toSlice()),
+            },
             else => switch (@typeInfo(@TypeOf(x))) {
                 .Bool, .Int, .Enum, .Array => hh.addBytes(mem.asBytes(&x)),
                 else => @compileError("unable to hash type " ++ @typeName(@TypeOf(x))),

--- a/src/link.zig
+++ b/src/link.zig
@@ -158,7 +158,7 @@ pub const Options = struct {
     skip_linker_dependencies: bool,
     parent_compilation_link_libc: bool,
     each_lib_rpath: bool,
-    build_id: ?BuildId,
+    build_id: BuildId,
     disable_lld_caching: bool,
     is_test: bool,
     hash_style: HashStyle,

--- a/src/link.zig
+++ b/src/link.zig
@@ -10,6 +10,7 @@ const wasi_libc = @import("wasi_libc.zig");
 
 const Air = @import("Air.zig");
 const Allocator = std.mem.Allocator;
+const BuildId = std.Build.CompileStep.BuildId;
 const Cache = std.Build.Cache;
 const Compilation = @import("Compilation.zig");
 const LibCInstallation = @import("libc_installation.zig").LibCInstallation;
@@ -157,7 +158,7 @@ pub const Options = struct {
     skip_linker_dependencies: bool,
     parent_compilation_link_libc: bool,
     each_lib_rpath: bool,
-    build_id: bool,
+    build_id: ?BuildId,
     disable_lld_caching: bool,
     is_test: bool,
     hash_style: HashStyle,

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1399,7 +1399,8 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
         man.hash.add(self.base.options.each_lib_rpath);
         if (self.base.options.output_mode == .Exe) {
             man.hash.add(stack_size);
-            man.hash.add(self.base.options.build_id);
+            if (self.base.options.build_id) |build_id|
+                build_id.hash(&man.hash.hasher);
         }
         man.hash.addListOfBytes(self.base.options.symbol_wrap_set.keys());
         man.hash.add(self.base.options.skip_linker_dependencies);
@@ -1542,8 +1543,12 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
             try argv.append("-z");
             try argv.append(try std.fmt.allocPrint(arena, "stack-size={d}", .{stack_size}));
 
-            if (self.base.options.build_id) {
-                try argv.append("--build-id");
+            if (self.base.options.build_id) |build_id| {
+                const fmt_str = "--build-id={s}{s}";
+                try argv.append(switch (build_id) {
+                    .hexstring => |str| try std.fmt.allocPrint(arena, fmt_str, .{ "0x", str }),
+                    .none, .fast, .uuid, .sha1, .md5 => try std.fmt.allocPrint(arena, fmt_str, .{ "", @tagName(build_id) }),
+                });
             }
         }
 


### PR DESCRIPTION
The hash of the build-id of the wasm binaries will change, because we are hashing a bit less now.

Deprecates `-fbuild-id` and `-fno-build-id` in favor of `--build-id[=style]`.

Fixes #12777