### PR TITLE
make @log2 work on integers

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -9403,11 +9403,11 @@ fn doTheTest() !void {
       {#header_open|@log2#}
       <pre>{#syntax#}@log2(value: anytype) @TypeOf(value){#endsyntax#}</pre>
       <p>
-      Returns the logarithm to the base 2 of a floating point number. Uses a dedicated hardware instruction
+      Returns the logarithm to the base 2 of an integer or a floating point number. Uses a dedicated hardware instruction
       when available.
       </p>
       <p>
-      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      Supports {#link|Integers}, {#link|Floats#}, and {#link|Vectors#} of floats.
       </p>
       {#header_close#}
       {#header_open|@log10#}

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -872,6 +872,7 @@ pub const panic_messages = struct {
     pub const memcpy_len_mismatch = "@memcpy arguments have non-equal lengths";
     pub const memcpy_alias = "@memcpy arguments alias";
     pub const noreturn_returned = "'noreturn' function returned";
+    pub const log2_zero = "@log2 received zero integer argument";
 };
 
 pub noinline fn returnError(st: *StackTrace) void {

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -127,7 +127,7 @@ pub const snan = @import("math/nan.zig").snan;
 ///
 /// NaN values are never considered equal to any value.
 pub fn approxEqAbs(comptime T: type, x: T, y: T, tolerance: T) bool {
-    assert(@typeInfo(T) == .Float);
+    assert(@typeInfo(T) == .Float or @typeInfo(T) == .ComptimeFloat);
     assert(tolerance >= 0);
 
     // Fast path for equal values (and signed zeros and infinites).
@@ -155,7 +155,7 @@ pub fn approxEqAbs(comptime T: type, x: T, y: T, tolerance: T) bool {
 ///
 /// NaN values are never considered equal to any value.
 pub fn approxEqRel(comptime T: type, x: T, y: T, tolerance: T) bool {
-    assert(@typeInfo(T) == .Float);
+    assert(@typeInfo(T) == .Float or @typeInfo(T) == .ComptimeFloat);
     assert(tolerance > 0);
 
     // Fast path for equal values (and signed zeros and infinites).
@@ -246,6 +246,7 @@ pub const expm1 = @import("math/expm1.zig").expm1;
 pub const ilogb = @import("math/ilogb.zig").ilogb;
 pub const ln = @import("math/ln.zig").ln;
 pub const log = @import("math/log.zig").log;
+// TODO: replace with @log2
 pub const log2 = @import("math/log2.zig").log2;
 pub const log10 = @import("math/log10.zig").log10;
 pub const log10_int = @import("math/log10.zig").log10_int;
@@ -1279,6 +1280,7 @@ fn testCeilPowerOfTwo() !void {
 
 /// Return the log base 2 of integer value x, rounding down to the
 /// nearest integer.
+// TODO: replace with @log2
 pub fn log2_int(comptime T: type, x: T) Log2Int(T) {
     if (@typeInfo(T) != .Int or @typeInfo(T).Int.signedness != .unsigned)
         @compileError("log2_int requires an unsigned integer, found " ++ @typeName(T));

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -2025,6 +2025,11 @@ pub const Const = struct {
         };
     }
 
+    pub fn log2(self: Const) usize {
+        const bit_len = (self.limbs.len * @bitSizeOf(Limb)) - @clz(self.limbs[self.limbs.len - 1]);
+        return bit_len - 1;
+    }
+
     pub fn negate(self: Const) Const {
         return .{
             .limbs = self.limbs,
@@ -2081,7 +2086,7 @@ pub const Const = struct {
     /// two's complement with the given integer width (bit_count).
     /// This includes the leading sign bit, which will be set for negative values.
     ///
-    /// Asserts that bit_count is enough to represent value in two's compliment
+    /// Asserts that bit_count is enough to represent the value in two's complement
     /// and that the final result fits in a usize.
     /// Asserts that there are no trailing empty limbs on the most significant end,
     /// i.e. that limb count matches `calcLimbLen()` and zero is not negative.

--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -476,6 +476,20 @@ test "big.int abs" {
     try testing.expect((try a.to(u32)) == 5);
 }
 
+test "big.int log2" {
+    var a = try Managed.init(testing.allocator);
+    defer a.deinit();
+
+    try a.setString(10, "322339239083928382323808921308908120819");
+    try testing.expect(a.toConst().log2() == 127);
+
+    try a.setString(10, "9999999999999999999999");
+    try testing.expect(a.toConst().log2() == 73);
+
+    try a.setString(10, "123");
+    try testing.expect(a.toConst().log2() == 6);
+}
+
 test "big.int negate" {
     var a = try Managed.initSet(testing.allocator, 5);
     defer a.deinit();

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -323,6 +323,7 @@ pub fn dupeZ(allocator: Allocator, comptime T: type, m: []const T) ![:0]T {
 
 /// TODO replace callsites with `@log2` after this proposal is implemented:
 /// https://github.com/ziglang/zig/issues/13642
+// TODO: replace with @log2
 inline fn log2a(x: anytype) switch (@typeInfo(@TypeOf(x))) {
     .Int => math.Log2Int(@TypeOf(x)),
     .ComptimeInt => comptime_int,

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -350,7 +350,7 @@ pub const Inst = struct {
         /// Natural (base e) logarithm of a float or a vector of floats.
         /// Uses the `un_op` field.
         log,
-        /// Base 2 logarithm of a float or a vector of floats.
+        /// Base 2 logarithm of an integer, float, or a vector of floats.
         /// Uses the `un_op` field.
         log2,
         /// Base 10 logarithm of a float or a vector of floats.

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -54,7 +54,7 @@ pub const Inst = struct {
         /// If either operand is NaN, the result value is undefined.
         /// Uses the `bin_op` field.
         add_optimized,
-        /// Twos complement wrapping integer addition.
+        /// Two's complement wrapping integer addition.
         /// Both operands are guaranteed to be the same type, and the result type
         /// is the same as both operands.
         /// Uses the `bin_op` field.
@@ -83,7 +83,7 @@ pub const Inst = struct {
         /// If either operand is NaN, the result value is undefined.
         /// Uses the `bin_op` field.
         sub_optimized,
-        /// Twos complement wrapping integer subtraction.
+        /// Two's complement wrapping integer subtraction.
         /// Both operands are guaranteed to be the same type, and the result type
         /// is the same as both operands.
         /// Uses the `bin_op` field.
@@ -112,7 +112,7 @@ pub const Inst = struct {
         /// If either operand is NaN, the result value is undefined.
         /// Uses the `bin_op` field.
         mul_optimized,
-        /// Twos complement wrapping integer multiplication.
+        /// Two's complement wrapping integer multiplication.
         /// Both operands are guaranteed to be the same type, and the result type
         /// is the same as both operands.
         /// Uses the `bin_op` field.
@@ -310,65 +310,65 @@ pub const Inst = struct {
         call_never_tail,
         /// Same as `call` except with the `never_inline` attribute.
         call_never_inline,
-        /// Count leading zeroes of an integer according to its representation in twos complement.
+        /// Count leading zeroes of an integer according to its representation in two's complement.
         /// Result type will always be an unsigned integer big enough to fit the answer.
         /// Uses the `ty_op` field.
         clz,
-        /// Count trailing zeroes of an integer according to its representation in twos complement.
+        /// Count trailing zeroes of an integer according to its representation in two's complement.
         /// Result type will always be an unsigned integer big enough to fit the answer.
         /// Uses the `ty_op` field.
         ctz,
-        /// Count number of 1 bits in an integer according to its representation in twos complement.
+        /// Count number of 1 bits in an integer according to its representation in two's complement.
         /// Result type will always be an unsigned integer big enough to fit the answer.
         /// Uses the `ty_op` field.
         popcount,
-        /// Reverse the bytes in an integer according to its representation in twos complement.
+        /// Reverse the bytes in an integer according to its representation in two's complement.
         /// Uses the `ty_op` field.
         byte_swap,
-        /// Reverse the bits in an integer according to its representation in twos complement.
+        /// Reverse the bits in an integer according to its representation in two's complement.
         /// Uses the `ty_op` field.
         bit_reverse,
 
-        /// Square root of a floating point number.
+        /// Square root of a float or a vector of floats.
         /// Uses the `un_op` field.
         sqrt,
-        /// Sine function on a floating point number.
+        /// Sine function on a float or a vector of floats.
         /// Uses the `un_op` field.
         sin,
-        /// Cosine function on a floating point number.
+        /// Cosine function on a float or a vector of floats.
         /// Uses the `un_op` field.
         cos,
-        /// Tangent function on a floating point number.
+        /// Tangent function on a float or a vector of floats.
         /// Uses the `un_op` field.
         tan,
-        /// Base e exponential of a floating point number.
+        /// Base e exponential of a float or a vector of floats.
         /// Uses the `un_op` field.
         exp,
-        /// Base 2 exponential of a floating point number.
+        /// Base 2 exponential of a float or a vector of floats.
         /// Uses the `un_op` field.
         exp2,
-        /// Natural (base e) logarithm of a floating point number.
+        /// Natural (base e) logarithm of a float or a vector of floats.
         /// Uses the `un_op` field.
         log,
-        /// Base 2 logarithm of a floating point number.
+        /// Base 2 logarithm of a float or a vector of floats.
         /// Uses the `un_op` field.
         log2,
-        /// Base 10 logarithm of a floating point number.
+        /// Base 10 logarithm of a float or a vector of floats.
         /// Uses the `un_op` field.
         log10,
-        /// Aboslute value of a floating point number.
+        /// Absolute value of a float or vector of floats.
         /// Uses the `un_op` field.
         fabs,
-        /// Floor: rounds a floating pointer number down to the nearest integer.
+        /// Rounds a float or a vector of floats down to the nearest integer.
         /// Uses the `un_op` field.
         floor,
-        /// Ceiling: rounds a floating pointer number up to the nearest integer.
+        /// Rounds a float or a vector of floats up to the nearest integer.
         /// Uses the `un_op` field.
         ceil,
-        /// Rounds a floating pointer number to the nearest integer.
+        /// Rounds a float or a vector of floats to the nearest integer, away from zero.
         /// Uses the `un_op` field.
         round,
-        /// Rounds a floating pointer number to the nearest integer towards zero.
+        /// Rounds a float or a vector of floats to the nearest integer, towards zero.
         /// Uses the `un_op` field.
         trunc_float,
         /// Float negation. This affects the sign of zero, inf, and NaN, which is impossible
@@ -787,7 +787,6 @@ pub const Inst = struct {
         /// Uses the `pl_op` field, payload represents the index of the target memory.
         /// The operand is unused and always set to `Ref.none`.
         wasm_memory_size,
-
         /// Implements @wasmMemoryGrow builtin.
         /// Result type is always `i32`,
         /// Uses the `pl_op` field, payload represents the index of the target memory.
@@ -804,8 +803,7 @@ pub const Inst = struct {
 
         /// Returns pointer to current error return trace.
         err_return_trace,
-
-        /// Sets the operand as the current error return trace,
+        /// Sets the operand as the current error return trace.
         set_err_return_trace,
 
         /// Convert the address space of a pointer.

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -218,6 +218,7 @@ pub const PanicId = enum {
     memcpy_len_mismatch,
     memcpy_alias,
     noreturn_returned,
+    log2_zero,
 
     pub const len = @typeInfo(PanicId).Enum.fields.len;
 };

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -22919,7 +22919,7 @@ fn zirMulAdd(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
 
     switch (ty.scalarType(mod).zigTypeTag(mod)) {
         .ComptimeFloat, .Float => {},
-        else => return sema.fail(block, src, "expected vector of floats or float type, found '{}'", .{ty.fmt(sema.mod)}),
+        else => return sema.fail(block, src, "expected float or vector of floats, found '{}'", .{ty.fmt(sema.mod)}),
     }
 
     const runtime_src = if (maybe_mulend1) |mulend1_val| rs: {

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -2611,7 +2611,7 @@ fn airBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
 }
 
 /// Performs a binary operation on the given `WValue`'s
-/// NOTE: THis leaves the value on top of the stack.
+/// NOTE: This leaves the value on top of the stack.
 fn binOp(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: Op) InnerError!WValue {
     const mod = func.bin_file.base.options.module.?;
     assert(!(lhs != .stack and rhs == .stack));
@@ -2776,9 +2776,19 @@ const FloatOp = enum {
 };
 
 fn airUnaryFloatOp(func: *CodeGen, inst: Air.Inst.Index, op: FloatOp) InnerError!void {
+    const mod = func.bin_file.base.options.module.?;
     const un_op = func.air.instructions.items(.data)[inst].un_op;
     const operand = try func.resolveInst(un_op);
     const ty = func.typeOf(un_op);
+
+    switch (op) {
+        .log2 => {
+            if (ty.zigTypeTag(mod) == .Int) {
+                return func.fail("TODO: implement @log2 for integers", .{});
+            }
+        },
+        else => {},
+    }
 
     const result = try (try func.floatOp(op, ty, &.{operand})).toLocal(func, ty);
     func.finishAir(inst, result, &.{un_op});

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -7005,6 +7005,12 @@ fn airUnFloatOp(f: *Function, inst: Air.Inst.Index, operation: []const u8) !CVal
     const inst_ty = f.typeOfIndex(inst);
     const inst_scalar_ty = inst_ty.scalarType(mod);
 
+    if (mem.eql(u8, operation, "log2")) {
+        if (inst_ty.zigTypeTag(mod) == .Int) {
+            return f.fail("TODO: implement @log2 for integers", .{});
+        }
+    }
+
     const writer = f.object.writer();
     const local = try f.allocLocal(inst, inst_ty);
     const v = try Vectorize.start(f, inst, writer, inst_ty);

--- a/src/value.zig
+++ b/src/value.zig
@@ -1853,7 +1853,7 @@ pub const Value = struct {
         return floatFromIntScalar(val, float_ty, mod, opt_sema);
     }
 
-    pub fn floatFromIntScalar(val: Value, float_ty: Type, mod: *Module, opt_sema: ?*Sema) !Value {
+    fn floatFromIntScalar(val: Value, float_ty: Type, mod: *Module, opt_sema: ?*Sema) !Value {
         return switch (mod.intern_pool.indexToKey(val.toIntern())) {
             .undef => (try mod.intern(.{ .undef = float_ty.toIntern() })).toValue(),
             .int => |int| switch (int.storage) {
@@ -1932,7 +1932,7 @@ pub const Value = struct {
     }
 
     /// Supports integers only; asserts neither operand is undefined.
-    pub fn intAddSatScalar(
+    fn intAddSatScalar(
         lhs: Value,
         rhs: Value,
         ty: Type,
@@ -1982,7 +1982,7 @@ pub const Value = struct {
     }
 
     /// Supports integers only; asserts neither operand is undefined.
-    pub fn intSubSatScalar(
+    fn intSubSatScalar(
         lhs: Value,
         rhs: Value,
         ty: Type,
@@ -2040,7 +2040,7 @@ pub const Value = struct {
         return intMulWithOverflowScalar(lhs, rhs, ty, arena, mod);
     }
 
-    pub fn intMulWithOverflowScalar(
+    fn intMulWithOverflowScalar(
         lhs: Value,
         rhs: Value,
         ty: Type,
@@ -2100,7 +2100,7 @@ pub const Value = struct {
     }
 
     /// Supports both floats and ints; handles undefined.
-    pub fn numberMulWrapScalar(
+    fn numberMulWrapScalar(
         lhs: Value,
         rhs: Value,
         ty: Type,
@@ -2146,7 +2146,7 @@ pub const Value = struct {
     }
 
     /// Supports (vectors of) integers only; asserts neither operand is undefined.
-    pub fn intMulSatScalar(
+    fn intMulSatScalar(
         lhs: Value,
         rhs: Value,
         ty: Type,
@@ -2222,7 +2222,7 @@ pub const Value = struct {
     }
 
     /// operands must be integers; handles undefined.
-    pub fn bitwiseNotScalar(val: Value, ty: Type, arena: Allocator, mod: *Module) !Value {
+    fn bitwiseNotScalar(val: Value, ty: Type, arena: Allocator, mod: *Module) !Value {
         if (val.isUndef(mod)) return (try mod.intern(.{ .undef = ty.toIntern() })).toValue();
         if (ty.toIntern() == .bool_type) return makeBool(!val.toBool());
 
@@ -2265,7 +2265,7 @@ pub const Value = struct {
     }
 
     /// operands must be integers; handles undefined.
-    pub fn bitwiseAndScalar(lhs: Value, rhs: Value, ty: Type, arena: Allocator, mod: *Module) !Value {
+    fn bitwiseAndScalar(lhs: Value, rhs: Value, ty: Type, arena: Allocator, mod: *Module) !Value {
         if (lhs.isUndef(mod) or rhs.isUndef(mod)) return (try mod.intern(.{ .undef = ty.toIntern() })).toValue();
         if (ty.toIntern() == .bool_type) return makeBool(lhs.toBool() and rhs.toBool());
 
@@ -2304,7 +2304,7 @@ pub const Value = struct {
     }
 
     /// operands must be integers; handles undefined.
-    pub fn bitwiseNandScalar(lhs: Value, rhs: Value, ty: Type, arena: Allocator, mod: *Module) !Value {
+    fn bitwiseNandScalar(lhs: Value, rhs: Value, ty: Type, arena: Allocator, mod: *Module) !Value {
         if (lhs.isUndef(mod) or rhs.isUndef(mod)) return (try mod.intern(.{ .undef = ty.toIntern() })).toValue();
         if (ty.toIntern() == .bool_type) return makeBool(!(lhs.toBool() and rhs.toBool()));
 
@@ -2332,7 +2332,7 @@ pub const Value = struct {
     }
 
     /// operands must be integers; handles undefined.
-    pub fn bitwiseOrScalar(lhs: Value, rhs: Value, ty: Type, arena: Allocator, mod: *Module) !Value {
+    fn bitwiseOrScalar(lhs: Value, rhs: Value, ty: Type, arena: Allocator, mod: *Module) !Value {
         if (lhs.isUndef(mod) or rhs.isUndef(mod)) return (try mod.intern(.{ .undef = ty.toIntern() })).toValue();
         if (ty.toIntern() == .bool_type) return makeBool(lhs.toBool() or rhs.toBool());
 
@@ -2370,7 +2370,7 @@ pub const Value = struct {
     }
 
     /// operands must be integers; handles undefined.
-    pub fn bitwiseXorScalar(lhs: Value, rhs: Value, ty: Type, arena: Allocator, mod: *Module) !Value {
+    fn bitwiseXorScalar(lhs: Value, rhs: Value, ty: Type, arena: Allocator, mod: *Module) !Value {
         if (lhs.isUndef(mod) or rhs.isUndef(mod)) return (try mod.intern(.{ .undef = ty.toIntern() })).toValue();
         if (ty.toIntern() == .bool_type) return makeBool(lhs.toBool() != rhs.toBool());
 
@@ -2435,7 +2435,7 @@ pub const Value = struct {
         return intDivScalar(lhs, rhs, ty, allocator, mod);
     }
 
-    pub fn intDivScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
+    fn intDivScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
         // TODO is this a performance issue? maybe we should try the operation without
         // resorting to BigInt first.
         var lhs_space: Value.BigIntSpace = undefined;
@@ -2483,7 +2483,7 @@ pub const Value = struct {
         return intDivFloorScalar(lhs, rhs, ty, allocator, mod);
     }
 
-    pub fn intDivFloorScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
+    fn intDivFloorScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
         // TODO is this a performance issue? maybe we should try the operation without
         // resorting to BigInt first.
         var lhs_space: Value.BigIntSpace = undefined;
@@ -2525,7 +2525,7 @@ pub const Value = struct {
         return intModScalar(lhs, rhs, ty, allocator, mod);
     }
 
-    pub fn intModScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
+    fn intModScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
         // TODO is this a performance issue? maybe we should try the operation without
         // resorting to BigInt first.
         var lhs_space: Value.BigIntSpace = undefined;
@@ -2599,7 +2599,7 @@ pub const Value = struct {
         return floatRemScalar(lhs, rhs, float_type, mod);
     }
 
-    pub fn floatRemScalar(lhs: Value, rhs: Value, float_type: Type, mod: *Module) !Value {
+    fn floatRemScalar(lhs: Value, rhs: Value, float_type: Type, mod: *Module) !Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @rem(lhs.toFloat(f16, mod), rhs.toFloat(f16, mod)) },
@@ -2632,7 +2632,7 @@ pub const Value = struct {
         return floatModScalar(lhs, rhs, float_type, mod);
     }
 
-    pub fn floatModScalar(lhs: Value, rhs: Value, float_type: Type, mod: *Module) !Value {
+    fn floatModScalar(lhs: Value, rhs: Value, float_type: Type, mod: *Module) !Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @mod(lhs.toFloat(f16, mod), rhs.toFloat(f16, mod)) },
@@ -2693,7 +2693,7 @@ pub const Value = struct {
         return intMulScalar(lhs, rhs, ty, allocator, mod);
     }
 
-    pub fn intMulScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
+    fn intMulScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
         if (ty.toIntern() != .comptime_int_type) {
             const res = try intMulWithOverflowScalar(lhs, rhs, ty, allocator, mod);
             if (res.overflow_bit.compareAllWithZero(.neq, mod)) return error.Overflow;
@@ -2760,7 +2760,7 @@ pub const Value = struct {
         return intTruncScalar(val, ty, allocator, signedness, @as(u16, @intCast(bits.toUnsignedInt(mod))), mod);
     }
 
-    pub fn intTruncScalar(
+    fn intTruncScalar(
         val: Value,
         ty: Type,
         allocator: Allocator,
@@ -2800,7 +2800,7 @@ pub const Value = struct {
         return shlScalar(lhs, rhs, ty, allocator, mod);
     }
 
-    pub fn shlScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
+    fn shlScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
         // TODO is this a performance issue? maybe we should try the operation without
         // resorting to BigInt first.
         var lhs_space: Value.BigIntSpace = undefined;
@@ -2857,7 +2857,7 @@ pub const Value = struct {
         return shlWithOverflowScalar(lhs, rhs, ty, allocator, mod);
     }
 
-    pub fn shlWithOverflowScalar(
+    fn shlWithOverflowScalar(
         lhs: Value,
         rhs: Value,
         ty: Type,
@@ -2911,7 +2911,7 @@ pub const Value = struct {
         return shlSatScalar(lhs, rhs, ty, arena, mod);
     }
 
-    pub fn shlSatScalar(
+    fn shlSatScalar(
         lhs: Value,
         rhs: Value,
         ty: Type,
@@ -2961,7 +2961,7 @@ pub const Value = struct {
         return shlTruncScalar(lhs, rhs, ty, arena, mod);
     }
 
-    pub fn shlTruncScalar(
+    fn shlTruncScalar(
         lhs: Value,
         rhs: Value,
         ty: Type,
@@ -2991,7 +2991,7 @@ pub const Value = struct {
         return shrScalar(lhs, rhs, ty, allocator, mod);
     }
 
-    pub fn shrScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
+    fn shrScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, mod: *Module) !Value {
         // TODO is this a performance issue? maybe we should try the operation without
         // resorting to BigInt first.
         var lhs_space: Value.BigIntSpace = undefined;
@@ -3043,7 +3043,7 @@ pub const Value = struct {
         return floatNegScalar(val, float_type, mod);
     }
 
-    pub fn floatNegScalar(
+    fn floatNegScalar(
         val: Value,
         float_type: Type,
         mod: *Module,
@@ -3086,7 +3086,7 @@ pub const Value = struct {
         return floatAddScalar(lhs, rhs, float_type, mod);
     }
 
-    pub fn floatAddScalar(
+    fn floatAddScalar(
         lhs: Value,
         rhs: Value,
         float_type: Type,
@@ -3130,7 +3130,7 @@ pub const Value = struct {
         return floatSubScalar(lhs, rhs, float_type, mod);
     }
 
-    pub fn floatSubScalar(
+    fn floatSubScalar(
         lhs: Value,
         rhs: Value,
         float_type: Type,
@@ -3174,7 +3174,7 @@ pub const Value = struct {
         return floatDivScalar(lhs, rhs, float_type, mod);
     }
 
-    pub fn floatDivScalar(
+    fn floatDivScalar(
         lhs: Value,
         rhs: Value,
         float_type: Type,
@@ -3218,7 +3218,7 @@ pub const Value = struct {
         return floatDivFloorScalar(lhs, rhs, float_type, mod);
     }
 
-    pub fn floatDivFloorScalar(
+    fn floatDivFloorScalar(
         lhs: Value,
         rhs: Value,
         float_type: Type,
@@ -3262,7 +3262,7 @@ pub const Value = struct {
         return floatDivTruncScalar(lhs, rhs, float_type, mod);
     }
 
-    pub fn floatDivTruncScalar(
+    fn floatDivTruncScalar(
         lhs: Value,
         rhs: Value,
         float_type: Type,
@@ -3306,7 +3306,7 @@ pub const Value = struct {
         return floatMulScalar(lhs, rhs, float_type, mod);
     }
 
-    pub fn floatMulScalar(
+    fn floatMulScalar(
         lhs: Value,
         rhs: Value,
         float_type: Type,
@@ -3343,7 +3343,7 @@ pub const Value = struct {
         return sqrtScalar(val, float_type, mod);
     }
 
-    pub fn sqrtScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn sqrtScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @sqrt(val.toFloat(f16, mod)) },
@@ -3375,7 +3375,7 @@ pub const Value = struct {
         return sinScalar(val, float_type, mod);
     }
 
-    pub fn sinScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn sinScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @sin(val.toFloat(f16, mod)) },
@@ -3407,7 +3407,7 @@ pub const Value = struct {
         return cosScalar(val, float_type, mod);
     }
 
-    pub fn cosScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn cosScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @cos(val.toFloat(f16, mod)) },
@@ -3439,7 +3439,7 @@ pub const Value = struct {
         return tanScalar(val, float_type, mod);
     }
 
-    pub fn tanScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn tanScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @tan(val.toFloat(f16, mod)) },
@@ -3471,7 +3471,7 @@ pub const Value = struct {
         return expScalar(val, float_type, mod);
     }
 
-    pub fn expScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn expScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @exp(val.toFloat(f16, mod)) },
@@ -3503,7 +3503,7 @@ pub const Value = struct {
         return exp2Scalar(val, float_type, mod);
     }
 
-    pub fn exp2Scalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn exp2Scalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @exp2(val.toFloat(f16, mod)) },
@@ -3535,7 +3535,7 @@ pub const Value = struct {
         return logScalar(val, float_type, mod);
     }
 
-    pub fn logScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn logScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @log(val.toFloat(f16, mod)) },
@@ -3567,7 +3567,7 @@ pub const Value = struct {
         return log2Scalar(val, float_type, mod);
     }
 
-    pub fn log2Scalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn log2Scalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @log2(val.toFloat(f16, mod)) },
@@ -3599,7 +3599,7 @@ pub const Value = struct {
         return log10Scalar(val, float_type, mod);
     }
 
-    pub fn log10Scalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn log10Scalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @log10(val.toFloat(f16, mod)) },
@@ -3631,7 +3631,7 @@ pub const Value = struct {
         return fabsScalar(val, float_type, mod);
     }
 
-    pub fn fabsScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn fabsScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @fabs(val.toFloat(f16, mod)) },
@@ -3663,7 +3663,7 @@ pub const Value = struct {
         return floorScalar(val, float_type, mod);
     }
 
-    pub fn floorScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn floorScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @floor(val.toFloat(f16, mod)) },
@@ -3695,7 +3695,7 @@ pub const Value = struct {
         return ceilScalar(val, float_type, mod);
     }
 
-    pub fn ceilScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn ceilScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @ceil(val.toFloat(f16, mod)) },
@@ -3727,7 +3727,7 @@ pub const Value = struct {
         return roundScalar(val, float_type, mod);
     }
 
-    pub fn roundScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn roundScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @round(val.toFloat(f16, mod)) },
@@ -3759,7 +3759,7 @@ pub const Value = struct {
         return truncScalar(val, float_type, mod);
     }
 
-    pub fn truncScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
+    fn truncScalar(val: Value, float_type: Type, mod: *Module) Allocator.Error!Value {
         const target = mod.getTarget();
         const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
             16 => .{ .f16 = @trunc(val.toFloat(f16, mod)) },
@@ -3800,7 +3800,7 @@ pub const Value = struct {
         return mulAddScalar(float_type, mulend1, mulend2, addend, mod);
     }
 
-    pub fn mulAddScalar(
+    fn mulAddScalar(
         float_type: Type,
         mulend1: Value,
         mulend2: Value,

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -430,12 +430,17 @@ test "@log2" {
 }
 
 fn testLog2() !void {
-    inline for ([_]type{ f16, f32, f64 }) |ty| {
-        const eps = epsForType(ty);
+    inline for ([_]type{ f16, f32, f64, comptime_float, u16, u32, u64, comptime_int }) |ty| {
+        try expect(@log2(@as(ty, 1)) == 0);
         try expect(@log2(@as(ty, 4)) == 2);
-        try expect(math.approxEqAbs(ty, @log2(@as(ty, 6)), 2.5849625007212, eps));
-        try expect(math.approxEqAbs(ty, @log2(@as(ty, 10)), 3.3219280948874, eps));
+        if (@typeInfo(ty) == .Float or @typeInfo(ty) == .ComptimeFloat) {
+            const eps = epsForType(ty);
+            try expect(math.approxEqAbs(ty, @log2(@as(ty, 6)), 2.5849625007212, eps));
+            try expect(math.approxEqAbs(ty, @log2(@as(ty, 10)), 3.3219280948874, eps));
+        }
     }
+    try expect(@log2(239230928938092208920890892800832) == 107);
+    try expect(@log2(823823892839289389238928923) == 89);
 }
 
 test "@log2 with vectors" {

--- a/test/cases/compile_errors/log2_bad_values.zig
+++ b/test/cases/compile_errors/log2_bad_values.zig
@@ -1,0 +1,40 @@
+export fn a() void {
+    var x: u0 = 0;
+    @compileLog(@log2(x));
+}
+export fn b() void {
+    _ = @log2(0);
+}
+export fn c() void {
+    _ = @log2("hello");
+}
+export fn d() void {
+    var x: i32 = 100;
+    _ = @log2(x);
+}
+export fn e() void {
+    _ = @log2(@as(i8, 0));
+}
+export fn f() void {
+    var x: i16 = 0;
+    _ = @log2(x);
+}
+export fn g() void {
+    _ = @log2(-1);
+}
+export fn h() void {
+    _ = @log2(@as(i8, -1));
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:23: error: @log2 integer operand cannot be zero
+// :6:15: error: @log2 integer operand cannot be zero
+// :9:15: error: expected integer, float, or vector of floats, found '*const [5:0]u8'
+// :13:15: error: @log2 integer operand must be unsigned
+// :16:15: error: @log2 integer operand cannot be zero
+// :20:15: error: @log2 integer operand must be unsigned
+// :23:15: error: @log2 integer operand must be positive
+// :26:15: error: @log2 integer operand must be positive

--- a/test/cases/compile_errors/muladd_int_vector.zig
+++ b/test/cases/compile_errors/muladd_int_vector.zig
@@ -6,4 +6,4 @@ comptime {
 // backend=stage2
 // target=native
 //
-// :2:9: error: expected vector of floats or float type, found '@Vector(1, u32)'
+// :2:9: error: expected float or vector of floats, found '@Vector(1, u32)'

--- a/test/cases/safety/log2_zero.zig
+++ b/test/cases/safety/log2_zero.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
+    _ = stack_trace;
+    if (std.mem.eql(u8, message, "@log2 received zero integer argument")) {
+        std.process.exit(0);
+    }
+    std.process.exit(1);
+}
+
+pub fn main() !void {
+    var x: u32 = undefined;
+    x = 0;
+    _ = @log2(x);
+    return error.TestFailed;
+}
+
+// run
+// backend=llvm
+// target=native


### PR DESCRIPTION
Fixes #13642

This adds support for integers to `@log2`.
This does not add support for vectors of integers because that is not mentioned in #13642.
If that is also desired, I can try implementing that too, or at least a little bit.

This is a draft pull request because even though the tests I added in `test/behavior/floatop.zig` already pass, there are still some things to do and **I have some questions**:
* [X] ~~Should a~~ runtime safety check with a panic id like this https://github.com/ziglang/zig/blob/8ae92fd17ee9a3d46e4f441864a8544b440c0b2d/src/Module.zig#L195C1-L195C4 ~~be~~ added for when a runtime-known integer 0 is passed to `@log2`~~? There is a TODO for this in the code.~~
* [x] Implement log2 for `std.math.big.int.Const` ~~or emit a compile error rather than panicking~~.
* [ ] Figure out if vectors of integers are desired (are they?)