### PR TITLE
elf: add basic TLS segment handling

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -926,6 +926,11 @@ pub fn growAllocSection(self: *Elf, shdr_index: u16, needed_size: u64) !void {
         phdr.p_offset = new_offset;
     }
 
+    shdr.sh_size = needed_size;
+    if (!is_zerofill) {
+        phdr.p_filesz = needed_size;
+    }
+
     const mem_capacity = self.allocatedVirtualSize(phdr.p_vaddr);
     if (needed_size > mem_capacity) {
         // We are exceeding our allocated VM capacity so we need to shift everything in memory
@@ -952,12 +957,7 @@ pub fn growAllocSection(self: *Elf, shdr_index: u16, needed_size: u64) !void {
         }
     }
 
-    shdr.sh_size = needed_size;
     phdr.p_memsz = needed_size;
-
-    if (!is_zerofill) {
-        phdr.p_filesz = needed_size;
-    }
 
     self.markDirty(shdr_index, phdr_index);
 }

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -367,10 +367,12 @@ fn detectAllocCollision(self: *Elf, start: u64, size: u64) ?u64 {
         }
     }
 
-    for (self.shdrs.items) |section| {
-        const increased_size = padToIdeal(section.sh_size);
-        const test_end = section.sh_offset + increased_size;
-        if (end > section.sh_offset and start < test_end) {
+    for (self.shdrs.items) |shdr| {
+        // SHT_NOBITS takes no physical space in the output file so set its size to 0.
+        const sh_size = if (shdr.sh_type == elf.SHT_NOBITS) 0 else shdr.sh_size;
+        const increased_size = padToIdeal(sh_size);
+        const test_end = shdr.sh_offset + increased_size;
+        if (end > shdr.sh_offset and start < test_end) {
             return test_end;
         }
     }

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -4098,7 +4098,7 @@ const ErrorWithNotes = struct {
     }
 };
 
-fn addErrorWithNotes(self: *Elf, note_count: usize) error{OutOfMemory}!ErrorWithNotes {
+pub fn addErrorWithNotes(self: *Elf, note_count: usize) error{OutOfMemory}!ErrorWithNotes {
     try self.misc_errors.ensureUnusedCapacity(self.base.allocator, 1);
     return self.addErrorWithNotesAssumeCapacity(note_count);
 }

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -46,7 +46,9 @@ phdr_load_zerofill_index: ?u16 = null,
 /// The index into the program headers of the PT_TLS program header.
 phdr_tls_index: ?u16 = null,
 /// The index into the program headers of a PT_LOAD program header with TLS data.
-phdr_load_tls_index: ?u16 = null,
+phdr_load_tls_data_index: ?u16 = null,
+/// The index into the program headers of a PT_LOAD program header with TLS zerofill data.
+phdr_load_tls_zerofill_index: ?u16 = null,
 
 entry_addr: ?u64 = null,
 page_size: u32,
@@ -499,7 +501,7 @@ pub fn allocateAllocSection(self: *Elf, opts: AllocateAllocSectionOpts) error{Ou
         .sh_flags = opts.flags,
         .sh_addr = phdr.p_vaddr,
         .sh_offset = phdr.p_offset,
-        .sh_size = phdr.p_filesz,
+        .sh_size = phdr.p_memsz,
         .sh_link = 0,
         .sh_info = 0,
         .sh_addralign = opts.alignment,
@@ -631,24 +633,37 @@ pub fn populateMissingMetadata(self: *Elf) !void {
     }
 
     if (!self.base.options.single_threaded) {
-        if (self.phdr_load_tls_index == null) {
+        if (self.phdr_load_tls_data_index == null) {
             const alignment = if (is_linux) self.page_size else @as(u16, ptr_size);
-            self.phdr_load_tls_index = try self.allocateSegment(.{
+            self.phdr_load_tls_data_index = try self.allocateSegment(.{
                 .size = 1024,
                 .alignment = alignment,
                 .flags = elf.PF_R | elf.PF_W,
             });
         }
 
+        if (self.phdr_load_tls_zerofill_index == null) {
+            const alignment = if (is_linux) self.page_size else @as(u16, ptr_size);
+            self.phdr_load_tls_zerofill_index = try self.allocateSegment(.{
+                .size = 0,
+                .alignment = alignment,
+                .flags = elf.PF_R | elf.PF_W,
+            });
+            const phdr = &self.phdrs.items[self.phdr_load_tls_zerofill_index.?];
+            phdr.p_offset = self.phdrs.items[self.phdr_load_tls_data_index.?].p_offset; // .tbss overlaps .tdata
+            phdr.p_memsz = 1024;
+        }
+
         if (self.phdr_tls_index == null) {
-            const phdr = &self.phdrs.items[self.phdr_load_tls_index.?];
+            const phdr_tdata = &self.phdrs.items[self.phdr_load_tls_data_index.?];
+            const phdr_tbss = &self.phdrs.items[self.phdr_load_tls_zerofill_index.?];
             try self.phdrs.append(gpa, .{
                 .p_type = elf.PT_TLS,
-                .p_offset = phdr.p_offset,
-                .p_vaddr = phdr.p_vaddr,
-                .p_paddr = phdr.p_paddr,
-                .p_filesz = phdr.p_filesz,
-                .p_memsz = phdr.p_memsz,
+                .p_offset = phdr_tdata.p_offset,
+                .p_vaddr = phdr_tdata.p_vaddr,
+                .p_paddr = phdr_tdata.p_paddr,
+                .p_filesz = phdr_tdata.p_filesz,
+                .p_memsz = phdr_tbss.p_vaddr + phdr_tbss.p_memsz - phdr_tdata.p_vaddr,
                 .p_align = ptr_size,
                 .p_flags = elf.PF_R,
             });
@@ -722,6 +737,31 @@ pub fn populateMissingMetadata(self: *Elf) !void {
             .type = elf.SHT_NOBITS,
         });
         try self.last_atom_and_free_list_table.putNoClobber(gpa, self.bss_section_index.?, .{});
+    }
+
+    if (self.phdr_load_tls_data_index) |phdr_index| {
+        if (self.tdata_section_index == null) {
+            self.tdata_section_index = try self.allocateAllocSection(.{
+                .name = ".tdata",
+                .phdr_index = phdr_index,
+                .alignment = ptr_size,
+                .flags = elf.SHF_ALLOC | elf.SHF_WRITE | elf.SHF_TLS,
+            });
+            try self.last_atom_and_free_list_table.putNoClobber(gpa, self.tdata_section_index.?, .{});
+        }
+    }
+
+    if (self.phdr_load_tls_zerofill_index) |phdr_index| {
+        if (self.tbss_section_index == null) {
+            self.tbss_section_index = try self.allocateAllocSection(.{
+                .name = ".tbss",
+                .phdr_index = phdr_index,
+                .alignment = ptr_size,
+                .flags = elf.SHF_ALLOC | elf.SHF_WRITE | elf.SHF_TLS,
+                .type = elf.SHT_NOBITS,
+            });
+            try self.last_atom_and_free_list_table.putNoClobber(gpa, self.tbss_section_index.?, .{});
+        }
     }
 
     if (self.symtab_section_index == null) {
@@ -1293,6 +1333,12 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
         const bss_phndx = self.phdr_to_shdr_table.get(bss_shndx).?;
         self.shdrs.items[bss_shndx].sh_offset = self.shdrs.items[data_shndx].sh_offset;
         self.phdrs.items[bss_phndx].p_offset = self.phdrs.items[data_phndx].p_offset;
+    }
+
+    // Same treatment for .tbss section.
+    if (self.tdata_section_index) |tdata_shndx| blk: {
+        const tbss_shndx = self.tbss_section_index orelse break :blk;
+        self.shdrs.items[tbss_shndx].sh_offset = self.shdrs.items[tdata_shndx].sh_offset;
     }
 
     // Dump the state for easy debugging.

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1353,12 +1353,6 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
     try self.updateSymtabSize();
     try self.writeSymtab();
 
-    // Dump the state for easy debugging.
-    // State can be dumped via `--debug-log link_state`.
-    if (build_options.enable_logging) {
-        state_log.debug("{}", .{self.dumpState()});
-    }
-
     if (self.dwarf) |*dw| {
         if (self.debug_abbrev_section_dirty) {
             try dw.writeDbgAbbrev();
@@ -1543,6 +1537,12 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
         log.debug("flushing. no_entry_point_found = false", .{});
         self.error_flags.no_entry_point_found = false;
         try self.writeElfHeader();
+    }
+
+    // Dump the state for easy debugging.
+    // State can be dumped via `--debug-log link_state`.
+    if (build_options.enable_logging) {
+        state_log.debug("{}", .{self.dumpState()});
     }
 
     // The point of flush() is to commit changes, so in theory, nothing should

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -388,7 +388,17 @@ pub fn scanRelocs(self: Atom, elf_file: *Elf, undefs: anytype) !void {
 
             elf.R_X86_64_PC32 => {},
 
-            else => @panic("TODO"),
+            else => {
+                var err = try elf_file.addErrorWithNotes(1);
+                try err.addMsg(elf_file, "fatal linker error: unhandled relocation type {}", .{
+                    fmtRelocType(rel.r_type()),
+                });
+                try err.addNote(elf_file, "in {}:{s} at offset 0x{x}", .{
+                    self.file(elf_file).?.fmtPath(),
+                    self.name(elf_file),
+                    rel.r_offset,
+                });
+            },
         }
     }
 }
@@ -512,10 +522,7 @@ pub fn resolveRelocs(self: Atom, elf_file: *Elf, code: []u8) !void {
                 try cwriter.writeIntLittle(i32, @as(i32, @intCast(G + GOT + A - P)));
             },
 
-            else => {
-                log.err("TODO: unhandled relocation type {}", .{fmtRelocType(rel.r_type())});
-                @panic("TODO unhandled relocation type");
-            },
+            else => {},
         }
     }
 }

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -59,38 +59,6 @@ pub fn outputShndx(self: Atom) ?u16 {
     return self.output_section_index;
 }
 
-pub fn codeInObject(self: Atom, elf_file: *Elf) error{Overflow}![]const u8 {
-    const object = self.file(elf_file).?.object;
-    return object.shdrContents(self.input_section_index);
-}
-
-/// Returns atom's code and optionally uncompresses data if required (for compressed sections).
-/// Caller owns the memory.
-pub fn codeInObjectUncompressAlloc(self: Atom, elf_file: *Elf) ![]u8 {
-    const gpa = elf_file.base.allocator;
-    const data = try self.codeInObject(elf_file);
-    const shdr = self.inputShdr(elf_file);
-    if (shdr.sh_flags & elf.SHF_COMPRESSED != 0) {
-        const chdr = @as(*align(1) const elf.Elf64_Chdr, @ptrCast(data.ptr)).*;
-        switch (chdr.ch_type) {
-            .ZLIB => {
-                var stream = std.io.fixedBufferStream(data[@sizeOf(elf.Elf64_Chdr)..]);
-                var zlib_stream = std.compress.zlib.decompressStream(gpa, stream.reader()) catch
-                    return error.InputOutput;
-                defer zlib_stream.deinit();
-                const size = std.math.cast(usize, chdr.ch_size) orelse return error.Overflow;
-                const decomp = try gpa.alloc(u8, size);
-                const nread = zlib_stream.reader().readAll(decomp) catch return error.InputOutput;
-                if (nread != decomp.len) {
-                    return error.InputOutput;
-                }
-                return decomp;
-            },
-            else => @panic("TODO unhandled compression scheme"),
-        }
-    } else return gpa.dupe(u8, data);
-}
-
 pub fn priority(self: Atom, elf_file: *Elf) u64 {
     const index = self.file(elf_file).?.index();
     return (@as(u64, @intCast(index)) << 32) | @as(u64, @intCast(self.input_section_index));
@@ -327,7 +295,15 @@ pub fn freeRelocs(self: Atom, elf_file: *Elf) void {
     zig_module.relocs.items[self.relocs_section_index].clearRetainingCapacity();
 }
 
-pub fn scanRelocs(self: Atom, elf_file: *Elf, undefs: anytype) !void {
+pub fn scanRelocsRequiresCode(self: Atom, elf_file: *Elf) error{Overflow}!bool {
+    for (try self.relocs(elf_file)) |rel| {
+        if (rel.r_type() == elf.R_X86_64_GOTTPOFF) return true;
+    }
+    return false;
+}
+
+pub fn scanRelocs(self: Atom, elf_file: *Elf, code: ?[]const u8, undefs: anytype) !void {
+    const is_dyn_lib = elf_file.isDynLib();
     const file_ptr = self.file(elf_file).?;
     const rels = try self.relocs(elf_file);
     var i: usize = 0;
@@ -391,7 +367,38 @@ pub fn scanRelocs(self: Atom, elf_file: *Elf, undefs: anytype) !void {
             elf.R_X86_64_TPOFF32,
             elf.R_X86_64_TPOFF64,
             => {
-                // if (is_shared) self.picError(symbol, rel, elf_file);
+                if (is_dyn_lib) {
+                    // TODO
+                    // self.picError(symbol, rel, elf_file);
+                }
+            },
+
+            elf.R_X86_64_TLSGD => {
+                // TODO verify followed by appropriate relocation such as PLT32 __tls_get_addr
+
+                if (elf_file.isStatic() or
+                    (!symbol.flags.import and !is_dyn_lib))
+                {
+                    // Relax if building with -static flag as __tls_get_addr() will not be present in libc.a
+                    // We skip the next relocation.
+                    i += 1;
+                } else if (!symbol.flags.import and is_dyn_lib) {
+                    symbol.flags.needs_gottp = true;
+                    i += 1;
+                } else {
+                    symbol.flags.needs_tlsgd = true;
+                }
+            },
+
+            elf.R_X86_64_GOTTPOFF => {
+                const should_relax = blk: {
+                    // if (!elf_file.options.relax or is_shared or symbol.flags.import) break :blk false;
+                    if (!x86_64.canRelaxGotTpOff(code.?[rel.r_offset - 3 ..])) break :blk false;
+                    break :blk true;
+                };
+                if (!should_relax) {
+                    symbol.flags.needs_gottp = true;
+                }
             },
 
             else => {
@@ -446,7 +453,10 @@ pub fn resolveRelocs(self: Atom, elf_file: *Elf, code: []u8) !void {
     var stream = std.io.fixedBufferStream(code);
     const cwriter = stream.writer();
 
-    for (try self.relocs(elf_file)) |rel| {
+    const rels = try self.relocs(elf_file);
+    var i: usize = 0;
+    while (i < rels.len) : (i += 1) {
+        const rel = rels[i];
         const r_type = rel.r_type();
         if (r_type == elf.R_X86_64_NONE) continue;
 
@@ -530,6 +540,39 @@ pub fn resolveRelocs(self: Atom, elf_file: *Elf, code: []u8) !void {
 
             elf.R_X86_64_TPOFF32 => try cwriter.writeIntLittle(i32, @as(i32, @truncate(S + A - TP))),
             elf.R_X86_64_TPOFF64 => try cwriter.writeIntLittle(i64, S + A - TP),
+
+            elf.R_X86_64_TLSGD => {
+                if (target.flags.has_tlsgd) {
+                    // TODO
+                    // const S_ = @as(i64, @intCast(target.tlsGdAddress(elf_file)));
+                    // try cwriter.writeIntLittle(i32, @as(i32, @intCast(S_ + A - P)));
+                } else if (target.flags.has_gottp) {
+                    // TODO
+                    // const S_ = @as(i64, @intCast(target.getGotTpAddress(elf_file)));
+                    // try relaxTlsGdToIe(relocs[i .. i + 2], @intCast(S_ - P), elf_file, &stream);
+                    i += 1;
+                } else {
+                    try x86_64.relaxTlsGdToLe(
+                        self,
+                        rels[i .. i + 2],
+                        @as(i32, @intCast(S - TP)),
+                        elf_file,
+                        &stream,
+                    );
+                    i += 1;
+                }
+            },
+
+            elf.R_X86_64_GOTTPOFF => {
+                if (target.flags.has_gottp) {
+                    // TODO
+                    // const S_ = @as(i64, @intCast(target.gotTpAddress(elf_file)));
+                    // try cwriter.writeIntLittle(i32, @as(i32, @intCast(S_ + A - P)));
+                } else {
+                    x86_64.relaxGotTpOff(code[rel.r_offset - 3 ..]) catch unreachable;
+                    try cwriter.writeIntLittle(i32, @as(i32, @intCast(S - TP)));
+                }
+            },
 
             else => {},
         }
@@ -694,6 +737,80 @@ const x86_64 = struct {
                 encode(&.{inst}, code) catch return error.RelaxFail;
             },
             else => return error.RelaxFail,
+        }
+    }
+
+    pub fn canRelaxGotTpOff(code: []const u8) bool {
+        const old_inst = disassemble(code) orelse return false;
+        switch (old_inst.encoding.mnemonic) {
+            .mov => if (Instruction.new(old_inst.prefix, .mov, &.{
+                old_inst.ops[0],
+                // TODO: hack to force imm32s in the assembler
+                .{ .imm = Immediate.s(-129) },
+            })) |inst| {
+                inst.encode(std.io.null_writer, .{}) catch return false;
+                return true;
+            } else |_| return false,
+            else => return false,
+        }
+    }
+
+    pub fn relaxGotTpOff(code: []u8) !void {
+        const old_inst = disassemble(code) orelse return error.RelaxFail;
+        switch (old_inst.encoding.mnemonic) {
+            .mov => {
+                const inst = try Instruction.new(old_inst.prefix, .mov, &.{
+                    old_inst.ops[0],
+                    // TODO: hack to force imm32s in the assembler
+                    .{ .imm = Immediate.s(-129) },
+                });
+                relocs_log.debug("    relaxing {} => {}", .{ old_inst.encoding, inst.encoding });
+                encode(&.{inst}, code) catch return error.RelaxFail;
+            },
+            else => return error.RelaxFail,
+        }
+    }
+
+    pub fn relaxTlsGdToLe(
+        self: Atom,
+        rels: []align(1) const elf.Elf64_Rela,
+        value: i32,
+        elf_file: *Elf,
+        stream: anytype,
+    ) !void {
+        assert(rels.len == 2);
+        const writer = stream.writer();
+        switch (rels[1].r_type()) {
+            elf.R_X86_64_PC32,
+            elf.R_X86_64_PLT32,
+            elf.R_X86_64_GOTPCREL,
+            elf.R_X86_64_GOTPCRELX,
+            => {
+                var insts = [_]u8{
+                    0x64, 0x48, 0x8b, 0x04, 0x25, 0, 0, 0, 0, // movq %fs:0,%rax
+                    0x48, 0x81, 0xc0, 0, 0, 0, 0, // add $tp_offset, %rax
+                };
+                std.mem.writeIntLittle(i32, insts[12..][0..4], value);
+                try stream.seekBy(-4);
+                try writer.writeAll(&insts);
+                relocs_log.debug("    relaxing {} and {}", .{
+                    fmtRelocType(rels[0].r_type()),
+                    fmtRelocType(rels[1].r_type()),
+                });
+            },
+
+            else => {
+                var err = try elf_file.addErrorWithNotes(1);
+                try err.addMsg(elf_file, "fatal linker error: rewrite {} when followed by {}", .{
+                    fmtRelocType(rels[0].r_type()),
+                    fmtRelocType(rels[1].r_type()),
+                });
+                try err.addNote(elf_file, "in {}:{s} at offset 0x{x}", .{
+                    self.file(elf_file).?.fmtPath(),
+                    self.name(elf_file),
+                    rels[0].r_offset,
+                });
+            },
         }
     }
 

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -208,6 +208,8 @@ fn getOutputSectionIndex(self: *Object, elf_file: *Elf, shdr: elf.Elf64_Shdr) er
                 break :blk prefix;
             }
         }
+        if (std.mem.eql(u8, name, ".tcommon")) break :blk ".tbss";
+        if (std.mem.eql(u8, name, ".common")) break :blk ".bss";
         break :blk name;
     };
     const @"type" = switch (shdr.sh_type) {
@@ -427,7 +429,13 @@ pub fn scanRelocs(self: *Object, elf_file: *Elf, undefs: anytype) !void {
         const shdr = atom.inputShdr(elf_file);
         if (shdr.sh_flags & elf.SHF_ALLOC == 0) continue;
         if (shdr.sh_type == elf.SHT_NOBITS) continue;
-        try atom.scanRelocs(elf_file, undefs);
+        if (try atom.scanRelocsRequiresCode(elf_file)) {
+            // TODO ideally, we don't have to decompress at this stage (should already be done)
+            // and we just fetch the code slice.
+            const code = try self.codeDecompressAlloc(elf_file, atom_index);
+            defer elf_file.base.allocator.free(code);
+            try atom.scanRelocs(elf_file, code, undefs);
+        } else try atom.scanRelocs(elf_file, null, undefs);
     }
 
     for (self.cies.items) |cie| {
@@ -590,7 +598,7 @@ pub fn convertCommonSymbols(self: *Object, elf_file: *Elf) !void {
         try self.atoms.append(gpa, atom_index);
 
         const is_tls = global.getType(elf_file) == elf.STT_TLS;
-        const name = if (is_tls) ".tls_common" else ".common";
+        const name = if (is_tls) ".tbss" else ".bss";
 
         const atom = elf_file.atom(atom_index).?;
         atom.atom_index = atom_index;
@@ -684,12 +692,41 @@ pub fn globals(self: *Object) []const Symbol.Index {
     return self.symbols.items[start..];
 }
 
-pub fn shdrContents(self: *Object, index: u32) error{Overflow}![]const u8 {
+fn shdrContents(self: Object, index: u32) error{Overflow}![]const u8 {
     assert(index < self.shdrs.items.len);
     const shdr = self.shdrs.items[index];
     const offset = math.cast(usize, shdr.sh_offset) orelse return error.Overflow;
     const size = math.cast(usize, shdr.sh_size) orelse return error.Overflow;
     return self.data[offset..][0..size];
+}
+
+/// Returns atom's code and optionally uncompresses data if required (for compressed sections).
+/// Caller owns the memory.
+pub fn codeDecompressAlloc(self: Object, elf_file: *Elf, atom_index: Atom.Index) ![]u8 {
+    const gpa = elf_file.base.allocator;
+    const atom_ptr = elf_file.atom(atom_index).?;
+    assert(atom_ptr.file_index == self.index);
+    const data = try self.shdrContents(atom_ptr.input_section_index);
+    const shdr = atom_ptr.inputShdr(elf_file);
+    if (shdr.sh_flags & elf.SHF_COMPRESSED != 0) {
+        const chdr = @as(*align(1) const elf.Elf64_Chdr, @ptrCast(data.ptr)).*;
+        switch (chdr.ch_type) {
+            .ZLIB => {
+                var stream = std.io.fixedBufferStream(data[@sizeOf(elf.Elf64_Chdr)..]);
+                var zlib_stream = std.compress.zlib.decompressStream(gpa, stream.reader()) catch
+                    return error.InputOutput;
+                defer zlib_stream.deinit();
+                const size = std.math.cast(usize, chdr.ch_size) orelse return error.Overflow;
+                const decomp = try gpa.alloc(u8, size);
+                const nread = zlib_stream.reader().readAll(decomp) catch return error.InputOutput;
+                if (nread != decomp.len) {
+                    return error.InputOutput;
+                }
+                return decomp;
+            },
+            else => @panic("TODO unhandled compression scheme"),
+        }
+    } else return gpa.dupe(u8, data);
 }
 
 fn getString(self: *Object, off: u32) [:0]const u8 {

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -233,8 +233,7 @@ fn getOutputSectionIndex(self: *Object, elf_file: *Elf, shdr: elf.Elf64_Shdr) er
         const is_alloc = flags & elf.SHF_ALLOC != 0;
         const is_write = flags & elf.SHF_WRITE != 0;
         const is_exec = flags & elf.SHF_EXECINSTR != 0;
-        const is_tls = flags & elf.SHF_TLS != 0;
-        if (!is_alloc or is_tls) {
+        if (!is_alloc) {
             log.err("{}: output section {s} not found", .{ self.fmtPath(), name });
             @panic("TODO: missing output section!");
         }
@@ -243,7 +242,7 @@ fn getOutputSectionIndex(self: *Object, elf_file: *Elf, shdr: elf.Elf64_Shdr) er
         if (is_exec) phdr_flags |= elf.PF_X;
         const phdr_index = try elf_file.allocateSegment(.{
             .size = Elf.padToIdeal(shdr.sh_size),
-            .alignment = if (is_tls) shdr.sh_addralign else elf_file.page_size,
+            .alignment = elf_file.page_size,
             .flags = phdr_flags,
         });
         const shndx = try elf_file.allocateAllocSection(.{

--- a/src/link/Elf/Symbol.zig
+++ b/src/link/Elf/Symbol.zig
@@ -196,9 +196,9 @@ pub fn setOutputSym(symbol: Symbol, elf_file: *Elf, out: *elf.Elf64_Sym) void {
         //     if (symbol.flags.is_canonical) break :blk symbol.address(.{}, elf_file);
         //     break :blk 0;
         // }
-        // if (st_shndx == elf.SHN_ABS) break :blk symbol.value;
-        // const shdr = &elf_file.sections.items(.shdr)[st_shndx];
-        // if (Elf.shdrIsTls(shdr)) break :blk symbol.value - elf_file.getTlsAddress();
+        if (st_shndx == elf.SHN_ABS) break :blk symbol.value;
+        const shdr = &elf_file.shdrs.items[st_shndx];
+        if (shdr.sh_flags & elf.SHF_TLS != 0) break :blk symbol.value - elf_file.tlsAddress();
         break :blk symbol.value;
     };
     out.* = .{

--- a/src/link/Elf/Symbol.zig
+++ b/src/link/Elf/Symbol.zig
@@ -327,10 +327,12 @@ pub const Flags = packed struct {
     has_dynamic: bool = false,
 
     /// Whether the symbol contains TLSGD indirection.
-    tlsgd: bool = false,
+    needs_tlsgd: bool = false,
+    has_tlsgd: bool = false,
 
     /// Whether the symbol contains GOTTP indirection.
-    gottp: bool = false,
+    needs_gottp: bool = false,
+    has_gottp: bool = false,
 
     /// Whether the symbol contains TLSDESC indirection.
     tlsdesc: bool = false,

--- a/src/link/Elf/Symbol.zig
+++ b/src/link/Elf/Symbol.zig
@@ -198,7 +198,8 @@ pub fn setOutputSym(symbol: Symbol, elf_file: *Elf, out: *elf.Elf64_Sym) void {
         // }
         if (st_shndx == elf.SHN_ABS) break :blk symbol.value;
         const shdr = &elf_file.shdrs.items[st_shndx];
-        if (shdr.sh_flags & elf.SHF_TLS != 0) break :blk symbol.value - elf_file.tlsAddress();
+        if (shdr.sh_flags & elf.SHF_TLS != 0 and file_ptr != .linker_defined)
+            break :blk symbol.value - elf_file.tlsAddress();
         break :blk symbol.value;
     };
     out.* = .{

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -158,17 +158,23 @@ fn addRunArtifact(comp: *Compile) *Run {
     return run;
 }
 
-fn addZigSourceBytes(comp: *Compile, bytes: []const u8) void {
+fn addZigSourceBytes(comp: *Compile, comptime bytes: []const u8) void {
     const b = comp.step.owner;
     const file = WriteFile.create(b).add("a.zig", bytes);
     file.addStepDependencies(&comp.step);
     comp.root_src = file;
 }
 
-fn addCSourceBytes(comp: *Compile, bytes: []const u8) void {
+fn addCSourceBytes(comp: *Compile, comptime bytes: []const u8) void {
     const b = comp.step.owner;
     const file = WriteFile.create(b).add("a.c", bytes);
     comp.addCSourceFile(.{ .file = file, .flags = &.{} });
+}
+
+fn addAsmSourceBytes(comp: *Compile, comptime bytes: []const u8) void {
+    const b = comp.step.owner;
+    const file = WriteFile.create(b).add("a.s", bytes ++ "\n");
+    comp.addAssemblyFile(file);
 }
 
 const std = @import("std");

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -196,6 +196,15 @@ const test_targets = blk: {
             },
             .link_libc = true,
         },
+        .{
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .link_libc = true,
+            .use_lld = false,
+        },
 
         .{
             .target = .{
@@ -1031,6 +1040,7 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
             "-selfhosted"
         else
             "";
+        const use_lld = if (test_target.use_lld == false) "-no-lld" else "";
 
         these_tests.addIncludePath(.{ .path = "test" });
 
@@ -1039,13 +1049,14 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
             these_tests.stack_size = 2 * 1024 * 1024;
         }
 
-        const qualified_name = b.fmt("{s}-{s}-{s}{s}{s}{s}", .{
+        const qualified_name = b.fmt("{s}-{s}-{s}{s}{s}{s}{s}", .{
             options.name,
             triple_txt,
             @tagName(test_target.optimize_mode),
             libc_suffix,
             single_threaded_suffix,
             backend_suffix,
+            use_lld,
         });
 
         if (test_target.target.ofmt == std.Target.ObjectFormat.c) {


### PR DESCRIPTION
It's not exactly efficient as `.tbss` is actually never mapped at runtime unlike `.bss`. For that reason, typically linker overlaps `.tbss` with a succeeding alloc section, usually `.data`, in virtual memory, since we only care about the continuity of `.tdata` into `.tbss`. When the relocations are resolved, they are lowered into positive and negative offsets wrt to the TLS segment. I think given this knowledge there exists the potential for improving current implementation by quite a bit.

In other news, I have now also added a new test target to the test matrix:

```diff
+        .{
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .link_libc = true,
+            .use_lld = false,
+        },
```