### PR TITLE
completed TODO, remove "mod" from Type.eql

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4106,7 +4106,7 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
     try sema.resolveTypeLayout(decl_tv.ty);
 
     if (decl.kind == .@"usingnamespace") {
-        if (!decl_tv.ty.eql(Type.type, mod)) {
+        if (!decl_tv.ty.eql(Type.type)) {
             return sema.fail(&block_scope, ty_src, "expected type, found {}", .{
                 decl_tv.ty.fmt(mod),
             });
@@ -4139,7 +4139,7 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
 
                 if (decl.has_tv) {
                     prev_type_has_bits = decl.ty.isFnOrHasRuntimeBits(mod);
-                    type_changed = !decl.ty.eql(decl_tv.ty, mod);
+                    type_changed = !decl.ty.eql(decl_tv.ty);
                     if (decl.getOwnedFunction(mod)) |prev_func| {
                         prev_is_inline = prev_func.analysis(ip).state == .inline_only;
                     }
@@ -4169,7 +4169,7 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
     }
     var type_changed = true;
     if (decl.has_tv) {
-        type_changed = !decl.ty.eql(decl_tv.ty, mod);
+        type_changed = !decl.ty.eql(decl_tv.ty);
     }
 
     decl.owns_tv = false;

--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -129,7 +129,7 @@ pub fn print(
                 const elem_ty = ty.elemType2(mod);
                 const len = payload.len.toUnsignedInt(mod);
 
-                if (elem_ty.eql(Type.u8, mod)) str: {
+                if (elem_ty.eql(Type.u8)) str: {
                     const max_len: usize = @min(len, max_string_len);
                     var buf: [max_string_len]u8 = undefined;
 
@@ -268,7 +268,7 @@ pub fn print(
                     }
                     const elem_ty = ptr_ty.child.toType();
                     const len = ptr.len.toValue().toUnsignedInt(mod);
-                    if (elem_ty.eql(Type.u8, mod)) str: {
+                    if (elem_ty.eql(Type.u8)) str: {
                         const max_len = @min(len, max_string_len);
                         var buf: [max_string_len]u8 = undefined;
                         for (buf[0..max_len], 0..) |*c, i| {
@@ -451,7 +451,7 @@ fn printAggregate(
         const elem_ty = ty.elemType2(mod);
         const len = ty.arrayLen(mod);
 
-        if (elem_ty.eql(Type.u8, mod)) str: {
+        if (elem_ty.eql(Type.u8)) str: {
             const max_len: usize = @min(len, max_string_len);
             var buf: [max_string_len]u8 = undefined;
 

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -1421,7 +1421,7 @@ fn minMax(
         .Float => return self.fail("TODO ARM min/max on floats", .{}),
         .Vector => return self.fail("TODO ARM min/max on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 var lhs_reg: Register = undefined;
@@ -1914,7 +1914,7 @@ fn addSub(
         .Float => return self.fail("TODO binary operations on floats", .{}),
         .Vector => return self.fail("TODO binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 const lhs_immediate = try lhs_bind.resolveToImmediate(self);
@@ -1974,7 +1974,7 @@ fn mul(
     switch (lhs_ty.zigTypeTag(mod)) {
         .Vector => return self.fail("TODO binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 // TODO add optimisations for multiplication
@@ -2023,7 +2023,7 @@ fn divTrunc(
         .Float => return self.fail("TODO div on floats", .{}),
         .Vector => return self.fail("TODO div on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 switch (int_info.signedness) {
@@ -2057,7 +2057,7 @@ fn divFloor(
         .Float => return self.fail("TODO div on floats", .{}),
         .Vector => return self.fail("TODO div on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 switch (int_info.signedness) {
@@ -2090,7 +2090,7 @@ fn divExact(
         .Float => return self.fail("TODO div on floats", .{}),
         .Vector => return self.fail("TODO div on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 switch (int_info.signedness) {
@@ -2126,7 +2126,7 @@ fn rem(
         .Float => return self.fail("TODO rem/mod on floats", .{}),
         .Vector => return self.fail("TODO rem/mod on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 var lhs_reg: Register = undefined;
@@ -2249,7 +2249,7 @@ fn bitwise(
     switch (lhs_ty.zigTypeTag(mod)) {
         .Vector => return self.fail("TODO binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 // TODO implement bitwise operations with immediates
@@ -2400,7 +2400,7 @@ fn ptrArithmetic(
     const mod = self.bin_file.options.module.?;
     switch (lhs_ty.zigTypeTag(mod)) {
         .Pointer => {
-            assert(rhs_ty.eql(Type.usize, mod));
+            assert(rhs_ty.eql(Type.usize));
 
             const ptr_ty = lhs_ty;
             const elem_ty = switch (ptr_ty.ptrSize(mod)) {
@@ -2535,7 +2535,7 @@ fn airOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement add_with_overflow/sub_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 switch (int_info.bits) {
                     1...31, 33...63 => {
@@ -2663,7 +2663,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement mul_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 if (int_info.bits <= 32) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -1381,7 +1381,7 @@ fn minMax(
         .Float => return self.fail("TODO ARM min/max on floats", .{}),
         .Vector => return self.fail("TODO ARM min/max on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 var lhs_reg: Register = undefined;
@@ -1600,7 +1600,7 @@ fn airOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement add_with_overflow/sub_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 if (int_info.bits < 32) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);
@@ -1713,7 +1713,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement mul_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 if (int_info.bits <= 16) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);
@@ -3393,7 +3393,7 @@ fn addSub(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 const lhs_immediate = try lhs_bind.resolveToImmediate(self);
@@ -3449,7 +3449,7 @@ fn mul(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 // TODO add optimisations for multiplication
@@ -3498,7 +3498,7 @@ fn divTrunc(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
@@ -3541,7 +3541,7 @@ fn divFloor(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
@@ -3606,7 +3606,7 @@ fn rem(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
@@ -3730,7 +3730,7 @@ fn bitwise(
     switch (lhs_ty.zigTypeTag(mod)) {
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.eql(rhs_ty));
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 const lhs_immediate = try lhs_bind.resolveToImmediate(self);
@@ -3890,7 +3890,7 @@ fn ptrArithmetic(
     const mod = self.bin_file.options.module.?;
     switch (lhs_ty.zigTypeTag(mod)) {
         .Pointer => {
-            assert(rhs_ty.eql(Type.usize, mod));
+            assert(rhs_ty.eql(Type.usize));
 
             const ptr_ty = lhs_ty;
             const elem_ty = switch (ptr_ty.ptrSize(mod)) {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1080,7 +1080,7 @@ fn binOp(
                 .Float => return self.fail("TODO binary operations on floats", .{}),
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    assert(lhs_ty.eql(rhs_ty, mod));
+                    assert(lhs_ty.eql(rhs_ty));
                     const int_info = lhs_ty.intInfo(mod);
                     if (int_info.bits <= 64) {
                         // TODO immediate operands
@@ -1839,7 +1839,7 @@ fn airCmp(self: *Self, inst: Air.Inst.Index, op: math.CompareOperator) !void {
         return self.finishAir(inst, .dead, .{ bin_op.lhs, bin_op.rhs, .none });
     const ty = self.typeOf(bin_op.lhs);
     const mod = self.bin_file.options.module.?;
-    assert(ty.eql(self.typeOf(bin_op.rhs), mod));
+    assert(ty.eql(self.typeOf(bin_op.rhs)));
     if (ty.zigTypeTag(mod) == .ErrorSet)
         return self.fail("TODO implement cmp for errors", .{});
 

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -771,7 +771,7 @@ fn airAddSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement add_with_overflow/sub_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 switch (int_info.bits) {
                     32, 64 => {
@@ -1905,7 +1905,7 @@ fn airMod(self: *Self, inst: Air.Inst.Index) !void {
     const rhs = try self.resolveInst(bin_op.rhs);
     const lhs_ty = self.typeOf(bin_op.lhs);
     const rhs_ty = self.typeOf(bin_op.rhs);
-    assert(lhs_ty.eql(rhs_ty, self.bin_file.options.module.?));
+    assert(lhs_ty.eql(rhs_ty));
 
     if (self.liveness.isUnused(inst))
         return self.finishAir(inst, .dead, .{ bin_op.lhs, bin_op.rhs, .none });
@@ -2057,7 +2057,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement mul_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.eql(rhs_ty));
                 const int_info = lhs_ty.intInfo(mod);
                 switch (int_info.bits) {
                     1...32 => {
@@ -2881,7 +2881,7 @@ fn binOp(
                 .Float => return self.fail("TODO binary operations on floats", .{}),
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    assert(lhs_ty.eql(rhs_ty, mod));
+                    assert(lhs_ty.eql(rhs_ty));
                     const int_info = lhs_ty.intInfo(mod);
                     if (int_info.bits <= 64) {
                         // Only say yes if the operation is
@@ -2971,7 +2971,7 @@ fn binOp(
             switch (lhs_ty.zigTypeTag(mod)) {
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    assert(lhs_ty.eql(rhs_ty, mod));
+                    assert(lhs_ty.eql(rhs_ty));
                     const int_info = lhs_ty.intInfo(mod);
                     if (int_info.bits <= 64) {
                         const rhs_immediate_ok = switch (tag) {
@@ -4340,7 +4340,7 @@ fn minMax(
     rhs_ty: Type,
 ) InnerError!MCValue {
     const mod = self.bin_file.options.module.?;
-    assert(lhs_ty.eql(rhs_ty, mod));
+    assert(lhs_ty.eql(rhs_ty));
     switch (lhs_ty.zigTypeTag(mod)) {
         .Float => return self.fail("TODO min/max on floats", .{}),
         .Vector => return self.fail("TODO min/max on vectors", .{}),

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -566,7 +566,7 @@ pub const DeclGen = struct {
         // them).  The analysis until now should ensure that the C function
         // pointers are compatible.  If they are not, then there is a bug
         // somewhere and we should let the C compiler tell us about it.
-        const need_typecast = if (ty.castPtrToFn(mod)) |_| false else !ty.childType(mod).eql(decl.ty, mod);
+        const need_typecast = if (ty.castPtrToFn(mod)) |_| false else !ty.childType(mod).eql(decl.ty);
         if (need_typecast) {
             try writer.writeAll("((");
             try dg.renderType(writer, ty);
@@ -869,7 +869,7 @@ pub const DeclGen = struct {
                 },
                 .Array, .Vector => {
                     const ai = ty.arrayInfo(mod);
-                    if (ai.elem_type.eql(Type.u8, mod)) {
+                    if (ai.elem_type.eql(Type.u8)) {
                         var literal = stringLiteral(writer);
                         try literal.start();
                         const c_len = ty.arrayLenIncludingSentinel(mod);
@@ -1221,7 +1221,7 @@ pub const DeclGen = struct {
                     const max_string_initializer_len = 65535;
 
                     const ai = ty.arrayInfo(mod);
-                    if (ai.elem_type.eql(Type.u8, mod)) {
+                    if (ai.elem_type.eql(Type.u8)) {
                         if (ai.len <= max_string_initializer_len) {
                             var literal = stringLiteral(writer);
                             try literal.start();
@@ -3641,7 +3641,7 @@ fn airStore(f: *Function, inst: Air.Inst.Index, safety: bool) !CValue {
     if (need_memcpy) {
         // For this memcpy to safely work we need the rhs to have the same
         // underlying type as the lhs (i.e. they must both be arrays of the same underlying type).
-        assert(src_ty.eql(ptr_info.child.toType(), f.object.dg.module));
+        assert(src_ty.eql(ptr_info.child.toType()));
 
         // If the source is a constant, writeCValue will emit a brace initialization
         // so work around this by initializing into new local.
@@ -5469,7 +5469,7 @@ fn airStructFieldVal(f: *Function, inst: Air.Inst.Index) !CValue {
                 if (cant_cast) try writer.writeByte(')');
                 try f.object.dg.renderBuiltinInfo(writer, field_int_ty, .bits);
                 try writer.writeAll(");\n");
-                if (inst_ty.eql(field_int_ty, f.object.dg.module)) return temp_local;
+                if (inst_ty.eql(field_int_ty)) return temp_local;
 
                 const local = try f.allocLocal(inst, inst_ty);
                 try writer.writeAll("memcpy(");

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -1961,8 +1961,8 @@ pub const DeclGen = struct {
 
         const result_ty_ref = try self.resolveType(ty, .direct);
 
-        assert(self.typeOf(bin_op.lhs).eql(ty, self.module));
-        assert(self.typeOf(bin_op.rhs).eql(ty, self.module));
+        assert(self.typeOf(bin_op.lhs).eql(ty));
+        assert(self.typeOf(bin_op.rhs).eql(ty));
 
         // Binary operations are generally applicable to both scalar and vector operations
         // in SPIR-V, but int and float versions of operations require different opcodes.
@@ -2346,7 +2346,7 @@ pub const DeclGen = struct {
         const rhs_id = try self.resolve(bin_op.rhs);
         const bool_ty_id = try self.resolveTypeId(Type.bool);
         const ty = self.typeOf(bin_op.lhs);
-        assert(ty.eql(self.typeOf(bin_op.rhs), self.module));
+        assert(ty.eql(self.typeOf(bin_op.rhs)));
 
         return try self.cmp(op, bool_ty_id, ty, lhs_id, rhs_id);
     }

--- a/src/value.zig
+++ b/src/value.zig
@@ -1708,7 +1708,7 @@ pub const Value = struct {
         const ptr_val = switch (mod.intern_pool.indexToKey(val.toIntern())) {
             .ptr => |ptr| ptr: {
                 switch (ptr.addr) {
-                    .elem => |elem| if (mod.intern_pool.typeOf(elem.base).toType().elemType2(mod).eql(elem_ty, mod))
+                    .elem => |elem| if (mod.intern_pool.typeOf(elem.base).toType().elemType2(mod).eql(elem_ty))
                         return (try mod.intern(.{ .ptr = .{
                             .ty = elem_ptr_ty.toIntern(),
                             .addr = .{ .elem = .{


### PR DESCRIPTION
I'm not too familiar with how TODOs are completed here, but I had a bit of time and noticed this one in the source code. Please tell me if the procedure is something different. I ran full test suite on it, and it completed.