### PR TITLE
std.c: fix few capcisum api calls, following-up on 6ae19fa.

### DIFF
--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -554,11 +554,11 @@ pub const CAP = struct {
 pub extern "c" fn __cap_rights_init(version: c_int, rights: ?*cap_rights_t, ...) ?*cap_rights_t;
 pub extern "c" fn __cap_rights_set(rights: ?*cap_rights_t, ...) ?*cap_rights_t;
 pub extern "c" fn __cap_rights_clear(rights: ?*cap_rights_t, ...) ?*cap_rights_t;
-pub extern "c" fn __cap_rights_merge(dst: ?*cap_rights_t, src: ?*const cap_rights_t) ?*cap_rights_t;
-pub extern "c" fn __cap_rights_remove(dst: ?*cap_rights_t, src: ?*const cap_rights_t) ?*cap_rights_t;
-pub extern "c" fn __cap_rights_contains(dst: ?*const cap_rights_t, src: ?*const cap_rights_t) bool;
 pub extern "c" fn __cap_rights_is_set(rights: ?*const cap_rights_t, ...) bool;
-pub extern "c" fn __cap_rights_is_valid(rights: ?*const cap_rights_t) bool;
+pub extern "c" fn cap_rights_merge(dst: ?*cap_rights_t, src: ?*const cap_rights_t) ?*cap_rights_t;
+pub extern "c" fn cap_rights_remove(dst: ?*cap_rights_t, src: ?*const cap_rights_t) ?*cap_rights_t;
+pub extern "c" fn cap_rights_contains(dst: ?*const cap_rights_t, src: ?*const cap_rights_t) bool;
+pub extern "c" fn cap_rights_is_valid(rights: ?*const cap_rights_t) bool;
 
 pub const kinfo_file = extern struct {
     /// Size of this record.


### PR DESCRIPTION
only variadic calls are prefixed with underscores.

ref: https://github.com/freebsd/freebsd-src/blob/59833b089e78463a561706fc03777249766aea01/sys/sys/capsicum.h#L326