### PR TITLE
Autodoc: Add u0, i0 to properly handled types

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1054,7 +1054,7 @@ const NAV_MODES = {
     if (wr.typeRef) return wr.typeRef;
     let resolved = resolveValue(wr);
     if (wr === resolved) {
-      return { type: 0 };
+      return { "undefined": {} };
     }
     return walkResultTypeRef(resolved);
   }

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -136,6 +136,8 @@ pub fn generateZirData(self: *Autodoc) !void {
                             },
                         };
                     },
+                    .u0_type,
+                    .i0_type,
                     .u1_type,
                     .u8_type,
                     .i8_type,


### PR DESCRIPTION
It fixes an infinite loop of `u0` being interpreted as `[1]u0` which recurses until breaking when touched by `exprName`