### PR TITLE
std.mem.zeroInit: zero all hidden padding for extern struct

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -437,7 +437,7 @@ pub fn zeroInit(comptime T: type, init: anytype) T {
                         }
                     }
 
-                    var value: T = undefined;
+                    var value: T = if (struct_info.layout == .Extern) zeroes(T) else undefined;
 
                     inline for (struct_info.fields, 0..) |field, i| {
                         if (field.is_comptime) {


### PR DESCRIPTION
The current implementation of `zeroInit` will leave padding undefined which is not consistent with its comments:

> /// Initializes all fields of the struct with their default value, or zero values if no default value is present.

Let's fix it.