### PR TITLE
Build: Print return traces from BuildStep errors

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -1216,6 +1216,10 @@ pub fn printErrorMessages(
         try stderr.writeAll(msg);
         try stderr.writeAll("\n");
     }
+
+    if (failing_step.result_error_trace) |trace| {
+        try trace.format("", .{}, stderr.writer());
+    }
 }
 
 fn steps(builder: *std.Build, out_stream: anytype) !void {

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -41,7 +41,8 @@ max_rss: usize,
 
 result_error_msgs: std.ArrayListUnmanaged([]const u8),
 result_error_bundle: std.zig.ErrorBundle,
-result_error_trace: ?*std.builtin.StackTrace,
+make_error_trace: ?MakeErrorTrace,
+
 result_stderr: []const u8,
 result_cached: bool,
 result_duration_ns: ?u64,
@@ -52,6 +53,12 @@ test_results: TestResults,
 /// The return address associated with creation of this step that can be useful
 /// to print along with debugging messages.
 debug_stack_trace: []usize,
+
+/// Storage for unhandled errors returned by the make function.
+pub const MakeErrorTrace = struct {
+    err: anyerror,
+    trace: ?*std.builtin.StackTrace,
+};
 
 pub const TestResults = struct {
     fail_count: u32 = 0,
@@ -215,7 +222,7 @@ pub fn init(options: StepOptions) Step {
         },
         .result_error_msgs = .{},
         .result_error_bundle = std.zig.ErrorBundle.empty,
-        .result_error_trace = null,
+        .make_error_trace = null,
         .result_stderr = "",
         .result_cached = false,
         .result_duration_ns = null,
@@ -225,8 +232,8 @@ pub fn init(options: StepOptions) Step {
 }
 
 /// If the Step's `make` function reports `error.MakeFailed`, it indicates they
-/// have already reported the error. Otherwise, we add a simple error report
-/// here.
+/// have already reported the error. Otherwise, we store the error for reporting
+/// later.
 pub fn make(s: *Step, options: MakeOptions) error{ MakeFailed, MakeSkipped }!void {
     const arena = s.owner.allocator;
 
@@ -235,8 +242,7 @@ pub fn make(s: *Step, options: MakeOptions) error{ MakeFailed, MakeSkipped }!voi
             error.MakeFailed => return error.MakeFailed,
             error.MakeSkipped => return error.MakeSkipped,
             else => {
-                s.result_error_trace = @errorReturnTrace();
-                s.addError("this step's make function failed with error {s}:", .{@errorName(err)}) catch @panic("OOM");
+                s.make_error_trace = .{ .err = err, .trace = @errorReturnTrace() };
                 return error.MakeFailed;
             },
         }
@@ -900,6 +906,7 @@ fn reset(step: *Step, gpa: Allocator) void {
 
     step.result_error_bundle.deinit(gpa);
     step.result_error_bundle = std.zig.ErrorBundle.empty;
+    step.make_error_trace = null;
 }
 
 /// Implementation detail of file watching. Prepares the step for being re-evaluated.


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/14961
```zig
// RunStep.zig
fn make(step: *Step, prog_node: *std.Progress.Node) !void {
    try std.testing.expect(false);
    // ...
```
Before:
```
C:\zigsrc\zig\build\stage4\bin\zig.exe build run
run compiler-testing: error: TestUnexpectedResult
```
After:
```
C:\zigsrc\zig\build\stage4\bin\zig.exe build run
run compiler-testing: error: step failed with error TestUnexpectedResult:
C:\zigsrc\zig\lib\std\testing.zig:509:14: 0x7ff6bcec10b7 in expect (build.exe.obj)
    if (!ok) return error.TestUnexpectedResult;
             ^
C:\zigsrc\zig\lib\std\Build\RunStep.zig:372:5: 0x7ff6bce9799d in make (build.exe.obj)
    try std.testing.expect(false);
    ^
```

If the return trace is too long and fills the internal buffer, we print the partial trace and a message notifying the user.
```zig
// RunStep.zig
fn fib(n: u32) !u32 {
    if (n <= 1) return n;
    if (n == 21) return error.Fibbage;
    return try fib(n - 1) + try fib(n - 2);
}

fn make(step: *Step, prog_node: *std.Progress.Node) !void {
    _ = try fib(55);
   // ...
```
```
C:\zigsrc\zig\build\stage4\bin\zig.exe build run
run compiler-testing: error: step failed with error Fibbage:
C:\zigsrc\zig\lib\std\Build\RunStep.zig:373:18: 0x7ff6298a1110 in fib (build.exe.obj)
    if (n == 21) return error.Fibbage;
                 ^
C:\zigsrc\zig\lib\std\Build\RunStep.zig:374:12: 0x7ff6298a118b in fib (build.exe.obj)
    return try fib(n - 1) + try fib(n - 2);
           ^
C:\zigsrc\zig\lib\std\Build\RunStep.zig:374:12: 0x7ff6298a118b in fib (build.exe.obj)
    return try fib(n - 1) + try fib(n - 2);
           ^
C:\zigsrc\zig\lib\std\Build\RunStep.zig:374:12: 0x7ff6298a118b in fib (build.exe.obj)
    return try fib(n - 1) + try fib(n - 2);
           ^
// etc....
C:\zigsrc\zig\lib\std\Build\RunStep.zig:374:12: 0x7ff6298a118b in fib (build.exe.obj)
    return try fib(n - 1) + try fib(n - 2);
           ^
C:\zigsrc\zig\lib.... errorReturnTrace exceeds buffer size!
```
I'm assuming 4096 chars is more than enough for most people, and I call `Allocator.resize()` to trim unused space.