### PR TITLE
Compilation: default to self-hosted backends when not using libllvm

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -112,7 +112,6 @@ unwind_tables: bool,
 test_evented_io: bool,
 debug_compiler_runtime_libs: bool,
 debug_compile_errors: bool,
-job_queued_compiler_rt_lib: bool = false,
 job_queued_compiler_rt_obj: bool = false,
 alloc_failure_occurred: bool = false,
 formatted_panics: bool = false,
@@ -158,9 +157,6 @@ libssp_static_lib: ?CRTFile = null,
 /// Populated when we build the libc static library. A Job to build this is placed in the queue
 /// and resolved before calling linker.flush().
 libc_static_lib: ?CRTFile = null,
-/// Populated when we build the libcompiler_rt static library. A Job to build this is indicated
-/// by setting `job_queued_compiler_rt_lib` and resolved before calling linker.flush().
-compiler_rt_lib: ?CRTFile = null,
 /// Populated when we build the compiler_rt_obj object. A Job to build this is indicated
 /// by setting `job_queued_compiler_rt_obj` and resolved before calling linker.flush().
 compiler_rt_obj: ?CRTFile = null,
@@ -1877,13 +1873,8 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
         }
 
         if (comp.bin_file.options.include_compiler_rt and capable_of_building_compiler_rt) {
-            if (is_exe_or_dyn_lib) {
-                log.debug("queuing a job to build compiler_rt_lib", .{});
-                comp.job_queued_compiler_rt_lib = true;
-            } else if (options.output_mode != .Obj) {
+            if (is_exe_or_dyn_lib or options.output_mode != .Obj) {
                 log.debug("queuing a job to build compiler_rt_obj", .{});
-                // In this case we are making a static library, so we ask
-                // for a compiler-rt object to put in it.
                 comp.job_queued_compiler_rt_obj = true;
             }
         }
@@ -1936,9 +1927,6 @@ pub fn destroy(self: *Compilation) void {
         crt_file.deinit(gpa);
     }
     if (self.libcxxabi_static_lib) |*crt_file| {
-        crt_file.deinit(gpa);
-    }
-    if (self.compiler_rt_lib) |*crt_file| {
         crt_file.deinit(gpa);
     }
     if (self.compiler_rt_obj) |*crt_file| {
@@ -3405,11 +3393,6 @@ pub fn performAllTheWork(
             continue;
         }
         break;
-    }
-
-    if (comp.job_queued_compiler_rt_lib) {
-        comp.job_queued_compiler_rt_lib = false;
-        buildCompilerRtOneShot(comp, .Lib, &comp.compiler_rt_lib, main_progress_node);
     }
 
     if (comp.job_queued_compiler_rt_obj) {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -841,6 +841,12 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             if (options.main_mod == null)
                 break :blk false;
 
+            // If we cannot use LLVM libraries, then our own backends will be a
+            // better default since the LLVM backend can only produce bitcode
+            // and not an object file or executable.
+            if (!use_lib_llvm)
+                break :blk false;
+
             // If LLVM does not support the target, then we can't use it.
             if (!target_util.hasLlvmSupport(options.target, options.target.ofmt))
                 break :blk false;

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -491,9 +491,8 @@ pub fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
             }
             // MSVC compiler_rt is missing some stuff, so we build it unconditionally but
             // and rely on weak linkage to allow MSVC compiler_rt functions to override ours.
-            if (comp.compiler_rt_obj) |obj| {
-                try argv.append(obj.full_object_path);
-            }
+            if (comp.compiler_rt_obj) |obj| try argv.append(obj.full_object_path);
+            if (comp.compiler_rt_lib) |lib| try argv.append(lib.full_object_path);
         }
 
         try argv.ensureUnusedCapacity(self.base.options.system_libs.count());

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -491,8 +491,8 @@ pub fn linkWithLLD(self: *Coff, comp: *Compilation, prog_node: *std.Progress.Nod
             }
             // MSVC compiler_rt is missing some stuff, so we build it unconditionally but
             // and rely on weak linkage to allow MSVC compiler_rt functions to override ours.
-            if (comp.compiler_rt_lib) |lib| {
-                try argv.append(lib.full_object_path);
+            if (comp.compiler_rt_obj) |obj| {
+                try argv.append(obj.full_object_path);
             }
         }
 

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1257,7 +1257,6 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
     // to be after the shared libraries, so they are picked up from the shared
     // libraries, not libcompiler_rt.
     const compiler_rt_path: ?[]const u8 = blk: {
-        if (comp.compiler_rt_lib) |x| break :blk x.full_object_path;
         if (comp.compiler_rt_obj) |x| break :blk x.full_object_path;
         break :blk null;
     };
@@ -1957,7 +1956,6 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
     const stack_size = self.base.options.stack_size_override orelse 16777216;
     const allow_shlib_undefined = self.base.options.allow_shlib_undefined orelse !self.base.options.is_native_os;
     const compiler_rt_path: ?[]const u8 = blk: {
-        if (comp.compiler_rt_lib) |x| break :blk x.full_object_path;
         if (comp.compiler_rt_obj) |x| break :blk x.full_object_path;
         break :blk null;
     };

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1257,6 +1257,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
     // to be after the shared libraries, so they are picked up from the shared
     // libraries, not libcompiler_rt.
     const compiler_rt_path: ?[]const u8 = blk: {
+        if (comp.compiler_rt_lib) |x| break :blk x.full_object_path;
         if (comp.compiler_rt_obj) |x| break :blk x.full_object_path;
         break :blk null;
     };
