### PR TITLE
autodoc: Implement `a[b]`, `a.?`, and `a.*`

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1451,6 +1451,24 @@ Happy writing!
         return;
       }
 
+      case "optionalPayload": {
+        const opt = zigAnalysis.exprs[expr.optionalPayload];
+        yield* ex(opt, opts);
+        yield Tok.period;
+        yield Tok.question_mark;
+        return;
+      }
+
+      case "elemVal": {
+        const lhs = zigAnalysis.exprs[expr.elemVal.lhs];
+        const rhs = zigAnalysis.exprs[expr.elemVal.rhs];
+        yield* ex(lhs);
+        yield Tok.l_bracket;
+        yield* ex(rhs);
+        yield Tok.r_bracket;
+        return;
+      }
+
       case "string": {
         yield { src: '"' + expr.string + '"', tag: Tag.string_literal };
         return;
@@ -1880,7 +1898,7 @@ Happy writing!
             return;
           }
           case typeKinds.Optional: {
-            yield { src: "?", tag: Tag.question_mark };
+            yield Tok.question_mark;
             yield* ex(typeObj.child, opts);
             return;
           }

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1350,6 +1350,14 @@ Happy writing!
         yield* ex(zigAnalysis.exprs[expr["&"]], opts);
         return;
       }
+
+      case "load": {
+        yield* ex(zigAnalysis.exprs[expr.load], opts);
+        yield Tok.period;
+        yield Tok.asterisk;
+        return;
+      }
+
       case "call": {
 
         let call = zigAnalysis.calls[expr.call];

--- a/lib/docs/ziglexer.js
+++ b/lib/docs/ziglexer.js
@@ -144,6 +144,7 @@ const Tok = {
     r_paren: { src: ")", tag: Tag.r_paren },
     period: { src: ".", tag: Tag.period },
     comma: { src: ",", tag: Tag.comma },
+    question_mark: { src: "?", tag: Tag.question_mark },
     identifier: (name) => { return { src: name, tag: Tag.identifier } },
 };
 

--- a/lib/docs/ziglexer.js
+++ b/lib/docs/ziglexer.js
@@ -145,6 +145,7 @@ const Tok = {
     period: { src: ".", tag: Tag.period },
     comma: { src: ",", tag: Tag.comma },
     question_mark: { src: "?", tag: Tag.question_mark },
+    asterisk: { src: "*", tag: Tag.asterisk },
     identifier: (name) => { return { src: name, tag: Tag.identifier } },
 };
 


### PR DESCRIPTION
Rendering of `optionalPayload` assumes `a.?` syntax for now since other expressions using `optional_payload_*` are `if`, `orelse` and `while` which we don't analyse yet