### PR TITLE
zig ld: handle `--library :path/to/lib.so`

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -1020,6 +1020,7 @@ pub const File = struct {
             for (base.options.objects) |obj| {
                 _ = try man.addFile(obj.path, null);
                 man.hash.add(obj.must_link);
+                man.hash.add(obj.loption);
             }
             for (comp.c_object_table.keys()) |key| {
                 _ = try man.addFile(key.status.success.object_path, null);

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -63,7 +63,7 @@ pub fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
         man = comp.cache_parent.obtain();
         self.base.releaseLock();
 
-        comptime assert(Compilation.link_hash_implementation_version == 8);
+        comptime assert(Compilation.link_hash_implementation_version == 9);
 
         for (self.base.options.objects) |obj| {
             _ = try man.addFile(obj.path, null);

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -3494,7 +3494,7 @@ pub fn linkWithZld(macho_file: *MachO, comp: *Compilation, prog_node: *std.Progr
         // We are about to obtain this lock, so here we give other processes a chance first.
         macho_file.base.releaseLock();
 
-        comptime assert(Compilation.link_hash_implementation_version == 8);
+        comptime assert(Compilation.link_hash_implementation_version == 9);
 
         for (options.objects) |obj| {
             _ = try man.addFile(obj.path, null);

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -3150,7 +3150,7 @@ fn linkWithZld(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) l
         // We are about to obtain this lock, so here we give other processes a chance first.
         wasm.base.releaseLock();
 
-        comptime assert(Compilation.link_hash_implementation_version == 8);
+        comptime assert(Compilation.link_hash_implementation_version == 9);
 
         for (options.objects) |obj| {
             _ = try man.addFile(obj.path, null);
@@ -4199,7 +4199,7 @@ fn linkWithLLD(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) !
         // We are about to obtain this lock, so here we give other processes a chance first.
         wasm.base.releaseLock();
 
-        comptime assert(Compilation.link_hash_implementation_version == 8);
+        comptime assert(Compilation.link_hash_implementation_version == 9);
 
         for (wasm.base.options.objects) |obj| {
             _ = try man.addFile(obj.path, null);

--- a/src/main.zig
+++ b/src/main.zig
@@ -889,14 +889,6 @@ fn buildOutputType(
     var link_objects = std.ArrayList(Compilation.LinkObject).init(gpa);
     defer link_objects.deinit();
 
-    // This map is a flag per link_objects item, used to represent the
-    // `-l :file.so` syntax from gcc/clang.
-    // This is only exposed from the `zig cc` interface. It means that the `path`
-    // field from the corresponding `link_objects` element is a suffix, and is
-    // to be tried against each library path as a prefix until an existing file is found.
-    // This map remains empty for the main CLI.
-    var link_objects_lib_search_paths: std.AutoHashMapUnmanaged(u32, void) = .{};
-
     var framework_dirs = std.ArrayList([]const u8).init(gpa);
     defer framework_dirs.deinit();
 
@@ -1627,14 +1619,15 @@ fn buildOutputType(
                         // We don't know whether this library is part of libc or libc++ until
                         // we resolve the target, so we simply append to the list for now.
                         if (mem.startsWith(u8, it.only_arg, ":")) {
-                            // This "feature" of gcc/clang means to treat this as a positional
-                            // link object, but using the library search directories as a prefix.
+                            // -l :path/to/filename is used when callers need
+                            // more control over what's in the resulting
+                            // binary: no extra rpaths and DSO filename exactly
+                            // as provided. Hello, Go.
                             try link_objects.append(.{
-                                .path = it.only_arg[1..],
+                                .path = it.only_arg,
                                 .must_link = must_link,
+                                .loption = true,
                             });
-                            const index = @intCast(u32, link_objects.items.len - 1);
-                            try link_objects_lib_search_paths.put(arena, index, {});
                         } else if (force_static_libs) {
                             try static_libs.append(it.only_arg);
                         } else {
@@ -2636,30 +2629,6 @@ fn buildOutputType(
                 fatal("static library '{s}' not found. search paths: {s}", .{
                     static_lib, search_paths.items,
                 });
-            }
-        }
-    }
-
-    // Resolve `-l :file.so` syntax from `zig cc`. We use a separate map for this data
-    // since this is an uncommon case.
-    {
-        var it = link_objects_lib_search_paths.iterator();
-        while (it.next()) |item| {
-            const link_object_i = item.key_ptr.*;
-            const suffix = link_objects.items[link_object_i].path;
-
-            for (lib_dirs.items) |lib_dir_path| {
-                const test_path = try fs.path.join(arena, &.{ lib_dir_path, suffix });
-                fs.cwd().access(test_path, .{}) catch |err| switch (err) {
-                    error.FileNotFound => continue,
-                    else => |e| fatal("unable to search for library '{s}': {s}", .{
-                        test_path, @errorName(e),
-                    }),
-                };
-                link_objects.items[link_object_i].path = test_path;
-                break;
-            } else {
-                fatal("library '{s}' not found", .{suffix});
             }
         }
     }


### PR DESCRIPTION
`-l :path/to/lib.so` behavior on gcc/clang is:

- the path is recorded as-is: no paths, exact filename (`libX.so.Y`).
- no rpaths.

The previous version removed the `:` and pretended it's a positional argument to the linker. That works in almost all cases, except in how rules_go[1] does things (the Bazel wrapper for Go).

Test case in #15743, output:

    gcc rpath:
     0x0000000000000001 (NEEDED)     Shared library: [libversioned.so.2]
     0x000000000000001d (RUNPATH)    Library runpath: [$ORIGIN/x]
    gcc plain:
     0x0000000000000001 (NEEDED)     Shared library: [libversioned.so.2]
    zig cc rpath:
     0x0000000000000001 (NEEDED)     Shared library: [libversioned.so.2]
     0x000000000000001d (RUNPATH)    Library runpath: [$ORIGIN/x]
    zig cc plain:
     0x0000000000000001 (NEEDED)     Shared library: [libversioned.so.2]

Fixes #15743

[1]: https://github.com/bazelbuild/rules_go