### PR TITLE
fix translate-c crash

### DIFF
--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -4150,4 +4150,18 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         ,
         \\pub export var struct_foo: [*c]const u8 = "hello world";
     });
+
+    cases.add("unsupport declare statement at the last of a compound statement which belongs to a statement expr",
+        \\void somefunc(void) {
+        \\  int y;
+        \\  (void)({y=1; _Static_assert(1);});
+        \\}
+    , &[_][]const u8{
+        \\pub export fn somefunc() void {
+        \\    var y: c_int = undefined;
+        \\    _ = blk: {
+        \\        y = 1;
+        \\    };
+        \\}
+    });
 }


### PR DESCRIPTION
fix #17098 

If transStmt fails to translate the last statement inside a StmtExpr, zig will cash.
This PR fixes this.