### PR TITLE
Add ability to construct a LazyPath out of any file from a dependency package

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1896,7 +1896,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                     continue;
                 }
             },
-            .generated => {},
+            .generated, .dependency => {},
         };
 
         zig_args.appendAssumeCapacity(rpath.getPath2(b, step));


### PR DESCRIPTION
Partly closes #16643

~~This PR implements dependencyPath, and allows for fetching dependencies without a build.zig.~~

This PR adds support for non zig dependencies (dependencies without a build.zig). It adds a function ```path``` to the ```Dependency``` struct which returns a ```LazyPath``` to a path inside the dependency.

It does not currently fetch these dependencies lazily, it instead just uses the current way of fetching dependencies before running the build. Doing actual lazy fetching should probably be implemented separately together with lazy dependency fetching a zig dependencies. Right now it would require duplicating a lot of work from the existing dependency fetching.

I also created a proof of concept project based on Andrews [SDL](https://github.com/andrewrk/SDL) which downloads a tagged release of SDL from the SDL website and builds a static library: https://github.com/antlilja/zig-sdl.