### PR TITLE
A few `IterableDir.Walker`/`Iterator` fixes

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -972,7 +972,7 @@ pub const IterableDir = struct {
                         {
                             errdefer new_dir.close();
                             try self.stack.append(StackItem{
-                                .iter = new_dir.iterate(),
+                                .iter = new_dir.iterateAssumeFirstIteration(),
                                 .dirname_len = self.name_buffer.items.len,
                             });
                             top = &self.stack.items[self.stack.items.len - 1];

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -662,6 +662,7 @@ pub const IterableDir = struct {
                             .NOTDIR => unreachable,
                             .NOENT => return error.DirNotFound, // The directory being iterated was deleted during iteration.
                             .INVAL => return error.Unexpected, // Linux may in some cases return EINVAL when reading /proc/$PID/net.
+                            .ACCES => return error.AccessDenied, // Do not have permission to iterate this directory.
                             else => |err| return os.unexpectedErrno(err),
                         }
                         if (rc == 0) return null;


### PR DESCRIPTION
The commit messages in a more readable format:

---

Allow recovering from `Walker.next` errors without continually hitting the same error

Before this commit, if Walker.next errored with e.g. `error.AccessDenied` and the caller did something like
```zig
var num_walked: u64 = 0;
while (true) {
    const curr = walker.next() catch |err| switch (err) {
        error.AccessDenied => continue,
        else => |e| return e,
    }

    if (curr) |_| {
        num_walked += 1;
    } else {
        break;
    }
}
```
 then the directory that errored with AccessDenied would be continually iterated in each `next` call and error every time with AccessDenied.

After this commit, the directory that errored will be popped off the stack before the error is returned, meaning that in the subsequent `next` call, it won't be retried and the Walker will continue with whatever directories remain on its stack.

For a real example, before this commit, walking `/proc/` on my system would infinitely loop due to repeated AccessDenied errors on the same directory. After this commit, I am able to walk `/proc/` on my system fully (skipping over any directories that are unable to be iterated).

---

Directory iteration: handle `EACCES` returned from `getdents64`

This can occur for directories that the user does not have the necessary permissions to be able to iterate.

Note: I was hitting this when trying to walk `/proc/` locally.

---

Use `iterateAssumeFirstIteration` in `Walker.next` to avoid unnecessary `lseek` calls

Since we are opening each directory for iteration, we know that we don't need to reset the directory's cursor before iterating. Using `iterateAssumeFirstIteration` skips the cursor resetting which eliminates an `lseek` syscall for every directory opened on non-Windows platforms.

This doesn't seem to actually matter much for performance (`1.01 ± 0.02 times faster` when walking `/home/` on my system) but avoiding unnecessary syscalls is always nice anyway.