### PR TITLE
fix array boundchecks performance regression (debug builds)

### DIFF
--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -621,11 +621,18 @@ pub fn categorizeOperand(
                 if (inst_data.operand == operand_ref and operandDies(l, body[0], 0))
                     return .tomb;
 
-                if (cond_extra.data.then_body_len != 1 or cond_extra.data.else_body_len != 1)
+                if (cond_extra.data.then_body_len > 2 or cond_extra.data.else_body_len > 2)
+                    return .complex;
+
+                const then_body = air.extra[cond_extra.end..][0..cond_extra.data.then_body_len];
+                const else_body = air.extra[cond_extra.end + cond_extra.data.then_body_len ..][0 .. cond_extra.data.then_body_len + cond_extra.data.else_body_len];
+                if (then_body.len > 1 and air_tags[then_body[1]] != .unreach)
+                    return .complex;
+                if (else_body.len > 1 and air_tags[else_body[1]] != .unreach)
                     return .complex;
 
                 var operand_live: bool = true;
-                for (air.extra[cond_extra.end..][0..2]) |cond_inst| {
+                for (&[_]u32{ then_body[0], else_body[0] }) |cond_inst| {
                     if (l.categorizeOperand(air, cond_inst, operand, ip) == .tomb)
                         operand_live = false;
 


### PR DESCRIPTION
I observed the llvm.memcpy elision to avoid the performance issue #12215 was no longer applied...

I reckon that's because there's an `unreach()` instruction after the call to panic , and the check introduced in  [25d3713b07a100d8fdb349317db97fd9d0c1e366] 
doesn't account for it.

so i've added some code to detect this case, and observed the debug performance is restored.

(caveat: I have no idea what I'm doing.. ^^ )
