### PR TITLE
std: math.absInt: update docs to use fabs for floats

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -743,6 +743,7 @@ fn testOverflow() !void {
 /// Returns the absolute value of x, where x is a value of a signed integer type.
 /// Does not convert and returns a value of a signed integer type.
 /// Use `absCast` if you want to convert the result and get an unsigned type.
+/// Use `@fabs` if you need the absolute value of a floating point value.
 pub fn absInt(x: anytype) !@TypeOf(x) {
     const T = @TypeOf(x);
     return switch (@typeInfo(T)) {


### PR DESCRIPTION
saw a random comment in chat which eventually led to https://github.com/nektro/zig-color/commit/c586d8ba0ca57a50ef2ed5f951b2b4ee9c5361c5

making this patch to help the next person