### PR TITLE
sliceAsBytes now includes sentinel, fix Allocator bugs

### DIFF
--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -1429,3 +1429,27 @@ test "bug 9995 fix, large allocs count requested size not backing size" {
     buf = try allocator.realloc(buf, 2);
     try std.testing.expect(gpa.total_requested_bytes == 2);
 }
+
+test "resize with sentinel" {
+    var gpa = GeneralPurposeAllocator(test_config){};
+    defer std.testing.expect(gpa.deinit() == .ok) catch @panic("leak");
+    const allocator = gpa.allocator();
+
+    var buf = try allocator.allocWithOptions(u8, 6, null, 5);
+    try std.testing.expect(allocator.resize(buf, 3));
+    buf[2] = 5;
+    buf = buf[0..2 :5];
+
+    allocator.free(buf);
+}
+
+test "realloc with sentinel" {
+    var gpa = GeneralPurposeAllocator(test_config){};
+    defer std.testing.expect(gpa.deinit() == .ok) catch @panic("leak");
+    const allocator = gpa.allocator();
+
+    var buf = try allocator.allocWithOptions(u8, 6, null, 5);
+    var buf2 = try allocator.realloc(buf, 3);
+
+    allocator.free(buf2);
+}

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3938,7 +3938,7 @@ pub fn bytesAsSlice(comptime T: type, bytes: anytype) BytesAsSliceReturnType(T, 
 /// undefined behavior results.
 pub fn bytesAsSliceSentinel(comptime T: type, comptime sentinel: *const T, bytes: anytype) BytesAsSliceReturnType(T, sentinel, @TypeOf(bytes)) {
     const slice = bytesAsSlice(T, bytes);
-    return slice[0..slice.len-1:sentinel.*];
+    return slice[0 .. slice.len - 1 :sentinel.*];
 }
 
 test "bytesAsSlice" {

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -305,13 +305,12 @@ pub fn reallocAdvanced(
 /// see `destroy`.
 pub fn free(self: Allocator, memory: anytype) void {
     const Slice = @typeInfo(@TypeOf(memory)).Pointer;
-    const bytes = mem.sliceAsBytes(memory);
-    const bytes_len = bytes.len + if (Slice.sentinel != null) @sizeOf(Slice.child) else 0;
-    if (bytes_len == 0) return;
+    const bytes = mem.sliceAsBytesSentinel(memory);
+    if (bytes.len == 0) return;
     const non_const_ptr = @constCast(bytes.ptr);
     // TODO: https://github.com/ziglang/zig/issues/4298
-    @memset(non_const_ptr[0..bytes_len], undefined);
-    self.rawFree(non_const_ptr[0..bytes_len], log2a(Slice.alignment), @returnAddress());
+    @memset(non_const_ptr[0..bytes.len], undefined);
+    self.rawFree(non_const_ptr[0..bytes.len], log2a(Slice.alignment), @returnAddress());
 }
 
 /// Copies `m` to newly allocated memory. Caller owns the memory.

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -241,7 +241,7 @@ pub fn resize(self: Allocator, old_mem: anytype, new_n: usize) bool {
     if (old_mem.len == 0) {
         return false;
     }
-    const old_byte_slice = mem.sliceAsBytes(old_mem);
+    const old_byte_slice = mem.sliceAsBytesSentinel(old_mem);
     // I would like to use saturating multiplication here, but LLVM cannot lower it
     // on WebAssembly: https://github.com/ziglang/zig/issues/9660
     //const new_byte_count = new_n *| @sizeOf(T);
@@ -279,7 +279,7 @@ pub fn reallocAdvanced(
         return @as([*]align(Slice.alignment) T, @ptrFromInt(ptr))[0..0];
     }
 
-    const old_byte_slice = mem.sliceAsBytes(old_mem);
+    const old_byte_slice = mem.sliceAsBytesSentinel(old_mem);
     const byte_count = math.mul(usize, @sizeOf(T), new_n) catch return Error.OutOfMemory;
     // Note: can't set shrunk memory to undefined as memory shouldn't be modified on realloc failure
     if (mem.isAligned(@intFromPtr(old_byte_slice.ptr), Slice.alignment)) {

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -241,7 +241,7 @@ pub fn resize(self: Allocator, old_mem: anytype, new_n: usize) bool {
     if (old_mem.len == 0) {
         return false;
     }
-    const old_byte_slice = mem.sliceAsBytesSentinel(old_mem);
+    const old_byte_slice = mem.sliceAsBytes(old_mem);
     // I would like to use saturating multiplication here, but LLVM cannot lower it
     // on WebAssembly: https://github.com/ziglang/zig/issues/9660
     //const new_byte_count = new_n *| @sizeOf(T);
@@ -279,7 +279,7 @@ pub fn reallocAdvanced(
         return @as([*]align(Slice.alignment) T, @ptrFromInt(ptr))[0..0];
     }
 
-    const old_byte_slice = mem.sliceAsBytesSentinel(old_mem);
+    const old_byte_slice = mem.sliceAsBytes(old_mem);
     const byte_count = math.mul(usize, @sizeOf(T), new_n) catch return Error.OutOfMemory;
     // Note: can't set shrunk memory to undefined as memory shouldn't be modified on realloc failure
     if (mem.isAligned(@intFromPtr(old_byte_slice.ptr), Slice.alignment)) {
@@ -305,7 +305,7 @@ pub fn reallocAdvanced(
 /// see `destroy`.
 pub fn free(self: Allocator, memory: anytype) void {
     const Slice = @typeInfo(@TypeOf(memory)).Pointer;
-    const bytes = mem.sliceAsBytesSentinel(memory);
+    const bytes = mem.sliceAsBytes(memory);
     if (bytes.len == 0) return;
     const non_const_ptr = @constCast(bytes.ptr);
     // TODO: https://github.com/ziglang/zig/issues/4298

--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -1049,13 +1049,13 @@ test "utf8ToUtf16LeWithNull" {
     {
         const utf16 = try utf8ToUtf16LeWithNull(testing.allocator, "𐐷");
         defer testing.allocator.free(utf16);
-        try testing.expectEqualSlices(u8, "\x01\xd8\x37\xdc", mem.sliceAsBytes(utf16[0..]));
+        try testing.expectEqualSlices(u8, "\x01\xd8\x37\xdc\x00\x00", mem.sliceAsBytes(utf16[0..]));
         try testing.expect(utf16[2] == 0);
     }
     {
         const utf16 = try utf8ToUtf16LeWithNull(testing.allocator, "\u{10FFFF}");
         defer testing.allocator.free(utf16);
-        try testing.expectEqualSlices(u8, "\xff\xdb\xff\xdf", mem.sliceAsBytes(utf16[0..]));
+        try testing.expectEqualSlices(u8, "\xff\xdb\xff\xdf\x00\x00", mem.sliceAsBytes(utf16[0..]));
         try testing.expect(utf16[2] == 0);
     }
     {


### PR DESCRIPTION
This makes `sliceAsBytes()` include the sentinel value (if there is one) in the returned byte slice.
* fixes 2 bugs in the Allocator interface for resize and realloc
* cleans up Allocator.free (which before was manually handling the sentinel)
* revealed a unicode test that wasn't working properly

It also adds `bytesAsSliceSentinel()` for completeness and because I want to use it in [dvui](https://github.com/david-vanderson/dvui) to provide storage for arbitrary user slices.  Right now I'm handling the sentinel values manually, and this would help clean it up.