### PR TITLE
Fix parsing of hexadecimal literals

### DIFF
--- a/lib/std/zig/number_literal.zig
+++ b/lib/std/zig/number_literal.zig
@@ -44,8 +44,6 @@ pub const Error = union(enum) {
     duplicate_period,
     /// Float literal has multiple exponents.
     duplicate_exponent: usize,
-    /// Decimal float has hexadecimal exponent.
-    invalid_hex_exponent: usize,
     /// Exponent comes directly after '_' digit separator.
     exponent_after_underscore: usize,
     /// Special character (+-.) comes directly after exponent.
@@ -103,7 +101,6 @@ pub fn parseNumberLiteral(bytes: []const u8) Result {
             },
             'e', 'E' => if (base == 10) {
                 float = true;
-                if (base != 10 and base != 16) return .{ .failure = .{ .invalid_float_base = 2 } };
                 if (exponent) return .{ .failure = .{ .duplicate_exponent = i } };
                 if (underscore) return .{ .failure = .{ .exponent_after_underscore = i } };
                 special = c;
@@ -112,10 +109,8 @@ pub fn parseNumberLiteral(bytes: []const u8) Result {
             },
             'p', 'P' => if (base == 16) {
                 float = true;
-                if (base != 10 and base != 16) return .{ .failure = .{ .invalid_float_base = 2 } };
                 if (exponent) return .{ .failure = .{ .duplicate_exponent = i } };
                 if (underscore) return .{ .failure = .{ .exponent_after_underscore = i } };
-                if (base != 16) return .{ .failure = .{ .invalid_hex_exponent = i } };
                 special = c;
                 exponent = true;
                 continue;

--- a/lib/std/zig/number_literal.zig
+++ b/lib/std/zig/number_literal.zig
@@ -126,7 +126,8 @@ pub fn parseNumberLiteral(bytes: []const u8) Result {
             },
             '+', '-' => {
                 switch (special) {
-                    'p', 'P', 'e', 'E' => {},
+                    'p', 'P' => {},
+                    'e', 'E' => if (base != 10) return .{ .failure = .{ .invalid_exponent_sign = i } },
                     else => return .{ .failure = .{ .invalid_exponent_sign = i } },
                 }
                 special = c;

--- a/lib/std/zig/number_literal.zig
+++ b/lib/std/zig/number_literal.zig
@@ -118,7 +118,7 @@ pub fn parseNumberLiteral(bytes: []const u8) Result {
             '.' => {
                 float = true;
                 if (base != 10 and base != 16) return .{ .failure = .{ .invalid_float_base = 2 } };
-                if (period) return .{ .failure = .{ .duplicate_exponent = i } };
+                if (period) return .{ .failure = .duplicate_period };
                 period = true;
                 if (underscore) return .{ .failure = .{ .special_after_underscore = i } };
                 special = c;

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -7628,7 +7628,10 @@ fn failWithNumberError(astgen: *AstGen, err: std.zig.number_literal.Error, token
         .trailing_underscore => |i| return astgen.failOff(token, @intCast(u32, i), "trailing digit separator", .{}),
         .duplicate_period => unreachable, // Validated by tokenizer
         .invalid_character => unreachable, // Validated by tokenizer
-        .invalid_exponent_sign => unreachable, // Validated by tokenizer
+        .invalid_exponent_sign => |i| {
+            assert(bytes.len >= 2 and bytes[0] == '0' and bytes[1] == 'x'); // Validated by tokenizer
+            return astgen.failOff(token, @intCast(u32, i), "sign '{c}' cannot follow digit '{c}' in hex base", .{ bytes[i], bytes[i - 1] });
+        },
     }
 }
 

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -7622,7 +7622,6 @@ fn failWithNumberError(astgen: *AstGen, err: std.zig.number_literal.Error, token
         .invalid_digit => |info| return astgen.failOff(token, @intCast(u32, info.i), "invalid digit '{c}' for {s} base", .{ bytes[info.i], @tagName(info.base) }),
         .invalid_digit_exponent => |i| return astgen.failOff(token, @intCast(u32, i), "invalid digit '{c}' in exponent", .{bytes[i]}),
         .duplicate_exponent => |i| return astgen.failOff(token, @intCast(u32, i), "duplicate exponent", .{}),
-        .invalid_hex_exponent => |i| return astgen.failOff(token, @intCast(u32, i), "hex exponent in decimal float", .{}),
         .exponent_after_underscore => |i| return astgen.failOff(token, @intCast(u32, i), "expected digit before exponent", .{}),
         .special_after_underscore => |i| return astgen.failOff(token, @intCast(u32, i), "expected digit before '{c}'", .{bytes[i]}),
         .trailing_special => |i| return astgen.failOff(token, @intCast(u32, i), "expected digit after '{c}'", .{bytes[i - 1]}),

--- a/test/cases/compile_errors/number_literal_bad_exponent.zig
+++ b/test/cases/compile_errors/number_literal_bad_exponent.zig
@@ -1,0 +1,13 @@
+const a = 0x1e-4;
+const b = 0x1e+4;
+const c = 0x1E-4;
+const d = 0x1E+4;
+
+// error
+// backend=stage2
+// target=native
+//
+// :1:15: error: sign '-' cannot follow digit 'e' in hex base
+// :2:15: error: sign '+' cannot follow digit 'e' in hex base
+// :3:15: error: sign '-' cannot follow digit 'E' in hex base
+// :4:15: error: sign '+' cannot follow digit 'E' in hex base


### PR DESCRIPTION
Closes #15480.

The linked issue is caused by the tokenizer not separating tokens between an 'e' and a '+' or '-', so a string like `0xab0e+3` would be tokenized as a single token, while AstGen asserts that the tokenizer doesn't do this. There are two fixes I can see - generate multiple tokens as is done for the string `1+3` or generate an error as it may be a footgun. ~This PR currently generates the addition tokens, so the above example would be tokenized in the same way as `0xab0e + 3` (i.e. as if there were spaces around `+`), but could be reworked to generate an error.~

When a hexadecimal number literal such as `0x12abe-4` is encountered, an error will be reported like this:

<pre><b>test.zig:1:18: </b><font color="#BF616A"><b>error:</b> </font><b>sign &apos;-&apos; cannot follow digit &apos;e&apos; in hex base</b>
const a = 0x12abe-4;
                 <font color="#A3BE8C"><b>^~</b></font>
</pre>
