### PR TITLE
TLS: The 0x1306 TLS identifier was updated to TLS_AEGIS_256_SHA512

### DIFF
--- a/lib/std/crypto/tls.zig
+++ b/lib/std/crypto/tls.zig
@@ -290,7 +290,7 @@ pub const CipherSuite = enum(u16) {
     CHACHA20_POLY1305_SHA256 = 0x1303,
     AES_128_CCM_SHA256 = 0x1304,
     AES_128_CCM_8_SHA256 = 0x1305,
-    AEGIS_256_SHA384 = 0x1306,
+    AEGIS_256_SHA512 = 0x1306,
     AEGIS_128L_SHA256 = 0x1307,
     _,
 };
@@ -330,7 +330,7 @@ pub const HandshakeCipher = union(enum) {
     AES_128_GCM_SHA256: HandshakeCipherT(crypto.aead.aes_gcm.Aes128Gcm, crypto.hash.sha2.Sha256),
     AES_256_GCM_SHA384: HandshakeCipherT(crypto.aead.aes_gcm.Aes256Gcm, crypto.hash.sha2.Sha384),
     CHACHA20_POLY1305_SHA256: HandshakeCipherT(crypto.aead.chacha_poly.ChaCha20Poly1305, crypto.hash.sha2.Sha256),
-    AEGIS_256_SHA384: HandshakeCipherT(crypto.aead.aegis.Aegis256, crypto.hash.sha2.Sha384),
+    AEGIS_256_SHA512: HandshakeCipherT(crypto.aead.aegis.Aegis256, crypto.hash.sha2.Sha512),
     AEGIS_128L_SHA256: HandshakeCipherT(crypto.aead.aegis.Aegis128L, crypto.hash.sha2.Sha256),
 };
 
@@ -355,7 +355,7 @@ pub const ApplicationCipher = union(enum) {
     AES_128_GCM_SHA256: ApplicationCipherT(crypto.aead.aes_gcm.Aes128Gcm, crypto.hash.sha2.Sha256),
     AES_256_GCM_SHA384: ApplicationCipherT(crypto.aead.aes_gcm.Aes256Gcm, crypto.hash.sha2.Sha384),
     CHACHA20_POLY1305_SHA256: ApplicationCipherT(crypto.aead.chacha_poly.ChaCha20Poly1305, crypto.hash.sha2.Sha256),
-    AEGIS_256_SHA384: ApplicationCipherT(crypto.aead.aegis.Aegis256, crypto.hash.sha2.Sha384),
+    AEGIS_256_SHA512: ApplicationCipherT(crypto.aead.aegis.Aegis256, crypto.hash.sha2.Sha512),
     AEGIS_128L_SHA256: ApplicationCipherT(crypto.aead.aegis.Aegis128L, crypto.hash.sha2.Sha256),
 };
 

--- a/lib/std/crypto/tls/Client.zig
+++ b/lib/std/crypto/tls/Client.zig
@@ -569,7 +569,7 @@ pub fn init(stream: anytype, ca_bundle: Certificate.Bundle, host: []const u8) In
                             try hsd.ensure(sig_len);
                             const encoded_sig = hsd.slice(sig_len);
                             const max_digest_len = 64;
-                            var verify_buffer =
+                            var verify_buffer: [64 + 34 + max_digest_len]u8 =
                                 ([1]u8{0x20} ** 64) ++
                                 "TLS 1.3, server CertificateVerify\x00".* ++
                                 @as([max_digest_len]u8, undefined);

--- a/lib/std/crypto/tls/Client.zig
+++ b/lib/std/crypto/tls/Client.zig
@@ -355,7 +355,7 @@ pub fn init(stream: anytype, ca_bundle: Certificate.Bundle, host: []const u8) In
                     inline .AES_128_GCM_SHA256,
                     .AES_256_GCM_SHA384,
                     .CHACHA20_POLY1305_SHA256,
-                    .AEGIS_256_SHA384,
+                    .AEGIS_256_SHA512,
                     .AEGIS_128L_SHA256,
                     => |tag| {
                         const P = std.meta.TagPayloadByName(tls.HandshakeCipher, @tagName(tag));
@@ -1406,7 +1406,7 @@ fn limitVecs(iovecs: []std.os.iovec, len: usize) []std.os.iovec {
 const cipher_suites = if (crypto.core.aes.has_hardware_support)
     enum_array(tls.CipherSuite, &.{
         .AEGIS_128L_SHA256,
-        .AEGIS_256_SHA384,
+        .AEGIS_256_SHA512,
         .AES_128_GCM_SHA256,
         .AES_256_GCM_SHA384,
         .CHACHA20_POLY1305_SHA256,
@@ -1415,7 +1415,7 @@ else
     enum_array(tls.CipherSuite, &.{
         .CHACHA20_POLY1305_SHA256,
         .AEGIS_128L_SHA256,
-        .AEGIS_256_SHA384,
+        .AEGIS_256_SHA512,
         .AES_128_GCM_SHA256,
         .AES_256_GCM_SHA384,
     });


### PR DESCRIPTION
Following the recommendations from [1], the AEGIS specification and the TLS registry [2] were updated to recommend SHA512 for the traffic secrets.

[1] https://eprint.iacr.org/2023/913.pdf
[2] https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4