### PR TITLE
Expand zig help that build have other useful subcommands

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -84,7 +84,7 @@ const normal_usage =
     \\
     \\Commands:
     \\
-    \\  build            Build project from build.zig
+    \\  build            Build project from build.zig with subcommands to run, test etc.
     \\  init-exe         Initialize a `zig build` application in the cwd
     \\  init-lib         Initialize a `zig build` library in the cwd
     \\

--- a/src/main.zig
+++ b/src/main.zig
@@ -84,7 +84,7 @@ const normal_usage =
     \\
     \\Commands:
     \\
-    \\  build            Build project from build.zig with subcommands to run, test etc.
+    \\  build            Build project from build.zig. There could be subcommands like run, test etc.
     \\  init-exe         Initialize a `zig build` application in the cwd
     \\  init-lib         Initialize a `zig build` library in the cwd
     \\


### PR DESCRIPTION
My main motivation is that when running `zig help` you may think that `zig run` is the way to go instead of `zig build run` for project.

Simple `zig help | grep run` will show `zig run` which may be misleading.