### PR TITLE
arena_allocator/reset: fix use after free, fix buffer overrun

### DIFF
--- a/lib/std/heap/arena_allocator.zig
+++ b/lib/std/heap/arena_allocator.zig
@@ -120,7 +120,7 @@ pub const ArenaAllocator = struct {
         }
         const total_size = switch (mode) {
             .retain_capacity => current_capacity,
-            .retain_with_limit => |limit| std.math.min(limit, current_capacity),
+            .retain_with_limit => |limit| std.math.min(@sizeOf(BufNode) + limit, current_capacity),
             .free_all => unreachable,
         };
         const align_bits = std.math.log2_int(usize, @alignOf(BufNode));


### PR DESCRIPTION
#### Main commit msgs
- Previously, when the last buffer in `buffer_list` was retained after deleting all other buffers, `buffer_list` wasn't updated and pointed to a deleted buffer.

- Previously, when the user-provided a limit in `retain_with_limit` that was smaller than `@sizeOf(BufNode)`, `reset` would store a new `BufNode` in an allocation smaller than `BufNode`, leading to a buffer overrun.

cc @MasterQ32