### PR TITLE
Reorder fields in `build.zig.zon.md`

### DIFF
--- a/doc/build.zig.zon.md
+++ b/doc/build.zig.zon.md
@@ -18,12 +18,6 @@ String. Required.
 
 [semver](https://semver.org/)
 
-### `dependencies`
-
-Struct.
-
-Each dependency must either provide a `url` and `hash`, or a `path`.
-
 ### `minimum_zig_version`
 
 String. Optional.
@@ -32,6 +26,12 @@ String. Optional.
 
 This is currently advisory only; the compiler does not yet do anything
 with this version.
+
+### `dependencies`
+
+Struct.
+
+Each dependency must either provide a `url` and `hash`, or a `path`.
 
 #### `url`
 


### PR DESCRIPTION
The order of `dependencies` and `minimum_zig_version` was misleading.