### PR TITLE
byos: Ease `GeneralPurposeAllocator` integration

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -223,7 +223,11 @@ fn rawCFree(
 
 /// This allocator makes a syscall directly for every allocation and free.
 /// Thread-safe and lock-free.
-pub const page_allocator = if (builtin.target.isWasm())
+pub const page_allocator = if (@hasDecl(root, "os") and
+    @hasDecl(root.os, "heap") and
+    @hasDecl(root.os.heap, "page_allocator"))
+    root.os.heap.page_allocator
+else if (builtin.target.isWasm())
     Allocator{
         .ptr = undefined,
         .vtable = &WasmPageAllocator.vtable,
@@ -233,8 +237,6 @@ else if (builtin.target.os.tag == .plan9)
         .ptr = undefined,
         .vtable = &SbrkAllocator(std.os.plan9.sbrk).vtable,
     }
-else if (builtin.target.os.tag == .freestanding)
-    root.os.heap.page_allocator
 else
     Allocator{
         .ptr = undefined,


### PR DESCRIPTION
These changes enable me to use `GeneralPurposeAllocator` with my "Bring Your Own OS" package. The previous checks for a freestanding target have been expanded to `@hasDecl` checks.

- `root.os.heap.page_allocator` is used if it exists.
- `debug.isValidMemory` only calls `os.msync` if it's supported.
