### PR TITLE
Force key allocation in streaming json parsing

### DIFF
--- a/lib/std/json/hashmap.zig
+++ b/lib/std/json/hashmap.zig
@@ -28,12 +28,6 @@ pub fn ArrayHashMap(comptime T: type) type {
                 switch (token) {
                     inline .string, .allocated_string => |k| {
                         const gop = try map.getOrPut(allocator, k);
-                        // Don't free the key if its allocation was intentional
-                        if (token == .allocated_string and options.allocate != .alloc_always) {
-                            // Free the key before recursing in case we're using an allocator
-                            // that optimizes freeing the last allocated object.
-                            allocator.free(k);
-                        }
                         if (gop.found_existing) {
                             switch (options.duplicate_field_behavior) {
                                 .use_first => {

--- a/lib/std/json/hashmap.zig
+++ b/lib/std/json/hashmap.zig
@@ -24,11 +24,12 @@ pub fn ArrayHashMap(comptime T: type) type {
 
             if (.object_begin != try source.next()) return error.UnexpectedToken;
             while (true) {
-                const token = try source.nextAlloc(allocator, .alloc_if_needed);
+                const token = try source.nextAlloc(allocator, options.allocate.?);
                 switch (token) {
                     inline .string, .allocated_string => |k| {
                         const gop = try map.getOrPut(allocator, k);
-                        if (token == .allocated_string) {
+                        // Don't free the key if its allocation was intentional
+                        if (token == .allocated_string and options.allocate != .alloc_always) {
                             // Free the key before recursing in case we're using an allocator
                             // that optimizes freeing the last allocated object.
                             allocator.free(k);

--- a/lib/std/json/hashmap_test.zig
+++ b/lib/std/json/hashmap_test.zig
@@ -5,9 +5,12 @@ const ArrayHashMap = @import("hashmap.zig").ArrayHashMap;
 
 const parseFromSlice = @import("static.zig").parseFromSlice;
 const parseFromSliceLeaky = @import("static.zig").parseFromSliceLeaky;
+const parseFromTokenSource = @import("static.zig").parseFromTokenSource;
 const parseFromValue = @import("static.zig").parseFromValue;
 const stringifyAlloc = @import("stringify.zig").stringifyAlloc;
 const Value = @import("dynamic.zig").Value;
+
+const jsonReader = @import("./scanner.zig").reader;
 
 const T = struct {
     i: i32,
@@ -23,6 +26,31 @@ test "parse json hashmap" {
     ;
     const parsed = try parseFromSlice(ArrayHashMap(T), testing.allocator, doc, .{});
     defer parsed.deinit();
+
+    try testing.expectEqual(@as(usize, 2), parsed.value.map.count());
+    try testing.expectEqualStrings("d", parsed.value.map.get("abc").?.s);
+    try testing.expectEqual(@as(i32, 1), parsed.value.map.get("xyz").?.i);
+}
+
+test "parse json hashmap while streaming" {
+    const doc =
+        \\{
+        \\  "abc": {"i": 0, "s": "d"},
+        \\  "xyz": {"i": 1, "s": "w"}
+        \\}
+    ;
+    var stream = std.io.fixedBufferStream(doc);
+    var json_reader = jsonReader(testing.allocator, stream.reader());
+
+    var parsed = try parseFromTokenSource(
+        ArrayHashMap(T),
+        testing.allocator,
+        &json_reader,
+        .{},
+    );
+    defer parsed.deinit();
+    // Deinit our reader to invalidate its buffer
+    json_reader.deinit();
 
     try testing.expectEqual(@as(usize, 2), parsed.value.map.count());
     try testing.expectEqualStrings("d", parsed.value.map.get("abc").?.s);


### PR DESCRIPTION
The ArrayHashMap Json parser added in #16366 does not propagate the `allocate` option added in #16312. This means that if a `Scanner` is used with `parseFromTokenSource*` function, use-after-free will occur with the keys, which will reference the Scanner's ephemeral buffer. This PR propagates this option, prevents keys from being freed if their allocation was intentional, and adds a test to demonstrate this behavior.
To see the issues the above behavior can cause, you can run the given test in `hashmap_test.zig` without applying the changes in `hashmap.zig`. The test will panic when attempting to access one of the keys, because the keys are now all `0xaa` after the scanner is invalidated, so no such key exists.
Please let me know if this solves the issue, or if this could cause other problems. Thank you.