### PR TITLE
cc: relax assumption that glibc is PIC/PIE only target

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1034,7 +1034,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
         const must_pic: bool = b: {
             if (target_util.requiresPIC(options.target, link_libc))
                 break :b true;
-            break :b link_mode == .Dynamic;
+            break :b link_mode == .Dynamic and options.output_mode == .Lib;
         };
         const pic = if (options.want_pic) |explicit| pic: {
             if (!explicit) {
@@ -5162,8 +5162,12 @@ pub fn addCCArgs(
                 },
             }
 
-            if (target_util.supports_fpic(target) and comp.bin_file.options.pic) {
-                try argv.append("-fPIC");
+            if (target_util.supports_fpic(target)) {
+                if (comp.bin_file.options.pic) {
+                    try argv.append("-fPIC");
+                } else {
+                    try argv.append("-fno-PIC");
+                }
             }
 
             if (comp.unwind_tables) {

--- a/src/target.zig
+++ b/src/target.zig
@@ -192,10 +192,10 @@ pub fn requiresPIE(target: std.Target) bool {
 
 /// This function returns whether non-pic code is completely invalid on the given target.
 pub fn requiresPIC(target: std.Target, linking_libc: bool) bool {
+    _ = linking_libc;
     return target.isAndroid() or
         target.os.tag == .windows or target.os.tag == .uefi or
-        osRequiresLibC(target) or
-        (linking_libc and target.isGnuLibC());
+        osRequiresLibC(target);
 }
 
 /// This is not whether the target supports Position Independent Code, but whether the -fPIC


### PR DESCRIPTION
Fixes #17430 

I've run into this while testing canonical PLT in the ELF linker.