### PR TITLE
crypto.ff: faster exponentiation with short/public exponents

### DIFF
--- a/lib/std/crypto/ff.zig
+++ b/lib/std/crypto/ff.zig
@@ -808,7 +808,7 @@ pub fn Modulus(comptime max_bits: comptime_int) type {
         /// Returns x^e (mod m), the exponent being public and provided as a byte string.
         /// Exponents are usually small, so this function is faster than `powPublic` as a field element
         /// doesn't have to be created if a serialized representation is already available.
-        /// b
+        ///
         /// If the exponent is secret, `powWithEncodedExponent` must be used instead.
         pub fn powWithEncodedPublicExponent(self: Self, x: Fe, e: []const u8, endian: builtin.Endian) NullExponentError!Fe {
             return self.powWithEncodedExponentInternal(x, e, endian, true);


### PR DESCRIPTION
RSA exponents are typically 3 or 65537, and public.

For those, we don't need to use conditional moves on the exponent, and precomputing a lookup table is not worth it. So, save a few cpu cycles and memory for that common case.

For safety, make `powWithEncodedExponent()` constant-time by default, and introduce a `powWithEncodedPublicExponent()` function for exponents that are assumed to be public.

With `powWithEncodedPublicExponent()`, short (<= 36 bits) exponents will take the fast path.