### PR TITLE
Sema: add note showing where error was added to ies

### DIFF
--- a/test/cases/compile_errors/error_added_to_ies_note.zig
+++ b/test/cases/compile_errors/error_added_to_ies_note.zig
@@ -1,0 +1,19 @@
+fn foo() !void {
+    return error.Bar;
+}
+fn bar() !void {
+    try foo();
+}
+pub export fn entry() void {
+    bar() catch |e| switch (e) {
+        // error.Bar => {},
+    };
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :8:21: error: switch must handle all possibilities
+// :8:21: note: unhandled error value: 'error.Bar'
+// :5:5: note: error added to inferred error set here

--- a/test/cases/compile_errors/error_not_handled_in_switch.zig
+++ b/test/cases/compile_errors/error_not_handled_in_switch.zig
@@ -18,4 +18,6 @@ fn foo(x: i32) !void {
 //
 // :2:26: error: switch must handle all possibilities
 // :2:26: note: unhandled error value: 'error.Bar'
+// :9:33: note: error added to inferred error set here
 // :2:26: note: unhandled error value: 'error.Baz'
+// :10:33: note: error added to inferred error set here


### PR DESCRIPTION
The goal of this note is to make errors like https://github.com/Vexu/arocc/issues/501 easier to debug:
```zig
fn foo() !void {
    return error.Bar;
}
fn bar() !void {
    try foo();
}
pub export fn entry() void {
    bar() catch |e| switch (e) {
        // error.Bar => {},
    };
}
```
```
a.zig:8:21: error: switch must handle all possibilities
    bar() catch |e| switch (e) {
                    ^~~~~~
a.zig:8:21: note: unhandled error value: 'error.Bar'
a.zig:5:5: note: error added to inferred error set here
    try foo();
    ^~~~~~~~~
```

I'm not too familiar with the intern pool system so reviews would be appreciated.