### PR TITLE
std.io.tty: cleanup detectConfig

### DIFF
--- a/doc/docgen.zig
+++ b/doc/docgen.zig
@@ -1305,7 +1305,7 @@ fn genHtml(
     defer root_node.end();
 
     var env_map = try process.getEnvMap(allocator);
-    try env_map.put("ZIG_DEBUG_COLOR", "1");
+    try env_map.put("YES_COLOR", "1");
 
     const host = try std.zig.system.NativeTargetInfo.detect(.{});
     const builtin_code = try getBuiltinCode(allocator, &env_map, zig_exe, opt_zig_lib_dir);

--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -282,7 +282,7 @@ pub fn main() !void {
     const ttyconf = get_tty_conf(color, stderr);
     switch (ttyconf) {
         .no_color => try builder.env_map.put("NO_COLOR", "1"),
-        .escape_codes => try builder.env_map.put("ZIG_DEBUG_COLOR", "1"),
+        .escape_codes => try builder.env_map.put("YES_COLOR", "1"),
         .windows_api => {},
     }
 

--- a/lib/std/io/tty.zig
+++ b/lib/std/io/tty.zig
@@ -7,11 +7,11 @@ const native_os = builtin.os.tag;
 
 /// Detect suitable TTY configuration options for the given file (commonly stdout/stderr).
 /// This includes feature checks for ANSI escape codes and the Windows console API, as well as
-/// respecting the `ZIG_DEBUG_COLOR` and `YES_COLOR` environment variables to override the default.
+/// respecting the `NO_COLOR` and `YES_COLOR` environment variables to override the default.
 pub fn detectConfig(file: File) Config {
     const force_color: ?bool = if (builtin.os.tag == .wasi)
         null // wasi does not support environment variables
-    else if (process.hasEnvVarConstant("ZIG_DEBUG_COLOR"))
+    else if (process.hasEnvVarConstant("NO_COLOR"))
         false
     else if (process.hasEnvVarConstant("YES_COLOR"))
         true

--- a/lib/std/io/tty.zig
+++ b/lib/std/io/tty.zig
@@ -7,29 +7,34 @@ const native_os = builtin.os.tag;
 
 /// Detect suitable TTY configuration options for the given file (commonly stdout/stderr).
 /// This includes feature checks for ANSI escape codes and the Windows console API, as well as
-/// respecting the `NO_COLOR` environment variable.
+/// respecting the `ZIG_DEBUG_COLOR` and `YES_COLOR` environment variables to override the default.
 pub fn detectConfig(file: File) Config {
-    if (builtin.os.tag == .wasi) {
-        // Per https://github.com/WebAssembly/WASI/issues/162 ANSI codes
-        // aren't currently supported.
-        return .no_color;
-    } else if (process.hasEnvVarConstant("ZIG_DEBUG_COLOR")) {
-        return .escape_codes;
-    } else if (process.hasEnvVarConstant("NO_COLOR")) {
-        return .no_color;
-    } else if (file.supportsAnsiEscapeCodes()) {
-        return .escape_codes;
-    } else if (native_os == .windows and file.isTty()) {
+    const force_color: ?bool = if (builtin.os.tag == .wasi)
+        null // wasi does not support environment variables
+    else if (process.hasEnvVarConstant("ZIG_DEBUG_COLOR"))
+        false
+    else if (process.hasEnvVarConstant("YES_COLOR"))
+        true
+    else
+        null;
+
+    if (force_color == false) return .no_color;
+
+    if (native_os == .windows and file.isTty()) {
         var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
         if (windows.kernel32.GetConsoleScreenBufferInfo(file.handle, &info) != windows.TRUE) {
-            // TODO: Should this return an error instead?
-            return .no_color;
+            return if (force_color == true) .escape_codes else .no_color;
         }
         return .{ .windows_api = .{
             .handle = file.handle,
             .reset_attributes = info.wAttributes,
         } };
     }
+
+    if (force_color == true or file.supportsAnsiEscapeCodes()) {
+        return .escape_codes;
+    }
+
     return .no_color;
 }
 

--- a/test/src/StackTrace.zig
+++ b/test/src/StackTrace.zig
@@ -81,7 +81,7 @@ fn addExpect(
     });
 
     const run = b.addRunArtifact(exe);
-    run.removeEnvironmentVariable("ZIG_DEBUG_COLOR");
+    run.removeEnvironmentVariable("YES_COLOR");
     run.setEnvironmentVariable("NO_COLOR", "1");
     run.expectExitCode(1);
     run.expectStdOutEqual("");


### PR DESCRIPTION
This PR adds `fn std.io.tty.detectConfigForce(File, bool) Config` which accepts an extra parameter to force coloring if the platform supports it. There are two code paths where `.no_color` will be returned: if the platform is wasi, or on windows if the `windows.kernel32.GetConsoleScreenBufferInfo()`  test fails - other options in this case could be to return an error, or `.escape_codes` (though this might be unexpected). If you want to force escape codes on wasi for some reason, you don't need to do TTY detection, just use `.escape_codes` directly.