### PR TITLE
Add std.json.ParseOptions for more flexible json parsing

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -88,6 +88,7 @@ pub const parseFromSlice = @import("json/static.zig").parseFromSlice;
 pub const parseFromSliceLeaky = @import("json/static.zig").parseFromSliceLeaky;
 pub const parseFromTokenSource = @import("json/static.zig").parseFromTokenSource;
 pub const parseFromTokenSourceLeaky = @import("json/static.zig").parseFromTokenSourceLeaky;
+pub const innerParse = @import("json/static.zig").innerParse;
 pub const parseFromValue = @import("json/static.zig").parseFromValue;
 pub const parseFromValueLeaky = @import("json/static.zig").parseFromValueLeaky;
 pub const ParseError = @import("json/static.zig").ParseError;

--- a/lib/std/json/static_test.zig
+++ b/lib/std/json/static_test.zig
@@ -801,3 +801,104 @@ test "parse into vector" {
     try testing.expectApproxEqAbs(@as(f32, 2.5), parsed.value.vec_f32[1], 0.0000001);
     try testing.expectEqual(@Vector(4, i32){ 4, 5, 6, 7 }, parsed.value.vec_i32);
 }
+
+fn assertKey(
+    allocator: Allocator,
+    test_string: []const u8,
+    scanner: anytype,
+) !void {
+    const token_outer = try scanner.nextAlloc(allocator, .alloc_always);
+    switch (token_outer) {
+        .allocated_string => |string| {
+            try testing.expectEqualSlices(u8, string, test_string);
+            allocator.free(string);
+        },
+        else => return error.UnexpectedToken,
+    }
+}
+test "json parse partial" {
+    const Inner = struct {
+        num: u32,
+        yes: bool,
+    };
+    var str =
+        \\{
+        \\  "outer": {
+        \\    "key1": {
+        \\      "num": 75,
+        \\      "yes": true
+        \\    },
+        \\    "key2": {
+        \\      "num": 95,
+        \\      "yes": false
+        \\    }
+        \\  }
+        \\}
+    ;
+    var allocator = testing.allocator;
+    var scanner = JsonScanner.initCompleteInput(allocator, str);
+    defer scanner.deinit();
+
+    var arena = ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    // Peel off the outer object
+    try testing.expectEqual(try scanner.next(), .object_begin);
+    try assertKey(allocator, "outer", &scanner);
+    try testing.expectEqual(try scanner.next(), .object_begin);
+    try assertKey(allocator, "key1", &scanner);
+
+    // Parse the inner object to an Inner struct
+    const options_partial = ParseOptions{ .allow_partial = true };
+    const inner_token = try parseFromTokenSourceLeaky(
+        Inner,
+        arena.allocator(),
+        &scanner,
+        options_partial,
+    );
+    try testing.expectEqual(inner_token.num, 75);
+    try testing.expectEqual(inner_token.yes, true);
+
+    // Get they next key
+    try assertKey(allocator, "key2", &scanner);
+    const inner_token_2 = try parseFromTokenSourceLeaky(
+        Inner,
+        arena.allocator(),
+        &scanner,
+        options_partial,
+    );
+    try testing.expectEqual(inner_token_2.num, 95);
+    try testing.expectEqual(inner_token_2.yes, false);
+    try testing.expectEqual(try scanner.next(), .object_end);
+}
+
+test "json parse trust buffer" {
+    const T = struct {
+        not_const: []u8,
+        is_const: []const u8,
+    };
+    var str =
+        \\{
+        \\  "not_const": "non const string",
+        \\  "is_const": "const string"
+        \\}
+    ;
+    var allocator = testing.allocator;
+    var arena = ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var stream = std.io.fixedBufferStream(str);
+    var json_reader = jsonReader(std.testing.allocator, stream.reader());
+
+    const options = ParseOptions{ .trust_buffer = false };
+    const parsed = parseFromTokenSourceLeaky(T, arena.allocator(), &json_reader, options) catch |err| {
+        json_reader.deinit();
+        return err;
+    };
+    // Deinit our reader to invalidate its buffer
+    json_reader.deinit();
+
+    // If either of these was invalidated, it would be full of '0xAA'
+    try testing.expectEqualSlices(u8, parsed.not_const, "non const string");
+    try testing.expectEqualSlices(u8, parsed.is_const, "const string");
+}

--- a/lib/std/json/static_test.zig
+++ b/lib/std/json/static_test.zig
@@ -872,7 +872,7 @@ test "json parse partial" {
     try testing.expectEqual(try scanner.next(), .object_end);
 }
 
