### PR TITLE
llvm: fixup elem_count argument of ZigLLVMCreateDebugArrayType to be i64

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1719,7 +1719,7 @@ pub const Object = struct {
                     ty.abiSize(mod) * 8,
                     ty.abiAlignment(mod) * 8,
                     try o.lowerDebugType(ty.childType(mod), .full),
-                    @intCast(c_int, ty.arrayLen(mod)),
+                    @intCast(i64, ty.arrayLen(mod)),
                 );
                 // The recursive call to `lowerDebugType` means we can't use `gop` anymore.
                 try o.di_type_map.put(gpa, ty.toIntern(), AnnotatedDITypePtr.initFull(array_di_ty));

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -1681,7 +1681,7 @@ pub const DIBuilder = opaque {
         size_in_bits: u64,
         align_in_bits: u64,
         elem_type: *DIType,
-        elem_count: c_int,
+        elem_count: i64,
     ) *DIType;
 
     pub const createEnumerator = ZigLLVMCreateDebugEnumerator;

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -601,7 +601,7 @@ struct ZigLLVMDIType *ZigLLVMDIBuilderCreateVectorType(struct ZigLLVMDIBuilder *
 }
 
 ZigLLVMDIType *ZigLLVMCreateDebugArrayType(ZigLLVMDIBuilder *dibuilder, uint64_t size_in_bits,
-        uint64_t align_in_bits, ZigLLVMDIType *elem_type, int elem_count)
+        uint64_t align_in_bits, ZigLLVMDIType *elem_type, int64_t elem_count)
 {
     SmallVector<Metadata *, 1> subrange;
     subrange.push_back(reinterpret_cast<DIBuilder*>(dibuilder)->getOrCreateSubrange(0, elem_count));

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -179,7 +179,7 @@ ZIG_EXTERN_C struct ZigLLVMDIType *ZigLLVMCreateDebugBasicType(struct ZigLLVMDIB
 
 ZIG_EXTERN_C struct ZigLLVMDIType *ZigLLVMCreateDebugArrayType(struct ZigLLVMDIBuilder *dibuilder,
         uint64_t size_in_bits, uint64_t align_in_bits, struct ZigLLVMDIType *elem_type,
-        int elem_count);
+        int64_t elem_count);
 
 ZIG_EXTERN_C struct ZigLLVMDIEnumerator *ZigLLVMCreateDebugEnumerator(struct ZigLLVMDIBuilder *dibuilder,
         const char *name, uint64_t val, bool isUnsigned);

--- a/test/cases/llvm/large_slices.zig
+++ b/test/cases/llvm/large_slices.zig
@@ -1,0 +1,9 @@
+pub fn main() void {
+    const large_slice = @ptrFromInt([*]const u8, 1)[0..(0xffffffffffffffff >> 3)];
+    _ = large_slice;
+}
+
+// compile
+// backend=llvm
+// target=x86_64-linux,x86_64-macos
+//


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/16156.

The signature is `getOrCreateSubrange(int64_t  Lo, int64_t  Count)`, so this updates the bindings to match.

This fixes a crash in `lowerDebugTypeImpl` when analyzing slices that have a length of 2^32 or larger (up to `2^64 >> 3`, which still crashes, because above that the array size in bits overflows u64: https://github.com/ziglang/zig/issues/14627).