### PR TITLE
build: do not emit `-iwithsysroot`/`-iframeworkwithsysroot` implicitly

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -128,8 +128,8 @@ pub fn build(b: *std.Build) !void {
         "llvm-has-xtensa",
         "Whether LLVM has the experimental target xtensa enabled",
     ) orelse false;
-    const enable_macos_sdk = b.option(bool, "enable-macos-sdk", "Run tests requiring presence of macOS SDK and frameworks") orelse false;
     const enable_ios_sdk = b.option(bool, "enable-ios-sdk", "Run tests requiring presence of iOS SDK and frameworks") orelse false;
+    const enable_macos_sdk = b.option(bool, "enable-macos-sdk", "Run tests requiring presence of macOS SDK and frameworks") orelse enable_ios_sdk;
     const enable_symlinks_windows = b.option(bool, "enable-symlinks-windows", "Run tests requiring presence of symlinks on Windows") orelse false;
     const config_h_path_option = b.option([]const u8, "config_h", "Path to the generated config.h");
 

--- a/build.zig
+++ b/build.zig
@@ -129,6 +129,7 @@ pub fn build(b: *std.Build) !void {
         "Whether LLVM has the experimental target xtensa enabled",
     ) orelse false;
     const enable_macos_sdk = b.option(bool, "enable-macos-sdk", "Run tests requiring presence of macOS SDK and frameworks") orelse false;
+    const enable_ios_sdk = b.option(bool, "enable-ios-sdk", "Run tests requiring presence of iOS SDK and frameworks") orelse false;
     const enable_symlinks_windows = b.option(bool, "enable-symlinks-windows", "Run tests requiring presence of symlinks on Windows") orelse false;
     const config_h_path_option = b.option([]const u8, "config_h", "Path to the generated config.h");
 
@@ -485,11 +486,12 @@ pub fn build(b: *std.Build) !void {
         b,
         optimization_modes,
         enable_macos_sdk,
+        enable_ios_sdk,
         false,
         enable_symlinks_windows,
     ));
     test_step.dependOn(tests.addCAbiTests(b, skip_non_native, skip_release));
-    test_step.dependOn(tests.addLinkTests(b, enable_macos_sdk, false, enable_symlinks_windows));
+    test_step.dependOn(tests.addLinkTests(b, enable_macos_sdk, enable_ios_sdk, false, enable_symlinks_windows));
     test_step.dependOn(tests.addStackTraceTests(b, test_filter, optimization_modes));
     test_step.dependOn(tests.addCliTests(b));
     test_step.dependOn(tests.addAssembleAndLinkTests(b, test_filter, optimization_modes));

--- a/lib/std/Build/Step/CheckObject.zig
+++ b/lib/std/Build/Step/CheckObject.zig
@@ -766,6 +766,60 @@ const MachODumper = struct {
                 });
             },
 
