### PR TITLE
std.math: add `wrap` function

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -427,7 +427,7 @@ test "wrap" {
     try testing.expect(std.math.wrap(@as(i32, 361), @as(i32, 180)) == 1);
 
     // Floating point
-    try testing.expect(std.math.wrap(@as(f32, 1.1), @as(f32, 1.0)) == 0.1);
+    try testing.expect(std.math.wrap(@as(f32, 1.1), @as(f32, 1.0)) == -0.9);
     try testing.expect(std.math.wrap(@as(f32, -127.5), @as(f32, 180)) == -127.5);
 
     // Mix of comptime and non-comptime

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -427,7 +427,7 @@ test "wrap" {
     try testing.expect(std.math.wrap(@as(i32, 361), @as(i32, 180)) == 1);
 
     // Floating point
-    try testing.expect(std.math.wrap(@as(f32, 1.1), @as(f32, 1.0)) == -0.9);
+    try testing.expect(std.math.wrap(@as(f32, 1.125), @as(f32, 1.0)) == -0.875);
     try testing.expect(std.math.wrap(@as(f32, -127.5), @as(f32, 180)) == -127.5);
 
     // Mix of comptime and non-comptime

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -406,6 +406,44 @@ pub const min3 = @compileError("deprecated; use @min instead");
 pub const max3 = @compileError("deprecated; use @max instead");
 pub const ln = @compileError("deprecated; use @log instead");
 
+/// Odd sawtooth function
+///         |
+///      /  | /    /
+///     /   |/    /
+///  --/----/----/--
+///   /    /|   /
+///  /    / |  /
+///         |
+/// Limit val to the interval [-r, r).
+pub fn wrap(x: anytype, r: anytype) @TypeOf(x) {
+    return @mod(x + r, 2 * r) - r;
+}
+test "wrap" {
+    // Within range
+    try testing.expect(std.math.wrap(@as(i32, -75), @as(i32, 180)) == -75);
+    // Below
+    try testing.expect(std.math.wrap(@as(i32, -225), @as(i32, 180)) == 135);
+    // Above
+    try testing.expect(std.math.wrap(@as(i32, 361), @as(i32, 180)) == 1);
+
+    // Floating point
+    try testing.expect(std.math.wrap(@as(f32, 1.1), @as(f32, 1.0)) == 0.1);
+    try testing.expect(std.math.wrap(@as(f32, -127.5), @as(f32, 180)) == -127.5);
+
+    // Mix of comptime and non-comptime
+    var i: i32 = 1;
+    _ = &i;
+    try testing.expect(std.math.wrap(i, 10) == 1);
+}
+
+/// Odd ramp function
+///         |  _____
+///         | /
+///         |/
+///  -------/-------
+///        /|
+///  _____/ |
+//          |
 /// Limit val to the inclusive range [lower, upper].
 pub fn clamp(val: anytype, lower: anytype, upper: anytype) @TypeOf(val, lower, upper) {
     assert(lower <= upper);

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -444,20 +444,41 @@ pub fn wrap(x: anytype, r: anytype) @TypeOf(x) {
 }
 test "wrap" {
     // Within range
-    try testing.expect(std.math.wrap(@as(i32, -75), @as(i32, 180)) == -75);
+    try testing.expect(wrap(@as(i32, -75), @as(i32, 180)) == -75);
+    try testing.expect(wrap(@as(i32, -75), @as(i32, -180)) == -75);
     // Below
-    try testing.expect(std.math.wrap(@as(i32, -225), @as(i32, 180)) == 135);
+    try testing.expect(wrap(@as(i32, -225), @as(i32, 180)) == 135);
+    try testing.expect(wrap(@as(i32, -225), @as(i32, -180)) == 135);
     // Above
-    try testing.expect(std.math.wrap(@as(i32, 361), @as(i32, 180)) == 1);
+    try testing.expect(wrap(@as(i32, 361), @as(i32, 180)) == 1);
+    try testing.expect(wrap(@as(i32, 361), @as(i32, -180)) == 1);
+
+    // One period, right limit, positive r
+    try testing.expect(wrap(@as(i32, 180), @as(i32, 180)) == -180);
+    // One period, left limit, positive r
+    try testing.expect(wrap(@as(i32, -180), @as(i32, 180)) == -180);
+    // One period, right limit, negative r
+    try testing.expect(wrap(@as(i32, 180), @as(i32, -180)) == 180);
+    // One period, left limit, negative r
+    try testing.expect(wrap(@as(i32, -180), @as(i32, -180)) == 180);
+
+    // Two periods, right limit, positive r
+    try testing.expect(wrap(@as(i32, 540), @as(i32, 180)) == -180);
+    // Two periods, left limit, positive r
+    try testing.expect(wrap(@as(i32, -540), @as(i32, 180)) == -180);
+    // Two periods, right limit, negative r
+    try testing.expect(wrap(@as(i32, 540), @as(i32, -180)) == 180);
+    // Two periods, left limit, negative r
+    try testing.expect(wrap(@as(i32, -540), @as(i32, -180)) == 180);
 
     // Floating point
-    try testing.expect(std.math.wrap(@as(f32, 1.125), @as(f32, 1.0)) == -0.875);
-    try testing.expect(std.math.wrap(@as(f32, -127.5), @as(f32, 180)) == -127.5);
+    try testing.expect(wrap(@as(f32, 1.125), @as(f32, 1.0)) == -0.875);
+    try testing.expect(wrap(@as(f32, -127.5), @as(f32, 180)) == -127.5);
 
     // Mix of comptime and non-comptime
     var i: i32 = 1;
     _ = &i;
-    try testing.expect(std.math.wrap(i, 10) == 1);
+    try testing.expect(wrap(i, 10) == 1);
 }
 test wrap {
     const limit: i32 = 180;

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -414,7 +414,7 @@ pub const ln = @compileError("deprecated; use @log instead");
 ///   /    /|   /
 ///  /    / |  /
 ///         |
-/// Limit x to the interval [-r, r).
+/// Limit x to the half-open interval [-r, r).
 pub fn wrap(x: anytype, r: anytype) @TypeOf(x) {
     return @mod(x + r, 2 * r) - r;
 }

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -443,7 +443,7 @@ test "wrap" {
 ///  -------/-------
 ///        /|
 ///  _____/ |
-//          |
+///         |
 /// Limit val to the inclusive range [lower, upper].
 pub fn clamp(val: anytype, lower: anytype, upper: anytype) @TypeOf(val, lower, upper) {
     assert(lower <= upper);

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -407,6 +407,7 @@ pub const max3 = @compileError("deprecated; use @max instead");
 pub const ln = @compileError("deprecated; use @log instead");
 
 /// Odd sawtooth function
+/// ```
 ///         |
 ///      /  | /    /
 ///     /   |/    /
@@ -414,6 +415,7 @@ pub const ln = @compileError("deprecated; use @log instead");
 ///   /    /|   /
 ///  /    / |  /
 ///         |
+/// ```
 /// Limit x to the half-open interval [-r, r).
 pub fn wrap(x: anytype, r: anytype) @TypeOf(x) {
     return @mod(x + r, 2 * r) - r;
@@ -437,6 +439,7 @@ test "wrap" {
 }
 
 /// Odd ramp function
+/// ```
 ///         |  _____
 ///         | /
 ///         |/
@@ -444,6 +447,7 @@ test "wrap" {
 ///        /|
 ///  _____/ |
 ///         |
+/// ```
 /// Limit val to the inclusive range [lower, upper].
 pub fn clamp(val: anytype, lower: anytype, upper: anytype) @TypeOf(val, lower, upper) {
     assert(lower <= upper);

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -414,7 +414,7 @@ pub const ln = @compileError("deprecated; use @log instead");
 ///   /    /|   /
 ///  /    / |  /
 ///         |
-/// Limit val to the interval [-r, r).
+/// Limit x to the interval [-r, r).
 pub fn wrap(x: anytype, r: anytype) @TypeOf(x) {
     return @mod(x + r, 2 * r) - r;
 }

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -437,6 +437,15 @@ test "wrap" {
     _ = &i;
     try testing.expect(std.math.wrap(i, 10) == 1);
 }
+test wrap {
+    const limit: i32 = 180;
+    // Within range
+    try testing.expect(wrap(@as(i32, -75), limit) == -75);
+    // Below
+    try testing.expect(wrap(@as(i32, -225), limit) == 135);
+    // Above
+    try testing.expect(wrap(@as(i32, 361), limit) == 1);
+}
 
 /// Odd ramp function
 /// ```


### PR DESCRIPTION
This function is frequently used for wrapping things like angle ranges, would be a strange omission to have clamp and not this since they complement each other.

```zig
fn mouseMove(dx: i32, dy: i32) void {
    yaw   += sensitivity(dx);
    pitch += sensitivity(dy);

    yaw   = wrap(yaw, 180);
    pitch = clamp(pitch, -90, 90);
}