### PR TITLE
std.io: add AnyWriter

### DIFF
--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -340,6 +340,9 @@ pub const Reader = GenericReader;
 pub const AnyReader = @import("io/Reader.zig");
 
 pub const Writer = @import("io/writer.zig").Writer;
+pub const AnyWriter = @import("io/writer.zig").AnyWriter;
+pub const WriterInterface = @import("io/writer.zig").WriterInterface;
+
 pub const SeekableStream = @import("io/seekable_stream.zig").SeekableStream;
 
 pub const BufferedWriter = @import("io/buffered_writer.zig").BufferedWriter;

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -190,3 +190,12 @@ test "GenericReader methods can return error.EndOfStream" {
         fbs.reader().isBytes("foo"),
     );
 }
+
+test "AnyWriter write to buffer" {
+    var buffer = std.ArrayList(u8).init(std.testing.allocator);
+    defer buffer.deinit();
+    const writer = buffer.writer().any();
+
+    try writer.print("{s}", .{"greetings"});
+    try std.testing.expectEqualStrings("greetings", buffer.items);
+}


### PR DESCRIPTION
This is a non-generic writer that holds a type-erased pointer to a generic writer and is suitable for use in scenarios, such as runtime callbacks, where generic functions cannot be used.

The approach taken here is a bit different from AnyReader in that the type-erased version has not replaced the generic version. Instead, an interface mixin is used to share the same interface between the two implementations.

Some additional thoughts:

- I wasn't sure where to add tests, so I put one in the general `std.io` test file. The test coverage here is pretty minimal since I didn't see a lot of other writer tests to be used as a template. This could be fleshed out.
- I opted for the mixin approach because I think the `pub usingnamespace` pattern for interface mixins is really nice and would like to see it used more in `std`. I think it's odd that `AnyReader` and `GenericReader` implement the same interface manually, but `GenericReader` internally creates an `AnyReader` for almost all of its methods. I am curious what the general opinion on this approach is.
- The `AnyWriter` could have more methods in its vtable, which would reduce the number of function calls through pointers at the cost of additional code complexity. Since IO is expected to be orders of magnitude slower than a virtual call, I think it makes sense to keep the code simple. Also, maybe the optimizer is smart enough to optimize these out in many cases?