### PR TITLE
autodoc: Start search on any search input event, not just keydown

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -133,6 +133,7 @@ const NAV_MODES = {
 
   domSearch.disabled = false;
   domSearch.addEventListener("keydown", onSearchKeyDown, false);
+  domSearch.addEventListener("input", onSearchInput, false);
   domSearch.addEventListener("focus", ev => {
     domSearchPlaceholder.classList.add("hidden");
     canToggleHelpModal = false;
@@ -4009,13 +4010,15 @@ function addDeclToSearchResults(decl, declIndex, modNames, item, list, stack) {
         ev.stopPropagation();
         return;
       default:
-        if (ev.shiftKey || ev.ctrlKey || ev.altKey) return;
-
-        curSearchIndex = -1;
+        // Search is triggered via an `input` event handler, not on arbitrary `keydown` events.
         ev.stopPropagation();
-        startAsyncSearch();
         return;
     }
+  }
+
+  function onSearchInput(ev) {
+    curSearchIndex = -1;
+    startAsyncSearch();
   }
 
   function moveSearchCursor(dir) {


### PR DESCRIPTION
Unlike `keydown`, the `input` event is dispatched regardless of how the input value was changed - key press, keyboard paste, mouse paste, ...

Closes #15632.