### PR TITLE
Remove `InternPool.Key.runtime_value`, clean up Sema value resolution functions

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3666,7 +3666,13 @@ fn ReverseIterator(comptime T: type) type {
         @compileError("expected slice or pointer to array, found '" ++ @typeName(T) ++ "'");
     };
     const Element = std.meta.Elem(Pointer);
-    const ElementPointer = @TypeOf(&@as(Pointer, undefined)[0]);
+    const ElementPointer = @Type(.{ .Pointer = ptr: {
+        var ptr = @typeInfo(Pointer).Pointer;
+        ptr.size = .One;
+        ptr.child = Element;
+        ptr.sentinel = null;
+        break :ptr ptr;
+    } });
     return struct {
         ptr: Pointer,
         index: usize,

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3757,7 +3757,7 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
     const address_space_src: LazySrcLoc = .{ .node_offset_var_decl_addrspace = 0 };
     const ty_src: LazySrcLoc = .{ .node_offset_var_decl_ty = 0 };
     const init_src: LazySrcLoc = .{ .node_offset_var_decl_init = 0 };
-    const decl_tv = try sema.resolveInstValue(&block_scope, init_src, result_ref, .{
+    const decl_tv = try sema.resolveInstValueAllowVariables(&block_scope, init_src, result_ref, .{
         .needed_comptime_reason = "global variable initializer must be comptime-known",
     });
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2104,7 +2104,6 @@ fn resolveDefinedValue(
     const mod = sema.mod;
     const val = try sema.resolveValue(air_ref) orelse return null;
     if (val.isUndef(mod)) {
-        if (block.is_typeof) return null;
         return sema.failWithUseOfUndef(block, src);
     }
     return val;

--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -206,7 +206,6 @@ pub fn print(
             .inferred_error_set_type,
             => return Type.print(val.toType(), writer, mod),
             .undef => return writer.writeAll("undefined"),
-            .runtime_value => return writer.writeAll("(runtime value)"),
             .simple_value => |simple_value| switch (simple_value) {
                 .void => return writer.writeAll("{}"),
                 .empty_struct => return printAggregate(ty, val, writer, level, mod),

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3224,16 +3224,11 @@ fn toTwosComplement(value: anytype, bits: u7) std.meta.Int(.unsigned, @typeInfo(
 
 /// This function is intended to assert that `isByRef` returns `false` for `ty`.
 /// However such an assertion fails on the behavior tests currently.
-fn lowerConstant(func: *CodeGen, arg_val: Value, ty: Type) InnerError!WValue {
+fn lowerConstant(func: *CodeGen, val: Value, ty: Type) InnerError!WValue {
     const mod = func.bin_file.base.options.module.?;
     // TODO: enable this assertion
     //assert(!isByRef(ty, mod));
     const ip = &mod.intern_pool;
-    var val = arg_val;
-    switch (ip.indexToKey(val.ip_index)) {
-        .runtime_value => |rt| val = rt.val.toValue(),
-        else => {},
-    }
     if (val.isUndefDeep(mod)) return func.emitUndefined(ty);
 
     switch (ip.indexToKey(val.ip_index)) {
@@ -3255,7 +3250,7 @@ fn lowerConstant(func: *CodeGen, arg_val: Value, ty: Type) InnerError!WValue {
         .inferred_error_set_type,
         => unreachable, // types, not values
 
-        .undef, .runtime_value => unreachable, // handled above
+        .undef => unreachable, // handled above
         .simple_value => |simple_value| switch (simple_value) {
             .undefined,
             .void,

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -167,11 +167,7 @@ pub fn generateSymbol(
 
     const mod = bin_file.options.module.?;
     const ip = &mod.intern_pool;
-    var typed_value = arg_tv;
-    switch (ip.indexToKey(typed_value.val.toIntern())) {
-        .runtime_value => |rt| typed_value.val = rt.val.toValue(),
-        else => {},
-    }
+    const typed_value = arg_tv;
 
     const target = mod.getTarget();
     const endian = target.cpu.arch.endian();
@@ -206,7 +202,7 @@ pub fn generateSymbol(
         .inferred_error_set_type,
         => unreachable, // types, not values
 
-        .undef, .runtime_value => unreachable, // handled above
+        .undef => unreachable, // handled above
         .simple_value => |simple_value| switch (simple_value) {
             .undefined,
             .void,
@@ -970,11 +966,7 @@ pub fn genTypedValue(
     owner_decl_index: Module.Decl.Index,
 ) CodeGenError!GenResult {
     const mod = bin_file.options.module.?;
-    var typed_value = arg_tv;
-    switch (mod.intern_pool.indexToKey(typed_value.val.toIntern())) {
-        .runtime_value => |rt| typed_value.val = rt.val.toValue(),
-        else => {},
-    }
+    const typed_value = arg_tv;
 
     log.debug("genTypedValue: ty = {}, val = {}", .{
         typed_value.ty.fmt(mod),

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -772,17 +772,12 @@ pub const DeclGen = struct {
         dg: *DeclGen,
         writer: anytype,
         ty: Type,
-        arg_val: Value,
+        val: Value,
         location: ValueRenderLocation,
     ) error{ OutOfMemory, AnalysisFail }!void {
         const mod = dg.module;
         const ip = &mod.intern_pool;
 
-        var val = arg_val;
-        switch (ip.indexToKey(val.ip_index)) {
-            .runtime_value => |rt| val = rt.val.toValue(),
-            else => {},
-        }
         const target = mod.getTarget();
         const initializer_type: ValueRenderLocation = switch (location) {
             .StaticInitializer => .StaticInitializer,
@@ -1005,7 +1000,7 @@ pub const DeclGen = struct {
             .memoized_call,
             => unreachable,
 
-            .undef, .runtime_value => unreachable, // handled above
+            .undef => unreachable, // handled above
             .simple_value => |simple_value| switch (simple_value) {
                 // non-runtime values
                 .undefined => unreachable,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3560,7 +3560,6 @@ pub const Object = struct {
                 .error_set_type, .inferred_error_set_type => try o.errorIntType(),
                 // values, not types
                 .undef,
-                .runtime_value,
                 .simple_value,
                 .variable,
                 .extern_func,
@@ -3672,17 +3671,13 @@ pub const Object = struct {
         const ip = &mod.intern_pool;
         const target = mod.getTarget();
 
-        var val = arg_val.toValue();
-        const arg_val_key = ip.indexToKey(arg_val);
-        switch (arg_val_key) {
-            .runtime_value => |rt| val = rt.val.toValue(),
-            else => {},
-        }
+        const val = arg_val.toValue();
+        const val_key = ip.indexToKey(val.toIntern());
+
         if (val.isUndefDeep(mod)) {
-            return o.builder.undefConst(try o.lowerType(arg_val_key.typeOf().toType()));
+            return o.builder.undefConst(try o.lowerType(val_key.typeOf().toType()));
         }
 
-        const val_key = ip.indexToKey(val.toIntern());
         const ty = val_key.typeOf().toType();
         return switch (val_key) {
             .int_type,
@@ -3703,7 +3698,7 @@ pub const Object = struct {
             .inferred_error_set_type,
             => unreachable, // types, not values
 
-            .undef, .runtime_value => unreachable, // handled above
+            .undef => unreachable, // handled above
             .simple_value => |simple_value| switch (simple_value) {
                 .undefined,
                 .void,

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -644,11 +644,7 @@ const DeclGen = struct {
         const result_ty_ref = try self.resolveType(ty, repr);
         const ip = &mod.intern_pool;
 
-        var val = arg_val;
-        switch (ip.indexToKey(val.toIntern())) {
-            .runtime_value => |rt| val = rt.val.toValue(),
-            else => {},
-        }
+        const val = arg_val;
 
         log.debug("constant: ty = {}, val = {}", .{ ty.fmt(mod), val.fmtValue(ty, mod) });
         if (val.isUndefDeep(mod)) {
@@ -674,7 +670,7 @@ const DeclGen = struct {
             .inferred_error_set_type,
             => unreachable, // types, not values
 
-            .undef, .runtime_value => unreachable, // handled above
+            .undef => unreachable, // handled above
 
             .variable,
             .extern_func,

--- a/src/type.zig
+++ b/src/type.zig
@@ -414,7 +414,6 @@ pub const Type = struct {
 
             // values, not types
             .undef,
-            .runtime_value,
             .simple_value,
             .variable,
             .extern_func,
@@ -633,7 +632,6 @@ pub const Type = struct {
 
                 // values, not types
                 .undef,
-                .runtime_value,
                 .simple_value,
                 .variable,
                 .extern_func,
@@ -741,7 +739,6 @@ pub const Type = struct {
 
             // values, not types
             .undef,
-            .runtime_value,
             .simple_value,
             .variable,
             .extern_func,
@@ -1103,7 +1100,6 @@ pub const Type = struct {
 
                 // values, not types
                 .undef,
-                .runtime_value,
                 .simple_value,
                 .variable,
                 .extern_func,
@@ -1461,7 +1457,6 @@ pub const Type = struct {
 
                 // values, not types
                 .undef,
-                .runtime_value,
                 .simple_value,
                 .variable,
                 .extern_func,
@@ -1681,7 +1676,6 @@ pub const Type = struct {
 
             // values, not types
             .undef,
-            .runtime_value,
             .simple_value,
             .variable,
             .extern_func,
@@ -2217,7 +2211,6 @@ pub const Type = struct {
 
                 // values, not types
                 .undef,
-                .runtime_value,
                 .simple_value,
                 .variable,
                 .extern_func,
@@ -2560,7 +2553,6 @@ pub const Type = struct {
 
                 // values, not types
                 .undef,
-                .runtime_value,
                 .simple_value,
                 .variable,
                 .extern_func,
@@ -2754,7 +2746,6 @@ pub const Type = struct {
 
                 // values, not types
                 .undef,
-                .runtime_value,
                 .simple_value,
                 .variable,
                 .extern_func,

--- a/src/value.zig
+++ b/src/value.zig
@@ -364,7 +364,6 @@ pub const Value = struct {
             .inferred_error_set_type,
 
             .undef,
-            .runtime_value,
             .simple_value,
             .variable,
             .extern_func,
@@ -464,7 +463,6 @@ pub const Value = struct {
             .bool_true => BigIntMutable.init(&space.limbs, 1).toConst(),
             .null_value => BigIntMutable.init(&space.limbs, 0).toConst(),
             else => switch (mod.intern_pool.indexToKey(val.toIntern())) {
-                .runtime_value => |runtime_value| runtime_value.val.toValue().toBigIntAdvanced(space, mod, opt_sema),
                 .int => |int| switch (int.storage) {
                     .u64, .i64, .big_int => int.storage.toBigInt(space),
                     .lazy_align, .lazy_size => |ty| {
@@ -1655,10 +1653,6 @@ pub const Value = struct {
             .int => |int| int.storage == .lazy_size,
             else => false,
         };
-    }
-
-    pub fn isRuntimeValue(val: Value, mod: *Module) bool {
-        return mod.intern_pool.isRuntimeValue(val.toIntern());
     }
 
     /// Returns true if a Value is backed by a variable

--- a/src/value.zig
+++ b/src/value.zig
@@ -1655,30 +1655,6 @@ pub const Value = struct {
         };
     }
 
-    /// Returns true if a Value is backed by a variable
-    pub fn isVariable(val: Value, mod: *Module) bool {
-        return val.ip_index != .none and switch (mod.intern_pool.indexToKey(val.toIntern())) {
-            .variable => true,
-            .ptr => |ptr| switch (ptr.addr) {
-                .decl => |decl_index| {
-                    const decl = mod.declPtr(decl_index);
-                    assert(decl.has_tv);
-                    return decl.val.isVariable(mod);
-                },
-                .mut_decl => |mut_decl| {
-                    const decl = mod.declPtr(mut_decl.decl);
-                    assert(decl.has_tv);
-                    return decl.val.isVariable(mod);
-                },
-                .int => false,
-                .eu_payload, .opt_payload => |base_ptr| base_ptr.toValue().isVariable(mod),
-                .comptime_field => |comptime_field| comptime_field.toValue().isVariable(mod),
-                .elem, .field => |base_index| base_index.base.toValue().isVariable(mod),
-            },
-            else => false,
-        };
-    }
-
     pub fn isPtrToThreadLocal(val: Value, mod: *Module) bool {
         const backing_decl = mod.intern_pool.getBackingDecl(val.toIntern()).unwrap() orelse return false;
         const variable = mod.declPtr(backing_decl).getOwnedVariable(mod) orelse return false;


### PR DESCRIPTION
See commit messages for details.

Depends on #17688.