### PR TITLE
x86_64: pass more tests with an x86_64 backend compiled compiler

### DIFF
--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -4877,11 +4877,14 @@ fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {
             switch (opt_mcv) {
                 else => unreachable,
 
-                .register => |opt_reg| try self.asmRegisterImmediate(
-                    .{ ._s, .bt },
-                    opt_reg,
-                    Immediate.u(@as(u6, @intCast(pl_abi_size * 8))),
-                ),
+                .register => |opt_reg| {
+                    try self.truncateRegister(pl_ty, opt_reg);
+                    try self.asmRegisterImmediate(
+                        .{ ._s, .bt },
+                        opt_reg,
+                        Immediate.u(@as(u6, @intCast(pl_abi_size * 8))),
+                    );
+                },
 
                 .load_frame => |frame_addr| try self.asmMemoryImmediate(
                     .{ ._, .mov },

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -7433,16 +7433,20 @@ fn genUnOp(self: *Self, maybe_inst: ?Air.Inst.Index, tag: Air.Inst.Tag, src_air:
     };
     defer if (dst_lock) |lock| self.register_manager.unlockReg(lock);
 
+    const abi_size: u16 = @intCast(src_ty.abiSize(mod));
     switch (tag) {
         .not => {
-            const limb_abi_size: u16 = @intCast(@min(src_ty.abiSize(mod), 8));
+            const limb_abi_size: u16 = @min(abi_size, 8);
             const int_info = if (src_ty.ip_index == .bool_type)
                 std.builtin.Type.Int{ .signedness = .unsigned, .bits = 1 }
             else
                 src_ty.intInfo(mod);
             var byte_off: i32 = 0;
             while (byte_off * 8 < int_info.bits) : (byte_off += limb_abi_size) {
-                const limb_bits: u16 = @intCast(@min(int_info.bits - byte_off * 8, limb_abi_size * 8));
+                const limb_bits: u16 = @intCast(@min(switch (int_info.signedness) {
+                    .signed => abi_size * 8,
+                    .unsigned => int_info.bits,
+                } - byte_off * 8, limb_abi_size * 8));
                 const limb_ty = try mod.intType(int_info.signedness, limb_bits);
                 const limb_mcv = switch (byte_off) {
                     0 => dst_mcv,
@@ -7457,7 +7461,6 @@ fn genUnOp(self: *Self, maybe_inst: ?Air.Inst.Index, tag: Air.Inst.Tag, src_air:
         },
         .neg => {
             try self.genUnOpMir(.{ ._, .neg }, src_ty, dst_mcv);
-            const abi_size: u16 = @intCast(src_ty.abiSize(mod));
             const bit_size = src_ty.intInfo(mod).bits;
             if (abi_size * 8 > bit_size) {
                 if (dst_mcv.isRegister()) {

--- a/src/link/MachO/uuid.zig
+++ b/src/link/MachO/uuid.zig
@@ -5,7 +5,7 @@
 /// TODO LLD also hashes the output filename to disambiguate between same builds with different
 /// output files. Should we also do that?
 pub fn calcUuid(comp: *const Compilation, file: fs.File, file_size: u64, out: *[Md5.digest_length]u8) !void {
-    const num_chunks = comp.thread_pool.threads.len * 0x10;
+    const num_chunks = @max(comp.thread_pool.threads.len, 1) * 0x10;
     const chunk_size = @divTrunc(file_size, num_chunks);
     const actual_num_chunks = if (@rem(file_size, num_chunks) > 0) num_chunks + 1 else num_chunks;
 


### PR DESCRIPTION
With `./zig` being a compiler compiled with the x86_64 backend with #17931 applied:
```
$ ./zig build test-universal-libc --summary all
Build Summary: 39/43 steps succeeded; 4 skipped; 85/85 tests passed
test-universal-libc success
<...>
$ ./zig build test-c-abi --summary all
Build Summary: 88/91 steps succeeded; 3 skipped; 1594/2223 tests passed; 629 skipped
test-c-abi success
<...>
$ ./zig build test-compiler-rt --summary all
Build Summary: 34/37 steps succeeded; 3 skipped; 3664/3825 tests passed; 161 skipped
test-compiler-rt success
<...>
$ ./zig build test-behavior --summary all
Build Summary: 82/88 steps succeeded; 6 skipped; 63980/68269 tests passed; 4289 skipped
test-behavior success
<...>
$ ./zig build test-std --summary all
Build Summary: 83/90 steps succeeded; 7 skipped; 15024/15606 tests passed; 582 skipped
test-std success
<...>
```