### PR TITLE
Fix minor error: std.ChildProcess.exec() already rename to run()

### DIFF
--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -1790,7 +1790,7 @@ fn runOneCase(
                     try comp.makeBinFileExecutable();
 
                     while (true) {
-                        break :x std.ChildProcess.exec(.{
+                        break :x std.ChildProcess.run(.{
                             .allocator = allocator,
                             .argv = argv.items,
                             .cwd_dir = tmp.dir,


### PR DESCRIPTION
relate commit: 
[child_process + Build: rename exec to run + all related code](https://github.com/ziglang/zig/commit/fd2239bde9e2051a32fb25c50c732a40d4afccd0)