### PR TITLE
llvm: enable the backend even when not linked to llvm

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1027,7 +1027,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             return error.TargetRequiresSingleThreaded;
         }
 
-        const llvm_cpu_features: ?[*:0]const u8 = if (build_options.have_llvm and use_llvm) blk: {
+        const llvm_cpu_features: ?[*:0]const u8 = if (use_llvm) blk: {
             var buf = std.ArrayList(u8).init(arena);
             for (options.target.cpu.arch.allFeaturesList(), 0..) |feature, index_usize| {
                 const index = @as(Target.Cpu.Feature.Set.Index, @intCast(index_usize));
@@ -5182,7 +5182,7 @@ pub fn dump_argv(argv: []const []const u8) void {
 }
 
 pub fn getZigBackend(comp: Compilation) std.builtin.CompilerBackend {
-    if (build_options.have_llvm and comp.bin_file.options.use_llvm) return .stage2_llvm;
+    if (comp.bin_file.options.use_llvm) return .stage2_llvm;
     const target = comp.bin_file.options.target;
     if (target.ofmt == .c) return .stage2_c;
     return switch (target.cpu.arch) {

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -225,7 +225,7 @@ pub const min_text_capacity = padToIdeal(minimum_text_block_size);
 pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Options) !*Coff {
     assert(options.target.ofmt == .coff);
 
-    if (build_options.have_llvm and options.use_llvm) {
+    if (options.use_llvm) {
         return createEmpty(allocator, options);
     }
 
@@ -267,8 +267,7 @@ pub fn createEmpty(gpa: Allocator, options: link.Options) !*Coff {
         .data_directories = comptime mem.zeroes([coff.IMAGE_NUMBEROF_DIRECTORY_ENTRIES]coff.ImageDataDirectory),
     };
 
-    const use_llvm = build_options.have_llvm and options.use_llvm;
-    if (use_llvm) {
+    if (options.use_llvm) {
         self.llvm_object = try LlvmObject.create(gpa, options);
     }
     return self;
@@ -277,9 +276,7 @@ pub fn createEmpty(gpa: Allocator, options: link.Options) !*Coff {
 pub fn deinit(self: *Coff) void {
     const gpa = self.base.allocator;
 
-    if (build_options.have_llvm) {
-        if (self.llvm_object) |llvm_object| llvm_object.destroy(gpa);
-    }
+    if (self.llvm_object) |llvm_object| llvm_object.destroy(gpa);
 
     for (self.objects.items) |*object| {
         object.deinit(gpa);
@@ -1036,10 +1033,8 @@ pub fn updateFunc(self: *Coff, mod: *Module, func_index: InternPool.Index, air: 
     if (build_options.skip_non_native and builtin.object_format != .coff) {
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
-    if (build_options.have_llvm) {
-        if (self.llvm_object) |llvm_object| {
-            return llvm_object.updateFunc(mod, func_index, air, liveness);
-        }
+    if (self.llvm_object) |llvm_object| {
+        return llvm_object.updateFunc(mod, func_index, air, liveness);
     }
     const tracy = trace(@src());
     defer tracy.end();
@@ -1147,9 +1142,7 @@ pub fn updateDecl(
     if (build_options.skip_non_native and builtin.object_format != .coff) {
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
-    if (build_options.have_llvm) {
-        if (self.llvm_object) |llvm_object| return llvm_object.updateDecl(mod, decl_index);
-    }
+    if (self.llvm_object) |llvm_object| return llvm_object.updateDecl(mod, decl_index);
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -1390,9 +1383,7 @@ fn freeUnnamedConsts(self: *Coff, decl_index: Module.Decl.Index) void {
 }
 
 pub fn freeDecl(self: *Coff, decl_index: Module.Decl.Index) void {
-    if (build_options.have_llvm) {
-        if (self.llvm_object) |llvm_object| return llvm_object.freeDecl(decl_index);
-    }
+    if (self.llvm_object) |llvm_object| return llvm_object.freeDecl(decl_index);
 
     const mod = self.base.options.module.?;
     const decl = mod.declPtr(decl_index);
@@ -1419,7 +1410,7 @@ pub fn updateDeclExports(
 
     const ip = &mod.intern_pool;
 
-    if (build_options.have_llvm) {
+    if (self.base.options.use_llvm) {
         // Even in the case of LLVM, we need to notice certain exported symbols in order to
         // detect the default subsystem.
         for (exports) |exp| {
@@ -1448,9 +1439,9 @@ pub fn updateDeclExports(
                 }
             }
         }
-
-        if (self.llvm_object) |llvm_object| return llvm_object.updateDeclExports(mod, decl_index, exports);
     }
+
+    if (self.llvm_object) |llvm_object| return llvm_object.updateDeclExports(mod, decl_index, exports);
 
     if (self.base.options.emit == null) return;
 
@@ -1583,10 +1574,8 @@ fn resolveGlobalSymbol(self: *Coff, current: SymbolWithLoc) !void {
 
 pub fn flush(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Node) link.File.FlushError!void {
     if (self.base.options.emit == null) {
-        if (build_options.have_llvm) {
-            if (self.llvm_object) |llvm_object| {
-                return try llvm_object.flushModule(comp, prog_node);
-            }
+        if (self.llvm_object) |llvm_object| {
+            return try llvm_object.flushModule(comp, prog_node);
         }
         return;
     }
@@ -1604,10 +1593,8 @@ pub fn flushModule(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
     const tracy = trace(@src());
     defer tracy.end();
 
-    if (build_options.have_llvm) {
-        if (self.llvm_object) |llvm_object| {
-            return try llvm_object.flushModule(comp, prog_node);
-        }
+    if (self.llvm_object) |llvm_object| {
+        return try llvm_object.flushModule(comp, prog_node);
     }
 
     var sub_prog_node = prog_node.start("COFF Flush", 0);

--- a/src/link/NvPtx.zig
+++ b/src/link/NvPtx.zig
@@ -27,7 +27,6 @@ llvm_object: *LlvmObject,
 ptx_file_name: []const u8,
 
 pub fn createEmpty(gpa: Allocator, options: link.Options) !*NvPtx {
-    if (!build_options.have_llvm) return error.PtxArchNotSupported;
     if (!options.use_llvm) return error.PtxArchNotSupported;
 
     if (!options.target.cpu.arch.isNvptx()) return error.PtxArchNotSupported;
@@ -55,7 +54,6 @@ pub fn createEmpty(gpa: Allocator, options: link.Options) !*NvPtx {
 }
 
 pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Options) !*NvPtx {
-    if (!build_options.have_llvm) @panic("nvptx target requires a zig compiler with llvm enabled.");
     if (!options.use_llvm) return error.PtxArchNotSupported;
     assert(options.target.ofmt == .nvptx);
 
@@ -64,18 +62,15 @@ pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Option
 }
 
 pub fn deinit(self: *NvPtx) void {
-    if (!build_options.have_llvm) return;
     self.llvm_object.destroy(self.base.allocator);
     self.base.allocator.free(self.ptx_file_name);
 }
 
 pub fn updateFunc(self: *NvPtx, module: *Module, func_index: InternPool.Index, air: Air, liveness: Liveness) !void {
-    if (!build_options.have_llvm) return;
     try self.llvm_object.updateFunc(module, func_index, air, liveness);
 }
 
 pub fn updateDecl(self: *NvPtx, module: *Module, decl_index: Module.Decl.Index) !void {
-    if (!build_options.have_llvm) return;
     return self.llvm_object.updateDecl(module, decl_index);
 }
 
@@ -85,7 +80,6 @@ pub fn updateDeclExports(
     decl_index: Module.Decl.Index,
     exports: []const *Module.Export,
 ) !void {
-    if (!build_options.have_llvm) return;
     if (build_options.skip_non_native and builtin.object_format != .nvptx) {
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
@@ -93,7 +87,6 @@ pub fn updateDeclExports(
 }
 
 pub fn freeDecl(self: *NvPtx, decl_index: Module.Decl.Index) void {
-    if (!build_options.have_llvm) return;
     return self.llvm_object.freeDecl(decl_index);
 }
 
@@ -102,7 +95,6 @@ pub fn flush(self: *NvPtx, comp: *Compilation, prog_node: *std.Progress.Node) li
 }
 
 pub fn flushModule(self: *NvPtx, comp: *Compilation, prog_node: *std.Progress.Node) link.File.FlushError!void {
-    if (!build_options.have_llvm) return;
     if (build_options.skip_non_native) {
         @panic("Attempted to compile for architecture that was disabled by build configuration");
     }

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -360,7 +360,7 @@ pub const StringTable = struct {
 pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Options) !*Wasm {
     assert(options.target.ofmt == .wasm);
 
-    if (build_options.have_llvm and options.use_llvm and options.use_lld) {
+    if (options.use_llvm and options.use_lld) {
         return createEmpty(allocator, options);
     }
 
@@ -522,8 +522,7 @@ pub fn createEmpty(gpa: Allocator, options: link.Options) !*Wasm {
         .name = undefined,
     };
 
-    const use_llvm = build_options.have_llvm and options.use_llvm;
-    if (use_llvm) {
+    if (options.use_llvm) {
         wasm.llvm_object = try LlvmObject.create(gpa, options);
     }
     return wasm;
@@ -1273,9 +1272,7 @@ fn checkUndefinedSymbols(wasm: *const Wasm) !void {
 
 pub fn deinit(wasm: *Wasm) void {
     const gpa = wasm.base.allocator;
-    if (build_options.have_llvm) {
-        if (wasm.llvm_object) |llvm_object| llvm_object.destroy(gpa);
-    }
+    if (wasm.llvm_object) |llvm_object| llvm_object.destroy(gpa);
 
     for (wasm.func_types.items) |*func_type| {
         func_type.deinit(gpa);
@@ -1354,9 +1351,7 @@ pub fn updateFunc(wasm: *Wasm, mod: *Module, func_index: InternPool.Index, air: 
     if (build_options.skip_non_native and builtin.object_format != .wasm) {
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
-    if (build_options.have_llvm) {
-        if (wasm.llvm_object) |llvm_object| return llvm_object.updateFunc(mod, func_index, air, liveness);
-    }
+    if (wasm.llvm_object) |llvm_object| return llvm_object.updateFunc(mod, func_index, air, liveness);
 
     const tracy = trace(@src());
     defer tracy.end();
@@ -1422,9 +1417,7 @@ pub fn updateDecl(wasm: *Wasm, mod: *Module, decl_index: Module.Decl.Index) !voi
     if (build_options.skip_non_native and builtin.object_format != .wasm) {
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
-    if (build_options.have_llvm) {
-        if (wasm.llvm_object) |llvm_object| return llvm_object.updateDecl(mod, decl_index);
-    }
+    if (wasm.llvm_object) |llvm_object| return llvm_object.updateDecl(mod, decl_index);
 
     const tracy = trace(@src());
     defer tracy.end();
@@ -1708,9 +1701,7 @@ pub fn updateDeclExports(
     if (build_options.skip_non_native and builtin.object_format != .wasm) {
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
-    if (build_options.have_llvm) {
-        if (wasm.llvm_object) |llvm_object| return llvm_object.updateDeclExports(mod, decl_index, exports);
-    }
+    if (wasm.llvm_object) |llvm_object| return llvm_object.updateDeclExports(mod, decl_index, exports);
 
     if (wasm.base.options.emit == null) return;
 
@@ -1811,9 +1802,7 @@ pub fn updateDeclExports(
 }
 
 pub fn freeDecl(wasm: *Wasm, decl_index: Module.Decl.Index) void {
-    if (build_options.have_llvm) {
-        if (wasm.llvm_object) |llvm_object| return llvm_object.freeDecl(decl_index);
-    }
+    if (wasm.llvm_object) |llvm_object| return llvm_object.freeDecl(decl_index);
     const mod = wasm.base.options.module.?;
     const decl = mod.declPtr(decl_index);
     const atom_index = wasm.decls.get(decl_index).?;
@@ -3137,17 +3126,15 @@ fn resetState(wasm: *Wasm) void {
 
 pub fn flush(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) link.File.FlushError!void {
     if (wasm.base.options.emit == null) {
-        if (build_options.have_llvm) {
-            if (wasm.llvm_object) |llvm_object| {
-                return try llvm_object.flushModule(comp, prog_node);
-            }
+        if (wasm.llvm_object) |llvm_object| {
+            return try llvm_object.flushModule(comp, prog_node);
         }
         return;
     }
 
     if (build_options.have_llvm and wasm.base.options.use_lld) {
         return wasm.linkWithLLD(comp, prog_node);
-    } else if (build_options.have_llvm and wasm.base.options.use_llvm and !wasm.base.options.use_lld) {
+    } else if (wasm.base.options.use_llvm and !wasm.base.options.use_lld) {
         return wasm.linkWithZld(comp, prog_node);
     } else {
         return wasm.flushModule(comp, prog_node);
@@ -3365,10 +3352,8 @@ pub fn flushModule(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Nod
     const tracy = trace(@src());
     defer tracy.end();
 
-    if (build_options.have_llvm) {
-        if (wasm.llvm_object) |llvm_object| {
-            return try llvm_object.flushModule(comp, prog_node);
-        }
+    if (wasm.llvm_object) |llvm_object| {
+        return try llvm_object.flushModule(comp, prog_node);
     }
 
     var sub_prog_node = prog_node.start("Wasm Flush", 0);

--- a/src/type.zig
+++ b/src/type.zig
@@ -2664,10 +2664,10 @@ pub const Type = struct {
                 .int_type => false,
                 .ptr_type => |ptr_type| {
                     const child_ty = ptr_type.child.toType();
-                    if (child_ty.zigTypeTag(mod) == .Fn) {
-                        return false;
-                    } else {
-                        return child_ty.comptimeOnly(mod);
+                    switch (child_ty.zigTypeTag(mod)) {
+                        .Fn => return mod.typeToFunc(child_ty).?.is_generic,
+                        .Opaque => return false,
+                        else => return child_ty.comptimeOnly(mod),
                     }
                 },
                 .anyframe_type => |child| {
@@ -2704,7 +2704,6 @@ pub const Type = struct {
                     .c_longlong,
                     .c_ulonglong,
                     .c_longdouble,
-                    .anyopaque,
                     .bool,
                     .void,
                     .anyerror,
@@ -2723,6 +2722,7 @@ pub const Type = struct {
                     .extern_options,
                     => false,
 
+                    .anyopaque,
                     .type,
                     .comptime_int,
                     .comptime_float,
@@ -2769,7 +2769,7 @@ pub const Type = struct {
                     }
                 },
 
-                .opaque_type => false,
+                .opaque_type => true,
 
                 .enum_type => |enum_type| enum_type.tag_ty.toType().comptimeOnly(mod),
 

--- a/test/behavior/optional.zig
+++ b/test/behavior/optional.zig
@@ -498,3 +498,8 @@ test "cast slice to const slice nested in error union and optional" {
     };
     try std.testing.expectError(error.Foo, S.outer());
 }
+
+test "variable of optional of noreturn" {
+    var null_opv: ?noreturn = null;
+    try std.testing.expectEqual(@as(?noreturn, null), null_opv);
+}


### PR DESCRIPTION
With these changes, it is now possible to compile the llvm backend even without llvm linked.  There is a lot of work to make this generally useful, but it is already capable of performing `-fno-libllvm -fno-emit-bin -fstrip --verbose-llvm-ir=output.ll` without any external help.  Compiling the behavior tests to an ll file and then using llvm to finish the compilation separately produces a binary that passes all tests.