### PR TITLE
std.fs.IterabDir.Iterator.next(): not assume that FILE_BOTH_DIR_INFORMATION is correctly aligned

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -749,7 +749,9 @@ pub const IterableDir = struct {
                         }
                     }
 
-                    const dir_info: *w.FILE_BOTH_DIR_INFORMATION = @ptrCast(@alignCast(&self.buf[self.index]));
+                    // While the official api docs guarantee FILE_BOTH_DIR_INFORMATION to be aligned properly
+                    // this may not always be the case (e.g. due to faulty VM/Sandboxing tools)
+                    const dir_info: *align(2) w.FILE_BOTH_DIR_INFORMATION = @ptrCast(@alignCast(&self.buf[self.index]));
                     if (dir_info.NextEntryOffset != 0) {
                         self.index += dir_info.NextEntryOffset;
                     } else {


### PR DESCRIPTION
This PR relaxes the assumed alignment of `FILE_BOTH_DIR_INFORMATION` in the windows implementation of `std.fs.IterabDir.Iterator.next()`.

I am quite new to zig, so I will happily receive any feedback about how this could be done differently - especially concerning the potential performance penalty of this.

## Background

The current windows implementation of `std.fs.IterabDir.Iterator.next()` makes the assumption that the FILE_BOTH_DIR_INFORMATION  struct returned by `NtQueryDirectoryFile` is aligned properly.

See https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_file_both_dir_information
> This structure must be aligned on a LONGLONG (8-byte) boundary. If a buffer contains two or more of these structures, the NextEntryOffset value in each entry, except the last, falls on an 8-byte boundary.

However, in practice this is not always guaranteed due to faulty file system drivers, sandboxing tools, or (in my case) endpoint security software.
Currently, this code will panic on the `@alignCast()` which makes it impossible for the user to work around this issue if it appears.

For context, I found that the same issue appeared in Rust:
 - Main issue: https://github.com/rust-lang/rust/issues/104530
 - Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1799442
 - Sandboxie (apparently triggering this issue in Firefox): https://github.com/sandboxie-plus/Sandboxie/issues/2443
 
 
 