### PR TITLE
docs: update build.zig examples from current stdlib

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10759,6 +10759,9 @@ const separator = if (builtin.os.tag == .windows) '\\' else '/';
       {#code_begin|syntax|build_executable#}
 const std = @import("std");
 
+// Although this function looks imperative, note that its job is to
+// declaratively construct a build graph that will be executed by an external
+// runner.
 pub fn build(b: *std.Build) void {
     // Standard target options allows the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which
@@ -10773,20 +10776,56 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "example",
+        // In this case the main source file is merely a path, however, in more
+        // complicated build scripts, this could be a generated file.
         .root_source_file = .{ .path = "src/main.zig" },
         .target = target,
         .optimize = optimize,
     });
-    exe.install();
 
-    const run_cmd = exe.run();
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+
+    // By making the run step depend on the install step, it will be run from the
+    // installation directory rather than directly from within the cache directory.
+    // This is not necessary, however, if the application depends on other installed
+    // files, this ensures they will be present and in the expected location.
     run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
     if (b.args) |args| {
         run_cmd.addArgs(args);
     }
 
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
+
+    // Creates a step for unit testing. This only builds the test executable
+    // but does not run it.
+    const unit_tests = b.addTest(.{
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_unit_tests.step);
 }
       {#code_end#}
       {#header_close#}
@@ -10798,21 +10837,31 @@ pub fn build(b: *std.Build) void {
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+
     const lib = b.addStaticLibrary(.{
         .name = "example",
         .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
         .optimize = optimize,
     });
-    lib.install();
+
+    // This declares intent for the library to be installed into the standard
+    // location when the user invokes the "install" step (the default step when
+    // running `zig build`).
+    b.installArtifact(lib);
 
     const main_tests = b.addTest(.{
         .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
         .optimize = optimize,
     });
 
+    const run_main_tests = b.addRunArtifact(main_tests);
+
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+    test_step.dependOn(&run_main_tests.step);
 }
       {#code_end#}
       {#header_close#}


### PR DESCRIPTION
I was learning the Zig build system and noticed the `build.zig` examples presented in the documentation are out of date and do not compile on zig 0.11.0 through current master due to the deprecation of the `.run()` and `.install()` methods.

This PR copies the current `build.zig` files into the docs from master, allowing the documented versions to compile on the current version of zig. I left the comments in the executable example because I found them helpful. I removed the duplicate comments from the library example.

The same error exists on the rendered [0.11.0 docs](https://github.com/ziglang/www.ziglang.org/blob/master/content/documentation/0.11.0/index.html#L12923-L12983). I would be happy to open a PR there as well.