### PR TITLE
`zig libc`: Add -includes option

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4887,7 +4887,7 @@ fn getZigShippedLibCIncludeDirsDarwin(arena: Allocator, zig_lib_dir: []const u8,
     };
 }
 
-fn detectLibCIncludeDirs(
+pub fn detectLibCIncludeDirs(
     arena: Allocator,
     zig_lib_dir: []const u8,
     target: Target,


### PR DESCRIPTION
If `-includes` is passed to `zig libc`, it will print the detected libc include paths for the target and then exit

Examples on Linux:

```console
$ zig libc -includes
/usr/include

$ zig libc -includes -target native-native-musl
/home/ryan/Programming/zig/zig/lib/libc/include/x86_64-linux-musl
/home/ryan/Programming/zig/zig/lib/libc/include/generic-musl
/home/ryan/Programming/zig/zig/lib/libc/include/x86-linux-any
/home/ryan/Programming/zig/zig/lib/libc/include/any-linux-any

$ zig libc -includes -target x86_64-windows
/home/ryan/Programming/zig/zig/lib/libc/include/x86_64-windows-gnu
/home/ryan/Programming/zig/zig/lib/libc/include/generic-mingw
/home/ryan/Programming/zig/zig/lib/libc/include/x86_64-windows-any
/home/ryan/Programming/zig/zig/lib/libc/include/any-windows-any

$ zig libc -includes -target x86_64-windows-msvc
error: no include dirs detected for target x86_64-windows.win8_1...win10_fe-msvc
```

On Windows:

```console
> zig libc -includes
Programming\Zig\zig\lib\libc\include\x86_64-windows-gnu
Programming\Zig\zig\lib\libc\include\generic-mingw
Programming\Zig\zig\lib\libc\include\x86_64-windows-any
Programming\Zig\zig\lib\libc\include\any-windows-any

> zig libc -includes -target native-native-msvc
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\shared

> zig libc -includes -target x86_64-linux-musl
Programming\Zig\zig\lib\libc\include\x86_64-linux-musl
Programming\Zig\zig\lib\libc\include\generic-musl
Programming\Zig\zig\lib\libc\include\x86-linux-any
Programming\Zig\zig\lib\libc\include\any-linux-any
```

Interestingly, it seems the includes distributed with Zig are given as relative paths ~~on Windows~~ when it's possible (depends on CWD)

## Motivation

The use case I have in mind for this is for the standalone version of [resinator](https://github.com/squeek502/resinator):

- I want to be able to use `zig clang` as the first choice for the preprocessor
- I want to be able to use `-nostdinc` when using `zig clang` as the preprocessor, meaning I would need to provide the include paths directly
- and I want the include dirs to work as outlined in [this comment](https://github.com/ziglang/zig/pull/17069#issuecomment-1713010357), where it uses the MSVC includes if they are present, and falls back to the mingw includes distributed with Zig if MSVC is not present

This `zig libc -includes` command will allow me to do everything I want to do. Note, though, that this functionality doesn't necessarily have to be via `zig libc`, it could be something else if that'd make more sense.