### PR TITLE
Added support for -mword-relocations flag

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -186,6 +186,8 @@ pie: ?bool = null,
 
 red_zone: ?bool = null,
 
+word_relocations: bool = false,
+
 omit_frame_pointer: ?bool = null,
 dll_export_fns: ?bool = null,
 
@@ -1645,6 +1647,11 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
             try zig_args.append("-mno-red-zone");
         }
     }
+
+    if (self.word_relocations) {
+        try zig_args.append("-mword-relocations");
+    }
+
     try addFlag(&zig_args, "omit-frame-pointer", self.omit_frame_pointer);
     try addFlag(&zig_args, "dll-export-fns", self.dll_export_fns);
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -150,6 +150,7 @@ pub const Options = struct {
     tsan: bool,
     stack_check: bool,
     red_zone: bool,
+    word_relocations: bool,
     omit_frame_pointer: bool,
     single_threaded: bool,
     verbose_link: bool,

--- a/src/main.zig
+++ b/src/main.zig
@@ -400,6 +400,7 @@ const usage_build_generic =
     \\            small|kernel|
     \\            medium|large]
     \\  -x language               Treat subsequent input files as having type <language>
+    \\  -mword-relocations        Only generate absolute relocations on word-sized values. (ARM only)
     \\  -mred-zone                Force-enable the "red-zone"
     \\  -mno-red-zone             Force-disable the "red-zone"
     \\  -fomit-frame-pointer      Omit the stack frame pointer
@@ -773,6 +774,7 @@ fn buildOutputType(
     var want_stack_check: ?bool = null;
     var want_stack_protector: ?u32 = null;
     var want_red_zone: ?bool = null;
+    var want_word_relocations: bool = false;
     var omit_frame_pointer: ?bool = null;
     var want_valgrind: ?bool = null;
     var want_tsan: ?bool = null;
@@ -1235,6 +1237,8 @@ fn buildOutputType(
                         want_stack_protector = Compilation.default_stack_protector_buffer_size;
                     } else if (mem.eql(u8, arg, "-fno-stack-protector")) {
                         want_stack_protector = 0;
+                    } else if (mem.eql(u8, arg, "-mword-relocations")) {
+                        want_word_relocations = true;
                     } else if (mem.eql(u8, arg, "-mred-zone")) {
                         want_red_zone = true;
                     } else if (mem.eql(u8, arg, "-mno-red-zone")) {
@@ -1651,6 +1655,7 @@ fn buildOutputType(
                     .no_lto => want_lto = false,
                     .red_zone => want_red_zone = true,
                     .no_red_zone => want_red_zone = false,
+                    .word_relocations => want_word_relocations = true,
                     .omit_frame_pointer => omit_frame_pointer = true,
                     .no_omit_frame_pointer => omit_frame_pointer = false,
                     .function_sections => function_sections = true,
@@ -3095,6 +3100,7 @@ fn buildOutputType(
         .want_stack_check = want_stack_check,
         .want_stack_protector = want_stack_protector,
         .want_red_zone = want_red_zone,
+        .want_word_relocations = want_word_relocations,
         .omit_frame_pointer = omit_frame_pointer,
         .want_valgrind = want_valgrind,
         .want_tsan = want_tsan,
@@ -5155,6 +5161,7 @@ pub const ClangArgIterator = struct {
         framework_dir,
         framework,
         nostdlibinc,
+        word_relocations,
         red_zone,
         no_red_zone,
         omit_frame_pointer,


### PR DESCRIPTION
**NOTE: Immediately before opening this PR, I pulled the latest zig code which was only a couple of days newer than what I had been using.  For whatever reason, this new version is generating the relocation tables, which seems to fix this issue for Playdate.  I looked through the Zig source code and did not find the `-mword-relocations` flag enabled anywhere, so I am opening this pull request anyway.  It looks like now enabling -fPIC generates the relocation tables now. I am almost certain this wasn't the case a couple of days ago. Maybe there was an LLVM upgrade recently?**

This PR adds support for the `-mword-relocations` flag in Zig.  I've been making sure that Zig can be used to make Playdate games.  With Playdate's new SDK update Zig support is currently broken since the SDK now requires the `-mword-relocations` [for generating binaries that can be played on the hardware.](https://devforum.play.date/t/error-compress-failed-buffer-is-empty-error-from-pdc-in-sdk-2-0-beta-2/11474/21)

This flag only really applies to the ARM architecture and forces the compiler to generate tables (called "relocation tables") in the resulting ELF executable that contains addresses for globals, such as functions. This is rather than having the addresses in immediate operands.  

Example with `-mword-relocations`

```
36:   4806            ldr     r0, [pc, #24]   ; (50 <eventHandler+0x50>)
...
50:   00000019        .word   0x00000019
```

Example without `-mword-relocations`
```
 10:   f240 00c1       movw    r0, #193        ; 0xc1
 14:   f2c0 0000       movt    r0, #0

```


With the relocation tables, the new Playdate SDK patches the table with the actual addresses that will used at runtime.  The Playdate SDK does not support patching immediate operands.


With this change I confirmed that Zig can work with the new Playdate SDK.

Please let me know if you feel anything is missing from this PR.