### PR TITLE
Windows: Fix `TooManyParentDirs` handling for paths that shouldn't be cwd-relative

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -961,7 +961,7 @@ fn windowsCreateProcessPathExt(
         try dir_buf.append(allocator, 0);
         defer dir_buf.shrinkRetainingCapacity(dir_path_len);
         const dir_path_z = dir_buf.items[0 .. dir_buf.items.len - 1 :0];
-        const prefixed_path = try windows.wToPrefixedFileW(dir_path_z);
+        const prefixed_path = try windows.wToPrefixedFileW(null, dir_path_z);
         break :dir fs.cwd().openDirW(prefixed_path.span().ptr, .{}, true) catch return error.FileNotFound;
     };
     defer dir.close();

--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -317,12 +317,12 @@ pub const WindowsDynLib = struct {
     dll: windows.HMODULE,
 
     pub fn open(path: []const u8) !WindowsDynLib {
-        const path_w = try windows.sliceToPrefixedFileW(path);
+        const path_w = try windows.sliceToPrefixedFileW(null, path);
         return openW(path_w.span().ptr);
     }
 
     pub fn openZ(path_c: [*:0]const u8) !WindowsDynLib {
-        const path_w = try windows.cStrToPrefixedFileW(path_c);
+        const path_w = try windows.cStrToPrefixedFileW(null, path_c);
         return openW(path_w.span().ptr);
     }
 

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -101,6 +101,27 @@ test "openDir cwd parent .." {
     defer dir.close();
 }
 
+test "openDir non-cwd parent .." {
+    if (builtin.os.tag == .wasi) return error.SkipZigTest;
+
+    var tmp = tmpDir(.{});
+    defer tmp.cleanup();
+
+    var subdir = try tmp.dir.makeOpenPath("subdir", .{});
+    defer subdir.close();
+
+    var dir = try subdir.openDir("..", .{});
+    defer dir.close();
+
+    const expected_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(expected_path);
+
+    const actual_path = try dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(actual_path);
+
+    try testing.expectEqualStrings(expected_path, actual_path);
+}
+
 test "readLinkAbsolute" {
     if (builtin.os.tag == .wasi) return error.SkipZigTest;
 

--- a/lib/std/os/windows/test.zig
+++ b/lib/std/os/windows/test.zig
@@ -28,7 +28,7 @@ fn RtlDosPathNameToNtPathName_U(path: [:0]const u16) !windows.PathSpace {
 fn testToPrefixedFileNoOracle(comptime path: []const u8, comptime expected_path: []const u8) !void {
     const path_utf16 = std.unicode.utf8ToUtf16LeStringLiteral(path);
     const expected_path_utf16 = std.unicode.utf8ToUtf16LeStringLiteral(expected_path);
-    const actual_path = try windows.wToPrefixedFileW(path_utf16);
+    const actual_path = try windows.wToPrefixedFileW(null, path_utf16);
     std.testing.expectEqualSlices(u16, expected_path_utf16, actual_path.span()) catch |e| {
         std.debug.print("got '{s}', expected '{s}'\n", .{ std.unicode.fmtUtf16le(actual_path.span()), std.unicode.fmtUtf16le(expected_path_utf16) });
         return e;
@@ -45,7 +45,7 @@ fn testToPrefixedFileWithOracle(comptime path: []const u8, comptime expected_pat
 /// Test that the Zig conversion matches the conversion that RtlDosPathNameToNtPathName_U does.
 fn testToPrefixedFileOnlyOracle(comptime path: []const u8) !void {
     const path_utf16 = std.unicode.utf8ToUtf16LeStringLiteral(path);
-    const zig_result = try windows.wToPrefixedFileW(path_utf16);
+    const zig_result = try windows.wToPrefixedFileW(null, path_utf16);
     const win32_api_result = try RtlDosPathNameToNtPathName_U(path_utf16);
     std.testing.expectEqualSlices(u16, win32_api_result.span(), zig_result.span()) catch |e| {
         std.debug.print("got '{s}', expected '{s}'\n", .{ std.unicode.fmtUtf16le(zig_result.span()), std.unicode.fmtUtf16le(win32_api_result.span()) });


### PR DESCRIPTION
Previously, a relative path like `..` would:
- Attempt to be normalized (i.e. remove . and .. without any path resolution), but would error with `TooManyParentDirs`
- This would make wToPrefixedFileW run it through `RtlGetFullPathName_U` to do the necessary path resolution, but `RtlGetFullPathName_U` always resolves relative paths relative to the CWD

Instead, when `error.TooManyParentDirs` occurs, we now look up the path of the passed in `dir` (if it's non-null) and append the relative path to it before giving it to `RtlGetFullPathName_U`. If `dir` is null, then we just give it `RtlGetFullPathName_U` directly and let it resolve it relative to the CWD.

Closes #16779

---

Before this PR, the added test would have failed with something like:

```
====== expected this output: =========
C:\Users\Ryan\Programming\Zig\zig\zig-cache\tmp\HXPJcC-cI6MVQzvg␃

======== instead found this: =========
C:\Users\Ryan\Programming\Zig␃

======================================
First difference occurs on line 1:
expected:
C:\Users\Ryan\Programming\Zig\zig\zig-cache\tmp\HXPJcC-cI6MVQzvg
                             ^ ('\x5c')
found:
C:\Users\Ryan\Programming\Zig
                             ^ (end of string)
```