### PR TITLE
std.math.big.int: Fix typo

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -1825,7 +1825,7 @@ pub const Mutable = struct {
     /// if it were a field in packed memory at the provided bit offset.
     pub fn readPackedTwosComplement(
         x: *Mutable,
-        bytes: []const u8,
+        buffer: []const u8,
         bit_offset: usize,
         bit_count: usize,
         endian: Endian,
@@ -1844,11 +1844,11 @@ pub const Mutable = struct {
             const total_bits = bit_offset + bit_count;
             var last_byte = switch (endian) {
                 .Little => ((total_bits + 7) / 8) - 1,
-                .Big => bytes.len - ((total_bits + 7) / 8),
+                .Big => buffer.len - ((total_bits + 7) / 8),
             };
 
             const sign_bit = @as(u8, 1) << @intCast(u3, (total_bits - 1) % 8);
-            positive = ((bytes[last_byte] & sign_bit) == 0);
+            positive = ((buffer[last_byte] & sign_bit) == 0);
         }
 
         // Copy all complete limbs
@@ -1857,7 +1857,7 @@ pub const Mutable = struct {
         var bit_index: usize = 0;
         while (limb_index < bit_count / @bitSizeOf(Limb)) : (limb_index += 1) {
             // Read one Limb of bits
-            var limb = mem.readPackedInt(Limb, bytes, bit_index + bit_offset, endian);
+            var limb = mem.readPackedInt(Limb, buffer, bit_index + bit_offset, endian);
             bit_index += @bitSizeOf(Limb);
 
             // 2's complement (bitwise not, then add carry bit)
@@ -1873,10 +1873,10 @@ pub const Mutable = struct {
         if (bit_count != bit_index) {
             // Read all remaining bits
             var limb = switch (signedness) {
-                .unsigned => mem.readVarPackedInt(Limb, bytes, bit_index + bit_offset, bit_count - bit_index, endian, .unsigned),
+                .unsigned => mem.readVarPackedInt(Limb, buffer, bit_index + bit_offset, bit_count - bit_index, endian, .unsigned),
                 .signed => b: {
                     const SLimb = std.meta.Int(.signed, @bitSizeOf(Limb));
-                    const limb = mem.readVarPackedInt(SLimb, bytes, bit_index + bit_offset, bit_count - bit_index, endian, .signed);
+                    const limb = mem.readVarPackedInt(SLimb, buffer, bit_index + bit_offset, bit_count - bit_index, endian, .signed);
                     break :b @bitCast(Limb, limb);
                 },
             };
@@ -2318,7 +2318,7 @@ pub const Const = struct {
     ///
     /// This is equivalent to storing the value of an integer with `bit_count` bits as
     /// if it were a field in packed memory at the provided bit offset.
-    pub fn writePackedTwosComplement(x: Const, bytes: []u8, bit_offset: usize, bit_count: usize, endian: Endian) void {
+    pub fn writePackedTwosComplement(x: Const, buffer: []u8, bit_offset: usize, bit_count: usize, endian: Endian) void {
         assert(x.fitsInTwosComp(if (x.positive) .unsigned else .signed, bit_count));
 
         // Copy all complete limbs
@@ -2336,7 +2336,7 @@ pub const Const = struct {
             }
 
             // Write one Limb of bits
-            mem.writePackedInt(Limb, bytes, bit_index + bit_offset, limb, endian);
+            mem.writePackedInt(Limb, buffer, bit_index + bit_offset, limb, endian);
             bit_index += @bitSizeOf(Limb);
         }
 
@@ -2348,7 +2348,7 @@ pub const Const = struct {
             if (!x.positive) limb = ~limb +% carry;
 
             // Write all remaining bits
-            mem.writeVarPackedInt(bytes, bit_index + bit_offset, bit_count - bit_index, limb, endian);
+            mem.writeVarPackedInt(buffer, bit_index + bit_offset, bit_count - bit_index, limb, endian);
         }
     }
 


### PR DESCRIPTION
I found typos while using std.math.big.int.

- `bytes` -> `buffer`
- Correct naming consistency between
  1. fn argument and doc comment of `(read|write)PackedTwosComplement`
  2. fn arguments of `(read|write)PackedTwosComplement` and `(read|write)TwosComplement`

From autodoc, we can see the naming inconsistencies.

[std:math.big.int.Mutable](https://ziglang.org/documentation/master/std/#A;std:math.big.int.Mutable)
<img width="1095" alt="Screenshot 2023-05-26 at 16 20 52" src="https://github.com/ziglang/zig/assets/1117014/c87f1364-a3fe-4bd5-adad-2f443d3495e3">

[std:math.big.int.Const](https://ziglang.org/documentation/master/std/#A;std:math.big.int.Const)
<img width="1095" alt="Screenshot 2023-05-26 at 15 52 38" src="https://github.com/ziglang/zig/assets/1117014/f03615d8-1914-4dd2-a73a-ba768bd99870">
