### PR TITLE
std.ChildProcess: fix EBADF when explicitly passing cwd as working directory

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -584,7 +584,10 @@ pub const ChildProcess = struct {
             }
 
             if (self.cwd_dir) |cwd| {
-                os.fchdir(cwd.fd) catch |err| forkChildErrReport(err_pipe[1], err);
+                // Calling fchdir with AT_FDCWD will cause an EBADF and would be a no-op anyways.
+                if (cwd.fd != std.os.AT.FDCWD) {
+                    os.fchdir(cwd.fd) catch |err| forkChildErrReport(err_pipe[1], err);
+                }
             } else if (self.cwd) |cwd| {
                 os.chdir(cwd) catch |err| forkChildErrReport(err_pipe[1], err);
             }


### PR DESCRIPTION
closes #9688

This fixes a bug where `ChildProcess.spawn` would try to call `fchdir` with `AT_FDCWD` causing an EBADF error to occur when `ChildProcess.cwd_dir` is set to `std.fs.cwd()`.