### PR TITLE
std.c: adding linger struct socket option value for most unixes.

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -4173,3 +4173,8 @@ pub const utsname = extern struct {
 };
 
 pub extern "c" fn uname(u: *utsname) c_int;
+
+pub const linger = extern struct {
+    l_onoff: i32,
+    l_linger: i32,
+};

--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -1165,3 +1165,8 @@ pub const sigevent = extern struct {
 pub const PTHREAD_STACK_MIN = 16 * 1024;
 
 pub const timer_t = *opaque {};
+
+pub const linger = extern struct {
+    l_onoff: i32,
+    l_linger: i32,
+};

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -2838,3 +2838,8 @@ pub const utsname = extern struct {
 };
 
 pub extern "c" fn uname(u: *utsname) c_int;
+
+pub const linger = extern struct {
+    l_onoff: i32,
+    l_linger: i32,
+};

--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -1073,3 +1073,8 @@ pub const sigevent = extern struct {
 pub const PTHREAD_STACK_MIN = 2 * 4096;
 
 pub extern "c" fn malloc_usable_size(?*anyopaque) usize;
+
+pub const linger = extern struct {
+    l_onoff: i32,
+    l_linger: i32,
+};

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -1741,3 +1741,8 @@ pub extern "c" fn ptrace(request: c_int, pid: pid_t, addr: ?*anyopaque, data: c_
 pub const PTHREAD_STACK_MIN = 16 * 1024;
 
 pub const timer_t = *opaque {};
+
+pub const linger = extern struct {
+    l_onoff: i32,
+    l_linger: i32,
+};

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -1651,3 +1651,8 @@ pub const PTHREAD_STACK_MIN = switch (builtin.cpu.arch) {
     .mips64 => 1 << 14,
     else => 1 << 12,
 };
+
+pub const linger = extern struct {
+    l_onoff: i32,
+    l_linger: i32,
+};

--- a/lib/std/c/solaris.zig
+++ b/lib/std/c/solaris.zig
@@ -1950,3 +1950,8 @@ pub const sigevent = extern struct {
 pub const PTHREAD_STACK_MIN = if (@sizeOf(usize) == 8) 8 * 1024 else 4 * 1024;
 
 pub const timer_t = *opaque {};
+
+pub const linger = extern struct {
+    l_onoff: i32,
+    l_linger: i32,
+};

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -5900,3 +5900,8 @@ pub const PTRACE = struct {
     pub const SECCOMP_GET_METADATA = 0x420d;
     pub const GET_SYSCALL_INFO = 0x420e;
 };
+
+pub const linger = extern struct {
+    l_onoff: i32,
+    l_linger: i32,
+};


### PR DESCRIPTION
when `SO_LINGER` is defined, it makes sense to have its related value type.
Now the linger type is fairly common across the board, using a signed int for its members except win32 (MSVC, cygwin, mingw...) using unsigned short (already defined in [std.os.windows] (https://github.com/ziglang/zig/blob/2e424e019f6e7e12656a045ed4b9804f786dede9/lib/std/os/windows/ws2_32.zig#L1068)).