### PR TITLE
build: split `--verbose` to specific flags

### DIFF
--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -116,8 +116,12 @@ pub fn main() !void {
                     usageAndErr(builder, false, stderr_stream);
             }
         } else if (mem.startsWith(u8, arg, "-")) {
-            if (mem.eql(u8, arg, "--verbose")) {
-                builder.verbose = true;
+            if (mem.eql(u8, arg, "--verbose-spawn")) {
+                builder.verbose_spawn = true;
+            } else if (mem.eql(u8, arg, "--verbose-install")) {
+                builder.verbose_install = true;
+            } else if (mem.eql(u8, arg, "--verbose-uninstall")) {
+                builder.verbose_uninstall = true;
             } else if (mem.eql(u8, arg, "-h") or mem.eql(u8, arg, "--help")) {
                 return usage(builder, false, stdout_stream);
             } else if (mem.eql(u8, arg, "-p") or mem.eql(u8, arg, "--prefix")) {
@@ -988,7 +992,9 @@ fn usage(builder: *std.Build, already_ran_build: bool, out_stream: anytype) !voi
         \\
         \\  -h, --help                   Print this help and exit
         \\  -l, --list-steps             Print available steps
-        \\  --verbose                    Print commands before executing them
+        \\  --verbose-spawn              Print to stderr the commandline before spawning any child process
+        \\  --verbose-install            Print to stderr more info during install step (copying build artifacts)
+        \\  --verbose-uninstall          Print to stderr more info during uninstall step (removing build artifacts)
         \\  --color [auto|off|on]        Enable or disable colored error messages
         \\  --summary [mode]             Control the printing of the build summary
         \\    all                        Print the build summary in its entirety

--- a/lib/std/Build/Step/InstallArtifact.zig
+++ b/lib/std/Build/Step/InstallArtifact.zig
@@ -135,6 +135,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                 full_src_path, full_dest_path, @errorName(err),
             });
         };
+        Step.handleVerboseInstallUpdateFile(dest_builder, p, full_dest_path);
         all_cached = all_cached and p == .fresh;
 
         if (self.dylib_symlinks) |dls| {
@@ -152,6 +153,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                 full_src_path, full_implib_path, @errorName(err),
             });
         };
+        Step.handleVerboseInstallUpdateFile(dest_builder, p, full_implib_path);
         all_cached = all_cached and p == .fresh;
     }
 
@@ -163,6 +165,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                 full_src_path, full_pdb_path, @errorName(err),
             });
         };
+        Step.handleVerboseInstallUpdateFile(dest_builder, p, full_pdb_path);
         all_cached = all_cached and p == .fresh;
     }
 
@@ -174,6 +177,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                 full_src_path, full_h_path, @errorName(err),
             });
         };
+        Step.handleVerboseInstallUpdateFile(dest_builder, p, full_h_path);
         all_cached = all_cached and p == .fresh;
     }
 

--- a/lib/std/Build/Step/InstallDir.zig
+++ b/lib/std/Build/Step/InstallDir.zig
@@ -104,7 +104,11 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
             .file => {
                 for (self.options.blank_extensions) |ext| {
                     if (mem.endsWith(u8, entry.path, ext)) {
-                        try dest_builder.truncateFile(dest_path);
+                        if (dest_builder.verbose_install) {
+                            // log implementation responsible for acquiring stdErr mutex
+                            std.log.info("truncate {s}", .{dest_path});
+                        }
+                        try std.Build.truncateFile(dest_path);
                         continue :next_entry;
                     }
                 }
@@ -120,6 +124,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                         src_builder.build_root, src_sub_path, dest_path, @errorName(err),
                     });
                 };
+                Step.handleVerboseInstallUpdateFile(dest_builder, prev_status, dest_path);
                 all_cached = all_cached and prev_status == .fresh;
             },
             else => continue,

--- a/lib/std/Build/Step/InstallFile.zig
+++ b/lib/std/Build/Step/InstallFile.zig
@@ -53,5 +53,6 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
             full_src_path, full_dest_path, @errorName(err),
         });
     };
+    Step.handleVerboseInstallUpdateFile(dest_builder, prev, full_dest_path);
     step.result_cached = prev == .fresh;
 }

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -657,7 +657,7 @@ fn runCommand(
     const cwd: ?[]const u8 = if (self.cwd) |lazy_cwd| lazy_cwd.getPath(b) else null;
 
     try step.handleChildProcUnsupported(cwd, argv);
-    try Step.handleVerbose2(step.owner, cwd, self.env_map, argv);
+    try Step.handleVerboseSpawn2(step.owner, cwd, self.env_map, argv);
 
     const allow_skip = switch (self.stdio) {
         .check, .zig_test => self.skip_foreign_checks,
@@ -784,7 +784,7 @@ fn runCommand(
                 self.addPathForDynLibs(exe);
             }
 
-            try Step.handleVerbose2(step.owner, cwd, self.env_map, interp_argv.items);
+            try Step.handleVerboseSpawn2(step.owner, cwd, self.env_map, interp_argv.items);
 
             break :term spawnChildAndCollect(self, interp_argv.items, has_side_effects, prog_node) catch |e| {
                 if (!self.failing_to_execute_foreign_is_an_error) return error.MakeSkipped;


### PR DESCRIPTION
Usage (excluding initialization) of `build.verbose` appears in two files:

1. lib/std/Build.zig
2. lib/std/Build/Step.zig

As it turns out only Step.zig is relevant in the new context of `--verbose-spawn`. The verbose references in Build.zig are through `makeUninstall` and `truncateFile`. The first of which is a bunch of deletion operations, and the second of which only got called from InstallDir.zig.

The `truncateFile` operation in itself is general enough to not depend on a specific flag and the log call is therefore hoisted to the InstallDir.zig callsite. The logging in InstallDir is then enabled by a new parameter `--verbose-install`. I also took the liberty of adding logging to the result of updateFile operations as well under this flag. The updateFile logic is also used in InstallFile and InstallArtifact, so the helper `handleVerboseInstallUpdateFile` was created and added to all call site results.

Regarding audit of child process invocations in Build.zig and default Steps:

`execAllowFail` is the child process spawning part of the Build API that did not log invocations, so a call to `handleVerboseSpawn2` was added.

The other APIs are `evalZigProcess` and `evalChildProcess`, but they already use the `handleVerboseSpawn` helper.

Closes #14970