### PR TITLE
Sema: preserve 'undefined' in @bitCast

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -30719,6 +30719,8 @@ fn bitCast(
     }
 
     if (try sema.resolveValue(inst)) |val| {
+        if (val.isUndef(mod))
+            return mod.undefRef(dest_ty);
         if (try sema.bitCastVal(block, inst_src, val, old_ty, dest_ty, 0)) |result_val| {
             return Air.internedToRef(result_val.toIntern());
         }


### PR DESCRIPTION
Currently there is invalid behavior in cases such as following
```zig
const x = packed struct{ f: u8, };
@compileLog(@as(x, @bitCast(@as(u8, undefined))));
```
```
Compile Log Output:
@as(example.main.x, .{.f = 170})
```
this patch add one more check to comptime-known 'undefiefd':
```
Compile Log Output:
@as(example.main.x, undefined)
```