### PR TITLE
os.renameatW: Handle OBJECT_NAME_COLLISION from NtSetInformationFile

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2674,6 +2674,7 @@ pub fn renameatW(
         .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
         .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
         .NOT_SAME_DEVICE => return error.RenameAcrossMountPoints,
+        .OBJECT_NAME_COLLISION => return error.PathAlreadyExists,
         else => return windows.unexpectedStatus(rc),
     }
 }


### PR DESCRIPTION
Partially addresses #16374 (see also #16492)