### PR TITLE
remove arbitrary stderr size limit when spawning a child process tool

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4067,9 +4067,7 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.P
 
                 try child.spawn();
 
-                const stderr_reader = child.stderr.?.reader();
-
-                const stderr = try stderr_reader.readAllAlloc(arena, 10 * 1024 * 1024);
+                const stderr = try child.stderr.?.reader().readAllAlloc(arena, std.math.maxInt(usize));
 
                 const term = child.wait() catch |err| {
                     return comp.failCObj(c_object, "unable to spawn {s}: {s}", .{ argv.items[0], @errorName(err) });

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -545,7 +545,7 @@ pub fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
 
                 try child.spawn();
 
-                const stderr = try child.stderr.?.reader().readAllAlloc(arena, 10 * 1024 * 1024);
+                const stderr = try child.stderr.?.reader().readAllAlloc(arena, std.math.maxInt(usize));
 
                 const term = child.wait() catch |err| {
                     log.err("unable to spawn {s}: {s}", .{ argv.items[0], @errorName(err) });

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1949,7 +1949,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
 
                 try child.spawn();
 
-                const stderr = try child.stderr.?.reader().readAllAlloc(arena, 10 * 1024 * 1024);
+                const stderr = try child.stderr.?.reader().readAllAlloc(arena, std.math.maxInt(usize));
 
                 const term = child.wait() catch |err| {
                     log.err("unable to spawn {s}: {s}", .{ argv.items[0], @errorName(err) });

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -4529,7 +4529,7 @@ fn linkWithLLD(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) !
 
                 try child.spawn();
 
-                const stderr = try child.stderr.?.reader().readAllAlloc(arena, 10 * 1024 * 1024);
+                const stderr = try child.stderr.?.reader().readAllAlloc(arena, std.math.maxInt(usize));
 
                 const term = child.wait() catch |err| {
                     log.err("unable to spawn {s}: {s}", .{ argv.items[0], @errorName(err) });

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -379,10 +379,7 @@ pub fn buildImportLib(comp: *Compilation, lib_name: []const u8) !void {
 
         try child.spawn();
 
-        const stderr_reader = child.stderr.?.reader();
-
-        // TODO https://github.com/ziglang/zig/issues/6343
-        const stderr = try stderr_reader.readAllAlloc(arena, 10 * 1024 * 1024);
+        const stderr = try child.stderr.?.reader().readAllAlloc(arena, std.math.maxInt(usize));
 
         const term = child.wait() catch |err| {
             // TODO surface a proper error here


### PR DESCRIPTION
closes https://github.com/ziglang/zig/issues/16379

and remove a leftover link to a closed issue.