### PR TITLE
Update std.zig.c_translation.zig to fix issue #15066

### DIFF
--- a/lib/std/zig/c_translation.zig
+++ b/lib/std/zig/c_translation.zig
@@ -384,17 +384,17 @@ pub const Macros = struct {
     }
 
     fn L_SUFFIX_ReturnType(comptime number: anytype) type {
-        switch (@TypeOf(number)) {
-            comptime_int => return @TypeOf(promoteIntLiteral(c_long, number, .decimal)),
-            comptime_float => return c_longdouble,
-            else => @compileError("Invalid value for L suffix"),
+        switch (@typeInfo(@TypeOf(number))) {
+            .Int, .ComptimeInt  => return @TypeOf(promoteIntLiteral(c_long, number, .decimal)),
+            .Float, .ComptimeFloat => return c_longdouble,
+            else => @compileError("Invalid value for L suffix: " ++ @typeName(@TypeOf(number))),
         }
     }
     pub fn L_SUFFIX(comptime number: anytype) L_SUFFIX_ReturnType(number) {
-        switch (@TypeOf(number)) {
-            comptime_int => return promoteIntLiteral(c_long, number, .decimal),
-            comptime_float => @compileError("TODO: c_longdouble initialization from comptime_float not supported"),
-            else => @compileError("Invalid value for L suffix"),
+        switch (@typeInfo(@TypeOf(number))) {
+            .Int, .ComptimeInt => return promoteIntLiteral(c_long, number, .decimal),
+            .Float, .ComptimeFloat  => @compileError("TODO: c_longdouble initialization from comptime_float not supported"),
+            else => @compileError("Invalid value for L suffix: " ++ @typeName(@TypeOf(number))),
         }
     }
 
@@ -643,4 +643,31 @@ test "CAST_OR_CALL calling" {
     try testing.expectEqual(Helper.returnsBool(-1), Macros.CAST_OR_CALL(Helper.returnsBool, @as(f32, -1)));
 
     try testing.expectEqual(Helper.identity(@as(c_uint, 100)), Macros.CAST_OR_CALL(Helper.identity, @as(c_uint, 100)));
+}
+
+
+test "Extended C casting" {
+    if (math.maxInt(c_long) > math.maxInt(c_char)) {
+        try testing.expect(@TypeOf(Macros.L_SUFFIX(math.maxInt(c_char) - 1)) == c_long);
+        try testing.expect(@TypeOf(Macros.L_SUFFIX(math.maxInt(c_char) + 1)) == c_long);
+    }
+    if (math.maxInt(c_long) > math.maxInt(c_short)) {
+        try testing.expect(@TypeOf(Macros.L_SUFFIX( math.maxInt(c_short) - 1)) == c_long);
+        try testing.expect(@TypeOf(Macros.L_SUFFIX( math.maxInt(c_short) + 1)) == c_long);
+    }
+
+    if (math.maxInt(c_long) > math.maxInt(c_ushort)) {
+        try testing.expect(@TypeOf(Macros.L_SUFFIX(math.maxInt(c_ushort) - 1)) == c_long);
+        try testing.expect(@TypeOf(Macros.L_SUFFIX(math.maxInt(c_ushort) + 1)) == c_long);
+    }
+
+    if (math.maxInt(c_long) > math.maxInt(c_int)) {
+        try testing.expect(@TypeOf(Macros.L_SUFFIX( math.maxInt(c_int) - 1)) == c_long);
+        try testing.expect(@TypeOf(Macros.L_SUFFIX( math.maxInt(c_int) + 1)) == c_long);
+    }
+    
+    if (math.maxInt(c_longlong) > math.maxInt(c_long)) {
+        try testing.expect(@TypeOf(Macros.L_SUFFIX(math.maxInt(c_long) + 1)) == c_longlong);
+        try testing.expect(@TypeOf(Macros.L_SUFFIX(math.maxInt(c_long) - 1)) == c_long);
+    }
 }


### PR DESCRIPTION
See commentary of issue #15066:
When including c-headers, values where automatically cast to c_int (as seen below) which the original Function would not accept (only comptime_int. 

pub const LONG = @import("std").zig.c_translation.Macros.L_SUFFIX; pub const X = LONG(@as(c_int, 10));

Hence the change to switch on typeinfo. Test is included at the file bottom.