### PR TITLE
llvm: add const addrspace cast

### DIFF
--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -9035,6 +9035,7 @@ fn castConstAssumeCapacity(self: *Builder, tag: Constant.Tag, val: Constant, ty:
             .ptrtoint => &llvm.Value.constPtrToInt,
             .inttoptr => &llvm.Value.constIntToPtr,
             .bitcast => &llvm.Value.constBitCast,
+            .addrspacecast => &llvm.Value.constAddrSpaceCast,
             else => unreachable,
         }(val.toLlvm(self), ty.toLlvm(self)));
     }


### PR DESCRIPTION
Seems that this was missed when migrating to the new builder.

This totally didnt break the example from the 0.11 release notes or anything.