### PR TITLE
AstGen: add source location to certain const initializers

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -3209,7 +3209,10 @@ fn varDecl(
                 // In case the result location did not do the coercion
                 // for us so we must do it here.
                 const coerced_init = if (opt_type_inst != .none)
-                    try gz.addBin(.as, opt_type_inst, init_inst)
+                    try gz.addPlNode(.as_node, var_decl.ast.init_node, Zir.Inst.As{
+                        .dest_type = opt_type_inst,
+                        .operand = init_inst,
+                    })
                 else
                     init_inst;
 

--- a/test/cases/compile_errors/assign_local_bad_coercion.zig
+++ b/test/cases/compile_errors/assign_local_bad_coercion.zig
@@ -1,0 +1,22 @@
+fn g() u64 {
+    return 0;
+}
+
+export fn constEntry() u32 {
+    const x: u32 = g();
+    return x;
+}
+
+export fn varEntry() u32 {
+    var x: u32 = g();
+    return x;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :6:21: error: expected type 'u32', found 'u64'
+// :6:21: note: unsigned 32-bit int cannot represent all possible unsigned 64-bit values
+// :11:19: error: expected type 'u32', found 'u64'
+// :11:19: note: unsigned 32-bit int cannot represent all possible unsigned 64-bit values

--- a/test/cases/compile_errors/break_void_result_location.zig
+++ b/test/cases/compile_errors/break_void_result_location.zig
@@ -29,4 +29,4 @@ export fn f4() void {
 // :2:22: error: expected type 'usize', found 'void'
 // :7:9: error: expected type 'usize', found 'void'
 // :14:9: error: expected type 'usize', found 'void'
-// :18:1: error: expected type 'usize', found 'void'
+// :19:27: error: expected type 'usize', found 'void'

--- a/test/cases/compile_errors/nested_error_set_mismatch.zig
+++ b/test/cases/compile_errors/nested_error_set_mismatch.zig
@@ -14,6 +14,6 @@ fn foo() ?OtherError!i32 {
 // backend=llvm
 // target=native
 //
-// :4:1: error: expected type '?error{NextError}!i32', found '?error{OutOfMemory}!i32'
-// :4:1: note: optional type child 'error{OutOfMemory}!i32' cannot cast into optional type child 'error{NextError}!i32'
-// :4:1: note: 'error.OutOfMemory' not a member of destination error set
+// :5:34: error: expected type '?error{NextError}!i32', found '?error{OutOfMemory}!i32'
+// :5:34: note: optional type child 'error{OutOfMemory}!i32' cannot cast into optional type child 'error{NextError}!i32'
+// :5:34: note: 'error.OutOfMemory' not a member of destination error set

--- a/test/cases/compile_errors/union_init_with_none_or_multiple_fields.zig
+++ b/test/cases/compile_errors/union_init_with_none_or_multiple_fields.zig
@@ -27,7 +27,7 @@ export fn u2m() void {
 // backend=stage2
 // target=native
 //
-// :9:1: error: union initializer must initialize one field
+// :10:20: error: union initializer must initialize one field
 // :1:12: note: union declared here
 // :14:20: error: cannot initialize multiple union fields at once; unions can only have one active field
 // :14:31: note: additional initializer here


### PR DESCRIPTION
Before:

    assign_local_bad_coercion.zig:5:1: error: expected type 'u32', found 'u64'
    export fn constEntry() u32 {
    ^~~~~~
    assign_local_bad_coercion.zig:11:19: error: expected type 'u32', found 'u64'
        var x: u32 = g();
                     ~^~

After:

    assign_local_bad_coercion.zig:6:21: error: expected type 'u32', found 'u64'
        const x: u32 = g();
                       ~^~
    assign_local_bad_coercion.zig:11:19: error: expected type 'u32', found 'u64'
        var x: u32 = g();
                     ~^~