### PR TITLE
convert `toType` and `toValue` to `Type.fromInterned` and `Value.fromInterned`

### DIFF
--- a/src/Air.zig
+++ b/src/Air.zig
@@ -1221,7 +1221,7 @@ pub fn getMainBody(air: Air) []const Air.Inst.Index {
 
 pub fn typeOf(air: *const Air, inst: Air.Inst.Ref, ip: *const InternPool) Type {
     if (refToInterned(inst)) |ip_index| {
-        return ip.typeOf(ip_index).toType();
+        return Type.fromInterned(ip.typeOf(ip_index));
     } else {
         return air.typeOfIndex(refToIndex(inst).?, ip);
     }
@@ -1438,7 +1438,7 @@ pub fn typeOfIndex(air: *const Air, inst: Air.Inst.Index, ip: *const InternPool)
 
         .call, .call_always_tail, .call_never_tail, .call_never_inline => {
             const callee_ty = air.typeOf(datas[inst].pl_op.operand, ip);
-            return ip.funcTypeReturnType(callee_ty.toIntern()).toType();
+            return Type.fromInterned(ip.funcTypeReturnType(callee_ty.toIntern()));
         },
 
         .slice_elem_val, .ptr_elem_val, .array_elem_val => {
@@ -1456,7 +1456,7 @@ pub fn typeOfIndex(air: *const Air, inst: Air.Inst.Index, ip: *const InternPool)
 
         .reduce, .reduce_optimized => {
             const operand_ty = air.typeOf(datas[inst].reduce.operand, ip);
-            return ip.indexToKey(operand_ty.ip_index).vector_type.child.toType();
+            return Type.fromInterned(ip.indexToKey(operand_ty.ip_index).vector_type.child);
         },
 
         .mul_add => return air.typeOf(datas[inst].pl_op.operand, ip),
@@ -1467,7 +1467,7 @@ pub fn typeOfIndex(air: *const Air, inst: Air.Inst.Index, ip: *const InternPool)
 
         .@"try" => {
             const err_union_ty = air.typeOf(datas[inst].pl_op.operand, ip);
-            return ip.indexToKey(err_union_ty.ip_index).error_union_type.payload_type.toType();
+            return Type.fromInterned(ip.indexToKey(err_union_ty.ip_index).error_union_type.payload_type);
         },
 
         .work_item_id,
@@ -1482,7 +1482,7 @@ pub fn typeOfIndex(air: *const Air, inst: Air.Inst.Index, ip: *const InternPool)
 
 pub fn getRefType(air: Air, ref: Air.Inst.Ref) Type {
     _ = air; // TODO: remove this parameter
-    return refToInterned(ref).?.toType();
+    return Type.fromInterned(refToInterned(ref).?);
 }
 
 /// Returns the requested data, as well as the new index which is at the start of the
@@ -1561,7 +1561,7 @@ pub fn indexToRef(inst: Inst.Index) Inst.Ref {
 /// Returns `null` if runtime-known.
 pub fn value(air: Air, inst: Inst.Ref, mod: *Module) !?Value {
     if (refToInterned(inst)) |ip_index| {
-        return ip_index.toValue();
+        return Value.fromInterned(ip_index);
     }
     const index = refToIndex(inst).?;
     return air.typeOfIndex(index, &mod.intern_pool).onePossibleValue(mod);

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -117,7 +117,7 @@ fn generateZirData(self: *Autodoc, output_dir: std.fs.Dir) !void {
                 // Not a real type, doesn't have a normal name
                 try tmpbuf.writer().writeAll("(generic poison)");
             } else {
-                try ip_index.toType().fmt(self.comp_module).format("", .{}, tmpbuf.writer());
+                try @import("type.zig").Type.fromInterned(ip_index).fmt(self.comp_module).format("", .{}, tmpbuf.writer());
             }
             try self.types.append(
                 self.arena,

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -2096,19 +2096,6 @@ pub const Index = enum(u32) {
         }
     };
 
-    pub fn toType(i: Index) @import("type.zig").Type {
-        assert(i != .none);
-        return .{ .ip_index = i };
-    }
-
-    pub fn toValue(i: Index) @import("value.zig").Value {
-        assert(i != .none);
-        return .{
-            .ip_index = i,
-            .legacy = undefined,
-        };
-    }
-
     /// Used for a map of `Index` values to the index within a list of `Index` values.
     const Adapter = struct {
         indexes: []const Index,
@@ -6145,8 +6132,8 @@ fn finishFuncInstance(
         .src_line = fn_owner_decl.src_line,
         .has_tv = true,
         .owns_tv = true,
-        .ty = func_ty.toType(),
-        .val = func_index.toValue(),
+        .ty = @import("type.zig").Type.fromInterned(func_ty),
+        .val = @import("value.zig").Value.fromInterned(func_index),
         .alignment = .none,
         .@"linksection" = section,
         .@"addrspace" = fn_owner_decl.@"addrspace",

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2153,13 +2153,13 @@ fn resolveValueAllowVariables(sema: *Sema, inst: Air.Inst.Ref) CompileError!?Val
     assert(inst != .none);
     // First section of indexes correspond to a set number of constant values.
     if (@intFromEnum(inst) < InternPool.static_len) {
-        return @as(InternPool.Index, @enumFromInt(@intFromEnum(inst))).toValue();
+        return Value.fromInterned(@as(InternPool.Index, @enumFromInt(@intFromEnum(inst))));
     }
 
     const air_tags = sema.air_instructions.items(.tag);
     if (try sema.typeHasOnePossibleValue(sema.typeOf(inst))) |opv| {
         if (Air.refToInterned(inst)) |ip_index| {
-            const val = ip_index.toValue();
+            const val = Value.fromInterned(ip_index);
             if (val.getVariable(sema.mod) != null) return val;
         }
         return opv;
@@ -2171,7 +2171,7 @@ fn resolveValueAllowVariables(sema: *Sema, inst: Air.Inst.Ref) CompileError!?Val
             else => return null,
         }
     };
-    const val = ip_index.toValue();
+    const val = Value.fromInterned(ip_index);
     if (val.isPtrToThreadLocal(sema.mod)) return null;
     return val;
 }
@@ -2364,7 +2364,7 @@ fn typeSupportsFieldAccess(mod: *const Module, ty: Type, field_name: InternPool.
             const ptr_info = ty.ptrInfo(mod);
             if (ptr_info.flags.size == .Slice) {
                 return ip.stringEqlSlice(field_name, "ptr") or ip.stringEqlSlice(field_name, "len");
-            } else if (ptr_info.child.toType().zigTypeTag(mod) == .Array) {
+            } else if (Type.fromInterned(ptr_info.child).zigTypeTag(mod) == .Array) {
                 return ip.stringEqlSlice(field_name, "len");
             } else return false;
         },
@@ -2752,8 +2752,8 @@ fn zirStructDecl(
     //errdefer ip.remove(struct_ty);
 
     new_decl.ty = Type.type;
-    new_decl.val = struct_ty.toValue();
-    new_namespace.ty = struct_ty.toType();
+    new_decl.val = Value.fromInterned(struct_ty);
+    new_namespace.ty = Type.fromInterned(struct_ty);
 
     const decl_val = sema.analyzeDeclVal(block, src, new_decl_index);
     try mod.finalizeAnonDecl(new_decl_index);
@@ -2959,8 +2959,8 @@ fn zirEnumDecl(
     //errdefer if (!done) mod.intern_pool.remove(incomplete_enum.index);
 
     new_decl.ty = Type.type;
-    new_decl.val = incomplete_enum.index.toValue();
-    new_namespace.ty = incomplete_enum.index.toType();
+    new_decl.val = Value.fromInterned(incomplete_enum.index);
+    new_namespace.ty = Type.fromInterned(incomplete_enum.index);
 
     const decl_val = try sema.analyzeDeclVal(block, src, new_decl_index);
     try mod.finalizeAnonDecl(new_decl_index);
@@ -3222,8 +3222,8 @@ fn zirUnionDecl(
     //errdefer mod.intern_pool.remove(union_ty);
 
     new_decl.ty = Type.type;
-    new_decl.val = union_ty.toValue();
-    new_namespace.ty = union_ty.toType();
+    new_decl.val = Value.fromInterned(union_ty);
+    new_namespace.ty = Type.fromInterned(union_ty);
 
     _ = try mod.scanNamespace(new_namespace_index, extra_index, decls_len, new_decl);
 
@@ -3285,8 +3285,8 @@ fn zirOpaqueDecl(
     //errdefer mod.intern_pool.remove(opaque_ty);
 
     new_decl.ty = Type.type;
-    new_decl.val = opaque_ty.toValue();
-    new_namespace.ty = opaque_ty.toType();
+    new_decl.val = Value.fromInterned(opaque_ty);
+    new_namespace.ty = Type.fromInterned(opaque_ty);
 
     extra_index = try mod.scanNamespace(new_namespace_index, extra_index, decls_len, new_decl);
 
@@ -3600,7 +3600,7 @@ fn zirMakePtrConst(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileErro
     const alloc = try sema.resolveInst(inst_data.operand);
     const alloc_ty = sema.typeOf(alloc);
     const ptr_info = alloc_ty.ptrInfo(mod);
-    const elem_ty = ptr_info.child.toType();
+    const elem_ty = Type.fromInterned(ptr_info.child);
 
     if (try sema.resolveComptimeKnownAllocValue(block, alloc, null)) |val| {
         const new_mut_ptr = Air.internedToRef((try mod.intern(.{ .ptr = .{
@@ -3652,7 +3652,7 @@ fn resolveComptimeKnownAllocValue(sema: *Sema, block: *Block, alloc: Air.Inst.Re
 
     const alloc_ty = resolved_alloc_ty orelse sema.typeOf(alloc);
     const ptr_info = alloc_ty.ptrInfo(mod);
-    const elem_ty = ptr_info.child.toType();
+    const elem_ty = Type.fromInterned(ptr_info.child);
 
     const alloc_inst = Air.refToIndex(alloc) orelse return null;
     const comptime_info = sema.maybe_comptime_allocs.fetchRemove(alloc_inst) orelse return null;
@@ -3803,7 +3803,7 @@ fn resolveComptimeKnownAllocValue(sema: *Sema, block: *Block, alloc: Air.Inst.Re
                     .index = field_idx,
                 } },
             } }),
-            .elem => |elem_idx| (try decl_parent_ptr.toValue().elemPtr(new_ptr_ty.toType(), @intCast(elem_idx), mod)).toIntern(),
+            .elem => |elem_idx| (try Value.fromInterned(decl_parent_ptr).elemPtr(Type.fromInterned(new_ptr_ty), @intCast(elem_idx), mod)).toIntern(),
         };
         try ptr_mapping.put(air_ptr, new_ptr);
     }
@@ -3823,7 +3823,7 @@ fn resolveComptimeKnownAllocValue(sema: *Sema, block: *Block, alloc: Air.Inst.Re
                 if (try sema.typeHasOnePossibleValue(payload_ty)) |payload_val| {
                     const new_ptr = ptr_mapping.get(air_ptr_inst).?;
                     const store_val = try mod.unionValue(union_ty, tag_val, payload_val);
-                    try sema.storePtrVal(block, .unneeded, new_ptr.toValue(), store_val, union_ty);
+                    try sema.storePtrVal(block, .unneeded, Value.fromInterned(new_ptr), store_val, union_ty);
                 }
             },
             .store, .store_safe => {
@@ -3831,14 +3831,14 @@ fn resolveComptimeKnownAllocValue(sema: *Sema, block: *Block, alloc: Air.Inst.Re
                 const air_ptr_inst = Air.refToIndex(bin_op.lhs).?;
                 const store_val = (try sema.resolveValue(bin_op.rhs)).?;
                 const new_ptr = ptr_mapping.get(air_ptr_inst).?;
-                try sema.storePtrVal(block, .unneeded, new_ptr.toValue(), store_val, mod.intern_pool.typeOf(store_val.toIntern()).toType());
+                try sema.storePtrVal(block, .unneeded, Value.fromInterned(new_ptr), store_val, Type.fromInterned(mod.intern_pool.typeOf(store_val.toIntern())));
             },
             else => unreachable,
         }
     }
 
     // The value is finalized - load it!
-    const val = (try sema.pointerDeref(block, .unneeded, decl_ptr.toValue(), alloc_ty)).?.toIntern();
+    const val = (try sema.pointerDeref(block, .unneeded, Value.fromInterned(decl_ptr), alloc_ty)).?.toIntern();
     return sema.finishResolveComptimeKnownAllocValue(val, alloc_inst, comptime_info.value);
 }
 
@@ -6757,8 +6757,8 @@ fn checkCallArgumentCount(
             .Fn => break :func_ty callee_ty,
             .Pointer => {
                 const ptr_info = callee_ty.ptrInfo(mod);
-                if (ptr_info.flags.size == .One and ptr_info.child.toType().zigTypeTag(mod) == .Fn) {
-                    break :func_ty ptr_info.child.toType();
+                if (ptr_info.flags.size == .One and Type.fromInterned(ptr_info.child).zigTypeTag(mod) == .Fn) {
+                    break :func_ty Type.fromInterned(ptr_info.child);
                 }
             },
             .Optional => {
@@ -6831,8 +6831,8 @@ fn callBuiltin(
             .Fn => break :func_ty callee_ty,
             .Pointer => {
                 const ptr_info = callee_ty.ptrInfo(mod);
-                if (ptr_info.flags.size == .One and ptr_info.child.toType().zigTypeTag(mod) == .Fn) {
-                    break :func_ty ptr_info.child.toType();
+                if (ptr_info.flags.size == .One and Type.fromInterned(ptr_info.child).zigTypeTag(mod) == .Fn) {
+                    break :func_ty Type.fromInterned(ptr_info.child);
                 }
             },
             else => {},
@@ -7179,14 +7179,14 @@ fn analyzeCall(
     var is_comptime_call = block.is_comptime or modifier == .compile_time;
     var comptime_reason: ?*const Block.ComptimeReason = null;
     if (!is_comptime_call) {
-        if (sema.typeRequiresComptime(func_ty_info.return_type.toType())) |ct| {
+        if (sema.typeRequiresComptime(Type.fromInterned(func_ty_info.return_type))) |ct| {
             is_comptime_call = ct;
             if (ct) {
                 comptime_reason = &.{ .comptime_ret_ty = .{
                     .block = block,
                     .func = func,
                     .func_src = func_src,
-                    .return_ty = func_ty_info.return_type.toType(),
+                    .return_ty = Type.fromInterned(func_ty_info.return_type),
                 } };
             }
         } else |err| switch (err) {
@@ -7234,7 +7234,7 @@ fn analyzeCall(
                     .block = block,
                     .func = func,
                     .func_src = func_src,
-                    .return_ty = func_ty_info.return_type.toType(),
+                    .return_ty = Type.fromInterned(func_ty_info.return_type),
                 } };
             },
             else => |e| return e,
@@ -7431,10 +7431,10 @@ fn analyzeCall(
             const ies = try sema.arena.create(InferredErrorSet);
             ies.* = .{ .func = .none };
             sema.fn_ret_ty_ies = ies;
-            sema.fn_ret_ty = (try ip.get(gpa, .{ .error_union_type = .{
+            sema.fn_ret_ty = Type.fromInterned((try ip.get(gpa, .{ .error_union_type = .{
                 .error_set_type = .adhoc_inferred_error_set_type,
                 .payload_type = sema.fn_ret_ty.toIntern(),
-            } })).toType();
+            } })));
         }
 
         // This `res2` is here instead of directly breaking from `res` due to a stage1
@@ -7529,7 +7529,7 @@ fn analyzeCall(
             if (new_ty != .none) {
                 // TODO: mutate in place the previous instruction if possible
                 // rather than adding a bitcast instruction.
-                break :res2 try block.addBitCast(new_ty.toType(), result);
+                break :res2 try block.addBitCast(Type.fromInterned(new_ty), result);
             }
 
             break :res2 result;
@@ -7543,8 +7543,8 @@ fn analyzeCall(
         for (args, 0..) |*arg_out, arg_idx| {
             // Non-generic, so param types are already resolved
             const param_ty = if (arg_idx < func_ty_info.param_types.len) ty: {
-                break :ty func_ty_info.param_types.get(ip)[arg_idx].toType();
-            } else InternPool.Index.var_args_param_type.toType();
+                break :ty Type.fromInterned(func_ty_info.param_types.get(ip)[arg_idx]);
+            } else Type.fromInterned(InternPool.Index.var_args_param_type);
             assert(!param_ty.isGenericPoison());
             arg_out.* = try args_info.analyzeArg(sema, block, arg_idx, param_ty, func_ty_info, func);
             if (sema.typeOf(arg_out.*).zigTypeTag(mod) == .NoReturn) {
@@ -7554,8 +7554,8 @@ fn analyzeCall(
 
         if (call_dbg_node) |some| try sema.zirDbgStmt(block, some);
 
-        try sema.queueFullTypeResolution(func_ty_info.return_type.toType());
-        if (sema.owner_func_index != .none and func_ty_info.return_type.toType().isError(mod)) {
+        try sema.queueFullTypeResolution(Type.fromInterned(func_ty_info.return_type));
+        if (sema.owner_func_index != .none and Type.fromInterned(func_ty_info.return_type).isError(mod)) {
             ip.funcAnalysis(sema.owner_func_index).calls_or_awaits_errorable_fn = true;
         }
 
@@ -7670,12 +7670,12 @@ fn analyzeInlineCallArg(
                 break :param_ty param_ty.toIntern();
             };
             new_param_types[arg_i.*] = param_ty;
-            const casted_arg = try args_info.analyzeArg(ics.caller(), arg_block, arg_i.*, param_ty.toType(), func_ty_info, func_inst);
+            const casted_arg = try args_info.analyzeArg(ics.caller(), arg_block, arg_i.*, Type.fromInterned(param_ty), func_ty_info, func_inst);
             if (ics.caller().typeOf(casted_arg).zigTypeTag(mod) == .NoReturn) {
                 return casted_arg;
             }
             const arg_src = args_info.argSrc(arg_block, arg_i.*);
-            if (try ics.callee().typeRequiresComptime(param_ty.toType())) {
+            if (try ics.callee().typeRequiresComptime(Type.fromInterned(param_ty))) {
                 _ = try ics.caller().resolveConstValue(arg_block, arg_src, casted_arg, .{
                     .needed_comptime_reason = "argument to parameter with comptime-only type must be comptime-known",
                     .block_comptime_reason = param_block.comptime_reason,
@@ -7705,7 +7705,7 @@ fn analyzeInlineCallArg(
                 // when the hash function is called.
                 const resolved_arg_val = try ics.caller().resolveLazyValue(arg_val);
                 should_memoize.* = should_memoize.* and !resolved_arg_val.canMutateComptimeVarState(mod);
-                memoized_arg_values[arg_i.*] = try resolved_arg_val.intern(param_ty.toType(), mod);
+                memoized_arg_values[arg_i.*] = try resolved_arg_val.intern(Type.fromInterned(param_ty), mod);
             } else {
                 ics.callee().inst_map.putAssumeCapacityNoClobber(inst, casted_arg);
             }
@@ -7790,7 +7790,7 @@ fn instantiateGenericCall(
         else => unreachable,
     };
     const generic_owner_func = mod.intern_pool.indexToKey(generic_owner).func;
-    const generic_owner_ty_info = mod.typeToFunc(generic_owner_func.ty.toType()).?;
+    const generic_owner_ty_info = mod.typeToFunc(Type.fromInterned(generic_owner_func.ty)).?;
 
     // Even though there may already be a generic instantiation corresponding
     // to this callsite, we must evaluate the expressions of the generic
@@ -7862,7 +7862,7 @@ fn instantiateGenericCall(
         const param_tag = fn_zir.instructions.items(.tag)[@intFromEnum(param_inst)];
 
         const param_ty = switch (generic_owner_ty_info.param_types.get(ip)[arg_index]) {
-            else => |ty| ty.toType(), // parameter is not generic, so type is already resolved
+            else => |ty| Type.fromInterned(ty), // parameter is not generic, so type is already resolved
             .generic_poison_type => param_ty: {
                 // We have every parameter before this one, so can resolve this parameter's type now.
                 // However, first check the param type, since it may be anytype.
@@ -7998,12 +7998,12 @@ fn instantiateGenericCall(
     try sema.addReferencedBy(block, call_src, callee.owner_decl);
 
     // Make a runtime call to the new function, making sure to omit the comptime args.
-    const func_ty = callee.ty.toType();
+    const func_ty = Type.fromInterned(callee.ty);
     const func_ty_info = mod.typeToFunc(func_ty).?;
 
     // If the call evaluated to a return type that requires comptime, never mind
     // our generic instantiation. Instead we need to perform a comptime call.
-    if (try sema.typeRequiresComptime(func_ty_info.return_type.toType())) {
+    if (try sema.typeRequiresComptime(Type.fromInterned(func_ty_info.return_type))) {
         return error.ComptimeReturn;
     }
     // Similarly, if the call evaluated to a generic type we need to instead
@@ -8012,12 +8012,12 @@ fn instantiateGenericCall(
         return error.GenericPoison;
     }
 
-    try sema.queueFullTypeResolution(func_ty_info.return_type.toType());
+    try sema.queueFullTypeResolution(Type.fromInterned(func_ty_info.return_type));
 
     if (call_dbg_node) |some| try sema.zirDbgStmt(block, some);
 
     if (sema.owner_func_index != .none and
-        func_ty_info.return_type.toType().isError(mod))
+        Type.fromInterned(func_ty_info.return_type).isError(mod))
     {
         ip.funcAnalysis(sema.owner_func_index).calls_or_awaits_errorable_fn = true;
     }
@@ -8057,10 +8057,10 @@ fn resolveTupleLazyValues(sema: *Sema, block: *Block, src: LazySrcLoc, ty: Type)
         else => return,
     };
     for (tuple.types.get(ip), tuple.values.get(ip)) |field_ty, field_val| {
-        try sema.resolveTupleLazyValues(block, src, field_ty.toType());
+        try sema.resolveTupleLazyValues(block, src, Type.fromInterned(field_ty));
         if (field_val == .none) continue;
         // TODO: mutate in intern pool
-        _ = try sema.resolveLazyValue(field_val.toValue());
+        _ = try sema.resolveLazyValue(Value.fromInterned(field_val));
     }
 }
 
@@ -9217,7 +9217,7 @@ fn funcCommon(
     const cc_resolved = cc orelse .Unspecified;
     var comptime_bits: u32 = 0;
     for (block.params.items(.ty), block.params.items(.is_comptime), 0..) |param_ty_ip, param_is_comptime, i| {
-        const param_ty = param_ty_ip.toType();
+        const param_ty = Type.fromInterned(param_ty_ip);
         const is_noalias = blk: {
             const index = std.math.cast(u5, i) orelse break :blk false;
             break :blk @as(u1, @truncate(noalias_bits >> index)) != 0;
@@ -9529,7 +9529,7 @@ fn finishFunc(
     const return_type: Type = if (opt_func_index == .none or ret_poison)
         bare_return_type
     else
-        ip.funcTypeReturnType(ip.typeOf(opt_func_index)).toType();
+        Type.fromInterned(ip.funcTypeReturnType(ip.typeOf(opt_func_index)));
 
     if (!return_type.isValidReturnType(mod)) {
         const opaque_str = if (return_type.zigTypeTag(mod) == .Opaque) "opaque " else "";
@@ -10078,10 +10078,10 @@ fn intCast(
                 // range to account for negative values.
                 const dest_range_val = if (wanted_info.signedness == .signed) range_val: {
                     const one_scalar = try mod.intValue(unsigned_scalar_operand_ty, 1);
-                    const one = if (is_vector) (try mod.intern(.{ .aggregate = .{
+                    const one = if (is_vector) Value.fromInterned((try mod.intern(.{ .aggregate = .{
                         .ty = unsigned_operand_ty.toIntern(),
                         .storage = .{ .repeated_elem = one_scalar.toIntern() },
-                    } })).toValue() else one_scalar;
+                    } }))) else one_scalar;
                     const range_minus_one = try dest_max_val.shl(one, unsigned_operand_ty, sema.arena, mod);
                     break :range_val try sema.intAdd(range_minus_one, one, unsigned_operand_ty, undefined);
                 } else try mod.getCoerced(dest_max_val, unsigned_operand_ty);
@@ -10734,7 +10734,7 @@ const SwitchProngAnalysis = struct {
             if (operand_ty.zigTypeTag(mod) == .Union) {
                 const field_index: u32 = @intCast(operand_ty.unionTagFieldIndex(item_val, mod).?);
                 const union_obj = mod.typeToUnion(operand_ty).?;
-                const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+                const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
                 if (capture_byref) {
                     const ptr_field_ty = try sema.ptrType(.{
                         .child = field_ty.toIntern(),
@@ -10790,7 +10790,7 @@ const SwitchProngAnalysis = struct {
                 const first_item_val = sema.resolveConstDefinedValue(block, .unneeded, case_vals[0], undefined) catch unreachable;
 
                 const first_field_index: u32 = mod.unionTagFieldIndex(union_obj, first_item_val).?;
-                const first_field_ty = union_obj.field_types.get(ip)[first_field_index].toType();
+                const first_field_ty = Type.fromInterned(union_obj.field_types.get(ip)[first_field_index]);
 
                 const field_indices = try sema.arena.alloc(u32, case_vals.len);
                 for (case_vals, field_indices) |item, *field_idx| {
@@ -10801,7 +10801,7 @@ const SwitchProngAnalysis = struct {
                 // Fast path: if all the operands are the same type already, we don't need to hit
                 // PTR! This will also allow us to emit simpler code.
                 const same_types = for (field_indices[1..]) |field_idx| {
-                    const field_ty = union_obj.field_types.get(ip)[field_idx].toType();
+                    const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_idx]);
                     if (!field_ty.eql(first_field_ty, sema.mod)) break false;
                 } else true;
 
@@ -10809,7 +10809,7 @@ const SwitchProngAnalysis = struct {
                     // We need values to run PTR on, so make a bunch of undef constants.
                     const dummy_captures = try sema.arena.alloc(Air.Inst.Ref, case_vals.len);
                     for (dummy_captures, field_indices) |*dummy, field_idx| {
-                        const field_ty = union_obj.field_types.get(ip)[field_idx].toType();
+                        const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_idx]);
                         dummy.* = try mod.undefRef(field_ty);
                     }
 
@@ -10857,7 +10857,7 @@ const SwitchProngAnalysis = struct {
                     // pointer type is in-memory coercible to the capture pointer type.
                     if (!same_types) {
                         for (field_indices, 0..) |field_idx, i| {
-                            const field_ty = union_obj.field_types.get(ip)[field_idx].toType();
+                            const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_idx]);
                             const field_ptr_ty = try sema.ptrType(.{
                                 .child = field_ty.toIntern(),
                                 .flags = .{
@@ -10906,7 +10906,7 @@ const SwitchProngAnalysis = struct {
                 if (try sema.resolveDefinedValue(block, operand_src, spa.operand)) |operand_val| {
                     if (operand_val.isUndef(mod)) return mod.undefRef(capture_ty);
                     const union_val = ip.indexToKey(operand_val.toIntern()).un;
-                    if (union_val.tag.toValue().isUndef(mod)) return mod.undefRef(capture_ty);
+                    if (Value.fromInterned(union_val.tag).isUndef(mod)) return mod.undefRef(capture_ty);
                     const uncoerced = Air.internedToRef(union_val.val);
                     return sema.coerce(block, capture_ty, uncoerced, operand_src);
                 }
@@ -10921,7 +10921,7 @@ const SwitchProngAnalysis = struct {
                 // If we can, try to avoid that using in-memory coercions.
                 const first_non_imc = in_mem: {
                     for (field_indices, 0..) |field_idx, i| {
-                        const field_ty = union_obj.field_types.get(ip)[field_idx].toType();
+                        const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_idx]);
                         if (.ok != try sema.coerceInMemoryAllowed(block, capture_ty, field_ty, false, sema.mod.getTarget(), .unneeded, .unneeded)) {
                             break :in_mem i;
                         }
@@ -10944,7 +10944,7 @@ const SwitchProngAnalysis = struct {
                 {
                     const next = first_non_imc + 1;
                     for (field_indices[next..], next..) |field_idx, i| {
-                        const field_ty = union_obj.field_types.get(ip)[field_idx].toType();
+                        const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_idx]);
                         if (.ok != try sema.coerceInMemoryAllowed(block, capture_ty, field_ty, false, sema.mod.getTarget(), .unneeded, .unneeded)) {
                             in_mem_coercible.unset(i);
                         }
@@ -10975,7 +10975,7 @@ const SwitchProngAnalysis = struct {
                         defer coerce_block.instructions.deinit(sema.gpa);
 
                         const field_idx = field_indices[idx];
-                        const field_ty = union_obj.field_types.get(ip)[field_idx].toType();
+                        const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_idx]);
                         const uncoerced = try coerce_block.addStructFieldVal(spa.operand, field_idx, field_ty);
                         const coerced = sema.coerce(&coerce_block, capture_ty, uncoerced, .unneeded) catch |err| switch (err) {
                             error.NeededSourceLocation => {
@@ -11004,7 +11004,7 @@ const SwitchProngAnalysis = struct {
 
                     const first_imc_item_idx = in_mem_coercible.findFirstSet().?;
                     const first_imc_field_idx = field_indices[first_imc_item_idx];
-                    const first_imc_field_ty = union_obj.field_types.get(ip)[first_imc_field_idx].toType();
+                    const first_imc_field_ty = Type.fromInterned(union_obj.field_types.get(ip)[first_imc_field_idx]);
                     const uncoerced = try coerce_block.addStructFieldVal(spa.operand, first_imc_field_idx, first_imc_field_ty);
                     const coerced = try coerce_block.addBitCast(capture_ty, uncoerced);
                     _ = try coerce_block.addBr(capture_block_inst, coerced);
@@ -12510,7 +12510,7 @@ fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index, operand_is_r
             for (seen_enum_fields, 0..) |seen_field, index| {
                 if (seen_field != null) continue;
                 const union_obj = mod.typeToUnion(maybe_union_ty).?;
-                const field_ty = union_obj.field_types.get(ip)[index].toType();
+                const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[index]);
                 if (field_ty.zigTypeTag(mod) != .NoReturn) break true;
             } else false
         else
@@ -12609,7 +12609,7 @@ const RangeSetUnhandledIterator = struct {
             inline .u64, .i64 => |val_int| {
                 const next_int = @addWithOverflow(val_int, 1);
                 if (next_int[1] == 0)
-                    return (try it.mod.intValue(int.ty.toType(), next_int[0])).toIntern();
+                    return (try it.mod.intValue(Type.fromInterned(int.ty), next_int[0])).toIntern();
             },
             .big_int => {},
             .lazy_align, .lazy_size => unreachable,
@@ -12625,7 +12625,7 @@ const RangeSetUnhandledIterator = struct {
         );
 
         result_bigint.addScalar(val_bigint, 1);
-        return (try it.mod.intValue_big(int.ty.toType(), result_bigint.toConst())).toIntern();
+        return (try it.mod.intValue_big(Type.fromInterned(int.ty), result_bigint.toConst())).toIntern();
     }
 
     fn next(it: *RangeSetUnhandledIterator) !?InternPool.Index {
@@ -12704,7 +12704,7 @@ fn validateSwitchRange(
     const mod = sema.mod;
     const first = try sema.resolveSwitchItemVal(block, first_ref, operand_ty, src_node_offset, switch_prong_src, .first);
     const last = try sema.resolveSwitchItemVal(block, last_ref, operand_ty, src_node_offset, switch_prong_src, .last);
-    if (try first.val.toValue().compareAll(.gt, last.val.toValue(), operand_ty, mod)) {
+    if (try Value.fromInterned(first.val).compareAll(.gt, Value.fromInterned(last.val), operand_ty, mod)) {
         const src = switch_prong_src.resolve(mod, mod.declPtr(block.src_decl), src_node_offset, .first);
         return sema.fail(block, src, "range start value is greater than the end value", .{});
     }
@@ -12815,7 +12815,7 @@ fn validateSwitchItemBool(
 ) CompileError!Air.Inst.Ref {
     const mod = sema.mod;
     const item = try sema.resolveSwitchItemVal(block, item_ref, Type.bool, src_node_offset, switch_prong_src, .none);
-    if (item.val.toValue().toBool()) {
+    if (Value.fromInterned(item.val).toBool()) {
         true_count.* += 1;
     } else {
         false_count.* += 1;
@@ -13645,7 +13645,7 @@ fn analyzeTupleCat(
             try sema.tupleFieldValByIndex(block, operand_src, rhs, i, rhs_ty);
     }
 
-    return block.addAggregateInit(tuple_ty.toType(), element_refs);
+    return block.addAggregateInit(Type.fromInterned(tuple_ty), element_refs);
 }
 
 fn zirArrayCat(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
@@ -13875,17 +13875,17 @@ fn getArrayCatInfo(sema: *Sema, block: *Block, src: LazySrcLoc, operand: Air.Ins
                         .needed_comptime_reason = "slice value being concatenated must be comptime-known",
                     });
                     return Type.ArrayInfo{
-                        .elem_type = ptr_info.child.toType(),
+                        .elem_type = Type.fromInterned(ptr_info.child),
                         .sentinel = switch (ptr_info.sentinel) {
                             .none => null,
-                            else => ptr_info.sentinel.toValue(),
+                            else => Value.fromInterned(ptr_info.sentinel),
                         },
                         .len = val.sliceLen(mod),
                     };
                 },
                 .One => {
-                    if (ptr_info.child.toType().zigTypeTag(mod) == .Array) {
-                        return ptr_info.child.toType().arrayInfo(mod);
+                    if (Type.fromInterned(ptr_info.child).zigTypeTag(mod) == .Array) {
+                        return Type.fromInterned(ptr_info.child).arrayInfo(mod);
                     }
                 },
                 .C => {},
@@ -13974,7 +13974,7 @@ fn analyzeTupleMul(
         @memcpy(element_refs[tuple_len * i ..][0..tuple_len], element_refs[0..tuple_len]);
     }
 
-    return block.addAggregateInit(tuple_ty.toType(), element_refs);
+    return block.addAggregateInit(Type.fromInterned(tuple_ty), element_refs);
 }
 
 fn zirArrayMul(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
@@ -14972,10 +14972,10 @@ fn zirModRem(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
                         .ComptimeInt, .Int => try mod.intValue(resolved_type.scalarType(mod), 0),
                         else => unreachable,
                     };
-                    const zero_val = if (is_vector) (try mod.intern(.{ .aggregate = .{
+                    const zero_val = if (is_vector) Value.fromInterned((try mod.intern(.{ .aggregate = .{
                         .ty = resolved_type.toIntern(),
                         .storage = .{ .repeated_elem = scalar_zero.toIntern() },
-                    } })).toValue() else scalar_zero;
+                    } }))) else scalar_zero;
                     return Air.internedToRef(zero_val.toIntern());
                 }
             } else if (lhs_scalar_ty.isSignedInt(mod)) {
@@ -15058,10 +15058,10 @@ fn intRem(
             const rhs_elem = try rhs.elemValue(mod, i);
             scalar.* = try (try sema.intRemScalar(lhs_elem, rhs_elem, scalar_ty)).intern(scalar_ty, mod);
         }
-        return (try mod.intern(.{ .aggregate = .{
+        return Value.fromInterned((try mod.intern(.{ .aggregate = .{
             .ty = ty.toIntern(),
             .storage = .{ .elems = result_data },
-        } })).toValue();
+        } })));
     }
     return sema.intRemScalar(lhs, rhs, ty);
 }
@@ -15335,7 +15335,7 @@ fn zirOverflowArithmetic(
     const maybe_rhs_val = try sema.resolveValue(rhs);
 
     const tuple_ty = try sema.overflowArithmeticTupleType(dest_ty);
-    const overflow_ty = ip.indexToKey(tuple_ty.toIntern()).anon_struct_type.types.get(ip)[1].toType();
+    const overflow_ty = Type.fromInterned(ip.indexToKey(tuple_ty.toIntern()).anon_struct_type.types.get(ip)[1]);
 
     var result: struct {
         inst: Air.Inst.Ref = .none,
@@ -15504,7 +15504,7 @@ fn splat(sema: *Sema, ty: Type, val: Value) !Value {
         .ty = ty.toIntern(),
         .storage = .{ .repeated_elem = val.toIntern() },
     } });
-    return repeated.toValue();
+    return Value.fromInterned(repeated);
 }
 
 fn overflowArithmeticTupleType(sema: *Sema, ty: Type) !Type {
@@ -15522,7 +15522,7 @@ fn overflowArithmeticTupleType(sema: *Sema, ty: Type) !Type {
         .values = &values,
         .names = &.{},
     });
-    return tuple_ty.toType();
+    return Type.fromInterned(tuple_ty);
 }
 
 fn analyzeArithmetic(
@@ -16036,7 +16036,7 @@ fn analyzePtrArithmetic(
         }
         // If the addend is not a comptime-known value we can still count on
         // it being a multiple of the type size.
-        const elem_size = ptr_info.child.toType().abiSize(mod);
+        const elem_size = Type.fromInterned(ptr_info.child).abiSize(mod);
         const addend = if (opt_off_val) |off_val| a: {
             const off_int = try sema.usizeCast(block, offset_src, off_val.toUnsignedInt(mod));
             break :a elem_size * off_int;
@@ -16073,7 +16073,7 @@ fn analyzePtrArithmetic(
                 const offset_int = try sema.usizeCast(block, offset_src, offset_val.toUnsignedInt(mod));
                 if (offset_int == 0) return ptr;
                 if (try ptr_val.getUnsignedIntAdvanced(mod, sema)) |addr| {
-                    const elem_size = ptr_info.child.toType().abiSize(mod);
+                    const elem_size = Type.fromInterned(ptr_info.child).abiSize(mod);
                     const new_addr = switch (air_tag) {
                         .ptr_add => addr + elem_size * offset_int,
                         .ptr_sub => addr - elem_size * offset_int,
@@ -16748,7 +16748,7 @@ fn zirClosureGet(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
 
     assert(block.is_typeof);
     // We need a dummy runtime instruction with the correct type.
-    return block.addTy(.alloc, capture_ty.toType());
+    return block.addTy(.alloc, Type.fromInterned(capture_ty));
 }
 
 fn zirRetAddr(
@@ -17042,7 +17042,7 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
             const alignment = if (info.flags.alignment.toByteUnitsOptional()) |alignment|
                 try mod.intValue(Type.comptime_int, alignment)
             else
-                try info.child.toType().lazyAbiAlignment(mod);
+                try Type.fromInterned(info.child).lazyAbiAlignment(mod);
 
             const addrspace_ty = try sema.getBuiltinType("AddressSpace");
             const pointer_ty = t: {
@@ -17086,7 +17086,7 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
                 // sentinel: ?*const anyopaque,
                 (try sema.optRefValue(switch (info.sentinel) {
                     .none => null,
-                    else => info.sentinel.toValue(),
+                    else => Value.fromInterned(info.sentinel),
                 })).toIntern(),
             };
             return Air.internedToRef((try mod.intern(.{ .un = .{
@@ -17630,10 +17630,10 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
                                 } });
                             };
 
-                            try sema.resolveTypeLayout(field_ty.toType());
+                            try sema.resolveTypeLayout(Type.fromInterned(field_ty));
 
                             const is_comptime = field_val != .none;
-                            const opt_default_val = if (is_comptime) field_val.toValue() else null;
+                            const opt_default_val = if (is_comptime) Value.fromInterned(field_val) else null;
                             const default_val_ptr = try sema.optRefValue(opt_default_val);
                             const struct_field_fields = .{
                                 // name: []const u8,
@@ -17645,7 +17645,7 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
                                 // is_comptime: bool,
                                 Value.makeBool(is_comptime).toIntern(),
                                 // alignment: comptime_int,
-                                (try mod.intValue(Type.comptime_int, field_ty.toType().abiAlignment(mod).toByteUnits(0))).toIntern(),
+                                (try mod.intValue(Type.comptime_int, Type.fromInterned(field_ty).abiAlignment(mod).toByteUnits(0))).toIntern(),
                             };
                             struct_field_val.* = try mod.intern(.{ .aggregate = .{
                                 .ty = struct_field_ty.toIntern(),
@@ -17667,7 +17667,7 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
                         try sema.arena.dupe(u8, ip.stringToSlice(name_nts))
                     else
                         try std.fmt.allocPrintZ(sema.arena, "{d}", .{i});
-                    const field_ty = struct_type.field_types.get(ip)[i].toType();
+                    const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
                     const field_init = struct_type.fieldInit(ip, i);
                     const field_is_comptime = struct_type.fieldIsComptime(ip, i);
                     const name_val = v: {
@@ -17689,7 +17689,7 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
                         } });
                     };
 
-                    const opt_default_val = if (field_init == .none) null else field_init.toValue();
+                    const opt_default_val = if (field_init == .none) null else Value.fromInterned(field_init);
                     const default_val_ptr = try sema.optRefValue(opt_default_val);
                     const alignment = switch (struct_type.layout) {
                         .Packed => .none,
@@ -17750,7 +17750,7 @@ fn zirTypeInfo(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
             const backing_integer_val = try mod.intern(.{ .opt = .{
                 .ty = (try mod.optionalType(.type_type)).toIntern(),
                 .val = if (mod.typeToPackedStruct(ty)) |packed_struct| val: {
-                    assert(packed_struct.backingIntType(ip).toType().isInt(mod));
+                    assert(Type.fromInterned(packed_struct.backingIntType(ip).*).isInt(mod));
                     break :val packed_struct.backingIntType(ip).*;
                 } else .none,
             } });
@@ -19145,7 +19145,7 @@ fn unionInit(
     const mod = sema.mod;
     const ip = &mod.intern_pool;
     const field_index = try sema.unionFieldIndex(block, union_ty, field_name, field_src);
-    const field_ty = mod.typeToUnion(union_ty).?.field_types.get(ip)[field_index].toType();
+    const field_ty = Type.fromInterned(mod.typeToUnion(union_ty).?.field_types.get(ip)[field_index]);
     const init = try sema.coerce(block, field_ty, uncasted_init, init_src);
 
     if (try sema.resolveValue(init)) |init_val| {
@@ -19256,7 +19256,7 @@ fn zirStructInit(
         const field_index = try sema.unionFieldIndex(block, resolved_ty, field_name, field_src);
         const tag_ty = resolved_ty.unionTagTypeHypothetical(mod);
         const tag_val = try mod.enumValueFieldIndex(tag_ty, field_index);
-        const field_ty = mod.typeToUnion(resolved_ty).?.field_types.get(ip)[field_index].toType();
+        const field_ty = Type.fromInterned(mod.typeToUnion(resolved_ty).?.field_types.get(ip)[field_index]);
 
         if (field_ty.zigTypeTag(mod) == .NoReturn) {
             return sema.failWithOwnedErrorMsg(block, msg: {
@@ -19275,11 +19275,11 @@ fn zirStructInit(
         const init_inst = try sema.coerce(block, field_ty, uncoerced_init_inst, field_src);
 
         if (try sema.resolveValue(init_inst)) |val| {
-            const struct_val = (try mod.intern(.{ .un = .{
+            const struct_val = Value.fromInterned((try mod.intern(.{ .un = .{
                 .ty = resolved_ty.toIntern(),
                 .tag = try tag_val.intern(tag_ty, mod),
                 .val = try val.intern(field_ty, mod),
-            } })).toValue();
+            } })));
             const final_val_inst = try sema.coerce(block, result_ty, Air.internedToRef(struct_val.toIntern()), src);
             const final_val = (try sema.resolveValue(final_val_inst)).?;
             return sema.addConstantMaybeRef(final_val.toIntern(), is_ref);
@@ -19336,7 +19336,7 @@ fn finishStructInit(
             for (0..anon_struct.types.len) |i| {
                 if (field_inits[i] != .none) {
                     // Coerce the init value to the field type.
-                    const field_ty = anon_struct.types.get(ip)[i].toType();
+                    const field_ty = Type.fromInterned(anon_struct.types.get(ip)[i]);
                     field_inits[i] = sema.coerce(block, field_ty, field_inits[i], .unneeded) catch |err| switch (err) {
                         error.NeededSourceLocation => {
                             const decl = mod.declPtr(block.src_decl);
@@ -19378,7 +19378,7 @@ fn finishStructInit(
             for (0..struct_type.field_types.len) |i| {
                 if (field_inits[i] != .none) {
                     // Coerce the init value to the field type.
-                    const field_ty = struct_type.field_types.get(ip)[i].toType();
+                    const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
                     field_inits[i] = sema.coerce(block, field_ty, field_inits[i], init_src) catch |err| switch (err) {
                         error.NeededSourceLocation => {
                             const decl = mod.declPtr(block.src_decl);
@@ -19548,20 +19548,20 @@ fn structInitAnon(
 
             const init = try sema.resolveInst(item.data.init);
             field_ty.* = sema.typeOf(init).toIntern();
-            if (field_ty.toType().zigTypeTag(mod) == .Opaque) {
+            if (Type.fromInterned(field_ty.*).zigTypeTag(mod) == .Opaque) {
                 const msg = msg: {
                     const decl = mod.declPtr(block.src_decl);
                     const field_src = mod.initSrc(src.node_offset.x, decl, @intCast(i_usize));
                     const msg = try sema.errMsg(block, field_src, "opaque types have unknown size and therefore cannot be directly embedded in structs", .{});
                     errdefer msg.destroy(sema.gpa);
 
-                    try sema.addDeclaredHereNote(msg, field_ty.toType());
+                    try sema.addDeclaredHereNote(msg, Type.fromInterned(field_ty.*));
                     break :msg msg;
                 };
                 return sema.failWithOwnedErrorMsg(block, msg);
             }
             if (try sema.resolveValue(init)) |init_val| {
-                field_val.* = try init_val.intern(field_ty.toType(), mod);
+                field_val.* = try init_val.intern(Type.fromInterned(field_ty.*), mod);
             } else {
                 field_val.* = .none;
                 runtime_index = @intCast(i_usize);
@@ -19635,7 +19635,7 @@ fn structInitAnon(
         element_refs[i] = try sema.resolveInst(item.data.init);
     }
 
-    return block.addAggregateInit(tuple_ty.toType(), element_refs);
+    return block.addAggregateInit(Type.fromInterned(tuple_ty), element_refs);
 }
 
 fn zirArrayInit(
@@ -19836,12 +19836,12 @@ fn arrayInitAnon(
             const operand_src = src; // TODO better source location
             const elem = try sema.resolveInst(operand);
             types[i] = sema.typeOf(elem).toIntern();
-            if (types[i].toType().zigTypeTag(mod) == .Opaque) {
+            if (Type.fromInterned(types[i]).zigTypeTag(mod) == .Opaque) {
                 const msg = msg: {
                     const msg = try sema.errMsg(block, operand_src, "opaque types have unknown size and therefore cannot be directly embedded in structs", .{});
                     errdefer msg.destroy(gpa);
 
-                    try sema.addDeclaredHereNote(msg, types[i].toType());
+                    try sema.addDeclaredHereNote(msg, Type.fromInterned(types[i]));
                     break :msg msg;
                 };
                 return sema.failWithOwnedErrorMsg(block, msg);
@@ -19899,7 +19899,7 @@ fn arrayInitAnon(
         element_refs[i] = try sema.resolveInst(operand);
     }
 
-    return block.addAggregateInit(tuple_ty.toType(), element_refs);
+    return block.addAggregateInit(Type.fromInterned(tuple_ty), element_refs);
 }
 
 fn addConstantMaybeRef(sema: *Sema, val: InternPool.Index, is_ref: bool) !Air.Inst.Ref {
@@ -19979,7 +19979,7 @@ fn fieldType(
             .Optional => {
                 // Struct/array init through optional requires the child type to not be a pointer.
                 // If the child of .optional is a pointer it'll error on the next loop.
-                cur_ty = ip.indexToKey(cur_ty.toIntern()).opt_type.toType();
+                cur_ty = Type.fromInterned(ip.indexToKey(cur_ty.toIntern()).opt_type);
                 continue;
             },
             .ErrorUnion => {
@@ -20294,8 +20294,8 @@ fn zirReify(
     });
     const union_val = ip.indexToKey(val.toIntern()).un;
     const target = mod.getTarget();
-    if (try union_val.val.toValue().anyUndef(mod)) return sema.failWithUseOfUndef(block, src);
-    const tag_index = type_info_ty.unionTagFieldIndex(union_val.tag.toValue(), mod).?;
+    if (try Value.fromInterned(union_val.val).anyUndef(mod)) return sema.failWithUseOfUndef(block, src);
+    const tag_index = type_info_ty.unionTagFieldIndex(Value.fromInterned(union_val.tag), mod).?;
     switch (@as(std.builtin.TypeId, @enumFromInt(tag_index))) {
         .Type => return .type_type,
         .Void => return .void_type,
@@ -20309,11 +20309,11 @@ fn zirReify(
         .EnumLiteral => return .enum_literal_type,
         .Int => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const signedness_val = try union_val.val.toValue().fieldValue(
+            const signedness_val = try Value.fromInterned(union_val.val).fieldValue(
                 mod,
                 struct_type.nameIndex(ip, try ip.getOrPutString(gpa, "signedness")).?,
             );
-            const bits_val = try union_val.val.toValue().fieldValue(
+            const bits_val = try Value.fromInterned(union_val.val).fieldValue(
                 mod,
                 struct_type.nameIndex(ip, try ip.getOrPutString(gpa, "bits")).?,
             );
@@ -20325,11 +20325,11 @@ fn zirReify(
         },
         .Vector => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const len_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const len_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "len"),
             ).?);
-            const child_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const child_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "child"),
             ).?);
@@ -20347,7 +20347,7 @@ fn zirReify(
         },
         .Float => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const bits_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const bits_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "bits"),
             ).?);
@@ -20365,35 +20365,35 @@ fn zirReify(
         },
         .Pointer => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const size_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const size_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "size"),
             ).?);
-            const is_const_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const is_const_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "is_const"),
             ).?);
-            const is_volatile_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const is_volatile_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "is_volatile"),
             ).?);
-            const alignment_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const alignment_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "alignment"),
             ).?);
-            const address_space_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const address_space_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "address_space"),
             ).?);
-            const child_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const child_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "child"),
             ).?);
-            const is_allowzero_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const is_allowzero_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "is_allowzero"),
             ).?);
-            const sentinel_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const sentinel_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "sentinel"),
             ).?);
@@ -20477,15 +20477,15 @@ fn zirReify(
         },
         .Array => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const len_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const len_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "len"),
             ).?);
-            const child_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const child_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "child"),
             ).?);
-            const sentinel_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const sentinel_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "sentinel"),
             ).?);
@@ -20506,7 +20506,7 @@ fn zirReify(
         },
         .Optional => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const child_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const child_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "child"),
             ).?);
@@ -20518,11 +20518,11 @@ fn zirReify(
         },
         .ErrorUnion => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const error_set_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const error_set_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "error_set"),
             ).?);
-            const payload_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const payload_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "payload"),
             ).?);
@@ -20538,7 +20538,7 @@ fn zirReify(
             return Air.internedToRef(ty.toIntern());
         },
         .ErrorSet => {
-            const payload_val = union_val.val.toValue().optionalValue(mod) orelse
+            const payload_val = Value.fromInterned(union_val.val).optionalValue(mod) orelse
                 return Air.internedToRef(Type.anyerror.toIntern());
 
             const len = try sema.usizeCast(block, src, payload_val.sliceLen(mod));
@@ -20567,23 +20567,23 @@ fn zirReify(
         },
         .Struct => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const layout_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const layout_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "layout"),
             ).?);
-            const backing_integer_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const backing_integer_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "backing_integer"),
             ).?);
-            const fields_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const fields_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "fields"),
             ).?);
-            const decls_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const decls_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "decls"),
             ).?);
-            const is_tuple_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const is_tuple_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "is_tuple"),
             ).?);
@@ -20603,19 +20603,19 @@ fn zirReify(
         },
         .Enum => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const tag_type_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const tag_type_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "tag_type"),
             ).?);
-            const fields_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const fields_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "fields"),
             ).?);
-            const decls_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const decls_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "decls"),
             ).?);
-            const is_exhaustive_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const is_exhaustive_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "is_exhaustive"),
             ).?);
@@ -20662,7 +20662,7 @@ fn zirReify(
             //errdefer ip.remove(incomplete_enum.index);
 
             new_decl.ty = Type.type;
-            new_decl.val = incomplete_enum.index.toValue();
+            new_decl.val = Value.fromInterned(incomplete_enum.index);
 
             for (0..fields_len) |field_i| {
                 const elem_val = try fields_val.elemValue(mod, field_i);
@@ -20718,7 +20718,7 @@ fn zirReify(
         },
         .Opaque => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const decls_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const decls_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "decls"),
             ).?);
@@ -20759,8 +20759,8 @@ fn zirReify(
             //errdefer ip.remove(opaque_ty);
 
             new_decl.ty = Type.type;
-            new_decl.val = opaque_ty.toValue();
-            new_namespace.ty = opaque_ty.toType();
+            new_decl.val = Value.fromInterned(opaque_ty);
+            new_namespace.ty = Type.fromInterned(opaque_ty);
 
             const decl_val = sema.analyzeDeclVal(block, src, new_decl_index);
             try mod.finalizeAnonDecl(new_decl_index);
@@ -20768,19 +20768,19 @@ fn zirReify(
         },
         .Union => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const layout_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const layout_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "layout"),
             ).?);
-            const tag_type_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const tag_type_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "tag_type"),
             ).?);
-            const fields_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const fields_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "fields"),
             ).?);
