### PR TITLE
linux: export getauxval when not compiling with libc

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -167,7 +167,9 @@ fn getauxvalImpl(index: usize) callconv(.C) usize {
     return 0;
 }
 comptime {
-    @export(getauxvalImpl, .{ .name = "getauxval", .linkage = .Weak });
+    if (!builtin.link_libc) {
+        @export(getauxvalImpl, .{ .name = "getauxval", .linkage = .Weak });
+    }
 }
 
 // Some architectures (and some syscalls) require 64bit parameters to be passed

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -153,6 +153,10 @@ pub usingnamespace @import("linux/io_uring.zig");
 
 /// Set by startup code, used by `getauxval`.
 pub var elf_aux_maybe: ?[*]std.elf.Auxv = null;
+pub extern var _elf_aux_maybe: ?[*]std.elf.Auxv;
+comptime {
+    @export(elf_aux_maybe, .{ .name = "_elf_aux_maybe", .linkage = .Weak });
+}
 
 /// See `std.elf` for the constants.
 pub fn getauxval(index: usize) usize {

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -154,9 +154,21 @@ pub usingnamespace @import("linux/io_uring.zig");
 /// Set by startup code, used by `getauxval`.
 pub var elf_aux_maybe: ?[*]std.elf.Auxv = null;
 
-/// See `std.elf` for the constants.
-/// This matches the libc getauxval function.
-pub extern fn getauxval(index: usize) usize;
+pub usingnamespace if (switch (builtin.zig_backend) {
+    // Calling extern functions is not yet supported with these backends
+    .stage2_x86_64, .stage2_aarch64, .stage2_arm, .stage2_riscv64, .stage2_sparc64 => false,
+    else => !builtin.link_libc,
+}) struct {
+    /// See `std.elf` for the constants.
+    /// This matches the libc getauxval function.
+    pub extern fn getauxval(index: usize) usize;
+    comptime {
+        @export(getauxvalImpl, .{ .name = "getauxval", .linkage = .Weak });
+    }
+} else struct {
+    pub const getauxval = getauxvalImpl;
+};
+
 fn getauxvalImpl(index: usize) callconv(.C) usize {
     const auxv = elf_aux_maybe orelse return 0;
     var i: usize = 0;
@@ -165,11 +177,6 @@ fn getauxvalImpl(index: usize) callconv(.C) usize {
             return auxv[i].a_un.a_val;
     }
     return 0;
-}
-comptime {
-    if (!builtin.link_libc) {
-        @export(getauxvalImpl, .{ .name = "getauxval", .linkage = .Weak });
-    }
 }
 
 // Some architectures (and some syscalls) require 64bit parameters to be passed


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/16975.

Before:
```
thread 4288 panic: panic
Panicked during a panic. Aborting.
Aborted
```

After:
```
thread 4135 panic: panic
/mnt/c/cygwin64/home/kcbanner/temp/16975/lib.zig:2:5: 0x2ae695 in panic (lib)
    @panic("panic");
    ^
/mnt/c/cygwin64/home/kcbanner/temp/16975/exe.zig:4:10: 0x23a7e8 in main (exe)
    panic();
         ^
/mnt/c/cygwin64/home/kcbanner/kit/zig/lib/std/start.zig:360:22: 0x23a0ac in posixCallMainAndExit (exe)
    while (envp_optional[envp_count]) |_| : (envp_count += 1) {}
                     ^
/mnt/c/cygwin64/home/kcbanner/kit/zig/lib/std/start.zig:243:5: 0x239c01 in _start (exe)
    asm volatile (switch (native_arch) {
    ^
???:?:?:
```

The issue was caused by the version of `elf_aux_maybe` (linux.zig) in `lib` not being initialized by the startup code (since only the version in the exe existed), which caused the phdr lookup to fail (due to underflow when subtracting from zero).

The panic within a panic trace:
```
#0  0x00000000002ddc54 in process.getBaseAddress () at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/process.zig:1079
#1  0x00000000002cec55 in os.dl_iterate_phdr__anon_5275 (context=0x7fffffffc120) at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/os.zig:5409
#2  0x00000000002ce749 in debug.DebugInfo.lookupModuleDl (self=0x326608 <debug.self_debug_info>, address=2992457) at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/debug.zig:1837
#3  0x00000000002cf5dd in debug.DebugInfo.getModuleForAddress (self=0x326608 <debug.self_debug_info>, address=2992457) at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/debug.zig:1561
#4  0x00000000002f633f in debug.StackIterator.next_unwind (self=0x7fffffffd120) at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/debug.zig:643
#5  0x00000000002e9670 in debug.StackIterator.next_internal (self=0x7fffffffd120) at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/debug.zig:669
#6  0x00000000002dad0f in debug.StackIterator.next (self=0x7fffffffd120) at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/debug.zig:584
#7  0x00000000002daadc in debug.writeCurrentStackTrace__anon_7051 (out_stream=..., debug_info=0x326608 <debug.self_debug_info>, tty_config=..., start_addr=...)
    at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/debug.zig:731
#8  0x00000000002aef67 in debug.dumpCurrentStackTrace (start_addr=...) at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/debug.zig:127
#9  0x00000000002ae897 in debug.panicImpl (trace=0x0, first_trace_addr=..., msg=...) at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/debug.zig:421
#10 0x00000000002ae6f7 in builtin.default_panic (msg=..., error_return_trace=0x0, ret_addr=...) at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/builtin.zig:813
#11 0x00000000002ae696 in panic () at lib.zig:2
#12 0x000000000023a7e9 in exe.main () at exe.zig:4
#13 0x000000000023a0ad in start.posixCallMainAndExit () at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/start.zig:360
#14 0x0000000000239c02 in _start () at /home/kcbanner/kit/zig-linux-x86_64-0.12.0-dev.170+750998eef/lib/std/start.zig:243
```

However, this fix does pose a couple questions:
- If a zig static library not linked with libc is linked against an exe that does link libc - `elf_aux_maybe` will not be initialized and we're back to the original problem. Is this use case valid, though?
  - Update: Example of this (except with a dynamic library) https://github.com/ziglang/zig/issues/16281
- Should an attempt be made (maybe with weak linkage?) to share the default panic handler so that multiple copies aren't included in the final binary (ie. multiple zig libs + zig exe)?