### PR TITLE
sema: fixup underflows during struct / ptr array init when using -fstrip

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4814,7 +4814,7 @@ fn validateStructInit(
 
             // Possible performance enhancement: save the `block_index` between iterations
             // of the for loop.
-            var block_index = block.instructions.items.len - 1;
+            var block_index = block.instructions.items.len -| 1;
             while (block_index > 0) : (block_index -= 1) {
                 const store_inst = block.instructions.items[block_index];
                 if (Air.indexToRef(store_inst) == field_ptr_ref) {
@@ -5070,7 +5070,7 @@ fn zirValidatePtrArrayInit(
 
         // Possible performance enhancement: save the `block_index` between iterations
         // of the for loop.
-        var block_index = block.instructions.items.len - 1;
+        var block_index = block.instructions.items.len -| 1;
         while (block_index > 0) : (block_index -= 1) {
             const store_inst = block.instructions.items[block_index];
             if (Air.indexToRef(store_inst) == elem_ptr_ref) {

--- a/test/standalone.zig
+++ b/test/standalone.zig
@@ -235,6 +235,10 @@ pub const build_cases = [_]BuildCase{
         .import = @import("standalone/strip_empty_loop/build.zig"),
     },
     .{
+        .build_root = "test/standalone/strip_struct_init",
+        .import = @import("standalone/strip_struct_init/build.zig"),
+    },
+    .{
         .build_root = "test/standalone/cmakedefine",
         .import = @import("standalone/cmakedefine/build.zig"),
     },

--- a/test/standalone/strip_struct_init/build.zig
+++ b/test/standalone/strip_struct_init/build.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    const optimize: std.builtin.OptimizeMode = .Debug;
+
+    const main = b.addTest(.{
+        .root_source_file = .{ .path = "main.zig" },
+        .optimize = optimize,
+    });
+    main.strip = true;
+
+    test_step.dependOn(&b.addRunArtifact(main).step);
+}

--- a/test/standalone/strip_struct_init/main.zig
+++ b/test/standalone/strip_struct_init/main.zig
@@ -1,0 +1,23 @@
+fn Func(comptime Type: type) type {
+    return struct { value: Type };
+}
+
+inline fn func(value: anytype) Func(@TypeOf(value)) {
+    return .{ .value = value };
+}
+
+test {
+    _ = func(type);
+}
+
+test {
+    const S = struct { field: u32 };
+    comptime var arr: [1]S = undefined;
+    arr[0] = .{ .field = 0 };
+}
+
+test {
+    const S = struct { u32 };
+    comptime var arr: [1]S = undefined;
+    arr[0] = .{0};
+}


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/15469

Where would be the best place to introduce these tests using -fstrip for this?

```
fn Func(comptime Type: type) type {
    return struct { value: Type };
}
inline fn func(value: anytype) Func(@TypeOf(value)) {
    return .{ .value = value };
}
export fn entry() void {
    _ = func(type);
}

test {
    const S = struct { field: u32 };
    comptime var arr: [1]S = undefined;
    arr[0] = .{ .field = 0 };
}

test {
    const S = struct { u32 };
    comptime var arr: [1]S = undefined;
    arr[0] = .{0};
}
```