### PR TITLE
std.os.uefi: use std.os.uefi.cc instead of .C as calling convention

### DIFF
--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -23,6 +23,12 @@ pub var system_table: *tables.SystemTable = undefined;
 /// A handle to an event structure.
 pub const Event = *opaque {};
 
+/// The calling convention used for all external functions part of the UEFI API.
+pub const cc = switch (@import("builtin").target.cpu.arch) {
+    .x86_64 => .Win64,
+    else => .C,
+};
+
 pub const MacAddress = extern struct {
     address: [32]u8,
 };

--- a/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
+++ b/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
@@ -3,11 +3,12 @@ const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 /// Protocol for touchscreens
 pub const AbsolutePointerProtocol = extern struct {
-    _reset: *const fn (*const AbsolutePointerProtocol, bool) callconv(.C) Status,
-    _get_state: *const fn (*const AbsolutePointerProtocol, *AbsolutePointerState) callconv(.C) Status,
+    _reset: *const fn (*const AbsolutePointerProtocol, bool) callconv(cc) Status,
+    _get_state: *const fn (*const AbsolutePointerProtocol, *AbsolutePointerState) callconv(cc) Status,
     wait_for_input: Event,
     mode: *AbsolutePointerMode,
 

--- a/lib/std/os/uefi/protocols/block_io_protocol.zig
+++ b/lib/std/os/uefi/protocols/block_io_protocol.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const uefi = std.os.uefi;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 pub const EfiBlockMedia = extern struct {
     /// The current media ID. If the media changes, this value is changed.
@@ -44,10 +45,10 @@ pub const BlockIoProtocol = extern struct {
     revision: u64,
     media: *EfiBlockMedia,
 
-    _reset: *const fn (*BlockIoProtocol, extended_verification: bool) callconv(.C) Status,
-    _read_blocks: *const fn (*BlockIoProtocol, media_id: u32, lba: u64, buffer_size: usize, buf: [*]u8) callconv(.C) Status,
-    _write_blocks: *const fn (*BlockIoProtocol, media_id: u32, lba: u64, buffer_size: usize, buf: [*]u8) callconv(.C) Status,
-    _flush_blocks: *const fn (*BlockIoProtocol) callconv(.C) Status,
+    _reset: *const fn (*BlockIoProtocol, extended_verification: bool) callconv(cc) Status,
+    _read_blocks: *const fn (*BlockIoProtocol, media_id: u32, lba: u64, buffer_size: usize, buf: [*]u8) callconv(cc) Status,
+    _write_blocks: *const fn (*BlockIoProtocol, media_id: u32, lba: u64, buffer_size: usize, buf: [*]u8) callconv(cc) Status,
+    _flush_blocks: *const fn (*BlockIoProtocol) callconv(cc) Status,
 
     /// Resets the block device hardware.
     pub fn reset(self: *Self, extended_verification: bool) Status {

--- a/lib/std/os/uefi/protocols/edid_override_protocol.zig
+++ b/lib/std/os/uefi/protocols/edid_override_protocol.zig
@@ -3,10 +3,11 @@ const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Handle = uefi.Handle;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 /// Override EDID information
 pub const EdidOverrideProtocol = extern struct {
-    _get_edid: *const fn (*const EdidOverrideProtocol, Handle, *EdidOverrideProtocolAttributes, *usize, *?[*]u8) callconv(.C) Status,
+    _get_edid: *const fn (*const EdidOverrideProtocol, Handle, *EdidOverrideProtocolAttributes, *usize, *?[*]u8) callconv(cc) Status,
 
     /// Returns policy information and potentially a replacement EDID for the specified video output device.
     pub fn getEdid(

--- a/lib/std/os/uefi/protocols/file_protocol.zig
+++ b/lib/std/os/uefi/protocols/file_protocol.zig
@@ -4,19 +4,20 @@ const io = std.io;
 const Guid = uefi.Guid;
 const Time = uefi.Time;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 pub const FileProtocol = extern struct {
     revision: u64,
-    _open: *const fn (*const FileProtocol, **const FileProtocol, [*:0]const u16, u64, u64) callconv(.C) Status,
-    _close: *const fn (*const FileProtocol) callconv(.C) Status,
-    _delete: *const fn (*const FileProtocol) callconv(.C) Status,
-    _read: *const fn (*const FileProtocol, *usize, [*]u8) callconv(.C) Status,
-    _write: *const fn (*const FileProtocol, *usize, [*]const u8) callconv(.C) Status,
-    _get_position: *const fn (*const FileProtocol, *u64) callconv(.C) Status,
-    _set_position: *const fn (*const FileProtocol, u64) callconv(.C) Status,
-    _get_info: *const fn (*const FileProtocol, *align(8) const Guid, *const usize, [*]u8) callconv(.C) Status,
-    _set_info: *const fn (*const FileProtocol, *align(8) const Guid, usize, [*]const u8) callconv(.C) Status,
-    _flush: *const fn (*const FileProtocol) callconv(.C) Status,
+    _open: *const fn (*const FileProtocol, **const FileProtocol, [*:0]const u16, u64, u64) callconv(cc) Status,
+    _close: *const fn (*const FileProtocol) callconv(cc) Status,
+    _delete: *const fn (*const FileProtocol) callconv(cc) Status,
+    _read: *const fn (*const FileProtocol, *usize, [*]u8) callconv(cc) Status,
+    _write: *const fn (*const FileProtocol, *usize, [*]const u8) callconv(cc) Status,
+    _get_position: *const fn (*const FileProtocol, *u64) callconv(cc) Status,
+    _set_position: *const fn (*const FileProtocol, u64) callconv(cc) Status,
+    _get_info: *const fn (*const FileProtocol, *align(8) const Guid, *const usize, [*]u8) callconv(cc) Status,
+    _set_info: *const fn (*const FileProtocol, *align(8) const Guid, usize, [*]const u8) callconv(cc) Status,
+    _flush: *const fn (*const FileProtocol) callconv(cc) Status,
 
     pub const SeekError = error{SeekError};
     pub const GetSeekPosError = error{GetSeekPosError};

--- a/lib/std/os/uefi/protocols/graphics_output_protocol.zig
+++ b/lib/std/os/uefi/protocols/graphics_output_protocol.zig
@@ -2,12 +2,13 @@ const std = @import("std");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 /// Graphics output
 pub const GraphicsOutputProtocol = extern struct {
-    _query_mode: *const fn (*const GraphicsOutputProtocol, u32, *usize, **GraphicsOutputModeInformation) callconv(.C) Status,
-    _set_mode: *const fn (*const GraphicsOutputProtocol, u32) callconv(.C) Status,
-    _blt: *const fn (*const GraphicsOutputProtocol, ?[*]GraphicsOutputBltPixel, GraphicsOutputBltOperation, usize, usize, usize, usize, usize, usize, usize) callconv(.C) Status,
+    _query_mode: *const fn (*const GraphicsOutputProtocol, u32, *usize, **GraphicsOutputModeInformation) callconv(cc) Status,
+    _set_mode: *const fn (*const GraphicsOutputProtocol, u32) callconv(cc) Status,
+    _blt: *const fn (*const GraphicsOutputProtocol, ?[*]GraphicsOutputBltPixel, GraphicsOutputBltOperation, usize, usize, usize, usize, usize, usize, usize) callconv(cc) Status,
     mode: *GraphicsOutputProtocolMode,
 
     /// Returns information for an available graphics mode that the graphics device and the set of active video output devices supports.

--- a/lib/std/os/uefi/protocols/hii_database_protocol.zig
+++ b/lib/std/os/uefi/protocols/hii_database_protocol.zig
@@ -3,14 +3,15 @@ const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 const hii = uefi.protocols.hii;
+const cc = uefi.cc;
 
 /// Database manager for HII-related data structures.
 pub const HIIDatabaseProtocol = extern struct {
     _new_package_list: Status, // TODO
-    _remove_package_list: *const fn (*const HIIDatabaseProtocol, hii.HIIHandle) callconv(.C) Status,
-    _update_package_list: *const fn (*const HIIDatabaseProtocol, hii.HIIHandle, *const hii.HIIPackageList) callconv(.C) Status,
-    _list_package_lists: *const fn (*const HIIDatabaseProtocol, u8, ?*const Guid, *usize, [*]hii.HIIHandle) callconv(.C) Status,
-    _export_package_lists: *const fn (*const HIIDatabaseProtocol, ?hii.HIIHandle, *usize, *hii.HIIPackageList) callconv(.C) Status,
+    _remove_package_list: *const fn (*const HIIDatabaseProtocol, hii.HIIHandle) callconv(cc) Status,
+    _update_package_list: *const fn (*const HIIDatabaseProtocol, hii.HIIHandle, *const hii.HIIPackageList) callconv(cc) Status,
+    _list_package_lists: *const fn (*const HIIDatabaseProtocol, u8, ?*const Guid, *usize, [*]hii.HIIHandle) callconv(cc) Status,
+    _export_package_lists: *const fn (*const HIIDatabaseProtocol, ?hii.HIIHandle, *usize, *hii.HIIPackageList) callconv(cc) Status,
     _register_package_notify: Status, // TODO
     _unregister_package_notify: Status, // TODO
     _find_keyboard_layouts: Status, // TODO

--- a/lib/std/os/uefi/protocols/hii_popup_protocol.zig
+++ b/lib/std/os/uefi/protocols/hii_popup_protocol.zig
@@ -3,11 +3,12 @@ const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
 const hii = uefi.protocols.hii;
+const cc = uefi.cc;
 
 /// Display a popup window
 pub const HIIPopupProtocol = extern struct {
     revision: u64,
-    _create_popup: *const fn (*const HIIPopupProtocol, HIIPopupStyle, HIIPopupType, hii.HIIHandle, u16, ?*HIIPopupSelection) callconv(.C) Status,
+    _create_popup: *const fn (*const HIIPopupProtocol, HIIPopupStyle, HIIPopupType, hii.HIIHandle, u16, ?*HIIPopupSelection) callconv(cc) Status,
 
     /// Displays a popup window.
     pub fn createPopup(self: *const HIIPopupProtocol, style: HIIPopupStyle, popup_type: HIIPopupType, handle: hii.HIIHandle, msg: u16, user_selection: ?*HIIPopupSelection) Status {

--- a/lib/std/os/uefi/protocols/ip6_config_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_config_protocol.zig
@@ -3,12 +3,13 @@ const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 pub const Ip6ConfigProtocol = extern struct {
-    _set_data: *const fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, usize, *const anyopaque) callconv(.C) Status,
-    _get_data: *const fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, *usize, ?*const anyopaque) callconv(.C) Status,
-    _register_data_notify: *const fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) callconv(.C) Status,
-    _unregister_data_notify: *const fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) callconv(.C) Status,
+    _set_data: *const fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, usize, *const anyopaque) callconv(cc) Status,
+    _get_data: *const fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, *usize, ?*const anyopaque) callconv(cc) Status,
+    _register_data_notify: *const fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) callconv(cc) Status,
+    _unregister_data_notify: *const fn (*const Ip6ConfigProtocol, Ip6ConfigDataType, Event) callconv(cc) Status,
 
     pub fn setData(self: *const Ip6ConfigProtocol, data_type: Ip6ConfigDataType, data_size: usize, data: *const anyopaque) Status {
         return self._set_data(self, data_type, data_size, data);

--- a/lib/std/os/uefi/protocols/ip6_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_protocol.zig
@@ -6,17 +6,18 @@ const Status = uefi.Status;
 const MacAddress = uefi.protocols.MacAddress;
 const ManagedNetworkConfigData = uefi.protocols.ManagedNetworkConfigData;
 const SimpleNetworkMode = uefi.protocols.SimpleNetworkMode;
+const cc = uefi.cc;
 
 pub const Ip6Protocol = extern struct {
-    _get_mode_data: *const fn (*const Ip6Protocol, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(.C) Status,
-    _configure: *const fn (*const Ip6Protocol, ?*const Ip6ConfigData) callconv(.C) Status,
-    _groups: *const fn (*const Ip6Protocol, bool, ?*const Ip6Address) callconv(.C) Status,
-    _routes: *const fn (*const Ip6Protocol, bool, ?*const Ip6Address, u8, ?*const Ip6Address) callconv(.C) Status,
-    _neighbors: *const fn (*const Ip6Protocol, bool, *const Ip6Address, ?*const MacAddress, u32, bool) callconv(.C) Status,
-    _transmit: *const fn (*const Ip6Protocol, *Ip6CompletionToken) callconv(.C) Status,
-    _receive: *const fn (*const Ip6Protocol, *Ip6CompletionToken) callconv(.C) Status,
-    _cancel: *const fn (*const Ip6Protocol, ?*Ip6CompletionToken) callconv(.C) Status,
-    _poll: *const fn (*const Ip6Protocol) callconv(.C) Status,
+    _get_mode_data: *const fn (*const Ip6Protocol, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(cc) Status,
+    _configure: *const fn (*const Ip6Protocol, ?*const Ip6ConfigData) callconv(cc) Status,
+    _groups: *const fn (*const Ip6Protocol, bool, ?*const Ip6Address) callconv(cc) Status,
+    _routes: *const fn (*const Ip6Protocol, bool, ?*const Ip6Address, u8, ?*const Ip6Address) callconv(cc) Status,
+    _neighbors: *const fn (*const Ip6Protocol, bool, *const Ip6Address, ?*const MacAddress, u32, bool) callconv(cc) Status,
+    _transmit: *const fn (*const Ip6Protocol, *Ip6CompletionToken) callconv(cc) Status,
+    _receive: *const fn (*const Ip6Protocol, *Ip6CompletionToken) callconv(cc) Status,
+    _cancel: *const fn (*const Ip6Protocol, ?*Ip6CompletionToken) callconv(cc) Status,
+    _poll: *const fn (*const Ip6Protocol) callconv(cc) Status,
 
     /// Gets the current operational settings for this instance of the EFI IPv6 Protocol driver.
     pub fn getModeData(self: *const Ip6Protocol, ip6_mode_data: ?*Ip6ModeData, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) Status {

--- a/lib/std/os/uefi/protocols/ip6_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_service_binding_protocol.zig
@@ -3,10 +3,11 @@ const uefi = std.os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 pub const Ip6ServiceBindingProtocol = extern struct {
-    _create_child: *const fn (*const Ip6ServiceBindingProtocol, *?Handle) callconv(.C) Status,
-    _destroy_child: *const fn (*const Ip6ServiceBindingProtocol, Handle) callconv(.C) Status,
+    _create_child: *const fn (*const Ip6ServiceBindingProtocol, *?Handle) callconv(cc) Status,
+    _destroy_child: *const fn (*const Ip6ServiceBindingProtocol, Handle) callconv(cc) Status,
 
     pub fn createChild(self: *const Ip6ServiceBindingProtocol, handle: *?Handle) Status {
         return self._create_child(self, handle);

--- a/lib/std/os/uefi/protocols/loaded_image_protocol.zig
+++ b/lib/std/os/uefi/protocols/loaded_image_protocol.zig
@@ -6,6 +6,7 @@ const Status = uefi.Status;
 const SystemTable = uefi.tables.SystemTable;
 const MemoryType = uefi.tables.MemoryType;
 const DevicePathProtocol = uefi.protocols.DevicePathProtocol;
+const cc = uefi.cc;
 
 pub const LoadedImageProtocol = extern struct {
     revision: u32,
@@ -20,7 +21,7 @@ pub const LoadedImageProtocol = extern struct {
     image_size: u64,
     image_code_type: MemoryType,
     image_data_type: MemoryType,
-    _unload: *const fn (*const LoadedImageProtocol, Handle) callconv(.C) Status,
+    _unload: *const fn (*const LoadedImageProtocol, Handle) callconv(cc) Status,
 
     /// Unloads an image from memory.
     pub fn unload(self: *const LoadedImageProtocol, handle: Handle) Status {

--- a/lib/std/os/uefi/protocols/managed_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/managed_network_protocol.zig
@@ -6,16 +6,17 @@ const Status = uefi.Status;
 const Time = uefi.Time;
 const SimpleNetworkMode = uefi.protocols.SimpleNetworkMode;
 const MacAddress = uefi.protocols.MacAddress;
+const cc = uefi.cc;
 
 pub const ManagedNetworkProtocol = extern struct {
-    _get_mode_data: *const fn (*const ManagedNetworkProtocol, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(.C) Status,
-    _configure: *const fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkConfigData) callconv(.C) Status,
-    _mcast_ip_to_mac: *const fn (*const ManagedNetworkProtocol, bool, *const anyopaque, *MacAddress) callconv(.C) Status,
-    _groups: *const fn (*const ManagedNetworkProtocol, bool, ?*const MacAddress) callconv(.C) Status,
-    _transmit: *const fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) callconv(.C) Status,
-    _receive: *const fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) callconv(.C) Status,
-    _cancel: *const fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkCompletionToken) callconv(.C) Status,
-    _poll: *const fn (*const ManagedNetworkProtocol) callconv(.C) Status,
+    _get_mode_data: *const fn (*const ManagedNetworkProtocol, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(cc) Status,
+    _configure: *const fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkConfigData) callconv(cc) Status,
+    _mcast_ip_to_mac: *const fn (*const ManagedNetworkProtocol, bool, *const anyopaque, *MacAddress) callconv(cc) Status,
+    _groups: *const fn (*const ManagedNetworkProtocol, bool, ?*const MacAddress) callconv(cc) Status,
+    _transmit: *const fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) callconv(cc) Status,
+    _receive: *const fn (*const ManagedNetworkProtocol, *const ManagedNetworkCompletionToken) callconv(cc) Status,
+    _cancel: *const fn (*const ManagedNetworkProtocol, ?*const ManagedNetworkCompletionToken) callconv(cc) Status,
+    _poll: *const fn (*const ManagedNetworkProtocol) callconv(cc) Status,
 
     /// Returns the operational parameters for the current MNP child driver.
     /// May also support returning the underlying SNP driver mode data.

--- a/lib/std/os/uefi/protocols/managed_network_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/managed_network_service_binding_protocol.zig
@@ -3,10 +3,11 @@ const uefi = std.os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 pub const ManagedNetworkServiceBindingProtocol = extern struct {
-    _create_child: *const fn (*const ManagedNetworkServiceBindingProtocol, *?Handle) callconv(.C) Status,
-    _destroy_child: *const fn (*const ManagedNetworkServiceBindingProtocol, Handle) callconv(.C) Status,
+    _create_child: *const fn (*const ManagedNetworkServiceBindingProtocol, *?Handle) callconv(cc) Status,
+    _destroy_child: *const fn (*const ManagedNetworkServiceBindingProtocol, Handle) callconv(cc) Status,
 
     pub fn createChild(self: *const ManagedNetworkServiceBindingProtocol, handle: *?Handle) Status {
         return self._create_child(self, handle);

--- a/lib/std/os/uefi/protocols/rng_protocol.zig
+++ b/lib/std/os/uefi/protocols/rng_protocol.zig
@@ -2,11 +2,12 @@ const std = @import("std");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 /// Random Number Generator protocol
 pub const RNGProtocol = extern struct {
-    _get_info: *const fn (*const RNGProtocol, *usize, [*]align(8) Guid) callconv(.C) Status,
-    _get_rng: *const fn (*const RNGProtocol, ?*align(8) const Guid, usize, [*]u8) callconv(.C) Status,
+    _get_info: *const fn (*const RNGProtocol, *usize, [*]align(8) Guid) callconv(cc) Status,
+    _get_rng: *const fn (*const RNGProtocol, ?*align(8) const Guid, usize, [*]u8) callconv(cc) Status,
 
     /// Returns information about the random number generation implementation.
     pub fn getInfo(self: *const RNGProtocol, list_size: *usize, list: [*]align(8) Guid) Status {

--- a/lib/std/os/uefi/protocols/simple_file_system_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_file_system_protocol.zig
@@ -3,10 +3,11 @@ const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const FileProtocol = uefi.protocols.FileProtocol;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 pub const SimpleFileSystemProtocol = extern struct {
     revision: u64,
-    _open_volume: *const fn (*const SimpleFileSystemProtocol, **const FileProtocol) callconv(.C) Status,
+    _open_volume: *const fn (*const SimpleFileSystemProtocol, **const FileProtocol) callconv(cc) Status,
 
     pub fn openVolume(self: *const SimpleFileSystemProtocol, root: **const FileProtocol) Status {
         return self._open_volume(self, root);

--- a/lib/std/os/uefi/protocols/simple_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_network_protocol.zig
@@ -3,22 +3,23 @@ const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 pub const SimpleNetworkProtocol = extern struct {
     revision: u64,
-    _start: *const fn (*const SimpleNetworkProtocol) callconv(.C) Status,
-    _stop: *const fn (*const SimpleNetworkProtocol) callconv(.C) Status,
-    _initialize: *const fn (*const SimpleNetworkProtocol, usize, usize) callconv(.C) Status,
-    _reset: *const fn (*const SimpleNetworkProtocol, bool) callconv(.C) Status,
-    _shutdown: *const fn (*const SimpleNetworkProtocol) callconv(.C) Status,
-    _receive_filters: *const fn (*const SimpleNetworkProtocol, SimpleNetworkReceiveFilter, SimpleNetworkReceiveFilter, bool, usize, ?[*]const MacAddress) callconv(.C) Status,
-    _station_address: *const fn (*const SimpleNetworkProtocol, bool, ?*const MacAddress) callconv(.C) Status,
-    _statistics: *const fn (*const SimpleNetworkProtocol, bool, ?*usize, ?*NetworkStatistics) callconv(.C) Status,
-    _mcast_ip_to_mac: *const fn (*const SimpleNetworkProtocol, bool, *const anyopaque, *MacAddress) callconv(.C) Status,
-    _nvdata: *const fn (*const SimpleNetworkProtocol, bool, usize, usize, [*]u8) callconv(.C) Status,
-    _get_status: *const fn (*const SimpleNetworkProtocol, *SimpleNetworkInterruptStatus, ?*?[*]u8) callconv(.C) Status,
-    _transmit: *const fn (*const SimpleNetworkProtocol, usize, usize, [*]const u8, ?*const MacAddress, ?*const MacAddress, ?*const u16) callconv(.C) Status,
-    _receive: *const fn (*const SimpleNetworkProtocol, ?*usize, *usize, [*]u8, ?*MacAddress, ?*MacAddress, ?*u16) callconv(.C) Status,
+    _start: *const fn (*const SimpleNetworkProtocol) callconv(cc) Status,
+    _stop: *const fn (*const SimpleNetworkProtocol) callconv(cc) Status,
+    _initialize: *const fn (*const SimpleNetworkProtocol, usize, usize) callconv(cc) Status,
+    _reset: *const fn (*const SimpleNetworkProtocol, bool) callconv(cc) Status,
+    _shutdown: *const fn (*const SimpleNetworkProtocol) callconv(cc) Status,
+    _receive_filters: *const fn (*const SimpleNetworkProtocol, SimpleNetworkReceiveFilter, SimpleNetworkReceiveFilter, bool, usize, ?[*]const MacAddress) callconv(cc) Status,
+    _station_address: *const fn (*const SimpleNetworkProtocol, bool, ?*const MacAddress) callconv(cc) Status,
+    _statistics: *const fn (*const SimpleNetworkProtocol, bool, ?*usize, ?*NetworkStatistics) callconv(cc) Status,
+    _mcast_ip_to_mac: *const fn (*const SimpleNetworkProtocol, bool, *const anyopaque, *MacAddress) callconv(cc) Status,
+    _nvdata: *const fn (*const SimpleNetworkProtocol, bool, usize, usize, [*]u8) callconv(cc) Status,
+    _get_status: *const fn (*const SimpleNetworkProtocol, *SimpleNetworkInterruptStatus, ?*?[*]u8) callconv(cc) Status,
+    _transmit: *const fn (*const SimpleNetworkProtocol, usize, usize, [*]const u8, ?*const MacAddress, ?*const MacAddress, ?*const u16) callconv(cc) Status,
+    _receive: *const fn (*const SimpleNetworkProtocol, ?*usize, *usize, [*]u8, ?*MacAddress, ?*MacAddress, ?*u16) callconv(cc) Status,
     wait_for_packet: Event,
     mode: *SimpleNetworkMode,
 

--- a/lib/std/os/uefi/protocols/simple_pointer_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_pointer_protocol.zig
@@ -3,11 +3,12 @@ const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 /// Protocol for mice
 pub const SimplePointerProtocol = struct {
-    _reset: *const fn (*const SimplePointerProtocol, bool) callconv(.C) Status,
-    _get_state: *const fn (*const SimplePointerProtocol, *SimplePointerState) callconv(.C) Status,
+    _reset: *const fn (*const SimplePointerProtocol, bool) callconv(cc) Status,
+    _get_state: *const fn (*const SimplePointerProtocol, *SimplePointerState) callconv(cc) Status,
     wait_for_input: Event,
     mode: *SimplePointerMode,
 

--- a/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
@@ -3,15 +3,16 @@ const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 /// Character input devices, e.g. Keyboard
 pub const SimpleTextInputExProtocol = extern struct {
-    _reset: *const fn (*const SimpleTextInputExProtocol, bool) callconv(.C) Status,
-    _read_key_stroke_ex: *const fn (*const SimpleTextInputExProtocol, *KeyData) callconv(.C) Status,
+    _reset: *const fn (*const SimpleTextInputExProtocol, bool) callconv(cc) Status,
+    _read_key_stroke_ex: *const fn (*const SimpleTextInputExProtocol, *KeyData) callconv(cc) Status,
     wait_for_key_ex: Event,
-    _set_state: *const fn (*const SimpleTextInputExProtocol, *const u8) callconv(.C) Status,
-    _register_key_notify: *const fn (*const SimpleTextInputExProtocol, *const KeyData, *const fn (*const KeyData) callconv(.C) usize, **anyopaque) callconv(.C) Status,
-    _unregister_key_notify: *const fn (*const SimpleTextInputExProtocol, *const anyopaque) callconv(.C) Status,
+    _set_state: *const fn (*const SimpleTextInputExProtocol, *const u8) callconv(cc) Status,
+    _register_key_notify: *const fn (*const SimpleTextInputExProtocol, *const KeyData, *const fn (*const KeyData) callconv(cc) usize, **anyopaque) callconv(cc) Status,
+    _unregister_key_notify: *const fn (*const SimpleTextInputExProtocol, *const anyopaque) callconv(cc) Status,
 
     /// Resets the input device hardware.
     pub fn reset(self: *const SimpleTextInputExProtocol, verify: bool) Status {
@@ -29,7 +30,7 @@ pub const SimpleTextInputExProtocol = extern struct {
     }
 
     /// Register a notification function for a particular keystroke for the input device.
-    pub fn registerKeyNotify(self: *const SimpleTextInputExProtocol, key_data: *const KeyData, notify: *const fn (*const KeyData) callconv(.C) usize, handle: **anyopaque) Status {
+    pub fn registerKeyNotify(self: *const SimpleTextInputExProtocol, key_data: *const KeyData, notify: *const fn (*const KeyData) callconv(cc) usize, handle: **anyopaque) Status {
         return self._register_key_notify(self, key_data, notify, handle);
     }
 

--- a/lib/std/os/uefi/protocols/simple_text_input_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_input_protocol.zig
@@ -4,11 +4,12 @@ const Event = uefi.Event;
 const Guid = uefi.Guid;
 const InputKey = uefi.protocols.InputKey;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 /// Character input devices, e.g. Keyboard
 pub const SimpleTextInputProtocol = extern struct {
-    _reset: *const fn (*const SimpleTextInputProtocol, bool) callconv(.C) Status,
-    _read_key_stroke: *const fn (*const SimpleTextInputProtocol, *InputKey) callconv(.C) Status,
+    _reset: *const fn (*const SimpleTextInputProtocol, bool) callconv(cc) Status,
+    _read_key_stroke: *const fn (*const SimpleTextInputProtocol, *InputKey) callconv(cc) Status,
     wait_for_key: Event,
 
     /// Resets the input device hardware.

--- a/lib/std/os/uefi/protocols/simple_text_output_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_output_protocol.zig
@@ -2,18 +2,19 @@ const std = @import("std");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 /// Character output devices
 pub const SimpleTextOutputProtocol = extern struct {
-    _reset: *const fn (*const SimpleTextOutputProtocol, bool) callconv(.C) Status,
-    _output_string: *const fn (*const SimpleTextOutputProtocol, [*:0]const u16) callconv(.C) Status,
-    _test_string: *const fn (*const SimpleTextOutputProtocol, [*:0]const u16) callconv(.C) Status,
-    _query_mode: *const fn (*const SimpleTextOutputProtocol, usize, *usize, *usize) callconv(.C) Status,
-    _set_mode: *const fn (*const SimpleTextOutputProtocol, usize) callconv(.C) Status,
-    _set_attribute: *const fn (*const SimpleTextOutputProtocol, usize) callconv(.C) Status,
-    _clear_screen: *const fn (*const SimpleTextOutputProtocol) callconv(.C) Status,
-    _set_cursor_position: *const fn (*const SimpleTextOutputProtocol, usize, usize) callconv(.C) Status,
-    _enable_cursor: *const fn (*const SimpleTextOutputProtocol, bool) callconv(.C) Status,
+    _reset: *const fn (*const SimpleTextOutputProtocol, bool) callconv(cc) Status,
+    _output_string: *const fn (*const SimpleTextOutputProtocol, [*:0]const u16) callconv(cc) Status,
+    _test_string: *const fn (*const SimpleTextOutputProtocol, [*:0]const u16) callconv(cc) Status,
+    _query_mode: *const fn (*const SimpleTextOutputProtocol, usize, *usize, *usize) callconv(cc) Status,
+    _set_mode: *const fn (*const SimpleTextOutputProtocol, usize) callconv(cc) Status,
+    _set_attribute: *const fn (*const SimpleTextOutputProtocol, usize) callconv(cc) Status,
+    _clear_screen: *const fn (*const SimpleTextOutputProtocol) callconv(cc) Status,
+    _set_cursor_position: *const fn (*const SimpleTextOutputProtocol, usize, usize) callconv(cc) Status,
+    _enable_cursor: *const fn (*const SimpleTextOutputProtocol, bool) callconv(cc) Status,
     mode: *SimpleTextOutputMode,
 
     /// Resets the text output device hardware.

--- a/lib/std/os/uefi/protocols/udp6_protocol.zig
+++ b/lib/std/os/uefi/protocols/udp6_protocol.zig
@@ -8,15 +8,16 @@ const Ip6ModeData = uefi.protocols.Ip6ModeData;
 const Ip6Address = uefi.protocols.Ip6Address;
 const ManagedNetworkConfigData = uefi.protocols.ManagedNetworkConfigData;
 const SimpleNetworkMode = uefi.protocols.SimpleNetworkMode;
+const cc = uefi.cc;
 
 pub const Udp6Protocol = extern struct {
-    _get_mode_data: *const fn (*const Udp6Protocol, ?*Udp6ConfigData, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(.C) Status,
-    _configure: *const fn (*const Udp6Protocol, ?*const Udp6ConfigData) callconv(.C) Status,
-    _groups: *const fn (*const Udp6Protocol, bool, ?*const Ip6Address) callconv(.C) Status,
-    _transmit: *const fn (*const Udp6Protocol, *Udp6CompletionToken) callconv(.C) Status,
-    _receive: *const fn (*const Udp6Protocol, *Udp6CompletionToken) callconv(.C) Status,
-    _cancel: *const fn (*const Udp6Protocol, ?*Udp6CompletionToken) callconv(.C) Status,
-    _poll: *const fn (*const Udp6Protocol) callconv(.C) Status,
+    _get_mode_data: *const fn (*const Udp6Protocol, ?*Udp6ConfigData, ?*Ip6ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(cc) Status,
+    _configure: *const fn (*const Udp6Protocol, ?*const Udp6ConfigData) callconv(cc) Status,
+    _groups: *const fn (*const Udp6Protocol, bool, ?*const Ip6Address) callconv(cc) Status,
+    _transmit: *const fn (*const Udp6Protocol, *Udp6CompletionToken) callconv(cc) Status,
+    _receive: *const fn (*const Udp6Protocol, *Udp6CompletionToken) callconv(cc) Status,
+    _cancel: *const fn (*const Udp6Protocol, ?*Udp6CompletionToken) callconv(cc) Status,
+    _poll: *const fn (*const Udp6Protocol) callconv(cc) Status,
 
     pub fn getModeData(self: *const Udp6Protocol, udp6_config_data: ?*Udp6ConfigData, ip6_mode_data: ?*Ip6ModeData, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) Status {
         return self._get_mode_data(self, udp6_config_data, ip6_mode_data, mnp_config_data, snp_mode_data);

--- a/lib/std/os/uefi/protocols/udp6_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/udp6_service_binding_protocol.zig
@@ -3,10 +3,11 @@ const uefi = std.os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;
 const Status = uefi.Status;
+const cc = uefi.cc;
 
 pub const Udp6ServiceBindingProtocol = extern struct {
-    _create_child: *const fn (*const Udp6ServiceBindingProtocol, *?Handle) callconv(.C) Status,
-    _destroy_child: *const fn (*const Udp6ServiceBindingProtocol, Handle) callconv(.C) Status,
+    _create_child: *const fn (*const Udp6ServiceBindingProtocol, *?Handle) callconv(cc) Status,
+    _destroy_child: *const fn (*const Udp6ServiceBindingProtocol, Handle) callconv(cc) Status,
 
     pub fn createChild(self: *const Udp6ServiceBindingProtocol, handle: *?Handle) Status {
         return self._create_child(self, handle);

--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -6,6 +6,7 @@ const Handle = uefi.Handle;
 const Status = uefi.Status;
 const TableHeader = uefi.tables.TableHeader;
 const DevicePathProtocol = uefi.protocols.DevicePathProtocol;
+const cc = uefi.cc;
 
 /// Boot services are services provided by the system's firmware until the operating system takes
 /// over control over the hardware by calling exitBootServices.
@@ -22,138 +23,140 @@ pub const BootServices = extern struct {
     hdr: TableHeader,
 
     /// Raises a task's priority level and returns its previous level.
-    raiseTpl: *const fn (new_tpl: usize) callconv(.C) usize,
+    raiseTpl: *const fn (new_tpl: usize) callconv(cc) usize,
 
     /// Restores a task's priority level to its previous value.
-    restoreTpl: *const fn (old_tpl: usize) callconv(.C) void,
+    restoreTpl: *const fn (old_tpl: usize) callconv(cc) void,
 
     /// Allocates memory pages from the system.
-    allocatePages: *const fn (alloc_type: AllocateType, mem_type: MemoryType, pages: usize, memory: *[*]align(4096) u8) callconv(.C) Status,
+    allocatePages: *const fn (alloc_type: AllocateType, mem_type: MemoryType, pages: usize, memory: *[*]align(4096) u8) callconv(cc) Status,
 
     /// Frees memory pages.
-    freePages: *const fn (memory: [*]align(4096) u8, pages: usize) callconv(.C) Status,
+    freePages: *const fn (memory: [*]align(4096) u8, pages: usize) callconv(cc) Status,
 
     /// Returns the current memory map.
-    getMemoryMap: *const fn (mmap_size: *usize, mmap: ?[*]MemoryDescriptor, mapKey: *usize, descriptor_size: *usize, descriptor_version: *u32) callconv(.C) Status,
+    getMemoryMap: *const fn (mmap_size: *usize, mmap: ?[*]MemoryDescriptor, mapKey: *usize, descriptor_size: *usize, descriptor_version: *u32) callconv(cc) Status,
 
     /// Allocates pool memory.
-    allocatePool: *const fn (pool_type: MemoryType, size: usize, buffer: *[*]align(8) u8) callconv(.C) Status,
+    allocatePool: *const fn (pool_type: MemoryType, size: usize, buffer: *[*]align(8) u8) callconv(cc) Status,
 
     /// Returns pool memory to the system.
-    freePool: *const fn (buffer: [*]align(8) u8) callconv(.C) Status,
+    freePool: *const fn (buffer: [*]align(8) u8) callconv(cc) Status,
 
     /// Creates an event.
-    createEvent: *const fn (type: u32, notify_tpl: usize, notify_func: ?*const fn (Event, ?*anyopaque) callconv(.C) void, notifyCtx: ?*const anyopaque, event: *Event) callconv(.C) Status,
+    createEvent: *const fn (type: u32, notify_tpl: usize, notify_func: ?*const fn (Event, ?*anyopaque) callconv(cc) void, notifyCtx: ?*const anyopaque, event: *Event) callconv(cc) Status,
 
     /// Sets the type of timer and the trigger time for a timer event.
-    setTimer: *const fn (event: Event, type: TimerDelay, triggerTime: u64) callconv(.C) Status,
+    setTimer: *const fn (event: Event, type: TimerDelay, triggerTime: u64) callconv(cc) Status,
 
     /// Stops execution until an event is signaled.
-    waitForEvent: *const fn (event_len: usize, events: [*]const Event, index: *usize) callconv(.C) Status,
+    waitForEvent: *const fn (event_len: usize, events: [*]const Event, index: *usize) callconv(cc) Status,
 
     /// Signals an event.
-    signalEvent: *const fn (event: Event) callconv(.C) Status,
+    signalEvent: *const fn (event: Event) callconv(cc) Status,
 
     /// Closes an event.
-    closeEvent: *const fn (event: Event) callconv(.C) Status,
+    closeEvent: *const fn (event: Event) callconv(cc) Status,
 
     /// Checks whether an event is in the signaled state.
-    checkEvent: *const fn (event: Event) callconv(.C) Status,
+    checkEvent: *const fn (event: Event) callconv(cc) Status,
 
     /// Installs a protocol interface on a device handle. If the handle does not exist, it is created
     /// and added to the list of handles in the system. installMultipleProtocolInterfaces()
     /// performs more error checking than installProtocolInterface(), so its use is recommended over this.
-    installProtocolInterface: *const fn (handle: Handle, protocol: *align(8) const Guid, interface_type: EfiInterfaceType, interface: *anyopaque) callconv(.C) Status,
+    installProtocolInterface: *const fn (handle: Handle, protocol: *align(8) const Guid, interface_type: EfiInterfaceType, interface: *anyopaque) callconv(cc) Status,
 
     /// Reinstalls a protocol interface on a device handle
-    reinstallProtocolInterface: *const fn (handle: Handle, protocol: *align(8) const Guid, old_interface: *anyopaque, new_interface: *anyopaque) callconv(.C) Status,
+    reinstallProtocolInterface: *const fn (handle: Handle, protocol: *align(8) const Guid, old_interface: *anyopaque, new_interface: *anyopaque) callconv(cc) Status,
 
     /// Removes a protocol interface from a device handle. Usage of
     /// uninstallMultipleProtocolInterfaces is recommended over this.
-    uninstallProtocolInterface: *const fn (handle: Handle, protocol: *align(8) const Guid, interface: *anyopaque) callconv(.C) Status,
+    uninstallProtocolInterface: *const fn (handle: Handle, protocol: *align(8) const Guid, interface: *anyopaque) callconv(cc) Status,
 
     /// Queries a handle to determine if it supports a specified protocol.
-    handleProtocol: *const fn (handle: Handle, protocol: *align(8) const Guid, interface: *?*anyopaque) callconv(.C) Status,
+    handleProtocol: *const fn (handle: Handle, protocol: *align(8) const Guid, interface: *?*anyopaque) callconv(cc) Status,
 
     reserved: *anyopaque,
 
     /// Creates an event that is to be signaled whenever an interface is installed for a specified protocol.
-    registerProtocolNotify: *const fn (protocol: *align(8) const Guid, event: Event, registration: **anyopaque) callconv(.C) Status,
+    registerProtocolNotify: *const fn (protocol: *align(8) const Guid, event: Event, registration: **anyopaque) callconv(cc) Status,
 
     /// Returns an array of handles that support a specified protocol.
-    locateHandle: *const fn (search_type: LocateSearchType, protocol: ?*align(8) const Guid, search_key: ?*const anyopaque, bufferSize: *usize, buffer: [*]Handle) callconv(.C) Status,
+    locateHandle: *const fn (search_type: LocateSearchType, protocol: ?*align(8) const Guid, search_key: ?*const anyopaque, bufferSize: *usize, buffer: [*]Handle) callconv(cc) Status,
 
     /// Locates the handle to a device on the device path that supports the specified protocol
-    locateDevicePath: *const fn (protocols: *align(8) const Guid, device_path: **const DevicePathProtocol, device: *?Handle) callconv(.C) Status,
+    locateDevicePath: *const fn (protocols: *align(8) const Guid, device_path: **const DevicePathProtocol, device: *?Handle) callconv(cc) Status,
 
     /// Adds, updates, or removes a configuration table entry from the EFI System Table.
-    installConfigurationTable: *const fn (guid: *align(8) const Guid, table: ?*anyopaque) callconv(.C) Status,
+    installConfigurationTable: *const fn (guid: *align(8) const Guid, table: ?*anyopaque) callconv(cc) Status,
 
     /// Loads an EFI image into memory.
-    loadImage: *const fn (boot_policy: bool, parent_image_handle: Handle, device_path: ?*const DevicePathProtocol, source_buffer: ?[*]const u8, source_size: usize, imageHandle: *?Handle) callconv(.C) Status,
+    loadImage: *const fn (boot_policy: bool, parent_image_handle: Handle, device_path: ?*const DevicePathProtocol, source_buffer: ?[*]const u8, source_size: usize, imageHandle: *?Handle) callconv(cc) Status,
 
     /// Transfers control to a loaded image's entry point.
-    startImage: *const fn (image_handle: Handle, exit_data_size: ?*usize, exit_data: ?*[*]u16) callconv(.C) Status,
+    startImage: *const fn (image_handle: Handle, exit_data_size: ?*usize, exit_data: ?*[*]u16) callconv(cc) Status,
 
     /// Terminates a loaded EFI image and returns control to boot services.
-    exit: *const fn (image_handle: Handle, exit_status: Status, exit_data_size: usize, exit_data: ?*const anyopaque) callconv(.C) Status,
+    exit: *const fn (image_handle: Handle, exit_status: Status, exit_data_size: usize, exit_data: ?*const anyopaque) callconv(cc) Status,
 
     /// Unloads an image.
-    unloadImage: *const fn (image_handle: Handle) callconv(.C) Status,
+    unloadImage: *const fn (image_handle: Handle) callconv(cc) Status,
 
     /// Terminates all boot services.
-    exitBootServices: *const fn (image_handle: Handle, map_key: usize) callconv(.C) Status,
+    exitBootServices: *const fn (image_handle: Handle, map_key: usize) callconv(cc) Status,
 
     /// Returns a monotonically increasing count for the platform.
-    getNextMonotonicCount: *const fn (count: *u64) callconv(.C) Status,
+    getNextMonotonicCount: *const fn (count: *u64) callconv(cc) Status,
 
     /// Induces a fine-grained stall.
-    stall: *const fn (microseconds: usize) callconv(.C) Status,
+    stall: *const fn (microseconds: usize) callconv(cc) Status,
 
     /// Sets the system's watchdog timer.
-    setWatchdogTimer: *const fn (timeout: usize, watchdogCode: u64, data_size: usize, watchdog_data: ?[*]const u16) callconv(.C) Status,
+    setWatchdogTimer: *const fn (timeout: usize, watchdogCode: u64, data_size: usize, watchdog_data: ?[*]const u16) callconv(cc) Status,
 
     /// Connects one or more drives to a controller.
-    connectController: *const fn (controller_handle: Handle, driver_image_handle: ?Handle, remaining_device_path: ?*DevicePathProtocol, recursive: bool) callconv(.C) Status,
+    connectController: *const fn (controller_handle: Handle, driver_image_handle: ?Handle, remaining_device_path: ?*DevicePathProtocol, recursive: bool) callconv(cc) Status,
 
     // Disconnects one or more drivers from a controller
-    disconnectController: *const fn (controller_handle: Handle, driver_image_handle: ?Handle, child_handle: ?Handle) callconv(.C) Status,
+    disconnectController: *const fn (controller_handle: Handle, driver_image_handle: ?Handle, child_handle: ?Handle) callconv(cc) Status,
 
     /// Queries a handle to determine if it supports a specified protocol.
-    openProtocol: *const fn (handle: Handle, protocol: *align(8) const Guid, interface: *?*anyopaque, agent_handle: ?Handle, controller_handle: ?Handle, attributes: OpenProtocolAttributes) callconv(.C) Status,
+    openProtocol: *const fn (handle: Handle, protocol: *align(8) const Guid, interface: *?*anyopaque, agent_handle: ?Handle, controller_handle: ?Handle, attributes: OpenProtocolAttributes) callconv(cc) Status,
 
     /// Closes a protocol on a handle that was opened using openProtocol().
-    closeProtocol: *const fn (handle: Handle, protocol: *align(8) const Guid, agentHandle: Handle, controller_handle: ?Handle) callconv(.C) Status,
+    closeProtocol: *const fn (handle: Handle, protocol: *align(8) const Guid, agentHandle: Handle, controller_handle: ?Handle) callconv(cc) Status,
 
     /// Retrieves the list of agents that currently have a protocol interface opened.
-    openProtocolInformation: *const fn (handle: Handle, protocol: *align(8) const Guid, entry_buffer: *[*]ProtocolInformationEntry, entry_count: *usize) callconv(.C) Status,
+    openProtocolInformation: *const fn (handle: Handle, protocol: *align(8) const Guid, entry_buffer: *[*]ProtocolInformationEntry, entry_count: *usize) callconv(cc) Status,
 
     /// Retrieves the list of protocol interface GUIDs that are installed on a handle in a buffer allocated from pool.
-    protocolsPerHandle: *const fn (handle: Handle, protocol_buffer: *[*]*align(8) const Guid, protocol_buffer_count: *usize) callconv(.C) Status,
+    protocolsPerHandle: *const fn (handle: Handle, protocol_buffer: *[*]*align(8) const Guid, protocol_buffer_count: *usize) callconv(cc) Status,
 
     /// Returns an array of handles that support the requested protocol in a buffer allocated from pool.
-    locateHandleBuffer: *const fn (search_type: LocateSearchType, protocol: ?*align(8) const Guid, search_key: ?*const anyopaque, num_handles: *usize, buffer: *[*]Handle) callconv(.C) Status,
+    locateHandleBuffer: *const fn (search_type: LocateSearchType, protocol: ?*align(8) const Guid, search_key: ?*const anyopaque, num_handles: *usize, buffer: *[*]Handle) callconv(cc) Status,
 
     /// Returns the first protocol instance that matches the given protocol.
-    locateProtocol: *const fn (protocol: *align(8) const Guid, registration: ?*const anyopaque, interface: *?*anyopaque) callconv(.C) Status,
+    locateProtocol: *const fn (protocol: *align(8) const Guid, registration: ?*const anyopaque, interface: *?*anyopaque) callconv(cc) Status,
 
     /// Installs one or more protocol interfaces into the boot services environment
+    // TODO: use callconv(cc) instead once that works
     installMultipleProtocolInterfaces: *const fn (handle: *Handle, ...) callconv(.C) Status,
 
     /// Removes one or more protocol interfaces into the boot services environment
+    // TODO: use callconv(cc) instead once that works
     uninstallMultipleProtocolInterfaces: *const fn (handle: *Handle, ...) callconv(.C) Status,
 
     /// Computes and returns a 32-bit CRC for a data buffer.
-    calculateCrc32: *const fn (data: [*]const u8, data_size: usize, *u32) callconv(.C) Status,
+    calculateCrc32: *const fn (data: [*]const u8, data_size: usize, *u32) callconv(cc) Status,
 
     /// Copies the contents of one buffer to another buffer
-    copyMem: *const fn (dest: [*]u8, src: [*]const u8, len: usize) callconv(.C) void,
+    copyMem: *const fn (dest: [*]u8, src: [*]const u8, len: usize) callconv(cc) void,
 
     /// Fills a buffer with a specified value
-    setMem: *const fn (buffer: [*]u8, size: usize, value: u8) callconv(.C) void,
+    setMem: *const fn (buffer: [*]u8, size: usize, value: u8) callconv(cc) void,
 
     /// Creates an event in a group.
-    createEventEx: *const fn (type: u32, notify_tpl: usize, notify_func: EfiEventNotify, notify_ctx: *const anyopaque, event_group: *align(8) const Guid, event: *Event) callconv(.C) Status,
+    createEventEx: *const fn (type: u32, notify_tpl: usize, notify_func: EfiEventNotify, notify_ctx: *const anyopaque, event_group: *align(8) const Guid, event: *Event) callconv(cc) Status,
 
     /// Opens a protocol with a structure as the loaded image for a UEFI application
     pub fn openProtocolSt(self: *BootServices, comptime protocol: type, handle: Handle) !*protocol {
@@ -191,7 +194,7 @@ pub const BootServices = extern struct {
     pub const tpl_high_level: usize = 31;
 };
 
-pub const EfiEventNotify = *const fn (event: Event, ctx: *anyopaque) callconv(.C) void;
+pub const EfiEventNotify = *const fn (event: Event, ctx: *anyopaque) callconv(cc) void;
 
 pub const TimerDelay = enum(u32) {
     TimerCancel,

--- a/lib/std/os/uefi/tables/runtime_services.zig
+++ b/lib/std/os/uefi/tables/runtime_services.zig
@@ -6,6 +6,7 @@ const Time = uefi.Time;
 const TimeCapabilities = uefi.TimeCapabilities;
 const Status = uefi.Status;
 const MemoryDescriptor = uefi.tables.MemoryDescriptor;
+const cc = uefi.cc;
 
 /// Runtime services are provided by the firmware before and after exitBootServices has been called.
 ///
@@ -19,50 +20,50 @@ pub const RuntimeServices = extern struct {
     hdr: TableHeader,
 
     /// Returns the current time and date information, and the time-keeping capabilities of the hardware platform.
-    getTime: *const fn (time: *uefi.Time, capabilities: ?*TimeCapabilities) callconv(.C) Status,
+    getTime: *const fn (time: *uefi.Time, capabilities: ?*TimeCapabilities) callconv(cc) Status,
 
     /// Sets the current local time and date information
-    setTime: *const fn (time: *uefi.Time) callconv(.C) Status,
+    setTime: *const fn (time: *uefi.Time) callconv(cc) Status,
 
     /// Returns the current wakeup alarm clock setting
-    getWakeupTime: *const fn (enabled: *bool, pending: *bool, time: *uefi.Time) callconv(.C) Status,
+    getWakeupTime: *const fn (enabled: *bool, pending: *bool, time: *uefi.Time) callconv(cc) Status,
 
     /// Sets the system wakeup alarm clock time
-    setWakeupTime: *const fn (enable: *bool, time: ?*uefi.Time) callconv(.C) Status,
+    setWakeupTime: *const fn (enable: *bool, time: ?*uefi.Time) callconv(cc) Status,
 
     /// Changes the runtime addressing mode of EFI firmware from physical to virtual.
-    setVirtualAddressMap: *const fn (mmap_size: usize, descriptor_size: usize, descriptor_version: u32, virtual_map: [*]MemoryDescriptor) callconv(.C) Status,
+    setVirtualAddressMap: *const fn (mmap_size: usize, descriptor_size: usize, descriptor_version: u32, virtual_map: [*]MemoryDescriptor) callconv(cc) Status,
 
     /// Determines the new virtual address that is to be used on subsequent memory accesses.
-    convertPointer: *const fn (debug_disposition: usize, address: **anyopaque) callconv(.C) Status,
+    convertPointer: *const fn (debug_disposition: usize, address: **anyopaque) callconv(cc) Status,
 
     /// Returns the value of a variable.
-    getVariable: *const fn (var_name: [*:0]const u16, vendor_guid: *align(8) const Guid, attributes: ?*u32, data_size: *usize, data: ?*anyopaque) callconv(.C) Status,
+    getVariable: *const fn (var_name: [*:0]const u16, vendor_guid: *align(8) const Guid, attributes: ?*u32, data_size: *usize, data: ?*anyopaque) callconv(cc) Status,
 
     /// Enumerates the current variable names.
-    getNextVariableName: *const fn (var_name_size: *usize, var_name: [*:0]u16, vendor_guid: *align(8) Guid) callconv(.C) Status,
+    getNextVariableName: *const fn (var_name_size: *usize, var_name: [*:0]u16, vendor_guid: *align(8) Guid) callconv(cc) Status,
 
     /// Sets the value of a variable.
-    setVariable: *const fn (var_name: [*:0]const u16, vendor_guid: *align(8) const Guid, attributes: u32, data_size: usize, data: *anyopaque) callconv(.C) Status,
+    setVariable: *const fn (var_name: [*:0]const u16, vendor_guid: *align(8) const Guid, attributes: u32, data_size: usize, data: *anyopaque) callconv(cc) Status,
 
     /// Return the next high 32 bits of the platform's monotonic counter
-    getNextHighMonotonicCount: *const fn (high_count: *u32) callconv(.C) Status,
+    getNextHighMonotonicCount: *const fn (high_count: *u32) callconv(cc) Status,
 
     /// Resets the entire platform.
-    resetSystem: *const fn (reset_type: ResetType, reset_status: Status, data_size: usize, reset_data: ?*const anyopaque) callconv(.C) noreturn,
+    resetSystem: *const fn (reset_type: ResetType, reset_status: Status, data_size: usize, reset_data: ?*const anyopaque) callconv(cc) noreturn,
 
     /// Passes capsules to the firmware with both virtual and physical mapping.
     /// Depending on the intended consumption, the firmware may process the capsule immediately.
     /// If the payload should persist across a system reset, the reset value returned from
     /// `queryCapsuleCapabilities` must be passed into resetSystem and will cause the capsule
     /// to be processed by the firmware as part of the reset process.
-    updateCapsule: *const fn (capsule_header_array: **CapsuleHeader, capsule_count: usize, scatter_gather_list: EfiPhysicalAddress) callconv(.C) Status,
+    updateCapsule: *const fn (capsule_header_array: **CapsuleHeader, capsule_count: usize, scatter_gather_list: EfiPhysicalAddress) callconv(cc) Status,
 
     /// Returns if the capsule can be supported via `updateCapsule`
-    queryCapsuleCapabilities: *const fn (capsule_header_array: **CapsuleHeader, capsule_count: usize, maximum_capsule_size: *usize, resetType: ResetType) callconv(.C) Status,
+    queryCapsuleCapabilities: *const fn (capsule_header_array: **CapsuleHeader, capsule_count: usize, maximum_capsule_size: *usize, resetType: ResetType) callconv(cc) Status,
 
     /// Returns information about the EFI variables
-    queryVariableInfo: *const fn (attributes: *u32, maximum_variable_storage_size: *u64, remaining_variable_storage_size: *u64, maximum_variable_size: *u64) callconv(.C) Status,
+    queryVariableInfo: *const fn (attributes: *u32, maximum_variable_storage_size: *u64, remaining_variable_storage_size: *u64, maximum_variable_size: *u64) callconv(cc) Status,
 
     pub const signature: u64 = 0x56524553544e5552;
 };

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6628,7 +6628,7 @@ fn checkCallArgumentCount(
     const fn_params_len = func_ty_info.param_types.len;
     const args_len = total_args - @intFromBool(member_fn);
     if (func_ty_info.is_var_args) {
-        assert(func_ty_info.cc == .C);
+        assert(callConvSupportsVarArgs(func_ty_info.cc));
         if (total_args >= fn_params_len) return func_ty;
     } else if (fn_params_len == total_args) {
         return func_ty;
@@ -8917,6 +8917,41 @@ fn handleExternLibName(
     return sema.gpa.dupeZ(u8, lib_name);
 }
 
+/// These are calling conventions that are confirmed to work with variadic functions.
+/// Any calling conventions not included here are either not yet verified to work with variadic
+/// functions or there are no more other calling conventions that support variadic functions.
+const calling_conventions_supporting_var_args = [_]std.builtin.CallingConvention{
+    .C,
+};
+fn callConvSupportsVarArgs(cc: std.builtin.CallingConvention) bool {
+    return for (calling_conventions_supporting_var_args) |supported_cc| {
+        if (cc == supported_cc) return true;
+    } else false;
+}
+fn checkCallConvSupportsVarArgs(sema: *Sema, block: *Block, src: LazySrcLoc, cc: std.builtin.CallingConvention) CompileError!void {
+    const CallingConventionsSupportingVarArgsList = struct {
+        pub fn format(_: @This(), comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
+            _ = fmt;
+            _ = options;
+            for (calling_conventions_supporting_var_args, 0..) |cc_inner, i| {
+                if (i != 0)
+                    try writer.writeAll(", ");
+                try writer.print("'.{s}'", .{@tagName(cc_inner)});
+            }
+        }
+    };
+
+    if (!callConvSupportsVarArgs(cc)) {
+        const msg = msg: {
+            const msg = try sema.errMsg(block, src, "variadic function does not support '.{s}' calling convention", .{@tagName(cc)});
+            errdefer msg.destroy(sema.gpa);
+            try sema.errNote(block, src, msg, "supported calling conventions: {}", .{CallingConventionsSupportingVarArgsList{}});
+            break :msg msg;
+        };
+        return sema.failWithOwnedErrorMsg(msg);
+    }
+}
+
 const FuncLinkSection = union(enum) {
     generic,
     default,
@@ -8963,9 +8998,7 @@ fn funcCommon(
         if (is_generic) {
             return sema.fail(block, func_src, "generic function cannot be variadic", .{});
         }
-        if (cc.? != .C) {
-            return sema.fail(block, cc_src, "variadic function must have 'C' calling convention", .{});
-        }
+        try sema.checkCallConvSupportsVarArgs(block, cc_src, cc.?);
     }
 
     var destroy_fn_on_error = false;
@@ -20325,8 +20358,8 @@ fn zirReify(
 
             const is_var_args = is_var_args_val.toBool();
             const cc = mod.toEnum(std.builtin.CallingConvention, calling_convention_val);
-            if (is_var_args and cc != .C) {
-                return sema.fail(block, src, "varargs functions must have C calling convention", .{});
+            if (is_var_args) {
+                try sema.checkCallConvSupportsVarArgs(block, src, cc);
             }
 
             const alignment = alignment: {

--- a/test/cases/compile_errors/invalid_variadic_function.zig
+++ b/test/cases/compile_errors/invalid_variadic_function.zig
@@ -1,5 +1,6 @@
 fn foo(...) void {}
 fn bar(a: anytype, ...) callconv(a) void {}
+inline fn foo2(...) void {}
 
 comptime {
     _ = foo;
@@ -7,10 +8,16 @@ comptime {
 comptime {
     _ = bar;
 }
+comptime {
+    _ = foo2;
+}
 
 // error
 // backend=stage2
 // target=native
 //
-// :1:1: error: variadic function must have 'C' calling convention
+// :1:1: error: variadic function does not support '.Unspecified' calling convention
+// :1:1: note: supported calling conventions: '.C'
 // :2:1: error: generic function cannot be variadic
+// :1:1: error: variadic function does not support '.Inline' calling convention
+// :1:1: note: supported calling conventions: '.C'

--- a/test/cases/compile_errors/reify_type.Fn_with_is_var_args_true_and_non-C_callconv.zig
+++ b/test/cases/compile_errors/reify_type.Fn_with_is_var_args_true_and_non-C_callconv.zig
@@ -16,4 +16,5 @@ comptime {
 // backend=stage2
 // target=native
 //
-// :1:13: error: varargs functions must have C calling convention
+// :1:13: error: variadic function does not support '.Unspecified' calling convention
+// :1:13: note: supported calling conventions: '.C'


### PR DESCRIPTION
I tested this and this definitely compiles and these
changes were done programmatically but if there's still anything wrong
it shouldn't be hard to fix.
With this change it's going to be very easy to make further adjustments
to the calling conventions of all these external UEFI functions.

Closes #16309
