### PR TITLE
Maths tests resurrected (exp and log functions) with bugfixes

### DIFF
--- a/lib/compiler_rt.zig
+++ b/lib/compiler_rt.zig
@@ -236,3 +236,7 @@ comptime {
         _ = @import("compiler_rt/ssp.zig");
     }
 }
+
+test {
+    _ = @import("compiler_rt/test.zig");
+}

--- a/lib/compiler_rt/exp.zig
+++ b/lib/compiler_rt/exp.zig
@@ -230,13 +230,3 @@ test "exp64" {
     try expect(math.approxEqAbs(f64, exp(0.8923), 2.440737, epsilon));
     try expect(math.approxEqAbs(f64, exp(1.5), 4.481689, epsilon));
 }
-
-test "exp32.special" {
-    try expect(math.isPositiveInf(expf(math.inf(f32))));
-    try expect(math.isNan(expf(math.nan(f32))));
-}
-
-test "exp64.special" {
-    try expect(math.isPositiveInf(exp(math.inf(f64))));
-    try expect(math.isNan(exp(math.nan(f64))));
-}

--- a/lib/compiler_rt/exp2.zig
+++ b/lib/compiler_rt/exp2.zig
@@ -58,7 +58,7 @@ pub fn exp2f(x: f32) callconv(.C) f32 {
                 mem.doNotOptimizeAway(-0x1.0p-149 / x);
             }
             // x <= -150
-            if (u >= 0x3160000) {
+            if (u >= 0xC3160000) {
                 return 0;
             }
         }
