### PR TITLE
Compare user input for multiple dependency build variants

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -488,7 +488,7 @@ const OrderedUserValue = union(enum) {
             }) catch @panic("OOM");
         }
 
-        std.sort.insertion(Pair, ordered.items, {}, Pair.lessThan);
+        std.mem.sortUnstable(Pair, ordered.items, {}, Pair.lessThan);
         return ordered;
     }
 
@@ -533,7 +533,7 @@ fn hashUserInputOptionsMap(allocator: Allocator, user_input_options: UserInputOp
     while (it.next()) |entry|
         ordered.append(OrderedUserInputOption.fromUnordered(allocator, entry.value_ptr.*)) catch @panic("OOM");
 
-    std.sort.insertion(OrderedUserInputOption, ordered.items, {}, OrderedUserInputOption.lessThan);
+    std.mem.sortUnstable(OrderedUserInputOption, ordered.items, {}, OrderedUserInputOption.lessThan);
 
     // juice it
     for (ordered.items) |user_option|

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -553,7 +553,6 @@ fn determineAndApplyInstallPrefix(b: *Build) !void {
     hashUserInputOptionsMap(b.allocator, b.user_input_options, &wyhash);
     hash.add(wyhash.final());
 
-    // TODO additionally update the hash with `args`.
     const digest = hash.final();
     const install_prefix = try b.cache_root.join(b.allocator, &.{ "i", &digest });
     b.resolveInstallPrefix(install_prefix, .{});


### PR DESCRIPTION
If I try to build a dependency with different arguments today, only one version of that dependency is built, when it should build every variant. Here's a simplified example, I've imported the `echo` dependency twice, but in each scenario I've specified the dependency with different optimization modes.

```zig
// build.zig
const dep_variant_1 = b.dependency("echo", .{
    .target = target,
    .optimize = .Debug,
});

const dep_variant_2 = b.dependency("echo", .{
    .target = target,
    .optimize = .ReleaseSafe,
});
```

I'll now write a program to print the value returned by `get_optimization()` in the `echo` static library of the `echo` dependency, and compile it twice, each using one of the dependency variants:

```zig
// build.zig continued...
const program_variant_1 = b.addExecutable(.{
    .name = "i_should_print_debug",
    .source_file = .{ .path = "src/main.zig" },
});
program_variant_1.addModule(dep_variant_1.module("echo"));
b.installArtifact(program_variant_1);

const program_variant_2 = b.addExecutable(.{
    .name = "i_should_print_release_safe",
    .source_file = .{ .path = "src/main.zig" },
});
program_variant_2.addModule(dep_variant_2.module("echo"));
b.installArtifact(program_variant_2);
```

However when I run both programs:

```
mattnite@Matts-MacBook-Pro ~/c/dependency-variants (main)> ./zig-out/bin/i_should_print_debug
Debug
mattnite@Matts-MacBook-Pro ~/c/dependency-variants (main)> ./zig-out/bin/i_should_print_release_safe
Debug
```

:(

## Alright Andrew, I'll bite

walking down the `b.dependency()` call stack there's a shiny lil todo:

```zig
if (b.initialized_deps.get(build_root_string)) |dep| {
    // TODO: check args are the same
    return dep;
}
```

To fill in this TODO, the `args` of different `Build`s of the same dependency need to be compared. This patch generates a `Build`'s `user_input_options` here for comparison with existing dependencies. If it's unique then the options are passed down to the newly created `Build`.

The other piece of work, and related TODO, was generating the hash for the install prefix. Which now looks like this:

```zig
  var hash = b.cache.hash;
  // Random bytes to make unique. Refresh this with new random bytes when
  // implementation is modified in a non-backwards-compatible way.
  hash.add(@as(u32, 0xd8cb0055));
  hash.addBytes(b.dep_prefix);

  hashUserInputOptionsMap(b.allocator, b.user_input_options, &hash);

  // TODO additionally update the hash with `args`.
  const digest = hash.final();
  const install_prefix = try b.cache_root.join(b.allocator, &.{ "i", &digest });
  b.resolveInstallPrefix(install_prefix, .{});
```

AFAIK, it's possible for entries in a`UserInputOptionsMap` to have different orders depending on order of insertion. `hashUserInputOptionsmap` orders all values recursively -- TIL there could be maps in the user input option -- and then hashes everything.

Note anyone reviewing please take a look at the hashing of different user values like `flag`, it seems to me that just hashing the name would be good enough? I'm also not sure if `used` should be included in hashing as well.

### I hope you're happy

Now my programs print:

```
mattnite@Matts-MacBook-Pro ~/c/dependency-variants (main)> ./zig-out/bin/i_should_print_debug
Debug
mattnite@Matts-MacBook-Pro ~/c/dependency-variants (main)> ./zig-out/bin/i_should_print_release_safe
ReleaseSafe
```

The repos to reproduce this are [dependency-variants](https://github.com/mattnite/dependency-variants) and [echo](https://github.com/mattnite/echo).
