### PR TITLE
std.http: more proxy support, buffer writes, tls toggle

### DIFF
--- a/lib/std/Uri.zig
+++ b/lib/std/Uri.zig
@@ -208,24 +208,45 @@ pub fn parseWithoutScheme(text: []const u8) ParseError!Uri {
     return uri;
 }
 
-pub fn format(
+pub const WriteToStreamOptions = struct {
+    /// When true, include the scheme part of the URI.
+    scheme: bool = false,
+
+    /// When true, include the user and password part of the URI. Ignored if `authority` is false.
+    authentication: bool = false,
+
+    /// When true, include the authority part of the URI.
+    authority: bool = false,
+
+    /// When true, include the path part of the URI.
+    path: bool = false,
+
+    /// When true, include the query part of the URI. Ignored when `path` is false.
+    query: bool = false,
+
+    /// When true, include the fragment part of the URI. Ignored when `path` is false.
+    fragment: bool = false,
+
+    /// When true, do not escape any part of the URI.
+    raw: bool = false,
+};
+
+pub fn writeToStream(
     uri: Uri,
-    comptime fmt: []const u8,
-    options: std.fmt.FormatOptions,
+    options: WriteToStreamOptions,
     writer: anytype,
 ) @TypeOf(writer).Error!void {
-    _ = options;
-
-    const needs_absolute = comptime std.mem.indexOf(u8, fmt, "+") != null;
-    const needs_path = comptime std.mem.indexOf(u8, fmt, "/") != null or fmt.len == 0;
-    const raw_uri = comptime std.mem.indexOf(u8, fmt, "r") != null;
-    const needs_fragment = comptime std.mem.indexOf(u8, fmt, "#") != null;
-
-    if (needs_absolute) {
+    if (options.scheme) {
         try writer.writeAll(uri.scheme);
         try writer.writeAll(":");
-        if (uri.host) |host| {
+
+        if (options.authority and uri.host != null) {
             try writer.writeAll("//");
+        }
+    }
+
+    if (options.authority) {
+        if (options.authentication and uri.host != null) {
             if (uri.user) |user| {
                 try writer.writeAll(user);
                 if (uri.password) |password| {
@@ -234,7 +255,9 @@ pub fn format(
                 }
                 try writer.writeAll("@");
             }
+        }
 
+        if (uri.host) |host| {
             try writer.writeAll(host);
 
             if (uri.port) |port| {
@@ -244,37 +267,60 @@ pub fn format(
         }
     }
 
-    if (needs_path) {
+    if (options.path) {
         if (uri.path.len == 0) {
             try writer.writeAll("/");
+        } else if (options.raw) {
+            try writer.writeAll(uri.path);
         } else {
-            if (raw_uri) {
-                try writer.writeAll(uri.path);
-            } else {
-                try Uri.writeEscapedPath(writer, uri.path);
-            }
+            try writeEscapedPath(writer, uri.path);
         }
 
-        if (uri.query) |q| {
+        if (options.query) if (uri.query) |q| {
             try writer.writeAll("?");
-            if (raw_uri) {
+            if (options.raw) {
                 try writer.writeAll(q);
             } else {
-                try Uri.writeEscapedQuery(writer, q);
+                try writeEscapedQuery(writer, q);
             }
-        }
+        };
 
-        if (needs_fragment) {
-            if (uri.fragment) |f| {
-                try writer.writeAll("#");
-                if (raw_uri) {
-                    try writer.writeAll(f);
-                } else {
-                    try Uri.writeEscapedQuery(writer, f);
-                }
+        if (options.fragment) if (uri.fragment) |f| {
+            try writer.writeAll("#");
+            if (options.raw) {
+                try writer.writeAll(f);
+            } else {
+                try writeEscapedQuery(writer, f);
             }
-        }
+        };
     }
+}
+
+pub fn format(
+    uri: Uri,
+    comptime fmt: []const u8,
+    options: std.fmt.FormatOptions,
+    writer: anytype,
+) @TypeOf(writer).Error!void {
+    _ = options;
+
+    const scheme = comptime std.mem.indexOf(u8, fmt, ":") != null or fmt.len == 0;
+    const authentication = comptime std.mem.indexOf(u8, fmt, "@") != null or fmt.len == 0;
+    const authority = comptime std.mem.indexOf(u8, fmt, "+") != null or fmt.len == 0;
+    const path = comptime std.mem.indexOf(u8, fmt, "/") != null or fmt.len == 0;
+    const query = comptime std.mem.indexOf(u8, fmt, "?") != null or fmt.len == 0;
+    const fragment = comptime std.mem.indexOf(u8, fmt, "#") != null or fmt.len == 0;
+    const raw = comptime std.mem.indexOf(u8, fmt, "r") != null or fmt.len == 0;
+
+    return writeToStream(uri, .{
+        .scheme = scheme,
+        .authentication = authentication,
+        .authority = authority,
+        .path = path,
+        .query = query,
+        .fragment = fragment,
+        .raw = raw,
+    }, writer);
 }
 
 /// Parses the URI or returns an error.
@@ -709,7 +755,7 @@ test "URI query escaping" {
     const parsed = try Uri.parse(address);
 
     // format the URI to escape it
-    const formatted_uri = try std.fmt.allocPrint(std.testing.allocator, "{}", .{parsed});
+    const formatted_uri = try std.fmt.allocPrint(std.testing.allocator, "{/?}", .{parsed});
     defer std.testing.allocator.free(formatted_uri);
     try std.testing.expectEqualStrings("/?response-content-type=application%2Foctet-stream", formatted_uri);
 }
@@ -727,6 +773,6 @@ test "format" {
     };
     var buf = std.ArrayList(u8).init(std.testing.allocator);
     defer buf.deinit();
-    try uri.format("+/", .{}, buf.writer());
+    try uri.format(":/?#", .{}, buf.writer());
     try std.testing.expectEqualSlices(u8, "file:/foo/bar/baz", buf.items);
 }

--- a/lib/std/crypto/tls/Client.zig
+++ b/lib/std/crypto/tls/Client.zig
@@ -881,7 +881,7 @@ pub fn readAll(c: *Client, stream: anytype, buffer: []u8) !usize {
 /// The `iovecs` parameter is mutable because this function needs to mutate the fields in
 /// order to handle partial reads from the underlying stream layer.
 pub fn readv(c: *Client, stream: anytype, iovecs: []std.os.iovec) !usize {
-    return readvAtLeast(c, stream, iovecs);
+    return readvAtLeast(c, stream, iovecs, 1);
 }
 
 /// Receives TLS-encrypted data from `stream`, which must conform to `StreamInterface`.

--- a/lib/std/http.zig
+++ b/lib/std/http.zig
@@ -289,14 +289,17 @@ pub const Status = enum(u10) {
 
 pub const TransferEncoding = enum {
     chunked,
+    none,
     // compression is intentionally omitted here, as std.http.Client stores it as content-encoding
 };
 
 pub const ContentEncoding = enum {
     identity,
     compress,
+    @"x-compress",
     deflate,
     gzip,
+    @"x-gzip",
     zstd,
 };
 

--- a/lib/std/http.zig
+++ b/lib/std/http.zig
@@ -35,7 +35,8 @@ pub const Method = enum(u64) { // TODO: should be u192 or u256, but neither is s
     /// Asserts that `s` is 24 or fewer bytes.
     pub fn parse(s: []const u8) u64 {
         var x: u64 = 0;
-        @memcpy(std.mem.asBytes(&x)[0..s.len], s);
+        const len = @min(s.len, @sizeOf(@TypeOf(x)));
+        @memcpy(std.mem.asBytes(&x)[0..len], s[0..len]);
         return x;
     }
 

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -605,7 +605,7 @@ pub const Request = struct {
         raw_uri: bool = false,
     };
 
-    /// Send the HTTP request to the server.
+    /// Send the HTTP request headers to the server.
     pub fn start(req: *Request, options: StartOptions) StartError!void {
         if (!req.method.requestHasBody() and req.transfer_encoding != .none) return error.UnsupportedTransferEncoding;
 

--- a/lib/std/http/Headers.zig
+++ b/lib/std/http/Headers.zig
@@ -14,14 +14,17 @@ pub const CaseInsensitiveStringContext = struct {
     pub fn hash(self: @This(), s: []const u8) u64 {
         _ = self;
         var buf: [64]u8 = undefined;
-        var i: u8 = 0;
+        var i: usize = 0;
 
         var h = std.hash.Wyhash.init(0);
-        while (i < s.len) : (i += 64) {
-            const left = @min(64, s.len - i);
-            const ret = ascii.lowerString(buf[0..], s[i..][0..left]);
+        while (i + 64 < s.len) : (i += 64) {
+            const ret = ascii.lowerString(buf[0..], s[i..][0..64]);
             h.update(ret);
         }
+
+        const left = @min(64, s.len - i);
+        const ret = ascii.lowerString(buf[0..], s[i..][0..left]);
+        h.update(ret);
 
         return h.final();
     }

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -178,7 +178,7 @@ pub const Request = struct {
     };
 
     pub fn parse(req: *Request, bytes: []const u8) ParseError!void {
-        var it = mem.tokenizeAny(u8, bytes[0 .. bytes.len - 4], "\r\n");
+        var it = mem.tokenizeAny(u8, bytes, "\r\n");
 
         const first_line = it.next() orelse return error.HttpHeadersInvalid;
         if (first_line.len < 10)

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -392,10 +392,10 @@ pub const Response = struct {
         }
     }
 
-    pub const StartError = Connection.WriteError || error{ UnsupportedTransferEncoding, InvalidContentLength };
+    pub const SendError = Connection.WriteError || error{ UnsupportedTransferEncoding, InvalidContentLength };
 
     /// Send the HTTP response headers to the client.
-    pub fn start(res: *Response) StartError!void {
+    pub fn send(res: *Response) SendError!void {
         switch (res.state) {
             .waited => res.state = .responded,
             .first, .start, .responded, .finished => unreachable,
@@ -771,7 +771,7 @@ test "HTTP server handles a chunked transfer coding request" {
             res.transfer_encoding = .{ .content_length = server_body.len };
             try res.headers.append("content-type", "text/plain");
             try res.headers.append("connection", "close");
-            try res.do();
+            try res.send();
 
             var buf: [128]u8 = undefined;
             const n = try res.readAll(&buf);

--- a/lib/std/http/protocol.zig
+++ b/lib/std/http/protocol.zig
@@ -529,7 +529,7 @@ pub const HeadersParser = struct {
                         try conn.fill();
 
                         const nread = @min(conn.peek().len, data_avail);
-                        conn.drop(@as(u16, @intCast(nread)));
+                        conn.drop(@intCast(nread));
                         r.next_chunk_length -= nread;
 
                         if (r.next_chunk_length == 0) r.done = true;
@@ -553,7 +553,7 @@ pub const HeadersParser = struct {
                     try conn.fill();
 
                     const i = r.findChunkedLen(conn.peek());
-                    conn.drop(@as(u16, @intCast(i)));
+                    conn.drop(@intCast(i));
 
                     switch (r.state) {
                         .invalid => return error.HttpChunkInvalid,
@@ -582,7 +582,7 @@ pub const HeadersParser = struct {
                         try conn.fill();
 
                         const nread = @min(conn.peek().len, data_avail);
-                        conn.drop(@as(u16, @intCast(nread)));
+                        conn.drop(@intCast(nread));
                         r.next_chunk_length -= nread;
                     } else if (out_avail > 0) {
                         const can_read: usize = @intCast(@min(data_avail, out_avail));

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -283,10 +283,15 @@ pub const options = struct {
     else
         false;
 
-    pub const http_connection_pool_size = if (@hasDecl(options_override, "http_connection_pool_size"))
-        options_override.http_connection_pool_size
+    /// By default, std.http.Client will support HTTPS connections.  Set this option to `true` to
+    /// disable TLS support.
+    /// 
+    /// This will likely reduce the size of the binary, but it will also make it impossible to
+    /// make a HTTPS connection.
+    pub const http_disable_tls = if (@hasDecl(options_override, "http_disable_tls"))
+        options_override.http_disable_tls
     else
-        http.Client.default_connection_pool_size;
+        false;
 
     pub const side_channels_mitigations: crypto.SideChannelsMitigations = if (@hasDecl(options_override, "side_channels_mitigations"))
         options_override.side_channels_mitigations

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -285,7 +285,7 @@ pub const options = struct {
 
     /// By default, std.http.Client will support HTTPS connections.  Set this option to `true` to
     /// disable TLS support.
-    /// 
+    ///
     /// This will likely reduce the size of the binary, but it will also make it impossible to
     /// make a HTTPS connection.
     pub const http_disable_tls = if (@hasDecl(options_override, "http_disable_tls"))

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -826,7 +826,7 @@ fn initResource(f: *Fetch, uri: std.Uri) RunError!Resource {
         var h = std.http.Headers{ .allocator = gpa };
         defer h.deinit();
 
-        var req = http_client.request(.GET, uri, h, .{}) catch |err| {
+        var req = http_client.open(.GET, uri, h, .{}) catch |err| {
             return f.fail(f.location_tok, try eb.printString(
                 "unable to connect to server: {s}",
                 .{@errorName(err)},
@@ -834,7 +834,7 @@ fn initResource(f: *Fetch, uri: std.Uri) RunError!Resource {
         };
         errdefer req.deinit(); // releases more than memory
 
-        req.start(.{}) catch |err| {
+        req.send(.{}) catch |err| {
             return f.fail(f.location_tok, try eb.printString(
                 "HTTP request failed: {s}",
                 .{@errorName(err)},

--- a/src/Package/Fetch/git.zig
+++ b/src/Package/Fetch/git.zig
@@ -518,11 +518,11 @@ pub const Session = struct {
         defer headers.deinit();
         try headers.append("Git-Protocol", "version=2");
 
-        var request = try session.transport.request(.GET, info_refs_uri, headers, .{
+        var request = try session.transport.open(.GET, info_refs_uri, headers, .{
             .max_redirects = 3,
         });
         errdefer request.deinit();
-        try request.start(.{});
+        try request.send(.{});
         try request.finish();
 
         try request.wait();
@@ -641,12 +641,12 @@ pub const Session = struct {
         }
         try Packet.write(.flush, body_writer);
 
-        var request = try session.transport.request(.POST, upload_pack_uri, headers, .{
+        var request = try session.transport.open(.POST, upload_pack_uri, headers, .{
             .handle_redirects = false,
         });
         errdefer request.deinit();
         request.transfer_encoding = .{ .content_length = body.items.len };
-        try request.start(.{});
+        try request.send(.{});
         try request.writeAll(body.items);
         try request.finish();
 
@@ -740,12 +740,12 @@ pub const Session = struct {
         try Packet.write(.{ .data = "done\n" }, body_writer);
         try Packet.write(.flush, body_writer);
 
-        var request = try session.transport.request(.POST, upload_pack_uri, headers, .{
+        var request = try session.transport.open(.POST, upload_pack_uri, headers, .{
             .handle_redirects = false,
         });
         errdefer request.deinit();
         request.transfer_encoding = .{ .content_length = body.items.len };
-        try request.start(.{});
+        try request.send(.{});
         try request.writeAll(body.items);
         try request.finish();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -5128,6 +5128,8 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
             var http_client: std.http.Client = .{ .allocator = gpa };
             defer http_client.deinit();
 
+            try http_client.loadDefaultProxies();
+
             var progress: std.Progress = .{ .dont_print_on_dumb = true };
             const root_prog_node = progress.start("Fetch Packages", 0);
             defer root_prog_node.end();
@@ -7038,6 +7040,8 @@ fn cmdFetch(
 
     var http_client: std.http.Client = .{ .allocator = gpa };
     defer http_client.deinit();
+
+    try http_client.loadDefaultProxies();
 
     var progress: std.Progress = .{ .dont_print_on_dumb = true };
     const root_prog_node = progress.start("Fetch", 0);

--- a/test/standalone/http.zig
+++ b/test/standalone/http.zig
@@ -7,6 +7,10 @@ const Client = http.Client;
 const mem = std.mem;
 const testing = std.testing;
 
+pub const std_options = struct {
+    pub const http_disable_tls = true;
+};
+
 const max_header_size = 8192;
 
 var gpa_server = std.heap.GeneralPurposeAllocator(.{ .stack_trace_frames = 12 }){};

--- a/test/standalone/http.zig
+++ b/test/standalone/http.zig
@@ -29,11 +29,11 @@ fn handleRequest(res: *Server.Response) !void {
     if (res.request.headers.contains("expect")) {
         if (mem.eql(u8, res.request.headers.getFirstValue("expect").?, "100-continue")) {
             res.status = .@"continue";
-            try res.do();
+            try res.start();
             res.status = .ok;
         } else {
             res.status = .expectation_failed;
-            try res.do();
+            try res.start();
             return;
         }
     }
@@ -54,7 +54,7 @@ fn handleRequest(res: *Server.Response) !void {
 
         try res.headers.append("content-type", "text/plain");
 
-        try res.do();
+        try res.start();
         if (res.request.method != .HEAD) {
             try res.writeAll("Hello, ");
             try res.writeAll("World!\n");
@@ -65,7 +65,7 @@ fn handleRequest(res: *Server.Response) !void {
     } else if (mem.startsWith(u8, res.request.target, "/large")) {
         res.transfer_encoding = .{ .content_length = 14 * 1024 + 14 * 10 };
 
-        try res.do();
+        try res.start();
 
         var i: u32 = 0;
         while (i < 5) : (i += 1) {
@@ -92,14 +92,14 @@ fn handleRequest(res: *Server.Response) !void {
             try testing.expectEqualStrings("14", res.request.headers.getFirstValue("content-length").?);
         }
 
-        try res.do();
+        try res.start();
         try res.writeAll("Hello, ");
         try res.writeAll("World!\n");
         try res.finish();
     } else if (mem.eql(u8, res.request.target, "/trailer")) {
         res.transfer_encoding = .chunked;
 
-        try res.do();
+        try res.start();
         try res.writeAll("Hello, ");
         try res.writeAll("World!\n");
         // try res.finish();
@@ -110,7 +110,7 @@ fn handleRequest(res: *Server.Response) !void {
         res.status = .found;
         try res.headers.append("location", "../../get");
 
-        try res.do();
+        try res.start();
         try res.writeAll("Hello, ");
         try res.writeAll("Redirected!\n");
         try res.finish();
@@ -120,7 +120,7 @@ fn handleRequest(res: *Server.Response) !void {
         res.status = .found;
         try res.headers.append("location", "/redirect/1");
 
-        try res.do();
+        try res.start();
         try res.writeAll("Hello, ");
         try res.writeAll("Redirected!\n");
         try res.finish();
@@ -133,7 +133,7 @@ fn handleRequest(res: *Server.Response) !void {
         res.status = .found;
         try res.headers.append("location", location);
 
-        try res.do();
+        try res.start();
         try res.writeAll("Hello, ");
         try res.writeAll("Redirected!\n");
         try res.finish();
@@ -143,7 +143,7 @@ fn handleRequest(res: *Server.Response) !void {
         res.status = .found;
         try res.headers.append("location", "/redirect/3");
 
-        try res.do();
+        try res.start();
         try res.writeAll("Hello, ");
         try res.writeAll("Redirected!\n");
         try res.finish();
@@ -154,11 +154,11 @@ fn handleRequest(res: *Server.Response) !void {
 
         res.status = .found;
         try res.headers.append("location", location);
-        try res.do();
+        try res.start();
         try res.finish();
     } else {
         res.status = .not_found;
-        try res.do();
+        try res.start();
     }
 }
 

--- a/test/standalone/http.zig
+++ b/test/standalone/http.zig
@@ -680,7 +680,7 @@ pub fn main() !void {
         for (0..total_connections) |i| {
             var req = try client.request(.GET, uri, .{ .allocator = calloc }, .{});
             req.response.parser.done = true;
-            req.connection.?.data.closing = false;
+            req.connection.?.closing = false;
             requests[i] = req;
         }
 

--- a/test/standalone/http.zig
+++ b/test/standalone/http.zig
@@ -634,9 +634,6 @@ pub fn main() !void {
         req.transfer_encoding = .chunked;
 
         try req.send(.{});
-        try req.wait();
-        try testing.expectEqual(http.Status.@"continue", req.response.status);
-
         try req.writeAll("Hello, ");
         try req.writeAll("World!\n");
         try req.finish();


### PR DESCRIPTION
## std.http.Client Changes

Proxies are now separated, so HTTP and HTTPS requests can be diverted thru different proxies. Connection pool now accepts a `Allocator` instead of a `*Client` for allocations. Now passes around a `*Connection` instead of a `*ConnectionPool.Node`.

Writes are now buffered, and reads now use iovecs to reduce syscalls.

Adds `client.loadDefaultProxies` to loads proxy information from common
environment variables (http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY,
all_proxy, ALL_PROXY).
- no_proxy and NO_PROXY are currently unsupported.

## Other Associated Fixes

`std.Uri` has expanded formatting capabilities so to enable more control over what appears in the output.

`std.crypto.tls.Client.readv` was evidently not tested, it was missing a parameter.

## std_options Changes

Removed `http_connection_pool_size`, Added `http_disable_tls`
- http_connection_pool_size: replaced with `client.connection_pool.resize(client.allocator, size)`
- http_disable_tls: When true, all HTTPS requests will error with `error.TlsInitializationFailed`, and std.http will make no references to `std.crypto.tls` (which may reduce the size of the overall binary, and potentially reduce compile times; unless referenced elsewhere).

When compiling without TLS: `test/standalone/http.zig` compiles 10 seconds faster, and is half the size (aprox. -4MB in ReleaseSafe).

## Documentation

Adds documentation to public functions that was missing documentation. Adds information about when order-specific functions need to be called.

Revisited old documentation and pulled it in line with what each function is actually doing now.