### PR TITLE
spirv: make more tests pass

### DIFF
--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -726,6 +726,10 @@ pub const DeclGen = struct {
                         try self.lower(ptr_ty, slice.ptr);
                         try self.addInt(Type.usize, slice.len);
                     },
+                    .null_value, .zero => try self.addNullPtr(try dg.resolveType(ty, .indirect)),
+                    .int_u64, .one, .int_big_positive, .lazy_align, .lazy_size => {
+                        try self.addInt(Type.usize, val);
+                    },
                     else => |tag| return dg.todo("pointer value of type {s}", .{@tagName(tag)}),
                 },
                 .Struct => {

--- a/src/codegen/spirv/Module.zig
+++ b/src/codegen/spirv/Module.zig
@@ -774,6 +774,16 @@ pub fn changePtrStorageClass(self: *Module, ptr_ty_ref: Type.Ref, new_storage_cl
     return try self.resolveType(Type.initPayload(&payload.base));
 }
 
+pub fn constComposite(self: *Module, ty_ref: Type.Ref, members: []const IdRef) !IdRef {
+    const result_id = self.allocId();
+    try self.sections.types_globals_constants.emit(self.gpa, .OpSpecConstantComposite, .{
+        .id_result_type = self.typeId(ty_ref),
+        .id_result = result_id,
+        .constituents = members,
+    });
+    return result_id;
+}
+
 pub fn emitConstant(
     self: *Module,
     ty_id: IdRef,

--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -33,8 +33,6 @@ test "default alignment allows unspecified in type syntax" {
 }
 
 test "implicitly decreasing pointer alignment" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const a: u32 align(4) = 3;
     const b: u32 align(8) = 4;
     try expect(addUnaligned(&a, &b) == 7);
@@ -45,8 +43,6 @@ fn addUnaligned(a: *align(1) const u32, b: *align(1) const u32) u32 {
 }
 
 test "@alignCast pointers" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     var x: u32 align(4) = 1;
     expectsOnly1(&x);
     try expect(x == 2);

--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -215,8 +215,6 @@ test "alignment and size of structs with 128-bit fields" {
 }
 
 test "@ptrCast preserves alignment of bigger source" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     var x: u32 align(16) = 1234;
     const ptr = @ptrCast(*u8, &x);
     try expect(@TypeOf(ptr) == *align(16) u8);

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -347,7 +347,6 @@ test "read/write through global variable array of struct fields initialized via 
 test "implicit cast single-item pointer" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try testImplicitCastSingleItemPtr();
     comptime try testImplicitCastSingleItemPtr();
@@ -542,7 +541,6 @@ test "sentinel element count towards the ABI size calculation" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {

--- a/test/behavior/asm.zig
+++ b/test/behavior/asm.zig
@@ -15,6 +15,10 @@ comptime {
             \\.type this_is_my_alias, @function;
             \\.set this_is_my_alias, derp;
         );
+    } else if (builtin.zig_backend == .stage2_spirv64) {
+        asm (
+            \\%a = OpString "hello there"
+        );
     }
 }
 
@@ -24,7 +28,6 @@ test "module level assembly" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     if (builtin.zig_backend == .stage2_c and builtin.os.tag == .windows) return error.SkipZigTest; // MSVC doesn't support inline assembly
 

--- a/test/behavior/atomics.zig
+++ b/test/behavior/atomics.zig
@@ -120,7 +120,6 @@ test "128-bit cmpxchg" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try test_u128_cmpxchg();
     comptime try test_u128_cmpxchg();
@@ -313,7 +312,6 @@ test "atomicrmw with 128-bit ints" {
 
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     // TODO "ld.lld: undefined symbol: __sync_lock_test_and_set_16" on -mcpu x86_64
     if (builtin.cpu.arch == .x86_64 and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest;

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -82,8 +82,6 @@ test "type equality" {
 }
 
 test "pointer dereferencing" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     var x = @as(i32, 3);
     const y = &x;
 
@@ -293,8 +291,6 @@ test "function closes over local const" {
 }
 
 test "volatile load and store" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     var number: i32 = 1234;
     const ptr = @as(*volatile i32, &number);
     ptr.* += 1;
@@ -466,7 +462,6 @@ fn nine() u8 {
 test "struct inside function" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try testStructInFn();
     comptime try testStructInFn();
@@ -691,7 +686,6 @@ test "string concatenation" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const a = "OK" ++ " IT " ++ "WORKED";
     const b = "OK IT WORKED";
@@ -1130,7 +1124,6 @@ test "returning an opaque type from a function" {
 test "orelse coercion as function argument" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const Loc = struct { start: i32 = -1 };
     const Container = struct {

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -583,7 +583,7 @@ test "comptime cast fn to ptr" {
 }
 
 test "equality compare fn ptrs" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // Test passes but should not
 
     var a = &emptyFn;
     try expect(a == a);

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -751,7 +751,6 @@ fn maybe(x: bool) anyerror!?u32 {
 test "auto created variables have correct alignment" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const S = struct {
         fn foo(str: [*]const u8) u32 {

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -134,21 +134,18 @@ fn first4KeysOfHomeRow() []const u8 {
 
 test "return string from function" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try expect(mem.eql(u8, first4KeysOfHomeRow(), "aoeu"));
 }
 
 test "hex escape" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try expect(mem.eql(u8, "\x68\x65\x6c\x6c\x6f", "hello"));
 }
 
 test "multiline string" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const s1 =
         \\one
@@ -161,7 +158,6 @@ test "multiline string" {
 
 test "multiline string comments at start" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const s1 =
         //\\one
@@ -174,7 +170,6 @@ test "multiline string comments at start" {
 
 test "multiline string comments at end" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const s1 =
         \\one
@@ -187,7 +182,6 @@ test "multiline string comments at end" {
 
 test "multiline string comments in middle" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const s1 =
         \\one
@@ -200,7 +194,6 @@ test "multiline string comments in middle" {
 
 test "multiline string comments at multiple places" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const s1 =
         \\one
@@ -214,14 +207,11 @@ test "multiline string comments at multiple places" {
 }
 
 test "string concatenation simple" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     try expect(mem.eql(u8, "OK" ++ " IT " ++ "WORKED", "OK IT WORKED"));
 }
 
 test "array mult operator" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try expect(mem.eql(u8, "ab" ** 5, "ababababab"));
 }
@@ -387,7 +377,6 @@ test "take address of parameter" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try testTakeAddressOfParameter(12.34);
 }
@@ -690,8 +679,6 @@ test "explicit cast optional pointers" {
 }
 
 test "pointer comparison" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const a = @as([]const u8, "a");
     const b = &a;
     try expect(ptrEql(b, b));
@@ -892,8 +879,6 @@ test "catch in block has correct result location" {
 }
 
 test "labeled block with runtime branch forwards its result location type to break statements" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const E = enum { a, b };
     var a = false;
     const e: E = blk: {
@@ -1062,8 +1047,6 @@ test "switch inside @as gets correct type" {
 }
 
 test "inline call of function with a switch inside the return statement" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const S = struct {
         inline fn foo(x: anytype) @TypeOf(x) {
             return switch (x) {

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -9,7 +9,6 @@ const native_endian = builtin.target.cpu.arch.endian();
 
 test "@bitCast iX -> uX (32, 64)" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const bit_values = [_]usize{ 32, 64 };
 

--- a/test/behavior/bitreverse.zig
+++ b/test/behavior/bitreverse.zig
@@ -5,7 +5,6 @@ const minInt = std.math.minInt;
 
 test "@bitReverse large exotic integer" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try expect(@bitReverse(@as(u95, 0x123456789abcdef111213141)) == 0x4146424447bd9eac8f351624);
 }

--- a/test/behavior/call.zig
+++ b/test/behavior/call.zig
@@ -385,8 +385,6 @@ test "generic function with generic function parameter" {
 }
 
 test "recursive inline call with comptime known argument" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const S = struct {
         inline fn foo(x: i32) i32 {
             if (x <= 0) {

--- a/test/behavior/call.zig
+++ b/test/behavior/call.zig
@@ -109,7 +109,6 @@ test "result location of function call argument through runtime condition and st
 
 test "function call with 40 arguments" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest(thirty_nine: i32) !void {
@@ -374,8 +373,6 @@ test "Enum constructed by @Type passed as generic argument" {
 }
 
 test "generic function with generic function parameter" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const S = struct {
         fn f(comptime a: fn (anytype) anyerror!void, b: anytype) anyerror!void {
             try a(b);

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -322,7 +322,6 @@ test "peer result null and comptime_int" {
 test "*const ?[*]const T to [*c]const [*c]const T" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     var array = [_]u8{ 'o', 'k' };
     const opt_array_ptr: ?[*]const u8 = &array;

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -366,7 +366,6 @@ test "return u8 coercing into ?u32 return type" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {
@@ -428,7 +427,6 @@ test "peer resolve array and const slice" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try testPeerResolveArrayConstSlice(true);
     comptime try testPeerResolveArrayConstSlice(true);

--- a/test/behavior/decltest.zig
+++ b/test/behavior/decltest.zig
@@ -5,7 +5,5 @@ pub fn the_add_function(a: u32, b: u32) u32 {
 }
 
 test the_add_function {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     if (the_add_function(1, 2) != 3) unreachable;
 }

--- a/test/behavior/defer.zig
+++ b/test/behavior/defer.zig
@@ -23,8 +23,6 @@ fn testBreakContInDefer(x: usize) void {
 }
 
 test "defer and labeled break" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     var i = @as(usize, 0);
 
     blk: {
@@ -58,7 +56,6 @@ test "return variable while defer expression in scope to modify it" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {

--- a/test/behavior/duplicated_test_names.zig
+++ b/test/behavior/duplicated_test_names.zig
@@ -15,7 +15,5 @@ comptime {
 test "thingy" {}
 
 test thingy {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     if (thingy(1, 2) != 3) unreachable;
 }

--- a/test/behavior/enum.zig
+++ b/test/behavior/enum.zig
@@ -20,8 +20,6 @@ test "enum to int" {
 }
 
 fn testIntToEnumEval(x: i32) !void {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     try expect(@intToEnum(IntToEnumNumber, x) == IntToEnumNumber.Three);
 }
 const IntToEnumNumber = enum { Zero, One, Two, Three, Four };

--- a/test/behavior/enum.zig
+++ b/test/behavior/enum.zig
@@ -1046,7 +1046,6 @@ test "tag name with assigned enum values" {
 test "@tagName on enum literals" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try expect(mem.eql(u8, @tagName(.FooBar), "FooBar"));
     comptime try expect(mem.eql(u8, @tagName(.FooBar), "FooBar"));

--- a/test/behavior/enum.zig
+++ b/test/behavior/enum.zig
@@ -20,6 +20,8 @@ test "enum to int" {
 }
 
 fn testIntToEnumEval(x: i32) !void {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
     try expect(@intToEnum(IntToEnumNumber, x) == IntToEnumNumber.Three);
 }
 const IntToEnumNumber = enum { Zero, One, Two, Three, Four };

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -22,7 +22,6 @@ test "error values" {
 }
 
 test "redefinition of error values allowed" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     shouldBeNotEqual(error.AnError, error.SecondError);
 }
 fn shouldBeNotEqual(a: anyerror, b: anyerror) void {

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -16,7 +16,6 @@ fn expectError(expected_err: anyerror, observed_err_union: anytype) !void {
 }
 
 test "error values" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     const a = @errorToInt(error.err1);
     const b = @errorToInt(error.err2);
     try expect(a != b);

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -47,8 +47,6 @@ test "inline variable gets result of const if" {
 }
 
 test "static function evaluation" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     try expect(statically_added_number == 3);
 }
 const statically_added_number = staticAdd(1, 2);

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -23,7 +23,6 @@ test "static add one" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try expect(should_be_1235 == 1235);
 }

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -506,7 +506,6 @@ test "@fabs" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     comptime try testFabs();
     try testFabs();

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -620,7 +620,6 @@ test "@floor" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     comptime try testFloor();
     try testFloor();

--- a/test/behavior/fn.zig
+++ b/test/behavior/fn.zig
@@ -12,8 +12,6 @@ fn testParamsAdd(a: i32, b: i32) i32 {
 }
 
 test "local variables" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     testLocVars(2);
 }
 fn testLocVars(b: i32) void {

--- a/test/behavior/fn.zig
+++ b/test/behavior/fn.zig
@@ -5,8 +5,6 @@ const expect = testing.expect;
 const expectEqual = testing.expectEqual;
 
 test "params" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     try expect(testParamsAdd(22, 11) == 33);
 }
 fn testParamsAdd(a: i32, b: i32) i32 {

--- a/test/behavior/fn_delegation.zig
+++ b/test/behavior/fn_delegation.zig
@@ -34,7 +34,6 @@ fn custom(comptime T: type, comptime num: u64) fn (T) u64 {
 test "fn delegation" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const foo = Foo{};
     try expect(foo.one() == 11);

--- a/test/behavior/fn_in_struct_in_comptime.zig
+++ b/test/behavior/fn_in_struct_in_comptime.zig
@@ -13,8 +13,6 @@ fn get_foo() fn (*u8) usize {
 }
 
 test "define a function in an anonymous struct in comptime" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const foo = get_foo();
     try expect(foo(@intToPtr(*u8, 12345)) == 12345);
 }

--- a/test/behavior/for.zig
+++ b/test/behavior/for.zig
@@ -39,8 +39,6 @@ fn testBreakOuter() !void {
 }
 
 test "continue outer for loop" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     try testContinueOuter();
     comptime try testContinueOuter();
 }

--- a/test/behavior/for.zig
+++ b/test/behavior/for.zig
@@ -22,8 +22,6 @@ test "continue in for loop" {
 }
 
 test "break from outer for loop" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     try testBreakOuter();
     comptime try testBreakOuter();
 }

--- a/test/behavior/generics.zig
+++ b/test/behavior/generics.zig
@@ -5,8 +5,6 @@ const expect = testing.expect;
 const expectEqual = testing.expectEqual;
 
 test "one param, explicit comptime" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     var x: usize = 0;
     x += checkSize(i32);
     x += checkSize(bool);

--- a/test/behavior/generics.zig
+++ b/test/behavior/generics.zig
@@ -19,7 +19,6 @@ fn checkSize(comptime T: type) usize {
 test "simple generic fn" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try expect(max(i32, 3, -1) == 3);
     try expect(max(u8, 1, 100) == 100);

--- a/test/behavior/if.zig
+++ b/test/behavior/if.zig
@@ -71,8 +71,6 @@ test "labeled break inside comptime if inside runtime if" {
 }
 
 test "const result loc, runtime if cond, else unreachable" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const Num = enum { One, Two };
 
     var t = true;

--- a/test/behavior/inttoptr.zig
+++ b/test/behavior/inttoptr.zig
@@ -14,7 +14,6 @@ test "mutate through ptr initialized with constant intToPtr value" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     forceCompilerAnalyzeBranchHardCodedPtrDereference(false);
 }

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -208,7 +208,6 @@ test "float equality" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const x: f64 = 0.012;
     const y: f64 = x + 1.0;
@@ -685,7 +684,6 @@ test "@addWithOverflow" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     {
         var a: u8 = 250;

--- a/test/behavior/maximum_minimum.zig
+++ b/test/behavior/maximum_minimum.zig
@@ -129,8 +129,6 @@ test "@min/max for floats" {
 }
 
 test "@min/@max on lazy values" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const A = extern struct { u8_4: [4]u8 };
     const B = extern struct { u8_16: [16]u8 };
     const size = @max(@sizeOf(A), @sizeOf(B));

--- a/test/behavior/memcpy.zig
+++ b/test/behavior/memcpy.zig
@@ -67,14 +67,16 @@ fn testMemcpyDestManyPtr() !void {
 }
 
 comptime {
-    const S = struct {
-        buffer: [8]u8 = undefined,
-        fn set(self: *@This(), items: []const u8) void {
-            @memcpy(self.buffer[0..items.len], items);
-        }
-    };
+    if (builtin.zig_backend != .stage2_spirv64) {
+        const S = struct {
+            buffer: [8]u8 = undefined,
+            fn set(self: *@This(), items: []const u8) void {
+                @memcpy(self.buffer[0..items.len], items);
+            }
+        };
 
-    var s = S{};
-    s.set("hello");
-    if (!std.mem.eql(u8, s.buffer[0..5], "hello")) @compileError("bad");
+        var s = S{};
+        s.set("hello");
+        if (!std.mem.eql(u8, s.buffer[0..5], "hello")) @compileError("bad");
+    }
 }

--- a/test/behavior/optional.zig
+++ b/test/behavior/optional.zig
@@ -8,7 +8,6 @@ const expectEqualStrings = std.testing.expectEqualStrings;
 test "passing an optional integer as a parameter" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const S = struct {
         fn entry() bool {

--- a/test/behavior/optional.zig
+++ b/test/behavior/optional.zig
@@ -421,7 +421,6 @@ test "optional of noreturn used with orelse" {
 }
 
 test "orelse on C pointer" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     // TODO https://github.com/ziglang/zig/issues/6597
     const foo: [*c]const u8 = "hey";

--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -93,7 +93,6 @@ test "flags in packed structs" {
 
 test "consistent size of packed structs" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const TxData1 = packed struct { data: u8, _23: u23, full: bool = false };
     const TxData2 = packed struct { data: u9, _22: u22, full: bool = false };

--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -7,7 +7,6 @@ const native_endian = builtin.cpu.arch.endian();
 
 test "flags in packed structs" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const Flags1 = packed struct {
         // first 8 bits

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -19,7 +19,6 @@ fn testDerefPtr() !void {
 test "pointer arithmetic" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     var ptr: [*]const u8 = "abcd";
 
@@ -300,7 +299,6 @@ test "null terminated pointer" {
 test "allow any sentinel" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -84,7 +84,6 @@ test "assigning integer to C pointer" {
 
 test "C pointer comparison and arithmetic" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -5,7 +5,6 @@ const expect = testing.expect;
 const expectError = testing.expectError;
 
 test "dereference pointer" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     comptime try testDerefPtr();
     try testDerefPtr();
 }
@@ -53,7 +52,6 @@ fn PtrOf(comptime T: type) type {
 
 test "implicit cast single item pointer to C pointer and back" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     var y: u8 = 11;
     var x: [*c]u8 = &y;
@@ -70,7 +68,6 @@ test "initialize const optional C pointer to null" {
 
 test "assigning integer to C pointer" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     var x: i32 = 0;
     var y: i32 = 1;

--- a/test/behavior/ref_var_in_if_after_if_2nd_switch_prong.zig
+++ b/test/behavior/ref_var_in_if_after_if_2nd_switch_prong.zig
@@ -8,7 +8,6 @@ test "reference a variable in an if after an if in the 2nd switch prong" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try foo(true, Num.Two, false, "aoeu");
     try expect(!ok);

--- a/test/behavior/reflection.zig
+++ b/test/behavior/reflection.zig
@@ -28,7 +28,6 @@ fn dummy(a: bool, b: i32, c: f32) i32 {
 test "reflection: @field" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     var f = Foo{
         .one = 42,

--- a/test/behavior/sizeof_and_typeof.zig
+++ b/test/behavior/sizeof_and_typeof.zig
@@ -154,7 +154,6 @@ test "@TypeOf() has no runtime side effects" {
 
 test "branching logic inside @TypeOf" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const S = struct {
         var data: i32 = 0;

--- a/test/behavior/sizeof_and_typeof.zig
+++ b/test/behavior/sizeof_and_typeof.zig
@@ -140,8 +140,6 @@ test "@sizeOf(T) == 0 doesn't force resolving struct size" {
 }
 
 test "@TypeOf() has no runtime side effects" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const S = struct {
         fn foo(comptime T: type, ptr: *T) T {
             ptr.* += 1;

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -201,8 +201,6 @@ test "slicing pointer by length" {
 const x = @intToPtr([*]i32, 0x1000)[0..0x500];
 const y = x[0x100..];
 test "compile time slice of pointer to hard coded address" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     try expect(@ptrToInt(x) == 0x1000);
     try expect(x.len == 0x500);
 

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -672,7 +672,6 @@ test "array mult of slice gives ptr to array" {
 
 test "slice bounds in comptime concatenation" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const bs = comptime blk: {
         const b = "........1........";

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -11,7 +11,6 @@ top_level_field: i32,
 test "top level fields" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     var instance = @This(){
         .top_level_field = 1234,

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -121,8 +121,6 @@ test "struct byval assign" {
 }
 
 test "call struct static method" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const result = StructWithNoFields.add(3, 4);
     try expect(result == 7);
 }

--- a/test/behavior/switch.zig
+++ b/test/behavior/switch.zig
@@ -215,7 +215,6 @@ fn poll() void {
 
 test "switch on global mutable var isn't constant-folded" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     while (state < 2) {
         poll();

--- a/test/behavior/switch.zig
+++ b/test/behavior/switch.zig
@@ -348,8 +348,6 @@ fn returnsFalse() bool {
     }
 }
 test "switch on const enum with var" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     try expect(!returnsFalse());
 }
 

--- a/test/behavior/this.zig
+++ b/test/behavior/this.zig
@@ -21,8 +21,6 @@ fn add(x: i32, y: i32) i32 {
 }
 
 test "this refer to module call private fn" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     try expect(module.add(1, 2) == 3);
 }
 

--- a/test/behavior/threadlocal.zig
+++ b/test/behavior/threadlocal.zig
@@ -46,7 +46,6 @@ test "reference a global threadlocal variable" {
         else => return error.SkipZigTest,
     }; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     _ = nrfx_uart_rx(&g_uart0);
 }

--- a/test/behavior/threadlocal.zig
+++ b/test/behavior/threadlocal.zig
@@ -11,7 +11,6 @@ test "thread local variable" {
         else => return error.SkipZigTest,
     }; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const S = struct {
         threadlocal var t: i32 = 1234;

--- a/test/behavior/type.zig
+++ b/test/behavior/type.zig
@@ -491,7 +491,6 @@ test "Type.Fn" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const some_opaque = opaque {};
     const some_ptr = *some_opaque;

--- a/test/behavior/type_info.zig
+++ b/test/behavior/type_info.zig
@@ -285,7 +285,6 @@ fn testUnion() !void {
 
 test "type info: struct info" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try testStruct();
     comptime try testStruct();

--- a/test/behavior/type_info.zig
+++ b/test/behavior/type_info.zig
@@ -512,7 +512,6 @@ test "type info for async frames" {
 
 test "Declarations are returned in declaration order" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const S = struct {
         const a = 1;

--- a/test/behavior/undefined.zig
+++ b/test/behavior/undefined.zig
@@ -81,7 +81,6 @@ test "assign undefined to struct with method" {
 
 test "type name of undefined" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const x = undefined;
     try expect(mem.eql(u8, @typeName(@TypeOf(x)), "@TypeOf(undefined)"));

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -1467,8 +1467,6 @@ test "packed union in packed struct" {
 }
 
 test "Namespace-like union" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     const DepType = enum {
         git,
         http,

--- a/test/behavior/var_args.zig
+++ b/test/behavior/var_args.zig
@@ -14,8 +14,6 @@ fn add(args: anytype) i32 {
 }
 
 test "add arbitrary args" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     try expect(add(.{ @as(i32, 1), @as(i32, 2), @as(i32, 3), @as(i32, 4) }) == 10);
     try expect(add(.{@as(i32, 1234)}) == 1234);
     try expect(add(.{}) == 0);

--- a/test/behavior/var_args.zig
+++ b/test/behavior/var_args.zig
@@ -30,7 +30,6 @@ test "send void arg to var args" {
 test "pass args directly" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try expect(addSomeStuff(.{ @as(i32, 1), @as(i32, 2), @as(i32, 3), @as(i32, 4) }) == 10);
     try expect(addSomeStuff(.{@as(i32, 1234)}) == 1234);

--- a/test/behavior/while.zig
+++ b/test/behavior/while.zig
@@ -38,8 +38,6 @@ fn staticWhileLoop2() i32 {
 }
 
 test "while with continue expression" {
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
     var sum: i32 = 0;
     {
         var i: i32 = 0;

--- a/test/behavior/while.zig
+++ b/test/behavior/while.zig
@@ -5,7 +5,6 @@ const assert = std.debug.assert;
 
 test "while loop" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     var i: i32 = 0;
     while (i < 4) {


### PR DESCRIPTION
- Implements cmp with pointers (also relational). This has a regression with an enum-to-int test. Also, some new (comptime) test had to be disabled.
- Fixes something in intCast that makes the previous test pass again..
- Remove use of OpIAddCarry as it is buggy in the LLVM SPIRV translator.
- Add a spir-v version of the module-scope assembly test.

All in all about 90 more tests pass now.