### PR TITLE
std.os.windows additions and fixes

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2637,6 +2637,7 @@ pub const HWND = *opaque {};
 pub const HDC = *opaque {};
 pub const HGLRC = *opaque {};
 pub const FARPROC = *opaque {};
+pub const PROC = *opaque {};
 pub const INT = c_int;
 pub const LPCSTR = [*:0]const CHAR;
 pub const LPCVOID = *const anyopaque;
@@ -3438,6 +3439,10 @@ pub const E_ACCESSDENIED = @as(c_long, @bitCast(@as(c_ulong, 0x80070005)));
 pub const E_HANDLE = @as(c_long, @bitCast(@as(c_ulong, 0x80070006)));
 pub const E_OUTOFMEMORY = @as(c_long, @bitCast(@as(c_ulong, 0x8007000E)));
 pub const E_INVALIDARG = @as(c_long, @bitCast(@as(c_ulong, 0x80070057)));
+
+pub fn HRESULT_CODE(hr: HRESULT) Win32Error {
+    return @enumFromInt(hr & 0xFFFF);
+}
 
 pub const FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
 pub const FILE_FLAG_DELETE_ON_CLOSE = 0x04000000;

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -193,7 +193,7 @@ pub extern "kernel32" fn GetExitCodeProcess(hProcess: HANDLE, lpExitCode: *DWORD
 
 pub extern "kernel32" fn GetFileSizeEx(hFile: HANDLE, lpFileSize: *LARGE_INTEGER) callconv(WINAPI) BOOL;
 
-pub extern "kernel32" fn GetFileAttributesW(lpFileName: [*]const WCHAR) callconv(WINAPI) DWORD;
+pub extern "kernel32" fn GetFileAttributesW(lpFileName: [*:0]const WCHAR) callconv(WINAPI) DWORD;
 
 pub extern "kernel32" fn GetModuleFileNameW(hModule: ?HMODULE, lpFilename: [*]u16, nSize: DWORD) callconv(WINAPI) DWORD;
 
@@ -392,7 +392,7 @@ pub extern "kernel32" fn WriteFileEx(
 
 pub extern "kernel32" fn LoadLibraryW(lpLibFileName: [*:0]const u16) callconv(WINAPI) ?HMODULE;
 
-pub extern "kernel32" fn GetProcAddress(hModule: HMODULE, lpProcName: [*]const u8) callconv(WINAPI) ?FARPROC;
+pub extern "kernel32" fn GetProcAddress(hModule: HMODULE, lpProcName: [*:0]const u8) callconv(WINAPI) ?FARPROC;
 
 pub extern "kernel32" fn FreeLibrary(hModule: HMODULE) callconv(WINAPI) BOOL;
 


### PR DESCRIPTION
This pull request addresses issues I have found with `std.os.windows` while using it.

### std.os.windows
- Added `PROC` type
- Added `HRESULT_CODE` macro

### std.os.windows.opengl32 (new)
- Moved `wglCreateContext` from gdi32
- Moved `wglMakeCurrent` from gdi32
- Fixed `wglCreateContext` using incorrect types
- Fixed `wglMakeCurrent` using incorrect types
- Added zig wrapper for `wglCreateContext`
- Added zig wrapper for `wglMakeCurrent`
- Added `wglDeleteContext` + zig wrapper
- Added `wglGetProcAddress`

### std.os.windows.dwmapi (new) 
- Added `DwmFlush` + zig wrapper

### std.os.windows.gdi32
- Added constants required for `PIXELFORMATDESCRIPTOR`
- Fixed `SetPixelFormat` using incorrect types
- Added zig wrapper for `SetPixelFormat` 
- Fixed `ChoosePixelFormat` using incorrect types
- Added zig wrapper for `ChoosePixelFormat`
- Added `DescribePixelFormat` + zig wrapper
- Moved `wglCreateContext` and `wglMakeCurrent` to opengl32
- Fixed `SwapBuffers` using incorrect types
- Added zig wrapper for `SwapBuffers`

### std.os.windows.kernel32
- Fixed `GetFileAttributesW` using incorrect types (`[*]const WCHAR` instead of `[*:0]const WCHAR`)
- Fixed `GetProcAddress` using incorrect types (`[*]const u8` instead of `[*:0]const u8`)

### std.os.windows.user32
- Added `WaitMessage` + zig wrapper
- Added `MsgWaitForMultipleObjects` + zig wrapper
- Added `GetQueueStatus`
- Added `QS_*` constants
- Added `MINMAXINFO` struct
- Added `SetPropA` + zig wrapper
- Added `SetPropW` + zig wrapper
- Added `GetPropA`
- Added `GetPropW`
- Added `GetClientRect` + zig wrapper
- Added `GetWindowRect` + zig wrapper
- Added `SetWindowPos` + zig wrapper
- Added `SWP_*` constants
- Added `HWND_*` constants
- Added `LoadCursorA` + zig wrapper
- Added `LoadCursorW` + zig wrapper
- Added `IDC_*` cursor constants
- Added `GetSystemMetrics`
- Added `GetSystemMetricsForDpi` + zig wrapper
- Added `SM_*` constants
- Added `ARW_*` constants
- Added `NID_*` constants

I am unsure about the names for opengl32 zig wrappers. The convention seems to be using lowercase, but wgl* functions are already lowercase, so I added a "Z" at the end for now. Perhaps removing the wgl prefix and using lowercase is the way to go?

I am also unsure about the `IDC_` constants. In C they are casted into the correct type (LPCSTR, LPCWSTR) depending on the defined character set. Currently passing them to LoadCursor* requires `@ptrFromInt(IDC_*)`.

Note that I am an on-and-off unexperienced Zig user, and a first time contributor, so I hope I didn't butcher any of the syntax.
