### PR TITLE
Sema: provide source location when analyzing panic handler

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -25202,7 +25202,7 @@ fn panicWithMsg(sema: *Sema, block: *Block, src: LazySrcLoc, msg_inst: Air.Inst.
     try sema.prepareSimplePanic(block);
 
     const panic_func = mod.funcInfo(mod.panic_func_index);
-    const panic_fn = try sema.analyzeDeclVal(block, .unneeded, panic_func.owner_decl);
+    const panic_fn = try sema.analyzeDeclVal(block, src, panic_func.owner_decl);
     const null_stack_trace = Air.internedToRef(mod.null_stack_trace);
 
     const opt_usize_ty = try mod.optionalType(.usize_type);
@@ -30702,7 +30702,15 @@ fn addReferencedBy(
     src: LazySrcLoc,
     decl_index: Decl.Index,
 ) !void {
-    if (sema.mod.comp.reference_trace == @as(u32, 0)) return;
+    if (sema.mod.comp.reference_trace == 0) return;
+    if (src == .unneeded) {
+        // We can't use NeededSourceLocation, since sites handling that assume it means a compile
+        // error. Our long-term strategy here is to gradually transition from NeededSourceLocation
+        // into having more LazySrcLoc tags. In the meantime, let release compilers just ignore this
+        // reference (a slightly-incomplete error is better than a crash!), but trigger a panic in
+        // debug so we can fix this case.
+        if (std.debug.runtime_safety) unreachable else return;
+    }
     try sema.mod.reference_table.put(sema.gpa, decl_index, .{
         .referencer = block.src_decl,
         .src = src,

--- a/test/cases/compile_errors/panic_has_source_location.zig
+++ b/test/cases/compile_errors/panic_has_source_location.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+
+export fn foo() void {
+    // This should appear in the reference trace
+    // (and definitely shouldn't crash due to an unneeded source location!)
+    @panic("oh no");
+}
+
+pub fn panic(_: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noreturn {
+    @compileError("panic");
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :10:5: error: panic


### PR DESCRIPTION
The panic handler decl_val was previously given a `unneeded` source location, which was then added to the reference trace, resulting in a crash if the source location was used in the reference trace. This commit makes two trivial changes:

* Don't add unneeded source locations to the ref table
* Pass a real source location when analyzing the panic handler