### PR TITLE
Sema: refactor detection of comptime-known consts

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -29922,8 +29922,13 @@ fn beginComptimePtrMutation(
                         // We might have a pointer to multiple elements of the array (e.g. a pointer
                         // to a sub-array). In this case, we just have to reinterpret the relevant
                         // bytes of the whole array rather than any single element.
-                        const elem_abi_size_u64 = try sema.typeAbiSize(base_elem_ty);
-                        if (elem_abi_size_u64 < try sema.typeAbiSize(ptr_elem_ty)) {
+                        reinterp_multi_elem: {
+                            if (try sema.typeRequiresComptime(base_elem_ty)) break :reinterp_multi_elem;
+                            if (try sema.typeRequiresComptime(ptr_elem_ty)) break :reinterp_multi_elem;
+
+                            const elem_abi_size_u64 = try sema.typeAbiSize(base_elem_ty);
+                            if (elem_abi_size_u64 >= try sema.typeAbiSize(ptr_elem_ty)) break :reinterp_multi_elem;
+
                             const elem_abi_size = try sema.usizeCast(block, src, elem_abi_size_u64);
                             const elem_idx = try sema.usizeCast(block, src, elem_ptr.index);
                             return .{

--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -257,9 +257,12 @@ pub fn print(
             },
             .ptr => |ptr| {
                 if (ptr.addr == .int) {
-                    const i = ip.indexToKey(ptr.addr.int).int;
-                    switch (i.storage) {
-                        inline else => |addr| return writer.print("{x:0>8}", .{addr}),
+                    switch (ip.indexToKey(ptr.addr.int)) {
+                        .int => |i| switch (i.storage) {
+                            inline else => |addr| return writer.print("{x:0>8}", .{addr}),
+                        },
+                        .undef => return writer.writeAll("undefined"),
+                        else => unreachable,
                     }
                 }
 

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -941,8 +941,16 @@ pub const Inst = struct {
         /// Allocates stack local memory.
         /// Uses the `un_node` union field. The operand is the type of the allocated object.
         /// The node source location points to a var decl node.
+        /// A `make_ptr_const` instruction should be used once the value has
+        /// been stored to the allocation. To ensure comptime value detection
+        /// functions, there are some restrictions on how this pointer should be
+        /// used prior to the `make_ptr_const` instruction: no pointer derived
+        /// from this `alloc` may be returned from a block or stored to another
+        /// address. In other words, it must be trivial to determine whether any
+        /// given pointer derives from this one.
         alloc,
-        /// Same as `alloc` except mutable.
+        /// Same as `alloc` except mutable. As such, `make_ptr_const` need not be used,
+        /// and there are no restrictions on the usage of the pointer.
         alloc_mut,
         /// Allocates comptime-mutable memory.
         /// Uses the `un_node` union field. The operand is the type of the allocated object.

--- a/test/behavior/destructure.zig
+++ b/test/behavior/destructure.zig
@@ -98,3 +98,43 @@ test "destructure from struct init with named tuple fields" {
     try expect(y == 200);
     try expect(z == 300);
 }
+
+test "destructure of comptime-known tuple is comptime-known" {
+    const x, const y = .{ 1, 2 };
+
+    comptime assert(@TypeOf(x) == comptime_int);
+    comptime assert(x == 1);
+
+    comptime assert(@TypeOf(y) == comptime_int);
+    comptime assert(y == 2);
+}
+
+test "destructure of comptime-known tuple where some destinations are runtime-known is comptime-known" {
+    var z: u32 = undefined;
+    var x: u8, const y, z = .{ 1, 2, 3 };
+
+    comptime assert(@TypeOf(y) == comptime_int);
+    comptime assert(y == 2);
+
+    try expect(x == 1);
+    try expect(z == 3);
+}
+
+test "destructure of tuple with comptime fields results in some comptime-known values" {
+    var runtime: u32 = 42;
+    const a, const b, const c, const d = .{ 123, runtime, 456, runtime };
+
+    // a, c are comptime-known
+    // b, d are runtime-known
+
+    comptime assert(@TypeOf(a) == comptime_int);
+    comptime assert(@TypeOf(b) == u32);
+    comptime assert(@TypeOf(c) == comptime_int);
+    comptime assert(@TypeOf(d) == u32);
+
+    comptime assert(a == 123);
+    comptime assert(c == 456);
+
+    try expect(b == 42);
+    try expect(d == 42);
+}

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -1724,3 +1724,21 @@ comptime {
     assert(foo[1] == 2);
     assert(foo[2] == 0x55);
 }
+
+test "const with allocation before result is comptime-known" {
+    const x = blk: {
+        const y = [1]u32{2};
+        _ = y;
+        break :blk [1]u32{42};
+    };
+    comptime assert(@TypeOf(x) == [1]u32);
+    comptime assert(x[0] == 42);
+}
+
+test "const with specified type initialized with typed array is comptime-known" {
+    const x: [3]u16 = [3]u16{ 1, 2, 3 };
+    comptime assert(@TypeOf(x) == [3]u16);
+    comptime assert(x[0] == 1);
+    comptime assert(x[1] == 2);
+    comptime assert(x[2] == 3);
+}


### PR DESCRIPTION
See commit message for details. Performance data points are below. Overall, it seems there's a slight performance regression, but it's insignificant. Interestingly, cache misses are consistently improved, probably because we're no longer having to traverse previous AIR (which could be arbitrarily large).

---

Analyze behavior tests:
```
Benchmark 1 (103 runs): /home/mlugg/zig/master/build/stage3/bin/zig test -Itest test/behavior.zig -fno-emit-bin --zig-lib-dir lib --global-cache-dir c1 --cache-dir c2
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           586ms ± 11.3ms     570ms …  623ms          1 ( 1%)        0%
  peak_rss            106MB ±  213KB     105MB …  106MB          1 ( 1%)        0%
  cpu_cycles         2.00G  ± 34.9M     1.94G  … 2.10G           0 ( 0%)        0%
  instructions       2.43G  ± 9.20K     2.43G  … 2.43G           2 ( 2%)        0%
  cache_references    248M  ± 2.14M      244M  …  253M           0 ( 0%)        0%
  cache_misses       35.7M  ±  986K     33.9M  … 38.6M           1 ( 1%)        0%
  branch_misses      14.0M  ± 85.3K     13.9M  … 14.2M           1 ( 1%)        0%
Benchmark 2 (101 runs): /home/mlugg/zig/comptime-known-const/stage4-release/bin/zig test -Itest test/behavior.zig -fno-emit-bin --zig-lib-dir lib --global-cache-dir c3 --cache-dir c4
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           596ms ± 10.8ms     574ms …  636ms          4 ( 4%)        💩+  1.6% ±  0.5%
  peak_rss            105MB ±  186KB     104MB …  105MB          0 ( 0%)          -  0.8% ±  0.1%
  cpu_cycles         2.03G  ± 33.3M     1.97G  … 2.16G           2 ( 2%)        💩+  1.6% ±  0.5%
  instructions       2.44G  ± 7.55K     2.44G  … 2.44G           0 ( 0%)          +  0.4% ±  0.0%
  cache_references    250M  ± 1.92M      246M  …  255M           0 ( 0%)          +  0.9% ±  0.2%
  cache_misses       34.6M  ±  818K     32.5M  … 36.6M           0 ( 0%)        ⚡-  2.9% ±  0.7%
  branch_misses      14.0M  ± 85.4K     13.9M  … 14.3M           1 ( 1%)          +  0.1% ±  0.2%
```

Analyze standard library tests:
```
Benchmark 1 (4 runs): /home/mlugg/zig/master/build/stage3/bin/zig test lib/std/std.zig -fno-emit-bin --zig-lib-dir lib --global-cache-dir c1 --cache-dir c2
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          15.2s  ± 65.0ms    15.2s  … 15.3s           0 ( 0%)        0%
  peak_rss            496MB ± 87.3KB     496MB …  496MB          0 ( 0%)        0%
  cpu_cycles         54.4G  ±  225M     54.2G  … 54.6G           0 ( 0%)        0%
  instructions       80.3G  ± 6.01K     80.3G  … 80.3G           0 ( 0%)        0%
  cache_references   5.23G  ± 14.2M     5.22G  … 5.25G           0 ( 0%)        0%
  cache_misses        648M  ± 10.1M      642M  …  663M           0 ( 0%)        0%
  branch_misses       249M  ±  861K      248M  …  250M           0 ( 0%)        0%
Benchmark 2 (4 runs): /home/mlugg/zig/comptime-known-const/stage4-release/bin/zig test lib/std/std.zig -fno-emit-bin --zig-lib-dir lib --global-cache-dir c3 --cache-dir c4
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          15.4s  ±  189ms    15.2s  … 15.6s           0 ( 0%)          +  0.9% ±  1.6%
  peak_rss            495MB ±  214KB     494MB …  495MB          0 ( 0%)          -  0.3% ±  0.1%
  cpu_cycles         54.9G  ±  711M     54.2G  … 55.8G           0 ( 0%)          +  0.9% ±  1.7%
  instructions       80.5G  ± 4.07K     80.5G  … 80.5G           0 ( 0%)          +  0.3% ±  0.0%
  cache_references   5.19G  ± 39.5M     5.15G  … 5.22G           0 ( 0%)          -  0.9% ±  1.0%
  cache_misses        594M  ± 18.8M      576M  …  618M           0 ( 0%)        ⚡-  8.4% ±  4.0%
  branch_misses       249M  ± 2.27M      247M  …  252M           0 ( 0%)          -  0.2% ±  1.2%
```

Analyze hello world:
```
Benchmark 1 (447 runs): /home/mlugg/zig/master/build/stage3/bin/zig build-exe /home/mlugg/test/hello.zig -fno-emit-bin --zig-lib-dir lib --global-cache-dir c1 --cache-dir c2
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           134ms ± 6.48ms     124ms …  193ms         28 ( 6%)        0%
  peak_rss           86.8MB ±  187KB    86.2MB … 87.6MB         65 (15%)        0%
  cpu_cycles          379M  ± 13.4M      361M  …  577M          10 ( 2%)        0%
  instructions        433M  ± 38.6K      433M  …  433M          34 ( 8%)        0%
  cache_references   44.6M  ±  501K     43.7M  … 48.0M           9 ( 2%)        0%
  cache_misses       7.22M  ±  213K     6.82M  … 8.40M          14 ( 3%)        0%
  branch_misses      2.96M  ± 28.2K     2.92M  … 3.21M          12 ( 3%)        0%
Benchmark 2 (449 runs): /home/mlugg/zig/comptime-known-const/stage4-release/bin/zig build-exe /home/mlugg/test/hello.zig -fno-emit-bin --zig-lib-dir lib --global-cache-dir c3 --cache-dir c4
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           134ms ± 5.87ms     124ms …  159ms         33 ( 7%)          -  0.5% ±  0.6%
  peak_rss           86.2MB ±  180KB    85.7MB … 86.8MB         60 (13%)          -  0.8% ±  0.0%
  cpu_cycles          377M  ± 9.08M      361M  …  434M           8 ( 2%)          -  0.3% ±  0.4%
  instructions        434M  ± 31.8K      434M  …  434M          27 ( 6%)          +  0.2% ±  0.0%
  cache_references   44.9M  ±  514K     44.0M  … 48.5M           5 ( 1%)          +  0.6% ±  0.1%
  cache_misses       7.06M  ±  226K     6.69M  … 8.54M           5 ( 1%)        ⚡-  2.2% ±  0.4%
  branch_misses      2.95M  ± 29.0K     2.91M  … 3.18M           5 ( 1%)          -  0.4% ±  0.1%
```

Analyze self-hosted compiler:
```
Benchmark 1 (7 runs): /home/mlugg/zig/master/build/stage3/bin/zig build-exe --stack 33554432 /home/mlugg/zig/comptime-known-const/src/main.zig -fno-emit-bin --cache-dir c2 --global-cache-dir c1 --name zig --mod build_options::/home/mlugg/zig/comptime-known-const/c2/c/1195e8fd7b4ae88691f041dd9e56fbe9/options.zig --deps build_options --zig-lib-dir /home/mlugg/zig/comptime-known-const/lib
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          9.80s  ± 77.8ms    9.71s  … 9.92s           0 ( 0%)        0%
  peak_rss            365MB ±  232KB     364MB …  365MB          0 ( 0%)        0%
  cpu_cycles         35.7G  ±  194M     35.5G  … 36.0G           0 ( 0%)        0%
  instructions       46.7G  ± 3.52K     46.7G  … 46.7G           0 ( 0%)        0%
  cache_references   4.04G  ± 13.6M     4.03G  … 4.07G           0 ( 0%)        0%
  cache_misses        534M  ± 7.57M      526M  …  548M           0 ( 0%)        0%
  branch_misses       222M  ±  707K      221M  …  223M           0 ( 0%)        0%
Benchmark 2 (7 runs): /home/mlugg/zig/comptime-known-const/stage4-release/bin/zig build-exe --stack 33554432 /home/mlugg/zig/comptime-known-const/src/main.zig -fno-emit-bin --cache-dir c4 --global-cache-dir c3 --name zig --mod build_options::/home/mlugg/zig/comptime-known-const/c4/c/a79851552461ab80ee0f41a7653bdce6/options.zig --deps build_options --zig-lib-dir /home/mlugg/zig/comptime-known-const/lib
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          9.80s  ± 46.6ms    9.73s  … 9.85s           0 ( 0%)          +  0.0% ±  0.8%
  peak_rss            369MB ±  190KB     369MB …  370MB          0 ( 0%)        💩+  1.2% ±  0.1%
  cpu_cycles         35.7G  ±  107M     35.6G  … 35.8G           0 ( 0%)          +  0.0% ±  0.5%
  instructions       46.8G  ± 5.67K     46.8G  … 46.8G           0 ( 0%)          +  0.2% ±  0.0%
  cache_references   4.02G  ± 17.3M     4.01G  … 4.06G           0 ( 0%)          -  0.5% ±  0.4%
  cache_misses        500M  ± 7.86M      493M  …  515M           0 ( 0%)        ⚡-  6.5% ±  1.7%
  branch_misses       219M  ±  292K      219M  …  220M           0 ( 0%)          -  1.2% ±  0.3%
```