### PR TITLE
AstGen: create more `@as` with source locations

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -11359,7 +11359,10 @@ const GenZir = struct {
             parent_gz.instructions.items.len -= src - dst;
             as_scope.instructions_top = GenZir.unstacked_top;
             // as_scope now unstacked, can add new instructions to parent_gz
-            const casted_result = try parent_gz.addBin(.as, dest_type, result);
+            const casted_result = try parent_gz.addPlNode(.as_node, src_node, Zir.Inst.As{
+                .dest_type = dest_type,
+                .operand = result,
+            });
             return rvalue(parent_gz, ri, casted_result, src_node);
         } else {
             // implicitly move all as_scope instructions to parent_gz

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -78,12 +78,13 @@ pub fn extraData(code: Zir, comptime T: type, index: usize) ExtraData(T) {
     inline for (fields) |field| {
         @field(result, field.name) = switch (field.type) {
             u32 => code.extra[i],
-            Inst.Ref => @as(Inst.Ref, @enumFromInt(code.extra[i])),
-            i32 => @as(i32, @bitCast(code.extra[i])),
-            Inst.Call.Flags => @as(Inst.Call.Flags, @bitCast(code.extra[i])),
-            Inst.BuiltinCall.Flags => @as(Inst.BuiltinCall.Flags, @bitCast(code.extra[i])),
-            Inst.SwitchBlock.Bits => @as(Inst.SwitchBlock.Bits, @bitCast(code.extra[i])),
-            Inst.FuncFancy.Bits => @as(Inst.FuncFancy.Bits, @bitCast(code.extra[i])),
+            Inst.Ref => @enumFromInt(code.extra[i]),
+            i32,
+            Inst.Call.Flags,
+            Inst.BuiltinCall.Flags,
+            Inst.SwitchBlock.Bits,
+            Inst.FuncFancy.Bits,
+            => @bitCast(code.extra[i]),
             else => @compileError("bad field type"),
         };
         i += 1;
@@ -115,8 +116,7 @@ pub fn nullTerminatedString2(code: Zir, index: NullTerminatedString) [:0]const u
 }
 
 pub fn refSlice(code: Zir, start: usize, len: usize) []Inst.Ref {
-    const raw_slice = code.extra[start..][0..len];
-    return @as([]Inst.Ref, @ptrCast(raw_slice));
+    return @ptrCast(code.extra[start..][0..len]);
 }
 
 pub fn hasCompileErrors(code: Zir) bool {
@@ -3266,10 +3266,10 @@ pub const DeclIterator = struct {
         }
         it.decl_i += 1;
 
-        const flags = @as(u4, @truncate(it.cur_bit_bag));
+        const flags: u4 = @truncate(it.cur_bit_bag);
         it.cur_bit_bag >>= 4;
 
-        const sub_index = @as(u32, @intCast(it.extra_index));
+        const sub_index: u32 = @intCast(it.extra_index);
         it.extra_index += 5; // src_hash(4) + line(1)
         const name = it.zir.nullTerminatedString(it.zir.extra[it.extra_index]);
         it.extra_index += 3; // name(1) + value(1) + doc_comment(1)
@@ -3296,7 +3296,7 @@ pub fn declIterator(zir: Zir, decl_inst: u32) DeclIterator {
             const extended = datas[decl_inst].extended;
             switch (extended.opcode) {
                 .struct_decl => {
-                    const small = @as(Inst.StructDecl.Small, @bitCast(extended.small));
+                    const small: Inst.StructDecl.Small = @bitCast(extended.small);
                     var extra_index: usize = extended.operand;
                     extra_index += @intFromBool(small.has_src_node);
                     extra_index += @intFromBool(small.has_fields_len);
@@ -3319,7 +3319,7 @@ pub fn declIterator(zir: Zir, decl_inst: u32) DeclIterator {
                     return declIteratorInner(zir, extra_index, decls_len);
                 },
                 .enum_decl => {
-                    const small = @as(Inst.EnumDecl.Small, @bitCast(extended.small));
+                    const small: Inst.EnumDecl.Small = @bitCast(extended.small);
                     var extra_index: usize = extended.operand;
                     extra_index += @intFromBool(small.has_src_node);
                     extra_index += @intFromBool(small.has_tag_type);
@@ -3334,7 +3334,7 @@ pub fn declIterator(zir: Zir, decl_inst: u32) DeclIterator {
                     return declIteratorInner(zir, extra_index, decls_len);
                 },
                 .union_decl => {
-                    const small = @as(Inst.UnionDecl.Small, @bitCast(extended.small));
+                    const small: Inst.UnionDecl.Small = @bitCast(extended.small);
                     var extra_index: usize = extended.operand;
                     extra_index += @intFromBool(small.has_src_node);
                     extra_index += @intFromBool(small.has_tag_type);
@@ -3349,7 +3349,7 @@ pub fn declIterator(zir: Zir, decl_inst: u32) DeclIterator {
                     return declIteratorInner(zir, extra_index, decls_len);
                 },
                 .opaque_decl => {
-                    const small = @as(Inst.OpaqueDecl.Small, @bitCast(extended.small));
+                    const small: Inst.OpaqueDecl.Small = @bitCast(extended.small);
                     var extra_index: usize = extended.operand;
                     extra_index += @intFromBool(small.has_src_node);
                     const decls_len = if (small.has_decls_len) decls_len: {
@@ -3545,7 +3545,7 @@ fn findDeclsSwitch(
 
     const special_prong = extra.data.bits.specialProng();
     if (special_prong != .none) {
-        const body_len = @as(u31, @truncate(zir.extra[extra_index]));
+        const body_len: u31 = @truncate(zir.extra[extra_index]);
         extra_index += 1;
         const body = zir.extra[extra_index..][0..body_len];
         extra_index += body.len;
@@ -3558,7 +3558,7 @@ fn findDeclsSwitch(
         var scalar_i: usize = 0;
         while (scalar_i < scalar_cases_len) : (scalar_i += 1) {
             extra_index += 1;
-            const body_len = @as(u31, @truncate(zir.extra[extra_index]));
+            const body_len: u31 = @truncate(zir.extra[extra_index]);
             extra_index += 1;
             const body = zir.extra[extra_index..][0..body_len];
             extra_index += body_len;
@@ -3573,7 +3573,7 @@ fn findDeclsSwitch(
             extra_index += 1;
             const ranges_len = zir.extra[extra_index];
             extra_index += 1;
-            const body_len = @as(u31, @truncate(zir.extra[extra_index]));
+            const body_len: u31 = @truncate(zir.extra[extra_index]);
             extra_index += 1;
             const items = zir.refSlice(extra_index, items_len);
             extra_index += items_len;
@@ -3655,7 +3655,7 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
                     ret_ty_ref = .void_type;
                 },
                 1 => {
-                    ret_ty_ref = @as(Inst.Ref, @enumFromInt(zir.extra[extra_index]));
+                    ret_ty_ref = @enumFromInt(zir.extra[extra_index]);
                     extra_index += 1;
                 },
                 else => {
@@ -3709,7 +3709,7 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
                 ret_ty_body = zir.extra[extra_index..][0..body_len];
                 extra_index += ret_ty_body.len;
             } else if (extra.data.bits.has_ret_ty_ref) {
-                ret_ty_ref = @as(Inst.Ref, @enumFromInt(zir.extra[extra_index]));
+                ret_ty_ref = @enumFromInt(zir.extra[extra_index]);
                 extra_index += 1;
             }
 
@@ -3753,7 +3753,7 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
 pub const ref_start_index: u32 = InternPool.static_len;
 
 pub fn indexToRef(inst: Inst.Index) Inst.Ref {
-    return @as(Inst.Ref, @enumFromInt(ref_start_index + inst));
+    return @enumFromInt(ref_start_index + inst);
 }
 
 pub fn refToIndex(inst: Inst.Ref) ?Inst.Index {

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2347,8 +2347,8 @@ pub const Inst = struct {
     pub const Break = struct {
         pub const no_src_node = std.math.maxInt(i32);
 
-        block_inst: Index,
         operand_src_node: i32,
+        block_inst: Index,
     };
 
     /// Trailing:

--- a/test/cases/compile_errors/invalid_coercion_in_aggregate_literal.zig
+++ b/test/cases/compile_errors/invalid_coercion_in_aggregate_literal.zig
@@ -1,0 +1,22 @@
+export fn invalidArrayElem() u8 {
+    const array_literal = [1]u8{@as(u8, 256)};
+    return array_literal[0];
+}
+
+export fn invalidTupleElem() u8 {
+    const tuple_literal = struct { u8 }{@as(u8, 256)};
+    return tuple_literal[0];
+}
+
+export fn invalidStructField() u8 {
+    const struct_literal = struct { field: u8 }{ .field = @as(u8, 256) };
+    return struct_literal.field;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:41: error: type 'u8' cannot represent integer value '256'
+// :7:49: error: type 'u8' cannot represent integer value '256'
+// :12:67: error: type 'u8' cannot represent integer value '256'

--- a/test/cases/compile_errors/invalid_coercion_in_labeled_break.zig
+++ b/test/cases/compile_errors/invalid_coercion_in_labeled_break.zig
@@ -1,0 +1,12 @@
+export fn invalidBreak() u8 {
+    const result: u8 = label: {
+        break :label 256;
+    };
+    return result;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:22: error: type 'u8' cannot represent integer value '256'

--- a/test/cases/compile_errors/invalid_if_expr_result_location_coercion.zig
+++ b/test/cases/compile_errors/invalid_if_expr_result_location_coercion.zig
@@ -1,0 +1,32 @@
+export fn invalidRuntimeThen(cond: bool) u0 {
+    const invalid: u16 = 256;
+    const result: u8 = if (cond) invalid else 0;
+    return result;
+}
+
+export fn invalidComptimeThen() u0 {
+    const invalid: u16 = 256;
+    const result: u8 = if (true) invalid else 0;
+    return result;
+}
+
+export fn invalidRuntimeElse(cond: bool) u0 {
+    const invalid: u16 = 256;
+    const result: u8 = if (cond) 0 else invalid;
+    return result;
+}
+
+export fn invalidComptimeElse() u0 {
+    const invalid: u16 = 256;
+    const result: u8 = if (false) 0 else invalid;
+    return result;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:34: error: type 'u8' cannot represent integer value '256'
+// :9:34: error: type 'u8' cannot represent integer value '256'
+// :15:41: error: type 'u8' cannot represent integer value '256'
+// :21:42: error: type 'u8' cannot represent integer value '256'

--- a/test/cases/compile_errors/invalid_switch_expr_result_location_coercion.zig
+++ b/test/cases/compile_errors/invalid_switch_expr_result_location_coercion.zig
@@ -1,0 +1,46 @@
+const Enum = enum(u8) { first, second, _ };
+
+export fn invalidFirstProng(enum_value: Enum) u8 {
+    const result: u8 = switch (enum_value) {
+        .first => 256,
+        .second => 0,
+        else => 0,
+    };
+    return result;
+}
+
+export fn invalidSecondProng(enum_value: Enum) u8 {
+    const result: u8 = switch (enum_value) {
+        .first => 0,
+        .second => 256,
+        _ => 0,
+    };
+    return result;
+}
+
+export fn invalidElseProng(enum_value: Enum) u8 {
+    const result: u8 = switch (enum_value) {
+        .first => 0,
+        .second => 0,
+        else => 256,
+    };
+    return result;
+}
+
+export fn invalidNonExhaustiveProng(enum_value: Enum) u8 {
+    const result: u8 = switch (enum_value) {
+        .first => 0,
+        .second => 0,
+        _ => 256,
+    };
+    return result;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :5:19: error: type 'u8' cannot represent integer value '256'
+// :15:20: error: type 'u8' cannot represent integer value '256'
+// :25:17: error: type 'u8' cannot represent integer value '256'
+// :34:14: error: type 'u8' cannot represent integer value '256'


### PR DESCRIPTION
For every single creation of an `.as` instruction in `AstGen.zig`, I was able to find a corresponding error message with a horrible source location that resulted.  This PR comes close to replacing every single one with an `.as_node` instruction, and I would have gotten away with it too, if it weren't for you [meddling *break*s](https://github.com/ziglang/zig/blob/5e0107fbce8f33f84af232c3edc912a81615175f/src/Zir.zig#L2348)!

Closes #12509

## Before
```
test/cases/compile_errors/invalid_if_expr_result_location_coercion.zig:3:28: error: type 'u8' cannot represent integer value '256'
    const result: u8 = if (cond) invalid else 0;
                           ^~~~
test/cases/compile_errors/invalid_if_expr_result_location_coercion.zig:8:26: error: type 'u8' cannot represent integer value '256'
    const invalid: u16 = 256;
                         ^~~
test/cases/compile_errors/invalid_if_expr_result_location_coercion.zig:15:28: error: type 'u8' cannot represent integer value '256'
    const result: u8 = if (cond) 0 else invalid;
                           ^~~~
test/cases/compile_errors/invalid_if_expr_result_location_coercion.zig:20:26: error: type 'u8' cannot represent integer value '256'
    const invalid: u16 = 256;
                         ^~~
test/cases/compile_errors/invalid_coercion_in_aggregate_literal.zig:2:5: error: type 'u8' cannot represent integer value '256'
    const array_literal = [1]u8{@as(u8, 256)};
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test/cases/compile_errors/invalid_coercion_in_aggregate_literal.zig:7:5: error: type 'u8' cannot represent integer value '256'
    const tuple_literal = struct { u8 }{@as(u8, 256)};
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test/cases/compile_errors/invalid_coercion_in_aggregate_literal.zig:12:5: error: type 'u8' cannot represent integer value '256'
    const struct_literal = struct { field: u8 }{ .field = @as(u8, 256) };
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test/cases/compile_errors/invalid_coercion_in_labeled_break.zig:1:1: error: type 'u8' cannot represent integer value '256'
export fn invalidBreak() u8 {
^~~~~~
test/cases/compile_errors/invalid_switch_expr_result_location_coercion.zig:3:1: error: type 'u8' cannot represent integer value '256'
export fn invalidFirstProng(enum_value: Enum) u8 {
^~~~~~
test/cases/compile_errors/invalid_switch_expr_result_location_coercion.zig:12:1: error: type 'u8' cannot represent integer value '256'
export fn invalidSecondProng(enum_value: Enum) u8 {
^~~~~~
test/cases/compile_errors/invalid_switch_expr_result_location_coercion.zig:21:1: error: type 'u8' cannot represent integer value '256'
export fn invalidElseProng(enum_value: Enum) u8 {
^~~~~~
test/cases/compile_errors/invalid_switch_expr_result_location_coercion.zig:30:1: error: type 'u8' cannot represent integer value '256'
export fn invalidNonExhaustiveProng(enum_value: Enum) u8 {
^~~~~~
```
## After
```
test/cases/compile_errors/invalid_if_expr_result_location_coercion.zig:3:34: error: type 'u8' cannot represent integer value '256'
    const result: u8 = if (cond) invalid else 0;
                                 ^~~~~~~
test/cases/compile_errors/invalid_if_expr_result_location_coercion.zig:9:34: error: type 'u8' cannot represent integer value '256'
    const result: u8 = if (true) invalid else 0;
                                 ^~~~~~~
test/cases/compile_errors/invalid_if_expr_result_location_coercion.zig:15:41: error: type 'u8' cannot represent integer value '256'
    const result: u8 = if (cond) 0 else invalid;
                                        ^~~~~~~
test/cases/compile_errors/invalid_if_expr_result_location_coercion.zig:21:42: error: type 'u8' cannot represent integer value '256'
    const result: u8 = if (false) 0 else invalid;
                                         ^~~~~~~
test/cases/compile_errors/invalid_coercion_in_aggregate_literal.zig:2:41: error: type 'u8' cannot represent integer value '256'
    const array_literal = [1]u8{@as(u8, 256)};
                                        ^~~
test/cases/compile_errors/invalid_coercion_in_aggregate_literal.zig:7:49: error: type 'u8' cannot represent integer value '256'
    const tuple_literal = struct { u8 }{@as(u8, 256)};
                                                ^~~
test/cases/compile_errors/invalid_coercion_in_aggregate_literal.zig:12:67: error: type 'u8' cannot represent integer value '256'
    const struct_literal = struct { field: u8 }{ .field = @as(u8, 256) };
                                                                  ^~~
test/cases/compile_errors/invalid_coercion_in_labeled_break.zig:3:22: error: type 'u8' cannot represent integer value '256'
        break :label 256;
                     ^~~
test/cases/compile_errors/invalid_switch_expr_result_location_coercion.zig:5:19: error: type 'u8' cannot represent integer value '256'
        .first => 256,
                  ^~~
test/cases/compile_errors/invalid_switch_expr_result_location_coercion.zig:15:20: error: type 'u8' cannot represent integer value '256'
        .second => 256,
                   ^~~
test/cases/compile_errors/invalid_switch_expr_result_location_coercion.zig:25:17: error: type 'u8' cannot represent integer value '256'
        else => 256,
                ^~~
test/cases/compile_errors/invalid_switch_expr_result_location_coercion.zig:34:14: error: type 'u8' cannot represent integer value '256'
        _ => 256,
             ^~~
```