### PR TITLE
Update Linux syscalls for 5.5 and add a wrapper for `cachestat` 

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1876,6 +1876,21 @@ pub fn ptrace(
     );
 }
 
+pub fn cachestat(
+    fd: fd_t,
+    cstat_range: *const cache_stat_range,
+    cstat: *cache_stat,
+    flags: u32,
+) usize {
+    return syscall4(
+        .cachestat,
+        @as(usize, @bitCast(@as(isize, fd))),
+        @intFromPtr(cstat_range),
+        @intFromPtr(cstat),
+        flags,
+    );
+}
+
 pub const E = switch (native_arch) {
     .mips, .mipsel => @import("linux/errno/mips.zig").E,
     .sparc, .sparcel, .sparc64 => @import("linux/errno/sparc.zig").E,
@@ -5828,4 +5843,17 @@ pub const PTRACE = struct {
     pub const SECCOMP_GET_FILTER = 0x420c;
     pub const SECCOMP_GET_METADATA = 0x420d;
     pub const GET_SYSCALL_INFO = 0x420e;
+};
+
+pub const cache_stat_range = extern struct {
+    off: u64,
+    len: u64,
+};
+
+pub const cache_stat = extern struct {
+    cache: u64,
+    dirty: u64,
+    writeback: u64,
+    evicted: u64,
+    recently_evicted: u64,
 };

--- a/lib/std/os/linux/syscalls.zig
+++ b/lib/std/os/linux/syscalls.zig
@@ -442,6 +442,7 @@ pub const X86 = enum(usize) {
     process_mrelease = 448,
     futex_waitv = 449,
     set_mempolicy_home_node = 450,
+    cachestat = 451,
 };
 
 pub const X64 = enum(usize) {
@@ -807,6 +808,7 @@ pub const X64 = enum(usize) {
     process_mrelease = 448,
     futex_waitv = 449,
     set_mempolicy_home_node = 450,
+    cachestat = 451,
 };
 
 pub const Arm = enum(usize) {
@@ -1215,6 +1217,7 @@ pub const Arm = enum(usize) {
     process_mrelease = 448,
     futex_waitv = 449,
     set_mempolicy_home_node = 450,
+    cachestat = 451,
 
     breakpoint = arm_base + 1,
     cacheflush = arm_base + 2,
@@ -1607,6 +1610,7 @@ pub const Sparc64 = enum(usize) {
     process_mrelease = 448,
     futex_waitv = 449,
     set_mempolicy_home_node = 450,
+    cachestat = 451,
 };
 
 pub const Mips = enum(usize) {
@@ -2030,6 +2034,7 @@ pub const Mips = enum(usize) {
     process_mrelease = Linux + 448,
     futex_waitv = Linux + 449,
     set_mempolicy_home_node = Linux + 450,
+    cachestat = Linux + 451,
 };
 
 pub const Mips64 = enum(usize) {
@@ -2389,6 +2394,7 @@ pub const Mips64 = enum(usize) {
     process_mrelease = Linux + 448,
     futex_waitv = Linux + 449,
     set_mempolicy_home_node = Linux + 450,
+    cachestat = Linux + 451,
 };
 
 pub const PowerPC = enum(usize) {
@@ -2823,6 +2829,7 @@ pub const PowerPC = enum(usize) {
     process_mrelease = 448,
     futex_waitv = 449,
     set_mempolicy_home_node = 450,
+    cachestat = 451,
 };
 
 pub const PowerPC64 = enum(usize) {
@@ -3229,6 +3236,7 @@ pub const PowerPC64 = enum(usize) {
     process_mrelease = 448,
     futex_waitv = 449,
     set_mempolicy_home_node = 450,
+    cachestat = 451,
 };
 
 pub const Arm64 = enum(usize) {
@@ -3538,6 +3546,7 @@ pub const Arm64 = enum(usize) {
     process_mrelease = 448,
     futex_waitv = 449,
     set_mempolicy_home_node = 450,
+    cachestat = 451,
 };
 
 pub const RiscV64 = enum(usize) {
@@ -3848,6 +3857,7 @@ pub const RiscV64 = enum(usize) {
     process_mrelease = 448,
     futex_waitv = 449,
     set_mempolicy_home_node = 450,
+    cachestat = 451,
 
     riscv_flush_icache = arch_specific_syscall + 15,
 };

--- a/tools/generate_linux_syscalls.zig
+++ b/tools/generate_linux_syscalls.zig
@@ -262,7 +262,6 @@ pub fn main() !void {
             .argv = &child_args,
             .cwd = linux_path,
             .cwd_dir = linux_dir,
-            .max_output_bytes = 20 * 1024,
         });
         if (child_result.stderr.len > 0) std.debug.print("{s}\n", .{child_result.stderr});
 
@@ -324,7 +323,6 @@ pub fn main() !void {
             .argv = &child_args,
             .cwd = linux_path,
             .cwd_dir = linux_dir,
-            .max_output_bytes = 20 * 1024,
         });
         if (child_result.stderr.len > 0) std.debug.print("{s}\n", .{child_result.stderr});
 


### PR DESCRIPTION
The wrapper can be tested using this program I whipped up:
https://gist.github.com/The-King-of-Toasters/aee448f5975c50f735fd1946794574f7