### PR TITLE
macos: try auto-detecting the SDK when building on Apple for Apple

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2542,12 +2542,6 @@ fn buildOutputType(
         }
     }
 
-    if (comptime builtin.target.isDarwin()) {
-        // If we want to link against frameworks, we need system headers.
-        if (framework_dirs.items.len > 0 or frameworks.count() > 0)
-            want_native_include_dirs = true;
-    }
-
     const want_native_paths_detection = blk: {
         if (sysroot != null) break :blk false;
         // If we are building natively on macOS and targeting any Apple platform,


### PR DESCRIPTION
This patch tweaks Zig's behavior to prefer native SDK when compiling on an Apple platform for an Apple platform, if available. This also includes the `build.zig` code path in `main.zig` which now auto-detects the presence of native SDK when compiling on an Apple platform.

The latter was a surprise for me as I blindly assumed we use the same code path for `build-exe`/`build-lib`/`cc` etc. as for `zig build` but the latter has its own, vastly simplified `Compilation` struct. If we are to support beta macOS releases out-of-the-box without the necessity to patch Zig up, we need to patch both code paths: `buildOutputType` and `cmdBuild`. I was wondering if there perhaps is a better way to achieve this than this PR, but on the other hand this PR is the simplest way forward as far as I can see.

Closes #16118 