### PR TITLE
simplify ContainerDeclarations grammar rule

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -12373,11 +12373,7 @@ Root <- skip container_doc_comment? ContainerMembers eof
 # *** Top level ***
 ContainerMembers <- ContainerDeclarations (ContainerField COMMA)* (ContainerField / ContainerDeclarations)
 
-ContainerDeclarations
-    <- TestDecl ContainerDeclarations
-     / ComptimeDecl ContainerDeclarations
-     / doc_comment? KEYWORD_pub? Decl ContainerDeclarations
-     /
+ContainerDeclarations <- (TestDecl / ComptimeDecl / doc_comment? KEYWORD_pub? Decl)*
 
 TestDecl <- KEYWORD_test (STRINGLITERALSINGLE / IDENTIFIER)? Block
 

--- a/lib/std/zig/Parse.zig
+++ b/lib/std/zig/Parse.zig
@@ -207,11 +207,7 @@ pub fn parseZon(p: *Parse) !void {
 
 /// ContainerMembers <- ContainerDeclarations (ContainerField COMMA)* (ContainerField / ContainerDeclarations)
 ///
-/// ContainerDeclarations
-///     <- TestDecl ContainerDeclarations
-///      / ComptimeDecl ContainerDeclarations
-///      / doc_comment? KEYWORD_pub? Decl ContainerDeclarations
-///      /
+/// ContainerDeclarations <- (TestDecl / ComptimeDecl / doc_comment? KEYWORD_pub? Decl)*
 ///
 /// ComptimeDecl <- KEYWORD_comptime Block
 fn parseContainerMembers(p: *Parse) !Members {


### PR DESCRIPTION
Noticed this grammar rule could be simplified using a repeating sequence rather than recursion.