### PR TITLE
compiler/macOS: Pass framework paths from `-F` through to compiler

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2693,12 +2693,12 @@ fn buildOutputType(
         try framework_dirs.appendSlice(paths.framework_dirs.items);
         try lib_dirs.appendSlice(paths.lib_dirs.items);
         try rpath_list.appendSlice(paths.rpaths.items);
+    }
 
-        try clang_argv.ensureUnusedCapacity(framework_dirs.items.len * 2);
-        for (framework_dirs.items) |framework_dir| {
-            clang_argv.appendAssumeCapacity("-F");
-            clang_argv.appendAssumeCapacity(framework_dir);
-        }
+    try clang_argv.ensureUnusedCapacity(framework_dirs.items.len * 2);
+    for (framework_dirs.items) |framework_dir| {
+        clang_argv.appendAssumeCapacity("-F");
+        clang_argv.appendAssumeCapacity(framework_dir);
     }
 
     // If any libs in this list are statically provided, we omit them from the

--- a/src/main.zig
+++ b/src/main.zig
@@ -2693,6 +2693,12 @@ fn buildOutputType(
         try framework_dirs.appendSlice(paths.framework_dirs.items);
         try lib_dirs.appendSlice(paths.lib_dirs.items);
         try rpath_list.appendSlice(paths.rpaths.items);
+
+        try clang_argv.ensureUnusedCapacity(framework_dirs.items.len * 2);
+        for (framework_dirs.items) |framework_dir| {
+            clang_argv.appendAssumeCapacity("-F");
+            clang_argv.appendAssumeCapacity(framework_dir);
+        }
     }
 
     // If any libs in this list are statically provided, we omit them from the


### PR DESCRIPTION
## Changes

- When `build-exe` is called with framework paths through `-F` option, pass the framework paths to compiler too. Reopen of PR #14151. Closes #7838
- Fixes one of the macOS header discrepancies noticed by @mikdusan. Now, when using the `cc` driver on macOS, `/usr/local/include` is included in the list of include paths.

## Remarks

- I looked into the other issue where `build-obj` uses Zig's bundled macOS headers (rather than the SDK headers) even when not in cross-compilation mode. I believe the reason is because of the following:
    - `want_native_include_dirs` is set to `false` [here](https://github.com/ziglang/zig/blob/a0652fb93077322c331345e1aeff25d5338f30b0/src/main.zig#L2556) in `buildOutputType` in `src/main.zig` when the `cc` or `cpp` driver is not used.
    - Therefore, there is no attempt to detect the macOS SDK, and when `Compilation.detectLibCIncludeDirs` is called by `Compilation.create`, it defaults to the included headers [because of this line](https://github.com/ziglang/zig/blob/a0652fb93077322c331345e1aeff25d5338f30b0/src/Compilation.zig#L4795)
- I would like to also fix the above issue but I'm not sure if my reasoning is correct or which part of the behavior to fix. I would be very grateful for suggestions as this is my first time contributing to this codebase.