### PR TITLE
Follow-up to cast builtin result type inference

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10267,7 +10267,7 @@ pub fn main() void {
     foo(Set1.B);
 }
 fn foo(set1: Set1) void {
-    const x = @as(Set2, @errSetCast(set1));
+    const x: Set2 = @errSetCast(set1);
     std.debug.print("value: {}\n", .{x});
 }
       {#code_end#}

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -8050,17 +8050,9 @@ fn ptrCast(
     }
 
     // Full cast including result type
-    const need_result_type_builtin = if (flags.ptr_cast)
-        "@ptrCast"
-    else if (flags.align_cast)
-        "@alignCast"
-    else if (flags.addrspace_cast)
-        "@addrSpaceCast"
-    else
-        unreachable;
 
     const cursor = maybeAdvanceSourceCursorToMainToken(gz, root_node);
-    const result_type = try ri.rl.resultType(gz, root_node, need_result_type_builtin);
+    const result_type = try ri.rl.resultType(gz, root_node, flags.needResultTypeBuiltinName());
     const operand = try expr(gz, scope, .{ .rl = .none }, node);
     try emitDbgStmt(gz, cursor);
     const result = try gz.addExtendedPayloadSmall(.ptr_cast_full, flags_i, Zir.Inst.BinNode{

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -6480,11 +6480,11 @@ fn forExpr(
                     return astgen.failTok(ident_tok, "cannot capture reference to range", .{});
                 }
                 const start_node = node_data[input].lhs;
-                const start_val = try expr(parent_gz, scope, .{ .rl = .none }, start_node);
+                const start_val = try expr(parent_gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, start_node);
 
                 const end_node = node_data[input].rhs;
                 const end_val = if (end_node != 0)
-                    try expr(parent_gz, scope, .{ .rl = .none }, node_data[input].rhs)
+                    try expr(parent_gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, node_data[input].rhs)
                 else
                     .none;
 

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2820,6 +2820,13 @@ pub const Inst = struct {
         addrspace_cast: bool = false,
         const_cast: bool = false,
         volatile_cast: bool = false,
+
+        pub inline fn needResultTypeBuiltinName(flags: FullPtrCastFlags) []const u8 {
+            if (flags.ptr_cast) return "@ptrCast";
+            if (flags.align_cast) return "@alignCast";
+            if (flags.addrspace_cast) return "@addrSpaceCast";
+            unreachable;
+        }
     };
 
     /// Trailing:

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -2219,3 +2219,125 @@ test "peer type resolution: pointer attributes are combined correctly" {
     try expectEqualSlices(u8, std.mem.span(@volatileCast(r2)), "bar");
     try expectEqualSlices(u8, std.mem.span(@volatileCast(r3)), "baz");
 }
+
+test "cast builtins can wrap result in optional" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        const MyEnum = enum(u32) { _ };
+        fn a() ?MyEnum {
+            return @enumFromInt(123);
+        }
+        fn b() ?u32 {
+            return @intFromFloat(42.50);
+        }
+        fn c() ?*const f32 {
+            const x: u32 = 1;
+            return @ptrCast(&x);
+        }
+
+        fn doTheTest() !void {
+            const ra = a() orelse return error.ImpossibleError;
+            const rb = b() orelse return error.ImpossibleError;
+            const rc = c() orelse return error.ImpossibleError;
+
+            comptime assert(@TypeOf(ra) == MyEnum);
+            comptime assert(@TypeOf(rb) == u32);
+            comptime assert(@TypeOf(rc) == *const f32);
+
+            try expect(@intFromEnum(ra) == 123);
+            try expect(rb == 42);
+            try expect(@as(*const u32, @ptrCast(rc)).* == 1);
+        }
+    };
+
+    try S.doTheTest();
+    try comptime S.doTheTest();
+}
+
+test "cast builtins can wrap result in error union" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        const MyEnum = enum(u32) { _ };
+        const E = error{ImpossibleError};
+        fn a() E!MyEnum {
+            return @enumFromInt(123);
+        }
+        fn b() E!u32 {
+            return @intFromFloat(42.50);
+        }
+        fn c() E!*const f32 {
+            const x: u32 = 1;
+            return @ptrCast(&x);
+        }
+
+        fn doTheTest() !void {
+            const ra = try a();
+            const rb = try b();
+            const rc = try c();
+
+            comptime assert(@TypeOf(ra) == MyEnum);
+            comptime assert(@TypeOf(rb) == u32);
+            comptime assert(@TypeOf(rc) == *const f32);
+
+            try expect(@intFromEnum(ra) == 123);
+            try expect(rb == 42);
+            try expect(@as(*const u32, @ptrCast(rc)).* == 1);
+        }
+    };
+
+    try S.doTheTest();
+    try comptime S.doTheTest();
+}
+
+test "cast builtins can wrap result in error union and optional" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        const MyEnum = enum(u32) { _ };
+        const E = error{ImpossibleError};
+        fn a() E!?MyEnum {
+            return @enumFromInt(123);
+        }
+        fn b() E!?u32 {
+            return @intFromFloat(42.50);
+        }
+        fn c() E!?*const f32 {
+            const x: u32 = 1;
+            return @ptrCast(&x);
+        }
+
+        fn doTheTest() !void {
+            const ra = try a() orelse return error.ImpossibleError;
+            const rb = try b() orelse return error.ImpossibleError;
+            const rc = try c() orelse return error.ImpossibleError;
+
+            comptime assert(@TypeOf(ra) == MyEnum);
+            comptime assert(@TypeOf(rb) == u32);
+            comptime assert(@TypeOf(rc) == *const f32);
+
+            try expect(@intFromEnum(ra) == 123);
+            try expect(rb == 42);
+            try expect(@as(*const u32, @ptrCast(rc)).* == 1);
+        }
+    };
+
+    try S.doTheTest();
+    try comptime S.doTheTest();
+}

