### PR TITLE
wasm codegen fixes 

### DIFF
--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3602,11 +3602,6 @@ fn cmp(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: std.math.CompareO
         return func.cmpBigInt(lhs, rhs, ty, op);
     }
 
-    // ensure that when we compare pointers, we emit
-    // the true pointer of a stack value, rather than the stack pointer.
-    try func.lowerToStack(lhs);
-    try func.lowerToStack(rhs);
-
     const signedness: std.builtin.Signedness = blk: {
         // by default we tell the operand type is unsigned (i.e. bools and enum values)
         if (ty.zigTypeTag(mod) != .Int) break :blk .unsigned;
@@ -3614,6 +3609,30 @@ fn cmp(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: std.math.CompareO
         // incase of an actual integer, we emit the correct signedness
         break :blk ty.intInfo(mod).signedness;
     };
+    const extend_sign = blk: {
+        // do we need to extend the sign bit?
+        if (signedness != .signed) break :blk false;
+        if (op == .eq or op == .neq) break :blk false;
+        const int_bits = ty.intInfo(mod).bits;
+        const wasm_bits = toWasmBits(int_bits) orelse unreachable;
+        break :blk (wasm_bits != int_bits);
+    };
+
+    const lhs_wasm = if (extend_sign)
+        try func.signExtendInt(lhs, ty)
+    else
+        lhs;
+
+    const rhs_wasm = if (extend_sign)
+        try func.signExtendInt(rhs, ty)
+    else
+        rhs;
+
+    // ensure that when we compare pointers, we emit
+    // the true pointer of a stack value, rather than the stack pointer.
+    try func.lowerToStack(lhs_wasm);
+    try func.lowerToStack(rhs_wasm);
+
     const opcode: wasm.Opcode = buildOpcode(.{
         .valtype1 = typeToValtype(ty, mod),
         .op = switch (op) {
@@ -6920,12 +6939,13 @@ fn signedSat(func: *CodeGen, lhs_operand: WValue, rhs_operand: WValue, ty: Type,
     const int_info = ty.intInfo(mod);
     const wasm_bits = toWasmBits(int_info.bits).?;
     const is_wasm_bits = wasm_bits == int_info.bits;
+    const ext_ty = if (!is_wasm_bits) try mod.intType(int_info.signedness, wasm_bits) else ty;
 
     var lhs = if (!is_wasm_bits) lhs: {
-        break :lhs try (try func.signExtendInt(lhs_operand, ty)).toLocal(func, ty);
+        break :lhs try (try func.signExtendInt(lhs_operand, ty)).toLocal(func, ext_ty);
     } else lhs_operand;
     var rhs = if (!is_wasm_bits) rhs: {
-        break :rhs try (try func.signExtendInt(rhs_operand, ty)).toLocal(func, ty);
+        break :rhs try (try func.signExtendInt(rhs_operand, ty)).toLocal(func, ext_ty);
     } else rhs_operand;
 
     const max_val: u64 = @as(u64, @intCast((@as(u65, 1) << @as(u7, @intCast(int_info.bits - 1))) - 1));
@@ -6941,20 +6961,20 @@ fn signedSat(func: *CodeGen, lhs_operand: WValue, rhs_operand: WValue, ty: Type,
         else => unreachable,
     };
 
-    var bin_result = try (try func.binOp(lhs, rhs, ty, op)).toLocal(func, ty);
+    var bin_result = try (try func.binOp(lhs, rhs, ext_ty, op)).toLocal(func, ext_ty);
     if (!is_wasm_bits) {
         defer bin_result.free(func); // not returned in this branch
         defer lhs.free(func); // uses temporary local for absvalue
         defer rhs.free(func); // uses temporary local for absvalue
         try func.emitWValue(bin_result);
         try func.emitWValue(max_wvalue);
-        _ = try func.cmp(bin_result, max_wvalue, ty, .lt);
+        _ = try func.cmp(bin_result, max_wvalue, ext_ty, .lt);
         try func.addTag(.select);
         try func.addLabel(.local_set, bin_result.local.value); // re-use local
 
         try func.emitWValue(bin_result);
         try func.emitWValue(min_wvalue);
-        _ = try func.cmp(bin_result, min_wvalue, ty, .gt);
+        _ = try func.cmp(bin_result, min_wvalue, ext_ty, .gt);
         try func.addTag(.select);
         try func.addLabel(.local_set, bin_result.local.value); // re-use local
         return (try func.wrapOperand(bin_result, ty)).toLocal(func, ty);
@@ -7036,12 +7056,13 @@ fn airShlSat(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
             64 => WValue{ .imm64 = shift_size },
             else => unreachable,
         };
+        const ext_ty = try mod.intType(int_info.signedness, wasm_bits);
 
-        var shl_res = try (try func.binOp(lhs, shift_value, ty, .shl)).toLocal(func, ty);
+        var shl_res = try (try func.binOp(lhs, shift_value, ext_ty, .shl)).toLocal(func, ext_ty);
         defer shl_res.free(func);
-        var shl = try (try func.binOp(shl_res, rhs, ty, .shl)).toLocal(func, ty);
+        var shl = try (try func.binOp(shl_res, rhs, ext_ty, .shl)).toLocal(func, ext_ty);
         defer shl.free(func);
-        var shr = try (try func.binOp(shl, rhs, ty, .shr)).toLocal(func, ty);
+        var shr = try (try func.binOp(shl, rhs, ext_ty, .shr)).toLocal(func, ext_ty);
         defer shr.free(func);
 
         switch (wasm_bits) {
@@ -7053,7 +7074,7 @@ fn airShlSat(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
                 try func.addImm32(std.math.minInt(i32));
                 try func.addImm32(std.math.maxInt(i32));
-                _ = try func.cmp(shl_res, .{ .imm32 = 0 }, ty, .lt);
+                _ = try func.cmp(shl_res, .{ .imm32 = 0 }, ext_ty, .lt);
                 try func.addTag(.select);
             },
             64 => blk: {
@@ -7064,16 +7085,16 @@ fn airShlSat(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
                 try func.addImm64(@as(u64, @bitCast(@as(i64, std.math.minInt(i64)))));
                 try func.addImm64(@as(u64, @bitCast(@as(i64, std.math.maxInt(i64)))));
-                _ = try func.cmp(shl_res, .{ .imm64 = 0 }, ty, .lt);
+                _ = try func.cmp(shl_res, .{ .imm64 = 0 }, ext_ty, .lt);
                 try func.addTag(.select);
             },
             else => unreachable,
         }
         try func.emitWValue(shl);
-        _ = try func.cmp(shl_res, shr, ty, .neq);
+        _ = try func.cmp(shl_res, shr, ext_ty, .neq);
         try func.addTag(.select);
         try func.addLabel(.local_set, result.local.value);
-        var shift_result = try func.binOp(result, shift_value, ty, .shr);
+        var shift_result = try func.binOp(result, shift_value, ext_ty, .shr);
         if (is_signed) {
             shift_result = try func.wrapOperand(shift_result, ty);
         }

--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -571,7 +571,6 @@ fn overaligned_fn() align(0x1000) i32 {
 test "comptime alloc alignment" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -1172,3 +1172,51 @@ test "pointer to struct literal with runtime field is constant" {
     const ptr = &S{ .data = runtime_zero };
     try expect(@typeInfo(@TypeOf(ptr)).Pointer.is_const);
 }
+
+test "integer compare" {
+    const S = struct {
+        fn doTheTestSigned(comptime T: type) !void {
+            var z: T = 0;
+            var p: T = 123;
+            var n: T = -123;
+            try expect(z == z and z != p and z != n);
+            try expect(p == p and p != n and n == n);
+            try expect(z > n and z < p and z >= n and z <= p);
+            try expect(!(z < n or z > p or z <= n or z >= p or z > z or z < z));
+            try expect(p > n and n < p and p >= n and n <= p and p >= p and p <= p and n >= n and n <= n);
+            try expect(!(p < n or n > p or p <= n or n >= p or p > p or p < p or n > n or n < n));
+            try expect(z == 0 and z != 123 and z != -123 and 0 == z and 0 != p and 0 != n);
+            try expect(z > -123 and p > -123 and !(n > 123));
+            try expect(z < 123 and !(p < 123) and n < 123);
+            try expect(-123 <= z and -123 <= p and -123 <= n);
+            try expect(123 >= z and 123 >= p and 123 >= n);
+            try expect(!(0 != z or 123 != p or -123 != n));
+            try expect(!(z > 0 or -123 > p or 123 < n));
+        }
+        fn doTheTestUnsigned(comptime T: type) !void {
+            var z: T = 0;
+            var p: T = 123;
+            try expect(z == z and z != p);
+            try expect(p == p);
+            try expect(z < p and z <= p);
+            try expect(!(z > p or z >= p or z > z or z < z));
+            try expect(p >= p and p <= p);
+            try expect(!(p > p or p < p));
+            try expect(z == 0 and z != 123 and z != -123 and 0 == z and 0 != p);
+            try expect(z > -123 and p > -123);
+            try expect(z < 123 and !(p < 123));
+            try expect(-123 <= z and -123 <= p);
+            try expect(123 >= z and 123 >= p);
+            try expect(!(0 != z or 123 != p));
+            try expect(!(z > 0 or -123 > p));
+        }
+    };
+    inline for (.{ u8, u16, u32, u64, usize, u10, u20, u30, u60 }) |T| {
+        try S.doTheTestUnsigned(T);
+        try comptime S.doTheTestUnsigned(T);
+    }
+    inline for (.{ i8, i16, i32, i64, isize, i10, i20, i30, i60 }) |T| {
+        try S.doTheTestSigned(T);
+        try comptime S.doTheTestSigned(T);
+    }
+}

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -38,7 +38,6 @@ test "truncate to non-power-of-two integers" {
 }
 
 test "truncate to non-power-of-two integers from 128-bit" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -398,7 +397,6 @@ test "array 2D const double ptr" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const rect_2d_vertexes = [_][1]f32{

--- a/test/behavior/bugs/10684.zig
+++ b/test/behavior/bugs/10684.zig
@@ -3,7 +3,6 @@ const builtin = @import("builtin");
 const expectEqualStrings = std.testing.expectEqualStrings;
 
 test "slicing slices" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/11787.zig
+++ b/test/behavior/bugs/11787.zig
@@ -3,7 +3,6 @@ const builtin = @import("builtin");
 const testing = std.testing;
 
 test "slicing zero length array field of struct" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/11995.zig
+++ b/test/behavior/bugs/11995.zig
@@ -17,7 +17,6 @@ const wuffs_base__slice_u8 = extern struct {
     len: usize,
 };
 test {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/12000.zig
+++ b/test/behavior/bugs/12000.zig
@@ -6,7 +6,6 @@ const T = struct {
 };
 
 test {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/12051.zig
+++ b/test/behavior/bugs/12051.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 test {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/12092.zig
+++ b/test/behavior/bugs/12092.zig
@@ -14,7 +14,6 @@ fn takeFoo(foo: *const Foo) !void {
 }
 
 test {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/12119.zig
+++ b/test/behavior/bugs/12119.zig
@@ -5,7 +5,6 @@ const u8x32 = @Vector(32, u8);
 const u32x8 = @Vector(8, u32);
 
 test {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/12450.zig
+++ b/test/behavior/bugs/12450.zig
@@ -9,7 +9,6 @@ const Foo = packed struct {
 var buffer: [256]u8 = undefined;
 
 test {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/12680.zig
+++ b/test/behavior/bugs/12680.zig
@@ -8,7 +8,6 @@ extern fn test_func() callconv(.C) usize;
 test "export a function twice" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;

--- a/test/behavior/bugs/13068.zig
+++ b/test/behavior/bugs/13068.zig
@@ -7,7 +7,6 @@ var list = std.ArrayList(u32).init(allocator);
 test {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 

--- a/test/behavior/bugs/13366.zig
+++ b/test/behavior/bugs/13366.zig
@@ -13,7 +13,6 @@ const Block = struct {
 };
 
 test {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/1741.zig
+++ b/test/behavior/bugs/1741.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 test "fixed" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;

--- a/test/behavior/bugs/1851.zig
+++ b/test/behavior/bugs/1851.zig
@@ -3,7 +3,6 @@ const std = @import("std");
 const expect = std.testing.expect;
 
 test "allocation and looping over 3-byte integer" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/2622.zig
+++ b/test/behavior/bugs/2622.zig
@@ -3,7 +3,6 @@ const builtin = @import("builtin");
 var buf: []u8 = undefined;
 
 test "reslice of undefined global var slice" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/2727.zig
+++ b/test/behavior/bugs/2727.zig
@@ -5,7 +5,6 @@ fn t() bool {
 }
 
 test {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/6047.zig
+++ b/test/behavior/bugs/6047.zig
@@ -10,7 +10,6 @@ fn getError2() !void {
 }
 
 test "`try`ing an if/else expression" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/6905.zig
+++ b/test/behavior/bugs/6905.zig
@@ -2,7 +2,6 @@ const expect = @import("std").testing.expect;
 const builtin = @import("builtin");
 
 test "sentinel-terminated 0-length slices" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/6947.zig
+++ b/test/behavior/bugs/6947.zig
@@ -5,7 +5,6 @@ fn destroy(ptr: *void) void {
 }
 
 test {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/7325.zig
+++ b/test/behavior/bugs/7325.zig
@@ -78,7 +78,6 @@ fn genExpression(expr: Expression) !ExpressionResult {
 }
 
 test {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/8646.zig
+++ b/test/behavior/bugs/8646.zig
@@ -7,7 +7,6 @@ const array = [_][]const []const u8{
 };
 
 test {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/bugs/920.zig
+++ b/test/behavior/bugs/920.zig
@@ -57,7 +57,6 @@ const NormalDist = blk: {
 };
 
 test "bug 920 fixed" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1544,7 +1544,6 @@ test "implicit cast from [:0]T to [*c]T" {
 
 test "bitcast packed struct with u0" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
 
     const S = packed struct(u2) { a: u0, b: u2 };
     const s = @as(S, @bitCast(@as(u2, 2)));
@@ -1572,7 +1571,6 @@ test "single item pointer to pointer to array to slice" {
 }
 
 test "peer type resolution forms error union" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     var foo: i32 = 123;
@@ -1611,7 +1609,6 @@ test "coercion from single-item pointer to @as to slice" {
 test "peer type resolution: const sentinel slice and mutable non-sentinel slice" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -1641,7 +1638,6 @@ test "peer type resolution: float and comptime-known fixed-width integer" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -1663,7 +1659,6 @@ test "peer type resolution: float and comptime-known fixed-width integer" {
 test "peer type resolution: same array type with sentinel" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -1685,7 +1680,6 @@ test "peer type resolution: same array type with sentinel" {
 test "peer type resolution: array with sentinel and array without sentinel" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -1707,7 +1701,6 @@ test "peer type resolution: array with sentinel and array without sentinel" {
 test "peer type resolution: array and vector with same child type" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -1752,7 +1745,6 @@ test "peer type resolution: array with smaller child type and vector with larger
 test "peer type resolution: error union and optional of same type" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -1775,7 +1767,6 @@ test "peer type resolution: error union and optional of same type" {
 test "peer type resolution: C pointer and @TypeOf(null)" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -1797,7 +1788,6 @@ test "peer type resolution: C pointer and @TypeOf(null)" {
 test "peer type resolution: three-way resolution combines error set and optional" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -1861,7 +1851,6 @@ test "peer type resolution: vector and optional vector" {
 test "peer type resolution: optional fixed-width int and comptime_int" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -1883,7 +1872,6 @@ test "peer type resolution: optional fixed-width int and comptime_int" {
 test "peer type resolution: array and tuple" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -1971,7 +1959,6 @@ test "peer type resolution: vector and array and tuple" {
 test "peer type resolution: empty tuple pointer and slice" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -1992,7 +1979,6 @@ test "peer type resolution: empty tuple pointer and slice" {
 test "peer type resolution: tuple pointer and slice" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -2013,7 +1999,6 @@ test "peer type resolution: tuple pointer and slice" {
 test "peer type resolution: tuple pointer and optional slice" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -2034,7 +2019,6 @@ test "peer type resolution: tuple pointer and optional slice" {
 test "peer type resolution: many compatible pointers" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -2100,7 +2084,6 @@ test "peer type resolution: many compatible pointers" {
 test "peer type resolution: tuples with comptime fields" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -2132,7 +2115,6 @@ test "peer type resolution: tuples with comptime fields" {
 test "peer type resolution: C pointer and many pointer" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -2155,7 +2137,6 @@ test "peer type resolution: C pointer and many pointer" {
 test "peer type resolution: pointer attributes are combined correctly" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -2199,7 +2180,6 @@ test "peer type resolution: pointer attributes are combined correctly" {
 test "cast builtins can wrap result in optional" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -2238,7 +2218,6 @@ test "cast builtins can wrap result in optional" {
 test "cast builtins can wrap result in error union" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     const S = struct {
@@ -2277,7 +2256,6 @@ test "cast builtins can wrap result in error union" {
 test "cast builtins can wrap result in error union and optional" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
 
@@ -2443,7 +2421,6 @@ test "@intFromBool on vector" {
 }
 
 test "numeric coercions with undefined" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
@@ -2465,7 +2442,6 @@ test "15-bit int to float" {
 }
 
 test "@as does not corrupt values with incompatible representations" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -2483,7 +2459,6 @@ test "@as does not corrupt values with incompatible representations" {
 }
 
 test "result information is preserved through many nested structures" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO

--- a/test/behavior/int_div.zig
+++ b/test/behavior/int_div.zig
@@ -4,7 +4,6 @@ const expect = std.testing.expect;
 
 test "integer division" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -409,7 +409,6 @@ fn testBinaryNot128(comptime Type: type, x: Type) !void {
 }
 
 test "division" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -190,7 +190,6 @@ test "compare equality of optional and non-optional pointer" {
 
 test "allowzero pointer and slice" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
@@ -347,7 +346,6 @@ test "pointer sentinel with optional element" {
 test "pointer sentinel with +inf" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     const S = struct {

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1091,7 +1091,6 @@ test "type coercion of pointer to anon struct literal to pointer to struct" {
 
 test "packed struct with undefined initializers" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
@@ -1650,7 +1649,6 @@ test "instantiate struct with comptime field" {
 
 test "struct field pointer has correct alignment" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -1682,7 +1680,6 @@ test "struct field pointer has correct alignment" {
 
 test "extern struct field pointer has correct alignment" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO

--- a/test/behavior/translate_c_macros.zig
+++ b/test/behavior/translate_c_macros.zig
@@ -54,7 +54,6 @@ test "reference to a struct type" {
 }
 
 test "cast negative integer to pointer" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -64,7 +63,6 @@ test "cast negative integer to pointer" {
 }
 
 test "casting to union with a macro" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -81,7 +79,6 @@ test "casting to union with a macro" {
 }
 
 test "casting or calling a value with a paren-surrounded macro" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -101,7 +98,6 @@ test "casting or calling a value with a paren-surrounded macro" {
 }
 
 test "nested comma operator" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -112,7 +108,6 @@ test "nested comma operator" {
 }
 
 test "cast functions" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -136,7 +131,6 @@ test "large integer macro" {
 }
 
 test "string literal macro with embedded tab character" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -146,7 +140,6 @@ test "string literal macro with embedded tab character" {
 }
 
 test "string and char literals that are not UTF-8 encoded. Issue #12784" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO

--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -379,7 +379,6 @@ test "tuple of struct concatenation and coercion to array" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 

--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -456,7 +456,6 @@ test "coerce anon tuple to tuple" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     var x: u8 = 1;
     var y: u16 = 2;

--- a/test/behavior/type.zig
+++ b/test/behavior/type.zig
@@ -199,7 +199,6 @@ test "Type.ErrorUnion" {
 }
 
 test "Type.Opaque" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -383,7 +382,6 @@ test "Type.Enum" {
 }
 
 test "Type.Union" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -1534,7 +1534,6 @@ test "coerce enum literal to union in result loc" {
 
 test "defined-layout union field pointer has correct alignment" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -1571,7 +1570,6 @@ test "defined-layout union field pointer has correct alignment" {
 
 test "undefined-layout union field pointer has correct alignment" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -1608,7 +1606,6 @@ test "undefined-layout union field pointer has correct alignment" {
 
 test "packed union field pointer has correct alignment" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO


### PR DESCRIPTION
```zig
test {
    var a: i32 = -12345;
    var b: i64 = -12345;
    const c: i21 = @intCast(b);
    const d: i60 = c;
    std.debug.print("{} {} {} {}\n", .{c, b, a, d});
}
``` 

previously: 
> `12345 -53017076301825 -12345 4539230677105560`

now:
> `-12345 -12345 -12345 -12345` 


in addition, enable more tests: 1543 -> 1611 passed
