### PR TITLE
x86_64: more `f80` support

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -11470,9 +11470,13 @@ fn airFloatFromInt(self: *Self, inst: Air.Inst.Index) !void {
     const result = result: {
         if (switch (dst_bits) {
             16, 80, 128 => true,
-            32, 64 => src_size > 8 and src_size < 16,
+            32, 64 => src_size > 8,
             else => unreachable,
         }) {
+            if (src_bits > 128) return self.fail("TODO implement airFloatFromInt from {} to {}", .{
+                src_ty.fmt(mod), dst_ty.fmt(mod),
+            });
+
             var callee: ["__floatun?i?f".len]u8 = undefined;
             break :result try self.genCall(.{ .lib = .{
                 .return_type = dst_ty.toIntern(),
@@ -11487,10 +11491,6 @@ fn airFloatFromInt(self: *Self, inst: Air.Inst.Index) !void {
                 }) catch unreachable,
             } }, &.{src_ty}, &.{.{ .air_ref = ty_op.operand }});
         }
-
-        if (src_size > 8) return self.fail("TODO implement airFloatFromInt from {} to {}", .{
-            src_ty.fmt(mod), dst_ty.fmt(mod),
-        });
 
         const src_mcv = try self.resolveInst(ty_op.operand);
         const src_reg = if (src_mcv.isRegister())
@@ -11549,9 +11549,13 @@ fn airIntFromFloat(self: *Self, inst: Air.Inst.Index) !void {
     const result = result: {
         if (switch (src_bits) {
             16, 80, 128 => true,
-            32, 64 => dst_size > 8 and dst_size < 16,
+            32, 64 => dst_size > 8,
             else => unreachable,
         }) {
+            if (dst_bits > 128) return self.fail("TODO implement airIntFromFloat from {} to {}", .{
+                src_ty.fmt(mod), dst_ty.fmt(mod),
+            });
+
             var callee: ["__fixuns?f?i".len]u8 = undefined;
             break :result try self.genCall(.{ .lib = .{
                 .return_type = dst_ty.toIntern(),
@@ -11566,10 +11570,6 @@ fn airIntFromFloat(self: *Self, inst: Air.Inst.Index) !void {
                 }) catch unreachable,
             } }, &.{src_ty}, &.{.{ .air_ref = ty_op.operand }});
         }
-
-        if (dst_size > 8) return self.fail("TODO implement airIntFromFloat from {} to {}", .{
-            src_ty.fmt(mod), dst_ty.fmt(mod),
-        });
 
         const src_mcv = try self.resolveInst(ty_op.operand);
         const src_reg = if (src_mcv.isRegister())

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -7733,7 +7733,10 @@ fn genBinOp(
             mir_tag,
             dst_reg,
             lhs_reg,
-            src_mcv.mem(Memory.PtrSize.fromSize(abi_size)),
+            src_mcv.mem(switch (lhs_ty.zigTypeTag(mod)) {
+                else => Memory.PtrSize.fromSize(abi_size),
+                .Vector => Memory.PtrSize.fromBitSize(dst_reg.bitSize()),
+            }),
         ) else try self.asmRegisterRegisterRegister(
             mir_tag,
             dst_reg,
@@ -7748,7 +7751,10 @@ fn genBinOp(
         if (src_mcv.isMemory()) try self.asmRegisterMemory(
             mir_tag,
             dst_reg,
-            src_mcv.mem(Memory.PtrSize.fromSize(abi_size)),
+            src_mcv.mem(switch (lhs_ty.zigTypeTag(mod)) {
+                else => Memory.PtrSize.fromSize(abi_size),
+                .Vector => Memory.PtrSize.fromBitSize(dst_reg.bitSize()),
+            }),
         ) else try self.asmRegisterRegister(
             mir_tag,
             dst_reg,

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -7177,6 +7177,23 @@ fn genBinOp(
                     dst_reg,
                     tmp_reg,
                 );
+                switch (air_tag) {
+                    .div_trunc, .div_floor => try self.asmRegisterRegisterRegisterImmediate(
+                        .{ .v_ss, .round },
+                        dst_reg,
+                        dst_reg,
+                        dst_reg,
+                        Immediate.u(@as(u5, @bitCast(RoundMode{
+                            .mode = switch (air_tag) {
+                                .div_trunc => .zero,
+                                .div_floor => .down,
+                                else => unreachable,
+                            },
+                            .precision = .inexact,
+                        }))),
+                    ),
+                    else => {},
+                }
                 try self.asmRegisterRegisterImmediate(
                     .{ .v_, .cvtps2ph },
                     dst_reg,

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -11332,11 +11332,15 @@ fn airBitCast(self: *Self, inst: Air.Inst.Index) !void {
             break :dst dst_mcv;
         };
 
+        if (dst_ty.isRuntimeFloat()) break :result dst_mcv;
+
         const dst_signedness =
             if (dst_ty.isAbiInt(mod)) dst_ty.intInfo(mod).signedness else .unsigned;
-        const src_signedness =
-            if (src_ty.isAbiInt(mod)) src_ty.intInfo(mod).signedness else .unsigned;
-        if (dst_signedness == src_signedness) break :result dst_mcv;
+        if (!src_ty.isRuntimeFloat() or src_ty.floatBits(self.target.*) != 80) {
+            const src_signedness =
+                if (src_ty.isAbiInt(mod)) src_ty.intInfo(mod).signedness else .unsigned;
+            if (dst_signedness == src_signedness) break :result dst_mcv;
+        }
 
         const abi_size: u16 = @intCast(dst_ty.abiSize(mod));
         const bit_size: u16 = @intCast(dst_ty.bitSize(mod));

--- a/src/arch/x86_64/Encoding.zig
+++ b/src/arch/x86_64/Encoding.zig
@@ -260,7 +260,7 @@ pub const Mnemonic = enum {
     ud2,
     xadd, xchg, xor,
     // X87
-    ffree, fisttp, fld, fst, fstp,
+    fabs, fchs, ffree, fisttp, fld, fst, fstp,
     // MMX
     movd, movq,
     packssdw, packsswb, packuswb,

--- a/src/arch/x86_64/Encoding.zig
+++ b/src/arch/x86_64/Encoding.zig
@@ -316,6 +316,8 @@ pub const Mnemonic = enum {
     xorpd,
     // SSE3
     movddup, movshdup, movsldup,
+    // SSSE3
+    pabsb, pabsd, pabsw,
     // SSE4.1
     blendpd, blendps, blendvpd, blendvps,
     extractps,
@@ -353,6 +355,7 @@ pub const Mnemonic = enum {
     vmovupd, vmovups,
     vmulpd, vmulps, vmulsd, vmulss,
     vorpd, vorps,
+    vpabsb, vpabsd, vpabsw,
     vpackssdw, vpacksswb, vpackusdw, vpackuswb,
     vpaddb, vpaddd, vpaddq, vpaddsb, vpaddsw, vpaddusb, vpaddusw, vpaddw,
     vpand, vpandn,
@@ -750,6 +753,7 @@ pub const Feature = enum {
     sse2,
     sse3,
     sse4_1,
+    ssse3,
     x87,
 };
 

--- a/src/arch/x86_64/Encoding.zig
+++ b/src/arch/x86_64/Encoding.zig
@@ -260,7 +260,7 @@ pub const Mnemonic = enum {
     ud2,
     xadd, xchg, xor,
     // X87
-    fisttp, fld,
+    ffree, fisttp, fld, fst, fstp,
     // MMX
     movd, movq,
     packssdw, packsswb, packuswb,

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -442,6 +442,10 @@ pub const Inst = struct {
         /// Bitwise logical xor of packed double-precision floating-point values
         xor,
 
+        /// Absolute value
+        abs,
+        /// Change sign
+        chs,
         /// Free floating-point register
         free,
         /// Store integer with truncation

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -342,14 +342,10 @@ pub const Inst = struct {
         div,
         ///
         int3,
-        /// Store integer with truncation
-        istt,
         /// Conditional jump
         j,
         /// Jump
         jmp,
-        /// Load floating-point value
-        ld,
         /// Load effective address
         lea,
         /// Load string
@@ -445,6 +441,15 @@ pub const Inst = struct {
         /// Bitwise logical xor of packed single-precision floating-point values
         /// Bitwise logical xor of packed double-precision floating-point values
         xor,
+
+        /// Free floating-point register
+        free,
+        /// Store integer with truncation
+        istt,
+        /// Load floating-point value
+        ld,
+        /// Store floating-point value
+        st,
 
         /// Pack with signed saturation
         ackssw,

--- a/src/arch/x86_64/encodings.zig
+++ b/src/arch/x86_64/encodings.zig
@@ -829,6 +829,10 @@ pub const table = [_]Entry{
     .{ .xor, .rm, &.{ .r64,  .rm64   }, &.{ 0x33 }, 0, .long,  .none },
 
     // X87
+    .{ .fabs, .np, &.{}, &.{ 0xd9, 0xe1 }, 0, .none, .x87 },
+
+    .{ .fchs, .np, &.{}, &.{ 0xd9, 0xe0 }, 0, .none, .x87 },
+
     .{ .ffree, .o, &.{ .st }, &.{ 0xdd, 0xc0 }, 0, .none, .x87 },
 
     .{ .fisttp, .m, &.{ .m16 }, &.{ 0xdf }, 1, .none, .x87 },

--- a/src/arch/x86_64/encodings.zig
+++ b/src/arch/x86_64/encodings.zig
@@ -829,13 +829,24 @@ pub const table = [_]Entry{
     .{ .xor, .rm, &.{ .r64,  .rm64   }, &.{ 0x33 }, 0, .long,  .none },
 
     // X87
+    .{ .ffree, .o, &.{ .st }, &.{ 0xdd, 0xc0 }, 0, .none, .x87 },
+
     .{ .fisttp, .m, &.{ .m16 }, &.{ 0xdf }, 1, .none, .x87 },
     .{ .fisttp, .m, &.{ .m32 }, &.{ 0xdb }, 1, .none, .x87 },
     .{ .fisttp, .m, &.{ .m64 }, &.{ 0xdd }, 1, .none, .x87 },
 
-    .{ .fld, .m, &.{ .m32 }, &.{ 0xd9 }, 0, .none, .x87 },
-    .{ .fld, .m, &.{ .m64 }, &.{ 0xdd }, 0, .none, .x87 },
-    .{ .fld, .m, &.{ .m80 }, &.{ 0xdb }, 5, .none, .x87 },
+    .{ .fld, .m, &.{ .m32 }, &.{ 0xd9       }, 0, .none, .x87 },
+    .{ .fld, .m, &.{ .m64 }, &.{ 0xdd       }, 0, .none, .x87 },
+    .{ .fld, .m, &.{ .m80 }, &.{ 0xdb       }, 5, .none, .x87 },
+    .{ .fld, .o, &.{ .st  }, &.{ 0xd9, 0xc0 }, 0, .none, .x87 },
+
+    .{ .fst,  .m, &.{ .m32 }, &.{ 0xd9       }, 2, .none, .x87 },
+    .{ .fst,  .m, &.{ .m64 }, &.{ 0xdd       }, 2, .none, .x87 },
+    .{ .fst,  .o, &.{ .st  }, &.{ 0xdd, 0xd0 }, 0, .none, .x87 },
+    .{ .fstp, .m, &.{ .m32 }, &.{ 0xd9       }, 3, .none, .x87 },
+    .{ .fstp, .m, &.{ .m64 }, &.{ 0xdd       }, 3, .none, .x87 },
+    .{ .fstp, .m, &.{ .m80 }, &.{ 0xdb       }, 7, .none, .x87 },
+    .{ .fstp, .o, &.{ .st  }, &.{ 0xdd, 0xd8 }, 0, .none, .x87 },
 
     // SSE
     .{ .addps, .rm, &.{ .xmm, .xmm_m128 }, &.{ 0x0f, 0x58 }, 0, .none, .sse },

--- a/src/arch/x86_64/encodings.zig
+++ b/src/arch/x86_64/encodings.zig
@@ -1108,6 +1108,14 @@ pub const table = [_]Entry{
 
     .{ .movsldup, .rm, &.{ .xmm, .xmm_m128 }, &.{ 0xf3, 0x0f, 0x12 }, 0, .none, .sse3 },
 
+    // SSSE3
+    .{ .pabsb, .rm, &.{  .mm,  .mm_m64  }, &.{       0x0f, 0x38, 0x1c }, 0, .none, .ssse3 },
+    .{ .pabsb, .rm, &.{ .xmm, .xmm_m128 }, &.{ 0x66, 0x0f, 0x38, 0x1c }, 0, .none, .ssse3 },
+    .{ .pabsd, .rm, &.{  .mm,  .mm_m64  }, &.{       0x0f, 0x38, 0x1e }, 0, .none, .ssse3 },
+    .{ .pabsd, .rm, &.{ .xmm, .xmm_m128 }, &.{ 0x66, 0x0f, 0x38, 0x1e }, 0, .none, .ssse3 },
+    .{ .pabsw, .rm, &.{  .mm,  .mm_m64  }, &.{       0x0f, 0x38, 0x1d }, 0, .none, .ssse3 },
+    .{ .pabsw, .rm, &.{ .xmm, .xmm_m128 }, &.{ 0x66, 0x0f, 0x38, 0x1d }, 0, .none, .ssse3 },
+
     // SSE4.1
     .{ .blendpd, .rmi, &.{ .xmm, .xmm_m128, .imm8 }, &.{ 0x66, 0x0f, 0x3a, 0x0d }, 0, .none, .sse4_1 },
 
@@ -1368,6 +1376,10 @@ pub const table = [_]Entry{
     .{ .vorps, .rvm, &.{ .xmm, .xmm, .xmm_m128 }, &.{ 0x0f, 0x56 }, 0, .vex_128_wig, .avx },
     .{ .vorps, .rvm, &.{ .ymm, .ymm, .ymm_m256 }, &.{ 0x0f, 0x56 }, 0, .vex_256_wig, .avx },
 
+    .{ .vpabsb, .rm, &.{ .xmm, .xmm_m128 }, &.{ 0x66, 0x0f, 0x38, 0x1c }, 0, .vex_128_wig, .avx },
+    .{ .vpabsd, .rm, &.{ .xmm, .xmm_m128 }, &.{ 0x66, 0x0f, 0x38, 0x1e }, 0, .vex_128_wig, .avx },
+    .{ .vpabsw, .rm, &.{ .xmm, .xmm_m128 }, &.{ 0x66, 0x0f, 0x38, 0x1d }, 0, .vex_128_wig, .avx },
+
     .{ .vpacksswb, .rvm, &.{ .xmm, .xmm, .xmm_m128 }, &.{ 0x66, 0x0f, 0x63 }, 0, .vex_128_wig, .avx },
     .{ .vpackssdw, .rvm, &.{ .xmm, .xmm, .xmm_m128 }, &.{ 0x66, 0x0f, 0x6b }, 0, .vex_128_wig, .avx },
 
@@ -1536,6 +1548,10 @@ pub const table = [_]Entry{
     .{ .vbroadcastss, .rm, &.{ .xmm, .xmm }, &.{ 0x66, 0x0f, 0x38, 0x18 }, 0, .vex_128_w0, .avx2 },
     .{ .vbroadcastss, .rm, &.{ .ymm, .xmm }, &.{ 0x66, 0x0f, 0x38, 0x18 }, 0, .vex_256_w0, .avx2 },
     .{ .vbroadcastsd, .rm, &.{ .ymm, .xmm }, &.{ 0x66, 0x0f, 0x38, 0x19 }, 0, .vex_256_w0, .avx2 },
+
+    .{ .vpabsb, .rm, &.{ .ymm, .ymm_m256 }, &.{ 0x66, 0x0f, 0x38, 0x1c }, 0, .vex_256_wig, .avx2 },
+    .{ .vpabsd, .rm, &.{ .ymm, .ymm_m256 }, &.{ 0x66, 0x0f, 0x38, 0x1e }, 0, .vex_256_wig, .avx2 },
+    .{ .vpabsw, .rm, &.{ .ymm, .ymm_m256 }, &.{ 0x66, 0x0f, 0x38, 0x1d }, 0, .vex_256_wig, .avx2 },
 
     .{ .vpacksswb, .rvm, &.{ .ymm, .ymm, .ymm_m256 }, &.{ 0x66, 0x0f, 0x63 }, 0, .vex_256_wig, .avx2 },
     .{ .vpackssdw, .rvm, &.{ .ymm, .ymm, .ymm_m256 }, &.{ 0x66, 0x0f, 0x6b }, 0, .vex_256_wig, .avx2 },

--- a/src/register_manager.zig
+++ b/src/register_manager.zig
@@ -91,11 +91,13 @@ pub fn RegisterManager(
             return null;
         }
 
-        pub fn indexOfRegIntoTracked(reg: Register) ?RegisterBitSet.ShiftInt {
+        pub fn indexOfRegIntoTracked(
+            reg: Register,
+        ) ?std.math.IntFittingRange(0, tracked_registers.len) {
             return indexOfReg(tracked_registers, reg);
         }
 
-        pub fn regAtTrackedIndex(index: RegisterBitSet.ShiftInt) Register {
+        pub fn regAtTrackedIndex(index: std.math.IntFittingRange(0, tracked_registers.len)) Register {
             return tracked_registers[index];
         }
 

--- a/test/behavior/abs.zig
+++ b/test/behavior/abs.zig
@@ -280,7 +280,7 @@ test "@abs float vectors" {
     try testAbsFloatVectors(f16, 16);
     try comptime testAbsFloatVectors(f16, 17);
 
-    try testAbsFloatVectors(f32, 17);
+    try testAbsFloatVectors(f32, 1);
     try comptime testAbsFloatVectors(f32, 1);
     try testAbsFloatVectors(f32, 1);
     try comptime testAbsFloatVectors(f32, 2);

--- a/test/behavior/abs.zig
+++ b/test/behavior/abs.zig
@@ -95,7 +95,7 @@ test "@abs floats" {
     try comptime testAbsFloats(f64);
     try testAbsFloats(f64);
     try comptime testAbsFloats(f80);
-    if (builtin.zig_backend != .stage2_x86_64 and builtin.zig_backend != .stage2_wasm) try testAbsFloats(f80);
+    if (builtin.zig_backend != .stage2_wasm) try testAbsFloats(f80);
     try comptime testAbsFloats(f128);
     if (builtin.zig_backend != .stage2_wasm) try testAbsFloats(f128);
 }

--- a/test/behavior/asm.zig
+++ b/test/behavior/asm.zig
@@ -42,7 +42,6 @@ test "module level assembly" {
 
 test "output constraint modifiers" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -66,7 +65,6 @@ test "output constraint modifiers" {
 
 test "alternative constraints" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -163,8 +161,8 @@ export fn derp() i32 {
 }
 
 test "rw constraint (x86_64)" {
-    if (builtin.target.cpu.arch != .x86_64 or builtin.zig_backend != .stage2_llvm)
-        return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.target.cpu.arch != .x86_64) return error.SkipZigTest;
 
     var res: i32 = 5;
     asm ("addl %[b], %[a]"

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -118,11 +118,11 @@ test "@floatFromInt" {
 
 test "@floatFromInt(f80)" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c and comptime builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest(comptime Int: type) !void {
@@ -1476,9 +1476,9 @@ test "pointer to empty struct literal to mutable slice" {
 test "coerce between pointers of compatible differently-named floats" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     if (builtin.os.tag == .windows) {
         // https://github.com/ziglang/zig/issues/12396

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -270,7 +270,7 @@ test "@sqrt f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     if (builtin.os.tag == .freebsd) {
         // TODO https://github.com/ziglang/zig/issues/10875
@@ -378,7 +378,7 @@ test "@sin f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testSin(f80);
     comptime try testSin(f80);
@@ -447,7 +447,7 @@ test "@cos f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testCos(f80);
     try comptime testCos(f80);
@@ -516,7 +516,7 @@ test "@tan f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testTan(f80);
     try comptime testTan(f80);
@@ -585,7 +585,7 @@ test "@exp f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testExp(f80);
     try comptime testExp(f80);
@@ -654,7 +654,7 @@ test "@exp2 f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testExp2(f80);
     try comptime testExp2(f80);
@@ -723,7 +723,7 @@ test "@log f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testLog(f80);
     try comptime testLog(f80);
@@ -790,7 +790,7 @@ test "@log2 f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testLog2(f80);
     try comptime testLog2(f80);
@@ -863,7 +863,7 @@ test "@log10 f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testLog10(f80);
     try comptime testLog10(f80);
@@ -929,7 +929,7 @@ test "@abs f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c and builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testFabs(f80);
     try comptime testFabs(f80);

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -1294,7 +1294,7 @@ test "neg f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testNeg(f80);
     try comptime testNeg(f80);

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -28,7 +28,7 @@ test "add f32/f64" {
 }
 
 test "add f80/f128/c_longdouble" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testAdd(f80);
     try comptime testAdd(f80);
@@ -59,7 +59,7 @@ test "sub f32/f64" {
 }
 
 test "sub f80/f128/c_longdouble" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testSub(f80);
     try comptime testSub(f80);
@@ -90,7 +90,7 @@ test "mul f32/f64" {
 }
 
 test "mul f80/f128/c_longdouble" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testMul(f80);
     try comptime testMul(f80);

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -1029,7 +1029,7 @@ test "@floor f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c and builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     if (builtin.zig_backend == .stage2_llvm and builtin.os.tag == .windows) {
         // https://github.com/ziglang/zig/issues/12602
@@ -1111,7 +1111,7 @@ test "@ceil f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c and builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     if (builtin.zig_backend == .stage2_llvm and builtin.os.tag == .windows) {
         // https://github.com/ziglang/zig/issues/12602
@@ -1203,7 +1203,7 @@ test "@trunc f80/f128/c_longdouble" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c and builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     if (builtin.zig_backend == .stage2_llvm and builtin.os.tag == .windows) {
         // https://github.com/ziglang/zig/issues/12602

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -1468,7 +1468,6 @@ test "@round f32/f64" {
 test "@round f80" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c and comptime builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -495,11 +495,11 @@ fn testDivision() !void {
 }
 
 test "division half-precision floats" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try testDivisionFP16();
     try comptime testDivisionFP16();

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -1332,6 +1332,7 @@ test "remainder division" {
     try comptime remdiv(f80);
     try comptime remdiv(f128);
     try remdiv(f16);
+    try remdiv(f32);
     try remdiv(f64);
     try remdiv(f80);
     try remdiv(f128);
@@ -1356,7 +1357,7 @@ test "float remainder division using @rem" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try comptime frem(f16);
     try comptime frem(f32);

--- a/test/behavior/maximum_minimum.zig
+++ b/test/behavior/maximum_minimum.zig
@@ -276,7 +276,8 @@ test "@min/@max notices bounds from vector types when element of comptime-known 
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and
+        !comptime std.Target.x86.featureSetHas(builtin.cpu.features, .sse4_1)) return error.SkipZigTest;
 
     var x: @Vector(2, u32) = .{ 1_000_000, 12345 };
     const y: @Vector(2, u16) = .{ 10, undefined };

--- a/test/behavior/muladd.zig
+++ b/test/behavior/muladd.zig
@@ -32,11 +32,11 @@ fn testMulAdd() !void {
 }
 
 test "@mulAdd f16" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try comptime testMulAdd16();
     try testMulAdd16();
@@ -50,12 +50,12 @@ fn testMulAdd16() !void {
 }
 
 test "@mulAdd f80" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c and comptime builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try comptime testMulAdd80();
     try testMulAdd80();
@@ -69,12 +69,12 @@ fn testMulAdd80() !void {
 }
 
 test "@mulAdd f128" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c and comptime builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     try comptime testMulAdd128();
     try testMulAdd128();

--- a/test/behavior/var_args.zig
+++ b/test/behavior/var_args.zig
@@ -108,7 +108,6 @@ test "simple variadic function" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.os.tag != .macos and comptime builtin.cpu.arch.isAARCH64()) {
         // https://github.com/ziglang/zig/issues/14096
@@ -158,7 +157,6 @@ test "variadic functions" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.os.tag != .macos and comptime builtin.cpu.arch.isAARCH64()) {
         // https://github.com/ziglang/zig/issues/14096
@@ -202,7 +200,6 @@ test "copy VaList" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.os.tag != .macos and comptime builtin.cpu.arch.isAARCH64()) {
         // https://github.com/ziglang/zig/issues/14096
@@ -235,7 +232,6 @@ test "unused VaList arg" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.os.tag != .macos and comptime builtin.cpu.arch.isAARCH64()) {
         // https://github.com/ziglang/zig/issues/14096

--- a/test/behavior/widening.zig
+++ b/test/behavior/widening.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const expect = std.testing.expect;
 const mem = std.mem;
 const builtin = @import("builtin");
-const has_f80_rt = @import("builtin").cpu.arch == .x86_64;
 
 test "integer widening" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
@@ -53,10 +52,8 @@ test "float widening" {
     try expect(a == b);
     try expect(b == c);
     try expect(c == d);
-    if (has_f80_rt) {
-        var e: f80 = c;
-        try expect(c == e);
-    }
+    var e: f80 = c;
+    try expect(c == e);
 }
 
 test "float widening f16 to f128" {

--- a/test/behavior/widening.zig
+++ b/test/behavior/widening.zig
@@ -40,11 +40,11 @@ test "implicit unsigned integer to signed integer" {
 }
 
 test "float widening" {
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     var a: f16 = 12.34;
     var b: f32 = a;


### PR DESCRIPTION
* movement of `f80` values
* negation of `f80`
* `@abs` of `f80`
* C var args ABI
* inline assembly features
     * instruction prefixes
     * mnemonic fixes
     * labels
     * memory operands
     * read-write constraint modifier
     * register and memory alternative constraint
* `@floor` of `f80`
* `@ceil` of `f80`
* `@trunc` of `f80`
* `@bitCast` of `f80`
* `@abs` of integer vectors
* binary operations of vectors
* `@divTrunc` of `f16`
* `@divFloor` of `f16`
* `@rem` of floats
* `@mulAdd` of floats