### PR TITLE
Fix `TTY.detectConfig` regression on windows

### DIFF
--- a/lib/std/io/tty.zig
+++ b/lib/std/io/tty.zig
@@ -20,6 +20,8 @@ pub fn detectConfig(file: File) Config {
 
     if (force_color == false) return .no_color;
 
+    if (file.supportsAnsiEscapeCodes()) return .escape_codes;
+
     if (native_os == .windows and file.isTty()) {
         var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
         if (windows.kernel32.GetConsoleScreenBufferInfo(file.handle, &info) != windows.TRUE) {
@@ -31,11 +33,7 @@ pub fn detectConfig(file: File) Config {
         } };
     }
 
-    if (force_color == true or file.supportsAnsiEscapeCodes()) {
-        return .escape_codes;
-    }
-
-    return .no_color;
+    return if (force_color == true) .escape_codes else .no_color;
 }
 
 pub const Color = enum {


### PR DESCRIPTION
e05412669c8dde1230612de5af64fbc3fb0bc17e inadvertently changed the logic on Windows and made it so that supportsAnsiEscapeCodes was never checked. This fixes that regression while keeping the logic intact for other platforms.

Semi-related: https://github.com/ziglang/zig/pull/16080

cc @dweiller 