### PR TITLE
Added new replacement methods for replacing multiple needles at once.

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3656,6 +3656,7 @@ pub fn replacementSizeMany(comptime T: type, input: []const T, replacement_pairs
                 size = size - pair.ToReplace.len + pair.Replacer.len;
                 i += pair.ToReplace.len;
                 found = true;
+                break;
             }
         }
 
@@ -3732,6 +3733,7 @@ pub fn replaceMany(comptime T: type, input: []const T, replacement_pairs: []cons
                 slide += pair.ToReplace.len;
                 replacements += 1;
                 found = true;
+                break;
             }
         }
         if (found == false) {


### PR DESCRIPTION
Added the methods `std.mem.replacementSizeMany`, `std.mem.replaceMany`, `std.mem.replaceManyOwned`and `std.mem.replaceManyScalar` which allow the individual replacing of multiple needles at once.

This is quite helpful when working with large format string, e.g: `$VERSION.$MAJOR.$MINOR.$PATCH`.
Previously you had to tediously add up the replacement sizes for each substring to replace ($VERSION, $MAJOR, $MINOR, $PATCH) and subtract the original size of the string each time to get the new size.
Even worse was it when came to the replacing, because it contained multiple unnecessary iterations of the string, which are no longer needed when using the new methods. This could add up to a decent performance improvement for projects working with large format files and who have to format them repeatedly. It is also a good quality of life and readability change for projects using the new method.