### PR TITLE
std.Uri: Don't double-escape escaped query parameters

### DIFF
--- a/lib/std/Uri.zig
+++ b/lib/std/Uri.zig
@@ -443,7 +443,7 @@ fn isPathChar(c: u8) bool {
 }
 
 fn isQueryChar(c: u8) bool {
-    return isPathChar(c) or c == '?';
+    return isPathChar(c) or c == '?' or c == '%';
 }
 
 fn isQuerySeparator(c: u8) bool {

--- a/lib/std/Uri.zig
+++ b/lib/std/Uri.zig
@@ -672,3 +672,13 @@ test "URI unescaping" {
 
     try std.testing.expectEqualSlices(u8, expected, actual);
 }
+
+test "URI query escaping" {
+    const address = "https://objects.githubusercontent.com/?response-content-type=application%2Foctet-stream";
+    const parsed = try Uri.parse(address);
+
+    // format the URI to escape it
+    const formatted_uri = try std.fmt.allocPrint(std.testing.allocator, "{}", .{parsed});
+    defer std.testing.allocator.free(formatted_uri);
+    try std.testing.expectEqualStrings("/?response-content-type=application%2Foctet-stream", formatted_uri);
+}


### PR DESCRIPTION
Zig's HTTP client breaks down when redirected to a URL with escaped query parameters. It seems to be doubly escaping them; this PR simply exempts the `%` character from being escaped in query parameters. I'm not sure if this will have unanticipated effects; we could also try a more complicated fix by looking ahead to see if the % in question is part of an escape sequence (and escaping it only if it's not).