### PR TITLE
darwin: drop underscore from SIG._{BLOCK,UNBLOCK,SETMASK}

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -1181,11 +1181,11 @@ pub const SIG = struct {
     pub const HOLD = @as(?Sigaction.handler_fn, @ptrFromInt(5));
 
     /// block specified signal set
-    pub const _BLOCK = 1;
+    pub const BLOCK = 1;
     /// unblock specified signal set
-    pub const _UNBLOCK = 2;
+    pub const UNBLOCK = 2;
     /// set specified signal set
-    pub const _SETMASK = 3;
+    pub const SETMASK = 3;
     /// hangup
     pub const HUP = 1;
     /// interrupt


### PR DESCRIPTION
this makes them match decls in other OSes

the below test case fails on darwin, but succeeds on linux currently; merging this makes it pass on both.

```zig
const builtin = @import("builtin");
const std = @import("std");

test {
    try std.testing.expect(@hasDecl(std.os.SIG, "BLOCK"));
    try std.testing.expect(@hasDecl(std.os.SIG, "UNBLOCK"));
    try std.testing.expect(@hasDecl(std.os.SIG, "SETMASK"));
}
```