### PR TITLE
move installation logic to the build script where it belongs

### DIFF
--- a/ci/aarch64-linux-debug.sh
+++ b/ci/aarch64-linux-debug.sh
@@ -40,6 +40,7 @@ cmake .. \
   -DZIG_TARGET_TRIPLE="$TARGET" \
   -DZIG_TARGET_MCPU="$MCPU" \
   -DZIG_STATIC=ON \
+  -DZIG_NO_LIB=ON \
   -GNinja
 
 # Now cmake will use zig as the C/C++ compiler. We reset the environment variables
@@ -49,16 +50,18 @@ unset CXX
 
 ninja install
 
+# TODO: move this to a build.zig step (check-fmt)
 echo "Looking for non-conforming code formatting..."
 stage3-debug/bin/zig fmt --check .. \
   --exclude ../test/cases/ \
   --exclude ../build-debug
 
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
-stage3-debug/bin/zig build -Dtarget=arm-linux-musleabihf
+stage3-debug/bin/zig build \
+  -Dtarget=arm-linux-musleabihf \
+  -Dno-lib
 
 # TODO: add -fqemu back to this line
-
 stage3-debug/bin/zig build test docs \
   --maxrss 24696061952 \
   -fwasmtime \
@@ -68,10 +71,8 @@ stage3-debug/bin/zig build test docs \
   --zig-lib-dir "$(pwd)/../lib"
 
 # Look for HTML errors.
-tidy --drop-empty-elements no -qe "stage3-debug/doc/langref.html"
-
-# Produce the experimental std lib documentation.
-stage3-debug/bin/zig test ../lib/std/std.zig -femit-docs -fno-emit-bin --zig-lib-dir ../lib
+# TODO: move this to a build.zig flag (-Denable-tidy)
+tidy --drop-empty-elements no -qe "zig-out/doc/langref.html"
 
 # Ensure that updating the wasm binary from this commit will result in a viable build.
 stage3-debug/bin/zig build update-zig1
@@ -91,6 +92,7 @@ cmake .. \
   -DZIG_TARGET_TRIPLE="$TARGET" \
   -DZIG_TARGET_MCPU="$MCPU" \
   -DZIG_STATIC=ON \
+  -DZIG_NO_LIB=ON \
   -GNinja
 
 unset CC
@@ -102,6 +104,7 @@ stage3/bin/zig test ../test/behavior.zig -I../test
 stage3/bin/zig build -p stage4 \
   -Dstatic-llvm \
   -Dtarget=native-native-musl \
+  -Dno-lib \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$(pwd)/../lib"
 stage4/bin/zig test ../test/behavior.zig -I../test

--- a/ci/aarch64-macos-debug.sh
+++ b/ci/aarch64-macos-debug.sh
@@ -39,6 +39,7 @@ PATH="$HOME/local/bin:$PATH" cmake .. \
   -DZIG_TARGET_TRIPLE="$TARGET" \
   -DZIG_TARGET_MCPU="$MCPU" \
   -DZIG_STATIC=ON \
+  -DZIG_NO_LIB=ON \
   -GNinja
 
 $HOME/local/bin/ninja install
@@ -49,6 +50,3 @@ stage3-debug/bin/zig build test docs \
   -Dstatic-llvm \
   -Dskip-non-native \
   --search-prefix "$PREFIX"
-
-# Produce the experimental std lib documentation.
-stage3-debug/bin/zig test ../lib/std/std.zig -femit-docs -fno-emit-bin --zig-lib-dir ../lib

--- a/ci/aarch64-macos-release.sh
+++ b/ci/aarch64-macos-release.sh
@@ -39,6 +39,7 @@ PATH="$HOME/local/bin:$PATH" cmake .. \
   -DZIG_TARGET_TRIPLE="$TARGET" \
   -DZIG_TARGET_MCPU="$MCPU" \
   -DZIG_STATIC=ON \
+  -DZIG_NO_LIB=ON \
   -GNinja
 
 $HOME/local/bin/ninja install
@@ -49,9 +50,6 @@ stage3-release/bin/zig build test docs \
   -Dstatic-llvm \
   -Dskip-non-native \
   --search-prefix "$PREFIX"
-
-# Produce the experimental std lib documentation.
-stage3-release/bin/zig test ../lib/std/std.zig -femit-docs -fno-emit-bin --zig-lib-dir ../lib
 
 # Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3-release/bin/zig build \

--- a/ci/aarch64-windows.ps1
+++ b/ci/aarch64-windows.ps1
@@ -55,7 +55,8 @@ $Env:ZIG_LOCAL_CACHE_DIR="$(Get-Location)\zig-local-cache"
   -DZIG_AR_WORKAROUND=ON `
   -DZIG_TARGET_TRIPLE="$TARGET" `
   -DZIG_TARGET_MCPU="$MCPU" `
-  -DZIG_STATIC=ON
+  -DZIG_STATIC=ON `
+  -DZIG_NO_LIB=ON
 CheckLastExitCode
 
 ninja install
@@ -69,11 +70,3 @@ Write-Output "Main test suite..."
   -Dskip-non-native `
   -Denable-symlinks-windows
 CheckLastExitCode
-
-Write-Output "Testing Autodocs..."
-& "stage3-release\bin\zig.exe" test "..\lib\std\std.zig" `
-  --zig-lib-dir "$ZIG_LIB_DIR" `
-  -femit-docs `
-  -fno-emit-bin
-CheckLastExitCode
-

--- a/ci/x86_64-linux-debug.sh
+++ b/ci/x86_64-linux-debug.sh
@@ -40,6 +40,7 @@ cmake .. \
   -DZIG_TARGET_TRIPLE="$TARGET" \
   -DZIG_TARGET_MCPU="$MCPU" \
   -DZIG_STATIC=ON \
+  -DZIG_NO_LIB=ON \
   -GNinja
 
 # Now cmake will use zig as the C/C++ compiler. We reset the environment variables
