### PR TITLE
frontend: fix -fsingle-threaded default detection logic

### DIFF
--- a/src/target.zig
+++ b/src/target.zig
@@ -641,6 +641,13 @@ pub fn supportsTailCall(target: std.Target, backend: std.builtin.CompilerBackend
     }
 }
 
+pub fn supportsThreads(target: std.Target, backend: std.builtin.CompilerBackend) bool {
+    return switch (backend) {
+        .stage2_x86_64 => target.ofmt == .macho,
+        else => true,
+    };
+}
+
 pub fn libcFloatPrefix(float_bits: u16) []const u8 {
     return switch (float_bits) {
         16, 80 => "__",


### PR DESCRIPTION
The logic in 509be7cf1f10c5d329d2b0524f2af6bfcabd52de assumed that `use_llvm` meant that the LLVM backend would be used, however, use_llvm is false when there are no zig files to compile, which is the case for zig cc. This logic resulted in `-fsingle-threaded` which made libc++ fail to compile for C++ code that includes the threading abstractions (such as LLVM).

This is expected to fix the build-tarballs CI script that has been failing.