### PR TITLE
std.c: freebsd fix SO_ACCEPTFILTER get/setsocketopt value argument st…

### DIFF
--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -1396,7 +1396,7 @@ pub const DT = struct {
     pub const WHT = 14;
 };
 
-pub const accept_filter = extern struct {
+pub const accept_filter_arg = extern struct {
     af_name: [16]u8,
     af_args: [240]u8,
 };

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -1397,8 +1397,8 @@ pub const DT = struct {
 };
 
 pub const accept_filter_arg = extern struct {
-    af_name: [16]u8,
-    af_args: [240]u8,
+    name: [16]u8,
+    args: [240]u8,
 };
 
 /// add event to kq (implies enable)

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -486,8 +486,8 @@ pub const AF = struct {
 };
 
 pub const accept_filter_arg = extern struct {
-    af_name: [16]u8,
-    af_args: [240]u8,
+    name: [16]u8,
+    args: [240]u8,
 };
 
 pub const in_port_t = u16;


### PR DESCRIPTION
…ruct typo.

follow-up on b677b36

ref https://github.com/freebsd/freebsd-src/blob/b7198dcfc03967cba191a373d99df47ee52d6e2a/sys/sys/socket.h#L205