### PR TITLE
add `jsonParseFromValue` to `std.json.Value`

### DIFF
--- a/lib/std/json/dynamic.zig
+++ b/lib/std/json/dynamic.zig
@@ -147,6 +147,12 @@ pub const Value = union(enum) {
             }
         }
     }
+
+    pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) !@This() {
+        _ = allocator;
+        _ = options;
+        return source;
+    }
 };
 
 fn handleCompleteValue(stack: *Array, allocator: Allocator, source: anytype, value_: Value) !?Value {

--- a/lib/std/json/dynamic_test.zig
+++ b/lib/std/json/dynamic_test.zig
@@ -245,6 +245,23 @@ test "Value.jsonStringify" {
     }
 }
 
+test "parseFromValue(std.json.Value,...)" {
+    const str =
+        \\{
+        \\  "int": 32,
+        \\  "float": 3.2,
+        \\  "str": "str",
+        \\  "array": [3, 2],
+        \\  "object": {}
+        \\}
+    ;
+
+    const parsed_tree = try parseFromSlice(Value, testing.allocator, str, .{});
+    defer parsed_tree.deinit();
+    const tree = try parseFromValueLeaky(Value, parsed_tree.arena.allocator(), parsed_tree.value, .{});
+    try testing.expect(std.meta.eql(parsed_tree.value, tree));
+}
+
 test "polymorphic parsing" {
     if (true) return error.SkipZigTest; // See https://github.com/ziglang/zig/issues/16108
     const doc =


### PR DESCRIPTION
Calling `std.json.parseFromValue(std.json.Value, ...)` will yield the compile error below. Obviously it doesn't make sense to do this directly, but you can still encounter this indirectly through structs or generic code.
```
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/json/static.zig:682:22: error: values of type 'anyopaque' must be comptime-known, but operand value is runtime-known
                    r.* = try internalParseFromValue(ptrInfo.child, allocator, source, options);
                    ~^~
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/json/static.zig:682:22: note: opaque type 'anyopaque' has undefined size
referenced by:
    internalParseFromValue__anon_8402: /opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/json/static.zig:635:53
    internalParseFromValue__anon_7820: /opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/json/static.zig:635:53
    remaining reference traces hidden; use '-freference-trace' to see all reference traces

/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/mem/Allocator.zig:104:17: error: no size available for type 'anyopaque'
    if (@sizeOf(T) == 0) return @as(*T, @ptrFromInt(math.maxInt(usize)));
                ^
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/json/static.zig:714:25: error: Unable to parse into type '[*]align(8) u8'
                else => @compileError("Unable to parse into type '" ++ @typeName(T) ++ "'"),
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/json/static.zig:682:22: error: values of type 'fn(*anyopaque, usize, u8, usize) ?[*]u8' must be comptime-known, but operand value is runtime-known
                    r.* = try internalParseFromValue(ptrInfo.child, allocator, source, options);
                    ~^~
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/json/static.zig:682:22: note: use '*const fn(*anyopaque, usize, u8, usize) ?[*]u8' for a function pointer type
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/json/static.zig:682:22: error: values of type 'fn(*anyopaque, []u8, u8, usize, usize) bool' must be comptime-known, but operand value is runtime-known
                    r.* = try internalParseFromValue(ptrInfo.child, allocator, source, options);
                    ~^~
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/json/static.zig:682:22: note: use '*const fn(*anyopaque, []u8, u8, usize, usize) bool' for a function pointer type
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/json/static.zig:682:22: error: values of type 'fn(*anyopaque, []u8, u8, usize) void' must be comptime-known, but operand value is runtime-known
                    r.* = try internalParseFromValue(ptrInfo.child, allocator, source, options);
                    ~^~
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/json/static.zig:682:22: note: use '*const fn(*anyopaque, []u8, u8, usize) void' for a function pointer type
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/mem/Allocator.zig:104:17: error: no size available for type 'fn(*anyopaque, usize, u8, usize) ?[*]u8'
    if (@sizeOf(T) == 0) return @as(*T, @ptrFromInt(math.maxInt(usize)));
                ^
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/mem/Allocator.zig:104:17: error: no size available for type 'fn(*anyopaque, []u8, u8, usize, usize) bool'
    if (@sizeOf(T) == 0) return @as(*T, @ptrFromInt(math.maxInt(usize)));
                ^
/opt/zig/0.11.0-dev.3932+17890f6b8/files/lib/std/mem/Allocator.zig:104:17: error: no size available for type 'fn(*anyopaque, []u8, u8, usize) void'
    if (@sizeOf(T) == 0) return @as(*T, @ptrFromInt(math.maxInt(usize)));
```