### PR TITLE
InternPool: various optimizations

### DIFF
--- a/src/Air.zig
+++ b/src/Air.zig
@@ -850,6 +850,8 @@ pub const Inst = struct {
     pub const Index = u32;
 
     pub const Ref = enum(u32) {
+        u0_type = @intFromEnum(InternPool.Index.u0_type),
+        i0_type = @intFromEnum(InternPool.Index.i0_type),
         u1_type = @intFromEnum(InternPool.Index.u1_type),
         u8_type = @intFromEnum(InternPool.Index.u8_type),
         i8_type = @intFromEnum(InternPool.Index.i8_type),
@@ -909,6 +911,7 @@ pub const Inst = struct {
         single_const_pointer_to_comptime_int_type = @intFromEnum(InternPool.Index.single_const_pointer_to_comptime_int_type),
         slice_const_u8_type = @intFromEnum(InternPool.Index.slice_const_u8_type),
         slice_const_u8_sentinel_0_type = @intFromEnum(InternPool.Index.slice_const_u8_sentinel_0_type),
+        optional_noreturn_type = @intFromEnum(InternPool.Index.optional_noreturn_type),
         anyerror_void_error_union_type = @intFromEnum(InternPool.Index.anyerror_void_error_union_type),
         generic_poison_type = @intFromEnum(InternPool.Index.generic_poison_type),
         empty_struct_type = @intFromEnum(InternPool.Index.empty_struct_type),

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -1182,7 +1182,7 @@ pub fn getMainBody(air: Air) []const Air.Inst.Index {
     return air.extra[extra.end..][0..extra.data.body_len];
 }
 
-pub fn typeOf(air: Air, inst: Air.Inst.Ref, ip: *const InternPool) Type {
+pub fn typeOf(air: *const Air, inst: Air.Inst.Ref, ip: *const InternPool) Type {
     const ref_int = @intFromEnum(inst);
     if (ref_int < InternPool.static_keys.len) {
         return InternPool.static_keys[ref_int].typeOf().toType();
@@ -1190,7 +1190,7 @@ pub fn typeOf(air: Air, inst: Air.Inst.Ref, ip: *const InternPool) Type {
     return air.typeOfIndex(ref_int - ref_start_index, ip);
 }
 
-pub fn typeOfIndex(air: Air, inst: Air.Inst.Index, ip: *const InternPool) Type {
+pub fn typeOfIndex(air: *const Air, inst: Air.Inst.Index, ip: *const InternPool) Type {
     const datas = air.instructions.items(.data);
     switch (air.instructions.items(.tag)[inst]) {
         .add,

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -1406,7 +1406,7 @@ pub fn typeOfIndex(air: *const Air, inst: Air.Inst.Index, ip: *const InternPool)
 
         .call, .call_always_tail, .call_never_tail, .call_never_inline => {
             const callee_ty = air.typeOf(datas[inst].pl_op.operand, ip);
-            return callee_ty.fnReturnTypeIp(ip);
+            return ip.funcReturnType(callee_ty.toIntern()).toType();
         },
 
         .slice_elem_val, .ptr_elem_val, .array_elem_val => {

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -5702,6 +5702,10 @@ pub fn isNoReturn(ip: *const InternPool, ty: Index) bool {
     };
 }
 
+pub fn isRuntimeValue(ip: *const InternPool, val: Index) bool {
+    return ip.items.items(.tag)[@intFromEnum(val)] == .runtime_value;
+}
+
 /// This is a particularly hot function, so we operate directly on encodings
 /// rather than the more straightforward implementation of calling `indexToKey`.
 pub fn zigTypeTagOrPoison(ip: *const InternPool, index: Index) error{GenericPoison}!std.builtin.TypeId {

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -2301,8 +2301,9 @@ pub const Alignment = enum(u6) {
         return fromByteUnits(n);
     }
 
-    pub fn min(a: Alignment, b: Alignment) Alignment {
-        return @enumFromInt(Alignment, @min(@intFromEnum(a), @intFromEnum(b)));
+    pub fn order(lhs: Alignment, rhs: Alignment) std.math.Order {
+        assert(lhs != .none and rhs != .none);
+        return std.math.order(@intFromEnum(lhs), @intFromEnum(rhs));
     }
 };
 

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2005,6 +2005,8 @@ pub const Inst = struct {
     /// The tag type is specified so that it is safe to bitcast between `[]u32`
     /// and `[]Ref`.
     pub const Ref = enum(u32) {
+        u0_type = @intFromEnum(InternPool.Index.u0_type),
+        i0_type = @intFromEnum(InternPool.Index.i0_type),
         u1_type = @intFromEnum(InternPool.Index.u1_type),
         u8_type = @intFromEnum(InternPool.Index.u8_type),
         i8_type = @intFromEnum(InternPool.Index.i8_type),
@@ -2064,6 +2066,7 @@ pub const Inst = struct {
         single_const_pointer_to_comptime_int_type = @intFromEnum(InternPool.Index.single_const_pointer_to_comptime_int_type),
         slice_const_u8_type = @intFromEnum(InternPool.Index.slice_const_u8_type),
         slice_const_u8_sentinel_0_type = @intFromEnum(InternPool.Index.slice_const_u8_sentinel_0_type),
+        optional_noreturn_type = @intFromEnum(InternPool.Index.optional_noreturn_type),
         anyerror_void_error_union_type = @intFromEnum(InternPool.Index.anyerror_void_error_union_type),
         generic_poison_type = @intFromEnum(InternPool.Index.generic_poison_type),
         empty_struct_type = @intFromEnum(InternPool.Index.empty_struct_type),

--- a/src/arch/wasm/abi.zig
+++ b/src/arch/wasm/abi.zig
@@ -34,8 +34,8 @@ pub fn classifyType(ty: Type, mod: *Module) [2]Class {
             if (ty.structFieldCount(mod) > 1) return memory;
             // When the struct's alignment is non-natural
             const field = ty.structFields(mod).values()[0];
-            if (field.abi_align != 0) {
-                if (field.abi_align > field.ty.abiAlignment(mod)) {
+            if (field.abi_align != .none) {
+                if (field.abi_align.toByteUnitsOptional().? > field.ty.abiAlignment(mod)) {
                     return memory;
                 }
             }

--- a/src/arch/x86_64/abi.zig
+++ b/src/arch/x86_64/abi.zig
@@ -223,8 +223,8 @@ pub fn classifySystemV(ty: Type, mod: *Module, ctx: Context) [8]Class {
             var byte_i: usize = 0; // out of 8
             const fields = ty.structFields(mod);
             for (fields.values()) |field| {
-                if (field.abi_align != 0) {
-                    if (field.abi_align < field.ty.abiAlignment(mod)) {
+                if (field.abi_align != .none) {
+                    if (field.abi_align.toByteUnitsOptional().? < field.ty.abiAlignment(mod)) {
                         return memory_class;
                     }
                 }
@@ -340,8 +340,8 @@ pub fn classifySystemV(ty: Type, mod: *Module, ctx: Context) [8]Class {
 
             const fields = ty.unionFields(mod);
             for (fields.values()) |field| {
-                if (field.abi_align != 0) {
-                    if (field.abi_align < field.ty.abiAlignment(mod)) {
+                if (field.abi_align != .none) {
+                    if (field.abi_align.toByteUnitsOptional().? < field.ty.abiAlignment(mod)) {
                         return memory_class;
                     }
                 }

--- a/src/codegen/c/type.zig
+++ b/src/codegen/c/type.zig
@@ -6,6 +6,7 @@ const assert = std.debug.assert;
 const autoHash = std.hash.autoHash;
 const Target = std.Target;
 
+const Alignment = @import("../../InternPool.zig").Alignment;
 const Module = @import("../../Module.zig");
 const Type = @import("../../type.zig").Type;
 
@@ -280,16 +281,15 @@ pub const CType = extern union {
     };
 
     pub const AlignAs = struct {
-        @"align": std.math.Log2Int(u32),
-        abi: std.math.Log2Int(u32),
+        @"align": Alignment,
+        abi: Alignment,
 
-        pub fn init(alignment: u32, abi_alignment: u32) AlignAs {
-            const actual_align = if (alignment != 0) alignment else abi_alignment;
-            assert(std.math.isPowerOfTwo(actual_align));
-            assert(std.math.isPowerOfTwo(abi_alignment));
+        pub fn init(alignment: u64, abi_alignment: u32) AlignAs {
+            const @"align" = Alignment.fromByteUnits(alignment);
+            const abi_align = Alignment.fromNonzeroByteUnits(abi_alignment);
             return .{
-                .@"align" = std.math.log2_int(u32, actual_align),
-                .abi = std.math.log2_int(u32, abi_alignment),
+                .@"align" = if (@"align" != .none) @"align" else abi_align,
+                .abi = abi_align,
             };
         }
         pub fn abiAlign(ty: Type, mod: *Module) AlignAs {
@@ -308,8 +308,14 @@ pub const CType = extern union {
             return init(union_payload_align, union_payload_align);
         }
 
-        pub fn getAlign(self: AlignAs) u32 {
-            return @as(u32, 1) << self.@"align";
+        pub fn order(lhs: AlignAs, rhs: AlignAs) std.math.Order {
+            return lhs.@"align".order(rhs.@"align");
+        }
+        pub fn abiOrder(self: AlignAs) std.math.Order {
+            return self.@"align".order(self.abi);
+        }
+        pub fn toByteUnits(self: AlignAs) u64 {
+            return self.@"align".toByteUnitsOptional().?;
         }
     };
 
@@ -1298,7 +1304,7 @@ pub const CType = extern union {
             const slice = self.storage.anon.fields[0..fields_len];
             mem.sort(Field, slice, {}, struct {
                 fn before(_: void, lhs: Field, rhs: Field) bool {
-                    return lhs.alignas.@"align" > rhs.alignas.@"align";
+                    return lhs.alignas.order(rhs.alignas).compare(.gt);
                 }
             }.before);
             return slice;
@@ -1424,7 +1430,7 @@ pub const CType = extern union {
 
                 .Pointer => {
                     const info = ty.ptrInfo(mod);
-                    switch (info.size) {
+                    switch (info.flags.size) {
                         .Slice => {
                             if (switch (kind) {
                                 .forward, .forward_parameter => @as(Index, undefined),
@@ -1454,27 +1460,24 @@ pub const CType = extern union {
                         },
 
                         .One, .Many, .C => {
-                            const t: Tag = switch (info.@"volatile") {
-                                false => switch (info.mutable) {
-                                    true => .pointer,
-                                    false => .pointer_const,
+                            const t: Tag = switch (info.flags.is_volatile) {
+                                false => switch (info.flags.is_const) {
+                                    false => .pointer,
+                                    true => .pointer_const,
                                 },
-                                true => switch (info.mutable) {
-                                    true => .pointer_volatile,
-                                    false => .pointer_const_volatile,
+                                true => switch (info.flags.is_const) {
+                                    false => .pointer_volatile,
+                                    true => .pointer_const_volatile,
                                 },
                             };
 
-                            const pointee_ty = if (info.host_size > 0 and info.vector_index == .none)
-                                try mod.intType(.unsigned, info.host_size * 8)
+                            const pointee_ty = if (info.packed_offset.host_size > 0 and
+                                info.flags.vector_index == .none)
+                                try mod.intType(.unsigned, info.packed_offset.host_size * 8)
                             else
-                                info.pointee_type;
+                                info.child.toType();
 
-                            if (if (info.size == .C and pointee_ty.ip_index == .u8_type)
-                                Tag.char.toIndex()
-                            else
-                                try lookup.typeToIndex(pointee_ty, .forward)) |child_idx|
-                            {
+                            if (try lookup.typeToIndex(pointee_ty, .forward)) |child_idx| {
                                 self.storage = .{ .child = .{
                                     .base = .{ .tag = t },
                                     .data = child_idx,
@@ -1586,7 +1589,7 @@ pub const CType = extern union {
                                 if (!field_ty.hasRuntimeBitsIgnoreComptime(mod)) continue;
 
                                 const field_align = AlignAs.fieldAlign(ty, field_i, mod);
-                                if (field_align.@"align" < field_align.abi) {
+                                if (field_align.abiOrder().compare(.lt)) {
                                     is_packed = true;
                                     if (!lookup.isMutable()) break;
                                 }

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -1210,13 +1210,13 @@ pub const DeclGen = struct {
             .Pointer => {
                 const ptr_info = ty.ptrInfo(mod);
 
-                const storage_class = spvStorageClass(ptr_info.@"addrspace");
-                const child_ty_ref = try self.resolveType(ptr_info.pointee_type, .indirect);
+                const storage_class = spvStorageClass(ptr_info.flags.address_space);
+                const child_ty_ref = try self.resolveType(ptr_info.child.toType(), .indirect);
                 const ptr_ty_ref = try self.spv.resolve(.{ .ptr_type = .{
                     .storage_class = storage_class,
                     .child_type = child_ty_ref,
                 } });
-                if (ptr_info.size != .Slice) {
+                if (ptr_info.flags.size != .Slice) {
                     return ptr_ty_ref;
                 }
 
@@ -1573,7 +1573,7 @@ pub const DeclGen = struct {
                 init_val,
                 actual_storage_class,
                 final_storage_class == .Generic,
-                decl.@"align",
+                @intCast(u32, decl.alignment.toByteUnits(0)),
             );
         }
     }

--- a/src/type.zig
+++ b/src/type.zig
@@ -2385,15 +2385,7 @@ pub const Type = struct {
 
     /// Asserts the type is a function or a function pointer.
     pub fn fnReturnType(ty: Type, mod: *Module) Type {
-        return fnReturnTypeIp(ty, &mod.intern_pool);
-    }
-
-    pub fn fnReturnTypeIp(ty: Type, ip: *const InternPool) Type {
-        return switch (ip.indexToKey(ty.toIntern())) {
-            .ptr_type => |ptr_type| ip.indexToKey(ptr_type.child).func_type.return_type,
-            .func_type => |func_type| func_type.return_type,
-            else => unreachable,
-        }.toType();
+        return mod.intern_pool.funcReturnType(ty.toIntern()).toType();
     }
 
     /// Asserts the type is a function.

--- a/src/value.zig
+++ b/src/value.zig
@@ -1991,12 +1991,7 @@ pub const Value = struct {
     }
 
     pub fn isUndef(val: Value, mod: *Module) bool {
-        if (val.ip_index == .none) return false;
-        return switch (mod.intern_pool.indexToKey(val.toIntern())) {
-            .undef => true,
-            .simple_value => |v| v == .undefined,
-            else => false,
-        };
+        return val.ip_index != .none and mod.intern_pool.isUndef(val.toIntern());
     }
 
     /// TODO: check for cases such as array that is not marked undef but all the element

--- a/src/value.zig
+++ b/src/value.zig
@@ -1823,7 +1823,7 @@ pub const Value = struct {
     }
 
     pub fn isRuntimeValue(val: Value, mod: *Module) bool {
-        return mod.intern_pool.indexToKey(val.toIntern()) == .runtime_value;
+        return mod.intern_pool.isRuntimeValue(val.toIntern());
     }
 
     /// Returns true if a Value is backed by a variable


### PR DESCRIPTION
This is the current progress in my `InternPool` optimization branch.  Last I checked, it makes up for about half of the losses from `InternPool`.  Opening this now before it gets too out of date with master.

```
Benchmark 1 (122 runs): master/bin/zig build-exe --stack 33554432 src/main.zig --mod build_options::zig-cache/c/3fb6e89d536536de349edafc1438f486/options.zig --deps build_options -fno-emit-bin
  measurement      mean ± σ               min … max                   outliers         delta
  wall_time        4.924s ± 60.51ms       4.749s … 5.104s               5 ( 4%)        0%
  peak_rss         428M ± 644K            426M … 429M                   0 ( 0%)        0%
  cpu_cycles       24644932956 ± 40187532523641864552 … 25413638166     0 ( 0%)        0%
  instructions     46260045656 ± 18645    46260004387 … 46260088670     0 ( 0%)        0%
  cache_references 2069202759 ± 13691256  2044999182 … 2114724459       7 ( 6%)        0%
  cache_misses     98526792 ± 2692262     91946493 … 105599801          0 ( 0%)        0%
  branch_misses    95286125 ± 745741      93675010 … 97676390           3 ( 2%)        0%
Benchmark 2 (148 runs): opt/bin/zig build-exe --stack 33554432 src/main.zig --mod build_options::zig-cache/c/3fb6e89d536536de349edafc1438f486/options.zig --deps build_options -fno-emit-bin
  measurement      mean ± σ               min … max                   outliers         delta
  wall_time        4.063s ± 32.536ms      3.998s … 4.174s               2 ( 1%)        ⚡- 17.5% ±  0.2%
  peak_rss         426M ± 611K            424M … 428M                   4 ( 3%)          -  0.4% ±  0.0%
  cpu_cycles       20286406609 ± 33506016819420543796 … 20934361547     3 ( 2%)        ⚡- 17.7% ±  0.4%
  instructions     41302252201 ± 14668    41302223526 … 41302308706     5 ( 3%)        ⚡- 10.7% ±  0.0%
  cache_references 1911471150 ± 9618251   1890673407 … 1945021142       8 ( 5%)        ⚡-  7.6% ±  0.1%
  cache_misses     87170902 ± 1770803     82167017 … 91797669           0 ( 0%)        ⚡- 11.5% ±  0.5%
  branch_misses    74823177 ± 403963      73646636 … 75866357           1 ( 1%)        ⚡- 21.5% ±  0.1%
```