### PR TITLE
Clarify that @sin, @cos, @tan use radians

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -9273,7 +9273,7 @@ fn doTheTest() !void {
       {#header_open|@sin#}
       <pre>{#syntax#}@sin(value: anytype) @TypeOf(value){#endsyntax#}</pre>
       <p>
-      Sine trigonometric function on a floating point number. Uses a dedicated hardware instruction
+      Sine trigonometric function on a floating point number in radians. Uses a dedicated hardware instruction
       when available.
       </p>
       <p>
@@ -9284,7 +9284,7 @@ fn doTheTest() !void {
       {#header_open|@cos#}
       <pre>{#syntax#}@cos(value: anytype) @TypeOf(value){#endsyntax#}</pre>
       <p>
-      Cosine trigonometric function on a floating point number. Uses a dedicated hardware instruction
+      Cosine trigonometric function on a floating point number in radians. Uses a dedicated hardware instruction
       when available.
       </p>
       <p>
@@ -9295,7 +9295,7 @@ fn doTheTest() !void {
       {#header_open|@tan#}
       <pre>{#syntax#}@tan(value: anytype) @TypeOf(value){#endsyntax#}</pre>
       <p>
-      Tangent trigonometric function on a floating point number.
+      Tangent trigonometric function on a floating point number in radians.
       Uses a dedicated hardware instruction when available.
       </p>
       <p>


### PR DESCRIPTION
Hey there! Ran in to a small bit of confusion today using [@sin](https://ziglang.org/documentation/master/#sin), [@cos](https://ziglang.org/documentation/master/#cos), and [@tan](https://ziglang.org/documentation/master/#tan) because I was passing in degrees by accident. I suggest this small change that clarifies in the documentation that these functions expect radians.