### PR TITLE
libunwind: Remove include for libcxx as its also done in upstream llvm repo

### DIFF
--- a/src/libunwind.zig
+++ b/src/libunwind.zig
@@ -42,11 +42,7 @@ pub fn buildStaticLib(comp: *Compilation, prog_node: *std.Progress.Node) !void {
                 try cflags.append("-std=c11");
             },
             .cpp => {
-                try cflags.appendSlice(&[_][]const u8{
-                    "-fno-rtti",
-                    "-I",
-                    try comp.zig_lib_directory.join(arena, &[_][]const u8{ "libcxx", "include" }),
-                });
+                try cflags.appendSlice(&[_][]const u8{"-fno-rtti"});
             },
             .assembly_with_cpp => {},
             else => unreachable, // You can see the entire list of files just above.


### PR DESCRIPTION
Trying to cross compile zig for a target that needs libunwind can lead to a situation where zig tries to link libunwind without linking libcpp. Since libunwinds sources include the stdlib.h header this can lead to the __availability being also included but without  _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS preprocessor directive being defined when cross compiling for targets like SerenityOS. See error description in https://github.com/SerenityOS/serenity/pull/20241 .

This PR ensures that libcpp is also linked as soon as libunwind is used.