### PR TITLE
stage2 wasm: Load signed values using the correct load instruction

### DIFF
--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -2521,7 +2521,7 @@ fn load(func: *CodeGen, operand: WValue, ty: Type, offset: u32) InnerError!WValu
         .valtype1 = typeToValtype(ty, mod),
         .width = abi_size * 8,
         .op = .load,
-        .signedness = .unsigned,
+        .signedness = if (ty.isSignedInt(mod)) .signed else .unsigned,
     });
 
     try func.addMemArg(


### PR DESCRIPTION
This PR fixes the stage2 wasm backend which was loading values integer values like unsigned values regardless of their actual sign resulting in incorrect generated code as can be seen in the example below.

How to reproduce the issue:
`zig test test.zig -target wasm32-wasi -fno-LLVM --test-cmd wasmtime --test-cmd-bin`

```zig
// test.zig
const std = @import("std");

test "wasm" {
    var x: i8 = -5;
    try std.testing.expectEqual(@as(i32, -5), x);
}
```

Output
```
1/1 test.wasm... expected -5, found 251
FAIL (TestExpectedEqual)
```

I found this issue while working on #16434 and this PR is a prerequisite.