### PR TITLE
Recognize the .res extension and link it as if it were an object file

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4436,7 +4436,7 @@ pub fn addCCArgs(
                 try argv.append("-fno-unwind-tables");
             }
         },
-        .shared_library, .ll, .bc, .unknown, .static_library, .object, .def, .zig => {},
+        .shared_library, .ll, .bc, .unknown, .static_library, .object, .def, .zig, .res => {},
         .assembly, .assembly_with_cpp => {
             // The Clang assembler does not accept the list of CPU features like the
             // compiler frontend does. Therefore we must hard-code the -m flags for
@@ -4602,6 +4602,7 @@ pub const FileExt = enum {
     static_library,
     zig,
     def,
+    res,
     unknown,
 
     pub fn clangSupportsDepFile(ext: FileExt) bool {
@@ -4617,6 +4618,7 @@ pub const FileExt = enum {
             .static_library,
             .zig,
             .def,
+            .res,
             .unknown,
             => false,
         };
@@ -4639,6 +4641,7 @@ pub const FileExt = enum {
             .static_library => target.staticLibSuffix(),
             .zig => ".zig",
             .def => ".def",
+            .res => ".res",
             .unknown => "",
         };
     }
@@ -4730,6 +4733,8 @@ pub fn classifyFileExt(filename: []const u8) FileExt {
         return .cu;
     } else if (mem.endsWith(u8, filename, ".def")) {
         return .def;
+    } else if (mem.endsWith(u8, filename, ".res")) {
+        return .res;
     } else {
         return .unknown;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1510,7 +1510,7 @@ fn buildOutputType(
                     }
                 } else switch (file_ext orelse
                     Compilation.classifyFileExt(arg)) {
-                    .object, .static_library, .shared_library => try link_objects.append(.{ .path = arg }),
+                    .object, .static_library, .shared_library, .res => try link_objects.append(.{ .path = arg }),
                     .assembly, .assembly_with_cpp, .c, .cpp, .h, .ll, .bc, .m, .mm, .cu => {
                         try c_source_files.append(.{
                             .src_path = arg,
@@ -1605,7 +1605,7 @@ fn buildOutputType(
                                 .ext = file_ext, // duped while parsing the args.
                             });
                         },
-                        .unknown, .shared_library, .object, .static_library => try link_objects.append(.{
+                        .unknown, .shared_library, .object, .static_library, .res => try link_objects.append(.{
                             .path = it.only_arg,
                             .must_link = must_link,
                         }),


### PR DESCRIPTION
.res files are compiled Windows resource files that get linked into executables/libraries. The linker knows what to do with them, but previously you had to trick Zig into thinking it was an object file (by renaming it to have the .obj extension, for example).

After this commit, the following works:

    zig build-exe main.zig resource.res

or, in build.zig:

    exe.addObjectFile("resource.res");

Closes #6488 (first baby steps towards https://github.com/ziglang/zig/issues/3702)

---

Basic example of embedding an icon in a .exe so that it shows up in explorer:

![zig-ico-exe](https://github.com/ziglang/zig/assets/2389051/fc87d62e-a205-4dec-bbfc-35c6f2174677)