### PR TITLE
Don't crash or CR/LF line endings in docgen

### DIFF
--- a/tools/docgen.zig
+++ b/tools/docgen.zig
@@ -970,7 +970,7 @@ fn tokenizeAndPrintRaw(
     source_token: Token,
     raw_src: []const u8,
 ) !void {
-    const src_non_terminated = mem.trim(u8, raw_src, " \n");
+    const src_non_terminated = mem.trim(u8, raw_src, " \r\n");
     const src = try allocator.dupeZ(u8, src_non_terminated);
 
     try out.writeAll("<code>" ++ start_line);
@@ -1233,7 +1233,7 @@ fn printSourceBlock(allocator: Allocator, docgen_tokenizer: *Tokenizer, out: any
         .zig => try tokenizeAndPrint(allocator, docgen_tokenizer, out, syntax_block.source_token),
         else => {
             const raw_source = docgen_tokenizer.buffer[syntax_block.source_token.start..syntax_block.source_token.end];
-            const trimmed_raw_source = mem.trim(u8, raw_source, " \n");
+            const trimmed_raw_source = mem.trim(u8, raw_source, " \r\n");
 
             try out.writeAll("<code>" ++ start_line);
             try writeEscapedLines(out, trimmed_raw_source);
@@ -1244,12 +1244,12 @@ fn printSourceBlock(allocator: Allocator, docgen_tokenizer: *Tokenizer, out: any
 }
 
 fn printShell(out: anytype, shell_content: []const u8, escape: bool) !void {
-    const trimmed_shell_content = mem.trim(u8, shell_content, " \n");
+    const trimmed_shell_content = mem.trim(u8, shell_content, " \r\n");
     try out.writeAll("<figure><figcaption class=\"shell-cap\">Shell</figcaption><pre><samp>");
     var cmd_cont: bool = false;
     var iter = std.mem.splitScalar(u8, trimmed_shell_content, '\n');
     while (iter.next()) |orig_line| {
-        const line = mem.trimRight(u8, orig_line, " ");
+        const line = mem.trimRight(u8, orig_line, " \r");
         if (!cmd_cont and line.len > 1 and mem.eql(u8, line[0..2], "$ ") and line[line.len - 1] != '\\') {
             try out.writeAll("$ <kbd>");
             const s = std.mem.trimLeft(u8, line[1..], " ");
@@ -1381,7 +1381,7 @@ fn genHtml(
                 }
 
                 const raw_source = tokenizer.buffer[code.source_token.start..code.source_token.end];
-                const trimmed_raw_source = mem.trim(u8, raw_source, " \n");
+                const trimmed_raw_source = mem.trim(u8, raw_source, " \r\n");
                 const tmp_source_file_name = try fs.path.join(
                     allocator,
                     &[_][]const u8{ tmp_dir_name, name_plus_ext },
@@ -2108,6 +2108,20 @@ test "printShell" {
             \\$ zig build test.zig
             \\build output
         ;
+        const expected =
+            \\<figure><figcaption class="shell-cap">Shell</figcaption><pre><samp>$ <kbd>zig build test.zig</kbd>
+            \\build output
+            \\</samp></pre></figure>
+        ;
+
+        var buffer = std.ArrayList(u8).init(test_allocator);
+        defer buffer.deinit();
+
+        try printShell(buffer.writer(), shell_out, false);
+        try testing.expectEqualSlices(u8, expected, buffer.items);
+    }
+    {
+        const shell_out = "$ zig build test.zig\r\nbuild output\r\n";
         const expected =
             \\<figure><figcaption class="shell-cap">Shell</figcaption><pre><samp>$ <kbd>zig build test.zig</kbd>
             \\build output


### PR DESCRIPTION
Fix crash when trying to build zig using zig-boostrap on Windows if `\r\n` line endings present in `langref.html`
Ref https://github.com/ziglang/zig-bootstrap/issues/162