### PR TITLE
std.Build: check for native CPU when serializing CrossTarget

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -414,7 +414,12 @@ fn userInputOptionsFromArgs(allocator: Allocator, args: anytype) UserInputOption
                 }) catch @panic("OOM");
                 user_input_options.put("cpu", .{
                     .name = "cpu",
-                    .value = .{ .scalar = serializeCpu(allocator, v.getCpu()) catch unreachable },
+                    .value = .{
+                        .scalar = if (v.isNativeCpu())
+                            "native"
+                        else
+                            serializeCpu(allocator, v.getCpu()) catch unreachable,
+                    },
                     .used = false,
                 }) catch @panic("OOM");
             },


### PR DESCRIPTION
When using `std.Build.dependency` with target options, dependencies
would sometimes get targets which are equivalent but have distinct
names, e.g. `native` vs `native-native`. This is a somewhat broad issue,
and it's unclear how to fix it more generally - perhaps we should
special-case CrossTarget in options passing, or maybe targets should
have a canonical name which we guarantee to use everywhere aside from
raw user input.

However, this commit fixes the most egregious issue, which was an active
blocker to using the package manager for some users. This was caused by
the CPU changing from `native` to a specific descriptor (e.g.
`skylake+sgx`), which then changed the behavior of `zigTriple`.

Resolves: #16856