### PR TITLE
make std.os.exit cross-platform and related start.zig changes

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -776,7 +776,7 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace, ret_addr
                     }
 
                     var fmt: [256]u8 = undefined;
-                    var slice = try std.fmt.bufPrint(&fmt, "\r\nerr: {s}\r\n", .{exit_msg});
+                    var slice = try std.fmt.bufPrint(&fmt, "\r\nerror: {s}\r\n", .{exit_msg});
 
                     var len = try std.unicode.utf8ToUtf16Le(utf16, slice);
 
@@ -792,10 +792,10 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace, ret_addr
             var exit_data = ExitData.create_exit_data(msg, &exit_size) catch null;
 
             if (exit_data) |data| {
-                if (uefi.system_table.std_err) |out| {
+                if (uefi.system_table.con_out) |out| {
                     _ = out.setAttribute(uefi.protocols.SimpleTextOutputProtocol.red);
                     _ = out.outputString(data);
-                    _ = out.setAttribute(uefi.protocols.SimpleTextOutputProtocol.white);
+                    _ = out.setAttribute(uefi.protocols.SimpleTextOutputProtocol.lightgray);
                 }
             }
 

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -1365,7 +1365,7 @@ fn forkChildErrReport(fd: i32, err: ChildProcess.SpawnError) noreturn {
         // The _exit(2) function does nothing but make the exit syscall, unlike exit(3)
         std.c._exit(1);
     }
-    os.exit(1);
+    os.exit(std.os.exit_status_failure);
 }
 
 const ErrInt = std.meta.Int(.unsigned, @sizeOf(anyerror) * 8);

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1959,7 +1959,7 @@ pub fn getenv(key: []const u8) ?[]const u8 {
         @compileError("std.os.getenv is unavailable for Windows because environment string is in WTF-16 format. See std.process.getEnvVarOwned for cross-platform API or std.os.getenvW for Windows-specific API.");
     }
     // The simplified start logic doesn't populate environ.
