### PR TITLE
Fix sqrt(0) panic in managed math

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -3228,8 +3228,19 @@ pub const Managed = struct {
 
     /// r = ⌊√a⌋
     pub fn sqrt(rma: *Managed, a: *const Managed) !void {
-        const needed_limbs = calcSqrtLimbsBufferLen(a.bitCountAbs());
+        const bit_count = a.bitCountAbs();
 
+        if (bit_count == 0) {
+            try rma.set(0);
+            rma.setMetadata(a.isPositive(), rma.len());
+            return;
+        }
+
+        if (!a.isPositive()) {
+            return error.SqrtOfNegativeNumber;
+        }
+
+        const needed_limbs = calcSqrtLimbsBufferLen(bit_count);
         const limbs_buffer = try rma.allocator.alloc(Limb, needed_limbs);
         defer rma.allocator.free(limbs_buffer);
 

--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -3149,3 +3149,29 @@ test "big.int.Const.order 0 == -0" {
     };
     try std.testing.expectEqual(std.math.Order.eq, a.order(b));
 }
+
+test "big.int.Managed sqrt(0) = 0" {
+    const allocator = testing.allocator;
+    var a = try Managed.initSet(allocator, 1);
+    defer a.deinit();
+
+    var res = try Managed.initSet(allocator, 1);
+    defer res.deinit();
+
+    try a.setString(10, "0");
+
+    try res.sqrt(&a);
+}
+
+test "big.int.Managed sqrt(-1) = error" {
+    const allocator = testing.allocator;
+    var a = try Managed.initSet(allocator, 1);
+    defer a.deinit();
+
+    var res = try Managed.initSet(allocator, 1);
+    defer res.deinit();
+
+    try a.setString(10, "-1");
+
+    try testing.expectError(error.SqrtOfNegativeNumber, res.sqrt(&a));
+}


### PR DESCRIPTION
fixes #17858

when the a value takes 0 bits, it will always be 0, by extension the square root will always be 0.

i also added a negative check that returns an `error.` because the current error is very misleading:
```
/home/dr/zig/lib/std/debug.zig:342:14: 0x222c22 in assert (test)
    if (!ok) unreachable; // assertion failure
             ^
/home/dr/zig/lib/std/math/big/int.zig:1524:15: 0x2293ef in div (test)
        assert(!y.eqlZero()); // division by zero