### PR TITLE
compiler: move unions into InternPool

### DIFF
--- a/lib/std/dwarf/call_frame.zig
+++ b/lib/std/dwarf/call_frame.zig
@@ -69,14 +69,7 @@ pub const Instruction = union(Opcode) {
         register: u8,
         offset: u64,
     },
-    offset_extended: struct {
-        register: u8,
-        offset: u64,
-    },
     restore: struct {
-        register: u8,
-    },
-    restore_extended: struct {
         register: u8,
     },
     nop: void,
@@ -91,6 +84,13 @@ pub const Instruction = union(Opcode) {
     },
     advance_loc4: struct {
         delta: u32,
+    },
+    offset_extended: struct {
+        register: u8,
+        offset: u64,
+    },
+    restore_extended: struct {
+        register: u8,
     },
     undefined: struct {
         register: u8,

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -614,9 +614,9 @@ test "std.meta.FieldEnum" {
     const Tagged = union(enum) { a: u8, b: void, c: f32 };
     try testing.expectEqual(Tag(Tagged), FieldEnum(Tagged));
 
-    const Tag2 = enum { b, c, a };
+    const Tag2 = enum { a, b, c };
     const Tagged2 = union(Tag2) { a: u8, b: void, c: f32 };
-    try testing.expect(Tag(Tagged2) != FieldEnum(Tagged2));
+    try testing.expect(Tag(Tagged2) == FieldEnum(Tagged2));
 
     const Tag3 = enum(u8) { a, b, c = 7 };
     const Tagged3 = union(Tag3) { a: u8, b: void, c: f32 };

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -4696,6 +4696,7 @@ fn unionDeclInner(
 
     const bits_per_field = 4;
     const max_field_size = 5;
+    var any_aligned_fields = false;
     var wip_members = try WipMembers.init(gpa, &astgen.scratch, decl_count, field_count, bits_per_field, max_field_size);
     defer wip_members.deinit();
 
@@ -4733,6 +4734,7 @@ fn unionDeclInner(
         if (have_align) {
             const align_inst = try expr(&block_scope, &block_scope.base, .{ .rl = .{ .ty = .u32_type } }, member.ast.align_expr);
             wip_members.appendToField(@intFromEnum(align_inst));
+            any_aligned_fields = true;
         }
         if (have_value) {
             if (arg_inst == .none) {
@@ -4783,6 +4785,7 @@ fn unionDeclInner(
         .fields_len = field_count,
         .decls_len = decl_count,
         .auto_enum_tag = auto_enum_tok != null,
+        .any_aligned_fields = any_aligned_fields,
     });
 
     wip_members.finishBits(bits_per_field);
@@ -11754,6 +11757,7 @@ const GenZir = struct {
         decls_len: u32,
         layout: std.builtin.Type.ContainerLayout,
         auto_enum_tag: bool,
+        any_aligned_fields: bool,
     }) !void {
         const astgen = gz.astgen;
         const gpa = astgen.gpa;
@@ -11790,6 +11794,7 @@ const GenZir = struct {
                     .name_strategy = gz.anon_name_strategy,
                     .layout = args.layout,
                     .auto_enum_tag = args.auto_enum_tag,
+                    .any_aligned_fields = args.any_aligned_fields,
                 }),
                 .operand = payload_index,
             } },

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -96,7 +96,7 @@ intern_pool: InternPool = .{},
 /// Current uses that must be eliminated:
 /// * Struct comptime_args
 /// * Struct optimized_order
-/// * Union fields
+/// * comptime pointer mutation
 /// This memory lives until the Module is destroyed.
 tmp_hack_arena: std.heap.ArenaAllocator,
 
@@ -736,7 +736,7 @@ pub const Decl = struct {
 
     /// If the Decl owns its value and it is a union, return it,
     /// otherwise null.
-    pub fn getOwnedUnion(decl: Decl, mod: *Module) ?*Union {
+    pub fn getOwnedUnion(decl: Decl, mod: *Module) ?InternPool.UnionType {
         if (!decl.owns_tv) return null;
         if (decl.val.ip_index == .none) return null;
         return mod.typeToUnion(decl.val.toType());
@@ -778,7 +778,7 @@ pub const Decl = struct {
             else => switch (mod.intern_pool.indexToKey(decl.val.toIntern())) {
                 .opaque_type => |opaque_type| opaque_type.namespace.toOptional(),
                 .struct_type => |struct_type| struct_type.namespace,
-                .union_type => |union_type| mod.unionPtr(union_type.index).namespace.toOptional(),
+                .union_type => |union_type| union_type.namespace.toOptional(),
                 .enum_type => |enum_type| enum_type.namespace,
                 else => .none,
             },
@@ -1060,246 +1060,6 @@ pub const Struct = struct {
         return .{
             .struct_obj = s,
             .module = module,
-        };
-    }
-};
-
-pub const Union = struct {
-    /// An enum type which is used for the tag of the union.
-    /// This type is created even for untagged unions, even when the memory
-    /// layout does not store the tag.
-    /// Whether zig chooses this type or the user specifies it, it is stored here.
-    /// This will be set to the null type until status is `have_field_types`.
-    tag_ty: Type,
-    /// Set of field names in declaration order.
-    fields: Fields,
-    /// Represents the declarations inside this union.
-    namespace: Namespace.Index,
-    /// The Decl that corresponds to the union itself.
-    owner_decl: Decl.Index,
-    /// Index of the union_decl ZIR instruction.
-    zir_index: Zir.Inst.Index,
-
-    layout: std.builtin.Type.ContainerLayout,
-    status: enum {
-        none,
-        field_types_wip,
-        have_field_types,
-        layout_wip,
-        have_layout,
-        fully_resolved_wip,
-        // The types and all its fields have had their layout resolved. Even through pointer,
-        // which `have_layout` does not ensure.
-        fully_resolved,
-    },
-    requires_comptime: PropertyBoolean = .unknown,
-    assumed_runtime_bits: bool = false,
-
-    pub const Index = enum(u32) {
-        _,
-
-        pub fn toOptional(i: Index) OptionalIndex {
-            return @as(OptionalIndex, @enumFromInt(@intFromEnum(i)));
-        }
-    };
-
-    pub const OptionalIndex = enum(u32) {
-        none = std.math.maxInt(u32),
-        _,
-
-        pub fn init(oi: ?Index) OptionalIndex {
-            return @as(OptionalIndex, @enumFromInt(@intFromEnum(oi orelse return .none)));
-        }
-
-        pub fn unwrap(oi: OptionalIndex) ?Index {
-            if (oi == .none) return null;
-            return @as(Index, @enumFromInt(@intFromEnum(oi)));
-        }
-    };
-
-    pub const Field = struct {
-        /// undefined until `status` is `have_field_types` or `have_layout`.
-        ty: Type,
-        /// 0 means the ABI alignment of the type.
-        abi_align: Alignment,
-
-        /// Returns the field alignment, assuming the union is not packed.
-        /// Keep implementation in sync with `Sema.unionFieldAlignment`.
-        /// Prefer to call that function instead of this one during Sema.
-        pub fn normalAlignment(field: Field, mod: *Module) u32 {
-            return @as(u32, @intCast(field.abi_align.toByteUnitsOptional() orelse field.ty.abiAlignment(mod)));
-        }
-    };
-
-    pub const Fields = std.AutoArrayHashMapUnmanaged(InternPool.NullTerminatedString, Field);
-
-    pub fn getFullyQualifiedName(s: *Union, mod: *Module) !InternPool.NullTerminatedString {
-        return mod.declPtr(s.owner_decl).getFullyQualifiedName(mod);
-    }
-
-    pub fn srcLoc(self: Union, mod: *Module) SrcLoc {
-        const owner_decl = mod.declPtr(self.owner_decl);
-        return .{
-            .file_scope = owner_decl.getFileScope(mod),
-            .parent_decl_node = owner_decl.src_node,
-            .lazy = LazySrcLoc.nodeOffset(0),
-        };
-    }
-
-    pub fn haveFieldTypes(u: Union) bool {
-        return switch (u.status) {
-            .none,
-            .field_types_wip,
-            => false,
-            .have_field_types,
-            .layout_wip,
-            .have_layout,
-            .fully_resolved_wip,
-            .fully_resolved,
-            => true,
-        };
-    }
-
-    pub fn hasAllZeroBitFieldTypes(u: Union, mod: *Module) bool {
-        assert(u.haveFieldTypes());
-        for (u.fields.values()) |field| {
-            if (field.ty.hasRuntimeBits(mod)) return false;
-        }
-        return true;
-    }
-
-    pub fn mostAlignedField(u: Union, mod: *Module) u32 {
-        assert(u.haveFieldTypes());
-        var most_alignment: u32 = 0;
-        var most_index: usize = undefined;
-        for (u.fields.values(), 0..) |field, i| {
-            if (!field.ty.hasRuntimeBits(mod)) continue;
-
-            const field_align = field.normalAlignment(mod);
-            if (field_align > most_alignment) {
-                most_alignment = field_align;
-                most_index = i;
-            }
-        }
-        return @as(u32, @intCast(most_index));
-    }
-
-    /// Returns 0 if the union is represented with 0 bits at runtime.
-    pub fn abiAlignment(u: Union, mod: *Module, have_tag: bool) u32 {
-        var max_align: u32 = 0;
-        if (have_tag) max_align = u.tag_ty.abiAlignment(mod);
-        for (u.fields.values()) |field| {
-            if (!field.ty.hasRuntimeBits(mod)) continue;
-
-            const field_align = field.normalAlignment(mod);
-            max_align = @max(max_align, field_align);
-        }
-        return max_align;
-    }
-
-    pub fn abiSize(u: Union, mod: *Module, have_tag: bool) u64 {
-        return u.getLayout(mod, have_tag).abi_size;
-    }
-
-    pub const Layout = struct {
-        abi_size: u64,
-        abi_align: u32,
-        most_aligned_field: u32,
-        most_aligned_field_size: u64,
-        biggest_field: u32,
-        payload_size: u64,
-        payload_align: u32,
-        tag_align: u32,
-        tag_size: u64,
-        padding: u32,
-    };
-
-    pub fn haveLayout(u: Union) bool {
-        return switch (u.status) {
-            .none,
-            .field_types_wip,
-            .have_field_types,
-            .layout_wip,
-            => false,
-            .have_layout,
-            .fully_resolved_wip,
-            .fully_resolved,
-            => true,
-        };
-    }
-
-    pub fn getLayout(u: Union, mod: *Module, have_tag: bool) Layout {
-        assert(u.haveLayout());
-        var most_aligned_field: u32 = undefined;
-        var most_aligned_field_size: u64 = undefined;
-        var biggest_field: u32 = undefined;
-        var payload_size: u64 = 0;
-        var payload_align: u32 = 0;
-        const fields = u.fields.values();
-        for (fields, 0..) |field, i| {
-            if (!field.ty.hasRuntimeBitsIgnoreComptime(mod)) continue;
-
-            const field_align = field.abi_align.toByteUnitsOptional() orelse field.ty.abiAlignment(mod);
-            const field_size = field.ty.abiSize(mod);
-            if (field_size > payload_size) {
-                payload_size = field_size;
-                biggest_field = @as(u32, @intCast(i));
-            }
-            if (field_align > payload_align) {
-                payload_align = @as(u32, @intCast(field_align));
-                most_aligned_field = @as(u32, @intCast(i));
-                most_aligned_field_size = field_size;
-            }
-        }
-        payload_align = @max(payload_align, 1);
-        if (!have_tag or !u.tag_ty.hasRuntimeBits(mod)) {
-            return .{
-                .abi_size = std.mem.alignForward(u64, payload_size, payload_align),
-                .abi_align = payload_align,
-                .most_aligned_field = most_aligned_field,
-                .most_aligned_field_size = most_aligned_field_size,
-                .biggest_field = biggest_field,
-                .payload_size = payload_size,
-                .payload_align = payload_align,
-                .tag_align = 0,
-                .tag_size = 0,
-                .padding = 0,
-            };
-        }
-        // Put the tag before or after the payload depending on which one's
-        // alignment is greater.
-        const tag_size = u.tag_ty.abiSize(mod);
-        const tag_align = @max(1, u.tag_ty.abiAlignment(mod));
-        var size: u64 = 0;
-        var padding: u32 = undefined;
-        if (tag_align >= payload_align) {
-            // {Tag, Payload}
-            size += tag_size;
-            size = std.mem.alignForward(u64, size, payload_align);
-            size += payload_size;
-            const prev_size = size;
-            size = std.mem.alignForward(u64, size, tag_align);
-            padding = @as(u32, @intCast(size - prev_size));
-        } else {
-            // {Payload, Tag}
-            size += payload_size;
-            size = std.mem.alignForward(u64, size, tag_align);
-            size += tag_size;
-            const prev_size = size;
-            size = std.mem.alignForward(u64, size, payload_align);
-            padding = @as(u32, @intCast(size - prev_size));
-        }
-        return .{
-            .abi_size = size,
-            .abi_align = @max(tag_align, payload_align),
-            .most_aligned_field = most_aligned_field,
-            .most_aligned_field_size = most_aligned_field_size,
-            .biggest_field = biggest_field,
-            .payload_size = payload_size,
-            .payload_align = payload_align,
-            .tag_align = tag_align,
-            .tag_size = tag_size,
-            .padding = padding,
         };
     }
 };
@@ -3182,10 +2942,6 @@ pub fn namespacePtr(mod: *Module, index: Namespace.Index) *Namespace {
     return mod.intern_pool.namespacePtr(index);
 }
 
-pub fn unionPtr(mod: *Module, index: Union.Index) *Union {
-    return mod.intern_pool.unionPtr(index);
-}
-
 pub fn structPtr(mod: *Module, index: Struct.Index) *Struct {
     return mod.intern_pool.structPtr(index);
 }
@@ -3651,11 +3407,11 @@ fn updateZirRefs(mod: *Module, file: *File, old_zir: Zir) !void {
             };
         }
 
-        if (decl.getOwnedUnion(mod)) |union_obj| {
-            union_obj.zir_index = inst_map.get(union_obj.zir_index) orelse {
+        if (decl.getOwnedUnion(mod)) |union_type| {
+            union_type.setZirIndex(ip, inst_map.get(union_type.zir_index) orelse {
                 try file.deleted_decls.append(gpa, decl_index);
                 continue;
-            };
+            });
         }
 
         if (decl.getOwnedFunction(mod)) |func| {
@@ -5550,14 +5306,6 @@ pub fn destroyStruct(mod: *Module, index: Struct.Index) void {
     return mod.intern_pool.destroyStruct(mod.gpa, index);
 }
 
-pub fn createUnion(mod: *Module, initialization: Union) Allocator.Error!Union.Index {
-    return mod.intern_pool.createUnion(mod.gpa, initialization);
-}
-
-pub fn destroyUnion(mod: *Module, index: Union.Index) void {
-    return mod.intern_pool.destroyUnion(mod.gpa, index);
-}
-
 pub fn allocateNewDecl(
     mod: *Module,
     namespace: Namespace.Index,
@@ -6956,10 +6704,14 @@ pub fn typeToStruct(mod: *Module, ty: Type) ?*Struct {
     return mod.structPtr(struct_index);
 }
 
-pub fn typeToUnion(mod: *Module, ty: Type) ?*Union {
+/// This asserts that the union's enum tag type has been resolved.
+pub fn typeToUnion(mod: *Module, ty: Type) ?InternPool.UnionType {
     if (ty.ip_index == .none) return null;
-    const union_index = mod.intern_pool.indexToUnionType(ty.toIntern()).unwrap() orelse return null;
-    return mod.unionPtr(union_index);
+    const ip = &mod.intern_pool;
+    switch (ip.indexToKey(ty.ip_index)) {
+        .union_type => |k| return ip.loadUnionType(k),
+        else => return null,
+    }
 }
 
 pub fn typeToFunc(mod: *Module, ty: Type) ?InternPool.Key.FuncType {
@@ -7044,4 +6796,132 @@ pub fn getParamName(mod: *Module, func_index: InternPool.Index, index: u32) [:0]
         },
         else => unreachable,
     };
+}
+
+pub const UnionLayout = struct {
+    abi_size: u64,
+    abi_align: u32,
+    most_aligned_field: u32,
+    most_aligned_field_size: u64,
+    biggest_field: u32,
+    payload_size: u64,
+    payload_align: u32,
+    tag_align: u32,
+    tag_size: u64,
+    padding: u32,
+};
+
+pub fn getUnionLayout(mod: *Module, u: InternPool.UnionType) UnionLayout {
+    const ip = &mod.intern_pool;
+    assert(u.haveLayout(ip));
+    var most_aligned_field: u32 = undefined;
+    var most_aligned_field_size: u64 = undefined;
+    var biggest_field: u32 = undefined;
+    var payload_size: u64 = 0;
+    var payload_align: u32 = 0;
+    for (u.field_types.get(ip), 0..) |field_ty, i| {
+        if (!field_ty.toType().hasRuntimeBitsIgnoreComptime(mod)) continue;
+
+        const field_align = u.fieldAlign(ip, @intCast(i)).toByteUnitsOptional() orelse
+            field_ty.toType().abiAlignment(mod);
+        const field_size = field_ty.toType().abiSize(mod);
+        if (field_size > payload_size) {
+            payload_size = field_size;
+            biggest_field = @intCast(i);
+        }
+        if (field_align > payload_align) {
+            payload_align = @intCast(field_align);
+            most_aligned_field = @intCast(i);
+            most_aligned_field_size = field_size;
+        }
+    }
+    payload_align = @max(payload_align, 1);
+    const have_tag = u.flagsPtr(ip).runtime_tag.hasTag();
+    if (!have_tag or !u.enum_tag_ty.toType().hasRuntimeBits(mod)) {
+        return .{
+            .abi_size = std.mem.alignForward(u64, payload_size, payload_align),
+            .abi_align = payload_align,
+            .most_aligned_field = most_aligned_field,
+            .most_aligned_field_size = most_aligned_field_size,
+            .biggest_field = biggest_field,
+            .payload_size = payload_size,
+            .payload_align = payload_align,
+            .tag_align = 0,
+            .tag_size = 0,
+            .padding = 0,
+        };
+    }
+    // Put the tag before or after the payload depending on which one's
+    // alignment is greater.
+    const tag_size = u.enum_tag_ty.toType().abiSize(mod);
+    const tag_align = @max(1, u.enum_tag_ty.toType().abiAlignment(mod));
+    var size: u64 = 0;
+    var padding: u32 = undefined;
+    if (tag_align >= payload_align) {
+        // {Tag, Payload}
+        size += tag_size;
+        size = std.mem.alignForward(u64, size, payload_align);
+        size += payload_size;
+        const prev_size = size;
+        size = std.mem.alignForward(u64, size, tag_align);
+        padding = @as(u32, @intCast(size - prev_size));
+    } else {
+        // {Payload, Tag}
+        size += payload_size;
+        size = std.mem.alignForward(u64, size, tag_align);
+        size += tag_size;
+        const prev_size = size;
+        size = std.mem.alignForward(u64, size, payload_align);
+        padding = @as(u32, @intCast(size - prev_size));
+    }
+    return .{
+        .abi_size = size,
+        .abi_align = @max(tag_align, payload_align),
+        .most_aligned_field = most_aligned_field,
+        .most_aligned_field_size = most_aligned_field_size,
+        .biggest_field = biggest_field,
+        .payload_size = payload_size,
+        .payload_align = payload_align,
+        .tag_align = tag_align,
+        .tag_size = tag_size,
+        .padding = padding,
+    };
+}
+
+pub fn unionAbiSize(mod: *Module, u: InternPool.UnionType) u64 {
+    return mod.getUnionLayout(u).abi_size;
+}
+
+/// Returns 0 if the union is represented with 0 bits at runtime.
+/// TODO: this returns alignment in byte units should should be a u64
+pub fn unionAbiAlignment(mod: *Module, u: InternPool.UnionType) u32 {
+    const ip = &mod.intern_pool;
+    const have_tag = u.flagsPtr(ip).runtime_tag.hasTag();
+    var max_align: u32 = 0;
+    if (have_tag) max_align = u.enum_tag_ty.toType().abiAlignment(mod);
+    for (u.field_types.get(ip), 0..) |field_ty, field_index| {
+        if (!field_ty.toType().hasRuntimeBits(mod)) continue;
+
+        const field_align = mod.unionFieldNormalAlignment(u, @intCast(field_index));
+        max_align = @max(max_align, field_align);
+    }
+    return max_align;
+}
+
+/// Returns the field alignment, assuming the union is not packed.
+/// Keep implementation in sync with `Sema.unionFieldAlignment`.
+/// Prefer to call that function instead of this one during Sema.
+/// TODO: this returns alignment in byte units should should be a u64
+pub fn unionFieldNormalAlignment(mod: *Module, u: InternPool.UnionType, field_index: u32) u32 {
+    const ip = &mod.intern_pool;
+    if (u.fieldAlign(ip, field_index).toByteUnitsOptional()) |a| return @intCast(a);
+    const field_ty = u.field_types.get(ip)[field_index].toType();
+    return field_ty.abiAlignment(mod);
+}
+
+pub fn unionTagFieldIndex(mod: *Module, u: InternPool.UnionType, enum_tag: Value) ?u32 {
+    const ip = &mod.intern_pool;
+    assert(ip.typeOf(enum_tag.toIntern()) == u.enum_tag_ty);
+    const enum_type = ip.indexToKey(u.enum_tag_ty).enum_type;
+    return enum_type.tagValueIndex(ip, enum_tag.toIntern());
 }

--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -88,7 +88,7 @@ pub fn print(
                 try writer.writeAll(".{ ");
 
                 try print(.{
-                    .ty = mod.unionPtr(ip.indexToKey(ty.toIntern()).union_type.index).tag_ty,
+                    .ty = ip.indexToKey(ty.toIntern()).union_type.enum_tag_ty.toType(),
                     .val = union_val.tag,
                 }, writer, level - 1, mod);
                 try writer.writeAll(" = ");
@@ -357,7 +357,7 @@ pub fn print(
                                 try writer.print(".{i}", .{field_name.fmt(ip)});
                             },
                             .Union => {
-                                const field_name = container_ty.unionFields(mod).keys()[@as(usize, @intCast(field.index))];
+                                const field_name = mod.typeToUnion(container_ty).?.field_names.get(ip)[@intCast(field.index)];
                                 try writer.print(".{i}", .{field_name.fmt(ip)});
                             },
                             .Pointer => {

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2956,7 +2956,8 @@ pub const Inst = struct {
             ///    true      | true          |  union(enum(T)) { }
             ///    true      | false         |  union(T) { }
             auto_enum_tag: bool,
-            _: u6 = undefined,
+            any_aligned_fields: bool,
+            _: u5 = undefined,
         };
     };
 

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -11534,6 +11534,7 @@ fn airAggregateInit(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airUnionInit(self: *Self, inst: Air.Inst.Index) !void {
     const mod = self.bin_file.options.module.?;
+    const ip = &mod.intern_pool;
     const ty_pl = self.air.instructions.items(.data)[inst].ty_pl;
     const extra = self.air.extraData(Air.UnionInit, ty_pl.payload).data;
     const result: MCValue = result: {
@@ -11553,8 +11554,8 @@ fn airUnionInit(self: *Self, inst: Air.Inst.Index) !void {
         const dst_mcv = try self.allocRegOrMem(inst, false);
 
         const union_obj = mod.typeToUnion(union_ty).?;
-        const field_name = union_obj.fields.keys()[extra.field_index];
-        const tag_ty = union_obj.tag_ty;
+        const field_name = union_obj.field_names.get(ip)[extra.field_index];
+        const tag_ty = union_obj.enum_tag_ty.toType();
         const field_index = tag_ty.enumFieldIndex(field_name, mod).?;
         const tag_val = try mod.enumValueFieldIndex(tag_ty, field_index);
         const tag_int_val = try tag_val.intFromEnum(tag_ty, mod);

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -708,8 +708,10 @@ pub const DeclGen = struct {
         location: ValueRenderLocation,
     ) error{ OutOfMemory, AnalysisFail }!void {
         const mod = dg.module;
+        const ip = &mod.intern_pool;
+
         var val = arg_val;
-        switch (mod.intern_pool.indexToKey(val.ip_index)) {
+        switch (ip.indexToKey(val.ip_index)) {
             .runtime_value => |rt| val = rt.val.toValue(),
             else => {},
         }
@@ -836,9 +838,10 @@ pub const DeclGen = struct {
                         if (layout.tag_size != 0) try writer.writeByte(',');
                         try writer.writeAll(" .payload = {");
                     }
-                    for (ty.unionFields(mod).values()) |field| {
-                        if (!field.ty.hasRuntimeBits(mod)) continue;
-                        try dg.renderValue(writer, field.ty, val, initializer_type);
+                    const union_obj = mod.typeToUnion(ty).?;
+                    for (union_obj.field_types.get(ip)) |field_ty| {
+                        if (!field_ty.toType().hasRuntimeBits(mod)) continue;
+                        try dg.renderValue(writer, field_ty.toType(), val, initializer_type);
                         break;
                     }
                     if (ty.unionTagTypeSafety(mod)) |_| try writer.writeByte('}');
@@ -912,7 +915,7 @@ pub const DeclGen = struct {
             unreachable;
         }
 
-        switch (mod.intern_pool.indexToKey(val.ip_index)) {
+        switch (ip.indexToKey(val.ip_index)) {
             // types, not values
             .int_type,
             .ptr_type,
@@ -962,7 +965,7 @@ pub const DeclGen = struct {
                 },
             },
             .err => |err| try writer.print("zig_error_{}", .{
-                fmtIdent(mod.intern_pool.stringToSlice(err.name)),
+                fmtIdent(ip.stringToSlice(err.name)),
             }),
             .error_union => |error_union| {
                 const payload_ty = ty.errorUnionPayload(mod);
@@ -1024,8 +1027,8 @@ pub const DeclGen = struct {
                 try writer.writeAll(" }");
             },
             .enum_tag => {
-                const enum_tag = mod.intern_pool.indexToKey(val.ip_index).enum_tag;
-                const int_tag_ty = mod.intern_pool.typeOf(enum_tag.int);
+                const enum_tag = ip.indexToKey(val.ip_index).enum_tag;
+                const int_tag_ty = ip.typeOf(enum_tag.int);
                 try dg.renderValue(writer, int_tag_ty.toType(), enum_tag.int.toValue(), location);
             },
             .float => {
@@ -1205,7 +1208,7 @@ pub const DeclGen = struct {
                 try dg.renderValue(writer, Type.bool, is_null_val, initializer_type);
                 try writer.writeAll(" }");
             },
-            .aggregate => switch (mod.intern_pool.indexToKey(ty.ip_index)) {
+            .aggregate => switch (ip.indexToKey(ty.ip_index)) {
                 .array_type, .vector_type => {
                     if (location == .FunctionArgument) {
                         try writer.writeByte('(');
@@ -1278,8 +1281,8 @@ pub const DeclGen = struct {
 
                         if (!empty) try writer.writeByte(',');
 
-                        const field_val = switch (mod.intern_pool.indexToKey(val.ip_index).aggregate.storage) {
-                            .bytes => |bytes| try mod.intern_pool.get(mod.gpa, .{ .int = .{
+                        const field_val = switch (ip.indexToKey(val.ip_index).aggregate.storage) {
+                            .bytes => |bytes| try ip.get(mod.gpa, .{ .int = .{
                                 .ty = field_ty,
                                 .storage = .{ .u64 = bytes[field_i] },
                             } }),
@@ -1309,8 +1312,8 @@ pub const DeclGen = struct {
                                 if (!field.ty.hasRuntimeBitsIgnoreComptime(mod)) continue;
 
                                 if (!empty) try writer.writeByte(',');
-                                const field_val = switch (mod.intern_pool.indexToKey(val.ip_index).aggregate.storage) {
-                                    .bytes => |bytes| try mod.intern_pool.get(mod.gpa, .{ .int = .{
+                                const field_val = switch (ip.indexToKey(val.ip_index).aggregate.storage) {
+                                    .bytes => |bytes| try ip.get(mod.gpa, .{ .int = .{
                                         .ty = field.ty.toIntern(),
                                         .storage = .{ .u64 = bytes[field_i] },
                                     } }),
@@ -1358,8 +1361,8 @@ pub const DeclGen = struct {
                                     if (field.is_comptime) continue;
                                     if (!field.ty.hasRuntimeBitsIgnoreComptime(mod)) continue;
 
-                                    const field_val = switch (mod.intern_pool.indexToKey(val.ip_index).aggregate.storage) {
-                                        .bytes => |bytes| try mod.intern_pool.get(mod.gpa, .{ .int = .{
+                                    const field_val = switch (ip.indexToKey(val.ip_index).aggregate.storage) {
+                                        .bytes => |bytes| try ip.get(mod.gpa, .{ .int = .{
                                             .ty = field.ty.toIntern(),
                                             .storage = .{ .u64 = bytes[field_i] },
                                         } }),
@@ -1400,8 +1403,8 @@ pub const DeclGen = struct {
                                     try dg.renderType(writer, ty);
                                     try writer.writeByte(')');
 
-                                    const field_val = switch (mod.intern_pool.indexToKey(val.ip_index).aggregate.storage) {
-                                        .bytes => |bytes| try mod.intern_pool.get(mod.gpa, .{ .int = .{
+                                    const field_val = switch (ip.indexToKey(val.ip_index).aggregate.storage) {
+                                        .bytes => |bytes| try ip.get(mod.gpa, .{ .int = .{
                                             .ty = field.ty.toIntern(),
                                             .storage = .{ .u64 = bytes[field_i] },
                                         } }),
@@ -1435,10 +1438,11 @@ pub const DeclGen = struct {
                     try writer.writeByte(')');
                 }
 
-                const field_i = ty.unionTagFieldIndex(un.tag.toValue(), mod).?;
-                const field_ty = ty.unionFields(mod).values()[field_i].ty;
-                const field_name = ty.unionFields(mod).keys()[field_i];
-                if (ty.containerLayout(mod) == .Packed) {
+                const union_obj = mod.typeToUnion(ty).?;
+                const field_i = mod.unionTagFieldIndex(union_obj, un.tag.toValue()).?;
+                const field_ty = union_obj.field_types.get(ip)[field_i].toType();
+                const field_name = union_obj.field_names.get(ip)[field_i];
+                if (union_obj.getLayout(ip) == .Packed) {
                     if (field_ty.hasRuntimeBits(mod)) {
                         if (field_ty.isPtrAtRuntime(mod)) {
                             try writer.writeByte('(');
@@ -1458,7 +1462,7 @@ pub const DeclGen = struct {
 
                 try writer.writeByte('{');
                 if (ty.unionTagTypeSafety(mod)) |tag_ty| {
-                    const layout = ty.unionGetLayout(mod);
+                    const layout = mod.getUnionLayout(union_obj);
                     if (layout.tag_size != 0) {
                         try writer.writeAll(" .tag = ");
                         try dg.renderValue(writer, tag_ty, un.tag.toValue(), initializer_type);
@@ -1468,12 +1472,12 @@ pub const DeclGen = struct {
                     try writer.writeAll(" .payload = {");
                 }
                 if (field_ty.hasRuntimeBits(mod)) {
-                    try writer.print(" .{ } = ", .{fmtIdent(mod.intern_pool.stringToSlice(field_name))});
+                    try writer.print(" .{ } = ", .{fmtIdent(ip.stringToSlice(field_name))});
                     try dg.renderValue(writer, field_ty, un.val.toValue(), initializer_type);
                     try writer.writeByte(' ');
-                } else for (ty.unionFields(mod).values()) |field| {
-                    if (!field.ty.hasRuntimeBits(mod)) continue;
-                    try dg.renderValue(writer, field.ty, Value.undef, initializer_type);
+                } else for (union_obj.field_types.get(ip)) |this_field_ty| {
+                    if (!this_field_ty.toType().hasRuntimeBits(mod)) continue;
+                    try dg.renderValue(writer, this_field_ty.toType(), Value.undef, initializer_type);
                     break;
                 }
                 if (ty.unionTagTypeSafety(mod)) |_| try writer.writeByte('}');
@@ -5237,22 +5241,25 @@ fn fieldLocation(
             else
                 .begin,
         },
-        .Union => switch (container_ty.containerLayout(mod)) {
-            .Auto, .Extern => {
-                const field_ty = container_ty.structFieldType(field_index, mod);
-                if (!field_ty.hasRuntimeBitsIgnoreComptime(mod))
-                    return if (container_ty.unionTagTypeSafety(mod) != null and
-                        !container_ty.unionHasAllZeroBitFieldTypes(mod))
-                        .{ .field = .{ .identifier = "payload" } }
+        .Union => {
+            const union_obj = mod.typeToUnion(container_ty).?;
+            return switch (union_obj.getLayout(ip)) {
+                .Auto, .Extern => {
+                    const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+                    if (!field_ty.hasRuntimeBitsIgnoreComptime(mod))
+                        return if (container_ty.unionTagTypeSafety(mod) != null and
+                            !container_ty.unionHasAllZeroBitFieldTypes(mod))
+                            .{ .field = .{ .identifier = "payload" } }
+                        else
+                            .begin;
+                    const field_name = union_obj.field_names.get(ip)[field_index];
+                    return .{ .field = if (container_ty.unionTagTypeSafety(mod)) |_|
+                        .{ .payload_identifier = ip.stringToSlice(field_name) }
                     else
-                        .begin;
-                const field_name = container_ty.unionFields(mod).keys()[field_index];
-                return .{ .field = if (container_ty.unionTagTypeSafety(mod)) |_|
-                    .{ .payload_identifier = ip.stringToSlice(field_name) }
-                else
-                    .{ .identifier = ip.stringToSlice(field_name) } };
-            },
-            .Packed => .begin,
+                        .{ .identifier = ip.stringToSlice(field_name) } };
+                },
+                .Packed => .begin,
+            };
         },
         .Pointer => switch (container_ty.ptrSize(mod)) {
             .Slice => switch (field_index) {
@@ -5479,8 +5486,8 @@ fn airStructFieldVal(f: *Function, inst: Air.Inst.Index) !CValue {
             .{ .identifier = ip.stringToSlice(struct_ty.structFieldName(extra.field_index, mod)) },
 
         .union_type => |union_type| field_name: {
-            const union_obj = mod.unionPtr(union_type.index);
-            if (union_obj.layout == .Packed) {
+            const union_obj = ip.loadUnionType(union_type);
+            if (union_obj.flagsPtr(ip).layout == .Packed) {
                 const operand_lval = if (struct_byval == .constant) blk: {
                     const operand_local = try f.allocLocal(inst, struct_ty);
                     try f.writeCValue(writer, operand_local, .Other);
@@ -5505,8 +5512,8 @@ fn airStructFieldVal(f: *Function, inst: Air.Inst.Index) !CValue {
 
                 return local;
             } else {
-                const name = union_obj.fields.keys()[extra.field_index];
-                break :field_name if (union_type.hasTag()) .{
+                const name = union_obj.field_names.get(ip)[extra.field_index];
+                break :field_name if (union_type.hasTag(ip)) .{
                     .payload_identifier = ip.stringToSlice(name),
                 } else .{
                     .identifier = ip.stringToSlice(name),
@@ -6902,14 +6909,14 @@ fn airUnionInit(f: *Function, inst: Air.Inst.Index) !CValue {
 
     const union_ty = f.typeOfIndex(inst);
     const union_obj = mod.typeToUnion(union_ty).?;
-    const field_name = union_obj.fields.keys()[extra.field_index];
+    const field_name = union_obj.field_names.get(ip)[extra.field_index];
     const payload_ty = f.typeOf(extra.init);
     const payload = try f.resolveInst(extra.init);
     try reap(f, inst, &.{extra.init});
 
     const writer = f.object.writer();
     const local = try f.allocLocal(inst, union_ty);
-    if (union_obj.layout == .Packed) {
+    if (union_obj.getLayout(ip) == .Packed) {
         try f.writeCValue(writer, local, .Other);
         try writer.writeAll(" = ");
         try f.writeCValue(writer, payload, .Initializer);

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2382,7 +2382,7 @@ pub const Object = struct {
                     break :blk fwd_decl;
                 };
 
-                switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+                switch (ip.indexToKey(ty.toIntern())) {
                     .anon_struct_type => |tuple| {
                         var di_fields: std.ArrayListUnmanaged(*llvm.DIType) = .{};
                         defer di_fields.deinit(gpa);
@@ -2401,7 +2401,7 @@ pub const Object = struct {
                             offset = field_offset + field_size;
 
                             const field_name = if (tuple.names.len != 0)
-                                mod.intern_pool.stringToSlice(tuple.names[i])
+                                ip.stringToSlice(tuple.names[i])
                             else
                                 try std.fmt.allocPrintZ(gpa, "{d}", .{i});
                             defer if (tuple.names.len == 0) gpa.free(field_name);
@@ -2491,7 +2491,7 @@ pub const Object = struct {
                     const field_offset = std.mem.alignForward(u64, offset, field_align);
                     offset = field_offset + field_size;
 
-                    const field_name = mod.intern_pool.stringToSlice(fields.keys()[field_and_index.index]);
+                    const field_name = ip.stringToSlice(fields.keys()[field_and_index.index]);
 
                     try di_fields.append(gpa, dib.createMemberType(
                         fwd_decl.toScope(),
@@ -2546,8 +2546,8 @@ pub const Object = struct {
                     break :blk fwd_decl;
                 };
 
-                const union_obj = mod.typeToUnion(ty).?;
-                if (!union_obj.haveFieldTypes() or !ty.hasRuntimeBitsIgnoreComptime(mod)) {
+                const union_type = ip.indexToKey(ty.toIntern()).union_type;
+                if (!union_type.haveFieldTypes(ip) or !ty.hasRuntimeBitsIgnoreComptime(mod)) {
                     const union_di_ty = try o.makeEmptyNamespaceDIType(owner_decl_index);
                     dib.replaceTemporary(fwd_decl, union_di_ty);
                     // The recursive call to `lowerDebugType` via `makeEmptyNamespaceDIType`
@@ -2556,10 +2556,11 @@ pub const Object = struct {
                     return union_di_ty;
                 }
 
-                const layout = ty.unionGetLayout(mod);
+                const union_obj = ip.loadUnionType(union_type);
+                const layout = mod.getUnionLayout(union_obj);
 
                 if (layout.payload_size == 0) {
-                    const tag_di_ty = try o.lowerDebugType(union_obj.tag_ty, .full);
+                    const tag_di_ty = try o.lowerDebugType(union_obj.enum_tag_ty.toType(), .full);
                     const di_fields = [_]*llvm.DIType{tag_di_ty};
                     const full_di_ty = dib.createStructType(
                         compile_unit_scope,
@@ -2586,22 +2587,20 @@ pub const Object = struct {
                 var di_fields: std.ArrayListUnmanaged(*llvm.DIType) = .{};
                 defer di_fields.deinit(gpa);
 
-                try di_fields.ensureUnusedCapacity(gpa, union_obj.fields.count());
+                try di_fields.ensureUnusedCapacity(gpa, union_obj.field_names.len);
 
-                var it = union_obj.fields.iterator();
-                while (it.next()) |kv| {
-                    const field_name = kv.key_ptr.*;
-                    const field = kv.value_ptr.*;
+                for (0..union_obj.field_names.len) |field_index| {
+                    const field_ty = union_obj.field_types.get(ip)[field_index];
+                    if (!field_ty.toType().hasRuntimeBitsIgnoreComptime(mod)) continue;
 
-                    if (!field.ty.hasRuntimeBitsIgnoreComptime(mod)) continue;
+                    const field_size = field_ty.toType().abiSize(mod);
+                    const field_align = mod.unionFieldNormalAlignment(union_obj, @intCast(field_index));
 
-                    const field_size = field.ty.abiSize(mod);
-                    const field_align = field.normalAlignment(mod);
-
-                    const field_di_ty = try o.lowerDebugType(field.ty, .full);
+                    const field_di_ty = try o.lowerDebugType(field_ty.toType(), .full);
+                    const field_name = union_obj.field_names.get(ip)[field_index];
                     di_fields.appendAssumeCapacity(dib.createMemberType(
                         fwd_decl.toScope(),
-                        mod.intern_pool.stringToSlice(field_name),
+                        ip.stringToSlice(field_name),
                         null, // file
                         0, // line
                         field_size * 8, // size in bits
@@ -2659,7 +2658,7 @@ pub const Object = struct {
                     layout.tag_align * 8, // align in bits
                     tag_offset * 8, // offset in bits
                     0, // flags
-                    try o.lowerDebugType(union_obj.tag_ty, .full),
+                    try o.lowerDebugType(union_obj.enum_tag_ty.toType(), .full),
                 );
 
                 const payload_di = dib.createMemberType(
@@ -3078,6 +3077,7 @@ pub const Object = struct {
     fn lowerTypeInner(o: *Object, t: Type) Allocator.Error!Builder.Type {
         const mod = o.module;
         const target = mod.getTarget();
+        const ip = &mod.intern_pool;
         return switch (t.toIntern()) {
             .u0_type, .i0_type => unreachable,
             inline .u1_type,
@@ -3172,7 +3172,7 @@ pub const Object = struct {
             .var_args_param_type,
             .none,
             => unreachable,
-            else => switch (mod.intern_pool.indexToKey(t.toIntern())) {
+            else => switch (ip.indexToKey(t.toIntern())) {
                 .int_type => |int_type| try o.builder.intType(int_type.bits),
                 .ptr_type => |ptr_type| type: {
                     const ptr_ty = try o.builder.ptrType(
@@ -3264,7 +3264,7 @@ pub const Object = struct {
                         return int_ty;
                     }
 
-                    const name = try o.builder.string(mod.intern_pool.stringToSlice(
+                    const name = try o.builder.string(ip.stringToSlice(
                         try struct_obj.getFullyQualifiedName(mod),
                     ));
                     const ty = try o.builder.opaqueType(name);
@@ -3357,40 +3357,40 @@ pub const Object = struct {
                     const gop = try o.type_map.getOrPut(o.gpa, t.toIntern());
                     if (gop.found_existing) return gop.value_ptr.*;
 
-                    const union_obj = mod.unionPtr(union_type.index);
-                    const layout = union_obj.getLayout(mod, union_type.hasTag());
+                    const union_obj = ip.loadUnionType(union_type);
+                    const layout = mod.getUnionLayout(union_obj);
 
-                    if (union_obj.layout == .Packed) {
+                    if (union_obj.flagsPtr(ip).layout == .Packed) {
                         const int_ty = try o.builder.intType(@intCast(t.bitSize(mod)));
                         gop.value_ptr.* = int_ty;
                         return int_ty;
                     }
 
                     if (layout.payload_size == 0) {
-                        const enum_tag_ty = try o.lowerType(union_obj.tag_ty);
+                        const enum_tag_ty = try o.lowerType(union_obj.enum_tag_ty.toType());
                         gop.value_ptr.* = enum_tag_ty;
                         return enum_tag_ty;
                     }
 
-                    const name = try o.builder.string(mod.intern_pool.stringToSlice(
-                        try union_obj.getFullyQualifiedName(mod),
+                    const name = try o.builder.string(ip.stringToSlice(
+                        try mod.declPtr(union_obj.decl).getFullyQualifiedName(mod),
                     ));
                     const ty = try o.builder.opaqueType(name);
                     gop.value_ptr.* = ty; // must be done before any recursive calls
 
-                    const aligned_field = union_obj.fields.values()[layout.most_aligned_field];
-                    const aligned_field_ty = try o.lowerType(aligned_field.ty);
+                    const aligned_field_ty = union_obj.field_types.get(ip)[layout.most_aligned_field].toType();
+                    const aligned_field_llvm_ty = try o.lowerType(aligned_field_ty);
 
                     const payload_ty = ty: {
                         if (layout.most_aligned_field_size == layout.payload_size) {
-                            break :ty aligned_field_ty;
+                            break :ty aligned_field_llvm_ty;
                         }
                         const padding_len = if (layout.tag_size == 0)
                             layout.abi_size - layout.most_aligned_field_size
                         else
                             layout.payload_size - layout.most_aligned_field_size;
                         break :ty try o.builder.structType(.@"packed", &.{
-                            aligned_field_ty,
+                            aligned_field_llvm_ty,
                             try o.builder.arrayType(padding_len, .i8),
                         });
                     };
@@ -3402,7 +3402,7 @@ pub const Object = struct {
                         );
                         return ty;
                     }
-                    const enum_tag_ty = try o.lowerType(union_obj.tag_ty);
+                    const enum_tag_ty = try o.lowerType(union_obj.enum_tag_ty.toType());
 
                     // Put the tag before or after the payload depending on which one's
                     // alignment is greater.
@@ -3430,7 +3430,7 @@ pub const Object = struct {
                 .opaque_type => |opaque_type| {
                     const gop = try o.type_map.getOrPut(o.gpa, t.toIntern());
                     if (!gop.found_existing) {
-                        const name = try o.builder.string(mod.intern_pool.stringToSlice(
+                        const name = try o.builder.string(ip.stringToSlice(
                             try mod.opaqueFullyQualifiedName(opaque_type),
                         ));
                         gop.value_ptr.* = try o.builder.opaqueType(name);
@@ -3551,10 +3551,11 @@ pub const Object = struct {
 
     fn lowerValue(o: *Object, arg_val: InternPool.Index) Error!Builder.Constant {
         const mod = o.module;
+        const ip = &mod.intern_pool;
         const target = mod.getTarget();
 
         var val = arg_val.toValue();
-        const arg_val_key = mod.intern_pool.indexToKey(arg_val);
+        const arg_val_key = ip.indexToKey(arg_val);
         switch (arg_val_key) {
             .runtime_value => |rt| val = rt.val.toValue(),
             else => {},
@@ -3563,7 +3564,7 @@ pub const Object = struct {
             return o.builder.undefConst(try o.lowerType(arg_val_key.typeOf().toType()));
         }
 
-        const val_key = mod.intern_pool.indexToKey(val.toIntern());
+        const val_key = ip.indexToKey(val.toIntern());
         const ty = val_key.typeOf().toType();
         return switch (val_key) {
             .int_type,
@@ -3749,7 +3750,7 @@ pub const Object = struct {
                     fields[0..llvm_ty_fields.len],
                 ), vals[0..llvm_ty_fields.len]);
             },
-            .aggregate => |aggregate| switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+            .aggregate => |aggregate| switch (ip.indexToKey(ty.toIntern())) {
                 .array_type => |array_type| switch (aggregate.storage) {
                     .bytes => |bytes| try o.builder.stringConst(try o.builder.string(bytes)),
                     .elems => |elems| {
@@ -4024,11 +4025,10 @@ pub const Object = struct {
                 if (layout.payload_size == 0) return o.lowerValue(un.tag);
 
                 const union_obj = mod.typeToUnion(ty).?;
-                const field_index = ty.unionTagFieldIndex(un.tag.toValue(), o.module).?;
-                assert(union_obj.haveFieldTypes());
+                const field_index = mod.unionTagFieldIndex(union_obj, un.tag.toValue()).?;
 
-                const field_ty = union_obj.fields.values()[field_index].ty;
-                if (union_obj.layout == .Packed) {
+                const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+                if (union_obj.getLayout(ip) == .Packed) {
                     if (!field_ty.hasRuntimeBits(mod)) return o.builder.intConst(union_ty, 0);
                     const small_int_val = try o.builder.castConst(
                         if (field_ty.isPtrAtRuntime(mod)) .ptrtoint else .bitcast,
@@ -9676,6 +9676,7 @@ pub const FuncGen = struct {
     fn airUnionInit(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.dg.object;
         const mod = o.module;
+        const ip = &mod.intern_pool;
         const ty_pl = self.air.instructions.items(.data)[inst].ty_pl;
         const extra = self.air.extraData(Air.UnionInit, ty_pl.payload).data;
         const union_ty = self.typeOfIndex(inst);
@@ -9683,13 +9684,13 @@ pub const FuncGen = struct {
         const layout = union_ty.unionGetLayout(mod);
         const union_obj = mod.typeToUnion(union_ty).?;
 
-        if (union_obj.layout == .Packed) {
+        if (union_obj.getLayout(ip) == .Packed) {
             const big_bits = union_ty.bitSize(mod);
             const int_llvm_ty = try o.builder.intType(@intCast(big_bits));
-            const field = union_obj.fields.values()[extra.field_index];
+            const field_ty = union_obj.field_types.get(ip)[extra.field_index].toType();
             const non_int_val = try self.resolveInst(extra.init);
-            const small_int_ty = try o.builder.intType(@intCast(field.ty.bitSize(mod)));
-            const small_int_val = if (field.ty.isPtrAtRuntime(mod))
+            const small_int_ty = try o.builder.intType(@intCast(field_ty.bitSize(mod)));
+            const small_int_val = if (field_ty.isPtrAtRuntime(mod))
                 try self.wip.cast(.ptrtoint, non_int_val, small_int_ty, "")
             else
                 try self.wip.cast(.bitcast, non_int_val, small_int_ty, "");
@@ -9698,7 +9699,7 @@ pub const FuncGen = struct {
 
         const tag_int = blk: {
             const tag_ty = union_ty.unionTagTypeHypothetical(mod);
-            const union_field_name = union_obj.fields.keys()[extra.field_index];
+            const union_field_name = union_obj.field_names.get(ip)[extra.field_index];
             const enum_field_index = tag_ty.enumFieldIndex(union_field_name, mod).?;
             const tag_val = try mod.enumValueFieldIndex(tag_ty, enum_field_index);
             const tag_int_val = try tag_val.intFromEnum(tag_ty, mod);
@@ -9719,18 +9720,17 @@ pub const FuncGen = struct {
         const alignment = Builder.Alignment.fromByteUnits(layout.abi_align);
         const result_ptr = try self.buildAlloca(union_llvm_ty, alignment);
         const llvm_payload = try self.resolveInst(extra.init);
-        assert(union_obj.haveFieldTypes());
-        const field = union_obj.fields.values()[extra.field_index];
-        const field_llvm_ty = try o.lowerType(field.ty);
-        const field_size = field.ty.abiSize(mod);
-        const field_align = field.normalAlignment(mod);
+        const field_ty = union_obj.field_types.get(ip)[extra.field_index].toType();
+        const field_llvm_ty = try o.lowerType(field_ty);
+        const field_size = field_ty.abiSize(mod);
+        const field_align = mod.unionFieldNormalAlignment(union_obj, extra.field_index);
         const llvm_usize = try o.lowerType(Type.usize);
         const usize_zero = try o.builder.intValue(llvm_usize, 0);
         const i32_zero = try o.builder.intValue(.i32, 0);
 
         const llvm_union_ty = t: {
             const payload_ty = p: {
-                if (!field.ty.hasRuntimeBitsIgnoreComptime(mod)) {
+                if (!field_ty.hasRuntimeBitsIgnoreComptime(mod)) {
                     const padding_len = layout.payload_size;
                     break :p try o.builder.arrayType(padding_len, .i8);
                 }
@@ -9743,7 +9743,7 @@ pub const FuncGen = struct {
                 });
             };
             if (layout.tag_size == 0) break :t try o.builder.structType(.normal, &.{payload_ty});
-            const tag_ty = try o.lowerType(union_obj.tag_ty);
+            const tag_ty = try o.lowerType(union_obj.enum_tag_ty.toType());
             var fields: [3]Builder.Type = undefined;
             var fields_len: usize = 2;
             if (layout.tag_align >= layout.payload_align) {
@@ -9761,7 +9761,7 @@ pub const FuncGen = struct {
         // Now we follow the layout as expressed above with GEP instructions to set the
         // tag and the payload.
         const field_ptr_ty = try mod.ptrType(.{
-            .child = field.ty.toIntern(),
+            .child = field_ty.toIntern(),
             .flags = .{ .alignment = InternPool.Alignment.fromNonzeroByteUnits(field_align) },
         });
         if (layout.tag_size == 0) {
@@ -9786,9 +9786,9 @@ pub const FuncGen = struct {
             const tag_index = @intFromBool(layout.tag_align < layout.payload_align);
             const indices: [2]Builder.Value = .{ usize_zero, try o.builder.intValue(.i32, tag_index) };
             const field_ptr = try self.wip.gep(.inbounds, llvm_union_ty, result_ptr, &indices, "");
-            const tag_ty = try o.lowerType(union_obj.tag_ty);
+            const tag_ty = try o.lowerType(union_obj.enum_tag_ty.toType());
             const llvm_tag = try o.builder.intValue(tag_ty, tag_int);
-            const tag_alignment = Builder.Alignment.fromByteUnits(union_obj.tag_ty.abiAlignment(mod));
+            const tag_alignment = Builder.Alignment.fromByteUnits(union_obj.enum_tag_ty.toType().abiAlignment(mod));
             _ = try self.wip.store(.normal, llvm_tag, field_ptr, tag_alignment);
         }
 

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -166,6 +166,7 @@ pub const DeclState = struct {
         const dbg_info_buffer = &self.dbg_info;
         const target = mod.getTarget();
         const target_endian = target.cpu.arch.endian();
+        const ip = &mod.intern_pool;
 
         switch (ty.zigTypeTag(mod)) {
             .NoReturn => unreachable,
@@ -321,7 +322,7 @@ pub const DeclState = struct {
                 // DW.AT.byte_size, DW.FORM.udata
                 try leb128.writeULEB128(dbg_info_buffer.writer(), ty.abiSize(mod));
 
-                switch (mod.intern_pool.indexToKey(ty.ip_index)) {
+                switch (ip.indexToKey(ty.ip_index)) {
                     .anon_struct_type => |fields| {
                         // DW.AT.name, DW.FORM.string
                         try dbg_info_buffer.writer().print("{}\x00", .{ty.fmt(mod)});
@@ -357,7 +358,7 @@ pub const DeclState = struct {
                             0..,
                         ) |field_name_ip, field, field_index| {
                             if (!field.ty.hasRuntimeBits(mod)) continue;
-                            const field_name = mod.intern_pool.stringToSlice(field_name_ip);
+                            const field_name = ip.stringToSlice(field_name_ip);
                             // DW.AT.member
                             try dbg_info_buffer.ensureUnusedCapacity(field_name.len + 2);
                             dbg_info_buffer.appendAssumeCapacity(@intFromEnum(AbbrevKind.struct_member));
@@ -388,7 +389,6 @@ pub const DeclState = struct {
                 try ty.print(dbg_info_buffer.writer(), mod);
                 try dbg_info_buffer.append(0);
 
-                const ip = &mod.intern_pool;
                 const enum_type = ip.indexToKey(ty.ip_index).enum_type;
                 for (enum_type.names.get(ip), 0..) |field_name_index, field_i| {
                     const field_name = ip.stringToSlice(field_name_index);
@@ -414,8 +414,8 @@ pub const DeclState = struct {
                 try dbg_info_buffer.append(0);
             },
             .Union => {
-                const layout = ty.unionGetLayout(mod);
                 const union_obj = mod.typeToUnion(ty).?;
+                const layout = mod.getUnionLayout(union_obj);
                 const payload_offset = if (layout.tag_align >= layout.payload_align) layout.tag_size else 0;
                 const tag_offset = if (layout.tag_align >= layout.payload_align) 0 else layout.payload_size;
                 // TODO this is temporary to match current state of unions in Zig - we don't yet have
@@ -457,19 +457,17 @@ pub const DeclState = struct {
                     try dbg_info_buffer.append(0);
                 }
 
-                const fields = ty.unionFields(mod);
-                for (fields.keys()) |field_name| {
-                    const field = fields.get(field_name).?;
-                    if (!field.ty.hasRuntimeBits(mod)) continue;
+                for (union_obj.field_types.get(ip), union_obj.field_names.get(ip)) |field_ty, field_name| {
+                    if (!field_ty.toType().hasRuntimeBits(mod)) continue;
                     // DW.AT.member
                     try dbg_info_buffer.append(@intFromEnum(AbbrevKind.struct_member));
                     // DW.AT.name, DW.FORM.string
-                    try dbg_info_buffer.appendSlice(mod.intern_pool.stringToSlice(field_name));
+                    try dbg_info_buffer.appendSlice(ip.stringToSlice(field_name));
                     try dbg_info_buffer.append(0);
                     // DW.AT.type, DW.FORM.ref4
                     const index = dbg_info_buffer.items.len;
                     try dbg_info_buffer.resize(index + 4);
-                    try self.addTypeRelocGlobal(atom_index, field.ty, @as(u32, @intCast(index)));
+                    try self.addTypeRelocGlobal(atom_index, field_ty.toType(), @intCast(index));
                     // DW.AT.data_member_location, DW.FORM.udata
                     try dbg_info_buffer.append(0);
                 }
@@ -486,7 +484,7 @@ pub const DeclState = struct {
                     // DW.AT.type, DW.FORM.ref4
                     const index = dbg_info_buffer.items.len;
                     try dbg_info_buffer.resize(index + 4);
-                    try self.addTypeRelocGlobal(atom_index, union_obj.tag_ty, @as(u32, @intCast(index)));
+                    try self.addTypeRelocGlobal(atom_index, union_obj.enum_tag_ty.toType(), @intCast(index));
                     // DW.AT.data_member_location, DW.FORM.udata
                     try leb128.writeULEB128(dbg_info_buffer.writer(), tag_offset);
 

--- a/src/type.zig
+++ b/src/type.zig
@@ -349,8 +349,7 @@ pub const Type = struct {
             },
 
             .union_type => |union_type| {
-                const union_obj = mod.unionPtr(union_type.index);
-                const decl = mod.declPtr(union_obj.owner_decl);
+                const decl = mod.declPtr(union_type.decl);
                 try decl.renderFullyQualifiedName(mod, writer);
             },
             .opaque_type => |opaque_type| {
@@ -462,10 +461,11 @@ pub const Type = struct {
         ignore_comptime_only: bool,
         strat: AbiAlignmentAdvancedStrat,
     ) RuntimeBitsError!bool {
+        const ip = &mod.intern_pool;
         return switch (ty.toIntern()) {
             // False because it is a comptime-only type.
             .empty_struct_type => false,
-            else => switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+            else => switch (ip.indexToKey(ty.toIntern())) {
                 .int_type => |int_type| int_type.bits != 0,
                 .ptr_type => |ptr_type| {
                     // Pointers to zero-bit types still have a runtime address; however, pointers
@@ -595,29 +595,36 @@ pub const Type = struct {
                 },
 
                 .union_type => |union_type| {
-                    const union_obj = mod.unionPtr(union_type.index);
-                    switch (union_type.runtime_tag) {
+                    switch (union_type.flagsPtr(ip).runtime_tag) {
                         .none => {
-                            if (union_obj.status == .field_types_wip) {
+                            if (union_type.flagsPtr(ip).status == .field_types_wip) {
                                 // In this case, we guess that hasRuntimeBits() for this type is true,
                                 // and then later if our guess was incorrect, we emit a compile error.
-                                union_obj.assumed_runtime_bits = true;
+                                union_type.flagsPtr(ip).assumed_runtime_bits = true;
                                 return true;
                             }
                         },
                         .safety, .tagged => {
-                            if (try union_obj.tag_ty.hasRuntimeBitsAdvanced(mod, ignore_comptime_only, strat)) {
+                            const tag_ty = union_type.tagTypePtr(ip).*;
+                            // tag_ty will be `none` if this union's tag type is not resolved yet,
+                            // in which case we want control flow to continue down below.
+                            if (tag_ty != .none and
+                                try tag_ty.toType().hasRuntimeBitsAdvanced(mod, ignore_comptime_only, strat))
+                            {
                                 return true;
                             }
                         },
                     }
                     switch (strat) {
                         .sema => |sema| _ = try sema.resolveTypeFields(ty),
-                        .eager => assert(union_obj.haveFieldTypes()),
-                        .lazy => if (!union_obj.haveFieldTypes()) return error.NeedLazy,
+                        .eager => assert(union_type.flagsPtr(ip).status.haveFieldTypes()),
+                        .lazy => if (!union_type.flagsPtr(ip).status.haveFieldTypes())
+                            return error.NeedLazy,
                     }
-                    for (union_obj.fields.values()) |value| {
-                        if (try value.ty.hasRuntimeBitsAdvanced(mod, ignore_comptime_only, strat))
+                    const union_obj = ip.loadUnionType(union_type);
+                    for (0..union_obj.field_types.len) |field_index| {
+                        const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+                        if (try field_ty.hasRuntimeBitsAdvanced(mod, ignore_comptime_only, strat))
                             return true;
                     } else {
                         return false;
@@ -656,7 +663,8 @@ pub const Type = struct {
     /// readFrom/writeToMemory are supported only for types with a well-
     /// defined memory layout
     pub fn hasWellDefinedLayout(ty: Type, mod: *Module) bool {
-        return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+        const ip = &mod.intern_pool;
+        return switch (ip.indexToKey(ty.toIntern())) {
             .int_type,
             .vector_type,
             => true,
@@ -728,8 +736,8 @@ pub const Type = struct {
                 };
                 return struct_obj.layout != .Auto;
             },
-            .union_type => |union_type| switch (union_type.runtime_tag) {
-                .none, .safety => mod.unionPtr(union_type.index).layout != .Auto,
+            .union_type => |union_type| switch (union_type.flagsPtr(ip).runtime_tag) {
+                .none, .safety => union_type.flagsPtr(ip).layout != .Auto,
                 .tagged => false,
             },
             .enum_type => |enum_type| switch (enum_type.tag_mode) {
@@ -867,6 +875,7 @@ pub const Type = struct {
         strat: AbiAlignmentAdvancedStrat,
     ) Module.CompileError!AbiAlignmentAdvanced {
         const target = mod.getTarget();
+        const ip = &mod.intern_pool;
 
         const opt_sema = switch (strat) {
             .sema => |sema| sema,
@@ -875,7 +884,7 @@ pub const Type = struct {
 
         switch (ty.toIntern()) {
             .empty_struct_type => return AbiAlignmentAdvanced{ .scalar = 0 },
-            else => switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+            else => switch (ip.indexToKey(ty.toIntern())) {
                 .int_type => |int_type| {
                     if (int_type.bits == 0) return AbiAlignmentAdvanced{ .scalar = 0 };
                     return AbiAlignmentAdvanced{ .scalar = intAbiAlignment(int_type.bits, target) };
@@ -1066,8 +1075,65 @@ pub const Type = struct {
                 },
 
                 .union_type => |union_type| {
-                    const union_obj = mod.unionPtr(union_type.index);
-                    return abiAlignmentAdvancedUnion(ty, mod, strat, union_obj, union_type.hasTag());
+                    if (opt_sema) |sema| {
+                        if (union_type.flagsPtr(ip).status == .field_types_wip) {
+                            // We'll guess "pointer-aligned", if the union has an
+                            // underaligned pointer field then some allocations
+                            // might require explicit alignment.
+                            return AbiAlignmentAdvanced{ .scalar = @divExact(target.ptrBitWidth(), 8) };
+                        }
+                        _ = try sema.resolveTypeFields(ty);
+                    }
+                    if (!union_type.haveFieldTypes(ip)) switch (strat) {
+                        .eager => unreachable, // union layout not resolved
+                        .sema => unreachable, // handled above
+                        .lazy => return .{ .val = (try mod.intern(.{ .int = .{
+                            .ty = .comptime_int_type,
+                            .storage = .{ .lazy_align = ty.toIntern() },
+                        } })).toValue() },
+                    };
+                    const union_obj = ip.loadUnionType(union_type);
+                    if (union_obj.field_names.len == 0) {
+                        if (union_obj.hasTag(ip)) {
+                            return abiAlignmentAdvanced(union_obj.enum_tag_ty.toType(), mod, strat);
+                        } else {
+                            return AbiAlignmentAdvanced{
+                                .scalar = @intFromBool(union_obj.flagsPtr(ip).layout == .Extern),
+                            };
+                        }
+                    }
+
+                    var max_align: u32 = 0;
+                    if (union_obj.hasTag(ip)) max_align = union_obj.enum_tag_ty.toType().abiAlignment(mod);
+                    for (0..union_obj.field_names.len) |field_index| {
+                        const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+                        const field_align = if (union_obj.field_aligns.len == 0)
+                            .none
+                        else
+                            union_obj.field_aligns.get(ip)[field_index];
+                        if (!(field_ty.hasRuntimeBitsAdvanced(mod, false, strat) catch |err| switch (err) {
+                            error.NeedLazy => return .{ .val = (try mod.intern(.{ .int = .{
+                                .ty = .comptime_int_type,
+                                .storage = .{ .lazy_align = ty.toIntern() },
+                            } })).toValue() },
+                            else => |e| return e,
+                        })) continue;
+
+                        const field_align_bytes: u32 = @intCast(field_align.toByteUnitsOptional() orelse
+                            switch (try field_ty.abiAlignmentAdvanced(mod, strat)) {
+                            .scalar => |a| a,
+                            .val => switch (strat) {
+                                .eager => unreachable, // struct layout not resolved
+                                .sema => unreachable, // handled above
+                                .lazy => return .{ .val = (try mod.intern(.{ .int = .{
+                                    .ty = .comptime_int_type,
+                                    .storage = .{ .lazy_align = ty.toIntern() },
+                                } })).toValue() },
+                            },
+                        });
+                        max_align = @max(max_align, field_align_bytes);
+                    }
+                    return AbiAlignmentAdvanced{ .scalar = max_align };
                 },
                 .opaque_type => return AbiAlignmentAdvanced{ .scalar = 1 },
                 .enum_type => |enum_type| return AbiAlignmentAdvanced{ .scalar = enum_type.tag_ty.toType().abiAlignment(mod) },
@@ -1177,71 +1243,6 @@ pub const Type = struct {
         }
     }
 
-    pub fn abiAlignmentAdvancedUnion(
-        ty: Type,
-        mod: *Module,
-        strat: AbiAlignmentAdvancedStrat,
-        union_obj: *Module.Union,
-        have_tag: bool,
-    ) Module.CompileError!AbiAlignmentAdvanced {
-        const opt_sema = switch (strat) {
-            .sema => |sema| sema,
-            else => null,
-        };
-        if (opt_sema) |sema| {
-            if (union_obj.status == .field_types_wip) {
-                // We'll guess "pointer-aligned", if the union has an
-                // underaligned pointer field then some allocations
-                // might require explicit alignment.
-                const target = mod.getTarget();
-                return AbiAlignmentAdvanced{ .scalar = @divExact(target.ptrBitWidth(), 8) };
-            }
-            _ = try sema.resolveTypeFields(ty);
-        }
-        if (!union_obj.haveFieldTypes()) switch (strat) {
-            .eager => unreachable, // union layout not resolved
-            .sema => unreachable, // handled above
-            .lazy => return .{ .val = (try mod.intern(.{ .int = .{
-                .ty = .comptime_int_type,
-                .storage = .{ .lazy_align = ty.toIntern() },
-            } })).toValue() },
-        };
-        if (union_obj.fields.count() == 0) {
-            if (have_tag) {
-                return abiAlignmentAdvanced(union_obj.tag_ty, mod, strat);
-            } else {
-                return AbiAlignmentAdvanced{ .scalar = @intFromBool(union_obj.layout == .Extern) };
-            }
-        }
-
-        var max_align: u32 = 0;
-        if (have_tag) max_align = union_obj.tag_ty.abiAlignment(mod);
-        for (union_obj.fields.values()) |field| {
-            if (!(field.ty.hasRuntimeBitsAdvanced(mod, false, strat) catch |err| switch (err) {
-                error.NeedLazy => return .{ .val = (try mod.intern(.{ .int = .{
-                    .ty = .comptime_int_type,
-                    .storage = .{ .lazy_align = ty.toIntern() },
-                } })).toValue() },
-                else => |e| return e,
-            })) continue;
-
-            const field_align = @as(u32, @intCast(field.abi_align.toByteUnitsOptional() orelse
-                switch (try field.ty.abiAlignmentAdvanced(mod, strat)) {
-                .scalar => |a| a,
-                .val => switch (strat) {
-                    .eager => unreachable, // struct layout not resolved
-                    .sema => unreachable, // handled above
-                    .lazy => return .{ .val = (try mod.intern(.{ .int = .{
-                        .ty = .comptime_int_type,
-                        .storage = .{ .lazy_align = ty.toIntern() },
-                    } })).toValue() },
-                },
-            }));
-            max_align = @max(max_align, field_align);
-        }
-        return AbiAlignmentAdvanced{ .scalar = max_align };
-    }
-
     /// May capture a reference to `ty`.
     pub fn lazyAbiSize(ty: Type, mod: *Module) !Value {
         switch (try ty.abiSizeAdvanced(mod, .lazy)) {
@@ -1273,11 +1274,12 @@ pub const Type = struct {
         strat: AbiAlignmentAdvancedStrat,
     ) Module.CompileError!AbiSizeAdvanced {
         const target = mod.getTarget();
+        const ip = &mod.intern_pool;
 
         switch (ty.toIntern()) {
             .empty_struct_type => return AbiSizeAdvanced{ .scalar = 0 },
 
-            else => switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+            else => switch (ip.indexToKey(ty.toIntern())) {
                 .int_type => |int_type| {
                     if (int_type.bits == 0) return AbiSizeAdvanced{ .scalar = 0 };
                     return AbiSizeAdvanced{ .scalar = intAbiSize(int_type.bits, target) };
@@ -1484,8 +1486,18 @@ pub const Type = struct {
                 },
 
                 .union_type => |union_type| {
-                    const union_obj = mod.unionPtr(union_type.index);
-                    return abiSizeAdvancedUnion(ty, mod, strat, union_obj, union_type.hasTag());
+                    switch (strat) {
+                        .sema => |sema| try sema.resolveTypeLayout(ty),
+                        .lazy => if (!union_type.flagsPtr(ip).status.haveLayout()) return .{
+                            .val = (try mod.intern(.{ .int = .{
+                                .ty = .comptime_int_type,
+                                .storage = .{ .lazy_size = ty.toIntern() },
+                            } })).toValue(),
+                        },
+                        .eager => {},
+                    }
+                    const union_obj = ip.loadUnionType(union_type);
+                    return AbiSizeAdvanced{ .scalar = mod.unionAbiSize(union_obj) };
                 },
                 .opaque_type => unreachable, // no size available
                 .enum_type => |enum_type| return AbiSizeAdvanced{ .scalar = enum_type.tag_ty.toType().abiSize(mod) },
@@ -1513,24 +1525,6 @@ pub const Type = struct {
                 => unreachable,
             },
         }
-    }
-
-    pub fn abiSizeAdvancedUnion(
-        ty: Type,
-        mod: *Module,
-        strat: AbiAlignmentAdvancedStrat,
-        union_obj: *Module.Union,
-        have_tag: bool,
-    ) Module.CompileError!AbiSizeAdvanced {
-        switch (strat) {
-            .sema => |sema| try sema.resolveTypeLayout(ty),
-            .lazy => if (!union_obj.haveLayout()) return .{ .val = (try mod.intern(.{ .int = .{
-                .ty = .comptime_int_type,
-                .storage = .{ .lazy_size = ty.toIntern() },
-            } })).toValue() },
-            .eager => {},
-        }
-        return AbiSizeAdvanced{ .scalar = union_obj.abiSize(mod, have_tag) };
     }
 
     fn abiSizeAdvancedOptional(
@@ -1602,10 +1596,11 @@ pub const Type = struct {
         opt_sema: ?*Sema,
     ) Module.CompileError!u64 {
         const target = mod.getTarget();
+        const ip = &mod.intern_pool;
 
         const strat: AbiAlignmentAdvancedStrat = if (opt_sema) |sema| .{ .sema = sema } else .eager;
 
-        switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+        switch (ip.indexToKey(ty.toIntern())) {
             .int_type => |int_type| return int_type.bits,
             .ptr_type => |ptr_type| switch (ptr_type.flags.size) {
                 .Slice => return target.ptrBitWidth() * 2,
@@ -1714,12 +1709,13 @@ pub const Type = struct {
                 if (ty.containerLayout(mod) != .Packed) {
                     return (try ty.abiSizeAdvanced(mod, strat)).scalar * 8;
                 }
-                const union_obj = mod.unionPtr(union_type.index);
-                assert(union_obj.haveFieldTypes());
+                const union_obj = ip.loadUnionType(union_type);
+                assert(union_obj.flagsPtr(ip).status.haveFieldTypes());
 
                 var size: u64 = 0;
-                for (union_obj.fields.values()) |field| {
-                    size = @max(size, try bitSizeAdvanced(field.ty, mod, opt_sema));
+                for (0..union_obj.field_types.len) |field_index| {
+                    const field_ty = union_obj.field_types.get(ip)[field_index];
+                    size = @max(size, try bitSizeAdvanced(field_ty.toType(), mod, opt_sema));
                 }
                 return size;
             },
@@ -1753,33 +1749,24 @@ pub const Type = struct {
     /// Returns true if the type's layout is already resolved and it is safe
     /// to use `abiSize`, `abiAlignment` and `bitSize` on it.
     pub fn layoutIsResolved(ty: Type, mod: *Module) bool {
-        switch (ty.zigTypeTag(mod)) {
-            .Struct => {
-                if (mod.typeToStruct(ty)) |struct_obj| {
+        const ip = &mod.intern_pool;
+        return switch (ip.indexToKey(ty.toIntern())) {
+            .struct_type => |struct_type| {
+                if (mod.structPtrUnwrap(struct_type.index)) |struct_obj| {
                     return struct_obj.haveLayout();
+                } else {
+                    return true;
                 }
-                return true;
             },
-            .Union => {
-                if (mod.typeToUnion(ty)) |union_obj| {
-                    return union_obj.haveLayout();
-                }
-                return true;
+            .union_type => |union_type| union_type.haveLayout(ip),
+            .array_type => |array_type| {
+                if ((array_type.len + @intFromBool(array_type.sentinel != .none)) == 0) return true;
+                return array_type.child.toType().layoutIsResolved(mod);
             },
-            .Array => {
-                if (ty.arrayLenIncludingSentinel(mod) == 0) return true;
-                return ty.childType(mod).layoutIsResolved(mod);
-            },
-            .Optional => {
-                const payload_ty = ty.optionalChild(mod);
-                return payload_ty.layoutIsResolved(mod);
-            },
-            .ErrorUnion => {
-                const payload_ty = ty.errorUnionPayload(mod);
-                return payload_ty.layoutIsResolved(mod);
-            },
-            else => return true,
-        }
+            .opt_type => |child| child.toType().layoutIsResolved(mod),
+            .error_union_type => |k| k.payload_type.toType().layoutIsResolved(mod),
+            else => true,
+        };
     }
 
     pub fn isSinglePointer(ty: Type, mod: *const Module) bool {
@@ -1970,12 +1957,12 @@ pub const Type = struct {
     /// Returns the tag type of a union, if the type is a union and it has a tag type.
     /// Otherwise, returns `null`.
     pub fn unionTagType(ty: Type, mod: *Module) ?Type {
-        return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
-            .union_type => |union_type| switch (union_type.runtime_tag) {
+        const ip = &mod.intern_pool;
+        return switch (ip.indexToKey(ty.toIntern())) {
+            .union_type => |union_type| switch (union_type.flagsPtr(ip).runtime_tag) {
                 .tagged => {
-                    const union_obj = mod.unionPtr(union_type.index);
-                    assert(union_obj.haveFieldTypes());
-                    return union_obj.tag_ty;
+                    assert(union_type.flagsPtr(ip).status.haveFieldTypes());
+                    return union_type.enum_tag_ty.toType();
                 },
                 else => null,
             },
@@ -1986,12 +1973,12 @@ pub const Type = struct {
     /// Same as `unionTagType` but includes safety tag.
     /// Codegen should use this version.
     pub fn unionTagTypeSafety(ty: Type, mod: *Module) ?Type {
-        return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+        const ip = &mod.intern_pool;
+        return switch (ip.indexToKey(ty.toIntern())) {
             .union_type => |union_type| {
-                if (!union_type.hasTag()) return null;
-                const union_obj = mod.unionPtr(union_type.index);
-                assert(union_obj.haveFieldTypes());
-                return union_obj.tag_ty;
+                if (!union_type.hasTag(ip)) return null;
+                assert(union_type.haveFieldTypes(ip));
+                return union_type.enum_tag_ty.toType();
             },
             else => null,
         };
@@ -2001,52 +1988,46 @@ pub const Type = struct {
     /// not be stored at runtime.
     pub fn unionTagTypeHypothetical(ty: Type, mod: *Module) Type {
         const union_obj = mod.typeToUnion(ty).?;
-        assert(union_obj.haveFieldTypes());
-        return union_obj.tag_ty;
-    }
-
-    pub fn unionFields(ty: Type, mod: *Module) Module.Union.Fields {
-        const union_obj = mod.typeToUnion(ty).?;
-        assert(union_obj.haveFieldTypes());
-        return union_obj.fields;
+        return union_obj.enum_tag_ty.toType();
     }
 
     pub fn unionFieldType(ty: Type, enum_tag: Value, mod: *Module) Type {
+        const ip = &mod.intern_pool;
         const union_obj = mod.typeToUnion(ty).?;
-        const index = ty.unionTagFieldIndex(enum_tag, mod).?;
-        assert(union_obj.haveFieldTypes());
-        return union_obj.fields.values()[index].ty;
+        const index = mod.unionTagFieldIndex(union_obj, enum_tag).?;
+        return union_obj.field_types.get(ip)[index].toType();
     }
 
-    pub fn unionTagFieldIndex(ty: Type, enum_tag: Value, mod: *Module) ?usize {
+    pub fn unionTagFieldIndex(ty: Type, enum_tag: Value, mod: *Module) ?u32 {
         const union_obj = mod.typeToUnion(ty).?;
-        const index = union_obj.tag_ty.enumTagFieldIndex(enum_tag, mod) orelse return null;
-        const name = union_obj.tag_ty.enumFieldName(index, mod);
-        return union_obj.fields.getIndex(name);
+        return mod.unionTagFieldIndex(union_obj, enum_tag);
     }
 
     pub fn unionHasAllZeroBitFieldTypes(ty: Type, mod: *Module) bool {
+        const ip = &mod.intern_pool;
         const union_obj = mod.typeToUnion(ty).?;
-        return union_obj.hasAllZeroBitFieldTypes(mod);
+        for (union_obj.field_types.get(ip)) |field_ty| {
+            if (field_ty.toType().hasRuntimeBits(mod)) return false;
+        }
+        return true;
     }
 
-    pub fn unionGetLayout(ty: Type, mod: *Module) Module.Union.Layout {
-        const union_type = mod.intern_pool.indexToKey(ty.toIntern()).union_type;
-        const union_obj = mod.unionPtr(union_type.index);
-        return union_obj.getLayout(mod, union_type.hasTag());
+    pub fn unionGetLayout(ty: Type, mod: *Module) Module.UnionLayout {
+        const ip = &mod.intern_pool;
+        const union_type = ip.indexToKey(ty.toIntern()).union_type;
+        const union_obj = ip.loadUnionType(union_type);
+        return mod.getUnionLayout(union_obj);
     }
 
     pub fn containerLayout(ty: Type, mod: *Module) std.builtin.Type.ContainerLayout {
-        return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+        const ip = &mod.intern_pool;
+        return switch (ip.indexToKey(ty.toIntern())) {
             .struct_type => |struct_type| {
                 const struct_obj = mod.structPtrUnwrap(struct_type.index) orelse return .Auto;
                 return struct_obj.layout;
             },
             .anon_struct_type => .Auto,
-            .union_type => |union_type| {
-                const union_obj = mod.unionPtr(union_type.index);
-                return union_obj.layout;
-            },
+            .union_type => |union_type| union_type.flagsPtr(ip).layout,
             else => unreachable,
         };
     }
@@ -2570,14 +2551,16 @@ pub const Type = struct {
                 },
 
                 .union_type => |union_type| {
-                    const union_obj = mod.unionPtr(union_type.index);
-                    const tag_val = (try union_obj.tag_ty.onePossibleValue(mod)) orelse return null;
-                    if (union_obj.fields.count() == 0) {
+                    const union_obj = ip.loadUnionType(union_type);
+                    const tag_val = (try union_obj.enum_tag_ty.toType().onePossibleValue(mod)) orelse
+                        return null;
+                    if (union_obj.field_names.len == 0) {
                         const only = try mod.intern(.{ .empty_enum_value = ty.toIntern() });
                         return only.toValue();
                     }
-                    const only_field = union_obj.fields.values()[0];
-                    const val_val = (try only_field.ty.onePossibleValue(mod)) orelse return null;
+                    const only_field_ty = union_obj.field_types.get(ip)[0];
+                    const val_val = (try only_field_ty.toType().onePossibleValue(mod)) orelse
+                        return null;
                     const only = try mod.intern(.{ .un = .{
                         .ty = ty.toIntern(),
                         .tag = tag_val.toIntern(),
@@ -2657,10 +2640,11 @@ pub const Type = struct {
     /// TODO merge these implementations together with the "advanced" pattern seen
     /// elsewhere in this file.
     pub fn comptimeOnly(ty: Type, mod: *Module) bool {
+        const ip = &mod.intern_pool;
         return switch (ty.toIntern()) {
             .empty_struct_type => false,
 
-            else => switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+            else => switch (ip.indexToKey(ty.toIntern())) {
                 .int_type => false,
                 .ptr_type => |ptr_type| {
                     const child_ty = ptr_type.child.toType();
@@ -2704,6 +2688,7 @@ pub const Type = struct {
                     .c_longlong,
                     .c_ulonglong,
                     .c_longdouble,
+                    .anyopaque,
                     .bool,
                     .void,
                     .anyerror,
@@ -2722,7 +2707,6 @@ pub const Type = struct {
                     .extern_options,
                     => false,
 
-                    .anyopaque,
                     .type,
                     .comptime_int,
                     .comptime_float,
@@ -2756,8 +2740,7 @@ pub const Type = struct {
                 },
 
                 .union_type => |union_type| {
-                    const union_obj = mod.unionPtr(union_type.index);
-                    switch (union_obj.requires_comptime) {
+                    switch (union_type.flagsPtr(ip).requires_comptime) {
                         .wip, .unknown => {
                             // Return false to avoid incorrect dependency loops.
                             // This will be handled correctly once merged with
@@ -2769,7 +2752,7 @@ pub const Type = struct {
                     }
                 },
 
-                .opaque_type => true,
+                .opaque_type => false,
 
                 .enum_type => |enum_type| enum_type.tag_ty.toType().comptimeOnly(mod),
 
@@ -2847,7 +2830,7 @@ pub const Type = struct {
         return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
             .opaque_type => |opaque_type| opaque_type.namespace.toOptional(),
             .struct_type => |struct_type| struct_type.namespace,
-            .union_type => |union_type| mod.unionPtr(union_type.index).namespace.toOptional(),
+            .union_type => |union_type| union_type.namespace.toOptional(),
             .enum_type => |enum_type| enum_type.namespace,
 
             else => .none,
@@ -2935,7 +2918,7 @@ pub const Type = struct {
     /// Asserts the type is an enum or a union.
     pub fn intTagType(ty: Type, mod: *Module) Type {
         return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
-            .union_type => |union_type| mod.unionPtr(union_type.index).tag_ty.intTagType(mod),
+            .union_type => |union_type| union_type.enum_tag_ty.toType().intTagType(mod),
             .enum_type => |enum_type| enum_type.tag_ty.toType(),
             else => unreachable,
         };
@@ -3038,15 +3021,16 @@ pub const Type = struct {
 
     /// Supports structs and unions.
     pub fn structFieldType(ty: Type, index: usize, mod: *Module) Type {
-        return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+        const ip = &mod.intern_pool;
+        return switch (ip.indexToKey(ty.toIntern())) {
             .struct_type => |struct_type| {
                 const struct_obj = mod.structPtrUnwrap(struct_type.index).?;
                 assert(struct_obj.haveFieldTypes());
                 return struct_obj.fields.values()[index].ty;
             },
             .union_type => |union_type| {
-                const union_obj = mod.unionPtr(union_type.index);
-                return union_obj.fields.values()[index].ty;
+                const union_obj = ip.loadUnionType(union_type);
+                return union_obj.field_types.get(ip)[index].toType();
             },
             .anon_struct_type => |anon_struct| anon_struct.types[index].toType(),
             else => unreachable,
@@ -3054,7 +3038,8 @@ pub const Type = struct {
     }
 
     pub fn structFieldAlign(ty: Type, index: usize, mod: *Module) u32 {
-        switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+        const ip = &mod.intern_pool;
+        switch (ip.indexToKey(ty.toIntern())) {
             .struct_type => |struct_type| {
                 const struct_obj = mod.structPtrUnwrap(struct_type.index).?;
                 assert(struct_obj.layout != .Packed);
@@ -3064,8 +3049,8 @@ pub const Type = struct {
                 return anon_struct.types[index].toType().abiAlignment(mod);
             },
             .union_type => |union_type| {
-                const union_obj = mod.unionPtr(union_type.index);
-                return union_obj.fields.values()[index].normalAlignment(mod);
+                const union_obj = ip.loadUnionType(union_type);
+                return mod.unionFieldNormalAlignment(union_obj, @intCast(index));
             },
             else => unreachable,
         }
@@ -3198,7 +3183,8 @@ pub const Type = struct {
 
     /// Supports structs and unions.
     pub fn structFieldOffset(ty: Type, index: usize, mod: *Module) u64 {
-        switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+        const ip = &mod.intern_pool;
+        switch (ip.indexToKey(ty.toIntern())) {
             .struct_type => |struct_type| {
                 const struct_obj = mod.structPtrUnwrap(struct_type.index).?;
                 assert(struct_obj.haveLayout());
@@ -3234,10 +3220,10 @@ pub const Type = struct {
             },
 
             .union_type => |union_type| {
-                if (!union_type.hasTag())
+                if (!union_type.hasTag(ip))
                     return 0;
-                const union_obj = mod.unionPtr(union_type.index);
-                const layout = union_obj.getLayout(mod, true);
+                const union_obj = ip.loadUnionType(union_type);
+                const layout = mod.getUnionLayout(union_obj);
                 if (layout.tag_align >= layout.payload_align) {
                     // {Tag, Payload}
                     return std.mem.alignForward(u64, layout.tag_size, layout.payload_align);
@@ -3262,8 +3248,7 @@ pub const Type = struct {
                 return struct_obj.srcLoc(mod);
             },
             .union_type => |union_type| {
-                const union_obj = mod.unionPtr(union_type.index);
-                return union_obj.srcLoc(mod);
+                return mod.declPtr(union_type.decl).srcLoc(mod);
             },
             .opaque_type => |opaque_type| mod.opaqueSrcLoc(opaque_type),
             .enum_type => |enum_type| mod.declPtr(enum_type.decl).srcLoc(mod),
@@ -3281,10 +3266,7 @@ pub const Type = struct {
                 const struct_obj = mod.structPtrUnwrap(struct_type.index) orelse return null;
                 return struct_obj.owner_decl;
             },
-            .union_type => |union_type| {
-                const union_obj = mod.unionPtr(union_type.index);
-                return union_obj.owner_decl;
-            },
+            .union_type => |union_type| union_type.decl,
             .opaque_type => |opaque_type| opaque_type.decl,
             .enum_type => |enum_type| enum_type.decl,
             else => null,

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -1347,31 +1347,6 @@ test "noreturn field in union" {
     try expect(count == 6);
 }
 
-test "union and enum field order doesn't match" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
-    const MyTag = enum(u32) {
-        b = 1337,
-        a = 1666,
-    };
-    const MyUnion = union(MyTag) {
-        a: f32,
-        b: void,
-    };
-    var x: MyUnion = .{ .a = 666 };
-    switch (x) {
-        .a => |my_f32| {
-            try expect(@TypeOf(my_f32) == f32);
-        },
-        .b => unreachable,
-    }
-    x = .b;
-    try expect(x == .b);
-}
-
 test "@unionInit uses tag value instead of field index" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -1383,8 +1358,8 @@ test "@unionInit uses tag value instead of field index" {
         a = 3,
     };
     const U = union(E) {
-        a: usize,
         b: isize,
+        a: usize,
     };
     var i: isize = -1;
     var u = @unionInit(U, "b", i);

--- a/test/cases/compile_errors/access_inactive_union_field_comptime.zig
+++ b/test/cases/compile_errors/access_inactive_union_field_comptime.zig
@@ -1,4 +1,4 @@
-const Enum = enum(u32) { a, b };
+const Enum = enum(u32) { b, a };
 const TaggedUnion = union(Enum) {
     b: []const u8,
     a: []const u8,

--- a/test/cases/compile_errors/dereference_anyopaque.zig
+++ b/test/cases/compile_errors/dereference_anyopaque.zig
@@ -45,8 +45,7 @@ pub export fn entry() void {
 // backend=llvm
 //
 // :11:22: error: comparison of 'void' with null
-// :25:51: error: values of type 'anyopaque' must be comptime-known, but operand value is runtime-known
-// :25:51: note: opaque type 'anyopaque' has undefined size
+// :25:51: error: cannot load opaque type 'anyopaque'
 // :25:51: error: values of type 'fn(*anyopaque, usize, u8, usize) ?[*]u8' must be comptime-known, but operand value is runtime-known
 // :25:51: note: use '*const fn(*anyopaque, usize, u8, usize) ?[*]u8' for a function pointer type
 // :25:51: error: values of type 'fn(*anyopaque, []u8, u8, usize, usize) bool' must be comptime-known, but operand value is runtime-known

--- a/test/cases/compile_errors/directly_embedding_opaque_type_in_struct_and_union.zig
+++ b/test/cases/compile_errors/directly_embedding_opaque_type_in_struct_and_union.zig
@@ -15,12 +15,12 @@ export fn b() void {
     _ = bar;
 }
 export fn c() void {
-    const baz = &@as(opaque {}, undefined);
+    const baz = &@as(O, undefined);
     const qux = .{baz.*};
     _ = qux;
 }
 export fn d() void {
-    const baz = &@as(opaque {}, undefined);
+    const baz = &@as(O, undefined);
     const qux = .{ .a = baz.* };
     _ = qux;
 }
@@ -33,7 +33,5 @@ export fn d() void {
 // :1:11: note: opaque declared here
 // :7:10: error: opaque types have unknown size and therefore cannot be directly embedded in unions
 // :1:11: note: opaque declared here
-// :19:18: error: opaque types have unknown size and therefore cannot be directly embedded in structs
-// :18:22: note: opaque declared here
-// :24:23: error: opaque types have unknown size and therefore cannot be directly embedded in structs
-// :23:22: note: opaque declared here
+// :19:22: error: cannot load opaque type 'tmp.O'
+// :24:28: error: cannot load opaque type 'tmp.O'

--- a/test/cases/compile_errors/non-const_variables_of_things_that_require_const_variables.zig
+++ b/test/cases/compile_errors/non-const_variables_of_things_that_require_const_variables.zig
@@ -27,6 +27,10 @@ export fn entry7() void {
     _ = f;
 }
 const Opaque = opaque {};
+export fn entry8() void {
+    var e: Opaque = undefined;
+    _ = &e;
+}
 
 // error
 // backend=stage2
@@ -39,7 +43,7 @@ const Opaque = opaque {};
 // :14:9: error: variable of type 'comptime_float' must be const or comptime
 // :14:9: note: to modify this variable at runtime, it must be given an explicit fixed-size number type
 // :18:9: error: variable of type '@TypeOf(null)' must be const or comptime
-// :22:20: error: values of type 'tmp.Opaque' must be comptime-known, but operand value is runtime-known
-// :22:20: note: opaque type 'tmp.Opaque' has undefined size
+// :22:20: error: cannot load opaque type 'tmp.Opaque'
 // :26:9: error: variable of type 'type' must be const or comptime
 // :26:9: note: types are not available at runtime
+// :31:12: error: non-extern variable with opaque type 'tmp.Opaque'


### PR DESCRIPTION
### Motivation

In short summary, this is a prerequisite to incremental compilation:

* [x] move unions into InternPool
* [ ] move structs into InternPool
* [ ] move decls into InternPool (represent anonymous decls via InternPool Index)
* [ ] rework CaptureScopes to not use pointers and ref counting
* [ ] make Namespace serialization friendly
* [ ] make the linker code serialization friendly
* [ ] implement serialization and deserialization of the compiler's state
* [ ] fix bugs / QA / fuzz testing / robustness enhancements

After this checklist, incremental compilation will be complete.

### The Commit

There are a couple concepts here worth understanding:

Key.UnionType - This type is available *before* resolving the union's fields. The enum tag type, number of fields, and field names, field types, and field alignments are not available with this.

InternPool.UnionType - This one can be obtained from the above type with `InternPool.loadUnionType` which asserts that the union's enum tag type has been resolved. This one has all the information available.

Additionally:

* ZIR: Turn an unused bit into `any_aligned_fields` flag to help semantic analysis know whether a union has explicit alignment on any fields (usually not).
* Sema: delete `resolveTypeRequiresComptime` which had the same type signature and near-duplicate logic to `typeRequiresComptime`.
  - Make opaque types not report comptime-only (this was inconsistent between the two implementations of this function).
* Implement accepted proposal #12556 which is a breaking change.

### self-hosted compiler InternPool stats after this change:

Note: decls are not in the InternPool yet, so actual intern pool size is 28 MiB, not 90 MiB.

```
intern pool stats for 'zig':
InternPool size: 94589751 bytes
  1433655 items: 7168275 bytes
  4708391 extra: 18833564 bytes
  286106 limbs: 2288848 bytes
  5800 structs: 742400 bytes
  482032 decls: 65556352 bytes
  top 50 tags:
    aggregate: 150707 occurrences, 5645027 total bytes
    ptr_elem: 205214 occurrences, 3488638 total bytes
    ptr_decl: 252426 occurrences, 3281538 total bytes
    ptr_mut_decl: 190277 occurrences, 3234709 total bytes
    int_positive: 134172 occurrences, 2955628 total bytes
    ptr_slice: 112705 occurrences, 1915985 total bytes
    ptr_field: 70539 occurrences, 1199163 total bytes
    func_instance: 30725 occurrences, 1173765 total bytes
    type_struct: 5800 occurrences, 1011928 total bytes
    type_function: 35010 occurrences, 954502 total bytes
    memoized_call: 34838 occurrences, 906754 total bytes
    bytes: 24375 occurrences, 854590 total bytes
    type_pointer: 39507 occurrences, 829647 total bytes
    func_decl: 19410 occurrences, 718170 total bytes
    union_value: 12038 occurrences, 204646 total bytes
    repeated: 13871 occurrences, 180323 total bytes
    type_error_union: 13421 occurrences, 174473 total bytes
    int_small: 11640 occurrences, 151320 total bytes
    enum_tag: 10507 occurrences, 136591 total bytes
    error_union_payload: 7984 occurrences, 103792 total bytes
    opt_payload: 6571 occurrences, 85423 total bytes
    type_inferred_error_set: 12320 occurrences, 61600 total bytes
    type_error_set: 1100 occurrences, 61224 total bytes
    type_tuple_anon: 1812 occurrences, 61212 total bytes
    enum_literal: 6104 occurrences, 30520 total bytes
    int_u32: 6066 occurrences, 30330 total bytes
    type_array_small: 2263 occurrences, 29419 total bytes
    float_comptime_float: 1211 occurrences, 25431 total bytes
    error_set_error: 1845 occurrences, 23985 total bytes
    error_union_error: 1206 occurrences, 15678 total bytes
    float_f64: 1199 occurrences, 15587 total bytes
    type_struct_anon: 396 occurrences, 13872 total bytes
    undef: 2449 occurrences, 12245 total bytes
    type_enum_auto: 489 occurrences, 12225 total bytes
    int_usize: 2432 occurrences, 12160 total bytes
    type_union: 188 occurrences, 10084 total bytes
    only_possible_value: 1968 occurrences, 9840 total bytes
    int_comptime_int_u32: 1954 occurrences, 9770 total bytes
    type_enum_explicit: 257 occurrences, 7453 total bytes
    int_i32: 1472 occurrences, 7360 total bytes
    int_negative: 253 occurrences, 5345 total bytes
    type_optional: 863 occurrences, 4315 total bytes
    opt_null: 841 occurrences, 4205 total bytes
    int_lazy_align: 301 occurrences, 3913 total bytes
    type_slice: 754 occurrences, 3770 total bytes
    type_array_big: 171 occurrences, 3591 total bytes
    int_u16: 688 occurrences, 3440 total bytes
    type_enum_nonexhaustive: 82 occurrences, 2378 total bytes
    runtime_value: 168 occurrences, 2184 total bytes
    ptr_eu_payload: 136 occurrences, 1768 total bytes
```