### PR TITLE
Handle `INVALID_DEVICE_REQUEST` in `std.os.windows.DeviceIoControl`

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -236,6 +236,7 @@ pub fn DeviceIoControl(
         .SUCCESS => {},
         .PRIVILEGE_NOT_HELD => return error.AccessDenied,
         .ACCESS_DENIED => return error.AccessDenied,
+        .INVALID_DEVICE_REQUEST => return error.AccessDenied, // Not supported by the underlying filesystem
         .INVALID_PARAMETER => unreachable,
         else => return unexpectedStatus(rc),
     }


### PR DESCRIPTION
This is possible when e.g. calling CreateSymbolicLink on a FAT32 filesystem.

---

In combination with #16492, #16498, and #16499, this is the last piece of the puzzle that will allow all the standard library tests to be run on a FAT32 filesystem without any failures.

```
E:\zigstd> zig test lib\std\std.zig --zig-lib-dir lib --main-pkg-path lib/std
2429 passed; 99 skipped; 0 failed.
```