### PR TITLE
Never implicitly add rpaths for each lib dir, add NixOS libdir to rpath

### DIFF
--- a/lib/std/zig/system/NativePaths.zig
+++ b/lib/std/zig/system/NativePaths.zig
@@ -74,6 +74,7 @@ pub fn detect(allocator: Allocator, native_info: NativeTargetInfo) !NativePaths 
             } else if (word.len > 2 and word[0] == '-' and word[1] == 'L') {
                 const lib_path = word[2..];
                 try self.addLibDir(lib_path);
+                try self.addRPath(lib_path);
             } else {
                 try self.addWarningFmt("Unrecognized C flag from NIX_LDFLAGS: {s}", .{word});
                 break;

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1519,7 +1519,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .llvm_cpu_features = llvm_cpu_features,
             .skip_linker_dependencies = options.skip_linker_dependencies,
             .parent_compilation_link_libc = options.parent_compilation_link_libc,
-            .each_lib_rpath = options.each_lib_rpath orelse options.is_native_os,
+            .each_lib_rpath = options.each_lib_rpath orelse false,
             .build_id = build_id,
             .cache_mode = cache_mode,
             .disable_lld_caching = options.disable_lld_caching or cache_mode == .whole,


### PR DESCRIPTION
resolves #13466
closes #15292 (alternative)

instead of adding all lib paths as an rpath implicitly when we are compiling for the Native OS, add NixOS lib paths to the rpath.

