### PR TITLE
Value: fix incorrect types returned from readFromMemory

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -30566,7 +30566,7 @@ fn analyzeLoad(
 
     if (try sema.resolveDefinedValue(block, ptr_src, ptr)) |ptr_val| {
         if (try sema.pointerDeref(block, src, ptr_val, ptr_ty)) |elem_val| {
-            return sema.addConstant(try mod.getCoerced(elem_val, elem_ty));
+            return sema.addConstant(elem_val);
         }
     }
 

--- a/test/behavior/comptime_memory.zig
+++ b/test/behavior/comptime_memory.zig
@@ -438,3 +438,15 @@ test "type pun extern struct" {
     @as(*u8, @ptrCast(&s)).* = 72;
     try testing.expectEqual(@as(u8, 72), s.f);
 }
+
+test "type pun @ptrFromInt" {
+    const p: *u8 = @ptrFromInt(42);
+    // note that expectEqual hides the bug
+    try testing.expect(@as(*const [*]u8, @ptrCast(&p)).* == @as([*]u8, @ptrFromInt(42)));
+}
+
+test "type pun null pointer-like optional" {
+    const p: ?*u8 = null;
+    // note that expectEqual hides the bug
+    try testing.expect(@as(*const ?*i8, @ptrCast(&p)).* == null);
+}


### PR DESCRIPTION
Fixes crashes encountered while upgrading [capy](https://github.com/capy-ui/capy).