### PR TITLE
elf: link against musl libc, add ELF test harness, dynamically allocate misc SHF_ALLOC sections

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -254,7 +254,7 @@ pub fn createEmpty(gpa: Allocator, options: link.Options) !*Elf {
         .default_sym_version = default_sym_version,
     };
     const use_llvm = options.use_llvm;
-    if (use_llvm) {
+    if (use_llvm and options.module != null) {
         self.llvm_object = try LlvmObject.create(gpa, options);
     }
 

--- a/test/link.zig
+++ b/test/link.zig
@@ -29,6 +29,12 @@ pub const cases = [_]Case{
         .import = @import("link/glibc_compat/build.zig"),
     },
 
+    // Elf Cases
+    .{
+        .build_root = "test/link",
+        .import = @import("link/elf.zig"),
+    },
+
     // WASM Cases
     // https://github.com/ziglang/zig/issues/16938
     //.{

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -29,7 +29,7 @@ fn testEmptyObject(b: *Build, opts: Options) *Step {
     addCSourceBytes(exe, "");
     exe.is_linking_libc = true;
 
-    const run = b.addRunArtifact(exe);
+    const run = addRunArtifact(exe);
     run.expectExitCode(0);
     test_step.dependOn(&run.step);
 
@@ -49,7 +49,7 @@ fn testLinkingC(b: *Build, opts: Options) *Step {
     );
     exe.is_linking_libc = true;
 
-    const run = b.addRunArtifact(exe);
+    const run = addRunArtifact(exe);
     run.expectStdOutEqual("Hello World!\n");
     test_step.dependOn(&run.step);
 
@@ -75,7 +75,7 @@ fn testLinkingZig(b: *Build, opts: Options) *Step {
         \\}
     );
 
-    const run = b.addRunArtifact(exe);
+    const run = addRunArtifact(exe);
     run.expectStdErrEqual("Hello World!\n");
     test_step.dependOn(&run.step);
 
@@ -118,6 +118,13 @@ fn addExecutable(b: *Build, opts: Options) *Compile {
         .use_llvm = opts.use_llvm,
         .use_lld = false,
     });
+}
+
+fn addRunArtifact(comp: *Compile) *Run {
+    const b = comp.step.owner;
+    const run = b.addRunArtifact(comp);
+    run.skip_foreign_checks = true;
+    return run;
 }
 
 fn addZigSourceBytes(comp: *Compile, bytes: []const u8) void {

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -1,0 +1,89 @@
+//! Here we test our ELF linker for correctness and functionality.
+//! Currently, we support linking x86_64 Linux, but in the future we
+//! will progressively relax those to exercise more combinations.
+
+pub fn build(b: *Build) void {
+    const elf_step = b.step("test-elf", "Run ELF tests");
+    b.default_step = elf_step;
+
+    const target: CrossTarget = .{
+        .cpu_arch = .x86_64, // TODO relax this once ELF linker is able to handle other archs
+        .os_tag = .linux,
+    };
+
+    elf_step.dependOn(testHelloStatic(b, .{ .target = target, .use_llvm = true }));
+    elf_step.dependOn(testHelloStatic(b, .{ .target = target, .use_llvm = false }));
+}
+
+fn testHelloStatic(b: *Build, opts: Options) *Step {
+    const test_step = addTestStep(b, "hello-static", opts);
+
+    const exe = addExecutable(b, opts);
+    addZigSourceBytes(exe,
+        \\pub fn main() void {
+        \\    @import("std").debug.print("Hello World!\n", .{});
+        \\}
+    );
+    exe.linkage = .static;
+
+    const run = b.addRunArtifact(exe);
+    run.expectStdErrEqual("Hello World!\n");
+    test_step.dependOn(&run.step);
+
+    const check = exe.checkObject();
+    check.checkStart();
+    check.checkExact("header");
+    check.checkExact("type EXEC");
+    check.checkStart();
+    check.checkExact("section headers");
+    check.checkNotPresent("name .dynamic");
+    test_step.dependOn(&check.step);
+
+    return test_step;
+}
+
+const Options = struct {
+    target: CrossTarget = .{ .os_tag = .linux },
+    optimize: std.builtin.OptimizeMode = .Debug,
+    use_llvm: bool = true,
+};
+
+fn addTestStep(b: *Build, comptime prefix: []const u8, opts: Options) *Step {
+    const target = opts.target.zigTriple(b.allocator) catch @panic("OOM");
+    const optimize = @tagName(opts.optimize);
+    const use_llvm = if (opts.use_llvm) "llvm" else "no-llvm";
+    const name = std.fmt.allocPrint(b.allocator, "test-elf-" ++ prefix ++ "-{s}-{s}-{s}", .{
+        target,
+        optimize,
+        use_llvm,
+    }) catch @panic("OOM");
+    return b.step(name, "");
+}
+
+fn addExecutable(b: *Build, opts: Options) *Compile {
+    return b.addExecutable(.{
+        .name = "test",
+        .target = opts.target,
+        .optimize = opts.optimize,
+        .single_threaded = true, // TODO temp until we teach linker how to handle TLS
+        .use_llvm = opts.use_llvm,
+        .use_lld = false,
+    });
+}
+
+fn addZigSourceBytes(comp: *Compile, bytes: []const u8) void {
+    const b = comp.step.owner;
+    const file = WriteFile.create(b).add("a.zig", bytes);
+    file.addStepDependencies(&comp.step);
+    comp.root_src = file;
+}
+
+const std = @import("std");
+
+const Build = std.Build;
+const Compile = Step.Compile;
+const CrossTarget = std.zig.CrossTarget;
+const LazyPath = Build.LazyPath;
+const Run = Step.Run;
+const Step = Build.Step;
+const WriteFile = Step.WriteFile;


### PR DESCRIPTION
This now works:

```
$ cat hello.c
#include <stdio.h>
int main() {
    printf("Hello!\n");
    return 0;
}
$ zig build-exe hello.c -lc -target x86_64-linux-musl -fno-lld
$ ./hello
Hello!
```