### PR TITLE
std.http: handle Expect: 100-continue, improve redirect logic, add Client.fetch for simple requests

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -365,8 +365,11 @@ pub const Response = struct {
             if (trailing) continue;
 
             if (std.ascii.eqlIgnoreCase(header_name, "content-length")) {
-                if (res.content_length != null) return error.HttpHeadersInvalid;
-                res.content_length = std.fmt.parseInt(u64, header_value, 10) catch return error.InvalidContentLength;
+                const content_length = std.fmt.parseInt(u64, header_value, 10) catch return error.InvalidContentLength;
+
+                if (res.content_length != null and res.content_length != content_length) return error.HttpHeadersInvalid;
+
+                res.content_length = content_length;
             } else if (std.ascii.eqlIgnoreCase(header_name, "transfer-encoding")) {
                 // Transfer-Encoding: second, first
                 // Transfer-Encoding: deflate, chunked
@@ -536,6 +539,8 @@ pub const Request = struct {
 
     /// Send the request to the server.
     pub fn start(req: *Request) StartError!void {
+        if (!req.method.requestHasBody() and req.transfer_encoding != .none) return error.UnsupportedTransferEncoding;
+
         var buffered = std.io.bufferedWriter(req.connection.?.data.writer());
         const w = buffered.writer();
 
@@ -607,7 +612,14 @@ pub const Request = struct {
             }
         }
 
-        try w.print("{}", .{req.headers});
+        for (req.headers.list.items) |entry| {
+            if (entry.value.len == 0) continue;
+
+            try w.writeAll(entry.name);
+            try w.writeAll(": ");
+            try w.writeAll(entry.value);
+            try w.writeAll("\r\n");
+        }
 
         try w.writeAll("\r\n");
 
@@ -635,13 +647,13 @@ pub const Request = struct {
         return index;
     }
 
-    pub const WaitError = RequestError || StartError || TransferReadError || proto.HeadersParser.CheckCompleteHeadError || Response.ParseError || Uri.ParseError || error{ TooManyHttpRedirects, CannotRedirect, HttpRedirectMissingLocation, CompressionInitializationFailed, CompressionNotSupported };
+    pub const WaitError = RequestError || StartError || TransferReadError || proto.HeadersParser.CheckCompleteHeadError || Response.ParseError || Uri.ParseError || error{ TooManyHttpRedirects, RedirectRequiresResend, HttpRedirectMissingLocation, CompressionInitializationFailed, CompressionNotSupported };
 
     /// Waits for a response from the server and parses any headers that are sent.
     /// This function will block until the final response is received.
     ///
     /// If `handle_redirects` is true and the request has no payload, then this function will automatically follow
-    /// redirects. If a request payload is present, then this function will error with error.CannotRedirect.
+    /// redirects. If a request payload is present, then this function will error with error.RedirectRequiresResend.
     pub fn wait(req: *Request) WaitError!void {
         while (true) { // handle redirects
             while (true) { // read headers
@@ -697,9 +709,10 @@ pub const Request = struct {
                 req.response.parser.done = true;
             }
 
-            if (req.transfer_encoding == .none and req.response.status.class() == .redirect and req.handle_redirects) {
+            if (req.response.status.class() == .redirect and req.handle_redirects) {
                 req.response.skip = true;
 
+                // skip the body of the redirect response, this will at least leave the connection in a known good state.
                 const empty = @as([*]u8, undefined)[0..0];
                 assert(try req.transferRead(empty) == 0); // we're skipping, no buffer is necessary
 
@@ -714,6 +727,30 @@ pub const Request = struct {
 
                 const new_url = Uri.parse(location_duped) catch try Uri.parseWithoutScheme(location_duped);
                 const resolved_url = try req.uri.resolve(new_url, false, arena);
+
+                // is the redirect location on the same domain, or a subdomain of the original request?
+                const is_same_domain_or_subdomain = std.ascii.endsWithIgnoreCase(resolved_url.host.?, req.uri.host.?) and (resolved_url.host.?.len == req.uri.host.?.len or resolved_url.host.?[resolved_url.host.?.len - req.uri.host.?.len - 1] == '.');
+
+                if (resolved_url.host == null or !is_same_domain_or_subdomain or !std.ascii.eqlIgnoreCase(resolved_url.scheme, req.uri.scheme)) {
+                    // we're redirecting to a different domain, strip privileged headers like cookies
+                    _ = req.headers.delete("authorization");
+                    _ = req.headers.delete("www-authenticate");
+                    _ = req.headers.delete("cookie");
+                    _ = req.headers.delete("cookie2");
+                }
+
+                if (req.response.status == .see_other or ((req.response.status == .moved_permanently or req.response.status == .found) and req.method == .POST)) {
+                    // we're redirecting to a GET, so we need to change the method and remove the body
+                    req.method = .GET;
+                    req.transfer_encoding = .none;
+                    _ = req.headers.delete("transfer-encoding");
+                    _ = req.headers.delete("content-length");
+                    _ = req.headers.delete("content-type");
+                }
+
+                if (req.transfer_encoding != .none) {
+                    return error.RedirectRequiresResend; // The request body has already been sent. The request is still in a valid state, but the redirect must be handled manually.
+                }
 
                 try req.redirect(resolved_url);
 
@@ -734,9 +771,6 @@ pub const Request = struct {
                         },
                     };
                 }
-
-                if (req.response.status.class() == .redirect and req.handle_redirects and req.transfer_encoding != .none)
-                    return error.CannotRedirect; // The request body has already been sent. The request is still in a valid state, but the redirect must be handled manually.
 
                 break;
             }
@@ -956,17 +990,17 @@ pub const RequestError = ConnectUnproxiedError || ConnectErrorPartial || Request
     UnsupportedTransferEncoding,
 };
 
-pub const Options = struct {
+pub const RequestOptions = struct {
     version: http.Version = .@"HTTP/1.1",
 
     handle_redirects: bool = true,
     max_redirects: u32 = 3,
-    header_strategy: HeaderStrategy = .{ .dynamic = 16 * 1024 },
+    header_strategy: StorageStrategy = .{ .dynamic = 16 * 1024 },
 
     /// Must be an already acquired connection.
     connection: ?*ConnectionPool.Node = null,
 
-    pub const HeaderStrategy = union(enum) {
+    pub const StorageStrategy = union(enum) {
         /// In this case, the client's Allocator will be used to store the
         /// entire HTTP header. This value is the maximum total size of
         /// HTTP headers allowed, otherwise
@@ -988,8 +1022,12 @@ pub const protocol_map = std.ComptimeStringMap(Connection.Protocol, .{
 });
 
 /// Form and send a http request to a server.
+///
+/// `uri` must remain alive during the entire request.
+/// `headers` is cloned and may be freed after this function returns.
+///
 /// This function is threadsafe.
-pub fn request(client: *Client, method: http.Method, uri: Uri, headers: http.Headers, options: Options) RequestError!Request {
+pub fn request(client: *Client, method: http.Method, uri: Uri, headers: http.Headers, options: RequestOptions) RequestError!Request {
     const protocol = protocol_map.get(uri.scheme) orelse return error.UnsupportedUrlScheme;
 
     const port: u16 = uri.port orelse switch (protocol) {
@@ -1015,7 +1053,7 @@ pub fn request(client: *Client, method: http.Method, uri: Uri, headers: http.Hea
         .uri = uri,
         .client = client,
         .connection = conn,
-        .headers = headers,
+        .headers = try headers.clone(client.allocator), // Headers must be cloned to properly handle header transformations in redirects.
         .method = method,
         .version = options.version,
         .redirects_left = options.max_redirects,
@@ -1037,6 +1075,123 @@ pub fn request(client: *Client, method: http.Method, uri: Uri, headers: http.Hea
     req.arena = std.heap.ArenaAllocator.init(client.allocator);
 
     return req;
+}
+
+pub const FetchOptions = struct {
+    pub const Location = union(enum) {
+        url: []const u8,
+        uri: Uri,
+    };
+
+    pub const Payload = union(enum) {
+        string: []const u8,
+        file: std.fs.File,
+        none,
+    };
+
+    pub const ResponseStrategy = union(enum) {
+        storage: RequestOptions.StorageStrategy,
+        file: std.fs.File,
+        none,
+    };
+
+    header_strategy: RequestOptions.StorageStrategy = .{ .dynamic = 16 * 1024 },
+    response_strategy: ResponseStrategy = .{ .storage = .{ .dynamic = 16 * 1024 * 1024 } },
+
+    location: Location,
+    method: http.Method = .GET,
+    headers: http.Headers = http.Headers{ .allocator = std.heap.page_allocator, .owned = false },
+    payload: Payload = .none,
+};
+
+pub const FetchResult = struct {
+    status: http.Status,
+    body: ?[]const u8 = null,
+    headers: http.Headers,
+
+    allocator: Allocator,
+    options: FetchOptions,
+
+    pub fn deinit(res: *FetchResult) void {
+        if (res.options.response_strategy == .storage and res.options.response_strategy.storage == .dynamic) {
+            if (res.body) |body| res.allocator.free(body);
+        }
+
+        res.headers.deinit();
+    }
+};
+
+pub fn fetch(client: *Client, allocator: Allocator, options: FetchOptions) !FetchResult {
+    const has_transfer_encoding = options.headers.contains("transfer-encoding");
+    const has_content_length = options.headers.contains("content-length");
+
+    if (has_content_length or has_transfer_encoding) return error.UnsupportedHeader;
+
+    const uri = switch (options.location) {
+        .url => |u| try Uri.parse(u),
+        .uri => |u| u,
+    };
+
+    var req = try request(client, options.method, uri, options.headers, .{
+        .header_strategy = options.header_strategy,
+        .handle_redirects = options.payload == .none,
+    });
+    defer req.deinit();
+
+    { // Block to maintain lock of file to attempt to prevent a race condition where another process modifies the file while we are reading it.
+        // This relies on other processes actually obeying the advisory lock, which is not guaranteed.
+        if (options.payload == .file) try options.payload.file.lock(.shared);
+        defer if (options.payload == .file) options.payload.file.unlock();
+
+        switch (options.payload) {
+            .string => |str| req.transfer_encoding = .{ .content_length = str.len },
+            .file => |file| req.transfer_encoding = .{ .content_length = (try file.stat()).size },
+            .none => {},
+        }
+
+        try req.start();
+
+        switch (options.payload) {
+            .string => |str| try req.writeAll(str),
+            .file => |file| {
+                try file.seekTo(0);
+                var fifo = std.fifo.LinearFifo(u8, .{ .Static = 8192 }).init();
+                try fifo.pump(file.reader(), req.writer());
+            },
+            .none => {},
+        }
+
+        try req.finish();
+    }
+
+    try req.wait();
+
+    var res = FetchResult{
+        .status = req.response.status,
+        .headers = try req.response.headers.clone(allocator),
+
+        .allocator = allocator,
+        .options = options,
+    };
+
+    switch (options.response_strategy) {
+        .storage => |storage| switch (storage) {
+            .dynamic => |max| res.body = try req.reader().readAllAlloc(allocator, max),
+            .static => |buf| res.body = buf[0..try req.reader().readAll(buf)],
+        },
+        .file => |file| {
+            var fifo = std.fifo.LinearFifo(u8, .{ .Static = 8192 }).init();
+            try fifo.pump(req.reader(), file.writer());
+        },
+        .none => { // Take advantage of request internals to discard the response body and make the connection available for another request.
+            req.response.skip = true;
+
+            const empty = @as([*]u8, undefined)[0..0];
+            assert(try req.transferRead(empty) == 0); // we're skipping, no buffer is necessary
+        },
+    }
+
+    return res;
 }
 
 test {

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -958,9 +958,11 @@ pub fn connectUnproxied(client: *Client, host: []const u8, port: u16, protocol: 
     return conn;
 }
 
-pub const ConnectUnixError = Allocator.Error || std.os.SocketError || error{NameTooLong} || std.os.ConnectError;
+pub const ConnectUnixError = Allocator.Error || std.os.SocketError || error{ NameTooLong, Unsupported } || std.os.ConnectError;
 
 pub fn connectUnix(client: *Client, path: []const u8) ConnectUnixError!*ConnectionPool.Node {
+    if (!net.has_unix_sockets) return error.Unsupported;
+
     if (client.connection_pool.findConnection(.{
         .host = path,
         .port = 0,

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -545,7 +545,7 @@ pub const Request = struct {
         var buffered = std.io.bufferedWriter(req.connection.?.data.writer());
         const w = buffered.writer();
 
-        try w.writeAll(@tagName(req.method));
+        try req.method.write(w);
         try w.writeByte(' ');
 
         if (req.method == .CONNECT) {
@@ -627,15 +627,15 @@ pub const Request = struct {
         try buffered.flush();
     }
 
-    pub const TransferReadError = Connection.ReadError || proto.HeadersParser.ReadError;
+    const TransferReadError = Connection.ReadError || proto.HeadersParser.ReadError;
 
-    pub const TransferReader = std.io.Reader(*Request, TransferReadError, transferRead);
+    const TransferReader = std.io.Reader(*Request, TransferReadError, transferRead);
 
-    pub fn transferReader(req: *Request) TransferReader {
+    fn transferReader(req: *Request) TransferReader {
         return .{ .context = req };
     }
 
-    pub fn transferRead(req: *Request, buf: []u8) TransferReadError!usize {
+    fn transferRead(req: *Request, buf: []u8) TransferReadError!usize {
         if (req.response.parser.done) return 0;
 
         var index: usize = 0;

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -185,8 +185,10 @@ pub const Request = struct {
             return error.HttpHeadersInvalid;
 
         const method_end = mem.indexOfScalar(u8, first_line, ' ') orelse return error.HttpHeadersInvalid;
+        if (method_end > 24) return error.HttpHeadersInvalid;
+
         const method_str = first_line[0..method_end];
-        const method = std.meta.stringToEnum(http.Method, method_str) orelse return error.UnknownHttpMethod;
+        const method: http.Method = @enumFromInt(http.Method.parse(method_str));
 
         const version_start = mem.lastIndexOfScalar(u8, first_line, ' ') orelse return error.HttpHeadersInvalid;
         if (version_start == method_end) return error.HttpHeadersInvalid;
@@ -467,11 +469,11 @@ pub const Response = struct {
         try buffered.flush();
     }
 
-    pub const TransferReadError = Connection.ReadError || proto.HeadersParser.ReadError;
+    const TransferReadError = Connection.ReadError || proto.HeadersParser.ReadError;
 
-    pub const TransferReader = std.io.Reader(*Response, TransferReadError, transferRead);
+    const TransferReader = std.io.Reader(*Response, TransferReadError, transferRead);
 
-    pub fn transferReader(res: *Response) TransferReader {
+    fn transferReader(res: *Response) TransferReader {
         return .{ .context = res };
     }
 

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -458,6 +458,10 @@ pub const Response = struct {
             try w.print("{}", .{res.headers});
         }
 
+        if (res.request.method == .HEAD) {
+            res.transfer_encoding = .none;
+        }
+
         try w.writeAll("\r\n");
 
         try buffered.flush();
@@ -517,10 +521,6 @@ pub const Response = struct {
 
             if (cl == 0) res.request.parser.done = true;
         } else {
-            res.request.parser.done = true;
-        }
-
-        if (res.request.method == .HEAD) {
             res.request.parser.done = true;
         }
 

--- a/test/standalone/http.zig
+++ b/test/standalone/http.zig
@@ -55,6 +55,8 @@ fn handleRequest(res: *Server.Response) !void {
             try res.writeAll("Hello, ");
             try res.writeAll("World!\n");
             try res.finish();
+        } else {
+            try testing.expectEqual(res.writeAll("errors"), error.NotWriteable);
         }
     } else if (mem.startsWith(u8, res.request.target, "/large")) {
         res.transfer_encoding = .{ .content_length = 14 * 1024 + 14 * 10 };

--- a/test/standalone/http.zig
+++ b/test/standalone/http.zig
@@ -22,6 +22,18 @@ fn handleRequest(res: *Server.Response) !void {
 
     log.info("{s} {s} {s}", .{ @tagName(res.request.method), @tagName(res.request.version), res.request.target });
 
+    if (res.request.headers.contains("expect")) {
+        if (mem.eql(u8, res.request.headers.getFirstValue("expect").?, "100-continue")) {
+            res.status = .@"continue";
+            try res.do();
+            res.status = .ok;
+        } else {
+            res.status = .expectation_failed;
+            try res.do();
+            return;
+        }
+    }
+
     const body = try res.reader().readAllAlloc(salloc, 8192);
     defer salloc.free(body);
 
@@ -62,7 +74,7 @@ fn handleRequest(res: *Server.Response) !void {
         }
 
         try res.finish();
-    } else if (mem.eql(u8, res.request.target, "/echo-content")) {
+    } else if (mem.startsWith(u8, res.request.target, "/echo-content")) {
         try testing.expectEqualStrings("Hello, World!\n", body);
         try testing.expectEqualStrings("text/plain", res.request.headers.getFirstValue("content-type").?);
 
@@ -590,6 +602,62 @@ pub fn main() !void {
         defer res.deinit();
 
         try testing.expectEqualStrings("Hello, World!\n", res.body.?);
+    }
+
+    { // expect: 100-continue
+        var h = http.Headers{ .allocator = calloc };
+        defer h.deinit();
+
+        try h.append("expect", "100-continue");
+        try h.append("content-type", "text/plain");
+
+        const location = try std.fmt.allocPrint(calloc, "http://127.0.0.1:{d}/echo-content#expect-100", .{port});
+        defer calloc.free(location);
+        const uri = try std.Uri.parse(location);
+
+        log.info("{s}", .{location});
+        var req = try client.request(.POST, uri, h, .{});
+        defer req.deinit();
+
+        req.transfer_encoding = .chunked;
+
+        try req.start();
+        try req.wait();
+        try testing.expectEqual(http.Status.@"continue", req.response.status);
+
+        try req.writeAll("Hello, ");
+        try req.writeAll("World!\n");
+        try req.finish();
+
+        try req.wait();
+        try testing.expectEqual(http.Status.ok, req.response.status);
+
+        const body = try req.reader().readAllAlloc(calloc, 8192);
+        defer calloc.free(body);
+
+        try testing.expectEqualStrings("Hello, World!\n", body);
+    }
+
+    { // expect: garbage
+        var h = http.Headers{ .allocator = calloc };
+        defer h.deinit();
+
+        try h.append("content-type", "text/plain");
+        try h.append("expect", "garbage");
+
+        const location = try std.fmt.allocPrint(calloc, "http://127.0.0.1:{d}/echo-content#expect-garbage", .{port});
+        defer calloc.free(location);
+        const uri = try std.Uri.parse(location);
+
+        log.info("{s}", .{location});
+        var req = try client.request(.POST, uri, h, .{});
+        defer req.deinit();
+
+        req.transfer_encoding = .chunked;
+
+        try req.start();
+        try req.wait();
+        try testing.expectEqual(http.Status.expectation_failed, req.response.status);
     }
 
     { // issue 16282 *** This test leaves the client in an invalid state, it must be last ***

--- a/test/standalone/http.zig
+++ b/test/standalone/http.zig
@@ -20,7 +20,7 @@ var server: Server = undefined;
 fn handleRequest(res: *Server.Response) !void {
     const log = std.log.scoped(.server);
 
-    log.info("{s} {s} {s}", .{ @tagName(res.request.method), @tagName(res.request.version), res.request.target });
+    log.info("{} {s} {s}", .{ res.request.method, @tagName(res.request.version), res.request.target });
 
     if (res.request.headers.contains("expect")) {
         if (mem.eql(u8, res.request.headers.getFirstValue("expect").?, "100-continue")) {


### PR DESCRIPTION
This PR provides a way for redirects to be handled with a payload when the redirect code indicates that the payload has been received and doesn't need to be re-transmitted such as with `see_other`, `moved_permanently`, or `found`. In such cases content headers are stripped, as they may confuse a server.

Privileged headers such as authentication are now stripped when redirecting off of the domain they were originally intended for (although to a subdomain is allowed).

CannotRedirect has been translated into a more informative RedirectRequiresResend error, indicating that the request is *still in a valid state*, but the request was left with the previous response (the redirection response), and the user will have to handle the redirection themselves to the Location provided in the response header.

HTTP headers are now cloned when passed to Client.request, this is a necessary evil to allow for stripping headers off of the request without causing questionable modification of potentially static header objects provided by the user.

Adds Client.connectUnix(), which allows forming a connection to a UNIX Domain Socket. This function must be called manually, and then passed into Client.request() as the `connection` field in options.

Adds Client.fetch, to allow for the common use case to not require intimate knowledge of all rules that a user of std.http must follow. It allows: sending either a []const u8 or std.fs.File as a payload, sending the response to a file, a static buffer, or to a dynamic allocation (or throwing it away altogether) in a single call.

std.http.Headers.initList has been added to allow for more efficient initialization of headers.
std.http.Headers.clone has been added to provide a way to clone a Headers.

std.http.Server handles HEAD requests correctly.
std.http.Client handles 100 Continue responses (although the user must explicitly handle them)
std.http.Server can now send 100 Continue responses (although the user must explicitly program this behavior).

Closes #16731
Closes #16849

