### PR TITLE
Allow run step to skip foreign binary execution if executor fails

### DIFF
--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -61,6 +61,13 @@ rename_step_with_output_arg: bool = true,
 /// nothing.
 skip_foreign_checks: bool = false,
 
+/// If this is true, failing to execute a foreign binary will be considered an
+/// error. However if this is false, the step will be skipped on failure instead.
+///
+/// This allows for a Run step to attempt to execute a foreign binary using an
+/// external executor (such as qemu) but not fail if the executor is unavailable.
+failing_to_execute_foreign_is_an_error: bool = true,
+
 /// If stderr or stdout exceeds this amount, the child process is killed and
 /// the step fails.
 max_stdio_size: usize = 10 * 1024 * 1024,
@@ -680,6 +687,8 @@ fn runCommand(
             try Step.handleVerbose2(step.owner, self.cwd, self.env_map, interp_argv.items);
 
             break :term spawnChildAndCollect(self, interp_argv.items, has_side_effects, prog_node) catch |e| {
+                if (!self.failing_to_execute_foreign_is_an_error) return error.MakeSkipped;
+
                 return step.fail("unable to spawn interpreter {s}: {s}", .{
                     interp_argv.items[0], @errorName(e),
                 });


### PR DESCRIPTION
This flag allows run steps for foreign binaries to be skipped if the executor is not available.

There are two reasons I want this functionality:
- I have a project with multiple architectures targeted and want to enable qemu for running tests on foreign architectures, however not all architectures have a qemu binary available.
- Contributors should not be expected to have a wide selection of qemu binaries but any they do have should be utilized and the rest skipped.