### PR TITLE
Fix the http.Server test and add it to the set of tests in http.zig

### DIFF
--- a/lib/std/http.zig
+++ b/lib/std/http.zig
@@ -274,5 +274,6 @@ const std = @import("std.zig");
 test {
     _ = Client;
     _ = Method;
+    _ = Server;
     _ = Status;
 }

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -735,9 +735,12 @@ test "HTTP server handles a chunked transfer coding request" {
 
     const server_thread = try std.Thread.spawn(.{}, (struct {
         fn apply(s: *std.http.Server) !void {
-            const res = try s.accept(.{ .dynamic = max_header_size });
+            var res = try s.accept(.{
+                .allocator = allocator,
+                .header_strategy = .{ .dynamic = max_header_size },
+            });
             defer res.deinit();
-            defer res.reset();
+            defer _ = res.reset();
             try res.wait();
 
             try expect(res.request.transfer_encoding.? == .chunked);


### PR DESCRIPTION
The `std.http.Server` test, "HTTP server handles a chunked transfer coding request", was out of sync with the Server implementation. Additionally we add Server to http.zig's tests so that the test will run when doing a `zig build test-std`.

If we rather not have this test run as part of the test-std that's totally cool, and we can amend this. However I think the test should still be updated to be functional as people use the tests as a form of documentation.