### PR TITLE
windows: fix ReadLink not using a synchronous file handle

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -834,14 +834,14 @@ pub fn ReadLink(dir: ?HANDLE, sub_path_w: []const u16, out_buffer: []u8) ReadLin
 
     const rc = ntdll.NtCreateFile(
         &result_handle,
-        FILE_READ_ATTRIBUTES,
+        FILE_READ_ATTRIBUTES | SYNCHRONIZE,
         &attr,
         &io,
         null,
         FILE_ATTRIBUTE_NORMAL,
         FILE_SHARE_READ,
         FILE_OPEN,
-        FILE_OPEN_REPARSE_POINT,
+        FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT,
         null,
         0,
     );


### PR DESCRIPTION
Without this flag, the subsequent call to `NtDeviceIoControlFile` can return `PENDING`.