### PR TITLE
CLI: delete dead option -femit-analysis and update -femit-docs buiild system API

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -61,7 +61,7 @@ pub fn build(b: *std.Build) !void {
     autodoc_test.overrideZigLibDir("lib");
     autodoc_test.emit_bin = .no_emit; // https://github.com/ziglang/zig/issues/16351
     const install_std_docs = b.addInstallDirectory(.{
-        .source_dir = autodoc_test.getOutputDocs(),
+        .source_dir = autodoc_test.getEmittedDocs(),
         .install_dir = .prefix,
         .install_subdir = "doc/std",
     });

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -46,7 +46,6 @@ framework_dirs: ArrayList(FileSource),
 frameworks: StringHashMap(FrameworkLinkInfo),
 verbose_link: bool,
 verbose_cc: bool,
-emit_analysis: EmitOption = .default,
 emit_asm: EmitOption = .default,
 emit_bin: EmitOption = .default,
 emit_implib: EmitOption = .default,
@@ -1516,7 +1515,6 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     if (b.verbose_cc or self.verbose_cc) try zig_args.append("--verbose-cc");
     if (b.verbose_llvm_cpu_features) try zig_args.append("--verbose-llvm-cpu-features");
 
-    if (self.emit_analysis.getArg(b, "emit-analysis")) |arg| try zig_args.append(arg);
     if (self.emit_asm.getArg(b, "emit-asm")) |arg| try zig_args.append(arg);
     if (self.emit_bin.getArg(b, "emit-bin")) |arg| try zig_args.append(arg);
     if (self.generated_docs != null) try zig_args.append("-femit-docs");

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1004,8 +1004,8 @@ pub fn getOutputPdbSource(self: *Compile) FileSource {
     return .{ .generated = &self.output_pdb_path_source };
 }
 
-pub fn getOutputDocs(self: *Compile) FileSource {
-    assert(self.generated_docs == null); // This function may only be called once.
+pub fn getEmittedDocs(self: *Compile) FileSource {
+    if (self.generated_docs) |g| return .{ .generated = g };
     const arena = self.step.owner.allocator;
     const generated_file = arena.create(GeneratedFile) catch @panic("OOM");
     generated_file.* = .{ .step = &self.step };

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -179,7 +179,6 @@ test_name_prefix: ?[]const u8,
 emit_asm: ?EmitLoc,
 emit_llvm_ir: ?EmitLoc,
 emit_llvm_bc: ?EmitLoc,
-emit_analysis: ?EmitLoc,
 
 work_queue_wait_group: WaitGroup = .{},
 astgen_wait_group: WaitGroup = .{},
@@ -482,8 +481,6 @@ pub const InitOptions = struct {
     emit_llvm_ir: ?EmitLoc = null,
     /// `null` means to not emit LLVM module bitcode.
     emit_llvm_bc: ?EmitLoc = null,
-    /// `null` means to not emit semantic analysis JSON.
-    emit_analysis: ?EmitLoc = null,
     /// `null` means to not emit docs.
     emit_docs: ?EmitLoc = null,
     /// `null` means to not emit an import lib.
@@ -1589,7 +1586,6 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .emit_asm = options.emit_asm,
             .emit_llvm_ir = options.emit_llvm_ir,
             .emit_llvm_bc = options.emit_llvm_bc,
-            .emit_analysis = options.emit_analysis,
             .work_queue = std.fifo.LinearFifo(Job, .Dynamic).init(gpa),
             .anon_work_queue = std.fifo.LinearFifo(Job, .Dynamic).init(gpa),
             .c_object_work_queue = std.fifo.LinearFifo(*CObject, .Dynamic).init(gpa),
@@ -2328,7 +2324,6 @@ fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifes
     cache_helpers.addOptionalEmitLoc(&man.hash, comp.emit_asm);
     cache_helpers.addOptionalEmitLoc(&man.hash, comp.emit_llvm_ir);
     cache_helpers.addOptionalEmitLoc(&man.hash, comp.emit_llvm_bc);
-    cache_helpers.addOptionalEmitLoc(&man.hash, comp.emit_analysis);
 
     man.hash.addListOfBytes(comp.clang_argv);
 


### PR DESCRIPTION
`-femit-analysis` used to do something with the old autodocs system. Now it does nothing.

As for `getOutputDocs`:
* Allow calling it multiple times.
* Rename it. Sorry, this is to coincide with https://github.com/ziglang/zig/issues/16353.