### PR TITLE
std(os/windows): Add GetTempPathW and GetTempPath

### DIFF
--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -229,6 +229,11 @@ pub extern "kernel32" fn GetProcessHeap() callconv(WINAPI) ?HANDLE;
 
 pub extern "kernel32" fn GetProcessTimes(in_hProcess: HANDLE, out_lpCreationTime: *FILETIME, out_lpExitTime: *FILETIME, out_lpKernelTime: *FILETIME, out_lpUserTime: *FILETIME) callconv(WINAPI) BOOL;
 
+pub extern "kernel32" fn GetTempPathW(
+    nBufferLength: u32,
+    lpBuffer: [*]u16,
+) callconv(WINAPI) u32;
+
 pub extern "kernel32" fn GetQueuedCompletionStatus(CompletionPort: HANDLE, lpNumberOfBytesTransferred: *DWORD, lpCompletionKey: *ULONG_PTR, lpOverlapped: *?*OVERLAPPED, dwMilliseconds: DWORD) callconv(WINAPI) BOOL;
 pub extern "kernel32" fn GetQueuedCompletionStatusEx(
     CompletionPort: HANDLE,


### PR DESCRIPTION
This change adds a kernel32.GetTempPathW binding to [GetTempPathW][1].
This function returns the system path for temporary directories
(e.g. "C:\Temp\").

[1]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw

The accompanying windows.GetTempPath function produces a UTF-8 string,
exposing an API with a similar pattern to GetCurrentDirectory.
