### PR TITLE
std: use BoundedArray less

### DIFF
--- a/deps/aro/aro/Parser.zig
+++ b/deps/aro/aro/Parser.zig
@@ -7796,7 +7796,7 @@ fn stringLiteral(p: *Parser) Error!Result {
                 }
             },
         };
-        for (char_literal_parser.errors.constSlice()) |item| {
+        for (char_literal_parser.errors()) |item| {
             try p.errExtra(item.tag, p.tok_i, item.extra);
         }
     }
@@ -7911,7 +7911,7 @@ fn charLiteral(p: *Parser) Error!Result {
             char_literal_parser.err(.char_lit_too_wide, .{ .none = {} });
         }
 
-        for (char_literal_parser.errors.constSlice()) |item| {
+        for (char_literal_parser.errors()) |item| {
             try p.errExtra(item.tag, p.tok_i, item.extra);
         }
     }

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -633,6 +633,17 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
             return self;
         }
 
+        /// Initialize with externally-managed memory. The buffer determines the
+        /// capacity, and the length is set to zero.
+        /// When initialized this way, all methods that accept an Allocator
+        /// argument are illegal to call.
+        pub fn initBuffer(buffer: Slice) Self {
+            return .{
+                .items = buffer[0..0],
+                .capacity = buffer.len,
+            };
+        }
+
         /// Release all allocated memory.
         pub fn deinit(self: *Self, allocator: Allocator) void {
             allocator.free(self.allocatedSlice());


### PR DESCRIPTION
Here are 8 places where I found that the use of BoundedArray was better served by doing something else instead.

In fact, this is all the uses of BoundedArray in the standard library and compiler codebase. I am tempted to remove the API entirely since it in practice leads to less than ideal code, however, I think there is nothing fundamentally wrong with the idea of abstracting over an array and a length, so I think it can remain in the standard library for now.