### PR TITLE
std.json: stringify enum literals

### DIFF
--- a/lib/std/json/stringify.zig
+++ b/lib/std/json/stringify.zig
@@ -178,6 +178,7 @@ pub fn writeStreamArbitraryDepth(
 ///      * If the union declares a method `pub fn jsonStringify(self: *@This(), jw: anytype) !void`, it is called to do the serialization instead of the default behavior. The given `jw` is a pointer to this `WriteStream`.
 ///  * Zig `enum` -> JSON string naming the active tag.
 ///      * If the enum declares a method `pub fn jsonStringify(self: *@This(), jw: anytype) !void`, it is called to do the serialization instead of the default behavior. The given `jw` is a pointer to this `WriteStream`.
+///  * Zig untyped enum literal -> JSON string naming the active tag.
 ///  * Zig error -> JSON string naming the error.
 ///  * Zig `*T` -> the rendering of `T`. Note there is no guard against circular-reference infinite recursion.
 ///

--- a/lib/std/json/stringify.zig
+++ b/lib/std/json/stringify.zig
@@ -452,7 +452,7 @@ pub fn WriteStream(
                         return try self.write(null);
                     }
                 },
-                .Enum => {
+                .Enum, .EnumLiteral => {
                     if (comptime std.meta.trait.hasFn("jsonStringify")(T)) {
                         return value.jsonStringify(self);
                     }

--- a/lib/std/json/stringify_test.zig
+++ b/lib/std/json/stringify_test.zig
@@ -171,6 +171,11 @@ test "stringify enums" {
     try testStringify("\"bar\"", E.bar, .{});
 }
 
+test "stringify enum literals" {
+    try testStringify("\"foo\"", .foo, .{});
+    try testStringify("\"bar\"", .bar, .{});
+}
+
 test "stringify tagged unions" {
     const T = union(enum) {
         nothing,


### PR DESCRIPTION
This improves upon #16239 and also enables stringifying raw enum literals. 