### PR TITLE
adjust building from source without LLVM process

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,13 @@ In this case, the only system dependency is a C compiler.
 
 ```
 cc -o bootstrap bootstrap.c
-./bootstrap build
+./bootstrap
 ```
 
-You can pass any options to this that you would pass to `zig build` (see
-`--help` for options).
-
-[Without LLVM extensions](https://github.com/ziglang/zig/issues/16270), a Zig
-compiler is missing these features:
+This produces a `zig2` executable in the current working directory. This is a
+"stage2" build of the compiler,
+[without LLVM extensions](https://github.com/ziglang/zig/issues/16270), and is
+therefore lacking these features:
 - Release mode optimizations
 - aarch64 machine code backend
 - `@cImport` / `zig translate-c`
@@ -86,13 +85,16 @@ compiler is missing these features:
 - [Some ELF linking features](https://github.com/ziglang/zig/issues/17749)
 - [Most COFF/PE linking features](https://github.com/ziglang/zig/issues/17751)
 - [Some WebAssembly linking features](https://github.com/ziglang/zig/issues/17750)
-- [COFF linking](https://github.com/ziglang/zig/issues/17751)
 - [Ability to output LLVM bitcode](https://github.com/ziglang/zig/issues/13265)
 - [Windows resource file compilation](https://github.com/ziglang/zig/issues/17752)
 - [Ability to create import libs from def files](https://github.com/ziglang/zig/issues/17807)
 - [Automatic importlib file generation for Windows DLLs](https://github.com/ziglang/zig/issues/17753)
 - [Ability to create static archives from object files](https://github.com/ziglang/zig/issues/9828)
 - Ability to compile C++, Objective-C, and Objective-C++ files
+
+However, a compiler built this way does provide a C backend, which may be
+useful for creating system packages of Zig projects using the system C
+toolchain. In such case, LLVM is not needed!
 
 ## Contributing
 

--- a/bootstrap.c
+++ b/bootstrap.c
@@ -42,11 +42,6 @@ static void run(char **argv) {
     if (WEXITSTATUS(status) != 0)
         panic("child process failed");
 }
-
-static void run_execv(char **argv) {
-    if (execv(argv[0], argv) == -1 && errno == ENOENT) return;
-    perror("execv failed");
-}
 #endif
 
 static void print_and_run(const char **argv) {
@@ -87,9 +82,6 @@ static const char *get_host_triple(void) {
 }
 
 int main(int argc, char **argv) {
-    argv[0] = "./zig2";
-    run_execv(argv);
-
     const char *cc = get_c_compiler();
     const char *host_triple = get_host_triple();
 
@@ -188,7 +180,4 @@ int main(int argc, char **argv) {
         };
         print_and_run(child_argv);
     }
-
-    run_execv(argv);
-    panic("build script failed to create valid zig2 executable");
 }

--- a/ci/x86_64-linux-debug.sh
+++ b/ci/x86_64-linux-debug.sh
@@ -24,7 +24,8 @@ git fetch --tags
 git clean -fd
 rm -rf zig-out
 cc -o bootstrap bootstrap.c
-./bootstrap build -Dno-lib
+./bootstrap
+./zig2 build -Dno-lib
 # In order to run these behavior tests we need to move the `@cImport` ones to somewhere else.
 # ./zig-out/bin/zig test test/behavior.zig
 

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -24,7 +24,8 @@ git fetch --tags
 git clean -fd
 rm -rf zig-out
 cc -o bootstrap bootstrap.c
-./bootstrap build -Dno-lib
+./bootstrap
+./zig2 build -Dno-lib
 # In order to run these behavior tests we need to move the `@cImport` ones to somewhere else.
 # ./zig-out/bin/zig test test/behavior.zig
 


### PR DESCRIPTION
The idea here is that the zig2 executable is perhaps the more useful deliverable until we implement our own optimization passes. This will allow system packages to provide Zig, and use it to compile Zig projects, all without LLVM!