### PR TITLE
macho: fix __unwind_info sentinel entry not always being the upper bound

### DIFF
--- a/src/link/MachO/UnwindInfo.zig
+++ b/src/link/MachO/UnwindInfo.zig
@@ -28,6 +28,9 @@ gpa: Allocator,
 records: std.ArrayListUnmanaged(macho.compact_unwind_entry) = .{},
 records_lookup: std.AutoHashMapUnmanaged(AtomIndex, RecordIndex) = .{},
 
+/// Upper bound (exclusive) of all the record ranges
+record_upper_bound: u32 = 0,
+
 /// List of all personalities referenced by either unwind info entries
 /// or __eh_frame entries.
 personalities: [max_personalities]SymbolWithLoc = undefined,
@@ -333,6 +336,7 @@ pub fn collect(info: *UnwindInfo, zld: *Zld) !void {
 
     var maybe_prev: ?macho.compact_unwind_entry = null;
     for (records.items, 0..) |record, i| {
+        info.record_upper_bound = @intCast(record.rangeStart + record.rangeLength);
         const record_id = blk: {
             if (maybe_prev) |prev| {
                 const is_dwarf = UnwindEncoding.isDwarf(record.compactUnwindEncoding, cpu_arch);
@@ -629,8 +633,7 @@ pub fn write(info: *UnwindInfo, zld: *Zld) !void {
         });
     }
 
-    const last_entry = info.records.items[info.records.items.len - 1];
-    const sentinel_address = @as(u32, @intCast(last_entry.rangeStart + last_entry.rangeLength));
+    const sentinel_address: u32 = @intCast(info.record_upper_bound + text_sect.addr - seg.vmaddr);
     try writer.writeStruct(macho.unwind_info_section_header_index_entry{
         .functionOffset = sentinel_address,
         .secondLevelPagesSectionOffset = 0,


### PR DESCRIPTION
If the last unwind info record was elided because it matched the preceding one, then the sentinel entry wouldn't take it into account. This change keeps track of the upper bound and use that instead of looking a the last added entry.

Question for @kubkon, are these records guaranteed to be sorted? ie. is `@max` needed?

For this code:
```
0000000000000380 <_frame1>:
     380: 48 83 ec 28                   subq    $40, %rsp
... snip ...
     41a: 66 0f 1f 44 00 00             nopw    (%rax,%rax)

0000000000000420 <_frame0>:
     420: 48 83 ec 28                   subq    $40, %rsp
... snip ...
     4bc: c3                            retq

Disassembly of section __TEXT,__cstring:

00000000000004bd <__cstring>:
     4bd: 43 3a 5c 63 79                cmpb    121(%r11,%r12,2), %bl
     4c2: 67 77 69                      ja      0x52e
     4c5: 6e                            outsb   (%rsi), %dx
```

Before:
```
  Top level indices: (count = 2)
    [0]: function offset=0x00000380, 2nd level page offset=0x00000034, LSDA offset=0x00000034
    [1]: function offset=0x00000420, 2nd level page offset=0x00000000, LSDA offset=0x00000034
  LSDA descriptors:
  Second level indices:
    Second level index[0]: offset in section=0x00000034, base function offset=0x00000380
      [0]: function offset=0x00000380, encoding[0]=0x02060000
```

After
```
  Top level indices: (count = 2)
    [0]: function offset=0x00000380, 2nd level page offset=0x00000034, LSDA offset=0x00000034
    [1]: function offset=0x000004bd, 2nd level page offset=0x00000000, LSDA offset=0x00000034
  LSDA descriptors:
  Second level indices:
    Second level index[0]: offset in section=0x00000034, base function offset=0x00000380
      Page encodings: (count = 1)
        encoding[0]: 0x02060000
      [0]: function offset=0x00000380, encoding[0]=0x02060000
```