### PR TITLE
add additional errno (INTR) to tcset,getpgrp calls

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -6869,6 +6869,7 @@ pub fn tcgetpgrp(handle: fd_t) TermioGetPgrpError!pid_t {
             .SUCCESS => return pgrp,
             .BADF => unreachable,
             .INVAL => unreachable,
+            .INTR => continue,
             .NOTTY => return error.NotATerminal,
             else => |err| return unexpectedErrno(err),
         }
@@ -6887,6 +6888,7 @@ pub fn tcsetpgrp(handle: fd_t, pgrp: pid_t) TermioSetPgrpError!void {
             .SUCCESS => return,
             .BADF => unreachable,
             .INVAL => unreachable,
+            .INTR => continue,
             .NOTTY => return error.NotATerminal,
             .PERM => return TermioSetPgrpError.NotAPgrpMember,
             else => |err| return unexpectedErrno(err),


### PR DESCRIPTION
Missed this originally because I was only able to trigger it when SA_RESTART was missing from the sigaction handlers. I'm unconvinced this is actually a sane way for stdlib to behave (see #15664). But this does duplicate the existing behavior throughout os.zig which IMO should be prioritized here.