### PR TITLE
AstGen: fix `@export` with undeclared identifier crashing

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -8283,6 +8283,10 @@ fn builtinCall(
                         },
                         .top => break,
                     };
+                    if (found_already == null) {
+                        const ident_name = try astgen.identifierTokenString(ident_token);
+                        return astgen.failNode(params[0], "use of undeclared identifier '{s}'", .{ident_name});
+                    }
                 },
                 .field_access => {
                     const namespace_node = node_datas[params[0]].lhs;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6401,7 +6401,7 @@ fn lookupIdentifier(sema: *Sema, block: *Block, src: LazySrcLoc, name: InternPoo
         }
         namespace = mod.namespacePtr(namespace).parent.unwrap() orelse break;
     }
-    unreachable; // AstGen detects use of undeclared identifier errors.
+    unreachable; // AstGen detects use of undeclared identifiers.
 }
 
 /// This looks up a member of a specific namespace. It is affected by `usingnamespace` but

--- a/test/cases/compile_errors/@export_with_undeclared_identifier.zig
+++ b/test/cases/compile_errors/@export_with_undeclared_identifier.zig
@@ -1,0 +1,9 @@
+export fn a() void {
+    @export(bogus, .{ .name = "bogus_alias" });
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:13: error: use of undeclared identifier 'bogus'


### PR DESCRIPTION
This required a third `if (found_already == null)` in another place in AstGen.zig for this special case of `@export`.

Fixes #17188