### PR TITLE
sema: improve the error message when coercing to []anyopaque

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -25323,7 +25323,7 @@ fn coerceExtra(
 
             // cast from *T and [*]T to *anyopaque
             // but don't do it if the source type is a double pointer
-            if (dest_info.pointee_type.tag() == .anyopaque and inst_ty.zigTypeTag() == .Pointer) {
+            if (dest_info.pointee_type.tag() == .anyopaque and inst_ty.zigTypeTag() == .Pointer) to_anyopaque: {
                 if (!sema.checkPtrAttributes(dest_ty, inst_ty, &in_memory_result)) break :pointer;
                 const elem_ty = inst_ty.elemType2();
                 if (elem_ty.zigTypeTag() == .Pointer or elem_ty.isPtrLikeOptional()) {
@@ -25333,6 +25333,7 @@ fn coerceExtra(
                     } };
                     break :pointer;
                 }
+                if (dest_ty.isSlice()) break :to_anyopaque;
                 if (inst_ty.isSlice()) {
                     in_memory_result = .{ .slice_to_anyopaque = .{
                         .actual = inst_ty,

--- a/test/cases/compile_errors/double_pointer_to_anyopaque_pointer.zig
+++ b/test/cases/compile_errors/double_pointer_to_anyopaque_pointer.zig
@@ -15,6 +15,11 @@ pub export fn entry3() void {
     const ptr: *const anyopaque = x;
     _ = ptr;
 }
+export fn entry4() void {
+    var a: []*u32 = undefined;
+    var b: []anyopaque = undefined;
+    b = a;
+}
 
 // error
 // backend=stage2
@@ -27,3 +32,5 @@ pub export fn entry3() void {
 // :11:12: note: parameter type declared here
 // :15:35: error: expected type '*const anyopaque', found '*?*usize'
 // :15:35: note: cannot implicitly cast double pointer '*?*usize' to anyopaque pointer '*const anyopaque'
+// :21:9: error: expected type '[]anyopaque', found '[]*u32'
+// :21:9: note: cannot implicitly cast double pointer '[]*u32' to anyopaque pointer '[]anyopaque'

--- a/test/cases/compile_errors/pointer_to_anyopaque_slice.zig
+++ b/test/cases/compile_errors/pointer_to_anyopaque_slice.zig
@@ -1,0 +1,11 @@
+export fn x() void {
+    var a: *u32 = undefined;
+    var b: []anyopaque = undefined;
+    b = a;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:9: error: expected type '[]anyopaque', found '*u32'


### PR DESCRIPTION
Before this change, the message for the new test case [test/cases/compile_errors/pointer_to_anyopaque_slice.zig](https://github.com/ziglang/zig/pull/15488/files#diff-8f3223e616ca12f5028ff69d0af6d802fcc545e71fe0d5750feb8b8f239742b4) looked like this:

```
test\cases\compile_errors\pointer_to_anyopaque_slice.zig:4:9: error: @bitCast size mismatch: destination type '[]anyopaque' has 128 bits but source type '*u32' has 64 bits
    b = a;
        ^
```

This is the result of this suggestion: https://github.com/ziglang/zig/pull/15434#pullrequestreview-1397607212