### PR TITLE
std.json: support parsing json at comptime using FixedBufferAllocator

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -436,7 +436,7 @@ pub const FixedBufferAllocator = struct {
         const self: *FixedBufferAllocator = @ptrCast(@alignCast(ctx));
         _ = log2_buf_align;
         _ = return_address;
-        assert(self.ownsSlice(buf)); // sanity check
+        assert(@inComptime() or self.ownsSlice(buf));
 
         if (!self.isLastAllocation(buf)) {
             if (new_size > buf.len) return false;
@@ -465,7 +465,7 @@ pub const FixedBufferAllocator = struct {
         const self: *FixedBufferAllocator = @ptrCast(@alignCast(ctx));
         _ = log2_buf_align;
         _ = return_address;
-        assert(self.ownsSlice(buf)); // sanity check
+        assert(@inComptime() or self.ownsSlice(buf));
 
         if (self.isLastAllocation(buf)) {
             self.end_index -= buf.len;


### PR DESCRIPTION
Updates `std.heap.FixedBufferAllocator` to skip ownership assertions at comptime. Adds a test that verifies this enables json parsing at comptime. Removes redundant (and ableist) language "sanity check" on an assertion.

I'm not totally clear on what the implications are of skipping the ownership assertions at comptime, but I think it's ok?
