### PR TITLE
LibCInstallation: no longer depends on LLVM

### DIFF
--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -3,7 +3,6 @@ const builtin = @import("builtin");
 const Target = std.Target;
 const fs = std.fs;
 const Allocator = std.mem.Allocator;
-const build_options = @import("build_options");
 
 const is_darwin = builtin.target.isDarwin();
 const is_windows = builtin.target.os.tag == .windows;
@@ -184,9 +183,6 @@ pub const LibCInstallation = struct {
         if (is_darwin) {
             @panic("Darwin is handled separately via std.zig.system.darwin module");
         } else if (is_windows) {
-            if (!build_options.have_llvm)
-                return error.WindowsSdkNotFound;
-
             var sdk: ZigWindowsSDK = ZigWindowsSDK.find(args.allocator) catch |err| switch (err) {
                 error.NotFound => return error.WindowsSdkNotFound,
                 error.PathTooLong => return error.WindowsSdkNotFound,


### PR DESCRIPTION
Reverts 4fa8cc736966544da381c90a6111158179fc550b. This check was added because it depended on C++ code, but after
77b96231a6bc195cc482d05599e8c20ee01645a6, this functionality no longer depends on C++ code.

This file is now independent from the rest of the compiler code and could be moved to the std.zig namespace if we wish.

cc @BratishkaErik :slightly_smiling_face: 