### PR TITLE
std.c: fix return type of recv/recvfrom on windows

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -213,7 +213,12 @@ pub extern "c" fn sendto(
 ) isize;
 pub extern "c" fn sendmsg(sockfd: c.fd_t, msg: *const c.msghdr_const, flags: u32) isize;
 
-pub extern "c" fn recv(sockfd: c.fd_t, arg1: ?*anyopaque, arg2: usize, arg3: c_int) isize;
+pub extern "c" fn recv(
+    sockfd: c.fd_t,
+    arg1: ?*anyopaque,
+    arg2: usize,
+    arg3: c_int,
+) if (builtin.os.tag == .windows) c_int else isize;
 pub extern "c" fn recvfrom(
     sockfd: c.fd_t,
     noalias buf: *anyopaque,
@@ -221,7 +226,7 @@ pub extern "c" fn recvfrom(
     flags: u32,
     noalias src_addr: ?*c.sockaddr,
     noalias addrlen: ?*c.socklen_t,
-) isize;
+) if (builtin.os.tag == .windows) c_int else isize;
 pub extern "c" fn recvmsg(sockfd: c.fd_t, msg: *c.msghdr, flags: u32) isize;
 
 pub extern "c" fn kill(pid: c.pid_t, sig: c_int) c_int;


### PR DESCRIPTION
Windows defines `recv` and `recvfrom` to return a value of type `int`, rather than a pointer-sized signed integer, and so should use `c_int` rather than `isize` for their return types.

This would cause a bug where windows may return `-1` to indicate an error, but `std.os.recv` will not recognize it as an error, rather interpretting it as (and returning) `2^32 - 1`, indicating that `2^32 - 1` bytes were read into the buffer. I'm unsure if this is UB as it depends on whatever the top 32 bits of the `isize`  end up being, but this behaviour seemed reliable in debug builds.

Here are the docs for [recv](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv) and [recvfrom](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom), the headers containing the declarations are in the headers [`lib/libc/include/any-windows-any/winsock.h`](https://github.com/ziglang/zig/blob/e584dd806259f37fc17bedbd4d0fb33b936747f6/lib/libc/include/any-windows-any/winsock.h#L296-L297) and [`lib/libc/include/any-windows-any/winsock2.h`](https://github.com/ziglang/zig/blob/e584dd806259f37fc17bedbd4d0fb33b936747f6/lib/libc/include/any-windows-any/winsock2.h#L1028-L1029).