### PR TITLE
Unwinding follow up: Don't strip compiler_rt symbols, enable unwind tables on supported platforms

### DIFF
--- a/lib/std/Build/Step/CheckObject.zig
+++ b/lib/std/Build/Step/CheckObject.zig
@@ -478,8 +478,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                 },
                 .not_present => {
                     while (it.next()) |line| {
-                        if (act.notPresent(b, step, line)) break;
-                    } else {
+                        if (act.notPresent(b, step, line)) continue;
                         return step.fail(
                             \\
                             \\========= expected not to find: ===================

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -242,8 +242,7 @@ pub fn dumpStackTraceFromBase(context: *const ThreadContext) void {
         printSourceAtAddress(debug_info, stderr, it.unwind_state.?.dwarf_context.pc, tty_config) catch return;
 
         while (it.next()) |return_address| {
-            if (it.getLastError()) |unwind_error|
-                printUnwindError(debug_info, stderr, unwind_error.address, unwind_error.err, tty_config) catch {};
+            printLastUnwindError(&it, debug_info, stderr, tty_config);
 
             // On arm64 macOS, the address of the last frame is 0x0 rather than 0x1 as on x86_64 macOS,
             // therefore, we do a check for `return_address == 0` before subtracting 1 from it to avoid
@@ -252,10 +251,7 @@ pub fn dumpStackTraceFromBase(context: *const ThreadContext) void {
             // same behaviour for x86-windows-msvc
             const address = if (return_address == 0) return_address else return_address - 1;
             printSourceAtAddress(debug_info, stderr, address, tty_config) catch return;
-        } else {
-            if (it.getLastError()) |unwind_error|
-                printUnwindError(debug_info, stderr, unwind_error.address, unwind_error.err, tty_config) catch {};
-        }
+        } else printLastUnwindError(&it, debug_info, stderr, tty_config);
     }
 }
 
@@ -734,8 +730,7 @@ pub fn writeCurrentStackTrace(
     defer it.deinit();
 
     while (it.next()) |return_address| {
-        if (it.getLastError()) |unwind_error|
-            try printUnwindError(debug_info, out_stream, unwind_error.address, unwind_error.err, tty_config);
+        printLastUnwindError(&it, debug_info, out_stream, tty_config);
 
         // On arm64 macOS, the address of the last frame is 0x0 rather than 0x1 as on x86_64 macOS,
         // therefore, we do a check for `return_address == 0` before subtracting 1 from it to avoid
@@ -744,10 +739,7 @@ pub fn writeCurrentStackTrace(
         // same behaviour for x86-windows-msvc
         const address = if (return_address == 0) return_address else return_address - 1;
         try printSourceAtAddress(debug_info, out_stream, address, tty_config);
-    } else {
-        if (it.getLastError()) |unwind_error|
-            try printUnwindError(debug_info, out_stream, unwind_error.address, unwind_error.err, tty_config);
-    }
+    } else printLastUnwindError(&it, debug_info, out_stream, tty_config);
 }
 
 pub noinline fn walkStackWindows(addresses: []usize, existing_context: ?*const windows.CONTEXT) usize {
@@ -885,7 +877,14 @@ fn printUnknownSource(debug_info: *DebugInfo, out_stream: anytype, address: usiz
     );
 }
 
-pub fn printUnwindError(debug_info: *DebugInfo, out_stream: anytype, address: usize, err: UnwindError, tty_config: io.tty.Config) !void {
+fn printLastUnwindError(it: *StackIterator, debug_info: *DebugInfo, out_stream: anytype, tty_config: io.tty.Config) void {
+    if (!have_ucontext) return;
+    if (it.getLastError()) |unwind_error| {
+        printUnwindError(debug_info, out_stream, unwind_error.address, unwind_error.err, tty_config) catch {};
+    }
+}
+
+fn printUnwindError(debug_info: *DebugInfo, out_stream: anytype, address: usize, err: UnwindError, tty_config: io.tty.Config) !void {
     const module_name = debug_info.getModuleNameForAddress(address) orelse "???";
     try tty_config.setColor(out_stream, .dim);
     if (err == error.MissingDebugInfo) {

--- a/lib/std/dwarf.zig
+++ b/lib/std/dwarf.zig
@@ -1656,7 +1656,7 @@ pub const DwarfInfo = struct {
     /// `explicit_fde_offset` is for cases where the FDE offset is known, such as when __unwind_info
     /// defers unwinding to DWARF. This is an offset into the `.eh_frame` section.
     pub fn unwindFrame(di: *const DwarfInfo, context: *UnwindContext, explicit_fde_offset: ?usize) !usize {
-        if (!comptime abi.isSupportedArch(builtin.target.cpu.arch)) return error.UnsupportedCpuArchitecture;
+        if (!comptime abi.supportsUnwinding(builtin.target)) return error.UnsupportedCpuArchitecture;
         if (context.pc == 0) return 0;
 
         // Find the FDE and CIE

--- a/lib/std/dwarf/abi.zig
+++ b/lib/std/dwarf/abi.zig
@@ -3,13 +3,24 @@ const std = @import("../std.zig");
 const os = std.os;
 const mem = std.mem;
 
-pub fn isSupportedArch(arch: std.Target.Cpu.Arch) bool {
-    return switch (arch) {
-        .x86,
-        .x86_64,
-        .arm,
-        .aarch64,
-        => true,
+pub fn supportsUnwinding(target: std.Target) bool {
+    return switch (target.cpu.arch) {
+        .x86 => switch (target.os.tag) {
+            .linux, .netbsd, .solaris => true,
+            else => false,
+        },
+        .x86_64 => switch (target.os.tag) {
+            .linux, .netbsd, .freebsd, .openbsd, .macos, .solaris => true,
+            else => false,
+        },
+        .arm => switch (target.os.tag) {
+            .linux => true,
+            else => false,
+        },
+        .aarch64 => switch (target.os.tag) {
+            .linux, .netbsd, .freebsd, .macos => true,
+            else => false,
+        },
         else => false,
     };
 }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5491,6 +5491,7 @@ fn buildOutputFromZig(
         .omit_frame_pointer = comp.bin_file.options.omit_frame_pointer,
         .want_valgrind = false,
         .want_tsan = false,
+        .want_unwind_tables = comp.bin_file.options.eh_frame_hdr,
         .want_pic = comp.bin_file.options.pic,
         .want_pie = comp.bin_file.options.pie,
         .emit_h = null,
@@ -5639,9 +5640,5 @@ pub fn compilerRtOptMode(comp: Compilation) std.builtin.Mode {
 /// This decides whether to strip debug info for all zig-provided libraries, including
 /// compiler-rt, libcxx, libc, libunwind, etc.
 pub fn compilerRtStrip(comp: Compilation) bool {
-    if (comp.debug_compiler_runtime_libs) {
-        return comp.bin_file.options.strip;
-    } else {
-        return true;
-    }
+    return comp.bin_file.options.strip;
 }

--- a/src/target.zig
+++ b/src/target.zig
@@ -510,7 +510,7 @@ pub fn clangAssemblerSupportsMcpuArg(target: std.Target) bool {
 }
 
 pub fn needUnwindTables(target: std.Target) bool {
-    return target.os.tag == .windows or target.isDarwin();
+    return target.os.tag == .windows or target.isDarwin() or std.dwarf.abi.supportsUnwinding(target);
 }
 
 pub fn defaultAddressSpace(

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -241,6 +241,10 @@ pub const build_cases = [_]BuildCase{
         .build_root = "test/standalone/coff_dwarf",
         .import = @import("standalone/coff_dwarf/build.zig"),
     },
+    .{
+        .build_root = "test/standalone/compiler_rt_panic",
+        .import = @import("standalone/compiler_rt_panic/build.zig"),
+    },
 };
 
 const std = @import("std");

--- a/test/standalone/compiler_rt_panic/build.zig
+++ b/test/standalone/compiler_rt_panic/build.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    if (target.getObjectFormat() != .elf) return;
+
+    const exe = b.addExecutable(.{
+        .name = "main",
+        .optimize = optimize,
+        .target = target,
+    });
+    exe.addCSourceFile("main.c", &.{});
+    exe.link_gc_sections = false;
+    exe.bundle_compiler_rt = true;
+
+    // Verify compiler_rt hasn't pulled in any debug handlers
+    const check_exe = exe.checkObject();
+    check_exe.checkInSymtab();
+    check_exe.checkNotPresent("debug.readElfDebugInfo");
+    test_step.dependOn(&check_exe.step);
+}

--- a/test/standalone/compiler_rt_panic/main.c
+++ b/test/standalone/compiler_rt_panic/main.c
@@ -1,0 +1,11 @@
+#include <stddef.h>
+
+void* __memset(void* dest, char c, size_t n, size_t dest_n);
+
+char foo[128];
+
+int main() {
+    __memset(&foo[0], 0xff, 128, 128);
+    return foo[64];
+}
+


### PR DESCRIPTION
This partially solves https://github.com/ziglang/zig/issues/16474, but will not close it. 

Problem summary:
- `memcpy` came from compiler_rt, but had no unwind info
  - Solved by setting `want_unwind_tables` on the compiler_rt sub-compilation if the main compilation had enabled `eh_frame_hdr`
- Debug symbols for compiler_rt were being stripped
  - Solved by inheriting the `strip` flag from the parent compilation
- Enable `unwind_tables` by default on platforms that support DWARF unwinding
  - This isn't strictly necessary (without this, we still get `.debug_frame` output). However, it's preferable to use `.eh_frame_hdr`/`.eh_frame` over `.debug_frame`, as lookups are improved (binary search table is built by the linker vs at runtime when we open the debug info). This also has the side effect of making a slightly smaller final binary (see below).

Output before (from #16474):
```
Segmentation fault at address 0x0
???:?:?: 0x2c9b40 in ??? (???)
Aborted (core dumped)
```

Output after:
```
Segmentation fault at address 0x0
/mnt/c/cygwin64/home/kcbanner/kit/zig/lib/compiler_rt/memcpy.zig:19:21: 0x2da4e0 in memcpy (compiler_rt)
            d[0] = s[0];
                    ^
???:?:?: 0x7f12da21e60c in ??? (swrast_dri.so)
Unwind information for `swrast_dri.so:0x7f12da21e60c` was not available, trace may be incomplete

Aborted
```

Size changes for the test executable (same one as in #16474):

Before:
```
1.6M 16474
2.2M 16474.o
240K libcompiler_rt.a
```

After:
```
2.3M 16474
2.1M 16474.o
1.6M libcompiler_rt.a
```

If the `unwind_tables` change wasn't made:
```
2.4M 16474
2.8M 16474.o
1.6M libcompiler_rt.a
```

So an overall increase of `0.7M` for the output executable, in Debug - attributed to not stripping compiler_rt symbols. 

If this size increase isn't acceptable by default, an option could be provided to the user to enable them?