### PR TITLE
Fix `Dir.statFile` for WASI when linking libc

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -570,6 +570,9 @@ test "readAllAlloc" {
 }
 
 test "Dir.statFile" {
+    // TODO: Re-enable once https://github.com/ziglang/zig/issues/17034 is solved
+    if (builtin.os.tag == .linux and builtin.link_libc and builtin.abi == .gnu) return error.SkipZigTest;
+
     try testWithAllSupportedPathTypes(struct {
         fn impl(ctx: *TestContext) !void {
             const test_file_name = try ctx.transformPath("test_file");

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -569,6 +569,21 @@ test "readAllAlloc" {
     try testing.expectError(error.FileTooBig, file.readToEndAlloc(testing.allocator, write_buf.len - 1));
 }
 
+test "Dir.statFile" {
+    try testWithAllSupportedPathTypes(struct {
+        fn impl(ctx: *TestContext) !void {
+            const test_file_name = try ctx.transformPath("test_file");
+
+            try testing.expectError(error.FileNotFound, ctx.dir.statFile(test_file_name));
+
+            try ctx.dir.writeFile(test_file_name, "");
+
+            const stat = try ctx.dir.statFile(test_file_name);
+            try testing.expectEqual(File.Kind.file, stat.kind);
+        }
+    }.impl);
+}
+
 test "directory operations on files" {
     try testWithAllSupportedPathTypes(struct {
         fn impl(ctx: *TestContext) !void {


### PR DESCRIPTION
`statFile` now only uses `os.fstatatWasi` when not linking libc, matching the pattern used throughout other `Dir` functions. This fixes the compilation error: `error: struct 'c.wasi.Stat' has no member named 'fromFilestat'` (which the added test would have failed with)

Unblocks https://github.com/ziglang/zig/pull/16878