### PR TITLE
Build: make `InstallDirStep` use a `FileSource`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -105,7 +105,7 @@ pub fn build(b: *std.Build) !void {
 
     if (!skip_install_lib_files) {
         b.installDirectory(InstallDirectoryOptions{
-            .source_dir = "lib",
+            .source_dir = .{ .path = "lib" },
             .install_dir = .lib,
             .install_subdir = "zig",
             .exclude_extensions = &[_][]const u8{

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1317,9 +1317,7 @@ pub fn addInstallFileWithDir(
 }
 
 pub fn addInstallDirectory(self: *Build, options: InstallDirectoryOptions) *Step.InstallDir {
-    const install_step = self.allocator.create(Step.InstallDir) catch @panic("OOM");
-    install_step.* = Step.InstallDir.init(self, options);
-    return install_step;
+    return Step.InstallDir.create(self, options);
 }
 
 pub fn addCheckFile(

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -564,7 +564,7 @@ pub fn installHeadersDirectory(
     dest_rel_path: []const u8,
 ) void {
     return installHeadersDirectoryOptions(a, .{
-        .source_dir = src_dir_path,
+        .source_dir = .{ .path = src_dir_path },
         .install_dir = .header,
         .install_subdir = dest_rel_path,
     });


### PR DESCRIPTION
Closes #16187

I feel like this could benefit from a test, but I'm not sure how to get a `FileSource` directory in a platform-independent way to create a proper `standalone` test. I used the following "project" to test the behavior manually, but it depends on executing a shell script:

`build.zig`

```zig
const std = @import("std");

pub fn build(b: *std.Build) !void {
    const mkdir = b.addSystemCommand(&.{"./gendir"});
    const src_dir = mkdir.addOutputFileArg("src");

    b.installDirectory(.{
        .source_dir = src_dir,
        .install_dir = .prefix,
        .install_subdir = "dest",
    });
}
```

`gendir`

```shell
#!/bin/sh
set -e

mkdir "$1"
for i in `seq 9`; do
    echo 'Hello, world!' >"$1/file$i"
done
```

If anyone has any advice on if/how to add a good test case for this, I would be happy to add one.