### PR TITLE
std.Build: use create() instead of init() for Step.RemoveDir

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -971,9 +971,7 @@ pub fn addWriteFiles(b: *Build) *Step.WriteFile {
 }
 
 pub fn addRemoveDirTree(self: *Build, dir_path: []const u8) *Step.RemoveDir {
-    const remove_dir_step = self.allocator.create(Step.RemoveDir) catch @panic("OOM");
-    remove_dir_step.* = Step.RemoveDir.init(self, dir_path);
-    return remove_dir_step;
+    return Step.RemoveDir.create(self, dir_path);
 }
 
 pub fn addFmt(b: *Build, options: Step.Fmt.Options) *Step.Fmt {

--- a/lib/std/Build/Step/RemoveDir.zig
+++ b/lib/std/Build/Step/RemoveDir.zig
@@ -8,8 +8,9 @@ pub const base_id = .remove_dir;
 step: Step,
 dir_path: []const u8,
 
-pub fn init(owner: *std.Build, dir_path: []const u8) RemoveDir {
-    return RemoveDir{
+pub fn create(owner: *std.Build, dir_path: []const u8) *RemoveDir {
+    const self = owner.allocator.create(RemoveDir) catch @panic("OOM");
+    self.* = .{
         .step = Step.init(.{
             .id = .remove_dir,
             .name = owner.fmt("RemoveDir {s}", .{dir_path}),
@@ -18,6 +19,7 @@ pub fn init(owner: *std.Build, dir_path: []const u8) RemoveDir {
         }),
         .dir_path = owner.dupePath(dir_path),
     };
+    return self;
 }
 
 fn make(step: *Step, prog_node: *std.Progress.Node) !void {


### PR DESCRIPTION
The init() function initialize a struct on the stack. This can cause issues if the struct is used later, like this example:
```zig
// build.zig
const std = @import("std");
pub fn build(b: *std.Build) void {
    var rmdir = std.Build.Step.RemoveDir.init(b, "tmp"); 
    const tls = b.step("rmdir", "rmdir");
    tls.dependOn(&rmdir.step);
}
```
Here the `rmdir` variable becomes invalid after the build() function returns, but is still used by `tls`.

This commit changes RemoveDir to use create() instead, allocating the struct on the heap rather than stack.
Also, it makes RemoveDir consistent with other build steps.