### PR TITLE
Add epoll_wait_or_signal to std.os

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3817,7 +3817,7 @@ pub fn epoll_ctl(epfd: i32, op: u32, fd: i32, event: ?*linux.epoll_event) EpollC
 /// Waits for an I/O event on an epoll file descriptor.
 /// Retries when interrupted by a signal.
 /// Returns the number of file descriptors ready for the requested I/O,
-/// or zero if no file descriptor became ready during the requested timeout milliseconds.
+/// or zero if no file descriptor became ready during the requested timeout (milliseconds).
 pub fn epoll_wait(epfd: i32, events: []linux.epoll_event, timeout: i32) usize {
     while (true) {
         if (epoll_pwait(epfd, events, timeout, null)) |value| {
@@ -3827,9 +3827,9 @@ pub fn epoll_wait(epfd: i32, events: []linux.epoll_event, timeout: i32) usize {
 }
 
 /// Waits for an I/O event on an epoll file descriptor.
-/// Returns an error if interrupted by a signal.
+/// Returns error.SignalInterrupt if interrupted by a signal.
 /// Returns the number of file descriptors ready for the requested I/O,
-/// or zero if no file descriptor became ready during the requested timeout milliseconds.
+/// or zero if no file descriptor became ready during the requested timeout (milliseconds).
 pub fn epoll_pwait(epfd: i32, events: []linux.epoll_event, timeout: i32, sigset: ?*const linux.sigset_t) !usize {
     // TODO get rid of the @intCast
     const rc = system.epoll_pwait(epfd, events.ptr, @as(u32, @intCast(events.len)), timeout, sigset);

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3820,7 +3820,7 @@ pub fn epoll_ctl(epfd: i32, op: u32, fd: i32, event: ?*linux.epoll_event) EpollC
 /// or zero if no file descriptor became ready during the requested timeout (milliseconds).
 pub fn epoll_wait(epfd: i32, events: []linux.epoll_event, timeout: i32) usize {
     while (true) {
-        if (epoll_pwait(epfd, events, timeout, null)) |value| {
+        if (epoll_wait_or_signal(epfd, events, timeout)) |value| {
             return value;
         } else |_| {}
     }
@@ -3830,9 +3830,9 @@ pub fn epoll_wait(epfd: i32, events: []linux.epoll_event, timeout: i32) usize {
 /// Returns error.SignalInterrupt if interrupted by a signal.
 /// Returns the number of file descriptors ready for the requested I/O,
 /// or zero if no file descriptor became ready during the requested timeout (milliseconds).
-pub fn epoll_pwait(epfd: i32, events: []linux.epoll_event, timeout: i32, sigset: ?*const linux.sigset_t) !usize {
+pub fn epoll_wait_or_signal(epfd: i32, events: []linux.epoll_event, timeout: i32) !usize {
     // TODO get rid of the @intCast
-    const rc = system.epoll_pwait(epfd, events.ptr, @as(u32, @intCast(events.len)), timeout, sigset);
+    const rc = system.epoll_pwait(epfd, events.ptr, @as(u32, @intCast(events.len)), timeout, null);
     switch (errno(rc)) {
         .SUCCESS => return @as(usize, @intCast(rc)),
         .INTR => return error.SignalInterrupt,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -3820,16 +3820,9 @@ pub fn epoll_ctl(epfd: i32, op: u32, fd: i32, event: ?*linux.epoll_event) EpollC
 /// or zero if no file descriptor became ready during the requested timeout milliseconds.
 pub fn epoll_wait(epfd: i32, events: []linux.epoll_event, timeout: i32) usize {
     while (true) {
-        // TODO get rid of the @intCast
-        const rc = system.epoll_wait(epfd, events.ptr, @as(u32, @intCast(events.len)), timeout);
-        switch (errno(rc)) {
-            .SUCCESS => return @as(usize, @intCast(rc)),
-            .INTR => continue,
-            .BADF => unreachable,
-            .FAULT => unreachable,
-            .INVAL => unreachable,
-            else => unreachable,
-        }
+        if (epoll_pwait(epfd, events, timeout, null)) |value| {
+            return value;
+        } else |_| {}
     }
 }
 


### PR DESCRIPTION
It is not possible to handle signals in `std.os.epoll_wait` - they are simply retried - so one must resort to `std.linux.epoll_pwait`, where the interface is not as nice to use. This PR adds a method that allows the user to handle signals more elegantly.