### PR TITLE
compiler_rt: use VFP as AEABI fp helper implementation

### DIFF
--- a/lib/compiler_rt/adddf3.zig
+++ b/lib/compiler_rt/adddf3.zig
@@ -16,5 +16,8 @@ fn __adddf3(a: f64, b: f64) callconv(.C) f64 {
 }
 
 fn __aeabi_dadd(a: f64, b: f64) callconv(.AAPCS) f64 {
+    if (common.has_hardware_f64) {
+        return a + b;
+    }
     return addf3(f64, a, b);
 }

--- a/lib/compiler_rt/addsf3.zig
+++ b/lib/compiler_rt/addsf3.zig
@@ -16,5 +16,8 @@ fn __addsf3(a: f32, b: f32) callconv(.C) f32 {
 }
 
 fn __aeabi_fadd(a: f32, b: f32) callconv(.AAPCS) f32 {
+    if (common.has_hardware_f32) {
+        return a + b;
+    }
     return addf3(f32, a, b);
 }

--- a/lib/compiler_rt/arm.zig
+++ b/lib/compiler_rt/arm.zig
@@ -40,8 +40,9 @@ comptime {
                 @export(__aeabi_read_tp, .{ .name = "__aeabi_read_tp", .linkage = common.linkage, .visibility = common.visibility });
             }
 
-            // floating-point helper functions (double-precision reverse subtraction, y – x), see subdf3.zig
+            // floating-point helper functions (double/single-precision reverse subtraction, y – x), see subdf3.zig & subsf3.zig
             @export(__aeabi_drsub, .{ .name = "__aeabi_drsub", .linkage = common.linkage, .visibility = common.visibility });
+            @export(__aeabi_frsub, .{ .name = "__aeabi_frsub", .linkage = common.linkage, .visibility = common.visibility });
         }
     }
 }
@@ -191,7 +192,18 @@ pub fn __aeabi_ldivmod() callconv(.Naked) void {
     unreachable;
 }
 
+pub fn __aeabi_frsub(a: f32, b: f32) callconv(.AAPCS) f32 {
+    if (common.has_hardware_f32) {
+        return b - a;
+    }
+    const neg_a = @bitCast(f32, @bitCast(u32, a) ^ (@as(u32, 1) << 31));
+    return b + neg_a;
+}
+
 pub fn __aeabi_drsub(a: f64, b: f64) callconv(.AAPCS) f64 {
+    if (common.has_hardware_f64) {
+        return b - a;
+    }
     const neg_a = @bitCast(f64, @bitCast(u64, a) ^ (@as(u64, 1) << 63));
     return b + neg_a;
 }

--- a/lib/compiler_rt/cmpdf2.zig
+++ b/lib/compiler_rt/cmpdf2.zig
@@ -56,13 +56,22 @@ pub fn __ltdf2(a: f64, b: f64) callconv(.C) i32 {
 }
 
 fn __aeabi_dcmpeq(a: f64, b: f64) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f64) {
+        return @boolToInt(a == b);
+    }
     return @boolToInt(comparef.cmpf2(f64, comparef.LE, a, b) == .Equal);
 }
 
 fn __aeabi_dcmplt(a: f64, b: f64) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f64) {
+        return @boolToInt(a < b);
+    }
     return @boolToInt(comparef.cmpf2(f64, comparef.LE, a, b) == .Less);
 }
 
 fn __aeabi_dcmple(a: f64, b: f64) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f64) {
+        return @boolToInt(a <= b);
+    }
     return @boolToInt(comparef.cmpf2(f64, comparef.LE, a, b) != .Greater);
 }

--- a/lib/compiler_rt/cmpsf2.zig
+++ b/lib/compiler_rt/cmpsf2.zig
@@ -56,13 +56,22 @@ pub fn __ltsf2(a: f32, b: f32) callconv(.C) i32 {
 }
 
 fn __aeabi_fcmpeq(a: f32, b: f32) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f32) {
+        return @boolToInt(a == b);
+    }
     return @boolToInt(comparef.cmpf2(f32, comparef.LE, a, b) == .Equal);
 }
 
 fn __aeabi_fcmplt(a: f32, b: f32) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f32) {
+        return @boolToInt(a < b);
+    }
     return @boolToInt(comparef.cmpf2(f32, comparef.LE, a, b) == .Less);
 }
 
 fn __aeabi_fcmple(a: f32, b: f32) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f32) {
+        return @boolToInt(a <= b);
+    }
     return @boolToInt(comparef.cmpf2(f32, comparef.LE, a, b) != .Greater);
 }

