### PR TITLE
Add NetworkNotFound to ReadLinkError

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2995,6 +2995,8 @@ pub const ReadLinkError = error{
     /// Windows-only. This error may occur if the opened reparse point is
     /// of unsupported type.
     UnsupportedReparsePointType,
+    /// On Windows, `\\server` or `\\server\share` was not found.
+    NetworkNotFound,
 } || UnexpectedError;
 
 /// Read value of a symbolic link.

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -803,6 +803,7 @@ pub fn CreateSymbolicLink(
 
 pub const ReadLinkError = error{
     FileNotFound,
+    NetworkNotFound,
     AccessDenied,
     Unexpected,
     NameTooLong,
@@ -850,9 +851,8 @@ pub fn ReadLink(dir: ?HANDLE, sub_path_w: []const u16, out_buffer: []u8) ReadLin
         .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
         .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
         .NO_MEDIA_IN_DEVICE => return error.FileNotFound,
-        // TODO: Should BAD_NETWORK_* be translated to a different error?
-        .BAD_NETWORK_PATH => return error.FileNotFound, // \\server was not found
-        .BAD_NETWORK_NAME => return error.FileNotFound, // \\server was found but \\server\share wasn't
+        .BAD_NETWORK_PATH => return error.NetworkNotFound, // \\server was not found
+        .BAD_NETWORK_NAME => return error.NetworkNotFound, // \\server was found but \\server\share wasn't
         .INVALID_PARAMETER => unreachable,
         .SHARING_VIOLATION => return error.AccessDenied,
         .ACCESS_DENIED => return error.AccessDenied,

--- a/lib/std/zig/system/NativeTargetInfo.zig
+++ b/lib/std/zig/system/NativeTargetInfo.zig
@@ -833,6 +833,7 @@ pub fn abiAndDynamicLinkerFromFile(
                 error.InvalidUtf8 => unreachable, // Windows only
                 error.BadPathName => unreachable, // Windows only
                 error.UnsupportedReparsePointType => unreachable, // Windows only
+                error.NetworkNotFound => unreachable, // Windows only
 
                 error.AccessDenied,
                 error.FileNotFound,


### PR DESCRIPTION
From https://github.com/ziglang/zig/pull/16568:

> The only other `NtCreateFile` call is in `ReadLink` but I made that translate `BAD_NETWORK_PATH`/`BAD_NETWORK_NAME` to `error.FileNotFound`. I'm unsure about that decision.

This will make `ReadLink` match how the other filesystem functions were made to handle `BAD_NETWORK_PATH`/`BAD_NETWORK_NAME` in https://github.com/ziglang/zig/pull/16568. ReadLink was previously the odd one out, but that will no longer be the case.

