### PR TITLE
std.os | Fix EFAULT read error

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -747,7 +747,7 @@ pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
             .SUCCESS => return @as(usize, @intCast(rc)),
             .INTR => continue,
             .INVAL => unreachable,
-            .FAULT => error.BadAddress,
+            .FAULT => return error.BadAddress,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForReading, // Can be a race condition.
             .IO => return error.InputOutput,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -687,6 +687,10 @@ pub const ReadError = error{
     /// In WASI, this error occurs when the file descriptor does
     /// not hold the required rights to read from it.
     AccessDenied,
+
+    /// An invalid pointer was detected.
+    /// https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html#index-EFAULT
+    BadAddress,
 } || UnexpectedError;
 
 /// Returns the number of bytes that were read, which can be less than
@@ -743,7 +747,7 @@ pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
             .SUCCESS => return @as(usize, @intCast(rc)),
             .INTR => continue,
             .INVAL => unreachable,
-            .FAULT => unreachable,
+            .FAULT => error.BadAddress,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForReading, // Can be a race condition.
             .IO => return error.InputOutput,


### PR DESCRIPTION
.FAULT is currently set to unreachable which is not correct 

[It can be triggered when utilizing an invalid pointer](https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html#index-EFAULT)

You can trigger it on os.read by passing a buffer to uninitialized memory
