### PR TITLE
windows: detect ANSI support in more terminals

### DIFF
--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -230,8 +230,6 @@ pub const File = struct {
     /// Test whether ANSI escape codes will be treated as such.
     pub fn supportsAnsiEscapeCodes(self: File) bool {
         if (builtin.os.tag == .windows) {
-            if (!os.isatty(self.handle)) return false;
-
             var console_mode: os.windows.DWORD = 0;
             if (os.windows.kernel32.GetConsoleMode(self.handle, &console_mode) != 0) {
                 if (console_mode & os.windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0) return true;

--- a/lib/std/fs/file.zig
+++ b/lib/std/fs/file.zig
@@ -230,6 +230,13 @@ pub const File = struct {
     /// Test whether ANSI escape codes will be treated as such.
     pub fn supportsAnsiEscapeCodes(self: File) bool {
         if (builtin.os.tag == .windows) {
+            if (!os.isatty(self.handle)) return false;
+
+            var console_mode: os.windows.DWORD = 0;
+            if (os.windows.kernel32.GetConsoleMode(self.handle, &console_mode) != 0) {
+                if (console_mode & os.windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0) return true;
+            }
+
             return os.isCygwinPty(self.handle);
         }
         if (builtin.os.tag == .wasi) {

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -3387,6 +3387,8 @@ pub const CONSOLE_SCREEN_BUFFER_INFO = extern struct {
     dwMaximumWindowSize: COORD,
 };
 
+pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4;
+
 pub const FOREGROUND_BLUE = 1;
 pub const FOREGROUND_GREEN = 2;
 pub const FOREGROUND_RED = 4;


### PR DESCRIPTION
This is a revival of #15282

Helps mitigate https://github.com/ziglang/zig/issues/15976 (and may be enough to warrant closing that issue if we're fine with the `.windows_api` `tty.Config` having slightly different behavior than `.escape_codes`, see the "Potential solutions" at the bottom of that issue)

---

From https://github.com/ziglang/zig/pull/15282#issuecomment-1556381417:

The new build runner means that on Windows the `SetConsoleTextAttribute` colors are not preserved when a test case fails. In combination with https://github.com/ziglang/zig/pull/13816 / https://github.com/ziglang/zig/pull/13723, this makes the output for `expectEqualSlices` much less useful.

With the changes in this PR, the colors *are* preserved (at least with Windows Terminal).

Before this PR:

![15206-before](https://github.com/ziglang/zig/assets/2389051/cedcad3c-29af-451e-8021-f37031ef4387)

After this PR:

![15206-after](https://github.com/ziglang/zig/assets/2389051/db893b4d-51b4-4288-8d02-a251e962000a)
