### PR TITLE
Small documentation fixes on `std.crypto`

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8772,6 +8772,8 @@ test "integer cast panic" {
       <p>{#syntax#}dest{#endsyntax#} must be a mutable slice or a mutable pointer to an array.
       It may have any alignment, and it may have any element type.</p>
       <p>{#syntax#}elem{#endsyntax#} is coerced to the element type of {#syntax#}dest{#endsyntax#}.</p>
+      <p>For securely zeroing out sensitive contents from memory, you should use
+      {#syntax#}std.crypto.utils.secureZero{#endsyntax#}</p>
       {#header_close#}
 
       {#header_open|@min#}

--- a/lib/std/crypto/chacha20.zig
+++ b/lib/std/crypto/chacha20.zig
@@ -15,12 +15,12 @@ pub const ChaCha20IETF = ChaChaIETF(20);
 
 /// IETF-variant of the ChaCha20 stream cipher, reduced to 12 rounds.
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only with 8 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 12 rounds.
 pub const ChaCha12IETF = ChaChaIETF(12);
 
 /// IETF-variant of the ChaCha20 stream cipher, reduced to 8 rounds.
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only with 8 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 8 rounds.
 pub const ChaCha8IETF = ChaChaIETF(8);
 
 /// Original ChaCha20 stream cipher.
@@ -28,12 +28,12 @@ pub const ChaCha20With64BitNonce = ChaChaWith64BitNonce(20);
 
 /// Original ChaCha20 stream cipher, reduced to 12 rounds.
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only with 8 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 12 rounds.
 pub const ChaCha12With64BitNonce = ChaChaWith64BitNonce(12);
 
 /// Original ChaCha20 stream cipher, reduced to 8 rounds.
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only with 8 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 8 rounds.
 pub const ChaCha8With64BitNonce = ChaChaWith64BitNonce(8);
 
 /// XChaCha20 (nonce-extended version of the IETF ChaCha20 variant) stream cipher
@@ -41,12 +41,12 @@ pub const XChaCha20IETF = XChaChaIETF(20);
 
 /// XChaCha20 (nonce-extended version of the IETF ChaCha20 variant) stream cipher, reduced to 12 rounds
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only with 8 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 12 rounds.
 pub const XChaCha12IETF = XChaChaIETF(12);
 
 /// XChaCha20 (nonce-extended version of the IETF ChaCha20 variant) stream cipher, reduced to 8 rounds
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only with 8 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 8 rounds.
 pub const XChaCha8IETF = XChaChaIETF(8);
 
 /// ChaCha20-Poly1305 authenticated cipher, as designed for TLS
@@ -54,12 +54,12 @@ pub const ChaCha20Poly1305 = ChaChaPoly1305(20);
 
 /// ChaCha20-Poly1305 authenticated cipher, reduced to 12 rounds
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only with 8 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 12 rounds.
 pub const ChaCha12Poly1305 = ChaChaPoly1305(12);
 
 /// ChaCha20-Poly1305 authenticated cipher, reduced to 8 rounds
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only with 8 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 8 rounds.
 pub const ChaCha8Poly1305 = ChaChaPoly1305(8);
 
 /// XChaCha20-Poly1305 authenticated cipher
@@ -67,12 +67,12 @@ pub const XChaCha20Poly1305 = XChaChaPoly1305(20);
 
 /// XChaCha20-Poly1305 authenticated cipher
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only with 8 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 12 rounds.
 pub const XChaCha12Poly1305 = XChaChaPoly1305(12);
 
 /// XChaCha20-Poly1305 authenticated cipher
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only with 8 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 8 rounds.
 pub const XChaCha8Poly1305 = XChaChaPoly1305(8);
 
 // Vectorized implementation of the core function

--- a/lib/std/crypto/chacha20.zig
+++ b/lib/std/crypto/chacha20.zig
@@ -15,7 +15,7 @@ pub const ChaCha20IETF = ChaChaIETF(20);
 
 /// IETF-variant of the ChaCha20 stream cipher, reduced to 12 rounds.
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only 12 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 8 rounds.
 pub const ChaCha12IETF = ChaChaIETF(12);
 
 /// IETF-variant of the ChaCha20 stream cipher, reduced to 8 rounds.
@@ -28,7 +28,7 @@ pub const ChaCha20With64BitNonce = ChaChaWith64BitNonce(20);
 
 /// Original ChaCha20 stream cipher, reduced to 12 rounds.
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only 12 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 8 rounds.
 pub const ChaCha12With64BitNonce = ChaChaWith64BitNonce(12);
 
 /// Original ChaCha20 stream cipher, reduced to 8 rounds.
@@ -41,7 +41,7 @@ pub const XChaCha20IETF = XChaChaIETF(20);
 
 /// XChaCha20 (nonce-extended version of the IETF ChaCha20 variant) stream cipher, reduced to 12 rounds
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only 12 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 8 rounds.
 pub const XChaCha12IETF = XChaChaIETF(12);
 
 /// XChaCha20 (nonce-extended version of the IETF ChaCha20 variant) stream cipher, reduced to 8 rounds
@@ -54,7 +54,7 @@ pub const ChaCha20Poly1305 = ChaChaPoly1305(20);
 
 /// ChaCha20-Poly1305 authenticated cipher, reduced to 12 rounds
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only 12 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 8 rounds.
 pub const ChaCha12Poly1305 = ChaChaPoly1305(12);
 
 /// ChaCha20-Poly1305 authenticated cipher, reduced to 8 rounds
@@ -67,7 +67,7 @@ pub const XChaCha20Poly1305 = XChaChaPoly1305(20);
 
 /// XChaCha20-Poly1305 authenticated cipher
 /// Reduced-rounds versions are faster than the full-round version, but have a lower security margin.
-/// However, ChaCha is still believed to have a comfortable security even with only 12 rounds.
+/// However, ChaCha is still believed to have a comfortable security even with only 8 rounds.
 pub const XChaCha12Poly1305 = XChaChaPoly1305(12);
 
 /// XChaCha20-Poly1305 authenticated cipher


### PR DESCRIPTION
0. Suggested the use of `std.crypto.utils.secureZero` under the docs for `@memset`, as an alternative that won't be optimized away for zeroing sensitive contents from memory;
1. Fixed copy-pasted segments on the documentation of ChaCha variants which stated the wrong number of rounds for certain variants;

That is all!