### PR TITLE
std.fmt.parseIntSizeSuffix: add R and Q

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1925,6 +1925,8 @@ pub fn parseIntSizeSuffix(buf: []const u8, radix: u8) ParseIntError!usize {
         'E' => 6,
         'Z' => 7,
         'Y' => 8,
+        'R' => 9,
+        'Q' => 10,
         else => 0,
     };
     var without_suffix = without_i;


### PR DESCRIPTION
https://www.nist.gov/pml/owm/metric-si-prefixes

https://www.npl.co.uk/si-prefix

https://www.nature.com/articles/d41586-022-03747-9