### PR TITLE
std.os.linux: Add filled_sigset and pause()

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -149,6 +149,7 @@ pub const cpu_set_t = system.cpu_set_t;
 pub const dev_t = system.dev_t;
 pub const dl_phdr_info = system.dl_phdr_info;
 pub const empty_sigset = system.empty_sigset;
+pub const filled_sigset = system.filled_sigset;
 pub const fd_t = system.fd_t;
 pub const fdflags_t = system.fdflags_t;
 pub const fdstat_t = system.fdstat_t;

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1042,6 +1042,14 @@ pub fn nanosleep(req: *const timespec, rem: ?*timespec) usize {
     return syscall2(.nanosleep, @intFromPtr(req), @intFromPtr(rem));
 }
 
+pub fn pause() usize {
+    if (@hasField(SYS, "pause")) {
+        return syscall0(.pause);
+    } else {
+        return syscall4(.ppoll, 0, 0, 0, 0);
+    }
+}
+
 pub fn setuid(uid: uid_t) usize {
     if (@hasField(SYS, "setuid32")) {
         return syscall1(.setuid32, uid);

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -3350,7 +3350,9 @@ pub const Sigaction = extern struct {
     restorer: ?*const fn () callconv(.C) void = null,
 };
 
-pub const empty_sigset = [_]u32{0} ** @typeInfo(sigset_t).Array.len;
+const sigset_len = @typeInfo(sigset_t).Array.len;
+pub const empty_sigset = [_]u32{0} ** sigset_len;
+pub const filled_sigset = [_]u32{(1 << (31 & (usize_bits - 1))) - 1} ++ [_]u32{0} ** (sigset_len - 1);
 
 pub const SFD = struct {
     pub const CLOEXEC = O.CLOEXEC;


### PR DESCRIPTION
filled_sigset is equivalent to sigfillset() as empty_sigset is equivalent to sigemptyset().
For Plan 9 I think something like that should do it
```zig
const usize_bits = @typeInfo(usize).Int.bits;
pub const filled_sigset = @as(sigset_t, 1 << (20 & (usize_bits - 1)) - 1);
```
The implementation is based on os.linux.sigaddset() and that 31 is the max correct signal possible based on os.linux.SIG as it is more portable than a magic number.