### PR TITLE
make Zir.Inst.Index typed

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3527,21 +3527,33 @@ test "max" {
 /// Finds the smallest and largest number in a slice. O(n).
 /// Returns an anonymous struct with the fields `min` and `max`.
 /// `slice` must not be empty.
-pub fn minMax(comptime T: type, slice: []const T) struct { min: T, max: T } {
+pub fn minMax(comptime T: type, slice: []const T) struct { T, T } {
     assert(slice.len > 0);
-    var minVal = slice[0];
-    var maxVal = slice[0];
+    var running_minimum = slice[0];
+    var running_maximum = slice[0];
     for (slice[1..]) |item| {
-        minVal = @min(minVal, item);
-        maxVal = @max(maxVal, item);
+        running_minimum = @min(running_minimum, item);
+        running_maximum = @max(running_maximum, item);
     }
-    return .{ .min = minVal, .max = maxVal };
+    return .{ running_minimum, running_maximum };
 }
 
-test "minMax" {
-    try testing.expectEqual(minMax(u8, "abcdefg"), .{ .min = 'a', .max = 'g' });
-    try testing.expectEqual(minMax(u8, "bcdefga"), .{ .min = 'a', .max = 'g' });
-    try testing.expectEqual(minMax(u8, "a"), .{ .min = 'a', .max = 'a' });
+test minMax {
+    {
+        const actual_min, const actual_max = minMax(u8, "abcdefg");
+        try testing.expectEqual(@as(u8, 'a'), actual_min);
+        try testing.expectEqual(@as(u8, 'g'), actual_max);
+    }
+    {
+        const actual_min, const actual_max = minMax(u8, "bcdefga");
+        try testing.expectEqual(@as(u8, 'a'), actual_min);
+        try testing.expectEqual(@as(u8, 'g'), actual_max);
+    }
+    {
+        const actual_min, const actual_max = minMax(u8, "a");
+        try testing.expectEqual(@as(u8, 'a'), actual_min);
+        try testing.expectEqual(@as(u8, 'a'), actual_max);
+    }
 }
 
 /// Returns the index of the smallest number in a slice. O(n).

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -13,8 +13,6 @@ const StringIndexContext = std.hash_map.StringIndexContext;
 const isPrimitive = std.zig.primitives.isPrimitive;
 
 const Zir = @import("Zir.zig");
-const refToIndex = Zir.refToIndex;
-const indexToRef = Zir.indexToRef;
 const trace = @import("tracy.zig").trace;
 const BuiltinFn = @import("BuiltinFn.zig");
 const AstRlAnnotate = @import("AstRlAnnotate.zig");
@@ -86,13 +84,18 @@ fn setExtra(astgen: *AstGen, index: usize, extra: anytype) void {
     inline for (fields) |field| {
         astgen.extra.items[i] = switch (field.type) {
             u32 => @field(extra, field.name),
-            Zir.Inst.Ref => @intFromEnum(@field(extra, field.name)),
+
+            Zir.Inst.Ref,
+            Zir.Inst.Index,
+            => @intFromEnum(@field(extra, field.name)),
+
             i32,
             Zir.Inst.Call.Flags,
             Zir.Inst.BuiltinCall.Flags,
             Zir.Inst.SwitchBlock.Bits,
             Zir.Inst.FuncFancy.Bits,
             => @bitCast(@field(extra, field.name)),
+
             else => @compileError("bad field type"),
         };
         i += 1;
@@ -166,7 +169,7 @@ pub fn generate(gpa: Allocator, tree: Ast) Allocator.Error!Zir {
             .Auto,
             0,
         )) |struct_decl_ref| {
-            assert(refToIndex(struct_decl_ref).? == 0);
+            assert(struct_decl_ref.toIndex().? == .main_struct_inst);
         } else |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             error.AnalysisFail => {}, // Handled via compile_errors below.
@@ -1200,7 +1203,7 @@ fn suspendExpr(
     }
     try suspend_scope.setBlockBody(suspend_inst);
 
-    return indexToRef(suspend_inst);
+    return suspend_inst.toRef();
 }
 
 fn awaitExpr(
@@ -1316,7 +1319,7 @@ fn fnProtoExpr(
                 var param_gz = block_scope.makeSubBlock(scope);
                 defer param_gz.unstack();
                 const param_type = try expr(&param_gz, scope, coerced_type_ri, param_type_node);
-                const param_inst_expected: u32 = @intCast(astgen.instructions.len + 1);
+                const param_inst_expected: Zir.Inst.Index = @enumFromInt(astgen.instructions.len + 1);
                 _ = try param_gz.addBreakWithSrcNode(.break_inline, param_inst_expected, param_type, param_type_node);
                 const main_tokens = tree.nodes.items(.main_token);
                 const name_token = param.name_token orelse main_tokens[param_type_node];
@@ -1386,7 +1389,7 @@ fn fnProtoExpr(
     try block_scope.setBlockBody(block_inst);
     try gz.instructions.append(astgen.gpa, block_inst);
 
-    return rvalue(gz, ri, indexToRef(block_inst), fn_proto.ast.proto_node);
+    return rvalue(gz, ri, block_inst.toRef(), fn_proto.ast.proto_node);
 }
 
 fn arrayInitExpr(
@@ -1625,7 +1628,7 @@ fn arrayInitExprPtr(
             .ptr = array_ptr_inst,
             .index = @intCast(i),
         });
-        astgen.extra.items[extra_index] = refToIndex(elem_ptr_inst).?;
+        astgen.extra.items[extra_index] = @intFromEnum(elem_ptr_inst.toIndex().?);
         extra_index += 1;
         _ = try expr(gz, scope, .{ .rl = .{ .ptr = .{ .inst = elem_ptr_inst } } }, elem_init);
     }
@@ -1825,7 +1828,7 @@ fn structInitExprTyped(
             .name_start = str_index,
         });
         setExtra(astgen, extra_index, Zir.Inst.StructInit.Item{
-            .field_type = refToIndex(field_ty_inst).?,
+            .field_type = field_ty_inst.toIndex().?,
             .init = try expr(gz, scope, .{ .rl = .{ .coerced_ty = field_ty_inst } }, field_init),
         });
         extra_index += field_size;
@@ -1860,7 +1863,7 @@ fn structInitExprPtr(
             .lhs = struct_ptr_inst,
             .field_name_start = str_index,
         });
-        astgen.extra.items[extra_index] = refToIndex(field_ptr).?;
+        astgen.extra.items[extra_index] = @intFromEnum(field_ptr.toIndex().?);
         extra_index += 1;
         _ = try expr(gz, scope, .{ .rl = .{ .ptr = .{ .inst = field_ptr } } }, field_init);
     }
@@ -1962,7 +1965,7 @@ fn comptimeExpr(
     try block_scope.setBlockBody(block_inst);
     try gz.instructions.append(gz.astgen.gpa, block_inst);
 
-    return rvalue(gz, ri, indexToRef(block_inst), node);
+    return rvalue(gz, ri, block_inst.toRef(), node);
 }
 
 /// This one is for an actual `comptime` syntax, and will emit a compile error if
@@ -2048,8 +2051,8 @@ fn breakExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) Inn
                                 break :blk label.block_inst;
                             }
                         }
-                    } else if (block_gz.break_block != 0) {
-                        break :blk block_gz.break_block;
+                    } else if (block_gz.break_block.unwrap()) |i| {
+                        break :blk i;
                     }
                     // If not the target, start over with the parent
                     scope = block_gz.parent;
@@ -2135,11 +2138,10 @@ fn continueExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) 
                         ),
                     });
                 }
