### PR TITLE
std.os: add sysconf(), getDefaultPageSize() with smoke tests

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -78,6 +78,7 @@ pub usingnamespace switch (builtin.os.tag) {
 
         pub extern "c" fn getrusage(who: c_int, usage: *c.rusage) c_int;
 
+        pub extern "c" fn sysconf(sc: c_int) c_long;
         pub extern "c" fn sched_yield() c_int;
 
         pub extern "c" fn sigaction(sig: c_int, noalias act: ?*const c.Sigaction, noalias oact: ?*c.Sigaction) c_int;

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -233,6 +233,9 @@ pub const mach_header_64 = macho.mach_header_64;
 pub const mach_header = macho.mach_header;
 
 pub const _errno = __error;
+pub const _SC = struct {
+    pub const PAGESIZE = 29;
+};
 
 pub extern "c" fn @"close$NOCANCEL"(fd: fd_t) c_int;
 pub extern "c" fn mach_host_self() mach_port_t;
@@ -3691,7 +3694,7 @@ pub const MachTask = extern struct {
         return left;
     }
 
-    fn getPageSize(task: MachTask) MachError!usize {
+    pub fn getPageSize(task: MachTask) MachError!usize {
         if (task.isValid()) {
             var info_count = TASK_VM_INFO_COUNT;
             var vm_info: task_vm_info_data_t = undefined;

--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -9,6 +9,10 @@ pub fn _errno() *c_int {
     return &errno;
 }
 
+pub const _SC = struct {
+    pub const PAGESIZE = 47;
+};
+
 pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) c_int;
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -8,6 +8,10 @@ const iovec_const = std.os.iovec_const;
 extern "c" fn __error() *c_int;
 pub const _errno = __error;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 47;
+};
+
 pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) isize;
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;

--- a/lib/std/c/fuchsia.zig
+++ b/lib/std/c/fuchsia.zig
@@ -1,3 +1,8 @@
+// third party ulib musl
+pub const _SC = struct {
+    pub const PAGESIZE = 30;
+};
+
 pub const pthread_mutex_t = extern struct {
     size: [__SIZEOF_PTHREAD_MUTEX_T]u8 align(@alignOf(usize)) = [_]u8{0} ** __SIZEOF_PTHREAD_MUTEX_T,
 };

--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -9,6 +9,10 @@ extern "c" fn _errnop() *c_int;
 
 pub const _errno = _errnop;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 27;
+};
+
 pub extern "c" fn find_directory(which: c_int, volume: i32, createIt: bool, path_ptr: [*]u8, length: i32) u64;
 
 pub extern "c" fn find_thread(thread_name: ?*anyopaque) i32;

--- a/lib/std/c/hermit.zig
+++ b/lib/std/c/hermit.zig
@@ -1,6 +1,10 @@
 const std = @import("std");
 const maxInt = std.math.maxInt;
 
+// pub const _SC = struct {
+//     pub const PAGESIZE = TODO;
+// };
+
 pub const pthread_mutex_t = extern struct {
     inner: usize = ~@as(usize, 0),
 };

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -105,6 +105,10 @@ pub const user_desc = linux.user_desc;
 pub const utsname = linux.utsname;
 pub const PR = linux.PR;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 30;
+};
+
 pub const _errno = switch (native_abi) {
     .android => struct {
         extern fn __errno() *c_int;

--- a/lib/std/c/minix.zig
+++ b/lib/std/c/minix.zig
@@ -1,4 +1,9 @@
 const builtin = @import("builtin");
+
+pub const _SC = struct {
+    pub const PAGESIZE = 28;
+};
+
 pub const pthread_mutex_t = extern struct {
     size: [__SIZEOF_PTHREAD_MUTEX_T]u8 align(@alignOf(usize)) = [_]u8{0} ** __SIZEOF_PTHREAD_MUTEX_T,
 };

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -10,6 +10,10 @@ const rusage = std.c.rusage;
 extern "c" fn __errno() *c_int;
 pub const _errno = __errno;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 28;
+};
+
 pub const dl_iterate_phdr_callback = *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int;
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -8,6 +8,10 @@ const iovec_const = std.os.iovec_const;
 extern "c" fn __errno() *c_int;
 pub const _errno = __errno;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 28;
+};
+
 pub const dl_iterate_phdr_callback = *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int;
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 

