### PR TITLE
[heapsort] Protect against integer overflow

### DIFF
--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -93,30 +93,34 @@ pub fn heapContext(a: usize, b: usize, context: anytype) void {
     }
 }
 
-fn siftDown(a: usize, cur: usize, b: usize, context: anytype) void {
-    var child = (math.mul(usize, cur - a, 2) catch return) + a + 1;
-    // When we don't overflow from the multiply, the above expression equals (2*cur) - (2*a) + a + 1
-    // The `+ a + 1` is safe because:
-    //  for `a > 0` then `2a >= a + 1`.
-    //  for `a = 0`, the expression equals `2*cur+1`. `2*cur` is an even number, therefore adding 1 is safe.
+fn siftDown(a: usize, target: usize, b: usize, context: anytype) void {
+    var cur = target;
+    while (true) {
+        // When we don't overflow from the multiply below, the following expression equals (2*cur) - (2*a) + a + 1
+        // The `+ a + 1` is safe because:
+        //  for `a > 0` then `2a >= a + 1`.
+        //  for `a = 0`, the expression equals `2*cur+1`. `2*cur` is an even number, therefore adding 1 is safe.
+        var child = (math.mul(usize, cur - a, 2) catch break) + a + 1;
 
-    // stop if we overshot the boundary
-    if (!(child < b)) return;
+        // stop if we overshot the boundary
+        if (!(child < b)) break;
 
-    const next_child = child + 1; // `next_child` is at most `b`, therefore no overflow is possible
+        // `next_child` is at most `b`, therefore no overflow is possible
+        const next_child = child + 1;
 
-    // store the greater child in `child`
-    if (next_child < b and context.lessThan(child, next_child)) {
-        child = next_child;
+        // store the greater child in `child`
+        if (next_child < b and context.lessThan(child, next_child)) {
+            child = next_child;
+        }
+
+        // stop if the Heap invariant holds at `cur`.
+        if (context.lessThan(child, cur)) break;
+
+        // swap `cur` with the greater child,
+        // move one step down, and continue sifting.
+        context.swap(child, cur);
+        cur = child;
     }
-
-    // stop if the invariant holds at `cur`.
-    if (context.lessThan(child, cur)) return;
-
-    // swap `cur` with the greater child,
-    // move one step down, and continue sifting.
-    context.swap(child, cur);
-    return @call(.always_tail, siftDown, .{ a, child, b, context });
 }
 
 /// Use to generate a comparator function for a given type. e.g. `sort(u8, slice, {}, asc(u8))`.

--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -101,7 +101,7 @@ fn siftDown(a: usize, cur: usize, b: usize, context: anytype) void {
     //  for `a = 0`, the expression equals `2*cur+1`. `2*cur` is an even number, therefore adding 1 is safe.
 
     // stop if we overshot the boundary
-    if (child < b) {} else return;
+    if (!(child < b)) return;
 
     const next_child = child + 1; // `next_child` is at most `b`, therefore no overflow is possible
 

--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -36,6 +36,9 @@ pub fn insertion(
 /// O(1) memory (no allocator required).
 /// Sorts in ascending order with respect to the given `lessThan` function.
 pub fn insertionContext(a: usize, b: usize, context: anytype) void {
+    assert(a <= b);
+    assert(a < std.math.maxInt(usize));
+
     var i = a + 1;
     while (i < b) : (i += 1) {
         var j = i;

--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -37,7 +37,6 @@ pub fn insertion(
 /// Sorts in ascending order with respect to the given `lessThan` function.
 pub fn insertionContext(a: usize, b: usize, context: anytype) void {
     assert(a <= b);
-    assert(a < std.math.maxInt(usize));
 
     var i = a + 1;
     while (i < b) : (i += 1) {


### PR DESCRIPTION
(Firstly, I changed `n` to `b`, as that is less confusing. It's not a length, it's a right boundary.)

The invariant maintained is `cur < b`. In the worst case `2*cur + 1` results in a maximum of `2b`. Since `2b` is not guaranteed to be lower than `maxInt`, we have to add one overflow check to `siftDown` to make sure we avoid undefined behavior.

LLVM also seems to have a nicer time compiling this version of the function. It is about 2x faster in my tests (I think LLVM was stumped by the `child += @intFromBool` line), and adding/removing the overflow check has a negligible performance difference on my machine. Of course, we could check `2b <= maxInt` in the parent function, and dispatch to a version of the function without the overflow check in the common case, but that probably is not worth the code size just to eliminate a single instruction.