### PR TITLE
std.c: fix host_basic_info definition for darwin.

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -4073,7 +4073,7 @@ pub const HOST = struct {
     pub const EXTMOD_INFO64_COUNT = HostCount(vm_extmod_statistics_data_t);
 };
 
-pub const host_basic_info = packed struct(u32) {
+pub const host_basic_info = extern struct {
     max_cpus: integer_t,
     avail_cpus: integer_t,
     memory_size: natural_t,


### PR DESCRIPTION
follow-up on ff59c45.

ref: https://github.com/ziglang/zig/blob/a5e15eced0e9cb00871966ede74eed9b3a07183c/lib/libc/include/any-macos-any/mach/host_info.h#L116