### PR TITLE
Hash improvements

### DIFF
--- a/lib/std/crypto/siphash.zig
+++ b/lib/std/crypto/siphash.zig
@@ -47,7 +47,6 @@ fn SipHashStateless(comptime T: type, comptime c_rounds: usize, comptime d_round
     return struct {
         const Self = @This();
         const block_length = 64;
-        const digest_length = 64;
         const key_length = 16;
 
         v0: u64,
@@ -56,7 +55,7 @@ fn SipHashStateless(comptime T: type, comptime c_rounds: usize, comptime d_round
         v3: u64,
         msg_len: u8,
 
-        pub fn init(key: *const [key_length]u8) Self {
+        fn init(key: *const [key_length]u8) Self {
             const k0 = mem.readIntLittle(u64, key[0..8]);
             const k1 = mem.readIntLittle(u64, key[8..16]);
 
@@ -75,7 +74,7 @@ fn SipHashStateless(comptime T: type, comptime c_rounds: usize, comptime d_round
             return d;
         }
 
-        pub fn update(self: *Self, b: []const u8) void {
+        fn update(self: *Self, b: []const u8) void {
             std.debug.assert(b.len % 8 == 0);
 
             var off: usize = 0;
@@ -87,12 +86,7 @@ fn SipHashStateless(comptime T: type, comptime c_rounds: usize, comptime d_round
             self.msg_len +%= @truncate(u8, b.len);
         }
 
-        pub fn peek(self: Self) [digest_length]u8 {
-            var copy = self;
-            return copy.finalResult();
-        }
-
-        pub fn final(self: *Self, b: []const u8) T {
+        fn final(self: *Self, b: []const u8) T {
             std.debug.assert(b.len < 8);
 
             self.msg_len +%= @truncate(u8, b.len);
@@ -129,14 +123,8 @@ fn SipHashStateless(comptime T: type, comptime c_rounds: usize, comptime d_round
             return (@as(u128, b2) << 64) | b1;
         }
 
-        pub fn finalResult(self: *Self) [digest_length]u8 {
-            var result: [digest_length]u8 = undefined;
-            self.final(&result);
-            return result;
-        }
-
         fn round(self: *Self, b: [8]u8) void {
-            const m = mem.readIntLittle(u64, b[0..8]);
+            const m = mem.readIntLittle(u64, &b);
             self.v3 ^= m;
 
             comptime var i: usize = 0;
@@ -164,7 +152,7 @@ fn SipHashStateless(comptime T: type, comptime c_rounds: usize, comptime d_round
             d.v2 = math.rotl(u64, d.v2, @as(u64, 32));
         }
 
-        pub fn hash(msg: []const u8, key: *const [key_length]u8) T {
+        fn hash(msg: []const u8, key: *const [key_length]u8) T {
             const aligned_len = msg.len - (msg.len % 8);
             var c = Self.init(key);
             @call(.always_inline, update, .{ &c, msg[0..aligned_len] });

--- a/lib/std/crypto/test.zig
+++ b/lib/std/crypto/test.zig
@@ -1,4 +1,4 @@
-const std = @import("../std.zig");
+const std = @import("std");
 const testing = std.testing;
 const fmt = std.fmt;
 

--- a/lib/std/hash.zig
+++ b/lib/std/hash.zig
@@ -1,3 +1,5 @@
+pub const StreamingCache = @import("hash/streaming_cache.zig").StreamingCache;
+
 const adler = @import("hash/adler.zig");
 pub const Adler32 = adler.Adler32;
 

--- a/lib/std/hash/benchmark.zig
+++ b/lib/std/hash/benchmark.zig
@@ -98,7 +98,7 @@ const Result = struct {
     throughput: u64,
 };
 
-const block_size: usize = 8 * 8192;
+const block_size: usize = 64 * 8192;
 
 pub fn benchmarkHash(comptime H: anytype, bytes: usize, allocator: std.mem.Allocator) !Result {
     var blocks = try allocator.alloc(u8, bytes);

--- a/lib/std/hash/benchmark.zig
+++ b/lib/std/hash/benchmark.zig
@@ -17,11 +17,22 @@ const Hash = struct {
     ty: type,
     name: []const u8,
     has_iterative_api: bool = true,
+    has_crypto_api: bool = false,
     init_u8s: ?[]const u8 = null,
     init_u64: ?u64 = null,
 };
 
 const hashes = [_]Hash{
+    Hash{
+        .ty = hash.XxHash64,
+        .name = "xxhash64",
+        .init_u64 = 0,
+    },
+    Hash{
+        .ty = hash.XxHash32,
+        .name = "xxhash32",
+        .init_u64 = 0,
+    },
     Hash{
         .ty = hash.Wyhash,
         .name = "wyhash",
@@ -68,6 +79,18 @@ const hashes = [_]Hash{
         .name = "murmur3-32",
         .has_iterative_api = false,
     },
+    Hash{
+        .ty = hash.SipHash64(1, 3),
+        .name = "siphash64",
+        .has_crypto_api = true,
+        .init_u8s = &[_]u8{0} ** 16,
+    },
+    Hash{
+        .ty = hash.SipHash128(1, 3),
+        .name = "siphash128",
+        .has_crypto_api = true,
+        .init_u8s = &[_]u8{0} ** 16,
+    },
 };
 
 const Result = struct {
@@ -77,10 +100,14 @@ const Result = struct {
 
 const block_size: usize = 8 * 8192;
 
-pub fn benchmarkHash(comptime H: anytype, bytes: usize) !Result {
+pub fn benchmarkHash(comptime H: anytype, bytes: usize, allocator: std.mem.Allocator) !Result {
+    var blocks = try allocator.alloc(u8, bytes);
+    defer allocator.free(blocks);
+    random.bytes(blocks);
+
     var h = blk: {
         if (H.init_u8s) |init| {
-            break :blk H.ty.init(init);
+            break :blk H.ty.init(init[0..H.ty.key_length]);
         }
         if (H.init_u64) |init| {
             break :blk H.ty.init(init);
@@ -88,30 +115,32 @@ pub fn benchmarkHash(comptime H: anytype, bytes: usize) !Result {
         break :blk H.ty.init();
     };
 
-    var block: [block_size]u8 = undefined;
-    random.bytes(block[0..]);
-
     var offset: usize = 0;
     var timer = try Timer.start();
     const start = timer.lap();
-    while (offset < bytes) : (offset += block.len) {
-        h.update(block[0..]);
+    while (offset < bytes) : (offset += block_size) {
+        h.update(blocks[offset..][0..block_size]);
     }
     const end = timer.read();
 
     const elapsed_s = @intToFloat(f64, end - start) / time.ns_per_s;
     const throughput = @floatToInt(u64, @intToFloat(f64, bytes) / elapsed_s);
 
+    const final = if (H.has_crypto_api) @truncate(u64, h.finalInt()) else h.final();
+    std.mem.doNotOptimizeAway(final);
+
     return Result{
-        .hash = h.final(),
+        .hash = final,
         .throughput = throughput,
     };
 }
 
-pub fn benchmarkHashSmallKeys(comptime H: anytype, key_size: usize, bytes: usize) !Result {
+pub fn benchmarkHashSmallKeys(comptime H: anytype, key_size: usize, bytes: usize, allocator: std.mem.Allocator) !Result {
+    var blocks = try allocator.alloc(u8, bytes);
+    defer allocator.free(blocks);
+    random.bytes(blocks);
+
     const key_count = bytes / key_size;
-    var block: [block_size]u8 = undefined;
-    random.bytes(block[0..]);
 
     var i: usize = 0;
     var timer = try Timer.start();
@@ -119,21 +148,28 @@ pub fn benchmarkHashSmallKeys(comptime H: anytype, key_size: usize, bytes: usize
 
     var sum: u64 = 0;
     while (i < key_count) : (i += 1) {
-        const small_key = block[0..key_size];
-        sum +%= blk: {
+        const small_key = blocks[i * key_size ..][0..key_size];
+        const final = blk: {
             if (H.init_u8s) |init| {
-                break :blk H.ty.hash(init, small_key);
+                if (H.has_crypto_api) {
+                    break :blk @truncate(u64, H.ty.toInt(small_key, init[0..H.ty.key_length]));
+                } else {
+                    break :blk H.ty.hash(init, small_key);
+                }
             }
             if (H.init_u64) |init| {
                 break :blk H.ty.hash(init, small_key);
             }
             break :blk H.ty.hash(small_key);
         };
+        sum +%= final;
     }
     const end = timer.read();
 
     const elapsed_s = @intToFloat(f64, end - start) / time.ns_per_s;
     const throughput = @floatToInt(u64, @intToFloat(f64, bytes) / elapsed_s);
+
+    std.mem.doNotOptimizeAway(sum);
 
     return Result{
         .hash = sum,
@@ -227,6 +263,10 @@ pub fn main() !void {
         }
     }
 
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer std.testing.expect(gpa.deinit() == .ok) catch @panic("leak");
+    const allocator = gpa.allocator();
+
     inline for (hashes) |H| {
         if (filter == null or std.mem.indexOf(u8, H.name, filter.?) != null) {
             if (!test_iterative_only or H.has_iterative_api) {
@@ -236,13 +276,13 @@ pub fn main() !void {
                 // This allows easier comparison between different implementations.
                 if (H.has_iterative_api) {
                     prng.seed(seed);
-                    const result = try benchmarkHash(H, count);
+                    const result = try benchmarkHash(H, count, allocator);
                     try stdout.print("   iterative: {:5} MiB/s [{x:0<16}]\n", .{ result.throughput / (1 * MiB), result.hash });
                 }
 
                 if (!test_iterative_only) {
                     prng.seed(seed);
-                    const result_small = try benchmarkHashSmallKeys(H, key_size, count);
+                    const result_small = try benchmarkHashSmallKeys(H, key_size, count, allocator);
                     try stdout.print("  small keys: {:5} MiB/s [{x:0<16}]\n", .{ result_small.throughput / (1 * MiB), result_small.hash });
                 }
             }

--- a/lib/std/hash/streaming_cache.zig
+++ b/lib/std/hash/streaming_cache.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+/// Abstracts buffer management for unaligned input blocks for hash and crypto functions.
+pub fn StreamingCache(comptime round_length: usize) type {
+    return struct {
+        buf: [round_length]u8 = undefined,
+        buf_len: usize = 0,
+
+        pub fn update(self: *@This(), context: anytype, round_fn: anytype, input: []const u8) void {
+            if (input.len < round_length - self.buf_len) {
+                @memcpy(self.buf[self.buf_len..][0..input.len], input);
+                self.buf_len += input.len;
+                return;
+            }
+
+            var i: usize = 0;
+
+            if (self.buf_len > 0) {
+                i = round_length - self.buf_len;
+                @memcpy(self.buf[self.buf_len..][0..i], input[0..i]);
+                round_fn(context, &self.buf);
+                self.buf_len = 0;
+            }
+
+            while (i + round_length <= input.len) : (i += round_length) {
+                round_fn(context, input[i..][0..round_length]);
+            }
+
+            const remaining_bytes = input[i..];
+            @memcpy(self.buf[0..remaining_bytes.len], remaining_bytes);
+            self.buf_len = remaining_bytes.len;
+        }
+    };
+}

--- a/lib/std/hash/wyhash.zig
+++ b/lib/std/hash/wyhash.zig
@@ -1,209 +1,184 @@
 const std = @import("std");
-const mem = std.mem;
+const StreamingCache = @import("streaming_cache.zig").StreamingCache;
 
-const primes = [_]u64{
-    0xa0761d6478bd642f,
-    0xe7037ed1a0b428db,
-    0x8ebc6af09c88c6e3,
-    0x589965cc75374cc3,
-    0x1d8e4e27c47d124f,
-};
-
-fn read_bytes(comptime bytes: u8, data: []const u8) u64 {
-    const T = std.meta.Int(.unsigned, 8 * bytes);
-    return mem.readIntLittle(T, data[0..bytes]);
-}
-
-fn read_8bytes_swapped(data: []const u8) u64 {
-    return (read_bytes(4, data) << 32 | read_bytes(4, data[4..]));
-}
-
-fn mum(a: u64, b: u64) u64 {
-    var r = std.math.mulWide(u64, a, b);
-    r = (r >> 64) ^ r;
-    return @truncate(u64, r);
-}
-
-fn mix0(a: u64, b: u64, seed: u64) u64 {
-    return mum(a ^ seed ^ primes[0], b ^ seed ^ primes[1]);
-}
-
-fn mix1(a: u64, b: u64, seed: u64) u64 {
-    return mum(a ^ seed ^ primes[2], b ^ seed ^ primes[3]);
-}
-
-// Wyhash version which does not store internal state for handling partial buffers.
-// This is needed so that we can maximize the speed for the short key case, which will
-// use the non-iterative api which the public Wyhash exposes.
-const WyhashStateless = struct {
-    seed: u64,
-    msg_len: usize,
-
-    pub fn init(seed: u64) WyhashStateless {
-        return WyhashStateless{
-            .seed = seed,
-            .msg_len = 0,
-        };
-    }
-
-    fn round(self: *WyhashStateless, b: []const u8) void {
-        std.debug.assert(b.len == 32);
-
-        self.seed = mix0(
-            read_bytes(8, b[0..]),
-            read_bytes(8, b[8..]),
-            self.seed,
-        ) ^ mix1(
-            read_bytes(8, b[16..]),
-            read_bytes(8, b[24..]),
-            self.seed,
-        );
-    }
-
-    pub fn update(self: *WyhashStateless, b: []const u8) void {
-        std.debug.assert(b.len % 32 == 0);
-
-        var off: usize = 0;
-        while (off < b.len) : (off += 32) {
-            @call(.always_inline, round, .{ self, b[off..][0..32] });
-        }
-
-        self.msg_len += b.len;
-    }
-
-    pub fn final(self: *WyhashStateless, b: []const u8) u64 {
-        std.debug.assert(b.len < 32);
-
-        const seed = self.seed;
-        const rem_len = @intCast(u5, b.len);
-        const rem_key = b[0..rem_len];
-
-        self.seed = switch (rem_len) {
-            0 => seed,
-            1 => mix0(read_bytes(1, rem_key), primes[4], seed),
-            2 => mix0(read_bytes(2, rem_key), primes[4], seed),
-            3 => mix0((read_bytes(2, rem_key) << 8) | read_bytes(1, rem_key[2..]), primes[4], seed),
-            4 => mix0(read_bytes(4, rem_key), primes[4], seed),
-            5 => mix0((read_bytes(4, rem_key) << 8) | read_bytes(1, rem_key[4..]), primes[4], seed),
-            6 => mix0((read_bytes(4, rem_key) << 16) | read_bytes(2, rem_key[4..]), primes[4], seed),
-            7 => mix0((read_bytes(4, rem_key) << 24) | (read_bytes(2, rem_key[4..]) << 8) | read_bytes(1, rem_key[6..]), primes[4], seed),
-            8 => mix0(read_8bytes_swapped(rem_key), primes[4], seed),
-            9 => mix0(read_8bytes_swapped(rem_key), read_bytes(1, rem_key[8..]), seed),
-            10 => mix0(read_8bytes_swapped(rem_key), read_bytes(2, rem_key[8..]), seed),
-            11 => mix0(read_8bytes_swapped(rem_key), (read_bytes(2, rem_key[8..]) << 8) | read_bytes(1, rem_key[10..]), seed),
-            12 => mix0(read_8bytes_swapped(rem_key), read_bytes(4, rem_key[8..]), seed),
-            13 => mix0(read_8bytes_swapped(rem_key), (read_bytes(4, rem_key[8..]) << 8) | read_bytes(1, rem_key[12..]), seed),
-            14 => mix0(read_8bytes_swapped(rem_key), (read_bytes(4, rem_key[8..]) << 16) | read_bytes(2, rem_key[12..]), seed),
-            15 => mix0(read_8bytes_swapped(rem_key), (read_bytes(4, rem_key[8..]) << 24) | (read_bytes(2, rem_key[12..]) << 8) | read_bytes(1, rem_key[14..]), seed),
-            16 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed),
-            17 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1(read_bytes(1, rem_key[16..]), primes[4], seed),
-            18 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1(read_bytes(2, rem_key[16..]), primes[4], seed),
-            19 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1((read_bytes(2, rem_key[16..]) << 8) | read_bytes(1, rem_key[18..]), primes[4], seed),
-            20 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1(read_bytes(4, rem_key[16..]), primes[4], seed),
-            21 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1((read_bytes(4, rem_key[16..]) << 8) | read_bytes(1, rem_key[20..]), primes[4], seed),
-            22 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1((read_bytes(4, rem_key[16..]) << 16) | read_bytes(2, rem_key[20..]), primes[4], seed),
-            23 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1((read_bytes(4, rem_key[16..]) << 24) | (read_bytes(2, rem_key[20..]) << 8) | read_bytes(1, rem_key[22..]), primes[4], seed),
-            24 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1(read_8bytes_swapped(rem_key[16..]), primes[4], seed),
-            25 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1(read_8bytes_swapped(rem_key[16..]), read_bytes(1, rem_key[24..]), seed),
-            26 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1(read_8bytes_swapped(rem_key[16..]), read_bytes(2, rem_key[24..]), seed),
-            27 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1(read_8bytes_swapped(rem_key[16..]), (read_bytes(2, rem_key[24..]) << 8) | read_bytes(1, rem_key[26..]), seed),
-            28 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1(read_8bytes_swapped(rem_key[16..]), read_bytes(4, rem_key[24..]), seed),
-            29 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1(read_8bytes_swapped(rem_key[16..]), (read_bytes(4, rem_key[24..]) << 8) | read_bytes(1, rem_key[28..]), seed),
-            30 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1(read_8bytes_swapped(rem_key[16..]), (read_bytes(4, rem_key[24..]) << 16) | read_bytes(2, rem_key[28..]), seed),
-            31 => mix0(read_8bytes_swapped(rem_key), read_8bytes_swapped(rem_key[8..]), seed) ^ mix1(read_8bytes_swapped(rem_key[16..]), (read_bytes(4, rem_key[24..]) << 24) | (read_bytes(2, rem_key[28..]) << 8) | read_bytes(1, rem_key[30..]), seed),
-        };
-
-        self.msg_len += b.len;
-        return mum(self.seed ^ self.msg_len, primes[4]);
-    }
-
-    pub fn hash(seed: u64, input: []const u8) u64 {
-        const aligned_len = input.len - (input.len % 32);
-
-        var c = WyhashStateless.init(seed);
-        @call(.always_inline, update, .{ &c, input[0..aligned_len] });
-        return @call(.always_inline, final, .{ &c, input[aligned_len..] });
-    }
-};
-
-/// Fast non-cryptographic 64bit hash function.
-/// See https://github.com/wangyi-fudan/wyhash
 pub const Wyhash = struct {
-    state: WyhashStateless,
+    const secret = [_]u64{
+        0xa0761d6478bd642f,
+        0xe7037ed1a0b428db,
+        0x8ebc6af09c88c6e3,
+        0x589965cc75374cc3,
+    };
 
-    buf: [32]u8,
-    buf_len: usize,
+    a: u64,
+    b: u64,
+    state: [3]u64,
+    total_len: usize,
+    cache: StreamingCache(48),
 
     pub fn init(seed: u64) Wyhash {
-        return Wyhash{
-            .state = WyhashStateless.init(seed),
-            .buf = undefined,
-            .buf_len = 0,
+        var self = Wyhash{
+            .a = undefined,
+            .b = undefined,
+            .state = undefined,
+            .total_len = 0,
+            .cache = .{},
         };
+
+        self.state[0] = seed ^ mix(seed ^ secret[0], secret[1]);
+        self.state[1] = self.state[0];
+        self.state[2] = self.state[0];
+        return self;
     }
 
-    pub fn update(self: *Wyhash, b: []const u8) void {
-        var off: usize = 0;
+    pub fn update(self: *Wyhash, input: []const u8) void {
+        self.cache.update(self, round, input);
+        self.total_len += input.len;
+    }
 
-        if (self.buf_len != 0 and self.buf_len + b.len >= 32) {
-            off += 32 - self.buf_len;
-            @memcpy(self.buf[self.buf_len..][0..off], b[0..off]);
-            self.state.update(self.buf[0..]);
-            self.buf_len = 0;
+    // TODO: this should be idempotent
+    pub fn final(self: *Wyhash) u64 {
+        var input = self.cache.buf[0..self.cache.buf_len];
+
+        if (self.total_len <= 16) {
+            self.smallKey(input);
+        } else {
+            if (self.cache.buf_len < 16) {
+                var scratch: [16]u8 = undefined;
+                const rem = 16 - self.cache.buf_len;
+                @memcpy(scratch[0..rem], self.cache.buf[self.cache.buf.len - rem ..][0..rem]);
+                @memcpy(scratch[rem..][0..self.cache.buf_len], self.cache.buf[0..self.cache.buf_len]);
+
+                // Same as input with lookbehind to pad to 16-bytes
+                input = scratch[rem..];
+            }
+            self.finalInternal(input);
         }
 
-        const remain_len = b.len - off;
-        const aligned_len = remain_len - (remain_len % 32);
-        self.state.update(b[off .. off + aligned_len]);
-
-        const src = b[off + aligned_len ..];
-        @memcpy(self.buf[self.buf_len..][0..src.len], src);
-        self.buf_len += @intCast(u8, b[off + aligned_len ..].len);
+        return self.finalInternal2();
     }
 
-    pub fn final(self: *Wyhash) u64 {
-        const rem_key = self.buf[0..self.buf_len];
+    inline fn smallKey(self: *Wyhash, input: []const u8) void {
+        std.debug.assert(input.len <= 16);
 
-        return self.state.final(rem_key);
+        if (input.len >= 4) {
+            const end = input.len - 4;
+            const quarter = (input.len >> 3) << 2;
+            self.a = (read(4, input[0..]) << 32) | read(4, input[quarter..]);
+            self.b = (read(4, input[end..]) << 32) | read(4, input[end - quarter ..]);
+        } else if (input.len > 0) {
+            self.a = (@as(u64, input[0]) << 16) | (@as(u64, input[input.len >> 1]) << 8) | input[input.len - 1];
+            self.b = 0;
+        } else {
+            self.a = 0;
+            self.b = 0;
+        }
+    }
+
+    inline fn round(self: *Wyhash, input: *const [48]u8) void {
+        inline for (0..3) |i| {
+            const a = read(8, input[8 * (2 * i) ..]);
+            const b = read(8, input[8 * (2 * i + 1) ..]);
+            self.state[i] = mix(a ^ secret[i + 1], b ^ self.state[i]);
+        }
+    }
+
+    inline fn read(comptime bytes: usize, data: []const u8) u64 {
+        std.debug.assert(bytes <= 8);
+        const T = std.meta.Int(.unsigned, 8 * bytes);
+        return @as(u64, std.mem.readIntLittle(T, data[0..bytes]));
+    }
+
+    inline fn mum(a: *u64, b: *u64) void {
+        const x = @as(u128, a.*) *% b.*;
+        a.* = @truncate(u64, x);
+        b.* = @truncate(u64, x >> 64);
+    }
+
+    inline fn mix(a_: u64, b_: u64) u64 {
+        var a = a_;
+        var b = b_;
+        mum(&a, &b);
+        return a ^ b;
+    }
+
+    // Input must reside in a 16-byte buffer. The input slice passed be offset into it in which
+    // case this function will index in front of the slice.
+    inline fn finalInternal(self: *Wyhash, input: []const u8) void {
+        std.debug.assert(input.len < 48);
+        self.state[0] ^= self.state[1] ^ self.state[2];
+
+        var i: usize = 0;
+        while (i + 16 < input.len) : (i += 16) {
+            self.state[0] = mix(read(8, input[i..]) ^ secret[1], read(8, input[i + 8 ..]) ^ self.state[0]);
+        }
+
+        // Possible lookbehind past pointer start.
+        self.a = read(8, (input.ptr + input.len - 16)[0..8]);
+        self.b = read(8, (input.ptr + input.len - 8)[0..8]);
+    }
+
+    inline fn finalInternal2(self: *Wyhash) u64 {
+        self.a ^= secret[1];
+        self.b ^= self.state[0];
+        mum(&self.a, &self.b);
+        return mix(self.a ^ secret[0] ^ self.total_len, self.b ^ secret[1]);
     }
 
     pub fn hash(seed: u64, input: []const u8) u64 {
-        return WyhashStateless.hash(seed, input);
+        var self = Wyhash.init(seed);
+
+        if (input.len <= 16) {
+            self.smallKey(input);
+        } else {
+            var i: usize = 0;
+            while (i + 48 <= input.len) : (i += 48) {
+                self.round(input[i..][0..48]);
+            }
+            self.finalInternal(input[i..]);
+        }
+
+        self.total_len = input.len;
+        return self.finalInternal2();
     }
 };
 
 const expectEqual = std.testing.expectEqual;
 
-test "test vectors" {
-    const hash = Wyhash.hash;
+const TestVector = struct {
+    expected: u64,
+    seed: u64,
+    input: []const u8,
+};
 
-    try expectEqual(hash(0, ""), 0x0);
-    try expectEqual(hash(1, "a"), 0xbed235177f41d328);
-    try expectEqual(hash(2, "abc"), 0xbe348debe59b27c3);
-    try expectEqual(hash(3, "message digest"), 0x37320f657213a290);
-    try expectEqual(hash(4, "abcdefghijklmnopqrstuvwxyz"), 0xd0b270e1d8a7019c);
-    try expectEqual(hash(5, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"), 0x602a1894d3bbfe7f);
-    try expectEqual(hash(6, "12345678901234567890123456789012345678901234567890123456789012345678901234567890"), 0x829e9c148b75970e);
+// Run https://github.com/wangyi-fudan/wyhash/blob/77e50f267fbc7b8e2d09f2d455219adb70ad4749/test_vector.cpp directly.
+const vectors = [_]TestVector{
+    .{ .seed = 0, .expected = 0x409638ee2bde459, .input = "" },
+    .{ .seed = 1, .expected = 0xa8412d091b5fe0a9, .input = "a" },
+    .{ .seed = 2, .expected = 0x32dd92e4b2915153, .input = "abc" },
+    .{ .seed = 3, .expected = 0x8619124089a3a16b, .input = "message digest" },
+    .{ .seed = 4, .expected = 0x7a43afb61d7f5f40, .input = "abcdefghijklmnopqrstuvwxyz" },
+    .{ .seed = 5, .expected = 0xff42329b90e50d58, .input = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
+    .{ .seed = 6, .expected = 0xc39cab13b115aad3, .input = "12345678901234567890123456789012345678901234567890123456789012345678901234567890" },
+};
+
+test "test vectors" {
+    for (vectors) |e| {
+        try expectEqual(e.expected, Wyhash.hash(e.seed, e.input));
+    }
 }
 
 test "test vectors streaming" {
-    var wh = Wyhash.init(5);
-    for ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789") |e| {
-        wh.update(mem.asBytes(&e));
-    }
-    try expectEqual(wh.final(), 0x602a1894d3bbfe7f);
+    const step = 5;
 
-    const pattern = "1234567890";
-    const count = 8;
-    const result = 0x829e9c148b75970e;
-    try expectEqual(Wyhash.hash(6, pattern ** 8), result);
-
-    wh = Wyhash.init(6);
-    var i: u32 = 0;
-    while (i < count) : (i += 1) {
-        wh.update(pattern);
+    for (vectors) |e| {
+        var wh = Wyhash.init(e.seed);
+        var i: usize = 0;
+        while (i < e.input.len) : (i += step) {
+            const len = if (i + step > e.input.len) e.input.len - i else step;
+            wh.update(e.input[i..][0..len]);
+        }
+        try expectEqual(e.expected, wh.final());
     }
-    try expectEqual(wh.final(), result);
 }
 
 test "iterative non-divisible update" {

--- a/lib/std/hash/xxhash.zig
+++ b/lib/std/hash/xxhash.zig
@@ -246,23 +246,23 @@ pub const XxHash32 = struct {
 test "xxhash64" {
     const hash = XxHash64.hash;
 
-    try expectEqual(hash(""), 0xef46db3751d8e999);
-    try expectEqual(hash("a"), 0xd24ec4f1a98c6e5b);
-    try expectEqual(hash("abc"), 0x44bc2cf5ad770999);
-    try expectEqual(hash("message digest"), 0x066ed728fceeb3be);
-    try expectEqual(hash("abcdefghijklmnopqrstuvwxyz"), 0xcfe1f278fa89835c);
-    try expectEqual(hash("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"), 0xaaa46907d3047814);
-    try expectEqual(hash("12345678901234567890123456789012345678901234567890123456789012345678901234567890"), 0xe04a477f19ee145d);
+    try expectEqual(hash(0, ""), 0xef46db3751d8e999);
+    try expectEqual(hash(0, "a"), 0xd24ec4f1a98c6e5b);
+    try expectEqual(hash(0, "abc"), 0x44bc2cf5ad770999);
+    try expectEqual(hash(0, "message digest"), 0x066ed728fceeb3be);
+    try expectEqual(hash(0, "abcdefghijklmnopqrstuvwxyz"), 0xcfe1f278fa89835c);
+    try expectEqual(hash(0, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"), 0xaaa46907d3047814);
+    try expectEqual(hash(0, "12345678901234567890123456789012345678901234567890123456789012345678901234567890"), 0xe04a477f19ee145d);
 }
 
 test "xxhash32" {
     const hash = XxHash32.hash;
 
-    try expectEqual(hash(""), 0x02cc5d05);
-    try expectEqual(hash("a"), 0x550d7456);
-    try expectEqual(hash("abc"), 0x32d153ff);
-    try expectEqual(hash("message digest"), 0x7c948494);
-    try expectEqual(hash("abcdefghijklmnopqrstuvwxyz"), 0x63a14d5f);
-    try expectEqual(hash("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"), 0x9c285e64);
-    try expectEqual(hash("12345678901234567890123456789012345678901234567890123456789012345678901234567890"), 0x9c05f475);
+    try expectEqual(hash(0, ""), 0x02cc5d05);
+    try expectEqual(hash(0, "a"), 0x550d7456);
+    try expectEqual(hash(0, "abc"), 0x32d153ff);
+    try expectEqual(hash(0, "message digest"), 0x7c948494);
+    try expectEqual(hash(0, "abcdefghijklmnopqrstuvwxyz"), 0x63a14d5f);
+    try expectEqual(hash(0, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"), 0x9c285e64);
+    try expectEqual(hash(0, "12345678901234567890123456789012345678901234567890123456789012345678901234567890"), 0x9c05f475);
 }

--- a/lib/std/hash/xxhash.zig
+++ b/lib/std/hash/xxhash.zig
@@ -126,8 +126,8 @@ pub const XxHash64 = struct {
         return b +% prime_4;
     }
 
-    pub fn hash(input: []const u8) u64 {
-        var hasher = XxHash64.init(0);
+    pub fn hash(seed: u64, input: []const u8) u64 {
+        var hasher = XxHash64.init(seed);
         hasher.update(input);
         return hasher.final();
     }
@@ -236,8 +236,8 @@ pub const XxHash32 = struct {
         return acc;
     }
 
-    pub fn hash(input: []const u8) u32 {
-        var hasher = XxHash32.init(0);
+    pub fn hash(seed: u32, input: []const u8) u32 {
+        var hasher = XxHash32.init(seed);
         hasher.update(input);
         return hasher.final();
     }


### PR DESCRIPTION
This is a bit of clean-up on the hashing functions and some performance improvements. 

The core of this PR is abstracting the internal buffer-management for hash/crypto functions which require blocks of data to process on. Currently we naively call these via the `init`, `update`, `final` sequence from most `hash` calls. This is not ideal however when data is small (less than internal block size) as it results in unnecessary memory copies which slows these down enourmously.

The intended approach is to bypass this in the `hash` function of a hasher to improve small key performance. This is usually trivially done by calling the internal round component directly and moving the `final` function to a small shim which computes with the remaining buffer. This way we can call with the known buffer (in the case of small keys) or defer to the internal buffer (if hashing long keys/streaming data).

There is additional improvement on an individual hashing level that can be done for small keys, these is focusing on more generic improvements.