### PR TITLE
fs tests: Skip UNC path types in Dir.rename tests

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -675,6 +675,12 @@ test "deleteDir" {
 test "Dir.rename files" {
     try testWithAllSupportedPathTypes(struct {
         fn impl(ctx: *TestContext) !void {
+            // Rename on Windows can hit intermittent AccessDenied errors
+            // when certain conditions are true about the host system.
+            // For now, skip this test when the path type is UNC to avoid them.
+            // See https://github.com/ziglang/zig/issues/17134
+            if (ctx.path_type == .unc) return;
+
             const missing_file_path = try ctx.transformPath("missing_file_name");
             const something_else_path = try ctx.transformPath("something_else");
 
@@ -711,6 +717,12 @@ test "Dir.rename files" {
 test "Dir.rename directories" {
     try testWithAllSupportedPathTypes(struct {
         fn impl(ctx: *TestContext) !void {
+            // Rename on Windows can hit intermittent AccessDenied errors
+            // when certain conditions are true about the host system.
+            // For now, skip this test when the path type is UNC to avoid them.
+            // See https://github.com/ziglang/zig/issues/17134
+            if (ctx.path_type == .unc) return;
+
             const test_dir_path = try ctx.transformPath("test_dir");
             const test_dir_renamed_path = try ctx.transformPath("test_dir_renamed");
 
@@ -721,12 +733,6 @@ test "Dir.rename directories" {
             // Ensure the directory was renamed
             try testing.expectError(error.FileNotFound, ctx.dir.openDir(test_dir_path, .{}));
             var dir = try ctx.dir.openDir(test_dir_renamed_path, .{});
-
-            // The next rename in this test can hit intermittent AccessDenied
-            // errors when certain conditions are true about the host system.
-            // For now, return early when the path type is UNC to avoid them.
-            // See https://github.com/ziglang/zig/issues/17134
-            if (ctx.path_type == .unc) return;
 
             // Put a file in the directory
             var file = try dir.createFile("test_file", .{ .read = true });


### PR DESCRIPTION
Follow up to https://github.com/ziglang/zig/pull/17136. The `Dir.rename files` test has now also been seen to fail in CI, so now all rename tests are skipped for the UNC path type. This is a heavy handed approach to hopefully get rid of any flakiness related to rename & UNC paths. See https://github.com/ziglang/zig/issues/17134