@@ -102,7 +102,7 @@ pub fn exp2(x: f64) callconv(.C) f64 {
 
     // TODO: This should be handled beneath.
     if (math.isNan(x)) {
-        return math.nan(f64);
+        return x;
     }
 
     // |x| >= 1022 or nan
@@ -477,14 +477,4 @@ test "exp2_64" {
     try expect(math.approxEqAbs(f64, exp2(1.5), 2.828427, epsilon));
     try expect(math.approxEqAbs(f64, exp2(-1), 0.5, epsilon));
     try expect(math.approxEqAbs(f64, exp2(-0x1.a05cc754481d1p-2), 0x1.824056efc687cp-1, epsilon));
-}
-
-test "exp2_32.special" {
-    try expect(math.isPositiveInf(exp2f(math.inf(f32))));
-    try expect(math.isNan(exp2f(math.nan(f32))));
-}
-
-test "exp2_64.special" {
-    try expect(math.isPositiveInf(exp2(math.inf(f64))));
-    try expect(math.isNan(exp2(math.nan(f64))));
 }

--- a/lib/compiler_rt/log.zig
+++ b/lib/compiler_rt/log.zig
@@ -38,6 +38,11 @@ pub fn logf(x_: f32) callconv(.C) f32 {
     const Lg3: f32 = 0x91e9ee.0p-25;
     const Lg4: f32 = 0xf89e26.0p-26;
 
+    // TODO: This should be handled beneath.
+    if (math.isNan(x_)) {
+        return x_;
+    }
+
     var x = x_;
     var ix: u32 = @bitCast(x);
     var k: i32 = 0;
@@ -93,6 +98,11 @@ pub fn log(x_: f64) callconv(.C) f64 {
     const Lg6: f64 = 1.531383769920937332e-01;
     const Lg7: f64 = 1.479819860511658591e-01;
 
+    // TODO: This should be handled beneath.
+    if (math.isNan(x_)) {
+        return x_;
+    }
+
     var x = x_;
     var ix: u64 = @bitCast(x);
     var hx: u32 = @intCast(ix >> 32);
@@ -110,8 +120,8 @@ pub fn log(x_: f64) callconv(.C) f64 {
 
         // subnormal, scale x
         k -= 54;
-        x *= 0x1.0p54;
-        hx = @intCast(@as(u64, @bitCast(ix)) >> 32);
+        x *= 0x1p54;
+        hx = @intCast(@as(u64, @bitCast(x)) >> 32);
     } else if (hx >= 0x7FF00000) {
         return x;
     } else if (hx == 0x3FF00000 and ix << 32 == 0) {
@@ -159,7 +169,7 @@ pub fn logl(x: c_longdouble) callconv(.C) c_longdouble {
     }
 }
 
-test "ln32" {
+test "log32" {
     const epsilon = 0.000001;
 
     try testing.expect(math.approxEqAbs(f32, logf(0.2), -1.609438, epsilon));
@@ -170,7 +180,7 @@ test "ln32" {
     try testing.expect(math.approxEqAbs(f32, logf(123123.234375), 11.720941, epsilon));
 }
 
-test "ln64" {
+test "log64" {
     const epsilon = 0.000001;
 
     try testing.expect(math.approxEqAbs(f64, log(0.2), -1.609438, epsilon));
@@ -179,18 +189,4 @@ test "ln64" {
     try testing.expect(math.approxEqAbs(f64, log(37.45), 3.623007, epsilon));
     try testing.expect(math.approxEqAbs(f64, log(89.123), 4.490017, epsilon));
     try testing.expect(math.approxEqAbs(f64, log(123123.234375), 11.720941, epsilon));
-}
-
-test "ln32.special" {
-    try testing.expect(math.isPositiveInf(logf(math.inf(f32))));
-    try testing.expect(math.isNegativeInf(logf(0.0)));
-    try testing.expect(math.isNan(logf(-1.0)));
-    try testing.expect(math.isNan(logf(math.nan(f32))));
-}
-
-test "ln64.special" {
-    try testing.expect(math.isPositiveInf(log(math.inf(f64))));
-    try testing.expect(math.isNegativeInf(log(0.0)));
-    try testing.expect(math.isNan(log(-1.0)));
-    try testing.expect(math.isNan(log(math.nan(f64))));
 }

--- a/lib/compiler_rt/log10.zig
+++ b/lib/compiler_rt/log10.zig
@@ -41,6 +41,11 @@ pub fn log10f(x_: f32) callconv(.C) f32 {
     const Lg3: f32 = 0x91e9ee.0p-25;
     const Lg4: f32 = 0xf89e26.0p-26;
 
+    // TODO: This should be handled beneath.
+    if (math.isNan(x_)) {
+        return x_;
+    }
+
     var x = x_;
     var u: u32 = @bitCast(x);
     var ix = u;
@@ -103,6 +108,11 @@ pub fn log10(x_: f64) callconv(.C) f64 {
     const Lg5: f64 = 1.818357216161805012e-01;
     const Lg6: f64 = 1.531383769920937332e-01;
     const Lg7: f64 = 1.479819860511658591e-01;
+
+    // TODO: This should be handled beneath.
+    if (math.isNan(x_)) {
+        return x_;
+    }
 
     var x = x_;
     var ix: u64 = @bitCast(x);
@@ -207,18 +217,4 @@ test "log10_64" {
     try testing.expect(math.approxEqAbs(f64, log10(37.45), 1.573452, epsilon));
     try testing.expect(math.approxEqAbs(f64, log10(89.123), 1.94999, epsilon));
     try testing.expect(math.approxEqAbs(f64, log10(123123.234375), 5.09034, epsilon));
-}
-
-test "log10_32.special" {
-    try testing.expect(math.isPositiveInf(log10f(math.inf(f32))));
-    try testing.expect(math.isNegativeInf(log10f(0.0)));
-    try testing.expect(math.isNan(log10f(-1.0)));
-    try testing.expect(math.isNan(log10f(math.nan(f32))));
-}
-
-test "log10_64.special" {
-    try testing.expect(math.isPositiveInf(log10(math.inf(f64))));
-    try testing.expect(math.isNegativeInf(log10(0.0)));
-    try testing.expect(math.isNan(log10(-1.0)));
-    try testing.expect(math.isNan(log10(math.nan(f64))));
 }

--- a/lib/compiler_rt/log2.zig
+++ b/lib/compiler_rt/log2.zig
@@ -39,6 +39,11 @@ pub fn log2f(x_: f32) callconv(.C) f32 {
     const Lg3: f32 = 0x91e9ee.0p-25;
     const Lg4: f32 = 0xf89e26.0p-26;
 
+    // TODO: This should be handled beneath.
+    if (math.isNan(x_)) {
+        return x_;
+    }
+
     var x = x_;
     var u: u32 = @bitCast(x);
     var ix = u;
@@ -97,6 +102,11 @@ pub fn log2(x_: f64) callconv(.C) f64 {
     const Lg5: f64 = 1.818357216161805012e-01;
     const Lg6: f64 = 1.531383769920937332e-01;
     const Lg7: f64 = 1.479819860511658591e-01;
+
+    // TODO: This should be handled beneath.
+    if (math.isNan(x_)) {
+        return x_;
+    }
 
     var x = x_;
     var ix: u64 = @bitCast(x);
@@ -197,18 +207,4 @@ test "log2_64" {
     try expect(math.approxEqAbs(f64, log2(1.5), 0.584962, epsilon));
     try expect(math.approxEqAbs(f64, log2(37.45), 5.226894, epsilon));
     try expect(math.approxEqAbs(f64, log2(123123.234375), 16.909744, epsilon));
-}
-
-test "log2_32.special" {
-    try expect(math.isPositiveInf(log2f(math.inf(f32))));
-    try expect(math.isNegativeInf(log2f(0.0)));
-    try expect(math.isNan(log2f(-1.0)));
-    try expect(math.isNan(log2f(math.nan(f32))));
-}
-
-test "log2_64.special" {
-    try expect(math.isPositiveInf(log2(math.inf(f64))));
-    try expect(math.isNegativeInf(log2(0.0)));
-    try expect(math.isNan(log2(-1.0)));
-    try expect(math.isNan(log2(math.nan(f64))));
 }

--- a/lib/compiler_rt/test.zig
+++ b/lib/compiler_rt/test.zig
@@ -1,0 +1,8 @@
+// Include all tests.
+comptime {
+    _ = @import("test/exp.zig");
+    _ = @import("test/exp2.zig");
+    _ = @import("test/log.zig");
+    _ = @import("test/log2.zig");
+    _ = @import("test/log10.zig");
+}

--- a/lib/compiler_rt/test/exp.zig
+++ b/lib/compiler_rt/test/exp.zig
@@ -1,0 +1,136 @@
+const compiler_rt_exp = @import("../exp.zig");
+const math = @import("std").math;
+const test_utils = math.test_utils;
+const Testcase = test_utils.Testcase;
+const runTests = test_utils.runTests;
+const floatFromBits = test_utils.floatFromBits;
+const negInf = test_utils.negInf;
+const inf32 = math.inf(f32);
+const inf64 = math.inf(f64);
+
+const Tc32 = Testcase(compiler_rt_exp.expf, "exp", f32);
+const tc32 = Tc32.init;
+
+const Tc64 = Testcase(compiler_rt_exp.exp, "exp", f64);
+const tc64 = Tc64.init;
+
+// in -> out
+// [-inf,   0] -> [0,   1]
+// [   0, inf] -> [1, inf]
+
+// Special-case tests shared between different float sizes, see genTests().
+const special_tests = .{
+    // zig fmt: off
+    .{ 0,        1       },
+    .{-0,        1       },
+    // TODO: Accuracy error - off in the last bit in 64-bit, disagreeing with GCC
+    // .{ 1,        math.e  },
+    .{ math.ln2, 2       },
+    .{ math.inf, math.inf},
+    .{ negInf,   0       },
+    // zig fmt: on
+};
+
+test "math.exp32() sanity" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32(-0x1.0223a0p+3, 0x1.490320p-12),
+        tc32( 0x1.161868p+2, 0x1.34712ap+6 ),
+        tc32(-0x1.0c34b4p+3, 0x1.e06b1ap-13),
+        tc32(-0x1.a206f0p+2, 0x1.7dd484p-10),
+        tc32( 0x1.288bbcp+3, 0x1.4abc80p+13),
+        tc32( 0x1.52efd0p-1, 0x1.f04a9cp+0 ),
+        tc32(-0x1.a05cc8p-2, 0x1.54f1e0p-1 ),
+        tc32( 0x1.1f9efap-1, 0x1.c0f628p+0 ),
+        tc32( 0x1.8c5db0p-1, 0x1.1599b2p+1 ),
+        tc32(-0x1.5b86eap-1, 0x1.03b572p-1 ),
+        tc32(-0x1.57f25cp+2, 0x1.2fbea2p-8 ),
+        tc32( 0x1.c7d310p+3, 0x1.76eefp+20 ),
+        tc32( 0x1.19be70p+4, 0x1.52d3dep+25),
+        tc32(-0x1.ab6d70p+3, 0x1.a88adep-20),
+        tc32(-0x1.5ac18ep+2, 0x1.22b328p-8 ),
+        tc32(-0x1.925982p-1, 0x1.d2acc0p-2 ),
+        tc32( 0x1.7221cep+3, 0x1.9c2ceap+16),
+        tc32( 0x1.11a0d4p+4, 0x1.980ee6p+24),
+        tc32(-0x1.ae41a2p+1, 0x1.1c28d0p-5 ),
+        tc32(-0x1.329154p+4, 0x1.47ef94p-28),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.exp32() special" {
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    try runTests(cases);
+}
+
+test "math.exp32() boundary" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32( 0x1.62e42ep+6,   0x1.ffff08p+127), // The last value before the result gets infinite
+        tc32( 0x1.62e430p+6,   inf32          ), // The first value that gives inf
+        tc32( 0x1.fffffep+127, inf32          ), // Max input value
+        tc32( 0x1p-149,        1              ), // Min positive input value
+        tc32(-0x1p-149,        1              ), // Min negative input value
+        tc32( 0x1p-126,        1              ), // First positive subnormal input
+        tc32(-0x1p-126,        1              ), // First negative subnormal input
+        tc32(-0x1.9fe368p+6,   0x1p-149       ), // The last value before the result flushes to zero
+        tc32(-0x1.9fe36ap+6,   0              ), // The first value at which the result flushes to zero
+        tc32(-0x1.5d589ep+6,   0x1.00004cp-126), // The last value before the result flushes to subnormal
+        tc32(-0x1.5d58a0p+6,   0x1.ffff98p-127), // The first value for which the result flushes to subnormal
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.exp64() sanity" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64(-0x1.02239f3c6a8f1p+3, 0x1.490327ea61235p-12),
+        tc64( 0x1.161868e18bc67p+2, 0x1.34712ed238c04p+6 ),
+        tc64(-0x1.0c34b3e01e6e7p+3, 0x1.e06b1b6c18e64p-13),
+        tc64(-0x1.a206f0a19dcc4p+2, 0x1.7dd47f810e68cp-10),
+        tc64( 0x1.288bbb0d6a1e6p+3, 0x1.4abc77496e07ep+13),
+        tc64( 0x1.52efd0cd80497p-1, 0x1.f04a9c1080500p+0 ),
+        tc64(-0x1.a05cc754481d1p-2, 0x1.54f1e0fd3ea0dp-1 ),
+        tc64( 0x1.1f9ef934745cbp-1, 0x1.c0f6266a6a547p+0 ),
+        tc64( 0x1.8c5db097f7442p-1, 0x1.1599b1d4a25fbp+1 ),
+        tc64(-0x1.5b86ea8118a0ep-1, 0x1.03b5728a00229p-1 ),
+        tc64(-0x1.57f25b2b5006dp+2, 0x1.2fbea6a01cab9p-8 ),
+        tc64( 0x1.c7d30fb825911p+3, 0x1.76eeed45a0634p+20),
+        tc64( 0x1.19be709de7505p+4, 0x1.52d3eb7be6844p+25),
+        tc64(-0x1.ab6d6fba96889p+3, 0x1.a88ae12f985d6p-20),
+        tc64(-0x1.5ac18e27084ddp+2, 0x1.22b327da9cca6p-8 ),
+        tc64(-0x1.925981b093c41p-1, 0x1.d2acc046b55f7p-2 ),
+        tc64( 0x1.7221cd18455f5p+3, 0x1.9c2cde8699cfbp+16),
+        tc64( 0x1.11a0d4a51b239p+4, 0x1.980ef612ff182p+24),
+        tc64(-0x1.ae41a1079de4dp+1, 0x1.1c28d16bb3222p-5 ),
+        tc64(-0x1.329153103b871p+4, 0x1.47efa6ddd0d22p-28),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.exp64() special" {
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    try runTests(cases);
+}
+
+test "math.exp64() boundary" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64( 0x1.62e42fefa39efp+9,    0x1.fffffffffff2ap+1023), // The last value before the result gets infinite
+        tc64( 0x1.62e42fefa39f0p+9,    inf64                  ), // The first value that gives inf
+        tc64( 0x1.fffffffffffffp+1023, inf64                  ), // Max input value
+        tc64( 0x1p-1074,               1                      ), // Min positive input value
+        tc64(-0x1p-1074,               1                      ), // Min negative input value
+        tc64( 0x1p-1022,               1                      ), // First positive subnormal input
+        tc64(-0x1p-1022,               1                      ), // First negative subnormal input
+        tc64(-0x1.74910d52d3051p+9,    0x1p-1074              ), // The last value before the result flushes to zero
+        tc64(-0x1.74910d52d3052p+9,    0                      ), // The first value at which the result flushes to zero
+        tc64(-0x1.6232bdd7abcd2p+9,    0x1.000000000007cp-1022), // The last value before the result flushes to subnormal
+        tc64(-0x1.6232bdd7abcd3p+9,    0x1.ffffffffffcf8p-1023), // The first value for which the result flushes to subnormal
+        // zig fmt: on
+    };
+    try runTests(cases);
+}

--- a/lib/compiler_rt/test/exp.zig
+++ b/lib/compiler_rt/test/exp.zig
@@ -21,13 +21,13 @@ const tc64 = Tc64.init;
 // Special-case tests shared between different float sizes, see genTests().
 const special_tests = .{
     // zig fmt: off
-    .{ 0,        1       },
-    .{-0,        1       },
+    .{ 0.0,        1.0   },
+    .{-0.0,        1.0   },
     // TODO: Accuracy error - off in the last bit in 64-bit, disagreeing with GCC
     // .{ 1,        math.e  },
-    .{ math.ln2, 2       },
+    .{ math.ln2, 2.0     },
     .{ math.inf, math.inf},
-    .{ negInf,   0       },
+    .{ negInf,   0.0     },
     // zig fmt: on
 };
 

--- a/lib/compiler_rt/test/exp.zig
+++ b/lib/compiler_rt/test/exp.zig
@@ -60,7 +60,7 @@ test "math.exp32() sanity" {
 }
 
 test "math.exp32() special" {
-    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.qnanTests(Tc32);
     try runTests(cases);
 }
 
@@ -112,7 +112,7 @@ test "math.exp64() sanity" {
 }
 
 test "math.exp64() special" {
-    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.qnanTests(Tc64);
     try runTests(cases);
 }
 

--- a/lib/compiler_rt/test/exp2.zig
+++ b/lib/compiler_rt/test/exp2.zig
@@ -21,12 +21,12 @@ const tc64 = Tc64.init;
 // Special-case tests shared between different float sizes, see genTests().
 const special_tests = .{
     // zig fmt: off
-    .{ 0,        1       },
-    .{-0,        1       },
-    .{ 1,        2       },
-    .{-1,        0.5     },
+    .{ 0.0,      1.0     },
+    .{-0.0,      1.0     },
+    .{ 1.0,      2.0     },
+    .{-1.0,      0.5     },
     .{ math.inf, math.inf},
-    .{ negInf,   0       },
+    .{ negInf,   0.0     },
     // zig fmt: on
 };
 

--- a/lib/compiler_rt/test/exp2.zig
+++ b/lib/compiler_rt/test/exp2.zig
@@ -1,0 +1,115 @@
+const compiler_rt_exp2 = @import("../exp2.zig");
+const math = @import("std").math;
+const test_utils = math.test_utils;
+const Testcase = test_utils.Testcase;
+const runTests = test_utils.runTests;
+const floatFromBits = test_utils.floatFromBits;
+const negInf = test_utils.negInf;
+const inf32 = math.inf(f32);
+const inf64 = math.inf(f64);
+
+const Tc32 = Testcase(compiler_rt_exp2.exp2f, "exp2", f32);
+const tc32 = Tc32.init;
+
+const Tc64 = Testcase(compiler_rt_exp2.exp2, "exp2", f64);
+const tc64 = Tc64.init;
+
+// in -> out
+// [-inf,   0] -> [0,   1]
+// [   0, inf] -> [1, inf]
+
+// Special-case tests shared between different float sizes, see genTests().
+const special_tests = .{
+    // zig fmt: off
+    .{ 0,        1       },
+    .{-0,        1       },
+    .{ 1,        2       },
+    .{-1,        0.5     },
+    .{ math.inf, math.inf},
+    .{ negInf,   0       },
+    // zig fmt: on
+};
+
+test "math.exp2_32() sanity" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32(-0x1.0223a0p+3, 0x1.e8d134p-9),
+        tc32( 0x1.161868p+2, 0x1.453672p+4),
+        tc32(-0x1.0c34b4p+3, 0x1.890ca0p-9),
+        tc32(-0x1.a206f0p+2, 0x1.622d4ep-7),
+        tc32( 0x1.288bbcp+3, 0x1.340ecep+9),
+        tc32( 0x1.52efd0p-1, 0x1.950eeep+0),
+        tc32(-0x1.a05cc8p-2, 0x1.824056p-1),
+        tc32( 0x1.1f9efap-1, 0x1.79dfa2p+0),
+        tc32( 0x1.8c5db0p-1, 0x1.b5ceacp+0),
+        tc32(-0x1.5b86eap-1, 0x1.3fd8bap-1),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.exp2_32() special" {
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    try runTests(cases);
+}
+
+test "math.exp2_32() boundary" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32( 0x1.fffffep+6,   0x1.ffff4ep+127), // The last value before the result gets infinite
+        tc32( 0x1p+7,          inf32          ), // The first value that gives infinite result
+        tc32(-0x1.2bccccp+7,   0x1p-149       ), // The last value before the result flushes to zero
+        tc32(-0x1.2cp+7,       0              ), // The first value at which the result flushes to zero
+        tc32(-0x1.f8p+6,       0x1p-126       ), // The last value before the result flushes to subnormal
+        tc32(-0x1.f80002p+6,   0x1.ffff50p-127), // The first value for which the result flushes to subnormal
+        tc32( 0x1.fffffep+127, inf32          ), // Max input value
+        tc32( 0x1p-149,        1              ), // Min positive input value
+        tc32(-0x1p-149,        1              ), // Min negative input value
+        tc32( 0x1p-126,        1              ), // First positive subnormal input
+        tc32(-0x1p-126,        1              ), // First negative subnormal input
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.exp2_64() sanity" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64(-0x1.02239f3c6a8f1p+3, 0x1.e8d13c396f452p-9),
+        tc64( 0x1.161868e18bc67p+2, 0x1.4536746bb6f12p+4),
+        tc64(-0x1.0c34b3e01e6e7p+3, 0x1.890ca0c00b9a2p-9),
+        tc64(-0x1.a206f0a19dcc4p+2, 0x1.622d4b0ebc6c1p-7),
+        tc64( 0x1.288bbb0d6a1e6p+3, 0x1.340ec7f3e607ep+9),
+        tc64( 0x1.52efd0cd80497p-1, 0x1.950eef4bc5451p+0),
+        tc64(-0x1.a05cc754481d1p-2, 0x1.824056efc687cp-1),
+        tc64( 0x1.1f9ef934745cbp-1, 0x1.79dfa14ab121ep+0),
+        tc64( 0x1.8c5db097f7442p-1, 0x1.b5cead2247372p+0),
+        tc64(-0x1.5b86ea8118a0ep-1, 0x1.3fd8ba33216b9p-1),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.exp2_64() special" {
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    try runTests(cases);
+}
+
+test "math.exp2_64() boundary" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64( 0x1.fffffffffffffp+9,    0x1.ffffffffffd3ap+1023), // The last value before the result gets infinite
+        tc64( 0x1p+10,                 inf64                  ), // The first value that gives infinite result
+        tc64(-0x1.0cbffffffffffp+10,   0x1p-1074              ), // The last value before the result flushes to zero
+        tc64(-0x1.0ccp+10,             0                      ), // The first value at which the result flushes to zero
+        tc64(-0x1.ffp+9,               0x1p-1022              ), // The last value before the result flushes to subnormal
+        tc64(-0x1.ff00000000001p+9,    0x1.ffffffffffd3ap-1023), // The first value for which the result flushes to subnormal
+        tc64( 0x1.fffffffffffffp+1023, inf64                  ), // Max input value
+        tc64( 0x1p-1074,               1                      ), // Min positive input value
+        tc64(-0x1p-1074,               1                      ), // Min negative input value
+        tc64( 0x1p-1022,               1                      ), // First positive subnormal input
+        tc64(-0x1p-1022,               1                      ), // First negative subnormal input
+        // zig fmt: on
+    };
+    try runTests(cases);
+}

--- a/lib/compiler_rt/test/exp2.zig
+++ b/lib/compiler_rt/test/exp2.zig
@@ -49,7 +49,7 @@ test "math.exp2_32() sanity" {
 }
 
 test "math.exp2_32() special" {
-    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.qnanTests(Tc32);
     try runTests(cases);
 }
 
@@ -91,7 +91,7 @@ test "math.exp2_64() sanity" {
 }
 
 test "math.exp2_64() special" {
-    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.qnanTests(Tc64);
     try runTests(cases);
 }
 

--- a/lib/compiler_rt/test/log.zig
+++ b/lib/compiler_rt/test/log.zig
@@ -22,12 +22,12 @@ const tc64 = Tc64.init;
 // Special-case tests shared between different float sizes, see genTests().
 const special_tests = .{
     // zig fmt: off
-    .{ 0,         negInf  },
-    .{-0,         negInf  },
-    .{ 1,         0       },
-    .{ math.e,    1       },
-    .{ 2,         math.ln2},
-    .{-1,         math.nan},
+    .{ 0.0,       negInf  },
+    .{-0.0,       negInf  },
+    .{ 1.0,       0.0     },
+    .{ math.e,    1.0     },
+    .{ 2.0,       math.ln2},
+    .{-1.0,       math.nan},
     .{ math.inf,  math.inf},
     .{ negInf,    math.nan},
     // zig fmt: on

--- a/lib/compiler_rt/test/log.zig
+++ b/lib/compiler_rt/test/log.zig
@@ -1,0 +1,110 @@
+const compiler_rt_log = @import("../log.zig");
+const math = @import("std").math;
+const test_utils = math.test_utils;
+const Testcase = test_utils.Testcase;
+const runTests = test_utils.runTests;
+const floatFromBits = test_utils.floatFromBits;
+const negInf = test_utils.negInf;
+const nan32 = math.nan_f32;
+const nan64 = math.nan_f64;
+
+const Tc32 = Testcase(compiler_rt_log.logf, "log", f32);
+const tc32 = Tc32.init;
+
+const Tc64 = Testcase(compiler_rt_log.log, "log", f64);
+const tc64 = Tc64.init;
+
+// in -> out
+// [-inf,   0) -> nan
+// [   0,   1] -> [-inf,   0]
+// [   1, inf] -> [   0, inf]
+
+// Special-case tests shared between different float sizes, see genTests().
+const special_tests = .{
+    // zig fmt: off
+    .{ 0,         negInf  },
+    .{-0,         negInf  },
+    .{ 1,         0       },
+    .{ math.e,    1       },
+    .{ 2,         math.ln2},
+    .{-1,         math.nan},
+    .{ math.inf,  math.inf},
+    .{ negInf,    math.nan},
+    // zig fmt: on
+};
+
+test "math.log32() sanity" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32(-0x1.0223a0p+3,  nan32        ),
+        tc32( 0x1.161868p+2,  0x1.7815b0p+0),
+        tc32(-0x1.0c34b4p+3,  nan32        ),
+        tc32(-0x1.a206f0p+2,  nan32        ),
+        tc32( 0x1.288bbcp+3,  0x1.1cfcd6p+1),
+        tc32( 0x1.52efd0p-1, -0x1.a6694cp-2),
+        tc32(-0x1.a05cc8p-2,  nan32        ),
+        tc32( 0x1.1f9efap-1, -0x1.2742bap-1),
+        tc32( 0x1.8c5db0p-1, -0x1.062160p-2),
+        tc32(-0x1.5b86eap-1,  nan32        ),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log32() special" {
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    try runTests(cases);
+}
+
+test "math.log32() boundary" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32( 0x1.fffffep+127,  0x1.62e430p+6 ), // Max input value
+        tc32( 0x1p-149,        -0x1.9d1da0p+6 ), // Min positive input value
+        tc32(-0x1p-149,         nan32         ), // Min negative input value
+        tc32( 0x1.000002p+0,    0x1.fffffep-24), // Last value before result reaches +0
+        tc32( 0x1.fffffep-1,   -0x1p-24       ), // Last value before result reaches -0
+        tc32( 0x1p-126,        -0x1.5d58a0p+6 ), // First subnormal
+        tc32(-0x1p-126,         nan32         ), // First negative subnormal
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log64() sanity" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64(-0x1.02239f3c6a8f1p+3,  nan64               ),
+        tc64( 0x1.161868e18bc67p+2,  0x1.7815b08f99c65p+0),
+        tc64(-0x1.0c34b3e01e6e7p+3,  nan64               ),
+        tc64(-0x1.a206f0a19dcc4p+2,  nan64               ),
+        tc64( 0x1.288bbb0d6a1e6p+3,  0x1.1cfcd53d72604p+1),
+        tc64( 0x1.52efd0cd80497p-1, -0x1.a6694a4a85621p-2),
+        tc64(-0x1.a05cc754481d1p-2,  nan64               ),
+        tc64( 0x1.1f9ef934745cbp-1, -0x1.2742bc03d02ddp-1),
+        tc64( 0x1.8c5db097f7442p-1, -0x1.06215de4a3f92p-2),
+        tc64(-0x1.5b86ea8118a0ep-1,  nan64               ),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log64() special" {
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    try runTests(cases);
+}
+
+test "math.log64() boundary" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64( 0x1.fffffffffffffp+1023,  0x1.62e42fefa39efp+9 ), // Max input value
+        tc64( 0x1p-1074,               -0x1.74385446d71c3p+9 ), // Min positive input value
+        tc64(-0x1p-1074,                nan64                ), // Min negative input value
+        tc64( 0x1.0000000000001p+0,     0x1.fffffffffffffp-53), // Last value before result reaches +0
+        tc64( 0x1.fffffffffffffp-1,    -0x1p-53              ), // Last value before result reaches -0
+        tc64( 0x1p-1022,               -0x1.6232bdd7abcd2p+9 ), // First subnormal
+        tc64(-0x1p-1022,                nan64                ), // First negative subnormal
+        // zig fmt: on
+    };
+    try runTests(cases);
+}

