### PR TITLE
sema: disallow slicing multi-pointer with different sentinel

### DIFF
--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -375,14 +375,12 @@ test "slice multi-pointer without end" {
             var array = [5:0]u8{ 1, 2, 3, 4, 5 };
             const pointer: [*:0]u8 = &array;
 
-            try comptime expect(@TypeOf(pointer[1..3]) == *[2]u8);
-            try comptime expect(@TypeOf(pointer[1..3 :4]) == *[2:4]u8);
-            try comptime expect(@TypeOf(pointer[1..5 :0]) == *[4:0]u8);
-
             const slice = pointer[1..];
             try comptime expect(@TypeOf(slice) == [*:0]u8);
             try expect(slice[0] == 2);
             try expect(slice[1] == 3);
+
+            try comptime expect(@TypeOf(pointer[1.. :0]) == [*:0]u8);
         }
     };
 

--- a/test/cases/compile_errors/slice_of_many-item_pointer_preserves_sentinel.zig
+++ b/test/cases/compile_errors/slice_of_many-item_pointer_preserves_sentinel.zig
@@ -1,0 +1,16 @@
+comptime {
+    var ptr: [*]const u8 = undefined;
+    _ = ptr[0.. :0];
+}
+
+comptime {
+    var ptrz: [*:0]const u8 = undefined;
+    _ = ptrz[0.. :1];
+}
+
+// error
+//
+// :3:18: error: cannot perform slice with sentinel '0' on pointer without sentinel
+// :3:12: note: use @ptrCast to cast pointer sentinel
+// :8:19: error: cannot perform slice with sentinel '1' on pointer with sentinel '0'
+// :8:13: note: use @ptrCast to cast pointer sentinel


### PR DESCRIPTION
Fixes #18019 by introducing compile errors when slicing a many-item pointer without an end and with a sentinel that does not match the original pointer type.