-            const decls_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const decls_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "decls"),
             ).?);
@@ -20847,10 +20847,10 @@ fn zirReify(
                         const msg = msg: {
                             const msg = try sema.errMsg(block, src, "no field named '{}' in enum '{}'", .{
                                 field_name.fmt(ip),
-                                enum_tag_ty.toType().fmt(mod),
+                                Type.fromInterned(enum_tag_ty).fmt(mod),
                             });
                             errdefer msg.destroy(gpa);
-                            try sema.addDeclaredHereNote(msg, enum_tag_ty.toType());
+                            try sema.addDeclaredHereNote(msg, Type.fromInterned(enum_tag_ty));
                             break :msg msg;
                         };
                         return sema.failWithOwnedErrorMsg(block, msg);
@@ -20929,11 +20929,11 @@ fn zirReify(
 
                         for (tag_info.names.get(ip), 0..) |field_name, field_index| {
                             if (explicit_tags_seen[field_index]) continue;
-                            try sema.addFieldErrNote(enum_tag_ty.toType(), field_index, msg, "field '{}' missing, declared here", .{
+                            try sema.addFieldErrNote(Type.fromInterned(enum_tag_ty), field_index, msg, "field '{}' missing, declared here", .{
                                 field_name.fmt(ip),
                             });
                         }
-                        try sema.addDeclaredHereNote(msg, enum_tag_ty.toType());
+                        try sema.addDeclaredHereNote(msg, Type.fromInterned(enum_tag_ty));
                         break :msg msg;
                     };
                     return sema.failWithOwnedErrorMsg(block, msg);
@@ -20993,8 +20993,8 @@ fn zirReify(
             });
 
             new_decl.ty = Type.type;
-            new_decl.val = union_ty.toValue();
-            new_namespace.ty = union_ty.toType();
+            new_decl.val = Value.fromInterned(union_ty);
+            new_namespace.ty = Type.fromInterned(union_ty);
 
             const decl_val = sema.analyzeDeclVal(block, src, new_decl_index);
             try mod.finalizeAnonDecl(new_decl_index);
@@ -21002,27 +21002,27 @@ fn zirReify(
         },
         .Fn => {
             const struct_type = ip.indexToKey(ip.typeOf(union_val.val)).struct_type;
-            const calling_convention_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const calling_convention_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "calling_convention"),
             ).?);
