### PR TITLE
Add --verbose-generic-instances to provide visibility on the number of generic function instantiations

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -89,6 +89,7 @@ clang_preprocessor_mode: ClangPreprocessorMode,
 verbose_cc: bool,
 verbose_air: bool,
 verbose_intern_pool: bool,
+verbose_generic_instances: bool,
 verbose_llvm_ir: ?[]const u8,
 verbose_llvm_bc: ?[]const u8,
 verbose_cimport: bool,
@@ -599,6 +600,7 @@ pub const InitOptions = struct {
     verbose_link: bool = false,
     verbose_air: bool = false,
     verbose_intern_pool: bool = false,
+    verbose_generic_instances: bool = false,
     verbose_llvm_ir: ?[]const u8 = null,
     verbose_llvm_bc: ?[]const u8 = null,
     verbose_cimport: bool = false,
@@ -1609,6 +1611,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .verbose_cc = options.verbose_cc,
             .verbose_air = options.verbose_air,
             .verbose_intern_pool = options.verbose_intern_pool,
+            .verbose_generic_instances = options.verbose_generic_instances,
             .verbose_llvm_ir = options.verbose_llvm_ir,
             .verbose_llvm_bc = options.verbose_llvm_bc,
             .verbose_cimport = options.verbose_cimport,
@@ -2072,6 +2075,14 @@ pub fn update(comp: *Compilation, main_progress_node: *std.Progress.Node) !void 
                 comp.bin_file.options.root_name,
             });
             module.intern_pool.dump();
