### PR TITLE
macho: track unwind/dwarf cfi records by symbol rather than atom

### DIFF
--- a/src/link/MachO/dead_strip.zig
+++ b/src/link/MachO/dead_strip.zig
@@ -294,124 +294,131 @@ fn markUnwindRecords(zld: *Zld, object_id: u32, alive: *AtomTable) !void {
     const unwind_records = object.getUnwindRecords();
 
     for (object.exec_atoms.items) |atom_index| {
-        if (!object.hasUnwindRecords()) {
-            if (object.eh_frame_records_lookup.get(atom_index)) |fde_offset| {
-                const ptr = object.eh_frame_relocs_lookup.getPtr(fde_offset).?;
-                if (ptr.dead) continue; // already marked
-                if (!alive.contains(atom_index)) {
-                    // Mark dead and continue.
-                    ptr.dead = true;
-                } else {
-                    // Mark references live and continue.
-                    try markEhFrameRecord(zld, object_id, atom_index, alive);
-                }
-                continue;
-            }
-        }
+        var inner_syms_it = Atom.getInnerSymbolsIterator(zld, atom_index);
 
-        const record_id = object.unwind_records_lookup.get(atom_index) orelse continue;
-        if (object.unwind_relocs_lookup[record_id].dead) continue; // already marked, nothing to do
-        if (!alive.contains(atom_index)) {
-            // Mark the record dead and continue.
-            object.unwind_relocs_lookup[record_id].dead = true;
-            if (object.eh_frame_records_lookup.get(atom_index)) |fde_offset| {
-                object.eh_frame_relocs_lookup.getPtr(fde_offset).?.dead = true;
+        if (!object.hasUnwindRecords()) {
+            if (alive.contains(atom_index)) {
+                // Mark references live and continue.
+                try markEhFrameRecords(zld, object_id, atom_index, alive);
+            } else {
+                while (inner_syms_it.next()) |sym| {
+                    if (object.eh_frame_records_lookup.get(sym)) |fde_offset| {
+                        // Mark dead and continue.
+                        object.eh_frame_relocs_lookup.getPtr(fde_offset).?.dead = true;
+                    }
+                }
             }
             continue;
         }
 
-        const record = unwind_records[record_id];
-        if (UnwindInfo.UnwindEncoding.isDwarf(record.compactUnwindEncoding, cpu_arch)) {
-            try markEhFrameRecord(zld, object_id, atom_index, alive);
-        } else {
-            if (UnwindInfo.getPersonalityFunctionReloc(zld, object_id, record_id)) |rel| {
-                const target = Atom.parseRelocTarget(zld, .{
-                    .object_id = object_id,
-                    .rel = rel,
-                    .code = mem.asBytes(&record),
-                    .base_offset = @as(i32, @intCast(record_id * @sizeOf(macho.compact_unwind_entry))),
-                });
-                const target_sym = zld.getSymbol(target);
-                if (!target_sym.undf()) {
+        while (inner_syms_it.next()) |sym| {
+            const record_id = object.unwind_records_lookup.get(sym) orelse continue;
+            if (object.unwind_relocs_lookup[record_id].dead) continue; // already marked, nothing to do
+            if (!alive.contains(atom_index)) {
+                // Mark the record dead and continue.
+                object.unwind_relocs_lookup[record_id].dead = true;
+                if (object.eh_frame_records_lookup.get(sym)) |fde_offset| {
+                    object.eh_frame_relocs_lookup.getPtr(fde_offset).?.dead = true;
+                }
+                continue;
+            }
+
+            const record = unwind_records[record_id];
+            if (UnwindInfo.UnwindEncoding.isDwarf(record.compactUnwindEncoding, cpu_arch)) {
+                try markEhFrameRecords(zld, object_id, atom_index, alive);
+            } else {
+                if (UnwindInfo.getPersonalityFunctionReloc(zld, object_id, record_id)) |rel| {
+                    const target = Atom.parseRelocTarget(zld, .{
+                        .object_id = object_id,
+                        .rel = rel,
+                        .code = mem.asBytes(&record),
+                        .base_offset = @as(i32, @intCast(record_id * @sizeOf(macho.compact_unwind_entry))),
+                    });
+                    const target_sym = zld.getSymbol(target);
+                    if (!target_sym.undf()) {
+                        const target_object = zld.objects.items[target.getFile().?];
+                        const target_atom_index = target_object.getAtomIndexForSymbol(target.sym_index).?;
+                        markLive(zld, target_atom_index, alive);
+                    }
+                }
+
+                if (UnwindInfo.getLsdaReloc(zld, object_id, record_id)) |rel| {
+                    const target = Atom.parseRelocTarget(zld, .{
+                        .object_id = object_id,
+                        .rel = rel,
+                        .code = mem.asBytes(&record),
+                        .base_offset = @as(i32, @intCast(record_id * @sizeOf(macho.compact_unwind_entry))),
+                    });
                     const target_object = zld.objects.items[target.getFile().?];
                     const target_atom_index = target_object.getAtomIndexForSymbol(target.sym_index).?;
                     markLive(zld, target_atom_index, alive);
                 }
             }
-
-            if (UnwindInfo.getLsdaReloc(zld, object_id, record_id)) |rel| {
-                const target = Atom.parseRelocTarget(zld, .{
-                    .object_id = object_id,
-                    .rel = rel,
-                    .code = mem.asBytes(&record),
-                    .base_offset = @as(i32, @intCast(record_id * @sizeOf(macho.compact_unwind_entry))),
-                });
-                const target_object = zld.objects.items[target.getFile().?];
-                const target_atom_index = target_object.getAtomIndexForSymbol(target.sym_index).?;
-                markLive(zld, target_atom_index, alive);
-            }
         }
     }
 }
 
-fn markEhFrameRecord(zld: *Zld, object_id: u32, atom_index: AtomIndex, alive: *AtomTable) !void {
+fn markEhFrameRecords(zld: *Zld, object_id: u32, atom_index: AtomIndex, alive: *AtomTable) !void {
     const cpu_arch = zld.options.target.cpu.arch;
     const object = &zld.objects.items[object_id];
     var it = object.getEhFrameRecordsIterator();
+    var inner_syms_it = Atom.getInnerSymbolsIterator(zld, atom_index);
 
-    const fde_offset = object.eh_frame_records_lookup.get(atom_index).?;
-    it.seekTo(fde_offset);
-    const fde = (try it.next()).?;
+    while (inner_syms_it.next()) |sym| {
+        const fde_offset = object.eh_frame_records_lookup.get(sym) orelse continue; // Continue in case we hit a temp symbol alias
+        it.seekTo(fde_offset);
+        const fde = (try it.next()).?;
 
-    const cie_ptr = fde.getCiePointerSource(object_id, zld, fde_offset);
-    const cie_offset = fde_offset + 4 - cie_ptr;
-    it.seekTo(cie_offset);
-    const cie = (try it.next()).?;
+        const cie_ptr = fde.getCiePointerSource(object_id, zld, fde_offset);
+        const cie_offset = fde_offset + 4 - cie_ptr;
+        it.seekTo(cie_offset);
+        const cie = (try it.next()).?;
 
-    switch (cpu_arch) {
-        .aarch64 => {
-            // Mark FDE references which should include any referenced LSDA record
-            const relocs = eh_frame.getRelocs(zld, object_id, fde_offset);
-            for (relocs) |rel| {
-                const target = Atom.parseRelocTarget(zld, .{
-                    .object_id = object_id,
-                    .rel = rel,
-                    .code = fde.data,
-                    .base_offset = @as(i32, @intCast(fde_offset)) + 4,
+        switch (cpu_arch) {
+            .aarch64 => {
+                // Mark FDE references which should include any referenced LSDA record
+                const relocs = eh_frame.getRelocs(zld, object_id, fde_offset);
+                for (relocs) |rel| {
+                    const target = Atom.parseRelocTarget(zld, .{
+                        .object_id = object_id,
+                        .rel = rel,
+                        .code = fde.data,
+                        .base_offset = @as(i32, @intCast(fde_offset)) + 4,
+                    });
+                    const target_sym = zld.getSymbol(target);
+                    if (!target_sym.undf()) blk: {
+                        const target_object = zld.objects.items[target.getFile().?];
+                        const target_atom_index = target_object.getAtomIndexForSymbol(target.sym_index) orelse
+                            break :blk;
+                        markLive(zld, target_atom_index, alive);
+                    }
+                }
+            },
+            .x86_64 => {
+                const sect = object.getSourceSection(object.eh_frame_sect_id.?);
+                const lsda_ptr = try fde.getLsdaPointer(cie, .{
+                    .base_addr = sect.addr,
+                    .base_offset = fde_offset,
                 });
-                const target_sym = zld.getSymbol(target);
-                if (!target_sym.undf()) blk: {
-                    const target_object = zld.objects.items[target.getFile().?];
-                    const target_atom_index = target_object.getAtomIndexForSymbol(target.sym_index) orelse
-                        break :blk;
+                if (lsda_ptr) |lsda_address| {
+                    // Mark LSDA record as live
+                    const sym_index = object.getSymbolByAddress(lsda_address, null);
+                    const target_atom_index = object.getAtomIndexForSymbol(sym_index).?;
                     markLive(zld, target_atom_index, alive);
                 }
-            }
-        },
-        .x86_64 => {
-            const sect = object.getSourceSection(object.eh_frame_sect_id.?);
-            const lsda_ptr = try fde.getLsdaPointer(cie, .{
-                .base_addr = sect.addr,
-                .base_offset = fde_offset,
-            });
-            if (lsda_ptr) |lsda_address| {
-                // Mark LSDA record as live
-                const sym_index = object.getSymbolByAddress(lsda_address, null);
-                const target_atom_index = object.getAtomIndexForSymbol(sym_index).?;
+            },
+            else => unreachable,
+        }
+
+        // Mark CIE references which should include any referenced personalities
+        // that are defined locally.
+        if (cie.getPersonalityPointerReloc(zld, object_id, cie_offset)) |target| {
+            const target_sym = zld.getSymbol(target);
+            if (!target_sym.undf()) {
+                const target_object = zld.objects.items[target.getFile().?];
+                const target_atom_index = target_object.getAtomIndexForSymbol(target.sym_index).?;
                 markLive(zld, target_atom_index, alive);
             }
-        },
-        else => unreachable,
-    }
-
-    // Mark CIE references which should include any referenced personalities
-    // that are defined locally.
-    if (cie.getPersonalityPointerReloc(zld, object_id, cie_offset)) |target| {
-        const target_sym = zld.getSymbol(target);
-        if (!target_sym.undf()) {
-            const target_object = zld.objects.items[target.getFile().?];
-            const target_atom_index = target_object.getAtomIndexForSymbol(target.sym_index).?;
-            markLive(zld, target_atom_index, alive);
         }
     }
 }

--- a/src/link/MachO/dead_strip.zig
+++ b/src/link/MachO/dead_strip.zig
@@ -465,8 +465,8 @@ fn prune(zld: *Zld, alive: AtomTable) void {
                     section.last_atom_index = prev_index;
                 } else {
                     assert(section.header.size == 0);
-                    section.first_atom_index = undefined;
-                    section.last_atom_index = undefined;
+                    section.first_atom_index = 0;
+                    section.last_atom_index = 0;
                 }
             }
 

--- a/test/link.zig
+++ b/test/link.zig
@@ -97,6 +97,10 @@ pub const cases = [_]Case{
         .import = @import("link/macho/bugs/16308/build.zig"),
     },
     .{
+        .build_root = "test/link/macho/bugs/16628",
+        .import = @import("link/macho/bugs/16628/build.zig"),
+    },
+    .{
         .build_root = "test/link/macho/dead_strip",
         .import = @import("link/macho/dead_strip/build.zig"),
     },

--- a/test/link/macho/bugs/16628/a_arm64.s
+++ b/test/link/macho/bugs/16628/a_arm64.s
@@ -1,0 +1,37 @@
+.globl _foo
+.align 4
+_foo: 
+  .cfi_startproc
+  stp     x29, x30, [sp, #-32]!
+  .cfi_def_cfa_offset 32
+  .cfi_offset w30, -24
+  .cfi_offset w29, -32
+  mov x29, sp
+  .cfi_def_cfa w29, 32
+  bl      _bar
+  ldp     x29, x30, [sp], #32
+  .cfi_restore w29
+  .cfi_restore w30
+  .cfi_def_cfa_offset 0
+  ret
+  .cfi_endproc
+
+.globl _bar
+.align 4
+_bar:
+  .cfi_startproc
+  sub     sp, sp, #32
+  .cfi_def_cfa_offset -32
+  stp     x29, x30, [sp, #16]
+  .cfi_offset w30, -24
+  .cfi_offset w29, -32
+  mov x29, sp
+  .cfi_def_cfa w29, 32
+  mov     w0, #4
+  ldp     x29, x30, [sp, #16]
+  .cfi_restore w29
+  .cfi_restore w30
+  add     sp, sp, #32
+  .cfi_def_cfa_offset 0
+  ret
+  .cfi_endproc

--- a/test/link/macho/bugs/16628/a_x64.s
+++ b/test/link/macho/bugs/16628/a_x64.s
@@ -1,0 +1,29 @@
+.globl _foo
+_foo: 
+  .cfi_startproc
+  push    %rbp
+  .cfi_def_cfa_offset 8
+  .cfi_offset %rbp, -8
+  mov     %rsp, %rbp
+  .cfi_def_cfa_register %rbp
+  call    _bar
+  pop     %rbp
+  .cfi_restore %rbp
+  .cfi_def_cfa_offset 0
+  ret
+  .cfi_endproc
+
+.globl _bar
+_bar:
+  .cfi_startproc
+  push     %rbp
+  .cfi_def_cfa_offset 8
+  .cfi_offset %rbp, -8
+  mov     %rsp, %rbp
+  .cfi_def_cfa_register %rbp
+  mov     $4, %rax
+  pop     %rbp
+  .cfi_restore %rbp
+  .cfi_def_cfa_offset 0
+  ret
+  .cfi_endproc

--- a/test/link/macho/bugs/16628/build.zig
+++ b/test/link/macho/bugs/16628/build.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const requires_symlinks = true;
+pub const requires_macos_sdk = false;
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    add(b, test_step, .Debug);
+    add(b, test_step, .ReleaseFast);
+    add(b, test_step, .ReleaseSmall);
+    add(b, test_step, .ReleaseSafe);
+}
+
+fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
+    const target: std.zig.CrossTarget = .{ .os_tag = .macos };
+
+    const exe = b.addExecutable(.{
+        .name = "test",
+        .optimize = optimize,
+        .target = target,
+    });
+    exe.addCSourceFile(.{ .file = .{ .path = "main.c" }, .flags = &[0][]const u8{} });
+    switch (builtin.cpu.arch) {
+        .aarch64 => {
+            exe.addCSourceFile(.{ .file = .{ .path = "a_arm64.s" }, .flags = &[0][]const u8{} });
+        },
+        .x86_64 => {
+            exe.addCSourceFile(.{ .file = .{ .path = "a_x64.s" }, .flags = &[0][]const u8{} });
+        },
+        else => unreachable,
+    }
+    exe.linkLibC();
+
+    const run = b.addRunArtifact(exe);
+    run.skip_foreign_checks = true;
+    run.expectStdOutEqual("4\n");
+
+    test_step.dependOn(&run.step);
+}

--- a/test/link/macho/bugs/16628/main.c
+++ b/test/link/macho/bugs/16628/main.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int foo();
+
+int main() {
+  printf("%d\n", foo());
+  return 0;
+}


### PR DESCRIPTION
This solves the nuance case of compiling hand-crafted assembly files which do not feature `MH_SUBSECTIONS_VIA_SYMBOLS` flag resulting in input `Atom`s encompassing multiple symbols each with unique unwind information.

Closes #16628 