### PR TITLE
std: add an option to log call childprocess commands

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -321,6 +321,7 @@ pub const ChildProcess = struct {
         max_output_bytes: usize = 50 * 1024,
         expand_arg0: Arg0Expand = .no_expand,
     }) ExecError!ExecResult {
+        if (std.options.log_exec) std.log.scoped(.exec).debug("{s}", .{argv});
         var child = ChildProcess.init(args.argv, args.allocator);
         child.stdin_behavior = .Ignore;
         child.stdout_behavior = .Pipe;

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -162,6 +162,7 @@ pub const ChildProcess = struct {
 
     /// First argument in argv is the executable.
     pub fn init(argv: []const []const u8, allocator: mem.Allocator) ChildProcess {
+        if (std.options.log_exec) std.log.scoped(.exec).debug("{s}", .{argv});
         return .{
             .allocator = allocator,
             .argv = argv,
@@ -321,7 +322,6 @@ pub const ChildProcess = struct {
         max_output_bytes: usize = 50 * 1024,
         expand_arg0: Arg0Expand = .no_expand,
     }) ExecError!ExecResult {
-        if (std.options.log_exec) std.log.scoped(.exec).debug("{s}", .{argv});
         var child = ChildProcess.init(args.argv, args.allocator);
         child.stdin_behavior = .Ignore;
         child.stdout_behavior = .Pipe;

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -196,6 +196,8 @@ pub const options = struct {
         options_override.side_channels_mitigations
     else
         crypto.default_side_channels_mitigations;
+
+    pub const log_exec: bool = if (@hasDecl(options_override, "log_exec")) options_override.log_exec else false;
 };
 
 // This forces the start.zig file to be imported, and the comptime logic inside that


### PR DESCRIPTION
defaults to false but adds the ability to get more observability into the goings on in the plumbing of your code