### PR TITLE
langref: more readable heading styling

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -187,6 +187,17 @@
         border-left: 0.25em solid #f7a41d;
         padding: 0 1em 0 1em;
       }
+      
+      #contents h2{
+        border-bottom: 1px solid;
+      } 
+      #contents h2,h3,h4{
+        margin-top:1.5em;
+        margin-bottom:0.5em;
+      }	
+      h3{
+        font-size: 1.25em;
+      }
 
       h1 a, h2 a, h3 a, h4 a, h5 a {
         text-decoration: none;


### PR DESCRIPTION
|h2|h3 & h4|
|--|-------|
|![image](https://github.com/ziglang/zig/assets/77922942/9a1fa602-faa2-49e0-be9d-7cdf2e142722)|![image](https://github.com/ziglang/zig/assets/77922942/cf0e6d8c-015e-4ca4-a98e-89888c5189bf)|


[Preview result,](https://github.com/ziglang/zig/files/13448693/langref.html.txt) when combined with #18066