### PR TITLE
langref: Add clarifying info and example to Bit Shift Left/Right

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1954,13 +1954,17 @@ a <<= b{#endsyntax#}</pre></th>
           </td>
           <td>Bit Shift Left.
             <ul>
-                <li>{#syntax#}b{#endsyntax#} must be {#link|comptime-known|comptime#} or have a type with log2 number of bits as {#syntax#}a{#endsyntax#}.</li>
+              <li>{#syntax#}b{#endsyntax#} must be {#link|comptime-known|comptime#} or have a type with log2 number of bits as {#syntax#}a{#endsyntax#}.</li>
+              <li>Shifts in {#syntax#}0{#endsyntax#}'s from the right.</li>
               <li>See also {#link|@shlExact#}.</li>
               <li>See also {#link|@shlWithOverflow#}.</li>
             </ul>
           </td>
           <td>
-            <pre>{#syntax#}1 << 8 == 256{#endsyntax#}</pre>
+            <pre>{#syntax#}1 << 8 == 256
+            
+// Equivalent in binary notation
+0b0_0000_0001 << 8 == 0b1_0000_0000{#endsyntax#}</pre>
           </td>
         </tr>
         <tr>
@@ -1991,12 +1995,16 @@ a >>= b{#endsyntax#}</pre></th>
           </td>
           <td>Bit Shift Right.
             <ul>
-                <li>{#syntax#}b{#endsyntax#} must be {#link|comptime-known|comptime#} or have a type with log2 number of bits as {#syntax#}a{#endsyntax#}.</li>
+              <li>{#syntax#}b{#endsyntax#} must be {#link|comptime-known|comptime#} or have a type with log2 number of bits as {#syntax#}a{#endsyntax#}.</li>
+              <li>Shifts in {#syntax#}0{#endsyntax#}'s from the left.</li>
               <li>See also {#link|@shrExact#}.</li>
             </ul>
           </td>
           <td>
-            <pre>{#syntax#}10 >> 1 == 5{#endsyntax#}</pre>
+            <pre>{#syntax#}10 >> 1 == 5
+            
+// Equivalent in binary notation
+0b0000_1010 >> 1 == 0b0000_0101{#endsyntax#}</pre>
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
Add clarification to [10.1 Table Of Operators](https://ziglang.org/documentation/master/#toc-Table-of-Operators), at Bit Shift Left/Right rows

- To communicate that bit shift operators shift in `0`'s (i.e. ignores overflow/carry bits).
- Add lines to example code, showing equivalent in binary notation.