### PR TITLE
cbe: add a system for avoiding collisions with C compiler intrinsics

### DIFF
--- a/ci/x86_64-windows-debug.ps1
+++ b/ci/x86_64-windows-debug.ps1
@@ -97,9 +97,8 @@ Enter-VsDevShell -VsInstallPath "C:\Program Files\Microsoft Visual Studio\2022\E
 CheckLastExitCode
 
 Write-Output "Build and run behavior tests with msvc..."
-Write-Output "Skipped due to https://github.com/ziglang/zig/issues/17817"
-#& cl.exe -I..\lib test-x86_64-windows-msvc.c compiler_rt-x86_64-windows-msvc.c /W3 /Z7 -link -nologo -debug -subsystem:console kernel32.lib ntdll.lib libcmt.lib
-#CheckLastExitCode
-#
-#& .\test-x86_64-windows-msvc.exe
-#CheckLastExitCode
+& cl.exe -I..\lib test-x86_64-windows-msvc.c compiler_rt-x86_64-windows-msvc.c /W3 /Z7 -link -nologo -debug -subsystem:console kernel32.lib ntdll.lib libcmt.lib
+CheckLastExitCode
+
+& .\test-x86_64-windows-msvc.exe
+CheckLastExitCode

--- a/ci/x86_64-windows-release.ps1
+++ b/ci/x86_64-windows-release.ps1
@@ -96,9 +96,8 @@ Enter-VsDevShell -VsInstallPath "C:\Program Files\Microsoft Visual Studio\2022\E
 CheckLastExitCode
 
 Write-Output "Build and run behavior tests with msvc..."
-Write-Output "Skipped due to https://github.com/ziglang/zig/issues/17817"
-#& cl.exe -I..\lib test-x86_64-windows-msvc.c compiler_rt-x86_64-windows-msvc.c /W3 /Z7 -link -nologo -debug -subsystem:console kernel32.lib ntdll.lib libcmt.lib
-#CheckLastExitCode
-#
-#& .\test-x86_64-windows-msvc.exe
-#CheckLastExitCode
+& cl.exe -I..\lib test-x86_64-windows-msvc.c compiler_rt-x86_64-windows-msvc.c /W3 /Z7 -link -nologo -debug -subsystem:console kernel32.lib ntdll.lib libcmt.lib
+CheckLastExitCode
+
+& .\test-x86_64-windows-msvc.exe
+CheckLastExitCode

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -1265,6 +1265,7 @@ pub fn lerp(a: anytype, b: anytype, t: anytype) @TypeOf(a, b, t) {
 }
 
 test "lerp" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/17884
     if (builtin.zig_backend == .stage2_x86_64 and
         !comptime std.Target.x86.featureSetHas(builtin.cpu.features, .fma)) return error.SkipZigTest;
 

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -194,9 +194,11 @@ typedef char bool;
 #endif /*_M_X64 */
 #else /* _MSC_VER */
 #if __APPLE__
