### PR TITLE
linux: add fanotify API

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -4339,6 +4339,73 @@ pub fn inotify_rm_watch(inotify_fd: i32, wd: i32) void {
     }
 }
 
+pub const FanotifyInitError = error{
+    ProcessFdQuotaExceeded,
+    SystemFdQuotaExceeded,
+    SystemResources,
+    OperationNotSupported,
+    PermissionDenied,
+} || UnexpectedError;
+
+pub fn fanotify_init(flags: u32, event_f_flags: u32) FanotifyInitError!i32 {
+    const rc = system.fanotify_init(flags, event_f_flags);
+    switch (errno(rc)) {
+        .SUCCESS => return @as(i32, @intCast(rc)),
+        .INVAL => unreachable,
+        .MFILE => return error.ProcessFdQuotaExceeded,
+        .NFILE => return error.SystemFdQuotaExceeded,
+        .NOMEM => return error.SystemResources,
+        .NOSYS => return error.OperationNotSupported,
+        .PERM => return error.PermissionDenied,
+        else => |err| return unexpectedErrno(err),
+    }
+}
+
+pub const FanotifyMarkError = error{
+    MarkAlreadyExists,
+    IsDir,
+    NotAssociatedWithFileSystem,
+    FileNotFound,
+    SystemResources,
+    UserMarkQuotaExceeded,
+    NotImplemented,
+    NotDir,
+    OperationNotSupported,
+    PermissionDenied,
+    NotSameFileSystem,
+    NameTooLong,
+} || UnexpectedError;
+
+pub fn fanotify_mark(fanotify_fd: i32, flags: u32, mask: u64, dirfd: i32, pathname: ?[]const u8) FanotifyMarkError!void {
+    if (pathname) |path| {
+        const path_c = try toPosixPath(path);
+        return fanotify_markZ(fanotify_fd, flags, mask, dirfd, &path_c);
+    }
+
+    return fanotify_markZ(fanotify_fd, flags, mask, dirfd, null);
+}
+
+pub fn fanotify_markZ(fanotify_fd: i32, flags: u32, mask: u64, dirfd: i32, pathname: ?[*:0]const u8) FanotifyMarkError!void {
+    const rc = system.fanotify_mark(fanotify_fd, flags, mask, dirfd, pathname);
+    switch (errno(rc)) {
+        .SUCCESS => return,
+        .BADF => unreachable,
+        .EXIST => return error.MarkAlreadyExists,
+        .INVAL => unreachable,
+        .ISDIR => return error.IsDir,
+        .NODEV => return error.NotAssociatedWithFileSystem,
+        .NOENT => return error.FileNotFound,
+        .NOMEM => return error.SystemResources,
+        .NOSPC => return error.UserMarkQuotaExceeded,
+        .NOSYS => return error.NotImplemented,
+        .NOTDIR => return error.NotDir,
+        .OPNOTSUPP => return error.OperationNotSupported,
+        .PERM => return error.PermissionDenied,
+        .XDEV => return error.NotSameFileSystem,
+        else => |err| return unexpectedErrno(err),
+    }
+}
+
 pub const MProtectError = error{
     /// The memory cannot be given the specified access.  This can happen, for example, if you
     /// mmap(2)  a  file  to  which  you have read-only access, then ask mprotect() to mark it

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -357,6 +357,14 @@ pub fn inotify_rm_watch(fd: i32, wd: i32) usize {
     return syscall2(.inotify_rm_watch, @as(usize, @bitCast(@as(isize, fd))), @as(usize, @bitCast(@as(isize, wd))));
 }
 
+pub fn fanotify_init(flags: u32, event_f_flags: u32) usize {
+    return syscall2(.fanotify_init, flags, event_f_flags);
+}
+
+pub fn fanotify_mark(fd: i32, flags: u32, mask: u64, dirfd: i32, pathname: ?[*:0]const u8) usize {
+    return syscall5(.fanotify_mark, @as(usize, @bitCast(@as(isize, fd))), flags, mask, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(pathname));
+}
+
 pub fn readlink(noalias path: [*:0]const u8, noalias buf_ptr: [*]u8, buf_len: usize) usize {
     if (@hasField(SYS, "readlink")) {
         return syscall3(.readlink, @intFromPtr(path), @intFromPtr(buf_ptr), buf_len);
@@ -3163,6 +3171,58 @@ pub const IN = struct {
 
     pub const ISDIR = 0x40000000;
     pub const ONESHOT = 0x80000000;
+};
+
+pub const FAN = struct {
+    pub const ACCESS = 0x00000001;
+    pub const MODIFY = 0x00000002;
+    pub const CLOSE_WRITE = 0x00000008;
+    pub const CLOSE_NOWRITE = 0x00000010;
+    pub const OPEN = 0x00000020;
+    pub const Q_OVERFLOW = 0x00004000;
+    pub const OPEN_PERM = 0x00010000;
+    pub const ACCESS_PERM = 0x00020000;
+    pub const ONDIR = 0x40000000;
+    pub const EVENT_ON_CHILD = 0x08000000;
+    pub const CLOSE = CLOSE_WRITE | CLOSE_NOWRITE;
+    pub const CLOEXEC = 0x00000001;
+    pub const NONBLOCK = 0x00000002;
+    pub const CLASS_NOTIF = 0x00000000;
+    pub const CLASS_CONTENT = 0x00000004;
+    pub const CLASS_PRE_CONTENT = 0x00000008;
+    pub const ALL_CLASS_BITS = CLASS_NOTIF | CLASS_CONTENT | CLASS_PRE_CONTENT;
+    pub const UNLIMITED_QUEUE = 0x00000010;
+    pub const UNLIMITED_MARKS = 0x00000020;
+    pub const ALL_INIT_FLAGS = CLOEXEC | NONBLOCK | ALL_CLASS_BITS | UNLIMITED_QUEUE | UNLIMITED_MARKS;
+    pub const MARK_ADD = 0x00000001;
+    pub const MARK_REMOVE = 0x00000002;
+    pub const MARK_DONT_FOLLOW = 0x00000004;
+    pub const MARK_ONLYDIR = 0x00000008;
+    pub const MARK_MOUNT = 0x00000010;
+    pub const MARK_IGNORED_MASK = 0x00000020;
+    pub const MARK_IGNORED_SURV_MODIFY = 0x00000040;
+    pub const MARK_FLUSH = 0x00000080;
+    pub const ALL_MARK_FLAGS = MARK_ADD | MARK_REMOVE | MARK_DONT_FOLLOW | MARK_ONLYDIR | MARK_MOUNT | MARK_IGNORED_MASK | MARK_IGNORED_SURV_MODIFY | MARK_FLUSH;
+    pub const ALL_EVENTS = ACCESS | MODIFY | CLOSE | OPEN;
+    pub const ALL_PERM_EVENTS = OPEN_PERM | ACCESS_PERM;
+    pub const ALL_OUTGOING_EVENTS = ALL_EVENTS | ALL_PERM_EVENTS | Q_OVERFLOW;
+    pub const ALLOW = 0x01;
+    pub const DENY = 0x02;
+};
+
+pub const fanotify_event_metadata = extern struct {
+    event_len: u32,
+    vers: u8,
+    reserved: u8,
+    metadata_len: u16,
+    mask: u64 align(8),
+    fd: i32,
+    pid: i32,
+};
+
+pub const fanotify_response = extern struct {
+    fd: i32,
+    response: u32,
 };
 
 pub const S = struct {


### PR DESCRIPTION
This PR adds [fanotify](https://man7.org/linux/man-pages/man7/fanotify.7.html) API to `std.os.linux` and relevant higher level functions to `std.os`. I've made the higher level functions analogous to inotify API. There are also `FAN_EVENT_NEXT` and `FAN_EVENT_OK` macros but I was unsure to include them. I believe it'd be best to implement them in `std.os` in the future (maybe with `inline`).