### PR TITLE
Support "--version" linker argument

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2211,6 +2211,9 @@ fn buildOutputType(
                         fatal("unable to parse /version '{s}': {s}", .{ arg, @errorName(err) });
                     };
                     have_version = true;
+                } else if (mem.eql(u8, arg, "--version")) {
+                    try std.io.getStdOut().writeAll("zig ld " ++ build_options.version ++ "\n");
+                    process.exit(0);
                 } else {
                     fatal("unsupported linker arg: {s}", .{arg});
                 }


### PR DESCRIPTION
This PR addresses  #15549 :  ```zig cc -Wl,--version``` not understood by the linker

With this PR, ```zig cc``` and ```zig c++``` support ```-Wl,--version``` argument.
The expected output is to print
```
zig ld <build-version>
```
and exit.