--- a/lib/std/c/solaris.zig
+++ b/lib/std/c/solaris.zig
@@ -9,6 +9,11 @@ const timezone = std.c.timezone;
 extern "c" fn ___errno() *c_int;
 pub const _errno = ___errno;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 11;
+    pub const NPROCESSORS_ONLN = 15;
+};
+
 pub const dl_iterate_phdr_callback = *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int;
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 
@@ -17,7 +22,6 @@ pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn pipe2(fds: *[2]fd_t, flags: u32) c_int;
 pub extern "c" fn arc4random_buf(buf: [*]u8, len: usize) void;
 pub extern "c" fn posix_memalign(memptr: *?*anyopaque, alignment: usize, size: usize) c_int;
-pub extern "c" fn sysconf(sc: c_int) i64;
 pub extern "c" fn signalfd(fd: fd_t, mask: *const sigset_t, flags: u32) c_int;
 pub extern "c" fn madvise(address: [*]u8, len: usize, advise: u32) c_int;
 
@@ -1682,11 +1686,6 @@ pub const AF_SUN = struct {
     /// hardware capabilities can be verified against AT_SUN_HWCAP
     pub const HWCAPVERIFY = 0x00000002;
     pub const NOPLM = 0x00000004;
-};
-
-// TODO: Add sysconf numbers when the other OSs do.
-pub const _SC = struct {
-    pub const NPROCESSORS_ONLN = 15;
 };
 
 pub const procfs = struct {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4738,7 +4738,7 @@ pub fn sysconf(sc: c_int) SysConfError!usize {
             else => |err| return unexpectedErrno(err),
         }
     };
-    const choice: u8 = 0;
+    var choice: u8 = 0;
     choice += @intFromBool(is_minus_one);
     choice += @intFromBool(is_inval);
     switch (choice) {

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -1224,7 +1224,7 @@ test "getDefaultPageSize smoke test" {
     const page_size = try os.getDefaultPageSize();
     switch (page_size) {
         // zig fmt: off
-        1024, 2048, 4096, 8192, 16384, 32768, // 1, 2, 4, 8, 16, 32KB
+        1024, 2048, 4096, 8192, 16384, 32768, 65536, // 1, 2, 4, 8, 16, 32, 64KB
         2097152, 4194304 => {}, // 2, 4MB
         // zig fmt: on
         else => return error.InvalidDefaultPageSize,

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -1,4 +1,4 @@
-const std = @import("../std.zig");
+const std = @import("std");
 const os = std.os;
 const testing = std.testing;
 const expect = testing.expect;
@@ -1218,4 +1218,15 @@ test "fchmodat smoke test" {
     try os.fchmodat(tmp.dir.fd, "foo.txt", 0o755, 0);
     const st = try os.fstatat(tmp.dir.fd, "foo.txt", 0);
     try expectEqual(@as(os.mode_t, 0o755), st.mode & 0b111_111_111);
+}
+
+test "getDefaultPageSize smoke test" {
+    const page_size = try os.getDefaultPageSize();
+    switch (page_size) {
+        // zig fmt: off
+        1024, 2048, 4096, 8192, 16384, 32768, // 1, 2, 4, 8, 16, 32KB
+        2097152, 4194304 => {}, // 2, 4MB
+        // zig fmt: on
+        else => return error.InvalidDefaultPageSize,
+    }
 }


### PR DESCRIPTION
sysconf() abstracts posix sysconf for comptime- and runtime probing.

getDefaultPageSize() reads the Kernel provided default page size,
which remains constant from program start to end.

Reproduce added abi bits with:
git clone --depth=1 https://github.com/DragonFlyBSD/DragonFlyBSD
git clone --depth=1 https://git.FreeBSD.org/src.git freebsd
git clone --depth=1 https://fuchsia.googlesource.com/fuchsia
git clone --depth=1 https://github.com/haiku/haiku
git clone --depth=1 https://github.com/Stichting-MINIX-Research-Foundation/minix/
git clone --depth=1 https://github.com/NetBSD/src netbsd
git clone --depth=1 https://github.com/openbsd/src openbsd
git clone --depth=1 https://github.com/kofemann/opensolaris
git clone --depth=1 https://github.com/apple-open-source-mirror/Libc
rg 'define.*_SC_PAGE_SIZE' -B 1 --vimgrep

Closes #11308.