### PR TITLE
std.http: add identity to content encodings

### DIFF
--- a/lib/std/http.zig
+++ b/lib/std/http.zig
@@ -285,6 +285,7 @@ pub const TransferEncoding = enum {
 };
 
 pub const ContentEncoding = enum {
+    identity,
     compress,
     deflate,
     gzip,

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -762,6 +762,7 @@ pub const Request = struct {
                 req.response.skip = false;
                 if (!req.response.parser.done) {
                     if (req.response.transfer_compression) |tc| switch (tc) {
+                        .identity => req.response.compression = .none,
                         .compress => return error.CompressionNotSupported,
                         .deflate => req.response.compression = .{
                             .deflate = std.compress.zlib.decompressStream(req.client.allocator, req.transferReader()) catch return error.CompressionInitializationFailed,


### PR DESCRIPTION
Some servers will respond with the identity encoding, meaning no encoding, especially when responding to range-get requests. Adding the identity encoding stops the header parser from failing when it encounters this.