### PR TITLE
Make a Couple Syscall Comments Consistent

### DIFF
--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -371,10 +371,10 @@ pub const IO_Uring = struct {
         },
     };
 
-    /// Queues (but does not submit) an SQE to perform a `read(2)` or `preadv` depending on the buffer type.
+    /// Queues (but does not submit) an SQE to perform a `read(2)` or `preadv(2)` depending on the buffer type.
     /// * Reading into a `ReadBuffer.buffer` uses `read(2)`
     /// * Reading into a `ReadBuffer.iovecs` uses `preadv(2)`
-    ///   If you want to do a `preadv2()` then set `rw_flags` on the returned SQE. See https://linux.die.net/man/2/preadv.
+    ///   If you want to do a `preadv2(2)` then set `rw_flags` on the returned SQE. See https://linux.die.net/man/2/preadv.
     ///
     /// Returns a pointer to the SQE.
     pub fn read(

--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -374,7 +374,7 @@ pub const IO_Uring = struct {
     /// Queues (but does not submit) an SQE to perform a `read(2)` or `preadv(2)` depending on the buffer type.
     /// * Reading into a `ReadBuffer.buffer` uses `read(2)`
     /// * Reading into a `ReadBuffer.iovecs` uses `preadv(2)`
-    ///   If you want to do a `preadv2(2)` then set `rw_flags` on the returned SQE. See https://linux.die.net/man/2/preadv.
+    ///   If you want to do a `preadv2(2)` then set `rw_flags` on the returned SQE. See https://man7.org/linux/man-pages/man2/preadv2.2.html
     ///
     /// Returns a pointer to the SQE.
     pub fn read(


### PR DESCRIPTION
Previous PR: #17060 

See thread on original PR. I also noticed a second syscall in this comment missing a `2`. cc: @daurnimator. Thanks!