### PR TITLE
langref: fix incorrect reference to string literal

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -10595,7 +10595,7 @@ pub fn main() !void {
       {#header_close#}
 
       {#header_open|Where are the bytes?#}
-      <p>String literals such as {#syntax#}"foo"{#endsyntax#} are in the global constant data section.
+      <p>String literals such as {#syntax#}"hello"{#endsyntax#} are in the global constant data section.
       This is why it is an error to pass a string literal to a mutable slice, like this:
       </p>
       {#code_begin|test_err|test_string_literal_to_slice|expected type '[]u8', found '*const [5:0]u8'#}


### PR DESCRIPTION
This fixes what appears to be an incorrect reference to a string literal in the example code snippet. The current version makes reference to a `"foo"` string literal, when in the snippet it's actually a `"hello"` string literal.

```zig
fn foo(s: []u8) void {
    _ = s;
}

test "string literal to mutable slice" {
    foo("hello");
}
```