### PR TITLE
C backend: remove unneeded ordering mechanism

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3495,7 +3495,7 @@ fn processOneJob(comp: *Compilation, job: Job, prog_node: *std.Progress.Node) !v
                         .module = module,
                         .error_msg = null,
                         .decl_index = decl_index.toOptional(),
-                        .decl = decl,
+                        .is_naked_fn = false,
                         .fwd_decl = fwd_decl.toManaged(gpa),
                         .ctypes = .{},
                     };

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -344,9 +344,9 @@ pub fn flushModule(self: *C, _: *Compilation, prog_node: *std.Progress.Node) !vo
         assert(f.ctypes.count() == 0);
         try self.flushCTypes(&f, .none, f.lazy_ctypes);
 
-        var it = self.decl_table.iterator();
-        while (it.next()) |entry|
-            try self.flushCTypes(&f, entry.key_ptr.toOptional(), entry.value_ptr.ctypes);
+        for (self.decl_table.keys(), self.decl_table.values()) |decl_index, db| {
+            try self.flushCTypes(&f, decl_index.toOptional(), db.ctypes);
+        }
     }
 
     f.all_buffers.items[ctypes_index] = .{


### PR DESCRIPTION
This logic to lower snippets of C code in a dependency order is no longer needed. Simplify the logic by deleting the mechanism.