### PR TITLE
Add test coverage for stage1 issues

### DIFF
--- a/test/behavior/bugs/6305.zig
+++ b/test/behavior/bugs/6305.zig
@@ -1,0 +1,10 @@
+const ListNode = struct {
+    next: ?*const @This() = null,
+};
+
+test "copy array of self-referential struct" {
+    comptime var nodes = [_]ListNode{ .{}, .{} };
+    nodes[0].next = &nodes[1];
+    const copy = nodes;
+    _ = copy;
+}

--- a/test/cases/compile_errors/comptime_dereference_slice_of_struct.zig
+++ b/test/cases/compile_errors/comptime_dereference_slice_of_struct.zig
@@ -1,0 +1,13 @@
+const MyStruct = struct { x: bool = false };
+
+comptime {
+    const x = &[_]MyStruct{ .{}, .{} };
+    const y = x[0..1] ++ &[_]MyStruct{};
+    _ = y;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :5:16: error: comptime dereference requires '[1]tmp.MyStruct' to have a well-defined layout, but it does not.


### PR DESCRIPTION
These were all bugs that caused the C++ implementation to crash or abort, but which are either valid Zig or properly handled errors in self-hosted.

I believe I captured the minimal reproductions accurately, but let me know if any of these is not the right type of test to satisfy closing the issues.