### PR TITLE
Add missing compiler error for @import on absolute paths

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4957,6 +4957,9 @@ pub fn importFile(
     if (!mem.endsWith(u8, import_string, ".zig")) {
         return error.PackageNotFound;
     }
+    if (std.fs.path.isAbsolute(import_string)) {
+        return error.ImportAbsolutePath;
+    }
     const gpa = mod.gpa;
 
     // The resolved path is used as the key in the import table, to detect if

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -11949,6 +11949,9 @@ fn zirImport(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
             defer sema.gpa.free(name);
             return sema.fail(block, operand_src, "no package named '{s}' available within package '{s}'", .{ operand, name });
         },
+        error.ImportAbsolutePath => {
+            return sema.fail(block, operand_src, "cannot import by absolute path", .{});
+        },
         else => {
             // TODO: these errors are file system errors; make sure an update() will
             // retry this and not cache the file system error, which may be transient.

--- a/test/cases/compile_errors/import_by_absolute_path.zig
+++ b/test/cases/compile_errors/import_by_absolute_path.zig
@@ -1,0 +1,9 @@
+comptime{
+    _ = @import("/usr/local/foo.zig");
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :1:17: error: cannot import by absolute path

--- a/test/cases/compile_errors/import_by_absolute_path.zig
+++ b/test/cases/compile_errors/import_by_absolute_path.zig
@@ -6,4 +6,4 @@ comptime{
 // backend=stage2
 // target=native
 //
-// :1:17: error: cannot import by absolute path
+// :2:17: error: cannot import by absolute path


### PR DESCRIPTION
According to #3393 ```@import```
is not supposed to accept absolute path. So this pr may close this issue.