### PR TITLE
build/ObjCopy: strip debug info to a separate elf file

### DIFF
--- a/lib/std/Build/Step/ObjCopy.zig
+++ b/lib/std/Build/Step/ObjCopy.zig
@@ -17,22 +17,40 @@ pub const base_id: Step.Id = .objcopy;
 pub const RawFormat = enum {
     bin,
     hex,
+    elf,
+};
+
+pub const Strip = enum {
+    none,
+    debug,
+    debug_and_symbols,
 };
 
 step: Step,
 input_file: std.Build.LazyPath,
 basename: []const u8,
 output_file: std.Build.GeneratedFile,
+output_file_debug: ?std.Build.GeneratedFile,
 
 format: ?RawFormat,
 only_section: ?[]const u8,
 pad_to: ?u64,
+strip: Strip,
+compress_debug: bool,
 
 pub const Options = struct {
     basename: ?[]const u8 = null,
     format: ?RawFormat = null,
     only_section: ?[]const u8 = null,
     pad_to: ?u64 = null,
+
+    compress_debug: bool = false,
+    strip: Strip = .none,
+
+    /// Put the stripped out debug sections in a separate file.
+    /// note: the `basename` is baked into the elf file to specify the link to the separate debug file.
+    /// see https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
+    extract_to_separate_file: bool = false,
 };
 
 pub fn create(
@@ -51,10 +69,12 @@ pub fn create(
         .input_file = input_file,
         .basename = options.basename orelse input_file.getDisplayName(),
         .output_file = std.Build.GeneratedFile{ .step = &self.step },
-
+        .output_file_debug = if (options.strip != .none and options.extract_to_separate_file) std.Build.GeneratedFile{ .step = &self.step } else null,
         .format = options.format,
         .only_section = options.only_section,
         .pad_to = options.pad_to,
+        .strip = options.strip,
+        .compress_debug = options.compress_debug,
     };
     input_file.addStepDependencies(&self.step);
     return self;
@@ -65,6 +85,9 @@ pub const getOutputSource = getOutput;
 
 pub fn getOutput(self: *const ObjCopy) std.Build.LazyPath {
     return .{ .generated = &self.output_file };
+}
+pub fn getOutputSeparatedDebug(self: *const ObjCopy) ?std.Build.LazyPath {
+    return if (self.output_file_debug) |*file| .{ .generated = file } else null;
 }
 
 fn make(step: *Step, prog_node: *std.Progress.Node) !void {
@@ -83,6 +106,9 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     man.hash.addOptionalBytes(self.only_section);
     man.hash.addOptional(self.pad_to);
     man.hash.addOptional(self.format);
+    man.hash.add(self.compress_debug);
+    man.hash.add(self.strip);
+    man.hash.add(self.output_file_debug != null);
 
     if (try step.cacheHit(&man)) {
         // Cache hit, skip subprocess execution.
@@ -90,12 +116,18 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         self.output_file.path = try b.cache_root.join(b.allocator, &.{
             "o", &digest, self.basename,
         });
+        if (self.output_file_debug) |*file| {
+            file.path = try b.cache_root.join(b.allocator, &.{
+                "o", &digest, b.fmt("{s}.debug", .{self.basename}),
+            });
+        }
         return;
     }
 
     const digest = man.final();
-    const full_dest_path = try b.cache_root.join(b.allocator, &.{ "o", &digest, self.basename });
     const cache_path = "o" ++ fs.path.sep_str ++ digest;
+    const full_dest_path = try b.cache_root.join(b.allocator, &.{ cache_path, self.basename });
+    const full_dest_path_debug = try b.cache_root.join(b.allocator, &.{ cache_path, b.fmt("{s}.debug", .{self.basename}) });
     b.cache_root.handle.makePath(cache_path) catch |err| {
         return step.fail("unable to make path {s}: {s}", .{ cache_path, @errorName(err) });
     };
@@ -106,13 +138,25 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     if (self.only_section) |only_section| {
         try argv.appendSlice(&.{ "-j", only_section });
     }
+    switch (self.strip) {
+        .none => {},
+        .debug => try argv.appendSlice(&.{"--strip-debug"}),
+        .debug_and_symbols => try argv.appendSlice(&.{"--strip-all"}),
+    }
     if (self.pad_to) |pad_to| {
         try argv.appendSlice(&.{ "--pad-to", b.fmt("{d}", .{pad_to}) });
     }
     if (self.format) |format| switch (format) {
         .bin => try argv.appendSlice(&.{ "-O", "binary" }),
         .hex => try argv.appendSlice(&.{ "-O", "hex" }),
+        .elf => try argv.appendSlice(&.{ "-O", "elf" }),
     };
+    if (self.compress_debug) {
+        try argv.appendSlice(&.{"--compress-debug-sections"});
+    }
+    if (self.output_file_debug != null) {
+        try argv.appendSlice(&.{b.fmt("--extract-to={s}", .{full_dest_path_debug})});
+    }
 
     try argv.appendSlice(&.{ full_src_path, full_dest_path });
 
@@ -120,5 +164,6 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     _ = try step.evalZigProcess(argv.items, prog_node);
 
     self.output_file.path = full_dest_path;
+    if (self.output_file_debug) |*file| file.path = full_dest_path_debug;
     try man.writeManifest();
 }


### PR DESCRIPTION
example usage:
```
    if (!strip) {
        b.installArtifact(exe);
    } else {
        const stripped_exe = b.addObjCopy(exe.getEmittedBin(), .{
            .basename = exe.out_filename, // set the name for the debuglink
            .compress_debug = true,
            .strip = .debug_and_symbols,
            .extract_to_separate_file = true,
        });
        b.getInstallStep().dependOn(&b.addInstallBinFile(stripped_exe.getOutput(), exe.out_filename).step);
        b.getInstallStep().dependOn(&b.addInstallBinFile(stripped_exe.getOutputSeparatedDebug().?, b.fmt("{s}.debug", .{exe.out_filename})).step);
    }
```