### PR TITLE
Add peer type resolution for [:s]const T and []T

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -30419,6 +30419,15 @@ fn resolvePeerTypes(
 
                         seen_const = seen_const or !chosen_info.mutable or !cand_info.mutable;
 
+                        // [:s]const T and []T to []const T
+                        if (cand_info.size == .Slice and chosen_info.size == .Slice and
+                            cand_info.mutable != chosen_info.mutable and
+                            (cand_info.sentinel == null) != (chosen_info.sentinel == null)) {
+                            // Resolve to whichever type doesn't have a sentinel.
+                            if (cand_info.sentinel == null) chosen = candidate;
+                            continue;
+                        }
+
                         // *[N]T to [*]T
                         // *[N]T to []T
                         if ((cand_info.size == .Many or cand_info.size == .Slice) and


### PR DESCRIPTION
Closes #15709

I got this to work for Andrew's test case in the issue. Though, after writing it I realized a similar case that I think still isn't covered: two slices that both have sentinels but different ones. I couldn't figure out a way to fix that without major changes to this code because `chosen_ty` after the loop is set to `chosen`, which seemingly must be a reference to one of the input types. I figured I could at least open this for now.

mlugg's pull request might obsolete this, but oh well :pensive: