### PR TITLE
Sema: resolve field type layout for anon struct type info

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -17293,6 +17293,8 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
                                 } });
                             };
 
+                            try sema.resolveTypeLayout(field_ty.toType());
+
                             const is_comptime = field_val != .none;
                             const opt_default_val = if (is_comptime) field_val.toValue() else null;
                             const default_val_ptr = try sema.optRefValue(block, field_ty.toType(), opt_default_val);

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1712,3 +1712,14 @@ test "extern struct field pointer has correct alignment" {
     try S.doTheTest();
     try comptime S.doTheTest();
 }
+
+test "packed struct field in anonymous struct" {
+    const T = packed struct {
+        f1: bool = false,
+    };
+
+    try std.testing.expect(countFields(.{ .t = T{} }) == 1);
+}
+fn countFields(v: anytype) usize {
+    return @typeInfo(@TypeOf(v)).Struct.fields.len;
+}


### PR DESCRIPTION
Closes #16148

Previously, the layout of a type used in a field in an anonymous struct was not guaranteed to be resolved, which triggered a failing assertion when trying to get the alignment of packed struct fields as part of executing `@typeInfo`.

This change fixes the resulting compiler crash for the example originally given in the linked issue, my additional reduced example (also added as a behavior test), and a larger project where I was running into this issue.