### PR TITLE
std.process.totalSystemMemory: return correct error type on FreeBSD

### DIFF
--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1168,7 +1168,7 @@ pub fn totalSystemMemory() TotalSystemMemoryError!usize {
             var len: usize = @sizeOf(c_ulong);
             os.sysctlbynameZ("hw.physmem", &physmem, &len, null, 0) catch |err| switch (err) {
                 error.NameTooLong, error.UnknownName => unreachable,
-                else => |e| return e,
+                else => return error.UnknownTotalSystemMemory,
             };
             return @as(usize, @intCast(physmem));
         },


### PR DESCRIPTION
closes #16641