--- a/lib/compiler_rt/common.zig
+++ b/lib/compiler_rt/common.zig
@@ -66,6 +66,21 @@ pub const gnu_f16_abi = switch (builtin.cpu.arch) {
 
 pub const want_sparc_abi = builtin.cpu.arch.isSPARC();
 
+// Incomplete set of helpers used to prevent emitting software implementations of
+// the ARM run-time ABI floating point functions if VFP is available.
+fn hasHardwareFloat(comptime T: type) bool {
+    return switch (builtin.cpu.arch) {
+        .arm, .armeb, .thumb, .thumbeb => switch (T) {
+            f32 => std.Target.arm.featureSetHas(builtin.cpu.features, .vfp2sp),
+            f64 => std.Target.arm.featureSetHas(builtin.cpu.features, .fp64),
+            else => false,
+        },
+        else => false,
+    };
+}
+pub const has_hardware_f32 = hasHardwareFloat(f32);
+pub const has_hardware_f64 = hasHardwareFloat(f64);
+
 // Avoid dragging in the runtime safety mechanisms into this .o file,
 // unless we're trying to test compiler-rt.
 pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {

--- a/lib/compiler_rt/divdf3.zig
+++ b/lib/compiler_rt/divdf3.zig
@@ -26,6 +26,9 @@ pub fn __divdf3(a: f64, b: f64) callconv(.C) f64 {
 }
 
 fn __aeabi_ddiv(a: f64, b: f64) callconv(.AAPCS) f64 {
+    if (common.has_hardware_f64) {
+        return a / b;
+    }
     return div(a, b);
 }
 

--- a/lib/compiler_rt/divsf3.zig
+++ b/lib/compiler_rt/divsf3.zig
@@ -24,6 +24,9 @@ pub fn __divsf3(a: f32, b: f32) callconv(.C) f32 {
 }
 
 fn __aeabi_fdiv(a: f32, b: f32) callconv(.AAPCS) f32 {
+    if (common.has_hardware_f32) {
+        return a / b;
+    }
     return div(a, b);
 }
 

--- a/lib/compiler_rt/extendsfdf2.zig
+++ b/lib/compiler_rt/extendsfdf2.zig
@@ -16,5 +16,8 @@ fn __extendsfdf2(a: f32) callconv(.C) f64 {
 }
 
 fn __aeabi_f2d(a: f32) callconv(.AAPCS) f64 {
+    if (common.has_hardware_f64) {
+        return a;
+    }
     return extendf(f64, f32, @bitCast(u32, a));
 }

--- a/lib/compiler_rt/fixdfdi.zig
+++ b/lib/compiler_rt/fixdfdi.zig
@@ -16,5 +16,8 @@ pub fn __fixdfdi(a: f64) callconv(.C) i64 {
 }
 
 fn __aeabi_d2lz(a: f64) callconv(.AAPCS) i64 {
+    if (common.has_hardware_f64) {
+        return @floatToInt(i64, a);
+    }
     return floatToInt(i64, a);
 }

--- a/lib/compiler_rt/fixdfsi.zig
+++ b/lib/compiler_rt/fixdfsi.zig
@@ -16,5 +16,8 @@ pub fn __fixdfsi(a: f64) callconv(.C) i32 {
 }
 
 fn __aeabi_d2iz(a: f64) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f64) {
+        return @floatToInt(i32, a);
+    }
     return floatToInt(i32, a);
 }

--- a/lib/compiler_rt/fixsfdi.zig
+++ b/lib/compiler_rt/fixsfdi.zig
@@ -16,5 +16,8 @@ pub fn __fixsfdi(a: f32) callconv(.C) i64 {
 }
 
 fn __aeabi_f2lz(a: f32) callconv(.AAPCS) i64 {
+    if (common.has_hardware_f32) {
+        return @floatToInt(i64, a);
+    }
     return floatToInt(i64, a);
 }

