### PR TITLE
Add .Pointer to baseZigTypeTag function

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -165,6 +165,7 @@ pub const Type = extern union {
     pub fn baseZigTypeTag(self: Type) std.builtin.TypeId {
         return switch (self.zigTypeTag()) {
             .ErrorUnion => self.errorUnionPayload().baseZigTypeTag(),
+            .Pointer => self.ptrInfo().data.pointee_type.baseZigTypeTag(),
             .Optional => {
                 var buf: Payload.ElemType = undefined;
                 return self.optionalChild(&buf).baseZigTypeTag();


### PR DESCRIPTION
It could be useful to get pointer base type too