### PR TITLE
std.meta: have fieldNames() return a mutable pointer to array

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -507,7 +507,7 @@ test "std.meta.FieldType" {
     try testing.expect(FieldType(U, .d) == *const u8);
 }
 
-pub fn fieldNames(comptime T: type) *const [fields(T).len][]const u8 {
+pub fn fieldNames(comptime T: type) *[fields(T).len][]const u8 {
     return comptime blk: {
         const fieldInfos = fields(T);
         var names: [fieldInfos.len][]const u8 = undefined;


### PR DESCRIPTION
function value is only computed at comptime so returning the address local is safe and this allows the result to for instance be sorted without an extra copy