### PR TITLE
wasm-linker: fix use of invalidated memory in populateErrorNameTable

### DIFF
--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -3005,7 +3005,6 @@ pub fn getErrorTableSymbol(wasm: *Wasm) !u32 {
 fn populateErrorNameTable(wasm: *Wasm) !void {
     const symbol_index = wasm.error_table_symbol orelse return;
     const atom_index = wasm.symbol_atom.get(.{ .file = null, .index = symbol_index }).?;
-    const atom = wasm.getAtomPtr(atom_index);
 
     // Rather than creating a symbol for each individual error name,
     // we create a symbol for the entire region of error names. We then calculate
@@ -3030,6 +3029,8 @@ fn populateErrorNameTable(wasm: *Wasm) !void {
     var addend: u32 = 0;
     const mod = wasm.base.options.module.?;
     for (mod.global_error_set.keys()) |error_name_nts| {
+        const atom = wasm.getAtomPtr(atom_index);
+
         const error_name = mod.intern_pool.stringToSlice(error_name_nts);
         const len = @as(u32, @intCast(error_name.len + 1)); // names are 0-termianted
 


### PR DESCRIPTION
`getAtomPtr` returns a pointer to an element in an ArrayList which is followed by a call to `createAtom` that calls append on that ArrayList.
```
==23256== Memcheck, a memory error detector
==23256== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==23256== Using Valgrind-3.20.0 and LibVEX; rerun with -h for copyright info
==23256== Command: stage4/bin/zig build-exe example.zig -target wasm32-wasi -fno-llvm -fno-lld
==23256== 
compiler_rt... ==23256== Invalid read of size 8
==23256==    at 0x12B5287: link.Wasm.populateErrorNameTable (Wasm.zig:3037)
==23256==    by 0xEB5FEC: link.Wasm.flushModule (Wasm.zig:3364)
==23256==    by 0xBE5C26: link.Wasm.flush (Wasm.zig:3140)
==23256==    by 0x961C23: link.File.flush (link.zig:795)
==23256==    by 0x9612F5: Compilation.flush (Compilation.zig:2226)
==23256==    by 0x999A5A: Compilation.update (Compilation.zig:2183)
==23256==    by 0x9C80D0: main.updateModule (main.zig:4098)
==23256==    by 0x9EAC45: main.buildOutputType (main.zig:3519)
==23256==    by 0x85106F: main.mainArgs (main.zig:270)
==23256==    by 0x84E3F5: main.main (main.zig:214)
==23256==    by 0x84DE0E: main (start.zig:477)
==23256==  Address 0x1d5b55e0 is 1,712 bytes inside a block of size 11,760 free'd
==23256==    at 0x4844F6C: free (in /nix/store/idvall8pnb7zi603jxwvxpvzkaic0i04-valgrind-3.20.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==23256==    by 0x8806C7: heap.rawCFree (heap.zig:221)
==23256==    by 0xF9DC5C: mem.Allocator.free__anon_138079 (Allocator.zig:307)
==23256==    by 0x11B9E52: array_list.ArrayListAlignedUnmanaged(link.Wasm.Atom,null).ensureTotalCapacityPrecise (array_list.zig:910)
==23256==    by 0xE15EFC: array_list.ArrayListAlignedUnmanaged(link.Wasm.Atom,null).ensureTotalCapacity (array_list.zig:884)
==23256==    by 0xBB8832: array_list.ArrayListAlignedUnmanaged(link.Wasm.Atom,null).addOne (array_list.zig:937)
==23256==    by 0xBB85AD: link.Wasm.createAtom (Wasm.zig:609)
==23256==    by 0x12B4DD1: link.Wasm.populateErrorNameTable (Wasm.zig:3013)
==23256==    by 0xEB5FEC: link.Wasm.flushModule (Wasm.zig:3364)
==23256==    by 0xBE5C26: link.Wasm.flush (Wasm.zig:3140)
==23256==    by 0x961C23: link.File.flush (link.zig:795)
==23256==    by 0x9612F5: Compilation.flush (Compilation.zig:2226)
==23256==  Block was alloc'd at
==23256==    at 0x484279B: malloc (in /nix/store/idvall8pnb7zi603jxwvxpvzkaic0i04-valgrind-3.20.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==23256==    by 0x880662: heap.rawCAlloc (heap.zig:198)
==23256==    by 0xA589A3: mem.Allocator.allocBytesWithAlignment__anon_60066 (Allocator.zig:215)
==23256==    by 0xC5905A: mem.Allocator.allocWithSizeAndAlignment__anon_115309 (Allocator.zig:211)
==23256==    by 0x16F14F8: mem.Allocator.alignedAlloc__anon_168074 (Allocator.zig:195)
==23256==    by 0x11B9C74: array_list.ArrayListAlignedUnmanaged(link.Wasm.Atom,null).ensureTotalCapacityPrecise (array_list.zig:908)
==23256==    by 0xE15EFC: array_list.ArrayListAlignedUnmanaged(link.Wasm.Atom,null).ensureTotalCapacity (array_list.zig:884)
==23256==    by 0xBB8832: array_list.ArrayListAlignedUnmanaged(link.Wasm.Atom,null).addOne (array_list.zig:937)
==23256==    by 0xBB85AD: link.Wasm.createAtom (Wasm.zig:609)
==23256==    by 0xBB8A5F: link.Wasm.getOrCreateAtomForDecl (Wasm.zig:601)
==23256==    by 0x2394702: arch.wasm.CodeGen.airCall (CodeGen.zig:2205)
==23256==    by 0x21479CD: arch.wasm.CodeGen.genInst (CodeGen.zig:1932)
==23256== 
thread 23256 panic: integer cast truncated bits
==23256== Syscall param msync(start) points to uninitialised byte(s)
==23256==    at 0x1135201F: msync (in /nix/store/46m4xx889wlhsdj72j38fnlyyvvvvbyb-glibc-2.37-8/lib/libc.so.6)
==23256==    by 0xF60FBA: os.msync (os.zig:4468)
==23256==    by 0xCD9D74: debug.StackIterator.isValidMemory (debug.zig:606)
==23256==    by 0x14530D7: dwarf.DwarfInfo.unwindFrame (dwarf.zig:1764)
==23256==    by 0x1451AE0: debug.StackIterator.next_unwind (debug.zig:660)
==23256==    by 0xF61189: debug.StackIterator.next_internal (debug.zig:669)
==23256==    by 0xCDA22E: debug.StackIterator.next (debug.zig:584)
==23256==    by 0xCDA096: debug.writeCurrentStackTrace__anon_117292 (debug.zig:731)
==23256==    by 0xA696FC: debug.dumpCurrentStackTrace (debug.zig:127)
==23256==    by 0xCD7B60: crash_report.StackContext.dumpStackTrace (crash_report.zig:280)
==23256==    by 0xA68CDC: crash_report.PanicSwitch.reportStack (crash_report.zig:435)
==23256==    by 0x87FD27: crash_report.PanicSwitch.initPanic (crash_report.zig:380)
==23256==  Address 0x1ffefe9000 is on thread 1's stack
==23256==  in frame #5, created by debug.StackIterator.next_internal (debug.zig:664)
==23256== 
==23256== Syscall param msync(start) points to uninitialised byte(s)
==23256==    at 0x1135201F: msync (in /nix/store/46m4xx889wlhsdj72j38fnlyyvvvvbyb-glibc-2.37-8/lib/libc.so.6)
==23256==    by 0xF60FBA: os.msync (os.zig:4468)
==23256==    by 0xCD9D74: debug.StackIterator.isValidMemory (debug.zig:606)
==23256==    by 0x18796AA: dwarf.call_frame.VirtualMachine.Column.resolveValue (call_frame.zig:387)
==23256==    by 0x145366E: dwarf.DwarfInfo.unwindFrame (dwarf.zig:1800)
==23256==    by 0x1451AE0: debug.StackIterator.next_unwind (debug.zig:660)
==23256==    by 0xF61189: debug.StackIterator.next_internal (debug.zig:669)
==23256==    by 0xCDA22E: debug.StackIterator.next (debug.zig:584)
==23256==    by 0xCDA096: debug.writeCurrentStackTrace__anon_117292 (debug.zig:731)
==23256==    by 0xA696FC: debug.dumpCurrentStackTrace (debug.zig:127)
==23256==    by 0xCD7B60: crash_report.StackContext.dumpStackTrace (crash_report.zig:280)
==23256==    by 0xA68CDC: crash_report.PanicSwitch.reportStack (crash_report.zig:435)
==23256==  Address 0x1ffefe9000 is on thread 1's stack
==23256==  in frame #6, created by debug.StackIterator.next_internal (debug.zig:664)
==23256== 
/home/techatrix/repos/zig/src/link/Wasm.zig:3037:33: 0x12b5384 in populateErrorNameTable (zig)
        const offset = @as(u32, @intCast(atom.code.items.len));
                                ^
/home/techatrix/repos/zig/src/link/Wasm.zig:3364:36: 0xeb5fec in flushModule (zig)
    try wasm.populateErrorNameTable();
                                   ^
/home/techatrix/repos/zig/src/link/Wasm.zig:3140:32: 0xbe5c26 in flush (zig)
        return wasm.flushModule(comp, prog_node);
                               ^
/home/techatrix/repos/zig/src/link.zig:795:70: 0x961c23 in flush (zig)
            .wasm => return @fieldParentPtr(Wasm, "base", base).flush(comp, prog_node),
                                                                     ^
/home/techatrix/repos/zig/src/Compilation.zig:2226:24: 0x9612f5 in flush (zig)
    comp.bin_file.flush(comp, prog_node) catch |err| switch (err) {
                       ^
/home/techatrix/repos/zig/src/Compilation.zig:2183:23: 0x999a5a in update (zig)
        try comp.flush(main_progress_node);
                      ^
/home/techatrix/repos/zig/src/main.zig:4098:24: 0x9c80d0 in updateModule (zig)
        try comp.update(main_progress_node);
                       ^
/home/techatrix/repos/zig/src/main.zig:3519:17: 0x9eac45 in buildOutputType (zig)
    updateModule(comp) catch |err| switch (err) {
                ^
/home/techatrix/repos/zig/src/main.zig:270:31: 0x85106f in mainArgs (zig)
        return buildOutputType(gpa, arena, args, .{ .build = .Exe });
                              ^
/home/techatrix/repos/zig/src/main.zig:214:20: 0x84e3f5 in main (zig)
    return mainArgs(gpa, arena, args);
                   ^
/home/techatrix/repos/zig/lib/std/start.zig:477:37: 0x84de0e in main (zig)
    std.os.argv = @as([*][*:0]u8, @ptrCast(c_argv))[0..@as(usize, @intCast(c_argc))];
                                    ^
???:?:?: 0x11275acd in ??? (libc.so.6)
Unwind information for `libc.so.6:0x11275acd` was not available, trace may be incomplete

==23256== 
==23256== Process terminating with default action of signal 6 (SIGABRT): dumping core
==23256==    at 0x112D9ADC: __pthread_kill_implementation (in /nix/store/46m4xx889wlhsdj72j38fnlyyvvvvbyb-glibc-2.37-8/lib/libc.so.6)
==23256==    by 0x1128ACB5: raise (in /nix/store/46m4xx889wlhsdj72j38fnlyyvvvvbyb-glibc-2.37-8/lib/libc.so.6)
==23256==    by 0x112748B9: abort (in /nix/store/46m4xx889wlhsdj72j38fnlyyvvvvbyb-glibc-2.37-8/lib/libc.so.6)
==23256==    by 0xA69118: os.abort (os.zig:598)
==23256==    by 0x87FFC8: crash_report.PanicSwitch.abort (crash_report.zig:501)
==23256==    by 0xA690DF: crash_report.PanicSwitch.releaseRefCount (crash_report.zig:473)
==23256==    by 0xA68C18: crash_report.PanicSwitch.releaseMutex (crash_report.zig:455)
==23256==    by 0xA68CED: crash_report.PanicSwitch.reportStack (crash_report.zig:434)
==23256==    by 0x87FD27: crash_report.PanicSwitch.initPanic (crash_report.zig:380)
==23256==    by 0x84E8D6: crash_report.PanicSwitch.dispatch (crash_report.zig:362)
==23256==    by 0x84DF70: crash_report.compilerPanic (crash_report.zig:161)
==23256==    by 0x12B5384: link.Wasm.populateErrorNameTable (Wasm.zig:3037)
==23256== 
==23256== HEAP SUMMARY:
==23256==     in use at exit: 49,126,509 bytes in 7,913 blocks
==23256==   total heap usage: 18,818 allocs, 10,905 frees, 64,982,807 bytes allocated
==23256== 
==23256== LEAK SUMMARY:
==23256==    definitely lost: 6,798 bytes in 192 blocks
==23256==    indirectly lost: 0 bytes in 0 blocks
==23256==      possibly lost: 16,916,565 bytes in 2,800 blocks
==23256==    still reachable: 32,203,146 bytes in 4,921 blocks
==23256==         suppressed: 0 bytes in 0 blocks
==23256== Rerun with --leak-check=full to see details of leaked memory
==23256== 
==23256== Use --track-origins=yes to see where uninitialised values come from
==23256== For lists of detected and suppressed errors, rerun with: -s
==23256== ERROR SUMMARY: 60 errors from 3 contexts (suppressed: 0 from 0)
Aborted (core dumped)
```