### PR TITLE
AstGen: fix missing array type validation

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -1454,7 +1454,12 @@ fn arrayInitExpr(
         },
         .ty, .coerced_ty => |ty_inst| {
             const arr_ty = if (types.array != .none) types.array else blk: {
-                break :blk try gz.addUnNode(.opt_eu_base_ty, ty_inst, node);
+                const arr_ty = try gz.addUnNode(.opt_eu_base_ty, ty_inst, node);
+                _ = try gz.addPlNode(.validate_array_init_ty, node, Zir.Inst.ArrayInit{
+                    .ty = arr_ty,
+                    .init_count = @intCast(array_init.ast.elements.len),
+                });
+                break :blk arr_ty;
             };
             const result = try arrayInitExprInner(gz, scope, node, array_init.ast.elements, arr_ty, types.elem, .array_init);
             return rvalue(gz, ri, result, node);

--- a/test/cases/compile_errors/array_init_invalid_elem_count.zig
+++ b/test/cases/compile_errors/array_init_invalid_elem_count.zig
@@ -24,6 +24,12 @@ pub export fn entry2() void {
     var bla: A = .{ 1, 2, 3, 4 };
     _ = bla;
 }
+const S = struct {
+    list: [2]u8 = .{0},
+};
+export fn entry3() void {
+    _ = S{};
+}
 
 // error
 // backend=stage2
@@ -35,3 +41,4 @@ pub export fn entry2() void {
 // :16:17: error: expected 8 array elements; found 0
 // :20:19: error: expected 8 vector elements; found 4
 // :24:19: error: expected 8 array elements; found 4
+// :28:20: error: expected 2 array elements; found 1


### PR DESCRIPTION
The struct equivalent already had this validation.