### PR TITLE
de-bitrot the BSDs

### DIFF
--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -34,6 +34,10 @@ pub const pthread_attr_t = extern struct { // copied from freebsd
     __align: c_long,
 };
 
+pub const pthread_rwlock_t = extern struct {
+    ptr: ?*anyopaque = null,
+};
+
 pub const sem_t = ?*opaque {};
 
 pub extern "c" fn pthread_setname_np(thread: std.c.pthread_t, name: [*:0]const u8) E;
@@ -54,6 +58,56 @@ pub const uid_t = u32;
 pub const gid_t = u32;
 pub const time_t = isize;
 pub const suseconds_t = c_long;
+
+pub const ucontext_t = extern struct {
+    sigmask: sigset_t,
+    mcontext: mcontext_t,
+    link: ?*ucontext_t,
+    stack: stack_t,
+    cofunc: ?*fn (?*ucontext_t, ?*anyopaque) void,
+    arg: ?*void,
+    _spare: [4]c_int,
+};
+
+pub const mcontext_t = extern struct {
+    onstack: register_t, // XXX - sigcontext compat.
+    rdi: register_t,
+    rsi: register_t,
+    rdx: register_t,
+    rcx: register_t,
+    r8: register_t,
+    r9: register_t,
+    rax: register_t,
+    rbx: register_t,
+    rbp: register_t,
+    r10: register_t,
+    r11: register_t,
+    r12: register_t,
+    r13: register_t,
+    r14: register_t,
+    r15: register_t,
+    xflags: register_t,
+    trapno: register_t,
+    addr: register_t,
+    flags: register_t,
+    err: register_t,
+    rip: register_t,
+    cs: register_t,
+    rflags: register_t,
+    rsp: register_t, // machine state
+    ss: register_t,
+
+    len: c_uint, // sizeof(mcontext_t)
+    fpformat: c_uint,
+    ownedfp: c_uint,
+    reserved: c_uint,
+    unused: [8]c_uint,
+
+    // NOTE! 64-byte aligned as of here. Also must match savefpu structure.
+    fpregs: [256]c_int align(64),
+};
+
+pub const register_t = isize;
 
 pub const E = enum(u16) {
     /// No error occurred.

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -93,7 +93,7 @@ pub const pthread_rwlock_t = extern struct {
     wblocked_first: ?*u8 = null,
     wblocked_last: ?*u8 = null,
     nreaders: c_uint = 0,
-    owner: std.c.pthread_t = null,
+    owner: ?std.c.pthread_t = null,
     private: ?*anyopaque = null,
 };
 

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -1227,9 +1227,32 @@ pub const REG = switch (builtin.cpu.arch) {
         pub const PC = 15;
     },
     .x86_64 => struct {
+        pub const RDI = 0;
+        pub const RSI = 1;
+        pub const RDX = 2;
+        pub const RCX = 3;
+        pub const R8 = 4;
+        pub const R9 = 5;
+        pub const R10 = 6;
+        pub const R11 = 7;
+        pub const R12 = 8;
+        pub const R13 = 9;
+        pub const R14 = 10;
+        pub const R15 = 11;
         pub const RBP = 12;
+        pub const RBX = 13;
+        pub const RAX = 14;
+        pub const GS = 15;
+        pub const FS = 16;
+        pub const ES = 17;
+        pub const DS = 18;
+        pub const TRAPNO = 19;
+        pub const ERR = 20;
         pub const RIP = 21;
+        pub const CS = 22;
+        pub const RFLAGS = 23;
         pub const RSP = 24;
+        pub const SS = 25;
     },
     else => struct {},
 };

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -168,6 +168,7 @@ pub fn relocateContext(context: *ThreadContext) void {
 }
 
 pub const have_getcontext = @hasDecl(os.system, "getcontext") and
+    builtin.os.tag != .openbsd and
     (builtin.os.tag != .linux or switch (builtin.cpu.arch) {
     .x86,
     .x86_64,

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1228,7 +1228,7 @@ pub fn readElfDebugInfo(
                 }
 
                 var cwd_buf: [fs.MAX_PATH_BYTES]u8 = undefined;
-                const cwd_path = fs.cwd().realpath("", &cwd_buf) catch break :blk;
+                const cwd_path = os.realpath(".", &cwd_buf) catch break :blk;
 
                 // <global debug directory>/<absolute folder of current binary>/<gnu_debuglink>
                 for (global_debug_directories) |global_directory| {

--- a/lib/std/dwarf/abi.zig
+++ b/lib/std/dwarf/abi.zig
@@ -229,7 +229,7 @@ pub fn regBytes(
             else => error.UnimplementedOs,
         },
         .x86_64 => switch (builtin.os.tag) {
-            .linux, .netbsd, .solaris => switch (reg_number) {
+            .linux, .solaris => switch (reg_number) {
                 0 => mem.asBytes(&ucontext_ptr.mcontext.gregs[os.REG.RAX]),
                 1 => mem.asBytes(&ucontext_ptr.mcontext.gregs[os.REG.RDX]),
                 2 => mem.asBytes(&ucontext_ptr.mcontext.gregs[os.REG.RCX]),

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -102,7 +102,10 @@ test "openDir cwd parent .." {
 }
 
 test "openDir non-cwd parent .." {
-    if (builtin.os.tag == .wasi) return error.SkipZigTest;
+    switch (builtin.os.tag) {
+        .wasi, .netbsd, .openbsd => return error.SkipZigTest,
+        else => {},
+    }
 
     var tmp = tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
Advance the state of various BSDs ports on x86_64 to be able to build stage3 and pass `zig test lib/std/std.zig`:

- netbsd 9.3
- openbsd 7.3
- dragonfly 6.4
- freebsd 13.2 (wasn't broken but tested anyways)
