### PR TITLE
std.os.sigprocmask: @bitCast flags parameter

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -5620,7 +5620,7 @@ pub fn sigaction(sig: u6, noalias act: ?*const Sigaction, noalias oact: ?*Sigact
 
 /// Sets the thread signal mask.
 pub fn sigprocmask(flags: u32, noalias set: ?*const sigset_t, noalias oldset: ?*sigset_t) void {
-    switch (errno(system.sigprocmask(flags, set, oldset))) {
+    switch (errno(system.sigprocmask(@bitCast(flags), set, oldset))) {
         .SUCCESS => return,
         .FAULT => unreachable,
         .INVAL => unreachable,


### PR DESCRIPTION
`std.os.sigprocmask` current accepts a `flags: u32`  parameter  which is passed to `system.sigprocmask`. However most implementations of `system` (either `std/c.zig` or `std/os/[platform].zig`) use a `c_int` for this argument. For example, when linking libc on linux, `std.c.sigprocmask` is used causing a compile error as `u32` cannot coerce to `c_int`.

This change is the minimal change that should make things work for all systems whose `sigprocmask` uses a 32 bit wide `flags` parameter - for any that don't, the current behaviour is already a compile error if they use a smaller type; this is a new compile error for a system that uses a flags parameter greater than 32bits wide.