### PR TITLE
std.os.windows: Support UTF-8 ↔ UTF-16 conversion for Windows native console I/O

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1068,6 +1068,10 @@ pub const WriteError = error{
 
     /// Connection reset by peer.
     ConnectionResetByPeer,
+
+    /// This error occurs when trying to write UTF-8 text to a Windows console,
+    /// and the UTF-8 to UTF-16 conversion fails. Windows-only.
+    InvalidUtf8,
 } || UnexpectedError;
 
 /// Write to a file descriptor.
@@ -3239,8 +3243,7 @@ pub fn isatty(handle: fd_t) bool {
         if (isCygwinPty(handle))
             return true;
 
-        var out: windows.DWORD = undefined;
-        return windows.kernel32.GetConsoleMode(handle, &out) != 0;
+        return windows.IsConsoleHandle(handle);
     }
     if (builtin.link_libc) {
         return system.isatty(handle) != 0;

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -174,6 +174,9 @@ pub extern "kernel32" fn FillConsoleOutputCharacterW(hConsoleOutput: HANDLE, cCh
 pub extern "kernel32" fn FillConsoleOutputAttribute(hConsoleOutput: HANDLE, wAttribute: WORD, nLength: DWORD, dwWriteCoord: COORD, lpNumberOfAttrsWritten: *DWORD) callconv(WINAPI) BOOL;
 pub extern "kernel32" fn SetConsoleCursorPosition(hConsoleOutput: HANDLE, dwCursorPosition: COORD) callconv(WINAPI) BOOL;
 
+pub extern "kernel32" fn ReadConsoleW(hConsoleInput: HANDLE, lpBuffer: LPVOID, nNumberOfCharsToRead: DWORD, lpNumberOfCharsRead: *DWORD, pInputControl: ?LPVOID) callconv(WINAPI) BOOL;
+pub extern "kernel32" fn WriteConsoleW(hConsoleOutput: HANDLE, lpBuffer: *const anyopaque, nNumberOfCharsToWrite: DWORD, lpNumberOfCharsWritten: ?*DWORD, lpReserved: ?LPVOID) callconv(WINAPI) BOOL;
+
 pub extern "kernel32" fn GetCurrentDirectoryW(nBufferLength: DWORD, lpBuffer: ?[*]WCHAR) callconv(WINAPI) DWORD;
 
 pub extern "kernel32" fn GetCurrentThread() callconv(WINAPI) HANDLE;

--- a/src/link.zig
+++ b/src/link.zig
@@ -543,6 +543,7 @@ pub const File = struct {
         DeviceBusy,
         InvalidArgument,
         HotSwapUnavailableOnHostOperatingSystem,
+        InvalidUtf8,
     };
 
     /// Called from within the CodeGen to lower a local variable instantion as an unnamed


### PR DESCRIPTION
These commits aim to eliminate text encoding problems regarding Windows native console I/O.

To-do list:

- [x] UTF-8 → UTF-16 conversion before writing to console with `WriteConsoleW()` (resolves #7600, closes #14411)
- [x] UTF-16 → UTF-8 conversion after reading from console with `ReadConsoleW()` (resolves #5148)