### PR TITLE
std: further windows resource fix

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1397,6 +1397,7 @@ pub const Dir = struct {
             .capable_io_mode = std.io.default_mode,
             .intended_io_mode = flags.intended_io_mode,
         };
+        errdefer file.close();
         var io: w.IO_STATUS_BLOCK = undefined;
         const range_off: w.LARGE_INTEGER = 0;
         const range_len: w.LARGE_INTEGER = 1;


### PR DESCRIPTION
addition to #15450
`createFileW` does not account for when  `LockFile` fails. This can result in a file handle not being closed on failure Which can be seen on test such as `open file with exclusive nonblocking lock twice` here:
https://github.com/ziglang/zig/blob/d8bdfd8192fb43ca8f6abd223396a4073e369499/lib/std/fs/test.zig#L1030-L1050

this can also be observed by finding the file specified in the test in the `zig-cache` due to failure in cleanup.