### PR TITLE
std: add compile error when using `std.os.getenv` on the wasi target

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1908,6 +1908,8 @@ pub fn getenv(key: []const u8) ?[:0]const u8 {
     }
     if (builtin.os.tag == .windows) {
         @compileError("std.os.getenv is unavailable for Windows because environment string is in WTF-16 format. See std.process.getEnvVarOwned for cross-platform API or std.os.getenvW for Windows-specific API.");
+    } else if (builtin.os.tag == .wasi) {
+        @compileError("std.os.getenv is unavailable for WASI. See std.process.getEnvMap or std.process.getEnvVarOwned for a cross-platform API.");
     }
     // The simplified start logic doesn't populate environ.
     if (std.start.simplified_logic) return null;

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -660,6 +660,11 @@ test "mmap" {
 }
 
 test "getenv" {
+    if (native_os == .wasi and !builtin.link_libc) {
+        // std.os.getenv is not supported on WASI due to the need of allocation
+        return error.SkipZigTest;
+    }
+
     if (native_os == .windows) {
         try expect(os.getenvW(&[_:0]u16{ 'B', 'O', 'G', 'U', 'S', 0x11, 0x22, 0x33, 0x44, 0x55 }) == null);
     } else {

--- a/lib/std/zig/system/NativePaths.zig
+++ b/lib/std/zig/system/NativePaths.zig
@@ -100,7 +100,7 @@ pub fn detect(arena: Allocator, native_info: NativeTargetInfo) !NativePaths {
         return self;
     }
 
-    if (builtin.os.tag != .windows) {
+    if (builtin.os.tag != .windows and builtin.os.tag != .wasi) {
         const triple = try native_target.linuxTriple(arena);
 
         const qual = native_target.ptrBitWidth();


### PR DESCRIPTION
`std.process.getEnvMap` or `std.process.getEnvVarOwned` should be used instead, requiring allocation.

Fixes: #17117 

Thanks to @squeek502 for the pointer!