### PR TITLE
Static libraries should not always compile with PIE

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1289,7 +1289,7 @@ pub fn create(gpa: Allocator, options: InitOptions) !*Compilation {
         const sysroot = options.sysroot orelse libc_dirs.sysroot;
 
         const pie: bool = pie: {
-            if (is_dyn_lib) {
+            if (link_mode == .Static or is_dyn_lib) {
                 if (options.want_pie == true) return error.OutputModeForbidsPie;
                 break :pie false;
             }


### PR DESCRIPTION
I have been working on [a crossplatform app template](https://github.com/geooot/zig-sokol-crossplatform-starter) but i've been facing an issue on linking for the android app.

I get these linker errors that look like this:
```
error: ld.lld: relocation R_AARCH64_TLSLE_ADD_TPREL_HI12 against debug.panic_stage cannot be used with -shared
    note: defined in /Users/george/projects/zig-sokol-crossplatform-starter/zig-cache/o/c22611fb108ffe2a286abe0c568edcbd/libMyApp_aarch64-linux-android.a(/Users/george/projects/zig-sokol-crossplatform-starter/zig-cache/o/c22611fb108ffe2a286abe0c568edcbd/libMyApp_aarch64-linux-android.a.o)
    note: referenced by debug.zig:399 (/Users/george/bin/lib/std/debug.zig:399)
    note:               /Users/george/projects/zig-sokol-crossplatform-starter/zig-cache/o/c22611fb108ffe2a286abe0c568edcbd/libMyApp_aarch64-linux-android.a.o:(debug.panicImpl) in archive /Users/george/projects/zig-sokol-crossplatform-starter/zig-cache/o/c22611fb108ffe2a286abe0c568edcbd/libMyApp_aarch64-linux-android.a
```
[[Full Log]](https://gist.github.com/geooot/276b23872e2e1ab53cecfe4507b6ea7d)

I found a related issue with #17575. The patch [in this comment](https://github.com/ziglang/zig/issues/17575#issuecomment-1768805247) worked for me.

I think this part in Compilation.zig is the culprit? If the output is a static library it compiles with PIE since the target (android) is set to require it.

Changing it to also not do PIE when the output is a library (not just a dynamic library) works with the sample repo above. 