### PR TITLE
fix: renameat returns ENOMEM when the destination is a directory and already exists

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -720,15 +720,7 @@ pub fn rename(old: [*:0]const u8, new: [*:0]const u8) usize {
 }
 
 pub fn renameat(oldfd: i32, oldpath: [*]const u8, newfd: i32, newpath: [*]const u8) usize {
-    if (@hasField(SYS, "renameat")) {
-        return syscall4(
-            .renameat,
-            @as(usize, @bitCast(@as(isize, oldfd))),
-            @intFromPtr(oldpath),
-            @as(usize, @bitCast(@as(isize, newfd))),
-            @intFromPtr(newpath),
-        );
-    } else {
+    if (@hasField(SYS, "renameat2")) {
         return syscall5(
             .renameat2,
             @as(usize, @bitCast(@as(isize, oldfd))),
@@ -736,6 +728,14 @@ pub fn renameat(oldfd: i32, oldpath: [*]const u8, newfd: i32, newpath: [*]const 
             @as(usize, @bitCast(@as(isize, newfd))),
             @intFromPtr(newpath),
             0,
+        );
+    } else {
+        return syscall4(
+            .renameat,
+            @as(usize, @bitCast(@as(isize, oldfd))),
+            @intFromPtr(oldpath),
+            @as(usize, @bitCast(@as(isize, newfd))),
+            @intFromPtr(newpath),
         );
     }
 }

--- a/lib/std/os/test.zig
+++ b/lib/std/os/test.zig
@@ -1030,6 +1030,13 @@ test "rename smoke test" {
     new_file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_other_dir" });
     try os.rename(file_path, new_file_path);
 
+    // Create extra directory
+    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "extra_dir" });
+    try os.mkdir(file_path, mode);
+
+    // Try to rename extra directory to existent directory
+    try expectError(error.PathAlreadyExists, try os.rename(file_path, new_file_path));
+
     // Try opening renamed directory
     file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_other_dir" });
     fd = try os.open(file_path, os.O.RDONLY | os.O.DIRECTORY, mode);

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -1255,17 +1255,11 @@ pub fn renameTmpIntoCache(
                 };
                 continue;
             },
-            error.PathAlreadyExists, error.AccessDenied, error.SystemResources => |e| {
+            error.PathAlreadyExists, error.AccessDenied, error.SystemResources => {
                 // Package has been already downloaded and may already be in use on the system.
                 cache_dir.deleteTree(tmp_dir_sub_path) catch {
                     // Garbage files leftover in zig-cache/tmp/ is, as they say
                     // on Star Trek, "operating within normal parameters".
-                };
-
-                // It is safe to assume a dest_dir_sub_path is valid if it exists,
-                // only bubble the error in case it doesn't
-                cache_dir.access(tmp_dir_sub_path, .{}) catch {
-                    return e;
                 };
             },
             else => |e| return e,

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -1255,11 +1255,17 @@ pub fn renameTmpIntoCache(
                 };
                 continue;
             },
