### PR TITLE
package manager: write deps in a flat format, eliminating the FQN concept

### DIFF
--- a/lib/build_runner.zig
+++ b/lib/build_runner.zig
@@ -81,6 +81,7 @@ pub fn main() !void {
         global_cache_directory,
         host,
         &cache,
+        dependencies.root_deps,
     );
     defer builder.destroy();
 

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -314,6 +314,7 @@ test Options {
         .{ .path = "test", .handle = std.fs.cwd() },
         host,
         &cache,
+        &.{},
     );
     defer builder.destroy();
 


### PR DESCRIPTION
Previously, the generated `@dependencies` module contained dependency metadata specified in a hierarchical manner using fully-qualified names. This exposes issues similar to the old `--pkg-begin`/`--pkg-end` options for modules: namely, shared dependencies cannot be reasonably modeled.

The new `@depedencies` module contains generated code like the following (where strings like "abc123" represent hashes):

```zig
pub const root_deps = [_]struct { []const u8, []const u8 }{
    .{ "foo", "abc123" },
};

pub const packages = struct {
    pub const abc123 = struct {
        pub const build_root = "/home/mlugg/.cache/zig/blah/abc123";
        pub const build_zig = @import("abc123");
        pub const deps = [_]struct { []const u8, []const u8 }{
            .{ "bar", "abc123" },
            .{ "name", "ghi789" },
        };
    };
};
```

Each package contains a build root string, the build.zig import, and a mapping from dependency names to package hashes. There is also such a mapping for the root package dependencies.

In theory, we could now remove the `dep_prefix` field from `std.Build`, since its main purpose is now handled differently. I believe this is a desirable goal, as it doesn't really make sense to assign a single FQN to any package (because it may appear in many different places in the package hierarchy). This commit does not remove that field, as it's used non-trivially in a few places in the build runner and compiler tests: this will be a future enhancement.

Resolves: #16354
Resolves: #17135

---

Note that this change is difficult to test, as it requires setting up package hierarchies which can be fetched by the package manager. I used a test case posted by @IntegratedQuantum to confirm, to the best of my ability, that it does resolve these issues. I've spoken to @slimsag (as the owner of the biggest project currently affected by these issues): he's happy for this to be merged, after which he can apply the needed changes to Mach's libraries and more definitely confirm that this change functions as desired.