### PR TITLE
cbe: fix crash caused by calling `mod.intValue` on `type_inferred_error_set`

### DIFF
--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -5654,14 +5654,13 @@ fn airErrUnionPayloadPtrSet(f: *Function, inst: Air.Inst.Index) !CValue {
     const operand = try f.resolveInst(ty_op.operand);
     const error_union_ty = f.typeOf(ty_op.operand).childType(mod);
 
-    const error_ty = error_union_ty.errorUnionSet(mod);
     const payload_ty = error_union_ty.errorUnionPayload(mod);
 
     // First, set the non-error value.
     if (!payload_ty.hasRuntimeBitsIgnoreComptime(mod)) {
         try f.writeCValueDeref(writer, operand);
         try writer.writeAll(" = ");
-        try f.object.dg.renderValue(writer, error_ty, try mod.intValue(error_ty, 0), .Other);
+        try f.object.dg.renderValue(writer, Type.err_int, try mod.intValue(Type.err_int, 0), .Other);
         try writer.writeAll(";\n ");
 
         return operand;

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -5534,7 +5534,7 @@ fn airUnwrapErrUnionErr(f: *Function, inst: Air.Inst.Index) !CValue {
             else
                 try f.writeCValueMember(writer, operand, .{ .identifier = "error" })
         else
-            try f.object.dg.renderValue(writer, error_ty, try mod.intValue(error_ty, 0), .Initializer);
+            try f.object.dg.renderValue(writer, Type.err_int, try mod.intValue(Type.err_int, 0), .Initializer);
     }
     try writer.writeAll(";\n");
     return local;

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -921,3 +921,20 @@ test "optional error set return type" {
     try expect(null == S.foo(true));
     try expect(E.A == S.foo(false).?);
 }
+
+test "returning an error union containing a type with no runtime bits" {
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    const ZeroByteType = struct {
+        foo: void,
+
+        pub fn init() !@This() {
+            return .{ .foo = {} };
+        }
+    };
+
+    var zero_byte: ZeroByteType = undefined;
+    (&zero_byte).* = try ZeroByteType.init();
+}


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/16186.

I believe this is the correct fix, based on the second part of this function (ie. the payload has runtime bits).

