### PR TITLE
test: re-enable json tests that caused errors

### DIFF
--- a/lib/std/json/dynamic_test.zig
+++ b/lib/std/json/dynamic_test.zig
@@ -245,7 +245,6 @@ test "parseFromValue(std.json.Value,...)" {
 }
 
 test "polymorphic parsing" {
-    if (true) return error.SkipZigTest; // See https://github.com/ziglang/zig/issues/16108
     const doc =
         \\{ "type": "div",
         \\  "color": "blue",

--- a/lib/std/json/static_test.zig
+++ b/lib/std/json/static_test.zig
@@ -355,7 +355,6 @@ fn testAllParseFunctions(comptime T: type, expected: T, doc: []const u8) !void {
 }
 
 test "test all types" {
-    if (true) return error.SkipZigTest; // See https://github.com/ziglang/zig/issues/16108
     try testAllParseFunctions(Primitives, primitives_0, primitives_0_doc_0);
     try testAllParseFunctions(Primitives, primitives_0, primitives_0_doc_1);
     try testAllParseFunctions(Primitives, primitives_1, primitives_1_doc_0);


### PR DESCRIPTION
From https://github.com/ziglang/zig/pull/15981 and documented in https://github.com/ziglang/zig/issues/16108 .

This is a PR that shows the CI failure until it gets fixed. (Is this object useful to exist on github? is it just annoying noise?)