### PR TITLE
Grammar: Use `ContainerDeclaration*` instead of `ContainerDeclarations`

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -12371,9 +12371,9 @@ fn readU32Be() u32 {}
 Root <- skip container_doc_comment? ContainerMembers eof
 
 # *** Top level ***
-ContainerMembers <- ContainerDeclarations (ContainerField COMMA)* (ContainerField / ContainerDeclarations)
+ContainerMembers <- ContainerDeclaration* (ContainerField COMMA)* (ContainerField / ContainerDeclaration*)
 
-ContainerDeclarations <- (TestDecl / ComptimeDecl / doc_comment? KEYWORD_pub? Decl)*
+ContainerDeclaration <- TestDecl / ComptimeDecl / doc_comment? KEYWORD_pub? Decl
 
 TestDecl <- KEYWORD_test (STRINGLITERALSINGLE / IDENTIFIER)? Block
 

--- a/lib/std/zig/Parse.zig
+++ b/lib/std/zig/Parse.zig
@@ -205,9 +205,9 @@ pub fn parseZon(p: *Parse) !void {
     };
 }
 
-/// ContainerMembers <- ContainerDeclarations (ContainerField COMMA)* (ContainerField / ContainerDeclarations)
+/// ContainerMembers <- ContainerDeclaration* (ContainerField COMMA)* (ContainerField / ContainerDeclaration*)
 ///
-/// ContainerDeclarations <- (TestDecl / ComptimeDecl / doc_comment? KEYWORD_pub? Decl)*
+/// ContainerDeclaration <- TestDecl / ComptimeDecl / doc_comment? KEYWORD_pub? Decl
 ///
 /// ComptimeDecl <- KEYWORD_comptime Block
 fn parseContainerMembers(p: *Parse) !Members {


### PR DESCRIPTION
`ContainerDeclarations` is an abstraction of `ContainerDeclaration*`. Removing this abstraction allows the `ContainerMembers` rule to contain more concrete information without having to look at the definition of `ContainerDeclarations` which arguably makes it easier to follow.