--- a/lib/compiler_rt/fixsfsi.zig
+++ b/lib/compiler_rt/fixsfsi.zig
@@ -16,5 +16,8 @@ pub fn __fixsfsi(a: f32) callconv(.C) i32 {
 }
 
 fn __aeabi_f2iz(a: f32) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f32) {
+        return @floatToInt(i32, a);
+    }
     return floatToInt(i32, a);
 }

--- a/lib/compiler_rt/fixunsdfdi.zig
+++ b/lib/compiler_rt/fixunsdfdi.zig
@@ -16,5 +16,8 @@ pub fn __fixunsdfdi(a: f64) callconv(.C) u64 {
 }
 
 fn __aeabi_d2ulz(a: f64) callconv(.AAPCS) u64 {
+    if (common.has_hardware_f64) {
+        return @floatToInt(u64, a);
+    }
     return floatToInt(u64, a);
 }

--- a/lib/compiler_rt/fixunsdfsi.zig
+++ b/lib/compiler_rt/fixunsdfsi.zig
@@ -16,5 +16,8 @@ pub fn __fixunsdfsi(a: f64) callconv(.C) u32 {
 }
 
 fn __aeabi_d2uiz(a: f64) callconv(.AAPCS) u32 {
+    if (common.has_hardware_f64) {
+        return @floatToInt(u32, a);
+    }
     return floatToInt(u32, a);
 }

--- a/lib/compiler_rt/fixunssfdi.zig
+++ b/lib/compiler_rt/fixunssfdi.zig
@@ -16,5 +16,8 @@ pub fn __fixunssfdi(a: f32) callconv(.C) u64 {
 }
 
 fn __aeabi_f2ulz(a: f32) callconv(.AAPCS) u64 {
+    if (common.has_hardware_f32) {
+        return @floatToInt(u64, a);
+    }
     return floatToInt(u64, a);
 }

--- a/lib/compiler_rt/fixunssfsi.zig
+++ b/lib/compiler_rt/fixunssfsi.zig
@@ -16,5 +16,8 @@ pub fn __fixunssfsi(a: f32) callconv(.C) u32 {
 }
 
 fn __aeabi_f2uiz(a: f32) callconv(.AAPCS) u32 {
+    if (common.has_hardware_f32) {
+        return @floatToInt(u32, a);
+    }
     return floatToInt(u32, a);
 }

--- a/lib/compiler_rt/floatdidf.zig
+++ b/lib/compiler_rt/floatdidf.zig
@@ -16,5 +16,8 @@ pub fn __floatdidf(a: i64) callconv(.C) f64 {
 }
 
 fn __aeabi_l2d(a: i64) callconv(.AAPCS) f64 {
+    if (common.has_hardware_f64) {
+        return @intToFloat(f64, a);
+    }
     return intToFloat(f64, a);
 }

--- a/lib/compiler_rt/floatdisf.zig
+++ b/lib/compiler_rt/floatdisf.zig
@@ -16,5 +16,8 @@ pub fn __floatdisf(a: i64) callconv(.C) f32 {
 }
 
 fn __aeabi_l2f(a: i64) callconv(.AAPCS) f32 {
+    if (common.has_hardware_f32) {
+        return @intToFloat(f32, a);
+    }
     return intToFloat(f32, a);
 }

--- a/lib/compiler_rt/floatsidf.zig
+++ b/lib/compiler_rt/floatsidf.zig
@@ -16,5 +16,8 @@ pub fn __floatsidf(a: i32) callconv(.C) f64 {
 }
 
 fn __aeabi_i2d(a: i32) callconv(.AAPCS) f64 {
+    if (common.has_hardware_f64) {
+        return @intToFloat(f64, a);
+    }
     return intToFloat(f64, a);
 }

--- a/lib/compiler_rt/floatsisf.zig
+++ b/lib/compiler_rt/floatsisf.zig
@@ -16,5 +16,8 @@ pub fn __floatsisf(a: i32) callconv(.C) f32 {
 }
 
 fn __aeabi_i2f(a: i32) callconv(.AAPCS) f32 {
+    if (common.has_hardware_f32) {
+        return @intToFloat(f32, a);
+    }
     return intToFloat(f32, a);
 }

