### PR TITLE
Fix issues in `@errorCast` with error unions

### DIFF
--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -238,12 +238,22 @@ fn testExplicitErrorSetCast(set1: Set1) !void {
 test "@errorCast on error unions" {
     const S = struct {
         fn doTheTest() !void {
-            const casted: error{Bad}!i32 = @errorCast(retErrUnion());
-            try expect((try casted) == 1234);
+            {
+                const casted: error{Bad}!i32 = @errorCast(retErrUnion());
+                try expect((try casted) == 1234);
+            }
+            {
+                const casted: error{Bad}!i32 = @errorCast(retInferredErrUnion());
+                try expect((try casted) == 5678);
+            }
         }
 
         fn retErrUnion() anyerror!i32 {
             return 1234;
+        }
+
+        fn retInferredErrUnion() !i32 {
+            return 5678;
         }
     };
 

--- a/test/cases/safety/@errorCast error union casted to disjoint set.zig
+++ b/test/cases/safety/@errorCast error union casted to disjoint set.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
+    _ = stack_trace;
+    if (std.mem.eql(u8, message, "invalid error code")) {
+        std.process.exit(0);
+    }
+    std.process.exit(1);
+}
+pub fn main() !void {
+    const bar: error{Foo}!i32 = @errorCast(foo());
+    _ = &bar;
+    return error.TestFailed;
+}
+fn foo() anyerror!i32 {
+    return error.Bar;
+}
+// run
+// backend=llvm
+// target=native


### PR DESCRIPTION
Closes #17353
Closes #17355

#17354 passes analysis but crashes in codegen because `error_set_has_value` doesn't work with adhoc inferred error sets and I'm not quite sure how it should be fixed.