### PR TITLE
std: use relative imports for stdlib

### DIFF
--- a/lib/std/BitStack.zig
+++ b/lib/std/BitStack.zig
@@ -2,7 +2,7 @@
 
 const BitStack = @This();
 
-const std = @import("std");
+const std = @import("std.zig");
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
 

--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -73,7 +73,7 @@ prefixes_len: usize = 0,
 pub const DepTokenizer = @import("Cache/DepTokenizer.zig");
 
 const Cache = @This();
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const crypto = std.crypto;
 const fs = std.fs;

--- a/lib/std/Build/Cache/DepTokenizer.zig
+++ b/lib/std/Build/Cache/DepTokenizer.zig
@@ -4,7 +4,7 @@ index: usize = 0,
 bytes: []const u8,
 state: State = .lhs,
 
-const std = @import("std");
+const std = @import("../../std.zig");
 const testing = std.testing;
 const assert = std.debug.assert;
 

--- a/lib/std/Build/Step/CheckFile.zig
+++ b/lib/std/Build/Step/CheckFile.zig
@@ -3,7 +3,7 @@
 //! TODO: generalize the code in std.testing.expectEqualStrings and make this
 //! CheckFile step produce those helpful diagnostics when there is not a match.
 const CheckFile = @This();
-const std = @import("std");
+const std = @import("../../std.zig");
 const Step = std.Build.Step;
 const fs = std.fs;
 const mem = std.mem;

--- a/lib/std/Build/Step/CheckObject.zig
+++ b/lib/std/Build/Step/CheckObject.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const assert = std.debug.assert;
 const elf = std.elf;
 const fs = std.fs;

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1,5 +1,5 @@
 const builtin = @import("builtin");
-const std = @import("std");
+const std = @import("../../std.zig");
 const mem = std.mem;
 const fs = std.fs;
 const assert = std.debug.assert;

--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const ConfigHeader = @This();
 const Step = std.Build.Step;
 const Allocator = std.mem.Allocator;

--- a/lib/std/Build/Step/Fmt.zig
+++ b/lib/std/Build/Step/Fmt.zig
@@ -1,7 +1,7 @@
 //! This step has two modes:
 //! * Modify mode: directly modify source files, formatting them in place.
 //! * Check mode: fail the step if a non-conforming file is found.
-const std = @import("std");
+const std = @import("../../std.zig");
 const Step = std.Build.Step;
 const Fmt = @This();
 

--- a/lib/std/Build/Step/InstallArtifact.zig
+++ b/lib/std/Build/Step/InstallArtifact.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const Step = std.Build.Step;
 const InstallDir = std.Build.InstallDir;
 const InstallArtifact = @This();

--- a/lib/std/Build/Step/InstallDir.zig
+++ b/lib/std/Build/Step/InstallDir.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const mem = std.mem;
 const fs = std.fs;
 const Step = std.Build.Step;

--- a/lib/std/Build/Step/InstallFile.zig
+++ b/lib/std/Build/Step/InstallFile.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const Step = std.Build.Step;
 const LazyPath = std.Build.LazyPath;
 const InstallDir = std.Build.InstallDir;

--- a/lib/std/Build/Step/ObjCopy.zig
+++ b/lib/std/Build/Step/ObjCopy.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const ObjCopy = @This();
 
 const Allocator = std.mem.Allocator;

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const fs = std.fs;
 const Step = std.Build.Step;

--- a/lib/std/Build/Step/RemoveDir.zig
+++ b/lib/std/Build/Step/RemoveDir.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const fs = std.fs;
 const Step = std.Build.Step;
 const RemoveDir = @This();

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const Step = std.Build.Step;
 const fs = std.fs;

--- a/lib/std/Build/Step/TranslateC.zig
+++ b/lib/std/Build/Step/TranslateC.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const Step = std.Build.Step;
 const fs = std.fs;
 const mem = std.mem;

--- a/lib/std/Build/Step/WriteFile.zig
+++ b/lib/std/Build/Step/WriteFile.zig
@@ -8,7 +8,7 @@
 //! during the normal build process, but as a utility run by a developer with
 //! intention to update source files, which will then be committed to version
 //! control.
-const std = @import("std");
+const std = @import("../../std.zig");
 const Step = std.Build.Step;
 const fs = std.fs;
 const ArrayList = std.ArrayList;

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -6,7 +6,7 @@
 //! * `refresh_rate_ms`
 //! * `initial_delay_ms`
 
-const std = @import("std");
+const std = @import("std.zig");
 const builtin = @import("builtin");
 const windows = std.os.windows;
 const testing = std.testing;

--- a/lib/std/RingBuffer.zig
+++ b/lib/std/RingBuffer.zig
@@ -9,8 +9,8 @@
 //! therefore should not be assumed to be suitable for use cases involving
 //! separate reader and writer threads.
 
-const Allocator = @import("std").mem.Allocator;
-const assert = @import("std").debug.assert;
+const Allocator = @import("std.zig").mem.Allocator;
+const assert = @import("std.zig").debug.assert;
 
 const RingBuffer = @This();
 

--- a/lib/std/SemanticVersion.zig
+++ b/lib/std/SemanticVersion.zig
@@ -2,7 +2,7 @@
 //!
 //! See: https://semver.org
 
-const std = @import("std");
+const std = @import("std.zig");
 const Version = @This();
 
 major: usize,

--- a/lib/std/Thread/Pool.zig
+++ b/lib/std/Thread/Pool.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const Pool = @This();
 const WaitGroup = @import("WaitGroup.zig");

--- a/lib/std/Thread/WaitGroup.zig
+++ b/lib/std/Thread/WaitGroup.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const Atomic = std.atomic.Atomic;
 const assert = std.debug.assert;
 const WaitGroup = @This();

--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -8,7 +8,7 @@
 //!
 //! See also: https://en.wikipedia.org/wiki/ASCII#Character_set
 
-const std = @import("std");
+const std = @import("std.zig");
 
 /// The C0 control codes of the ASCII encoding.
 ///

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("std.zig");
 const builtin = @import("builtin");
 const c = @This();
 const page_size = std.mem.page_size;

