### PR TITLE
link: support exporting constant values without a Decl

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6034,13 +6034,7 @@ fn zirExportValue(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
     const operand = try sema.resolveInstConst(block, operand_src, extra.operand, .{
         .needed_comptime_reason = "export target must be comptime-known",
     });
-    const options = sema.resolveExportOptions(block, .unneeded, extra.options) catch |err| switch (err) {
-        error.NeededSourceLocation => {
-            _ = try sema.resolveExportOptions(block, options_src, extra.options);
-            unreachable;
-        },
-        else => |e| return e,
-    };
+    const options = try sema.resolveExportOptions(block, options_src, extra.options);
     const decl_index = if (operand.val.getFunction(sema.mod)) |function| function.owner_decl else blk: {
         var anon_decl = try block.startAnonDecl(); // TODO: export value without Decl
         defer anon_decl.deinit();

--- a/src/link.zig
+++ b/src/link.zig
@@ -587,7 +587,7 @@ pub const File = struct {
         }
     }
 
-    /// May be called before or after updateDeclExports for any given Decl.
+    /// May be called before or after updateExports for any given Decl.
     pub fn updateDecl(base: *File, module: *Module, decl_index: Module.Decl.Index) UpdateDeclError!void {
         const decl = module.declPtr(decl_index);
         assert(decl.has_tv);
@@ -609,7 +609,7 @@ pub const File = struct {
         }
     }
 
-    /// May be called before or after updateDeclExports for any given Decl.
+    /// May be called before or after updateExports for any given Decl.
     pub fn updateFunc(base: *File, module: *Module, func_index: InternPool.Index, air: Air, liveness: Liveness) UpdateDeclError!void {
         if (build_options.only_c) {
             assert(base.tag == .c);
@@ -882,33 +882,34 @@ pub const File = struct {
         }
     }
 
-    pub const UpdateDeclExportsError = error{
+    pub const UpdateExportsError = error{
         OutOfMemory,
         AnalysisFail,
     };
 
+    /// This is called for every exported thing. `exports` is almost always
+    /// a list of size 1, meaning that `exported` is exported once. However, it is possible
+    /// to export the same thing with multiple different symbol names (aliases).
     /// May be called before or after updateDecl for any given Decl.
-    pub fn updateDeclExports(
+    pub fn updateExports(
         base: *File,
         module: *Module,
-        decl_index: Module.Decl.Index,
+        exported: Module.Exported,
         exports: []const *Module.Export,
-    ) UpdateDeclExportsError!void {
-        const decl = module.declPtr(decl_index);
-        assert(decl.has_tv);
+    ) UpdateExportsError!void {
         if (build_options.only_c) {
             assert(base.tag == .c);
-            return @fieldParentPtr(C, "base", base).updateDeclExports(module, decl_index, exports);
+            return @fieldParentPtr(C, "base", base).updateExports(module, exported, exports);
         }
         switch (base.tag) {
-            .coff => return @fieldParentPtr(Coff, "base", base).updateDeclExports(module, decl_index, exports),
-            .elf => return @fieldParentPtr(Elf, "base", base).updateDeclExports(module, decl_index, exports),
-            .macho => return @fieldParentPtr(MachO, "base", base).updateDeclExports(module, decl_index, exports),
-            .c => return @fieldParentPtr(C, "base", base).updateDeclExports(module, decl_index, exports),
-            .wasm => return @fieldParentPtr(Wasm, "base", base).updateDeclExports(module, decl_index, exports),
-            .spirv => return @fieldParentPtr(SpirV, "base", base).updateDeclExports(module, decl_index, exports),
-            .plan9 => return @fieldParentPtr(Plan9, "base", base).updateDeclExports(module, decl_index, exports),
-            .nvptx => return @fieldParentPtr(NvPtx, "base", base).updateDeclExports(module, decl_index, exports),
+            .coff => return @fieldParentPtr(Coff, "base", base).updateExports(module, exported, exports),
+            .elf => return @fieldParentPtr(Elf, "base", base).updateExports(module, exported, exports),
+            .macho => return @fieldParentPtr(MachO, "base", base).updateExports(module, exported, exports),
+            .c => return @fieldParentPtr(C, "base", base).updateExports(module, exported, exports),
+            .wasm => return @fieldParentPtr(Wasm, "base", base).updateExports(module, exported, exports),
+            .spirv => return @fieldParentPtr(SpirV, "base", base).updateExports(module, exported, exports),
+            .plan9 => return @fieldParentPtr(Plan9, "base", base).updateExports(module, exported, exports),
+            .nvptx => return @fieldParentPtr(NvPtx, "base", base).updateExports(module, exported, exports),
         }
     }
 
@@ -965,6 +966,20 @@ pub const File = struct {
             .wasm => return @fieldParentPtr(Wasm, "base", base).getAnonDeclVAddr(decl_val, reloc_info),
             .spirv => unreachable,
             .nvptx => unreachable,
+        }
+    }
+
+    pub fn deleteDeclExport(base: *File, decl_index: Module.Decl.Index, name: InternPool.NullTerminatedString) !void {
+        if (build_options.only_c) unreachable;
+        switch (base.tag) {
+            .coff => return @fieldParentPtr(Coff, "base", base).deleteDeclExport(decl_index, name),
+            .elf => return @fieldParentPtr(Elf, "base", base).deleteDeclExport(decl_index, name),
+            .macho => return @fieldParentPtr(MachO, "base", base).deleteDeclExport(decl_index, name),
+            .plan9 => {},
+            .c => {},
+            .wasm => return @fieldParentPtr(Wasm, "base", base).deleteDeclExport(decl_index),
+            .spirv => {},
+            .nvptx => {},
         }
     }
 

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -753,14 +753,14 @@ pub fn flushEmitH(module: *Module) !void {
     try file.pwritevAll(all_buffers.items, 0);
 }
 
-pub fn updateDeclExports(
+pub fn updateExports(
     self: *C,
     module: *Module,
-    decl_index: Module.Decl.Index,
+    exported: Module.Exported,
     exports: []const *Module.Export,
 ) !void {
     _ = exports;
-    _ = decl_index;
+    _ = exported;
     _ = module;
     _ = self;
 }

--- a/src/link/NvPtx.zig
+++ b/src/link/NvPtx.zig
@@ -74,16 +74,16 @@ pub fn updateDecl(self: *NvPtx, module: *Module, decl_index: Module.Decl.Index) 
     return self.llvm_object.updateDecl(module, decl_index);
 }
 
-pub fn updateDeclExports(
+pub fn updateExports(
     self: *NvPtx,
     module: *Module,
-    decl_index: Module.Decl.Index,
+    exported: Module.Exported,
     exports: []const *Module.Export,
 ) !void {
     if (build_options.skip_non_native and builtin.object_format != .nvptx) {
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
-    return self.llvm_object.updateDeclExports(module, decl_index, exports);
+    return self.llvm_object.updateExports(module, exported, exports);
 }
 
 pub fn freeDecl(self: *NvPtx, decl_index: Module.Decl.Index) void {

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -1116,13 +1116,16 @@ pub fn seeDecl(self: *Plan9, decl_index: Module.Decl.Index) !Atom.Index {
     return atom_idx;
 }
 
-pub fn updateDeclExports(
+pub fn updateExports(
     self: *Plan9,
     module: *Module,
-    decl_index: Module.Decl.Index,
+    exported: Module.Exported,
     exports: []const *Module.Export,
 ) !void {
-    _ = try self.seeDecl(decl_index);
+    switch (exported) {
+        .value => @panic("TODO: plan9 updateExports handling values"),
+        .decl_index => |decl_index| _ = try self.seeDecl(decl_index),
+    }
     // we do all the things in flush
     _ = module;
     _ = exports;

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -120,12 +120,19 @@ pub fn updateDecl(self: *SpirV, module: *Module, decl_index: Module.Decl.Index) 
     try self.object.updateDecl(module, decl_index);
 }
 
-pub fn updateDeclExports(
+pub fn updateExports(
     self: *SpirV,
     mod: *Module,
-    decl_index: Module.Decl.Index,
+    exported: Module.Exported,
     exports: []const *Module.Export,
 ) !void {
+    const decl_index = switch (exported) {
+        .decl_index => |i| i,
+        .value => |val| {
+            _ = val;
+            @panic("TODO: implement SpirV linker code for exporting a constant value");
+        },
+    };
     const decl = mod.declPtr(decl_index);
     if (decl.val.isFuncBody(mod) and decl.ty.fnCallingConvention(mod) == .Kernel) {
         const spv_decl_index = try self.object.resolveDecl(mod, decl_index);

--- a/test/behavior/export.zig
+++ b/test/behavior/export.zig
@@ -72,6 +72,8 @@ test "exporting using field access" {
 }
 
 test "exporting comptime-known value" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+
     const x: u32 = 10;
     @export(x, .{ .name = "exporting_comptime_known_value_foo" });
     const S = struct {
@@ -81,6 +83,8 @@ test "exporting comptime-known value" {
 }
 
 test "exporting comptime var" {
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+
     comptime var x: u32 = 5;
     @export(x, .{ .name = "exporting_comptime_var_foo" });
     x = 7; // modifying this now shouldn't change anything


### PR DESCRIPTION
The main motivating change here is to prevent the creation of a fake Decl object by the frontend in order to `@export()` a value.

Instead, `link.updateDeclExports` is renamed to `link.updateExports` and accepts a tagged union which can be either a Decl.Index or a InternPool.Index.

With this, the only remaining calls to startAnonDecl() are for comptime value mutation:
```
$ grep -RI startAnonDecl ../src
../src/Sema.zig:    pub fn startAnonDecl(block: *Block) !WipAnonDecl {
../src/Sema.zig:    var anon_decl = try block.startAnonDecl(); // TODO: comptime value mutation without Decl
../src/Sema.zig:        var anon_decl = try block.startAnonDecl(); // TODO: comptime value mutation without Decl
../src/Sema.zig:    var anon_decl = try block.startAnonDecl(); // TODO: comptime value mutation without Decl
```