### PR TITLE
bpf: remove unhelpful "comptime" and fix union order

### DIFF
--- a/lib/std/os/linux/bpf.zig
+++ b/lib/std/os/linux/bpf.zig
@@ -455,8 +455,8 @@ pub const Insn = packed struct {
     };
 
     const ImmOrReg = union(Source) {
-        imm: i32,
         reg: Reg,
+        imm: i32,
     };
 
     fn imm_reg(code: u8, dst: Reg, src: anytype, off: i16) Insn {
@@ -673,7 +673,7 @@ pub const Insn = packed struct {
         return ld_imm_impl2(@as(u64, @intCast(map_fd)));
     }
 
-    pub fn st(comptime size: Size, dst: Reg, off: i16, imm: i32) Insn {
+    pub fn st(size: Size, dst: Reg, off: i16, imm: i32) Insn {
         return Insn{
             .code = MEM | @intFromEnum(size) | ST,
             .dst = @intFromEnum(dst),


### PR DESCRIPTION
`Insn.st()` can be used with dynamic size just like `Insn.stx()`, which is relevant in a code generation context.

using `ImmOrReg` caused an error as its fields were ordered differently than `Source`.