### PR TITLE
differentiate between different types of lib dirs

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1523,7 +1523,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .llvm_cpu_features = llvm_cpu_features,
             .skip_linker_dependencies = options.skip_linker_dependencies,
             .parent_compilation_link_libc = options.parent_compilation_link_libc,
-            .each_lib_rpath = options.each_lib_rpath orelse false,
+            .each_lib_rpath = options.each_lib_rpath orelse options.is_native_os,
             .build_id = build_id,
             .cache_mode = cache_mode,
             .disable_lld_caching = options.disable_lld_caching or cache_mode == .whole,

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -500,6 +500,7 @@ pub const InitOptions = struct {
     keep_source_files_loaded: bool = false,
     clang_argv: []const []const u8 = &[0][]const u8{},
     lib_dirs: []const []const u8 = &[0][]const u8{},
+    system_lib_dirs: []const []const u8 = &[0][]const u8{},
     rpath_list: []const []const u8 = &[0][]const u8{},
     symbol_wrap_set: std.StringArrayHashMapUnmanaged(void) = .{},
     c_source_files: []const CSourceFile = &[0]CSourceFile{},
@@ -1450,6 +1451,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .system_libs = system_libs,
             .wasi_emulated_libs = options.wasi_emulated_libs,
             .lib_dirs = options.lib_dirs,
+            .system_lib_dirs = options.system_lib_dirs,
             .rpath_list = options.rpath_list,
             .symbol_wrap_set = options.symbol_wrap_set,
             .strip = strip,
@@ -2283,6 +2285,7 @@ fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifes
     man.hash.add(comp.bin_file.options.emit_relocs);
     man.hash.add(comp.bin_file.options.rdynamic);
     man.hash.addListOfBytes(comp.bin_file.options.lib_dirs);
+    man.hash.addListOfBytes(comp.bin_file.options.system_lib_dirs);
     man.hash.addListOfBytes(comp.bin_file.options.rpath_list);
     man.hash.addListOfBytes(comp.bin_file.options.symbol_wrap_set.keys());
     man.hash.add(comp.bin_file.options.each_lib_rpath);

--- a/src/link.zig
+++ b/src/link.zig
@@ -183,6 +183,7 @@ pub const Options = struct {
     system_libs: std.StringArrayHashMapUnmanaged(SystemLib),
     wasi_emulated_libs: []const wasi_libc.CRTFile,
     lib_dirs: []const []const u8,
+    system_lib_dirs: []const []const u8,
     rpath_list: []const []const u8,
 
     /// List of symbols forced as undefined in the symbol table

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1397,6 +1397,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
         man.hash.add(self.base.options.emit_relocs);
         man.hash.add(self.base.options.rdynamic);
         man.hash.addListOfBytes(self.base.options.lib_dirs);
+        man.hash.addListOfBytes(self.base.options.system_lib_dirs);
         man.hash.addListOfBytes(self.base.options.rpath_list);
         man.hash.add(self.base.options.each_lib_rpath);
         if (self.base.options.output_mode == .Exe) {
@@ -1734,6 +1735,10 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
         for (self.base.options.lib_dirs) |lib_dir| {
             try argv.append("-L");
             try argv.append(lib_dir);
+        }
+        for (self.base.options.system_lib_dirs) |system_lib_dir| {
+            try argv.append("-L");
+            try argv.append(system_lib_dir);
         }
 
         if (self.base.options.link_libc) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -880,6 +880,9 @@ fn buildOutputType(
     var lib_dirs = std.ArrayList([]const u8).init(gpa);
     defer lib_dirs.deinit();
 
+    var system_lib_dirs = std.ArrayList([]const u8).init(gpa);
+    defer system_lib_dirs.deinit();
+
     var rpath_list = std.ArrayList([]const u8).init(gpa);
     defer rpath_list.deinit();
 
@@ -2590,6 +2593,9 @@ fn buildOutputType(
         for (paths.lib_dirs.items) |lib_dir| {
             try lib_dirs.append(lib_dir);
         }
+        for (paths.system_lib_dirs.items) |system_lib_dir| {
+            try system_lib_dirs.append(system_lib_dir);
+        }
         for (paths.rpaths.items) |rpath| {
             try rpath_list.append(rpath);
         }
@@ -3073,6 +3079,7 @@ fn buildOutputType(
         .keep_source_files_loaded = false,
         .clang_argv = clang_argv.items,
         .lib_dirs = lib_dirs.items,
+        .system_lib_dirs = system_lib_dirs.items,
         .rpath_list = rpath_list.items,
         .symbol_wrap_set = symbol_wrap_set,
         .c_source_files = c_source_files.items,


### PR DESCRIPTION
#15970 was elegant, but ended up breaking another setup (like every previous variant of it)

Relevant bug #16056

a bit ugly and only has code for the Elf linker, but that appears to be the only relevant part.
