### PR TITLE
io_uring: ring mapped buffers

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -4387,6 +4387,16 @@ pub const io_uring_cqe = extern struct {
         }
         return .SUCCESS;
     }
+
+    // On successful completion of the provided buffers IO request, the CQE flags field
+    // will have IORING_CQE_F_BUFFER set and the selected buffer ID will be indicated by
+    // the upper 16-bits of the flags field.
+    pub fn buffer_id(self: io_uring_cqe) !u16 {
+        if (self.flags & IORING_CQE_F_BUFFER != IORING_CQE_F_BUFFER) {
+            return error.NoBufferSelected;
+        }
+        return @as(u16, @intCast(self.flags >> IORING_CQE_BUFFER_SHIFT));
+    }
 };
 
 // io_uring_cqe.flags
@@ -4667,8 +4677,12 @@ pub const io_uring_buf = extern struct {
     resv: u16,
 };
 
-// io_uring_buf_ring struct omitted
-// it's a io_uring_buf array with the resv of the first item used as a "tail" field.
+pub const io_uring_buf_ring = extern struct {
+    resv1: u64,
+    resv2: u32,
+    resv3: u16,
+    tail: u16,
+};
 
 /// argument for IORING_(UN)REGISTER_PBUF_RING
 pub const io_uring_buf_reg = extern struct {

--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -4139,15 +4139,13 @@ test "ring mapped buffers multishot recv" {
                 cqe_recv = a;
             }
 
-            // Note on differnet kernel results:
+            // Note on different kernel results:
             // on older kernel (tested with v6.0.16, v6.1.57, v6.2.12, v6.4.16)
             //   cqe_cancel.err() == .NOENT
-            //   cqe_crecv.err() == .NOBUFS
+            //   cqe_recv.err() == .NOBUFS
             // on kernel (tested with v6.5.0, v6.5.7)
             //   cqe_cancel.err() == .SUCCESS
-            //   cqe_crecv.err() == .CANCELED
-            //
-            // std.debug.print("cancel: {}, recv: {}\n", .{ cqe_cancel.err(), cqe_recv.err() });
+            //   cqe_recv.err() == .CANCELED
 
             // cancel operation is success (or NOENT on older kernels)
             try testing.expectEqual(cancel_user_data, cqe_cancel.user_data);

--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -4139,17 +4139,24 @@ test "ring mapped buffers multishot recv" {
                 cqe_recv = a;
             }
 
-            // cancel operation is success
-            try testing.expectEqual(cancel_user_data, cqe_cancel.user_data);
-            // NOENT - the request identified by user_data could not be located.
-            if (cqe_cancel.err() != os.E.NOENT) {
-                try testing.expect(cqe_cancel.res == 0);
-            }
+            // Note on differnet kernel results:
+            // on older kernel (tested with v6.0.16, v6.1.57, v6.2.12, v6.4.16)
+            //   cqe_cancel.err() == .NOENT
+            //   cqe_crecv.err() == .NOBUFS
+            // on kernel (tested with v6.5.0, v6.5.7)
+            //   cqe_cancel.err() == .SUCCESS
+            //   cqe_crecv.err() == .CANCELED
+            //
+            // std.debug.print("cancel: {}, recv: {}\n", .{ cqe_cancel.err(), cqe_recv.err() });
 
-            // recv operation is failed with err CANCELED
+            // cancel operation is success (or NOENT on older kernels)
+            try testing.expectEqual(cancel_user_data, cqe_cancel.user_data);
+            try testing.expect(cqe_cancel.err() == .NOENT or cqe_cancel.err() == .SUCCESS);
+
+            // recv operation is failed with err CANCELED (or NOBUFS on older kernels)
             try testing.expectEqual(recv_user_data, cqe_recv.user_data);
             try testing.expect(cqe_recv.res < 0);
-            try testing.expectEqual(os.E.CANCELED, cqe_recv.err());
+            try testing.expect(cqe_recv.err() == .NOBUFS or cqe_recv.err() == .CANCELED);
             try testing.expect(cqe_recv.flags & linux.IORING_CQE_F_MORE == 0);
         }
     }

--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -4140,11 +4140,11 @@ test "ring mapped buffers multishot recv" {
             }
 
             // cancel operation is success
-            try testing.expectEqual(linux.io_uring_cqe{
-                .user_data = cancel_user_data,
-                .res = 0,
-                .flags = 0,
-            }, cqe_cancel);
+            try testing.expectEqual(cancel_user_data, cqe_cancel.user_data);
+            // NOENT - the request identified by user_data could not be located.
+            if (cqe_cancel.err() != os.E.NOENT) {
+                try testing.expect(cqe_cancel.res == 0);
+            }
 
             // recv operation is failed with err CANCELED
             try testing.expectEqual(recv_user_data, cqe_recv.user_data);

