### PR TITLE
add precompiled c/c++ header support to zig build

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -1504,9 +1504,8 @@ fn createModuleDependenciesForStep(step: *Step) Allocator.Error!void {
             .special => {},
         };
         for (mod.link_objects.items) |link_object| switch (link_object) {
-            .static_path,
-            .assembly_file,
-            => |lp| lp.addStepDependencies(step),
+            .static_path => |lp| lp.addStepDependencies(step),
+            .assembly_file => |source| source.file.addStepDependencies(step),
             .other_step => |other| step.dependOn(&other.step),
             .system_lib => {},
             .c_source_file => |source| source.file.addStepDependencies(step),

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -1546,11 +1546,17 @@ fn createModuleDependenciesForStep(step: *Step) Allocator.Error!void {
             .system_lib => {},
             .c_source_file => |source| {
                 source.file.addStepDependencies(step);
-                if (source.precompiled_header) |pch| pch.addStepDependencies(step);
+                if (source.precompiled_header) |pch| switch (pch) {
+                    .source_header => |src| src.path.addStepDependencies(step),
+                    .pch_step => |s| step.dependOn(&s.step),
+                };
             },
             .c_source_files => |source_files| {
                 source_files.root.addStepDependencies(step);
-                if (source_files.precompiled_header) |pch| pch.addStepDependencies(step);
+                if (source_files.precompiled_header) |pch| switch (pch) {
+                    .source_header => |src| src.path.addStepDependencies(step),
+                    .pch_step => |s| step.dependOn(&s.step),
+                };
             },
             .win32_resource_file => |rc_source| {
                 rc_source.file.addStepDependencies(step);

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -340,6 +340,10 @@ pub fn main() !void {
         createModuleDependencies(builder) catch @panic("OOM");
     }
 
+    for (builder.top_level_steps.values()) |s| {
+        try finalizeSteps(&s.step);
+    }
+
     if (graph.needed_lazy_dependencies.entries.len != 0) {
         var buffer: std.ArrayListUnmanaged(u8) = .empty;
         for (graph.needed_lazy_dependencies.keys()) |k| {
@@ -637,6 +641,7 @@ fn runStepNames(
         test_count += s.test_results.test_count;
 
         switch (s.state) {
+            .unfinalized => unreachable,
             .precheck_unstarted => unreachable,
             .precheck_started => unreachable,
             .running => unreachable,
@@ -782,6 +787,7 @@ fn printStepStatus(
     run: *const Run,
 ) !void {
     switch (s.state) {
+        .unfinalized => unreachable,
         .precheck_unstarted => unreachable,
         .precheck_started => unreachable,
         .precheck_done => unreachable,
@@ -979,6 +985,34 @@ fn printTreeStep(
     }
 }
 
+/// Traverse the dependency graph after the user build() call,
+/// this allows for checks and postprocessing after the steps are fully configured by the user.
+fn finalizeSteps(
+    s: *Step,
+) !void {
+    switch (s.state) {
+        .unfinalized => {
+            try s.finalize();
+            s.state = .precheck_unstarted;
+
+            for (s.dependencies.items) |dep| {
+                try finalizeSteps(dep);
+            }
+        },
+
+        .precheck_unstarted => {},
+
+        .precheck_started => unreachable,
+        .precheck_done => unreachable,
+        .dependency_failure => unreachable,
+        .running => unreachable,
+        .success => unreachable,
+        .failure => unreachable,
+        .skipped => unreachable,
+        .skipped_oom => unreachable,
+    }
+}
+
 /// Traverse the dependency graph depth-first and make it undirected by having
 /// steps know their dependants (they only know dependencies at start).
 /// Along the way, check that there is no dependency loop, and record the steps
@@ -997,6 +1031,7 @@ fn constructGraphAndCheckForDependencyLoop(
     rand: std.Random,
 ) !void {
     switch (s.state) {
+        .unfinalized => unreachable,
         .precheck_started => {
             std.debug.print("dependency loop detected:\n  {s}\n", .{s.name});
             return error.DependencyLoopDetected;
@@ -1059,6 +1094,7 @@ fn workerMakeOneStep(
                 // dependency is not finished yet.
                 return;
             },
+            .unfinalized => unreachable,
             .precheck_unstarted => unreachable,
             .precheck_started => unreachable,
         }
@@ -1508,8 +1544,14 @@ fn createModuleDependenciesForStep(step: *Step) Allocator.Error!void {
             .assembly_file => |source| source.file.addStepDependencies(step),
             .other_step => |other| step.dependOn(&other.step),
             .system_lib => {},
-            .c_source_file => |source| source.file.addStepDependencies(step),
-            .c_source_files => |source_files| source_files.root.addStepDependencies(step),
+            .c_source_file => |source| {
+                source.file.addStepDependencies(step);
+                if (source.precompiled_header) |pch| pch.addStepDependencies(step);
+            },
+            .c_source_files => |source_files| {
+                source_files.root.addStepDependencies(step);
+                if (source_files.precompiled_header) |pch| pch.addStepDependencies(step);
+            },
             .win32_resource_file => |rc_source| {
                 rc_source.file.addStepDependencies(step);
                 for (rc_source.include_paths) |lp| lp.addStepDependencies(step);

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -828,6 +828,31 @@ pub fn addObject(b: *Build, options: ObjectOptions) *Step.Compile {
     });
 }
 
+pub const PchOptions = struct {
+    name: []const u8,
+    target: ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    max_rss: usize = 0,
+    link_libc: ?bool = null,
+    link_libcpp: ?bool = null,
+};
+
+pub fn addPrecompiledCHeader(b: *Build, options: PchOptions, source: Module.CSourceFile) *Step.Compile {
+    const pch = Step.Compile.create(b, .{
+        .name = options.name,
+        .root_module = .{
+            .target = options.target,
+            .optimize = options.optimize,
+            .link_libc = options.link_libc,
+            .link_libcpp = options.link_libcpp,
+        },
+        .kind = .pch,
+        .max_rss = options.max_rss,
+    });
+    pch.root_module.addCSourceFile(source);
+    return pch;
+}
+
 pub const SharedLibraryOptions = struct {
     name: []const u8,
     version: ?std.SemanticVersion = null,

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -840,12 +840,12 @@ pub const PchOptions = struct {
 pub fn addPrecompiledCHeader(b: *Build, options: PchOptions, source: Module.CSourceFile) *Step.Compile {
     const pch = Step.Compile.create(b, .{
         .name = options.name,
-        .root_module = .{
+        .root_module = b.createModule(.{
             .target = options.target,
             .optimize = options.optimize,
             .link_libc = options.link_libc,
             .link_libcpp = options.link_libcpp,
-        },
+        }),
         .kind = .pch,
         .max_rss = options.max_rss,
     });

--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -157,18 +157,21 @@ pub const CSourceFiles = struct {
     /// if null, deduce the language from the file extension
     lang: ?CSourceLang = null,
     flags: []const []const u8,
+    precompiled_header: ?LazyPath = null,
 };
 
 pub const CSourceFile = struct {
     file: LazyPath,
     lang: ?CSourceLang = null,
     flags: []const []const u8 = &.{},
+    precompiled_header: ?LazyPath = null,
 
     pub fn dupe(file: CSourceFile, b: *std.Build) CSourceFile {
         return .{
             .file = file.file.dupe(b),
             .lang = file.lang,
             .flags = b.dupeStrings(file.flags),
+            .precompiled_header = file.precompiled_header,
         };
     }
 };
@@ -454,6 +457,7 @@ pub const AddCSourceFilesOptions = struct {
     files: []const []const u8,
     lang: ?CSourceLang = null,
     flags: []const []const u8 = &.{},
+    precompiled_header: ?LazyPath = null,
 };
 
 /// Handy when you have many C/C++ source files and want them all to have the same flags.
@@ -476,6 +480,7 @@ pub fn addCSourceFiles(m: *Module, options: AddCSourceFilesOptions) void {
         .files = b.dupeStrings(options.files),
         .lang = options.lang,
         .flags = b.dupeStrings(options.flags),
+        .precompiled_header = options.precompiled_header,
     };
     m.link_objects.append(allocator, .{ .c_source_files = c_source_files }) catch @panic("OOM");
 }

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -284,6 +284,7 @@ pub const Kind = enum {
     exe,
     lib,
     obj,
+    pch,
     @"test",
 };
 
@@ -368,6 +369,7 @@ pub fn create(owner: *std.Build, options: Options) *Compile {
             .exe => "zig build-exe",
             .lib => "zig build-lib",
             .obj => "zig build-obj",
+            .pch => "zig build-pch",
             .@"test" => "zig test",
         },
         name_adjusted,
@@ -375,17 +377,21 @@ pub fn create(owner: *std.Build, options: Options) *Compile {
         resolved_target.query.zigTriple(owner.allocator) catch @panic("OOM"),
     });
 
-    const out_filename = std.zig.binNameAlloc(owner.allocator, .{
-        .root_name = name,
-        .target = target,
-        .output_mode = switch (options.kind) {
-            .lib => .Lib,
-            .obj => .Obj,
-            .exe, .@"test" => .Exe,
-        },
-        .link_mode = options.linkage,
-        .version = options.version,
-    }) catch @panic("OOM");
+    const out_filename = if (options.kind == .pch)
+        std.fmt.allocPrint(owner.allocator, "{s}.pch", .{name}) catch @panic("OOM")
+    else
+        std.zig.binNameAlloc(owner.allocator, .{
+            .root_name = name,
+            .target = target,
+            .output_mode = switch (options.kind) {
+                .lib => .Lib,
+                .obj => .Obj,
+                .exe, .@"test" => .Exe,
+                .pch => unreachable,
+            },
+            .link_mode = options.linkage,
+            .version = options.version,
+        }) catch @panic("OOM");
 
     const compile = owner.allocator.create(Compile) catch @panic("OOM");
     compile.* = .{
@@ -799,10 +805,12 @@ pub fn linkFramework(c: *Compile, name: []const u8) void {
 
 /// Handy when you have many C/C++ source files and want them all to have the same flags.
 pub fn addCSourceFiles(compile: *Compile, options: Module.AddCSourceFilesOptions) void {
+    assert(compile.kind != .pch); // pch can only be generated from a single C header file
     compile.root_module.addCSourceFiles(options);
 }
 
 pub fn addCSourceFile(compile: *Compile, source: Module.CSourceFile) void {
+    assert(compile.kind != .pch); // pch can only be generated from a single C header file
     compile.root_module.addCSourceFile(source);
 }
 
@@ -810,6 +818,7 @@ pub fn addCSourceFile(compile: *Compile, source: Module.CSourceFile) void {
 /// Can be called regardless of target. The .rc file will be ignored
 /// if the target object format does not support embedded resources.
 pub fn addWin32ResourceFile(compile: *Compile, source: Module.RcSourceFile) void {
+    assert(compile.kind != .pch); // pch can only be generated from a single C header file
     compile.root_module.addWin32ResourceFile(source);
 }
 
@@ -890,14 +899,17 @@ pub fn getEmittedLlvmBc(compile: *Compile) LazyPath {
 }
 
 pub fn addAssemblyFile(compile: *Compile, source: Module.AsmSourceFile) void {
+    assert(compile.kind != .pch); // pch can only be generated from a single C header file
     compile.root_module.addAssemblyFile(source);
 }
 
 pub fn addObjectFile(compile: *Compile, source: LazyPath) void {
+    assert(compile.kind != .pch); // pch can only be generated from a single C header file
     compile.root_module.addObjectFile(source);
 }
 
 pub fn addObject(compile: *Compile, object: *Compile) void {
+    assert(compile.kind != .pch); // pch can only be generated from a single C header file
     compile.root_module.addObject(object);
 }
 
@@ -1021,6 +1033,7 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
         .lib => "build-lib",
         .exe => "build-exe",
         .obj => "build-obj",
+        .pch => "build-pch",
         .@"test" => "test",
     };
     try zig_args.append(cmd);
@@ -1086,6 +1099,14 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                 if (mod.link_libc == true) compile.is_linking_libc = true;
                 if (mod.link_libcpp == true) compile.is_linking_libcpp = true;
             }
+        }
+
+        if (compile.kind == .pch) {
+            // precompiled headers must have a single input header file.
+            const deps = compile.getCompileDependencies(false);
+            assert(deps.len == 1);
+            const link_objects = deps[0].root_module.link_objects.items;
+            assert(link_objects.len == 1 and link_objects[0] == .c_source_file);
         }
 
         var cli_named_modules = try CliNamedModules.init(arena, compile.root_module);
@@ -1198,6 +1219,7 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                             switch (other.kind) {
                                 .exe => return step.fail("cannot link with an executable build artifact", .{}),
                                 .@"test" => return step.fail("cannot link with a test", .{}),
+                                .pch => return step.fail("cannot link with a precompiled header file", .{}),
                                 .obj => {
                                     const included_in_lib_or_obj = !my_responsibility and
                                         (dep_compile.kind == .lib or dep_compile.kind == .obj);

--- a/lib/std/Build/Step/InstallArtifact.zig
+++ b/lib/std/Build/Step/InstallArtifact.zig
@@ -57,6 +57,7 @@ pub fn create(owner: *std.Build, artifact: *Step.Compile, options: Options) *Ins
         .disabled => null,
         .default => switch (artifact.kind) {
             .obj => @panic("object files have no standard installation procedure"),
+            .pch => @panic("precompiled headers have no standard installation procedure"),
             .exe, .@"test" => .bin,
             .lib => if (artifact.isDll()) .bin else .lib,
         },

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4720,11 +4720,11 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
             else
                 "/dev/null";
 
-            try argv.ensureUnusedCapacity(6);
+            try argv.ensureUnusedCapacity(7);
             switch (comp.clang_preprocessor_mode) {
                 .no => argv.appendSliceAssumeCapacity(&.{ "-c", "-o", out_obj_path }),
                 .yes => argv.appendSliceAssumeCapacity(&.{ "-E", "-o", out_obj_path }),
-                .pch => argv.appendSliceAssumeCapacity(&.{ "-Xclang", "-emit-pch", "-o", out_obj_path }),
+                .pch => argv.appendSliceAssumeCapacity(&.{ "-Xclang", "-emit-pch", "-fpch-validate-input-files-content", "-o", out_obj_path }),
                 .stdout => argv.appendAssumeCapacity("-E"),
             }
 
@@ -4763,11 +4763,11 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
         try argv.appendSlice(c_object.src.extra_flags);
         try argv.appendSlice(c_object.src.cache_exempt_flags);
 
-        try argv.ensureUnusedCapacity(6);
+        try argv.ensureUnusedCapacity(7);
         switch (comp.clang_preprocessor_mode) {
             .no => argv.appendSliceAssumeCapacity(&.{ "-c", "-o", out_obj_path }),
             .yes => argv.appendSliceAssumeCapacity(&.{ "-E", "-o", out_obj_path }),
-            .pch => argv.appendSliceAssumeCapacity(&.{ "-Xclang", "-emit-pch", "-o", out_obj_path }),
+            .pch => argv.appendSliceAssumeCapacity(&.{ "-Xclang", "-emit-pch", "-fpch-validate-input-files-content", "-o", out_obj_path }),
             .stdout => argv.appendAssumeCapacity("-E"),
         }
         if (out_diag_path) |diag_file_path| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -87,6 +87,7 @@ const normal_usage =
     \\  build-exe        Create executable from source or object files
     \\  build-lib        Create library from source or object files
     \\  build-obj        Create object from source or object files
+    \\  build-pch        Create a precompiled header from a c or c++ header
     \\  test             Perform unit testing
     \\  run              Create executable and run immediately
     \\
@@ -268,6 +269,8 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     } else if (mem.eql(u8, cmd, "build-obj")) {
         dev.check(.build_obj_command);
         return buildOutputType(gpa, arena, args, .{ .build = .Obj });
+    } else if (mem.eql(u8, cmd, "build-pch")) {
+        return buildOutputType(gpa, arena, args, .pch);
     } else if (mem.eql(u8, cmd, "test")) {
         dev.check(.test_command);
         return buildOutputType(gpa, arena, args, .zig_test);
@@ -386,6 +389,7 @@ const usage_build_generic =
     \\Usage: zig build-exe   [options] [files]
     \\       zig build-lib   [options] [files]
     \\       zig build-obj   [options] [files]
+    \\       zig build-pch   [options] [files]
     \\       zig test        [options] [files]
     \\       zig run         [options] [files] [-- [args]]
     \\       zig translate-c [options] [file]
@@ -739,6 +743,7 @@ const ArgMode = union(enum) {
     build: std.builtin.OutputMode,
     cc,
     cpp,
+    pch,
     translate_c,
     zig_test,
     run,
@@ -1005,10 +1010,14 @@ fn buildOutputType(
     var n_jobs: ?u32 = null;
 
     switch (arg_mode) {
-        .build, .translate_c, .zig_test, .run => {
+        .build, .translate_c, .zig_test, .run, .pch => {
             switch (arg_mode) {
                 .build => |m| {
                     create_module.opts.output_mode = m;
+                },
+                .pch => {
+                    create_module.opts.output_mode = .Obj;
+                    clang_preprocessor_mode = .pch;
                 },
                 .translate_c => {
                     emit_bin = .no;

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -2918,7 +2918,7 @@ fn testSharedAbsSymbol(b: *Build, opts: Options) *Step {
     addAsmSourceBytes(dso,
         \\.globl foo
         \\foo = 3;
-    );
+    , &.{});
 
     const obj = addObject(b, opts, .{
         .name = "obj",
@@ -3533,7 +3533,7 @@ fn testTlsLargeTbss(b: *Build, opts: Options) *Step {
         \\.section .tcommon,"awT",@nobits
         \\y:
         \\.zero 1024
-    );
+    , &.{});
     addCSourceBytes(exe,
         \\#include <stdio.h>
         \\extern _Thread_local char x[1024000];

--- a/test/link/macho.zig
+++ b/test/link/macho.zig
@@ -630,13 +630,13 @@ fn testHeaderWeakFlags(b: *Build, opts: Options) *Step {
                 \\_main:
                 \\  bl _x
                 \\  ret
-            ),
+            , &.{}),
             .x86_64 => addAsmSourceBytes(obj,
                 \\.globl _main
                 \\_main:
                 \\  callq _x
                 \\  ret
-            ),
+            , &.{}),
             else => unreachable,
         }
 

--- a/test/src/CompareOutput.zig
+++ b/test/src/CompareOutput.zig
@@ -104,7 +104,7 @@ pub fn addCase(self: *CompareOutput, case: TestCase) void {
                     .optimize = .Debug,
                 }),
             });
-            exe.root_module.addAssemblyFile(first_file);
+            exe.root_module.addAssemblyFile(.{ .file = first_file });
 
             const run = b.addRunArtifact(exe);
             run.setName(annotated_case_name);

--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -126,6 +126,9 @@
         .c_compiler = .{
             .path = "c_compiler",
         },
+        .c_header = .{
+            .path = "c_header",
+        },
         .pie = .{
             .path = "pie",
         },

--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -24,6 +24,9 @@
         .mix_c_files = .{
             .path = "mix_c_files",
         },
+        .mix_lang_files = .{
+            .path = "mix_lang_files",
+        },
         .global_linkage = .{
             .path = "global_linkage",
         },

--- a/test/standalone/c_header/build.zig
+++ b/test/standalone/c_header/build.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // single-file c-header library
+    {
+        const exe = b.addExecutable(.{
+            .name = "single-file-library",
+            .root_source_file = b.path("main.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+
+        exe.linkLibC();
+        exe.addIncludePath(b.path("."));
+        exe.addCSourceFile(.{
+            .file = b.path("single_file_library.h"),
+            .lang = .c,
+            .flags = &.{"-DTSTLIB_IMPLEMENTATION"},
+        });
+
+        test_step.dependOn(&b.addRunArtifact(exe).step);
+    }
+}

--- a/test/standalone/c_header/include_a.h
+++ b/test/standalone/c_header/include_a.h
@@ -9,6 +9,7 @@
 #include <iostream>
 #else
 #include <stdio.h>
+#include <stdbool.h>
 #endif
 
 #define A_INCLUDED 1

--- a/test/standalone/c_header/include_a.h
+++ b/test/standalone/c_header/include_a.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "include_b.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+#if defined(__cplusplus)
+#include <iostream>
+#else
+#include <stdio.h>
+#endif
+
+#define A_INCLUDED 1
+

--- a/test/standalone/c_header/include_b.h
+++ b/test/standalone/c_header/include_b.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <math.h>
+
+typedef double real;
+
+#define B_INCLUDED 1

--- a/test/standalone/c_header/main.zig
+++ b/test/standalone/c_header/main.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+const C = @cImport({
+    @cInclude("single_file_library.h");
+});
+
+pub fn main() !void {
+    const msg = "hello";
+    const val = C.tstlib_len(msg);
+    if (val != msg.len)
+        std.process.exit(1);
+}

--- a/test/standalone/c_header/single_file_library.h
+++ b/test/standalone/c_header/single_file_library.h
@@ -1,0 +1,14 @@
+// library header:
+extern unsigned tstlib_len(const char* msg);
+
+// library implementation:
+#ifdef TSTLIB_IMPLEMENTATION
+
+#include <string.h>
+
+unsigned tstlib_len(const char* msg)
+{
+    return strlen(msg);
+}
+
+#endif

--- a/test/standalone/c_header/test.c
+++ b/test/standalone/c_header/test.c
@@ -1,0 +1,22 @@
+
+// includes commented out to make sure the symbols come from the precompiled header.
+//#include "include_a.h"
+//#include "include_b.h"
+
+#ifndef A_INCLUDED
+#error "pch not included"
+#endif
+#ifndef B_INCLUDED
+#error "pch not included"
+#endif
+
+int main(int argc, char *argv[])
+{
+	real a = 0.123;
+
+	if (argc > 1) {
+		fprintf(stdout, "abs(%g)=%g\n", a, fabs(a));
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/test/standalone/c_header/test.c2
+++ b/test/standalone/c_header/test.c2
@@ -10,10 +10,11 @@
 #error "pch not included"
 #endif
 
-extern int func(real a, bool cond);
-
-int main(int argc, char *argv[])
+int func(real a, bool cond)
 {
-	real a = 0.123;
-	return func(a, (argc > 1));
+	if (cond) {
+		fprintf(stdout, "abs(%g)=%g\n", a, fabs(a));
+	}
+
+	return EXIT_SUCCESS;
 }

--- a/test/standalone/c_header/test.cpp
+++ b/test/standalone/c_header/test.cpp
@@ -1,0 +1,23 @@
+
+// includes commented out to make sure the symbols come from the precompiled header.
+//#include "includeA.h"
+//#include "includeB.h"
+
+#ifndef A_INCLUDED
+#error "pch not included"
+#endif
+#ifndef B_INCLUDED
+#error "pch not included"
+#endif
+
+int main(int argc, char *argv[])
+{
+	real a = -0.123;
+
+	if (argc > 1) {
+		std::cout << "abs(" << a << ")=" << fabs(a) << "\n";
+	}
+
+	return EXIT_SUCCESS;
+}
+

--- a/test/standalone/mix_lang_files/build.zig
+++ b/test/standalone/mix_lang_files/build.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    const target = b.standardTargetOptions(.{});
+
+    add(b, test_step, target, .Debug);
+    add(b, test_step, target, .ReleaseFast);
+    add(b, test_step, target, .ReleaseSmall);
+    add(b, test_step, target, .ReleaseSafe);
+}
+
+fn add(b: *std.Build, test_step: *std.Build.Step, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) void {
+    const lib = b.addStaticLibrary(.{
+        .name = "test",
+        .root_source_file = b.path("test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const options = b.addOptions();
+    const exe = b.addExecutable(.{
+        .name = "test",
+        .root_source_file = b.path("main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.root_module.addOptions("build_options", options);
+
+    exe.addCSourceFile(.{ .file = b.path("test.c"), .flags = &[_][]const u8{"-std=c11"} });
+    exe.addCSourceFile(.{ .file = b.path("test.c++"), .flags = &[_][]const u8{ "-fno-exceptions", "-fno-rtti" } });
+
+    exe.addCSourceFile(.{ .file = b.path("test.m") });
+
+    var with_asm = false;
+    if (target.result.os.tag == .linux) {
+        switch (target.result.cpu.arch) {
+            .x86_64 => {
+                exe.addAssemblyFile(.{ .file = b.path("test_x86_64.s") });
+                with_asm = true;
+            },
+            .aarch64 => {
+                exe.addAssemblyFile(.{ .file = b.path("test_aarch64.s") });
+                with_asm = true;
+            },
+            else => {},
+        }
+    }
+    options.addOption(bool, "with_asm", with_asm);
+
+    const with_asm_prep = switch (target.result.cpu.arch) {
+        .x86_64, .x86, .aarch64, .arm, .riscv64 => true,
+        else => false,
+    };
+    if (with_asm_prep) exe.addAssemblyFile(.{ .file = b.path("test.S"), .lang = .assembly_with_cpp, .flags = &[_][]const u8{"-DNO_ERROR"} });
+    options.addOption(bool, "with_asm_prep", with_asm_prep);
+
+    exe.addCSourceFile(.{ .file = b.path("test.h"), .lang = .cpp, .flags = &[_][]const u8{"-DIMPLEMENTATION"} });
+
+    exe.linkLibrary(lib);
+    //exe.linkLibC();
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.skip_foreign_checks = true;
+    run_cmd.expectExitCode(0);
+
+    test_step.dependOn(&run_cmd.step);
+}

--- a/test/standalone/mix_lang_files/main.zig
+++ b/test/standalone/mix_lang_files/main.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+const build_options = @import("build_options");
+
+extern fn add_C(x: i32, a: i32) i32;
+extern fn add_CXX(x: i32, a: i32) i32;
+extern fn add_objc(x: i32, a: i32) i32;
+extern fn add_asm_prep(x: i32, a: i32) i32;
+extern fn add_asm(x: i32, a: i32) i32;
+extern fn add_C_header(x: i32, a: i32) i32;
+extern fn add_lib_zig(x: i32, a: i32) i32;
+
+pub fn main() anyerror!void {
+    var val: i32 = 0;
+    var ref: i32 = 0;
+
+    val = add_lib_zig(val, 1);
+    ref = ref + 1;
+
+    val = add_C(val, 10);
+    ref = ref + 10;
+
+    val = add_CXX(val, 100);
+    ref = ref + 100;
+
+    if (build_options.with_asm) {
+        val = add_asm(val, 100);
+        ref = ref + 100;
+    }
+
+    if (build_options.with_asm_prep) {
+        val = add_asm_prep(val, 1000);
+        ref = ref + 1000;
+    }
+
+    val = add_objc(val, 10000);
+    ref = ref + 10000;
+
+    val = add_C_header(val, 100000);
+    ref = ref + 100000;
+
+    //x = add_C_header(x, 10000);
+
+    try std.testing.expectEqual(ref, val);
+}

--- a/test/standalone/mix_lang_files/test.S
+++ b/test/standalone/mix_lang_files/test.S
@@ -1,0 +1,67 @@
+#ifndef NO_ERROR
+#error "missing define
+#endif
+
+.text
+
+#if  defined(__APPLE__)
+.global _add_asm_prep
+_add_asm_prep:
+#else
+.global add_asm_prep
+add_asm_prep:
+#endif
+
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
+    #if defined(__x86_64__)
+        mov     %edi, %eax
+        add     %esi, %eax
+        ret
+
+    #elif defined(__i386__)
+        mov     4(%esp), %eax
+        add     8(%esp), %eax
+        ret
+
+    #elif defined(__aarch64__)
+        add     w0, w0, w1
+        ret
+
+    #elif defined(__arm__)
+        add     r0, r0, r1
+        bx      lr
+
+    #elif defined(__riscv) && __riscv_xlen == 64
+        add     a0, a0, a1
+        ret
+
+    #else
+        #error "Architecture not supported"
+    #endif
+
+#elif defined(_WIN32) || defined(_WIN64)
+    #if defined(_M_X64) || defined(__x86_64__)
+        mov     %ecx, %eax
+        add     %edx, %eax
+        ret
+
+    #elif defined(_M_IX86) || defined(__i386__)
+        mov     4(%esp), %eax
+        add     8(%esp), %eax
+        ret
+
+    #elif defined(_M_ARM64) || defined(__aarch64__)
+        add     w0, w0, w1
+        ret
+
+    #elif defined(_M_ARM) || defined(__arm__)
+        add     r0, r0, r1
+        bx      lr
+
+    #else
+        #error "Architecture not supported"
+    #endif
+
+#else
+    #error "Platform not supported"
+#endif

--- a/test/standalone/mix_lang_files/test.c
+++ b/test/standalone/mix_lang_files/test.c
@@ -1,0 +1,1 @@
+int add_C(int x, int a) { return x+a; }

--- a/test/standalone/mix_lang_files/test.c++
+++ b/test/standalone/mix_lang_files/test.c++
@@ -1,0 +1,12 @@
+template <typename T>
+class Adder {
+    const T increment;
+public:
+    Adder(T _increment) : increment(_increment) {}
+    T add(T x) const  { return x + increment; }
+};
+
+extern "C" int add_CXX(int x, int a) {
+    Adder<int> adder(a);
+    return adder.add(x);
+}

--- a/test/standalone/mix_lang_files/test.h
+++ b/test/standalone/mix_lang_files/test.h
@@ -1,0 +1,10 @@
+
+extern "C" int add_C_header(int x, int a);
+
+#ifdef IMPLEMENTATION
+
+int add_C_header(int x, int a) {
+    return x+a;
+}
+
+#endif

--- a/test/standalone/mix_lang_files/test.m
+++ b/test/standalone/mix_lang_files/test.m
@@ -1,0 +1,6 @@
+
+@class NSObject;
+
+int add_objc(int x, int a) {
+    return x+a;
+}

--- a/test/standalone/mix_lang_files/test.zig
+++ b/test/standalone/mix_lang_files/test.zig
@@ -1,0 +1,3 @@
+export fn add_lib_zig(x: i32, a: i32) i32 {
+    return x + a;
+}

--- a/test/standalone/mix_lang_files/test_aarch64.s
+++ b/test/standalone/mix_lang_files/test_aarch64.s
@@ -1,0 +1,6 @@
+.text
+.global add_asm
+.type   add_asm,@function
+add_asm:
+        add     w0, w0, w1
+        ret

--- a/test/standalone/mix_lang_files/test_x86_64.s
+++ b/test/standalone/mix_lang_files/test_x86_64.s
@@ -1,0 +1,6 @@
+.text
+.global add_asm
+add_asm:
+        mov     %edi, %eax
+        add     %esi, %eax
+        ret


### PR DESCRIPTION
It gets my c++ project full rebuild time from
```
real	10m13.212s
user	139m23.711s
sys	12m1.938s
```

to 
```
real	4m52.636s
user	64m52.851s
sys	5m59.472s
```

pch are a little bit different from other compile steps:
- like binary object files they are built by the C compiler from a (single) source header file.
- however, unlike binary object files, they are not to be fed to the linker, but  as a companion source file to subsequent C compiles.

