### PR TITLE
replace all uses of `Type.eql` with `ip_index` comparisons

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3663,7 +3663,7 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
     try sema.resolveTypeLayout(decl_tv.ty);
 
     if (decl.kind == .@"usingnamespace") {
-        if (!decl_tv.ty.eql(Type.type, mod)) {
+        if (!(decl_tv.ty.ip_index == Type.type.ip_index)) {
             return sema.fail(&block_scope, ty_src, "expected type, found {}", .{
                 decl_tv.ty.fmt(mod),
             });
@@ -3696,7 +3696,7 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
 
                 if (decl.has_tv) {
                     prev_type_has_bits = decl.ty.isFnOrHasRuntimeBits(mod);
-                    type_changed = !decl.ty.eql(decl_tv.ty, mod);
+                    type_changed = !(decl.ty.ip_index == decl_tv.ty.ip_index);
                     if (decl.getOwnedFunction(mod)) |prev_func| {
                         prev_is_inline = prev_func.analysis(ip).state == .inline_only;
                     }
@@ -3726,7 +3726,7 @@ fn semaDecl(mod: *Module, decl_index: Decl.Index) !bool {
     }
     var type_changed = true;
     if (decl.has_tv) {
-        type_changed = !decl.ty.eql(decl_tv.ty, mod);
+        type_changed = !(decl.ty.ip_index == decl_tv.ty.ip_index);
     }
 
     decl.owns_tv = false;

--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -139,7 +139,7 @@ pub fn print(
                 const elem_ty = ty.elemType2(mod);
                 const len = payload.len.toUnsignedInt(mod);
 
-                if (elem_ty.eql(Type.u8, mod)) str: {
+                if (elem_ty.ip_index == Type.u8.ip_index) str: {
                     const max_len: usize = @min(len, max_string_len);
                     var buf: [max_string_len]u8 = undefined;
 
@@ -282,7 +282,7 @@ pub fn print(
                     }
                     const elem_ty = Type.fromInterned(ptr_ty.child);
                     const len = Value.fromInterned(ptr.len).toUnsignedInt(mod);
-                    if (elem_ty.eql(Type.u8, mod)) str: {
+                    if (elem_ty.ip_index == Type.u8.ip_index) str: {
                         const max_len = @min(len, max_string_len);
                         var buf: [max_string_len]u8 = undefined;
                         for (buf[0..max_len], 0..) |*c, i| {
@@ -488,7 +488,7 @@ fn printAggregate(
         const elem_ty = ty.elemType2(mod);
         const len = ty.arrayLen(mod);
 
-        if (elem_ty.eql(Type.u8, mod)) str: {
+        if (elem_ty.ip_index == Type.u8.ip_index) str: {
             const max_len: usize = @min(len, max_string_len);
             var buf: [max_string_len]u8 = undefined;
 

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -1420,7 +1420,7 @@ fn minMax(
         .Float => return self.fail("TODO ARM min/max on floats", .{}),
         .Vector => return self.fail("TODO ARM min/max on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 var lhs_reg: Register = undefined;
@@ -1910,7 +1910,7 @@ fn addSub(
         .Float => return self.fail("TODO binary operations on floats", .{}),
         .Vector => return self.fail("TODO binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 const lhs_immediate = try lhs_bind.resolveToImmediate(self);
@@ -1970,7 +1970,7 @@ fn mul(
     switch (lhs_ty.zigTypeTag(mod)) {
         .Vector => return self.fail("TODO binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 // TODO add optimisations for multiplication
@@ -2019,7 +2019,7 @@ fn divTrunc(
         .Float => return self.fail("TODO div on floats", .{}),
         .Vector => return self.fail("TODO div on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 switch (int_info.signedness) {
@@ -2053,7 +2053,7 @@ fn divFloor(
         .Float => return self.fail("TODO div on floats", .{}),
         .Vector => return self.fail("TODO div on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 switch (int_info.signedness) {
@@ -2086,7 +2086,7 @@ fn divExact(
         .Float => return self.fail("TODO div on floats", .{}),
         .Vector => return self.fail("TODO div on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 switch (int_info.signedness) {
@@ -2122,7 +2122,7 @@ fn rem(
         .Float => return self.fail("TODO rem/mod on floats", .{}),
         .Vector => return self.fail("TODO rem/mod on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 var lhs_reg: Register = undefined;
@@ -2245,7 +2245,7 @@ fn bitwise(
     switch (lhs_ty.zigTypeTag(mod)) {
         .Vector => return self.fail("TODO binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 64) {
                 // TODO implement bitwise operations with immediates
@@ -2396,7 +2396,7 @@ fn ptrArithmetic(
     const mod = self.bin_file.options.module.?;
     switch (lhs_ty.zigTypeTag(mod)) {
         .Pointer => {
-            assert(rhs_ty.eql(Type.usize, mod));
+            assert(rhs_ty.ip_index == Type.usize.ip_index);
 
             const ptr_ty = lhs_ty;
             const elem_ty = switch (ptr_ty.ptrSize(mod)) {
@@ -2531,7 +2531,7 @@ fn airOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement add_with_overflow/sub_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.ip_index == rhs_ty.ip_index);
                 const int_info = lhs_ty.intInfo(mod);
                 switch (int_info.bits) {
                     1...31, 33...63 => {
@@ -2659,7 +2659,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement mul_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.ip_index == rhs_ty.ip_index);
                 const int_info = lhs_ty.intInfo(mod);
                 if (int_info.bits <= 32) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -1382,7 +1382,7 @@ fn minMax(
         .Float => return self.fail("TODO ARM min/max on floats", .{}),
         .Vector => return self.fail("TODO ARM min/max on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 var lhs_reg: Register = undefined;
@@ -1601,7 +1601,7 @@ fn airOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement add_with_overflow/sub_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.ip_index == rhs_ty.ip_index);
                 const int_info = lhs_ty.intInfo(mod);
                 if (int_info.bits < 32) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);
@@ -1714,7 +1714,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement mul_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.ip_index == rhs_ty.ip_index);
                 const int_info = lhs_ty.intInfo(mod);
                 if (int_info.bits <= 16) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);
@@ -3401,7 +3401,7 @@ fn addSub(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 const lhs_immediate = try lhs_bind.resolveToImmediate(self);
@@ -3457,7 +3457,7 @@ fn mul(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 // TODO add optimisations for multiplication
@@ -3506,7 +3506,7 @@ fn divTrunc(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
@@ -3549,7 +3549,7 @@ fn divFloor(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
@@ -3614,7 +3614,7 @@ fn rem(
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
@@ -3738,7 +3738,7 @@ fn bitwise(
     switch (lhs_ty.zigTypeTag(mod)) {
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
+            assert(lhs_ty.ip_index == rhs_ty.ip_index);
             const int_info = lhs_ty.intInfo(mod);
             if (int_info.bits <= 32) {
                 const lhs_immediate = try lhs_bind.resolveToImmediate(self);
@@ -3898,7 +3898,7 @@ fn ptrArithmetic(
     const mod = self.bin_file.options.module.?;
     switch (lhs_ty.zigTypeTag(mod)) {
         .Pointer => {
-            assert(rhs_ty.eql(Type.usize, mod));
+            assert(rhs_ty.ip_index == Type.usize.ip_index);
 
             const ptr_ty = lhs_ty;
             const elem_ty = switch (ptr_ty.ptrSize(mod)) {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1079,7 +1079,7 @@ fn binOp(
                 .Float => return self.fail("TODO binary operations on floats", .{}),
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    assert(lhs_ty.eql(rhs_ty, mod));
+                    assert(lhs_ty.ip_index == rhs_ty.ip_index);
                     const int_info = lhs_ty.intInfo(mod);
                     if (int_info.bits <= 64) {
                         // TODO immediate operands
@@ -1844,7 +1844,7 @@ fn airCmp(self: *Self, inst: Air.Inst.Index, op: math.CompareOperator) !void {
         return self.finishAir(inst, .dead, .{ bin_op.lhs, bin_op.rhs, .none });
     const ty = self.typeOf(bin_op.lhs);
     const mod = self.bin_file.options.module.?;
-    assert(ty.eql(self.typeOf(bin_op.rhs), mod));
+    assert(ty.ip_index == self.typeOf(bin_op.rhs).ip_index);
     if (ty.zigTypeTag(mod) == .ErrorSet)
         return self.fail("TODO implement cmp for errors", .{});
 

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -772,7 +772,7 @@ fn airAddSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement add_with_overflow/sub_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.ip_index == rhs_ty.ip_index);
                 const int_info = lhs_ty.intInfo(mod);
                 switch (int_info.bits) {
                     32, 64 => {
@@ -1903,7 +1903,7 @@ fn airMod(self: *Self, inst: Air.Inst.Index) !void {
     const rhs = try self.resolveInst(bin_op.rhs);
     const lhs_ty = self.typeOf(bin_op.lhs);
     const rhs_ty = self.typeOf(bin_op.rhs);
-    assert(lhs_ty.eql(rhs_ty, self.bin_file.options.module.?));
+    assert(lhs_ty.ip_index == rhs_ty.ip_index);
 
     if (self.liveness.isUnused(inst))
         return self.finishAir(inst, .dead, .{ bin_op.lhs, bin_op.rhs, .none });
@@ -2055,7 +2055,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         switch (lhs_ty.zigTypeTag(mod)) {
             .Vector => return self.fail("TODO implement mul_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
+                assert(lhs_ty.ip_index == rhs_ty.ip_index);
                 const int_info = lhs_ty.intInfo(mod);
                 switch (int_info.bits) {
                     1...32 => {
@@ -2874,7 +2874,7 @@ fn binOp(
                 .Float => return self.fail("TODO binary operations on floats", .{}),
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    assert(lhs_ty.eql(rhs_ty, mod));
+                    assert(lhs_ty.ip_index == rhs_ty.ip_index);
                     const int_info = lhs_ty.intInfo(mod);
                     if (int_info.bits <= 64) {
                         // Only say yes if the operation is
@@ -2964,7 +2964,7 @@ fn binOp(
             switch (lhs_ty.zigTypeTag(mod)) {
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    assert(lhs_ty.eql(rhs_ty, mod));
+                    assert(lhs_ty.ip_index == rhs_ty.ip_index);
                     const int_info = lhs_ty.intInfo(mod);
                     if (int_info.bits <= 64) {
                         const rhs_immediate_ok = switch (tag) {
@@ -4333,7 +4333,7 @@ fn minMax(
     rhs_ty: Type,
 ) InnerError!MCValue {
     const mod = self.bin_file.options.module.?;
-    assert(lhs_ty.eql(rhs_ty, mod));
+    assert(lhs_ty.ip_index == rhs_ty.ip_index);
     switch (lhs_ty.zigTypeTag(mod)) {
         .Float => return self.fail("TODO min/max on floats", .{}),
         .Vector => return self.fail("TODO min/max on vectors", .{}),

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -2399,8 +2399,8 @@ const DeclGen = struct {
         const lhs_id = try self.resolve(bin_op.lhs);
         const rhs_id = try self.resolve(bin_op.rhs);
 
-        assert(self.typeOf(bin_op.lhs).eql(ty, self.module));
-        assert(self.typeOf(bin_op.rhs).eql(ty, self.module));
+        assert(self.typeOf(bin_op.lhs).ip_index == ty.ip_index);
+        assert(self.typeOf(bin_op.rhs).ip_index == ty.ip_index);
 
         return try self.arithOp(ty, lhs_id, rhs_id, fop, sop, uop, modular);
     }

--- a/src/type.zig
+++ b/src/type.zig
@@ -113,14 +113,6 @@ pub const Type = struct {
         };
     }
 
-    pub fn eql(a: Type, b: Type, mod: *const Module) bool {
-        _ = mod; // TODO: remove this parameter
-        // The InternPool data structure hashes based on Key to make interned objects
-        // unique. An Index can be treated simply as u32 value for the
-        // purpose of Type/Value hashing and equality.
-        return a.toIntern() == b.toIntern();
-    }
-
     pub fn format(ty: Type, comptime unused_fmt_string: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
         _ = ty;
         _ = unused_fmt_string;

--- a/src/value.zig
+++ b/src/value.zig
@@ -1781,7 +1781,7 @@ pub const Value = struct {
         const ptr_val = switch (mod.intern_pool.indexToKey(val.toIntern())) {
             .ptr => |ptr| ptr: {
                 switch (ptr.addr) {
-                    .elem => |elem| if (Type.fromInterned(mod.intern_pool.typeOf(elem.base)).elemType2(mod).eql(elem_ty, mod))
+                    .elem => |elem| if (Type.fromInterned(mod.intern_pool.typeOf(elem.base)).elemType2(mod).ip_index == elem_ty.ip_index)
                         return Value.fromInterned((try mod.intern(.{ .ptr = .{
                             .ty = elem_ptr_ty.toIntern(),
                             .addr = .{ .elem = .{


### PR DESCRIPTION
this removes another TODO 😄 
took a bit of time to get all of them, was pretty tedious

a bit more context...
the original todo was:
```zig
pub fn eql(a: Type, b: Type, mod: *const Module) bool {
    _ = mod; // TODO: remove this parameter
    // The InternPool data structure hashes based on Key to make interned objects
    // unique. An Index can be treated simply as u32 value for the
    // purpose of Type/Value hashing and equality.
    return a.toIntern() == b.toIntern();
}
```

however, i actually made this exact same PR a while ago (back when i still had no idea what i was doing) #17181.

mlugg suggested to simply compare the `ip_index` of the types, and I agree that this is a much better solution.


this PR is just a chore and can be rebased super easily later to account for any changes. nothing urgent 😄 