### PR TITLE
explicitly specify error set of `std.json.stringify`

### DIFF
--- a/lib/std/json/stringify.zig
+++ b/lib/std/json/stringify.zig
@@ -140,7 +140,7 @@ pub fn stringify(
     value: anytype,
     options: StringifyOptions,
     out_stream: anytype,
-) !void {
+) @TypeOf(out_stream).Error!void {
     const T = @TypeOf(value);
     switch (@typeInfo(T)) {
         .Float, .ComptimeFloat => {

--- a/lib/std/json/stringify_test.zig
+++ b/lib/std/json/stringify_test.zig
@@ -260,23 +260,6 @@ fn teststringify(expected: []const u8, value: anytype, options: StringifyOptions
     if (vos.expected_remaining.len > 0) return error.NotEnoughData;
 }
 
-test "stringify struct with custom stringify that returns a custom error" {
-    var ret = stringify(struct {
-        field: Field = .{},
-
-        pub const Field = struct {
-            field: ?[]*Field = null,
-
-            const Self = @This();
-            pub fn jsonStringify(_: Self, _: StringifyOptions, _: anytype) error{CustomError}!void {
-                return error.CustomError;
-            }
-        };
-    }{}, StringifyOptions{}, std.io.null_writer);
-
-    try std.testing.expectError(error.CustomError, ret);
-}
-
 test "stringify alloc" {
     const allocator = std.testing.allocator;
     const expected =


### PR DESCRIPTION
fixes #15859
This change wouldn't be necessary if #2971 was implemented, but until that happens, this will make using `std.json.stringify` on recursive structures easier to deal with.