### PR TITLE
Expose summary to Build

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -74,6 +74,7 @@ verbose_llvm_ir: ?[]const u8,
 verbose_llvm_bc: ?[]const u8,
 verbose_cimport: bool,
 verbose_llvm_cpu_features: bool,
+summary: ?Summary = null,
 reference_trace: ?u32 = null,
 invalid_user_input: bool,
 zig_exe: [:0]const u8,
@@ -171,6 +172,8 @@ const InitializedDepContext = struct {
         return true;
     }
 };
+
+pub const Summary = enum { all, failures, none };
 
 pub const RunError = error{
     ReadFailure,


### PR DESCRIPTION
This PR adds a `summary: ?Summary = null` field to `lib/std/Build.zig`. This can be used to set the summary mode (`all, failures, none`) in `build.zig`. If the `--summary` argument is passed to `zig build`, it will supersede anything set in `build.zig`.

Example usage:
```
[jrz@jrz mytest]$ head build.zig
const std = @import("std");

// Although this function looks imperative, note that its job is to
// declaratively construct a build graph that will be executed by an external
// runner.
pub fn build(b: *std.Build) void {
    // By default, show the full summary.
    b.summary = .all;
    // Standard target options allows the person running `zig build` to choose
    // what target to build for. Here we do not override the defaults, which
```
```
[jrz@jrz mytest]$ zig build; echo $? # By default, this build.zig shows the full summary
Build Summary: 5/5 steps succeeded
install cached
├─ install mytest cached
│  └─ zig build-lib mytest Debug native cached 8ms MaxRSS:78M
└─ install mytest cached
   └─ zig build-exe mytest Debug native cached 8ms MaxRSS:78M
0
[jrz@jrz mytest]$ zig build --summary none; echo $? # We can still override this
0
[jrz@jrz mytest]$
```