### PR TITLE
Fix io_uring tests on kernel 5.4

### DIFF
--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -2072,6 +2072,7 @@ test "openat" {
     const cqe_openat = try ring.copy_cqe();
     try testing.expectEqual(@as(u64, 0x33333333), cqe_openat.user_data);
     if (cqe_openat.err() == .INVAL) return error.SkipZigTest;
+    if (cqe_openat.err() == .BADF) return error.SkipZigTest;
     if (cqe_openat.res <= 0) std.debug.print("\ncqe_openat.res={}\n", .{cqe_openat.res});
     try testing.expect(cqe_openat.res > 0);
     try testing.expectEqual(@as(u32, 0), cqe_openat.flags);
@@ -2500,6 +2501,8 @@ test "statx" {
         // The filesystem containing the file referred to by fd does not support this operation;
         // or the mode is not supported by the filesystem containing the file referred to by fd:
         .OPNOTSUPP => return error.SkipZigTest,
+        // not supported on older kernels (5.4)
+        .BADF => return error.SkipZigTest,
         else => |errno| std.debug.panic("unhandled errno: {}", .{errno}),
     }
     try testing.expectEqual(linux.io_uring_cqe{
@@ -3145,6 +3148,7 @@ test "remove_buffers" {
 
         const cqe = try ring.copy_cqe();
         switch (cqe.err()) {
+            .INVAL => return error.SkipZigTest,
             .SUCCESS => {},
             else => |errno| std.debug.panic("unhandled errno: {}", .{errno}),
         }
@@ -3235,6 +3239,8 @@ test "provide_buffers: accept/connect/send/recv" {
         switch (cqe.err()) {
             // Happens when the kernel is < 5.7
             .INVAL => return error.SkipZigTest,
+            // Happens on the kernel 5.4
+            .BADF => return error.SkipZigTest,
             .SUCCESS => {},
             else => |errno| std.debug.panic("unhandled errno: {}", .{errno}),
         }

--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -2329,7 +2329,8 @@ test "timeout_remove" {
     // * kernel 5.18 gives user data 0x99999999 first, 0x88888888 second
 
     var cqes: [2]os.linux.io_uring_cqe = undefined;
-    try testing.expectEqual(@as(u32, 2), try ring.copy_cqes(cqes[0..], 2));
+    cqes[0] = try ring.copy_cqe();
+    cqes[1] = try ring.copy_cqe();
 
     for (cqes) |cqe| {
         // IORING_OP_TIMEOUT_REMOVE is not supported by this kernel version:


### PR DESCRIPTION

Unsupported tests are now skipped on kernel 5.4:
```
uname -a
Linux d20 5.4.0-166-generic 
zig test lib/std/std.zig --zig-lib-dir lib --main-mod-path lib/std 2>&1 | cat
...
709/2616 test.nop... OK
710/2616 test.readv... OK
711/2616 test.writev/fsync/readv... OK
712/2616 test.write/read... SKIP
713/2616 test.splice/read... SKIP
714/2616 test.write_fixed/read_fixed... OK
715/2616 test.openat... SKIP
716/2616 test.close... SKIP
717/2616 test.accept/connect/send/recv... SKIP
718/2616 test.sendmsg/recvmsg... OK
719/2616 test.timeout (after a relative time)... SKIP
720/2616 test.timeout (after a number of completions)... OK
721/2616 test.timeout_remove... SKIP
722/2616 test.accept/connect/recv/link_timeout... SKIP
723/2616 test.fallocate... SKIP
724/2616 test.statx... SKIP
725/2616 test.accept/connect/recv/cancel... SKIP
726/2616 test.register_files_update... SKIP
727/2616 test.shutdown... SKIP
728/2616 test.renameat... SKIP
729/2616 test.unlinkat... SKIP
730/2616 test.mkdirat... SKIP
731/2616 test.symlinkat... SKIP
732/2616 test.linkat... SKIP
733/2616 test.provide_buffers: read... SKIP
734/2616 test.remove_buffers... SKIP
735/2616 test.provide_buffers: accept/connect/send/recv... SKIP
736/2616 test.accept multishot... SKIP
```

On the newer kernel they are all passing: 
```
uname -a
Linux dev 6.5.0-10-generic 
zig test lib/std/std.zig --zig-lib-dir lib --main-mod-path lib/std 2>&1 | cat
...
708/2616 test.structs/offsets/entries... OK
709/2616 test.nop... OK
710/2616 test.readv... OK
711/2616 test.writev/fsync/readv... OK
712/2616 test.write/read... OK
713/2616 test.splice/read... OK
714/2616 test.write_fixed/read_fixed... OK
715/2616 test.openat... OK
716/2616 test.close... OK
717/2616 test.accept/connect/send/recv... OK
718/2616 test.sendmsg/recvmsg... OK
719/2616 test.timeout (after a relative time)... OK
720/2616 test.timeout (after a number of completions)... OK
721/2616 test.timeout_remove... OK
722/2616 test.accept/connect/recv/link_timeout... OK
723/2616 test.fallocate... OK
724/2616 test.statx... OK
725/2616 test.accept/connect/recv/cancel... OK
726/2616 test.register_files_update... OK
727/2616 test.shutdown... OK
728/2616 test.renameat... OK
729/2616 test.unlinkat... OK
730/2616 test.mkdirat... OK
731/2616 test.symlinkat... OK
732/2616 test.linkat... OK
733/2616 test.provide_buffers: read... OK
734/2616 test.remove_buffers... OK
735/2616 test.provide_buffers: accept/connect/send/recv... OK
736/2616 test.accept multishot... OK
```

Fixes: #13974
