### PR TITLE
Sema: disallow @intFromPtr to accept comptime-only types

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9892,7 +9892,7 @@ fn zirIntFromPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
         return sema.fail(block, ptr_src, "expected pointer, found '{}'", .{ptr_ty.fmt(mod)});
     }
     const pointee_ty = ptr_ty.childType(mod);
-    if (try sema.typeRequiresComptime(pointee_ty)) {
+    if (try sema.typeRequiresComptime(ptr_ty)) {
         const msg = msg: {
             const msg = try sema.errMsg(block, ptr_src, "cannot accept pointer to comptime-only type '{}'", .{pointee_ty.fmt(mod)});
             errdefer msg.destroy(sema.gpa);

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9894,7 +9894,7 @@ fn zirIntFromPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
     const pointee_ty = ptr_ty.childType(mod);
     if (try sema.typeRequiresComptime(ptr_ty)) {
         const msg = msg: {
-            const msg = try sema.errMsg(block, ptr_src, "cannot accept pointer to comptime-only type '{}'", .{pointee_ty.fmt(mod)});
+            const msg = try sema.errMsg(block, ptr_src, "comptime-only type '{}' has no pointer address", .{pointee_ty.fmt(mod)});
             errdefer msg.destroy(sema.gpa);
             const src_decl = mod.declPtr(block.src_decl);
             try sema.explainWhyTypeIsComptime(msg, ptr_src.toSrcLoc(src_decl, mod), pointee_ty);

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -507,23 +507,6 @@ test "ptrCast comptime known slice to C pointer" {
     try std.testing.expectEqualStrings(s, std.mem.sliceTo(p, 0));
 }
 
-test "intFromPtr on a generic function" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-
-    const S = struct {
-        fn generic(i: anytype) @TypeOf(i) {
-            return i;
-        }
-        fn doTheTest(a: anytype) !void {
-            try expect(@intFromPtr(a) != 0);
-        }
-    };
-    try S.doTheTest(&S.generic);
-}
-
 test "pointer alignment and element type include call expression" {
     const S = struct {
         fn T() type {

--- a/test/cases/compile_errors/@intFromPtr_with_bad_type.zig
+++ b/test/cases/compile_errors/@intFromPtr_with_bad_type.zig
@@ -8,4 +8,4 @@ pub export fn entry() void {
 // backend=stage2
 // target=native
 //
-// :2:23: error: "comptime-only type 'comptime_int' has no pointer address
+// :2:23: error: comptime-only type 'comptime_int' has no pointer address

--- a/test/cases/compile_errors/@intFromPtr_with_bad_type.zig
+++ b/test/cases/compile_errors/@intFromPtr_with_bad_type.zig
@@ -1,0 +1,11 @@
+const x = 42;
+const y = @intFromPtr(&x);
+pub export fn entry() void {
+    _ = y;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:27: error: cannot accept pointer to comptime-only type 'comptime_int'

--- a/test/cases/compile_errors/@intFromPtr_with_bad_type.zig
+++ b/test/cases/compile_errors/@intFromPtr_with_bad_type.zig
@@ -8,4 +8,4 @@ pub export fn entry() void {
 // backend=stage2
 // target=native
 //
-// :2:23: error: cannot accept pointer to comptime-only type 'comptime_int'
+// :2:23: error: "comptime-only type 'comptime_int' has no pointer address

--- a/test/cases/compile_errors/@intFromPtr_with_bad_type.zig
+++ b/test/cases/compile_errors/@intFromPtr_with_bad_type.zig
@@ -8,4 +8,4 @@ pub export fn entry() void {
 // backend=stage2
 // target=native
 //
-// :2:27: error: cannot accept pointer to comptime-only type 'comptime_int'
+// :2:23: error: cannot accept pointer to comptime-only type 'comptime_int'


### PR DESCRIPTION
It would make a lot more sense if we prevented it from accepting pointers to comptime-only types.