### PR TITLE
Deprecate math.doNotOptimizeAway, use mem.doNotOptimizeAway

### DIFF
--- a/lib/compiler_rt/ceil.zig
+++ b/lib/compiler_rt/ceil.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const arch = builtin.cpu.arch;
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 const common = @import("common.zig");
 
@@ -47,14 +48,14 @@ pub fn ceilf(x: f32) callconv(.C) f32 {
         if (u & m == 0) {
             return x;
         }
-        math.doNotOptimizeAway(x + 0x1.0p120);
+        mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 == 0) {
             u += m;
         }
         u &= ~m;
         return @bitCast(u);
     } else {
-        math.doNotOptimizeAway(x + 0x1.0p120);
+        mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 != 0) {
             return -0.0;
         } else {
@@ -81,7 +82,7 @@ pub fn ceil(x: f64) callconv(.C) f64 {
     }
 
     if (e <= 0x3FF - 1) {
-        math.doNotOptimizeAway(y);
+        mem.doNotOptimizeAway(y);
         if (u >> 63 != 0) {
             return -0.0;
         } else {
@@ -115,7 +116,7 @@ pub fn ceilq(x: f128) callconv(.C) f128 {
     }
 
     if (e <= 0x3FFF - 1) {
-        math.doNotOptimizeAway(y);
+        mem.doNotOptimizeAway(y);
         if (u >> 127 != 0) {
             return -0.0;
         } else {

--- a/lib/compiler_rt/cos.zig
+++ b/lib/compiler_rt/cos.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 const common = @import("common.zig");
 
@@ -40,7 +41,7 @@ pub fn cosf(x: f32) callconv(.C) f32 {
     if (ix <= 0x3f490fda) { // |x| ~<= pi/4
         if (ix < 0x39800000) { // |x| < 2**-12
             // raise inexact if x != 0
-            math.doNotOptimizeAway(x + 0x1p120);
+            mem.doNotOptimizeAway(x + 0x1p120);
             return 1.0;
         }
         return trig.__cosdf(x);
@@ -91,7 +92,7 @@ pub fn cos(x: f64) callconv(.C) f64 {
     if (ix <= 0x3fe921fb) {
         if (ix < 0x3e46a09e) { // |x| < 2**-27 * sqrt(2)
             // raise inexact if x!=0
-            math.doNotOptimizeAway(x + 0x1p120);
+            mem.doNotOptimizeAway(x + 0x1p120);
             return 1.0;
         }
         return trig.__cos(x, 0);

--- a/lib/compiler_rt/exp.zig
+++ b/lib/compiler_rt/exp.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const arch = builtin.cpu.arch;
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 const common = @import("common.zig");
 
@@ -58,7 +59,7 @@ pub fn expf(x_: f32) callconv(.C) f32 {
             return x * 0x1.0p127;
         }
         if (sign != 0) {
-            math.doNotOptimizeAway(-0x1.0p-149 / x); // overflow
+            mem.doNotOptimizeAway(-0x1.0p-149 / x); // overflow
             // x <= -103.972084
             if (hx >= 0x42CFF1B5) {
                 return 0;
@@ -90,7 +91,7 @@ pub fn expf(x_: f32) callconv(.C) f32 {
         hi = x;
         lo = 0;
     } else {
-        math.doNotOptimizeAway(0x1.0p127 + x); // inexact
+        mem.doNotOptimizeAway(0x1.0p127 + x); // inexact
         return 1 + x;
     }
 
@@ -141,7 +142,7 @@ pub fn exp(x_: f64) callconv(.C) f64 {
         }
         if (x < -708.39641853226410622) {
             // underflow if x != -inf
-            // math.doNotOptimizeAway(@as(f32, -0x1.0p-149 / x));
+            // mem.doNotOptimizeAway(@as(f32, -0x1.0p-149 / x));
             if (x < -745.13321910194110842) {
                 return 0;
             }
@@ -174,7 +175,7 @@ pub fn exp(x_: f64) callconv(.C) f64 {
         lo = 0;
     } else {
         // inexact if x != 0
-        // math.doNotOptimizeAway(0x1.0p1023 + x);
+        // mem.doNotOptimizeAway(0x1.0p1023 + x);
         return 1 + x;
     }
 

--- a/lib/compiler_rt/exp2.zig
+++ b/lib/compiler_rt/exp2.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const arch = builtin.cpu.arch;
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 const common = @import("common.zig");
 
@@ -54,7 +55,7 @@ pub fn exp2f(x: f32) callconv(.C) f32 {
         // x < -126
         if (u >= 0x80000000) {
             if (u >= 0xC3160000 or u & 0x000FFFF != 0) {
-                math.doNotOptimizeAway(-0x1.0p-149 / x);
+                mem.doNotOptimizeAway(-0x1.0p-149 / x);
             }
             // x <= -150
             if (u >= 0x3160000) {
@@ -119,7 +120,7 @@ pub fn exp2(x: f64) callconv(.C) f64 {
         if (ux >> 63 != 0) {
             // underflow
             if (x <= -1075 or x - 0x1.0p52 + 0x1.0p52 != x) {
-                math.doNotOptimizeAway(@as(f32, @floatCast(-0x1.0p-149 / x)));
+                mem.doNotOptimizeAway(@as(f32, @floatCast(-0x1.0p-149 / x)));
             }
             if (x <= -1075) {
                 return 0;

--- a/lib/compiler_rt/floor.zig
+++ b/lib/compiler_rt/floor.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 const arch = builtin.cpu.arch;
 const common = @import("common.zig");
@@ -44,13 +45,13 @@ pub fn __floorh(x: f16) callconv(.C) f16 {
         if (u & m == 0) {
             return x;
         }
-        math.doNotOptimizeAway(x + 0x1.0p120);
+        mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 15 != 0) {
             u += m;
         }
         return @bitCast(u & ~m);
     } else {
-        math.doNotOptimizeAway(x + 0x1.0p120);
+        mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 15 == 0) {
             return 0.0;
         } else {
@@ -78,13 +79,13 @@ pub fn floorf(x: f32) callconv(.C) f32 {
         if (u & m == 0) {
             return x;
         }
-        math.doNotOptimizeAway(x + 0x1.0p120);
+        mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 != 0) {
             u += m;
         }
         return @bitCast(u & ~m);
     } else {
-        math.doNotOptimizeAway(x + 0x1.0p120);
+        mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 == 0) {
             return 0.0;
         } else {
@@ -111,7 +112,7 @@ pub fn floor(x: f64) callconv(.C) f64 {
     }
 
     if (e <= 0x3FF - 1) {
-        math.doNotOptimizeAway(y);
+        mem.doNotOptimizeAway(y);
         if (u >> 63 != 0) {
             return -1.0;
         } else {
@@ -145,7 +146,7 @@ pub fn floorq(x: f128) callconv(.C) f128 {
     }
 
     if (e <= 0x3FFF - 1) {
-        math.doNotOptimizeAway(y);
+        mem.doNotOptimizeAway(y);
         if (u >> 127 != 0) {
             return -1.0;
         } else {

--- a/lib/compiler_rt/round.zig
+++ b/lib/compiler_rt/round.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 const arch = builtin.cpu.arch;
 const common = @import("common.zig");
@@ -45,7 +46,7 @@ pub fn roundf(x_: f32) callconv(.C) f32 {
         x = -x;
     }
     if (e < 0x7F - 1) {
-        math.doNotOptimizeAway(x + f32_toint);
+        mem.doNotOptimizeAway(x + f32_toint);
         return 0 * @as(f32, @bitCast(u));
     }
 
@@ -80,7 +81,7 @@ pub fn round(x_: f64) callconv(.C) f64 {
         x = -x;
     }
     if (e < 0x3ff - 1) {
-        math.doNotOptimizeAway(x + f64_toint);
+        mem.doNotOptimizeAway(x + f64_toint);
         return 0 * @as(f64, @bitCast(u));
     }
 
@@ -120,7 +121,7 @@ pub fn roundq(x_: f128) callconv(.C) f128 {
         x = -x;
     }
     if (e < 0x3FFF - 1) {
-        math.doNotOptimizeAway(x + f128_toint);
+        mem.doNotOptimizeAway(x + f128_toint);
         return 0 * @as(f128, @bitCast(u));
     }
 

--- a/lib/compiler_rt/sin.zig
+++ b/lib/compiler_rt/sin.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const arch = builtin.cpu.arch;
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 const common = @import("common.zig");
 
@@ -48,7 +49,7 @@ pub fn sinf(x: f32) callconv(.C) f32 {
     if (ix <= 0x3f490fda) { // |x| ~<= pi/4
         if (ix < 0x39800000) { // |x| < 2**-12
             // raise inexact if x!=0 and underflow if subnormal
-            math.doNotOptimizeAway(if (ix < 0x00800000) x / 0x1p120 else x + 0x1p120);
+            mem.doNotOptimizeAway(if (ix < 0x00800000) x / 0x1p120 else x + 0x1p120);
             return x;
         }
         return trig.__sindf(x);
@@ -97,7 +98,7 @@ pub fn sin(x: f64) callconv(.C) f64 {
     if (ix <= 0x3fe921fb) {
         if (ix < 0x3e500000) { // |x| < 2**-26
             // raise inexact if x != 0 and underflow if subnormal
-            math.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
             return x;
         }
         return trig.__sin(x, 0.0, 0);

--- a/lib/compiler_rt/sincos.zig
+++ b/lib/compiler_rt/sincos.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const arch = builtin.cpu.arch;
 const math = std.math;
+const mem = std.mem;
 const trig = @import("trig.zig");
 const rem_pio2 = @import("rem_pio2.zig").rem_pio2;
 const rem_pio2f = @import("rem_pio2f.zig").rem_pio2f;
@@ -45,7 +46,7 @@ pub fn sincosf(x: f32, r_sin: *f32, r_cos: *f32) callconv(.C) void {
         // |x| < 2**-12
         if (ix < 0x39800000) {
             // raise inexact if x!=0 and underflow if subnormal
-            math.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
             r_sin.* = x;
             r_cos.* = 1.0;
             return;
@@ -133,7 +134,7 @@ pub fn sincos(x: f64, r_sin: *f64, r_cos: *f64) callconv(.C) void {
         // if |x| < 2**-27 * sqrt(2)
         if (ix < 0x3e46a09e) {
             // raise inexact if x != 0 and underflow if subnormal
-            math.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
             r_sin.* = x;
             r_cos.* = 1.0;
             return;
@@ -231,7 +232,7 @@ inline fn sincos_generic(comptime F: type, x: F, r_sin: *F, r_cos: *F) void {
         if (se < 0x3fff - math.floatFractionalBits(F) - 1) {
             // raise underflow if subnormal
             if (se == 0) {
-                math.doNotOptimizeAway(x * 0x1p-120);
+                mem.doNotOptimizeAway(x * 0x1p-120);
             }
             r_sin.* = x;
             // raise inexact if x!=0

--- a/lib/compiler_rt/tan.zig
+++ b/lib/compiler_rt/tan.zig
@@ -8,6 +8,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 
 const kernel = @import("trig.zig");
@@ -50,7 +51,7 @@ pub fn tanf(x: f32) callconv(.C) f32 {
     if (ix <= 0x3f490fda) { // |x| ~<= pi/4
         if (ix < 0x39800000) { // |x| < 2**-12
             // raise inexact if x!=0 and underflow if subnormal
-            math.doNotOptimizeAway(if (ix < 0x00800000) x / 0x1p120 else x + 0x1p120);
+            mem.doNotOptimizeAway(if (ix < 0x00800000) x / 0x1p120 else x + 0x1p120);
             return x;
         }
         return kernel.__tandf(x, false);
@@ -88,7 +89,7 @@ pub fn tan(x: f64) callconv(.C) f64 {
     if (ix <= 0x3fe921fb) {
         if (ix < 0x3e400000) { // |x| < 2**-27
             // raise inexact if x!=0 and underflow if subnormal
-            math.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
             return x;
         }
         return kernel.__tan(x, 0.0, false);

--- a/lib/compiler_rt/trunc.zig
+++ b/lib/compiler_rt/trunc.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const arch = builtin.cpu.arch;
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 const common = @import("common.zig");
 
@@ -46,7 +47,7 @@ pub fn truncf(x: f32) callconv(.C) f32 {
     if (u & m == 0) {
         return x;
     } else {
-        math.doNotOptimizeAway(x + 0x1p120);
+        mem.doNotOptimizeAway(x + 0x1p120);
         return @bitCast(u & ~m);
     }
 }
@@ -67,7 +68,7 @@ pub fn trunc(x: f64) callconv(.C) f64 {
     if (u & m == 0) {
         return x;
     } else {
-        math.doNotOptimizeAway(x + 0x1p120);
+        mem.doNotOptimizeAway(x + 0x1p120);
         return @bitCast(u & ~m);
     }
 }
@@ -93,7 +94,7 @@ pub fn truncq(x: f128) callconv(.C) f128 {
     if (u & m == 0) {
         return x;
     } else {
-        math.doNotOptimizeAway(x + 0x1p120);
+        mem.doNotOptimizeAway(x + 0x1p120);
         return @bitCast(u & ~m);
     }
 }

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -186,9 +186,7 @@ test "approxEqAbs and approxEqRel" {
     }
 }
 
-pub fn doNotOptimizeAway(val: anytype) void {
-    return mem.doNotOptimizeAway(val);
-}
+pub const doNotOptimizeAway = @compileError("Deprecated: use `std.mem.doNotOptimizeAway` instead");
 
 pub fn raiseInvalid() void {
     // Raise INVALID fpu exception

--- a/lib/std/math/asinh.zig
+++ b/lib/std/math/asinh.zig
@@ -6,6 +6,7 @@
 
 const std = @import("../std.zig");
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 const maxInt = std.math.maxInt;
 
@@ -46,7 +47,7 @@ fn asinh32(x: f32) f32 {
     }
     // |x| < 0x1p-12, inexact if x != 0
     else {
-        math.doNotOptimizeAway(rx + 0x1.0p120);
+        mem.doNotOptimizeAway(rx + 0x1.0p120);
     }
 
     return if (s != 0) -rx else rx;
@@ -73,7 +74,7 @@ fn asinh64(x: f64) f64 {
     }
     // |x| < 0x1p-12, inexact if x != 0
     else {
-        math.doNotOptimizeAway(rx + 0x1.0p120);
+        mem.doNotOptimizeAway(rx + 0x1.0p120);
     }
 
     return if (s != 0) -rx else rx;

--- a/lib/std/math/atan.zig
+++ b/lib/std/math/atan.zig
@@ -6,6 +6,7 @@
 
 const std = @import("../std.zig");
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 
 /// Returns the arc-tangent of x.
@@ -67,7 +68,7 @@ fn atan32(x_: f32) f32 {
         // |x| < 2^(-12)
         if (ix < 0x39800000) {
             if (ix < 0x00800000) {
-                math.doNotOptimizeAway(x * x);
+                mem.doNotOptimizeAway(x * x);
             }
             return x;
         }
@@ -165,7 +166,7 @@ fn atan64(x_: f64) f64 {
         // |x| < 2^(-27)
         if (ix < 0x3E400000) {
             if (ix < 0x00100000) {
-                math.doNotOptimizeAway(@as(f32, @floatCast(x)));
+                mem.doNotOptimizeAway(@as(f32, @floatCast(x)));
             }
             return x;
         }

--- a/lib/std/math/atanh.zig
+++ b/lib/std/math/atanh.zig
@@ -6,6 +6,7 @@
 
 const std = @import("../std.zig");
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 const maxInt = std.math.maxInt;
 
@@ -40,7 +41,7 @@ fn atanh_32(x: f32) f32 {
         if (u < 0x3F800000 - (32 << 23)) {
             // underflow
             if (u < (1 << 23)) {
-                math.doNotOptimizeAway(y * y);
+                mem.doNotOptimizeAway(y * y);
             }
         }
         // |x| < 0.5
@@ -69,7 +70,7 @@ fn atanh_64(x: f64) f64 {
         if (e < 0x3FF - 32) {
             // underflow
             if (e == 0) {
-                math.doNotOptimizeAway(@as(f32, @floatCast(y)));
+                mem.doNotOptimizeAway(@as(f32, @floatCast(y)));
             }
         }
         // |x| < 0.5

--- a/lib/std/math/expm1.zig
+++ b/lib/std/math/expm1.zig
@@ -8,6 +8,7 @@
 
 const std = @import("../std.zig");
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 
 /// Returns e raised to the power of x, minus 1 (e^x - 1). This is more accurate than exp(e, x) - 1
@@ -100,7 +101,7 @@ fn expm1_32(x_: f32) f32 {
     // |x| < 2^(-25)
     else if (hx < 0x33000000) {
         if (hx < 0x00800000) {
-            math.doNotOptimizeAway(x * x);
+            mem.doNotOptimizeAway(x * x);
         }
         return x;
     } else {
@@ -231,7 +232,7 @@ fn expm1_64(x_: f64) f64 {
     // |x| < 2^(-54)
     else if (hx < 0x3C900000) {
         if (hx < 0x00100000) {
-            math.doNotOptimizeAway(@as(f32, @floatCast(x)));
+            mem.doNotOptimizeAway(@as(f32, @floatCast(x)));
         }
         return x;
     } else {

--- a/lib/std/math/log1p.zig
+++ b/lib/std/math/log1p.zig
@@ -6,6 +6,7 @@
 
 const std = @import("../std.zig");
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 
 /// Returns the natural logarithm of 1 + x with greater accuracy when x is near zero.
@@ -56,7 +57,7 @@ fn log1p_32(x: f32) f32 {
         if ((ix << 1) < (0x33800000 << 1)) {
             // underflow if subnormal
             if (ix & 0x7F800000 == 0) {
-                math.doNotOptimizeAway(x * x);
+                mem.doNotOptimizeAway(x * x);
             }
             return x;
         }

--- a/lib/std/math/tanh.zig
+++ b/lib/std/math/tanh.zig
@@ -6,6 +6,7 @@
 
 const std = @import("../std.zig");
 const math = std.math;
+const mem = std.mem;
 const expect = std.testing.expect;
 const expo2 = @import("expo2.zig").expo2;
 const maxInt = std.math.maxInt;
@@ -58,7 +59,7 @@ fn tanh32(x: f32) f32 {
     }
     // |x| is subnormal
     else {
-        math.doNotOptimizeAway(ax * ax);
+        mem.doNotOptimizeAway(ax * ax);
         t = ax;
     }
 
@@ -96,7 +97,7 @@ fn tanh64(x: f64) f64 {
     }
     // |x| is subnormal
     else {
-        math.doNotOptimizeAway(@as(f32, @floatCast(ax)));
+        mem.doNotOptimizeAway(@as(f32, @floatCast(ax)));
         t = ax;
     }
 


### PR DESCRIPTION
Addresses #18004, and a follow up to #13790.

1) Stop using ``math.doNotOptimizeAway`` in favor of ``mem.doNotOptimizeAway``.

2) Make ``math.doNotOptimizeAway`` a ``@compileError("Deprecated: ...");``