### PR TITLE
os/plan9: fix order of register setting in syscall1

### DIFF
--- a/lib/std/os/plan9/x86_64.zig
+++ b/lib/std/os/plan9/x86_64.zig
@@ -9,8 +9,8 @@ pub fn syscall1(sys: plan9.SYS, arg0: usize) usize {
         \\pop %%r11
         \\pop %%r11
         : [ret] "={rax}" (-> usize),
-        : [syscall_number] "{rbp}" (@enumToInt(sys)),
-          [arg0] "{r8}" (arg0),
+        : [arg0] "{r8}" (arg0),
+          [syscall_number] "{rbp}" (@enumToInt(sys)),
         : "rcx", "rax", "rbp", "r11", "memory"
     );
 }


### PR DESCRIPTION
We need to set rbp last because the arguments are stored on the stack. If we clobber rbp first, then we will get a segfault when trying to access the function arguments.

I believe I had already done this with the other syscall* functions, but not with syscall1, so this allows single argument syscalls like close to work.