### PR TITLE
fix: Prevent segfault when using b.addModule()

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -869,7 +869,7 @@ pub fn createModule(b: *Build, options: CreateModuleOptions) *Module {
     const module = b.allocator.create(Module) catch @panic("OOM");
     module.* = .{
         .builder = b,
-        .source_file = options.source_file,
+        .source_file = options.source_file.dupe(b),
         .dependencies = moduleDependenciesToArrayHashMap(b.allocator, options.dependencies),
     };
     return module;


### PR DESCRIPTION
I'm currently seeing a segfault when using a `source_file` string that has been allocated on the head, and using a defer statement to free the allocated string. e.g:

```zig
    const modZig = std.fmt.allocPrint(allocator, "path/to/mod.zig", .{}) catch unreachable;
    defer allocator.free(modZig); // Removing this statement prevents a segfault
    const mod = b.addModule("mod", .{ .source_file = .{ .path = modZig } });
```

This results in the following error when building:
```
Segmentation fault at address 0x7fcec5b51000                                                                                                                   
/home/dacm/.local/lib/zig/std/fs/path.zig:287:33: 0x31f3db in isAbsolutePosix (build)
    return path.len > 0 and path[0] == sep_posix;
                                ^
/home/dacm/.local/lib/zig/std/fs/path.zig:670:28: 0x31740d in resolvePosix (build)
        if (isAbsolutePosix(p)) {
                           ^
/home/dacm/.local/lib/zig/std/fs/path.zig:473:28: 0x317278 in resolve (build)
        return resolvePosix(allocator, paths);
                           ^
/home/dacm/.local/lib/zig/std/Build.zig:1568:27: 0x3afead in pathFromRoot (build)
    return fs.path.resolve(b.allocator, &.{ b.build_root.path orelse ".", p }) catch @panic("OOM");
                          ^
/home/dacm/.local/lib/zig/std/Build.zig:1977:57: 0x3b1cf0 in getPath2 (build)
            .path => |p| return src_builder.pathFromRoot(p),
                                                        ^
/home/dacm/.local/lib/zig/std/Build.zig:1967:24: 0x3968d4 in getPath (build)
        return getPath2(self, src_builder, null);
                       ^
/home/dacm/.local/lib/zig/std/Build/Step/Compile.zig:1345:48: 0x3b1975 in appendModuleArgs (build)
            const src = mod.source_file.getPath(mod.builder);
                                               ^
/home/dacm/.local/lib/zig/std/Build/Step/Compile.zig:1922:30: 0x378f59 in make (build)
    try self.appendModuleArgs(&zig_args);
                             ^
/home/dacm/.local/lib/zig/std/Build/Step.zig:180:13: 0x327038 in make (build)
    s.makeFn(s, prog_node) catch |err| switch (err) {
            ^
/home/dacm/.local/lib/zig/build_runner.zig:888:31: 0x2dc030 in workerMakeOneStep (build)
    const make_result = s.make(&sub_prog_node);
                              ^
/home/dacm/.local/lib/zig/std/Thread/Pool.zig:94:39: 0x2b4682 in runFn (build)
            @call(.auto, func, closure.arguments);
                                      ^                                        
/home/dacm/.local/lib/zig/std/Thread/Pool.zig:133:18: 0x3540a4 in worker (build)
            runFn(&run_node.data);
[...]
```

This is with Zig v0.12.0-dev.1726+8b1097083.

I'm not seeing these segfaults when doing similar things for the `root_source_file` or an assembly file.

This PR duplicates the source file string (as is done in other places such as `addAssemblyFile()`) in order to prevent a segfault when the supplied string is freed by the caller. This is still seen when the caller makes use of a defer statement.

Example in `addAssemblyFile()`: https://github.com/ziglang/zig/blob/2549de80b226cddd0664ce4ad8c40887101f302b/lib/std/Build/Step/Compile.zig#L1113-L1118

Example in `addObjectFile()`: https://github.com/ziglang/zig/blob/2549de80b226cddd0664ce4ad8c40887101f302b/lib/std/Build/Step/Compile.zig#L1120-L1124

Finally, I guess this is where this is done for `addExecutable()` and friends: https://github.com/ziglang/zig/blob/2549de80b226cddd0664ce4ad8c40887101f302b/lib/std/Build/Step/Compile.zig#L447-L449

Please accept my apologies if I'm being stupid somehow, or if I'm duplicating the string in the wrong place. (The examples I referenced are in a different file, after all.)