### PR TITLE
Fix typo in langref

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5320,7 +5320,7 @@ test "fn reflection" {
       </p>
       <p>
       The number of unique error values across the entire compilation should determine the size of the error set type.
-      However right now it is hard coded to be a {#syntax#}u16{#endsyntax#}. See <a href="https://github.com/ziglang/zig/issues/786">#768</a>.
+      However right now it is hard coded to be a {#syntax#}u16{#endsyntax#}. See <a href="https://github.com/ziglang/zig/issues/786">#786</a>.
       </p>
       <p>
       You can {#link|coerce|Type Coercion#} an error from a subset to a superset:


### PR DESCRIPTION
- 768 -> 786
- The link seems to be correct
- The link-text points to a seemingly unrelated issue