### PR TITLE
std.math.atan: fix mistyped magic constant

### DIFF
--- a/lib/std/math/atan.zig
+++ b/lib/std/math/atan.zig
@@ -161,7 +161,7 @@ fn atan64(x_: f64) f64 {
     var id: ?usize = undefined;
 
     // |x| < 0.4375
-    if (ix < 0x3DFC0000) {
+    if (ix < 0x3FDC0000) {
         // |x| < 2^(-27)
         if (ix < 0x3E400000) {
             if (ix < 0x00100000) {


### PR DESCRIPTION
The constant must have been mistyped while being ported over from musl.
Bug found and rectified by WiserOrb.

Co-authored-by: WiserOrb <diego99.masotti@gmail.com>