### PR TITLE
child_process + Build: rename exec to run + all related code

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -255,7 +255,7 @@ pub fn build(b: *std.Build) !void {
         const version_string = b.fmt("{d}.{d}.{d}", .{ zig_version.major, zig_version.minor, zig_version.patch });
 
         var code: u8 = undefined;
-        const git_describe_untrimmed = b.execAllowFail(&[_][]const u8{
+        const git_describe_untrimmed = b.runAllowFail(&[_][]const u8{
             "git", "-C", b.build_root.path orelse ".", "describe", "--match", "*.*.*", "--tags",
         }, &code, .Ignore) catch {
             break :v version_string;
@@ -737,9 +737,9 @@ fn addCxxKnownPath(
         return error.RequiredLibraryNotFound;
 
     const path_padded = if (ctx.cxx_compiler_arg1.len > 0)
-        b.exec(&.{ ctx.cxx_compiler, ctx.cxx_compiler_arg1, b.fmt("-print-file-name={s}", .{objname}) })
+        b.run(&.{ ctx.cxx_compiler, ctx.cxx_compiler_arg1, b.fmt("-print-file-name={s}", .{objname}) })
     else
-        b.exec(&.{ ctx.cxx_compiler, b.fmt("-print-file-name={s}", .{objname}) });
+        b.run(&.{ ctx.cxx_compiler, b.fmt("-print-file-name={s}", .{objname}) });
     var tokenizer = mem.tokenizeAny(u8, path_padded, "\r\n");
     const path_unpadded = tokenizer.next().?;
     if (mem.eql(u8, path_unpadded, objname)) {

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -172,7 +172,7 @@ const InitializedDepContext = struct {
     }
 };
 
-pub const ExecError = error{
+pub const RunError = error{
     ReadFailure,
     ExitCodeFailure,
     ProcessTerminated,
@@ -1629,12 +1629,12 @@ pub fn findProgram(self: *Build, names: []const []const u8, paths: []const []con
     return error.FileNotFound;
 }
 
-pub fn execAllowFail(
+pub fn runAllowFail(
     self: *Build,
     argv: []const []const u8,
     out_code: *u8,
     stderr_behavior: std.ChildProcess.StdIo,
-) ExecError![]u8 {
+) RunError![]u8 {
     assert(argv.len != 0);
 
     if (!process.can_spawn)
@@ -1673,7 +1673,7 @@ pub fn execAllowFail(
 /// This is a helper function to be called from build.zig scripts, *not* from
 /// inside step make() functions. If any errors occur, it fails the build with
 /// a helpful message.
-pub fn exec(b: *Build, argv: []const []const u8) []u8 {
+pub fn run(b: *Build, argv: []const []const u8) []u8 {
     if (!process.can_spawn) {
         std.debug.print("unable to spawn the following command: cannot spawn child process\n{s}\n", .{
             try allocPrintCmd(b.allocator, null, argv),
@@ -1682,7 +1682,7 @@ pub fn exec(b: *Build, argv: []const []const u8) []u8 {
     }
 
     var code: u8 = undefined;
-    return b.execAllowFail(argv, &code, .Inherit) catch |err| {
+    return b.runAllowFail(argv, &code, .Inherit) catch |err| {
         const printed_cmd = allocPrintCmd(b.allocator, null, argv) catch @panic("OOM");
         std.debug.print("unable to spawn the following command: {s}\n{s}\n", .{
             @errorName(err), printed_cmd,

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -273,7 +273,7 @@ pub fn evalChildProcess(s: *Step, argv: []const []const u8) !void {
     try handleChildProcUnsupported(s, null, argv);
     try handleVerbose(s.owner, null, argv);
 
-    const result = std.ChildProcess.exec(.{
+    const result = std.ChildProcess.run(.{
         .allocator = arena,
         .argv = argv,
     }) catch |err| return s.fail("unable to spawn {s}: {s}", .{ argv[0], @errorName(err) });

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -14,7 +14,7 @@ const NativeTargetInfo = std.zig.system.NativeTargetInfo;
 const LazyPath = std.Build.LazyPath;
 const PkgConfigPkg = std.Build.PkgConfigPkg;
 const PkgConfigError = std.Build.PkgConfigError;
-const ExecError = std.Build.ExecError;
+const RunError = std.Build.RunError;
 const Module = std.Build.Module;
 const VcpkgRoot = std.Build.VcpkgRoot;
 const InstallDir = std.Build.InstallDir;
@@ -854,7 +854,7 @@ fn runPkgConfig(self: *Compile, lib_name: []const u8) ![]const []const u8 {
     };
 
     var code: u8 = undefined;
-    const stdout = if (b.execAllowFail(&[_][]const u8{
+    const stdout = if (b.runAllowFail(&[_][]const u8{
         "pkg-config",
         pkg_name,
         "--cflags",
@@ -2263,8 +2263,8 @@ pub fn doAtomicSymLinks(
     };
 }
 
-fn execPkgConfigList(self: *std.Build, out_code: *u8) (PkgConfigError || ExecError)![]const PkgConfigPkg {
-    const stdout = try self.execAllowFail(&[_][]const u8{ "pkg-config", "--list-all" }, out_code, .Ignore);
+fn execPkgConfigList(self: *std.Build, out_code: *u8) (PkgConfigError || RunError)![]const PkgConfigPkg {
+    const stdout = try self.runAllowFail(&[_][]const u8{ "pkg-config", "--list-all" }, out_code, .Ignore);
     var list = ArrayList(PkgConfigPkg).init(self.allocator);
     errdefer list.deinit();
     var line_it = mem.tokenizeAny(u8, stdout, "\r\n");

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -7,8 +7,6 @@ const mem = std.mem;
 const process = std.process;
 const ArrayList = std.ArrayList;
 const EnvMap = process.EnvMap;
-const Allocator = mem.Allocator;
-const ExecError = std.Build.ExecError;
 const assert = std.debug.assert;
 
 const Run = @This();

--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -262,7 +262,7 @@ pub const ChildProcess = struct {
         return term;
     }
 
-    pub const ExecResult = struct {
+    pub const RunResult = struct {
         term: Term,
         stdout: []u8,
         stderr: []u8,
@@ -317,14 +317,14 @@ pub const ChildProcess = struct {
         stderr.* = fifoToOwnedArrayList(poller.fifo(.stderr));
     }
 
-    pub const ExecError = os.GetCwdError || os.ReadError || SpawnError || os.PollError || error{
+    pub const RunError = os.GetCwdError || os.ReadError || SpawnError || os.PollError || error{
         StdoutStreamTooLong,
         StderrStreamTooLong,
     };
 
     /// Spawns a child process, waits for it, collecting stdout and stderr, and then returns.
     /// If it succeeds, the caller owns result.stdout and result.stderr memory.
-    pub fn exec(args: struct {
+    pub fn run(args: struct {
         allocator: mem.Allocator,
         argv: []const []const u8,
         cwd: ?[]const u8 = null,
@@ -332,7 +332,7 @@ pub const ChildProcess = struct {
         env_map: ?*const EnvMap = null,
         max_output_bytes: usize = 50 * 1024,
         expand_arg0: Arg0Expand = .no_expand,
-    }) ExecError!ExecResult {
+    }) RunError!RunResult {
         var child = ChildProcess.init(args.argv, args.allocator);
         child.stdin_behavior = .Ignore;
         child.stdout_behavior = .Pipe;
@@ -352,7 +352,7 @@ pub const ChildProcess = struct {
         try child.spawn();
         try child.collectOutput(&stdout, &stderr, args.max_output_bytes);
 
-        return ExecResult{
+        return RunResult{
             .term = try child.wait(),
             .stdout = try stdout.toOwnedSlice(),
             .stderr = try stderr.toOwnedSlice(),
@@ -821,7 +821,7 @@ pub const ChildProcess = struct {
         const cmd_line_w = try unicode.utf8ToUtf16LeWithNull(self.allocator, cmd_line);
         defer self.allocator.free(cmd_line_w);
 
-        exec: {
+        run: {
             const PATH: [:0]const u16 = std.os.getenvW(unicode.utf8ToUtf16LeStringLiteral("PATH")) orelse &[_:0]u16{};
             const PATHEXT: [:0]const u16 = std.os.getenvW(unicode.utf8ToUtf16LeStringLiteral("PATHEXT")) orelse &[_:0]u16{};
 
@@ -873,7 +873,7 @@ pub const ChildProcess = struct {
                     dir_buf.shrinkRetainingCapacity(normalized_len);
 
                     if (windowsCreateProcessPathExt(self.allocator, &dir_buf, &app_buf, PATHEXT, cmd_line_w.ptr, envp_ptr, cwd_w_ptr, &siStartInfo, &piProcInfo)) {
-                        break :exec;
+                        break :run;
                     } else |err| switch (err) {
                         error.FileNotFound, error.AccessDenied, error.InvalidExe => continue,
                         error.UnrecoverableInvalidExe => return error.InvalidExe,

--- a/lib/std/zig/system/darwin.zig
+++ b/lib/std/zig/system/darwin.zig
@@ -13,7 +13,7 @@ pub const macos = @import("darwin/macos.zig");
 /// stderr from xcode-select is ignored.
 /// If error.OutOfMemory occurs in Allocator, this function returns null.
 pub fn isSdkInstalled(allocator: Allocator) bool {
-    const result = std.process.Child.exec(.{
+    const result = std.process.Child.run(.{
         .allocator = allocator,
         .argv = &.{ "/usr/bin/xcode-select", "--print-path" },
     }) catch return false;
@@ -44,7 +44,7 @@ pub fn getSdk(allocator: Allocator, target: Target) ?[]const u8 {
         else => return null,
     };
     const argv = &[_][]const u8{ "/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-path" };
-    const result = std.process.Child.exec(.{ .allocator = allocator, .argv = argv }) catch return null;
+    const result = std.process.Child.run(.{ .allocator = allocator, .argv = argv }) catch return null;
     defer {
         allocator.free(result.stderr);
         allocator.free(result.stdout);

--- a/src/libc_installation.zig
+++ b/src/libc_installation.zig
@@ -274,7 +274,7 @@ pub const LibCInstallation = struct {
             dev_null,
         });
 
-        const exec_res = std.ChildProcess.exec(.{
+        const run_res = std.ChildProcess.run(.{
             .allocator = allocator,
             .argv = argv.items,
             .max_output_bytes = 1024 * 1024,
@@ -292,21 +292,21 @@ pub const LibCInstallation = struct {
             },
         };
         defer {
-            allocator.free(exec_res.stdout);
-            allocator.free(exec_res.stderr);
+            allocator.free(run_res.stdout);
+            allocator.free(run_res.stderr);
         }
-        switch (exec_res.term) {
+        switch (run_res.term) {
             .Exited => |code| if (code != 0) {
-                printVerboseInvocation(argv.items, null, args.verbose, exec_res.stderr);
+                printVerboseInvocation(argv.items, null, args.verbose, run_res.stderr);
                 return error.CCompilerExitCode;
             },
             else => {
-                printVerboseInvocation(argv.items, null, args.verbose, exec_res.stderr);
+                printVerboseInvocation(argv.items, null, args.verbose, run_res.stderr);
                 return error.CCompilerCrashed;
             },
         }
 
-        var it = std.mem.tokenizeAny(u8, exec_res.stderr, "\n\r");
+        var it = std.mem.tokenizeAny(u8, run_res.stderr, "\n\r");
         var search_paths = std.ArrayList([]const u8).init(allocator);
         defer search_paths.deinit();
         while (it.next()) |line| {
@@ -596,7 +596,7 @@ fn ccPrintFileName(args: CCPrintFileNameOptions) ![:0]u8 {
     try appendCcExe(&argv, skip_cc_env_var);
     try argv.append(arg1);
 
-    const exec_res = std.ChildProcess.exec(.{
+    const run_res = std.ChildProcess.run(.{
         .allocator = allocator,
         .argv = argv.items,
         .max_output_bytes = 1024 * 1024,
@@ -611,21 +611,21 @@ fn ccPrintFileName(args: CCPrintFileNameOptions) ![:0]u8 {
         else => return error.UnableToSpawnCCompiler,
     };
     defer {
-        allocator.free(exec_res.stdout);
-        allocator.free(exec_res.stderr);
+        allocator.free(run_res.stdout);
+        allocator.free(run_res.stderr);
     }
-    switch (exec_res.term) {
+    switch (run_res.term) {
         .Exited => |code| if (code != 0) {
-            printVerboseInvocation(argv.items, args.search_basename, args.verbose, exec_res.stderr);
+            printVerboseInvocation(argv.items, args.search_basename, args.verbose, run_res.stderr);
             return error.CCompilerExitCode;
         },
         else => {
-            printVerboseInvocation(argv.items, args.search_basename, args.verbose, exec_res.stderr);
+            printVerboseInvocation(argv.items, args.search_basename, args.verbose, run_res.stderr);
             return error.CCompilerCrashed;
         },
     }
 
-    var it = std.mem.tokenizeAny(u8, exec_res.stdout, "\n\r");
+    var it = std.mem.tokenizeAny(u8, run_res.stdout, "\n\r");
     const line = it.next() orelse return error.LibCRuntimeNotFound;
     // When this command fails, it returns exit code 0 and duplicates the input file name.
     // So we detect failure by checking if the output matches exactly the input.

--- a/src/main.zig
+++ b/src/main.zig
@@ -4472,7 +4472,7 @@ fn cmdRc(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
             }
 
             if (process.can_spawn) {
-                var result = std.ChildProcess.exec(.{
+                var result = std.ChildProcess.run(.{
                     .allocator = gpa,
                     .argv = argv.items,
                     .max_output_bytes = std.math.maxInt(u32),

--- a/test/standalone/windows_spawn/main.zig
+++ b/test/standalone/windows_spawn/main.zig
@@ -158,7 +158,7 @@ fn testExec(allocator: std.mem.Allocator, command: []const u8, expected_stdout: 
 }
 
 fn testExecWithCwd(allocator: std.mem.Allocator, command: []const u8, cwd: ?[]const u8, expected_stdout: []const u8) !void {
-    var result = try std.ChildProcess.exec(.{
+    var result = try std.ChildProcess.run(.{
         .allocator = allocator,
         .argv = &[_][]const u8{command},
         .cwd = cwd,

--- a/tools/generate_linux_syscalls.zig
+++ b/tools/generate_linux_syscalls.zig
@@ -257,7 +257,7 @@ pub fn main() !void {
             "arch/arm64/include/uapi/asm/unistd.h",
         };
 
-        const child_result = try std.ChildProcess.exec(.{
+        const child_result = try std.ChildProcess.run(.{
             .allocator = allocator,
             .argv = &child_args,
             .cwd = linux_path,
@@ -318,7 +318,7 @@ pub fn main() !void {
             "arch/riscv/include/uapi/asm/unistd.h",
         };
 
-        const child_result = try std.ChildProcess.exec(.{
+        const child_result = try std.ChildProcess.run(.{
             .allocator = allocator,
             .argv = &child_args,
             .cwd = linux_path,

--- a/tools/update_clang_options.zig
+++ b/tools/update_clang_options.zig
@@ -613,7 +613,7 @@ pub fn main() anyerror!void {
         try std.fmt.allocPrint(allocator, "-I={s}/clang/include/clang/Driver", .{llvm_src_root}),
     };
 
-    const child_result = try std.ChildProcess.exec(.{
+    const child_result = try std.ChildProcess.run(.{
         .allocator = allocator,
         .argv = &child_args,
         .max_output_bytes = 100 * 1024 * 1024,

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -1064,7 +1064,7 @@ fn processOneTarget(job: Job) anyerror!void {
         }),
     };
 
-    const child_result = try std.ChildProcess.exec(.{
+    const child_result = try std.ChildProcess.run(.{
         .allocator = arena,
         .argv = &child_args,
         .max_output_bytes = 400 * 1024 * 1024,


### PR DESCRIPTION
Justification: exec, execv etc are unix concepts and portable version should be called differently.

Do no touch non-Zig code. Adjust error names as well, if associated. Closes #5853.