### PR TITLE
Make stack protector available when using zig cc

### DIFF
--- a/src/target.zig
+++ b/src/target.zig
@@ -339,7 +339,7 @@ pub fn supportsStackProtector(target: std.Target, backend: std.builtin.CompilerB
     }
     return switch (backend) {
         .stage2_llvm => true,
-        else => false,
+        else => libcProvidesStackProtector(target),
     };
 }
 


### PR DESCRIPTION
Closes #18009.

This felt suspiciously easy so either someone forgot to call this function and I fixed this correctly or this fix is total garbage. Please let me know. :P
