### PR TITLE
std.log.defaultLog: remove freestanding compile error

### DIFF
--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -146,12 +146,6 @@ pub fn defaultLog(
     comptime format: []const u8,
     args: anytype,
 ) void {
-    if (builtin.os.tag == .freestanding)
-        @compileError(
-            \\freestanding targets do not have I/O configured;
-            \\please provide at least an empty `log` function declaration
-        );
-
     const level_txt = comptime message_level.asText();
     const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
     const stderr = std.io.getStdErr().writer();


### PR DESCRIPTION
I ran into this compile error while working on a project that targets wasm32-freestanding and felt it was unnecessarily restrictive so I'm putting removing it up as a suggestion.

Programs that provide their own implementation of the subset of `os.system` features required for writing to stderr shouldn't need to also override the default logging function just to be allowed to use `std.log`.

Looking at why this was added in 6f17be063d37f5ecd9552479e65428a5c60d9152, it seems to be because a compile error is preferable over the previous runtime no-op. Removing this line replaces still results in a compile error, but the message is now

>error: struct 'os.system__struct_1234' has no member named 'fd_t'.

which is less informative but is the same error as you get when using other "print to stderr" utilities like `std.debug.print()`. The user should still be able to figure out what the cause of the error is from the reference trace.