### PR TITLE
fs.Dir.deleteTree: Add configurable max_retries to avoid infinite loops

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -99,7 +99,7 @@ pub fn main() !void {
     var toc = try genToc(allocator, &tokenizer);
 
     try fs.cwd().makePath(tmp_dir_name);
-    defer fs.cwd().deleteTree(tmp_dir_name) catch {};
+    defer fs.cwd().deleteTree(tmp_dir_name, .{}) catch {};
 
     try genHtml(allocator, &tokenizer, &toc, buffered_writer.writer(), zig_exe, opt_zig_lib_dir, do_code_tests);
     try buffered_writer.flush();

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -776,7 +776,7 @@ fn makeUninstall(uninstall_step: *Step, prog_node: *std.Progress.Node) anyerror!
         if (self.verbose) {
             log.info("rm {s}", .{full_path});
         }
-        fs.cwd().deleteTree(full_path) catch {};
+        fs.cwd().deleteTree(full_path, .{}) catch {};
     }
 
     // TODO remove empty directories

--- a/lib/std/Build/RemoveDirStep.zig
+++ b/lib/std/Build/RemoveDirStep.zig
@@ -28,7 +28,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     const b = step.owner;
     const self = @fieldParentPtr(RemoveDirStep, "step", step);
 
-    b.build_root.handle.deleteTree(self.dir_path) catch |err| {
+    b.build_root.handle.deleteTree(self.dir_path, .{}) catch |err| {
         if (b.build_root.path) |base| {
             return step.fail("unable to recursively delete path '{s}/{s}': {s}", .{
                 base, self.dir_path, @errorName(err),

--- a/lib/std/fs/watch.zig
+++ b/lib/std/fs/watch.zig
@@ -643,7 +643,7 @@ test "write a file, watch it, write it again, delete it" {
     if (builtin.single_threaded) return error.SkipZigTest;
 
     try std.fs.cwd().makePath(test_tmp_dir);
-    defer std.fs.cwd().deleteTree(test_tmp_dir) catch {};
+    defer std.fs.cwd().deleteTree(test_tmp_dir, .{}) catch {};
 
     return testWriteWatchWriteDelete(std.testing.allocator);
 }

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -519,7 +519,7 @@ pub const TmpDir = struct {
 
     pub fn cleanup(self: *TmpDir) void {
         self.dir.close();
-        self.parent_dir.deleteTree(&self.sub_path) catch {};
+        self.parent_dir.deleteTree(&self.sub_path, .{}) catch {};
         self.parent_dir.close();
         self.* = undefined;
     }
@@ -535,7 +535,7 @@ pub const TmpIterableDir = struct {
 
     pub fn cleanup(self: *TmpIterableDir) void {
         self.iterable_dir.close();
-        self.parent_dir.deleteTree(&self.sub_path) catch {};
+        self.parent_dir.deleteTree(&self.sub_path, .{}) catch {};
         self.parent_dir.close();
         self.* = undefined;
     }

--- a/src/Package.zig
+++ b/src/Package.zig
@@ -719,7 +719,7 @@ fn renameTmpIntoCache(
             },
             error.PathAlreadyExists, error.AccessDenied => {
                 // Package has been already downloaded and may already be in use on the system.
-                cache_dir.deleteTree(tmp_dir_sub_path) catch |del_err| {
+                cache_dir.deleteTree(tmp_dir_sub_path, .{}) catch |del_err| {
                     std.log.warn("unable to delete temp directory: {s}", .{@errorName(del_err)});
                 };
             },

--- a/src/link.zig
+++ b/src/link.zig
@@ -937,7 +937,7 @@ pub const File = struct {
                 // Work around windows `renameW` can't fail with `PathAlreadyExists`
                 // See https://github.com/ziglang/zig/issues/8362
                 if (cache_directory.handle.access(o_sub_path, .{})) |_| {
-                    try cache_directory.handle.deleteTree(o_sub_path);
+                    try cache_directory.handle.deleteTree(o_sub_path, .{});
                     continue;
                 } else |err| switch (err) {
                     error.FileNotFound => {},
@@ -961,7 +961,7 @@ pub const File = struct {
                     o_sub_path,
                 ) catch |err| switch (err) {
                     error.PathAlreadyExists => {
-                        try cache_directory.handle.deleteTree(o_sub_path);
+                        try cache_directory.handle.deleteTree(o_sub_path, .{});
                         continue;
                     },
                     else => |e| return e,

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -1198,7 +1198,7 @@ fn processOneTarget(job: Job) anyerror!void {
 
     if (all_features.items.len == 0) {
         // We represent this with an empty file.
-        try target_dir.deleteTree(zig_code_basename);
+        try target_dir.deleteTree(zig_code_basename, .{});
         return;
     }
 


### PR DESCRIPTION
Previously, it was possible for deleteTree to get into a state where it would continually retry deleting the same directory over and over infinitely, since it would think all of the children were successfully deleted but when deleting the directory it would hit `error.DirNotEmpty`. Now, there is a (user-configurable) limit to the number of times it will retry deleting directories, and return `error.TooManyRetries` if the limit is exceeded.

Closes #15465, possibly related to #14948

Follow up to https://github.com/ziglang/zig/pull/13073#discussion_r987838660 (cc @matu3ba)

---

Notes:

- `usize` for `max_retries` is definitely overkill, but using a smaller type didn't affect `@sizeOf(StackItem)` in `deleteTree` so I just stuck with `usize`
- Adding the `options` parameter allowed for making `kind_hint` configurable which can be used to save a syscall if you know what the type of `sub_path` is (it's defaulted to `.File` since that's how it's always worked, but maybe `.Directory` would be a better default? Or maybe callsites should just pass `.Directory` more often?)
- I believe the added test relies on the `DeleteFile` behavior added in https://github.com/ziglang/zig/pull/15316 (`DELETE_PENDING` treated as success), relevant issue: https://github.com/ziglang/zig/issues/6452
- It may make some sense to do something like:
```zig
        self.parent_dir.deleteTree(&self.sub_path, .{}) catch |err| switch (err) {
            error.TooManyRetries => {
                @panic("too many retries while deleting tmp dir; it is either being continually modified or a file handle was leaked during the test");
            },
            else => {},
        };
```
in `TmpDir.cleanup`