### PR TITLE
test: Fix windows_spawn tmp directory cleanup

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1434,3 +1434,18 @@ test "delete a read-only file on windows" {
     file.close();
     try tmp.dir.deleteFile("test_file");
 }
+
+test "delete a setAsCwd directory on Windows" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    var tmp = tmpDir(.{});
+    // Set tmp dir as current working directory.
+    try tmp.dir.setAsCwd();
+    tmp.dir.close();
+    try testing.expectError(error.FileBusy, tmp.parent_dir.deleteTree(&tmp.sub_path));
+    // Now set the parent dir as the current working dir for clean up.
+    try tmp.parent_dir.setAsCwd();
+    try tmp.parent_dir.deleteTree(&tmp.sub_path);
+    // Close the parent "tmp" so we don't leak the HANDLE.
+    tmp.parent_dir.close();
+}

--- a/test/standalone/windows_spawn/main.zig
+++ b/test/standalone/windows_spawn/main.zig
@@ -116,6 +116,7 @@ pub fn main() anyerror!void {
 
     // Now let's set the tmp dir as the cwd and set the path only include the "something" sub dir
     try tmp.dir.setAsCwd();
+    defer tmp.parent_dir.setAsCwd() catch {};
     const something_subdir_abs_path = try std.mem.concatWithSentinel(allocator, u16, &.{ tmp_absolute_path_w, utf16Literal("\\something") }, 0);
     defer allocator.free(something_subdir_abs_path);
 


### PR DESCRIPTION
On Windows, a directory that's set as the current working directory is not allowed to be removed. This can cause error on `deleteTree` if the CWD is set to the handle to be removed and will result in `error.FileBusy`. However, due to `tmp.cleanup()` ignoring the errors, the folder removal error will be ignored. (Possibly Related: #15465)

The only test that I found to be violating this is `windows_spawn` as it sets CWD to the tmp dir then tries to remove it. I added a test to verify this occurrence. 

Another option for solving is to always set the CWD to the parent in both `cleanup()` functions: 
https://github.com/ziglang/zig/blob/7285eedcd26b92afb03c313a167133103a78ded5/lib/std/testing.zig#L520-L525

I hate to take another guess, but this \* _might be_ \* be the last test causing the random CI timeouts on Windows (#14948) as it was also re-enabled on #14647 . However, I believe when #15467 is merged, it could also mitigate these from happening all together. 