### PR TITLE
Prevent hitting a clang assert when dealing with FullSourceLoc

### DIFF
--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -3053,6 +3053,11 @@ ZigClangASTUnit *ZigClangLoadFromCommandLine(const char **args_begin, const char
             msg->msg_len = msg_str_ref.size();
 
             clang::FullSourceLoc fsl = it->getLocation();
+
+            // Ensure the source location is valid before expanding it
+            if (fsl.isInvalid()) {
+                continue;
+            }
             // Expand the location if possible
             fsl = fsl.getFileLoc();
 


### PR DESCRIPTION
Clang's `FullSourceLoc::getFileLoc()` contains an assert which causes a panic in `translate-c` if too many errors occur, this PR prevents that assert from causing an abort. 

Closes #17208

This is the output of `zig translate-c` before:
```
/usr/bin/zig translate-c -DCONFIG_X86_X32_ABI= -DCONFIG_AS_CFI=1 -DCONFIG_AS_CFI_SIGNAL_FRAME=1 -DCONFIG_AS_CFI_SECTIONS=1 -DCONFIG_AS_FXSAVEQ=1 -DCONFIG_AS_SSSE3=1 -DCONFIG_AS_CRC32=1 -DCONFIG_AS_AVX=1 -DCONFIG_AS_AVX2=1 -DCONFIG_AS_AVX512=1 -DCONFIG_AS_SHA1=1 -DCONFIG_AS_SHA256_NI=1 -DCC_USE_FENTRY=1 -DMODULE= -D__KERNEL__= -DKBUILD_BASENAME=gtrace -DKBUILD_MODNAME=gtrace -I/usr/lib/gcc/x86_64-pc-linux-gnu/13.2.1/include -I/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/ -I/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/generated/ -I/usr/lib/modules/6.5.4-arch2-1/build/include/ -I/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/uapi/ -I/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/generated/uapi -I/usr/lib/modules/6.5.4-arch2-1/build/include/uapi /usr/lib/modules/6.5.4-arch2-1/build/include/linux/module.h
```
```
zig: /home/jrz/program/makeclang/llvm-project-17/clang/lib/Basic/SourceLocation.cpp:179: clang::FullSourceLoc clang::FullSourceLoc::getFileLoc() const: Assertion `isValid()' failed.
Aborted (core dumped)
```
This is the output after:
```
/usr/bin/zig translate-c -DCONFIG_X86_X32_ABI= -DCONFIG_AS_CFI=1 -DCONFIG_AS_CFI_SIGNAL_FRAME=1 -DCONFIG_AS_CFI_SECTIONS=1 -DCONFIG_AS_FXSAVEQ=1 -DCONFIG_AS_SSSE3=1 -DCONFIG_AS_CRC32=1 -DCONFIG_AS_AVX=1 -DCONFIG_AS_AVX2=1 -DCONFIG_AS_AVX512=1 -DCONFIG_AS_SHA1=1 -DCONFIG_AS_SHA256_NI=1 -DCC_USE_FENTRY=1 -DMODULE= -D__KERNEL__= -DKBUILD_BASENAME=gtrace -DKBUILD_MODNAME=gtrace -I/usr/lib/gcc/x86_64-pc-linux-gnu/13.2.1/include -I/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/ -I/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/generated/ -I/usr/lib/modules/6.5.4-arch2-1/build/include/ -I/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/uapi/ -I/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/generated/uapi -I/usr/lib/modules/6.5.4-arch2-1/build/include/uapi /usr/lib/modules/6.5.4-arch2-1/build/include/linux/module.h
```
```
/usr/lib/modules/6.5.4-arch2-1/build/include/asm-generic/bitops/instrumented-non-atomic.h:66:6: call to undeclared function 'IS_ENABLED'; ISO C99 and later do not support implicit function declarations
/usr/lib/modules/6.5.4-arch2-1/build/include/asm-generic/bitops/instrumented-non-atomic.h:66:17: use of undeclared identifier 'CONFIG_KCSAN_ASSUME_PLAIN_WRITES_ATOMIC'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/current.h:37:1: use of undeclared identifier 'CONFIG_X86_L1_CACHE_SHIFT'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:13:53: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:18:47: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:23:54: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:30:54: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:37:63: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:43:47: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:51:47: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:59:56: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:65:56: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:71:63: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:77:60: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:83:60: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:89:59: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:95:59: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:101:50: unknown type name 'atomic64_t'
/usr/lib/modules/6.5.4-arch2-1/build/arch/x86/include/asm/atomic64_64.h:107:55: unknown type name 'atomic64_t'
(no file):1:1: too many errors emitted, stopping now
```
This shows the user the real issue (in this case, my original command didn't contain the correct includes).