### PR TITLE
std: Support user-provided jsonParse method. Unify json.Parser and json.parse*

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -4,12 +4,11 @@
 //! The `Reader` API connects a `std.io.Reader` to a `Scanner`.
 //!
 //! The high-level `parseFromSlice` and `parseFromTokenSource` deserializes a JSON document into a Zig type.
-//! The high-level `Parser` parses any JSON document into a dynamically typed `ValueTree` that has its own memory arena.
+//! Parse into a dynamically-typed `Value` to load any JSON value for runtime inspection.
 //!
 //! The low-level `writeStream` emits syntax-conformant JSON tokens to a `std.io.Writer`.
-//! The high-level `stringify` serializes a Zig type into JSON.
+//! The high-level `stringify` serializes a Zig or `Value` type into JSON.
 
-pub const ValueTree = @import("json/dynamic.zig").ValueTree;
 pub const ObjectMap = @import("json/dynamic.zig").ObjectMap;
 pub const Array = @import("json/dynamic.zig").Array;
 pub const Value = @import("json/dynamic.zig").Value;
@@ -29,9 +28,11 @@ pub const isNumberFormattedLikeAnInteger = @import("json/scanner.zig").isNumberF
 
 pub const ParseOptions = @import("json/static.zig").ParseOptions;
 pub const parseFromSlice = @import("json/static.zig").parseFromSlice;
+pub const parseFromSliceLeaky = @import("json/static.zig").parseFromSliceLeaky;
 pub const parseFromTokenSource = @import("json/static.zig").parseFromTokenSource;
+pub const parseFromTokenSourceLeaky = @import("json/static.zig").parseFromTokenSourceLeaky;
 pub const ParseError = @import("json/static.zig").ParseError;
-pub const parseFree = @import("json/static.zig").parseFree;
+pub const Parsed = @import("json/static.zig").Parsed;
 
 pub const StringifyOptions = @import("json/stringify.zig").StringifyOptions;
 pub const encodeJsonString = @import("json/stringify.zig").encodeJsonString;
@@ -44,7 +45,9 @@ pub const writeStream = @import("json/write_stream.zig").writeStream;
 
 // Deprecations
 pub const parse = @compileError("Deprecated; use parseFromSlice() or parseFromTokenSource() instead.");
-pub const Parser = @compileError("Deprecated; instead use parseFromSlice() or parseFromTokenSource() where T is ValueTree or Value.");
+pub const parseFree = @compileError("Deprecated; call Parsed(T).deinit() instead.");
+pub const Parser = @compileError("Deprecated; use parseFromSlice(Value) or parseFromTokenSource(Value) instead.");
+pub const ValueTree = @compileError("Deprecated; use Parsed(Value) instead.");
 pub const StreamingParser = @compileError("Deprecated; use json.Scanner or json.Reader instead.");
 pub const TokenStream = @compileError("Deprecated; use json.Scanner or json.Reader instead.");
 

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1,13 +1,69 @@
 //! JSON parsing and stringification conforming to RFC 8259. https://datatracker.ietf.org/doc/html/rfc8259
 //!
-//! The low-level `Scanner` API reads from an input slice or successive slices of inputs,
+//! The low-level `Scanner` API produces `Token`s from an input slice or successive slices of inputs,
 //! The `Reader` API connects a `std.io.Reader` to a `Scanner`.
 //!
-//! The high-level `parseFromSlice` and `parseFromTokenSource` deserializes a JSON document into a Zig type.
+//! The high-level `parseFromSlice` and `parseFromTokenSource` deserialize a JSON document into a Zig type.
 //! Parse into a dynamically-typed `Value` to load any JSON value for runtime inspection.
 //!
 //! The low-level `writeStream` emits syntax-conformant JSON tokens to a `std.io.Writer`.
 //! The high-level `stringify` serializes a Zig or `Value` type into JSON.
