### PR TITLE
GenericReader error set fixes

### DIFF
--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -308,7 +308,7 @@ pub fn GenericReader(
             return @errorCast(self.any().skipBytes(num_bytes, options));
         }
 
-        pub inline fn isBytes(self: Self, slice: []const u8) Error!bool {
+        pub inline fn isBytes(self: Self, slice: []const u8) NoEofError!bool {
             return @errorCast(self.any().isBytes(slice));
         }
 
@@ -320,7 +320,7 @@ pub fn GenericReader(
             return @errorCast(self.any().readStructBig(T));
         }
 
-        pub const ReadEnumError = Error || error{
+        pub const ReadEnumError = NoEofError || error{
             /// An integer was read, but it did not match any of the tags in the supplied enum.
             InvalidValue,
         };

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -182,3 +182,16 @@ test "updateTimes" {
     try expect(stat_new.atime < stat_old.atime);
     try expect(stat_new.mtime < stat_old.mtime);
 }
+
+test "GenericReader methods can return error.EndOfStream" {
+    // https://github.com/ziglang/zig/issues/17733
+    var fbs = std.io.fixedBufferStream("");
+    try std.testing.expectError(
+        error.EndOfStream,
+        fbs.reader().readEnum(enum(u8) { a, b }, .Little),
+    );
+    try std.testing.expectError(
+        error.EndOfStream,
+        fbs.reader().isBytes("foo"),
+    );
+}


### PR DESCRIPTION
add error.EndOfStream to readEnum() and isBytes() so that users can catch these errors.  this also prevents them from panicing with 'invalid error value' on EndOfStream.

test both methods.  before these changes the new test would panic.

closes #17733