### PR TITLE
multi-writer: test with a non-comptime stream

### DIFF
--- a/lib/std/io/multi_writer.zig
+++ b/lib/std/io/multi_writer.zig
@@ -1,6 +1,5 @@
 const std = @import("../std.zig");
 const io = std.io;
-const testing = std.testing;
 
 /// Takes a tuple of streams, and constructs a new stream that writes to all of them
 pub fn MultiWriter(comptime Writers: type) type {
@@ -23,14 +22,8 @@ pub fn MultiWriter(comptime Writers: type) type {
         }
 
         pub fn write(self: *Self, bytes: []const u8) Error!usize {
-            var batch = std.event.Batch(Error!void, self.streams.len, .auto_async).init();
-            comptime var i = 0;
-            inline while (i < self.streams.len) : (i += 1) {
-                const stream = self.streams[i];
-                // TODO: remove ptrCast: https://github.com/ziglang/zig/issues/5258
-                batch.add(@ptrCast(anyframe->Error!void, &async stream.writeAll(bytes)));
-            }
-            try batch.wait();
+            inline for (self.streams) |stream|
+                try stream.writeAll(bytes);
             return bytes.len;
         }
     };
@@ -40,13 +33,21 @@ pub fn multiWriter(streams: anytype) MultiWriter(@TypeOf(streams)) {
     return .{ .streams = streams };
 }
 
+const testing = std.testing;
+
 test "MultiWriter" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var f = try tmp.dir.createFile("t.txt", .{});
+
     var buf1: [255]u8 = undefined;
     var fbs1 = io.fixedBufferStream(&buf1);
     var buf2: [255]u8 = undefined;
-    var fbs2 = io.fixedBufferStream(&buf2);
-    var stream = multiWriter(.{ fbs1.writer(), fbs2.writer() });
+    var stream = multiWriter(.{ fbs1.writer(), f.writer() });
+
     try stream.writer().print("HI", .{});
+    f.close();
+
     try testing.expectEqualSlices(u8, "HI", fbs1.getWritten());
-    try testing.expectEqualSlices(u8, "HI", fbs2.getWritten());
+    try testing.expectEqualSlices(u8, "HI", try tmp.dir.readFile("t.txt", &buf2));
 }


### PR DESCRIPTION
Since #14819 this test failed with:

    $ ../../../build/stage3/bin/zig test multi_writer.zig
    multi_writer.zig:26:57: error: unable to evaluate comptime expression
                var batch = std.event.Batch(Error!void, self.streams.len, .auto_async).init();
                                                        ~~~~^~~~~~~~
    referenced by:
        Writer: multi_writer.zig:19:52
        writer: multi_writer.zig:21:36
        remaining reference traces hidden; use '-freference-trace' to see all reference traces

Thanks @jacobly0 for hints how to fix this on IRC.