### PR TITLE
std.http: fix the http.Client.wait() hanging when there is 1 more byt…

### DIFF
--- a/lib/std/http/protocol.zig
+++ b/lib/std/http/protocol.zig
@@ -581,7 +581,7 @@ pub const HeadersParser = struct {
                         const nread = @min(conn.peek().len, data_avail);
                         conn.drop(@intCast(u16, nread));
                         r.next_chunk_length -= nread;
-                    } else {
+                    } else if (out_avail > 0) {
                         const can_read = @intCast(usize, @min(data_avail, out_avail));
                         const nread = try conn.read(buffer[out_index..][0..can_read]);
                         r.next_chunk_length -= nread;


### PR DESCRIPTION
…e left
This is according to my discussion with @truemedian on the issue https://github.com/ziglang/zig/issues/15902 and he suggested that I apply the patch described in https://github.com/ziglang/zig/issues/15710#issuecomment-1577201394 and send in a PR.
This fixes my long-held problem of using http/1.1 with google oauth2 server so I had to downgrade to http/1.0 for google only.