### PR TITLE
general-use std.debug.hexdump for printing hexdumps

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -104,6 +104,63 @@ pub fn getSelfDebugInfo() !*DebugInfo {
     }
 }
 
+/// Tries to print a hexadecimal view of the bytes, unbuffered, and ignores any error returned.
+pub fn hexdump(bytes: []const u8) void {
+    hexdump_internal(bytes) catch {};
+}
+
+fn hexdump_internal(bytes: []const u8) !void {
+    const stderr = std.io.getStdErr();
+    const ttyconf = std.io.tty.detectConfig(stderr);
+    const writer = stderr.writer();
+    var chunks = mem.window(u8, bytes, 16, 16);
+    while (chunks.next()) |window| {
+        // 1. Print the address.
+        const address = (@intFromPtr(bytes.ptr) + 0x10 * (chunks.index orelse 0) / 16) - 0x10;
+        try ttyconf.setColor(writer, .dim);
+        // We print the address in lowercase and the bytes in uppercase hexadecimal to distinguish them more.
+        // Also, make sure all lines are aligned by padding the address.
+        try writer.print("{x:0>[1]}  ", .{ address, @sizeOf(usize) * 2 });
+        try ttyconf.setColor(writer, .reset);
+
+        // 2. Print the bytes.
+        for (window, 0..) |byte, index| {
+            try writer.print("{X:0>2} ", .{byte});
+            if (index == 7) try writer.writeByte(' ');
+        }
+        try writer.writeByte(' ');
+        if (window.len < 16) {
+            var missing_columns = (16 - window.len) * 3;
+            if (window.len < 8) missing_columns += 1;
+            try writer.writeByteNTimes(' ', missing_columns);
+        }
+
+        // 3. Print the characters.
+        for (window) |byte| {
+            if (std.ascii.isPrint(byte)) {
+                try writer.writeByte(byte);
+            } else {
+                // TODO: remove this `if` when https://github.com/ziglang/zig/issues/7600 is fixed
+                if (ttyconf == .windows_api) {
+                    try writer.writeByte('.');
+                    continue;
+                }
+
+                // Let's print some common control codes as graphical Unicode symbols.
+                // We don't want to do this for all control codes because most control codes apart from
+                // the ones that Zig has escape sequences for are likely not very useful to print as symbols.
+                switch (byte) {
+                    '\n' => try writer.writeAll("␊"),
+                    '\r' => try writer.writeAll("␍"),
+                    '\t' => try writer.writeAll("␉"),
+                    else => try writer.writeByte('.'),
+                }
+            }
+        }
+        try writer.writeByte('\n');
+    }
+}
+
 /// Tries to print the current stack trace to stderr, unbuffered, and ignores any error returned.
 /// TODO multithreaded awareness
 pub fn dumpCurrentStackTrace(start_addr: ?usize) void {


### PR DESCRIPTION
Recently, when I've been working with structures of data that are not directly in RAM but rather laid out in bytes somewhere else, it was always very useful to print out maybe the next 50 bytes or the previous 50 bytes or so to see what's ahead or before me. I usually do this with a quick
`std.debug.print("{any}\n", .{bytes});` or something but the output is not as nice obviously.

That reminded me to this hexdump-like printing code that we already have in `std.testing` and use for `std.testing.expectEqualSlices` thanks to @squeek502.

We can reuse it for a general-purpose `std.debug.hexdump` function which should be an excellent debugging tool when you want to know what or where the bytes are.

```zig
const std = @import("std");

pub fn main() !void {
    var bytes: [5 * 1000 * 1000]u8 = undefined; // 5 MB
    for (&bytes, 0..) |*byte, index| {
        byte.* = @truncate(index);
    }
    std.debug.hexdump(bytes[0..500]); // dump the first 500 bytes
}
```
![image](https://github.com/ziglang/zig/assets/35064754/1524e6c6-6dfe-461d-8dde-070a965c3dbf)

This does not intend to change the existing `std.testing.expectEqualSlices` output. I compared the output before and after and I couldn't see a difference. This is why `BytesDiffer` is configurable to make it actually be a hexdump printer instead of a bytes diff printer.

This, except that now in both outputs `\n`, `\r`, and `\t` will be printed with graphical Unicode symbols instead of periods in the character output if color is enabled.