### PR TITLE
std.unicode: Disable utf8 -> utf16 ASCII fast path on mips

### DIFF
--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -942,7 +942,8 @@ pub fn utf8ToUtf16LeWithNull(allocator: mem.Allocator, utf8: []const u8) ![:0]u1
     errdefer result.deinit();
 
     var remaining = utf8;
-    if (builtin.zig_backend != .stage2_x86_64) {
+    // Need support for std.simd.interlace
+    if (builtin.zig_backend != .stage2_x86_64 and comptime !builtin.cpu.arch.isMIPS()) {
         const chunk_len = std.simd.suggestVectorSize(u8) orelse 1;
         const Chunk = @Vector(chunk_len, u8);
 
@@ -986,7 +987,8 @@ pub fn utf8ToUtf16Le(utf16le: []u16, utf8: []const u8) !usize {
     var dest_i: usize = 0;
 
     var remaining = utf8;
-    if (builtin.zig_backend != .stage2_x86_64) {
+    // Need support for std.simd.interlace
+    if (builtin.zig_backend != .stage2_x86_64 and comptime !builtin.cpu.arch.isMIPS()) {
         const chunk_len = std.simd.suggestVectorSize(u8) orelse 1;
         const Chunk = @Vector(chunk_len, u8);
 


### PR DESCRIPTION
Fixes a compile error when the target is mips, since `std.simd.interlace` does not work correctly on mips and raises a compile error if it is used.

https://github.com/ziglang/zig/blob/2ac0ba03a60a133e7ffbab9ad6aaf3b54f6c747b/lib/std/simd.zig#L131-L136

Follow up to https://github.com/ziglang/zig/pull/17797