### PR TITLE
linker tests: add missing dependOn calls for CheckObject steps

### DIFF
--- a/test/link/macho/dead_strip/build.zig
+++ b/test/link/macho/dead_strip/build.zig
@@ -16,6 +16,7 @@ pub fn build(b: *std.Build) void {
         const check = exe.checkObject();
         check.checkInSymtab();
         check.checkNext("{*} (__TEXT,__text) external _iAmUnused");
+        test_step.dependOn(&check.step);
 
         const run = b.addRunArtifact(exe);
         run.skip_foreign_checks = true;
@@ -31,6 +32,7 @@ pub fn build(b: *std.Build) void {
         const check = exe.checkObject();
         check.checkInSymtab();
         check.checkNotPresent("{*} (__TEXT,__text) external _iAmUnused");
+        test_step.dependOn(&check.step);
 
         const run = b.addRunArtifact(exe);
         run.skip_foreign_checks = true;

--- a/test/link/macho/dylib/build.zig
+++ b/test/link/macho/dylib/build.zig
@@ -53,6 +53,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
 
     check_exe.checkStart("cmd RPATH");
     check_exe.checkNextFileSource("path", dylib.getOutputDirectorySource());
+    test_step.dependOn(&check_exe.step);
 
     const run = b.addRunArtifact(exe);
     run.skip_foreign_checks = true;

--- a/test/link/macho/entry/build.zig
+++ b/test/link/macho/entry/build.zig
@@ -34,6 +34,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     check_exe.checkNext("{n_value} (__TEXT,__text) external _non_main");
 
     check_exe.checkComputeCompare("vmaddr entryoff +", .{ .op = .eq, .value = .{ .variable = "n_value" } });
+    test_step.dependOn(&check_exe.step);
 
     const run = b.addRunArtifact(exe);
     run.skip_foreign_checks = true;

--- a/test/link/macho/entry_in_dylib/build.zig
+++ b/test/link/macho/entry_in_dylib/build.zig
@@ -47,6 +47,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .op = .eq,
         .value = .{ .variable = "stubs_vmaddr" }, // The entrypoint should be a synthetic stub
     });
+    test_step.dependOn(&check_exe.step);
 
     const run = b.addRunArtifact(exe);
     run.skip_foreign_checks = true;

--- a/test/link/macho/needed_library/build.zig
+++ b/test/link/macho/needed_library/build.zig
@@ -41,6 +41,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     const check = exe.checkObject();
     check.checkStart("cmd LOAD_DYLIB");
     check.checkNext("name @rpath/liba.dylib");
+    test_step.dependOn(&check.step);
 
     const run = b.addRunArtifact(exe);
     run.skip_foreign_checks = true;

--- a/test/link/macho/search_strategy/build.zig
+++ b/test/link/macho/search_strategy/build.zig
@@ -23,6 +23,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         const check = exe.checkObject();
         check.checkStart("cmd LOAD_DYLIB");
         check.checkNext("name @rpath/libsearch_dylibs_first.dylib");
+        test_step.dependOn(&check.step);
 
         const run = b.addRunArtifact(exe);
         run.skip_foreign_checks = true;

--- a/test/link/macho/stack_size/build.zig
+++ b/test/link/macho/stack_size/build.zig
@@ -27,6 +27,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     const check_exe = exe.checkObject();
     check_exe.checkStart("cmd MAIN");
     check_exe.checkNext("stacksize 100000000");
+    test_step.dependOn(&check_exe.step);
 
     const run = b.addRunArtifact(exe);
     run.skip_foreign_checks = true;

--- a/test/link/macho/strict_validation/build.zig
+++ b/test/link/macho/strict_validation/build.zig
@@ -121,6 +121,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         },
         else => unreachable,
     }
+    test_step.dependOn(&check_exe.step);
 
     const run = b.addRunArtifact(exe);
     run.skip_foreign_checks = true;

--- a/test/link/macho/unwind_info/build.zig
+++ b/test/link/macho/unwind_info/build.zig
@@ -46,6 +46,7 @@ fn testUnwindInfo(
 
     check.checkInSymtab();
     check.checkNext("{*} (__TEXT,__text) external ___gxx_personality_v0");
+    test_step.dependOn(&check.step);
 
     const run = b.addRunArtifact(exe);
     run.skip_foreign_checks = true;

--- a/test/link/macho/weak_library/build.zig
+++ b/test/link/macho/weak_library/build.zig
@@ -45,6 +45,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
 
     check.checkInSymtab();
     check.checkNext("(undefined) weak external _asStr (from liba)");
+    test_step.dependOn(&check.step);
 
     const run = b.addRunArtifact(exe);
     run.skip_foreign_checks = true;


### PR DESCRIPTION
I noticed that when editing some of these tests, they weren't actually running their `CheckObject` steps. This change adds the missing `dependOn` calls.