### PR TITLE
Make `std.os.getenv` always a compile error on Windows

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1893,6 +1893,9 @@ pub fn execvpeZ(
 /// Get an environment variable.
 /// See also `getenvZ`.
 pub fn getenv(key: []const u8) ?[:0]const u8 {
+    if (builtin.os.tag == .windows) {
+        @compileError("std.os.getenv is unavailable for Windows because environment strings are in WTF-16 format. See std.process.getEnvVarOwned for a cross-platform API or std.os.getenvW for a Windows-specific API.");
+    }
     if (builtin.link_libc) {
         var ptr = std.c.environ;
         while (ptr[0]) |line| : (ptr += 1) {
@@ -1906,9 +1909,7 @@ pub fn getenv(key: []const u8) ?[:0]const u8 {
         }
         return null;
     }
-    if (builtin.os.tag == .windows) {
-        @compileError("std.os.getenv is unavailable for Windows because environment string is in WTF-16 format. See std.process.getEnvVarOwned for cross-platform API or std.os.getenvW for Windows-specific API.");
-    } else if (builtin.os.tag == .wasi) {
+    if (builtin.os.tag == .wasi) {
         @compileError("std.os.getenv is unavailable for WASI. See std.process.getEnvMap or std.process.getEnvVarOwned for a cross-platform API.");
     }
     // The simplified start logic doesn't populate environ.


### PR DESCRIPTION
The [_environ variable](https://learn.microsoft.com/en-us/cpp/c-runtime-library/environ-wenviron) that is populated when linking libc on Windows does not support Unicode keys/values (or, at least, the encoding is not necessarily UTF-8). So, for Unicode support, _wenviron would need to be used instead. However, this means that the keys/values would be encoded as UTF-16, so they would need to be converted to UTF-8 before being returned by `os.getenv`. This would require allocation, which is not part of the `os.getenv` API, so `os.getenv` is not implementable on Windows even when linking libc.

See https://github.com/ziglang/zig/pull/16464#issuecomment-1647337848 for a bit more detail.

Closes https://github.com/ziglang/zig/issues/8456. Alternative to https://github.com/ziglang/zig/pull/16464.