### PR TITLE
[std][pq] Simplify siftDown function.

### DIFF
--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -134,24 +134,18 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
             while (true) {
                 var left_index = (index << 1) + 1;
                 var right_index = left_index + 1;
-                var left = if (left_index < self.len) self.items[left_index] else null;
-                var right = if (right_index < self.len) self.items[right_index] else null;
 
                 var smallest_index = index;
                 var smallest = self.items[index];
-
-                if (left) |e| {
-                    if (compareFn(self.context, e, smallest) == .lt) {
-                        smallest_index = left_index;
-                        smallest = e;
-                    }
+                var candidate_index = left_index;
+                
+                if (right_index < self.len && compareFn(self.context, self.items[right_index], self.items[left_index]) == .lt) {
+                    candidate_index = right_index;
                 }
-
-                if (right) |e| {
-                    if (compareFn(self.context, e, smallest) == .lt) {
-                        smallest_index = right_index;
-                        smallest = e;
-                    }
+                
+                if (candidate_index < self.len && compareFn(self.context, self.items[candidate_index], smallest) == .lt) {
+                    smallest_index = candidate_index;
+                    smallest = self.items[candidate_index];
                 }
 
                 if (smallest_index == index) return;

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -139,11 +139,11 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
                 var smallest = self.items[index];
                 var candidate_index = left_index;
                 
-                if (right_index < self.len && compareFn(self.context, self.items[right_index], self.items[left_index]) == .lt) {
+                if (right_index < self.len and compareFn(self.context, self.items[right_index], self.items[left_index]) == .lt) {
                     candidate_index = right_index;
                 }
                 
-                if (candidate_index < self.len && compareFn(self.context, self.items[candidate_index], smallest) == .lt) {
+                if (candidate_index < self.len and compareFn(self.context, self.items[candidate_index], smallest) == .lt) {
                     smallest_index = candidate_index;
                     smallest = self.items[candidate_index];
                 }

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -138,11 +138,11 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
                 var smallest_index = index;
                 var smallest = self.items[index];
                 var candidate_index = left_index;
-                
+
                 if (right_index < self.len and compareFn(self.context, self.items[right_index], self.items[left_index]) == .lt) {
                     candidate_index = right_index;
                 }
-                
+
                 if (candidate_index < self.len and compareFn(self.context, self.items[candidate_index], smallest) == .lt) {
                     smallest_index = candidate_index;
                     smallest = self.items[candidate_index];


### PR DESCRIPTION
- if `right_index` is valid, there is no need to check left one for validity, so just use left_index as a candidate and update it in case right value is "smaller".

This avoids the need to deal with nullables and shortens the code. Optimizing compilers may in theory perform some of these optimizations, but I believe this also improves readability.