### PR TITLE
compiler_rt: fixup exports of PPC routines

### DIFF
--- a/lib/compiler_rt/divtc3.zig
+++ b/lib/compiler_rt/divtc3.zig
@@ -4,11 +4,9 @@ const Complex = @import("./mulc3.zig").Complex;
 
 comptime {
     if (@import("builtin").zig_backend != .stage2_c) {
-        if (common.want_ppc_abi) {
+        if (common.want_ppc_abi)
             @export(__divtc3, .{ .name = "__divkc3", .linkage = common.linkage, .visibility = common.visibility });
-        } else {
-            @export(__divtc3, .{ .name = "__divtc3", .linkage = common.linkage, .visibility = common.visibility });
-        }
+        @export(__divtc3, .{ .name = "__divtc3", .linkage = common.linkage, .visibility = common.visibility });
     }
 }
 

--- a/lib/compiler_rt/divtf3.zig
+++ b/lib/compiler_rt/divtf3.zig
@@ -9,7 +9,6 @@ pub const panic = common.panic;
 
 comptime {
     if (common.want_ppc_abi) {
-        // TODO: why did this not error?
         @export(__divtf3, .{ .name = "__divkf3", .linkage = common.linkage, .visibility = common.visibility });
     } else if (common.want_sparc_abi) {
         @export(_Qp_div, .{ .name = "_Qp_div", .linkage = common.linkage, .visibility = common.visibility });

--- a/lib/compiler_rt/fixtfti.zig
+++ b/lib/compiler_rt/fixtfti.zig
@@ -7,9 +7,9 @@ pub const panic = common.panic;
 comptime {
     if (common.want_windows_v2u64_abi) {
         @export(__fixtfti_windows_x86_64, .{ .name = "__fixtfti", .linkage = common.linkage, .visibility = common.visibility });
-    } else if (common.want_ppc_abi) {
-        @export(__fixtfti, .{ .name = "__fixkfti", .linkage = common.linkage, .visibility = common.visibility });
     } else {
+        if (common.want_ppc_abi)
+            @export(__fixtfti, .{ .name = "__fixkfti", .linkage = common.linkage, .visibility = common.visibility });
         @export(__fixtfti, .{ .name = "__fixtfti", .linkage = common.linkage, .visibility = common.visibility });
     }
 }

--- a/lib/compiler_rt/fixunstfti.zig
+++ b/lib/compiler_rt/fixunstfti.zig
@@ -7,9 +7,9 @@ pub const panic = common.panic;
 comptime {
     if (common.want_windows_v2u64_abi) {
         @export(__fixunstfti_windows_x86_64, .{ .name = "__fixunstfti", .linkage = common.linkage, .visibility = common.visibility });
-    } else if (common.want_ppc_abi) {
-        @export(__fixunstfti, .{ .name = "__fixunskfti", .linkage = common.linkage, .visibility = common.visibility });
     } else {
+        if (common.want_ppc_abi)
+            @export(__fixunstfti, .{ .name = "__fixunskfti", .linkage = common.linkage, .visibility = common.visibility });
         @export(__fixunstfti, .{ .name = "__fixunstfti", .linkage = common.linkage, .visibility = common.visibility });
     }
 }

--- a/lib/compiler_rt/floattitf.zig
+++ b/lib/compiler_rt/floattitf.zig
@@ -7,9 +7,9 @@ pub const panic = common.panic;
 comptime {
     if (common.want_windows_v2u64_abi) {
         @export(__floattitf_windows_x86_64, .{ .name = "__floattitf", .linkage = common.linkage, .visibility = common.visibility });
-    } else if (common.want_ppc_abi) {
-        @export(__floattitf, .{ .name = "__floattikf", .linkage = common.linkage, .visibility = common.visibility });
     } else {
+        if (common.want_ppc_abi)
+            @export(__floattitf, .{ .name = "__floattikf", .linkage = common.linkage, .visibility = common.visibility });
         @export(__floattitf, .{ .name = "__floattitf", .linkage = common.linkage, .visibility = common.visibility });
     }
 }

--- a/lib/compiler_rt/floatuntitf.zig
+++ b/lib/compiler_rt/floatuntitf.zig
@@ -8,9 +8,8 @@ comptime {
     if (common.want_windows_v2u64_abi) {
         @export(__floatuntitf_windows_x86_64, .{ .name = "__floatuntitf", .linkage = common.linkage, .visibility = common.visibility });
     } else {
-        if (common.want_ppc_abi) {
+        if (common.want_ppc_abi)
             @export(__floatuntitf, .{ .name = "__floatuntikf", .linkage = common.linkage, .visibility = common.visibility });
-        }
         @export(__floatuntitf, .{ .name = "__floatuntitf", .linkage = common.linkage, .visibility = common.visibility });
     }
 }

--- a/lib/compiler_rt/multc3.zig
+++ b/lib/compiler_rt/multc3.zig
@@ -5,11 +5,9 @@ pub const panic = common.panic;
 
 comptime {
     if (@import("builtin").zig_backend != .stage2_c) {
-        if (common.want_ppc_abi) {
+        if (common.want_ppc_abi)
             @export(__multc3, .{ .name = "__mulkc3", .linkage = common.linkage, .visibility = common.visibility });
-        } else {
-            @export(__multc3, .{ .name = "__multc3", .linkage = common.linkage, .visibility = common.visibility });
-        }
+        @export(__multc3, .{ .name = "__multc3", .linkage = common.linkage, .visibility = common.visibility });
     }
 }
 

--- a/lib/compiler_rt/negtf2.zig
+++ b/lib/compiler_rt/negtf2.zig
@@ -3,11 +3,9 @@ const common = @import("./common.zig");
 pub const panic = common.panic;
 
 comptime {
-    if (common.want_ppc_abi) {
+    if (common.want_ppc_abi)
         @export(__negtf2, .{ .name = "__negkf2", .linkage = common.linkage, .visibility = common.visibility });
-    } else {
-        @export(__negtf2, .{ .name = "__negtf2", .linkage = common.linkage, .visibility = common.visibility });
-    }
+    @export(__negtf2, .{ .name = "__negtf2", .linkage = common.linkage, .visibility = common.visibility });
 }
 
 fn __negtf2(a: f128) callconv(.C) f128 {

--- a/lib/compiler_rt/powiXf2.zig
+++ b/lib/compiler_rt/powiXf2.zig
@@ -13,11 +13,9 @@ comptime {
     @export(__powihf2, .{ .name = "__powihf2", .linkage = common.linkage, .visibility = common.visibility });
     @export(__powisf2, .{ .name = "__powisf2", .linkage = common.linkage, .visibility = common.visibility });
     @export(__powidf2, .{ .name = "__powidf2", .linkage = common.linkage, .visibility = common.visibility });
-    if (common.want_ppc_abi) {
+    if (common.want_ppc_abi)
         @export(__powitf2, .{ .name = "__powikf2", .linkage = common.linkage, .visibility = common.visibility });
-    } else {
-        @export(__powitf2, .{ .name = "__powitf2", .linkage = common.linkage, .visibility = common.visibility });
-    }
+    @export(__powitf2, .{ .name = "__powitf2", .linkage = common.linkage, .visibility = common.visibility });
     @export(__powixf2, .{ .name = "__powixf2", .linkage = common.linkage, .visibility = common.visibility });
 }
 


### PR DESCRIPTION
PPC targets can also use the functionality-equivalent standard routine, so unconditionally export the standard routine.

Fixup of #16054 merged in f043071cdfb956ff16b1441c9d01ce43eea9fb7b.