### PR TITLE
Fix minor typo in the description of Progress

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -1,4 +1,4 @@
-//! This API non-allocating, non-fallible, and thread-safe.
+//! This API is non-allocating, non-fallible, and thread-safe.
 //! The tradeoff is that users of this API must provide the storage
 //! for each `Progress.Node`.
 //!


### PR DESCRIPTION
I noticed that there was a missing "is" in the description of Progress, so I added one.