### PR TITLE
InternPool: safer enum API

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -6655,7 +6655,7 @@ pub fn enumValueFieldIndex(mod: *Module, ty: Type, field_index: u32) Allocator.E
 
     return (try ip.get(gpa, .{ .enum_tag = .{
         .ty = ty.toIntern(),
-        .int = enum_type.values[field_index],
+        .int = enum_type.values.get(ip)[field_index],
     } })).toValue();
 }
 

--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -238,7 +238,7 @@ pub fn print(
                 }
                 const enum_type = ip.indexToKey(ty.toIntern()).enum_type;
                 if (enum_type.tagValueIndex(ip, val.toIntern())) |tag_index| {
-                    try writer.print(".{i}", .{enum_type.names[tag_index].fmt(ip)});
+                    try writer.print(".{i}", .{enum_type.names.get(ip)[tag_index].fmt(ip)});
                     return;
                 }
                 try writer.writeAll("@enumFromInt(");

--- a/src/type.zig
+++ b/src/type.zig
@@ -2434,11 +2434,11 @@ pub const Type = struct {
     /// resolves field types rather than asserting they are already resolved.
     pub fn onePossibleValue(starting_type: Type, mod: *Module) !?Value {
         var ty = starting_type;
-
+        const ip = &mod.intern_pool;
         while (true) switch (ty.toIntern()) {
             .empty_struct_type => return Value.empty_struct,
 
-            else => switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+            else => switch (ip.indexToKey(ty.toIntern())) {
                 .int_type => |int_type| {
                     if (int_type.bits == 0) {
                         return try mod.intValue(ty, 0);
@@ -2619,7 +2619,7 @@ pub const Type = struct {
                                     } });
                                     return only.toValue();
                                 } else {
-                                    return enum_type.values[0].toValue();
+                                    return enum_type.values.get(ip)[0].toValue();
                                 }
                             },
                             else => return null,
@@ -2967,7 +2967,8 @@ pub const Type = struct {
     }
 
     pub fn enumFields(ty: Type, mod: *Module) []const InternPool.NullTerminatedString {
-        return mod.intern_pool.indexToKey(ty.toIntern()).enum_type.names;
+        const ip = &mod.intern_pool;
+        return ip.indexToKey(ty.toIntern()).enum_type.names.get(ip);
     }
 
     pub fn enumFieldCount(ty: Type, mod: *Module) usize {
@@ -2975,7 +2976,8 @@ pub const Type = struct {
     }
 
     pub fn enumFieldName(ty: Type, field_index: usize, mod: *Module) InternPool.NullTerminatedString {
-        return mod.intern_pool.indexToKey(ty.toIntern()).enum_type.names[field_index];
+        const ip = &mod.intern_pool;
+        return ip.indexToKey(ty.toIntern()).enum_type.names.get(ip)[field_index];
     }
 
     pub fn enumFieldIndex(ty: Type, field_name: InternPool.NullTerminatedString, mod: *Module) ?u32 {

--- a/src/value.zig
+++ b/src/value.zig
@@ -426,7 +426,7 @@ pub const Value = struct {
                     // Assume it is already an integer and return it directly.
                     .simple_type, .int_type => val,
                     .enum_type => |enum_type| if (enum_type.values.len != 0)
-                        enum_type.values[field_index].toValue()
+                        enum_type.values.get(ip)[field_index].toValue()
                     else // Field index and integer values are the same.
                         mod.intValue(enum_type.tag_ty.toType(), field_index),
                     else => unreachable,


### PR DESCRIPTION
The key changes in this commit are:

```diff
-        names: []const NullTerminatedString,
+        names: NullTerminatedString.Slice,
-        values: []const Index,
+        values: Index.Slice,
```

Which eliminates the slices from `InternPool.Key.EnumType` and replaces them with structs that contain `start` and `len` indexes. This makes the lifetime of `EnumType` change from expiring with updates to InternPool, to expiring when the InternPool is garbage-collected, which is currently never.

This is gearing up for a larger change I started working on locally which moves union types into InternPool.

As a bonus, I fixed some unnecessary instances of `@as`.