### PR TITLE
(WIP) Progress Bar for 3rd Party Packages

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4461,6 +4461,12 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
             try wip_errors.init(gpa);
             defer wip_errors.deinit();
 
+
+ 
+            var progress = std.Progress{};
+            const root_node = progress.start("downloading packages...", 0);
+            defer root_node.end();
+
             // Here we borrow main package's table and will replace it with a fresh
             // one after this process completes.
             const fetch_result = build_pkg.fetchAndAddDependencies(
@@ -4476,7 +4482,11 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
                 "",
                 &wip_errors,
                 &all_modules,
+                root_node,
             );
+
+
+
             if (wip_errors.root_list.items.len > 0) {
                 var errors = try wip_errors.toOwnedBundle("");
                 defer errors.deinit(gpa);


### PR DESCRIPTION
Currently, the total number of dependencies is displayed along with the current iteration. When "content-length" is accessable, that is displayed (in bytes?) along with the dependency name. When encountering a subdependency, another counter is displayed with the name "{parent}.{child}" along with the subdependency count. However, the parent iteration is not incremented. Currently trying to find a fix for that.