### PR TITLE
Sema: fix @intToPtr of zero value to optional pointer

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -6817,17 +6817,12 @@ pub fn errorSetFromUnsortedNames(
     return new_ty.toType();
 }
 
-/// Supports optionals in addition to pointers.
+/// Supports only pointers, not pointer-like optionals.
 pub fn ptrIntValue(mod: *Module, ty: Type, x: u64) Allocator.Error!Value {
-    return mod.getCoerced(try mod.intValue_u64(Type.usize, x), ty);
-}
-
-/// Supports only pointers. See `ptrIntValue` for pointer-like optional support.
-pub fn ptrIntValue_ptronly(mod: *Module, ty: Type, x: u64) Allocator.Error!Value {
     assert(ty.zigTypeTag(mod) == .Pointer);
     const i = try intern(mod, .{ .ptr = .{
         .ty = ty.toIntern(),
-        .addr = .{ .int = try mod.intValue_u64(Type.usize, x) },
+        .addr = .{ .int = (try mod.intValue_u64(Type.usize, x)).toIntern() },
     } });
     return i.toValue();
 }

--- a/test/behavior/inttoptr.zig
+++ b/test/behavior/inttoptr.zig
@@ -1,4 +1,6 @@
+const std = @import("std");
 const builtin = @import("builtin");
+const expectEqual = std.testing.expectEqual;
 
 test "casting integer address to function pointer" {
     addressToFunction();
@@ -25,4 +27,22 @@ fn forceCompilerAnalyzeBranchHardCodedPtrDereference(x: bool) void {
     } else {
         return;
     }
+}
+
+test "@intToPtr creates null pointer" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+
+    const ptr = @intToPtr(?*u32, 0);
+    try expectEqual(@as(?*u32, null), ptr);
+}
+
+test "@intToPtr creates allowzero zero pointer" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+
+    const ptr = @intToPtr(*allowzero u32, 0);
+    try expectEqual(@as(usize, 0), @ptrToInt(ptr));
 }


### PR DESCRIPTION
Calling into coercion logic here is a little opaque, and more to the point wholly unnecessary. Instead, the (very short) logic is now implemented directly in Sema.

Resolves: #16033