### PR TITLE
zstandard: fix incorrect RLE decompression into ring buffer

### DIFF
--- a/lib/std/compress/zstandard/decode/block.zig
+++ b/lib/std/compress/zstandard/decode/block.zig
@@ -721,7 +721,9 @@ pub fn decodeBlockRingBuffer(
         },
         .rle => {
             if (src.len < 1) return error.MalformedRleBlock;
-            dest.writeSliceAssumeCapacity(src[0..block_size]);
+            for (0..block_size) |_| {
+                dest.writeAssumeCapacity(src[0]);
+            }
             consumed_count.* += 1;
             decode_state.written_count += block_size;
             return block_size;


### PR DESCRIPTION
This reverts a change introduced in #17400 causing a bug when decompressing an RLE block into a ring buffer.

RLE blocks contain only a single byte of data to copy into the output, so attempting to copy a slice causes buffer overruns and incorrect decompression.

This bug only arises when using the allocating `decodeAlloc` (or lower-level APIs it uses).

Better testing coverage for zstandard could have caught this bug in CI, but several things would have to change. Currently the allocating APIs are not covered by stdlib tests, only the non-allocating top-level API is tests. In addition, the zstandard data that is decompressed for testing is two copies of the zstandard RFC (at different compressions levels). These both contain only a single frame with a single block of type 'compressed', so compressed data containing blocks of type `rle` and `raw` are not covered by the CI.

I have various other tests that I used while myself and @squeek502 were fuzzing the initial implementation that do catch this bug and would provide better test coverage, however I'm not sure it's appropriate to just add every crashing/failing input that fuzzing found at some point into `lib/std/compress/testdata`.

@andrewrk If it is desired to include a regression test that catches this bug before merging this PR I can add one, but if better test coverage more generally is desired I'd rather punt that to a new issue as it will probably take some thinking about how to approach it and be quite a bit more work (maybe the answer is the Zig wants to run it's own fuzzing for various parts of std?).