### PR TITLE
std.math.complex: use Peer Type Resolution for ducktyped functions

### DIFF
--- a/lib/std/math/complex/acos.zig
+++ b/lib/std/math/complex/acos.zig
@@ -5,8 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the arc-cosine of z.
-pub fn acos(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn acos(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     const q = cmath.asin(z);
     return Complex(T).init(@as(T, math.pi) / 2 - q.re, -q.im);
 }

--- a/lib/std/math/complex/acosh.zig
+++ b/lib/std/math/complex/acosh.zig
@@ -5,8 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the hyperbolic arc-cosine of z.
-pub fn acosh(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn acosh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     const q = cmath.acos(z);
     return Complex(T).init(-q.im, q.re);
 }

--- a/lib/std/math/complex/asin.zig
+++ b/lib/std/math/complex/asin.zig
@@ -5,8 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 // Returns the arc-sine of z.
-pub fn asin(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn asin(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     const x = z.re;
     const y = z.im;
 

--- a/lib/std/math/complex/asinh.zig
+++ b/lib/std/math/complex/asinh.zig
@@ -5,8 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the hyperbolic arc-sine of z.
-pub fn asinh(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn asinh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     const q = Complex(T).init(-z.im, z.re);
     const r = cmath.asin(q);
     return Complex(T).init(r.im, -r.re);

--- a/lib/std/math/complex/atan.zig
+++ b/lib/std/math/complex/atan.zig
@@ -11,8 +11,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the arc-tangent of z.
-pub fn atan(z: anytype) @TypeOf(z) {
-    const T = @TypeOf(z.re);
+pub fn atan(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     return switch (T) {
         f32 => atan32(z),
         f64 => atan64(z),

--- a/lib/std/math/complex/atanh.zig
+++ b/lib/std/math/complex/atanh.zig
@@ -5,8 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the hyperbolic arc-tangent of z.
-pub fn atanh(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn atanh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     const q = Complex(T).init(-z.im, z.re);
     const r = cmath.atan(q);
     return Complex(T).init(r.im, -r.re);

--- a/lib/std/math/complex/conj.zig
+++ b/lib/std/math/complex/conj.zig
@@ -5,8 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the complex conjugate of z.
-pub fn conj(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn conj(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     return Complex(T).init(z.re, -z.im);
 }
 

--- a/lib/std/math/complex/cos.zig
+++ b/lib/std/math/complex/cos.zig
@@ -5,8 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the cosine of z.
-pub fn cos(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn cos(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     const p = Complex(T).init(-z.im, z.re);
     return cmath.cosh(p);
 }

--- a/lib/std/math/complex/cosh.zig
+++ b/lib/std/math/complex/cosh.zig
@@ -13,8 +13,8 @@ const Complex = cmath.Complex;
 const ldexp_cexp = @import("ldexp.zig").ldexp_cexp;
 
 /// Returns the hyperbolic arc-cosine of z.
-pub fn cosh(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn cosh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     return switch (T) {
         f32 => cosh32(z),
         f64 => cosh64(z),

--- a/lib/std/math/complex/exp.zig
+++ b/lib/std/math/complex/exp.zig
@@ -13,8 +13,8 @@ const Complex = cmath.Complex;
 const ldexp_cexp = @import("ldexp.zig").ldexp_cexp;
 
 /// Returns e raised to the power of z (e^z).
-pub fn exp(z: anytype) @TypeOf(z) {
-    const T = @TypeOf(z.re);
+pub fn exp(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
 
     return switch (T) {
         f32 => exp32(z),

--- a/lib/std/math/complex/ldexp.zig
+++ b/lib/std/math/complex/ldexp.zig
@@ -12,8 +12,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns exp(z) scaled to avoid overflow.
-pub fn ldexp_cexp(z: anytype, expt: i32) @TypeOf(z) {
-    const T = @TypeOf(z.re);
+pub fn ldexp_cexp(z: anytype, expt: i32) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
 
     return switch (T) {
         f32 => ldexp_cexp32(z, expt),

--- a/lib/std/math/complex/log.zig
+++ b/lib/std/math/complex/log.zig
@@ -5,8 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the natural logarithm of z.
-pub fn log(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn log(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     const r = cmath.abs(z);
     const phi = cmath.arg(z);
 

--- a/lib/std/math/complex/proj.zig
+++ b/lib/std/math/complex/proj.zig
@@ -5,8 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the projection of z onto the riemann sphere.
-pub fn proj(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn proj(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
 
     if (math.isInf(z.re) or math.isInf(z.im)) {
         return Complex(T).init(math.inf(T), math.copysign(@as(T, 0.0), z.re));

--- a/lib/std/math/complex/sin.zig
+++ b/lib/std/math/complex/sin.zig
@@ -5,8 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the sine of z.
-pub fn sin(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn sin(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     const p = Complex(T).init(-z.im, z.re);
     const q = cmath.sinh(p);
     return Complex(T).init(q.im, -q.re);

--- a/lib/std/math/complex/sinh.zig
+++ b/lib/std/math/complex/sinh.zig
@@ -13,8 +13,8 @@ const Complex = cmath.Complex;
 const ldexp_cexp = @import("ldexp.zig").ldexp_cexp;
 
 /// Returns the hyperbolic sine of z.
-pub fn sinh(z: anytype) @TypeOf(z) {
-    const T = @TypeOf(z.re);
+pub fn sinh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     return switch (T) {
         f32 => sinh32(z),
         f64 => sinh64(z),

--- a/lib/std/math/complex/sqrt.zig
+++ b/lib/std/math/complex/sqrt.zig
@@ -12,8 +12,8 @@ const Complex = cmath.Complex;
 
 /// Returns the square root of z. The real and imaginary parts of the result have the same sign
 /// as the imaginary part of z.
-pub fn sqrt(z: anytype) @TypeOf(z) {
-    const T = @TypeOf(z.re);
+pub fn sqrt(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
 
     return switch (T) {
         f32 => sqrt32(z),

--- a/lib/std/math/complex/tan.zig
+++ b/lib/std/math/complex/tan.zig
@@ -5,8 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the tangent of z.
-pub fn tan(z: anytype) Complex(@TypeOf(z.re)) {
-    const T = @TypeOf(z.re);
+pub fn tan(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     const q = Complex(T).init(-z.im, z.re);
     const r = cmath.tanh(q);
     return Complex(T).init(r.im, -r.re);

--- a/lib/std/math/complex/tanh.zig
+++ b/lib/std/math/complex/tanh.zig
@@ -11,8 +11,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns the hyperbolic tangent of z.
-pub fn tanh(z: anytype) @TypeOf(z) {
-    const T = @TypeOf(z.re);
+pub fn tanh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
+    const T = @TypeOf(z.re, z.im);
     return switch (T) {
         f32 => tanh32(z),
         f64 => tanh64(z),


### PR DESCRIPTION
See https://github.com/ziglang/zig/pull/17840#discussion_r1383863142

This also fixes some inconsistencies before where some function's return result reuses the argument's original type, yet implicitly it is always constructing from the `Complex(T)` type, meaning that it will be an error if the input was some bastard duck possessing the same field name.