### PR TITLE
codegen/llvm: truncate padding bits when loading a non-byte-sized value

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -6179,7 +6179,6 @@ pub const FuncGen = struct {
                 const elem_alignment = elem_ty.abiAlignment(mod).toLlvm();
                 return self.loadByRef(elem_ptr, elem_ty, elem_alignment, .normal);
             } else {
-                const elem_llvm_ty = try o.lowerType(elem_ty);
                 if (Air.refToIndex(bin_op.lhs)) |lhs_index| {
                     if (self.air.instructions.items(.tag)[lhs_index] == .load) {
                         const load_data = self.air.instructions.items(.data)[lhs_index];
@@ -6201,7 +6200,7 @@ pub const FuncGen = struct {
                                         &indices,
                                         "",
                                     );
-                                    return self.wip.load(.normal, elem_llvm_ty, gep, .default, "");
+                                    return self.loadTruncate(.normal, elem_ty, gep, .default);
                                 },
                                 else => {},
                             }
@@ -6210,7 +6209,7 @@ pub const FuncGen = struct {
                 }
                 const elem_ptr =
                     try self.wip.gep(.inbounds, array_llvm_ty, array_llvm_val, &indices, "");
-                return self.wip.load(.normal, elem_llvm_ty, elem_ptr, .default, "");
+                return self.loadTruncate(.normal, elem_ty, elem_ptr, .default);
             }
         }
 
@@ -6378,13 +6377,12 @@ pub const FuncGen = struct {
                 const payload_index = @intFromBool(layout.tag_align.compare(.gte, layout.payload_align));
                 const field_ptr =
                     try self.wip.gepStruct(union_llvm_ty, struct_llvm_val, payload_index, "");
-                const llvm_field_ty = try o.lowerType(field_ty);
                 const payload_alignment = layout.payload_align.toLlvm();
                 if (isByRef(field_ty, mod)) {
                     if (canElideLoad(self, body_tail)) return field_ptr;
                     return self.loadByRef(field_ptr, field_ty, payload_alignment, .normal);
                 } else {
-                    return self.wip.load(.normal, llvm_field_ty, field_ptr, payload_alignment, "");
+                    return self.loadTruncate(.normal, field_ty, field_ptr, payload_alignment);
                 }
             },
             else => unreachable,
@@ -10219,8 +10217,7 @@ pub const FuncGen = struct {
 
                 return fg.loadByRef(payload_ptr, payload_ty, payload_alignment, .normal);
             }
-            const payload_llvm_ty = try o.lowerType(payload_ty);
-            return fg.wip.load(.normal, payload_llvm_ty, payload_ptr, payload_alignment, "");
+            return fg.loadTruncate(.normal, payload_ty, payload_ptr, payload_alignment);
         }
 
         assert(!isByRef(payload_ty, mod));
@@ -10321,6 +10318,36 @@ pub const FuncGen = struct {
         }
     }
 
