### PR TITLE
Handle all errors on std.net.Ipv4address.resolveIP

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -251,6 +251,7 @@ pub const Ip4Address = extern struct {
             error.InvalidEnd,
             error.InvalidCharacter,
             error.Incomplete,
+            error.NonCanonical,
             => {},
         }
         return error.InvalidIPAddressFormat;


### PR DESCRIPTION
The following test fails since NonCanonical is not handled
```
test "foo" {
    std.net.Ip4Address.resolveIp("1.1.1.1", 0) catch unreachable;
}

/usr/lib/zig/std/net.zig:240:60: error: switch must handle all possibilities
        if (parse(name, port)) |ip4| return ip4 else |err| switch (err) {
                                                           ^~~~~~
/usr/lib/zig/std/net.zig:240:60: note: unhandled error value: 'error.NonCanonical' referenced by:
    test.foo: src/dhcp.zig:383:23
```