### PR TITLE
std: slightly improve codegen of `std.unicode.utf8ValidateSlice`

### DIFF
--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -200,21 +200,18 @@ pub fn utf8CountCodepoints(s: []const u8) !usize {
 pub fn utf8ValidateSlice(input: []const u8) bool {
     var remaining = input;
 
-    const V_len = std.simd.suggestVectorSize(usize) orelse 1;
-    const V = @Vector(V_len, usize);
-    const u8s_in_vector = @sizeOf(usize) * V_len;
+    const chunk_len = std.simd.suggestVectorSize(u8) orelse 1;
+    const Chunk = @Vector(chunk_len, u8);
 
     // Fast path. Check for and skip ASCII characters at the start of the input.
-    while (remaining.len >= u8s_in_vector) {
-        const chunk: V = @bitCast(remaining[0..u8s_in_vector].*);
-        const swapped = mem.littleToNative(V, chunk);
-        const reduced = @reduce(.Or, swapped);
-        const mask: usize = @bitCast([1]u8{0x80} ** @sizeOf(usize));
-        if (reduced & mask != 0) {
-            // Found a non ASCII byte
+    while (remaining.len >= chunk_len) {
+        const chunk: Chunk = remaining[0..chunk_len].*;
+        const mask: Chunk = @splat(0x80);
+        if (@reduce(.Or, chunk & mask == mask)) {
+            // found a non ASCII byte
             break;
         }
-        remaining = remaining[u8s_in_vector..];
+        remaining = remaining[chunk_len..];
     }
 
     // default lowest and highest continuation byte


### PR DESCRIPTION
This changes optimized x86_64 from
```
  20bbe0:	f3 0f 6f 07          	movdqu (%rdi),%xmm0
  20bbe4:	66 0f 70 c8 ee       	pshufd $0xee,%xmm0,%xmm1
  20bbe9:	66 0f eb c8          	por    %xmm0,%xmm1
  20bbed:	66 48 0f 7e c9       	movq   %xmm1,%rcx
  20bbf2:	48 85 c1             	test   %rax,%rcx
  20bbf5:	75 17                	jne    20bc0e <std_utf8ValidateSlice+0x4e>
```
to
```
  20bcd0:	f3 0f 6f 07          	movdqu (%rdi),%xmm0
  20bcd4:	66 0f d7 c0          	pmovmskb %xmm0,%eax
  20bcd8:	85 c0                	test   %eax,%eax
  20bcda:	75 17                	jne    20bcf3 <new_utf8ValidateSlice+0x33>
```

While this isn't a complete wash performance-wise for some reason, I also have an ulterior motive of making it easier to codegen in the x86_64 backend.

[bench.zig](https://github.com/ziglang/zig/files/13061410/bench.zig.txt)
```
=== x86_64 Debug ===
empty.std: 91.243us
empty.new: 79.823us

short.ascii.std: 159.426us
short.ascii.new: 144.175us

long.ascii.std: 26.52ms
long.ascii.new: 19.436ms

long.chinese.std: 487.397ms
long.chinese.new: 531.267ms

short.invalid.std: 202.888us
short.invalid.new: 236.049us

long.invalid.std: 484.941ms
long.invalid.new: 526.923ms

=== x86_64 ReleaseFast ===
empty.std: 60ns
empty.new: 30ns

short.ascii.std: 20ns
short.ascii.new: 20ns

long.ascii.std: 230ns
long.ascii.new: 210ns

long.chinese.std: 4.26us
long.chinese.new: 4.22us

short.invalid.std: 40ns
short.invalid.new: 40ns

long.invalid.std: 4.16us
long.invalid.new: 4.19us

=== x86_64_v2 Debug ===
empty.std: 91.273us
empty.new: 79.823us

short.ascii.std: 159.446us
short.ascii.new: 150.235us

long.ascii.std: 26.617ms
long.ascii.new: 19.532ms

long.chinese.std: 493.534ms
long.chinese.new: 540.193ms

short.invalid.std: 213.779us
short.invalid.new: 240.49us

long.invalid.std: 492.831ms
long.invalid.new: 537.528ms

=== x86_64_v2 ReleaseFast ===
empty.std: 50ns
empty.new: 30ns

short.ascii.std: 20ns
short.ascii.new: 20ns

long.ascii.std: 240ns
long.ascii.new: 210ns

long.chinese.std: 4.26us
long.chinese.new: 4.14us

short.invalid.std: 30ns
short.invalid.new: 40ns

long.invalid.std: 4.17us
long.invalid.new: 4.151us

=== x86_64_v3 Debug ===
empty.std: 90.843us
empty.new: 79.453us

short.ascii.std: 158.707us
short.ascii.new: 143.495us

long.ascii.std: 26.444ms
long.ascii.new: 19.42ms

long.chinese.std: 493.351ms
long.chinese.new: 537.322ms

short.invalid.std: 199.248us
short.invalid.new: 236.05us

long.invalid.std: 490.375ms
long.invalid.new: 536.322ms

=== x86_64_v3 ReleaseFast ===
empty.std: 100ns
empty.new: 30ns

short.ascii.std: 30ns
short.ascii.new: 20ns

long.ascii.std: 230ns
long.ascii.new: 210ns

long.chinese.std: 4.28us
long.chinese.new: 4.22us

short.invalid.std: 40ns
short.invalid.new: 30ns

long.invalid.std: 4.2us
long.invalid.new: 4.18us

=== x86_64_v4 Debug ===
empty.std: 90.803us
empty.new: 81.723us

short.ascii.std: 165.417us
short.ascii.new: 143.496us

long.ascii.std: 26.533ms
long.ascii.new: 19.501ms

long.chinese.std: 496.125ms
long.chinese.new: 544.263ms

short.invalid.std: 200.288us
short.invalid.new: 239.469us

long.invalid.std: 501.129ms
long.invalid.new: 544.503ms

=== x86_64_v4 ReleaseFast ===
empty.std: 100ns
empty.new: 30ns

short.ascii.std: 20ns
short.ascii.new: 20ns

long.ascii.std: 420ns
long.ascii.new: 200ns

long.chinese.std: 4.14us
long.chinese.new: 4.05us

short.invalid.std: 40ns
short.invalid.new: 40ns

long.invalid.std: 4.03us
long.invalid.new: 4.04us
```