### PR TITLE
wasm - fix bitcasting between arrays and scalar types

### DIFF
--- a/lib/test_runner.zig
+++ b/lib/test_runner.zig
@@ -13,9 +13,7 @@ var cmdline_buffer: [4096]u8 = undefined;
 var fba = std.heap.FixedBufferAllocator.init(&cmdline_buffer);
 
 pub fn main() void {
-    if (builtin.zig_backend == .stage2_aarch64 or
-        builtin.zig_backend == .stage2_wasm)
-    {
+    if (builtin.zig_backend == .stage2_aarch64) {
         return mainSimple() catch @panic("test failure");
     }
 

--- a/test/behavior/bugs/1851.zig
+++ b/test/behavior/bugs/1851.zig
@@ -7,7 +7,6 @@ test "allocation and looping over 3-byte integer" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     if (builtin.zig_backend == .stage2_llvm and builtin.os.tag == .macos) {
         return error.SkipZigTest; // TODO

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1351,7 +1351,6 @@ test "under-aligned struct field" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const U = extern union {
         fd: i32,


### PR DESCRIPTION
A bug was discovered by #17802, where in the Wasm backend it didn't correctly bitcast values between array and scalar types. This fixes that and re-enables the behavior tests as well as the default test-runner.