### PR TITLE
Sema: fix crash when coercion dest is var args

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9846,11 +9846,19 @@ fn analyzeAs(
     const mod = sema.mod;
     const operand = try sema.resolveInst(zir_operand);
     if (zir_dest_type == .var_args_param_type) return operand;
-    const dest_ty = sema.resolveType(block, src, zir_dest_type) catch |err| switch (err) {
+    const operand_air_inst = sema.resolveInst(zir_dest_type) catch |err| switch (err) {
         error.GenericPoison => return operand,
         else => |e| return e,
     };
-    if (dest_ty.zigTypeTag(mod) == .NoReturn) {
+    if (operand_air_inst == .var_args_param_type) return operand;
+    const dest_ty = sema.analyzeAsType(block, src, operand_air_inst) catch |err| switch (err) {
+        error.GenericPoison => return operand,
+        else => |e| return e,
+    };
+    const dest_ty_tag = dest_ty.zigTypeTagOrPoison(mod) catch |err| switch (err) {
+        error.GenericPoison => return operand,
+    };
+    if (dest_ty_tag == .NoReturn) {
         return sema.fail(block, src, "cannot cast to noreturn", .{});
     }
     const is_ret = if (Zir.refToIndex(zir_dest_type)) |ptr_index|

--- a/test/behavior/var_args.zig
+++ b/test/behavior/var_args.zig
@@ -150,6 +150,15 @@ test "simple variadic function" {
     try std.testing.expectEqual(@as(c_int, 0), S.add(0));
     try std.testing.expectEqual(@as(c_int, 1), S.add(1, @as(c_int, 1)));
     try std.testing.expectEqual(@as(c_int, 3), S.add(2, @as(c_int, 1), @as(c_int, 2)));
+
+    {
+        // Test type coercion of a var args argument.
+        // Originally reported at https://github.com/ziglang/zig/issues/16197
+        var runtime: bool = true;
+        var a: i32 = 1;
+        var b: i32 = 2;
+        try expect(1 == S.add(1, if (runtime) a else b));
+    }
 }
 
 test "variadic functions" {


### PR DESCRIPTION
When analyzing the `as` ZIR instruction, an assertion would trip if the result type was a var args function argument. The fix is simple: inline a little bit of the `resolveType` logic into `analyzeAs` to make it detect this situation - which it was already attempting to do.

Closes #16197