### PR TITLE
path-related fixes for Package.Fetch and Package.Manifest

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -1507,6 +1507,7 @@ const Filter = struct {
     pub fn includePath(self: Filter, sub_path: []const u8) bool {
         if (self.include_paths.count() == 0) return true;
         if (self.include_paths.contains("")) return true;
+        if (self.include_paths.contains(".")) return true;
         if (self.include_paths.contains(sub_path)) return true;
 
         // Check if any included paths are parent directories of sub_path.
@@ -1571,4 +1572,5 @@ const ErrorBundle = std.zig.ErrorBundle;
 
 test {
     _ = Filter;
+    _ = FileType;
 }

--- a/src/Package/Manifest.zig
+++ b/src/Package/Manifest.zig
@@ -313,7 +313,7 @@ const Parse = struct {
         var buf: [2]Ast.Node.Index = undefined;
         const array_init = ast.fullArrayInit(&buf, node) orelse {
             const tok = main_tokens[node];
-            return fail(p, tok, "expected paths expression to be a struct", .{});
+            return fail(p, tok, "expected paths expression to be a list of strings", .{});
         };
 
         for (array_init.ast.elements) |elem_node| {


### PR DESCRIPTION
* Package.Fetch: fix empty path and "." not including all
* Package.Manifest: fix error message for paths

closes #17491