--- a/lib/compiler_rt/floatundidf.zig
+++ b/lib/compiler_rt/floatundidf.zig
@@ -16,5 +16,8 @@ pub fn __floatundidf(a: u64) callconv(.C) f64 {
 }
 
 fn __aeabi_ul2d(a: u64) callconv(.AAPCS) f64 {
+    if (common.has_hardware_f64) {
+        return @intToFloat(f64, a);
+    }
     return intToFloat(f64, a);
 }

--- a/lib/compiler_rt/floatundisf.zig
+++ b/lib/compiler_rt/floatundisf.zig
@@ -16,5 +16,8 @@ pub fn __floatundisf(a: u64) callconv(.C) f32 {
 }
 
 fn __aeabi_ul2f(a: u64) callconv(.AAPCS) f32 {
+    if (common.has_hardware_f32) {
+        return @intToFloat(f32, a);
+    }
     return intToFloat(f32, a);
 }

--- a/lib/compiler_rt/floatunsidf.zig
+++ b/lib/compiler_rt/floatunsidf.zig
@@ -16,5 +16,8 @@ pub fn __floatunsidf(a: u32) callconv(.C) f64 {
 }
 
 fn __aeabi_ui2d(a: u32) callconv(.AAPCS) f64 {
+    if (common.has_hardware_f64) {
+        return @intToFloat(f64, a);
+    }
     return intToFloat(f64, a);
 }

--- a/lib/compiler_rt/floatunsisf.zig
+++ b/lib/compiler_rt/floatunsisf.zig
@@ -16,5 +16,8 @@ pub fn __floatunsisf(a: u32) callconv(.C) f32 {
 }
 
 fn __aeabi_ui2f(a: u32) callconv(.AAPCS) f32 {
+    if (common.has_hardware_f32) {
+        return @intToFloat(f32, a);
+    }
     return intToFloat(f32, a);
 }

--- a/lib/compiler_rt/gedf2.zig
+++ b/lib/compiler_rt/gedf2.zig
@@ -28,9 +28,15 @@ pub fn __gtdf2(a: f64, b: f64) callconv(.C) i32 {
 }
 
 fn __aeabi_dcmpge(a: f64, b: f64) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f64) {
+        return @boolToInt(a >= b);
+    }
     return @boolToInt(comparef.cmpf2(f64, comparef.GE, a, b) != .Less);
 }
 
 fn __aeabi_dcmpgt(a: f64, b: f64) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f64) {
+        return @boolToInt(a > b);
+    }
     return @boolToInt(comparef.cmpf2(f64, comparef.GE, a, b) == .Greater);
 }

--- a/lib/compiler_rt/gesf2.zig
+++ b/lib/compiler_rt/gesf2.zig
@@ -28,9 +28,15 @@ pub fn __gtsf2(a: f32, b: f32) callconv(.C) i32 {
 }
 
 fn __aeabi_fcmpge(a: f32, b: f32) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f32) {
+        return @boolToInt(a >= b);
+    }
     return @boolToInt(comparef.cmpf2(f32, comparef.GE, a, b) != .Less);
 }
 
 fn __aeabi_fcmpgt(a: f32, b: f32) callconv(.AAPCS) i32 {
-    return @boolToInt(comparef.cmpf2(f32, comparef.LE, a, b) == .Greater);
+    if (common.has_hardware_f32) {
+        return @boolToInt(a > b);
+    }
+    return @boolToInt(comparef.cmpf2(f32, comparef.GE, a, b) == .Greater);
 }

--- a/lib/compiler_rt/muldf3.zig
+++ b/lib/compiler_rt/muldf3.zig
@@ -16,5 +16,8 @@ pub fn __muldf3(a: f64, b: f64) callconv(.C) f64 {
 }
 
 fn __aeabi_dmul(a: f64, b: f64) callconv(.AAPCS) f64 {
+    if (common.has_hardware_f64) {
+        return a * b;
+    }
     return mulf3(f64, a, b);
 }

--- a/lib/compiler_rt/mulsf3.zig
+++ b/lib/compiler_rt/mulsf3.zig
@@ -16,5 +16,8 @@ pub fn __mulsf3(a: f32, b: f32) callconv(.C) f32 {
 }
 
 fn __aeabi_fmul(a: f32, b: f32) callconv(.AAPCS) f32 {
+    if (common.has_hardware_f32) {
+        return a * b;
+    }
     return mulf3(f32, a, b);
 }

