### PR TITLE
std: fix memory bug in getExternalExecutor

### DIFF
--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -679,7 +679,7 @@ fn runCommand(
             }
 
             const need_cross_glibc = exe.target.isGnuLibC() and exe.is_linking_libc;
-            switch (b.host.getExternalExecutor(exe.target_info, .{
+            switch (b.host.getExternalExecutor(&exe.target_info, .{
                 .qemu_fixes_dl = need_cross_glibc and b.glibc_runtimes_dir != null,
                 .link_libc = exe.is_linking_libc,
             })) {

--- a/lib/std/zig/system/NativeTargetInfo.zig
+++ b/lib/std/zig/system/NativeTargetInfo.zig
@@ -1002,7 +1002,7 @@ pub const GetExternalExecutorOptions = struct {
 /// of the other target.
 pub fn getExternalExecutor(
     host: NativeTargetInfo,
-    candidate: NativeTargetInfo,
+    candidate: *const NativeTargetInfo,
     options: GetExternalExecutorOptions,
 ) Executor {
     const os_match = host.target.os.tag == candidate.target.os.tag;

--- a/src/main.zig
+++ b/src/main.zig
@@ -3667,7 +3667,7 @@ fn buildOutputType(
             test_exec_args.items,
             self_exe_path.?,
             arg_mode,
-            target_info,
+            &target_info,
             &comp_destroyed,
             all_args,
             runtime_args_start,
@@ -3995,7 +3995,7 @@ fn runOrTest(
     test_exec_args: []const ?[]const u8,
     self_exe_path: []const u8,
     arg_mode: ArgMode,
-    target_info: std.zig.system.NativeTargetInfo,
+    target_info: *const std.zig.system.NativeTargetInfo,
     comp_destroyed: *bool,
     all_args: []const []const u8,
     runtime_args_start: ?usize,
@@ -6256,7 +6256,7 @@ fn parseIntSuffix(arg: []const u8, prefix_len: usize) u64 {
 fn warnAboutForeignBinaries(
     arena: Allocator,
     arg_mode: ArgMode,
-    target_info: std.zig.system.NativeTargetInfo,
+    target_info: *const std.zig.system.NativeTargetInfo,
     link_libc: bool,
 ) !void {
     const host_cross_target: std.zig.CrossTarget = .{};

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -590,7 +590,7 @@ pub fn lowerToBuildSteps(
                 const run = if (case.target.ofmt == .c) run_step: {
                     const target_info = std.zig.system.NativeTargetInfo.detect(case.target) catch |err|
                         std.debug.panic("unable to detect notive host: {s}\n", .{@errorName(err)});
-                    if (host.getExternalExecutor(target_info, .{ .link_libc = true }) != .native) {
+                    if (host.getExternalExecutor(&target_info, .{ .link_libc = true }) != .native) {
                         // We wouldn't be able to run the compiled C code.
                         break :no_exec;
                     }

--- a/tools/docgen.zig
+++ b/tools/docgen.zig
@@ -1571,7 +1571,7 @@ fn genHtml(
                             const target_info = try std.zig.system.NativeTargetInfo.detect(
                                 cross_target,
                             );
-                            switch (host.getExternalExecutor(target_info, .{
+                            switch (host.getExternalExecutor(&target_info, .{
                                 .link_libc = code.link_libc,
                             })) {
                                 .native => {},


### PR DESCRIPTION
Until now, we would pass `candidate: NativeTargetInfo` which creates a copy of the `NativeTargetInfo.DynamicLinker` buffer. We would then return pointer to this buffer in `bad_dl: []const u8` which would goes out-of-scope the moment we leave this function frame yielding garbage. To fix this, we just need to remember to pass by const-pointer
`candidate: *const NativeTargetInfo`.

This resulted in cute test runner error messages such as this one:

```
test.link.run test: error: the host system is unable to execute binaries from the target
  because the host dynamic linker is '/nix/store/b2hc0i92l22ir2kavnjn3z5z6mzabbvm-glibc-2.34-210/lib/ld-linux-x86-64.so.2',
  while the target dynamic linker is 'SX'.
  consider setting the dynamic linker or enabling skip_foreign_checks in the Run step
```

Note `SX` for target dynamic linker path.