### PR TITLE
cmake: Fix typo: elif → elseif

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,7 +714,7 @@ endif()
 
 if(MSVC)
   set(ZIG_HOST_TARGET_ABI "-msvc")
-elif(MINGW)
+elseif(MINGW)
   set(ZIG_HOST_TARGET_ABI "-gnu")
 else()
   set(ZIG_HOST_TARGET_ABI "")


### PR DESCRIPTION
This commit fixes CMake configuration error:

```
CMake Error at CMakeLists.txt:717 (elif):
  Unknown CMake command "elif".
```