### PR TITLE
target.zig adds ps4 and ps5 type sizes.

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -2236,6 +2236,15 @@ pub const Target = struct {
                 .longdouble => return 128,
             },
 
+            .ps4, .ps5 => switch (c_type) {
+                .char => return 8,
+                .short, .ushort => return 16,
+                .int, .uint, .float => return 32,
+                .long, .ulong => return 64,
+                .longlong, .ulonglong, .double => return 64,
+                .longdouble => return 80,
+            },
+
             .cloudabi,
             .kfreebsd,
             .lv2,
@@ -2243,8 +2252,6 @@ pub const Target = struct {
             .rtems,
             .nacl,
             .aix,
-            .ps4,
-            .ps5,
             .elfiamcu,
             .mesa3d,
             .contiki,


### PR DESCRIPTION
Since both consoles use standard x86_64 amd cpu, these should do the trick.