### PR TITLE
std.atomic.Atomic: update tests to new for-loop syntax, re-enable tes…

### DIFF
--- a/lib/std/atomic/Atomic.zig
+++ b/lib/std/atomic/Atomic.zig
@@ -374,10 +374,6 @@ const atomic_rmw_orderings = [_]Ordering{
 };
 
 test "Atomic.swap" {
-    // TODO: Re-enable when LLVM is released with a bugfix for isel of
-    //       atomic load (currently fixed on trunk, broken on 15.0.2)
-    if (builtin.cpu.arch == .powerpc64le) return error.SkipZigTest;
-
     inline for (atomic_rmw_orderings) |ordering| {
         var x = Atomic(usize).init(5);
         try testing.expectEqual(x.swap(10, ordering), 5);
@@ -546,9 +542,8 @@ test "Atomic.bitSet" {
     inline for (atomicIntTypes()) |Int| {
         inline for (atomic_rmw_orderings) |ordering| {
             var x = Atomic(Int).init(0);
-            const bit_array = @as([@bitSizeOf(Int)]void, undefined);
 
-            for (bit_array, 0..) |_, bit_index| {
+            for (0..@bitSizeOf(Int)) |bit_index| {
                 const bit = @intCast(std.math.Log2Int(Int), bit_index);
                 const mask = @as(Int, 1) << bit;
 
@@ -562,7 +557,7 @@ test "Atomic.bitSet" {
                 try testing.expect(x.load(.SeqCst) & mask != 0);
 
                 // all the previous bits should have not changed (still be set)
-                for (bit_array[0..bit_index], 0..) |_, prev_bit_index| {
+                for (0..bit_index) |prev_bit_index| {
                     const prev_bit = @intCast(std.math.Log2Int(Int), prev_bit_index);
                     const prev_mask = @as(Int, 1) << prev_bit;
                     try testing.expect(x.load(.SeqCst) & prev_mask != 0);
@@ -576,9 +571,8 @@ test "Atomic.bitReset" {
     inline for (atomicIntTypes()) |Int| {
         inline for (atomic_rmw_orderings) |ordering| {
             var x = Atomic(Int).init(0);
-            const bit_array = @as([@bitSizeOf(Int)]void, undefined);
 
-            for (bit_array, 0..) |_, bit_index| {
+            for (0..@bitSizeOf(Int)) |bit_index| {
                 const bit = @intCast(std.math.Log2Int(Int), bit_index);
                 const mask = @as(Int, 1) << bit;
                 x.storeUnchecked(x.loadUnchecked() | mask);
@@ -593,7 +587,7 @@ test "Atomic.bitReset" {
                 try testing.expect(x.load(.SeqCst) & mask == 0);
 
                 // all the previous bits should have not changed (still be reset)
-                for (bit_array[0..bit_index], 0..) |_, prev_bit_index| {
+                for (0..bit_index) |prev_bit_index| {
                     const prev_bit = @intCast(std.math.Log2Int(Int), prev_bit_index);
                     const prev_mask = @as(Int, 1) << prev_bit;
                     try testing.expect(x.load(.SeqCst) & prev_mask == 0);
@@ -607,9 +601,8 @@ test "Atomic.bitToggle" {
     inline for (atomicIntTypes()) |Int| {
         inline for (atomic_rmw_orderings) |ordering| {
             var x = Atomic(Int).init(0);
-            const bit_array = @as([@bitSizeOf(Int)]void, undefined);
 
-            for (bit_array, 0..) |_, bit_index| {
+            for (0..@bitSizeOf(Int)) |bit_index| {
                 const bit = @intCast(std.math.Log2Int(Int), bit_index);
                 const mask = @as(Int, 1) << bit;
 
@@ -623,7 +616,7 @@ test "Atomic.bitToggle" {
                 try testing.expect(x.load(.SeqCst) & mask == 0);
 
                 // all the previous bits should have not changed (still be toggled back)
-                for (bit_array[0..bit_index], 0..) |_, prev_bit_index| {
+                for (0..bit_index) |prev_bit_index| {
                     const prev_bit = @intCast(std.math.Log2Int(Int), prev_bit_index);
                     const prev_mask = @as(Int, 1) << prev_bit;
                     try testing.expect(x.load(.SeqCst) & prev_mask == 0);


### PR DESCRIPTION
…t with isel