### PR TITLE
wasm-linker: implement `-fno-entry` and correctly pass `--shared` and `--pie` when given

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -11336,12 +11336,12 @@ all your base are belong to us{#end_shell_samp#}
       {#header_open|WebAssembly#}
       <p>Zig supports building for WebAssembly out of the box.</p>
       {#header_open|Freestanding#}
-      <p>For host environments like the web browser and nodejs, build as a dynamic library using the freestanding
+      <p>For host environments like the web browser and nodejs, build as an executable using the freestanding
       OS target. Here's an example of running Zig code compiled to WebAssembly with nodejs.</p>
-      {#code_begin|lib|math#}
+      {#code_begin|exe|math#}
       {#target_wasm#}
-      {#link_mode_dynamic#}
-      {#additonal_option|-rdynamic#}
+      {#additonal_option|-fno-entry#}
+      {#additonal_option|--export=add#}
 extern fn print(i32) void;
 
 export fn add(a: i32, b: i32) void {

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -64,6 +64,8 @@ initial_memory: ?u64 = null,
 max_memory: ?u64 = null,
 shared_memory: bool = false,
 global_base: ?u64 = null,
+/// For WebAssembly only. Tells the linker to not output an entry point.
+no_entry: ?bool = null,
 c_std: std.Build.CStd,
 /// Set via options; intended to be read-only after that.
 zig_lib_dir: ?LazyPath,
@@ -1851,6 +1853,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     if (self.global_base) |global_base| {
         try zig_args.append(b.fmt("--global-base={d}", .{global_base}));
     }
+    try addFlag(&zig_args, "entry", self.no_entry);
 
     if (self.code_model != .default) {
         try zig_args.append("-mcmodel");

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -64,8 +64,6 @@ initial_memory: ?u64 = null,
 max_memory: ?u64 = null,
 shared_memory: bool = false,
 global_base: ?u64 = null,
-/// For WebAssembly only. Tells the linker to not output an entry point.
-no_entry: ?bool = null,
 c_std: std.Build.CStd,
 /// Set via options; intended to be read-only after that.
 zig_lib_dir: ?LazyPath,
@@ -191,7 +189,8 @@ dll_export_fns: ?bool = null,
 
 subsystem: ?std.Target.SubSystem = null,
 
-entry_symbol_name: ?[]const u8 = null,
+/// How the linker must handle the entry point of the executable.
+entry: Entry = .default,
 
 /// List of symbols forced as undefined in the symbol table
 /// thus forcing their resolution by the linker.
@@ -304,6 +303,18 @@ pub const SystemLib = struct {
 const FrameworkLinkInfo = struct {
     needed: bool = false,
     weak: bool = false,
+};
+
+const Entry = union(enum) {
+    /// Let the compiler decide whether to make an entry point and what to name
+    /// it.
+    default,
+    /// The executable will have no entry point.
+    disabled,
+    /// The executable will have an entry point with the default symbol name.
+    enabled,
+    /// The executable will have an entry point with the specified symbol name.
+    symbol_name: []const u8,
 };
 
 pub const IncludeDir = union(enum) {
@@ -1420,9 +1431,13 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         try zig_args.append(try std.fmt.allocPrint(b.allocator, "-ofmt={s}", .{@tagName(ofmt)}));
     }
 
-    if (self.entry_symbol_name) |entry| {
-        try zig_args.append("--entry");
-        try zig_args.append(entry);
+    switch (self.entry) {
+        .default => {},
+        .disabled => try zig_args.append("-fno-entry"),
+        .enabled => try zig_args.append("-fentry"),
+        .symbol_name => |entry_name| {
+            try zig_args.append(try std.fmt.allocPrint(b.allocator, "-fentry={s}", .{entry_name}));
+        },
     }
 
     {
@@ -1852,11 +1867,6 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     }
     if (self.global_base) |global_base| {
         try zig_args.append(b.fmt("--global-base={d}", .{global_base}));
-    }
-    // invert the value due to naming so when `no_entry` is set to 'true'
-    // we actually emit the flag `-fno_entry`.
-    if (self.no_entry) |no_entry| {
-        try addFlag(&zig_args, "entry", !no_entry);
     }
 
     if (self.code_model != .default) {

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1853,7 +1853,11 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     if (self.global_base) |global_base| {
         try zig_args.append(b.fmt("--global-base={d}", .{global_base}));
     }
-    try addFlag(&zig_args, "entry", self.no_entry);
+    // invert the value due to naming so when `no_entry` is set to 'true'
+    // we actually emit the flag `-fno_entry`.
+    if (self.no_entry) |no_entry| {
+        try addFlag(&zig_args, "entry", !no_entry);
+    }
 
     if (self.code_model != .default) {
         try zig_args.append("-mcmodel");

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -82,11 +82,15 @@ comptime {
                     .reactor => "_initialize",
                     .command => "_start",
                 };
-                if (!@hasDecl(root, wasm_start_sym)) {
+                if (!@hasDecl(root, wasm_start_sym) and @hasDecl(root, "main")) {
+                    // Only call main when defined. For WebAssembly it's allowed to pass `-fno-entry` in which
+                    // case it's not required to provide an entrypoint such as main.
                     @export(wasi_start, .{ .name = wasm_start_sym });
                 }
             } else if (native_arch.isWasm() and native_os == .freestanding) {
-                if (!@hasDecl(root, start_sym_name)) @export(wasm_freestanding_start, .{ .name = start_sym_name });
+                // Only call main when defined. For WebAssembly it's allowed to pass `-fno-entry` in which
+                // case it's not required to provide an entrypoint such as main.
+                if (!@hasDecl(root, start_sym_name) and @hasDecl(root, "main")) @export(wasm_freestanding_start, .{ .name = start_sym_name });
             } else if (native_os != .other and native_os != .freestanding) {
                 if (!@hasDecl(root, start_sym_name)) @export(_start, .{ .name = start_sym_name });
             }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -643,7 +643,6 @@ pub const InitOptions = struct {
     linker_import_symbols: bool = false,
     linker_import_table: bool = false,
     linker_export_table: bool = false,
-    linker_no_entry: bool = false,
     linker_initial_memory: ?u64 = null,
     linker_max_memory: ?u64 = null,
     linker_shared_memory: bool = false,
@@ -1615,7 +1614,6 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .import_symbols = options.linker_import_symbols,
             .import_table = options.linker_import_table,
             .export_table = options.linker_export_table,
-            .no_entry = options.linker_no_entry,
             .initial_memory = options.linker_initial_memory,
             .max_memory = options.linker_max_memory,
             .shared_memory = options.linker_shared_memory,
@@ -2579,7 +2577,6 @@ fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifes
     man.hash.addOptional(comp.bin_file.options.max_memory);
     man.hash.add(comp.bin_file.options.shared_memory);
     man.hash.addOptional(comp.bin_file.options.global_base);
-    man.hash.add(comp.bin_file.options.no_entry);
 
     // Mach-O specific stuff
     man.hash.addListOfBytes(comp.bin_file.options.framework_dirs);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -643,6 +643,7 @@ pub const InitOptions = struct {
     linker_import_symbols: bool = false,
     linker_import_table: bool = false,
     linker_export_table: bool = false,
+    linker_no_entry: bool = false,
     linker_initial_memory: ?u64 = null,
     linker_max_memory: ?u64 = null,
     linker_shared_memory: bool = false,
@@ -1614,6 +1615,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
             .import_symbols = options.linker_import_symbols,
             .import_table = options.linker_import_table,
             .export_table = options.linker_export_table,
+            .no_entry = options.linker_no_entry,
             .initial_memory = options.linker_initial_memory,
             .max_memory = options.linker_max_memory,
             .shared_memory = options.linker_shared_memory,
@@ -2577,6 +2579,7 @@ fn addNonIncrementalStuffToCacheManifest(comp: *Compilation, man: *Cache.Manifes
     man.hash.addOptional(comp.bin_file.options.max_memory);
     man.hash.add(comp.bin_file.options.shared_memory);
     man.hash.addOptional(comp.bin_file.options.global_base);
+    man.hash.add(comp.bin_file.options.no_entry);
 
     // Mach-O specific stuff
     man.hash.addListOfBytes(comp.bin_file.options.framework_dirs);

--- a/src/link.zig
+++ b/src/link.zig
@@ -166,6 +166,7 @@ pub const Options = struct {
     export_table: bool,
     initial_memory: ?u64,
     max_memory: ?u64,
+    no_entry: bool,
     shared_memory: bool,
     export_symbol_names: []const []const u8,
     global_base: ?u64,

--- a/src/link.zig
+++ b/src/link.zig
@@ -166,7 +166,6 @@ pub const Options = struct {
     export_table: bool,
     initial_memory: ?u64,
     max_memory: ?u64,
-    no_entry: bool,
     shared_memory: bool,
     export_symbol_names: []const []const u8,
     global_base: ?u64,

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -4548,6 +4548,13 @@ fn linkWithLLD(wasm: *Wasm, comp: *Compilation, prog_node: *std.Progress.Node) !
             try argv.append("--no-entry");
         }
 
+        if (wasm.base.options.output_mode == .Lib and wasm.base.options.link_mode == .Dynamic) {
+            try argv.append("--shared");
+        }
+        if (wasm.base.options.pie) {
+            try argv.append("--pie");
+        }
+
         // XXX - TODO: add when wasm-ld supports --build-id.
         // if (wasm.base.options.build_id) {
         //     try argv.append("--build-id=tree");

--- a/src/main.zig
+++ b/src/main.zig
@@ -509,7 +509,9 @@ const usage_build_generic =
     \\  --dynamic-linker [path]        Set the dynamic interpreter path (usually ld.so)
     \\  --sysroot [path]               Set the system root directory (usually /)
     \\  --version [ver]                Dynamic library semver
-    \\  --entry [name]                 Set the entrypoint symbol name
+    \\  -fentry                        Enable entry point with default symbol name
+    \\  -fentry=[name]                 Override the entry point symbol name
+    \\  -fno-entry                     Do not output any entry point
     \\  --force_undefined [name]       Specify the symbol must be defined for the link to succeed
     \\  -fsoname[=name]                Override the default SONAME value
     \\  -fno-soname                    Disable emitting a SONAME
@@ -577,8 +579,6 @@ const usage_build_generic =
     \\  --shared-memory                (WebAssembly) use shared linear memory
     \\  --global-base=[addr]           (WebAssembly) where to start to place global data
     \\  --export=[value]               (WebAssembly) Force a symbol to be exported
-    \\  -fentry                        (WebAssembly) Force output an entry point
-    \\  -fno-entry                     (WebAssembly) Do not output any entry point
     \\
     \\Test Options:
     \\  --test-filter [text]           Skip tests that do not match filter
@@ -837,7 +837,7 @@ fn buildOutputType(
     var linker_import_symbols: bool = false;
     var linker_import_table: bool = false;
     var linker_export_table: bool = false;
-    var linker_no_entry: ?bool = null;
+    var linker_force_entry: ?bool = null;
     var linker_initial_memory: ?u64 = null;
     var linker_max_memory: ?u64 = null;
     var linker_shared_memory: bool = false;
@@ -1074,8 +1074,8 @@ fn buildOutputType(
                         subsystem = try parseSubSystem(args_iter.nextOrFatal());
                     } else if (mem.eql(u8, arg, "-O")) {
                         optimize_mode_string = args_iter.nextOrFatal();
-                    } else if (mem.eql(u8, arg, "--entry")) {
-                        entry = args_iter.nextOrFatal();
+                    } else if (mem.startsWith(u8, arg, "-fentry=")) {
+                        entry = arg["-fentry=".len..];
                     } else if (mem.eql(u8, arg, "--force_undefined")) {
                         try force_undefined_symbols.put(gpa, args_iter.nextOrFatal(), {});
                     } else if (mem.eql(u8, arg, "--stack")) {
@@ -1507,9 +1507,9 @@ fn buildOutputType(
                     } else if (mem.eql(u8, arg, "--import-memory")) {
                         linker_import_memory = true;
                     } else if (mem.eql(u8, arg, "-fentry")) {
-                        linker_no_entry = false;
+                        linker_force_entry = true;
                     } else if (mem.eql(u8, arg, "-fno-entry")) {
-                        linker_no_entry = true;
+                        linker_force_entry = false;
                     } else if (mem.eql(u8, arg, "--export-memory")) {
                         linker_export_memory = true;
                     } else if (mem.eql(u8, arg, "--import-symbols")) {
@@ -2142,7 +2142,7 @@ fn buildOutputType(
                 } else if (mem.eql(u8, arg, "--export-table")) {
                     linker_export_table = true;
                 } else if (mem.eql(u8, arg, "--no-entry")) {
-                    linker_no_entry = true;
+                    linker_force_entry = false;
                 } else if (mem.eql(u8, arg, "--initial-memory")) {
                     const next_arg = linker_args_it.nextOrFatal();
                     linker_initial_memory = std.fmt.parseUnsigned(u32, eatIntPrefix(next_arg, 16), 16) catch |err| {
@@ -2605,6 +2605,23 @@ fn buildOutputType(
             link_libcpp = true;
     }
 
+    if (linker_force_entry) |force| {
+        if (!force) {
+            entry = null;
+        } else if (entry == null and output_mode == .Exe) {
+            entry = switch (target_info.target.ofmt) {
+                .coff => "wWinMainCRTStartup",
+                .macho => "_main",
+                .elf, .plan9 => "_start",
+                .wasm => defaultWasmEntryName(wasi_exec_model),
+                else => |tag| fatal("No default entry point available for output format {s}", .{@tagName(tag)}),
+            };
+        }
+    } else if (entry == null and target_info.target.isWasm() and output_mode == .Exe) {
+        // For WebAssembly the compiler defaults to setting the entry name when no flags are set.
+        entry = defaultWasmEntryName(wasi_exec_model);
+    }
+
     if (target_info.target.ofmt == .coff) {
         // Now that we know the target supports resources,
         // we can add the res files as link objects.
@@ -2637,23 +2654,11 @@ fn buildOutputType(
                 linker_export_memory = false;
             }
         }
-        if (wasi_exec_model) |model| {
-            if (model == .reactor) {
-                if (linker_no_entry != null and !linker_no_entry.?) {
-                    fatal("WASI exucution model 'reactor' incompatible with flag '-fentry'. Reactor execution model has no entry point", .{});
+        if (wasi_exec_model != null and wasi_exec_model.? == .reactor) {
+            if (entry) |entry_name| {
+                if (!mem.eql(u8, "_initialize", entry_name)) {
+                    fatal("the entry symbol of the reactor model must be '_initialize', but found '{s}'", .{entry_name});
                 }
-                if (entry) |entry_name| {
-                    if (!mem.eql(u8, "_initialize", entry_name)) {
-                        fatal("the entry symbol of the reactor model must be '_initialize', but found '{s}'", .{entry_name});
-                    }
-                } else {
-                    entry = "_initialize";
-                }
-            }
-        }
-        if (linker_no_entry) |no_entry| {
-            if (no_entry and entry != null) {
-                fatal("combination of '--entry' and `-fno-entry` are incompatible", .{});
             }
         }
         if (linker_shared_memory) {
@@ -3503,7 +3508,6 @@ fn buildOutputType(
         .linker_import_symbols = linker_import_symbols,
         .linker_import_table = linker_import_table,
         .linker_export_table = linker_export_table,
-        .linker_no_entry = linker_no_entry orelse false,
         .linker_initial_memory = linker_initial_memory,
         .linker_max_memory = linker_max_memory,
         .linker_shared_memory = linker_shared_memory,
@@ -7252,4 +7256,12 @@ fn createDependenciesModule(
     });
     try main_mod.deps.put(arena, "@dependencies", deps_mod);
     return deps_mod;
+}
+
+fn defaultWasmEntryName(exec_model: ?std.builtin.WasiExecModel) []const u8 {
+    const model = exec_model orelse .command;
+    if (model == .reactor) {
+        return "_initialize";
+    }
+    return "_start";
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -2627,6 +2627,16 @@ fn buildOutputType(
         if (single_threaded == null) {
             single_threaded = true;
         }
+        if (link_mode) |mode| {
+            if (mode == .Dynamic) {
+                if (linker_export_memory != null and linker_export_memory.?) {
+                    fatal("flags '-dynamic' and '--export-memory' are incompatible", .{});
+                }
+                // User did not supply `--export-memory` which is incompatible with -dynamic, therefore
+                // set the flag to false to ensure it does not get enabled by default.
+                linker_export_memory = false;
+            }
+        }
         if (wasi_exec_model) |model| {
             if (model == .reactor) {
                 if (linker_no_entry != null and !linker_no_entry.?) {

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -651,7 +651,7 @@ fn testEntryPoint(b: *Build, opts: Options) *Step {
         const exe = addExecutable(b, "main", opts);
         exe.addObject(a_o);
         exe.addObject(b_o);
-        exe.entry_symbol_name = "foo";
+        exe.entry = .{ .symbol_name = "foo" };
 
         const check = exe.checkObject();
         check.checkStart();
@@ -667,7 +667,7 @@ fn testEntryPoint(b: *Build, opts: Options) *Step {
         const exe = addExecutable(b, "other", opts);
         exe.addObject(a_o);
         exe.addObject(b_o);
-        exe.entry_symbol_name = "bar";
+        exe.entry = .{ .symbol_name = "bar" };
 
         const check = exe.checkObject();
         check.checkStart();

--- a/test/link/macho/entry/build.zig
+++ b/test/link/macho/entry/build.zig
@@ -20,7 +20,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     });
     exe.addCSourceFile(.{ .file = .{ .path = "main.c" }, .flags = &.{} });
     exe.linkLibC();
-    exe.entry_symbol_name = "_non_main";
+    exe.entry = .{ .symbol_name = "_non_main" };
 
     const check_exe = exe.checkObject();
 

--- a/test/link/macho/entry_in_dylib/build.zig
+++ b/test/link/macho/entry_in_dylib/build.zig
@@ -30,7 +30,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.addCSourceFile(.{ .file = .{ .path = "main.c" }, .flags = &.{} });
     exe.linkLibrary(lib);
     exe.linkLibC();
-    exe.entry_symbol_name = "_bootstrap";
+    exe.entry = .{ .symbol_name = "_bootstrap" };
     exe.forceUndefinedSymbol("_my_main");
 
     const check_exe = exe.checkObject();

--- a/test/link/wasm/archive/build.zig
+++ b/test/link/wasm/archive/build.zig
@@ -21,7 +21,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .optimize = optimize,
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
     });
-    lib.no_entry = true;
+    lib.entry = .disabled;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.strip = false;

--- a/test/link/wasm/archive/build.zig
+++ b/test/link/wasm/archive/build.zig
@@ -15,12 +15,13 @@ pub fn build(b: *std.Build) void {
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
     // The code in question will pull-in compiler-rt,
     // and therefore link with its archive file.
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addExecutable(.{
         .name = "main",
         .root_source_file = .{ .path = "main.zig" },
         .optimize = optimize,
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
     });
+    lib.no_entry = true;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.strip = false;

--- a/test/link/wasm/basic-features/build.zig
+++ b/test/link/wasm/basic-features/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
             .os_tag = .freestanding,
         },
     });
-    lib.no_entry = true;
+    lib.entry = .disabled;
     lib.use_llvm = false;
     lib.use_lld = false;
 

--- a/test/link/wasm/basic-features/build.zig
+++ b/test/link/wasm/basic-features/build.zig
@@ -4,7 +4,7 @@ pub const requires_stage2 = true;
 
 pub fn build(b: *std.Build) void {
     // Library with explicitly set cpu features
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addExecutable(.{
         .name = "lib",
         .root_source_file = .{ .path = "main.zig" },
         .optimize = .Debug,
@@ -15,6 +15,7 @@ pub fn build(b: *std.Build) void {
             .os_tag = .freestanding,
         },
     });
+    lib.no_entry = true;
     lib.use_llvm = false;
     lib.use_lld = false;
 

--- a/test/link/wasm/bss/build.zig
+++ b/test/link/wasm/bss/build.zig
@@ -20,7 +20,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.Opt
             .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
             .optimize = optimize_mode,
         });
-        lib.no_entry = true;
+        lib.entry = .disabled;
         lib.use_llvm = false;
         lib.use_lld = false;
         lib.strip = false;
@@ -67,7 +67,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.Opt
             .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
             .optimize = optimize_mode,
         });
-        lib.no_entry = true;
+        lib.entry = .disabled;
         lib.use_llvm = false;
         lib.use_lld = false;
         lib.strip = false;

--- a/test/link/wasm/bss/build.zig
+++ b/test/link/wasm/bss/build.zig
@@ -14,12 +14,13 @@ pub fn build(b: *std.Build) void {
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.OptimizeMode, is_safe: bool) void {
     {
-        const lib = b.addSharedLibrary(.{
+        const lib = b.addExecutable(.{
             .name = "lib",
             .root_source_file = .{ .path = "lib.zig" },
             .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
             .optimize = optimize_mode,
         });
+        lib.no_entry = true;
         lib.use_llvm = false;
         lib.use_lld = false;
         lib.strip = false;
@@ -60,12 +61,13 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.Opt
 
     // verify zero'd declaration is stored in bss for all optimization modes.
     {
-        const lib = b.addSharedLibrary(.{
+        const lib = b.addExecutable(.{
             .name = "lib",
             .root_source_file = .{ .path = "lib2.zig" },
             .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
             .optimize = optimize_mode,
         });
+        lib.no_entry = true;
         lib.use_llvm = false;
         lib.use_lld = false;
         lib.strip = false;

--- a/test/link/wasm/export-data/build.zig
+++ b/test/link/wasm/export-data/build.zig
@@ -9,12 +9,13 @@ pub fn build(b: *std.Build) void {
         return;
     }
 
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addExecutable(.{
         .name = "lib",
         .root_source_file = .{ .path = "lib.zig" },
         .optimize = .ReleaseSafe, // to make the output deterministic in address positions
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
     });
+    lib.no_entry = true;
     lib.use_lld = false;
     lib.export_symbol_names = &.{ "foo", "bar" };
     lib.global_base = 0; // put data section at address 0 to make data symbols easier to parse

--- a/test/link/wasm/export-data/build.zig
+++ b/test/link/wasm/export-data/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
         .optimize = .ReleaseSafe, // to make the output deterministic in address positions
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
     });
-    lib.no_entry = true;
+    lib.entry = .disabled;
     lib.use_lld = false;
     lib.export_symbol_names = &.{ "foo", "bar" };
     lib.global_base = 0; // put data section at address 0 to make data symbols easier to parse

--- a/test/link/wasm/export/build.zig
+++ b/test/link/wasm/export/build.zig
@@ -19,7 +19,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .optimize = optimize,
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
     });
-    no_export.no_entry = true;
+    no_export.entry = .disabled;
     no_export.use_llvm = false;
     no_export.use_lld = false;
 
@@ -29,7 +29,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .optimize = optimize,
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
     });
-    dynamic_export.no_entry = true;
+    dynamic_export.entry = .disabled;
     dynamic_export.rdynamic = true;
     dynamic_export.use_llvm = false;
     dynamic_export.use_lld = false;
@@ -40,7 +40,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .optimize = optimize,
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
     });
-    force_export.no_entry = true;
+    force_export.entry = .disabled;
     force_export.export_symbol_names = &.{"foo"};
     force_export.use_llvm = false;
     force_export.use_lld = false;

--- a/test/link/wasm/export/build.zig
+++ b/test/link/wasm/export/build.zig
@@ -13,31 +13,34 @@ pub fn build(b: *std.Build) void {
 }
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
-    const no_export = b.addSharedLibrary(.{
+    const no_export = b.addExecutable(.{
         .name = "no-export",
         .root_source_file = .{ .path = "main.zig" },
         .optimize = optimize,
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
     });
+    no_export.no_entry = true;
     no_export.use_llvm = false;
     no_export.use_lld = false;
 
-    const dynamic_export = b.addSharedLibrary(.{
+    const dynamic_export = b.addExecutable(.{
         .name = "dynamic",
         .root_source_file = .{ .path = "main.zig" },
         .optimize = optimize,
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
     });
+    dynamic_export.no_entry = true;
     dynamic_export.rdynamic = true;
     dynamic_export.use_llvm = false;
     dynamic_export.use_lld = false;
 
-    const force_export = b.addSharedLibrary(.{
+    const force_export = b.addExecutable(.{
         .name = "force",
         .root_source_file = .{ .path = "main.zig" },
         .optimize = optimize,
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
     });
+    force_export.no_entry = true;
     force_export.export_symbol_names = &.{"foo"};
     force_export.use_llvm = false;
     force_export.use_lld = false;

--- a/test/link/wasm/extern-mangle/build.zig
+++ b/test/link/wasm/extern-mangle/build.zig
@@ -11,12 +11,13 @@ pub fn build(b: *std.Build) void {
 }
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addExecutable(.{
         .name = "lib",
         .root_source_file = .{ .path = "lib.zig" },
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
+    lib.no_entry = true;
     lib.import_symbols = true; // import `a` and `b`
     lib.rdynamic = true; // export `foo`
 

--- a/test/link/wasm/extern-mangle/build.zig
+++ b/test/link/wasm/extern-mangle/build.zig
@@ -17,7 +17,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
-    lib.no_entry = true;
+    lib.entry = .disabled;
     lib.import_symbols = true; // import `a` and `b`
     lib.rdynamic = true; // export `foo`
 

--- a/test/link/wasm/function-table/build.zig
+++ b/test/link/wasm/function-table/build.zig
@@ -13,32 +13,35 @@ pub fn build(b: *std.Build) void {
 }
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
-    const import_table = b.addSharedLibrary(.{
+    const import_table = b.addExecutable(.{
         .name = "import_table",
         .root_source_file = .{ .path = "lib.zig" },
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
+    import_table.no_entry = true;
     import_table.use_llvm = false;
     import_table.use_lld = false;
     import_table.import_table = true;
 
-    const export_table = b.addSharedLibrary(.{
+    const export_table = b.addExecutable(.{
         .name = "export_table",
         .root_source_file = .{ .path = "lib.zig" },
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
+    export_table.no_entry = true;
     export_table.use_llvm = false;
     export_table.use_lld = false;
     export_table.export_table = true;
 
-    const regular_table = b.addSharedLibrary(.{
+    const regular_table = b.addExecutable(.{
         .name = "regular_table",
         .root_source_file = .{ .path = "lib.zig" },
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
+    regular_table.no_entry = true;
     regular_table.use_llvm = false;
     regular_table.use_lld = false;
 

--- a/test/link/wasm/function-table/build.zig
+++ b/test/link/wasm/function-table/build.zig
@@ -19,7 +19,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
-    import_table.no_entry = true;
+    import_table.entry = .disabled;
     import_table.use_llvm = false;
     import_table.use_lld = false;
     import_table.import_table = true;
@@ -30,7 +30,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
-    export_table.no_entry = true;
+    export_table.entry = .disabled;
     export_table.use_llvm = false;
     export_table.use_lld = false;
     export_table.export_table = true;
@@ -41,7 +41,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
-    regular_table.no_entry = true;
+    regular_table.entry = .disabled;
     regular_table.use_llvm = false;
     regular_table.use_lld = false;
 

--- a/test/link/wasm/infer-features/build.zig
+++ b/test/link/wasm/infer-features/build.zig
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) void {
             .os_tag = .freestanding,
         },
     });
-    lib.no_entry = true;
+    lib.entry = .disabled;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.addObject(c_obj);

--- a/test/link/wasm/infer-features/build.zig
+++ b/test/link/wasm/infer-features/build.zig
@@ -17,7 +17,7 @@ pub fn build(b: *std.Build) void {
 
     // Wasm library that doesn't have any features specified. This will
     // infer its featureset from other linked object files.
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addExecutable(.{
         .name = "lib",
         .root_source_file = .{ .path = "main.zig" },
         .optimize = .Debug,
@@ -27,6 +27,7 @@ pub fn build(b: *std.Build) void {
             .os_tag = .freestanding,
         },
     });
+    lib.no_entry = true;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.addObject(c_obj);

--- a/test/link/wasm/producers/build.zig
+++ b/test/link/wasm/producers/build.zig
@@ -14,12 +14,13 @@ pub fn build(b: *std.Build) void {
 }
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addExecutable(.{
         .name = "lib",
         .root_source_file = .{ .path = "lib.zig" },
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
+    lib.no_entry = true;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.strip = false;

--- a/test/link/wasm/producers/build.zig
+++ b/test/link/wasm/producers/build.zig
@@ -20,7 +20,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
-    lib.no_entry = true;
+    lib.entry = .disabled;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.strip = false;

--- a/test/link/wasm/segments/build.zig
+++ b/test/link/wasm/segments/build.zig
@@ -13,12 +13,13 @@ pub fn build(b: *std.Build) void {
 }
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addExecutable(.{
         .name = "lib",
         .root_source_file = .{ .path = "lib.zig" },
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
+    lib.no_entry = true;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.strip = false;

--- a/test/link/wasm/segments/build.zig
+++ b/test/link/wasm/segments/build.zig
@@ -19,7 +19,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
-    lib.no_entry = true;
+    lib.entry = .disabled;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.strip = false;

--- a/test/link/wasm/shared-memory/build.zig
+++ b/test/link/wasm/shared-memory/build.zig
@@ -11,88 +11,87 @@ pub fn build(b: *std.Build) void {
 }
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.OptimizeMode) void {
-    {
-        const lib = b.addSharedLibrary(.{
-            .name = "lib",
-            .root_source_file = .{ .path = "lib.zig" },
-            .target = .{
-                .cpu_arch = .wasm32,
-                .cpu_model = .{ .explicit = &std.Target.wasm.cpu.mvp },
-                .cpu_features_add = std.Target.wasm.featureSet(&.{ .atomics, .bulk_memory }),
-                .os_tag = .freestanding,
-            },
-            .optimize = optimize_mode,
-        });
-        lib.use_lld = false;
-        lib.strip = false;
-        lib.import_memory = true;
-        lib.export_memory = true;
-        lib.shared_memory = true;
-        lib.max_memory = 67108864;
-        lib.single_threaded = false;
-        lib.export_symbol_names = &.{"foo"};
+    const lib = b.addExecutable(.{
+        .name = "lib",
+        .root_source_file = .{ .path = "lib.zig" },
+        .target = .{
+            .cpu_arch = .wasm32,
+            .cpu_model = .{ .explicit = &std.Target.wasm.cpu.mvp },
+            .cpu_features_add = std.Target.wasm.featureSet(&.{ .atomics, .bulk_memory }),
+            .os_tag = .freestanding,
+        },
+        .optimize = optimize_mode,
+    });
+    lib.no_entry = true;
+    lib.use_lld = false;
+    lib.strip = false;
+    lib.import_memory = true;
+    lib.export_memory = true;
+    lib.shared_memory = true;
+    lib.max_memory = 67108864;
+    lib.single_threaded = false;
+    lib.export_symbol_names = &.{"foo"};
 
-        const check_lib = lib.checkObject();
+    const check_lib = lib.checkObject();
 
-        check_lib.checkStart("Section import");
-        check_lib.checkNext("entries 1");
-        check_lib.checkNext("module env");
-        check_lib.checkNext("name memory"); // ensure we are importing memory
+    check_lib.checkStart("Section import");
+    check_lib.checkNext("entries 1");
+    check_lib.checkNext("module env");
+    check_lib.checkNext("name memory"); // ensure we are importing memory
 
-        check_lib.checkStart("Section export");
-        check_lib.checkNext("entries 2");
-        check_lib.checkNext("name memory"); // ensure we also export memory again
+    check_lib.checkStart("Section export");
+    check_lib.checkNext("entries 2");
+    check_lib.checkNext("name memory"); // ensure we also export memory again
 
-        // This section *must* be emit as the start function is set to the index
-        // of __wasm_init_memory
-        // release modes will have the TLS segment optimized out in our test-case.
-        // This means we won't have __wasm_init_memory in such case, and therefore
-        // should also not have a section "start"
-        if (optimize_mode == .Debug) {
-            check_lib.checkStart("Section start");
-        }
-
-        // This section is only and *must* be emit when shared-memory is enabled
-        // release modes will have the TLS segment optimized out in our test-case.
-        if (optimize_mode == .Debug) {
-            check_lib.checkStart("Section data_count");
-            check_lib.checkNext("count 3");
-        }
-
-        check_lib.checkStart("Section custom");
-        check_lib.checkNext("name name");
-        check_lib.checkNext("type function");
-        if (optimize_mode == .Debug) {
-            check_lib.checkNext("name __wasm_init_memory");
-        }
-        check_lib.checkNext("name __wasm_init_tls");
-        check_lib.checkNext("type global");
-
-        // In debug mode the symbol __tls_base is resolved to an undefined symbol
-        // from the object file, hence its placement differs than in release modes
-        // where the entire tls segment is optimized away, and tls_base will have
-        // its original position.
-        if (optimize_mode == .Debug) {
-            check_lib.checkNext("name __tls_size");
-            check_lib.checkNext("name __tls_align");
-            check_lib.checkNext("name __tls_base");
-        } else {
-            check_lib.checkNext("name __tls_base");
-            check_lib.checkNext("name __tls_size");
-            check_lib.checkNext("name __tls_align");
-        }
-
-        check_lib.checkNext("type data_segment");
-        if (optimize_mode == .Debug) {
-            check_lib.checkNext("names 3");
-            check_lib.checkNext("index 0");
-            check_lib.checkNext("name .rodata");
-            check_lib.checkNext("index 1");
-            check_lib.checkNext("name .bss");
-            check_lib.checkNext("index 2");
-            check_lib.checkNext("name .tdata");
-        }
-
-        test_step.dependOn(&check_lib.step);
+    // This section *must* be emit as the start function is set to the index
+    // of __wasm_init_memory
+    // release modes will have the TLS segment optimized out in our test-case.
+    // This means we won't have __wasm_init_memory in such case, and therefore
+    // should also not have a section "start"
+    if (optimize_mode == .Debug) {
+        check_lib.checkStart("Section start");
     }
+
+    // This section is only and *must* be emit when shared-memory is enabled
+    // release modes will have the TLS segment optimized out in our test-case.
+    if (optimize_mode == .Debug) {
+        check_lib.checkStart("Section data_count");
+        check_lib.checkNext("count 3");
+    }
+
+    check_lib.checkStart("Section custom");
+    check_lib.checkNext("name name");
+    check_lib.checkNext("type function");
+    if (optimize_mode == .Debug) {
+        check_lib.checkNext("name __wasm_init_memory");
+    }
+    check_lib.checkNext("name __wasm_init_tls");
+    check_lib.checkNext("type global");
+
+    // In debug mode the symbol __tls_base is resolved to an undefined symbol
+    // from the object file, hence its placement differs than in release modes
+    // where the entire tls segment is optimized away, and tls_base will have
+    // its original position.
+    if (optimize_mode == .Debug) {
+        check_lib.checkNext("name __tls_size");
+        check_lib.checkNext("name __tls_align");
+        check_lib.checkNext("name __tls_base");
+    } else {
+        check_lib.checkNext("name __tls_base");
+        check_lib.checkNext("name __tls_size");
+        check_lib.checkNext("name __tls_align");
+    }
+
+    check_lib.checkNext("type data_segment");
+    if (optimize_mode == .Debug) {
+        check_lib.checkNext("names 3");
+        check_lib.checkNext("index 0");
+        check_lib.checkNext("name .rodata");
+        check_lib.checkNext("index 1");
+        check_lib.checkNext("name .bss");
+        check_lib.checkNext("index 2");
+        check_lib.checkNext("name .tdata");
+    }
+
+    test_step.dependOn(&check_lib.step);
 }

--- a/test/link/wasm/shared-memory/build.zig
+++ b/test/link/wasm/shared-memory/build.zig
@@ -22,7 +22,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.Opt
         },
         .optimize = optimize_mode,
     });
-    lib.no_entry = true;
+    lib.entry = .disabled;
     lib.use_lld = false;
     lib.strip = false;
     lib.import_memory = true;

--- a/test/link/wasm/stack_pointer/build.zig
+++ b/test/link/wasm/stack_pointer/build.zig
@@ -13,12 +13,13 @@ pub fn build(b: *std.Build) void {
 }
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addExecutable(.{
         .name = "lib",
         .root_source_file = .{ .path = "lib.zig" },
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
+    lib.no_entry = true;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.strip = false;

--- a/test/link/wasm/stack_pointer/build.zig
+++ b/test/link/wasm/stack_pointer/build.zig
@@ -19,7 +19,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
-    lib.no_entry = true;
+    lib.entry = .disabled;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.strip = false;

--- a/test/link/wasm/type/build.zig
+++ b/test/link/wasm/type/build.zig
@@ -13,12 +13,13 @@ pub fn build(b: *std.Build) void {
 }
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addExecutable(.{
         .name = "lib",
         .root_source_file = .{ .path = "lib.zig" },
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
+    lib.no_entry = true;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.strip = false;

--- a/test/link/wasm/type/build.zig
+++ b/test/link/wasm/type/build.zig
@@ -19,7 +19,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
         .optimize = optimize,
     });
-    lib.no_entry = true;
+    lib.entry = .disabled;
     lib.use_llvm = false;
     lib.use_lld = false;
     lib.strip = false;


### PR DESCRIPTION
As discussed in https://github.com/ziglang/zig/pull/16949#issuecomment-1692779628 this changes the invocation when building for the WebAssembly target. Users who previously used `-dynamic` in combination with `build-lib` will now be required to use `build-exe` in combination with `-fno-entry`. This is the same behavior as found in other compilers such as Clang and Rust. `-fno-entry` will tell the linker there's no entry point available and therefore the built binary can be used, for instance, in a browser where no entry point is expected.

This change also now correctly passes the `--shared` and `--pie` linker flags to wasm-ld when enabled in the frontend. e.g. when the user used the combination of `build-lib -dynamic` or `build-exe -fPIE`.

Closes #16937 
Closes #16938 
Closes #11045