### PR TITLE
std.c: openbsd adding secure allocator calls, differs from usual call…

### DIFF
--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -1638,3 +1638,7 @@ pub const PTHREAD_STACK_MIN = switch (builtin.cpu.arch) {
     .mips64 => 1 << 14,
     else => 1 << 12,
 };
+
+pub extern "c" fn malloc_conceal(usize) ?*anyopaque;
+pub extern "c" fn calloc_conceal(usize, usize) ?*anyopaque;
+pub extern "c" fn freezero(?*anyopaque, usize) void;


### PR DESCRIPTION
…s as memory contents not included in core dumps