### PR TITLE
Autodoc: enable light / dark theme override using user preferences

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -6,27 +6,88 @@
     <title>Documentation - Zig</title>
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAgklEQVR4AWMYWuD7EllJIM4G4g4g5oIJ/odhOJ8wToOxSTXgNxDHoeiBMfA4+wGShjyYOCkG/IGqWQziEzYAoUAeiF9D5U+DxEg14DRU7jWIT5IBIOdCxf+A+CQZAAoopEB7QJwBCBwHiip8UYmRdrAlDpIMgApwQZNnNii5Dq0MBgCxxycBnwEd+wAAAABJRU5ErkJggg==">
     <style>
+      html {
+        /* dark */
+        --dark-tx-color: #bbb;
+        --dark-bg-color: #111;
+        --dark-link-color: #88f;
+        --dark-sidebar-sh-color: rgba(128, 128, 128, 0.09);
+        --dark-sidebar-mod-bg-color: #333;
+        --dark-sidebar-modlnk-tx-color: #fff;
+        --dark-sidebar-modlnk-tx-color-hover: #fff;
+        --dark-sidebar-modlnk-tx-color-active: #000;
+        --dark-sidebar-modlnk-bg-color: transparent;
+        --dark-sidebar-modlnk-bg-color-hover: #555;
+        --dark-sidebar-modlnk-bg-color-active: #FFBB4D;
+        --dark-search-bg-color: #3c3c3c;
+        --dark-search-bg-color-focus: #000;
+        --dark-search-sh-color: rgba(255, 255, 255, 0.28);
+        --dark-search-other-results-color: rgba(255, 255, 255, 0.28);
+        --dark-modal-sh-color: rgba(142, 142, 142, 0.5);
+        --dark-modal-bg-color: #333;
+
+        /* light */
+        --light-tx-color: #141414;
+        --light-bg-color: #ffffff;
+        --light-link-color: #2A6286;
+        --light-sidebar-sh-color: rgba(0, 0, 0, 0.09);
+        --light-sidebar-mod-bg-color: #f1f1f1;
+        --light-sidebar-modlnk-tx-color: #141414;
+        --light-sidebar-modlnk-tx-color-hover: #fff;
+        --light-sidebar-modlnk-tx-color-active: #000;
+        --light-sidebar-modlnk-bg-color: transparent;
+        --light-sidebar-modlnk-bg-color-hover: #555;
+        --light-sidebar-modlnk-bg-color-active: #FFBB4D;
+        --light-search-bg-color: #f3f3f3;
+        --light-search-bg-color-focus: #ffffff;
+        --light-search-sh-color: rgba(0, 0, 0, 0.18);
+        --light-search-other-results-color: rgb(100, 100, 100);
+        --light-modal-sh-color: rgba(0, 0, 0, 0.75);
+        --light-modal-bg-color: #aaa;
+      }
+
       :root {
         font-size: 1em;
         --ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
         --mono: "Source Code Pro", monospace;
-        --tx-color: #141414;
-        --bg-color: #ffffff;
-        --link-color: #2A6286;
-        --sidebar-sh-color: rgba(0, 0, 0, 0.09);
-        --sidebar-mod-bg-color: #f1f1f1;
-        --sidebar-modlnk-tx-color: #141414;
-        --sidebar-modlnk-tx-color-hover: #fff;
-        --sidebar-modlnk-tx-color-active: #000;
-        --sidebar-modlnk-bg-color: transparent;
-        --sidebar-modlnk-bg-color-hover: #555;
-        --sidebar-modlnk-bg-color-active: #FFBB4D;
-        --search-bg-color: #f3f3f3;
-        --search-bg-color-focus: #ffffff;
-        --search-sh-color: rgba(0, 0, 0, 0.18);
-        --search-other-results-color: rgb(100, 100, 100);
-        --modal-sh-color: rgba(0, 0, 0, 0.75);
-        --modal-bg-color: #aaa;
+        --tx-color: var(--dark-tx-color);
+        --bg-color: var(--dark-bg-color);
+        --link-color: var(--dark-link-color);
+        --sidebar-sh-color: var(--dark-sidebar-sh-color);
+        --sidebar-mod-bg-color: var(--dark-sidebar-mod-bg-color);
+        --sidebar-modlnk-tx-color: var(--dark-sidebar-modlnk-tx-color);
+        --sidebar-modlnk-tx-color-hover: var(--dark-sidebar-modlnk-tx-color-hover);
+        --sidebar-modlnk-tx-color-active: var(--dark-sidebar-modlnk-tx-color-active);
+        --sidebar-modlnk-bg-color: var(--dark-sidebar-modlnk-bg-color);
+        --sidebar-modlnk-bg-color-hover: var(--dark-sidebar-modlnk-bg-color-hover);
+        --sidebar-modlnk-bg-color-active: var(--dark-sidebar-modlnk-bg-color-active);
+        --search-bg-color: var(--dark-search-bg-color);
+        --search-bg-color-focus: var(--dark-search-bg-color-focus);
+        --search-sh-color: var(--dark-search-sh-color);
+        --search-other-results-color: var(--dark-search-other-results-color);
+        --modal-sh-color: var(--dark-modal-sh-color);
+        --modal-bg-color: var(--dark-modal-bg-color);
+      }
+
+      body[data-colortheme='light'] {
+        --tx-color: var(--light-tx-color);
+        --bg-color: var(--light-bg-color);
+        --link-color: var(--light-link-color);
+        --sidebar-sh-color: var(--light-sidebar-sh-color);
+        --sidebar-mod-bg-color: var(--light-sidebar-mod-bg-color);
+        --sidebar-modlnk-tx-color: var(--light-sidebar-modlnk-tx-color);
+        --sidebar-modlnk-tx-color-hover: var(--light-sidebar-modlnk-tx-color-hover);
+        --sidebar-modlnk-tx-color-active: var(--light-sidebar-modlnk-tx-color-active);
+        --sidebar-modlnk-bg-color: var(--light-sidebar-modlnk-bg-color);
+        --sidebar-modlnk-bg-color-hover: var(--light-sidebar-modlnk-bg-color-hover);
+        --sidebar-modlnk-bg-color-active: var(--light-sidebar-modlnk-bg-color-active);
+        --search-bg-color: var(--light-search-bg-color);
+        --search-bg-color-focus: var(--light-search-bg-color-focus);
+        --search-sh-color: var(--light-search-sh-color);
+        --search-other-results-color: var(--light-search-other-results-color);
+        --modal-sh-color: var(--light-modal-sh-color);
+        --modal-bg-color: var(--light-modal-bg-color);
+
       }
 
       html, body { margin: 0; padding: 0; height: 100%; }
