### PR TITLE
autodoc: make help modal toggleable and allow entering "?" in search

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -875,7 +875,7 @@
       <div class="help-modal">
         <div class="modal">
           <h1>Keyboard Shortcuts</h1>
-          <dl><dt><kbd>?</kbd></dt><dd>Show this help modal</dd></dl>
+          <dl><dt><kbd>?</kbd></dt><dd>Toggle this help modal</dd></dl>
           <dl><dt><kbd>s</kbd></dt><dd>Focus the search field</dd></dl>
           <div style="margin-left: 1em">
             <dl><dt><kbd>↑</kbd></dt><dd>Move up in search results</dd></dl>

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -4044,9 +4044,14 @@ function addDeclToSearchResults(decl, declIndex, modNames, item, list, stack) {
         }
         break;
       case "?":
-        ev.preventDefault();
-        ev.stopPropagation();
-        showHelpModal();
+        // toggle the help modal
+        if (!domHelpModal.classList.contains("hidden")) {
+            onEscape(ev);
+        } else {
+            ev.preventDefault();
+            ev.stopPropagation();
+            showHelpModal();
+        }
         break;
     }
   }

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -127,16 +127,20 @@ const NAV_MODES = {
   window.guideSearch = guidesSearchIndex;
   parseGuides();
 
-  
+  // identifiers can contain '?' so we want to allow typing
+  // the question mark when the search is focused instead of toggling the help modal
+  let canToggleHelpModal = true;
 
   domSearch.disabled = false;
   domSearch.addEventListener("keydown", onSearchKeyDown, false);
   domSearch.addEventListener("focus", ev => {
     domSearchPlaceholder.classList.add("hidden");
+    canToggleHelpModal = false;
   });
   domSearch.addEventListener("blur", ev => {
     if (domSearch.value.length == 0)
       domSearchPlaceholder.classList.remove("hidden");
+    canToggleHelpModal = true;
   });
   domSectSearchAllResultsLink.addEventListener('click', onClickSearchShowAllResults, false);
   function onClickSearchShowAllResults(ev) {
@@ -4044,6 +4048,8 @@ function addDeclToSearchResults(decl, declIndex, modNames, item, list, stack) {
         }
         break;
       case "?":
+        if (!canToggleHelpModal) break;
+
         // toggle the help modal
         if (!domHelpModal.classList.contains("hidden")) {
             onEscape(ev);


### PR DESCRIPTION
Now you can simply press "?" again to toggle the help modal instead of
requiring Esc. Both Esc and "?" work.

Also, the question mark character can appear in identifiers as part of the
`@"syntax"` so we should allow typing it. Now, when the search is
selected, "?" is entered instead. It also shouldn't be that common in
general for the user to want to open the help modal.