### PR TITLE
Add runtime page_size

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -686,7 +686,7 @@ const PosixThreadImpl = struct {
         // Use the same set of parameters used by the libc-less impl.
         const stack_size = @max(config.stack_size, 16 * 1024);
         assert(c.pthread_attr_setstacksize(&attr, stack_size) == .SUCCESS);
-        assert(c.pthread_attr_setguardsize(&attr, std.mem.page_size) == .SUCCESS);
+        assert(c.pthread_attr_setguardsize(&attr, std.heap.pageSize()) == .SUCCESS);
 
         var handle: c.pthread_t = undefined;
         switch (c.pthread_create(
@@ -1066,7 +1066,7 @@ const LinuxThreadImpl = struct {
         completion: Completion = Completion.init(.running),
         child_tid: std.atomic.Value(i32) = std.atomic.Value(i32).init(1),
         parent_tid: i32 = undefined,
-        mapped: []align(std.mem.page_size) u8,
+        mapped: []u8,
 
         /// Calls `munmap(mapped.ptr, mapped.len)` then `exit(1)` without touching the stack (which lives in `mapped.ptr`).
         /// Ported over from musl libc's pthread detached implementation:
@@ -1210,7 +1210,7 @@ const LinuxThreadImpl = struct {
     };
 
     fn spawn(config: SpawnConfig, comptime f: anytype, args: anytype) !Impl {
-        const page_size = std.mem.page_size;
+        const page_size = std.heap.pageSize();
         const Args = @TypeOf(args);
         const Instance = struct {
             fn_args: Args,

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const c = @This();
-const page_size = std.mem.page_size;
 const iovec = std.posix.iovec;
 const iovec_const = std.posix.iovec_const;
 const wasi = @import("c/wasi.zig");
@@ -1507,6 +1506,8 @@ pub extern "c" fn sigwait(set: ?*c.sigset_t, sig: ?*c_int) c_int;
 
 pub extern "c" fn alarm(seconds: c_uint) c_uint;
 
+pub extern "c" fn sysconf(sc: c_int) c_long;
+
 pub const clock_getres = switch (native_os) {
     .netbsd => private.__clock_getres50,
     else => private.clock_getres,
@@ -1632,9 +1633,9 @@ pub extern "c" fn writev(fd: c_int, iov: [*]const iovec_const, iovcnt: c_uint) i
 pub extern "c" fn pwritev(fd: c_int, iov: [*]const iovec_const, iovcnt: c_uint, offset: c.off_t) isize;
 pub extern "c" fn write(fd: c.fd_t, buf: [*]const u8, nbyte: usize) isize;
 pub extern "c" fn pwrite(fd: c.fd_t, buf: [*]const u8, nbyte: usize, offset: c.off_t) isize;
-pub extern "c" fn mmap(addr: ?*align(page_size) anyopaque, len: usize, prot: c_uint, flags: MAP, fd: c.fd_t, offset: c.off_t) *anyopaque;
-pub extern "c" fn munmap(addr: *align(page_size) const anyopaque, len: usize) c_int;
-pub extern "c" fn mprotect(addr: *align(page_size) anyopaque, len: usize, prot: c_uint) c_int;
+pub extern "c" fn mmap(addr: ?*anyopaque, len: usize, prot: c_uint, flags: MAP, fd: c.fd_t, offset: c.off_t) *anyopaque;
+pub extern "c" fn munmap(addr: *const anyopaque, len: usize) c_int;
+pub extern "c" fn mprotect(addr: *anyopaque, len: usize, prot: c_uint) c_int;
 pub extern "c" fn link(oldpath: [*:0]const u8, newpath: [*:0]const u8, flags: c_int) c_int;
 pub extern "c" fn linkat(oldfd: c.fd_t, oldpath: [*:0]const u8, newfd: c.fd_t, newpath: [*:0]const u8, flags: c_int) c_int;
 pub extern "c" fn unlink(path: [*:0]const u8) c_int;
@@ -1922,7 +1923,7 @@ const private = struct {
     extern "c" fn getdirentries(fd: c.fd_t, buf_ptr: [*]u8, nbytes: usize, basep: *i64) isize;
     extern "c" fn getrusage(who: c_int, usage: *c.rusage) c_int;
     extern "c" fn gettimeofday(noalias tv: ?*c.timeval, noalias tz: ?*c.timezone) c_int;
-    extern "c" fn msync(addr: *align(page_size) const anyopaque, len: usize, flags: c_int) c_int;
+    extern "c" fn msync(addr: *const anyopaque, len: usize, flags: c_int) c_int;
     extern "c" fn nanosleep(rqtp: *const c.timespec, rmtp: ?*c.timespec) c_int;
     extern "c" fn readdir(dir: *c.DIR) ?*c.dirent;
     extern "c" fn realpath(noalias file_name: [*:0]const u8, noalias resolved_name: [*]u8) ?[*:0]u8;
@@ -1952,7 +1953,7 @@ const private = struct {
     extern "c" fn __getrusage50(who: c_int, usage: *c.rusage) c_int;
     extern "c" fn __gettimeofday50(noalias tv: ?*c.timeval, noalias tz: ?*c.timezone) c_int;
     extern "c" fn __libc_thr_yield() c_int;
-    extern "c" fn __msync13(addr: *align(std.mem.page_size) const anyopaque, len: usize, flags: c_int) c_int;
+    extern "c" fn __msync13(addr: *const anyopaque, len: usize, flags: c_int) c_int;
     extern "c" fn __nanosleep50(rqtp: *const c.timespec, rmtp: ?*c.timespec) c_int;
     extern "c" fn __sigaction14(sig: c_int, noalias act: ?*const c.Sigaction, noalias oact: ?*c.Sigaction) c_int;
     extern "c" fn __sigfillset14(set: ?*c.sigset_t) void;

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -3184,7 +3184,7 @@ pub const MachTask = extern struct {
         return left;
     }
 
-    fn getPageSize(task: MachTask) MachError!usize {
+    pub fn getPageSize(task: MachTask) MachError!usize {
         if (task.isValid()) {
             var info_count = TASK_VM_INFO_COUNT;
             var vm_info: task_vm_info_data_t = undefined;
@@ -3337,3 +3337,5 @@ pub extern "c" fn os_signpost_interval_begin(log: os_log_t, signpos: os_signpost
 pub extern "c" fn os_signpost_interval_end(log: os_log_t, signpos: os_signpost_id_t, func: [*]const u8, ...) void;
 pub extern "c" fn os_signpost_id_make_with_pointer(log: os_log_t, ptr: ?*anyopaque) os_signpost_id_t;
 pub extern "c" fn os_signpost_enabled(log: os_log_t) bool;
+
+pub extern "c" fn getpagesize() c_int;

--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -238,7 +238,7 @@ pub extern "c" fn fstatat64(dirfd: fd_t, noalias path: [*:0]const u8, noalias st
 pub extern "c" fn ftruncate64(fd: c_int, length: off_t) c_int;
 pub extern "c" fn getrlimit64(resource: rlimit_resource, rlim: *rlimit) c_int;
 pub extern "c" fn lseek64(fd: fd_t, offset: i64, whence: c_int) i64;
-pub extern "c" fn mmap64(addr: ?*align(std.mem.page_size) anyopaque, len: usize, prot: c_uint, flags: c_uint, fd: fd_t, offset: i64) *anyopaque;
+pub extern "c" fn mmap64(addr: ?*anyopaque, len: usize, prot: c_uint, flags: c_uint, fd: fd_t, offset: i64) *anyopaque;
 pub extern "c" fn open64(path: [*:0]const u8, oflag: linux.O, ...) c_int;
 pub extern "c" fn openat64(fd: c_int, path: [*:0]const u8, oflag: linux.O, ...) c_int;
 pub extern "c" fn pread64(fd: fd_t, buf: [*]u8, nbyte: usize, offset: i64) isize;
@@ -295,13 +295,13 @@ pub extern "c" fn posix_memalign(memptr: *?*anyopaque, alignment: usize, size: u
 pub extern "c" fn malloc_usable_size(?*const anyopaque) usize;
 
 pub extern "c" fn mincore(
-    addr: *align(std.mem.page_size) anyopaque,
+    addr: *anyopaque,
     length: usize,
     vec: [*]u8,
 ) c_int;
 
 pub extern "c" fn madvise(
-    addr: *align(std.mem.page_size) anyopaque,
+    addr: *anyopaque,
     length: usize,
     advice: c_uint,
 ) c_int;

--- a/lib/std/crypto/tlcsprng.zig
+++ b/lib/std/crypto/tlcsprng.zig
@@ -61,7 +61,7 @@ var install_atfork_handler = std.once(struct {
     }
 }.do);
 
-threadlocal var wipe_mem: []align(mem.page_size) u8 = &[_]u8{};
+threadlocal var wipe_mem: []u8 = &[_]u8{};
 
 fn tlsCsprngFill(_: *anyopaque, buffer: []u8) void {
     if (builtin.link_libc and @hasDecl(std.c, "arc4random_buf")) {
@@ -96,7 +96,7 @@ fn tlsCsprngFill(_: *anyopaque, buffer: []u8) void {
         } else {
             // Use a static thread-local buffer.
             const S = struct {
-                threadlocal var buf: Context align(mem.page_size) = .{
+                threadlocal var buf: Context = .{
                     .init_state = .uninitialized,
                     .rng = undefined,
                 };
@@ -104,7 +104,7 @@ fn tlsCsprngFill(_: *anyopaque, buffer: []u8) void {
             wipe_mem = mem.asBytes(&S.buf);
         }
     }
-    const ctx = @as(*Context, @ptrCast(wipe_mem.ptr));
+    const ctx = @as(*Context, @ptrCast(@alignCast(wipe_mem.ptr)));
 
     switch (ctx.init_state) {
         .uninitialized => {
@@ -160,7 +160,7 @@ fn childAtForkHandler() callconv(.C) void {
 }
 
 fn fillWithCsprng(buffer: []u8) void {
-    const ctx = @as(*Context, @ptrCast(wipe_mem.ptr));
+    const ctx = @as(*Context, @ptrCast(@alignCast(wipe_mem.ptr)));
     return ctx.rng.fill(buffer);
 }
 
@@ -176,7 +176,7 @@ fn initAndFill(buffer: []u8) void {
     // the `std.options.cryptoRandomSeed` function is provided.
     std.options.cryptoRandomSeed(&seed);
 
-    const ctx = @as(*Context, @ptrCast(wipe_mem.ptr));
+    const ctx = @as(*Context, @ptrCast(@alignCast(wipe_mem.ptr)));
     ctx.rng = Rng.init(seed);
     std.crypto.utils.secureZero(u8, &seed);
 

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -663,9 +663,9 @@ pub const StackIterator = struct {
         // We are unable to determine validity of memory for freestanding targets
         if (native_os == .freestanding) return true;
 
-        const aligned_address = address & ~@as(usize, @intCast((mem.page_size - 1)));
+        const aligned_address = address & ~@as(usize, @intCast((std.heap.pageSize() - 1)));
         if (aligned_address == 0) return false;
-        const aligned_memory = @as([*]align(mem.page_size) u8, @ptrFromInt(aligned_address))[0..mem.page_size];
+        const aligned_memory = @as([*]u8, @ptrFromInt(aligned_address))[0..std.heap.pageSize()];
 
         if (native_os == .windows) {
             var memory_info: windows.MEMORY_BASIC_INFORMATION = undefined;
@@ -1139,7 +1139,7 @@ pub fn readElfDebugInfo(
     build_id: ?[]const u8,
     expected_crc: ?u32,
     parent_sections: *DW.DwarfInfo.SectionArray,
-    parent_mapped_mem: ?[]align(mem.page_size) const u8,
+    parent_mapped_mem: ?[]const u8,
 ) !ModuleDebugInfo {
     nosuspend {
         const elf_file = (if (elf_filename) |filename| blk: {
@@ -1152,7 +1152,7 @@ pub fn readElfDebugInfo(
         const mapped_mem = try mapWholeFile(elf_file);
         if (expected_crc) |crc| if (crc != std.hash.crc.Crc32SmallWithPoly(.IEEE).hash(mapped_mem)) return error.InvalidDebugInfo;
 
-        const hdr: *const elf.Ehdr = @ptrCast(&mapped_mem[0]);
+        const hdr: *const elf.Ehdr = @ptrCast(@alignCast(&mapped_mem[0]));
         if (!mem.eql(u8, hdr.e_ident[0..4], elf.MAGIC)) return error.InvalidElfMagic;
         if (hdr.e_ident[elf.EI_VERSION] != 1) return error.InvalidElfVersion;
 
@@ -1457,7 +1457,7 @@ fn printLineFromFileAnyOs(out_stream: anytype, line_info: LineInfo) !void {
     defer f.close();
     // TODO fstat and make sure that the file has the correct size
 
-    var buf: [mem.page_size]u8 = undefined;
+    var buf: [1024]u8 = undefined;
     var amt_read = try f.read(buf[0..]);
     const line_start = seek: {
         var current_line_start: usize = 0;
@@ -1557,7 +1557,7 @@ test "printLineFromFileAnyOs" {
 
         const overlap = 10;
         var writer = file.writer();
-        try writer.writeByteNTimes('a', mem.page_size - overlap);
+        try writer.writeByteNTimes('a', std.heap.pageSize() - overlap);
         try writer.writeByte('\n');
         try writer.writeByteNTimes('a', overlap);
 
@@ -1572,10 +1572,16 @@ test "printLineFromFileAnyOs" {
         defer allocator.free(path);
 
         var writer = file.writer();
-        try writer.writeByteNTimes('a', mem.page_size);
+        try writer.writeByteNTimes('a', std.heap.pageSize());
+
+        const expected = try allocator.alloc(u8, std.heap.pageSize() + 1);
+        defer allocator.free(expected);
+
+        @memset(expected, 'a');
+        expected[expected.len - 1] = '\n';
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 1, .column = 0 });
-        try expectEqualStrings(("a" ** mem.page_size) ++ "\n", output.items);
+        try expectEqualStrings(expected, output.items);
         output.clearRetainingCapacity();
     }
     {
@@ -1585,18 +1591,28 @@ test "printLineFromFileAnyOs" {
         defer allocator.free(path);
 
         var writer = file.writer();
-        try writer.writeByteNTimes('a', 3 * mem.page_size);
+        try writer.writeByteNTimes('a', 3 * std.heap.pageSize());
 
         try expectError(error.EndOfFile, printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 2, .column = 0 }));
 
+        var expected = try allocator.alloc(u8, (3 * std.heap.pageSize()) + 1);
+        defer allocator.free(expected);
+
+        @memset(expected, 'a');
+        expected[expected.len - 1] = '\n';
+
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 1, .column = 0 });
-        try expectEqualStrings(("a" ** (3 * mem.page_size)) ++ "\n", output.items);
+        try expectEqualStrings(expected, output.items);
         output.clearRetainingCapacity();
 
         try writer.writeAll("a\na");
 
+        expected = try allocator.realloc(expected, (3 * std.heap.pageSize()) + 2);
+        @memset(expected, 'a');
+        expected[expected.len - 1] = '\n';
+
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 1, .column = 0 });
-        try expectEqualStrings(("a" ** (3 * mem.page_size)) ++ "a\n", output.items);
+        try expectEqualStrings(expected, output.items);
         output.clearRetainingCapacity();
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 2, .column = 0 });
@@ -1610,7 +1626,7 @@ test "printLineFromFileAnyOs" {
         defer allocator.free(path);
 
         var writer = file.writer();
-        const real_file_start = 3 * mem.page_size;
+        const real_file_start = 3 * std.heap.pageSize();
         try writer.writeByteNTimes('\n', real_file_start);
         try writer.writeAll("abc\ndef");
 
@@ -1643,7 +1659,7 @@ const MachoSymbol = struct {
 
 /// Takes ownership of file, even on error.
 /// TODO it's weird to take ownership even on error, rework this code.
-fn mapWholeFile(file: File) ![]align(mem.page_size) const u8 {
+fn mapWholeFile(file: File) ![]const u8 {
     nosuspend {
         defer file.close();
 
@@ -2132,7 +2148,7 @@ pub const ModuleDebugInfo = switch (native_os) {
     .macos, .ios, .watchos, .tvos => struct {
         base_address: usize,
         vmaddr_slide: usize,
-        mapped_memory: []align(mem.page_size) const u8,
+        mapped_memory: []const u8,
         symbols: []const MachoSymbol,
         strings: [:0]const u8,
         ofiles: OFileTable,
@@ -2425,8 +2441,8 @@ pub const ModuleDebugInfo = switch (native_os) {
     .linux, .netbsd, .freebsd, .dragonfly, .openbsd, .haiku, .solaris, .illumos => struct {
         base_address: usize,
         dwarf: DW.DwarfInfo,
-        mapped_memory: []align(mem.page_size) const u8,
-        external_mapped_memory: ?[]align(mem.page_size) const u8,
+        mapped_memory: []const u8,
+        external_mapped_memory: ?[]const u8,
 
         pub fn deinit(self: *@This(), allocator: mem.Allocator) void {
             self.dwarf.deinit(allocator);

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -91,7 +91,7 @@ pub fn LinearFifo(
                 mem.copyForwards(T, self.buf[0..self.count], self.buf[self.head..][0..self.count]);
                 self.head = 0;
             } else {
-                var tmp: [mem.page_size / 2 / @sizeOf(T)]T = undefined;
+                var tmp: [4096 / 2 / @sizeOf(T)]T = undefined;
 
                 while (self.head != 0) {
                     const n = @min(self.head, tmp.len);

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -30,7 +30,7 @@ pub const MemoryPoolExtra = memory_pool.MemoryPoolExtra;
 pub const MemoryPoolOptions = memory_pool.Options;
 
 /// TODO Utilize this on Windows.
-pub var next_mmap_addr_hint: ?[*]align(mem.page_size) u8 = null;
+pub var next_mmap_addr_hint: ?[*]u8 = null;
 
 const CAllocator = struct {
     comptime {
@@ -255,7 +255,7 @@ pub const wasm_allocator = Allocator{
 /// Verifies that the adjusted length will still map to the full length
 pub fn alignPageAllocLen(full_len: usize, len: usize) usize {
     const aligned_len = mem.alignAllocLen(full_len, len);
-    assert(mem.alignForward(usize, aligned_len, mem.page_size) == full_len);
+    assert(mem.alignForward(usize, aligned_len, std.heap.pageSize()) == full_len);
     return aligned_len;
 }
 
@@ -591,11 +591,68 @@ pub fn StackFallbackAllocator(comptime size: usize) type {
     };
 }
 
+pub inline fn pageSize() usize {
+    // Comptime overrides for when we are certain the page size is impossible
+    // to change on the platform or the platform does not have a method to
+    // retrieve the page size.
+    comptime {
+        // https://developer.mozilla.org/en-US/docs/webassembly/reference/memory/size
+        // WASM has no page size retrieval method so we always assume 64k
+        if (builtin.cpu.arch.isWasm()) {
+            return 64 * 1024;
+        }
+
+        // Apple uses 16k page sizes on aarch64
+        if (builtin.cpu.arch == .aarch64) {
+            switch (builtin.os.tag) {
+                .macos, .ios, .watchos, .tvos => return 16 * 1024,
+                else => {},
+            }
+        }
+
+        // https://unix.stackexchange.com/a/80736
+        // Linux uses 4k page sizes on x86_64
+        if (builtin.cpu.arch == .x86_64 and builtin.os.tag == .linux) {
+            return 4 * 1024;
+        }
+    }
+
+    // Utilize the cache when we cannot assume the page size.
+    const cache = struct {
+        var page_size: std.atomic.Value(usize) = .{ .raw = 0 };
+
+        fn get() usize {
+            var pgsz = page_size.load(.unordered);
+            if (pgsz > 0) return pgsz;
+
+            pgsz = if (std.options.pageSizeFn) |f| f() else switch (builtin.os.tag) {
+                .linux => if (builtin.link_libc) @intCast(std.c.sysconf(std.os.linux.SC.PAGESIZE)) else std.os.linux.getauxval(std.elf.AT_PAGESZ),
+                .macos => std.c.darwin.machTaskForSelf().getPageSize() catch 0,
+                .windows => blk: {
+                    var info: std.os.windows.SYSTEM_INFO = undefined;
+                    std.os.windows.kernel32.GetSystemInfo(&info);
+                    break :blk info.dwPageSize;
+                },
+                else => if (builtin.link_libc and @hasDecl(std.c, "getpagesize")) @intCast(std.c.getpagesize()) else switch (builtin.cpu.arch) {
+                    .sparc64 => 8 * 1024,
+                    else => 4 * 1024,
+                },
+            };
+
+            assert(pgsz % 2 == 0);
+            if (pgsz == 0) @panic("Failed to retrieve a valid page size");
+
+            page_size.store(pgsz, .unordered);
+            return pgsz;
+        }
+    };
+    return cache.get();
+}
+
 test "c_allocator" {
     if (builtin.link_libc) {
         try testAllocator(c_allocator);
         try testAllocatorAligned(c_allocator);
-        try testAllocatorLargeAlignment(c_allocator);
         try testAllocatorAlignedShrink(c_allocator);
     }
 }
@@ -611,18 +668,17 @@ test "PageAllocator" {
     try testAllocator(allocator);
     try testAllocatorAligned(allocator);
     if (!builtin.target.isWasm()) {
-        try testAllocatorLargeAlignment(allocator);
         try testAllocatorAlignedShrink(allocator);
     }
 
     if (builtin.os.tag == .windows) {
-        const slice = try allocator.alignedAlloc(u8, mem.page_size, 128);
+        const slice = try allocator.alloc(u8, 128);
         slice[0] = 0x12;
         slice[127] = 0x34;
         allocator.free(slice);
     }
     {
-        var buf = try allocator.alloc(u8, mem.page_size + 1);
+        var buf = try allocator.alloc(u8, pageSize() + 1);
         defer allocator.free(buf);
         buf = try allocator.realloc(buf, 1); // shrink past the page boundary
     }
@@ -639,7 +695,6 @@ test "HeapAllocator" {
 
         try testAllocator(allocator);
         try testAllocatorAligned(allocator);
-        try testAllocatorLargeAlignment(allocator);
         try testAllocatorAlignedShrink(allocator);
     }
 }
@@ -651,7 +706,6 @@ test "ArenaAllocator" {
 
     try testAllocator(allocator);
     try testAllocatorAligned(allocator);
-    try testAllocatorLargeAlignment(allocator);
     try testAllocatorAlignedShrink(allocator);
 }
 
@@ -662,7 +716,6 @@ test "FixedBufferAllocator" {
 
     try testAllocator(allocator);
     try testAllocatorAligned(allocator);
-    try testAllocatorLargeAlignment(allocator);
     try testAllocatorAlignedShrink(allocator);
 }
 
@@ -695,10 +748,6 @@ test "StackFallbackAllocator" {
     {
         var stack_allocator = stackFallback(4096, std.testing.allocator);
         try testAllocatorAligned(stack_allocator.get());
-    }
-    {
-        var stack_allocator = stackFallback(4096, std.testing.allocator);
-        try testAllocatorLargeAlignment(stack_allocator.get());
     }
     {
         var stack_allocator = stackFallback(4096, std.testing.allocator);
@@ -742,7 +791,6 @@ test "Thread safe FixedBufferAllocator" {
 
     try testAllocator(fixed_buffer_allocator.threadSafeAllocator());
     try testAllocatorAligned(fixed_buffer_allocator.threadSafeAllocator());
-    try testAllocatorLargeAlignment(fixed_buffer_allocator.threadSafeAllocator());
     try testAllocatorAlignedShrink(fixed_buffer_allocator.threadSafeAllocator());
 }
 
@@ -821,35 +869,6 @@ pub fn testAllocatorAligned(base_allocator: mem.Allocator) !void {
     }
 }
 
-pub fn testAllocatorLargeAlignment(base_allocator: mem.Allocator) !void {
-    var validationAllocator = mem.validationWrap(base_allocator);
-    const allocator = validationAllocator.allocator();
-
-    const large_align: usize = mem.page_size / 2;
-
-    var align_mask: usize = undefined;
-    align_mask = @shlWithOverflow(~@as(usize, 0), @as(Allocator.Log2Align, @ctz(large_align)))[0];
-
-    var slice = try allocator.alignedAlloc(u8, large_align, 500);
-    try testing.expect(@intFromPtr(slice.ptr) & align_mask == @intFromPtr(slice.ptr));
-
-    if (allocator.resize(slice, 100)) {
-        slice = slice[0..100];
-    }
-
-    slice = try allocator.realloc(slice, 5000);
-    try testing.expect(@intFromPtr(slice.ptr) & align_mask == @intFromPtr(slice.ptr));
-
-    if (allocator.resize(slice, 10)) {
-        slice = slice[0..10];
-    }
-
-    slice = try allocator.realloc(slice, 20000);
-    try testing.expect(@intFromPtr(slice.ptr) & align_mask == @intFromPtr(slice.ptr));
-
-    allocator.free(slice);
-}
-
 pub fn testAllocatorAlignedShrink(base_allocator: mem.Allocator) !void {
     var validationAllocator = mem.validationWrap(base_allocator);
     const allocator = validationAllocator.allocator();
@@ -858,7 +877,7 @@ pub fn testAllocatorAlignedShrink(base_allocator: mem.Allocator) !void {
     var fib = FixedBufferAllocator.init(&debug_buffer);
     const debug_allocator = fib.allocator();
 
-    const alloc_size = mem.page_size * 2 + 50;
+    const alloc_size = pageSize() * 2 + 50;
     var slice = try allocator.alignedAlloc(u8, 16, alloc_size);
     defer allocator.free(slice);
 
@@ -867,7 +886,7 @@ pub fn testAllocatorAlignedShrink(base_allocator: mem.Allocator) !void {
     // which is 16 pages, hence the 32. This test may require to increase
     // the size of the allocations feeding the `allocator` parameter if they
     // fail, because of this high over-alignment we want to have.
-    while (@intFromPtr(slice.ptr) == mem.alignForward(usize, @intFromPtr(slice.ptr), mem.page_size * 32)) {
+    while (@intFromPtr(slice.ptr) == mem.alignForward(usize, @intFromPtr(slice.ptr), pageSize() * 32)) {
         try stuff_to_free.append(slice);
         slice = try allocator.alignedAlloc(u8, 16, alloc_size);
     }

--- a/lib/std/heap/PageAllocator.zig
+++ b/lib/std/heap/PageAllocator.zig
@@ -2,6 +2,7 @@ const std = @import("../std.zig");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const mem = std.mem;
+const heap = std.heap;
 const maxInt = std.math.maxInt;
 const assert = std.debug.assert;
 const native_os = builtin.os.tag;
@@ -18,8 +19,8 @@ fn alloc(_: *anyopaque, n: usize, log2_align: u8, ra: usize) ?[*]u8 {
     _ = ra;
     _ = log2_align;
     assert(n > 0);
-    if (n > maxInt(usize) - (mem.page_size - 1)) return null;
-    const aligned_len = mem.alignForward(usize, n, mem.page_size);
+    if (n > maxInt(usize) - (heap.pageSize() - 1)) return null;
+    const aligned_len = mem.alignForward(usize, n, heap.pageSize());
 
     if (native_os == .windows) {
         const addr = windows.VirtualAlloc(
@@ -40,8 +41,8 @@ fn alloc(_: *anyopaque, n: usize, log2_align: u8, ra: usize) ?[*]u8 {
         -1,
         0,
     ) catch return null;
-    assert(mem.isAligned(@intFromPtr(slice.ptr), mem.page_size));
-    const new_hint: [*]align(mem.page_size) u8 = @alignCast(slice.ptr + aligned_len);
+    assert(mem.isAligned(@intFromPtr(slice.ptr), heap.pageSize()));
+    const new_hint: [*]u8 = @alignCast(slice.ptr + aligned_len);
     _ = @cmpxchgStrong(@TypeOf(std.heap.next_mmap_addr_hint), &std.heap.next_mmap_addr_hint, hint, new_hint, .monotonic, .monotonic);
     return slice.ptr;
 }
@@ -55,13 +56,13 @@ fn resize(
 ) bool {
     _ = log2_buf_align;
     _ = return_address;
-    const new_size_aligned = mem.alignForward(usize, new_size, mem.page_size);
+    const new_size_aligned = mem.alignForward(usize, new_size, heap.pageSize());
 
     if (native_os == .windows) {
         if (new_size <= buf_unaligned.len) {
             const base_addr = @intFromPtr(buf_unaligned.ptr);
             const old_addr_end = base_addr + buf_unaligned.len;
-            const new_addr_end = mem.alignForward(usize, base_addr + new_size, mem.page_size);
+            const new_addr_end = mem.alignForward(usize, base_addr + new_size, heap.pageSize());
             if (old_addr_end > new_addr_end) {
                 // For shrinking that is not releasing, we will only
                 // decommit the pages not needed anymore.
@@ -73,14 +74,14 @@ fn resize(
             }
             return true;
         }
-        const old_size_aligned = mem.alignForward(usize, buf_unaligned.len, mem.page_size);
+        const old_size_aligned = mem.alignForward(usize, buf_unaligned.len, heap.pageSize());
         if (new_size_aligned <= old_size_aligned) {
             return true;
         }
         return false;
     }
 
-    const buf_aligned_len = mem.alignForward(usize, buf_unaligned.len, mem.page_size);
+    const buf_aligned_len = mem.alignForward(usize, buf_unaligned.len, heap.pageSize());
     if (new_size_aligned == buf_aligned_len)
         return true;
 
@@ -103,7 +104,7 @@ fn free(_: *anyopaque, slice: []u8, log2_buf_align: u8, return_address: usize) v
     if (native_os == .windows) {
         windows.VirtualFree(slice.ptr, 0, windows.MEM_RELEASE);
     } else {
-        const buf_aligned_len = mem.alignForward(usize, slice.len, mem.page_size);
+        const buf_aligned_len = mem.alignForward(usize, slice.len, heap.pageSize());
         posix.munmap(@alignCast(slice.ptr[0..buf_aligned_len]));
     }
 }

--- a/lib/std/heap/WasmPageAllocator.zig
+++ b/lib/std/heap/WasmPageAllocator.zig
@@ -73,7 +73,7 @@ const FreeBlock = struct {
                 var count: usize = 0;
                 while (j + count < self.totalPages() and self.getBit(j + count) == .free) {
                     count += 1;
-                    const addr = j * mem.page_size;
+                    const addr = j * std.heap.pageSize();
                     if (count >= num_pages and mem.isAlignedLog2(addr, log2_align)) {
                         self.setBits(j, num_pages, .used);
                         return j;
@@ -100,16 +100,16 @@ fn extendedOffset() usize {
 }
 
 fn nPages(memsize: usize) usize {
-    return mem.alignForward(usize, memsize, mem.page_size) / mem.page_size;
+    return mem.alignForward(usize, memsize, std.heap.pageSize()) / std.heap.pageSize();
 }
 
 fn alloc(ctx: *anyopaque, len: usize, log2_align: u8, ra: usize) ?[*]u8 {
     _ = ctx;
     _ = ra;
-    if (len > maxInt(usize) - (mem.page_size - 1)) return null;
+    if (len > maxInt(usize) - (std.heap.pageSize() - 1)) return null;
     const page_count = nPages(len);
     const page_idx = allocPages(page_count, log2_align) catch return null;
-    return @as([*]u8, @ptrFromInt(page_idx * mem.page_size));
+    return @as([*]u8, @ptrFromInt(page_idx * std.heap.pageSize()));
 }
 
 fn allocPages(page_count: usize, log2_align: u8) !usize {
@@ -126,9 +126,9 @@ fn allocPages(page_count: usize, log2_align: u8) !usize {
     }
 
     const next_page_idx = @wasmMemorySize(0);
-    const next_page_addr = next_page_idx * mem.page_size;
+    const next_page_addr = next_page_idx * std.heap.pageSize();
     const aligned_addr = mem.alignForwardLog2(next_page_addr, log2_align);
-    const drop_page_count = @divExact(aligned_addr - next_page_addr, mem.page_size);
+    const drop_page_count = @divExact(aligned_addr - next_page_addr, std.heap.pageSize());
     const result = @wasmMemoryGrow(0, @as(u32, @intCast(drop_page_count + page_count)));
     if (result <= 0)
         return error.OutOfMemory;
@@ -151,7 +151,7 @@ fn freePages(start: usize, end: usize) void {
             // TODO: would it be better if we use the first page instead?
             new_end -= 1;
 
-            extended.data = @as([*]u128, @ptrFromInt(new_end * mem.page_size))[0 .. mem.page_size / @sizeOf(u128)];
+            extended.data = @as([*]u128, @ptrFromInt(new_end * std.heap.pageSize()))[0 .. std.heap.pageSize() / @sizeOf(u128)];
             // Since this is the first page being freed and we consume it, assume *nothing* is free.
             @memset(extended.data, PageStatus.none_free);
         }
@@ -170,7 +170,7 @@ fn resize(
     _ = ctx;
     _ = log2_buf_align;
     _ = return_address;
-    const aligned_len = mem.alignForward(usize, buf.len, mem.page_size);
+    const aligned_len = mem.alignForward(usize, buf.len, std.heap.pageSize());
     if (new_len > aligned_len) return false;
     const current_n = nPages(aligned_len);
     const new_n = nPages(new_len);
@@ -190,7 +190,7 @@ fn free(
     _ = ctx;
     _ = log2_buf_align;
     _ = return_address;
-    const aligned_len = mem.alignForward(usize, buf.len, mem.page_size);
+    const aligned_len = mem.alignForward(usize, buf.len, std.heap.pageSize());
     const current_n = nPages(aligned_len);
     const base = nPages(@intFromPtr(buf.ptr));
     freePages(base, base + current_n);
@@ -200,8 +200,8 @@ test "internals" {
     const page_allocator = std.heap.page_allocator;
     const testing = std.testing;
 
-    const conventional_memsize = WasmPageAllocator.conventional.totalPages() * mem.page_size;
-    const initial = try page_allocator.alloc(u8, mem.page_size);
+    const conventional_memsize = WasmPageAllocator.conventional.totalPages() * std.heap.pageSize();
+    const initial = try page_allocator.alloc(u8, std.heap.pageSize());
     try testing.expect(@intFromPtr(initial.ptr) < conventional_memsize); // If this isn't conventional, the rest of these tests don't make sense. Also we have a serious memory leak in the test suite.
 
     var inplace = try page_allocator.realloc(initial, 1);

--- a/lib/std/heap/sbrk_allocator.zig
+++ b/lib/std/heap/sbrk_allocator.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const math = std.math;
 const Allocator = std.mem.Allocator;
 const mem = std.mem;
+const heap = std.heap;
 const assert = std.debug.assert;
 
 pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
@@ -20,7 +21,7 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
         const max_usize = math.maxInt(usize);
         const ushift = math.Log2Int(usize);
         const bigpage_size = 64 * 1024;
-        const pages_per_bigpage = bigpage_size / mem.page_size;
+        const pages_per_bigpage = bigpage_size / heap.pageSize();
         const bigpage_count = max_usize / bigpage_size;
 
         /// Because of storing free list pointers, the minimum size class is 3.
@@ -60,7 +61,7 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
                     }
 
                     const next_addr = next_addrs[class];
-                    if (next_addr % mem.page_size == 0) {
+                    if (next_addr % heap.pageSize() == 0) {
                         const addr = allocBigPages(1);
                         if (addr == 0) return null;
                         //std.debug.print("allocated fresh slot_size={d} class={d} addr=0x{x}\n", .{
@@ -155,7 +156,7 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
                 big_frees[class] = node.*;
                 return top_free_ptr;
             }
-            return sbrk(pow2_pages * pages_per_bigpage * mem.page_size);
+            return sbrk(pow2_pages * pages_per_bigpage * heap.pageSize());
         }
     };
 }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -8,18 +8,6 @@ const testing = std.testing;
 const Endian = std.builtin.Endian;
 const native_endian = builtin.cpu.arch.endian();
 
-/// Compile time known minimum page size.
-/// https://github.com/ziglang/zig/issues/4082
-pub const page_size = switch (builtin.cpu.arch) {
-    .wasm32, .wasm64 => 64 * 1024,
-    .aarch64 => switch (builtin.os.tag) {
-        .macos, .ios, .watchos, .tvos => 16 * 1024,
-        else => 4 * 1024,
-    },
-    .sparc64 => 8 * 1024,
-    else => 4 * 1024,
-};
-
 /// The standard library currently thoroughly depends on byte size
 /// being 8 bits.  (see the use of u8 throughout allocation code as
 /// the "byte" type.)  Code which depends on this can reference this
@@ -1046,12 +1034,12 @@ pub fn indexOfSentinel(comptime T: type, comptime sentinel: T, p: [*:sentinel]co
                 const Block = @Vector(block_len, T);
                 const mask: Block = @splat(sentinel);
 
-                comptime std.debug.assert(std.mem.page_size % @sizeOf(Block) == 0);
+                std.debug.assert(std.heap.pageSize() % @sizeOf(Block) == 0);
 
                 // First block may be unaligned
                 const start_addr = @intFromPtr(&p[i]);
-                const offset_in_page = start_addr & (std.mem.page_size - 1);
-                if (offset_in_page <= std.mem.page_size - @sizeOf(Block)) {
+                const offset_in_page = start_addr & (std.heap.pageSize() - 1);
+                if (offset_in_page < std.heap.pageSize() - @sizeOf(Block)) {
                     // Will not read past the end of a page, full block.
                     const block: Block = p[i..][0..block_len].*;
                     const matches = block == mask;
@@ -1099,18 +1087,18 @@ test "indexOfSentinel vector paths" {
         const block_len = std.simd.suggestVectorLength(T) orelse continue;
 
         // Allocate three pages so we guarantee a page-crossing address with a full page after
-        const memory = try allocator.alloc(T, 3 * std.mem.page_size / @sizeOf(T));
+        const memory = try allocator.alloc(T, 3 * std.heap.pageSize() / @sizeOf(T));
         defer allocator.free(memory);
         @memset(memory, 0xaa);
 
         // Find starting page-alignment = 0
         var start: usize = 0;
         const start_addr = @intFromPtr(&memory);
-        start += (std.mem.alignForward(usize, start_addr, std.mem.page_size) - start_addr) / @sizeOf(T);
-        try testing.expect(start < std.mem.page_size / @sizeOf(T));
+        start += (std.mem.alignForward(usize, start_addr, std.heap.pageSize()) - start_addr) / @sizeOf(T);
+        try testing.expect(start < std.heap.pageSize() / @sizeOf(T));
 
         // Validate all sub-block alignments
-        const search_len = std.mem.page_size / @sizeOf(T);
+        const search_len = std.heap.pageSize() / @sizeOf(T);
         memory[start + search_len] = 0;
         for (0..block_len) |offset| {
             try testing.expectEqual(search_len - offset, indexOfSentinel(T, 0, @ptrCast(&memory[start + offset])));
@@ -1118,7 +1106,7 @@ test "indexOfSentinel vector paths" {
         memory[start + search_len] = 0xaa;
 
         // Validate page boundary crossing
-        const start_page_boundary = start + (std.mem.page_size / @sizeOf(T));
+        const start_page_boundary = start + (std.heap.pageSize() / @sizeOf(T));
         memory[start_page_boundary + block_len] = 0;
         for (0..block_len) |offset| {
             try testing.expectEqual(2 * block_len - offset, indexOfSentinel(T, 0, @ptrCast(&memory[start_page_boundary - block_len + offset])));

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -215,7 +215,9 @@ fn allocBytesWithAlignment(self: Allocator, comptime alignment: u29, byte_count:
     // The Zig Allocator interface is not intended to solve alignments beyond
     // the minimum OS page size. For these use cases, the caller must use OS
     // APIs directly.
-    comptime assert(alignment <= mem.page_size);
+
+    // Weird fix to prevent "unable to evaluate comptime expression" with pageSize()
+    if (!@inComptime()) assert(alignment <= std.heap.pageSize());
 
     if (byte_count == 0) {
         const ptr = comptime std.mem.alignBackward(usize, math.maxInt(usize), alignment);

--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -1345,8 +1345,8 @@ pub const SubmissionQueue = struct {
     dropped: *u32,
     array: []u32,
     sqes: []linux.io_uring_sqe,
-    mmap: []align(mem.page_size) u8,
-    mmap_sqes: []align(mem.page_size) u8,
+    mmap: []u8,
+    mmap_sqes: []u8,
 
     // We use `sqe_head` and `sqe_tail` in the same way as liburing:
     // We increment `sqe_tail` (but not `tail`) for each call to `get_sqe()`.
@@ -1464,7 +1464,7 @@ pub const BufferGroup = struct {
     /// Pointer to the memory shared by the kernel.
     /// `buffers_count` of `io_uring_buf` structures are shared by the kernel.
     /// First `io_uring_buf` is overlaid by `io_uring_buf_ring` struct.
-    br: *align(mem.page_size) linux.io_uring_buf_ring,
+    br: *linux.io_uring_buf_ring,
     /// Contiguous block of memory of size (buffers_count * buffer_size).
     buffers: []u8,
     /// Size of each buffer in buffers.
@@ -1559,7 +1559,7 @@ pub const BufferGroup = struct {
 /// `fd` is IO_Uring.fd for which the provided buffer ring is being registered.
 /// `entries` is the number of entries requested in the buffer ring, must be power of 2.
 /// `group_id` is the chosen buffer group ID, unique in IO_Uring.
-pub fn setup_buf_ring(fd: posix.fd_t, entries: u16, group_id: u16) !*align(mem.page_size) linux.io_uring_buf_ring {
+pub fn setup_buf_ring(fd: posix.fd_t, entries: u16, group_id: u16) !*linux.io_uring_buf_ring {
     if (entries == 0 or entries > 1 << 15) return error.EntriesNotInRange;
     if (!std.math.isPowerOfTwo(entries)) return error.EntriesNotPowerOfTwo;
 
@@ -1575,7 +1575,7 @@ pub fn setup_buf_ring(fd: posix.fd_t, entries: u16, group_id: u16) !*align(mem.p
     errdefer posix.munmap(mmap);
     assert(mmap.len == mmap_size);
 
-    const br: *align(mem.page_size) linux.io_uring_buf_ring = @ptrCast(mmap.ptr);
+    const br: *linux.io_uring_buf_ring = @ptrCast(@alignCast(mem.alignPointer(mmap.ptr, std.heap.pageSize()) orelse unreachable));
     try register_buf_ring(fd, @intFromPtr(br), entries, group_id);
     return br;
 }
@@ -1617,9 +1617,9 @@ fn handle_register_buf_ring_result(res: usize) !void {
 }
 
 // Unregisters a previously registered shared buffer ring, returned from io_uring_setup_buf_ring.
-pub fn free_buf_ring(fd: posix.fd_t, br: *align(mem.page_size) linux.io_uring_buf_ring, entries: u32, group_id: u16) void {
+pub fn free_buf_ring(fd: posix.fd_t, br: *linux.io_uring_buf_ring, entries: u32, group_id: u16) void {
     unregister_buf_ring(fd, group_id) catch {};
-    var mmap: []align(mem.page_size) u8 = undefined;
+    var mmap: []u8 = undefined;
     mmap.ptr = @ptrCast(br);
     mmap.len = entries * @sizeOf(linux.io_uring_buf);
     posix.munmap(mmap);

--- a/lib/std/os/linux/arm-eabi.zig
+++ b/lib/std/os/linux/arm-eabi.zig
@@ -320,3 +320,27 @@ pub const ucontext_t = extern struct {
 };
 
 pub const Elf_Symndx = u32;
+
+pub const SC = struct {
+    pub const socket = 1;
+    pub const bind = 2;
+    pub const connect = 3;
+    pub const listen = 4;
+    pub const accept = 5;
+    pub const getsockname = 6;
+    pub const getpeername = 7;
+    pub const socketpair = 8;
+    pub const send = 9;
+    pub const recv = 10;
+    pub const sendto = 11;
+    pub const recvfrom = 12;
+    pub const shutdown = 13;
+    pub const setsockopt = 14;
+    pub const getsockopt = 15;
+    pub const sendmsg = 16;
+    pub const recvmsg = 17;
+    pub const accept4 = 18;
+    pub const recvmmsg = 19;
+    pub const sendmmsg = 20;
+    pub const PAGESIZE = 30;
+};

--- a/lib/std/os/linux/arm64.zig
+++ b/lib/std/os/linux/arm64.zig
@@ -265,3 +265,27 @@ pub const ucontext_t = extern struct {
 };
 
 pub const Elf_Symndx = u32;
+
+pub const SC = struct {
+    pub const socket = 1;
+    pub const bind = 2;
+    pub const connect = 3;
+    pub const listen = 4;
+    pub const accept = 5;
+    pub const getsockname = 6;
+    pub const getpeername = 7;
+    pub const socketpair = 8;
+    pub const send = 9;
+    pub const recv = 10;
+    pub const sendto = 11;
+    pub const recvfrom = 12;
+    pub const shutdown = 13;
+    pub const setsockopt = 14;
+    pub const getsockopt = 15;
+    pub const sendmsg = 16;
+    pub const recvmsg = 17;
+    pub const accept4 = 18;
+    pub const recvmmsg = 19;
+    pub const sendmmsg = 20;
+    pub const PAGESIZE = 30;
+};

--- a/lib/std/os/linux/mips.zig
+++ b/lib/std/os/linux/mips.zig
@@ -396,3 +396,7 @@ pub const rlimit_resource = enum(c_int) {
 
     _,
 };
+
+pub const SC = struct {
+    pub const PAGESIZE = 30;
+};

--- a/lib/std/os/linux/mips64.zig
+++ b/lib/std/os/linux/mips64.zig
@@ -381,3 +381,7 @@ pub const rlimit_resource = enum(c_int) {
 
     _,
 };
+
+pub const SC = struct {
+    pub const PAGESIZE = 30;
+};

--- a/lib/std/os/linux/powerpc.zig
+++ b/lib/std/os/linux/powerpc.zig
@@ -290,3 +290,7 @@ pub const ucontext_t = extern struct {
 pub const Elf_Symndx = u32;
 
 pub const MMAP2_UNIT = 4096;
+
+pub const SC = struct {
+    pub const PAGESIZE = 30;
+};

--- a/lib/std/os/linux/powerpc64.zig
+++ b/lib/std/os/linux/powerpc64.zig
@@ -298,3 +298,7 @@ pub const ucontext_t = extern struct {
 };
 
 pub const Elf_Symndx = u32;
+
+pub const SC = struct {
+    pub const PAGESIZE = 30;
+};

--- a/lib/std/os/linux/riscv64.zig
+++ b/lib/std/os/linux/riscv64.zig
@@ -223,3 +223,7 @@ pub const Stat = extern struct {
 pub const Elf_Symndx = u32;
 
 pub const VDSO = struct {};
+
+pub const SC = struct {
+    pub const PAGESIZE = 30;
+};

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -471,3 +471,7 @@ pub const rlimit_resource = enum(c_int) {
 
     _,
 };
+
+pub const SC = struct {
+    pub const PAGESIZE = 30;
+};

--- a/lib/std/os/linux/x86.zig
+++ b/lib/std/os/linux/x86.zig
@@ -353,6 +353,7 @@ pub const SC = struct {
     pub const accept4 = 18;
     pub const recvmmsg = 19;
     pub const sendmmsg = 20;
+    pub const PAGESIZE = 30;
 };
 
 fn gpRegisterOffset(comptime reg_index: comptime_int) usize {

--- a/lib/std/os/linux/x86_64.zig
+++ b/lib/std/os/linux/x86_64.zig
@@ -451,3 +451,27 @@ pub inline fn getcontext(context: *ucontext_t) usize {
         : "cc", "memory", "rcx", "rdx", "rsi", "r8", "r10", "r11"
     );
 }
+
+pub const SC = struct {
+    pub const socket = 1;
+    pub const bind = 2;
+    pub const connect = 3;
+    pub const listen = 4;
+    pub const accept = 5;
+    pub const getsockname = 6;
+    pub const getpeername = 7;
+    pub const socketpair = 8;
+    pub const send = 9;
+    pub const recv = 10;
+    pub const sendto = 11;
+    pub const recvfrom = 12;
+    pub const shutdown = 13;
+    pub const setsockopt = 14;
+    pub const getsockopt = 15;
+    pub const sendmsg = 16;
+    pub const recvmsg = 17;
+    pub const accept4 = 18;
+    pub const recvmmsg = 19;
+    pub const sendmmsg = 20;
+    pub const PAGESIZE = 30;
+};

--- a/lib/std/os/plan9.zig
+++ b/lib/std/os/plan9.zig
@@ -367,8 +367,8 @@ pub fn sbrk(n: usize) usize {
         bloc = @intFromPtr(&ExecData.end);
         bloc_max = @intFromPtr(&ExecData.end);
     }
-    const bl = std.mem.alignForward(usize, bloc, std.mem.page_size);
-    const n_aligned = std.mem.alignForward(usize, n, std.mem.page_size);
+    const bl = std.mem.alignForward(usize, bloc, std.heap.pageSize());
+    const n_aligned = std.mem.alignForward(usize, n, std.heap.pageSize());
     if (bl + n_aligned > bloc_max) {
         // we need to allocate
         if (brk_(bl + n_aligned) < 0) return 0;

--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -659,7 +659,7 @@ test "PackedIntArray at end of available memory" {
     const PackedArray = PackedIntArray(u3, 8);
 
     const Padded = struct {
-        _: [std.mem.page_size - @sizeOf(PackedArray)]u8,
+        _: [4096 - @sizeOf(PackedArray)]u8,
         p: PackedArray,
     };
 
@@ -679,9 +679,9 @@ test "PackedIntSlice at end of available memory" {
 
     const allocator = std.testing.allocator;
 
-    var page = try allocator.alloc(u8, std.mem.page_size);
+    var page = try allocator.alloc(u8, std.heap.pageSize());
     defer allocator.free(page);
 
-    var p = PackedSlice.init(page[std.mem.page_size - 2 ..], 1);
+    var p = PackedSlice.init(page[std.heap.pageSize() - 2 ..], 1);
     p.set(0, std.math.maxInt(u11));
 }

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -18,6 +18,7 @@ const builtin = @import("builtin");
 const root = @import("root");
 const std = @import("std.zig");
 const mem = std.mem;
+const heap = std.heap;
 const fs = std.fs;
 const max_path_bytes = fs.MAX_PATH_BYTES;
 const maxInt = std.math.maxInt;
@@ -4567,8 +4568,8 @@ pub const MProtectError = error{
 } || UnexpectedError;
 
 /// `memory.len` must be page-aligned.
-pub fn mprotect(memory: []align(mem.page_size) u8, protection: u32) MProtectError!void {
-    assert(mem.isAligned(memory.len, mem.page_size));
+pub fn mprotect(memory: []u8, protection: u32) MProtectError!void {
+    assert(mem.isAligned(memory.len, heap.pageSize()));
     if (native_os == .windows) {
         const win_prot: windows.DWORD = switch (@as(u3, @truncate(protection))) {
             0b000 => windows.PAGE_NOACCESS,
@@ -4633,21 +4634,21 @@ pub const MMapError = error{
 /// * SIGSEGV - Attempted write into a region mapped as read-only.
 /// * SIGBUS - Attempted  access to a portion of the buffer that does not correspond to the file
 pub fn mmap(
-    ptr: ?[*]align(mem.page_size) u8,
+    ptr: ?[*]u8,
     length: usize,
     prot: u32,
     flags: system.MAP,
     fd: fd_t,
     offset: u64,
-) MMapError![]align(mem.page_size) u8 {
+) MMapError![]u8 {
     const mmap_sym = if (lfs64_abi) system.mmap64 else system.mmap;
     const rc = mmap_sym(ptr, length, prot, @bitCast(flags), fd, @bitCast(offset));
     const err: E = if (builtin.link_libc) blk: {
-        if (rc != std.c.MAP_FAILED) return @as([*]align(mem.page_size) u8, @ptrCast(@alignCast(rc)))[0..length];
+        if (rc != std.c.MAP_FAILED) return @as([*]u8, @ptrCast(@alignCast(rc)))[0..length];
         break :blk @enumFromInt(system._errno().*);
     } else blk: {
         const err = errno(rc);
-        if (err == .SUCCESS) return @as([*]align(mem.page_size) u8, @ptrFromInt(rc))[0..length];
+        if (err == .SUCCESS) return @as([*]u8, @ptrFromInt(rc))[0..length];
         break :blk err;
     };
     switch (err) {
@@ -4673,7 +4674,7 @@ pub fn mmap(
 /// Zig's munmap function does not, for two reasons:
 /// * It violates the Zig principle that resource deallocation must succeed.
 /// * The Windows function, VirtualFree, has this restriction.
-pub fn munmap(memory: []align(mem.page_size) const u8) void {
+pub fn munmap(memory: []const u8) void {
     switch (errno(system.munmap(memory.ptr, memory.len))) {
         .SUCCESS => return,
         .INVAL => unreachable, // Invalid parameters.
@@ -4686,7 +4687,7 @@ pub const MSyncError = error{
     UnmappedMemory,
 } || UnexpectedError;
 
-pub fn msync(memory: []align(mem.page_size) u8, flags: i32) MSyncError!void {
+pub fn msync(memory: []u8, flags: i32) MSyncError!void {
     switch (errno(system.msync(memory.ptr, memory.len, flags))) {
         .SUCCESS => return,
         .NOMEM => return error.UnmappedMemory, // Unsuccessful, provided pointer does not point mapped memory
@@ -7015,7 +7016,7 @@ pub const MincoreError = error{
 } || UnexpectedError;
 
 /// Determine whether pages are resident in memory.
-pub fn mincore(ptr: [*]align(mem.page_size) u8, length: usize, vec: [*]u8) MincoreError!void {
+pub fn mincore(ptr: [*]u8, length: usize, vec: [*]u8) MincoreError!void {
     return switch (errno(system.mincore(ptr, length, vec))) {
         .SUCCESS => {},
         .AGAIN => error.SystemResources,
@@ -7061,7 +7062,7 @@ pub const MadviseError = error{
 
 /// Give advice about use of memory.
 /// This syscall is optional and is sometimes configured to be disabled.
-pub fn madvise(ptr: [*]align(mem.page_size) u8, length: usize, advice: u32) MadviseError!void {
+pub fn madvise(ptr: [*]u8, length: usize, advice: u32) MadviseError!void {
     switch (errno(system.madvise(ptr, length, advice))) {
         .SUCCESS => return,
         .ACCES => return error.AccessDenied,

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1422,7 +1422,7 @@ pub fn posixGetUserInfo(name: []const u8) !UserInfo {
         ReadGroupId,
     };
 
-    var buf: [std.mem.page_size]u8 = undefined;
+    var buf: [4096]u8 = undefined;
     var name_index: usize = 0;
     var state = State.Start;
     var uid: posix.uid_t = 0;

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -429,7 +429,7 @@ fn expandStackSize(phdrs: []elf.Phdr) void {
     for (phdrs) |*phdr| {
         switch (phdr.p_type) {
             elf.PT_GNU_STACK => {
-                assert(phdr.p_memsz % std.mem.page_size == 0);
+                assert(phdr.p_memsz % std.heap.pageSize() == 0);
 
                 // Silently fail if we are unable to get limits.
                 const limits = std.posix.getrlimit(.STACK) catch break;

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -158,6 +158,8 @@ pub const Options = struct {
     http_disable_tls: bool = false,
 
     side_channels_mitigations: crypto.SideChannelsMitigations = crypto.default_side_channels_mitigations,
+
+    pageSizeFn: ?fn () usize = null,
 };
 
 // This forces the start.zig file to be imported, and the comptime logic inside that


### PR DESCRIPTION
Fixes #16331 and makes it possible to use Zig correctly on Apple M1 with Asahi.

This PR implements the `std.mem.getPageSize()` function. It also changes how `std.mem.page_size` fundamentally works. Before, we had hard coded every page size for how the `builtin.target` value was "set up". Now the default behavior is to check if `builtin.target.page_size` is set, if it then use it, if not then do what we did before. We also now pass the page size from the compiler at build time to `builtin.target.page_size`. There are also some changes to pass the page size fully around allowing developers to set per executable page sizes. I've tested this out on my Apple M1 Pro running NixOS Asahi and it works.