### PR TITLE
Air: store interned values in Air.Inst.Ref

### DIFF
--- a/src/Liveness/Verify.zig
+++ b/src/Liveness/Verify.zig
@@ -44,7 +44,6 @@ fn verifyBody(self: *Verify, body: []const Air.Inst.Index) Error!void {
             .inferred_alloc,
             .inferred_alloc_comptime,
             .ret_ptr,
-            .interned,
             .breakpoint,
             .dbg_stmt,
             .dbg_inline_begin,
@@ -559,10 +558,6 @@ fn verifyOperand(self: *Verify, inst: Air.Inst.Index, op_ref: Air.Inst.Ref, dies
         assert(!dies);
         return;
     };
-    if (self.air.instructions.items(.tag)[operand] == .interned) {
-        assert(!dies);
-        return;
-    }
     if (dies) {
         if (!self.live.remove(operand)) return invalid("%{}: dead operand %{} reused and killed again", .{ inst, operand });
     } else {
@@ -583,7 +578,6 @@ fn verifyInstOperands(
 }
 
 fn verifyInst(self: *Verify, inst: Air.Inst.Index) Error!void {
-    if (self.air.instructions.items(.tag)[inst] == .interned) return;
     if (self.liveness.isUnused(inst)) {
         assert(!self.live.contains(inst));
     } else {

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -845,7 +845,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .ptr_elem_val        => try self.airPtrElemVal(inst),
             .ptr_elem_ptr        => try self.airPtrElemPtr(inst),
 
-            .inferred_alloc, .inferred_alloc_comptime, .interned => unreachable,
+            .inferred_alloc, .inferred_alloc_comptime => unreachable,
             .unreach  => self.finishAirBookkeeping(),
 
             .optional_payload           => try self.airOptionalPayload(inst),
@@ -920,7 +920,6 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
 
 /// Asserts there is already capacity to insert into top branch inst_table.
 fn processDeath(self: *Self, inst: Air.Inst.Index) void {
-    assert(self.air.instructions.items(.tag)[inst] != .interned);
     // When editing this function, note that the logic must synchronize with `reuseOperand`.
     const prev_value = self.getResolvedInstValue(inst);
     const branch = &self.branch_stack.items[self.branch_stack.items.len - 1];
@@ -953,9 +952,7 @@ fn finishAir(self: *Self, inst: Air.Inst.Index, result: MCValue, operands: [Live
         const dies = @as(u1, @truncate(tomb_bits)) != 0;
         tomb_bits >>= 1;
         if (!dies) continue;
-        const op_int = @intFromEnum(op);
-        if (op_int < Air.ref_start_index) continue;
-        const op_index = @as(Air.Inst.Index, @intCast(op_int - Air.ref_start_index));
+        const op_index = Air.refToIndex(op) orelse continue;
         self.processDeath(op_index);
     }
     const is_used = @as(u1, @truncate(tomb_bits)) == 0;
@@ -4696,9 +4693,7 @@ fn airCondBr(self: *Self, inst: Air.Inst.Index) !void {
     // that death now instead of later as this has an effect on
     // whether it needs to be spilled in the branches
     if (self.liveness.operandDies(inst, 0)) {
-        const op_int = @intFromEnum(pl_op.operand);
-        if (op_int >= Air.ref_start_index) {
-            const op_index = @as(Air.Inst.Index, @intCast(op_int - Air.ref_start_index));
+        if (Air.refToIndex(pl_op.operand)) |op_index| {
             self.processDeath(op_index);
         }
     }
@@ -6149,22 +6144,7 @@ fn resolveInst(self: *Self, inst: Air.Inst.Ref) InnerError!MCValue {
         .val = (try self.air.value(inst, mod)).?,
     });
 
-    switch (self.air.instructions.items(.tag)[inst_index]) {
-        .interned => {
-            // Constants have static lifetimes, so they are always memoized in the outer most table.
-            const branch = &self.branch_stack.items[0];
-            const gop = try branch.inst_table.getOrPut(self.gpa, inst_index);
-            if (!gop.found_existing) {
-                const interned = self.air.instructions.items(.data)[inst_index].interned;
-                gop.value_ptr.* = try self.genTypedValue(.{
-                    .ty = inst_ty,
-                    .val = interned.toValue(),
-                });
-            }
-            return gop.value_ptr.*;
-        },
-        else => return self.getResolvedInstValue(inst_index),
-    }
+    return self.getResolvedInstValue(inst_index);
 }
 
 fn getResolvedInstValue(self: *Self, inst: Air.Inst.Index) MCValue {

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -829,7 +829,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .ptr_elem_val        => try self.airPtrElemVal(inst),
             .ptr_elem_ptr        => try self.airPtrElemPtr(inst),
 
-            .inferred_alloc, .inferred_alloc_comptime, .interned => unreachable,
+            .inferred_alloc, .inferred_alloc_comptime => unreachable,
             .unreach  => self.finishAirBookkeeping(),
 
             .optional_payload           => try self.airOptionalPayload(inst),
@@ -904,7 +904,6 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
 
 /// Asserts there is already capacity to insert into top branch inst_table.
 fn processDeath(self: *Self, inst: Air.Inst.Index) void {
-    assert(self.air.instructions.items(.tag)[inst] != .interned);
     // When editing this function, note that the logic must synchronize with `reuseOperand`.
     const prev_value = self.getResolvedInstValue(inst);
     const branch = &self.branch_stack.items[self.branch_stack.items.len - 1];
@@ -939,9 +938,7 @@ fn finishAir(self: *Self, inst: Air.Inst.Index, result: MCValue, operands: [Live
         const dies = @as(u1, @truncate(tomb_bits)) != 0;
         tomb_bits >>= 1;
         if (!dies) continue;
-        const op_int = @intFromEnum(op);
-        if (op_int < Air.ref_start_index) continue;
-        const op_index = @as(Air.Inst.Index, @intCast(op_int - Air.ref_start_index));
+        const op_index = Air.refToIndex(op) orelse continue;
         self.processDeath(op_index);
     }
     const is_used = @as(u1, @truncate(tomb_bits)) == 0;
@@ -4651,9 +4648,7 @@ fn airCondBr(self: *Self, inst: Air.Inst.Index) !void {
     // that death now instead of later as this has an effect on
     // whether it needs to be spilled in the branches
     if (self.liveness.operandDies(inst, 0)) {
-        const op_int = @intFromEnum(pl_op.operand);
-        if (op_int >= Air.ref_start_index) {
-            const op_index = @as(Air.Inst.Index, @intCast(op_int - Air.ref_start_index));
+        if (Air.refToIndex(pl_op.operand)) |op_index| {
             self.processDeath(op_index);
         }
     }
@@ -6102,22 +6097,7 @@ fn resolveInst(self: *Self, inst: Air.Inst.Ref) InnerError!MCValue {
         .val = (try self.air.value(inst, mod)).?,
     });
 
-    switch (self.air.instructions.items(.tag)[inst_index]) {
-        .interned => {
-            // Constants have static lifetimes, so they are always memoized in the outer most table.
-            const branch = &self.branch_stack.items[0];
-            const gop = try branch.inst_table.getOrPut(self.gpa, inst_index);
-            if (!gop.found_existing) {
-                const interned = self.air.instructions.items(.data)[inst_index].interned;
-                gop.value_ptr.* = try self.genTypedValue(.{
-                    .ty = inst_ty,
-                    .val = interned.toValue(),
-                });
-            }
-            return gop.value_ptr.*;
-        },
-        else => return self.getResolvedInstValue(inst_index),
-    }
+    return self.getResolvedInstValue(inst_index);
 }
 
 fn getResolvedInstValue(self: *Self, inst: Air.Inst.Index) MCValue {

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -677,7 +677,7 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .ptr_elem_val        => try self.airPtrElemVal(inst),
             .ptr_elem_ptr        => try self.airPtrElemPtr(inst),
 
-            .inferred_alloc, .inferred_alloc_comptime, .interned => unreachable,
+            .inferred_alloc, .inferred_alloc_comptime => unreachable,
             .unreach  => self.finishAirBookkeeping(),
 
             .optional_payload           => try self.airOptionalPayload(inst),
@@ -1515,9 +1515,7 @@ fn airCondBr(self: *Self, inst: Air.Inst.Index) !void {
     // that death now instead of later as this has an effect on
     // whether it needs to be spilled in the branches
     if (self.liveness.operandDies(inst, 0)) {
-        const op_int = @intFromEnum(pl_op.operand);
-        if (op_int >= Air.ref_start_index) {
-            const op_index = @as(Air.Inst.Index, @intCast(op_int - Air.ref_start_index));
+        if (Air.refToIndex(pl_op.operand)) |op_index| {
             self.processDeath(op_index);
         }
     }
@@ -3570,9 +3568,7 @@ fn finishAir(self: *Self, inst: Air.Inst.Index, result: MCValue, operands: [Live
         const dies = @as(u1, @truncate(tomb_bits)) != 0;
         tomb_bits >>= 1;
         if (!dies) continue;
-        const op_int = @intFromEnum(op);
-        if (op_int < Air.ref_start_index) continue;
-        const op_index = @as(Air.Inst.Index, @intCast(op_int - Air.ref_start_index));
+        const op_index = Air.refToIndex(op) orelse continue;
         self.processDeath(op_index);
     }
     const is_used = @as(u1, @truncate(tomb_bits)) == 0;
@@ -4422,7 +4418,6 @@ fn performReloc(self: *Self, inst: Mir.Inst.Index) !void {
 
 /// Asserts there is already capacity to insert into top branch inst_table.
 fn processDeath(self: *Self, inst: Air.Inst.Index) void {
-    assert(self.air.instructions.items(.tag)[inst] != .interned);
     // When editing this function, note that the logic must synchronize with `reuseOperand`.
     const prev_value = self.getResolvedInstValue(inst);
     const branch = &self.branch_stack.items[self.branch_stack.items.len - 1];
@@ -4550,22 +4545,7 @@ fn resolveInst(self: *Self, ref: Air.Inst.Ref) InnerError!MCValue {
     if (!ty.hasRuntimeBitsIgnoreComptime(mod)) return .none;
 
     if (Air.refToIndex(ref)) |inst| {
-        switch (self.air.instructions.items(.tag)[inst]) {
-            .interned => {
-                // Constants have static lifetimes, so they are always memoized in the outer most table.
-                const branch = &self.branch_stack.items[0];
-                const gop = try branch.inst_table.getOrPut(self.gpa, inst);
-                if (!gop.found_existing) {
-                    const interned = self.air.instructions.items(.data)[inst].interned;
-                    gop.value_ptr.* = try self.genTypedValue(.{
-                        .ty = ty,
-                        .val = interned.toValue(),
-                    });
-                }
-                return gop.value_ptr.*;
-            },
-            else => return self.getResolvedInstValue(inst),
-        }
+        return self.getResolvedInstValue(inst);
     }
 
     return self.genTypedValue(.{


### PR DESCRIPTION
Previously, interned values were represented as AIR instructions using the `interned` tag. Now, the AIR ref directly encodes the InternPool index. The encoding works as follows:
* If the ref matches one of the static values, it corresponds to the same InternPool index.
* Otherwise, if the MSB is 0, the ref corresponds to an InternPool index.
* Otherwise, if the MSB is 1, the ref corresponds to an AIR instruction index (after removing the MSB).

Note that since most static InternPool indices are low values (the exceptions being `.none` and `.var_args_param_type`), the first rule is almost a nop.