### PR TITLE
std.crypto.chacha: support larger vectors on AVX2 and AVX512 targets

### DIFF
--- a/lib/std/crypto/chacha20.zig
+++ b/lib/std/crypto/chacha20.zig
@@ -485,6 +485,11 @@ fn ChaChaImpl(comptime rounds_nb: usize) type {
             if (has_avx2) return ChaChaVecImpl(rounds_nb, 2);
             return ChaChaVecImpl(rounds_nb, 1);
         },
+        .aarch64 => {
+            const has_neon = std.Target.aarch64.featureSetHas(builtin.cpu.features, .neon);
+            if (has_neon) return ChaChaVecImpl(rounds_nb, 4);
+            return ChaChaNonVecImpl(rounds_nb);
+        },
         else => return ChaChaNonVecImpl(rounds_nb),
     }
 }

--- a/lib/std/rand/ChaCha.zig
+++ b/lib/std/rand/ChaCha.zig
@@ -10,7 +10,7 @@ const Self = @This();
 
 const Cipher = std.crypto.stream.chacha.ChaCha8IETF;
 
-const State = [2 * Cipher.block_length]u8;
+const State = [8 * Cipher.block_length]u8;
 
 state: State,
 offset: usize,


### PR DESCRIPTION
Ryzen 7 7700, ChaCha20/8 stream, long outputs:

```
Generic: 3268 MiB/s
AVX2   : 6023 MiB/s
AVX512 : 8086 MiB/s
```

Apple M1 CPUs seem to also benefit from a 4-way implementation on micro-benchmarks, but only on full-round ChaCha, and I'm not sure we can generalize it to other aarch64 CPUs, or to real workloads.

~~So, enable this only on x86_64 for now.~~ verified to also improve performance on a Cortex A72, so enabling on aarch64, too.

Bump the rand.chacha buffer a tiny bit to take advantage of this. More than 8 blocks doesn't seem to make any measurable difference.

ChaChaPoly also gets a small performance boost from this, albeit Poly1305 remains the bottleneck.

```
Generic:  707 MiB/s
AVX2   :  981 MiB/s
AVX512 : 1202 MiB/s
```