### PR TITLE
Add std.mem.indexOfNone

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1013,10 +1013,16 @@ pub fn indexOfAnyPos(comptime T: type, slice: []const T, start_index: usize, val
     return null;
 }
 
+/// Find the first item in `slice` which is not contained in `values`.
+///
+/// Comparable to `strspn` in the C standard library.
 pub fn indexOfNone(comptime T: type, slice: []const T, values: []const T) ?usize {
     return indexOfNonePos(T, slice, 0, values);
 }
 
+/// Find the last item in `slice` which is not contained in `values`.
+///
+/// Like `strspn` in the C standard library, but searches from the end.
 pub fn lastIndexOfNone(comptime T: type, slice: []const T, values: []const T) ?usize {
     var i: usize = slice.len;
     outer: while (i != 0) {
@@ -1029,6 +1035,10 @@ pub fn lastIndexOfNone(comptime T: type, slice: []const T, values: []const T) ?u
     return null;
 }
 
+/// Find the first item in `slice[start_index..]` which is not contained in `values`.
+/// The returned index will be relative to the start of `slice`, and never less than `start_index`.
+///
+/// Comparable to `strspn` in the C standard library.
 pub fn indexOfNonePos(comptime T: type, slice: []const T, start_index: usize, values: []const T) ?usize {
     var i: usize = start_index;
     outer: while (i < slice.len) : (i += 1) {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1013,6 +1013,42 @@ pub fn indexOfAnyPos(comptime T: type, slice: []const T, start_index: usize, val
     return null;
 }
 
+pub fn indexOfNone(comptime T: type, slice: []const T, values: []const T) ?usize {
+    return indexOfNonePos(T, slice, 0, values);
+}
+
+pub fn lastIndexOfNone(comptime T: type, slice: []const T, values: []const T) ?usize {
+    var i: usize = slice.len;
+    outer: while (i != 0) {
+        i -= 1;
+        for (values) |value| {
+            if (slice[i] == value) continue :outer;
+        }
+        return i;
+    }
+    return null;
+}
+
+pub fn indexOfNonePos(comptime T: type, slice: []const T, start_index: usize, values: []const T) ?usize {
+    var i: usize = start_index;
+    outer: while (i < slice.len) : (i += 1) {
+        for (values) |value| {
+            if (slice[i] == value) continue :outer;
+        }
+        return i;
+    }
+    return null;
+}
+
+test "indexOfNone" {
+    try testing.expect(indexOfNone(u8, "abc123", "123").? == 0);
+    try testing.expect(lastIndexOfNone(u8, "abc123", "123").? == 2);
+    try testing.expect(indexOfNone(u8, "123abc", "123").? == 3);
+    try testing.expect(lastIndexOfNone(u8, "123abc", "123").? == 5);
+    try testing.expect(indexOfNone(u8, "123123", "123") == null);
+    try testing.expect(indexOfNone(u8, "333333", "123") == null);
+}
+
 pub fn indexOf(comptime T: type, haystack: []const T, needle: []const T) ?usize {
     return indexOfPos(T, haystack, 0, needle);
 }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1047,6 +1047,8 @@ test "indexOfNone" {
     try testing.expect(lastIndexOfNone(u8, "123abc", "123").? == 5);
     try testing.expect(indexOfNone(u8, "123123", "123") == null);
     try testing.expect(indexOfNone(u8, "333333", "123") == null);
+
+    try testing.expect(indexOfNonePos(u8, "abc123", 3, "321") == null);
 }
 
 pub fn indexOf(comptime T: type, haystack: []const T, needle: []const T) ?usize {


### PR DESCRIPTION
This introduces a parallel set of functions to the std.mem.indexOfAny functions. They simply invert the logic, yielding the first/last index which is *not* contained in the "values" slice.

Inverting this logic is useful when you are attempting to determine the initial span which contains only characters in a particular set. For example, finding the length of an integer literal could be done (somewhat naively) using indexOfNone.

This is my first attempt to contribute to Zig, so please let me know of any steps I accidentally skipped or mistakes I made.