### PR TITLE
Tar: add executable_bit_only support.

### DIFF
--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -259,7 +259,7 @@ pub fn pipeToFileSystem(dir: std.fs.Dir, reader: anytype, options: Options) !voi
                     // the compiler requires chmod take a u0 on windows.
                     // mask is a u32, so it would fail on windows.
                     if (builtin.os.tag != .windows and builtin.os.tag != .wasi) {
-                        try file.?.chmod(modebits.mask);
+                        if (file) |f| try f.chmod(modebits.mask);
                     }
                 }
 

--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -254,7 +254,13 @@ pub fn pipeToFileSystem(dir: std.fs.Dir, reader: anytype, options: Options) !voi
                     const has_owner_exe_bit = modebits.isSet(6);
                     modebits.setValue(3, has_owner_exe_bit);
                     modebits.setValue(0, has_owner_exe_bit);
-                    try file.?.chmod(modebits.mask);
+
+                    // Needed for comptime fix, as should_exec is runtime, and
+                    // the compiler requires chmod take a u0 on windows.
+                    // mask is a u32, so it would fail on windows.
+                    if (builtin.os.tag != .windows and builtin.os.tag != .wasi) {
+                        try file.?.chmod(modebits.mask);
+                    }
                 }
 
                 while (true) {
@@ -411,3 +417,4 @@ test parsePaxAttribute {
 
 const std = @import("std.zig");
 const assert = std.debug.assert;
+const builtin = @import("builtin");

--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -245,15 +245,17 @@ pub fn pipeToFileSystem(dir: std.fs.Dir, reader: anytype, options: Options) !voi
 
                 var file_off: usize = 0;
 
-                const mode = header.mode();
-                var modebits = std.StaticBitSet(32){
-                    .mask = @intCast(try std.fmt.parseInt(u32, mode, 8)),
-                };
+                if (should_exec) {
+                    const mode = header.mode();
+                    var modebits = std.StaticBitSet(32){
+                        .mask = @intCast(try std.fmt.parseInt(u32, mode, 8)),
+                    };
 
-                const has_owner_exe_bit = modebits.isSet(6);
-                modebits.setValue(3, has_owner_exe_bit);
-                modebits.setValue(0, has_owner_exe_bit);
-                try file.?.chmod(modebits.mask);
+                    const has_owner_exe_bit = modebits.isSet(6);
+                    modebits.setValue(3, has_owner_exe_bit);
+                    modebits.setValue(0, has_owner_exe_bit);
+                    try file.?.chmod(modebits.mask);
+                }
 
                 while (true) {
                     const temp = try buffer.readChunk(reader, @intCast(rounded_file_size + 512 - file_off));


### PR DESCRIPTION
Closes: #17462

Still working on polishing this and seeing if there any any issues with this. To be honest, I'm just doubting that it's this simple, so I need some time to make sure.

Trying it on something like `ci` folder, it seems to be working.
![image](https://github.com/ziglang/zig/assets/87927264/555a5a0c-8753-45fc-aa02-32b31ebb7840)

if I'm missing something super obvious please let me know.
