### PR TITLE
glibc headers: reallocarray added to glibc in v2.26

### DIFF
--- a/lib/libc/include/generic-glibc/malloc.h
+++ b/lib/libc/include/generic-glibc/malloc.h
@@ -51,6 +51,11 @@ __THROW __attribute_malloc__ __attribute_alloc_size__ ((1, 2)) __wur;
 extern void *realloc (void *__ptr, size_t __size)
 __THROW __attribute_warn_unused_result__ __attribute_alloc_size__ ((2));
 
+/*
+ * reallocarray introduced in glibc 2.26
+ * https://sourceware.org/git/?p=glibc.git;a=commit;h=2e0bbbfbf95fc9e22692e93658a6fbdd2d4554da
+ */
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 26) || __GLIBC__ > 2
 /* Re-allocate the previously allocated block in PTR, making the new
    block large enough for NMEMB elements of SIZE bytes each.  */
 /* __attribute_malloc__ is not used, because if reallocarray returns
@@ -59,6 +64,7 @@ __THROW __attribute_warn_unused_result__ __attribute_alloc_size__ ((2));
 extern void *reallocarray (void *__ptr, size_t __nmemb, size_t __size)
   __THROW __attribute_warn_unused_result__ __attribute_alloc_size__ ((2, 3))
   __attr_dealloc_free;
+#endif /* glibc v2.26 and later */
 
 /* Free a block allocated by `malloc', `realloc' or `calloc'.  */
 extern void free (void *__ptr) __THROW;

--- a/lib/libc/include/generic-glibc/stdlib.h
+++ b/lib/libc/include/generic-glibc/stdlib.h
@@ -686,6 +686,11 @@ extern void *realloc (void *__ptr, size_t __size)
 /* Free a block allocated by `malloc', `realloc' or `calloc'.  */
 extern void free (void *__ptr) __THROW;
 
+/*
+ * reallocarray introduced in glibc 2.26
+ * https://sourceware.org/git/?p=glibc.git;a=commit;h=2e0bbbfbf95fc9e22692e93658a6fbdd2d4554da
+ */
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 26) || __GLIBC__ > 2
 #ifdef __USE_MISC
 /* Re-allocate the previously allocated block in PTR, making the new
    block large enough for NMEMB elements of SIZE bytes each.  */
@@ -701,6 +706,7 @@ extern void *reallocarray (void *__ptr, size_t __nmemb, size_t __size)
 extern void *reallocarray (void *__ptr, size_t __nmemb, size_t __size)
      __THROW __attr_dealloc (reallocarray, 1);
 #endif
+#endif /* glibc v2.26 and later */
 
 #ifdef __USE_MISC
 # include <alloca.h>


### PR DESCRIPTION
Here's the glibc commit that adds reallocarray to glibc: https://sourceware.org/git/?p=glibc.git;a=commit;h=2e0bbbfbf95fc9e22692e93658a6fbdd2d4554da

The reallocarray symbol is declared in both stdlib.h and malloc.h.

Fix #17607