### PR TITLE
bootstrap: support aarch64 in 32-bit mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,17 +689,28 @@ target_link_libraries(zigcpp LINK_PUBLIC
     ${CMAKE_THREAD_LIBS_INIT}
 )
 
-string(TOLOWER "${CMAKE_HOST_SYSTEM_PROCESSOR}" HOST_TARGET_ARCH)
-if(HOST_TARGET_ARCH STREQUAL "amd64")
-  set(HOST_TARGET_ARCH "x86_64")
-elseif(HOST_TARGET_ARCH STREQUAL "arm64")
-  set(HOST_TARGET_ARCH "aarch64")
+string(TOLOWER "${CMAKE_HOST_SYSTEM_PROCESSOR}" ZIG_HOST_TARGET_ARCH)
+if(ZIG_HOST_TARGET_ARCH STREQUAL "amd64")
+  set(ZIG_HOST_TARGET_ARCH "x86_64")
+elseif(ZIG_HOST_TARGET_ARCH STREQUAL "arm64")
+  set(ZIG_HOST_TARGET_ARCH "aarch64")
+elseif(ZIG_HOST_TARGET_ARCH STREQUAL "armv7l")
+  set(ZIG_HOST_TARGET_ARCH "arm")
+elseif(ZIG_HOST_TARGET_ARCH STREQUAL "armv7b")
+  set(ZIG_HOST_TARGET_ARCH "armeb")
 endif()
-string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" HOST_TARGET_OS)
-if(HOST_TARGET_OS STREQUAL "darwin")
-  set(HOST_TARGET_OS "macos")
+if(ZIG_HOST_TARGET_ARCH MATCHES "^arm(eb)?$")
+  include(CheckSymbolExists)
+  check_symbol_exists(__thumb__ "" ZIG_HOST_TARGET_DEFAULTS_TO_THUMB)
+  if(ZIG_HOST_TARGET_DEFAULTS_TO_THUMB)
+    string(REGEX REPLACE "^arm" "thumb" ZIG_HOST_TARGET_ARCH "${ZIG_HOST_TARGET_ARCH}")
+  endif()
 endif()
-set(HOST_TARGET_TRIPLE "${HOST_TARGET_ARCH}-${HOST_TARGET_OS}")
+string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" ZIG_HOST_TARGET_OS)
+if(ZIG_HOST_TARGET_OS STREQUAL "darwin")
+  set(ZIG_HOST_TARGET_OS "macos")
+endif()
+set(ZIG_HOST_TARGET_TRIPLE "${ZIG_HOST_TARGET_ARCH}-${ZIG_HOST_TARGET_OS}" CACHE STRING "Host zig target triple.")
 
 if(MSVC)
   set(ZIG_WASM2C_COMPILE_FLAGS "")
@@ -749,7 +760,7 @@ set(BUILD_ZIG2_ARGS
   --name zig2 -femit-bin="${ZIG2_C_SOURCE}"
   --mod "build_options::${ZIG_CONFIG_ZIG_OUT}"
   --deps build_options
-  -target "${HOST_TARGET_TRIPLE}"
+  -target "${ZIG_HOST_TARGET_TRIPLE}"
 )
 
 add_custom_command(
@@ -767,7 +778,7 @@ set(BUILD_COMPILER_RT_ARGS
   --name compiler_rt -femit-bin="${ZIG_COMPILER_RT_C_SOURCE}"
   --mod "build_options::${ZIG_CONFIG_ZIG_OUT}"
   --deps build_options
-  -target "${HOST_TARGET_TRIPLE}"
+  -target "${ZIG_HOST_TARGET_TRIPLE}"
 )
 
 add_custom_command(

--- a/lib/std/os/linux/thumb.zig
+++ b/lib/std/os/linux/thumb.zig
@@ -17,7 +17,7 @@ pub fn syscall0(number: SYS) usize {
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
         : [ret] "={r0}" (-> usize),
-        : [tmp] "{r1}" (buf),
+        : [tmp] "{r1}" (&buf),
         : "memory"
     );
 }
@@ -32,7 +32,7 @@ pub fn syscall1(number: SYS, arg1: usize) usize {
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
         : [ret] "={r0}" (-> usize),
-        : [tmp] "{r1}" (buf),
+        : [tmp] "{r1}" (&buf),
           [arg1] "{r0}" (arg1),
         : "memory"
     );
@@ -48,7 +48,7 @@ pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
         : [ret] "={r0}" (-> usize),
-        : [tmp] "{r2}" (buf),
+        : [tmp] "{r2}" (&buf),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
         : "memory"
@@ -65,7 +65,7 @@ pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
         : [ret] "={r0}" (-> usize),
-        : [tmp] "{r3}" (buf),
+        : [tmp] "{r3}" (&buf),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
           [arg3] "{r2}" (arg3),
@@ -83,7 +83,7 @@ pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize)
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
         : [ret] "={r0}" (-> usize),
