### PR TITLE
Fix `zig test` being unusable on files within the std library

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -148,6 +148,13 @@ stage1_flags: packed struct {
 
 job_queued_update_builtin_zig: bool = true,
 
+/// This is set to true when the root source file is within the lib/std directory.
+/// When this is true, the 'file exists in multiple packages' error is supressed
+/// for this module to allow for `zig test` to be run directly on files within the
+/// standard library. This is a (possibly temporary) workaround.
+/// See https://github.com/ziglang/zig/issues/14504
+main_path_in_std: bool,
+
 compile_log_text: ArrayListUnmanaged(u8) = .{},
 
 emit_h: ?*GlobalEmitH,
@@ -1680,7 +1687,7 @@ pub const File = struct {
             .import => |loc| loc.file_scope.pkg,
             .root => |pkg| pkg,
         };
-        if (pkg != file.pkg) file.multi_pkg = true;
+        if (pkg != file.pkg and !mod.main_path_in_std) file.multi_pkg = true;
     }
 
     /// Mark this file and every file referenced by it as multi_pkg and report an


### PR DESCRIPTION
This will suppress 'file exists in multiple packages' errors if the module's root is within the `std` directory, which allows running `zig test` directly on files within the standard library again (e.g. `zig test lib/std/fs/test.zig --zig-lib-dir lib --main-pkg-path lib/std` to only run the tests in `std/fs/test.zig`).

This is potentially a temporary workaround if there's something added that satisfies this use-case without needing to special case `std` (e.g. `--test-filter` that allows file-based filtering). See https://github.com/ziglang/zig/issues/14504

After this PR:

```console
$ zig test lib/std/fs/test.zig --zig-lib-dir lib --main-pkg-path lib/std
Test [51/52] test.delete a read-only file on windows... SKIP
Test [52/52] test.delete a setAsCwd directory on Windows... SKIP
50 passed; 2 skipped; 0 failed.
```

Before this PR:

```console
$ zig test lib/std/fs/test.zig --zig-lib-dir lib --main-pkg-path lib/std
lib/std/std.zig:1:1: error: file exists in multiple modules
lib/std/std.zig:1:1: note: root of module root.std
lib/std/bounded_array.zig:1:21: note: imported from module root.std
const std = @import("std.zig");
                    ^~~~~~~~~
lib/std/fs/test.zig:1:21: note: imported from module root
const std = @import("../std.zig");
                    ^~~~~~~~~~~~
lib/std/Ini.zig:39:21: note: imported from module root.std
const std = @import("std.zig");
                    ^~~~~~~~~
lib/std/comptime_string_map.zig:1:21: note: imported from module root.std
const std = @import("std.zig");
                    ^~~~~~~~~
lib/std/std.zig:1:1: note: 291 more references omitted
lib/std/fs/test.zig:1:1: error: file exists in multiple modules
lib/std/fs/test.zig:1:1: note: root of module root
lib/std/fs.zig:3167:17: note: imported from module root.std
    _ = @import("fs/test.zig");
                ^~~~~~~~~~~~~
```

I'm unsure if this will cause any unforeseen problems, but it seems to work for what I want to use it for.

cc @mlugg