### PR TITLE
Remove all usages of `std.mem.copy` and remove `std.mem.set`

### DIFF
--- a/deps/aro/aro/Type.zig
+++ b/deps/aro/aro/Type.zig
@@ -149,7 +149,7 @@ pub const Attributed = struct {
         errdefer allocator.destroy(attributed_type);
 
         const all_attrs = try allocator.alloc(Attribute, existing_attributes.len + attributes.len);
-        @memcpy(all_attrs, existing_attributes);
+        @memcpy(all_attrs[0..existing_attributes.len], existing_attributes);
         @memcpy(all_attrs[existing_attributes.len..], attributes);
 
         attributed_type.* = .{

--- a/deps/aro/aro/Type.zig
+++ b/deps/aro/aro/Type.zig
@@ -149,8 +149,8 @@ pub const Attributed = struct {
         errdefer allocator.destroy(attributed_type);
 
         const all_attrs = try allocator.alloc(Attribute, existing_attributes.len + attributes.len);
-        std.mem.copy(Attribute, all_attrs, existing_attributes);
-        std.mem.copy(Attribute, all_attrs[existing_attributes.len..], attributes);
+        @memcpy(all_attrs, existing_attributes);
+        @memcpy(all_attrs[existing_attributes.len..], attributes);
 
         attributed_type.* = .{
             .attributes = all_attrs,

--- a/deps/aro/backend/Ir.zig
+++ b/deps/aro/backend/Ir.zig
@@ -158,7 +158,7 @@ pub const Builder = struct {
         const a = b.arena.allocator();
         const input_refs = try a.alloc(Ref, inputs.len * 2 + 1);
         input_refs[0] = @enumFromInt(inputs.len);
-        std.mem.copy(Ref, input_refs[1..], std.mem.bytesAsSlice(Ref, std.mem.sliceAsBytes(inputs)));
+        @memcpy(input_refs[1..], std.mem.bytesAsSlice(Ref, std.mem.sliceAsBytes(inputs)));
 
         return b.addInst(.phi, .{ .phi = .{ .ptr = input_refs.ptr } }, ty);
     }

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10509,7 +10509,7 @@ test "using an allocator" {
 
 fn concat(allocator: Allocator, a: []const u8, b: []const u8) ![]u8 {
     const result = try allocator.alloc(u8, a.len + b.len);
-    @memcpy(result, a);
+    @memcpy(result[0..a.len], a);
     @memcpy(result[a.len..], b);
     return result;
 }

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10509,8 +10509,8 @@ test "using an allocator" {
 
 fn concat(allocator: Allocator, a: []const u8, b: []const u8) ![]u8 {
     const result = try allocator.alloc(u8, a.len + b.len);
-    std.mem.copy(u8, result, a);
-    std.mem.copy(u8, result[a.len..], b);
+    @memcpy(result, a);
+    @memcpy(result[a.len..], b);
     return result;
 }
       {#code_end#}

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1705,7 +1705,7 @@ pub const DebugInfo = struct {
                 if (coff_obj.strtabRequired()) {
                     var name_buffer: [windows.PATH_MAX_WIDE + 4:0]u16 = undefined;
                     // openFileAbsoluteW requires the prefix to be present
-                    mem.copy(u16, name_buffer[0..4], &[_]u16{ '\\', '?', '?', '\\' });
+                    @memcpy(name_buffer[0..4], &[_]u16{ '\\', '?', '?', '\\' });
 
                     const process_handle = windows.kernel32.GetCurrentProcess();
                     const len = windows.kernel32.K32GetModuleFileNameExW(

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -190,10 +190,6 @@ test "Allocator.resize" {
     }
 }
 
-/// Deprecated: use `@memcpy` if the arguments do not overlap, or
-/// `copyForwards` if they do.
-pub const copy = copyForwards;
-
 /// Copy all of source into dest at position 0.
 /// dest.len must be >= source.len.
 /// If the slices overlap, dest.ptr must be <= src.ptr.

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -213,8 +213,6 @@ pub fn copyBackwards(comptime T: type, dest: []T, source: []const T) void {
     }
 }
 
-pub const set = @compileError("deprecated; use @memset instead");
-
 /// Generally, Zig users are encouraged to explicitly initialize all fields of a struct explicitly rather than using this function.
 /// However, it is recognized that there are sometimes use cases for initializing all fields to a "zero" value. For example, when
 /// interfacing with a C API where this practice is more common and relied upon. If you are performing code review and see this
@@ -2948,12 +2946,12 @@ fn joinMaybeZ(allocator: Allocator, separator: []const u8, slices: []const []con
     const buf = try allocator.alloc(u8, total_len);
     errdefer allocator.free(buf);
 
-    @memcpy(buf, slices[0]);
+    @memcpy(buf[0..slices[0].len], slices[0]);
     var buf_index: usize = slices[0].len;
     for (slices[1..]) |slice| {
-        @memcpy(buf[buf_index..], separator);
+        @memcpy(buf[buf_index .. buf_index + separator.len], separator);
         buf_index += separator.len;
-        @memcpy(buf[buf_index..], slice);
+        @memcpy(buf[buf_index .. buf_index + slice.len], slice);
         buf_index += slice.len;
     }
 
@@ -3046,7 +3044,7 @@ pub fn concatMaybeSentinel(allocator: Allocator, comptime T: type, slices: []con
 
     var buf_index: usize = 0;
     for (slices) |slice| {
-        @memcpy(buf[buf_index..], slice);
+        @memcpy(buf[buf_index .. buf_index + slice.len], slice);
         buf_index += slice.len;
     }
 

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2948,12 +2948,12 @@ fn joinMaybeZ(allocator: Allocator, separator: []const u8, slices: []const []con
     const buf = try allocator.alloc(u8, total_len);
     errdefer allocator.free(buf);
 
-    copy(u8, buf, slices[0]);
+    @memcpy(buf, slices[0]);
     var buf_index: usize = slices[0].len;
     for (slices[1..]) |slice| {
-        copy(u8, buf[buf_index..], separator);
+        @memcpy(buf[buf_index..], separator);
         buf_index += separator.len;
-        copy(u8, buf[buf_index..], slice);
+        @memcpy(buf[buf_index..], slice);
         buf_index += slice.len;
     }
 
@@ -3046,7 +3046,7 @@ pub fn concatMaybeSentinel(allocator: Allocator, comptime T: type, slices: []con
 
     var buf_index: usize = 0;
     for (slices) |slice| {
-        copy(T, buf[buf_index..], slice);
+        @memcpy(buf[buf_index..], slice);
         buf_index += slice.len;
     }
 

--- a/lib/std/os/windows/test.zig
+++ b/lib/std/os/windows/test.zig
@@ -16,7 +16,7 @@ fn RtlDosPathNameToNtPathName_U(path: [:0]const u16) !windows.PathSpace {
 
     var path_space: windows.PathSpace = undefined;
     const out_path = out.Buffer[0 .. out.Length / 2];
-    @memcpy(path_space.data[0..], out_path);
+    @memcpy(path_space.data[0..out_path.len], out_path);
     path_space.len = out.Length / 2;
     path_space.data[path_space.len] = 0;
 

--- a/lib/std/os/windows/test.zig
+++ b/lib/std/os/windows/test.zig
@@ -16,7 +16,7 @@ fn RtlDosPathNameToNtPathName_U(path: [:0]const u16) !windows.PathSpace {
 
     var path_space: windows.PathSpace = undefined;
     const out_path = out.Buffer[0 .. out.Length / 2];
-    std.mem.copy(u16, path_space.data[0..], out_path);
+    @memcpy(path_space.data[0..], out_path);
     path_space.len = out.Length / 2;
     path_space.data[path_space.len] = 0;
 

--- a/src/link/MachO/uuid.zig
+++ b/src/link/MachO/uuid.zig
@@ -22,7 +22,7 @@ pub fn calcUuid(comp: *const Compilation, file: fs.File, file_size: u64, out: *[
     defer comp.gpa.free(final_buffer);
 
     for (hashes, 0..) |hash, i| {
-        mem.copy(u8, final_buffer[i * Md5.digest_length ..][0..Md5.digest_length], &hash);
+        @memcpy(final_buffer[i * Md5.digest_length ..][0..Md5.digest_length], &hash);
     }
 
     Md5.hash(final_buffer, out, .{});

--- a/src/resinator/cli.zig
+++ b/src/resinator/cli.zig
@@ -207,7 +207,7 @@ pub const Options = struct {
             cwd.access(options.input_filename, .{}) catch |err| switch (err) {
                 error.FileNotFound => {
                     var filename_bytes = try options.allocator.alloc(u8, options.input_filename.len + 3);
-                    @memcpy(filename_bytes, options.input_filename);
+                    @memcpy(filename_bytes[0 .. filename_bytes.len - 3], options.input_filename);
                     @memcpy(filename_bytes[filename_bytes.len - 3 ..], ".rc");
                     options.allocator.free(options.input_filename);
                     options.input_filename = filename_bytes;

--- a/src/resinator/cli.zig
+++ b/src/resinator/cli.zig
@@ -207,8 +207,8 @@ pub const Options = struct {
             cwd.access(options.input_filename, .{}) catch |err| switch (err) {
                 error.FileNotFound => {
                     var filename_bytes = try options.allocator.alloc(u8, options.input_filename.len + 3);
-                    std.mem.copy(u8, filename_bytes, options.input_filename);
-                    std.mem.copy(u8, filename_bytes[filename_bytes.len - 3 ..], ".rc");
+                    @memcpy(filename_bytes, options.input_filename);
+                    @memcpy(filename_bytes[filename_bytes.len - 3 ..], ".rc");
                     options.allocator.free(options.input_filename);
                     options.input_filename = filename_bytes;
                 },

--- a/src/resinator/compile.zig
+++ b/src/resinator/compile.zig
@@ -2890,7 +2890,7 @@ pub fn HeaderSlurpingReader(comptime size: usize, comptime ReaderType: anytype) 
             if (self.bytes_read < size) {
                 const bytes_to_add = @min(amt, size - self.bytes_read);
                 const end_index = self.bytes_read + bytes_to_add;
-                std.mem.copy(u8, self.slurped_header[self.bytes_read..end_index], buf[0..bytes_to_add]);
+                @memcpy(self.slurped_header[self.bytes_read..end_index], buf[0..bytes_to_add]);
             }
             self.bytes_read +|= amt;
             return amt;

--- a/src/resinator/lang.zig
+++ b/src/resinator/lang.zig
@@ -140,7 +140,7 @@ test "exhaustive tagToId" {
         writer.writeAll(parsed_sort.suffix.?) catch unreachable;
         const expected_field_name = comptime field: {
             var name_buf: [5]u8 = undefined;
-            @memcpy(&name_buf, parsed_sort.language_code);
+            @memcpy(&name_buf[0..parsed_sort.language_code.len], parsed_sort.language_code);
             name_buf[2] = '_';
             @memcpy(name_buf[3..], parsed_sort.country_code.?);
             break :field name_buf;

--- a/src/resinator/lang.zig
+++ b/src/resinator/lang.zig
@@ -140,9 +140,9 @@ test "exhaustive tagToId" {
         writer.writeAll(parsed_sort.suffix.?) catch unreachable;
         const expected_field_name = comptime field: {
             var name_buf: [5]u8 = undefined;
-            std.mem.copy(u8, &name_buf, parsed_sort.language_code);
+            @memcpy(&name_buf, parsed_sort.language_code);
             name_buf[2] = '_';
-            std.mem.copy(u8, name_buf[3..], parsed_sort.country_code.?);
+            @memcpy(name_buf[3..], parsed_sort.country_code.?);
             break :field name_buf;
         };
         const expected = @field(LanguageId, &expected_field_name);

--- a/src/resinator/source_mapping.zig
+++ b/src/resinator/source_mapping.zig
@@ -476,7 +476,7 @@ pub const SourceMappings = struct {
 
         const after_collapsed_start = line_num + num_following_lines_to_collapse;
         const new_num_lines = self.mapping.items.len - num_following_lines_to_collapse;
-        std.mem.copy(SourceSpan, self.mapping.items[line_num..new_num_lines], self.mapping.items[after_collapsed_start..]);
+        @memcpy(self.mapping.items[line_num..new_num_lines], self.mapping.items[after_collapsed_start..]);
 
         self.mapping.items.len = new_num_lines;
     }

--- a/src/resinator/source_mapping.zig
+++ b/src/resinator/source_mapping.zig
@@ -476,7 +476,7 @@ pub const SourceMappings = struct {
 
         const after_collapsed_start = line_num + num_following_lines_to_collapse;
         const new_num_lines = self.mapping.items.len - num_following_lines_to_collapse;
-        @memcpy(self.mapping.items[line_num..new_num_lines], self.mapping.items[after_collapsed_start..]);
+        std.mem.copyForwards(SourceSpan, self.mapping.items[line_num..new_num_lines], self.mapping.items[after_collapsed_start..]);
 
         self.mapping.items.len = new_num_lines;
     }

--- a/test/behavior/for.zig
+++ b/test/behavior/for.zig
@@ -156,7 +156,7 @@ test "for loop with pointer elem var" {
 
     const source = "abcdefg";
     var target: [source.len]u8 = undefined;
-    mem.copy(u8, target[0..], source);
+    @memcpy(target[0..], source);
     mangleString(target[0..]);
     try expect(mem.eql(u8, &target, "bcdefgh"));
 

--- a/test/behavior/ptrcast.zig
+++ b/test/behavior/ptrcast.zig
@@ -265,7 +265,8 @@ test "comptime @ptrCast a subset of an array, then write through it" {
         var buff: [16]u8 align(4) = undefined;
         const len_bytes = @as(*u32, @ptrCast(&buff));
         len_bytes.* = 16;
-        @memcpy(buff[4..], "abcdef");
+        const source = "abcdef";
+        @memcpy(buff[4 .. 4 + source.len], source);
     }
 }
 

--- a/test/behavior/ptrcast.zig
+++ b/test/behavior/ptrcast.zig
@@ -265,7 +265,7 @@ test "comptime @ptrCast a subset of an array, then write through it" {
         var buff: [16]u8 align(4) = undefined;
         const len_bytes = @as(*u32, @ptrCast(&buff));
         len_bytes.* = 16;
-        std.mem.copy(u8, buff[4..], "abcdef");
+        @memcpy(buff[4..], "abcdef");
     }
 }
 

--- a/test/behavior/threadlocal.zig
+++ b/test/behavior/threadlocal.zig
@@ -35,7 +35,7 @@ test "pointer to thread local array" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     const s = "Hello world";
-    std.mem.copy(u8, buffer[0..], s);
+    @memcpy(buffer[0..], s);
     try std.testing.expectEqualSlices(u8, buffer[0..], s);
 }
 

--- a/test/behavior/threadlocal.zig
+++ b/test/behavior/threadlocal.zig
@@ -35,7 +35,7 @@ test "pointer to thread local array" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     const s = "Hello world";
-    @memcpy(buffer[0..], s);
+    @memcpy(buffer[0..s.len], s);
     try std.testing.expectEqualSlices(u8, buffer[0..], s);
 }
 

--- a/tools/update-license-headers.zig
+++ b/tools/update-license-headers.zig
@@ -40,7 +40,7 @@ pub fn main() !void {
 
         const new_source = try arena.alloc(u8, truncated_source.len + new_header.len);
         @memcpy(new_source[0..new_source.len], new_header);
-        @memcpy(new_source[new_header.len .. new_header.len + truncated_source], truncated_source);
+        @memcpy(new_source[new_header.len .. new_header.len + truncated_source.len], truncated_source);
 
         try dir.writeFile(entry.path, new_source);
     }

--- a/tools/update-license-headers.zig
+++ b/tools/update-license-headers.zig
@@ -39,8 +39,8 @@ pub fn main() !void {
         const truncated_source = source[expected_header.len..];
 
         const new_source = try arena.alloc(u8, truncated_source.len + new_header.len);
-        std.mem.copy(u8, new_source, new_header);
-        std.mem.copy(u8, new_source[new_header.len..], truncated_source);
+        @memcpy(new_source, new_header);
+        @memcpy(new_source[new_header.len..], truncated_source);
 
         try dir.writeFile(entry.path, new_source);
     }

--- a/tools/update-license-headers.zig
+++ b/tools/update-license-headers.zig
@@ -39,8 +39,8 @@ pub fn main() !void {
         const truncated_source = source[expected_header.len..];
 
         const new_source = try arena.alloc(u8, truncated_source.len + new_header.len);
-        @memcpy(new_source, new_header);
-        @memcpy(new_source[new_header.len..], truncated_source);
+        @memcpy(new_source[0..new_source.len], new_header);
+        @memcpy(new_source[new_header.len .. new_header.len + truncated_source], truncated_source);
 
         try dir.writeFile(entry.path, new_source);
     }


### PR DESCRIPTION
My reasoning for making this PR is 2 reasons.

1. This should have been simply removed/`@compileError` the first time, and now there is just no point in keeping it around.


2. In my opinion this creates a bad practice function alias. By aliasing `copyForward`, we are creating possible bugs that are not caught and corrupt data due to overlap. The pointer overlap detection of `@memcpy` is more important than I believe given credit to. So it leads to the thought that all uses of `std.mem.copy` (after it was aliased/depricated), were made out of ignorance of the dangerous it could pose to the codebase. If the writer wanted to ensure overlap, they would have / should use `copyForward`, and if they did *not* want overlap, they need to use `@memcpy`.