-            error.PathAlreadyExists, error.AccessDenied => {
+            error.PathAlreadyExists, error.AccessDenied, error.SystemResources => |e| {
                 // Package has been already downloaded and may already be in use on the system.
                 cache_dir.deleteTree(tmp_dir_sub_path) catch {
                     // Garbage files leftover in zig-cache/tmp/ is, as they say
                     // on Star Trek, "operating within normal parameters".
+                };
+
+                // It is safe to assume a dest_dir_sub_path is valid if it exists,
+                // only bubble the error in case it doesn't
+                cache_dir.access(tmp_dir_sub_path, .{}) catch {
+                    return e;
                 };
             },
             else => |e| return e,


### PR DESCRIPTION
In `Linux nixos 6.5.9 #1-NixOS SMP Wed Oct 25 10:16:30 UTC 2023 aarch64 GNU/Linux` the zig compiler works. What does not work is a the artifact that was built with `zig build` using the `build.zig+dependencies`. It yields a `errors.SystemResources` error and then it suddenly dies.

While trying to isolate the error, I created a hello world project with `zig init-exe` and the problem remains the same.

Here is a detailed list of steps I figured to debug the issue:

I was able to isolate the problem to the minimum noop command possible `zig build --help`. Running an strace yields the following

```
❭ strace --trace=%file zig build --help
...
openat(AT_FDCWD, "/media/psf/code/zt-arduz/test", O_RDONLY|O_LARGEFILE|O_CLOEXEC|O_PATH|O_DIRECTORY) = 3
openat(AT_FDCWD, "/home/usr/.cache/zig", O_RDONLY|O_LARGEFILE|O_CLOEXEC|O_PATH|O_DIRECTORY) = 5
openat(3, "zig-cache", O_RDONLY|O_LARGEFILE|O_CLOEXEC|O_PATH|O_DIRECTORY) = 6
...
openat(6, "tmp/27c41eea9328d258", O_RDONLY|O_LARGEFILE|O_CLOEXEC|O_PATH|O_DIRECTORY) = -1 ENOENT (No such file or directory)
mkdirat(6, "tmp/27c41eea9328d258", 0755) = 0
...
renameat(6, "tmp/27c41eea9328d258", 6, "o/9fbcd93ecdd6353c70a6f02101137191") = -1 ENOMEM (Cannot allocate memory)
error: SystemResources
+++ exited with 1 +++
```

It seems like the `renameat(6, "tmp/27c41eea9328d258", 6, "o/9fbcd93ecdd6353c70a6f02101137191")` syscall is causing trouble.

The directory zig-cache/o/9fbcd93ecdd6353c70a6f02101137191 already exists. So I will assume the ENOMEM is a bug in the kernel for an "already exists" exit condition. To verify this, I removed the directory manually and re-run the trace correctly, this time the build did work.

To verify that the problem was the syscall/kernel and not zig, I ran `mv` over the same directories. Since the final 
directory structure contains a single dependencies.zig file, we are swapping the directories instead of simply `mv A B`, to do so, we must instruct mv to treat B as a normal file instead of a directory using the -T argument.

```
❭ strace --trace=%file mv -T zig-cache/tmp/27c41eea9328d258 zig-cache/o/9fbcd93ecdd6353c70a6f02101137191
...
renameat2(AT_FDCWD, "zig-cache/tmp/27c41eea9328d258", AT_FDCWD, "zig-cache/o/9fbcd93ecdd6353c70a6f02101137191", RENAME_NOREPLACE) = -1 EEXIST (File exists)
newfstatat(AT_FDCWD, "zig-cache/tmp/27c41eea9328d258", {st_mode=S_IFDIR|0755, st_size=96, ...}, AT_SYMLINK_NOFOLLOW) = 0
newfstatat(AT_FDCWD, "zig-cache/o/9fbcd93ecdd6353c70a6f02101137191", {st_mode=S_IFDIR|0755, st_size=96, ...}, AT_SYMLINK_NOFOLLOW) = 0
faccessat2(AT_FDCWD, "zig-cache/o/9fbcd93ecdd6353c70a6f02101137191", W_OK, AT_EACCESS) = 0
renameat(AT_FDCWD, "zig-cache/tmp/27c41eea9328d258", AT_FDCWD, "zig-cache/o/9fbcd93ecdd6353c70a6f02101137191") = -1 ENOMEM (Cannot allocate memory)
...
newfstatat(3, "", {st_mode=S_IFREG|0444, st_size=2998, ...}, AT_EMPTY_PATH) = 0
...
: Cannot allocate memory
```

As expected, mv fails in the same way.

So here is my patch, it assumes the SystemResources error is of the same kind as PathAlreadyExists, and it also adds a safeguard to prevent false assumptions.

---

Answers https://discord.com/channels/605571803288698900/1169415771026378802