### PR TITLE
fix std.fs.Dir.makePath silent failure

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1094,8 +1094,8 @@ test "makePath but sub_path contains pre-existing file" {
     defer tmp.cleanup();
 
     try tmp.dir.makeDir("foo");
-    try tmp.dir.writeFile("foo" ++ fs.path.sep_str ++ "bar", "");
-    
+    try tmp.dir.writeFile("foo/bar", "");
+
     try testing.expectError(error.NotDir, tmp.dir.makePath("foo/bar/baz"));
 }
 

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1090,22 +1090,13 @@ test "makePath in a directory that no longer exists" {
 }
 
 test "makePath but sub_path contains pre-existing file" {
-    // makePath tmp/foo/bar/baz, but bar is a file
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
-    var fba = std.heap.FixedBufferAllocator.init(&buf);
-    var buf_alloc = fba.allocator();
-
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
-    
+
     try tmp.dir.makeDir("foo");
-    var foo = try tmp.dir.openDir("foo", .{});
-    defer foo.close();
-    var bar = try foo.createFile("bar", .{});
-    defer bar.close();
+    try tmp.dir.writeFile("foo" ++ fs.path.sep_str ++ "bar", "");
     
-    var sub_path = try std.fs.path.join(buf_alloc, &[_][]const u8{"foo", "bar", "baz"});
-    try testing.expectError(error.NotDir, tmp.dir.makePath(sub_path));
+    try testing.expectError(error.NotDir, tmp.dir.makePath("foo/bar/baz"));
 }
 
 fn expectDir(dir: Dir, path: []const u8) !void {


### PR DESCRIPTION
std.fs.dir.makePath silently fails if one of the items in the path already exists. For example:

cwd.makePath("foo/bar/baz")

Silently failing is OK if "bar" is already a directory or a symlink that resolves to a directory - this is the intended use of makePath (like mkdir -p). But if bar is a file then the subdirectory baz cannot be created - the end result is that makePath doesn't do anything and never creates the directory baz which should be a detectable error.

The existing code had a TODO comment that did not specifically cover this error, but the solution for this silent failure also accomplishes the TODO task - the code now stats "foo" and returns an appropriate error if necessary. The new code also handles potential race condition if "bar" is deleted/permissions changed/etc in between the initial makeDir and statFile calls.