### PR TITLE
Fix rendering ast in zon mode

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -12,7 +12,7 @@ tokens: TokenList.Slice,
 /// references to the root node, this means 0 is available to indicate null.
 nodes: NodeList.Slice,
 extra_data: []Node.Index,
-mode: Mode,
+mode: Mode = .zig,
 
 errors: []const Error,
 

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -12,6 +12,7 @@ tokens: TokenList.Slice,
 /// references to the root node, this means 0 is available to indicate null.
 nodes: NodeList.Slice,
 extra_data: []Node.Index,
+mode: Mode,
 
 errors: []const Error,
 
@@ -96,6 +97,7 @@ pub fn parse(gpa: Allocator, source: [:0]const u8, mode: Mode) Allocator.Error!A
     // TODO experiment with compacting the MultiArrayList slices here
     return Ast{
         .source = source,
+        .mode = mode,
         .tokens = tokens.toOwnedSlice(),
         .nodes = parser.nodes.toOwnedSlice(),
         .extra_data = try parser.extra_data.toOwnedSlice(gpa),

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -30,7 +30,17 @@ pub fn renderTree(buffer: *std.ArrayList(u8), tree: Ast) Error!void {
         try renderContainerDocComments(ais, tree, 0);
     }
 
-    try renderMembers(buffer.allocator, ais, tree, tree.rootDecls());
+    if (tree.mode == .zon) {
+        try renderExpression(
+            buffer.allocator,
+            ais,
+            tree,
+            tree.nodes.items(.data)[0].lhs,
+            .newline,
+        );
+    } else {
+        try renderMembers(buffer.allocator, ais, tree, tree.rootDecls());
+    }
 
     if (ais.disabled_offset) |disabled_offset| {
         try writeFixingWhitespace(ais.underlying_writer, tree.source[disabled_offset..]);

--- a/src/translate_c/ast.zig
+++ b/src/translate_c/ast.zig
@@ -794,6 +794,7 @@ pub fn render(gpa: Allocator, nodes: []const Node) !std.zig.Ast {
         .nodes = ctx.nodes.toOwnedSlice(),
         .extra_data = try ctx.extra_data.toOwnedSlice(gpa),
         .errors = &.{},
+        .mode = .zig,
     };
 }
 


### PR DESCRIPTION
Currently, when parsing an ast in `.zon` mode, `renderToArrayList` fails in `rootdecls`:

```
thread 1219690 panic: index out of bounds: index 2863311530, len 7
/home/tobi/zig/0.12.0-dev.929+a126afa1c/files/lib/std/zig/Ast.zig:192:27: 0x2aa9da in rootDecls (zbuild)
    return tree.extra_data[nodes_data[0].lhs..nodes_data[0].rhs];
                          ^
/home/tobi/zig/0.12.0-dev.929+a126afa1c/files/lib/std/zig/render.zig:33:66: 0x25dba6 in renderTree (zbuild)
    try renderMembers(buffer.allocator, ais, tree, tree.rootDecls());
                                                                 ^
/home/tobi/zig/0.12.0-dev.929+a126afa1c/files/lib/std/zig/Ast.zig:119:46: 0x23cd9f in renderToArrayList (zbuild)
    return @import("./render.zig").renderTree(buffer, tree);
                                             ^
/home/tobi/repos/zbuild/src/build/ZBuild.zig:109:34: 0x23a859 in zon (zbuild)
        try ast.renderToArrayList(&out_buf);
```

Since `.zon` is just a top level expression, it should be switched on and rendered as such.
