### PR TITLE
define `_WIN32_WINNT` for windows compilations based on target minver

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4880,6 +4880,14 @@ pub fn addCCArgs(
     const llvm_triple = try @import("codegen/llvm.zig").targetTriple(arena, target);
     try argv.appendSlice(&[_][]const u8{ "-target", llvm_triple });
 
+    if (target.os.tag == .windows) switch (ext) {
+        .c, .cpp, .m, .mm, .h, .cu, .assembly, .assembly_with_cpp => {
+            const minver: u16 = @truncate(@intFromEnum(target.os.getVersionRange().windows.min) >> 16);
+            try argv.append(try std.fmt.allocPrint(argv.allocator, "-D_WIN32_WINNT=0x{x:0>4}", .{minver}));
+        },
+        else => {},
+    };
+
     switch (ext) {
         .c, .cpp, .m, .mm, .h, .cu, .rc => {
             try argv.appendSlice(&[_][]const u8{

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4881,7 +4881,7 @@ pub fn addCCArgs(
     try argv.appendSlice(&[_][]const u8{ "-target", llvm_triple });
 
     if (target.os.tag == .windows) switch (ext) {
-        .c, .cpp, .m, .mm, .h, .cu, .assembly, .assembly_with_cpp => {
+        .c, .cpp, .m, .mm, .h, .cu, .rc, .assembly, .assembly_with_cpp => {
             const minver: u16 = @truncate(@intFromEnum(target.os.getVersionRange().windows.min) >> 16);
             try argv.append(try std.fmt.allocPrint(argv.allocator, "-D_WIN32_WINNT=0x{x:0>4}", .{minver}));
         },

--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -139,6 +139,11 @@ pub fn buildLibCXX(comp: *Compilation, prog_node: *std.Progress.Node) !void {
     });
     var c_source_files = try std.ArrayList(Compilation.CSourceFile).initCapacity(arena, libcxx_files.len);
 
+    var libcxx_flags = switch (try std.process.hasEnvVar(arena, "ZIG_LIBCXX_FLAGS")) {
+        false => "",
+        else => try std.process.getEnvVarOwned(arena, "ZIG_LIBCXX_FLAGS"),
+    };
+
     for (libcxx_files) |cxx_src| {
         var cflags = std.ArrayList([]const u8).init(arena);
 
@@ -159,6 +164,10 @@ pub fn buildLibCXX(comp: *Compilation, prog_node: *std.Progress.Node) !void {
                 continue;
             }
             try cflags.append("-D_LIBCPP_HAS_NO_THREADS");
+        }
+
+        if (libcxx_flags.len != 0) {
+            try cflags.append(libcxx_flags);
         }
 
         try cflags.append("-DNDEBUG");

--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -139,11 +139,6 @@ pub fn buildLibCXX(comp: *Compilation, prog_node: *std.Progress.Node) !void {
     });
     var c_source_files = try std.ArrayList(Compilation.CSourceFile).initCapacity(arena, libcxx_files.len);
 
-    var libcxx_flags = switch (try std.process.hasEnvVar(arena, "ZIG_LIBCXX_FLAGS")) {
-        false => "",
-        else => try std.process.getEnvVarOwned(arena, "ZIG_LIBCXX_FLAGS"),
-    };
-
     for (libcxx_files) |cxx_src| {
         var cflags = std.ArrayList([]const u8).init(arena);
 

--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -161,10 +161,6 @@ pub fn buildLibCXX(comp: *Compilation, prog_node: *std.Progress.Node) !void {
             try cflags.append("-D_LIBCPP_HAS_NO_THREADS");
         }
 
-        if (target.os.tag == .windows) {
-            try cflags.append(try minVersionStr(arena, @intFromEnum(target.os.getVersionRange().windows.min)));
-        }
-
         try cflags.append("-DNDEBUG");
         try cflags.append("-D_LIBCPP_BUILDING_LIBRARY");
         try cflags.append("-D_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER");
@@ -346,10 +342,6 @@ pub fn buildLibCXXABI(comp: *Compilation, prog_node: *std.Progress.Node) !void {
             try cflags.append("-DHAVE___CXA_THREAD_ATEXIT_IMPL");
         }
 
-        if (target.os.tag == .windows) {
-            try cflags.append(try minVersionStr(arena, @intFromEnum(target.os.getVersionRange().windows.min)));
-        }
-
         try cflags.append("-D_LIBCPP_DISABLE_EXTERN_TEMPLATE");
         try cflags.append("-D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS");
         try cflags.append("-D_LIBCXXABI_BUILDING_LIBRARY");
@@ -450,12 +442,4 @@ pub fn buildLibCXXABI(comp: *Compilation, prog_node: *std.Progress.Node) !void {
         }),
         .lock = sub_compilation.bin_file.toOwnedLock(),
     };
-}
-
-// helper function to format the minimum windows target version as a hex string
-fn minVersionStr(allocator: std.mem.Allocator, targetVer: u32) ![]const u8 {
-    // Take the most significant 2 bytes of the u32 windows version enum, and truncate to a u16.
-    // Then write as eg 0x0601 (padded to 4 digits).
-    var minVer: u16 = @truncate(targetVer >> 16);
-    return try std.fmt.allocPrint(allocator, "-D_WIN32_WINNT=0x{x:0>4}", .{minVer});
 }

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -89,7 +89,6 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: *std.Progr
 
                     "-std=gnu99",
                     "-D_CRTBLD",
-                    "-D_WIN32_WINNT=0x0f00",
                     "-D__MSVCRT_VERSION__=0x700",
                     "-D__USE_MINGW_ANSI_STDIO=0",
                 });
@@ -114,7 +113,6 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: *std.Progr
 
                 "-std=gnu99",
                 "-D_CRTBLD",
-                "-D_WIN32_WINNT=0x0f00",
                 "-D__MSVCRT_VERSION__=0x700",
                 "-D__USE_MINGW_ANSI_STDIO=0",
 
@@ -163,7 +161,6 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: *std.Progr
 
                 "-std=gnu99",
                 "-D_CRTBLD",
-                "-D_WIN32_WINNT=0x0f00",
                 "-D__MSVCRT_VERSION__=0x700",
                 "-D__USE_MINGW_ANSI_STDIO=0",
 
@@ -226,7 +223,6 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: *std.Progr
 
                 "-std=gnu99",
                 "-D_CRTBLD",
-                "-D_WIN32_WINNT=0x0f00",
                 "-D__MSVCRT_VERSION__=0x700",
                 "-D__USE_MINGW_ANSI_STDIO=0",
 
@@ -272,7 +268,6 @@ fn add_cc_args(
     try args.appendSlice(&[_][]const u8{
         "-std=gnu11",
         "-D_CRTBLD",
-        "-D_WIN32_WINNT=0x0f00",
         "-D__MSVCRT_VERSION__=0x700",
         "-D__USE_MINGW_ANSI_STDIO=0",
     });


### PR DESCRIPTION
This PR enables the use case of cross-compiling for old versions of Windows. Currently, any dlls or exes built for Windows won't run on anything older than 8, since a new function, `GetSystemTimePreciseAsFileTime`, was added in windows 8, and which libcxx will depend on if it is built for Window 8 or above. 

Zig will currently build libcxx without specifying `_WIN32_WINNT`, which controls the target version, and so libcxx ends up targeting 8+.

This PR uses the target version information already present in libcxx.zig for the value of the `_WIN32_WINNT` define.

This the first time I've written any zig code, so it may not be idiomatic. 

Thanks.