### PR TITLE
Passing open file descriptors to std.process.Child for StdIn, StdOut, and StdErr

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -5283,3 +5283,23 @@ pub fn ProcessBaseAddress(handle: HANDLE) ProcessBaseAddressError!HMODULE {
     const ppeb: *const PEB = @ptrCast(@alignCast(peb_out.ptr));
     return ppeb.ImageBaseAddress;
 }
+
+pub const InitializeProcThreadAttributeListError = error{ Unexpected, InsufficientBuffer };
+pub fn InitializeProcThreadAttributeList(lpAttributeList: ?kernel32.LPPROC_THREAD_ATTRIBUTE_LIST, dwAttributeCount: DWORD, dwFlags: DWORD, lpSize: ?*usize) InitializeProcThreadAttributeListError!void {
+    if (kernel32.InitializeProcThreadAttributeList(lpAttributeList, dwAttributeCount, dwFlags, lpSize) == 0) {
+        switch (kernel32.GetLastError()) {
+            .INSUFFICIENT_BUFFER => return error.InsufficientBuffer,
+            else => |err| return unexpectedError(err),
+        }
+    }
+}
+
+pub const UpdateProcThreadAttributeError = error{ NoSpaceLeft, Unexpected };
+pub fn UpdateProcThreadAttribute(lpAttributeList: ?kernel32.LPPROC_THREAD_ATTRIBUTE_LIST, dwFlags: DWORD, attribute: usize, lpValue: ?*anyopaque, cbSize: SIZE_T, lpPreviousValue: ?*anyopaque, lpReturnSize: ?*anyopaque) UpdateProcThreadAttributeError!void {
+    if (kernel32.UpdateProcThreadAttribute(lpAttributeList, dwFlags, attribute, lpValue, cbSize, lpPreviousValue, lpReturnSize) == 0) {
+        switch (kernel32.GetLastError()) {
+            .BAD_LENGTH => return error.NoSpaceLeft,
+            else => |err| return unexpectedError(err),
+        }
+    }
+}

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -452,3 +452,24 @@ pub extern "kernel32" fn RegOpenKeyExW(
 ) callconv(WINAPI) LSTATUS;
 
 pub extern "kernel32" fn GetPhysicallyInstalledSystemMemory(TotalMemoryInKilobytes: *ULONGLONG) BOOL;
+
+pub const LPPROC_THREAD_ATTRIBUTE_LIST = *anyopaque;
+pub const PROC_THREAD_ATTRIBUTE = struct {
+    pub const GROUP_AFFINITY: u32 = 0x30003;
+    pub const HANDLE_LIST: u32 = 0x20002;
+    pub const IDEAL_PROCESSOR: u32 = 0x30005;
+    pub const MACHINE_TYPE: u32 = 0x20019;
+    pub const MITIGATION_POLICY: u32 = 0x20007;
+    pub const PARENT_PROCESS: u32 = 0x20000;
+    pub const PREFERRED_NODE: u32 = 0x20004;
+    pub const UMS_THREAD: u32 = 0x30006;
+    pub const SECURITY_CAPABILITIES: u32 = 0x20009;
+    pub const PROTECTION_LEVEL: u32 = 0x2000B;
+    pub const CHILD_PROCESS_POLICY: u32 = 0x2000E;
+    pub const DESKTOP_APP_POLICY: u32 = 0x20012;
+    pub const JOB_LIST: u32 = 0x2000D;
+    pub const ENABLE_OPTIONAL_XSTATE_FEATURES: u32 = 0x3001B;
+};
+pub extern "kernel32" fn InitializeProcThreadAttributeList(lpAttributeList: ?LPPROC_THREAD_ATTRIBUTE_LIST, dwAttributeCount: DWORD, dwFlags: DWORD, lpSize: ?*usize) BOOL;
+pub extern "kernel32" fn DeleteProcThreadAttributeList(lpAttributeList: ?LPPROC_THREAD_ATTRIBUTE_LIST) void;
+pub extern "kernel32" fn UpdateProcThreadAttribute(lpAttributeList: ?LPPROC_THREAD_ATTRIBUTE_LIST, dwFlags: DWORD, attribute: usize, lpValue: ?*anyopaque, cbSize: SIZE_T, lpPreviousValue: ?*anyopaque, lpReturnSize: ?*anyopaque) BOOL;


### PR DESCRIPTION
As my first contribution to a project that wasn't my own twisted creation, I tackled what seemed like a relatively quick implementation. I spent a few hours pulling my hair out because of arcane WINE errors, but I resolved them. This adds a new variant to `std.process.Child.StdIo` named `.File`. This indicates that for a given std(in|out|err), there is a file in the child's `.std(in|out|err)` field. If it is not there, it will throw a `FileNotFound` error, which seemed like a fairly good one. (A null file can't be found, it doesn't exist!) If that is unsatisfactory, it is easily changeable. Regarding the first problem, I wasn't entirely sure what you meant by that, and a cursory look around with ZLS didn't reveal the clues (or I wasn't looking hard enough). If you give me a little push, I can probably get that one too. I tested it with a toy program and ran the zig tests and none of them seemed to fail as a result of something I did (something about not finding `/lib64/ld-linux-$arch.so.1` from Qemu and such). Let me know if anything feels wrong or is stupid or so forth!