-    if (std.start.simplified_logic) return null;
+    if (@import("start.zig").simplified_logic) return null;
     // TODO see https://github.com/ziglang/zig/issues/4524
     for (environ) |ptr| {
         var line_i: usize = 0;

--- a/lib/std/os/plan9.zig
+++ b/lib/std/os/plan9.zig
@@ -148,13 +148,11 @@ pub fn create(path: [*:0]const u8, omode: OpenMode, perms: usize) usize {
     return syscall_bits.syscall3(.CREATE, @ptrToInt(path), @enumToInt(omode), perms);
 }
 
-pub fn exit(status: u8) noreturn {
-    if (status == 0) {
+pub fn exit(status: [:0]const u8) noreturn {
+    if (status.len == 0) {
         exits(null);
     } else {
-        // TODO plan9 does not have exit codes. You either exit with 0 or a string
-        const arr: [1:0]u8 = .{status};
-        exits(&arr);
+        exits(status);
     }
 }
 

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -952,7 +952,7 @@ test "POSIX file locking with fcntl" {
         struct_flock.type = os.F.WRLCK;
         _ = try os.fcntl(fd, os.F.SETLKW, @ptrToInt(&struct_flock));
         // child exits without continuing:
-        os.exit(0);
+        os.exit(os.exit_status_success);
     } else {
         // parent waits for child to get shared lock:
         std.time.sleep(1 * std.time.ns_per_ms);

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1231,11 +1231,11 @@ fn totalSystemMemoryLinux() !usize {
 /// In debug builds, this is a no-op, so that the calling code's
 /// cleanup mechanisms are tested and so that external tools that
 /// check for resource leaks can be accurate. In release builds, this
-/// calls exit(0), and does not return.
+/// calls `exit(std.os.exit_status_success)`, and does not return.
 pub fn cleanExit() void {
     if (builtin.mode == .Debug) {
         return;
     } else {
-        exit(0);
+        exit(std.os.exit_status_success);
     }
 }

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -248,13 +248,10 @@ fn EfiMain(handle: uefi.Handle, system_table: *uefi.tables.SystemTable) callconv
             root.main();
             return 0;
         },
-        usize => {
-            return root.main();
-        },
         uefi.Status => {
             return @enumToInt(root.main());
         },
-        else => @compileError("expected return type of main to be 'void', 'noreturn', 'usize', or 'std.os.uefi.Status'"),
+        else => @compileError("expected return type of main to be 'void', 'noreturn', or 'std.os.uefi.Status'"),
     }
 }
 

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -544,7 +544,7 @@ fn callMainAsync(loop: *std.event.Loop) callconv(.Async) CallMainReturnType {
 
 // This is not marked inline because it is called with @asyncCall when
 // there is an event loop.
-pub fn callMain() CallMainReturnType {
+fn callMain() CallMainReturnType {
     if (use_wWinMain) return call_wWinMain();
 
     switch (@typeInfo(@typeInfo(@TypeOf(root.main)).Fn.return_type.?)) {
@@ -584,7 +584,7 @@ pub fn callMain() CallMainReturnType {
     }
 }
 
-pub fn call_wWinMain() std.os.windows.UINT {
+fn call_wWinMain() std.os.windows.UINT {
     const MAIN_HINSTANCE = @typeInfo(@TypeOf(root.wWinMain)).Fn.params[0].type.?;
     const hInstance = @ptrCast(MAIN_HINSTANCE, std.os.windows.kernel32.GetModuleHandleW(null).?);
     const lpCmdLine = std.os.windows.kernel32.GetCommandLineW();

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -37,11 +37,11 @@ comptime {
                 if (@typeInfo(@TypeOf(root.main)).Fn.calling_convention != .C) {
                     @export(main2, .{ .name = "main" });
                 }
-            } else if (builtin.os.tag == .windows) {
+            } else if (native_os == .windows) {
                 if (!@hasDecl(root, "wWinMainCRTStartup") and !@hasDecl(root, "mainCRTStartup")) {
                     @export(wWinMainCRTStartup2, .{ .name = "wWinMainCRTStartup" });
                 }
-            } else if (builtin.os.tag == .opencl) {
+            } else if (native_os == .opencl) {
                 if (@hasDecl(root, "main"))
                     @export(spirvMain2, .{ .name = "main" });
             } else {
@@ -497,7 +497,7 @@ fn main(c_argc: c_int, c_argv: [*][*:0]c_char, c_envp: [*:null]?[*:0]c_char) cal
     while (c_envp[env_count] != null) : (env_count += 1) {}
     const envp = @ptrCast([*][*:0]u8, c_envp)[0..env_count];
 
-    if (builtin.os.tag == .linux) {
+    if (native_os == .linux) {
         const at_phdr = std.c.getauxval(elf.AT_PHDR);
         const at_phnum = std.c.getauxval(elf.AT_PHNUM);
         const phdrs = (@intToPtr([*]elf.Phdr, at_phdr))[0..at_phnum];

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -97,7 +97,6 @@ pub const unicode = @import("unicode.zig");
 pub const valgrind = @import("valgrind.zig");
 pub const wasm = @import("wasm.zig");
 pub const zig = @import("zig.zig");
-pub const start = @import("start.zig");
 
 /// deprecated: use `Build`.
 pub const build = Build;
@@ -201,7 +200,7 @@ pub const options = struct {
 // This forces the start.zig file to be imported, and the comptime logic inside that
 // file decides whether to export any appropriate start symbols, and call main.
 comptime {
-    _ = start;
+    _ = @import("start.zig");
 
     for (@typeInfo(options_override).Struct.decls) |decl| {
         if (!@hasDecl(options, decl.name)) @compileError("no option named " ++ decl.name);


### PR DESCRIPTION
**It is highly recommended you read the commit descriptions**. A lot of information in these commit descriptions.

The main focus here was fixing the fact that `std.os.exit` is not appropriately abstracted so that it's cross-platform.
`std.os.exit(0)` is not cross-platform. There are operating systems where you can't return an integer (Plan 9), or at least not `u8` when exiting (UEFI uses `usize`), or anything at all (many older systems). On Plan 9 for example, you return a string as the exit status instead of an integer.
Or maybe you wrote an operating system where you return a data structure as the exit status.
TL;DR we cannot assume `u8` as the exit status for all platforms.
The current approach of taking `u8` but then fixing it up to make it kind of compatible with the underlying system is not ideal either.

This means there is now `std.os.ExitStatus` which is the type of the value that can be returned to the operating system when exiting.

However to make it easier to write cross-platform code without having to deal with `std.os.ExitStatus` directly (because the type depends on the OS), the declarations `std.os.exit_status_success` and `std.os.exit_status_failure` are provided for these two most common situations: 1. exiting and communicating success and 2. exiting and communicating failure. 

This abstracts the API so that `std.os.exit(0)` still works but, assuming 0 means success here, it's now considered unidiomatic and the recommended pattern is `std.os.exit(std.os.exit_status_success)`.
Similarly, instead of `std.os.exit(1)` you use `std.os.exit(std.os.exit_status_failure)`.
For more specific exit statuses you either ignore cross-platform compatibility or come up with a different exit status for that specific case for each platform that you support.

---

Exiting a program goes in hand with the return type of the main function, because that is what's returned, so there are also many changes to `lib/std/start.zig`, namely:
* `std.start` no longer exists in the public std API surface.
* `void`, `!void`, `noreturn` + whatever `std.os.ExitStatus` is are now supported as the return types for `main` on all platforms. Previously, on the UEFI, error unions weren't supported.

Finally, now if your program returns from `main` a value of a type other than `void`, `!void`, or `noreturn`, you might want to use `std.os.ExitStatus` instead of `u8`.
Basically,
```zig
pub fn main() u8 {
    return 0;
}
```
still works as before but the cross-platform way of doing it would be
```zig
pub fn main() std.os.ExitStatus {
    return std.os.exit_status_success;
}
```
(assuming that 0 means success).

Uses of `std.os` always look kind of low-level though so maybe we can create aliases for these definitions in `std.process` (`std.process.exit` is also an alias of `std.os.exit`).
Or maybe aliases in `std.start`?

**It is highly recommended you read the commit descriptions**. A lot of information in these commit descriptions.