### PR TITLE
http: fix getting Transfer-Encoding value

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -597,7 +597,7 @@ pub const Request = struct {
 
                 req.transfer_encoding = .{ .content_length = content_length };
             } else if (has_transfer_encoding) {
-                const transfer_encoding = req.headers.getFirstValue("content-length").?;
+                const transfer_encoding = req.headers.getFirstValue("transfer-encoding").?;
                 if (std.mem.eql(u8, transfer_encoding, "chunked")) {
                     req.transfer_encoding = .chunked;
                 } else {


### PR DESCRIPTION
The 'Content-Length' header was inspected by mistake, which makes it effectively impossible to use chunked Transfer-Encoding when using the http client.

Tested locally with a HTTP server - data is properly sent with POST method and the proper encoding declared, after the fix.