+            .BUILD_VERSION => {
+                const blc = lc.cast(macho.build_version_command).?;
+                try writer.writeByte('\n');
+                try writer.print(
+                    \\platform {s}
+                    \\minos {d}.{d}.{d}
+                    \\sdk {d}.{d}.{d}
+                    \\ntools {d}
+                , .{
+                    @tagName(blc.platform),
+                    blc.minos >> 16,
+                    @as(u8, @truncate(blc.minos >> 8)),
+                    @as(u8, @truncate(blc.minos)),
+                    blc.sdk >> 16,
+                    @as(u8, @truncate(blc.sdk >> 8)),
+                    @as(u8, @truncate(blc.sdk)),
+                    blc.ntools,
+                });
+                for (lc.getBuildVersionTools()) |tool| {
+                    try writer.writeByte('\n');
+                    switch (tool.tool) {
+                        .CLANG, .SWIFT, .LD, .LLD, .ZIG => try writer.print("tool {s}\n", .{@tagName(tool.tool)}),
+                        else => |x| try writer.print("tool {d}\n", .{@intFromEnum(x)}),
+                    }
+                    try writer.print(
+                        \\version {d}.{d}.{d}
+                    , .{
+                        tool.version >> 16,
+                        @as(u8, @truncate(tool.version >> 8)),
+                        @as(u8, @truncate(tool.version)),
+                    });
+                }
+            },
+
+            .VERSION_MIN_MACOSX,
+            .VERSION_MIN_IPHONEOS,
+            .VERSION_MIN_WATCHOS,
+            .VERSION_MIN_TVOS,
+            => {
+                const vlc = lc.cast(macho.version_min_command).?;
+                try writer.writeByte('\n');
+                try writer.print(
+                    \\version {d}.{d}.{d}
+                    \\sdk {d}.{d}.{d}
+                , .{
+                    vlc.version >> 16,
+                    @as(u8, @truncate(vlc.version >> 8)),
+                    @as(u8, @truncate(vlc.version)),
+                    vlc.sdk >> 16,
+                    @as(u8, @truncate(vlc.sdk >> 8)),
+                    @as(u8, @truncate(vlc.sdk)),
+                });
+            },
+
             else => {},
         }
     }

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1829,11 +1829,8 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     }
 
     for (self.framework_dirs.items) |directory_source| {
-        const path = directory_source.getPath(b);
-        try zig_args.append("-iframework");
-        try zig_args.append(path);
         try zig_args.append("-F");
-        try zig_args.append(path);
+        try zig_args.append(directory_source.getPath2(b, step));
     }
 
     {

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -1898,6 +1898,16 @@ pub const LoadCommandIterator = struct {
             const data = lc.data[rpath_lc.path..];
             return mem.sliceTo(data, 0);
         }
+
+        /// Asserts LoadCommand is of type build_version_command.
+        pub fn getBuildVersionTools(lc: LoadCommand) []const build_tool_version {
+            const build_lc = lc.cast(build_version_command).?;
+            const ntools = build_lc.ntools;
+            if (ntools == 0) return &[0]build_tool_version{};
+            const data = lc.data[@sizeOf(build_version_command)..];
+            const tools = @as([*]const build_tool_version, @ptrCast(@alignCast(&data[0])))[0..ntools];
+            return tools;
+        }
     };
 
     pub fn next(it: *LoadCommandIterator) ?LoadCommand {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1156,12 +1156,16 @@ fn buildOutputType(
                         try clang_argv.append(args_iter.nextOrFatal());
                     } else if (mem.eql(u8, arg, "-I")) {
                         try cssan.addIncludePath(.I, arg, args_iter.nextOrFatal(), false);
-                    } else if (mem.eql(u8, arg, "-isystem") or mem.eql(u8, arg, "-iwithsysroot")) {
+                    } else if (mem.eql(u8, arg, "-isystem")) {
                         try cssan.addIncludePath(.isystem, arg, args_iter.nextOrFatal(), false);
+                    } else if (mem.eql(u8, arg, "-iwithsysroot")) {
+                        try cssan.addIncludePath(.iwithsysroot, arg, args_iter.nextOrFatal(), false);
                     } else if (mem.eql(u8, arg, "-idirafter")) {
                         try cssan.addIncludePath(.idirafter, arg, args_iter.nextOrFatal(), false);
-                    } else if (mem.eql(u8, arg, "-iframework") or mem.eql(u8, arg, "-iframeworkwithsysroot")) {
+                    } else if (mem.eql(u8, arg, "-iframework")) {
                         try cssan.addIncludePath(.iframework, arg, args_iter.nextOrFatal(), false);
+                    } else if (mem.eql(u8, arg, "-iframeworkwithsysroot")) {
+                        try cssan.addIncludePath(.iframeworkwithsysroot, arg, args_iter.nextOrFatal(), false);
                     } else if (mem.eql(u8, arg, "--version")) {
                         const next_arg = args_iter.nextOrFatal();
                         version = std.SemanticVersion.parse(next_arg) catch |err| {
@@ -6191,6 +6195,11 @@ const ClangSearchSanitizer = struct {
                 if (m.idirafter) std.log.warn(wtxt, .{ dir, "isystem", "idirafter" });
                 if (m.iframework) std.log.warn(wtxt, .{ dir, "isystem", "iframework" });
             },
+            .iwithsysroot => {
+                if (m.iwithsysroot) return;
+                m.iwithsysroot = true;
+                if (m.iframeworkwithsysroot) std.log.warn(wtxt, .{ dir, "iwithsysroot", "iframeworkwithsysroot" });
+            },
             .idirafter => {
                 if (m.idirafter) return;
                 m.idirafter = true;
@@ -6205,18 +6214,25 @@ const ClangSearchSanitizer = struct {
                 if (m.isystem) std.log.warn(wtxt, .{ dir, "iframework", "isystem" });
                 if (m.idirafter) std.log.warn(wtxt, .{ dir, "iframework", "idirafter" });
             },
+            .iframeworkwithsysroot => {
+                if (m.iframeworkwithsysroot) return;
+                m.iframeworkwithsysroot = true;
+                if (m.iwithsysroot) std.log.warn(wtxt, .{ dir, "iframeworkwithsysroot", "iwithsysroot" });
+            },
         }
         try self.argv.append(arg);
         if (!joined) try self.argv.append(dir);
     }
 
-    const Group = enum { I, isystem, idirafter, iframework };
+    const Group = enum { I, isystem, iwithsysroot, idirafter, iframework, iframeworkwithsysroot };
 
     const Membership = packed struct {
         I: bool = false,
         isystem: bool = false,
+        iwithsysroot: bool = false,
         idirafter: bool = false,
         iframework: bool = false,
+        iframeworkwithsysroot: bool = false,
     };
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1163,9 +1163,13 @@ fn buildOutputType(
                     } else if (mem.eql(u8, arg, "-idirafter")) {
                         try cssan.addIncludePath(.idirafter, arg, args_iter.nextOrFatal(), false);
                     } else if (mem.eql(u8, arg, "-iframework")) {
-                        try cssan.addIncludePath(.iframework, arg, args_iter.nextOrFatal(), false);
+                        const path = args_iter.nextOrFatal();
+                        try cssan.addIncludePath(.iframework, arg, path, false);
+                        try framework_dirs.append(path); // Forward to the backend as -F
                     } else if (mem.eql(u8, arg, "-iframeworkwithsysroot")) {
-                        try cssan.addIncludePath(.iframeworkwithsysroot, arg, args_iter.nextOrFatal(), false);
+                        const path = args_iter.nextOrFatal();
+                        try cssan.addIncludePath(.iframeworkwithsysroot, arg, path, false);
+                        try framework_dirs.append(path); // Forward to the backend as -F
                     } else if (mem.eql(u8, arg, "--version")) {
                         const next_arg = args_iter.nextOrFatal();
                         version = std.SemanticVersion.parse(next_arg) catch |err| {

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -245,6 +245,10 @@ pub const build_cases = [_]BuildCase{
         .build_root = "test/standalone/compiler_rt_panic",
         .import = @import("standalone/compiler_rt_panic/build.zig"),
     },
+    .{
+        .build_root = "test/standalone/ios",
+        .import = @import("standalone/ios/build.zig"),
+    },
 };
 
 const std = @import("std");

--- a/test/standalone/ios/build.zig
+++ b/test/standalone/ios/build.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+pub const requires_symlinks = true;
+pub const requires_ios_sdk = true;
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    const optimize: std.builtin.OptimizeMode = .Debug;
+    const target: std.zig.CrossTarget = .{
+        .cpu_arch = .aarch64,
+        .os_tag = .ios,
+    };
+    const target_info = std.zig.system.NativeTargetInfo.detect(target) catch @panic("couldn't detect native target");
+    const sdk = std.zig.system.darwin.getSdk(b.allocator, target_info.target) orelse @panic("no iOS SDK found");
+    b.sysroot = sdk.path;
+
+    const exe = b.addExecutable(.{
+        .name = "main",
+        .optimize = optimize,
+        .target = target,
+    });
+    exe.addCSourceFile(.{ .file = .{ .path = "main.m" }, .flags = &.{} });
+    exe.addSystemIncludePath(.{ .path = b.pathJoin(&.{ sdk.path, "/usr/include" }) });
+    exe.addSystemFrameworkPath(.{ .path = b.pathJoin(&.{ sdk.path, "/System/Library/Frameworks" }) });
+    exe.addLibraryPath(.{ .path = b.pathJoin(&.{ sdk.path, "/usr/lib" }) });
+    exe.linkFramework("Foundation");
+    exe.linkFramework("UIKit");
+    exe.linkLibC();
+
+    const check = exe.checkObject();
+    check.checkStart();
+    check.checkExact("cmd BUILD_VERSION");
+    check.checkExact("platform IOS");
+    test_step.dependOn(&check.step);
+}

--- a/test/standalone/ios/main.m
+++ b/test/standalone/ios/main.m
@@ -1,0 +1,34 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@property (strong, nonatomic) UIWindow *window;
+@end
+
+int main() {
+  @autoreleasepool {
+    return UIApplicationMain(0, nil, nil, NSStringFromClass([AppDelegate class]));
+  }
+}
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(id)options {
+  CGRect mainScreenBounds = [[UIScreen mainScreen] bounds];
+  self.window = [[UIWindow alloc] initWithFrame:mainScreenBounds];
+  UIViewController *viewController = [[UIViewController alloc] init];
+  viewController.view.frame = mainScreenBounds;
+
+  NSString* msg = @"Hello world";
+
+  UILabel *label = [[UILabel alloc] initWithFrame:mainScreenBounds];
+  [label setText:msg];
+  [viewController.view addSubview: label];
+
+  self.window.rootViewController = viewController;
+
+  [self.window makeKeyAndVisible];
+
+  return YES;
+}
+
+@end

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -566,6 +566,7 @@ pub fn addStandaloneTests(
     b: *std.Build,
     optimize_modes: []const OptimizeMode,
     enable_macos_sdk: bool,
+    enable_ios_sdk: bool,
     omit_stage2: bool,
     enable_symlinks_windows: bool,
 ) *Step {
@@ -615,10 +616,13 @@ pub fn addStandaloneTests(
             case.import.requires_symlinks;
         const requires_macos_sdk = @hasDecl(case.import, "requires_macos_sdk") and
             case.import.requires_macos_sdk;
+        const requires_ios_sdk = @hasDecl(case.import, "requires_ios_sdk") and
+            case.import.requires_ios_sdk;
         const bad =
             (requires_stage2 and omit_stage2) or
             (requires_symlinks and omit_symlinks) or
-            (requires_macos_sdk and !enable_macos_sdk);
+            (requires_macos_sdk and !enable_macos_sdk) or
+            (requires_ios_sdk and !enable_ios_sdk);
         if (!bad) {
             const dep = b.anonymousDependency(case.build_root, case.import, .{});
             const dep_step = dep.builder.default_step;
@@ -635,6 +639,7 @@ pub fn addStandaloneTests(
 pub fn addLinkTests(
     b: *std.Build,
     enable_macos_sdk: bool,
+    enable_ios_sdk: bool,
     omit_stage2: bool,
     enable_symlinks_windows: bool,
 ) *Step {
@@ -648,10 +653,13 @@ pub fn addLinkTests(
             case.import.requires_symlinks;
         const requires_macos_sdk = @hasDecl(case.import, "requires_macos_sdk") and
             case.import.requires_macos_sdk;
+        const requires_ios_sdk = @hasDecl(case.import, "requires_ios_sdk") and
+            case.import.requires_ios_sdk;
         const bad =
             (requires_stage2 and omit_stage2) or
             (requires_symlinks and omit_symlinks) or
-            (requires_macos_sdk and !enable_macos_sdk);
+            (requires_macos_sdk and !enable_macos_sdk) or
+            (requires_ios_sdk and !enable_ios_sdk);
         if (!bad) {
             const dep = b.anonymousDependency(case.build_root, case.import, .{});
             const dep_step = dep.builder.default_step;


### PR DESCRIPTION
Prior to this change, we would unconditionally emit any system include path/framework path as `-iwithsysroot`/`-iframeworkwithsysroot` if the sysroot was set which can lead to unexpected build failures. Now, calls to `b.addSystemIncludePath` and `b.addFrameworkPath` will always emit search paths as `-isystem`/`-iframework`. As a result, it is now up to the user to correctly concat the search paths with the sysroot when and where desired.

If there is a need for emitting `-iwithsysroot`/`-iframeworkwithsysroot` I would advise adding explicit hooks such as `addSystemIncludePathWithSysroot` and `addFrameworkPathWithSysroot`.

While at it, disambiguate includes with sysroot in `ClangSearchSanitizer`. This noninvasive change improves warning messages for mixing up paths between `-iwithsysroot` and `-iframeworkwithsysroot`.