### PR TITLE
ComptimeStringMap: Add version that takes an equality function

### DIFF
--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -16,7 +16,8 @@ pub const BufMap = @import("buf_map.zig").BufMap;
 pub const BufSet = @import("buf_set.zig").BufSet;
 /// Deprecated: use `process.Child`.
 pub const ChildProcess = @import("child_process.zig").ChildProcess;
-pub const ComptimeStringMap = @import("comptime_string_map.zig").ComptimeStringMap;
+pub const ComptimeStringMap = comptime_string_map.ComptimeStringMap;
+pub const ComptimeStringMapWithEql = comptime_string_map.ComptimeStringMapWithEql;
 pub const DoublyLinkedList = @import("linked_list.zig").DoublyLinkedList;
 pub const DynLib = @import("dynamic_library.zig").DynLib;
 pub const DynamicBitSet = bit_set.DynamicBitSet;
@@ -73,6 +74,8 @@ pub const coff = @import("coff.zig");
 
 /// Compression algorithms such as zlib, zstd, etc.
 pub const compress = @import("compress.zig");
+
+pub const comptime_string_map = @import("comptime_string_map.zig");
 
 /// Cryptography.
 pub const crypto = @import("crypto.zig");


### PR DESCRIPTION
This will allow users to construct e.g. a ComptimeStringMap that uses case-insensitive ASCII comparison.

Note: the previous ComptimeStringMap API is unchanged (i.e. this does not break any existing code).

(the motivating use case for this comes from https://github.com/ziglang/zig/pull/17069)

Prior art: https://github.com/ziglang/zig/pull/5520