@@ -49,13 +50,16 @@ unset CXX
 
 ninja install
 
+# TODO: move this to a build.zig step (check-fmt)
 echo "Looking for non-conforming code formatting..."
 stage3-debug/bin/zig fmt --check .. \
   --exclude ../test/cases/ \
   --exclude ../build-debug
 
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
-stage3-debug/bin/zig build -Dtarget=arm-linux-musleabihf
+stage3-debug/bin/zig build \
+  -Dtarget=arm-linux-musleabihf \
+  -Dno-lib
 
 stage3-debug/bin/zig build test docs \
   --maxrss 21000000000 \
@@ -67,10 +71,8 @@ stage3-debug/bin/zig build test docs \
   --zig-lib-dir "$(pwd)/../lib"
 
 # Look for HTML errors.
-tidy --drop-empty-elements no -qe "stage3-debug/doc/langref.html"
-
-# Produce the experimental std lib documentation.
-stage3-debug/bin/zig test ../lib/std/std.zig -femit-docs -fno-emit-bin --zig-lib-dir ../lib
+# TODO: move this to a build.zig flag (-Denable-tidy)
+tidy --drop-empty-elements no -qe "zig-out/doc/langref.html"
 
 # Ensure that updating the wasm binary from this commit will result in a viable build.
 stage3-debug/bin/zig build update-zig1
@@ -90,6 +92,7 @@ cmake .. \
   -DZIG_TARGET_TRIPLE="$TARGET" \
   -DZIG_TARGET_MCPU="$MCPU" \
   -DZIG_STATIC=ON \
+  -DZIG_NO_LIB=ON \
   -GNinja
 
 unset CC
@@ -101,6 +104,7 @@ stage3/bin/zig test ../test/behavior.zig -I../test
 stage3/bin/zig build -p stage4 \
   -Dstatic-llvm \
   -Dtarget=native-native-musl \
+  -Dno-lib \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$(pwd)/../lib"
 stage4/bin/zig test ../test/behavior.zig -I../test

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -40,6 +40,7 @@ cmake .. \
   -DZIG_TARGET_TRIPLE="$TARGET" \
   -DZIG_TARGET_MCPU="$MCPU" \
   -DZIG_STATIC=ON \
+  -DZIG_NO_LIB=ON \
   -GNinja
 
 # Now cmake will use zig as the C/C++ compiler. We reset the environment variables
@@ -49,6 +50,7 @@ unset CXX
 
 ninja install
 
+# TODO: move this to a build.zig step (check-fmt)
 echo "Looking for non-conforming code formatting..."
 stage3-release/bin/zig fmt --check .. \
   --exclude ../test/cases/ \
@@ -56,7 +58,9 @@ stage3-release/bin/zig fmt --check .. \
   --exclude ../build-release
 
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
-stage3-release/bin/zig build -Dtarget=arm-linux-musleabihf
+stage3-release/bin/zig build \
+  -Dtarget=arm-linux-musleabihf \
+  -Dno-lib
 
 stage3-release/bin/zig build test docs \
   --maxrss 21000000000 \
@@ -68,10 +72,8 @@ stage3-release/bin/zig build test docs \
   --zig-lib-dir "$(pwd)/../lib"
 
 # Look for HTML errors.
-tidy --drop-empty-elements no -qe "stage3-release/doc/langref.html"
-
-# Produce the experimental std lib documentation.
-stage3-release/bin/zig test ../lib/std/std.zig -femit-docs -fno-emit-bin --zig-lib-dir ../lib
+# TODO: move this to a build.zig flag (-Denable-tidy)
+tidy --drop-empty-elements no -qe "zig-out/doc/langref.html"
 
 # Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3-release/bin/zig build \
@@ -107,6 +109,7 @@ cmake .. \
   -DZIG_TARGET_TRIPLE="$TARGET" \
   -DZIG_TARGET_MCPU="$MCPU" \
   -DZIG_STATIC=ON \
+  -DZIG_NO_LIB=ON \
   -GNinja
 
 unset CC
@@ -118,6 +121,7 @@ stage3/bin/zig test ../test/behavior.zig -I../test
 stage3/bin/zig build -p stage4 \
   -Dstatic-llvm \
   -Dtarget=native-native-musl \
+  -Dno-lib \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$(pwd)/../lib"
 stage4/bin/zig test ../test/behavior.zig -I../test

--- a/ci/x86_64-macos-release.sh
+++ b/ci/x86_64-macos-release.sh
@@ -43,7 +43,8 @@ cmake .. \
   -DCMAKE_CXX_COMPILER="$ZIG;c++;-target;$TARGET;-mcpu=$MCPU" \
   -DZIG_TARGET_TRIPLE="$TARGET" \
   -DZIG_TARGET_MCPU="$MCPU" \
-  -DZIG_STATIC=ON
+  -DZIG_STATIC=ON \
+  -DZIG_NO_LIB=ON
 
 make $JOBS install
 
@@ -53,9 +54,6 @@ stage3/bin/zig build test docs \
   -Dstatic-llvm \
   -Dskip-non-native \
   --search-prefix "$PREFIX"
-
-# Produce the experimental std lib documentation.
-stage3/bin/zig test ../lib/std/std.zig -femit-docs -fno-emit-bin --zig-lib-dir ../lib
 
 # Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3/bin/zig build \

--- a/ci/x86_64-windows-debug.ps1
+++ b/ci/x86_64-windows-debug.ps1
@@ -45,7 +45,8 @@ Set-Location -Path 'build-debug'
   -DCMAKE_CXX_COMPILER="$($ZIG -Replace "\\", "/");c++;-target;$TARGET;-mcpu=$MCPU" `
   -DZIG_TARGET_TRIPLE="$TARGET" `
   -DZIG_TARGET_MCPU="$MCPU" `
-  -DZIG_STATIC=ON
+  -DZIG_STATIC=ON `
+  -DZIG_NO_LIB=ON
 CheckLastExitCode
 
 ninja install
