### PR TITLE
llvm: also generate metadata for extern global variables

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2560,7 +2560,7 @@ pub const DeclGen = struct {
                 );
 
                 try dg.object.di_map.put(dg.gpa, dg.decl, di_global.getVariable().toNode());
-                if (!is_internal_linkage) global.attachMetaData(di_global);
+                if (!is_internal_linkage or decl.isExtern()) global.attachMetaData(di_global);
             }
         }
     }


### PR DESCRIPTION
This is a follow up of #15349 