### PR TITLE
json: auto set the optional fields to null

### DIFF
--- a/lib/std/json/static.zig
+++ b/lib/std/json/static.zig
@@ -781,6 +781,8 @@ fn fillDefaultStructValues(comptime T: type, r: *T, fields_seen: *[@typeInfo(T).
             if (field.default_value) |default_ptr| {
                 const default = @as(*align(1) const field.type, @ptrCast(default_ptr)).*;
                 @field(r, field.name) = default;
+            } else if (@typeInfo(field.type) == .Optional) {
+                @field(r, field.name) = null;
             } else {
                 return error.MissingField;
             }


### PR DESCRIPTION
simple sample:
```zig
const Point = { x: u32, y: u32, desc: ?[]const u8 }; 

const pased_str = \\{"x": 100, "y": 200}
                  ;
_ = try std.json.parseFromSlice(Point, allocator, parsed_str, .{});
```

the parse call will throw error.MissingField.

We can set the optional field ('desc')  default vaule to null to suppress this error,
```zig
const Point = { x: u32, y: u32, desc: ?[]const u8 = null }; 
```
but it's not simplicity and elegance when  have several optional fields, like this:
```
const Point = { x: u32, y: u32, desc: ?[]const u8 = null, a:? struct{} = null, b: ? [] const u8 = null, 
                      c: ?[] const u8=null,  d: ?bool = null}; 
```

Auto set the optional fields to null (if no value) is very convenient.