### PR TITLE
Add myself as a code owner of /src/resinator/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,6 @@
 
 # std.Thread
 /lib/std/Thread* @kprotty
+
+# resinator
+/src/resinator/* @squeek502


### PR DESCRIPTION
From, https://github.com/ziglang/zig/pull/17221#issuecomment-1736281498, the current strategy with resinator is option 1:

> Put Aro in src/, don't mark it as vendored, allow tight coupling with other compiler code, and periodically port code back and forth between the Zig source tree and the Aro source tree.

so it would be good if I were notified of any PRs that modify the files in `src/resinator`

EDIT: Nevermind, looks like CODEOWNERS only works for people with write access to the repo.

> The people you choose as code owners must have write permissions for the repository.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners