### PR TITLE
x86 backend: don't read bogus safety flag

### DIFF
--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -334,10 +334,11 @@ test "*const ?[*]const T to [*c]const [*c]const T" {
     try expect(b[0][1] == 'k');
 }
 
-test "array coersion to undefined at runtime" {
+test "array coercion to undefined at runtime" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     @setRuntimeSafety(true);
 

--- a/test/behavior/int128.zig
+++ b/test/behavior/int128.zig
@@ -28,6 +28,7 @@ test "undefined 128 bit int" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     @setRuntimeSafety(true);
 


### PR DESCRIPTION
Safety is not a global flag that should be enabled or disabled for all stores - it's lowered by the frontend directly into AIR instruction semantics. The flag for this is communicated via the `store` vs `store_safe` AIR instructions, and whether to write 0xaa bytes or not should be decided in `airStore` and passed down via function parameters.

This commit is a step backwards since it removes functionality but it aims our feet towards a better mountain to climb.

Correct place to restore functionality is here:
https://github.com/ziglang/zig/blob/5af5d87ad2227b6a7b5347c7217312ef8a83de12/src/arch/x86_64/CodeGen.zig#L5528C4-L5534