### PR TITLE
Disable flaky part of Dir.rename directories test on Windows

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -722,6 +722,12 @@ test "Dir.rename directories" {
             try testing.expectError(error.FileNotFound, ctx.dir.openDir(test_dir_path, .{}));
             var dir = try ctx.dir.openDir(test_dir_renamed_path, .{});
 
+            // The next rename in this test can hit intermittent AccessDenied
+            // errors when certain conditions are true about the host system.
+            // For now, return early when the path type is UNC to avoid them.
+            // See https://github.com/ziglang/zig/issues/17134
+            if (ctx.path_type == .unc) return;
+
             // Put a file in the directory
             var file = try dir.createFile("test_file", .{ .read = true });
             file.close();


### PR DESCRIPTION
See https://github.com/ziglang/zig/issues/17134. I tried to disable the least amount of the test that would fix the flakiness without reducing the usefulness of the test too much. I didn't include an `aarch64` check since it's possible to hit this on `x86_64` as well (it just likely can't be hit in the specific x86_64 CI environment that is being used currently).