### PR TITLE
CI: update windows tarballs

### DIFF
--- a/ci/x86_64-windows-debug.ps1
+++ b/ci/x86_64-windows-debug.ps1
@@ -1,5 +1,5 @@
 $TARGET = "$($Env:ARCH)-windows-gnu"
-$ZIG_LLVM_CLANG_LLD_NAME = "zig+llvm+lld+clang-$TARGET-0.12.0-dev.203+d3bc1cfc4"
+$ZIG_LLVM_CLANG_LLD_NAME = "zig+llvm+lld+clang-$TARGET-0.12.0-dev.888+130227492"
 $MCPU = "baseline"
 $ZIG_LLVM_CLANG_LLD_URL = "https://ziglang.org/deps/$ZIG_LLVM_CLANG_LLD_NAME.zip"
 $PREFIX_PATH = "$(Get-Location)\$ZIG_LLVM_CLANG_LLD_NAME"

--- a/ci/x86_64-windows-release.ps1
+++ b/ci/x86_64-windows-release.ps1
@@ -1,5 +1,5 @@
 $TARGET = "$($Env:ARCH)-windows-gnu"
-$ZIG_LLVM_CLANG_LLD_NAME = "zig+llvm+lld+clang-$TARGET-0.12.0-dev.203+d3bc1cfc4"
+$ZIG_LLVM_CLANG_LLD_NAME = "zig+llvm+lld+clang-$TARGET-0.12.0-dev.888+130227492"
 $MCPU = "baseline"
 $ZIG_LLVM_CLANG_LLD_URL = "https://ziglang.org/deps/$ZIG_LLVM_CLANG_LLD_NAME.zip"
 $PREFIX_PATH = "$(Get-Location)\$ZIG_LLVM_CLANG_LLD_NAME"

--- a/test/standalone/c_compiler/build.zig
+++ b/test/standalone/c_compiler/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Test it");
     b.default_step = test_step;
 
-    if (builtin.os.tag == .windows and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .windows) {
         // https://github.com/ziglang/zig/issues/16965
         return;
     }

--- a/test/standalone/load_dynamic_library/build.zig
+++ b/test/standalone/load_dynamic_library/build.zig
@@ -10,7 +10,7 @@ pub fn build(b: *std.Build) void {
 
     if (builtin.os.tag == .wasi) return;
 
-    if (builtin.os.tag == .windows and builtin.cpu.arch == .aarch64) {
+    if (builtin.os.tag == .windows) {
         // https://github.com/ziglang/zig/issues/16960
         return;
     }

--- a/test/standalone/shared_library/build.zig
+++ b/test/standalone/shared_library/build.zig
@@ -4,9 +4,7 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Test it");
     b.default_step = test_step;
 
-    if (@import("builtin").os.tag == .windows and
-        @import("builtin").cpu.arch == .aarch64)
-    {
+    if (@import("builtin").os.tag == .windows) {
         // https://github.com/ziglang/zig/issues/16959
         return;
     }


### PR DESCRIPTION
The previous tarball for x86_64-windows did not have LLVM assertions enabled.

Related:
* https://github.com/ziglang/zig/issues/16959
* https://github.com/ziglang/zig/issues/16960
* https://github.com/ziglang/zig/issues/16965

Closes #17237 