### PR TITLE
make some panics more helpful

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2911,7 +2911,7 @@ test "function alignment" {
       pointer into a more aligned pointer. This is a no-op at runtime, but inserts a
       {#link|safety check|Incorrect Pointer Alignment#}:
       </p>
-      {#code_begin|test_safety|test_incorrect_pointer_alignment|incorrect alignment#}
+      {#code_begin|test_safety|test_incorrect_pointer_alignment|not aligned#}
 const std = @import("std");
 
 test "pointer alignment safety" {

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -832,7 +832,7 @@ pub fn panicUnwrapError(st: ?*StackTrace, err: anyerror) noreturn {
 
 pub fn panicOutOfBounds(index: usize, len: usize) noreturn {
     @setCold(true);
-    std.debug.panicExtra(null, @returnAddress(), "index out of bounds: index {d}, len {d}", .{ index, len });
+    std.debug.panicExtra(null, @returnAddress(), "index out of bounds: index={d}, len={d}", .{ index, len });
 }
 
 pub fn panicStartGreaterThanEnd(start: usize, end: usize) noreturn {

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -845,6 +845,11 @@ pub fn panicInactiveUnionField(active: anytype, wanted: @TypeOf(active)) noretur
     std.debug.panicExtra(null, @returnAddress(), "access of union field '{s}' while field '{s}' is active", .{ @tagName(wanted), @tagName(active) });
 }
 
+pub fn panicMemcpyLenMismatch(dst: usize, src: usize) noreturn {
+    @setCold(true);
+    std.debug.panicExtra(null, @returnAddress(), "@memcpy arguments have non-equal lengths: dst={d}, src={d}", .{ dst, src });
+}
+
 pub const panic_messages = struct {
     pub const unreach = "reached unreachable code";
     pub const unwrap_null = "attempt to use null value";

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -850,11 +850,16 @@ pub fn panicMemcpyLenMismatch(dst: usize, src: usize) noreturn {
     std.debug.panicExtra(null, @returnAddress(), "@memcpy arguments have non-equal lengths: dst={d}, src={d}", .{ dst, src });
 }
 
+pub fn panicIncorrectAlignment(ptr_addr: usize, expected_alignment_minus_1: u29) noreturn {
+    @setCold(true);
+    std.debug.panicExtra(null, @returnAddress(), "pointer address 0x{x} is not aligned to {} bytes", .{ ptr_addr, expected_alignment_minus_1 + 1 });
+}
+
 pub const panic_messages = struct {
     pub const unreach = "reached unreachable code";
     pub const unwrap_null = "attempt to use null value";
     pub const cast_to_null = "cast causes pointer to be null";
-    pub const incorrect_alignment = "incorrect alignment";
+    pub const incorrect_alignment = "incorrect pointer address alignment";
     pub const invalid_error_code = "invalid error code";
     pub const cast_truncated_data = "integer cast truncated bits";
     pub const negative_to_unsigned = "attempt to cast negative value to unsigned integer";

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -10013,7 +10013,7 @@ fn zirElemPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air
     if (indexable_ty.zigTypeTag(mod) != .Pointer) {
         const capture_src: LazySrcLoc = .{ .for_capture_from_input = inst_data.src_node };
         const msg = msg: {
-            const msg = try sema.errMsg(block, capture_src, "pointer capture of non pointer type '{}'", .{
+            const msg = try sema.errMsg(block, capture_src, "pointer capture of non-pointer type '{}'", .{
                 indexable_ty.fmt(mod),
             });
             errdefer msg.destroy(sema.gpa);
@@ -13127,7 +13127,7 @@ fn zirBitNot(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
     const scalar_type = operand_type.scalarType(mod);
 
     if (scalar_type.zigTypeTag(mod) != .Int) {
-        return sema.fail(block, src, "unable to perform binary not operation on type '{}'", .{
+        return sema.fail(block, src, "unable to perform bitwise NOT operation on type '{}'", .{
             operand_type.fmt(mod),
         });
     }

--- a/test/cases/compile_errors/binary_not_on_number_literal.zig
+++ b/test/cases/compile_errors/binary_not_on_number_literal.zig
@@ -10,4 +10,4 @@ export fn entry() usize {
 // backend=stage2
 // target=native
 //
-// :3:60: error: unable to perform binary not operation on type 'comptime_int'
+// :3:60: error: unable to perform bitwise NOT operation on type 'comptime_int'

--- a/test/cases/compile_errors/for.zig
+++ b/test/cases/compile_errors/for.zig
@@ -37,7 +37,7 @@ export fn d() void {
 // :2:19: note: length 11 here
 // :10:14: error: type 'bool' is not indexable and not a range
 // :10:14: note: for loop operand must be a range, array, slice, tuple, or vector
-// :17:16: error: pointer capture of non pointer type '[10]u8'
+// :17:16: error: pointer capture of non-pointer type '[10]u8'
 // :17:10: note: consider using '&' here
 // :24:5: error: unbounded for loop
 // :24:10: note: type '[*]const u8' has no upper bound

--- a/test/cases/safety/@alignCast misaligned.zig
+++ b/test/cases/safety/@alignCast misaligned.zig
@@ -1,8 +1,11 @@
 const std = @import("std");
 
+var ptr_addr: usize = undefined;
+
 pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
+    var buf: [64]u8 = undefined;
     _ = stack_trace;
-    if (std.mem.eql(u8, message, "incorrect alignment")) {
+    if (std.mem.eql(u8, message, std.fmt.bufPrint(&buf, "pointer address 0x{x} is not aligned to 4 bytes", .{ptr_addr}) catch unreachable)) {
         std.process.exit(0);
     }
     std.process.exit(1);
@@ -16,6 +19,7 @@ pub fn main() !void {
 }
 fn foo(bytes: []u8) u32 {
     const slice4 = bytes[1..5];
+    ptr_addr = @intFromPtr(slice4);
     const aligned: *align(4) [4]u8 = @alignCast(slice4);
     const int_slice = std.mem.bytesAsSlice(u32, aligned);
     return int_slice[0];

--- a/test/cases/safety/@ptrFromInt with misaligned address.zig
+++ b/test/cases/safety/@ptrFromInt with misaligned address.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
     _ = stack_trace;
-    if (std.mem.eql(u8, message, "incorrect alignment")) {
+    if (std.mem.eql(u8, message, "pointer address 0x5 is not aligned to 4 bytes")) {
         std.process.exit(0);
     }
     std.process.exit(1);

--- a/test/cases/safety/empty slice with sentinel out of bounds.zig
+++ b/test/cases/safety/empty slice with sentinel out of bounds.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
     _ = stack_trace;
-    if (std.mem.eql(u8, message, "index out of bounds: index 1, len 0")) {
+    if (std.mem.eql(u8, message, "index out of bounds: index=1, len=0")) {
         std.process.exit(0);
     }
     std.process.exit(1);

--- a/test/cases/safety/memcpy_len_mismatch.zig
+++ b/test/cases/safety/memcpy_len_mismatch.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
     _ = stack_trace;
-    if (std.mem.eql(u8, message, "@memcpy arguments have non-equal lengths")) {
+    if (std.mem.eql(u8, message, "@memcpy arguments have non-equal lengths: dst=5, src=4")) {
         std.process.exit(0);
     }
     std.process.exit(1);

--- a/test/cases/safety/out of bounds slice access.zig
+++ b/test/cases/safety/out of bounds slice access.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
     _ = stack_trace;
-    if (std.mem.eql(u8, message, "index out of bounds: index 4, len 4")) {
+    if (std.mem.eql(u8, message, "index out of bounds: index=4, len=4")) {
         std.process.exit(0);
     }
     std.process.exit(1);

--- a/test/cases/safety/slice with sentinel out of bounds - runtime len.zig
+++ b/test/cases/safety/slice with sentinel out of bounds - runtime len.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
     _ = stack_trace;
-    if (std.mem.eql(u8, message, "index out of bounds: index 5, len 4")) {
+    if (std.mem.eql(u8, message, "index out of bounds: index=5, len=4")) {
         std.process.exit(0);
     }
     std.process.exit(1);

--- a/test/cases/safety/slice with sentinel out of bounds.zig
+++ b/test/cases/safety/slice with sentinel out of bounds.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
     _ = stack_trace;
-    if (std.mem.eql(u8, message, "index out of bounds: index 5, len 4")) {
+    if (std.mem.eql(u8, message, "index out of bounds: index=5, len=4")) {
         std.process.exit(0);
     }
     std.process.exit(1);


### PR DESCRIPTION
Nobody asked for this and I didn't make a proposal so I don't know if any of this will be accepted but basically I thought we could introduce more `fn panic*`-type functions in `lib/std/builtin.zig` and make panics more helpful by including values we have. One of my main reasons is: when we have the values why not print them to be more helpful?

The one I like the most is this one:
```zig
test {
    var a: u8 = 250;
    var b: u8 = 50;
    _ = a + b;
}
```
Before:
```
$ zig test x.zig
Test [1/1] test_0... thread 333527 panic: integer overflow
```
After:
```
$ zig test x.zig
Test [1/1] test_0... thread 333527 panic: integer overflow: 250 + 50
```
Now it tells you which operation and operands overflowed.

This is arguably more helpful than the compile error equivalent:
```
x.zig:4:11: error: overflow of integer type 'u8' with value '300'
    _ = a + b;
        ~~^~~
```

Another one:
```zig
test {
    var slice: []const u8 = "hello";
    for (10..20, slice, 20..30) |a, b, c| {
        _ = a;
        _ = b;
        _ = c;
    }
}
```
Before:
```
$ zig test x.zig
thread 318078 panic: for loop over objects with non-equal lengths
```
After:
```
$ zig test x.zig
thread 318078 panic: for loop over objects with non-equal lengths: 10, 5, 10
```

Read the commit descriptions for more.

For one of my projects I can see an increase of 222238 bytes in output size (compiled to C though which is not a binary format):
```
$ wc -c ./zig-cache/o/0717b167d94db6e87af37facf7c08e06/test.c
4487814 ./zig-cache/o/0717b167d94db6e87af37facf7c08e06/test.c
$ wc -c ./zig-cache/o/61661f68c5b84d33a08ba7d034eba4d2/test.c
4265576 ./zig-cache/o/61661f68c5b84d33a08ba7d034eba4d2/test.c
```
Of course, formatted panics can be disabled with `-fno-formatted-panics` after which the binary size is back to what it was before. People that ship ReleaseSafe binaries and want them smaller should certainly consider it.

Yes, you can also find out this info with a debugger but my reasoning is that this speeds up the debugging experience and this is entirely optional (but on by default).

---

By the way, I would like to document how I was able to work on this PR entirely without LLVM support and even without the x86_64 backend (it's not far enough along yet) by using these commands:
```
$ cat x.zig
pub fn main() void {
    var x: u8 = 6;
    for (0..5, 0..x) |_, _| {}
}
$ zig-out/bin/zig build-exe x.zig --name x -ofmt=c
$ zig build-obj lib/compiler_rt.zig
$ clang x.c -Ilib -no-pie -fPIC -nostdlib -o x -lc compiler_rt.o
$ ./x
```