### PR TITLE
Package.Fetch: retry fetch on error

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -659,8 +659,7 @@ fn queueJobsForDeps(f: *Fetch) RunError!void {
             };
         }
 
-        // job_queue mutex is locked so this is OK.
-        f.prog_node.unprotected_estimated_total_items += new_fetch_index;
+        _ = @atomicRmw(usize, &f.prog_node.unprotected_estimated_total_items, .Add, new_fetch_index, .Monotonic);
 
         break :nf .{ new_fetches[0..new_fetch_index], prog_names[0..new_fetch_index] };
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -4841,7 +4841,7 @@ pub fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !voi
             defer http_client.deinit();
 
             var progress: std.Progress = .{ .dont_print_on_dumb = true };
-            const root_prog_node = progress.start("Fetch Packages", 0);
+            const root_prog_node = progress.start("Fetch Packages", 1);
             defer root_prog_node.end();
 
             var job_queue: Package.Fetch.JobQueue = .{
@@ -6746,7 +6746,7 @@ fn cmdFetch(
     defer http_client.deinit();
 
     var progress: std.Progress = .{ .dont_print_on_dumb = true };
-    const root_prog_node = progress.start("Fetch", 0);
+    const root_prog_node = progress.start("Fetch", 1);
     defer root_prog_node.end();
 
     var global_cache_directory: Compilation.Directory = l: {


### PR DESCRIPTION
See commit messages for details. A package fetch may now be attempted up to 4 times, with inter-attempt delays of 200ms, 800ms, and 4000ms.