### PR TITLE
dwarf: fix copy-paste typo in variable lowering code for reg and stack

### DIFF
--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -663,7 +663,6 @@ pub const DeclState = struct {
         switch (loc) {
             .register => |reg| {
                 try dbg_info.ensureUnusedCapacity(4);
-                dbg_info.appendAssumeCapacity(@intFromEnum(AbbrevKind.parameter));
                 // DW.AT.location, DW.FORM.exprloc
                 var expr_len = std.io.countingWriter(std.io.null_writer);
                 if (reg < 32) {
@@ -683,7 +682,6 @@ pub const DeclState = struct {
 
             .stack => |info| {
                 try dbg_info.ensureUnusedCapacity(9);
-                dbg_info.appendAssumeCapacity(@intFromEnum(AbbrevKind.parameter));
                 // DW.AT.location, DW.FORM.exprloc
                 var expr_len = std.io.countingWriter(std.io.null_writer);
                 if (info.fp_register < 32) {


### PR DESCRIPTION
This un-breaks debug info generated by self-hosted native `x86_64` backend.

A wake-up call for me to finally add some DWARF tests into the mix.