### PR TITLE
Remove unnecessary branch on absolute path

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1078,13 +1078,8 @@ pub fn readElfDebugInfo(
     parent_mapped_mem: ?[]align(mem.page_size) const u8,
 ) !ModuleDebugInfo {
     nosuspend {
-
-        // TODO https://github.com/ziglang/zig/issues/5525
         const elf_file = (if (elf_filename) |filename| blk: {
-            break :blk if (fs.path.isAbsolute(filename))
-                fs.openFileAbsolute(filename, .{ .intended_io_mode = .blocking })
-            else
-                fs.cwd().openFile(filename, .{ .intended_io_mode = .blocking });
+            break :blk fs.cwd().openFile(filename, .{ .intended_io_mode = .blocking });
         } else fs.openSelfExe(.{ .intended_io_mode = .blocking })) catch |err| switch (err) {
             error.FileNotFound => return error.MissingDebugInfo,
             else => return err,


### PR DESCRIPTION
Also remove the TODO--it was added in fd067fbe8b14c445ed764da15fff5163156126df, but the current code no longer used that workaround, so this TODO didn't seem relevant anymore.

Follow up to #16743 (see https://github.com/ziglang/zig/pull/16743#discussion_r1402802261).