### PR TITLE
translate-c: fix panic when translating long double literals

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -110,9 +110,11 @@ pub const APFloatBaseSemantics = enum(c_int) {
     BFloat,
     IEEEsingle,
     IEEEdouble,
-    x86DoubleExtended,
     IEEEquad,
     PPCDoubleDouble,
+    Float8E5M2,
+    Float8E4M3FN,
+    x87DoubleExtended,
 };
 
 pub const APInt = opaque {

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -1205,7 +1205,10 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\#define baz 1e1
         \\#define BAZ 42e-3f
         \\#define foobar -73.L
-    , &[_][]const u8{
+        \\extern const float my_float = 1.0f;
+        \\extern const double my_double = 1.0;
+        \\extern const long double my_longdouble = 1.0l;
+    , &([_][]const u8{
         "pub const foo = @as(f32, 3.14);",
         "pub const bar = @as(c_longdouble, 16.0e-2);",
         "pub const FOO = @as(f64, 0.12345);",
@@ -1213,7 +1216,16 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         "pub const baz = @as(f64, 1e1);",
         "pub const BAZ = @as(f32, 42e-3);",
         "pub const foobar = -@as(c_longdouble, 73.0);",
-    });
+        "pub export const my_float: f32 = 1.0;",
+        "pub export const my_double: f64 = 1.0;",
+    } ++ if (@bitSizeOf(c_longdouble) != 64) .{
+        // TODO properly translate non-64-bit long doubles
+        "source.h:10:42: warning: unsupported floating point constant format",
+        "source.h:10:26: warning: unable to translate variable initializer, demoted to extern",
+        "pub extern const my_longdouble: c_longdouble;",
+    } else .{
+        "pub export const my_longdouble: c_longdouble = 1.0;",
+    }));
 
     cases.add("macro defines hexadecimal float",
         \\#define FOO 0xf7p38


### PR DESCRIPTION
`zig translate-c` currently panics with a "switch on corrupt value" when encountering long double literals, such as when given the following input:
```c
extern const long double value = 1.0L;
```

The problem seems to have stemmed from the `APFloatBaseSemantics` enum in `clang.zig` being out of sync with LLVM 16's [`llvm::APFloatBase::Semantics`](https://github.com/llvm/llvm-project/blob/llvmorg-16.0.6/llvm/include/llvm/ADT/APFloat.h#L151-L168) enum.

The added test cases fail on older zig compiler builds and result in panics.