--- a/lib/compiler_rt/test/log.zig
+++ b/lib/compiler_rt/test/log.zig
@@ -5,8 +5,8 @@ const Testcase = test_utils.Testcase;
 const runTests = test_utils.runTests;
 const floatFromBits = test_utils.floatFromBits;
 const negInf = test_utils.negInf;
-const nan32 = math.nan_f32;
-const nan64 = math.nan_f64;
+const nan32 = math.nan(f32);
+const nan64 = math.nan(f64);
 
 const Tc32 = Testcase(compiler_rt_log.logf, "log", f32);
 const tc32 = Tc32.init;
@@ -52,7 +52,7 @@ test "math.log32() sanity" {
 }
 
 test "math.log32() special" {
-    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.qnanTests(Tc32);
     try runTests(cases);
 }
 
@@ -90,7 +90,7 @@ test "math.log64() sanity" {
 }
 
 test "math.log64() special" {
-    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.qnanTests(Tc64);
     try runTests(cases);
 }
 

--- a/lib/compiler_rt/test/log10.zig
+++ b/lib/compiler_rt/test/log10.zig
@@ -1,0 +1,110 @@
+const compiler_rt_log10 = @import("../log10.zig");
+const math = @import("std").math;
+const test_utils = math.test_utils;
+const Testcase = test_utils.Testcase;
+const runTests = test_utils.runTests;
+const floatFromBits = test_utils.floatFromBits;
+const negInf = test_utils.negInf;
+const nan32 = math.nan_f32;
+const nan64 = math.nan_f64;
+
+const Tc32 = Testcase(compiler_rt_log10.log10f, "log10", f32);
+const tc32 = Tc32.init;
+
+const Tc64 = Testcase(compiler_rt_log10.log10, "log10", f64);
+const tc64 = Tc64.init;
+
+// in -> out
+// [-inf,   0) -> nan
+// [   0,   1] -> [-inf,   0]
+// [   1, inf] -> [   0, inf]
+
+// Special-case tests shared between different float sizes, see genTests().
+const special_tests = .{
+    // zig fmt: off
+    .{ 0,         negInf  },
+    .{-0,         negInf  },
+    .{ 1,         0       },
+    .{ 10,        1       },
+    .{ 0.1,      -1       },
+    .{-1,         math.nan},
+    .{ math.inf,  math.inf},
+    .{ negInf,    math.nan},
+    // zig fmt: on
+};
+
+test "math.log10_32() sanity" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32(-0x1.0223a0p+3,  nan32        ),
+        tc32( 0x1.161868p+2,  0x1.46a9bcp-1),
+        tc32(-0x1.0c34b4p+3,  nan32        ),
+        tc32(-0x1.a206f0p+2,  nan32        ),
+        tc32( 0x1.288bbcp+3,  0x1.ef1300p-1),
+        tc32( 0x1.52efd0p-1, -0x1.6ee6dcp-3), // Disagrees with GCC in last bit
+        tc32(-0x1.a05cc8p-2,  nan32        ),
+        tc32( 0x1.1f9efap-1, -0x1.0075ccp-2),
+        tc32( 0x1.8c5db0p-1, -0x1.c75df8p-4),
+        tc32(-0x1.5b86eap-1,  nan32        ),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log10_32() special" {
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    try runTests(cases);
+}
+
+test "math.log10_32() boundary" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32( 0x1.fffffep+127,  0x1.344136p+5 ), // Max input value
+        tc32( 0x1p-149,        -0x1.66d3e8p+5 ), // Min positive input value
+        tc32(-0x1p-149,         nan32         ), // Min negative input value
+        tc32( 0x1.000002p+0,    0x1.bcb7b0p-25), // Last value before result reaches +0
+        tc32( 0x1.fffffep-1,   -0x1.bcb7b2p-26), // Last value before result reaches -0
+        tc32( 0x1p-126,        -0x1.2f7030p+5 ), // First subnormal
+        tc32(-0x1p-126,         nan32         ), // First negative subnormal
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log10_64() sanity" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64(-0x1.02239f3c6a8f1p+3,  nan64               ),
+        tc64( 0x1.161868e18bc67p+2,  0x1.46a9bd1d2eb87p-1),
+        tc64(-0x1.0c34b3e01e6e7p+3,  nan64               ),
+        tc64(-0x1.a206f0a19dcc4p+2,  nan64               ),
+        tc64( 0x1.288bbb0d6a1e6p+3,  0x1.ef12fff994862p-1),
+        tc64( 0x1.52efd0cd80497p-1, -0x1.6ee6db5a155cbp-3),
+        tc64(-0x1.a05cc754481d1p-2,  nan64               ),
+        tc64( 0x1.1f9ef934745cbp-1, -0x1.0075cda79d321p-2),
+        tc64( 0x1.8c5db097f7442p-1, -0x1.c75df6442465ap-4),
+        tc64(-0x1.5b86ea8118a0ep-1,  nan64               ),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log10_64() special" {
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    try runTests(cases);
+}
+
+test "math.log10_64() boundary" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64( 0x1.fffffffffffffp+1023,  0x1.34413509f79ffp+8 ), // Max input value
+        tc64( 0x1p-1074,               -0x1.434e6420f4374p+8 ), // Min positive input value
+        tc64(-0x1p-1074,                nan64                ), // Min negative input value
+        tc64( 0x1.0000000000001p+0,     0x1.bcb7b1526e50dp-54), // Last value before result reaches +0
+        tc64( 0x1.fffffffffffffp-1,    -0x1.bcb7b1526e50fp-55), // Last value before result reaches -0
+        tc64( 0x1p-1022,               -0x1.33a7146f72a42p+8 ), // First subnormal
+        tc64(-0x1p-1022,                nan64                ), // First negative subnormal
+        // zig fmt: on
+    };
+    try runTests(cases);
+}

