### PR TITLE
Use indexOfScalarPos when indexOf is called where needle.len == 1

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1344,7 +1344,10 @@ pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?us
 /// Uses Boyer-Moore-Horspool algorithm on large inputs; `indexOfPosLinear` on small inputs.
 pub fn indexOfPos(comptime T: type, haystack: []const T, start_index: usize, needle: []const T) ?usize {
     if (needle.len > haystack.len) return null;
-    if (needle.len == 0) return start_index;
+    if (needle.len < 2) {
+        if (needle.len == 0) return start_index;
+        return indexOfScalarPos(T, haystack, start_index, needle[0]);
+    }
 
     if (!meta.trait.hasUniqueRepresentation(T) or haystack.len < 52 or needle.len <= 4)
         return indexOfPosLinear(T, haystack, start_index, needle);


### PR DESCRIPTION
`indexOfScalarPos` is much faster than `indexOfPosLinear`. The exact speed difference is dependent on the input, but even on a short `haystack` it can be 3-5x faster. There's already a check for `needle.len == 0`, so for the "normal" case where `needle.len > 1` this can be written without adding a condition.

There are a few places in the standard library where `indexOf` is being used where `needle.len == 1`...all the functions/names are hard to keep track of. I think it's good to have the most obvious `indexOf` handle all cases well.