### PR TITLE
elf: grow segments in virtual memory if they exceed allocated capacity

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -790,7 +790,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
     }
 
     if (self.base.options.module) |module| {
-        if (self.zig_module_index == null) {
+        if (self.zig_module_index == null and !self.base.options.use_llvm) {
             const index = @as(File.Index, @intCast(try self.files.addOne(gpa)));
             self.files.set(index, .{ .zig_module = .{
                 .index = index,
@@ -905,14 +905,15 @@ fn growSegment(self: *Elf, shndx: u16, needed_size: u64) !void {
             const sym = self.symbol(sym_index);
             const atom_ptr = sym.atom(self) orelse continue;
             if (!atom_ptr.flags.alive or !atom_ptr.flags.allocated) continue;
-            if (atom_ptr.value >= end_addr) sym.value += diff;
+            if (sym.value >= end_addr) sym.value += diff;
         }
 
         for (file_ptr.globals()) |sym_index| {
             const sym = self.symbol(sym_index);
+            if (sym.file_index != index) continue;
             const atom_ptr = sym.atom(self) orelse continue;
             if (!atom_ptr.flags.alive or !atom_ptr.flags.allocated) continue;
-            if (atom_ptr.value >= end_addr) sym.value += diff;
+            if (sym.value >= end_addr) sym.value += diff;
         }
 
         for (file_ptr.atoms()) |atom_index| {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -534,6 +534,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
     };
     const ptr_size: u8 = self.ptrWidthBytes();
     const is_linux = self.base.options.target.os.tag == .linux;
+    const large_addrspace = self.base.options.target.ptrBitWidth() >= 32;
     const image_base = self.calcImageBase();
 
     if (self.phdr_table_index == null) {
@@ -581,7 +582,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
     }
 
     if (self.phdr_got_index == null) {
-        const addr: u64 = if (ptr_size >= 4) 0x4000000 else 0x8000;
+        const addr: u64 = if (large_addrspace) 0x4000000 else 0x8000;
         // We really only need ptr alignment but since we are using PROGBITS, linux requires
         // page align.
         const alignment = if (is_linux) self.page_size else @as(u16, ptr_size);
@@ -594,7 +595,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
     }
 
     if (self.phdr_load_ro_index == null) {
-        const addr: u64 = if (ptr_size >= 4) 0xc000000 else 0xa000;
+        const addr: u64 = if (large_addrspace) 0xc000000 else 0xa000;
         const alignment = if (is_linux) self.page_size else @as(u16, ptr_size);
         self.phdr_load_ro_index = try self.allocateSegment(.{
             .addr = addr,
@@ -605,7 +606,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
     }
 
     if (self.phdr_load_rw_index == null) {
-        const addr: u64 = if (ptr_size >= 4) 0x10000000 else 0xc000;
+        const addr: u64 = if (large_addrspace) 0x10000000 else 0xc000;
         const alignment = if (is_linux) self.page_size else @as(u16, ptr_size);
         self.phdr_load_rw_index = try self.allocateSegment(.{
             .addr = addr,
@@ -616,7 +617,7 @@ pub fn populateMissingMetadata(self: *Elf) !void {
     }
 
     if (self.phdr_load_zerofill_index == null) {
-        const addr: u64 = if (ptr_size >= 4) 0x14000000 else 0xf000;
+        const addr: u64 = if (large_addrspace) 0x14000000 else 0xf000;
         const alignment = if (is_linux) self.page_size else @as(u16, ptr_size);
         self.phdr_load_zerofill_index = try self.allocateSegment(.{
             .addr = addr,

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -89,6 +89,21 @@ pub const File = union(enum) {
         }
     }
 
+    pub fn atoms(file: File) []const Atom.Index {
+        return switch (file) {
+            .linker_defined => unreachable,
+            .zig_module => |x| x.atoms.keys(),
+            .object => |x| x.atoms.items,
+        };
+    }
+
+    pub fn locals(file: File) []const Symbol.Index {
+        return switch (file) {
+            .linker_defined => unreachable,
+            inline else => |x| x.locals(),
+        };
+    }
+
     pub fn globals(file: File) []const Symbol.Index {
         return switch (file) {
             inline else => |x| x.globals(),
@@ -110,6 +125,7 @@ const std = @import("std");
 const elf = std.elf;
 
 const Allocator = std.mem.Allocator;
+const Atom = @import("Atom.zig");
 const Elf = @import("../Elf.zig");
 const LinkerDefined = @import("LinkerDefined.zig");
 const Object = @import("Object.zig");

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -169,6 +169,21 @@ pub const GotSection = struct {
         }
     }
 
+    pub fn writeAllEntries(got: GotSection, elf_file: *Elf, writer: anytype) !void {
+        assert(!got.dirty);
+        const entry_size: u16 = elf_file.archPtrWidthBytes();
+        const endian = elf_file.base.options.target.cpu.arch.endian();
+        for (got.entries.items) |entry| {
+            const value = elf_file.symbol(entry.symbol_index).value;
+            switch (entry_size) {
+                2 => try writer.writeInt(u16, @intCast(value), endian),
+                4 => try writer.writeInt(u32, @intCast(value), endian),
+                8 => try writer.writeInt(u64, @intCast(value), endian),
+                else => unreachable,
+            }
+        }
+    }
+
     // pub fn write(got: GotSection, elf_file: *Elf, writer: anytype) !void {
     //     const is_shared = elf_file.options.output_mode == .lib;
     //     const apply_relocs = elf_file.options.apply_dynamic_relocs;


### PR DESCRIPTION
Extracted from https://github.com/ziglang/zig/pull/17288

For object-only linking, so clang and LLVM drivers, segments get automatically expanded when required. For self-hosted backends, we cannot expand the segments since we do not emit relocations that the linker can use to track movement of symbol references when shifting things in memory. Since we are lacking this in all self-hosted backends, if we hit this during immediate development, the linker will print a helpful error message like the following:

```
$ ./stage4/bin/zig build test-link                                                                                                                                                                                                      
test.link.zig build-exe test Debug x86_64-linux: error: the following command failed with 11 compilation errors:
/home/kubkon/dev/zig/build/stage4/bin/zig build-exe -fno-llvm -fno-lld /home/kubkon/dev/zig/zig-cache/o/db86d0c72237436565700e5b7ebff91c/a.zig --cache-dir /home/kubkon/dev/zig/zig-cache --global-cache-dir /home/kubkon/.cache/zig --name test -fsingle-threaded -target x86_64-linux -mcpu x86_64 --listen=-
Build Summary: 486/570 steps succeeded; 78 skipped; 1 failed (disable with --summary none)
test-link transitive failure
└─ link.test-elf transitive failure
   └─ test-elf-linking-zig-static-x86_64-linux-Debug-no-llvm transitive failure
      ├─ run test transitive failure
      │  └─ zig build-exe test Debug x86_64-linux 11 errors
      └─ CheckObject transitive failure
         └─ zig build-exe test Debug x86_64-linux (+1 more reused dependencies)
error: fatal linker error: cannot expand load segment phdr(4) in virtual memory
    note: TODO: emit relocations to memory locations in self-hosted backends
    note: as a workaround, try increasing pre-allocated virtual memory of each segment
error: fatal linker error: cannot expand load segment phdr(4) in virtual memory
    note: TODO: emit relocations to memory locations in self-hosted backends
    note: as a workaround, try increasing pre-allocated virtual memory of each segment
error: fatal linker error: cannot expand load segment phdr(4) in virtual memory
    note: TODO: emit relocations to memory locations in self-hosted backends
    note: as a workaround, try increasing pre-allocated virtual memory of each segment
error: fatal linker error: cannot expand load segment phdr(4) in virtual memory
    note: TODO: emit relocations to memory locations in self-hosted backends
    note: as a workaround, try increasing pre-allocated virtual memory of each segment
error: fatal linker error: cannot expand load segment phdr(4) in virtual memory
    note: TODO: emit relocations to memory locations in self-hosted backends
    note: as a workaround, try increasing pre-allocated virtual memory of each segment
error: fatal linker error: cannot expand load segment phdr(4) in virtual memory
    note: TODO: emit relocations to memory locations in self-hosted backends
    note: as a workaround, try increasing pre-allocated virtual memory of each segment
error: fatal linker error: cannot expand load segment phdr(3) in virtual memory
    note: TODO: emit relocations to memory locations in self-hosted backends
    note: as a workaround, try increasing pre-allocated virtual memory of each segment
error: fatal linker error: cannot expand load segment phdr(2) in virtual memory
    note: TODO: emit relocations to memory locations in self-hosted backends
    note: as a workaround, try increasing pre-allocated virtual memory of each segment
error: fatal linker error: cannot expand load segment phdr(2) in virtual memory
    note: TODO: emit relocations to memory locations in self-hosted backends
    note: as a workaround, try increasing pre-allocated virtual memory of each segment
error: fatal linker error: cannot expand load segment phdr(2) in virtual memory
    note: TODO: emit relocations to memory locations in self-hosted backends
    note: as a workaround, try increasing pre-allocated virtual memory of each segment
error: fatal linker error: cannot expand load segment phdr(3) in virtual memory
    note: TODO: emit relocations to memory locations in self-hosted backends
    note: as a workaround, try increasing pre-allocated virtual memory of each segment
```