### PR TITLE
llvm: convert more things to use Builder

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -6243,7 +6243,7 @@ pub const FuncGen = struct {
         if (elem_ptr.ptrInfo(mod).flags.vector_index != .none) return base_ptr;
 
         const llvm_elem_ty = try o.lowerPtrElemTy(elem_ty);
-        return try self.wip.gep(.inbounds, llvm_elem_ty, base_ptr, if (ptr_ty.isSinglePointer(mod))
+        return self.wip.gep(.inbounds, llvm_elem_ty, base_ptr, if (ptr_ty.isSinglePointer(mod))
             // If this is a single-item pointer to an array, we need another index in the GEP.
             &.{ try o.builder.intValue(try o.lowerType(Type.usize), 0), rhs }
         else
@@ -10532,7 +10532,7 @@ pub const FuncGen = struct {
             else => unreachable,
         };
 
-        return try fg.wip.callAsm(
+        return fg.wip.callAsm(
             .none,
             try o.builder.fnType(llvm_usize, &.{ llvm_usize, llvm_usize }, .normal),
             .{ .sideeffect = true },

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9775,10 +9775,8 @@ pub const FuncGen = struct {
                         else
                             try self.wip.cast(.bitcast, non_int_val, small_int_ty, "");
                         const shift_rhs = try o.builder.intValue(int_ty, running_bits);
-                        // If the field is as large as the entire packed struct, this
-                        // zext would go from, e.g. i16 to i16. This is legal with
-                        // constZExtOrBitCast but not legal with constZExt.
-                        const extended_int_val = try self.wip.conv(.unsigned, small_int_val, int_ty, "");
+                        const extended_int_val =
+                            try self.wip.conv(.unsigned, small_int_val, int_ty, "");
                         const shifted = try self.wip.bin(.shl, extended_int_val, shift_rhs, "");
                         running_int = try self.wip.bin(.@"or", running_int, shifted, "");
                         running_bits += ty_bit_size;

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -1151,13 +1151,13 @@ pub const Attribute = union(Kind) {
                 .sret,
                 .elementtype,
                 => |ty| try writer.print(" {s}({%})", .{ @tagName(attribute), ty.fmt(data.builder) }),
-                .@"align" => |alignment| try writer.print("{}", .{alignment}),
+                .@"align" => |alignment| try writer.print("{ }", .{alignment}),
                 .dereferenceable,
                 .dereferenceable_or_null,
                 => |size| try writer.print(" {s}({d})", .{ @tagName(attribute), size }),
                 .nofpclass => |fpclass| {
                     const Int = @typeInfo(FpClass).Struct.backing_integer.?;
-                    try writer.print("{s}(", .{@tagName(attribute)});
+                    try writer.print(" {s}(", .{@tagName(attribute)});
                     var any = false;
                     var remaining: Int = @bitCast(fpclass);
                     inline for (@typeInfo(FpClass).Struct.decls) |decl| {
@@ -1175,13 +1175,13 @@ pub const Attribute = union(Kind) {
                 },
                 .alignstack => |alignment| try writer.print(
                     if (comptime std.mem.indexOfScalar(u8, fmt_str, '#') != null)
-                        "{s}={d}"
+                        " {s}={d}"
                     else
-                        "{s}({d})",
+                        " {s}({d})",
                     .{ @tagName(attribute), alignment.toByteUnits() orelse return },
                 ),
                 .allockind => |allockind| {
-                    try writer.print("{s}(\"", .{@tagName(attribute)});
+                    try writer.print(" {s}(\"", .{@tagName(attribute)});
                     var any = false;
                     inline for (@typeInfo(AllocKind).Struct.fields) |field| {
                         if (comptime std.mem.eql(u8, field.name, "_")) continue;
@@ -1196,22 +1196,22 @@ pub const Attribute = union(Kind) {
                     try writer.writeAll("\")");
                 },
                 .allocsize => |allocsize| {
-                    try writer.print("{s}({d}", .{ @tagName(attribute), allocsize.elem_size });
+                    try writer.print(" {s}({d}", .{ @tagName(attribute), allocsize.elem_size });
                     if (allocsize.num_elems != AllocSize.none)
                         try writer.print(",{d}", .{allocsize.num_elems});
                     try writer.writeByte(')');
                 },
-                .memory => |memory| try writer.print("{s}({s}, argmem: {s}, inaccessiblemem: {s})", .{
+                .memory => |memory| try writer.print(" {s}({s}, argmem: {s}, inaccessiblemem: {s})", .{
                     @tagName(attribute),
                     @tagName(memory.other),
                     @tagName(memory.argmem),
                     @tagName(memory.inaccessiblemem),
                 }),
                 .uwtable => |uwtable| if (uwtable != .none) {
-                    try writer.writeAll(@tagName(attribute));
+                    try writer.print(" {s}", .{@tagName(attribute)});
                     if (uwtable != UwTable.default) try writer.print("({s})", .{@tagName(uwtable)});
                 },
-                .vscale_range => |vscale_range| try writer.print("{s}({d},{d})", .{
+                .vscale_range => |vscale_range| try writer.print(" {s}({d},{d})", .{
                     @tagName(attribute),
                     vscale_range.min.toByteUnits().?,
                     vscale_range.max.toByteUnits() orelse 0,
@@ -1867,7 +1867,7 @@ pub const AddrSpace = enum(u24) {
         _: std.fmt.FormatOptions,
         writer: anytype,
     ) @TypeOf(writer).Error!void {
-        if (self != .default) try writer.print("{s} addrspace({d})", .{ prefix, @intFromEnum(self) });
+        if (self != .default) try writer.print("{s}addrspace({d})", .{ prefix, @intFromEnum(self) });
     }
 };
 
@@ -1908,7 +1908,7 @@ pub const Alignment = enum(u6) {
         _: std.fmt.FormatOptions,
         writer: anytype,
     ) @TypeOf(writer).Error!void {
-        try writer.print("{s} align {d}", .{ prefix, self.toByteUnits() orelse return });
+        try writer.print("{s}align {d}", .{ prefix, self.toByteUnits() orelse return });
     }
 };
 
@@ -7413,7 +7413,7 @@ pub fn printUnbuffered(
             if (variable.global.getReplacement(self) != .none) continue;
             const global = variable.global.ptrConst(self);
             try writer.print(
-                \\{} ={}{}{}{}{}{}{}{} {s} {%}{ }{,}
+                \\{} ={}{}{}{}{}{}{}{} {s} {%}{ }{, }
                 \\
             , .{
                 variable.global.fmt(self),
@@ -7612,7 +7612,7 @@ pub fn printUnbuffered(
                         => |tag| {
                             const extra =
                                 function.extraData(Function.Instruction.Alloca, instruction.data);
-                            try writer.print("  %{} = {s} {%}{,%}{,}{,}\n", .{
+                            try writer.print("  %{} = {s} {%}{,%}{, }{, }\n", .{
                                 instruction_index.name(&function).fmt(self),
                                 @tagName(tag),
                                 extra.type.fmt(self),
@@ -7840,7 +7840,7 @@ pub fn printUnbuffered(
                         => |tag| {
                             const extra =
                                 function.extraData(Function.Instruction.Load, instruction.data);
-                            try writer.print("  %{} = {s} {%}, {%}{}{}{,}\n", .{
+                            try writer.print("  %{} = {s} {%}, {%}{}{}{, }\n", .{
                                 instruction_index.name(&function).fmt(self),
                                 @tagName(tag),
                                 extra.type.fmt(self),
@@ -7908,7 +7908,7 @@ pub fn printUnbuffered(
                         => |tag| {
                             const extra =
                                 function.extraData(Function.Instruction.Store, instruction.data);
-                            try writer.print("  {s} {%}, {%}{}{}{,}\n", .{
+                            try writer.print("  {s} {%}, {%}{}{}{, }\n", .{
                                 @tagName(tag),
                                 extra.val.fmt(function_index, self),
                                 extra.ptr.fmt(function_index, self),

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -2472,12 +2472,13 @@ pub const Intrinsic = enum {
 
             const Kind = union(enum) {
                 type: Type,
-                change_scalar: struct {
+                overloaded,
+                matches: u8,
+                matches_scalar: u8,
+                matches_changed_scalar: struct {
                     index: u8,
                     scalar: Type,
                 },
-                overloaded,
-                matches: u8,
             };
         };
     };
@@ -2921,7 +2922,7 @@ pub const Intrinsic = enum {
             .ret_len = 2,
             .params = &.{
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches_changed_scalar = .{ .index = 0, .scalar = .i1 } } },
                 .{ .kind = .{ .matches = 0 } },
                 .{ .kind = .{ .matches = 0 } },
             },
@@ -2931,7 +2932,7 @@ pub const Intrinsic = enum {
             .ret_len = 2,
             .params = &.{
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches_changed_scalar = .{ .index = 0, .scalar = .i1 } } },
                 .{ .kind = .{ .matches = 0 } },
                 .{ .kind = .{ .matches = 0 } },
             },
@@ -2941,7 +2942,7 @@ pub const Intrinsic = enum {
             .ret_len = 2,
             .params = &.{
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches_changed_scalar = .{ .index = 0, .scalar = .i1 } } },
                 .{ .kind = .{ .matches = 0 } },
                 .{ .kind = .{ .matches = 0 } },
             },
@@ -2951,7 +2952,7 @@ pub const Intrinsic = enum {
             .ret_len = 2,
             .params = &.{
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches_changed_scalar = .{ .index = 0, .scalar = .i1 } } },
                 .{ .kind = .{ .matches = 0 } },
                 .{ .kind = .{ .matches = 0 } },
             },
@@ -2961,7 +2962,7 @@ pub const Intrinsic = enum {
             .ret_len = 2,
             .params = &.{
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches_changed_scalar = .{ .index = 0, .scalar = .i1 } } },
                 .{ .kind = .{ .matches = 0 } },
                 .{ .kind = .{ .matches = 0 } },
             },
@@ -2971,7 +2972,7 @@ pub const Intrinsic = enum {
             .ret_len = 2,
             .params = &.{
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches_changed_scalar = .{ .index = 0, .scalar = .i1 } } },
                 .{ .kind = .{ .matches = 0 } },
                 .{ .kind = .{ .matches = 0 } },
             },
@@ -3112,6 +3113,148 @@ pub const Intrinsic = enum {
                 .{ .kind = .{ .type = .i32 }, .attrs = &.{.immarg} },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+
+        .@"vector.reduce.add" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.fadd" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 2 } },
+                .{ .kind = .{ .matches_scalar = 2 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.mul" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.fmul" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 2 } },
+                .{ .kind = .{ .matches_scalar = 2 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.and" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.or" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.xor" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.smax" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.smin" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.umax" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.umin" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.fmax" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.fmin" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.fmaximum" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.reduce.fminimum" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .matches_scalar = 1 } },
+                .{ .kind = .overloaded },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.insert" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .overloaded },
+                .{ .kind = .{ .matches = 0 } },
+                .{ .kind = .overloaded },
+                .{ .kind = .{ .type = .i64 } },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .@"vector.extract" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .overloaded },
+                .{ .kind = .overloaded },
+                .{ .kind = .{ .type = .i64 } },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
 
         .trap = .{
@@ -7742,18 +7885,11 @@ pub fn getIntrinsic(
     for (0.., param_types, signature.params) |param_index, *param_type, signature_param| {
         switch (signature_param.kind) {
             .type => |ty| param_type.* = ty,
-            .change_scalar => |info| {
-                assert(info.index < param_index);
-                param_type.* = try param_types[info.index].changeScalar(info.scalar, self);
-            },
             .overloaded => {
                 param_type.* = overload[overload_index];
                 overload_index += 1;
             },
-            .matches => |index| {
-                assert(index < param_index);
-                param_type.* = param_types[index];
-            },
+            .matches, .matches_scalar, .matches_changed_scalar => {},
         }
         function_attributes[
             if (param_index < signature.ret_len)
@@ -7763,6 +7899,15 @@ pub fn getIntrinsic(
         ] = try attributes.get(signature_param.attrs);
     }
     assert(overload_index == overload.len);
+    for (param_types, signature.params) |*param_type, signature_param| {
+        param_type.* = switch (signature_param.kind) {
+            .type, .overloaded => continue,
+            .matches => |param_index| param_types[param_index],
+            .matches_scalar => |param_index| param_types[param_index].scalarType(self),
+            .matches_changed_scalar => |info| try param_types[info.index]
+                .changeScalar(info.scalar, self),
+        };
+    }
 
     const function_index =
         try self.addFunction(try self.fnType(switch (signature.ret_len) {

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -2462,7 +2462,8 @@ pub const Intrinsic = enum {
     @"wasm.memory.grow",
 
     const Signature = struct {
-        params: []const Parameter = &.{},
+        ret_len: u8,
+        params: []const Parameter,
         attrs: []const Attribute = &.{},
 
         const Parameter = struct {
@@ -2471,33 +2472,37 @@ pub const Intrinsic = enum {
 
             const Kind = union(enum) {
                 type: Type,
+                change_scalar: struct {
+                    index: u8,
+                    scalar: Type,
+                },
                 overloaded,
-                overloaded_tuple: u8,
                 matches: u8,
-                matches_tuple: packed struct { param: u4, field: u4 },
-                matches_with_overflow: u8,
             };
         };
     };
 
-    const signatures = std.enums.EnumArray(Intrinsic, Signature).initDefault(.{}, .{
+    const signatures = std.enums.EnumArray(Intrinsic, Signature).initDefault(.{
+        .ret_len = 0,
+        .params = &.{},
+    }, .{
         .va_start = .{
+            .ret_len = 0,
             .params = &.{
-                .{ .kind = .{ .type = .void } },
                 .{ .kind = .{ .type = .ptr } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn },
         },
         .va_end = .{
+            .ret_len = 0,
             .params = &.{
-                .{ .kind = .{ .type = .void } },
                 .{ .kind = .{ .type = .ptr } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn },
         },
         .va_copy = .{
+            .ret_len = 0,
             .params = &.{
-                .{ .kind = .{ .type = .void } },
                 .{ .kind = .{ .type = .ptr } },
                 .{ .kind = .{ .type = .ptr } },
             },
@@ -2505,6 +2510,7 @@ pub const Intrinsic = enum {
         },
 
         .returnaddress = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .{ .type = .ptr } },
                 .{ .kind = .{ .type = .i32 }, .attrs = &.{.immarg} },
@@ -2512,18 +2518,21 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .addressofreturnaddress = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .sponentry = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .frameaddress = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .type = .i32 }, .attrs = &.{.immarg} },
@@ -2531,8 +2540,8 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .prefetch = .{
+            .ret_len = 0,
             .params = &.{
-                .{ .kind = .{ .type = .void } },
                 .{ .kind = .overloaded, .attrs = &.{ .nocapture, .readonly } },
                 .{ .kind = .{ .type = .i32 }, .attrs = &.{.immarg} },
                 .{ .kind = .{ .type = .i32 }, .attrs = &.{.immarg} },
@@ -2541,6 +2550,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn, .{ .memory = Attribute.Memory.all(.readwrite) } },
         },
         .@"thread.pointer" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .{ .type = .ptr } },
             },
@@ -2548,6 +2558,7 @@ pub const Intrinsic = enum {
         },
 
         .abs = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2556,6 +2567,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .smax = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2564,6 +2576,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .smin = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2572,6 +2585,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .umax = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2580,6 +2594,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .umin = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2588,6 +2603,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .sqrt = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2595,6 +2611,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .powi = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2603,6 +2620,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .sin = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2610,6 +2628,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .cos = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2617,6 +2636,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .pow = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2625,6 +2645,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .exp = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2632,6 +2653,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .exp2 = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2639,6 +2661,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .ldexp = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2647,13 +2670,16 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .frexp = .{
+            .ret_len = 2,
             .params = &.{
-                .{ .kind = .{ .overloaded_tuple = 2 } },
-                .{ .kind = .{ .matches_tuple = .{ .param = 0, .field = 0 } } },
+                .{ .kind = .overloaded },
+                .{ .kind = .overloaded },
+                .{ .kind = .{ .matches = 0 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .log = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2661,6 +2687,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .log10 = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2668,6 +2695,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .log2 = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2675,6 +2703,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .fma = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2684,6 +2713,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .fabs = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2691,6 +2721,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .minnum = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2699,6 +2730,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .maxnum = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2707,6 +2739,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .minimum = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2715,6 +2748,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .maximum = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2723,6 +2757,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .copysign = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2731,6 +2766,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .floor = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2738,6 +2774,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .ceil = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2745,6 +2782,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .trunc = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2752,6 +2790,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .rint = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2759,6 +2798,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .nearbyint = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2766,6 +2806,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .round = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2773,6 +2814,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .roundeven = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2780,6 +2822,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .lround = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .overloaded },
@@ -2787,6 +2830,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .llround = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .overloaded },
@@ -2794,6 +2838,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .lrint = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .overloaded },
@@ -2801,6 +2846,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .llrint = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .overloaded },
@@ -2809,6 +2855,7 @@ pub const Intrinsic = enum {
         },
 
         .bitreverse = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2816,6 +2863,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .bswap = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2823,6 +2871,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .ctpop = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2830,6 +2879,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .ctlz = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2838,6 +2888,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .cttz = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2846,6 +2897,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .fshl = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2855,6 +2907,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .fshr = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2865,55 +2918,68 @@ pub const Intrinsic = enum {
         },
 
         .@"sadd.with.overflow" = .{
+            .ret_len = 2,
             .params = &.{
-                .{ .kind = .{ .matches_with_overflow = 1 } },
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .matches = 1 } },
+                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches = 0 } },
+                .{ .kind = .{ .matches = 0 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"uadd.with.overflow" = .{
+            .ret_len = 2,
             .params = &.{
-                .{ .kind = .{ .matches_with_overflow = 1 } },
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .matches = 1 } },
+                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches = 0 } },
+                .{ .kind = .{ .matches = 0 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"ssub.with.overflow" = .{
+            .ret_len = 2,
             .params = &.{
-                .{ .kind = .{ .matches_with_overflow = 1 } },
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .matches = 1 } },
+                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches = 0 } },
+                .{ .kind = .{ .matches = 0 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"usub.with.overflow" = .{
+            .ret_len = 2,
             .params = &.{
-                .{ .kind = .{ .matches_with_overflow = 1 } },
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .matches = 1 } },
+                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches = 0 } },
+                .{ .kind = .{ .matches = 0 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"smul.with.overflow" = .{
+            .ret_len = 2,
             .params = &.{
-                .{ .kind = .{ .matches_with_overflow = 1 } },
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .matches = 1 } },
+                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches = 0 } },
+                .{ .kind = .{ .matches = 0 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"umul.with.overflow" = .{
+            .ret_len = 2,
             .params = &.{
-                .{ .kind = .{ .matches_with_overflow = 1 } },
                 .{ .kind = .overloaded },
-                .{ .kind = .{ .matches = 1 } },
+                .{ .kind = .{ .change_scalar = .{ .index = 0, .scalar = .i1 } } },
+                .{ .kind = .{ .matches = 0 } },
+                .{ .kind = .{ .matches = 0 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
 
         .@"sadd.sat" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2922,6 +2988,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"uadd.sat" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2930,6 +2997,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"ssub.sat" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2938,6 +3006,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"usub.sat" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2946,6 +3015,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"sshl.sat" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2954,6 +3024,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"ushl.sat" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2963,6 +3034,7 @@ pub const Intrinsic = enum {
         },
 
         .@"smul.fix" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2972,6 +3044,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"umul.fix" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2981,6 +3054,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"smul.fix.sat" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2990,6 +3064,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"umul.fix.sat" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -2999,6 +3074,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"sdiv.fix" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -3008,6 +3084,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"udiv.fix" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -3017,6 +3094,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"sdiv.fix.sat" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -3026,6 +3104,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"udiv.fix.sat" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .matches = 0 } },
@@ -3036,62 +3115,67 @@ pub const Intrinsic = enum {
         },
 
         .trap = .{
-            .params = &.{
-                .{ .kind = .{ .type = .void } },
-            },
+            .ret_len = 0,
+            .params = &.{},
             .attrs = &.{ .cold, .noreturn, .nounwind, .{ .memory = .{ .inaccessiblemem = .write } } },
         },
         .debugtrap = .{
-            .params = &.{
-                .{ .kind = .{ .type = .void } },
-            },
+            .ret_len = 0,
+            .params = &.{},
             .attrs = &.{.nounwind},
         },
         .ubsantrap = .{
+            .ret_len = 0,
             .params = &.{
-                .{ .kind = .{ .type = .void } },
                 .{ .kind = .{ .type = .i8 }, .attrs = &.{.immarg} },
             },
             .attrs = &.{ .cold, .noreturn, .nounwind },
         },
 
         .@"amdgcn.workitem.id.x" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .{ .type = .i32 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"amdgcn.workitem.id.y" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .{ .type = .i32 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"amdgcn.workitem.id.z" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .{ .type = .i32 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"amdgcn.workgroup.id.x" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .{ .type = .i32 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"amdgcn.workgroup.id.y" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .{ .type = .i32 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"amdgcn.workgroup.id.z" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .{ .type = .i32 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"amdgcn.dispatch.ptr" = .{
+            .ret_len = 1,
             .params = &.{
                 .{
                     .kind = .{ .type = Type.ptr_amdgpu_constant },
@@ -3102,6 +3186,7 @@ pub const Intrinsic = enum {
         },
 
         .@"wasm.memory.size" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .type = .i32 } },
@@ -3109,6 +3194,7 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .@"wasm.memory.grow" = .{
+            .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },
                 .{ .kind = .{ .type = .i32 } },
@@ -7627,8 +7713,10 @@ pub fn getIntrinsic(
     const signature = Intrinsic.signatures.get(id);
     const param_types = try allocator.alloc(Type, signature.params.len);
     defer allocator.free(param_types);
-    const function_attributes =
-        try allocator.alloc(Attributes, FunctionAttributes.return_index + signature.params.len);
+    const function_attributes = try allocator.alloc(
+        Attributes,
+        FunctionAttributes.params_index + (signature.params.len - signature.ret_len),
+    );
     defer allocator.free(function_attributes);
 
     var attributes: struct {
@@ -7651,42 +7739,37 @@ pub fn getIntrinsic(
 
     var overload_index: usize = 0;
     function_attributes[FunctionAttributes.function_index] = try attributes.get(signature.attrs);
-    for (
-        param_types,
-        function_attributes[FunctionAttributes.return_index..],
-        signature.params,
-    ) |*param_type, *param_attributes, signature_param| {
+    for (0.., param_types, signature.params) |param_index, *param_type, signature_param| {
         switch (signature_param.kind) {
             .type => |ty| param_type.* = ty,
+            .change_scalar => |info| {
+                assert(info.index < param_index);
+                param_type.* = try param_types[info.index].changeScalar(info.scalar, self);
+            },
             .overloaded => {
                 param_type.* = overload[overload_index];
                 overload_index += 1;
             },
-            .overloaded_tuple => |len| {
-                const fields = try allocator.alloc(Type, len);
-                defer allocator.free(fields);
-                for (fields, overload[overload_index..][0..len]) |*field, ty| field.* = ty;
-                param_type.* = try self.structType(.normal, fields);
-                overload_index += len;
+            .matches => |index| {
+                assert(index < param_index);
+                param_type.* = param_types[index];
             },
-            .matches, .matches_tuple, .matches_with_overflow => {},
         }
-        param_attributes.* = try attributes.get(signature_param.attrs);
+        function_attributes[
+            if (param_index < signature.ret_len)
+                FunctionAttributes.return_index
+            else
+                FunctionAttributes.params_index + (param_index - signature.ret_len)
+        ] = try attributes.get(signature_param.attrs);
     }
     assert(overload_index == overload.len);
-    for (param_types, signature.params) |*param_type, signature_param| switch (signature_param.kind) {
-        .type, .overloaded, .overloaded_tuple => {},
-        .matches => |param_index| param_type.* = param_types[param_index],
-        .matches_tuple => |tuple| param_type.* =
-            param_types[tuple.param].structFields(self)[tuple.field],
-        .matches_with_overflow => |param_index| {
-            const ty = param_types[param_index];
-            param_type.* = try self.structType(.normal, &.{ ty, try ty.changeScalar(.i1, self) });
-        },
-    };
 
     const function_index =
-        try self.addFunction(try self.fnType(param_types[0], param_types[1..], .normal), name);
+        try self.addFunction(try self.fnType(switch (signature.ret_len) {
+        0 => .void,
+        1 => param_types[0],
+        else => try self.structType(.normal, param_types[0..signature.ret_len]),
+    }, param_types[signature.ret_len..], .normal), name);
     function_index.ptr(self).attributes = try self.fnAttrs(function_attributes);
     return function_index;
 }

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -115,11 +115,14 @@ pub const Context = opaque {
 };
 
 pub const Value = opaque {
-    pub const addAttributeAtIndex = ZigLLVMAddAttributeAtIndex;
-    extern fn ZigLLVMAddAttributeAtIndex(*Value, Idx: AttributeIndex, A: *Attribute) void;
+    pub const addAttributeAtIndex = LLVMAddAttributeAtIndex;
+    extern fn LLVMAddAttributeAtIndex(F: *Value, Idx: AttributeIndex, A: *Attribute) void;
 
     pub const removeEnumAttributeAtIndex = LLVMRemoveEnumAttributeAtIndex;
     extern fn LLVMRemoveEnumAttributeAtIndex(F: *Value, Idx: AttributeIndex, KindID: c_uint) void;
+
+    pub const removeStringAttributeAtIndex = LLVMRemoveStringAttributeAtIndex;
+    extern fn LLVMRemoveStringAttributeAtIndex(F: *Value, Idx: AttributeIndex, K: [*]const u8, KLen: c_uint) void;
 
     pub const getFirstBasicBlock = LLVMGetFirstBasicBlock;
     extern fn LLVMGetFirstBasicBlock(Fn: *Value) ?*BasicBlock;
@@ -342,9 +345,6 @@ pub const Value = opaque {
     pub const deleteFunction = LLVMDeleteFunction;
     extern fn LLVMDeleteFunction(Fn: *Value) void;
 
-    pub const addSretAttr = ZigLLVMAddSretAttr;
-    extern fn ZigLLVMAddSretAttr(fn_ref: *Value, type_val: *Type) void;
-
     pub const getParam = LLVMGetParam;
     extern fn LLVMGetParam(Fn: *Value, Index: c_uint) *Value;
 
@@ -368,9 +368,6 @@ pub const Value = opaque {
 
     pub const getAlignment = LLVMGetAlignment;
     extern fn LLVMGetAlignment(V: *Value) c_uint;
-
-    pub const addFunctionAttr = ZigLLVMAddFunctionAttr;
-    extern fn ZigLLVMAddFunctionAttr(Fn: *Value, attr_name: [*:0]const u8, attr_value: [*:0]const u8) void;
 
     pub const addByValAttr = ZigLLVMAddByValAttr;
     extern fn ZigLLVMAddByValAttr(Fn: *Value, ArgNo: c_uint, type: *Type) void;

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -142,8 +142,14 @@ pub const Value = opaque {
     pub const setSection = LLVMSetSection;
     extern fn LLVMSetSection(Global: *Value, Section: [*:0]const u8) void;
 
-    pub const deleteGlobal = LLVMDeleteGlobal;
-    extern fn LLVMDeleteGlobal(GlobalVar: *Value) void;
+    pub const removeGlobalValue = ZigLLVMRemoveGlobalValue;
+    extern fn ZigLLVMRemoveGlobalValue(GlobalVal: *Value) void;
+
+    pub const eraseGlobalValue = ZigLLVMEraseGlobalValue;
+    extern fn ZigLLVMEraseGlobalValue(GlobalVal: *Value) void;
+
+    pub const deleteGlobalValue = ZigLLVMDeleteGlobalValue;
+    extern fn ZigLLVMDeleteGlobalValue(GlobalVal: *Value) void;
 
     pub const setAliasee = LLVMAliasSetAliasee;
     extern fn LLVMAliasSetAliasee(Alias: *Value, Aliasee: *Value) void;
@@ -292,20 +298,14 @@ pub const Value = opaque {
     pub const setValueName = LLVMSetValueName2;
     extern fn LLVMSetValueName2(Val: *Value, Name: [*]const u8, NameLen: usize) void;
 
-    pub const getValueName = LLVMGetValueName;
-    extern fn LLVMGetValueName(Val: *Value) [*:0]const u8;
-
     pub const takeName = ZigLLVMTakeName;
     extern fn ZigLLVMTakeName(new_owner: *Value, victim: *Value) void;
-
-    pub const deleteFunction = LLVMDeleteFunction;
-    extern fn LLVMDeleteFunction(Fn: *Value) void;
 
     pub const getParam = LLVMGetParam;
     extern fn LLVMGetParam(Fn: *Value, Index: c_uint) *Value;
 
-    pub const setInitializer = LLVMSetInitializer;
-    extern fn LLVMSetInitializer(GlobalVar: *Value, ConstantVal: *Value) void;
+    pub const setInitializer = ZigLLVMSetInitializer;
+    extern fn ZigLLVMSetInitializer(GlobalVar: *Value, ConstantVal: ?*Value) void;
 
     pub const setDLLStorageClass = LLVMSetDLLStorageClass;
     extern fn LLVMSetDLLStorageClass(Global: *Value, Class: DLLStorageClass) void;
@@ -315,15 +315,6 @@ pub const Value = opaque {
 
     pub const replaceAllUsesWith = LLVMReplaceAllUsesWith;
     extern fn LLVMReplaceAllUsesWith(OldVal: *Value, NewVal: *Value) void;
-
-    pub const getLinkage = LLVMGetLinkage;
-    extern fn LLVMGetLinkage(Global: *Value) Linkage;
-
-    pub const getUnnamedAddress = LLVMGetUnnamedAddress;
-    extern fn LLVMGetUnnamedAddress(Global: *Value) Bool;
-
-    pub const getAlignment = LLVMGetAlignment;
-    extern fn LLVMGetAlignment(V: *Value) c_uint;
 
     pub const attachMetaData = ZigLLVMAttachMetaData;
     extern fn ZigLLVMAttachMetaData(GlobalVar: *Value, DIG: *DIGlobalVariableExpression) void;
@@ -423,17 +414,11 @@ pub const Module = opaque {
     pub const setModuleCodeModel = ZigLLVMSetModuleCodeModel;
     extern fn ZigLLVMSetModuleCodeModel(module: *Module, code_model: CodeModel) void;
 
-    pub const addFunction = LLVMAddFunction;
-    extern fn LLVMAddFunction(*Module, Name: [*:0]const u8, FunctionTy: *Type) *Value;
-
     pub const addFunctionInAddressSpace = ZigLLVMAddFunctionInAddressSpace;
     extern fn ZigLLVMAddFunctionInAddressSpace(*Module, Name: [*:0]const u8, FunctionTy: *Type, AddressSpace: c_uint) *Value;
 
     pub const printToString = LLVMPrintModuleToString;
     extern fn LLVMPrintModuleToString(*Module) [*:0]const u8;
-
-    pub const addGlobal = LLVMAddGlobal;
-    extern fn LLVMAddGlobal(M: *Module, Ty: *Type, Name: [*:0]const u8) *Value;
 
     pub const addGlobalInAddressSpace = LLVMAddGlobalInAddressSpace;
     extern fn LLVMAddGlobalInAddressSpace(M: *Module, Ty: *Type, Name: [*:0]const u8, AddressSpace: c_uint) *Value;
@@ -449,16 +434,6 @@ pub const Module = opaque {
         Aliasee: *Value,
         Name: [*:0]const u8,
     ) *Value;
-
-    pub const getNamedGlobalAlias = LLVMGetNamedGlobalAlias;
-    extern fn LLVMGetNamedGlobalAlias(
-        M: *Module,
-        /// Empirically, LLVM will call strlen() on `Name` and so it
-        /// must be both null terminated and also have `NameLen` set
-        /// to the size.
-        Name: [*:0]const u8,
-        NameLen: usize,
-    ) ?*Value;
 
     pub const setTarget = LLVMSetTarget;
     extern fn LLVMSetTarget(M: *Module, Triple: [*:0]const u8) void;

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -330,10 +330,7 @@ pub const Value = opaque {
     pub const fnSetSubprogram = ZigLLVMFnSetSubprogram;
     extern fn ZigLLVMFnSetSubprogram(f: *Value, subprogram: *DISubprogram) void;
 
-    pub const setValueName = LLVMSetValueName;
-    extern fn LLVMSetValueName(Val: *Value, Name: [*:0]const u8) void;
-
-    pub const setValueName2 = LLVMSetValueName2;
+    pub const setValueName = LLVMSetValueName2;
     extern fn LLVMSetValueName2(Val: *Value, Name: [*]const u8, NameLen: usize) void;
 
     pub const getValueName = LLVMGetValueName;

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -345,9 +345,6 @@ pub const Value = opaque {
     pub const addSretAttr = ZigLLVMAddSretAttr;
     extern fn ZigLLVMAddSretAttr(fn_ref: *Value, type_val: *Type) void;
 
-    pub const setCallSret = ZigLLVMSetCallSret;
-    extern fn ZigLLVMSetCallSret(Call: *Value, return_type: *Type) void;
-
     pub const getParam = LLVMGetParam;
     extern fn LLVMGetParam(Fn: *Value, Index: c_uint) *Value;
 
@@ -487,9 +484,6 @@ pub const Module = opaque {
 
     pub const getNamedFunction = LLVMGetNamedFunction;
     extern fn LLVMGetNamedFunction(*Module, Name: [*:0]const u8) ?*Value;
-
-    pub const getIntrinsicDeclaration = LLVMGetIntrinsicDeclaration;
-    extern fn LLVMGetIntrinsicDeclaration(Mod: *Module, ID: c_uint, ParamTypes: ?[*]const *Type, ParamCount: usize) *Value;
 
     pub const printToString = LLVMPrintModuleToString;
     extern fn LLVMPrintModuleToString(*Module) [*:0]const u8;
@@ -664,18 +658,6 @@ pub const Builder = opaque {
         Name: [*:0]const u8,
     ) *Value;
 
-    pub const buildCallOld = ZigLLVMBuildCall;
-    extern fn ZigLLVMBuildCall(
-        *Builder,
-        *Type,
-        Fn: *Value,
-        Args: [*]const *Value,
-        NumArgs: c_uint,
-        CC: CallConv,
-        attr: CallAttr,
-        Name: [*:0]const u8,
-    ) *Value;
-
     pub const buildRetVoid = LLVMBuildRetVoid;
     extern fn LLVMBuildRetVoid(*Builder) *Value;
 
@@ -712,12 +694,6 @@ pub const Builder = opaque {
     pub const buildNUWAdd = LLVMBuildNUWAdd;
     extern fn LLVMBuildNUWAdd(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
 
-    pub const buildSAddSat = ZigLLVMBuildSAddSat;
-    extern fn ZigLLVMBuildSAddSat(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
-
-    pub const buildUAddSat = ZigLLVMBuildUAddSat;
-    extern fn ZigLLVMBuildUAddSat(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
-
     pub const buildFSub = LLVMBuildFSub;
     extern fn LLVMBuildFSub(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
 
@@ -733,12 +709,6 @@ pub const Builder = opaque {
     pub const buildNUWSub = LLVMBuildNUWSub;
     extern fn LLVMBuildNUWSub(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
 
-    pub const buildSSubSat = ZigLLVMBuildSSubSat;
-    extern fn ZigLLVMBuildSSubSat(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
-
-    pub const buildUSubSat = ZigLLVMBuildUSubSat;
-    extern fn ZigLLVMBuildUSubSat(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
-
     pub const buildFMul = LLVMBuildFMul;
     extern fn LLVMBuildFMul(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
 
@@ -750,12 +720,6 @@ pub const Builder = opaque {
 
     pub const buildNUWMul = LLVMBuildNUWMul;
     extern fn LLVMBuildNUWMul(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
-
-    pub const buildSMulFixSat = ZigLLVMBuildSMulFixSat;
-    extern fn ZigLLVMBuildSMulFixSat(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
-
-    pub const buildUMulFixSat = ZigLLVMBuildUMulFixSat;
-    extern fn ZigLLVMBuildUMulFixSat(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
 
     pub const buildUDiv = LLVMBuildUDiv;
     extern fn LLVMBuildUDiv(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
@@ -799,20 +763,11 @@ pub const Builder = opaque {
     pub const buildNSWShl = ZigLLVMBuildNSWShl;
     extern fn ZigLLVMBuildNSWShl(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
 
-    pub const buildSShlSat = ZigLLVMBuildSShlSat;
-    extern fn ZigLLVMBuildSShlSat(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
-
-    pub const buildUShlSat = ZigLLVMBuildUShlSat;
-    extern fn ZigLLVMBuildUShlSat(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
-
     pub const buildOr = LLVMBuildOr;
     extern fn LLVMBuildOr(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
 
     pub const buildXor = LLVMBuildXor;
     extern fn LLVMBuildXor(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
-
-    pub const buildIntCast2 = LLVMBuildIntCast2;
-    extern fn LLVMBuildIntCast2(*Builder, Val: *Value, DestTy: *Type, IsSigned: Bool, Name: [*:0]const u8) *Value;
 
     pub const buildBitCast = LLVMBuildBitCast;
     extern fn LLVMBuildBitCast(*Builder, Val: *Value, DestTy: *Type, Name: [*:0]const u8) *Value;
@@ -1019,81 +974,6 @@ pub const Builder = opaque {
         Size: *Value,
         is_volatile: bool,
     ) *Value;
-
-    pub const buildMaxNum = ZigLLVMBuildMaxNum;
-    extern fn ZigLLVMBuildMaxNum(builder: *Builder, LHS: *Value, RHS: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildMinNum = ZigLLVMBuildMinNum;
-    extern fn ZigLLVMBuildMinNum(builder: *Builder, LHS: *Value, RHS: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildCeil = ZigLLVMBuildCeil;
-    extern fn ZigLLVMBuildCeil(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildCos = ZigLLVMBuildCos;
-    extern fn ZigLLVMBuildCos(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildExp = ZigLLVMBuildExp;
-    extern fn ZigLLVMBuildExp(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildExp2 = ZigLLVMBuildExp2;
-    extern fn ZigLLVMBuildExp2(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildFAbs = ZigLLVMBuildFAbs;
-    extern fn ZigLLVMBuildFAbs(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildFloor = ZigLLVMBuildFloor;
-    extern fn ZigLLVMBuildFloor(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildLog = ZigLLVMBuildLog;
-    extern fn ZigLLVMBuildLog(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildLog10 = ZigLLVMBuildLog10;
-    extern fn ZigLLVMBuildLog10(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildLog2 = ZigLLVMBuildLog2;
-    extern fn ZigLLVMBuildLog2(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildRound = ZigLLVMBuildRound;
-    extern fn ZigLLVMBuildRound(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildSin = ZigLLVMBuildSin;
-    extern fn ZigLLVMBuildSin(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildSqrt = ZigLLVMBuildSqrt;
-    extern fn ZigLLVMBuildSqrt(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildFTrunc = ZigLLVMBuildFTrunc;
-    extern fn ZigLLVMBuildFTrunc(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildBitReverse = ZigLLVMBuildBitReverse;
-    extern fn ZigLLVMBuildBitReverse(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildBSwap = ZigLLVMBuildBSwap;
-    extern fn ZigLLVMBuildBSwap(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildCTPop = ZigLLVMBuildCTPop;
-    extern fn ZigLLVMBuildCTPop(builder: *Builder, V: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildCTLZ = ZigLLVMBuildCTLZ;
-    extern fn ZigLLVMBuildCTLZ(builder: *Builder, LHS: *Value, RHS: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildCTTZ = ZigLLVMBuildCTTZ;
-    extern fn ZigLLVMBuildCTTZ(builder: *Builder, LHS: *Value, RHS: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildFMA = ZigLLVMBuildFMA;
-    extern fn ZigLLVMBuildFMA(builder: *Builder, a: *Value, b: *Value, c: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildUMax = ZigLLVMBuildUMax;
-    extern fn ZigLLVMBuildUMax(builder: *Builder, LHS: *Value, RHS: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildUMin = ZigLLVMBuildUMin;
-    extern fn ZigLLVMBuildUMin(builder: *Builder, LHS: *Value, RHS: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildSMax = ZigLLVMBuildSMax;
-    extern fn ZigLLVMBuildSMax(builder: *Builder, LHS: *Value, RHS: *Value, name: [*:0]const u8) *Value;
-
-    pub const buildSMin = ZigLLVMBuildSMin;
-    extern fn ZigLLVMBuildSMin(builder: *Builder, LHS: *Value, RHS: *Value, name: [*:0]const u8) *Value;
 
     pub const buildExactUDiv = LLVMBuildExactUDiv;
     extern fn LLVMBuildExactUDiv(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
@@ -1563,9 +1443,6 @@ extern fn ZigLLVMWriteImportLibrary(
     kill_at: bool,
 ) bool;
 
-pub const setCallElemTypeAttr = ZigLLVMSetCallElemTypeAttr;
-extern fn ZigLLVMSetCallElemTypeAttr(Call: *Value, arg_index: usize, return_type: *Type) void;
-
 pub const Linkage = enum(c_uint) {
     External,
     AvailableExternally,
@@ -1784,9 +1661,6 @@ pub const DIGlobalVariable = opaque {
 pub const DIGlobalVariableExpression = opaque {
     pub const getVariable = ZigLLVMGlobalGetVariable;
     extern fn ZigLLVMGlobalGetVariable(global_variable: *DIGlobalVariableExpression) *DIGlobalVariable;
-
-    pub const getExpression = ZigLLVMGlobalGetExpression;
-    extern fn ZigLLVMGlobalGetExpression(global_variable: *DIGlobalVariableExpression) *DIGlobalExpression;
 };
 pub const DIType = opaque {
     pub const toScope = ZigLLVMTypeToScope;

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -93,17 +93,6 @@ pub const Context = opaque {
     pub const constString = LLVMConstStringInContext;
     extern fn LLVMConstStringInContext(C: *Context, Str: [*]const u8, Length: c_uint, DontNullTerminate: Bool) *Value;
 
-    pub const constStruct = LLVMConstStructInContext;
-    extern fn LLVMConstStructInContext(
-        C: *Context,
-        ConstantVals: [*]const *Value,
-        Count: c_uint,
-        Packed: Bool,
-    ) *Value;
-
-    pub const createBasicBlock = LLVMCreateBasicBlockInContext;
-    extern fn LLVMCreateBasicBlockInContext(C: *Context, Name: [*:0]const u8) *BasicBlock;
-
     pub const appendBasicBlock = LLVMAppendBasicBlockInContext;
     extern fn LLVMAppendBasicBlockInContext(C: *Context, Fn: *Value, Name: [*:0]const u8) *BasicBlock;
 
@@ -127,9 +116,6 @@ pub const Value = opaque {
     pub const getFirstBasicBlock = LLVMGetFirstBasicBlock;
     extern fn LLVMGetFirstBasicBlock(Fn: *Value) ?*BasicBlock;
 
-    pub const appendExistingBasicBlock = LLVMAppendExistingBasicBlock;
-    extern fn LLVMAppendExistingBasicBlock(Fn: *Value, BB: *BasicBlock) void;
-
     pub const addIncoming = LLVMAddIncoming;
     extern fn LLVMAddIncoming(
         PhiNode: *Value,
@@ -137,9 +123,6 @@ pub const Value = opaque {
         IncomingBlocks: [*]const *BasicBlock,
         Count: c_uint,
     ) void;
-
-    pub const getNextInstruction = LLVMGetNextInstruction;
-    extern fn LLVMGetNextInstruction(Inst: *Value) ?*Value;
 
     pub const setGlobalConstant = LLVMSetGlobalConstant;
     extern fn LLVMSetGlobalConstant(GlobalVar: *Value, IsConstant: Bool) void;
@@ -162,29 +145,8 @@ pub const Value = opaque {
     pub const deleteGlobal = LLVMDeleteGlobal;
     extern fn LLVMDeleteGlobal(GlobalVar: *Value) void;
 
-    pub const getNextGlobalAlias = LLVMGetNextGlobalAlias;
-    extern fn LLVMGetNextGlobalAlias(GA: *Value) *Value;
-
-    pub const getAliasee = LLVMAliasGetAliasee;
-    extern fn LLVMAliasGetAliasee(Alias: *Value) *Value;
-
     pub const setAliasee = LLVMAliasSetAliasee;
     extern fn LLVMAliasSetAliasee(Alias: *Value, Aliasee: *Value) void;
-
-    pub const constZExtOrBitCast = LLVMConstZExtOrBitCast;
-    extern fn LLVMConstZExtOrBitCast(ConstantVal: *Value, ToType: *Type) *Value;
-
-    pub const constNeg = LLVMConstNeg;
-    extern fn LLVMConstNeg(ConstantVal: *Value) *Value;
-
-    pub const constNSWNeg = LLVMConstNSWNeg;
-    extern fn LLVMConstNSWNeg(ConstantVal: *Value) *Value;
-
-    pub const constNUWNeg = LLVMConstNUWNeg;
-    extern fn LLVMConstNUWNeg(ConstantVal: *Value) *Value;
-
-    pub const constNot = LLVMConstNot;
-    extern fn LLVMConstNot(ConstantVal: *Value) *Value;
 
     pub const constAdd = LLVMConstAdd;
     extern fn LLVMConstAdd(LHSConstant: *Value, RHSConstant: *Value) *Value;
@@ -309,9 +271,6 @@ pub const Value = opaque {
     pub const setVolatile = LLVMSetVolatile;
     extern fn LLVMSetVolatile(MemoryAccessInst: *Value, IsVolatile: Bool) void;
 
-    pub const setAtomicSingleThread = LLVMSetAtomicSingleThread;
-    extern fn LLVMSetAtomicSingleThread(AtomicInst: *Value, SingleThread: Bool) void;
-
     pub const setAlignment = LLVMSetAlignment;
     extern fn LLVMSetAlignment(V: *Value, Bytes: c_uint) void;
 
@@ -366,9 +325,6 @@ pub const Value = opaque {
     pub const getAlignment = LLVMGetAlignment;
     extern fn LLVMGetAlignment(V: *Value) c_uint;
 
-    pub const addByValAttr = ZigLLVMAddByValAttr;
-    extern fn ZigLLVMAddByValAttr(Fn: *Value, ArgNo: c_uint, type: *Type) void;
-
     pub const attachMetaData = ZigLLVMAttachMetaData;
     extern fn ZigLLVMAttachMetaData(GlobalVar: *Value, DIG: *DIGlobalVariableExpression) void;
 
@@ -379,9 +335,6 @@ pub const Value = opaque {
 pub const Type = opaque {
     pub const constNull = LLVMConstNull;
     extern fn LLVMConstNull(Ty: *Type) *Value;
-
-    pub const constAllOnes = LLVMConstAllOnes;
-    extern fn LLVMConstAllOnes(Ty: *Type) *Value;
 
     pub const constInt = LLVMConstInt;
     extern fn LLVMConstInt(IntTy: *Type, N: c_ulonglong, SignExtend: Bool) *Value;
@@ -476,9 +429,6 @@ pub const Module = opaque {
     pub const addFunctionInAddressSpace = ZigLLVMAddFunctionInAddressSpace;
     extern fn ZigLLVMAddFunctionInAddressSpace(*Module, Name: [*:0]const u8, FunctionTy: *Type, AddressSpace: c_uint) *Value;
 
-    pub const getNamedFunction = LLVMGetNamedFunction;
-    extern fn LLVMGetNamedFunction(*Module, Name: [*:0]const u8) ?*Value;
-
     pub const printToString = LLVMPrintModuleToString;
     extern fn LLVMPrintModuleToString(*Module) [*:0]const u8;
 
@@ -488,17 +438,8 @@ pub const Module = opaque {
     pub const addGlobalInAddressSpace = LLVMAddGlobalInAddressSpace;
     extern fn LLVMAddGlobalInAddressSpace(M: *Module, Ty: *Type, Name: [*:0]const u8, AddressSpace: c_uint) *Value;
 
-    pub const getNamedGlobal = LLVMGetNamedGlobal;
-    extern fn LLVMGetNamedGlobal(M: *Module, Name: [*:0]const u8) ?*Value;
-
     pub const dump = LLVMDumpModule;
     extern fn LLVMDumpModule(M: *Module) void;
-
-    pub const getFirstGlobalAlias = LLVMGetFirstGlobalAlias;
-    extern fn LLVMGetFirstGlobalAlias(M: *Module) *Value;
-
-    pub const getLastGlobalAlias = LLVMGetLastGlobalAlias;
-    extern fn LLVMGetLastGlobalAlias(M: *Module) *Value;
 
     pub const addAlias = LLVMAddAlias2;
     extern fn LLVMAddAlias2(
@@ -540,9 +481,6 @@ pub const Module = opaque {
     pub const writeBitcodeToFile = LLVMWriteBitcodeToFile;
     extern fn LLVMWriteBitcodeToFile(M: *Module, Path: [*:0]const u8) c_int;
 };
-
-pub const lookupIntrinsicID = LLVMLookupIntrinsicID;
-extern fn LLVMLookupIntrinsicID(Name: [*]const u8, NameLen: usize) c_uint;
 
 pub const disposeMessage = LLVMDisposeMessage;
 extern fn LLVMDisposeMessage(Message: [*:0]const u8) void;
@@ -604,12 +542,6 @@ pub const Builder = opaque {
         Instr: ?*Value,
     ) void;
 
-    pub const positionBuilderAtEnd = LLVMPositionBuilderAtEnd;
-    extern fn LLVMPositionBuilderAtEnd(Builder: *Builder, Block: *BasicBlock) void;
-
-    pub const getInsertBlock = LLVMGetInsertBlock;
-    extern fn LLVMGetInsertBlock(Builder: *Builder) *BasicBlock;
-
     pub const buildZExt = LLVMBuildZExt;
     extern fn LLVMBuildZExt(
         *Builder,
@@ -618,24 +550,8 @@ pub const Builder = opaque {
         Name: [*:0]const u8,
     ) *Value;
 
-    pub const buildZExtOrBitCast = LLVMBuildZExtOrBitCast;
-    extern fn LLVMBuildZExtOrBitCast(
-        *Builder,
-        Val: *Value,
-        DestTy: *Type,
-        Name: [*:0]const u8,
-    ) *Value;
-
     pub const buildSExt = LLVMBuildSExt;
     extern fn LLVMBuildSExt(
-        *Builder,
-        Val: *Value,
-        DestTy: *Type,
-        Name: [*:0]const u8,
-    ) *Value;
-
-    pub const buildSExtOrBitCast = LLVMBuildSExtOrBitCast;
-    extern fn LLVMBuildSExtOrBitCast(
         *Builder,
         Val: *Value,
         DestTy: *Type,
@@ -669,12 +585,6 @@ pub const Builder = opaque {
 
     pub const buildLoad = LLVMBuildLoad2;
     extern fn LLVMBuildLoad2(*Builder, Ty: *Type, PointerVal: *Value, Name: [*:0]const u8) *Value;
-
-    pub const buildNeg = LLVMBuildNeg;
-    extern fn LLVMBuildNeg(*Builder, V: *Value, Name: [*:0]const u8) *Value;
-
-    pub const buildNot = LLVMBuildNot;
-    extern fn LLVMBuildNot(*Builder, V: *Value, Name: [*:0]const u8) *Value;
 
     pub const buildFAdd = LLVMBuildFAdd;
     extern fn LLVMBuildFAdd(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -951,27 +951,6 @@ pub const Builder = opaque {
         Name: [*:0]const u8,
     ) *Value;
 
-    pub const buildMemSet = ZigLLVMBuildMemSet;
-    extern fn ZigLLVMBuildMemSet(
-        B: *Builder,
-        Ptr: *Value,
-        Val: *Value,
-        Len: *Value,
-        Align: c_uint,
-        is_volatile: bool,
-    ) *Value;
-
-    pub const buildMemCpy = ZigLLVMBuildMemCpy;
-    extern fn ZigLLVMBuildMemCpy(
-        B: *Builder,
-        Dst: *Value,
-        DstAlign: c_uint,
-        Src: *Value,
-        SrcAlign: c_uint,
-        Size: *Value,
-        is_volatile: bool,
-    ) *Value;
-
     pub const buildExactUDiv = LLVMBuildExactUDiv;
     extern fn LLVMBuildExactUDiv(*Builder, LHS: *Value, RHS: *Value, Name: [*:0]const u8) *Value;
 

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -993,39 +993,6 @@ pub const Builder = opaque {
     pub const buildShuffleVector = LLVMBuildShuffleVector;
     extern fn LLVMBuildShuffleVector(*Builder, V1: *Value, V2: *Value, Mask: *Value, Name: [*:0]const u8) *Value;
 
-    pub const buildAndReduce = ZigLLVMBuildAndReduce;
-    extern fn ZigLLVMBuildAndReduce(B: *Builder, Val: *Value) *Value;
-
-    pub const buildOrReduce = ZigLLVMBuildOrReduce;
-    extern fn ZigLLVMBuildOrReduce(B: *Builder, Val: *Value) *Value;
-
-    pub const buildXorReduce = ZigLLVMBuildXorReduce;
-    extern fn ZigLLVMBuildXorReduce(B: *Builder, Val: *Value) *Value;
-
-    pub const buildIntMaxReduce = ZigLLVMBuildIntMaxReduce;
-    extern fn ZigLLVMBuildIntMaxReduce(B: *Builder, Val: *Value, is_signed: bool) *Value;
-
-    pub const buildIntMinReduce = ZigLLVMBuildIntMinReduce;
-    extern fn ZigLLVMBuildIntMinReduce(B: *Builder, Val: *Value, is_signed: bool) *Value;
-
-    pub const buildFPMaxReduce = ZigLLVMBuildFPMaxReduce;
-    extern fn ZigLLVMBuildFPMaxReduce(B: *Builder, Val: *Value) *Value;
-
-    pub const buildFPMinReduce = ZigLLVMBuildFPMinReduce;
-    extern fn ZigLLVMBuildFPMinReduce(B: *Builder, Val: *Value) *Value;
-
-    pub const buildAddReduce = ZigLLVMBuildAddReduce;
-    extern fn ZigLLVMBuildAddReduce(B: *Builder, Val: *Value) *Value;
-
-    pub const buildMulReduce = ZigLLVMBuildMulReduce;
-    extern fn ZigLLVMBuildMulReduce(B: *Builder, Val: *Value) *Value;
-
-    pub const buildFPAddReduce = ZigLLVMBuildFPAddReduce;
-    extern fn ZigLLVMBuildFPAddReduce(B: *Builder, Acc: *Value, Val: *Value) *Value;
-
-    pub const buildFPMulReduce = ZigLLVMBuildFPMulReduce;
-    extern fn ZigLLVMBuildFPMulReduce(B: *Builder, Acc: *Value, Val: *Value) *Value;
-
     pub const setFastMath = ZigLLVMSetFastMath;
     extern fn ZigLLVMSetFastMath(B: *Builder, on_state: bool) void;
 

--- a/src/value.zig
+++ b/src/value.zig
@@ -3831,7 +3831,7 @@ pub const Value = struct {
 
     /// If the value is represented in-memory as a series of bytes that all
     /// have the same value, return that byte value, otherwise null.
-    pub fn hasRepeatedByteRepr(val: Value, ty: Type, mod: *Module) !?Value {
+    pub fn hasRepeatedByteRepr(val: Value, ty: Type, mod: *Module) !?u8 {
         const abi_size = std.math.cast(usize, ty.abiSize(mod)) orelse return null;
         assert(abi_size >= 1);
         const byte_buffer = try mod.gpa.alloc(u8, abi_size);
@@ -3852,7 +3852,7 @@ pub const Value = struct {
         for (byte_buffer[1..]) |byte| {
             if (byte != first_byte) return null;
         }
-        return try mod.intValue(Type.u8, first_byte);
+        return first_byte;
     }
 
     pub fn isGenericPoison(val: Value) bool {

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -1123,11 +1123,11 @@ void ZigLLVMTakeName(LLVMValueRef new_owner, LLVMValueRef victim) {
 }
 
 ZigLLVMDIGlobalVariable* ZigLLVMGlobalGetVariable(ZigLLVMDIGlobalVariableExpression *global_variable_expression) {
-	return reinterpret_cast<ZigLLVMDIGlobalVariable*>(reinterpret_cast<DIGlobalVariableExpression*>(global_variable_expression)->getVariable());
+    return reinterpret_cast<ZigLLVMDIGlobalVariable*>(reinterpret_cast<DIGlobalVariableExpression*>(global_variable_expression)->getVariable());
 }
 
 void ZigLLVMAttachMetaData(LLVMValueRef Val, ZigLLVMDIGlobalVariableExpression *global_variable_expression) {
-	unwrap<GlobalVariable>(Val)->addDebugInfo(reinterpret_cast<DIGlobalVariableExpression*>(global_variable_expression));
+    unwrap<GlobalVariable>(Val)->addDebugInfo(reinterpret_cast<DIGlobalVariableExpression*>(global_variable_expression));
 }
 
 static_assert((Triple::ArchType)ZigLLVM_UnknownArch == Triple::UnknownArch, "");

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -408,22 +408,6 @@ void ZigLLVMSetTailCallKind(LLVMValueRef Call, enum ZigLLVMTailCallKind TailCall
     unwrap<CallInst>(Call)->setTailCallKind(TCK);
 }
 
-LLVMValueRef ZigLLVMBuildMemCpy(LLVMBuilderRef B, LLVMValueRef Dst, unsigned DstAlign,
-        LLVMValueRef Src, unsigned SrcAlign, LLVMValueRef Size, bool isVolatile)
-{
-    CallInst *call_inst = unwrap(B)->CreateMemCpy(unwrap(Dst),
-        MaybeAlign(DstAlign), unwrap(Src), MaybeAlign(SrcAlign), unwrap(Size), isVolatile);
-    return wrap(call_inst);
-}
-
-LLVMValueRef ZigLLVMBuildMemSet(LLVMBuilderRef B, LLVMValueRef Ptr, LLVMValueRef Val, LLVMValueRef Size,
-        unsigned Align, bool isVolatile)
-{
-    CallInst *call_inst = unwrap(B)->CreateMemSet(unwrap(Ptr), unwrap(Val), unwrap(Size),
-            MaybeAlign(Align), isVolatile);
-    return wrap(call_inst);
-}
-
 void ZigLLVMFnSetSubprogram(LLVMValueRef fn, ZigLLVMDISubprogram *subprogram) {
     assert( isa<Function>(unwrap(fn)) );
     Function *unwrapped_function = reinterpret_cast<Function*>(unwrap(fn));

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -1122,6 +1122,22 @@ void ZigLLVMTakeName(LLVMValueRef new_owner, LLVMValueRef victim) {
     unwrap(new_owner)->takeName(unwrap(victim));
 }
 
+void ZigLLVMRemoveGlobalValue(LLVMValueRef GlobalVal) {
+    unwrap<GlobalValue>(GlobalVal)->removeFromParent();
+}
+
+void ZigLLVMEraseGlobalValue(LLVMValueRef GlobalVal) {
+    unwrap<GlobalValue>(GlobalVal)->eraseFromParent();
+}
+
+void ZigLLVMDeleteGlobalValue(LLVMValueRef GlobalVal) {
+    delete unwrap<GlobalVariable>(GlobalVal);
+}
+
+void ZigLLVMSetInitializer(LLVMValueRef GlobalVar, LLVMValueRef ConstantVal) {
+    unwrap<GlobalVariable>(GlobalVar)->setInitializer(ConstantVal ? unwrap<Constant>(ConstantVal) : nullptr);
+}
+
 ZigLLVMDIGlobalVariable* ZigLLVMGlobalGetVariable(ZigLLVMDIGlobalVariableExpression *global_variable_expression) {
     return reinterpret_cast<ZigLLVMDIGlobalVariable*>(reinterpret_cast<DIGlobalVariableExpression*>(global_variable_expression)->getVariable());
 }

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -1134,50 +1134,6 @@ bool ZigLLDLinkWasm(int argc, const char **argv, bool can_exit_early, bool disab
     return lld::wasm::link(args, llvm::outs(), llvm::errs(), can_exit_early, disable_output);
 }
 
-LLVMValueRef ZigLLVMBuildAndReduce(LLVMBuilderRef B, LLVMValueRef Val) {
-    return wrap(unwrap(B)->CreateAndReduce(unwrap(Val)));
-}
-
-LLVMValueRef ZigLLVMBuildOrReduce(LLVMBuilderRef B, LLVMValueRef Val) {
-    return wrap(unwrap(B)->CreateOrReduce(unwrap(Val)));
-}
-
-LLVMValueRef ZigLLVMBuildXorReduce(LLVMBuilderRef B, LLVMValueRef Val) {
-    return wrap(unwrap(B)->CreateXorReduce(unwrap(Val)));
-}
-
-LLVMValueRef ZigLLVMBuildIntMaxReduce(LLVMBuilderRef B, LLVMValueRef Val, bool is_signed) {
-    return wrap(unwrap(B)->CreateIntMaxReduce(unwrap(Val), is_signed));
-}
-
-LLVMValueRef ZigLLVMBuildIntMinReduce(LLVMBuilderRef B, LLVMValueRef Val, bool is_signed) {
-    return wrap(unwrap(B)->CreateIntMinReduce(unwrap(Val), is_signed));
-}
-
-LLVMValueRef ZigLLVMBuildFPMaxReduce(LLVMBuilderRef B, LLVMValueRef Val) {
-    return wrap(unwrap(B)->CreateFPMaxReduce(unwrap(Val)));
-}
-
-LLVMValueRef ZigLLVMBuildFPMinReduce(LLVMBuilderRef B, LLVMValueRef Val) {
-    return wrap(unwrap(B)->CreateFPMinReduce(unwrap(Val)));
-}
-
-LLVMValueRef ZigLLVMBuildAddReduce(LLVMBuilderRef B, LLVMValueRef Val) {
-    return wrap(unwrap(B)->CreateAddReduce(unwrap(Val)));
-}
-
-LLVMValueRef ZigLLVMBuildMulReduce(LLVMBuilderRef B, LLVMValueRef Val) {
-    return wrap(unwrap(B)->CreateMulReduce(unwrap(Val)));
-}
-
-LLVMValueRef ZigLLVMBuildFPAddReduce(LLVMBuilderRef B, LLVMValueRef Acc, LLVMValueRef Val) {
-    return wrap(unwrap(B)->CreateFAddReduce(unwrap(Acc), unwrap(Val)));
-}
-
-LLVMValueRef ZigLLVMBuildFPMulReduce(LLVMBuilderRef B, LLVMValueRef Acc, LLVMValueRef Val) {
-    return wrap(unwrap(B)->CreateFMulReduce(unwrap(Acc), unwrap(Val)));
-}
-
 void ZigLLVMTakeName(LLVMValueRef new_owner, LLVMValueRef victim) {
     unwrap(new_owner)->takeName(unwrap(victim));
 }

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -122,15 +122,6 @@ enum ZigLLVM_CallingConv {
     ZigLLVM_MaxID = 1023,
 };
 
-enum ZigLLVM_CallAttr {
-    ZigLLVM_CallAttrAuto,
-    ZigLLVM_CallAttrNeverTail,
-    ZigLLVM_CallAttrNeverInline,
-    ZigLLVM_CallAttrAlwaysTail,
-    ZigLLVM_CallAttrAlwaysInline,
-};
-ZIG_EXTERN_C void ZigLLVMAddAttributeAtIndex(LLVMValueRef Val, unsigned Idx, LLVMAttributeRef A);
-
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMemCpy(LLVMBuilderRef B, LLVMValueRef Dst, unsigned DstAlign,
         LLVMValueRef Src, unsigned SrcAlign, LLVMValueRef Size, bool isVolatile);
 
@@ -300,11 +291,6 @@ ZIG_EXTERN_C LLVMValueRef ZigLLVMInsertDbgValueIntrinsicAtEnd(struct ZigLLVMDIBu
         struct ZigLLVMDILocation *debug_loc, LLVMBasicBlockRef basic_block_ref);
 
 ZIG_EXTERN_C void ZigLLVMSetFastMath(LLVMBuilderRef builder_wrapped, bool on_state);
-
-ZIG_EXTERN_C void ZigLLVMAddFunctionAttr(LLVMValueRef fn, const char *attr_name, const char *attr_value);
-ZIG_EXTERN_C void ZigLLVMAddByValAttr(LLVMValueRef fn_ref, unsigned ArgNo, LLVMTypeRef type_val);
-ZIG_EXTERN_C void ZigLLVMAddSretAttr(LLVMValueRef fn_ref, LLVMTypeRef type_val);
-ZIG_EXTERN_C void ZigLLVMAddFunctionAttrCold(LLVMValueRef fn);
 
 ZIG_EXTERN_C void ZigLLVMParseCommandLineOptions(size_t argc, const char *const *argv);
 

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -122,12 +122,6 @@ enum ZigLLVM_CallingConv {
     ZigLLVM_MaxID = 1023,
 };
 
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMemCpy(LLVMBuilderRef B, LLVMValueRef Dst, unsigned DstAlign,
-        LLVMValueRef Src, unsigned SrcAlign, LLVMValueRef Size, bool isVolatile);
-
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMemSet(LLVMBuilderRef B, LLVMValueRef Ptr, LLVMValueRef Val, LLVMValueRef Size,
-        unsigned Align, bool isVolatile);
-
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildNSWShl(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS,
         const char *name);
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildNUWShl(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS,

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -497,18 +497,6 @@ enum ZigLLVM_ObjectFormatType {
     ZigLLVM_XCOFF,
 };
 
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildAndReduce(LLVMBuilderRef B, LLVMValueRef Val);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildOrReduce(LLVMBuilderRef B, LLVMValueRef Val);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildXorReduce(LLVMBuilderRef B, LLVMValueRef Val);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildIntMaxReduce(LLVMBuilderRef B, LLVMValueRef Val, bool is_signed);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildIntMinReduce(LLVMBuilderRef B, LLVMValueRef Val, bool is_signed);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildFPMaxReduce(LLVMBuilderRef B, LLVMValueRef Val);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildFPMinReduce(LLVMBuilderRef B, LLVMValueRef Val);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildAddReduce(LLVMBuilderRef B, LLVMValueRef Val);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMulReduce(LLVMBuilderRef B, LLVMValueRef Val);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildFPAddReduce(LLVMBuilderRef B, LLVMValueRef Acc, LLVMValueRef Val);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildFPMulReduce(LLVMBuilderRef B, LLVMValueRef Acc, LLVMValueRef Val);
-
 ZIG_EXTERN_C void ZigLLVMTakeName(LLVMValueRef new_owner, LLVMValueRef victim);
 
 #define ZigLLVM_DIFlags_Zero 0U

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -43,13 +43,6 @@ struct ZigLLVMInsertionPoint;
 struct ZigLLVMDINode;
 struct ZigLLVMMDString;
 
-ZIG_EXTERN_C void ZigLLVMInitializeLoopStrengthReducePass(LLVMPassRegistryRef R);
-ZIG_EXTERN_C void ZigLLVMInitializeLowerIntrinsicsPass(LLVMPassRegistryRef R);
-
-/// Caller must free memory with LLVMDisposeMessage
-ZIG_EXTERN_C char *ZigLLVMGetHostCPUName(void);
-ZIG_EXTERN_C char *ZigLLVMGetNativeFeatures(void);
-
 ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef module_ref,
         char **error_message, bool is_debug,
         bool is_small, bool time_report, bool tsan, bool lto,
@@ -67,12 +60,19 @@ ZIG_EXTERN_C LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, co
     const char *CPU, const char *Features, LLVMCodeGenOptLevel Level, LLVMRelocMode Reloc,
     LLVMCodeModel CodeModel, bool function_sections, enum ZigLLVMABIType float_abi, const char *abi_name);
 
-ZIG_EXTERN_C LLVMTypeRef ZigLLVMTokenTypeInContext(LLVMContextRef context_ref);
-
 ZIG_EXTERN_C void ZigLLVMSetOptBisectLimit(LLVMContextRef context_ref, int limit);
 
 ZIG_EXTERN_C LLVMValueRef ZigLLVMAddFunctionInAddressSpace(LLVMModuleRef M, const char *Name,
         LLVMTypeRef FunctionTy, unsigned AddressSpace);
+
+enum ZigLLVMTailCallKind {
+    ZigLLVMTailCallKindNone,
+    ZigLLVMTailCallKindTail,
+    ZigLLVMTailCallKindMustTail,
+    ZigLLVMTailCallKindNoTail,
+};
+
+ZIG_EXTERN_C void ZigLLVMSetTailCallKind(LLVMValueRef Call, enum ZigLLVMTailCallKind TailCallKind);
 
 enum ZigLLVM_CallingConv {
     ZigLLVM_C = 0,
@@ -129,10 +129,6 @@ enum ZigLLVM_CallAttr {
     ZigLLVM_CallAttrAlwaysTail,
     ZigLLVM_CallAttrAlwaysInline,
 };
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildCall(LLVMBuilderRef B, LLVMTypeRef function_type,
-        LLVMValueRef Fn, LLVMValueRef *Args, unsigned NumArgs, enum ZigLLVM_CallingConv CC,
-        enum ZigLLVM_CallAttr attr, const char *Name);
-
 ZIG_EXTERN_C void ZigLLVMAddAttributeAtIndex(LLVMValueRef Val, unsigned Idx, LLVMAttributeRef A);
 
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMemCpy(LLVMBuilderRef B, LLVMValueRef Dst, unsigned DstAlign,
@@ -140,47 +136,6 @@ ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMemCpy(LLVMBuilderRef B, LLVMValueRef Dst,
 
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMemSet(LLVMBuilderRef B, LLVMValueRef Ptr, LLVMValueRef Val, LLVMValueRef Size,
         unsigned Align, bool isVolatile);
-
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildCeil(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildCos(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildExp(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildExp2(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildFAbs(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildFloor(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildLog(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildLog10(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildLog2(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildRound(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildSin(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildSqrt(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildFTrunc(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildBitReverse(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildBSwap(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildCTPop(LLVMBuilderRef builder, LLVMValueRef V, const char* name);
-
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildCTLZ(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildCTTZ(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildFMA(LLVMBuilderRef builder, LLVMValueRef A, LLVMValueRef B, LLVMValueRef C, const char* name);
-
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMaxNum(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildMinNum(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildUMax(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildUMin(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildSMax(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildSMin(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildUAddSat(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildSAddSat(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildUSubSat(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildSSubSat(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildSMulFixSat(LLVMBuilderRef B, LLVMValueRef LHS, LLVMValueRef RHS, const char *name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildUMulFixSat(LLVMBuilderRef B, LLVMValueRef LHS, LLVMValueRef RHS, const char *name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildUShlSat(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildSShlSat(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS, const char* name);
-ZIG_EXTERN_C LLVMValueRef LLVMBuildVectorSplat(LLVMBuilderRef B, unsigned elem_count, LLVMValueRef V, const char *Name);
-
 
 ZIG_EXTERN_C LLVMValueRef ZigLLVMBuildNSWShl(LLVMBuilderRef builder, LLVMValueRef LHS, LLVMValueRef RHS,
         const char *name);
@@ -345,22 +300,15 @@ ZIG_EXTERN_C LLVMValueRef ZigLLVMInsertDbgValueIntrinsicAtEnd(struct ZigLLVMDIBu
         struct ZigLLVMDILocation *debug_loc, LLVMBasicBlockRef basic_block_ref);
 
 ZIG_EXTERN_C void ZigLLVMSetFastMath(LLVMBuilderRef builder_wrapped, bool on_state);
-ZIG_EXTERN_C void ZigLLVMSetTailCall(LLVMValueRef Call);
-ZIG_EXTERN_C void ZigLLVMSetCallSret(LLVMValueRef Call, LLVMTypeRef return_type);
-ZIG_EXTERN_C void ZigLLVMSetCallElemTypeAttr(LLVMValueRef Call, size_t arg_index, LLVMTypeRef return_type);
-ZIG_EXTERN_C void ZigLLVMFunctionSetPrefixData(LLVMValueRef fn, LLVMValueRef data);
-ZIG_EXTERN_C void ZigLLVMFunctionSetCallingConv(LLVMValueRef function, enum ZigLLVM_CallingConv cc);
 
 ZIG_EXTERN_C void ZigLLVMAddFunctionAttr(LLVMValueRef fn, const char *attr_name, const char *attr_value);
 ZIG_EXTERN_C void ZigLLVMAddByValAttr(LLVMValueRef fn_ref, unsigned ArgNo, LLVMTypeRef type_val);
 ZIG_EXTERN_C void ZigLLVMAddSretAttr(LLVMValueRef fn_ref, LLVMTypeRef type_val);
-ZIG_EXTERN_C void ZigLLVMAddFunctionElemTypeAttr(LLVMValueRef fn_ref, size_t arg_index, LLVMTypeRef elem_ty);
 ZIG_EXTERN_C void ZigLLVMAddFunctionAttrCold(LLVMValueRef fn);
 
 ZIG_EXTERN_C void ZigLLVMParseCommandLineOptions(size_t argc, const char *const *argv);
 
 ZIG_EXTERN_C ZigLLVMDIGlobalVariable* ZigLLVMGlobalGetVariable(ZigLLVMDIGlobalVariableExpression *global_variable_expression);
-ZIG_EXTERN_C ZigLLVMDIGlobalExpression* ZigLLVMGlobalGetExpression(ZigLLVMDIGlobalVariableExpression *global_variable_expression);
 ZIG_EXTERN_C void ZigLLVMAttachMetaData(LLVMValueRef Val, ZigLLVMDIGlobalVariableExpression *global_variable_expression);
 
 
@@ -610,11 +558,6 @@ ZIG_EXTERN_C void ZigLLVMTakeName(LLVMValueRef new_owner, LLVMValueRef victim);
 #define ZigLLVM_DIFlags_LittleEndian (1U << 28)
 #define ZigLLVM_DIFlags_AllCallsDescribed (1U << 29)
 
-ZIG_EXTERN_C const char *ZigLLVMGetArchTypeName(enum ZigLLVM_ArchType arch);
-ZIG_EXTERN_C const char *ZigLLVMGetVendorTypeName(enum ZigLLVM_VendorType vendor);
-ZIG_EXTERN_C const char *ZigLLVMGetOSTypeName(enum ZigLLVM_OSType os);
-ZIG_EXTERN_C const char *ZigLLVMGetEnvironmentTypeName(enum ZigLLVM_EnvironmentType abi);
-
 ZIG_EXTERN_C bool ZigLLDLinkCOFF(int argc, const char **argv, bool can_exit_early, bool disable_output);
 ZIG_EXTERN_C bool ZigLLDLinkELF(int argc, const char **argv, bool can_exit_early, bool disable_output);
 ZIG_EXTERN_C bool ZigLLDLinkWasm(int argc, const char **argv, bool can_exit_early, bool disable_output);
@@ -624,12 +567,5 @@ ZIG_EXTERN_C bool ZigLLVMWriteArchive(const char *archive_name, const char **fil
 
 ZIG_EXTERN_C bool ZigLLVMWriteImportLibrary(const char *def_path, const enum ZigLLVM_ArchType arch,
                                const char *output_lib_path, bool kill_at);
-
-ZIG_EXTERN_C void ZigLLVMGetNativeTarget(enum ZigLLVM_ArchType *arch_type,
-        enum ZigLLVM_VendorType *vendor_type, enum ZigLLVM_OSType *os_type, enum ZigLLVM_EnvironmentType *environ_type,
-        enum ZigLLVM_ObjectFormatType *oformat);
-
-ZIG_EXTERN_C unsigned ZigLLVMDataLayoutGetStackAlignment(LLVMTargetDataRef TD);
-ZIG_EXTERN_C unsigned ZigLLVMDataLayoutGetProgramAddressSpace(LLVMTargetDataRef TD);
 
 #endif

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -492,6 +492,10 @@ enum ZigLLVM_ObjectFormatType {
 };
 
 ZIG_EXTERN_C void ZigLLVMTakeName(LLVMValueRef new_owner, LLVMValueRef victim);
+ZIG_EXTERN_C void ZigLLVMRemoveGlobalValue(LLVMValueRef GlobalVal);
+ZIG_EXTERN_C void ZigLLVMEraseGlobalValue(LLVMValueRef GlobalVal);
+ZIG_EXTERN_C void ZigLLVMDeleteGlobalValue(LLVMValueRef GlobalVal);
+ZIG_EXTERN_C void ZigLLVMSetInitializer(LLVMValueRef GlobalVar, LLVMValueRef ConstantVal);
 
 #define ZigLLVM_DIFlags_Zero 0U
 #define ZigLLVM_DIFlags_Private 1U


### PR DESCRIPTION
 * finish converting intrinsics
 * finish converting attributes
 * finish converting instructions
 * finish converting globals
 * pass behavior tests with no dependence on the llvm api (`-fno-libllvm`)