### PR TITLE
wasm: enable standard test runner

### DIFF
--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -12,9 +12,7 @@ var cmdline_buffer: [4096]u8 = undefined;
 var fba = std.heap.FixedBufferAllocator.init(&cmdline_buffer);
 
 pub fn main() void {
-    if (builtin.zig_backend == .stage2_wasm or
-        builtin.zig_backend == .stage2_aarch64)
-    {
+    if (builtin.zig_backend == .stage2_aarch64) {
         return mainSimple() catch @panic("test failure");
     }
 

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -2122,16 +2122,13 @@ fn airRetLoad(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const un_op = func.air.instructions.items(.data)[inst].un_op;
     const operand = try func.resolveInst(un_op);
     const ret_ty = func.air.typeOf(un_op).childType();
+
+    const fn_info = func.decl.ty.fnInfo();
     if (!ret_ty.hasRuntimeBitsIgnoreComptime()) {
         if (ret_ty.isError()) {
             try func.addImm32(0);
-        } else {
-            return func.finishAir(inst, .none, &.{});
         }
-    }
-
-    const fn_info = func.decl.ty.fnInfo();
-    if (!firstParamSRet(fn_info.cc, fn_info.return_type, func.target)) {
+    } else if (!firstParamSRet(fn_info.cc, fn_info.return_type, func.target)) {
         // leave on the stack
         _ = try func.load(operand, ret_ty, 0);
     }

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -2604,6 +2604,7 @@ fn binOpBigInt(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: Op) Inner
     switch (op) {
         .mul => return func.callIntrinsic("__multi3", &.{ ty, ty }, ty, &.{ lhs, rhs }),
         .shr => return func.callIntrinsic("__lshrti3", &.{ ty, Type.i32 }, ty, &.{ lhs, rhs }),
+        .shl => return func.callIntrinsic("__ashlti3", &.{ ty, Type.i32 }, ty, &.{ lhs, rhs }),
         .xor => {
             const result = try func.allocStack(ty);
             try func.emitWValue(result);

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -4464,7 +4464,9 @@ fn airMemset(func: *CodeGen, inst: Air.Inst.Index, safety: bool) InnerError!void
         .One => @as(WValue, .{ .imm32 = @intCast(u32, ptr_ty.childType().arrayLen()) }),
         .C, .Many => unreachable,
     };
-    try func.memset(ptr, len, value);
+
+    const dst_ptr = try func.sliceOrArrayPtr(ptr, ptr_ty);
+    try func.memset(dst_ptr, len, value);
 
     func.finishAir(inst, .none, &.{ bin_op.lhs, bin_op.rhs });
 }

--- a/test/behavior/int128.zig
+++ b/test/behavior/int128.zig
@@ -87,7 +87,6 @@ test "truncate int128" {
 }
 
 test "shift int128" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -486,7 +486,6 @@ fn testDivision() !void {
 }
 
 test "division half-precision floats" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/memset.zig
+++ b/test/behavior/memset.zig
@@ -7,10 +7,6 @@ test "@memset on array pointers" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) {
-        // TODO: implement memset when element ABI size > 1
-        return error.SkipZigTest;
-    }
 
     try testMemsetArray();
     try comptime testMemsetArray();
@@ -40,11 +36,6 @@ test "@memset on slices" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) {
-        // TODO: implement memset when element ABI size > 1
-        // TODO: implement memset on slices
-        return error.SkipZigTest;
-    }
 
     try testMemsetSlice();
     try comptime testMemsetSlice();
@@ -78,7 +69,6 @@ test "memset with bool element" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     var buf: [5]bool = undefined;
     @memset(&buf, true);
@@ -91,7 +81,6 @@ test "memset with 1-byte struct element" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const S = struct { x: bool };
     var buf: [5]S = undefined;
@@ -105,7 +94,6 @@ test "memset with 1-byte array element" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const A = [1]bool;
     var buf: [5]A = undefined;
@@ -119,7 +107,6 @@ test "memset with large array element, runtime known" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const A = [128]u64;
     var buf: [5]A = undefined;
@@ -137,7 +124,6 @@ test "memset with large array element, comptime known" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const A = [128]u64;
     var buf: [5]A = undefined;

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -185,7 +185,6 @@ test "slicing zero length array" {
 }
 
 test "slicing pointer by length" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const array = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };


### PR DESCRIPTION
This implements the remaining instructions to enable the standard test runner rather than the simplified one.