### PR TITLE
elf: rename ZigModule to ZigObject and move all codegen hooks into it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,7 +594,7 @@ set(ZIG_STAGE2_SOURCES
     "${CMAKE_SOURCE_DIR}/src/link/Elf/Object.zig"
     "${CMAKE_SOURCE_DIR}/src/link/Elf/SharedObject.zig"
     "${CMAKE_SOURCE_DIR}/src/link/Elf/Symbol.zig"
-    "${CMAKE_SOURCE_DIR}/src/link/Elf/ZigModule.zig"
+    "${CMAKE_SOURCE_DIR}/src/link/Elf/ZigObject.zig"
     "${CMAKE_SOURCE_DIR}/src/link/Elf/eh_frame.zig"
     "${CMAKE_SOURCE_DIR}/src/link/Elf/file.zig"
     "${CMAKE_SOURCE_DIR}/src/link/Elf/gc.zig"

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -4316,7 +4316,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
     if (try self.air.value(callee, mod)) |func_value| {
         if (func_value.getFunction(mod)) |func| {
             if (self.bin_file.cast(link.File.Elf)) |elf_file| {
-                const sym_index = try elf_file.getOrCreateMetadataForDecl(func.owner_decl);
+                const sym_index = try elf_file.zigObjectPtr().?.getOrCreateMetadataForDecl(elf_file, func.owner_decl);
                 const sym = elf_file.symbol(sym_index);
                 _ = try sym.getOrCreateZigGotEntry(sym_index, elf_file);
                 const got_addr = @as(u32, @intCast(sym.zigGotAddress(elf_file)));

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -4302,7 +4302,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
     if (try self.air.value(callee, mod)) |func_value| {
         if (func_value.getFunction(mod)) |func| {
             if (self.bin_file.cast(link.File.Elf)) |elf_file| {
-                const sym_index = try elf_file.getOrCreateMetadataForDecl(func.owner_decl);
+                const sym_index = try elf_file.zigObjectPtr().?.getOrCreateMetadataForDecl(elf_file, func.owner_decl);
                 const sym = elf_file.symbol(sym_index);
                 _ = try sym.getOrCreateZigGotEntry(sym_index, elf_file);
                 const got_addr = @as(u32, @intCast(sym.zigGotAddress(elf_file)));

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1752,7 +1752,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
         if (try self.air.value(callee, mod)) |func_value| {
             switch (mod.intern_pool.indexToKey(func_value.ip_index)) {
                 .func => |func| {
-                    const sym_index = try elf_file.getOrCreateMetadataForDecl(func.owner_decl);
+                    const sym_index = try elf_file.zigObjectPtr().?.getOrCreateMetadataForDecl(elf_file, func.owner_decl);
                     const sym = elf_file.symbol(sym_index);
                     _ = try sym.getOrCreateZigGotEntry(sym_index, elf_file);
                     const got_addr = @as(u32, @intCast(sym.zigGotAddress(elf_file)));

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -1347,7 +1347,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
             switch (mod.intern_pool.indexToKey(func_value.ip_index)) {
                 .func => |func| {
                     const got_addr = if (self.bin_file.cast(link.File.Elf)) |elf_file| blk: {
-                        const sym_index = try elf_file.getOrCreateMetadataForDecl(func.owner_decl);
+                        const sym_index = try elf_file.zigObjectPtr().?.getOrCreateMetadataForDecl(elf_file, func.owner_decl);
                         const sym = elf_file.symbol(sym_index);
                         _ = try sym.getOrCreateZigGotEntry(sym_index, elf_file);
                         break :blk @as(u32, @intCast(sym.zigGotAddress(elf_file)));

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -134,7 +134,7 @@ const Owner = union(enum) {
                 const mod = ctx.bin_file.options.module.?;
                 const decl_index = mod.funcOwnerDeclIndex(func_index);
                 if (ctx.bin_file.cast(link.File.Elf)) |elf_file| {
-                    return elf_file.getOrCreateMetadataForDecl(decl_index);
+                    return elf_file.zigObjectPtr().?.getOrCreateMetadataForDecl(elf_file, decl_index);
                 } else if (ctx.bin_file.cast(link.File.MachO)) |macho_file| {
                     const atom = try macho_file.getOrCreateAtomForDecl(decl_index);
                     return macho_file.getAtom(atom).getSymbolIndex().?;
@@ -147,7 +147,7 @@ const Owner = union(enum) {
             },
             .lazy_sym => |lazy_sym| {
                 if (ctx.bin_file.cast(link.File.Elf)) |elf_file| {
-                    return elf_file.getOrCreateMetadataForLazySymbol(lazy_sym) catch |err|
+                    return elf_file.zigObjectPtr().?.getOrCreateMetadataForLazySymbol(elf_file, lazy_sym) catch |err|
                         ctx.fail("{s} creating lazy symbol", .{@errorName(err)});
                 } else if (ctx.bin_file.cast(link.File.MachO)) |macho_file| {
                     const atom = macho_file.getOrCreateAtomForLazySymbol(lazy_sym) catch |err|
@@ -10233,7 +10233,7 @@ fn genCall(self: *Self, info: union(enum) {
                 .func => |func| {
                     try mod.markDeclAlive(mod.declPtr(func.owner_decl));
                     if (self.bin_file.cast(link.File.Elf)) |elf_file| {
-                        const sym_index = try elf_file.getOrCreateMetadataForDecl(func.owner_decl);
+                        const sym_index = try elf_file.zigObjectPtr().?.getOrCreateMetadataForDecl(elf_file, func.owner_decl);
                         const sym = elf_file.symbol(sym_index);
                         _ = try sym.getOrCreateZigGotEntry(sym_index, elf_file);
                         if (self.bin_file.options.pic) {
@@ -13100,7 +13100,7 @@ fn genLazySymbolRef(
     lazy_sym: link.File.LazySymbol,
 ) InnerError!void {
     if (self.bin_file.cast(link.File.Elf)) |elf_file| {
-        const sym_index = elf_file.getOrCreateMetadataForLazySymbol(lazy_sym) catch |err|
+        const sym_index = elf_file.zigObjectPtr().?.getOrCreateMetadataForLazySymbol(elf_file, lazy_sym) catch |err|
             return self.fail("{s} creating lazy symbol", .{@errorName(err)});
         const sym = elf_file.symbol(sym_index);
         _ = try sym.getOrCreateZigGotEntry(sym_index, elf_file);

--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -86,7 +86,7 @@ pub fn emitMir(emit: *Emit) Error!void {
                 }),
                 .linker_reloc => |data| if (emit.lower.bin_file.cast(link.File.Elf)) |elf_file| {
                     const atom = elf_file.symbol(data.atom_index).atom(elf_file).?;
-                    const sym = elf_file.symbol(elf_file.zigModulePtr().symbol(data.sym_index));
+                    const sym = elf_file.symbol(elf_file.zigObjectPtr().?.symbol(data.sym_index));
                     if (emit.lower.bin_file.options.pic) {
                         const r_type: u32 = if (sym.flags.has_zig_got)
                             link.File.Elf.R_X86_64_ZIG_GOTPCREL

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -907,7 +907,7 @@ fn genDeclRef(
             elf_file.symbol(elf_file.zigObjectPtr().?.symbol(sym_index)).flags.needs_got = true;
             return GenResult.mcv(.{ .load_symbol = sym_index });
         }
-        const sym_index = try elf_file.getOrCreateMetadataForDecl(decl_index);
+        const sym_index = try elf_file.zigObjectPtr().?.getOrCreateMetadataForDecl(elf_file, decl_index);
         const sym = elf_file.symbol(sym_index);
         _ = try sym.getOrCreateZigGotEntry(sym_index, elf_file);
         return GenResult.mcv(.{ .load_symbol = sym.esym_index });

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -904,7 +904,7 @@ fn genDeclRef(
             else
                 null;
             const sym_index = try elf_file.getGlobalSymbol(name, lib_name);
-            elf_file.symbol(elf_file.zigModulePtr().symbol(sym_index)).flags.needs_got = true;
+            elf_file.symbol(elf_file.zigObjectPtr().?.symbol(sym_index)).flags.needs_got = true;
             return GenResult.mcv(.{ .load_symbol = sym_index });
         }
         const sym_index = try elf_file.getOrCreateMetadataForDecl(decl_index);

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -292,28 +292,7 @@ pub fn openPath(allocator: Allocator, sub_path: []const u8, options: link.Option
             .path = options.module.?.main_mod.root_src_path,
         } });
         self.zig_object_index = index;
-        const zig_object = self.zigObjectPtr().?;
-
-        try zig_object.atoms.append(allocator, 0); // null input section
-
-        const name_off = try self.strtab.insert(allocator, std.fs.path.stem(options.module.?.main_mod.root_src_path));
-        const symbol_index = try self.addSymbol();
-        try zig_object.local_symbols.append(allocator, symbol_index);
-        const symbol_ptr = self.symbol(symbol_index);
-        symbol_ptr.file_index = zig_object.index;
-        symbol_ptr.name_offset = name_off;
-
-        const esym_index = try zig_object.addLocalEsym(allocator);
-        const esym = &zig_object.local_esyms.items(.elf_sym)[esym_index];
-        esym.st_name = name_off;
-        esym.st_info |= elf.STT_FILE;
-        esym.st_shndx = elf.SHN_ABS;
-        symbol_ptr.esym_index = esym_index;
-
-        if (!options.strip) {
-            zig_object.dwarf = Dwarf.init(allocator, &self.base, .dwarf32);
-        }
-
+        try self.zigObjectPtr().?.init(self);
         try self.initMetadata();
     }
 

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -52,7 +52,7 @@ pub fn file(self: Atom, elf_file: *Elf) ?File {
 pub fn inputShdr(self: Atom, elf_file: *Elf) Object.ElfShdr {
     return switch (self.file(elf_file).?) {
         .object => |x| x.shdrs.items[self.input_section_index],
-        .zig_module => |x| x.inputShdr(self.atom_index, elf_file),
+        .zig_object => |x| x.inputShdr(self.atom_index, elf_file),
         else => unreachable,
     };
 }
@@ -270,14 +270,14 @@ pub fn free(self: *Atom, elf_file: *Elf) void {
     // TODO create relocs free list
     self.freeRelocs(elf_file);
     // TODO figure out how to free input section mappind in ZigModule
-    // const zig_module = self.file(elf_file).?.zig_module;
-    // assert(zig_module.atoms.swapRemove(self.atom_index));
+    // const zig_object = elf_file.zigObjectPtr().?
+    // assert(zig_object.atoms.swapRemove(self.atom_index));
     self.* = .{};
 }
 
 pub fn relocs(self: Atom, elf_file: *Elf) []align(1) const elf.Elf64_Rela {
     return switch (self.file(elf_file).?) {
-        .zig_module => |x| x.relocs.items[self.relocs_section_index].items,
+        .zig_object => |x| x.relocs.items[self.relocs_section_index].items,
         .object => |x| x.getRelocs(self.relocs_section_index),
         else => unreachable,
     };
@@ -298,17 +298,17 @@ pub fn markFdesDead(self: Atom, elf_file: *Elf) void {
 pub fn addReloc(self: Atom, elf_file: *Elf, reloc: elf.Elf64_Rela) !void {
     const gpa = elf_file.base.allocator;
     const file_ptr = self.file(elf_file).?;
-    assert(file_ptr == .zig_module);
-    const zig_module = file_ptr.zig_module;
-    const rels = &zig_module.relocs.items[self.relocs_section_index];
+    assert(file_ptr == .zig_object);
+    const zig_object = file_ptr.zig_object;
+    const rels = &zig_object.relocs.items[self.relocs_section_index];
     try rels.append(gpa, reloc);
 }
 
 pub fn freeRelocs(self: Atom, elf_file: *Elf) void {
     const file_ptr = self.file(elf_file).?;
-    assert(file_ptr == .zig_module);
-    const zig_module = file_ptr.zig_module;
-    zig_module.relocs.items[self.relocs_section_index].clearRetainingCapacity();
+    assert(file_ptr == .zig_object);
+    const zig_object = file_ptr.zig_object;
+    zig_object.relocs.items[self.relocs_section_index].clearRetainingCapacity();
 }
 
 pub fn scanRelocsRequiresCode(self: Atom, elf_file: *Elf) bool {
@@ -332,7 +332,7 @@ pub fn scanRelocs(self: Atom, elf_file: *Elf, code: ?[]const u8, undefs: anytype
         const r_offset = std.math.cast(usize, rel.r_offset) orelse return error.Overflow;
 
         const symbol_index = switch (file_ptr) {
-            .zig_module => |x| x.symbol(rel.r_sym()),
+            .zig_object => |x| x.symbol(rel.r_sym()),
             .object => |x| x.symbols.items[rel.r_sym()],
             else => unreachable,
         };
@@ -690,7 +690,7 @@ fn reportUndefined(
     undefs: anytype,
 ) !void {
     const rel_esym = switch (self.file(elf_file).?) {
-        .zig_module => |x| x.elfSym(rel.r_sym()).*,
+        .zig_object => |x| x.elfSym(rel.r_sym()).*,
         .object => |x| x.symtab[rel.r_sym()],
         else => unreachable,
     };
@@ -724,7 +724,7 @@ pub fn resolveRelocsAlloc(self: Atom, elf_file: *Elf, code: []u8) !void {
         if (r_type == elf.R_X86_64_NONE) continue;
 
         const target = switch (file_ptr) {
-            .zig_module => |x| elf_file.symbol(x.symbol(rel.r_sym())),
+            .zig_object => |x| elf_file.symbol(x.symbol(rel.r_sym())),
             .object => |x| elf_file.symbol(x.symbols.items[rel.r_sym()]),
             else => unreachable,
         };
@@ -1004,7 +1004,7 @@ pub fn resolveRelocsNonAlloc(self: Atom, elf_file: *Elf, code: []u8, undefs: any
         const r_offset = std.math.cast(usize, rel.r_offset) orelse return error.Overflow;
 
         const target_index = switch (file_ptr) {
-            .zig_module => |x| x.symbol(rel.r_sym()),
+            .zig_object => |x| x.symbol(rel.r_sym()),
             .object => |x| x.symbols.items[rel.r_sym()],
             else => unreachable,
         };

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -166,7 +166,7 @@ pub fn allocate(self: *Atom, elf_file: *Elf) !void {
         try elf_file.growAllocSection(self.outputShndx().?, needed_size);
         last_atom_index.* = self.atom_index;
 
-        if (elf_file.dwarf) |_| {
+        if (elf_file.zigObjectPtr().?.dwarf) |_| {
             // The .debug_info section has `low_pc` and `high_pc` values which is the virtual address
             // range of the compilation unit. When we expand the text section, this range changes,
             // so the DW_TAG.compile_unit tag of the .debug_info section becomes dirty.

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -166,15 +166,16 @@ pub fn allocate(self: *Atom, elf_file: *Elf) !void {
         try elf_file.growAllocSection(self.outputShndx().?, needed_size);
         last_atom_index.* = self.atom_index;
 
-        if (elf_file.zigObjectPtr().?.dwarf) |_| {
+        const zig_object = elf_file.zigObjectPtr().?;
+        if (zig_object.dwarf) |_| {
             // The .debug_info section has `low_pc` and `high_pc` values which is the virtual address
             // range of the compilation unit. When we expand the text section, this range changes,
             // so the DW_TAG.compile_unit tag of the .debug_info section becomes dirty.
-            elf_file.debug_info_header_dirty = true;
+            zig_object.debug_info_header_dirty = true;
             // This becomes dirty for the same reason. We could potentially make this more
             // fine-grained with the addition of support for more compilation units. It is planned to
             // model each package as a different compilation unit.
-            elf_file.debug_aranges_section_dirty = true;
+            zig_object.debug_aranges_section_dirty = true;
         }
     }
     shdr.sh_addralign = @max(shdr.sh_addralign, self.alignment.toByteUnitsOptional().?);

--- a/src/link/Elf/Symbol.zig
+++ b/src/link/Elf/Symbol.zig
@@ -72,7 +72,7 @@ pub fn file(symbol: Symbol, elf_file: *Elf) ?File {
 pub fn elfSym(symbol: Symbol, elf_file: *Elf) elf.Elf64_Sym {
     const file_ptr = symbol.file(elf_file).?;
     switch (file_ptr) {
-        .zig_module => |x| return x.elfSym(symbol.esym_index).*,
+        .zig_object => |x| return x.elfSym(symbol.esym_index).*,
         .linker_defined => |x| return x.symtab.items[symbol.esym_index],
         inline else => |x| return x.symtab[symbol.esym_index],
     }
@@ -406,4 +406,3 @@ const PltSection = synthetic_sections.PltSection;
 const SharedObject = @import("SharedObject.zig");
 const Symbol = @This();
 const ZigGotSection = synthetic_sections.ZigGotSection;
-const ZigModule = @import("ZigModule.zig");

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -285,7 +285,7 @@ pub fn globals(self: *ZigModule) []const Symbol.Index {
 }
 
 pub fn asFile(self: *ZigModule) File {
-    return .{ .zig_module = self };
+    return .{ .zig_object = self };
 }
 
 /// Returns atom's code.

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -1,5 +1,5 @@
 pub const File = union(enum) {
-    zig_module: *ZigModule,
+    zig_object: *ZigObject,
     linker_defined: *LinkerDefined,
     object: *Object,
     shared_object: *SharedObject,
@@ -23,7 +23,7 @@ pub const File = union(enum) {
         _ = unused_fmt_string;
         _ = options;
         switch (file) {
-            .zig_module => |x| try writer.print("{s}", .{x.path}),
+            .zig_object => |x| try writer.print("{s}", .{x.path}),
             .linker_defined => try writer.writeAll("(linker defined)"),
             .object => |x| try writer.print("{}", .{x.fmtPath()}),
             .shared_object => |x| try writer.writeAll(x.path),
@@ -32,7 +32,7 @@ pub const File = union(enum) {
 
     pub fn isAlive(file: File) bool {
         return switch (file) {
-            .zig_module => true,
+            .zig_object => true,
             .linker_defined => true,
             inline else => |x| x.alive,
         };
@@ -76,7 +76,7 @@ pub const File = union(enum) {
 
     pub fn setAlive(file: File) void {
         switch (file) {
-            .zig_module, .linker_defined => {},
+            .zig_object, .linker_defined => {},
             inline else => |x| x.alive = true,
         }
     }
@@ -92,7 +92,7 @@ pub const File = union(enum) {
         return switch (file) {
             .linker_defined => unreachable,
             .shared_object => unreachable,
-            .zig_module => |x| x.atoms.items,
+            .zig_object => |x| x.atoms.items,
             .object => |x| x.atoms.items,
         };
     }
@@ -115,7 +115,7 @@ pub const File = union(enum) {
 
     pub const Entry = union(enum) {
         null: void,
-        zig_module: ZigModule,
+        zig_object: ZigObject,
         linker_defined: LinkerDefined,
         object: Object,
         shared_object: SharedObject,
@@ -132,4 +132,4 @@ const LinkerDefined = @import("LinkerDefined.zig");
 const Object = @import("Object.zig");
 const SharedObject = @import("SharedObject.zig");
 const Symbol = @import("Symbol.zig");
-const ZigModule = @import("ZigModule.zig");
+const ZigObject = @import("ZigObject.zig");


### PR DESCRIPTION
`ZigObject` is effectively equivalent to the final stage of your typical compiler's pipeline when it emits a relocatable object file.