### PR TITLE
Sema: move remaining anon decls to new mechanism

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3556,7 +3556,7 @@ fn processOneJob(comp: *Compilation, job: Job, prog_node: *std.Progress.Node) !v
                         .gpa = gpa,
                         .module = module,
                         .error_msg = null,
-                        .decl_index = decl_index.toOptional(),
+                        .pass = .{ .decl = decl_index },
                         .is_naked_fn = false,
                         .fwd_decl = fwd_decl.toManaged(gpa),
                         .ctypes = .{},

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -16813,7 +16813,6 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
             .val = .void_value,
         } }))),
         .Fn => {
-            // TODO: look into memoizing this result.
             var params_anon_decl = try block.startAnonDecl();
             defer params_anon_decl.deinit();
 
@@ -17270,7 +17269,6 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
             } })));
         },
         .Enum => {
-            // TODO: look into memoizing this result.
             const is_exhaustive = Value.makeBool(ip.indexToKey(ty.toIntern()).enum_type.tag_mode != .nonexhaustive);
 
             var fields_anon_decl = try block.startAnonDecl();
@@ -17397,8 +17395,6 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
             } })));
         },
         .Union => {
-            // TODO: look into memoizing this result.
-
             var fields_anon_decl = try block.startAnonDecl();
             defer fields_anon_decl.deinit();
 
@@ -17547,8 +17543,6 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
             } })));
         },
         .Struct => {
-            // TODO: look into memoizing this result.
-
             var fields_anon_decl = try block.startAnonDecl();
             defer fields_anon_decl.deinit();
 
@@ -17781,8 +17775,6 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
             } })));
         },
         .Opaque => {
-            // TODO: look into memoizing this result.
-
             const type_opaque_ty = t: {
                 const type_opaque_ty_decl_index = (try sema.namespaceLookup(
                     block,

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1290,11 +1290,14 @@ pub const DeclGen = struct {
                             var index: usize = 0;
                             while (index < ai.len) : (index += 1) {
                                 const elem_val = try val.elemValue(mod, index);
-                                const elem_val_u8 = if (elem_val.isUndef(mod)) undefPattern(u8) else @as(u8, @intCast(elem_val.toUnsignedInt(mod)));
+                                const elem_val_u8: u8 = if (elem_val.isUndef(mod))
+                                    undefPattern(u8)
+                                else
+                                    @intCast(elem_val.toUnsignedInt(mod));
                                 try literal.writeChar(elem_val_u8);
                             }
                             if (ai.sentinel) |s| {
-                                const s_u8 = @as(u8, @intCast(s.toUnsignedInt(mod)));
+                                const s_u8: u8 = @intCast(s.toUnsignedInt(mod));
                                 if (s_u8 != 0) try literal.writeChar(s_u8);
                             }
                             try literal.end();
@@ -1304,7 +1307,10 @@ pub const DeclGen = struct {
                             while (index < ai.len) : (index += 1) {
                                 if (index != 0) try writer.writeByte(',');
                                 const elem_val = try val.elemValue(mod, index);
-                                const elem_val_u8 = if (elem_val.isUndef(mod)) undefPattern(u8) else @as(u8, @intCast(elem_val.toUnsignedInt(mod)));
+                                const elem_val_u8: u8 = if (elem_val.isUndef(mod))
+                                    undefPattern(u8)
+                                else
+                                    @intCast(elem_val.toUnsignedInt(mod));
                                 try writer.print("'\\x{x}'", .{elem_val_u8});
                             }
                             if (ai.sentinel) |s| {

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1737,46 +1737,51 @@ pub fn getDeclVAddr(self: *Coff, decl_index: Module.Decl.Index, reloc_info: link
     return 0;
 }
 
-pub fn lowerAnonDecl(self: *Coff, decl_val: InternPool.Index, decl_align: InternPool.Alignment, src_loc: Module.SrcLoc) !codegen.Result {
-    // This is basically the same as lowerUnnamedConst.
-    // example:
-    // const ty = mod.intern_pool.typeOf(decl_val).toType();
-    // const val = decl_val.toValue();
-    // The symbol name can be something like `__anon_{d}` with `@intFromEnum(decl_val)`.
-    // It doesn't have an owner decl because it's just an unnamed constant that might
-    // be used by more than one function, however, its address is being used so we need
-    // to put it in some location.
-    // ...
+pub fn lowerAnonDecl(
+    self: *Coff,
+    decl_val: InternPool.Index,
+    explicit_alignment: InternPool.Alignment,
+    src_loc: Module.SrcLoc,
+) !codegen.Result {
     const gpa = self.base.allocator;
     const mod = self.base.options.module.?;
     const ty = mod.intern_pool.typeOf(decl_val).toType();
-    const gop = try self.anon_decls.getOrPut(gpa, decl_val);
-    const required_alignment = switch (decl_align) {
+    const decl_alignment = switch (explicit_alignment) {
         .none => ty.abiAlignment(mod),
-        else => decl_align,
+        else => explicit_alignment,
     };
-    if (!gop.found_existing or
-        !required_alignment.check(self.getAtom(gop.value_ptr.*).getSymbol(self).value))
-    {
-        const val = decl_val.toValue();
-        const tv = TypedValue{ .ty = ty, .val = val };
-        const name = try std.fmt.allocPrint(gpa, "__anon_{d}", .{@intFromEnum(decl_val)});
-        defer gpa.free(name);
-        const res = self.lowerConst(name, tv, required_alignment, self.rdata_section_index.?, src_loc) catch |err| switch (err) {
-            else => {
-                // TODO improve error message
-                const em = try Module.ErrorMsg.create(gpa, src_loc, "lowerAnonDecl failed with error: {s}", .{
-                    @errorName(err),
-                });
-                return .{ .fail = em };
-            },
-        };
-        const atom_index = switch (res) {
-            .ok => |atom_index| atom_index,
-            .fail => |em| return .{ .fail = em },
-        };
-        gop.value_ptr.* = atom_index;
+    if (self.anon_decls.get(decl_val)) |atom_index| {
+        const existing_addr = self.getAtom(atom_index).getSymbol(self).value;
+        if (decl_alignment.check(existing_addr))
+            return .ok;
     }
+
+    const val = decl_val.toValue();
+    const tv = TypedValue{ .ty = ty, .val = val };
+    var name_buf: [32]u8 = undefined;
+    const name = std.fmt.bufPrint(&name_buf, "__anon_{d}", .{
+        @intFromEnum(decl_val),
+    }) catch unreachable;
+    const res = self.lowerConst(
+        name,
+        tv,
+        decl_alignment,
+        self.rdata_section_index.?,
+        src_loc,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => |e| return .{ .fail = try Module.ErrorMsg.create(
+            gpa,
+            src_loc,
+            "lowerAnonDecl failed with error: {s}",
+            .{@errorName(e)},
+        ) },
+    };
+    const atom_index = switch (res) {
+        .ok => |atom_index| atom_index,
+        .fail => |em| return .{ .fail = em },
+    };
+    try self.anon_decls.put(gpa, decl_val, atom_index);
     return .ok;
 }
 

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2866,46 +2866,51 @@ pub fn getDeclVAddr(self: *MachO, decl_index: Module.Decl.Index, reloc_info: Fil
     return 0;
 }
 
-pub fn lowerAnonDecl(self: *MachO, decl_val: InternPool.Index, decl_align: InternPool.Alignment, src_loc: Module.SrcLoc) !codegen.Result {
-    // This is basically the same as lowerUnnamedConst.
-    // example:
-    // const ty = mod.intern_pool.typeOf(decl_val).toType();
-    // const val = decl_val.toValue();
-    // The symbol name can be something like `__anon_{d}` with `@intFromEnum(decl_val)`.
-    // It doesn't have an owner decl because it's just an unnamed constant that might
-    // be used by more than one function, however, its address is being used so we need
-    // to put it in some location.
-    // ...
+pub fn lowerAnonDecl(
+    self: *MachO,
+    decl_val: InternPool.Index,
+    explicit_alignment: InternPool.Alignment,
+    src_loc: Module.SrcLoc,
+) !codegen.Result {
     const gpa = self.base.allocator;
     const mod = self.base.options.module.?;
     const ty = mod.intern_pool.typeOf(decl_val).toType();
-    const gop = try self.anon_decls.getOrPut(gpa, decl_val);
-    const required_alignment = switch (decl_align) {
+    const decl_alignment = switch (explicit_alignment) {
         .none => ty.abiAlignment(mod),
-        else => decl_align,
+        else => explicit_alignment,
     };
-    if (!gop.found_existing or
-        !required_alignment.check(self.getAtom(gop.value_ptr.*).getSymbol(self).n_value))
-    {
-        const val = decl_val.toValue();
-        const tv = TypedValue{ .ty = ty, .val = val };
-        const name = try std.fmt.allocPrint(gpa, "__anon_{d}", .{@intFromEnum(decl_val)});
-        defer gpa.free(name);
-        const res = self.lowerConst(name, tv, required_alignment, self.data_const_section_index.?, src_loc) catch |err| switch (err) {
-            else => {
-                // TODO improve error message
-                const em = try Module.ErrorMsg.create(gpa, src_loc, "lowerAnonDecl failed with error: {s}", .{
-                    @errorName(err),
-                });
-                return .{ .fail = em };
-            },
-        };
-        const atom_index = switch (res) {
-            .ok => |atom_index| atom_index,
-            .fail => |em| return .{ .fail = em },
-        };
-        gop.value_ptr.* = atom_index;
+    if (self.anon_decls.get(decl_val)) |atom_index| {
+        const existing_addr = self.getAtom(atom_index).getSymbol(self).n_value;
+        if (decl_alignment.check(existing_addr))
+            return .ok;
     }
+
+    const val = decl_val.toValue();
+    const tv = TypedValue{ .ty = ty, .val = val };
+    var name_buf: [32]u8 = undefined;
+    const name = std.fmt.bufPrint(&name_buf, "__anon_{d}", .{
+        @intFromEnum(decl_val),
+    }) catch unreachable;
+    const res = self.lowerConst(
+        name,
+        tv,
+        decl_alignment,
+        self.data_const_section_index.?,
+        src_loc,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => |e| return .{ .fail = try Module.ErrorMsg.create(
+            gpa,
+            src_loc,
+            "unable to lower constant value: {s}",
+            .{@errorName(e)},
+        ) },
+    };
+    const atom_index = switch (res) {
+        .ok => |atom_index| atom_index,
+        .fail => |em| return .{ .fail = em },
+    };
+    try self.anon_decls.put(gpa, decl_val, atom_index);
     return .ok;
 }
 


### PR DESCRIPTION
After this, down to only 4 uses of startAnonDecl() and 3 of them are for comptime value mutation.
```
$ grep -RI startAnonDecl src
src/Sema.zig:    pub fn startAnonDecl(block: *Block) !WipAnonDecl {
src/Sema.zig:    var anon_decl = try block.startAnonDecl(); // TODO: comptime value mutation without Decl
src/Sema.zig:        var anon_decl = try block.startAnonDecl(); // TODO: comptime value mutation without Decl
src/Sema.zig:        var anon_decl = try block.startAnonDecl(); // TODO: export value without Decl
src/Sema.zig:    var anon_decl = try block.startAnonDecl(); // TODO: comptime value mutation without Decl
```