--- a/lib/compiler_rt/test/log10.zig
+++ b/lib/compiler_rt/test/log10.zig
@@ -5,8 +5,8 @@ const Testcase = test_utils.Testcase;
 const runTests = test_utils.runTests;
 const floatFromBits = test_utils.floatFromBits;
 const negInf = test_utils.negInf;
-const nan32 = math.nan_f32;
-const nan64 = math.nan_f64;
+const nan32 = math.nan(f32);
+const nan64 = math.nan(f64);
 
 const Tc32 = Testcase(compiler_rt_log10.log10f, "log10", f32);
 const tc32 = Tc32.init;
@@ -52,7 +52,7 @@ test "math.log10_32() sanity" {
 }
 
 test "math.log10_32() special" {
-    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.qnanTests(Tc32);
     try runTests(cases);
 }
 
@@ -90,7 +90,7 @@ test "math.log10_64() sanity" {
 }
 
 test "math.log10_64() special" {
-    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.qnanTests(Tc64);
     try runTests(cases);
 }
 

--- a/lib/compiler_rt/test/log10.zig
+++ b/lib/compiler_rt/test/log10.zig
@@ -22,14 +22,14 @@ const tc64 = Tc64.init;
 // Special-case tests shared between different float sizes, see genTests().
 const special_tests = .{
     // zig fmt: off
-    .{ 0,         negInf  },
-    .{-0,         negInf  },
-    .{ 1,         0       },
-    .{ 10,        1       },
-    .{ 0.1,      -1       },
-    .{-1,         math.nan},
-    .{ math.inf,  math.inf},
-    .{ negInf,    math.nan},
+    .{  0.0,       negInf  },
+    .{ -0.0,       negInf  },
+    .{  1.0,       0.0     },
+    .{ 10.0,       1.0     },
+    .{  0.1,      -1.0     },
+    .{ -1,         math.nan},
+    .{  math.inf,  math.inf},
+    .{  negInf,    math.nan},
     // zig fmt: on
 };
 

--- a/lib/compiler_rt/test/log2.zig
+++ b/lib/compiler_rt/test/log2.zig
@@ -1,0 +1,109 @@
+const compiler_rt_log2 = @import("../log2.zig");
+const math = @import("std").math;
+const test_utils = math.test_utils;
+const Testcase = test_utils.Testcase;
+const runTests = test_utils.runTests;
+const floatFromBits = test_utils.floatFromBits;
+const negInf = test_utils.negInf;
+const nan32 = math.nan_f32;
+const nan64 = math.nan_f64;
+
+const Tc32 = Testcase(compiler_rt_log2.log2f, "log2", f32);
+const tc32 = Tc32.init;
+
+const Tc64 = Testcase(compiler_rt_log2.log2, "log2", f64);
+const tc64 = Tc64.init;
+
+// in -> out
+// [-inf,   0) -> nan
+// [   0,   1] -> [-inf,   0]
+// [   1, inf] -> [   0, inf]
+
+// Special-case tests shared between different float sizes, see genTests().
+const special_tests = .{
+    // zig fmt: off
+    .{ 0,        negInf  },
+    .{-0,        negInf  },
+    .{ 1,        0       },
+    .{ 2,        1       },
+    .{-1,        math.nan},
+    .{ math.inf, math.inf},
+    .{ negInf,   math.nan},
+    // zig fmt: on
+};
+
+test "math.log2_32() sanity" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32(-0x1.0223a0p+3,  nan32        ),
+        tc32( 0x1.161868p+2,  0x1.0f49acp+1),
+        tc32(-0x1.0c34b4p+3,  nan32        ),
+        tc32(-0x1.a206f0p+2,  nan32        ),
+        tc32( 0x1.288bbcp+3,  0x1.9b2676p+1),
+        tc32( 0x1.52efd0p-1, -0x1.30b494p-1), // Disagrees with GCC in last bit
+        tc32(-0x1.a05cc8p-2,  nan32        ),
+        tc32( 0x1.1f9efap-1, -0x1.a9f89ap-1),
+        tc32( 0x1.8c5db0p-1, -0x1.7a2c96p-2),
+        tc32(-0x1.5b86eap-1,  nan32        ),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log2_32() special" {
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    try runTests(cases);
+}
+
+test "math.log2_32() boundary" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32( 0x1.fffffep+127,  0x1p+7        ), // Max input value
+        tc32( 0x1p-149,        -0x1.2ap+7     ), // Min positive input value
+        tc32(-0x1p-149,         nan32         ), // Min negative input value
+        tc32( 0x1.000002p+0,    0x1.715474p-23), // Last value before result reaches +0
+        tc32( 0x1.fffffep-1,   -0x1.715478p-24), // Last value before result reaches -0
+        tc32( 0x1p-126,        -0x1.f8p+6     ), // First subnormal
+        tc32(-0x1p-126,         nan32         ), // First negative subnormal
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log2_64() sanity" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64(-0x1.02239f3c6a8f1p+3,  nan64               ),
+        tc64( 0x1.161868e18bc67p+2,  0x1.0f49ac3838580p+1),
+        tc64(-0x1.0c34b3e01e6e7p+3,  nan64               ),
+        tc64(-0x1.a206f0a19dcc4p+2,  nan64               ),
+        tc64( 0x1.288bbb0d6a1e6p+3,  0x1.9b26760c2a57ep+1),
+        tc64( 0x1.52efd0cd80497p-1, -0x1.30b490ef684c7p-1),
+        tc64(-0x1.a05cc754481d1p-2,  nan64               ),
+        tc64( 0x1.1f9ef934745cbp-1, -0x1.a9f89b5f5acb8p-1),
+        tc64( 0x1.8c5db097f7442p-1, -0x1.7a2c947173f06p-2),
+        tc64(-0x1.5b86ea8118a0ep-1,  nan64               ),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log2_64() special" {
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    try runTests(cases);
+}
+
+test "math.log2_64() boundary" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64( 0x1.fffffffffffffp+1023,  0x1p+10              ), // Max input value
+        tc64( 0x1p-1074,               -0x1.0c8p+10          ), // Min positive input value
+        tc64(-0x1p-1074,                nan64                ), // Min negative input value
+        tc64( 0x1.0000000000001p+0,     0x1.71547652b82fdp-52), // Last value before result reaches +0
+        tc64( 0x1.fffffffffffffp-1,    -0x1.71547652b82fep-53), // Last value before result reaches -0
+        tc64( 0x1p-1022,               -0x1.ffp+9            ), // First subnormal
+        tc64(-0x1p-1022,                nan64                ), // First negative subnormal
+        // zig fmt: on
+    };
+    try runTests(cases);
+}

--- a/lib/compiler_rt/test/log2.zig
+++ b/lib/compiler_rt/test/log2.zig
@@ -22,13 +22,13 @@ const tc64 = Tc64.init;
 // Special-case tests shared between different float sizes, see genTests().
 const special_tests = .{
     // zig fmt: off
-    .{ 0,        negInf  },
-    .{-0,        negInf  },
-    .{ 1,        0       },
-    .{ 2,        1       },
-    .{-1,        math.nan},
-    .{ math.inf, math.inf},
-    .{ negInf,   math.nan},
+    .{ 0.0,        negInf  },
+    .{-0.0,        negInf  },
+    .{ 1.0,        0.0     },
+    .{ 2.0,        1.0     },
+    .{-1.0,        math.nan},
+    .{ math.inf,   math.inf},
+    .{ negInf,     math.nan},
     // zig fmt: on
 };
 

