### PR TITLE
Fixes `WriteFile.getFileSource` failure on Windows

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -759,7 +759,7 @@ pub fn dupePath(self: *Build, bytes: []const u8) []u8 {
 
 pub fn addWriteFile(self: *Build, file_path: []const u8, data: []const u8) *Step.WriteFile {
     const write_file_step = self.addWriteFiles();
-    write_file_step.add(file_path, data);
+    _ = write_file_step.add(file_path, data);
     return write_file_step;
 }
 

--- a/lib/std/Build/Step/WriteFile.zig
+++ b/lib/std/Build/Step/WriteFile.zig
@@ -55,7 +55,7 @@ pub fn create(owner: *std.Build) *WriteFile {
     return wf;
 }
 
-pub fn add(wf: *WriteFile, sub_path: []const u8, bytes: []const u8) void {
+pub fn add(wf: *WriteFile, sub_path: []const u8, bytes: []const u8) std.Build.FileSource {
     const b = wf.step.owner;
     const gpa = b.allocator;
     const file = gpa.create(File) catch @panic("OOM");
@@ -67,6 +67,7 @@ pub fn add(wf: *WriteFile, sub_path: []const u8, bytes: []const u8) void {
     wf.files.append(gpa, file) catch @panic("OOM");
 
     wf.maybeUpdateName();
+    return .{ .generated = &file.generated_file };
 }
 
 /// Place the file into the generated directory within the local cache,
@@ -76,7 +77,7 @@ pub fn add(wf: *WriteFile, sub_path: []const u8, bytes: []const u8) void {
 /// include sub-directories, in which case this step will ensure the
 /// required sub-path exists.
 /// This is the option expected to be used most commonly with `addCopyFile`.
-pub fn addCopyFile(wf: *WriteFile, source: std.Build.FileSource, sub_path: []const u8) void {
+pub fn addCopyFile(wf: *WriteFile, source: std.Build.FileSource, sub_path: []const u8) std.Build.FileSource {
     const b = wf.step.owner;
     const gpa = b.allocator;
     const file = gpa.create(File) catch @panic("OOM");
@@ -89,6 +90,7 @@ pub fn addCopyFile(wf: *WriteFile, source: std.Build.FileSource, sub_path: []con
 
     wf.maybeUpdateName();
     source.addStepDependencies(&wf.step);
+    return .{ .generated = &file.generated_file };
 }
 
 /// A path relative to the package root.

--- a/lib/std/Build/Step/WriteFile.zig
+++ b/lib/std/Build/Step/WriteFile.zig
@@ -123,6 +123,8 @@ pub fn addBytesToSource(wf: *WriteFile, bytes: []const u8, sub_path: []const u8)
     }) catch @panic("OOM");
 }
 
+pub const getFileSource = @compileError("Deprecated; use the return value from add()/addCopyFile(), or use files[i].getFileSource()");
+
 /// Returns a `FileSource` representing the base directory that contains all the
 /// files from this `WriteFile`.
 pub fn getDirectorySource(wf: *WriteFile) std.Build.FileSource {

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -494,10 +494,12 @@ pub fn lowerToBuildSteps(
         }
 
         const writefiles = b.addWriteFiles();
+        var file_sources = std.StringHashMap(std.Build.FileSource).init(b.allocator);
+        defer file_sources.deinit();
         for (update.files.items) |file| {
-            _ = writefiles.add(file.path, file.src);
+            file_sources.put(file.path, writefiles.add(file.path, file.src)) catch @panic("OOM");
         }
-        const root_source_file = writefiles.getFileSource(update.files.items[0].path).?;
+        const root_source_file = writefiles.files.items[0].getFileSource();
 
         const artifact = if (case.is_test) b.addTest(.{
             .root_source_file = root_source_file,
@@ -540,7 +542,7 @@ pub fn lowerToBuildSteps(
 
         for (case.deps.items) |dep| {
             artifact.addAnonymousModule(dep.name, .{
-                .source_file = writefiles.getFileSource(dep.path).?,
+                .source_file = file_sources.get(dep.path).?,
             });
         }
 

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -495,7 +495,7 @@ pub fn lowerToBuildSteps(
 
         const writefiles = b.addWriteFiles();
         for (update.files.items) |file| {
-            writefiles.add(file.path, file.src);
+            _ = writefiles.add(file.path, file.src);
         }
         const root_source_file = writefiles.getFileSource(update.files.items[0].path).?;
 

--- a/test/src/CompareOutput.zig
+++ b/test/src/CompareOutput.zig
@@ -82,7 +82,7 @@ pub fn addCase(self: *CompareOutput, case: TestCase) void {
 
     const write_src = b.addWriteFiles();
     for (case.sources.items) |src_file| {
-        write_src.add(src_file.filename, src_file.source);
+        _ = write_src.add(src_file.filename, src_file.source);
     }
 
     switch (case.special) {

--- a/test/src/CompareOutput.zig
+++ b/test/src/CompareOutput.zig
@@ -99,7 +99,7 @@ pub fn addCase(self: *CompareOutput, case: TestCase) void {
                 .target = .{},
                 .optimize = .Debug,
             });
-            exe.addAssemblyFileSource(write_src.getFileSource(case.sources.items[0].filename).?);
+            exe.addAssemblyFileSource(write_src.files.items[0].getFileSource());
 
             const run = b.addRunArtifact(exe);
             run.setName(annotated_case_name);
@@ -117,10 +117,9 @@ pub fn addCase(self: *CompareOutput, case: TestCase) void {
                     if (mem.indexOf(u8, annotated_case_name, filter) == null) continue;
                 }
 
-                const basename = case.sources.items[0].filename;
                 const exe = b.addExecutable(.{
                     .name = "test",
-                    .root_source_file = write_src.getFileSource(basename).?,
+                    .root_source_file = write_src.files.items[0].getFileSource(),
                     .optimize = optimize,
                     .target = .{},
                 });
@@ -144,10 +143,9 @@ pub fn addCase(self: *CompareOutput, case: TestCase) void {
                 if (mem.indexOf(u8, annotated_case_name, filter) == null) return;
             }
 
-            const basename = case.sources.items[0].filename;
             const exe = b.addExecutable(.{
                 .name = "test",
-                .root_source_file = write_src.getFileSource(basename).?,
+                .root_source_file = write_src.files.items[0].getFileSource(),
                 .target = .{},
                 .optimize = .Debug,
             });

--- a/test/src/StackTrace.zig
+++ b/test/src/StackTrace.zig
@@ -72,11 +72,10 @@ fn addExpect(
         if (mem.indexOf(u8, annotated_case_name, filter) == null) return;
     }
 
-    const src_basename = "source.zig";
-    const write_src = b.addWriteFile(src_basename, source);
+    const write_src = b.addWriteFile("source.zig", source);
     const exe = b.addExecutable(.{
         .name = "test",
-        .root_source_file = write_src.getFileSource(src_basename).?,
+        .root_source_file = write_src.files.items[0].getFileSource(),
         .optimize = optimize_mode,
         .target = .{},
     });

--- a/test/src/run_translated_c.zig
+++ b/test/src/run_translated_c.zig
@@ -85,7 +85,7 @@ pub const RunTranslatedCContext = struct {
             _ = write_src.add(src_file.filename, src_file.source);
         }
         const translate_c = b.addTranslateC(.{
-            .source_file = write_src.getFileSource(case.sources.items[0].filename).?,
+            .source_file = write_src.files.items[0].getFileSource(),
             .target = .{},
             .optimize = .Debug,
         });

--- a/test/src/run_translated_c.zig
+++ b/test/src/run_translated_c.zig
@@ -82,7 +82,7 @@ pub const RunTranslatedCContext = struct {
 
         const write_src = b.addWriteFiles();
         for (case.sources.items) |src_file| {
-            write_src.add(src_file.filename, src_file.source);
+            _ = write_src.add(src_file.filename, src_file.source);
         }
         const translate_c = b.addTranslateC(.{
             .source_file = write_src.getFileSource(case.sources.items[0].filename).?,

--- a/test/src/translate_c.zig
+++ b/test/src/translate_c.zig
@@ -104,7 +104,7 @@ pub const TranslateCContext = struct {
 
         const write_src = b.addWriteFiles();
         for (case.sources.items) |src_file| {
-            write_src.add(src_file.filename, src_file.source);
+            _ = write_src.add(src_file.filename, src_file.source);
         }
 
         const translate_c = b.addTranslateC(.{

--- a/test/src/translate_c.zig
+++ b/test/src/translate_c.zig
@@ -108,7 +108,7 @@ pub const TranslateCContext = struct {
         }
 
         const translate_c = b.addTranslateC(.{
-            .source_file = write_src.getFileSource(case.sources.items[0].filename).?,
+            .source_file = write_src.files.items[0].getFileSource(),
             .target = case.target,
             .optimize = .Debug,
         });

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -759,7 +759,7 @@ pub fn addCliTests(b: *std.Build) *Step {
             "-fno-emit-bin", "-fno-emit-h",
             "-fstrip",       "-OReleaseFast",
         });
-        run.addFileSourceArg(writefile.getFileSource("example.zig").?);
+        run.addFileSourceArg(writefile.files.items[0].getFileSource());
         const example_s = run.addPrefixedOutputFileArg("-femit-asm=", "example.s");
 
         const checkfile = b.addCheckFile(example_s, .{


### PR DESCRIPTION
# The Problem

Prior to this change, to add a file to a `WriteFile` step and then use the written file elsewhere in your build script, you'd write the following code:
```zig
const path = "foo/bar.baz";
write_files.add(path, contents);
const file_source = write_files.getFileSource(path).?; // This line fails on Windows!
```

Aside from being a little verbose and doing some unecessary string comparisons, this fails on Windows: When the file is added to `WriteFiles`, it is passed to `dupePath` which replaces the path separators. Because the path separators were replaced, `getFileSource` fails to find an exact match.

# Potential Resolutions

There are a few ways we could resolve this issue:

### 1. Stop Calling `dupePath`

Unfortunately this is not cross platform because there's no single path separator that all platforms recognize. Forward slash is close, but not recognized on UEFI. We could fix all the paths during `make`, but then we'd be duplicating every path twice.

### 2. Perform a More Forgiving Path Equality Check

This would work, it still does unnecessary (and more complicated) string comparisons, requires the user unwrap results that shouldn't ever be null, and is surprising IMO.

### 3. Rework The API to Remove `getFileSource(path)`

I went with this option, because it doesn't have the downsides of either of the above approaches, the API is overall easier to work with, and it avoids the unnecessary string comparisons and failure cases.

# My Changes

`WriteFile.getFileSource()` is deprecated. `WriteFile.add()` and `WriteFile.addCopyFile()` now return a `FileSource` directly, and `WriteFile.File` has a `getFileSource` method that directly returns the source for that file.

Code that used to look like this:
```zig
const path = "foo/bar.baz";
write_files.add(path, contents);
const file_source = write_files.getFileSource(path).?;
```

Now looks like this:
```zig
const file_source = write_files.add("foo/bar.baz", contents);
```

And code that used to look like this:
```zig
const path = "foo/bar.baz";
const write_file = b.addWriteFile(path, "contents");
const file_source = write_file.getFileSource(path).?;
```

Now looks like this:
```zig
const write_file = b.addWriteFile("foo/bar.baz", "contents");
const file_source = write_file.files[0].getFileSource(); 
```
