### PR TITLE
autodoc: Add `hidden` class to [src] link when starting renderApi to …

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -750,6 +750,7 @@ Happy writing!
     domSectFnErrors.classList.add("hidden");
     domFnExamples.classList.add("hidden");
     domFnNoExamples.classList.add("hidden");
+    domFnSourceLink.classList.add("hidden");
     domDeclNoRef.classList.add("hidden");
     domFnErrorsAnyError.classList.add("hidden");
     domTableFnErrors.classList.add("hidden");
@@ -904,7 +905,7 @@ Happy writing!
     let typeObj = getType(value.expr.type);
 
     domFnProtoCode.innerHTML = renderTokens(ex(value.expr, { fnDecl: fnDecl }));
-
+    domFnSourceLink.classList.remove("hidden");
     domFnSourceLink.innerHTML = "[<a target=\"_blank\" href=\"" + sourceFileLink(fnDecl) + "\">src</a>]";
 
     let docsSource = null;


### PR DESCRIPTION
…only show it for functions