### PR TITLE
std.os.windows: add `SetConsoleMode`

### DIFF
--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -165,6 +165,7 @@ pub extern "kernel32" fn GetCommandLineA() callconv(WINAPI) LPSTR;
 pub extern "kernel32" fn GetCommandLineW() callconv(WINAPI) LPWSTR;
 
 pub extern "kernel32" fn GetConsoleMode(in_hConsoleHandle: HANDLE, out_lpMode: *DWORD) callconv(WINAPI) BOOL;
+pub extern "kernel32" fn SetConsoleMode(in_hConsoleHandle: HANDLE, in_dwMode: DWORD) callconv(WINAPI) BOOL;
 
 pub extern "kernel32" fn GetConsoleOutputCP() callconv(WINAPI) UINT;
 


### PR DESCRIPTION
This is crucial for enabling ANSI escape sequences on Windows. If Zig is not going to enable it by default, at least make the sys calls easily available for the boilerplate init procedure:

```zig
test {

    const std = @import("std")
    const kernel32 = std.os.windows.kernel32;
    var stdout_mode: u32 = undefined;
    _ = kernel32.GetConsoleMode(std.io.getStdOut().handle, &stdout_mode);
    _ = kernel32.SetConsoleMode(std.io.getStdOut().handle, stdout_mode|4);

    std.debug.print("\n\x1b[30;47m" ++ "That's all," ++ "\x1b[m" ++ " folks\n", .{});

}
```

Whereas before, without this change you'd need to do:

```zig
test {

    const std = @import("std");
    const kernel32 = opaque {
        usingnamespace std.os.windows.kernel32;
        extern "kernel32" fn SetConsoleMode(*anyopaque,u32) callconv(std.os.windows.WINAPI) c_int;
    };
    var stdout_mode: u32 = undefined;
    _ = kernel32.GetConsoleMode(std.io.getStdOut().handle, &stdout_mode);
    _ = kernel32.SetConsoleMode(std.io.getStdOut().handle, stdout_mode|4);

    std.debug.print("\n\x1b[30;47m" ++ "That's all," ++ "\x1b[m" ++ " folks\n", .{});

}
```