### PR TITLE
Wasm: make --initial-memory and --max-memory take pages instead of bytes

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -548,8 +548,8 @@ const usage_build_generic =
     \\  --import-symbols               (WebAssembly) import missing symbols from the host environment
     \\  --import-table                 (WebAssembly) import function table from the host environment
     \\  --export-table                 (WebAssembly) export function table to the host environment
-    \\  --initial-memory=[bytes]       (WebAssembly) initial size of the linear memory
-    \\  --max-memory=[bytes]           (WebAssembly) maximum size of the linear memory
+    \\  --initial-memory=[pages]       (WebAssembly) initial size of the linear memory
+    \\  --max-memory=[pages]           (WebAssembly) maximum size of the linear memory
     \\  --shared-memory                (WebAssembly) use shared linear memory
     \\  --global-base=[addr]           (WebAssembly) where to start to place global data
     \\  --export=[value]               (WebAssembly) Force a symbol to be exported


### PR DESCRIPTION
The limits of a memory in Wasm are always given in units of page size,
instead of bytes. So I think it makes more sense for these two options
to accept a number of pages instead of bytes.
This avoids the whole "number of bytes must be aligned to pages" error in the
first place.

```
# testing --initial-memory
$ zig-out/bin/zig build-exe -target wasm64-wasi x.zig --initial-memory=10
error(link): Initial memory too small, must be at least 16 pages
$ zig-out/bin/zig build-exe -target wasm64-wasi x.zig --initial-memory=16
$ wasm2wat x.wasm | grep "memory ("
  (memory (;0;) 16)
$ zig-out/bin/zig build-exe -target wasm64-wasi x.zig --initial-memory=100
$ wasm2wat x.wasm | grep "memory ("
  (memory (;0;) 100)
$ zig-out/bin/zig build-exe -target wasm64-wasi x.zig --initial-memory=23292
$ wasm2wat x.wasm | grep "memory ("
  (memory (;0;) 23292)
$ zig-out/bin/zig build-exe -target wasm64-wasi x.zig --initial-memory=2932938293982398298
error(link): Initial memory exceeds maximum memory 65535

# testing --max-memory too
$ zig-out/bin/zig build-exe -target wasm64-wasi x.zig --initial-memory=102 --max-memory=105
$ wasm2wat x.wasm | grep "memory ("
  (memory (;0;) 102 105)
$ zig-out/bin/zig build-exe -target wasm64-wasi x.zig --initial-memory=110 --max-memory=105
error(link): Maximum memory too small, must be at least 110 pages
```