### PR TITLE
sema: Fix overflow when analyzing an inline switch prong range that ends on the maximum value of the switched type

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -11646,6 +11646,8 @@ fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index, operand_is_r
                     cases_extra.appendAssumeCapacity(@intCast(u32, case_block.instructions.items.len));
                     cases_extra.appendAssumeCapacity(@intFromEnum(item_ref));
                     cases_extra.appendSliceAssumeCapacity(case_block.instructions.items);
+
+                    if (item.compareScalar(.eq, item_last, operand_ty, mod)) break;
                 }
             }
 

--- a/test/behavior/switch.zig
+++ b/test/behavior/switch.zig
@@ -785,3 +785,15 @@ test "switch pointer capture peer type resolution" {
     try expectEqual(U{ .a = 111 }, ua);
     try expectEqual(U{ .b = 222 }, ub);
 }
+
+test "inline switch range that includes the maximum value of the switched type" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    const inputs: [3]u8 = .{ 0, 254, 255 };
+    for (inputs) |input| {
+        switch (input) {
+            inline 254...255 => |val| try expectEqual(input, val),
+            else => |val| try expectEqual(input, val),
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/16165