### PR TITLE
std.zig.system: remove explicit `usize` cast

### DIFF
--- a/lib/std/zig/system/NativeTargetInfo.zig
+++ b/lib/std/zig/system/NativeTargetInfo.zig
@@ -801,11 +801,9 @@ pub fn abiAndDynamicLinkerFromFile(
 
         if (dynstr) |ds| {
             if (rpath_offset) |rpoff| {
-                // TODO this pointer cast should not be necessary
-                const rpoff_usize = std.math.cast(usize, rpoff) orelse return error.InvalidElfFile;
-                if (rpoff_usize > ds.size) return error.InvalidElfFile;
-                const rpoff_file = ds.offset + rpoff_usize;
-                const rp_max_size = ds.size - rpoff_usize;
+                if (rpoff > ds.size) return error.InvalidElfFile;
+                const rpoff_file = ds.offset + rpoff;
+                const rp_max_size = ds.size - rpoff;
 
                 const strtab_len = @min(rp_max_size, strtab_buf.len);
                 const strtab_read_len = try preadMin(file, &strtab_buf, rpoff_file, strtab_len);


### PR DESCRIPTION
The cast seems to no longer be necessary after changes in interactions between `u64` and `usize`.