### PR TITLE
compiler: provide result type to @enumFromInt operand

### DIFF
--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -251,6 +251,9 @@ pub const Inst = struct {
         /// Given a vector type, returns its element type.
         /// Uses the `un_node` field.
         vector_elem_type,
+        /// Given an enum type, returns its int backing type.
+        /// Uses the `un_node` field.
+        enum_backing_type,
         /// Given a pointer to an indexable object, returns the len property. This is
         /// used by for loops. This instruction also emits a for-loop specific compile
         /// error if the indexable object is not indexable.
@@ -1022,6 +1025,7 @@ pub const Inst = struct {
                 .elem_type_index,
                 .elem_type,
                 .vector_elem_type,
+                .enum_backing_type,
                 .indexable_ptr_len,
                 .anyframe_type,
                 .as,
@@ -1326,6 +1330,7 @@ pub const Inst = struct {
                 .elem_type_index,
                 .elem_type,
                 .vector_elem_type,
+                .enum_backing_type,
                 .indexable_ptr_len,
                 .anyframe_type,
                 .as,
@@ -1558,6 +1563,7 @@ pub const Inst = struct {
                 .elem_type_index = .bin,
                 .elem_type = .un_node,
                 .vector_elem_type = .un_node,
+                .enum_backing_type = .un_node,
                 .indexable_ptr_len = .un_node,
                 .anyframe_type = .un_node,
                 .as = .bin,

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -155,6 +155,7 @@ const Writer = struct {
             .alloc_comptime_mut,
             .elem_type,
             .vector_elem_type,
+            .enum_backing_type,
             .indexable_ptr_len,
             .anyframe_type,
             .bit_not,

--- a/test/behavior/enum.zig
+++ b/test/behavior/enum.zig
@@ -1214,3 +1214,15 @@ test "auto-numbered enum with signed tag type" {
     try std.testing.expectEqualStrings("a", @tagName(E.a));
     try std.testing.expectEqualStrings("b", @tagName(E.b));
 }
+
+test "@enumFromInt gives operand result type" {
+    const large_two: u64 = (1 << 40) + 2;
+
+    const Explicit = enum(u8) { a = 1, b = 2, c = 0 };
+    const x: Explicit = @enumFromInt(@truncate(large_two));
+    try std.testing.expectEqual(Explicit.b, x);
+
+    const Implicit = enum { a, b, c };
+    const y: Implicit = @enumFromInt(@truncate(large_two));
+    try std.testing.expectEqual(Implicit.c, y);
+}


### PR DESCRIPTION
The enum's backing type is used to provide the result type via a new ZIR instruction.

Resolves: #16814