### PR TITLE
std.json: Fix decoding of UTF-16 surrogate pairs

### DIFF
--- a/lib/std/json/scanner_test.zig
+++ b/lib/std/json/scanner_test.zig
@@ -236,6 +236,7 @@ const string_test_cases = .{
     .{ "\\u000a", "\n" },
     .{ "𝄞", "\u{1D11E}" },
     .{ "\\uD834\\uDD1E", "\u{1D11E}" },
+    .{ "\\uD87F\\uDFFE", "\u{2FFFE}" },
     .{ "\\uff20", "＠" },
 };
 


### PR DESCRIPTION
Before this PR, there were 524,288 codepoints that would get decoded improperly (starting with codepoint U+20000). After this PR, there will be 0.

Fixes #16828

Note: It's possible that the 'decode into a single u21' aspect of the JSON implementation could have been retained while fixing this, but I think the approach taken in this PR makes the code more understandable and there's no real reason the JSON stuff should have it's own version of UTF-16 decoding logic separate from `std.unicode`.

---

Exhaustively tested against the full unicode range with this code:

<details>

```zig
const std = @import("std");

fn testCodepoint(input: []const u8, expected_utf8: []const u8) !void {
    var stream = std.io.fixedBufferStream(input);
    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
    defer arena.deinit();
    var json_reader = std.json.reader(std.testing.allocator, stream.reader());
    defer json_reader.deinit();

    const token = try json_reader.nextAlloc(arena.allocator(), .alloc_if_needed);
    const value = switch (token) {
        .string => |value| value,
        .allocated_string => |value| value,
        else => return error.ExpectedString,
    };
    try std.testing.expectEqualStrings(expected_utf8, value);

    try std.testing.expectEqual(std.json.Token.end_of_document, try json_reader.next());
}

test "json scanner strings" {
    var utf8_buf: [4]u8 = undefined;
    var utf16_buf: [2]u16 = undefined;
    var string_buf = "\"\\uXXXX\\uXXXX\"".*;
    var codepoint: u21 = 0;
    while (codepoint <= 0x10FFFF) : (codepoint += 1) {
        if (!std.unicode.utf8ValidCodepoint(codepoint)) continue;

        const utf16_code_units = try encodeUtf16(codepoint, &utf16_buf);
        const num_utf8_bytes = try std.unicode.utf8Encode(codepoint, &utf8_buf);
        const utf8_bytes = utf8_buf[0..num_utf8_bytes];
        const as_json_string = switch (utf16_code_units.len) {
            1 => try std.fmt.bufPrint(&string_buf, "\"\\u{x:0>4}\"", .{utf16_code_units[0]}),
            2 => try std.fmt.bufPrint(&string_buf, "\"\\u{x:0>4}\\u{x:0>4}\"", .{ utf16_code_units[0], utf16_code_units[1] }),
            else => unreachable,
        };

        testCodepoint(as_json_string, utf8_bytes) catch |err| {
            std.debug.print("U+{x}\n", .{codepoint});
            return err;
        };
    }
}

fn encodeUtf16(codepoint: u21, buf: []u16) ![]u16 {
    const len = try std.unicode.utf16CodepointSequenceLength(codepoint);
    std.debug.assert(buf.len >= len);
    switch (len) {
        1 => {
            buf[0] = @intCast(codepoint);
        },
        2 => {
            const u = codepoint - 0x10000;
            const high_surrogate = u / 0x400 + 0xD800;
            const low_surrogate = u % 0x400 + 0xDC00;
            buf[0] = @intCast(high_surrogate);
            buf[1] = @intCast(low_surrogate);
        },
        else => unreachable,
    }
    return buf[0..len];
}
```

</details>