### PR TITLE
Use the word 'base' consistently instead of 'radix'

### DIFF
--- a/lib/std/fmt/parse_float/decimal.zig
+++ b/lib/std/fmt/parse_float/decimal.zig
@@ -34,13 +34,13 @@ pub fn Decimal(comptime T: type) type {
         /// For a double-precision IEEE-754 float, this required 767 digits,
         /// so we store the max digits + 1.
         ///
-        /// We can exactly represent a float in radix `b` from radix 2 if
+        /// We can exactly represent a float in base `b` from base 2 if
         /// `b` is divisible by 2. This function calculates the exact number of
         /// digits required to exactly represent that float.
         ///
         /// According to the "Handbook of Floating Point Arithmetic",
         /// for IEEE754, with emin being the min exponent, p2 being the
-        /// precision, and b being the radix, the number of digits follows as:
+        /// precision, and b being the base, the number of digits follows as:
         ///
         /// `−emin + p2 + ⌊(emin + 1) log(2, b) − log(1 − 2^(−p2), b)⌋`
         ///

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -1627,7 +1627,7 @@ pub const Mutable = struct {
         // while x >= y * b^(n - t):
         //    x -= y * b^(n - t)
         //    q[n - t] += 1
-        // Note, this algorithm is performed only once if y[t] > radix/2 and y is even, which we
+        // Note, this algorithm is performed only once if y[t] > base/2 and y is even, which we
         // enforced in step 0. This means we can replace the while with an if.
         // Note, multiplication by b^(n - t) comes down to shifting to the right by n - t limbs.
         // We can also replace x >= y * b^(n - t) by x/b^(n - t) >= y, and use shifts for that.
@@ -2206,20 +2206,20 @@ pub const Const = struct {
         out_stream: anytype,
     ) !void {
         _ = options;
-        comptime var radix = 10;
+        comptime var base = 10;
         comptime var case: std.fmt.Case = .lower;
 
         if (fmt.len == 0 or comptime mem.eql(u8, fmt, "d")) {
-            radix = 10;
+            base = 10;
             case = .lower;
         } else if (comptime mem.eql(u8, fmt, "b")) {
-            radix = 2;
+            base = 2;
             case = .lower;
         } else if (comptime mem.eql(u8, fmt, "x")) {
-            radix = 16;
+            base = 16;
             case = .lower;
         } else if (comptime mem.eql(u8, fmt, "X")) {
-            radix = 16;
+            base = 16;
             case = .upper;
         } else {
             std.fmt.invalidFmtError(fmt, self);
@@ -2237,8 +2237,8 @@ pub const Const = struct {
             .limbs = &([1]Limb{comptime math.maxInt(Limb)} ** available_len),
             .positive = false,
         };
-        var buf: [biggest.sizeInBaseUpperBound(radix)]u8 = undefined;
-        const len = self.toString(&buf, radix, case, &limbs);
+        var buf: [biggest.sizeInBaseUpperBound(base)]u8 = undefined;
+        const len = self.toString(&buf, base, case, &limbs);
         return out_stream.writeAll(buf[0..len]);
     }
 

--- a/lib/std/math/scalbn.zig
+++ b/lib/std/math/scalbn.zig
@@ -3,11 +3,11 @@ const expect = std.testing.expect;
 
 /// Returns a * FLT_RADIX ^ exp.
 ///
-/// Zig only supports binary radix IEEE-754 floats. Hence FLT_RADIX=2, and this is an alias for ldexp.
+/// Zig only supports binary base IEEE-754 floats. Hence FLT_RADIX=2, and this is an alias for ldexp.
 pub const scalbn = @import("ldexp.zig").ldexp;
 
 test "math.scalbn" {
-    // Verify we are using radix 2.
+    // Verify we are using base 2.
     try expect(scalbn(@as(f16, 1.5), 4) == 24.0);
     try expect(scalbn(@as(f32, 1.5), 4) == 24.0);
     try expect(scalbn(@as(f64, 1.5), 4) == 24.0);

--- a/lib/std/zig/c_translation.zig
+++ b/lib/std/zig/c_translation.zig
@@ -262,16 +262,19 @@ test "sizeof" {
     try testing.expect(sizeof(anyopaque) == 1);
 }
 
-pub const CIntLiteralRadix = enum { decimal, octal, hexadecimal };
+pub const CIntLiteralBase = enum { decimal, octal, hexadecimal };
 
-fn PromoteIntLiteralReturnType(comptime SuffixType: type, comptime number: comptime_int, comptime radix: CIntLiteralRadix) type {
+/// Deprecated: use `CIntLiteralBase`
+pub const CIntLiteralRadix = CIntLiteralBase;
+
+fn PromoteIntLiteralReturnType(comptime SuffixType: type, comptime number: comptime_int, comptime base: CIntLiteralBase) type {
     const signed_decimal = [_]type{ c_int, c_long, c_longlong, c_ulonglong };
     const signed_oct_hex = [_]type{ c_int, c_uint, c_long, c_ulong, c_longlong, c_ulonglong };
     const unsigned = [_]type{ c_uint, c_ulong, c_ulonglong };
 
     const list: []const type = if (@typeInfo(SuffixType).Int.signedness == .unsigned)
         &unsigned
-    else if (radix == .decimal)
+    else if (base == .decimal)
         &signed_decimal
     else
         &signed_oct_hex;
@@ -290,8 +293,8 @@ fn PromoteIntLiteralReturnType(comptime SuffixType: type, comptime number: compt
 pub fn promoteIntLiteral(
     comptime SuffixType: type,
     comptime number: comptime_int,
-    comptime radix: CIntLiteralRadix,
-) PromoteIntLiteralReturnType(SuffixType, number, radix) {
+    comptime base: CIntLiteralBase,
+) PromoteIntLiteralReturnType(SuffixType, number, base) {
     return number;
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -5786,12 +5786,12 @@ pub fn cmdChangelist(
     try bw.flush();
 }
 
-fn eatIntPrefix(arg: []const u8, radix: u8) []const u8 {
+fn eatIntPrefix(arg: []const u8, base: u8) []const u8 {
     if (arg.len > 2 and arg[0] == '0') {
         switch (std.ascii.toLower(arg[1])) {
-            'b' => if (radix == 2) return arg[2..],
-            'o' => if (radix == 8) return arg[2..],
-            'x' => if (radix == 16) return arg[2..],
+            'b' => if (base == 2) return arg[2..],
+            'o' => if (base == 8) return arg[2..],
+            'x' => if (base == 16) return arg[2..],
             else => {},
         }
     }

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -5735,21 +5735,21 @@ fn parseCNumLit(c: *Context, m: *MacroCtx) ParseError!Node {
 
     switch (m.list[m.i].id) {
         .IntegerLiteral => |suffix| {
-            var radix: []const u8 = "decimal";
+            var base: []const u8 = "decimal";
             if (lit_bytes.len >= 2 and lit_bytes[0] == '0') {
                 switch (lit_bytes[1]) {
                     '0'...'7' => {
                         // Octal
                         lit_bytes = try std.fmt.allocPrint(c.arena, "0o{s}", .{lit_bytes[1..]});
-                        radix = "octal";
+                        base = "octal";
                     },
                     'X' => {
                         // Hexadecimal with capital X, valid in C but not in Zig
                         lit_bytes = try std.fmt.allocPrint(c.arena, "0x{s}", .{lit_bytes[2..]});
-                        radix = "hexadecimal";
+                        base = "hexadecimal";
                     },
                     'x' => {
-                        radix = "hexadecimal";
+                        base = "hexadecimal";
                     },
                     else => {},
                 }
@@ -5794,7 +5794,7 @@ fn parseCNumLit(c: *Context, m: *MacroCtx) ParseError!Node {
                 return Tag.helpers_promoteIntLiteral.create(c.arena, .{
                     .type = type_node,
                     .value = literal_node,
-                    .radix = try Tag.enum_literal.create(c.arena, radix),
+                    .base = try Tag.enum_literal.create(c.arena, base),
                 });
             }
         },

--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -120,7 +120,7 @@ pub const Node = extern union {
         std_math_Log2Int,
         /// @intCast(lhs, rhs)
         int_cast,
-        /// @import("std").zig.c_translation.promoteIntLiteral(value, type, radix)
+        /// @import("std").zig.c_translation.promoteIntLiteral(value, type, base)
         helpers_promoteIntLiteral,
         /// @import("std").meta.alignment(value)
         std_meta_alignment,
@@ -699,7 +699,7 @@ pub const Payload = struct {
         data: struct {
             value: Node,
             type: Node,
-            radix: Node,
+            base: Node,
         },
     };
 
@@ -898,7 +898,7 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
         .helpers_promoteIntLiteral => {
             const payload = node.castTag(.helpers_promoteIntLiteral).?.data;
             const import_node = try renderStdImport(c, &.{ "zig", "c_translation", "promoteIntLiteral" });
-            return renderCall(c, import_node, &.{ payload.type, payload.value, payload.radix });
+            return renderCall(c, import_node, &.{ payload.type, payload.value, payload.base });
         },
         .std_meta_alignment => {
             const payload = node.castTag(.std_meta_alignment).?.data;


### PR DESCRIPTION
This is for #15789. I chose 'base' because the std lib seemed closer to consistently using 'base' than 'radix'. I skipped a couple of occurrences of 'radix'  in `zig/c_translation.zig` because there it was part of the name of a type, which would be a breaking change. (There are other cases that would be breaking if we changed everything to radix)