### PR TITLE
resinator: Update to latest, fix for big endian arch

### DIFF
--- a/src/resinator/bmp.zig
+++ b/src/resinator/bmp.zig
@@ -92,7 +92,7 @@ pub fn read(reader: anytype, max_size: u64) ReadError!BitmapInfo {
     const id = std.mem.readIntNative(u16, file_header[0..2]);
     if (id != windows_format_id) return error.InvalidFileHeader;
 
-    bitmap_info.pixel_data_offset = std.mem.readIntNative(u32, file_header[10..14]);
+    bitmap_info.pixel_data_offset = std.mem.readIntLittle(u32, file_header[10..14]);
     if (bitmap_info.pixel_data_offset > max_size) return error.ImpossiblePixelDataOffset;
 
     bitmap_info.dib_header_size = reader.readIntLittle(u32) catch return error.UnexpectedEOF;


### PR DESCRIPTION
Also contains slight modifications of the 32-bit fixes from https://github.com/ziglang/zig/commit/80ae27bc844ce7fe18bc686ce4befa24ab0f86bb

Both 32-bit targets and big endian targets are now also tested in resinator's CI: https://github.com/squeek502/resinator/commit/92d4010629f9db3e8d6df8b038b814f135572567