### PR TITLE
Fix incorrect lib search paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ At runtime, the executable searches up the file system for the lib/ directory,
 relative to itself:
 
 * lib/
-* zig/lib/
+* lib/zig/
 * ../lib/
-* ../zig/lib/
+* ../lib/zig/
 * (and so on)
 
 In other words, you can **unpack a release of Zig anywhere**, and then begin


### PR DESCRIPTION
The README contains a typo stating 'zig/lib/' and '../zig/lib/' as the lib search paths. This should be 'lib/zig' and '../lib/zig'.