### PR TITLE
module: return null if no candidate src

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -6115,6 +6115,8 @@ pub const PeerTypeCandidateSrc = union(enum) {
                 return null;
             },
             .override => |candidate_srcs| {
+                if (candidate_i >= candidate_srcs.len)
+                    return null;
                 return candidate_srcs[candidate_i];
             },
             .typeof_builtin_call_node_offset => |node_offset| {

--- a/test/cases/compile_errors/issue_15572_break_on_inline_while.zig
+++ b/test/cases/compile_errors/issue_15572_break_on_inline_while.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub const DwarfSection = enum {
+    eh_frame,
+    eh_frame_hdr,
+};
+
+pub fn main() void {
+    const section = inline for (@typeInfo(DwarfSection).Enum.fields) |section| {
+        if (std.mem.eql(u8, section.name, "eh_frame")) break section;
+    };
+
+    _ = section;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :9:28: error: incompatible types: 'builtin.Type.EnumField' and 'void'


### PR DESCRIPTION
Closes #15572.

The example in the issue now results in this:

```zig
main.zig:9:28: error: incompatible types: 'builtin.Type.EnumField' and 'void'
    const section = inline for (@typeInfo(DwarfSection).Enum.fields) |section| {
                    ~~~~~~~^~~
referenced by:
    comptime_0: /Users/<USER>/repos/zig/lib/std/start.zig:63:50
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```