### PR TITLE
restore useful compiler errors on dumb terminals

### DIFF
--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -1064,7 +1064,5 @@ fn get_tty_conf(color: Color, stderr: std.fs.File) std.io.tty.Config {
 fn renderOptions(ttyconf: std.io.tty.Config) std.zig.ErrorBundle.RenderOptions {
     return .{
         .ttyconf = ttyconf,
-        .include_source_line = ttyconf != .no_color,
-        .include_reference_trace = ttyconf != .no_color,
     };
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -6369,8 +6369,6 @@ fn renderOptions(color: Color) std.zig.ErrorBundle.RenderOptions {
     const ttyconf = get_tty_conf(color);
     return .{
         .ttyconf = ttyconf,
-        .include_source_line = ttyconf != .no_color,
-        .include_reference_trace = ttyconf != .no_color,
     };
 }
 


### PR DESCRIPTION
This reverts a part of 7cc4a6965c28e427cbfba57a985f837734d6257e, and closes #16376.

While the "correct" behavior on dumb terminals is still to be determined, this is arguably a major regression from 0.10.0 to 0.11.0, leaving users of various tools and CI platforms without any useful build logs.

This change mirrors the behavior of basically every other compiler out there, which is to just not color the output (done implicitly in `std.io.tty`).

Of course, the idea for machine-readable compiler errors still has merit, and with things like the to-be-implemented Zig compiler server [0] and ZLS, there are just better ways to go about it than to print somewhat useless error messages that a good portion of users will see.

[0]: https://github.com/ziglang/zig/issues/615