### PR TITLE
Fix alined_alloc missing from glibc 2.15 and earlier

### DIFF
--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -174,6 +174,11 @@ pub fn buildLibCXX(comp: *Compilation, prog_node: *std.Progress.Node) !void {
 
         if (target.abi.isMusl()) {
             try cflags.append("-D_LIBCPP_HAS_MUSL_LIBC");
+        } else if (comp.bin_file.options.link_libc and target.isGnuLibC()) {
+            const target_version = target.os.version_range.linux.glibc;
+            if (target_version.major == 2 and target_version.minor < 16) {
+                try cflags.append("-D_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION");
+            }
         }
 
         if (target.os.tag == .wasi) {


### PR DESCRIPTION
I'm not sure if this is the right solution for #15486 but it seems to be working. Unfortunately I can't test it soon with my original use case due to the difficulty of building a zig release locally and the use case being building LLVM in a docker CI build environment