### PR TITLE
workflows | Avoid running workflow on non-relevant files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,13 @@ on:
     branches:
       - master
       - llvm16
+    paths-ignore:
+      - '.github/**'
+      - '.gitattributes'
+      - '.gitignore'
+      - '.mailmap'
+      - 'LICENSE'
+      - 'README.md'
 concurrency:
   # Cancels pending runs when a PR gets updated.
   group: ${{ github.head_ref || github.run_id }}-${{ github.actor }}


### PR DESCRIPTION
Adds paths-ignore param with files which do not need tests run on them to save resources for other jobs which do