### PR TITLE
std: dump .dynamic, .symtab, .dysym for ELF in `CheckObject`; remove wildcard matchers in favour of `checkContains` helper

### DIFF
--- a/lib/std/Build/Step/CheckObject.zig
+++ b/lib/std/Build/Step/CheckObject.zig
@@ -950,6 +950,8 @@ const ElfDumper = struct {
     fn dumpShdrs(ctx: Context, writer: anytype) !void {
         if (ctx.shdrs.len == 0) return;
 
+        try writer.writeAll("section headers\n");
+
         for (ctx.shdrs, 0..) |shdr, shndx| {
             try writer.print("shdr {d}\n", .{shndx});
             try writer.print("name {s}\n", .{getSectionName(ctx, shndx)});
@@ -1113,45 +1115,45 @@ const ElfDumper = struct {
     ) !void {
         _ = unused_fmt_string;
         _ = options;
-        if (elf.SHT_LOOS <= sh_type and sh_type < elf.SHT_HIOS) {
-            try writer.print("LOOS+0x{x}", .{sh_type - elf.SHT_LOOS});
-        } else if (elf.SHT_LOPROC <= sh_type and sh_type < elf.SHT_HIPROC) {
-            try writer.print("LOPROC+0x{x}", .{sh_type - elf.SHT_LOPROC});
-        } else if (elf.SHT_LOUSER <= sh_type and sh_type < elf.SHT_HIUSER) {
-            try writer.print("LOUSER+0x{x}", .{sh_type - elf.SHT_LOUSER});
-        } else {
-            const name = switch (sh_type) {
-                elf.SHT_NULL => "NULL",
-                elf.SHT_PROGBITS => "PROGBITS",
-                elf.SHT_SYMTAB => "SYMTAB",
-                elf.SHT_STRTAB => "STRTAB",
-                elf.SHT_RELA => "RELA",
-                elf.SHT_HASH => "HASH",
-                elf.SHT_DYNAMIC => "DYNAMIC",
-                elf.SHT_NOTE => "NOTE",
-                elf.SHT_NOBITS => "NOBITS",
-                elf.SHT_REL => "REL",
-                elf.SHT_SHLIB => "SHLIB",
-                elf.SHT_DYNSYM => "DYNSYM",
-                elf.SHT_INIT_ARRAY => "INIT_ARRAY",
-                elf.SHT_FINI_ARRAY => "FINI_ARRAY",
-                elf.SHT_PREINIT_ARRAY => "PREINIT_ARRAY",
-                elf.SHT_GROUP => "GROUP",
-                elf.SHT_SYMTAB_SHNDX => "SYMTAB_SHNDX",
-                elf.SHT_X86_64_UNWIND => "X86_64_UNWIND",
-                elf.SHT_LLVM_ADDRSIG => "LLVM_ADDRSIG",
-                elf.SHT_GNU_HASH => "GNU_HASH",
-                elf.SHT_GNU_VERDEF => "VERDEF",
-                elf.SHT_GNU_VERNEED => "VERNEED",
-                elf.SHT_GNU_VERSYM => "VERSYM",
-                else => "UNKNOWN",
-            };
-            try writer.writeAll(name);
-        }
+        const name = switch (sh_type) {
+            elf.SHT_NULL => "NULL",
+            elf.SHT_PROGBITS => "PROGBITS",
+            elf.SHT_SYMTAB => "SYMTAB",
+            elf.SHT_STRTAB => "STRTAB",
+            elf.SHT_RELA => "RELA",
+            elf.SHT_HASH => "HASH",
+            elf.SHT_DYNAMIC => "DYNAMIC",
+            elf.SHT_NOTE => "NOTE",
+            elf.SHT_NOBITS => "NOBITS",
+            elf.SHT_REL => "REL",
+            elf.SHT_SHLIB => "SHLIB",
+            elf.SHT_DYNSYM => "DYNSYM",
+            elf.SHT_INIT_ARRAY => "INIT_ARRAY",
+            elf.SHT_FINI_ARRAY => "FINI_ARRAY",
+            elf.SHT_PREINIT_ARRAY => "PREINIT_ARRAY",
+            elf.SHT_GROUP => "GROUP",
+            elf.SHT_SYMTAB_SHNDX => "SYMTAB_SHNDX",
+            elf.SHT_X86_64_UNWIND => "X86_64_UNWIND",
+            elf.SHT_LLVM_ADDRSIG => "LLVM_ADDRSIG",
+            elf.SHT_GNU_HASH => "GNU_HASH",
+            elf.SHT_GNU_VERDEF => "VERDEF",
+            elf.SHT_GNU_VERNEED => "VERNEED",
+            elf.SHT_GNU_VERSYM => "VERSYM",
+            else => if (elf.SHT_LOOS <= sh_type and sh_type < elf.SHT_HIOS) {
+                return try writer.print("LOOS+0x{x}", .{sh_type - elf.SHT_LOOS});
+            } else if (elf.SHT_LOPROC <= sh_type and sh_type < elf.SHT_HIPROC) {
+                return try writer.print("LOPROC+0x{x}", .{sh_type - elf.SHT_LOPROC});
+            } else if (elf.SHT_LOUSER <= sh_type and sh_type < elf.SHT_HIUSER) {
+                return try writer.print("LOUSER+0x{x}", .{sh_type - elf.SHT_LOUSER});
+            } else "UNKNOWN",
+        };
+        try writer.writeAll(name);
     }
 
     fn dumpPhdrs(ctx: Context, writer: anytype) !void {
         if (ctx.phdrs.len == 0) return;
+
+        try writer.writeAll("program headers\n");
 
         for (ctx.phdrs, 0..) |phdr, phndx| {
             try writer.print("phdr {d}\n", .{phndx});
@@ -1162,7 +1164,28 @@ const ElfDumper = struct {
             try writer.print("memsz {x}\n", .{phdr.p_memsz});
             try writer.print("filesz {x}\n", .{phdr.p_filesz});
             try writer.print("align {x}\n", .{phdr.p_align});
-            // TODO dump formatted p_flags
+
+            {
+                const flags = phdr.p_flags;
+                try writer.writeAll("flags");
+                if (flags > 0) try writer.writeByte(' ');
+                if (flags & elf.PF_R != 0) {
+                    try writer.writeByte('R');
+                }
+                if (flags & elf.PF_W != 0) {
+                    try writer.writeByte('W');
+                }
+                if (flags & elf.PF_X != 0) {
+                    try writer.writeByte('E');
+                }
+                if (flags & elf.PF_MASKOS != 0) {
+                    try writer.writeAll("OS");
+                }
+                if (flags & elf.PF_MASKPROC != 0) {
+                    try writer.writeAll("PROC");
+                }
+                try writer.writeByte('\n');
+            }
         }
     }
 
@@ -1178,28 +1201,26 @@ const ElfDumper = struct {
     ) !void {
         _ = unused_fmt_string;
         _ = options;
-        if (elf.PT_LOOS <= ph_type and ph_type < elf.PT_HIOS) {
-            try writer.print("LOOS+0x{x}", .{ph_type - elf.PT_LOOS});
-        } else if (elf.PT_LOPROC <= ph_type and ph_type < elf.PT_HIPROC) {
-            try writer.print("LOPROC+0x{x}", .{ph_type - elf.PT_LOPROC});
-        } else {
-            const p_type = switch (ph_type) {
-                elf.PT_NULL => "NULL",
-                elf.PT_LOAD => "LOAD",
-                elf.PT_DYNAMIC => "DYNAMIC",
-                elf.PT_INTERP => "INTERP",
-                elf.PT_NOTE => "NOTE",
-                elf.PT_SHLIB => "SHLIB",
-                elf.PT_PHDR => "PHDR",
-                elf.PT_TLS => "TLS",
-                elf.PT_NUM => "NUM",
-                elf.PT_GNU_EH_FRAME => "GNU_EH_FRAME",
-                elf.PT_GNU_STACK => "GNU_STACK",
-                elf.PT_GNU_RELRO => "GNU_RELRO",
-                else => "UNKNOWN",
-            };
-            try writer.writeAll(p_type);
-        }
+        const p_type = switch (ph_type) {
+            elf.PT_NULL => "NULL",
+            elf.PT_LOAD => "LOAD",
+            elf.PT_DYNAMIC => "DYNAMIC",
+            elf.PT_INTERP => "INTERP",
+            elf.PT_NOTE => "NOTE",
+            elf.PT_SHLIB => "SHLIB",
+            elf.PT_PHDR => "PHDR",
+            elf.PT_TLS => "TLS",
+            elf.PT_NUM => "NUM",
+            elf.PT_GNU_EH_FRAME => "GNU_EH_FRAME",
+            elf.PT_GNU_STACK => "GNU_STACK",
+            elf.PT_GNU_RELRO => "GNU_RELRO",
+            else => if (elf.PT_LOOS <= ph_type and ph_type < elf.PT_HIOS) {
+                return try writer.print("LOOS+0x{x}", .{ph_type - elf.PT_LOOS});
+            } else if (elf.PT_LOPROC <= ph_type and ph_type < elf.PT_HIPROC) {
+                return try writer.print("LOPROC+0x{x}", .{ph_type - elf.PT_LOPROC});
+            } else "UNKNOWN",
+        };
+        try writer.writeAll(p_type);
     }
 
     fn dumpSymtab(ctx: Context, comptime @"type": enum { symtab, dysymtab }, writer: anytype) !void {

--- a/test/link/macho/dead_strip/build.zig
+++ b/test/link/macho/dead_strip/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
 
         const check = exe.checkObject();
         check.checkInSymtab();
-        check.checkNext("{*} (__TEXT,__text) external _iAmUnused");
+        check.checkContains("(__TEXT,__text) external _iAmUnused");
         test_step.dependOn(&check.step);
 
         const run = b.addRunArtifact(exe);
@@ -31,7 +31,7 @@ pub fn build(b: *std.Build) void {
 
         const check = exe.checkObject();
         check.checkInSymtab();
-        check.checkNotPresent("{*} (__TEXT,__text) external _iAmUnused");
+        check.checkNotPresent("(__TEXT,__text) external _iAmUnused");
         test_step.dependOn(&check.step);
 
         const run = b.addRunArtifact(exe);

--- a/test/link/macho/dead_strip_dylibs/build.zig
+++ b/test/link/macho/dead_strip_dylibs/build.zig
@@ -19,11 +19,13 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         const exe = createScenario(b, optimize, "no-dead-strip");
 
         const check = exe.checkObject();
-        check.checkStart("cmd LOAD_DYLIB");
-        check.checkNext("name {*}Cocoa");
+        check.checkStart();
+        check.checkExact("cmd LOAD_DYLIB");
+        check.checkContains("Cocoa");
 
-        check.checkStart("cmd LOAD_DYLIB");
-        check.checkNext("name {*}libobjc{*}.dylib");
+        check.checkStart();
+        check.checkExact("cmd LOAD_DYLIB");
+        check.checkContains("libobjc");
 
         test_step.dependOn(&check.step);
 

--- a/test/link/macho/dylib/build.zig
+++ b/test/link/macho/dylib/build.zig
@@ -25,11 +25,12 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     dylib.linkLibC();
 
     const check_dylib = dylib.checkObject();
-    check_dylib.checkStart("cmd ID_DYLIB");
-    check_dylib.checkNext("name @rpath/liba.dylib");
-    check_dylib.checkNext("timestamp 2");
-    check_dylib.checkNext("current version 10000");
-    check_dylib.checkNext("compatibility version 10000");
+    check_dylib.checkStart();
+    check_dylib.checkExact("cmd ID_DYLIB");
+    check_dylib.checkExact("name @rpath/liba.dylib");
+    check_dylib.checkExact("timestamp 2");
+    check_dylib.checkExact("current version 10000");
+    check_dylib.checkExact("compatibility version 10000");
 
     test_step.dependOn(&check_dylib.step);
 
@@ -45,14 +46,16 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.linkLibC();
 
     const check_exe = exe.checkObject();
-    check_exe.checkStart("cmd LOAD_DYLIB");
-    check_exe.checkNext("name @rpath/liba.dylib");
-    check_exe.checkNext("timestamp 2");
-    check_exe.checkNext("current version 10000");
-    check_exe.checkNext("compatibility version 10000");
+    check_exe.checkStart();
+    check_exe.checkExact("cmd LOAD_DYLIB");
+    check_exe.checkExact("name @rpath/liba.dylib");
+    check_exe.checkExact("timestamp 2");
+    check_exe.checkExact("current version 10000");
+    check_exe.checkExact("compatibility version 10000");
 
-    check_exe.checkStart("cmd RPATH");
-    check_exe.checkNextFileSource("path", dylib.getOutputDirectorySource());
+    check_exe.checkStart();
+    check_exe.checkExact("cmd RPATH");
+    check_exe.checkExactFileSource("path", dylib.getOutputDirectorySource());
     test_step.dependOn(&check_exe.step);
 
     const run = b.addRunArtifact(exe);

--- a/test/link/macho/entry/build.zig
+++ b/test/link/macho/entry/build.zig
@@ -24,14 +24,16 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
 
     const check_exe = exe.checkObject();
 
-    check_exe.checkStart("segname __TEXT");
-    check_exe.checkNext("vmaddr {vmaddr}");
+    check_exe.checkStart();
+    check_exe.checkExact("segname __TEXT");
+    check_exe.checkExtract("vmaddr {vmaddr}");
 
-    check_exe.checkStart("cmd MAIN");
-    check_exe.checkNext("entryoff {entryoff}");
+    check_exe.checkStart();
+    check_exe.checkExact("cmd MAIN");
+    check_exe.checkExtract("entryoff {entryoff}");
 
     check_exe.checkInSymtab();
-    check_exe.checkNext("{n_value} (__TEXT,__text) external _non_main");
+    check_exe.checkExtract("{n_value} (__TEXT,__text) external _non_main");
 
     check_exe.checkComputeCompare("vmaddr entryoff +", .{ .op = .eq, .value = .{ .variable = "n_value" } });
     test_step.dependOn(&check_exe.step);

--- a/test/link/macho/entry_in_dylib/build.zig
+++ b/test/link/macho/entry_in_dylib/build.zig
@@ -34,14 +34,17 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.forceUndefinedSymbol("_my_main");
 
     const check_exe = exe.checkObject();
-    check_exe.checkStart("segname __TEXT");
-    check_exe.checkNext("vmaddr {text_vmaddr}");
+    check_exe.checkStart();
+    check_exe.checkExact("segname __TEXT");
+    check_exe.checkExtract("vmaddr {text_vmaddr}");
 
-    check_exe.checkStart("sectname __stubs");
-    check_exe.checkNext("addr {stubs_vmaddr}");
+    check_exe.checkStart();
+    check_exe.checkExact("sectname __stubs");
+    check_exe.checkExtract("addr {stubs_vmaddr}");
 
-    check_exe.checkStart("cmd MAIN");
-    check_exe.checkNext("entryoff {entryoff}");
+    check_exe.checkStart();
+    check_exe.checkExact("cmd MAIN");
+    check_exe.checkExtract("entryoff {entryoff}");
 
     check_exe.checkComputeCompare("text_vmaddr entryoff +", .{
         .op = .eq,

--- a/test/link/macho/headerpad/build.zig
+++ b/test/link/macho/headerpad/build.zig
@@ -21,8 +21,9 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         exe.headerpad_max_install_names = true;
 
         const check = exe.checkObject();
-        check.checkStart("sectname __text");
-        check.checkNext("offset {offset}");
+        check.checkStart();
+        check.checkExact("sectname __text");
+        check.checkExtract("offset {offset}");
 
         switch (builtin.cpu.arch) {
             .aarch64 => {
@@ -46,8 +47,9 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         exe.headerpad_size = 0x10000;
 
         const check = exe.checkObject();
-        check.checkStart("sectname __text");
-        check.checkNext("offset {offset}");
+        check.checkStart();
+        check.checkExact("sectname __text");
+        check.checkExtract("offset {offset}");
         check.checkComputeCompare("offset", .{ .op = .gte, .value = .{ .literal = 0x10000 } });
 
         test_step.dependOn(&check.step);
@@ -63,8 +65,9 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         exe.headerpad_size = 0x10000;
 
         const check = exe.checkObject();
-        check.checkStart("sectname __text");
-        check.checkNext("offset {offset}");
+        check.checkStart();
+        check.checkExact("sectname __text");
+        check.checkExtract("offset {offset}");
         check.checkComputeCompare("offset", .{ .op = .gte, .value = .{ .literal = 0x10000 } });
 
         test_step.dependOn(&check.step);
@@ -80,8 +83,9 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         exe.headerpad_max_install_names = true;
 
         const check = exe.checkObject();
-        check.checkStart("sectname __text");
-        check.checkNext("offset {offset}");
+        check.checkStart();
+        check.checkExact("sectname __text");
+        check.checkExtract("offset {offset}");
 
         switch (builtin.cpu.arch) {
             .aarch64 => {

--- a/test/link/macho/linksection/build.zig
+++ b/test/link/macho/linksection/build.zig
@@ -25,14 +25,14 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     const check = obj.checkObject();
 
     check.checkInSymtab();
-    check.checkNext("{*} (__DATA,__TestGlobal) external _test_global");
+    check.checkContains("(__DATA,__TestGlobal) external _test_global");
 
     check.checkInSymtab();
-    check.checkNext("{*} (__TEXT,__TestFn) external _testFn");
+    check.checkContains("(__TEXT,__TestFn) external _testFn");
 
     if (optimize == .Debug) {
         check.checkInSymtab();
-        check.checkNext("{*} (__TEXT,__TestGenFnA) _main.testGenericFn__anon_{*}");
+        check.checkContains("(__TEXT,__TestGenFnA) _main.testGenericFn__anon_");
     }
 
     test_step.dependOn(&check.step);

--- a/test/link/macho/needed_framework/build.zig
+++ b/test/link/macho/needed_framework/build.zig
@@ -26,8 +26,9 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.dead_strip_dylibs = true;
 
     const check = exe.checkObject();
-    check.checkStart("cmd LOAD_DYLIB");
-    check.checkNext("name {*}Cocoa");
+    check.checkStart();
+    check.checkExact("cmd LOAD_DYLIB");
+    check.checkContains("Cocoa");
     test_step.dependOn(&check.step);
 
     const run_cmd = b.addRunArtifact(exe);

--- a/test/link/macho/needed_library/build.zig
+++ b/test/link/macho/needed_library/build.zig
@@ -39,8 +39,9 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.dead_strip_dylibs = true;
 
     const check = exe.checkObject();
-    check.checkStart("cmd LOAD_DYLIB");
-    check.checkNext("name @rpath/liba.dylib");
+    check.checkStart();
+    check.checkExact("cmd LOAD_DYLIB");
+    check.checkExact("name @rpath/liba.dylib");
     test_step.dependOn(&check.step);
 
     const run = b.addRunArtifact(exe);

--- a/test/link/macho/pagezero/build.zig
+++ b/test/link/macho/pagezero/build.zig
@@ -20,13 +20,15 @@ pub fn build(b: *std.Build) void {
         exe.pagezero_size = 0x4000;
 
         const check = exe.checkObject();
-        check.checkStart("LC 0");
-        check.checkNext("segname __PAGEZERO");
-        check.checkNext("vmaddr 0");
-        check.checkNext("vmsize 4000");
+        check.checkStart();
+        check.checkExact("LC 0");
+        check.checkExact("segname __PAGEZERO");
+        check.checkExact("vmaddr 0");
+        check.checkExact("vmsize 4000");
 
-        check.checkStart("segname __TEXT");
-        check.checkNext("vmaddr 4000");
+        check.checkStart();
+        check.checkExact("segname __TEXT");
+        check.checkExact("vmaddr 4000");
 
         test_step.dependOn(&check.step);
     }
@@ -42,9 +44,10 @@ pub fn build(b: *std.Build) void {
         exe.pagezero_size = 0;
 
         const check = exe.checkObject();
-        check.checkStart("LC 0");
-        check.checkNext("segname __TEXT");
-        check.checkNext("vmaddr 0");
+        check.checkStart();
+        check.checkExact("LC 0");
+        check.checkExact("segname __TEXT");
+        check.checkExact("vmaddr 0");
 
         test_step.dependOn(&check.step);
     }

--- a/test/link/macho/search_strategy/build.zig
+++ b/test/link/macho/search_strategy/build.zig
@@ -21,8 +21,9 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         exe.search_strategy = .dylibs_first;
 
         const check = exe.checkObject();
-        check.checkStart("cmd LOAD_DYLIB");
-        check.checkNext("name @rpath/libsearch_dylibs_first.dylib");
+        check.checkStart();
+        check.checkExact("cmd LOAD_DYLIB");
+        check.checkExact("name @rpath/libsearch_dylibs_first.dylib");
         test_step.dependOn(&check.step);
 
         const run = b.addRunArtifact(exe);

--- a/test/link/macho/stack_size/build.zig
+++ b/test/link/macho/stack_size/build.zig
@@ -25,8 +25,9 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.stack_size = 0x100000000;
 
     const check_exe = exe.checkObject();
-    check_exe.checkStart("cmd MAIN");
-    check_exe.checkNext("stacksize 100000000");
+    check_exe.checkStart();
+    check_exe.checkExact("cmd MAIN");
+    check_exe.checkExact("stacksize 100000000");
     test_step.dependOn(&check_exe.step);
 
     const run = b.addRunArtifact(exe);

--- a/test/link/macho/strict_validation/build.zig
+++ b/test/link/macho/strict_validation/build.zig
@@ -26,44 +26,51 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
 
     const check_exe = exe.checkObject();
 
-    check_exe.checkStart("cmd SEGMENT_64");
-    check_exe.checkNext("segname __LINKEDIT");
-    check_exe.checkNext("fileoff {fileoff}");
-    check_exe.checkNext("filesz {filesz}");
+    check_exe.checkStart();
+    check_exe.checkExact("cmd SEGMENT_64");
+    check_exe.checkExact("segname __LINKEDIT");
+    check_exe.checkExtract("fileoff {fileoff}");
+    check_exe.checkExtract("filesz {filesz}");
 
-    check_exe.checkStart("cmd DYLD_INFO_ONLY");
-    check_exe.checkNext("rebaseoff {rebaseoff}");
-    check_exe.checkNext("rebasesize {rebasesize}");
-    check_exe.checkNext("bindoff {bindoff}");
-    check_exe.checkNext("bindsize {bindsize}");
-    check_exe.checkNext("lazybindoff {lazybindoff}");
-    check_exe.checkNext("lazybindsize {lazybindsize}");
-    check_exe.checkNext("exportoff {exportoff}");
-    check_exe.checkNext("exportsize {exportsize}");
+    check_exe.checkStart();
+    check_exe.checkExact("cmd DYLD_INFO_ONLY");
+    check_exe.checkExtract("rebaseoff {rebaseoff}");
+    check_exe.checkExtract("rebasesize {rebasesize}");
+    check_exe.checkExtract("bindoff {bindoff}");
+    check_exe.checkExtract("bindsize {bindsize}");
+    check_exe.checkExtract("lazybindoff {lazybindoff}");
+    check_exe.checkExtract("lazybindsize {lazybindsize}");
+    check_exe.checkExtract("exportoff {exportoff}");
+    check_exe.checkExtract("exportsize {exportsize}");
 
-    check_exe.checkStart("cmd FUNCTION_STARTS");
-    check_exe.checkNext("dataoff {fstartoff}");
-    check_exe.checkNext("datasize {fstartsize}");
+    check_exe.checkStart();
+    check_exe.checkExact("cmd FUNCTION_STARTS");
+    check_exe.checkExtract("dataoff {fstartoff}");
+    check_exe.checkExtract("datasize {fstartsize}");
 
-    check_exe.checkStart("cmd DATA_IN_CODE");
-    check_exe.checkNext("dataoff {diceoff}");
-    check_exe.checkNext("datasize {dicesize}");
+    check_exe.checkStart();
+    check_exe.checkExact("cmd DATA_IN_CODE");
+    check_exe.checkExtract("dataoff {diceoff}");
+    check_exe.checkExtract("datasize {dicesize}");
 
-    check_exe.checkStart("cmd SYMTAB");
-    check_exe.checkNext("symoff {symoff}");
-    check_exe.checkNext("nsyms {symnsyms}");
-    check_exe.checkNext("stroff {stroff}");
-    check_exe.checkNext("strsize {strsize}");
+    check_exe.checkStart();
+    check_exe.checkExact("cmd SYMTAB");
+    check_exe.checkExtract("symoff {symoff}");
+    check_exe.checkExtract("nsyms {symnsyms}");
+    check_exe.checkExtract("stroff {stroff}");
+    check_exe.checkExtract("strsize {strsize}");
 
-    check_exe.checkStart("cmd DYSYMTAB");
-    check_exe.checkNext("indirectsymoff {dysymoff}");
-    check_exe.checkNext("nindirectsyms {dysymnsyms}");
+    check_exe.checkStart();
+    check_exe.checkExact("cmd DYSYMTAB");
+    check_exe.checkExtract("indirectsymoff {dysymoff}");
+    check_exe.checkExtract("nindirectsyms {dysymnsyms}");
 
     switch (builtin.cpu.arch) {
         .aarch64 => {
-            check_exe.checkStart("cmd CODE_SIGNATURE");
-            check_exe.checkNext("dataoff {codesigoff}");
-            check_exe.checkNext("datasize {codesigsize}");
+            check_exe.checkStart();
+            check_exe.checkExact("cmd CODE_SIGNATURE");
+            check_exe.checkExtract("dataoff {codesigoff}");
+            check_exe.checkExtract("datasize {codesigsize}");
         },
         .x86_64 => {},
         else => unreachable,

--- a/test/link/macho/unwind_info/build.zig
+++ b/test/link/macho/unwind_info/build.zig
@@ -32,20 +32,21 @@ fn testUnwindInfo(
     exe.link_gc_sections = dead_strip;
 
     const check = exe.checkObject();
-    check.checkStart("segname __TEXT");
-    check.checkNext("sectname __gcc_except_tab");
-    check.checkNext("sectname __unwind_info");
+    check.checkStart();
+    check.checkExact("segname __TEXT");
+    check.checkExact("sectname __gcc_except_tab");
+    check.checkExact("sectname __unwind_info");
 
     switch (builtin.cpu.arch) {
         .aarch64 => {
-            check.checkNext("sectname __eh_frame");
+            check.checkExact("sectname __eh_frame");
         },
         .x86_64 => {}, // We do not expect `__eh_frame` section on x86_64 in this case
         else => unreachable,
     }
 
     check.checkInSymtab();
-    check.checkNext("{*} (__TEXT,__text) external ___gxx_personality_v0");
+    check.checkContains("(__TEXT,__text) external ___gxx_personality_v0");
     test_step.dependOn(&check.step);
 
     const run = b.addRunArtifact(exe);

--- a/test/link/macho/weak_framework/build.zig
+++ b/test/link/macho/weak_framework/build.zig
@@ -23,8 +23,9 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.linkFrameworkWeak("Cocoa");
 
     const check = exe.checkObject();
-    check.checkStart("cmd LOAD_WEAK_DYLIB");
-    check.checkNext("name {*}Cocoa");
+    check.checkStart();
+    check.checkExact("cmd LOAD_WEAK_DYLIB");
+    check.checkContains("Cocoa");
     test_step.dependOn(&check.step);
 
     const run_cmd = b.addRunArtifact(exe);

--- a/test/link/macho/weak_library/build.zig
+++ b/test/link/macho/weak_library/build.zig
@@ -37,14 +37,15 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.addRPathDirectorySource(dylib.getOutputDirectorySource());
 
     const check = exe.checkObject();
-    check.checkStart("cmd LOAD_WEAK_DYLIB");
-    check.checkNext("name @rpath/liba.dylib");
+    check.checkStart();
+    check.checkExact("cmd LOAD_WEAK_DYLIB");
+    check.checkExact("name @rpath/liba.dylib");
 
     check.checkInSymtab();
-    check.checkNext("(undefined) weak external _a (from liba)");
+    check.checkExact("(undefined) weak external _a (from liba)");
 
     check.checkInSymtab();
-    check.checkNext("(undefined) weak external _asStr (from liba)");
+    check.checkExact("(undefined) weak external _asStr (from liba)");
     test_step.dependOn(&check.step);
 
     const run = b.addRunArtifact(exe);

--- a/test/link/wasm/archive/build.zig
+++ b/test/link/wasm/archive/build.zig
@@ -26,8 +26,9 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     lib.strip = false;
 
     const check = lib.checkObject();
-    check.checkStart("Section custom");
-    check.checkNext("name __trunch"); // Ensure it was imported and resolved
+    check.checkStart();
+    check.checkExact("Section custom");
+    check.checkExact("name __trunch"); // Ensure it was imported and resolved
 
     test_step.dependOn(&check.step);
 }

--- a/test/link/wasm/basic-features/build.zig
+++ b/test/link/wasm/basic-features/build.zig
@@ -20,9 +20,10 @@ pub fn build(b: *std.Build) void {
 
     // Verify the result contains the features explicitly set on the target for the library.
     const check = lib.checkObject();
-    check.checkStart("name target_features");
-    check.checkNext("features 1");
-    check.checkNext("+ atomics");
+    check.checkStart();
+    check.checkExact("name target_features");
+    check.checkExact("features 1");
+    check.checkExact("+ atomics");
 
     const test_step = b.step("test", "Run linker test");
     test_step.dependOn(&check.step);

--- a/test/link/wasm/bss/build.zig
+++ b/test/link/wasm/bss/build.zig
@@ -29,28 +29,31 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.Opt
         const check_lib = lib.checkObject();
 
         // since we import memory, make sure it exists with the correct naming
-        check_lib.checkStart("Section import");
-        check_lib.checkNext("entries 1");
-        check_lib.checkNext("module env"); // default module name is "env"
-        check_lib.checkNext("name memory"); // as per linker specification
+        check_lib.checkStart();
+        check_lib.checkExact("Section import");
+        check_lib.checkExact("entries 1");
+        check_lib.checkExact("module env"); // default module name is "env"
+        check_lib.checkExact("name memory"); // as per linker specification
 
         // since we are importing memory, ensure it's not exported
+        check_lib.checkStart();
         check_lib.checkNotPresent("Section export");
 
         // validate the name of the stack pointer
-        check_lib.checkStart("Section custom");
-        check_lib.checkNext("type data_segment");
-        check_lib.checkNext("names 2");
-        check_lib.checkNext("index 0");
-        check_lib.checkNext("name .rodata");
+        check_lib.checkStart();
+        check_lib.checkExact("Section custom");
+        check_lib.checkExact("type data_segment");
+        check_lib.checkExact("names 2");
+        check_lib.checkExact("index 0");
+        check_lib.checkExact("name .rodata");
         // for safe optimization modes `undefined` is stored in data instead of bss.
         if (is_safe) {
-            check_lib.checkNext("index 1");
-            check_lib.checkNext("name .data");
+            check_lib.checkExact("index 1");
+            check_lib.checkExact("name .data");
             check_lib.checkNotPresent("name .bss");
         } else {
-            check_lib.checkNext("index 1"); // bss section always last
-            check_lib.checkNext("name .bss");
+            check_lib.checkExact("index 1"); // bss section always last
+            check_lib.checkExact("name .bss");
         }
         test_step.dependOn(&check_lib.step);
     }
@@ -70,13 +73,14 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.Opt
         lib.import_memory = true;
 
         const check_lib = lib.checkObject();
-        check_lib.checkStart("Section custom");
-        check_lib.checkNext("type data_segment");
-        check_lib.checkNext("names 2");
-        check_lib.checkNext("index 0");
-        check_lib.checkNext("name .rodata");
-        check_lib.checkNext("index 1");
-        check_lib.checkNext("name .bss");
+        check_lib.checkStart();
+        check_lib.checkExact("Section custom");
+        check_lib.checkExact("type data_segment");
+        check_lib.checkExact("names 2");
+        check_lib.checkExact("index 0");
+        check_lib.checkExact("name .rodata");
+        check_lib.checkExact("index 1");
+        check_lib.checkExact("name .bss");
 
         test_step.dependOn(&check_lib.step);
     }

--- a/test/link/wasm/export-data/build.zig
+++ b/test/link/wasm/export-data/build.zig
@@ -21,26 +21,28 @@ pub fn build(b: *std.Build) void {
 
     const check_lib = lib.checkObject();
 
-    check_lib.checkStart("Section global");
-    check_lib.checkNext("entries 3");
-    check_lib.checkNext("type i32"); // stack pointer so skip other fields
-    check_lib.checkNext("type i32");
-    check_lib.checkNext("mutable false");
-    check_lib.checkNext("i32.const {foo_address}");
-    check_lib.checkNext("type i32");
-    check_lib.checkNext("mutable false");
-    check_lib.checkNext("i32.const {bar_address}");
+    check_lib.checkStart();
+    check_lib.checkExact("Section global");
+    check_lib.checkExact("entries 3");
+    check_lib.checkExact("type i32"); // stack pointer so skip other fields
+    check_lib.checkExact("type i32");
+    check_lib.checkExact("mutable false");
+    check_lib.checkExtract("i32.const {foo_address}");
+    check_lib.checkExact("type i32");
+    check_lib.checkExact("mutable false");
+    check_lib.checkExtract("i32.const {bar_address}");
     check_lib.checkComputeCompare("foo_address", .{ .op = .eq, .value = .{ .literal = 4 } });
     check_lib.checkComputeCompare("bar_address", .{ .op = .eq, .value = .{ .literal = 0 } });
 
-    check_lib.checkStart("Section export");
-    check_lib.checkNext("entries 3");
-    check_lib.checkNext("name foo");
-    check_lib.checkNext("kind global");
-    check_lib.checkNext("index 1");
-    check_lib.checkNext("name bar");
-    check_lib.checkNext("kind global");
-    check_lib.checkNext("index 2");
+    check_lib.checkStart();
+    check_lib.checkExact("Section export");
+    check_lib.checkExact("entries 3");
+    check_lib.checkExact("name foo");
+    check_lib.checkExact("kind global");
+    check_lib.checkExact("index 1");
+    check_lib.checkExact("name bar");
+    check_lib.checkExact("kind global");
+    check_lib.checkExact("index 2");
 
     test_step.dependOn(&check_lib.step);
 }

--- a/test/link/wasm/export/build.zig
+++ b/test/link/wasm/export/build.zig
@@ -43,22 +43,25 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     force_export.use_lld = false;
 
     const check_no_export = no_export.checkObject();
-    check_no_export.checkStart("Section export");
-    check_no_export.checkNext("entries 1");
-    check_no_export.checkNext("name memory");
-    check_no_export.checkNext("kind memory");
+    check_no_export.checkStart();
+    check_no_export.checkExact("Section export");
+    check_no_export.checkExact("entries 1");
+    check_no_export.checkExact("name memory");
+    check_no_export.checkExact("kind memory");
 
     const check_dynamic_export = dynamic_export.checkObject();
-    check_dynamic_export.checkStart("Section export");
-    check_dynamic_export.checkNext("entries 2");
-    check_dynamic_export.checkNext("name foo");
-    check_dynamic_export.checkNext("kind function");
+    check_dynamic_export.checkStart();
+    check_dynamic_export.checkExact("Section export");
+    check_dynamic_export.checkExact("entries 2");
+    check_dynamic_export.checkExact("name foo");
+    check_dynamic_export.checkExact("kind function");
 
     const check_force_export = force_export.checkObject();
-    check_force_export.checkStart("Section export");
-    check_force_export.checkNext("entries 2");
-    check_force_export.checkNext("name foo");
-    check_force_export.checkNext("kind function");
+    check_force_export.checkStart();
+    check_force_export.checkExact("Section export");
+    check_force_export.checkExact("entries 2");
+    check_force_export.checkExact("name foo");
+    check_force_export.checkExact("kind function");
 
     test_step.dependOn(&check_no_export.step);
     test_step.dependOn(&check_dynamic_export.step);

--- a/test/link/wasm/extern-mangle/build.zig
+++ b/test/link/wasm/extern-mangle/build.zig
@@ -21,12 +21,13 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     lib.rdynamic = true; // export `foo`
 
     const check_lib = lib.checkObject();
-    check_lib.checkStart("Section import");
-    check_lib.checkNext("entries 2"); // a.hello & b.hello
-    check_lib.checkNext("module a");
-    check_lib.checkNext("name hello");
-    check_lib.checkNext("module b");
-    check_lib.checkNext("name hello");
+    check_lib.checkStart();
+    check_lib.checkExact("Section import");
+    check_lib.checkExact("entries 2"); // a.hello & b.hello
+    check_lib.checkExact("module a");
+    check_lib.checkExact("name hello");
+    check_lib.checkExact("module b");
+    check_lib.checkExact("name hello");
 
     test_step.dependOn(&check_lib.step);
 }

--- a/test/link/wasm/function-table/build.zig
+++ b/test/link/wasm/function-table/build.zig
@@ -46,31 +46,36 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     const check_export = export_table.checkObject();
     const check_regular = regular_table.checkObject();
 
-    check_import.checkStart("Section import");
-    check_import.checkNext("entries 1");
-    check_import.checkNext("module env");
-    check_import.checkNext("name __indirect_function_table");
-    check_import.checkNext("kind table");
-    check_import.checkNext("type funcref");
-    check_import.checkNext("min 1"); // 1 function pointer
+    check_import.checkStart();
+    check_import.checkExact("Section import");
+    check_import.checkExact("entries 1");
+    check_import.checkExact("module env");
+    check_import.checkExact("name __indirect_function_table");
+    check_import.checkExact("kind table");
+    check_import.checkExact("type funcref");
+    check_import.checkExact("min 1"); // 1 function pointer
     check_import.checkNotPresent("max"); // when importing, we do not provide a max
     check_import.checkNotPresent("Section table"); // we're importing it
 
-    check_export.checkStart("Section export");
-    check_export.checkNext("entries 2");
-    check_export.checkNext("name __indirect_function_table"); // as per linker specification
-    check_export.checkNext("kind table");
+    check_export.checkStart();
+    check_export.checkExact("Section export");
+    check_export.checkExact("entries 2");
+    check_export.checkExact("name __indirect_function_table"); // as per linker specification
+    check_export.checkExact("kind table");
 
-    check_regular.checkStart("Section table");
-    check_regular.checkNext("entries 1");
-    check_regular.checkNext("type funcref");
-    check_regular.checkNext("min 2"); // index starts at 1 & 1 function pointer = 2.
-    check_regular.checkNext("max 2");
-    check_regular.checkStart("Section element");
-    check_regular.checkNext("entries 1");
-    check_regular.checkNext("table index 0");
-    check_regular.checkNext("i32.const 1"); // we want to start function indexes at 1
-    check_regular.checkNext("indexes 1"); // 1 function pointer
+    check_regular.checkStart();
+    check_regular.checkExact("Section table");
+    check_regular.checkExact("entries 1");
+    check_regular.checkExact("type funcref");
+    check_regular.checkExact("min 2"); // index starts at 1 & 1 function pointer = 2.
+    check_regular.checkExact("max 2");
+
+    check_regular.checkStart();
+    check_regular.checkExact("Section element");
+    check_regular.checkExact("entries 1");
+    check_regular.checkExact("table index 0");
+    check_regular.checkExact("i32.const 1"); // we want to start function indexes at 1
+    check_regular.checkExact("indexes 1"); // 1 function pointer
 
     test_step.dependOn(&check_import.step);
     test_step.dependOn(&check_export.step);

--- a/test/link/wasm/infer-features/build.zig
+++ b/test/link/wasm/infer-features/build.zig
@@ -33,15 +33,16 @@ pub fn build(b: *std.Build) void {
 
     // Verify the result contains the features from the C Object file.
     const check = lib.checkObject();
-    check.checkStart("name target_features");
-    check.checkNext("features 7");
-    check.checkNext("+ atomics");
-    check.checkNext("+ bulk-memory");
-    check.checkNext("+ mutable-globals");
-    check.checkNext("+ nontrapping-fptoint");
-    check.checkNext("+ sign-ext");
-    check.checkNext("+ simd128");
-    check.checkNext("+ tail-call");
+    check.checkStart();
+    check.checkExact("name target_features");
+    check.checkExact("features 7");
+    check.checkExact("+ atomics");
+    check.checkExact("+ bulk-memory");
+    check.checkExact("+ mutable-globals");
+    check.checkExact("+ nontrapping-fptoint");
+    check.checkExact("+ sign-ext");
+    check.checkExact("+ simd128");
+    check.checkExact("+ tail-call");
 
     const test_step = b.step("test", "Run linker test");
     test_step.dependOn(&check.step);

--- a/test/link/wasm/producers/build.zig
+++ b/test/link/wasm/producers/build.zig
@@ -28,16 +28,17 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     const version_fmt = "version " ++ builtin.zig_version_string;
 
     const check_lib = lib.checkObject();
-    check_lib.checkStart("name producers");
-    check_lib.checkNext("fields 2");
-    check_lib.checkNext("field_name language");
-    check_lib.checkNext("values 1");
-    check_lib.checkNext("value_name Zig");
-    check_lib.checkNext(version_fmt);
-    check_lib.checkNext("field_name processed-by");
-    check_lib.checkNext("values 1");
-    check_lib.checkNext("value_name Zig");
-    check_lib.checkNext(version_fmt);
+    check_lib.checkStart();
+    check_lib.checkExact("name producers");
+    check_lib.checkExact("fields 2");
+    check_lib.checkExact("field_name language");
+    check_lib.checkExact("values 1");
+    check_lib.checkExact("value_name Zig");
+    check_lib.checkExact(version_fmt);
+    check_lib.checkExact("field_name processed-by");
+    check_lib.checkExact("values 1");
+    check_lib.checkExact("value_name Zig");
+    check_lib.checkExact(version_fmt);
 
     test_step.dependOn(&check_lib.step);
 }

--- a/test/link/wasm/segments/build.zig
+++ b/test/link/wasm/segments/build.zig
@@ -25,16 +25,20 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     b.installArtifact(lib);
 
     const check_lib = lib.checkObject();
-    check_lib.checkStart("Section data");
-    check_lib.checkNext("entries 2"); // rodata & data, no bss because we're exporting memory
+    check_lib.checkStart();
+    check_lib.checkExact("Section data");
+    check_lib.checkExact("entries 2"); // rodata & data, no bss because we're exporting memory
 
-    check_lib.checkStart("Section custom");
-    check_lib.checkStart("name name"); // names custom section
-    check_lib.checkStart("type data_segment");
-    check_lib.checkNext("names 2");
-    check_lib.checkNext("index 0");
-    check_lib.checkNext("name .rodata");
-    check_lib.checkNext("index 1");
-    check_lib.checkNext("name .data");
+    check_lib.checkStart();
+    check_lib.checkExact("Section custom");
+    check_lib.checkStart();
+    check_lib.checkExact("name name"); // names custom section
+    check_lib.checkStart();
+    check_lib.checkExact("type data_segment");
+    check_lib.checkExact("names 2");
+    check_lib.checkExact("index 0");
+    check_lib.checkExact("name .rodata");
+    check_lib.checkExact("index 1");
+    check_lib.checkExact("name .data");
     test_step.dependOn(&check_lib.step);
 }

--- a/test/link/wasm/stack_pointer/build.zig
+++ b/test/link/wasm/stack_pointer/build.zig
@@ -28,23 +28,26 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     const check_lib = lib.checkObject();
 
     // ensure global exists and its initial value is equal to explitic stack size
-    check_lib.checkStart("Section global");
-    check_lib.checkNext("entries 1");
-    check_lib.checkNext("type i32"); // on wasm32 the stack pointer must be i32
-    check_lib.checkNext("mutable true"); // must be able to mutate the stack pointer
-    check_lib.checkNext("i32.const {stack_pointer}");
+    check_lib.checkStart();
+    check_lib.checkExact("Section global");
+    check_lib.checkExact("entries 1");
+    check_lib.checkExact("type i32"); // on wasm32 the stack pointer must be i32
+    check_lib.checkExact("mutable true"); // must be able to mutate the stack pointer
+    check_lib.checkExtract("i32.const {stack_pointer}");
     check_lib.checkComputeCompare("stack_pointer", .{ .op = .eq, .value = .{ .literal = lib.stack_size.? } });
 
     // validate memory section starts after virtual stack
-    check_lib.checkNext("Section data");
-    check_lib.checkNext("i32.const {data_start}");
+    check_lib.checkStart();
+    check_lib.checkExact("Section data");
+    check_lib.checkExtract("i32.const {data_start}");
     check_lib.checkComputeCompare("data_start", .{ .op = .eq, .value = .{ .variable = "stack_pointer" } });
 
     // validate the name of the stack pointer
-    check_lib.checkStart("Section custom");
-    check_lib.checkNext("type global");
-    check_lib.checkNext("names 1");
-    check_lib.checkNext("index 0");
-    check_lib.checkNext("name __stack_pointer");
+    check_lib.checkStart();
+    check_lib.checkExact("Section custom");
+    check_lib.checkExact("type global");
+    check_lib.checkExact("names 1");
+    check_lib.checkExact("index 0");
+    check_lib.checkExact("name __stack_pointer");
     test_step.dependOn(&check_lib.step);
 }

--- a/test/link/wasm/type/build.zig
+++ b/test/link/wasm/type/build.zig
@@ -25,17 +25,18 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     b.installArtifact(lib);
 
     const check_lib = lib.checkObject();
-    check_lib.checkStart("Section type");
+    check_lib.checkStart();
+    check_lib.checkExact("Section type");
     // only 2 entries, although we have more functions.
     // This is to test functions with the same function signature
     // have their types deduplicated.
-    check_lib.checkNext("entries 2");
-    check_lib.checkNext("params 1");
-    check_lib.checkNext("type i32");
-    check_lib.checkNext("returns 1");
-    check_lib.checkNext("type i64");
-    check_lib.checkNext("params 0");
-    check_lib.checkNext("returns 0");
+    check_lib.checkExact("entries 2");
+    check_lib.checkExact("params 1");
+    check_lib.checkExact("type i32");
+    check_lib.checkExact("returns 1");
+    check_lib.checkExact("type i64");
+    check_lib.checkExact("params 0");
+    check_lib.checkExact("returns 0");
 
     test_step.dependOn(&check_lib.step);
 }


### PR DESCRIPTION
Instead, we now have a looser helper called `checkContains(...)`
that will match on any occurrence similarly to `std.mem.indexOf()`.

While at it, I have cleaned up other combinators to make the entire
API more consistent, and so:
* `checkStart(phrase)` is now `checkStart()` followed by
`checkExact(phrase)`
* `checkNext(phrase)` if matching exactly is now `checkExact(phrase)`
* `checkNext(phrase)` if matching loosely is now `checkContains(phrase)`
* `checkNext(phrase)` if matching exactly with var extractors is now
`checkExtract(phrase)`

Finally, `ElfDumper` is now dumping contents of `.symtab` and `.dynsym`
symbol tables. I have also removed dumping of symtabs as optional - they
are now always dumped which cleaned up the implementation even more.