### PR TITLE
package manager: don't show progress indicator on dumb terminals

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4438,7 +4438,7 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
             try wip_errors.init(gpa);
             defer wip_errors.deinit();
 
-            var progress: std.Progress = .{};
+            var progress: std.Progress = .{ .dont_print_on_dumb = true };
             const root_prog_node = progress.start("Fetch Packages", 0);
             defer root_prog_node.end();
 


### PR DESCRIPTION
This mirrors the behavior of the progress indicator for the actual compilation. Not doing this was causing sporadic CI failures due to the (non-existent) fetches taking long enough to appear in stderr.