### PR TITLE
std.math.big.int: Add Sqrt

### DIFF
--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -2622,6 +2622,36 @@ test "big.int pow" {
     }
 }
 
+test "big.int sqrt" {
+    var r = try Managed.init(testing.allocator);
+    defer r.deinit();
+    var a = try Managed.init(testing.allocator);
+    defer a.deinit();
+
+    // not aliased
+    try r.set(0);
+    try a.set(25);
+    try r.sqrt(&a);
+    try testing.expectEqual(@as(i32, 5), try r.to(i32));
+
+    // aliased
+    try a.set(25);
+    try a.sqrt(&a);
+    try testing.expectEqual(@as(i32, 5), try a.to(i32));
+
+    // bottom
+    try r.set(0);
+    try a.set(24);
+    try r.sqrt(&a);
+    try testing.expectEqual(@as(i32, 4), try r.to(i32));
+
+    // large number
+    try r.set(0);
+    try a.set(0x1_0000_0000_0000);
+    try r.sqrt(&a);
+    try testing.expectEqual(@as(i32, 0x100_0000), try r.to(i32));
+}
+
 test "big.int regression test for 1 limb overflow with alias" {
     // Note these happen to be two consecutive Fibonacci sequence numbers, the
     // first two whose sum exceeds 2**64.


### PR DESCRIPTION
Implemented with reference to Modern Computer Arithmetic, Algorithm 1.13 \[[PDF](https://members.loria.fr/PZimmermann/mca/mca-cup-0.5.9.pdf)\]. https://members.loria.fr/PZimmermann/mca/pub226.html

The below optimization ideas are derived from Go's big package.

* Minimize initial loop value
* Reuse loop values

math/big/int.go: https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/math/big/int.go;l=1286

Motivation: I'm implementing cryptocurrency algorithms in Zig.
It is common to use 256-bit integer values in this domain. So it would be helpful if std.math.big.int supports common operations like square root.