@@ -1956,6 +1957,7 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
     const stack_size = self.base.options.stack_size_override orelse 16777216;
     const allow_shlib_undefined = self.base.options.allow_shlib_undefined orelse !self.base.options.is_native_os;
     const compiler_rt_path: ?[]const u8 = blk: {
+        if (comp.compiler_rt_lib) |x| break :blk x.full_object_path;
         if (comp.compiler_rt_obj) |x| break :blk x.full_object_path;
         break :blk null;
     };

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -186,8 +186,8 @@ pub fn linkWithZld(
             try positionals.append(.{ .path = p });
         }
 
-        if (comp.compiler_rt_lib) |lib| {
-            try positionals.append(.{ .path = lib.full_object_path });
+        if (comp.compiler_rt_obj) |obj| {
+            try positionals.append(.{ .path = obj.full_object_path });
         }
 
         // libc++ dep
@@ -301,8 +301,8 @@ pub fn linkWithZld(
                 try argv.append(p);
             }
 
-            if (comp.compiler_rt_lib) |lib| {
-                try argv.append(lib.full_object_path);
+            if (comp.compiler_rt_obj) |obj| {
+                try argv.append(obj.full_object_path);
             }
 
             if (options.link_libcpp) {

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -186,9 +186,8 @@ pub fn linkWithZld(
             try positionals.append(.{ .path = p });
         }
 
-        if (comp.compiler_rt_obj) |obj| {
-            try positionals.append(.{ .path = obj.full_object_path });
-        }
+        if (comp.compiler_rt_lib) |lib| try positionals.append(.{ .path = lib.full_object_path });
+        if (comp.compiler_rt_obj) |obj| try positionals.append(.{ .path = obj.full_object_path });
 
         // libc++ dep
         if (options.link_libcpp) {
@@ -301,9 +300,8 @@ pub fn linkWithZld(
                 try argv.append(p);
             }
 
-            if (comp.compiler_rt_obj) |obj| {
-                try argv.append(obj.full_object_path);
-            }
+            if (comp.compiler_rt_lib) |lib| try argv.append(lib.full_object_path);
+            if (comp.compiler_rt_obj) |obj| try argv.append(obj.full_object_path);
 
             if (options.link_libcpp) {
                 try argv.append(comp.libcxxabi_static_lib.?.full_object_path);

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -3257,11 +3257,7 @@ fn linkWithZld(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) l
     sub_prog_node.activate();
     defer sub_prog_node.end();
 
-    const is_obj = options.output_mode == .Obj;
-    const compiler_rt_path: ?[]const u8 = if (options.include_compiler_rt and !is_obj)
-        comp.compiler_rt_lib.?.full_object_path
-    else
-        null;
+    const compiler_rt_path: ?[]const u8 = if (comp.compiler_rt_obj) |o| o.full_object_path else null;
     const id_symlink_basename = "zld.id";
 
     var man: Cache.Manifest = undefined;
@@ -3376,8 +3372,8 @@ fn linkWithZld(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) l
         try positionals.append(c_object.status.success.object_path);
     }
 
-    if (comp.compiler_rt_lib) |lib| {
-        try positionals.append(lib.full_object_path);
+    if (comp.compiler_rt_obj) |obj| {
+        try positionals.append(obj.full_object_path);
     }
 
     try wasm.parseInputFiles(positionals.items);
@@ -3463,8 +3459,8 @@ pub fn flushModule(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Nod
         try positionals.append(c_object.status.success.object_path);
     }
 
-    if (comp.compiler_rt_lib) |lib| {
-        try positionals.append(lib.full_object_path);
+    if (comp.compiler_rt_obj) |obj| {
+        try positionals.append(obj.full_object_path);
     }
 
     try wasm.parseInputFiles(positionals.items);
@@ -4325,11 +4321,7 @@ fn linkWithLLD(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) !
     defer sub_prog_node.end();
 
     const is_obj = wasm.base.options.output_mode == .Obj;
-
-    const compiler_rt_path: ?[]const u8 = if (wasm.base.options.include_compiler_rt and !is_obj)
-        comp.compiler_rt_lib.?.full_object_path
-    else
-        null;
+    const compiler_rt_path: ?[]const u8 = if (comp.compiler_rt_obj) |o| o.full_object_path else null;
 
     const target = wasm.base.options.target;
 

--- a/test/link/macho/bugs/16308/build.zig
+++ b/test/link/macho/bugs/16308/build.zig
@@ -17,7 +17,7 @@ pub fn build(b: *std.Build) void {
 
     const check = lib.checkObject();
     check.checkInSymtab();
-    check.checkNotPresent("external");
+    check.checkNotPresent("external _abc");
 
     test_step.dependOn(&check.step);
 }


### PR DESCRIPTION
Originally, this PR tried to switch compiler_rt from making a static library to making an object file. However, that change did not pan out, and what is left over is some minor related enhancements.

Mainly, the default backend is self-hosted when LLVM libraries are not available.