### PR TITLE
request to remove "unrecognized args" panic from test_runner

### DIFF
--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -26,6 +26,7 @@ pub fn main() void {
             listen = true;
         } else {
             @panic("unrecognized command line argument");
+            //listen = false;
         }
     }
 

--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -25,8 +25,7 @@ pub fn main() void {
         if (std.mem.eql(u8, arg, "--listen=-")) {
             listen = true;
         } else {
-            //@panic("unrecognized command line argument");
-            listen = false;
+            @panic("unrecognized command line argument");
         }
     }
 

--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -25,7 +25,8 @@ pub fn main() void {
         if (std.mem.eql(u8, arg, "--listen=-")) {
             listen = true;
         } else {
-            @panic("unrecognized command line argument");
+            //@panic("unrecognized command line argument");
+            listen = false;
         }
     }
 

--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -24,9 +24,6 @@ pub fn main() void {
     for (args[1..]) |arg| {
         if (std.mem.eql(u8, arg, "--listen=-")) {
             listen = true;
-        } else {
-            @panic("unrecognized command line argument");
-            //listen = false;
         }
     }
 


### PR DESCRIPTION
given this simple args tester:

test "hello" {

   std.debug.print("\n", .{});

   const args = try std.process.argsAlloc(allocator);
   defer std.process.argsFree(allocator, args);

   std.debug.print("ARGS::{s}\n", .{args});

}

in order to run the test and pass random arguments, i have to use a custom test runner which is a copy of the default test runner with the panic removed. I run the command with:
zig test args.zig --test-cmd-bin --test-cmd hello --test-runner .\test_runner_custom.zig

with my edits to the code (the same edits i made for the custom test runner), i can narrow down the command to use the builtin test runner:
zig test args.zig --test-cmd-bin --test-cmd hello

It seems to me like having to use a custom test runner just to pass command line arguments to a test is overkill. I do a lot of testing with random inputs both from stdin as well as cmd args, so it should be more useful if this was part of the default test runner, if possible. I only removed the else statement within the loop checking for the "--listen=-" parameter. After that I recompiled and ran the tests with no apparent issues. I can't imagine what problems allowing unspecified command line arguments in the test runner would cause, since any extra data should be discarded anyway, but I could be wrong. Also this is my first pull request here, so if there's anything I'm not seeing or understanding as to why this might not work, I would be happy to look into that as well.