### PR TITLE
Add a compiler error for `@mulAdd` with int vectors.

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -22151,8 +22151,8 @@ fn zirMulAdd(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
     const maybe_addend = try sema.resolveMaybeUndefVal(addend);
     const mod = sema.mod;
 
-    switch (ty.zigTypeTag(mod)) {
-        .ComptimeFloat, .Float, .Vector => {},
+    switch (ty.scalarType(mod).zigTypeTag(mod)) {
+        .ComptimeFloat, .Float => {},
         else => return sema.fail(block, src, "expected vector of floats or float type, found '{}'", .{ty.fmt(sema.mod)}),
     }
 

--- a/test/cases/compile_errors/muladd_int_vector.zig
+++ b/test/cases/compile_errors/muladd_int_vector.zig
@@ -1,0 +1,9 @@
+comptime {
+    _ = @mulAdd(@Vector(1, u32), .{0}, .{0}, .{0});
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:9: error: expected vector of floats or float type, found '@Vector(1, u32)'


### PR DESCRIPTION
Fixes #16013

The given test case now correctly outputs
```
error: expected vector of floats or float type, found '@Vector(1, u32)'
```