### PR TITLE
Smaller memory footprint for BoundedArray

### DIFF
--- a/lib/std/bounded_array.zig
+++ b/lib/std/bounded_array.zig
@@ -39,14 +39,17 @@ pub fn BoundedArrayAligned(
 ) type {
     return struct {
         const Self = @This();
+        /// Smallest integer type that is able to hold values from 0 to `buffer_capacity`.
+        const Len = std.meta.Int(.unsigned, std.math.log2_int(u16, buffer_capacity) + 1);
+
         buffer: [buffer_capacity]T align(alignment) = undefined,
-        len: usize = 0,
+        len: Len = 0,
 
         /// Set the actual length of the slice.
         /// Returns error.Overflow if it exceeds the length of the backing array.
         pub fn init(len: usize) error{Overflow}!Self {
             if (len > buffer_capacity) return error.Overflow;
-            return Self{ .len = len };
+            return Self{ .len = @intCast(len) };
         }
 
         /// View the internal array as a slice whose size was previously set.
@@ -67,7 +70,7 @@ pub fn BoundedArrayAligned(
         /// Does not initialize added items if any.
         pub fn resize(self: *Self, len: usize) error{Overflow}!void {
             if (len > buffer_capacity) return error.Overflow;
-            self.len = len;
+            self.len = @intCast(len);
         }
 
         /// Copy the content of an existing slice.
@@ -163,7 +166,7 @@ pub fn BoundedArrayAligned(
         /// This operation is O(N).
         pub fn insertSlice(self: *Self, i: usize, items: []const T) error{Overflow}!void {
             try self.ensureUnusedCapacity(items.len);
-            self.len += items.len;
+            self.len += @intCast(items.len);
             mem.copyBackwards(T, self.slice()[i + items.len .. self.len], self.constSlice()[i .. self.len - items.len]);
             @memcpy(self.slice()[i..][0..items.len], items);
         }
@@ -193,7 +196,7 @@ pub fn BoundedArrayAligned(
                 for (self.constSlice()[after_range..], 0..) |item, i| {
                     self.slice()[after_subrange..][i] = item;
                 }
-                self.len -= len - new_items.len;
+                self.len -= @intCast(len - new_items.len);
             }
         }
 
@@ -244,7 +247,7 @@ pub fn BoundedArrayAligned(
         /// enough to store the new items.
         pub fn appendSliceAssumeCapacity(self: *Self, items: []const T) void {
             const old_len = self.len;
-            self.len += items.len;
+            self.len += @intCast(items.len);
             @memcpy(self.slice()[old_len..][0..items.len], items);
         }
 
@@ -260,8 +263,8 @@ pub fn BoundedArrayAligned(
         /// Asserts the capacity is enough.
         pub fn appendNTimesAssumeCapacity(self: *Self, value: T, n: usize) void {
             const old_len = self.len;
-            self.len += n;
-            assert(self.len <= buffer_capacity);
+            assert(self.len + n <= buffer_capacity);
+            self.len += @intCast(n);
             @memset(self.slice()[old_len..self.len], value);
         }
 
@@ -391,7 +394,12 @@ test "BoundedArray sizeOf" {
     // Just sanity check size on one CPU
     if (@import("builtin").cpu.arch != .x86_64)
         return;
-    try testing.expectEqual(@sizeOf(BoundedArray(u8, 3)), 16);
+
+    try testing.expectEqual(@sizeOf(BoundedArray(u8, 3)), 4);
+
+    // `len` is the minimum required size to hold the maximum capacity
+    try testing.expectEqual(@TypeOf(@as(BoundedArray(u8, 15), undefined).len), u4);
+    try testing.expectEqual(@TypeOf(@as(BoundedArray(u8, 16), undefined).len), u5);
 }
 
 test "BoundedArrayAligned" {

--- a/lib/std/bounded_array.zig
+++ b/lib/std/bounded_array.zig
@@ -39,8 +39,7 @@ pub fn BoundedArrayAligned(
 ) type {
     return struct {
         const Self = @This();
-        /// Smallest integer type that is able to hold values from 0 to `buffer_capacity`.
-        const Len = std.meta.Int(.unsigned, std.math.log2_int(u16, buffer_capacity) + 1);
+        const Len = std.math.IntFittingRange(0, buffer_capacity);
 
         buffer: [buffer_capacity]T align(alignment) = undefined,
         len: Len = 0,

--- a/lib/std/bounded_array.zig
+++ b/lib/std/bounded_array.zig
@@ -387,6 +387,13 @@ test "BoundedArray" {
     try testing.expectEqualStrings(s, a.constSlice());
 }
 
+test "BoundedArray sizeOf" {
+    // Just sanity check size on one CPU
+    if (@import("builtin").cpu.arch != .x86_64)
+        return;
+    try testing.expectEqual(@sizeOf(BoundedArray(u8, 3)), 16);
+}
+
 test "BoundedArrayAligned" {
     var a = try BoundedArrayAligned(u8, 16, 4).init(0);
     try a.append(0);

--- a/lib/std/bounded_array.zig
+++ b/lib/std/bounded_array.zig
@@ -165,7 +165,7 @@ pub fn BoundedArrayAligned(
         /// This operation is O(N).
         pub fn insertSlice(self: *Self, i: usize, items: []const T) error{Overflow}!void {
             try self.ensureUnusedCapacity(items.len);
-            self.len += @intCast(items.len);
+            self.len = @intCast(self.len + items.len);
             mem.copyBackwards(T, self.slice()[i + items.len .. self.len], self.constSlice()[i .. self.len - items.len]);
             @memcpy(self.slice()[i..][0..items.len], items);
         }
@@ -195,7 +195,7 @@ pub fn BoundedArrayAligned(
                 for (self.constSlice()[after_range..], 0..) |item, i| {
                     self.slice()[after_subrange..][i] = item;
                 }
-                self.len -= @intCast(len - new_items.len);
+                self.len = @intCast(self.len - len + new_items.len);
             }
         }
 
@@ -246,7 +246,7 @@ pub fn BoundedArrayAligned(
         /// enough to store the new items.
         pub fn appendSliceAssumeCapacity(self: *Self, items: []const T) void {
             const old_len = self.len;
-            self.len += @intCast(items.len);
+            self.len = @intCast(self.len + items.len);
             @memcpy(self.slice()[old_len..][0..items.len], items);
         }
 
@@ -263,7 +263,7 @@ pub fn BoundedArrayAligned(
         pub fn appendNTimesAssumeCapacity(self: *Self, value: T, n: usize) void {
             const old_len = self.len;
             assert(self.len + n <= buffer_capacity);
-            self.len += @intCast(n);
+            self.len = @intCast(self.len + n);
             @memset(self.slice()[old_len..self.len], value);
         }
 


### PR DESCRIPTION
This PR changes `BoundedArray`'s `len` field from a `usize` to a minimum-sized integer. If you're keeping a million of these in memory, their size can add up.

`BoundedArray(u8, 3)` used to take **16 bytes**, but now (with `len` stored as a `u2`) it only takes **4 bytes**.

Notes:

- `len` is the only type that changed. I left all the `usize` parameters alone, to not break existing code. A new test was added, and the old tests were not changed.
  - The test is testing memory layout, which varies across targets, so I only let it run on x86_64. Not sure if that's the right approach?
- `@intCast` is sprinkled in. For each one, either the value had already checked before that point, or it's in an "assume" method.
  - `appendNTimesAssumeCapacity` is an "assume" method, but it had an assert inside. Am I right to think it's odd to mix assumes with asserts? Either way I left the assert as it was.

This PR message is now longer than the diff, oops. I'll stop rambling. Happy reviewing!