### PR TITLE
std: add ELF parse'n'dump functionality to std.Build.Step.CheckObject

### DIFF
--- a/lib/std/Build/Step/CheckObject.zig
+++ b/lib/std/Build/Step/CheckObject.zig
@@ -815,6 +815,10 @@ const ElfDumper = struct {
             try writer.print("shdr {d}\n", .{shndx});
             try writer.print("name {s}\n", .{getSectionName(ctx, shndx)});
             try writer.print("type {s}\n", .{try fmtShType(ctx.gpa, shdr.sh_type)});
+            try writer.print("addr {x}\n", .{shdr.sh_addr});
+            try writer.print("offset {x}\n", .{shdr.sh_offset});
+            try writer.print("size {x}\n", .{shdr.sh_size});
+            try writer.print("addralign {x}\n", .{shdr.sh_addralign});
         }
     }
 

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -221,6 +221,58 @@ pub const DT_IA_64_NUM = 1;
 
 pub const DT_NIOS2_GP = 0x70000002;
 
+pub const DF_ORIGIN = 0x00000001;
+pub const DF_SYMBOLIC = 0x00000002;
+pub const DF_TEXTREL = 0x00000004;
+pub const DF_BIND_NOW = 0x00000008;
+pub const DF_STATIC_TLS = 0x00000010;
+
+pub const DF_1_NOW = 0x00000001;
+pub const DF_1_GLOBAL = 0x00000002;
+pub const DF_1_GROUP = 0x00000004;
+pub const DF_1_NODELETE = 0x00000008;
+pub const DF_1_LOADFLTR = 0x00000010;
+pub const DF_1_INITFIRST = 0x00000020;
+pub const DF_1_NOOPEN = 0x00000040;
+pub const DF_1_ORIGIN = 0x00000080;
+pub const DF_1_DIRECT = 0x00000100;
+pub const DF_1_TRANS = 0x00000200;
+pub const DF_1_INTERPOSE = 0x00000400;
+pub const DF_1_NODEFLIB = 0x00000800;
+pub const DF_1_NODUMP = 0x00001000;
+pub const DF_1_CONFALT = 0x00002000;
+pub const DF_1_ENDFILTEE = 0x00004000;
+pub const DF_1_DISPRELDNE = 0x00008000;
+pub const DF_1_DISPRELPND = 0x00010000;
+pub const DF_1_NODIRECT = 0x00020000;
+pub const DF_1_IGNMULDEF = 0x00040000;
+pub const DF_1_NOKSYMS = 0x00080000;
+pub const DF_1_NOHDR = 0x00100000;
+pub const DF_1_EDITED = 0x00200000;
+pub const DF_1_NORELOC = 0x00400000;
+pub const DF_1_SYMINTPOSE = 0x00800000;
+pub const DF_1_GLOBAUDIT = 0x01000000;
+pub const DF_1_SINGLETON = 0x02000000;
+pub const DF_1_STUB = 0x04000000;
+pub const DF_1_PIE = 0x08000000;
+
+pub const VERSYM_HIDDEN = 0x8000;
+pub const VERSYM_VERSION = 0x7fff;
+
+/// Symbol is local
+pub const VER_NDX_LOCAL = 0;
+/// Symbol is global
+pub const VER_NDX_GLOBAL = 1;
+/// Beginning of reserved entries
+pub const VER_NDX_LORESERVE = 0xff00;
+/// Symbol is to be eliminated
+pub const VER_NDX_ELIMINATE = 0xff01;
+
+/// Version definition of the file itself
+pub const VER_FLG_BASE = 1;
+/// Weak version identifier
+pub const VER_FLG_WEAK = 2;
+
 /// Program header table entry unused
 pub const PT_NULL = 0;
 /// Loadable program segment
@@ -298,6 +350,14 @@ pub const SHT_SYMTAB_SHNDX = 18;
 pub const SHT_LOOS = 0x60000000;
 /// LLVM address-significance table
 pub const SHT_LLVM_ADDRSIG = 0x6fff4c03;
+/// GNU hash table
+pub const SHT_GNU_HASH = 0x6ffffff6;
+/// GNU version definition table
+pub const SHT_GNU_VERDEF = 0x6ffffffd;
+/// GNU needed versions table
+pub const SHT_GNU_VERNEED = 0x6ffffffe;
+/// GNU symbol version table
+pub const SHT_GNU_VERSYM = 0x6fffffff;
 /// End of OS-specific
 pub const SHT_HIOS = 0x6fffffff;
 /// Start of processor-specific
@@ -368,9 +428,6 @@ pub const STT_HP_STUB = (STT_LOOS + 0x2);
 
 pub const STT_ARM_TFUNC = STT_LOPROC;
 pub const STT_ARM_16BIT = STT_HIPROC;
-
-pub const VER_FLG_BASE = 0x1;
-pub const VER_FLG_WEAK = 0x2;
 
 pub const MAGIC = "\x7fELF";
 


### PR DESCRIPTION
Dumping symtabs and relocs I will work out in a follow-up PR. For ELF it's a lot more interesting than other formats as depending on link context we can have more than 1 or even 2 symbol tables.