### PR TITLE
cbe: fix pointers to aliases of extern values

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -888,13 +888,17 @@ pub const Decl = struct {
         assert(decl.dependencies.swapRemove(other));
     }
 
-    pub fn isExtern(decl: Decl, mod: *Module) bool {
+    pub fn getExternDecl(decl: Decl, mod: *Module) OptionalIndex {
         assert(decl.has_tv);
         return switch (mod.intern_pool.indexToKey(decl.val.toIntern())) {
-            .variable => |variable| variable.is_extern,
-            .extern_func => true,
-            else => false,
+            .variable => |variable| if (variable.is_extern) variable.decl.toOptional() else .none,
+            .extern_func => |extern_func| extern_func.decl.toOptional(),
+            else => .none,
         };
+    }
+
+    pub fn isExtern(decl: Decl, mod: *Module) bool {
+        return decl.getExternDecl(mod) != .none;
     }
 
     pub fn getAlignment(decl: Decl, mod: *Module) u32 {

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1846,8 +1846,8 @@ pub const DeclGen = struct {
 
         if (mod.decl_exports.get(decl_index)) |exports| {
             try writer.print("{}", .{exports.items[export_index].opts.name.fmt(&mod.intern_pool)});
-        } else if (decl.isExtern(mod)) {
-            try writer.print("{}", .{decl.name.fmt(&mod.intern_pool)});
+        } else if (decl.getExternDecl(mod).unwrap()) |extern_decl_index| {
+            try writer.print("{}", .{mod.declPtr(extern_decl_index).name.fmt(&mod.intern_pool)});
         } else {
             // MSVC has a limit of 4095 character token length limit, and fmtIdent can (worst case),
             // expand to 3x the length of its input, but let's cut it off at a much shorter limit.


### PR DESCRIPTION
Fixes a bootstrap bug hacked around in #16430