### PR TITLE
std.hash_map: adding a rehash() method

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -680,7 +680,17 @@ pub fn HashMap(
             return result;
         }
 
-        /// Rehash the map, in-place
+        /// Rehash the map, in-place.
+        ///
+        /// Over time, due to the current tombstone-based implementation, a
+        /// HashMap could become fragmented due to the buildup of tombstone
+        /// entries that causes a performance degradation due to excessive
+        /// probing. The kind of pattern that might cause this is a long-lived
+        /// HashMap with repeated inserts and deletes.
+        ///
+        /// After this function is called, there will be no tombstones in
+        /// the HashMap, each of the entries is rehashed and any existing
+        /// key/value pointers into the HashMap are invalidated.
         pub fn rehash(self: *Self) void {
             self.unmanaged.rehash(self.ctx);
         }
@@ -1517,8 +1527,9 @@ pub fn HashMapUnmanaged(
         /// probing. The kind of pattern that might cause this is a long-lived
         /// HashMap with repeated inserts and deletes.
         ///
-        /// All existing key/value pointers in the HashMap are maintained at
-        /// their new rehashed location.
+        /// After this function is called, there will be no tombstones in
+        /// the HashMap, each of the entries is rehashed and any existing
+        /// key/value pointers into the HashMap are invalidated.
         pub fn rehash(self: *Self, ctx: anytype) void {
             const mask = self.capacity() - 1;
 

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1545,8 +1545,8 @@ pub fn HashMapUnmanaged(
                     continue;
                 }
 
-                var hash = ctx.hash(keys_ptr[curr]);
-                var fingerprint = Metadata.takeFingerprint(hash);
+                const hash = ctx.hash(keys_ptr[curr]);
+                const fingerprint = Metadata.takeFingerprint(hash);
                 var idx = @as(usize, @truncate(hash & mask));
 
                 // For each bucket, rehash to an index:

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1509,7 +1509,16 @@ pub fn HashMapUnmanaged(
             return result;
         }
 
-        /// Rehash the map, in-place
+        /// Rehash the map, in-place.
+        ///
+        /// Over time, due to the current tombstone-based implementation, a
+        /// HashMap could become fragmented due to the buildup of tombstone
+        /// entries that causes a performance degradation due to excessive
+        /// probing. The kind of pattern that might cause this is a long-lived
+        /// HashMap with repeated inserts and deletes.
+        ///
+        /// All existing key/value pointers in the HashMap are maintained at
+        /// their new rehashed location.
         pub fn rehash(self: *Self, ctx: anytype) void {
             const mask = self.capacity() - 1;
 


### PR DESCRIPTION
This allows a highly fragmented HashMap to have tombstones removed as the values are all rehashed.

It would be nice to make this ``rehash()`` automatically, but that currently presents a challenge where it doesn't work with adapted contexts since the keys are not preserved in the map for re-hashing and the hash value is not stored currently, and the non-adapted contexts require a bit of additional book-keeping to check before calling rehash().

This is a partial fix for #17851, but requires the user to call ``rehash()`` periodically to get the benefit.