### PR TITLE
Build: Fix bug causing ReleaseSmall to fail on Windows

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -433,7 +433,7 @@ pub fn create(owner: *std.Build, options: Options) *Compile {
 
     const self = owner.allocator.create(Compile) catch @panic("OOM");
     self.* = Compile{
-        .strip = null,
+        .strip = if (options.optimize == .ReleaseSmall) true else null,
         .unwind_tables = null,
         .verbose_link = false,
         .verbose_cc = false,

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -433,7 +433,7 @@ pub fn create(owner: *std.Build, options: Options) *Compile {
 
     const self = owner.allocator.create(Compile) catch @panic("OOM");
     self.* = Compile{
-        .strip = if (options.optimize == .ReleaseSmall) true else null,
+        .strip = null,
         .unwind_tables = null,
         .verbose_link = false,
         .verbose_cc = false,
@@ -691,7 +691,7 @@ pub fn isStaticLibrary(self: *Compile) bool {
 pub fn producesPdbFile(self: *Compile) bool {
     if (!self.target.isWindows() and !self.target.isUefi()) return false;
     if (self.target.getObjectFormat() == .c) return false;
-    if (self.strip == true) return false;
+    if (self.strip == true or (self.strip == null and self.optimize == .ReleaseSmall)) return false;
     return self.isDynamicLibrary() or self.kind == .exe or self.kind == .@"test";
 }
 

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -2183,6 +2183,9 @@ pub fn dumpStackPointerAddr(prefix: []const u8) void {
 }
 
 test "manage resources correctly" {
+    // Skip on stripped builds (ReleaseSmall)
+    if (builtin.strip_debug_info) return error.SkipZigTest;
+
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
     if (builtin.os.tag == .windows and builtin.cpu.arch == .x86_64) {

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -2183,9 +2183,6 @@ pub fn dumpStackPointerAddr(prefix: []const u8) void {
 }
 
 test "manage resources correctly" {
-    // Skip on stripped builds (ReleaseSmall)
-    if (builtin.strip_debug_info) return error.SkipZigTest;
-
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
     if (builtin.os.tag == .windows and builtin.cpu.arch == .x86_64) {


### PR DESCRIPTION
closes: #13405


Due to the change in default behavior of ReleaseSmall (#13067), debug info (pdb here) are stripped by default. However because `Compile.create` defaults to null, `producesPdbFile` will report true for
`lib/std/Build/Step/InstallArtifact.zig` 
https://github.com/ziglang/zig/blob/378264d404e71da878f9e6934c045ad64193877f/lib/std/Build/Step/InstallArtifact.zig#L33

Because of this, this only affects `zig build` and not `zig build-exe`. After this change, a simple program compiled with  `ReleaseSmall` will successfully compile and won't try to copy/produce the pdb file.

Of course, this still allows the user to choose not to strip the build and will produce a pdb file. 

