### PR TITLE
ci: use zig build check-fmt instead of zig fmt --check

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -422,13 +422,18 @@ pub fn build(b: *std.Build) !void {
     const optimization_modes = chosen_opt_modes_buf[0..chosen_mode_index];
 
     const fmt_include_paths = &.{ "doc", "lib", "src", "test", "tools", "build.zig" };
-    const fmt_exclude_paths = &.{"test/cases"};
+    const fmt_exclude_paths = &.{
+        "test/cases",
+        // This is for the CI scripts.
+        "build-debug",
+        "build-release",
+    };
     const do_fmt = b.addFmt(.{
         .paths = fmt_include_paths,
         .exclude_paths = fmt_exclude_paths,
     });
 
-    b.step("test-fmt", "Check source files having conforming formatting").dependOn(&b.addFmt(.{
+    b.step("check-fmt", "Check source files having conforming formatting").dependOn(&b.addFmt(.{
         .paths = fmt_include_paths,
         .exclude_paths = fmt_exclude_paths,
         .check = true,

--- a/ci/aarch64-linux-debug.sh
+++ b/ci/aarch64-linux-debug.sh
@@ -50,11 +50,8 @@ unset CXX
 
 ninja install
 
-# TODO: move this to a build.zig step (check-fmt)
 echo "Looking for non-conforming code formatting..."
-stage3-debug/bin/zig fmt --check .. \
-  --exclude ../test/cases/ \
-  --exclude ../build-debug
+stage3-debug/bin/zig build check-fmt
 
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
 stage3-debug/bin/zig build \

--- a/ci/aarch64-linux-release.sh
+++ b/ci/aarch64-linux-release.sh
@@ -50,11 +50,8 @@ unset CXX
 
 ninja install
 
-# TODO: move this to a build.zig step (check-fmt)
 echo "Looking for non-conforming code formatting..."
-stage3-release/bin/zig fmt --check .. \
-  --exclude ../test/cases/ \
-  --exclude ../build-release
+stage3-release/bin/zig build check-fmt
 
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
 stage3-release/bin/zig build \

--- a/ci/x86_64-linux-debug.sh
+++ b/ci/x86_64-linux-debug.sh
@@ -50,11 +50,8 @@ unset CXX
 
 ninja install
 
-# TODO: move this to a build.zig step (check-fmt)
 echo "Looking for non-conforming code formatting..."
-stage3-debug/bin/zig fmt --check .. \
-  --exclude ../test/cases/ \
-  --exclude ../build-debug
+stage3-debug/bin/zig build check-fmt
 
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
 stage3-debug/bin/zig build \

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -50,12 +50,8 @@ unset CXX
 
 ninja install
 
-# TODO: move this to a build.zig step (check-fmt)
 echo "Looking for non-conforming code formatting..."
-stage3-release/bin/zig fmt --check .. \
-  --exclude ../test/cases/ \
-  --exclude ../build-debug \
-  --exclude ../build-release
+stage3-release/bin/zig build check-fmt
 
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
 stage3-release/bin/zig build \


### PR DESCRIPTION
We already have a zig build step for this: test-fmt.

* Rename the test-fmt step to check-fmt. test-fmt sounds like it runs tests for `zig fmt` itself (`lib/std/zig/render.zig`). It's also more similar to `zig fmt --check` and the `std.Build.FmtStep.Options` `check` field.
* Use the step instead of `zig fmt --check` in the CI scripts.
* ~~Also use it in CI scripts that didn't have this check before.~~ (decided not to do this anymore)

That, or should we have the check in only one of the scripts, like `ci/x86_64-linux-debug.sh`?
This includes the `tidy` check. Wouldn't it make sense to run these two checks only in one of the scripts?

I'm also not sure about the `--exclude ../build-{optimize_mode}` excludes found in the CI scripts but not in the `build.zig`. For now I decided to add them in `build.zig` too.