### PR TITLE
Add '--compress-debug-sections=zstd'

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -39,7 +39,7 @@ name_only_filename: ?[]const u8,
 strip: ?bool,
 unwind_tables: ?bool,
 // keep in sync with src/link.zig:CompressDebugSections
-compress_debug_sections: enum { none, zlib } = .none,
+compress_debug_sections: enum { none, zlib, zstd } = .none,
 lib_paths: ArrayList(LazyPath),
 rpaths: ArrayList(LazyPath),
 framework_dirs: ArrayList(LazyPath),
@@ -1562,6 +1562,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     switch (self.compress_debug_sections) {
         .none => {},
         .zlib => try zig_args.append("--compress-debug-sections=zlib"),
+        .zstd => try zig_args.append("--compress-debug-sections=zstd"),
     }
 
     if (self.link_eh_frame_hdr) {

--- a/src/link.zig
+++ b/src/link.zig
@@ -285,7 +285,7 @@ pub const Options = struct {
 
 pub const HashStyle = enum { sysv, gnu, both };
 
-pub const CompressDebugSections = enum { none, zlib };
+pub const CompressDebugSections = enum { none, zlib, zstd };
 
 pub const File = struct {
     tag: Tag,

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1901,6 +1901,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
         switch (self.base.options.compress_debug_sections) {
             .none => {},
             .zlib => try argv.append("--compress-debug-sections=zlib"),
+            .zstd => try argv.append("--compress-debug-sections=zstd"),
         }
 
         if (self.base.options.bind_global_refs_locally) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -534,6 +534,7 @@ const usage_build_generic =
     \\  --compress-debug-sections=[e]  Debug section compression settings
     \\      none                       No compression
     \\      zlib                       Compression with deflate/inflate
+    \\      zstd                       Compression with zstandard
     \\  --gc-sections                  Force removal of functions and data that are unreachable by the entry point or exported symbols
     \\  --no-gc-sections               Don't force removal of unreachable functions and data
     \\  --sort-section=[value]         Sort wildcard section patterns by 'name' or 'alignment'
@@ -1081,7 +1082,7 @@ fn buildOutputType(
                     } else if (mem.startsWith(u8, arg, "--compress-debug-sections=")) {
                         const param = arg["--compress-debug-sections=".len..];
                         linker_compress_debug_sections = std.meta.stringToEnum(link.CompressDebugSections, param) orelse {
-                            fatal("expected --compress-debug-sections=[none|zlib], found '{s}'", .{param});
+                            fatal("expected --compress-debug-sections=[none|zlib|zstd], found '{s}'", .{param});
                         };
                     } else if (mem.eql(u8, arg, "--compress-debug-sections")) {
                         linker_compress_debug_sections = link.CompressDebugSections.zlib;
@@ -1935,7 +1936,7 @@ fn buildOutputType(
                             linker_compress_debug_sections = .zlib;
                         } else {
                             linker_compress_debug_sections = std.meta.stringToEnum(link.CompressDebugSections, it.only_arg) orelse {
-                                fatal("expected [none|zlib] after --compress-debug-sections, found '{s}'", .{it.only_arg});
+                                fatal("expected [none|zlib|zstd] after --compress-debug-sections, found '{s}'", .{it.only_arg});
                             };
                         }
                     },
@@ -2088,7 +2089,7 @@ fn buildOutputType(
                 } else if (mem.eql(u8, arg, "--compress-debug-sections")) {
                     const arg1 = linker_args_it.nextOrFatal();
                     linker_compress_debug_sections = std.meta.stringToEnum(link.CompressDebugSections, arg1) orelse {
-                        fatal("expected [none|zlib] after --compress-debug-sections, found '{s}'", .{arg1});
+                        fatal("expected [none|zlib|zstd] after --compress-debug-sections, found '{s}'", .{arg1});
                     };
                 } else if (mem.startsWith(u8, arg, "-z")) {
                     var z_arg = arg[2..];


### PR DESCRIPTION
Adds `--compress-debug-sections=zstd` (supported by llvm 16, see https://www.phoronix.com/news/LLVM-Landing-Zstd-Debug-Section)


Only tested with `zig cc`, after the PR:
```bash
 ~ $ zig cc hello.c -g -O0 -Wl,--compress-debug-sections=zstd && ls -l a.out
-rwxr-xr-x 1 user user 4064 Aug 16 22:13 a.out
 ~ $ zig cc hello.c -g -O0 -Wl,--compress-debug-sections=zlib && ls -l a.out
-rwxr-xr-x 1 user user 4040 Aug 16 22:13 a.out
 ~ $ zig cc hello.c -g -O0 -Wl,--compress-debug-sections=none && ls -l a.out
-rwxr-xr-x 1 user user 3976 Aug 16 22:13 a.out
```

with file `hello.c`
```bash
extern int printf(const char *restrict fmt, ...);
int main(void) {
    printf("Hello, world!\n");
    return 0;
}
```
Closes https://github.com/ziglang/zig/issues/16858