### PR TITLE
re-enable test "fmt.parseFloat nan and inf" after llvm fix

### DIFF
--- a/lib/std/fmt/parse_float.zig
+++ b/lib/std/fmt/parse_float.zig
@@ -70,11 +70,6 @@ test "fmt.parseFloat" {
 }
 
 test "fmt.parseFloat nan and inf" {
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .aarch64) {
-        // https://github.com/ziglang/zig/issues/12027
-        return error.SkipZigTest;
-    }
-
     inline for ([_]type{ f16, f32, f64, f128 }) |T| {
         const Z = std.meta.Int(.unsigned, @typeInfo(T).Float.bits);
 


### PR DESCRIPTION
Closes #12027.