### PR TITLE
dwarf: decouple DWARF format from target pointer size + misc fixes

### DIFF
--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -1788,8 +1788,6 @@ pub fn writeDbgAbbrev(self: *Dwarf) !void {
         DW.AT.count,          DW.FORM.udata,
         0,
         0, // table sentinel
-        0,
-        0,
         0, // section sentinel
     };
     const abbrev_offset = 0;

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -1823,7 +1823,7 @@ pub fn writeDbgInfoHeader(self: *Dwarf, module: *Module, low_pc: u64, high_pc: u
     // We have to come back and write it later after we know the size.
     const after_init_len = di_buf.items.len + init_len_size;
     const dbg_info_end = self.getDebugInfoEnd().?;
-    const init_len = dbg_info_end - after_init_len;
+    const init_len = dbg_info_end - after_init_len + 1;
 
     if (self.format == .dwarf64) di_buf.appendNTimesAssumeCapacity(0xff, 4);
     self.writeOffsetAssumeCapacity(&di_buf, init_len);
@@ -2417,7 +2417,7 @@ fn getDebugInfoOff(self: Dwarf) ?u32 {
 fn getDebugInfoEnd(self: Dwarf) ?u32 {
     const last_index = self.di_atom_last_index orelse return null;
     const last = self.getAtom(.di_atom, last_index);
-    return last.off + last.len + 1;
+    return last.off + last.len;
 }
 
 fn getDebugLineProgramOff(self: Dwarf) ?u32 {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -310,7 +310,7 @@ pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Option
 
     if (options.module != null and !options.use_llvm) {
         if (!options.strip) {
-            self.dwarf = Dwarf.init(allocator, &self.base, options.target);
+            self.dwarf = Dwarf.init(allocator, &self.base, .dwarf32);
         }
 
         const index = @as(File.Index, @intCast(try self.files.addOne(allocator)));

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -206,7 +206,7 @@ pub fn openPath(allocator: Allocator, options: link.Options) !*MachO {
 
         self.d_sym = .{
             .allocator = allocator,
-            .dwarf = link.File.Dwarf.init(allocator, &self.base, options.target),
+            .dwarf = link.File.Dwarf.init(allocator, &self.base, .dwarf32),
             .file = d_sym_file,
         };
     }

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -507,7 +507,7 @@ pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Option
     }
 
     // if (!options.strip and options.module != null) {
-    //     wasm_bin.dwarf = Dwarf.init(allocator, &wasm_bin.base, options.target);
+    //     wasm_bin.dwarf = Dwarf.init(allocator, &wasm_bin.base, .dwarf32);
     //     try wasm_bin.initDebugSections();
     // }
 


### PR DESCRIPTION
`Dwarf.zig` now allows selecting appropriate DWARF format at runtime via `Dwarf.Format = enum { dwarf32, dwarf64 }`. The actual format has no impact on the pointer size - DWARF64 format should only ever be selected for debug sections that exceed 4GB in file size, and even then it is not very well supported by the debuggers out there. For example, `lldb` still refuses to correctly load CUs in DWARF64 format. For that reason, I am changing generated DWARF targeting ELF to DWARF32. This makes it now possible to step through code with source line annotations in `lldb` on Linux. Please note that if we ever do exceed 4GB in file size for debug sections, it is now trivial to switch from DWARF32 to DWARF64. Finally, this significantly cleans up and unifies emitting DWARF between ELF and MachO.

Oh I have also refactored how we generate input dirs and files lists - `Package` has changed its API a while back but the codepath relying on it was wrong. We still use `realpath` to get full absolute path to each source file, but I want to re-investigate this and see if we can go back to relative paths where possible. In a subsequent PR however.