### PR TITLE
Emit check for memory intrinsics for WebAssembly

### DIFF
--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -230,6 +230,10 @@ pub const build_cases = [_]BuildCase{
         .build_root = "test/standalone/cmakedefine",
         .import = @import("standalone/cmakedefine/build.zig"),
     },
+    .{
+        .build_root = "test/standalone/zerolength_check",
+        .import = @import("standalone/zerolength_check/build.zig"),
+    },
 };
 
 const std = @import("std");

--- a/test/standalone/zerolength_check/build.zig
+++ b/test/standalone/zerolength_check/build.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    add(b, test_step, .Debug);
+    add(b, test_step, .ReleaseFast);
+    add(b, test_step, .ReleaseSmall);
+    add(b, test_step, .ReleaseSafe);
+}
+
+fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
+    const unit_tests = b.addTest(.{
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = .{
+            .os_tag = .wasi,
+            .cpu_arch = .wasm32,
+            .cpu_features_add = std.Target.wasm.featureSet(&.{.bulk_memory}),
+        },
+        .optimize = optimize,
+    });
+
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+    run_unit_tests.skip_foreign_checks = true;
+    test_step.dependOn(&run_unit_tests.step);
+}

--- a/test/standalone/zerolength_check/src/main.zig
+++ b/test/standalone/zerolength_check/src/main.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+
+test {
+    var dest = foo();
+    var source = foo();
+
+    @memcpy(dest, source);
+    @memset(dest, 4);
+    @memset(dest, undefined);
+
+    var dest2 = foo2();
+    @memset(dest2, 0);
+}
+
+fn foo() []u8 {
+    const ptr = comptime std.mem.alignBackward(usize, std.math.maxInt(usize), 1);
+    return @as([*]align(1) u8, @ptrFromInt(ptr))[0..0];
+}
+
+fn foo2() []u64 {
+    const ptr = comptime std.mem.alignBackward(usize, std.math.maxInt(usize), 1);
+    return @as([*]align(1) u64, @ptrFromInt(ptr))[0..0];
+}


### PR DESCRIPTION
Originally, in WebAssembly, a zero-length `memory.copy` or `memory.fill` would [not result in a trap](https://github.com/WebAssembly/bulk-memory-operations/issues/97) for zero-length out-of-bounds operations. Unfortunately, that decision was reverted, and now any out-of-bounds memory operations regardless of length [will trap instead](https://github.com/WebAssembly/bulk-memory-operations/issues/124). [Attempts](https://github.com/WebAssembly/bulk-memory-operations/issues/145) were made to convince the committee to not trap on zero-length operations, but due to simplicity reasons, the status quo remains. 

The intended semantics of Zig is to not panic/UB for `@memcpy` and `@memset` when the length is 0. For this reason, this PR adds a safety check for the WebAssembly target to verify the length is non-zero. This check is ***only*** emitted when the CPU feature `bulk-memory` is enabled.

This PR is a prerequisite to getting all tests passing for the upcoming multi-thread test enablement for WASI. (Due to multi-threading requiring the feature `bulk-memory` to be enabled). For this reason, also, a standalone test was added as we do not yet have a test matrix with additional CPU features enabled. (This will be added in a follow-up PR, in which I will move this test case to a behavior test instead).

Closes #15920 

For now, this only emits the check in the LLVM backend.

