### PR TITLE
std.coff: Fixed compile error.

### DIFF
--- a/lib/std/coff.zig
+++ b/lib/std/coff.zig
@@ -1291,8 +1291,8 @@ pub const Symtab = struct {
 
     pub const Tag = enum {
         symbol,
-        func_def,
         debug_info,
+        func_def,
         weak_ext,
         file_def,
         sect_def,


### PR DESCRIPTION
@kubkon Trivial change that fixes compile error.