### PR TITLE
Sema: suggest the use of opaque pointer types + better function pointer type notes

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -20447,7 +20447,9 @@ fn checkPtrType(
                 );
                 errdefer msg.destroy(sema.gpa);
 
-                try sema.errNote(block, ty_src, msg, "use '*const ' to make a function pointer type", .{});
+                try sema.errNote(block, ty_src, msg, "use '*const {}' for a function pointer type", .{
+                    ty.fmt(sema.mod),
+                });
 
                 break :msg msg;
             };
@@ -23227,7 +23229,9 @@ fn explainWhyTypeIsNotExtern(
         .Fn => {
             if (position != .other) {
                 try mod.errNoteNonLazy(src_loc, msg, "type has no guaranteed in-memory representation", .{});
-                try mod.errNoteNonLazy(src_loc, msg, "use '*const ' to make a function pointer type", .{});
+                try mod.errNoteNonLazy(src_loc, msg, "use '*const {}' for a function pointer type", .{
+                    ty.fmt(sema.mod),
+                });
                 return;
             }
             switch (ty.fnCallingConvention()) {
@@ -23323,7 +23327,9 @@ fn explainWhyTypeIsNotPacked(
         .Pointer => try mod.errNoteNonLazy(src_loc, msg, "slices have no guaranteed in-memory representation", .{}),
         .Fn => {
             try mod.errNoteNonLazy(src_loc, msg, "type has no guaranteed in-memory representation", .{});
-            try mod.errNoteNonLazy(src_loc, msg, "use '*const ' to make a function pointer type", .{});
+            try mod.errNoteNonLazy(src_loc, msg, "use '*const {}' for a function pointer type", .{
+                ty.fmt(sema.mod),
+            });
         },
         .Struct => try mod.errNoteNonLazy(src_loc, msg, "only packed structs layout are allowed in packed types", .{}),
         .Union => try mod.errNoteNonLazy(src_loc, msg, "only packed unions layout are allowed in packed types", .{}),

--- a/test/cases/compile_errors/directly_embedding_opaque_type_in_struct_and_union.zig
+++ b/test/cases/compile_errors/directly_embedding_opaque_type_in_struct_and_union.zig
@@ -30,10 +30,14 @@ export fn d() void {
 // target=native
 //
 // :3:8: error: opaque types have unknown size and therefore cannot be directly embedded in structs
+// :3:8: note: use '*opaque {}' or '*anyopaque' to make opaques representable
 // :1:11: note: opaque declared here
 // :7:10: error: opaque types have unknown size and therefore cannot be directly embedded in unions
+// :7:10: note: use '*opaque {}' or '*anyopaque' to make opaques representable
 // :1:11: note: opaque declared here
 // :19:18: error: opaque types have unknown size and therefore cannot be directly embedded in structs
+// :19:18: note: use '*opaque {}' or '*anyopaque' to make opaques representable
 // :18:22: note: opaque declared here
 // :24:23: error: opaque types have unknown size and therefore cannot be directly embedded in structs
+// :24:23: note: use '*opaque {}' or '*anyopaque' to make opaques representable
 // :23:22: note: opaque declared here

--- a/test/cases/compile_errors/old_fn_ptr_in_extern_context.zig
+++ b/test/cases/compile_errors/old_fn_ptr_in_extern_context.zig
@@ -5,7 +5,7 @@ comptime {
     _ = @sizeOf(S) == 1;
 }
 comptime {
-    _ = [*c][4]fn() callconv(.C) void;
+    _ = [*c][4]fn () callconv(.C) void;
 }
 
 // error
@@ -14,7 +14,7 @@ comptime {
 //
 // :2:8: error: extern structs cannot contain fields of type 'fn() callconv(.C) void'
 // :2:8: note: type has no guaranteed in-memory representation
-// :2:8: note: use '*const ' to make a function pointer type
+// :2:8: note: use '*const fn () callconv(.C) void' for a function pointer type
 // :8:13: error: C pointers cannot point to non-C-ABI-compatible type '[4]fn() callconv(.C) void'
 // :8:13: note: type has no guaranteed in-memory representation
-// :8:13: note: use '*const ' to make a function pointer type
+// :8:13: note: use '*const fn () callconv(.C) void' for a function pointer type

--- a/test/cases/compile_errors/packed_struct_with_fields_of_not_allowed_types.zig
+++ b/test/cases/compile_errors/packed_struct_with_fields_of_not_allowed_types.zig
@@ -86,6 +86,6 @@ export fn entry12() void {
 // :28:12: note: type has no guaranteed in-memory representation
 // :38:12: error: packed structs cannot contain fields of type 'fn() void'
 // :38:12: note: type has no guaranteed in-memory representation
-// :38:12: note: use '*const ' to make a function pointer type
+// :38:12: note: use '*const fn () void' for a function pointer type
 // :65:31: error: packed structs cannot contain fields of type '[]u8'
 // :65:31: note: slices have no guaranteed in-memory representation

--- a/test/cases/compile_errors/reify_type_for_union_with_opaque_field.zig
+++ b/test/cases/compile_errors/reify_type_for_union_with_opaque_field.zig
@@ -17,4 +17,5 @@ export fn entry() usize {
 // target=native
 //
 // :1:18: error: opaque types have unknown size and therefore cannot be directly embedded in unions
+// :1:18: note: use '*opaque {}' or '*anyopaque' to make opaques representable
 // :6:39: note: opaque declared here


### PR DESCRIPTION
I think it'd be nice if we told the user why opaque types have unknown size and therefore cannot be directly embedded in X.

* [ ] Get a decision from a core team member if it should be written `fn () Type` or `fn() Type`: https://github.com/ziglang/zig/pull/15571#issuecomment-1534968671 (I would like to make it consistent in this PR in an extra commit)
* [ ] After that's done add a helpful note here in `zirOptionalType` too:
```zig
    if (child_type.zigTypeTag() == .Opaque) {
        return sema.fail(block, operand_src, "opaque type '{}' cannot be optional", .{child_type.fmt(sema.mod)});
```
as well as in the other two places that you can find by grepping for `"opaque "`.