### PR TITLE
Update `std.testing.expectEqual` and friends to use peer type resolution

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -853,8 +853,8 @@ test "machoSearchSymbols" {
         .{ .addr = 300, .strx = undefined, .size = undefined, .ofile = undefined },
     };
 
-    try testing.expectEqual(@as(?*const MachoSymbol, null), machoSearchSymbols(&symbols, 0));
-    try testing.expectEqual(@as(?*const MachoSymbol, null), machoSearchSymbols(&symbols, 99));
+    try testing.expectEqual(null, machoSearchSymbols(&symbols, 0));
+    try testing.expectEqual(null, machoSearchSymbols(&symbols, 99));
     try testing.expectEqual(&symbols[0], machoSearchSymbols(&symbols, 100).?);
     try testing.expectEqual(&symbols[0], machoSearchSymbols(&symbols, 150).?);
     try testing.expectEqual(&symbols[0], machoSearchSymbols(&symbols, 199).?);

--- a/lib/std/http.zig
+++ b/lib/std/http.zig
@@ -283,8 +283,8 @@ pub const Status = enum(u10) {
     }
 
     test {
-        try std.testing.expectEqual(@as(?Status.Class, Status.Class.success), Status.ok.class());
-        try std.testing.expectEqual(@as(?Status.Class, Status.Class.client_error), Status.not_found.class());
+        try std.testing.expectEqual(Status.Class.success, Status.ok.class());
+        try std.testing.expectEqual(Status.Class.client_error, Status.not_found.class());
     }
 };
 

