### PR TITLE
ErrorBundle: fix integer overflow printing caret

### DIFF
--- a/lib/std/zig/ErrorBundle.zig
+++ b/lib/std/zig/ErrorBundle.zig
@@ -224,7 +224,7 @@ fn renderErrorMessageToWriter(
             // TODO basic unicode code point monospace width
             const before_caret = src.data.span_main - src.data.span_start;
             // -1 since span.main includes the caret
-            const after_caret = src.data.span_end - src.data.span_main -| 1;
+            const after_caret = src.data.span_end -| src.data.span_main -| 1;
             try stderr.writeByteNTimes(' ', src.data.column - before_caret);
             try ttyconf.setColor(stderr, .green);
             try stderr.writeByteNTimes('~', before_caret);


### PR DESCRIPTION
Do `zig init-exe` and put something like
```zig
    const x = [1]u8{
        .{
            `
        },
    };
```
in it and run `zig build`. You'll see:
```
zig build-exe x Debug native: error: the following command failed with 1 compilation errors:
/home/wooster/Desktop/zig-linux-x86_64/zig build-exe /home/wooster/Desktop/os/x/src/main.zig --cache-dir /home/wooster/Desktop/os/x/zig-cache --global-cache-dir /home/wooster/.cache/zig --name x --listen=-
Build Summary: 0/3 steps succeeded; 1 failed (disable with -fno-summary)
install transitive failure
└─ install x transitive failure
   └─ zig build-exe x Debug native 1 errors
src/main.zig:2:11: error: expected expression, found 'invalid bytes'
        .{
          ^
src/main.zig:3:13: note: invalid byte: '`'
            `
thread 431336 panic: integer overflow
/home/wooster/Desktop/zig-linux-x86_64/lib/std/zig/ErrorBundle.zig:227:51: 0x30384f in renderErrorMessageToWriter__anon_12356 (build)
            const after_caret = src.data.span_end - src.data.span_main -| 1;
                                                  ^
```

After applying this patch locally:
```
zig build-exe x Debug native: error: the following command failed with 1 compilation errors:
/home/wooster/Desktop/zig-linux-x86_64/zig build-exe /home/wooster/Desktop/os/x/src/main.zig --cache-dir /home/wooster/Desktop/os/x/zig-cache --global-cache-dir /home/wooster/.cache/zig --name x --listen=-
Build Summary: 0/3 steps succeeded; 1 failed (disable with -fno-summary)
install transitive failure
└─ install x transitive failure
   └─ zig build-exe x Debug native 1 errors
src/main.zig:2:11: error: expected expression, found 'invalid bytes'
        .{
          ^
src/main.zig:3:13: note: invalid byte: '`'
            `
            ^
```
Fixes #15596