### PR TITLE
std.math.isPowerOfTwo: return false for 0

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -1117,9 +1117,22 @@ pub fn alignCast(comptime alignment: u29, ptr: anytype) AlignCastError!@TypeOf(@
     return @alignCast(alignment, ptr);
 }
 
-pub fn isPowerOfTwo(v: anytype) bool {
-    assert(v != 0);
-    return (v & (v - 1)) == 0;
+/// Asserts `int > 0`.
+pub fn isPowerOfTwo(int: anytype) bool {
+    assert(int > 0);
+    return (int & (int - 1)) == 0;
+}
+
+test isPowerOfTwo {
+    try testing.expect(isPowerOfTwo(@as(u8, 1)));
+    try testing.expect(isPowerOfTwo(2));
+    try testing.expect(!isPowerOfTwo(@as(i16, 3)));
+    try testing.expect(isPowerOfTwo(4));
+    try testing.expect(!isPowerOfTwo(@as(u32, 31)));
+    try testing.expect(isPowerOfTwo(32));
+    try testing.expect(!isPowerOfTwo(@as(i64, 63)));
+    try testing.expect(isPowerOfTwo(128));
+    try testing.expect(isPowerOfTwo(@as(u128, 256)));
 }
 
 /// Aligns the given integer type bit width to a width divisible by 8.


### PR DESCRIPTION
I would argue that the input of 0 can happen pretty often and mathematically it makes more sense to actually return false rather than assert that the input can't be 0. We're in `std.math`, not `std.fast`.

When trying to compile
```zig
export fn x() u0 {
    return 0;
}
```
a debug crash happens only with a debug build of the compiler:
```
src/Sema.zig:23338:43: 0x9395c1 in explainWhyTypeIsNotExtern (zig)
        .Int => if (!std.math.isPowerOfTwo(ty.intInfo(sema.mod.getTarget()).bits)) {
                                          ^
```
In the release build of the compiler it does compile-error as expected but takes the wrong compile error branch and thus still exhibits incorrect behavior because the `assert(v != 0)` is not there and so `isPowerOfTwo` returns true for 0. Cases like this exist elsewhere in the compiler too. Of course this is something that can be fixed in the compiler itself but clearly it would be convenient for `isPowerOfTwo` to just correctly handle this very common input.

The user can always add an `assert(x != 0)` in their own code as an optimization or they can just use their own `isPowerOfTwo` function.