### PR TITLE
std.target: mark helper functions inline

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -59,14 +59,14 @@ pub const Target = struct {
             plan9,
             other,
 
-            pub fn isDarwin(tag: Tag) bool {
+            pub inline fn isDarwin(tag: Tag) bool {
                 return switch (tag) {
                     .ios, .macos, .watchos, .tvos => true,
                     else => false,
                 };
             }
 
-            pub fn isBSD(tag: Tag) bool {
+            pub inline fn isBSD(tag: Tag) bool {
                 return tag.isDarwin() or switch (tag) {
                     .kfreebsd, .freebsd, .openbsd, .netbsd, .dragonfly => true,
                     else => false,
@@ -135,7 +135,7 @@ pub const Target = struct {
             };
 
             /// Returns whether the first version `self` is newer (greater) than or equal to the second version `ver`.
-            pub fn isAtLeast(self: WindowsVersion, ver: WindowsVersion) bool {
+            pub inline fn isAtLeast(self: WindowsVersion, ver: WindowsVersion) bool {
                 return @intFromEnum(self) >= @intFromEnum(ver);
             }
 
@@ -143,13 +143,13 @@ pub const Target = struct {
                 min: WindowsVersion,
                 max: WindowsVersion,
 
-                pub fn includesVersion(self: Range, ver: WindowsVersion) bool {
+                pub inline fn includesVersion(self: Range, ver: WindowsVersion) bool {
                     return @intFromEnum(ver) >= @intFromEnum(self.min) and @intFromEnum(ver) <= @intFromEnum(self.max);
                 }
 
                 /// Checks if system is guaranteed to be at least `version` or older than `version`.
                 /// Returns `null` if a runtime check is required.
-                pub fn isAtLeast(self: Range, ver: WindowsVersion) ?bool {
+                pub inline fn isAtLeast(self: Range, ver: WindowsVersion) ?bool {
                     if (@intFromEnum(self.min) >= @intFromEnum(ver)) return true;
                     if (@intFromEnum(self.max) < @intFromEnum(ver)) return false;
                     return null;
@@ -187,13 +187,13 @@ pub const Target = struct {
             range: Version.Range,
             glibc: Version,
 
-            pub fn includesVersion(self: LinuxVersionRange, ver: Version) bool {
+            pub inline fn includesVersion(self: LinuxVersionRange, ver: Version) bool {
                 return self.range.includesVersion(ver);
             }
 
             /// Checks if system is guaranteed to be at least `version` or older than `version`.
             /// Returns `null` if a runtime check is required.
-            pub fn isAtLeast(self: LinuxVersionRange, ver: Version) ?bool {
+            pub inline fn isAtLeast(self: LinuxVersionRange, ver: Version) ?bool {
                 return self.range.isAtLeast(ver);
             }
         };
@@ -360,7 +360,7 @@ pub const Target = struct {
 
         /// Provides a tagged union. `Target` does not store the tag because it is
         /// redundant with the OS tag; this function abstracts that part away.
-        pub fn getVersionRange(self: Os) TaggedVersionRange {
+        pub inline fn getVersionRange(self: Os) TaggedVersionRange {
             switch (self.tag) {
                 .linux => return TaggedVersionRange{ .linux = self.version_range.linux },
                 .windows => return TaggedVersionRange{ .windows = self.version_range.windows },
@@ -382,7 +382,7 @@ pub const Target = struct {
 
         /// Checks if system is guaranteed to be at least `version` or older than `version`.
         /// Returns `null` if a runtime check is required.
-        pub fn isAtLeast(self: Os, comptime tag: Tag, version: anytype) ?bool {
+        pub inline fn isAtLeast(self: Os, comptime tag: Tag, version: anytype) ?bool {
             if (self.tag != tag) return false;
 
             return switch (tag) {
@@ -395,7 +395,7 @@ pub const Target = struct {
         /// On Darwin, we always link libSystem which contains libc.
         /// Similarly on FreeBSD and NetBSD we always link system libc
         /// since this is the stable syscall interface.
-        pub fn requiresLibC(os: Os) bool {
+        pub inline fn requiresLibC(os: Os) bool {
             return switch (os.tag) {
                 .freebsd,
                 .netbsd,
@@ -569,21 +569,21 @@ pub const Target = struct {
             }
         }
 
-        pub fn isGnu(abi: Abi) bool {
+        pub inline fn isGnu(abi: Abi) bool {
             return switch (abi) {
                 .gnu, .gnuabin32, .gnuabi64, .gnueabi, .gnueabihf, .gnux32 => true,
                 else => false,
             };
         }
 
-        pub fn isMusl(abi: Abi) bool {
+        pub inline fn isMusl(abi: Abi) bool {
             return switch (abi) {
                 .musl, .musleabi, .musleabihf => true,
                 else => false,
             };
         }
 
-        pub fn floatAbi(abi: Abi) FloatAbi {
+        pub inline fn floatAbi(abi: Abi) FloatAbi {
             return switch (abi) {
                 .gnueabihf,
                 .eabihf,
@@ -871,95 +871,95 @@ pub const Target = struct {
             // map one-to-one with the ZigLLVM_ArchType enum.
             spu_2,
 
-            pub fn isX86(arch: Arch) bool {
+            pub inline fn isX86(arch: Arch) bool {
                 return switch (arch) {
                     .x86, .x86_64 => true,
                     else => false,
                 };
             }
 
-            pub fn isARM(arch: Arch) bool {
+            pub inline fn isARM(arch: Arch) bool {
                 return switch (arch) {
                     .arm, .armeb => true,
                     else => false,
                 };
             }
 
-            pub fn isAARCH64(arch: Arch) bool {
+            pub inline fn isAARCH64(arch: Arch) bool {
                 return switch (arch) {
                     .aarch64, .aarch64_be, .aarch64_32 => true,
                     else => false,
                 };
             }
 
-            pub fn isThumb(arch: Arch) bool {
+            pub inline fn isThumb(arch: Arch) bool {
                 return switch (arch) {
                     .thumb, .thumbeb => true,
                     else => false,
                 };
             }
 
-            pub fn isArmOrThumb(arch: Arch) bool {
+            pub inline fn isArmOrThumb(arch: Arch) bool {
                 return arch.isARM() or arch.isThumb();
             }
 
-            pub fn isWasm(arch: Arch) bool {
+            pub inline fn isWasm(arch: Arch) bool {
                 return switch (arch) {
                     .wasm32, .wasm64 => true,
                     else => false,
                 };
             }
 
-            pub fn isRISCV(arch: Arch) bool {
+            pub inline fn isRISCV(arch: Arch) bool {
                 return switch (arch) {
                     .riscv32, .riscv64 => true,
                     else => false,
                 };
             }
 
-            pub fn isMIPS(arch: Arch) bool {
+            pub inline fn isMIPS(arch: Arch) bool {
                 return switch (arch) {
                     .mips, .mipsel, .mips64, .mips64el => true,
                     else => false,
                 };
             }
 
-            pub fn isPPC(arch: Arch) bool {
+            pub inline fn isPPC(arch: Arch) bool {
                 return switch (arch) {
                     .powerpc, .powerpcle => true,
                     else => false,
                 };
             }
 
-            pub fn isPPC64(arch: Arch) bool {
+            pub inline fn isPPC64(arch: Arch) bool {
                 return switch (arch) {
                     .powerpc64, .powerpc64le => true,
                     else => false,
                 };
             }
 
-            pub fn isSPARC(arch: Arch) bool {
+            pub inline fn isSPARC(arch: Arch) bool {
                 return switch (arch) {
                     .sparc, .sparcel, .sparc64 => true,
                     else => false,
                 };
             }
 
-            pub fn isSpirV(arch: Arch) bool {
+            pub inline fn isSpirV(arch: Arch) bool {
                 return switch (arch) {
                     .spirv32, .spirv64 => true,
                     else => false,
                 };
             }
 
-            pub fn isBpf(arch: Arch) bool {
+            pub inline fn isBpf(arch: Arch) bool {
                 return switch (arch) {
                     .bpfel, .bpfeb => true,
                     else => false,
                 };
             }
 
-            pub fn isNvptx(arch: Arch) bool {
+            pub inline fn isNvptx(arch: Arch) bool {
                 return switch (arch) {
                     .nvptx, .nvptx64 => true,
                     else => false,
@@ -975,7 +975,7 @@ pub const Target = struct {
                 return error.UnknownCpuModel;
             }
 
-            pub fn toElfMachine(arch: Arch) std.elf.EM {
+            pub inline fn toElfMachine(arch: Arch) std.elf.EM {
                 return switch (arch) {
                     .avr => .AVR,
                     .msp430 => .MSP430,
@@ -1040,7 +1040,7 @@ pub const Target = struct {
                 };
             }
 
-            pub fn toCoffMachine(arch: Arch) std.coff.MachineType {
+            pub inline fn toCoffMachine(arch: Arch) std.coff.MachineType {
                 return switch (arch) {
                     .avr => .Unknown,
                     .msp430 => .Unknown,
@@ -1105,7 +1105,7 @@ pub const Target = struct {
                 };
             }
 
-            pub fn endian(arch: Arch) std.builtin.Endian {
+            pub inline fn endian(arch: Arch) std.builtin.Endian {
                 return switch (arch) {
                     .avr,
                     .arm,
@@ -1176,7 +1176,7 @@ pub const Target = struct {
             }
 
             /// Returns whether this architecture supports the address space
-            pub fn supportsAddressSpace(arch: Arch, address_space: std.builtin.AddressSpace) bool {
+            pub inline fn supportsAddressSpace(arch: Arch, address_space: std.builtin.AddressSpace) bool {
                 const is_nvptx = arch == .nvptx or arch == .nvptx64;
                 const is_spirv = arch == .spirv32 or arch == .spirv64;
                 const is_gpu = is_nvptx or is_spirv or arch == .amdgcn;
@@ -1418,51 +1418,51 @@ pub const Target = struct {
         return libPrefix_os_abi(self.os.tag, self.abi);
     }
 
-    pub fn isMinGW(self: Target) bool {
+    pub inline fn isMinGW(self: Target) bool {
         return self.os.tag == .windows and self.isGnu();
     }
 
-    pub fn isGnu(self: Target) bool {
+    pub inline fn isGnu(self: Target) bool {
         return self.abi.isGnu();
     }
 
-    pub fn isMusl(self: Target) bool {
+    pub inline fn isMusl(self: Target) bool {
         return self.abi.isMusl();
     }
 
-    pub fn isAndroid(self: Target) bool {
+    pub inline fn isAndroid(self: Target) bool {
         return self.abi == .android;
     }
 
-    pub fn isWasm(self: Target) bool {
+    pub inline fn isWasm(self: Target) bool {
         return self.cpu.arch.isWasm();
     }
 
-    pub fn isDarwin(self: Target) bool {
+    pub inline fn isDarwin(self: Target) bool {
         return self.os.tag.isDarwin();
     }
 
-    pub fn isBSD(self: Target) bool {
+    pub inline fn isBSD(self: Target) bool {
         return self.os.tag.isBSD();
     }
 
-    pub fn isBpfFreestanding(self: Target) bool {
+    pub inline fn isBpfFreestanding(self: Target) bool {
         return self.cpu.arch.isBpf() and self.os.tag == .freestanding;
     }
 
-    pub fn isGnuLibC_os_tag_abi(os_tag: Os.Tag, abi: Abi) bool {
+    pub inline fn isGnuLibC_os_tag_abi(os_tag: Os.Tag, abi: Abi) bool {
         return os_tag == .linux and abi.isGnu();
     }
 
-    pub fn isGnuLibC(self: Target) bool {
+    pub inline fn isGnuLibC(self: Target) bool {
         return isGnuLibC_os_tag_abi(self.os.tag, self.abi);
     }
 
-    pub fn supportsNewStackCall(self: Target) bool {
+    pub inline fn supportsNewStackCall(self: Target) bool {
         return !self.cpu.arch.isWasm();
     }
 
-    pub fn isSpirV(self: Target) bool {
+    pub inline fn isSpirV(self: Target) bool {
         return self.cpu.arch.isSpirV();
     }
 
@@ -1472,11 +1472,11 @@ pub const Target = struct {
         soft_fp,
     };
 
-    pub fn getFloatAbi(self: Target) FloatAbi {
+    pub inline fn getFloatAbi(self: Target) FloatAbi {
         return self.abi.floatAbi();
     }
 
-    pub fn hasDynamicLinker(self: Target) bool {
+    pub inline fn hasDynamicLinker(self: Target) bool {
         if (self.cpu.arch.isWasm()) {
             return false;
         }
@@ -1832,7 +1832,7 @@ pub const Target = struct {
         };
     }
 
-    pub fn ptrBitWidth(target: Target) u16 {
+    pub inline fn ptrBitWidth(target: Target) u16 {
         switch (target.abi) {
             .gnux32, .muslx32, .gnuabin32, .gnuilp32 => return 32,
             .gnuabi64 => return 64,
@@ -1909,7 +1909,7 @@ pub const Target = struct {
         }
     }
 
-    pub fn stackAlignment(target: Target) u16 {
+    pub inline fn stackAlignment(target: Target) u16 {
         return switch (target.cpu.arch) {
             .m68k => 2,
             .amdgcn => 4,
@@ -1954,7 +1954,7 @@ pub const Target = struct {
     /// Default signedness of `char` for the native C compiler for this target
     /// Note that char signedness is implementation-defined and many compilers provide
     /// an option to override the default signedness e.g. GCC's -funsigned-char / -fsigned-char
-    pub fn charSignedness(target: Target) std.builtin.Signedness {
+    pub inline fn charSignedness(target: Target) std.builtin.Signedness {
         switch (target.cpu.arch) {
             .aarch64,
             .aarch64_32,
@@ -1993,7 +1993,7 @@ pub const Target = struct {
         longdouble,
     };
 
-    pub fn c_type_byte_size(t: Target, c_type: CType) u16 {
+    pub inline fn c_type_byte_size(t: Target, c_type: CType) u16 {
         return switch (c_type) {
             .char,
             .short,
@@ -2019,7 +2019,7 @@ pub const Target = struct {
         };
     }
 
-    pub fn c_type_bit_size(target: Target, c_type: CType) u16 {
+    pub inline fn c_type_bit_size(target: Target, c_type: CType) u16 {
         switch (target.os.tag) {
             .freestanding, .other => switch (target.cpu.arch) {
                 .msp430 => switch (c_type) {
@@ -2333,7 +2333,7 @@ pub const Target = struct {
         }
     }
 
-    pub fn c_type_alignment(target: Target, c_type: CType) u16 {
+    pub inline fn c_type_alignment(target: Target, c_type: CType) u16 {
         // Overrides for unusual alignments
         switch (target.cpu.arch) {
             .avr => return 1,
@@ -2440,7 +2440,7 @@ pub const Target = struct {
         );
     }
 
-    pub fn c_type_preferred_alignment(target: Target, c_type: CType) u16 {
+    pub inline fn c_type_preferred_alignment(target: Target, c_type: CType) u16 {
         // Overrides for unusual alignments
         switch (target.cpu.arch) {
             .arm, .armeb, .thumb, .thumbeb => switch (target.os.tag) {


### PR DESCRIPTION
This was discussed in #16597. It makes sense for most of the functions in this file to be marked inline: many are simple helper functions so inlining is likely a strict win, and having the return values be comptime-known may improve userspace code in some cases by preventing it from unintentionally checking properties of the target at runtime.

This changeset is somewhat conservative: the functions marked inline are generally returning booleans or simple integers, and many are simple one-line checks.