### PR TITLE
linux: do not set stack size hard limit

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -459,22 +459,29 @@ fn expandStackSize(phdrs: []elf.Phdr) void {
     for (phdrs) |*phdr| {
         switch (phdr.p_type) {
             elf.PT_GNU_STACK => {
-                const wanted_stack_size = phdr.p_memsz;
-                assert(wanted_stack_size % std.mem.page_size == 0);
+                assert(phdr.p_memsz % std.mem.page_size == 0);
 
-                std.os.setrlimit(.STACK, .{
-                    .cur = wanted_stack_size,
-                    .max = wanted_stack_size,
-                }) catch {
-                    // Because we could not increase the stack size to the upper bound,
-                    // depending on what happens at runtime, a stack overflow may occur.
-                    // However it would cause a segmentation fault, thanks to stack probing,
-                    // so we do not have a memory safety issue here.
-                    // This is intentional silent failure.
-                    // This logic should be revisited when the following issues are addressed:
-                    // https://github.com/ziglang/zig/issues/157
-                    // https://github.com/ziglang/zig/issues/1006
-                };
+                // Silently fail if we are unable to get limits.
+                const limits = std.os.getrlimit(.STACK) catch break;
+
+                // Clamp to limits.max .
+                const wanted_stack_size = @min(phdr.p_memsz, limits.max);
+
+                if (wanted_stack_size > limits.cur) {
+                    std.os.setrlimit(.STACK, .{
+                        .cur = wanted_stack_size,
+                        .max = limits.max,
+                    }) catch {
+                        // Because we could not increase the stack size to the upper bound,
+                        // depending on what happens at runtime, a stack overflow may occur.
+                        // However it would cause a segmentation fault, thanks to stack probing,
+                        // so we do not have a memory safety issue here.
+                        // This is intentional silent failure.
+                        // This logic should be revisited when the following issues are addressed:
+                        // https://github.com/ziglang/zig/issues/157
+                        // https://github.com/ziglang/zig/issues/1006
+                    };
+                }
                 break;
             },
             else => {},


### PR DESCRIPTION
At main startup, if the ELF auxiliary vector contains a stacksize value, use it as a hint for the minimum stacksize required by the executable.

1. Never lower the hard-limit. Once a hard-limit is lowered, then it can never be increased (including child processes).

2. If hint exceeds hard-limit then clamp hint to hard-limit.

3. If soft-limit exceeds hint then do nothing.