@@ -58,13 +59,6 @@ Write-Output "Main test suite..."
   -Dstatic-llvm `
   -Dskip-non-native `
   -Denable-symlinks-windows
-CheckLastExitCode
-
-Write-Output "Testing Autodocs..."
-& "stage3-debug\bin\zig.exe" test "..\lib\std\std.zig" `
-  --zig-lib-dir "$ZIG_LIB_DIR" `
-  -femit-docs `
-  -fno-emit-bin
 CheckLastExitCode
 
 Write-Output "Build x86_64-windows-msvc behavior tests using the C backend..."

--- a/ci/x86_64-windows-release.ps1
+++ b/ci/x86_64-windows-release.ps1
@@ -45,7 +45,8 @@ Set-Location -Path 'build-release'
   -DCMAKE_CXX_COMPILER="$($ZIG -Replace "\\", "/");c++;-target;$TARGET;-mcpu=$MCPU" `
   -DZIG_TARGET_TRIPLE="$TARGET" `
   -DZIG_TARGET_MCPU="$MCPU" `
-  -DZIG_STATIC=ON
+  -DZIG_STATIC=ON `
+  -DZIG_NO_LIB=ON
 CheckLastExitCode
 
 ninja install
@@ -58,13 +59,6 @@ Write-Output "Main test suite..."
   -Dstatic-llvm `
   -Dskip-non-native `
   -Denable-symlinks-windows
-CheckLastExitCode
-
-Write-Output "Testing Autodocs..."
-& "stage3-release\bin\zig.exe" test "..\lib\std\std.zig" `
-  --zig-lib-dir "$ZIG_LIB_DIR" `
-  -femit-docs `
-  -fno-emit-bin
 CheckLastExitCode
 
 Write-Output "Build x86_64-windows-msvc behavior tests using the C backend..."

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -49,7 +49,6 @@ verbose_cc: bool,
 emit_analysis: EmitOption = .default,
 emit_asm: EmitOption = .default,
 emit_bin: EmitOption = .default,
-emit_docs: EmitOption = .default,
 emit_implib: EmitOption = .default,
 emit_llvm_bc: EmitOption = .default,
 emit_llvm_ir: EmitOption = .default,
@@ -217,6 +216,7 @@ output_lib_path_source: GeneratedFile,
 output_h_path_source: GeneratedFile,
 output_pdb_path_source: GeneratedFile,
 output_dirname_source: GeneratedFile,
+generated_docs: ?*GeneratedFile,
 
 pub const CSourceFiles = struct {
     files: []const []const u8,
@@ -433,7 +433,7 @@ pub fn create(owner: *std.Build, options: Options) *Compile {
     }) catch @panic("OOM");
 
     const self = owner.allocator.create(Compile) catch @panic("OOM");
