### PR TITLE
translate-c: translate 80/128-bit long double literals

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -506,6 +506,9 @@ pub const FloatingLiteral = opaque {
     pub const getValueAsApproximateDouble = ZigClangFloatingLiteral_getValueAsApproximateDouble;
     extern fn ZigClangFloatingLiteral_getValueAsApproximateDouble(*const FloatingLiteral) f64;
 
+    pub const getValueAsApproximateQuadBits = ZigClangFloatingLiteral_getValueAsApproximateQuadBits;
+    extern fn ZigClangFloatingLiteral_getValueAsApproximateQuadBits(*const FloatingLiteral, low: *u64, high: *u64) void;
+
     pub const getBeginLoc = ZigClangFloatingLiteral_getBeginLoc;
     extern fn ZigClangFloatingLiteral_getBeginLoc(*const FloatingLiteral) SourceLocation;
 

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -3245,6 +3245,17 @@ double ZigClangFloatingLiteral_getValueAsApproximateDouble(const ZigClangFloatin
     return casted->getValueAsApproximateDouble();
 }
 
+void ZigClangFloatingLiteral_getValueAsApproximateQuadBits(const ZigClangFloatingLiteral *self, uint64_t *low, uint64_t *high) {
+    auto casted = reinterpret_cast<const clang::FloatingLiteral *>(self);
+    llvm::APFloat apf = casted->getValue();
+    bool ignored;
+    apf.convert(llvm::APFloat::IEEEquad(), llvm::APFloat::rmNearestTiesToEven, &ignored);
+    const llvm::APInt api = apf.bitcastToAPInt();
+    const uint64_t *api_data = api.getRawData();
+    *low = api_data[0];
+    *high = api_data[1];
+}
+
 struct ZigClangSourceLocation ZigClangFloatingLiteral_getBeginLoc(const struct ZigClangFloatingLiteral *self) {
     auto casted = reinterpret_cast<const clang::FloatingLiteral *>(self);
     return bitcast(casted->getBeginLoc());

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -1510,6 +1510,7 @@ ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangDeclStmt_getBeginLoc(const st
 ZIG_EXTERN_C unsigned ZigClangAPFloat_convertToHexString(const struct ZigClangAPFloat *self, char *DST,
         unsigned HexDigits, bool UpperCase, enum ZigClangAPFloat_roundingMode RM);
 ZIG_EXTERN_C double ZigClangFloatingLiteral_getValueAsApproximateDouble(const ZigClangFloatingLiteral *self);
+ZIG_EXTERN_C void ZigClangFloatingLiteral_getValueAsApproximateQuadBits(const ZigClangFloatingLiteral *self, uint64_t *low, uint64_t *high);
 ZIG_EXTERN_C struct ZigClangSourceLocation ZigClangFloatingLiteral_getBeginLoc(const struct ZigClangFloatingLiteral *);
 ZIG_EXTERN_C ZigClangAPFloatBase_Semantics ZigClangFloatingLiteral_getRawSemantics(const ZigClangFloatingLiteral *self);
 

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -1215,6 +1215,7 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\extern const float my_float = 1.0f;
         \\extern const double my_double = 1.0;
         \\extern const long double my_longdouble = 1.0l;
+        \\extern const long double my_extended_precision_longdouble = 1.0000000000000003l;
     , &([_][]const u8{
         "pub const foo = @as(f32, 3.14);",
         "pub const bar = @as(c_longdouble, 16.0e-2);",
@@ -1225,13 +1226,14 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         "pub const foobar = -@as(c_longdouble, 73.0);",
         "pub export const my_float: f32 = 1.0;",
         "pub export const my_double: f64 = 1.0;",
-    } ++ if (@bitSizeOf(c_longdouble) != 64) .{
-        // TODO properly translate non-64-bit long doubles
-        "source.h:10:42: warning: unsupported floating point constant format",
-        "source.h:10:26: warning: unable to translate variable initializer, demoted to extern",
-        "pub extern const my_longdouble: c_longdouble;",
-    } else .{
         "pub export const my_longdouble: c_longdouble = 1.0;",
+        switch (@bitSizeOf(c_longdouble)) {
+            // TODO implement decimal format for f128 <https://github.com/ziglang/zig/issues/1181>
+            // (so that f80/f128 values not exactly representable as f64 can be emitted in decimal form)
+            80 => "pub export const my_extended_precision_longdouble: c_longdouble = 0x1.000000000000159ep0;",
+            128 => "pub export const my_extended_precision_longdouble: c_longdouble = 0x1.000000000000159e05f1e2674d21p0;",
+            else => "pub export const my_extended_precision_longdouble: c_longdouble = 1.0000000000000002;",
+        },
     }));
 
     cases.add("macro defines hexadecimal float",


### PR DESCRIPTION
Closes #17720

80/128-bit `long double` literals are converted to quadruple precision before formatting, just like how 64-bit and smaller values are converted to double precision.

Decimal formatting for `f128` is not yet implemented (#1181) and I don't have the know-how necessary to fix that. I still think it would be useful to translate these `long double` literals instead of demoting them to extern, even if the representation isn't as friendly to humans as it could be.

The way I've implemented formatting for now is to try and round-trip the `f128` value by

1. casting it to `f64`,
2. serializing it to the decimal format,
3. parsing the serialized string as a `f128`, and finally
4. checking if the parsed value is exactly the same as the original `f128`.

If we could successfully roundtrip the value, we use that decimal form, otherwise, we fall back to the hexadecimal format.

The end result is that "nice and even" literals like `765.0l` or `0.1875l` are translated as `765.0` and `0.1875` respectively, while literals like `0.3l` might be translated as either `0x1.3333333333333334p-2` or `0.3` depending on if `long double` is 80-bit or 128-bit.

Should hopefully be good enough until proper `f128` printing is implemented.