### PR TITLE
 std.RingBuffer: Implement mem.copy read/write 

### DIFF
--- a/lib/std/compress/zstandard.zig
+++ b/lib/std/compress/zstandard.zig
@@ -219,9 +219,7 @@ pub fn DecompressStream(
             }
 
             const size = @min(self.buffer.len(), buffer.len);
-            for (0..size) |i| {
-                buffer[i] = self.buffer.read().?;
-            }
+            self.buffer.readFirstAssumeLength(buffer, size);
             if (self.state == .LastBlock and self.buffer.len() == 0) {
                 self.state = .NewFrame;
                 self.allocator.free(self.literal_fse_buffer);

--- a/lib/std/compress/zstandard/decode/block.zig
+++ b/lib/std/compress/zstandard/decode/block.zig
@@ -311,8 +311,8 @@ pub const DecodeState = struct {
         try self.decodeLiteralsRingBuffer(dest, sequence.literal_length);
         const copy_start = dest.write_index + dest.data.len - sequence.offset;
         const copy_slice = dest.sliceAt(copy_start, sequence.match_length);
-        for (copy_slice.first) |b| dest.writeAssumeCapacity(b);
-        for (copy_slice.second) |b| dest.writeAssumeCapacity(b);
+        dest.writeSliceForwardsAssumeCapacity(copy_slice.first);
+        dest.writeSliceForwardsAssumeCapacity(copy_slice.second);
         self.written_count += sequence.match_length;
     }
 
@@ -723,9 +723,7 @@ pub fn decodeBlockRingBuffer(
         },
         .rle => {
             if (src.len < 1) return error.MalformedRleBlock;
-            for (0..block_size) |_| {
-                dest.writeAssumeCapacity(src[0]);
-            }
+            dest.writeSliceAssumeCapacity(src[0..block_size]);
             consumed_count.* += 1;
             decode_state.written_count += block_size;
             return block_size;


### PR DESCRIPTION
Metron benchmarks on M1 mac, testing time to write a slice to buffer then read it. Number corresponds to input size in bytes. RingBuffer capacity > 500.

- masterRead = read() function, which still exists following proposed changes
- newRead = readFirst()/readLast(), newly implemented.
- masterWrite = master writeSlice() function
- newWrite = modified writeSlice() function

Can see a slight loss in performance for small read/write sizes, mostly for the new read methods, however old read method still exists so not an issue. New write method is strictly an improvement. Huge improvements for large read/write sizes. Have not benchmarked writing data with a length greater than RingBuffer capacity but new writeSlice() method will be extremely efficient here as it skips data that will get overwritten (excluding first write). 23x performance for new impl with 500 bytes length write/read
```
-----------------------------------------------------------
Benchmark                               Time       Iterations
-----------------------------------------------------------
Length = 1
ringbuffer/masterWriteMasterRead       1.10 ns     1145553870
ringbuffer/masterWriteNewRead          1.19 ns     1184928558
ringbuffer/newWriteNewRead             1.17 ns     1185958676
ringbuffer/newWriteMasterRead          1.12 ns     1237117497
Length = 5
ringbuffer/masterWriteMasterRead       4.83 ns      294598897
ringbuffer/masterWriteNewRead          3.57 ns      393993845
ringbuffer/newWriteNewRead             5.33 ns      262691990
ringbuffer/newWriteMasterRead          4.10 ns      328091998
Length = 25
ringbuffer/masterWriteMasterRead       14.4 ns       87942575
ringbuffer/masterWriteNewRead          7.21 ns      197825287
ringbuffer/newWriteNewRead             5.92 ns      236331394
ringbuffer/newWriteMasterRead          11.1 ns      125616070
Length = 100
ringbuffer/masterWriteMasterRead        121 ns       10656980
ringbuffer/masterWriteNewRead          71.5 ns       19619597
ringbuffer/newWriteNewRead             9.94 ns      142748448
ringbuffer/newWriteMasterRead          65.1 ns       21449213
Length = 500
ringbuffer/masterWriteMasterRead        642 ns        2182755
ringbuffer/masterWriteNewRead           335 ns        4215511
ringbuffer/newWriteNewRead             28.4 ns       50308287
ringbuffer/newWriteMasterRead           338 ns        4150044
```

Could eek out some more performance improvements by forcing capacity to a power of two to enable for bitwise AND masking but fairly negligible - not allowing for writing a slice of length > max buffer length would also improve write performance slightly due to removal of branch and one @min call

also still very easy to use buffer to write a slice byte by byte manually as with previous writeSlice implementation via manual use of write() function in loop