### PR TITLE
link.Elf: report file not found error

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1415,9 +1415,12 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
     }
 
     for (system_libs.items) |lib| {
-        const in_file = try std.fs.cwd().openFile(lib.path, .{});
-        defer in_file.close();
         var parse_ctx: ParseErrorCtx = .{ .detected_cpu_arch = undefined };
+        const in_file = std.fs.cwd().openFile(lib.path, .{}) catch |err| {
+            try self.handleAndReportParseError(lib.path, err, &parse_ctx);
+            continue;
+        };
+        defer in_file.close();
         self.parseLibrary(in_file, lib, false, &parse_ctx) catch |err|
             try self.handleAndReportParseError(lib.path, err, &parse_ctx);
     }


### PR DESCRIPTION
On Ubuntu 22.04 (jammy), this code path was triggered when linking against system libc, and this patch makes it report nice linker errors rather than only printing `error: FileNotFound` to stderr.