### PR TITLE
cbe: fix typos

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -159,7 +159,7 @@ const reserved_idents = std.ComptimeStringMap(void, .{
     .{ "double", {} },
     .{ "else", {} },
     .{ "enum", {} },
-    .{ "extern ", {} },
+    .{ "extern", {} },
     .{ "float", {} },
     .{ "for", {} },
     .{ "fortran", {} },
@@ -198,7 +198,7 @@ const reserved_idents = std.ComptimeStringMap(void, .{
     .{ "unsigned", {} },
     .{ "void", {} },
     .{ "volatile", {} },
-    .{ "while ", {} },
+    .{ "while", {} },
 
     // stdarg.h
     .{ "va_start", {} },


### PR DESCRIPTION
Unfortunately, I need a `zig1.wasm` update that includes this fix in order for #15597 to be able to pass CI.  This is not an immediate blocker, but it be within a week.