### PR TITLE
Add behavior test for empty tuple type

### DIFF
--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -465,3 +465,15 @@ test "coerce anon tuple to tuple" {
     try expectEqual(x, s[0]);
     try expectEqual(y, s[1]);
 }
+
+test "empty tuple type" {
+    const S = @Type(.{ .Struct = .{
+        .layout = .Auto,
+        .fields = &.{},
+        .decls = &.{},
+        .is_tuple = true,
+    } });
+
+    const s: S = .{};
+    try expect(s.len == 0);
+}


### PR DESCRIPTION
Closes #16412

---

This bug appears to have been fixed at some point since I opened the issue. I didn't see a behavior test for an empty tuple type, so I figured it would be good to add one along with closing the issue.