+
+const testing = @import("std").testing;
+const ArrayList = @import("std").ArrayList;
+
+test Scanner {
+    var scanner = Scanner.initCompleteInput(testing.allocator, "{\"foo\": 123}\n");
+    defer scanner.deinit();
+    try testing.expectEqual(Token.object_begin, try scanner.next());
+    try testing.expectEqualSlices(u8, "foo", (try scanner.next()).string);
+    try testing.expectEqualSlices(u8, "123", (try scanner.next()).number);
+    try testing.expectEqual(Token.object_end, try scanner.next());
+    try testing.expectEqual(Token.end_of_document, try scanner.next());
+}
+
+test parseFromSlice {
+    var parsed_str = try parseFromSlice([]const u8, testing.allocator, "\"a\\u0020b\"", .{});
+    defer parsed_str.deinit();
+    try testing.expectEqualSlices(u8, "a b", parsed_str.value);
+
+    const T = struct { a: i32 = -1, b: [2]u8 };
+    var parsed_struct = try parseFromSlice(T, testing.allocator, "{\"b\":\"xy\"}", .{});
+    defer parsed_struct.deinit();
+    try testing.expectEqual(@as(i32, -1), parsed_struct.value.a); // default value
+    try testing.expectEqualSlices(u8, "xy", parsed_struct.value.b[0..]);
+}
+
+test Value {
+    var parsed = try parseFromSlice(Value, testing.allocator, "{\"anything\": \"goes\"}", .{});
+    defer parsed.deinit();
+    try testing.expectEqualSlices(u8, "goes", parsed.value.object.get("anything").?.string);
+}
+
+test writeStream {
+    var out = ArrayList(u8).init(testing.allocator);
+    defer out.deinit();
+    var write_stream = writeStream(out.writer(), 99);
+    try write_stream.beginObject();
+    try write_stream.objectField("foo");
+    try write_stream.emitNumber(123);
+    try write_stream.endObject();
+    const expected =
+        \\{
+        \\ "foo": 123
+        \\}
+    ;
+    try testing.expectEqualSlices(u8, expected, out.items);
+}
+
+test stringify {
+    var out = ArrayList(u8).init(testing.allocator);
+    defer out.deinit();
+
+    const T = struct { a: i32, b: []const u8 };
+    try stringify(T{ .a = 123, .b = "xy" }, .{}, out.writer());
+    try testing.expectEqualSlices(u8, "{\"a\":123,\"b\":\"xy\"}", out.items);
+}
 
 pub const ObjectMap = @import("json/dynamic.zig").ObjectMap;
 pub const Array = @import("json/dynamic.zig").Array;

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -13,7 +13,6 @@ pub const ValueTree = @import("json/dynamic.zig").ValueTree;
 pub const ObjectMap = @import("json/dynamic.zig").ObjectMap;
 pub const Array = @import("json/dynamic.zig").Array;
 pub const Value = @import("json/dynamic.zig").Value;
-pub const Parser = @import("json/dynamic.zig").Parser;
 
 pub const validate = @import("json/scanner.zig").validate;
 pub const Error = @import("json/scanner.zig").Error;
@@ -45,6 +44,7 @@ pub const writeStream = @import("json/write_stream.zig").writeStream;
 
 // Deprecations
 pub const parse = @compileError("Deprecated; use parseFromSlice() or parseFromTokenSource() instead.");
+pub const Parser = @compileError("Deprecated; instead use parseFromSlice() or parseFromTokenSource() where T is ValueTree or Value.");
 pub const StreamingParser = @compileError("Deprecated; use json.Scanner or json.Reader instead.");
 pub const TokenStream = @compileError("Deprecated; use json.Scanner or json.Reader instead.");
 

--- a/lib/std/json/dynamic.zig
+++ b/lib/std/json/dynamic.zig
@@ -101,7 +101,7 @@ pub const Value = union(enum) {
         }
     }
 
