### PR TITLE
write function types consistently with a space before `fn` keyword

### DIFF
--- a/lib/std/atomic/Atomic.zig
+++ b/lib/std/atomic/Atomic.zig
@@ -21,7 +21,7 @@ pub fn Atomic(comptime T: type) type {
         /// ```
         /// const RefCount = struct {
         ///     count: Atomic(usize),
-        ///     dropFn: *const fn(*RefCount) void,
+        ///     dropFn: *const fn (*RefCount) void,
         ///
         ///     fn ref(self: *RefCount) void {
         ///         _ =  self.count.fetchAdd(1, .Monotonic); // no ordering necessary, just updating a counter

--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -1269,10 +1269,10 @@ pub fn ensureIndexer(comptime T: type) void {
         if (@TypeOf(T.Key) != type) @compileError("Indexer.Key must be a type.");
         if (!@hasDecl(T, "count")) @compileError("Indexer must have decl count: usize.");
         if (@TypeOf(T.count) != usize) @compileError("Indexer.count must be a usize.");
-        if (!@hasDecl(T, "indexOf")) @compileError("Indexer.indexOf must be a fn(Key)usize.");
-        if (@TypeOf(T.indexOf) != fn (T.Key) usize) @compileError("Indexer must have decl indexOf: fn(Key)usize.");
-        if (!@hasDecl(T, "keyForIndex")) @compileError("Indexer must have decl keyForIndex: fn(usize)Key.");
-        if (@TypeOf(T.keyForIndex) != fn (usize) T.Key) @compileError("Indexer.keyForIndex must be a fn(usize)Key.");
+        if (!@hasDecl(T, "indexOf")) @compileError("Indexer.indexOf must be a fn (Key) usize.");
+        if (@TypeOf(T.indexOf) != fn (T.Key) usize) @compileError("Indexer must have decl indexOf: fn (Key) usize.");
+        if (!@hasDecl(T, "keyForIndex")) @compileError("Indexer must have decl keyForIndex: fn (usize) Key.");
+        if (@TypeOf(T.keyForIndex) != fn (usize) T.Key) @compileError("Indexer.keyForIndex must be a fn (usize) Key.");
     }
 }
 

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2255,11 +2255,11 @@ test "pointer" {
     const FnPtr = *align(1) const fn () void;
     {
         const value = @as(FnPtr, @ptrFromInt(0xdeadbeef));
-        try expectFmt("pointer: fn() void@deadbeef\n", "pointer: {}\n", .{value});
+        try expectFmt("pointer: fn () void@deadbeef\n", "pointer: {}\n", .{value});
     }
     {
         const value = @as(FnPtr, @ptrFromInt(0xdeadbeef));
-        try expectFmt("pointer: fn() void@deadbeef\n", "pointer: {}\n", .{value});
+        try expectFmt("pointer: fn () void@deadbeef\n", "pointer: {}\n", .{value});
     }
 }
 

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -969,9 +969,9 @@ test "std.meta.Float" {
 /// correspond to the argument types.
 ///
 /// Examples:
-/// - `ArgsTuple(fn() void)` ⇒ `tuple { }`
-/// - `ArgsTuple(fn(a: u32) u32)` ⇒ `tuple { u32 }`
-/// - `ArgsTuple(fn(a: u32, b: f16) noreturn)` ⇒ `tuple { u32, f16 }`
+/// - `ArgsTuple(fn () void)` ⇒ `tuple { }`
+/// - `ArgsTuple(fn (a: u32) u32)` ⇒ `tuple { u32 }`
+/// - `ArgsTuple(fn (a: u32, b: f16) noreturn)` ⇒ `tuple { u32, f16 }`
 pub fn ArgsTuple(comptime Function: type) type {
     const info = @typeInfo(Function);
     if (info != .Fn)

--- a/lib/std/treap.zig
+++ b/lib/std/treap.zig
@@ -7,7 +7,7 @@ pub fn Treap(comptime Key: type, comptime compareFn: anytype) type {
     return struct {
         const Self = @This();
 
-        // Allow for compareFn to be fn(anytype, anytype) anytype
+        // Allow for compareFn to be fn (anytype, anytype) anytype
         // which allows the convenient use of std.math.order.
         fn compare(a: Key, b: Key) Order {
             return compareFn(a, b);

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -3255,23 +3255,23 @@ pub const Node = struct {
         @"break",
         /// `return lhs`. lhs can be omitted. rhs is unused.
         @"return",
-        /// `fn(a: lhs) rhs`. lhs can be omitted.
+        /// `fn (a: lhs) rhs`. lhs can be omitted.
         /// anytype and ... parameters are omitted from the AST tree.
         /// main_token is the `fn` keyword.
         /// extern function declarations use this tag.
         fn_proto_simple,
-        /// `fn(a: b, c: d) rhs`. `sub_range_list[lhs]`.
+        /// `fn (a: b, c: d) rhs`. `sub_range_list[lhs]`.
         /// anytype and ... parameters are omitted from the AST tree.
         /// main_token is the `fn` keyword.
         /// extern function declarations use this tag.
         fn_proto_multi,
-        /// `fn(a: b) rhs addrspace(e) linksection(f) callconv(g)`. `FnProtoOne[lhs]`.
+        /// `fn (a: b) rhs addrspace(e) linksection(f) callconv(g)`. `FnProtoOne[lhs]`.
         /// zero or one parameters.
         /// anytype and ... parameters are omitted from the AST tree.
         /// main_token is the `fn` keyword.
         /// extern function declarations use this tag.
         fn_proto_one,
-        /// `fn(a: b, c: d) rhs addrspace(e) linksection(f) callconv(g)`. `FnProto[lhs]`.
+        /// `fn (a: b, c: d) rhs addrspace(e) linksection(f) callconv(g)`. `FnProto[lhs]`.
         /// anytype and ... parameters are omitted from the AST tree.
         /// main_token is the `fn` keyword.
         /// extern function declarations use this tag.

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5251,8 +5251,8 @@ test "zig fmt: make single-line if no trailing comma, fmt: off" {
         \\    }
         \\}
         \\
-        \\const fn_no_comma = fn(i32, i32)void;
-        \\const fn_trailing_comma = fn(i32, i32,)void;
+        \\const fn_no_comma = fn (i32, i32) void;
+        \\const fn_trailing_comma = fn (i32, i32,) void;
         \\
         \\fn fn_calls() void {
         \\    fn add(x: i32, y: i32,) i32 { x + y };

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6722,7 +6722,7 @@ fn zirCall(
     {
         const return_ty = sema.typeOf(call_inst);
         if (modifier != .always_tail and return_ty.isNoReturn(mod))
-            return call_inst; // call to "fn(...) noreturn", don't pop
+            return call_inst; // call to "fn (...) noreturn", don't pop
 
         // TODO: we don't fix up the error trace for always_tail correctly, we should be doing it
         // *before* the recursive call. This will be a bit tricky to do and probably requires

--- a/src/type.zig
+++ b/src/type.zig
@@ -364,7 +364,7 @@ pub const Type = struct {
                 if (fn_info.is_noinline) {
                     try writer.writeAll("noinline ");
                 }
-                try writer.writeAll("fn(");
+                try writer.writeAll("fn (");
                 const param_types = fn_info.param_types.get(&mod.intern_pool);
                 for (param_types, 0..) |param_ty, i| {
                     if (i != 0) try writer.writeAll(", ");

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1193,7 +1193,7 @@ test "implicit ptr to *anyopaque" {
     try expect(c.* == 1);
 }
 
-test "return null from fn() anyerror!?&T" {
+test "return null from fn () anyerror!?&T" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;

--- a/test/behavior/typename.zig
+++ b/test/behavior/typename.zig
@@ -73,18 +73,18 @@ test "basic" {
     try expectEqualStrings("*usize", @typeName(*usize));
     try expectEqualStrings("[]u8", @typeName([]u8));
 
-    try expectEqualStrings("fn() void", @typeName(fn () void));
-    try expectEqualStrings("fn(u32) void", @typeName(fn (u32) void));
-    try expectEqualStrings("fn(u32) void", @typeName(fn (a: u32) void));
+    try expectEqualStrings("fn () void", @typeName(fn () void));
+    try expectEqualStrings("fn (u32) void", @typeName(fn (u32) void));
+    try expectEqualStrings("fn (u32) void", @typeName(fn (a: u32) void));
 
-    try expectEqualStrings("fn(comptime u32) void", @typeName(fn (comptime u32) void));
-    try expectEqualStrings("fn(noalias []u8) void", @typeName(fn (noalias []u8) void));
+    try expectEqualStrings("fn (comptime u32) void", @typeName(fn (comptime u32) void));
+    try expectEqualStrings("fn (noalias []u8) void", @typeName(fn (noalias []u8) void));
 
-    try expectEqualStrings("fn() align(32) void", @typeName(fn () align(32) void));
-    try expectEqualStrings("fn() callconv(.C) void", @typeName(fn () callconv(.C) void));
-    try expectEqualStrings("fn() align(32) callconv(.C) void", @typeName(fn () align(32) callconv(.C) void));
-    try expectEqualStrings("fn(...) align(32) callconv(.C) void", @typeName(fn (...) align(32) callconv(.C) void));
-    try expectEqualStrings("fn(u32, ...) align(32) callconv(.C) void", @typeName(fn (u32, ...) align(32) callconv(.C) void));
+    try expectEqualStrings("fn () align(32) void", @typeName(fn () align(32) void));
+    try expectEqualStrings("fn () callconv(.C) void", @typeName(fn () callconv(.C) void));
+    try expectEqualStrings("fn () align(32) callconv(.C) void", @typeName(fn () align(32) callconv(.C) void));
+    try expectEqualStrings("fn (...) align(32) callconv(.C) void", @typeName(fn (...) align(32) callconv(.C) void));
+    try expectEqualStrings("fn (u32, ...) align(32) callconv(.C) void", @typeName(fn (u32, ...) align(32) callconv(.C) void));
 }
 
 test "top level decl" {
@@ -108,17 +108,17 @@ test "top level decl" {
 
     // regular fn, without error
     try expectEqualStrings(
-        "fn() void",
+        "fn () void",
         @typeName(@TypeOf(regular)),
     );
     // regular fn inside struct, with error
     try expectEqualStrings(
-        "fn() @typeInfo(@typeInfo(@TypeOf(behavior.typename.B.doTest)).Fn.return_type.?).ErrorUnion.error_set!void",
+        "fn () @typeInfo(@typeInfo(@TypeOf(behavior.typename.B.doTest)).Fn.return_type.?).ErrorUnion.error_set!void",
         @typeName(@TypeOf(B.doTest)),
     );
     // generic fn
     try expectEqualStrings(
-        "fn(comptime type) type",
+        "fn (comptime type) type",
         @typeName(@TypeOf(TypeFromFn)),
     );
 }
@@ -234,7 +234,7 @@ test "comptime parameters not converted to anytype in function type" {
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const T = fn (fn (type) void, void) void;
-    try expectEqualStrings("fn(comptime fn(comptime type) void, void) void", @typeName(T));
+    try expectEqualStrings("fn (comptime fn (comptime type) void, void) void", @typeName(T));
 }
 
 test "anon name strategy used in sub expression" {

--- a/test/cases/compile_errors/AstGen_comptime_known_struct_is_resolved_before_error.zig
+++ b/test/cases/compile_errors/AstGen_comptime_known_struct_is_resolved_before_error.zig
@@ -16,4 +16,4 @@ pub export fn entry() void {
 // :8:12: error: variable of type 'tmp.S1' must be const or comptime
 // :2:8: note: struct requires comptime because of this field
 // :5:8: note: struct requires comptime because of this field
-// :5:8: note: use '*const fn() void' for a function pointer type
+// :5:8: note: use '*const fn () void' for a function pointer type

--- a/test/cases/compile_errors/assign_inline_fn_to_non-comptime_var.zig
+++ b/test/cases/compile_errors/assign_inline_fn_to_non-comptime_var.zig
@@ -8,5 +8,5 @@ inline fn b() void {}
 // backend=stage2
 // target=native
 //
-// :2:9: error: variable of type '*const fn() callconv(.Inline) void' must be const or comptime
+// :2:9: error: variable of type '*const fn () callconv(.Inline) void' must be const or comptime
 // :2:9: note: function has inline calling convention

--- a/test/cases/compile_errors/async/non_async_function_pointer_passed_to_asyncCall.zig
+++ b/test/cases/compile_errors/async/non_async_function_pointer_passed_to_asyncCall.zig
@@ -9,4 +9,4 @@ fn afunc() void {}
 // backend=stage1
 // target=native
 //
-// tmp.zig:4:32: error: expected async function, found 'fn() void'
+// tmp.zig:4:32: error: expected async function, found 'fn () void'

--- a/test/cases/compile_errors/call_optional_function.zig
+++ b/test/cases/compile_errors/call_optional_function.zig
@@ -11,7 +11,7 @@ pub export fn entry2() void {
 // backend=stage2
 // target=native
 //
-// :3:9: error: cannot call optional type '?fn() void'
+// :3:9: error: cannot call optional type '?fn () void'
 // :3:9: note: consider using '.?', 'orelse' or 'if'
-// :7:9: error: cannot call optional type '?*const fn() void'
+// :7:9: error: cannot call optional type '?*const fn () void'
 // :7:9: note: consider using '.?', 'orelse' or 'if'

--- a/test/cases/compile_errors/cast_between_optional_T_where_T_is_not_a_pointer.zig
+++ b/test/cases/compile_errors/cast_between_optional_T_where_T_is_not_a_pointer.zig
@@ -17,10 +17,10 @@ export fn entry2() void {
 // backend=stage2
 // target=native
 //
-// :6:9: error: expected type '?*const fn(i8) void', found '?*const fn(u64) void'
-// :6:9: note: pointer type child 'fn(u64) void' cannot cast into pointer type child 'fn(i8) void'
+// :6:9: error: expected type '?*const fn (i8) void', found '?*const fn (u64) void'
+// :6:9: note: pointer type child 'fn (u64) void' cannot cast into pointer type child 'fn (i8) void'
 // :6:9: note: parameter 0 'u64' cannot cast into 'i8'
 // :6:9: note: unsigned 64-bit int cannot represent all possible signed 8-bit values
-// :13:9: error: expected type '?*const fn(u63) void', found '?*const fn(u64) void'
-// :13:9: note: pointer type child 'fn(u64) void' cannot cast into pointer type child 'fn(u63) void'
+// :13:9: error: expected type '?*const fn (u63) void', found '?*const fn (u64) void'
+// :13:9: note: pointer type child 'fn (u64) void' cannot cast into pointer type child 'fn (u63) void'
 // :13:9: note: parameter 0 'u64' cannot cast into 'u63'

--- a/test/cases/compile_errors/comptime_param_coersion.zig
+++ b/test/cases/compile_errors/comptime_param_coersion.zig
@@ -14,7 +14,7 @@ fn bar(comptime _: i32, _: i32) void {}
 // backend=stage2
 // target=native
 //
-// :3:9: error: expected type 'fn(comptime i32, comptime i32) void', found 'fn(comptime i32, i32) void'
+// :3:9: error: expected type 'fn (comptime i32, comptime i32) void', found 'fn (comptime i32, i32) void'
 // :3:9: note: non-comptime parameter 1 cannot cast into a comptime parameter
-// :7:9: error: expected type 'fn(i32, i32) void', found 'fn(comptime i32, comptime i32) void'
+// :7:9: error: expected type 'fn (i32, i32) void', found 'fn (comptime i32, comptime i32) void'
 // :7:9: note: generic function cannot cast into a non-generic function

--- a/test/cases/compile_errors/comptime_parameter_not_declared_as_such.zig
+++ b/test/cases/compile_errors/comptime_parameter_not_declared_as_such.zig
@@ -20,6 +20,6 @@ pub export fn entry1() void {
 // backend=stage2
 // target=native
 //
-// :3:6: error: parameter of type '*const fn(anytype) void' must be declared comptime
+// :3:6: error: parameter of type '*const fn (anytype) void' must be declared comptime
 // :3:6: note: function is generic
 // :10:34: error: parameter of type 'comptime_int' must be declared comptime

--- a/test/cases/compile_errors/condition_comptime_reason_explained.zig
+++ b/test/cases/compile_errors/condition_comptime_reason_explained.zig
@@ -40,11 +40,11 @@ pub export fn entry2() void {
 // :8:9: note: condition in comptime branch must be comptime-known
 // :7:13: note: expression is evaluated at comptime because the function returns a comptime-only type 'tmp.S'
 // :2:12: note: struct requires comptime because of this field
-// :2:12: note: use '*const fn() void' for a function pointer type
+// :2:12: note: use '*const fn () void' for a function pointer type
 // :19:15: note: called from here
 // :22:13: error: unable to resolve comptime value
 // :22:13: note: condition in comptime switch must be comptime-known
 // :21:17: note: expression is evaluated at comptime because the function returns a comptime-only type 'tmp.S'
 // :2:12: note: struct requires comptime because of this field
-// :2:12: note: use '*const fn() void' for a function pointer type
+// :2:12: note: use '*const fn () void' for a function pointer type
 // :32:19: note: called from here

--- a/test/cases/compile_errors/dereference_anyopaque.zig
+++ b/test/cases/compile_errors/dereference_anyopaque.zig
@@ -46,9 +46,9 @@ pub export fn entry() void {
 //
 // :11:22: error: comparison of 'void' with null
 // :25:51: error: cannot load opaque type 'anyopaque'
-// :25:51: error: values of type 'fn(*anyopaque, usize, u8, usize) ?[*]u8' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn(*anyopaque, usize, u8, usize) ?[*]u8' for a function pointer type
-// :25:51: error: values of type 'fn(*anyopaque, []u8, u8, usize, usize) bool' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn(*anyopaque, []u8, u8, usize, usize) bool' for a function pointer type
-// :25:51: error: values of type 'fn(*anyopaque, []u8, u8, usize) void' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn(*anyopaque, []u8, u8, usize) void' for a function pointer type
+// :25:51: error: values of type 'fn (*anyopaque, usize, u8, usize) ?[*]u8' must be comptime-known, but operand value is runtime-known
+// :25:51: note: use '*const fn (*anyopaque, usize, u8, usize) ?[*]u8' for a function pointer type
+// :25:51: error: values of type 'fn (*anyopaque, []u8, u8, usize, usize) bool' must be comptime-known, but operand value is runtime-known
+// :25:51: note: use '*const fn (*anyopaque, []u8, u8, usize, usize) bool' for a function pointer type
+// :25:51: error: values of type 'fn (*anyopaque, []u8, u8, usize) void' must be comptime-known, but operand value is runtime-known
+// :25:51: note: use '*const fn (*anyopaque, []u8, u8, usize) void' for a function pointer type

--- a/test/cases/compile_errors/error_note_for_function_parameter_incompatibility.zig
+++ b/test/cases/compile_errors/error_note_for_function_parameter_incompatibility.zig
@@ -12,6 +12,6 @@ export fn entry() void {
 // backend=stage2
 // target=native
 //
-// :8:18: error: expected type '*const fn(i32) void', found '*const fn(bool) void'
-// :8:18: note: pointer type child 'fn(bool) void' cannot cast into pointer type child 'fn(i32) void'
+// :8:18: error: expected type '*const fn (i32) void', found '*const fn (bool) void'
+// :8:18: note: pointer type child 'fn (bool) void' cannot cast into pointer type child 'fn (i32) void'
 // :8:18: note: parameter 0 'bool' cannot cast into 'i32'

--- a/test/cases/compile_errors/explain_why_fn_is_called_at_comptime.zig
+++ b/test/cases/compile_errors/explain_why_fn_is_called_at_comptime.zig
@@ -20,4 +20,4 @@ pub export fn entry() void {
 // :12:13: note: argument to function being called at comptime must be comptime-known
 // :7:25: note: expression is evaluated at comptime because the function returns a comptime-only type 'tmp.S'
 // :2:12: note: struct requires comptime because of this field
-// :2:12: note: use '*const fn() void' for a function pointer type
+// :2:12: note: use '*const fn () void' for a function pointer type

--- a/test/cases/compile_errors/extern_function_pointer_mismatch.zig
+++ b/test/cases/compile_errors/extern_function_pointer_mismatch.zig
@@ -17,5 +17,5 @@ export fn entry() usize {
 // backend=stage2
 // target=native
 //
-// :1:38: error: expected type 'fn(i32) i32', found 'fn(i32) callconv(.C) i32'
+// :1:38: error: expected type 'fn (i32) i32', found 'fn (i32) callconv(.C) i32'
 // :1:38: note: calling convention 'C' cannot cast into calling convention 'Unspecified'

--- a/test/cases/compile_errors/file_level_struct_invalid_field_type.zig
+++ b/test/cases/compile_errors/file_level_struct_invalid_field_type.zig
@@ -14,4 +14,4 @@ comptime {
 // backend=stage2
 // target=native
 //
-// :7:15: error: expected type 'type', found 'fn() type'
+// :7:15: error: expected type 'type', found 'fn () type'

--- a/test/cases/compile_errors/function_type_coercion.zig
+++ b/test/cases/compile_errors/function_type_coercion.zig
@@ -13,9 +13,9 @@ export fn wrong_return_type() void {
 // backend=stage2,llvm
 // target=native
 //
-// :3:25: error: expected type 'fn() void', found 'fn(i32) void'
+// :3:25: error: expected type 'fn () void', found 'fn (i32) void'
 // :3:25: note: function with 1 parameters cannot cast into a function with 0 parameters
-// :6:28: error: expected type 'fn(f32) void', found 'fn(i32) void'
+// :6:28: error: expected type 'fn (f32) void', found 'fn (i32) void'
 // :6:28: note: parameter 0 'i32' cannot cast into 'f32'
-// :9:24: error: expected type 'fn() i32', found 'fn(i32) void'
+// :9:24: error: expected type 'fn () i32', found 'fn (i32) void'
 // :9:24: note: return type 'void' cannot cast into return type 'i32'

--- a/test/cases/compile_errors/invalid_array_elem_ty.zig
+++ b/test/cases/compile_errors/invalid_array_elem_ty.zig
@@ -9,4 +9,4 @@ pub export fn entry() void {
 // target=native
 // backend=stage2
 //
-// :5:12: error: expected type 'type', found 'fn() type'
+// :5:12: error: expected type 'type', found 'fn () type'

--- a/test/cases/compile_errors/invalid_comparison_for_function_pointers.zig
+++ b/test/cases/compile_errors/invalid_comparison_for_function_pointers.zig
@@ -9,4 +9,4 @@ export fn entry() usize {
 // backend=stage2
 // target=native
 //
-// :2:21: error: operator > not allowed for type 'fn() void'
+// :2:21: error: operator > not allowed for type 'fn () void'

--- a/test/cases/compile_errors/invalid_tail_call.zig
+++ b/test/cases/compile_errors/invalid_tail_call.zig
@@ -9,4 +9,4 @@ pub export fn entry() void {
 // backend=llvm
 // target=native
 //
-// :5:5: error: unable to perform tail call: type of function being called 'fn(usize) void' does not match type of calling function 'fn() callconv(.C) void'
+// :5:5: error: unable to perform tail call: type of function being called 'fn (usize) void' does not match type of calling function 'fn () callconv(.C) void'

--- a/test/cases/compile_errors/nested_generic_function_param_type_mismatch.zig
+++ b/test/cases/compile_errors/nested_generic_function_param_type_mismatch.zig
@@ -19,6 +19,6 @@ pub export fn entry() void {
 // backend=llvm
 // target=native
 //
-// :15:28: error: expected type '*const fn(comptime type, u8, u8) u32', found '*const fn(void, u8, u8) u32'
-// :15:28: note: pointer type child 'fn(void, u8, u8) u32' cannot cast into pointer type child 'fn(comptime type, u8, u8) u32'
+// :15:28: error: expected type '*const fn (comptime type, u8, u8) u32', found '*const fn (void, u8, u8) u32'
+// :15:28: note: pointer type child 'fn (void, u8, u8) u32' cannot cast into pointer type child 'fn (comptime type, u8, u8) u32'
 // :15:28: note: non-generic function cannot cast into a generic function

--- a/test/cases/compile_errors/noalias_param_coersion.zig
+++ b/test/cases/compile_errors/noalias_param_coersion.zig
@@ -14,7 +14,7 @@ fn bar(noalias _: *i32, _: *i32) void {}
 // backend=stage2
 // target=native
 //
-// :3:9: error: expected type 'fn(noalias *i32, noalias *i32) void', found 'fn(noalias *i32, *i32) void'
+// :3:9: error: expected type 'fn (noalias *i32, noalias *i32) void', found 'fn (noalias *i32, *i32) void'
 // :3:9: note: regular parameter 1 cannot cast into a noalias parameter
-// :7:9: error: expected type 'fn(*i32, *i32) void', found 'fn(noalias *i32, noalias *i32) void'
+// :7:9: error: expected type 'fn (*i32, *i32) void', found 'fn (noalias *i32, noalias *i32) void'
 // :7:9: note: noalias parameter 0 cannot cast into a regular parameter

--- a/test/cases/compile_errors/non_comptime_param_in_comptime_function.zig
+++ b/test/cases/compile_errors/non_comptime_param_in_comptime_function.zig
@@ -31,6 +31,6 @@ export fn entry2() void {
 // :1:6: note: param 'val' is required to be comptime
 // :11:16: error: function with comptime-only return type 'tmp.S' requires all parameters to be comptime
 // :9:10: note: struct requires comptime because of this field
-// :9:10: note: use '*const fn() void' for a function pointer type
+// :9:10: note: use '*const fn () void' for a function pointer type
 // :11:8: note: param is required to be comptime
 // :18:29: error: return type 'comptime_int' not allowed in function with calling convention 'C'

--- a/test/cases/compile_errors/old_fn_ptr_in_extern_context.zig
+++ b/test/cases/compile_errors/old_fn_ptr_in_extern_context.zig
@@ -12,9 +12,9 @@ comptime {
 // backend=stage2
 // target=native
 //
-// :2:8: error: extern structs cannot contain fields of type 'fn() callconv(.C) void'
+// :2:8: error: extern structs cannot contain fields of type 'fn () callconv(.C) void'
 // :2:8: note: type has no guaranteed in-memory representation
 // :2:8: note: use '*const ' to make a function pointer type
-// :8:13: error: C pointers cannot point to non-C-ABI-compatible type '[4]fn() callconv(.C) void'
+// :8:13: error: C pointers cannot point to non-C-ABI-compatible type '[4]fn () callconv(.C) void'
 // :8:13: note: type has no guaranteed in-memory representation
 // :8:13: note: use '*const ' to make a function pointer type

--- a/test/cases/compile_errors/packed_struct_with_fields_of_not_allowed_types.zig
+++ b/test/cases/compile_errors/packed_struct_with_fields_of_not_allowed_types.zig
@@ -84,7 +84,7 @@ export fn entry12() void {
 // :59:18: note: union declared here
 // :28:12: error: packed structs cannot contain fields of type '?anyerror'
 // :28:12: note: type has no guaranteed in-memory representation
-// :38:12: error: packed structs cannot contain fields of type 'fn() void'
+// :38:12: error: packed structs cannot contain fields of type 'fn () void'
 // :38:12: note: type has no guaranteed in-memory representation
 // :38:12: note: use '*const ' to make a function pointer type
 // :65:31: error: packed structs cannot contain fields of type '[]u8'

--- a/test/cases/compile_errors/passing_an_under-aligned_function_pointer.zig
+++ b/test/cases/compile_errors/passing_an_under-aligned_function_pointer.zig
@@ -12,5 +12,5 @@ fn alignedSmall() align(4) i32 {
 // backend=stage2
 // target=x86_64-linux
 //
-// :2:35: error: expected type '*const fn() align(8) i32', found '*const fn() align(4) i32'
+// :2:35: error: expected type '*const fn () align(8) i32', found '*const fn () align(4) i32'
 // :2:35: note: pointer alignment '4' cannot cast into pointer alignment '8'

--- a/test/cases/compile_errors/runtime_indexing_comptime_array.zig
+++ b/test/cases/compile_errors/runtime_indexing_comptime_array.zig
@@ -24,9 +24,9 @@ pub export fn entry3() void {
 // target=native
 // backend=stage2
 //
-// :7:10: error: values of type '[2]fn() void' must be comptime-known, but index value is runtime-known
-// :7:10: note: use '*const fn() void' for a function pointer type
-// :15:18: error: values of type '[2]fn() void' must be comptime-known, but index value is runtime-known
-// :15:17: note: use '*const fn() void' for a function pointer type
-// :21:19: error: values of type '[2]fn() void' must be comptime-known, but index value is runtime-known
-// :21:18: note: use '*const fn() void' for a function pointer type
+// :7:10: error: values of type '[2]fn () void' must be comptime-known, but index value is runtime-known
+// :7:10: note: use '*const fn () void' for a function pointer type
+// :15:18: error: values of type '[2]fn () void' must be comptime-known, but index value is runtime-known
+// :15:17: note: use '*const fn () void' for a function pointer type
+// :21:19: error: values of type '[2]fn () void' must be comptime-known, but index value is runtime-known
+// :21:18: note: use '*const fn () void' for a function pointer type

--- a/test/cases/compile_errors/self_referential_struct_requires_comptime.zig
+++ b/test/cases/compile_errors/self_referential_struct_requires_comptime.zig
@@ -13,5 +13,5 @@ pub export fn entry() void {
 //
 // :6:12: error: variable of type 'tmp.S' must be const or comptime
 // :2:8: note: struct requires comptime because of this field
-// :2:8: note: use '*const fn() void' for a function pointer type
+// :2:8: note: use '*const fn () void' for a function pointer type
 // :3:8: note: struct requires comptime because of this field

--- a/test/cases/compile_errors/self_referential_union_requires_comptime.zig
+++ b/test/cases/compile_errors/self_referential_union_requires_comptime.zig
@@ -13,5 +13,5 @@ pub export fn entry() void {
 //
 // :6:12: error: variable of type 'tmp.U' must be const or comptime
 // :2:8: note: union requires comptime because of this field
-// :2:8: note: use '*const fn() void' for a function pointer type
+// :2:8: note: use '*const fn () void' for a function pointer type
 // :3:8: note: union requires comptime because of this field

--- a/test/cases/compile_errors/stage1/obj/generic_fn_as_parameter_without_comptime_keyword.zig
+++ b/test/cases/compile_errors/stage1/obj/generic_fn_as_parameter_without_comptime_keyword.zig
@@ -8,4 +8,4 @@ export fn entry() void {
 // backend=stage1
 // target=native
 //
-// tmp.zig:1:9: error: parameter of type 'fn(anytype) anytype' must be declared comptime
+// tmp.zig:1:9: error: parameter of type 'fn (anytype) anytype' must be declared comptime

--- a/test/cases/compile_errors/type_checking_function_pointers.zig
+++ b/test/cases/compile_errors/type_checking_function_pointers.zig
@@ -12,6 +12,6 @@ export fn entry() void {
 // backend=stage2
 // target=native
 //
-// :8:7: error: expected type '*const fn(*const u8) void', found '*const fn(u8) void'
-// :8:7: note: pointer type child 'fn(u8) void' cannot cast into pointer type child 'fn(*const u8) void'
+// :8:7: error: expected type '*const fn (*const u8) void', found '*const fn (u8) void'
+// :8:7: note: pointer type child 'fn (u8) void' cannot cast into pointer type child 'fn (*const u8) void'
 // :8:7: note: parameter 0 'u8' cannot cast into '*const u8'

--- a/test/cases/compile_errors/type_mismatch_in_C_prototype_with_varargs.zig
+++ b/test/cases/compile_errors/type_mismatch_in_C_prototype_with_varargs.zig
@@ -10,6 +10,6 @@ export fn main() void {
 // backend=stage2
 // target=native
 //
-// :5:22: error: expected type '?fn([*c]u8, ...) callconv(.C) void', found 'fn([*:0]u8, ...) callconv(.C) void'
+// :5:22: error: expected type '?fn ([*c]u8, ...) callconv(.C) void', found 'fn ([*:0]u8, ...) callconv(.C) void'
 // :5:22: note: parameter 0 '[*:0]u8' cannot cast into '[*c]u8'
 // :5:22: note: '[*c]u8' could have null values which are illegal in type '[*:0]u8'

--- a/test/cases/compile_errors/wrong_function_type.zig
+++ b/test/cases/compile_errors/wrong_function_type.zig
@@ -16,5 +16,5 @@ export fn entry() usize {
 // backend=stage2
 // target=native
 //
-// :1:28: error: expected type 'fn() void', found 'fn() i32'
+// :1:28: error: expected type 'fn () void', found 'fn () i32'
 // :1:28: note: return type 'i32' cannot cast into return type 'void'

--- a/test/cases/compile_log.0.zig
+++ b/test/cases/compile_log.0.zig
@@ -17,6 +17,6 @@ fn x() void {}
 // :6:23: error: expected type 'usize', found 'bool'
 //
 // Compile Log Output:
-// @as(bool, true), @as(comptime_int, 20), @as(u32, [runtime value]), @as(fn() void, (function 'x'))
+// @as(bool, true), @as(comptime_int, 20), @as(u32, [runtime value]), @as(fn () void, (function 'x'))
 // @as(comptime_int, 1000)
 // @as(comptime_int, 1234)

--- a/test/cases/compile_log.1.zig
+++ b/test/cases/compile_log.1.zig
@@ -16,5 +16,5 @@ fn x() void {}
 // :4:5: note: also here
 //
 // Compile Log Output:
-// @as(bool, true), @as(comptime_int, 20), @as(u32, [runtime value]), @as(fn() void, (function 'x'))
+// @as(bool, true), @as(comptime_int, 20), @as(u32, [runtime value]), @as(fn () void, (function 'x'))
 // @as(comptime_int, 1000)


### PR DESCRIPTION
Currently, the compiler (like @typeName) writes it `fn(...) Type` but zig fmt writes it `fn (...) Type` (notice the space after `fn`). This inconsistency is now resolved and function types are consistently written the zig fmt way. Before this there were more `fn (...) Type` occurrences than `fn(...) Type` already.

This should unblock PR #15571 which was closed as abandoned
because I was waiting for a decision from a core team member on this question. Now I just made
the decision myself and implemented it.