--- a/lib/compiler_rt/test/log2.zig
+++ b/lib/compiler_rt/test/log2.zig
@@ -5,8 +5,8 @@ const Testcase = test_utils.Testcase;
 const runTests = test_utils.runTests;
 const floatFromBits = test_utils.floatFromBits;
 const negInf = test_utils.negInf;
-const nan32 = math.nan_f32;
-const nan64 = math.nan_f64;
+const nan32 = math.nan(f32);
+const nan64 = math.nan(f64);
 
 const Tc32 = Testcase(compiler_rt_log2.log2f, "log2", f32);
 const tc32 = Tc32.init;
@@ -51,7 +51,7 @@ test "math.log2_32() sanity" {
 }
 
 test "math.log2_32() special" {
-    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.qnanTests(Tc32);
     try runTests(cases);
 }
 
@@ -89,7 +89,7 @@ test "math.log2_64() sanity" {
 }
 
 test "math.log2_64() special" {
-    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.qnanTests(Tc64);
     try runTests(cases);
 }
 

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -255,6 +255,8 @@ pub const atan = @import("math/atan.zig").atan;
 pub const atan2 = @import("math/atan2.zig").atan2;
 pub const hypot = @import("math/hypot.zig").hypot;
 pub const expm1 = @import("math/expm1.zig").expm1;
+// TODO: Currently broken, add this in when fixed.
+// pub const expo2 = @import("math/expo2.zig").expo2;
 pub const ilogb = @import("math/ilogb.zig").ilogb;
 pub const log = @import("math/log.zig").log;
 pub const log2 = @import("math/log2.zig").log2;
@@ -271,6 +273,10 @@ pub const tanh = @import("math/tanh.zig").tanh;
 pub const gcd = @import("math/gcd.zig").gcd;
 pub const gamma = @import("math/gamma.zig").gamma;
 pub const lgamma = @import("math/gamma.zig").lgamma;
+
+// TODO: This should not be part of the public API, but compiler-rt tests need
+//       access to it...
+pub const test_utils = @import("math/test.zig");
 
 /// Sine trigonometric function on a floating point number.
 /// Uses a dedicated hardware instruction when available.
@@ -401,6 +407,8 @@ test {
     _ = Complex;
 
     _ = big;
+
+    _ = @import("math/test.zig");
 }
 
 /// Given two types, returns the smallest one which is capable of holding the

