### PR TITLE
zig reduce: support inlining `@import` and more

### DIFF
--- a/lib/std/array_hash_map.zig
+++ b/lib/std/array_hash_map.zig
@@ -574,6 +574,19 @@ pub fn ArrayHashMapUnmanaged(
             };
         }
 
+        pub fn init(allocator: Allocator, key_list: []const K, value_list: []const V) !Self {
+            var self: Self = .{};
+            try self.entries.resize(allocator, key_list.len);
+            errdefer self.entries.deinit(allocator);
+            @memcpy(self.keys(), key_list);
+            if (@sizeOf(V) != 0) {
+                assert(key_list.len == value_list.len);
+                @memcpy(self.values(), value_list);
+            }
+            try self.reIndex(allocator);
+            return self;
+        }
+
         /// Frees the backing allocation and leaves the map in an undefined state.
         /// Note that this does not free keys or values.  You must take care of that
         /// before calling this function, if it is needed.

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2037,6 +2037,7 @@ fn finishRenderBlock(
     const ais = r.ais;
     for (statements, 0..) |stmt, i| {
         if (i != 0) try renderExtraNewline(r, stmt);
+        if (r.fixups.omit_nodes.contains(stmt)) continue;
         switch (node_tags[stmt]) {
             .global_var_decl,
             .local_var_decl,
@@ -2044,11 +2045,7 @@ fn finishRenderBlock(
             .aligned_var_decl,
             => try renderVarDecl(r, tree.fullVarDecl(stmt).?, false, .semicolon),
 
-            else => {
-                if (!r.fixups.omit_nodes.contains(stmt)) {
-                    try renderExpression(r, stmt, .semicolon);
-                }
-            },
+            else => try renderExpression(r, stmt, .semicolon),
         }
     }
     ais.popIndent();

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2043,7 +2043,12 @@ fn finishRenderBlock(
             .simple_var_decl,
             .aligned_var_decl,
             => try renderVarDecl(r, tree.fullVarDecl(stmt).?, false, .semicolon),
-            else => try renderExpression(r, stmt, .semicolon),
+
+            else => {
+                if (!r.fixups.omit_nodes.contains(stmt)) {
+                    try renderExpression(r, stmt, .semicolon);
+                }
+            },
         }
     }
     ais.popIndent();

--- a/src/reduce.zig
+++ b/src/reduce.zig
@@ -229,8 +229,8 @@ pub fn main(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
             //std.debug.print("trying this code:\n{s}\n", .{rendered.items});
 
             const interestingness = try runCheck(arena, interestingness_argv.items);
-            std.debug.print("{d} random transformations: {s}. {d} remaining\n", .{
-                subset_size, @tagName(interestingness), transformations.items.len - start_index,
+            std.debug.print("{d} random transformations: {s}. {d}/{d}\n", .{
+                subset_size, @tagName(interestingness), start_index, transformations.items.len,
             });
             switch (interestingness) {
                 .interesting => {

--- a/src/reduce.zig
+++ b/src/reduce.zig
@@ -321,6 +321,12 @@ fn transformationsToFixups(
         .delete_node => |decl_node| {
             try fixups.omit_nodes.put(gpa, decl_node, {});
         },
+        .delete_var_decl => |delete_var_decl| {
+            try fixups.omit_nodes.put(gpa, delete_var_decl.var_decl_node, {});
+            for (delete_var_decl.references.items) |ident_node| {
+                try fixups.replace_nodes.put(gpa, ident_node, "undefined");
+            }
+        },
         .replace_with_undef => |node| {
             try fixups.replace_nodes.put(gpa, node, "undefined");
         },

--- a/src/reduce/Walk.zig
+++ b/src/reduce/Walk.zig
@@ -649,7 +649,11 @@ fn walkBlock(
             => try walkLocalVarDecl(w, ast.fullVarDecl(stmt).?),
 
             else => {
-                try w.transformations.append(.{ .delete_node = stmt });
+                // Don't try to remove `_ = foo;` discards; those are handled separately.
+                switch (categorizeStmt(ast, stmt)) {
+                    .discard_identifier => {},
+                    else => try w.transformations.append(.{ .delete_node = stmt }),
+                }
                 try walkExpression(w, stmt);
             },
         }

--- a/src/reduce/Walk.zig
+++ b/src/reduce/Walk.zig
@@ -581,9 +581,12 @@ fn walkGlobalVarDecl(w: *Walk, decl_node: Ast.Node.Index, var_decl: Ast.full.Var
         try walkExpression(w, var_decl.ast.section_node);
     }
 
-    assert(var_decl.ast.init_node != 0);
-
-    return walkExpression(w, var_decl.ast.init_node);
+    if (var_decl.ast.init_node != 0) {
+        if (!isUndefinedIdent(w.ast, var_decl.ast.init_node)) {
+            try w.transformations.append(.{ .replace_with_undef = var_decl.ast.init_node });
+        }
+        try walkExpression(w, var_decl.ast.init_node);
+    }
 }
 
 fn walkLocalVarDecl(w: *Walk, var_decl: Ast.full.VarDecl) Error!void {

--- a/src/reduce/Walk.zig
+++ b/src/reduce/Walk.zig
@@ -165,7 +165,10 @@ fn walkMember(w: *Walk, decl: Ast.Node.Index) Error!void {
         .container_field_init,
         .container_field_align,
         .container_field,
-        => try walkContainerField(w, ast.fullContainerField(decl).?),
+        => {
+            try w.transformations.append(.{ .delete_node = decl });
+            try walkContainerField(w, ast.fullContainerField(decl).?);
+        },
 
         .@"comptime" => {
             try w.transformations.append(.{ .delete_node = decl });

--- a/src/reduce/Walk.zig
+++ b/src/reduce/Walk.zig
@@ -134,8 +134,8 @@ fn walkMember(w: *Walk, decl: Ast.Node.Index) Error!void {
             const body_node = datas[decl].rhs;
             if (!isFnBodyGutted(ast, body_node)) {
                 try w.transformations.append(.{ .gut_function = decl });
+                try walkExpression(w, body_node);
             }
-            try walkExpression(w, body_node);
         },
         .fn_proto_simple,
         .fn_proto_multi,
@@ -648,7 +648,10 @@ fn walkBlock(
             .aligned_var_decl,
             => try walkLocalVarDecl(w, ast.fullVarDecl(stmt).?),
 
-            else => try walkExpression(w, stmt),
+            else => {
+                try w.transformations.append(.{ .delete_node = stmt });
+                try walkExpression(w, stmt);
+            },
         }
     }
 }


### PR DESCRIPTION
Follow-up from  #17852. Still using #17618 as a motivating example, even though the bug has been solved.

With these changes, we arrive at the following reduction after 12 minutes:

```zig
const Compilation = struct {
    const Compilation2 = @This();

    const std2 = @import("std");

    const Allocator = std2.mem.Allocator;

    const data_structures = @import("data_structures.zig");
    const BlockList = data_structures.BlockList;
    const StringHashMap = data_structures.StringHashMap;
    const StringArrayHashMap = data_structures.StringArrayHashMap;

    base_allocator: Allocator,
    build_directory: std2.fs.Dir,

    pub fn init(allocator: Allocator) !*Compilation2 {
        _ = allocator;
        @trap();
    }

    pub const Module = struct {
        main_package: *Package,
        import_table: StringArrayHashMap(*File) = .{},
        files: BlockList(File) = .{},

        pub const Descriptor = struct {};

        const ImportFileResult = struct {};

        const ImportPackageResult = struct {};

        fn getFile(module: *Module, allocator: Allocator, full_path: []const u8, relative_path: []const u8, package: *Package) !ImportFileResult {
            const path_lookup = try module.import_table.getOrPut(allocator, full_path);
            const file, const index = switch (path_lookup.found_existing) {
                true => blk: {
                    const index = undefined;
                    break :blk .{
                        undefined,
                        index,
                    };
                },
                false => blk: {
                    const file_allocation = try module.files.append(allocator, File{
                        .relative_path = relative_path,
                        .package = package,
                    });
                    break :blk .{
                        file_allocation.ptr,
                        file_allocation.index,
                    };
                },
            };

            return .{
                .ptr = file,
                .index = index,
                .is_new = !path_lookup.found_existing,
            };
        }

        pub fn importPackage(module: *Module, allocator: Allocator, package: *Package) !ImportPackageResult {
            const import_file = try module.getFile(allocator, undefined, package.source_path, package);
            _ = import_file;
        }
    };

    pub fn compileModule(compilation: *Compilation2, descriptor: Module.Descriptor) !void {
        // TODO: generate an actual file
        _ = descriptor;
        var cache_dir = try compilation.build_directory.openDir("cache", .{});
        _ = cache_dir;

        const module: *Module = try compilation.base_allocator.create(Module);

        _ = try module.importPackage(compilation.base_allocator, module.main_package.dependencies.get("std").?);
    }

    pub const Package = struct {
        /// Relative to the package main directory
        source_path: []const u8,
        dependencies: StringHashMap(*Package) = .{},
    };

    pub const File = struct {
        relative_path: []const u8,
        package: *Package,
    };
};

pub fn main() !void {
    const compilation = try Compilation.init(undefined);

    try compilation.compileModule(undefined);
}
```

Follow-up enhancements that will get us even further on this example case:

* replace function parameter types with `anytype`
* when inlining an import, delete all the globals that have conflicting names with the pub decls of the imported file