--- a/lib/compiler_rt/negdf2.zig
+++ b/lib/compiler_rt/negdf2.zig
@@ -15,5 +15,8 @@ fn __negdf2(a: f64) callconv(.C) f64 {
 }
 
 fn __aeabi_dneg(a: f64) callconv(.AAPCS) f64 {
+    if (common.has_hardware_f64) {
+        return -a;
+    }
     return common.fneg(a);
 }

--- a/lib/compiler_rt/negsf2.zig
+++ b/lib/compiler_rt/negsf2.zig
@@ -15,5 +15,8 @@ fn __negsf2(a: f32) callconv(.C) f32 {
 }
 
 fn __aeabi_fneg(a: f32) callconv(.AAPCS) f32 {
+    if (common.has_hardware_f32) {
+        return -a;
+    }
     return common.fneg(a);
 }

--- a/lib/compiler_rt/subdf3.zig
+++ b/lib/compiler_rt/subdf3.zig
@@ -16,6 +16,9 @@ fn __subdf3(a: f64, b: f64) callconv(.C) f64 {
 }
 
 fn __aeabi_dsub(a: f64, b: f64) callconv(.AAPCS) f64 {
+    if (common.has_hardware_f64) {
+        return a - b;
+    }
     const neg_b = @bitCast(f64, @bitCast(u64, b) ^ (@as(u64, 1) << 63));
     return a + neg_b;
 }

--- a/lib/compiler_rt/subsf3.zig
+++ b/lib/compiler_rt/subsf3.zig
@@ -16,6 +16,9 @@ fn __subsf3(a: f32, b: f32) callconv(.C) f32 {
 }
 
 fn __aeabi_fsub(a: f32, b: f32) callconv(.AAPCS) f32 {
+    if (common.has_hardware_f32) {
+        return a - b;
+    }
     const neg_b = @bitCast(f32, @bitCast(u32, b) ^ (@as(u32, 1) << 31));
     return a + neg_b;
 }

--- a/lib/compiler_rt/truncdfsf2.zig
+++ b/lib/compiler_rt/truncdfsf2.zig
@@ -16,5 +16,8 @@ pub fn __truncdfsf2(a: f64) callconv(.C) f32 {
 }
 
 fn __aeabi_d2f(a: f64) callconv(.AAPCS) f32 {
+    if (common.has_hardware_f64) {
+        return @floatCast(f32, a);
+    }
     return truncf(f32, f64, a);
 }

--- a/lib/compiler_rt/unorddf2.zig
+++ b/lib/compiler_rt/unorddf2.zig
@@ -16,5 +16,8 @@ pub fn __unorddf2(a: f64, b: f64) callconv(.C) i32 {
 }
 
 fn __aeabi_dcmpun(a: f64, b: f64) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f64) {
+        return @boolToInt(a != a or b != b);
+    }
     return comparef.unordcmp(f64, a, b);
 }

--- a/lib/compiler_rt/unordsf2.zig
+++ b/lib/compiler_rt/unordsf2.zig
@@ -16,5 +16,8 @@ pub fn __unordsf2(a: f32, b: f32) callconv(.C) i32 {
 }
 
 fn __aeabi_fcmpun(a: f32, b: f32) callconv(.AAPCS) i32 {
+    if (common.has_hardware_f32) {
+        return @boolToInt(a != a or b != b);
+    }
     return comparef.unordcmp(f32, a, b);
 }


### PR DESCRIPTION
Introduce a(n incomplete) set of helpers for short-circuiting the software implementation of functions like `__aeabi_fadd` with a native floating point expression, expected to be lowered to the proper VFP instructions by stages after AIR *(if it was implemented in the ARM back-end ~~and LLVM didn't choke on instruction choice with `Cannot select` on certain CPU configurations~~)*.

This is explicitly allowed by the ARM run-time ABI: "If the FP instruction set is available, implementations of these functions may use it."

The LLVM IR for the modified functions is reduced to 1/2 lines each.

In addition:
* implements `__aeabi_frsub` (add that to the #14634 tally)
* fixes a bug where `__aeabi_fcmpgt` used the wrong compare mode