### PR TITLE
zig cc: implement `-###` (dry run)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1796,11 +1796,11 @@ fn buildOutputType(
                         try clang_argv.append("-v");
                     },
                     .dry_run => {
+                        // This flag means "dry run". Clang will not actually output anything
+                        // to the file system.
                         verbose_link = true;
+                        disable_c_depfile = true;
                         try clang_argv.append("-###");
-                        // This flag is supposed to mean "dry run" but currently this
-                        // will actually still execute. The tracking issue for this is
-                        // https://github.com/ziglang/zig/issues/7170
                     },
                     .for_linker => try linker_args.append(it.only_arg),
                     .linker_input_z => {


### PR DESCRIPTION
closes #7170

### Before:

```
$ stage4/bin/zig cc -### -c hello.c
clang version 16.0.3 (git@github.com:llvm/llvm-project.git 6e5368c3967a68e6b5bd047c7ec606e4c7348c8d)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /run/current-system/sw/bin
 (in-process)
 "/home/andy/Downloads/zig/build-release/stage4/bin/zig" "-cc1" "-triple" "x86_64-unknown-linux-gnu" "-emit-obj" "-mrelax-all" "-disable-free" "-clear-ast-before-backend" "-main-file-name" "hello.c" "-mrelocation-model" "pic" "-pic-level" "2" "-fhalf-no-semantic-interposition" "-mframe-pointer=all" "-fmath-errno" "-ffp-contract=on" "-fno-rounding-math" "-mconstructor-aliases" "-funwind-tables=2" "-target-cpu" "x86-64" "-tune-cpu" "generic" "-mllvm" "-treat-scalable-fixed-error-as-warning" "-debug-info-kind=constructor" "-dwarf-version=4" "-debugger-tuning=gdb" "-fcoverage-compilation-dir=/home/andy/Downloads/zig/build-release" "-nostdsysteminc" "-nobuiltininc" "-resource-dir" "/home/andy/Downloads/zig/build-release/stage4/lib/clang/16" "-dependency-file" "/home/andy/.cache/zig/tmp/f3bbe3064725ba1-hello.o.d" "-MT" "/home/andy/.cache/zig/tmp/f3bbe3064725ba1-hello.o" "-sys-header-deps" "-MV" "-isystem" "/home/andy/Downloads/zig/lib/include" "-isystem" "/nix/store/iczlqwdj10xiz3mmms6adnra0mn3ljk1-glibc-2.35-224-dev/include" "-isystem" "/nix/store/whj46bv76i42c25b1yf2d8f4xxrb2kpv-zlib-1.2.13-dev/include" "-isystem" "/nix/store/6lsmmw09kn5vy4609nisbxp41rghnaqk-perf-linux-5.15.108/include" "-isystem" "/nix/store/z74qy88yn6pd9xvr27wgpidzsp6dvibh-gdb-12.1/include" "-isystem" "/nix/store/vd9lngmxxma42m4sws1gy9jhjbcyp03b-wabt-1.0.31/include" "-isystem" "/nix/store/j67c2j8przw03j642911xssyxyi0bc67-binaryen-109/include" "-isystem" "/nix/store/whj46bv76i42c25b1yf2d8f4xxrb2kpv-zlib-1.2.13-dev/include" "-isystem" "/nix/store/6lsmmw09kn5vy4609nisbxp41rghnaqk-perf-linux-5.15.108/include" "-isystem" "/nix/store/z74qy88yn6pd9xvr27wgpidzsp6dvibh-gdb-12.1/include" "-isystem" "/nix/store/vd9lngmxxma42m4sws1gy9jhjbcyp03b-wabt-1.0.31/include" "-isystem" "/nix/store/j67c2j8przw03j642911xssyxyi0bc67-binaryen-109/include" "-D" "__GLIBC_MINOR__=35" "-D" "_DEBUG" "-source-date-epoch" "315532800" "-O0" "-fdebug-compilation-dir=/home/andy/Downloads/zig/build-release" "-ferror-limit" "19" "-fsanitize=alignment,array-bounds,bool,builtin,enum,float-cast-overflow,function,integer-divide-by-zero,nonnull-attribute,null,pointer-overflow,return,returns-nonnull-attribute,shift-base,shift-exponent,signed-integer-overflow,unreachable,vla-bound" "-fsanitize-trap=alignment,array-bounds,bool,builtin,enum,float-cast-overflow,function,integer-divide-by-zero,nonnull-attribute,null,pointer-overflow,return,returns-nonnull-attribute,shift-base,shift-exponent,signed-integer-overflow,unreachable,vla-bound" "-fno-sanitize-memory-param-retval" "-fno-sanitize-address-use-odr-indicator" "-stack-protector" "2" "-stack-protector-buffer-size" "4" "-fgnuc-version=4.2.1" "-fcolor-diagnostics" "-fno-spell-checking" "-target-cpu" "skylake" "-target-feature" "-16bit-mode" "-target-feature" "-32bit-mode" "-target-feature" "-3dnow" "-target-feature" "-3dnowa" "-target-feature" "+64bit" "-target-feature" "+adx" "-target-feature" "+aes" "-target-feature" "+allow-light-256-bit" "-target-feature" "-amx-bf16" "-target-feature" "-amx-fp16" "-target-feature" "-amx-int8" "-target-feature" "-amx-tile" "-target-feature" "+avx" "-target-feature" "+avx2" "-target-feature" "-avx512bf16" "-target-feature" "-avx512bitalg" "-target-feature" "-avx512bw" "-target-feature" "-avx512cd" "-target-feature" "-avx512dq" "-target-feature" "-avx512er" "-target-feature" "-avx512f" "-target-feature" "-avx512fp16" "-target-feature" "-avx512ifma" "-target-feature" "-avx512pf" "-target-feature" "-avx512vbmi" "-target-feature" "-avx512vbmi2" "-target-feature" "-avx512vl" "-target-feature" "-avx512vnni" "-target-feature" "-avx512vp2intersect" "-target-feature" "-avx512vpopcntdq" "-target-feature" "-avxifma" "-target-feature" "-avxneconvert" "-target-feature" "-avxvnni" "-target-feature" "-avxvnniint8" "-target-feature" "+bmi" "-target-feature" "+bmi2" "-target-feature" "-branchfusion" "-target-feature" "-cldemote" "-target-feature" "+clflushopt" "-target-feature" "-clwb" "-target-feature" "-clzero" "-target-feature" "+cmov" "-target-feature" "-cmpccxadd" "-target-feature" "+crc32" "-target-feature" "+cx16" "-target-feature" "+cx8" "-target-feature" "-enqcmd" "-target-feature" "+ermsb" "-target-feature" "+f16c" "-target-feature" "-false-deps-getmant" "-target-feature" "-false-deps-lzcnt-tzcnt" "-target-feature" "-false-deps-mulc" "-target-feature" "-false-deps-mullq" "-target-feature" "-false-deps-perm" "-target-feature" "+false-deps-popcnt" "-target-feature" "-false-deps-range" "-target-feature" "-fast-11bytenop" "-target-feature" "+fast-15bytenop" "-target-feature" "-fast-7bytenop" "-target-feature" "-fast-bextr" "-target-feature" "+fast-gather" "-target-feature" "-fast-hops" "-target-feature" "-fast-lzcnt" "-target-feature" "-fast-movbe" "-target-feature" "+fast-scalar-fsqrt" "-target-feature" "-fast-scalar-shift-masks" "-target-feature" "+fast-shld-rotate" "-target-feature" "+fast-variable-crosslane-shuffle" "-target-feature" "+fast-variable-perlane-shuffle" "-target-feature" "+fast-vector-fsqrt" "-target-feature" "-fast-vector-shift-masks" "-target-feature" "+fma" "-target-feature" "-fma4" "-target-feature" "+fsgsbase" "-target-feature" "-fsrm" "-target-feature" "+fxsr" "-target-feature" "-gfni" "-target-feature" "-harden-sls-ijmp" "-target-feature" "-harden-sls-ret" "-target-feature" "-hreset" "-target-feature" "-idivl-to-divb" "-target-feature" "+idivq-to-divl" "-target-feature" "+invpcid" "-target-feature" "-kl" "-target-feature" "-lea-sp" "-target-feature" "-lea-uses-ag" "-target-feature" "-lvi-cfi" "-target-feature" "-lvi-load-hardening" "-target-feature" "-lwp" "-target-feature" "+lzcnt" "-target-feature" "+macrofusion" "-target-feature" "+mmx" "-target-feature" "+movbe" "-target-feature" "-movdir64b" "-target-feature" "-movdiri" "-target-feature" "-mwaitx" "-target-feature" "+nopl" "-target-feature" "-pad-short-functions" "-target-feature" "+pclmul" "-target-feature" "-pconfig" "-target-feature" "-pku" "-target-feature" "+popcnt" "-target-feature" "-prefer-128-bit" "-target-feature" "-prefer-256-bit" "-target-feature" "-prefer-mask-registers" "-target-feature" "-prefetchi" "-target-feature" "-prefetchwt1" "-target-feature" "+prfchw" "-target-feature" "-ptwrite" "-target-feature" "-raoint" "-target-feature" "-rdpid" "-target-feature" "-rdpru" "-target-feature" "+rdrnd" "-target-feature" "+rdseed" "-target-feature" "-retpoline" "-target-feature" "-retpoline-external-thunk" "-target-feature" "-retpoline-indirect-branches" "-target-feature" "-retpoline-indirect-calls" "-target-feature" "-rtm" "-target-feature" "+sahf" "-target-feature" "-sbb-dep-breaking" "-target-feature" "-serialize" "-target-feature" "-seses" "-target-feature" "+sgx" "-target-feature" "-sha" "-target-feature" "-shstk" "-target-feature" "+slow-3ops-lea" "-target-feature" "-slow-incdec" "-target-feature" "-slow-lea" "-target-feature" "-slow-pmaddwd" "-target-feature" "-slow-pmulld" "-target-feature" "-slow-shld" "-target-feature" "-slow-two-mem-ops" "-target-feature" "-slow-unaligned-mem-16" "-target-feature" "-slow-unaligned-mem-32" "-target-feature" "-soft-float" "-target-feature" "+sse" "-target-feature" "+sse2" "-target-feature" "+sse3" "-target-feature" "+sse4.1" "-target-feature" "+sse4.2" "-target-feature" "-sse4a" "-target-feature" "-sse-unaligned-mem" "-target-feature" "+ssse3" "-target-feature" "-tagged-globals" "-target-feature" "-tbm" "-target-feature" "-tsxldtrk" "-target-feature" "-uintr" "-target-feature" "-use-glm-div-sqrt-costs" "-target-feature" "-use-slm-arith-costs" "-target-feature" "-vaes" "-target-feature" "-vpclmulqdq" "-target-feature" "+vzeroupper" "-target-feature" "-waitpkg" "-target-feature" "-wbnoinvd" "-target-feature" "-widekl" "-target-feature" "+x87" "-target-feature" "-xop" "-target-feature" "+xsave" "-target-feature" "+xsavec" "-target-feature" "+xsaveopt" "-target-feature" "+xsaves" "-faddrsig" "-D__GCC_HAVE_DWARF2_CFI_ASM=1" "-o" "/home/andy/.cache/zig/tmp/f3bbe3064725ba1-hello.o" "-x" "c" "hello.c"
hello.c:1:1: error: unable to build C object: FileNotFound
```

(exit code failure)

### After:

```
$ stage4/bin/zig cc -### -c hello.c
clang version 16.0.3 (git@github.com:llvm/llvm-project.git 6e5368c3967a68e6b5bd047c7ec606e4c7348c8d)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /run/current-system/sw/bin
 (in-process)
 "/home/andy/Downloads/zig/build-release/stage4/bin/zig" "-cc1" "-triple" "x86_64-unknown-linux-gnu" "-emit-obj" "-mrelax-all" "-disable-free" "-clear-ast-before-backend" "-main-file-name" "hello.c" "-mrelocation-model" "pic" "-pic-level" "2" "-fhalf-no-semantic-interposition" "-mframe-pointer=all" "-fmath-errno" "-ffp-contract=on" "-fno-rounding-math" "-mconstructor-aliases" "-funwind-tables=2" "-target-cpu" "x86-64" "-tune-cpu" "generic" "-mllvm" "-treat-scalable-fixed-error-as-warning" "-debug-info-kind=constructor" "-dwarf-version=4" "-debugger-tuning=gdb" "-fcoverage-compilation-dir=/home/andy/Downloads/zig/build-release" "-nostdsysteminc" "-nobuiltininc" "-resource-dir" "/home/andy/Downloads/zig/build-release/stage4/lib/clang/16" "-isystem" "/home/andy/Downloads/zig/lib/include" "-isystem" "/nix/store/iczlqwdj10xiz3mmms6adnra0mn3ljk1-glibc-2.35-224-dev/include" "-isystem" "/nix/store/whj46bv76i42c25b1yf2d8f4xxrb2kpv-zlib-1.2.13-dev/include" "-isystem" "/nix/store/6lsmmw09kn5vy4609nisbxp41rghnaqk-perf-linux-5.15.108/include" "-isystem" "/nix/store/z74qy88yn6pd9xvr27wgpidzsp6dvibh-gdb-12.1/include" "-isystem" "/nix/store/vd9lngmxxma42m4sws1gy9jhjbcyp03b-wabt-1.0.31/include" "-isystem" "/nix/store/j67c2j8przw03j642911xssyxyi0bc67-binaryen-109/include" "-isystem" "/nix/store/whj46bv76i42c25b1yf2d8f4xxrb2kpv-zlib-1.2.13-dev/include" "-isystem" "/nix/store/6lsmmw09kn5vy4609nisbxp41rghnaqk-perf-linux-5.15.108/include" "-isystem" "/nix/store/z74qy88yn6pd9xvr27wgpidzsp6dvibh-gdb-12.1/include" "-isystem" "/nix/store/vd9lngmxxma42m4sws1gy9jhjbcyp03b-wabt-1.0.31/include" "-isystem" "/nix/store/j67c2j8przw03j642911xssyxyi0bc67-binaryen-109/include" "-D" "__GLIBC_MINOR__=35" "-D" "_DEBUG" "-source-date-epoch" "315532800" "-O0" "-fdebug-compilation-dir=/home/andy/Downloads/zig/build-release" "-ferror-limit" "19" "-fsanitize=alignment,array-bounds,bool,builtin,enum,float-cast-overflow,function,integer-divide-by-zero,nonnull-attribute,null,pointer-overflow,return,returns-nonnull-attribute,shift-base,shift-exponent,signed-integer-overflow,unreachable,vla-bound" "-fsanitize-trap=alignment,array-bounds,bool,builtin,enum,float-cast-overflow,function,integer-divide-by-zero,nonnull-attribute,null,pointer-overflow,return,returns-nonnull-attribute,shift-base,shift-exponent,signed-integer-overflow,unreachable,vla-bound" "-fno-sanitize-memory-param-retval" "-fno-sanitize-address-use-odr-indicator" "-stack-protector" "2" "-stack-protector-buffer-size" "4" "-fgnuc-version=4.2.1" "-fcolor-diagnostics" "-fno-spell-checking" "-target-cpu" "skylake" "-target-feature" "-16bit-mode" "-target-feature" "-32bit-mode" "-target-feature" "-3dnow" "-target-feature" "-3dnowa" "-target-feature" "+64bit" "-target-feature" "+adx" "-target-feature" "+aes" "-target-feature" "+allow-light-256-bit" "-target-feature" "-amx-bf16" "-target-feature" "-amx-fp16" "-target-feature" "-amx-int8" "-target-feature" "-amx-tile" "-target-feature" "+avx" "-target-feature" "+avx2" "-target-feature" "-avx512bf16" "-target-feature" "-avx512bitalg" "-target-feature" "-avx512bw" "-target-feature" "-avx512cd" "-target-feature" "-avx512dq" "-target-feature" "-avx512er" "-target-feature" "-avx512f" "-target-feature" "-avx512fp16" "-target-feature" "-avx512ifma" "-target-feature" "-avx512pf" "-target-feature" "-avx512vbmi" "-target-feature" "-avx512vbmi2" "-target-feature" "-avx512vl" "-target-feature" "-avx512vnni" "-target-feature" "-avx512vp2intersect" "-target-feature" "-avx512vpopcntdq" "-target-feature" "-avxifma" "-target-feature" "-avxneconvert" "-target-feature" "-avxvnni" "-target-feature" "-avxvnniint8" "-target-feature" "+bmi" "-target-feature" "+bmi2" "-target-feature" "-branchfusion" "-target-feature" "-cldemote" "-target-feature" "+clflushopt" "-target-feature" "-clwb" "-target-feature" "-clzero" "-target-feature" "+cmov" "-target-feature" "-cmpccxadd" "-target-feature" "+crc32" "-target-feature" "+cx16" "-target-feature" "+cx8" "-target-feature" "-enqcmd" "-target-feature" "+ermsb" "-target-feature" "+f16c" "-target-feature" "-false-deps-getmant" "-target-feature" "-false-deps-lzcnt-tzcnt" "-target-feature" "-false-deps-mulc" "-target-feature" "-false-deps-mullq" "-target-feature" "-false-deps-perm" "-target-feature" "+false-deps-popcnt" "-target-feature" "-false-deps-range" "-target-feature" "-fast-11bytenop" "-target-feature" "+fast-15bytenop" "-target-feature" "-fast-7bytenop" "-target-feature" "-fast-bextr" "-target-feature" "+fast-gather" "-target-feature" "-fast-hops" "-target-feature" "-fast-lzcnt" "-target-feature" "-fast-movbe" "-target-feature" "+fast-scalar-fsqrt" "-target-feature" "-fast-scalar-shift-masks" "-target-feature" "+fast-shld-rotate" "-target-feature" "+fast-variable-crosslane-shuffle" "-target-feature" "+fast-variable-perlane-shuffle" "-target-feature" "+fast-vector-fsqrt" "-target-feature" "-fast-vector-shift-masks" "-target-feature" "+fma" "-target-feature" "-fma4" "-target-feature" "+fsgsbase" "-target-feature" "-fsrm" "-target-feature" "+fxsr" "-target-feature" "-gfni" "-target-feature" "-harden-sls-ijmp" "-target-feature" "-harden-sls-ret" "-target-feature" "-hreset" "-target-feature" "-idivl-to-divb" "-target-feature" "+idivq-to-divl" "-target-feature" "+invpcid" "-target-feature" "-kl" "-target-feature" "-lea-sp" "-target-feature" "-lea-uses-ag" "-target-feature" "-lvi-cfi" "-target-feature" "-lvi-load-hardening" "-target-feature" "-lwp" "-target-feature" "+lzcnt" "-target-feature" "+macrofusion" "-target-feature" "+mmx" "-target-feature" "+movbe" "-target-feature" "-movdir64b" "-target-feature" "-movdiri" "-target-feature" "-mwaitx" "-target-feature" "+nopl" "-target-feature" "-pad-short-functions" "-target-feature" "+pclmul" "-target-feature" "-pconfig" "-target-feature" "-pku" "-target-feature" "+popcnt" "-target-feature" "-prefer-128-bit" "-target-feature" "-prefer-256-bit" "-target-feature" "-prefer-mask-registers" "-target-feature" "-prefetchi" "-target-feature" "-prefetchwt1" "-target-feature" "+prfchw" "-target-feature" "-ptwrite" "-target-feature" "-raoint" "-target-feature" "-rdpid" "-target-feature" "-rdpru" "-target-feature" "+rdrnd" "-target-feature" "+rdseed" "-target-feature" "-retpoline" "-target-feature" "-retpoline-external-thunk" "-target-feature" "-retpoline-indirect-branches" "-target-feature" "-retpoline-indirect-calls" "-target-feature" "-rtm" "-target-feature" "+sahf" "-target-feature" "-sbb-dep-breaking" "-target-feature" "-serialize" "-target-feature" "-seses" "-target-feature" "+sgx" "-target-feature" "-sha" "-target-feature" "-shstk" "-target-feature" "+slow-3ops-lea" "-target-feature" "-slow-incdec" "-target-feature" "-slow-lea" "-target-feature" "-slow-pmaddwd" "-target-feature" "-slow-pmulld" "-target-feature" "-slow-shld" "-target-feature" "-slow-two-mem-ops" "-target-feature" "-slow-unaligned-mem-16" "-target-feature" "-slow-unaligned-mem-32" "-target-feature" "-soft-float" "-target-feature" "+sse" "-target-feature" "+sse2" "-target-feature" "+sse3" "-target-feature" "+sse4.1" "-target-feature" "+sse4.2" "-target-feature" "-sse4a" "-target-feature" "-sse-unaligned-mem" "-target-feature" "+ssse3" "-target-feature" "-tagged-globals" "-target-feature" "-tbm" "-target-feature" "-tsxldtrk" "-target-feature" "-uintr" "-target-feature" "-use-glm-div-sqrt-costs" "-target-feature" "-use-slm-arith-costs" "-target-feature" "-vaes" "-target-feature" "-vpclmulqdq" "-target-feature" "+vzeroupper" "-target-feature" "-waitpkg" "-target-feature" "-wbnoinvd" "-target-feature" "-widekl" "-target-feature" "+x87" "-target-feature" "-xop" "-target-feature" "+xsave" "-target-feature" "+xsavec" "-target-feature" "+xsaveopt" "-target-feature" "+xsaves" "-faddrsig" "-D__GCC_HAVE_DWARF2_CFI_ASM=1" "-o" "hello.o" "-x" "c" "hello.c"
```

(exit code success)