### PR TITLE
std.os Return error.WouldBlock when ws2_32 connect returns .WSAEWOULDBLOCK

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3982,7 +3982,7 @@ pub fn connect(sock: socket_t, sock_addr: *const sockaddr, len: socklen_t) Conne
             .WSAEINVAL => unreachable,
             .WSAEISCONN => unreachable,
             .WSAENOTSOCK => unreachable,
-            .WSAEWOULDBLOCK => unreachable,
+            .WSAEWOULDBLOCK => return error.WouldBlock,
             .WSAEACCES => unreachable,
             .WSAENOBUFS => return error.SystemResources,
             .WSAEAFNOSUPPORT => return error.AddressFamilyNotSupported,


### PR DESCRIPTION
From the Microsoft page:
[link](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect#return-value)

> If no error occurs, connect returns zero. Otherwise, it returns SOCKET_ERROR, and a specific error code can be retrieved by calling [WSAGetLastError](https://learn.microsoft.com/en-us/windows/desktop/api/winsock/nf-winsock-wsagetlasterror).
> 
> On a blocking socket, the return value indicates success or failure of the connection attempt.
> 
> With a nonblocking socket, the connection attempt cannot be completed immediately. In this case, connect will return SOCKET_ERROR, and [WSAGetLastError](https://learn.microsoft.com/en-us/windows/desktop/api/winsock/nf-winsock-wsagetlasterror) will return [WSAEWOULDBLOCK](https://learn.microsoft.com/en-us/windows/desktop/WinSock/windows-sockets-error-codes-2).

So this change just returns the error.WouldBlock when WSAGetLastError returns .WSAEWOULDBLOCK after the connect function.

The caller will have the opportunity to filter this error if a non-blocking socket is used instead of crashing.

