### PR TITLE
BoundedArray: add a len() function to get the length as a usize

### DIFF
--- a/lib/std/bounded_array.zig
+++ b/lib/std/bounded_array.zig
@@ -43,7 +43,7 @@ pub fn BoundedArrayAligned(
 
         buffer: [buffer_capacity]T align(alignment) = undefined,
 
-        /// The active array length. Not that in order to save space, this is not
+        /// The active array length. Note that in order to save space, this is not
         /// a `usize`, but rather the smallest integer type that can hold the
         /// maximum capacity. In order to get the length as a `usize`, use `len()`.
         active_len: Len = 0,
@@ -405,7 +405,7 @@ test "BoundedArray sizeOf" {
 
     try testing.expectEqual(@sizeOf(BoundedArray(u8, 3)), 4);
 
-    // `len` is the minimum required size to hold the maximum capacity
+    // `active_len` is the minimum required size to hold the maximum capacity
     try testing.expectEqual(@TypeOf(@as(BoundedArray(u8, 15), undefined).active_len), u4);
     try testing.expectEqual(@TypeOf(@as(BoundedArray(u8, 16), undefined).active_len), u5);
 }

--- a/lib/std/io/Reader.zig
+++ b/lib/std/io/Reader.zig
@@ -258,14 +258,14 @@ pub fn readIntoBoundedBytes(
     comptime num_bytes: usize,
     bounded: *std.BoundedArray(u8, num_bytes),
 ) anyerror!void {
-    while (bounded.len < num_bytes) {
+    while (bounded.len() < num_bytes) {
         // get at most the number of bytes free in the bounded array
         const bytes_read = try self.read(bounded.unusedCapacitySlice());
         if (bytes_read == 0) return;
 
-        // bytes_read will never be larger than @TypeOf(bounded.len)
+        // bytes_read will never be larger than the unused capacity
         // due to `self.read` being bounded by `bounded.unusedCapacitySlice()`
-        bounded.len += @as(@TypeOf(bounded.len), @intCast(bytes_read));
+        try bounded.resize(bounded.len() + bytes_read);
     }
 }
 


### PR DESCRIPTION
The type of the active length was changed to the smallest possible type, which is nice to get a more compact representation.

However, that change introduced unexpected side effects. For example, `a.len + b.len` can now trigger an integer overflow.

There's also an inconsistency between functions that set the size, which all use a `usize`, and the way to read the size, that uses a different type. This is also inconsistent with pretty much anything else that represents a slice length.

Replace `.len` with `len()`, a function that returns the length as a `usize` to minimize surprise and simplify application code.

Originally suggested by @matklad