### PR TITLE
Correct cmakedefine implementation

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -226,6 +226,10 @@ pub const build_cases = [_]BuildCase{
         .build_root = "test/standalone/strip_empty_loop",
         .import = @import("standalone/strip_empty_loop/build.zig"),
     },
+    .{
+        .build_root = "test/standalone/cmakedefine",
+        .import = @import("standalone/cmakedefine/build.zig"),
+    },
 };
 
 const std = @import("std");

--- a/test/standalone/cmakedefine/build.zig
+++ b/test/standalone/cmakedefine/build.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const ConfigHeader = std.Build.Step.ConfigHeader;
+
+pub fn build(b: *std.Build) void {
+    const config_header = b.addConfigHeader(
+        .{
+            .style = .{ .cmake = .{ .path = "config.h.cmake" } },
+        },
+        .{
+            .noval = null,
+            .trueval = true,
+            .falseval = false,
+            .zeroval = 0,
+            .oneval = 1,
+            .tenval = 10,
+            .stringval = "test",
+
+            .boolnoval = void{},
+            .booltrueval = true,
+            .boolfalseval = false,
+            .boolzeroval = 0,
+            .booloneval = 1,
+            .booltenval = 10,
+            .boolstringval = "test",
+        },
+    );
+
+    const test_step = b.step("test", "Test it");
+    test_step.makeFn = compare_headers;
+    test_step.dependOn(&config_header.step);
+}
+
+fn compare_headers(step: *std.Build.Step, prog_node: *std.Progress.Node) !void {
+    _ = prog_node;
+    const allocator = step.owner.allocator;
+    const cmake_header_path = "expected.h";
+
+    const config_header_step = step.dependencies.getLast();
+    const config_header = @fieldParentPtr(ConfigHeader, "step", config_header_step);
+
+    const zig_header_path = config_header.output_file.path orelse @panic("Could not locate header file");
+
+    const cwd = std.fs.cwd();
+
+    const cmake_header = try cwd.readFileAlloc(allocator, cmake_header_path, config_header.max_bytes);
+    defer allocator.free(cmake_header);
+
+    const zig_header = try cwd.readFileAlloc(allocator, zig_header_path, config_header.max_bytes);
+    defer allocator.free(zig_header);
+
+    const header_text_index = std.mem.indexOf(u8, zig_header, "\n") orelse @panic("Could not find comment in header filer");
+
+    if (!std.mem.eql(u8, zig_header[header_text_index + 1 ..], cmake_header)) {
+        @panic("processed cmakedefine header does not match expected output");
+    }
+}

--- a/test/standalone/cmakedefine/config.h.cmake
+++ b/test/standalone/cmakedefine/config.h.cmake
@@ -1,0 +1,93 @@
+// cmakedefine
+// undefined
+#cmakedefine noval unreachable
+
+// 1
+#cmakedefine trueval 1
+
+// undefined
+#cmakedefine falseval unreachable
+
+// undefined
+#cmakedefine zeroval unreachable
+
+// 1
+#cmakedefine oneval 1
+
+// 1
+#cmakedefine tenval 1
+
+// 1
+#cmakedefine stringval 1
+
+
+// cmakedefine01
+// 0
+#cmakedefine01 boolnoval
+
+// 1
+#cmakedefine01 booltrueval
+
+// 0
+#cmakedefine01 boolfalseval
+
+// 0
+#cmakedefine01 boolzeroval
+
+// 1
+#cmakedefine01 booloneval
+
+// 1
+#cmakedefine01 booltenval
+
+// 1
+#cmakedefine01 boolstringval
+
+
+// @ substition
+
+// no substition
+// @noval@
+
+// 1
+// @trueval@
+
+// 0
+// @falseval@
+
+// 0
+// @zeroval@
+
+// 1
+// @oneval@
+
+// 10
+// @tenval@
+
+// test
+// @stringval@
+
+
+// ${} substition
+
+// removal
+// ${noval}
+
+// 1
+// ${trueval}
+
+// 0
+// ${falseval}
+
+// 0
+// ${zeroval}
+
+// 1
+// ${oneval}
+
+// 10
+// ${tenval}
+
+// test
+// ${stringval}
+

--- a/test/standalone/cmakedefine/expected.h
+++ b/test/standalone/cmakedefine/expected.h
@@ -1,0 +1,93 @@
+// cmakedefine
+// undefined
+/* #undef noval */
+
+// 1
+#define trueval 1
+
+// undefined
+/* #undef falseval */
+
+// undefined
+/* #undef zeroval */
+
+// 1
+#define oneval 1
+
+// 1
+#define tenval 1
+
+// 1
+#define stringval 1
+
+
+// cmakedefine01
+// 0
+#define boolnoval 0
+
+// 1
+#define booltrueval 1
+
+// 0
+#define boolfalseval 0
+
+// 0
+#define boolzeroval 0
+
+// 1
+#define booloneval 1
+
+// 1
+#define booltenval 1
+
+// 1
+#define boolstringval 1
+
+
+// @ substition
+
+// no substition
+// 
+
+// 1
+// 1
+
+// 0
+// 0
+
+// 0
+// 0
+
+// 1
+// 1
+
+// 10
+// 10
+
+// test
+// test
+
+
+//  substition
+
+// removal
+// 
+
+// 1
+// 1
+
+// 0
+// 0
+
+// 0
+// 0
+
+// 1
+// 1
+
+// 10
+// 10
+
+// test
+// test
+


### PR DESCRIPTION
Changes the implementation behind `cmakedefine` and `cmakedefine01` to match the actual cmake behavior.

Tested against https://github.com/Jan200101/cmakedefine-test, which can configure a test header against cmake, meson and zig.

The diff between the cmake and zig configured header with this PR
```patch
--- cmake_build/test.h  2023-06-14 22:55:53.531659521 +0200
+++ zig-cache/o/9dcd70028e62d4109280ca26a82c002c/config.h       2023-06-14 22:53:41.225032597 +0200
@@ -1,3 +1,4 @@
+/* This file was generated by ConfigHeader using the Zig Build System. */

 // defined as "foo_content"
 #define foo "foo_content"
@@ -46,3 +47,4 @@

 // defined as 0, no value
 #define nofoo 0
+
```

Currently only supports `@var@` substition and not `${var}`.

`@var@` substition is also implemented in a very messy way, and I don't what would be the best way to clean it up, feedback on how to improve it would be useful.
