### PR TITLE
Add muslnoexceptions abi and corresponding x86_64 linux target

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -501,6 +501,7 @@ pub const Target = struct {
         musleabi,
         musleabihf,
         muslx32,
+        muslnoexceptions,
         msvc,
         itanium,
         cygnus,
@@ -590,7 +591,14 @@ pub const Target = struct {
 
         pub inline fn isMusl(abi: Abi) bool {
             return switch (abi) {
-                .musl, .musleabi, .musleabihf => true,
+                .musl, .musleabi, .musleabihf, .muslnoexceptions => true,
+                else => false,
+            };
+        }
+
+        pub inline fn isNoExceptions(abi: Abi) bool {
+            return switch (abi) {
+                .muslnoexceptions => true,
                 else => false,
             };
         }

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -187,6 +187,7 @@ pub fn targetTriple(allocator: Allocator, target: std.Target) ![]const u8 {
         .musleabi => "musleabi",
         .musleabihf => "musleabihf",
         .muslx32 => "muslx32",
+        .muslnoexceptions => "musl",
         .msvc => "msvc",
         .itanium => "itanium",
         .cygnus => "cygnus",

--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -187,7 +187,7 @@ pub fn buildLibCXX(comp: *Compilation, prog_node: *std.Progress.Node) !void {
             try cflags.append("-D_LIBCPP_HAS_MUSL_LIBC");
         }
 
-        if (target.os.tag == .wasi) {
+        if (target.os.tag == .wasi or target.abi.isNoExceptions()) {
             // WASI doesn't support exceptions yet.
             try cflags.append("-fno-exceptions");
         }
@@ -323,7 +323,7 @@ pub fn buildLibCXXABI(comp: *Compilation, prog_node: *std.Progress.Node) !void {
     for (libcxxabi_files) |cxxabi_src| {
         var cflags = std.ArrayList([]const u8).init(arena);
 
-        if (target.os.tag == .wasi) {
+        if (target.os.tag == .wasi or target.abi.isNoExceptions()) {
             // WASI doesn't support exceptions yet.
             if (std.mem.startsWith(u8, cxxabi_src, "src/cxa_exception.cpp") or
                 std.mem.startsWith(u8, cxxabi_src, "src/cxa_personality.cpp"))

--- a/src/target.zig
+++ b/src/target.zig
@@ -69,6 +69,7 @@ pub const available_libcs = [_]ArchOsAbi{
     .{ .arch = .x86_64, .os = .linux, .abi = .gnu },
     .{ .arch = .x86_64, .os = .linux, .abi = .gnux32 },
     .{ .arch = .x86_64, .os = .linux, .abi = .musl },
+    .{ .arch = .x86_64, .os = .linux, .abi = .muslnoexceptions },
     .{ .arch = .x86_64, .os = .windows, .abi = .gnu },
     .{ .arch = .x86_64, .os = .macos, .abi = .none, .os_ver = .{ .major = 10, .minor = 7, .patch = 0 } },
 };
@@ -95,6 +96,7 @@ pub fn libCGenericName(target: std.Target) [:0]const u8 {
         .musleabi,
         .musleabihf,
         .muslx32,
+        .muslnoexceptions,
         .none,
         => return "musl",
         .code16,


### PR DESCRIPTION
Adds muslnoexceptions abi and triple x86_64-linux-muslnoexceptions.

When using this abi with `zig c++` that adds `-fno-exceptions` flag for building libcxx and libcxxabi.

That may be helppfull when use `zig c++` as drop-in compiler for c++ projects that do not use exceptions.

This PR adresses https://github.com/ziglang/zig/issues/17470 that i have created

Closes #17470