### PR TITLE
add bound check on for and while nodes

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -752,11 +752,11 @@ pub fn firstToken(tree: Ast, node: Node.Index) TokenIndex {
             // Look for a label and inline.
             const main_token = main_tokens[n];
             var result = main_token;
-            if (token_tags[result - 1] == .keyword_inline) {
+            if (token_tags[result -| 1] == .keyword_inline) {
                 result -= 1;
             }
-            if (token_tags[result - 1] == .colon) {
-                result -= 2;
+            if (token_tags[result -| 1] == .colon) {
+                result -|= 2;
             }
             return result - end_offset;
         },
@@ -2246,13 +2246,13 @@ fn fullWhileComponents(tree: Ast, info: full.While.Components) full.While {
         .else_token = undefined,
         .error_token = null,
     };
-    var tok_i = info.while_token - 1;
+    var tok_i = info.while_token -| 1;
     if (token_tags[tok_i] == .keyword_inline) {
         result.inline_token = tok_i;
-        tok_i -= 1;
+        tok_i -|= 1;
     }
     if (token_tags[tok_i] == .colon and
-        token_tags[tok_i - 1] == .identifier)
+        token_tags[tok_i -| 1] == .identifier)
     {
         result.label_token = tok_i - 1;
     }
@@ -2280,13 +2280,13 @@ fn fullForComponents(tree: Ast, info: full.For.Components) full.For {
         .payload_token = undefined,
         .else_token = undefined,
     };
-    var tok_i = info.for_token - 1;
+    var tok_i = info.for_token -| 1;
     if (token_tags[tok_i] == .keyword_inline) {
         result.inline_token = tok_i;
-        tok_i -= 1;
+        tok_i -|= 1;
     }
     if (token_tags[tok_i] == .colon and
-        token_tags[tok_i - 1] == .identifier)
+        token_tags[tok_i -| 1] == .identifier)
     {
         result.label_token = tok_i - 1;
     }

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -272,6 +272,17 @@ test "zig fmt: top-level enum missing 'const name ='" {
     , &[_]Error{.expected_token});
 }
 
+test "zig fmt: top-level for/while loop" {
+    try testCanonical(
+        \\for (foo) |_| foo
+        \\
+    );
+    try testCanonical(
+        \\while (foo) |_| foo
+        \\
+    );
+}
+
 test "zig fmt: top-level bare asterisk+identifier" {
     try testCanonical(
         \\*x


### PR DESCRIPTION
compiling the following source file will crash zig. (this is the entire file)
```zig
for (foo) |_| foo
```
or
```zig
while (foo) |_| foo
```

```
thread 74656 panic: integer overflow
/home/techatrix/Documents/zig/lib/std/zig/Ast.zig:2283:32: 0xcb6781 in fullForComponents (zig)
    var tok_i = info.for_token - 1;
                               ^
/home/techatrix/Documents/zig/lib/std/zig/Ast.zig:1948:34: 0xa8c45f in forSimple (zig)
    return tree.fullForComponents(.{
                                 ^
/home/techatrix/Documents/zig/lib/std/zig/Ast.zig:2343:38: 0x8ba921 in fullFor (zig)
        .for_simple => tree.forSimple(node),
                                     ^
/home/techatrix/Documents/zig/src/AstGen.zig:863:86: 0xccdcab in expr (zig)
        .for_simple, .@"for" => return forExpr(gz, scope, ri.br(), node, tree.fullFor(node).?, false),
                                                                                     ^
/home/techatrix/Documents/zig/src/AstGen.zig:1920:20: 0x10467f5 in comptimeExpr (zig)
        return expr(gz, scope, ri, node);
                   ^
/home/techatrix/Documents/zig/src/AstGen.zig:391:24: 0xcc2da5 in typeExpr (zig)
    return comptimeExpr(gz, scope, coerced_type_ri, type_node);
                       ^
/home/techatrix/Documents/zig/src/AstGen.zig:4750:40: 0xa9f4c8 in structDeclInner (zig)
        const field_type = try typeExpr(&block_scope, &namespace.base, member.ast.type_expr);
                                       ^
/home/techatrix/Documents/zig/src/AstGen.zig:154:35: 0x90a811 in generate (zig)
        if (AstGen.structDeclInner(
                                  ^
/home/techatrix/Documents/zig/src/Module.zig:3376:35: 0xd656fd in astGenFile (zig)
    file.zir = try AstGen.generate(gpa, file.tree);
                                  ^
/home/techatrix/Documents/zig/src/Compilation.zig:3515:19: 0xb91b08 in workerAstGenFile (zig)
    mod.astGenFile(file) catch |err| switch (err) {
                  ^
/home/techatrix/Documents/zig/lib/std/Thread/Pool.zig:94:39: 0xd668be in runFn (zig)
            @call(.auto, func, closure.arguments);
                                      ^
/home/techatrix/Documents/zig/lib/std/Thread/Pool.zig:133:18: 0xd38ff4 in worker (zig)
            runFn(&run_node.data);
                 ^
/home/techatrix/Documents/zig/lib/std/Thread.zig:412:13: 0xb5677d in callFn__anon_106169 (zig)
            @call(.auto, f, args);
            ^
/home/techatrix/Documents/zig/lib/std/Thread.zig:1210:30: 0x994513 in entryFn (zig)
                return callFn(f, self.fn_args);
                             ^
/home/techatrix/Documents/zig/lib/c.zig:241:13: 0x2112d0e in clone (c)
            asm volatile (
            ^
???:?:?: 0xfff in ??? (???)
Unwind information for `???:0xfff` was not available, trace may be incomplete

Aborted
```