### PR TITLE
Unlock the SingleThread limitation for ARM

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1034,15 +1034,6 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
         if (must_single_thread and !single_threaded) {
             return error.TargetRequiresSingleThreaded;
         }
-        if (!single_threaded and options.link_libcpp) {
-            if (options.target.cpu.arch.isARM()) {
-                log.warn(
-                    \\libc++ does not work on multi-threaded ARM yet.
-                    \\For more details: https://github.com/ziglang/zig/issues/6573
-                , .{});
-                return error.TargetRequiresSingleThreaded;
-            }
-        }
 
         const llvm_cpu_features: ?[*:0]const u8 = if (build_options.have_llvm and use_llvm) blk: {
             var buf = std.ArrayList(u8).init(arena);


### PR DESCRIPTION
Please refer to this issue https://github.com/ziglang/zig/issues/6573

This issue has been fixed in https://reviews.llvm.org/D118391, so we don't have a compiling error for arm-linux-musleabi in LLVM 16. So I am wondering if we unlock this limitation in zig, so we can start testing C++ for arm-linux-musleabi(hf) again.
