### PR TITLE
compilation: forbid PIE for dynamic libraries

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1295,7 +1295,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
         const sysroot = options.sysroot orelse libc_dirs.sysroot;
 
         const pie: bool = pie: {
-            if (options.output_mode != .Exe) {
+            if (is_dyn_lib) {
                 if (options.want_pie == true) return error.OutputModeForbidsPie;
                 break :pie false;
             }


### PR DESCRIPTION
but allow for { .exe, .o, .a }.

closes #17928

- tested this does not regress #17575