### PR TITLE
std.cstr: remove deprecated namespace

### DIFF
--- a/lib/std/cstr.zig
+++ b/lib/std/cstr.zig
@@ -1,3 +1,0 @@
-pub const line_sep = @compileError("deprecated; choose correct end-of-line sequence of characters by yourself instead");
-pub const cmp = @compileError("deprecated; use `std.mem.orderZ` instead");
-pub const addNullByte = @compileError("deprecated; use `allocator.dupeZ(u8, stuff)` instead");

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -80,8 +80,6 @@ pub const comptime_string_map = @import("comptime_string_map.zig");
 /// Cryptography.
 pub const crypto = @import("crypto.zig");
 
-pub const cstr = @import("cstr.zig");
-
 /// Debug printing, allocation and other debug helpers.
 pub const debug = @import("debug.zig");
 

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -2109,14 +2109,14 @@ test "zig fmt: multiline string parameter in fn call with trailing comma" {
     try testCanonical(
         \\fn foo() void {
         \\    try stdout.print(
-        \\        \\ZIG_CMAKE_BINARY_DIR {}
-        \\        \\ZIG_C_HEADER_FILES   {}
-        \\        \\ZIG_DIA_GUIDS_LIB    {}
+        \\        \\ZIG_CMAKE_BINARY_DIR {s}
+        \\        \\ZIG_C_HEADER_FILES   {s}
+        \\        \\ZIG_DIA_GUIDS_LIB    {s}
         \\        \\
         \\    ,
-        \\        std.cstr.toSliceConst(c.ZIG_CMAKE_BINARY_DIR),
-        \\        std.cstr.toSliceConst(c.ZIG_CXX_COMPILER),
-        \\        std.cstr.toSliceConst(c.ZIG_DIA_GUIDS_LIB),
+        \\        std.mem.sliceTo(c.ZIG_CMAKE_BINARY_DIR, 0),
+        \\        std.mem.sliceTo(c.ZIG_CXX_COMPILER, 0),
+        \\        std.mem.sliceTo(c.ZIG_DIA_GUIDS_LIB, 0),
         \\    );
         \\}
         \\


### PR DESCRIPTION
Followup to 0a868dacdd31b7d5c529a332da718683477a2505 .