### PR TITLE
removed functions set to deprecate with 0.11 release

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -147,9 +147,6 @@ pub const Mutable = struct {
         };
     }
 
-    // TODO: remove after release of 0.11
-    pub const eqZero = @compileError("use eqlZero");
-
     /// Returns true if `a == 0`.
     pub fn eqlZero(self: Mutable) bool {
         return self.toConst().eqlZero();
@@ -2485,11 +2482,6 @@ pub const Const = struct {
         return order(lhs, rhs.toConst());
     }
 
-    // TODO: remove after release of 0.11
-    pub const eqZero = @compileError("use eqlZero");
-    pub const eqAbs = @compileError("use eqlAbs");
-    pub const eq = @compileError("use eql");
-
     /// Returns true if `a == 0`.
     pub fn eqlZero(a: Const) bool {
         var d: Limb = 0;
@@ -2833,11 +2825,6 @@ pub const Managed = struct {
     pub fn order(a: Managed, b: Managed) math.Order {
         return a.toConst().order(b.toConst());
     }
-
-    // TODO: remove after release of 0.11
-    pub const eqZero = @compileError("use eqlZero");
-    pub const eqAbs = @compileError("use eqlAbs");
-    pub const eq = @compileError("use eql");
 
     /// Returns true if a == 0.
     pub fn eqlZero(a: Managed) bool {


### PR DESCRIPTION
Removed functions set to @compileError and had a comment "TODO: remove after release of 0.11" in lib/std/math/big/int.zig.