+        }
+
+        if (builtin.mode == .Debug and comp.verbose_generic_instances) {
+            std.debug.print("generic instances for '{s}:0x{x}':\n", .{
+                comp.bin_file.options.root_name,
+                @as(usize, @intFromPtr(module)),
+            });
+            module.intern_pool.dumpGenericInstances(comp.gpa);
         }
 
         if (comp.bin_file.options.is_test and comp.totalErrorCount() == 0) {
@@ -5495,6 +5506,7 @@ fn buildOutputFromZig(
         .verbose_link = comp.bin_file.options.verbose_link,
         .verbose_air = comp.verbose_air,
         .verbose_intern_pool = comp.verbose_intern_pool,
+        .verbose_generic_instances = comp.verbose_intern_pool,
         .verbose_llvm_ir = comp.verbose_llvm_ir,
         .verbose_llvm_bc = comp.verbose_llvm_bc,
         .verbose_cimport = comp.verbose_cimport,
@@ -5574,6 +5586,7 @@ pub fn build_crt_file(
         .verbose_link = comp.bin_file.options.verbose_link,
         .verbose_air = comp.verbose_air,
         .verbose_intern_pool = comp.verbose_intern_pool,
+        .verbose_generic_instances = comp.verbose_generic_instances,
         .verbose_llvm_ir = comp.verbose_llvm_ir,
         .verbose_llvm_bc = comp.verbose_llvm_bc,
         .verbose_cimport = comp.verbose_cimport,

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -6245,6 +6245,59 @@ fn dumpAllFallible(ip: *const InternPool) anyerror!void {
     try bw.flush();
 }
 
+pub fn dumpGenericInstances(ip: *const InternPool, allocator: Allocator) void {
+    ip.dumpGenericInstancesFallible(allocator) catch return;
+}
+
+pub fn dumpGenericInstancesFallible(ip: *const InternPool, allocator: Allocator) anyerror!void {
+    var arena_allocator = std.heap.ArenaAllocator.init(allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    var bw = std.io.bufferedWriter(std.io.getStdErr().writer());
+    const w = bw.writer();
+
+    var instances: std.AutoArrayHashMapUnmanaged(Index, std.ArrayListUnmanaged(Index)) = .{};
+    const datas = ip.items.items(.data);
+    for (ip.items.items(.tag), 0..) |tag, i| {
+        if (tag != .func_instance) continue;
+        const info = ip.extraData(Tag.FuncInstance, datas[i]);
+
+        const gop = try instances.getOrPut(arena, info.generic_owner);
+        if (!gop.found_existing) gop.value_ptr.* = .{};
+
+        try gop.value_ptr.append(arena, @enumFromInt(i));
+    }
+
+    const SortContext = struct {
+        values: []std.ArrayListUnmanaged(Index),
+        pub fn lessThan(ctx: @This(), a_index: usize, b_index: usize) bool {
+            return ctx.values[a_index].items.len > ctx.values[b_index].items.len;
+        }
+    };
+
+    instances.sort(SortContext{ .values = instances.values() });
+    var it = instances.iterator();
+    while (it.next()) |entry| {
+        const generic_fn_owner_decl = ip.declPtrConst(ip.funcDeclOwner(entry.key_ptr.*));
+        try w.print("{} ({}): \n", .{ generic_fn_owner_decl.name.fmt(ip), entry.value_ptr.items.len });
+        for (entry.value_ptr.items) |index| {
+            const func = ip.extraFuncInstance(datas[@intFromEnum(index)]);
+            const owner_decl = ip.declPtrConst(func.owner_decl);
+            try w.print("  {}: (", .{owner_decl.name.fmt(ip)});
+            for (func.comptime_args.get(ip)) |arg| {
+                if (arg != .none) {
+                    const key = ip.indexToKey(arg);
+                    try w.print(" {} ", .{key});
+                }
+            }
+            try w.writeAll(")\n");
+        }
+    }
+
+    try bw.flush();
+}
+
 pub fn structPtr(ip: *InternPool, index: Module.Struct.Index) *Module.Struct {
     return ip.allocated_structs.at(@intFromEnum(index));
 }
@@ -6266,6 +6319,10 @@ pub fn unionPtrConst(ip: *const InternPool, index: Module.Union.Index) *const Mo
 }
 
 pub fn declPtr(ip: *InternPool, index: Module.Decl.Index) *Module.Decl {
+    return ip.allocated_decls.at(@intFromEnum(index));
+}
+
+pub fn declPtrConst(ip: *const InternPool, index: Module.Decl.Index) *const Module.Decl {
     return ip.allocated_decls.at(@intFromEnum(index));
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -573,6 +573,7 @@ const usage_build_generic =
     \\  --verbose-cc                 Display C compiler invocations
     \\  --verbose-air                Enable compiler debug output for Zig AIR
     \\  --verbose-intern-pool        Enable compiler debug output for InternPool
+    \\  --verbose-generic-instances  Enable compiler debug output for generic instance generation
     \\  --verbose-llvm-ir[=path]     Enable compiler debug output for unoptimized LLVM IR
     \\  --verbose-llvm-bc=[path]     Enable compiler debug output for unoptimized LLVM BC
     \\  --verbose-cimport            Enable compiler debug output for C imports
@@ -743,6 +744,7 @@ fn buildOutputType(
     var verbose_cc = (builtin.os.tag != .wasi or builtin.link_libc) and std.process.hasEnvVarConstant("ZIG_VERBOSE_CC");
     var verbose_air = false;
     var verbose_intern_pool = false;
+    var verbose_generic_instances = false;
     var verbose_llvm_ir: ?[]const u8 = null;
     var verbose_llvm_bc: ?[]const u8 = null;
     var verbose_cimport = false;
@@ -1478,6 +1480,8 @@ fn buildOutputType(
                         verbose_air = true;
                     } else if (mem.eql(u8, arg, "--verbose-intern-pool")) {
                         verbose_intern_pool = true;
+                    } else if (mem.eql(u8, arg, "--verbose-generic-instances")) {
+                        verbose_generic_instances = true;
                     } else if (mem.eql(u8, arg, "--verbose-llvm-ir")) {
                         verbose_llvm_ir = "-";
                     } else if (mem.startsWith(u8, arg, "--verbose-llvm-ir=")) {
@@ -3194,6 +3198,7 @@ fn buildOutputType(
         .verbose_link = verbose_link,
         .verbose_air = verbose_air,
         .verbose_intern_pool = verbose_intern_pool,
+        .verbose_generic_instances = verbose_generic_instances,
         .verbose_llvm_ir = verbose_llvm_ir,
         .verbose_llvm_bc = verbose_llvm_bc,
         .verbose_cimport = verbose_cimport,


### PR DESCRIPTION
I found this useful when trying to optimize compile times (in https://github.com/ziglang/zig/pull/16538):

A section of example output:
```
allocBytesWithAlignment (4): 
  allocBytesWithAlignment__anon_7903: ( InternPool.Key{ .int = InternPool.Key.Int{ .ty = InternPool.Index.u29_type, .storage = InternPool.Key.Int.Storage{ .u64 = 8 } } } )
  allocBytesWithAlignment__anon_8077: ( InternPool.Key{ .int = InternPool.Key.Int{ .ty = InternPool.Index.u29_type, .storage = InternPool.Key.Int.Storage{ .u64 = 4 } } } )
  allocBytesWithAlignment__anon_8481: ( InternPool.Key{ .int = InternPool.Key.Int{ .ty = InternPool.Index.u29_type, .storage = InternPool.Key.Int.Storage{ .u64 = 2 } } } )
  allocBytesWithAlignment__anon_8483: ( InternPool.Key{ .int = InternPool.Key.Int{ .ty = InternPool.Index.u29_type, .storage = InternPool.Key.Int.Storage{ .u64 = 1 } } } )
isPowerOfTwo (3): 
  isPowerOfTwo__anon_3940: ()
  isPowerOfTwo__anon_8900: ()
  isPowerOfTwo__anon_9196: ()
alloc (3): 
  alloc__anon_6733: ( InternPool.Key{ .ptr_type = InternPool.Key.PtrType{ .child = InternPool.Index.u16_type, .sentinel = InternPool.Index.none, .flags = InternPool.Key.PtrType.Flags{ .size = builtin.Type.Pointer.Size.Slice, .alignment = InternPool.Alignment.none, .is_const = false, .is_volatile = false, .is_allowzero = false, .address_space = builtin.AddressSpace.generic, .vector_index = InternPool.Key.PtrType.VectorIndex.none }, .packed_offset = InternPool.Key.PtrType.PackedOffset{ .host_size = 0, .bit_offset = 0 } } } )
  alloc__anon_6740: ( InternPool.Key{ .int_type = builtin.Type.Int{ .signedness = builtin.Signedness.unsigned, .bits = 16 } } )
  alloc__anon_6753: ( InternPool.Key{ .int_type = builtin.Type.Int{ .signedness = builtin.Signedness.unsigned, .bits = 8 } } )
getUInt (3): 
  getUInt__anon_7250: ( InternPool.Key{ .simple_type = InternPool.SimpleType.usize } )
  getUInt__anon_7431: ( InternPool.Key{ .int_type = builtin.Type.Int{ .signedness = builtin.Signedness.unsigned, .bits = 64 } } )
  getUInt__anon_7575: ( InternPool.Key{ .int_type = builtin.Type.Int{ .signedness = builtin.Signedness.unsigned, .bits = 32 } } )
sub (3): 
  sub__anon_7322: ( InternPool.Key{ .int_type = builtin.Type.Int{ .signedness = builtin.Signedness.unsigned, .bits = 64 } } )
  sub__anon_7331: ( InternPool.Key{ .simple_type = InternPool.SimpleType.usize } )
  sub__anon_9186: ( InternPool.Key{ .simple_type = InternPool.SimpleType.isize } )
items (3): 
  items__anon_7399: ( InternPool.Key{ .enum_tag = InternPool.Key.EnumTag{ .ty = InternPool.Index(7797), .int = InternPool.Index(176) } } )
  items__anon_7410: ( InternPool.Key{ .enum_tag = InternPool.Key.EnumTag{ .ty = InternPool.Index(7797), .int = InternPool.Index(178) } } )
  items__anon_8193: ( InternPool.Key{ .enum_tag = InternPool.Key.EnumTag{ .ty = InternPool.Index(7797), .int = InternPool.Index(175) } } )
formatValue (3): 
  formatValue__anon_7735: ( InternPool.Key{ .ptr = InternPool.Key.Ptr{ .ty = InternPool.Index.slice_const_u8_type, .addr = InternPool.Key.Ptr.Addr{ .decl = Module.Decl.Index(4338) }, .len = InternPool.Index.one_usize } } )
  formatValue__anon_8560: ( InternPool.Key{ .ptr = InternPool.Key.Ptr{ .ty = InternPool.Index.slice_const_u8_type, .addr = InternPool.Key.Ptr.Addr{ .decl = Module.Decl.Index(8261) }, .len = InternPool.Index.one_usize } } )
  formatValue__anon_8861: ( InternPool.Key{ .ptr = InternPool.Key.Ptr{ .ty = InternPool.Index.slice_const_u8_type, .addr = InternPool.Key.Ptr.Addr{ .decl = Module.Decl.Index(8261) }, .len = InternPool.Index.one_usize } } )
formatIntValue (3): 
  formatIntValue__anon_7736: ( InternPool.Key{ .ptr = InternPool.Key.Ptr{ .ty = InternPool.Index.slice_const_u8_type, .addr = InternPool.Key.Ptr.Addr{ .decl = Module.Decl.Index(4338) }, .len = InternPool.Index.one_usize } } )
  formatIntValue__anon_8561: ( InternPool.Key{ .ptr = InternPool.Key.Ptr{ .ty = InternPool.Index.slice_const_u8_type, .addr = InternPool.Key.Ptr.Addr{ .decl = Module.Decl.Index(8261) }, .len = InternPool.Index.one_usize } } )
  formatIntValue__anon_8862: ( InternPool.Key{ .ptr = InternPool.Key.Ptr{ .ty = InternPool.Index.slice_const_u8_type, .addr = InternPool.Key.Ptr.Addr{ .decl = Module.Decl.Index(8261) }, .len = InternPool.Index.one_usize } } )
  ```