### PR TITLE
type.Type.eql: remove mod parameter 

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4632,7 +4632,7 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
     try sema.resolveTypeLayout(decl_tv.ty);
 
     if (decl.kind == .@"usingnamespace") {
-        if (!decl_tv.ty.eql(Type.type, mod)) {
+        if (!decl_tv.ty.eql(Type.type)) {
             return sema.fail(&block_scope, ty_src, "expected type, found {}", .{
                 decl_tv.ty.fmt(mod),
             });
@@ -4664,7 +4664,7 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
 
             if (decl.has_tv) {
                 prev_type_has_bits = decl.ty.isFnOrHasRuntimeBits(mod);
-                type_changed = !decl.ty.eql(decl_tv.ty, mod);
+                type_changed = !decl.ty.eql(decl_tv.ty);
                 if (decl.getOwnedFunction(mod)) |prev_func| {
                     prev_is_inline = prev_func.state == .inline_only;
                 }
@@ -4693,7 +4693,7 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
     }
     var type_changed = true;
     if (decl.has_tv) {
-        type_changed = !decl.ty.eql(decl_tv.ty, mod);
+        type_changed = !decl.ty.eql(decl_tv.ty);
     }
     decl.clearValues(mod);
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2690,7 +2690,7 @@ fn coerceResultPtr(
             if (try sema.resolveDefinedValue(block, src, new_ptr)) |ptr_val| {
                 return sema.addConstant(ptr_val);
             }
-            if (pointee_ty.eql(Type.null, sema.mod)) {
+            if (pointee_ty.eql(Type.null)) {
                 const null_inst = try sema.addConstant(Value.null);
                 _ = try block.addBinOp(.store, new_ptr, null_inst);
                 return Air.Inst.Ref.void_value;
@@ -4017,7 +4017,7 @@ fn zirResolveInferredAlloc(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Com
             for (peer_inst_list, placeholders) |peer_inst, placeholder_inst| {
                 const sub_ptr_ty = sema.typeOf(Air.indexToRef(placeholder_inst));
 
-                if (mut_final_ptr_ty.eql(sub_ptr_ty, mod)) {
+                if (mut_final_ptr_ty.eql(sub_ptr_ty)) {
                     // New result location type is the same as the old one; nothing
                     // to do here.
                     continue;
@@ -5772,7 +5772,7 @@ fn analyzeBlockBody(
         const br_operand = sema.air_instructions.items(.data)[br].br.operand;
         const br_operand_src = src;
         const br_operand_ty = sema.typeOf(br_operand);
-        if (br_operand_ty.eql(resolved_ty, mod)) {
+        if (br_operand_ty.eql(resolved_ty)) {
             // No type coercion needed.
             continue;
         }
@@ -7216,7 +7216,7 @@ fn handleTailCall(sema: *Sema, block: *Block, call_src: LazySrcLoc, func_ty: Typ
         });
     }
     const func_decl = mod.declPtr(sema.owner_func.?.owner_decl);
-    if (!func_ty.eql(func_decl.ty, mod)) {
+    if (!func_ty.eql(func_decl.ty)) {
         return sema.fail(block, call_src, "unable to perform tail call: type of function being called '{}' does not match type of calling function '{}'", .{
             func_ty.fmt(mod), func_decl.ty.fmt(mod),
         });
@@ -10388,7 +10388,7 @@ const SwitchProngAnalysis = struct {
                 // Fast path: if all the operands are the same type already, we don't need to hit
                 // PTR! This will also allow us to emit simpler code.
                 const same_types = for (field_tys[1..]) |field_ty| {
-                    if (!field_ty.eql(field_tys[0], sema.mod)) break false;
+                    if (!field_ty.eql(field_tys[0])) break false;
                 } else true;
 
                 const capture_ty = if (same_types) field_tys[0] else capture_ty: {
@@ -15943,7 +15943,7 @@ fn zirCmpEq(
     if (lhs_ty_tag == .Type and rhs_ty_tag == .Type) {
         const lhs_as_type = try sema.analyzeAsType(block, lhs_src, lhs);
         const rhs_as_type = try sema.analyzeAsType(block, rhs_src, rhs);
-        if (lhs_as_type.eql(rhs_as_type, mod) == (op == .eq)) {
+        if (lhs_as_type.eql(rhs_as_type) == (op == .eq)) {
             return Air.Inst.Ref.bool_true;
         } else {
             return Air.Inst.Ref.bool_false;
@@ -21266,7 +21266,7 @@ fn ptrCastFull(
                     .len = arr_len.toIntern(),
                 } })).toValue());
             } else {
-                assert(dest_ptr_ty.eql(dest_ty, mod));
+                assert(dest_ptr_ty.eql(dest_ty));
                 return sema.addConstant(try mod.getCoerced(ptr_val, dest_ty));
             }
         }
@@ -21318,7 +21318,7 @@ fn ptrCastFull(
                 .operand = ptr,
             } },
         });
-        if (intermediate_ty.eql(dest_ptr_ty, mod)) {
+        if (intermediate_ty.eql(dest_ptr_ty)) {
             // We only changed the address space, so no need for a bitcast
             break :ptr intermediate;
         }
@@ -21344,7 +21344,7 @@ fn ptrCastFull(
             } },
         });
     } else {
-        assert(dest_ptr_ty.eql(dest_ty, mod));
+        assert(dest_ptr_ty.eql(dest_ty));
         return result_ptr;
     }
 }
@@ -23192,7 +23192,7 @@ fn analyzeMinMax(
         switch (bounds_status) {
             .unknown, .defined => refine_bounds: {
                 const ty = sema.typeOf(operand);
-                if (!ty.scalarType(mod).isInt(mod) and !ty.scalarType(mod).eql(Type.comptime_int, mod)) {
+                if (!ty.scalarType(mod).isInt(mod) and !ty.scalarType(mod).eql(Type.comptime_int)) {
                     bounds_status = .non_integral;
                     break :refine_bounds;
                 }
@@ -23263,7 +23263,7 @@ fn analyzeMinMax(
         const val = (try sema.resolveMaybeUndefVal(ct_minmax_ref)).?;
         const orig_ty = sema.typeOf(ct_minmax_ref);
 
-        if (opt_runtime_idx == null and orig_ty.scalarType(mod).eql(Type.comptime_int, mod)) {
+        if (opt_runtime_idx == null and orig_ty.scalarType(mod).eql(Type.comptime_int)) {
             // If all arguments were `comptime_int`, and there are no runtime args, we'll preserve that type
             break :refine;
         }
@@ -23360,7 +23360,7 @@ fn analyzeMinMax(
         .child = refined_scalar_ty.toIntern(),
     }) else refined_scalar_ty;
 
-    if (!refined_ty.eql(unrefined_ty, mod)) {
+    if (!refined_ty.eql(unrefined_ty)) {
         // We've reduced the type - cast the result down
         return block.addTyOp(.intcast, refined_ty, cur_minmax.?);
     }
@@ -25643,7 +25643,7 @@ fn fieldCallBind(
                                 first_param_type.zigTypeTag(mod) == .Pointer and
                                 (first_param_type.ptrSize(mod) == .One or
                                 first_param_type.ptrSize(mod) == .C) and
-                                first_param_type.childType(mod).eql(concrete_ty, mod)))
+                                first_param_type.childType(mod).eql(concrete_ty)))
                         {
                         // zig fmt: on
                             // Note that if the param type is generic poison, we know that it must
@@ -25655,7 +25655,7 @@ fn fieldCallBind(
                                 .func_inst = decl_val,
                                 .arg0_inst = object_ptr,
                             } };
-                        } else if (first_param_type.eql(concrete_ty, mod)) {
+                        } else if (first_param_type.eql(concrete_ty)) {
                             const deref = try sema.analyzeLoad(block, src, object_ptr, src);
                             return .{ .method = .{
                                 .func_inst = decl_val,
@@ -25663,7 +25663,7 @@ fn fieldCallBind(
                             } };
                         } else if (first_param_type.zigTypeTag(mod) == .Optional) {
                             const child = first_param_type.optionalChild(mod);
-                            if (child.eql(concrete_ty, mod)) {
+                            if (child.eql(concrete_ty)) {
                                 const deref = try sema.analyzeLoad(block, src, object_ptr, src);
                                 return .{ .method = .{
                                     .func_inst = decl_val,
@@ -25671,7 +25671,7 @@ fn fieldCallBind(
                                 } };
                             } else if (child.zigTypeTag(mod) == .Pointer and
                                 child.ptrSize(mod) == .One and
-                                child.childType(mod).eql(concrete_ty, mod))
+                                child.childType(mod).eql(concrete_ty))
                             {
                                 return .{ .method = .{
                                     .func_inst = decl_val,
@@ -25679,7 +25679,7 @@ fn fieldCallBind(
                                 } };
                             }
                         } else if (first_param_type.zigTypeTag(mod) == .ErrorUnion and
-                            first_param_type.errorUnionPayload(mod).eql(concrete_ty, mod))
+                            first_param_type.errorUnionPayload(mod).eql(concrete_ty))
                         {
                             const deref = try sema.analyzeLoad(block, src, object_ptr, src);
                             return .{ .method = .{
@@ -26851,7 +26851,7 @@ fn coerceExtra(
     const inst_ty = try sema.resolveTypeFields(sema.typeOf(inst));
     const target = mod.getTarget();
     // If the types are the same, we can return the operand.
-    if (dest_ty.eql(inst_ty, mod))
+    if (dest_ty.eql(inst_ty))
         return inst;
 
     const maybe_inst_val = try sema.resolveMaybeUndefVal(inst);
@@ -27349,7 +27349,7 @@ fn coerceExtra(
             .Union => blk: {
                 // union to its own tag type
                 const union_tag_ty = inst_ty.unionTagType(mod) orelse break :blk;
-                if (union_tag_ty.eql(dest_ty, mod)) {
+                if (union_tag_ty.eql(dest_ty)) {
                     return sema.unionToTag(block, dest_ty, inst, inst_src);
                 }
             },
@@ -27902,7 +27902,7 @@ fn coerceInMemoryAllowed(
 ) CompileError!InMemoryCoercionResult {
     const mod = sema.mod;
 
-    if (dest_ty.eql(src_ty, mod))
+    if (dest_ty.eql(src_ty))
         return .ok;
 
     const dest_tag = dest_ty.zigTypeTag(mod);
@@ -28631,7 +28631,7 @@ fn obtainBitCastedVectorPtr(sema: *Sema, ptr: Air.Inst.Ref) ?Air.Inst.Ref {
 
     // We have a pointer-to-array and a pointer-to-vector. If the elements and
     // lengths match, return the result.
-    if (array_ty.childType(mod).eql(vector_ty.childType(mod), sema.mod) and
+    if (array_ty.childType(mod).eql(vector_ty.childType(mod)) and
         array_ty.arrayLen(mod) == vector_ty.vectorLen(mod))
     {
         return ptr_ref;
@@ -29391,7 +29391,7 @@ fn beginComptimePtrLoad(
                 // our parent is not an elem_ptr with the same elem_ty, since that would be "unflattened"
                 switch (mod.intern_pool.indexToKey(elem_ptr.base)) {
                     .ptr => |base_ptr| switch (base_ptr.addr) {
-                        .elem => |base_elem| assert(!mod.intern_pool.typeOf(base_elem.base).toType().elemType2(mod).eql(elem_ty, mod)),
+                        .elem => |base_elem| assert(!mod.intern_pool.typeOf(base_elem.base).toType().elemType2(mod).eql(elem_ty)),
                         else => {},
                     },
                     else => {},
@@ -29428,7 +29428,7 @@ fn beginComptimePtrLoad(
                 if (maybe_array_ty) |load_ty| {
                     // It's possible that we're loading a [N]T, in which case we'd like to slice
                     // the pointee array directly from our parent array.
-                    if (load_ty.isArrayOrVector(mod) and load_ty.childType(mod).eql(elem_ty, mod)) {
+                    if (load_ty.isArrayOrVector(mod) and load_ty.childType(mod).eql(elem_ty)) {
                         const len = try sema.usizeCast(block, src, load_ty.arrayLenIncludingSentinel(mod));
                         const elem_idx = try sema.usizeCast(block, src, elem_ptr.index);
                         deref.pointee = if (elem_ptr.index + len <= check_len) TypedValue{
@@ -29577,7 +29577,7 @@ fn bitCastVal(
     buffer_offset: usize,
 ) !?Value {
     const mod = sema.mod;
-    if (old_ty.eql(new_ty, mod)) return val;
+    if (old_ty.eql(new_ty)) return val;
 
     // For types with well-defined memory layouts, we serialize them a byte buffer,
     // then deserialize to the new type.
@@ -32181,7 +32181,7 @@ fn resolvePeerTypesInner(
         .nullable => {
             for (peer_tys, 0..) |opt_ty, i| {
                 const ty = opt_ty orelse continue;
-                if (!ty.eql(Type.null, mod)) return .{ .conflict = .{
+                if (!ty.eql(Type.null)) return .{ .conflict = .{
                     .peer_idx_a = strat_reason,
                     .peer_idx_b = i,
                 } };
@@ -32268,7 +32268,7 @@ fn resolvePeerTypesInner(
                     .peer_idx_b = i,
                 } };
 
-                if (!ty.childType(mod).eql(elem_ty, mod)) {
+                if (!ty.childType(mod).eql(elem_ty)) {
                     return .{ .conflict = .{
                         .peer_idx_a = first_arr_idx,
                         .peer_idx_b = i,
@@ -32813,11 +32813,11 @@ fn resolvePeerTypesInner(
                     .Enum => switch (ty.zigTypeTag(mod)) {
                         .EnumLiteral => {},
                         .Enum => {
-                            if (!ty.eql(cur_ty, mod)) return generic_err;
+                            if (!ty.eql(cur_ty)) return generic_err;
                         },
                         .Union => {
                             const tag_ty = ty.unionTagTypeHypothetical(mod);
-                            if (!tag_ty.eql(cur_ty, mod)) return generic_err;
+                            if (!tag_ty.eql(cur_ty)) return generic_err;
                             opt_cur_ty = ty;
                             cur_ty_idx = i;
                         },
@@ -32827,10 +32827,10 @@ fn resolvePeerTypesInner(
                         .EnumLiteral => {},
                         .Enum => {
                             const cur_tag_ty = cur_ty.unionTagTypeHypothetical(mod);
-                            if (!ty.eql(cur_tag_ty, mod)) return generic_err;
+                            if (!ty.eql(cur_tag_ty)) return generic_err;
                         },
                         .Union => {
-                            if (!ty.eql(cur_ty, mod)) return generic_err;
+                            if (!ty.eql(cur_ty)) return generic_err;
                         },
                         else => unreachable,
                     },
@@ -32969,7 +32969,7 @@ fn resolvePeerTypesInner(
                     },
                     .Float => {
                         if (opt_cur_ty) |cur_ty| {
-                            if (cur_ty.eql(ty, mod)) continue;
+                            if (cur_ty.eql(ty)) continue;
                             // Recreate the type so we eliminate any c_longdouble
                             const bits = @max(cur_ty.floatBits(target), ty.floatBits(target));
                             opt_cur_ty = switch (bits) {
@@ -33142,7 +33142,7 @@ fn resolvePeerTypesInner(
             for (peer_tys, 0..) |opt_ty, i| {
                 const ty = opt_ty orelse continue;
                 if (expect_ty) |expect| {
-                    if (!ty.eql(expect, mod)) return .{ .conflict = .{
+                    if (!ty.eql(expect)) return .{ .conflict = .{
                         .peer_idx_a = first_idx,
                         .peer_idx_b = i,
                     } };
@@ -33205,7 +33205,7 @@ fn typeIsArrayLike(sema: *Sema, ty: Type) ?ArrayLike {
             if (!ty.isTuple(mod)) return null;
             const elem_ty = ty.structFieldType(0, mod);
             for (1..field_count) |i| {
-                if (!ty.structFieldType(i, mod).eql(elem_ty, mod)) {
+                if (!ty.structFieldType(i, mod).eql(elem_ty)) {
                     return null;
                 }
             }
@@ -35363,7 +35363,7 @@ pub fn typeHasOnePossibleValue(sema: *Sema, ty: Type) CompileError!?Value {
                                 field_val.* = field.default_val;
                                 continue;
                             }
-                            if (field.ty.eql(resolved_ty, sema.mod)) {
+                            if (field.ty.eql(resolved_ty)) {
                                 const msg = try Module.ErrorMsg.create(
                                     sema.gpa,
                                     s.srcLoc(sema.mod),
@@ -35418,7 +35418,7 @@ pub fn typeHasOnePossibleValue(sema: *Sema, ty: Type) CompileError!?Value {
                         return only.toValue();
                     }
                     const only_field = fields[0];
-                    if (only_field.ty.eql(resolved_ty, sema.mod)) {
+                    if (only_field.ty.eql(resolved_ty)) {
                         const msg = try Module.ErrorMsg.create(
                             sema.gpa,
                             union_obj.srcLoc(sema.mod),

--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -120,7 +120,7 @@ pub fn print(
                 const elem_ty = ty.elemType2(mod);
                 const len = payload.len.toUnsignedInt(mod);
 
-                if (elem_ty.eql(Type.u8, mod)) str: {
+                if (elem_ty.eql(Type.u8)) str: {
                     const max_len: usize = @min(len, max_string_len);
                     var buf: [max_string_len]u8 = undefined;
 
@@ -258,7 +258,7 @@ pub fn print(
                     }
                     const elem_ty = ptr_ty.child.toType();
                     const len = ptr.len.toValue().toUnsignedInt(mod);
-                    if (elem_ty.eql(Type.u8, mod)) str: {
+                    if (elem_ty.eql(Type.u8)) str: {
                         const max_len = @min(len, max_string_len);
                         var buf: [max_string_len]u8 = undefined;
                         for (buf[0..max_len], 0..) |*c, i| {
@@ -440,7 +440,7 @@ fn printAggregate(
         const elem_ty = ty.elemType2(mod);
         const len = ty.arrayLen(mod);
 
-        if (elem_ty.eql(Type.u8, mod)) str: {
+        if (elem_ty.eql(Type.u8)) str: {
             const max_len: usize = @min(len, max_string_len);
             var buf: [max_string_len]u8 = undefined;
 

--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -32,15 +32,6 @@ pub fn copy(self: TypedValue, arena: Allocator) error{OutOfMemory}!TypedValue {
     };
 }
 
-pub fn eql(a: TypedValue, b: TypedValue, mod: *Module) bool {
-    if (a.ty.toIntern() != b.ty.toIntern()) return false;
-    return a.val.eql(b.val, a.ty, mod);
-}
-
-pub fn hash(tv: TypedValue, hasher: *std.hash.Wyhash, mod: *Module) void {
-    return tv.val.hash(tv.ty, hasher, mod);
-}
-
 pub fn intFromEnum(tv: TypedValue, mod: *Module) Allocator.Error!Value {
     return tv.val.intFromEnum(tv.ty, mod);
 }

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -1421,7 +1421,7 @@ fn minMax(
         .Float => return self.fail("TODO ARM min/max on floats", .{}),
         .Vector => return self.fail("TODO ARM min/max on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 var lhs_reg: Register = undefined;
@@ -1914,7 +1914,7 @@ fn addSub(
         .Float => return self.fail("TODO binary operations on floats", .{}),
         .Vector => return self.fail("TODO binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 const lhs_immediate = try lhs_bind.resolveToImmediate(self);
@@ -1974,7 +1974,7 @@ fn mul(
     switch (lhs_ty.zigTypeTag(mod)) {
         .Vector => return self.fail("TODO binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 // TODO add optimisations for multiplication
@@ -2023,7 +2023,7 @@ fn divTrunc(
         .Float => return self.fail("TODO div on floats", .{}),
         .Vector => return self.fail("TODO div on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 switch (int_info.signedness) {
@@ -2057,7 +2057,7 @@ fn divFloor(
         .Float => return self.fail("TODO div on floats", .{}),
         .Vector => return self.fail("TODO div on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 switch (int_info.signedness) {
@@ -2090,7 +2090,7 @@ fn divExact(
         .Float => return self.fail("TODO div on floats", .{}),
         .Vector => return self.fail("TODO div on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 switch (int_info.signedness) {
@@ -2126,7 +2126,7 @@ fn rem(
         .Float => return self.fail("TODO rem/mod on floats", .{}),
         .Vector => return self.fail("TODO rem/mod on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 var lhs_reg: Register = undefined;
@@ -2249,7 +2249,7 @@ fn bitwise(
     switch (lhs_ty.zigTypeTag(mod)) {
         .Vector => return self.fail("TODO binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 // TODO implement bitwise operations with immediates
@@ -2400,7 +2400,7 @@ fn ptrArithmetic(
     const mod = self.bin_file.options.module.?;
     switch (lhs_ty.zigTypeTag(mod)) {
         .Pointer => {
-            assert(rhs_ty.eql(Type.usize, mod));
+            assert(rhs_ty.eql(Type.usize));
 
             const ptr_ty = lhs_ty;
             const elem_ty = switch (ptr_ty.ptrSize(mod)) {
@@ -2535,7 +2535,7 @@ fn airOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement add_with_overflow/sub_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 switch (int_info.bits) {
                     1...31, 33...63 => {
@@ -2663,7 +2663,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement mul_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 if (int_info.bits <= 32) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -1381,7 +1381,7 @@ fn minMax(
         .Float => return self.fail("TODO ARM min/max on floats", .{}),
         .Vector => return self.fail("TODO ARM min/max on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 var lhs_reg: Register = undefined;
@@ -1600,7 +1600,7 @@ fn airOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement add_with_overflow/sub_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 if (int_info.bits < 32) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);
@@ -1713,7 +1713,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement mul_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 if (int_info.bits <= 16) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);
@@ -3393,7 +3393,7 @@ fn addSub(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 const lhs_immediate = try lhs_bind.resolveToImmediate(self);
@@ -3449,7 +3449,7 @@ fn mul(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 // TODO add optimisations for multiplication
@@ -3498,7 +3498,7 @@ fn divTrunc(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
@@ -3541,7 +3541,7 @@ fn divFloor(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
@@ -3606,7 +3606,7 @@ fn rem(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
@@ -3730,7 +3730,7 @@ fn bitwise(
     switch (lhs_ty.zigTypeTag(mod)) {
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 const lhs_immediate = try lhs_bind.resolveToImmediate(self);
@@ -3890,7 +3890,7 @@ fn ptrArithmetic(
     const mod = self.bin_file.options.module.?;
     switch (lhs_ty.zigTypeTag(mod)) {
         .Pointer => {
-            assert(rhs_ty.eql(Type.usize, mod));
+            assert(rhs_ty.eql(Type.usize));
 
             const ptr_ty = lhs_ty;
             const elem_ty = switch (ptr_ty.ptrSize(mod)) {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1082,7 +1082,7 @@ fn binOp(
                 .Float => return self.fail("TODO binary operations on floats", .{}),
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    assert(lhs_ty.eql(rhs_ty, mod));
+                    assert(lhs_ty.eql(rhs_ty));
                     const int_info = lhs_ty.intInfo(mod);
                     if (int_info.bits <= 64) {
                         // TODO immediate operands
@@ -1835,7 +1835,7 @@ fn airCmp(self: *Self, inst: Air.Inst.Index, op: math.CompareOperator) !void {
         return self.finishAir(inst, .dead, .{ bin_op.lhs, bin_op.rhs, .none });
     const ty = self.typeOf(bin_op.lhs);
     const mod = self.bin_file.options.module.?;
-    assert(ty.eql(self.typeOf(bin_op.rhs), mod));
+    assert(ty.eql(self.typeOf(bin_op.rhs)));
     if (ty.zigTypeTag(mod) == .ErrorSet)
         return self.fail("TODO implement cmp for errors", .{});
 

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -770,7 +770,7 @@ fn airAddSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement add_with_overflow/sub_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 switch (int_info.bits) {
                     32, 64 => {
@@ -1902,7 +1902,7 @@ fn airMod(self: *Self, inst: Air.Inst.Index) !void {
     const rhs = try self.resolveInst(bin_op.rhs);
     const lhs_ty = self.typeOf(bin_op.lhs);
     const rhs_ty = self.typeOf(bin_op.rhs);
-    assert(lhs_ty.eql(rhs_ty, self.bin_file.options.module.?));
+    assert(lhs_ty.eql(rhs_ty));
 
     if (self.liveness.isUnused(inst))
         return self.finishAir(inst, .dead, .{ bin_op.lhs, bin_op.rhs, .none });
@@ -2054,7 +2054,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement mul_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 switch (int_info.bits) {
                     1...32 => {
@@ -2878,7 +2878,7 @@ fn binOp(
                 .Float => return self.fail("TODO binary operations on floats", .{}),
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    assert(lhs_ty.eql(rhs_ty, mod));
+                    assert(lhs_ty.eql(rhs_ty));
                     const int_info = lhs_ty.intInfo(mod);
                     if (int_info.bits <= 64) {
                         // Only say yes if the operation is
@@ -2968,7 +2968,7 @@ fn binOp(
             switch (lhs_ty.zigTypeTag(mod)) {
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    assert(lhs_ty.eql(rhs_ty, mod));
+                    assert(lhs_ty.eql(rhs_ty));
                     const int_info = lhs_ty.intInfo(mod);
                     if (int_info.bits <= 64) {
                         const rhs_immediate_ok = switch (tag) {
@@ -4336,7 +4336,7 @@ fn minMax(
     rhs_ty: Type,
 ) InnerError!MCValue {
     const mod = self.bin_file.options.module.?;
-    assert(lhs_ty.eql(rhs_ty, mod));
+    assert(lhs_ty.eql(rhs_ty));
     switch (lhs_ty.zigTypeTag(mod)) {
         .Float => return self.fail("TODO min/max on floats", .{}),
         .Vector => return self.fail("TODO min/max on vectors", .{}),

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -561,7 +561,7 @@ pub const DeclGen = struct {
         // them).  The analysis until now should ensure that the C function
         // pointers are compatible.  If they are not, then there is a bug
         // somewhere and we should let the C compiler tell us about it.
-        const need_typecast = if (ty.castPtrToFn(mod)) |_| false else !ty.childType(mod).eql(decl.ty, mod);
+        const need_typecast = if (ty.castPtrToFn(mod)) |_| false else !ty.childType(mod).eql(decl.ty);
         if (need_typecast) {
             try writer.writeAll("((");
             try dg.renderType(writer, ty);
@@ -863,7 +863,7 @@ pub const DeclGen = struct {
                 },
                 .Array, .Vector => {
                     const ai = ty.arrayInfo(mod);
-                    if (ai.elem_type.eql(Type.u8, mod)) {
+                    if (ai.elem_type.eql(Type.u8)) {
                         var literal = stringLiteral(writer);
                         try literal.start();
                         const c_len = ty.arrayLenIncludingSentinel(mod);
@@ -1218,7 +1218,7 @@ pub const DeclGen = struct {
                     const max_string_initializer_len = 65535;
 
                     const ai = ty.arrayInfo(mod);
-                    if (ai.elem_type.eql(Type.u8, mod)) {
+                    if (ai.elem_type.eql(Type.u8)) {
                         if (ai.len <= max_string_initializer_len) {
                             var literal = stringLiteral(writer);
                             try literal.start();
@@ -3625,7 +3625,7 @@ fn airStore(f: *Function, inst: Air.Inst.Index, safety: bool) !CValue {
     if (need_memcpy) {
         // For this memcpy to safely work we need the rhs to have the same
         // underlying type as the lhs (i.e. they must both be arrays of the same underlying type).
-        assert(src_ty.eql(ptr_info.child.toType(), f.object.dg.module));
+        assert(src_ty.eql(ptr_info.child.toType()));
 
         // If the source is a constant, writeCValue will emit a brace initialization
         // so work around this by initializing into new local.
@@ -5434,7 +5434,7 @@ fn airStructFieldVal(f: *Function, inst: Air.Inst.Index) !CValue {
                 if (cant_cast) try writer.writeByte(')');
                 try f.object.dg.renderBuiltinInfo(writer, field_int_ty, .bits);
                 try writer.writeAll(");\n");
-                if (inst_ty.eql(field_int_ty, f.object.dg.module)) return temp_local;
+                if (inst_ty.eql(field_int_ty)) return temp_local;
 
                 const local = try f.allocLocal(inst, inst_ty);
                 try writer.writeAll("memcpy(");

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -1887,8 +1887,8 @@ pub const DeclGen = struct {
 
         const result_ty_ref = try self.resolveType(ty, .direct);
 
-        assert(self.typeOf(bin_op.lhs).eql(ty, self.module));
-        assert(self.typeOf(bin_op.rhs).eql(ty, self.module));
+        assert(self.typeOf(bin_op.lhs).eql(ty));
+        assert(self.typeOf(bin_op.rhs).eql(ty));
 
         // Binary operations are generally applicable to both scalar and vector operations
         // in SPIR-V, but int and float versions of operations require different opcodes.
@@ -2272,7 +2272,7 @@ pub const DeclGen = struct {
         const rhs_id = try self.resolve(bin_op.rhs);
         const bool_ty_id = try self.resolveTypeId(Type.bool);
         const ty = self.typeOf(bin_op.lhs);
-        assert(ty.eql(self.typeOf(bin_op.rhs), self.module));
+        assert(ty.eql(self.typeOf(bin_op.rhs)));
 
         return try self.cmp(op, bool_ty_id, ty, lhs_id, rhs_id);
     }

--- a/src/type.zig
+++ b/src/type.zig
@@ -112,8 +112,7 @@ pub const Type = struct {
         };
     }
 
-    pub fn eql(a: Type, b: Type, mod: *const Module) bool {
-        _ = mod; // TODO: remove this parameter
+    pub fn eql(a: Type, b: Type) bool {
         // The InternPool data structure hashes based on Key to make interned objects
         // unique. An Index can be treated simply as u32 value for the
         // purpose of Type/Value hashing and equality.

--- a/src/value.zig
+++ b/src/value.zig
@@ -1696,7 +1696,7 @@ pub const Value = struct {
         const ptr_val = switch (mod.intern_pool.indexToKey(val.toIntern())) {
             .ptr => |ptr| ptr: {
                 switch (ptr.addr) {
-                    .elem => |elem| if (mod.intern_pool.typeOf(elem.base).toType().elemType2(mod).eql(elem_ty, mod))
+                    .elem => |elem| if (mod.intern_pool.typeOf(elem.base).toType().elemType2(mod).eql(elem_ty))
                         return (try mod.intern(.{ .ptr = .{
                             .ty = elem_ptr_ty.toIntern(),
                             .addr = .{ .elem = .{


### PR DESCRIPTION
I was gonna do more than this (namely remove `Type.Payload`) but that quickly turned out to be a bit too much to do all at once.