--- a/lib/std/math/expm1.zig
+++ b/lib/std/math/expm1.zig
@@ -28,9 +28,6 @@ pub fn expm1(x: anytype) @TypeOf(x) {
 }
 
 fn expm1_32(x_: f32) f32 {
-    if (math.isNan(x_))
-        return math.nan(f32);
-
     const o_threshold: f32 = 8.8721679688e+01;
     const ln2_hi: f32 = 6.9313812256e-01;
     const ln2_lo: f32 = 9.0580006145e-06;
@@ -41,7 +38,7 @@ fn expm1_32(x_: f32) f32 {
     var x = x_;
     const ux = @as(u32, @bitCast(x));
     const hx = ux & 0x7FFFFFFF;
-    const sign = hx >> 31;
+    const sign = ux >> 31;
 
     // TODO: Shouldn't need this check explicitly.
     if (math.isNegativeInf(x)) {
@@ -147,7 +144,7 @@ fn expm1_32(x_: f32) f32 {
         return y - 1.0;
     }
 
-    const uf = @as(f32, @bitCast(@as(u32, @intCast(0x7F -% k)) << 23));
+    const uf: f32 = @bitCast(@as(u32, @intCast(0x7F -% k)) << 23);
     if (k < 23) {
         return (x - e + (1 - uf)) * twopk;
     } else {
@@ -156,9 +153,6 @@ fn expm1_32(x_: f32) f32 {
 }
 
 fn expm1_64(x_: f64) f64 {
-    if (math.isNan(x_))
-        return math.nan(f64);
-
     const o_threshold: f64 = 7.09782712893383973096e+02;
     const ln2_hi: f64 = 6.93147180369123816490e-01;
     const ln2_lo: f64 = 1.90821492927058770002e-10;
@@ -176,6 +170,11 @@ fn expm1_64(x_: f64) f64 {
 
     if (math.isNegativeInf(x)) {
         return -1.0;
+    }
+
+    // TODO: This should be handled beneath.
+    if (math.isNan(x_)) {
+        return x_;
     }
 
     // |x| >= 56 * ln2
@@ -286,7 +285,7 @@ fn expm1_64(x_: f64) f64 {
     }
 }
 
-test "math.exp1m" {
+test "math.expm1" {
     try expect(expm1(@as(f32, 0.0)) == expm1_32(0.0));
     try expect(expm1(@as(f64, 0.0)) == expm1_64(0.0));
 }
@@ -309,16 +308,4 @@ test "math.expm1_64" {
     try expect(math.approxEqAbs(f64, expm1_64(0.2), 0.221403, epsilon));
     try expect(math.approxEqAbs(f64, expm1_64(0.8923), 1.440737, epsilon));
     try expect(math.approxEqAbs(f64, expm1_64(1.5), 3.481689, epsilon));
-}
-
-test "math.expm1_32.special" {
-    try expect(math.isPositiveInf(expm1_32(math.inf(f32))));
-    try expect(expm1_32(-math.inf(f32)) == -1.0);
-    try expect(math.isNan(expm1_32(math.nan(f32))));
-}
-
-test "math.expm1_64.special" {
-    try expect(math.isPositiveInf(expm1_64(math.inf(f64))));
-    try expect(expm1_64(-math.inf(f64)) == -1.0);
-    try expect(math.isNan(expm1_64(math.nan(f64))));
 }

--- a/lib/std/math/log1p.zig
+++ b/lib/std/math/log1p.zig
@@ -34,8 +34,12 @@ fn log1p_32(x: f32) f32 {
     const Lg3: f32 = 0x91e9ee.0p-25;
     const Lg4: f32 = 0xf89e26.0p-26;
 
-    const u: u32 = @bitCast(x);
-    const ix = u;
+    // TODO: This should be handled beneath.
+    if (math.isNan(x)) {
+        return x;
+    }
+
+    const ix: u32 = @bitCast(x);
     var k: i32 = 1;
     var f: f32 = undefined;
     var c: f32 = undefined;
@@ -112,6 +116,11 @@ fn log1p_64(x: f64) f64 {
     const Lg5: f64 = 1.818357216161805012e-01;
     const Lg6: f64 = 1.531383769920937332e-01;
     const Lg7: f64 = 1.479819860511658591e-01;
+
+    // TODO: This should be handled beneath.
+    if (math.isNan(x)) {
+        return x;
+    }
 
     const ix: u64 = @bitCast(x);
     const hx: u32 = @intCast(ix >> 32);
@@ -218,13 +227,4 @@ test "math.log1p_32.special" {
     try expect(math.isNegativeInf(log1p_32(-1.0)));
     try expect(math.isNan(log1p_32(-2.0)));
     try expect(math.isNan(log1p_32(math.nan(f32))));
-}
-
-test "math.log1p_64.special" {
-    try expect(math.isPositiveInf(log1p_64(math.inf(f64))));
-    try expect(math.isPositiveZero(log1p_64(0.0)));
-    try expect(math.isNegativeZero(log1p_64(-0.0)));
-    try expect(math.isNegativeInf(log1p_64(-1.0)));
-    try expect(math.isNan(log1p_64(-2.0)));
-    try expect(math.isNan(log1p_64(math.nan(f64))));
 }

--- a/lib/std/math/test.zig
+++ b/lib/std/math/test.zig
@@ -1,0 +1,168 @@
+const std = @import("../std.zig");
+const print = std.debug.print;
+const meta = std.meta;
+const math = std.math;
+const nan = math.nan;
+
+// Change to '.info' to enable verbose output.
+pub const log_level: std.log.Level = .warn;
+
+// Include all tests.
+comptime {
+    _ = @import("test/expm1.zig");
+    // TODO: The implementation seems to be broken...
+    // _ = @import("test/expo2.zig");
+    _ = @import("test/log1p.zig");
+}
+
+/// Return negative infinity of the given float type.
+///
+/// Intended for use with 'genTests()'.
+pub fn negInf(comptime T: type) T {
+    return -math.inf(T);
+}
+
+// Used for the type signature.
+fn genericFloatInFloatOut(x: anytype) @TypeOf(x) {
+    return x;
+}
+
+/// Create a testcase struct type for a given function that takes in a generic
+/// float value and outputs the same float type. Provides descriptive reporting
+/// of errors.
+pub fn Testcase(
+    comptime func: anytype,
+    comptime name: []const u8,
+    comptime float_type: type,
+) type {
+    if (@typeInfo(float_type) != .Float) @compileError("Expected float type");
+
+    return struct {
+        pub const F: type = float_type;
+
+        input: F,
+        exp_output: F,
+
+        const Self = @This();
+
+        pub const bits = @bitSizeOf(F);
+        const U: type = meta.Int(.unsigned, bits);
+
+        pub fn init(input: F, exp_output: F) Self {
+            return .{ .input = input, .exp_output = exp_output };
+        }
+
+        pub fn run(tc: Self) !void {
+            const hex_bits_fmt_size = comptime std.fmt.comptimePrint("{d}", .{bits / 4});
+            const hex_float_fmt_size = switch (bits) {
+                16 => "10",
+                32 => "16",
+                64 => "24",
+                128 => "40",
+                else => unreachable,
+            };
+            const input_bits: U = @bitCast(tc.input);
+            std.log.info(
+                " IN:  0x{X:0>" ++ hex_bits_fmt_size ++ "}  " ++
+                    "{[1]x:<" ++ hex_float_fmt_size ++ "}  {[1]e}",
+                .{ input_bits, tc.input },
+            );
+
+            const output = func(tc.input);
+            const output_bits: U = @bitCast(output);
+            std.log.info(
+                "OUT:  0x{X:0>" ++ hex_bits_fmt_size ++ "}  " ++
+                    "{[1]x:<" ++ hex_float_fmt_size ++ "}  {[1]e}",
+                .{ output_bits, output },
+            );
+            const exp_output_bits: U = @bitCast(tc.exp_output);
+            // Compare bits rather than values so that NaN compares correctly.
+            if (output_bits != exp_output_bits) {
+                std.log.info(
+                    "EXP:  0x{X:0>" ++ hex_bits_fmt_size ++ "}  " ++
+                        "{[1]x:<" ++ hex_float_fmt_size ++ "}  {[1]e}",
+                    .{ exp_output_bits, tc.exp_output },
+                );
+                print(
+                    "FAILURE: expected {s}({x})->{x}, got {x} ({d}-bit)\n",
+                    .{ name, tc.input, tc.exp_output, output, bits },
+                );
+                return error.TestExpectedEqual;
+            }
+        }
+    };
+}
+
+/// Run all testcases in the given iterable, using the '.run()' method.
+pub fn runTests(tests: anytype) !void {
+    const old_log_level = std.testing.log_level;
+    std.testing.log_level = log_level;
+    defer std.testing.log_level = old_log_level;
+
+    var failures: usize = 0;
+    std.log.info("", .{});
+    for (tests) |tc| {
+        tc.run() catch {
+            failures += 1;
+        };
+        std.log.info("", .{});
+    }
+    std.log.info(
+        "Subtest summary: {d} passed; {d} failed",
+        .{ tests.len - failures, failures },
+    );
+    if (failures > 0) return error.Failure;
+}
+
+/// Create a float of the given type using the unsigned integer bit representation.
+pub fn floatFromBits(comptime T: type, bits: meta.Int(.unsigned, @bitSizeOf(T))) T {
+    return @bitCast(bits);
+}
+
+/// Generate a comptime slice of testcases of the given type.
+///
+/// The input type should be an instance of 'Testcase'.
+///
+/// The input testcases should be a comptime iterable of 2-tuples containing
+/// input and expected output for the testcase. These values may be any of:
+///  - a comptime integer or float
+///  - a regular float (to be cast to the destination float type)
+///  - a function that takes a float type and returns the value, intended for
+///    use with math.inf() and math.nan()
+pub fn genTests(comptime T: type, comptime testcases: anytype) []const T {
+    comptime var out_tests: []const T = &.{};
+    inline for (testcases) |tc| {
+        const input: T.F = switch (@typeInfo(@TypeOf(tc[0]))) {
+            .ComptimeInt, .ComptimeFloat, .Float => tc[0],
+            else => tc[0](T.F),
+        };
+        const exp_output: T.F = switch (@typeInfo(@TypeOf(tc[1]))) {
+            .ComptimeInt, .ComptimeFloat, .Float => tc[1],
+            else => tc[1](T.F),
+        };
+        out_tests = out_tests ++ &[_]T{T.init(input, exp_output)};
+    }
+    return out_tests;
+}
+
+/// A comptime slice of NaN testcases, applicable to all functions.
+///
+/// The input type should be an instance of 'Testcase'.
+pub fn nanTests(comptime T: type) []const T {
+    // NaNs should always be unchanged when passed through.
+    switch (T.bits) {
+        32 => return &.{
+            T.init(nan(T.F), nan(T.F)),
+            T.init(-nan(T.F), -nan(T.F)),
+            T.init(floatFromBits(T.F, 0x7ff01234), floatFromBits(T.F, 0x7ff01234)),
+            T.init(floatFromBits(T.F, 0xfff01234), floatFromBits(T.F, 0xfff01234)),
+        },
+        64 => return &.{
+            T.init(nan(T.F), nan(T.F)),
+            T.init(-nan(T.F), -nan(T.F)),
+            T.init(floatFromBits(T.F, 0x7ff0123400000000), floatFromBits(T.F, 0x7ff0123400000000)),
+            T.init(floatFromBits(T.F, 0xfff0123400000000), floatFromBits(T.F, 0xfff0123400000000)),
+        },
+        else => @compileError("Not yet implemented for " ++ @typeName(T.F)),
+    }
+}

--- a/lib/std/math/test.zig
+++ b/lib/std/math/test.zig
@@ -86,6 +86,12 @@ pub fn Testcase(
                     "FAILURE: expected {s}({x})->{x}, got {x} ({d}-bit)\n",
                     .{ name, tc.input, tc.exp_output, output, bits },
                 );
+                print(
+                    "         expected {s}(0x{X:0>" ++ hex_bits_fmt_size ++ "})->" ++
+                        "0x{X:0>" ++ hex_bits_fmt_size ++ "}, " ++
+                        "got 0x{X:0>" ++ hex_bits_fmt_size ++ "}\n",
+                    .{ name, input_bits, exp_output_bits, output_bits },
+                );
                 return error.TestExpectedEqual;
             }
         }

--- a/lib/std/math/test.zig
+++ b/lib/std/math/test.zig
@@ -2,7 +2,6 @@ const std = @import("../std.zig");
 const print = std.debug.print;
 const meta = std.meta;
 const math = std.math;
-const nan = math.nan;
 
 // Change to '.info' to enable verbose output.
 pub const log_level: std.log.Level = .warn;
@@ -145,23 +144,24 @@ pub fn genTests(comptime T: type, comptime testcases: anytype) []const T {
     return out_tests;
 }
 
-/// A comptime slice of NaN testcases, applicable to all functions.
+/// A comptime slice of qNaN testcases, applicable to all functions.
 ///
 /// The input type should be an instance of 'Testcase'.
-pub fn nanTests(comptime T: type) []const T {
-    // NaNs should always be unchanged when passed through.
+pub fn qnanTests(comptime T: type) []const T {
+    // Quiet NaNs should always be unchanged when passed through.
+    // These are all quiet NaNs (with the uppermost bit of the mantissa set).
+    // Zig does not yet properly support signalling NaNs (see std.math.isSignalNan()).
+    // Negative NaNs are somewhat meaningless, so not tested.
     switch (T.bits) {
         32 => return &.{
-            T.init(nan(T.F), nan(T.F)),
-            T.init(-nan(T.F), -nan(T.F)),
-            T.init(floatFromBits(T.F, 0x7ff01234), floatFromBits(T.F, 0x7ff01234)),
-            T.init(floatFromBits(T.F, 0xfff01234), floatFromBits(T.F, 0xfff01234)),
+            T.init(math.nan(T.F), math.nan(T.F)),
+            T.init(floatFromBits(T.F, 0x7fc01234), floatFromBits(T.F, 0x7fc01234)),
+            T.init(floatFromBits(T.F, 0x7fff0000), floatFromBits(T.F, 0x7fff0000)),
         },
         64 => return &.{
-            T.init(nan(T.F), nan(T.F)),
-            T.init(-nan(T.F), -nan(T.F)),
-            T.init(floatFromBits(T.F, 0x7ff0123400000000), floatFromBits(T.F, 0x7ff0123400000000)),
-            T.init(floatFromBits(T.F, 0xfff0123400000000), floatFromBits(T.F, 0xfff0123400000000)),
+            T.init(math.nan(T.F), math.nan(T.F)),
+            T.init(floatFromBits(T.F, 0x7ff8000000001234), floatFromBits(T.F, 0x7ff8000000001234)),
+            T.init(floatFromBits(T.F, 0x7ffff00000000000), floatFromBits(T.F, 0x7ffff00000000000)),
         },
         else => @compileError("Not yet implemented for " ++ @typeName(T.F)),
     }

--- a/lib/std/math/test/expm1.zig
+++ b/lib/std/math/test/expm1.zig
@@ -1,0 +1,114 @@
+const math = @import("../../math.zig");
+const test_utils = @import("../test.zig");
+const Testcase = test_utils.Testcase;
+const runTests = test_utils.runTests;
+const floatFromBits = test_utils.floatFromBits;
+const negInf = test_utils.negInf;
+const inf32 = math.inf(f32);
+const inf64 = math.inf(f64);
+
+const Tc32 = Testcase(math.expm1, "expm1", f32);
+const tc32 = Tc32.init;
+
+const Tc64 = Testcase(math.expm1, "expm1", f64);
+const tc64 = Tc64.init;
+
+// in -> out
+// [-inf,   0] -> [-1,   0]
+// [   0, inf] -> [ 0, inf]
+
+// Special-case tests shared between different float sizes, see genTests().
+const special_tests = .{
+    // zig fmt: off
+    .{ 0,         0       },
+    .{-0,         0       },
+    .{ math.ln2,  1       },
+    .{ math.inf,  math.inf},
+    .{ negInf,   -1       },
+    // zig fmt: on
+};
+
+test "math.expm1_32() sanity" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32(-0x1.0223a0p+3, -0x1.ffd6e0p-1 ),
+        tc32( 0x1.161868p+2,  0x1.30712ap+6 ),
+        tc32(-0x1.0c34b4p+3, -0x1.ffe1fap-1 ),
+        tc32(-0x1.a206f0p+2, -0x1.ff4116p-1 ),
+        tc32( 0x1.288bbcp+3,  0x1.4ab480p+13), // Disagrees with GCC in last bit
+        tc32( 0x1.52efd0p-1,  0x1.e09536p-1 ),
+        tc32(-0x1.a05cc8p-2, -0x1.561c3ep-2 ),
+        tc32( 0x1.1f9efap-1,  0x1.81ec4ep-1 ),
+        tc32( 0x1.8c5db0p-1,  0x1.2b3364p+0 ),
+        tc32(-0x1.5b86eap-1, -0x1.f8951ap-2 ),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.expm1_32() special" {
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    try runTests(cases);
+}
+
+test "math.expm1_32() boundary" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        // TODO: The last value before inf is actually 0x1.62e300p+6 -> 0x1.ff681ep+127
+        // tc32( 0x1.62e42ep+6,    0x1.ffff08p+127), // Last value before result is inf
+        tc32( 0x1.62e430p+6,    inf32          ), // First value that gives inf
+        tc32( 0x1.fffffep+127,  inf32          ), // Max input value
+        tc32( 0x1p-149,         0x1p-149       ), // Min positive input value
+        tc32(-0x1p-149,        -0x1p-149       ), // Min negative input value
+        tc32( 0x1p-126,         0x1p-126       ), // First positive subnormal input
+        tc32(-0x1p-126,        -0x1p-126       ), // First negative subnormal input
+        tc32( 0x1.fffffep-125,  0x1.fffffep-125), // Last positive value before subnormal
+        tc32(-0x1.fffffep-125, -0x1.fffffep-125), // Last negative value before subnormal
+        tc32(-0x1.154244p+4,   -0x1.fffffep-1  ), // Last value before result is -1
+        tc32(-0x1.154246p+4,   -1              ), // First value where result is -1
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.expm1_64() sanity" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64(-0x1.02239f3c6a8f1p+3, -0x1.ffd6df9b02b3ep-1 ),
+        tc64( 0x1.161868e18bc67p+2,  0x1.30712ed238c04p+6 ),
+        tc64(-0x1.0c34b3e01e6e7p+3, -0x1.ffe1f94e493e7p-1 ),
+        tc64(-0x1.a206f0a19dcc4p+2, -0x1.ff4115c03f78dp-1 ),
+        tc64( 0x1.288bbb0d6a1e6p+3,  0x1.4ab477496e07ep+13),
+        tc64( 0x1.52efd0cd80497p-1,  0x1.e095382100a01p-1 ),
+        tc64(-0x1.a05cc754481d1p-2, -0x1.561c3e0582be6p-2 ),
+        tc64( 0x1.1f9ef934745cbp-1,  0x1.81ec4cd4d4a8fp-1 ),
+        tc64( 0x1.8c5db097f7442p-1,  0x1.2b3363a944bf7p+0 ),
+        tc64(-0x1.5b86ea8118a0ep-1, -0x1.f8951aebffbafp-2 ),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.expm1_64() special" {
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    try runTests(cases);
+}
+
+test "math.expm1_64() boundary" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64( 0x1.62e42fefa39efp+9,     0x1.fffffffffff2ap+1023), // Last value before result is inf
+        tc64( 0x1.62e42fefa39f0p+9,     inf64                  ), // First value that gives inf
+        tc64( 0x1.fffffffffffffp+1023,  inf64                  ), // Max input value
+        tc64( 0x1p-1074,                0x1p-1074              ), // Min positive input value
+        tc64(-0x1p-1074,               -0x1p-1074              ), // Min negative input value
+        tc64( 0x1p-1022,                0x1p-1022              ), // First positive subnormal input
+        tc64(-0x1p-1022,               -0x1p-1022              ), // First negative subnormal input
+        tc64( 0x1.fffffffffffffp-1021,  0x1.fffffffffffffp-1021), // Last positive value before subnormal
+        tc64(-0x1.fffffffffffffp-1021, -0x1.fffffffffffffp-1021), // Last negative value before subnormal
+        tc64(-0x1.2b708872320e1p+5,    -0x1.fffffffffffffp-1   ), // Last value before result is -1
+        tc64(-0x1.2b708872320e2p+5,    -1                      ), // First value where result is -1
+        // zig fmt: on
+    };
+    try runTests(cases);
+}

--- a/lib/std/math/test/expm1.zig
+++ b/lib/std/math/test/expm1.zig
@@ -47,7 +47,7 @@ test "math.expm1_32() sanity" {
 }
 
 test "math.expm1_32() special" {
-    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.qnanTests(Tc32);
     try runTests(cases);
 }
 
@@ -90,7 +90,7 @@ test "math.expm1_64() sanity" {
 }
 
 test "math.expm1_64() special" {
-    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.qnanTests(Tc64);
     try runTests(cases);
 }
 

--- a/lib/std/math/test/expm1.zig
+++ b/lib/std/math/test/expm1.zig
@@ -20,11 +20,11 @@ const tc64 = Tc64.init;
 // Special-case tests shared between different float sizes, see genTests().
 const special_tests = .{
     // zig fmt: off
-    .{ 0,         0       },
-    .{-0,         0       },
-    .{ math.ln2,  1       },
-    .{ math.inf,  math.inf},
-    .{ negInf,   -1       },
+    .{ 0.0,       0.0      },
+    .{-0.0,       0.0      },
+    .{ math.ln2,  1.0      },
+    .{ math.inf,  math.inf },
+    .{ negInf,   -1.0      },
     // zig fmt: on
 };
 

--- a/lib/std/math/test/expo2.zig
+++ b/lib/std/math/test/expo2.zig
@@ -1,0 +1,113 @@
+const math = @import("../../math.zig");
+const test_utils = @import("../test.zig");
+const Testcase = test_utils.Testcase;
+const runTests = test_utils.runTests;
+const floatFromBits = test_utils.floatFromBits;
+const negInf = test_utils.negInf;
+const inf32 = math.inf(f32);
+const inf64 = math.inf(f64);
+
+const Tc32 = Testcase(math.expo2, "expo2", f32);
+const tc32 = Tc32.init;
+
+const Tc64 = Testcase(math.expo2, "expo2", f64);
+const tc64 = Tc64.init;
+
+// in -> out
+// [-inf,   0] -> [0,   0.5]
+// [   0, inf] -> [0.5, inf]
+
+// Special-case tests shared between different float sizes, see genTests().
+const special_tests = .{
+    // zig fmt: off
+    .{ 0,        0.5     },
+    .{-0,        0.5     },
+    .{ math.ln2, 1       },
+    .{ math.inf, math.inf},
+    .{ negInf,   0       },
+    // zig fmt: on
+};
+
+test "math.expo2_32() sanity" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32(-0x1.0223a0p+3, 0x1.490320p-13),
+        tc32( 0x1.161868p+2, 0x1.34712ap+5 ),
+        tc32(-0x1.0c34b4p+3, 0x1.e06b1ap-14),
+        tc32(-0x1.a206f0p+2, 0x1.7dd484p-11),
+        tc32( 0x1.288bbcp+3, 0x1.4abc80p+12),
+        tc32( 0x1.52efd0p-1, 0x1.f04a9cp-1 ),
+        tc32(-0x1.a05cc8p-2, 0x1.54f1e0p-2 ),
+        tc32( 0x1.1f9efap-1, 0x1.c0f628p-1 ),
+        tc32( 0x1.8c5db0p-1, 0x1.1599b2p+0 ),
+        tc32(-0x1.5b86eap-1, 0x1.03b572p-2 ),
+        tc32(-0x1.57f25cp+2, 0x1.2fbea2p-9 ),
+        tc32( 0x1.c7d310p+3, 0x1.76eefp+19 ),
+        tc32( 0x1.19be70p+4, 0x1.52d3dep+24),
+        tc32(-0x1.ab6d70p+3, 0x1.a88adep-21),
+        tc32(-0x1.5ac18ep+2, 0x1.22b328p-9 ),
+        tc32(-0x1.925982p-1, 0x1.d2acc0p-3 ),
+        tc32( 0x1.7221cep+3, 0x1.9c2ceap+15),
+        tc32( 0x1.11a0d4p+4, 0x1.980ee6p+23),
+        tc32(-0x1.ae41a2p+1, 0x1.1c28d0p-6 ),
+        tc32(-0x1.329154p+4, 0x1.47ef94p-29),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.expo2_32() special" {
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    try runTests(cases);
+}
+
+test "math.expo2_32() boundary" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        // TODO
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.expo2_64() sanity" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64(-0x1.02239f3c6a8f1p+3, 0x1.490327ea61235p-13),
+        tc64( 0x1.161868e18bc67p+2, 0x1.34712ed238c04p+5 ),
+        tc64(-0x1.0c34b3e01e6e7p+3, 0x1.e06b1b6c18e64p-14),
+        tc64(-0x1.a206f0a19dcc4p+2, 0x1.7dd47f810e68cp-11),
+        tc64( 0x1.288bbb0d6a1e6p+3, 0x1.4abc77496e07ep+12),
+        tc64( 0x1.52efd0cd80497p-1, 0x1.f04a9c1080500p-1 ),
+        tc64(-0x1.a05cc754481d1p-2, 0x1.54f1e0fd3ea0dp-2 ),
+        tc64( 0x1.1f9ef934745cbp-1, 0x1.c0f6266a6a547p-1 ),
+        tc64( 0x1.8c5db097f7442p-1, 0x1.1599b1d4a25fbp+0 ),
+        tc64(-0x1.5b86ea8118a0ep-1, 0x1.03b5728a00229p-2 ),
+        tc64(-0x1.57f25b2b5006dp+2, 0x1.2fbea6a01cab9p-9 ),
+        tc64( 0x1.c7d30fb825911p+3, 0x1.76eeed45a0634p+19),
+        tc64( 0x1.19be709de7505p+4, 0x1.52d3eb7be6844p+24),
+        tc64(-0x1.ab6d6fba96889p+3, 0x1.a88ae12f985d6p-21),
+        tc64(-0x1.5ac18e27084ddp+2, 0x1.22b327da9cca6p-9 ),
+        tc64(-0x1.925981b093c41p-1, 0x1.d2acc046b55f7p-3 ),
+        tc64( 0x1.7221cd18455f5p+3, 0x1.9c2cde8699cfbp+15),
+        tc64( 0x1.11a0d4a51b239p+4, 0x1.980ef612ff182p+23),
+        tc64(-0x1.ae41a1079de4dp+1, 0x1.1c28d16bb3222p-6 ),
+        tc64(-0x1.329153103b871p+4, 0x1.47efa6ddd0d22p-29),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.expo2_64() special" {
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    try runTests(cases);
+}
+
+test "math.expo2_64() boundary" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        // TODO
+        // zig fmt: on
+    };
+    try runTests(cases);
+}

