### PR TITLE
comp: when targeting any Apple platform from macOS, always prefer native paths and libc installation

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4881,7 +4881,7 @@ fn detectLibCIncludeDirs(
 
     // If linking system libraries and targeting the native abi, default to
     // using the system libc installation.
-    if (is_native_abi and !target.isMinGW()) {
+    if ((is_native_abi and !target.isMinGW()) or (builtin.target.os.tag == .macos and target.isDarwin())) {
         const libc = try arena.create(LibCInstallation);
         libc.* = LibCInstallation.findNative(.{ .allocator = arena, .target = target }) catch |err| switch (err) {
             error.CCompilerExitCode,

--- a/src/main.zig
+++ b/src/main.zig
@@ -2674,9 +2674,13 @@ fn buildOutputType(
     // After this point, external_system_libs is used instead of system_libs.
 
     // Trigger native system library path detection if necessary.
-    if (sysroot == null and cross_target.isNativeOs() and cross_target.isNativeAbi() and
-        (external_system_libs.len != 0 or want_native_include_dirs))
-    {
+    const want_native_paths = blk: {
+        if (sysroot != null) break :blk false;
+        if (builtin.target.os.tag == .macos and cross_target.isDarwin()) break :blk true;
+        break :blk cross_target.isNativeOs() and cross_target.isNativeAbi() and
+            (external_system_libs.len != 0 or want_native_include_dirs);
+    };
+    if (want_native_paths) {
         const paths = std.zig.system.NativePaths.detect(arena, target_info) catch |err| {
             fatal("unable to detect native system paths: {s}", .{@errorName(err)});
         };


### PR DESCRIPTION
This change makes targeting iOS/watchOS/tvOS and macOS as a cross-compilation target from a macOS host use the system SDK by default before falling back to Zig shipped libc headers (if available).

Closes #16557 