### PR TITLE
add `std.debug.forceRuntimeValue`

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -2629,7 +2629,7 @@ pub fn ConfigurableTrace(comptime size: usize, comptime stack_frame_count: usize
     };
 }
 
-pub fn forceRuntimeEvaluation(val: anytype) @TypeOf(val) {
+pub fn forceRuntimeValue(val: anytype) @TypeOf(val) {
     if (@inComptime()) @compileError("This function must be run at runtime");
     return val;
 }


### PR DESCRIPTION
<s>To inspect the assembly code of a function, I use [this line](https://ziggit.dev/t/how-to-force-runtime-evaluation/943/8) to force the function to always be runtime-evaluated without doing a whole bunch of I/O rituals at callsite just to test a simple function.

As far as I can tell there doesn't seem to any language built-in or std utility for this purpose.</s>


Use `std.mem.doNotOptimizeAway` instead.