### PR TITLE
std.BoundedArray: make capacity a comptime field

### DIFF
--- a/lib/std/crypto/ff.zig
+++ b/lib/std/crypto/ff.zig
@@ -99,7 +99,7 @@ pub fn Uint(comptime max_bits: comptime_int) type {
         pub fn fromPrimitive(comptime T: type, x_: T) OverflowError!Self {
             var x = x_;
             var out = Self.zero;
-            for (0..out.limbs.capacity()) |i| {
+            for (0..out.limbs.capacity) |i| {
                 const t = if (@bitSizeOf(T) > t_bits) @as(TLimb, @truncate(x)) else x;
                 out.limbs.set(i, t);
                 x = math.shr(T, x, t_bits);

--- a/lib/std/io/reader.zig
+++ b/lib/std/io/reader.zig
@@ -260,7 +260,7 @@ pub fn Reader(
         /// Reads bytes until `bounded.len` is equal to `num_bytes`,
         /// or the stream ends.
         ///
-        /// * it is assumed that `num_bytes` will not exceed `bounded.capacity()`
+        /// * it is assumed that `num_bytes` will not exceed `bounded.capacity`
         pub fn readIntoBoundedBytes(
             self: Self,
             comptime num_bytes: usize,
@@ -751,7 +751,7 @@ test "Reader.readIntoBoundedBytes correctly reads into a provided bounded array"
 
     var bounded_array = std.BoundedArray(u8, 10000){};
 
-    // compile time error if the size is not the same at the provided `bounded.capacity()`
+    // compile time error if the size is not the same at the provided `bounded.capacity`
     try reader.readIntoBoundedBytes(10000, &bounded_array);
     try testing.expectEqualStrings(bounded_array.slice(), test_string);
 }


### PR DESCRIPTION
I think the more compatible `std.ArrayList` and `std.BoundedArray` are,
the better.
This makes the two slightly more compatible because `std.ArrayList` also
has its capacity as a field.
In the case of `std.BoundedArray` it's going to be a comptime field and so doesn't make
the data structure any bigger.

The main motivation for this however was that there's not actually any
way to get the capacity of a `std.BoundedArray` at comptime which makes it
difficult for example to easily make use of the passed capacity when defining
global variables for example without making the capacity I pass another
constant beforehand, or doing some weird comptime/`@TypeOf` stuff.

`bounded_array.buffer.len` does not work at comptime:
```zig
lib/std/bounded_array.zig:403:41: error: unable to evaluate comptime expression
    var i: std.math.IntFittingRange(0, a.buffer.len) = 0;
                                       ~^~~~~~~
```