### PR TITLE
std.Target: update default Linux cross-compiling version

### DIFF
--- a/lib/std/target.zig
+++ b/lib/std/target.zig
@@ -342,10 +342,10 @@ pub const Target = struct {
                     .linux => return .{
                         .linux = .{
                             .range = .{
-                                .min = .{ .major = 3, .minor = 16, .patch = 0 },
-                                .max = .{ .major = 5, .minor = 10, .patch = 81 },
+                                .min = .{ .major = 4, .minor = 19, .patch = 0 },
+                                .max = .{ .major = 6, .minor = 5, .patch = 7 },
                             },
-                            .glibc = .{ .major = 2, .minor = 19, .patch = 0 },
+                            .glibc = .{ .major = 2, .minor = 28, .patch = 0 },
                         },
                     },
 


### PR DESCRIPTION
Currently, Zig uses the oldest Debian release that is still under LTS for the default version minimum. This is now Debian 10 (Buster), with long-term support until 2024-06-30.

Debian Buster uses Linux 4.19 and glibc 2.28.

For the default version maximum, Zig uses the newest stable Linux version, which is currently 6.5.7.

Citations:
* https://www.debian.org/News/2019/20190706
* https://packages.debian.org/source/buster/glibc
* https://kernel.org/

Previous update commit: 1530203c804db7e5abd7d6eac05cfbe449d30aea