### PR TITLE
Package.Fetch: allow relative paths outside project root

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -257,8 +257,9 @@ pub fn run(f: *Fetch) RunError!void {
                 f.hash_tok,
                 try eb.addString("path-based dependencies are not hashed"),
             );
-            if (std.mem.startsWith(u8, pkg_root.sub_path, "../") or
-                std.mem.eql(u8, pkg_root.sub_path, ".."))
+            if ((std.mem.startsWith(u8, pkg_root.sub_path, "../") or
+                std.mem.eql(u8, pkg_root.sub_path, "..")) and
+                pkg_root.root_dir.eql(cache_root))
             {
                 return f.fail(
                     f.location_tok,


### PR DESCRIPTION
Only for packages that come from the main package. Fetched packages still cannot depend on paths outside their package root.