### PR TITLE
InternPool: mark indexToKey inline

### DIFF
--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -2846,7 +2846,7 @@ pub fn deinit(ip: *InternPool, gpa: Allocator) void {
     ip.* = undefined;
 }
 
-pub fn indexToKey(ip: *const InternPool, index: Index) Key {
+pub inline fn indexToKey(ip: *const InternPool, index: Index) Key {
     assert(index != .none);
     const item = ip.items.get(@intFromEnum(index));
     const data = item.data;


### PR DESCRIPTION
This change achieves notable performance gains with a minimal increase in binary size. I thought to try this after making two key observations:

* `InternPool.indexToKey` appears as one of the highest costs in profiles
* Most use sites of this function only require a small subset of its logic

To expand on the second point a little, within Sema, the most common use for `indexToKey` is in logic such as the following:

```zig
switch (ip.indexToKey(val)) {
    .foo => |foo| { ... },
    else => {
	// emit error
    },
}
```

That means the only logic we actually need in this case is the decoding logic for any tag corresponding to key `foo`. Moreover, the error path will end up calling `Sema.failWithOwnedErrorMsg`, meaning the optimizer knows it's a cold path, so can optimize for the likely case of valid code. Effectively, the vast majority of the logic of `indexToKey` can be optimized away at most call sites.

I saw a 5% wall-clock time improvement analyzing behavior tests, and 9-10% wall-clock time improvement analyzing the compiler. icache misses increased around 10%, but branch mispredictions fell by over 15%! This probably does a lot to make up for the performance regressions we saw when InternPool was introduced.

My release binaries got around 2% larger with symbols included, and less than 1% larger when stripped.