### PR TITLE
fix bad return types for BSDs getdents and debitrot openbsd

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -624,7 +624,7 @@ const PosixThreadImpl = struct {
             .openbsd => {
                 var count: c_int = undefined;
                 var count_size: usize = @sizeOf(c_int);
-                const mib = [_]c_int{ os.CTL.HW, os.system.HW_NCPUONLINE };
+                const mib = [_]c_int{ os.CTL.HW, os.system.HW.NCPUONLINE };
                 os.sysctl(&mib, &count, &count_size, null, 0) catch |err| switch (err) {
                     error.NameTooLong, error.UnknownName => unreachable,
                     else => |e| return e,

--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -9,7 +9,7 @@ pub fn _errno() *c_int {
     return &errno;
 }
 
-pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) usize;
+pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) c_int;
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;
 pub extern "c" fn pipe2(fds: *[2]fd_t, flags: u32) c_int;

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -75,7 +75,7 @@ pub const _errno = __error;
 
 pub extern "c" var malloc_options: [*:0]const u8;
 
-pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) usize;
+pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) isize;
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;
 pub extern "c" fn getentropy(buf_ptr: [*]u8, buf_len: usize) c_int;

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -16,7 +16,7 @@ pub extern "c" fn arc4random_buf(buf: [*]u8, len: usize) void;
 pub extern "c" fn getthrid() pid_t;
 pub extern "c" fn pipe2(fds: *[2]fd_t, flags: u32) c_int;
 
-pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) usize;
+pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) c_int;
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 
 pub const pthread_mutex_t = extern struct {
@@ -1606,31 +1606,34 @@ pub const KERN = struct {
     pub const PROC_NENV = 4;
 };
 
-pub const HW_MACHINE = 1;
-pub const HW_MODEL = 2;
-pub const HW_NCPU = 3;
-pub const HW_BYTEORDER = 4;
-pub const HW_PHYSMEM = 5;
-pub const HW_USERMEM = 6;
-pub const HW_PAGESIZE = 7;
-pub const HW_DISKNAMES = 8;
-pub const HW_DISKSTATS = 9;
-pub const HW_DISKCOUNT = 10;
-pub const HW_SENSORS = 11;
-pub const HW_CPUSPEED = 12;
-pub const HW_SETPERF = 13;
-pub const HW_VENDOR = 14;
-pub const HW_PRODUCT = 15;
-pub const HW_VERSION = 16;
-pub const HW_SERIALNO = 17;
-pub const HW_UUID = 18;
-pub const HW_PHYSMEM64 = 19;
-pub const HW_USERMEM64 = 20;
-pub const HW_NCPUFOUND = 21;
-pub const HW_ALLOWPOWERDOWN = 22;
-pub const HW_PERFPOLICY = 23;
-pub const HW_SMT = 24;
-pub const HW_NCPUONLINE = 25;
+pub const HW = struct {
+    pub const MACHINE = 1;
+    pub const MODEL = 2;
+    pub const NCPU = 3;
+    pub const BYTEORDER = 4;
+    pub const PHYSMEM = 5;
+    pub const USERMEM = 6;
+    pub const PAGESIZE = 7;
+    pub const DISKNAMES = 8;
+    pub const DISKSTATS = 9;
+    pub const DISKCOUNT = 10;
+    pub const SENSORS = 11;
+    pub const CPUSPEED = 12;
+    pub const SETPERF = 13;
+    pub const VENDOR = 14;
+    pub const PRODUCT = 15;
+    pub const VERSION = 16;
+    pub const SERIALNO = 17;
+    pub const UUID = 18;
+    pub const PHYSMEM64 = 19;
+    pub const USERMEM64 = 20;
+    pub const NCPUFOUND = 21;
+    pub const ALLOWPOWERDOWN = 22;
+    pub const PERFPOLICY = 23;
+    pub const SMT = 24;
+    pub const NCPUONLINE = 25;
+    pub const POWER = 26;
+};
 
 /// TODO refines if necessary
 pub const PTHREAD_STACK_MIN = switch (builtin.cpu.arch) {

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -478,6 +478,9 @@ pub const IterableDir = struct {
                             .FAULT => unreachable,
                             .NOTDIR => unreachable,
                             .INVAL => unreachable,
+                            // Introduced in freebsd 13.2: directory unlinked but still open.
+                            // To be consistent, iteration ends if the directory being iterated is deleted during iteration.
+                            .NOENT => return null,
                             else => |err| return os.unexpectedErrno(err),
                         }
                         if (rc == 0) return null;

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -87,6 +87,10 @@ pub const F = system.F;
 pub const FD_CLOEXEC = system.FD_CLOEXEC;
 pub const Flock = system.Flock;
 pub const HOST_NAME_MAX = system.HOST_NAME_MAX;
+pub const HW = switch (builtin.os.tag) {
+    .openbsd => system.HW,
+    else => .{},
+};
 pub const IFNAMESIZE = system.IFNAMESIZE;
 pub const IOV_MAX = system.IOV_MAX;
 pub const IPPROTO = system.IPPROTO;


### PR DESCRIPTION
with this PR:

- fixed getdents signature for freebsd, openbsd, dragonfly
- freebsd 13.2 passes `zig test lib/std/std.zig`
- openbsd builds stage3

tested on:

- freebsd 13.2, 13.1 (amd64)
- openbsd 7.3 (amd64)
- dragonfly 6.4

impact:
I don't foresee an impact on any tier1 platforms, each of the commits are special cased for the respective OS.

other note:
Unfortunately I do not have access to a solaris platform to test (and no luck with solaris x86 qemu guest), and `getdents` return type should be changed from `usize` → `c_int` .