-    self.* = Compile{
+    self.* = .{
         .strip = null,
         .unwind_tables = null,
         .verbose_link = false,
@@ -486,6 +486,7 @@ pub fn create(owner: *std.Build, options: Options) *Compile {
         .output_h_path_source = GeneratedFile{ .step = &self.step },
         .output_pdb_path_source = GeneratedFile{ .step = &self.step },
         .output_dirname_source = GeneratedFile{ .step = &self.step },
+        .generated_docs = null,
 
         .target_info = target_info,
 
@@ -1004,6 +1005,15 @@ pub fn getOutputPdbSource(self: *Compile) FileSource {
     return .{ .generated = &self.output_pdb_path_source };
 }
 
+pub fn getOutputDocs(self: *Compile) FileSource {
+    assert(self.generated_docs == null); // This function may only be called once.
+    const arena = self.step.owner.allocator;
+    const generated_file = arena.create(GeneratedFile) catch @panic("OOM");
+    generated_file.* = .{ .step = &self.step };
+    self.generated_docs = generated_file;
+    return .{ .generated = generated_file };
+}
+
 pub fn addAssemblyFile(self: *Compile, path: []const u8) void {
     const b = self.step.owner;
     self.link_objects.append(.{
@@ -1509,7 +1519,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     if (self.emit_analysis.getArg(b, "emit-analysis")) |arg| try zig_args.append(arg);
     if (self.emit_asm.getArg(b, "emit-asm")) |arg| try zig_args.append(arg);
     if (self.emit_bin.getArg(b, "emit-bin")) |arg| try zig_args.append(arg);
-    if (self.emit_docs.getArg(b, "emit-docs")) |arg| try zig_args.append(arg);
+    if (self.generated_docs != null) try zig_args.append("-femit-docs");
     if (self.emit_implib.getArg(b, "emit-implib")) |arg| try zig_args.append(arg);
     if (self.emit_llvm_bc.getArg(b, "emit-llvm-bc")) |arg| try zig_args.append(arg);
     if (self.emit_llvm_ir.getArg(b, "emit-llvm-ir")) |arg| try zig_args.append(arg);
@@ -2021,6 +2031,10 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
             self.output_pdb_path_source.path = b.pathJoin(
                 &.{ output_dir, self.out_pdb_filename },
             );
+        }
+
+        if (self.generated_docs) |generated_docs| {
+            generated_docs.path = b.pathJoin(&.{ output_dir, "docs" });
         }
     }
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -71,8 +71,10 @@ pub const Emit = struct {
 pub const Options = struct {
     /// This is `null` when `-fno-emit-bin` is used.
     emit: ?Emit,
-    /// This is `null` not building a Windows DLL, or when `-fno-emit-implib` is used.
+    /// This is `null` when not building a Windows DLL, or when `-fno-emit-implib` is used.
     implib_emit: ?Emit,
+    /// This is non-null when `-femit-docs` is provided.
+    docs_emit: ?Emit,
     target: std.Target,
     output_mode: std.builtin.OutputMode,
     link_mode: std.builtin.LinkMode,

--- a/src/main.zig
+++ b/src/main.zig
@@ -622,7 +622,7 @@ const Emit = union(enum) {
         }
     };
 
-    fn resolve(emit: Emit, default_basename: []const u8) !Resolved {
+    fn resolve(emit: Emit, default_basename: []const u8, output_to_cache: bool) !Resolved {
         var resolved: Resolved = .{ .data = null, .dir = null };
         errdefer resolved.deinit();
 
@@ -630,7 +630,10 @@ const Emit = union(enum) {
             .no => {},
             .yes_default_path => {
                 resolved.data = Compilation.EmitLoc{
-                    .directory = .{ .path = null, .handle = fs.cwd() },
+                    .directory = if (output_to_cache) null else .{
+                        .path = null,
+                        .handle = fs.cwd(),
+                    },
                     .basename = default_basename,
                 };
             },
@@ -2750,7 +2753,7 @@ fn buildOutputType(
     };
 
     const default_h_basename = try std.fmt.allocPrint(arena, "{s}.h", .{root_name});
-    var emit_h_resolved = emit_h.resolve(default_h_basename) catch |err| {
+    var emit_h_resolved = emit_h.resolve(default_h_basename, output_to_cache) catch |err| {
         switch (emit_h) {
             .yes => |p| {
                 fatal("unable to open directory from argument '-femit-h', '{s}': {s}", .{
@@ -2768,7 +2771,7 @@ fn buildOutputType(
     defer emit_h_resolved.deinit();
 
     const default_asm_basename = try std.fmt.allocPrint(arena, "{s}.s", .{root_name});
-    var emit_asm_resolved = emit_asm.resolve(default_asm_basename) catch |err| {
+    var emit_asm_resolved = emit_asm.resolve(default_asm_basename, output_to_cache) catch |err| {
         switch (emit_asm) {
             .yes => |p| {
                 fatal("unable to open directory from argument '-femit-asm', '{s}': {s}", .{
@@ -2786,7 +2789,7 @@ fn buildOutputType(
     defer emit_asm_resolved.deinit();
 
     const default_llvm_ir_basename = try std.fmt.allocPrint(arena, "{s}.ll", .{root_name});
-    var emit_llvm_ir_resolved = emit_llvm_ir.resolve(default_llvm_ir_basename) catch |err| {
+    var emit_llvm_ir_resolved = emit_llvm_ir.resolve(default_llvm_ir_basename, output_to_cache) catch |err| {
         switch (emit_llvm_ir) {
             .yes => |p| {
                 fatal("unable to open directory from argument '-femit-llvm-ir', '{s}': {s}", .{
@@ -2804,7 +2807,7 @@ fn buildOutputType(
     defer emit_llvm_ir_resolved.deinit();
 
     const default_llvm_bc_basename = try std.fmt.allocPrint(arena, "{s}.bc", .{root_name});
-    var emit_llvm_bc_resolved = emit_llvm_bc.resolve(default_llvm_bc_basename) catch |err| {
+    var emit_llvm_bc_resolved = emit_llvm_bc.resolve(default_llvm_bc_basename, output_to_cache) catch |err| {
         switch (emit_llvm_bc) {
             .yes => |p| {
                 fatal("unable to open directory from argument '-femit-llvm-bc', '{s}': {s}", .{
@@ -2822,7 +2825,7 @@ fn buildOutputType(
     defer emit_llvm_bc_resolved.deinit();
 
     const default_analysis_basename = try std.fmt.allocPrint(arena, "{s}-analysis.json", .{root_name});
-    var emit_analysis_resolved = emit_analysis.resolve(default_analysis_basename) catch |err| {
+    var emit_analysis_resolved = emit_analysis.resolve(default_analysis_basename, output_to_cache) catch |err| {
         switch (emit_analysis) {
             .yes => |p| {
                 fatal("unable to open directory from argument '-femit-analysis',  '{s}': {s}", .{
@@ -2839,7 +2842,7 @@ fn buildOutputType(
     };
     defer emit_analysis_resolved.deinit();
 
-    var emit_docs_resolved = emit_docs.resolve("docs") catch |err| {
+    var emit_docs_resolved = emit_docs.resolve("docs", output_to_cache) catch |err| {
         switch (emit_docs) {
             .yes => |p| {
                 fatal("unable to open directory from argument '-femit-docs', '{s}': {s}", .{
@@ -2873,7 +2876,7 @@ fn buildOutputType(
     const default_implib_basename = try std.fmt.allocPrint(arena, "{s}.lib", .{root_name});
     var emit_implib_resolved = switch (emit_implib) {
         .no => Emit.Resolved{ .data = null, .dir = null },
-        .yes => |p| emit_implib.resolve(default_implib_basename) catch |err| {
+        .yes => |p| emit_implib.resolve(default_implib_basename, output_to_cache) catch |err| {
             fatal("unable to open directory from argument '-femit-implib', '{s}': {s}", .{
                 p, @errorName(err),
             });
@@ -3566,7 +3569,21 @@ fn serveUpdateResults(s: *Server, comp: *Compilation) !void {
     defer error_bundle.deinit(gpa);
     if (error_bundle.errorMessageCount() > 0) {
         try s.serveErrorBundle(error_bundle);
-    } else if (comp.bin_file.options.emit) |emit| {
+        return;
+    }
+    // This logic is a bit counter-intuitive because the protocol implies that
+    // each emitted artifact could possibly be in a different location, when in
+    // reality, there is only one artifact output directory, and the build
+    // system depends on that fact. So, until the protocol is changed to
+    // reflect this, this logic only needs to ensure that emit_bin_path is
+    // emitted for at least one thing, if there are any artifacts.
+    if (comp.bin_file.options.emit) |emit| {
+        const full_path = try emit.directory.join(gpa, &.{emit.sub_path});
+        defer gpa.free(full_path);
+        try s.serveEmitBinPath(full_path, .{
+            .flags = .{ .cache_hit = comp.last_update_was_cache_hit },
+        });
+    } else if (comp.bin_file.options.docs_emit) |emit| {
         const full_path = try emit.directory.join(gpa, &.{emit.sub_path});
         defer gpa.free(full_path);
         try s.serveEmitBinPath(full_path, .{


### PR DESCRIPTION
* build.zig: introduce `-Dflat` option which makes the installation match what we want to ship for our download tarballs. This allows deleting a bunch of shell script logic from the CI.
  - for example it puts the executable directly in prefix/zig rather than prefix/bin/zig and it additionally includes prefix/LICENSE.
* build.zig: by default also install std lib documentation to doc/std/
  - this can be disabled by `-Dno-autodocs` similar to how there is already `-Dno-langref`.
* build.zig: add `std-docs` and `langref` steps which build and install the std lib autodocs and langref to prefix/doc/std and prefix/doc/langref.html, respectively.

* std.Build: implement proper handling of `-femit-docs` using the LazyPath system. This is a breaking change.
  - this is a partial implementation of #16351
* frontend: fixed the handling of Autodocs with regards to caching and putting the artifacts in the proper location to integrate with the build system.
  - closes #15864

* CI: delete the logic for autodocs since it is now handled by build.zig and is enabled by default.
  - in the future we should strive to have nearly all the CI shell script logic deleted in favor of `zig build` commands.
* CI: pass `-DZIG_NO_LIB=ON`/`-Dno-lib` except for the one command where we want to actually generate the langref and autodocs. Generating the langref takes 14 minutes right now (why?!) so we don't want to do that more times than necessary.

* Autodoc: fixed use of a global variable. It works fine as a local variable instead.
  - note that in the future we will want to make Autodoc run simultaneously using the job system, but for now the principle of YAGNI dictates that we don't have an init()/deinit() API and instead simply call the function that does the things.
* Autodoc: only do it when there are no compile errors

------

After this is merged, I can make the following diff to zig-bootstrap:

```diff
--- a/build
+++ b/build
@@ -60,6 +60,7 @@ cmake "$ROOTDIR/zig" \
   -DCMAKE_INSTALL_PREFIX="$ROOTDIR/out/host" \
   -DCMAKE_PREFIX_PATH="$ROOTDIR/out/host" \
   -DCMAKE_BUILD_TYPE=Release \
+  -DZIG_NO_LIB=ON \
   -DZIG_VERSION="$ZIG_VERSION"
 cmake --build . --target install
 
@@ -192,6 +193,7 @@ cd "$ROOTDIR/zig"
 $ZIG build \
   --prefix "$ROOTDIR/out/zig-$TARGET-$MCPU" \
   --search-prefix "$ROOTDIR/out/$TARGET-$MCPU" \
+  -Dflat \
   -Dstatic-llvm \
   -Doptimize=ReleaseFast \
   -Dstrip \
```

Then I can make the following diff to the website repository:

```diff
diff --git a/.github/workflows/build-tarballs.sh b/.github/workflows/build-tarballs.sh
index acafbdf8..48309544 100755
--- a/.github/workflows/build-tarballs.sh
+++ b/.github/workflows/build-tarballs.sh
@@ -97,8 +97,7 @@ CMAKE_GENERATOR=Ninja ./build x86-linux-musl baseline
 CMAKE_GENERATOR=Ninja ./build x86_64-windows-gnu baseline
 CMAKE_GENERATOR=Ninja ./build aarch64-windows-gnu baseline
 CMAKE_GENERATOR=Ninja ./build x86-windows-gnu baseline
-
-# CMAKE_GENERATOR=Ninja ./build arm-linux-musleabihf generic+v7a
+CMAKE_GENERATOR=Ninja ./build arm-linux-musleabihf generic+v7a
 
 ZIG="$BOOTSTRAP_SRC/out/host/bin/zig"
 
@@ -109,7 +108,7 @@ cp -r $BOOTSTRAP_SRC/out/zig-x86_64-macos-none-baseline zig-macos-x86_64-$ZIG_VE
 cp -r $BOOTSTRAP_SRC/out/zig-aarch64-linux-musl-baseline zig-linux-aarch64-$ZIG_VERSION/
 cp -r $BOOTSTRAP_SRC/out/zig-aarch64-macos-none-apple_a14 zig-macos-aarch64-$ZIG_VERSION/
 cp -r $BOOTSTRAP_SRC/out/zig-x86-linux-musl-baseline zig-linux-x86-$ZIG_VERSION/
-#cp -r $BOOTSTRAP_SRC/out/zig-arm-linux-musleabihf-generic+v7a zig-linux-armv7a-$ZIG_VERSION/
+cp -r $BOOTSTRAP_SRC/out/zig-arm-linux-musleabihf-generic+v7a zig-linux-armv7a-$ZIG_VERSION/
 cp -r $BOOTSTRAP_SRC/out/zig-riscv64-linux-musl-baseline zig-linux-riscv64-$ZIG_VERSION/
 cp -r $BOOTSTRAP_SRC/out/zig-powerpc64le-linux-musl-baseline zig-linux-powerpc64le-$ZIG_VERSION/
 cp -r $BOOTSTRAP_SRC/out/zig-powerpc-linux-musl-baseline zig-linux-powerpc-$ZIG_VERSION/
@@ -118,96 +117,12 @@ cp -r $BOOTSTRAP_SRC/out/zig-aarch64-windows-gnu-baseline zig-windows-aarch64-$Z
 cp -r $BOOTSTRAP_SRC/out/zig-x86-windows-gnu-baseline zig-windows-x86-$ZIG_VERSION/
 #cp -r $BOOTSTRAP_SRC/out/zig-x86_64-freebsd-gnu-baseline zig-freebsd-x86_64-$ZIG_VERSION/
 
-mv zig-linux-x86_64-$ZIG_VERSION/bin/zig         zig-linux-x86_64-$ZIG_VERSION/zig
-mv zig-macos-x86_64-$ZIG_VERSION/bin/zig         zig-macos-x86_64-$ZIG_VERSION/zig
-mv zig-linux-aarch64-$ZIG_VERSION/bin/zig        zig-linux-aarch64-$ZIG_VERSION/zig
-mv zig-macos-aarch64-$ZIG_VERSION/bin/zig        zig-macos-aarch64-$ZIG_VERSION/zig
-mv zig-linux-x86-$ZIG_VERSION/bin/zig            zig-linux-x86-$ZIG_VERSION/zig
-#mv zig-linux-armv7a-$ZIG_VERSION/bin/zig        zig-linux-armv7a-$ZIG_VERSION/zig
-mv zig-linux-riscv64-$ZIG_VERSION/bin/zig        zig-linux-riscv64-$ZIG_VERSION/zig
-mv zig-linux-powerpc64le-$ZIG_VERSION/bin/zig    zig-linux-powerpc64le-$ZIG_VERSION/zig
-mv zig-linux-powerpc-$ZIG_VERSION/bin/zig        zig-linux-powerpc-$ZIG_VERSION/zig
-mv zig-windows-x86_64-$ZIG_VERSION/bin/zig.exe   zig-windows-x86_64-$ZIG_VERSION/zig.exe
-mv zig-windows-aarch64-$ZIG_VERSION/bin/zig.exe  zig-windows-aarch64-$ZIG_VERSION/zig.exe
-mv zig-windows-x86-$ZIG_VERSION/bin/zig.exe      zig-windows-x86-$ZIG_VERSION/zig.exe
-#mv zig-freebsd-x86_64-$ZIG_VERSION/bin/zig      zig-freebsd-x86_64-$ZIG_VERSION/zig
-
-mv zig-linux-x86_64-$ZIG_VERSION/lib zig-linux-x86_64-$ZIG_VERSION/lib2
-mv zig-macos-x86_64-$ZIG_VERSION/lib zig-macos-x86_64-$ZIG_VERSION/lib2
-mv zig-linux-aarch64-$ZIG_VERSION/lib zig-linux-aarch64-$ZIG_VERSION/lib2
-mv zig-macos-aarch64-$ZIG_VERSION/lib zig-macos-aarch64-$ZIG_VERSION/lib2
-mv zig-linux-x86-$ZIG_VERSION/lib zig-linux-x86-$ZIG_VERSION/lib2
-#mv zig-linux-armv7a-$ZIG_VERSION/lib zig-linux-armv7a-$ZIG_VERSION/lib2
-mv zig-linux-riscv64-$ZIG_VERSION/lib zig-linux-riscv64-$ZIG_VERSION/lib2
-mv zig-linux-powerpc64le-$ZIG_VERSION/lib zig-linux-powerpc64le-$ZIG_VERSION/lib2
-mv zig-linux-powerpc-$ZIG_VERSION/lib zig-linux-powerpc-$ZIG_VERSION/lib2
-mv zig-windows-x86_64-$ZIG_VERSION/lib zig-windows-x86_64-$ZIG_VERSION/lib2
-mv zig-windows-aarch64-$ZIG_VERSION/lib zig-windows-aarch64-$ZIG_VERSION/lib2
-mv zig-windows-x86-$ZIG_VERSION/lib zig-windows-x86-$ZIG_VERSION/lib2
-#mv zig-freebsd-x86_64-$ZIG_VERSION/lib zig-freebsd-x86_64-$ZIG_VERSION/lib2
-
-mv zig-linux-x86_64-$ZIG_VERSION/lib2/zig zig-linux-x86_64-$ZIG_VERSION/lib
-mv zig-macos-x86_64-$ZIG_VERSION/lib2/zig zig-macos-x86_64-$ZIG_VERSION/lib
-mv zig-linux-aarch64-$ZIG_VERSION/lib2/zig zig-linux-aarch64-$ZIG_VERSION/lib
-mv zig-macos-aarch64-$ZIG_VERSION/lib2/zig zig-macos-aarch64-$ZIG_VERSION/lib
-mv zig-linux-x86-$ZIG_VERSION/lib2/zig zig-linux-x86-$ZIG_VERSION/lib
-#mv zig-linux-armv7a-$ZIG_VERSION/lib2/zig zig-linux-armv7a-$ZIG_VERSION/lib
-mv zig-linux-riscv64-$ZIG_VERSION/lib2/zig zig-linux-riscv64-$ZIG_VERSION/lib
-mv zig-linux-powerpc64le-$ZIG_VERSION/lib2/zig zig-linux-powerpc64le-$ZIG_VERSION/lib
-mv zig-linux-powerpc-$ZIG_VERSION/lib2/zig zig-linux-powerpc-$ZIG_VERSION/lib
-mv zig-windows-x86_64-$ZIG_VERSION/lib2/zig zig-windows-x86_64-$ZIG_VERSION/lib
-mv zig-windows-aarch64-$ZIG_VERSION/lib2/zig zig-windows-aarch64-$ZIG_VERSION/lib
-mv zig-windows-x86-$ZIG_VERSION/lib2/zig zig-windows-x86-$ZIG_VERSION/lib
-#mv zig-freebsd-x86_64-$ZIG_VERSION/lib2/zig zig-freebsd-x86_64-$ZIG_VERSION/lib
-
-rmdir zig-linux-x86_64-$ZIG_VERSION/bin zig-linux-x86_64-$ZIG_VERSION/lib2
-rmdir zig-macos-x86_64-$ZIG_VERSION/bin zig-macos-x86_64-$ZIG_VERSION/lib2
-rmdir zig-linux-aarch64-$ZIG_VERSION/bin zig-linux-aarch64-$ZIG_VERSION/lib2
-rmdir zig-macos-aarch64-$ZIG_VERSION/bin zig-macos-aarch64-$ZIG_VERSION/lib2
-rmdir zig-linux-x86-$ZIG_VERSION/bin zig-linux-x86-$ZIG_VERSION/lib2
-#rmdir zig-linux-armv7a-$ZIG_VERSION/bin zig-linux-armv7a-$ZIG_VERSION/lib2
-rmdir zig-linux-riscv64-$ZIG_VERSION/bin zig-linux-riscv64-$ZIG_VERSION/lib2
-rmdir zig-linux-powerpc64le-$ZIG_VERSION/bin zig-linux-powerpc64le-$ZIG_VERSION/lib2
-rmdir zig-linux-powerpc-$ZIG_VERSION/bin zig-linux-powerpc-$ZIG_VERSION/lib2
-rmdir zig-windows-x86_64-$ZIG_VERSION/bin zig-windows-x86_64-$ZIG_VERSION/lib2
-rmdir zig-windows-aarch64-$ZIG_VERSION/bin zig-windows-aarch64-$ZIG_VERSION/lib2
-rmdir zig-windows-x86-$ZIG_VERSION/bin zig-windows-x86-$ZIG_VERSION/lib2
-#rmdir zig-freebsd-x86_64-$ZIG_VERSION/bin zig-freebsd-x86_64-$ZIG_VERSION/lib2
-
-cp $ZIGDIR/LICENSE zig-linux-x86_64-$ZIG_VERSION/
-cp $ZIGDIR/LICENSE zig-macos-x86_64-$ZIG_VERSION/
-cp $ZIGDIR/LICENSE zig-linux-aarch64-$ZIG_VERSION/
-cp $ZIGDIR/LICENSE zig-macos-aarch64-$ZIG_VERSION/
-cp $ZIGDIR/LICENSE zig-linux-x86-$ZIG_VERSION/
-#cp $ZIGDIR/LICENSE zig-linux-armv7a-$ZIG_VERSION/
-cp $ZIGDIR/LICENSE zig-linux-riscv64-$ZIG_VERSION/
-cp $ZIGDIR/LICENSE zig-linux-powerpc64le-$ZIG_VERSION/
-cp $ZIGDIR/LICENSE zig-linux-powerpc-$ZIG_VERSION/
-cp $ZIGDIR/LICENSE zig-windows-x86_64-$ZIG_VERSION/
-cp $ZIGDIR/LICENSE zig-windows-aarch64-$ZIG_VERSION/
-cp $ZIGDIR/LICENSE zig-windows-x86-$ZIG_VERSION/
-#cp $ZIGDIR/LICENSE zig-freebsd-x86_64-$ZIG_VERSION/
-
-"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target x86_64-linux-musl   -femit-docs="zig-linux-x86_64-$ZIG_VERSION/doc/std"    -fno-emit-bin
-"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target x86_64-macos        -femit-docs="zig-macos-x86_64-$ZIG_VERSION/doc/std"    -fno-emit-bin
-"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target aarch64-linux-musl  -femit-docs="zig-linux-aarch64-$ZIG_VERSION/doc/std"   -fno-emit-bin
-"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target aarch64-macos       -femit-docs="zig-macos-aarch64-$ZIG_VERSION/doc/std"   -fno-emit-bin
-"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target x86-linux-musl      -femit-docs="zig-linux-x86-$ZIG_VERSION/doc/std"       -fno-emit-bin
-#"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target arm-linux-musl -mcpu=generic+v7a  -femit-docs="zig-linux-armv7a-$ZIG_VERSION/doc/std" -fno-emit-bin
-"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target riscv64-linux-musl  -femit-docs="zig-linux-riscv64-$ZIG_VERSION/doc/std"   -fno-emit-bin
-"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target powerpc64le-linux-musl -femit-docs="zig-linux-powerpc64le-$ZIG_VERSION/doc/std" -fno-emit-bin
-"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target powerpc-linux-musl  -femit-docs="zig-linux-powerpc-$ZIG_VERSION/doc/std"   -fno-emit-bin
-"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target x86_64-windows-gnu  -femit-docs="zig-windows-x86_64-$ZIG_VERSION/doc/std"  -fno-emit-bin
-"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target aarch64-windows-gnu -femit-docs="zig-windows-aarch64-$ZIG_VERSION/doc/std" -fno-emit-bin
-"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target x86-windows-gnu     -femit-docs="zig-windows-x86-$ZIG_VERSION/doc/std"     -fno-emit-bin
-#"$ZIG" test "$BOOTSTRAP_SRC/zig/lib/std/std.zig" --zig-lib-dir "$BOOTSTRAP_SRC/zig/lib" -target x86_64-freebsd     -femit-docs="zig-freebsd-x86_64-$ZIG_VERSION/doc/std"  -fno-emit-bin
-
 XZ_OPT=-9 tar cJf zig-linux-x86_64-$ZIG_VERSION.tar.xz zig-linux-x86_64-$ZIG_VERSION/ --sort=name
 XZ_OPT=-9 tar cJf zig-macos-x86_64-$ZIG_VERSION.tar.xz zig-macos-x86_64-$ZIG_VERSION/ --sort=name
 XZ_OPT=-9 tar cJf zig-linux-aarch64-$ZIG_VERSION.tar.xz zig-linux-aarch64-$ZIG_VERSION/ --sort=name
 XZ_OPT=-9 tar cJf zig-macos-aarch64-$ZIG_VERSION.tar.xz zig-macos-aarch64-$ZIG_VERSION/ --sort=name
 XZ_OPT=-9 tar cJf zig-linux-x86-$ZIG_VERSION.tar.xz zig-linux-x86-$ZIG_VERSION/ --sort=name
-#XZ_OPT=-9 tar cJf zig-linux-armv7a-$ZIG_VERSION.tar.xz zig-linux-armv7a-$ZIG_VERSION/ --sort=name
+XZ_OPT=-9 tar cJf zig-linux-armv7a-$ZIG_VERSION.tar.xz zig-linux-armv7a-$ZIG_VERSION/ --sort=name
 XZ_OPT=-9 tar cJf zig-linux-riscv64-$ZIG_VERSION.tar.xz zig-linux-riscv64-$ZIG_VERSION/ --sort=name
 XZ_OPT=-9 tar cJf zig-linux-powerpc64le-$ZIG_VERSION.tar.xz zig-linux-powerpc64le-$ZIG_VERSION/ --sort=name
 XZ_OPT=-9 tar cJf zig-linux-powerpc-$ZIG_VERSION.tar.xz zig-linux-powerpc-$ZIG_VERSION/ --sort=name
@@ -224,7 +139,7 @@ echo | minisign -Sm zig-macos-x86_64-$ZIG_VERSION.tar.xz
 echo | minisign -Sm zig-linux-aarch64-$ZIG_VERSION.tar.xz
 echo | minisign -Sm zig-macos-aarch64-$ZIG_VERSION.tar.xz
 echo | minisign -Sm zig-linux-x86-$ZIG_VERSION.tar.xz
-#echo | minisign -Sm zig-linux-armv7a-$ZIG_VERSION.tar.xz
+echo | minisign -Sm zig-linux-armv7a-$ZIG_VERSION.tar.xz
 echo | minisign -Sm zig-linux-riscv64-$ZIG_VERSION.tar.xz
 echo | minisign -Sm zig-linux-powerpc64le-$ZIG_VERSION.tar.xz
 echo | minisign -Sm zig-linux-powerpc-$ZIG_VERSION.tar.xz
@@ -242,7 +157,7 @@ s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" z
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-aarch64-$ZIG_VERSION.tar.xz s3://ziglang.org/builds/
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-macos-aarch64-$ZIG_VERSION.tar.xz s3://ziglang.org/builds/
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-x86-$ZIG_VERSION.tar.xz s3://ziglang.org/builds/
-#s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-armv7a-$ZIG_VERSION.tar.xz s3://ziglang.org/builds/
+s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-armv7a-$ZIG_VERSION.tar.xz s3://ziglang.org/builds/
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-riscv64-$ZIG_VERSION.tar.xz s3://ziglang.org/builds/
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-powerpc64le-$ZIG_VERSION.tar.xz s3://ziglang.org/builds/
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-powerpc-$ZIG_VERSION.tar.xz s3://ziglang.org/builds/
@@ -258,7 +173,7 @@ s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" z
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-aarch64-$ZIG_VERSION.tar.xz.minisig s3://ziglang.org/builds/
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-macos-aarch64-$ZIG_VERSION.tar.xz.minisig s3://ziglang.org/builds/
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-x86-$ZIG_VERSION.tar.xz.minisig s3://ziglang.org/builds/
-#s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-armv7a-$ZIG_VERSION.tar.xz.minisig s3://ziglang.org/builds/
+s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-armv7a-$ZIG_VERSION.tar.xz.minisig s3://ziglang.org/builds/
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-riscv64-$ZIG_VERSION.tar.xz.minisig s3://ziglang.org/builds/
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-powerpc64le-$ZIG_VERSION.tar.xz.minisig s3://ziglang.org/builds/
 s3cmd put -P --add-header="cache-control: public, max-age=31536000, immutable" zig-linux-powerpc-$ZIG_VERSION.tar.xz.minisig s3://ziglang.org/builds/
@@ -286,6 +201,10 @@ export AARCH64_LINUX_TARBALL="zig-linux-aarch64-$ZIG_VERSION.tar.xz"
 export AARCH64_LINUX_BYTESIZE=$(wc -c < "zig-linux-aarch64-$ZIG_VERSION.tar.xz")
 export AARCH64_LINUX_SHASUM="$(sha256sum "zig-linux-aarch64-$ZIG_VERSION.tar.xz" | cut '-d ' -f1)"
 
+export ARMV7A_LINUX_TARBALL="zig-linux-armv7a-$ZIG_VERSION.tar.xz"
+export ARMV7A_LINUX_BYTESIZE=$(wc -c < "zig-linux-armv7a-$ZIG_VERSION.tar.xz")
+export ARMV7A_LINUX_SHASUM="$(sha256sum "zig-linux-armv7a-$ZIG_VERSION.tar.xz" | cut '-d ' -f1)"
+
 export AARCH64_MACOS_TARBALL="zig-macos-aarch64-$ZIG_VERSION.tar.xz"
 export AARCH64_MACOS_BYTESIZE=$(wc -c < "zig-macos-aarch64-$ZIG_VERSION.tar.xz")
 export AARCH64_MACOS_SHASUM="$(sha256sum "zig-macos-aarch64-$ZIG_VERSION.tar.xz" | cut '-d ' -f1)"
diff --git a/.github/workflows/index.json b/.github/workflows/index.json
index f55e9ea1..b4e26333 100644
--- a/.github/workflows/index.json
+++ b/.github/workflows/index.json
@@ -34,6 +34,11 @@
       "shasum": "{{AARCH64_LINUX_SHASUM}}",
       "size": "{{AARCH64_LINUX_BYTESIZE}}"
     },
+    "armv7a-linux": {
+      "tarball": "https://ziglang.org/builds/{{ARMV7A_LINUX_TARBALL}}",
+      "shasum": "{{ARMV7A_LINUX_SHASUM}}",
+      "size": "{{ARMV7A_LINUX_BYTESIZE}}"
+    },
     "riscv64-linux": {
       "tarball": "https://ziglang.org/builds/{{RISCV64_LINUX_TARBALL}}",
       "shasum": "{{RISCV64_LINUX_SHASUM}}",
```