### PR TITLE
request to add descriptive comment to the top of test_runner.zig

### DIFF
--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -1,3 +1,4 @@
+//! Default test runner for unit tests.
 const std = @import("std");
 const io = std.io;
 const builtin = @import("builtin");


### PR DESCRIPTION
This is a follow-up to my previous request #16522, where @matu3ba suggested it would be useful to add this comment to the top of the test_runner source, so that it would be clear that the default test_runner is for unit testing. This was the source of a lot of confusion for me when trying to understand how the testing system works, so I would like to go ahead and get this added if possible.