### PR TITLE
Parse --dynamicbase linker arg

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2072,6 +2072,8 @@ fn buildOutputType(
                     linker_tsaware = true;
                 } else if (mem.eql(u8, arg, "--nxcompat")) {
                     linker_nxcompat = true;
+                } else if (mem.eql(u8, arg, "--dynamicbase")) {
+                    linker_dynamicbase = true;
                 } else if (mem.eql(u8, arg, "--no-dynamicbase")) {
                     linker_dynamicbase = false;
                 } else if (mem.eql(u8, arg, "--high-entropy-va")) {


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/15499.

In https://github.com/ziglang/zig/pull/14771 I added support for `--no-dynamicbase`, but I removed the parsing of the `--dynamicbase` linker argument, since being enabled is the default. 

That broke any tooling that still passed `--dynamicbase` to the linker. This PR fixes that.