### PR TITLE
std.os: unlinkW shouldn't return error.DirNotEmpty

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2355,7 +2355,12 @@ pub fn unlinkZ(file_path: [*:0]const u8) UnlinkError!void {
 
 /// Windows-only. Same as `unlink` except the parameter is null-terminated, WTF16 encoded.
 pub fn unlinkW(file_path_w: []const u16) UnlinkError!void {
-    return windows.DeleteFile(file_path_w, .{ .dir = std.fs.cwd().fd });
+    windows.DeleteFile(file_path_w, .{ .dir = std.fs.cwd().fd }) catch |err| {
+        switch (err) {
+            error.DirNotEmpty => unreachable, // we're not passing .remove_dir = true
+            inline else => |e| return e,
+        }
+    };
 }
 
 pub const UnlinkatError = UnlinkError || error{


### PR DESCRIPTION
I hope this is the correct approach