### PR TITLE
std.math.big.int: better name for equal function

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -147,9 +147,12 @@ pub const Mutable = struct {
         };
     }
 
+    // TODO: remove after release of 0.11
+    pub const eqZero = @compileError("use eqlZero");
+
     /// Returns true if `a == 0`.
-    pub fn eqZero(self: Mutable) bool {
-        return self.toConst().eqZero();
+    pub fn eqlZero(self: Mutable) bool {
+        return self.toConst().eqlZero();
     }
 
     /// Asserts that the allocator owns the limbs memory. If this is not the case,
@@ -420,10 +423,10 @@ pub const Mutable = struct {
     ///
     /// Asserts r has enough elements to hold the result. The upper bound is `@max(a.limbs.len, b.limbs.len)`.
     fn addCarry(r: *Mutable, a: Const, b: Const) bool {
-        if (a.eqZero()) {
+        if (a.eqlZero()) {
             r.copy(b);
             return false;
-        } else if (b.eqZero()) {
+        } else if (b.eqlZero()) {
             r.copy(a);
             return false;
         } else if (a.positive != b.positive) {
@@ -556,11 +559,11 @@ pub const Mutable = struct {
     ///
     /// Asserts r has enough elements to hold the result. The upper bound is `@max(a.limbs.len, b.limbs.len)`.
     fn subCarry(r: *Mutable, a: Const, b: Const) bool {
-        if (a.eqZero()) {
+        if (a.eqlZero()) {
             r.copy(b);
             r.positive = !b.positive;
             return false;
-        } else if (b.eqZero()) {
+        } else if (b.eqlZero()) {
             r.copy(a);
             return false;
         } else if (a.positive != b.positive) {
@@ -1002,7 +1005,7 @@ pub const Mutable = struct {
             // Else:
             //   @rem(a - 1, b) = @rem(a + b - 1, b) = @rem(b - 1, b) = b - 1
             //   => @mod(a, -b) = b - 1 - b + 1 = 0
-            if (!r.eqZero()) {
+            if (!r.eqlZero()) {
                 q.addScalar(q.toConst(), -1);
                 r.positive = true;
                 r.sub(r.toConst(), y.toConst().abs());
@@ -1033,7 +1036,7 @@ pub const Mutable = struct {
             // Else :
             //   @rem(a - 1, b) = b - 1
             //   => @mod(-a, b) = -(b - 1) + b - 1 = 0
-            if (!r.eqZero()) {
+            if (!r.eqlZero()) {
                 q.addScalar(q.toConst(), -1);
                 r.positive = false;
                 r.add(r.toConst(), y.toConst().abs());
@@ -1119,7 +1122,7 @@ pub const Mutable = struct {
         // 0-bit integers.
         if (bit_count <= shift) {
             // In this case, there is only no overflow if `a` is zero.
-            if (a.eqZero()) {
+            if (a.eqlZero()) {
                 r.set(0);
             } else {
                 r.setTwosCompIntLimit(if (a.positive) .max else .min, signedness, bit_count);
@@ -1214,10 +1217,10 @@ pub const Mutable = struct {
     /// Asserts that r has enough limbs to store the result. Upper bound is `@max(a.limbs.len, b.limbs.len)`.
     pub fn bitOr(r: *Mutable, a: Const, b: Const) void {
         // Trivial cases, llsignedor does not support zero.
-        if (a.eqZero()) {
+        if (a.eqlZero()) {
             r.copy(b);
             return;
-        } else if (b.eqZero()) {
+        } else if (b.eqlZero()) {
             r.copy(a);
             return;
         }
@@ -1239,10 +1242,10 @@ pub const Mutable = struct {
     /// If a and b are negative, the upper bound is `@max(a.limbs.len, b.limbs.len) + 1`.
     pub fn bitAnd(r: *Mutable, a: Const, b: Const) void {
         // Trivial cases, llsignedand does not support zero.
-        if (a.eqZero()) {
+        if (a.eqlZero()) {
             r.copy(a);
             return;
-        } else if (b.eqZero()) {
+        } else if (b.eqlZero()) {
             r.copy(b);
             return;
         }
@@ -1264,10 +1267,10 @@ pub const Mutable = struct {
     /// but not both, the upper bound is `@max(a.limbs.len, b.limbs.len) + 1`.
     pub fn bitXor(r: *Mutable, a: Const, b: Const) void {
         // Trivial cases, because llsignedxor does not support negative zero.
-        if (a.eqZero()) {
+        if (a.eqlZero()) {
             r.copy(b);
             return;
-        } else if (b.eqZero()) {
+        } else if (b.eqlZero()) {
             r.copy(a);
             return;
         }
@@ -1330,7 +1333,7 @@ pub const Mutable = struct {
             else => {},
         }
 
-        if (a.eqZero()) {
+        if (a.eqlZero()) {
             // 0^b = 0
             return r.set(0);
         } else if (a.limbs.len == 1 and a.limbs[0] == 1) {
@@ -1442,7 +1445,7 @@ pub const Mutable = struct {
         var tmp_x = try Managed.init(limbs_buffer.allocator);
         defer tmp_x.deinit();
 
-        while (y.len() > 1 and !y.eqZero()) {
+        while (y.len() > 1 and !y.eqlZero()) {
             assert(x.isPositive() and y.isPositive());
             assert(x.len() >= y.len());
 
@@ -1506,7 +1509,7 @@ pub const Mutable = struct {
         // euclidean algorithm
         assert(x.toConst().order(y.toConst()) != .lt);
 
-        while (!y.toConst().eqZero()) {
+        while (!y.toConst().eqlZero()) {
             try t_big.divTrunc(&r, &x, &y);
             x.swap(&y);
             y.swap(&r);
@@ -1517,7 +1520,7 @@ pub const Mutable = struct {
 
     // Truncates by default.
     fn div(q: *Mutable, r: *Mutable, x: *Mutable, y: *Mutable) void {
-        assert(!y.eqZero()); // division by zero
+        assert(!y.eqlZero()); // division by zero
         assert(q != r); // illegal aliasing
 
         const q_positive = (x.positive == y.positive);
@@ -1745,7 +1748,7 @@ pub const Mutable = struct {
         }
 
         const req_limbs = calcTwosCompLimbCount(bit_count);
-        if (req_limbs == 0 or a.eqZero()) {
+        if (req_limbs == 0 or a.eqlZero()) {
             r.set(0);
             return;
         }
@@ -1776,7 +1779,7 @@ pub const Mutable = struct {
         const req_limbs = calcTwosCompLimbCount(bit_count);
 
         // Handle 0-bit integers.
-        if (req_limbs == 0 or a.eqZero()) {
+        if (req_limbs == 0 or a.eqlZero()) {
             r.set(0);
             return;
         }
@@ -2121,7 +2124,7 @@ pub const Const = struct {
     }
 
     pub fn fitsInTwosComp(self: Const, signedness: Signedness, bit_count: usize) bool {
-        if (self.eqZero()) {
+        if (self.eqlZero()) {
             return true;
         }
         if (signedness == .unsigned and !self.positive) {
@@ -2159,7 +2162,7 @@ pub const Const = struct {
         switch (@typeInfo(T)) {
             .Int => |info| {
                 // Make sure -0 is handled correctly.
-                if (self.eqZero()) return 0;
+                if (self.eqlZero()) return 0;
 
                 const UT = std.meta.Int(.unsigned, info.bits);
 
@@ -2253,7 +2256,7 @@ pub const Const = struct {
         assert(base >= 2);
         assert(base <= 16);
 
-        if (self.eqZero()) {
+        if (self.eqlZero()) {
             return allocator.dupe(u8, "0");
         }
         const string = try allocator.alloc(u8, self.sizeInBaseUpperBound(base));
@@ -2278,7 +2281,7 @@ pub const Const = struct {
         assert(base >= 2);
         assert(base <= 16);
 
-        if (self.eqZero()) {
+        if (self.eqlZero()) {
             string[0] = '0';
             return 1;
         }
@@ -2478,20 +2481,25 @@ pub const Const = struct {
         return order(lhs, rhs.toConst());
     }
 
+    // TODO: remove after release of 0.11
+    pub const eqZero = @compileError("use eqlZero");
+    pub const eqAbs = @compileError("use eqlAbs");
+    pub const eq = @compileError("use eql");
+
     /// Returns true if `a == 0`.
-    pub fn eqZero(a: Const) bool {
+    pub fn eqlZero(a: Const) bool {
         var d: Limb = 0;
         for (a.limbs) |limb| d |= limb;
         return d == 0;
     }
 
     /// Returns true if `|a| == |b|`.
-    pub fn eqAbs(a: Const, b: Const) bool {
+    pub fn eqlAbs(a: Const, b: Const) bool {
         return orderAbs(a, b) == .eq;
     }
 
     /// Returns true if `a == b`.
-    pub fn eq(a: Const, b: Const) bool {
+    pub fn eql(a: Const, b: Const) bool {
         return order(a, b) == .eq;
     }
 
@@ -2822,19 +2830,24 @@ pub const Managed = struct {
         return a.toConst().order(b.toConst());
     }
 
+    // TODO: remove after release of 0.11
+    pub const eqZero = @compileError("use eqlZero");
+    pub const eqAbs = @compileError("use eqlAbs");
+    pub const eq = @compileError("use eql");
+
     /// Returns true if a == 0.
-    pub fn eqZero(a: Managed) bool {
-        return a.toConst().eqZero();
+    pub fn eqlZero(a: Managed) bool {
+        return a.toConst().eqlZero();
     }
 
     /// Returns true if |a| == |b|.
-    pub fn eqAbs(a: Managed, b: Managed) bool {
-        return a.toConst().eqAbs(b.toConst());
+    pub fn eqlAbs(a: Managed, b: Managed) bool {
+        return a.toConst().eqlAbs(b.toConst());
     }
 
     /// Returns true if a == b.
-    pub fn eq(a: Managed, b: Managed) bool {
-        return a.toConst().eq(b.toConst());
+    pub fn eql(a: Managed, b: Managed) bool {
+        return a.toConst().eql(b.toConst());
     }
 
     /// Normalize a possible sequence of leading zeros.

--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -461,8 +461,8 @@ test "big.int equality" {
     var b = try Managed.initSet(testing.allocator, -0xffffffff1);
     defer b.deinit();
 
-    try testing.expect(a.eqAbs(b));
-    try testing.expect(!a.eq(b));
+    try testing.expect(a.eqlAbs(b));
+    try testing.expect(!a.eql(b));
 }
 
 test "big.int abs" {
@@ -1006,7 +1006,7 @@ test "big.int mul large" {
     try b.mul(&a, &a);
     try c.sqr(&a);
 
-    try testing.expect(b.eq(c));
+    try testing.expect(b.eql(c));
 }
 
 test "big.int mulWrap single-single unsigned" {
@@ -1088,7 +1088,7 @@ test "big.int mulWrap large" {
     try c.sqr(&a);
     try c.truncate(&c, .signed, testbits);
 
-    try testing.expect(b.eq(c));
+    try testing.expect(b.eql(c));
 }
 
 test "big.int div single-half no rem" {
@@ -1716,8 +1716,8 @@ test "big.int div multi-single zero-limb trailing" {
 
     var expected = try Managed.initSet(testing.allocator, 0x6000000000000000000000000000000000000000000000000);
     defer expected.deinit();
-    try testing.expect(q.eq(expected));
-    try testing.expect(r.eqZero());
+    try testing.expect(q.eql(expected));
+    try testing.expect(r.eqlZero());
 }
 
 test "big.int div multi-multi zero-limb trailing (with rem)" {
@@ -1962,7 +1962,7 @@ test "big.int saturate multi unsigned zero" {
 
     try a.saturate(&a, .unsigned, @bitSizeOf(DoubleLimb));
 
-    try testing.expect(a.eqZero());
+    try testing.expect(a.eqlZero());
 }
 
 test "big.int saturate multi unsigned" {
@@ -1993,7 +1993,7 @@ test "big.int shift-right multi" {
     try a.shiftRight(&a, 63);
     try a.shiftRight(&a, 63);
     try a.shiftRight(&a, 2);
-    try testing.expect(a.eqZero());
+    try testing.expect(a.eqlZero());
 }
 
 test "big.int shift-left single" {
@@ -2224,7 +2224,7 @@ test "big.int bitwise and negative-positive multi-limb" {
 
     try a.bitAnd(&a, &b);
 
-    try testing.expect(a.eqZero());
+    try testing.expect(a.eqlZero());
 }
 
 test "big.int bitwise and positive-negative simple" {
@@ -2246,7 +2246,7 @@ test "big.int bitwise and positive-negative multi-limb" {
 
     try a.bitAnd(&a, &b);
 
-    try testing.expect(a.eqZero());
+    try testing.expect(a.eqlZero());
 }
 
 test "big.int bitwise and negative-negative simple" {
@@ -2325,7 +2325,7 @@ test "big.int bitwise xor single negative zero" {
 
     try a.bitXor(&a, &b);
 
-    try testing.expect(a.eqZero());
+    try testing.expect(a.eqlZero());
 }
 
 test "big.int bitwise xor single negative multi-limb" {
@@ -2554,7 +2554,7 @@ test "big.int mutable to managed" {
     var a = Mutable.init(limbs_buf, 0xdeadbeef);
     var a_managed = a.toManaged(allocator);
 
-    try testing.expect(a.toConst().eq(a_managed.toConst()));
+    try testing.expect(a.toConst().eql(a_managed.toConst()));
 }
 
 test "big.int const to managed" {
@@ -2564,7 +2564,7 @@ test "big.int const to managed" {
     var b = try a.toConst().toManaged(testing.allocator);
     defer b.deinit();
 
-    try testing.expect(a.toConst().eq(b.toConst()));
+    try testing.expect(a.toConst().eql(b.toConst()));
 }
 
 test "big.int pow" {
@@ -2590,7 +2590,7 @@ test "big.int pow" {
         // y and a are aliased
         try a.pow(&a, 123);
 
-        try testing.expect(a.eq(y));
+        try testing.expect(a.eql(y));
 
         const ys = try y.toString(testing.allocator, 16, .lower);
         defer testing.allocator.free(ys);
@@ -3096,7 +3096,7 @@ test "big.int mul multi-multi alias r with a and b" {
     var want = try Managed.initSet(testing.allocator, 4 * maxInt(Limb) * maxInt(Limb));
     defer want.deinit();
 
-    try testing.expect(a.eq(want));
+    try testing.expect(a.eql(want));
 
     if (@typeInfo(Limb).Int.bits == 64) {
         try testing.expectEqual(@as(usize, 5), a.limbs.len);
@@ -3112,7 +3112,7 @@ test "big.int sqr multi alias r with a" {
     var want = try Managed.initSet(testing.allocator, 4 * maxInt(Limb) * maxInt(Limb));
     defer want.deinit();
 
-    try testing.expect(a.eq(want));
+    try testing.expect(a.eql(want));
 
     if (@typeInfo(Limb).Int.bits == 64) {
         try testing.expectEqual(@as(usize, 5), a.limbs.len);

--- a/lib/std/math/big/rational.zig
+++ b/lib/std/math/big/rational.zig
@@ -205,7 +205,7 @@ pub const Rational = struct {
         const ebias = (1 << (esize - 1)) - 1;
         const emin = 1 - ebias;
 
-        if (self.p.eqZero()) {
+        if (self.p.eqlZero()) {
             return 0;
         }
 
@@ -294,7 +294,7 @@ pub const Rational = struct {
 
         try self.reduce();
 
-        if (self.q.eqZero()) {
+        if (self.q.eqlZero()) {
             @panic("cannot set rational with denominator = 0");
         }
     }
@@ -434,7 +434,7 @@ pub const Rational = struct {
     ///
     /// Returns an error if memory could not be allocated.
     pub fn div(r: *Rational, a: Rational, b: Rational) !void {
-        if (b.p.eqZero()) {
+        if (b.p.eqlZero()) {
             @panic("division by zero");
         }
 

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -1037,7 +1037,7 @@ pub const Key = union(enum) {
                     .big_int => |aa| switch (b_info.storage) {
                         .u64 => |bb| aa.orderAgainstScalar(bb) == .eq,
                         .i64 => |bb| aa.orderAgainstScalar(bb) == .eq,
-                        .big_int => |bb| aa.eq(bb),
+                        .big_int => |bb| aa.eql(bb),
                         .lazy_align, .lazy_size => false,
                     },
                     .lazy_align => |aa| switch (b_info.storage) {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -7049,7 +7049,7 @@ pub fn intBitsForValue(mod: *Module, val: Value, sign: bool) u16 {
             if (big.positive) return @as(u16, @intCast(big.bitCountAbs() + @intFromBool(sign)));
 
             // Zero is still a possibility, in which case unsigned is fine
-            if (big.eqZero()) return 0;
+            if (big.eqlZero()) return 0;
 
             return @as(u16, @intCast(big.bitCountTwosComp()));
         },

--- a/src/RangeSet.zig
+++ b/src/RangeSet.zig
@@ -95,7 +95,7 @@ pub fn spans(self: *RangeSet, first: InternPool.Index, last: InternPool.Index) !
         try counter.addScalar(&counter, 1);
 
         const cur_start_int = cur.first.toValue().toBigInt(&space, mod);
-        if (!cur_start_int.eq(counter.toConst())) {
+        if (!cur_start_int.eql(counter.toConst())) {
             return false;
         }
     }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -36375,7 +36375,7 @@ fn float128IntPartToBigInt(
 
     // The float is reduced in rational.setFloat, so we assert that denominator is equal to one
     const big_one = std.math.big.int.Const{ .limbs = &.{1}, .positive = true };
-    assert(rational.q.toConst().eqAbs(big_one));
+    assert(rational.q.toConst().eqlAbs(big_one));
 
     if (is_negative) {
         rational.negate();

--- a/src/value.zig
+++ b/src/value.zig
@@ -1771,7 +1771,7 @@ pub const Value = struct {
                 .ptr => |ptr| switch (ptr.addr) {
                     .int => {
                         var buf: BigIntSpace = undefined;
-                        return val.toBigInt(&buf, mod).eqZero();
+                        return val.toBigInt(&buf, mod).eqlZero();
                     },
                     else => false,
                 },


### PR DESCRIPTION
All of the std except these few functions call it "eql" instead of "eq". This has previously tripped me up when I expected the equality check function to be called "eql" (just like all the rest of the std) instead of "eq".

The motivation is consistency.

If search "eq" on Autodoc, these functions stick out and it looks inconsistent.

I just noticed there are also a few functions spelling it out as "equal" (such as std.mem.allEqual). Maybe those functions should also spell it "eql" but that can be done in a future PR.