### PR TITLE
Sema: allow destructuring vectors

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5205,7 +5205,7 @@ fn zirValidateDestructure(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Comp
     const operand_ty = sema.typeOf(operand);
 
     const can_destructure = switch (operand_ty.zigTypeTag(mod)) {
-        .Array => true,
+        .Array, .Vector => true,
         .Struct => operand_ty.isTuple(mod),
         else => false,
     };

--- a/test/behavior/destructure.zig
+++ b/test/behavior/destructure.zig
@@ -138,3 +138,14 @@ test "destructure of tuple with comptime fields results in some comptime-known v
     try expect(b == 42);
     try expect(d == 42);
 }
+
+test "destructure vector" {
+    const vec: @Vector(2, i32) = .{ 1, 2 };
+    const x, const y = vec;
+
+    comptime assert(@TypeOf(x) == i32);
+    comptime assert(@TypeOf(y) == i32);
+
+    try expect(x == 1);
+    try expect(y == 2);
+}


### PR DESCRIPTION
This was intended to work when destructuring was first implemented, and was just unintentionally missed out.