### PR TITLE
Optimize `Allocator.allocAdvancedBla` to create less duplicate code for similar types.

### DIFF
--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -213,14 +213,14 @@ fn allocWithSizeAndAlignment(self: Allocator, comptime size: usize, comptime ali
 
     if (n == 0) {
         const ptr = comptime std.mem.alignBackward(usize, math.maxInt(usize), alignment);
-        return @ptrFromInt(ptr);
+        return @as([*]align(alignment) u8, @ptrFromInt(ptr));
     }
 
     const byte_count = math.mul(usize, size, n) catch return Error.OutOfMemory;
     const byte_ptr = self.rawAlloc(byte_count, log2a(alignment), return_address) orelse return Error.OutOfMemory;
     // TODO: https://github.com/ziglang/zig/issues/4298
     @memset(byte_ptr[0..byte_count], undefined);
-    return @alignCast(byte_ptr);
+    return @as([*]align(alignment) u8, @alignCast(byte_ptr));
 }
 
 /// Requests to modify the size of an allocation. It is guaranteed to not move


### PR DESCRIPTION
## Motivation
Take a look at the following code:
```zig
_ = allocator.create(u32) catch return;
_ = allocator.create(i32) catch return;
```
This is allocating two pieces of memory with the exact same size and alignment. Yet under the hood this generates two different functions, increasing the binary size and compile time. And now in the compiler there is 102 of these plus 125 calls to `alloc`.
Overall `800 kB` of zig's (debug) binary are wasted for allocator functions. That's `~2%` of the total size (measuring only zig functions).

In my own project it's even worse. Almost `10%` of the (debug) binary (excluding C functions) is filled with allocator functions.

## Solution
Essentially I put all the common functionality from `allocAdvancedWithRetAddr` into a new function that is only generic over size and alignment:
```zig
fn allocWithSizeAndAlignment(self: Allocator, comptime size: usize, comptime alignment: u29, n: usize, return_address: usize)
```
This reduces the amount of code that is duplicated when two types with same size+align are allocated.

## Results
The zig debug binary size was reduced by `503 kB`.
In my own project the debug binary was reduced by `175 kB` (`~4-5%` of the zig functions)
In my project the compile time decreased by `~0.4` seconds (`~3%`) (Note that this comes purely from the fact that there is less duplicate code to compile)

### Best case improvement
```zig
// time zig build-lib test.zig
const std = @import("std");

export fn allocThemAll(allocator: *std.mem.Allocator) void {
	inline for(1..200) |i| {
		_ = allocator.alloc(std.meta.Int(.signed, i), 1) catch return;
		_ = allocator.create(std.meta.Int(.signed, i)) catch return;
		_ = allocator.alloc(std.meta.Int(.unsigned, i), 1) catch return;
		_ = allocator.create(std.meta.Int(.unsigned, i)) catch return;
	}
}
```
The compile-time of this best-case example was reduced from 2.3 s to 1.3 s and the size of the binary decreased from 1 MB to 550 kB.