-            const alignment_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const alignment_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "alignment"),
             ).?);
-            const is_generic_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const is_generic_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "is_generic"),
             ).?);
-            const is_var_args_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const is_var_args_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "is_var_args"),
             ).?);
-            const return_type_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const return_type_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "return_type"),
             ).?);
-            const params_val = try union_val.val.toValue().fieldValue(mod, struct_type.nameIndex(
+            const params_val = try Value.fromInterned(union_val.val).fieldValue(mod, struct_type.nameIndex(
                 ip,
                 try ip.getOrPutString(gpa, "params"),
             ).?);
@@ -21075,7 +21075,7 @@ fn zirReify(
                 param_type.* = param_type_val.toIntern();
 
                 if (param_is_noalias_val.toBool()) {
-                    if (!param_type.toType().isPtrAtRuntime(mod)) {
+                    if (!Type.fromInterned(param_type.*).isPtrAtRuntime(mod)) {
                         return sema.fail(block, src, "non-pointer parameter declared noalias", .{});
                     }
                     noalias_bits |= @as(u32, 1) << (std.math.cast(u5, i) orelse
@@ -21158,7 +21158,7 @@ fn reifyStruct(
     const struct_type = ip.indexToKey(ty).struct_type;
 
     new_decl.ty = Type.type;
-    new_decl.val = ty.toValue();
+    new_decl.val = Value.fromInterned(ty);
 
     // Fields
     for (0..fields_len) |i| {
@@ -21290,11 +21290,11 @@ fn reifyStruct(
 
     if (layout == .Packed) {
         for (0..struct_type.field_types.len) |index| {
-            const field_ty = struct_type.field_types.get(ip)[index].toType();
+            const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[index]);
             sema.resolveTypeLayout(field_ty) catch |err| switch (err) {
                 error.AnalysisFail => {
                     const msg = sema.err orelse return err;
-                    try sema.addFieldErrNote(ty.toType(), index, msg, "while checking this field", .{});
+                    try sema.addFieldErrNote(Type.fromInterned(ty), index, msg, "while checking this field", .{});
                     return err;
                 },
                 else => return err,
@@ -21303,7 +21303,7 @@ fn reifyStruct(
 
         var fields_bit_sum: u64 = 0;
         for (0..struct_type.field_types.len) |i| {
-            const field_ty = struct_type.field_types.get(ip)[i].toType();
+            const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
             fields_bit_sum += field_ty.bitSize(mod);
         }
 
@@ -21657,10 +21657,10 @@ fn ptrFromIntVal(
         return sema.fail(block, operand_src, "pointer type '{}' requires aligned address", .{ptr_ty.fmt(sema.mod)});
 
     return switch (ptr_ty.zigTypeTag(mod)) {
-        .Optional => (try mod.intern(.{ .opt = .{
+        .Optional => Value.fromInterned((try mod.intern(.{ .opt = .{
             .ty = ptr_ty.toIntern(),
             .val = if (addr == 0) .none else (try mod.ptrIntValue(ptr_ty.childType(mod), addr)).toIntern(),
-        } })).toValue(),
+        } }))),
         .Pointer => try mod.ptrIntValue(ptr_ty, addr),
         else => unreachable,
     };
@@ -21849,14 +21849,14 @@ fn ptrCastFull(
     const src_info = operand_ty.ptrInfo(mod);
     const dest_info = dest_ty.ptrInfo(mod);
 
-    try sema.resolveTypeLayout(src_info.child.toType());
-    try sema.resolveTypeLayout(dest_info.child.toType());
+    try sema.resolveTypeLayout(Type.fromInterned(src_info.child));
+    try sema.resolveTypeLayout(Type.fromInterned(dest_info.child));
 
     const src_slice_like = src_info.flags.size == .Slice or
-        (src_info.flags.size == .One and src_info.child.toType().zigTypeTag(mod) == .Array);
+        (src_info.flags.size == .One and Type.fromInterned(src_info.child).zigTypeTag(mod) == .Array);
 
     const dest_slice_like = dest_info.flags.size == .Slice or
-        (dest_info.flags.size == .One and dest_info.child.toType().zigTypeTag(mod) == .Array);
+        (dest_info.flags.size == .One and Type.fromInterned(dest_info.child).zigTypeTag(mod) == .Array);
 
     if (dest_info.flags.size == .Slice and !src_slice_like) {
         return sema.fail(block, src, "illegal pointer cast to slice", .{});
@@ -21864,12 +21864,12 @@ fn ptrCastFull(
 
     if (dest_info.flags.size == .Slice) {
         const src_elem_size = switch (src_info.flags.size) {
-            .Slice => src_info.child.toType().abiSize(mod),
+            .Slice => Type.fromInterned(src_info.child).abiSize(mod),
             // pointer to array
-            .One => src_info.child.toType().childType(mod).abiSize(mod),
+            .One => Type.fromInterned(src_info.child).childType(mod).abiSize(mod),
             else => unreachable,
         };
-        const dest_elem_size = dest_info.child.toType().abiSize(mod);
+        const dest_elem_size = Type.fromInterned(dest_info.child).abiSize(mod);
         if (src_elem_size != dest_elem_size) {
             return sema.fail(block, src, "TODO: implement @ptrCast between slices changing the length", .{});
         }
@@ -21891,7 +21891,7 @@ fn ptrCastFull(
                 errdefer msg.destroy(sema.gpa);
                 if (dest_info.flags.size == .Many and
                     (src_info.flags.size == .Slice or
-                    (src_info.flags.size == .One and src_info.child.toType().zigTypeTag(mod) == .Array)))
+                    (src_info.flags.size == .One and Type.fromInterned(src_info.child).zigTypeTag(mod) == .Array)))
                 {
                     try sema.errNote(block, src, msg, "use 'ptr' field to convert slice to many pointer", .{});
                 } else {
@@ -21904,10 +21904,10 @@ fn ptrCastFull(
         check_child: {
             const src_child = if (dest_info.flags.size == .Slice and src_info.flags.size == .One) blk: {
                 // *[n]T -> []T
-                break :blk src_info.child.toType().childType(mod);
-            } else src_info.child.toType();
+                break :blk Type.fromInterned(src_info.child).childType(mod);
+            } else Type.fromInterned(src_info.child);
 
-            const dest_child = dest_info.child.toType();
+            const dest_child = Type.fromInterned(dest_info.child);
 
             const imc_res = try sema.coerceInMemoryAllowed(
                 block,
@@ -21940,7 +21940,7 @@ fn ptrCastFull(
             }
             if (src_slice_like and src_info.flags.size == .One and dest_info.flags.size == .Slice) {
                 // [*]nT -> []T
-                const arr_ty = src_info.child.toType();
+                const arr_ty = Type.fromInterned(src_info.child);
                 if (arr_ty.sentinel(mod)) |src_sentinel| {
                     const coerced_sent = try mod.intern_pool.getCoerced(sema.gpa, src_sentinel.toIntern(), dest_info.child);
                     if (dest_info.sentinel == coerced_sent) break :check_sent;
@@ -21949,12 +21949,12 @@ fn ptrCastFull(
             return sema.failWithOwnedErrorMsg(block, msg: {
                 const msg = if (src_info.sentinel == .none) blk: {
                     break :blk try sema.errMsg(block, src, "destination pointer requires '{}' sentinel", .{
-                        dest_info.sentinel.toValue().fmtValue(dest_info.child.toType(), mod),
+                        Value.fromInterned(dest_info.sentinel).fmtValue(Type.fromInterned(dest_info.child), mod),
                     });
                 } else blk: {
                     break :blk try sema.errMsg(block, src, "pointer sentinel '{}' cannot coerce into pointer sentinel '{}'", .{
-                        src_info.sentinel.toValue().fmtValue(src_info.child.toType(), mod),
-                        dest_info.sentinel.toValue().fmtValue(dest_info.child.toType(), mod),
+                        Value.fromInterned(src_info.sentinel).fmtValue(Type.fromInterned(src_info.child), mod),
+                        Value.fromInterned(dest_info.sentinel).fmtValue(Type.fromInterned(dest_info.child), mod),
                     });
                 };
                 errdefer msg.destroy(sema.gpa);
@@ -22010,12 +22010,12 @@ fn ptrCastFull(
     const src_align = if (src_info.flags.alignment != .none)
         src_info.flags.alignment
     else
-        src_info.child.toType().abiAlignment(mod);
+        Type.fromInterned(src_info.child).abiAlignment(mod);
 
     const dest_align = if (dest_info.flags.alignment != .none)
         dest_info.flags.alignment
     else
-        dest_info.child.toType().abiAlignment(mod);
+        Type.fromInterned(dest_info.child).abiAlignment(mod);
 
     if (!flags.align_cast) {
         if (dest_align.compare(.gt, src_align)) {
@@ -22123,7 +22123,7 @@ fn ptrCastFull(
             }
             if (dest_info.flags.size == .Slice and src_info.flags.size != .Slice) {
                 if (ptr_val.isUndef(mod)) return mod.undefRef(dest_ty);
-                const arr_len = try mod.intValue(Type.usize, src_info.child.toType().arrayLen(mod));
+                const arr_len = try mod.intValue(Type.usize, Type.fromInterned(src_info.child).arrayLen(mod));
                 return Air.internedToRef((try mod.intern(.{ .ptr = .{
                     .ty = dest_ty.toIntern(),
                     .addr = mod.intern_pool.indexToKey(ptr_val.toIntern()).ptr.addr,
@@ -22139,7 +22139,7 @@ fn ptrCastFull(
     try sema.requireRuntimeBlock(block, src, null);
 
     if (block.wantSafety() and operand_ty.ptrAllowsZero(mod) and !dest_ty.ptrAllowsZero(mod) and
-        (try sema.typeHasRuntimeBits(dest_info.child.toType()) or dest_info.child.toType().zigTypeTag(mod) == .Fn))
+        (try sema.typeHasRuntimeBits(Type.fromInterned(dest_info.child)) or Type.fromInterned(dest_info.child).zigTypeTag(mod) == .Fn))
     {
         const ptr_int = try block.addUnOp(.int_from_ptr, ptr);
         const is_non_zero = try block.addBinOp(.cmp_neq, ptr_int, .zero_usize);
@@ -22153,7 +22153,7 @@ fn ptrCastFull(
 
     if (block.wantSafety() and
         dest_align.compare(.gt, src_align) and
-        try sema.typeHasRuntimeBits(dest_info.child.toType()))
+        try sema.typeHasRuntimeBits(Type.fromInterned(dest_info.child)))
     {
         const align_bytes_minus_1 = dest_align.toByteUnitsOptional().? - 1;
         const align_minus_1 = Air.internedToRef((try mod.intValue(Type.usize, align_bytes_minus_1)).toIntern());
@@ -22196,7 +22196,7 @@ fn ptrCastFull(
     if (dest_info.flags.size == .Slice and src_info.flags.size != .Slice) {
         // We have to construct a slice using the operand's child's array length
         // Note that we know from the check at the start of the function that operand_ty is slice-like
-        const arr_len = Air.internedToRef((try mod.intValue(Type.usize, src_info.child.toType().arrayLen(mod))).toIntern());
+        const arr_len = Air.internedToRef((try mod.intValue(Type.usize, Type.fromInterned(src_info.child).arrayLen(mod))).toIntern());
         return block.addInst(.{
             .tag = .slice,
             .data = .{ .ty_pl = .{
@@ -22549,7 +22549,7 @@ fn bitOffsetOf(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!u6
                 if (i == field_index) {
                     return bit_sum;
                 }
-                const field_ty = struct_type.field_types.get(ip)[i].toType();
+                const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
                 bit_sum += field_ty.bitSize(mod);
             } else unreachable;
         },
@@ -23447,10 +23447,10 @@ fn analyzeShuffle(
 
         if (a_len < b_len) {
             const undef = try mod.undefRef(a_ty);
-            a = try sema.analyzeShuffle(block, src_node, elem_ty, a, undef, expand_mask.toValue(), @intCast(max_len));
+            a = try sema.analyzeShuffle(block, src_node, elem_ty, a, undef, Value.fromInterned(expand_mask), @intCast(max_len));
         } else {
             const undef = try mod.undefRef(b_ty);
-            b = try sema.analyzeShuffle(block, src_node, elem_ty, b, undef, expand_mask.toValue(), @intCast(max_len));
+            b = try sema.analyzeShuffle(block, src_node, elem_ty, b, undef, Value.fromInterned(expand_mask), @intCast(max_len));
         }
     }
 
@@ -24546,10 +24546,10 @@ fn zirMemset(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void
     const dest_elem_ty: Type = dest_elem_ty: {
         const ptr_info = dest_ptr_ty.ptrInfo(mod);
         switch (ptr_info.flags.size) {
-            .Slice => break :dest_elem_ty ptr_info.child.toType(),
+            .Slice => break :dest_elem_ty Type.fromInterned(ptr_info.child),
             .One => {
-                if (ptr_info.child.toType().zigTypeTag(mod) == .Array) {
-                    break :dest_elem_ty ptr_info.child.toType().childType(mod);
+                if (Type.fromInterned(ptr_info.child).zigTypeTag(mod) == .Array) {
+                    break :dest_elem_ty Type.fromInterned(ptr_info.child).childType(mod);
                 }
             },
             .Many, .C => {},
@@ -24583,10 +24583,10 @@ fn zirMemset(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void
             .child = dest_elem_ty.toIntern(),
             .len = len_u64,
         });
-        const array_val = (try mod.intern(.{ .aggregate = .{
+        const array_val = Value.fromInterned((try mod.intern(.{ .aggregate = .{
             .ty = array_ty.toIntern(),
             .storage = .{ .repeated_elem = elem_val.toIntern() },
-        } })).toValue();
+        } })));
         const array_ptr_ty = ty: {
             var info = dest_ptr_ty.ptrInfo(mod);
             info.flags.size = .One;
@@ -25227,7 +25227,7 @@ fn zirBuiltinExtern(
         // We only access this decl through the decl_ref with the correct type created
         // below, so this type doesn't matter
         new_decl.ty = ty;
-        new_decl.val = new_var.toValue();
+        new_decl.val = Value.fromInterned(new_var);
         new_decl.alignment = .none;
         new_decl.@"linksection" = .none;
         new_decl.has_tv = true;
@@ -25237,14 +25237,14 @@ fn zirBuiltinExtern(
 
     try sema.ensureDeclAnalyzed(new_decl_index);
 
-    return Air.internedToRef((try mod.getCoerced((try mod.intern(.{ .ptr = .{
+    return Air.internedToRef((try mod.getCoerced(Value.fromInterned((try mod.intern(.{ .ptr = .{
         .ty = switch (mod.intern_pool.indexToKey(ty.toIntern())) {
             .ptr_type => ty.toIntern(),
             .opt_type => |child_type| child_type,
             else => unreachable,
         },
         .addr = .{ .decl = new_decl_index },
-    } })).toValue(), ty)).toIntern());
+    } }))), ty)).toIntern());
 }
 
 fn zirWorkItem(
@@ -25430,7 +25430,7 @@ fn explainWhyTypeIsComptimeInner(
                     .Inline => try mod.errNoteNonLazy(src_loc, msg, "function has inline calling convention", .{}),
                     else => {},
                 }
-                if (fn_info.return_type.toType().comptimeOnly(mod)) {
+                if (Type.fromInterned(fn_info.return_type).comptimeOnly(mod)) {
                     try mod.errNoteNonLazy(src_loc, msg, "function has a comptime-only return type", .{});
                 }
                 return;
@@ -25450,7 +25450,7 @@ fn explainWhyTypeIsComptimeInner(
 
             if (mod.typeToStruct(ty)) |struct_type| {
                 for (0..struct_type.field_types.len) |i| {
-                    const field_ty = struct_type.field_types.get(ip)[i].toType();
+                    const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
                     const field_src_loc = mod.fieldSrcLoc(struct_type.decl.unwrap().?, .{
                         .index = i,
                         .range = .type,
@@ -25470,7 +25470,7 @@ fn explainWhyTypeIsComptimeInner(
 
             if (mod.typeToUnion(ty)) |union_obj| {
                 for (0..union_obj.field_types.len) |i| {
-                    const field_ty = union_obj.field_types.get(ip)[i].toType();
+                    const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[i]);
                     const field_src_loc = mod.fieldSrcLoc(union_obj.decl, .{
                         .index = i,
                         .range = .type,
@@ -26096,7 +26096,7 @@ fn fieldVal(
             } else if (ip.stringEqlSlice(field_name, "ptr") and is_pointer_to) {
                 const ptr_info = object_ty.ptrInfo(mod);
                 const result_ty = try sema.ptrType(.{
-                    .child = ptr_info.child.toType().childType(mod).toIntern(),
+                    .child = Type.fromInterned(ptr_info.child).childType(mod).toIntern(),
                     .sentinel = if (inner_ty.sentinel(mod)) |s| s.toIntern() else .none,
                     .flags = .{
                         .size = .Many,
@@ -26515,7 +26515,7 @@ fn fieldCallBind(
                 if (mod.typeToStruct(concrete_ty)) |struct_type| {
                     const field_index = struct_type.nameIndex(ip, field_name) orelse
                         break :find_field;
-                    const field_ty = struct_type.field_types.get(ip)[field_index].toType();
+                    const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[field_index]);
 
                     return sema.finishFieldCallBind(block, src, ptr_ty, field_ty, field_index, object_ptr);
                 } else if (concrete_ty.isTuple(mod)) {
@@ -26540,7 +26540,7 @@ fn fieldCallBind(
                 try sema.resolveTypeFields(concrete_ty);
                 const union_obj = mod.typeToUnion(concrete_ty).?;
                 const field_index = union_obj.nameIndex(ip, field_name) orelse break :find_field;
-                const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+                const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
 
                 return sema.finishFieldCallBind(block, src, ptr_ty, field_ty, field_index, object_ptr);
             },
@@ -26563,7 +26563,7 @@ fn fieldCallBind(
                     if (mod.typeToFunc(decl_type)) |func_type| f: {
                         if (func_type.param_types.len == 0) break :f;
 
-                        const first_param_type = func_type.param_types.get(ip)[0].toType();
+                        const first_param_type = Type.fromInterned(func_type.param_types.get(ip)[0]);
                         // zig fmt: off
                         if (first_param_type.isGenericPoison() or (
                                 first_param_type.zigTypeTag(mod) == .Pointer and
@@ -26803,14 +26803,14 @@ fn structFieldPtrByIndex(
     const parent_align = if (struct_ptr_ty_info.flags.alignment != .none)
         struct_ptr_ty_info.flags.alignment
     else
-        try sema.typeAbiAlignment(struct_ptr_ty_info.child.toType());
+        try sema.typeAbiAlignment(Type.fromInterned(struct_ptr_ty_info.child));
 
     if (struct_type.layout == .Packed) {
         comptime assert(Type.packed_struct_layout_version == 2);
 
         var running_bits: u16 = 0;
         for (0..struct_type.field_types.len) |i| {
-            const f_ty = struct_type.field_types.get(ip)[i].toType();
+            const f_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
             if (!(try sema.typeHasRuntimeBits(f_ty))) continue;
 
             if (i == field_index) {
@@ -26840,8 +26840,8 @@ fn structFieldPtrByIndex(
         if (parent_align != .none and ptr_ty_data.packed_offset.bit_offset % 8 == 0 and
             target.cpu.arch.endian() == .little)
         {
-            const elem_size_bytes = try sema.typeAbiSize(ptr_ty_data.child.toType());
-            const elem_size_bits = ptr_ty_data.child.toType().bitSize(mod);
+            const elem_size_bytes = try sema.typeAbiSize(Type.fromInterned(ptr_ty_data.child));
+            const elem_size_bits = Type.fromInterned(ptr_ty_data.child).bitSize(mod);
             if (elem_size_bytes * 8 == elem_size_bits) {
                 const byte_offset = ptr_ty_data.packed_offset.bit_offset / 8;
                 const new_align: Alignment = @enumFromInt(@ctz(byte_offset | parent_align.toByteUnitsOptional().?));
@@ -26863,7 +26863,7 @@ fn structFieldPtrByIndex(
         // Our alignment is capped at the field alignment.
         const field_align = try sema.structFieldAlignment(
             struct_type.fieldAlign(ip, field_index),
-            field_ty.toType(),
+            Type.fromInterned(field_ty),
             struct_type.layout,
         );
         ptr_ty_data.flags.alignment = if (struct_ptr_ty_info.flags.alignment == .none)
@@ -26925,7 +26925,7 @@ fn structFieldVal(
                 return Air.internedToRef(struct_type.field_inits.get(ip)[field_index]);
             }
 
-            const field_ty = struct_type.field_types.get(ip)[field_index].toType();
+            const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[field_index]);
 
             if (try sema.resolveValue(struct_byval)) |struct_val| {
                 if (struct_val.isUndef(mod)) return mod.undefRef(field_ty);
@@ -27013,8 +27013,8 @@ fn tupleFieldValByIndex(
             .undef => mod.undefRef(field_ty),
             .aggregate => |aggregate| Air.internedToRef(switch (aggregate.storage) {
                 .bytes => |bytes| try mod.intValue(Type.u8, bytes[0]),
-                .elems => |elems| elems[field_index].toValue(),
-                .repeated_elem => |elem| elem.toValue(),
+                .elems => |elems| Value.fromInterned(elems[field_index]),
+                .repeated_elem => |elem| Value.fromInterned(elem),
             }.toIntern()),
             else => unreachable,
         };
@@ -27049,7 +27049,7 @@ fn unionFieldPtr(
     try sema.resolveTypeFields(union_ty);
     const union_obj = mod.typeToUnion(union_ty).?;
     const field_index = try sema.unionFieldIndex(block, union_ty, field_name, field_name_src);
-    const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+    const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
     const ptr_field_ty = try sema.ptrType(.{
         .child = field_ty.toIntern(),
         .flags = .{
@@ -27067,7 +27067,7 @@ fn unionFieldPtr(
         },
         .packed_offset = union_ptr_info.packed_offset,
     });
-    const enum_field_index: u32 = @intCast(union_obj.enum_tag_ty.toType().enumFieldIndex(field_name, mod).?);
+    const enum_field_index: u32 = @intCast(Type.fromInterned(union_obj.enum_tag_ty).enumFieldIndex(field_name, mod).?);
 
     if (initializing and field_ty.zigTypeTag(mod) == .NoReturn) {
         const msg = msg: {
@@ -27092,12 +27092,12 @@ fn unionFieldPtr(
                     return sema.failWithUseOfUndef(block, src);
                 }
                 const un = ip.indexToKey(union_val.toIntern()).un;
-                const field_tag = try mod.enumValueFieldIndex(union_obj.enum_tag_ty.toType(), enum_field_index);
+                const field_tag = try mod.enumValueFieldIndex(Type.fromInterned(union_obj.enum_tag_ty), enum_field_index);
                 const tag_matches = un.tag == field_tag.toIntern();
                 if (!tag_matches) {
                     const msg = msg: {
-                        const active_index = union_obj.enum_tag_ty.toType().enumTagFieldIndex(un.tag.toValue(), mod).?;
-                        const active_field_name = union_obj.enum_tag_ty.toType().enumFieldName(active_index, mod);
+                        const active_index = Type.fromInterned(union_obj.enum_tag_ty).enumTagFieldIndex(Value.fromInterned(un.tag), mod).?;
+                        const active_field_name = Type.fromInterned(union_obj.enum_tag_ty).enumFieldName(active_index, mod);
                         const msg = try sema.errMsg(block, src, "access of union field '{}' while field '{}' is active", .{
                             field_name.fmt(ip),
                             active_field_name.fmt(ip),
@@ -27124,11 +27124,11 @@ fn unionFieldPtr(
     if (!initializing and union_obj.getLayout(ip) == .Auto and block.wantSafety() and
         union_ty.unionTagTypeSafety(mod) != null and union_obj.field_names.len > 1)
     {
-        const wanted_tag_val = try mod.enumValueFieldIndex(union_obj.enum_tag_ty.toType(), enum_field_index);
+        const wanted_tag_val = try mod.enumValueFieldIndex(Type.fromInterned(union_obj.enum_tag_ty), enum_field_index);
         const wanted_tag = Air.internedToRef(wanted_tag_val.toIntern());
         // TODO would it be better if get_union_tag supported pointers to unions?
         const union_val = try block.addTyOp(.load, union_ty, union_ptr);
-        const active_tag = try block.addTyOp(.get_union_tag, union_obj.enum_tag_ty.toType(), union_val);
+        const active_tag = try block.addTyOp(.get_union_tag, Type.fromInterned(union_obj.enum_tag_ty), union_val);
         try sema.panicInactiveUnionField(block, src, active_tag, wanted_tag);
     }
     if (field_ty.zigTypeTag(mod) == .NoReturn) {
@@ -27154,14 +27154,14 @@ fn unionFieldVal(
     try sema.resolveTypeFields(union_ty);
     const union_obj = mod.typeToUnion(union_ty).?;
     const field_index = try sema.unionFieldIndex(block, union_ty, field_name, field_name_src);
-    const field_ty = union_obj.field_types.get(ip)[field_index].toType();
-    const enum_field_index: u32 = @intCast(union_obj.enum_tag_ty.toType().enumFieldIndex(field_name, mod).?);
+    const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
+    const enum_field_index: u32 = @intCast(Type.fromInterned(union_obj.enum_tag_ty).enumFieldIndex(field_name, mod).?);
 
     if (try sema.resolveValue(union_byval)) |union_val| {
         if (union_val.isUndef(mod)) return mod.undefRef(field_ty);
 
         const un = ip.indexToKey(union_val.toIntern()).un;
-        const field_tag = try mod.enumValueFieldIndex(union_obj.enum_tag_ty.toType(), enum_field_index);
+        const field_tag = try mod.enumValueFieldIndex(Type.fromInterned(union_obj.enum_tag_ty), enum_field_index);
         const tag_matches = un.tag == field_tag.toIntern();
         switch (union_obj.getLayout(ip)) {
             .Auto => {
@@ -27169,8 +27169,8 @@ fn unionFieldVal(
                     return Air.internedToRef(un.val);
                 } else {
                     const msg = msg: {
-                        const active_index = union_obj.enum_tag_ty.toType().enumTagFieldIndex(un.tag.toValue(), mod).?;
-                        const active_field_name = union_obj.enum_tag_ty.toType().enumFieldName(active_index, mod);
+                        const active_index = Type.fromInterned(union_obj.enum_tag_ty).enumTagFieldIndex(Value.fromInterned(un.tag), mod).?;
+                        const active_field_name = Type.fromInterned(union_obj.enum_tag_ty).enumFieldName(active_index, mod);
                         const msg = try sema.errMsg(block, src, "access of union field '{}' while field '{}' is active", .{
                             field_name.fmt(ip), active_field_name.fmt(ip),
                         });
@@ -27186,11 +27186,11 @@ fn unionFieldVal(
                     return Air.internedToRef(un.val);
                 } else {
                     const old_ty = if (un.tag == .none)
-                        ip.typeOf(un.val).toType()
+                        Type.fromInterned(ip.typeOf(un.val))
                     else
-                        union_ty.unionFieldType(un.tag.toValue(), mod).?;
+                        union_ty.unionFieldType(Value.fromInterned(un.tag), mod).?;
 
-                    if (try sema.bitCastUnionFieldVal(block, src, un.val.toValue(), old_ty, field_ty, layout)) |new_val| {
+                    if (try sema.bitCastUnionFieldVal(block, src, Value.fromInterned(un.val), old_ty, field_ty, layout)) |new_val| {
                         return Air.internedToRef(new_val.toIntern());
                     }
                 }
@@ -27202,9 +27202,9 @@ fn unionFieldVal(
     if (union_obj.getLayout(ip) == .Auto and block.wantSafety() and
         union_ty.unionTagTypeSafety(mod) != null and union_obj.field_names.len > 1)
     {
-        const wanted_tag_val = try mod.enumValueFieldIndex(union_obj.enum_tag_ty.toType(), enum_field_index);
+        const wanted_tag_val = try mod.enumValueFieldIndex(Type.fromInterned(union_obj.enum_tag_ty), enum_field_index);
         const wanted_tag = Air.internedToRef(wanted_tag_val.toIntern());
-        const active_tag = try block.addTyOp(.get_union_tag, union_obj.enum_tag_ty.toType(), union_byval);
+        const active_tag = try block.addTyOp(.get_union_tag, Type.fromInterned(union_obj.enum_tag_ty), union_byval);
         try sema.panicInactiveUnionField(block, src, active_tag, wanted_tag);
     }
     if (field_ty.zigTypeTag(mod) == .NoReturn) {
@@ -27906,7 +27906,7 @@ fn coerceExtra(
                 if (!inst_ty.isSinglePointer(mod)) break :single_item;
                 if (!sema.checkPtrAttributes(dest_ty, inst_ty, &in_memory_result)) break :pointer;
                 const ptr_elem_ty = inst_ty.childType(mod);
-                const array_ty = dest_info.child.toType();
+                const array_ty = Type.fromInterned(dest_info.child);
                 if (array_ty.zigTypeTag(mod) != .Array) break :single_item;
                 const array_elem_ty = array_ty.childType(mod);
                 if (array_ty.arrayLen(mod) != 1) break :single_item;
@@ -27927,7 +27927,7 @@ fn coerceExtra(
                 const array_elem_type = array_ty.childType(mod);
                 const dest_is_mut = !dest_info.flags.is_const;
 
-                const dst_elem_type = dest_info.child.toType();
+                const dst_elem_type = Type.fromInterned(dest_info.child);
                 const elem_res = try sema.coerceInMemoryAllowed(block, dst_elem_type, array_elem_type, dest_is_mut, target, dest_ty_src, inst_src);
                 switch (elem_res) {
                     .ok => {},
@@ -27948,7 +27948,7 @@ fn coerceExtra(
                         {
                             in_memory_result = .{ .ptr_sentinel = .{
                                 .actual = inst_sent,
-                                .wanted = dest_info.sentinel.toValue(),
+                                .wanted = Value.fromInterned(dest_info.sentinel),
                                 .ty = dst_elem_type,
                             } };
                             break :src_array_ptr;
@@ -27956,7 +27956,7 @@ fn coerceExtra(
                     } else {
                         in_memory_result = .{ .ptr_sentinel = .{
                             .actual = Value.@"unreachable",
-                            .wanted = dest_info.sentinel.toValue(),
+                            .wanted = Value.fromInterned(dest_info.sentinel),
                             .ty = dst_elem_type,
                         } };
                         break :src_array_ptr;
@@ -27988,7 +27988,7 @@ fn coerceExtra(
                 // could be null.
                 const src_elem_ty = inst_ty.childType(mod);
                 const dest_is_mut = !dest_info.flags.is_const;
-                const dst_elem_type = dest_info.child.toType();
+                const dst_elem_type = Type.fromInterned(dest_info.child);
                 switch (try sema.coerceInMemoryAllowed(block, dst_elem_type, src_elem_ty, dest_is_mut, target, dest_ty_src, inst_src)) {
                     .ok => {},
                     else => break :src_c_ptr,
@@ -28053,8 +28053,8 @@ fn coerceExtra(
                         const inst_info = inst_ty.ptrInfo(mod);
                         switch (try sema.coerceInMemoryAllowed(
                             block,
-                            dest_info.child.toType(),
-                            inst_info.child.toType(),
+                            Type.fromInterned(dest_info.child),
+                            Type.fromInterned(inst_info.child),
                             !dest_info.flags.is_const,
                             target,
                             dest_ty_src,
@@ -28066,7 +28066,7 @@ fn coerceExtra(
                         if (inst_info.flags.size == .Slice) {
                             assert(dest_info.sentinel == .none);
                             if (inst_info.sentinel == .none or
-                                inst_info.sentinel != (try mod.intValue(inst_info.child.toType(), 0)).toIntern())
+                                inst_info.sentinel != (try mod.intValue(Type.fromInterned(inst_info.child), 0)).toIntern())
                                 break :p;
 
                             const slice_ptr = try sema.analyzeSlicePtr(block, inst_src, inst, inst_ty);
@@ -28076,7 +28076,7 @@ fn coerceExtra(
                     },
                     else => {},
                 },
-                .One => switch (dest_info.child.toType().zigTypeTag(mod)) {
+                .One => switch (Type.fromInterned(dest_info.child).zigTypeTag(mod)) {
                     .Union => {
                         // pointer to anonymous struct to pointer to union
                         if (inst_ty.isSinglePointer(mod) and
@@ -28139,7 +28139,7 @@ fn coerceExtra(
                                 try mod.intern_pool.getCoercedInts(
                                     mod.gpa,
                                     mod.intern_pool.indexToKey(
-                                        (try dest_info.child.toType().lazyAbiAlignment(mod)).toIntern(),
+                                        (try Type.fromInterned(dest_info.child).lazyAbiAlignment(mod)).toIntern(),
                                     ).int,
                                     .usize_type,
                                 ) },
@@ -28166,8 +28166,8 @@ fn coerceExtra(
 
                     switch (try sema.coerceInMemoryAllowed(
                         block,
-                        dest_info.child.toType(),
-                        inst_info.child.toType(),
+                        Type.fromInterned(dest_info.child),
+                        Type.fromInterned(inst_info.child),
                         !dest_info.flags.is_const,
                         target,
                         dest_ty_src,
@@ -28179,7 +28179,7 @@ fn coerceExtra(
 
                     if (dest_info.sentinel == .none or inst_info.sentinel == .none or
                         Air.internedToRef(dest_info.sentinel) !=
-                        try sema.coerceInMemory(inst_info.sentinel.toValue(), dest_info.child.toType()))
+                        try sema.coerceInMemory(Value.fromInterned(inst_info.sentinel), Type.fromInterned(dest_info.child)))
                         break :p;
 
                     const slice_ptr = try sema.analyzeSlicePtr(block, inst_src, inst, inst_ty);
@@ -29220,8 +29220,8 @@ fn coerceInMemoryAllowedFns(
         switch (src_info.return_type) {
             .noreturn_type, .generic_poison_type => {},
             else => {
-                const dest_return_type = dest_info.return_type.toType();
-                const src_return_type = src_info.return_type.toType();
+                const dest_return_type = Type.fromInterned(dest_info.return_type);
+                const src_return_type = Type.fromInterned(src_info.return_type);
                 const rt = try sema.coerceInMemoryAllowed(block, dest_return_type, src_return_type, false, target, dest_src, src_src);
                 if (rt != .ok) {
                     return InMemoryCoercionResult{ .fn_return_type = .{
@@ -29253,8 +29253,8 @@ fn coerceInMemoryAllowedFns(
     };
 
     for (0..params_len) |param_i| {
-        const dest_param_ty = dest_info.param_types.get(ip)[param_i].toType();
-        const src_param_ty = src_info.param_types.get(ip)[param_i].toType();
+        const dest_param_ty = Type.fromInterned(dest_info.param_types.get(ip)[param_i]);
+        const src_param_ty = Type.fromInterned(src_info.param_types.get(ip)[param_i]);
 
         const param_i_small: u5 = @intCast(param_i);
         if (dest_info.paramIsComptime(param_i_small) != src_info.paramIsComptime(param_i_small)) {
@@ -29329,12 +29329,12 @@ fn coerceInMemoryAllowedPtrs(
         } };
     }
 
-    const child = try sema.coerceInMemoryAllowed(block, dest_info.child.toType(), src_info.child.toType(), !dest_info.flags.is_const, target, dest_src, src_src);
+    const child = try sema.coerceInMemoryAllowed(block, Type.fromInterned(dest_info.child), Type.fromInterned(src_info.child), !dest_info.flags.is_const, target, dest_src, src_src);
     if (child != .ok) {
         return InMemoryCoercionResult{ .ptr_child = .{
             .child = try child.dupe(sema.arena),
-            .actual = src_info.child.toType(),
-            .wanted = dest_info.child.toType(),
+            .actual = Type.fromInterned(src_info.child),
+            .wanted = Type.fromInterned(dest_info.child),
         } };
     }
 
@@ -29369,13 +29369,13 @@ fn coerceInMemoryAllowedPtrs(
         return InMemoryCoercionResult{ .ptr_sentinel = .{
             .actual = switch (src_info.sentinel) {
                 .none => Value.@"unreachable",
-                else => src_info.sentinel.toValue(),
+                else => Value.fromInterned(src_info.sentinel),
             },
             .wanted = switch (dest_info.sentinel) {
                 .none => Value.@"unreachable",
-                else => dest_info.sentinel.toValue(),
+                else => Value.fromInterned(dest_info.sentinel),
             },
-            .ty = dest_info.child.toType(),
+            .ty = Type.fromInterned(dest_info.child),
         } };
     }
 
@@ -29389,12 +29389,12 @@ fn coerceInMemoryAllowedPtrs(
         const src_align = if (src_info.flags.alignment != .none)
             src_info.flags.alignment
         else
-            try sema.typeAbiAlignment(src_info.child.toType());
+            try sema.typeAbiAlignment(Type.fromInterned(src_info.child));
 
         const dest_align = if (dest_info.flags.alignment != .none)
             dest_info.flags.alignment
         else
-            try sema.typeAbiAlignment(dest_info.child.toType());
+            try sema.typeAbiAlignment(Type.fromInterned(dest_info.child));
 
         if (dest_align.compare(.gt, src_align)) {
             return InMemoryCoercionResult{ .ptr_alignment = .{
@@ -29719,14 +29719,14 @@ fn storePtrVal(
         .opv => {},
         .direct => |val_ptr| {
             if (mut_kit.mut_decl.runtime_index == .comptime_field_ptr) {
-                val_ptr.* = (try val_ptr.intern(operand_ty, mod)).toValue();
+                val_ptr.* = Value.fromInterned((try val_ptr.intern(operand_ty, mod)));
                 if (!operand_val.eql(val_ptr.*, operand_ty, mod)) {
                     // TODO use failWithInvalidComptimeFieldStore
                     return sema.fail(block, src, "value stored in comptime field does not match the default value of the field", .{});
                 }
                 return;
             }
-            val_ptr.* = (try operand_val.intern(operand_ty, mod)).toValue();
+            val_ptr.* = Value.fromInterned((try operand_val.intern(operand_ty, mod)));
         },
         .reinterpret => |reinterpret| {
             const abi_size = try sema.usizeCast(block, src, mut_kit.ty.abiSize(mod));
@@ -29756,7 +29756,7 @@ fn storePtrVal(
                 error.IllDefinedMemoryLayout => unreachable,
                 error.Unimplemented => return sema.fail(block, src, "TODO: implement readFromMemory for type '{}'", .{mut_kit.ty.fmt(mod)}),
             };
-            reinterpret.val_ptr.* = (try val.intern(mut_kit.ty, mod)).toValue();
+            reinterpret.val_ptr.* = Value.fromInterned((try val.intern(mut_kit.ty, mod)));
         },
         .bad_decl_ty, .bad_ptr_ty => {
             // TODO show the decl declaration site in a note and explain whether the decl
@@ -29817,15 +29817,15 @@ fn beginComptimePtrMutation(
         },
         .comptime_field => |comptime_field| {
             const duped = try sema.arena.create(Value);
-            duped.* = comptime_field.toValue();
-            return sema.beginComptimePtrMutationInner(block, src, mod.intern_pool.typeOf(comptime_field).toType(), duped, ptr_elem_ty, .{
+            duped.* = Value.fromInterned(comptime_field);
+            return sema.beginComptimePtrMutationInner(block, src, Type.fromInterned(mod.intern_pool.typeOf(comptime_field)), duped, ptr_elem_ty, .{
                 .decl = undefined,
                 .runtime_index = .comptime_field_ptr,
             });
         },
         .eu_payload => |eu_ptr| {
-            const eu_ty = mod.intern_pool.typeOf(eu_ptr).toType().childType(mod);
-            var parent = try sema.beginComptimePtrMutation(block, src, eu_ptr.toValue(), eu_ty);
+            const eu_ty = Type.fromInterned(mod.intern_pool.typeOf(eu_ptr)).childType(mod);
+            var parent = try sema.beginComptimePtrMutation(block, src, Value.fromInterned(eu_ptr), eu_ty);
             switch (parent.pointee) {
                 .opv => unreachable,
                 .direct => |val_ptr| {
@@ -29844,7 +29844,7 @@ fn beginComptimePtrMutation(
                         const payload = try sema.arena.create(Value.Payload.SubValue);
                         payload.* = .{
                             .base = .{ .tag = .eu_payload },
-                            .data = (try mod.intern(.{ .undef = payload_ty.toIntern() })).toValue(),
+                            .data = Value.fromInterned((try mod.intern(.{ .undef = payload_ty.toIntern() }))),
                         };
 
                         val_ptr.* = Value.initPayload(&payload.base);
@@ -29867,8 +29867,8 @@ fn beginComptimePtrMutation(
             }
         },
         .opt_payload => |opt_ptr| {
-            const opt_ty = mod.intern_pool.typeOf(opt_ptr).toType().childType(mod);
-            var parent = try sema.beginComptimePtrMutation(block, src, opt_ptr.toValue(), opt_ty);
+            const opt_ty = Type.fromInterned(mod.intern_pool.typeOf(opt_ptr)).childType(mod);
+            var parent = try sema.beginComptimePtrMutation(block, src, Value.fromInterned(opt_ptr), opt_ty);
             switch (parent.pointee) {
                 .opv => unreachable,
                 .direct => |val_ptr| {
@@ -29896,7 +29896,7 @@ fn beginComptimePtrMutation(
                             const payload = try sema.arena.create(Value.Payload.SubValue);
                             payload.* = .{
                                 .base = .{ .tag = .opt_payload },
-                                .data = payload_val.toValue(),
+                                .data = Value.fromInterned(payload_val),
                             };
 
                             val_ptr.* = Value.initPayload(&payload.base);
@@ -29920,8 +29920,8 @@ fn beginComptimePtrMutation(
             }
         },
         .elem => |elem_ptr| {
-            const base_elem_ty = mod.intern_pool.typeOf(elem_ptr.base).toType().elemType2(mod);
-            var parent = try sema.beginComptimePtrMutation(block, src, elem_ptr.base.toValue(), base_elem_ty);
+            const base_elem_ty = Type.fromInterned(mod.intern_pool.typeOf(elem_ptr.base)).elemType2(mod);
+            var parent = try sema.beginComptimePtrMutation(block, src, Value.fromInterned(elem_ptr.base), base_elem_ty);
 
             switch (parent.pointee) {
                 .opv => unreachable,
@@ -30017,7 +30017,7 @@ fn beginComptimePtrMutation(
                                     const array_len_including_sentinel =
                                         try sema.usizeCast(block, src, parent.ty.arrayLenIncludingSentinel(mod));
                                     const elems = try arena.alloc(Value, array_len_including_sentinel);
-                                    @memset(elems, repeated_val.toValue());
+                                    @memset(elems, Value.fromInterned(repeated_val));
 
                                     val_ptr.* = try Value.Tag.aggregate.create(arena, elems);
 
@@ -30054,7 +30054,7 @@ fn beginComptimePtrMutation(
                                     const array_len_including_sentinel =
                                         try sema.usizeCast(block, src, parent.ty.arrayLenIncludingSentinel(mod));
                                     const elems = try arena.alloc(Value, array_len_including_sentinel);
-                                    @memset(elems, (try mod.intern(.{ .undef = elem_ty.toIntern() })).toValue());
+                                    @memset(elems, Value.fromInterned((try mod.intern(.{ .undef = elem_ty.toIntern() }))));
 
                                     val_ptr.* = try Value.Tag.aggregate.create(arena, elems);
 
@@ -30117,10 +30117,10 @@ fn beginComptimePtrMutation(
             }
         },
         .field => |field_ptr| {
-            const base_child_ty = mod.intern_pool.typeOf(field_ptr.base).toType().childType(mod);
+            const base_child_ty = Type.fromInterned(mod.intern_pool.typeOf(field_ptr.base)).childType(mod);
             const field_index: u32 = @intCast(field_ptr.index);
 
-            var parent = try sema.beginComptimePtrMutation(block, src, field_ptr.base.toValue(), base_child_ty);
+            var parent = try sema.beginComptimePtrMutation(block, src, Value.fromInterned(field_ptr.base), base_child_ty);
             switch (parent.pointee) {
                 .opv => unreachable,
                 .direct => |val_ptr| switch (val_ptr.ip_index) {
@@ -30238,9 +30238,9 @@ fn beginComptimePtrMutation(
                             switch (parent.ty.zigTypeTag(mod)) {
                                 .Struct => {
                                     const fields = try arena.alloc(Value, parent.ty.structFieldCount(mod));
-                                    for (fields, 0..) |*field, i| field.* = (try mod.intern(.{
+                                    for (fields, 0..) |*field, i| field.* = Value.fromInterned((try mod.intern(.{
                                         .undef = parent.ty.structFieldType(i, mod).toIntern(),
-                                    })).toValue();
+                                    })));
 
                                     val_ptr.* = try Value.Tag.aggregate.create(arena, fields);
 
@@ -30260,7 +30260,7 @@ fn beginComptimePtrMutation(
                                     const payload_ty = parent.ty.structFieldType(field_index, mod);
                                     payload.* = .{ .data = .{
                                         .tag = try mod.enumValueFieldIndex(tag_ty, field_index),
-                                        .val = (try mod.intern(.{ .undef = payload_ty.toIntern() })).toValue(),
+                                        .val = Value.fromInterned((try mod.intern(.{ .undef = payload_ty.toIntern() }))),
                                     } };
 
                                     val_ptr.* = Value.initPayload(&payload.base);
@@ -30279,8 +30279,8 @@ fn beginComptimePtrMutation(
                                     assert(parent.ty.isSlice(mod));
                                     const ptr_ty = parent.ty.slicePtrFieldType(mod);
                                     val_ptr.* = try Value.Tag.slice.create(arena, .{
-                                        .ptr = (try mod.intern(.{ .undef = ptr_ty.toIntern() })).toValue(),
-                                        .len = (try mod.intern(.{ .undef = .usize_type })).toValue(),
+                                        .ptr = Value.fromInterned((try mod.intern(.{ .undef = ptr_ty.toIntern() }))),
+                                        .len = Value.fromInterned((try mod.intern(.{ .undef = .usize_type }))),
                                     });
 
                                     switch (field_index) {
@@ -30449,9 +30449,9 @@ fn beginComptimePtrLoad(
             },
             .anon_decl => |anon_decl| blk: {
                 const decl_val = anon_decl.val;
-                if (decl_val.toValue().getVariable(mod) != null) return error.RuntimeLoad;
-                const decl_ty = ip.typeOf(decl_val).toType();
-                const decl_tv: TypedValue = .{ .ty = decl_ty, .val = decl_val.toValue() };
+                if (Value.fromInterned(decl_val).getVariable(mod) != null) return error.RuntimeLoad;
+                const decl_ty = Type.fromInterned(ip.typeOf(decl_val));
+                const decl_tv: TypedValue = .{ .ty = decl_ty, .val = Value.fromInterned(decl_val) };
                 const layout_defined = decl_ty.hasWellDefinedLayout(mod);
                 break :blk ComptimePtrLoadKit{
                     .parent = if (layout_defined) .{ .tv = decl_tv, .byte_offset = 0 } else null,
@@ -30462,13 +30462,13 @@ fn beginComptimePtrLoad(
             },
             .int => return error.RuntimeLoad,
             .eu_payload, .opt_payload => |container_ptr| blk: {
-                const container_ty = ip.typeOf(container_ptr).toType().childType(mod);
+                const container_ty = Type.fromInterned(ip.typeOf(container_ptr)).childType(mod);
                 const payload_ty = switch (ptr.addr) {
                     .eu_payload => container_ty.errorUnionPayload(mod),
                     .opt_payload => container_ty.optionalChild(mod),
                     else => unreachable,
                 };
-                var deref = try sema.beginComptimePtrLoad(block, src, container_ptr.toValue(), container_ty);
+                var deref = try sema.beginComptimePtrLoad(block, src, Value.fromInterned(container_ptr), container_ty);
 
                 // eu_payload and opt_payload never have a well-defined layout
                 if (deref.parent != null) {
@@ -30484,7 +30484,7 @@ fn beginComptimePtrLoad(
                         const payload_val = switch (tv.val.ip_index) {
                             .none => tv.val.cast(Value.Payload.SubValue).?.data,
                             .null_value => return sema.fail(block, src, "attempt to use null value", .{}),
-                            else => switch (ip.indexToKey(tv.val.toIntern())) {
+                            else => Value.fromInterned(switch (ip.indexToKey(tv.val.toIntern())) {
                                 .error_union => |error_union| switch (error_union.val) {
                                     .err_name => |err_name| return sema.fail(
                                         block,
@@ -30499,7 +30499,7 @@ fn beginComptimePtrLoad(
                                     else => |payload| payload,
                                 },
                                 else => unreachable,
-                            }.toValue(),
+                            }),
                         };
                         tv.* = TypedValue{ .ty = payload_ty, .val = payload_val };
                         break :blk deref;
@@ -30509,24 +30509,24 @@ fn beginComptimePtrLoad(
                 break :blk deref;
             },
             .comptime_field => |comptime_field| blk: {
-                const field_ty = ip.typeOf(comptime_field).toType();
+                const field_ty = Type.fromInterned(ip.typeOf(comptime_field));
                 break :blk ComptimePtrLoadKit{
                     .parent = null,
-                    .pointee = .{ .ty = field_ty, .val = comptime_field.toValue() },
+                    .pointee = .{ .ty = field_ty, .val = Value.fromInterned(comptime_field) },
                     .is_mutable = false,
                     .ty_without_well_defined_layout = field_ty,
                 };
             },
             .elem => |elem_ptr| blk: {
-                const elem_ty = ip.typeOf(elem_ptr.base).toType().elemType2(mod);
-                var deref = try sema.beginComptimePtrLoad(block, src, elem_ptr.base.toValue(), null);
+                const elem_ty = Type.fromInterned(ip.typeOf(elem_ptr.base)).elemType2(mod);
+                var deref = try sema.beginComptimePtrLoad(block, src, Value.fromInterned(elem_ptr.base), null);
 
                 // This code assumes that elem_ptrs have been "flattened" in order for direct dereference
                 // to succeed, meaning that elem ptrs of the same elem_ty are coalesced. Here we check that
                 // our parent is not an elem_ptr with the same elem_ty, since that would be "unflattened"
                 switch (ip.indexToKey(elem_ptr.base)) {
                     .ptr => |base_ptr| switch (base_ptr.addr) {
-                        .elem => |base_elem| assert(!ip.typeOf(base_elem.base).toType().elemType2(mod).eql(elem_ty, mod)),
+                        .elem => |base_elem| assert(!Type.fromInterned(ip.typeOf(base_elem.base)).elemType2(mod).eql(elem_ty, mod)),
                         else => {},
                     },
                     else => {},
@@ -30598,8 +30598,8 @@ fn beginComptimePtrLoad(
             },
             .field => |field_ptr| blk: {
                 const field_index: u32 = @intCast(field_ptr.index);
-                const container_ty = ip.typeOf(field_ptr.base).toType().childType(mod);
-                var deref = try sema.beginComptimePtrLoad(block, src, field_ptr.base.toValue(), container_ty);
+                const container_ty = Type.fromInterned(ip.typeOf(field_ptr.base)).childType(mod);
+                var deref = try sema.beginComptimePtrLoad(block, src, Value.fromInterned(field_ptr.base), container_ty);
 
                 if (container_ty.hasWellDefinedLayout(mod)) {
                     const struct_obj = mod.typeToStruct(container_ty);
@@ -30637,7 +30637,7 @@ fn beginComptimePtrLoad(
                         },
                         Value.slice_len_index => TypedValue{
                             .ty = Type.usize,
-                            .val = ip.indexToKey(try tv.val.intern(tv.ty, mod)).ptr.len.toValue(),
+                            .val = Value.fromInterned(ip.indexToKey(try tv.val.intern(tv.ty, mod)).ptr.len),
                         },
                         else => unreachable,
                     };
@@ -30653,7 +30653,7 @@ fn beginComptimePtrLoad(
         },
         .opt => |opt| switch (opt.val) {
             .none => return sema.fail(block, src, "attempt to use null value", .{}),
-            else => |payload| try sema.beginComptimePtrLoad(block, src, payload.toValue(), null),
+            else => |payload| try sema.beginComptimePtrLoad(block, src, Value.fromInterned(payload), null),
         },
         else => unreachable,
     };
@@ -30822,9 +30822,9 @@ fn checkPtrAttributes(sema: *Sema, dest_ty: Type, inst_ty: Type, in_memory_resul
     const mod = sema.mod;
     const dest_info = dest_ty.ptrInfo(mod);
     const inst_info = inst_ty.ptrInfo(mod);
-    const len0 = (inst_info.child.toType().zigTypeTag(mod) == .Array and (inst_info.child.toType().arrayLenIncludingSentinel(mod) == 0 or
-        (inst_info.child.toType().arrayLen(mod) == 0 and dest_info.sentinel == .none and dest_info.flags.size != .C and dest_info.flags.size != .Many))) or
-        (inst_info.child.toType().isTuple(mod) and inst_info.child.toType().structFieldCount(mod) == 0);
+    const len0 = (Type.fromInterned(inst_info.child).zigTypeTag(mod) == .Array and (Type.fromInterned(inst_info.child).arrayLenIncludingSentinel(mod) == 0 or
+        (Type.fromInterned(inst_info.child).arrayLen(mod) == 0 and dest_info.sentinel == .none and dest_info.flags.size != .C and dest_info.flags.size != .Many))) or
+        (Type.fromInterned(inst_info.child).isTuple(mod) and Type.fromInterned(inst_info.child).structFieldCount(mod) == 0);
 
     const ok_cv_qualifiers =
         ((!inst_info.flags.is_const or dest_info.flags.is_const) or len0) and
@@ -30852,12 +30852,12 @@ fn checkPtrAttributes(sema: *Sema, dest_ty: Type, inst_ty: Type, in_memory_resul
     const inst_align = if (inst_info.flags.alignment != .none)
         inst_info.flags.alignment
     else
-        inst_info.child.toType().abiAlignment(mod);
+        Type.fromInterned(inst_info.child).abiAlignment(mod);
 
     const dest_align = if (dest_info.flags.alignment != .none)
         dest_info.flags.alignment
     else
-        dest_info.child.toType().abiAlignment(mod);
+        Type.fromInterned(dest_info.child).abiAlignment(mod);
 
     if (dest_align.compare(.gt, inst_align)) {
         in_memory_result.* = .{ .ptr_alignment = .{
@@ -30884,7 +30884,7 @@ fn coerceCompatiblePtrs(
         }
         // The comptime Value representation is compatible with both types.
         return Air.internedToRef(
-            (try mod.getCoerced((try val.intern(inst_ty, mod)).toValue(), dest_ty)).toIntern(),
+            (try mod.getCoerced(Value.fromInterned((try val.intern(inst_ty, mod))), dest_ty)).toIntern(),
         );
     }
     try sema.requireRuntimeBlock(block, inst_src, null);
@@ -30950,7 +30950,7 @@ fn coerceEnumToUnion(
         };
 
         const union_obj = mod.typeToUnion(union_ty).?;
-        const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+        const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
         try sema.resolveTypeFields(field_ty);
         if (field_ty.zigTypeTag(mod) == .NoReturn) {
             const msg = msg: {
@@ -31007,7 +31007,7 @@ fn coerceEnumToUnion(
         errdefer if (msg) |some| some.destroy(sema.gpa);
 
         for (union_obj.field_types.get(ip), 0..) |field_ty, field_index| {
-            if (field_ty.toType().zigTypeTag(mod) == .NoReturn) {
+            if (Type.fromInterned(field_ty).zigTypeTag(mod) == .NoReturn) {
                 const err_msg = msg orelse try sema.errMsg(
                     block,
                     inst_src,
@@ -31042,7 +31042,7 @@ fn coerceEnumToUnion(
 
         for (0..union_obj.field_names.len) |field_index| {
             const field_name = union_obj.field_names.get(ip)[field_index];
-            const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+            const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
             if (!(try sema.typeHasRuntimeBits(field_ty))) continue;
             try sema.addFieldErrNote(union_ty, field_index, msg, "field '{}' has type '{}'", .{
                 field_name.fmt(ip),
@@ -31320,7 +31320,7 @@ fn coerceTupleToArrayPtrs(
     const mod = sema.mod;
     const tuple = try sema.analyzeLoad(block, tuple_src, ptr_tuple, tuple_src);
     const ptr_info = ptr_array_ty.ptrInfo(mod);
-    const array_ty = ptr_info.child.toType();
+    const array_ty = Type.fromInterned(ptr_info.child);
     const array_inst = try sema.coerceTupleToArray(block, array_ty, array_ty_src, tuple, tuple_src);
     if (ptr_info.flags.alignment != .none) {
         return sema.fail(block, array_ty_src, "TODO: override the alignment of the array decl we create here", .{});
@@ -31372,7 +31372,7 @@ fn coerceTupleToStruct(
             else => unreachable,
         };
         const field_index = try sema.structFieldIndex(block, struct_ty, field_name, field_src);
-        const field_ty = struct_type.field_types.get(ip)[field_index].toType();
+        const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[field_index]);
         const elem_ref = try sema.tupleField(block, inst_src, inst, field_src, field_i);
         const coerced = try sema.coerce(block, field_ty, elem_ref, field_src);
         field_refs[field_index] = coerced;
@@ -31383,7 +31383,7 @@ fn coerceTupleToStruct(
                 });
             };
 
-            const field_init = struct_type.field_inits.get(ip)[field_index].toValue();
+            const field_init = Value.fromInterned(struct_type.field_inits.get(ip)[field_index]);
             if (!init_val.eql(field_init, field_ty, sema.mod)) {
                 return sema.failWithInvalidComptimeFieldStore(block, field_src, inst_ty, field_i);
             }
@@ -31502,7 +31502,7 @@ fn coerceTupleToTuple(
         const field_index = try sema.tupleFieldIndex(block, tuple_ty, field_name, field_src);
 
         const elem_ref = try sema.tupleField(block, inst_src, inst, field_src, field_i);
-        const coerced = try sema.coerce(block, field_ty.toType(), elem_ref, field_src);
+        const coerced = try sema.coerce(block, Type.fromInterned(field_ty), elem_ref, field_src);
         field_refs[field_index] = coerced;
         if (default_val != .none) {
             const init_val = (try sema.resolveValue(coerced)) orelse {
@@ -31511,7 +31511,7 @@ fn coerceTupleToTuple(
                 });
             };
 
-            if (!init_val.eql(default_val.toValue(), field_ty.toType(), sema.mod)) {
+            if (!init_val.eql(Value.fromInterned(default_val), Type.fromInterned(field_ty), sema.mod)) {
                 return sema.failWithInvalidComptimeFieldStore(block, field_src, inst_ty, field_i);
             }
         }
@@ -31658,13 +31658,13 @@ fn ensureFuncBodyAnalyzed(sema: *Sema, func: InternPool.Index) CompileError!void
 fn optRefValue(sema: *Sema, opt_val: ?Value) !Value {
     const mod = sema.mod;
     const ptr_anyopaque_ty = try mod.singleConstPtrType(Type.anyopaque);
-    return (try mod.intern(.{ .opt = .{
+    return Value.fromInterned((try mod.intern(.{ .opt = .{
         .ty = (try mod.optionalType(ptr_anyopaque_ty.toIntern())).toIntern(),
         .val = if (opt_val) |val| (try mod.getCoerced(
-            (try sema.refValue(val.toIntern())).toValue(),
+            Value.fromInterned((try sema.refValue(val.toIntern()))),
             ptr_anyopaque_ty,
         )).toIntern() else .none,
-    } })).toValue();
+    } })));
 }
 
 fn analyzeDeclRef(sema: *Sema, decl_index: Decl.Index) CompileError!Air.Inst.Ref {
@@ -32378,7 +32378,7 @@ fn analyzeSlice(
 
         if (!new_ptr_val.isUndef(mod)) {
             return Air.internedToRef((try mod.getCoerced(
-                (try new_ptr_val.intern(new_ptr_ty, mod)).toValue(),
+                Value.fromInterned((try new_ptr_val.intern(new_ptr_ty, mod))),
                 return_ty,
             )).toIntern());
         }
@@ -33362,10 +33362,10 @@ fn resolvePeerTypesInner(
                         ty_ptr.* = ty.errorUnionPayload(mod);
                         if (val_ptr.*) |eu_val| switch (ip.indexToKey(eu_val.toIntern())) {
                             .error_union => |eu| switch (eu.val) {
-                                .payload => |payload_ip| val_ptr.* = payload_ip.toValue(),
+                                .payload => |payload_ip| val_ptr.* = Value.fromInterned(payload_ip),
                                 .err_name => val_ptr.* = null,
                             },
-                            .undef => val_ptr.* = (try sema.mod.intern(.{ .undef = ty_ptr.*.?.toIntern() })).toValue(),
+                            .undef => val_ptr.* = Value.fromInterned((try sema.mod.intern(.{ .undef = ty_ptr.*.?.toIntern() }))),
                             else => unreachable,
                         };
                         break :blk set_ty;
@@ -33606,7 +33606,7 @@ fn resolvePeerTypesInner(
                 };
 
                 // Try peer -> cur, then cur -> peer
-                ptr_info.child = ((try sema.resolvePairInMemoryCoercible(block, src, ptr_info.child.toType(), peer_info.child.toType())) orelse {
+                ptr_info.child = ((try sema.resolvePairInMemoryCoercible(block, src, Type.fromInterned(ptr_info.child), Type.fromInterned(peer_info.child))) orelse {
                     return .{ .conflict = .{
                         .peer_idx_a = first_idx,
                         .peer_idx_b = i,
@@ -33630,12 +33630,12 @@ fn resolvePeerTypesInner(
                     if (ptr_info.flags.alignment != .none)
                         ptr_info.flags.alignment
                     else
-                        ptr_info.child.toType().abiAlignment(mod),
+                        Type.fromInterned(ptr_info.child).abiAlignment(mod),
 
                     if (peer_info.flags.alignment != .none)
                         peer_info.flags.alignment
                     else
-                        peer_info.child.toType().abiAlignment(mod),
+                        Type.fromInterned(peer_info.child).abiAlignment(mod),
                 );
                 if (ptr_info.flags.address_space != peer_info.flags.address_space) {
                     return .{ .conflict = .{
@@ -33714,12 +33714,12 @@ fn resolvePeerTypesInner(
                     if (ptr_info.flags.alignment != .none)
                         ptr_info.flags.alignment
                     else
-                        try sema.typeAbiAlignment(ptr_info.child.toType()),
+                        try sema.typeAbiAlignment(Type.fromInterned(ptr_info.child)),
 
                     if (peer_info.flags.alignment != .none)
                         peer_info.flags.alignment
                     else
-                        try sema.typeAbiAlignment(peer_info.child.toType()),
+                        try sema.typeAbiAlignment(Type.fromInterned(peer_info.child)),
                 );
 
                 if (ptr_info.flags.address_space != peer_info.flags.address_space) {
@@ -33754,8 +33754,8 @@ fn resolvePeerTypesInner(
                 };
 
                 // We abstract array handling slightly so that tuple pointers can work like array pointers
-                const peer_pointee_array = sema.typeIsArrayLike(peer_info.child.toType());
-                const cur_pointee_array = sema.typeIsArrayLike(ptr_info.child.toType());
+                const peer_pointee_array = sema.typeIsArrayLike(Type.fromInterned(peer_info.child));
+                const cur_pointee_array = sema.typeIsArrayLike(Type.fromInterned(ptr_info.child));
 
                 // This switch is just responsible for deciding the size and pointee (not including
                 // single-pointer array sentinel).
@@ -33763,7 +33763,7 @@ fn resolvePeerTypesInner(
                     switch (peer_info.flags.size) {
                         .One => switch (ptr_info.flags.size) {
                             .One => {
-                                if (try sema.resolvePairInMemoryCoercible(block, src, ptr_info.child.toType(), peer_info.child.toType())) |pointee| {
+                                if (try sema.resolvePairInMemoryCoercible(block, src, Type.fromInterned(ptr_info.child), Type.fromInterned(peer_info.child))) |pointee| {
                                     ptr_info.child = pointee.toIntern();
                                     break :good;
                                 }
@@ -33805,7 +33805,7 @@ fn resolvePeerTypesInner(
                             .Many => {
                                 // Only works for *[n]T + [*]T -> [*]T
                                 const arr = peer_pointee_array orelse return generic_err;
-                                if (try sema.resolvePairInMemoryCoercible(block, src, ptr_info.child.toType(), arr.elem_ty)) |pointee| {
+                                if (try sema.resolvePairInMemoryCoercible(block, src, Type.fromInterned(ptr_info.child), arr.elem_ty)) |pointee| {
                                     ptr_info.child = pointee.toIntern();
                                     break :good;
                                 }
@@ -33818,7 +33818,7 @@ fn resolvePeerTypesInner(
                             .Slice => {
                                 // Only works for *[n]T + []T -> []T
                                 const arr = peer_pointee_array orelse return generic_err;
-                                if (try sema.resolvePairInMemoryCoercible(block, src, ptr_info.child.toType(), arr.elem_ty)) |pointee| {
+                                if (try sema.resolvePairInMemoryCoercible(block, src, Type.fromInterned(ptr_info.child), arr.elem_ty)) |pointee| {
                                     ptr_info.child = pointee.toIntern();
                                     break :good;
                                 }
@@ -33834,7 +33834,7 @@ fn resolvePeerTypesInner(
                             .One => {
                                 // Only works for [*]T + *[n]T -> [*]T
                                 const arr = cur_pointee_array orelse return generic_err;
-                                if (try sema.resolvePairInMemoryCoercible(block, src, arr.elem_ty, peer_info.child.toType())) |pointee| {
+                                if (try sema.resolvePairInMemoryCoercible(block, src, arr.elem_ty, Type.fromInterned(peer_info.child))) |pointee| {
                                     ptr_info.flags.size = .Many;
                                     ptr_info.child = pointee.toIntern();
                                     break :good;
@@ -33848,7 +33848,7 @@ fn resolvePeerTypesInner(
                                 return generic_err;
                             },
                             .Many => {
-                                if (try sema.resolvePairInMemoryCoercible(block, src, ptr_info.child.toType(), peer_info.child.toType())) |pointee| {
+                                if (try sema.resolvePairInMemoryCoercible(block, src, Type.fromInterned(ptr_info.child), Type.fromInterned(peer_info.child))) |pointee| {
                                     ptr_info.child = pointee.toIntern();
                                     break :good;
                                 }
@@ -33863,7 +33863,7 @@ fn resolvePeerTypesInner(
                                     } };
                                 }
                                 // Okay, then works for [*]T + "[]T" -> [*]T
-                                if (try sema.resolvePairInMemoryCoercible(block, src, ptr_info.child.toType(), peer_info.child.toType())) |pointee| {
+                                if (try sema.resolvePairInMemoryCoercible(block, src, Type.fromInterned(ptr_info.child), Type.fromInterned(peer_info.child))) |pointee| {
                                     ptr_info.flags.size = .Many;
                                     ptr_info.child = pointee.toIntern();
                                     break :good;
@@ -33876,7 +33876,7 @@ fn resolvePeerTypesInner(
                             .One => {
                                 // Only works for []T + *[n]T -> []T
                                 const arr = cur_pointee_array orelse return generic_err;
-                                if (try sema.resolvePairInMemoryCoercible(block, src, arr.elem_ty, peer_info.child.toType())) |pointee| {
+                                if (try sema.resolvePairInMemoryCoercible(block, src, arr.elem_ty, Type.fromInterned(peer_info.child))) |pointee| {
                                     ptr_info.flags.size = .Slice;
                                     ptr_info.child = pointee.toIntern();
                                     break :good;
@@ -33894,7 +33894,7 @@ fn resolvePeerTypesInner(
                                 return generic_err;
                             },
                             .Slice => {
-                                if (try sema.resolvePairInMemoryCoercible(block, src, ptr_info.child.toType(), peer_info.child.toType())) |pointee| {
+                                if (try sema.resolvePairInMemoryCoercible(block, src, Type.fromInterned(ptr_info.child), Type.fromInterned(peer_info.child))) |pointee| {
                                     ptr_info.child = pointee.toIntern();
                                     break :good;
                                 }
@@ -34331,7 +34331,7 @@ fn resolvePeerTypesInner(
                         break;
                     };
                     const uncoerced_field = Air.internedToRef(uncoerced_field_val.toIntern());
-                    const coerced_inst = sema.coerceExtra(block, field_ty.toType(), uncoerced_field, src, .{ .report_err = false }) catch |err| switch (err) {
+                    const coerced_inst = sema.coerceExtra(block, Type.fromInterned(field_ty.*), uncoerced_field, src, .{ .report_err = false }) catch |err| switch (err) {
                         // It's possible for PTR to give false positives. Just give up on making this a comptime field, we'll get an error later anyway
                         error.NotCoercible => {
                             comptime_val = null;
@@ -34344,7 +34344,7 @@ fn resolvePeerTypesInner(
                         comptime_val = coerced_val;
                         continue;
                     };
-                    if (!coerced_val.eql(existing, field_ty.toType(), mod)) {
+                    if (!coerced_val.eql(existing, Type.fromInterned(field_ty.*), mod)) {
                         comptime_val = null;
                         break;
                     }
@@ -34359,7 +34359,7 @@ fn resolvePeerTypesInner(
                 .values = field_vals,
             });
 
-            return .{ .success = final_ty.toType() };
+            return .{ .success = Type.fromInterned(final_ty) };
         },
 
         .exact => {
@@ -34460,15 +34460,15 @@ pub fn resolveFnTypes(sema: *Sema, fn_ty: Type) CompileError!void {
     const ip = &mod.intern_pool;
     const fn_ty_info = mod.typeToFunc(fn_ty).?;
 
-    try sema.resolveTypeFully(fn_ty_info.return_type.toType());
+    try sema.resolveTypeFully(Type.fromInterned(fn_ty_info.return_type));
 
-    if (mod.comp.bin_file.options.error_return_tracing and fn_ty_info.return_type.toType().isError(mod)) {
+    if (mod.comp.bin_file.options.error_return_tracing and Type.fromInterned(fn_ty_info.return_type).isError(mod)) {
         // Ensure the type exists so that backends can assume that.
         _ = try sema.getBuiltinType("StackTrace");
     }
 
     for (0..fn_ty_info.param_types.len) |i| {
-        try sema.resolveTypeFully(fn_ty_info.param_types.get(ip)[i].toType());
+        try sema.resolveTypeFully(Type.fromInterned(fn_ty_info.param_types.get(ip)[i]));
     }
 }
 
@@ -34480,20 +34480,20 @@ fn resolveLazyValue(sema: *Sema, val: Value) CompileError!Value {
         .int => |int| switch (int.storage) {
             .u64, .i64, .big_int => return val,
             .lazy_align, .lazy_size => return mod.intValue(
-                int.ty.toType(),
+                Type.fromInterned(int.ty),
                 (try val.getUnsignedIntAdvanced(mod, sema)).?,
             ),
         },
         .ptr => |ptr| {
             const resolved_len = switch (ptr.len) {
                 .none => .none,
-                else => (try sema.resolveLazyValue(ptr.len.toValue())).toIntern(),
+                else => (try sema.resolveLazyValue(Value.fromInterned(ptr.len))).toIntern(),
             };
             switch (ptr.addr) {
                 .decl, .mut_decl, .anon_decl => return if (resolved_len == ptr.len)
                     val
                 else
-                    (try mod.intern(.{ .ptr = .{
+                    Value.fromInterned((try mod.intern(.{ .ptr = .{
                         .ty = ptr.ty,
                         .addr = switch (ptr.addr) {
                             .decl => |decl| .{ .decl = decl },
@@ -34502,36 +34502,36 @@ fn resolveLazyValue(sema: *Sema, val: Value) CompileError!Value {
                             else => unreachable,
                         },
                         .len = resolved_len,
-                    } })).toValue(),
+                    } }))),
                 .comptime_field => |field_val| {
                     const resolved_field_val =
-                        (try sema.resolveLazyValue(field_val.toValue())).toIntern();
+                        (try sema.resolveLazyValue(Value.fromInterned(field_val))).toIntern();
                     return if (resolved_field_val == field_val and resolved_len == ptr.len)
                         val
                     else
-                        (try mod.intern(.{ .ptr = .{
+                        Value.fromInterned((try mod.intern(.{ .ptr = .{
                             .ty = ptr.ty,
                             .addr = .{ .comptime_field = resolved_field_val },
                             .len = resolved_len,
-                        } })).toValue();
+                        } })));
                 },
                 .int => |int| {
-                    const resolved_int = (try sema.resolveLazyValue(int.toValue())).toIntern();
+                    const resolved_int = (try sema.resolveLazyValue(Value.fromInterned(int))).toIntern();
                     return if (resolved_int == int and resolved_len == ptr.len)
                         val
                     else
-                        (try mod.intern(.{ .ptr = .{
+                        Value.fromInterned((try mod.intern(.{ .ptr = .{
                             .ty = ptr.ty,
                             .addr = .{ .int = resolved_int },
                             .len = resolved_len,
-                        } })).toValue();
+                        } })));
                 },
                 .eu_payload, .opt_payload => |base| {
-                    const resolved_base = (try sema.resolveLazyValue(base.toValue())).toIntern();
+                    const resolved_base = (try sema.resolveLazyValue(Value.fromInterned(base))).toIntern();
                     return if (resolved_base == base and resolved_len == ptr.len)
                         val
                     else
-                        (try mod.intern(.{ .ptr = .{
+                        Value.fromInterned((try mod.intern(.{ .ptr = .{
                             .ty = ptr.ty,
                             .addr = switch (ptr.addr) {
                                 .eu_payload => .{ .eu_payload = resolved_base },
@@ -34539,14 +34539,14 @@ fn resolveLazyValue(sema: *Sema, val: Value) CompileError!Value {
                                 else => unreachable,
                             },
                             .len = ptr.len,
-                        } })).toValue();
+                        } })));
                 },
                 .elem, .field => |base_index| {
-                    const resolved_base = (try sema.resolveLazyValue(base_index.base.toValue())).toIntern();
+                    const resolved_base = (try sema.resolveLazyValue(Value.fromInterned(base_index.base))).toIntern();
                     return if (resolved_base == base_index.base and resolved_len == ptr.len)
                         val
                     else
-                        (try mod.intern(.{ .ptr = .{
+                        Value.fromInterned((try mod.intern(.{ .ptr = .{
                             .ty = ptr.ty,
                             .addr = switch (ptr.addr) {
                                 .elem => .{ .elem = .{
@@ -34560,7 +34560,7 @@ fn resolveLazyValue(sema: *Sema, val: Value) CompileError!Value {
                                 else => unreachable,
                             },
                             .len = ptr.len,
-                        } })).toValue();
+                        } })));
                 },
             }
         },
@@ -34569,37 +34569,37 @@ fn resolveLazyValue(sema: *Sema, val: Value) CompileError!Value {
             .elems => |elems| {
                 var resolved_elems: []InternPool.Index = &.{};
                 for (elems, 0..) |elem, i| {
-                    const resolved_elem = (try sema.resolveLazyValue(elem.toValue())).toIntern();
+                    const resolved_elem = (try sema.resolveLazyValue(Value.fromInterned(elem))).toIntern();
                     if (resolved_elems.len == 0 and resolved_elem != elem) {
                         resolved_elems = try sema.arena.alloc(InternPool.Index, elems.len);
                         @memcpy(resolved_elems[0..i], elems[0..i]);
                     }
                     if (resolved_elems.len > 0) resolved_elems[i] = resolved_elem;
                 }
-                return if (resolved_elems.len == 0) val else (try mod.intern(.{ .aggregate = .{
+                return if (resolved_elems.len == 0) val else Value.fromInterned((try mod.intern(.{ .aggregate = .{
                     .ty = aggregate.ty,
                     .storage = .{ .elems = resolved_elems },
-                } })).toValue();
+                } })));
             },
             .repeated_elem => |elem| {
-                const resolved_elem = (try sema.resolveLazyValue(elem.toValue())).toIntern();
-                return if (resolved_elem == elem) val else (try mod.intern(.{ .aggregate = .{
+                const resolved_elem = (try sema.resolveLazyValue(Value.fromInterned(elem))).toIntern();
+                return if (resolved_elem == elem) val else Value.fromInterned((try mod.intern(.{ .aggregate = .{
                     .ty = aggregate.ty,
                     .storage = .{ .repeated_elem = resolved_elem },
-                } })).toValue();
+                } })));
             },
         },
         .un => |un| {
-            const resolved_tag = (try sema.resolveLazyValue(un.tag.toValue())).toIntern();
-            const resolved_val = (try sema.resolveLazyValue(un.val.toValue())).toIntern();
+            const resolved_tag = (try sema.resolveLazyValue(Value.fromInterned(un.tag))).toIntern();
+            const resolved_val = (try sema.resolveLazyValue(Value.fromInterned(un.val))).toIntern();
             return if (resolved_tag == un.tag and resolved_val == un.val)
                 val
             else
-                (try mod.intern(.{ .un = .{
+                Value.fromInterned((try mod.intern(.{ .un = .{
                     .ty = un.ty,
                     .tag = resolved_tag,
                     .val = resolved_val,
-                } })).toValue();
+                } })));
         },
         else => return val,
     }
@@ -34641,9 +34641,9 @@ pub fn resolveTypeLayout(sema: *Sema, ty: Type) CompileError!void {
             const ip = &mod.intern_pool;
             for (0..info.param_types.len) |i| {
                 const param_ty = info.param_types.get(ip)[i];
-                try sema.resolveTypeLayout(param_ty.toType());
+                try sema.resolveTypeLayout(Type.fromInterned(param_ty));
             }
-            try sema.resolveTypeLayout(info.return_type.toType());
+            try sema.resolveTypeLayout(Type.fromInterned(info.return_type));
         },
         else => {},
     }
@@ -34689,7 +34689,7 @@ pub fn resolveStructAlignment(
     var result: Alignment = .@"1";
 
     for (0..struct_type.field_types.len) |i| {
-        const field_ty = struct_type.field_types.get(ip)[i].toType();
+        const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
         if (struct_type.fieldIsComptime(ip, i) or try sema.typeRequiresComptime(field_ty))
             continue;
         const field_align = try sema.structFieldAlignment(
@@ -34736,7 +34736,7 @@ fn resolveStructLayout(sema: *Sema, ty: Type) CompileError!void {
     var big_align: Alignment = .@"1";
 
     for (aligns, sizes, 0..) |*field_align, *field_size, i| {
-        const field_ty = struct_type.field_types.get(ip)[i].toType();
+        const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
         if (struct_type.fieldIsComptime(ip, i) or try sema.typeRequiresComptime(field_ty)) {
             struct_type.offsets.get(ip)[i] = 0;
             field_size.* = 0;
@@ -34786,7 +34786,7 @@ fn resolveStructLayout(sema: *Sema, ty: Type) CompileError!void {
         const runtime_order = struct_type.runtime_order.get(ip);
 
         for (runtime_order, 0..) |*ro, i| {
-            const field_ty = struct_type.field_types.get(ip)[i].toType();
+            const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
             if (struct_type.fieldIsComptime(ip, i) or try sema.typeRequiresComptime(field_ty)) {
                 ro.* = .omitted;
             } else {
@@ -34892,7 +34892,7 @@ fn semaBackingIntType(mod: *Module, struct_type: InternPool.Key.StructType) Comp
     const fields_bit_sum = blk: {
         var accumulator: u64 = 0;
         for (0..struct_type.field_types.len) |i| {
-            const field_ty = struct_type.field_types.get(ip)[i].toType();
+            const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
             accumulator += try field_ty.bitSizeAdvanced(mod, &sema);
         }
         break :blk accumulator;
@@ -35018,7 +35018,7 @@ pub fn resolveUnionAlignment(
     const union_obj = ip.loadUnionType(union_type);
     var max_align: Alignment = .@"1";
     for (0..union_obj.field_names.len) |field_index| {
-        const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+        const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
         if (!(try sema.typeHasRuntimeBits(field_ty))) continue;
 
         const explicit_align = union_obj.fieldAlign(ip, @intCast(field_index));
@@ -35067,7 +35067,7 @@ fn resolveUnionLayout(sema: *Sema, ty: Type) CompileError!void {
     var max_size: u64 = 0;
     var max_align: Alignment = .@"1";
     for (0..union_obj.field_names.len) |field_index| {
-        const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+        const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
         if (!(try sema.typeHasRuntimeBits(field_ty))) continue;
 
         max_size = @max(max_size, sema.typeAbiSize(field_ty) catch |err| switch (err) {
@@ -35089,9 +35089,9 @@ fn resolveUnionLayout(sema: *Sema, ty: Type) CompileError!void {
     }
 
     const flags = union_obj.flagsPtr(ip);
-    const has_runtime_tag = flags.runtime_tag.hasTag() and try sema.typeHasRuntimeBits(union_obj.enum_tag_ty.toType());
+    const has_runtime_tag = flags.runtime_tag.hasTag() and try sema.typeHasRuntimeBits(Type.fromInterned(union_obj.enum_tag_ty));
     const size, const alignment, const padding = if (has_runtime_tag) layout: {
-        const enum_tag_type = union_obj.enum_tag_ty.toType();
+        const enum_tag_type = Type.fromInterned(union_obj.enum_tag_ty);
         const tag_align = try sema.typeAbiAlignment(enum_tag_type);
         const tag_size = try sema.typeAbiSize(enum_tag_type);
 
@@ -35161,7 +35161,7 @@ pub fn resolveTypeFully(sema: *Sema, ty: Type) CompileError!void {
             .struct_type => return sema.resolveStructFully(ty),
             .anon_struct_type => |tuple| {
                 for (tuple.types.get(ip)) |field_ty| {
-                    try sema.resolveTypeFully(field_ty.toType());
+                    try sema.resolveTypeFully(Type.fromInterned(field_ty));
                 }
             },
             .simple_type => |simple_type| try sema.resolveSimpleType(simple_type),
@@ -35182,9 +35182,9 @@ pub fn resolveTypeFully(sema: *Sema, ty: Type) CompileError!void {
             }
             for (0..info.param_types.len) |i| {
                 const param_ty = info.param_types.get(ip)[i];
-                try sema.resolveTypeFully(param_ty.toType());
+                try sema.resolveTypeFully(Type.fromInterned(param_ty));
             }
-            try sema.resolveTypeFully(info.return_type.toType());
+            try sema.resolveTypeFully(Type.fromInterned(info.return_type));
         },
         else => {},
     }
@@ -35205,7 +35205,7 @@ fn resolveStructFully(sema: *Sema, ty: Type) CompileError!void {
     // See also similar code for unions.
 
     for (0..struct_type.field_types.len) |i| {
-        const field_ty = struct_type.field_types.get(ip)[i].toType();
+        const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
         try sema.resolveTypeFully(field_ty);
     }
 }
@@ -35230,7 +35230,7 @@ fn resolveUnionFully(sema: *Sema, ty: Type) CompileError!void {
 
         union_obj.flagsPtr(ip).status = .fully_resolved_wip;
         for (0..union_obj.field_types.len) |field_index| {
-            const field_ty = union_obj.field_types.get(ip)[field_index].toType();
+            const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
             try sema.resolveTypeFully(field_ty);
         }
         union_obj.flagsPtr(ip).status = .fully_resolved;
@@ -35333,7 +35333,7 @@ pub fn resolveTypeFields(sema: *Sema, ty: Type) CompileError!void {
             .type_struct_packed_inits,
             => try sema.resolveTypeFieldsStruct(ty_ip, ip.indexToKey(ty_ip).struct_type),
 
-            .type_union => try sema.resolveTypeFieldsUnion(ty_ip.toType(), ip.indexToKey(ty_ip).union_type),
+            .type_union => try sema.resolveTypeFieldsUnion(Type.fromInterned(ty_ip), ip.indexToKey(ty_ip).union_type),
             .simple_type => try sema.resolveSimpleType(ip.indexToKey(ty_ip).simple_type),
             else => {},
         },
@@ -35392,7 +35392,7 @@ pub fn resolveTypeFieldsStruct(
             sema.gpa,
             mod.declPtr(owner_decl).srcLoc(mod),
             "struct '{}' depends on itself",
-            .{ty.toType().fmt(mod)},
+            .{Type.fromInterned(ty).fmt(mod)},
         );
         return sema.failWithOwnedErrorMsg(null, msg);
     }
@@ -36042,7 +36042,7 @@ fn semaStructFieldInits(
             // In init bodies, the zir index of the struct itself is used
             // to refer to the current field type.
 
-            const field_ty = struct_type.field_types.get(ip)[field_i].toType();
+            const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[field_i]);
             const type_ref = Air.internedToRef(field_ty.toIntern());
             try sema.inst_map.ensureSpaceForInstructions(sema.gpa, &.{zir_index});
             sema.inst_map.putAssumeCapacity(zir_index, type_ref);
@@ -36368,10 +36368,10 @@ fn semaUnionFields(mod: *Module, arena: Allocator, union_type: InternPool.Key.Un
                         .range = .type,
                     }).lazy;
                     const msg = try sema.errMsg(&block_scope, ty_src, "no field named '{}' in enum '{}'", .{
-                        field_name.fmt(ip), union_type.tagTypePtr(ip).toType().fmt(mod),
+                        field_name.fmt(ip), Type.fromInterned(union_type.tagTypePtr(ip).*).fmt(mod),
                     });
                     errdefer msg.destroy(sema.gpa);
-                    try sema.addDeclaredHereNote(msg, union_type.tagTypePtr(ip).toType());
+                    try sema.addDeclaredHereNote(msg, Type.fromInterned(union_type.tagTypePtr(ip).*));
                     break :msg msg;
                 };
                 return sema.failWithOwnedErrorMsg(&block_scope, msg);
@@ -36483,11 +36483,11 @@ fn semaUnionFields(mod: *Module, arena: Allocator, union_type: InternPool.Key.Un
 
                 for (tag_info.names.get(ip), 0..) |field_name, field_index| {
                     if (explicit_tags_seen[field_index]) continue;
-                    try sema.addFieldErrNote(union_type.tagTypePtr(ip).toType(), field_index, msg, "field '{}' missing, declared here", .{
+                    try sema.addFieldErrNote(Type.fromInterned(union_type.tagTypePtr(ip).*), field_index, msg, "field '{}' missing, declared here", .{
                         field_name.fmt(ip),
                     });
                 }
-                try sema.addDeclaredHereNote(msg, union_type.tagTypePtr(ip).toType());
+                try sema.addDeclaredHereNote(msg, Type.fromInterned(union_type.tagTypePtr(ip).*));
                 break :msg msg;
             };
             return sema.failWithOwnedErrorMsg(&block_scope, msg);
@@ -36548,7 +36548,7 @@ fn generateUnionTagTypeNumbered(
     });
 
     new_decl.ty = Type.type;
-    new_decl.val = enum_ty.toValue();
+    new_decl.val = Value.fromInterned(enum_ty);
 
     try mod.finalizeAnonDecl(new_decl_index);
     return enum_ty;
@@ -36600,7 +36600,7 @@ fn generateUnionTagTypeSimple(
     const new_decl = mod.declPtr(new_decl_index);
     new_decl.owns_tv = true;
     new_decl.ty = Type.type;
-    new_decl.val = enum_ty.toValue();
+    new_decl.val = Value.fromInterned(enum_ty);
 
     try mod.finalizeAnonDecl(new_decl_index);
     return enum_ty;
@@ -36869,16 +36869,16 @@ pub fn typeHasOnePossibleValue(sema: *Sema, ty: Type) CompileError!?Value {
             => switch (ip.indexToKey(ty.toIntern())) {
                 inline .array_type, .vector_type => |seq_type, seq_tag| {
                     const has_sentinel = seq_tag == .array_type and seq_type.sentinel != .none;
-                    if (seq_type.len + @intFromBool(has_sentinel) == 0) return (try mod.intern(.{ .aggregate = .{
+                    if (seq_type.len + @intFromBool(has_sentinel) == 0) return Value.fromInterned((try mod.intern(.{ .aggregate = .{
                         .ty = ty.toIntern(),
                         .storage = .{ .elems = &.{} },
-                    } })).toValue();
+                    } })));
 
-                    if (try sema.typeHasOnePossibleValue(seq_type.child.toType())) |opv| {
-                        return (try mod.intern(.{ .aggregate = .{
+                    if (try sema.typeHasOnePossibleValue(Type.fromInterned(seq_type.child))) |opv| {
+                        return Value.fromInterned((try mod.intern(.{ .aggregate = .{
                             .ty = ty.toIntern(),
                             .storage = .{ .repeated_elem = opv.toIntern() },
-                        } })).toValue();
+                        } })));
                     }
                     return null;
                 },
@@ -36889,10 +36889,10 @@ pub fn typeHasOnePossibleValue(sema: *Sema, ty: Type) CompileError!?Value {
                     if (struct_type.field_types.len == 0) {
                         // In this case the struct has no fields at all and
                         // therefore has one possible value.
-                        return (try mod.intern(.{ .aggregate = .{
+                        return Value.fromInterned((try mod.intern(.{ .aggregate = .{
                             .ty = ty.toIntern(),
                             .storage = .{ .elems = &.{} },
-                        } })).toValue();
+                        } })));
                     }
 
                     const field_vals = try sema.arena.alloc(
@@ -36905,7 +36905,7 @@ pub fn typeHasOnePossibleValue(sema: *Sema, ty: Type) CompileError!?Value {
                             field_val.* = struct_type.field_inits.get(ip)[i];
                             continue;
                         }
-                        const field_ty = struct_type.field_types.get(ip)[i].toType();
+                        const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
                         if (field_ty.eql(ty, mod)) {
                             const msg = try Module.ErrorMsg.create(
                                 sema.gpa,
@@ -36923,10 +36923,10 @@ pub fn typeHasOnePossibleValue(sema: *Sema, ty: Type) CompileError!?Value {
 
                     // In this case the struct has no runtime-known fields and
                     // therefore has one possible value.
-                    return (try mod.intern(.{ .aggregate = .{
+                    return Value.fromInterned((try mod.intern(.{ .aggregate = .{
                         .ty = ty.toIntern(),
                         .storage = .{ .elems = field_vals },
-                    } })).toValue();
+                    } })));
                 },
 
                 .anon_struct_type => |tuple| {
@@ -36936,22 +36936,22 @@ pub fn typeHasOnePossibleValue(sema: *Sema, ty: Type) CompileError!?Value {
                     // In this case the struct has all comptime-known fields and
                     // therefore has one possible value.
                     // TODO: write something like getCoercedInts to avoid needing to dupe
-                    return (try mod.intern(.{ .aggregate = .{
+                    return Value.fromInterned((try mod.intern(.{ .aggregate = .{
                         .ty = ty.toIntern(),
                         .storage = .{ .elems = try sema.arena.dupe(InternPool.Index, tuple.values.get(ip)) },
-                    } })).toValue();
+                    } })));
                 },
 
                 .union_type => |union_type| {
                     try sema.resolveTypeFields(ty);
                     const union_obj = ip.loadUnionType(union_type);
-                    const tag_val = (try sema.typeHasOnePossibleValue(union_obj.enum_tag_ty.toType())) orelse
+                    const tag_val = (try sema.typeHasOnePossibleValue(Type.fromInterned(union_obj.enum_tag_ty))) orelse
                         return null;
                     if (union_obj.field_types.len == 0) {
                         const only = try mod.intern(.{ .empty_enum_value = ty.toIntern() });
-                        return only.toValue();
+                        return Value.fromInterned(only);
                     }
-                    const only_field_ty = union_obj.field_types.get(ip)[0].toType();
+                    const only_field_ty = Type.fromInterned(union_obj.field_types.get(ip)[0]);
                     if (only_field_ty.eql(ty, mod)) {
                         const msg = try Module.ErrorMsg.create(
                             sema.gpa,
@@ -36969,32 +36969,32 @@ pub fn typeHasOnePossibleValue(sema: *Sema, ty: Type) CompileError!?Value {
                         .tag = tag_val.toIntern(),
                         .val = val_val.toIntern(),
                     } });
-                    return only.toValue();
+                    return Value.fromInterned(only);
                 },
 
                 .enum_type => |enum_type| switch (enum_type.tag_mode) {
                     .nonexhaustive => {
                         if (enum_type.tag_ty == .comptime_int_type) return null;
 
-                        if (try sema.typeHasOnePossibleValue(enum_type.tag_ty.toType())) |int_opv| {
+                        if (try sema.typeHasOnePossibleValue(Type.fromInterned(enum_type.tag_ty))) |int_opv| {
                             const only = try mod.intern(.{ .enum_tag = .{
                                 .ty = ty.toIntern(),
                                 .int = int_opv.toIntern(),
                             } });
-                            return only.toValue();
+                            return Value.fromInterned(only);
                         }
 
                         return null;
                     },
                     .auto, .explicit => {
-                        if (enum_type.tag_ty.toType().hasRuntimeBits(mod)) return null;
+                        if (Type.fromInterned(enum_type.tag_ty).hasRuntimeBits(mod)) return null;
 
-                        return switch (enum_type.names.len) {
+                        return Value.fromInterned(switch (enum_type.names.len) {
                             0 => try mod.intern(.{ .empty_enum_value = ty.toIntern() }),
                             1 => try mod.intern(.{ .enum_tag = .{
                                 .ty = ty.toIntern(),
                                 .int = if (enum_type.values.len == 0)
-                                    (try mod.intValue(enum_type.tag_ty.toType(), 0)).toIntern()
+                                    (try mod.intValue(Type.fromInterned(enum_type.tag_ty), 0)).toIntern()
                                 else
                                     try mod.intern_pool.getCoercedInts(
                                         mod.gpa,
@@ -37003,7 +37003,7 @@ pub fn typeHasOnePossibleValue(sema: *Sema, ty: Type) CompileError!?Value {
                                     ),
                             } }),
                             else => return null,
-                        }.toValue();
+                        });
                     },
                 },
 
@@ -37092,7 +37092,7 @@ fn analyzeComptimeAlloc(
         // There will be stores before the first load, but they may be to sub-elements or
         // sub-fields. So we need to initialize with undef to allow the mechanism to expand
         // into fields/elements and have those overridden with stored values.
-        (try mod.intern(.{ .undef = var_type.toIntern() })).toValue(),
+        Value.fromInterned((try mod.intern(.{ .undef = var_type.toIntern() }))),
         alignment,
     );
     const decl = mod.declPtr(decl_index);
@@ -37226,7 +37226,7 @@ fn pointerDerefExtra(sema: *Sema, block: *Block, src: LazySrcLoc, ptr_val: Value
             // Move mutable decl values to the InternPool and assert other decls are already in
             // the InternPool.
             const uncoerced_val = if (deref.is_mutable) try tv.val.intern(tv.ty, mod) else tv.val.toIntern();
-            const coerced_val = try mod.getCoerced(uncoerced_val.toValue(), load_ty);
+            const coerced_val = try mod.getCoerced(Value.fromInterned(uncoerced_val), load_ty);
             return .{ .val = coerced_val };
         }
     }
@@ -37284,7 +37284,7 @@ fn typePtrOrOptionalPtrTy(sema: *Sema, ty: Type) !?Type {
                     if (ptr_type.flags.is_allowzero) return null;
 
                     // optionals of zero sized types behave like bools, not pointers
-                    const payload_ty = opt_child.toType();
+                    const payload_ty = Type.fromInterned(opt_child);
                     if ((try sema.typeHasOnePossibleValue(payload_ty)) != null) {
                         return null;
                     }
@@ -37328,7 +37328,7 @@ fn unionFieldAlignment(sema: *Sema, u: InternPool.UnionType, field_index: u32) !
     const ip = &mod.intern_pool;
     const field_align = u.fieldAlign(ip, field_index);
     if (field_align != .none) return field_align;
-    const field_ty = u.field_types.get(ip)[field_index].toType();
+    const field_ty = Type.fromInterned(u.field_types.get(ip)[field_index]);
     if (field_ty.isNoReturn(sema.mod)) return .none;
     return sema.typeAbiAlignment(field_ty);
 }
@@ -37458,10 +37458,10 @@ fn intAddInner(sema: *Sema, lhs: Value, rhs: Value, ty: Type, overflow_idx: *usi
             };
             scalar.* = try val.intern(scalar_ty, mod);
         }
-        return (try mod.intern(.{ .aggregate = .{
+        return Value.fromInterned((try mod.intern(.{ .aggregate = .{
             .ty = ty.toIntern(),
             .storage = .{ .elems = result_data },
-        } })).toValue();
+        } })));
     }
     return sema.intAddScalar(lhs, rhs, ty);
 }
@@ -37548,10 +37548,10 @@ fn intSubInner(sema: *Sema, lhs: Value, rhs: Value, ty: Type, overflow_idx: *usi
             };
             scalar.* = try val.intern(scalar_ty, mod);
         }
-        return (try mod.intern(.{ .aggregate = .{
+        return Value.fromInterned((try mod.intern(.{ .aggregate = .{
             .ty = ty.toIntern(),
             .storage = .{ .elems = result_data },
-        } })).toValue();
+        } })));
     }
     return sema.intSubScalar(lhs, rhs, ty);
 }
@@ -37620,14 +37620,14 @@ fn intSubWithOverflow(
             scalar.* = try of_math_result.wrapped_result.intern(scalar_ty, mod);
         }
         return Value.OverflowArithmeticResult{
-            .overflow_bit = (try mod.intern(.{ .aggregate = .{
+            .overflow_bit = Value.fromInterned((try mod.intern(.{ .aggregate = .{
                 .ty = (try mod.vectorType(.{ .len = vec_len, .child = .u1_type })).toIntern(),
                 .storage = .{ .elems = overflowed_data },
-            } })).toValue(),
-            .wrapped_result = (try mod.intern(.{ .aggregate = .{
+            } }))),
+            .wrapped_result = Value.fromInterned((try mod.intern(.{ .aggregate = .{
                 .ty = ty.toIntern(),
                 .storage = .{ .elems = result_data },
-            } })).toValue(),
+            } }))),
         };
     }
     return sema.intSubWithOverflowScalar(lhs, rhs, ty);
@@ -37679,10 +37679,10 @@ fn intFromFloat(
             const elem_val = try val.elemValue(sema.mod, i);
             scalar.* = try (try sema.intFromFloatScalar(block, src, elem_val, elem_ty, int_ty.scalarType(mod), mode)).intern(scalar_ty, mod);
         }
-        return (try mod.intern(.{ .aggregate = .{
+        return Value.fromInterned((try mod.intern(.{ .aggregate = .{
             .ty = int_ty.toIntern(),
             .storage = .{ .elems = result_data },
-        } })).toValue();
+        } })));
     }
     return sema.intFromFloatScalar(block, src, val, float_ty, int_ty, mode);
 }
@@ -37792,7 +37792,7 @@ fn intFitsInType(
                     const max_needed_bits = @as(u16, 16) + @intFromBool(info.signedness == .signed);
                     // If it is u16 or bigger we know the alignment fits without resolving it.
                     if (info.bits >= max_needed_bits) return true;
-                    const x = try sema.typeAbiAlignment(lazy_ty.toType());
+                    const x = try sema.typeAbiAlignment(Type.fromInterned(lazy_ty));
                     if (x == .none) return true;
                     const actual_needed_bits = @as(usize, x.toLog2Units()) + 1 + @intFromBool(info.signedness == .signed);
                     return info.bits >= actual_needed_bits;
@@ -37801,7 +37801,7 @@ fn intFitsInType(
                     const max_needed_bits = @as(u16, 64) + @intFromBool(info.signedness == .signed);
                     // If it is u64 or bigger we know the size fits without resolving it.
                     if (info.bits >= max_needed_bits) return true;
-                    const x = try sema.typeAbiSize(lazy_ty.toType());
+                    const x = try sema.typeAbiSize(Type.fromInterned(lazy_ty));
                     if (x == 0) return true;
                     const actual_needed_bits = std.math.log2(x) + 1 + @intFromBool(info.signedness == .signed);
                     return info.bits >= actual_needed_bits;
@@ -37822,7 +37822,7 @@ fn intFitsInType(
                         .elems => |elems| elems,
                         .repeated_elem => |elem| @as(*const [1]InternPool.Index, &elem),
                     }, 0..) |elem, i| {
-                        if (try sema.intFitsInType(elem.toValue(), ty.scalarType(mod), null)) continue;
+                        if (try sema.intFitsInType(Value.fromInterned(elem), ty.scalarType(mod), null)) continue;
                         if (vector_index) |vi| vi.* = i;
                         break false;
                     } else true,
@@ -37848,8 +37848,8 @@ fn enumHasInt(sema: *Sema, ty: Type, int: Value) CompileError!bool {
     assert(enum_type.tag_mode != .nonexhaustive);
     // The `tagValueIndex` function call below relies on the type being the integer tag type.
     // `getCoerced` assumes the value will fit the new type.
-    if (!(try sema.intFitsInType(int, enum_type.tag_ty.toType(), null))) return false;
-    const int_coerced = try mod.getCoerced(int, enum_type.tag_ty.toType());
+    if (!(try sema.intFitsInType(int, Type.fromInterned(enum_type.tag_ty), null))) return false;
+    const int_coerced = try mod.getCoerced(int, Type.fromInterned(enum_type.tag_ty));
 
     return enum_type.tagValueIndex(&mod.intern_pool, int_coerced.toIntern()) != null;
 }
@@ -37874,14 +37874,14 @@ fn intAddWithOverflow(
             scalar.* = try of_math_result.wrapped_result.intern(scalar_ty, mod);
         }
         return Value.OverflowArithmeticResult{
-            .overflow_bit = (try mod.intern(.{ .aggregate = .{
+            .overflow_bit = Value.fromInterned((try mod.intern(.{ .aggregate = .{
                 .ty = (try mod.vectorType(.{ .len = vec_len, .child = .u1_type })).toIntern(),
                 .storage = .{ .elems = overflowed_data },
-            } })).toValue(),
-            .wrapped_result = (try mod.intern(.{ .aggregate = .{
+            } }))),
+            .wrapped_result = Value.fromInterned((try mod.intern(.{ .aggregate = .{
                 .ty = ty.toIntern(),
                 .storage = .{ .elems = result_data },
-            } })).toValue(),
+            } }))),
         };
     }
     return sema.intAddWithOverflowScalar(lhs, rhs, ty);
@@ -37983,10 +37983,10 @@ fn compareVector(
         const res_bool = try sema.compareScalar(lhs_elem, op, rhs_elem, ty.scalarType(mod));
         scalar.* = try Value.makeBool(res_bool).intern(Type.bool, mod);
     }
-    return (try mod.intern(.{ .aggregate = .{
+    return Value.fromInterned((try mod.intern(.{ .aggregate = .{
         .ty = (try mod.vectorType(.{ .len = ty.vectorLen(mod), .child = .bool_type })).toIntern(),
         .storage = .{ .elems = result_data },
-    } })).toValue();
+    } })));
 }
 
 /// Returns the type of a pointer to an element.
@@ -38102,7 +38102,7 @@ fn isKnownZigType(sema: *Sema, ref: Air.Inst.Ref, tag: std.builtin.TypeId) bool 
 
 fn ptrType(sema: *Sema, info: InternPool.Key.PtrType) CompileError!Type {
     if (info.flags.alignment != .none) {
-        _ = try sema.typeAbiAlignment(info.child.toType());
+        _ = try sema.typeAbiAlignment(Type.fromInterned(info.child));
     }
     return sema.mod.ptrType(info);
 }

--- a/src/arch/aarch64/abi.zig
+++ b/src/arch/aarch64/abi.zig
@@ -83,7 +83,7 @@ fn countFloats(ty: Type, mod: *Module, maybe_float_bits: *?u16) u8 {
             const union_obj = mod.typeToUnion(ty).?;
             var max_count: u8 = 0;
             for (union_obj.field_types.get(ip)) |field_ty| {
-                const field_count = countFloats(field_ty.toType(), mod, maybe_float_bits);
+                const field_count = countFloats(Type.fromInterned(field_ty), mod, maybe_float_bits);
                 if (field_count == invalid) return invalid;
                 if (field_count > max_count) max_count = field_count;
                 if (max_count > sret_float_count) return invalid;
@@ -122,7 +122,7 @@ pub fn getFloatArrayType(ty: Type, mod: *Module) ?Type {
         .Union => {
             const union_obj = mod.typeToUnion(ty).?;
             for (union_obj.field_types.get(ip)) |field_ty| {
-                if (getFloatArrayType(field_ty.toType(), mod)) |some| return some;
+                if (getFloatArrayType(Type.fromInterned(field_ty), mod)) |some| return some;
             }
             return null;
         },

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -6209,10 +6209,10 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
             }
 
             for (fn_info.param_types.get(ip), result.args) |ty, *result_arg| {
-                if (ty.toType().abiAlignment(mod) == .@"8")
+                if (Type.fromInterned(ty).abiAlignment(mod) == .@"8")
                     ncrn = std.mem.alignForward(usize, ncrn, 2);
 
-                const param_size = @as(u32, @intCast(ty.toType().abiSize(mod)));
+                const param_size = @as(u32, @intCast(Type.fromInterned(ty).abiSize(mod)));
                 if (std.math.divCeil(u32, param_size, 4) catch unreachable <= 4 - ncrn) {
                     if (param_size <= 4) {
                         result_arg.* = .{ .register = c_abi_int_param_regs[ncrn] };
@@ -6224,7 +6224,7 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
                     return self.fail("TODO MCValues split between registers and stack", .{});
                 } else {
                     ncrn = 4;
-                    if (ty.toType().abiAlignment(mod) == .@"8")
+                    if (Type.fromInterned(ty).abiAlignment(mod) == .@"8")
                         nsaa = std.mem.alignForward(u32, nsaa, 8);
 
                     result_arg.* = .{ .stack_argument_offset = nsaa };
@@ -6259,9 +6259,9 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
             var stack_offset: u32 = 0;
 
             for (fn_info.param_types.get(ip), result.args) |ty, *result_arg| {
-                if (ty.toType().abiSize(mod) > 0) {
-                    const param_size: u32 = @intCast(ty.toType().abiSize(mod));
-                    const param_alignment = ty.toType().abiAlignment(mod);
+                if (Type.fromInterned(ty).abiSize(mod) > 0) {
+                    const param_size: u32 = @intCast(Type.fromInterned(ty).abiSize(mod));
+                    const param_alignment = Type.fromInterned(ty).abiAlignment(mod);
 
                     stack_offset = @intCast(param_alignment.forward(stack_offset));
                     result_arg.* = .{ .stack_argument_offset = stack_offset };

--- a/src/arch/arm/abi.zig
+++ b/src/arch/arm/abi.zig
@@ -65,7 +65,7 @@ pub fn classifyType(ty: Type, mod: *Module, ctx: Context) Class {
             if (float_count <= byval_float_count) return .byval;
 
             for (union_obj.field_types.get(ip), 0..) |field_ty, field_index| {
-                if (field_ty.toType().bitSize(mod) > 32 or
+                if (Type.fromInterned(field_ty).bitSize(mod) > 32 or
                     mod.unionFieldNormalAlignment(union_obj, @intCast(field_index)).compare(.gt, .@"32"))
                 {
                     return Class.arrSize(bit_size, 64);
@@ -129,7 +129,7 @@ fn countFloats(ty: Type, mod: *Module, maybe_float_bits: *?u16) u32 {
             const union_obj = mod.typeToUnion(ty).?;
             var max_count: u32 = 0;
             for (union_obj.field_types.get(ip)) |field_ty| {
-                const field_count = countFloats(field_ty.toType(), mod, maybe_float_bits);
+                const field_count = countFloats(Type.fromInterned(field_ty), mod, maybe_float_bits);
                 if (field_count == invalid) return invalid;
                 if (field_count > max_count) max_count = field_count;
                 if (max_count > byval_float_count) return invalid;

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -2656,7 +2656,7 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
             const argument_registers = [_]Register{ .a0, .a1, .a2, .a3, .a4, .a5, .a6, .a7 };
 
             for (fn_info.param_types.get(ip), result.args) |ty, *result_arg| {
-                const param_size = @as(u32, @intCast(ty.toType().abiSize(mod)));
+                const param_size = @as(u32, @intCast(Type.fromInterned(ty).abiSize(mod)));
                 if (param_size <= 8) {
                     if (next_register < argument_registers.len) {
                         result_arg.* = .{ .register = argument_registers[next_register] };

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -4493,7 +4493,7 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type, role: RegisterView) 
             };
 
             for (fn_info.param_types.get(ip), result.args) |ty, *result_arg| {
-                const param_size = @as(u32, @intCast(ty.toType().abiSize(mod)));
+                const param_size = @as(u32, @intCast(Type.fromInterned(ty).abiSize(mod)));
                 if (param_size <= 8) {
                     if (next_register < argument_registers.len) {
                         result_arg.* = .{ .register = argument_registers[next_register] };

--- a/src/arch/wasm/abi.zig
+++ b/src/arch/wasm/abi.zig
@@ -37,7 +37,7 @@ pub fn classifyType(ty: Type, mod: *Module) [2]Class {
                 // The struct type is non-scalar.
                 return memory;
             }
-            const field_ty = struct_type.field_types.get(ip)[0].toType();
+            const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[0]);
             const explicit_align = struct_type.fieldAlign(ip, 0);
             if (explicit_align != .none) {
                 if (explicit_align.compareStrict(.gt, field_ty.abiAlignment(mod)))
@@ -76,7 +76,7 @@ pub fn classifyType(ty: Type, mod: *Module) [2]Class {
             const layout = ty.unionGetLayout(mod);
             assert(layout.tag_size == 0);
             if (union_obj.field_names.len > 1) return memory;
-            const first_field_ty = union_obj.field_types.get(ip)[0].toType();
+            const first_field_ty = Type.fromInterned(union_obj.field_types.get(ip)[0]);
             return classifyType(first_field_ty, mod);
         },
         .ErrorUnion,
@@ -104,7 +104,7 @@ pub fn scalarType(ty: Type, mod: *Module) Type {
     switch (ty.zigTypeTag(mod)) {
         .Struct => {
             if (mod.typeToPackedStruct(ty)) |packed_struct| {
-                return scalarType(packed_struct.backingIntType(ip).toType(), mod);
+                return scalarType(Type.fromInterned(packed_struct.backingIntType(ip).*), mod);
             } else {
                 assert(ty.structFieldCount(mod) == 1);
                 return scalarType(ty.structFieldType(0, mod), mod);
@@ -119,7 +119,7 @@ pub fn scalarType(ty: Type, mod: *Module) Type {
                 }
                 assert(union_obj.field_types.len == 1);
             }
-            const first_field_ty = union_obj.field_types.get(ip)[0].toType();
+            const first_field_ty = Type.fromInterned(union_obj.field_types.get(ip)[0]);
             return scalarType(first_field_ty, mod);
         },
         else => return ty,

--- a/src/arch/x86_64/abi.zig
+++ b/src/arch/x86_64/abi.zig
@@ -224,7 +224,7 @@ pub fn classifySystemV(ty: Type, mod: *Module, ctx: Context) [8]Class {
             var result_i: usize = 0; // out of 8
             var byte_i: usize = 0; // out of 8
             for (struct_type.field_types.get(ip), 0..) |field_ty_ip, i| {
-                const field_ty = field_ty_ip.toType();
+                const field_ty = Type.fromInterned(field_ty_ip);
                 const field_align = struct_type.fieldAlign(ip, i);
                 if (field_align != .none and field_align.compare(.lt, field_ty.abiAlignment(mod)))
                     return memory_class;
@@ -342,12 +342,12 @@ pub fn classifySystemV(ty: Type, mod: *Module, ctx: Context) [8]Class {
             for (union_obj.field_types.get(ip), 0..) |field_ty, field_index| {
                 const field_align = union_obj.fieldAlign(ip, @intCast(field_index));
                 if (field_align != .none and
-                    field_align.compare(.lt, field_ty.toType().abiAlignment(mod)))
+                    field_align.compare(.lt, Type.fromInterned(field_ty).abiAlignment(mod)))
                 {
                     return memory_class;
                 }
                 // Combine this field with the previous one.
-                const field_class = classifySystemV(field_ty.toType(), mod, .field);
+                const field_class = classifySystemV(Type.fromInterned(field_ty), mod, .field);
                 for (&result, 0..) |*result_item, i| {
                     const field_item = field_class[i];
                     // "If both classes are equal, this is the resulting class."

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -13,6 +13,7 @@ const codegen = @import("../codegen/c.zig");
 const link = @import("../link.zig");
 const trace = @import("../tracy.zig").trace;
 const Type = @import("../type.zig").Type;
+const Value = @import("../value.zig").Value;
 const Air = @import("../Air.zig");
 const Liveness = @import("../Liveness.zig");
 
@@ -254,8 +255,8 @@ fn updateAnonDecl(self: *C, module: *Module, i: usize) !void {
     }
 
     const tv: @import("../TypedValue.zig") = .{
-        .ty = module.intern_pool.typeOf(anon_decl).toType(),
-        .val = anon_decl.toValue(),
+        .ty = Type.fromInterned(module.intern_pool.typeOf(anon_decl)),
+        .val = Value.fromInterned(anon_decl),
     };
     const c_value: codegen.CValue = .{ .constant = anon_decl };
     const alignment: Alignment = self.aligned_anon_decls.get(anon_decl) orelse .none;

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1189,7 +1189,7 @@ pub fn updateDecl(
     var code_buffer = std.ArrayList(u8).init(self.base.allocator);
     defer code_buffer.deinit();
 
-    const decl_val = if (decl.val.getVariable(mod)) |variable| variable.init.toValue() else decl.val;
+    const decl_val = if (decl.val.getVariable(mod)) |variable| Value.fromInterned(variable.init) else decl.val;
     const res = try codegen.generateSymbol(&self.base, decl.srcLoc(mod), .{
         .ty = decl.ty,
         .val = decl_val,
@@ -1794,7 +1794,7 @@ pub fn lowerAnonDecl(
 ) !codegen.Result {
     const gpa = self.base.allocator;
     const mod = self.base.options.module.?;
-    const ty = mod.intern_pool.typeOf(decl_val).toType();
+    const ty = Type.fromInterned(mod.intern_pool.typeOf(decl_val));
     const decl_alignment = switch (explicit_alignment) {
         .none => ty.abiAlignment(mod),
         else => explicit_alignment,
@@ -1805,7 +1805,7 @@ pub fn lowerAnonDecl(
             return .ok;
     }
 
-    const val = decl_val.toValue();
+    const val = Value.fromInterned(decl_val);
     const tv = TypedValue{ .ty = ty, .val = val };
     var name_buf: [32]u8 = undefined;
     const name = std.fmt.bufPrint(&name_buf, "__anon_{d}", .{
@@ -2669,6 +2669,7 @@ const Relocation = @import("Coff/Relocation.zig");
 const TableSection = @import("table_section.zig").TableSection;
 const StringTable = @import("StringTable.zig");
 const Type = @import("../type.zig").Type;
+const Value = @import("../value.zig").Value;
 const TypedValue = @import("../TypedValue.zig");
 
 pub const base_tag: link.File.Tag = .coff;

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -305,7 +305,7 @@ pub const DeclState = struct {
                                 // DW.AT.type, DW.FORM.ref4
                                 const index = dbg_info_buffer.items.len;
                                 try dbg_info_buffer.resize(index + 4);
-                                try self.addTypeRelocGlobal(atom_index, field_ty.toType(), @intCast(index));
+                                try self.addTypeRelocGlobal(atom_index, Type.fromInterned(field_ty), @intCast(index));
                                 // DW.AT.data_member_location, DW.FORM.udata
                                 const field_off = ty.structFieldOffset(field_index, mod);
                                 try leb128.writeULEB128(dbg_info_buffer.writer(), field_off);
@@ -323,7 +323,7 @@ pub const DeclState = struct {
 
                             if (struct_type.isTuple(ip)) {
                                 for (struct_type.field_types.get(ip), struct_type.offsets.get(ip), 0..) |field_ty, field_off, field_index| {
-                                    if (!field_ty.toType().hasRuntimeBits(mod)) continue;
+                                    if (!Type.fromInterned(field_ty).hasRuntimeBits(mod)) continue;
                                     // DW.AT.member
                                     try dbg_info_buffer.append(@intFromEnum(AbbrevKind.struct_member));
                                     // DW.AT.name, DW.FORM.string
@@ -331,7 +331,7 @@ pub const DeclState = struct {
                                     // DW.AT.type, DW.FORM.ref4
                                     const index = dbg_info_buffer.items.len;
                                     try dbg_info_buffer.resize(index + 4);
-                                    try self.addTypeRelocGlobal(atom_index, field_ty.toType(), @intCast(index));
+                                    try self.addTypeRelocGlobal(atom_index, Type.fromInterned(field_ty), @intCast(index));
                                     // DW.AT.data_member_location, DW.FORM.udata
                                     try leb128.writeULEB128(dbg_info_buffer.writer(), field_off);
                                 }
@@ -341,7 +341,7 @@ pub const DeclState = struct {
                                     struct_type.field_types.get(ip),
                                     struct_type.offsets.get(ip),
                                 ) |field_name_ip, field_ty, field_off| {
-                                    if (!field_ty.toType().hasRuntimeBits(mod)) continue;
+                                    if (!Type.fromInterned(field_ty).hasRuntimeBits(mod)) continue;
                                     const field_name = ip.stringToSlice(field_name_ip);
                                     // DW.AT.member
                                     try dbg_info_buffer.ensureUnusedCapacity(field_name.len + 2);
@@ -352,7 +352,7 @@ pub const DeclState = struct {
                                     // DW.AT.type, DW.FORM.ref4
                                     const index = dbg_info_buffer.items.len;
                                     try dbg_info_buffer.resize(index + 4);
-                                    try self.addTypeRelocGlobal(atom_index, field_ty.toType(), @intCast(index));
+                                    try self.addTypeRelocGlobal(atom_index, Type.fromInterned(field_ty), @intCast(index));
                                     // DW.AT.data_member_location, DW.FORM.udata
                                     try leb128.writeULEB128(dbg_info_buffer.writer(), field_off);
                                 }
@@ -389,7 +389,7 @@ pub const DeclState = struct {
                         const value = enum_type.values.get(ip)[field_i];
                         // TODO do not assume a 64bit enum value - could be bigger.
                         // See https://github.com/ziglang/zig/issues/645
-                        const field_int_val = try value.toValue().intFromEnum(ty, mod);
+                        const field_int_val = try Value.fromInterned(value).intFromEnum(ty, mod);
                         break :value @bitCast(field_int_val.toSignedInt(mod));
                     };
                     mem.writeInt(u64, dbg_info_buffer.addManyAsArrayAssumeCapacity(8), value, target_endian);
@@ -443,7 +443,7 @@ pub const DeclState = struct {
                 }
 
                 for (union_obj.field_types.get(ip), union_obj.field_names.get(ip)) |field_ty, field_name| {
-                    if (!field_ty.toType().hasRuntimeBits(mod)) continue;
+                    if (!Type.fromInterned(field_ty).hasRuntimeBits(mod)) continue;
                     // DW.AT.member
                     try dbg_info_buffer.append(@intFromEnum(AbbrevKind.struct_member));
                     // DW.AT.name, DW.FORM.string
@@ -452,7 +452,7 @@ pub const DeclState = struct {
                     // DW.AT.type, DW.FORM.ref4
                     const index = dbg_info_buffer.items.len;
                     try dbg_info_buffer.resize(index + 4);
-                    try self.addTypeRelocGlobal(atom_index, field_ty.toType(), @intCast(index));
+                    try self.addTypeRelocGlobal(atom_index, Type.fromInterned(field_ty), @intCast(index));
                     // DW.AT.data_member_location, DW.FORM.udata
                     try dbg_info_buffer.append(0);
                 }
@@ -469,7 +469,7 @@ pub const DeclState = struct {
                     // DW.AT.type, DW.FORM.ref4
                     const index = dbg_info_buffer.items.len;
                     try dbg_info_buffer.resize(index + 4);
-                    try self.addTypeRelocGlobal(atom_index, union_obj.enum_tag_ty.toType(), @intCast(index));
+                    try self.addTypeRelocGlobal(atom_index, Type.fromInterned(union_obj.enum_tag_ty), @intCast(index));
                     // DW.AT.data_member_location, DW.FORM.udata
                     try leb128.writeULEB128(dbg_info_buffer.writer(), tag_offset);
 

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2400,7 +2400,7 @@ pub fn updateDecl(self: *MachO, mod: *Module, decl_index: Module.Decl.Index) !vo
         null;
     defer if (decl_state) |*ds| ds.deinit();
 
-    const decl_val = if (decl.val.getVariable(mod)) |variable| variable.init.toValue() else decl.val;
+    const decl_val = if (decl.val.getVariable(mod)) |variable| Value.fromInterned(variable.init) else decl.val;
     const res = if (decl_state) |*ds|
         try codegen.generateSymbol(&self.base, decl.srcLoc(mod), .{
             .ty = decl.ty,
@@ -2569,7 +2569,7 @@ fn updateThreadlocalVariable(self: *MachO, module: *Module, decl_index: Module.D
 
     const decl = module.declPtr(decl_index);
     const decl_metadata = self.decls.get(decl_index).?;
-    const decl_val = decl.val.getVariable(mod).?.init.toValue();
+    const decl_val = Value.fromInterned(decl.val.getVariable(mod).?.init);
     const res = if (decl_state) |*ds|
         try codegen.generateSymbol(&self.base, decl.srcLoc(mod), .{
             .ty = decl.ty,
@@ -2995,7 +2995,7 @@ pub fn lowerAnonDecl(
 ) !codegen.Result {
     const gpa = self.base.allocator;
     const mod = self.base.options.module.?;
-    const ty = mod.intern_pool.typeOf(decl_val).toType();
+    const ty = Type.fromInterned(mod.intern_pool.typeOf(decl_val));
     const decl_alignment = switch (explicit_alignment) {
         .none => ty.abiAlignment(mod),
         else => explicit_alignment,
@@ -3006,7 +3006,7 @@ pub fn lowerAnonDecl(
             return .ok;
     }
 
-    const val = decl_val.toValue();
+    const val = Value.fromInterned(decl_val);
     const tv = TypedValue{ .ty = ty, .val = val };
     var name_buf: [32]u8 = undefined;
     const name = std.fmt.bufPrint(&name_buf, "__anon_{d}", .{

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -13,6 +13,8 @@ const File = link.File;
 const build_options = @import("build_options");
 const Air = @import("../Air.zig");
 const Liveness = @import("../Liveness.zig");
+const Type = @import("../type.zig").Type;
+const Value = @import("../value.zig").Value;
 const TypedValue = @import("../TypedValue.zig");
 
 const std = @import("std");
@@ -517,7 +519,7 @@ pub fn updateDecl(self: *Plan9, mod: *Module, decl_index: Module.Decl.Index) !vo
 
     var code_buffer = std.ArrayList(u8).init(self.base.allocator);
     defer code_buffer.deinit();
-    const decl_val = if (decl.val.getVariable(mod)) |variable| variable.init.toValue() else decl.val;
+    const decl_val = if (decl.val.getVariable(mod)) |variable| Value.fromInterned(variable.init) else decl.val;
     // TODO we need the symbol index for symbol in the table of locals for the containing atom
     const res = try codegen.generateSymbol(&self.base, decl.srcLoc(mod), .{
         .ty = decl.ty,
@@ -1492,8 +1494,8 @@ pub fn lowerAnonDecl(self: *Plan9, decl_val: InternPool.Index, src_loc: Module.S
     const gop = try self.anon_decls.getOrPut(gpa, decl_val);
     const mod = self.base.options.module.?;
     if (!gop.found_existing) {
-        const ty = mod.intern_pool.typeOf(decl_val).toType();
-        const val = decl_val.toValue();
+        const ty = Type.fromInterned(mod.intern_pool.typeOf(decl_val));
+        const val = Value.fromInterned(decl_val);
         const tv = TypedValue{ .ty = ty, .val = val };
         const name = try std.fmt.allocPrint(gpa, "__anon_{d}", .{@intFromEnum(decl_val)});
 

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -940,10 +940,10 @@ const Writer = struct {
             return s.print("@{}", .{operand});
         } else if (Air.refToInterned(operand)) |ip_index| {
             const mod = w.module;
-            const ty = mod.intern_pool.indexToKey(ip_index).typeOf().toType();
+            const ty = Type.fromInterned(mod.intern_pool.indexToKey(ip_index).typeOf());
             try s.print("<{}, {}>", .{
                 ty.fmt(mod),
-                ip_index.toValue().fmtValue(ty, mod),
+                Value.fromInterned(ip_index).fmtValue(ty, mod),
             });
         } else {
             return w.writeInstIndex(s, Air.refToIndex(operand).?, dies);


### PR DESCRIPTION
From @andrewrk's  pre-requisites to decouple the InternPool from the compiler.
Except for [`finishFuncInstance`](https://github.com/ziglang/zig/blob/8b10970836480a43a3bbb1276cb258c2a8b613f2/src/InternPool.zig#L6130), there are no more direct references to `Type` or `Value` in `InternPool`.
 