### PR TITLE
codegen/llvm: improve loadTruncate() to use a simple load when possible

### DIFF
--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -4325,6 +4325,16 @@ pub const Function = struct {
                 };
             }
 
+            /// if the instruction is alloca returns pointee type, otherwise returns null
+            pub fn getAllocaPointeeTypeWip(self: Instruction.Index, wip: *const WipFunction) ?Type {
+                const instruction = wip.instructions.get(@intFromEnum(self));
+                return switch (instruction.tag) {
+                    .alloca, .@"alloca inalloca" => return wip.extraData(Alloca, instruction.data).type,
+
+                    else => null,
+                };
+            }
+
             pub fn typeOfWip(self: Instruction.Index, wip: *const WipFunction) Type {
                 const instruction = wip.instructions.get(@intFromEnum(self));
                 return switch (instruction.tag) {


### PR DESCRIPTION
forcing llvm to truncate the padding bits on load prevents some optimizations.

fixes 370662c565ba541157e3c69d12625c28787d642e
closes https://github.com/ziglang/zig/issues/17768
