### PR TITLE
ErrorBundle: remove extra newline

### DIFF
--- a/lib/std/zig/ErrorBundle.zig
+++ b/lib/std/zig/ErrorBundle.zig
@@ -265,7 +265,6 @@ fn renderErrorMessageToWriter(
                     );
                 }
             }
-            try stderr.writeByte('\n');
             try ttyconf.setColor(stderr, .reset);
         }
     } else {


### PR DESCRIPTION
This is another minor change but still makes a visual difference and will reduce the amount you have to scroll in your terminal by a little bit.

Reasoning:
1. The `for (0..src.data.reference_trace_len)` loop will run at least once due to the `src.data.reference_trace_len > 0` check above.
2. In all 3 branches of the `if` in that `for` it will print something.
3. The 3 strings of all of those prints already end in `\n`. Therefore, the extra `try stderr.writeByte('\n');` is unnecessary.

The extra newline looks like this by the way (it's the only empty line at the end):
```
$ zig test x.zig
x.zig:6:21: error: cast discards const qualifier
    const x: []u8 = @ptrCast("a");
                    ^~~~~~~~~~~~~
x.zig:6:21: note: use @constCast to discard const qualifier
referenced by:
    test_0: x.zig:2:5
    remaining reference traces hidden; use '-freference-trace' to see all reference traces

$
```