### PR TITLE
std.crypto.hash.sha2: require avx2 on x86_64

### DIFF
--- a/lib/std/crypto/sha2.zig
+++ b/lib/std/crypto/sha2.zig
@@ -238,7 +238,7 @@ fn Sha2x32(comptime params: Sha2Params32) type {
                         return;
                     },
                     // C backend doesn't currently support passing vectors to inline asm.
-                    .x86_64 => if (builtin.zig_backend != .stage2_c and comptime std.Target.x86.featureSetHas(builtin.cpu.features, .sha)) {
+                    .x86_64 => if (builtin.zig_backend != .stage2_c and comptime std.Target.x86.featureSetHasAll(builtin.cpu.features, .{ .sha, .avx2 })) {
                         var x: v4u32 = [_]u32{ d.s[5], d.s[4], d.s[1], d.s[0] };
                         var y: v4u32 = [_]u32{ d.s[7], d.s[6], d.s[3], d.s[2] };
                         const s_v = @as(*[16]v4u32, @ptrCast(&s));


### PR DESCRIPTION
according to
https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=vpalignr&ig_expand=283,283,284,283,283&techs=AVX_ALL the vpalignr instruction requires AVX2 support

---

Context: I have an Intel J5005 CPU, which apparently supports .sha, but does not support .avx2 (or .avx). Without this patch, sha2 hashing crashes with "Illegal instruction" on this CPU:

```
~/src/zig/build % stage3/bin/zig test ../lib/std/std.zig --test-filter sha2               #910ad92e0e
Test [35/64] test.hmac sha256... Illegal instruction at address 0x33d25d
/home/lotheac/src/zig/lib/std/crypto/sha2.zig:260:56: 0x33d25d in round (test)
                                      [w12_15] "x" (s_v[k + 3]),
                                                       ^
/home/lotheac/src/zig/lib/std/crypto/sha2.zig:129:24: 0x31f8c6 in update (test)
                d.round(b[off..][0..64]);
                       ^
/home/lotheac/src/zig/lib/std/crypto/hmac.zig:58:28: 0x33aabb in init (test)
            ctx.hash.update(&i_key_pad);
                           ^
/home/lotheac/src/zig/lib/std/crypto/hmac.zig:28:32: 0x31c1de in create (test)
            var ctx = Self.init(key);
                               ^
/home/lotheac/src/zig/lib/std/crypto/hmac.zig:99:27: 0x31c0d0 in test.hmac sha256 (test)
    sha2.HmacSha256.create(out[0..], "", "");
                          ^
/home/lotheac/src/zig/lib/test_runner.zig:175:28: 0x2d5da0 in mainTerminal (test)
        } else test_fn.func();
                           ^
/home/lotheac/src/zig/lib/test_runner.zig:35:28: 0x2c8fd7 in main (test)
        return mainTerminal();
                           ^
/home/lotheac/src/zig/lib/std/start.zig:598:22: 0x2c86be in posixCallMainAndExit (test)
            root.main();
                     ^
/home/lotheac/src/zig/lib/std/start.zig:367:5: 0x2c81f1 in _start (test)
    @call(.never_inline, posixCallMainAndExit, .{});
    ^
error: the following test command crashed:
/home/lotheac/src/zig/zig-cache/o/e8a20caf1fbc87d73b68b642f5be3d88/test
```

With the patch applied, all the sha2 tests pass on this CPU.

I'm somewhat out of my depth when it comes to cpuid and x86_64 instructions, so I'm not totally sure that the AVX2 check is correct here.