-        : [tmp] "{r4}" (buf),
+        : [tmp] "{r4}" (&buf),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
           [arg3] "{r2}" (arg3),
@@ -102,7 +102,7 @@ pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize,
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
         : [ret] "={r0}" (-> usize),
-        : [tmp] "{r5}" (buf),
+        : [tmp] "{r5}" (&buf),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
           [arg3] "{r2}" (arg3),
@@ -130,7 +130,7 @@ pub fn syscall6(
         \\ svc #0
         \\ ldr r7, [%[tmp], #4]
         : [ret] "={r0}" (-> usize),
-        : [tmp] "{r6}" (buf),
+        : [tmp] "{r6}" (&buf),
           [arg1] "{r0}" (arg1),
           [arg2] "{r1}" (arg2),
           [arg3] "{r2}" (arg3),

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -3178,18 +3178,6 @@ zig_bitCast_float(f64, uint64_t)
 zig_bitCast_float(f80, zig_u128)
 zig_bitCast_float(f128, zig_u128)
 
-#define zig_cast_f16 (zig_f16)
-#define zig_cast_f32 (zig_f32)
-#define zig_cast_f64 (zig_f64)
-
-#if _MSC_VER && !zig_has_f128
-#define zig_cast_f80
-#define zig_cast_f128
-#else
-#define zig_cast_f80 (zig_f80)
-#define zig_cast_f128 (zig_f128)
-#endif
-
 #define zig_convert_builtin(ExternResType, ResType, operation, ExternArgType, ArgType, version) \
     zig_extern ExternResType zig_expand_concat(zig_expand_concat(zig_expand_concat(__##operation, \
         zig_compiler_rt_abbrev_##ArgType), zig_compiler_rt_abbrev_##ResType), version)(ExternArgType); \

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -732,9 +732,7 @@ pub const DeclGen = struct {
                     // All unsigned ints matching float types are pre-allocated.
                     const repr_ty = mod.intType(.unsigned, bits) catch unreachable;
 
-                    try writer.writeAll("zig_cast_");
-                    try dg.renderTypeForBuiltinFnName(writer, ty);
-                    try writer.writeAll(" zig_make_");
+                    try writer.writeAll("zig_make_");
                     try dg.renderTypeForBuiltinFnName(writer, ty);
                     try writer.writeByte('(');
                     switch (bits) {
@@ -1049,9 +1047,6 @@ pub const DeclGen = struct {
 
                 const repr_val = try mod.intValue_big(repr_ty, repr_val_big.toConst());
 
-                try writer.writeAll("zig_cast_");
-                try dg.renderTypeForBuiltinFnName(writer, ty);
-                try writer.writeByte(' ');
                 var empty = true;
                 if (std.math.isFinite(f128_val)) {
                     try writer.writeAll("zig_make_");

--- a/stage1/zig.h
+++ b/stage1/zig.h
@@ -3178,17 +3178,11 @@ zig_bitCast_float(f64, uint64_t)
 zig_bitCast_float(f80, zig_u128)
 zig_bitCast_float(f128, zig_u128)
 
-#define zig_cast_f16 (zig_f16)
-#define zig_cast_f32 (zig_f32)
-#define zig_cast_f64 (zig_f64)
-
-#if _MSC_VER && !zig_has_f128
+#define zig_cast_f16
+#define zig_cast_f32
+#define zig_cast_f64
 #define zig_cast_f80
 #define zig_cast_f128
-#else
-#define zig_cast_f80 (zig_f80)
-#define zig_cast_f128 (zig_f128)
-#endif
 
 #define zig_convert_builtin(ExternResType, ResType, operation, ExternArgType, ArgType, version) \
     zig_extern ExternResType zig_expand_concat(zig_expand_concat(zig_expand_concat(__##operation, \


### PR DESCRIPTION
 * `CMakeLists.txt`: support the weird `uname -m` output.
 * `CMakeLists.txt`: detect and use the C compiler's default arm mode.
 * cbe: support gcc with both `f128` and `u128` emulated.
 * std.os.linux.thumb: fix incorrectly passed asm inputs.