### PR TITLE
std.Build: fix issue with emit_h outputting to cwd

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1440,7 +1440,9 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     if (self.emit_llvm_bc.getArg(b, "emit-llvm-bc")) |arg| try zig_args.append(arg);
     if (self.emit_llvm_ir.getArg(b, "emit-llvm-ir")) |arg| try zig_args.append(arg);
 
-    if (self.emit_h) try zig_args.append("-femit-h");
+    if (self.emit_h) {
+      try zig_args.append(try std.fmt.allocPrint(b.allocator, "-femit-h={s}", .{ self.out_h_filename }));
+    }
 
     try addFlag(&zig_args, "strip", self.strip);
     try addFlag(&zig_args, "unwind-tables", self.unwind_tables);

--- a/lib/std/Build/Step/InstallArtifact.zig
+++ b/lib/std/Build/Step/InstallArtifact.zig
@@ -57,9 +57,6 @@ pub fn create(owner: *std.Build, artifact: *Step.Compile) *InstallArtifact {
     if (self.pdb_dir) |pdb_dir| {
         owner.pushInstalledFile(pdb_dir, artifact.out_pdb_filename);
     }
-    if (self.h_dir) |h_dir| {
-        owner.pushInstalledFile(h_dir, artifact.out_h_filename);
-    }
     return self;
 }
 
@@ -110,16 +107,6 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         const p = fs.Dir.updateFile(cwd, full_src_path, cwd, full_pdb_path, .{}) catch |err| {
             return step.fail("unable to update file from '{s}' to '{s}': {s}", .{
                 full_src_path, full_pdb_path, @errorName(err),
-            });
-        };
-        all_cached = all_cached and p == .fresh;
-    }
-    if (self.h_dir) |h_dir| {
-        const full_src_path = self.artifact.getOutputHSource().getPath(src_builder);
-        const full_h_path = dest_builder.getInstallPath(h_dir, self.artifact.out_h_filename);
-        const p = fs.Dir.updateFile(cwd, full_src_path, cwd, full_h_path, .{}) catch |err| {
-            return step.fail("unable to update file from '{s}' to '{s}': {s}", .{
-                full_src_path, full_h_path, @errorName(err),
             });
         };
         all_cached = all_cached and p == .fresh;


### PR DESCRIPTION
Fixes #15156 by making `emit_h` function like the old `emit_*` options. Might update PR to implement #14971. Currently WIP.