--- a/lib/std/math/test/expo2.zig
+++ b/lib/std/math/test/expo2.zig
@@ -57,7 +57,7 @@ test "math.expo2_32() sanity" {
 }
 
 test "math.expo2_32() special" {
-    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.qnanTests(Tc32);
     try runTests(cases);
 }
 
@@ -99,7 +99,7 @@ test "math.expo2_64() sanity" {
 }
 
 test "math.expo2_64() special" {
-    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.qnanTests(Tc64);
     try runTests(cases);
 }
 

--- a/lib/std/math/test/log1p.zig
+++ b/lib/std/math/test/log1p.zig
@@ -1,0 +1,108 @@
+const math = @import("../../math.zig");
+const test_utils = @import("../test.zig");
+const Testcase = test_utils.Testcase;
+const runTests = test_utils.runTests;
+const floatFromBits = test_utils.floatFromBits;
+const negInf = test_utils.negInf;
+const nan32 = math.nan_f32;
+const nan64 = math.nan_f64;
+
+const Tc32 = Testcase(math.log1p, "log1p", f32);
+const tc32 = Tc32.init;
+
+const Tc64 = Testcase(math.log1p, "log1p", f64);
+const tc64 = Tc64.init;
+
+// in -> out
+// [-inf,  -1) -> nan
+// [  -1,  -0] -> [-inf,  -0]
+// [  +0, inf] -> [  +0, inf]
+
+// Special-case tests shared between different float sizes, see genTests().
+const special_tests = .{
+    // zig fmt: off
+    .{ 0,         0       },
+    .{-0,        -0       },
+    .{-1,         negInf  },
+    .{ 1,         math.ln2},
+    .{-2,         math.nan},
+    .{ math.inf,  math.inf},
+    .{ negInf,    math.nan},
+    // zig fmt: on
+};
+
+test "math.log1p_32() sanity" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32(-0x1.0223a0p+3,  nan32        ),
+        tc32( 0x1.161868p+2,  0x1.ad1bdcp+0),
+        tc32(-0x1.0c34b4p+3,  nan32        ),
+        tc32(-0x1.a206f0p+2,  nan32        ),
+        tc32( 0x1.288bbcp+3,  0x1.2a1ab8p+1),
+        tc32( 0x1.52efd0p-1,  0x1.041a4ep-1),
+        tc32(-0x1.a05cc8p-2, -0x1.0b3596p-1),
+        tc32( 0x1.1f9efap-1,  0x1.c88344p-2),
+        tc32( 0x1.8c5db0p-1,  0x1.258a8ep-1),
+        tc32(-0x1.5b86eap-1, -0x1.22b542p+0),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log1p_32() special" {
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    try runTests(cases);
+}
+
+test "math.log1p_32() boundary" {
+    const cases = [_]Tc32{
+        // zig fmt: off
+        tc32( 0x1.fffffep+127,  0x1.62e430p+6), // Max input value
+        tc32( 0x1p-149,         0x1p-149     ), // Min positive input value
+        tc32(-0x1p-149,        -0x1p-149     ), // Min negative input value
+        tc32( 0x1p-126,         0x1p-126     ), // First subnormal
+        tc32(-0x1p-126,        -0x1p-126     ), // First negative subnormal
+        tc32(-0x1.fffffep-1,   -0x1.0a2b24p+4), // Last value before result is -inf
+        tc32(-0x1.000002p+0,    nan32        ), // First value where result is nan
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log1p_64() sanity" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64(-0x1.02239f3c6a8f1p+3,  nan64               ),
+        tc64( 0x1.161868e18bc67p+2,  0x1.ad1bdd1e9e686p+0), // Disagrees with GCC in last bit
+        tc64(-0x1.0c34b3e01e6e7p+3,  nan64               ),
+        tc64(-0x1.a206f0a19dcc4p+2,  nan64               ),
+        tc64( 0x1.288bbb0d6a1e6p+3,  0x1.2a1ab8365b56fp+1),
+        tc64( 0x1.52efd0cd80497p-1,  0x1.041a4ec2a680ap-1),
+        tc64(-0x1.a05cc754481d1p-2, -0x1.0b3595423aec1p-1),
+        tc64( 0x1.1f9ef934745cbp-1,  0x1.c8834348a846ep-2),
+        tc64( 0x1.8c5db097f7442p-1,  0x1.258a8e8a35bbfp-1),
+        tc64(-0x1.5b86ea8118a0ep-1, -0x1.22b5426327502p+0),
+        // zig fmt: on
+    };
+    try runTests(cases);
+}
+
+test "math.log1p_64() special" {
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    try runTests(cases);
+}
+
+test "math.log1p_64() boundary" {
+    const cases = [_]Tc64{
+        // zig fmt: off
+        tc64( 0x1.fffffffffffffp+1023,  0x1.62e42fefa39efp+9), // Max input value
+        tc64( 0x1p-1074,                0x1p-1074           ), // Min positive input value
+        tc64(-0x1p-1074,               -0x1p-1074           ), // Min negative input value
+        tc64( 0x1p-1022,                0x1p-1022           ), // First subnormal
+        tc64(-0x1p-1022,               -0x1p-1022           ), // First negative subnormal
+        tc64(-0x1.fffffffffffffp-1,    -0x1.25e4f7b2737fap+5), // Last value before result is -inf
+        tc64(-0x1.0000000000001p+0,     nan64               ), // First value where result is nan
+        // zig fmt: on
+    };
+    try runTests(cases);
+}

