### PR TITLE
make @trap return unreachable/noreturn

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -8324,7 +8324,7 @@ fn builtinCall(
         .trap => {
             try emitDbgNode(gz, node);
             _ = try gz.addNode(.trap, node);
-            return rvalue(gz, ri, .void_value, node);
+            return rvalue(gz, ri, .unreachable_value, node);
         },
         .error_to_int => {
             const operand = try expr(gz, scope, .{ .rl = .none }, params[0]);

--- a/test/behavior/builtin_functions_returning_void_or_noreturn.zig
+++ b/test/behavior/builtin_functions_returning_void_or_noreturn.zig
@@ -26,5 +26,4 @@ test {
     try testing.expectEqual({}, @setEvalBranchQuota(0));
     try testing.expectEqual({}, @setFloatMode(.Optimized));
     try testing.expectEqual({}, @setRuntimeSafety(true));
-    try testing.expectEqual(noreturn, @TypeOf(if (true) @trap() else {}));
 }

--- a/test/cases/compile_errors/noreturn_builtins_divert_control_flow.zig
+++ b/test/cases/compile_errors/noreturn_builtins_divert_control_flow.zig
@@ -1,0 +1,23 @@
+export fn entry1() void {
+    @trap();
+    @trap();
+}
+export fn entry2() void {
+    @panic("");
+    @panic("");
+}
+export fn entry3() void {
+    @compileError("");
+    @compileError("");
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:5: error: unreachable code
+// :2:5: note: control flow is diverted here
+// :7:5: error: unreachable code
+// :6:5: note: control flow is diverted here
+// :11:5: error: unreachable code
+// :10:5: note: control flow is diverted here


### PR DESCRIPTION
@trap is a special function that we know never returns so it should behave just like @panic and @compileError do currently and cause the "unreachable code" + "control flow is diverted here" compile error. Currently, `@trap(); @trap();` does not cause this error. Now it does.