### PR TITLE
Fix PBKDF2 docstring comment

### DIFF
--- a/lib/std/crypto/pbkdf2.zig
+++ b/lib/std/crypto/pbkdf2.zig
@@ -49,7 +49,7 @@ const WeakParametersError = std.crypto.errors.WeakParametersError;
 ///         Larger iteration counts improve security by increasing the time required to compute
 ///         the dk. It is common to tune this parameter to achieve approximately 100ms.
 ///
-/// Prf: Pseudo-random function to use. A common choice is `std.crypto.auth.hmac.HmacSha256`.
+/// Prf: Pseudo-random function to use. A common choice is `std.crypto.auth.hmac.sha2.HmacSha256`.
 pub fn pbkdf2(dk: []u8, password: []const u8, salt: []const u8, rounds: u32, comptime Prf: type) (WeakParametersError || OutputTooLongError)!void {
     if (rounds < 1) return error.WeakParameters;
 


### PR DESCRIPTION
Hi there! I noticed an inaccuracy in the [docs for pbkdf2](https://ziglang.org/documentation/master/std/#A;std:crypto.pwhash.pbkdf2) (the namespace for [SHA256 et al](https://github.com/ziglang/zig/blob/e963793e37f93d84f1e5295d309ebe0c738b663d/lib/std/crypto/hmac.zig#L9-L14) has been updated to be behind `sha2`).

Thanks!