### PR TITLE
compiler: resolve framework paths in the frontend

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -37,6 +37,7 @@ pub const SystemLib = struct {
 pub const Framework = struct {
     needed: bool = false,
     weak: bool = false,
+    path: []const u8,
 };
 
 pub const SortSection = enum { name, alignment };

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -870,7 +870,7 @@ fn resolveLibSystemInDirs(arena: Allocator, dirs: []const []const u8, out_libs: 
     return false;
 }
 
-pub fn resolveLib(
+fn resolveLib(
     arena: Allocator,
     search_dir: []const u8,
     name: []const u8,
@@ -878,26 +878,6 @@ pub fn resolveLib(
 ) !?[]const u8 {
     const search_name = try std.fmt.allocPrint(arena, "lib{s}{s}", .{ name, ext });
     const full_path = try fs.path.join(arena, &[_][]const u8{ search_dir, search_name });
-
-    // Check if the file exists.
-    const tmp = fs.cwd().openFile(full_path, .{}) catch |err| switch (err) {
-        error.FileNotFound => return null,
-        else => |e| return e,
-    };
-    defer tmp.close();
-
-    return full_path;
-}
-
-pub fn resolveFramework(
-    arena: Allocator,
-    search_dir: []const u8,
-    name: []const u8,
-    ext: []const u8,
-) !?[]const u8 {
-    const search_name = try std.fmt.allocPrint(arena, "{s}{s}", .{ name, ext });
-    const prefix_path = try std.fmt.allocPrint(arena, "{s}.framework", .{name});
-    const full_path = try fs.path.join(arena, &[_][]const u8{ search_dir, prefix_path, search_name });
 
     // Check if the file exists.
     const tmp = fs.cwd().openFile(full_path, .{}) catch |err| switch (err) {

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -3560,17 +3560,8 @@ pub fn linkWithZld(macho_file: *MachO, comp: *Compilation, prog_node: *std.Progr
         try MachO.resolveLibSystem(arena, comp, options.sysroot, target, options.lib_dirs, &libs);
 
         // frameworks
-        var framework_dirs = std.ArrayList([]const u8).init(arena);
-        for (options.framework_dirs) |dir| {
-            if (try MachO.resolveSearchDir(arena, dir, options.sysroot)) |search_dir| {
-                try framework_dirs.append(search_dir);
-            } else {
-                log.warn("directory not found for '-F{s}'", .{dir});
-            }
-        }
-
         outer: for (options.frameworks.keys()) |f_name| {
-            for (framework_dirs.items) |dir| {
+            for (options.framework_dirs) |dir| {
                 for (&[_][]const u8{ ".tbd", ".dylib", "" }) |ext| {
                     if (try MachO.resolveFramework(arena, dir, f_name, ext)) |full_path| {
                         const info = options.frameworks.get(f_name).?;
@@ -3590,7 +3581,7 @@ pub fn linkWithZld(macho_file: *MachO, comp: *Compilation, prog_node: *std.Progr
 
         if (framework_not_found) {
             log.warn("Framework search paths:", .{});
-            for (framework_dirs.items) |dir| {
+            for (options.framework_dirs) |dir| {
                 log.warn("  {s}", .{dir});
             }
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -2566,7 +2566,7 @@ fn buildOutputType(
             want_native_include_dirs = true;
     }
 
-    // Resolve the library path arguments with respect to sysroot.
+    // Resolve the library and framework path arguments with respect to sysroot.
     var lib_dirs = std.ArrayList([]const u8).init(arena);
     if (sysroot) |root| {
         for (lib_dir_args.items) |dir| {


### PR DESCRIPTION
This is a follow-up to #16058 and moves framework path resolution from the linker to the frontend. Here's what this now looks like:

```
$ zig cc hello.c -framework Foo
error: unable to find framework 'Foo'. searched paths: 
 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/System/Library/Frameworks/Foo.framework/Foo.tbd
 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/System/Library/Frameworks/Foo.framework/Foo.dylib

$ zig cc hello.c -framework Foundation
$ otool -lv a.out | grep Foundation
         name /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (offset 24)
```