### PR TITLE
crypto/tls: switch X25519Kyber768Draft00 to new codepoint

### DIFF
--- a/lib/std/crypto/tls.zig
+++ b/lib/std/crypto/tls.zig
@@ -217,7 +217,7 @@ pub const NamedGroup = enum(u16) {
 
     // Hybrid post-quantum key agreements
     x25519_kyber512d00 = 0xFE30,
-    x25519_kyber768d00 = 0xFE31,
+    x25519_kyber768d00 = 0x6399,
 
     _,
 };


### PR DESCRIPTION
The tls wg preferred a codepoint outside of the reserved range. This new codepoint has been assigned by IANA.

See

 - https://datatracker.ietf.org/doc/draft-tls-westerbaan-xyber768d00-02/
 - https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#table-tls-parameters-8