### PR TITLE
Sema: fix `@min`/`@max` type resolution with all runtime args

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -23301,6 +23301,7 @@ fn analyzeMinMax(
 
     if (cur_minmax == null) {
         // No comptime operands - use the first operand as the starting value
+        assert(bounds_status == .unknown);
         assert(runtime_idx == 0);
         cur_minmax = operands[0];
         cur_minmax_src = runtime_src;
@@ -23309,6 +23310,9 @@ fn analyzeMinMax(
         if (scalar_ty.isInt(mod)) {
             cur_min_scalar = try scalar_ty.minInt(mod, scalar_ty);
             cur_max_scalar = try scalar_ty.maxInt(mod, scalar_ty);
+            bounds_status = .defined;
+        } else {
+            bounds_status = .non_integral;
         }
     }
 

--- a/test/behavior/maximum_minimum.zig
+++ b/test/behavior/maximum_minimum.zig
@@ -295,3 +295,17 @@ test "@min/@max notices bounds from vector types when element of comptime-known 
     try expectEqual(@as(u32, 1_000_000), max[0]);
     // Cannot assert values at index 1 as one was undefined
 }
+
+test "@min/@max of signed and unsigned runtime integers" {
+    var x: i32 = -1;
+    var y: u31 = 1;
+
+    const min = @min(x, y);
+    const max = @max(x, y);
+
+    comptime assert(@TypeOf(min) == i32);
+    comptime assert(@TypeOf(max) == u31);
+
+    try expectEqual(x, @min(x, y));
+    try expectEqual(y, @max(x, y));
+}


### PR DESCRIPTION
Closes #16229