### PR TITLE
make inline calls of function pointers illegal

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7267,9 +7267,6 @@ fn analyzeCall(
 
                     if (modifier == .always_inline)
                         return sema.fail(block, call_src, "inline call of function pointer", .{});
-                    
-                    if (func_ty_info.cc == .Inline)
-                        return sema.fail(block, call_src, "calling pointer of inline function", .{});
 
                     break :blk func_val_ptr;
                 },

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7264,6 +7264,13 @@ fn analyzeCall(
                         return sema.fail(block, call_src, "{s} call of extern function pointer", .{
                             @as([]const u8, if (is_comptime_call) "comptime" else "inline"),
                         });
+
+                    if (modifier == .always_inline)
+                        return sema.fail(block, call_src, "inline call of function pointer", .{});
+                    
+                    if (func_ty_info.cc == .Inline)
+                        return sema.fail(block, call_src, "calling pointer of inline function", .{});
+
                     break :blk func_val_ptr;
                 },
                 else => {

--- a/test/cases/compile_errors/call_inline_function_pointer.zig
+++ b/test/cases/compile_errors/call_inline_function_pointer.zig
@@ -1,0 +1,9 @@
+inline fn a() void {}
+
+export fn b() void {
+    @call(.auto, &a, .{});
+}
+
+// error
+//
+// :4:5: error: calling pointer of inline function

--- a/test/cases/compile_errors/call_inline_function_pointer.zig
+++ b/test/cases/compile_errors/call_inline_function_pointer.zig
@@ -1,9 +1,0 @@
-inline fn a() void {}
-
-export fn b() void {
-    @call(.auto, &a, .{});
-}
-
-// error
-//
-// :4:5: error: calling pointer of inline function

--- a/test/cases/compile_errors/inline_call_function_pointer.zig
+++ b/test/cases/compile_errors/inline_call_function_pointer.zig
@@ -1,0 +1,9 @@
+fn a() void {}
+
+export fn b() void {
+    @call(.always_inline, &a, .{});
+}
+
+// error
+//
+// :5:5: error: inline call of function pointer

--- a/test/cases/compile_errors/inline_call_function_pointer.zig
+++ b/test/cases/compile_errors/inline_call_function_pointer.zig
@@ -6,4 +6,4 @@ export fn b() void {
 
 // error
 //
-// :5:5: error: inline call of function pointer
+// :4:5: error: inline call of function pointer


### PR DESCRIPTION
as discussed on the discord, inlining function pointers, makes little sense currently.

```
InKryption: if it were to be allowed, zig would need to emit an actual non-inline definition for the function first, and then point at that
```

this adds an error to that specific behavior, and a test to confirm it


