### PR TITLE
std.c: fix ptrace addr argument which is the old school void pointer,…

### DIFF
--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -2819,7 +2819,7 @@ pub const ptrace_cs_remote = extern struct {
     args: *isize,
 };
 
-pub extern "c" fn ptrace(request: c_int, pid: pid_t, addr: [*:0]u8, data: c_int) c_int;
+pub extern "c" fn ptrace(request: c_int, pid: pid_t, addr: ?[*]u8, data: c_int) c_int;
 
 /// TODO refines if necessary
 pub const PTHREAD_STACK_MIN = switch (builtin.cpu.arch) {


### PR DESCRIPTION
… caddr_t type

following-up on b754068.

ref: https://github.com/freebsd/freebsd-src/blob/544deacc90f4f6dc93017a6e18b2fdbf3bc4e059/sys/sys/ptrace.h#L271