### PR TITLE
resinator: Fix `INCLUDE` var handling and sync with upstream

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -243,6 +243,8 @@ pub const RcSourceFile = struct {
     file: LazyPath,
     /// Any option that rc.exe accepts will work here, with the exception of:
     /// - `/fo`: The output filename is set by the build system
+    /// - `/p`: Only running the preprocessor is not supported in this context
+    /// - `/:no-preprocess` (non-standard option): Not supported in this context
     /// - Any MUI-related option
     /// https://learn.microsoft.com/en-us/windows/win32/menurc/using-rc-the-rc-command-line-
     ///

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4759,11 +4759,17 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
         // unconditionally set `ignore_include_env_var` to true
         options.ignore_include_env_var = true;
 
+        if (options.preprocess != .yes) {
+            return comp.failWin32Resource(win32_resource, "the '{s}' option is not supported in this context", .{switch (options.preprocess) {
+                .no => "/:no-preprocess",
+                .only => "/p",
+                .yes => unreachable,
+            }});
+        }
+
         var argv = std.ArrayList([]const u8).init(comp.gpa);
         defer argv.deinit();
 
-        // TODO: support options.preprocess == .no and .only
-        //       alternatively, error if those options are used
         try argv.appendSlice(&[_][]const u8{ self_exe_path, "clang" });
 
         try resinator.preprocess.appendClangArgs(arena, &argv, options, .{

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4755,6 +4755,10 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
         };
         defer options.deinit();
 
+        // We never want to read the INCLUDE environment variable, so
+        // unconditionally set `ignore_include_env_var` to true
+        options.ignore_include_env_var = true;
+
         var argv = std.ArrayList([]const u8).init(comp.gpa);
         defer argv.deinit();
 

--- a/src/introspect.zig
+++ b/src/introspect.zig
@@ -157,8 +157,6 @@ pub const EnvVar = enum {
     NO_COLOR,
     XDG_CACHE_HOME,
     HOME,
-    /// https://github.com/ziglang/zig/issues/17585
-    INCLUDE,
 
     pub fn isSet(comptime ev: EnvVar) bool {
         return std.process.hasEnvVarConstant(@tagName(ev));

--- a/src/resinator/compile.zig
+++ b/src/resinator/compile.zig
@@ -28,7 +28,6 @@ const windows1252 = @import("windows1252.zig");
 const lang = @import("lang.zig");
 const code_pages = @import("code_pages.zig");
 const errors = @import("errors.zig");
-const introspect = @import("../introspect.zig");
 
 pub const CompileOptions = struct {
     cwd: std.fs.Dir,
@@ -89,10 +88,23 @@ pub fn compile(allocator: Allocator, source: []const u8, writer: anytype, option
         }
     }
     // Re-open the passed in cwd since we want to be able to close it (std.fs.cwd() shouldn't be closed)
-    // `catch unreachable` since `options.cwd` is expected to be a valid dir handle, so opening
-    // a new handle to it should be fine as well.
-    // TODO: Maybe catch and return an error instead
-    const cwd_dir = options.cwd.openDir(".", .{}) catch @panic("unable to open dir");
+    const cwd_dir = options.cwd.openDir(".", .{}) catch |err| {
+        try options.diagnostics.append(.{
+            .err = .failed_to_open_cwd,
+            .token = .{
+                .id = .invalid,
+                .start = 0,
+                .end = 0,
+                .line_number = 1,
+            },
+            .print_source_line = false,
+            .extra = .{ .file_open_error = .{
+                .err = ErrorDetails.FileOpenError.enumFromError(err),
+                .filename_string_index = undefined,
+            } },
+        });
+        return error.CompileError;
+    };
     try search_dirs.append(.{ .dir = cwd_dir, .path = null });
     for (options.extra_include_paths) |extra_include_path| {
         var dir = openSearchPathDir(options.cwd, extra_include_path) catch {
@@ -111,11 +123,16 @@ pub fn compile(allocator: Allocator, source: []const u8, writer: anytype, option
         try search_dirs.append(.{ .dir = dir, .path = try allocator.dupe(u8, system_include_path) });
     }
     if (!options.ignore_include_env_var) {
-        const INCLUDE = (introspect.EnvVar.INCLUDE.get(allocator) catch @panic("OOM")) orelse "";
+        const INCLUDE = std.process.getEnvVarOwned(allocator, "INCLUDE") catch "";
         defer allocator.free(INCLUDE);
 
-        // TODO: Should this be platform-specific? How does windres/llvm-rc handle this (if at all)?
-        var it = std.mem.tokenize(u8, INCLUDE, ";");
+        // The only precedence here is llvm-rc which also uses the platform-specific
+        // delimiter. There's no precedence set by `rc.exe` since it's Windows-only.
+        const delimiter = switch (builtin.os.tag) {
+            .windows => ';',
+            else => ':',
+        };
+        var it = std.mem.tokenizeScalar(u8, INCLUDE, delimiter);
         while (it.next()) |search_path| {
             var dir = openSearchPathDir(options.cwd, search_path) catch continue;
             errdefer dir.close();

--- a/src/resinator/literals.zig
+++ b/src/resinator/literals.zig
@@ -775,6 +775,13 @@ pub fn columnsUntilTabStop(column: usize, tab_columns: usize) usize {
     return tab_columns - (column % tab_columns);
 }
 
+pub fn columnWidth(cur_column: usize, c: u8, tab_columns: usize) usize {
+    return switch (c) {
+        '\t' => columnsUntilTabStop(cur_column, tab_columns),
+        else => 1,
+    };
+}
+
 pub const Number = struct {
     value: u32,
     is_long: bool = false,

--- a/src/resinator/preprocess.zig
+++ b/src/resinator/preprocess.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const cli = @import("cli.zig");
-const introspect = @import("../introspect.zig");
 
 pub const IncludeArgs = struct {
     clang_target: ?[]const u8 = null,
@@ -68,10 +68,15 @@ pub fn appendClangArgs(arena: Allocator, argv: *std.ArrayList([]const u8), optio
     }
 
     if (!options.ignore_include_env_var) {
-        const INCLUDE = (introspect.EnvVar.INCLUDE.get(arena) catch @panic("OOM")) orelse "";
+        const INCLUDE = std.process.getEnvVarOwned(arena, "INCLUDE") catch "";
 
-        // TODO: Should this be platform-specific? How does windres/llvm-rc handle this (if at all)?
-        var it = std.mem.tokenize(u8, INCLUDE, ";");
+        // The only precedence here is llvm-rc which also uses the platform-specific
+        // delimiter. There's no precedence set by `rc.exe` since it's Windows-only.
+        const delimiter = switch (builtin.os.tag) {
+            .windows => ';',
+            else => ':',
+        };
+        var it = std.mem.tokenizeScalar(u8, INCLUDE, delimiter);
         while (it.next()) |include_path| {
             try argv.append("-isystem");
             try argv.append(include_path);

--- a/src/resinator/source_mapping.zig
+++ b/src/resinator/source_mapping.zig
@@ -240,6 +240,9 @@ pub fn handleLineCommand(allocator: Allocator, line_command: []const u8, current
     };
     defer allocator.free(filename);
 
+    // \x00 bytes in the filename is incompatible with how StringTable works
+    if (std.mem.indexOfScalar(u8, filename, '\x00') != null) return;
+
     current_mapping.line_num = linenum;
     current_mapping.filename.clearRetainingCapacity();
     try current_mapping.filename.appendSlice(allocator, filename);
@@ -441,7 +444,7 @@ pub const SourceMappings = struct {
         ptr.* = span;
     }
 
-    pub fn has(self: *SourceMappings, line_num: usize) bool {
+    pub fn has(self: SourceMappings, line_num: usize) bool {
         return self.mapping.items.len >= line_num;
     }
 


### PR DESCRIPTION
`src/` changes:

- Fix `ignore_include_env_var` not being set when preprocessing `.rc` files. Closes #17585
- Make using the `/p` or `/:no-preprocess` options for an `.rc` file an error when going through `zig build-exe`/`zig build`/etc

`src/resinator` changes:

- Revert the `INCLUDE` env var related changes in 09dea957ed74f87b7f5f88bc2c760f3f93d0165a since `INCLUDE` is now never read by anything except `zig rc`
- Added proper error handling when failing to open the CWD for the `.rc` compilation (an improvement on a change in 09dea957ed74f87b7f5f88bc2c760f3f93d0165a)
- Fixes for various bugs found when fuzz testing
- Made it use platform-specific delimiters when parsing `INCLUDE`