### PR TITLE
InternPool: prevent anon struct UAF bugs with type safety

### DIFF
--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -423,6 +423,7 @@ fn printAggregate(
     if (level == 0) {
         return writer.writeAll(".{ ... }");
     }
+    const ip = &mod.intern_pool;
     if (ty.zigTypeTag(mod) == .Struct) {
         try writer.writeAll(".{");
         const max_len = @min(ty.structFieldCount(mod), max_aggregate_items);
@@ -430,13 +431,13 @@ fn printAggregate(
         for (0..max_len) |i| {
             if (i != 0) try writer.writeAll(", ");
 
-            const field_name = switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+            const field_name = switch (ip.indexToKey(ty.toIntern())) {
                 .struct_type => |x| mod.structPtrUnwrap(x.index).?.fields.keys()[i].toOptional(),
-                .anon_struct_type => |x| if (x.isTuple()) .none else x.names[i].toOptional(),
+                .anon_struct_type => |x| if (x.isTuple()) .none else x.names.get(ip)[i].toOptional(),
                 else => unreachable,
             };
 
-            if (field_name.unwrap()) |name| try writer.print(".{} = ", .{name.fmt(&mod.intern_pool)});
+            if (field_name.unwrap()) |name| try writer.print(".{} = ", .{name.fmt(ip)});
             try print(.{
                 .ty = ty.structFieldType(i, mod),
                 .val = try val.fieldValue(mod, i),

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -438,7 +438,11 @@ pub fn generateSymbol(
             },
             .anon_struct_type => |tuple| {
                 const struct_begin = code.items.len;
-                for (tuple.types, tuple.values, 0..) |field_ty, comptime_val, index| {
+                for (
+                    tuple.types.get(ip),
+                    tuple.values.get(ip),
+                    0..,
+                ) |field_ty, comptime_val, index| {
                     if (comptime_val != .none) continue;
                     if (!field_ty.toType().hasRuntimeBits(mod)) continue;
 

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -327,7 +327,7 @@ pub const DeclState = struct {
                         // DW.AT.name, DW.FORM.string
                         try dbg_info_buffer.writer().print("{}\x00", .{ty.fmt(mod)});
 
-                        for (fields.types, 0..) |field_ty, field_index| {
+                        for (fields.types.get(ip), 0..) |field_ty, field_index| {
                             // DW.AT.member
                             try dbg_info_buffer.append(@intFromEnum(AbbrevKind.struct_member));
                             // DW.AT.name, DW.FORM.string


### PR DESCRIPTION
Instead of using actual slices for InternPool.Key.AnonStructType, this commit changes to use Slice types instead, which store a long-lived index rather than a pointer.

This is a follow-up to 7ef1eb1c27754cb0349fdc10db1f02ff2dddd99b.