### PR TITLE
Fix sentinel in string literals

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -26126,7 +26126,7 @@ fn fieldVal(
                 const ptr_info = object_ty.ptrInfo(mod);
                 const result_ty = try sema.ptrType(.{
                     .child = ptr_info.child.toType().childType(mod).toIntern(),
-                    .sentinel = ptr_info.sentinel,
+                    .sentinel = if (inner_ty.sentinel(mod)) |s| s.toIntern() else .none,
                     .flags = .{
                         .size = .Many,
                         .alignment = ptr_info.flags.alignment,

--- a/test/behavior/string_literals.zig
+++ b/test/behavior/string_literals.zig
@@ -74,3 +74,9 @@ test "@src() returns a struct containing 0-terminated string slices" {
     const ptr_src_fn_name: [*:0]const u8 = src.fn_name;
     _ = ptr_src_fn_name; // unused
 }
+
+test "string literal pointer sentinel" {
+    const string_literal = "something";
+
+    try std.testing.expect(@TypeOf(string_literal.ptr) == [*:0]const u8);
+}


### PR DESCRIPTION
Fixes #18007

Issue was caused by `fieldVal` access the pointer's sentinel, instead of the value's.

thanks @mlugg :D