### PR TITLE
test: Fix missing _start symbol warning in the `compiler_rt_panic` test

### DIFF
--- a/test/standalone/compiler_rt_panic/build.zig
+++ b/test/standalone/compiler_rt_panic/build.zig
@@ -7,13 +7,15 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    if (target.getObjectFormat() != .elf) return;
+    const abi = target.getAbi();
+    if (target.getObjectFormat() != .elf or !(abi.isMusl() or abi.isGnu())) return;
 
     const exe = b.addExecutable(.{
         .name = "main",
         .optimize = optimize,
         .target = target,
     });
+    exe.linkLibC();
     exe.addCSourceFile("main.c", &.{});
     exe.link_gc_sections = false;
     exe.bundle_compiler_rt = true;


### PR DESCRIPTION
Context: https://github.com/ziglang/zig/pull/16559#issuecomment-1657061004