### PR TITLE
Fix some frameworks not linking macos

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -707,6 +707,17 @@ fn accessLibPath(
         return true;
     }
 
+    noextension: {
+        test_path.clearRetainingCapacity();
+        try test_path.writer().print("{s}" ++ sep ++ "{s}", .{ search_dir, lib_name });
+        try checked_paths.append(try gpa.dupe(u8, test_path.items));
+        fs.cwd().access(test_path.items, .{}) catch |err| switch (err) {
+            error.FileNotFound => break :noextension,
+            else => |e| return e,
+        };
+        return true;
+    }
+
     return false;
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -6929,9 +6929,9 @@ fn accessFrameworkPath(
 ) !bool {
     const sep = fs.path.sep_str;
 
-    for (&[_][]const u8{ "tbd", "dylib" }) |ext| {
+    for (&[_][]const u8{ ".tbd", ".dylib", "" }) |ext| {
         test_path.clearRetainingCapacity();
-        try test_path.writer().print("{s}" ++ sep ++ "{s}.framework" ++ sep ++ "{s}.{s}", .{
+        try test_path.writer().print("{s}" ++ sep ++ "{s}.framework" ++ sep ++ "{s}{s}", .{
             framework_dir_path,
             framework_name,
             framework_name,


### PR DESCRIPTION
Pull request #16888 removed searching for libraries with no extensions when linking frameworks... this adds that feature back.

This fixes #17294.