### PR TITLE
Tweak `windows.UNWIND_HISTORY_TABLE` for `mem.zeroes` compatibility

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -764,7 +764,7 @@ pub noinline fn walkStackWindows(addresses: []usize, existing_context: ?*const w
 
     var i: usize = 0;
     var image_base: usize = undefined;
-    var history_table: windows.UNWIND_HISTORY_TABLE = std.mem.zeroes(windows.UNWIND_HISTORY_TABLE);
+    var history_table = std.mem.zeroes(windows.UNWIND_HISTORY_TABLE);
 
     while (i < addresses.len) : (i += 1) {
         const current_regs = context.getRegs();

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -4104,7 +4104,7 @@ pub const EXCEPTION_ROUTINE = *const fn (
 pub const UNWIND_HISTORY_TABLE_SIZE = 12;
 pub const UNWIND_HISTORY_TABLE_ENTRY = extern struct {
     ImageBase: ULONG64,
-    FunctionEntry: *Self.RUNTIME_FUNCTION,
+    FunctionEntry: ?*Self.RUNTIME_FUNCTION,
 };
 
 pub const UNWIND_HISTORY_TABLE = extern struct {


### PR DESCRIPTION
`mem.zeroes` was not compatible with the structure because it contained non-nullable pointers. Those pointers have been made nullable.

This PR is spun off from #17286 in an attempt to isolate Windows CI failures.