### PR TITLE
Doc nitpick

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3018,7 +3018,7 @@ test "basic slices" {
     slice[10] += 1;
 
     // Note that `slice.ptr` does not invoke safety checking, while `&slice[0]`
-    // asserts that the slice has len >= 1.
+    // asserts that the slice has len > 0.
 }
       {#code_end#}
       <p>This is one reason we prefer slices to pointers.</p>


### PR DESCRIPTION
`slice[i]` should assert `len > i`, not `len >= i + 1`.

I apologize for being nitpicky. 