### PR TITLE
LLVM: always add argument attributes to calls

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -5324,8 +5324,8 @@ pub const FuncGen = struct {
             },
         };
 
-        if (callee_ty.zigTypeTag(mod) == .Pointer) {
-            // Add argument attributes for function pointer calls.
+        {
+            // Add argument attributes.
             it = iterateParamTypes(o, fn_info);
             it.llvm_index += @intFromBool(sret);
             it.llvm_index += @intFromBool(err_return_tracing);

--- a/test/c_abi/cfuncs.c
+++ b/test/c_abi/cfuncs.c
@@ -1034,3 +1034,20 @@ struct ByRef __attribute__((sysv_abi)) c_explict_sys_v(struct ByRef in) {
     return in;
 }
 #endif
+
+
+struct byval_tail_callsite_attr_Point {
+    double x;
+    double y;
+} Point;
+struct byval_tail_callsite_attr_Size {
+    double width;
+    double height;
+} Size;
+struct byval_tail_callsite_attr_Rect {
+    struct byval_tail_callsite_attr_Point origin;
+    struct byval_tail_callsite_attr_Size size;
+};
+double c_byval_tail_callsite_attr(struct byval_tail_callsite_attr_Rect in) {
+    return in.size.width;
+}


### PR DESCRIPTION
These are needed for correctness. There's no reason to only add them for function pointers.

closes #16290