### PR TITLE
parse_float: Error when a float is attempted to be parsed into an invalid type

### DIFF
--- a/lib/std/fmt/parse_float/common.zig
+++ b/lib/std/fmt/parse_float/common.zig
@@ -86,6 +86,6 @@ pub fn mantissaType(comptime T: type) type {
     return switch (T) {
         f16, f32, f64 => u64,
         f128 => u128,
-        else => unreachable,
+        else => @compileError("Invalid type for Mantissa - should be a floating-point type."),
     };
 }

--- a/lib/std/fmt/parse_float/common.zig
+++ b/lib/std/fmt/parse_float/common.zig
@@ -86,6 +86,6 @@ pub fn mantissaType(comptime T: type) type {
     return switch (T) {
         f16, f32, f64 => u64,
         f128 => u128,
-        else => @compileError("Invalid type for Mantissa - should be a floating-point type."),
+        else => unreachable,
     };
 }

--- a/lib/std/fmt/parse_float/parse_float.zig
+++ b/lib/std/fmt/parse_float/parse_float.zig
@@ -12,8 +12,12 @@ pub const ParseFloatError = error{
 };
 
 pub fn parseFloat(comptime T: type, s: []const u8) ParseFloatError!T {
-    if (T != f16 and T != f32 and T != f64 and T != f128) {
+    if (@typeInfo(T) != .Float) {
         @compileError("Cannot parse a float into a non-floating point type.");
+    }
+
+    if (T == f80) {
+        @compileError("TODO support parsing float to f80");
     }
 
     if (s.len == 0) {

--- a/lib/std/fmt/parse_float/parse_float.zig
+++ b/lib/std/fmt/parse_float/parse_float.zig
@@ -12,6 +12,10 @@ pub const ParseFloatError = error{
 };
 
 pub fn parseFloat(comptime T: type, s: []const u8) ParseFloatError!T {
+    if (T != f16 and T != f32 and T != f64 and T != f128) {
+        @compileError("Cannot parse a float into a non-floating point type.");
+    }
+
     if (s.len == 0) {
         return error.InvalidCharacter;
     }


### PR DESCRIPTION
I experienced an error while writing some code:

```zig
var reset: u64 = try std.fmt.parseFloat(u64, resetStr);
```

Obviously, you can't parse a float into a u64, but the error message this gave confused me a little bit:

```zig
/home/jvyden/Documents/zig/build/stage4/lib/zig/std/fmt/parse_float/common.zig:89:17: error: reached unreachable code
        else => unreachable,
                ^~~~~~~~~~~
/home/jvyden/Documents/zig/build/stage4/lib/zig/std/fmt/parse_float/common.zig:57:31: note: called from here
        mantissa: mantissaType(T),
                  ~~~~~~~~~~~~^~~
```

I tried to fix this with by changing the unreachable to a `@compileError`, but [tiehuis had a better suggestion](https://github.com/ziglang/zig/pull/15593#issuecomment-1537265319). The error now prints a stack trace when calling `parseFloat` directly:

```zig
/home/jvyden/Documents/zig/build/stage4/lib/zig/std/fmt/parse_float/parse_float.zig:16:9: error: Cannot parse a float into a non-floating point type.
        @compileError("Cannot parse a float into a non-floating point type.");
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    main: src/main.zig:4:31
    callMain: /home/jvyden/Documents/zig/build/stage4/lib/zig/std/start.zig:609:32
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```
