### PR TITLE
SPIR-V InternPool aftermath damage control

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -741,7 +741,8 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace, ret_addr
         builtin.zig_backend == .stage2_x86_64 or
         builtin.zig_backend == .stage2_x86 or
         builtin.zig_backend == .stage2_riscv64 or
-        builtin.zig_backend == .stage2_sparc64)
+        builtin.zig_backend == .stage2_sparc64 or
+        builtin.zig_backend == .stage2_spirv64)
     {
         while (true) {
             @breakpoint();

--- a/test/behavior/c_char_signedness.zig
+++ b/test/behavior/c_char_signedness.zig
@@ -1,10 +1,13 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const expectEqual = std.testing.expectEqual;
 const c = @cImport({
     @cInclude("limits.h");
 });
 
 test "c_char signedness" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
     try expectEqual(@as(c_char, c.CHAR_MIN), std.math.minInt(c_char));
     try expectEqual(@as(c_char, c.CHAR_MAX), std.math.maxInt(c_char));
 }

--- a/test/behavior/call.zig
+++ b/test/behavior/call.zig
@@ -417,6 +417,8 @@ test "inline while with @call" {
 }
 
 test "method call as parameter type" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
     const S = struct {
         fn foo(x: anytype, y: @TypeOf(x).Inner()) @TypeOf(y) {
             return y;

--- a/test/behavior/comptime_memory.zig
+++ b/test/behavior/comptime_memory.zig
@@ -433,6 +433,8 @@ test "dereference undefined pointer to zero-bit type" {
 }
 
 test "type pun extern struct" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
     const S = extern struct { f: u8 };
     comptime var s = S{ .f = 123 };
     @as(*u8, @ptrCast(&s)).* = 72;

--- a/test/behavior/enum.zig
+++ b/test/behavior/enum.zig
@@ -1199,6 +1199,8 @@ test "enum tag from a local variable" {
 }
 
 test "auto-numbered enum with signed tag type" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
     const E = enum(i32) { a, b };
 
     try std.testing.expectEqual(@as(i32, 0), @intFromEnum(E.a));

--- a/test/behavior/maximum_minimum.zig
+++ b/test/behavior/maximum_minimum.zig
@@ -297,6 +297,8 @@ test "@min/@max notices bounds from vector types when element of comptime-known 
 }
 
 test "@min/@max of signed and unsigned runtime integers" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
     var x: i32 = -1;
     var y: u31 = 1;
 

--- a/test/behavior/ptrfromint.zig
+++ b/test/behavior/ptrfromint.zig
@@ -33,6 +33,7 @@ test "@ptrFromInt creates null pointer" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const ptr = @as(?*u32, @ptrFromInt(0));
     try expectEqual(@as(?*u32, null), ptr);
@@ -42,6 +43,7 @@ test "@ptrFromInt creates allowzero zero pointer" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const ptr = @as(*allowzero u32, @ptrFromInt(0));
     try expectEqual(@as(usize, 0), @intFromPtr(ptr));


### PR DESCRIPTION
This fixes a bunch of stuff that got broken.
- Fixes up some todos & errors from intern pool changes
- Enables a simplified panic handler, because we cannot print from spirv
- Disables prints in std.testing if the target does not support it.
  - This still requires `.aggregate_init` to be implemented, so it does not really do anything for spir-v yet.
- Disables a bunch of new tests that fail (some of the reasons include the previous point).