@@ -530,25 +591,6 @@
 
       /* dark mode */
       @media (prefers-color-scheme: dark) {
-        :root {
-          --tx-color: #bbb;
-          --bg-color: #111;
-          --link-color: #88f;
-          --sidebar-sh-color: rgba(128, 128, 128, 0.09);
-          --sidebar-mod-bg-color: #333;
-          --sidebar-modlnk-tx-color: #fff;
-          --sidebar-modlnk-tx-color-hover: #fff;
-          --sidebar-modlnk-tx-color-active: #000;
-          --sidebar-modlnk-bg-color: transparent;
-          --sidebar-modlnk-bg-color-hover: #555;
-          --sidebar-modlnk-bg-color-active: #FFBB4D;
-          --search-bg-color: #3c3c3c;
-          --search-bg-color-focus: #000;
-          --search-sh-color: rgba(255, 255, 255, 0.28);
-          --search-other-results-color: rgba(255, 255, 255, 0.28);
-          --modal-sh-color: rgba(142, 142, 142, 0.5);
-          --modal-bg-color: #333;
-        }
 
         .docs pre {
           background-color:#2A2A2A;
@@ -683,7 +725,7 @@
       }
     </style>
   </head>
-  <body class="canvas">
+  <body class="canvas" data-colorTheme="auto">
     <div id="banner" class="banner">
       This is a beta autodoc build; expect bugs and missing information.
       <a href="https://github.com/ziglang/zig/wiki/How-to-contribute-to-Autodoc">Report an Issue</a>,
@@ -900,6 +942,14 @@
           <h1>Preferences</h1>
           <ul class="prefs-list">
             <li><input id="prefSlashSearch" type="checkbox"><label for="prefSlashSearch">Enable <kbd>/</kbd> for search</label></li>
+            <li>
+              <select id="prefColorMode" name="prefColorMode">
+                <option value="auto">Auto</option>
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </select>
+              <label for="prefColorMode">Color Mode</label>
+            </li>
           </ul>
         </div>
       </div>

--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -10,6 +10,7 @@
         /* dark */
         --dark-tx-color: #bbb;
         --dark-bg-color: #111;
+        --dark-doc-pre-color: #2a2a2a;
         --dark-link-color: #88f;
         --dark-sidebar-sh-color: rgba(128, 128, 128, 0.09);
         --dark-sidebar-mod-bg-color: #333;
@@ -29,6 +30,7 @@
         /* light */
         --light-tx-color: #141414;
         --light-bg-color: #ffffff;
+        --light-doc-pre-color: #f5f5f5;
         --light-link-color: #2A6286;
         --light-sidebar-sh-color: rgba(0, 0, 0, 0.09);
         --light-sidebar-mod-bg-color: #f1f1f1;
@@ -40,6 +42,7 @@
         --light-sidebar-modlnk-bg-color-active: #FFBB4D;
         --light-search-bg-color: #f3f3f3;
         --light-search-bg-color-focus: #ffffff;
+        --light-search-border-bottom-color: #ffbb4d;
         --light-search-sh-color: rgba(0, 0, 0, 0.18);
         --light-search-other-results-color: rgb(100, 100, 100);
         --light-modal-sh-color: rgba(0, 0, 0, 0.75);
@@ -52,6 +55,7 @@
         --mono: "Source Code Pro", monospace;
         --tx-color: var(--dark-tx-color);
         --bg-color: var(--dark-bg-color);
+        --doc-pre-color: var(--dark-doc-pre-color);
         --link-color: var(--dark-link-color);
         --sidebar-sh-color: var(--dark-sidebar-sh-color);
         --sidebar-mod-bg-color: var(--dark-sidebar-mod-bg-color);
@@ -63,6 +67,7 @@
         --sidebar-modlnk-bg-color-active: var(--dark-sidebar-modlnk-bg-color-active);
         --search-bg-color: var(--dark-search-bg-color);
         --search-bg-color-focus: var(--dark-search-bg-color-focus);
+        --search-border-bottom-color: var(--dark-search-border-bottom-color);
         --search-sh-color: var(--dark-search-sh-color);
         --search-other-results-color: var(--dark-search-other-results-color);
         --modal-sh-color: var(--dark-modal-sh-color);
@@ -72,6 +77,7 @@
       body[data-colortheme='light'] {
         --tx-color: var(--light-tx-color);
         --bg-color: var(--light-bg-color);
+        --doc-pre-color: var(--light-doc-pre-color);
         --link-color: var(--light-link-color);
         --sidebar-sh-color: var(--light-sidebar-sh-color);
         --sidebar-mod-bg-color: var(--light-sidebar-mod-bg-color);
@@ -83,6 +89,7 @@
         --sidebar-modlnk-bg-color-active: var(--light-sidebar-modlnk-bg-color-active);
         --search-bg-color: var(--light-search-bg-color);
         --search-bg-color-focus: var(--light-search-bg-color-focus);
+        --search-border-bottom-color: var(--light-search-border-bottom-color);
         --search-sh-color: var(--light-search-sh-color);
         --search-other-results-color: var(--light-search-other-results-color);
         --modal-sh-color: var(--light-modal-sh-color);
@@ -300,7 +307,7 @@
 
       .docs .search:focus {
         background-color: var(--search-bg-color-focus);
-        border-bottom-color: #ffbb4d;
+        border-bottom-color: var(--search-border-bottom-color);
         box-shadow: 0 0.3em 1em 0.125em var(--search-sh-color);
       }
 
@@ -353,7 +360,7 @@
       .docs pre {
         font-family: var(--mono);
         font-size: 1em;
-        background-color: #F5F5F5;
+        background-color: var(--doc-pre-color);
         padding: 1em;
         overflow-x: auto;
       }
@@ -381,25 +388,25 @@
         margin: 0;
         padding: 0;
         overflow: hidden;
-        background-color: #f1f1f1;
+        background-color: var(--sidebar-mod-bg-color);
       }
       #listNav li {
         float:left;
       }
       #listNav li a {
         display: block;
