### PR TITLE
Sema: error when attempting to mutate pointer to comptime-only type at runtime

### DIFF
--- a/test/cases/compile_errors/mutate_pointer_to_comptime_only_const.zig
+++ b/test/cases/compile_errors/mutate_pointer_to_comptime_only_const.zig
@@ -1,0 +1,19 @@
+export fn foo() void {
+    const x = 1;
+    const ptr: *comptime_int = @constCast(&x);
+    ptr.* = 123;
+}
+export fn bar() void {
+    const T = u32;
+    const ptr: *type = @constCast(&T);
+    ptr.* = anyopaque;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:11: error: cannot assign to constant
+// :4:8: note: mutable pointer refers to constant data
+// :9:11: error: cannot assign to constant
+// :9:8: note: mutable pointer refers to constant data


### PR DESCRIPTION
In this case, we know the pointer was not comptime-mutable, so it must refer to a comptime constant.

Resolves: #16877

edit: ugh inferred allocations suck. this will be harder than expected