### PR TITLE
 std.math.complex: make complex.pow infer type from argument

### DIFF
--- a/lib/std/math/complex/pow.zig
+++ b/lib/std/math/complex/pow.zig
@@ -5,10 +5,8 @@ const cmath = math.complex;
 const Complex = cmath.Complex;
 
 /// Returns z raised to the complex power of c.
-pub fn pow(comptime T: type, z: T, c: T) T {
-    const p = cmath.log(z);
-    const q = c.mul(p);
-    return cmath.exp(q);
+pub fn pow(z: anytype, s: anytype) Complex(@TypeOf(z.re, z.im, s.re, s.im)) {
+    return cmath.exp(cmath.log(z).mul(s));
 }
 
 const epsilon = 0.0001;
@@ -16,7 +14,7 @@ const epsilon = 0.0001;
 test "complex.cpow" {
     const a = Complex(f32).init(5, 3);
     const b = Complex(f32).init(2.3, -1.3);
-    const c = pow(Complex(f32), a, b);
+    const c = pow(a, b);
 
     try testing.expect(math.approxEqAbs(f32, c.re, 58.049110, epsilon));
     try testing.expect(math.approxEqAbs(f32, c.im, -101.003433, epsilon));


### PR DESCRIPTION
related to https://github.com/ziglang/zig/pull/17901 but split into its own pull request since the interface is changed