### PR TITLE
std.io.Reader.readIntoBoundedBytes: remove redundant parameter 

### DIFF
--- a/lib/std/crypto/ff.zig
+++ b/lib/std/crypto/ff.zig
@@ -99,7 +99,7 @@ pub fn Uint(comptime max_bits: comptime_int) type {
         pub fn fromPrimitive(comptime T: type, x_: T) OverflowError!Self {
             var x = x_;
             var out = Self.zero;
-            for (0..out.limbs.capacity()) |i| {
+            for (0..out.limbs.capacity) |i| {
                 const t = if (@bitSizeOf(T) > t_bits) @as(TLimb, @truncate(x)) else x;
                 out.limbs.set(i, t);
                 x = math.shr(T, x, t_bits);

--- a/lib/std/io/reader.zig
+++ b/lib/std/io/reader.zig
@@ -260,7 +260,7 @@ pub fn Reader(
         /// Reads bytes until `bounded.len` is equal to `num_bytes`,
         /// or the stream ends.
         ///
-        /// * it is assumed that `num_bytes` will not exceed `bounded.capacity()`
+        /// * it is assumed that `num_bytes` will not exceed `bounded.capacity`
         pub fn readIntoBoundedBytes(
             self: Self,
             comptime num_bytes: usize,
@@ -751,7 +751,7 @@ test "Reader.readIntoBoundedBytes correctly reads into a provided bounded array"
 
     var bounded_array = std.BoundedArray(u8, 10000){};
 
-    // compile time error if the size is not the same at the provided `bounded.capacity()`
+    // compile time error if the size is not the same at the provided `bounded.capacity`
     try reader.readIntoBoundedBytes(10000, &bounded_array);
     try testing.expectEqualStrings(bounded_array.slice(), test_string);
 }


### PR DESCRIPTION
**Depends on #16993**. #16993 should be merged before this one.

The `comptime num_bytes: usize` parameter is redundant and results in
the user having to specify the comptime-known capacity twice for no reason. My solution is to use `anytype`.