### PR TITLE
Add a tiny `println` helper that just appends a `\n` to std.debug.print

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -88,6 +88,10 @@ pub fn print(comptime fmt: []const u8, args: anytype) void {
     nosuspend stderr.print(fmt, args) catch return;
 }
 
+pub fn println(comptime fmt: []const u8, args: anytype) void {
+    print(fmt ++ "\n", args);
+}
+
 pub fn getStderrMutex() *std.Thread.Mutex {
     return &stderr_mutex;
 }


### PR DESCRIPTION
`test { }` is supposed to be the shortest REPL-like quick checking, but std.log doesn't print there, while std.debug.print doesn't append newlines.

So the result is I usually end up unnecessarily using `pub fn main() void { }` for even the quickest learning exercises.