### PR TITLE
Speed up ast.tokenLocation

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -140,9 +140,20 @@ pub fn tokenLocation(self: Ast, start_offset: ByteOffset, token_index: TokenInde
         .line_end = self.source.len,
     };
     const token_start = self.tokens.items(.start)[token_index];
-    for (self.source[start_offset..], 0..) |c, i| {
-        if (i + start_offset == token_start) {
-            loc.line_end = i + start_offset;
+
+    // Scan to by line until we go past the token start
+    while (std.mem.indexOfScalarPos(u8, self.source, loc.line_start, '\n')) |i| {
+        if (i >= token_start) {
+            break; // Went past
+        }
+        loc.line += 1;
+        loc.line_start = i + 1;
+    }
+
+    const offset = loc.line_start;
+    for (self.source[offset..], 0..) |c, i| {
+        if (i + offset == token_start) {
+            loc.line_end = i + offset;
             while (loc.line_end < self.source.len and self.source[loc.line_end] != '\n') {
                 loc.line_end += 1;
             }


### PR DESCRIPTION
This changes ast.tokenLocation to scan for the first line before looking for the token. This avoids a lot of pointless adding on the loc.column. The speedup depends on the size of the file. For small files this can be slower but the time difference negligible, for normal sized files it is about 70% faster and can have meaningful time savings.  

```
[default] (warn): test/compile_errors.zig
[default] (warn):   old:  9.313ms
[default] (warn):   new:  3.004ms
[default] (warn):   diff: -6.309ms -67.75% faster
[default] (warn): test/c_abi/main.zig
[default] (warn):   old: 996.415ms
[default] (warn):   new: 305.051ms
[default] (warn):   diff: -691.364ms -69.39% faster
[default] (warn): test/llvm_targets.zig
[default] (warn):   old: 47.332ms
[default] (warn):   new:  8.905ms
[default] (warn):   diff: -38.427ms -81.19% faster
[default] (warn): test/link/glibc_compat/build.zig
...
[default] (warn): src/arch/x86_64/CodeGen.zig
[default] (warn):   old: 234824.597ms
[default] (warn):   new: 58980.527ms
[default] (warn):   diff: -175844.070ms -74.88% faster
```


The reason for this change is I am using zig's builtin parser to add support to kdevelop and profiling showed this was a slow spot.

I tested with the following script which runs the old and new implementation and times it for each token then compares that both are always equal.

```zig
const std = @import("std");
const Ast = std.zig.Ast;
const ByteOffset = Ast.ByteOffset;
const Location = Ast.Location;
const TokenIndex = Ast.TokenIndex;


pub fn tokenLocationScan(self: Ast, start_offset: ByteOffset, token_index: TokenIndex) Location {
    var loc = Location{
        .line = 0,
        .column = 0,
        .line_start = start_offset,
        .line_end = self.source.len,
    };
    const token_start = self.tokens.items(.start)[token_index];

    // Scan to by line until we go past the token start
    while (std.mem.indexOfScalarPos(u8, self.source, loc.line_start, '\n')) |i| {
        if (i >= token_start) {
            break; // Went past
        }
        loc.line += 1;
        loc.line_start = i + 1;
    }

    const offset = loc.line_start;
    for (self.source[offset..], 0..) |c, i| {
        if (i + offset == token_start) {
            loc.line_end = i + offset;
            while (loc.line_end < self.source.len and self.source[loc.line_end] != '\n') {
                loc.line_end += 1;
            }
            return loc;
        }
        if (c == '\n') {
            loc.line += 1;
            loc.column = 0;
            loc.line_start = i + 1;
        } else {
            loc.column += 1;
        }
    }
    return loc;
}


fn testTokenLocation(source: [:0]const u8) !void {
    const allocator = std.testing.allocator;
    var ast = try Ast.parse(allocator, source, .zig);
    defer ast.deinit(allocator);

    if (ast.errors.len > 0) {
        return error.ParseError;
    }

    var timer = try std.time.Timer.start();
    for (0..ast.tokens.len) |i| {
        _ = ast.tokenLocation(0, @intCast(i));
    }
    const t0: f64 = @floatFromInt(timer.read());
    std.log.warn("  old: {d:6.3}ms", .{t0/std.time.ns_per_ms});

    timer.reset();
    for (0..ast.tokens.len) |i| {
        _ = tokenLocationScan(ast, 0, @intCast(i));
    }
    const t1: f64 = @floatFromInt(timer.read());
    std.log.warn("  new: {d:6.3}ms", .{t1/std.time.ns_per_ms});
    const dt = (t1-t0)/std.time.ns_per_ms;
    const pct = 100*(t1-t0)/t0;
    const result = if (t1 < t0) "faster" else "slower";
    std.log.warn("  diff: {d:6.3}ms {d:6.2}% {s}", .{dt, pct, result});

    for (0..ast.tokens.len) |i| {
        const a = ast.tokenLocation(0, @intCast(i));
        const b = tokenLocationScan(ast, 0, @intCast(i));
        try std.testing.expectEqual(a, b);
    }
}


test "token-location" {
    // Walk entire zig lib source tree
    const allocator = std.testing.allocator;
    const zig_lib = "put/path/to/zig/";
    var dir = try std.fs.cwd().openIterableDir(zig_lib, .{});
    defer dir.close();
    var walker = try dir.walk(allocator);
    defer walker.deinit();
    const buffer_size = 20*1000*1024; // 20MB
    while (try walker.next()) |entry| {
        if (entry.kind == .file and std.mem.endsWith(u8, entry.path, ".zig")) {
            std.log.warn("{s}", .{entry.path});
            const file = try entry.dir.openFile(entry.basename, .{});
            const source = try file.readToEndAllocOptions(
                allocator, buffer_size, null, 4, 0
            );
            defer allocator.free(source);
            defer file.close();
            testTokenLocation(source) catch |err| switch (err) {
                error.ParseError => {}, // Skip
                else => return err,
            };
        }
    }
}


```

Any feedback or further improvements are welcome. Thank you.

