### PR TITLE
Change IORING_REGISTER to u32

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -4053,7 +4053,7 @@ pub const IORING_ENTER_EXT_ARG = 1 << 3;
 pub const IORING_ENTER_REGISTERED_RING = 1 << 4;
 
 // io_uring_register opcodes and arguments
-pub const IORING_REGISTER = enum(u8) {
+pub const IORING_REGISTER = enum(u32) {
     REGISTER_BUFFERS,
     UNREGISTER_BUFFERS,
     REGISTER_FILES,


### PR DESCRIPTION
See [this flag](https://github.com/openSUSE/kernel/blob/1a9fef3bcb745f00c5021b883746edb4c37946e9/include/uapi/linux/io_uring.h#L553) with value `1 << 31`

Maybe it would be better to just use `usize`, but this is a conservative change and works right now.

This also doesn't model the `IORING_REGISTER_USE_REGISTERED_RING` flag at all - I'm not sure what the best way to do that is. This will at least allow the `@enumFromInt(@as(u32, @intFromEnum(linux.IORING_REGISTER.IORING_REGISTER_FILES2)) | (1 << 31))` variant. Not pretty, but should work.