--- a/lib/std/json/static_test.zig
+++ b/lib/std/json/static_test.zig
@@ -373,19 +373,19 @@ test "test all types" {
 test "parse" {
     try testing.expectEqual(false, try parseFromSliceLeaky(bool, testing.allocator, "false", .{}));
     try testing.expectEqual(true, try parseFromSliceLeaky(bool, testing.allocator, "true", .{}));
-    try testing.expectEqual(@as(u1, 1), try parseFromSliceLeaky(u1, testing.allocator, "1", .{}));
+    try testing.expectEqual(1, try parseFromSliceLeaky(u1, testing.allocator, "1", .{}));
     try testing.expectError(error.Overflow, parseFromSliceLeaky(u1, testing.allocator, "50", .{}));
-    try testing.expectEqual(@as(u64, 42), try parseFromSliceLeaky(u64, testing.allocator, "42", .{}));
-    try testing.expectEqual(@as(f64, 42), try parseFromSliceLeaky(f64, testing.allocator, "42.0", .{}));
-    try testing.expectEqual(@as(?bool, null), try parseFromSliceLeaky(?bool, testing.allocator, "null", .{}));
-    try testing.expectEqual(@as(?bool, true), try parseFromSliceLeaky(?bool, testing.allocator, "true", .{}));
+    try testing.expectEqual(42, try parseFromSliceLeaky(u64, testing.allocator, "42", .{}));
+    try testing.expectEqual(42, try parseFromSliceLeaky(f64, testing.allocator, "42.0", .{}));
+    try testing.expectEqual(null, try parseFromSliceLeaky(?bool, testing.allocator, "null", .{}));
+    try testing.expectEqual(true, try parseFromSliceLeaky(?bool, testing.allocator, "true", .{}));
 
-    try testing.expectEqual(@as([3]u8, "foo".*), try parseFromSliceLeaky([3]u8, testing.allocator, "\"foo\"", .{}));
-    try testing.expectEqual(@as([3]u8, "foo".*), try parseFromSliceLeaky([3]u8, testing.allocator, "[102, 111, 111]", .{}));
-    try testing.expectEqual(@as([0]u8, undefined), try parseFromSliceLeaky([0]u8, testing.allocator, "[]", .{}));
+    try testing.expectEqual("foo".*, try parseFromSliceLeaky([3]u8, testing.allocator, "\"foo\"", .{}));
+    try testing.expectEqual("foo".*, try parseFromSliceLeaky([3]u8, testing.allocator, "[102, 111, 111]", .{}));
+    try testing.expectEqual(undefined, try parseFromSliceLeaky([0]u8, testing.allocator, "[]", .{}));
 
-    try testing.expectEqual(@as(u64, 12345678901234567890), try parseFromSliceLeaky(u64, testing.allocator, "\"12345678901234567890\"", .{}));
-    try testing.expectEqual(@as(f64, 123.456), try parseFromSliceLeaky(f64, testing.allocator, "\"123.456\"", .{}));
+    try testing.expectEqual(12345678901234567890, try parseFromSliceLeaky(u64, testing.allocator, "\"12345678901234567890\"", .{}));
+    try testing.expectEqual(123.456, try parseFromSliceLeaky(f64, testing.allocator, "\"123.456\"", .{}));
 }
 
 test "parse into enum" {
@@ -394,9 +394,9 @@ test "parse into enum" {
         Bar,
         @"with\\escape",
     };
-    try testing.expectEqual(@as(T, .Foo), try parseFromSliceLeaky(T, testing.allocator, "\"Foo\"", .{}));
-    try testing.expectEqual(@as(T, .Foo), try parseFromSliceLeaky(T, testing.allocator, "42", .{}));
-    try testing.expectEqual(@as(T, .@"with\\escape"), try parseFromSliceLeaky(T, testing.allocator, "\"with\\\\escape\"", .{}));
+    try testing.expectEqual(.Foo, try parseFromSliceLeaky(T, testing.allocator, "\"Foo\"", .{}));
+    try testing.expectEqual(.Foo, try parseFromSliceLeaky(T, testing.allocator, "42", .{}));
+    try testing.expectEqual(.@"with\\escape", try parseFromSliceLeaky(T, testing.allocator, "\"with\\\\escape\"", .{}));
     try testing.expectError(error.InvalidEnumTag, parseFromSliceLeaky(T, testing.allocator, "5", .{}));
     try testing.expectError(error.InvalidEnumTag, parseFromSliceLeaky(T, testing.allocator, "\"Qux\"", .{}));
 }

--- a/lib/std/math/float.zig
+++ b/lib/std/math/float.zig
@@ -138,11 +138,11 @@ test "math.inf" {
     const inf_u64: u64 = 0x7FF0000000000000;
     const inf_u80: u80 = 0x7FFF8000000000000000;
     const inf_u128: u128 = 0x7FFF0000000000000000000000000000;
-    try expectEqual(inf_u16, @bitCast(inf(f16)));
-    try expectEqual(inf_u32, @bitCast(inf(f32)));
-    try expectEqual(inf_u64, @bitCast(inf(f64)));
-    try expectEqual(inf_u80, @bitCast(inf(f80)));
-    try expectEqual(inf_u128, @bitCast(inf(f128)));
+    try expectEqual(inf_u16, @as(u16, @bitCast(inf(f16))));
+    try expectEqual(inf_u32, @as(u32, @bitCast(inf(f32))));
+    try expectEqual(inf_u64, @as(u64, @bitCast(inf(f64))));
+    try expectEqual(inf_u80, @as(u80, @bitCast(inf(f80))));
+    try expectEqual(inf_u128, @as(u128, @bitCast(inf(f128))));
 }
 
 test "math.nan" {
@@ -151,11 +151,11 @@ test "math.nan" {
     const qnan_u64: u64 = 0x7FF8000000000000;
     const qnan_u80: u80 = 0x7FFFC000000000000000;
     const qnan_u128: u128 = 0x7FFF8000000000000000000000000000;
-    try expectEqual(qnan_u16, @bitCast(nan(f16)));
-    try expectEqual(qnan_u32, @bitCast(nan(f32)));
-    try expectEqual(qnan_u64, @bitCast(nan(f64)));
-    try expectEqual(qnan_u80, @bitCast(nan(f80)));
-    try expectEqual(qnan_u128, @bitCast(nan(f128)));
+    try expectEqual(qnan_u16, @as(u16, @bitCast(nan(f16))));
+    try expectEqual(qnan_u32, @as(u32, @bitCast(nan(f32))));
+    try expectEqual(qnan_u64, @as(u64, @bitCast(nan(f64))));
+    try expectEqual(qnan_u80, @as(u80, @bitCast(nan(f80))));
+    try expectEqual(qnan_u128, @as(u128, @bitCast(nan(f128))));
 }
 
 test "math.snan" {
@@ -167,9 +167,9 @@ test "math.snan" {
     const snan_u64: u64 = 0x7FF4000000000000;
     const snan_u80: u80 = 0x7FFFA000000000000000;
     const snan_u128: u128 = 0x7FFF4000000000000000000000000000;
-    try expectEqual(snan_u16, @bitCast(snan(f16)));
-    try expectEqual(snan_u32, @bitCast(snan(f32)));
-    try expectEqual(snan_u64, @bitCast(snan(f64)));
-    try expectEqual(snan_u80, @bitCast(snan(f80)));
-    try expectEqual(snan_u128, @bitCast(snan(f128)));
+    try expectEqual(snan_u16, @as(u16, @bitCast(snan(f16))));
+    try expectEqual(snan_u32, @as(u32, @bitCast(snan(f32))));
+    try expectEqual(snan_u64, @as(u64, @bitCast(snan(f64))));
+    try expectEqual(snan_u80, @as(u80, @bitCast(snan(f80))));
+    try expectEqual(snan_u128, @as(u128, @bitCast(snan(f128))));
 }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3284,9 +3284,9 @@ pub fn indexOfMinMax(comptime T: type, slice: []const T) IndexOfMinMaxResult {
 pub const IndexOfMinMaxResult = struct { index_min: usize, index_max: usize };
 
 test "indexOfMinMax" {
-    try testing.expectEqual(indexOfMinMax(u8, "abcdefg"), IndexOfMinMaxResult{ .index_min = 0, .index_max = 6 });
-    try testing.expectEqual(indexOfMinMax(u8, "gabcdef"), IndexOfMinMaxResult{ .index_min = 1, .index_max = 0 });
-    try testing.expectEqual(indexOfMinMax(u8, "a"), IndexOfMinMaxResult{ .index_min = 0, .index_max = 0 });
+    try testing.expectEqual(IndexOfMinMaxResult{ .index_min = 0, .index_max = 6 }, indexOfMinMax(u8, "abcdefg"));
+    try testing.expectEqual(IndexOfMinMaxResult{ .index_min = 1, .index_max = 0 }, indexOfMinMax(u8, "gabcdef"));
+    try testing.expectEqual(IndexOfMinMaxResult{ .index_min = 0, .index_max = 0 }, indexOfMinMax(u8, "a"));
 }
 
 pub fn swap(comptime T: type, a: *T, b: *T) void {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3262,7 +3262,7 @@ test "indexOfMax" {
 /// Finds the indices of the smallest and largest number in a slice. O(n).
 /// Returns an anonymous struct with the fields `index_min` and `index_max`.
 /// `slice` must not be empty.
-pub fn indexOfMinMax(comptime T: type, slice: []const T) struct { index_min: usize, index_max: usize } {
+pub fn indexOfMinMax(comptime T: type, slice: []const T) IndexOfMinMaxResult {
     assert(slice.len > 0);
     var minVal = slice[0];
     var maxVal = slice[0];
@@ -3281,10 +3281,12 @@ pub fn indexOfMinMax(comptime T: type, slice: []const T) struct { index_min: usi
     return .{ .index_min = minIdx, .index_max = maxIdx };
 }
 
+pub const IndexOfMinMaxResult = struct { index_min: usize, index_max: usize };
+
 test "indexOfMinMax" {
-    try testing.expectEqual(indexOfMinMax(u8, "abcdefg"), .{ .index_min = 0, .index_max = 6 });
-    try testing.expectEqual(indexOfMinMax(u8, "gabcdef"), .{ .index_min = 1, .index_max = 0 });
-    try testing.expectEqual(indexOfMinMax(u8, "a"), .{ .index_min = 0, .index_max = 0 });
+    try testing.expectEqual(indexOfMinMax(u8, "abcdefg"), IndexOfMinMaxResult{ .index_min = 0, .index_max = 6 });
+    try testing.expectEqual(indexOfMinMax(u8, "gabcdef"), IndexOfMinMaxResult{ .index_min = 1, .index_max = 0 });
+    try testing.expectEqual(indexOfMinMax(u8, "a"), IndexOfMinMaxResult{ .index_min = 0, .index_max = 0 });
 }
 
 pub fn swap(comptime T: type, a: *T, b: *T) void {

--- a/lib/std/multi_array_list.zig
+++ b/lib/std/multi_array_list.zig
@@ -842,24 +842,24 @@ test "union" {
         &.{ .a, .b, .b, .a, .a, .a, .a, .a, .a },
         list.items(.tags),
     );
-    try testing.expectEqual(list.get(0), .{ .a = 1 });
-    try testing.expectEqual(list.get(1), .{ .b = "zigzag" });
-    try testing.expectEqual(list.get(2), .{ .b = "foobar" });
-    try testing.expectEqual(list.get(3), .{ .a = 4 });
-    try testing.expectEqual(list.get(4), .{ .a = 5 });
-    try testing.expectEqual(list.get(5), .{ .a = 6 });
-    try testing.expectEqual(list.get(6), .{ .a = 7 });
-    try testing.expectEqual(list.get(7), .{ .a = 8 });
-    try testing.expectEqual(list.get(8), .{ .a = 9 });
+    try testing.expectEqual(list.get(0), Foo{ .a = 1 });
+    try testing.expectEqual(list.get(1), Foo{ .b = "zigzag" });
+    try testing.expectEqual(list.get(2), Foo{ .b = "foobar" });
+    try testing.expectEqual(list.get(3), Foo{ .a = 4 });
+    try testing.expectEqual(list.get(4), Foo{ .a = 5 });
+    try testing.expectEqual(list.get(5), Foo{ .a = 6 });
+    try testing.expectEqual(list.get(6), Foo{ .a = 7 });
+    try testing.expectEqual(list.get(7), Foo{ .a = 8 });
+    try testing.expectEqual(list.get(8), Foo{ .a = 9 });
 
     list.shrinkAndFree(ally, 3);
 
     try testing.expectEqual(@as(usize, 3), list.items(.tags).len);
     try testing.expectEqualSlices(meta.Tag(Foo), list.items(.tags), &.{ .a, .b, .b });
 
-    try testing.expectEqual(list.get(0), .{ .a = 1 });
-    try testing.expectEqual(list.get(1), .{ .b = "zigzag" });
-    try testing.expectEqual(list.get(2), .{ .b = "foobar" });
+    try testing.expectEqual(list.get(0), Foo{ .a = 1 });
+    try testing.expectEqual(list.get(1), Foo{ .b = "zigzag" });
+    try testing.expectEqual(list.get(2), Foo{ .b = "foobar" });
 }
 
 test "sorting a span" {

--- a/lib/std/multi_array_list.zig
+++ b/lib/std/multi_array_list.zig
@@ -842,24 +842,24 @@ test "union" {
         &.{ .a, .b, .b, .a, .a, .a, .a, .a, .a },
         list.items(.tags),
     );
-    try testing.expectEqual(list.get(0), Foo{ .a = 1 });
-    try testing.expectEqual(list.get(1), Foo{ .b = "zigzag" });
-    try testing.expectEqual(list.get(2), Foo{ .b = "foobar" });
-    try testing.expectEqual(list.get(3), Foo{ .a = 4 });
-    try testing.expectEqual(list.get(4), Foo{ .a = 5 });
-    try testing.expectEqual(list.get(5), Foo{ .a = 6 });
-    try testing.expectEqual(list.get(6), Foo{ .a = 7 });
-    try testing.expectEqual(list.get(7), Foo{ .a = 8 });
-    try testing.expectEqual(list.get(8), Foo{ .a = 9 });
+    try testing.expectEqual(Foo{ .a = 1 }, list.get(0));
+    try testing.expectEqual(Foo{ .b = "zigzag" }, list.get(1));
+    try testing.expectEqual(Foo{ .b = "foobar" }, list.get(2));
+    try testing.expectEqual(Foo{ .a = 4 }, list.get(3));
+    try testing.expectEqual(Foo{ .a = 5 }, list.get(4));
+    try testing.expectEqual(Foo{ .a = 6 }, list.get(5));
+    try testing.expectEqual(Foo{ .a = 7 }, list.get(6));
+    try testing.expectEqual(Foo{ .a = 8 }, list.get(7));
+    try testing.expectEqual(Foo{ .a = 9 }, list.get(8));
 
     list.shrinkAndFree(ally, 3);
 
     try testing.expectEqual(@as(usize, 3), list.items(.tags).len);
     try testing.expectEqualSlices(meta.Tag(Foo), list.items(.tags), &.{ .a, .b, .b });
 
-    try testing.expectEqual(list.get(0), Foo{ .a = 1 });
-    try testing.expectEqual(list.get(1), Foo{ .b = "zigzag" });
-    try testing.expectEqual(list.get(2), Foo{ .b = "foobar" });
+    try testing.expectEqual(Foo{ .a = 1 }, list.get(0));
+    try testing.expectEqual(Foo{ .b = "zigzag" }, list.get(1));
+    try testing.expectEqual(Foo{ .b = "foobar" }, list.get(2));
 }
 
 test "sorting a span" {

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1156,7 +1156,7 @@ test "cast function with an opaque parameter" {
         .func = @ptrCast(&Foo.funcImpl),
     };
     c.func(c.ctx);
-    try std.testing.expectEqual(foo, Foo{ .x = 101, .y = 201 });
+    try std.testing.expectEqual(Foo{ .x = 101, .y = 201 }, foo);
 }
 
 test "implicit ptr to *anyopaque" {

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1156,7 +1156,7 @@ test "cast function with an opaque parameter" {
         .func = @ptrCast(&Foo.funcImpl),
     };
     c.func(c.ctx);
-    try std.testing.expectEqual(foo, .{ .x = 101, .y = 201 });
+    try std.testing.expectEqual(foo, Foo{ .x = 101, .y = 201 });
 }
 
 test "implicit ptr to *anyopaque" {

--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -1033,7 +1033,7 @@ test "modify nested packed struct aligned field" {
 
     var opts = Options{};
     opts.pretty_print.indent += 1;
-    try std.testing.expectEqual(@as(u17, 0b00000000100100000), @bitCast(opts));
+    try std.testing.expectEqual(@as(u17, 0b00000000100100000), @as(u17, @bitCast(opts)));
     try std.testing.expect(!opts.foo);
     try std.testing.expect(!opts.bar);
     try std.testing.expect(!opts.pretty_print.enabled);

--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -173,17 +173,17 @@ test "correct sizeOf and offsets in packed structs" {
         try expectEqual(true, s1.bool_d);
         try expectEqual(true, s1.bool_e);
         try expectEqual(true, s1.bool_f);
-        try expectEqual(@as(u1, 1), s1.u1_a);
+        try expectEqual(1, s1.u1_a);
         try expectEqual(false, s1.bool_g);
-        try expectEqual(@as(u1, 0), s1.u1_b);
-        try expectEqual(@as(u3, 3), s1.u3_a);
-        try expectEqual(@as(u10, 0b1101000101), s1.u10_a);
-        try expectEqual(@as(u10, 0b0001001000), s1.u10_b);
+        try expectEqual(0, s1.u1_b);
+        try expectEqual(3, s1.u3_a);
+        try expectEqual(0b1101000101, s1.u10_a);
+        try expectEqual(0b0001001000, s1.u10_b);
 
         const s2 = @as(packed struct { x: u1, y: u7, z: u24 }, @bitCast(@as(u32, 0xd5c71ff4)));
-        try expectEqual(@as(u1, 0), s2.x);
-        try expectEqual(@as(u7, 0b1111010), s2.y);
-        try expectEqual(@as(u24, 0xd5c71f), s2.z);
+        try expectEqual(0, s2.x);
+        try expectEqual(0b1111010, s2.y);
+        try expectEqual(0xd5c71f, s2.z);
     }
 }
 
@@ -208,12 +208,12 @@ test "nested packed structs" {
 
     if (native_endian == .little) {
         const s3 = @as(S3Padded, @bitCast(@as(u64, 0xe952d5c71ff4))).s3;
-        try expectEqual(@as(u8, 0xf4), s3.x.a);
-        try expectEqual(@as(u8, 0x1f), s3.x.b);
-        try expectEqual(@as(u8, 0xc7), s3.x.c);
-        try expectEqual(@as(u8, 0xd5), s3.y.d);
-        try expectEqual(@as(u8, 0x52), s3.y.e);
-        try expectEqual(@as(u8, 0xe9), s3.y.f);
+        try expectEqual(0xf4, s3.x.a);
+        try expectEqual(0x1f, s3.x.b);
+        try expectEqual(0xc7, s3.x.c);
+        try expectEqual(0xd5, s3.y.d);
+        try expectEqual(0x52, s3.y.e);
+        try expectEqual(0xe9, s3.y.f);
     }
 
     const S4 = packed struct { a: i32, b: i8 };
@@ -249,8 +249,8 @@ test "regular in irregular packed struct" {
     foo.bar.a = 235;
     foo.bar.b = 42;
 
-    try expectEqual(@as(u16, 235), foo.bar.a);
-    try expectEqual(@as(u8, 42), foo.bar.b);
+    try expectEqual(235, foo.bar.a);
+    try expectEqual(42, foo.bar.b);
 }
 
 test "nested packed struct unaligned" {
@@ -456,12 +456,12 @@ test "nested packed struct field pointers" {
     const ptr_p0_c = &S2.s.p0.c;
     const ptr_p1_a = &S2.s.p1.a;
     const ptr_p1_b = &S2.s.p1.b;
-    try expectEqual(@as(u8, 1), ptr_base.*);
-    try expectEqual(@as(u4, 2), ptr_p0_a.*);
-    try expectEqual(@as(u4, 3), ptr_p0_b.*);
-    try expectEqual(@as(u8, 4), ptr_p0_c.*);
-    try expectEqual(@as(u7, 5), ptr_p1_a.*);
-    try expectEqual(@as(u8, 6), ptr_p1_b.*);
+    try expectEqual(1, ptr_base.*);
+    try expectEqual(2, ptr_p0_a.*);
+    try expectEqual(3, ptr_p0_b.*);
+    try expectEqual(4, ptr_p0_c.*);
+    try expectEqual(5, ptr_p1_a.*);
+    try expectEqual(6, ptr_p1_b.*);
 }
 
 test "load pointer from packed struct" {
@@ -1033,12 +1033,12 @@ test "modify nested packed struct aligned field" {
 
     var opts = Options{};
     opts.pretty_print.indent += 1;
-    try std.testing.expectEqual(@as(u17, 0b00000000100100000), @as(u17, @bitCast(opts)));
+    try std.testing.expectEqual(0b00000000100100000, @as(u17, @bitCast(opts)));
     try std.testing.expect(!opts.foo);
     try std.testing.expect(!opts.bar);
     try std.testing.expect(!opts.pretty_print.enabled);
-    try std.testing.expectEqual(@as(u4, 4), opts.pretty_print.num_spaces);
-    try std.testing.expectEqual(@as(u8, 1), opts.pretty_print.indent);
+    try std.testing.expectEqual(4, opts.pretty_print.num_spaces);
+    try std.testing.expectEqual(1, opts.pretty_print.indent);
     try std.testing.expect(!opts.baz);
 }
 

--- a/test/behavior/type.zig
+++ b/test/behavior/type.zig
@@ -438,9 +438,9 @@ test "Type.Union" {
         },
     });
     var tagged = Tagged{ .signed = -1 };
-    try testing.expectEqual(Tag.signed, tagged);
+    try testing.expectEqual(Tag.signed, @as(Tag, tagged));
     tagged = .{ .unsigned = 1 };
-    try testing.expectEqual(Tag.unsigned, tagged);
+    try testing.expectEqual(Tag.unsigned, @as(Tag, tagged));
 }
 
 test "Type.Union from Type.Enum" {

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -946,7 +946,7 @@ test "DC: C returns to Zig" {
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
-    try expectEqual(c_ret_DC(), .{ .v1 = -0.25, .v2 = 15 });
+    try expectEqual(c_ret_DC(), DC{ .v1 = -0.25, .v2 = 15 });
 }
 
 pub extern fn c_assert_DC(lv: DC) c_int;
@@ -998,7 +998,7 @@ test "CFF: C returns to Zig" {
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
-    try expectEqual(c_ret_CFF(), .{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 });
+    try expectEqual(c_ret_CFF(), CFF{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 });
 }
 pub extern fn c_assert_CFF(lv: CFF) c_int;
 pub extern fn c_assert_ret_CFF() c_int;
@@ -1045,7 +1045,7 @@ test "PD: C returns to Zig" {
     if (comptime builtin.cpu.arch.isMIPS() and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
-    try expectEqual(c_ret_PD(), .{ .v1 = null, .v2 = 0.5 });
+    try expectEqual(c_ret_PD(), PD{ .v1 = null, .v2 = 0.5 });
 }
 pub extern fn c_assert_PD(lv: PD) c_int;
 pub extern fn c_assert_ret_PD() c_int;

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -946,7 +946,7 @@ test "DC: C returns to Zig" {
     if (comptime builtin.cpu.arch.isRISCV()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
-    try expectEqual(c_ret_DC(), DC{ .v1 = -0.25, .v2 = 15 });
+    try expectEqual(DC{ .v1 = -0.25, .v2 = 15 }, c_ret_DC());
 }
 
 pub extern fn c_assert_DC(lv: DC) c_int;
@@ -998,7 +998,7 @@ test "CFF: C returns to Zig" {
     if (comptime builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
-    try expectEqual(c_ret_CFF(), CFF{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 });
+    try expectEqual(CFF{ .v1 = 39, .v2 = 0.875, .v3 = 1.0 }, c_ret_CFF());
 }
 pub extern fn c_assert_CFF(lv: CFF) c_int;
 pub extern fn c_assert_ret_CFF() c_int;
@@ -1045,7 +1045,7 @@ test "PD: C returns to Zig" {
     if (comptime builtin.cpu.arch.isMIPS() and builtin.mode != .Debug) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC()) return error.SkipZigTest;
     if (comptime builtin.cpu.arch.isPPC64()) return error.SkipZigTest;
-    try expectEqual(c_ret_PD(), PD{ .v1 = null, .v2 = 0.5 });
+    try expectEqual(PD{ .v1 = null, .v2 = 0.5 }, c_ret_PD());
 }
 pub extern fn c_assert_PD(lv: PD) c_int;
 pub extern fn c_assert_ret_PD() c_int;


### PR DESCRIPTION
This PR is an attempt of improving the ergonomics of passing literals to `std.testing.expectEqual` by changing the type of its second parameter to `anytype` and coercing both arguments to a common type `@TypeOf(expected, actual)`.

```diff
-pub fn expectEqual(expected: anytype, actual: @TypeOf(expected)) !void
+pub inline fn expectEqual(expected: anytype, actual: anytype) !void
```

The function is made `inline` to help ensure that certain coercions that can't happen at runtime happen at comptime, for example, from a value of the union's underlying enum type to an instance of the union itself.

This PR offers a partial solution to the problem described in the body of #4437. I invite everyone to provide feedback and suggest alternative solutions, and the core Zig team is encouraged to close this PR if they feel it does not align with their vision for the standard library.

In addition to `expectEqual`, this PR also applies similar changes to `expectEqualDeep`, `expectApproxEqAbs` and `expectApproxEqRel`.

## Motivation

Currently, the second parameter `actual` is of the type `@TypeOf(expected)` which makes it difficult to pass literals like numbers or `null` as the first argument. Simple code that *feels* like it should "just work" results in compile errors due to the function trying to coerce the second argument either to a comptime-only type or a very conservative one such as `@TypeOf(null)`. The reason for these compile errors is not always very obvious, especially for newcomers to the language, and every so often someone new will make a post in a Zig community confused why their assertions don't compile.

```zig
var my_int: i32 = 123;
try std.testing.expectEqual(246, my_int * 2);

// error: unable to resolve comptime value
// try std.testing.expectEqual(246, my_int * 2);
//                                  ~~~~~~~^~~
// note: value being casted to 'comptime_int' must be comptime-known

var my_optional: ?*const MyStruct = null;
try std.testing.expectEqual(null, my_optional);

// error: expected type '@TypeOf(null)', found '?*const main.MyStruct'
// note: parameter type declared here
// pub fn expectEqual(expected: anytype, actual: @TypeOf(expected)) !void {
//                                               ^~~~~~~~~~~~~~~~~
```

As a result of this, the user is often required to explicitly coerce the first argument to the expected type by using `@as` which makes assertions more cumbersome to type and more difficult to read. It might also encourage the user to swap the order of the arguments which will result in incorrect log messages from failed assertions.

```zig
var my_int: i32 = 123;
try std.testing.expectEqual(@as(i32, 246), my_int * 2);

var my_optional: ?*const MyStruct = null;
try std.testing.expectEqual(@as(?*const MyStruct, null), my_optional);

// '@as' is annoying, so let's swap the arguments

my_optional = &.{ .x = 1 };
try std.testing.expectEqual(my_optional, null);

// error: 'test_0' failed: expected main.MyStruct{ .x = 1 }, found null
```

Zig's `test` declarations is an excellet asset that makes writing tests a lot easier compared to other languages. In order to help encourage developers to write and maintain tests, test code should be ergonomic and easy to both write and read. The status quo of `expectEqual` being difficult to use conflicts with those goals.

The third commit demonstrates some cherry-picked cases where verbose `@as` was previously required but can now be removed.

## Does this change break existing code?

If the Zig code base is anything to go by, the vast majority of existing uses of `expectEqual` should continue to work and only a small number of existing uses will result in compile errors that require fixing.

Because the previous signature was more strict and often required explicitly coercing the first argument to a specific type, I believe that this change should not *silently* break any existing uses of `expectEqual`. Assertions that pass prior to this change should continue to pass, and assertions that fail should continue to fail.

This change does however *loudly* break a minor number of specific uses that will now result in compile errors. These mostly involve passing anonymous struct/union/enum literals and the results of builtins that invoke result locations semantics such as `@bitCast` as the second argument, which no longer resolve to an appropriate type because the parameter type is now `anytype`.

Luckily, fixing these compile errors is as simple as specifying the struct/union/enum name or explicitly coercing the expressions by wrappping them in `@as`. The second commit in this PR fixes all the compile errors that were introduced to the Zig code base.

Because the function has been made `inline`, it could in theory also break function pointers and assignments to function body types (resulting in compile errors), but I strongly doubt anyone is using the assertion functions like that.