### PR TITLE
std.testing.expectEqualSlices: On failure, print address for pointer types

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -394,7 +394,11 @@ fn SliceDiffer(comptime T: type) type {
                 var full_index = self.start_index + i;
                 const diff = if (i < self.actual.len) !std.meta.eql(self.actual[i], value) else true;
                 if (diff) try self.ttyconf.setColor(writer, .red);
-                try writer.print("[{}]: {any}\n", .{ full_index, value });
+                if (@typeInfo(T) == .Pointer) {
+                    try writer.print("[{}]{*}: {any}\n", .{ full_index, value, value });
+                } else {
+                    try writer.print("[{}]: {any}\n", .{ full_index, value });
+                }
                 if (diff) try self.ttyconf.setColor(writer, .reset);
             }
         }


### PR DESCRIPTION
When comparing slice elements, `std.meta.eql` is used which only compares pointer address and length to determine equality for pointer types. This previously led to confusing results where `expectEqualSlices` would appear to fail on seemingly equal slices (judging by the output of `expectEqualSlices`). For example:

```zig
try testing.expectEqualSlices(
    []const i64,
    &[_][]const i64{ &[_]i64{ 1, 2, 3 }, &[_]i64{ 5, 5, 5 } },
    &[_][]const i64{ &[_]i64{ 1, 2, 3 }, &[_]i64{ 5, 5, 5 } },
);
```

Previously, this would result in:

```
============ expected this output: =============  len: 2 (0x2)

[0]: { 1, 2, 3 }
[1]: { 5, 5, 5 }

============= instead found this: ==============  len: 2 (0x2)

[0]: { 1, 2, 3 }
[1]: { 5, 5, 5 }

================================================
```

After this commit, it will result in:

```
============ expected this output: =============  len: 2 (0x2)

[0]i64@7ff7e2773758: { 1, 2, 3 }
[1]i64@7ff7e2773770: { 5, 5, 5 }

============= instead found this: ==============  len: 2 (0x2)

[0]i64@7ff7e2773788: { 1, 2, 3 }
[1]i64@7ff7e27737a0: { 5, 5, 5 }

================================================
```