### PR TITLE
Sema: catch invalid asm input operands

### DIFF
--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -989,6 +989,14 @@ pub const SrcLoc = struct {
                 const node_datas = tree.nodes.items(.data);
                 return tree.nodeToSpan(node_datas[asm_output].lhs);
             },
+            .asm_input_op => |asm_input_op| {
+                const tree = try src_loc.file_scope.getTree(gpa);
+                const node = src_loc.relativeToNodeIndex(asm_input_op.asm_node_offset);
+                const full = tree.fullAsm(node).?;
+                const asm_input = full.inputs[asm_input_op.input_index];
+                const node_datas = tree.nodes.items(.data);
+                return tree.nodeToSpan(node_datas[asm_input].lhs);
+            },
 
             .node_offset_if_cond => |node_off| {
                 const tree = try src_loc.file_scope.getTree(gpa);
@@ -1795,6 +1803,16 @@ pub const LazySrcLoc = struct {
         /// base node, which points to inline assembly AST node. Next, navigate
         /// to the return type expression.
         node_offset_asm_ret_ty: i32,
+        /// The source location points to an input operand of an inline assembly
+        /// expression, found by taking this AST node index offset from the containing
+        /// Decl AST node, which points to inline assembly AST node. Next, navigate
+        /// to the input operand expression.
+        asm_input_op: struct {
+            /// Points to the asm AST node.
+            asm_node_offset: i32,
+            /// Picks one of the inputs from the asm.
+            input_index: u32,
+        },
         /// The source location points to the condition expression of an if
         /// expression, found by taking this AST node index offset from the containing
         /// base node, which points to an if expression AST node. Next, navigate

--- a/test/behavior/asm.zig
+++ b/test/behavior/asm.zig
@@ -150,12 +150,24 @@ test "struct/array/union types as input values" {
     ); // fails
     asm volatile (""
         :
-        : [_] "m" (@as(struct { x: u32, y: u8 }, undefined)),
+        : [_] "m" (@as(packed struct { x: u32, y: u8 }, undefined)),
     ); // fails
+    // TODO: CBE struggles with unions here
+    if (builtin.zig_backend != .stage2_c)
+        asm volatile (""
+            :
+            : [_] "m" (@as(packed union { x: u32, y: u8 }, undefined)),
+        ); // fails
     asm volatile (""
         :
-        : [_] "m" (@as(union { x: u32, y: u8 }, undefined)),
+        : [_] "m" (@as(extern struct { x: u32, y: u8 }, undefined)),
     ); // fails
+    // TODO: CBE struggles with unions here
+    if (builtin.zig_backend != .stage2_c)
+        asm volatile (""
+            :
+            : [_] "m" (@as(extern union { x: u32, y: u8 }, undefined)),
+        ); // fails
 }
 
 extern fn this_is_my_alias() i32;

--- a/test/cases/compile_errors/bad_asm_input_operands.zig
+++ b/test/cases/compile_errors/bad_asm_input_operands.zig
@@ -1,0 +1,70 @@
+export fn a() void {
+    asm volatile (""
+        :
+        : [_] "{al}" (u8),
+    );
+}
+export fn b() void {
+    asm volatile (""
+        :
+        : [_] "{a}" (0),
+          [_] "{x}" (&&void),
+    );
+}
+export fn c() void {
+    const A = struct {};
+    asm volatile (""
+        :
+        : [_] "{x}" (1),
+          [_] "{x}" (A{}),
+    );
+}
+export fn d() void {
+    const A = struct { x: u8 };
+    asm volatile (""
+        :
+        : [_] "{x}" (((packed struct { x: u8 }){ .x = 1 })),
+          [_] "{x}" (extern struct { x: u8 }{ .x = 1 }),
+          [_] "{x}" (A{ .x = 1 }),
+    );
+}
+export fn e() void {
+    asm volatile (""
+        :
+        : [_] "{x}" (@Vector(3, u8){ 1, 2, 3 }),
+          [_] "{x}" ([2]*const type{ &u8, &u8 }),
+    );
+}
+export fn f() void {
+    asm volatile (""
+        :
+        : [_] "{x}" (undefined),
+    );
+}
+export fn g() void {
+    asm volatile (""
+        :
+        : [_] "{x}" ({}),
+    );
+}
+export fn h() void {
+    asm volatile (""
+        :
+        : [_] "{x}" (@as([]const u8, "hello")),
+    );
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:23: error: type 'type' is comptime-only and cannot be used for an assembly input operand
+// :11:22: error: type '*const *const type' is comptime-only and cannot be used for an assembly input operand
+// :19:23: error: type 'tmp.c.A' does not have runtime bits and cannot be used for an assembly input operand
+// :15:15: note: struct declared here
+// :28:23: error: type 'tmp.d.A' does not have a well-defined memory layout and cannot be used for an assembly input operand
+// :23:15: note: struct declared here
+// :35:36: error: type '[2]*const type' is comptime-only and cannot be used for an assembly input operand
+// :41:22: error: type '@TypeOf(undefined)' is comptime-only and cannot be used for an assembly input operand
+// :47:22: error: type 'void' does not have runtime bits and cannot be used for an assembly input operand
+// :53:22: error: type '[]const u8' does not have a well-defined memory layout and cannot be used for an assembly input operand


### PR DESCRIPTION
```
$ zig-out/bin/zig test test/cases/compile_errors/non_sized_asm_input_operand.zig
test/cases/compile_errors/non_sized_asm_input_operand.zig:4:23: error: input operand of type 'type' is not sized
        : [_] "{al}" (u8),
                      ^~
test/cases/compile_errors/non_sized_asm_input_operand.zig:12:22: error: input operand of type 'type' is not sized
          [_] "{x}" (void),
                     ^~~~
test/cases/compile_errors/non_sized_asm_input_operand.zig:19:22: error: input operand of type 'type' is not sized
        : [_] "{x}" (enum {}),
                     ^~~~~~~
```
I don't know if disallowing non-sized types is the best solution because for example RISC-V has a zero register that is hardwired to zero so `: [x0] "{x0}" (@as(u0, 0)),` in a way could be valid but `u0` is non-sized so it won't work.
At the same time though you can argue that anything that isn't sized can't actually be in a register.

Fixes #7843 (wasn't an issue with just stage1 btw, stage2 too segfaults without this patch)