--- a/test/cases/compile_errors/cast_without_result_type.zig
+++ b/test/cases/compile_errors/cast_without_result_type.zig
@@ -1,0 +1,28 @@
+export fn a() void {
+    _ = @ptrFromInt(123);
+}
+export fn b() void {
+    const x = @ptrCast(@alignCast(@as(*u8, undefined)));
+    _ = x;
+}
+export fn c() void {
+    _ = &@intCast(@as(u64, 123));
+    _ = S;
+}
+export fn d() void {
+    var x: f32 = 0;
+    _ = x + @floatFromInt(123);
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:9: error: @ptrFromInt must have a known result type
+// :2:9: note: use @as to provide explicit result type
+// :5:15: error: @ptrCast must have a known result type
+// :5:15: note: use @as to provide explicit result type
+// :9:10: error: @intCast must have a known result type
+// :9:10: note: use @as to provide explicit result type
+// :14:13: error: @floatFromInt must have a known result type
+// :14:13: note: use @as to provide explicit result type

--- a/test/cases/compile_errors/cast_without_result_type_due_to_generic_parameter.zig
+++ b/test/cases/compile_errors/cast_without_result_type_due_to_generic_parameter.zig
@@ -1,0 +1,31 @@
+export fn a() void {
+    bar(@ptrFromInt(123));
+}
+export fn b() void {
+    bar(@ptrCast(@alignCast(@as(*u8, undefined))));
+}
+export fn c() void {
+    bar(@intCast(@as(u64, 123)));
+}
+export fn d() void {
+    bar(@floatFromInt(123));
+}
+
+fn bar(_: anytype) void {}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:9: error: @ptrFromInt must have a known result type
+// :2:9: note: result type is unknown due to anytype parameter
+// :2:9: note: use @as to provide explicit result type
+// :5:9: error: @ptrCast must have a known result type
+// :5:9: note: result type is unknown due to anytype parameter
+// :5:9: note: use @as to provide explicit result type
+// :8:9: error: @intCast must have a known result type
+// :8:9: note: result type is unknown due to anytype parameter
+// :8:9: note: use @as to provide explicit result type
+// :11:9: error: @floatFromInt must have a known result type
+// :11:9: note: result type is unknown due to anytype parameter
+// :11:9: note: use @as to provide explicit result type

--- a/test/cases/compile_errors/nested_ptr_cast_bad_operand.zig
+++ b/test/cases/compile_errors/nested_ptr_cast_bad_operand.zig
@@ -1,0 +1,22 @@
+const p: ?*const u8 = null;
+export fn a() void {
+    _ = @as(*const u32, @ptrCast(@alignCast(p)));
+}
+export fn b() void {
+    _ = @constCast(@volatileCast(123));
+}
+export fn c() void {
+    const x: ?*f32 = @constCast(@ptrCast(@addrSpaceCast(@volatileCast(p))));
+    _ = x;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:45: error: null pointer casted to type '*const u32'
+// :6:34: error: expected pointer type, found 'comptime_int'
+// :9:22: error: cast increases pointer alignment
+// :9:71: note: '?*const u8' has alignment '1'
+// :9:22: note: '?*f32' has alignment '4'
+// :9:22: note: use @alignCast to assert pointer alignment

--- a/test/cases/compile_errors/redundant_ptr_cast.zig
+++ b/test/cases/compile_errors/redundant_ptr_cast.zig
@@ -1,0 +1,19 @@
+const p: *anyopaque = undefined;
+export fn a() void {
+    _ = @ptrCast(@ptrCast(p));
+}
+export fn b() void {
+    const ptr1: *u32 = @alignCast(@ptrCast(@alignCast(p)));
+    _ = ptr1;
+}
+export fn c() void {
+    _ = @constCast(@alignCast(@ptrCast(@constCast(@volatileCast(p)))));
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:18: error: redundant @ptrCast
+// :6:44: error: redundant @alignCast
+// :10:40: error: redundant @constCast


### PR DESCRIPTION
Two main things here:
* Add the ability for cast builtins to unwrap a layer of error union and/or optional from the result type. e.g. `@as(?MyEnum, @enumFromInt(123))` is now valid.
* Add a bunch of tests (both behavior and compile error).