### PR TITLE
fix missing insertion of module to all_modules on first download

### DIFF
--- a/src/Package.zig
+++ b/src/Package.zig
@@ -582,6 +582,7 @@ fn fetchAndUnpack(
     });
 
     const mod = try createWithDir(gpa, global_cache_directory, pkg_dir_sub_path, build_zig_basename);
+    try all_modules.put(gpa, actual_hex, mod);
     return .{
         .mod = mod,
         .found_existing = false,


### PR DESCRIPTION
fixes an issue where multiple dependencies have a common module will crash on download because all_modules do not add the package unless it is cached ->
```
thread 15204 panic: reached unreachable code
C:\Git\zigcode\zig\lib\std\debug.zig:260:14: 0x7ff622d5e847 in assert (zig.exe.obj)
    if (!ok) unreachable; // assertion failure
             ^
C:\Git\zigcode\zig\src\Package.zig:297:36: 0x7ff622f419bd in fetchAndAddDependencies (zig.exe.obj)
            assert(other_sub == sub.mod);
                                   ^
C:\Git\zigcode\zig\src\main.zig:4412:67: 0x7ff622d905ae in cmdBuild (zig.exe.obj)
            const fetch_result = build_pkg.fetchAndAddDependencies(
```