### PR TITLE
add apple chips to arm CPU detection

### DIFF
--- a/lib/std/zig/system/arm.zig
+++ b/lib/std/zig/system/arm.zig
@@ -111,6 +111,21 @@ pub const cpu_models = struct {
         E{ .part = 0xc01, .m64 = &A64.saphira },
     };
 
+    const Apple = [_]E{
+        E{ .part = 0x022, .m64 = &A64.apple_m1 },
+        E{ .part = 0x023, .m64 = &A64.apple_m1 },
+        E{ .part = 0x024, .m64 = &A64.apple_m1 },
+        E{ .part = 0x025, .m64 = &A64.apple_m1 },
+        E{ .part = 0x028, .m64 = &A64.apple_m1 },
+        E{ .part = 0x029, .m64 = &A64.apple_m1 },
+        E{ .part = 0x032, .m64 = &A64.apple_m2 },
+        E{ .part = 0x033, .m64 = &A64.apple_m2 },
+        E{ .part = 0x034, .m64 = &A64.apple_m2 },
+        E{ .part = 0x035, .m64 = &A64.apple_m2 },
+        E{ .part = 0x038, .m64 = &A64.apple_m2 },
+        E{ .part = 0x039, .m64 = &A64.apple_m2 },
+    };
+
     pub fn isKnown(core: CoreInfo, is_64bit: bool) ?*const Target.Cpu.Model {
         const models = switch (core.implementer) {
             0x41 => &ARM,
@@ -120,6 +135,7 @@ pub const cpu_models = struct {
             0x48 => &HiSilicon,
             0x50 => &Ampere,
             0x51 => &Qualcomm,
+            0x61 => &Apple,
             else => return null,
         };
 


### PR DESCRIPTION
before this change if someone were to run apple silicon on e.g. Asahi linux zig would never search for apple chips and default to a generic cpu. the part numbers for the M1 and implementer number were found by reading `/proc/cpuinfo` on an M1 running asahi linux, the numbers for the M2 i found [here](https://lkml.kernel.org/kvm/9d00b09a-044b-55c6-9596-dd04d5b0ca19@huawei.com/T/) which i cannot confirm but the numbers fall in line with the M1 so i think its safe to trust.
i can do a follow up for the M3 if/when I can find the info I need and it's added to zigs list of targets