### PR TITLE
add getName helper to inotify_event

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -3621,7 +3621,7 @@ pub const inotify_event = extern struct {
     // returns `null` if the directory/file is the one being watched
     pub fn getName(self: *const inotify_event) ?[:0]const u8 {
         if (self.len == 0) return null;
-        return std.mem.sliceTo(@as([*:0]const u8, @ptrCast(self)) + @sizeOf(inotify_event), 0);
+        return std.mem.span(@as([*:0]const u8, @ptrCast(self)) + @sizeOf(inotify_event));
     }
 };
 

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -3615,6 +3615,14 @@ pub const inotify_event = extern struct {
     cookie: u32,
     len: u32,
     //name: [?]u8,
+
+    // if an event is returned for a directory or file inside the directory being watched
+    // returns the name of said directory/file
+    // returns `null` if the directory/file is the one being watched
+    pub fn getName(self: *const inotify_event) ?[:0]const u8 {
+        if (self.len == 0) return null;
+        return std.mem.sliceTo(@as([*:0]const u8, @ptrCast(self)) + @sizeOf(inotify_event), 0);
+    }
 };
 
 pub const dirent64 = extern struct {


### PR DESCRIPTION
the name field is represented as trailing data after the struct so it can be confusing how to get it