### PR TITLE
rework memory management of Module.Namespace hash maps

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2522,18 +2522,6 @@ pub fn update(comp: *Compilation, main_progress_node: *std.Progress.Node) !void 
             try module.populateTestFunctions(main_progress_node);
         }
 
-        // Process the deletion set. We use a while loop here because the
-        // deletion set may grow as we call `clearDecl` within this loop,
-        // and more unreferenced Decls are revealed.
-        while (module.deletion_set.count() != 0) {
-            const decl_index = module.deletion_set.keys()[0];
-            const decl = module.declPtr(decl_index);
-            assert(decl.deletion_flag);
-            assert(decl.zir_decl_index != .none);
-
-            try module.clearDecl(decl_index, null);
-        }
-
         try module.processExports();
     }
 
@@ -3684,16 +3672,6 @@ pub fn performAllTheWork(
 
     if (comp.bin_file.options.module) |mod| {
         try reportMultiModuleErrors(mod);
-    }
-
-    {
-        const outdated_and_deleted_decls_frame = tracy.namedFrame("outdated_and_deleted_decls");
-        defer outdated_and_deleted_decls_frame.end();
-
-        // Iterate over all the files and look for outdated and deleted declarations.
-        if (comp.bin_file.options.module) |mod| {
-            try mod.processOutdatedAndDeletedDecls();
-        }
     }
 
     if (comp.bin_file.options.module) |mod| {

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -6151,7 +6151,6 @@ fn finishFuncInstance(
         .@"linksection" = section,
         .@"addrspace" = fn_owner_decl.@"addrspace",
         .analysis = .complete,
-        .deletion_flag = false,
         .zir_decl_index = fn_owner_decl.zir_decl_index,
         .src_scope = fn_owner_decl.src_scope,
         .generation = generation,
@@ -7617,7 +7616,11 @@ pub fn createNamespace(
 }
 
 pub fn destroyNamespace(ip: *InternPool, gpa: Allocator, index: Module.Namespace.Index) void {
-    ip.namespacePtr(index).* = undefined;
+    ip.namespacePtr(index).* = .{
+        .parent = undefined,
+        .file_scope = undefined,
+        .ty = undefined,
+    };
     ip.namespaces_free_list.append(gpa, index) catch {
         // In order to keep `destroyNamespace` a non-fallible function, we ignore memory
         // allocation failures here, instead leaking the Namespace until garbage collection.

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -2506,8 +2506,9 @@ pub fn genTypeDecl(
 }
 
 pub fn genGlobalAsm(mod: *Module, writer: anytype) !void {
-    var it = mod.global_assembly.valueIterator();
-    while (it.next()) |asm_source| try writer.print("__asm({s});\n", .{fmtStringLiteral(asm_source.*, null)});
+    for (mod.global_assembly.values()) |asm_source| {
+        try writer.print("__asm({s});\n", .{fmtStringLiteral(asm_source, null)});
+    }
 }
 
 pub fn genErrDecls(o: *Object) !void {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1121,8 +1121,9 @@ pub const Object = struct {
         const mod = object.module;
 
         const writer = object.builder.setModuleAsm();
-        var it = mod.global_assembly.valueIterator();
-        while (it.next()) |assembly| try writer.print("{s}\n", .{assembly.*});
+        for (mod.global_assembly.values()) |assembly| {
+            try writer.print("{s}\n", .{assembly});
+        }
         try object.builder.finishModuleAsm();
     }
 


### PR DESCRIPTION
The motivating problem here was a memory leak in the hash maps of Module.Namespace.

The commit deletes more of the legacy incremental compilation implementation. It had things like use of orderedRemove and trying to do too much OOP-style creation and deletion of objects.

Instead, this commit iterates over all the namespaces on Module deinit and calls deinit on the hash map fields. This logic is much simpler to reason about.

Similarly, change global inline assembly to an array hash map since iterating over the values is a primary use of it, and clean up the remaining values on Module deinit, solving another memory leak.

After this there are no more memory leaks remaining when using the x86 backend in a libc-less compiler.