### PR TITLE
build: avoid repeating objects when linking a static library

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -2192,7 +2192,8 @@ const TransitiveDeps = struct {
                     if ((try td.seen_steps.fetchPut(&inner_other.step, {})) != null)
                         continue;
 
-                    if (!dyn)
+                    const included_in_lib = (other.kind == .lib and inner_other.kind == .obj);
+                    if (!dyn and !included_in_lib)
                         try td.link_objects.append(other_link_object);
 
                     try addInner(td, inner_other, dyn or inner_other.isDynamicLibrary());

--- a/test/link.zig
+++ b/test/link.zig
@@ -21,6 +21,10 @@ pub const cases = [_]Case{
         .import = @import("link/interdependent_static_c_libs/build.zig"),
     },
     .{
+        .build_root = "test/link/static_libs_from_object_files",
+        .import = @import("link/static_libs_from_object_files/build.zig"),
+    },
+    .{
         .build_root = "test/link/glibc_compat",
         .import = @import("link/glibc_compat/build.zig"),
     },

--- a/test/link/static_libs_from_object_files/main.zig
+++ b/test/link/static_libs_from_object_files/main.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+extern fn foo_last() i32;
+extern fn bar_last() i32;
+
+export const one_0: i32 = 1;
+
+export fn foo_0() i32 {
+    return 1234;
+}
+export fn bar_0() i32 {
+    return 5678;
+}
+
+pub fn main() anyerror!void {
+    const foo_expected: i32 = 1 + 1234;
+    const bar_expected: i32 = 5678;
+    try std.testing.expectEqual(foo_expected, foo_last());
+    try std.testing.expectEqual(bar_expected, bar_last());
+}


### PR DESCRIPTION
I upgraded a build.zig for a c++ project, from zig 1.10 to master.

And got many errors of the form:
```
error: ld.lld: duplicate symbol: func()
    note: defined at file.cpp:13 
    note:            .../zig-cache/o/d2b46afbd2cd5d5c57e09b90cda4b76b/file_0.o in archive .../zig-cache/o/9f8d50303481988c02df2817264684bd/lib.a
    note: defined at file.cpp:13 
    note:            .../zig-cache/o/d2b46afbd2cd5d5c57e09b90cda4b76b/file_0.o
```

For context, the project is build by compiling a few static libraries, and then linking the libraries into an exe.
And instead of making each library directly from the source files (which exceeds the windows command line line, when cross compiling), batches of source files are instead compiled into a small number of object files, which are then combined into each library.

It looks like the behaviour has been modified by https://github.com/ziglang/zig/commit/7ea3937c5a6f63557db99c8a8f7b3f6d3de8c38b ?

~~(I tried to make a test case exhibiting the behaviour, but did not succeed.)~~