### PR TITLE
Make distinct error limit configurable

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -735,6 +735,7 @@ pub const InitOptions = struct {
     pdb_source_path: ?[]const u8 = null,
     /// (Windows) PDB output path
     pdb_out_path: ?[]const u8 = null,
+    error_limit: ?Module.ErrorInt = null,
 };
 
 fn addModuleTableToCacheHash(
@@ -1414,6 +1415,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
                 .local_zir_cache = local_zir_cache,
                 .emit_h = emit_h,
                 .tmp_hack_arena = std.heap.ArenaAllocator.init(gpa),
+                .error_limit = options.error_limit orelse (std.math.maxInt(u16) - 1),
             };
             try module.init();
 
@@ -2458,6 +2460,7 @@ fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifes
         man.hash.add(comp.bin_file.options.skip_linker_dependencies);
         man.hash.add(comp.bin_file.options.parent_compilation_link_libc);
         man.hash.add(mod.emit_h != null);
+        man.hash.add(mod.error_limit);
     }
 
     try man.addOptionalFile(comp.bin_file.options.linker_script);
@@ -2831,6 +2834,10 @@ pub fn totalErrorCount(self: *Compilation) u32 {
                 }
             }
         }
+
+        if (module.global_error_set.entries.len - 1 > module.error_limit) {
+            total += 1;
+        }
     }
 
     // The "no entry point found" error only counts if there are no semantic analysis errors.
@@ -2980,6 +2987,22 @@ pub fn getAllErrorsAlloc(self: *Compilation) !ErrorBundle {
         }
         for (module.failed_exports.values()) |value| {
             try addModuleErrorMsg(module, &bundle, value.*);
+        }
+
+        const actual_error_count = module.global_error_set.entries.len - 1;
+        if (actual_error_count > module.error_limit) {
+            try bundle.addRootErrorMessage(.{
+                .msg = try bundle.printString("module used more errors than possible: used {d}, max {d}", .{
+                    actual_error_count, module.error_limit,
+                }),
+                .notes_len = 1,
+            });
+            const notes_start = try bundle.reserveNotes(1);
+            bundle.extra.items[notes_start] = @intFromEnum(try bundle.addErrorMessage(.{
+                .msg = try bundle.printString("use '--error-limit {d}' to increase limit", .{
+                    actual_error_count,
+                }),
+            }));
         }
     }
 

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -137,6 +137,9 @@ deletion_set: std.AutoArrayHashMapUnmanaged(Decl.Index, void) = .{},
 /// Key is the error name, index is the error tag value. Index 0 has a length-0 string.
 global_error_set: GlobalErrorSet = .{},
 
+/// Maximum amount of distinct error values, set by --error-limit
+error_limit: ErrorInt,
+
 /// Incrementing integer used to compare against the corresponding Decl
 /// field to determine whether a Decl's status applies to an ongoing update, or a
 /// previous analysis.
@@ -5018,6 +5021,11 @@ pub fn getErrorValueFromSlice(
 ) Allocator.Error!ErrorInt {
     const interned_name = try mod.intern_pool.getOrPutString(mod.gpa, name);
     return getErrorValue(mod, interned_name);
+}
+
+pub fn errorSetBits(mod: *Module) u16 {
+    if (mod.error_limit == 0) return 0;
+    return std.math.log2_int_ceil(ErrorInt, mod.error_limit + 1); // +1 for no error
 }
 
 pub fn createAnonymousDecl(mod: *Module, block: *Sema.Block, typed_value: TypedValue) !Decl.Index {

--- a/src/main.zig
+++ b/src/main.zig
@@ -420,6 +420,7 @@ const usage_build_generic =
     \\  --deps [dep],[dep],...    Set dependency names for the root package
     \\      dep:  [[import=]name]
     \\  --main-mod-path           Set the directory of the root module
+    \\  --error-limit [num]       Set the maximum amount of distinct error values
     \\  -fPIC                     Force-enable Position Independent Code
     \\  -fno-PIC                  Force-disable Position Independent Code
     \\  -fPIE                     Force-enable Position Independent Executable
@@ -921,6 +922,8 @@ fn buildOutputType(
     var error_tracing: ?bool = null;
     var pdb_out_path: ?[]const u8 = null;
     var dwarf_format: ?std.dwarf.Format = null;
+    var error_limit: ?Module.ErrorInt = null;
+
     // e.g. -m3dnow or -mno-outline-atomics. They correspond to std.Target llvm cpu feature names.
     // This array is populated by zig cc frontend and then has to be converted to zig-style
     // CPU features.
@@ -1049,6 +1052,11 @@ fn buildOutputType(
                         root_deps_str = args_iter.nextOrFatal();
                     } else if (mem.eql(u8, arg, "--main-mod-path")) {
                         main_mod_path = args_iter.nextOrFatal();
+                    } else if (mem.eql(u8, arg, "--error-limit")) {
+                        const next_arg = args_iter.nextOrFatal();
+                        error_limit = std.fmt.parseUnsigned(Module.ErrorInt, next_arg, 0) catch |err| {
+                            fatal("unable to parse error limit '{s}': {s}", .{ next_arg, @errorName(err) });
+                        };
                     } else if (mem.eql(u8, arg, "-cflags")) {
                         extra_cflags.shrinkRetainingCapacity(0);
                         while (true) {
@@ -3538,6 +3546,7 @@ fn buildOutputType(
         .reference_trace = reference_trace,
         .error_tracing = error_tracing,
         .pdb_out_path = pdb_out_path,
+        .error_limit = error_limit,
     }) catch |err| switch (err) {
         error.LibCUnavailable => {
             const target = target_info.target;


### PR DESCRIPTION
I chose to use a CLI argument instead of a const in the root file since changing it would invalidate most functions in an incremental compilation.

Closes #786