### PR TITLE
autodoc: Add handling for array_cat, array_mul, struct_init_empty_result

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -3246,7 +3246,10 @@ Happy writing!
               const definitionDecl = getDecl(seenDecls[seenDecls.length - 1]);
               docs = getAstNode(definitionDecl.src).docs;
             } else {
-              docs = getAstNode(getType(value.expr.type).src).docs;
+              const type = getType(value.expr.type);
+              if ("src" in type) {
+                docs = getAstNode(type.src).docs;
+              }
             }
         }
         

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -1547,7 +1547,6 @@ fn walkInstruction(
             };
         },
 
-        // @check array_cat and array_mul
         .add,
         .addwrap,
         .add_sat,
@@ -1564,9 +1563,8 @@ fn walkInstruction(
         .bit_or,
         .bit_and,
         .xor,
-        // @check still not working when applied in std
-        // .array_cat,
-        // .array_mul,
+        .array_cat,
+        .array_mul,
         => {
             const pl_node = data[inst_index].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
@@ -2881,7 +2879,9 @@ fn walkInstruction(
                 .expr = .{ .@"struct" = field_vals },
             };
         },
-        .struct_init_empty => {
+        .struct_init_empty,
+        .struct_init_empty_result,
+        => {
             const un_node = data[inst_index].un_node;
 
             var operand: DocData.WalkResult = try self.walkRef(


### PR DESCRIPTION
Fix issue with getting docs for src-less types in main.js