### PR TITLE
netbsd: pkgsrc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,8 @@ if(ZIG_AR_WORKAROUND)
   string(REPLACE "<CMAKE_AR>" "<CMAKE_AR> ar" CMAKE_CXX_ARCHIVE_CREATE ${CMAKE_CXX_ARCHIVE_CREATE})
 endif()
 
+set(ZIG_PIE off CACHE BOOL "produce a position independent zig executable")
+
 find_package(llvm 16)
 find_package(clang 16)
 find_package(lld 16)
@@ -671,7 +673,12 @@ if(ZIG_STATIC)
 endif()
 
 add_library(zigcpp STATIC ${ZIG_CPP_SOURCES})
-set_target_properties(zigcpp PROPERTIES COMPILE_FLAGS ${EXE_CXX_FLAGS})
+if(ZIG_PIE)
+    set(ZIGCPP_CXX_FLAGS "${EXE_CXX_FLAGS} -fPIC")
+else()
+    set(ZIGCPP_CXX_FLAGS "${EXE_CXX_FLAGS}")
+endif()
+set_target_properties(zigcpp PROPERTIES COMPILE_FLAGS ${ZIGCPP_CXX_FLAGS})
 
 target_link_libraries(zigcpp LINK_PUBLIC
     ${CLANG_LIBRARIES}
@@ -823,10 +830,10 @@ else()
   set(ZIG_STATIC_ARG "")
 endif()
 
-if(CMAKE_POSITION_INDEPENDENT_CODE)
-  set(ZIG_PIE_ARG="-Dpie")
+if(CMAKE_POSITION_INDEPENDENT_CODE OR ZIG_PIE)
+  set(ZIG_PIE_ARG "-Dpie")
 else()
-  set(ZIG_PIE_ARG="")
+  set(ZIG_PIE_ARG "")
 endif()
 
 set(ZIG_BUILD_ARGS

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1654,10 +1654,10 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
             try argv.append("-pie");
         }
 
-        if (self.base.options.link_mode == .Dynamic and target.os.tag == .netbsd) {
+        if (is_dyn_lib and target.os.tag == .netbsd) {
             // Add options to produce shared objects with only 2 PT_LOAD segments.
             // NetBSD expects 2 PT_LOAD segments in a shared object, otherwise
-            // ld.elf_so fails to load, emitting a general "not found" error.
+            // ld.elf_so fails loading dynamic libraries with "not found" error.
             // See https://github.com/ziglang/zig/issues/9109 .
             try argv.append("--no-rosegment");
             try argv.append("-znorelro");


### PR DESCRIPTION
Add enough support to enable building zig in netbsd's pkgsrc tree. PIE and RELRO are general requirements for their tree.

for PIE support, a cmake `ZIG_PIE` option is added which does two things:
1. builds `libzigcpp.a` with `-fPIC`
2. passes `-Dpie` to stage3 build args

for RELRO support, an old workaround's scope was too wide and is now narrowed to apply to dynamic libraries only. Side note, this unfortunately doesn't fix `ld.lld` to support RELRO dynamic libraries but the effect of this PR does allow zig to create PIE executables.

closes #14420