### PR TITLE
ConfigHeader: Add support for meson style templates

### DIFF
--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -571,4 +571,6 @@ test {
     _ = Run;
     _ = TranslateC;
     _ = WriteFile;
+    _ = Options;
+    _ = ConfigHeader;
 }

--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -10,6 +10,9 @@ pub const Style = union(enum) {
     /// The configure format supported by CMake. It uses `@@FOO@@` and
     /// `#cmakedefine` for template substitution.
     cmake: std.Build.LazyPath,
+    /// The configure format supported by Meson. It uses `@FOO@` and
+    /// `#mesondefine` for template substitution.
+    meson: std.Build.LazyPath,
     /// Instead of starting with an input file, start with nothing.
     blank,
     /// Start with nothing, like blank, and output a nasm .asm file.
@@ -17,7 +20,7 @@ pub const Style = union(enum) {
 
     pub fn getPath(style: Style) ?std.Build.LazyPath {
         switch (style) {
-            .autoconf, .cmake => |s| return s,
+            .autoconf, .cmake, .meson => |s| return s,
             .blank, .nasm => return null,
         }
     }
@@ -200,6 +203,12 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
             const src_path = file_source.getPath(b);
             const contents = try std.fs.cwd().readFileAlloc(arena, src_path, self.max_bytes);
             try render_cmake(step, contents, &output, self.values, src_path);
+        },
+        .meson => |file_source| {
+            try output.appendSlice(c_generated_line);
+            const src_path = file_source.getPath(b);
+            const contents = try std.fs.cwd().readFileAlloc(arena, src_path, self.max_bytes);
+            try render_meson(step, contents, &output, self.values, src_path);
         },
         .blank => {
             try output.appendSlice(c_generated_line);
@@ -406,6 +415,59 @@ fn render_cmake(
         }
 
         try renderValueC(output, name, value);
+    }
+
+    if (any_errors) {
+        return error.HeaderConfigFailed;
+    }
+}
+
+fn render_meson(
+    step: *Step,
+    contents: []const u8,
+    output: *std.ArrayList(u8),
+    values: std.StringArrayHashMap(Value),
+    src_path: []const u8,
+) !void {
+    var values_copy = try values.clone();
+    defer values_copy.deinit();
+
+    var any_errors = false;
+    var line_index: u32 = 0;
+    var line_it = std.mem.split(u8, contents, "\n");
+    while (line_it.next()) |line| : (line_index += 1) {
+        if (!std.mem.startsWith(u8, line, "#")) {
+            try output.appendSlice(line);
+            try output.appendSlice("\n");
+            continue;
+        }
+        var it = std.mem.tokenize(u8, line[1..], " \t\r");
+        const mesondefine = it.next().?;
+        if (!std.mem.eql(u8, mesondefine, "mesondefine")) {
+            try output.appendSlice(line);
+            try output.appendSlice("\n");
+            continue;
+        }
+        const name = it.next() orelse {
+            try step.addError("{s}:{d}: error: missing define name", .{
+                src_path, line_index + 1,
+            });
+            any_errors = true;
+            continue;
+        };
+        const kv = values_copy.fetchSwapRemove(name) orelse {
+            try step.addError("{s}:{d}: error: unspecified config header value: '{s}'", .{
+                src_path, line_index + 1, name,
+            });
+            any_errors = true;
+            continue;
+        };
+        try renderValueC(output, name, kv.value);
+    }
+
+    for (values_copy.keys()) |name| {
+        try step.addError("{s}: error: config header value unused: '{s}'", .{ src_path, name });
+        any_errors = true;
     }
 
     if (any_errors) {

--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const ConfigHeader = @This();
 const Step = std.Build.Step;
 const Allocator = std.mem.Allocator;
@@ -432,39 +433,335 @@ fn render_meson(
     var values_copy = try values.clone();
     defer values_copy.deinit();
 
+    const State = union(enum) {
+        copy,
+        escape: usize,
+        newline,
+        mesondefine: usize,
+        inline_at_var: usize,
+        dollar: usize,
+        inline_curly_var: usize,
+    };
+
     var any_errors = false;
     var line_index: u32 = 0;
-    var line_it = std.mem.split(u8, contents, "\n");
-    while (line_it.next()) |line| : (line_index += 1) {
-        if (!std.mem.startsWith(u8, line, "#")) {
-            try output.appendSlice(line);
-            try output.appendSlice("\n");
-            continue;
+
+    var state: State = .copy;
+    var index: usize = 0;
+    while (index < contents.len) {
+        switch (state) {
+            .copy => switch (contents[index]) {
+                '\\' => {
+                    state = .{ .escape = index };
+                    index += 1;
+                    continue;
+                },
+                '\n' => {
+                    try output.append('\n');
+                    state = .newline;
+                    index += 1;
+                    line_index += 1;
+                    continue;
+                },
+                '@' => {
+                    state = .{ .inline_at_var = index };
+                    index += 1;
+                    continue;
+                },
+                '$' => {
+                    state = .{ .dollar = index };
+                    index += 1;
+                    continue;
+                },
+                else => |character| {
+                    try output.append(character);
+                    index += 1;
+                    continue;
+                },
+            },
+            .escape => |start_index| switch (contents[index]) {
+                '\\' => {
+                    index += 1;
+                    continue;
+                },
+                '\n' => {
+                    try output.append('\n');
+                    state = .newline;
+                    index += 1;
+                    line_index += 1;
+                    continue;
+                },
+                '@' => {
+                    const count = index - start_index;
+                    try output.appendNTimes('\\', count / 2);
+                    if (count % 2 == 0) {
+                        state = .{ .inline_at_var = index };
+                        index += 1;
+                    } else {
+                        try output.append('@');
+                        state = .copy;
+                        index += 1;
+                    }
+                    continue;
+                },
+                '$' => {
+                    const count = index - start_index;
+                    try output.appendNTimes('\\', count / 2);
+                    if (count % 2 == 0) {
+                        state = .{ .dollar = index };
+                        index += 1;
+                    } else {
+                        try output.append('$');
+                        state = .copy;
+                        index += 1;
+                    }
+                    continue;
+                },
+                else => |character| {
+                    const count = index - start_index;
+                    try output.appendNTimes('\\', count);
+                    try output.append(character);
+                    state = .copy;
+                    index += 1;
+                    continue;
+                },
+            },
+            .newline => switch (contents[index]) {
+                '\n' => {
+                    try output.append('\n');
+                    state = .newline;
+                    index += 1;
+                    line_index += 1;
+                    continue;
+                },
+                '@' => {
+                    state = .{ .inline_at_var = index };
+                    index += 1;
+                    line_index += 1;
+                    continue;
+                },
+                '#' => if (std.mem.startsWith(u8, contents[index..], "#mesondefine ")) {
+                    index += "#mesondefine ".len;
+                    state = .{ .mesondefine = index };
+                    continue;
+                } else {
+                    try output.append('#');
+                    state = .copy;
+                    index += 1;
+                    continue;
+                },
+                else => |character| {
+                    try output.append(character);
+                    state = .copy;
+                    index += 1;
+                    continue;
+                },
+            },
+            .mesondefine => |start_index| switch (contents[index]) {
+                ' ' => {
+                    index += 1;
+                    state = .{ .mesondefine = index };
+                    continue;
+                },
+                '\n' => {
+                    const name = contents[start_index..index];
+                    state = .newline;
+                    index += 1;
+                    defer line_index += 1;
+
+                    const kv = values_copy.fetchSwapRemove(name) orelse {
+                        try step.addError("{s}:{d}: error: unspecified config header value: '{s}'", .{
+                            src_path, line_index + 1, name,
+                        });
+                        any_errors = true;
+                        continue;
+                    };
+                    try renderValueC(output, name, kv.value);
+                    continue;
+                },
+                else => {
+                    index += 1;
+                    continue;
+                },
+            },
+            .inline_at_var => |start_index| switch (contents[index]) {
+                '\n' => {
+                    try output.appendSlice(contents[start_index .. index + 1]);
+                    state = .newline;
+                    index += 1;
+                    defer line_index += 1;
+                    continue;
+                },
+                ' ' => {
+                    try output.appendSlice(contents[start_index .. index + 1]);
+                    state = .copy;
+                    index += 1;
+                    continue;
+                },
+                '@' => {
+                    const name = contents[start_index + 1 .. index];
+                    state = .copy;
+                    index += 1;
+
+                    const kv = values_copy.fetchSwapRemove(name) orelse get_from_original_or_error: {
+                        if (values.getEntry(name)) |entry| {
+                            break :get_from_original_or_error std.StringArrayHashMap(Value).KV{
+                                .key = entry.key_ptr.*,
+                                .value = entry.value_ptr.*,
+                            };
+                        }
+                        try step.addError("{s}:{d}: error: unspecified config header value: '{s}'", .{
+                            src_path, line_index + 1, name,
+                        });
+                        any_errors = true;
+                        continue;
+                    };
+                    switch (kv.value) {
+                        // output nothing
+                        .undef => {},
+                        .defined => try output.appendSlice("1"),
+                        .boolean => |b| try output.appendSlice(if (b) "true" else "false"),
+                        .int => |i| try output.writer().print("{d}", .{i}),
+                        .ident => |ident| try output.appendSlice(ident),
+                        .string => |string| {
+                            // TODO: use C-specific escaping instead of zig string literals
+                            try output.writer().print("{}", .{std.zig.fmtEscapes(string)});
+                        },
+                    }
+                    continue;
+                },
+                else => {
+                    index += 1;
+                    continue;
+                },
+            },
+            .dollar => |start_index| switch (contents[index]) {
+                '{' => {
+                    state = .{ .inline_curly_var = start_index };
+                    index += 1;
+                    continue;
+                },
+                '\\' => {
+                    try output.append('$');
+                    state = .{ .escape = index };
+                    index += 1;
+                    continue;
+                },
+                '\n' => {
+                    try output.append('$');
+                    try output.append('\n');
+                    state = .newline;
+                    index += 1;
+                    line_index += 1;
+                    continue;
+                },
+                '@' => {
+                    try output.append('$');
+                    state = .{ .inline_at_var = index };
+                    index += 1;
+                    continue;
+                },
+                '$' => {
+                    try output.append('$');
+                    state = .{ .dollar = index };
+                    index += 1;
+                    continue;
+                },
+                else => |character| {
+                    try output.append('$');
+                    try output.append(character);
+                    state = .copy;
+                    index += 1;
+                    continue;
+                },
+            },
+            .inline_curly_var => |start_index| switch (contents[index]) {
+                '\n' => {
+                    try output.appendSlice(contents[start_index .. index + 1]);
+                    state = .newline;
+                    index += 1;
+                    defer line_index += 1;
+                    continue;
+                },
+                ' ' => {
+                    try output.appendSlice(contents[start_index .. index + 1]);
+                    state = .copy;
+                    index += 1;
+                    continue;
+                },
+                '}' => {
+                    const name = contents[start_index + 2 .. index];
+                    state = .copy;
+                    index += 1;
+
+                    const kv = values_copy.fetchSwapRemove(name) orelse get_from_original_or_error: {
+                        if (values.getEntry(name)) |entry| {
+                            break :get_from_original_or_error std.StringArrayHashMap(Value).KV{
+                                .key = entry.key_ptr.*,
+                                .value = entry.value_ptr.*,
+                            };
+                        }
+                        try step.addError("{s}:{d}: error: unspecified config header value: '{s}'", .{
+                            src_path, line_index + 1, name,
+                        });
+                        any_errors = true;
+                        continue;
+                    };
+                    switch (kv.value) {
+                        // output nothing
+                        .undef => {},
+                        .defined => try output.appendSlice("1"),
+                        .boolean => |b| try output.appendSlice(if (b) "true" else "false"),
+                        .int => |i| try output.writer().print("{d}", .{i}),
+                        .ident => |ident| try output.appendSlice(ident),
+                        .string => |string| {
+                            // TODO: use C-specific escaping instead of zig string literals
+                            try output.writer().print("{}", .{std.zig.fmtEscapes(string)});
+                        },
+                    }
+                    continue;
+                },
+                else => {
+                    index += 1;
+                    continue;
+                },
+            },
         }
-        var it = std.mem.tokenize(u8, line[1..], " \t\r");
-        const mesondefine = it.next().?;
-        if (!std.mem.eql(u8, mesondefine, "mesondefine")) {
-            try output.appendSlice(line);
-            try output.appendSlice("\n");
-            continue;
-        }
-        const name = it.next() orelse {
-            try step.addError("{s}:{d}: error: missing define name", .{
-                src_path, line_index + 1,
-            });
-            any_errors = true;
-            continue;
-        };
-        const kv = values_copy.fetchSwapRemove(name) orelse {
-            try step.addError("{s}:{d}: error: unspecified config header value: '{s}'", .{
-                src_path, line_index + 1, name,
-            });
-            any_errors = true;
-            continue;
-        };
-        try renderValueC(output, name, kv.value);
+        std.debug.panic("index = {}, character = {}, state = {}", .{
+            index,
+            contents[index],
+            state,
+        });
     }
 
+    // clean up any remaining state
+    switch (state) {
+        .copy,
+        .escape,
+        .newline,
+        => {},
+        .mesondefine => |start_index| eof_terminated_mesondefine: {
+            const name = contents[start_index..];
+            const kv = values_copy.fetchSwapRemove(name) orelse {
+                try step.addError("{s}:{d}: error: unspecified config header value: '{s}'", .{
+                    src_path, line_index + 1, name,
+                });
+                any_errors = true;
+                break :eof_terminated_mesondefine;
+            };
+            try renderValueC(output, name, kv.value);
+        },
+        .inline_at_var,
+        .inline_curly_var,
+        => |start_index| {
+            try output.appendSlice(contents[start_index..]);
+        },
+        .dollar => {
+            try output.append('$');
+        },
+    }
+
+    // Check for unused values
     for (values_copy.keys()) |name| {
         try step.addError("{s}: error: config header value unused: '{s}'", .{ src_path, name });
         any_errors = true;
@@ -636,4 +933,320 @@ fn replace_variables(
     }
 
     return content_buf;
+}
+
+test "meson" {
+    if (builtin.os.tag == .wasi) return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const host = try std.zig.system.NativeTargetInfo.detect(.{});
+
+    var cache: std.Build.Cache = .{
+        .gpa = arena.allocator(),
+        .manifest_dir = std.fs.cwd(),
+    };
+
+    var builder = try std.Build.create(
+        arena.allocator(),
+        "test",
+        .{ .path = "test", .handle = std.fs.cwd() },
+        .{ .path = "test", .handle = std.fs.cwd() },
+        .{ .path = "test", .handle = std.fs.cwd() },
+        host,
+        &cache,
+        &.{},
+    );
+    defer builder.destroy();
+
+    const config_h_in_contents =
+        \\#define MESSAGE "@var@"
+        \\#define OTHER "@other@" "@second@" "@empty@"
+        \\
+        \\#mesondefine BE_TRUE
+        \\#mesondefine SHOULD_BE_UNDEF
+        \\
+    ;
+
+    const generate_config_header = ConfigHeader.create(builder, .{});
+    generate_config_header.addValues(.{
+        .@"var" = "mystring",
+        .other = "mystring 2",
+        .second = "bonus",
+        .empty = null,
+        .BE_TRUE = {},
+        .SHOULD_BE_UNDEF = null,
+    });
+    errdefer {
+        for (generate_config_header.step.result_error_msgs.items) |msg| {
+            std.debug.print("{s}\n", .{msg});
+        }
+    }
+
+    var output = std.ArrayList(u8).init(arena.allocator());
+
+    try render_meson(
+        &generate_config_header.step,
+        config_h_in_contents,
+        &output,
+        generate_config_header.values,
+        "config.h.in",
+    );
+
+    try std.testing.expectEqualStrings(
+        \\#define MESSAGE "mystring"
+        \\#define OTHER "mystring 2" "bonus" ""
+        \\
+        \\#define BE_TRUE
+        \\/* #undef SHOULD_BE_UNDEF */
+        \\
+    , output.items);
+}
+
+test "meson at style escapes" {
+    if (builtin.os.tag == .wasi) return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const host = try std.zig.system.NativeTargetInfo.detect(.{});
+
+    var cache: std.Build.Cache = .{
+        .gpa = arena.allocator(),
+        .manifest_dir = std.fs.cwd(),
+    };
+
+    var builder = try std.Build.create(
+        arena.allocator(),
+        "test",
+        .{ .path = "test", .handle = std.fs.cwd() },
+        .{ .path = "test", .handle = std.fs.cwd() },
+        .{ .path = "test", .handle = std.fs.cwd() },
+        host,
+        &cache,
+        &.{},
+    );
+    defer builder.destroy();
+
+    const config_h_in_contents =
+        \\/* No escape */
+        \\#define MESSAGE1 "@var1@"
+        \\
+        \\/* Single escape means no replace */
+        \\#define MESSAGE2 "\@var1@"
+        \\
+        \\/* Replace pairs of escapes before '@' or '\@' with escape characters
+        \\* (note we have to double number of pairs due to C string escaping)
+        \\*/
+        \\#define MESSAGE3 "\\\\@var1@"
+        \\
+        \\/* Pairs of escapes and then single escape to avoid replace */
+        \\#define MESSAGE4 "\\\\\@var1@"
+        \\
+        \\/* Check escaped variable does not overlap following variable */
+        \\#define MESSAGE5 "\@var1@var2@"
+        \\
+        \\/* Check escape character outside variables */
+        \\#define MESSAGE6 "\\ @ \@ \\\\@ \\\\\@"
+        \\
+    ;
+
+    const generate_config_header = ConfigHeader.create(builder, .{});
+    generate_config_header.addValues(.{
+        .var1 = "foo",
+        .var2 = "bar",
+    });
+    errdefer {
+        for (generate_config_header.step.result_error_msgs.items) |msg| {
+            std.debug.print("{s}\n", .{msg});
+        }
+    }
+
+    var output = std.ArrayList(u8).init(arena.allocator());
+
+    try render_meson(
+        &generate_config_header.step,
+        config_h_in_contents,
+        &output,
+        generate_config_header.values,
+        "config.h.in",
+    );
+
+    try std.testing.expectEqualStrings(
+        \\/* No escape */
+        \\#define MESSAGE1 "foo"
+        \\
+        \\/* Single escape means no replace */
+        \\#define MESSAGE2 "@var1@"
+        \\
+        \\/* Replace pairs of escapes before '@' or '@' with escape characters
+        \\* (note we have to double number of pairs due to C string escaping)
+        \\*/
+        \\#define MESSAGE3 "\\foo"
+        \\
+        \\/* Pairs of escapes and then single escape to avoid replace */
+        \\#define MESSAGE4 "\\@var1@"
+        \\
+        \\/* Check escaped variable does not overlap following variable */
+        \\#define MESSAGE5 "@var1bar"
+        \\
+        \\/* Check escape character outside variables */
+        \\#define MESSAGE6 "\\ @ @ \\@ \\@"
+        \\
+    , output.items);
+}
+
+test "meson curly brace style escapes" {
+    if (builtin.os.tag == .wasi) return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const host = try std.zig.system.NativeTargetInfo.detect(.{});
+
+    var cache: std.Build.Cache = .{
+        .gpa = arena.allocator(),
+        .manifest_dir = std.fs.cwd(),
+    };
+
+    var builder = try std.Build.create(
+        arena.allocator(),
+        "test",
+        .{ .path = "test", .handle = std.fs.cwd() },
+        .{ .path = "test", .handle = std.fs.cwd() },
+        .{ .path = "test", .handle = std.fs.cwd() },
+        host,
+        &cache,
+        &.{},
+    );
+    defer builder.destroy();
+
+    const config_h_in_contents =
+        \\/* No escape */
+        \\#define MESSAGE1 "${var1}"
+        \\
+        \\/* Single escape means no replace */
+        \\#define MESSAGE2 "\${var1}"
+        \\
+        \\/* Replace pairs of escapes before '@' or '\@' with escape characters
+        \\ * (note we have to double number of pairs due to C string escaping)
+        \\ */
+        \\#define MESSAGE3 "\\\\${var1}"
+        \\
+        \\/* Pairs of escapes and then single escape to avoid replace */
+        \\#define MESSAGE4 "\\\\\${var1}"
+        \\
+        \\/* Check escape character outside variables */
+        \\#define MESSAGE5 "\\ ${ ${ \\\\${ \\\\\${"
+        \\
+    ;
+
+    const generate_config_header = ConfigHeader.create(builder, .{});
+    generate_config_header.addValues(.{
+        .var1 = "foo",
+    });
+    errdefer {
+        for (generate_config_header.step.result_error_msgs.items) |msg| {
+            std.debug.print("{s}\n", .{msg});
+        }
+    }
+
+    var output = std.ArrayList(u8).init(arena.allocator());
+
+    try render_meson(
+        &generate_config_header.step,
+        config_h_in_contents,
+        &output,
+        generate_config_header.values,
+        "config.h.in",
+    );
+
+    try std.testing.expectEqualStrings(
+        \\/* No escape */
+        \\#define MESSAGE1 "foo"
+        \\
+        \\/* Single escape means no replace */
+        \\#define MESSAGE2 "${var1}"
+        \\
+        \\/* Replace pairs of escapes before '@' or '@' with escape characters
+        \\ * (note we have to double number of pairs due to C string escaping)
+        \\ */
+        \\#define MESSAGE3 "\\foo"
+        \\
+        \\/* Pairs of escapes and then single escape to avoid replace */
+        \\#define MESSAGE4 "\\${var1}"
+        \\
+        \\/* Check escape character outside variables */
+        \\#define MESSAGE5 "\\ ${ ${ \\${ \\${"
+        \\
+    , output.items);
+}
+
+test "meson glibconfig.h.in snippets" {
+    if (builtin.os.tag == .wasi) return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const host = try std.zig.system.NativeTargetInfo.detect(.{});
+
+    var cache: std.Build.Cache = .{
+        .gpa = arena.allocator(),
+        .manifest_dir = std.fs.cwd(),
+    };
+
+    var builder = try std.Build.create(
+        arena.allocator(),
+        "test",
+        .{ .path = "test", .handle = std.fs.cwd() },
+        .{ .path = "test", .handle = std.fs.cwd() },
+        .{ .path = "test", .handle = std.fs.cwd() },
+        host,
+        &cache,
+        &.{},
+    );
+    defer builder.destroy();
+
+    const config_h_in_contents =
+        \\typedef signed @gint32@ gint32;
+        \\
+        \\@glib_extension@typedef signed @gint64@ gint64;
+        \\
+        \\@glib_os@
+        \\
+    ;
+
+    const generate_config_header = ConfigHeader.create(builder, .{});
+    generate_config_header.addValues(.{
+        .gint32 = .int,
+        .glib_extension = null,
+        .gint64 = .long,
+        .glib_os = .@"#define G_OS_WIN32\n#define G_PLATFORM_WIN32",
+    });
+    errdefer {
+        for (generate_config_header.step.result_error_msgs.items) |msg| {
+            std.debug.print("{s}\n", .{msg});
+        }
+    }
+
+    var output = std.ArrayList(u8).init(arena.allocator());
+
+    try render_meson(
+        &generate_config_header.step,
+        config_h_in_contents,
+        &output,
+        generate_config_header.values,
+        "config.h.in",
+    );
+
+    try std.testing.expectEqualStrings(
+        \\typedef signed int gint32;
+        \\
+        \\typedef signed long gint64;
+        \\
+        \\#define G_OS_WIN32
+        \\#define G_PLATFORM_WIN32
+        \\
+    , output.items);
 }


### PR DESCRIPTION
Rebases #15017

Adds tests and support for backslash escaping variables.

Duplicates some functionality of `replace_variables`, as I didn't realize it existed. `replace_variables` would need backslash escaping added to replace the current code.

I worked on this pull request as I'm trying to add `build.zig` support to `glib`, which uses meson. I haven't yet tested generating the config header using this code, but I plan to.