### PR TITLE
add KillError.NoSuchProcess

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -629,14 +629,14 @@ pub fn raise(sig: u8) RaiseError!void {
     @compileError("std.os.raise unimplemented for this target");
 }
 
-pub const KillError = error{PermissionDenied} || UnexpectedError;
+pub const KillError = error{ PermissionDenied, NoSuchProcess } || UnexpectedError;
 
 pub fn kill(pid: pid_t, sig: u8) KillError!void {
     switch (errno(system.kill(pid, sig))) {
         .SUCCESS => return,
         .INVAL => unreachable, // invalid signal
         .PERM => return error.PermissionDenied,
-        .SRCH => unreachable, // always a race condition
+        .SRCH => return error.NoSuchProcess, // always a race condition
         else => |err| return unexpectedErrno(err),
     }
 }


### PR DESCRIPTION
### WHAT

Adds `NoSuchProcess` to the `KillError` error set in `std.os.kill`, and returns that error when `errno` is set `ESRCH`.

### WHY

Returning this error from `os.kill` is useful for determining if a process id is valid. 
```bash
# https://pubs.opengroup.org/onlinepubs/9699919799/
If sig is 0 (the null signal), error checking is performed but no signal is actually sent.
The null signal can be used to check the validity of pid.
```
This facilitates a nice set of features in binaries that are meant to be executed as a daemon or background process. You can cache the daemon's pid to some type of storage at start up, and  implement conditional branching with something such as cli arguments. A new process wants conditionally execute depending on a daemon's current state. i.e. (`start`, `stop`, `restart`, `status` ...) The process can then reach out to the storage location and pull up a pid of a potentially running daemon process and check with the operating system if that pid is still in use. Sending out signals is an asynchronous operation so super tight coordination is not reliable, however, this makes for a relatively simple low frequency heartbeat mechanism that can come in really handy.

### HOW
```zig
const std = @import("std");
const os = std.os;
const debug = std.debug;

const s_fmt = "{s:<18} : {s}\n";
const d_fmt = "{s:<18} : {d}\n";
const p_fmt = "pid({d}) exists : {any}\n";

// https://pubs.opengroup.org/onlinepubs/9699919799/
// If sig is 0 (the null signal), error checking is performed but no signal is actually sent. 
// The null signal can be used to check the validity of pid. 
fn pokeProcess(pid: os.pid_t) bool {
    if (os.kill(pid, 0)) |_| {
        return true;
    } else |err| {
        // this is just to demostrate that the error makes it back clearly the 
        // implementation needs to isolate os.KillError.NoSuchProcess to verify
        // that this error was spawned from that errno
        debug.print(s_fmt, .{ "error type", @errorName(err) });
        return false;
    }
}   

test "os_kill_no_process" {
    const pid = os.linux.getpid();
    debug.print("\n", .{});
    debug.print(p_fmt, .{ pid, pokeProcess(pid) });

    if (os.fork()) |c_pid| {
        if (os.linux.getpid() == pid) {
            debug.print(d_fmt, .{ "c_pid", c_pid });
            os.exit(0); // parent process early exit
        } else {
            debug.print(d_fmt, .{ "pid", pid });
        }
    } else |err| {
        debug.print("{s}\n", .{@errorName(err)});
        os.exit(1);
    }
    // because of asynchronistic nature of singals 
    // wait for os to fully clean up parent process
    std.time.sleep(10000);
    debug.print(d_fmt, .{ "killing pid", pid });

    debug.print(p_fmt, .{ pid, pokeProcess(pid) });
    os.exit(0);
}
```