+    /// Load a value and, if needed, mask out padding bits for non byte-sized integer values.
+    fn loadTruncate(
+        fg: *FuncGen,
+        access_kind: Builder.MemoryAccessKind,
+        payload_ty: Type,
+        payload_ptr: Builder.Value,
+        payload_alignment: Builder.Alignment,
+    ) !Builder.Value {
+        // from https://llvm.org/docs/LangRef.html#load-instruction :
+        // "When loading a value of a type like i20 with a size that is not an integral number of bytes, the result is undefined if the value was not originally written using a store of the same type. "
+        // => so load the byte aligned value and trunc the unwanted bits.
+
+        const o = fg.dg.object;
+        const mod = o.module;
+        const payload_llvm_ty = try o.lowerType(payload_ty);
+        const load_llvm_ty = if (payload_ty.isAbiInt(mod))
+            try o.builder.intType(@intCast(payload_ty.abiSize(mod) * 8))
+        else
+            payload_llvm_ty;
+        const loaded = try fg.wip.load(access_kind, load_llvm_ty, payload_ptr, payload_alignment, "");
+        const shifted = if (payload_llvm_ty != load_llvm_ty and o.target.cpu.arch.endian() == .Big)
+            try fg.wip.bin(.lshr, loaded, try o.builder.intValue(
+                load_llvm_ty,
+                (payload_ty.abiSize(mod) - (std.math.divCeil(u64, payload_ty.bitSize(mod), 8) catch unreachable)) * 8,
+            ), "")
+        else
+            loaded;
+        return fg.wip.conv(.unneeded, shifted, payload_llvm_ty, "");
+    }
+
     /// Load a by-ref type by constructing a new alloca and performing a memcpy.
     fn loadByRef(
         fg: *FuncGen,
@@ -10378,21 +10405,7 @@ pub const FuncGen = struct {
             if (isByRef(elem_ty, mod)) {
                 return self.loadByRef(ptr, elem_ty, ptr_alignment, access_kind);
             }
-            const llvm_elem_ty = try o.lowerType(elem_ty);
-            const llvm_load_ty = if (elem_ty.isAbiInt(mod))
-                try o.builder.intType(@intCast(elem_ty.abiSize(mod) * 8))
-            else
-                llvm_elem_ty;
-            const loaded = try self.wip.load(access_kind, llvm_load_ty, ptr, ptr_alignment, "");
-            const shifted = if (llvm_elem_ty != llvm_load_ty and o.target.cpu.arch.endian() == .Big)
-                try self.wip.bin(.lshr, loaded, try o.builder.intValue(
-                    llvm_load_ty,
-                    (elem_ty.abiSize(mod) - (std.math.divCeil(u64, elem_ty.bitSize(mod), 8) catch
-                        unreachable)) * 8,
-                ), "")
-            else
-                loaded;
-            return self.wip.conv(.unneeded, shifted, llvm_elem_ty, "");
+            return self.loadTruncate(access_kind, elem_ty, ptr, ptr_alignment);
         }
 
         const containing_int_ty = try o.builder.intType(@intCast(info.packed_offset.host_size * 8));

--- a/test/behavior/cast_int.zig
+++ b/test/behavior/cast_int.zig
@@ -1,6 +1,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 const expect = std.testing.expect;
+const expectEqual = std.testing.expectEqual;
 const maxInt = std.math.maxInt;
 
 test "@intCast i32 to u7" {
@@ -28,3 +29,95 @@ test "coerce i8 to i32 and @intCast back" {
     var y2: i8 = -5;
     try expect(y2 == @as(i8, @intCast(x2)));
 }
+
+test "coerce non byte-sized integers accross 32bits boundary" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+    {
+        var v: u21 = 6417;
+        const a: u32 = v;
+        const b: u64 = v;
+        const c: u64 = a;
+        var w: u64 = 0x1234567812345678;
+        const d: u21 = @truncate(w);
+        const e: u60 = d;
+        try expectEqual(@as(u32, 6417), a);
+        try expectEqual(@as(u64, 6417), b);
+        try expectEqual(@as(u64, 6417), c);
+        try expectEqual(@as(u21, 0x145678), d);
+        try expectEqual(@as(u60, 0x145678), e);
+    }
+
+    {
+        var v: u10 = 234;
+        const a: u32 = v;
+        const b: u64 = v;
+        const c: u64 = a;
+        var w: u64 = 0x1234567812345678;
+        const d: u10 = @truncate(w);
+        const e: u60 = d;
+        try expectEqual(@as(u32, 234), a);
+        try expectEqual(@as(u64, 234), b);
+        try expectEqual(@as(u64, 234), c);
+        try expectEqual(@as(u21, 0x278), d);
+        try expectEqual(@as(u60, 0x278), e);
+    }
+    {
+        var v: u7 = 11;
+        const a: u32 = v;
+        const b: u64 = v;
+        const c: u64 = a;
+        var w: u64 = 0x1234567812345678;
+        const d: u7 = @truncate(w);
+        const e: u60 = d;
+        try expectEqual(@as(u32, 11), a);
+        try expectEqual(@as(u64, 11), b);
+        try expectEqual(@as(u64, 11), c);
+        try expectEqual(@as(u21, 0x78), d);
+        try expectEqual(@as(u60, 0x78), e);
+    }
+
+    {
+        var v: i21 = -6417;
+        const a: i32 = v;
+        const b: i64 = v;
+        const c: i64 = a;
+        var w: i64 = -12345;
+        const d: i21 = @intCast(w);
+        const e: i60 = d;
+        try expectEqual(@as(i32, -6417), a);
+        try expectEqual(@as(i64, -6417), b);
+        try expectEqual(@as(i64, -6417), c);
+        try expectEqual(@as(i21, -12345), d);
+        try expectEqual(@as(i60, -12345), e);
+    }
+
+    {
+        var v: i10 = -234;
+        const a: i32 = v;
+        const b: i64 = v;
+        const c: i64 = a;
+        var w: i64 = -456;
+        const d: i10 = @intCast(w);
+        const e: i60 = d;
+        try expectEqual(@as(i32, -234), a);
+        try expectEqual(@as(i64, -234), b);
+        try expectEqual(@as(i64, -234), c);
+        try expectEqual(@as(i10, -456), d);
+        try expectEqual(@as(i60, -456), e);
+    }
+    {
+        var v: i7 = -11;
+        const a: i32 = v;
+        const b: i64 = v;
+        const c: i64 = a;
+        var w: i64 = -42;
+        const d: i7 = @intCast(w);
+        const e: i60 = d;
+        try expectEqual(@as(i32, -11), a);
+        try expectEqual(@as(i64, -11), b);
+        try expectEqual(@as(i64, -11), c);
+        try expectEqual(@as(i7, -42), d);
+        try expectEqual(@as(i60, -42), e);
+    }
+}
+

--- a/test/behavior/cast_int.zig
+++ b/test/behavior/cast_int.zig
@@ -31,7 +31,6 @@ test "coerce i8 to i32 and @intCast back" {
 }
 
 test "coerce non byte-sized integers accross 32bits boundary" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     {
         var v: u21 = 6417;
         const a: u32 = v;

--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -991,7 +991,7 @@ test "bitcast back and forth" {
 
 test "field access of packed struct smaller than its abi size inside struct initialized with rls" {
     // Originally reported at https://github.com/ziglang/zig/issues/14200
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .arm) return error.SkipZigTest;
+
     const S = struct {
         ps: packed struct { x: i2, y: i2 },
 


### PR DESCRIPTION
This is generalisation of @jacobly0 https://github.com/ziglang/zig/pull/16605 to support optional and unions.

llvm appears to assume padding bits are "properly set" when using `llvm.load i4`:
https://llvm.org/docs/LangRef.html#load-instruction
> "When loading a value of a type like i20 with a size that is not an integral number of bytes, the result is undefined if the value was not originally written using a store of the same type."

so llvm assumes the `and` is redundant  and doesn't generate code to mask out  the bits.
```llvm
  %26 = getelementptr inbounds { i4, i8 }, ptr %3, i32 0, i32 0, !dbg !3141
  %27 = load i4, ptr %26, align 1, !dbg !3141
  %28 = lshr i4 %27, 1, !dbg !3142
  %29 = and i4 %28, 7, !dbg !3142  <<< does nothing
  %30 = trunc i4 %29 to i3, !dbg !3142
  %31 = icmp eq i3 %30, -3, !dbg !3142
```

after this commit,  this byte code is generated instead, and the hi bits are properly zeroed:
```llvm
  %26 = getelementptr inbounds { i4, i8 }, ptr %3, i32 0, i32 0, !dbg !3141
  %27 = load i8, ptr %26, align 1, !dbg !3141
  %28 = trunc i8 %27 to i4, !dbg !3141
  %29 = lshr i4 %28, 1, !dbg !3142
  %30 = and i4 %29, 7, !dbg !3142
  %31 = trunc i4 %30 to i3, !dbg !3142
  %32 = icmp eq i3 %31, -3, !dbg !3142
```

closes #14200

also, a pair of bugs seem to be fixed now by this or previous commits -> add a test case.
closes #9674
closes #16581