### PR TITLE
std.mem: add vectorized indexOfScalarPos and indexOfSentinel

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -953,9 +953,57 @@ test "len" {
     try testing.expect(len(c_ptr) == 2);
 }
 
-pub fn indexOfSentinel(comptime Elem: type, comptime sentinel: Elem, ptr: [*:sentinel]const Elem) usize {
+pub fn indexOfSentinel(comptime T: type, comptime sentinel: T, p: [*:sentinel]const T) usize {
     var i: usize = 0;
-    while (ptr[i] != sentinel) {
+
+    if (!@inComptime() and (@typeInfo(T) == .Int or @typeInfo(T) == .Float) and std.math.isPowerOfTwo(@bitSizeOf(T))) {
+        switch (@import("builtin").cpu.arch) {
+            // The below branch assumes that reading past the end of the buffer is valid, as long
+            // as we don't read into a new page. This should be the case for most architectures
+            // which use paged memory, however should be confirmed before adding a new arch below.
+            .aarch64, .x86, .x86_64 => if (comptime std.simd.suggestVectorSize(T)) |block_len| {
+                comptime std.debug.assert(std.mem.page_size % block_len == 0);
+                const Block = @Vector(block_len, T);
+                const mask: Block = @splat(sentinel);
+
+                // First block may be unaligned
+                const start_addr = @intFromPtr(&p[i]);
+                const offset_in_page = start_addr & (std.mem.page_size - 1);
+                if (offset_in_page < std.mem.page_size - block_len) {
+                    // Will not read past the end of a page, full block.
+                    const block: Block = p[i..][0..block_len].*;
+                    const matches = block == mask;
+                    if (@reduce(.Or, matches)) {
+                        return i + std.simd.firstTrue(matches).?;
+                    }
+
+                    i += std.mem.alignForward(usize, start_addr, block_len) - start_addr;
+                } else {
+                    // Would read over a page boundary. Per-byte at a time until aligned or found.
+                    // 0.39% chance this branch is taken for 4K pages at 16b block length.
+                    //
+                    // An alternate strategy is to do read a full block (the last in the page) and
+                    // mask the entries before the pointer.
+                    while ((@intFromPtr(&p[i]) & (block_len - 1)) != 0) : (i += 1) {
+                        if (p[i] == sentinel) return i;
+                    }
+                }
+
+                std.debug.assert(std.mem.isAligned(@intFromPtr(&p[i]), block_len));
+                while (true) {
+                    const block: *const Block = @ptrCast(@alignCast(p[i..][0..block_len]));
+                    const matches = block.* == mask;
+                    if (@reduce(.Or, matches)) {
+                        return i + std.simd.firstTrue(matches).?;
+                    }
+                    i += block_len;
+                }
+            },
+            else => {},
+        }
+    }
+
+    while (p[i] != sentinel) {
         i += 1;
     }
     return i;
@@ -1016,8 +1064,58 @@ pub fn lastIndexOfScalar(comptime T: type, slice: []const T, value: T) ?usize {
 
 pub fn indexOfScalarPos(comptime T: type, slice: []const T, start_index: usize, value: T) ?usize {
     if (start_index >= slice.len) return null;
-    for (slice[start_index..], start_index..) |c, i| {
-        if (c == value) return i;
+
+    var i: usize = start_index;
+    if (!@inComptime() and (@typeInfo(T) == .Int or @typeInfo(T) == .Float) and std.math.isPowerOfTwo(@bitSizeOf(T))) {
+        if (comptime std.simd.suggestVectorSize(T)) |block_len| {
+            // For Intel Nehalem (2009) and AMD Bulldozer (2012) or later, unaligned loads on aligned data result
+            // in the same execution as aligned loads. We ignore older arch's here and don't bother pre-aligning.
+            //
+            // Use `comptime std.simd.suggestVectorSize(T)` to get the same alignment as used in this function
+            // however this usually isn't necessary unless your arch has a performance penalty due to this.
+            //
+            // This may differ for other arch's. Arm for example costs a cycle when loading across a cache
+            // line so explicit alignment prologues may be worth exploration.
+
+            // Unrolling here is ~10% improvement. We can then do one bounds check every 2 blocks
+            // instead of one which adds up.
+            const Block = @Vector(block_len, T);
+            if (i + 2 * block_len < slice.len) {
+                const mask: Block = @splat(value);
+                while (true) {
+                    inline for (0..2) |_| {
+                        const block: Block = slice[i..][0..block_len].*;
+                        const matches = block == mask;
+                        if (@reduce(.Or, matches)) {
+                            return i + std.simd.firstTrue(matches).?;
+                        }
+                        i += block_len;
+                    }
+                    if (i + 2 * block_len >= slice.len) break;
+                }
+            }
+
+            // {block_len, block_len / 2} check
+            inline for (0..2) |j| {
+                const block_x_len = block_len / (1 << j);
+                comptime if (block_x_len < 4) break;
+
+                const BlockX = @Vector(block_x_len, T);
+                if (i + block_x_len < slice.len) {
+                    const mask: BlockX = @splat(value);
+                    const block: BlockX = slice[i..][0..block_x_len].*;
+                    const matches = block == mask;
+                    if (@reduce(.Or, matches)) {
+                        return i + std.simd.firstTrue(matches).?;
+                    }
+                    i += block_x_len;
+                }
+            }
+        }
+    }
+
+    for (slice[i..], i..) |c, j| {
+        if (c == value) return j;
     }
     return null;
 }


### PR DESCRIPTION
Closes #11634.

These are an order of magnitude quicker than the previous implementations:

A relative comparison of each, measuring scanning a 1G file.

```
    Reading 1G (1.0000000009313226GiB)

             std.mem.sliceTo: 281.232ms
          vectorized.sliceTo: 24.769ms
                      strlen: 24.291ms

           std.indexOfScalar: 229.016ms
    vectorized.indexOfScalar: 24.685ms
                      memchr: 24.958ms
```

This has overlap with an existing PR https://github.com/ziglang/zig/pull/16646 which we started independently at similar times. Am looking to combine the ideas between the two as needed.

`indexOfSentinel` is currently only enabled for `x86`, `x86_64` and `aarch64` as these are machines I was able to test (`x86` disasm is identical enough to be comfortable). These rely on OS' paged memory and certain indexing properties which I would prefer to verify on an actual machine before enabling everywhere.

---

## Testing

Supplementary testing/perf files can be found in this repo: https://github.com/tiehuis/zig-simd-mem

I have fuzz-tested this on a few tens of million buffers of varying alignment and confirmed results match against a reference C implementation and that we exhibit no panic's. https://github.com/tiehuis/zig-simd-mem/blob/6ac3d49c72f498597e696ade6876a9cd22c1fee5/fuzz.zig

## Performance

For small buffer sizes, the new implementation should still be faster than std even from as little as 2-3 bytes. On a random selection of buffers within a single page (avg 1KiB block length) the following times are reported after 10 million runs.

```
memory size: 4KiB
  c:     36ns avg
zig:     41ns avg
zig.std: 246ns avg
```

Performance has been measured for buffer sizes from 1 to 512MiB and can be found here (for x86_64) with the caveat that sub-1MiB C reference times are incorrect: https://github.com/tiehuis/zig-simd-mem/blob/6ac3d49c72f498597e696ade6876a9cd22c1fee5/results.x86_64.txt

A few selections can be seen below:

### x86_64

| buffer size | std.indexOfSentinel | vector.indexOfSentinel | strlen(glibc 2.3.8) | vector.indexOfScalarPos | memchr(glibc 2.3.8) |
------------|-----------|----------|----------|----------|-----------
|     4.00B | 1ns       | 1ns      |       | 2ns      | 
|    64.00B | 27ns      | 1ns      |       | 1ns      | 
|   1.00KiB | 414ns     | 13ns     |       | 9ns      | 
|   1.00MiB | 224.409us | 13.21us  | 8.99us   | 9.79us   | 9.01us
| 100.00MiB | 22.474ms  | 2.392ms  | 2.165ms  | 2.373ms  | 2.151ms
| 511.00MiB | 115.823ms | 13.425ms | 12.925ms | 13.488ms | 13.144ms

### aarch64

| buffer size | std.indexOfSentinel | vector.indexOfSentinel | strlen(glibc 2.3.8) | vector.indexOfScalarPos | memchr(glibc 2.3.8) |
------------|-----------|----------|----------|----------|-----------
|     4.00B | 2ns       | 0ns      |       | 3ns      | 
|    64.00B | 27ns      | 2ns      |       | 1ns      | 
|   1.00KiB | 327ns     | 21ns     |       | 19ns      | 
|   1.00MiB | 324.834us | 20.458us  | 8.99us   | 19.083us   | 23.792us
| 100.00MiB | 32.604ms  | 2.088ms  | 2.069ms  | 1.96ms  | 2.427ms
| 511.00MiB | 166.26ms | 10.712ms | 11.571ms | 10.108ms | 12.428ms

---

## Assembly Snippets

A compiler explorer link is here: https://godbolt.org/z/cMEjzbv97. Adjust `Ty` to check different types.

<details>
  <summary>Click to See Snippets</summary>

The core loop of each is below:

### x86_64.indexOfScalarPos

```
.LBB3_7:
        movdqu  xmm2, xmmword ptr [rdi + 8*rcx]
        pcmpeqd xmm2, xmm0
        pshufd  xmm1, xmm2, 177
        pand    xmm1, xmm2
        movmskpd        eax, xmm1
        test    eax, eax
        jne     .LBB3_8
        movdqu  xmm2, xmmword ptr [rdi + 8*rcx + 16]
        pcmpeqd xmm2, xmm0
        pshufd  xmm1, xmm2, 177
        pand    xmm1, xmm2
        movmskpd        eax, xmm1
        test    eax, eax
        jne     .LBB3_11
        lea     rax, [rcx + 4]
        add     rcx, 8
        cmp     rcx, rsi
        mov     rcx, rax
        jb      .LBB3_7
```

### x86_64.indexOfSentinel

```
.LBB2_2:
        movdqa  xmm1, xmmword ptr [rdi + 8*rcx + 16]
        movdqa  xmm2, xmm1
        pcmpeqd xmm2, xmm0
        pshufd  xmm3, xmm2, 177
        pand    xmm3, xmm2
        movmskpd        eax, xmm3
        add     rcx, 2
        test    eax, eax
        je      .LBB2_2
```

### aarch64.indexOfScalarPos

```
.LBB3_2:
        ldur    q1, [x10, #-16]
        cmeq    v1.2d, v1.2d, v0.2d
        xtn     v2.2s, v1.2d
        umaxp   v2.2s, v2.2s, v2.2s
        fmov    w8, s2
        tbnz    w8, #0, .LBB3_11
        ldr     q1, [x10]
        cmeq    v1.2d, v1.2d, v0.2d
        xtn     v2.2s, v1.2d
        umaxp   v2.2s, v2.2s, v2.2s
        fmov    w8, s2
        tbnz    w8, #0, .LBB3_12
        add     x8, x9, #4
        add     x11, x9, #8
        add     x10, x10, #32
        mov     x9, x8
        cmp     x11, x1
        b.lo    .LBB3_2
```

### aarch64.indexOfSentinel

```
.LBB2_3:
        ldr     q0, [x0], #16
        add     x8, x8, #2
        cmeq    v1.2d, v0.2d, #0
        xtn     v1.2s, v1.2d
        umaxp   v1.2s, v1.2s, v1.2s
        fmov    w9, s1
        tbz     w9, #0, .LBB2_3
```

### mips.indexOfSentinel

Any targets without knowledge of the SIMD vector size will defer back to the byte-by-byte approach.

```
_vectorized_indexOfSentinel:
        addiu   $sp, $sp, -24
        sw      $ra, 20($sp)
        jal     _std_indexOfSentinel
        nop
        lw      $ra, 20($sp)
        jr      $ra
        addiu   $sp, $sp, 24
```

</details>

### Improvements

While this PR is at a stage where the performance is now competitive there are a few improvements that can be explored. These are primarily aimed at the small buffer size cases as on longer buffers the time is dominated by the mostly already optimal core loops.

 - indexOfSentinel byte-by-byte alignment if in the last page can be improved by reading the last page in its entirety and doing a partial mask of the bytes before. Have omitted due to low impact and more complicated.
 - I am not completely happy with the `std.simd.firstTrue` usage. We should be able to use `@ctz` on the matches result with a division to get the index. This is probably similar to this https://github.com/ziglang/zig/pull/16648/files.
 - We should allow an optional (or perhaps always) alignment prologue  for indexOfScalarPos and measure.