### PR TITLE
Autodoc: fix search results navigation

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -4013,9 +4013,10 @@ Happy writing!
       return;
     }
 
-    let liDom = domListSearchResults.children[curSearchIndex];
-    if (liDom == null && domListSearchResults.children.length !== 0) {
-      liDom = domListSearchResults.children[0];
+    const searchResults = domListSearchResults.getElementsByTagName("li");
+    let liDom = searchResults[curSearchIndex];
+    if (liDom == null && searchResults.length !== 0) {
+      liDom = searchResults[0];
     }
     if (liDom != null) {
       let aDom = liDom.children[0];
@@ -4110,14 +4111,15 @@ Happy writing!
   }
 
   function moveSearchCursor(dir) {
+    const searchResults = domListSearchResults.getElementsByTagName("li");
     if (
       curSearchIndex < 0 ||
-      curSearchIndex >= domListSearchResults.children.length
+      curSearchIndex >= searchResults.length
     ) {
       if (dir > 0) {
         curSearchIndex = -1 + dir;
       } else if (dir < 0) {
-        curSearchIndex = domListSearchResults.children.length + dir;
+        curSearchIndex = searchResults.length + dir;
       }
     } else {
       curSearchIndex += dir;
@@ -4125,8 +4127,8 @@ Happy writing!
     if (curSearchIndex < 0) {
       curSearchIndex = 0;
     }
-    if (curSearchIndex >= domListSearchResults.children.length) {
-      curSearchIndex = domListSearchResults.children.length - 1;
+    if (curSearchIndex >= searchResults.length) {
+      curSearchIndex = searchResults.length - 1;
     }
     renderSearchCursor();
   }
@@ -4465,8 +4467,9 @@ Happy writing!
   
 
   function renderSearchCursor() {
-    for (let i = 0; i < domListSearchResults.children.length; i += 1) {
-      let liDom = domListSearchResults.children[i];
+    const searchResults = domListSearchResults.getElementsByTagName("li");
+    for (let i = 0; i < searchResults.length; i += 1) {
+      let liDom = searchResults[i];
       if (curSearchIndex === i) {
         liDom.classList.add("selected");
       } else {


### PR DESCRIPTION
Closes #17013

The addition of the "other results" `hr` to the search results broke the previous code's assumption that the only elements in the search results were search results (`li` elements). This change fixes the linked issue along with some related navigation issues stemming from treating the `hr` as a search result (e.g. search for a term like "array list" and then navigate with the arrow keys to the "other results" divider: the previous code allows the divider to be "selected" as a result).