### PR TITLE
langref: improve atomics documentation

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8625,12 +8625,23 @@ test "@hasDecl" {
       The following packages are always available:
       </p>
       <ul>
-          <li>{#syntax#}@import("std"){#endsyntax#} - Zig Standard Library</li>
-          <li>{#syntax#}@import("builtin"){#endsyntax#} - Target-specific information
-              The command <code>zig build-exe --show-builtin</code> outputs the source to stdout for reference.
+          <li>
+              {#syntax#}@import("std"){#endsyntax#} - Zig Standard Library
+              <p>
+              This is <code>lib/std.zig</code> and can be changed by passing a different directory to <code>--zig-lib-dir</code>.
+              </p>
           </li>
-          <li>{#syntax#}@import("root"){#endsyntax#} - Root source file
-              This is usually <code>src/main.zig</code> but depends on what file is built.
+          <li>
+              {#syntax#}@import("builtin"){#endsyntax#} - Target-specific information
+              <p>
+              The command <code>zig build-exe --show-builtin</code> outputs the source to stdout for reference.
+              </p>
+          </li>
+          <li>
+              {#syntax#}@import("root"){#endsyntax#} - Root source file
+              <p>
+              This is often <code>src/main.zig</code> but depends on which file is built.
+              </p>
           </li>
       </ul>
       {#see_also|Compile Variables|@embedFile#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7829,7 +7829,7 @@ comptime {
       {#header_close#}
 
       {#header_open|@atomicLoad#}
-      <pre>{#syntax#}@atomicLoad(comptime T: type, ptr: *const T, comptime ordering: builtin.AtomicOrder) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@atomicLoad(comptime T: type, ptr: *const T, comptime ordering: std.builtin.AtomicOrder) T{#endsyntax#}</pre>
       <p>
       This builtin function atomically dereferences a pointer to a {#syntax#}T{#endsyntax#} and returns the value.
       </p>
@@ -7841,36 +7841,20 @@ comptime {
       {#header_close#}
 
       {#header_open|@atomicRmw#}
-      <pre>{#syntax#}@atomicRmw(comptime T: type, ptr: *T, comptime op: builtin.AtomicRmwOp, operand: T, comptime ordering: builtin.AtomicOrder) T{#endsyntax#}</pre>
+      <pre>{#syntax#}@atomicRmw(comptime T: type, ptr: *T, comptime op: std.builtin.AtomicRmwOp, operand: T, comptime ordering: std.builtin.AtomicOrder) T{#endsyntax#}</pre>
       <p>
       This builtin function dereferences a pointer to a {#syntax#}T{#endsyntax#} and atomically
-      modifies the value and returns the previous value.
+      modifies the value and returns the previous value - "Read-Modify-Write".
       </p>
       <p>
       {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#}, a float,
       an integer or an enum.
       </p>
-      <p>
-      Supported values for the {#syntax#}op{#endsyntax#} parameter:
-      </p>
-      <ul>
-        <li>{#syntax#}.Xchg{#endsyntax#} - stores the operand unmodified. Supports enums, integers and floats.</li>
-        <li>{#syntax#}.Add{#endsyntax#} - for integers, twos complement wraparound addition.
-            Also supports {#link|Floats#}.</li>
-        <li>{#syntax#}.Sub{#endsyntax#} - for integers, twos complement wraparound subtraction.
-            Also supports {#link|Floats#}.</li>
-        <li>{#syntax#}.And{#endsyntax#} - bitwise and</li>
-        <li>{#syntax#}.Nand{#endsyntax#} - bitwise nand</li>
-        <li>{#syntax#}.Or{#endsyntax#} - bitwise or</li>
-        <li>{#syntax#}.Xor{#endsyntax#} - bitwise xor</li>
-        <li>{#syntax#}.Max{#endsyntax#} - stores the operand if it is larger. Supports integers and floats.</li>
-        <li>{#syntax#}.Min{#endsyntax#} - stores the operand if it is smaller. Supports integers and floats.</li>
-      </ul>
       {#see_also|@atomicStore|@atomicLoad|@fence|@cmpxchgWeak|@cmpxchgStrong#}
       {#header_close#}
 
       {#header_open|@atomicStore#}
-      <pre>{#syntax#}@atomicStore(comptime T: type, ptr: *T, value: T, comptime ordering: builtin.AtomicOrder) void{#endsyntax#}</pre>
+      <pre>{#syntax#}@atomicStore(comptime T: type, ptr: *T, value: T, comptime ordering: std.builtin.AtomicOrder) void{#endsyntax#}</pre>
       <p>
       This builtin function dereferences a pointer to a {#syntax#}T{#endsyntax#} and atomically stores the given value.
       </p>
@@ -8128,7 +8112,7 @@ pub const CallModifier = enum {
       {#header_close#}
 
       {#header_open|@cmpxchgStrong#}
-      <pre>{#syntax#}@cmpxchgStrong(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
+      <pre>{#syntax#}@cmpxchgStrong(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: std.builtin.AtomicOrder, fail_order: std.builtin.AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a strong atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
       if the current value is not the given expected value. It's the equivalent of this code,
@@ -8158,7 +8142,7 @@ fn cmpxchgStrongButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_v
       {#header_close#}
 
       {#header_open|@cmpxchgWeak#}
-      <pre>{#syntax#}@cmpxchgWeak(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
+      <pre>{#syntax#}@cmpxchgWeak(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: std.builtin.AtomicOrder, fail_order: std.builtin.AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a weak atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
       if the current value is not the given expected value. It's the equivalent of this code,
@@ -8471,12 +8455,9 @@ export fn @"A function name that is a complete sentence."() void {}
       {#header_close#}
 
       {#header_open|@fence#}
-      <pre>{#syntax#}@fence(order: AtomicOrder) void{#endsyntax#}</pre>
+      <pre>{#syntax#}@fence(order: std.builtin.AtomicOrder) void{#endsyntax#}</pre>
       <p>
-      The {#syntax#}fence{#endsyntax#} function is used to introduce happens-before edges between operations.
-      </p>
-      <p>
-      {#syntax#}AtomicOrder{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicOrder{#endsyntax#}.
+      The {#syntax#}fence{#endsyntax#} function is used to introduce happens-before edges between atomic operations.
       </p>
       {#see_also|@atomicStore|@atomicLoad|@atomicRmw|@cmpxchgWeak|@cmpxchgStrong#}
       {#header_close#}
@@ -8906,37 +8887,6 @@ test "@wasmMemoryGrow" {
       address to prefetch. This function does not dereference the pointer, it is perfectly legal
       to pass a pointer to invalid memory to this function and no illegal behavior will result.
       </p>
-      <p>
-      The {#syntax#}options{#endsyntax#} argument is the following struct:
-      </p>
-      {#code_begin|syntax|builtin#}
-/// This data structure is used by the Zig language code generation and
-/// therefore must be kept in sync with the compiler implementation.
-pub const PrefetchOptions = struct {
-    /// Whether the prefetch should prepare for a read or a write.
-    rw: Rw = .read,
-    /// The data's locality in an inclusive range from 0 to 3.
-    ///
-    /// 0 means no temporal locality. That is, the data can be immediately
-    /// dropped from the cache after it is accessed.
-    ///
-    /// 3 means high temporal locality. That is, the data should be kept in
-    /// the cache as it is likely to be accessed again soon.
-    locality: u2 = 3,
-    /// The cache that the prefetch should be preformed on.
-    cache: Cache = .data,
-
-    pub const Rw = enum(u1) {
-        read,
-        write,
-    };
-
-    pub const Cache = enum(u1) {
-        instruction,
-        data,
-    };
-};
-      {#code_end#}
       {#header_close#}
 
       {#header_open|@ptrCast#}
@@ -9065,7 +9015,7 @@ test "foo" {
       {#header_close#}
 
       {#header_open|@setFloatMode#}
-      <pre>{#syntax#}@setFloatMode(comptime mode: @import("std").builtin.FloatMode) void{#endsyntax#}</pre>
+      <pre>{#syntax#}@setFloatMode(comptime mode: std.builtin.FloatMode) void{#endsyntax#}</pre>
       <p>
       Sets the floating point mode of the current scope. Possible values are:
       </p>

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -83,7 +83,9 @@ pub const AtomicOrder = enum {
     Monotonic,
     Acquire,
     Release,
+    /// "Acquire-release"
     AcqRel,
+    /// "Sequentially consistent"
     SeqCst,
 };
 
@@ -102,14 +104,34 @@ pub const ReduceOp = enum {
 /// This data structure is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
 pub const AtomicRmwOp = enum {
+    /// Exchange - store the operand unmodified.
+    /// Supports enums, integers, and floats.
     Xchg,
+    /// Add operand to existing value.
+    /// Supports integers and floats.
+    /// For integers, two's complement wraparound applies.
     Add,
+    /// Subtract operand from existing value.
+    /// Supports integers and floats.
+    /// For integers, two's complement wraparound applies.
     Sub,
+    /// Perform bitwise AND on existing value with operand.
+    /// Supports integers.
     And,
+    /// Perform bitwise NAND on existing value with operand.
+    /// Supports integers.
     Nand,
+    /// Perform bitwise OR on existing value with operand.
+    /// Supports integers.
     Or,
+    /// Perform bitwise XOR on existing value with operand.
+    /// Supports integers.
     Xor,
+    /// Store operand if it is larger than the existing value.
+    /// Supports integers and floats.
     Max,
+    /// Store operand if it is smaller than the existing value.
+    /// Supports integers and floats.
     Min,
 };
 


### PR DESCRIPTION
This does a few things.
* This moves some documentation into `lib/std/builtin.zig` where it belongs.
* Resolves inconsistencies in parameter types.
  Sometimes it was `@import("std").builtin.X`, sometimes `std.builtin.X`, sometimes `builtin.X`, or just `X`.
  Now I changed it all to `std.builtin.X` because it's a good balance
  between not being too long (especially for some of the atomics builtins) while not being ambiguous
  (the `builtin` in `builtin.X` might be mistaken as `@import("builtin")` instead of `std.builtin`).
* No longer copy-pastes `PrefetchOptions` into the langref.
  I think this is just a bad idea long-term. It will get out of date
  over and over and also if we're copy-pasting `PrefetchOptions` why
  aren't we doing that for other structs? That's inconsistent.
  The user should know to reference the standard library documentation
  if they want to know what an std struct that is used in a builtin's prototype does.
  We shouldn't mix std documentation and language documentation.