### PR TITLE
os: expect ETIMEDOUT, ECONNRESET, ENOTCONN from recvfrom & read family

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -686,6 +686,7 @@ pub const ReadError = error{
     ConnectionResetByPeer,
     ConnectionTimedOut,
     NotOpenForReading,
+    SocketNotConnected,
 
     // Windows only
     NetNameDeleted,
@@ -732,6 +733,7 @@ pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
             .ISDIR => return error.IsDir,
             .NOBUFS => return error.SystemResources,
             .NOMEM => return error.SystemResources,
+            .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
             .TIMEDOUT => return error.ConnectionTimedOut,
             .NOTCAPABLE => return error.AccessDenied,
@@ -760,6 +762,7 @@ pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
             .ISDIR => return error.IsDir,
             .NOBUFS => return error.SystemResources,
             .NOMEM => return error.SystemResources,
+            .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
             .TIMEDOUT => return error.ConnectionTimedOut,
             else => |err| return unexpectedErrno(err),
@@ -800,6 +803,9 @@ pub fn readv(fd: fd_t, iov: []const iovec) ReadError!usize {
             .ISDIR => return error.IsDir,
             .NOBUFS => return error.SystemResources,
             .NOMEM => return error.SystemResources,
+            .NOTCONN => return error.SocketNotConnected,
+            .CONNRESET => return error.ConnectionResetByPeer,
+            .TIMEDOUT => return error.ConnectionTimedOut,
             .NOTCAPABLE => return error.AccessDenied,
             else => |err| return unexpectedErrno(err),
         }
@@ -819,7 +825,9 @@ pub fn readv(fd: fd_t, iov: []const iovec) ReadError!usize {
             .ISDIR => return error.IsDir,
             .NOBUFS => return error.SystemResources,
             .NOMEM => return error.SystemResources,
+            .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
+            .TIMEDOUT => return error.ConnectionTimedOut,
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -864,7 +872,9 @@ pub fn pread(fd: fd_t, buf: []u8, offset: u64) PReadError!usize {
             .ISDIR => return error.IsDir,
             .NOBUFS => return error.SystemResources,
             .NOMEM => return error.SystemResources,
+            .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
+            .TIMEDOUT => return error.ConnectionTimedOut,
             .NXIO => return error.Unseekable,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
@@ -897,7 +907,9 @@ pub fn pread(fd: fd_t, buf: []u8, offset: u64) PReadError!usize {
             .ISDIR => return error.IsDir,
             .NOBUFS => return error.SystemResources,
             .NOMEM => return error.SystemResources,
+            .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
+            .TIMEDOUT => return error.ConnectionTimedOut,
             .NXIO => return error.Unseekable,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
@@ -1009,6 +1021,9 @@ pub fn preadv(fd: fd_t, iov: []const iovec, offset: u64) PReadError!usize {
             .ISDIR => return error.IsDir,
             .NOBUFS => return error.SystemResources,
             .NOMEM => return error.SystemResources,
+            .NOTCONN => return error.SocketNotConnected,
+            .CONNRESET => return error.ConnectionResetByPeer,
+            .TIMEDOUT => return error.ConnectionTimedOut,
             .NXIO => return error.Unseekable,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
@@ -1035,6 +1050,9 @@ pub fn preadv(fd: fd_t, iov: []const iovec, offset: u64) PReadError!usize {
             .ISDIR => return error.IsDir,
             .NOBUFS => return error.SystemResources,
             .NOMEM => return error.SystemResources,
+            .NOTCONN => return error.SocketNotConnected,
+            .CONNRESET => return error.ConnectionResetByPeer,
+            .TIMEDOUT => return error.ConnectionTimedOut,
             .NXIO => return error.Unseekable,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
@@ -6624,6 +6642,7 @@ pub const RecvFromError = error{
     SystemResources,
 
     ConnectionResetByPeer,
+    ConnectionTimedOut,
 
     /// The socket has not been bound.
     SocketNotBound,
@@ -6663,6 +6682,7 @@ pub fn recvfrom(
                     .WSAENETDOWN => return error.NetworkSubsystemFailed,
                     .WSAENOTCONN => return error.SocketNotConnected,
                     .WSAEWOULDBLOCK => return error.WouldBlock,
+                    .WSAETIMEDOUT => return error.ConnectionTimedOut,
                     // TODO: handle more errors
                     else => |err| return windows.unexpectedWSAError(err),
                 }
@@ -6682,6 +6702,7 @@ pub fn recvfrom(
                 .NOMEM => return error.SystemResources,
                 .CONNREFUSED => return error.ConnectionRefused,
                 .CONNRESET => return error.ConnectionResetByPeer,
+                .TIMEDOUT => return error.ConnectionTimedOut,
                 else => |err| return unexpectedErrno(err),
             }
         }

--- a/lib/std/zig/system/NativeTargetInfo.zig
+++ b/lib/std/zig/system/NativeTargetInfo.zig
@@ -917,6 +917,7 @@ fn preadMin(file: fs.File, buf: []u8, offset: u64, min_read_len: usize) !usize {
             error.Unseekable => return error.UnableToReadElfFile,
             error.ConnectionResetByPeer => return error.UnableToReadElfFile,
             error.ConnectionTimedOut => return error.UnableToReadElfFile,
+            error.SocketNotConnected => return error.UnableToReadElfFile,
             error.NetNameDeleted => return error.UnableToReadElfFile,
             error.Unexpected => return error.Unexpected,
             error.InputOutput => return error.FileSystem,

--- a/src/link.zig
+++ b/src/link.zig
@@ -531,6 +531,7 @@ pub const File = struct {
         BrokenPipe,
         ConnectionResetByPeer,
         ConnectionTimedOut,
+        SocketNotConnected,
         NotOpenForReading,
         WouldBlock,
         AccessDenied,

--- a/src/main.zig
+++ b/src/main.zig
@@ -5682,6 +5682,7 @@ const FmtError = error{
     NotOpenForWriting,
     UnsupportedEncoding,
     ConnectionResetByPeer,
+    SocketNotConnected,
     LockViolation,
     NetNameDeleted,
     InvalidArgument,


### PR DESCRIPTION
reads on eg. connected TCP sockets can fail with ETIMEDOUT, and ENOTCONN happens eg. if you try to read a TCP socket that has not been connected yet.

interestingly read() was already handling CONNRESET & TIMEDOUT, but readv(), pread(), and preadv() were somewhat inconsistent.

---
same as https://github.com/ziglang/zig/pull/16579 which I abandoned previously. this new version passed tests on linux-amd64.
---

example partial stacktrace I happened to see using tls client on darwin; errno 60 is ETIMEDOUT.
```
unexpected errno: 60
/Users/lotheac/danjon/zig-macos-aarch64-0.11.0-dev.4246+71dfce31b/lib/std/debug.zig:129:31: 0x104b9abaf in dumpCurrentStackTrace (danjon)
        writeCurrentStackTrace(stderr, debug_info, io.tty.detectConfig(io.getStdErr()), start_addr) catch |err| {
                              ^
/Users/lotheac/danjon/zig-macos-aarch64-0.11.0-dev.4246+71dfce31b/lib/std/os.zig:5573:40: 0x104b78aa3 in unexpectedErrno (danjon)
        std.debug.dumpCurrentStackTrace(null);
                                       ^
/Users/lotheac/danjon/zig-macos-aarch64-0.11.0-dev.4246+71dfce31b/lib/std/os.zig:832:49: 0x104c98647 in readv (danjon)
            else => |err| return unexpectedErrno(err),
                                                ^
/Users/lotheac/danjon/zig-macos-aarch64-0.11.0-dev.4246+71dfce31b/lib/std/net.zig:1783:24: 0x104b8c4bb in readv (danjon)
        return os.readv(s.handle, iovecs);
                       ^
/Users/lotheac/danjon/zig-macos-aarch64-0.11.0-dev.4246+71dfce31b/lib/std/crypto/tls/Client.zig:989:45: 0x104b86c47 in readvAdvanced__anon_5715 (danjon)
    const actual_read_len = try stream.readv(ask_iovecs);
                                            ^
/Users/lotheac/danjon/zig-macos-aarch64-0.11.0-dev.4246+71dfce31b/lib/std/crypto/tls/Client.zig:900:38: 0x104b9265f in readvAtLeast__anon_5714 (danjon)
        var amt = try c.readvAdvanced(stream, iovecs[vec_i..]);
                                     ^
/Users/lotheac/danjon/zig-macos-aarch64-0.11.0-dev.4246+71dfce31b/lib/std/crypto/tls/Client.zig:861:24: 0x104b92adf in readAtLeast__anon_5712 (danjon)
    return readvAtLeast(c, stream, &iovecs, len);
                       ^
/Users/lotheac/danjon/zig-macos-aarch64-0.11.0-dev.4246+71dfce31b/lib/std/crypto/tls/Client.zig:866:23: 0x104b92bab in read__anon_5711 (danjon)
    return readAtLeast(c, stream, buffer, 1);
                      ^
/Users/lotheac/danjon/src/main.zig:277:28: 0x104b92cc3 in read (danjon)
            return tls.read(self.stream, buf);
                           ^
```