### PR TITLE
link: initialize LLVM before calling the LLVM API

### DIFF
--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -7999,11 +7999,13 @@ pub fn init(options: Options) InitError!Builder {
     assert(try self.string("") == .empty);
 
     if (options.name.len > 0) self.source_filename = try self.string(options.name);
-    self.initializeLLVMTarget(options.target.cpu.arch);
-    if (self.useLibLlvm()) self.llvm.module = llvm.Module.createWithName(
-        (self.source_filename.slice(&self) orelse ""),
-        self.llvm.context,
-    );
+    if (self.useLibLlvm()) {
+        initializeLLVMTarget(options.target.cpu.arch);
+        self.llvm.module = llvm.Module.createWithName(
+            (self.source_filename.slice(&self) orelse ""),
+            self.llvm.context,
+        );
+    }
 
     if (options.triple.len > 0) {
         self.target_triple = try self.string(options.triple);
@@ -8117,8 +8119,7 @@ pub fn deinit(self: *Builder) void {
     self.* = undefined;
 }
 
-pub fn initializeLLVMTarget(self: *const Builder, arch: std.Target.Cpu.Arch) void {
-    if (!self.useLibLlvm()) return;
+pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
     switch (arch) {
         .aarch64, .aarch64_be, .aarch64_32 => {
             llvm.LLVMInitializeAArch64Target();

--- a/src/link.zig
+++ b/src/link.zig
@@ -1150,7 +1150,9 @@ pub const File = struct {
         }
 
         const llvm_bindings = @import("codegen/llvm/bindings.zig");
+        const Builder = @import("codegen/llvm/Builder.zig");
         const llvm = @import("codegen/llvm.zig");
+        Builder.initializeLLVMTarget(base.options.target.cpu.arch);
         const os_tag = llvm.targetOs(base.options.target.os.tag);
         const bad = llvm_bindings.WriteArchive(full_out_path_z, object_files.items.ptr, object_files.items.len, os_tag);
         if (bad) return error.UnableToWriteArchive;


### PR DESCRIPTION
Without this change, I hit a crash in LLVM while cross-linking libcxx for arm with optimizations.  I didn't look too closely at what codepath in LLVM requires this, but the fact that I found one suggests the target should just always be initialized.