### PR TITLE
std.Thread: Fix counting in SingleThreadedRwLock's tryLockShared

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -1438,6 +1438,7 @@ test {
     _ = Mutex;
     _ = Semaphore;
     _ = Condition;
+    _ = RwLock;
 }
 
 fn testIncrementNotify(value: *usize, event: *ResetEvent) void {

--- a/lib/std/Thread/RwLock.zig
+++ b/lib/std/Thread/RwLock.zig
@@ -95,7 +95,11 @@ pub const SingleThreadedRwLock = struct {
                 rwl.shared_count = 1;
                 return true;
             },
-            .locked_exclusive, .locked_shared => return false,
+            .locked_shared => {
+                rwl.shared_count += 1;
+                return true;
+            },
+            .locked_exclusive => return false,
         }
     }
 


### PR DESCRIPTION
Adding RwLock to Thread.zig's list of tests resulted in a failure of `RwLock - smoke test` when running  `std-native-Debug-single`. This exposed an issue with `SingleThreadedRwLock.tryLockShared` where it would fail to count more than one shared lock.

This PR addresses the issue with tryLockShared, and ensures that RwLock's tests are run when testing the std-lib.
