### PR TITLE
wasm: correctly intcast signed integers

### DIFF
--- a/test/behavior/cast_int.zig
+++ b/test/behavior/cast_int.zig
@@ -14,3 +14,18 @@ test "@intCast i32 to u7" {
     var z = x >> @as(u7, @intCast(y));
     try expect(z == 0xff);
 }
+
+test "coerce i8 to i32 and @intCast back" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    var x: i8 = -5;
+    var y: i32 = -5;
+    try expect(y == x);
+
+    var x2: i32 = -5;
+    var y2: i8 = -5;
+    try expect(y2 == @as(i8, @intCast(x2)));
+}


### PR DESCRIPTION
When a signed integer's bitsize is not 32 or 64, but the given bitsize and wanted bitsize are either both represented by Wasm's i32 or i64, we must either sign extend or wrap the integer.

Fixes #16475
