### PR TITLE
Autodoc: implement boolean operations

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1078,6 +1078,9 @@ Happy writing!
       case "void": {
         return "void";
       }
+      case "unreachable": {
+        return "unreachable";
+      }
       case "slice": {
         let payloadHtml = "";
         const lhsExpr = zigAnalysis.exprs[expr.slice.lhs];
@@ -1386,6 +1389,9 @@ Happy writing!
           case "bit_not": {
             return "~" + param;
           }
+          case "bool_not": {
+            return "!" + param;
+          }
           case "clz": {
             return "@clz(T" + ", " + param + ")";
           }
@@ -1655,6 +1661,14 @@ Happy writing!
           }
           case "cmp_lte": {
             operator += "<=";
+            break;
+          }
+          case "bool_br_and": {
+            operator += "and";
+            break;
+          }
+          case "bool_br_or": {
+            operator += "or";
             break;
           }
           default:

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -255,7 +255,7 @@ pub const Inst = struct {
         /// Uses the pl_node field with payload `Bin`.
         bitcast,
         /// Bitwise NOT. `~`
-        /// Uses `un_tok`.
+        /// Uses `un_node`.
         bit_not,
         /// Bitwise OR. `|`
         bit_or,
@@ -274,7 +274,7 @@ pub const Inst = struct {
         /// Uses the `pl_node` union field. Payload is `Block`.
         suspend_block,
         /// Boolean NOT. See also `bit_not`.
-        /// Uses the `un_tok` field.
+        /// Uses the `un_node` field.
         bool_not,
         /// Short-circuiting boolean `and`. `lhs` is a boolean `Ref` and the other operand
         /// is a block, which is evaluated if `lhs` is `true`.


### PR DESCRIPTION
Examples within the standard library where this change can be observed:

- `std.Thread.use_pthreads`
- `std.crypto.core.aes.has_hardware_support`
- `std.fs.need_async_thread`

In some of these, there seems to be a separate issue where `<match result>` is displayed for some fields, such as `target.os.tag`, which is part of a TODO in `tryResolveRefPath`.

Additionally, while I can't come up with any examples to the contrary, I'm slightly unsure about my assumption that the `Block` for the RHS of an `and` or `or` will always end in an `break_inline` or contain a single noreturn expression (such as `unreachable`) and hence walking the final instruction will reproduce the entire block. The approach taken for some other instructions that use a `Block` is to fall back on just rendering the source using `src_node` if the final instruction isn't `break_inline`, but `bool_br` doesn't have a `src_node`, so I can't do that here.

Another possible approach would be to try to more intelligently walk the `Block`, which could provide benefits to other parts of Autodoc which are currently just spitting out source text using `src_node`, and will probably have to be done eventually. If it would be preferable for me to take that approach here, I can close this PR and reopen it once I have something for that (will apply to other parts of Autodoc using `Block` as well).