### PR TITLE
Use special arm eabi memset/memclr signature

### DIFF
--- a/lib/compiler_rt/arm.zig
+++ b/lib/compiler_rt/arm.zig
@@ -51,7 +51,7 @@ const __udivmodsi4 = @import("int.zig").__udivmodsi4;
 const __divmoddi4 = @import("int.zig").__divmoddi4;
 const __udivmoddi4 = @import("int.zig").__udivmoddi4;
 
-extern fn memset(dest: ?[*]u8, c: u8, n: usize) ?[*]u8;
+extern fn memset(dest: ?[*]u8, c: i32, n: usize) ?[*]u8;
 extern fn memcpy(noalias dest: ?[*]u8, noalias src: ?[*]const u8, n: usize) ?[*]u8;
 extern fn memmove(dest: ?[*]u8, src: ?[*]const u8, n: usize) ?[*]u8;
 
@@ -81,17 +81,17 @@ pub fn __aeabi_memmove8(dest: [*]u8, src: [*]u8, n: usize) callconv(.AAPCS) void
     _ = memmove(dest, src, n);
 }
 
-pub fn __aeabi_memset(dest: [*]u8, n: usize, c: u8) callconv(.AAPCS) void {
+pub fn __aeabi_memset(dest: [*]u8, n: usize, c: i32) callconv(.AAPCS) void {
     @setRuntimeSafety(false);
     // This is dentical to the standard `memset` definition but with the last
     // two arguments swapped
     _ = memset(dest, c, n);
 }
-pub fn __aeabi_memset4(dest: [*]u8, n: usize, c: u8) callconv(.AAPCS) void {
+pub fn __aeabi_memset4(dest: [*]u8, n: usize, c: i32) callconv(.AAPCS) void {
     @setRuntimeSafety(false);
     _ = memset(dest, c, n);
 }
-pub fn __aeabi_memset8(dest: [*]u8, n: usize, c: u8) callconv(.AAPCS) void {
+pub fn __aeabi_memset8(dest: [*]u8, n: usize, c: i32) callconv(.AAPCS) void {
     @setRuntimeSafety(false);
     _ = memset(dest, c, n);
 }


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/13530

Arm eabi uses a different memset signature http://orangetide.com/OLD/ARM/IHI0043C_rtabi.pdf

The new code generated after this change is

```zig
__aeabi_memset (int16_t arg1, int16_t arg2, int16_t arg3);
; arg int16_t arg1 @ r0
; arg int16_t arg2 @ r1
; arg int16_t arg3 @ r2
0x0000cfb8      mov     r3, r1     ; arg2
0x0000cfba      mov     r1, r2     ; arg3
0x0000cfbc      mov     r2, r3
0x0000cfbe      b.w     memset     ; sym.memset
__aeabi_memset4 (int16_t arg1, int16_t arg2, int16_t arg3);
; arg int16_t arg1 @ r0
; arg int16_t arg2 @ r1
; arg int16_t arg3 @ r2
0x0000cfc2      mov     r3, r1     ; arg2
0x0000cfc4      mov     r1, r2     ; arg3
0x0000cfc6      mov     r2, r3
0x0000cfc8      b.w     memset     ; sym.memset
__aeabi_memclr4 (int16_t arg1, int16_t arg2);
; arg int16_t arg1 @ r0
; arg int16_t arg2 @ r1
0x0000cfcc      mov     r2, r1     ; arg2
0x0000cfce      movs    r1, 0
0x0000cfd0      b.w     memset     ; sym.memset
void *memset (void *s, int c, size_t n);
; arg void *s @ r0
; arg int c @ r1
; arg size_t n @ r2
0x0000cfd4      push    {r7, lr}
0x0000cfd6      mov     r7, sp
0x0000cfd8      cbz     r2, 0xd026
0x0000cfda      ands    lr, r2, 3  ; n
0x0000cfde      mov     r3, r2     ; n
0x0000cfe0      mov     ip, r0     ; arg1
0x0000cfe2      beq     0xd00c
0x0000cfe4      mov     ip, r0     ; arg1
0x0000cfe6      cmp.w   lr, 1      ; aav.0x00000001
0x0000cfea      strb    r1, [ip], 1 ; c
0x0000cfee      bne     0xcff4
0x0000cff0      subs    r3, r2, 1  ; n
0x0000cff2      b       0xd00c
0x0000cff4      cmp.w   lr, 2
0x0000cff8      strb    r1, [r0, 1] ; arg1
0x0000cffa      bne     0xd004
0x0000cffc      subs    r3, r2, 2  ; n
;-- (0x0000d000) aav.0x0000d000:
0x0000cffe      add.w   ip, r0, 2  ; arg1
0x0000d002      b       0xd00c
0x0000d004      subs    r3, r2, 3  ; n
0x0000d006      add.w   ip, r0, 3  ; arg1
0x0000d00a      strb    r1, [r0, 2] ; arg1
0x0000d00c      cmp     r2, 4      ; obj.vector_table ; n
0x0000d00e      it      lo
0x0000d010      poplo   {r7, pc}
0x0000d012      sub.w   r2, ip, 4
0x0000d016      nop
0x0000d018      strb    r1, [r2, 4]! ; c
0x0000d01c      subs    r3, 4
0x0000d01e      strb    r1, [r2, 1] ; c
0x0000d020      strb    r1, [r2, 2] ; c
0x0000d022      strb    r1, [r2, 3] ; c
0x0000d024      bne     0xd018
0x0000d026      pop     {r7, pc}
```

If anyone else can confirm it'd be much appreciated.