### PR TITLE
std.json: add generic hash map that parses/stringifies with arbitrary string keys

### DIFF
--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -69,7 +69,7 @@ pub const ObjectMap = @import("json/dynamic.zig").ObjectMap;
 pub const Array = @import("json/dynamic.zig").Array;
 pub const Value = @import("json/dynamic.zig").Value;
 
-pub const ArrayHashMapUnmanaged = @import("json/hashmap.zig").ArrayHashMapUnmanaged;
+pub const ArrayHashMap = @import("json/hashmap.zig").ArrayHashMap;
 
 pub const validate = @import("json/scanner.zig").validate;
 pub const Error = @import("json/scanner.zig").Error;

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -69,6 +69,8 @@ pub const ObjectMap = @import("json/dynamic.zig").ObjectMap;
 pub const Array = @import("json/dynamic.zig").Array;
 pub const Value = @import("json/dynamic.zig").Value;
 
+pub const ArrayHashMapUnmanaged = @import("json/hashmap.zig").ArrayHashMapUnmanaged;
+
 pub const validate = @import("json/scanner.zig").validate;
 pub const Error = @import("json/scanner.zig").Error;
 pub const reader = @import("json/scanner.zig").reader;
@@ -117,6 +119,7 @@ test {
     _ = @import("json/scanner.zig");
     _ = @import("json/write_stream.zig");
     _ = @import("json/dynamic.zig");
+    _ = @import("json/hashmap_test.zig");
     _ = @import("json/static.zig");
     _ = @import("json/stringify.zig");
     _ = @import("json/JSONTestSuite_test.zig");

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -91,6 +91,7 @@ pub const parseFromTokenSourceLeaky = @import("json/static.zig").parseFromTokenS
 pub const innerParse = @import("json/static.zig").innerParse;
 pub const parseFromValue = @import("json/static.zig").parseFromValue;
 pub const parseFromValueLeaky = @import("json/static.zig").parseFromValueLeaky;
+pub const innerParseFromValue = @import("json/static.zig").innerParseFromValue;
 pub const ParseError = @import("json/static.zig").ParseError;
 pub const ParseFromValueError = @import("json/static.zig").ParseFromValueError;
 

--- a/lib/std/json/hashmap.zig
+++ b/lib/std/json/hashmap.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const ParseOptions = @import("static.zig").ParseOptions;
+const innerParse = @import("static.zig").innerParse;
+const innerParseFromValue = @import("static.zig").innerParseFromValue;
+const Value = @import("dynamic.zig").Value;
+const StringifyOptions = @import("stringify.zig").StringifyOptions;
+const stringify = @import("stringify.zig").stringify;
+const encodeJsonString = @import("stringify.zig").encodeJsonString;
+
+/// A thin wrapper around `std.StringArrayHashMapUnmanaged` that implements
+/// `jsonParse`, `jsonParseFromValue`, and `jsonStringify`.
+/// This is useful when your JSON schema has an object with arbitrary data keys
+/// instead of comptime-known struct field names.
+pub fn ArrayHashMapUnmanaged(comptime T: type) type {
+    return struct {
+        map: std.StringArrayHashMapUnmanaged(T) = .{},
+
+        pub fn deinit(self: *@This(), allocator: Allocator) void {
+            self.map.deinit(allocator);
+        }
+
+        pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) !@This() {
+            var map = std.StringArrayHashMapUnmanaged(T){};
+            errdefer map.deinit(allocator);
+
+            if (.object_begin != try source.next()) return error.UnexpectedToken;
+            while (true) {
+                const token = try source.nextAlloc(allocator, .alloc_if_needed);
+                switch (token) {
+                    inline .string, .allocated_string => |k| {
+                        const gop = try map.getOrPut(allocator, k);
+                        if (token == .allocated_string) {
+                            // Free the key before recursing in case we're using an allocator
+                            // that optimizes freeing the last allocated object.
+                            allocator.free(k);
+                        }
+                        if (gop.found_existing) {
+                            switch (options.duplicate_field_behavior) {
+                                .use_first => {
+                                    // Parse and ignore the redundant value.
+                                    // We don't want to skip the value, because we want type checking.
+                                    _ = try innerParse(T, allocator, source, options);
+                                    continue;
+                                },
+                                .@"error" => return error.DuplicateField,
+                                .use_last => {},
+                            }
+                        }
+                        gop.value_ptr.* = try innerParse(T, allocator, source, options);
+                    },
+                    .object_end => break,
+                    else => unreachable,
+                }
+            }
+            return .{ .map = map };
+        }
+
+        pub fn jsonParseFromValue(allocator: Allocator, source: Value, options: ParseOptions) !@This() {
+            if (source != .object) return error.UnexpectedToken;
+
+            var map = std.StringArrayHashMapUnmanaged(T){};
+            errdefer map.deinit(allocator);
+
+            var it = source.object.iterator();
+            while (it.next()) |kv| {
+                try map.put(allocator, kv.key_ptr.*, try innerParseFromValue(T, allocator, kv.value_ptr.*, options));
+            }
+            return .{ .map = map };
+        }
+
+        pub fn jsonStringify(self: @This(), options: StringifyOptions, out_stream: anytype) !void {
+            try out_stream.writeByte('{');
+            var field_output = false;
+            var child_options = options;
+            child_options.whitespace.indent_level += 1;
+            var it = self.map.iterator();
+            while (it.next()) |kv| {
+                if (!field_output) {
+                    field_output = true;
+                } else {
+                    try out_stream.writeByte(',');
+                }
+                try child_options.whitespace.outputIndent(out_stream);
+                try encodeJsonString(kv.key_ptr.*, options, out_stream);
+                try out_stream.writeByte(':');
+                if (child_options.whitespace.separator) {
+                    try out_stream.writeByte(' ');
+                }
+                try stringify(kv.value_ptr.*, child_options, out_stream);
+            }
+            if (field_output) {
+                try options.whitespace.outputIndent(out_stream);
+            }
+            try out_stream.writeByte('}');
+        }
+    };
+}
+
+test {
+    _ = @import("hashmap_test.zig");
+}

