### PR TITLE
langref: more readable sidebar spacing & hyperlinks

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -75,6 +75,7 @@
       }
       a:hover {
         text-decoration: underline;
+        color: #fff2a8;
       }
       a:focus {
         background: #fff2a8;

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -242,8 +242,8 @@
 
       @media (prefers-color-scheme: dark) {
         :root{
-	    color-scheme: dark;
-	}
+            color-scheme: dark;
+        }
         body{
             background:#121212;
             color: #ccc;

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -241,6 +241,9 @@
       }
 
       @media (prefers-color-scheme: dark) {
+        :root{
+	    color-scheme: dark;
+	}
         body{
             background:#121212;
             color: #ccc;

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -75,6 +75,7 @@
       }
       a:hover {
         text-decoration: underline;
+	color: unset;
       }
       a:focus {
         background: #fff2a8;
@@ -251,9 +252,9 @@
         a {
             color: #88f;
         }
-	a:hover {
+        a:hover {
             color: #fff2a8;
-	}
+        }
         a:focus {
             color: #000;
         }

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -55,7 +55,28 @@
         }
       }
 
-      a:hover,a:focus {
+      #table-of-contents {
+        margin-bottom: 0;
+      }
+      #navigation ul {
+        margin-top: 0;
+        list-style-type: none;
+        column-gap: 0;
+        width: fit-content;
+      }
+      #navigation li {
+        padding-top: 0.75em;
+        line-height: 1.15;
+        overflow-wrap:anywhere;
+        line-break: wrap;
+      }
+      a {
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      a:focus {
         background: #fff2a8;
       }
       dt {
@@ -227,7 +248,7 @@
         a {
             color: #88f;
         }
-        a:hover,a:focus {
+        a:focus {
             color: #000;
         }
         table, th, td {

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -75,7 +75,6 @@
       }
       a:hover {
         text-decoration: underline;
-        color: #fff2a8;
       }
       a:focus {
         background: #fff2a8;
@@ -252,6 +251,9 @@
         a {
             color: #88f;
         }
+	a:hover {
+            color: #fff2a8;
+	}
         a:focus {
             color: #000;
         }

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -68,7 +68,7 @@
         padding-top: 0.75em;
         line-height: 1.15;
         overflow-wrap:anywhere;
-        line-break: wrap;
+        line-break: auto;
       }
       a {
         text-decoration: none;


### PR DESCRIPTION
Added minimal css styles for lineheight and padding for better readability of the navigation sidebar.

Also matches hyperlink & scrollbar with the current ziglang.org homepage

<details><summary>Before</summary>

![image](https://github.com/ziglang/zig/assets/77922942/f2d55839-54f0-407c-8b37-d28683d83b6d)

</details>

<details><summary>After</summary>

![image](https://github.com/ziglang/zig/assets/77922942/99ebd057-b2bc-4333-a048-7a7fe7a5b7dd)

</details>

Side-by-side:

![image](https://github.com/ziglang/zig/assets/77922942/f838050f-6ece-4057-83d4-07f76224ee3d)
