### PR TITLE
Make distinct error limit configurable (attempt #2)

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5373,8 +5373,9 @@ test "fn reflection" {
       gets assigned the same integer value.
       </p>
       <p>
-      The number of unique error values across the entire compilation should determine the size of the error set type.
-      However right now it is hard coded to be a {#syntax#}u16{#endsyntax#}. See <a href="https://github.com/ziglang/zig/issues/786">#786</a>.
+      The error set type defaults to a {#syntax#}u16{#endsyntax#}, though if the maximum number of distinct
+      error values is provided via the <kbd>--error-limit [num]</kbd> command line parameter an integer type
+      with the minimum number of bits required to represent all of the error values will be used.
       </p>
       <p>
       You can {#link|coerce|Type Coercion#} an error from a subset to a superset:

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -8373,7 +8373,7 @@ test "main" {
       {#header_close#}
 
       {#header_open|@errorFromInt#}
-      <pre>{#syntax#}@errorFromInt(value: std.meta.Int(.unsigned, @sizeOf(anyerror) * 8)) anyerror{#endsyntax#}</pre>
+      <pre>{#syntax#}@errorFromInt(value: std.meta.Int(.unsigned, @bitSizeOf(anyerror))) anyerror{#endsyntax#}</pre>
       <p>
       Converts from the integer representation of an error into {#link|The Global Error Set#} type.
       </p>
@@ -8694,7 +8694,7 @@ test "integer cast panic" {
       {#header_close#}
 
       {#header_open|@intFromError#}
-      <pre>{#syntax#}@intFromError(err: anytype) std.meta.Int(.unsigned, @sizeOf(anyerror) * 8){#endsyntax#}</pre>
+      <pre>{#syntax#}@intFromError(err: anytype) std.meta.Int(.unsigned, @bitSizeOf(anyerror)){#endsyntax#}</pre>
       <p>
       Supports the following types:
       </p>

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -8430,7 +8430,7 @@ fn builtinCall(
             return rvalue(gz, ri, result, node);
         },
         .error_from_int => {
-            const operand = try expr(gz, scope, .{ .rl = .{ .coerced_ty = .u16_type } }, params[0]);
+            const operand = try expr(gz, scope, .{ .rl = .none }, params[0]);
             const result = try gz.addExtendedPayload(.error_from_int, Zir.Inst.UnNode{
                 .node = gz.nodeIndexToRelative(node),
                 .operand = operand,

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -137,6 +137,9 @@ deletion_set: std.AutoArrayHashMapUnmanaged(Decl.Index, void) = .{},
 /// Key is the error name, index is the error tag value. Index 0 has a length-0 string.
 global_error_set: GlobalErrorSet = .{},
 
+/// Maximum amount of distinct error values, set by --error-limit
+error_limit: ErrorInt,
+
 /// Incrementing integer used to compare against the corresponding Decl
 /// field to determine whether a Decl's status applies to an ongoing update, or a
 /// previous analysis.
@@ -5018,6 +5021,11 @@ pub fn getErrorValueFromSlice(
 ) Allocator.Error!ErrorInt {
     const interned_name = try mod.intern_pool.getOrPutString(mod.gpa, name);
     return getErrorValue(mod, interned_name);
+}
+
+pub fn errorSetBits(mod: *Module) u16 {
+    if (mod.error_limit == 0) return 0;
+    return std.math.log2_int_ceil(ErrorInt, mod.error_limit + 1); // +1 for no error
 }
 
 pub fn createAnonymousDecl(mod: *Module, block: *Sema.Block, typed_value: TypedValue) !Decl.Index {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -5906,6 +5906,10 @@ pub fn intType(mod: *Module, signedness: std.builtin.Signedness, bits: u16) Allo
     } })).toType();
 }
 
+pub fn errorIntType(mod: *Module) std.mem.Allocator.Error!Type {
+    return mod.intType(.unsigned, mod.errorSetBits());
+}
+
 pub fn arrayType(mod: *Module, info: InternPool.Key.ArrayType) Allocator.Error!Type {
     const i = try intern(mod, .{ .array_type = info });
     return i.toType();

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -1052,6 +1052,7 @@ pub fn genTypedValue(
             const payload_type = typed_value.ty.errorUnionPayload(mod);
             if (!payload_type.hasRuntimeBitsIgnoreComptime(mod)) {
                 // We use the error type directly as the type.
+                const err_int_ty = try mod.errorIntType();
                 switch (mod.intern_pool.indexToKey(typed_value.val.toIntern()).error_union.val) {
                     .err_name => |err_name| return genTypedValue(bin_file, src_loc, .{
                         .ty = err_type,
@@ -1061,8 +1062,8 @@ pub fn genTypedValue(
                         } })).toValue(),
                     }, owner_decl_index),
                     .payload => return genTypedValue(bin_file, src_loc, .{
-                        .ty = Type.err_int,
-                        .val = try mod.intValue(Type.err_int, 0),
+                        .ty = err_int_ty,
+                        .val = try mod.intValue(err_int_ty, 0),
                     }, owner_decl_index),
                 }
             }

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1021,6 +1021,7 @@ pub const DeclGen = struct {
             .error_union => |error_union| {
                 const payload_ty = ty.errorUnionPayload(mod);
                 const error_ty = ty.errorUnionSet(mod);
+                const err_int_ty = try mod.errorIntType();
                 if (!payload_ty.hasRuntimeBitsIgnoreComptime(mod)) {
                     switch (error_union.val) {
                         .err_name => |err_name| return dg.renderValue(
@@ -1034,8 +1035,8 @@ pub const DeclGen = struct {
                         ),
                         .payload => return dg.renderValue(
                             writer,
-                            Type.err_int,
-                            try mod.intValue(Type.err_int, 0),
+                            err_int_ty,
+                            try mod.intValue(err_int_ty, 0),
                             location,
                         ),
                     }
@@ -1070,8 +1071,8 @@ pub const DeclGen = struct {
                     ),
                     .payload => try dg.renderValue(
                         writer,
-                        Type.err_int,
-                        try mod.intValue(Type.err_int, 0),
+                        err_int_ty,
+                        try mod.intValue(err_int_ty, 0),
                         location,
                     ),
                 }
@@ -1227,7 +1228,7 @@ pub const DeclGen = struct {
                     payload_ty,
                     switch (opt.val) {
                         .none => switch (payload_ty.zigTypeTag(mod)) {
-                            .ErrorSet => try mod.intValue(Type.err_int, 0),
+                            .ErrorSet => try mod.intValue(try mod.errorIntType(), 0),
                             .Pointer => try mod.getCoerced(val, payload_ty),
                             else => unreachable,
                         },
@@ -5179,6 +5180,7 @@ fn airIsNull(
     const operand_ty = f.typeOf(un_op);
     const optional_ty = if (is_ptr) operand_ty.childType(mod) else operand_ty;
     const payload_ty = optional_ty.optionalChild(mod);
+    const err_int_ty = try mod.errorIntType();
 
     const rhs = if (!payload_ty.hasRuntimeBitsIgnoreComptime(mod))
         TypedValue{ .ty = Type.bool, .val = Value.true }
@@ -5186,7 +5188,7 @@ fn airIsNull(
         // operand is a regular pointer, test `operand !=/== NULL`
         TypedValue{ .ty = optional_ty, .val = try mod.getCoerced(Value.null, optional_ty) }
     else if (payload_ty.zigTypeTag(mod) == .ErrorSet)
-        TypedValue{ .ty = Type.err_int, .val = try mod.intValue(Type.err_int, 0) }
+        TypedValue{ .ty = err_int_ty, .val = try mod.intValue(err_int_ty, 0) }
     else if (payload_ty.isSlice(mod) and optional_ty.optionalReprIsPayload(mod)) rhs: {
         try writer.writeAll(".ptr");
         const slice_ptr_ty = payload_ty.slicePtrFieldType(mod);
@@ -5672,8 +5674,10 @@ fn airUnwrapErrUnionErr(f: *Function, inst: Air.Inst.Index) !CValue {
                 try f.writeCValueDerefMember(writer, operand, .{ .identifier = "error" })
             else
                 try f.writeCValueMember(writer, operand, .{ .identifier = "error" })
-        else
-            try f.object.dg.renderValue(writer, Type.err_int, try mod.intValue(Type.err_int, 0), .Initializer);
+        else {
+            const err_int_ty = try mod.errorIntType();
+            try f.object.dg.renderValue(writer, err_int_ty, try mod.intValue(err_int_ty, 0), .Initializer);
+        }
     }
     try writer.writeAll(";\n");
     return local;
@@ -5794,12 +5798,13 @@ fn airErrUnionPayloadPtrSet(f: *Function, inst: Air.Inst.Index) !CValue {
     const error_union_ty = f.typeOf(ty_op.operand).childType(mod);
 
     const payload_ty = error_union_ty.errorUnionPayload(mod);
+    const err_int_ty = try mod.errorIntType();
 
     // First, set the non-error value.
     if (!payload_ty.hasRuntimeBitsIgnoreComptime(mod)) {
         try f.writeCValueDeref(writer, operand);
         try writer.writeAll(" = ");
-        try f.object.dg.renderValue(writer, Type.err_int, try mod.intValue(Type.err_int, 0), .Other);
+        try f.object.dg.renderValue(writer, err_int_ty, try mod.intValue(err_int_ty, 0), .Other);
         try writer.writeAll(";\n ");
 
         return operand;
@@ -5807,7 +5812,7 @@ fn airErrUnionPayloadPtrSet(f: *Function, inst: Air.Inst.Index) !CValue {
     try reap(f, inst, &.{ty_op.operand});
     try f.writeCValueDeref(writer, operand);
     try writer.writeAll(".error = ");
-    try f.object.dg.renderValue(writer, Type.err_int, try mod.intValue(Type.err_int, 0), .Other);
+    try f.object.dg.renderValue(writer, err_int_ty, try mod.intValue(err_int_ty, 0), .Other);
     try writer.writeAll(";\n");
 
     // Then return the payload pointer (only if it is used)
@@ -5863,7 +5868,8 @@ fn airWrapErrUnionPay(f: *Function, inst: Air.Inst.Index) !CValue {
         else
             try f.writeCValueMember(writer, local, .{ .identifier = "error" });
         try a.assign(f, writer);
-        try f.object.dg.renderValue(writer, Type.err_int, try mod.intValue(Type.err_int, 0), .Other);
+        const err_int_ty = try mod.errorIntType();
+        try f.object.dg.renderValue(writer, err_int_ty, try mod.intValue(err_int_ty, 0), .Other);
         try a.end(f, writer);
     }
     return local;
@@ -5885,6 +5891,7 @@ fn airIsErr(f: *Function, inst: Air.Inst.Index, is_ptr: bool, operator: []const 
     try f.writeCValue(writer, local, .Other);
     try writer.writeAll(" = ");
 
+    const err_int_ty = try mod.errorIntType();
     if (!error_ty.errorSetIsEmpty(mod))
         if (payload_ty.hasRuntimeBits(mod))
             if (is_ptr)
@@ -5894,11 +5901,11 @@ fn airIsErr(f: *Function, inst: Air.Inst.Index, is_ptr: bool, operator: []const 
         else
             try f.writeCValue(writer, operand, .Other)
     else
-        try f.object.dg.renderValue(writer, Type.err_int, try mod.intValue(Type.err_int, 0), .Other);
+        try f.object.dg.renderValue(writer, err_int_ty, try mod.intValue(err_int_ty, 0), .Other);
     try writer.writeByte(' ');
     try writer.writeAll(operator);
     try writer.writeByte(' ');
-    try f.object.dg.renderValue(writer, Type.err_int, try mod.intValue(Type.err_int, 0), .Other);
+    try f.object.dg.renderValue(writer, err_int_ty, try mod.intValue(err_int_ty, 0), .Other);
     try writer.writeAll(";\n");
     return local;
 }

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -159,7 +159,6 @@ pub const Type = enum(u32) {
     none = std.math.maxInt(u32),
     _,
 
-    pub const err_int = Type.i16;
     pub const ptr_amdgpu_constant =
         @field(Type, std.fmt.comptimePrint("ptr{ }", .{AddrSpace.amdgpu.constant}));
 

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -742,16 +742,17 @@ const DeclGen = struct {
             .error_union => |error_union| {
                 // TODO: Error unions may be constructed with constant instructions if the payload type
                 // allows it. For now, just generate it here regardless.
+                const err_int_ty = try mod.errorIntType();
                 const err_ty = switch (error_union.val) {
                     .err_name => ty.errorUnionSet(mod),
-                    .payload => Type.err_int,
+                    .payload => err_int_ty,
                 };
                 const err_val = switch (error_union.val) {
                     .err_name => |err_name| (try mod.intern(.{ .err = .{
                         .ty = ty.errorUnionSet(mod).toIntern(),
                         .name = err_name,
                     } })).toValue(),
-                    .payload => try mod.intValue(Type.err_int, 0),
+                    .payload => try mod.intValue(err_int_ty, 0),
                 };
                 const payload_ty = ty.errorUnionPayload(mod);
                 const eu_layout = self.errorUnionLayout(payload_ty);

--- a/src/main.zig
+++ b/src/main.zig
@@ -421,6 +421,7 @@ const usage_build_generic =
     \\  --deps [dep],[dep],...    Set dependency names for the root package
     \\      dep:  [[import=]name]
     \\  --main-mod-path           Set the directory of the root module
+    \\  --error-limit [num]       Set the maximum amount of distinct error values
     \\  -fPIC                     Force-enable Position Independent Code
     \\  -fno-PIC                  Force-disable Position Independent Code
     \\  -fPIE                     Force-enable Position Independent Executable
@@ -911,6 +912,8 @@ fn buildOutputType(
     var error_tracing: ?bool = null;
     var pdb_out_path: ?[]const u8 = null;
     var dwarf_format: ?std.dwarf.Format = null;
+    var error_limit: ?Module.ErrorInt = null;
+
     // e.g. -m3dnow or -mno-outline-atomics. They correspond to std.Target llvm cpu feature names.
     // This array is populated by zig cc frontend and then has to be converted to zig-style
     // CPU features.
@@ -1040,6 +1043,11 @@ fn buildOutputType(
                         root_deps_str = args_iter.nextOrFatal();
                     } else if (mem.eql(u8, arg, "--main-mod-path")) {
                         main_mod_path = args_iter.nextOrFatal();
+                    } else if (mem.eql(u8, arg, "--error-limit")) {
+                        const next_arg = args_iter.nextOrFatal();
+                        error_limit = std.fmt.parseUnsigned(Module.ErrorInt, next_arg, 0) catch |err| {
+                            fatal("unable to parse error limit '{s}': {s}", .{ next_arg, @errorName(err) });
+                        };
                     } else if (mem.eql(u8, arg, "-cflags")) {
                         extra_cflags.shrinkRetainingCapacity(0);
                         while (true) {
@@ -3546,6 +3554,7 @@ fn buildOutputType(
         .reference_trace = reference_trace,
         .error_tracing = error_tracing,
         .pdb_out_path = pdb_out_path,
+        .error_limit = error_limit,
     }) catch |err| switch (err) {
         error.LibCUnavailable => {
             const target = target_info.target;

--- a/src/type.zig
+++ b/src/type.zig
@@ -3309,8 +3309,6 @@ pub const Type = struct {
 
     pub const generic_poison: Type = .{ .ip_index = .generic_poison_type };
 
-    pub const err_int = Type.u16;
-
     pub fn smallestUnsignedBits(max: u64) u16 {
         if (max == 0) return 0;
         const base = std.math.log2(max);


### PR DESCRIPTION
First attempt #17532 was rebased from a pre-InternPool version so I didn't notice these changes with no `TODO revisit` comment.

Closes #786
Includes #17627