### PR TITLE
Use struct_init_one for no-initializer struct

### DIFF
--- a/test/cases/translate_c/static empty struct.c
+++ b/test/cases/translate_c/static empty struct.c
@@ -1,0 +1,17 @@
+struct empty_struct {};
+
+static inline void foo() {
+    static struct empty_struct bar = {};
+}
+
+// translate-c
+// target=x86_64-linux
+// c_frontend=clang
+//
+// pub const struct_empty_struct = extern struct {};
+// pub fn foo() callconv(.C) void {
+//     const bar = struct {
+//         var static: struct_empty_struct = struct_empty_struct{};
+//     };
+//     _ = &bar;
+// }

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -976,7 +976,7 @@ const TestManifest = struct {
 
         fn next(self: *TrailingIterator) ?[]const u8 {
             const next_inner = self.inner.next() orelse return null;
-            return std.mem.trim(u8, next_inner[2..], " \t");
+            return if (next_inner.len == 2) "" else std.mem.trimRight(u8, next_inner[3..], " \t");
         }
     };
 


### PR DESCRIPTION
Closes #18093 
`test.h`:
```
struct empty_struct {};

static inline void foo() {
    static struct empty_struct bar = {};
}
```
`zig translate-c test.h` relevant output:
```
pub const struct_empty_struct = extern struct {};
pub fn foo() callconv(.C) void {
    const bar = struct {
        var static: struct_empty_struct = struct_empty_struct{};
    };
    _ = &bar;
}
```