### PR TITLE
std.Build.Step.WriteFile: fix call to nonexistent function

### DIFF
--- a/lib/std/Build/Step/WriteFile.zig
+++ b/lib/std/Build/Step/WriteFile.zig
@@ -96,7 +96,7 @@ pub fn addCopyFile(wf: *WriteFile, source: std.Build.LazyPath, sub_path: []const
 
     wf.maybeUpdateName();
     source.addStepDependencies(&wf.step);
-    return file.getLazyPath();
+    return file.getPath();
 }
 
 /// A path relative to the package root.


### PR DESCRIPTION
Just a little typo from the LazyPath change