### PR TITLE
Sema: do not force resolution of struct field inits when calling function pointer field

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -26652,8 +26652,9 @@ fn finishFieldCallBind(
 
     const container_ty = ptr_ty.childType(mod);
     if (container_ty.zigTypeTag(mod) == .Struct) {
-        try sema.resolveStructFieldInits(container_ty);
-        if (try container_ty.structFieldValueComptime(mod, field_index)) |default_val| {
+        if (container_ty.structFieldIsComptime(field_index, mod)) {
+            try sema.resolveStructFieldInits(container_ty);
+            const default_val = (try container_ty.structFieldValueComptime(mod, field_index)).?;
             return .{ .direct = Air.internedToRef(default_val.toIntern()) };
         }
     }

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1842,3 +1842,18 @@ test "circular dependency through pointer field of a struct" {
     try expect(outer.middle.outer == null);
     try expect(outer.middle.inner == null);
 }
+
+test "field calls do not force struct field init resolution" {
+    const S = struct {
+        x: u32 = blk: {
+            _ = @TypeOf(make().dummyFn()); // runtime field call - S not fully resolved - dummyFn call should not force field init resolution
+            break :blk 123;
+        },
+        dummyFn: *const fn () void = undefined,
+        fn make() @This() {
+            return .{};
+        }
+    };
+    var s: S = .{};
+    try expect(s.x == 123);
+}


### PR DESCRIPTION
b3462b7 caused a regression in a third-party project, since it forced resolution of field initializers for any field call 'foo.bar()', despite this only being necessary when 'bar' is a comptime field.

See https://github.com/ziglang/zig/pull/17692#issuecomment-1802096734.