### PR TITLE
std.os: do nothing when calling fchdir with AT_FDCWD

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -2966,6 +2966,7 @@ pub const FchdirError = error{
 } || UnexpectedError;
 
 pub fn fchdir(dirfd: fd_t) FchdirError!void {
+    if (dirfd == AT.FDCWD) return;
     while (true) {
         switch (errno(system.fchdir(dirfd))) {
             .SUCCESS => return,


### PR DESCRIPTION
supersedes #15592
closes #9688