### PR TITLE
Sema: simplify "duplicate test name" error message

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -5354,7 +5354,7 @@ fn scanDecl(iter: *ScanDeclIter, decl_sub_index: usize, flags: u4) Allocator.Err
         const msg = try ErrorMsg.create(
             gpa,
             src_loc,
-            "found test declaration with duplicate name: {s}",
+            "duplicate test name: {s}",
             .{decl_name},
         );
         errdefer msg.destroy(gpa);

--- a/test/cases/compile_errors/invalid_duplicate_test_decl_name.zig
+++ b/test/cases/compile_errors/invalid_duplicate_test_decl_name.zig
@@ -6,5 +6,5 @@ test "thingy" {}
 // target=native
 // is_test=1
 //
-// :1:6: error: found test declaration with duplicate name: test.thingy
+// :1:6: error: duplicate test name: test.thingy
 // :2:6: note: other test here


### PR DESCRIPTION
 * Avoid redundant words ("found")
   - All compile errors are found by the compiler
 * Avoid unnecessary prepositions ("with")
   - There is a grammatically correct alternate word order without the preposition.