### PR TITLE
Add new fields to io_sqring_offsets & io_cqring_offsets

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -3750,7 +3750,7 @@ pub const io_sqring_offsets = extern struct {
     array: u32,
 
     resv1: u32,
-    resv2: u64,
+    user_addr: u64,
 };
 
 // io_sqring_offsets.flags
@@ -3769,7 +3769,9 @@ pub const io_cqring_offsets = extern struct {
     ring_entries: u32,
     overflow: u32,
     cqes: u32,
-    resv: [2]u64,
+    flags: u32,
+    resv: u32,
+    user_addr: u64,
 };
 
 pub const io_uring_sqe = extern struct {


### PR DESCRIPTION
`user_addr`s were introduced in `03d89a2` ([github link](https://github.com/torvalds/linux/commit/03d89a2de25bbc5c77e61a0cf77663978c4b6ea7) which was shipped in v6.5.
`flags` was introduced even earlier

Not sure what the policy is here - are the old resv names left behind as u0 or something? Is breaking like this ok?