### PR TITLE
std: page_size design and implementation

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,19 @@
+TODO
+- Design
+  * [ ] unclear, if variable `os.default_page_size` should exist or if
+    getDefaultPageSize() is sufficient
+    - [ ] implement naive solution
+    - [ ] get representable use cases
+    - [ ] profile
+  * [x] Use case optimal performance via input handling on stack/heap with
+  page alinged memory structure: `var buf: [std.mem.page_size]u8 = undefined;`
+  Default to min_page_size for these cases. Otherwise, the API should have the
+  buffer logic selection at comptime explicit as input. Justification: global
+  config can not reflect use cases, release optimizations neither and default
+  is fallback algorithm of Zig.
+
+Implementation
+  * [ ] lib/std/heap/general_purpose_allocator.zig wants to be available on
+  embedded, but this requires a user choice of what page size to use for
+  program lifetime for the particular instantiation of the allocator (because
+  we cant get that from the Kernel). Look into how to do that.

--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -697,7 +697,8 @@ const PosixThreadImpl = struct {
         // Use the same set of parameters used by the libc-less impl.
         const stack_size = @max(config.stack_size, 16 * 1024);
         assert(c.pthread_attr_setstacksize(&attr, stack_size) == .SUCCESS);
-        assert(c.pthread_attr_setguardsize(&attr, std.mem.page_size) == .SUCCESS);
+        const default_page_size = os.getDefaultPageSize() catch unreachable;
+        assert(c.pthread_attr_setguardsize(&attr, default_page_size) == .SUCCESS);
 
         var handle: c.pthread_t = undefined;
         switch (c.pthread_create(

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -78,6 +78,7 @@ pub usingnamespace switch (builtin.os.tag) {
 
         pub extern "c" fn getrusage(who: c_int, usage: *c.rusage) c_int;
 
+        pub extern "c" fn sysconf(sc: c_int) c_long;
         pub extern "c" fn sched_yield() c_int;
 
         pub extern "c" fn sigaction(sig: c_int, noalias act: ?*const c.Sigaction, noalias oact: ?*c.Sigaction) c_int;

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -92,6 +92,7 @@ pub usingnamespace switch (builtin.os.tag) {
 
         pub extern "c" fn alarm(seconds: c_uint) c_uint;
 
+        // TODO minimal page size
         pub extern "c" fn msync(addr: *align(page_size) const anyopaque, len: usize, flags: c_int) c_int;
     },
 };
@@ -146,6 +147,7 @@ pub extern "c" fn writev(fd: c_int, iov: [*]const iovec_const, iovcnt: c_uint) i
 pub extern "c" fn pwritev(fd: c_int, iov: [*]const iovec_const, iovcnt: c_uint, offset: c.off_t) isize;
 pub extern "c" fn write(fd: c.fd_t, buf: [*]const u8, nbyte: usize) isize;
 pub extern "c" fn pwrite(fd: c.fd_t, buf: [*]const u8, nbyte: usize, offset: c.off_t) isize;
+// TODO minimal page size
 pub extern "c" fn mmap(addr: ?*align(page_size) anyopaque, len: usize, prot: c_uint, flags: c_uint, fd: c.fd_t, offset: c.off_t) *anyopaque;
 pub extern "c" fn munmap(addr: *align(page_size) const anyopaque, len: usize) c_int;
 pub extern "c" fn mprotect(addr: *align(page_size) anyopaque, len: usize, prot: c_uint) c_int;

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -233,6 +233,9 @@ pub const mach_header_64 = macho.mach_header_64;
 pub const mach_header = macho.mach_header;
 
 pub const _errno = __error;
+pub const _SC = struct {
+    pub const PAGESIZE = 29;
+};
 
 pub extern "c" fn @"close$NOCANCEL"(fd: fd_t) c_int;
 pub extern "c" fn mach_host_self() mach_port_t;
@@ -3691,7 +3694,7 @@ pub const MachTask = extern struct {
         return left;
     }
 
-    fn getPageSize(task: MachTask) MachError!usize {
+    pub fn getPageSize(task: MachTask) MachError!usize {
         if (task.isValid()) {
             var info_count = TASK_VM_INFO_COUNT;
             var vm_info: task_vm_info_data_t = undefined;

--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -9,6 +9,10 @@ pub fn _errno() *c_int {
     return &errno;
 }
 
+pub const _SC = struct {
+    pub const PAGESIZE = 47;
+};
+
 pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) c_int;
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -8,6 +8,10 @@ const iovec_const = std.os.iovec_const;
 extern "c" fn __error() *c_int;
 pub const _errno = __error;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 47;
+};
+
 pub extern "c" fn getdents(fd: c_int, buf_ptr: [*]u8, nbytes: usize) isize;
 pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn getrandom(buf_ptr: [*]u8, buf_len: usize, flags: c_uint) isize;

--- a/lib/std/c/fuchsia.zig
+++ b/lib/std/c/fuchsia.zig
@@ -1,3 +1,8 @@
+// third party ulib musl
+pub const _SC = struct {
+    pub const PAGESIZE = 30;
+};
+
 pub const pthread_mutex_t = extern struct {
     size: [__SIZEOF_PTHREAD_MUTEX_T]u8 align(@alignOf(usize)) = [_]u8{0} ** __SIZEOF_PTHREAD_MUTEX_T,
 };

--- a/lib/std/c/haiku.zig
+++ b/lib/std/c/haiku.zig
@@ -9,6 +9,10 @@ extern "c" fn _errnop() *c_int;
 
 pub const _errno = _errnop;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 27;
+};
+
 pub extern "c" fn find_directory(which: c_int, volume: i32, createIt: bool, path_ptr: [*]u8, length: i32) u64;
 
 pub extern "c" fn find_thread(thread_name: ?*anyopaque) i32;

--- a/lib/std/c/hermit.zig
+++ b/lib/std/c/hermit.zig
@@ -1,6 +1,10 @@
 const std = @import("std");
 const maxInt = std.math.maxInt;
 
+// pub const _SC = struct {
+//     pub const PAGESIZE = TODO;
+// };
+
 pub const pthread_mutex_t = extern struct {
     inner: usize = ~@as(usize, 0),
 };

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -237,6 +237,7 @@ pub extern "c" fn fstatat64(dirfd: fd_t, noalias path: [*:0]const u8, noalias st
 pub extern "c" fn ftruncate64(fd: c_int, length: off_t) c_int;
 pub extern "c" fn getrlimit64(resource: rlimit_resource, rlim: *rlimit) c_int;
 pub extern "c" fn lseek64(fd: fd_t, offset: i64, whence: c_int) i64;
+// TODO minimal page_size
 pub extern "c" fn mmap64(addr: ?*align(std.mem.page_size) anyopaque, len: usize, prot: c_uint, flags: c_uint, fd: fd_t, offset: i64) *anyopaque;
 pub extern "c" fn open64(path: [*:0]const u8, oflag: c_uint, ...) c_int;
 pub extern "c" fn openat64(fd: c_int, path: [*:0]const u8, oflag: c_uint, ...) c_int;
@@ -294,12 +295,14 @@ pub extern "c" fn posix_memalign(memptr: *?*anyopaque, alignment: usize, size: u
 pub extern "c" fn malloc_usable_size(?*const anyopaque) usize;
 
 pub extern "c" fn mincore(
+    // TODO minimal page size
     addr: *align(std.mem.page_size) anyopaque,
     length: usize,
     vec: [*]u8,
 ) c_int;
 
 pub extern "c" fn madvise(
+    // TODO minimal page size
     addr: *align(std.mem.page_size) anyopaque,
     length: usize,
     advice: c_uint,

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -105,6 +105,10 @@ pub const user_desc = linux.user_desc;
 pub const utsname = linux.utsname;
 pub const PR = linux.PR;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 30;
+};
+
 pub const _errno = switch (native_abi) {
     .android => struct {
         extern fn __errno() *c_int;

--- a/lib/std/c/minix.zig
+++ b/lib/std/c/minix.zig
@@ -1,4 +1,9 @@
 const builtin = @import("builtin");
+
+pub const _SC = struct {
+    pub const PAGESIZE = 28;
+};
+
 pub const pthread_mutex_t = extern struct {
     size: [__SIZEOF_PTHREAD_MUTEX_T]u8 align(@alignOf(usize)) = [_]u8{0} ** __SIZEOF_PTHREAD_MUTEX_T,
 };

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -10,6 +10,10 @@ const rusage = std.c.rusage;
 extern "c" fn __errno() *c_int;
 pub const _errno = __errno;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 28;
+};
+
 pub const dl_iterate_phdr_callback = *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int;
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -63,6 +63,7 @@ pub const sched_yield = __libc_thr_yield;
 
 pub extern "c" fn posix_memalign(memptr: *?*anyopaque, alignment: usize, size: usize) c_int;
 
+// TODO minimal page size
 pub extern "c" fn __msync13(addr: *align(std.mem.page_size) const anyopaque, len: usize, flags: c_int) c_int;
 pub const msync = __msync13;
 

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -8,6 +8,10 @@ const iovec_const = std.os.iovec_const;
 extern "c" fn __errno() *c_int;
 pub const _errno = __errno;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 28;
+};
+
 pub const dl_iterate_phdr_callback = *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int;
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 

--- a/lib/std/c/solaris.zig
+++ b/lib/std/c/solaris.zig
@@ -9,6 +9,11 @@ const timezone = std.c.timezone;
 extern "c" fn ___errno() *c_int;
 pub const _errno = ___errno;
 
+pub const _SC = struct {
+    pub const PAGESIZE = 11;
+    pub const NPROCESSORS_ONLN = 15;
+};
+
 pub const dl_iterate_phdr_callback = *const fn (info: *dl_phdr_info, size: usize, data: ?*anyopaque) callconv(.C) c_int;
 pub extern "c" fn dl_iterate_phdr(callback: dl_iterate_phdr_callback, data: ?*anyopaque) c_int;
 
@@ -17,7 +22,6 @@ pub extern "c" fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) c_int;
 pub extern "c" fn pipe2(fds: *[2]fd_t, flags: u32) c_int;
 pub extern "c" fn arc4random_buf(buf: [*]u8, len: usize) void;
 pub extern "c" fn posix_memalign(memptr: *?*anyopaque, alignment: usize, size: usize) c_int;
-pub extern "c" fn sysconf(sc: c_int) i64;
 pub extern "c" fn signalfd(fd: fd_t, mask: *const sigset_t, flags: u32) c_int;
 pub extern "c" fn madvise(address: [*]u8, len: usize, advise: u32) c_int;
 
@@ -1682,11 +1686,6 @@ pub const AF_SUN = struct {
     /// hardware capabilities can be verified against AT_SUN_HWCAP
     pub const HWCAPVERIFY = 0x00000002;
     pub const NOPLM = 0x00000004;
-};
-
-// TODO: Add sysconf numbers when the other OSs do.
-pub const _SC = struct {
-    pub const NPROCESSORS_ONLN = 15;
 };
 
 pub const procfs = struct {

--- a/lib/std/crypto/tlcsprng.zig
+++ b/lib/std/crypto/tlcsprng.zig
@@ -59,6 +59,7 @@ var install_atfork_handler = std.once(struct {
     }
 }.do);
 
+// TODO minimal page size
 threadlocal var wipe_mem: []align(mem.page_size) u8 = &[_]u8{};
 
 fn tlsCsprngFill(_: *anyopaque, buffer: []u8) void {
@@ -94,6 +95,7 @@ fn tlsCsprngFill(_: *anyopaque, buffer: []u8) void {
         } else {
             // Use a static thread-local buffer.
             const S = struct {
+                // TODO minimal page size
                 threadlocal var buf: Context align(mem.page_size) = .{
                     .init_state = .uninitialized,
                     .rng = undefined,

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -597,7 +597,8 @@ pub const StackIterator = struct {
         // We are unable to determine validity of memory for freestanding targets
         if (native_os == .freestanding) return true;
 
-        const aligned_address = address & ~@as(usize, @intCast((mem.page_size - 1)));
+        const default_page_size = os.getDefaultPageSize() catch unreachable;
+        const aligned_address = address & ~@as(usize, @intCast((default_page_size - 1)));
         if (aligned_address == 0) return false;
         const aligned_memory = @as([*]align(mem.page_size) u8, @ptrFromInt(aligned_address))[0..mem.page_size];
 
@@ -1069,6 +1070,7 @@ pub fn readElfDebugInfo(
     build_id: ?[]const u8,
     expected_crc: ?u32,
     parent_sections: *DW.DwarfInfo.SectionArray,
+    // TODO minimal page size
     parent_mapped_mem: ?[]align(mem.page_size) const u8,
 ) !ModuleDebugInfo {
     nosuspend {
@@ -1393,6 +1395,7 @@ fn printLineFromFileAnyOs(out_stream: anytype, line_info: LineInfo) !void {
     defer f.close();
     // TODO fstat and make sure that the file has the correct size
 
+    // TODO minimal page size (no good default)
     var buf: [mem.page_size]u8 = undefined;
     var line: usize = 1;
     var column: usize = 1;

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -88,6 +88,7 @@ pub fn LinearFifo(
                 mem.copyForwards(T, self.buf[0..self.count], self.buf[self.head..][0..self.count]);
                 self.head = 0;
             } else {
+                // TODO minimal page size
                 var tmp: [mem.page_size / 2 / @sizeOf(T)]T = undefined;
 
                 while (self.head != 0) {

--- a/lib/std/heap/PageAllocator.zig
+++ b/lib/std/heap/PageAllocator.zig
@@ -16,8 +16,9 @@ fn alloc(_: *anyopaque, n: usize, log2_align: u8, ra: usize) ?[*]u8 {
     _ = ra;
     _ = log2_align;
     assert(n > 0);
-    if (n > maxInt(usize) - (mem.page_size - 1)) return null;
-    const aligned_len = mem.alignForward(usize, n, mem.page_size);
+    const default_page_size = os.getDefaultPageSize() catch unreachable;
+    if (n > maxInt(usize) - (default_page_size - 1)) return null;
+    const aligned_len = mem.alignForward(usize, n, default_page_size);
 
     if (builtin.os.tag == .windows) {
         const w = os.windows;
@@ -39,8 +40,8 @@ fn alloc(_: *anyopaque, n: usize, log2_align: u8, ra: usize) ?[*]u8 {
         -1,
         0,
     ) catch return null;
-    assert(mem.isAligned(@intFromPtr(slice.ptr), mem.page_size));
-    const new_hint: [*]align(mem.page_size) u8 = @alignCast(slice.ptr + aligned_len);
+    assert(mem.isAligned(@intFromPtr(slice.ptr), default_page_size));
+    const new_hint: [*]align(default_page_size) u8 = @alignCast(slice.ptr + aligned_len);
     _ = @cmpxchgStrong(@TypeOf(std.heap.next_mmap_addr_hint), &std.heap.next_mmap_addr_hint, hint, new_hint, .Monotonic, .Monotonic);
     return slice.ptr;
 }
@@ -54,14 +55,15 @@ fn resize(
 ) bool {
     _ = log2_buf_align;
     _ = return_address;
-    const new_size_aligned = mem.alignForward(usize, new_size, mem.page_size);
+    const default_page_size = os.getDefaultPageSize() catch unreachable;
+    const new_size_aligned = mem.alignForward(usize, new_size, default_page_size);
 
     if (builtin.os.tag == .windows) {
         const w = os.windows;
         if (new_size <= buf_unaligned.len) {
             const base_addr = @intFromPtr(buf_unaligned.ptr);
             const old_addr_end = base_addr + buf_unaligned.len;
-            const new_addr_end = mem.alignForward(usize, base_addr + new_size, mem.page_size);
+            const new_addr_end = mem.alignForward(usize, base_addr + new_size, default_page_size);
             if (old_addr_end > new_addr_end) {
                 // For shrinking that is not releasing, we will only
                 // decommit the pages not needed anymore.
@@ -73,14 +75,14 @@ fn resize(
             }
             return true;
         }
-        const old_size_aligned = mem.alignForward(usize, buf_unaligned.len, mem.page_size);
+        const old_size_aligned = mem.alignForward(usize, buf_unaligned.len, default_page_size);
         if (new_size_aligned <= old_size_aligned) {
             return true;
         }
         return false;
     }
 
-    const buf_aligned_len = mem.alignForward(usize, buf_unaligned.len, mem.page_size);
+    const buf_aligned_len = mem.alignForward(usize, buf_unaligned.len, default_page_size);
     if (new_size_aligned == buf_aligned_len)
         return true;
 
@@ -103,7 +105,8 @@ fn free(_: *anyopaque, slice: []u8, log2_buf_align: u8, return_address: usize) v
     if (builtin.os.tag == .windows) {
         os.windows.VirtualFree(slice.ptr, 0, os.windows.MEM_RELEASE);
     } else {
-        const buf_aligned_len = mem.alignForward(usize, slice.len, mem.page_size);
+        const default_page_size = os.getDefaultPageSize() catch unreachable;
+        const buf_aligned_len = mem.alignForward(usize, slice.len, default_page_size);
         os.munmap(@alignCast(slice.ptr[0..buf_aligned_len]));
     }
 }

--- a/lib/std/heap/WasmPageAllocator.zig
+++ b/lib/std/heap/WasmPageAllocator.zig
@@ -5,6 +5,7 @@ const Allocator = std.mem.Allocator;
 const mem = std.mem;
 const maxInt = std.math.maxInt;
 const assert = std.debug.assert;
+const wasm = std.wasm;
 
 comptime {
     if (!builtin.target.isWasm()) {
@@ -73,7 +74,7 @@ const FreeBlock = struct {
                 var count: usize = 0;
                 while (j + count < self.totalPages() and self.getBit(j + count) == .free) {
                     count += 1;
-                    const addr = j * mem.page_size;
+                    const addr = j * wasm.page_size;
                     if (count >= num_pages and mem.isAlignedLog2(addr, log2_align)) {
                         self.setBits(j, num_pages, .used);
                         return j;
@@ -100,16 +101,16 @@ fn extendedOffset() usize {
 }
 
 fn nPages(memsize: usize) usize {
-    return mem.alignForward(usize, memsize, mem.page_size) / mem.page_size;
+    return mem.alignForward(usize, memsize, wasm.page_size) / wasm.page_size;
 }
 
 fn alloc(ctx: *anyopaque, len: usize, log2_align: u8, ra: usize) ?[*]u8 {
     _ = ctx;
     _ = ra;
-    if (len > maxInt(usize) - (mem.page_size - 1)) return null;
+    if (len > maxInt(usize) - (wasm.page_size - 1)) return null;
     const page_count = nPages(len);
     const page_idx = allocPages(page_count, log2_align) catch return null;
-    return @as([*]u8, @ptrFromInt(page_idx * mem.page_size));
+    return @as([*]u8, @ptrFromInt(page_idx * wasm.page_size));
 }
 
 fn allocPages(page_count: usize, log2_align: u8) !usize {
@@ -126,9 +127,9 @@ fn allocPages(page_count: usize, log2_align: u8) !usize {
     }
 
     const next_page_idx = @wasmMemorySize(0);
-    const next_page_addr = next_page_idx * mem.page_size;
+    const next_page_addr = next_page_idx * wasm.page_size;
     const aligned_addr = mem.alignForwardLog2(next_page_addr, log2_align);
-    const drop_page_count = @divExact(aligned_addr - next_page_addr, mem.page_size);
+    const drop_page_count = @divExact(aligned_addr - next_page_addr, wasm.page_size);
     const result = @wasmMemoryGrow(0, @as(u32, @intCast(drop_page_count + page_count)));
     if (result <= 0)
         return error.OutOfMemory;
@@ -151,7 +152,7 @@ fn freePages(start: usize, end: usize) void {
             // TODO: would it be better if we use the first page instead?
             new_end -= 1;
 
-            extended.data = @as([*]u128, @ptrFromInt(new_end * mem.page_size))[0 .. mem.page_size / @sizeOf(u128)];
+            extended.data = @as([*]u128, @ptrFromInt(new_end * wasm.page_size))[0 .. wasm.page_size / @sizeOf(u128)];
             // Since this is the first page being freed and we consume it, assume *nothing* is free.
             @memset(extended.data, PageStatus.none_free);
         }
@@ -170,7 +171,7 @@ fn resize(
     _ = ctx;
     _ = log2_buf_align;
     _ = return_address;
-    const aligned_len = mem.alignForward(usize, buf.len, mem.page_size);
+    const aligned_len = mem.alignForward(usize, buf.len, wasm.page_size);
     if (new_len > aligned_len) return false;
     const current_n = nPages(aligned_len);
     const new_n = nPages(new_len);
@@ -190,7 +191,7 @@ fn free(
     _ = ctx;
     _ = log2_buf_align;
     _ = return_address;
-    const aligned_len = mem.alignForward(usize, buf.len, mem.page_size);
+    const aligned_len = mem.alignForward(usize, buf.len, wasm.page_size);
     const current_n = nPages(aligned_len);
     const base = nPages(@intFromPtr(buf.ptr));
     freePages(base, base + current_n);
@@ -200,8 +201,8 @@ test "internals" {
     const page_allocator = std.heap.page_allocator;
     const testing = std.testing;
 
-    const conventional_memsize = WasmPageAllocator.conventional.totalPages() * mem.page_size;
-    const initial = try page_allocator.alloc(u8, mem.page_size);
+    const conventional_memsize = WasmPageAllocator.conventional.totalPages() * wasm.page_size;
+    const initial = try page_allocator.alloc(u8, wasm.page_size);
     try testing.expect(@intFromPtr(initial.ptr) < conventional_memsize); // If this isn't conventional, the rest of these tests don't make sense. Also we have a serious memory leak in the test suite.
 
     var inplace = try page_allocator.realloc(initial, 1);

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -103,7 +103,7 @@ const page_size = std.mem.page_size;
 const StackTrace = std.builtin.StackTrace;
 
 /// Integer type for pointing to slots in a small allocation
-const SlotIndex = std.meta.Int(.unsigned, math.log2(page_size) + 1);
+const SlotIndex = std.meta.Int(.unsigned, math.log2(page_size) + 1); // TODO use max_page_size
 
 const default_test_stack_trace_frames: usize = if (builtin.is_test) 10 else 6;
 const default_sys_stack_trace_frames: usize = if (std.debug.sys_can_stack_trace) default_test_stack_trace_frames else 0;
@@ -194,6 +194,7 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
 
         pub const Error = mem.Allocator.Error;
 
+        // TODO minimal page size
         const small_bucket_count = math.log2(page_size);
         const largest_bucket_object_size = 1 << (small_bucket_count - 1);
 
@@ -245,6 +246,7 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
         const BucketHeader = struct {
             prev: *BucketHeader,
             next: *BucketHeader,
+            // TODO minimal page size
             page: [*]align(page_size) u8,
             alloc_cursor: SlotIndex,
             used_count: SlotIndex,

--- a/lib/std/heap/sbrk_allocator.zig
+++ b/lib/std/heap/sbrk_allocator.zig
@@ -17,6 +17,8 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
 
         lock: std.Thread.Mutex = .{},
 
+        // TODO User must ensure the default page size is correct by compiled or configured Kernel
+        // or this logic would be wrong and os.getDefaultPageSize() must be used.
         const max_usize = math.maxInt(usize);
         const ushift = math.Log2Int(usize);
         const bigpage_size = 64 * 1024;

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -215,6 +215,8 @@ fn allocBytesWithAlignment(self: Allocator, comptime alignment: u29, byte_count:
     // The Zig Allocator interface is not intended to solve alignments beyond
     // the minimum OS page size. For these use cases, the caller must use OS
     // APIs directly.
+
+    // TODO minimal page size
     comptime assert(alignment <= mem.page_size);
 
     if (byte_count == 0) {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4738,7 +4738,7 @@ pub fn sysconf(sc: c_int) SysConfError!usize {
             else => |err| return unexpectedErrno(err),
         }
     };
-    const choice: u8 = 0;
+    var choice: u8 = 0;
     choice += @intFromBool(is_minus_one);
     choice += @intFromBool(is_inval);
     switch (choice) {

--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -1080,6 +1080,7 @@ pub const SubmissionQueue = struct {
     dropped: *u32,
     array: []u32,
     sqes: []linux.io_uring_sqe,
+    // TODO minimal page size
     mmap: []align(mem.page_size) u8,
     mmap_sqes: []align(mem.page_size) u8,
 

--- a/lib/std/os/linux/tls.zig
+++ b/lib/std/os/linux/tls.zig
@@ -306,7 +306,7 @@ pub fn prepareTLS(area: []u8) usize {
 // because it's less than 3 pages of memory, and putting it in the ELF like this
 // is equivalent to moving the mmap call below into the kernel, avoiding syscall
 // overhead.
-var main_thread_tls_buffer: [0x2100]u8 align(mem.page_size) = undefined;
+var main_thread_tls_buffer: [0x2100]u8 align(mem.page_size) = undefined; // TODO minimal page size
 
 pub fn initStaticTLS(phdrs: []elf.Phdr) void {
     initTLS(phdrs);
@@ -314,6 +314,7 @@ pub fn initStaticTLS(phdrs: []elf.Phdr) void {
     const tls_area = blk: {
         // Fast path for the common case where the TLS data is really small,
         // avoid an allocation and use our local buffer.
+        // TODO minimal page size
         if (tls_image.alloc_align <= mem.page_size and
             tls_image.alloc_size <= main_thread_tls_buffer.len)
         {

--- a/lib/std/os/plan9.zig
+++ b/lib/std/os/plan9.zig
@@ -278,6 +278,7 @@ pub fn sbrk(n: usize) usize {
         bloc = @intFromPtr(&ExecData.end);
         bloc_max = @intFromPtr(&ExecData.end);
     }
+    // TODO use underlying call to os.getDefaultPageSize() directly
     var bl = std.mem.alignForward(usize, bloc, std.mem.page_size);
     const n_aligned = std.mem.alignForward(usize, n, std.mem.page_size);
     if (bl + n_aligned > bloc_max) {

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -1224,7 +1224,7 @@ test "getDefaultPageSize smoke test" {
     const page_size = try os.getDefaultPageSize();
     switch (page_size) {
         // zig fmt: off
-        1024, 2048, 4096, 8192, 16384, 32768, // 1, 2, 4, 8, 16, 32KB
+        1024, 2048, 4096, 8192, 16384, 32768, 65536, // 1, 2, 4, 8, 16, 32, 64KB
         2097152, 4194304 => {}, // 2, 4MB
         // zig fmt: on
         else => return error.InvalidDefaultPageSize,

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -1,4 +1,4 @@
-const std = @import("../std.zig");
+const std = @import("std");
 const os = std.os;
 const testing = std.testing;
 const expect = testing.expect;
@@ -1218,4 +1218,15 @@ test "fchmodat smoke test" {
     try os.fchmodat(tmp.dir.fd, "foo.txt", 0o755, 0);
     const st = try os.fstatat(tmp.dir.fd, "foo.txt", 0);
     try expectEqual(@as(os.mode_t, 0o755), st.mode & 0b111_111_111);
+}
+
+test "getDefaultPageSize smoke test" {
+    const page_size = try os.getDefaultPageSize();
+    switch (page_size) {
+        // zig fmt: off
+        1024, 2048, 4096, 8192, 16384, 32768, // 1, 2, 4, 8, 16, 32KB
+        2097152, 4194304 => {}, // 2, 4MB
+        // zig fmt: on
+        else => return error.InvalidDefaultPageSize,
+    }
 }

--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -658,6 +658,8 @@ test "PackedIntArray at end of available memory" {
     }
     const PackedArray = PackedIntArray(u3, 8);
 
+    // TODO This logic is flawed, as Kernel can be compiled or configure page size
+    // from available ones on architecture.
     const Padded = struct {
         _: [std.mem.page_size - @sizeOf(PackedArray)]u8,
         p: PackedArray,

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -980,6 +980,7 @@ pub fn posixGetUserInfo(name: []const u8) !UserInfo {
         ReadGroupId,
     };
 
+    // TODO minimal page size (no good default)
     var buf: [std.mem.page_size]u8 = undefined;
     var name_index: usize = 0;
     var state = State.Start;

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -1,4 +1,4 @@
-// This file is included in the compilation unit when exporting an executable.
+//! This file is included in the compilation unit when exporting an executable.
 
 const root = @import("root");
 const std = @import("std.zig");
@@ -418,6 +418,8 @@ fn expandStackSize(phdrs: []elf.Phdr) void {
     for (phdrs) |*phdr| {
         switch (phdr.p_type) {
             elf.PT_GNU_STACK => {
+                // TODO Kernel has loader and decides page_size, which can be
+                // configurable at Kernel compilation or runtiem
                 assert(phdr.p_memsz % std.mem.page_size == 0);
 
                 // Silently fail if we are unable to get limits.


### PR DESCRIPTION
Justification: Kernel compilation or configuration determines page size
from available page sizes of architecture (for optimal performance).
Currently, Zig is not portable to that regard.

This is WIP to get CI-coverage, ideas and clarify questions.

Follow-up will be large page abstraction API.

Depends on #16638.