-        color: #000;
+        color: var(--sidebar-modlnk-tx-color-active);
         text-align: center;
         padding: .5em .8em;
         text-decoration: none;
       }
       #listNav li a:hover {
-        background-color: #555;
-        color: #fff;
+        background-color: var(--sidebar-modlnk-bg-color-hover);
+        color: var(--sidebar-modlnk-tx-color-hover);
       }
       #listNav li a.active {
-        background-color: #FFBB4D;
-        color: #000;
+        background-color: var(--sidebar-modlnk-bg-color-active);
+        color: var(--sidebar-modlnk-tx-color-active);
       }
 
       #listSearchResults li.selected {
@@ -559,6 +566,7 @@
         display: none;
       }
 
+      /* TODO: Change tokens to use CSS variables */
       /* tokens */
       .tok-kw {
           color: #333;
@@ -592,25 +600,8 @@
       /* dark mode */
       @media (prefers-color-scheme: dark) {
 
-        .docs pre {
-          background-color:#2A2A2A;
-        }
         .fieldDocs {
           border-color:#2A2A2A;
-        }
-        #listNav {
-          background-color: #333;
-        }
-        #listNav li a {
-          color: #fff;
-        }
-        #listNav li a:hover {
-          background-color: #555;
-          color: #fff;
-        }
-        #listNav li a.active {
-          background-color: #FFBB4D;
-          color: #000;
         }
         #listSearchResults li.selected {
           background-color: #000;
