### PR TITLE
std.zig.system.NativePaths: ignore linkage directives in `NIX_LDFLAGS`

### DIFF
--- a/lib/std/zig/system/NativePaths.zig
+++ b/lib/std/zig/system/NativePaths.zig
@@ -60,6 +60,8 @@ pub fn detect(arena: Allocator, native_target: std.Target) !NativePaths {
                 const lib_path = word[2..];
                 try self.addLibDir(lib_path);
                 try self.addRPath(lib_path);
+            } else if (word.len > 2 and word[0] == '-' and word[1] == 'l') {
+                // There could still be paths after this.
             } else {
                 try self.addWarningFmt("Unrecognized C flag from NIX_LDFLAGS: {s}", .{word});
                 break;

--- a/lib/std/zig/system/NativePaths.zig
+++ b/lib/std/zig/system/NativePaths.zig
@@ -56,12 +56,17 @@ pub fn detect(arena: Allocator, native_target: std.Target) !NativePaths {
                     break;
                 };
                 try self.addRPath(rpath);
-            } else if (word.len > 2 and word[0] == '-' and word[1] == 'L') {
+            } else if (mem.eql(u8, word, "-L") or mem.eql(u8, word, "-l")) {
+                _ = it.next() orelse {
+                    try self.addWarning("Expected argument after -L or -l in NIX_LDFLAGS");
+                    break;
+                };
+            } else if (mem.startsWith(u8, word, "-L")) {
                 const lib_path = word[2..];
                 try self.addLibDir(lib_path);
                 try self.addRPath(lib_path);
-            } else if (word.len > 2 and word[0] == '-' and word[1] == 'l') {
-                // There could still be paths after this.
+            } else if (mem.startsWith(u8, word, "-l")) {
+                // Ignore this argument.
             } else {
                 try self.addWarningFmt("Unrecognized C flag from NIX_LDFLAGS: {s}", .{word});
                 break;


### PR DESCRIPTION
`NIX_LDFLAGS` typically contains just `-rpath` and `-L`, which we already handle. However, at least one setup hook in Nixpkgs [0] adds a linkage directive to it. To prevent library paths from being missed (as I've observed myself with `NIX_LDFLAGS` being `-liconv ...`, making it so that *all* paths are missed), let's just skip over them.

[0]: https://github.com/NixOS/nixpkgs/blob/08f615eb1b3c5cf7481996f29c6092c7c891b15b/pkgs/development/libraries/libiconv/setup-hook.sh