### PR TITLE
std: introduce pointer stability locks to hash maps

### DIFF
--- a/lib/std/array_hash_map.zig
+++ b/lib/std/array_hash_map.zig
@@ -137,6 +137,23 @@ pub fn ArrayHashMap(
             self.* = undefined;
         }
 
+        /// Puts the hash map into a state where any method call that would
+        /// cause an existing key or value pointer to become invalidated will
+        /// instead trigger an assertion.
+        ///
+        /// An additional call to `lockMutation` in such state also triggers an
+        /// assertion.
+        ///
+        /// `unlockMutation` returns the hash map to the previous state.
+        pub fn lockMutation(self: *Self) void {
+            self.unmanaged.lockMutation();
+        }
+
+        /// Undoes a call to `lockMutation`.
+        pub fn unlockMutation(self: *Self) void {
+            self.unmanaged.unlockMutation();
+        }
+
         /// Clears the map but retains the backing allocation for future use.
         pub fn clearRetainingCapacity(self: *Self) void {
             return self.unmanaged.clearRetainingCapacity();
@@ -403,6 +420,7 @@ pub fn ArrayHashMap(
         /// Set the map to an empty state, making deinitialization a no-op, and
         /// returning a copy of the original.
         pub fn move(self: *Self) Self {
+            self.mutation_lock.assertUnlocked();
             const result = self.*;
             self.unmanaged = .{};
             return result;
@@ -494,6 +512,9 @@ pub fn ArrayHashMapUnmanaged(
         /// an IndexHeader followed by an array of Index(I) structs, where I is defined
         /// by how many total indexes there are.
         index_header: ?*IndexHeader = null,
+
+        /// Used to detect memory safety violations.
+        mutation_lock: std.debug.SafetyLock = .{},
 
         comptime {
             std.hash_map.verifyContext(Context, K, K, u32, true);
@@ -589,6 +610,7 @@ pub fn ArrayHashMapUnmanaged(
         /// Note that this does not free keys or values.  You must take care of that
         /// before calling this function, if it is needed.
         pub fn deinit(self: *Self, allocator: Allocator) void {
+            self.mutation_lock.assertUnlocked();
             self.entries.deinit(allocator);
             if (self.index_header) |header| {
                 header.free(allocator);
@@ -596,8 +618,28 @@ pub fn ArrayHashMapUnmanaged(
             self.* = undefined;
         }
 
+        /// Puts the hash map into a state where any method call that would
+        /// cause an existing key or value pointer to become invalidated will
+        /// instead trigger an assertion.
+        ///
+        /// An additional call to `lockMutation` in such state also triggers an
+        /// assertion.
+        ///
+        /// `unlockMutation` returns the hash map to the previous state.
+        pub fn lockMutation(self: *Self) void {
+            self.mutation_lock.lock();
+        }
+
+        /// Undoes a call to `lockMutation`.
+        pub fn unlockMutation(self: *Self) void {
+            self.mutation_lock.unlock();
+        }
+
         /// Clears the map but retains the backing allocation for future use.
         pub fn clearRetainingCapacity(self: *Self) void {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             self.entries.len = 0;
             if (self.index_header) |header| {
                 switch (header.capacityIndexType()) {
@@ -610,6 +652,9 @@ pub fn ArrayHashMapUnmanaged(
 
         /// Clears the map and releases the backing allocation
         pub fn clearAndFree(self: *Self, allocator: Allocator) void {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             self.entries.shrinkAndFree(allocator, 0);
             if (self.index_header) |header| {
                 header.free(allocator);
@@ -795,6 +840,9 @@ pub fn ArrayHashMapUnmanaged(
             return self.ensureTotalCapacityContext(allocator, new_capacity, undefined);
         }
         pub fn ensureTotalCapacityContext(self: *Self, allocator: Allocator, new_capacity: usize, ctx: Context) !void {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             if (new_capacity <= linear_scan_max) {
                 try self.entries.ensureTotalCapacity(allocator, new_capacity);
                 return;
@@ -1079,6 +1127,9 @@ pub fn ArrayHashMapUnmanaged(
             return self.fetchSwapRemoveContextAdapted(key, ctx, undefined);
         }
         pub fn fetchSwapRemoveContextAdapted(self: *Self, key: anytype, key_ctx: anytype, ctx: Context) ?KV {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             return self.fetchRemoveByKey(key, key_ctx, if (store_hash) {} else ctx, .swap);
         }
 
@@ -1100,6 +1151,9 @@ pub fn ArrayHashMapUnmanaged(
             return self.fetchOrderedRemoveContextAdapted(key, ctx, undefined);
         }
         pub fn fetchOrderedRemoveContextAdapted(self: *Self, key: anytype, key_ctx: anytype, ctx: Context) ?KV {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             return self.fetchRemoveByKey(key, key_ctx, if (store_hash) {} else ctx, .ordered);
         }
 
@@ -1121,6 +1175,9 @@ pub fn ArrayHashMapUnmanaged(
             return self.swapRemoveContextAdapted(key, ctx, undefined);
         }
         pub fn swapRemoveContextAdapted(self: *Self, key: anytype, key_ctx: anytype, ctx: Context) bool {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             return self.removeByKey(key, key_ctx, if (store_hash) {} else ctx, .swap);
         }
 
@@ -1142,6 +1199,9 @@ pub fn ArrayHashMapUnmanaged(
             return self.orderedRemoveContextAdapted(key, ctx, undefined);
         }
         pub fn orderedRemoveContextAdapted(self: *Self, key: anytype, key_ctx: anytype, ctx: Context) bool {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             return self.removeByKey(key, key_ctx, if (store_hash) {} else ctx, .ordered);
         }
 
@@ -1154,6 +1214,9 @@ pub fn ArrayHashMapUnmanaged(
             return self.swapRemoveAtContext(index, undefined);
         }
         pub fn swapRemoveAtContext(self: *Self, index: usize, ctx: Context) void {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             self.removeByIndex(index, if (store_hash) {} else ctx, .swap);
         }
 
@@ -1167,6 +1230,9 @@ pub fn ArrayHashMapUnmanaged(
             return self.orderedRemoveAtContext(index, undefined);
         }
         pub fn orderedRemoveAtContext(self: *Self, index: usize, ctx: Context) void {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             self.removeByIndex(index, if (store_hash) {} else ctx, .ordered);
         }
 
@@ -1196,6 +1262,7 @@ pub fn ArrayHashMapUnmanaged(
         /// Set the map to an empty state, making deinitialization a no-op, and
         /// returning a copy of the original.
         pub fn move(self: *Self) Self {
+            self.mutation_lock.assertUnlocked();
             const result = self.*;
             self.* = .{};
             return result;
@@ -1271,6 +1338,9 @@ pub fn ArrayHashMapUnmanaged(
             sort_ctx: anytype,
             ctx: Context,
         ) void {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             switch (mode) {
                 .stable => self.entries.sort(sort_ctx),
                 .unstable => self.entries.sortUnstable(sort_ctx),
@@ -1288,6 +1358,9 @@ pub fn ArrayHashMapUnmanaged(
             return self.shrinkRetainingCapacityContext(new_len, undefined);
         }
         pub fn shrinkRetainingCapacityContext(self: *Self, new_len: usize, ctx: Context) void {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             // Remove index entries from the new length onwards.
             // Explicitly choose to ONLY remove index entries and not the underlying array list
             // entries as we're going to remove them in the subsequent shrink call.
@@ -1307,6 +1380,9 @@ pub fn ArrayHashMapUnmanaged(
             return self.shrinkAndFreeContext(allocator, new_len, undefined);
         }
         pub fn shrinkAndFreeContext(self: *Self, allocator: Allocator, new_len: usize, ctx: Context) void {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             // Remove index entries from the new length onwards.
             // Explicitly choose to ONLY remove index entries and not the underlying array list
             // entries as we're going to remove them in the subsequent shrink call.
@@ -1325,6 +1401,9 @@ pub fn ArrayHashMapUnmanaged(
             return self.popContext(undefined);
         }
         pub fn popContext(self: *Self, ctx: Context) KV {
+            self.mutation_lock.lock();
+            defer self.mutation_lock.unlock();
+
             const item = self.entries.get(self.entries.len - 1);
             if (self.index_header) |header|
                 self.removeFromIndexByIndex(self.entries.len - 1, if (store_hash) {} else ctx, header);
@@ -1346,9 +1425,13 @@ pub fn ArrayHashMapUnmanaged(
             return if (self.entries.len == 0) null else self.popContext(ctx);
         }
 
-        // ------------------ No pub fns below this point ------------------
-
-        fn fetchRemoveByKey(self: *Self, key: anytype, key_ctx: anytype, ctx: ByIndexContext, comptime removal_type: RemovalType) ?KV {
+        fn fetchRemoveByKey(
+            self: *Self,
+            key: anytype,
+            key_ctx: anytype,
+            ctx: ByIndexContext,
+            comptime removal_type: RemovalType,
+        ) ?KV {
             const header = self.index_header orelse {
                 // Linear scan.
                 const key_hash = if (store_hash) key_ctx.hash(key) else {};
@@ -1377,7 +1460,15 @@ pub fn ArrayHashMapUnmanaged(
                 .u32 => self.fetchRemoveByKeyGeneric(key, key_ctx, ctx, header, u32, removal_type),
             };
         }
-        fn fetchRemoveByKeyGeneric(self: *Self, key: anytype, key_ctx: anytype, ctx: ByIndexContext, header: *IndexHeader, comptime I: type, comptime removal_type: RemovalType) ?KV {
+        fn fetchRemoveByKeyGeneric(
+            self: *Self,
+            key: anytype,
+            key_ctx: anytype,
+            ctx: ByIndexContext,
+            header: *IndexHeader,
+            comptime I: type,
+            comptime removal_type: RemovalType,
+        ) ?KV {
             const indexes = header.indexes(I);
             const entry_index = self.removeFromIndexByKey(key, key_ctx, header, I, indexes) orelse return null;
             const slice = self.entries.slice();
@@ -1389,7 +1480,13 @@ pub fn ArrayHashMapUnmanaged(
             return removed_entry;
         }
 
-        fn removeByKey(self: *Self, key: anytype, key_ctx: anytype, ctx: ByIndexContext, comptime removal_type: RemovalType) bool {
+        fn removeByKey(
+            self: *Self,
+            key: anytype,
+            key_ctx: anytype,
+            ctx: ByIndexContext,
+            comptime removal_type: RemovalType,
+        ) bool {
             const header = self.index_header orelse {
                 // Linear scan.
                 const key_hash = if (store_hash) key_ctx.hash(key) else {};

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -2838,6 +2838,29 @@ pub fn ConfigurableTrace(comptime size: usize, comptime stack_frame_count: usize
     };
 }
 
+pub const SafetyLock = struct {
+    state: State = .unlocked,
+
+    pub const State = if (runtime_safety) enum { unlocked, locked } else enum { unlocked };
+
+    pub fn lock(l: *SafetyLock) void {
+        if (!runtime_safety) return;
+        assert(l.state == .unlocked);
+        l.state = .locked;
+    }
+
+    pub fn unlock(l: *SafetyLock) void {
+        if (!runtime_safety) return;
+        assert(l.state == .locked);
+        l.state = .unlocked;
+    }
+
+    pub fn assertUnlocked(l: SafetyLock) void {
+        if (!runtime_safety) return;
+        assert(l.state == .unlocked);
+    }
+};
+
 test {
     _ = &dump_hex;
 }

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -416,6 +416,23 @@ pub fn HashMap(
             };
         }
 
+        /// Puts the hash map into a state where any method call that would
+        /// cause an existing key or value pointer to become invalidated will
+        /// instead trigger an assertion.
+        ///
+        /// An additional call to `lockMutation` in such state also triggers an
+        /// assertion.
+        ///
+        /// `unlockMutation` returns the hash map to the previous state.
+        pub fn lockMutation(self: *Self) void {
+            self.unmanaged.lockMutation();
+        }
+
+        /// Undoes a call to `lockMutation`.
+        pub fn unlockMutation(self: *Self) void {
+            self.unmanaged.unlockMutation();
+        }
+
         /// Release the backing array and invalidate this map.
         /// This does *not* deinit keys, values, or the context!
         /// If your keys or values need to be released, ensure
@@ -672,6 +689,7 @@ pub fn HashMap(
         /// Set the map to an empty state, making deinitialization a no-op, and
         /// returning a copy of the original.
         pub fn move(self: *Self) Self {
+            self.unmanaged.mutation_lock.assertUnlocked();
             const result = self.*;
             self.unmanaged = .{};
             return result;
@@ -887,10 +905,19 @@ pub fn HashMapUnmanaged(
             };
         }
 
+        /// Puts the hash map into a state where any method call that would
+        /// cause an existing key or value pointer to become invalidated will
+        /// instead trigger an assertion.
+        ///
+        /// An additional call to `lockMutation` in such state also triggers an
+        /// assertion.
+        ///
+        /// `unlockMutation` returns the hash map to the previous state.
         pub fn lockMutation(self: *Self) void {
             self.mutation_lock.lock();
         }
 
+        /// Undoes a call to `lockMutation`.
         pub fn unlockMutation(self: *Self) void {
             self.mutation_lock.unlock();
         }


### PR DESCRIPTION
This adds `std.debug.SafetyLock` and uses it in standard library hash maps by adding `lockPointers()` and `unlockPointers()`.

This provides a way to detect when an illegal modification has happened and panic rather than invoke undefined behavior.

### Example

```zig
const std = @import("std");

pub fn main() !void {
    const gpa = std.heap.page_allocator;
    var map: std.AutoHashMapUnmanaged(i32, i32) = .{};

    const gop = try map.getOrPut(gpa, 1234);
    map.lockPointers();
    defer map.unlockPointers();

    gop.value_ptr.* = try calculate(gpa, &map);
}

fn calculate(gpa: std.mem.Allocator, m: anytype) !i32 {
    try m.put(gpa, 42, 420);
    return 999;
}
```

```
$ zig run test3.zig 
thread 96878 panic: reached unreachable code
/home/andy/Downloads/zig/lib/std/debug.zig:342:14: 0x220772 in assert (test3)
    if (!ok) unreachable; // assertion failure
             ^
/home/andy/Downloads/zig/lib/std/debug.zig:2641:15: 0x22125b in lock (test3)
        assert(l.state == .unlocked);
              ^
/home/andy/Downloads/zig/lib/std/hash_map.zig:1309:40: 0x251a23 in getOrPutContextAdapted__anon_7181 (test3)
                self.pointer_stability.lock();
                                       ^
/home/andy/Downloads/zig/lib/std/hash_map.zig:1296:56: 0x221165 in getOrPutContext (test3)
            const gop = try self.getOrPutContextAdapted(allocator, key, ctx, ctx);
                                                       ^
/home/andy/Downloads/zig/lib/std/hash_map.zig:1222:52: 0x2212ba in putContext (test3)
            const result = try self.getOrPutContext(allocator, key, ctx);
                                                   ^
/home/andy/Downloads/zig/lib/std/hash_map.zig:1219:35: 0x21e353 in put (test3)
            return self.putContext(allocator, key, value, undefined);
                                  ^
/home/andy/Downloads/zig/build-release/test3.zig:15:14: 0x21e2e6 in calculate__anon_3623 (test3)
    try m.put(gpa, 42, 420);
             ^
/home/andy/Downloads/zig/build-release/test3.zig:11:36: 0x21e51b in main (test3)
    gop.value_ptr.* = try calculate(gpa, &map);
                                   ^
/home/andy/Downloads/zig/lib/std/start.zig:583:37: 0x21e1f5 in posixCallMainAndExit (test3)
            const result = root.main() catch |err| {
                                    ^
/home/andy/Downloads/zig/lib/std/start.zig:251:5: 0x21dce1 in _start (test3)
    asm volatile (switch (native_arch) {
    ^
???:?:?: 0x0 in ??? (???)
Aborted (core dumped)
```

Something nice about this is that if you use the "assume capacity" variants then such mutations are actually well-defined, and don't trigger the problem:

```zig
const std = @import("std");

pub fn main() !void {
    const gpa = std.heap.page_allocator;
    var map: std.AutoHashMapUnmanaged(i32, i32) = .{};

    try map.ensureUnusedCapacity(gpa, 2);
    const gop = map.getOrPutAssumeCapacity(1234);
    map.lockPointers();
    defer map.unlockPointers();

    gop.value_ptr.* = calculate(&map);
}

fn calculate(m: anytype) i32 {
    m.putAssumeCapacity(42, 420);
    return 999;
}
```

```
$ stage3/bin/zig run test3.zig 
```

### Merge Checklist
* [x] add to managed variants
* [x] add to array hash maps

### Follow-Up Issues
* [x] #19326
* [ ] #19327
* [ ] #19328