### PR TITLE
child_process: Add write and inheritable access to the null handle

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -650,7 +650,7 @@ pub const ChildProcess = struct {
     }
 
     fn spawnWindows(self: *ChildProcess) SpawnError!void {
-        const saAttr = windows.SECURITY_ATTRIBUTES{
+        var saAttr = windows.SECURITY_ATTRIBUTES{
             .nLength = @sizeOf(windows.SECURITY_ATTRIBUTES),
             .bInheritHandle = windows.TRUE,
             .lpSecurityDescriptor = null,
@@ -663,6 +663,7 @@ pub const ChildProcess = struct {
             windows.OpenFile(&[_]u16{ '\\', 'D', 'e', 'v', 'i', 'c', 'e', '\\', 'N', 'u', 'l', 'l' }, .{
                 .access_mask = windows.GENERIC_READ | windows.GENERIC_WRITE | windows.SYNCHRONIZE,
                 .share_access = windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE,
+                .sa = &saAttr,
                 .creation = windows.OPEN_EXISTING,
                 .io_mode = .blocking,
             }) catch |err| switch (err) {
@@ -679,9 +680,6 @@ pub const ChildProcess = struct {
             undefined;
         defer {
             if (any_ignore) os.close(nul_handle);
-        }
-        if (any_ignore) {
-            try windows.SetHandleInformation(nul_handle, windows.HANDLE_FLAG_INHERIT, windows.HANDLE_FLAG_INHERIT);
         }
 
         var g_hChildStd_IN_Rd: ?windows.HANDLE = null;

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -661,8 +661,8 @@ pub const ChildProcess = struct {
         const nul_handle = if (any_ignore)
             // "\Device\Null" or "\??\NUL"
             windows.OpenFile(&[_]u16{ '\\', 'D', 'e', 'v', 'i', 'c', 'e', '\\', 'N', 'u', 'l', 'l' }, .{
-                .access_mask = windows.GENERIC_READ | windows.SYNCHRONIZE,
-                .share_access = windows.FILE_SHARE_READ,
+                .access_mask = windows.GENERIC_READ | windows.GENERIC_WRITE | windows.SYNCHRONIZE,
+                .share_access = windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE,
                 .creation = windows.OPEN_EXISTING,
                 .io_mode = .blocking,
             }) catch |err| switch (err) {
@@ -681,7 +681,7 @@ pub const ChildProcess = struct {
             if (any_ignore) os.close(nul_handle);
         }
         if (any_ignore) {
-            try windows.SetHandleInformation(nul_handle, windows.HANDLE_FLAG_INHERIT, 0);
+            try windows.SetHandleInformation(nul_handle, windows.HANDLE_FLAG_INHERIT, windows.HANDLE_FLAG_INHERIT);
         }
 
         var g_hChildStd_IN_Rd: ?windows.HANDLE = null;

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -86,7 +86,10 @@ pub fn OpenFile(sub_path_w: []const u16, options: OpenFileOptions) OpenError!HAN
     var attr = OBJECT_ATTRIBUTES{
         .Length = @sizeOf(OBJECT_ATTRIBUTES),
         .RootDirectory = if (std.fs.path.isAbsoluteWindowsWTF16(sub_path_w)) null else options.dir,
-        .Attributes = 0, // Note we do not use OBJ_CASE_INSENSITIVE here.
+        .Attributes = if (options.sa) |ptr| blk: { // Note we do not use OBJ_CASE_INSENSITIVE here.
+            const inherit: ULONG = if (ptr.bInheritHandle == TRUE) OBJ_INHERIT else 0;
+            break :blk inherit;
+        } else 0,
         .ObjectName = &nt_name,
         .SecurityDescriptor = if (options.sa) |ptr| ptr.lpSecurityDescriptor else null,
         .SecurityQualityOfService = null,


### PR DESCRIPTION
closes #15506 


the `\\Device\\Null` Handle requires write access in case a child program wants to write to it. An example using bash is found in the linked issue.

this is not limited to bash, it also applies to cmd batch files and any application that wants to access the ignored stdout/stderr/stdin. A bit modified code from the original: 
<details>
  <summary>Example</summary>

```zig
const std = @import("std");
const fmt = std.fmt;
const heap = std.heap;
const Allocator = std.mem.Allocator;
const Child = std.process.Child;

pub fn main() !void {
    var arena = heap.ArenaAllocator.init(heap.page_allocator);
    defer arena.deinit();
    const allocator = arena.allocator();
    var buf: [16]u8 = undefined;
    for (0..255) |i| {
        const cmd = try fmt.bufPrint(&buf, ".\\script.bat {}", .{i});
        const argv = &.{ "cmd", "/C", cmd };
        var child = Child.init(argv, allocator);
        child.stdout_behavior = .Ignore;
        child.stdin_behavior = .Ignore;
        _ = try child.spawnAndWait();
    }
}
```
```cmd
@ECHO OFF
echo start %1 1>&2
echo devnull
echo end 1>&2
```
</details>

Without a write access, the handle of the spawned child will be inaccessible. causing "The system cannot write to the specified device." error or "invalid handle" if the inherit is off.


As a requirement `SetHandleInformation` was also changed to mark the handle as heritable (by adding it to Flags) by the spawned process. This allows the child to access the NUL device that was opened. Without that flag enabled, the child process won't be able to access the Null device opened in the `spawnWindows` code. I could not think of any downside to this inherit to be disabled especially for this null device case.

This also makes the Windows part to behave similarly to `spawnPosix` when stdout/stderr/stdin is set to ignore.

----

Before this commit, the spawned child will have no write access and access to the null device handle and will fail to write to it, after this commit, it will be able to write to it and the null handle will be valid.