### PR TITLE
fix compile errors introduced by #16953

### DIFF
--- a/lib/std/os/uefi/protocol.zig
+++ b/lib/std/os/uefi/protocol.zig
@@ -18,7 +18,7 @@ pub const GraphicsOutput = @import("protocol/graphics_output.zig").GraphicsOutpu
 
 pub const edid = @import("protocol/edid.zig");
 
-pub const SimpleNetworkMode = @import("protocol/simple_network.zig").SimpleNetwork;
+pub const SimpleNetwork = @import("protocol/simple_network.zig").SimpleNetwork;
 pub const ManagedNetwork = @import("protocol/managed_network.zig").ManagedNetwork;
 
 pub const Ip6ServiceBinding = @import("protocol/ip6_service_binding.zig").Ip6ServiceBinding;
@@ -28,8 +28,8 @@ pub const Ip6Config = @import("protocol/ip6_config.zig").Ip6Config;
 pub const Udp6ServiceBinding = @import("protocol/udp6_service_binding.zig").Udp6ServiceBinding;
 pub const Udp6 = @import("protocol/udp6.zig").Udp6;
 
-pub const HiiDatabase = @import("protocol/hii_database.zig").HIIDatabase;
-pub const HiiPopup = @import("protocol/hii_popup.zig").HIIPopup;
+pub const HiiDatabase = @import("protocol/hii_database.zig").HiiDatabase;
+pub const HiiPopup = @import("protocol/hii_popup.zig").HiiPopup;
 
 test {
     @setEvalBranchQuota(2000);

--- a/lib/std/os/uefi/protocol.zig
+++ b/lib/std/os/uefi/protocol.zig
@@ -18,7 +18,7 @@ pub const GraphicsOutput = @import("protocol/graphics_output.zig").GraphicsOutpu
 
 pub const edid = @import("protocol/edid.zig");
 
-pub const SimpleNetwork = @import("protocol/simple_network.zig").SimpleNetwork;
+pub const SimpleNetworkMode = @import("protocol/simple_network.zig").SimpleNetwork;
 pub const ManagedNetwork = @import("protocol/managed_network.zig").ManagedNetwork;
 
 pub const Ip6ServiceBinding = @import("protocol/ip6_service_binding.zig").Ip6ServiceBinding;
@@ -28,8 +28,8 @@ pub const Ip6Config = @import("protocol/ip6_config.zig").Ip6Config;
 pub const Udp6ServiceBinding = @import("protocol/udp6_service_binding.zig").Udp6ServiceBinding;
 pub const Udp6 = @import("protocol/udp6.zig").Udp6;
 
-pub const HiiDatabase = @import("protocol/hii_database.zig").HiiDatabase;
-pub const HiiPopup = @import("protocol/hii_popup.zig").HiiPopup;
+pub const HiiDatabase = @import("protocol/hii_database.zig").HIIDatabase;
+pub const HiiPopup = @import("protocol/hii_popup.zig").HIIPopup;
 
 test {
     @setEvalBranchQuota(2000);

--- a/lib/std/os/uefi/protocol/hii_database.zig
+++ b/lib/std/os/uefi/protocol/hii_database.zig
@@ -6,12 +6,12 @@ const hii = uefi.hii;
 const cc = uefi.cc;
 
 /// Database manager for HII-related data structures.
-pub const HIIDatabase = extern struct {
+pub const HiiDatabase = extern struct {
     _new_package_list: Status, // TODO
-    _remove_package_list: *const fn (*const HIIDatabase, hii.Handle) callconv(cc) Status,
-    _update_package_list: *const fn (*const HIIDatabase, hii.Handle, *const hii.PackageList) callconv(cc) Status,
-    _list_package_lists: *const fn (*const HIIDatabase, u8, ?*const Guid, *usize, [*]hii.Handle) callconv(cc) Status,
-    _export_package_lists: *const fn (*const HIIDatabase, ?hii.Handle, *usize, *hii.PackageList) callconv(cc) Status,
+    _remove_package_list: *const fn (*const HiiDatabase, hii.Handle) callconv(cc) Status,
+    _update_package_list: *const fn (*const HiiDatabase, hii.Handle, *const hii.PackageList) callconv(cc) Status,
+    _list_package_lists: *const fn (*const HiiDatabase, u8, ?*const Guid, *usize, [*]hii.Handle) callconv(cc) Status,
+    _export_package_lists: *const fn (*const HiiDatabase, ?hii.Handle, *usize, *hii.PackageList) callconv(cc) Status,
     _register_package_notify: Status, // TODO
     _unregister_package_notify: Status, // TODO
     _find_keyboard_layouts: Status, // TODO
@@ -20,22 +20,22 @@ pub const HIIDatabase = extern struct {
     _get_package_list_handle: Status, // TODO
 
     /// Removes a package list from the HII database.
-    pub fn removePackageList(self: *const HIIDatabase, handle: hii.Handle) Status {
+    pub fn removePackageList(self: *const HiiDatabase, handle: hii.Handle) Status {
         return self._remove_package_list(self, handle);
     }
 
     /// Update a package list in the HII database.
-    pub fn updatePackageList(self: *const HIIDatabase, handle: hii.Handle, buffer: *const hii.PackageList) Status {
+    pub fn updatePackageList(self: *const HiiDatabase, handle: hii.Handle, buffer: *const hii.PackageList) Status {
         return self._update_package_list(self, handle, buffer);
     }
 
     /// Determines the handles that are currently active in the database.
-    pub fn listPackageLists(self: *const HIIDatabase, package_type: u8, package_guid: ?*const Guid, buffer_length: *usize, handles: [*]hii.Handle) Status {
+    pub fn listPackageLists(self: *const HiiDatabase, package_type: u8, package_guid: ?*const Guid, buffer_length: *usize, handles: [*]hii.Handle) Status {
         return self._list_package_lists(self, package_type, package_guid, buffer_length, handles);
     }
 
     /// Exports the contents of one or all package lists in the HII database into a buffer.
-    pub fn exportPackageLists(self: *const HIIDatabase, handle: ?hii.Handle, buffer_size: *usize, buffer: *hii.PackageList) Status {
+    pub fn exportPackageLists(self: *const HiiDatabase, handle: ?hii.Handle, buffer_size: *usize, buffer: *hii.PackageList) Status {
         return self._export_package_lists(self, handle, buffer_size, buffer);
     }
 

--- a/lib/std/os/uefi/protocol/hii_popup.zig
+++ b/lib/std/os/uefi/protocol/hii_popup.zig
@@ -6,12 +6,12 @@ const hii = uefi.hii;
 const cc = uefi.cc;
 
 /// Display a popup window
-pub const HIIPopup = extern struct {
+pub const HiiPopup = extern struct {
     revision: u64,
-    _create_popup: *const fn (*const HIIPopup, PopupStyle, PopupType, hii.Handle, u16, ?*PopupSelection) callconv(cc) Status,
+    _create_popup: *const fn (*const HiiPopup, PopupStyle, PopupType, hii.Handle, u16, ?*PopupSelection) callconv(cc) Status,
 
     /// Displays a popup window.
-    pub fn createPopup(self: *const HIIPopup, style: PopupStyle, popup_type: PopupType, handle: hii.Handle, msg: u16, user_selection: ?*PopupSelection) Status {
+    pub fn createPopup(self: *const HiiPopup, style: PopupStyle, popup_type: PopupType, handle: hii.Handle, msg: u16, user_selection: ?*PopupSelection) Status {
         return self._create_popup(self, style, popup_type, handle, msg, user_selection);
     }
 

--- a/lib/std/os/uefi/protocol/hii_popup.zig
+++ b/lib/std/os/uefi/protocol/hii_popup.zig
@@ -8,10 +8,10 @@ const cc = uefi.cc;
 /// Display a popup window
 pub const HIIPopup = extern struct {
     revision: u64,
-    _create_popup: *const fn (*const HIIPopup, PopupStyle, PopupType, hii.HIIHandle, u16, ?*PopupSelection) callconv(cc) Status,
+    _create_popup: *const fn (*const HIIPopup, PopupStyle, PopupType, hii.Handle, u16, ?*PopupSelection) callconv(cc) Status,
 
     /// Displays a popup window.
-    pub fn createPopup(self: *const HIIPopup, style: PopupStyle, popup_type: PopupType, handle: hii.HIIHandle, msg: u16, user_selection: ?*PopupSelection) Status {
+    pub fn createPopup(self: *const HIIPopup, style: PopupStyle, popup_type: PopupType, handle: hii.Handle, msg: u16, user_selection: ?*PopupSelection) Status {
         return self._create_popup(self, style, popup_type, handle, msg, user_selection);
     }
 

--- a/lib/std/os/uefi/protocol/ip6.zig
+++ b/lib/std/os/uefi/protocol/ip6.zig
@@ -3,8 +3,8 @@ const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Event = uefi.Event;
 const Status = uefi.Status;
-const MacAddress = uefi.protocol.MacAddress;
-const ManagedNetworkConfigData = uefi.protocol.ManagedNetworkConfigData;
+const MacAddress = uefi.MacAddress;
+const ManagedNetworkConfigData = uefi.protocol.ManagedNetwork.Config;
 const SimpleNetworkMode = uefi.protocol.SimpleNetworkMode;
 const cc = uefi.cc;
 

--- a/lib/std/os/uefi/protocol/ip6.zig
+++ b/lib/std/os/uefi/protocol/ip6.zig
@@ -5,11 +5,11 @@ const Event = uefi.Event;
 const Status = uefi.Status;
 const MacAddress = uefi.MacAddress;
 const ManagedNetworkConfigData = uefi.protocol.ManagedNetwork.Config;
-const SimpleNetworkMode = uefi.protocol.SimpleNetworkMode;
+const SimpleNetwork = uefi.protocol.SimpleNetwork;
 const cc = uefi.cc;
 
 pub const Ip6 = extern struct {
-    _get_mode_data: *const fn (*const Ip6, ?*Mode, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(cc) Status,
+    _get_mode_data: *const fn (*const Ip6, ?*Mode, ?*ManagedNetworkConfigData, ?*SimpleNetwork) callconv(cc) Status,
     _configure: *const fn (*const Ip6, ?*const Config) callconv(cc) Status,
     _groups: *const fn (*const Ip6, bool, ?*const Address) callconv(cc) Status,
     _routes: *const fn (*const Ip6, bool, ?*const Address, u8, ?*const Address) callconv(cc) Status,
@@ -20,7 +20,7 @@ pub const Ip6 = extern struct {
     _poll: *const fn (*const Ip6) callconv(cc) Status,
 
     /// Gets the current operational settings for this instance of the EFI IPv6 Protocol driver.
-    pub fn getModeData(self: *const Ip6, ip6_mode_data: ?*Mode, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) Status {
+    pub fn getModeData(self: *const Ip6, ip6_mode_data: ?*Mode, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetwork) Status {
         return self._get_mode_data(self, ip6_mode_data, mnp_config_data, snp_mode_data);
     }
 

--- a/lib/std/os/uefi/protocol/managed_network.zig
+++ b/lib/std/os/uefi/protocol/managed_network.zig
@@ -6,7 +6,7 @@ const Handle = uefi.Handle;
 const Status = uefi.Status;
 const Time = uefi.Time;
 const SimpleNetworkMode = uefi.protocol.SimpleNetworkMode;
-const MacAddress = uefi.protocol.MacAddress;
+const MacAddress = uefi.MacAddress;
 const cc = uefi.cc;
 
 pub const ManagedNetwork = extern struct {

--- a/lib/std/os/uefi/protocol/managed_network.zig
+++ b/lib/std/os/uefi/protocol/managed_network.zig
@@ -5,12 +5,12 @@ const Event = uefi.Event;
 const Handle = uefi.Handle;
 const Status = uefi.Status;
 const Time = uefi.Time;
-const SimpleNetworkMode = uefi.protocol.SimpleNetworkMode;
+const SimpleNetwork = uefi.protocol.SimpleNetwork;
 const MacAddress = uefi.MacAddress;
 const cc = uefi.cc;
 
 pub const ManagedNetwork = extern struct {
-    _get_mode_data: *const fn (*const ManagedNetwork, ?*Config, ?*SimpleNetworkMode) callconv(cc) Status,
+    _get_mode_data: *const fn (*const ManagedNetwork, ?*Config, ?*SimpleNetwork) callconv(cc) Status,
     _configure: *const fn (*const ManagedNetwork, ?*const Config) callconv(cc) Status,
     _mcast_ip_to_mac: *const fn (*const ManagedNetwork, bool, *const anyopaque, *MacAddress) callconv(cc) Status,
     _groups: *const fn (*const ManagedNetwork, bool, ?*const MacAddress) callconv(cc) Status,
@@ -21,7 +21,7 @@ pub const ManagedNetwork = extern struct {
 
     /// Returns the operational parameters for the current MNP child driver.
     /// May also support returning the underlying SNP driver mode data.
-    pub fn getModeData(self: *const ManagedNetwork, mnp_config_data: ?*Config, snp_mode_data: ?*SimpleNetworkMode) Status {
+    pub fn getModeData(self: *const ManagedNetwork, mnp_config_data: ?*Config, snp_mode_data: ?*SimpleNetwork) Status {
         return self._get_mode_data(self, mnp_config_data, snp_mode_data);
     }
 

--- a/lib/std/os/uefi/protocol/udp6.zig
+++ b/lib/std/os/uefi/protocol/udp6.zig
@@ -6,11 +6,11 @@ const Status = uefi.Status;
 const Time = uefi.Time;
 const Ip6 = uefi.protocol.Ip6;
 const ManagedNetworkConfigData = uefi.protocol.ManagedNetwork.Config;
-const SimpleNetworkMode = uefi.protocol.SimpleNetworkMode;
+const SimpleNetwork = uefi.protocol.SimpleNetwork;
 const cc = uefi.cc;
 
 pub const Udp6 = extern struct {
-    _get_mode_data: *const fn (*const Udp6, ?*Config, ?*Ip6.Mode, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(cc) Status,
+    _get_mode_data: *const fn (*const Udp6, ?*Config, ?*Ip6.Mode, ?*ManagedNetworkConfigData, ?*SimpleNetwork) callconv(cc) Status,
     _configure: *const fn (*const Udp6, ?*const Config) callconv(cc) Status,
     _groups: *const fn (*const Udp6, bool, ?*const Ip6.Address) callconv(cc) Status,
     _transmit: *const fn (*const Udp6, *CompletionToken) callconv(cc) Status,
@@ -18,7 +18,7 @@ pub const Udp6 = extern struct {
     _cancel: *const fn (*const Udp6, ?*CompletionToken) callconv(cc) Status,
     _poll: *const fn (*const Udp6) callconv(cc) Status,
 
-    pub fn getModeData(self: *const Udp6, udp6_config_data: ?*Config, ip6_mode_data: ?*Ip6.Mode, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) Status {
+    pub fn getModeData(self: *const Udp6, udp6_config_data: ?*Config, ip6_mode_data: ?*Ip6.Mode, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetwork) Status {
         return self._get_mode_data(self, udp6_config_data, ip6_mode_data, mnp_config_data, snp_mode_data);
     }
 

--- a/lib/std/os/uefi/protocol/udp6.zig
+++ b/lib/std/os/uefi/protocol/udp6.zig
@@ -5,12 +5,12 @@ const Event = uefi.Event;
 const Status = uefi.Status;
 const Time = uefi.Time;
 const Ip6 = uefi.protocol.Ip6;
-const ManagedNetworkConfigData = uefi.protocol.ManagedNetworkConfigData;
+const ManagedNetworkConfigData = uefi.protocol.ManagedNetwork.Config;
 const SimpleNetworkMode = uefi.protocol.SimpleNetworkMode;
 const cc = uefi.cc;
 
 pub const Udp6 = extern struct {
-    _get_mode_data: *const fn (*const Udp6, ?*Config, ?*Ip6.ModeData, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(cc) Status,
+    _get_mode_data: *const fn (*const Udp6, ?*Config, ?*Ip6.Mode, ?*ManagedNetworkConfigData, ?*SimpleNetworkMode) callconv(cc) Status,
     _configure: *const fn (*const Udp6, ?*const Config) callconv(cc) Status,
     _groups: *const fn (*const Udp6, bool, ?*const Ip6.Address) callconv(cc) Status,
     _transmit: *const fn (*const Udp6, *CompletionToken) callconv(cc) Status,
@@ -18,7 +18,7 @@ pub const Udp6 = extern struct {
     _cancel: *const fn (*const Udp6, ?*CompletionToken) callconv(cc) Status,
     _poll: *const fn (*const Udp6) callconv(cc) Status,
 
-    pub fn getModeData(self: *const Udp6, udp6_config_data: ?*Config, ip6_mode_data: ?*Ip6.ModeData, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) Status {
+    pub fn getModeData(self: *const Udp6, udp6_config_data: ?*Config, ip6_mode_data: ?*Ip6.Mode, mnp_config_data: ?*ManagedNetworkConfigData, snp_mode_data: ?*SimpleNetworkMode) Status {
         return self._get_mode_data(self, udp6_config_data, ip6_mode_data, mnp_config_data, snp_mode_data);
     }
 


### PR DESCRIPTION
this is a very naive fix. all it does is get rid of errors that appear when running `std.testing.refAllDecls(std.uefi)` 