### PR TITLE
Fix compile error in `addVcpkgPaths`

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1146,7 +1146,7 @@ pub fn addVcpkgPaths(self: *Compile, linkage: Compile.Linkage) !void {
 
             const include_path = b.pathJoin(&.{ root, "installed", triplet, "include" });
             errdefer allocator.free(include_path);
-            try self.include_dirs.append(IncludeDir{ .raw_path = include_path });
+            try self.include_dirs.append(IncludeDir{ .path = .{ .path = include_path } });
 
             const lib_path = b.pathJoin(&.{ root, "installed", triplet, "lib" });
             try self.lib_paths.append(.{ .path = lib_path });


### PR DESCRIPTION
Found while updating https://github.com/fabioarnold/zig-gorillas/commit/cc7dc2c33fe2d1ee9e27d58d7cddc723a9e291e7