### PR TITLE
Sema: mark pointers to inline functions as comptime-only

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -36506,7 +36506,7 @@ pub fn typeRequiresComptime(sema: *Sema, ty: Type) CompileError!bool {
             .ptr_type => |ptr_type| {
                 const child_ty = ptr_type.child.toType();
                 switch (child_ty.zigTypeTag(mod)) {
-                    .Fn => return mod.typeToFunc(child_ty).?.is_generic,
+                    .Fn => return !try sema.fnHasRuntimeBits(child_ty),
                     .Opaque => return false,
                     else => return sema.typeRequiresComptime(child_ty),
                 }

--- a/test/behavior/call.zig
+++ b/test/behavior/call.zig
@@ -491,3 +491,13 @@ test "argument to generic function has correct result type" {
     try S.doTheTest();
     try comptime S.doTheTest();
 }
+
+test "call inline fn through pointer" {
+    const S = struct {
+        inline fn foo(x: u8) !void {
+            try expect(x == 123);
+        }
+    };
+    const f = &S.foo;
+    try f(123);
+}


### PR DESCRIPTION
This is supposed to be the case, similar to how pointers to generic functions are comptime-only (several pieces of logic already assumed this). These types being considered runtime was causing `dbg_var_val` AIR instructions to be wrongly emitted for such values, causing codegen backends to create a runtime reference to the inline function, which (at least on the LLVM backend) triggers an error.

Resolves: #38