### PR TITLE
start.zig: Replace kernel32 usage with ntdll/PEB

### DIFF
--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -330,3 +330,7 @@ pub extern "ntdll" fn NtProtectVirtualMemory(
     NewAccessProtection: ULONG,
     OldAccessProtection: *ULONG,
 ) callconv(WINAPI) NTSTATUS;
+
+pub extern "ntdll" fn RtlExitUserProcess(
+    ExitStatus: u32,
+) callconv(WINAPI) noreturn;


### PR DESCRIPTION
Credit to @e4m2 for identifying which `ntdll` functions/PEB fields could be used to replace the `kernel32` functions (https://github.com/ziglang/zig/pull/17763#discussion_r1375249495). Progress towards https://github.com/ziglang/zig/issues/1840

Functionality is equivalent before and after:

Test code:

`winmain-zig.zig`:

```zig
const std = @import("std");

pub fn wWinMain(
    inst: std.os.windows.HINSTANCE,
    prev: ?std.os.windows.HINSTANCE,
    cmd_line: std.os.windows.LPWSTR,
    cmd_show: i32,
) std.os.windows.INT {
    std.debug.print("inst: {}\n", .{inst});
    std.debug.print("prev: {?}\n", .{prev});
    const cmd_line_slice = std.mem.span(cmd_line);
    std.debug.print("cmd_line: {}\n", .{std.unicode.fmtUtf16le(cmd_line_slice)});
    std.debug.print("cmd_show: {}\n", .{cmd_show});
    return 0;
}
```

### Before:
```
> winmain-zig-kernel32.exe a b c "кириллица"
inst: os.windows.HINSTANCE__opaque_2599@7ff62c1f0000
prev: null
cmd_line: winmain-zig-kernel32.exe  a b c "кириллица"
cmd_show: 10
```
[NtTrace](https://github.com/rogerorr/NtTrace) of how the process is terminated:
```
NtTerminateProcess( ProcessHandle=0, ExitStatus=0 ) => 0
NtClose( Handle=0x78 ) => 0
NtClose( Handle=0x50 ) => 0
NtClose( Handle=0x70 ) => 0
NtClose( Handle=0x74 ) => 0
Process 15996 exit code: 0
```

### After:
```
> winmain-zig-ntdll.exe a b c "кириллица"
inst: os.windows.HINSTANCE__opaque_2599@7ff62c1f0000
prev: null
cmd_line: winmain-zig-kernel32.exe  a b c "кириллица"
cmd_show: 10
```
NtTrace:
```
NtTerminateProcess( ProcessHandle=0, ExitStatus=0 ) => 0
NtClose( Handle=0x78 ) => 0
NtClose( Handle=0x60 ) => 0
NtClose( Handle=0x70 ) => 0
NtClose( Handle=0x74 ) => 0
Process 23044 exit code: 0
```