-                const continue_block = gen_zir.continue_block;
-                if (continue_block == 0) {
+                const continue_block = gen_zir.continue_block.unwrap() orelse {
                     scope = gen_zir.parent;
                     continue;
-                }
+                };
                 if (break_label != 0) blk: {
                     if (gen_zir.label) |*label| {
                         if (try astgen.tokenIdentEql(label.token, break_label)) {
@@ -2157,7 +2159,7 @@ fn continueExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) 
                 else
                     .@"break";
                 if (break_tag == .break_inline) {
-                    _ = try parent_gz.addUnNode(.check_comptime_control_flow, Zir.indexToRef(continue_block), node);
+                    _ = try parent_gz.addUnNode(.check_comptime_control_flow, continue_block.toRef(), node);
                 }
 
                 // As our last action before the continue, "pop" the error trace if needed
@@ -2333,9 +2335,9 @@ fn labeledBlockExpr(
 
     try block_scope.setBlockBody(block_inst);
     if (need_result_rvalue) {
-        return rvalue(gz, ri, indexToRef(block_inst), block_node);
+        return rvalue(gz, ri, block_inst.toRef(), block_node);
     } else {
-        return indexToRef(block_inst);
+        return block_inst.toRef();
     }
 }
 
@@ -2438,15 +2440,15 @@ fn unusedResultExpr(gz: *GenZir, scope: *Scope, statement: Ast.Node.Index) Inner
 
 fn addEnsureResult(gz: *GenZir, maybe_unused_result: Zir.Inst.Ref, statement: Ast.Node.Index) InnerError!Ast.Node.Index {
     var noreturn_src_node: Ast.Node.Index = 0;
-    const elide_check = if (refToIndex(maybe_unused_result)) |inst| b: {
+    const elide_check = if (maybe_unused_result.toIndex()) |inst| b: {
         // Note that this array becomes invalid after appending more items to it
         // in the above while loop.
         const zir_tags = gz.astgen.instructions.items(.tag);
-        switch (zir_tags[inst]) {
+        switch (zir_tags[@intFromEnum(inst)]) {
             // For some instructions, modify the zir data
             // so we can avoid a separate ensure_result_used instruction.
             .call, .field_call => {
-                const break_extra = gz.astgen.instructions.items(.data)[inst].pl_node.payload_index;
+                const break_extra = gz.astgen.instructions.items(.data)[@intFromEnum(inst)].pl_node.payload_index;
                 comptime assert(std.meta.fieldIndex(Zir.Inst.Call, "flags") ==
                     std.meta.fieldIndex(Zir.Inst.FieldCall, "flags"));
                 const flags: *Zir.Inst.Call.Flags = @ptrCast(&gz.astgen.extra.items[
@@ -2456,7 +2458,7 @@ fn addEnsureResult(gz: *GenZir, maybe_unused_result: Zir.Inst.Ref, statement: As
                 break :b true;
             },
             .builtin_call => {
-                const break_extra = gz.astgen.instructions.items(.data)[inst].pl_node.payload_index;
+                const break_extra = gz.astgen.instructions.items(.data)[@intFromEnum(inst)].pl_node.payload_index;
                 const flags: *Zir.Inst.BuiltinCall.Flags = @ptrCast(&gz.astgen.extra.items[
                     break_extra + std.meta.fieldIndex(Zir.Inst.BuiltinCall, "flags").?
                 ]);
@@ -2670,7 +2672,7 @@ fn addEnsureResult(gz: *GenZir, maybe_unused_result: Zir.Inst.Ref, statement: As
             .array_init_elem_ptr,
             => break :b false,
 
-            .extended => switch (gz.astgen.instructions.items(.data)[inst].extended.opcode) {
+            .extended => switch (gz.astgen.instructions.items(.data)[@intFromEnum(inst)].extended.opcode) {
                 .breakpoint,
                 .fence,
                 .set_float_mode,
@@ -2783,7 +2785,7 @@ fn countDefers(outer_scope: *Scope, inner_scope: *Scope) struct {
 
                 have_err = true;
 
-                const have_err_payload = defer_scope.remapped_err_code != 0;
+                const have_err_payload = defer_scope.remapped_err_code != .none;
                 need_err_code = need_err_code or have_err_payload;
             },
             .namespace, .enum_namespace => unreachable,
@@ -2831,18 +2833,16 @@ fn genDefers(
                         try gz.addDefer(defer_scope.index, defer_scope.len);
                     },
                     .both => |err_code| {
-                        if (defer_scope.remapped_err_code == 0) {
-                            try gz.addDefer(defer_scope.index, defer_scope.len);
-                        } else {
+                        if (defer_scope.remapped_err_code.unwrap()) |remapped_err_code| {
                             try gz.instructions.ensureUnusedCapacity(gpa, 1);
                             try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
                             const payload_index = try gz.astgen.addExtra(Zir.Inst.DeferErrCode{
-                                .remapped_err_code = defer_scope.remapped_err_code,
+                                .remapped_err_code = remapped_err_code,
                                 .index = defer_scope.index,
                                 .len = defer_scope.len,
                             });
-                            const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+                            const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
                             gz.astgen.instructions.appendAssumeCapacity(.{
                                 .tag = .defer_err_code,
                                 .data = .{ .defer_err_code = .{
@@ -2851,6 +2851,8 @@ fn genDefers(
                                 } },
                             });
                             gz.instructions.appendAssumeCapacity(new_index);
+                        } else {
+                            try gz.addDefer(defer_scope.index, defer_scope.len);
                         }
                     },
                     .normal_only => continue,
@@ -2916,12 +2918,13 @@ fn deferStmt(
 
     const payload_token = node_datas[node].lhs;
     var local_val_scope: Scope.LocalVal = undefined;
-    var remapped_err_code: Zir.Inst.Index = 0;
+    var opt_remapped_err_code: Zir.Inst.OptionalIndex = .none;
     const have_err_code = scope_tag == .defer_error and payload_token != 0;
     const sub_scope = if (!have_err_code) &defer_gen.base else blk: {
         try gz.addDbgBlockBegin();
         const ident_name = try gz.astgen.identAsString(payload_token);
-        remapped_err_code = @intCast(gz.astgen.instructions.len);
+        const remapped_err_code: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
+        opt_remapped_err_code = remapped_err_code.toOptional();
         try gz.astgen.instructions.append(gz.astgen.gpa, .{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -2930,7 +2933,7 @@ fn deferStmt(
                 .operand = undefined,
             } },
         });
-        const remapped_err_code_ref = Zir.indexToRef(remapped_err_code);
+        const remapped_err_code_ref = remapped_err_code.toRef();
         local_val_scope = .{
             .parent = &defer_gen.base,
             .gen_zir = gz,
@@ -2945,13 +2948,13 @@ fn deferStmt(
     _ = try unusedResultExpr(&defer_gen, sub_scope, expr_node);
     try checkUsed(gz, scope, sub_scope);
     if (have_err_code) try gz.addDbgBlockEnd();
-    _ = try defer_gen.addBreak(.break_inline, 0, .void_value);
+    _ = try defer_gen.addBreak(.break_inline, @enumFromInt(0), .void_value);
 
     // We must handle ref_table for remapped_err_code manually.
     const body = defer_gen.instructionsSlice();
     const body_len = blk: {
         var refs: u32 = 0;
-        if (have_err_code) {
+        if (opt_remapped_err_code.unwrap()) |remapped_err_code| {
             var cur_inst = remapped_err_code;
             while (gz.astgen.ref_table.get(cur_inst)) |ref_inst| {
                 refs += 1;
@@ -2963,7 +2966,7 @@ fn deferStmt(
 
     const index: u32 = @intCast(gz.astgen.extra.items.len);
     try gz.astgen.extra.ensureUnusedCapacity(gz.astgen.gpa, body_len);
-    if (have_err_code) {
+    if (opt_remapped_err_code.unwrap()) |remapped_err_code| {
         if (gz.astgen.ref_table.fetchRemove(remapped_err_code)) |kv| {
             gz.astgen.appendPossiblyRefdBodyInst(&gz.astgen.extra, kv.value);
         }
@@ -2977,7 +2980,7 @@ fn deferStmt(
         .parent = scope,
         .index = index,
         .len = body_len,
-        .remapped_err_code = remapped_err_code,
+        .remapped_err_code = opt_remapped_err_code,
     };
     return &defer_scope.base;
 }
@@ -3226,9 +3229,9 @@ fn emitDbgNode(gz: *GenZir, node: Ast.Node.Index) !void {
     if (gz.instructions.items.len > 0) {
         const last = gz.instructions.items[gz.instructions.items.len - 1];
         const zir_tags = astgen.instructions.items(.tag);
-        if (zir_tags[last] == .dbg_stmt) {
+        if (zir_tags[@intFromEnum(last)] == .dbg_stmt) {
             const zir_datas = astgen.instructions.items(.data);
-            zir_datas[last].dbg_stmt = .{
+            zir_datas[@intFromEnum(last)].dbg_stmt = .{
                 .line = line,
                 .column = column,
             };
@@ -3721,8 +3724,8 @@ fn ptrType(
         gz.astgen.extra.appendAssumeCapacity(@intFromEnum(bit_end_ref));
     }
 
-    const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
-    const result = indexToRef(new_index);
+    const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
+    const result = new_index.toRef();
     gz.astgen.instructions.appendAssumeCapacity(.{ .tag = .ptr_type, .data = .{
         .ptr_type = .{
             .flags = .{
@@ -4049,7 +4052,7 @@ fn fnDecl(
                 var param_gz = decl_gz.makeSubBlock(scope);
                 defer param_gz.unstack();
                 const param_type = try expr(&param_gz, params_scope, coerced_type_ri, param_type_node);
-                const param_inst_expected: u32 = @intCast(astgen.instructions.len + 1);
+                const param_inst_expected: Zir.Inst.Index = @enumFromInt(astgen.instructions.len + 1);
                 _ = try param_gz.addBreakWithSrcNode(.break_inline, param_inst_expected, param_type, param_type_node);
 
                 const main_tokens = tree.nodes.items(.main_token);
@@ -4057,7 +4060,7 @@ fn fnDecl(
                 const tag: Zir.Inst.Tag = if (is_comptime) .param_comptime else .param;
                 const param_inst = try decl_gz.addParam(&param_gz, tag, name_token, param_name, param.first_doc_comment);
                 assert(param_inst_expected == param_inst);
-                break :param indexToRef(param_inst);
+                break :param param_inst.toRef();
             };
 
             if (param_name == 0 or is_extern) continue;
@@ -4102,7 +4105,7 @@ fn fnDecl(
             // In this case we will send a len=0 body which can be encoded more efficiently.
             break :inst inst;
         }
-        _ = try align_gz.addBreak(.break_inline, 0, inst);
+        _ = try align_gz.addBreak(.break_inline, @enumFromInt(0), inst);
         break :inst inst;
     };
 
@@ -4114,7 +4117,7 @@ fn fnDecl(
             // In this case we will send a len=0 body which can be encoded more efficiently.
             break :inst inst;
         }
-        _ = try addrspace_gz.addBreak(.break_inline, 0, inst);
+        _ = try addrspace_gz.addBreak(.break_inline, @enumFromInt(0), inst);
         break :inst inst;
     };
 
@@ -4126,7 +4129,7 @@ fn fnDecl(
             // In this case we will send a len=0 body which can be encoded more efficiently.
             break :inst inst;
         }
-        _ = try section_gz.addBreak(.break_inline, 0, inst);
+        _ = try section_gz.addBreak(.break_inline, @enumFromInt(0), inst);
         break :inst inst;
     };
 
@@ -4151,7 +4154,7 @@ fn fnDecl(
                 // In this case we will send a len=0 body which can be encoded more efficiently.
                 break :blk inst;
             }
-            _ = try cc_gz.addBreak(.break_inline, 0, inst);
+            _ = try cc_gz.addBreak(.break_inline, @enumFromInt(0), inst);
             break :blk inst;
         } else if (is_extern) {
             // note: https://github.com/ziglang/zig/issues/5269
@@ -4171,7 +4174,7 @@ fn fnDecl(
             // In this case we will send a len=0 body which can be encoded more efficiently.
             break :inst inst;
         }
-        _ = try ret_gz.addBreak(.break_inline, 0, inst);
+        _ = try ret_gz.addBreak(.break_inline, @enumFromInt(0), inst);
         break :inst inst;
     };
 
@@ -4271,7 +4274,7 @@ fn fnDecl(
         wip_members.appendToDecl(line_delta);
     }
     wip_members.appendToDecl(fn_name_str_index);
-    wip_members.appendToDecl(block_inst);
+    wip_members.appendToDecl(@intFromEnum(block_inst));
     wip_members.appendToDecl(doc_comment_index);
 }
 
@@ -4421,7 +4424,7 @@ fn globalVarDecl(
         wip_members.appendToDecl(line_delta);
     }
     wip_members.appendToDecl(name_str_index);
-    wip_members.appendToDecl(block_inst);
+    wip_members.appendToDecl(@intFromEnum(block_inst));
     wip_members.appendToDecl(doc_comment_index); // doc_comment wip
     if (align_inst != .none) {
         wip_members.appendToDecl(@intFromEnum(align_inst));
@@ -4475,7 +4478,7 @@ fn comptimeDecl(
         wip_members.appendToDecl(line_delta);
     }
     wip_members.appendToDecl(0);
-    wip_members.appendToDecl(block_inst);
+    wip_members.appendToDecl(@intFromEnum(block_inst));
     wip_members.appendToDecl(0); // no doc comments on comptime decls
 }
 
@@ -4526,7 +4529,7 @@ fn usingnamespaceDecl(
         wip_members.appendToDecl(line_delta);
     }
     wip_members.appendToDecl(0);
-    wip_members.appendToDecl(block_inst);
+    wip_members.appendToDecl(@intFromEnum(block_inst));
     wip_members.appendToDecl(0); // no doc comments on usingnamespace decls
 }
 
@@ -4715,7 +4718,7 @@ fn testDecl(
         wip_members.appendToDecl(2) // 2 here means that it is a decltest, look at doc comment for name
     else
         wip_members.appendToDecl(test_name);
-    wip_members.appendToDecl(block_inst);
+    wip_members.appendToDecl(@intFromEnum(block_inst));
     if (is_decltest)
         wip_members.appendToDecl(test_name) // the doc comment on a decltest represents it's name
     else
@@ -4747,7 +4750,7 @@ fn structDeclInner(
             .any_default_inits = false,
             .any_aligned_fields = false,
         });
-        return indexToRef(decl_inst);
+        return decl_inst.toRef();
     }
 
     const astgen = gz.astgen;
@@ -4993,7 +4996,7 @@ fn structDeclInner(
 
     block_scope.unstack();
     try gz.addNamespaceCaptures(&namespace);
-    return indexToRef(decl_inst);
+    return decl_inst.toRef();
 }
 
 fn unionDeclInner(
@@ -5154,7 +5157,7 @@ fn unionDeclInner(
 
     block_scope.unstack();
     try gz.addNamespaceCaptures(&namespace);
-    return indexToRef(decl_inst);
+    return decl_inst.toRef();
 }
 
 fn containerDecl(
@@ -5404,7 +5407,7 @@ fn containerDecl(
 
             block_scope.unstack();
             try gz.addNamespaceCaptures(&namespace);
-            return rvalue(gz, ri, indexToRef(decl_inst), node);
+            return rvalue(gz, ri, decl_inst.toRef(), node);
         },
         .keyword_opaque => {
             assert(container_decl.ast.arg == 0);
@@ -5455,7 +5458,7 @@ fn containerDecl(
 
             block_scope.unstack();
             try gz.addNamespaceCaptures(&namespace);
-            return rvalue(gz, ri, indexToRef(decl_inst), node);
+            return rvalue(gz, ri, decl_inst.toRef(), node);
         },
         else => unreachable,
     }
@@ -5642,7 +5645,7 @@ fn tryExpr(
     _ = try else_scope.addUnNode(.ret_node, err_code, node);
 
     try else_scope.setTryBody(try_inst, operand);
-    const result = indexToRef(try_inst);
+    const result = try_inst.toRef();
     switch (ri.rl) {
         .ref, .ref_coerced_ty => return result,
         else => return rvalue(parent_gz, ri, result, node),
@@ -5755,9 +5758,9 @@ fn orelseCatchExpr(
     try setCondBrPayload(condbr, cond, &then_scope, &else_scope);
 
     if (need_result_rvalue) {
-        return rvalue(parent_gz, ri, indexToRef(block), node);
+        return rvalue(parent_gz, ri, block.toRef(), node);
     } else {
-        return indexToRef(block);
+        return block.toRef();
     }
 }
 
@@ -5916,7 +5919,7 @@ fn boolBinOp(
     }
     try rhs_scope.setBoolBrBody(bool_br);
 
-    const block_ref = indexToRef(bool_br);
+    const block_ref = bool_br.toRef();
     return rvalue(gz, ri, block_ref, node);
 }
 
@@ -6116,9 +6119,9 @@ fn ifExpr(
     try setCondBrPayload(condbr, cond.bool_bit, &then_scope, &else_scope);
 
     if (need_result_rvalue) {
-        return rvalue(parent_gz, ri, indexToRef(block), node);
+        return rvalue(parent_gz, ri, block.toRef(), node);
     } else {
-        return indexToRef(block);
+        return block.toRef();
     }
 }
 
@@ -6142,7 +6145,7 @@ fn setCondBrPayload(
     );
 
     const zir_datas = astgen.instructions.items(.data);
-    zir_datas[condbr].pl_node.payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.CondBr{
+    zir_datas[@intFromEnum(condbr)].pl_node.payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.CondBr{
         .condition = cond,
         .then_body_len = then_body_len,
         .else_body_len = else_body_len,
@@ -6245,7 +6248,7 @@ fn whileExpr(
 
     var dbg_var_name: ?u32 = null;
     var dbg_var_inst: Zir.Inst.Ref = undefined;
-    var payload_inst: Zir.Inst.Index = 0;
+    var opt_payload_inst: Zir.Inst.OptionalIndex = .none;
     var payload_val_scope: Scope.LocalVal = undefined;
     const then_sub_scope = s: {
         if (while_full.error_token != null) {
@@ -6255,7 +6258,8 @@ fn whileExpr(
                 else
                     .err_union_payload_unsafe;
                 // will add this instruction to then_scope.instructions below
-                payload_inst = try then_scope.makeUnNode(tag, cond.inst, while_full.ast.cond_expr);
+                const payload_inst = try then_scope.makeUnNode(tag, cond.inst, while_full.ast.cond_expr);
+                opt_payload_inst = payload_inst.toOptional();
                 const ident_token = if (payload_is_ref) payload_token + 1 else payload_token;
                 const ident_bytes = tree.tokenSlice(ident_token);
                 if (mem.eql(u8, "_", ident_bytes))
@@ -6267,12 +6271,12 @@ fn whileExpr(
                     .parent = &then_scope.base,
                     .gen_zir = &then_scope,
                     .name = ident_name,
-                    .inst = indexToRef(payload_inst),
+                    .inst = payload_inst.toRef(),
                     .token_src = payload_token,
                     .id_cat = .capture,
                 };
                 dbg_var_name = ident_name;
-                dbg_var_inst = indexToRef(payload_inst);
+                dbg_var_inst = payload_inst.toRef();
                 break :s &payload_val_scope.base;
             } else {
                 _ = try then_scope.addUnNode(.ensure_err_union_payload_void, cond.inst, node);
@@ -6285,7 +6289,8 @@ fn whileExpr(
             else
                 .optional_payload_unsafe;
             // will add this instruction to then_scope.instructions below
-            payload_inst = try then_scope.makeUnNode(tag, cond.inst, while_full.ast.cond_expr);
+            const payload_inst = try then_scope.makeUnNode(tag, cond.inst, while_full.ast.cond_expr);
+            opt_payload_inst = payload_inst.toOptional();
             const ident_name = try astgen.identAsString(ident_token);
             const ident_bytes = tree.tokenSlice(ident_token);
             if (mem.eql(u8, "_", ident_bytes))
@@ -6295,12 +6300,12 @@ fn whileExpr(
                 .parent = &then_scope.base,
                 .gen_zir = &then_scope,
                 .name = ident_name,
-                .inst = indexToRef(payload_inst),
+                .inst = payload_inst.toRef(),
                 .token_src = ident_token,
                 .id_cat = .capture,
             };
             dbg_var_name = ident_name;
-            dbg_var_inst = indexToRef(payload_inst);
+            dbg_var_inst = payload_inst.toRef();
             break :s &payload_val_scope.base;
         } else {
             break :s &then_scope.base;
@@ -6316,8 +6321,8 @@ fn whileExpr(
     _ = try loop_scope.addNode(repeat_tag, node);
 
     try loop_scope.setBlockBody(loop_block);
-    loop_scope.break_block = loop_block;
-    loop_scope.continue_block = continue_block;
+    loop_scope.break_block = loop_block.toOptional();
+    loop_scope.continue_block = continue_block.toOptional();
     if (while_full.label_token) |label_token| {
         loop_scope.label = .{
             .token = label_token,
@@ -6330,7 +6335,9 @@ fn whileExpr(
 
     try then_scope.addDbgBlockBegin();
     const then_node = while_full.ast.then_expr;
-    if (payload_inst != 0) try then_scope.instructions.append(astgen.gpa, payload_inst);
+    if (opt_payload_inst.unwrap()) |payload_inst| {
+        try then_scope.instructions.append(astgen.gpa, payload_inst);
+    }
     if (dbg_var_name) |name| try then_scope.addDbgVar(.dbg_var_val, name, dbg_var_inst);
     try then_scope.instructions.append(astgen.gpa, continue_block);
     // This code could be improved to avoid emitting the continue expr when there
@@ -6386,8 +6393,8 @@ fn whileExpr(
         };
         // Remove the continue block and break block so that `continue` and `break`
         // control flow apply to outer loops; not this one.
-        loop_scope.continue_block = 0;
-        loop_scope.break_block = 0;
+        loop_scope.continue_block = .none;
+        loop_scope.break_block = .none;
         const else_result = try expr(&else_scope, sub_scope, loop_scope.break_result_info, else_node);
         if (is_statement) {
             _ = try addEnsureResult(&else_scope, else_result, else_node);
@@ -6412,9 +6419,9 @@ fn whileExpr(
     try setCondBrPayload(condbr, cond.bool_bit, &then_scope, &else_scope);
 
     const result = if (need_result_rvalue)
-        try rvalue(parent_gz, ri, indexToRef(loop_block), node)
+        try rvalue(parent_gz, ri, loop_block.toRef(), node)
     else
-        indexToRef(loop_block);
+        loop_block.toRef();
 
     if (is_statement) {
         _ = try parent_gz.addUnNode(.ensure_result_used, result, node);
@@ -6577,8 +6584,8 @@ fn forExpr(
     const cond_block = try loop_scope.makeBlockInst(block_tag, node);
     try cond_scope.setBlockBody(cond_block);
 
-    loop_scope.break_block = loop_block;
-    loop_scope.continue_block = cond_block;
+    loop_scope.break_block = loop_block.toOptional();
+    loop_scope.continue_block = cond_block.toOptional();
     if (for_full.label_token) |label_token| {
         loop_scope.label = .{
             .token = label_token,
@@ -6671,8 +6678,8 @@ fn forExpr(
         const sub_scope = &else_scope.base;
         // Remove the continue block and break block so that `continue` and `break`
         // control flow apply to outer loops; not this one.
-        loop_scope.continue_block = 0;
-        loop_scope.break_block = 0;
+        loop_scope.continue_block = .none;
+        loop_scope.break_block = .none;
         const else_result = try expr(&else_scope, sub_scope, loop_scope.break_result_info, else_node);
         if (is_statement) {
             _ = try addEnsureResult(&else_scope, else_result, else_node);
@@ -6696,7 +6703,7 @@ fn forExpr(
     // then_block and else_block unstacked now, can resurrect loop_scope to finally finish it
     {
         loop_scope.instructions_top = loop_scope.instructions.items.len;
-        try loop_scope.instructions.appendSlice(gpa, &.{ Zir.refToIndex(index).?, cond_block });
+        try loop_scope.instructions.appendSlice(gpa, &.{ index.toIndex().?, cond_block });
 
         // Increment the index variable.
         const index_plus_one = try loop_scope.addPlNode(.add_unsafe, node, Zir.Inst.Bin{
@@ -6711,9 +6718,9 @@ fn forExpr(
     }
 
     const result = if (need_result_rvalue)
-        try rvalue(parent_gz, ri, indexToRef(loop_block), node)
+        try rvalue(parent_gz, ri, loop_block.toRef(), node)
     else
-        indexToRef(loop_block);
+        loop_block.toRef();
 
     if (is_statement) {
         _ = try parent_gz.addUnNode(.ensure_result_used, result, node);
@@ -6912,7 +6919,7 @@ fn switchExpr(
 
     // If any prong has an inline tag capture, allocate a shared dummy instruction for it
     const tag_inst = if (any_has_tag_capture) tag_inst: {
-        const inst: Zir.Inst.Index = @intCast(astgen.instructions.len);
+        const inst: Zir.Inst.Index = @enumFromInt(astgen.instructions.len);
         try astgen.instructions.append(astgen.gpa, .{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -6967,12 +6974,12 @@ fn switchExpr(
                     .parent = &case_scope.base,
                     .gen_zir = &case_scope,
                     .name = capture_name,
-                    .inst = indexToRef(switch_block),
+                    .inst = switch_block.toRef(),
                     .token_src = payload_token,
                     .id_cat = .capture,
                 };
                 dbg_var_name = capture_name;
-                dbg_var_inst = indexToRef(switch_block);
+                dbg_var_inst = switch_block.toRef();
                 payload_sub_scope = &capture_val_scope.base;
             }
 
@@ -6996,12 +7003,12 @@ fn switchExpr(
                 .parent = payload_sub_scope,
                 .gen_zir = &case_scope,
                 .name = tag_name,
-                .inst = indexToRef(tag_inst),
+                .inst = tag_inst.toRef(),
                 .token_src = tag_token,
                 .id_cat = .@"switch tag capture",
             };
             dbg_var_tag_name = tag_name;
-            dbg_var_tag_inst = indexToRef(tag_inst);
+            dbg_var_tag_inst = tag_inst.toRef();
             break :blk &tag_scope.base;
         };
 
@@ -7136,11 +7143,11 @@ fn switchExpr(
     }
 
     if (any_has_tag_capture) {
-        astgen.extra.appendAssumeCapacity(tag_inst);
+        astgen.extra.appendAssumeCapacity(@intFromEnum(tag_inst));
     }
 
     const zir_datas = astgen.instructions.items(.data);
-    zir_datas[switch_block].pl_node.payload_index = payload_index;
+    zir_datas[@intFromEnum(switch_block)].pl_node.payload_index = payload_index;
 
     for (payloads.items[case_table_start..case_table_end], 0..) |start_index, i| {
         var body_len_index = start_index;
@@ -7163,9 +7170,9 @@ fn switchExpr(
     }
 
     if (need_result_rvalue) {
-        return rvalue(parent_gz, ri, indexToRef(switch_block), switch_node);
+        return rvalue(parent_gz, ri, switch_block.toRef(), switch_node);
     } else {
-        return indexToRef(switch_block);
+        return switch_block.toRef();
     }
 }
 
@@ -7524,13 +7531,13 @@ fn tunnelThroughClosure(
 ) !Zir.Inst.Ref {
     // For trivial values, we don't need a tunnel.
     // Just return the ref.
-    if (num_tunnels == 0 or refToIndex(value) == null) {
+    if (num_tunnels == 0 or value.toIndex() == null) {
         return value;
     }
 
     // Otherwise we need a tunnel.  Check if this namespace
     // already has one for this value.
-    const gop = try ns.?.captures.getOrPut(gpa, refToIndex(value).?);
+    const gop = try ns.?.captures.getOrPut(gpa, value.toIndex().?);
     if (!gop.found_existing) {
         // Make a new capture for this value but don't add it to the declaring_gz yet
         try gz.astgen.instructions.append(gz.astgen.gpa, .{
@@ -7540,7 +7547,7 @@ fn tunnelThroughClosure(
                 .src_tok = ns.?.declaring_gz.?.tokenIndexToRelative(token),
             } },
         });
-        gop.value_ptr.* = @intCast(gz.astgen.instructions.len - 1);
+        gop.value_ptr.* = @enumFromInt(gz.astgen.instructions.len - 1);
     }
 
     // Add an instruction to get the value from the closure into
@@ -8032,7 +8039,7 @@ fn typeOf(
 
         // typeof_scope unstacked now, can add new instructions to gz
         try gz.instructions.append(gpa, typeof_inst);
-        return rvalue(gz, ri, indexToRef(typeof_inst), node);
+        return rvalue(gz, ri, typeof_inst.toRef(), node);
     }
     const payload_size: u32 = std.meta.fields(Zir.Inst.TypeOfPeer).len;
     const payload_index = try reserveExtra(astgen, payload_size + args.len);
@@ -8047,7 +8054,7 @@ fn typeOf(
         const param_ref = try reachableExpr(&typeof_scope, &typeof_scope.base, .{ .rl = .none }, arg, node);
         astgen.extra.items[args_index + i] = @intFromEnum(param_ref);
     }
-    _ = try typeof_scope.addBreak(.break_inline, refToIndex(typeof_inst).?, .void_value);
+    _ = try typeof_scope.addBreak(.break_inline, typeof_inst.toIndex().?, .void_value);
 
     const body = typeof_scope.instructionsSlice();
     const body_len = astgen.countBodyLenAfterFixups(body);
@@ -8401,7 +8408,7 @@ fn builtinCall(
                 .node = gz.nodeIndexToRelative(node),
                 .operand = operand,
             });
-            const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+            const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
             gz.astgen.instructions.appendAssumeCapacity(.{
                 .tag = .extended,
                 .data = .{ .extended = .{
@@ -8411,7 +8418,7 @@ fn builtinCall(
                 } },
             });
             gz.instructions.appendAssumeCapacity(new_index);
-            const result = indexToRef(new_index);
+            const result = new_index.toRef();
             return rvalue(gz, ri, result, node);
         },
         .panic => {
@@ -8993,7 +9000,7 @@ fn cImport(
     // block_scope unstacked now, can add new instructions to gz
     try gz.instructions.append(gpa, block_inst);
 
-    return indexToRef(block_inst);
+    return block_inst.toRef();
 }
 
 fn overflowArithmetic(
@@ -9056,8 +9063,8 @@ fn callExpr(
     }
     assert(node != 0);
 
-    const call_index: Zir.Inst.Index = @intCast(astgen.instructions.len);
-    const call_inst = Zir.indexToRef(call_index);
+    const call_index: Zir.Inst.Index = @enumFromInt(astgen.instructions.len);
+    const call_inst = call_index.toRef();
     try gz.astgen.instructions.append(astgen.gpa, undefined);
     try gz.instructions.append(astgen.gpa, call_index);
 
@@ -9104,7 +9111,7 @@ fn callExpr(
             if (call.ast.params.len != 0) {
                 try astgen.extra.appendSlice(astgen.gpa, astgen.scratch.items[scratch_top..]);
             }
-            gz.astgen.instructions.set(call_index, .{
+            gz.astgen.instructions.set(@intFromEnum(call_index), .{
                 .tag = .call,
                 .data = .{ .pl_node = .{
                     .src_node = gz.nodeIndexToRelative(node),
@@ -9125,7 +9132,7 @@ fn callExpr(
             if (call.ast.params.len != 0) {
                 try astgen.extra.appendSlice(astgen.gpa, astgen.scratch.items[scratch_top..]);
             }
-            gz.astgen.instructions.set(call_index, .{
+            gz.astgen.instructions.set(@intFromEnum(call_index), .{
                 .tag = .field_call,
                 .data = .{ .pl_node = .{
                     .src_node = gz.nodeIndexToRelative(node),
@@ -10062,10 +10069,10 @@ fn rvalueInner(
     allow_coerce_pre_ref: bool,
 ) InnerError!Zir.Inst.Ref {
     const result = r: {
-        if (refToIndex(raw_result)) |result_index| {
+        if (raw_result.toIndex()) |result_index| {
             const zir_tags = gz.astgen.instructions.items(.tag);
-            const data = gz.astgen.instructions.items(.data)[result_index];
-            if (zir_tags[result_index].isAlwaysVoid(data)) {
+            const data = gz.astgen.instructions.items(.data)[@intFromEnum(result_index)];
+            if (zir_tags[@intFromEnum(result_index)].isAlwaysVoid(data)) {
                 break :r Zir.Inst.Ref.void_value;
             }
         }
@@ -10094,16 +10101,16 @@ fn rvalueInner(
             const astgen = gz.astgen;
             const tree = astgen.tree;
             const src_token = tree.firstToken(src_node);
-            const result_index = refToIndex(coerced_result) orelse
+            const result_index = coerced_result.toIndex() orelse
                 return gz.addUnTok(.ref, coerced_result, src_token);
             const zir_tags = gz.astgen.instructions.items(.tag);
-            if (zir_tags[result_index].isParam() or astgen.isInferred(coerced_result))
+            if (zir_tags[@intFromEnum(result_index)].isParam() or astgen.isInferred(coerced_result))
                 return gz.addUnTok(.ref, coerced_result, src_token);
             const gop = try astgen.ref_table.getOrPut(astgen.gpa, result_index);
             if (!gop.found_existing) {
                 gop.value_ptr.* = try gz.makeUnTok(.ref, coerced_result, src_token);
             }
-            return indexToRef(gop.value_ptr.*);
+            return gop.value_ptr.*.toRef();
         },
         .ty => |ty_inst| {
             // Quickly eliminate some common, unnecessary type coercion.
@@ -10849,7 +10856,7 @@ const Scope = struct {
         parent: *Scope,
         index: u32,
         len: u32,
-        remapped_err_code: Zir.Inst.Index = 0,
+        remapped_err_code: Zir.Inst.OptionalIndex = .none,
     };
 
     /// Represents a global scope that has any number of declarations in it.
@@ -10919,8 +10926,8 @@ const GenZir = struct {
     /// if use is strictly nested. This saves prior size of list for unstacking.
     instructions_top: usize,
     label: ?Label = null,
-    break_block: Zir.Inst.Index = 0,
-    continue_block: Zir.Inst.Index = 0,
+    break_block: Zir.Inst.OptionalIndex = .none,
+    continue_block: Zir.Inst.OptionalIndex = .none,
     /// Only valid when setBreakResultInfo is called.
     break_result_info: AstGen.ResultInfo = undefined,
 
@@ -10995,14 +11002,14 @@ const GenZir = struct {
         if (gz.isEmpty()) return false;
         const tags = gz.astgen.instructions.items(.tag);
         const last_inst = gz.instructions.items[gz.instructions.items.len - 1];
-        return tags[last_inst].isNoReturn();
+        return tags[@intFromEnum(last_inst)].isNoReturn();
     }
 
     /// TODO all uses of this should be replaced with uses of `endsWithNoReturn`.
     fn refIsNoReturn(gz: GenZir, inst_ref: Zir.Inst.Ref) bool {
         if (inst_ref == .unreachable_value) return true;
-        if (refToIndex(inst_ref)) |inst_index| {
-            return gz.astgen.instructions.items(.tag)[inst_index].isNoReturn();
+        if (inst_ref.toIndex()) |inst_index| {
+            return gz.astgen.instructions.items(.tag)[@intFromEnum(inst_index)].isNoReturn();
         }
         return false;
     }
@@ -11053,7 +11060,7 @@ const GenZir = struct {
             @typeInfo(Zir.Inst.Block).Struct.fields.len + body_len,
         );
         const zir_datas = astgen.instructions.items(.data);
-        zir_datas[inst].bool_br.payload_index = astgen.addExtraAssumeCapacity(
+        zir_datas[@intFromEnum(inst)].bool_br.payload_index = astgen.addExtraAssumeCapacity(
             Zir.Inst.Block{ .body_len = body_len },
         );
         astgen.appendBodyWithFixups(body);
@@ -11071,7 +11078,7 @@ const GenZir = struct {
             @typeInfo(Zir.Inst.Block).Struct.fields.len + body_len,
         );
         const zir_datas = astgen.instructions.items(.data);
-        zir_datas[inst].pl_node.payload_index = astgen.addExtraAssumeCapacity(
+        zir_datas[@intFromEnum(inst)].pl_node.payload_index = astgen.addExtraAssumeCapacity(
             Zir.Inst.Block{ .body_len = body_len },
         );
         astgen.appendBodyWithFixups(body);
@@ -11089,7 +11096,7 @@ const GenZir = struct {
             @typeInfo(Zir.Inst.Try).Struct.fields.len + body_len,
         );
         const zir_datas = astgen.instructions.items(.data);
-        zir_datas[inst].pl_node.payload_index = astgen.addExtraAssumeCapacity(
+        zir_datas[@intFromEnum(inst)].pl_node.payload_index = astgen.addExtraAssumeCapacity(
             Zir.Inst.Try{
                 .operand = operand,
                 .body_len = body_len,
@@ -11139,7 +11146,7 @@ const GenZir = struct {
         const astgen = gz.astgen;
         const gpa = astgen.gpa;
         const ret_ref = if (args.ret_ref == .void_type) .none else args.ret_ref;
-        const new_index: Zir.Inst.Index = @intCast(astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(astgen.instructions.len);
 
         try astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
@@ -11235,9 +11242,9 @@ const GenZir = struct {
             if (align_body.len != 0) {
                 astgen.extra.appendAssumeCapacity(countBodyLenAfterFixups(astgen, align_body));
                 astgen.appendBodyWithFixups(align_body);
-                const break_extra = zir_datas[align_body[align_body.len - 1]].@"break".payload_index;
+                const break_extra = zir_datas[@intFromEnum(align_body[align_body.len - 1])].@"break".payload_index;
                 astgen.extra.items[break_extra + std.meta.fieldIndex(Zir.Inst.Break, "block_inst").?] =
-                    new_index;
+                    @intFromEnum(new_index);
             } else if (args.align_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@intFromEnum(args.align_ref));
             }
@@ -11245,9 +11252,9 @@ const GenZir = struct {
                 astgen.extra.appendAssumeCapacity(countBodyLenAfterFixups(astgen, addrspace_body));
                 astgen.appendBodyWithFixups(addrspace_body);
                 const break_extra =
-                    zir_datas[addrspace_body[addrspace_body.len - 1]].@"break".payload_index;
+                    zir_datas[@intFromEnum(addrspace_body[addrspace_body.len - 1])].@"break".payload_index;
                 astgen.extra.items[break_extra + std.meta.fieldIndex(Zir.Inst.Break, "block_inst").?] =
-                    new_index;
+                    @intFromEnum(new_index);
             } else if (args.addrspace_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@intFromEnum(args.addrspace_ref));
             }
@@ -11255,27 +11262,27 @@ const GenZir = struct {
                 astgen.extra.appendAssumeCapacity(countBodyLenAfterFixups(astgen, section_body));
                 astgen.appendBodyWithFixups(section_body);
                 const break_extra =
-                    zir_datas[section_body[section_body.len - 1]].@"break".payload_index;
+                    zir_datas[@intFromEnum(section_body[section_body.len - 1])].@"break".payload_index;
                 astgen.extra.items[break_extra + std.meta.fieldIndex(Zir.Inst.Break, "block_inst").?] =
-                    new_index;
+                    @intFromEnum(new_index);
             } else if (args.section_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@intFromEnum(args.section_ref));
             }
             if (cc_body.len != 0) {
                 astgen.extra.appendAssumeCapacity(countBodyLenAfterFixups(astgen, cc_body));
                 astgen.appendBodyWithFixups(cc_body);
-                const break_extra = zir_datas[cc_body[cc_body.len - 1]].@"break".payload_index;
+                const break_extra = zir_datas[@intFromEnum(cc_body[cc_body.len - 1])].@"break".payload_index;
                 astgen.extra.items[break_extra + std.meta.fieldIndex(Zir.Inst.Break, "block_inst").?] =
-                    new_index;
+                    @intFromEnum(new_index);
             } else if (args.cc_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@intFromEnum(args.cc_ref));
             }
             if (ret_body.len != 0) {
                 astgen.extra.appendAssumeCapacity(countBodyLenAfterFixups(astgen, ret_body));
                 astgen.appendBodyWithFixups(ret_body);
-                const break_extra = zir_datas[ret_body[ret_body.len - 1]].@"break".payload_index;
+                const break_extra = zir_datas[@intFromEnum(ret_body[ret_body.len - 1])].@"break".payload_index;
                 astgen.extra.items[break_extra + std.meta.fieldIndex(Zir.Inst.Break, "block_inst").?] =
-                    new_index;
+                    @intFromEnum(new_index);
             } else if (ret_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@intFromEnum(ret_ref));
             }
@@ -11307,7 +11314,7 @@ const GenZir = struct {
                 } },
             });
             gz.instructions.appendAssumeCapacity(new_index);
-            return indexToRef(new_index);
+            return new_index.toRef();
         } else {
             try astgen.extra.ensureUnusedCapacity(
                 gpa,
@@ -11330,9 +11337,9 @@ const GenZir = struct {
             if (ret_body.len != 0) {
                 astgen.appendBodyWithFixups(ret_body);
 
-                const break_extra = zir_datas[ret_body[ret_body.len - 1]].@"break".payload_index;
+                const break_extra = zir_datas[@intFromEnum(ret_body[ret_body.len - 1])].@"break".payload_index;
                 astgen.extra.items[break_extra + std.meta.fieldIndex(Zir.Inst.Break, "block_inst").?] =
-                    new_index;
+                    @intFromEnum(new_index);
             } else if (ret_ref != .none) {
                 astgen.extra.appendAssumeCapacity(@intFromEnum(ret_ref));
             }
@@ -11358,7 +11365,7 @@ const GenZir = struct {
                 } },
             });
             gz.instructions.appendAssumeCapacity(new_index);
-            return indexToRef(new_index);
+            return new_index.toRef();
         }
     }
 
@@ -11402,7 +11409,7 @@ const GenZir = struct {
             astgen.extra.appendAssumeCapacity(@intFromEnum(args.init));
         }
 
-        const new_index: Zir.Inst.Index = @intCast(astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(astgen.instructions.len);
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -11418,7 +11425,7 @@ const GenZir = struct {
             } },
         });
         gz.instructions.appendAssumeCapacity(new_index);
-        return indexToRef(new_index);
+        return new_index.toRef();
     }
 
     /// Note that this returns a `Zir.Inst.Index` not a ref.
@@ -11433,7 +11440,7 @@ const GenZir = struct {
         try gz.instructions.ensureUnusedCapacity(gpa, 1);
         try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
-        const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .bool_br = .{
@@ -11459,7 +11466,7 @@ const GenZir = struct {
         try astgen.instructions.ensureUnusedCapacity(gpa, 1);
         try astgen.string_bytes.ensureUnusedCapacity(gpa, @sizeOf(std.math.big.Limb) * limbs.len);
 
-        const new_index: Zir.Inst.Index = @intCast(astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(astgen.instructions.len);
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .int_big,
             .data = .{ .str = .{
@@ -11469,7 +11476,7 @@ const GenZir = struct {
         });
         gz.instructions.appendAssumeCapacity(new_index);
         astgen.string_bytes.appendSliceAssumeCapacity(mem.sliceAsBytes(limbs));
-        return indexToRef(new_index);
+        return new_index.toRef();
     }
 
     fn addFloat(gz: *GenZir, number: f64) !Zir.Inst.Ref {
@@ -11504,7 +11511,7 @@ const GenZir = struct {
         src_node: Ast.Node.Index,
     ) !Zir.Inst.Index {
         assert(operand != .none);
-        const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
         try gz.astgen.instructions.append(gz.astgen.gpa, .{
             .tag = tag,
             .data = .{ .un_node = .{
@@ -11527,7 +11534,7 @@ const GenZir = struct {
         try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
         const payload_index = try gz.astgen.addExtra(extra);
-        const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .pl_node = .{
@@ -11536,7 +11543,7 @@ const GenZir = struct {
             } },
         });
         gz.instructions.appendAssumeCapacity(new_index);
-        return indexToRef(new_index);
+        return new_index.toRef();
     }
 
     fn addPlNodePayloadIndex(
@@ -11584,7 +11591,7 @@ const GenZir = struct {
         gz.astgen.appendBodyWithFixups(param_body);
         param_gz.unstack();
 
-        const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .pl_tok = .{
@@ -11612,7 +11619,7 @@ const GenZir = struct {
         try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
         const payload_index = try gz.astgen.addExtra(extra);
-        const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -11622,7 +11629,7 @@ const GenZir = struct {
             } },
         });
         gz.instructions.appendAssumeCapacity(new_index);
-        return indexToRef(new_index);
+        return new_index.toRef();
     }
 
     fn addExtendedMultiOp(
@@ -11644,7 +11651,7 @@ const GenZir = struct {
         const payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.NodeMultiOp{
             .src_node = gz.nodeIndexToRelative(node),
         });
-        const new_index: Zir.Inst.Index = @intCast(astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(astgen.instructions.len);
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -11655,7 +11662,7 @@ const GenZir = struct {
         });
         gz.instructions.appendAssumeCapacity(new_index);
         astgen.appendRefsAssumeCapacity(operands);
-        return indexToRef(new_index);
+        return new_index.toRef();
     }
 
     fn addExtendedMultiOpPayloadIndex(
@@ -11669,7 +11676,7 @@ const GenZir = struct {
 
         try gz.instructions.ensureUnusedCapacity(gpa, 1);
         try astgen.instructions.ensureUnusedCapacity(gpa, 1);
-        const new_index: Zir.Inst.Index = @intCast(astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(astgen.instructions.len);
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -11679,7 +11686,7 @@ const GenZir = struct {
             } },
         });
         gz.instructions.appendAssumeCapacity(new_index);
-        return indexToRef(new_index);
+        return new_index.toRef();
     }
 
     fn addUnTok(
@@ -11707,7 +11714,7 @@ const GenZir = struct {
         abs_tok_index: Ast.TokenIndex,
     ) !Zir.Inst.Index {
         const astgen = gz.astgen;
-        const new_index: Zir.Inst.Index = @intCast(astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(astgen.instructions.len);
         assert(operand != .none);
         try astgen.instructions.append(astgen.gpa, .{
             .tag = tag,
@@ -11771,7 +11778,7 @@ const GenZir = struct {
             .data = .{ .restore_err_ret_index = .{
                 .block = switch (bt) {
                     .ret => .none,
-                    .block => |b| Zir.indexToRef(b),
+                    .block => |b| b.toRef(),
                 },
                 .operand = if (cond == .if_non_error) cond.if_non_error else .none,
             } },
@@ -11837,7 +11844,7 @@ const GenZir = struct {
         try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
         try gz.astgen.extra.ensureUnusedCapacity(gpa, @typeInfo(Zir.Inst.Break).Struct.fields.len);
 
-        const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .@"break" = .{
@@ -11978,7 +11985,7 @@ const GenZir = struct {
         const is_comptime: u4 = @intFromBool(args.is_comptime);
         const small: u16 = has_type | (has_align << 1) | (is_const << 2) | (is_comptime << 3);
 
-        const new_index: Zir.Inst.Index = @intCast(astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(astgen.instructions.len);
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -11988,7 +11995,7 @@ const GenZir = struct {
             } },
         });
         gz.instructions.appendAssumeCapacity(new_index);
-        return indexToRef(new_index);
+        return new_index.toRef();
     }
 
     fn addAsm(
@@ -12037,7 +12044,7 @@ const GenZir = struct {
             @as(u16, @intCast(args.clobbers.len << 10)) |
             (@as(u16, @intFromBool(args.is_volatile)) << 15);
 
-        const new_index: Zir.Inst.Index = @intCast(astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(astgen.instructions.len);
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -12047,14 +12054,14 @@ const GenZir = struct {
             } },
         });
         gz.instructions.appendAssumeCapacity(new_index);
-        return indexToRef(new_index);
+        return new_index.toRef();
     }
 
     /// Note that this returns a `Zir.Inst.Index` not a ref.
     /// Does *not* append the block instruction to the scope.
     /// Leaves the `payload_index` field undefined.
     fn makeBlockInst(gz: *GenZir, tag: Zir.Inst.Tag, node: Ast.Node.Index) !Zir.Inst.Index {
-        const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
         const gpa = gz.astgen.gpa;
         try gz.astgen.instructions.append(gpa, .{
             .tag = tag,
@@ -12071,7 +12078,7 @@ const GenZir = struct {
     fn addCondBr(gz: *GenZir, tag: Zir.Inst.Tag, node: Ast.Node.Index) !Zir.Inst.Index {
         const gpa = gz.astgen.gpa;
         try gz.instructions.ensureUnusedCapacity(gpa, 1);
-        const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
         try gz.astgen.instructions.append(gpa, .{
             .tag = tag,
             .data = .{ .pl_node = .{
@@ -12119,7 +12126,7 @@ const GenZir = struct {
                 astgen.extra.appendAssumeCapacity(@intFromEnum(args.backing_int_ref));
             }
         }
-        astgen.instructions.set(inst, .{
+        astgen.instructions.set(@intFromEnum(inst), .{
             .tag = .extended,
             .data = .{ .extended = .{
                 .opcode = .struct_decl,
@@ -12174,7 +12181,7 @@ const GenZir = struct {
         if (args.decls_len != 0) {
             astgen.extra.appendAssumeCapacity(args.decls_len);
         }
-        astgen.instructions.set(inst, .{
+        astgen.instructions.set(@intFromEnum(inst), .{
             .tag = .extended,
             .data = .{ .extended = .{
                 .opcode = .union_decl,
@@ -12224,7 +12231,7 @@ const GenZir = struct {
         if (args.decls_len != 0) {
             astgen.extra.appendAssumeCapacity(args.decls_len);
         }
-        astgen.instructions.set(inst, .{
+        astgen.instructions.set(@intFromEnum(inst), .{
             .tag = .extended,
             .data = .{ .extended = .{
                 .opcode = .enum_decl,
@@ -12259,7 +12266,7 @@ const GenZir = struct {
         if (args.decls_len != 0) {
             astgen.extra.appendAssumeCapacity(args.decls_len);
         }
-        astgen.instructions.set(inst, .{
+        astgen.instructions.set(@intFromEnum(inst), .{
             .tag = .extended,
             .data = .{ .extended = .{
                 .opcode = .opaque_decl,
@@ -12274,7 +12281,7 @@ const GenZir = struct {
     }
 
     fn add(gz: *GenZir, inst: Zir.Inst) !Zir.Inst.Ref {
-        return indexToRef(try gz.addAsIndex(inst));
+        return (try gz.addAsIndex(inst)).toRef();
     }
 
     fn addAsIndex(gz: *GenZir, inst: Zir.Inst) !Zir.Inst.Index {
@@ -12282,7 +12289,7 @@ const GenZir = struct {
         try gz.instructions.ensureUnusedCapacity(gpa, 1);
         try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
-        const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
         gz.astgen.instructions.appendAssumeCapacity(inst);
         gz.instructions.appendAssumeCapacity(new_index);
         return new_index;
@@ -12293,7 +12300,7 @@ const GenZir = struct {
         try gz.instructions.ensureUnusedCapacity(gpa, 1);
         try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
-        const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
         gz.astgen.instructions.len += 1;
         gz.instructions.appendAssumeCapacity(new_index);
         return new_index;
@@ -12340,12 +12347,12 @@ const GenZir = struct {
         const tags = gz.astgen.instructions.items(.tag);
         const last_inst = gz.instructions.items[gz.instructions.items.len - 1];
         // remove dbg_block_begin immediately followed by dbg_block_end
-        if (tags[last_inst] == .dbg_block_begin) {
+        if (tags[@intFromEnum(last_inst)] == .dbg_block_begin) {
             _ = gz.instructions.pop();
             return;
         }
 
-        const new_index: Zir.Inst.Index = @intCast(gz.astgen.instructions.len);
+        const new_index: Zir.Inst.Index = @enumFromInt(gz.astgen.instructions.len);
         try gz.astgen.instructions.append(gpa, .{ .tag = .dbg_block_end, .data = undefined });
         try gz.instructions.append(gpa, new_index);
     }
@@ -12622,9 +12629,9 @@ fn scanDecls(astgen: *AstGen, namespace: *Scope.Namespace, members: []const Ast.
 }
 
 fn isInferred(astgen: *AstGen, ref: Zir.Inst.Ref) bool {
-    const inst = refToIndex(ref) orelse return false;
+    const inst = ref.toIndex() orelse return false;
     const zir_tags = astgen.instructions.items(.tag);
-    return switch (zir_tags[inst]) {
+    return switch (zir_tags[@intFromEnum(inst)]) {
         .alloc_inferred,
         .alloc_inferred_mut,
         .alloc_inferred_comptime,
@@ -12633,8 +12640,8 @@ fn isInferred(astgen: *AstGen, ref: Zir.Inst.Ref) bool {
 
         .extended => {
             const zir_data = astgen.instructions.items(.data);
-            if (zir_data[inst].extended.opcode != .alloc) return false;
-            const small: Zir.Inst.AllocExtended.Small = @bitCast(zir_data[inst].extended.small);
+            if (zir_data[@intFromEnum(inst)].extended.opcode != .alloc) return false;
+            const small: Zir.Inst.AllocExtended.Small = @bitCast(zir_data[@intFromEnum(inst)].extended.small);
             return !small.has_type;
         },
 
@@ -12663,7 +12670,7 @@ fn appendPossiblyRefdBodyInst(
     list: *std.ArrayListUnmanaged(u32),
     body_inst: Zir.Inst.Index,
 ) void {
-    list.appendAssumeCapacity(body_inst);
+    list.appendAssumeCapacity(@intFromEnum(body_inst));
     const kv = astgen.ref_table.fetchRemove(body_inst) orelse return;
     const ref_inst = kv.value;
     return appendPossiblyRefdBodyInst(astgen, list, ref_inst);

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -333,7 +333,7 @@ fn generateZirData(self: *Autodoc, output_dir: std.fs.Dir) !void {
         file,
         &root_scope,
         .{},
-        Zir.main_struct_inst,
+        .main_struct_inst,
         false,
         null,
     );
@@ -464,14 +464,14 @@ const Scope = struct {
     /// Another reason is that in some places we use the pointer to uniquely
     /// refer to a decl, as we wait for it to be analyzed. This means that
     /// those pointers must stay stable.
-    pub fn resolveDeclName(self: Scope, string_table_idx: u32, file: *File, inst_index: usize) *DeclStatus {
+    pub fn resolveDeclName(self: Scope, string_table_idx: u32, file: *File, inst: Zir.Inst.OptionalIndex) *DeclStatus {
         var cur: ?*const Scope = &self;
         return while (cur) |s| : (cur = s.parent) {
             break s.map.get(string_table_idx) orelse continue;
         } else {
-            printWithContext(
+            printWithOptionalContext(
                 file,
-                inst_index,
+                inst,
                 "Could not find `{s}`\n\n",
                 .{file.zir.nullTerminatedString(string_table_idx)},
             );
@@ -937,7 +937,7 @@ const AutodocErrors = error{
 ///  This type is used to keep track of dangerous instruction
 ///  numbers that we definitely don't want to recurse into.
 const CallContext = struct {
-    inst: usize,
+    inst: Zir.Inst.Index,
     prev: ?*const CallContext,
 };
 
@@ -954,14 +954,14 @@ fn walkInstruction(
     file: *File,
     parent_scope: *Scope,
     parent_src: SrcLocInfo,
-    inst_index: usize,
+    inst: Zir.Inst.Index,
     need_type: bool, // true if the caller needs us to provide also a typeRef
     call_ctx: ?*const CallContext,
 ) AutodocErrors!DocData.WalkResult {
     const tags = file.zir.instructions.items(.tag);
     const data = file.zir.instructions.items(.data);
 
-    if (self.repurposed_insts.contains(@intCast(inst_index))) {
+    if (self.repurposed_insts.contains(inst)) {
         // TODO: better handling here
         return .{ .expr = .{ .comptimeExpr = 0 } };
     }
@@ -969,18 +969,18 @@ fn walkInstruction(
     // We assume that the topmost ast_node entry corresponds to our decl
     const self_ast_node_index = self.ast_nodes.items.len - 1;
 
-    switch (tags[inst_index]) {
+    switch (tags[@intFromEnum(inst)]) {
         else => {
             printWithContext(
                 file,
-                inst_index,
+                inst,
                 "TODO: implement `{s}` for walkInstruction\n\n",
-                .{@tagName(tags[inst_index])},
+                .{@tagName(tags[@intFromEnum(inst)])},
             );
-            return self.cteTodo(@tagName(tags[inst_index]));
+            return self.cteTodo(@tagName(tags[@intFromEnum(inst)]));
         },
         .import => {
-            const str_tok = data[inst_index].str_tok;
+            const str_tok = data[@intFromEnum(inst)].str_tok;
             var path = str_tok.get(file.zir);
 
             // importFile cannot error out since all files
@@ -1048,7 +1048,7 @@ fn walkInstruction(
                     new_file,
                     &root_scope,
                     .{},
-                    Zir.main_struct_inst,
+                    .main_struct_inst,
                     false,
                     call_ctx,
                 );
@@ -1080,7 +1080,7 @@ fn walkInstruction(
                 new_file.file,
                 &new_scope,
                 .{},
-                Zir.main_struct_inst,
+                .main_struct_inst,
                 need_type,
                 call_ctx,
             );
@@ -1092,7 +1092,7 @@ fn walkInstruction(
             };
         },
         .ret_node => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
             return self.walkRef(
                 file,
                 parent_scope,
@@ -1103,9 +1103,9 @@ fn walkInstruction(
             );
         },
         .ret_load => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
             const res_ptr_ref = un_node.operand;
-            const res_ptr_inst = Zir.refToIndex(res_ptr_ref).?;
+            const res_ptr_inst = @intFromEnum(res_ptr_ref.toIndex().?);
             // TODO: this instruction doesn't let us know trivially if there's
             //       branching involved or not. For now here's the strat:
             //       We search backwarts until `ret_ptr` for `store_node`,
@@ -1113,7 +1113,7 @@ fn walkInstruction(
             //       than one, then it means that there's branching involved.
             //       Maybe.
 
-            var i = inst_index - 1;
+            var i = @intFromEnum(inst) - 1;
             var result_ref: ?Ref = null;
             while (i > res_ptr_inst) : (i -= 1) {
                 if (tags[i] == .store_node) {
@@ -1146,7 +1146,7 @@ fn walkInstruction(
             };
         },
         .closure_get => {
-            const inst_node = data[inst_index].inst_node;
+            const inst_node = data[@intFromEnum(inst)].inst_node;
             return try self.walkInstruction(
                 file,
                 parent_scope,
@@ -1157,7 +1157,7 @@ fn walkInstruction(
             );
         },
         .closure_capture => {
-            const un_tok = data[inst_index].un_tok;
+            const un_tok = data[@intFromEnum(inst)].un_tok;
             return try self.walkRef(
                 file,
                 parent_scope,
@@ -1168,7 +1168,7 @@ fn walkInstruction(
             );
         },
         .str => {
-            const str = data[inst_index].str.get(file.zir);
+            const str = data[@intFromEnum(inst)].str.get(file.zir);
 
             const tRef: ?DocData.Expr = if (!need_type) null else blk: {
                 const arrTypeId = self.types.items.len;
@@ -1204,7 +1204,7 @@ fn walkInstruction(
             };
         },
         .compile_error => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
 
             var operand: DocData.WalkResult = try self.walkRef(
                 file,
@@ -1223,7 +1223,7 @@ fn walkInstruction(
             };
         },
         .enum_literal => {
-            const str_tok = data[inst_index].str_tok;
+            const str_tok = data[@intFromEnum(inst)].str_tok;
             const literal = file.zir.nullTerminatedString(str_tok.start);
             const type_index = self.types.items.len;
             try self.types.append(self.arena, .{
@@ -1236,7 +1236,7 @@ fn walkInstruction(
             };
         },
         .int => {
-            const int = data[inst_index].int;
+            const int = data[@intFromEnum(inst)].int;
             return DocData.WalkResult{
                 .typeRef = .{ .type = @intFromEnum(Ref.comptime_int_type) },
                 .expr = .{ .int = .{ .value = int } },
@@ -1244,7 +1244,7 @@ fn walkInstruction(
         },
         .int_big => {
             // @check
-            const str = data[inst_index].str; //.get(file.zir);
+            const str = data[@intFromEnum(inst)].str; //.get(file.zir);
             const byte_count = str.len * @sizeOf(std.math.big.Limb);
             const limb_bytes = file.zir.string_bytes[str.start..][0..byte_count];
 
@@ -1271,7 +1271,7 @@ fn walkInstruction(
         },
 
         .slice_start => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.SliceStart, pl_node.payload_index);
 
             const slice_index = self.exprs.items.len;
@@ -1311,7 +1311,7 @@ fn walkInstruction(
             };
         },
         .slice_end => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.SliceEnd, pl_node.payload_index);
 
             const slice_index = self.exprs.items.len;
@@ -1361,7 +1361,7 @@ fn walkInstruction(
             };
         },
         .slice_sentinel => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.SliceSentinel, pl_node.payload_index);
 
             const slice_index = self.exprs.items.len;
@@ -1426,7 +1426,7 @@ fn walkInstruction(
             };
         },
         .slice_length => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.SliceLength, pl_node.payload_index);
 
             const slice_index = self.exprs.items.len;
@@ -1498,7 +1498,7 @@ fn walkInstruction(
         },
 
         .load => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
             const operand = try self.walkRef(
                 file,
                 parent_scope,
@@ -1529,7 +1529,7 @@ fn walkInstruction(
             };
         },
         .ref => {
-            const un_tok = data[inst_index].un_tok;
+            const un_tok = data[@intFromEnum(inst)].un_tok;
             const operand = try self.walkRef(
                 file,
                 parent_scope,
@@ -1565,7 +1565,7 @@ fn walkInstruction(
         .array_cat,
         .array_mul,
         => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
 
             const binop_index = self.exprs.items.len;
@@ -1593,7 +1593,7 @@ fn walkInstruction(
             const rhs_index = self.exprs.items.len;
             try self.exprs.append(self.arena, rhs.expr);
             self.exprs.items[binop_index] = .{ .binOp = .{
-                .name = @tagName(tags[inst_index]),
+                .name = @tagName(tags[@intFromEnum(inst)]),
                 .lhs = lhs_index,
                 .rhs = rhs_index,
             } };
@@ -1611,7 +1611,7 @@ fn walkInstruction(
         .cmp_lt,
         .cmp_lte,
         => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
 
             const binop_index = self.exprs.items.len;
@@ -1639,7 +1639,7 @@ fn walkInstruction(
             const rhs_index = self.exprs.items.len;
             try self.exprs.append(self.arena, rhs.expr);
             self.exprs.items[binop_index] = .{ .binOp = .{
-                .name = @tagName(tags[inst_index]),
+                .name = @tagName(tags[@intFromEnum(inst)]),
                 .lhs = lhs_index,
                 .rhs = rhs_index,
             } };
@@ -1684,7 +1684,7 @@ fn walkInstruction(
         .byte_swap,
         .bit_reverse,
         => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
             const bin_index = self.exprs.items.len;
             try self.exprs.append(self.arena, .{ .builtin = .{ .param = 0 } });
             const param = try self.walkRef(
@@ -1701,7 +1701,7 @@ fn walkInstruction(
 
             self.exprs.items[bin_index] = .{
                 .builtin = .{
-                    .name = @tagName(tags[inst_index]),
+                    .name = @tagName(tags[@intFromEnum(inst)]),
                     .param = param_index,
                 },
             };
@@ -1715,7 +1715,7 @@ fn walkInstruction(
         .bool_not,
         .negate_wrap,
         => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
             const un_index = self.exprs.items.len;
             try self.exprs.append(self.arena, .{ .unOp = .{ .param = 0 } });
             const param = try self.walkRef(
@@ -1732,7 +1732,7 @@ fn walkInstruction(
 
             self.exprs.items[un_index] = .{
                 .unOp = .{
-                    .name = @tagName(tags[inst_index]),
+                    .name = @tagName(tags[@intFromEnum(inst)]),
                     .param = param_index,
                 },
             };
@@ -1743,7 +1743,7 @@ fn walkInstruction(
             };
         },
         .bool_br_and, .bool_br_or => {
-            const bool_br = data[inst_index].bool_br;
+            const bool_br = data[@intFromEnum(inst)].bool_br;
 
             const bin_index = self.exprs.items.len;
             try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
@@ -1764,14 +1764,14 @@ fn walkInstruction(
                 file,
                 parent_scope,
                 parent_src,
-                file.zir.extra[extra.end..][extra.data.body_len - 1],
+                @enumFromInt(file.zir.extra[extra.end..][extra.data.body_len - 1]),
                 false,
                 call_ctx,
             );
             const rhs_index = self.exprs.items.len;
             try self.exprs.append(self.arena, rhs.expr);
 
-            self.exprs.items[bin_index] = .{ .binOp = .{ .name = @tagName(tags[inst_index]), .lhs = lhs_index, .rhs = rhs_index } };
+            self.exprs.items[bin_index] = .{ .binOp = .{ .name = @tagName(tags[@intFromEnum(inst)]), .lhs = lhs_index, .rhs = rhs_index } };
 
             return DocData.WalkResult{
                 .typeRef = .{ .type = @intFromEnum(Ref.bool_type) },
@@ -1780,7 +1780,7 @@ fn walkInstruction(
         },
         .truncate => {
             // in the ZIR this node is a builtin `bin` but we want send it as a `un` builtin
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
 
             var rhs: DocData.WalkResult = try self.walkRef(
@@ -1807,7 +1807,7 @@ fn walkInstruction(
                 call_ctx,
             );
 
-            self.exprs.items[bin_index] = .{ .builtin = .{ .name = @tagName(tags[inst_index]), .param = rhs_index } };
+            self.exprs.items[bin_index] = .{ .builtin = .{ .name = @tagName(tags[@intFromEnum(inst)]), .param = rhs_index } };
 
             return DocData.WalkResult{
                 .typeRef = lhs.expr,
@@ -1841,7 +1841,7 @@ fn walkInstruction(
         .min,
         .max,
         => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
 
             const binop_index = self.exprs.items.len;
@@ -1868,7 +1868,7 @@ fn walkInstruction(
             try self.exprs.append(self.arena, lhs.expr);
             const rhs_index = self.exprs.items.len;
             try self.exprs.append(self.arena, rhs.expr);
-            self.exprs.items[binop_index] = .{ .builtinBin = .{ .name = @tagName(tags[inst_index]), .lhs = lhs_index, .rhs = rhs_index } };
+            self.exprs.items[binop_index] = .{ .builtinBin = .{ .name = @tagName(tags[@intFromEnum(inst)]), .lhs = lhs_index, .rhs = rhs_index } };
 
             return DocData.WalkResult{
                 .typeRef = .{ .type = @intFromEnum(Ref.type_type) },
@@ -1876,7 +1876,7 @@ fn walkInstruction(
             };
         },
         .mul_add => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.MulAdd, pl_node.payload_index);
 
             var mul1: DocData.WalkResult = try self.walkRef(
@@ -1927,7 +1927,7 @@ fn walkInstruction(
             };
         },
         .union_init => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.UnionInit, pl_node.payload_index);
 
             var union_type: DocData.WalkResult = try self.walkRef(
@@ -1974,7 +1974,7 @@ fn walkInstruction(
             };
         },
         .builtin_call => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.BuiltinCall, pl_node.payload_index);
 
             var modifier: DocData.WalkResult = try self.walkRef(
@@ -2022,7 +2022,7 @@ fn walkInstruction(
             };
         },
         .error_union_type => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
 
             var lhs: DocData.WalkResult = try self.walkRef(
@@ -2054,7 +2054,7 @@ fn walkInstruction(
             };
         },
         .merge_error_sets => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
 
             var lhs: DocData.WalkResult = try self.walkRef(
@@ -2085,7 +2085,7 @@ fn walkInstruction(
             };
         },
         // .elem_type => {
-        //     const un_node = data[inst_index].un_node;
+        //     const un_node = data[@intFromEnum(inst)].un_node;
 
         //     var operand: DocData.WalkResult = try self.walkRef(
         //         file,
@@ -2097,7 +2097,7 @@ fn walkInstruction(
         //     return operand;
         // },
         .ptr_type => {
-            const ptr = data[inst_index].ptr_type;
+            const ptr = data[@intFromEnum(inst)].ptr_type;
             const extra = file.zir.extraData(Zir.Inst.PtrType, ptr.payload_index);
             var extra_index = extra.end;
 
@@ -2208,7 +2208,7 @@ fn walkInstruction(
             };
         },
         .array_type => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
 
             const bin = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index).data;
             const len = try self.walkRef(
@@ -2242,7 +2242,7 @@ fn walkInstruction(
             };
         },
         .array_type_sentinel => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.ArrayTypeSentinel, pl_node.payload_index);
             const len = try self.walkRef(
                 file,
@@ -2283,7 +2283,7 @@ fn walkInstruction(
             };
         },
         .array_init => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.MultiOp, pl_node.payload_index);
             const operands = file.zir.refSlice(extra.end, extra.data.operands_len);
             const array_data = try self.arena.alloc(usize, operands.len - 1);
@@ -2318,7 +2318,7 @@ fn walkInstruction(
             };
         },
         .array_init_anon => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.MultiOp, pl_node.payload_index);
             const operands = file.zir.refSlice(extra.end, extra.data.operands_len);
             const array_data = try self.arena.alloc(usize, operands.len);
@@ -2343,7 +2343,7 @@ fn walkInstruction(
             };
         },
         .array_init_ref => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.MultiOp, pl_node.payload_index);
             const operands = file.zir.refSlice(extra.end, extra.data.operands_len);
             const array_data = try self.arena.alloc(usize, operands.len - 1);
@@ -2389,7 +2389,7 @@ fn walkInstruction(
             };
         },
         .float => {
-            const float = data[inst_index].float;
+            const float = data[@intFromEnum(inst)].float;
             return DocData.WalkResult{
                 .typeRef = .{ .type = @intFromEnum(Ref.comptime_float_type) },
                 .expr = .{ .float = float },
@@ -2397,7 +2397,7 @@ fn walkInstruction(
         },
         // @check: In frontend I'm handling float128 with `.toFixed(2)`
         .float128 => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Float128, pl_node.payload_index);
             return DocData.WalkResult{
                 .typeRef = .{ .type = @intFromEnum(Ref.comptime_float_type) },
@@ -2405,7 +2405,7 @@ fn walkInstruction(
             };
         },
         .negate => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
 
             var operand: DocData.WalkResult = try self.walkRef(
                 file,
@@ -2425,7 +2425,7 @@ fn walkInstruction(
                     try self.exprs.append(self.arena, operand.expr);
                     self.exprs.items[un_index] = .{
                         .unOp = .{
-                            .name = @tagName(tags[inst_index]),
+                            .name = @tagName(tags[@intFromEnum(inst)]),
                             .param = param_index,
                         },
                     };
@@ -2438,7 +2438,7 @@ fn walkInstruction(
             return operand;
         },
         .size_of => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
 
             const operand = try self.walkRef(
                 file,
@@ -2457,7 +2457,7 @@ fn walkInstruction(
         },
         .bit_size_of => {
             // not working correctly with `align()`
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
 
             const operand = try self.walkRef(
                 file,
@@ -2477,7 +2477,7 @@ fn walkInstruction(
         },
         .int_from_enum => {
             // not working correctly with `align()`
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
             const operand = try self.walkRef(
                 file,
                 parent_scope,
@@ -2492,7 +2492,7 @@ fn walkInstruction(
             try self.exprs.append(self.arena, operand.expr);
             self.exprs.items[builtin_index] = .{
                 .builtin = .{
-                    .name = @tagName(tags[inst_index]),
+                    .name = @tagName(tags[@intFromEnum(inst)]),
                     .param = operand_index,
                 },
             };
@@ -2504,7 +2504,7 @@ fn walkInstruction(
         },
         .switch_block => {
             // WIP
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.SwitchBlock, pl_node.payload_index);
 
             const switch_cond = try self.walkRef(
@@ -2553,7 +2553,7 @@ fn walkInstruction(
         },
 
         .typeof => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
 
             const operand = try self.walkRef(
                 file,
@@ -2572,7 +2572,7 @@ fn walkInstruction(
             };
         },
         .typeof_builtin => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Block, pl_node.payload_index);
             const body = file.zir.extra[extra.end..][extra.data.body_len - 1];
             var operand: DocData.WalkResult = try self.walkRef(
@@ -2593,11 +2593,11 @@ fn walkInstruction(
             };
         },
         .as_node, .as_shift_operand => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.As, pl_node.payload_index);
 
             // Skip the as_node if the destination type is a call instruction
-            if (Zir.refToIndex(extra.data.dest_type)) |dti| {
+            if (extra.data.dest_type.toIndex()) |dti| {
                 var maybe_cc = call_ctx;
                 while (maybe_cc) |cc| : (maybe_cc = cc.prev) {
                     if (cc.inst == dti) {
@@ -2650,7 +2650,7 @@ fn walkInstruction(
             };
         },
         .optional_type => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
 
             const operand: DocData.WalkResult = try self.walkRef(
                 file,
@@ -2672,14 +2672,14 @@ fn walkInstruction(
             };
         },
         .decl_val, .decl_ref => {
-            const str_tok = data[inst_index].str_tok;
-            const decl_status = parent_scope.resolveDeclName(str_tok.start, file, inst_index);
+            const str_tok = data[@intFromEnum(inst)].str_tok;
+            const decl_status = parent_scope.resolveDeclName(str_tok.start, file, inst.toOptional());
             return DocData.WalkResult{
                 .expr = .{ .declRef = decl_status },
             };
         },
         .field_val, .field_ptr => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Field, pl_node.payload_index);
 
             var path: std.ArrayListUnmanaged(DocData.Expr) = .{};
@@ -2692,12 +2692,15 @@ fn walkInstruction(
             const lhs_ref = blk: {
                 var lhs_extra = extra;
                 while (true) {
-                    const lhs = Zir.refToIndex(lhs_extra.data.lhs) orelse {
+                    const lhs = @intFromEnum(lhs_extra.data.lhs.toIndex() orelse {
                         break :blk lhs_extra.data.lhs;
-                    };
+                    });
 
                     if (tags[lhs] != .field_val and
-                        tags[lhs] != .field_ptr) break :blk lhs_extra.data.lhs;
+                        tags[lhs] != .field_ptr)
+                    {
+                        break :blk lhs_extra.data.lhs;
+                    }
 
                     lhs_extra = file.zir.extraData(
                         Zir.Inst.Field,
@@ -2721,15 +2724,16 @@ fn walkInstruction(
             // TODO: double check that we really don't need type info here
 
             const wr = blk: {
-                if (Zir.refToIndex(lhs_ref)) |lhs_inst| {
-                    if (tags[lhs_inst] == .call or tags[lhs_inst] == .field_call) {
+                if (lhs_ref.toIndex()) |lhs_inst| switch (tags[@intFromEnum(lhs_inst)]) {
+                    .call, .field_call => {
                         break :blk DocData.WalkResult{
                             .expr = .{
                                 .comptimeExpr = 0,
                             },
                         };
-                    }
-                }
+                    },
+                    else => {},
+                };
 
                 break :blk try self.walkRef(
                     file,
@@ -2758,11 +2762,11 @@ fn walkInstruction(
             // - (2) Paths can sometimes never resolve fully. This means that
             //       any value that depends on that will have to become a
             //       comptimeExpr.
-            try self.tryResolveRefPath(file, inst_index, path.items);
+            try self.tryResolveRefPath(file, inst, path.items);
             return DocData.WalkResult{ .expr = .{ .refPath = path.items } };
         },
         .int_type => {
-            const int_type = data[inst_index].int_type;
+            const int_type = data[@intFromEnum(inst)].int_type;
             const sign = if (int_type.signedness == .unsigned) "u" else "i";
             const bits = int_type.bit_count;
             const name = try std.fmt.allocPrint(self.arena, "{s}{}", .{ sign, bits });
@@ -2781,7 +2785,7 @@ fn walkInstruction(
                 .typeRef = .{ .type = @intFromEnum(Ref.type_type) },
                 .expr = .{ .comptimeExpr = self.comptime_exprs.items.len },
             };
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const block_expr = try self.getBlockSource(file, parent_src, pl_node.src_node);
             try self.comptime_exprs.append(self.arena, .{
                 .code = block_expr,
@@ -2793,12 +2797,12 @@ fn walkInstruction(
                 file,
                 parent_scope,
                 parent_src,
-                getBlockInlineBreak(file.zir, inst_index) orelse {
+                getBlockInlineBreak(file.zir, inst) orelse {
                     const res = DocData.WalkResult{
                         .typeRef = .{ .type = @intFromEnum(Ref.type_type) },
                         .expr = .{ .comptimeExpr = self.comptime_exprs.items.len },
                     };
-                    const pl_node = data[inst_index].pl_node;
+                    const pl_node = data[@intFromEnum(inst)].pl_node;
                     const block_inline_expr = try self.getBlockSource(file, parent_src, pl_node.src_node);
                     try self.comptime_exprs.append(self.arena, .{
                         .code = block_inline_expr,
@@ -2810,7 +2814,7 @@ fn walkInstruction(
             );
         },
         .break_inline => {
-            const @"break" = data[inst_index].@"break";
+            const @"break" = data[@intFromEnum(inst)].@"break";
             return try self.walkRef(
                 file,
                 parent_scope,
@@ -2821,7 +2825,7 @@ fn walkInstruction(
             );
         },
         .struct_init => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.StructInit, pl_node.payload_index);
             const field_vals = try self.arena.alloc(
                 DocData.Expr.FieldVal,
@@ -2835,7 +2839,7 @@ fn walkInstruction(
                 defer idx = init_extra.end;
 
                 const field_name = blk: {
-                    const field_inst_index = init_extra.data.field_type;
+                    const field_inst_index = @intFromEnum(init_extra.data.field_type);
                     if (tags[field_inst_index] != .struct_init_field_type) unreachable;
                     const field_pl_node = data[field_inst_index].pl_node;
                     const field_extra = file.zir.extraData(
@@ -2881,7 +2885,7 @@ fn walkInstruction(
         .struct_init_empty,
         .struct_init_empty_result,
         => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
 
             var operand: DocData.WalkResult = try self.walkRef(
                 file,
@@ -2898,7 +2902,7 @@ fn walkInstruction(
             };
         },
         .struct_init_empty_ref_result => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
 
             var operand: DocData.WalkResult = try self.walkRef(
                 file,
@@ -2918,7 +2922,7 @@ fn walkInstruction(
             };
         },
         .struct_init_anon => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.StructInitAnon, pl_node.payload_index);
 
             const field_vals = try self.arena.alloc(
@@ -2947,7 +2951,7 @@ fn walkInstruction(
             };
         },
         .error_set_decl => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.ErrorSetDecl, pl_node.payload_index);
             const fields = try self.arena.alloc(
                 DocData.Type.Field,
@@ -2986,7 +2990,7 @@ fn walkInstruction(
             // This switch case handles the case where an expression depends
             // on an anytype field. E.g.: `fn foo(bar: anytype) @TypeOf(bar)`.
             // This means that we're looking at a generic expression.
-            const str_tok = data[inst_index].str_tok;
+            const str_tok = data[@intFromEnum(inst)].str_tok;
             const name = str_tok.get(file.zir);
             const cte_slot_index = self.comptime_exprs.items.len;
             try self.comptime_exprs.append(self.arena, .{
@@ -2996,7 +3000,7 @@ fn walkInstruction(
         },
         .param, .param_comptime => {
             // See .param_anytype for more information.
-            const pl_tok = data[inst_index].pl_tok;
+            const pl_tok = data[@intFromEnum(inst)].pl_tok;
             const extra = file.zir.extraData(Zir.Inst.Param, pl_tok.payload_index);
             const name = file.zir.nullTerminatedString(extra.data.name);
 
@@ -3007,7 +3011,7 @@ fn walkInstruction(
             return DocData.WalkResult{ .expr = .{ .comptimeExpr = cte_slot_index } };
         },
         .call => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Call, pl_node.payload_index);
 
             const callee = try self.walkRef(
@@ -3023,8 +3027,8 @@ fn walkInstruction(
             var args = try self.arena.alloc(DocData.Expr, args_len);
             const body = file.zir.extra[extra.end..];
 
-            try self.repurposed_insts.put(self.arena, @intCast(inst_index), {});
-            defer _ = self.repurposed_insts.remove(@intCast(inst_index));
+            try self.repurposed_insts.put(self.arena, inst, {});
+            defer _ = self.repurposed_insts.remove(inst);
 
             var i: usize = 0;
             while (i < args_len) : (i += 1) {
@@ -3042,7 +3046,7 @@ fn walkInstruction(
                     ref,
                     false,
                     &.{
-                        .inst = inst_index,
+                        .inst = inst,
                         .prev = call_ctx,
                     },
                 );
@@ -3068,7 +3072,7 @@ fn walkInstruction(
                         else => blk: {
                             printWithContext(
                                 file,
-                                inst_index,
+                                inst,
                                 "unexpected callee type in walkInstruction.call: `{s}`\n",
                                 .{@tagName(self.types.items[func_type_idx])},
                             );
@@ -3089,10 +3093,10 @@ fn walkInstruction(
                 file,
                 parent_scope,
                 parent_src,
-                inst_index,
+                inst,
                 self_ast_node_index,
                 type_slot_index,
-                tags[inst_index] == .func_inferred,
+                tags[@intFromEnum(inst)] == .func_inferred,
                 call_ctx,
             );
 
@@ -3106,7 +3110,7 @@ fn walkInstruction(
                 file,
                 parent_scope,
                 parent_src,
-                inst_index,
+                inst,
                 self_ast_node_index,
                 type_slot_index,
                 call_ctx,
@@ -3115,7 +3119,7 @@ fn walkInstruction(
             return result;
         },
         .optional_payload_safe, .optional_payload_unsafe => {
-            const un_node = data[inst_index].un_node;
+            const un_node = data[@intFromEnum(inst)].un_node;
             const operand = try self.walkRef(
                 file,
                 parent_scope,
@@ -3135,7 +3139,7 @@ fn walkInstruction(
                         switch (t) {
                             .Optional => |opt| typeRef = opt.child,
                             else => {
-                                printWithContext(file, inst_index, "Invalid type for optional_payload_*: {}\n", .{t});
+                                printWithContext(file, inst, "Invalid type for optional_payload_*: {}\n", .{t});
                             },
                         }
                     },
@@ -3149,7 +3153,7 @@ fn walkInstruction(
             };
         },
         .elem_val_node => {
-            const pl_node = data[inst_index].pl_node;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
             const extra = file.zir.extraData(Zir.Inst.Bin, pl_node.payload_index);
             const lhs = try self.walkRef(
                 file,
@@ -3181,12 +3185,12 @@ fn walkInstruction(
             };
         },
         .extended => {
-            const extended = data[inst_index].extended;
+            const extended = data[@intFromEnum(inst)].extended;
             switch (extended.opcode) {
                 else => {
                     printWithContext(
                         file,
-                        inst_index,
+                        inst,
                         "TODO: implement `walkInstruction.extended` for {s}",
                         .{@tagName(extended.opcode)},
                     );
@@ -3265,7 +3269,7 @@ fn walkInstruction(
                     extra_index = try self.analyzeAllDecls(
                         file,
                         &scope,
-                        inst_index,
+                        inst,
                         src_info,
                         &decl_indexes,
                         &priv_decl_indexes,
@@ -3285,7 +3289,7 @@ fn walkInstruction(
                         for (paths.items) |resume_info| {
                             try self.tryResolveRefPath(
                                 resume_info.file,
-                                inst_index,
+                                inst,
                                 resume_info.ref_path,
                             );
                         }
@@ -3393,7 +3397,7 @@ fn walkInstruction(
                     extra_index = try self.analyzeAllDecls(
                         file,
                         &scope,
-                        inst_index,
+                        inst,
                         src_info,
                         &decl_indexes,
                         &priv_decl_indexes,
@@ -3452,7 +3456,7 @@ fn walkInstruction(
                         for (paths.items) |resume_info| {
                             try self.tryResolveRefPath(
                                 resume_info.file,
-                                inst_index,
+                                inst,
                                 resume_info.ref_path,
                             );
                         }
@@ -3524,7 +3528,7 @@ fn walkInstruction(
                     extra_index = try self.analyzeAllDecls(
                         file,
                         &scope,
-                        inst_index,
+                        inst,
                         src_info,
                         &decl_indexes,
                         &priv_decl_indexes,
@@ -3604,7 +3608,7 @@ fn walkInstruction(
                         for (paths.items) |resume_info| {
                             try self.tryResolveRefPath(
                                 resume_info.file,
-                                inst_index,
+                                inst,
                                 resume_info.ref_path,
                             );
                         }
@@ -3668,9 +3672,9 @@ fn walkInstruction(
                             backing_int = backing_int_res.expr;
                             extra_index += 1; // backing_int_ref
                         } else {
-                            const backing_int_body = file.zir.extra[extra_index..][0..backing_int_body_len];
+                            const backing_int_body = file.zir.bodySlice(extra_index, backing_int_body_len);
                             const break_inst = backing_int_body[backing_int_body.len - 1];
-                            const operand = data[break_inst].@"break".operand;
+                            const operand = data[@intFromEnum(break_inst)].@"break".operand;
                             const backing_int_res = try self.walkRef(
                                 file,
                                 &scope,
@@ -3695,7 +3699,7 @@ fn walkInstruction(
                     extra_index = try self.analyzeAllDecls(
                         file,
                         &scope,
-                        inst_index,
+                        inst,
                         src_info,
                         &decl_indexes,
                         &priv_decl_indexes,
@@ -3739,7 +3743,7 @@ fn walkInstruction(
                         for (paths.items) |resume_info| {
                             try self.tryResolveRefPath(
                                 resume_info.file,
-                                inst_index,
+                                inst,
                                 resume_info.ref_path,
                             );
                         }
@@ -3883,7 +3887,7 @@ fn walkInstruction(
 
                     const cmpxchg_index = self.exprs.items.len;
                     try self.exprs.append(self.arena, .{ .cmpxchg = .{
-                        .name = @tagName(tags[inst_index]),
+                        .name = @tagName(tags[@intFromEnum(inst)]),
                         .type = type_index,
                         .ptr = ptr_index,
                         .expected_value = expected_value_index,
@@ -3912,14 +3916,14 @@ fn analyzeAllDecls(
     self: *Autodoc,
     file: *File,
     scope: *Scope,
-    parent_inst_index: usize,
+    parent_inst: Zir.Inst.Index,
     parent_src: SrcLocInfo,
     decl_indexes: *std.ArrayListUnmanaged(usize),
     priv_decl_indexes: *std.ArrayListUnmanaged(usize),
     call_ctx: ?*const CallContext,
 ) AutodocErrors!usize {
     const first_decl_indexes_slot = decl_indexes.items.len;
-    const original_it = file.zir.declIterator(@as(u32, @intCast(parent_inst_index)));
+    const original_it = file.zir.declIterator(parent_inst);
 
     // First loop to discover decl names
     {
@@ -4038,7 +4042,7 @@ fn analyzeDecl(
     const decl_name_index = file.zir.extra[extra_index];
 
     extra_index += 1;
-    const value_index = file.zir.extra[extra_index];
+    const value_index: Zir.Inst.Index = @enumFromInt(file.zir.extra[extra_index]);
 
     extra_index += 1;
     const doc_comment_index = file.zir.extra[extra_index];
@@ -4066,7 +4070,7 @@ fn analyzeDecl(
     _ = addrspace_inst;
 
     // This is known to work because decl values are always block_inlines
-    const value_pl_node = data[value_index].pl_node;
+    const value_pl_node = data[@intFromEnum(value_index)].pl_node;
     const decl_src = try self.srcLocInfo(file, value_pl_node.src_node, parent_src);
 
     const name: []const u8 = switch (decl_name_index) {
@@ -4124,7 +4128,7 @@ fn analyzeDecl(
         try priv_decl_indexes.append(self.arena, decls_slot_index);
     }
 
-    const decl_status_ptr = scope.resolveDeclName(decl_name_index, file, 0);
+    const decl_status_ptr = scope.resolveDeclName(decl_name_index, file, .none);
     std.debug.assert(decl_status_ptr.* == .Pending);
     decl_status_ptr.* = .{ .Analyzed = decls_slot_index };
 
@@ -4158,11 +4162,11 @@ fn analyzeUsingnamespaceDecl(
     const data = file.zir.instructions.items(.data);
 
     const is_pub = @as(u1, @truncate(d.flags)) != 0;
-    const value_index = file.zir.extra[@intFromEnum(d.sub_index) + 6];
+    const value_index: Zir.Inst.Index = @enumFromInt(file.zir.extra[@intFromEnum(d.sub_index) + 6]);
     const doc_comment_index = file.zir.extra[@intFromEnum(d.sub_index) + 7];
 
     // This is known to work because decl values are always block_inlines
-    const value_pl_node = data[value_index].pl_node;
+    const value_pl_node = data[@intFromEnum(value_index)].pl_node;
     const decl_src = try self.srcLocInfo(file, value_pl_node.src_node, parent_src);
 
     const doc_comment: ?[]const u8 = if (doc_comment_index != 0)
@@ -4244,7 +4248,7 @@ fn analyzeDecltest(
         break :idx idx;
     };
 
-    const decl_status = scope.resolveDeclName(decl_name_index, file, 0);
+    const decl_status = scope.resolveDeclName(decl_name_index, file, .none);
 
     switch (decl_status.*) {
         .Analyzed => |idx| {
@@ -4277,7 +4281,7 @@ fn tryResolveRefPath(
     self: *Autodoc,
     /// File from which the decl path originates.
     file: *File,
-    inst_index: usize, // used only for panicWithContext
+    inst: Zir.Inst.Index, // used only for panicWithContext
     path: []DocData.Expr,
 ) AutodocErrors!void {
     var i: usize = 0;
@@ -4374,7 +4378,7 @@ fn tryResolveRefPath(
         } else {
             panicWithContext(
                 file,
-                inst_index,
+                inst,
                 "exhausted eval quota for `{}`in tryResolveRefPath\n",
                 .{resolved_parent},
             );
@@ -4386,7 +4390,7 @@ fn tryResolveRefPath(
                 //       in the switch above this one!
                 printWithContext(
                     file,
-                    inst_index,
+                    inst,
                     "TODO: handle `{s}`in tryResolveRefPath\nInfo: {}",
                     .{ @tagName(resolved_parent), resolved_parent },
                 );
@@ -4403,7 +4407,7 @@ fn tryResolveRefPath(
                 else => {
                     panicWithContext(
                         file,
-                        inst_index,
+                        inst,
                         "TODO: handle `{s}` in tryResolveDeclPath.type\nInfo: {}",
                         .{ @tagName(self.types.items[t_index]), resolved_parent },
                     );
@@ -4442,7 +4446,7 @@ fn tryResolveRefPath(
                     } else {
                         panicWithContext(
                             file,
-                            inst_index,
+                            inst,
                             "TODO: handle `{s}` in tryResolveDeclPath.type.Array\nInfo: {}",
                             .{ child_string, resolved_parent },
                         );
@@ -4500,7 +4504,7 @@ fn tryResolveRefPath(
                     // if we got here, our search failed
                     printWithContext(
                         file,
-                        inst_index,
+                        inst,
                         "failed to match `{s}` in enum",
                         .{child_string},
                     );
@@ -4557,7 +4561,7 @@ fn tryResolveRefPath(
                     // if we got here, our search failed
                     printWithContext(
                         file,
-                        inst_index,
+                        inst,
                         "failed to match `{s}` in union",
                         .{child_string},
                     );
@@ -4614,7 +4618,7 @@ fn tryResolveRefPath(
                     // if we got here, our search failed
                     // printWithContext(
                     //     file,
-                    //     inst_index,
+                    //     inst,
                     //     "failed to match `{s}` in struct",
                     //     .{child_string},
                     // );
@@ -4659,7 +4663,7 @@ fn tryResolveRefPath(
                     // if we got here, our search failed
                     printWithContext(
                         file,
-                        inst_index,
+                        inst,
                         "failed to match `{s}` in opaque",
                         .{child_string},
                     );
@@ -4679,7 +4683,7 @@ fn tryResolveRefPath(
                 // if we got here, our search failed
                 printWithContext(
                     file,
-                    inst_index,
+                    inst,
                     "failed to match `{s}` in struct",
                     .{child_string},
                 );
@@ -4696,7 +4700,7 @@ fn tryResolveRefPath(
         _ = self.pending_ref_paths.remove(&path[path.len - 1]);
 
         for (waiter_list.items) |resume_info| {
-            try self.tryResolveRefPath(resume_info.file, inst_index, resume_info.ref_path);
+            try self.tryResolveRefPath(resume_info.file, inst, resume_info.ref_path);
         }
         // TODO: this is where we should free waiter_list, but its in the arena
         //       that said, we might want to store it elsewhere and reclaim memory asap
@@ -4805,14 +4809,14 @@ fn analyzeFancyFunction(
     file: *File,
     scope: *Scope,
     parent_src: SrcLocInfo,
-    inst_index: usize,
+    inst: Zir.Inst.Index,
     self_ast_node_index: usize,
     type_slot_index: usize,
     call_ctx: ?*const CallContext,
 ) AutodocErrors!DocData.WalkResult {
     const tags = file.zir.instructions.items(.tag);
     const data = file.zir.instructions.items(.data);
-    const fn_info = file.zir.getFnInfo(@as(u32, @intCast(inst_index)));
+    const fn_info = file.zir.getFnInfo(inst);
 
     try self.ast_nodes.ensureUnusedCapacity(self.arena, fn_info.total_params_len);
     var param_type_refs = try std.ArrayListUnmanaged(DocData.Expr).initCapacity(
@@ -4826,18 +4830,18 @@ fn analyzeFancyFunction(
 
     // TODO: handle scope rules for fn parameters
     for (fn_info.param_body[0..fn_info.total_params_len]) |param_index| {
-        switch (tags[param_index]) {
+        switch (tags[@intFromEnum(param_index)]) {
             else => {
                 panicWithContext(
                     file,
                     param_index,
                     "TODO: handle `{s}` in walkInstruction.func\n",
-                    .{@tagName(tags[param_index])},
+                    .{@tagName(tags[@intFromEnum(param_index)])},
                 );
             },
             .param_anytype, .param_anytype_comptime => {
                 // TODO: where are the doc comments?
-                const str_tok = data[param_index].str_tok;
+                const str_tok = data[@intFromEnum(param_index)].str_tok;
 
                 const name = str_tok.get(file.zir);
 
@@ -4845,7 +4849,7 @@ fn analyzeFancyFunction(
                 self.ast_nodes.appendAssumeCapacity(.{
                     .name = name,
                     .docs = "",
-                    .@"comptime" = tags[param_index] == .param_anytype_comptime,
+                    .@"comptime" = tags[@intFromEnum(param_index)] == .param_anytype_comptime,
                 });
 
                 param_type_refs.appendAssumeCapacity(
@@ -4853,7 +4857,7 @@ fn analyzeFancyFunction(
                 );
             },
             .param, .param_comptime => {
-                const pl_tok = data[param_index].pl_tok;
+                const pl_tok = data[@intFromEnum(param_index)].pl_tok;
                 const extra = file.zir.extraData(Zir.Inst.Param, pl_tok.payload_index);
                 const doc_comment = if (extra.data.doc_comment != 0)
                     file.zir.nullTerminatedString(extra.data.doc_comment)
@@ -4865,7 +4869,7 @@ fn analyzeFancyFunction(
                 try self.ast_nodes.append(self.arena, .{
                     .name = name,
                     .docs = doc_comment,
-                    .@"comptime" = tags[param_index] == .param_comptime,
+                    .@"comptime" = tags[@intFromEnum(param_index)] == .param_comptime,
                 });
 
                 const break_index = file.zir.extra[extra.end..][extra.data.body_len - 1];
@@ -4886,7 +4890,7 @@ fn analyzeFancyFunction(
 
     self.ast_nodes.items[self_ast_node_index].fields = param_ast_indexes.items;
 
-    const pl_node = data[inst_index].pl_node;
+    const pl_node = data[@intFromEnum(inst)].pl_node;
     const extra = file.zir.extraData(Zir.Inst.FuncFancy, pl_node.payload_index);
 
     var extra_index: usize = extra.end;
@@ -4971,7 +4975,7 @@ fn analyzeFancyFunction(
 
     var cc_index: ?usize = null;
     if (extra.data.bits.has_cc_ref and !extra.data.bits.has_cc_body) {
-        const cc_ref = @as(Zir.Inst.Ref, @enumFromInt(file.zir.extra[extra_index]));
+        const cc_ref: Zir.Inst.Ref = @enumFromInt(file.zir.extra[extra_index]);
         const cc_expr = try self.walkRef(
             file,
             scope,
@@ -4988,11 +4992,11 @@ fn analyzeFancyFunction(
     } else if (extra.data.bits.has_cc_body) {
         const cc_body_len = file.zir.extra[extra_index];
         extra_index += 1;
-        const cc_body = file.zir.extra[extra_index..][0..cc_body_len];
+        const cc_body = file.zir.bodySlice(extra_index, cc_body_len);
 
         // We assume the body ends with a break_inline
         const break_index = cc_body[cc_body.len - 1];
-        const break_operand = data[break_index].@"break".operand;
+        const break_operand = data[@intFromEnum(break_index)].@"break".operand;
         const cc_expr = try self.walkRef(
             file,
             scope,
@@ -5029,7 +5033,7 @@ fn analyzeFancyFunction(
         },
         else => blk: {
             const last_instr_index = fn_info.ret_ty_body[fn_info.ret_ty_body.len - 1];
-            const break_operand = data[last_instr_index].@"break".operand;
+            const break_operand = data[@intFromEnum(last_instr_index)].@"break".operand;
             const wr = try self.walkRef(
                 file,
                 scope,
@@ -5096,7 +5100,7 @@ fn analyzeFunction(
     file: *File,
     scope: *Scope,
     parent_src: SrcLocInfo,
-    inst_index: usize,
+    inst: Zir.Inst.Index,
     self_ast_node_index: usize,
     type_slot_index: usize,
     ret_is_inferred_error_set: bool,
@@ -5104,7 +5108,7 @@ fn analyzeFunction(
 ) AutodocErrors!DocData.WalkResult {
     const tags = file.zir.instructions.items(.tag);
     const data = file.zir.instructions.items(.data);
-    const fn_info = file.zir.getFnInfo(@as(u32, @intCast(inst_index)));
+    const fn_info = file.zir.getFnInfo(inst);
 
     try self.ast_nodes.ensureUnusedCapacity(self.arena, fn_info.total_params_len);
     var param_type_refs = try std.ArrayListUnmanaged(DocData.Expr).initCapacity(
@@ -5118,18 +5122,18 @@ fn analyzeFunction(
 
     // TODO: handle scope rules for fn parameters
     for (fn_info.param_body[0..fn_info.total_params_len]) |param_index| {
-        switch (tags[param_index]) {
+        switch (tags[@intFromEnum(param_index)]) {
             else => {
                 panicWithContext(
                     file,
                     param_index,
                     "TODO: handle `{s}` in walkInstruction.func\n",
-                    .{@tagName(tags[param_index])},
+                    .{@tagName(tags[@intFromEnum(param_index)])},
                 );
             },
             .param_anytype, .param_anytype_comptime => {
                 // TODO: where are the doc comments?
-                const str_tok = data[param_index].str_tok;
+                const str_tok = data[@intFromEnum(param_index)].str_tok;
 
                 const name = str_tok.get(file.zir);
 
@@ -5137,7 +5141,7 @@ fn analyzeFunction(
                 self.ast_nodes.appendAssumeCapacity(.{
                     .name = name,
                     .docs = "",
-                    .@"comptime" = tags[param_index] == .param_anytype_comptime,
+                    .@"comptime" = tags[@intFromEnum(param_index)] == .param_anytype_comptime,
                 });
 
                 param_type_refs.appendAssumeCapacity(
@@ -5145,7 +5149,7 @@ fn analyzeFunction(
                 );
             },
             .param, .param_comptime => {
-                const pl_tok = data[param_index].pl_tok;
+                const pl_tok = data[@intFromEnum(param_index)].pl_tok;
                 const extra = file.zir.extraData(Zir.Inst.Param, pl_tok.payload_index);
                 const doc_comment = if (extra.data.doc_comment != 0)
                     file.zir.nullTerminatedString(extra.data.doc_comment)
@@ -5157,7 +5161,7 @@ fn analyzeFunction(
                 try self.ast_nodes.append(self.arena, .{
                     .name = name,
                     .docs = doc_comment,
-                    .@"comptime" = tags[param_index] == .param_comptime,
+                    .@"comptime" = tags[@intFromEnum(param_index)] == .param_comptime,
                 });
 
                 const break_index = file.zir.extra[extra.end..][extra.data.body_len - 1];
@@ -5195,7 +5199,7 @@ fn analyzeFunction(
         },
         else => blk: {
             const last_instr_index = fn_info.ret_ty_body[fn_info.ret_ty_body.len - 1];
-            const break_operand = data[last_instr_index].@"break".operand;
+            const break_operand = data[@intFromEnum(last_instr_index)].@"break".operand;
             const wr = try self.walkRef(
                 file,
                 scope,
@@ -5266,7 +5270,7 @@ fn getGenericReturnType(
     file: *File,
     scope: *Scope,
     parent_src: SrcLocInfo, // function decl line
-    body_main_block: usize,
+    body_main_block: Zir.Inst.Index,
     call_ctx: ?*const CallContext,
 ) !DocData.Expr {
     const tags = file.zir.instructions.items(.tag);
@@ -5274,25 +5278,27 @@ fn getGenericReturnType(
 
     // We expect `body_main_block` to be the first instruction
     // inside the function body, and for it to be a block instruction.
-    const pl_node = data[body_main_block].pl_node;
+    const pl_node = data[@intFromEnum(body_main_block)].pl_node;
     const extra = file.zir.extraData(Zir.Inst.Block, pl_node.payload_index);
-    const maybe_ret_node = file.zir.extra[extra.end..][extra.data.body_len - 4];
-    switch (tags[maybe_ret_node]) {
-        .ret_node, .ret_load => {
-            const wr = try self.walkInstruction(
-                file,
-                scope,
-                parent_src,
-                maybe_ret_node,
-                false,
-                call_ctx,
-            );
-            return wr.expr;
-        },
-        else => {
-            return DocData.Expr{ .comptimeExpr = 0 };
-        },
+    const body = file.zir.bodySlice(extra.end, extra.data.body_len);
+    if (body.len >= 4) {
+        const maybe_ret_inst = body[body.len - 4];
+        switch (tags[@intFromEnum(maybe_ret_inst)]) {
+            .ret_node, .ret_load => {
+                const wr = try self.walkInstruction(
+                    file,
+                    scope,
+                    parent_src,
+                    maybe_ret_inst,
+                    false,
+                    call_ctx,
+                );
+                return wr.expr;
+            },
+            else => {},
+        }
     }
+    return DocData.Expr{ .comptimeExpr = 0 };
 }
 
 fn collectUnionFieldInfo(
@@ -5470,11 +5476,11 @@ fn collectStructFieldInfo(
             }
 
             std.debug.assert(field.type_body_len != 0);
-            const body = file.zir.extra[extra_index..][0..field.type_body_len];
+            const body = file.zir.bodySlice(extra_index, field.type_body_len);
             extra_index += body.len;
 
             const break_inst = body[body.len - 1];
-            const operand = data[break_inst].@"break".operand;
+            const operand = data[@intFromEnum(break_inst)].@"break".operand;
             try self.ast_nodes.append(self.arena, .{
                 .file = self.files.getIndex(file).?,
                 .line = parent_src.line,
@@ -5499,11 +5505,11 @@ fn collectStructFieldInfo(
                 break :def null;
             }
 
-            const body = file.zir.extra[extra_index..][0..field.init_body_len];
+            const body = file.zir.bodySlice(extra_index, field.init_body_len);
             extra_index += body.len;
 
             const break_inst = body[body.len - 1];
-            const operand = data[break_inst].@"break".operand;
+            const operand = data[@intFromEnum(break_inst)].@"break".operand;
             const walk_result = try self.walkRef(
                 file,
                 scope,
@@ -5559,7 +5565,7 @@ fn walkRef(
             .typeRef = .{ .type = @intFromEnum(std.builtin.TypeId.Type) },
             .expr = .{ .type = @intFromEnum(ref) },
         };
-    } else if (Zir.refToIndex(ref)) |zir_index| {
+    } else if (ref.toIndex()) |zir_index| {
         return self.walkInstruction(
             file,
             parent_scope,
@@ -5571,9 +5577,9 @@ fn walkRef(
     } else {
         switch (ref) {
             else => {
-                panicWithContext(
+                panicWithOptionalContext(
                     file,
-                    0,
+                    .none,
                     "TODO: handle {s} in walkRef",
                     .{@tagName(ref)},
                 );
@@ -5664,10 +5670,10 @@ fn walkRef(
     }
 }
 
-fn getBlockInlineBreak(zir: Zir, inst_index: usize) ?Zir.Inst.Ref {
+fn getBlockInlineBreak(zir: Zir, inst: Zir.Inst.Index) ?Zir.Inst.Ref {
     const tags = zir.instructions.items(.tag);
     const data = zir.instructions.items(.data);
-    const pl_node = data[inst_index].pl_node;
+    const pl_node = data[@intFromEnum(inst)].pl_node;
     const extra = zir.extraData(Zir.Inst.Block, pl_node.payload_index);
     const break_index = zir.extra[extra.end..][extra.data.body_len - 1];
     if (tags[break_index] == .condbr_inline) return null;
@@ -5675,12 +5681,36 @@ fn getBlockInlineBreak(zir: Zir, inst_index: usize) ?Zir.Inst.Ref {
     return data[break_index].@"break".operand;
 }
 
-fn printWithContext(file: *File, inst: usize, comptime fmt: []const u8, args: anytype) void {
+fn printWithContext(
+    file: *File,
+    inst: Zir.Inst.Index,
+    comptime fmt: []const u8,
+    args: anytype,
+) void {
+    return printWithOptionalContext(file, inst.toOptional(), fmt, args);
+}
+
+fn printWithOptionalContext(file: *File, inst: Zir.Inst.OptionalIndex, comptime fmt: []const u8, args: anytype) void {
     log.debug("Context [{s}] % {} \n " ++ fmt, .{ file.sub_file_path, inst } ++ args);
 }
 
-fn panicWithContext(file: *File, inst: usize, comptime fmt: []const u8, args: anytype) noreturn {
-    printWithContext(file, inst, fmt, args);
+fn panicWithContext(
+    file: *File,
+    inst: Zir.Inst.Index,
+    comptime fmt: []const u8,
+    args: anytype,
+) noreturn {
+    printWithOptionalContext(file, inst.toOptional(), fmt, args);
+    unreachable;
+}
+
+fn panicWithOptionalContext(
+    file: *File,
+    inst: Zir.Inst.OptionalIndex,
+    comptime fmt: []const u8,
+    args: anytype,
+) noreturn {
+    printWithOptionalContext(file, inst, fmt, args);
     unreachable;
 }
 

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -93,13 +93,18 @@ pub fn extraData(code: Zir, comptime T: type, index: usize) ExtraData(T) {
     inline for (fields) |field| {
         @field(result, field.name) = switch (field.type) {
             u32 => code.extra[i],
-            Inst.Ref => @enumFromInt(code.extra[i]),
+
+            Inst.Ref,
+            Inst.Index,
+            => @enumFromInt(code.extra[i]),
+
             i32,
             Inst.Call.Flags,
             Inst.BuiltinCall.Flags,
             Inst.SwitchBlock.Bits,
             Inst.FuncFancy.Bits,
             => @bitCast(code.extra[i]),
+
             else => @compileError("bad field type"),
         };
         i += 1;
@@ -134,6 +139,10 @@ pub fn refSlice(code: Zir, start: usize, len: usize) []Inst.Ref {
     return @ptrCast(code.extra[start..][0..len]);
 }
 
+pub fn bodySlice(zir: Zir, start: usize, len: usize) []Inst.Index {
+    return @ptrCast(zir.extra[start..][0..len]);
+}
+
 pub fn hasCompileErrors(code: Zir) bool {
     return code.extra[@intFromEnum(ExtraIndex.compile_errors)] != 0;
 }
@@ -144,10 +153,6 @@ pub fn deinit(code: *Zir, gpa: Allocator) void {
     gpa.free(code.extra);
     code.* = undefined;
 }
-
-/// ZIR is structured so that the outermost "main" struct of any file
-/// is always at index 0.
-pub const main_struct_inst: Inst.Index = 0;
 
 /// These are untyped instructions generated from an Abstract Syntax Tree.
 /// The data here is immutable because it is possible to have multiple
@@ -2093,7 +2098,34 @@ pub const Inst = struct {
     };
 
     /// The position of a ZIR instruction within the `Zir` instructions array.
-    pub const Index = u32;
+    pub const Index = enum(u32) {
+        /// ZIR is structured so that the outermost "main" struct of any file
+        /// is always at index 0.
+        main_struct_inst = 0,
+        ref_start_index = InternPool.static_len,
+        _,
+
+        pub fn toRef(i: Index) Inst.Ref {
+            return @enumFromInt(@intFromEnum(Index.ref_start_index) + @intFromEnum(i));
+        }
+
+        pub fn toOptional(i: Index) OptionalIndex {
+            return @enumFromInt(@intFromEnum(i));
+        }
+    };
+
+    pub const OptionalIndex = enum(u32) {
+        /// ZIR is structured so that the outermost "main" struct of any file
+        /// is always at index 0.
+        main_struct_inst = 0,
+        ref_start_index = InternPool.static_len,
+        none = std.math.maxInt(u32),
+        _,
+
+        pub fn unwrap(oi: OptionalIndex) ?Index {
+            return if (oi == .none) null else @enumFromInt(@intFromEnum(oi));
+        }
+    };
 
     /// A reference to ZIR instruction, or to an InternPool index, or neither.
     ///
@@ -2196,6 +2228,21 @@ pub const Inst = struct {
         /// value and may instead be used as a sentinel to indicate null.
         none = @intFromEnum(InternPool.Index.none),
         _,
+
+        pub fn toIndex(inst: Ref) ?Index {
+            assert(inst != .none);
+            const ref_int = @intFromEnum(inst);
+            if (ref_int >= @intFromEnum(Index.ref_start_index)) {
+                return @enumFromInt(ref_int - @intFromEnum(Index.ref_start_index));
+            } else {
+                return null;
+            }
+        }
+
+        pub fn toIndexAllowNone(inst: Ref) ?Index {
+            if (inst == .none) return null;
+            return toIndex(inst);
+        }
     };
 
     /// All instructions have an 8-byte payload, which is contained within
@@ -3286,7 +3333,7 @@ pub const Inst = struct {
 
     /// Trailing: for each `imports_len` there is an Item
     pub const Imports = struct {
-        imports_len: Inst.Index,
+        imports_len: u32,
 
         pub const Item = struct {
             /// null terminated string index
@@ -3371,16 +3418,16 @@ pub const DeclIterator = struct {
     }
 };
 
-pub fn declIterator(zir: Zir, decl_inst: u32) DeclIterator {
+pub fn declIterator(zir: Zir, decl_inst: Zir.Inst.Index) DeclIterator {
     const tags = zir.instructions.items(.tag);
     const datas = zir.instructions.items(.data);
-    switch (tags[decl_inst]) {
+    switch (tags[@intFromEnum(decl_inst)]) {
         // Functions are allowed and yield no iterations.
         // There is one case matching this in the extended instruction set below.
         .func, .func_inferred, .func_fancy => return declIteratorInner(zir, 0, 0),
 
         .extended => {
-            const extended = datas[decl_inst].extended;
+            const extended = datas[@intFromEnum(decl_inst)].extended;
             switch (extended.opcode) {
                 .struct_decl => {
                     const small: Inst.StructDecl.Small = @bitCast(extended.small);
@@ -3469,7 +3516,7 @@ pub fn declIteratorInner(zir: Zir, extra_index: usize, decls_len: u32) DeclItera
 /// The iterator would have to allocate memory anyway to iterate. So here we populate
 /// an ArrayList as the result.
 pub fn findDecls(zir: Zir, list: *std.ArrayList(Inst.Index), decl_sub_index: ExtraIndex) !void {
-    const block_inst = zir.extra[@intFromEnum(decl_sub_index) + 6];
+    const block_inst: Zir.Inst.Index = @enumFromInt(zir.extra[@intFromEnum(decl_sub_index) + 6]);
     list.clearRetainingCapacity();
 
     return zir.findDeclsInner(list, block_inst);
@@ -3483,32 +3530,32 @@ fn findDeclsInner(
     const tags = zir.instructions.items(.tag);
     const datas = zir.instructions.items(.data);
 
-    switch (tags[inst]) {
+    switch (tags[@intFromEnum(inst)]) {
         // Functions instructions are interesting and have a body.
         .func,
         .func_inferred,
         => {
             try list.append(inst);
 
-            const inst_data = datas[inst].pl_node;
+            const inst_data = datas[@intFromEnum(inst)].pl_node;
             const extra = zir.extraData(Inst.Func, inst_data.payload_index);
             var extra_index: usize = extra.end;
             switch (extra.data.ret_body_len) {
                 0 => {},
                 1 => extra_index += 1,
                 else => {
-                    const body = zir.extra[extra_index..][0..extra.data.ret_body_len];
+                    const body = zir.bodySlice(extra_index, extra.data.ret_body_len);
                     extra_index += body.len;
                     try zir.findDeclsBody(list, body);
                 },
             }
-            const body = zir.extra[extra_index..][0..extra.data.body_len];
+            const body = zir.bodySlice(extra_index, extra.data.body_len);
             return zir.findDeclsBody(list, body);
         },
         .func_fancy => {
             try list.append(inst);
 
-            const inst_data = datas[inst].pl_node;
+            const inst_data = datas[@intFromEnum(inst)].pl_node;
             const extra = zir.extraData(Inst.FuncFancy, inst_data.payload_index);
             var extra_index: usize = extra.end;
             extra_index += @intFromBool(extra.data.bits.has_lib_name);
@@ -3516,7 +3563,7 @@ fn findDeclsInner(
             if (extra.data.bits.has_align_body) {
                 const body_len = zir.extra[extra_index];
                 extra_index += 1;
-                const body = zir.extra[extra_index..][0..body_len];
+                const body = zir.bodySlice(extra_index, body_len);
                 try zir.findDeclsBody(list, body);
                 extra_index += body.len;
             } else if (extra.data.bits.has_align_ref) {
@@ -3526,7 +3573,7 @@ fn findDeclsInner(
             if (extra.data.bits.has_addrspace_body) {
                 const body_len = zir.extra[extra_index];
                 extra_index += 1;
-                const body = zir.extra[extra_index..][0..body_len];
+                const body = zir.bodySlice(extra_index, body_len);
                 try zir.findDeclsBody(list, body);
                 extra_index += body.len;
             } else if (extra.data.bits.has_addrspace_ref) {
@@ -3536,7 +3583,7 @@ fn findDeclsInner(
             if (extra.data.bits.has_section_body) {
                 const body_len = zir.extra[extra_index];
                 extra_index += 1;
-                const body = zir.extra[extra_index..][0..body_len];
+                const body = zir.bodySlice(extra_index, body_len);
                 try zir.findDeclsBody(list, body);
                 extra_index += body.len;
             } else if (extra.data.bits.has_section_ref) {
@@ -3546,7 +3593,7 @@ fn findDeclsInner(
             if (extra.data.bits.has_cc_body) {
                 const body_len = zir.extra[extra_index];
                 extra_index += 1;
-                const body = zir.extra[extra_index..][0..body_len];
+                const body = zir.bodySlice(extra_index, body_len);
                 try zir.findDeclsBody(list, body);
                 extra_index += body.len;
             } else if (extra.data.bits.has_cc_ref) {
@@ -3556,7 +3603,7 @@ fn findDeclsInner(
             if (extra.data.bits.has_ret_ty_body) {
                 const body_len = zir.extra[extra_index];
                 extra_index += 1;
-                const body = zir.extra[extra_index..][0..body_len];
+                const body = zir.bodySlice(extra_index, body_len);
                 try zir.findDeclsBody(list, body);
                 extra_index += body.len;
             } else if (extra.data.bits.has_ret_ty_ref) {
@@ -3565,11 +3612,11 @@ fn findDeclsInner(
 
             extra_index += @intFromBool(extra.data.bits.has_any_noalias);
 
-            const body = zir.extra[extra_index..][0..extra.data.body_len];
+            const body = zir.bodySlice(extra_index, extra.data.body_len);
             return zir.findDeclsBody(list, body);
         },
         .extended => {
-            const extended = datas[inst].extended;
+            const extended = datas[@intFromEnum(inst)].extended;
             switch (extended.opcode) {
 
                 // Decl instructions are interesting but have no body.
@@ -3587,23 +3634,23 @@ fn findDeclsInner(
         // Block instructions, recurse over the bodies.
 
         .block, .block_comptime, .block_inline => {
-            const inst_data = datas[inst].pl_node;
+            const inst_data = datas[@intFromEnum(inst)].pl_node;
             const extra = zir.extraData(Inst.Block, inst_data.payload_index);
-            const body = zir.extra[extra.end..][0..extra.data.body_len];
+            const body = zir.bodySlice(extra.end, extra.data.body_len);
             return zir.findDeclsBody(list, body);
         },
         .condbr, .condbr_inline => {
-            const inst_data = datas[inst].pl_node;
+            const inst_data = datas[@intFromEnum(inst)].pl_node;
             const extra = zir.extraData(Inst.CondBr, inst_data.payload_index);
-            const then_body = zir.extra[extra.end..][0..extra.data.then_body_len];
-            const else_body = zir.extra[extra.end + then_body.len ..][0..extra.data.else_body_len];
+            const then_body = zir.bodySlice(extra.end, extra.data.then_body_len);
+            const else_body = zir.bodySlice(extra.end + then_body.len, extra.data.else_body_len);
             try zir.findDeclsBody(list, then_body);
             try zir.findDeclsBody(list, else_body);
         },
         .@"try", .try_ptr => {
-            const inst_data = datas[inst].pl_node;
+            const inst_data = datas[@intFromEnum(inst)].pl_node;
             const extra = zir.extraData(Inst.Try, inst_data.payload_index);
-            const body = zir.extra[extra.end..][0..extra.data.body_len];
+            const body = zir.bodySlice(extra.end, extra.data.body_len);
             try zir.findDeclsBody(list, body);
         },
         .switch_block => return findDeclsSwitch(zir, list, inst),
@@ -3619,7 +3666,7 @@ fn findDeclsSwitch(
     list: *std.ArrayList(Inst.Index),
     inst: Inst.Index,
 ) Allocator.Error!void {
-    const inst_data = zir.instructions.items(.data)[inst].pl_node;
+    const inst_data = zir.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const extra = zir.extraData(Inst.SwitchBlock, inst_data.payload_index);
 
     var extra_index: usize = extra.end;
@@ -3634,7 +3681,7 @@ fn findDeclsSwitch(
     if (special_prong != .none) {
         const body_len: u31 = @truncate(zir.extra[extra_index]);
         extra_index += 1;
-        const body = zir.extra[extra_index..][0..body_len];
+        const body = zir.bodySlice(extra_index, body_len);
         extra_index += body.len;
 
         try zir.findDeclsBody(list, body);
@@ -3642,20 +3689,18 @@ fn findDeclsSwitch(
 
     {
         const scalar_cases_len = extra.data.bits.scalar_cases_len;
-        var scalar_i: usize = 0;
-        while (scalar_i < scalar_cases_len) : (scalar_i += 1) {
+        for (0..scalar_cases_len) |_| {
             extra_index += 1;
             const body_len: u31 = @truncate(zir.extra[extra_index]);
             extra_index += 1;
-            const body = zir.extra[extra_index..][0..body_len];
+            const body = zir.bodySlice(extra_index, body_len);
             extra_index += body_len;
 
             try zir.findDeclsBody(list, body);
         }
     }
     {
-        var multi_i: usize = 0;
-        while (multi_i < multi_cases_len) : (multi_i += 1) {
+        for (0..multi_cases_len) |_| {
             const items_len = zir.extra[extra_index];
             extra_index += 1;
             const ranges_len = zir.extra[extra_index];
@@ -3672,7 +3717,7 @@ fn findDeclsSwitch(
                 extra_index += 1;
             }
 
-            const body = zir.extra[extra_index..][0..body_len];
+            const body = zir.bodySlice(extra_index, body_len);
             extra_index += body_len;
 
             try zir.findDeclsBody(list, body);
@@ -3699,12 +3744,12 @@ pub const FnInfo = struct {
     total_params_len: u32,
 };
 
-pub fn getParamBody(zir: Zir, fn_inst: Inst.Index) []const u32 {
+pub fn getParamBody(zir: Zir, fn_inst: Inst.Index) []const Zir.Inst.Index {
     const tags = zir.instructions.items(.tag);
     const datas = zir.instructions.items(.data);
-    const inst_data = datas[fn_inst].pl_node;
+    const inst_data = datas[@intFromEnum(fn_inst)].pl_node;
 
-    const param_block_index = switch (tags[fn_inst]) {
+    const param_block_index = switch (tags[@intFromEnum(fn_inst)]) {
         .func, .func_inferred => blk: {
             const extra = zir.extraData(Inst.Func, inst_data.payload_index);
             break :blk extra.data.param_block;
@@ -3716,8 +3761,8 @@ pub fn getParamBody(zir: Zir, fn_inst: Inst.Index) []const u32 {
         else => unreachable,
     };
 
-    const param_block = zir.extraData(Inst.Block, datas[param_block_index].pl_node.payload_index);
-    return zir.extra[param_block.end..][0..param_block.data.body_len];
+    const param_block = zir.extraData(Inst.Block, datas[@intFromEnum(param_block_index)].pl_node.payload_index);
+    return zir.bodySlice(param_block.end, param_block.data.body_len);
 }
 
 pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
@@ -3728,9 +3773,9 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
         body: []const Inst.Index,
         ret_ty_ref: Inst.Ref,
         ret_ty_body: []const Inst.Index,
-    } = switch (tags[fn_inst]) {
+    } = switch (tags[@intFromEnum(fn_inst)]) {
         .func, .func_inferred => blk: {
-            const inst_data = datas[fn_inst].pl_node;
+            const inst_data = datas[@intFromEnum(fn_inst)].pl_node;
             const extra = zir.extraData(Inst.Func, inst_data.payload_index);
 
             var extra_index: usize = extra.end;
@@ -3746,12 +3791,12 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
                     extra_index += 1;
                 },
                 else => {
-                    ret_ty_body = zir.extra[extra_index..][0..extra.data.ret_body_len];
+                    ret_ty_body = zir.bodySlice(extra_index, extra.data.ret_body_len);
                     extra_index += ret_ty_body.len;
                 },
             }
 
-            const body = zir.extra[extra_index..][0..extra.data.body_len];
+            const body = zir.bodySlice(extra_index, extra.data.body_len);
             extra_index += body.len;
 
             break :blk .{
@@ -3762,7 +3807,7 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
             };
         },
         .func_fancy => blk: {
-            const inst_data = datas[fn_inst].pl_node;
+            const inst_data = datas[@intFromEnum(fn_inst)].pl_node;
             const extra = zir.extraData(Inst.FuncFancy, inst_data.payload_index);
 
             var extra_index: usize = extra.end;
@@ -3793,7 +3838,7 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
             if (extra.data.bits.has_ret_ty_body) {
                 const body_len = zir.extra[extra_index];
                 extra_index += 1;
-                ret_ty_body = zir.extra[extra_index..][0..body_len];
+                ret_ty_body = zir.bodySlice(extra_index, body_len);
                 extra_index += ret_ty_body.len;
             } else if (extra.data.bits.has_ret_ty_ref) {
                 ret_ty_ref = @enumFromInt(zir.extra[extra_index]);
@@ -3802,7 +3847,7 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
 
             extra_index += @intFromBool(extra.data.bits.has_any_noalias);
 
-            const body = zir.extra[extra_index..][0..extra.data.body_len];
+            const body = zir.bodySlice(extra_index, extra.data.body_len);
             extra_index += body.len;
             break :blk .{
                 .param_block = extra.data.param_block,
@@ -3813,14 +3858,15 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
         },
         else => unreachable,
     };
-    assert(tags[info.param_block] == .block or
-        tags[info.param_block] == .block_comptime or
-        tags[info.param_block] == .block_inline);
-    const param_block = zir.extraData(Inst.Block, datas[info.param_block].pl_node.payload_index);
-    const param_body = zir.extra[param_block.end..][0..param_block.data.body_len];
+    switch (tags[@intFromEnum(info.param_block)]) {
+        .block, .block_comptime, .block_inline => {}, // OK
+        else => unreachable, // assertion failure
+    }
+    const param_block = zir.extraData(Inst.Block, datas[@intFromEnum(info.param_block)].pl_node.payload_index);
+    const param_body = zir.bodySlice(param_block.end, param_block.data.body_len);
     var total_params_len: u32 = 0;
     for (param_body) |inst| {
-        switch (tags[inst]) {
+        switch (tags[@intFromEnum(inst)]) {
             .param, .param_comptime, .param_anytype, .param_anytype_comptime => {
                 total_params_len += 1;
             },
@@ -3835,25 +3881,4 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
         .body = info.body,
         .total_params_len = total_params_len,
     };
-}
-
-pub const ref_start_index: u32 = InternPool.static_len;
-
-pub fn indexToRef(inst: Inst.Index) Inst.Ref {
-    return @enumFromInt(ref_start_index + inst);
-}
-
-pub fn refToIndex(inst: Inst.Ref) ?Inst.Index {
-    assert(inst != .none);
-    const ref_int = @intFromEnum(inst);
-    if (ref_int >= ref_start_index) {
-        return ref_int - ref_start_index;
-    } else {
-        return null;
-    }
-}
-
-pub fn refToIndexAllowNone(inst: Inst.Ref) ?Inst.Index {
-    if (inst == .none) return null;
-    return refToIndex(inst);
 }


### PR DESCRIPTION
This commit starts by making `Zir.Inst.Index` a nonexhaustive enum rather than a `u32` alias for type safety purposes, and the rest of the changes are needed to get everything compiling again.

As a bonus, break the standard library.

Depends on #17758.