### PR TITLE
Sema: improve new error messages related to naked functions

### DIFF
--- a/test/cases/compile_errors/call_from_naked_func.zig
+++ b/test/cases/compile_errors/call_from_naked_func.zig
@@ -1,0 +1,24 @@
+export fn runtimeCall() callconv(.Naked) void {
+    f();
+}
+
+export fn runtimeBuiltinCall() callconv(.Naked) void {
+    @call(.auto, f, .{});
+}
+
+export fn comptimeCall() callconv(.Naked) void {
+    comptime f();
+}
+
+export fn comptimeBuiltinCall() callconv(.Naked) void {
+    @call(.compile_time, f, .{});
+}
+
+fn f() void {}
+
+// error
+// backend=llvm
+// target=native
+//
+// :2:6: error: runtime call not allowed in naked function
+// :6:5: error: runtime @call not allowed in naked function

--- a/test/cases/compile_errors/return_from_naked_function.zig
+++ b/test/cases/compile_errors/return_from_naked_function.zig
@@ -1,0 +1,14 @@
+fn foo() callconv(.Naked) void {
+    return;
+}
+
+comptime {
+    _ = &foo;
+}
+
+// error
+// backend=llvm
+// target=native
+//
+// :2:5: error: cannot return from naked function
+// :2:5: note: can only return using assembly

--- a/test/cases/compile_errors/unreachable_in_naked_func.zig
+++ b/test/cases/compile_errors/unreachable_in_naked_func.zig
@@ -1,0 +1,30 @@
+fn runtimeSafetyDefault() callconv(.Naked) void {
+    unreachable;
+}
+
+fn runtimeSafetyOn() callconv(.Naked) void {
+    @setRuntimeSafety(true);
+    unreachable;
+}
+
+fn runtimeSafetyOff() callconv(.Naked) void {
+    @setRuntimeSafety(false);
+    unreachable;
+}
+
+comptime {
+    _ = &runtimeSafetyDefault;
+    _ = &runtimeSafetyOn;
+    _ = &runtimeSafetyOff;
+}
+
+// error
+// backend=llvm
+// target=native
+//
+// :2:5: error: runtime safety check not allowed in naked function
+// :2:5: note: use @setRuntimeSafety to disable runtime safety
+// :2:5: note: the end of a naked function is implicitly unreachable
+// :7:5: error: runtime safety check not allowed in naked function
+// :7:5: note: use @setRuntimeSafety to disable runtime safety
+// :7:5: note: the end of a naked function is implicitly unreachable


### PR DESCRIPTION
 * pass a source location to all safety checks
 * add notes about what is disallowed in naked functions

Turns
```
src/cpu/arch/x86/64/init.zig:483:17: error: runtime call not allowed in naked function
            if (!has_error_code) {
                ^~~~~~~~~~~~~~~
```
into
```
src/cpu/arch/x86/64/init.zig:588:13: error: runtime safety check not allowed in naked function
            unreachable;
            ^~~~~~~~~~~
src/cpu/arch/x86/64/init.zig:588:13: note: use @setRuntimeSafety to disable runtime safety
src/cpu/arch/x86/64/init.zig:588:13: note: the end of a naked function is implicitly unreachable
```

Closes #16651