### PR TITLE
x86_64+elf: emit relocations instead of hard-coding VM addresses

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -8170,11 +8170,14 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
                 const sym = elf_file.symbol(sym_index);
                 sym.flags.needs_got = true;
                 _ = try sym.getOrCreateGotEntry(sym_index, elf_file);
-                const got_addr = sym.gotAddress(elf_file);
-                try self.asmMemory(.{ ._, .call }, Memory.sib(.qword, .{
-                    .base = .{ .reg = .ds },
-                    .disp = @intCast(got_addr),
-                }));
+                _ = try self.addInst(.{
+                    .tag = .call,
+                    .ops = .direct_got_reloc,
+                    .data = .{ .reloc = .{
+                        .atom_index = try self.owner.getSymbolIndex(self),
+                        .sym_index = sym.esym_index,
+                    } },
+                });
             } else if (self.bin_file.cast(link.File.Coff)) |coff_file| {
                 const atom = try coff_file.getOrCreateAtomForDecl(owner_decl);
                 const sym_index = coff_file.getAtom(atom).getSymbolIndex().?;
@@ -10237,12 +10240,24 @@ fn genLazySymbolRef(
         const sym = elf_file.symbol(sym_index);
         sym.flags.needs_got = true;
         _ = try sym.getOrCreateGotEntry(sym_index, elf_file);
-        const got_addr = sym.gotAddress(elf_file);
-        const got_mem =
-            Memory.sib(.qword, .{ .base = .{ .reg = .ds }, .disp = @intCast(got_addr) });
+        const reloc = Mir.Reloc{
+            .atom_index = try self.owner.getSymbolIndex(self),
+            .sym_index = sym.esym_index,
+        };
         switch (tag) {
-            .lea, .mov => try self.asmRegisterMemory(.{ ._, .mov }, reg.to64(), got_mem),
-            .call => try self.asmMemory(.{ ._, .call }, got_mem),
+            .lea, .mov => _ = try self.addInst(.{
+                .tag = .mov,
+                .ops = .direct_got_reloc,
+                .data = .{ .rx = .{
+                    .r1 = reg.to64(),
+                    .payload = try self.addExtra(reloc),
+                } },
+            }),
+            .call => _ = try self.addInst(.{
+                .tag = .call,
+                .ops = .direct_got_reloc,
+                .data = .{ .reloc = reloc },
+            }),
             else => unreachable,
         }
         switch (tag) {

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -783,6 +783,9 @@ pub const Inst = struct {
         /// Linker relocation - threadlocal variable via GOT indirection.
         /// Uses `rx` payload with extra data of type `Reloc`.
         tlv_reloc,
+        /// Linker relocation - non-PIC direct reference to GOT cell.
+        /// Uses `reloc` payload if tag is `call`, `rx` otherwise.
+        direct_got_reloc,
 
         // Pseudo instructions:
 

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -480,6 +480,9 @@ pub fn resolveRelocs(self: Atom, elf_file: *Elf, code: []u8) !void {
             elf.R_X86_64_PC32,
             => try cwriter.writeIntLittle(i32, @as(i32, @intCast(S + A - P))),
 
+            elf.R_X86_64_GOT32 => try cwriter.writeIntLittle(u32, @as(u32, @intCast(G + GOT + A))),
+            elf.R_X86_64_GOT64 => try cwriter.writeIntLittle(u64, @as(u64, @intCast(G + GOT + A))),
+
             elf.R_X86_64_GOTPCREL => try cwriter.writeIntLittle(i32, @as(i32, @intCast(G + GOT + A - P))),
             elf.R_X86_64_GOTPC32 => try cwriter.writeIntLittle(i32, @as(i32, @intCast(GOT + A - P))),
             elf.R_X86_64_GOTPC64 => try cwriter.writeIntLittle(i64, GOT + A - P),


### PR DESCRIPTION
As discussed offline, this is a proposed start to rewriting part of the x86_64 backend concerned with lowering VM addresses of symbols when targeting ELF. This change implements lowering of non-PIC GOT references, however it doesn't touch `MCValue.memory` which also needs to be tweaked to work based on symbol indexes passed by the linker rather than hard-coded VM addresses which may change if we are forced to shuffle things around in memory.