### PR TITLE
start: make stack size strategy configurable

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -483,7 +483,7 @@ fn main(c_argc: c_int, c_argv: [*][*:0]c_char, c_envp: [*:null]?[*:0]c_char) cal
         const at_phdr = std.c.getauxval(elf.AT_PHDR);
         const at_phnum = std.c.getauxval(elf.AT_PHNUM);
         const phdrs = (@as([*]elf.Phdr, @ptrFromInt(at_phdr)))[0..at_phnum];
-        expandStackSize(phdrs);
+        expandStackSizeFromProgramHeader(phdrs);
     }
 
     return @call(.always_inline, callMainWithArgs, .{ @as(usize, @intCast(c_argc)), @as([*][*:0]u8, @ptrCast(c_argv)), envp });

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -426,10 +426,14 @@ fn posixCallMainAndExit() callconv(.C) noreturn {
         // This logic should be revisited when the following issues are addressed:
         // https://github.com/ziglang/zig/issues/157
         // https://github.com/ziglang/zig/issues/1006
+
         switch (std.options.stack_size_strategy) {
             .none => {},
             .program_header => expandStackSizeFromProgramHeader(phdrs) catch {},
-            .fixed => expandStackSize(std.options.stack_size) catch {},
+            .fixed => {
+                comptime assert(std.options.stack_size % std.mem.page_size == 0);
+                expandStackSize(std.options.stack_size) catch {};
+            },
         }
     }
 

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -483,7 +483,7 @@ fn main(c_argc: c_int, c_argv: [*][*:0]c_char, c_envp: [*:null]?[*:0]c_char) cal
         const at_phdr = std.c.getauxval(elf.AT_PHDR);
         const at_phnum = std.c.getauxval(elf.AT_PHNUM);
         const phdrs = (@as([*]elf.Phdr, @ptrFromInt(at_phdr)))[0..at_phnum];
-        expandStackSizeFromProgramHeader(phdrs);
+        expandStackSizeFromProgramHeader(phdrs) catch {};
     }
 
     return @call(.always_inline, callMainWithArgs, .{ @as(usize, @intCast(c_argc)), @as([*][*:0]u8, @ptrCast(c_argv)), envp });

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -426,7 +426,6 @@ fn posixCallMainAndExit() callconv(.C) noreturn {
         // This logic should be revisited when the following issues are addressed:
         // https://github.com/ziglang/zig/issues/157
         // https://github.com/ziglang/zig/issues/1006
-
         switch (std.options.stack_size_strategy) {
             .none => {},
             .program_header => expandStackSizeFromProgramHeader(phdrs) catch {},

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -283,6 +283,16 @@ pub const options = struct {
     else
         false;
 
+    pub const stack_size_strategy: start.StackSizeStrategy = if (@hasDecl(options_override, "stack_size_strategy"))
+        options_override.stack_size_strategy
+    else
+        start.StackSizeStrategy.program_header;
+
+    pub const stack_size: usize = if (@hasDecl(options_override, "stack_size"))
+        options_override.stack_size
+    else
+        8 * 1024 * 1024;
+
     /// By default, std.http.Client will support HTTPS connections.  Set this option to `true` to
     /// disable TLS support.
     ///


### PR DESCRIPTION
With this PR, one can specify what Linux stack-resizing behaviour by setting the appropriate option in `std_options`. There are three possibilities:

 * *none*, which relies on the default Linux stack size of 8 MiB.
 * *program_header*, which will look through the ELF headers set the stack size using setrlimit. This is the current and default behaviour.
 * *fixed*, which sets the value to a configurable fixed size, compile-time asserted to be divisible by the page size as the syscall wants.

If you don't set any of these values the default of *program_header* is chosen, which is the current behaviour, so this PR should have no effect on existing code.