### PR TITLE
autodoc: Fix rendering of imported modules

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -557,7 +557,7 @@ const NAV_MODES = {
     let rootMod = zigAnalysis.modules[zigAnalysis.rootMod];
     let mod = rootMod;
     curNav.modObjs = [mod];
-    for (let i = 1; i < curNav.modNames.length; i += 1) {
+    for (let i = 0; i < curNav.modNames.length; i += 1) {
       let childMod = zigAnalysis.modules[mod.table[curNav.modNames[i]]];
       if (childMod == null) {
         return render404();


### PR DESCRIPTION
Before this fix clicking on any module in under `Dependencies` did nothing and still rendered main module