@@ -758,8 +749,8 @@
               </g>
             </g>
             <style>
-            #text { fill: #121212 }
-            @media (prefers-color-scheme: dark) { #text { fill: #f2f2f2 } }
+            body[data-colortheme='light'] #text { fill: #121212 }
+            body[data-colortheme='dark'] #text { fill: #f2f2f2 }
             </style>
             <g id="text">
               <g>

--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -26,6 +26,14 @@
         --dark-search-other-results-color: rgba(255, 255, 255, 0.28);
         --dark-modal-sh-color: rgba(142, 142, 142, 0.5);
         --dark-modal-bg-color: #333;
+        --dark-token-kw-color: #eee;
+        --dark-token-str-color: #2e5;
+        --dark-token-builtin-color: #ff894c;
+        --dark-token-comment-color: #aa7;
+        --dark-token-fn-color: #e33;
+        --dark-token-null-color: #ff8080;
+        --dark-token-number-color: #ff8080;
+        --dark-token-type-color: #68f;
 
         /* light */
         --light-tx-color: #141414;
@@ -47,6 +55,14 @@
         --light-search-other-results-color: rgb(100, 100, 100);
         --light-modal-sh-color: rgba(0, 0, 0, 0.75);
         --light-modal-bg-color: #aaa;
+        --light-token-kw-color: #333;
+        --light-token-str-color: #d14;
+        --light-token-builtin-color: #0086b3;
+        --light-token-comment-color: #777;
+        --light-token-fn-color: #900;
+        --light-token-null-color: #008080;
+        --light-token-number-color: #008080;
+        --light-token-type-color: #458;
       }
 
       :root {
@@ -72,6 +88,15 @@
         --search-other-results-color: var(--dark-search-other-results-color);
         --modal-sh-color: var(--dark-modal-sh-color);
         --modal-bg-color: var(--dark-modal-bg-color);
+
+        --token-kw-color: var(--dark-token-kw-color);
+        --token-str-color: var(--dark-token-str-color);
+        --token-builtin-color: var(--dark-token-builtin-color);
+        --token-comment-color: var(--dark-token-comment-color);
+        --token-fn-color: var(--dark-token-fn-color);
+        --token-null-color: var(--dark-token-null-color);
+        --token-number-color: var(--dark-token-number-color);
+        --token-type-color: var(--dark-token-type-color);
       }
 
       body[data-colortheme='light'] {
@@ -95,6 +120,14 @@
         --modal-sh-color: var(--light-modal-sh-color);
         --modal-bg-color: var(--light-modal-bg-color);
 
+        --token-kw-color: var(--light-token-kw-color);
+        --token-str-color: var(--light-token-str-color);
+        --token-builtin-color: var(--light-token-builtin-color);
+        --token-comment-color: var(--light-token-comment-color);
+        --token-fn-color: var(--light-token-fn-color);
+        --token-null-color: var(--light-token-null-color);
+        --token-number-color: var(--light-token-number-color);
+        --token-type-color: var(--light-token-type-color);
       }
 
       html, body { margin: 0; padding: 0; height: 100%; }
@@ -566,34 +599,33 @@
         display: none;
       }
 
