### PR TITLE
codegen: `writer().writeByteNTimes` -> `appendNTimes`

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -294,7 +294,7 @@ pub fn generateSymbol(
                 const padding = math.cast(usize, padded_end - unpadded_end) orelse return error.Overflow;
 
                 if (padding > 0) {
-                    try code.writer().writeByteNTimes(0, padding);
+                    try code.appendNTimes(0, padding);
                 }
             }
 
@@ -307,7 +307,7 @@ pub fn generateSymbol(
                 const padding = math.cast(usize, padded_end - unpadded_end) orelse return error.Overflow;
 
                 if (padding > 0) {
-                    try code.writer().writeByteNTimes(0, padding);
+                    try code.appendNTimes(0, padding);
                 }
             }
         },
@@ -367,7 +367,7 @@ pub fn generateSymbol(
                         .fail => |em| return Result{ .fail = em },
                     }
                 } else {
-                    try code.writer().writeByteNTimes(0, abi_size);
+                    try code.appendNTimes(0, abi_size);
                 }
             } else {
                 const padding = abi_size - (math.cast(usize, payload_type.abiSize(mod)) orelse return error.Overflow) - 1;
@@ -382,7 +382,7 @@ pub fn generateSymbol(
                     }
                 }
                 try code.writer().writeByte(@intFromBool(payload_val != null));
-                try code.writer().writeByteNTimes(0, padding);
+                try code.appendNTimes(0, padding);
             }
         },
         .aggregate => |aggregate| switch (mod.intern_pool.indexToKey(typed_value.ty.toIntern())) {
@@ -433,7 +433,7 @@ pub fn generateSymbol(
                     error.DivisionByZero => unreachable,
                     else => |e| return e,
                 })) orelse return error.Overflow;
-                if (padding > 0) try code.writer().writeByteNTimes(0, padding);
+                if (padding > 0) try code.appendNTimes(0, padding);
             },
             .anon_struct_type => |tuple| {
                 const struct_begin = code.items.len;
@@ -465,7 +465,7 @@ pub fn generateSymbol(
                         return error.Overflow;
 
                     if (padding > 0) {
-                        try code.writer().writeByteNTimes(0, padding);
+                        try code.appendNTimes(0, padding);
                     }
                 }
             },
@@ -540,7 +540,7 @@ pub fn generateSymbol(
                         const padding = math.cast(usize, padded_field_end - unpadded_field_end) orelse return error.Overflow;
 
                         if (padding > 0) {
-                            try code.writer().writeByteNTimes(0, padding);
+                            try code.appendNTimes(0, padding);
                         }
                     }
                 }
@@ -573,7 +573,7 @@ pub fn generateSymbol(
             assert(union_ty.haveFieldTypes());
             const field_ty = union_ty.fields.values()[field_index].ty;
             if (!field_ty.hasRuntimeBits(mod)) {
-                try code.writer().writeByteNTimes(0xaa, math.cast(usize, layout.payload_size) orelse return error.Overflow);
+                try code.appendNTimes(0xaa, math.cast(usize, layout.payload_size) orelse return error.Overflow);
             } else {
                 switch (try generateSymbol(bin_file, src_loc, .{
                     .ty = field_ty,
@@ -585,7 +585,7 @@ pub fn generateSymbol(
 
                 const padding = math.cast(usize, layout.payload_size - field_ty.abiSize(mod)) orelse return error.Overflow;
                 if (padding > 0) {
-                    try code.writer().writeByteNTimes(0, padding);
+                    try code.appendNTimes(0, padding);
                 }
             }
 
@@ -599,7 +599,7 @@ pub fn generateSymbol(
                 }
 
                 if (layout.padding > 0) {
-                    try code.writer().writeByteNTimes(0, layout.padding);
+                    try code.appendNTimes(0, layout.padding);
                 }
             }
         },
@@ -734,7 +734,7 @@ fn lowerDeclRef(
     const decl = mod.declPtr(decl_index);
     const is_fn_body = decl.ty.zigTypeTag(mod) == .Fn;
     if (!is_fn_body and !decl.ty.hasRuntimeBits(mod)) {
-        try code.writer().writeByteNTimes(0xaa, @divExact(ptr_width, 8));
+        try code.appendNTimes(0xaa, @divExact(ptr_width, 8));
         return Result.ok;
     }
 


### PR DESCRIPTION
Both ways do the same thing but I think the compiler might have an easier time optimizing `appendNTimes` because it does less things/the path is shorter.

I have not done any benchmarking at runtime but have compared the instruction count of both ways a little here: https://zig.godbolt.org/z/vr193W9oj `b` (`appendNTimes`) is ~103 instructions while `a` (`writer().writeByteNTimes`) is ~117 instructions.

And looking at the implementation of `writeByteNTimes`, it only seems to buffer up 256 bytes before doing another `writeAll` which for `std.ArrayList` probably means another allocation, whereas when directly using `appendNTimes`, the entire exact additional capacity required is known from the start.

Either way, this would be more consistent anyway.