### PR TITLE
std.meta.trait: add `hasArchetype`

### DIFF
--- a/lib/std/meta/trait.zig
+++ b/lib/std/meta/trait.zig
@@ -72,9 +72,9 @@ test "hasArchetype" {
         }
     };
 
-    try testing.expect(hasArchetype("use",Use)(TestStruct));
-    try testing.expect(!hasArchetype("use",Add)(TestStruct));
-    try testing.expect(!hasArchetype("add",Add)(TestStruct));
+    try testing.expect(hasArchetype("use",env.Use)(TestStruct));
+    try testing.expect(!hasArchetype("use",env.Add)(TestStruct));
+    try testing.expect(!hasArchetype("add",env.Add)(TestStruct));
 }
 
 pub fn hasFn(comptime name: []const u8) TraitFn {

--- a/lib/std/meta/trait.zig
+++ b/lib/std/meta/trait.zig
@@ -6,7 +6,7 @@ const testing = std.testing;
 const meta = @import("../meta.zig");
 
 pub const TraitFn = fn (type) bool;
-pub const SignatureFn = fn(comptime Self: type) type; 
+pub const SignatureFn = fn (comptime Self: type) type;
 
 pub fn multiTrait(comptime traits: anytype) TraitFn {
     const Closure = struct {
@@ -59,10 +59,10 @@ pub fn hasArchetype(comptime name: []const u8, comptime signature: SignatureFn) 
 test "hasArchetype" {
     const env = struct {
         pub fn Use(comptime Self: type) type {
-            return fn(Self) Self;
+            return fn (Self) Self;
         }
         pub fn Add(comptime Self: type) type {
-            return fn(self: Self, other: Self) Self;
+            return fn (self: Self, other: Self) Self;
         }
     };
     const TestStruct = struct {
@@ -72,9 +72,9 @@ test "hasArchetype" {
         }
     };
 
-    try testing.expect(hasArchetype("use",env.Use)(TestStruct));
-    try testing.expect(!hasArchetype("use",env.Add)(TestStruct));
-    try testing.expect(!hasArchetype("add",env.Add)(TestStruct));
+    try testing.expect(hasArchetype("use", env.Use)(TestStruct));
+    try testing.expect(!hasArchetype("use", env.Add)(TestStruct));
+    try testing.expect(!hasArchetype("add", env.Add)(TestStruct));
 }
 
 pub fn hasFn(comptime name: []const u8) TraitFn {

--- a/lib/std/meta/trait.zig
+++ b/lib/std/meta/trait.zig
@@ -67,7 +67,7 @@ test "hasArchetype" {
     };
     const TestStruct = struct {
         used: usize = 0,
-        pub fn use(self: @This()) @This {
+        pub fn use(self: @This()) @This() {
             return @This(){ .used = self.used + 1 };
         }
     };

--- a/lib/std/meta/trait.zig
+++ b/lib/std/meta/trait.zig
@@ -6,7 +6,6 @@ const testing = std.testing;
 const meta = @import("../meta.zig");
 
 pub const TraitFn = fn (type) bool;
-pub const SignatureFn = fn (comptime Self: type) type;
 
 pub fn multiTrait(comptime traits: anytype) TraitFn {
     const Closure = struct {
@@ -43,7 +42,7 @@ test "multiTrait" {
     try testing.expect(!isVector(u8));
 }
 
-pub fn hasArchetype(comptime name: []const u8, comptime signature: SignatureFn) TraitFn {
+pub fn hasArchetype(comptime name: []const u8, comptime signature: fn (comptime Self: type) type) TraitFn {
     const Closure = struct {
         pub fn trait(comptime Self: type) bool {
             if (!comptime isContainer(Self)) return false;

--- a/lib/std/meta/trait.zig
+++ b/lib/std/meta/trait.zig
@@ -42,14 +42,14 @@ test "multiTrait" {
     try testing.expect(!isVector(u8));
 }
 
-pub fn hasArchetype(comptime name: []const u8, comptime signature: fn (comptime Self: type) type) TraitFn {
+pub fn hasArchetype(comptime name: []const u8, comptime Signature: fn (comptime Self: type) type) TraitFn {
     const Closure = struct {
         pub fn trait(comptime Self: type) bool {
             if (!comptime isContainer(Self)) return false;
             if (!comptime @hasDecl(Self, name)) return false;
             const DeclType = @TypeOf(@field(Self, name));
             if (@typeInfo(DeclType) != .Fn) return false;
-            return DeclType == signature(Self);
+            return DeclType == Signature(Self);
         }
     };
     return Closure.trait;


### PR DESCRIPTION
Currently, `hasFn` only checks the name of the function and do not verify that the signature matches. 

This change adds a new TraitFn `hasArchetype` which can be thought of as being like `hasFn` but takes an extra "signature constructor" argument that consumes a `Self` type and returns the corresponding function signature (which may or may not contain inputs/outputs of type `Self`) that matches the intended signature.