### PR TITLE
Fixes crash when a struct is given as the first parameter to the unionInit builtin

### DIFF
--- a/test/cases/compile_errors/union_init_with_struct_as_first_param.zig
+++ b/test/cases/compile_errors/union_init_with_struct_as_first_param.zig
@@ -1,0 +1,14 @@
+const S = struct {
+    a: u8,
+};
+
+export fn u() void {
+    _ = @unionInit(S, "a", 5);
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :6:20: error: expected union type, found 'tmp.S'
+// :1:11: note: struct declared here


### PR DESCRIPTION
Found this while fixing #16383. The compiler crashes inside the unionFields function on line 2001 when the type given to the ```@unionInit``` builtin is not a union. https://github.com/ziglang/zig/blob/6bc9c4f716afbb15465f79f84f61221f394fa5b6/src/type.zig#L2000-L2004

This PR adds as check to ```zirUnionInit```which checks wether or not the given type is a union.