### PR TITLE
init-exe: Remove exit code detection for run_cmd

### DIFF
--- a/lib/init-exe/build.zig
+++ b/lib/init-exe/build.zig
@@ -46,6 +46,10 @@ pub fn build(b: *std.Build) void {
         run_cmd.addArgs(args);
     }
 
+    // This removes error reporting when the command exits with abnormal exit code (!= 0).
+    // The error is only useful when executing external tools.
+    run_cmd.expected_exit_code = null;
+
     // This creates a build step. It will be visible in the `zig build --help` menu,
     // and can be selected like this: `zig build run`
     // This will evaluate the `run` step rather than the default, which is "install".


### PR DESCRIPTION
Before this patch, if a command fails with exit code != 0, then `zig build run` will print the following:

```
The following command exited with error code 1 (expected 0):
...
error: UnexpectedExitCode
/home/user/.local/share/zig/0.10.1/files/lib/std/build/RunStep.zig:277:17: 0x314766 in runCommand (build)
                return error.UnexpectedExitCode;
                ^
/home/user/.local/share/zig/0.10.1/files/lib/std/build/RunStep.zig:183:5: 0x300acd in make (build)
    try runCommand(
    ^
/home/user/.local/share/zig/0.10.1/files/lib/std/build.zig:3653:9: 0x2a6a8b in make (build)
        try self.makeFn(self);
        ^
/home/user/.local/share/zig/0.10.1/files/lib/std/build.zig:510:9: 0x2932f1 in makeOneStep (build)
        try s.make();
        ^
/home/user/.local/share/zig/0.10.1/files/lib/std/build.zig:504:17: 0x29325c in makeOneStep (build)
                return err;
                ^
/home/user/.local/share/zig/0.10.1/files/lib/std/build.zig:465:13: 0x292f83 in make (build)
            try self.makeOneStep(s);
            ^
/home/user/.local/share/zig/0.10.1/files/lib/build_runner.zig:225:21: 0x296048 in main (build)
            else => return err,
                    ^
```

The "feature" is confusing for beginners, so I removed it in the `init-exe` template.