### PR TITLE
x86_64: fix codegen errors when compiling compiler_rt

### DIFF
--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -515,12 +515,12 @@ const foo_ref = &foo_contents;
 
 test "runtime 128 bit integer division" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c and comptime builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
     var a: u128 = 152313999999999991610955792383;
     var b: u128 = 10000000000000000000;


### PR DESCRIPTION
```
$ zig build-lib lib/compiler_rt.zig -fno-llvm -fno-lld -OReleaseFast
error: TODOImplementWritingLibFiles
src/link/Elf.zig:1149:17: 0xd43afe in flush (zig)
        .Lib => return error.TODOImplementWritingLibFiles,
                ^
src/link.zig:819:21: 0xa22bd1 in flush (zig)
            .elf => return @fieldParentPtr(Elf, "base", base).flush(comp, prog_node),
                    ^
src/Compilation.zig:2357:21: 0xa2249a in flush (zig)
        else => |e| return e,
                    ^
src/Compilation.zig:2311:9: 0xa60533 in update (zig)
        try comp.flush(main_progress_node);
        ^
src/main.zig:4206:9: 0xa8d787 in updateModule (zig)
        try comp.update(main_progress_node);
        ^
src/main.zig:3615:21: 0xab0cd0 in buildOutputType (zig)
        else => |e| return e,
                    ^
src/main.zig:271:9: 0x8c9d5a in mainArgs (zig)
        return buildOutputType(gpa, arena, args, .{ .build = .Lib });
        ^
src/main.zig:213:5: 0x8c6f30 in main (zig)
    return mainArgs(gpa, arena, args);
    ^
```
This error indicates that it made it all the way to linking, meaning that there are no more codegen compile errors in this compilation.

The single behavior test this PR enables gets the behavior test passing percentage for the x86_64 backend rounding to 93% (1643/1776). :tada: