### PR TITLE
Some amdgcn fixes

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -806,7 +806,7 @@ pub fn default_panic(msg: []const u8, error_return_trace: ?*StackTrace, ret_addr
             // Didn't have boot_services, just fallback to whatever.
             std.os.abort();
         },
-        .cuda => std.os.abort(),
+        .cuda, .amdhsa => std.os.abort(),
         else => {
             const first_trace_addr = ret_addr orelse @returnAddress();
             std.debug.panicImpl(error_return_trace, first_trace_addr, msg);

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -613,7 +613,7 @@ pub fn abort() noreturn {
         exit(127); // Pid 1 might not be signalled in some containers.
     }
     switch (builtin.os.tag) {
-        .uefi, .wasi, .cuda => @trap(),
+        .uefi, .wasi, .cuda, .amdhsa => @trap(),
         else => system.abort(),
     }
 }


### PR DESCRIPTION
The panic handler expects that this value is represented with the generic address space, so cast the global to the generic addressspace before caching and returning the value.

Also attached is a commit that sets the default panic handler for amdhsa to one that does not crash.