### PR TITLE
std: correct getcontext for Android bionic libc

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -408,7 +408,11 @@ pub extern "c" fn setlogmask(maskpri: c_int) c_int;
 
 pub extern "c" fn if_nametoindex([*:0]const u8) c_int;
 
-pub usingnamespace if (builtin.os.tag == .linux and builtin.target.isMusl()) struct {
+pub usingnamespace if (builtin.target.isAndroid()) struct {
+    // android bionic libc does not implement getcontext,
+    // and std.os.linux.getcontext also cannot be built for
+    // bionic libc currently.
+} else if (builtin.os.tag == .linux and builtin.target.isMusl()) struct {
     // musl does not implement getcontext
     pub const getcontext = std.os.linux.getcontext;
 } else struct {


### PR DESCRIPTION
I have updated @MasterQ32's ZigAndroidTemplate to work with the latest version of Zig and we are exploring adding Android support to Mach https://github.com/hexops/mach/issues/17

`std.c.getcontext` is not used during the build, but if the `pub extern "c"` switch here is hit then it refers to a symbol that is not preset in Android's bionic libc. If the `std.os.linux.getcontext` switch is hit in contrast, then it cannot be built when targeting bionic libc - so it seems prudent to just disable this switch when targeting android for now.

This may not be the perfect long-term solution, but I have a golden rebuttal to that: before I was unable to compile Zig applications for Android, and now with this change I can:

<img width="828" alt="image" src="https://github.com/hexops/mach/assets/3173176/1e29142b-0419-4459-9c8b-75d92f87f822">