-test "json parse trust buffer" {
+test "json parse allocate when streaming" {
     const T = struct {
         not_const: []u8,
         is_const: []const u8,
@@ -890,7 +890,7 @@ test "json parse trust buffer" {
     var stream = std.io.fixedBufferStream(str);
     var json_reader = jsonReader(std.testing.allocator, stream.reader());
 
-    const options = ParseOptions{ .trust_buffer = false };
+    const options = ParseOptions{ .allocate = .alloc_always };
     const parsed = parseFromTokenSourceLeaky(T, arena.allocator(), &json_reader, options) catch |err| {
         json_reader.deinit();
         return err;


### PR DESCRIPTION
This PR addresses 2 issues with std.json:
1. The polymorphic parseByValue functions are inefficient for parsing json which are only partially polymorphic.
2. Parsing json with a streaming reader can cause use-after-free errors.

## 1
Imagine a json with this formatting:
```
{
  "outer": {
    "key1": {
      // Large struct with known keys/values, including arrays and strings
    },
    "key2": {
      // Same struct
    },
    // Many more unknown keys containing the same struct.
  }
}
```
This json is partially polymorphic, because the "key1" keys aren't known at compile time. However, parsing this struct with the parseByValue method (parse the entire json into a Value, then reconstructing the inner structs) is inefficient, because it creates many more StringArrayHashMaps than needed. Ideally, we'd only want one StringArrayHashMap, which maps "key1" to the inner, known struct. This can almost be achieved by creating a struct contining a jsonParse method, which loops through and calls parseFromTokenSource on each inner known struct. Problem is, the standard library currently disallows parsing partial json objects.

https://github.com/ziglang/zig/blob/b26fa4ec4baff7af8023f64230cbc0bdf1c99433/lib/std/json/static.zig#L128

Part 1 of this PR is simply to allow for partial parsing using a new ParseOptions option: `.allow_partial`. This simply gives the user the option to skip this assert by passing this aditional option into the parseFrom* function, while keeping the functions' default behaviors the same to allow for stronger checks on malformed json. See the included test `lib/std/json/static_test.zig:"json parse partial"` for an example of this being used.

This is only one example of this being useful. In general, allowing the user access to the json parsing utilities with less restrictions will allow for many different json to be parsed without needing to reinvent `lib/std/json/static.zig:internalParse()`

## 2

<details>
<summary>old description</summary>
This second issue is more of a potential footgun with the current implementation: If the given scanner_or_reader to any parseFromTokenSource* function is a stream without all of the underlying bytes allocated, use-after-free is likely. See the included test `lib/std/json/static_test.zig:"json parse trust buffer"` for a clear example. As written, the test passes. It simply creates a stream from a json buffer, parses it, then verifies the contents. However, if that same test were run without the newly added `.trust_buffer = false` option being passed in, the test would fail. This is because the testing allocator would invalidate the stream's internal buffer after it's discarded, but the resulting parsed json structure would still be usable. If you were to run the same test with a very large json, you would see that even without the testing allocator, parsed string would likely be corrupted after the reader or scanner was free'd.

This `.trust_buffer = false` option that was added simply forces the internal json parser to make new allocations of any references, rather than relying on references to the scanner's internal buffer, which may not always be sound. This addition allows for a streaming Reader or Scanner to be passed into a parseFromTokenSource* function. While this was possible before, it was likely always unsound.
</details>

This second issue is more of a potential footgun with the current implementation: If the given scanner_or_reader to any parseFromTokenSource* function is a stream without all of the underlying bytes allocated, use-after-free is likely. See the included test `lib/std/json/static_test.zig:"json parse allocate when streaming"` for a clear example. As written, the test passes. It simply creates a stream from a json buffer, parses it, then verifies the contents. However, if that same test were run without the newly added `.allocate = .alloc_always` field (of type AllocWhen) being passed in, the test would fail. This is because the testing allocator would invalidate the stream's internal buffer after it's discarded, but the resulting parsed json structure would still be usable. If you were to run the same test with a very large json, you would see that even without the testing allocator, parsed string would likely be corrupted after the reader or scanner was free'd.

This `.allocate` field allows the user to force the internal json parser to make new allocations of any references, rather than relying on references to the scanner's internal buffer, which may not always be sound. This addition allows for a streaming Reader or Scanner to be passed into a parseFromTokenSource* function. While this was possible before, it was likely always unsound.

Please let me know if this is acceptable, or how I can improve it. Thanks!
