### PR TITLE
cbe: support more symbol attributes

### DIFF
--- a/lib/zig.h
+++ b/lib/zig.h
@@ -190,10 +190,13 @@ typedef char bool;
 
 #if zig_has_attribute(weak) || defined(zig_gnuc)
 #define zig_weak_linkage __attribute__((weak))
+#define zig_weak_linkage_fn __attribute__((weak))
 #elif _MSC_VER
 #define zig_weak_linkage __declspec(selectany)
+#define zig_weak_linkage_fn
 #else
 #define zig_weak_linkage zig_weak_linkage_unavailable
+#define zig_weak_linkage_fn zig_weak_linkage_unavailable
 #endif
 
 #if zig_has_builtin(trap)


### PR DESCRIPTION
implement codegen for:

- decl weak linkage
- decl aliases
- fn decl weak linkage

windows:
- `__declspec(selectany)` is not supported for functions
- skip weak linkage for functions

closes #17050