### PR TITLE
compiler: start handling anonymous decls differently

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3499,6 +3499,7 @@ fn processOneJob(comp: *Compilation, job: Job, prog_node: *std.Progress.Node) !v
                         .is_naked_fn = false,
                         .fwd_decl = fwd_decl.toManaged(gpa),
                         .ctypes = .{},
+                        .anon_decl_deps = .{},
                     };
                     defer {
                         dg.ctypes.deinit(gpa);

--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -321,6 +321,15 @@ pub fn print(
                             .val = decl.val,
                         }, writer, level - 1, mod);
                     },
+                    .anon_decl => |decl_val| {
+                        if (level == 0) return writer.print("(anon decl '{d}')", .{
+                            @intFromEnum(decl_val),
+                        });
+                        return print(.{
+                            .ty = ip.typeOf(decl_val).toType(),
+                            .val = decl_val.toValue(),
+                        }, writer, level - 1, mod);
+                    },
                     .mut_decl => |mut_decl| {
                         const decl = mod.declPtr(mut_decl.decl);
                         if (level == 0) return writer.print("(mut decl '{}')", .{decl.name.fmt(ip)});

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3075,6 +3075,7 @@ fn lowerParentPtr(func: *CodeGen, ptr_val: Value, offset: u32) InnerError!WValue
         .decl => |decl_index| {
             return func.lowerParentPtrDecl(ptr_val, decl_index, offset);
         },
+        .anon_decl => @panic("TODO"),
         .mut_decl => |mut_decl| {
             const decl_index = mut_decl.decl;
             return func.lowerParentPtrDecl(ptr_val, decl_index, offset);

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3075,7 +3075,7 @@ fn lowerParentPtr(func: *CodeGen, ptr_val: Value, offset: u32) InnerError!WValue
         .decl => |decl_index| {
             return func.lowerParentPtrDecl(ptr_val, decl_index, offset);
         },
-        .anon_decl => @panic("TODO"),
+        .anon_decl => |ad| return func.lowerAnonDeclRef(ad, offset),
         .mut_decl => |mut_decl| {
             const decl_index = mut_decl.decl;
             return func.lowerParentPtrDecl(ptr_val, decl_index, offset);
@@ -3137,6 +3137,32 @@ fn lowerParentPtrDecl(func: *CodeGen, ptr_val: Value, decl_index: Module.Decl.In
     try mod.markDeclAlive(decl);
     const ptr_ty = try mod.singleMutPtrType(decl.ty);
     return func.lowerDeclRefValue(.{ .ty = ptr_ty, .val = ptr_val }, decl_index, offset);
+}
+
+fn lowerAnonDeclRef(func: *CodeGen, anon_decl: InternPool.Index, offset: u32) InnerError!WValue {
+    const mod = func.bin_file.base.options.module.?;
+    const ty = mod.intern_pool.typeOf(anon_decl).toType();
+
+    const is_fn_body = ty.zigTypeTag(mod) == .Fn;
+    if (!is_fn_body and !ty.hasRuntimeBitsIgnoreComptime(mod)) {
+        return WValue{ .imm32 = 0xaaaaaaaa };
+    }
+
+    const res = try func.bin_file.lowerAnonDecl(anon_decl, func.decl.srcLoc(mod));
+    switch (res) {
+        .ok => {},
+        .fail => |em| {
+            func.err_msg = em;
+            return error.CodegenFail;
+        },
+    }
+    const target_atom_index = func.bin_file.anon_decls.get(anon_decl).?;
+    const target_sym_index = func.bin_file.getAtom(target_atom_index).getSymbolIndex().?;
+    if (is_fn_body) {
+        return WValue{ .function_index = target_sym_index };
+    } else if (offset == 0) {
+        return WValue{ .memory = target_sym_index };
+    } else return WValue{ .memory_offset = .{ .pointer = target_sym_index, .offset = offset } };
 }
 
 fn lowerDeclRefValue(func: *CodeGen, tv: TypedValue, decl_index: Module.Decl.Index, offset: u32) InnerError!WValue {
@@ -3306,6 +3332,7 @@ fn lowerConstant(func: *CodeGen, arg_val: Value, ty: Type) InnerError!WValue {
             .mut_decl => |mut_decl| return func.lowerDeclRefValue(.{ .ty = ty, .val = val }, mut_decl.decl, 0),
             .int => |int| return func.lowerConstant(int.toValue(), ip.typeOf(int).toType()),
             .opt_payload, .elem, .field => return func.lowerParentPtr(val, 0),
+            .anon_decl => |ad| return func.lowerAnonDeclRef(ad, 0),
             else => return func.fail("Wasm TODO: lowerConstant for other const addr tag {}", .{ptr.addr}),
         },
         .opt => if (ty.optionalReprIsPayload(mod)) {

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -655,6 +655,7 @@ fn lowerParentPtr(
             debug_output,
             reloc_info,
         ),
+        .anon_decl => @panic("TODO"),
         .int => |int| try generateSymbol(bin_file, src_loc, .{
             .ty = Type.usize,
             .val = int.toValue(),

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -739,7 +739,6 @@ fn lowerAnonDeclRef(
     debug_output: DebugInfoOutput,
     reloc_info: RelocInfo,
 ) CodeGenError!Result {
-    _ = src_loc;
     _ = debug_output;
     const target = bin_file.options.target;
     const mod = bin_file.options.module.?;
@@ -750,6 +749,12 @@ fn lowerAnonDeclRef(
     if (!is_fn_body and !decl_ty.hasRuntimeBits(mod)) {
         try code.appendNTimes(0xaa, ptr_width_bytes);
         return Result.ok;
+    }
+
+    const res = try bin_file.lowerAnonDecl(decl_val, src_loc);
+    switch (res) {
+        .ok => {},
+        .fail => |em| return .{ .fail = em },
     }
 
     const vaddr = try bin_file.getAnonDeclVAddr(decl_val, .{

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -604,6 +604,7 @@ pub const DeclGen = struct {
                 },
                 location,
             ),
+            .anon_decl => @panic("TODO"),
             .int => |int| {
                 try writer.writeByte('(');
                 try dg.renderCType(writer, ptr_cty);
@@ -1155,6 +1156,7 @@ pub const DeclGen = struct {
                         },
                         ptr_location,
                     ),
+                    .anon_decl => @panic("TODO"),
                     .int => |int| {
                         try writer.writeAll("((");
                         try dg.renderType(writer, ptr_ty);

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -530,7 +530,7 @@ pub const DeclGen = struct {
     ctypes: CType.Store,
     /// Keeps track of anonymous decls that need to be rendered before this
     /// (named) Decl in the output C code.
-    anon_decl_deps: std.AutoArrayHashMapUnmanaged(InternPool.Index, void),
+    anon_decl_deps: std.AutoArrayHashMapUnmanaged(InternPool.Index, C.DeclBlock),
 
     fn fail(dg: *DeclGen, comptime format: []const u8, args: anytype) error{ AnalysisFail, OutOfMemory } {
         @setCold(true);
@@ -586,12 +586,13 @@ pub const DeclGen = struct {
             try dg.renderType(writer, ty);
             try writer.writeByte(')');
         }
-        try writer.print("&__anon_{d}", .{@intFromEnum(decl_val)});
+        try writer.writeByte('&');
+        try renderAnonDeclName(writer, decl_val);
         if (need_typecast) try writer.writeByte(')');
 
         // Indicate that the anon decl should be rendered to the output so that
         // our reference above is not undefined.
-        try dg.anon_decl_deps.put(dg.gpa, decl_val, {});
+        _ = try dg.anon_decl_deps.getOrPut(dg.gpa, decl_val);
     }
 
     fn renderDeclValue(
@@ -1806,7 +1807,7 @@ pub const DeclGen = struct {
             .none => unreachable,
             .local, .new_local => |i| return w.print("t{d}", .{i}),
             .local_ref => |i| return w.print("&t{d}", .{i}),
-            .constant => unreachable,
+            .constant => |val| return renderAnonDeclName(w, val),
             .arg => |i| return w.print("a{d}", .{i}),
             .arg_array => |i| return dg.writeCValueMember(w, .{ .arg = i }, .{ .identifier = "array" }),
             .field => |i| return w.print("f{d}", .{i}),
@@ -1922,6 +1923,10 @@ pub const DeclGen = struct {
                 @intFromEnum(decl_index),
             });
         }
+    }
+
+    fn renderAnonDeclName(writer: anytype, anon_decl_val: InternPool.Index) !void {
+        return writer.print("__anon_{d}", .{@intFromEnum(anon_decl_val)});
     }
 
     fn renderTypeForBuiltinFnName(dg: *DeclGen, writer: anytype, ty: Type) !void {
@@ -2761,7 +2766,6 @@ pub fn genDecl(o: *Object) !void {
 
     const mod = o.dg.module;
     const decl_index = o.dg.decl_index.unwrap().?;
-    const decl_c_value = .{ .decl = decl_index };
     const decl = mod.declPtr(decl_index);
     const tv: TypedValue = .{ .ty = decl.ty, .val = (try decl.internValue(mod)).toValue() };
 
@@ -2785,6 +2789,7 @@ pub fn genDecl(o: *Object) !void {
         if (variable.is_threadlocal) try w.writeAll("zig_threadlocal ");
         if (mod.intern_pool.stringToSliceUnwrap(decl.@"linksection")) |s|
             try w.print("zig_linksection(\"{s}\", ", .{s});
+        const decl_c_value = .{ .decl = decl_index };
         try o.dg.renderTypeAndName(w, tv.ty, decl_c_value, .{}, decl.alignment, .complete);
         if (decl.@"linksection" != .none) try w.writeAll(", read, write)");
         try w.writeAll(" = ");
@@ -2793,22 +2798,35 @@ pub fn genDecl(o: *Object) !void {
         try o.indent_writer.insertNewline();
     } else {
         const is_global = o.dg.module.decl_exports.contains(decl_index);
-        const fwd_decl_writer = o.dg.fwd_decl.writer();
-
-        try fwd_decl_writer.writeAll(if (is_global) "zig_extern " else "static ");
-        try o.dg.renderTypeAndName(fwd_decl_writer, tv.ty, decl_c_value, Const, decl.alignment, .complete);
-        try fwd_decl_writer.writeAll(";\n");
-
-        const w = o.writer();
-        if (!is_global) try w.writeAll("static ");
-        if (mod.intern_pool.stringToSliceUnwrap(decl.@"linksection")) |s|
-            try w.print("zig_linksection(\"{s}\", ", .{s});
-        try o.dg.renderTypeAndName(w, tv.ty, decl_c_value, Const, decl.alignment, .complete);
-        if (decl.@"linksection" != .none) try w.writeAll(", read)");
-        try w.writeAll(" = ");
-        try o.dg.renderValue(w, tv.ty, tv.val, .StaticInitializer);
-        try w.writeAll(";\n");
+        const decl_c_value = .{ .decl = decl_index };
+        return genDeclValue(o, tv, is_global, decl_c_value, decl.alignment, decl.@"linksection");
     }
+}
+
+pub fn genDeclValue(
+    o: *Object,
+    tv: TypedValue,
+    is_global: bool,
+    decl_c_value: CValue,
+    alignment: Alignment,
+    link_section: InternPool.OptionalNullTerminatedString,
+) !void {
+    const fwd_decl_writer = o.dg.fwd_decl.writer();
+
+    try fwd_decl_writer.writeAll(if (is_global) "zig_extern " else "static ");
+    try o.dg.renderTypeAndName(fwd_decl_writer, tv.ty, decl_c_value, Const, alignment, .complete);
+    try fwd_decl_writer.writeAll(";\n");
+
+    const mod = o.dg.module;
+    const w = o.writer();
+    if (!is_global) try w.writeAll("static ");
+    if (mod.intern_pool.stringToSliceUnwrap(link_section)) |s|
+        try w.print("zig_linksection(\"{s}\", ", .{s});
+    try o.dg.renderTypeAndName(w, tv.ty, decl_c_value, Const, alignment, .complete);
+    if (link_section != .none) try w.writeAll(", read)");
+    try w.writeAll(" = ");
+    try o.dg.renderValue(w, tv.ty, tv.val, .StaticInitializer);
+    try w.writeAll(";\n");
 }
 
 pub fn genHeader(dg: *DeclGen) error{ AnalysisFail, OutOfMemory }!void {

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -818,6 +818,7 @@ pub const DeclGen = struct {
         const mod = self.module;
         switch (mod.intern_pool.indexToKey(ptr_val.toIntern()).ptr.addr) {
             .decl => |decl| return try self.constructDeclRef(ptr_ty, decl),
+            .anon_decl => @panic("TODO"),
             .mut_decl => |decl_mut| return try self.constructDeclRef(ptr_ty, decl_mut.decl),
             .int => |int| {
                 const ptr_id = self.spv.allocId();

--- a/src/link.zig
+++ b/src/link.zig
@@ -937,6 +937,20 @@ pub const File = struct {
         }
     }
 
+    pub fn getAnonDeclVAddr(base: *File, decl_val: InternPool.Index, reloc_info: RelocInfo) !u64 {
+        if (build_options.only_c) unreachable;
+        switch (base.tag) {
+            .coff => return @fieldParentPtr(Coff, "base", base).getAnonDeclVAddr(decl_val, reloc_info),
+            .elf => return @fieldParentPtr(Elf, "base", base).getAnonDeclVAddr(decl_val, reloc_info),
+            .macho => return @fieldParentPtr(MachO, "base", base).getAnonDeclVAddr(decl_val, reloc_info),
+            .plan9 => return @fieldParentPtr(Plan9, "base", base).getAnonDeclVAddr(decl_val, reloc_info),
+            .c => unreachable,
+            .wasm => return @fieldParentPtr(Wasm, "base", base).getAnonDeclVAddr(decl_val, reloc_info),
+            .spirv => unreachable,
+            .nvptx => unreachable,
+        }
+    }
+
     /// This function is called by the frontend before flush(). It communicates that
     /// `options.bin_file.emit` directory needs to be renamed from
     /// `[zig-cache]/tmp/[random]` to `[zig-cache]/o/[digest]`.

--- a/src/link.zig
+++ b/src/link.zig
@@ -937,6 +937,22 @@ pub const File = struct {
         }
     }
 
+    pub const LowerResult = @import("codegen.zig").Result;
+
+    pub fn lowerAnonDecl(base: *File, decl_val: InternPool.Index, src_loc: Module.SrcLoc) !LowerResult {
+        if (build_options.only_c) unreachable;
+        switch (base.tag) {
+            .coff => return @fieldParentPtr(Coff, "base", base).lowerAnonDecl(decl_val, src_loc),
+            .elf => return @fieldParentPtr(Elf, "base", base).lowerAnonDecl(decl_val, src_loc),
+            .macho => return @fieldParentPtr(MachO, "base", base).lowerAnonDecl(decl_val, src_loc),
+            .plan9 => return @fieldParentPtr(Plan9, "base", base).lowerAnonDecl(decl_val, src_loc),
+            .c => unreachable,
+            .wasm => return @fieldParentPtr(Wasm, "base", base).lowerAnonDecl(decl_val, src_loc),
+            .spirv => unreachable,
+            .nvptx => unreachable,
+        }
+    }
+
     pub fn getAnonDeclVAddr(base: *File, decl_val: InternPool.Index, reloc_info: RelocInfo) !u64 {
         if (build_options.only_c) unreachable;
         switch (base.tag) {

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -27,6 +27,9 @@ decl_table: std.AutoArrayHashMapUnmanaged(Module.Decl.Index, DeclBlock) = .{},
 /// While in progress, a separate buffer is used, and then when finished, the
 /// buffer is copied into this one.
 string_bytes: std.ArrayListUnmanaged(u8) = .{},
+/// Tracks all the anonymous decls that are used by all the decls so they can
+/// be rendered during flush().
+anon_decls: std.AutoArrayHashMapUnmanaged(InternPool.Index, DeclBlock) = .{},
 
 /// Optimization, `updateDecl` reuses this buffer rather than creating a new
 /// one with every call.
@@ -34,9 +37,6 @@ fwd_decl_buf: std.ArrayListUnmanaged(u8) = .{},
 /// Optimization, `updateDecl` reuses this buffer rather than creating a new
 /// one with every call.
 code_buf: std.ArrayListUnmanaged(u8) = .{},
-/// Optimization, `updateDecl` reuses this table rather than creating a new one
-/// with every call.
-scratch_anon_decl_deps: std.AutoArrayHashMapUnmanaged(InternPool.Index, void) = .{},
 /// Optimization, `flush` reuses this buffer rather than creating a new
 /// one with every call.
 lazy_fwd_decl_buf: std.ArrayListUnmanaged(u8) = .{},
@@ -45,7 +45,7 @@ lazy_fwd_decl_buf: std.ArrayListUnmanaged(u8) = .{},
 lazy_code_buf: std.ArrayListUnmanaged(u8) = .{},
 
 /// A reference into `string_bytes`.
-const String = struct {
+const String = extern struct {
     start: u32,
     len: u32,
 
@@ -54,8 +54,9 @@ const String = struct {
         .len = 0,
     };
 };
+
 /// Per-declaration data.
-const DeclBlock = struct {
+pub const DeclBlock = struct {
     code: String = String.empty,
     fwd_decl: String = String.empty,
     /// Each `Decl` stores a set of used `CType`s.  In `flush()`, we iterate
@@ -120,10 +121,14 @@ pub fn deinit(self: *C) void {
     }
     self.decl_table.deinit(gpa);
 
+    for (self.anon_decls.values()) |*db| {
+        db.deinit(gpa);
+    }
+    self.anon_decls.deinit(gpa);
+
     self.string_bytes.deinit(gpa);
     self.fwd_decl_buf.deinit(gpa);
     self.code_buf.deinit(gpa);
-    self.scratch_anon_decl_deps.deinit(gpa);
 }
 
 pub fn freeDecl(self: *C, decl_index: Module.Decl.Index) void {
@@ -158,57 +163,110 @@ pub fn updateFunc(
     lazy_fns.clearRetainingCapacity();
     fwd_decl.clearRetainingCapacity();
     code.clearRetainingCapacity();
-    self.scratch_anon_decl_deps.clearRetainingCapacity();
 
-    {
-        var function: codegen.Function = .{
-            .value_map = codegen.CValueMap.init(gpa),
-            .air = air,
-            .liveness = liveness,
-            .func_index = func_index,
-            .object = .{
-                .dg = .{
-                    .gpa = gpa,
-                    .module = module,
-                    .error_msg = null,
-                    .decl_index = decl_index.toOptional(),
-                    .is_naked_fn = decl.ty.fnCallingConvention(module) == .Naked,
-                    .fwd_decl = fwd_decl.toManaged(gpa),
-                    .ctypes = ctypes.*,
-                    .anon_decl_deps = self.scratch_anon_decl_deps,
-                },
-                .code = code.toManaged(gpa),
-                .indent_writer = undefined, // set later so we can get a pointer to object.code
+    var function: codegen.Function = .{
+        .value_map = codegen.CValueMap.init(gpa),
+        .air = air,
+        .liveness = liveness,
+        .func_index = func_index,
+        .object = .{
+            .dg = .{
+                .gpa = gpa,
+                .module = module,
+                .error_msg = null,
+                .decl_index = decl_index.toOptional(),
+                .is_naked_fn = decl.ty.fnCallingConvention(module) == .Naked,
+                .fwd_decl = fwd_decl.toManaged(gpa),
+                .ctypes = ctypes.*,
+                .anon_decl_deps = self.anon_decls,
             },
-            .lazy_fns = lazy_fns.*,
-        };
+            .code = code.toManaged(gpa),
+            .indent_writer = undefined, // set later so we can get a pointer to object.code
+        },
+        .lazy_fns = lazy_fns.*,
+    };
 
-        function.object.indent_writer = .{ .underlying_writer = function.object.code.writer() };
-        defer {
-            self.scratch_anon_decl_deps = function.object.dg.anon_decl_deps;
-            fwd_decl.* = function.object.dg.fwd_decl.moveToUnmanaged();
-            code.* = function.object.code.moveToUnmanaged();
-            function.deinit();
-        }
-
-        codegen.genFunc(&function) catch |err| switch (err) {
-            error.AnalysisFail => {
-                try module.failed_decls.put(gpa, decl_index, function.object.dg.error_msg.?);
-                return;
-            },
-            else => |e| return e,
-        };
-
-        ctypes.* = function.object.dg.ctypes.move();
-        lazy_fns.* = function.lazy_fns.move();
-
-        // Free excess allocated memory for this Decl.
-        ctypes.shrinkAndFree(gpa, ctypes.count());
-        lazy_fns.shrinkAndFree(gpa, lazy_fns.count());
-
-        gop.value_ptr.code = try self.addString(function.object.code.items);
-        gop.value_ptr.fwd_decl = try self.addString(function.object.dg.fwd_decl.items);
+    function.object.indent_writer = .{ .underlying_writer = function.object.code.writer() };
+    defer {
+        self.anon_decls = function.object.dg.anon_decl_deps;
+        fwd_decl.* = function.object.dg.fwd_decl.moveToUnmanaged();
+        code.* = function.object.code.moveToUnmanaged();
+        function.deinit();
     }
+
+    codegen.genFunc(&function) catch |err| switch (err) {
+        error.AnalysisFail => {
+            try module.failed_decls.put(gpa, decl_index, function.object.dg.error_msg.?);
+            return;
+        },
+        else => |e| return e,
+    };
+
+    ctypes.* = function.object.dg.ctypes.move();
+    lazy_fns.* = function.lazy_fns.move();
+
+    // Free excess allocated memory for this Decl.
+    ctypes.shrinkAndFree(gpa, ctypes.count());
+    lazy_fns.shrinkAndFree(gpa, lazy_fns.count());
+
+    gop.value_ptr.code = try self.addString(function.object.code.items);
+    gop.value_ptr.fwd_decl = try self.addString(function.object.dg.fwd_decl.items);
+}
+
+fn updateAnonDecl(self: *C, module: *Module, i: usize) !void {
+    const gpa = self.base.allocator;
+    const anon_decl = self.anon_decls.keys()[i];
+
+    const fwd_decl = &self.fwd_decl_buf;
+    const code = &self.code_buf;
+    fwd_decl.clearRetainingCapacity();
+    code.clearRetainingCapacity();
+
+    var object: codegen.Object = .{
+        .dg = .{
+            .gpa = gpa,
+            .module = module,
+            .error_msg = null,
+            .decl_index = .none,
+            .is_naked_fn = false,
+            .fwd_decl = fwd_decl.toManaged(gpa),
+            .ctypes = .{},
+            .anon_decl_deps = self.anon_decls,
+        },
+        .code = code.toManaged(gpa),
+        .indent_writer = undefined, // set later so we can get a pointer to object.code
+    };
+    object.indent_writer = .{ .underlying_writer = object.code.writer() };
+
+    defer {
+        self.anon_decls = object.dg.anon_decl_deps;
+        object.dg.ctypes.deinit(object.dg.gpa);
+        fwd_decl.* = object.dg.fwd_decl.moveToUnmanaged();
+        code.* = object.code.moveToUnmanaged();
+    }
+
+    const tv: @import("../TypedValue.zig") = .{
+        .ty = module.intern_pool.typeOf(anon_decl).toType(),
+        .val = anon_decl.toValue(),
+    };
+    const c_value: codegen.CValue = .{ .constant = anon_decl };
+    codegen.genDeclValue(&object, tv, false, c_value, .none, .none) catch |err| switch (err) {
+        error.AnalysisFail => {
+            @panic("TODO: C backend AnalysisFail on anonymous decl");
+            //try module.failed_decls.put(gpa, decl_index, object.dg.error_msg.?);
+            //return;
+        },
+        else => |e| return e,
+    };
+
+    // Free excess allocated memory for this Decl.
+    object.dg.ctypes.shrinkAndFree(gpa, object.dg.ctypes.count());
+
+    object.dg.anon_decl_deps.values()[i] = .{
+        .code = try self.addString(object.code.items),
+        .fwd_decl = try self.addString(object.dg.fwd_decl.items),
+        .ctypes = object.dg.ctypes.move(),
+    };
 }
 
 pub fn updateDecl(self: *C, module: *Module, decl_index: Module.Decl.Index) !void {
@@ -227,7 +285,6 @@ pub fn updateDecl(self: *C, module: *Module, decl_index: Module.Decl.Index) !voi
     ctypes.clearRetainingCapacity(gpa);
     fwd_decl.clearRetainingCapacity();
     code.clearRetainingCapacity();
-    self.scratch_anon_decl_deps.clearRetainingCapacity();
 
     var object: codegen.Object = .{
         .dg = .{
@@ -238,14 +295,14 @@ pub fn updateDecl(self: *C, module: *Module, decl_index: Module.Decl.Index) !voi
             .is_naked_fn = false,
             .fwd_decl = fwd_decl.toManaged(gpa),
             .ctypes = ctypes.*,
-            .anon_decl_deps = self.scratch_anon_decl_deps,
+            .anon_decl_deps = self.anon_decls,
         },
         .code = code.toManaged(gpa),
         .indent_writer = undefined, // set later so we can get a pointer to object.code
     };
     object.indent_writer = .{ .underlying_writer = object.code.writer() };
     defer {
-        self.scratch_anon_decl_deps = object.dg.anon_decl_deps;
+        self.anon_decls = object.dg.anon_decl_deps;
         object.dg.ctypes.deinit(object.dg.gpa);
         fwd_decl.* = object.dg.fwd_decl.moveToUnmanaged();
         code.* = object.code.moveToUnmanaged();
@@ -303,6 +360,13 @@ pub fn flushModule(self: *C, _: *Compilation, prog_node: *std.Progress.Node) !vo
     const gpa = self.base.allocator;
     const module = self.base.options.module.?;
 
+    {
+        var i: usize = 0;
+        while (i < self.anon_decls.count()) : (i += 1) {
+            try updateAnonDecl(self, module, i);
+        }
+    }
+
     // This code path happens exclusively with -ofmt=c. The flush logic for
     // emit-h is in `flushEmitH` below.
 
@@ -345,10 +409,15 @@ pub fn flushModule(self: *C, _: *Compilation, prog_node: *std.Progress.Node) !vo
         for (module.decl_exports.values()) |exports| for (exports.items) |@"export"|
             try export_names.put(gpa, @"export".opts.name, {});
 
-        const decl_keys = self.decl_table.keys();
-        for (decl_keys) |decl_index| {
+        for (self.anon_decls.values()) |*decl_block| {
+            try self.flushDeclBlock(&f, decl_block, export_names, .none);
+        }
+
+        for (self.decl_table.keys(), self.decl_table.values()) |decl_index, *decl_block| {
             assert(module.declPtr(decl_index).has_tv);
-            try self.flushDecl(&f, decl_index, export_names);
+            const decl = module.declPtr(decl_index);
+            const extern_symbol_name = if (decl.isExtern(module)) decl.name.toOptional() else .none;
+            try self.flushDeclBlock(&f, decl_block, export_names, extern_symbol_name);
         }
     }
 
@@ -358,8 +427,12 @@ pub fn flushModule(self: *C, _: *Compilation, prog_node: *std.Progress.Node) !vo
         assert(f.ctypes.count() == 0);
         try self.flushCTypes(&f, .none, f.lazy_ctypes);
 
-        for (self.decl_table.keys(), self.decl_table.values()) |decl_index, db| {
-            try self.flushCTypes(&f, decl_index.toOptional(), db.ctypes);
+        for (self.anon_decls.values()) |decl_block| {
+            try self.flushCTypes(&f, .none, decl_block.ctypes);
+        }
+
+        for (self.decl_table.keys(), self.decl_table.values()) |decl_index, decl_block| {
+            try self.flushCTypes(&f, decl_index.toOptional(), decl_block.ctypes);
         }
     }
 
@@ -377,10 +450,12 @@ pub fn flushModule(self: *C, _: *Compilation, prog_node: *std.Progress.Node) !vo
     f.file_size += lazy_fwd_decl_len;
 
     // Now the code.
+    const anon_decl_values = self.anon_decls.values();
     const decl_values = self.decl_table.values();
-    try f.all_buffers.ensureUnusedCapacity(gpa, 1 + decl_values.len);
+    try f.all_buffers.ensureUnusedCapacity(gpa, 1 + anon_decl_values.len + decl_values.len);
     f.appendBufAssumeCapacity(self.lazy_code_buf.items);
-    for (decl_values) |decl| f.appendBufAssumeCapacity(self.getString(decl.code));
+    for (anon_decl_values) |db| f.appendBufAssumeCapacity(self.getString(db.code));
+    for (decl_values) |db| f.appendBufAssumeCapacity(self.getString(db.code));
 
     const file = self.base.file.?;
     try file.setEndPos(f.file_size);
@@ -526,16 +601,14 @@ fn flushErrDecls(self: *C, ctypes: *codegen.CType.Store) FlushDeclError!void {
             .is_naked_fn = false,
             .fwd_decl = fwd_decl.toManaged(gpa),
             .ctypes = ctypes.*,
-            .anon_decl_deps = .{},
+            .anon_decl_deps = self.anon_decls,
         },
         .code = code.toManaged(gpa),
         .indent_writer = undefined, // set later so we can get a pointer to object.code
     };
     object.indent_writer = .{ .underlying_writer = object.code.writer() };
     defer {
-        // If this assert trips just handle the anon_decl_deps the same as
-        // `updateFunc()` does.
-        assert(object.dg.anon_decl_deps.count() == 0);
+        self.anon_decls = object.dg.anon_decl_deps;
         object.dg.ctypes.deinit(gpa);
         fwd_decl.* = object.dg.fwd_decl.moveToUnmanaged();
         code.* = object.code.moveToUnmanaged();
@@ -604,22 +677,22 @@ fn flushLazyFns(self: *C, f: *Flush, lazy_fns: codegen.LazyFnMap) FlushDeclError
     }
 }
 
-fn flushDecl(
+fn flushDeclBlock(
     self: *C,
     f: *Flush,
-    decl_index: Module.Decl.Index,
+    decl_block: *DeclBlock,
     export_names: std.AutoHashMapUnmanaged(InternPool.NullTerminatedString, void),
+    extern_symbol_name: InternPool.OptionalNullTerminatedString,
 ) FlushDeclError!void {
     const gpa = self.base.allocator;
-    const mod = self.base.options.module.?;
-    const decl = mod.declPtr(decl_index);
-
-    const decl_block = self.decl_table.getPtr(decl_index).?;
-
     try self.flushLazyFns(f, decl_block.lazy_fns);
     try f.all_buffers.ensureUnusedCapacity(gpa, 1);
-    if (!(decl.isExtern(mod) and export_names.contains(decl.name)))
+    fwd_decl: {
+        if (extern_symbol_name.unwrap()) |name| {
+            if (export_names.contains(name)) break :fwd_decl;
+        }
         f.appendBufAssumeCapacity(self.getString(decl_block.fwd_decl));
+    }
 }
 
 pub fn flushEmitH(module: *Module) !void {

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1727,6 +1727,27 @@ pub fn getDeclVAddr(self: *Coff, decl_index: Module.Decl.Index, reloc_info: link
     return 0;
 }
 
+pub fn getAnonDeclVAddr(
+    self: *Coff,
+    decl_val: InternPool.Index,
+    reloc_info: link.File.RelocInfo,
+) !u64 {
+    // This is basically the same as lowerUnnamedConst except it needs
+    // to return the same thing as `getDeclVAddr`
+    // example:
+    // const ty = mod.intern_pool.typeOf(decl_val).toType();
+    // const val = decl_val.toValue();
+    // The symbol name can be something like `__anon_{d}` with `@intFromEnum(decl_val)`.
+    // It doesn't have an owner decl because it's just an unnamed constant that might
+    // be used by more than one function, however, its address is being used so we need
+    // to put it in some location.
+    // ...
+    _ = self;
+    _ = decl_val;
+    _ = reloc_info;
+    _ = @panic("TODO: link/Coff getAnonDeclVAddr");
+}
+
 pub fn getGlobalSymbol(self: *Coff, name: []const u8, lib_name_name: ?[]const u8) !u32 {
     const gop = try self.getOrPutGlobalPtr(name);
     const global_index = self.getGlobalIndex(name).?;

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1727,13 +1727,8 @@ pub fn getDeclVAddr(self: *Coff, decl_index: Module.Decl.Index, reloc_info: link
     return 0;
 }
 
-pub fn getAnonDeclVAddr(
-    self: *Coff,
-    decl_val: InternPool.Index,
-    reloc_info: link.File.RelocInfo,
-) !u64 {
-    // This is basically the same as lowerUnnamedConst except it needs
-    // to return the same thing as `getDeclVAddr`
+pub fn lowerAnonDecl(self: *Coff, decl_val: InternPool.Index, src_loc: Module.SrcLoc) !codegen.Result {
+    // This is basically the same as lowerUnnamedConst.
     // example:
     // const ty = mod.intern_pool.typeOf(decl_val).toType();
     // const val = decl_val.toValue();
@@ -1742,6 +1737,13 @@ pub fn getAnonDeclVAddr(
     // be used by more than one function, however, its address is being used so we need
     // to put it in some location.
     // ...
+    _ = self;
+    _ = decl_val;
+    _ = src_loc;
+    _ = @panic("TODO: link/Coff lowerAnonDecl");
+}
+
+pub fn getAnonDeclVAddr(self: *Coff, decl_val: InternPool.Index, reloc_info: link.File.RelocInfo) !u64 {
     _ = self;
     _ = decl_val;
     _ = reloc_info;

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -82,6 +82,7 @@ atom_by_index_table: std.AutoHashMapUnmanaged(u32, Atom.Index) = .{},
 /// value assigned to label `foo` is an unnamed constant belonging/associated
 /// with `Decl` `main`, and lives as long as that `Decl`.
 unnamed_const_atoms: UnnamedConstTable = .{},
+anon_decls: AnonDeclTable = .{},
 
 /// A table of relocations indexed by the owning them `Atom`.
 /// Note that once we refactor `Atom`'s lifetime and ownership rules,
@@ -107,6 +108,7 @@ const HotUpdateState = struct {
     loaded_base_address: ?std.os.windows.HMODULE = null,
 };
 
+const AnonDeclTable = std.AutoHashMapUnmanaged(InternPool.Index, Atom.Index);
 const RelocTable = std.AutoArrayHashMapUnmanaged(Atom.Index, std.ArrayListUnmanaged(Relocation));
 const BaseRelocationTable = std.AutoArrayHashMapUnmanaged(Atom.Index, std.ArrayListUnmanaged(u32));
 const UnnamedConstTable = std.AutoArrayHashMapUnmanaged(Module.Decl.Index, std.ArrayListUnmanaged(Atom.Index));
@@ -323,6 +325,7 @@ pub fn deinit(self: *Coff) void {
         atoms.deinit(gpa);
     }
     self.unnamed_const_atoms.deinit(gpa);
+    self.anon_decls.deinit(gpa);
 
     for (self.relocs.values()) |*relocs| {
         relocs.deinit(gpa);
@@ -1077,45 +1080,53 @@ pub fn updateFunc(self: *Coff, mod: *Module, func_index: InternPool.Index, air: 
 
 pub fn lowerUnnamedConst(self: *Coff, tv: TypedValue, decl_index: Module.Decl.Index) !u32 {
     const gpa = self.base.allocator;
-    var code_buffer = std.ArrayList(u8).init(gpa);
-    defer code_buffer.deinit();
-
     const mod = self.base.options.module.?;
     const decl = mod.declPtr(decl_index);
-
     const gop = try self.unnamed_const_atoms.getOrPut(gpa, decl_index);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
     const unnamed_consts = gop.value_ptr;
-
-    const atom_index = try self.createAtom();
-
-    const sym_name = blk: {
-        const decl_name = mod.intern_pool.stringToSlice(try decl.getFullyQualifiedName(mod));
-
-        const index = unnamed_consts.items.len;
-        break :blk try std.fmt.allocPrint(gpa, "__unnamed_{s}_{d}", .{ decl_name, index });
-    };
+    const decl_name = mod.intern_pool.stringToSlice(try decl.getFullyQualifiedName(mod));
+    const index = unnamed_consts.items.len;
+    const sym_name = try std.fmt.allocPrint(gpa, "__unnamed_{s}_{d}", .{ decl_name, index });
     defer gpa.free(sym_name);
-    {
-        const atom = self.getAtom(atom_index);
-        const sym = atom.getSymbolPtr(self);
-        try self.setSymbolName(sym, sym_name);
-        sym.section_number = @as(coff.SectionNumber, @enumFromInt(self.rdata_section_index.? + 1));
-    }
-
-    const res = try codegen.generateSymbol(&self.base, decl.srcLoc(mod), tv, &code_buffer, .none, .{
-        .parent_atom_index = self.getAtom(atom_index).getSymbolIndex().?,
-    });
-    var code = switch (res) {
-        .ok => code_buffer.items,
+    const atom_index = switch (try self.lowerConst(sym_name, tv, self.rdata_section_index.?, decl.srcLoc(mod))) {
+        .ok => |atom_index| atom_index,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try mod.failed_decls.put(mod.gpa, decl_index, em);
             log.err("{s}", .{em.msg});
             return error.CodegenFail;
         },
+    };
+    try unnamed_consts.append(gpa, atom_index);
+    return self.getAtom(atom_index).getSymbolIndex().?;
+}
+
+const LowerConstResult = union(enum) {
+    ok: Atom.Index,
+    fail: *Module.ErrorMsg,
+};
+
+fn lowerConst(self: *Coff, name: []const u8, tv: TypedValue, sect_id: u16, src_loc: Module.SrcLoc) !LowerConstResult {
+    const gpa = self.base.allocator;
+
+    var code_buffer = std.ArrayList(u8).init(gpa);
+    defer code_buffer.deinit();
+
+    const mod = self.base.options.module.?;
+    const atom_index = try self.createAtom();
+    const sym = self.getAtom(atom_index).getSymbolPtr(self);
+    try self.setSymbolName(sym, name);
+    sym.section_number = @as(coff.SectionNumber, @enumFromInt(sect_id + 1));
+
+    const res = try codegen.generateSymbol(&self.base, src_loc, tv, &code_buffer, .none, .{
+        .parent_atom_index = self.getAtom(atom_index).getSymbolIndex().?,
+    });
+    var code = switch (res) {
+        .ok => code_buffer.items,
+        .fail => |em| return .{ .fail = em },
     };
 
     const required_alignment: u32 = @intCast(tv.ty.abiAlignment(mod).toByteUnits(0));
@@ -1124,14 +1135,12 @@ pub fn lowerUnnamedConst(self: *Coff, tv: TypedValue, decl_index: Module.Decl.In
     atom.getSymbolPtr(self).value = try self.allocateAtom(atom_index, atom.size, required_alignment);
     errdefer self.freeAtom(atom_index);
 
-    try unnamed_consts.append(gpa, atom_index);
-
-    log.debug("allocated atom for {s} at 0x{x}", .{ sym_name, atom.getSymbol(self).value });
+    log.debug("allocated atom for {s} at 0x{x}", .{ name, atom.getSymbol(self).value });
     log.debug("  (required alignment 0x{x})", .{required_alignment});
 
     try self.writeAtom(atom_index, code);
 
-    return atom.getSymbolIndex().?;
+    return .{ .ok = atom_index };
 }
 
 pub fn updateDecl(
@@ -1737,17 +1746,51 @@ pub fn lowerAnonDecl(self: *Coff, decl_val: InternPool.Index, src_loc: Module.Sr
     // be used by more than one function, however, its address is being used so we need
     // to put it in some location.
     // ...
-    _ = self;
-    _ = decl_val;
-    _ = src_loc;
-    _ = @panic("TODO: link/Coff lowerAnonDecl");
+    const gpa = self.base.allocator;
+    const gop = try self.anon_decls.getOrPut(gpa, decl_val);
+    if (!gop.found_existing) {
+        const mod = self.base.options.module.?;
+        const ty = mod.intern_pool.typeOf(decl_val).toType();
+        const val = decl_val.toValue();
+        const tv = TypedValue{ .ty = ty, .val = val };
+        const name = try std.fmt.allocPrint(gpa, "__anon_{d}", .{@intFromEnum(decl_val)});
+        defer gpa.free(name);
+        const res = self.lowerConst(name, tv, self.rdata_section_index.?, src_loc) catch |err| switch (err) {
+            else => {
+                // TODO improve error message
+                const em = try Module.ErrorMsg.create(gpa, src_loc, "lowerAnonDecl failed with error: {s}", .{
+                    @errorName(err),
+                });
+                return .{ .fail = em };
+            },
+        };
+        const atom_index = switch (res) {
+            .ok => |atom_index| atom_index,
+            .fail => |em| return .{ .fail = em },
+        };
+        gop.value_ptr.* = atom_index;
+    }
+    return .ok;
 }
 
 pub fn getAnonDeclVAddr(self: *Coff, decl_val: InternPool.Index, reloc_info: link.File.RelocInfo) !u64 {
-    _ = self;
-    _ = decl_val;
-    _ = reloc_info;
-    _ = @panic("TODO: link/Coff getAnonDeclVAddr");
+    assert(self.llvm_object == null);
+
+    const this_atom_index = self.anon_decls.get(decl_val).?;
+    const sym_index = self.getAtom(this_atom_index).getSymbolIndex().?;
+    const atom_index = self.getAtomIndexForSymbol(.{ .sym_index = reloc_info.parent_atom_index, .file = null }).?;
+    const target = SymbolWithLoc{ .sym_index = sym_index, .file = null };
+    try Atom.addRelocation(self, atom_index, .{
+        .type = .direct,
+        .target = target,
+        .offset = @as(u32, @intCast(reloc_info.offset)),
+        .addend = reloc_info.addend,
+        .pcrel = false,
+        .length = 3,
+    });
+    try Atom.addBaseRelocation(self, atom_index, @as(u32, @intCast(reloc_info.offset)));
+
+    return 0;
 }
 
 pub fn getGlobalSymbol(self: *Coff, name: []const u8, lib_name_name: ?[]const u8) !u32 {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -348,6 +348,27 @@ pub fn getDeclVAddr(self: *Elf, decl_index: Module.Decl.Index, reloc_info: link.
     return vaddr;
 }
 
+pub fn getAnonDeclVAddr(
+    self: *Elf,
+    decl_val: InternPool.Index,
+    reloc_info: link.File.RelocInfo,
+) !u64 {
+    // This is basically the same as lowerUnnamedConst except it needs
+    // to return the same thing as `getDeclVAddr`
+    // example:
+    // const ty = mod.intern_pool.typeOf(decl_val).toType();
+    // const val = decl_val.toValue();
+    // The symbol name can be something like `__anon_{d}` with `@intFromEnum(decl_val)`.
+    // It doesn't have an owner decl because it's just an unnamed constant that might
+    // be used by more than one function, however, its address is being used so we need
+    // to put it in some location.
+    // ...
+    _ = self;
+    _ = decl_val;
+    _ = reloc_info;
+    _ = @panic("TODO: link/Elf getAnonDeclVAddr");
+}
+
 /// Returns end pos of collision, if any.
 fn detectAllocCollision(self: *Elf, start: u64, size: u64) ?u64 {
     const small_ptr = self.ptr_width == .p32;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -337,7 +337,6 @@ pub fn deinit(self: *Elf) void {
 
 pub fn getDeclVAddr(self: *Elf, decl_index: Module.Decl.Index, reloc_info: link.File.RelocInfo) !u64 {
     assert(self.llvm_object == null);
-
     const this_sym_index = try self.getOrCreateMetadataForDecl(decl_index);
     const this_sym = self.symbol(this_sym_index);
     const vaddr = this_sym.value;
@@ -347,7 +346,6 @@ pub fn getDeclVAddr(self: *Elf, decl_index: Module.Decl.Index, reloc_info: link.
         .r_info = (@as(u64, @intCast(this_sym.esym_index)) << 32) | elf.R_X86_64_64,
         .r_addend = reloc_info.addend,
     });
-
     return vaddr;
 }
 
@@ -389,6 +387,7 @@ pub fn lowerAnonDecl(self: *Elf, decl_val: InternPool.Index, src_loc: Module.Src
 }
 
 pub fn getAnonDeclVAddr(self: *Elf, decl_val: InternPool.Index, reloc_info: link.File.RelocInfo) !u64 {
+    assert(self.llvm_object == null);
     const sym_index = self.anon_decls.get(decl_val).?;
     const sym = self.symbol(sym_index);
     const vaddr = sym.value;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -155,12 +155,14 @@ last_atom_and_free_list_table: std.AutoArrayHashMapUnmanaged(u16, LastAtomAndFre
 /// value assigned to label `foo` is an unnamed constant belonging/associated
 /// with `Decl` `main`, and lives as long as that `Decl`.
 unnamed_consts: UnnamedConstTable = .{},
+anon_decls: AnonDeclTable = .{},
 
 comdat_groups: std.ArrayListUnmanaged(ComdatGroup) = .{},
 comdat_groups_owners: std.ArrayListUnmanaged(ComdatGroupOwner) = .{},
 comdat_groups_table: std.AutoHashMapUnmanaged(u32, ComdatGroupOwner.Index) = .{},
 
 const UnnamedConstTable = std.AutoHashMapUnmanaged(Module.Decl.Index, std.ArrayListUnmanaged(Symbol.Index));
+const AnonDeclTable = std.AutoHashMapUnmanaged(InternPool.Index, Symbol.Index);
 const LazySymbolTable = std.AutoArrayHashMapUnmanaged(Module.Decl.OptionalIndex, LazySymbolMetadata);
 
 /// When allocating, the ideal_capacity is calculated by
@@ -321,6 +323,7 @@ pub fn deinit(self: *Elf) void {
         }
         self.unnamed_consts.deinit(gpa);
     }
+    self.anon_decls.deinit(gpa);
 
     if (self.dwarf) |*dw| {
         dw.deinit();
@@ -348,13 +351,8 @@ pub fn getDeclVAddr(self: *Elf, decl_index: Module.Decl.Index, reloc_info: link.
     return vaddr;
 }
 
-pub fn getAnonDeclVAddr(
-    self: *Elf,
-    decl_val: InternPool.Index,
-    reloc_info: link.File.RelocInfo,
-) !u64 {
-    // This is basically the same as lowerUnnamedConst except it needs
-    // to return the same thing as `getDeclVAddr`
+pub fn lowerAnonDecl(self: *Elf, decl_val: InternPool.Index, src_loc: Module.SrcLoc) !codegen.Result {
+    // This is basically the same as lowerUnnamedConst.
     // example:
     // const ty = mod.intern_pool.typeOf(decl_val).toType();
     // const val = decl_val.toValue();
@@ -363,10 +361,44 @@ pub fn getAnonDeclVAddr(
     // be used by more than one function, however, its address is being used so we need
     // to put it in some location.
     // ...
-    _ = self;
-    _ = decl_val;
-    _ = reloc_info;
-    _ = @panic("TODO: link/Elf getAnonDeclVAddr");
+    const gpa = self.base.allocator;
+    const gop = try self.anon_decls.getOrPut(gpa, decl_val);
+    if (!gop.found_existing) {
+        const mod = self.base.options.module.?;
+        const ty = mod.intern_pool.typeOf(decl_val).toType();
+        const val = decl_val.toValue();
+        const tv = TypedValue{ .ty = ty, .val = val };
+        const name = try std.fmt.allocPrint(gpa, "__anon_{d}", .{@intFromEnum(decl_val)});
+        defer gpa.free(name);
+        const res = self.lowerConst(name, tv, self.rodata_section_index.?, src_loc) catch |err| switch (err) {
+            else => {
+                // TODO improve error message
+                const em = try Module.ErrorMsg.create(gpa, src_loc, "lowerAnonDecl failed with error: {s}", .{
+                    @errorName(err),
+                });
+                return .{ .fail = em };
+            },
+        };
+        const sym_index = switch (res) {
+            .ok => |sym_index| sym_index,
+            .fail => |em| return .{ .fail = em },
+        };
+        gop.value_ptr.* = sym_index;
+    }
+    return .ok;
+}
+
+pub fn getAnonDeclVAddr(self: *Elf, decl_val: InternPool.Index, reloc_info: link.File.RelocInfo) !u64 {
+    const sym_index = self.anon_decls.get(decl_val).?;
+    const sym = self.symbol(sym_index);
+    const vaddr = sym.value;
+    const parent_atom = self.symbol(reloc_info.parent_atom_index).atom(self).?;
+    try parent_atom.addReloc(self, .{
+        .r_offset = reloc_info.offset,
+        .r_info = (@as(u64, @intCast(sym.esym_index)) << 32) | elf.R_X86_64_64,
+        .r_addend = reloc_info.addend,
+    });
+    return vaddr;
 }
 
 /// Returns end pos of collision, if any.
@@ -3126,36 +3158,19 @@ fn updateLazySymbol(self: *Elf, sym: link.File.LazySymbol, symbol_index: Symbol.
 
 pub fn lowerUnnamedConst(self: *Elf, typed_value: TypedValue, decl_index: Module.Decl.Index) !u32 {
     const gpa = self.base.allocator;
-
-    var code_buffer = std.ArrayList(u8).init(gpa);
-    defer code_buffer.deinit();
-
     const mod = self.base.options.module.?;
     const gop = try self.unnamed_consts.getOrPut(gpa, decl_index);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
     const unnamed_consts = gop.value_ptr;
-
     const decl = mod.declPtr(decl_index);
-    const name_str_index = blk: {
-        const decl_name = mod.intern_pool.stringToSlice(try decl.getFullyQualifiedName(mod));
-        const index = unnamed_consts.items.len;
-        const name = try std.fmt.allocPrint(gpa, "__unnamed_{s}_{d}", .{ decl_name, index });
-        defer gpa.free(name);
-        break :blk try self.strtab.insert(gpa, name);
-    };
-
-    const zig_module = self.file(self.zig_module_index.?).?.zig_module;
-    const sym_index = try zig_module.addAtom(self);
-
-    const res = try codegen.generateSymbol(&self.base, decl.srcLoc(mod), typed_value, &code_buffer, .{
-        .none = {},
-    }, .{
-        .parent_atom_index = sym_index,
-    });
-    const code = switch (res) {
-        .ok => code_buffer.items,
+    const decl_name = mod.intern_pool.stringToSlice(try decl.getFullyQualifiedName(mod));
+    const index = unnamed_consts.items.len;
+    const name = try std.fmt.allocPrint(gpa, "__unnamed_{s}_{d}", .{ decl_name, index });
+    defer gpa.free(name);
+    const sym_index = switch (try self.lowerConst(name, typed_value, self.rodata_section_index.?, decl.srcLoc(mod))) {
+        .ok => |sym_index| sym_index,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try mod.failed_decls.put(mod.gpa, decl_index, em);
@@ -3163,13 +3178,48 @@ pub fn lowerUnnamedConst(self: *Elf, typed_value: TypedValue, decl_index: Module
             return error.CodegenFail;
         },
     };
+    const sym = self.symbol(sym_index);
+    try unnamed_consts.append(gpa, sym.atom_index);
+    return sym_index;
+}
 
-    const required_alignment = typed_value.ty.abiAlignment(mod);
-    const shdr_index = self.rodata_section_index.?;
-    const phdr_index = self.phdr_to_shdr_table.get(shdr_index).?;
+const LowerConstResult = union(enum) {
+    ok: Symbol.Index,
+    fail: *Module.ErrorMsg,
+};
+
+fn lowerConst(
+    self: *Elf,
+    name: []const u8,
+    tv: TypedValue,
+    output_section_index: u16,
+    src_loc: Module.SrcLoc,
+) !LowerConstResult {
+    const gpa = self.base.allocator;
+
+    var code_buffer = std.ArrayList(u8).init(gpa);
+    defer code_buffer.deinit();
+
+    const mod = self.base.options.module.?;
+    const zig_module = self.file(self.zig_module_index.?).?.zig_module;
+    const sym_index = try zig_module.addAtom(self);
+
+    const res = try codegen.generateSymbol(&self.base, src_loc, tv, &code_buffer, .{
+        .none = {},
+    }, .{
+        .parent_atom_index = sym_index,
+    });
+    const code = switch (res) {
+        .ok => code_buffer.items,
+        .fail => |em| return .{ .fail = em },
+    };
+
+    const required_alignment = tv.ty.abiAlignment(mod);
+    const phdr_index = self.phdr_to_shdr_table.get(output_section_index).?;
     const local_sym = self.symbol(sym_index);
+    const name_str_index = try self.strtab.insert(gpa, name);
     local_sym.name_offset = name_str_index;
-    local_sym.output_section_index = self.rodata_section_index.?;
+    local_sym.output_section_index = output_section_index;
     const local_esym = &zig_module.local_esyms.items[local_sym.esym_index];
     local_esym.st_name = name_str_index;
     local_esym.st_info |= elf.STT_OBJECT;
@@ -3179,21 +3229,20 @@ pub fn lowerUnnamedConst(self: *Elf, typed_value: TypedValue, decl_index: Module
     atom_ptr.name_offset = name_str_index;
     atom_ptr.alignment = required_alignment;
     atom_ptr.size = code.len;
-    atom_ptr.output_section_index = self.rodata_section_index.?;
+    atom_ptr.output_section_index = output_section_index;
 
     try atom_ptr.allocate(self);
+    // TODO rename and re-audit this method
     errdefer self.freeDeclMetadata(sym_index);
 
     local_sym.value = atom_ptr.value;
     local_esym.st_value = atom_ptr.value;
 
-    try unnamed_consts.append(gpa, atom_ptr.atom_index);
-
     const section_offset = atom_ptr.value - self.phdrs.items[phdr_index].p_vaddr;
-    const file_offset = self.shdrs.items[shdr_index].sh_offset + section_offset;
+    const file_offset = self.shdrs.items[output_section_index].sh_offset + section_offset;
     try self.base.file.?.pwriteAll(code, file_offset);
 
-    return sym_index;
+    return .{ .ok = sym_index };
 }
 
 pub fn updateDeclExports(

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2840,6 +2840,27 @@ pub fn getDeclVAddr(self: *MachO, decl_index: Module.Decl.Index, reloc_info: Fil
     return 0;
 }
 
+pub fn getAnonDeclVAddr(
+    self: *MachO,
+    decl_val: InternPool.Index,
+    reloc_info: link.File.RelocInfo,
+) !u64 {
+    // This is basically the same as lowerUnnamedConst except it needs
+    // to return the same thing as `getDeclVAddr`
+    // example:
+    // const ty = mod.intern_pool.typeOf(decl_val).toType();
+    // const val = decl_val.toValue();
+    // The symbol name can be something like `__anon_{d}` with `@intFromEnum(decl_val)`.
+    // It doesn't have an owner decl because it's just an unnamed constant that might
+    // be used by more than one function, however, its address is being used so we need
+    // to put it in some location.
+    // ...
+    _ = self;
+    _ = decl_val;
+    _ = reloc_info;
+    _ = @panic("TODO: link/MachO getAnonDeclVAddr");
+}
+
 fn populateMissingMetadata(self: *MachO) !void {
     assert(self.mode == .incremental);
 

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2840,13 +2840,8 @@ pub fn getDeclVAddr(self: *MachO, decl_index: Module.Decl.Index, reloc_info: Fil
     return 0;
 }
 
-pub fn getAnonDeclVAddr(
-    self: *MachO,
-    decl_val: InternPool.Index,
-    reloc_info: link.File.RelocInfo,
-) !u64 {
-    // This is basically the same as lowerUnnamedConst except it needs
-    // to return the same thing as `getDeclVAddr`
+pub fn lowerAnonDecl(self: *MachO, decl_val: InternPool.Index, src_loc: Module.SrcLoc) !codegen.Result {
+    // This is basically the same as lowerUnnamedConst.
     // example:
     // const ty = mod.intern_pool.typeOf(decl_val).toType();
     // const val = decl_val.toValue();
@@ -2855,6 +2850,13 @@ pub fn getAnonDeclVAddr(
     // be used by more than one function, however, its address is being used so we need
     // to put it in some location.
     // ...
+    _ = self;
+    _ = decl_val;
+    _ = src_loc;
+    _ = @panic("TODO: link/MachO lowerAnonDecl");
+}
+
+pub fn getAnonDeclVAddr(self: *MachO, decl_val: InternPool.Index, reloc_info: link.File.RelocInfo) !u64 {
     _ = self;
     _ = decl_val;
     _ = reloc_info;

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -109,6 +109,7 @@ atom_by_index_table: std.AutoHashMapUnmanaged(u32, Atom.Index) = .{},
 /// value assigned to label `foo` is an unnamed constant belonging/associated
 /// with `Decl` `main`, and lives as long as that `Decl`.
 unnamed_const_atoms: UnnamedConstTable = .{},
+anon_decls: AnonDeclTable = .{},
 
 /// A table of relocations indexed by the owning them `Atom`.
 /// Note that once we refactor `Atom`'s lifetime and ownership rules,
@@ -1899,6 +1900,7 @@ pub fn deinit(self: *MachO) void {
         atoms.deinit(gpa);
     }
     self.unnamed_const_atoms.deinit(gpa);
+    self.anon_decls.deinit(gpa);
 
     self.atom_by_index_table.deinit(gpa);
 
@@ -2172,39 +2174,19 @@ pub fn updateFunc(self: *MachO, mod: *Module, func_index: InternPool.Index, air:
 
 pub fn lowerUnnamedConst(self: *MachO, typed_value: TypedValue, decl_index: Module.Decl.Index) !u32 {
     const gpa = self.base.allocator;
-
-    var code_buffer = std.ArrayList(u8).init(gpa);
-    defer code_buffer.deinit();
-
     const mod = self.base.options.module.?;
     const gop = try self.unnamed_const_atoms.getOrPut(gpa, decl_index);
     if (!gop.found_existing) {
         gop.value_ptr.* = .{};
     }
     const unnamed_consts = gop.value_ptr;
-
     const decl = mod.declPtr(decl_index);
     const decl_name = mod.intern_pool.stringToSlice(try decl.getFullyQualifiedName(mod));
-
-    const name_str_index = blk: {
-        const index = unnamed_consts.items.len;
-        const name = try std.fmt.allocPrint(gpa, "___unnamed_{s}_{d}", .{ decl_name, index });
-        defer gpa.free(name);
-        break :blk try self.strtab.insert(gpa, name);
-    };
-    const name = self.strtab.get(name_str_index).?;
-
-    log.debug("allocating symbol indexes for {s}", .{name});
-
-    const sym_index = try self.allocateSymbol();
-    const atom_index = try self.createAtom(sym_index, .{});
-    try self.atom_by_index_table.putNoClobber(gpa, sym_index, atom_index);
-
-    const res = try codegen.generateSymbol(&self.base, decl.srcLoc(mod), typed_value, &code_buffer, .none, .{
-        .parent_atom_index = self.getAtom(atom_index).getSymbolIndex().?,
-    });
-    var code = switch (res) {
-        .ok => code_buffer.items,
+    const index = unnamed_consts.items.len;
+    const name = try std.fmt.allocPrint(gpa, "___unnamed_{s}_{d}", .{ decl_name, index });
+    defer gpa.free(name);
+    const atom_index = switch (try self.lowerConst(name, typed_value, self.data_const_section_index.?, decl.srcLoc(mod))) {
+        .ok => |atom_index| atom_index,
         .fail => |em| {
             decl.analysis = .codegen_failure;
             try mod.failed_decls.put(mod.gpa, decl_index, em);
@@ -2212,28 +2194,63 @@ pub fn lowerUnnamedConst(self: *MachO, typed_value: TypedValue, decl_index: Modu
             return error.CodegenFail;
         },
     };
+    try unnamed_consts.append(gpa, atom_index);
+    const atom = self.getAtomPtr(atom_index);
+    return atom.getSymbolIndex().?;
+}
 
-    const required_alignment = typed_value.ty.abiAlignment(mod);
+const LowerConstResult = union(enum) {
+    ok: Atom.Index,
+    fail: *Module.ErrorMsg,
+};
+
+fn lowerConst(
+    self: *MachO,
+    name: []const u8,
+    tv: TypedValue,
+    sect_id: u8,
+    src_loc: Module.SrcLoc,
+) !LowerConstResult {
+    const gpa = self.base.allocator;
+
+    var code_buffer = std.ArrayList(u8).init(gpa);
+    defer code_buffer.deinit();
+
+    const mod = self.base.options.module.?;
+
+    log.debug("allocating symbol indexes for {s}", .{name});
+
+    const sym_index = try self.allocateSymbol();
+    const atom_index = try self.createAtom(sym_index, .{});
+    try self.atom_by_index_table.putNoClobber(gpa, sym_index, atom_index);
+
+    const res = try codegen.generateSymbol(&self.base, src_loc, tv, &code_buffer, .none, .{
+        .parent_atom_index = self.getAtom(atom_index).getSymbolIndex().?,
+    });
+    var code = switch (res) {
+        .ok => code_buffer.items,
+        .fail => |em| return .{ .fail = em },
+    };
+
+    const required_alignment = tv.ty.abiAlignment(mod);
     const atom = self.getAtomPtr(atom_index);
     atom.size = code.len;
     // TODO: work out logic for disambiguating functions from function pointers
     // const sect_id = self.getDeclOutputSection(decl_index);
-    const sect_id = self.data_const_section_index.?;
     const symbol = atom.getSymbolPtr(self);
+    const name_str_index = try self.strtab.insert(gpa, name);
     symbol.n_strx = name_str_index;
     symbol.n_type = macho.N_SECT;
     symbol.n_sect = sect_id + 1;
     symbol.n_value = try self.allocateAtom(atom_index, code.len, required_alignment);
     errdefer self.freeAtom(atom_index);
 
-    try unnamed_consts.append(gpa, atom_index);
-
     log.debug("allocated atom for {s} at 0x{x}", .{ name, symbol.n_value });
     log.debug("  (required alignment 0x{x})", .{required_alignment});
 
     try self.writeAtom(atom_index, code);
 
-    return atom.getSymbolIndex().?;
+    return .{ .ok = atom_index };
 }
 
 pub fn updateDecl(self: *MachO, mod: *Module, decl_index: Module.Decl.Index) !void {
@@ -2850,17 +2867,50 @@ pub fn lowerAnonDecl(self: *MachO, decl_val: InternPool.Index, src_loc: Module.S
     // be used by more than one function, however, its address is being used so we need
     // to put it in some location.
     // ...
-    _ = self;
-    _ = decl_val;
-    _ = src_loc;
-    _ = @panic("TODO: link/MachO lowerAnonDecl");
+    const gpa = self.base.allocator;
+    const gop = try self.anon_decls.getOrPut(gpa, decl_val);
+    if (!gop.found_existing) {
+        const mod = self.base.options.module.?;
+        const ty = mod.intern_pool.typeOf(decl_val).toType();
+        const val = decl_val.toValue();
+        const tv = TypedValue{ .ty = ty, .val = val };
+        const name = try std.fmt.allocPrint(gpa, "__anon_{d}", .{@intFromEnum(decl_val)});
+        defer gpa.free(name);
+        const res = self.lowerConst(name, tv, self.data_const_section_index.?, src_loc) catch |err| switch (err) {
+            else => {
+                // TODO improve error message
+                const em = try Module.ErrorMsg.create(gpa, src_loc, "lowerAnonDecl failed with error: {s}", .{
+                    @errorName(err),
+                });
+                return .{ .fail = em };
+            },
+        };
+        const atom_index = switch (res) {
+            .ok => |atom_index| atom_index,
+            .fail => |em| return .{ .fail = em },
+        };
+        gop.value_ptr.* = atom_index;
+    }
+    return .ok;
 }
 
 pub fn getAnonDeclVAddr(self: *MachO, decl_val: InternPool.Index, reloc_info: link.File.RelocInfo) !u64 {
-    _ = self;
-    _ = decl_val;
-    _ = reloc_info;
-    _ = @panic("TODO: link/MachO getAnonDeclVAddr");
+    assert(self.llvm_object == null);
+
+    const this_atom_index = self.anon_decls.get(decl_val).?;
+    const sym_index = self.getAtom(this_atom_index).getSymbolIndex().?;
+    const atom_index = self.getAtomIndexForSymbol(.{ .sym_index = reloc_info.parent_atom_index }).?;
+    try Atom.addRelocation(self, atom_index, .{
+        .type = .unsigned,
+        .target = .{ .sym_index = sym_index },
+        .offset = @as(u32, @intCast(reloc_info.offset)),
+        .addend = reloc_info.addend,
+        .pcrel = false,
+        .length = 3,
+    });
+    try Atom.addRebase(self, atom_index, @as(u32, @intCast(reloc_info.offset)));
+
+    return 0;
 }
 
 fn populateMissingMetadata(self: *MachO) !void {
@@ -5412,6 +5462,7 @@ const DeclMetadata = struct {
     }
 };
 
+const AnonDeclTable = std.AutoHashMapUnmanaged(InternPool.Index, Atom.Index);
 const BindingTable = std.AutoArrayHashMapUnmanaged(Atom.Index, std.ArrayListUnmanaged(Atom.Binding));
 const UnnamedConstTable = std.AutoArrayHashMapUnmanaged(Module.Decl.Index, std.ArrayListUnmanaged(Atom.Index));
 const RebaseTable = std.AutoArrayHashMapUnmanaged(Atom.Index, std.ArrayListUnmanaged(u32));

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -1418,6 +1418,27 @@ pub fn getDeclVAddr(
     return undefined;
 }
 
+pub fn getAnonDeclVAddr(
+    self: *Plan9,
+    decl_val: InternPool.Index,
+    reloc_info: link.File.RelocInfo,
+) !u64 {
+    // This is basically the same as lowerUnnamedConst except it needs
+    // to return the same thing as `getDeclVAddr`
+    // example:
+    // const ty = mod.intern_pool.typeOf(decl_val).toType();
+    // const val = decl_val.toValue();
+    // The symbol name can be something like `__anon_{d}` with `@intFromEnum(decl_val)`.
+    // It doesn't have an owner decl because it's just an unnamed constant that might
+    // be used by more than one function, however, its address is being used so we need
+    // to put it in some location.
+    // ...
+    _ = self;
+    _ = decl_val;
+    _ = reloc_info;
+    _ = @panic("TODO: link/Plan9 getAnonDeclVAddr");
+}
+
 pub fn addReloc(self: *Plan9, parent_index: Atom.Index, reloc: Reloc) !void {
     const gop = try self.relocs.getOrPut(self.base.allocator, parent_index);
     if (!gop.found_existing) {

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -82,6 +82,8 @@ unnamed_const_atoms: UnnamedConstTable = .{},
 
 lazy_syms: LazySymbolTable = .{},
 
+anon_decls: std.AutoHashMapUnmanaged(InternPool.Index, Atom.Index) = .{},
+
 relocs: std.AutoHashMapUnmanaged(Atom.Index, std.ArrayListUnmanaged(Reloc)) = .{},
 hdr: aout.ExecHdr = undefined,
 
@@ -166,6 +168,9 @@ pub const Atom = struct {
             code_len: usize,
             decl_index: Module.Decl.Index,
         },
+        fn fromSlice(slice: []u8) CodePtr {
+            return .{ .code_ptr = slice.ptr, .other = .{ .code_len = slice.len } };
+        }
         fn getCode(self: CodePtr, plan9: *const Plan9) []u8 {
             const mod = plan9.base.options.module.?;
             return if (self.code_ptr) |p| p[0..self.other.code_len] else blk: {
@@ -608,8 +613,9 @@ fn atomCount(self: *Plan9) usize {
     while (it_lazy.next()) |kv| {
         lazy_atom_count += kv.value_ptr.numberOfAtoms();
     }
+    const anon_atom_count = self.anon_decls.count();
     const extern_atom_count = self.externCount();
-    return data_decl_count + fn_decl_count + unnamed_const_count + lazy_atom_count + extern_atom_count;
+    return data_decl_count + fn_decl_count + unnamed_const_count + lazy_atom_count + extern_atom_count + anon_atom_count;
 }
 
 pub fn flushModule(self: *Plan9, comp: *Compilation, prog_node: *std.Progress.Node) link.File.FlushError!void {
@@ -790,6 +796,27 @@ pub fn flushModule(self: *Plan9, comp: *Compilation, prog_node: *std.Progress.No
                 const atom = self.getAtomPtr(atom_idx);
                 const code = atom.code.getOwnedCode().?; // unnamed consts must own their code
                 log.debug("write unnamed const: ({s})", .{self.syms.items[atom.sym_index.?].name});
+                foff += code.len;
+                iovecs[iovecs_i] = .{ .iov_base = code.ptr, .iov_len = code.len };
+                iovecs_i += 1;
+                const off = self.getAddr(data_i, .d);
+                data_i += code.len;
+                atom.offset = off;
+                if (!self.sixtyfour_bit) {
+                    mem.writeInt(u32, got_table[atom.got_index.? * 4 ..][0..4], @as(u32, @intCast(off)), self.base.options.target.cpu.arch.endian());
+                } else {
+                    mem.writeInt(u64, got_table[atom.got_index.? * 8 ..][0..8], off, self.base.options.target.cpu.arch.endian());
+                }
+                self.syms.items[atom.sym_index.?].value = off;
+            }
+        }
+        // the anon decls
+        {
+            var it_anon = self.anon_decls.iterator();
+            while (it_anon.next()) |kv| {
+                const atom = self.getAtomPtr(kv.value_ptr.*);
+                const code = atom.code.getOwnedCode().?;
+                log.debug("write anon decl: {s}", .{self.syms.items[atom.sym_index.?].name});
                 foff += code.len;
                 iovecs[iovecs_i] = .{ .iov_base = code.ptr, .iov_len = code.len };
                 iovecs_i += 1;
@@ -1196,6 +1223,11 @@ pub fn deinit(self: *Plan9) void {
     while (itd.next()) |entry| {
         gpa.free(entry.value_ptr.*);
     }
+    var it_anon = self.anon_decls.iterator();
+    while (it_anon.next()) |entry| {
+        const sym_index = self.getAtom(entry.value_ptr.*).sym_index.?;
+        gpa.free(self.syms.items[sym_index].name);
+    }
     self.data_decl_table.deinit(gpa);
     self.syms.deinit(gpa);
     self.got_index_free_list.deinit(gpa);
@@ -1428,17 +1460,51 @@ pub fn lowerAnonDecl(self: *Plan9, decl_val: InternPool.Index, src_loc: Module.S
     // be used by more than one function, however, its address is being used so we need
     // to put it in some location.
     // ...
-    _ = self;
-    _ = decl_val;
-    _ = src_loc;
-    _ = @panic("TODO: link/Plan9 lowerAnonDecl");
+    const gpa = self.base.allocator;
+    var gop = try self.anon_decls.getOrPut(gpa, decl_val);
+    const mod = self.base.options.module.?;
+    if (!gop.found_existing) {
+        const ty = mod.intern_pool.typeOf(decl_val).toType();
+        const val = decl_val.toValue();
+        const tv = TypedValue{ .ty = ty, .val = val };
+        const name = try std.fmt.allocPrint(gpa, "__anon_{d}", .{@intFromEnum(decl_val)});
+
+        const index = try self.createAtom();
+        const got_index = self.allocateGotIndex();
+        gop.value_ptr.* = index;
+        // we need to free name latex
+        var code_buffer = std.ArrayList(u8).init(gpa);
+        const res = try codegen.generateSymbol(&self.base, src_loc, tv, &code_buffer, .{ .none = {} }, .{ .parent_atom_index = index });
+        const code = switch (res) {
+            .ok => code_buffer.items,
+            .fail => |em| return .{ .fail = em },
+        };
+        const atom_ptr = self.getAtomPtr(index);
+        atom_ptr.* = .{
+            .type = .d,
+            .offset = undefined,
+            .sym_index = null,
+            .got_index = got_index,
+            .code = Atom.CodePtr.fromSlice(code),
+        };
+        _ = try atom_ptr.getOrCreateSymbolTableEntry(self);
+        self.syms.items[atom_ptr.sym_index.?] = .{
+            .type = .d,
+            .value = undefined,
+            .name = name,
+        };
+    }
+    return .ok;
 }
 
 pub fn getAnonDeclVAddr(self: *Plan9, decl_val: InternPool.Index, reloc_info: link.File.RelocInfo) !u64 {
-    _ = self;
-    _ = decl_val;
-    _ = reloc_info;
-    _ = @panic("TODO: link/Plan9 getAnonDeclVAddr");
+    const atom_index = self.anon_decls.get(decl_val).?;
+    try self.addReloc(reloc_info.parent_atom_index, .{
+        .target = atom_index,
+        .offset = reloc_info.offset,
+        .addend = reloc_info.addend,
+    });
+    return undefined;
 }
 
 pub fn addReloc(self: *Plan9, parent_index: Atom.Index, reloc: Reloc) !void {

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -1418,13 +1418,8 @@ pub fn getDeclVAddr(
     return undefined;
 }
 
-pub fn getAnonDeclVAddr(
-    self: *Plan9,
-    decl_val: InternPool.Index,
-    reloc_info: link.File.RelocInfo,
-) !u64 {
-    // This is basically the same as lowerUnnamedConst except it needs
-    // to return the same thing as `getDeclVAddr`
+pub fn lowerAnonDecl(self: *Plan9, decl_val: InternPool.Index, src_loc: Module.SrcLoc) !codegen.Result {
+    // This is basically the same as lowerUnnamedConst.
     // example:
     // const ty = mod.intern_pool.typeOf(decl_val).toType();
     // const val = decl_val.toValue();
@@ -1433,6 +1428,13 @@ pub fn getAnonDeclVAddr(
     // be used by more than one function, however, its address is being used so we need
     // to put it in some location.
     // ...
+    _ = self;
+    _ = decl_val;
+    _ = src_loc;
+    _ = @panic("TODO: link/Plan9 lowerAnonDecl");
+}
+
+pub fn getAnonDeclVAddr(self: *Plan9, decl_val: InternPool.Index, reloc_info: link.File.RelocInfo) !u64 {
     _ = self;
     _ = decl_val;
     _ = reloc_info;

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -1679,6 +1679,27 @@ pub fn getDeclVAddr(
     return target_symbol_index;
 }
 
+pub fn getAnonDeclVAddr(
+    wasm: *Wasm,
+    decl_val: InternPool.Index,
+    reloc_info: link.File.RelocInfo,
+) !u64 {
+    // This is basically the same as lowerUnnamedConst except it needs
+    // to return the same thing as `getDeclVAddr`
+    // example:
+    // const ty = mod.intern_pool.typeOf(decl_val).toType();
+    // const val = decl_val.toValue();
+    // The symbol name can be something like `__anon_{d}` with `@intFromEnum(decl_val)`.
+    // It doesn't have an owner decl because it's just an unnamed constant that might
+    // be used by more than one function, however, its address is being used so we need
+    // to put it in some location.
+    // ...
+    _ = wasm;
+    _ = decl_val;
+    _ = reloc_info;
+    _ = @panic("TODO: link/Wasm getAnonDeclVAddr");
+}
+
 pub fn deleteDeclExport(wasm: *Wasm, decl_index: Module.Decl.Index) void {
     if (wasm.llvm_object) |_| return;
     const atom_index = wasm.decls.get(decl_index) orelse return;

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -187,6 +187,9 @@ debug_pubtypes_atom: ?Atom.Index = null,
 /// rather than by the linker.
 synthetic_functions: std.ArrayListUnmanaged(Atom.Index) = .{},
 
+/// Map for storing anonymous declarations. Each anonymous decl maps to its Atom's index.
+anon_decls: std.AutoArrayHashMapUnmanaged(InternPool.Index, Atom.Index) = .{},
+
 pub const Alignment = types.Alignment;
 
 pub const Segment = struct {
@@ -1291,6 +1294,7 @@ pub fn deinit(wasm: *Wasm) void {
     }
 
     wasm.decls.deinit(gpa);
+    wasm.anon_decls.deinit(gpa);
     wasm.atom_types.deinit(gpa);
     wasm.symbols.deinit(gpa);
     wasm.symbols_free_list.deinit(gpa);
@@ -1548,17 +1552,38 @@ pub fn lowerUnnamedConst(wasm: *Wasm, tv: TypedValue, decl_index: Module.Decl.In
     assert(tv.ty.zigTypeTag(mod) != .Fn); // cannot create local symbols for functions
     const decl = mod.declPtr(decl_index);
 
-    // Create and initialize a new local symbol and atom
-    const atom_index = try wasm.createAtom();
     const parent_atom_index = try wasm.getOrCreateAtomForDecl(decl_index);
-    const parent_atom = wasm.getAtomPtr(parent_atom_index);
+    const parent_atom = wasm.getAtom(parent_atom_index);
     const local_index = parent_atom.locals.items.len;
-    try parent_atom.locals.append(wasm.base.allocator, atom_index);
     const fqn = mod.intern_pool.stringToSlice(try decl.getFullyQualifiedName(mod));
     const name = try std.fmt.allocPrintZ(wasm.base.allocator, "__unnamed_{s}_{d}", .{
         fqn, local_index,
     });
     defer wasm.base.allocator.free(name);
+
+    switch (try wasm.lowerConst(name, tv, decl.srcLoc(mod))) {
+        .ok => |atom_index| {
+            try wasm.getAtomPtr(parent_atom_index).locals.append(wasm.base.allocator, atom_index);
+            return wasm.getAtom(atom_index).getSymbolIndex().?;
+        },
+        .fail => |em| {
+            decl.analysis = .codegen_failure;
+            try mod.failed_decls.put(mod.gpa, decl_index, em);
+            return error.CodegenFail;
+        },
+    }
+}
+
+const LowerConstResult = union(enum) {
+    ok: Atom.Index,
+    fail: *Module.ErrorMsg,
+};
+
+fn lowerConst(wasm: *Wasm, name: []const u8, tv: TypedValue, src_loc: Module.SrcLoc) !LowerConstResult {
+    const mod = wasm.base.options.module.?;
+
+    // Create and initialize a new local symbol and atom
+    const atom_index = try wasm.createAtom();
     var value_bytes = std.ArrayList(u8).init(wasm.base.allocator);
     defer value_bytes.deinit();
 
@@ -1576,7 +1601,7 @@ pub fn lowerUnnamedConst(wasm: *Wasm, tv: TypedValue, decl_index: Module.Decl.In
 
         const result = try codegen.generateSymbol(
             &wasm.base,
-            decl.srcLoc(mod),
+            src_loc,
             tv,
             &value_bytes,
             .none,
@@ -1588,17 +1613,15 @@ pub fn lowerUnnamedConst(wasm: *Wasm, tv: TypedValue, decl_index: Module.Decl.In
         break :code switch (result) {
             .ok => value_bytes.items,
             .fail => |em| {
-                decl.analysis = .codegen_failure;
-                try mod.failed_decls.put(mod.gpa, decl_index, em);
-                return error.CodegenFail;
+                return .{ .fail = em };
             },
         };
     };
 
     const atom = wasm.getAtomPtr(atom_index);
-    atom.size = @as(u32, @intCast(code.len));
+    atom.size = @intCast(code.len);
     try atom.code.appendSlice(wasm.base.allocator, code);
-    return atom.sym_index;
+    return .{ .ok = atom_index };
 }
 
 /// Returns the symbol index from a symbol of which its flag is set global,
@@ -1679,27 +1702,61 @@ pub fn getDeclVAddr(
     return target_symbol_index;
 }
 
-pub fn lowerAnonDecl(self: *Wasm, decl_val: InternPool.Index, src_loc: Module.SrcLoc) !codegen.Result {
-    // This is basically the same as lowerUnnamedConst.
-    // example:
-    // const ty = mod.intern_pool.typeOf(decl_val).toType();
-    // const val = decl_val.toValue();
-    // The symbol name can be something like `__anon_{d}` with `@intFromEnum(decl_val)`.
-    // It doesn't have an owner decl because it's just an unnamed constant that might
-    // be used by more than one function, however, its address is being used so we need
-    // to put it in some location.
-    // ...
-    _ = self;
-    _ = decl_val;
-    _ = src_loc;
-    _ = @panic("TODO: link/Wasm lowerAnonDecl");
+pub fn lowerAnonDecl(wasm: *Wasm, decl_val: InternPool.Index, src_loc: Module.SrcLoc) !codegen.Result {
+    const gop = try wasm.anon_decls.getOrPut(wasm.base.allocator, decl_val);
+    if (gop.found_existing) {
+        return .ok;
+    }
+
+    const mod = wasm.base.options.module.?;
+    const ty = mod.intern_pool.typeOf(decl_val).toType();
+    const tv: TypedValue = .{ .ty = ty, .val = decl_val.toValue() };
+    const name = try std.fmt.allocPrintZ(wasm.base.allocator, "__anon_{d}", .{@intFromEnum(decl_val)});
+    defer wasm.base.allocator.free(name);
+
+    switch (try wasm.lowerConst(name, tv, src_loc)) {
+        .ok => |atom_index| {
+            gop.value_ptr.* = atom_index;
+            return .ok;
+        },
+        .fail => |em| return .{ .fail = em },
+    }
 }
 
 pub fn getAnonDeclVAddr(wasm: *Wasm, decl_val: InternPool.Index, reloc_info: link.File.RelocInfo) !u64 {
-    _ = wasm;
-    _ = decl_val;
-    _ = reloc_info;
-    _ = @panic("TODO: link/Wasm getAnonDeclVAddr");
+    const atom_index = wasm.anon_decls.get(decl_val).?;
+    const target_symbol_index = wasm.getAtom(atom_index).getSymbolIndex().?;
+
+    const parent_atom_index = wasm.symbol_atom.get(.{ .file = null, .index = reloc_info.parent_atom_index }).?;
+    const parent_atom = wasm.getAtomPtr(parent_atom_index);
+    const is_wasm32 = wasm.base.options.target.cpu.arch == .wasm32;
+    const mod = wasm.base.options.module.?;
+    const ty = mod.intern_pool.typeOf(decl_val).toType();
+    if (ty.zigTypeTag(mod) == .Fn) {
+        assert(reloc_info.addend == 0); // addend not allowed for function relocations
+        // We found a function pointer, so add it to our table,
+        // as function pointers are not allowed to be stored inside the data section.
+        // They are instead stored in a function table which are called by index.
+        try wasm.addTableFunction(target_symbol_index);
+        try parent_atom.relocs.append(wasm.base.allocator, .{
+            .index = target_symbol_index,
+            .offset = @as(u32, @intCast(reloc_info.offset)),
+            .relocation_type = if (is_wasm32) .R_WASM_TABLE_INDEX_I32 else .R_WASM_TABLE_INDEX_I64,
+        });
+    } else {
+        try parent_atom.relocs.append(wasm.base.allocator, .{
+            .index = target_symbol_index,
+            .offset = @as(u32, @intCast(reloc_info.offset)),
+            .relocation_type = if (is_wasm32) .R_WASM_MEMORY_ADDR_I32 else .R_WASM_MEMORY_ADDR_I64,
+            .addend = @as(i32, @intCast(reloc_info.addend)),
+        });
+    }
+
+    // we do not know the final address at this point,
+    // as atom allocation will determine the address and relocations
+    // will calculate and rewrite this. Therefore, we simply return the symbol index
+    // that was targeted.
+    return target_symbol_index;
 }
 
 pub fn deleteDeclExport(wasm: *Wasm, decl_index: Module.Decl.Index) void {
@@ -3463,6 +3520,15 @@ pub fn flushModule(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Nod
             // also parse atoms for a decl's locals
             for (atom.locals.items) |local_atom_index| {
                 try wasm.parseAtom(local_atom_index, .{ .data = .read_only });
+            }
+        }
+        // parse anonymous declarations
+        for (wasm.anon_decls.keys(), wasm.anon_decls.values()) |decl_val, atom_index| {
+            const ty = mod.intern_pool.typeOf(decl_val).toType();
+            if (ty.zigTypeTag(mod) == .Fn) {
+                try wasm.parseAtom(atom_index, .function);
+            } else {
+                try wasm.parseAtom(atom_index, .{ .data = .read_only });
             }
         }
 

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -1679,13 +1679,8 @@ pub fn getDeclVAddr(
     return target_symbol_index;
 }
 
-pub fn getAnonDeclVAddr(
-    wasm: *Wasm,
-    decl_val: InternPool.Index,
-    reloc_info: link.File.RelocInfo,
-) !u64 {
-    // This is basically the same as lowerUnnamedConst except it needs
-    // to return the same thing as `getDeclVAddr`
+pub fn lowerAnonDecl(self: *Wasm, decl_val: InternPool.Index, src_loc: Module.SrcLoc) !codegen.Result {
+    // This is basically the same as lowerUnnamedConst.
     // example:
     // const ty = mod.intern_pool.typeOf(decl_val).toType();
     // const val = decl_val.toValue();
@@ -1694,6 +1689,13 @@ pub fn getAnonDeclVAddr(
     // be used by more than one function, however, its address is being used so we need
     // to put it in some location.
     // ...
+    _ = self;
+    _ = decl_val;
+    _ = src_loc;
+    _ = @panic("TODO: link/Wasm lowerAnonDecl");
+}
+
+pub fn getAnonDeclVAddr(wasm: *Wasm, decl_val: InternPool.Index, reloc_info: link.File.RelocInfo) !u64 {
     _ = wasm;
     _ = decl_val;
     _ = reloc_info;


### PR DESCRIPTION
Instead of explicitly creating a `Module.Decl` object for each anonymous declaration, each `InternPool.Index` value is implicitly understood to be an unnamed constant declaration when encountered by backend code generation.

The memory management strategy for these anonymous decls then becomes to garbage collect them along with the rest of InternPool garbage.

In the interest of a smooth transition, this commit only implements this new scheme for string literals and leaves all the previous mechanisms in place.

self-hosted compiler perf delta:

```
Benchmark 1 (3 runs): before/zig build-exe ...
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          50.7s  ±  394ms    50.3s  … 51.0s           0 ( 0%)        0%
  peak_rss           3.92GB ±  945KB    3.92GB … 3.92GB          0 ( 0%)        0%
  cpu_cycles          212G  ± 1.26G      210G  …  213G           0 ( 0%)        0%
  instructions        275G  ± 75.6M      275G  …  275G           0 ( 0%)        0%
  cache_references   13.1G  ± 67.9M     13.0G  … 13.1G           0 ( 0%)        0%
  cache_misses       1.10G  ± 5.82M     1.10G  … 1.11G           0 ( 0%)        0%
  branch_misses      1.53G  ± 1.74M     1.53G  … 1.53G           0 ( 0%)        0%
Benchmark 2 (3 runs): after/zig build-exe ...
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          50.5s  ±  701ms    49.9s  … 51.3s           0 ( 0%)          -  0.3% ±  2.5%
  peak_rss           3.90GB ±  947KB    3.90GB … 3.90GB          0 ( 0%)          -  0.4% ±  0.1%
  cpu_cycles          209G  ±  450M      208G  …  209G           0 ( 0%)          -  1.5% ±  1.0%
  instructions        274G  ± 77.3M      274G  …  274G           0 ( 0%)          -  0.3% ±  0.1%
  cache_references   12.9G  ±  115M     12.8G  … 13.0G           0 ( 0%)          -  1.4% ±  1.6%
  cache_misses       1.10G  ± 11.8M     1.08G  … 1.11G           0 ( 0%)          -  0.8% ±  1.9%
  branch_misses      1.53G  ± 1.71M     1.53G  … 1.53G           0 ( 0%)          -  0.1% ±  0.3%
```

Looks promising since this is only for string literals. The rewards might be more significant when the rest of anon decls are ported over.

But the immediate perf is not even the point, that's just a side benefit. The real purpose here is to simplify the frontend with regards to lifetime management of decls in order to implement incremental compilation in a more robust and maintainable manner. This effectively removes anonymous decls from the equation, making the implementation much simpler.