### PR TITLE
std.testing: fail and fatal formatted messaging

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -24,7 +24,7 @@ pub var base_allocator_instance = std.heap.FixedBufferAllocator.init("");
 pub var log_level = std.log.Level.warn;
 
 /// Non-zero counts imply test failure. The value is reset for every test.
-pub var error_count: usize = 0;
+pub var fail_count: usize = 0;
 
 /// Fail the test with a formatted message but continue execution, unlike fatal.
 pub fn fail(comptime fmt: []const u8, args: anytype) void {
@@ -37,11 +37,11 @@ pub fn fail(comptime fmt: []const u8, args: anytype) void {
         @compileError("message format string with trailing whitespace");
 
     // follow-up ellipsis ("...") from test header if first
-    if (error_count == 0) print("failed\n", .{});
+    if (fail_count == 0) print("failed\n", .{});
     // output error as indented line
     print("> " ++ fmt ++ "\n", args);
 
-    error_count += 1;
+    fail_count += 1;
 }
 
 test fail {
@@ -83,7 +83,7 @@ test fatal {
 
 // FailFinal maintains a single output-line when possible for the expect fn.
 fn failFinal(comptime fmt: []const u8, args: anytype) void {
-    if (error_count == 0) {
+    if (fail_count == 0) {
         // follow-up ellipsis ("...") from test header directly
         print(fmt ++ "\n", args);
     } else {
@@ -91,7 +91,7 @@ fn failFinal(comptime fmt: []const u8, args: anytype) void {
         print("> " ++ fmt ++ "\n", args);
     }
 
-    error_count += 1;
+    fail_count += 1;
 }
 
 fn print(comptime fmt: []const u8, args: anytype) void {

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -28,8 +28,12 @@ pub var error_count: usize = 0;
 /// The common pattern is as follows.
 ///
 /// ```zig
+/// test "Demo" {
+/// …
 ///     if (got != want)
 ///         testing.fail("got {}, want {}", got, want);
+/// …
+/// }
 /// ```
 pub fn fail(comptime fmt: []const u8, args: anytype) void {
     // sanity check in compile-time
@@ -51,8 +55,12 @@ pub fn fail(comptime fmt: []const u8, args: anytype) void {
 /// Fatal test scenario must return immediately, unlike fail.
 ///
 /// ```zig
+/// test "Demo" {
+/// …
 ///     const got = foo(x) catch |err|
 ///         return testing.fatal("foo {} got error {}", .{ x, err });
+/// …
+/// }
 /// ```
 pub fn fatal(comptime fmt: []const u8, args: anytype) error{TestFatal} {
     fail(fmt, args);
@@ -393,8 +401,7 @@ pub fn expectEqualSlices(comptime T: type, expected: []const T, actual: []const 
     const index_fmt = if (T == u8) "0x{X}" else "{}";
 
     print("====== expected this output: ====== len: {} (0x{X})\n\n", .{
-        expected.len,
-        expected.len,
+        expected.len, expected.len,
     });
     if (window_start > 0) {
         if (T == u8) {
@@ -418,8 +425,7 @@ pub fn expectEqualSlices(comptime T: type, expected: []const T, actual: []const 
     differ.expected = actual_window;
     differ.actual = expected_window;
     print("\n======== instead found this: ====== len: {} (0x{X})\n\n", .{
-        actual.len,
-        actual.len,
+        actual.len, actual.len,
     });
     if (window_start > 0) {
         if (T == u8) {

--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -89,7 +89,7 @@ fn mainServer() !void {
             },
 
             .run_test => {
-                std.testing.error_count = 0;
+                std.testing.fail_count = 0;
                 std.testing.allocator_instance = .{};
                 log_err_count = 0;
                 const index = try server.receiveBody_u32();
@@ -108,7 +108,7 @@ fn mainServer() !void {
                         }
                     },
                 };
-                if (std.testing.error_count != 0)
+                if (std.testing.fail_count != 0)
                     fail = true;
                 leak = std.testing.allocator_instance.deinit() == .leak;
                 try server.serveTestResults(.{
@@ -152,7 +152,7 @@ fn mainTerminal() void {
 
     var leaks: usize = 0;
     for (test_fn_list, 0..) |test_fn, i| {
-        std.testing.error_count = 0;
+        std.testing.fail_count = 0;
         std.testing.allocator_instance = .{};
         defer {
             if (std.testing.allocator_instance.deinit() == .leak) {
@@ -184,13 +184,13 @@ fn mainTerminal() void {
             },
         } else test_fn.func();
         if (result) |_| {
-            if (std.testing.error_count == 0) {
+            if (std.testing.fail_count == 0) {
                 ok_count += 1;
                 test_node.end();
                 if (!have_tty) std.debug.print("OK\n", .{});
             } else {
                 fail_count += 1;
-                progress.log("FAIL ({d} errors)\n", .{std.testing.error_count});
+                progress.log("FAIL ({d} failures)\n", .{std.testing.fail_count});
                 test_node.end();
             }
         } else |err| switch (err) {


### PR DESCRIPTION
Two new functions in std.testing:

```zig
/// Fail the test with a formatted message but continue execution, unlike fatal.
/// The common pattern is as follows.
///
/// ```zig
///     if (got != want)
///         testing.fail("got {}, want {}", got, want);
/// ```
pub fn fail(comptime fmt: []const u8, args: anytype) void {
```

```zig
/// Fatal test scenario must return immediately, unlike fail.
///
/// ```zig
///     const got = foo(x) catch |err|
///         return testing.fatal("foo {} got error {}", .{ x, err });
/// ```
pub fn fatal(comptime fmt: []const u8, args: anytype) error{TestFatal} {
```

The purpose is more readable test failures, with a single line of context each.
Fail format-strings have a documenting effect on the respective test-scenario too.

The commit includes some assertion message normalization and a demonstration in net/net.zig (arbitrarily chosen).
