### PR TITLE
std.net: Fix IPv6 address parsing for single digit

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -406,6 +406,9 @@ pub const Ip6Address = extern struct {
         if (!saw_any_digits and !abbrv) {
             return error.Incomplete;
         }
+        if (!abbrv and index < 14) {
+            return error.Incomplete;
+        }
 
         if (index == 14) {
             ip_slice[14] = @as(u8, @truncate(x >> 8));

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -13,6 +13,7 @@ test "parse and render IPv6 addresses" {
         "FF01::Fb",
         "::1",
         "::",
+        "1::",
         "2001:db8::",
         "::1234:5678",
         "2001:db8::1234:5678",
@@ -24,6 +25,7 @@ test "parse and render IPv6 addresses" {
         "ff01::fb",
         "::1",
         "::",
+        "1::",
         "2001:db8::",
         "::1234:5678",
         "2001:db8::1234:5678",
@@ -48,6 +50,7 @@ test "parse and render IPv6 addresses" {
     try testing.expectError(error.InvalidEnd, net.Address.parseIp6("FF01:0:0:0:0:0:0:FB:", 0));
     try testing.expectError(error.Incomplete, net.Address.parseIp6("FF01:", 0));
     try testing.expectError(error.InvalidIpv4Mapping, net.Address.parseIp6("::123.123.123.123", 0));
+    try testing.expectError(error.Incomplete, net.Address.parseIp6("1", 0));
     // TODO Make this test pass on other operating systems.
     if (builtin.os.tag == .linux or comptime builtin.os.tag.isDarwin()) {
         try testing.expectError(error.Incomplete, net.Address.resolveIp6("ff01::fb%", 0));


### PR DESCRIPTION
This fixes the case where IPv6 address parsing incorrectly succeeded on input such as `1`, which now returns error.Incomplete. This is done by adding a check that if there is no abbreviation (i.e. the case where there is no `::` somewhere) then we must have written at least 14 of the 16 bytes in the IPv6 address result before the check (the last two bytes are handled after this check). This check is not needed for the case of abbreviation because this difference (14 - num of written bytes) determines how many zeroes are being abbreviated.

This PR fixes https://github.com/ziglang/zig/issues/17019.