### PR TITLE
objcopy: fix typo

### DIFF
--- a/src/objcopy.zig
+++ b/src/objcopy.zig
@@ -124,7 +124,7 @@ pub fn cmdObjCopy(
     };
 
     const mode = mode: {
-        if (out_fmt != .elf or !only_keep_debug)
+        if (out_fmt != .elf or only_keep_debug)
             break :mode fs.File.default_mode;
         if (in_file.stat()) |stat|
             break :mode stat.mode


### PR DESCRIPTION
fixes aecc15391a4c37a4504d29cb7e3179990b180773
the usual last 'harmless' cosmetic adjustment before commit strikes again...