### PR TITLE
lib: Fix asm code in _start for arches with branch delay slot

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -327,8 +327,8 @@ fn _start() callconv(.Naked) noreturn {
             // argc is stored after a register window (16 registers) plus stack bias
             \\ mov %%g0, %%i6
             \\ add %%o6, 2175, %%l0
-            \\ stx %%l0, %[argc_argv_ptr]
             \\ ba %[posixCallMainAndExit]
+            \\  stx %%l0, %[argc_argv_ptr]
             ,
             else => @compileError("unsupported arch"),
         }


### PR DESCRIPTION
MIPS and SPARC have delayed branches, that is, they will unconditionally run the next instruction following a branch.
Stuff a `nop` in that place to prevent our startup routine from executing stray instructions, which may result in odd program behavior.