--- a/lib/std/c/hermit.zig
+++ b/lib/std/c/hermit.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const maxInt = std.math.maxInt;
 
 pub const pthread_mutex_t = extern struct {

--- a/lib/std/c/tokenizer.zig
+++ b/lib/std/c/tokenizer.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 
 pub const Token = struct {
     id: Id,

--- a/lib/std/compress/deflate/bits_utils.zig
+++ b/lib/std/compress/deflate/bits_utils.zig
@@ -1,4 +1,4 @@
-const math = @import("std").math;
+const math = @import("../../std.zig").math;
 
 // Reverse bit-by-bit a N-bit code.
 pub fn bitReverse(comptime T: type, value: T, N: usize) T {
@@ -7,7 +7,7 @@ pub fn bitReverse(comptime T: type, value: T, N: usize) T {
 }
 
 test "bitReverse" {
-    const std = @import("std");
+    const std = @import("../../std.zig");
 
     const ReverseBitsTest = struct {
         in: u16,

--- a/lib/std/compress/deflate/compressor.zig
+++ b/lib/std/compress/deflate/compressor.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const assert = std.debug.assert;
 const fmt = std.fmt;
 const io = std.io;

--- a/lib/std/compress/deflate/compressor_test.zig
+++ b/lib/std/compress/deflate/compressor_test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const expect = std.testing.expect;
 const fifo = std.fifo;

--- a/lib/std/compress/deflate/decompressor.zig
+++ b/lib/std/compress/deflate/decompressor.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;

--- a/lib/std/compress/deflate/deflate_fast.zig
+++ b/lib/std/compress/deflate/deflate_fast.zig
@@ -1,7 +1,7 @@
 // This encoding algorithm, which prioritizes speed over output size, is
 // based on Snappy's LZ77-style encoder: github.com/golang/snappy
 
-const std = @import("std");
+const std = @import("../../std.zig");
 const math = std.math;
 const mem = std.mem;
 

--- a/lib/std/compress/deflate/deflate_fast_test.zig
+++ b/lib/std/compress/deflate/deflate_fast_test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const expect = std.testing.expect;
 const io = std.io;
 const mem = std.mem;

--- a/lib/std/compress/deflate/dict_decoder.zig
+++ b/lib/std/compress/deflate/dict_decoder.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const assert = std.debug.assert;
 const mem = std.mem;
 

--- a/lib/std/compress/deflate/huffman_bit_writer.zig
+++ b/lib/std/compress/deflate/huffman_bit_writer.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const io = std.io;
 

--- a/lib/std/compress/deflate/huffman_code.zig
+++ b/lib/std/compress/deflate/huffman_code.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;

--- a/lib/std/compress/deflate/token.zig
+++ b/lib/std/compress/deflate/token.zig
@@ -98,6 +98,6 @@ pub fn offsetCode(off: u32) u32 {
 }
 
 test {
-    const std = @import("std");
+    const std = @import("../../std.zig");
     try std.testing.expectEqual(@as(Token, 3_401_581_099), matchToken(555, 555));
 }

--- a/lib/std/compress/xz.zig
+++ b/lib/std/compress/xz.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const block = @import("xz/block.zig");
 const Allocator = std.mem.Allocator;
 const Crc32 = std.hash.Crc32;

--- a/lib/std/compress/zlib.zig
+++ b/lib/std/compress/zlib.zig
@@ -1,7 +1,7 @@
 //
 // Compressor/Decompressor for ZLIB data streams (RFC1950)
 
-const std = @import("std");
+const std = @import("../std.zig");
 const io = std.io;
 const fs = std.fs;
 const testing = std.testing;

--- a/lib/std/compress/zstandard.zig
+++ b/lib/std/compress/zstandard.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const Allocator = std.mem.Allocator;
 const RingBuffer = std.RingBuffer;
 

--- a/lib/std/compress/zstandard/decode/block.zig
+++ b/lib/std/compress/zstandard/decode/block.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const assert = std.debug.assert;
 const RingBuffer = std.RingBuffer;
 

--- a/lib/std/compress/zstandard/decode/fse.zig
+++ b/lib/std/compress/zstandard/decode/fse.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const assert = std.debug.assert;
 
 const types = @import("../types.zig");

--- a/lib/std/compress/zstandard/decode/huffman.zig
+++ b/lib/std/compress/zstandard/decode/huffman.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 
 const types = @import("../types.zig");
 const LiteralsSection = types.compressed_block.LiteralsSection;

--- a/lib/std/compress/zstandard/decompress.zig
+++ b/lib/std/compress/zstandard/decompress.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const RingBuffer = std.RingBuffer;

--- a/lib/std/compress/zstandard/readers.zig
+++ b/lib/std/compress/zstandard/readers.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 
 pub const ReversedByteReader = struct {
     remaining_bytes: usize,

--- a/lib/std/compress/zstandard/types.zig
+++ b/lib/std/compress/zstandard/types.zig
@@ -396,6 +396,6 @@ pub const compressed_block = struct {
 };
 
 test {
-    const testing = @import("std").testing;
+    const testing = @import("../../std.zig").testing;
     testing.refAllDeclsRecursive(@This());
 }

--- a/lib/std/crypto/25519/curve25519.zig
+++ b/lib/std/crypto/25519/curve25519.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const crypto = std.crypto;
 
 const IdentityElementError = crypto.errors.IdentityElementError;

--- a/lib/std/crypto/25519/ed25519.zig
+++ b/lib/std/crypto/25519/ed25519.zig
@@ -1,5 +1,5 @@
 const builtin = @import("builtin");
-const std = @import("std");
+const std = @import("../../std.zig");
 const crypto = std.crypto;
 const debug = std.debug;
 const fmt = std.fmt;

--- a/lib/std/crypto/25519/edwards25519.zig
+++ b/lib/std/crypto/25519/edwards25519.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const crypto = std.crypto;
 const debug = std.debug;
 const fmt = std.fmt;

--- a/lib/std/crypto/25519/field.zig
+++ b/lib/std/crypto/25519/field.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const crypto = std.crypto;
 const readIntLittle = std.mem.readIntLittle;

--- a/lib/std/crypto/25519/ristretto255.zig
+++ b/lib/std/crypto/25519/ristretto255.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const fmt = std.fmt;
 
 const EncodingError = std.crypto.errors.EncodingError;

--- a/lib/std/crypto/25519/scalar.zig
+++ b/lib/std/crypto/25519/scalar.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const crypto = std.crypto;
 const mem = std.mem;
 

--- a/lib/std/crypto/25519/x25519.zig
+++ b/lib/std/crypto/25519/x25519.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const crypto = std.crypto;
 const mem = std.mem;
 const fmt = std.fmt;

--- a/lib/std/crypto/Certificate/Bundle/macos.zig
+++ b/lib/std/crypto/Certificate/Bundle/macos.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const assert = std.debug.assert;
 const fs = std.fs;
 const mem = std.mem;

--- a/lib/std/crypto/aegis.zig
+++ b/lib/std/crypto/aegis.zig
@@ -16,7 +16,7 @@
 //!
 //! https://datatracker.ietf.org/doc/draft-irtf-cfrg-aegis-aead/
 
-const std = @import("std");
+const std = @import("../std.zig");
 const crypto = std.crypto;
 const mem = std.mem;
 const assert = std.debug.assert;

--- a/lib/std/crypto/aes_gcm.zig
+++ b/lib/std/crypto/aes_gcm.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const assert = std.debug.assert;
 const crypto = std.crypto;
 const debug = std.debug;

--- a/lib/std/crypto/aes_ocb.zig
+++ b/lib/std/crypto/aes_ocb.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const crypto = std.crypto;
 const aes = crypto.core.aes;

--- a/lib/std/crypto/argon2.zig
+++ b/lib/std/crypto/argon2.zig
@@ -2,7 +2,7 @@
 // https://github.com/golang/crypto/tree/master/argon2
 // https://github.com/P-H-C/phc-winner-argon2
 
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 
 const blake2 = crypto.hash.blake2;

--- a/lib/std/crypto/ascon.zig
+++ b/lib/std/crypto/ascon.zig
@@ -7,7 +7,7 @@
 //!
 //! It is not meant to be used directly, but as a building block for symmetric cryptography.
 
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = std.builtin;
 const debug = std.debug;
 const mem = std.mem;

--- a/lib/std/crypto/bcrypt.zig
+++ b/lib/std/crypto/bcrypt.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const base64 = std.base64;
 const crypto = std.crypto;
 const debug = std.debug;

--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -1,6 +1,6 @@
 // zig run -O ReleaseFast --zig-lib-dir ../.. benchmark.zig
 
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const mem = std.mem;
 const time = std.time;

--- a/lib/std/crypto/cmac.zig
+++ b/lib/std/crypto/cmac.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const crypto = std.crypto;
 const mem = std.mem;
 

--- a/lib/std/crypto/ecdsa.zig
+++ b/lib/std/crypto/ecdsa.zig
@@ -1,5 +1,5 @@
 const builtin = @import("builtin");
-const std = @import("std");
+const std = @import("../std.zig");
 const crypto = std.crypto;
 const fmt = std.fmt;
 const io = std.io;

--- a/lib/std/crypto/ff.zig
+++ b/lib/std/crypto/ff.zig
@@ -5,7 +5,7 @@
 //!
 //! Parts of that code was ported from the BSD-licensed crypto/internal/bigmod/nat.go file in the Go language, itself inspired from BearSSL.
 
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = std.builtin;
 const crypto = std.crypto;
 const math = std.math;

--- a/lib/std/crypto/isap.zig
+++ b/lib/std/crypto/isap.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const crypto = std.crypto;
 const debug = std.debug;
 const mem = std.mem;

--- a/lib/std/crypto/keccak_p.zig
+++ b/lib/std/crypto/keccak_p.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;

--- a/lib/std/crypto/kyber_d00.zig
+++ b/lib/std/crypto/kyber_d00.zig
@@ -102,7 +102,7 @@
 //   can just have a pointer in the private key to the public key, but
 //   how do we do this elegantly in Zig?
 
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 
 const testing = std.testing;

--- a/lib/std/crypto/pbkdf2.zig
+++ b/lib/std/crypto/pbkdf2.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const mem = std.mem;
 const maxInt = std.math.maxInt;
 const OutputTooLongError = std.crypto.errors.OutputTooLongError;

--- a/lib/std/crypto/pcurves/common.zig
+++ b/lib/std/crypto/pcurves/common.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const crypto = std.crypto;
 const debug = std.debug;
 const mem = std.mem;

--- a/lib/std/crypto/pcurves/p256.zig
+++ b/lib/std/crypto/pcurves/p256.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const crypto = std.crypto;
 const mem = std.mem;
 const meta = std.meta;

--- a/lib/std/crypto/pcurves/p256/field.zig
+++ b/lib/std/crypto/pcurves/p256/field.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const common = @import("../common.zig");
 
 const Field = common.Field;

--- a/lib/std/crypto/pcurves/p256/p256_64.zig
+++ b/lib/std/crypto/pcurves/p256/p256_64.zig
@@ -48,7 +48,7 @@
 //   twos_complement_eval z = let x1 := z[0] + (z[1] << 64) + (z[2] << 128) + (z[3] << 192) in
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
-const std = @import("std");
+const std = @import("../../../std.zig");
 const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/lib/std/crypto/pcurves/p256/p256_scalar_64.zig
+++ b/lib/std/crypto/pcurves/p256/p256_scalar_64.zig
@@ -48,7 +48,7 @@
 //   twos_complement_eval z = let x1 := z[0] + (z[1] << 64) + (z[2] << 128) + (z[3] << 192) in
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
-const std = @import("std");
+const std = @import("../../../std.zig");
 const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/lib/std/crypto/pcurves/p256/scalar.zig
+++ b/lib/std/crypto/pcurves/p256/scalar.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const common = @import("../common.zig");
 const crypto = std.crypto;
 const debug = std.debug;

--- a/lib/std/crypto/pcurves/p384.zig
+++ b/lib/std/crypto/pcurves/p384.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const crypto = std.crypto;
 const mem = std.mem;
 const meta = std.meta;

--- a/lib/std/crypto/pcurves/p384/field.zig
+++ b/lib/std/crypto/pcurves/p384/field.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const common = @import("../common.zig");
 
 const Field = common.Field;

--- a/lib/std/crypto/pcurves/p384/p384_64.zig
+++ b/lib/std/crypto/pcurves/p384/p384_64.zig
@@ -17,7 +17,7 @@
 //   twos_complement_eval z = let x1 := z[0] + (z[1] << 64) + (z[2] << 128) + (z[3] << 192) + (z[4] << 256) + (z[5] << 0x140) in
 //                            if x1 & (2^384-1) < 2^383 then x1 & (2^384-1) else (x1 & (2^384-1)) - 2^384
 
-const std = @import("std");
+const std = @import("../../../std.zig");
 const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/lib/std/crypto/pcurves/p384/p384_scalar_64.zig
+++ b/lib/std/crypto/pcurves/p384/p384_scalar_64.zig
@@ -17,7 +17,7 @@
 //   twos_complement_eval z = let x1 := z[0] + (z[1] << 64) + (z[2] << 128) + (z[3] << 192) + (z[4] << 256) + (z[5] << 0x140) in
 //                            if x1 & (2^384-1) < 2^383 then x1 & (2^384-1) else (x1 & (2^384-1)) - 2^384
 
-const std = @import("std");
+const std = @import("../../../std.zig");
 const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/lib/std/crypto/pcurves/p384/scalar.zig
+++ b/lib/std/crypto/pcurves/p384/scalar.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const common = @import("../common.zig");
 const crypto = std.crypto;
 const debug = std.debug;

--- a/lib/std/crypto/pcurves/secp256k1.zig
+++ b/lib/std/crypto/pcurves/secp256k1.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const crypto = std.crypto;
 const math = std.math;
 const mem = std.mem;

--- a/lib/std/crypto/pcurves/secp256k1/field.zig
+++ b/lib/std/crypto/pcurves/secp256k1/field.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const common = @import("../common.zig");
 
 const Field = common.Field;

--- a/lib/std/crypto/pcurves/secp256k1/scalar.zig
+++ b/lib/std/crypto/pcurves/secp256k1/scalar.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const common = @import("../common.zig");
 const crypto = std.crypto;
 const debug = std.debug;

--- a/lib/std/crypto/pcurves/secp256k1/secp256k1_64.zig
+++ b/lib/std/crypto/pcurves/secp256k1/secp256k1_64.zig
@@ -17,7 +17,7 @@
 //   twos_complement_eval z = let x1 := z[0] + (z[1] << 64) + (z[2] << 128) + (z[3] << 192) in
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
-const std = @import("std");
+const std = @import("../../../std.zig");
 const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/lib/std/crypto/pcurves/secp256k1/secp256k1_scalar_64.zig
+++ b/lib/std/crypto/pcurves/secp256k1/secp256k1_scalar_64.zig
@@ -17,7 +17,7 @@
 //   twos_complement_eval z = let x1 := z[0] + (z[1] << 64) + (z[2] << 128) + (z[3] << 192) in
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
-const std = @import("std");
+const std = @import("../../../std.zig");
 const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/lib/std/crypto/pcurves/tests/p256.zig
+++ b/lib/std/crypto/pcurves/tests/p256.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const fmt = std.fmt;
 const testing = std.testing;
 

--- a/lib/std/crypto/pcurves/tests/p384.zig
+++ b/lib/std/crypto/pcurves/tests/p384.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const fmt = std.fmt;
 const testing = std.testing;
 

--- a/lib/std/crypto/pcurves/tests/secp256k1.zig
+++ b/lib/std/crypto/pcurves/tests/secp256k1.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const fmt = std.fmt;
 const testing = std.testing;
 

--- a/lib/std/crypto/phc_encoding.zig
+++ b/lib/std/crypto/phc_encoding.zig
@@ -1,6 +1,6 @@
 // https://github.com/P-H-C/phc-string-format
 
-const std = @import("std");
+const std = @import("../std.zig");
 const fmt = std.fmt;
 const io = std.io;
 const mem = std.mem;

--- a/lib/std/crypto/salsa20.zig
+++ b/lib/std/crypto/salsa20.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const crypto = std.crypto;
 const debug = std.debug;

--- a/lib/std/crypto/scrypt.zig
+++ b/lib/std/crypto/scrypt.zig
@@ -2,7 +2,7 @@
 // https://github.com/golang/crypto/blob/master/scrypt/scrypt.go
 // https://github.com/Tarsnap/scrypt
 
-const std = @import("std");
+const std = @import("../std.zig");
 const crypto = std.crypto;
 const fmt = std.fmt;
 const io = std.io;

--- a/lib/std/crypto/sha3.zig
+++ b/lib/std/crypto/sha3.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;

--- a/lib/std/crypto/tlcsprng.zig
+++ b/lib/std/crypto/tlcsprng.zig
@@ -3,7 +3,7 @@
 //! by the standard library; this namespace is not intended to be exposed
 //! directly to standard library users.
 
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const mem = std.mem;
 const os = std.os;

--- a/lib/std/dwarf/expressions.zig
+++ b/lib/std/dwarf/expressions.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const OP = @import("OP.zig");
 const leb = std.leb;

--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -1,6 +1,6 @@
 //! This module contains utilities and data structures for working with enums.
 
-const std = @import("std");
+const std = @import("std.zig");
 const assert = std.debug.assert;
 const testing = std.testing;
 const EnumField = std.builtin.Type.EnumField;

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -1,7 +1,7 @@
 // FIFO of fixed size items
 // Usually used for e.g. byte buffers
 
-const std = @import("std");
+const std = @import("std.zig");
 const math = std.math;
 const mem = std.mem;
 const Allocator = mem.Allocator;

--- a/lib/std/fmt/parse_float.zig
+++ b/lib/std/fmt/parse_float.zig
@@ -2,7 +2,7 @@ pub const parseFloat = @import("parse_float/parse_float.zig").parseFloat;
 pub const ParseFloatError = @import("parse_float/parse_float.zig").ParseFloatError;
 
 const builtin = @import("builtin");
-const std = @import("std");
+const std = @import("../std.zig");
 const math = std.math;
 const testing = std.testing;
 const expect = testing.expect;

--- a/lib/std/fmt/parse_float/FloatInfo.zig
+++ b/lib/std/fmt/parse_float/FloatInfo.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const Self = @This();
 
 // Minimum exponent that for a fast path case, or `-⌊(MANTISSA_EXPLICIT_BITS+1)/log2(5)⌋`

--- a/lib/std/fmt/parse_float/FloatStream.zig
+++ b/lib/std/fmt/parse_float/FloatStream.zig
@@ -1,6 +1,6 @@
 //! A wrapper over a byte-slice, providing useful methods for parsing string floating point values.
 
-const std = @import("std");
+const std = @import("../../std.zig");
 const FloatStream = @This();
 const common = @import("common.zig");
 

--- a/lib/std/fmt/parse_float/common.zig
+++ b/lib/std/fmt/parse_float/common.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 
 /// A custom N-bit floating point type, representing `f * 2^e`.
 /// e is biased, so it be directly shifted into the exponent bits.

--- a/lib/std/fmt/parse_float/convert_eisel_lemire.zig
+++ b/lib/std/fmt/parse_float/convert_eisel_lemire.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const math = std.math;
 const common = @import("common.zig");
 const FloatInfo = @import("FloatInfo.zig");

--- a/lib/std/fmt/parse_float/convert_fast.zig
+++ b/lib/std/fmt/parse_float/convert_fast.zig
@@ -8,7 +8,7 @@
 //! There is an exception: disguised fast-path cases, where we can shift
 //! powers-of-10 from the exponent to the significant digits.
 
-const std = @import("std");
+const std = @import("../../std.zig");
 const math = std.math;
 const common = @import("common.zig");
 const FloatInfo = @import("FloatInfo.zig");

--- a/lib/std/fmt/parse_float/convert_hex.zig
+++ b/lib/std/fmt/parse_float/convert_hex.zig
@@ -2,7 +2,7 @@
 //
 // Derived from golang strconv/atof.go.
 
-const std = @import("std");
+const std = @import("../../std.zig");
 const math = std.math;
 const common = @import("common.zig");
 const Number = common.Number;

--- a/lib/std/fmt/parse_float/convert_slow.zig
+++ b/lib/std/fmt/parse_float/convert_slow.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const math = std.math;
 const common = @import("common.zig");
 const BiasedFp = common.BiasedFp;

--- a/lib/std/fmt/parse_float/decimal.zig
+++ b/lib/std/fmt/parse_float/decimal.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const math = std.math;
 const common = @import("common.zig");
 const FloatStream = @import("FloatStream.zig");

--- a/lib/std/fmt/parse_float/parse.zig
+++ b/lib/std/fmt/parse_float/parse.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const common = @import("common.zig");
 const FloatStream = @import("FloatStream.zig");
 const isEightDigits = common.isEightDigits;

--- a/lib/std/fmt/parse_float/parse_float.zig
+++ b/lib/std/fmt/parse_float/parse_float.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const parse = @import("parse.zig");
 const convertFast = @import("convert_fast.zig").convertFast;
 const convertEiselLemire = @import("convert_eisel_lemire.zig").convertEiselLemire;

--- a/lib/std/fs/wasi.zig
+++ b/lib/std/fs/wasi.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const os = std.os;
 const mem = std.mem;

--- a/lib/std/fs/watch.zig
+++ b/lib/std/fs/watch.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const event = std.event;
 const assert = std.debug.assert;

--- a/lib/std/hash/auto_hash.zig
+++ b/lib/std/hash/auto_hash.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const assert = std.debug.assert;
 const mem = std.mem;
 const meta = std.meta;

--- a/lib/std/hash/benchmark.zig
+++ b/lib/std/hash/benchmark.zig
@@ -1,6 +1,6 @@
 // zig run -O ReleaseFast --zig-lib-dir ../.. benchmark.zig
 
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const time = std.time;
 const Timer = time.Timer;

--- a/lib/std/hash/cityhash.zig
+++ b/lib/std/hash/cityhash.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 
 inline fn offsetPtr(ptr: [*]const u8, offset: usize) [*]const u8 {
     // ptr + offset doesn't work at comptime so we need this instead.

--- a/lib/std/hash/murmur.zig
+++ b/lib/std/hash/murmur.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const testing = std.testing;
 const native_endian = builtin.target.cpu.arch.endian();

--- a/lib/std/hash/wyhash.zig
+++ b/lib/std/hash/wyhash.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 
 pub const Wyhash = struct {
     const secret = [_]u64{

--- a/lib/std/hash/xxhash.zig
+++ b/lib/std/hash/xxhash.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const mem = std.mem;
 const expectEqual = std.testing.expectEqual;
 

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -92,7 +92,7 @@
 //! Large objects are allocated directly using the backing allocator and their metadata is stored
 //! in a `std.HashMap` using the backing allocator.
 
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const log = std.log.scoped(.gpa);
 const math = std.math;

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const io = std.io;
 const meta = std.meta;

--- a/lib/std/io/tty.zig
+++ b/lib/std/io/tty.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const File = std.fs.File;
 const process = std.process;

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -9,8 +9,8 @@
 //! The low-level `writeStream` emits syntax-conformant JSON tokens to a `std.io.Writer`.
 //! The high-level `stringify` serializes a Zig or `Value` type into JSON.
 
-const testing = @import("std").testing;
-const ArrayList = @import("std").ArrayList;
+const testing = @import("std.zig").testing;
+const ArrayList = @import("std.zig").ArrayList;
 
 test Scanner {
     var scanner = Scanner.initCompleteInput(testing.allocator, "{\"foo\": 123}\n");

--- a/lib/std/json/dynamic.zig
+++ b/lib/std/json/dynamic.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const debug = std.debug;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const ArrayList = std.ArrayList;

--- a/lib/std/json/dynamic_test.zig
+++ b/lib/std/json/dynamic_test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const mem = std.mem;
 const testing = std.testing;
 const ArenaAllocator = std.heap.ArenaAllocator;

--- a/lib/std/json/hashmap.zig
+++ b/lib/std/json/hashmap.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const Allocator = std.mem.Allocator;
 
 const ParseOptions = @import("static.zig").ParseOptions;

--- a/lib/std/json/hashmap_test.zig
+++ b/lib/std/json/hashmap_test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const testing = std.testing;
 
 const ArrayHashMap = @import("hashmap.zig").ArrayHashMap;

--- a/lib/std/json/scanner.zig
+++ b/lib/std/json/scanner.zig
@@ -28,7 +28,7 @@
 // * This low-level implementation allows duplicate object keys,
 //   and key/value pairs are emitted in the order they appear in the input.
 
-const std = @import("std");
+const std = @import("../std.zig");
 
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;

--- a/lib/std/json/scanner_test.zig
+++ b/lib/std/json/scanner_test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const JsonScanner = @import("./scanner.zig").Scanner;
 const jsonReader = @import("./scanner.zig").reader;
 const JsonReader = @import("./scanner.zig").Reader;

--- a/lib/std/json/static.zig
+++ b/lib/std/json/static.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;

--- a/lib/std/json/static_test.zig
+++ b/lib/std/json/static_test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const testing = std.testing;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const Allocator = std.mem.Allocator;

--- a/lib/std/json/stringify.zig
+++ b/lib/std/json/stringify.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;

--- a/lib/std/json/stringify_test.zig
+++ b/lib/std/json/stringify_test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const mem = std.mem;
 const testing = std.testing;
 

--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const testing = std.testing;
 const parseFromSlice = @import("./static.zig").parseFromSlice;
 const validate = @import("./scanner.zig").validate;

--- a/lib/std/leb128.zig
+++ b/lib/std/leb128.zig
@@ -1,5 +1,5 @@
 const builtin = @import("builtin");
-const std = @import("std");
+const std = @import("std.zig");
 const testing = std.testing;
 
 /// Read a single unsigned LEB128 value from the given reader as type T,

--- a/lib/std/macho.zig
+++ b/lib/std/macho.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("std.zig");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 const io = std.io;

--- a/lib/std/math/gcd.zig
+++ b/lib/std/math/gcd.zig
@@ -1,5 +1,5 @@
 //! Greatest common divisor (https://mathworld.wolfram.com/GreatestCommonDivisor.html)
-const std = @import("std");
+const std = @import("../std.zig");
 const expectEqual = std.testing.expectEqual;
 
 /// Returns the greatest common divisor (GCD) of two unsigned integers (a and b) which are not both zero.

--- a/lib/std/math/ldexp.zig
+++ b/lib/std/math/ldexp.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const math = std.math;
 const Log2Int = std.math.Log2Int;
 const assert = std.debug.assert;

--- a/lib/std/math/scalbn.zig
+++ b/lib/std/math/scalbn.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const expect = std.testing.expect;
 
 /// Returns a * FLT_RADIX ^ exp.

--- a/lib/std/multi_array_list.zig
+++ b/lib/std/multi_array_list.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("std.zig");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 const meta = std.meta;

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const net = std.net;
 const mem = std.mem;

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -40,7 +40,7 @@ pub const wasi = @import("os/wasi.zig");
 pub const windows = @import("os/windows.zig");
 
 comptime {
-    assert(@import("std") == std); // std lib tests require --zig-lib-dir
+    assert(@import("std.zig") == std); // std lib tests require --zig-lib-dir
 }
 
 test {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -40,7 +40,7 @@ pub const wasi = @import("os/wasi.zig");
 pub const windows = @import("os/windows.zig");
 
 comptime {
-    assert(@import("std.zig") == std); // std lib tests require --zig-lib-dir
+    assert(@import("std") == std); // std lib tests require --zig-lib-dir
 }
 
 test {

--- a/lib/std/os/linux/start_pie.zig
+++ b/lib/std/os/linux/start_pie.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const elf = std.elf;
 const assert = std.debug.assert;

--- a/lib/std/os/linux/tls.zig
+++ b/lib/std/os/linux/tls.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const os = std.os;
 const mem = std.mem;
 const elf = std.elf;

--- a/lib/std/os/uefi/pool_allocator.zig
+++ b/lib/std/os/uefi/pool_allocator.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 
 const mem = std.mem;
 const uefi = std.os.uefi;

--- a/lib/std/os/uefi/protocols.zig
+++ b/lib/std/os/uefi/protocols.zig
@@ -46,5 +46,5 @@ pub usingnamespace @import("protocols/hii_popup_protocol.zig");
 
 test {
     @setEvalBranchQuota(2000);
-    @import("std").testing.refAllDeclsRecursive(@This());
+    @import("../../std.zig").testing.refAllDeclsRecursive(@This());
 }

--- a/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
+++ b/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;

--- a/lib/std/os/uefi/protocols/block_io_protocol.zig
+++ b/lib/std/os/uefi/protocols/block_io_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Status = uefi.Status;
 const cc = uefi.cc;

--- a/lib/std/os/uefi/protocols/device_path_protocol.zig
+++ b/lib/std/os/uefi/protocols/device_path_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const mem = std.mem;
 const uefi = std.os.uefi;
 const Allocator = mem.Allocator;

--- a/lib/std/os/uefi/protocols/edid_active_protocol.zig
+++ b/lib/std/os/uefi/protocols/edid_active_protocol.zig
@@ -1,4 +1,4 @@
-const uefi = @import("std").os.uefi;
+const uefi = @import("../../../std.zig").os.uefi;
 const Guid = uefi.Guid;
 
 /// EDID information for an active video output device

--- a/lib/std/os/uefi/protocols/edid_discovered_protocol.zig
+++ b/lib/std/os/uefi/protocols/edid_discovered_protocol.zig
@@ -1,4 +1,4 @@
-const uefi = @import("std").os.uefi;
+const uefi = @import("../../../std.zig").os.uefi;
 const Guid = uefi.Guid;
 
 /// EDID information for a video output device

--- a/lib/std/os/uefi/protocols/edid_override_protocol.zig
+++ b/lib/std/os/uefi/protocols/edid_override_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Handle = uefi.Handle;

--- a/lib/std/os/uefi/protocols/file_protocol.zig
+++ b/lib/std/os/uefi/protocols/file_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const io = std.io;
 const Guid = uefi.Guid;

--- a/lib/std/os/uefi/protocols/graphics_output_protocol.zig
+++ b/lib/std/os/uefi/protocols/graphics_output_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;

--- a/lib/std/os/uefi/protocols/hii.zig
+++ b/lib/std/os/uefi/protocols/hii.zig
@@ -1,4 +1,4 @@
-const uefi = @import("std").os.uefi;
+const uefi = @import("../../../std.zig").os.uefi;
 const Guid = uefi.Guid;
 
 pub const HIIHandle = *opaque {};

--- a/lib/std/os/uefi/protocols/hii_database_protocol.zig
+++ b/lib/std/os/uefi/protocols/hii_database_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;

--- a/lib/std/os/uefi/protocols/hii_popup_protocol.zig
+++ b/lib/std/os/uefi/protocols/hii_popup_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;

--- a/lib/std/os/uefi/protocols/ip6_config_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_config_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;

--- a/lib/std/os/uefi/protocols/ip6_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;

--- a/lib/std/os/uefi/protocols/ip6_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/ip6_service_binding_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;

--- a/lib/std/os/uefi/protocols/loaded_image_protocol.zig
+++ b/lib/std/os/uefi/protocols/loaded_image_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Handle = uefi.Handle;

--- a/lib/std/os/uefi/protocols/managed_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/managed_network_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;

--- a/lib/std/os/uefi/protocols/managed_network_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/managed_network_service_binding_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;

--- a/lib/std/os/uefi/protocols/rng_protocol.zig
+++ b/lib/std/os/uefi/protocols/rng_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;

--- a/lib/std/os/uefi/protocols/shell_parameters_protocol.zig
+++ b/lib/std/os/uefi/protocols/shell_parameters_protocol.zig
@@ -1,4 +1,4 @@
-const uefi = @import("std").os.uefi;
+const uefi = @import("../../../std.zig").os.uefi;
 const Guid = uefi.Guid;
 const FileHandle = uefi.FileHandle;
 

--- a/lib/std/os/uefi/protocols/simple_file_system_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_file_system_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const FileProtocol = uefi.protocols.FileProtocol;

--- a/lib/std/os/uefi/protocols/simple_network_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_network_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;

--- a/lib/std/os/uefi/protocols/simple_pointer_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_pointer_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;

--- a/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_input_ex_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;

--- a/lib/std/os/uefi/protocols/simple_text_input_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_input_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;

--- a/lib/std/os/uefi/protocols/simple_text_output_protocol.zig
+++ b/lib/std/os/uefi/protocols/simple_text_output_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Status = uefi.Status;

--- a/lib/std/os/uefi/protocols/udp6_protocol.zig
+++ b/lib/std/os/uefi/protocols/udp6_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;

--- a/lib/std/os/uefi/protocols/udp6_service_binding_protocol.zig
+++ b/lib/std/os/uefi/protocols/udp6_service_binding_protocol.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Handle = uefi.Handle;
 const Guid = uefi.Guid;

--- a/lib/std/os/uefi/status.zig
+++ b/lib/std/os/uefi/status.zig
@@ -1,4 +1,4 @@
-const testing = @import("std").testing;
+const testing = @import("../../std.zig").testing;
 
 const high_bit = 1 << @typeInfo(usize).Int.bits - 1;
 

--- a/lib/std/os/uefi/tables.zig
+++ b/lib/std/os/uefi/tables.zig
@@ -5,5 +5,5 @@ pub usingnamespace @import("tables/system_table.zig");
 pub usingnamespace @import("tables/table_header.zig");
 
 test {
-    @import("std").testing.refAllDeclsRecursive(@This());
+    @import("../../std.zig").testing.refAllDeclsRecursive(@This());
 }

--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Event = uefi.Event;
 const Guid = uefi.Guid;

--- a/lib/std/os/uefi/tables/configuration_table.zig
+++ b/lib/std/os/uefi/tables/configuration_table.zig
@@ -1,4 +1,4 @@
-const uefi = @import("std").os.uefi;
+const uefi = @import("../../../std.zig").os.uefi;
 const Guid = uefi.Guid;
 
 pub const ConfigurationTable = extern struct {

--- a/lib/std/os/uefi/tables/runtime_services.zig
+++ b/lib/std/os/uefi/tables/runtime_services.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const TableHeader = uefi.tables.TableHeader;

--- a/lib/std/os/uefi/tables/system_table.zig
+++ b/lib/std/os/uefi/tables/system_table.zig
@@ -1,4 +1,4 @@
-const uefi = @import("std").os.uefi;
+const uefi = @import("../../../std.zig").os.uefi;
 const BootServices = uefi.tables.BootServices;
 const ConfigurationTable = uefi.tables.ConfigurationTable;
 const Handle = uefi.Handle;

--- a/lib/std/os/wasi.zig
+++ b/lib/std/os/wasi.zig
@@ -2,7 +2,7 @@
 // * typenames -- https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/witx/typenames.witx
 // * module -- https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/witx/wasi_snapshot_preview1.witx
 const builtin = @import("builtin");
-const std = @import("std");
+const std = @import("../std.zig");
 const assert = std.debug.assert;
 
 comptime {

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -221,7 +221,7 @@ pub extern "kernel32" fn GetFullPathNameW(
     nBufferLength: u32,
     lpBuffer: [*]u16,
     lpFilePart: ?*?[*:0]u16,
-) callconv(@import("std").os.windows.WINAPI) u32;
+) callconv(@import("../../std.zig").os.windows.WINAPI) u32;
 
 pub extern "kernel32" fn GetOverlappedResult(hFile: HANDLE, lpOverlapped: *OVERLAPPED, lpNumberOfBytesTransferred: *DWORD, bWait: BOOL) callconv(WINAPI) BOOL;
 

--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -2,7 +2,7 @@
 //! takes up 12 bytes of memory since u3's alignment is 1. PackedArray(u3, 12) only
 //! takes up 4 bytes of memory.
 
-const std = @import("std");
+const std = @import("std.zig");
 const builtin = @import("builtin");
 const debug = std.debug;
 const testing = std.testing;

--- a/lib/std/rand/Ascon.zig
+++ b/lib/std/rand/Ascon.zig
@@ -8,7 +8,7 @@
 //! - A Robust and Sponge-Like PRNG with Improved Efficiency https://eprint.iacr.org/2016/886.pdf
 //! - Ascon https://ascon.iaik.tugraz.at/files/asconv12-nist.pdf
 
-const std = @import("std");
+const std = @import("../std.zig");
 const mem = std.mem;
 const Random = std.rand.Random;
 const Self = @This();

--- a/lib/std/rand/ChaCha.zig
+++ b/lib/std/rand/ChaCha.zig
@@ -3,7 +3,7 @@
 //! References:
 //! - Fast-key-erasure random-number generators https://blog.cr.yp.to/20170723-random.html
 
-const std = @import("std");
+const std = @import("../std.zig");
 const mem = std.mem;
 const Random = std.rand.Random;
 const Self = @This();

--- a/lib/std/rand/Isaac64.zig
+++ b/lib/std/rand/Isaac64.zig
@@ -3,7 +3,7 @@
 //! Follows the general idea of the implementation from here with a few shortcuts.
 //! https://doc.rust-lang.org/rand/src/rand/prng/isaac64.rs.html
 
-const std = @import("std");
+const std = @import("../std.zig");
 const Random = std.rand.Random;
 const mem = std.mem;
 const Isaac64 = @This();

--- a/lib/std/rand/Pcg.zig
+++ b/lib/std/rand/Pcg.zig
@@ -2,7 +2,7 @@
 //!
 //! PRNG
 
-const std = @import("std");
+const std = @import("../std.zig");
 const Random = std.rand.Random;
 const Pcg = @This();
 

--- a/lib/std/rand/RomuTrio.zig
+++ b/lib/std/rand/RomuTrio.zig
@@ -2,7 +2,7 @@
 // Reference paper:   http://arxiv.org/abs/2002.11331
 // Beware: this PRNG is trivially predictable. While fast, it should *never* be used for cryptographic purposes.
 
-const std = @import("std");
+const std = @import("../std.zig");
 const Random = std.rand.Random;
 const math = std.math;
 const RomuTrio = @This();

--- a/lib/std/rand/Sfc64.zig
+++ b/lib/std/rand/Sfc64.zig
@@ -2,7 +2,7 @@
 //! Fastest engine of pracrand and smallest footprint.
 //! See http://pracrand.sourceforge.net/
 
-const std = @import("std");
+const std = @import("../std.zig");
 const Random = std.rand.Random;
 const math = std.math;
 const Sfc64 = @This();

--- a/lib/std/rand/Xoroshiro128.zig
+++ b/lib/std/rand/Xoroshiro128.zig
@@ -2,7 +2,7 @@
 //!
 //! PRNG
 
-const std = @import("std");
+const std = @import("../std.zig");
 const Random = std.rand.Random;
 const math = std.math;
 const Xoroshiro128 = @This();

--- a/lib/std/rand/Xoshiro256.zig
+++ b/lib/std/rand/Xoshiro256.zig
@@ -2,7 +2,7 @@
 //!
 //! PRNG
 
-const std = @import("std");
+const std = @import("../std.zig");
 const Random = std.rand.Random;
 const math = std.math;
 const Xoshiro256 = @This();

--- a/lib/std/rand/benchmark.zig
+++ b/lib/std/rand/benchmark.zig
@@ -1,6 +1,6 @@
 // zig run -O ReleaseFast --zig-lib-dir ../.. benchmark.zig
 
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const time = std.time;
 const Timer = time.Timer;

--- a/lib/std/simd.zig
+++ b/lib/std/simd.zig
@@ -3,7 +3,7 @@
 //! multiple elements at once.
 //! Please be aware that some functions are known to not work on MIPS.
 
-const std = @import("std");
+const std = @import("std.zig");
 const builtin = @import("builtin");
 
 pub fn suggestVectorSizeForCpu(comptime T: type, comptime cpu: std.Target.Cpu) ?usize {

--- a/lib/std/start_windows_tls.zig
+++ b/lib/std/start_windows_tls.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("std.zig");
 const builtin = @import("builtin");
 
 export var _tls_index: u32 = std.os.windows.TLS_OUT_OF_INDEXES;

--- a/lib/std/unicode/throughput_test.zig
+++ b/lib/std/unicode/throughput_test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const time = std.time;
 const unicode = std.unicode;
 

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -202,5 +202,5 @@ pub fn binNameAlloc(allocator: std.mem.Allocator, options: BinNameOptions) error
 }
 
 test {
-    @import("std").testing.refAllDecls(@This());
+    @import("std.zig").testing.refAllDecls(@This());
 }

--- a/lib/std/zig/ErrorBundle.zig
+++ b/lib/std/zig/ErrorBundle.zig
@@ -302,7 +302,7 @@ fn writeMsg(eb: ErrorBundle, err_msg: ErrorMessage, stderr: anytype, indent: usi
     }
 }
 
-const std = @import("std");
+const std = @import("../std.zig");
 const ErrorBundle = @This();
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;

--- a/lib/std/zig/Server.zig
+++ b/lib/std/zig/Server.zig
@@ -294,7 +294,7 @@ const InMessage = std.zig.Client.Message;
 
 const Server = @This();
 const builtin = @import("builtin");
-const std = @import("std");
+const std = @import("../std.zig");
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const native_endian = builtin.target.cpu.arch.endian();

--- a/lib/std/zig/c_builtins.zig
+++ b/lib/std/zig/c_builtins.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 
 pub inline fn __builtin_bswap16(val: u16) u16 {
     return @byteSwap(val);

--- a/lib/std/zig/c_translation.zig
+++ b/lib/std/zig/c_translation.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const builtin = @import("builtin");
 const testing = std.testing;
 const math = std.math;

--- a/lib/std/zig/fmt.zig
+++ b/lib/std/zig/fmt.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const mem = std.mem;
 
 /// Print the string as a Zig identifier escaping it with @"" syntax if needed.

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -6178,7 +6178,7 @@ test "ampersand" {
     , &.{});
 }
 
-const std = @import("std");
+const std = @import("../std.zig");
 const mem = std.mem;
 const print = std.debug.print;
 const io = std.io;

--- a/lib/std/zig/perf_test.zig
+++ b/lib/std/zig/perf_test.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const mem = std.mem;
 const Tokenizer = std.zig.Tokenizer;
 const io = std.io;

--- a/lib/std/zig/primitives.zig
+++ b/lib/std/zig/primitives.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 
 /// Set of primitive type and value names.
 /// Does not include `_` or integer type names.

--- a/lib/std/zig/system/arm.zig
+++ b/lib/std/zig/system/arm.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const Target = std.Target;
 
 pub const CoreInfo = struct {

--- a/lib/std/zig/system/darwin.zig
+++ b/lib/std/zig/system/darwin.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const mem = std.mem;
 const Allocator = mem.Allocator;
 const Target = std.Target;

--- a/lib/std/zig/system/darwin/macos.zig
+++ b/lib/std/zig/system/darwin/macos.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../../std.zig");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 const mem = std.mem;

--- a/lib/std/zig/system/linux.zig
+++ b/lib/std/zig/system/linux.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const mem = std.mem;
 const io = std.io;

--- a/lib/std/zig/system/windows.zig
+++ b/lib/std/zig/system/windows.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 const mem = std.mem;

--- a/lib/std/zig/system/x86.zig
+++ b/lib/std/zig/system/x86.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const builtin = @import("builtin");
 const Target = std.Target;
 const CrossTarget = std.zig.CrossTarget;


### PR DESCRIPTION
This changes all imports of `std` to be relative rather than import it as an external module. 