### PR TITLE
std.meta: remove tagName

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -14,48 +14,7 @@ test {
     _ = TrailerFlags;
 }
 
-pub fn tagName(v: anytype) []const u8 {
-    const T = @TypeOf(v);
-    switch (@typeInfo(T)) {
-        .ErrorSet => return @errorName(v),
-        else => return @tagName(v),
-    }
-}
-
-test "std.meta.tagName" {
-    const E1 = enum {
-        A,
-        B,
-    };
-    const E2 = enum(u8) {
-        C = 33,
-        D,
-    };
-    const U1 = union(enum) {
-        G: u8,
-        H: u16,
-    };
-    const U2 = union(E2) {
-        C: u8,
-        D: u16,
-    };
-
-    var u1g = U1{ .G = 0 };
-    var u1h = U1{ .H = 0 };
-    var u2a = U2{ .C = 0 };
-    var u2b = U2{ .D = 0 };
-
-    try testing.expect(mem.eql(u8, tagName(E1.A), "A"));
-    try testing.expect(mem.eql(u8, tagName(E1.B), "B"));
-    try testing.expect(mem.eql(u8, tagName(E2.C), "C"));
-    try testing.expect(mem.eql(u8, tagName(E2.D), "D"));
-    try testing.expect(mem.eql(u8, tagName(error.E), "E"));
-    try testing.expect(mem.eql(u8, tagName(error.F), "F"));
-    try testing.expect(mem.eql(u8, tagName(u1g), "G"));
-    try testing.expect(mem.eql(u8, tagName(u1h), "H"));
-    try testing.expect(mem.eql(u8, tagName(u2a), "C"));
-    try testing.expect(mem.eql(u8, tagName(u2b), "D"));
-}
+pub const tagName = @compileError("deprecated; use @tagName or @errorName directly");
 
 /// Given an enum or tagged union, returns true if the comptime-supplied
 /// string matches the name of the tag value.  This match process should


### PR DESCRIPTION
not used by Zig itself anywhere and not using the function is more idiomatic