### PR TITLE
objcopy.zig allow outputting zero length sections

### DIFF
--- a/src/objcopy.zig
+++ b/src/objcopy.zig
@@ -442,7 +442,7 @@ const BinaryElfOutput = struct {
     }
 
     fn sectionValidForOutput(shdr: anytype) bool {
-        return shdr.sh_size >= 0 and shdr.sh_type != elf.SHT_NOBITS and
+        return shdr.sh_type != elf.SHT_NOBITS and
             ((shdr.sh_flags & elf.SHF_ALLOC) == elf.SHF_ALLOC);
     }
 

--- a/src/objcopy.zig
+++ b/src/objcopy.zig
@@ -442,7 +442,7 @@ const BinaryElfOutput = struct {
     }
 
     fn sectionValidForOutput(shdr: anytype) bool {
-        return shdr.sh_size > 0 and shdr.sh_type != elf.SHT_NOBITS and
+        return shdr.sh_size >= 0 and shdr.sh_type != elf.SHT_NOBITS and
             ((shdr.sh_flags & elf.SHF_ALLOC) == elf.SHF_ALLOC);
     }
 


### PR DESCRIPTION
Regular objcopy allows to copy empty sections this is an interface change. Please fix this.