### PR TITLE
std: Optimize std.mem.indexOfSentinel

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -976,7 +976,7 @@ pub fn indexOfSentinel(comptime Elem: type, comptime sentinel: Elem, ptr: [*:sen
     // protection. It is therefore correct and entirely equivalent to
     // indexOfSentinelNaive to read past the sentinel.
 
-    const v_len = comptime simd.suggestVectorSize(Elem) orelse return indexOfSentinelNaive(Elem, sentinel, ptr);
+    const v_len = (comptime simd.suggestVectorSize(Elem)) orelse return indexOfSentinelNaive(Elem, sentinel, ptr);
 
     {
         // FIXME: Allow the native x86_64 backend once it supports vectors.


### PR DESCRIPTION
Should be merged after #16648
Add a faster version of `std.mem.indexOfSentinel`. It outperforms both the common word-wise and the naive version.