### PR TITLE
std.tar: trim also spaces from the beginning of file size

### DIFF
--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -82,7 +82,7 @@ pub const Header = struct {
 
     pub fn fileSize(header: Header) !u64 {
         const raw = header.bytes[124..][0..12];
-        const ltrimmed = std.mem.trimLeft(u8, raw, "0");
+        const ltrimmed = std.mem.trimLeft(u8, raw, "0 ");
         const rtrimmed = std.mem.trimRight(u8, ltrimmed, " \x00");
         if (rtrimmed.len == 0) return 0;
         return std.fmt.parseInt(u64, rtrimmed, 8);


### PR DESCRIPTION
tbh I don't even know if this is the right behavior, but it fixes unpacking tar archives from https://sourceforge.net/projects/sdl2gfx/files/