### PR TITLE
std.Uri: fix parsing edge case panic

### DIFF
--- a/lib/std/Uri.zig
+++ b/lib/std/Uri.zig
@@ -176,6 +176,11 @@ pub fn parseWithoutScheme(text: []const u8) ParseError!Uri {
 
         var end_of_host: usize = authority.len;
 
+        // if  we see `]` firsst without `@`
+        if (authority[start_of_host] == ']') {
+            return error.InvalidFormat;
+        }
+
         if (authority.len > start_of_host and authority[start_of_host] == '[') { // IPv6
             end_of_host = std.mem.lastIndexOf(u8, authority, "]") orelse return error.InvalidFormat;
             end_of_host += 1;
@@ -193,6 +198,7 @@ pub fn parseWithoutScheme(text: []const u8) ParseError!Uri {
             }
         }
 
+        if (start_of_host >= end_of_host) return error.InvalidFormat;
         uri.host = authority[start_of_host..end_of_host];
     }
 
@@ -779,4 +785,11 @@ test "format" {
     defer buf.deinit();
     try uri.format(":/?#", .{}, buf.writer());
     try std.testing.expectEqualSlices(u8, "file:/foo/bar/baz", buf.items);
+}
+
+test "URI malformed input" {
+    // Originally reported at https://github.com/ziglang/zig/issues/17869
+    try std.testing.expectError(error.InvalidFormat, std.Uri.parse("http://]["));
+    try std.testing.expectError(error.InvalidFormat, std.Uri.parse("http://]@["));
+    try std.testing.expectError(error.InvalidFormat, std.Uri.parse("http://lo]s\x85hc@[/8\x10?0Q"));
 }

--- a/lib/std/Uri.zig
+++ b/lib/std/Uri.zig
@@ -176,7 +176,7 @@ pub fn parseWithoutScheme(text: []const u8) ParseError!Uri {
 
         var end_of_host: usize = authority.len;
 
-        // if  we see `]` firsst without `@`
+        // if  we see `]` first without `@`
         if (authority[start_of_host] == ']') {
             return error.InvalidFormat;
         }
@@ -788,7 +788,6 @@ test "format" {
 }
 
 test "URI malformed input" {
-    // Originally reported at https://github.com/ziglang/zig/issues/17869
     try std.testing.expectError(error.InvalidFormat, std.Uri.parse("http://]["));
     try std.testing.expectError(error.InvalidFormat, std.Uri.parse("http://]@["));
     try std.testing.expectError(error.InvalidFormat, std.Uri.parse("http://lo]s\x85hc@[/8\x10?0Q"));


### PR DESCRIPTION
Fixes: https://github.com/ziglang/zig/issues/17869

The issue suggested `error.unexpectedCharacter`, but `error.InvalidFormat` felt more fitting since these are expected characters, just in the wrong order.

This is a pretty tactical change, no hard feelings if we prefer a different approach.