### PR TITLE
Update comment on for_range in Ast

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -3225,7 +3225,7 @@ pub const Node = struct {
         for_simple,
         /// `for (lhs[0..inputs]) lhs[inputs + 1] else lhs[inputs + 2]`. `For[rhs]`.
         @"for",
-        /// `lhs..rhs`.
+        /// `lhs..rhs`. rhs can be omitted.
         for_range,
         /// `if (lhs) rhs`.
         /// `if (lhs) |a| rhs`.


### PR DESCRIPTION
The rhs can be omitted eg `0..`

Working on an ast visitor and assuming the rhs was always valid created an infinite loop...