### PR TITLE
macho: tie FDEs and unwind records to all symbol aliases, not just the first global

### DIFF
--- a/test/link.zig
+++ b/test/link.zig
@@ -157,6 +157,10 @@ pub const cases = [_]Case{
         .import = @import("link/macho/pagezero/build.zig"),
     },
     .{
+        .build_root = "test/link/macho/reexports",
+        .import = @import("link/macho/reexports/build.zig"),
+    },
+    .{
         .build_root = "test/link/macho/search_strategy",
         .import = @import("link/macho/search_strategy/build.zig"),
     },

--- a/test/link/macho/reexports/a.zig
+++ b/test/link/macho/reexports/a.zig
@@ -1,0 +1,7 @@
+const x: i32 = 42;
+export fn foo() i32 {
+    return x;
+}
+comptime {
+    @export(foo, .{ .name = "bar", .linkage = .Strong });
+}

--- a/test/link/macho/reexports/build.zig
+++ b/test/link/macho/reexports/build.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+
+pub const requires_symlinks = true;
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    add(b, test_step, .Debug);
+    add(b, test_step, .ReleaseFast);
+    add(b, test_step, .ReleaseSmall);
+    add(b, test_step, .ReleaseSafe);
+}
+
+fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
+    const target: std.zig.CrossTarget = .{ .os_tag = .macos };
+
+    const lib = b.addStaticLibrary(.{
+        .name = "a",
+        .root_source_file = .{ .path = "a.zig" },
+        .optimize = optimize,
+        .target = target,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "test",
+        .optimize = optimize,
+        .target = target,
+    });
+    exe.addCSourceFile(.{ .file = .{ .path = "main.c" }, .flags = &.{} });
+    exe.linkLibrary(lib);
+    exe.linkLibC();
+
+    const run = b.addRunArtifact(exe);
+    run.skip_foreign_checks = true;
+    run.expectExitCode(0);
+    test_step.dependOn(&run.step);
+}

--- a/test/link/macho/reexports/main.c
+++ b/test/link/macho/reexports/main.c
@@ -1,0 +1,5 @@
+extern int foo();
+extern int bar();
+int main() {
+  return bar() - foo();
+}


### PR DESCRIPTION
This is in particular very important to the Zig language which allows exporting the same symbol under different names. For instance, it is possible to have a case such that:

```
...
4258 T _foo
4258 T _bar
...
```

In this case we need to keep track of both symbol names when resolving FDEs and unwind records.

Closes #16751
