### PR TITLE
Fix compilation failure in valgrind.zig

### DIFF
--- a/lib/std/valgrind.zig
+++ b/lib/std/valgrind.zig
@@ -171,7 +171,7 @@ pub fn createMempool(pool: [*]u8, rzB: usize, is_zeroed: bool, flags: usize) voi
 
 /// Destroy a memory pool.
 pub fn destroyMempool(pool: [*]u8) void {
-    doClientRequestStmt(.DestroyMempool, pool, 0, 0, 0, 0);
+    doClientRequestStmt(.DestroyMempool, @intFromPtr(pool), 0, 0, 0, 0);
 }
 
 /// Associate a piece of memory with a memory pool.


### PR DESCRIPTION
I haven't otherwise tested whether this actually makes everything *work* as I'm just learning how valgrind works in the first place, but in terms of the code I think this makes sense. Was probably just missed at some point when the other functions were refactored.