### PR TITLE
wasm-linker: ensure symbol tag is set for decls

### DIFF
--- a/src/link/Wasm/Symbol.zig
+++ b/src/link/Wasm/Symbol.zig
@@ -34,6 +34,7 @@ pub const Tag = enum {
     /// synthetic kind used by the wasm linker during incremental compilation
     /// to notate a symbol has been freed, but still lives in the symbol list.
     dead,
+    undefined,
 
     /// From a given symbol tag, returns the `ExternalType`
     /// Asserts the given tag can be represented as an external type.
@@ -45,6 +46,7 @@ pub const Tag = enum {
             .section => unreachable, // Not an external type
             .event => unreachable, // Not an external type
             .dead => unreachable, // Dead symbols should not be referenced
+            .undefined => unreachable,
             .table => .table,
         };
     }
@@ -169,6 +171,7 @@ pub fn format(symbol: Symbol, comptime fmt: []const u8, options: std.fmt.FormatO
         .event => 'E',
         .table => 'T',
         .dead => '-',
+        .undefined => unreachable,
     };
     const visible: []const u8 = if (symbol.isVisible()) "yes" else "no";
     const binding: []const u8 = if (symbol.isLocal()) "local" else "global";


### PR DESCRIPTION
Previously the symbol tag field would remain `undefined` until it was set during `flush`. However, the symbol's tag would be observed earlier than where it was being set. We now set it to the explicit tag `undefined` so this can be caught during debug. The symbol tag of a decl will now also be set right after `updateDecl` and `updateFunc`.
