### PR TITLE
dwarf: add missing length check in rowColumns

### DIFF
--- a/lib/std/dwarf/call_frame.zig
+++ b/lib/std/dwarf/call_frame.zig
@@ -452,6 +452,7 @@ pub const VirtualMachine = struct {
 
     /// Return a slice backed by the row's non-CFA columns
     pub fn rowColumns(self: VirtualMachine, row: Row) []Column {
+        if (row.columns.len == 0) return &.{};
         return self.columns.items[row.columns.start..][0..row.columns.len];
     }
 


### PR DESCRIPTION
Thanks to @jacobly0 for finding this one!

main.zig:
```
pub fn main() void { @trap(); }
```

Before:
```
$ zig run main.zig -ofmt=c
Illegal instruction at address 0x21a694
/home/kcbanner/.cache/zig/o/f2420382f0eadd063c1653d1468fdd5d/main.c:6998:2: 0x21a694 in main_main__147 (/home/kcbanner/.cache/zig/o/f2420382f0eadd063c1653d1468fdd5d/main.c)
 zig_trap();
 ^
Panicked during a panic. Aborting.
Aborted
```

After:
```
$ zig run main.zig -ofmt=c
Illegal instruction at address 0x21a674
/home/kcbanner/.cache/zig/o/f2420382f0eadd063c1653d1468fdd5d/main.c:6998:2: 0x21a674 in main_main__147 (/home/kcbanner/.cache/zig/o/f2420382f0eadd063c1653d1468fdd5d/main.c)
 zig_trap();
 ^
/home/kcbanner/.cache/zig/o/f2420382f0eadd063c1653d1468fdd5d/main.c:6558:2: 0x218eb3 in start_posixCallMainAndExit__133 (/home/kcbanner/.cache/zig/o/f2420382f0eadd063c1653d1468fdd5d/main.c)
 main_main__147();
 ^
/home/kcbanner/.cache/zig/o/f2420382f0eadd063c1653d1468fdd5d/main.c:6226:2: 0x217f31 in _start (/home/kcbanner/.cache/zig/o/f2420382f0eadd063c1653d1468fdd5d/main.c)
 __asm volatile(" xorl %%ebp, %%ebp\n movq %%rsp, %[argc_argv_ptr]\n andq $-16, %%rsp\n callq %P[posixCallMainAndExit]": [argc_argv_ptr]"=m"((*&start_argc_argv_ptr__115)): [posixCallMainAndExit]"X"(&start_posixCallMainAndExit__133):);
 ^
???:?:?: 0x0 in ??? (???)
Aborted
```

The code wasn't crashing with the llvm backend because `start` happened to be 0. The CBE preserved the undefined value and triggered the overflow.

The fix was to add a length check.

