### PR TITLE
Add 'optional types' to json parse

### DIFF
--- a/lib/std/json/static.zig
+++ b/lib/std/json/static.zig
@@ -781,6 +781,8 @@ fn fillDefaultStructValues(comptime T: type, r: *T, fields_seen: *[@typeInfo(T).
             if (field.default_value) |default_ptr| {
                 const default = @as(*align(1) const field.type, @ptrCast(default_ptr)).*;
                 @field(r, field.name) = default;
+            } else if (@typeInfo(field.type) == .Optional) {
+                @field(r, field.name) = null;
             } else {
                 return error.MissingField;
             }


### PR DESCRIPTION
Code such as
```zig
const T = struct {
  x: u32,
  y: ?u32,
};
var stream = std.io.fixedBufferStream(
  \\ {
  \\   "x": 4,
  \\ }
);
var reader = std.json.reader(alloc, stream.reader());
defer reader.deinit();
const out = try std.json.parseFromTokenSource(T, alloc, &reader, .{});
std.debug.print("{any}\n", .{out});
```
Should return:
```
{ .x = 4, .y = null }
```
Instead of:
```
error: MissingField
```