### PR TITLE
actually assert length of collections

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -463,6 +463,7 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
         /// Asserts the list has at least one item.
         /// Invalidates pointers to the removed element.
         pub fn pop(self: *Self) T {
+            assert(self.items.len > 0);
             const val = self.items[self.items.len - 1];
             self.items.len -= 1;
             return val;
@@ -683,6 +684,7 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
         /// last element.
         /// This operation is O(N).
         pub fn orderedRemove(self: *Self, i: usize) T {
+            assert(self.items.len > 0);
             const newlen = self.items.len - 1;
             if (newlen == i) return self.pop();
 
@@ -983,6 +985,7 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
         /// Return the last element from the list.
         /// Asserts the list has at least one item.
         pub fn getLast(self: Self) T {
+            assert(self.items.len > 0);
             const val = self.items[self.items.len - 1];
             return val;
         }

--- a/lib/std/multi_array_list.zig
+++ b/lib/std/multi_array_list.zig
@@ -257,6 +257,7 @@ pub fn MultiArrayList(comptime T: type) type {
         /// Asserts the list has at least one item.
         /// Invalidates pointers to fields of the removed element.
         pub fn pop(self: *Self) T {
+            assert(self.len > 0);
             const val = self.get(self.len - 1);
             self.len -= 1;
             return val;


### PR DESCRIPTION
When using a `MultiArrayList` or `ArrayList`, the methods `pop()`, `getLast()`, etc. on an empty list should not crash as the comment suggests, but rather produce an assertion error. The changes added fixes that, unless I'm mistaken, and the original intention was never to assert at all.