### PR TITLE
x86_64: fix C abi argument passing in memory

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -13755,7 +13755,8 @@ fn resolveCallingConventionValues(
                 }
 
                 const param_size: u31 = @intCast(ty.abiSize(mod));
-                const param_align: u31 = @intCast(ty.abiAlignment(mod).toByteUnitsOptional().?);
+                const param_align: u31 =
+                    @intCast(@max(ty.abiAlignment(mod).toByteUnitsOptional().?, 8));
                 result.stack_byte_count =
                     mem.alignForward(u31, result.stack_byte_count, param_align);
                 arg.* = .{ .load_frame = .{


### PR DESCRIPTION
Added to #17556, this fixes a bug with text in [tetris](https://github.com/andrewrk/tetris) when compiled with the x86_64 backend:

![image](https://github.com/ziglang/zig/assets/15544577/d7e31938-62b6-4e5d-af53-be2a30159ab2)

My patch for reference:
```diff
diff --git a/build.zig b/build.zig
index 3500b0c..61213ab 100644
--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const use_llvm = b.option(bool, "use-llvm", "use the LLVM backend");
+    const use_lld = b.option(bool, "use-lld", "use the LLD linker");
 
     const exe = b.addExecutable(.{
         .name = "tetris",
@@ -14,11 +15,15 @@ pub fn build(b: *Build) void {
         .target = target,
     });
     exe.use_llvm = use_llvm;
-    exe.use_lld = use_llvm;
+    exe.use_lld = use_lld;
+    exe.single_threaded = true;
+    exe.pie = true;
 
     exe.linkLibC();
     exe.linkSystemLibrary("glfw");
     exe.linkSystemLibrary("epoxy");
+    exe.addLibraryPath(.{ .path = "/usr/lib64" });
+    exe.addIncludePath(.{ .path = "/usr/include" });
     b.installArtifact(exe);
 
     const play = b.step("play", "Play the game");
diff --git a/src/debug_gl.zig b/src/debug_gl.zig
index 8a9968e..5cf3414 100644
--- a/src/debug_gl.zig
+++ b/src/debug_gl.zig
@@ -9,7 +9,7 @@ pub fn assertNoError() void {
     if (builtin.mode != .ReleaseFast) {
         const err = c.glGetError();
         if (err != c.GL_NO_ERROR) {
-            _ = c.printf("GL error: %s\n", err);
+            _ = c.printf("GL error: %d\n", err);
             c.abort();
         }
     }
```
```
$ zig build play -Duse-llvm=false -Duse-lld=false -Dtarget=x86_64-linux-gnu -Dcpu=native
```