### PR TITLE
elf: the dreaded `-r` mode

### DIFF
--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -1664,6 +1664,8 @@ pub const EM = enum(u16) {
     }
 };
 
+pub const GRP_COMDAT = 1;
+
 /// Section data should be writable during execution.
 pub const SHF_WRITE = 0x1;
 

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -6124,11 +6124,67 @@ fn formatShdr(
     _ = options;
     _ = unused_fmt_string;
     const shdr = ctx.shdr;
-    try writer.print("{s} : @{x} ({x}) : align({x}) : size({x})", .{
+    try writer.print("{s} : @{x} ({x}) : align({x}) : size({x}) : flags({})", .{
         ctx.elf_file.getShString(shdr.sh_name), shdr.sh_offset,
         shdr.sh_addr,                           shdr.sh_addralign,
-        shdr.sh_size,
+        shdr.sh_size,                           fmtShdrFlags(shdr.sh_flags),
     });
+}
+
+fn fmtShdrFlags(sh_flags: u64) std.fmt.Formatter(formatShdrFlags) {
+    return .{ .data = sh_flags };
+}
+
+fn formatShdrFlags(
+    sh_flags: u64,
+    comptime unused_fmt_string: []const u8,
+    options: std.fmt.FormatOptions,
+    writer: anytype,
+) !void {
+    _ = unused_fmt_string;
+    _ = options;
+    if (elf.SHF_WRITE & sh_flags != 0) {
+        try writer.writeAll("W");
+    }
+    if (elf.SHF_ALLOC & sh_flags != 0) {
+        try writer.writeAll("A");
+    }
+    if (elf.SHF_EXECINSTR & sh_flags != 0) {
+        try writer.writeAll("X");
+    }
+    if (elf.SHF_MERGE & sh_flags != 0) {
+        try writer.writeAll("M");
+    }
+    if (elf.SHF_STRINGS & sh_flags != 0) {
+        try writer.writeAll("S");
+    }
+    if (elf.SHF_INFO_LINK & sh_flags != 0) {
+        try writer.writeAll("I");
+    }
+    if (elf.SHF_LINK_ORDER & sh_flags != 0) {
+        try writer.writeAll("L");
+    }
+    if (elf.SHF_EXCLUDE & sh_flags != 0) {
+        try writer.writeAll("E");
+    }
+    if (elf.SHF_COMPRESSED & sh_flags != 0) {
+        try writer.writeAll("C");
+    }
+    if (elf.SHF_GROUP & sh_flags != 0) {
+        try writer.writeAll("G");
+    }
+    if (elf.SHF_OS_NONCONFORMING & sh_flags != 0) {
+        try writer.writeAll("O");
+    }
+    if (elf.SHF_TLS & sh_flags != 0) {
+        try writer.writeAll("T");
+    }
+    if (elf.SHF_X86_64_LARGE & sh_flags != 0) {
+        try writer.writeAll("l");
+    }
+    if (elf.SHF_MIPS_ADDR & sh_flags != 0 or elf.SHF_ARM_PURECODE & sh_flags != 0) {
+        try writer.writeAll("p");
+    }
 }
 
 const FormatPhdrCtx = struct {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2041,14 +2041,16 @@ fn claimUnresolved(self: *Elf) void {
         zig_object.claimUnresolved(self);
     }
     for (self.objects.items) |index| {
-        const object = self.file(index).?.object;
-        object.claimUnresolved(self);
+        self.file(index).?.object.claimUnresolved(self);
     }
 }
 
 fn claimUnresolvedObject(self: *Elf) void {
     if (self.zigObjectPtr()) |zig_object| {
         zig_object.claimUnresolvedObject(self);
+    }
+    for (self.objects.items) |index| {
+        self.file(index).?.object.claimUnresolvedObject(self);
     }
 }
 
@@ -5081,6 +5083,10 @@ fn writeSectionSymbols(self: *Elf) void {
         };
         ilocal += 1;
     }
+}
+
+pub fn sectionSymbolOutputSymtabIndex(self: Elf, shndx: u32) u32 {
+    return @intCast(self.output_sections.getIndex(shndx).? + 1);
 }
 
 /// Always 4 or 8 depending on whether this is 32-bit ELF or 64-bit ELF.

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -5003,7 +5003,8 @@ fn writeSyntheticSectionsObject(self: *Elf) !void {
 
         const shdr = self.shdrs.items[sec.shndx];
 
-        const num_relocs = @divExact(shdr.sh_size, shdr.sh_entsize);
+        const num_relocs = math.cast(usize, @divExact(shdr.sh_size, shdr.sh_entsize)) orelse
+            return error.Overflow;
         var relocs = try std.ArrayList(elf.Elf64_Rela).initCapacity(gpa, num_relocs);
         defer relocs.deinit();
 

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -3904,15 +3904,11 @@ fn sortShdrs(self: *Elf) !void {
         shdr.sh_info = self.plt_section_index.?;
     }
 
-    for (&[_]?u16{
-        self.zig_text_rela_section_index,
-        self.zig_data_rel_ro_rela_section_index,
-        self.zig_data_rela_section_index,
-    }) |maybe_index| {
-        const index = maybe_index orelse continue;
-        const shdr = &self.shdrs.items[index];
-        shdr.sh_link = self.symtab_section_index.?;
-        shdr.sh_info = backlinks[shdr.sh_info];
+    for (self.shdrs.items) |*shdr| {
+        if (shdr.sh_type == elf.SHT_RELA and shdr.sh_flags & elf.SHF_INFO_LINK != 0) {
+            shdr.sh_link = self.symtab_section_index.?;
+            shdr.sh_info = backlinks[shdr.sh_info];
+        }
     }
 
     {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -3951,6 +3951,12 @@ fn sortShdrs(self: *Elf) !void {
         self.shdrs.appendAssumeCapacity(slice[sorted.shndx]);
     }
 
+    try self.resetShdrIndexes(backlinks);
+}
+
+fn resetShdrIndexes(self: *Elf, backlinks: []const u16) !void {
+    const gpa = self.base.allocator;
+
     for (&[_]*?u16{
         &self.eh_frame_section_index,
         &self.eh_frame_rela_section_index,

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -4245,6 +4245,11 @@ fn updateSectionSizesObject(self: *Elf) !void {
 
     if (self.eh_frame_section_index) |index| {
         self.shdrs.items[index].sh_size = try eh_frame.calcEhFrameSize(self);
+
+        if (self.eh_frame_rela_section_index) |rela_index| {
+            const shdr = &self.shdrs.items[rela_index];
+            shdr.sh_size = eh_frame.calcEhFrameRelocs(self) * shdr.sh_entsize;
+        }
     }
 
     try self.updateSymtabSize();

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -4307,7 +4307,6 @@ fn updateComdatGroupsSizes(self: *Elf) void {
         shdr.sh_link = self.symtab_section_index.?;
 
         const sym = self.symbol(cg.symbol(self));
-        std.debug.print("{s}\n", .{sym.name(self)});
         shdr.sh_info = sym.outputSymtabIndex(self) orelse
             self.sectionSymbolOutputSymtabIndex(sym.outputShndx().?);
     }
@@ -6131,7 +6130,7 @@ fn formatShdr(
     });
 }
 
-fn fmtShdrFlags(sh_flags: u64) std.fmt.Formatter(formatShdrFlags) {
+pub fn fmtShdrFlags(sh_flags: u64) std.fmt.Formatter(formatShdrFlags) {
     return .{ .data = sh_flags };
 }
 
@@ -6288,12 +6287,12 @@ fn fmtDumpState(
 
     try writer.writeAll("Output COMDAT groups\n");
     for (self.comdat_group_sections.items) |cg| {
-        try writer.print("shdr({d}) : COMDAT({d})\n", .{ cg.shndx, cg.cg_index });
+        try writer.print("  shdr({d}) : COMDAT({d})\n", .{ cg.shndx, cg.cg_index });
     }
 
     try writer.writeAll("\nOutput shdrs\n");
     for (self.shdrs.items, 0..) |shdr, shndx| {
-        try writer.print("shdr({d}) : phdr({?d}) : {}\n", .{
+        try writer.print("  shdr({d}) : phdr({?d}) : {}\n", .{
             shndx,
             self.phdr_to_shdr_table.get(@intCast(shndx)),
             self.fmtShdr(shdr),
@@ -6301,7 +6300,7 @@ fn fmtDumpState(
     }
     try writer.writeAll("\nOutput phdrs\n");
     for (self.phdrs.items, 0..) |phdr, phndx| {
-        try writer.print("phdr{d} : {}\n", .{ phndx, self.fmtPhdr(phdr) });
+        try writer.print("  phdr{d} : {}\n", .{ phndx, self.fmtPhdr(phdr) });
     }
 }
 

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -3452,6 +3452,7 @@ fn initSectionsObject(self: *Elf) !void {
             .addralign = ptr_size,
             .offset = std.math.maxInt(u64),
         });
+        _ = try self.addRelaShdr(".rela.eh_frame", self.eh_frame_section_index.?);
     }
 
     try self.initSymtab();

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -60,6 +60,11 @@ pub fn inputShdr(self: Atom, elf_file: *Elf) Object.ElfShdr {
     };
 }
 
+pub fn relocsShndx(self: Atom) ?u32 {
+    if (self.relocs_section_index == 0) return null;
+    return self.relocs_section_index;
+}
+
 pub fn outputShndx(self: Atom) ?u16 {
     if (self.output_section_index == 0) return null;
     return self.output_section_index;
@@ -280,9 +285,10 @@ pub fn free(self: *Atom, elf_file: *Elf) void {
 }
 
 pub fn relocs(self: Atom, elf_file: *Elf) []align(1) const elf.Elf64_Rela {
+    const shndx = self.relocsShndx() orelse return &[0]elf.Elf64_Rela{};
     return switch (self.file(elf_file).?) {
-        .zig_object => |x| x.relocs.items[self.relocs_section_index].items,
-        .object => |x| x.getRelocs(self.relocs_section_index),
+        .zig_object => |x| x.relocs.items[shndx].items,
+        .object => |x| x.getRelocs(shndx),
         else => unreachable,
     };
 }

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -319,7 +319,7 @@ pub fn writeRelocs(self: Atom, elf_file: *Elf, out_relocs: *std.ArrayList(elf.El
                 r_sym = elf_file.sectionSymbolOutputSymtabIndex(target.outputShndx().?);
             },
             else => {
-                r_sym = target.outputSymtabIndex(elf_file);
+                r_sym = target.outputSymtabIndex(elf_file) orelse 0;
             },
         }
 

--- a/src/link/Elf/LinkerDefined.zig
+++ b/src/link/Elf/LinkerDefined.zig
@@ -3,7 +3,7 @@ symtab: std.ArrayListUnmanaged(elf.Elf64_Sym) = .{},
 strtab: std.ArrayListUnmanaged(u8) = .{},
 symbols: std.ArrayListUnmanaged(Symbol.Index) = .{},
 
-output_symtab_size: Elf.SymtabSize = .{},
+output_symtab_ctx: Elf.SymtabCtx = .{},
 
 pub fn deinit(self: *LinkerDefined, allocator: Allocator) void {
     self.symtab.deinit(allocator);

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -654,6 +654,21 @@ pub fn allocateAtoms(self: Object, elf_file: *Elf) void {
     }
 }
 
+pub fn initRelaSections(self: Object, elf_file: *Elf) !void {
+    _ = self;
+    _ = elf_file;
+}
+
+pub fn updateRelaSectionsSizes(self: Object, elf_file: *Elf) void {
+    _ = self;
+    _ = elf_file;
+}
+
+pub fn writeRelaSections(self: Object, elf_file: *Elf) !void {
+    _ = self;
+    _ = elf_file;
+}
+
 pub fn updateArSymtab(self: Object, ar_symtab: *Archive.ArSymtab, elf_file: *Elf) !void {
     const gpa = elf_file.base.allocator;
     const start = self.first_global orelse self.symtab.items.len;

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -668,6 +668,7 @@ pub fn initRelaSections(self: Object, elf_file: *Elf) !void {
         const out_shdr = &elf_file.shdrs.items[out_shndx];
         out_shdr.sh_addralign = @alignOf(elf.Elf64_Rela);
         out_shdr.sh_entsize = @sizeOf(elf.Elf64_Rela);
+        out_shdr.sh_info = self.initOutputSection(elf_file, atom.inputShdr(elf_file)) catch unreachable;
     }
 }
 

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -687,6 +687,7 @@ pub fn initRelaSections(self: Object, elf_file: *Elf) !void {
         const out_shdr = &elf_file.shdrs.items[out_shndx];
         out_shdr.sh_addralign = @alignOf(elf.Elf64_Rela);
         out_shdr.sh_entsize = @sizeOf(elf.Elf64_Rela);
+        out_shdr.sh_flags |= elf.SHF_INFO_LINK;
     }
 }
 

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -681,9 +681,9 @@ pub fn addAtomsToRelaSections(self: Object, elf_file: *Elf) !void {
         const out_shndx = self.initOutputSection(elf_file, shdr) catch unreachable;
 
         const gpa = elf_file.base.allocator;
-        const gop = try elf_file.output_rela_sections.getOrPut(gpa, out_shndx);
-        if (!gop.found_existing) gop.value_ptr.* = .{};
-        try gop.value_ptr.append(gpa, atom_index);
+        const gop = try elf_file.output_rela_sections.getOrPut(gpa, atom.outputShndx().?);
+        if (!gop.found_existing) gop.value_ptr.* = .{ .shndx = out_shndx };
+        try gop.value_ptr.atom_list.append(gpa, atom_index);
     }
 }
 
@@ -718,11 +718,13 @@ pub fn writeAr(self: Object, writer: anytype) !void {
 }
 
 pub fn locals(self: Object) []const Symbol.Index {
+    if (self.symbols.items.len == 0) return &[0]Symbol.Index{};
     const end = self.first_global orelse self.symbols.items.len;
     return self.symbols.items[0..end];
 }
 
 pub fn globals(self: Object) []const Symbol.Index {
+    if (self.symbols.items.len == 0) return &[0]Symbol.Index{};
     const start = self.first_global orelse self.symbols.items.len;
     return self.symbols.items[start..];
 }

--- a/src/link/Elf/SharedObject.zig
+++ b/src/link/Elf/SharedObject.zig
@@ -21,7 +21,7 @@ verdef_sect_index: ?u16 = null,
 needed: bool,
 alive: bool,
 
-output_symtab_size: Elf.SymtabSize = .{},
+output_symtab_ctx: Elf.SymtabCtx = .{},
 
 pub fn isSharedObject(path: []const u8) !bool {
     const file = try std.fs.cwd().openFile(path, .{});

--- a/src/link/Elf/Symbol.zig
+++ b/src/link/Elf/Symbol.zig
@@ -219,8 +219,6 @@ pub fn setOutputSym(symbol: Symbol, elf_file: *Elf, out: *elf.Elf64_Sym) void {
     const st_shndx = blk: {
         if (symbol.flags.has_copy_rel) break :blk elf_file.copy_rel_section_index.?;
         if (file_ptr == .shared_object or esym.st_shndx == elf.SHN_UNDEF) break :blk elf.SHN_UNDEF;
-        // TODO I think this is wrong and obsolete
-        if (elf_file.isRelocatable() and st_type == elf.STT_SECTION) break :blk symbol.outputShndx().?;
         if (symbol.atom(elf_file) == null and file_ptr != .linker_defined)
             break :blk elf.SHN_ABS;
         break :blk symbol.outputShndx() orelse elf.SHN_UNDEF;

--- a/src/link/Elf/Symbol.zig
+++ b/src/link/Elf/Symbol.zig
@@ -107,8 +107,8 @@ pub fn address(symbol: Symbol, opts: struct { plt: bool = true }, elf_file: *Elf
     return symbol.value;
 }
 
-pub fn outputSymtabIndex(symbol: Symbol, elf_file: *Elf) u32 {
-    assert(symbol.flags.output_symtab);
+pub fn outputSymtabIndex(symbol: Symbol, elf_file: *Elf) ?u32 {
+    if (!symbol.flags.output_symtab) return null;
     const file_ptr = symbol.file(elf_file).?;
     const symtab_ctx = switch (file_ptr) {
         inline else => |x| x.output_symtab_ctx,

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -287,22 +287,6 @@ pub fn addAtom(self: *ZigObject, elf_file: *Elf) !Symbol.Index {
     return symbol_index;
 }
 
-pub fn addSectionSymbol(self: *ZigObject, shndx: u16, elf_file: *Elf) !void {
-    assert(elf_file.isRelocatable());
-    const gpa = elf_file.base.allocator;
-    const symbol_index = try elf_file.addSymbol();
-    try self.local_symbols.append(gpa, symbol_index);
-    const symbol_ptr = elf_file.symbol(symbol_index);
-    symbol_ptr.file_index = self.index;
-    symbol_ptr.output_section_index = shndx;
-
-    const esym_index = try self.addLocalEsym(gpa);
-    const esym = &self.local_esyms.items(.elf_sym)[esym_index];
-    esym.st_info = elf.STT_SECTION;
-    esym.st_shndx = shndx;
-    symbol_ptr.esym_index = esym_index;
-}
-
 /// TODO actually create fake input shdrs and return that instead.
 pub fn inputShdr(self: ZigObject, atom_index: Atom.Index, elf_file: *Elf) Object.ElfShdr {
     _ = self;

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -538,6 +538,8 @@ pub fn addAtomsToRelaSections(self: ZigObject, elf_file: *Elf) !void {
         if (!atom.flags.alive) continue;
         _ = atom.relocsShndx() orelse continue;
         const out_shndx = atom.outputShndx().?;
+        const out_shdr = elf_file.shdrs.items[out_shndx];
+        if (out_shdr.sh_type == elf.SHT_NOBITS) continue;
 
         const gpa = elf_file.base.allocator;
         const sec = elf_file.output_rela_sections.getPtr(out_shndx).?;

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -75,6 +75,7 @@ pub fn init(self: *ZigObject, elf_file: *Elf) !void {
     const gpa = elf_file.base.allocator;
 
     try self.atoms.append(gpa, 0); // null input section
+    try self.relocs.append(gpa, .{}); // null relocs section
     try self.strtab.buffer.append(gpa, 0);
 
     const name_off = try self.strtab.insert(gpa, self.path);

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -377,8 +377,7 @@ pub fn claimUnresolvedObject(self: ZigObject, elf_file: *Elf) void {
 
         const global = elf_file.symbol(index);
         if (global.file(elf_file)) |file| {
-            if (global.elfSym(elf_file).st_shndx != elf.SHN_UNDEF or
-                file.index() <= self.index) continue;
+            if (global.elfSym(elf_file).st_shndx != elf.SHN_UNDEF or file.index() <= self.index) continue;
         }
 
         global.value = 0;

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -541,9 +541,8 @@ pub fn addAtomsToRelaSections(self: ZigObject, elf_file: *Elf) !void {
         const out_shndx = atom.outputShndx().?;
 
         const gpa = elf_file.base.allocator;
-        const gop = try elf_file.output_rela_sections.getOrPut(gpa, out_shndx);
-        if (!gop.found_existing) gop.value_ptr.* = .{};
-        try gop.value_ptr.append(gpa, atom_index);
+        const sec = elf_file.output_rela_sections.getPtr(out_shndx).?;
+        try sec.atom_list.append(gpa, atom_index);
     }
 }
 

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -549,7 +549,7 @@ pub fn writeAr(self: ZigObject, elf_file: *Elf, writer: anytype) !void {
     try writer.writeAll(contents);
 }
 
-pub fn updateRelaSectionSizes(self: ZigObject, elf_file: *Elf) void {
+pub fn updateRelaSectionsSizes(self: ZigObject, elf_file: *Elf) void {
     _ = self;
 
     for (&[_]?u16{

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -18,7 +18,7 @@ relocs: std.ArrayListUnmanaged(std.ArrayListUnmanaged(elf.Elf64_Rela)) = .{},
 
 num_dynrelocs: u32 = 0,
 
-output_symtab_size: Elf.SymtabSize = .{},
+output_symtab_ctx: Elf.SymtabCtx = .{},
 output_ar_state: Archive.ArState = .{},
 
 dwarf: ?Dwarf = null,
@@ -533,94 +533,17 @@ pub fn writeAr(self: ZigObject, elf_file: *Elf, writer: anytype) !void {
     try writer.writeAll(contents);
 }
 
-pub fn updateRelaSectionsSizes(self: ZigObject, elf_file: *Elf) void {
-    _ = self;
+pub fn addAtomsToRelaSections(self: ZigObject, elf_file: *Elf) !void {
+    for (self.atoms.items) |atom_index| {
+        const atom = elf_file.atom(atom_index) orelse continue;
+        if (!atom.flags.alive) continue;
+        _ = atom.relocsShndx() orelse continue;
+        const out_shndx = atom.outputShndx().?;
 
-    for (&[_]?u16{
-        elf_file.zig_text_rela_section_index,
-        elf_file.zig_data_rel_ro_rela_section_index,
-        elf_file.zig_data_rela_section_index,
-    }) |maybe_index| {
-        const index = maybe_index orelse continue;
-        const shdr = &elf_file.shdrs.items[index];
-        const meta = elf_file.last_atom_and_free_list_table.get(@intCast(shdr.sh_info)).?;
-        const last_atom_index = meta.last_atom_index;
-
-        var atom = elf_file.atom(last_atom_index) orelse continue;
-        while (true) {
-            const relocs = atom.relocs(elf_file);
-            shdr.sh_size += relocs.len * shdr.sh_entsize;
-            if (elf_file.atom(atom.prev_index)) |prev| {
-                atom = prev;
-            } else break;
-        }
-    }
-
-    for (&[_]?u16{
-        elf_file.zig_text_rela_section_index,
-        elf_file.zig_data_rel_ro_rela_section_index,
-        elf_file.zig_data_rela_section_index,
-    }) |maybe_index| {
-        const index = maybe_index orelse continue;
-        const shdr = &elf_file.shdrs.items[index];
-        if (shdr.sh_size == 0) shdr.sh_offset = 0;
-    }
-}
-
-pub fn writeRelaSections(self: ZigObject, elf_file: *Elf) !void {
-    const gpa = elf_file.base.allocator;
-
-    for (&[_]?u16{
-        elf_file.zig_text_rela_section_index,
-        elf_file.zig_data_rel_ro_rela_section_index,
-        elf_file.zig_data_rela_section_index,
-    }) |maybe_index| {
-        const index = maybe_index orelse continue;
-        const shdr = elf_file.shdrs.items[index];
-        const meta = elf_file.last_atom_and_free_list_table.get(@intCast(shdr.sh_info)).?;
-        const last_atom_index = meta.last_atom_index;
-
-        var atom = elf_file.atom(last_atom_index) orelse continue;
-
-        var relocs = std.ArrayList(elf.Elf64_Rela).init(gpa);
-        defer relocs.deinit();
-        try relocs.ensureTotalCapacityPrecise(@intCast(@divExact(shdr.sh_size, shdr.sh_entsize)));
-
-        while (true) {
-            for (atom.relocs(elf_file)) |rel| {
-                const target = elf_file.symbol(self.symbol(rel.r_sym()));
-                const r_offset = atom.value + rel.r_offset;
-                const r_sym: u32 = if (target.flags.global)
-                    (target.esym_index & symbol_mask) + @as(u32, @intCast(self.local_esyms.slice().len))
-                else
-                    target.esym_index;
-                const r_type = switch (rel.r_type()) {
-                    Elf.R_X86_64_ZIG_GOT32,
-                    Elf.R_X86_64_ZIG_GOTPCREL,
-                    => unreachable, // Sanity check if we accidentally emitted those.
-                    else => |r_type| r_type,
-                };
-                relocs.appendAssumeCapacity(.{
-                    .r_offset = r_offset,
-                    .r_addend = rel.r_addend,
-                    .r_info = (@as(u64, @intCast(r_sym + 1)) << 32) | r_type,
-                });
-            }
-            if (elf_file.atom(atom.prev_index)) |prev| {
-                atom = prev;
-            } else break;
-        }
-
-        const SortRelocs = struct {
-            pub fn lessThan(ctx: void, lhs: elf.Elf64_Rela, rhs: elf.Elf64_Rela) bool {
-                _ = ctx;
-                return lhs.r_offset < rhs.r_offset;
-            }
-        };
-
-        mem.sort(elf.Elf64_Rela, relocs.items, {}, SortRelocs.lessThan);
-
-        try elf_file.base.file.?.pwriteAll(mem.sliceAsBytes(relocs.items), shdr.sh_offset);
+        const gpa = elf_file.base.allocator;
+        const gop = try elf_file.output_rela_sections.getOrPut(gpa, out_shndx);
+        if (!gop.found_existing) gop.value_ptr.* = .{};
+        try gop.value_ptr.append(gpa, atom_index);
     }
 }
 

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -136,8 +136,7 @@ pub const File = union(enum) {
             if (local.atom(elf_file)) |atom| if (!atom.flags.alive) continue;
             const esym = local.elfSym(elf_file);
             switch (esym.st_type()) {
-                elf.STT_SECTION => if (!elf_file.isRelocatable()) continue,
-                elf.STT_NOTYPE => continue,
+                elf.STT_SECTION, elf.STT_NOTYPE => continue,
                 else => {},
             }
             local.flags.output_symtab = true;

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -165,8 +165,7 @@ pub const File = union(enum) {
     pub fn writeSymtab(file: File, elf_file: *Elf) void {
         for (file.locals()) |local_index| {
             const local = elf_file.symbol(local_index);
-            if (!local.flags.output_symtab) continue;
-            const idx = local.outputSymtabIndex(elf_file);
+            const idx = local.outputSymtabIndex(elf_file) orelse continue;
             const out_sym = &elf_file.symtab.items[idx];
             out_sym.st_name = @intCast(elf_file.strtab.items.len);
             elf_file.strtab.appendSliceAssumeCapacity(local.name(elf_file));
@@ -178,11 +177,10 @@ pub const File = union(enum) {
             const global = elf_file.symbol(global_index);
             const file_ptr = global.file(elf_file) orelse continue;
             if (file_ptr.index() != file.index()) continue;
-            if (!global.flags.output_symtab) continue;
+            const idx = global.outputSymtabIndex(elf_file) orelse continue;
             const st_name = @as(u32, @intCast(elf_file.strtab.items.len));
             elf_file.strtab.appendSliceAssumeCapacity(global.name(elf_file));
             elf_file.strtab.appendAssumeCapacity(0);
-            const idx = global.outputSymtabIndex(elf_file);
             const out_sym = &elf_file.symtab.items[idx];
             out_sym.st_name = st_name;
             global.setOutputSym(elf_file, out_sym);

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -1527,7 +1527,7 @@ pub const ComdatGroupSection = struct {
         const cg = elf_file.comdatGroup(cgs.cg_index);
         const object = cgs.file(elf_file).?.object;
         const members = object.comdatGroupMembers(cg.shndx);
-        try writeInt(@as(u32, elf.GRP_COMDAT), elf_file, writer);
+        try writer.writeInt(u32, elf.GRP_COMDAT, .little);
         for (members) |shndx| {
             const shdr = object.shdrs.items[shndx];
             switch (shdr.sh_type) {
@@ -1535,12 +1535,12 @@ pub const ComdatGroupSection = struct {
                     const atom_index = object.atoms.items[shdr.sh_info];
                     const atom = elf_file.atom(atom_index).?;
                     const rela = elf_file.output_rela_sections.get(atom.outputShndx().?).?;
-                    try writeInt(rela.shndx, elf_file, writer);
+                    try writer.writeInt(u32, rela.shndx, .little);
                 },
                 else => {
                     const atom_index = object.atoms.items[shndx];
                     const atom = elf_file.atom(atom_index).?;
-                    try writeInt(atom.outputShndx().?, elf_file, writer);
+                    try writer.writeInt(u32, atom.outputShndx().?, .little);
                 },
             }
         }

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -1499,6 +1499,30 @@ pub const VerneedSection = struct {
     }
 };
 
+pub const ComdatGroupSection = struct {
+    shndx: u32,
+    cg_index: u32,
+
+    // pub fn size(cg: ComdatGroupSection) usize {
+    //     return cg.members.items.len + 1;
+    // }
+
+    // pub fn write(cg: ComdatGroupSection, elf_file: *Elf, writer: anytype) !void {
+    //     try writeInt(@as(u32, elf.GRP_COMDAT), elf_file, writer);
+    //     for (cg.members.items) |atom_index| {
+    //         const atom = elf_file.atom(atom_index);
+    //         const input_shdr = atom.inputShdr(elf_file);
+    //         switch (input_shdr.sh_type) {
+    //             elf.SHT_RELA => {
+
+    //         },
+    //             else => {},
+    //         }
+    //     }
+    //     try writer.writeAll(mem.sliceAsBytes(cg.members.items));
+    // }
+};
+
 fn writeInt(value: anytype, elf_file: *Elf, writer: anytype) !void {
     const entry_size = elf_file.archPtrWidthBytes();
     const endian = elf_file.base.options.target.cpu.arch.endian();

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -2167,7 +2167,7 @@ fn testRelocatableEhFrame(b: *Build, opts: Options) *Step {
         \\  try {
         \\    try_again();
         \\  } catch (const std::exception &e) {
-        \\    std::cout << "exception=" << e.what() << std::endl;
+        \\    std::cout << "exception=" << e.what();
         \\  }
         \\  return 0;
         \\}


### PR DESCRIPTION
- [x] combine and emit a relocatable with patched up sections and relocations
- [x] test for both LLVM and x86 backends
- [x] emit relocations for `.eh_frame` section
- [x] emit COMDAT groups