### PR TITLE
std: fix a bunch of typos

### DIFF
--- a/lib/std/Build/Cache/DepTokenizer.zig
+++ b/lib/std/Build/Cache/DepTokenizer.zig
@@ -829,7 +829,7 @@ test "error illegal char at position - bad target escape" {
     );
 }
 
-test "error illegal char at position - execting dollar_sign" {
+test "error illegal char at position - expecting dollar_sign" {
     try depTokenizer("$\t",
         \\ERROR: illegal char \x09 at position 1: expecting '$'
     );

--- a/lib/std/Build/CheckObjectStep.zig
+++ b/lib/std/Build/CheckObjectStep.zig
@@ -68,7 +68,7 @@ const SearchPhrase = struct {
     }
 };
 
-/// There two types of actions currently suported:
+/// There two types of actions currently supported:
 /// * `.match` - is the main building block of standard matchers with optional eat-all token `{*}`
 /// and extractors by name such as `{n_value}`. Please note this action is very simplistic in nature
 /// i.e., it won't really handle edge cases/nontrivial examples. But given that we do want to use

--- a/lib/std/Build/RunStep.zig
+++ b/lib/std/Build/RunStep.zig
@@ -90,7 +90,7 @@ pub const StdIo = union(enum) {
     /// certain conditions, and the step will succeed or fail based on these
     /// conditions.
     /// Note that an explicit check for exit code 0 needs to be added to this
-    /// list if such a check is desireable.
+    /// list if such a check is desirable.
     check: std.ArrayList(Check),
     /// This RunStep is running a zig unit test binary and will communicate
     /// extra metadata over the IPC protocol.

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -37,7 +37,7 @@ result_duration_ns: ?u64,
 result_peak_rss: usize,
 test_results: TestResults,
 
-/// The return addresss associated with creation of this step that can be useful
+/// The return address associated with creation of this step that can be useful
 /// to print along with debugging messages.
 debug_stack_trace: [n_debug_stack_frames]usize,
 

--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -469,8 +469,8 @@ const UnsupportedImpl = struct {
         return unsupported(self);
     }
 
-    fn unsupported(unusued: anytype) noreturn {
-        _ = unusued;
+    fn unsupported(unused: anytype) noreturn {
+        _ = unused;
         @compileError("Unsupported operating system " ++ @tagName(target.os.tag));
     }
 };

--- a/lib/std/Thread/Condition.zig
+++ b/lib/std/Thread/Condition.zig
@@ -261,7 +261,7 @@ const FutexImpl = struct {
             const signals = (state & signal_mask) / one_signal;
 
             // Reserves which waiters to wake up by incrementing the signals count.
-            // Therefor, the signals count is always less than or equal to the waiters count.
+            // Therefore, the signals count is always less than or equal to the waiters count.
             // We don't need to Futex.wake if there's nothing to wake up or if other wake() threads have reserved to wake up the current waiters.
             const wakeable = waiters - signals;
             if (wakeable == 0) {

--- a/lib/std/Thread/Futex.zig
+++ b/lib/std/Thread/Futex.zig
@@ -772,7 +772,7 @@ const PosixImpl = struct {
 
         waiter.event.wait(timeout) catch {
             // If we fail to cancel after a timeout, it means a wake() thread dequeued us and will wake us up.
-            // We must wait until the event is set as that's a signal that the wake() thread wont access the waiter memory anymore.
+            // We must wait until the event is set as that's a signal that the wake() thread won't access the waiter memory anymore.
             // If we return early without waiting, the waiter on the stack would be invalidated and the wake() thread risks a UAF.
             defer if (!cancelled) waiter.event.wait(null) catch unreachable;
 

--- a/lib/std/atomic/Atomic.zig
+++ b/lib/std/atomic/Atomic.zig
@@ -31,7 +31,7 @@ pub fn Atomic(comptime T: type) type {
         ///         // Release ensures code before unref() happens-before the count is decremented as dropFn could be called by then.
         ///         if (self.count.fetchSub(1, .Release)) {
         ///             // Acquire ensures count decrement and code before previous unrefs()s happens-before we call dropFn below.
-        ///             // NOTE: another alterative is to use .AcqRel on the fetchSub count decrement but it's extra barrier in possibly hot path.
+        ///             // NOTE: another alternative is to use .AcqRel on the fetchSub count decrement but it's extra barrier in possibly hot path.
         ///             self.count.fence(.Acquire);
         ///             (self.dropFn)(self);
         ///         }

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -749,7 +749,7 @@ pub const PrefetchOptions = struct {
     /// 3 means high temporal locality. That is, the data should be kept in
     /// the cache as it is likely to be accessed again soon.
     locality: u2 = 3,
-    /// The cache that the prefetch should be preformed on.
+    /// The cache that the prefetch should be performed on.
     cache: Cache = .data,
 
     pub const Rw = enum(u1) {

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -178,13 +178,13 @@ pub extern "c" fn __getdirentries64(fd: c_int, buf_ptr: [*]u8, buf_len: usize, b
 
 const private = struct {
     extern "c" fn fstat(fd: fd_t, buf: *Stat) c_int;
-    /// On x86_64 Darwin, fstat has to be manully linked with $INODE64 suffix to
+    /// On x86_64 Darwin, fstat has to be manually linked with $INODE64 suffix to
     /// force 64bit version.
     /// Note that this is fixed on aarch64 and no longer necessary.
     extern "c" fn @"fstat$INODE64"(fd: fd_t, buf: *Stat) c_int;
 
     extern "c" fn fstatat(dirfd: fd_t, path: [*:0]const u8, stat_buf: *Stat, flags: u32) c_int;
-    /// On x86_64 Darwin, fstatat has to be manully linked with $INODE64 suffix to
+    /// On x86_64 Darwin, fstatat has to be manually linked with $INODE64 suffix to
     /// force 64bit version.
     /// Note that this is fixed on aarch64 and no longer necessary.
     extern "c" fn @"fstatat$INODE64"(dirfd: fd_t, path_name: [*:0]const u8, buf: *Stat, flags: u32) c_int;
@@ -2643,7 +2643,7 @@ pub const F = struct {
     pub const ADDSIGS = 59;
     /// add signature from same file (used by dyld for shared libs)
     pub const ADDFILESIGS = 61;
-    /// used in conjunction with F.NOCACHE to indicate that DIRECT, synchonous writes
+    /// used in conjunction with F.NOCACHE to indicate that DIRECT, synchronous writes
     /// should not be used (i.e. its ok to temporaily create cached pages)
     pub const NODIRECT = 62;
     ///Get the protection class of a file from the EA, returns int
@@ -3866,4 +3866,4 @@ pub const MIN = struct {
     pub const ANONYMOUS = 0x80;
 };
 
-pub extern "c" fn mincore(addr: *align(std.mem.page_size) const anyopaque, lengh: usize, vec: [*]u8) c_int;
+pub extern "c" fn mincore(addr: *align(std.mem.page_size) const anyopaque, length: usize, vec: [*]u8) c_int;

--- a/lib/std/c/solaris.zig
+++ b/lib/std/c/solaris.zig
@@ -1822,7 +1822,7 @@ pub const file_obj = extern struct {
     name: [*:0]u8,
 };
 
-// struct ifreq is marked obsolete, with struct lifreq prefered for interface requests.
+// struct ifreq is marked obsolete, with struct lifreq preferred for interface requests.
 // Here we alias lifreq to ifreq to avoid chainging existing code in os and x.os.IPv6.
 pub const SIOCGLIFINDEX = IOWR('i', 133, lifreq);
 pub const SIOCGIFINDEX = SIOCGLIFINDEX;

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -1174,7 +1174,7 @@ fn windowsCreateProcess(app_name: [*:0]u16, cmd_line: [*:0]u16, envp_ptr: ?[*]u1
     );
 }
 
-/// Case-insenstive UTF-16 lookup
+/// Case-insensitive UTF-16 lookup
 fn windowsCreateProcessSupportsExtension(ext: []const u16) bool {
     if (ext.len != 4) return false;
     const State = enum {

--- a/lib/std/compress/deflate/huffman_code.zig
+++ b/lib/std/compress/deflate/huffman_code.zig
@@ -421,7 +421,7 @@ test "generate a Huffman code from an array of frequencies" {
     try testing.expectEqual(@as(u16, 0x3f), enc.codes[16].code);
 }
 
-test "generate a Huffman code for the fixed litteral table specific to Deflate" {
+test "generate a Huffman code for the fixed literal table specific to Deflate" {
     var enc = try generateFixedLiteralEncoding(testing.allocator);
     defer enc.deinit();
 }

--- a/lib/std/crypto/25519/edwards25519.zig
+++ b/lib/std/crypto/25519/edwards25519.zig
@@ -137,7 +137,7 @@ pub const Edwards25519 = struct {
         };
     }
 
-    /// Substract two Edwards25519 points.
+    /// Subtract two Edwards25519 points.
     pub fn sub(p: Edwards25519, q: Edwards25519) Edwards25519 {
         return p.add(q.neg());
     }
@@ -529,7 +529,7 @@ test "edwards25519 packing/unpacking" {
     }
 }
 
-test "edwards25519 point addition/substraction" {
+test "edwards25519 point addition/subtraction" {
     var s1: [32]u8 = undefined;
     var s2: [32]u8 = undefined;
     crypto.random.bytes(&s1);

--- a/lib/std/crypto/25519/field.zig
+++ b/lib/std/crypto/25519/field.zig
@@ -179,7 +179,7 @@ pub const Fe = struct {
         return fe;
     }
 
-    /// Substract a field element
+    /// Subtract a field element
     pub inline fn sub(a: Fe, b: Fe) Fe {
         var fe = b;
         comptime var i = 0;

--- a/lib/std/crypto/Certificate.zig
+++ b/lib/std/crypto/Certificate.zig
@@ -1134,9 +1134,9 @@ pub const rsa = struct {
         return res;
     }
 
-    fn setBytes(r: *BigInt, bytes: []const u8, allcator: std.mem.Allocator) !void {
+    fn setBytes(r: *BigInt, bytes: []const u8, allocator: std.mem.Allocator) !void {
         try r.set(0);
-        var tmp = try BigInt.init(allcator);
+        var tmp = try BigInt.init(allocator);
         defer tmp.deinit();
         for (bytes) |b| {
             try r.shiftLeft(r, 8);

--- a/lib/std/crypto/errors.zig
+++ b/lib/std/crypto/errors.zig
@@ -10,7 +10,7 @@ pub const IdentityElementError = error{IdentityElement};
 /// Encoded input cannot be decoded
 pub const EncodingError = error{InvalidEncoding};
 
-/// The signature does't verify for the given message and public key
+/// The signature doesn't verify for the given message and public key
 pub const SignatureVerificationError = error{SignatureVerificationFailed};
 
 /// Both a public and secret key have been provided, but they are incompatible

--- a/lib/std/crypto/kyber_d00.zig
+++ b/lib/std/crypto/kyber_d00.zig
@@ -80,7 +80,7 @@
 //! m = Compress(Decompress(c_2, d_v) - s^T Decompress(c_1, d_u), 1).
 //!
 //! It it not straight-forward to see that this formula is correct.  In
-//! fact, there is negligable but non-zero probability that a ciphertext
+//! fact, there is negligible but non-zero probability that a ciphertext
 //! does not decrypt correctly given by the DFP column in Table 4.  This
 //! failure probability can be computed by a careful automated analysis
 //! of the probabilities involved, see kyber_failure.py of [SecEst].
@@ -640,7 +640,7 @@ fn montReduce(x: i32) i16 {
     // we have int32(int64(a)*int64(b)) = int32(a*b) and so the result is ok.
     const m = @truncate(i16, @truncate(i32, x *% qInv));
 
-    // Note that x - m q is divisable by R; indeed modulo R we have
+    // Note that x - m q is divisible by R; indeed modulo R we have
     //
     //  x - m q ≡ x - x q' q ≡ x - x q⁻¹ q ≡ x - x = 0.
     //

--- a/lib/std/event/lock.zig
+++ b/lib/std/event/lock.zig
@@ -36,7 +36,7 @@ pub const Lock = struct {
 
         // self.head transitions from multiple stages depending on the value:
         // UNLOCKED -> LOCKED:
-        //   acquire Lock ownership when theres no waiters
+        //   acquire Lock ownership when there are no waiters
         // LOCKED -> <Waiter head ptr>:
         //   Lock is already owned, enqueue first Waiter
         // <head ptr> -> <head ptr>:
@@ -87,7 +87,7 @@ pub const Lock = struct {
 
                 // self.head goes through the reverse transition from acquire():
                 // <head ptr> -> <new head ptr>:
-                //   pop a waiter from the queue to give Lock ownership when theres still others pending
+                //   pop a waiter from the queue to give Lock ownership when there are still others pending
                 // <head ptr> -> LOCKED:
                 //   pop the laster waiter from the queue, while also giving it lock ownership when awaken
                 // LOCKED -> UNLOCKED:

--- a/lib/std/event/loop.zig
+++ b/lib/std/event/loop.zig
@@ -903,7 +903,7 @@ pub const Loop = struct {
             }
         }
 
-        // TODO: use a tickless heirarchical timer wheel:
+        // TODO: use a tickless hierarchical timer wheel:
         // https://github.com/wahern/timeout/
         const Waiters = struct {
             entries: std.atomic.Queue(anyframe),
@@ -947,7 +947,7 @@ pub const Loop = struct {
                 // starting from the head
                 var head = self.entries.head orelse return null;
 
-                // traverse the list of waiting entires to
+                // traverse the list of waiting entries to
                 // find the Node with the smallest `expires` field
                 var min = head;
                 while (head.next) |node| {
@@ -1756,7 +1756,7 @@ test "std.event.Loop - runDetached" {
     try loop.runDetached(std.testing.allocator, testRunDetached, .{});
 
     // Now we can start the event loop. The function will return only
-    // after all tasks have been completed, allowing us to synchonize
+    // after all tasks have been completed, allowing us to synchronize
     // with the previous runDetached.
     loop.run();
 

--- a/lib/std/fmt/parse_float/convert_fast.zig
+++ b/lib/std/fmt/parse_float/convert_fast.zig
@@ -1,4 +1,4 @@
-//! Representation of a float as the signficant digits and exponent.
+//! Representation of a float as the significant digits and exponent.
 //! The fast path algorithm using machine-sized integers and floats.
 //!
 //! This only works if both the mantissa and the exponent can be exactly

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -92,7 +92,7 @@ pub const File = struct {
         /// processes from acquiring a exclusive lock, but does not prevent
         /// other process from getting their own shared locks.
         ///
-        /// The lock is advisory, except on Linux in very specific cirsumstances[1].
+        /// The lock is advisory, except on Linux in very specific circumstances[1].
         /// This means that a process that does not respect the locking API can still get access
         /// to the file, despite the lock.
         ///
@@ -156,7 +156,7 @@ pub const File = struct {
         /// processes from acquiring a exclusive lock, but does not prevent
         /// other process from getting their own shared locks.
         ///
-        /// The lock is advisory, except on Linux in very specific cirsumstances[1].
+        /// The lock is advisory, except on Linux in very specific circumstances[1].
         /// This means that a process that does not respect the locking API can still get access
         /// to the file, despite the lock.
         ///

--- a/lib/std/fs/path.zig
+++ b/lib/std/fs/path.zig
@@ -105,13 +105,13 @@ fn joinSepMaybeZ(allocator: Allocator, separator: u8, comptime sepPredicate: fn 
     return buf;
 }
 
-/// Naively combines a series of paths with the native path seperator.
+/// Naively combines a series of paths with the native path separator.
 /// Allocates memory for the result, which must be freed by the caller.
 pub fn join(allocator: Allocator, paths: []const []const u8) ![]u8 {
     return joinSepMaybeZ(allocator, sep, isSep, paths, false);
 }
 
-/// Naively combines a series of paths with the native path seperator and null terminator.
+/// Naively combines a series of paths with the native path separator and null terminator.
 /// Allocates memory for the result, which must be freed by the caller.
 pub fn joinZ(allocator: Allocator, paths: []const []const u8) ![:0]u8 {
     const out = try joinSepMaybeZ(allocator, sep, isSep, paths, true);

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -690,7 +690,7 @@ pub fn HashMap(
 /// It achieves good performance with quite high load factors (by default,
 /// grow is triggered at 80% full) and only one byte of overhead per element.
 /// The struct itself is only 16 bytes for a small footprint. This comes at
-/// the price of handling size with u32, which should be reasonnable enough
+/// the price of handling size with u32, which should be reasonable enough
 /// for almost all uses.
 /// Deletions are achieved with tombstones.
 pub fn HashMapUnmanaged(

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -79,7 +79,7 @@ const CAllocator = struct {
         }
 
         // Thin wrapper around regular malloc, overallocate to account for
-        // alignment padding and store the orignal malloc()'ed pointer before
+        // alignment padding and store the original malloc()'ed pointer before
         // the aligned address.
         var unaligned_ptr = @ptrCast([*]u8, c.malloc(len + alignment - 1 + @sizeOf(usize)) orelse return null);
         const unaligned_addr = @ptrToInt(unaligned_ptr);

--- a/lib/std/heap/arena_allocator.zig
+++ b/lib/std/heap/arena_allocator.zig
@@ -136,7 +136,7 @@ pub const ArenaAllocator = struct {
             it = next_it;
         } else null;
         std.debug.assert(maybe_first_node == null or maybe_first_node.?.next == null);
-        // reset the state before we try resizing the buffers, so we definitly have reset the arena to 0.
+        // reset the state before we try resizing the buffers, so we definitely have reset the arena to 0.
         self.state.end_index = 0;
         if (maybe_first_node) |first_node| {
             // perfect, no need to invoke the child_allocator

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -130,7 +130,7 @@ pub const Config = struct {
     thread_safe: bool = !builtin.single_threaded,
 
     /// What type of mutex you'd like to use, for thread safety.
-    /// when specfied, the mutex type must have the same shape as `std.Thread.Mutex` and
+    /// when specified, the mutex type must have the same shape as `std.Thread.Mutex` and
     /// `DummyMutex`, and have no required fields. Specifying this field causes
     /// the `thread_safe` field to be ignored.
     ///
@@ -1241,7 +1241,7 @@ test "realloc large object to small object" {
     try std.testing.expect(slice[16] == 0x34);
 }
 
-test "overrideable mutexes" {
+test "overridable mutexes" {
     var gpa = GeneralPurposeAllocator(.{ .MutexType = std.Thread.Mutex }){
         .backing_allocator = std.testing.allocator,
         .mutex = std.Thread.Mutex{},

--- a/lib/std/heap/memory_pool.zig
+++ b/lib/std/heap/memory_pool.zig
@@ -150,7 +150,7 @@ test "memory pool: basic" {
     pool.destroy(p2);
     const p4 = try pool.create();
 
-    // Assert memory resuse
+    // Assert memory reuse
     try std.testing.expect(p2 == p4);
 }
 

--- a/lib/std/http.zig
+++ b/lib/std/http.zig
@@ -12,7 +12,7 @@ pub const Version = enum {
 };
 
 /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
-/// https://datatracker.ietf.org/doc/html/rfc7231#section-4 Initial definiton
+/// https://datatracker.ietf.org/doc/html/rfc7231#section-4 Initial definition
 /// https://datatracker.ietf.org/doc/html/rfc5789#section-2 PATCH
 pub const Method = enum {
     GET,

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1603,7 +1603,7 @@ fn parseInternal(
                                 if (fields_seen[i]) {
                                     switch (options.duplicate_field_behavior) {
                                         .UseFirst => {
-                                            // unconditonally ignore value. for comptime fields, this skips check against default_value
+                                            // unconditionally ignore value. for comptime fields, this skips check against default_value
                                             parseFree(field.type, try parse(field.type, tokens, child_options), child_options);
                                             found = true;
                                             break;

--- a/lib/std/linked_list.zig
+++ b/lib/std/linked_list.zig
@@ -406,7 +406,7 @@ test "TailQueue concatenation" {
         }
     }
 
-    // Swap them back, this verifies that concating to an empty list works.
+    // Swap them back, this verifies that concatenating to an empty list works.
     list2.concatByMoving(&list1);
 
     // Traverse forwards.

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -356,7 +356,7 @@ pub const dysymtab_command = extern struct {
 
     // All the local relocation entries are grouped together (they are not
     // grouped by their module since they are only used if the object is moved
-    // from it staticly link edited address).
+    // from its statically link edited address).
 
     /// offset to local relocation entries
     locreloff: u32 = 0,
@@ -418,7 +418,7 @@ pub const dyld_info_command = extern struct {
     //    <seg-index, seg-offset, type, symbol-library-ordinal, symbol-name, addend>
     // The opcodes are a compressed way to encode the table by only
     // encoding when a column changes.  In addition simple patterns
-    // like for runs of pointers initialzed to the same value can be
+    // like for runs of pointers initialized to the same value can be
     // encoded in a few bytes.
 
     /// file offset to binding info
@@ -1141,7 +1141,7 @@ pub const MH_NOUNDEFS = 0x1;
 /// the object file is the output of an incremental link against a base file and can't be link edited again
 pub const MH_INCRLINK = 0x2;
 
-/// the object file is input for the dynamic linker and can't be staticly link edited again
+/// the object file is input for the dynamic linker and can't be statically link edited again
 pub const MH_DYLDLINK = 0x4;
 
 /// the object file's undefined references are bound by the dynamic linker when loaded.
@@ -1162,7 +1162,7 @@ pub const MH_TWOLEVEL = 0x80;
 /// the executable is forcing all images to use flat name space bindings
 pub const MH_FORCE_FLAT = 0x100;
 
-/// this umbrella guarantees no multiple defintions of symbols in its sub-images so the two-level namespace hints can always be used.
+/// this umbrella guarantees no multiple definitions of symbols in its sub-images so the two-level namespace hints can always be used.
 pub const MH_NOMULTIDEFS = 0x200;
 
 /// do not have dyld notify the prebinding agent about this executable
@@ -1658,7 +1658,7 @@ pub const EXPORT_SYMBOL_FLAGS_REEXPORT: u8 = 0x08;
 pub const EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER: u8 = 0x10;
 
 // An indirect symbol table entry is simply a 32bit index into the symbol table
-// to the symbol that the pointer or stub is refering to.  Unless it is for a
+// to the symbol that the pointer or stub is referring to.  Unless it is for a
 // non-lazy symbol pointer section for a defined symbol which strip(1) as
 // removed.  In which case it has the value INDIRECT_SYMBOL_LOCAL.  If the
 // symbol was also absolute INDIRECT_SYMBOL_ABS is or'ed with that.
@@ -1741,7 +1741,7 @@ pub const CS_LINKER_SIGNED: u32 = 0x20000;
 
 pub const CS_EXECSEG_MAIN_BINARY: u32 = 0x1;
 
-/// This CodeDirectory is tailored specfically at version 0x20400.
+/// This CodeDirectory is tailored specifically at version 0x20400.
 pub const CodeDirectory = extern struct {
     /// Magic number (CSMAGIC_CODEDIRECTORY)
     magic: u32,

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -408,7 +408,7 @@ pub const Mutable = struct {
     }
 
     /// Base implementation for addition. Adds `max(a.limbs.len, b.limbs.len)` elements from a and b,
-    /// and returns whether any overflow occured.
+    /// and returns whether any overflow occurred.
     /// r, a and b may be aliases.
     ///
     /// Asserts r has enough elements to hold the result. The upper bound is `max(a.limbs.len, b.limbs.len)`.
@@ -467,7 +467,7 @@ pub const Mutable = struct {
         const req_limbs = calcTwosCompLimbCount(bit_count);
 
         // Slice of the upper bits if they exist, these will be ignored and allows us to use addCarry to determine
-        // if an overflow occured.
+        // if an overflow occurred.
         const x = Const{
             .positive = a.positive,
             .limbs = a.limbs[0..math.min(req_limbs, a.limbs.len)],
@@ -512,7 +512,7 @@ pub const Mutable = struct {
         const req_limbs = calcTwosCompLimbCount(bit_count);
 
         // Slice of the upper bits if they exist, these will be ignored and allows us to use addCarry to determine
-        // if an overflow occured.
+        // if an overflow occurred.
         const x = Const{
             .positive = a.positive,
             .limbs = a.limbs[0..math.min(req_limbs, a.limbs.len)],
@@ -544,7 +544,7 @@ pub const Mutable = struct {
     }
 
     /// Base implementation for subtraction. Subtracts `max(a.limbs.len, b.limbs.len)` elements from a and b,
-    /// and returns whether any overflow occured.
+    /// and returns whether any overflow occurred.
     /// r, a and b may be aliases.
     ///
     /// Asserts r has enough elements to hold the result. The upper bound is `max(a.limbs.len, b.limbs.len)`.
@@ -605,7 +605,7 @@ pub const Mutable = struct {
         r.add(a, b.negate());
     }
 
-    /// r = a - b with 2s-complement wrapping semantics. Returns whether any overflow occured.
+    /// r = a - b with 2s-complement wrapping semantics. Returns whether any overflow occurred.
     ///
     /// r, a and b may be aliases
     /// Asserts the result fits in `r`. An upper bound on the number of limbs needed by
@@ -1141,7 +1141,7 @@ pub const Mutable = struct {
             return;
         }
 
-        // Generate a mask with the bits to check in the most signficant limb. We'll need to check
+        // Generate a mask with the bits to check in the most significant limb. We'll need to check
         // all bits with equal or more significance than checkbit.
         // const msb = @truncate(Log2Limb, checkbit);
         // const checkmask = (@as(Limb, 1) << msb) -% 1;
@@ -2037,7 +2037,7 @@ pub const Const = struct {
                 add_res = ov[0];
                 carry = ov[1];
                 sum += @popCount(add_res);
-                remaining_bits -= limb_bits; // Asserted not to undeflow by fitsInTwosComp
+                remaining_bits -= limb_bits; // Asserted not to underflow by fitsInTwosComp
             }
 
             // The most significant limb may have fewer than @bitSizeOf(Limb) meaningful bits,
@@ -2813,7 +2813,7 @@ pub const Managed = struct {
         r.setMetadata(m.positive, m.len);
     }
 
-    /// r = a + b with 2s-complement wrapping semantics. Returns whether any overflow occured.
+    /// r = a + b with 2s-complement wrapping semantics. Returns whether any overflow occurred.
     ///
     /// r, a and b may be aliases.
     ///
@@ -2856,7 +2856,7 @@ pub const Managed = struct {
         r.setMetadata(m.positive, m.len);
     }
 
-    /// r = a - b with 2s-complement wrapping semantics. Returns whether any overflow occured.
+    /// r = a - b with 2s-complement wrapping semantics. Returns whether any overflow occurred.
     ///
     /// r, a and b may be aliases.
     ///
@@ -4010,7 +4010,7 @@ fn llsquareBasecase(r: []Limb, x: []const Limb) void {
     assert(r.len >= 2 * x_norm.len + 1);
 
     // Compute the square of a N-limb bigint with only (N^2 + N)/2
-    // multiplications by exploting the symmetry of the coefficients around the
+    // multiplications by exploiting the symmetry of the coefficients around the
     // diagonal:
     //
     //           a   b   c *

--- a/lib/std/math/complex/tan.zig
+++ b/lib/std/math/complex/tan.zig
@@ -4,7 +4,7 @@ const math = std.math;
 const cmath = math.complex;
 const Complex = cmath.Complex;
 
-/// Returns the tanget of z.
+/// Returns the tangent of z.
 pub fn tan(z: anytype) Complex(@TypeOf(z.re)) {
     const T = @TypeOf(z.re);
     const q = Complex(T).init(-z.im, z.re);

--- a/lib/std/math/log10.zig
+++ b/lib/std/math/log10.zig
@@ -58,7 +58,7 @@ pub fn log10_int(x: anytype) Log2Int(@TypeOf(x)) {
     var log: u32 = 0;
 
     inline for (0..11) |i| {
-        // Unnecesary branches should be removed by the compiler
+        // Unnecessary branches should be removed by the compiler
         if (bit_size > (1 << (11 - i)) * 5 * @log2(10.0) and val >= pow10((1 << (11 - i)) * 5)) {
             const num_digits = (1 << (11 - i)) * 5;
             val /= pow10(num_digits);

--- a/lib/std/math/sqrt.zig
+++ b/lib/std/math/sqrt.zig
@@ -11,7 +11,7 @@ const maxInt = std.math.maxInt;
 ///  - sqrt(+-0)   = +-0
 ///  - sqrt(x)     = nan if x < 0
 ///  - sqrt(nan)   = nan
-/// TODO Decide if all this logic should be implemented directly in the @sqrt bultin function.
+/// TODO Decide if all this logic should be implemented directly in the @sqrt builtin function.
 pub fn sqrt(x: anytype) Sqrt(@TypeOf(x)) {
     const T = @TypeOf(x);
     switch (@typeInfo(T)) {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -114,7 +114,7 @@ pub fn validationWrap(allocator: anytype) ValidationAllocator(@TypeOf(allocator)
 
 /// An allocator helper function.  Adjusts an allocation length satisfy `len_align`.
 /// `full_len` should be the full capacity of the allocation which may be greater
-/// than the `len` that was requsted.  This function should only be used by allocators
+/// than the `len` that was requested.  This function should only be used by allocators
 /// that are unaffected by `len_align`.
 pub fn alignAllocLen(full_len: usize, alloc_len: usize, len_align: u29) usize {
     assert(alloc_len > 0);
@@ -427,7 +427,7 @@ pub fn zeroInit(comptime T: type, init: anytype) T {
                 .Struct => |init_info| {
                     if (init_info.is_tuple) {
                         if (init_info.fields.len > struct_info.fields.len) {
-                            @compileError("Tuple initializer has more elments than there are fields in `" ++ @typeName(T) ++ "`");
+                            @compileError("Tuple initializer has more elements than there are fields in `" ++ @typeName(T) ++ "`");
                         }
                     } else {
                         inline for (init_info.fields) |field| {
@@ -668,7 +668,7 @@ test "Span" {
 
 /// Takes a sentinel-terminated pointer and returns a slice, iterating over the
 /// memory to find the sentinel and determine the length.
-/// Ponter attributes such as const are preserved.
+/// Pointer attributes such as const are preserved.
 /// `[*c]` pointers are assumed to be non-null and 0-terminated.
 pub fn span(ptr: anytype) Span(@TypeOf(ptr)) {
     if (@typeInfo(@TypeOf(ptr)) == .Optional) {
@@ -1835,7 +1835,7 @@ test "writeIntBig and writeIntLittle" {
 }
 
 /// Swap the byte order of all the members of the fields of a struct
-/// (Changing their endianess)
+/// (Changing their endianness)
 pub fn byteSwapAllFields(comptime S: type, ptr: *S) void {
     if (@typeInfo(S) != .Struct) @compileError("byteSwapAllFields expects a struct as the first argument");
     inline for (std.meta.fields(S)) |f| {
@@ -3168,7 +3168,7 @@ test "replace" {
     try testing.expectEqualStrings(expected, output[0..expected.len]);
 }
 
-/// Replace all occurences of `needle` with `replacement`.
+/// Replace all occurrences of `needle` with `replacement`.
 pub fn replaceScalar(comptime T: type, slice: []T, needle: T, replacement: T) void {
     for (slice, 0..) |e, i| {
         if (e == needle) {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -659,7 +659,7 @@ pub fn exit(status: u8) noreturn {
         linux.exit_group(status);
     }
     if (builtin.os.tag == .uefi) {
-        // exit() is only avaliable if exitBootServices() has not been called yet.
+        // exit() is only available if exitBootServices() has not been called yet.
         // This call to exit should not fail, so we don't care about its return value.
         if (uefi.system_table.boot_services) |bs| {
             _ = bs.exit(uefi.handle, @intToEnum(uefi.Status, status), 0, null);
@@ -2978,7 +2978,7 @@ pub fn chdirZ(dir_path: [*:0]const u8) ChangeCurDirError!void {
     }
 }
 
-/// Windows-only. Same as `chdir` except the paramter is WTF16 encoded.
+/// Windows-only. Same as `chdir` except the parameter is WTF16 encoded.
 pub fn chdirW(dir_path: []const u16) ChangeCurDirError!void {
     windows.SetCurrentDirectory(dir_path) catch |err| switch (err) {
         error.NoDevice => return error.FileSystem,
@@ -6925,7 +6925,7 @@ pub const PrctlError = error{
     /// Can only occur with PR_SET_SPECULATION_CTRL, PR_MPX_ENABLE_MANAGEMENT,
     /// or PR_MPX_DISABLE_MANAGEMENT
     UnsupportedFeature,
-    /// Can only occur wih PR_SET_FP_MODE
+    /// Can only occur with PR_SET_FP_MODE
     OperationNotSupported,
     PermissionDenied,
 } || UnexpectedError;

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -472,7 +472,7 @@ pub fn preadv(fd: i32, iov: [*]const iovec, count: usize, offset: i64) usize {
         @bitCast(usize, @as(isize, fd)),
         @ptrToInt(iov),
         count,
-        // Kernel expects the offset is splitted into largest natural word-size.
+        // Kernel expects the offset is split into largest natural word-size.
         // See following link for detail:
         // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=601cc11d054ae4b5e9b5babec3d8e4667a2cb9b5
         @truncate(usize, offset_u),
@@ -3912,7 +3912,7 @@ pub const io_uring_cqe = extern struct {
 /// If set, the upper 16 bits are the buffer ID
 pub const IORING_CQE_F_BUFFER = 1 << 0;
 /// If set, parent SQE will generate more CQE entries.
-/// Avaiable since Linux 5.13.
+/// Available since Linux 5.13.
 pub const IORING_CQE_F_MORE = 1 << 1;
 /// If set, more data to read after socket recv
 pub const IORING_CQE_F_SOCK_NONEMPTY = 1 << 2;
@@ -4234,7 +4234,7 @@ pub const tcp_fastopen_client_fail = enum {
 pub const TCPI_OPT_TIMESTAMPS = 1;
 pub const TCPI_OPT_SACK = 2;
 pub const TCPI_OPT_WSCALE = 4;
-/// ECN was negociated at TCP session init
+/// ECN was negotiated at TCP session init
 pub const TCPI_OPT_ECN = 8;
 /// we received at least one packet with ECT
 pub const TCPI_OPT_ECN_SEEN = 16;

--- a/lib/std/os/linux/bpf/btf.zig
+++ b/lib/std/os/linux/bpf/btf.zig
@@ -109,7 +109,7 @@ pub const Enum64 = extern struct {
     val_hi32: i32,
 };
 
-/// array kind is followd by this struct
+/// array kind is followed by this struct
 pub const Array = extern struct {
     typ: u32,
     index_type: u32,
@@ -149,13 +149,13 @@ pub const FuncLinkage = enum {
     external,
 };
 
-/// var kind is followd by a single Var struct to describe additional
+/// var kind is followed by a single Var struct to describe additional
 /// information related to the variable such as its linkage
 pub const Var = extern struct {
     linkage: u32,
 };
 
-/// datasec kind is followed by multible VarSecInfo to describe all Var kind
+/// datasec kind is followed by multiple VarSecInfo to describe all Var kind
 /// types it contains along with it's in-section offset as well as size.
 pub const VarSecInfo = extern struct {
     typ: u32,

--- a/lib/std/os/linux/seccomp.zig
+++ b/lib/std/os/linux/seccomp.zig
@@ -65,7 +65,7 @@
 //!
 //! Unfortunately, there is no easy solution for issue 5. The most reliable
 //! strategy is to keep testing; test newer Zig versions, different libcs,
-//! different distros, and design your filter to accomidate all of them.
+//! different distros, and design your filter to accommodate all of them.
 //! Alternatively, you could inject a filter at runtime. Since filters are
 //! preserved across execve(2), a filter could be setup before executing your
 //! program, without your program having any knowledge of this happening. This

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2114,7 +2114,7 @@ pub fn loadWinsockExtensionFunction(comptime T: type, sock: ws2_32.SOCKET, guid:
 /// and you get an unexpected error.
 pub fn unexpectedError(err: Win32Error) std.os.UnexpectedError {
     if (std.os.unexpected_error_tracing) {
-        // 614 is the length of the longest windows error desciption
+        // 614 is the length of the longest windows error description
         var buf_wstr: [614]WCHAR = undefined;
         var buf_utf8: [614]u8 = undefined;
         const len = kernel32.FormatMessageW(

--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -33,7 +33,7 @@ pub fn PackedIntIo(comptime Int: type, comptime endian: Endian) type {
     // In the worst case, this is the number of bytes we need to touch
     // to read or write a value, as bits. To calculate for int_bits > 1,
     // set aside 2 bits to touch the first and last bytes, then divide
-    // by 8 to see how many bytes can be filled up inbetween.
+    // by 8 to see how many bytes can be filled up in between.
     const max_io_bits = switch (int_bits) {
         0 => 0,
         1 => 8,
@@ -298,7 +298,7 @@ pub fn PackedIntSliceEndian(comptime Int: type, comptime endian: Endian) type {
         }
 
         /// Initialize a packed slice using the memory at `bytes`, with `int_count`
-        /// elements. `bytes` must be large enough to accomodate the requested
+        /// elements. `bytes` must be large enough to accommodate the requested
         /// count.
         pub fn init(bytes: []u8, int_count: usize) Self {
             debug.assert(bytes.len >= bytesRequired(int_count));

--- a/lib/std/pdb.zig
+++ b/lib/std/pdb.zig
@@ -912,7 +912,7 @@ const Msf = struct {
         const stream_sizes = try allocator.alloc(u32, stream_count);
         defer allocator.free(stream_sizes);
 
-        // Microsoft's implementation uses @as(u32, -1) for inexistant streams.
+        // Microsoft's implementation uses @as(u32, -1) for inexistent streams.
         // These streams are not used, but still participate in the file
         // and must be taken into account when resolving stream indices.
         const Nil = 0xFFFFFFFF;

--- a/lib/std/simd.zig
+++ b/lib/std/simd.zig
@@ -159,7 +159,7 @@ pub fn interlace(vecs: anytype) @Vector(vectorLength(@TypeOf(vecs[0])) * vecs.le
 }
 
 /// The contents of `interlaced` is evenly split between vec_count vectors that are returned as an array. They "take turns",
-/// recieving one element from `interlaced` at a time.
+/// receiving one element from `interlaced` at a time.
 pub fn deinterlace(
     comptime vec_count: usize,
     interlaced: anytype,

--- a/lib/std/target/csky.zig
+++ b/lib/std/target/csky.zig
@@ -214,7 +214,7 @@ pub const all_features = blk: {
     };
     result[@enumToInt(Feature.dsp_silan)] = .{
         .llvm_name = "dsp_silan",
-        .description = "Enable DSP Silan instrutions",
+        .description = "Enable DSP Silan instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@enumToInt(Feature.dspe60)] = .{
@@ -224,7 +224,7 @@ pub const all_features = blk: {
     };
     result[@enumToInt(Feature.dspv2)] = .{
         .llvm_name = "dspv2",
-        .description = "Enable DSP V2.0 instrutions",
+        .description = "Enable DSP V2.0 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@enumToInt(Feature.e1)] = .{
@@ -243,7 +243,7 @@ pub const all_features = blk: {
     };
     result[@enumToInt(Feature.edsp)] = .{
         .llvm_name = "edsp",
-        .description = "Enable DSP instrutions",
+        .description = "Enable DSP instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@enumToInt(Feature.elrw)] = .{
@@ -333,12 +333,12 @@ pub const all_features = blk: {
     };
     result[@enumToInt(Feature.hwdiv)] = .{
         .llvm_name = "hwdiv",
-        .description = "Enable divide instrutions",
+        .description = "Enable divide instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@enumToInt(Feature.istack)] = .{
         .llvm_name = "istack",
-        .description = "Enable interrput attribute",
+        .description = "Enable interrupt attribute",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@enumToInt(Feature.java)] = .{
@@ -362,7 +362,7 @@ pub const all_features = blk: {
     };
     result[@enumToInt(Feature.multiple_stld)] = .{
         .llvm_name = "multiple_stld",
-        .description = "Enable multiple load/store instrutions",
+        .description = "Enable multiple load/store instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@enumToInt(Feature.nvic)] = .{
@@ -372,7 +372,7 @@ pub const all_features = blk: {
     };
     result[@enumToInt(Feature.pushpop)] = .{
         .llvm_name = "pushpop",
-        .description = "Enable push/pop instrutions",
+        .description = "Enable push/pop instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@enumToInt(Feature.smart)] = .{

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -258,7 +258,7 @@ pub const Instant = struct {
 
 /// A monotonic, high performance timer.
 ///
-/// Timer.start() is used to initalize the timer
+/// Timer.start() is used to initialize the timer
 /// and gives the caller an opportunity to check for the existence of a supported clock.
 /// Once a supported clock is discovered,
 /// it is assumed that it will be available for the duration of the Timer's use.

--- a/lib/std/valgrind/memcheck.zig
+++ b/lib/std/valgrind/memcheck.zig
@@ -77,7 +77,7 @@ pub fn discard(blkindex: usize) bool {
 }
 
 /// Check that memory at qzz.ptr is addressable for qzz.len bytes.
-/// If suitable addressibility is not established, Valgrind prints an
+/// If suitable addressability is not established, Valgrind prints an
 /// error message and returns the address of the first offending byte.
 /// Otherwise it returns zero.
 pub fn checkMemIsAddressable(qzz: []u8) usize {
@@ -85,7 +85,7 @@ pub fn checkMemIsAddressable(qzz: []u8) usize {
 }
 
 /// Check that memory at qzz.ptr is addressable and defined for
-/// qzz.len bytes.  If suitable addressibility and definedness are not
+/// qzz.len bytes.  If suitable addressability and definedness are not
 /// established, Valgrind prints an error message and returns the
 /// address of the first offending byte.  Otherwise it returns zero.
 pub fn checkMemIsDefined(qzz: []u8) usize {

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -239,7 +239,7 @@ test "zig fmt: file ends in comment after var decl" {
     );
 }
 
-test "zig fmt: if statment" {
+test "zig fmt: if statement" {
     try testCanonical(
         \\test "" {
         \\    if (optional()) |some|
@@ -529,7 +529,7 @@ test "zig fmt: remove empty lines at start/end of block" {
     );
 }
 
-test "zig fmt: allow empty line before commment at start of block" {
+test "zig fmt: allow empty line before comment at start of block" {
     try testCanonical(
         \\test {
         \\
@@ -4371,7 +4371,7 @@ test "zig fmt: same line doc comment returns error" {
         \\const Foo = struct{
         \\    bar: u32, /// comment
         \\    foo: u32, /// comment
-        \\    /// commment
+        \\    /// comment
         \\};
         \\
         \\const a = 42; /// comment

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -681,7 +681,7 @@ fn renderExpression(gpa: Allocator, ais: *Ais, tree: Ast, node: Ast.Node.Index, 
 
             try renderToken(ais, tree, switch_token, .space); // switch keyword
             try renderToken(ais, tree, switch_token + 1, .none); // lparen
-            try renderExpression(gpa, ais, tree, condition, .none); // condtion expression
+            try renderExpression(gpa, ais, tree, condition, .none); // condition expression
             try renderToken(ais, tree, rparen, .space); // rparen
 
             ais.pushIndentNextLine();


### PR DESCRIPTION
I noticed a typo while reading some of `std`'s code and ended up finding a few more with the help of `codespell`. Not the most impactful contribution, but I gotta start somewhere, right? :)

The majority of these are in comments, some in doc comments which might affect the generated documentation, and a few in parameter names - nothing that should be breaking, however.