### PR TITLE
fmt: convert @byteSwap

### DIFF
--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1398,6 +1398,11 @@ fn renderBuiltinCall(
         "@floatCast",
         "@intCast",
         "@ptrCast",
+        "@alignCast",
+        "@addrSpaceCast",
+        "@constCast",
+        "@volatileCast",
+
         "@intFromFloat",
         "@floatToInt",
         "@enumFromInt",
@@ -1406,7 +1411,9 @@ fn renderBuiltinCall(
         "@intToFloat",
         "@ptrFromInt",
         "@intToPtr",
+
         "@truncate",
+        "@byteSwap",
     }) |name| {
         if (mem.eql(u8, slice, name)) break true;
     } else false;

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1398,10 +1398,6 @@ fn renderBuiltinCall(
         "@floatCast",
         "@intCast",
         "@ptrCast",
-        "@alignCast",
-        "@addrSpaceCast",
-        "@constCast",
-        "@volatileCast",
 
         "@intFromFloat",
         "@floatToInt",


### PR DESCRIPTION
Now `zig fmt` should do the job cleanly.

Previous commit that doesn't convert all of it: 283d65097

Reference: https://github.com/ziglang/zig/commit/be0c69957e7489423606023ad820599652a60e15