### PR TITLE
macho: create export trie root explicitly with Trie.init rather than implicitly on first Trie.put

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -3227,6 +3227,7 @@ fn writeDyldInfoData(self: *MachO) !void {
 
     var trie: Trie = .{};
     defer trie.deinit(gpa);
+    try trie.init(gpa);
     try self.collectExportData(&trie);
 
     const link_seg = self.getLinkeditSegmentPtr();

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -2107,6 +2107,7 @@ pub const Zld = struct {
 
         var trie = Trie{};
         defer trie.deinit(gpa);
+        try trie.init(gpa);
         try self.collectExportData(&trie);
 
         const link_seg = self.getLinkeditSegmentPtr();

--- a/test/link.zig
+++ b/test/link.zig
@@ -93,6 +93,10 @@ pub const cases = [_]Case{
         .import = @import("link/macho/bugs/13457/build.zig"),
     },
     .{
+        .build_root = "test/link/macho/bugs/16308",
+        .import = @import("link/macho/bugs/16308/build.zig"),
+    },
+    .{
         .build_root = "test/link/macho/dead_strip",
         .import = @import("link/macho/dead_strip/build.zig"),
     },

--- a/test/link/macho/bugs/16308/build.zig
+++ b/test/link/macho/bugs/16308/build.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+
+pub const requires_symlinks = true;
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    const target: std.zig.CrossTarget = .{ .os_tag = .macos };
+
+    const lib = b.addSharedLibrary(.{
+        .name = "a",
+        .root_source_file = .{ .path = "main.zig" },
+        .optimize = .Debug,
+        .target = target,
+    });
+
+    const check = lib.checkObject();
+    check.checkInSymtab();
+    check.checkNotPresent("external");
+
+    test_step.dependOn(&check.step);
+}

--- a/test/link/macho/bugs/16308/main.zig
+++ b/test/link/macho/bugs/16308/main.zig
@@ -1,0 +1,1 @@
+fn abc() void {}


### PR DESCRIPTION
Fixed #16308 