--- a/lib/std/math/test/log1p.zig
+++ b/lib/std/math/test/log1p.zig
@@ -4,8 +4,8 @@ const Testcase = test_utils.Testcase;
 const runTests = test_utils.runTests;
 const floatFromBits = test_utils.floatFromBits;
 const negInf = test_utils.negInf;
-const nan32 = math.nan_f32;
-const nan64 = math.nan_f64;
+const nan32 = math.nan(f32);
+const nan64 = math.nan(f64);
 
 const Tc32 = Testcase(math.log1p, "log1p", f32);
 const tc32 = Tc32.init;
@@ -50,7 +50,7 @@ test "math.log1p_32() sanity" {
 }
 
 test "math.log1p_32() special" {
-    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.nanTests(Tc32);
+    const cases = comptime test_utils.genTests(Tc32, special_tests) ++ test_utils.qnanTests(Tc32);
     try runTests(cases);
 }
 
@@ -88,7 +88,7 @@ test "math.log1p_64() sanity" {
 }
 
 test "math.log1p_64() special" {
-    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.nanTests(Tc64);
+    const cases = comptime test_utils.genTests(Tc64, special_tests) ++ test_utils.qnanTests(Tc64);
     try runTests(cases);
 }
 

--- a/lib/std/math/test/log1p.zig
+++ b/lib/std/math/test/log1p.zig
@@ -21,13 +21,13 @@ const tc64 = Tc64.init;
 // Special-case tests shared between different float sizes, see genTests().
 const special_tests = .{
     // zig fmt: off
-    .{ 0,         0       },
-    .{-0,        -0       },
-    .{-1,         negInf  },
-    .{ 1,         math.ln2},
-    .{-2,         math.nan},
-    .{ math.inf,  math.inf},
-    .{ negInf,    math.nan},
+    .{ 0.0,         0.0     },
+    .{-0.0,        -0.0     },
+    .{-1.0,         negInf  },
+    .{ 1.0,         math.ln2},
+    .{-2.0,         math.nan},
+    .{ math.inf,    math.inf},
+    .{ negInf,      math.nan},
     // zig fmt: on
 };
 


### PR DESCRIPTION
New PR following bad merge on https://github.com/ziglang/zig/pull/16225 (previously reviving https://github.com/ziglang/zig/pull/13311, https://github.com/ziglang/zig/pull/12355 and https://github.com/ziglang/zig/pull/10415!).

- Add test framework (at `lib/std/math/test.zig`) for maths functions that take in a float and output a float of the same type, e.g. `exp()`
- Create tests for all exp/log functions under `lib/std/math/test/` and `lib/compiler_rt/test/` (alongside implementations under test)
  - Sanity tests, taken from [libc-test](https://wiki.musl-libc.org/libc-test.html) (e.g. [exp.h](http://nsz.repo.hu/git/?p=libc-test;a=blob;f=src/math/sanity/exp.h;h=7cbdfcae8770955be175e824e92e535fabae4430;hb=HEAD))
  - Special cases (inf, nan, 0, ...)
  - Boundary cases (last value before inf, first subnormal, ...)
- Remove special case tests from function implementation modules to avoid duplication (leave the basic tests intact)
- Bugfixes uncovered by improved testing:
  - `exp2_32()` flushing to zero too soon
  - `expm1_32()` giving incorrect results for a certain range of small negative inputs
  - `ln64()` giving incorrect results for positive subnormal inputs
  - Some functions returning canonical NaN instead of passing through input NaNs unchanged (as per Musl and GCC)
  - `log10_64()` returning 32-bit inf and NaN, which would be fine as it's cast up, except casting NaN results in failure to pass through the input unchanged

Need resolving:
- [ ] Allow compiler-rt to access the maths test utils without exposing it from the std package available to all users (see https://github.com/ziglang/zig/pull/16808/files#r1292880458 and the following paragraphs)
- [X] Merge https://github.com/ziglang/zig/pull/16826 and rebase, to remove use of signalling NaNs

Some history/context:
- When I originally wrote these tests all the code under test was in `lib/std/math/`, so it made sense for the test infra to live there too (it was suggested to me to use `lib/std/math/test.zig` and `lib/std/math/test/`).
- Some of the code under test now lives in `lib/compiler_rt/`, with the functions in `lib/std/math/` only falling back to the `compiler_rt` code *sometimes* (depending on the target, I'm not clear exactly when).
- We still want the tests to live alongside the code under test, i.e. some tests in `lib/std/math/` and others in `lib/compiler_rt/`.
- The test infra in `lib/std/math/test.zig` is still relevant across all of these tests.

The one remaining problem is I don't know how to share this test infra between `lib/compiler_rt/` and `lib/std/math/`... Currently I have exposed `lib/std/math/test.zig` as `std.math.test_utils`, but I don't think this is desirable! If I try to import the file directly from tests in `lib/compiler_rt/test/` with `@import("../../std/math/test.zig");` then I get the compiler error "error: file exists in multiple modules" :( If it can't be shared between `std.math` tests and `compiler_rt` tests without exposing it to users, perhaps it should be moved to somewhere like `lib/testing/`?

Example output with 'log_level = .info' for debugging (failing test uncommented for illustration):
```
$./zig test lib/compiler_rt.zig --test-filter "math.exp64() special"
Test [31/31] test.math.exp64() special... [default] (info):
[default] (info):  IN:  0x0000000000000000  0x0.0p0                   0.0e+00
[default] (info): OUT:  0x3FF0000000000000  0x1p0                     1.0e+00
[default] (info):
[default] (info):  IN:  0x0000000000000000  0x0.0p0                   0.0e+00
[default] (info): OUT:  0x3FF0000000000000  0x1p0                     1.0e+00
[default] (info):
[default] (info):  IN:  0x3FF0000000000000  0x1p0                     1.0e+00
[default] (info): OUT:  0x4005BF0A8B14576A  0x1.5bf0a8b14576ap1       2.7182818284590455e+00
[default] (info): EXP:  0x4005BF0A8B145769  0x1.5bf0a8b145769p1       2.718281828459045e+00
FAILURE: expected exp(0x1p0)->0x1.5bf0a8b145769p1, got 0x1.5bf0a8b14576ap1 (64-bit)
         expected exp(0x3FF0000000000000)->0x4005BF0A8B145769, got 0x4005BF0A8B14576A
[default] (info):
[default] (info):  IN:  0x3FE62E42FEFA39EF  0x1.62e42fefa39efp-1      6.931471805599453e-01
[default] (info): OUT:  0x4000000000000000  0x1p1                     2.0e+00
[default] (info):
[default] (info):  IN:  0x7FF0000000000000  inf                       inf
[default] (info): OUT:  0x7FF0000000000000  inf                       inf
[default] (info):
[default] (info):  IN:  0xFFF0000000000000  -inf                      -inf
[default] (info): OUT:  0x0000000000000000  0x0.0p0                   0.0e+00
[default] (info):
[default] (info):  IN:  0x7FF0000000000001  nan                       nan
[default] (info): OUT:  0x7FF0000000000001  nan                       nan
[default] (info):
[default] (info):  IN:  0xFFF0000000000001  -nan                      -nan
[default] (info): OUT:  0xFFF0000000000001  -nan                      -nan
[default] (info):
[default] (info):  IN:  0x7FF0123400000000  nan                       nan
[default] (info): OUT:  0x7FF0123400000000  nan                       nan
[default] (info):
[default] (info):  IN:  0xFFF0123400000000  -nan                      -nan
[default] (info): OUT:  0xFFF0123400000000  -nan                      -nan
[default] (info):
[default] (info): Subtest summary: 9 passed; 1 failed
Test [31/31] test.math.exp64() special... FAIL (Failure)
/mnt/c/Users/legaul/repos/zig/lib/std/math/test.zig:114:23: 0x2448bc in runTests__anon_8139 (test)
    if (failures > 0) return error.Failure;
                      ^
/mnt/c/Users/legaul/repos/zig/lib/compiler_rt/test/exp.zig:116:5: 0x24492b in test.math.exp64() special (test)
    try runTests(cases);
    ^
30 passed; 0 skipped; 1 failed.
error: the following test command failed with exit code 1:
/mnt/c/Users/legaul/repos/zig/zig-cache/o/53dd19fa852e86f59f08ef2154127c98/test
```

---

Previous suggestions from @matu3ba that I'm considering out of scope of this PR:

- Adding tests for all extreme values (e.g. +/- inf) rather than targeted boundary cases (see https://github.com/ziglang/zig/pull/10415#discussion_r775308449)

- Taking on all Musl tests
> 2 ideas for discussion
> 
> 1. port [libc-test](https://wiki.musl-libc.org/libc-test.html) to zig
> 
> * 1.1. Port the test running functions from [libc-test](https://wiki.musl-libc.org/libc-test.html), which is the test library of musl.
> * 1.2. Use scripts to generate the test code from the musl test macros.
> * more code to write, but less dependency on C/clang
> * caveat, but actually a feature: Include the comments in the generated test code.
> 
> 2. vendor [libc-test](https://wiki.musl-libc.org/libc-test.html)
> 
> * 2.1 use zig stubs for the build scripts and test calls
> * less code to write, but more dependency on C/clang