### PR TITLE
Type: remove arbitrary restrictions on param and return types

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -2403,14 +2403,14 @@ pub const Type = struct {
 
     pub fn isValidParamType(self: Type, mod: *const Module) bool {
         return switch (self.zigTypeTagOrPoison(mod) catch return true) {
-            .Undefined, .Null, .Opaque, .NoReturn => false,
+            .Opaque, .NoReturn => false,
             else => true,
         };
     }
 
     pub fn isValidReturnType(self: Type, mod: *const Module) bool {
         return switch (self.zigTypeTagOrPoison(mod) catch return true) {
-            .Undefined, .Null, .Opaque => false,
+            .Opaque => false,
             else => true,
         };
     }

--- a/test/behavior/fn.zig
+++ b/test/behavior/fn.zig
@@ -580,3 +580,17 @@ test "lazy values passed to anytype parameter" {
     const D = struct {};
     try expect(@sizeOf(D) << 1 == 0);
 }
+
+test "pass and return comptime-only types" {
+    const S = struct {
+        fn returnNull(comptime x: @Type(.Null)) @Type(.Null) {
+            return x;
+        }
+        fn returnUndefined(comptime x: @Type(.Undefined)) @Type(.Undefined) {
+            return x;
+        }
+    };
+
+    try expectEqual(null, S.returnNull(null));
+    try expectEqual(@as(u0, 0), S.returnUndefined(undefined));
+}

--- a/test/cases/compile_errors/function_parameter_is_opaque.zig
+++ b/test/cases/compile_errors/function_parameter_is_opaque.zig
@@ -4,23 +4,11 @@ export fn entry1() void {
     _ = someFuncPtr;
 }
 
-export fn entry2() void {
-    const someFuncPtr: fn (@TypeOf(null)) void = undefined;
-    _ = someFuncPtr;
-}
-
 fn foo(p: FooType) void {
     _ = p;
 }
 export fn entry3() void {
     _ = foo;
-}
-
-fn bar(p: @TypeOf(null)) void {
-    _ = p;
-}
-export fn entry4() void {
-    _ = bar;
 }
 
 // error
@@ -29,7 +17,5 @@ export fn entry4() void {
 //
 // :3:28: error: parameter of opaque type 'tmp.FooType' not allowed
 // :1:17: note: opaque declared here
-// :8:28: error: parameter of type '@TypeOf(null)' not allowed
-// :12:8: error: parameter of opaque type 'tmp.FooType' not allowed
+// :7:8: error: parameter of opaque type 'tmp.FooType' not allowed
 // :1:17: note: opaque declared here
-// :19:8: error: parameter of type '@TypeOf(null)' not allowed

--- a/test/cases/compile_errors/function_returning_opaque_type.zig
+++ b/test/cases/compile_errors/function_returning_opaque_type.zig
@@ -2,12 +2,6 @@ const FooType = opaque {};
 export fn bar() FooType {
     return error.InvalidValue;
 }
-export fn bav() @TypeOf(null) {
-    return error.InvalidValue;
-}
-export fn baz() @TypeOf(undefined) {
-    return error.InvalidValue;
-}
 
 // error
 // backend=stage2
@@ -15,5 +9,3 @@ export fn baz() @TypeOf(undefined) {
 //
 // :2:17: error: opaque return type 'tmp.FooType' not allowed
 // :1:17: note: opaque declared here
-// :5:17: error: return type '@TypeOf(null)' not allowed
-// :8:17: error: return type '@TypeOf(undefined)' not allowed


### PR DESCRIPTION
Opaque and `noreturn` make sense since they don't represent real values, but `null` and `undefined` are perfectly normal comptime-only values.

Closes #16088