### PR TITLE
frontend: make Decl.zir_decl_index typed

### DIFF
--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -3925,7 +3925,7 @@ fn analyzeAllDecls(
     {
         var it = original_it;
         while (it.next()) |d| {
-            const decl_name_index = file.zir.extra[d.sub_index + 5];
+            const decl_name_index = file.zir.extra[@intFromEnum(d.sub_index) + 5];
             switch (decl_name_index) {
                 0, 1, 2 => continue,
                 else => if (file.zir.string_bytes[decl_name_index] == 0) {
@@ -3942,7 +3942,7 @@ fn analyzeAllDecls(
         var it = original_it;
         var decl_indexes_slot = first_decl_indexes_slot;
         while (it.next()) |d| : (decl_indexes_slot += 1) {
-            const decl_name_index = file.zir.extra[d.sub_index + 5];
+            const decl_name_index = file.zir.extra[@intFromEnum(d.sub_index) + 5];
             switch (decl_name_index) {
                 0 => {
                     const is_exported = @as(u1, @truncate(d.flags >> 1));
@@ -3969,7 +3969,7 @@ fn analyzeAllDecls(
     // Third loop to analyze all remaining decls
     var it = original_it;
     while (it.next()) |d| {
-        const decl_name_index = file.zir.extra[d.sub_index + 5];
+        const decl_name_index = file.zir.extra[@intFromEnum(d.sub_index) + 5];
         switch (decl_name_index) {
             0, 1 => continue, // skip over usingnamespace decls
             2 => continue, // skip decltests
@@ -3993,7 +3993,7 @@ fn analyzeAllDecls(
     // Fourth loop to analyze decltests
     it = original_it;
     while (it.next()) |d| {
-        const decl_name_index = file.zir.extra[d.sub_index + 5];
+        const decl_name_index = file.zir.extra[@intFromEnum(d.sub_index) + 5];
         switch (decl_name_index) {
             0, 1 => continue, // skip over usingnamespace decls
             2 => {},
@@ -4028,7 +4028,7 @@ fn analyzeDecl(
     const has_align = @as(u1, @truncate(d.flags >> 2)) != 0;
     const has_section_or_addrspace = @as(u1, @truncate(d.flags >> 3)) != 0;
 
-    var extra_index = d.sub_index;
+    var extra_index = @intFromEnum(d.sub_index);
     // const hash_u32s = file.zir.extra[extra_index..][0..4];
 
     extra_index += 4;
@@ -4158,8 +4158,8 @@ fn analyzeUsingnamespaceDecl(
     const data = file.zir.instructions.items(.data);
 
     const is_pub = @as(u1, @truncate(d.flags)) != 0;
-    const value_index = file.zir.extra[d.sub_index + 6];
-    const doc_comment_index = file.zir.extra[d.sub_index + 7];
+    const value_index = file.zir.extra[@intFromEnum(d.sub_index) + 6];
+    const doc_comment_index = file.zir.extra[@intFromEnum(d.sub_index) + 7];
 
     // This is known to work because decl values are always block_inlines
     const value_pl_node = data[value_index].pl_node;
@@ -4218,8 +4218,8 @@ fn analyzeDecltest(
 ) AutodocErrors!void {
     const data = file.zir.instructions.items(.data);
 
-    const value_index = file.zir.extra[d.sub_index + 6];
-    const decl_name_index = file.zir.extra[d.sub_index + 7];
+    const value_index = file.zir.extra[@intFromEnum(d.sub_index) + 6];
+    const decl_name_index = file.zir.extra[@intFromEnum(d.sub_index) + 7];
 
     const value_pl_node = data[value_index].pl_node;
     const decl_src = try self.srcLocInfo(file, value_pl_node.src_node, parent_src);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2267,7 +2267,7 @@ pub fn update(comp: *Compilation, main_progress_node: *std.Progress.Node) !void 
             const decl = module.declPtr(decl_index);
             assert(decl.deletion_flag);
             assert(decl.dependants.count() == 0);
-            assert(decl.zir_decl_index != 0);
+            assert(decl.zir_decl_index != .none);
 
             try module.clearDecl(decl_index, null);
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -6632,7 +6632,7 @@ pub fn cmdChangelist(
     var inst_map: std.AutoHashMapUnmanaged(Zir.Inst.Index, Zir.Inst.Index) = .{};
     defer inst_map.deinit(gpa);
 
-    var extra_map: std.AutoHashMapUnmanaged(u32, u32) = .{};
+    var extra_map: std.AutoHashMapUnmanaged(Zir.ExtraIndex, Zir.ExtraIndex) = .{};
     defer extra_map.deinit(gpa);
 
     try Module.mapOldZirToNew(gpa, old_zir, file.zir, &inst_map, &extra_map);


### PR DESCRIPTION
This field had the wrong type. It's not a `Zir.Inst.Index`, it's actually a `Zir.OptionalExtraIndex`. Also, the former is currently aliased to `u32` while the latter is a nonexhaustive enum that gives us more type checking.

This commit is preparation for making this field non-optional. Now it can be changed to `Zir.ExtraIndex` and then the compiler will point out all the places that the non-optional assumption is being violated.