### PR TITLE
std.http: account for renames in docs

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -521,7 +521,7 @@ pub const Response = struct {
 
 /// A HTTP request that has been sent.
 ///
-/// Order of operations: request -> start[ -> write -> finish] -> wait -> read
+/// Order of operations: open -> send[ -> write -> finish] -> wait -> read
 pub const Request = struct {
     uri: Uri,
     client: *Client,
@@ -754,7 +754,7 @@ pub const Request = struct {
     /// If `handle_redirects` is true and the request has no payload, then this function will automatically follow
     /// redirects. If a request payload is present, then this function will error with error.RedirectRequiresResend.
     ///
-    /// Must be called after `start` and, if any data was written to the request body, then also after `finish`.
+    /// Must be called after `send` and, if any data was written to the request body, then also after `finish`.
     pub fn wait(req: *Request) WaitError!void {
         while (true) { // handle redirects
             while (true) { // read headers
@@ -943,7 +943,7 @@ pub const Request = struct {
     }
 
     /// Write `bytes` to the server. The `transfer_encoding` field determines how data will be sent.
-    /// Must be called after `start` and before `finish`.
+    /// Must be called after `send` and before `finish`.
     pub fn write(req: *Request, bytes: []const u8) WriteError!usize {
         switch (req.transfer_encoding) {
             .chunked => {
@@ -965,7 +965,7 @@ pub const Request = struct {
     }
 
     /// Write `bytes` to the server. The `transfer_encoding` field determines how data will be sent.
-    /// Must be called after `start` and before `finish`.
+    /// Must be called after `send` and before `finish`.
     pub fn writeAll(req: *Request, bytes: []const u8) WriteError!void {
         var index: usize = 0;
         while (index < bytes.len) {
@@ -976,7 +976,7 @@ pub const Request = struct {
     pub const FinishError = WriteError || error{MessageNotCompleted};
 
     /// Finish the body of a request. This notifies the server that you have no more data to send.
-    /// Must be called after `start`.
+    /// Must be called after `send`.
     pub fn finish(req: *Request) FinishError!void {
         switch (req.transfer_encoding) {
             .chunked => try req.connection.?.writer().writeAll("0\r\n\r\n"),
@@ -1308,7 +1308,7 @@ pub fn connectTunnel(
     };
 }
 
-// Prevents a dependency loop in request()
+// Prevents a dependency loop in open()
 const ConnectErrorPartial = ConnectTcpError || error{ UnsupportedUrlScheme, ConnectionRefused };
 pub const ConnectError = ConnectErrorPartial || RequestError;
 

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -290,7 +290,7 @@ pub const Request = struct {
 /// A HTTP response waiting to be sent.
 ///
 ///                                  [/ <----------------------------------- \]
-/// Order of operations: accept -> wait -> do  [ -> write -> finish][ -> reset /]
+/// Order of operations: accept -> wait -> send  [ -> write -> finish][ -> reset /]
 ///                                   \ -> read /
 pub const Response = struct {
     version: http.Version = .@"HTTP/1.1",
@@ -346,7 +346,7 @@ pub const Response = struct {
         // A connection is only keep-alive if the Connection header is present and it's value is not "close".
         // The server and client must both agree
         //
-        // do() defaults to using keep-alive if the client requests it.
+        // send() defaults to using keep-alive if the client requests it.
         const res_connection = res.headers.getFirstValue("connection");
         const res_keepalive = res_connection != null and !std.ascii.eqlIgnoreCase("close", res_connection.?);
 
@@ -610,7 +610,7 @@ pub const Response = struct {
     }
 
     /// Write `bytes` to the server. The `transfer_encoding` request header determines how data will be sent.
-    /// Must be called after `start` and before `finish`.
+    /// Must be called after `send` and before `finish`.
     pub fn write(res: *Response, bytes: []const u8) WriteError!usize {
         switch (res.state) {
             .responded => {},
@@ -637,7 +637,7 @@ pub const Response = struct {
     }
 
     /// Write `bytes` to the server. The `transfer_encoding` request header determines how data will be sent.
-    /// Must be called after `start` and before `finish`.
+    /// Must be called after `send` and before `finish`.
     pub fn writeAll(req: *Response, bytes: []const u8) WriteError!void {
         var index: usize = 0;
         while (index < bytes.len) {
@@ -648,7 +648,7 @@ pub const Response = struct {
     pub const FinishError = WriteError || error{MessageNotCompleted};
 
     /// Finish the body of a request. This notifies the server that you have no more data to send.
-    /// Must be called after `start`.
+    /// Must be called after `send`.
     pub fn finish(res: *Response) FinishError!void {
         switch (res.state) {
             .responded => res.state = .finished,


### PR DESCRIPTION
While learning `std.http` server and client, noticed some docs referenced nonexistent names. Traced it to a commit in #17407. Changed the docs to account for the renames.