### PR TITLE
Change managed ArrayHashMap capacity method to take a non-pointer parameter

### DIFF
--- a/lib/std/array_hash_map.zig
+++ b/lib/std/array_hash_map.zig
@@ -216,7 +216,7 @@ pub fn ArrayHashMap(
 
         /// Returns the number of total elements which may be present before it is
         /// no longer guaranteed that no allocations will be performed.
-        pub fn capacity(self: *Self) usize {
+        pub fn capacity(self: Self) usize {
             return self.unmanaged.capacity();
         }
 


### PR DESCRIPTION
I don't believe there's a requirement for this to take a pointer, as the underlying function doesn't. This should stop users from having to take a reference for no reason, and unify ArrayHashMap and ArrayHashMapUnmanaged's API.