### PR TITLE
`@mem{cpy,set}` fixes

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -22146,7 +22146,7 @@ fn zirMemcpy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void
             const len = try sema.usizeCast(block, dest_src, len_u64);
             for (0..len) |i| {
                 const elem_index = try sema.addIntUnsigned(Type.usize, i);
-                const dest_elem_ptr = try sema.elemPtr(
+                const dest_elem_ptr = try sema.elemPtrOneLayerOnly(
                     block,
                     src,
                     dest_ptr,
@@ -22155,7 +22155,7 @@ fn zirMemcpy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void
                     true, // init
                     false, // oob_safety
                 );
-                const src_elem_ptr = try sema.elemPtr(
+                const src_elem_ptr = try sema.elemPtrOneLayerOnly(
                     block,
                     src,
                     src_ptr,

--- a/test/behavior/memcpy.zig
+++ b/test/behavior/memcpy.zig
@@ -65,3 +65,16 @@ fn testMemcpyDestManyPtr() !void {
     try expect(buf[3] == 'l');
     try expect(buf[4] == 'o');
 }
+
+comptime {
+    const S = struct {
+        buffer: [8]u8 = undefined,
+        fn set(self: *@This(), items: []const u8) void {
+            @memcpy(self.buffer[0..items.len], items);
+        }
+    };
+
+    var s = S{};
+    s.set("hello");
+    if (!std.mem.eql(u8, s.buffer[0..5], "hello")) @compileError("bad");
+}

--- a/test/behavior/memcpy.zig
+++ b/test/behavior/memcpy.zig
@@ -44,3 +44,24 @@ fn testMemcpyBothSinglePtrArrayOneIsNullTerminated() !void {
     try expect(buf[98] == 'l');
     try expect(buf[99] == 'o');
 }
+
+test "@memcpy dest many pointer" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    try testMemcpyDestManyPtr();
+    try comptime testMemcpyDestManyPtr();
+}
+
+fn testMemcpyDestManyPtr() !void {
+    var str = "hello".*;
+    var buf: [5]u8 = undefined;
+    @memcpy(@ptrCast([*]u8, &buf), @ptrCast([*]const u8, &str)[0..5]);
+    try expect(buf[0] == 'h');
+    try expect(buf[1] == 'e');
+    try expect(buf[2] == 'l');
+    try expect(buf[3] == 'l');
+    try expect(buf[4] == 'o');
+}

--- a/test/cases/compile_errors/incorrect_type_to_memset_memcpy.zig
+++ b/test/cases/compile_errors/incorrect_type_to_memset_memcpy.zig
@@ -19,6 +19,19 @@ pub export fn non_matching_lengths() void {
     var buf2: [6]u8 = .{ 1, 2, 3, 4, 5, 6 };
     @memcpy(&buf2, &buf1);
 }
+pub export fn memset_const_dest_ptr() void {
+    const buf: [5]u8 = .{ 1, 2, 3, 4, 5 };
+    @memset(&buf, 1);
+}
+pub export fn memcpy_const_dest_ptr() void {
+    const buf1: [5]u8 = .{ 1, 2, 3, 4, 5 };
+    var buf2: [5]u8 = .{ 1, 2, 3, 4, 5 };
+    @memcpy(&buf1, &buf2);
+}
+pub export fn memset_array() void {
+    var buf: [5]u8 = .{ 1, 2, 3, 4, 5 };
+    @memcpy(buf, 1);
+}
 
 // error
 // backend=stage2
@@ -27,10 +40,14 @@ pub export fn non_matching_lengths() void {
 // :5:5: error: unknown @memcpy length
 // :5:18: note: destination type '[*]u8' provides no length
 // :5:24: note: source type '[*]align(4) const u8' provides no length
-// :10:13: error: type 'u8' does not support indexing
-// :10:13: note: operand must be an array, slice, tuple, or vector
-// :15:13: error: type '*u8' does not support indexing
-// :15:13: note: operand must be an array, slice, tuple, or vector
+// :10:13: error: type '*u8' is not an indexable pointer
+// :10:13: note: operand must be a slice, a many pointer or a pointer to an array
+// :15:13: error: type '*u8' is not an indexable pointer
+// :15:13: note: operand must be a slice, a many pointer or a pointer to an array
 // :20:5: error: non-matching @memcpy lengths
 // :20:13: note: length 6 here
 // :20:20: note: length 5 here
+// :24:13: error: cannot memset constant pointer
+// :29:13: error: cannot memcpy to constant pointer
+// :33:13: error: type '[5]u8' is not an indexable pointer
+// :33:13: note: operand must be a slice, a many pointer or a pointer to an array


### PR DESCRIPTION
Closes #15638, with parts being reused with attribution