### PR TITLE
Sema: implement reference trace with called from here notes

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1566,12 +1566,6 @@ pub const ErrorMsg = struct {
         gpa.free(err_msg.reference_trace);
         err_msg.* = undefined;
     }
-
-    pub fn clearTrace(err_msg: *ErrorMsg, gpa: Allocator) void {
-        if (err_msg.reference_trace.len == 0) return;
-        gpa.free(err_msg.reference_trace);
-        err_msg.reference_trace = &.{};
-    }
 };
 
 /// Canonical reference to a position within a source file.

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2409,8 +2409,8 @@ fn failWithOwnedErrorMsg(sema: *Sema, err_msg: *Module.ErrorMsg) CompileError {
             break :blk default_reference_trace_len;
         };
 
-        var referenced_by = if (sema.func_index != .none)
-            mod.funcOwnerDeclIndex(sema.func_index)
+        var referenced_by = if (sema.owner_func_index != .none)
+            mod.funcOwnerDeclIndex(sema.owner_func_index)
         else
             sema.owner_decl_index;
         var reference_stack = std.ArrayList(Module.ErrorMsg.Trace).init(gpa);
@@ -7430,7 +7430,6 @@ fn analyzeCall(
                         const err_msg = sema.err orelse return err;
                         if (mem.eql(u8, err_msg.msg, recursive_msg)) return err;
                         try sema.errNote(block, call_src, err_msg, "called from here", .{});
-                        err_msg.clearTrace(gpa);
                         return err;
                     },
                     else => |e| return e,


### PR DESCRIPTION
Extracted from #16969 for easier inclusion in a bugfix release.

Closes #15124

---

```diff
 repro.zig:24:5: error: bad
     @compileError("bad");
     ^~~~~~~~~~~~~~~~~~~~
 repro.zig:20:6: note: called from here
     l();
     ~^~
 repro.zig:16:6: note: called from here
     k();
     ~^~
 repro.zig:12:6: note: called from here
     j();
     ~^~
 repro.zig:9:9: note: called from here
 fn h() i() {}
        ~^~
+referenced by:
+    g: repro.zig:6:5
+    f: repro.zig:2:5
+    comptime_0: repro.zig:28:5
 
```

---

```diff
 lib/std/mem.zig:4143:9: error: expected []T or *[_]T, passed *u32
         @compileError("expected []T or *[_]T, passed " ++ @typeName(Slice));
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 lib/std/mem.zig:4150:59: note: called from here
 pub fn sliceAsBytes(slice: anytype) SliceAsBytesReturnType(@TypeOf(slice)) {
                                     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
+referenced by:
+    theImportantFunctionTheUserWantsToSee: repro.zig:5:33
 
```