### PR TITLE
codegen/llvm: fix wrong field offset in packed structs

### DIFF
--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3015,7 +3015,10 @@ fn lowerParentPtr(func: *CodeGen, ptr_val: Value, offset: u32) InnerError!WValue
 
             const field_offset = switch (parent_ty.zigTypeTag(mod)) {
                 .Struct => switch (parent_ty.containerLayout(mod)) {
-                    .Packed => parent_ty.packedStructFieldByteOffset(@as(usize, @intCast(field.index)), mod),
+                    .Packed => if (parent_ty.packedStructFieldByteAligned(@intCast(field.index), mod))
+                        parent_ty.packedStructFieldByteOffset(@as(usize, @intCast(field.index)), mod)
+                    else
+                        0,
                     else => parent_ty.structFieldOffset(@as(usize, @intCast(field.index)), mod),
                 },
                 .Union => switch (parent_ty.containerLayout(mod)) {

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -696,13 +696,10 @@ fn lowerParentPtr(
                             mod,
                         )),
                         .Packed => if (mod.typeToStruct(base_type.toType())) |struct_obj|
-                            math.divExact(u16, struct_obj.packedFieldBitOffset(
-                                mod,
-                                @intCast(field.index),
-                            ), 8) catch |err| switch (err) {
-                                error.UnexpectedRemainder => 0,
-                                error.DivisionByZero => unreachable,
-                            }
+                            if (base_type.toType().packedStructFieldByteAligned(@intCast(field.index), mod))
+                                @divExact(struct_obj.packedFieldBitOffset(mod, @intCast(field.index)), 8)
+                            else
+                                0
                         else
                             0,
                     },


### PR DESCRIPTION
when a field was 'byte_aligned', the offset was applied once to the pointer
 and again when dereferencing it (because it's a ptr with a 'packed_offset')

resolves https://github.com/ziglang/zig/issues/16615 
and maybe https://github.com/ziglang/zig/issues/16621 ?
