### PR TITLE
Fix missing newline in render_cmake()

### DIFF
--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -301,10 +301,9 @@ fn render_cmake(
 
     var any_errors = false;
     var line_index: u32 = 0;
-    var line_it = std.mem.splitScalar(u8, contents, '\n');
+    const contents_no_end_newline = std.mem.trimRight(u8, contents, &[1]u8{'\n'});
+    var line_it = std.mem.splitScalar(u8, contents_no_end_newline, '\n');
     while (line_it.next()) |raw_line| : (line_index += 1) {
-        const last_line = line_it.index == line_it.buffer.len;
-
         const first_pass = replace_variables(allocator, raw_line, values, "@", "@") catch @panic("Failed to substitute");
         const line = replace_variables(allocator, first_pass, values, "${", "}") catch @panic("Failed to substitute");
 
@@ -313,9 +312,7 @@ fn render_cmake(
 
         if (!std.mem.startsWith(u8, line, "#")) {
             try output.appendSlice(line);
-            if (!last_line) {
-                try output.appendSlice("\n");
-            }
+            try output.append('\n');
             continue;
         }
         var it = std.mem.tokenizeAny(u8, line[1..], " \t\r");
@@ -324,9 +321,7 @@ fn render_cmake(
             !std.mem.eql(u8, cmakedefine, "cmakedefine01"))
         {
             try output.appendSlice(line);
-            if (!last_line) {
-                try output.appendSlice("\n");
-            }
+            try output.append('\n');
             continue;
         }
 


### PR DESCRIPTION
- remove fragile 'last_line' check: it assumed last line of 'contents' is valid (ends with '\n')
- terminate every line with '\n' (as POSIX defines it)