-      /* TODO: Change tokens to use CSS variables */
       /* tokens */
       .tok-kw {
-          color: #333;
+          color: var(--token-kw-color);
           font-weight: bold;
       }
       .tok-str {
-          color: #d14;
+          color: var(--token-str-color);
       }
       .tok-builtin {
-          color: #0086b3;
+          color: var(--token-builtin-color);
       }
       .tok-comment {
-          color: #777;
+          color: var(--token-comment-color);
           font-style: italic;
       }
       .tok-fn {
-          color: #900;
+          color: var(--token-fn-color);
           font-weight: bold;
       }
       .tok-null {
-          color: #008080;
+          color: var(--token-null-color);
       }
       .tok-number {
-          color: #008080;
+          color: var(--token-number-color);
       }
       .tok-type {
-          color: #458;
+          color: var(--token-type-color);
           font-weight: bold;
       }
 
@@ -608,30 +640,6 @@
         }
         #listSearchResults li.selected a {
           color: #fff;
-        }
-        .tok-kw {
-            color: #eee;
-        }
-        .tok-str {
-            color: #2e5;
-        }
-        .tok-builtin {
-            color: #ff894c;
-        }
-        .tok-comment {
-            color: #aa7;
-        }
-        .tok-fn {
-            color: #e33;
-        }
-        .tok-null {
-            color: #ff8080;
-        }
-        .tok-number {
-            color: #ff8080;
-        }
-        .tok-type {
-            color: #68f;
         }
       }
 

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -74,10 +74,12 @@ const NAV_MODES = {
   const domLangRefLink = document.getElementById("langRefLink");
 
   const domPrefSlashSearch = document.getElementById("prefSlashSearch");
+  const domPrefColorMode = document.getElementById("prefColorMode");
   const prefs = getLocalStorage();
   loadPrefs();
 
   domPrefSlashSearch.addEventListener("change", () => setPrefSlashSearch(domPrefSlashSearch.checked));
+  domPrefColorMode.addEventListener("change", () => setPrefColorMode(domPrefColorMode.value));
 
   let searchTimer = null;
   let searchTrimResults = true;
@@ -4762,6 +4764,13 @@ function addDeclToSearchResults(decl, declIndex, modNames, item, list, stack) {
     } else {
       setPrefSlashSearch(storedPrefSlashSearch === "true");
     }
+    const storedColorMode = prefs.getItem("colorMode");
+    if (storedColorMode === null) {
+      // Color mode defaults to auto
+      setPrefColorMode("auto");
+    } else {
+      setPrefColorMode(storedColorMode);
+    }
   }
 
   function getPrefSlashSearch() {
@@ -4774,6 +4783,23 @@ function addDeclToSearchResults(decl, declIndex, modNames, item, list, stack) {
     const searchKeys = enabled ? "<kbd>/</kbd> or <kbd>s</kbd>" : "<kbd>s</kbd>";
     domSearchKeys.innerHTML = searchKeys;
     domSearchPlaceholder.innerHTML = searchKeys + " to search, <kbd>?</kbd> for more options";
+  }
+
+  function getPrefColorMode() {
+    return prefs.getItem("colorMode");
+  }
+
+  function setPrefColorMode(mode) {
+    prefs.setItem("colorMode", mode);
+    // If the color mode is auto, get the user's preference from their OS
+    if (mode === "auto") {
+      mode = window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+    }
+    domPrefColorMode.value = mode;
+    // Update the <body> attribute to reflect the new color mode
+    document.body.attributes['data-colorTheme'].value = mode;
   }
 })();
 


### PR DESCRIPTION
Closes #16257 

This uses the modal created by #16251 and adds a menu that allows the user to select their theme preference of either

- Auto
- Light
- Dark

If "Auto" is chosen, then the system's theme preference is attempted to be used. An HTML tag attribute, `data-colortheme` is used on the `body` tag to manage the currently-selected theme. This code also uses CSS variables to store the values of light and dark mode variables, such as with
```css
html {
  --dark-tx-color: #bbb;
  \* ... *\
  --light-tx-color: #141414;
  \* ... *\
}

:root {
  --tx-color: var(--dark-tx-color);
}

body[data-colortheme='light'] {
  --tx-color: var(--light-tx-color);
}
```
I understand that it was requested after `autodoc-guides-sidebar` is merged and so I understand if this request is denied.