### PR TITLE
Skip blank macros when translating defines

### DIFF
--- a/src/aro_translate_c.zig
+++ b/src/aro_translate_c.zig
@@ -141,7 +141,7 @@ pub fn translate(
     defer mapper.deinit(tree.comp.gpa);
 
     var arena_allocator = std.heap.ArenaAllocator.init(gpa);
-    errdefer arena_allocator.deinit();
+    defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
     var context = Context{

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -5979,6 +5979,7 @@ fn parseCPrimaryExpr(c: *Context, m: *MacroCtx, scope: *Scope) ParseError!Node {
                 const tok = m.list[m.i + 1];
                 const slice = m.source[tok.start..tok.end];
                 if (c.global_scope.blank_macros.contains(slice)) {
+                    m.i += 1;
                     continue;
                 }
             },

--- a/src/translate_c/common.zig
+++ b/src/translate_c/common.zig
@@ -184,6 +184,7 @@ pub fn ScopeExtra(comptime Context: type, comptime Type: type) type {
             base: Scope,
             sym_table: SymbolTable,
             macro_table: SymbolTable,
+            blank_macros: std.StringArrayHashMap(void),
             context: *Context,
             nodes: std.ArrayList(Node),
 
@@ -195,6 +196,7 @@ pub fn ScopeExtra(comptime Context: type, comptime Type: type) type {
                     },
                     .sym_table = SymbolTable.init(c.gpa),
                     .macro_table = SymbolTable.init(c.gpa),
+                    .blank_macros = std.StringArrayHashMap(void).init(c.gpa),
                     .context = c,
                     .nodes = std.ArrayList(Node).init(c.gpa),
                 };
@@ -203,6 +205,7 @@ pub fn ScopeExtra(comptime Context: type, comptime Type: type) type {
             pub fn deinit(scope: *Root) void {
                 scope.sym_table.deinit();
                 scope.macro_table.deinit();
+                scope.blank_macros.deinit();
                 scope.nodes.deinit();
             }
 

--- a/test/behavior/translate_c_macros.h
+++ b/test/behavior/translate_c_macros.h
@@ -62,3 +62,9 @@ typedef _Bool uintptr_t;
 
 #define LONG(x) x##L
 #define X LONG(10)
+
+#define BLANK_MACRO
+#define BLANK_CHILD_MACRO BLANK_MACRO BLANK_MACRO BLANK_MACRO
+#define MACRO_VALUE 0
+typedef long def_type;
+#define BLANK_MACRO_CAST (BLANK_CHILD_MACRO def_type BLANK_CHILD_MACRO)MACRO_VALUE

--- a/test/behavior/translate_c_macros.zig
+++ b/test/behavior/translate_c_macros.zig
@@ -231,3 +231,12 @@ test "Macro that uses Long type concatenation casting" {
     try expect((@TypeOf(h.X)) == c_long);
     try expectEqual(h.X, @as(c_long, 10));
 }
+
+test "Blank macros" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    try expectEqual(h.BLANK_MACRO, "");
+    try expectEqual(h.BLANK_CHILD_MACRO, "");
+    try expect(@TypeOf(h.BLANK_MACRO_CAST) == h.def_type);
+    try expectEqual(h.BLANK_MACRO_CAST, @as(c_long, 0));
+}


### PR DESCRIPTION
Should close #17327 
This adds a `blank_macros` set to Scope.Root, used to keep track of macros with no content (in the form `#define blank `, or any macro derived from macros of such macros). Then, when these macros are encountered in casts/expressions, they are skipped instead of concatenated with the rest of the cast/expression. This PR also includes a behavior test.

Here is a *.h to compare the new behavior:
```
[jrz@jrz scratch]$ cat test.h
#define useful_attr 
typedef float useful_type;
#define useful_enum 0
#define useful_thing_0 ((float)0)
#define useful_thing_1 ((useful_type)0)
#define useful_thing_2 ((useful_attr float)0)
#define useful_thing_3 ((useful_attr useful_type)0)
#define useful_thing_4 ((float)useful_enum)
#define useful_thing_5 ((useful_type)useful_enum)
#define useful_thing_6 ((useful_attr float)useful_enum)
#define useful_thing_7 ((useful_attr useful_type)useful_enum)
```
`translate-c` output before:
```
[jrz@jrz scratch]$ zig translate-c test.h | grep useful
pub const useful_type = f32;
pub const useful_thing_2 = @compileError("unable to translate C expr: expected ')' instead got 'float'"); // test.h:6:9
pub const useful_thing_3 = @compileError("unable to translate C expr: expected ')' instead got 'IntegerLiteral'"); // test.h:7:9
pub const useful_thing_6 = @compileError("unable to translate C expr: expected ')' instead got 'float'"); // test.h:10:9
pub const useful_attr = "";
pub const useful_enum = @as(c_int, 0);
pub const useful_thing_0 = @import("std").zig.c_translation.cast(f32, @as(c_int, 0));
pub const useful_thing_1 = @import("std").zig.c_translation.cast(useful_type, @as(c_int, 0));
pub const useful_thing_4 = @import("std").zig.c_translation.cast(f32, useful_enum);
pub const useful_thing_5 = @import("std").zig.c_translation.cast(useful_type, useful_enum);
pub const useful_thing_7 = useful_attr ++ useful_type ++ useful_enum;
```
`translate-c` output after:
```
[jrz@jrz scratch]$ zig translate-c test.h | grep useful
pub const useful_type = f32;
pub const useful_attr = "";
pub const useful_enum = @as(c_int, 0);
pub const useful_thing_0 = @import("std").zig.c_translation.cast(f32, @as(c_int, 0));
pub const useful_thing_1 = @import("std").zig.c_translation.cast(useful_type, @as(c_int, 0));
pub const useful_thing_2 = @import("std").zig.c_translation.cast(f32, @as(c_int, 0));
pub const useful_thing_3 = @import("std").zig.c_translation.cast(useful_type, @as(c_int, 0));
pub const useful_thing_4 = @import("std").zig.c_translation.cast(f32, useful_enum);
pub const useful_thing_5 = @import("std").zig.c_translation.cast(useful_type, useful_enum);
pub const useful_thing_6 = @import("std").zig.c_translation.cast(f32, useful_enum);
pub const useful_thing_7 = @import("std").zig.c_translation.cast(useful_type, useful_enum);
```


An in-the-wild example from the Linux kernel:
All `kmalloc` calls take GFP flags, which are defined with a `__force` macro which is blank under normal circumstanced.
```
#define __GFP_IO	((__force gfp_t)___GFP_IO)
#define __GFP_FS	((__force gfp_t)___GFP_FS)
#define __GFP_DIRECT_RECLAIM	((__force gfp_t)___GFP_DIRECT_RECLAIM) /* Caller can reclaim */
#define __GFP_KSWAPD_RECLAIM	((__force gfp_t)___GFP_KSWAPD_RECLAIM) /* kswapd can wake */
#define __GFP_RECLAIM ((__force gfp_t)(___GFP_DIRECT_RECLAIM|___GFP_KSWAPD_RECLAIM))
#define __GFP_RETRY_MAYFAIL	((__force gfp_t)___GFP_RETRY_MAYFAIL)
#define __GFP_NOFAIL	((__force gfp_t)___GFP_NOFAIL)
#define __GFP_NORETRY	((__force gfp_t)___GFP_NORETRY)
```
Before this patch, Zig produced unusable defines. `__force` is defined as `""` and `gfp_t` is defined as `c_uint`, so of course they can't be concatenated. This makes it difficult to do something as simple as allocate memory:
```
pub const __GFP_IO = __force ++ gfp_t ++ ___GFP_IO;
pub const __GFP_FS = __force ++ gfp_t ++ ___GFP_FS;
pub const __GFP_DIRECT_RECLAIM = __force ++ gfp_t ++ ___GFP_DIRECT_RECLAIM;
pub const __GFP_KSWAPD_RECLAIM = __force ++ gfp_t ++ ___GFP_KSWAPD_RECLAIM;
pub const __GFP_RECLAIM = (__force ++ gfp_t)(___GFP_DIRECT_RECLAIM | ___GFP_KSWAPD_RECLAIM);
pub const __GFP_RETRY_MAYFAIL = __force ++ gfp_t ++ ___GFP_RETRY_MAYFAIL;
pub const __GFP_NOFAIL = __force ++ gfp_t ++ ___GFP_NOFAIL;
pub const __GFP_NORETRY = __force ++ gfp_t ++ ___GFP_NORETRY;
```
After this patch, they translate to useable defines, with no bad string concatenation:
```
pub const __GFP_IO = @import("std").zig.c_translation.cast(gfp_t, ___GFP_IO);
pub const __GFP_FS = @import("std").zig.c_translation.cast(gfp_t, ___GFP_FS);
pub const __GFP_DIRECT_RECLAIM = @import("std").zig.c_translation.cast(gfp_t, ___GFP_DIRECT_RECLAIM);
pub const __GFP_KSWAPD_RECLAIM = @import("std").zig.c_translation.cast(gfp_t, ___GFP_KSWAPD_RECLAIM);
pub const __GFP_RECLAIM = @import("std").zig.c_translation.cast(gfp_t, ___GFP_DIRECT_RECLAIM | ___GFP_KSWAPD_RECLAIM);
pub const __GFP_RETRY_MAYFAIL = @import("std").zig.c_translation.cast(gfp_t, ___GFP_RETRY_MAYFAIL);
pub const __GFP_NOFAIL = @import("std").zig.c_translation.cast(gfp_t, ___GFP_NOFAIL);
pub const __GFP_NORETRY = @import("std").zig.c_translation.cast(gfp_t, ___GFP_NORETRY);

```