### PR TITLE
macos: change rules and improve detection of native SDK

### DIFF
--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -351,13 +351,7 @@ test "getEnvMap" {
     defer env.deinit();
 }
 
-pub const GetEnvVarOwnedError = error{
-    OutOfMemory,
-    EnvironmentVariableNotFound,
-
-    /// See https://github.com/ziglang/zig/issues/1774
-    InvalidUtf8,
-};
+pub const GetEnvVarOwnedError = error{EnvironmentVariableNotFound} || HasEnvVarError;
 
 /// Caller must free returned memory.
 pub fn getEnvVarOwned(allocator: Allocator, key: []const u8) GetEnvVarOwnedError![]u8 {
@@ -396,7 +390,13 @@ pub fn hasEnvVarConstant(comptime key: []const u8) bool {
     }
 }
 
-pub fn hasEnvVar(allocator: Allocator, key: []const u8) error{OutOfMemory}!bool {
+pub const HasEnvVarError = error{
+    OutOfMemory,
+    /// See https://github.com/ziglang/zig/issues/1774
+    InvalidUtf8,
+};
+
+pub fn hasEnvVar(allocator: Allocator, key: []const u8) HasEnvVarError!bool {
     if (builtin.os.tag == .windows) {
         var stack_alloc = std.heap.stackFallback(256 * @sizeOf(u16), allocator);
         const key_w = try std.unicode.utf8ToUtf16LeWithNull(stack_alloc.get(), key);

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -398,9 +398,10 @@ pub const HasEnvVarError = error{
 
 pub fn hasEnvVar(allocator: Allocator, key: []const u8) HasEnvVarError!bool {
     if (builtin.os.tag == .windows) {
-        var stack_alloc = std.heap.stackFallback(256 * @sizeOf(u16), allocator);
-        const key_w = try std.unicode.utf8ToUtf16LeWithNull(stack_alloc.get(), key);
-        defer stack_alloc.allocator.free(key_w);
+        var stack_allocator = std.heap.stackFallback(256 * @sizeOf(u16), allocator);
+        const stack_alloc = stack_allocator.get();
+        const key_w = try std.unicode.utf8ToUtf16LeWithNull(stack_alloc, key);
+        defer stack_alloc.free(key_w);
         return std.os.getenvW(key_w) != null;
     } else if (builtin.os.tag == .wasi and !builtin.link_libc) {
         var envmap = getEnvMap(allocator) catch return error.OutOfMemory;

--- a/lib/std/zig/system/NativePaths.zig
+++ b/lib/std/zig/system/NativePaths.zig
@@ -13,11 +13,10 @@ framework_dirs: ArrayList([:0]u8),
 rpaths: ArrayList([:0]u8),
 warnings: ArrayList([:0]u8),
 
-pub fn isNix() bool {
-    if (builtin.os.tag == .wasi and !builtin.link_libc) {
-        @compileError("isNix check is not supported for WASI without libc");
-    }
-    return process.hasEnvVarConstant("NIX_CFLAGS_COMPILE") and process.hasEnvVarConstant("NIX_LDFLAGS");
+pub fn isNix(allocator: Allocator) bool {
+    const cflags = process.hasEnvVar(allocator, "NIX_CFLAGS_COMPILE") catch return false;
+    const ldflags = process.hasEnvVar(allocator, "NIX_LDFLAGS") catch return false;
+    return cflags and ldflags;
 }
 
 pub fn detect(allocator: Allocator, native_target: std.Target) !NativePaths {

--- a/lib/std/zig/system/NativePaths.zig
+++ b/lib/std/zig/system/NativePaths.zig
@@ -192,6 +192,22 @@ fn deinitArray(array: *ArrayList([:0]u8)) void {
     array.deinit();
 }
 
+pub inline fn getIncludeDirs(self: *const NativePaths) []const [:0]const u8 {
+    return self.include_dirs.items;
+}
+
+pub inline fn getLibDirs(self: *const NativePaths) []const [:0]const u8 {
+    return self.lib_dirs.items;
+}
+
+pub inline fn getFrameworkDirs(self: *const NativePaths) []const [:0]const u8 {
+    return self.framework_dirs.items;
+}
+
+pub inline fn getRpaths(self: *const NativePaths) []const [:0]const u8 {
+    return self.rpaths.items;
+}
+
 pub fn addIncludeDir(self: *NativePaths, s: []const u8) !void {
     return self.appendArray(&self.include_dirs, s);
 }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -900,7 +900,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
                 try rpath_list.append(rpath);
             }
 
-            if (!std.zig.system.NativePaths.isNix() and std.zig.system.darwin.isDarwinSDKInstalled(arena)) {
+            if (darwin_native and !std.zig.system.NativePaths.isNix() and std.zig.system.darwin.isDarwinSDKInstalled(arena)) {
                 darwin_sdk = std.zig.system.darwin.getDarwinSDK(arena, options.target);
             }
         }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -857,7 +857,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
 
         const darwin_native = options.is_native_os and options.target.isDarwin() and options.sysroot == null;
         const darwin_sdk: ?std.zig.system.darwin.DarwinSDK = if (darwin_native and
-            !std.zig.system.NativePaths.isNix() and
+            !std.zig.system.NativePaths.isNix(arena) and
             std.zig.system.darwin.isDarwinSDKInstalled(arena))
             std.zig.system.darwin.getDarwinSDK(arena, options.target)
         else

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -855,8 +855,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             break :blk false;
         };
 
-        const darwin_native = (comptime builtin.target.isDarwin()) and options.target.isDarwin() and
-            options.sysroot == null;
+        const darwin_native = options.is_native_os and options.target.isDarwin() and options.sysroot == null;
         const darwin_sdk: ?std.zig.system.darwin.DarwinSDK = if (darwin_native and
             !std.zig.system.NativePaths.isNix() and
             std.zig.system.darwin.isDarwinSDKInstalled(arena))

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -855,7 +855,8 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             break :blk false;
         };
 
-        const darwin_native = options.is_native_os and options.target.isDarwin() and options.sysroot == null;
+        const darwin_native = (comptime builtin.target.isDarwin()) and options.target.isDarwin() and
+            options.sysroot == null;
         const darwin_sdk: ?std.zig.system.darwin.DarwinSDK = if (darwin_native and
             !std.zig.system.NativePaths.isNix(arena) and
             std.zig.system.darwin.isDarwinSDKInstalled(arena))

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4913,7 +4913,6 @@ fn detectLibCIncludeDirs(
             error.CCompilerCrashed,
             error.CCompilerCannotFindHeaders,
             error.UnableToSpawnCCompiler,
-            error.DarwinSdkNotFound,
             => |e| {
                 // We tried to integrate with the native system C compiler,
                 // however, it is not installed. So we must rely on our bundled

--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -37,7 +37,6 @@ pub const LibCInstallation = struct {
         UnsupportedArchitecture,
         WindowsSdkNotFound,
         ZigIsTheCCompiler,
-        DarwinSdkNotFound,
     };
 
     pub fn parse(

--- a/src/link.zig
+++ b/src/link.zig
@@ -247,6 +247,8 @@ pub const Options = struct {
     /// (Windows) .def file to specify when linking
     module_definition_file: ?[]const u8 = null,
 
+    want_native_paths: bool = false,
+
     pub fn effectiveOutputMode(options: Options) std.builtin.OutputMode {
         return if (options.use_lld) .Obj else options.output_mode;
     }

--- a/src/link.zig
+++ b/src/link.zig
@@ -213,8 +213,8 @@ pub const Options = struct {
     /// (Zig compiler development) Enable dumping of linker's state as JSON.
     enable_link_snapshots: bool = false,
 
-    /// (Darwin) Path and version of the native SDK if detected.
-    native_darwin_sdk: ?std.zig.system.darwin.DarwinSDK = null,
+    /// (Darwin) Version of the native SDK if detected.
+    darwin_sdk_version: ?std.SemanticVersion = null,
 
     /// (Darwin) Install name for the dylib
     install_name: ?[]const u8 = null,

--- a/src/link.zig
+++ b/src/link.zig
@@ -16,6 +16,7 @@ const Compilation = @import("Compilation.zig");
 const LibCInstallation = @import("libc_installation.zig").LibCInstallation;
 const Liveness = @import("Liveness.zig");
 const Module = @import("Module.zig");
+const NativePaths = std.zig.system.NativePaths;
 const InternPool = @import("InternPool.zig");
 const Type = @import("type.zig").Type;
 const TypedValue = @import("TypedValue.zig");
@@ -204,6 +205,8 @@ pub const Options = struct {
     version: ?std.SemanticVersion,
     compatibility_version: ?std.SemanticVersion,
     libc_installation: ?*const LibCInstallation,
+    // TODO figure out if we can make it part of LibCInstallation
+    native_paths: ?NativePaths = null,
 
     dwarf_format: ?std.dwarf.Format,
 
@@ -246,8 +249,6 @@ pub const Options = struct {
 
     /// (Windows) .def file to specify when linking
     module_definition_file: ?[]const u8 = null,
-
-    want_native_paths: bool = false,
 
     pub fn effectiveOutputMode(options: Options) std.builtin.OutputMode {
         return if (options.use_lld) .Obj else options.output_mode;

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -503,9 +503,8 @@ pub fn flushModule(self: *MachO, comp: *Compilation, prog_node: *std.Progress.No
 
     var input_rpath_list = std.ArrayList([]const u8).init(arena);
 
-    if (options.want_native_paths) {
-        const paths = try std.zig.system.NativePaths.detect(arena, options.target);
-        try input_rpath_list.appendSlice(paths.rpaths.items);
+    if (options.native_paths) |paths| {
+        try input_rpath_list.appendSlice(paths.getRpaths());
     }
 
     if (self.lazy_syms.getPtr(.none)) |metadata| {

--- a/src/link/MachO/load_commands.zig
+++ b/src/link/MachO/load_commands.zig
@@ -278,8 +278,7 @@ pub fn writeBuildVersionLC(options: *const link.Options, lc_writer: anytype) !vo
         const platform_version = @as(u32, @intCast(ver.major << 16 | ver.minor << 8));
         break :blk platform_version;
     };
-    const sdk_version = if (options.native_darwin_sdk) |sdk| blk: {
-        const ver = sdk.version;
+    const sdk_version = if (options.darwin_sdk_version) |ver| blk: {
         const sdk_version = @as(u32, @intCast(ver.major << 16 | ver.minor << 8));
         break :blk sdk_version;
     } else platform_version;

--- a/src/link/MachO/load_commands.zig
+++ b/src/link/MachO/load_commands.zig
@@ -247,8 +247,8 @@ const RpathIterator = struct {
     }
 };
 
-pub fn writeRpathLCs(gpa: Allocator, options: *const link.Options, lc_writer: anytype) !void {
-    var it = RpathIterator.init(gpa, options.rpath_list);
+pub fn writeRpathLCs(gpa: Allocator, rpaths: []const []const u8, lc_writer: anytype) !void {
+    var it = RpathIterator.init(gpa, rpaths);
     defer it.deinit();
 
     while (try it.next()) |rpath| {

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -3357,11 +3357,10 @@ pub fn linkWithZld(macho_file: *MachO, comp: *Compilation, prog_node: *std.Progr
     try input_framework_dirs.appendSlice(options.framework_dirs);
     try input_rpath_list.appendSlice(options.rpath_list);
 
-    if (options.want_native_paths) {
-        const paths = try std.zig.system.NativePaths.detect(arena, target);
-        try input_lib_dirs.appendSlice(paths.lib_dirs.items);
-        try input_framework_dirs.appendSlice(paths.framework_dirs.items);
-        try input_rpath_list.appendSlice(paths.rpaths.items);
+    if (options.native_paths) |paths| {
+        try input_lib_dirs.appendSlice(paths.getLibDirs());
+        try input_framework_dirs.appendSlice(paths.getFrameworkDirs());
+        try input_rpath_list.appendSlice(paths.getRpaths());
     }
 
     var man: Cache.Manifest = undefined;

--- a/src/main.zig
+++ b/src/main.zig
@@ -4018,7 +4018,7 @@ pub fn cmdLibC(gpa: Allocator, args: []const []const u8) !void {
         }
 
         var darwin_sdk: ?std.zig.system.darwin.DarwinSDK = if ((comptime builtin.target.isDarwin()) and
-            !std.zig.system.NativePaths.isNix() and
+            !std.zig.system.NativePaths.isNix(gpa) and
             std.zig.system.darwin.isDarwinSDKInstalled(gpa))
             std.zig.system.darwin.getDarwinSDK(gpa, builtin.target)
         else

--- a/src/main.zig
+++ b/src/main.zig
@@ -4017,7 +4017,7 @@ pub fn cmdLibC(gpa: Allocator, args: []const []const u8) !void {
             fatal("unable to detect libc for non-native target", .{});
         }
 
-        var darwin_sdk = if ((comptime builtin.target.isDarwin()) and
+        var darwin_sdk: ?std.zig.system.darwin.DarwinSDK = if ((comptime builtin.target.isDarwin()) and
             !std.zig.system.NativePaths.isNix() and
             std.zig.system.darwin.isDarwinSDKInstalled(gpa))
             std.zig.system.darwin.getDarwinSDK(gpa, builtin.target)


### PR DESCRIPTION
Summary of breaking changes:
1. if we build on an Apple host (mainly macOS) and we target an Apple platform, we will try linking against the SDK if available
2. however, if we detect Nix, we ignore native SDK and instead rely fully on paths supplied by Nix via env vars

Now, the nitty-gritty:
In order to achieve 1. we have to apply this rule to all possible `Compilation.create` invocations which made it natural to move some of the existing code that is concerned with native paths detection into `Compilation.create`. And so, now detection of native Apple SDK is done within `Compilation.create`, as well as detection/unpacking of paths supplied by Nix. I think this bit of functionality really belongs in `LibcInstallation` struct, as it is a natural companion to autodetection logic of libc include paths that `LibcInstallation` provides. I haven't acted on this yet in this PR, so feel free to comment on the correctness of my assertion.

Detection of native libc include paths for Apple platforms is now done via `LibcInstallation` struct as it is done for other platforms - this got rid of a lot of special casing for Apple in `Compilation.zig` which is nice. The detection logic in `LibcInstallation` for Apple platforms relies on a two-tier logic: if SDK was detected, we use that, otherwise, we fallback to `clang` for detection. The latter is to mainly support the Nix environment. Anyhow, with this PR, `zig libc` now works on macOS (no more panicking). Instead we get this if the SDK is available:

```
# The directory that contains `stdlib.h`.
# On POSIX-like systems, include directories be found with: `cc -E -Wp,-v -xc /dev/null`
include_dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include

# The system-specific include directory. May be the same as `include_dir`.
# On Windows it's the directory that includes `vcruntime.h`.
# On POSIX it's the directory that includes `sys/errno.h`.
sys_include_dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include

# The directory that contains `crt1.o` or `crt2.o`.
# On POSIX, can be found with `cc -print-file-name=crt1.o`.
# Not needed when targeting MacOS.
crt_dir=

# The directory that contains `vcruntime.lib`.
# Only needed when targeting MSVC on Windows.
msvc_lib_dir=

# The directory that contains `kernel32.lib`.
# Only needed when targeting MSVC on Windows.
kernel32_lib_dir=

# The directory that contains `crtbeginS.o` and `crtendS.o`
# Only needed when targeting Haiku.
gcc_dir=

# The directory that contains system frameworks (Darwin only).
framework_dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/System/Library/Frameworks
```

Closes #15024
Closes #14569

EDIT:
Closes #11631 

@haze marking #11631 as closed but I will ask you to verify it did indeed completely fix the issue for you once 0.11 lands, and is available via Nix.

EDIT2:
Closes https://github.com/ziglang/zig/issues/16118
Closes #15963 