-    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!Value {
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
         // The grammar of the stack is:
         //  (.array | .object .string)*
         var stack = Array.init(allocator);

--- a/lib/std/json/dynamic.zig
+++ b/lib/std/json/dynamic.zig
@@ -8,26 +8,58 @@ const Allocator = std.mem.Allocator;
 const StringifyOptions = @import("./stringify.zig").StringifyOptions;
 const stringify = @import("./stringify.zig").stringify;
 
+const ParseOptions = @import("./static.zig").ParseOptions;
+const ParseError = @import("./static.zig").ParseError;
+
 const JsonScanner = @import("./scanner.zig").Scanner;
 const AllocWhen = @import("./scanner.zig").AllocWhen;
 const Token = @import("./scanner.zig").Token;
 const isNumberFormattedLikeAnInteger = @import("./scanner.zig").isNumberFormattedLikeAnInteger;
 
+/// A `std.json.Value` and a `std.heap.ArenaAllocator` used for any allocations for the `Value`.
+/// When parsing, the `.alloc_if_needed` optimization is always enabled;
+/// see `std.json.ParseOptions.alloc_when`.
 pub const ValueTree = struct {
     arena: *ArenaAllocator,
     root: Value,
 
-    pub fn deinit(self: *ValueTree) void {
+    pub fn deinit(self: *const ValueTree) void {
         self.arena.deinit();
         self.arena.child_allocator.destroy(self.arena);
+    }
+
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!ValueTree {
+        var arena = try allocator.create(ArenaAllocator);
+        errdefer allocator.destroy(arena);
+
+        arena.* = ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+
+        var child_options = options;
+        child_options.alloc_when = .alloc_if_needed;
+        const root = try Value.jsonParse(arena.allocator(), source, child_options);
+
+        return ValueTree{
+            .arena = arena,
+            .root = root,
+        };
+    }
+    pub fn jsonParseFree(self: *const @This(), allocator: Allocator) void {
+        _ = allocator;
+        self.deinit();
+    }
+
+    pub fn jsonStringify(self: @This(), options: StringifyOptions, out_stream: anytype) @TypeOf(out_stream).Error!void {
+        return self.root.jsonStringify(options, out_stream);
     }
 };
 
 pub const ObjectMap = StringArrayHashMap(Value);
 pub const Array = ArrayList(Value);
 
-/// Represents a JSON value
-/// Currently only supports numbers that fit into i64 or f64.
+/// Represents any JSON value, potentially containing other JSON values.
+/// A .float value may be an approximation of the original value.
+/// Arbitrary precision numbers can be represented by .number_string values.
 pub const Value = union(enum) {
     null,
     bool: bool,
@@ -37,6 +69,33 @@ pub const Value = union(enum) {
     string: []const u8,
     array: Array,
     object: ObjectMap,
+
+    pub fn parseFromNumberSlice(s: []const u8) Value {
+        if (!isNumberFormattedLikeAnInteger(s)) {
+            const f = std.fmt.parseFloat(f64, s) catch unreachable;
+            if (std.math.isFinite(f)) {
+                return Value{ .float = f };
+            } else {
+                return Value{ .number_string = s };
+            }
+        }
+        if (std.fmt.parseInt(i64, s, 10)) |i| {
+            return Value{ .integer = i };
+        } else |e| {
+            switch (e) {
+                error.Overflow => return Value{ .number_string = s },
+                error.InvalidCharacter => unreachable,
+            }
+        }
+    }
+
+    pub fn dump(self: Value) void {
+        std.debug.getStderrMutex().lock();
+        defer std.debug.getStderrMutex().unlock();
+
+        const stderr = std.io.getStdErr().writer();
+        stringify(self, .{}, stderr) catch return;
+    }
 
     pub fn jsonStringify(
         value: @This(),
@@ -80,264 +139,101 @@ pub const Value = union(enum) {
         }
     }
 
-    pub fn dump(self: Value) void {
-        std.debug.getStderrMutex().lock();
-        defer std.debug.getStderrMutex().unlock();
-
-        const stderr = std.io.getStdErr().writer();
-        stringify(self, .{}, stderr) catch return;
-    }
-};
-
-/// A non-stream JSON parser which constructs a tree of Value's.
-pub const Parser = struct {
-    allocator: Allocator,
-    state: State,
-    alloc_when: AllocWhen,
-    // Stores parent nodes and un-combined Values.
-    stack: Array,
-
-    const State = enum {
-        object_key,
-        object_value,
-        array_value,
-        simple,
-    };
-
-    pub fn init(allocator: Allocator, alloc_when: AllocWhen) Parser {
-        return Parser{
-            .allocator = allocator,
-            .state = .simple,
-            .alloc_when = alloc_when,
-            .stack = Array.init(allocator),
-        };
-    }
-
-    pub fn deinit(p: *Parser) void {
-        p.stack.deinit();
-    }
-
-    pub fn reset(p: *Parser) void {
-        p.state = .simple;
-        p.stack.shrinkRetainingCapacity(0);
-    }
-
-    pub fn parse(p: *Parser, input: []const u8) !ValueTree {
-        var scanner = JsonScanner.initCompleteInput(p.allocator, input);
-        defer scanner.deinit();
-
-        var arena = try p.allocator.create(ArenaAllocator);
-        errdefer p.allocator.destroy(arena);
-
-        arena.* = ArenaAllocator.init(p.allocator);
-        errdefer arena.deinit();
-
-        const allocator = arena.allocator();
+    pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!Value {
+        // The grammar of the stack is:
+        //  (.array | .object .string)*
+        var stack = Array.init(allocator);
+        defer stack.deinit();
 
         while (true) {
-            const token = try scanner.nextAlloc(allocator, p.alloc_when);
-            if (token == .end_of_document) break;
-            try p.transition(allocator, token);
-        }
+            // Assert the stack grammar at the top of the stack.
+            debug.assert(stack.items.len == 0 or
+                stack.items[stack.items.len - 1] == .array or
+                (stack.items[stack.items.len - 2] == .object and stack.items[stack.items.len - 1] == .string));
 
-        debug.assert(p.stack.items.len == 1);
-
-        return ValueTree{
-            .arena = arena,
-            .root = p.stack.items[0],
-        };
-    }
-
-    // Even though p.allocator exists, we take an explicit allocator so that allocation state
-    // can be cleaned up on error correctly during a `parse` on call.
-    fn transition(p: *Parser, allocator: Allocator, token: Token) !void {
-        switch (p.state) {
-            .object_key => switch (token) {
-                .object_end => {
-                    if (p.stack.items.len == 1) {
-                        return;
-                    }
-
-                    var value = p.stack.pop();
-                    try p.pushToParent(&value);
+            switch (try source.nextAlloc(allocator, options.alloc_when)) {
+                inline .string, .allocated_string => |s| {
+                    return try handleCompleteValue(&stack, allocator, source, options.alloc_when, Value{ .string = s }) orelse continue;
                 },
-                .string => |s| {
-                    try p.stack.append(Value{ .string = s });
-                    p.state = .object_value;
+                inline .number, .allocated_number => |slice| {
+                    return try handleCompleteValue(&stack, allocator, source, options.alloc_when, Value.parseFromNumberSlice(slice)) orelse continue;
                 },
-                .allocated_string => |s| {
-                    try p.stack.append(Value{ .string = s });
-                    p.state = .object_value;
-                },
-                else => unreachable,
-            },
-            .object_value => {
-                var object = &p.stack.items[p.stack.items.len - 2].object;
-                var key = p.stack.items[p.stack.items.len - 1].string;
 
-                switch (token) {
-                    .object_begin => {
-                        try p.stack.append(Value{ .object = ObjectMap.init(allocator) });
-                        p.state = .object_key;
-                    },
-                    .array_begin => {
-                        try p.stack.append(Value{ .array = Array.init(allocator) });
-                        p.state = .array_value;
-                    },
-                    .string => |s| {
-                        try object.put(key, Value{ .string = s });
-                        _ = p.stack.pop();
-                        p.state = .object_key;
-                    },
-                    .allocated_string => |s| {
-                        try object.put(key, Value{ .string = s });
-                        _ = p.stack.pop();
-                        p.state = .object_key;
-                    },
-                    .number => |slice| {
-                        try object.put(key, try p.parseNumber(slice));
-                        _ = p.stack.pop();
-                        p.state = .object_key;
-                    },
-                    .allocated_number => |slice| {
-                        try object.put(key, try p.parseNumber(slice));
-                        _ = p.stack.pop();
-                        p.state = .object_key;
-                    },
-                    .true => {
-                        try object.put(key, Value{ .bool = true });
-                        _ = p.stack.pop();
-                        p.state = .object_key;
-                    },
-                    .false => {
-                        try object.put(key, Value{ .bool = false });
-                        _ = p.stack.pop();
-                        p.state = .object_key;
-                    },
-                    .null => {
-                        try object.put(key, .null);
-                        _ = p.stack.pop();
-                        p.state = .object_key;
-                    },
-                    .object_end, .array_end, .end_of_document => unreachable,
-                    .partial_number, .partial_string, .partial_string_escaped_1, .partial_string_escaped_2, .partial_string_escaped_3, .partial_string_escaped_4 => unreachable,
-                }
-            },
-            .array_value => {
-                var array = &p.stack.items[p.stack.items.len - 1].array;
+                .null => return try handleCompleteValue(&stack, allocator, source, options.alloc_when, .null) orelse continue,
+                .true => return try handleCompleteValue(&stack, allocator, source, options.alloc_when, Value{ .bool = true }) orelse continue,
+                .false => return try handleCompleteValue(&stack, allocator, source, options.alloc_when, Value{ .bool = false }) orelse continue,
 
-                switch (token) {
-                    .array_end => {
-                        if (p.stack.items.len == 1) {
-                            return;
-                        }
-
-                        var value = p.stack.pop();
-                        try p.pushToParent(&value);
-                    },
-                    .object_begin => {
-                        try p.stack.append(Value{ .object = ObjectMap.init(allocator) });
-                        p.state = .object_key;
-                    },
-                    .array_begin => {
-                        try p.stack.append(Value{ .array = Array.init(allocator) });
-                        p.state = .array_value;
-                    },
-                    .string => |s| {
-                        try array.append(Value{ .string = s });
-                    },
-                    .allocated_string => |s| {
-                        try array.append(Value{ .string = s });
-                    },
-                    .number => |slice| {
-                        try array.append(try p.parseNumber(slice));
-                    },
-                    .allocated_number => |slice| {
-                        try array.append(try p.parseNumber(slice));
-                    },
-                    .true => {
-                        try array.append(Value{ .bool = true });
-                    },
-                    .false => {
-                        try array.append(Value{ .bool = false });
-                    },
-                    .null => {
-                        try array.append(.null);
-                    },
-                    .object_end, .end_of_document => unreachable,
-                    .partial_number, .partial_string, .partial_string_escaped_1, .partial_string_escaped_2, .partial_string_escaped_3, .partial_string_escaped_4 => unreachable,
-                }
-            },
-            .simple => switch (token) {
                 .object_begin => {
-                    try p.stack.append(Value{ .object = ObjectMap.init(allocator) });
-                    p.state = .object_key;
+                    switch (try source.nextAlloc(allocator, options.alloc_when)) {
+                        .object_end => return try handleCompleteValue(&stack, allocator, source, options.alloc_when, Value{ .object = ObjectMap.init(allocator) }) orelse continue,
+                        inline .string, .allocated_string => |key| {
+                            try stack.appendSlice(&[_]Value{
+                                Value{ .object = ObjectMap.init(allocator) },
+                                Value{ .string = key },
+                            });
+                        },
+                        else => unreachable,
+                    }
                 },
                 .array_begin => {
-                    try p.stack.append(Value{ .array = Array.init(allocator) });
-                    p.state = .array_value;
+                    try stack.append(Value{ .array = Array.init(allocator) });
                 },
-                .string => |s| {
-                    try p.stack.append(Value{ .string = s });
-                },
-                .allocated_string => |s| {
-                    try p.stack.append(Value{ .string = s });
-                },
-                .number => |slice| {
-                    try p.stack.append(try p.parseNumber(slice));
-                },
-                .allocated_number => |slice| {
-                    try p.stack.append(try p.parseNumber(slice));
-                },
-                .true => {
-                    try p.stack.append(Value{ .bool = true });
-                },
-                .false => {
-                    try p.stack.append(Value{ .bool = false });
-                },
-                .null => {
-                    try p.stack.append(.null);
-                },
-                .object_end, .array_end, .end_of_document => unreachable,
-                .partial_number, .partial_string, .partial_string_escaped_1, .partial_string_escaped_2, .partial_string_escaped_3, .partial_string_escaped_4 => unreachable,
-            },
-        }
-    }
+                .array_end => return try handleCompleteValue(&stack, allocator, source, options.alloc_when, stack.pop()) orelse continue,
 
-    fn pushToParent(p: *Parser, value: *const Value) !void {
-        switch (p.stack.items[p.stack.items.len - 1]) {
-            // Object Parent -> [ ..., object, <key>, value ]
-            .string => |key| {
-                _ = p.stack.pop();
-
-                var object = &p.stack.items[p.stack.items.len - 1].object;
-                try object.put(key, value.*);
-                p.state = .object_key;
-            },
-            // Array Parent -> [ ..., <array>, value ]
-            .array => |*array| {
-                try array.append(value.*);
-                p.state = .array_value;
-            },
-            else => {
-                unreachable;
-            },
-        }
-    }
-
-    fn parseNumber(p: *Parser, slice: []const u8) !Value {
-        _ = p;
-        return if (isNumberFormattedLikeAnInteger(slice))
-            Value{
-                .integer = std.fmt.parseInt(i64, slice, 10) catch |e| switch (e) {
-                    error.Overflow => return Value{ .number_string = slice },
-                    error.InvalidCharacter => |err| return err,
-                },
+                else => unreachable,
             }
-        else
-            Value{ .float = try std.fmt.parseFloat(f64, slice) };
+        }
+    }
+    pub fn jsonParseFree(self: *const @This(), allocator: Allocator) void {
+        _ = self;
+        _ = allocator;
     }
 };
+
+fn handleCompleteValue(stack: *Array, allocator: Allocator, source: anytype, alloc_when: AllocWhen, value_: Value) !?Value {
+    if (stack.items.len == 0) return value_;
+    var value = value_;
+    while (true) {
+        // Assert the stack grammar at the top of the stack.
+        debug.assert(stack.items[stack.items.len - 1] == .array or
+            (stack.items[stack.items.len - 2] == .object and stack.items[stack.items.len - 1] == .string));
+        switch (stack.items[stack.items.len - 1]) {
+            .string => |key| {
+                // stack: [..., .object, .string]
+                _ = stack.pop();
+
+                // stack: [..., .object]
+                var object = &stack.items[stack.items.len - 1].object;
+                try object.put(key, value);
+
+                // This is an invalid state to leave the stack in,
+                // so we have to process the next token before we return.
+                switch (try source.nextAlloc(allocator, alloc_when)) {
+                    .object_end => {
+                        // This object is complete.
+                        value = stack.pop();
+                        // Effectively recurse now that we have a complete value.
+                        if (stack.items.len == 0) return value;
+                        continue;
+                    },
+                    inline .string, .allocated_string => |next_key| {
+                        // We've got another key.
+                        try stack.append(Value{ .string = next_key });
+                        // stack: [..., .object, .string]
+                        return null;
+                    },
+                    else => unreachable,
+                }
+            },
+            .array => |*array| {
+                // stack: [..., .array]
+                try array.append(value);
+                return null;
+            },
+            else => unreachable,
+        }
+    }
+}
 
 test {
     _ = @import("dynamic_test.zig");

--- a/lib/std/json/dynamic.zig
+++ b/lib/std/json/dynamic.zig
@@ -68,7 +68,13 @@ pub const Value = union(enum) {
     number_string: []const u8,
     string: []const u8,
     array: Array,
-    object: ObjectMap,
+    object: *ObjectMap,
+
+    pub fn initObject(allocator: Allocator) Allocator.Error!@This() {
+        const object = try allocator.create(ObjectMap);
+        object.* = ObjectMap.init(allocator);
+        return Value{ .object = object };
+    }
 
     pub fn parseFromNumberSlice(s: []const u8) Value {
         if (!isNumberFormattedLikeAnInteger(s)) {
@@ -86,6 +92,32 @@ pub const Value = union(enum) {
                 error.Overflow => return Value{ .number_string = s },
                 error.InvalidCharacter => unreachable,
             }
+        }
+    }
+
+    /// This function recursively deallocates all memory for this value.
+    /// This function must not be called when this value was created while
+    /// `std.json.ParseOptions.alloc_when` was `.alloc_if_needed`;
+    /// this function unconditionally attempts to free all strings.
+    pub fn deinit(value: @This(), allocator: Allocator) void {
+        switch (value) {
+            .null, .bool, .integer, .float => {},
+            .number_string, .string => |inner| allocator.free(inner),
+            .array => |inner| {
+                for (inner.items) |child| {
+                    child.jsonParseFree(allocator);
+                }
+                inner.deinit();
+            },
+            .object => |inner| {
+                var it = inner.iterator();
+                while (it.next()) |entry| {
+                    allocator.free(entry.key_ptr.*);
+                    entry.value_ptr.*.jsonParseFree(allocator);
+                }
+                inner.deinit();
+                allocator.destroy(inner);
+            },
         }
     }
 
@@ -165,10 +197,10 @@ pub const Value = union(enum) {
 
                 .object_begin => {
                     switch (try source.nextAlloc(allocator, options.alloc_when)) {
-                        .object_end => return try handleCompleteValue(&stack, allocator, source, options.alloc_when, Value{ .object = ObjectMap.init(allocator) }) orelse continue,
+                        .object_end => return try handleCompleteValue(&stack, allocator, source, options.alloc_when, try Value.initObject(allocator)) orelse continue,
                         inline .string, .allocated_string => |key| {
                             try stack.appendSlice(&[_]Value{
-                                Value{ .object = ObjectMap.init(allocator) },
+                                try Value.initObject(allocator),
                                 Value{ .string = key },
                             });
                         },
@@ -184,16 +216,15 @@ pub const Value = union(enum) {
             }
         }
     }
-    pub fn jsonParseFree(self: *const @This(), allocator: Allocator) void {
-        _ = self;
-        _ = allocator;
+    pub fn jsonParseFree(value: @This(), allocator: Allocator) void {
+        value.deinit(allocator);
     }
 };
 
 fn handleCompleteValue(stack: *Array, allocator: Allocator, source: anytype, alloc_when: AllocWhen, value_: Value) !?Value {
-    if (stack.items.len == 0) return value_;
     var value = value_;
     while (true) {
+        if (stack.items.len == 0) return value;
         // Assert the stack grammar at the top of the stack.
         debug.assert(stack.items[stack.items.len - 1] == .array or
             (stack.items[stack.items.len - 2] == .object and stack.items[stack.items.len - 1] == .string));
@@ -203,7 +234,7 @@ fn handleCompleteValue(stack: *Array, allocator: Allocator, source: anytype, all
                 _ = stack.pop();
 
                 // stack: [..., .object]
-                var object = &stack.items[stack.items.len - 1].object;
+                var object = stack.items[stack.items.len - 1].object;
                 try object.put(key, value);
 
                 // This is an invalid state to leave the stack in,
@@ -213,7 +244,6 @@ fn handleCompleteValue(stack: *Array, allocator: Allocator, source: anytype, all
                         // This object is complete.
                         value = stack.pop();
                         // Effectively recurse now that we have a complete value.
-                        if (stack.items.len == 0) return value;
                         continue;
                     },
                     inline .string, .allocated_string => |next_key| {

--- a/lib/std/json/dynamic_test.zig
+++ b/lib/std/json/dynamic_test.zig
@@ -270,10 +270,13 @@ test "Value.jsonStringify" {
     {
         var buffer: [10]u8 = undefined;
         var fbs = std.io.fixedBufferStream(&buffer);
-        var obj = ObjectMap.init(testing.allocator);
-        defer obj.deinit();
-        try obj.putNoClobber("a", .{ .string = "b" });
-        try (Value{ .object = obj }).jsonStringify(.{}, fbs.writer());
+        var obj = try Value.initObject(testing.allocator);
+        defer {
+            obj.object.clearAndFree();
+            obj.deinit(testing.allocator);
+        }
+        try obj.object.putNoClobber("a", .{ .string = "b" });
+        try obj.jsonStringify(.{}, fbs.writer());
         try testing.expectEqualSlices(u8, fbs.getWritten(), "{\"a\":\"b\"}");
     }
 }

--- a/lib/std/json/dynamic_test.zig
+++ b/lib/std/json/dynamic_test.zig
@@ -270,13 +270,10 @@ test "Value.jsonStringify" {
     {
         var buffer: [10]u8 = undefined;
         var fbs = std.io.fixedBufferStream(&buffer);
-        var obj = try Value.initObject(testing.allocator);
-        defer {
-            obj.object.clearAndFree();
-            obj.deinit(testing.allocator);
-        }
-        try obj.object.putNoClobber("a", .{ .string = "b" });
-        try obj.jsonStringify(.{}, fbs.writer());
+        var obj = ObjectMap.init(testing.allocator);
+        defer obj.deinit();
+        try obj.putNoClobber("a", .{ .string = "b" });
+        try (Value{ .object = obj }).jsonStringify(.{}, fbs.writer());
         try testing.expectEqualSlices(u8, fbs.getWritten(), "{\"a\":\"b\"}");
     }
 }

--- a/lib/std/json/static.zig
+++ b/lib/std/json/static.zig
@@ -56,7 +56,9 @@ pub fn parseFromSlice(
     return parseFromTokenSource(T, allocator, &scanner, options);
 }
 
-/// Parses
+/// Parses the json document from `s` and returns the result.
+/// Allocations made during this operation are not carefully tracked and may not be possible to individually clean up.
+/// It is recommended to use a `std.heap.ArenaAllocator` or similar.
 pub fn parseFromSliceLeaky(
     comptime T: type,
     allocator: Allocator,
@@ -90,6 +92,9 @@ pub fn parseFromTokenSource(
     return parsed;
 }
 
+/// `scanner_or_reader` must be either a `*std.json.Scanner` with complete input or a `*std.json.Reader`.
+/// Allocations made during this operation are not carefully tracked and may not be possible to individually clean up.
+/// It is recommended to use a `std.heap.ArenaAllocator` or similar.
 pub fn parseFromTokenSourceLeaky(
     comptime T: type,
     allocator: Allocator,
@@ -162,7 +167,7 @@ fn parseInternal(
             const token = try source.nextAllocMax(allocator, .alloc_if_needed, options.max_value_len.?);
             defer freeAllocated(allocator, token);
             const slice = switch (token) {
-                inline .number, .allocated_number, .string, .allocated_string=> |slice| slice,
+                inline .number, .allocated_number, .string, .allocated_string => |slice| slice,
                 else => return error.UnexpectedToken,
             };
             if (isNumberFormattedLikeAnInteger(slice))

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -1,8 +1,10 @@
 const std = @import("std");
 const testing = std.testing;
-const Parser = @import("./dynamic.zig").Parser;
+const parseFromSlice = @import("./static.zig").parseFromSlice;
+const parseFree = @import("./static.zig").parseFree;
 const validate = @import("./scanner.zig").validate;
 const JsonScanner = @import("./scanner.zig").Scanner;
+const ValueTree = @import("./dynamic.zig").ValueTree;
 
 // Support for JSONTestSuite.zig
 pub fn ok(s: []const u8) !void {
@@ -26,10 +28,8 @@ fn testLowLevelScanner(s: []const u8) !void {
     }
 }
 fn testHighLevelDynamicParser(s: []const u8) !void {
-    var p = Parser.init(testing.allocator, .alloc_if_needed);
-    defer p.deinit();
-    var tree = try p.parse(s);
-    defer tree.deinit();
+    var tree = try parseFromSlice(ValueTree, testing.allocator, s, .{});
+    defer parseFree(ValueTree, testing.allocator, tree);
 }
 
 // Additional tests not part of test JSONTestSuite.
@@ -47,10 +47,7 @@ test "n_object_closed_missing_value" {
 fn roundTrip(s: []const u8) !void {
     try testing.expect(try validate(testing.allocator, s));
 
-    var p = Parser.init(testing.allocator, .alloc_if_needed);
-    defer p.deinit();
-
-    var tree = try p.parse(s);
+    var tree = try parseFromSlice(ValueTree, testing.allocator, s, .{});
     defer tree.deinit();
 
     var buf: [256]u8 = undefined;

--- a/lib/std/json/write_stream.zig
+++ b/lib/std/json/write_stream.zig
@@ -293,7 +293,7 @@ test "json write stream" {
 }
 
 fn getJsonObject(allocator: std.mem.Allocator) !Value {
-    var value = try Value.initObject(allocator);
+    var value = Value{ .object = ObjectMap.init(allocator) };
     try value.object.put("one", Value{ .integer = @intCast(i64, 1) });
     try value.object.put("two", Value{ .float = 2.0 });
     return value;

--- a/lib/std/json/write_stream.zig
+++ b/lib/std/json/write_stream.zig
@@ -293,7 +293,7 @@ test "json write stream" {
 }
 
 fn getJsonObject(allocator: std.mem.Allocator) !Value {
-    var value = Value{ .object = ObjectMap.init(allocator) };
+    var value = try Value.initObject(allocator);
     try value.object.put("one", Value{ .integer = @intCast(i64, 1) });
     try value.object.put("two", Value{ .float = 2.0 });
     return value;

--- a/tools/gen_spirv_spec.zig
+++ b/tools/gen_spirv_spec.zig
@@ -20,15 +20,16 @@ pub fn main() !void {
     // Required for json parsing.
     @setEvalBranchQuota(10000);
 
-    var registry = try std.json.parseFromSlice(g.Registry, allocator, spec, .{});
-
-    const core_reg = switch (registry) {
-        .core => |core_reg| core_reg,
-        .extension => return error.TODOSpirVExtensionSpec,
+    var scanner = std.json.Scanner.initCompleteInput(allocator, spec);
+    var diagnostics = std.json.Diagnostics{};
+    scanner.enableDiagnostics(&diagnostics);
+    var parsed = std.json.parseFromTokenSource(g.CoreRegistry, allocator, &scanner, .{}) catch |err| {
+        std.debug.print("line,col: {},{}\n", .{ diagnostics.getLine(), diagnostics.getColumn() });
+        return err;
     };
 
     var bw = std.io.bufferedWriter(std.io.getStdOut().writer());
-    try render(bw.writer(), allocator, core_reg);
+    try render(bw.writer(), allocator, parsed.value);
     try bw.flush();
 }
 

--- a/tools/spirv/grammar.zig
+++ b/tools/spirv/grammar.zig
@@ -88,6 +88,7 @@ pub const Enumerant = struct {
             source: anytype,
             options: std.json.ParseOptions,
         ) std.json.ParseError(@TypeOf(source.*))!@This() {
+            _ = options;
             switch (try source.nextAlloc(allocator, .alloc_if_needed)) {
                 inline .string, .allocated_string => |s| return @This(){ .bitflag = s },
                 inline .number, .allocated_number => |s| return @This(){ .int = try std.fmt.parseInt(u31, s, 10) },

--- a/tools/spirv/grammar.zig
+++ b/tools/spirv/grammar.zig
@@ -1,6 +1,9 @@
 //! See https://www.khronos.org/registry/spir-v/specs/unified1/MachineReadableGrammar.html
 //! and the files in https://github.com/KhronosGroup/SPIRV-Headers/blob/master/include/spirv/unified1/
 //! Note: Non-canonical casing in these structs used to match SPIR-V spec json.
+
+const std = @import("std");
+
 pub const Registry = union(enum) {
     core: CoreRegistry,
     extension: ExtensionRegistry,
@@ -79,6 +82,19 @@ pub const Enumerant = struct {
     value: union(enum) {
         bitflag: []const u8, // Hexadecimal representation of the value
         int: u31,
+
+        pub fn jsonParse(
+            allocator: std.mem.Allocator,
+            source: anytype,
+            options: std.json.ParseOptions,
+        ) std.json.ParseError(@TypeOf(source.*))!@This() {
+            switch (try source.nextAlloc(allocator, options.alloc_when)) {
+                inline .string, .allocated_string => |s| return @This(){ .bitflag = s },
+                inline .number, .allocated_number => |s| return @This(){ .int = try std.fmt.parseInt(u31, s, 10) },
+                else => return error.UnexpectedToken,
+            }
+        }
+        pub const jsonStringify = @compileError("not supported");
     },
     capabilities: [][]const u8 = &[_][]const u8{},
     /// Valid for .ValueEnum and .BitEnum

--- a/tools/spirv/grammar.zig
+++ b/tools/spirv/grammar.zig
@@ -88,7 +88,7 @@ pub const Enumerant = struct {
             source: anytype,
             options: std.json.ParseOptions,
         ) std.json.ParseError(@TypeOf(source.*))!@This() {
-            switch (try source.nextAlloc(allocator, options.alloc_when)) {
+            switch (try source.nextAlloc(allocator, .alloc_if_needed)) {
                 inline .string, .allocated_string => |s| return @This(){ .bitflag = s },
                 inline .number, .allocated_number => |s| return @This(){ .int = try std.fmt.parseInt(u31, s, 10) },
                 else => return error.UnexpectedToken,

--- a/tools/update_clang_options.zig
+++ b/tools/update_clang_options.zig
@@ -624,9 +624,9 @@ pub fn main() anyerror!void {
         },
     };
 
-    var parser = json.Parser.init(allocator, .alloc_if_needed);
-    const tree = try parser.parse(json_text);
-    const root_map = &tree.root.object;
+    const parsed = try json.parseFromSlice(json.Value, allocator, json_text, .{});
+    defer parsed.deinit();
+    const root_map = &parsed.value.object;
 
     var all_objects = std.ArrayList(*json.ObjectMap).init(allocator);
     {

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -1054,14 +1054,14 @@ fn processOneTarget(job: Job) anyerror!void {
     var json_parse_progress = progress_node.start("parse JSON", 0);
     json_parse_progress.activate();
 
-    var parser = json.Parser.init(arena, .alloc_if_needed);
-    const tree = try parser.parse(json_text);
+    const parsed = try json.parseFromSlice(json.Value, arena, json_text, .{});
+    defer parsed.deinit();
+    const root_map = &parsed.value.object;
     json_parse_progress.end();
 
     var render_progress = progress_node.start("render zig code", 0);
     render_progress.activate();
 
-    const root_map = &tree.root.object;
     var features_table = std.StringHashMap(Feature).init(arena);
     var all_features = std.ArrayList(Feature).init(arena);
     var all_cpus = std.ArrayList(Cpu).init(arena);


### PR DESCRIPTION
This PR combines the dynamic `json.Parser` and the static `json.parse*()`. The bundled arena strategy from `ParseTree` is now available for all parsing via `json.parseFrom*()`. The old behavior is still available at `json.parseFrom*Leaky()` (name bikeshedding welcome on that one).

The `parseFree()` function is gone in favor of deinitting an arena instead. The main motivation for this was to allow customizable `jsonParse()` methods, and it was too hard to get customizable `jsonParseFree()` methods to work.

## Breaking changes in this specific PR

Uses of `parseFromSlice` or `parseFromTokenStream` (introduced in https://github.com/ziglang/zig/pull/15602 ) need to change.
1. If you're using your own arena allocator, call `parse*Leaky` instead.
2. Otherwise, the return value goes into a wrapper object that needs to be deinitted with `defer parsed.deinit();`.
3. No more `parseFree()`.

See also below:

## Breaking changes since 0.10

### `json.Parser` replaced by `json.parseFromSlice(json.Value, ...)`

The dynamically typed use case previously supported by:

```zig
var parser = json.Parser.init(allocator, b);
defer parser.deinit();
var tree = parser.parse(str);
defer tree.deinit();
const root = tree.root;
```

Now accomplished like this:

```zig
var parsed = json.parseFromSlice(json.Value, allocator, str, .{});
defer parsed.deinit();
const root = parsed.value;
```

### `json.parse` and `json.parseFree` replaced by `json.parseFromSlice`

You no longer get the value directly; it's now wrapped in a `json.Parsed(T)`. Instead of calling `json.parseFree` on the value, `defer parsed.deinit();` instead.

### Implement `jsonParse` in your class

The old `union` parsing behavior can possibly be accomplished by implementing a custom parse function. See `tools/spirv/grammar.zig` for a string-vs-int implementation of parsing into a union.

## Potential improvements

The `jsonParse` customization could be better documented and sanity checked. For example asserting the stack height before and after calling a user-supplied function would be nice.