-#define zig_export(sig, symbol, name) __asm("_" name " = _" #symbol)
+#define zig_export(sig, symbol, name) zig_extern sig;\
+    __asm("_" name " = _" #symbol)
 #else /* __APPLE__ */
-#define zig_export(sig, symbol, name) __asm(name " = " #symbol)
+#define zig_export(sig, symbol, name) zig_extern sig;\
+    __asm(name " = " #symbol)
 #endif /* __APPLE__ */
 #endif /* _MSC_VER */
 

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -174,6 +174,12 @@ typedef char bool;
 #define zig_extern extern
 #endif
 
+#if _MSC_VER
+#define zig_extern_mangled zig_extern
+#else
+#define zig_extern_mangled static
+#endif
+
 #if zig_has_attribute(alias)
 #define zig_export(sig, symbol, name) zig_extern sig __attribute__((alias(#symbol)))
 #elif _MSC_VER
@@ -190,14 +196,14 @@ typedef char bool;
 
 #if _MSC_VER
 #if _M_X64
-#define zig_import(sig, symbol, name) sig;\
+#define zig_import(sig, symbol, name) zig_extern sig;\
     __pragma(comment(linker, "/alternatename:" #symbol "=" #name ))
 #else /*_M_X64 */
-#define zig_import(sig, symbol, name) sig;\
+#define zig_import(sig, symbol, name) zig_extern sig;\
     __pragma(comment(linker, "/alternatename:_" #symbol "=_" #name ))
 #endif /*_M_X64 */
 #else
-#define zig_import(sig, symbol, name) zig_extern sig asm(#name);
+#define zig_import(sig, symbol, name) zig_extern sig __asm(#name);
 #endif
 
 #define zig_expand_import(sig, symbol, name) zig_import(sig, symbol, name)
@@ -3344,24 +3350,24 @@ zig_float_negate_builtin(128, zig_make_u128, (UINT64_C(1) << 63, UINT64_C(0)))
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_f##w)(f##w, sub, -) \
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_f##w)(f##w, mul, *) \
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_f##w)(f##w, div, /) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_sqrt(zig_f##w), zig_float_fn_f##w##_sqrt, zig_libc_name_f##w(sqrt)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_sin(zig_f##w), zig_float_fn_f##w##_sin, zig_libc_name_f##w(sin)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_cos(zig_f##w), zig_float_fn_f##w##_cos, zig_libc_name_f##w(cos)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_tan(zig_f##w), zig_float_fn_f##w##_tan, zig_libc_name_f##w(tan)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_exp(zig_f##w), zig_float_fn_f##w##_exp, zig_libc_name_f##w(exp)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_exp2(zig_f##w), zig_float_fn_f##w##_exp2, zig_libc_name_f##w(exp2)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_log(zig_f##w), zig_float_fn_f##w##_log, zig_libc_name_f##w(log)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_log2(zig_f##w), zig_float_fn_f##w##_log2, zig_libc_name_f##w(log2)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_log10(zig_f##w), zig_float_fn_f##w##_log10, zig_libc_name_f##w(log10)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_fabs(zig_f##w), zig_float_fn_f##w##_fabs, zig_libc_name_f##w(fabs)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_floor(zig_f##w), zig_float_fn_f##w##_floor, zig_libc_name_f##w(floor)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_ceil(zig_f##w), zig_float_fn_f##w##_ceil, zig_libc_name_f##w(ceil)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_round(zig_f##w), zig_float_fn_f##w##_round, zig_libc_name_f##w(round)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_trunc(zig_f##w), zig_float_fn_f##w##_trunc, zig_libc_name_f##w(trunc)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_fmod(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmod, zig_libc_name_f##w(fmod)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_fmin(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmin, zig_libc_name_f##w(fmin)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_fmax(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmax, zig_libc_name_f##w(fmax)) \
-    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_fma(zig_f##w, zig_f##w, zig_f##w), zig_float_fn_f##w##_fma, zig_libc_name_f##w(fma)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_sqrt(zig_f##w), zig_float_fn_f##w##_sqrt, zig_libc_name_f##w(sqrt)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_sin(zig_f##w), zig_float_fn_f##w##_sin, zig_libc_name_f##w(sin)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_cos(zig_f##w), zig_float_fn_f##w##_cos, zig_libc_name_f##w(cos)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_tan(zig_f##w), zig_float_fn_f##w##_tan, zig_libc_name_f##w(tan)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_exp(zig_f##w), zig_float_fn_f##w##_exp, zig_libc_name_f##w(exp)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_exp2(zig_f##w), zig_float_fn_f##w##_exp2, zig_libc_name_f##w(exp2)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_log(zig_f##w), zig_float_fn_f##w##_log, zig_libc_name_f##w(log)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_log2(zig_f##w), zig_float_fn_f##w##_log2, zig_libc_name_f##w(log2)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_log10(zig_f##w), zig_float_fn_f##w##_log10, zig_libc_name_f##w(log10)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_fabs(zig_f##w), zig_float_fn_f##w##_fabs, zig_libc_name_f##w(fabs)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_floor(zig_f##w), zig_float_fn_f##w##_floor, zig_libc_name_f##w(floor)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_ceil(zig_f##w), zig_float_fn_f##w##_ceil, zig_libc_name_f##w(ceil)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_round(zig_f##w), zig_float_fn_f##w##_round, zig_libc_name_f##w(round)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_trunc(zig_f##w), zig_float_fn_f##w##_trunc, zig_libc_name_f##w(trunc)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_fmod(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmod, zig_libc_name_f##w(fmod)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_fmin(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmin, zig_libc_name_f##w(fmin)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_fmax(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmax, zig_libc_name_f##w(fmax)) \
+    zig_expand_import(zig_f##w zig_float_fn_f##w##_fma(zig_f##w, zig_f##w, zig_f##w), zig_float_fn_f##w##_fma, zig_libc_name_f##w(fma)) \
 \
     static inline zig_f##w zig_div_trunc_f##w(zig_f##w lhs, zig_f##w rhs) { \
         return zig_float_fn_f##w##_trunc(zig_div_f##w(lhs, rhs)); \

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -203,7 +203,11 @@ typedef char bool;
     __pragma(comment(linker, "/alternatename:_" #symbol "=_" #name ))
 #endif /*_M_X64 */
 #else
+#if __APPLE__
+#define zig_import(sig, symbol, name) zig_extern sig __asm("_" #name);
+#else /* __APPLE__ */
 #define zig_import(sig, symbol, name) zig_extern sig __asm(#name);
+#endif /* __APPLE__ */
 #endif
 
 #define zig_expand_import(sig, symbol, name) zig_import(sig, symbol, name)

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -175,18 +175,32 @@ typedef char bool;
 #endif
 
 #if zig_has_attribute(alias)
-#define zig_export(sig, symbol, name) zig_extern sig __attribute__((alias(symbol)))
+#define zig_export(sig, symbol, name) zig_extern sig __attribute__((alias(#symbol)))
 #elif _MSC_VER
 #if _M_X64
-#define zig_export(sig, symbol, name) sig;\
-    __pragma(comment(linker, "/alternatename:" name "=" symbol ))
+#define zig_export(sig, symbol, name) zig_extern sig;\
+    __pragma(comment(linker, "/alternatename:" name "=" #symbol ))
 #else /*_M_X64 */
-#define zig_export(sig, symbol, name) sig;\
-    __pragma(comment(linker, "/alternatename:_" name "=_" symbol ))
+#define zig_export(sig, symbol, name) zig_extern sig;\
+    __pragma(comment(linker, "/alternatename:" name "=" #symbol ))
 #endif /*_M_X64 */
 #else
-#define zig_export(sig, symbol, name) __asm(name " = " symbol)
+#define zig_export(sig, symbol, name) __asm(name " = " #symbol)
 #endif
+
+#if _MSC_VER
+#if _M_X64
+#define zig_import(sig, symbol, name) sig;\
+    __pragma(comment(linker, "/alternatename:" #symbol "=" #name ))
+#else /*_M_X64 */
+#define zig_import(sig, symbol, name) sig;\
+    __pragma(comment(linker, "/alternatename:_" #symbol "=_" #name ))
+#endif /*_M_X64 */
+#else
+#define zig_import(sig, symbol, name) zig_extern sig asm(#name);
+#endif
+
+#define zig_expand_import(sig, symbol, name) zig_import(sig, symbol, name)
 
 #if zig_has_attribute(weak) || defined(zig_gnuc)
 #define zig_weak_linkage __attribute__((weak))
@@ -3330,31 +3344,31 @@ zig_float_negate_builtin(128, zig_make_u128, (UINT64_C(1) << 63, UINT64_C(0)))
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_f##w)(f##w, sub, -) \
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_f##w)(f##w, mul, *) \
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_f##w)(f##w, div, /) \
-    zig_extern zig_f##w zig_libc_name_f##w(sqrt)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(sin)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(cos)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(tan)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(exp)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(exp2)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(log)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(log2)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(log10)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(fabs)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(floor)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(ceil)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(round)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(trunc)(zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(fmod)(zig_f##w, zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(fmin)(zig_f##w, zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(fmax)(zig_f##w, zig_f##w); \
-    zig_extern zig_f##w zig_libc_name_f##w(fma)(zig_f##w, zig_f##w, zig_f##w); \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_sqrt(zig_f##w), zig_float_fn_f##w##_sqrt, zig_libc_name_f##w(sqrt)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_sin(zig_f##w), zig_float_fn_f##w##_sin, zig_libc_name_f##w(sin)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_cos(zig_f##w), zig_float_fn_f##w##_cos, zig_libc_name_f##w(cos)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_tan(zig_f##w), zig_float_fn_f##w##_tan, zig_libc_name_f##w(tan)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_exp(zig_f##w), zig_float_fn_f##w##_exp, zig_libc_name_f##w(exp)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_exp2(zig_f##w), zig_float_fn_f##w##_exp2, zig_libc_name_f##w(exp2)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_log(zig_f##w), zig_float_fn_f##w##_log, zig_libc_name_f##w(log)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_log2(zig_f##w), zig_float_fn_f##w##_log2, zig_libc_name_f##w(log2)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_log10(zig_f##w), zig_float_fn_f##w##_log10, zig_libc_name_f##w(log10)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_fabs(zig_f##w), zig_float_fn_f##w##_fabs, zig_libc_name_f##w(fabs)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_floor(zig_f##w), zig_float_fn_f##w##_floor, zig_libc_name_f##w(floor)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_ceil(zig_f##w), zig_float_fn_f##w##_ceil, zig_libc_name_f##w(ceil)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_round(zig_f##w), zig_float_fn_f##w##_round, zig_libc_name_f##w(round)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_trunc(zig_f##w), zig_float_fn_f##w##_trunc, zig_libc_name_f##w(trunc)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_fmod(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmod, zig_libc_name_f##w(fmod)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_fmin(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmin, zig_libc_name_f##w(fmin)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_fmax(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmax, zig_libc_name_f##w(fmax)) \
+    zig_expand_import(zig_extern zig_f##w zig_float_fn_f##w##_fma(zig_f##w, zig_f##w, zig_f##w), zig_float_fn_f##w##_fma, zig_libc_name_f##w(fma)) \
 \
     static inline zig_f##w zig_div_trunc_f##w(zig_f##w lhs, zig_f##w rhs) { \
-        return zig_libc_name_f##w(trunc)(zig_div_f##w(lhs, rhs)); \
+        return zig_float_fn_f##w##_trunc(zig_div_f##w(lhs, rhs)); \
     } \
 \
     static inline zig_f##w zig_div_floor_f##w(zig_f##w lhs, zig_f##w rhs) { \
-        return zig_libc_name_f##w(floor)(zig_div_f##w(lhs, rhs)); \
+        return zig_float_fn_f##w##_floor(zig_div_f##w(lhs, rhs)); \
     } \
 \
     static inline zig_f##w zig_mod_f##w(zig_f##w lhs, zig_f##w rhs) { \
@@ -3458,7 +3472,7 @@ zig_float_builtins(64)
     zig_##Type zig_atomicrmw_desired; \
     zig_atomic_load(zig_atomicrmw_expected, obj, memory_order_relaxed, Type, ReprType); \
     do { \
-        zig_atomicrmw_desired = zig_libc_name_##Type(fmin)(zig_atomicrmw_expected, arg); \
+        zig_atomicrmw_desired = zig_float_fn_##Type##_fmin(zig_atomicrmw_expected, arg); \
     } while (!zig_cmpxchg_weak(obj, zig_atomicrmw_expected, zig_atomicrmw_desired, order, memory_order_relaxed, Type, ReprType)); \
     res = zig_atomicrmw_expected; \
 } while (0)
@@ -3467,7 +3481,7 @@ zig_float_builtins(64)
     zig_##Type zig_atomicrmw_desired; \
     zig_atomic_load(zig_atomicrmw_expected, obj, memory_order_relaxed, Type, ReprType); \
     do { \
-        zig_atomicrmw_desired = zig_libc_name_##Type(fmax)(zig_atomicrmw_expected, arg); \
+        zig_atomicrmw_desired = zig_float_fn_##Type##_fmax(zig_atomicrmw_expected, arg); \
     } while (!zig_cmpxchg_weak(obj, zig_atomicrmw_expected, zig_atomicrmw_desired, order, memory_order_relaxed, Type, ReprType)); \
     res = zig_atomicrmw_expected; \
 } while (0)

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -106,7 +106,7 @@ typedef char bool;
 #define zig_never_tail zig_never_tail_unavailable
 #endif
 
-#if zig_has_attribute(always_inline)
+#if zig_has_attribute(musttail)
 #define zig_always_tail __attribute__((musttail))
 #else
 #define zig_always_tail zig_always_tail_unavailable
@@ -177,40 +177,50 @@ typedef char bool;
 #if _MSC_VER
 #define zig_extern_mangled zig_extern
 #else
-#define zig_extern_mangled static
-#endif
-
-#if zig_has_attribute(alias)
-#define zig_export(sig, symbol, name) zig_extern sig __attribute__((alias(#symbol)))
-#elif _MSC_VER
-#if _M_X64
-#define zig_export(sig, symbol, name) zig_extern sig;\
-    __pragma(comment(linker, "/alternatename:" name "=" #symbol ))
-#else /*_M_X64 */
-#define zig_export(sig, symbol, name) zig_extern sig;\
-    __pragma(comment(linker, "/alternatename:" name "=" #symbol ))
-#endif /*_M_X64 */
+#if zig_has_attribute(visibility)
+#define zig_extern_mangled zig_extern __attribute__((visibility("hidden")))
 #else
-#define zig_export(sig, symbol, name) __asm(name " = " #symbol)
+#define zig_extern_mangled zig_extern
+#endif
 #endif
 
 #if _MSC_VER
 #if _M_X64
-#define zig_import(sig, symbol, name) zig_extern sig;\
-    __pragma(comment(linker, "/alternatename:" #symbol "=" #name ))
+#define zig_export(sig, symbol, name) zig_extern sig;\
+    __pragma(comment(linker, "/alternatename:" name "=" #symbol ))
 #else /*_M_X64 */
-#define zig_import(sig, symbol, name) zig_extern sig;\
-    __pragma(comment(linker, "/alternatename:_" #symbol "=_" #name ))
+#define zig_export(sig, symbol, name) zig_extern sig;\
+    __pragma(comment(linker, "/alternatename:" name "=" #symbol ))
 #endif /*_M_X64 */
-#else
+#else /* _MSC_VER */
 #if __APPLE__
-#define zig_import(sig, symbol, name) zig_extern sig __asm("_" #name);
+#define zig_export(sig, symbol, name) __asm("_" name " = _" #symbol)
 #else /* __APPLE__ */
-#define zig_import(sig, symbol, name) zig_extern sig __asm(#name);
+#define zig_export(sig, symbol, name) __asm(name " = " #symbol)
 #endif /* __APPLE__ */
+#endif /* _MSC_VER */
+
+#if _MSC_VER
+#if _M_X64
+#define zig_import(Type, fn_name, libc_name, sig_args, call_args) zig_extern Type fn_name sig_args;\
+    __pragma(comment(linker, "/alternatename:" #fn_name "=" #libc_name ));
+#else /*_M_X64 */
+#define zig_import(Type, fn_name, libc_name, sig_args, call_args) zig_extern Type fn_name sig_args;\
+    __pragma(comment(linker, "/alternatename:_" #fn_name "=_" #libc_name ));
+#endif /*_M_X64 */
+#define zig_import_builtin(Type, fn_name, libc_name, sig_args, call_args) zig_import(Type, fn_name, sig_args, call_args)
+#else /* _MSC_VER */
+#if __APPLE__
+#define zig_import(Type, fn_name, libc_name, sig_args, call_args) zig_extern Type fn_name sig_args __asm("_" #libc_name);
+#else /* __APPLE__ */
+#define zig_import(Type, fn_name, libc_name, sig_args, call_args) zig_extern Type fn_name sig_args __asm(#libc_name);
+#endif /* __APPLE__ */
+#define zig_import_builtin(Type, fn_name, libc_name, sig_args, call_args) zig_extern Type libc_name sig_args; \
+    static inline Type fn_name sig_args { return libc_name call_args; }
 #endif
 
-#define zig_expand_import(sig, symbol, name) zig_import(sig, symbol, name)
+#define zig_expand_import_0(Type, fn_name, libc_name, sig_args, call_args) zig_import(Type, fn_name, libc_name, sig_args, call_args)
+#define zig_expand_import_1(Type, fn_name, libc_name, sig_args, call_args) zig_import_builtin(Type, fn_name, libc_name, sig_args, call_args)
 
 #if zig_has_attribute(weak) || defined(zig_gnuc)
 #define zig_weak_linkage __attribute__((weak))
@@ -3111,6 +3121,7 @@ ypedef uint32_t zig_f32;
 
 #define zig_has_f64 1
 #define zig_libc_name_f64(name) name
+
 #if _MSC_VER
 #define zig_init_special_f64(sign, name, arg, repr) sign zig_make_f64(zig_msvc_flt_##name, )
 #else
@@ -3336,6 +3347,7 @@ zig_float_negate_builtin(128, zig_make_u128, (UINT64_C(1) << 63, UINT64_C(0)))
         return lhs operator rhs; \
     }
 
+#define zig_expand_has_builtin(b) zig_has_builtin(b)
 #define zig_common_float_builtins(w) \
     zig_convert_builtin( int64_t,  int64_t, fix,     zig_f##w, zig_f##w, ) \
     zig_convert_builtin(zig_i128, zig_i128, fix,     zig_f##w, zig_f##w, ) \
@@ -3354,24 +3366,24 @@ zig_float_negate_builtin(128, zig_make_u128, (UINT64_C(1) << 63, UINT64_C(0)))
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_f##w)(f##w, sub, -) \
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_f##w)(f##w, mul, *) \
     zig_expand_concat(zig_float_binary_builtin_,  zig_has_f##w)(f##w, div, /) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_sqrt(zig_f##w), zig_float_fn_f##w##_sqrt, zig_libc_name_f##w(sqrt)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_sin(zig_f##w), zig_float_fn_f##w##_sin, zig_libc_name_f##w(sin)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_cos(zig_f##w), zig_float_fn_f##w##_cos, zig_libc_name_f##w(cos)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_tan(zig_f##w), zig_float_fn_f##w##_tan, zig_libc_name_f##w(tan)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_exp(zig_f##w), zig_float_fn_f##w##_exp, zig_libc_name_f##w(exp)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_exp2(zig_f##w), zig_float_fn_f##w##_exp2, zig_libc_name_f##w(exp2)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_log(zig_f##w), zig_float_fn_f##w##_log, zig_libc_name_f##w(log)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_log2(zig_f##w), zig_float_fn_f##w##_log2, zig_libc_name_f##w(log2)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_log10(zig_f##w), zig_float_fn_f##w##_log10, zig_libc_name_f##w(log10)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_fabs(zig_f##w), zig_float_fn_f##w##_fabs, zig_libc_name_f##w(fabs)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_floor(zig_f##w), zig_float_fn_f##w##_floor, zig_libc_name_f##w(floor)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_ceil(zig_f##w), zig_float_fn_f##w##_ceil, zig_libc_name_f##w(ceil)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_round(zig_f##w), zig_float_fn_f##w##_round, zig_libc_name_f##w(round)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_trunc(zig_f##w), zig_float_fn_f##w##_trunc, zig_libc_name_f##w(trunc)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_fmod(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmod, zig_libc_name_f##w(fmod)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_fmin(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmin, zig_libc_name_f##w(fmin)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_fmax(zig_f##w, zig_f##w), zig_float_fn_f##w##_fmax, zig_libc_name_f##w(fmax)) \
-    zig_expand_import(zig_f##w zig_float_fn_f##w##_fma(zig_f##w, zig_f##w, zig_f##w), zig_float_fn_f##w##_fma, zig_libc_name_f##w(fma)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(sqrt)))(zig_f##w, zig_float_fn_f##w##_sqrt, zig_libc_name_f##w(sqrt), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(sin)))(zig_f##w, zig_float_fn_f##w##_sin, zig_libc_name_f##w(sin), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(cos)))(zig_f##w, zig_float_fn_f##w##_cos, zig_libc_name_f##w(cos), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(tan)))(zig_f##w, zig_float_fn_f##w##_tan, zig_libc_name_f##w(tan), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(exp)))(zig_f##w, zig_float_fn_f##w##_exp, zig_libc_name_f##w(exp), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(exp2)))(zig_f##w, zig_float_fn_f##w##_exp2, zig_libc_name_f##w(exp2), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(log)))(zig_f##w, zig_float_fn_f##w##_log, zig_libc_name_f##w(log), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(log2)))(zig_f##w, zig_float_fn_f##w##_log2, zig_libc_name_f##w(log2), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(log10)))(zig_f##w, zig_float_fn_f##w##_log10, zig_libc_name_f##w(log10), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(fabs)))(zig_f##w, zig_float_fn_f##w##_fabs, zig_libc_name_f##w(fabs), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(floor)))(zig_f##w, zig_float_fn_f##w##_floor, zig_libc_name_f##w(floor), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(ceil)))(zig_f##w, zig_float_fn_f##w##_ceil, zig_libc_name_f##w(ceil), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(round)))(zig_f##w, zig_float_fn_f##w##_round, zig_libc_name_f##w(round), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(trunc)))(zig_f##w, zig_float_fn_f##w##_trunc, zig_libc_name_f##w(trunc), (zig_f##w x), (x)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(fmod)))(zig_f##w, zig_float_fn_f##w##_fmod, zig_libc_name_f##w(fmod), (zig_f##w x, zig_f##w y), (x, y)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(fmin)))(zig_f##w, zig_float_fn_f##w##_fmin, zig_libc_name_f##w(fmin), (zig_f##w x, zig_f##w y), (x, y)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(fmax)))(zig_f##w, zig_float_fn_f##w##_fmax, zig_libc_name_f##w(fmax), (zig_f##w x, zig_f##w y), (x, y)) \
+    zig_expand_concat(zig_expand_import_, zig_expand_has_builtin(zig_libc_name_f##w(fma)))(zig_f##w, zig_float_fn_f##w##_fma, zig_libc_name_f##w(fma), (zig_f##w x, zig_f##w y, zig_f##w z), (x, y, z)) \
 \
     static inline zig_f##w zig_div_trunc_f##w(zig_f##w lhs, zig_f##w rhs) { \
         return zig_float_fn_f##w##_trunc(zig_div_f##w(lhs, rhs)); \

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1978,7 +1978,7 @@ pub const DeclGen = struct {
         if (mod.decl_exports.get(decl_index)) |exports| {
             try writer.print("{ }", .{fmtIdent(mod.intern_pool.stringToSlice(exports.items[export_index].opts.name))});
         } else if (decl.getExternDecl(mod).unwrap()) |extern_decl_index| {
-            try writer.print("{ }", .{fmtIdent(mod.intern_pool.stringToSlice(mod.declPtr(extern_decl_index).name))});
+            try writer.print("{}", .{mod.declPtr(extern_decl_index).name.fmt(&mod.intern_pool)});
         } else {
             // MSVC has a limit of 4095 character token length limit, and fmtIdent can (worst case),
             // expand to 3x the length of its input, but let's cut it off at a much shorter limit.

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -259,7 +259,7 @@ fn updateAnonDecl(self: *C, module: *Module, i: usize) !void {
     };
     const c_value: codegen.CValue = .{ .constant = anon_decl };
     const alignment: Alignment = self.aligned_anon_decls.get(anon_decl) orelse .none;
-    codegen.genDeclValue(&object, tv, false, c_value, alignment, .none) catch |err| switch (err) {
+    codegen.genDeclValue(&object, tv, .local, c_value, alignment, .none) catch |err| switch (err) {
         error.AnalysisFail => {
             @panic("TODO: C backend AnalysisFail on anonymous decl");
             //try module.failed_decls.put(gpa, decl_index, object.dg.error_msg.?);

--- a/test/behavior/bugs/12680.zig
+++ b/test/behavior/bugs/12680.zig
@@ -12,11 +12,6 @@ test "export a function twice" {
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf) return error.SkipZigTest;
 
-    if (builtin.os.tag == .macos and builtin.zig_backend == .stage2_c) {
-        // TODO: test.c: error: aliases are not supported on darwin
-        return error.SkipZigTest;
-    }
-
     // If it exports the function correctly, `test_func` and `testFunc` will points to the same address.
     try expectEqual(test_func(), other_file.testFunc());
 }


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/17817, and re-enables the MSVC CBE tests.

It's possible for some of the names generated by the macros in zig.h to collide with compiler intrinsics. This change introduces a system for avoiding these collisions, while still allowing the colliding name to be exported.

To avoid compile errors, the colliding names are redefined as `zig_intrin_<name>` in zig.h. If the symbol is exported, then a `zig_export` is generated mapping the mangled name back to the original.

The specific problem that sparked this change was the unfortunate combination of `zig_libc_name_f80(name) __##name##x` with the input `fma`, resulting in `__fmax`, which seems to be a new intrinsic in recent versions of cl.exe. If more of these intrinsic collisions come up in the future, all that has to be done is to add an entry to `colliding_intrinsics` and a `#define` in zig.h in the `Intrinsic Collisions` section.