--- a/lib/std/json/hashmap.zig
+++ b/lib/std/json/hashmap.zig
@@ -13,7 +13,7 @@ const encodeJsonString = @import("stringify.zig").encodeJsonString;
 /// `jsonParse`, `jsonParseFromValue`, and `jsonStringify`.
 /// This is useful when your JSON schema has an object with arbitrary data keys
 /// instead of comptime-known struct field names.
-pub fn ArrayHashMapUnmanaged(comptime T: type) type {
+pub fn ArrayHashMap(comptime T: type) type {
     return struct {
         map: std.StringArrayHashMapUnmanaged(T) = .{},
 

--- a/lib/std/json/hashmap_test.zig
+++ b/lib/std/json/hashmap_test.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const testing = std.testing;
 
-const ArrayHashMapUnmanaged = @import("hashmap.zig").ArrayHashMapUnmanaged;
+const ArrayHashMap = @import("hashmap.zig").ArrayHashMap;
 
 const parseFromSlice = @import("static.zig").parseFromSlice;
 const parseFromSliceLeaky = @import("static.zig").parseFromSliceLeaky;
@@ -21,7 +21,7 @@ test "parse json hashmap" {
         \\  "xyz": {"i": 1, "s": "w"}
         \\}
     ;
-    const parsed = try parseFromSlice(ArrayHashMapUnmanaged(T), testing.allocator, doc, .{});
+    const parsed = try parseFromSlice(ArrayHashMap(T), testing.allocator, doc, .{});
     defer parsed.deinit();
 
     try testing.expectEqual(@as(usize, 2), parsed.value.map.count());
@@ -40,17 +40,17 @@ test "parse json hashmap duplicate fields" {
         \\}
     ;
 
-    try testing.expectError(error.DuplicateField, parseFromSliceLeaky(ArrayHashMapUnmanaged(T), arena.allocator(), doc, .{
+    try testing.expectError(error.DuplicateField, parseFromSliceLeaky(ArrayHashMap(T), arena.allocator(), doc, .{
         .duplicate_field_behavior = .@"error",
     }));
 
-    const first = try parseFromSliceLeaky(ArrayHashMapUnmanaged(T), arena.allocator(), doc, .{
+    const first = try parseFromSliceLeaky(ArrayHashMap(T), arena.allocator(), doc, .{
         .duplicate_field_behavior = .use_first,
     });
     try testing.expectEqual(@as(usize, 1), first.map.count());
     try testing.expectEqual(@as(i32, 0), first.map.get("abc").?.i);
 
-    const last = try parseFromSliceLeaky(ArrayHashMapUnmanaged(T), arena.allocator(), doc, .{
+    const last = try parseFromSliceLeaky(ArrayHashMap(T), arena.allocator(), doc, .{
         .duplicate_field_behavior = .use_last,
     });
     try testing.expectEqual(@as(usize, 1), last.map.count());
@@ -58,7 +58,7 @@ test "parse json hashmap duplicate fields" {
 }
 
 test "stringify json hashmap" {
-    var value = ArrayHashMapUnmanaged(T){};
+    var value = ArrayHashMap(T){};
     defer value.deinit(testing.allocator);
     {
         const doc = try stringifyAlloc(testing.allocator, value, .{});
@@ -95,7 +95,7 @@ test "stringify json hashmap" {
 }
 
 test "stringify json hashmap whitespace" {
-    var value = ArrayHashMapUnmanaged(T){};
+    var value = ArrayHashMap(T){};
     defer value.deinit(testing.allocator);
     try value.map.put(testing.allocator, "abc", .{ .i = 0, .s = "d" });
     try value.map.put(testing.allocator, "xyz", .{ .i = 1, .s = "w" });
@@ -132,7 +132,7 @@ test "json parse from value hashmap" {
     const parsed1 = try parseFromSlice(Value, testing.allocator, doc, .{});
     defer parsed1.deinit();
 
-    const parsed2 = try parseFromValue(ArrayHashMapUnmanaged(T), testing.allocator, parsed1.value, .{});
+    const parsed2 = try parseFromValue(ArrayHashMap(T), testing.allocator, parsed1.value, .{});
     defer parsed2.deinit();
 
     try testing.expectEqualStrings("d", parsed2.value.map.get("abc").?.s);

--- a/lib/std/json/hashmap_test.zig
+++ b/lib/std/json/hashmap_test.zig
@@ -1,0 +1,139 @@
+const std = @import("std");
+const testing = std.testing;
+
+const ArrayHashMapUnmanaged = @import("hashmap.zig").ArrayHashMapUnmanaged;
+
+const parseFromSlice = @import("static.zig").parseFromSlice;
+const parseFromSliceLeaky = @import("static.zig").parseFromSliceLeaky;
+const parseFromValue = @import("static.zig").parseFromValue;
+const stringifyAlloc = @import("stringify.zig").stringifyAlloc;
+const Value = @import("dynamic.zig").Value;
+
+const T = struct {
+    i: i32,
+    s: []const u8,
+};
+
+test "parse json hashmap" {
+    const doc =
+        \\{
+        \\  "abc": {"i": 0, "s": "d"},
+        \\  "xyz": {"i": 1, "s": "w"}
+        \\}
+    ;
+    const parsed = try parseFromSlice(ArrayHashMapUnmanaged(T), testing.allocator, doc, .{});
+    defer parsed.deinit();
+
+    try testing.expectEqual(@as(usize, 2), parsed.value.map.count());
+    try testing.expectEqualStrings("d", parsed.value.map.get("abc").?.s);
+    try testing.expectEqual(@as(i32, 1), parsed.value.map.get("xyz").?.i);
+}
+
+test "parse json hashmap duplicate fields" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const doc =
+        \\{
+        \\  "abc": {"i": 0, "s": "d"},
+        \\  "abc": {"i": 1, "s": "w"}
+        \\}
+    ;
+
+    try testing.expectError(error.DuplicateField, parseFromSliceLeaky(ArrayHashMapUnmanaged(T), arena.allocator(), doc, .{
+        .duplicate_field_behavior = .@"error",
+    }));
+
+    const first = try parseFromSliceLeaky(ArrayHashMapUnmanaged(T), arena.allocator(), doc, .{
+        .duplicate_field_behavior = .use_first,
+    });
+    try testing.expectEqual(@as(usize, 1), first.map.count());
+    try testing.expectEqual(@as(i32, 0), first.map.get("abc").?.i);
+
+    const last = try parseFromSliceLeaky(ArrayHashMapUnmanaged(T), arena.allocator(), doc, .{
+        .duplicate_field_behavior = .use_last,
+    });
+    try testing.expectEqual(@as(usize, 1), last.map.count());
+    try testing.expectEqual(@as(i32, 1), last.map.get("abc").?.i);
+}
+
+test "stringify json hashmap" {
+    var value = ArrayHashMapUnmanaged(T){};
+    defer value.deinit(testing.allocator);
+    {
+        const doc = try stringifyAlloc(testing.allocator, value, .{});
+        defer testing.allocator.free(doc);
+        try testing.expectEqualStrings("{}", doc);
+    }
+
+    try value.map.put(testing.allocator, "abc", .{ .i = 0, .s = "d" });
+    try value.map.put(testing.allocator, "xyz", .{ .i = 1, .s = "w" });
+
+    {
+        const doc = try stringifyAlloc(testing.allocator, value, .{});
+        defer testing.allocator.free(doc);
+        try testing.expectEqualStrings(
+            \\{"abc":{"i":0,"s":"d"},"xyz":{"i":1,"s":"w"}}
+        , doc);
+    }
+
+    try testing.expect(value.map.swapRemove("abc"));
+    {
+        const doc = try stringifyAlloc(testing.allocator, value, .{});
+        defer testing.allocator.free(doc);
+        try testing.expectEqualStrings(
+            \\{"xyz":{"i":1,"s":"w"}}
+        , doc);
+    }
+
+    try testing.expect(value.map.swapRemove("xyz"));
+    {
+        const doc = try stringifyAlloc(testing.allocator, value, .{});
+        defer testing.allocator.free(doc);
+        try testing.expectEqualStrings("{}", doc);
+    }
+}
+
+test "stringify json hashmap whitespace" {
+    var value = ArrayHashMapUnmanaged(T){};
+    defer value.deinit(testing.allocator);
+    try value.map.put(testing.allocator, "abc", .{ .i = 0, .s = "d" });
+    try value.map.put(testing.allocator, "xyz", .{ .i = 1, .s = "w" });
+
+    {
+        const doc = try stringifyAlloc(testing.allocator, value, .{
+            .whitespace = .{
+                .indent = .{ .space = 2 },
+            },
+        });
+        defer testing.allocator.free(doc);
+        try testing.expectEqualStrings(
+            \\{
+            \\  "abc": {
+            \\    "i": 0,
+            \\    "s": "d"
+            \\  },
+            \\  "xyz": {
+            \\    "i": 1,
+            \\    "s": "w"
+            \\  }
+            \\}
+        , doc);
+    }
+}
+
+test "json parse from value hashmap" {
+    const doc =
+        \\{
+        \\  "abc": {"i": 0, "s": "d"},
+        \\  "xyz": {"i": 1, "s": "w"}
+        \\}
+    ;
+    const parsed1 = try parseFromSlice(Value, testing.allocator, doc, .{});
+    defer parsed1.deinit();
+
+    const parsed2 = try parseFromValue(ArrayHashMapUnmanaged(T), testing.allocator, parsed1.value, .{});
+    defer parsed2.deinit();
+
+    try testing.expectEqualStrings("d", parsed2.value.map.get("abc").?.s);
+}


### PR DESCRIPTION
Inspired by @garrettlennoxbeck 's `JsonHashmap` here: https://github.com/garrettlennoxbeck/gotta_print_em_all/blob/7a2e79c10497c2a1f4cfad45bedb3eee628b8395/src/json.zig , this data structure can be used in the `parseFromSlice(T, ...)` system for objects that have arbitrary data keys rather than comptime known struct field names.

This PR also:
* exposes `innerParseFromValue` analogous to `innerParse` from https://github.com/ziglang/zig/pull/16312
* deletes unreachable "duplicate field" handling in `innerParseFromValue`.
* documents `parseFromValue`'s usage of the `options` object.

I ran into some of the same the trouble with `json.stringify` that @kristoff-it ran into here: https://github.com/ziglang/zig/blob/27a66191c271d2a8b1b6ebcbef0bbdeb8d389a38/src/Autodoc.zig#L948-L953

Potential improvement for another time ... :thinking: 