### PR TITLE
Special-case switching on error union capture

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6801,6 +6801,32 @@ test "peer type resolution: *const T and ?*T" {
     try expect(a == b);
     try expect(b == a);
 }
+
+test "peer type resolution: error union switch" {
+    // The non-error and error cases are only peers if the error case is just a switch expression;
+    // the pattern `if (x) {...} else |err| blk: { switch (err) {...} }` does not consider the
+    // non-error and error case to be peers.
+    var a: error{ A, B, C }!u32 = 0;
+    _ = &a;
+    const b = if (a) |x|
+        x + 3
+    else |err| switch (err) {
+        error.A => 0,
+        error.B => 1,
+        error.C => null,
+    };
+    try expect(@TypeOf(b) == ?u32);
+
+    // The non-error and error cases are only peers if the error case is just a switch expression;
+    // the pattern `x catch |err| blk: { switch (err) {...} }` does not consider the unwrapped `x`
+    // and error case to be peers.
+    const c = a catch |err| switch (err) {
+        error.A => 0,
+        error.B => 1,
+        error.C => null,
+    };
+    try expect(@TypeOf(c) == ?u32);
+}
       {#code_end#}
       {#header_close#}
       {#header_close#}

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -93,6 +93,7 @@ fn setExtra(astgen: *AstGen, index: usize, extra: anytype) void {
             Zir.Inst.Call.Flags,
             Zir.Inst.BuiltinCall.Flags,
             Zir.Inst.SwitchBlock.Bits,
+            Zir.Inst.SwitchBlockErrUnion.Bits,
             Zir.Inst.FuncFancy.Bits,
             => @bitCast(@field(extra, field.name)),
 
@@ -2640,6 +2641,7 @@ fn addEnsureResult(gz: *GenZir, maybe_unused_result: Zir.Inst.Ref, statement: As
             .import,
             .switch_block,
             .switch_block_ref,
+            .switch_block_err_union,
             .union_init,
             .field_type_ref,
             .error_set_decl,

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -2556,7 +2556,6 @@ fn addEnsureResult(gz: *GenZir, maybe_unused_result: Zir.Inst.Ref, statement: As
             .vector_type,
             .indexable_ptr_len,
             .anyframe_type,
-            .as,
             .as_node,
             .as_shift_operand,
             .bit_and,

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -7201,7 +7201,7 @@ fn switchExprErrUnion(
         const is_multi_case = case.ast.values.len > 1 or
             (case.ast.values.len == 1 and node_tags[case.ast.values[0]] == .switch_range);
 
-        var dbg_var_name: ?u32 = null;
+        var dbg_var_name: Zir.NullTerminatedString = .empty;
         var dbg_var_inst: Zir.Inst.Ref = undefined;
         var err_scope: Scope.LocalVal = undefined;
         var capture_scope: Scope.LocalVal = undefined;
@@ -7294,8 +7294,8 @@ fn switchExprErrUnion(
             defer case_scope.unstack();
 
             try case_scope.addDbgBlockBegin();
-            if (dbg_var_name) |some| {
-                try case_scope.addDbgVar(.dbg_var_val, some, dbg_var_inst);
+            if (dbg_var_name != .empty) {
+                try case_scope.addDbgVar(.dbg_var_val, dbg_var_name, dbg_var_inst);
             }
             const target_expr_node = case.ast.target_expr;
             const case_result = try expr(&case_scope, sub_scope, block_scope.break_result_info, target_expr_node);

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -7367,6 +7367,7 @@ fn switchExprErrUnion(
             .any_uses_err_capture = any_uses_err_capture,
             .payload_is_ref = payload_is_ref,
         },
+        .main_src_node_offset = parent_gz.nodeIndexToRelative(catch_or_if_node),
     });
 
     if (multi_cases_len != 0) {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -11292,6 +11292,7 @@ fn zirSwitchBlockErrUnion(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Comp
         .runtime_loop = block.runtime_loop,
         .runtime_index = block.runtime_index,
         .error_return_trace_index = block.error_return_trace_index,
+        .want_safety = block.want_safety,
     };
     const merges = &child_block.label.?.merges;
     defer child_block.instructions.deinit(gpa);

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1097,6 +1097,7 @@ fn analyzeBodyInner(
             .str                          => try sema.zirStr(inst),
             .switch_block                 => try sema.zirSwitchBlock(block, inst, false),
             .switch_block_ref             => try sema.zirSwitchBlock(block, inst, true),
+            .switch_block_err_union       => @panic("TODO: implement lowering of switch_block_err_union"),
             .type_info                    => try sema.zirTypeInfo(block, inst),
             .size_of                      => try sema.zirSizeOf(block, inst),
             .bit_size_of                  => try sema.zirBitSizeOf(block, inst),

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1018,7 +1018,6 @@ fn analyzeBodyInner(
             .array_type                   => try sema.zirArrayType(block, inst),
             .array_type_sentinel          => try sema.zirArrayTypeSentinel(block, inst),
             .vector_type                  => try sema.zirVectorType(block, inst),
-            .as                           => try sema.zirAs(block, inst),
             .as_node                      => try sema.zirAsNode(block, inst),
             .as_shift_operand             => try sema.zirAsShiftOperand(block, inst),
             .bit_and                      => try sema.zirBitwise(block, inst, .bit_and),
@@ -9792,14 +9791,6 @@ fn zirParamAnytype(
         .name = param_name,
     });
     sema.inst_map.putAssumeCapacity(inst, .generic_poison);
-}
-
-fn zirAs(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
-
-    const bin_inst = sema.code.instructions.items(.data)[@intFromEnum(inst)].bin;
-    return sema.analyzeAs(block, sema.src, bin_inst.lhs, bin_inst.rhs, false);
 }
 
 fn zirAsNode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2793,9 +2793,10 @@ pub const Inst = struct {
             /// If true, there is an else prong. This is mutually exclusive with `has_under`.
             has_else: bool,
             any_uses_err_capture: bool,
+            payload_is_ref: bool,
             scalar_cases_len: ScalarCasesLen,
 
-            pub const ScalarCasesLen = u29;
+            pub const ScalarCasesLen = u28;
         };
 
         pub const MultiProng = struct {

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -277,9 +277,6 @@ pub const Inst = struct {
         /// Create a `anyframe->T` type.
         /// Uses the `un_node` field.
         anyframe_type,
-        /// Type coercion. No source location attached.
-        /// Uses the `bin` field.
-        as,
         /// Type coercion to the function's return type.
         /// Uses the `pl_node` field. Payload is `As`. AST node could be many things.
         as_node,
@@ -1083,7 +1080,6 @@ pub const Inst = struct {
                 .vector_elem_type,
                 .indexable_ptr_len,
                 .anyframe_type,
-                .as,
                 .as_node,
                 .as_shift_operand,
                 .bit_and,
@@ -1396,7 +1392,6 @@ pub const Inst = struct {
                 .vector_elem_type,
                 .indexable_ptr_len,
                 .anyframe_type,
-                .as,
                 .as_node,
                 .as_shift_operand,
                 .bit_and,
@@ -1629,7 +1624,6 @@ pub const Inst = struct {
                 .vector_elem_type = .un_node,
                 .indexable_ptr_len = .un_node,
                 .anyframe_type = .un_node,
-                .as = .bin,
                 .as_node = .pl_node,
                 .as_shift_operand = .pl_node,
                 .bit_and = .pl_node,

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2792,9 +2792,10 @@ pub const Inst = struct {
             has_multi_cases: bool,
             /// If true, there is an else prong. This is mutually exclusive with `has_under`.
             has_else: bool,
+            any_uses_err_capture: bool,
             scalar_cases_len: ScalarCasesLen,
 
-            pub const ScalarCasesLen = u30;
+            pub const ScalarCasesLen = u29;
         };
 
         pub const MultiProng = struct {

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -2786,6 +2786,7 @@ pub const Inst = struct {
     pub const SwitchBlockErrUnion = struct {
         operand: Ref,
         bits: Bits,
+        main_src_node_offset: i32,
 
         pub const Bits = packed struct(u32) {
             /// If true, one or more prongs have multiple items.

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -2040,7 +2040,18 @@ const Writer = struct {
             break :blk multi_cases_len;
         } else 0;
 
+        const err_capture_inst: Zir.Inst.Index = if (extra.data.bits.any_uses_err_capture) blk: {
+            const tag_capture_inst = self.code.extra[extra_index];
+            extra_index += 1;
+            break :blk @enumFromInt(tag_capture_inst);
+        } else undefined;
+
         try self.writeInstRef(stream, extra.data.operand);
+
+        if (extra.data.bits.any_uses_err_capture) {
+            try stream.writeAll(", err_capture=");
+            try self.writeInstIndex(stream, err_capture_inst);
+        }
 
         self.indent += 2;
 

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -464,6 +464,8 @@ const Writer = struct {
             .switch_block_ref,
             => try self.writeSwitchBlock(stream, inst),
 
+            .switch_block_err_union => try self.writeSwitchBlockErrUnion(stream, inst),
+
             .field_val,
             .field_ptr,
             => try self.writePlNodeField(stream, inst),
@@ -2023,6 +2025,132 @@ const Writer = struct {
         try stream.writeByteNTimes(' ', self.indent);
         try stream.writeAll("}) ");
 
+        try self.writeSrc(stream, inst_data.src());
+    }
+
+    fn writeSwitchBlockErrUnion(self: *Writer, stream: anytype, inst: Zir.Inst.Index) !void {
+        const inst_data = self.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
+        const extra = self.code.extraData(Zir.Inst.SwitchBlockErrUnion, inst_data.payload_index);
+
+        var extra_index: usize = extra.end;
+
+        const multi_cases_len = if (extra.data.bits.has_multi_cases) blk: {
+            const multi_cases_len = self.code.extra[extra_index];
+            extra_index += 1;
+            break :blk multi_cases_len;
+        } else 0;
+
+        try self.writeInstRef(stream, extra.data.operand);
+
+        self.indent += 2;
+
+        {
+            const info = @as(Zir.Inst.SwitchBlock.ProngInfo, @bitCast(self.code.extra[extra_index]));
+            extra_index += 1;
+
+            assert(!info.is_inline);
+            const body = self.code.bodySlice(extra_index, info.body_len);
+            extra_index += body.len;
+
+            try stream.writeAll(",\n");
+            try stream.writeByteNTimes(' ', self.indent);
+            try stream.writeAll("non_err => ");
+            try self.writeBracedBody(stream, body);
+        }
+
+        if (extra.data.bits.has_else) {
+            const info = @as(Zir.Inst.SwitchBlock.ProngInfo, @bitCast(self.code.extra[extra_index]));
+            extra_index += 1;
+            const capture_text = switch (info.capture) {
+                .none => "",
+                .by_val => "by_val ",
+                .by_ref => "by_ref ",
+            };
+            const inline_text = if (info.is_inline) "inline " else "";
+            const body = self.code.bodySlice(extra_index, info.body_len);
+            extra_index += body.len;
+
+            try stream.writeAll(",\n");
+            try stream.writeByteNTimes(' ', self.indent);
+            try stream.print("{s}{s}else => ", .{ capture_text, inline_text });
+            try self.writeBracedBody(stream, body);
+        }
+
+        {
+            const scalar_cases_len = extra.data.bits.scalar_cases_len;
+            var scalar_i: usize = 0;
+            while (scalar_i < scalar_cases_len) : (scalar_i += 1) {
+                const item_ref = @as(Zir.Inst.Ref, @enumFromInt(self.code.extra[extra_index]));
+                extra_index += 1;
+                const info = @as(Zir.Inst.SwitchBlock.ProngInfo, @bitCast(self.code.extra[extra_index]));
+                extra_index += 1;
+                const body = self.code.bodySlice(extra_index, info.body_len);
+                extra_index += info.body_len;
+
+                try stream.writeAll(",\n");
+                try stream.writeByteNTimes(' ', self.indent);
+                switch (info.capture) {
+                    .none => {},
+                    .by_val => try stream.writeAll("by_val "),
+                    .by_ref => try stream.writeAll("by_ref "),
+                }
+                if (info.is_inline) try stream.writeAll("inline ");
+                try self.writeInstRef(stream, item_ref);
+                try stream.writeAll(" => ");
+                try self.writeBracedBody(stream, body);
+            }
+        }
+        {
+            var multi_i: usize = 0;
+            while (multi_i < multi_cases_len) : (multi_i += 1) {
+                const items_len = self.code.extra[extra_index];
+                extra_index += 1;
+                const ranges_len = self.code.extra[extra_index];
+                extra_index += 1;
+                const info = @as(Zir.Inst.SwitchBlock.ProngInfo, @bitCast(self.code.extra[extra_index]));
+                extra_index += 1;
+                const items = self.code.refSlice(extra_index, items_len);
+                extra_index += items_len;
+
+                try stream.writeAll(",\n");
+                try stream.writeByteNTimes(' ', self.indent);
+                switch (info.capture) {
+                    .none => {},
+                    .by_val => try stream.writeAll("by_val "),
+                    .by_ref => try stream.writeAll("by_ref "),
+                }
+                if (info.is_inline) try stream.writeAll("inline ");
+
+                for (items, 0..) |item_ref, item_i| {
+                    if (item_i != 0) try stream.writeAll(", ");
+                    try self.writeInstRef(stream, item_ref);
+                }
+
+                var range_i: usize = 0;
+                while (range_i < ranges_len) : (range_i += 1) {
+                    const item_first = @as(Zir.Inst.Ref, @enumFromInt(self.code.extra[extra_index]));
+                    extra_index += 1;
+                    const item_last = @as(Zir.Inst.Ref, @enumFromInt(self.code.extra[extra_index]));
+                    extra_index += 1;
+
+                    if (range_i != 0 or items.len != 0) {
+                        try stream.writeAll(", ");
+                    }
+                    try self.writeInstRef(stream, item_first);
+                    try stream.writeAll("...");
+                    try self.writeInstRef(stream, item_last);
+                }
+
+                const body = self.code.bodySlice(extra_index, info.body_len);
+                extra_index += info.body_len;
+                try stream.writeAll(" => ");
+                try self.writeBracedBody(stream, body);
+            }
+        }
+
+        self.indent -= 2;
+
+        try stream.writeAll(") ");
         try self.writeSrc(stream, inst_data.src());
     }
 

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -199,7 +199,6 @@ const Writer = struct {
         const tag = tags[@intFromEnum(inst)];
         try stream.print("= {s}(", .{@tagName(tags[@intFromEnum(inst)])});
         switch (tag) {
-            .as,
             .store,
             .store_to_inferred_ptr,
             => try self.writeBin(stream, inst),

--- a/test/behavior/switch_on_captured_error.zig
+++ b/test/behavior/switch_on_captured_error.zig
@@ -1,0 +1,750 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const expect = std.testing.expect;
+const expectError = std.testing.expectError;
+const expectEqual = std.testing.expectEqual;
+
+test "switch on error union catch capture" {
+    const S = struct {
+        const Error = error{ A, B, C };
+        fn doTheTest() !void {
+            try testScalar();
+            try testMulti();
+            try testElse();
+            try testCapture();
+            try testInline();
+            try testEmptyErrSet();
+        }
+
+        fn testScalar() !void {
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    error.B => 1,
+                    error.C => 2,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    error.B => @intFromError(err) + 4,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    error.B => @intFromError(err) + 4,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+        }
+
+        fn testMulti() !void {
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A, error.B => 0,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A, error.B => 0,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testElse() !void {
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    else => 1,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 1,
+                    else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 1), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    else => 1,
+                };
+                try expectEqual(@as(u64, 1), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testCapture() !void {
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => |e| @intFromError(e) + 4,
+                    else => 0,
+                };
+                try expectEqual(@as(u64, @intFromError(error.A) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => |e| @intFromError(e) + 4,
+                    else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testInline() !void {
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    inline else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => |e| @intFromError(e) + 4,
+                    inline else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    inline else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.A => 0,
+                    inline error.B, error.C => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testEmptyErrSet() !void {
+            {
+                var a: error{}!u64 = 0;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    else => |e| return e,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: error{}!u64 = 0;
+                _ = &a;
+                const b: u64 = a catch |err| switch (err) {
+                    error.UnknownError => return error.Fail,
+                    else => |e| return e,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+        }
+    };
+
+    try comptime S.doTheTest();
+    try S.doTheTest();
+}
+
+test "switch on error union if else capture" {
+    const S = struct {
+        const Error = error{ A, B, C };
+        fn doTheTest() !void {
+            try testScalar();
+            try testScalarPtr();
+            try testMulti();
+            try testMultiPtr();
+            try testElse();
+            try testElsePtr();
+            try testCapture();
+            try testCapturePtr();
+            try testInline();
+            try testInlinePtr();
+            try testEmptyErrSet();
+            try testEmptyErrSetPtr();
+        }
+
+        fn testScalar() !void {
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    error.B => 1,
+                    error.C => 2,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    error.B => @intFromError(err) + 4,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    error.B => @intFromError(err) + 4,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+        }
+
+        fn testScalarPtr() !void {
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    error.B => 1,
+                    error.C => 2,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    error.B => @intFromError(err) + 4,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    error.B => @intFromError(err) + 4,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+        }
+
+        fn testMulti() !void {
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A, error.B => 0,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A, error.B => 0,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testMultiPtr() !void {
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A, error.B => 0,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A, error.B => 0,
+                    error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testElse() !void {
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    else => 1,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 1,
+                    else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 1), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    else => 1,
+                };
+                try expectEqual(@as(u64, 1), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testElsePtr() !void {
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    else => 1,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = 3;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 3), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 1,
+                    else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, 1), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    else => 1,
+                };
+                try expectEqual(@as(u64, 1), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testCapture() !void {
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => |e| @intFromError(e) + 4,
+                    else => 0,
+                };
+                try expectEqual(@as(u64, @intFromError(error.A) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => |e| @intFromError(e) + 4,
+                    else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testCapturePtr() !void {
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => |e| @intFromError(e) + 4,
+                    else => 0,
+                };
+                try expectEqual(@as(u64, @intFromError(error.A) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.A;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => |e| @intFromError(e) + 4,
+                    else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    error.B, error.C => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testInline() !void {
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    inline else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => |e| @intFromError(e) + 4,
+                    inline else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    inline else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.A => 0,
+                    inline error.B, error.C => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testInlinePtr() !void {
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    inline else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => |e| @intFromError(e) + 4,
+                    inline else => @intFromError(err) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    inline else => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+            {
+                var a: Error!u64 = error.B;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.A => 0,
+                    inline error.B, error.C => |e| @intFromError(e) + 4,
+                };
+                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+            }
+        }
+
+        fn testEmptyErrSet() !void {
+            {
+                var a: error{}!u64 = 0;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    else => |e| return e,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: error{}!u64 = 0;
+                _ = &a;
+                const b: u64 = if (a) |x| x else |err| switch (err) {
+                    error.UnknownError => return error.Fail,
+                    else => |e| return e,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+        }
+
+        fn testEmptyErrSetPtr() !void {
+            {
+                var a: error{}!u64 = 0;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    else => |e| return e,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+            {
+                var a: error{}!u64 = 0;
+                _ = &a;
+                const b: u64 = if (a) |*x| x.* else |err| switch (err) {
+                    error.UnknownError => return error.Fail,
+                    else => |e| return e,
+                };
+                try expectEqual(@as(u64, 0), b);
+            }
+        }
+    };
+
+    try comptime S.doTheTest();
+    try S.doTheTest();
+}

--- a/test/cases/compile_errors/switch_expression-duplicate_error_prong.zig
+++ b/test/cases/compile_errors/switch_expression-duplicate_error_prong.zig
@@ -1,0 +1,33 @@
+fn f(n: Error!i32) i32 {
+    if (n) |x|
+        _ = x
+    else |e| switch (e) {
+        error.Foo => 1,
+        error.Bar => 2,
+        error.Baz => 3,
+        error.Foo => 2,
+    }
+}
+fn g(n: Error!i32) i32 {
+    n catch |e| switch (e) {
+        error.Foo => 1,
+        error.Bar => 2,
+        error.Baz => 3,
+        error.Foo => 2,
+    };
+}
+
+const Error = error{ Foo, Bar, Baz };
+
+export fn entry() usize {
+    return @sizeOf(@TypeOf(&f)) + @sizeOf(@TypeOf(&g));
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :8:9: error: duplicate switch value
+// :5:9: note: previous value here
+// :16:9: error: duplicate switch value
+// :13:9: note: previous value here

--- a/test/cases/compile_errors/switch_expression-duplicate_error_prong_when_else_present.zig
+++ b/test/cases/compile_errors/switch_expression-duplicate_error_prong_when_else_present.zig
@@ -1,0 +1,35 @@
+fn f(n: Error!i32) i32 {
+    if (n) |x|
+        _ = x
+    else |e| switch (e) {
+        error.Foo => 1,
+        error.Bar => 2,
+        error.Baz => 3,
+        error.Foo => 2,
+        else => 10,
+    }
+}
+fn g(n: Error!i32) i32 {
+    n catch |e| switch (e) {
+        error.Foo => 1,
+        error.Bar => 2,
+        error.Baz => 3,
+        error.Foo => 2,
+        else => 10,
+    };
+}
+
+const Error = error{ Foo, Bar, Baz };
+
+export fn entry() usize {
+    return @sizeOf(@TypeOf(&f)) + @sizeOf(@TypeOf(&g));
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :8:9: error: duplicate switch value
+// :5:9: note: previous value here
+// :17:9: error: duplicate switch value
+// :14:9: note: previous value here

--- a/test/cases/compile_errors/switch_expression-missing_error_prong.zig
+++ b/test/cases/compile_errors/switch_expression-missing_error_prong.zig
@@ -1,0 +1,33 @@
+const Error = error {
+    One,
+    Two,
+    Three,
+    Four,
+};
+fn f(n: Error!i32) i32 {
+    if (n) |x| x else |e| switch (e) {
+        error.One => 1,
+        error.Two => 2,
+        error.Three => 3,
+    }
+}
+fn h(n: Error!i32) i32 {
+    n catch |e| switch (e) {
+        error.One => 1,
+        error.Two => 2,
+        error.Three => 3,
+    };
+}
+
+export fn entry() usize {
+    return @sizeOf(@TypeOf(&f)) + @sizeOf(@TypeOf(&h));
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :8:27: error: switch must handle all possibilities
+// :8:27: note: unhandled error value: 'error.Four'
+// :15:17: error: switch must handle all possibilities
+// :15:17: note: unhandled error value: 'error.Four'

--- a/test/cases/compile_errors/switch_expression-multiple_else_prongs.zig
+++ b/test/cases/compile_errors/switch_expression-multiple_else_prongs.zig
@@ -5,8 +5,24 @@ fn f(x: u32) void {
         else => true,
     };
 }
+fn g(x: error{Foo, Bar, Baz}!u32) void {
+    const value: bool = if (x) |_| true else |e| switch (e) {
+        error.Foo => false,
+        else => true,
+        else => true,
+    };
+}
+fn h(x: error{Foo, Bar, Baz}!u32) void {
+    const value: u32 = x catch |e| switch (e) {
+        error.Foo => 1,
+        else => 2,
+        else => 3,
+    };
+}
 export fn entry() void {
     f(1234);
+    g(1234);
+    h(1234);
 }
 
 // error
@@ -15,3 +31,7 @@ export fn entry() void {
 //
 // :5:9: error: multiple else prongs in switch expression
 // :4:9: note: previous else prong here
+// :12:9: error: multiple else prongs in switch expression
+// :11:9: note: previous else prong here
+// :19:9: error: multiple else prongs in switch expression
+// :18:9: note: previous else prong here

--- a/test/cases/compile_errors/switch_expression-unreachable_else_prong_error.zig
+++ b/test/cases/compile_errors/switch_expression-unreachable_else_prong_error.zig
@@ -1,0 +1,32 @@
+fn foo(x: u2) void {
+    const y: Error!u2 = x;
+    if (y) |_| {} else |e| switch (e) {
+        error.Foo => {},
+        error.Bar => {},
+        error.Baz => {},
+        else => {},
+    }
+}
+
+fn bar(x: u2) void {
+    const y: Error!u2 = x;
+    y catch |e| switch (e) {
+        error.Foo => {},
+        error.Bar => {},
+        error.Baz => {},
+        else => {},
+    };
+}
+
+const Error = error{ Foo, Bar, Baz };
+
+export fn entry() usize {
+    return @sizeOf(@TypeOf(&foo)) + @sizeOf(@TypeOf(&bar));
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :7:14: error: unreachable else prong; all cases already handled
+// :17:14: error: unreachable else prong; all cases already handled

--- a/test/cases/compile_errors/switch_on_error_union_discard.zig
+++ b/test/cases/compile_errors/switch_on_error_union_discard.zig
@@ -1,0 +1,12 @@
+export fn entry() void {
+    const x: error{}!u32 = 0;
+    if (x) |v| v else |_| switch (_) {
+    }
+}
+
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:24: error: discard of error capture; omit it instead

--- a/test/cases/compile_errors/switch_on_error_with_1_field_with_no_prongs.zig
+++ b/test/cases/compile_errors/switch_on_error_with_1_field_with_no_prongs.zig
@@ -1,0 +1,20 @@
+const Error = error{M};
+
+export fn entry() void {
+    const f: Error!void = void{};
+    if (f) {} else |e| switch (e) {}
+}
+
+export fn entry2() void {
+    const f: Error!void = void{};
+    f catch |e| switch (e) {};
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :5:24: error: switch must handle all possibilities
+// :5:24: note: unhandled error value: 'error.M'
+// :10:17: error: switch must handle all possibilities
+// :10:17: note: unhandled error value: 'error.M'

--- a/test/cases/inherit_want_safety.zig
+++ b/test/cases/inherit_want_safety.zig
@@ -23,6 +23,13 @@ pub export fn entry() usize {
             u += 1;
         },
     }
+    if (@as(error{}!usize, u)) |_| {
+        u += 1;
+    } else |e| switch (e) {
+        else => {
+            u += 1;
+        }
+    }
     return u;
 }
 


### PR DESCRIPTION
Closes #11957 and as well as the related issues #16770 and #11812.

There are a few things left to do before merging:

  - [x] implement AstGen (and any sema changes needed) for `if (x) { ... } else |err| switch (err) { ... }` pattern
  - [x] check compile error messages makes sense (e.g. source locations) and consider adding compile error test cases
  - [x] cleanup commit history (drop commit adding `-Donly-ast-check` build flag?)
  - [x] look for ways to share more logic between normal switch, condbr and error union switch (both in `AstGen.zig` and `Sema.zig`)
  - [x] mention the special-cased `if` and `catch` patterns in langref (contrast with using a block around the `switch`)