### PR TITLE
Adds support for Fossil SCM source tree archives as zig build dependencies

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -982,7 +982,9 @@ fn unpackResource(
             if (ascii.eqlIgnoreCase(mime_type, "application/zstd"))
                 break :ft .@"tar.zst";
 
-            if (!ascii.eqlIgnoreCase(mime_type, "application/octet-stream")) {
+            if (!ascii.eqlIgnoreCase(mime_type, "application/octet-stream") and
+                !ascii.eqlIgnoreCase(mime_type, "application/x-compressed"))
+            {
                 return f.fail(f.location_tok, try eb.printString(
                     "unrecognized 'Content-Type' header: '{s}'",
                     .{content_type},


### PR DESCRIPTION
Fossil SCM can generate `tar.gz` compressed source tree archives at any given artifiact, which aligns well with zig build dependency fetching system.

Problem is that fossil serves these archives with mime type `application/x-compressed`. While it's too generic, zig should accept it nonetheless, but fall back to filename parsing to determine source archive type.

Other problem is that fossil generates tar archives where directory headers don't have trailing slash which causes issues with the way how `std/tar.zig` parses archive paths.