### PR TITLE
std.crypto.sha3: Minor TurboSHAKE/Keccak fixes

### DIFF
--- a/lib/std/crypto/keccak_p.zig
+++ b/lib/std/crypto/keccak_p.zig
@@ -56,7 +56,7 @@ pub fn KeccakF(comptime f: u11) type {
         /// Byte-swap the entire state if the architecture doesn't match the required endianness.
         pub fn endianSwap(self: *Self) void {
             for (&self.st) |*w| {
-                w.* = mem.littleTooNative(T, w.*);
+                w.* = mem.littleToNative(T, w.*);
             }
         }
 

--- a/lib/std/crypto/sha3.zig
+++ b/lib/std/crypto/sha3.zig
@@ -21,13 +21,14 @@ pub const Shake256 = Shake(256);
 /// TurboSHAKE128 is a XOF (a secure hash function with a variable output length), with a 128 bit security level.
 /// It is based on the same permutation as SHA3 and SHAKE128, but which much higher performance.
 /// The delimiter is 0x1f by default, but can be changed for context-separation.
+/// For a protocol that uses both KangarooTwelve and TurboSHAKE128, it is recommended to avoid using 0x06, 0x07 or 0x0b for the delimiter.
 pub fn TurboShake128(comptime delim: ?u8) type {
     return TurboShake(128, delim);
 }
 
 /// TurboSHAKE256 is a XOF (a secure hash function with a variable output length), with a 256 bit security level.
 /// It is based on the same permutation as SHA3 and SHAKE256, but which much higher performance.
-/// The delimiter is 0x01 by default, but can be changed for context-separation.
+/// The delimiter is 0x1f by default, but can be changed for context-separation.
 pub fn TurboShake256(comptime delim: ?u8) type {
     return TurboShake(256, delim);
 }
@@ -94,9 +95,14 @@ pub fn Shake(comptime security_level: u11) type {
 }
 
 /// The TurboSHAKE extendable output hash function.
-/// https://datatracker.ietf.org/doc/draft-irtf-cfrg-kangarootwelve/
+/// It is based on the same permutation as SHA3 and SHAKE, but which much higher performance.
+/// The delimiter is 0x1f by default, but can be changed for context-separation.
+/// https://eprint.iacr.org/2023/342
 pub fn TurboShake(comptime security_level: u11, comptime delim: ?u8) type {
-    return ShakeLike(security_level, delim orelse 0x1f, 12);
+    comptime assert(security_level <= 256);
+    const d = delim orelse 0x1f;
+    comptime assert(0x01 <= d and d <= 0x7f);
+    return ShakeLike(security_level, d, 12);
 }
 
 fn ShakeLike(comptime security_level: u11, comptime delim: u8, comptime rounds: u5) type {

--- a/lib/std/crypto/sha3.zig
+++ b/lib/std/crypto/sha3.zig
@@ -22,14 +22,14 @@ pub const Shake256 = Shake(256);
 /// It is based on the same permutation as SHA3 and SHAKE128, but which much higher performance.
 /// The delimiter is 0x1f by default, but can be changed for context-separation.
 /// For a protocol that uses both KangarooTwelve and TurboSHAKE128, it is recommended to avoid using 0x06, 0x07 or 0x0b for the delimiter.
-pub fn TurboShake128(comptime delim: ?u8) type {
+pub fn TurboShake128(comptime delim: ?u7) type {
     return TurboShake(128, delim);
 }
 
 /// TurboSHAKE256 is a XOF (a secure hash function with a variable output length), with a 256 bit security level.
 /// It is based on the same permutation as SHA3 and SHAKE256, but which much higher performance.
 /// The delimiter is 0x1f by default, but can be changed for context-separation.
-pub fn TurboShake256(comptime delim: ?u8) type {
+pub fn TurboShake256(comptime delim: ?u7) type {
     return TurboShake(256, delim);
 }
 
@@ -98,10 +98,10 @@ pub fn Shake(comptime security_level: u11) type {
 /// It is based on the same permutation as SHA3 and SHAKE, but which much higher performance.
 /// The delimiter is 0x1f by default, but can be changed for context-separation.
 /// https://eprint.iacr.org/2023/342
-pub fn TurboShake(comptime security_level: u11, comptime delim: ?u8) type {
+pub fn TurboShake(comptime security_level: u11, comptime delim: ?u7) type {
     comptime assert(security_level <= 256);
     const d = delim orelse 0x1f;
-    comptime assert(0x01 <= d and d <= 0x7f);
+    comptime assert(d >= 0x01); // delimiter must be >= 1
     return ShakeLike(security_level, d, 12);
 }
 


### PR DESCRIPTION
Just some very minor changes I'd noticed while using this:
- Semantic typo in KeccakF
- Typo in default delimiter for TurboShake256
- Recommendation to not use the same delimiter as K12 as per the paper
- Duplicate some useful docs as per doc comment guidance while this is already being changed
- Constrain security level and delimiter as per the paper
- Change URL ref to TurboSHAKE paper, now that it has its own