### PR TITLE
std: remove meta.Tuple, native tuple construction is here now

### DIFF
--- a/lib/std/json/static_test.zig
+++ b/lib/std/json/static_test.zig
@@ -672,7 +672,7 @@ test "parse into tuple" {
         float: f64,
         string: []const u8,
     };
-    const T = std.meta.Tuple(&.{
+    const T = struct {
         i64,
         f64,
         bool,
@@ -682,9 +682,9 @@ test "parse into tuple" {
             foo: i32,
             bar: []const u8,
         },
-        std.meta.Tuple(&.{ u8, []const u8, u8 }),
+        struct { u8, []const u8, u8 },
         Union,
-    });
+    };
     var str =
         \\[
         \\  420,

--- a/lib/std/json/stringify_test.zig
+++ b/lib/std/json/stringify_test.zig
@@ -292,7 +292,7 @@ test "stringify vector" {
 }
 
 test "stringify tuple" {
-    try testStringify("[\"foo\",42]", std.meta.Tuple(&.{ []const u8, usize }){ "foo", 42 }, .{});
+    try testStringify("[\"foo\",42]", (struct { []const u8, usize }){ "foo", 42 }, .{});
 }
 
 fn testStringify(expected: []const u8, value: anytype, options: StringifyOptions) !void {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -23337,7 +23337,7 @@ fn analyzeShuffle(
     if (maybe_a_len == null) a = try mod.undefRef(a_ty) else a = try sema.coerce(block, a_ty, a, a_src);
     if (maybe_b_len == null) b = try mod.undefRef(b_ty) else b = try sema.coerce(block, b_ty, b, b_src);
 
-    const operand_info = [2]std.meta.Tuple(&.{ u64, LazySrcLoc, Type }){
+    const operand_info = [2](struct { u64, LazySrcLoc, Type }){
         .{ a_len, a_src, a_ty },
         .{ b_len, b_src, b_ty },
     };

--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -268,7 +268,7 @@ test "tuple in tuple passed to generic function" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     const S = struct {
-        fn pair(x: f32, y: f32) std.meta.Tuple(&.{ f32, f32 }) {
+        fn pair(x: f32, y: f32) struct { f32, f32 } {
             return .{ x, y };
         }
 
@@ -286,7 +286,7 @@ test "coerce tuple to tuple" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
-    const T = std.meta.Tuple(&.{u8});
+    const T = struct { u8 };
     const S = struct {
         fn foo(x: T) !void {
             try expect(x[0] == 123);
@@ -300,7 +300,7 @@ test "tuple type with void field" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
-    const T = std.meta.Tuple(&[_]type{void});
+    const T = struct { void };
     const x = T{{}};
     try expect(@TypeOf(x[0]) == void);
 }
@@ -336,7 +336,7 @@ test "tuple type with void field and a runtime field" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
-    const T = std.meta.Tuple(&[_]type{ usize, void });
+    const T = struct { usize, void };
     var t: T = .{ 5, {} };
     try expect(t[0] == 5);
 }


### PR DESCRIPTION
not a specific issue but the feature has been around for a while now. cleaned up the last stragglers of its usage