### PR TITLE
std.base64: Improve Encoder/Decoder performance

### DIFF
--- a/lib/std/base64.zig
+++ b/lib/std/base64.zig
@@ -102,14 +102,28 @@ pub const Base64Encoder = struct {
 
         var idx: usize = 0;
         var out_idx: usize = 0;
-        while (idx + 2 < source.len) : (idx += 3) {
+        while (idx + 15 < source.len) : (idx += 12) {
+            const bits = std.mem.readIntBig(u128, source[idx..][0..16]);
+            inline for (0..16) |i| {
+                dest[out_idx + i] = encoder.alphabet_chars[@truncate((bits >> (122 - i * 6)) & 0x3f)];
+            }
+            out_idx += 16;
+        }
+        while (idx + 3 < source.len) : (idx += 3) {
+            const bits = std.mem.readIntBig(u32, source[idx..][0..4]);
+            dest[out_idx] = encoder.alphabet_chars[(bits >> 26) & 0x3f];
+            dest[out_idx + 1] = encoder.alphabet_chars[(bits >> 20) & 0x3f];
+            dest[out_idx + 2] = encoder.alphabet_chars[(bits >> 14) & 0x3f];
+            dest[out_idx + 3] = encoder.alphabet_chars[(bits >> 8) & 0x3f];
+            out_idx += 4;
+        }
+        if (idx + 2 < source.len) {
             dest[out_idx] = encoder.alphabet_chars[source[idx] >> 2];
             dest[out_idx + 1] = encoder.alphabet_chars[((source[idx] & 0x3) << 4) | (source[idx + 1] >> 4)];
             dest[out_idx + 2] = encoder.alphabet_chars[(source[idx + 1] & 0xf) << 2 | (source[idx + 2] >> 6)];
             dest[out_idx + 3] = encoder.alphabet_chars[source[idx + 2] & 0x3f];
             out_idx += 4;
-        }
-        if (idx + 1 < source.len) {
+        } else if (idx + 1 < source.len) {
             dest[out_idx] = encoder.alphabet_chars[source[idx] >> 2];
             dest[out_idx + 1] = encoder.alphabet_chars[((source[idx] & 0x3) << 4) | (source[idx + 1] >> 4)];
             dest[out_idx + 2] = encoder.alphabet_chars[(source[idx + 1] & 0xf) << 2];
@@ -130,15 +144,18 @@ pub const Base64Encoder = struct {
 
 pub const Base64Decoder = struct {
     const invalid_char: u8 = 0xff;
+    const invalid_char_tst: u32 = 0xff000000;
 
     /// e.g. 'A' => 0.
     /// `invalid_char` for any value not in the 64 alphabet chars.
     char_to_index: [256]u8,
+    fast_char_to_index: [4][256]u32,
     pad_char: ?u8,
 
     pub fn init(alphabet_chars: [64]u8, pad_char: ?u8) Base64Decoder {
         var result = Base64Decoder{
             .char_to_index = [_]u8{invalid_char} ** 256,
+            .fast_char_to_index = .{[_]u32{invalid_char_tst} ** 256} ** 4,
             .pad_char = pad_char,
         };
 
@@ -146,6 +163,12 @@ pub const Base64Decoder = struct {
         for (alphabet_chars, 0..) |c, i| {
             assert(!char_in_alphabet[c]);
             assert(pad_char == null or c != pad_char.?);
+
+            const ci = @as(u32, @intCast(i));
+            result.fast_char_to_index[0][c] = ci << 2;
+            result.fast_char_to_index[1][c] = (ci >> 4) | ((ci & 0x0f) << 12);
+            result.fast_char_to_index[2][c] = ((ci & 0x3) << 22) | ((ci & 0x3c) << 6);
+            result.fast_char_to_index[3][c] = ci << 16;
 
             result.char_to_index[c] = @as(u8, @intCast(i));
             char_in_alphabet[c] = true;
@@ -184,11 +207,39 @@ pub const Base64Decoder = struct {
     /// invalid padding results in error.InvalidPadding.
     pub fn decode(decoder: *const Base64Decoder, dest: []u8, source: []const u8) Error!void {
         if (decoder.pad_char != null and source.len % 4 != 0) return error.InvalidPadding;
+        var dest_idx: usize = 0;
+        var fast_src_idx: usize = 0;
         var acc: u12 = 0;
         var acc_len: u4 = 0;
-        var dest_idx: usize = 0;
         var leftover_idx: ?usize = null;
-        for (source, 0..) |c, src_idx| {
+        while (fast_src_idx + 16 < source.len and dest_idx + 15 < dest.len) : ({
+            fast_src_idx += 16;
+            dest_idx += 12;
+        }) {
+            var bits: u128 = 0;
+            inline for (0..4) |i| {
+                var new_bits: u128 = decoder.fast_char_to_index[0][source[fast_src_idx + i * 4]];
+                new_bits |= decoder.fast_char_to_index[1][source[fast_src_idx + 1 + i * 4]];
+                new_bits |= decoder.fast_char_to_index[2][source[fast_src_idx + 2 + i * 4]];
+                new_bits |= decoder.fast_char_to_index[3][source[fast_src_idx + 3 + i * 4]];
+                if ((new_bits & invalid_char_tst) != 0) return error.InvalidCharacter;
+                bits |= (new_bits << (24 * i));
+            }
+            std.mem.writeIntLittle(u128, dest[dest_idx..][0..16], bits);
+        }
+        while (fast_src_idx + 4 < source.len and dest_idx + 3 < dest.len) : ({
+            fast_src_idx += 4;
+            dest_idx += 3;
+        }) {
+            var bits = decoder.fast_char_to_index[0][source[fast_src_idx]];
+            bits |= decoder.fast_char_to_index[1][source[fast_src_idx + 1]];
+            bits |= decoder.fast_char_to_index[2][source[fast_src_idx + 2]];
+            bits |= decoder.fast_char_to_index[3][source[fast_src_idx + 3]];
+            if ((bits & invalid_char_tst) != 0) return error.InvalidCharacter;
+            std.mem.writeIntLittle(u32, dest[dest_idx..][0..4], bits);
+        }
+        var remaining = source[fast_src_idx..];
+        for (remaining, fast_src_idx..) |c, src_idx| {
             const d = decoder.char_to_index[c];
             if (d == invalid_char) {
                 if (decoder.pad_char == null or c != decoder.pad_char.?) return error.InvalidCharacter;
@@ -338,6 +389,10 @@ fn testBase64() !void {
     try testAllApis(codecs, "foob", "Zm9vYg==");
     try testAllApis(codecs, "fooba", "Zm9vYmE=");
     try testAllApis(codecs, "foobar", "Zm9vYmFy");
+    try testAllApis(codecs, "foobarfoobarfoo", "Zm9vYmFyZm9vYmFyZm9v");
+    try testAllApis(codecs, "foobarfoobarfoob", "Zm9vYmFyZm9vYmFyZm9vYg==");
+    try testAllApis(codecs, "foobarfoobarfooba", "Zm9vYmFyZm9vYmFyZm9vYmE=");
+    try testAllApis(codecs, "foobarfoobarfoobar", "Zm9vYmFyZm9vYmFyZm9vYmFy");
 
     try testDecodeIgnoreSpace(codecs, "", " ");
     try testDecodeIgnoreSpace(codecs, "f", "Z g= =");
@@ -357,11 +412,23 @@ fn testBase64() !void {
     try testError(codecs, "A/==", error.InvalidPadding);
     try testError(codecs, "A===", error.InvalidPadding);
     try testError(codecs, "====", error.InvalidPadding);
+    try testError(codecs, "Zm9vYmFyZm9vYmFyA..A", error.InvalidCharacter);
+    try testError(codecs, "Zm9vYmFyZm9vYmFyAA=A", error.InvalidPadding);
+    try testError(codecs, "Zm9vYmFyZm9vYmFyAA/=", error.InvalidPadding);
+    try testError(codecs, "Zm9vYmFyZm9vYmFyA/==", error.InvalidPadding);
+    try testError(codecs, "Zm9vYmFyZm9vYmFyA===", error.InvalidPadding);
+    try testError(codecs, "A..AZm9vYmFyZm9vYmFy", error.InvalidCharacter);
+    try testError(codecs, "Zm9vYmFyZm9vAA=A", error.InvalidPadding);
+    try testError(codecs, "Zm9vYmFyZm9vAA/=", error.InvalidPadding);
+    try testError(codecs, "Zm9vYmFyZm9vA/==", error.InvalidPadding);
+    try testError(codecs, "Zm9vYmFyZm9vA===", error.InvalidPadding);
 
     try testNoSpaceLeftError(codecs, "AA==");
     try testNoSpaceLeftError(codecs, "AAA=");
     try testNoSpaceLeftError(codecs, "AAAA");
     try testNoSpaceLeftError(codecs, "AAAAAA==");
+
+    try testFourBytesDestNoSpaceLeftError(codecs, "AAAAAAAAAAAAAAAA");
 }
 
 fn testBase64UrlSafeNoPad() !void {
@@ -374,6 +441,7 @@ fn testBase64UrlSafeNoPad() !void {
     try testAllApis(codecs, "foob", "Zm9vYg");
     try testAllApis(codecs, "fooba", "Zm9vYmE");
     try testAllApis(codecs, "foobar", "Zm9vYmFy");
+    try testAllApis(codecs, "foobarfoobarfoobar", "Zm9vYmFyZm9vYmFyZm9vYmFy");
 
     try testDecodeIgnoreSpace(codecs, "", " ");
     try testDecodeIgnoreSpace(codecs, "f", "Z g ");
@@ -392,11 +460,15 @@ fn testBase64UrlSafeNoPad() !void {
     try testError(codecs, "A/==", error.InvalidCharacter);
     try testError(codecs, "A===", error.InvalidCharacter);
     try testError(codecs, "====", error.InvalidCharacter);
+    try testError(codecs, "Zm9vYmFyZm9vYmFyA..A", error.InvalidCharacter);
+    try testError(codecs, "A..AZm9vYmFyZm9vYmFy", error.InvalidCharacter);
 
     try testNoSpaceLeftError(codecs, "AA");
     try testNoSpaceLeftError(codecs, "AAA");
     try testNoSpaceLeftError(codecs, "AAAA");
     try testNoSpaceLeftError(codecs, "AAAAAA");
+
+    try testFourBytesDestNoSpaceLeftError(codecs, "AAAAAAAAAAAAAAAA");
 }
 
 fn testAllApis(codecs: Codecs, expected_decoded: []const u8, expected_encoded: []const u8) !void {
@@ -453,6 +525,15 @@ fn testNoSpaceLeftError(codecs: Codecs, encoded: []const u8) !void {
     const decoder_ignore_space = codecs.decoderWithIgnore(" ");
     var buffer: [0x100]u8 = undefined;
     var decoded = buffer[0 .. (try codecs.Decoder.calcSizeForSlice(encoded)) - 1];
+    if (decoder_ignore_space.decode(decoded, encoded)) |_| {
+        return error.ExpectedError;
+    } else |err| if (err != error.NoSpaceLeft) return err;
+}
+
+fn testFourBytesDestNoSpaceLeftError(codecs: Codecs, encoded: []const u8) !void {
+    const decoder_ignore_space = codecs.decoderWithIgnore(" ");
+    var buffer: [0x100]u8 = undefined;
+    var decoded = buffer[0..4];
     if (decoder_ignore_space.decode(decoded, encoded)) |_| {
         return error.ExpectedError;
     } else |err| if (err != error.NoSpaceLeft) return err;


### PR DESCRIPTION
Massively improves performance of encoding and decoding (~5+x faster for unencoded data >= 10 bytes long) via addition of fast loops at start of methods.

Does worsen memory usage of Decoder as now has to store a [4][256]u32 fast lookup array, but likely worthwhile for this performance increase - if wanting to provide a lower memory usage decoder, may be worth having a fast/slow variant.
Idea behind the fast lookup table is simply to store pre-shifted data as an int based on position in 4 byte block, then just need to bitwise OR each byte in block.
This fast lookup table is also currently being instantied for DecoderWithIgnore as this holds a Decoder despite not using the fast lookup - maybe worth separating these two to avoid this. I did attempt to improve ignore decoder using fast lookup table but worsens performance as no way around carrying out byte by byte checks here (unless you want to make some assumptions about ignore character density).

Can do with some thinking about testing still although these additions should be fairly safe as just "encode/decode simple data until need to handle last 4 bytes or find an invalid character".
 
Also wouldn't be surprised if lot more code in this repo could be improved via use of read/writeInt methods for working with multiple bytes, as this is pretty much responsible for entire encoding improvement.

ReleaseFast benchmark results - length is byte length of unencoded input:
```
-------------------------------------------------------
Benchmark                           Time     Iterations
-------------------------------------------------------
LENGTH = 1
ringbuffer/stdBase64Encode      0.473 ns     2920527750
ringbuffer/newEncode            0.471 ns     2968441751
ringbuffer/stdBase64Decode      0.323 ns     4444695492
ringbuffer/newDecode            0.315 ns     4447358763

LENGTH  = 5
ringbuffer/stdBase64Encode      0.577 ns     2482595234
ringbuffer/newEncode            0.575 ns     2433304640
ringbuffer/stdBase64Decode      0.335 ns     4341348888
ringbuffer/newDecode            0.481 ns     2965567120

LENGTH = 10
ringbuffer/stdBase64Encode      0.629 ns     2221372018
ringbuffer/newEncode            0.634 ns     2232671625
ringbuffer/stdBase64Decode       8.17 ns      168490999
ringbuffer/newDecode            0.782 ns     1786256635

LENGTH = 25
ringbuffer/stdBase64Encode       38.0 ns       36765244
ringbuffer/newEncode            0.906 ns     1559694087
ringbuffer/stdBase64Decode       29.9 ns       44287977
ringbuffer/newDecode             7.95 ns      175760696


LENGTH = 100
ringbuffer/stdBase64Encode        157 ns        8190325
ringbuffer/newEncode             29.8 ns       46469789
ringbuffer/stdBase64Decode        132 ns       10556440
ringbuffer/newDecode             32.5 ns       43006574


LENGTH = 500
ringbuffer/stdBase64Encode        770 ns        1391510
ringbuffer/jdzEncode              153 ns        8701279
ringbuffer/stdBase64Decode        678 ns        2066127
ringbuffer/jdzDecode              168 ns        8389837

LENGTH = 1000
ringbuffer/stdBase64Encode       1530 ns         831907
ringbuffer/jdzEncode              315 ns        4509426
ringbuffer/stdBase64Decode       1388 ns        1001302
ringbuffer/jdzDecode              338 ns        4136550
```

will have a look at doing this via vector api soon