### PR TITLE
Add argument asserts to copyForwards and copyBackwards

### DIFF
--- a/src/arch/x86_64/Encoding.zig
+++ b/src/arch/x86_64/Encoding.zig
@@ -793,10 +793,8 @@ const mnemonic_to_encodings_map = init: {
             .mode = entry[5],
             .feature = entry[6],
         };
-        // TODO: use `@memcpy` for these. When I did that, I got a false positive
-        // compile error for this copy happening at compile time.
-        std.mem.copyForwards(Op, &data.ops, entry[2]);
-        std.mem.copyForwards(u8, &data.opc, entry[3]);
+        @memcpy(data.ops[0..entry[2].len], entry[2]);
+        @memcpy(data.opc[0..entry[3].len], entry[3]);
 
         while (mnemonic_int < @intFromEnum(entry[0])) : (mnemonic_int += 1) {
             mnemonic_map[mnemonic_int] = data_storage[mnemonic_start..data_index];


### PR DESCRIPTION
Helps document in code what the comments already say. I had to fixup a comptime use case of these functions in Encoding.zig (as you can't retrieve the pointer value at comptime...). However, @memcpy seems to work at comptime now so it resolves a pre-existing TODO there anyway!

It does raise the question of how you should handle comptime memcpys with overlapping arrays though - as ideally you would be able to still validate the ptr ordering in that case as well?

This also fixes a bug where an assert in `copyBackwards` was effectively doing nothing due to an `@setRuntimeSafety` call in the same scope.