### PR TITLE
Value: some fixes to bitcasting

### DIFF
--- a/src/value.zig
+++ b/src/value.zig
@@ -1309,6 +1309,7 @@ pub const Value = extern union {
                         .one => 1,
                         .int_u64 => int_val.castTag(.int_u64).?.data,
                         .int_i64 => @bitCast(u64, int_val.castTag(.int_i64).?.data),
+                        .lazy_size => val.castTag(.lazy_size).?.data.abiSize(target),
                         else => unreachable,
                     };
                     for (buffer[0..byte_count], 0..) |_, i| switch (endian) {
@@ -1436,6 +1437,7 @@ pub const Value = extern union {
                         .one => 1,
                         .int_u64 => int_val.castTag(.int_u64).?.data,
                         .int_i64 => @bitCast(u64, int_val.castTag(.int_i64).?.data),
+                        .lazy_size => val.castTag(.lazy_size).?.data.abiSize(target),
                         else => unreachable,
                     };
                     std.mem.writeVarPackedInt(buffer, bit_offset, bits, int, endian);

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -448,6 +448,15 @@ test "bitcast nan float does modify signaling bit" {
     try expectEqual(math.nan_u128, bitCastWrapper128(snan_f128_var));
 }
 
+test "bitcasting non-sized structs to u0" {
+    var a = @bitCast(u0, packed struct {}{});
+    try expectEqual(@as(u0, 0), a);
+    var b = @bitCast(u0, packed struct { a: u0 }{ .a = 0 });
+    try expectEqual(@as(u0, 0), b);
+    var c = @bitCast(u0, extern struct {}{});
+    try expectEqual(@as(u0, 0), c);
+}
+
 const packed_Request = packed struct {
     nr: u8,
     io_type: u8,

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -447,3 +447,47 @@ test "bitcast nan float does modify signaling bit" {
     try expectEqual(math.nan_u128, @bitCast(u128, snan_f128_var));
     try expectEqual(math.nan_u128, bitCastWrapper128(snan_f128_var));
 }
+
+const packed_Request = packed struct {
+    nr: u8,
+    io_type: u8,
+    size: u14,
+    dir: u2,
+};
+fn packed_IOR(comptime T: type) u32 {
+    const request = packed_Request{
+        .dir = 2,
+        .size = @sizeOf(T),
+        .io_type = 100,
+        .nr = 31,
+    };
+    return @bitCast(u32, request);
+}
+test "bitcasting packed struct value involving comptime" {
+    const bitcasted1 = packed_IOR(struct { x: u32 });
+    const bitcasted2 = @bitCast(packed_Request, bitcasted1);
+    const bitcasted3 = @bitCast(u32, bitcasted2);
+    try std.testing.expectEqual(bitcasted1, bitcasted3);
+}
+
+const extern_Request = packed struct {
+    nr: u8,
+    io_type: u8,
+    size: u16,
+    dir: u8,
+};
+fn extern_IOR(comptime T: type) u40 {
+    const request = extern_Request{
+        .dir = 254,
+        .size = @sizeOf(T),
+        .io_type = 3,
+        .nr = 80,
+    };
+    return @bitCast(u40, request);
+}
+test "bitcasting extern struct value involving comptime" {
+    const bitcasted1 = extern_IOR(struct { x: u40 });
+    const bitcasted2 = @bitCast(extern_Request, bitcasted1);
+    const bitcasted3 = @bitCast(u40, bitcasted2);
+    try std.testing.expectEqual(bitcasted1, bitcasted3);
+}

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -509,3 +509,83 @@ test "bitcasting extern unions" {
     var c = @bitCast(u64, extern union { a: u16, b: u64 }{ .b = 0xf3f3 });
     try expectEqual(@as(u64, 0xf3f3), c);
 }
+
+test "bitcasting value to packed union" {
+    const A = packed union {
+        a: u16,
+        b: u8,
+    };
+
+    const a = @bitCast(A, @as(u16, 64));
+    const a_back = @bitCast(u16, a);
+    try expectEqual(@as(u16, 64), a_back);
+}
+
+test "bitcasting value to extern union" {
+    // TODO: https://github.com/ziglang/zig/issues/15621
+    if (true) return error.SkipZigTest;
+
+    const A = extern union {
+        a: u16,
+        b: u8,
+    };
+
+    const a = @bitCast(A, @as(u16, 64));
+    const a_back = @bitCast(u16, a);
+    try expectEqual(@as(u16, 64), a_back);
+}
+
+test "bitcasting value to packed struct with packed union" {
+    const Val = packed struct {
+        isTagged: bool,
+        body: packed union {
+            u63: u63,
+            tagged: packed union {
+                tags: enum(u3) {
+                    hello = 0,
+                    world = 1,
+                },
+                body: packed union {
+                    static: enum(u60) {
+                        void = 0,
+                        true = 1,
+                        false = 2,
+                    },
+                },
+            },
+        },
+    };
+
+    const v = @bitCast(Val, @as(u64, 2));
+    const v_back = @bitCast(u64, v);
+    try expectEqual(@as(u64, 2), v_back);
+}
+
+test "bitcasting value to extern struct with extern union" {
+    // TODO: https://github.com/ziglang/zig/issues/15621
+    if (true) return error.SkipZigTest;
+
+    const Val = extern struct {
+        isTagged: bool,
+        body: extern union {
+            u32: u32,
+            tagged: extern union {
+                tags: enum(u8) {
+                    hello = 0,
+                    world = 1,
+                },
+                body: extern union {
+                    static: enum(u32) {
+                        void = 0,
+                        true = 1,
+                        false = 2,
+                    },
+                },
+            },
+        },
+    };
+
+    const v = @bitCast(Val, @as(u64, 2));
+    const v_back = @bitCast(u64, v);
+    try expectEqual(@as(u64, 2), v_back);
+}

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -500,3 +500,12 @@ test "bitcasting extern struct value involving comptime" {
     const bitcasted3 = @bitCast(u40, bitcasted2);
     try std.testing.expectEqual(bitcasted1, bitcasted3);
 }
+
+test "bitcasting extern unions" {
+    var a = @bitCast(u8, extern union { a: u8 }{ .a = 5 });
+    try expectEqual(@as(u8, 5), a);
+    var b = @bitCast(u16, extern union { a: u16, b: u16 }{ .a = 0xf0 });
+    try expectEqual(@as(u16, 0xf0), b);
+    var c = @bitCast(u64, extern union { a: u16, b: u64 }{ .b = 0xf3f3 });
+    try expectEqual(@as(u64, 0xf3f3), c);
+}

--- a/test/behavior/memcpy.zig
+++ b/test/behavior/memcpy.zig
@@ -42,3 +42,42 @@ fn testMemcpyBothSinglePtrArrayOneIsNullTerminated() !void {
     try expect(buf[98] == 'l');
     try expect(buf[99] == 'o');
 }
+
+const LanguageCode = enum(u16) {
+    ENG_US = 0x0409,
+    _,
+};
+fn LanguageDescriptor(comptime value: LanguageCode) type {
+    return extern struct {
+        length: u8 = @sizeOf(@This()),
+        descriptor_type: u8 = 0x03,
+        string: [1]u16 align(1) = [1]u16{std.mem.nativeToLittle(u16, @enumToInt(value))},
+    };
+}
+fn langDesc(comptime value: LanguageCode) LanguageDescriptor(value) {
+    return comptime LanguageDescriptor(value){};
+}
+fn DescriptorTable(comptime values: anytype) !void {
+    const default_data = comptime default_data: {
+        var total_size: usize = 0;
+        var value_offsets: [values.len]u8 = undefined;
+        inline for (values, 0..) |v, i| {
+            total_size += @sizeOf(@TypeOf(v));
+            value_offsets[i] = total_size;
+        }
+        var default_data: [total_size]u8 = undefined;
+        var i: usize = 0;
+        inline for (values) |v| {
+            const src = std.mem.asBytes(&v);
+            @memcpy(default_data[i .. i + src.len], src);
+            i += src.len;
+        }
+        break :default_data default_data;
+    };
+    try std.testing.expectEqualSlices(u8, &default_data, &.{ 0x04, 0x03, 0x09, 0x04 });
+}
+test "@memcpy at comptime in `inline for` with comptime `extern struct` value" {
+    _ = try DescriptorTable(.{
+        langDesc(.ENG_US),
+    });
+}

--- a/test/behavior/memset.zig
+++ b/test/behavior/memset.zig
@@ -144,3 +144,25 @@ test "memset with large array element, comptime known" {
     for (buf[3]) |elem| try expect(elem == 0);
     for (buf[4]) |elem| try expect(elem == 0);
 }
+
+test "@memset at comptime of extern union inside extern struct" {
+    // TODO: https://github.com/ziglang/zig/issues/15621
+    if (true) return error.SkipZigTest;
+
+    const bar_union = extern union {
+        a: u8,
+        b: u16,
+    };
+
+    const baz_struct = extern struct {
+        t: bar_union,
+    };
+
+    const foo: baz_struct = comptime foo: {
+        var item: baz_struct = undefined;
+        @memset(std.mem.asBytes(&item), 0);
+        break :foo item;
+    };
+
+    try expect(@bitCast(u16, foo.t) == 0);
+}

--- a/test/behavior/ptrcast.zig
+++ b/test/behavior/ptrcast.zig
@@ -290,3 +290,19 @@ test "@ptrCast undefined value at comptime" {
         _ = x;
     }
 }
+
+test "@ptrCast at comptime of extern union to [*]u8" {
+    // TODO: https://github.com/ziglang/zig/issues/15621
+    if (true) return error.SkipZigTest;
+
+    const bar_union = extern union {
+        a: u8,
+        b: u16,
+    };
+
+    comptime var foo: bar_union = undefined;
+    comptime for (@ptrCast([*]u8, &foo)[0..@sizeOf(bar_union)]) |*b| {
+        b.* = 0;
+    };
+    try expect(@bitCast(u16, foo) == 0);
+}


### PR DESCRIPTION
This fixes some crashes with bitcasting extern/packed structs in certain ways and implements bitcasting extern unions.

* [x] Add `Fixes #15589` to the commit message of https://github.com/r00ster91/zig/commit/75c192720c9ecd65304508357ea50b891dfa4ff5 and add a test for that issue in `test/behavior/bitcast.zig`.
* [ ] Get rid of `@panic("TODO implement writeToPackedMemory for more types")` and `error.Unimplemented` if this one missing `extern union` case gets implemented in this PR. Reference `std.builtin.TypeId` as the checklist.