--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -1464,7 +1464,7 @@ pub const CompletionQueue = struct {
 ///     const buffers_count: u16 = 256;
 ///     const buffer_size: u32 = 4096;
 ///     const buffers = try allocator.alloc(u8, buffers_count * buffers_size);
-///     var buf_grp = try BuffersGroup.init.ring(&ring, group_id, buffers, buffer_size, buffers_count);
+///     var buf_grp = try BufferGroup.init.ring(&ring, group_id, buffers, buffer_size, buffers_count);
 ///
 ///     // prepare recv on fd with buffer picked from group
 ///     _ = try buf_grp.recv(user_data, fd, 0);

--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -1660,7 +1660,7 @@ pub fn buf_ring_add(
 /// `io_uring_buf_ring_add` has been called `count` times to fill in new buffers.
 pub fn buf_ring_advance(br: *linux.io_uring_buf_ring, count: u16) void {
     const tail: u16 = br.tail +% count;
-    @atomicStore(u16, &br.tail, tail, .Release);
+    @atomicStore(u16, &br.tail, tail, .release);
 }
 
 test "structs/offsets/entries" {

--- a/lib/std/os/linux/io_uring_sqe.zig
+++ b/lib/std/os/linux/io_uring_sqe.zig
@@ -200,6 +200,36 @@ pub const io_uring_sqe = extern struct {
         sqe.rw_flags = flags;
     }
 
+    pub fn prep_recv_multishot(
+        sqe: *linux.io_uring_sqe,
+        fd: os.fd_t,
+        buffer: []u8,
+        flags: u32,
+    ) void {
+        sqe.prep_recv(fd, buffer, flags);
+        sqe.ioprio |= linux.IORING_RECV_MULTISHOT;
+    }
+
+    pub fn prep_recvmsg(
+        sqe: *linux.io_uring_sqe,
+        fd: os.fd_t,
+        msg: *os.msghdr,
+        flags: u32,
+    ) void {
+        sqe.prep_rw(.RECVMSG, fd, @intFromPtr(msg), 1, 0);
+        sqe.rw_flags = flags;
+    }
+
+    pub fn prep_recvmsg_multishot(
+        sqe: *linux.io_uring_sqe,
+        fd: os.fd_t,
+        msg: *os.msghdr,
+        flags: u32,
+    ) void {
+        sqe.prep_recvmsg(fd, msg, flags);
+        sqe.ioprio |= linux.IORING_RECV_MULTISHOT;
+    }
+
     pub fn prep_send(sqe: *linux.io_uring_sqe, fd: os.fd_t, buffer: []const u8, flags: u32) void {
         sqe.prep_rw(.SEND, fd, @intFromPtr(buffer.ptr), buffer.len, 0);
         sqe.rw_flags = flags;
@@ -225,16 +255,6 @@ pub const io_uring_sqe = extern struct {
     ) void {
         prep_sendmsg(sqe, fd, msg, flags);
         sqe.opcode = .SENDMSG_ZC;
-    }
-
-    pub fn prep_recvmsg(
-        sqe: *linux.io_uring_sqe,
-        fd: os.fd_t,
-        msg: *os.msghdr,
-        flags: u32,
-    ) void {
-        sqe.prep_rw(.RECVMSG, fd, @intFromPtr(msg), 1, 0);
-        sqe.rw_flags = flags;
     }
 
     pub fn prep_sendmsg(


### PR DESCRIPTION
Ring mapped buffers are newer implementation of provided buffers, supported since kernel 5.19.
Best described by Jens Axboe in [io_uring and networking in 2023](https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#provided-buffers).  
Newer implementation requires less management, after initial setup, and should be more [efficient](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c7fb19428d67dd0a2a78a4f237af01d39c78dc5a).

This commit implements low level io_uring_buf_ring functions as mostly direct translation from liburing:
* io_uring_setup_buf_ring
* io_uring_free_buf_ring
* io_uring_buf_ring_init
* io_uring_buf_ring_mask
* io_uring_buf_ring_add
* io_uring_buf_ring_advance

Using this functions is little work-some. Application need first to setup_buf_ring, add buffers with appropriate buffer ID, advance to make buffers visible to the kernel, find buffer for buffer ID from the CQE, repeat cycle of add/advance after application wants to return buffer to the kernel and call free_buf_ring at the end.

So I incorporate this low level functions into developer friendly abstraction: BufferGroup. Didn't named it BufferRing or BufRing as in liburing because ring is already overused word in io_uring.zig file. To avoid confusion I stayed away from ring word.

Application provides to the BufferGroup contiguous block of memory of size `buffers_count` * `buffers_size`. It can then use BufferGroup to submit `recv` operation without providing buffer upfront. Once the operation is ready to receive data, a buffer is picked automatically and the resulting CQE will contain the buffer ID in `cqe.buffer_id()`. Use `get` method to get buffer for buffer ID identified by CQE. Once the application has processed the buffer, it may hand ownership back to the kernel, by calling `put` allowing the cycle to repeat.

Example BufferGroup usage: 
```Zig
     // setup buffer group
     const group_id: u16 = 0;
     const buffers_count: u16 = 256;
     const buffer_size: u32 = 4096;
     const buffers = try allocator.alloc(u8, buffers_count * buffers_size);
     var buf_grp = try BufferGroup.init.ring(&ring, group_id, buffers, buffer_size, buffers_count);

     // prepare recv on fd with buffer picked from group
     _ = try buf_grp.recv(user_data, fd, 0);

     // ... when we have completion for recv operation
     // (assuming cqe.err() == .SUCCESS)
     const buffer_id = try cqe.buffer_id();
     const len = @as(usize, @intCast(cqe.res));
     var buf = buf_grp.get(buffer_id)[0..len];
     // ... use buf
     buf_grp.release(buffer_id);

     // ...
     buf_grp.deinit();
```