### PR TITLE
lib: add usage example for std.process.argsAlloc()

### DIFF
--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -868,7 +868,7 @@ pub fn argsAlloc(allocator: Allocator) ![][:0]u8 {
 }
 
 test argsAlloc {
-    const allocator = std.heap.page_allocator;
+    const allocator = std.testing.allocator;
     const arg_iterator = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, arg_iterator);
     for (arg_iterator) |arg| {

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -867,6 +867,15 @@ pub fn argsAlloc(allocator: Allocator) ![][:0]u8 {
     return result_slice_list;
 }
 
+test argsAlloc {
+    const allocator = std.heap.page_allocator;
+    const arg_iterator = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, arg_iterator);
+    for (arg_iterator) |arg| {
+        std.debug.print("{s}\n", .{arg});
+    }
+}
+
 pub fn argsFree(allocator: Allocator, args_alloc: []const [:0]u8) void {
     var total_bytes: usize = 0;
     for (args_alloc) |arg| {


### PR DESCRIPTION
This PR adds a usage example to the standard library for `std.process.argsAlloc`, which should be automatically detected by autodoc.