### PR TITLE
wasm-linker: finish shared-memory & TLS implementation

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -65,6 +65,7 @@ sanitize_thread: bool,
 rdynamic: bool,
 dwarf_format: ?std.dwarf.Format = null,
 import_memory: bool = false,
+export_memory: bool = false,
 /// For WebAssembly targets, this will allow for undefined symbols to
 /// be imported from the host environment.
 import_symbols: bool = false,
@@ -1661,6 +1662,9 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     }
     if (self.import_memory) {
         try zig_args.append("--import-memory");
+    }
+    if (self.export_memory) {
+        try zig_args.append("--export-memory");
     }
     if (self.import_symbols) {
         try zig_args.append("--import-symbols");

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -2153,7 +2153,14 @@ fn allocateVirtualAddresses(wasm: *Wasm) void {
         const segment_name = segment_info[symbol.index].outputName(merge_segment);
         const segment_index = wasm.data_segments.get(segment_name).?;
         const segment = wasm.segments.items[segment_index];
-        symbol.virtual_address = atom.offset + segment.offset;
+
+        // TLS symbols have their virtual address set relative to their own TLS segment,
+        // rather than the entire Data section.
+        if (symbol.hasFlag(.WASM_SYM_TLS)) {
+            symbol.virtual_address = atom.offset;
+        } else {
+            symbol.virtual_address = atom.offset + segment.offset;
+        }
     }
 }
 

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -3519,6 +3519,7 @@ fn writeToFile(
 
     // Import section
     const import_memory = wasm.base.options.import_memory or is_obj;
+    const export_memory = wasm.base.options.export_memory;
     if (wasm.imports.count() != 0 or import_memory) {
         const header_offset = try reserveVecSectionHeader(&binary_bytes);
 
@@ -3621,7 +3622,7 @@ fn writeToFile(
     }
 
     // Export section
-    if (wasm.exports.items.len != 0 or !import_memory) {
+    if (wasm.exports.items.len != 0 or export_memory) {
         const header_offset = try reserveVecSectionHeader(&binary_bytes);
 
         for (wasm.exports.items) |exp| {
@@ -3632,7 +3633,7 @@ fn writeToFile(
             try leb.writeULEB128(binary_writer, exp.index);
         }
 
-        if (!import_memory) {
+        if (export_memory) {
             try leb.writeULEB128(binary_writer, @as(u32, @intCast("memory".len)));
             try binary_writer.writeAll("memory");
             try binary_writer.writeByte(std.wasm.externalKind(.memory));
@@ -3644,7 +3645,7 @@ fn writeToFile(
             header_offset,
             .@"export",
             @as(u32, @intCast(binary_bytes.items.len - header_offset - header_size)),
-            @as(u32, @intCast(wasm.exports.items.len)) + @intFromBool(!import_memory),
+            @as(u32, @intCast(wasm.exports.items.len)) + @intFromBool(export_memory),
         );
         section_count += 1;
     }

--- a/src/link/Wasm/Atom.zig
+++ b/src/link/Wasm/Atom.zig
@@ -174,14 +174,14 @@ fn relocationValue(atom: Atom, relocation: types.Relocation, wasm_bin: *const Wa
                 return 0;
             }
             const va = @as(i64, @intCast(symbol.virtual_address));
-            return @as(u32, @intCast(va + relocation.addend));
+            return @intCast(va + relocation.addend);
         },
         .R_WASM_EVENT_INDEX_LEB => return symbol.index,
         .R_WASM_SECTION_OFFSET_I32 => {
             const target_atom_index = wasm_bin.symbol_atom.get(target_loc).?;
             const target_atom = wasm_bin.getAtom(target_atom_index);
-            const rel_value = @as(i32, @intCast(target_atom.offset)) + relocation.addend;
-            return @as(u32, @intCast(rel_value));
+            const rel_value: i32 = @intCast(target_atom.offset);
+            return @intCast(rel_value + relocation.addend);
         },
         .R_WASM_FUNCTION_OFFSET_I32 => {
             const target_atom_index = wasm_bin.symbol_atom.get(target_loc) orelse {
@@ -189,13 +189,14 @@ fn relocationValue(atom: Atom, relocation: types.Relocation, wasm_bin: *const Wa
             };
             const target_atom = wasm_bin.getAtom(target_atom_index);
             const offset: u32 = 11 + Wasm.getULEB128Size(target_atom.size); // Header (11 bytes fixed-size) + body size (leb-encoded)
-            const rel_value = @as(i32, @intCast(target_atom.offset + offset)) + relocation.addend;
-            return @as(u32, @intCast(rel_value));
+            const rel_value: i32 = @intCast(target_atom.offset + offset);
+            return @intCast(rel_value + relocation.addend);
         },
         .R_WASM_MEMORY_ADDR_TLS_SLEB,
         .R_WASM_MEMORY_ADDR_TLS_SLEB64,
         => {
-            @panic("TODO: Implement TLS relocations");
+            const va: i32 = @intCast(symbol.virtual_address);
+            return @intCast(va + relocation.addend);
         },
     }
 }

--- a/src/link/Wasm/Object.zig
+++ b/src/link/Wasm/Object.zig
@@ -353,9 +353,14 @@ fn Parser(comptime ReaderType: type) type {
             var debug_names = std.ArrayList(u8).init(gpa);
 
             errdefer {
-                while (relocatable_data.popOrNull()) |rel_data| {
-                    gpa.free(rel_data.data[0..rel_data.size]);
-                } else relocatable_data.deinit();
+                // only free the inner contents of relocatable_data if we didn't
+                // assign it to the object yet.
+                if (parser.object.relocatable_data.len == 0) {
+                    for (relocatable_data.items) |rel_data| {
+                        gpa.free(rel_data.data[0..rel_data.size]);
+                    }
+                    relocatable_data.deinit();
+                }
                 gpa.free(debug_names.items);
                 debug_names.deinit();
             }

--- a/test/link/wasm/shared-memory/build.zig
+++ b/test/link/wasm/shared-memory/build.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test");
+    b.default_step = test_step;
+
+    add(b, test_step, .Debug);
+
+    // Enable the following build modes once garbage-collection is implemented properly.
+    // add(b, test_step, .ReleaseFast);
+    // add(b, test_step, .ReleaseSmall);
+    // add(b, test_step, .ReleaseSafe);
+}
+
+fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.OptimizeMode) void {
+    {
+        const lib = b.addSharedLibrary(.{
+            .name = "lib",
+            .root_source_file = .{ .path = "lib.zig" },
+            .target = .{
+                .cpu_arch = .wasm32,
+                .cpu_model = .{ .explicit = &std.Target.wasm.cpu.mvp },
+                .cpu_features_add = std.Target.wasm.featureSet(&.{ .atomics, .bulk_memory }),
+                .os_tag = .freestanding,
+            },
+            .optimize = optimize_mode,
+        });
+        lib.use_lld = false;
+        lib.strip = false;
+        lib.import_memory = true;
+        lib.export_memory = true;
+        lib.shared_memory = true;
+        lib.max_memory = 67108864;
+        lib.single_threaded = false;
+        lib.export_symbol_names = &.{"foo"};
+
+        const check_lib = lib.checkObject();
+
+        check_lib.checkStart("Section import");
+        check_lib.checkNext("entries 1");
+        check_lib.checkNext("module env");
+        check_lib.checkNext("name memory"); // ensure we are importing memory
+
+        check_lib.checkStart("Section export");
+        check_lib.checkNext("entries 2");
+        check_lib.checkNext("name memory"); // ensure we also export memory again
+
+        // This section *must* be emit as the start function is set to the index
+        // of __wasm_init_memory
+        check_lib.checkStart("Section start");
+
+        // This section is only and *must* be emit when shared-memory is enabled
+        check_lib.checkStart("Section data_count");
+        check_lib.checkNext("count 3");
+
+        check_lib.checkStart("Section custom");
+        check_lib.checkNext("name name");
+        check_lib.checkNext("type function");
+        check_lib.checkNext("name __wasm_init_memory");
+        check_lib.checkNext("name __wasm_init_tls");
+        check_lib.checkNext("type global");
+        check_lib.checkNext("name __tls_size");
+        check_lib.checkNext("name __tls_align");
+        check_lib.checkNext("name __tls_base");
+
+        check_lib.checkNext("type data_segment");
+        check_lib.checkNext("names 3");
+        check_lib.checkNext("index 0");
+        check_lib.checkNext("name .rodata");
+        check_lib.checkNext("index 1");
+        check_lib.checkNext("name .bss");
+        check_lib.checkNext("index 2");
+        check_lib.checkNext("name .tdata");
+
+        test_step.dependOn(&check_lib.step);
+    }
+}

--- a/test/link/wasm/shared-memory/lib.zig
+++ b/test/link/wasm/shared-memory/lib.zig
@@ -1,0 +1,5 @@
+threadlocal var some_tls_global: u32 = 1;
+
+export fn foo() void {
+    some_tls_global = 2;
+}


### PR DESCRIPTION
This fixes several bugs in the shared-memory implementation and adds TLS relocations which was the last component required to get the shared-memory linker feature fully working. 

With this PR, we can now use the self-hosted WebAssembly linker to link the threading example from: #16207 (i.e. appending `-fno-LLD` to the listed command).
