### PR TITLE
elf: report errors for some detected malformed object contents

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1042,7 +1042,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
 
     for (positionals.items) |obj| {
         self.parsePositional(obj.path, obj.must_link) catch |err| switch (err) {
-            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => continue, // already reported
             else => |e| try self.reportParseError(
                 obj.path,
                 "unexpected error: parsing input file failed with error {s}",
@@ -1128,7 +1128,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
 
     for (system_libs.items) |lib| {
         self.parseLibrary(lib, false) catch |err| switch (err) {
-            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => continue, // already reported
             else => |e| try self.reportParseError(
                 lib.path,
                 "unexpected error: parsing library failed with error {s}",
@@ -1151,7 +1151,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
 
     for (positionals.items) |obj| {
         self.parsePositional(obj.path, obj.must_link) catch |err| switch (err) {
-            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => continue, // already reported
             else => |e| try self.reportParseError(
                 obj.path,
                 "unexpected error: parsing input file failed with error {s}",
@@ -1316,7 +1316,7 @@ pub fn flushStaticLib(self: *Elf, comp: *Compilation, module_obj_path: ?[]const 
 
     for (positionals.items) |obj| {
         self.parsePositional(obj.path, obj.must_link) catch |err| switch (err) {
-            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => continue, // already reported
             else => |e| try self.reportParseError(
                 obj.path,
                 "unexpected error: parsing input file failed with error {s}",
@@ -1453,7 +1453,7 @@ pub fn flushObject(self: *Elf, comp: *Compilation, module_obj_path: ?[]const u8)
 
     for (positionals.items) |obj| {
         self.parsePositional(obj.path, obj.must_link) catch |err| switch (err) {
-            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => continue, // already reported
             else => |e| try self.reportParseError(
                 obj.path,
                 "unexpected error: parsing input file failed with error {s}",
@@ -1959,7 +1959,7 @@ fn parseLdScript(self: *Elf, lib: SystemLib) ParseError!void {
             .needed = scr_obj.needed,
             .path = full_path,
         }, false) catch |err| switch (err) {
-            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => continue, // already reported
             else => |e| try self.reportParseError(
                 full_path,
                 "unexpected error: parsing library failed with error {s}",

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1331,6 +1331,8 @@ pub fn flushStaticLib(self: *Elf, comp: *Compilation, module_obj_path: ?[]const 
         };
     }
 
+    if (self.misc_errors.items.len > 0) return error.FlushFailure;
+
     // First, we flush relocatable object file generated with our backends.
     if (self.zigObjectPtr()) |zig_object| {
         zig_object.resolveSymbols(self);
@@ -1468,10 +1470,14 @@ pub fn flushObject(self: *Elf, comp: *Compilation, module_obj_path: ?[]const u8)
         };
     }
 
+    if (self.misc_errors.items.len > 0) return error.FlushFailure;
+
     // Init all objects
     for (self.objects.items) |index| {
         try self.file(index).?.object.init(self);
     }
+
+    if (self.misc_errors.items.len > 0) return error.FlushFailure;
 
     // Now, we are ready to resolve the symbols across all input files.
     // We will first resolve the files in the ZigObject, next in the parsed

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1042,7 +1042,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
 
     for (positionals.items) |obj| {
         self.parsePositional(obj.path, obj.must_link) catch |err| switch (err) {
-            error.MalformedObject, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
             else => |e| try self.reportParseError(
                 obj.path,
                 "unexpected error: parsing input file failed with error {s}",
@@ -1128,7 +1128,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
 
     for (system_libs.items) |lib| {
         self.parseLibrary(lib, false) catch |err| switch (err) {
-            error.MalformedObject, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
             else => |e| try self.reportParseError(
                 lib.path,
                 "unexpected error: parsing library failed with error {s}",
@@ -1151,7 +1151,7 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
 
     for (positionals.items) |obj| {
         self.parsePositional(obj.path, obj.must_link) catch |err| switch (err) {
-            error.MalformedObject, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
             else => |e| try self.reportParseError(
                 obj.path,
                 "unexpected error: parsing input file failed with error {s}",
@@ -1316,7 +1316,7 @@ pub fn flushStaticLib(self: *Elf, comp: *Compilation, module_obj_path: ?[]const 
 
     for (positionals.items) |obj| {
         self.parsePositional(obj.path, obj.must_link) catch |err| switch (err) {
-            error.MalformedObject, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
             else => |e| try self.reportParseError(
                 obj.path,
                 "unexpected error: parsing input file failed with error {s}",
@@ -1453,7 +1453,7 @@ pub fn flushObject(self: *Elf, comp: *Compilation, module_obj_path: ?[]const u8)
 
     for (positionals.items) |obj| {
         self.parsePositional(obj.path, obj.must_link) catch |err| switch (err) {
-            error.MalformedObject, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
             else => |e| try self.reportParseError(
                 obj.path,
                 "unexpected error: parsing input file failed with error {s}",
@@ -1959,7 +1959,7 @@ fn parseLdScript(self: *Elf, lib: SystemLib) ParseError!void {
             .needed = scr_obj.needed,
             .path = full_path,
         }, false) catch |err| switch (err) {
-            error.MalformedObject, error.InvalidCpuArch => {}, // already reported
+            error.MalformedObject, error.MalformedArchive, error.InvalidCpuArch => {}, // already reported
             else => |e| try self.reportParseError(
                 full_path,
                 "unexpected error: parsing library failed with error {s}",

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1160,6 +1160,8 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
         };
     }
 
+    if (self.misc_errors.items.len > 0) return error.FlushFailure;
+
     // Init all objects
     for (self.objects.items) |index| {
         try self.file(index).?.object.init(self);
@@ -1167,6 +1169,8 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
     for (self.shared_objects.items) |index| {
         try self.file(index).?.shared_object.init(self);
     }
+
+    if (self.misc_errors.items.len > 0) return error.FlushFailure;
 
     // Dedup shared objects
     {
@@ -1294,6 +1298,8 @@ pub fn flushModule(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node
         self.error_flags.no_entry_point_found = false;
         try self.writeElfHeader();
     }
+
+    if (self.misc_errors.items.len > 0) return error.FlushFailure;
 }
 
 pub fn flushStaticLib(self: *Elf, comp: *Compilation, module_obj_path: ?[]const u8) link.File.FlushError!void {
@@ -2803,7 +2809,6 @@ fn linkWithLLD(self: *Elf, comp: *Compilation, prog_node: *std.Progress.Node) !v
                     }));
                 } else {
                     self.error_flags.missing_libc = true;
-                    return error.FlushFailure;
                 }
             }
         }

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1348,7 +1348,7 @@ pub fn flushStaticLib(self: *Elf, comp: *Compilation, module_obj_path: ?[]const 
         try self.allocateNonAllocSections();
 
         if (build_options.enable_logging) {
-            log.debug("{}", .{self.dumpState()});
+            state_log.debug("{}", .{self.dumpState()});
         }
 
         try self.writeSyntheticSectionsObject();

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1442,6 +1442,8 @@ pub fn flushStaticLib(self: *Elf, comp: *Compilation, module_obj_path: ?[]const 
 
     try self.base.file.?.setEndPos(total_size);
     try self.base.file.?.pwriteAll(buffer.items, 0);
+
+    if (self.misc_errors.items.len > 0) return error.FlushFailure;
 }
 
 pub fn flushObject(self: *Elf, comp: *Compilation, module_obj_path: ?[]const u8) link.File.FlushError!void {
@@ -1512,6 +1514,8 @@ pub fn flushObject(self: *Elf, comp: *Compilation, module_obj_path: ?[]const u8)
     try self.writeSyntheticSectionsObject();
     try self.writeShdrTable();
     try self.writeElfHeader();
+
+    if (self.misc_errors.items.len > 0) return error.FlushFailure;
 }
 
 /// --verbose-link output

--- a/src/link/Elf/Archive.zig
+++ b/src/link/Elf/Archive.zig
@@ -33,12 +33,10 @@ pub fn parse(self: *Archive, elf_file: *Elf) !void {
         const hdr = try reader.readStruct(elf.ar_hdr);
 
         if (!mem.eql(u8, &hdr.ar_fmag, elf.ARFMAG)) {
-            // TODO convert into an error
-            log.debug(
-                "{s}: invalid header delimiter: expected '{s}', found '{s}'",
-                .{ self.path, std.fmt.fmtSliceEscapeLower(elf.ARFMAG), std.fmt.fmtSliceEscapeLower(&hdr.ar_fmag) },
-            );
-            return;
+            try elf_file.reportParseError(self.path, "invalid archive header delimiter: {s}", .{
+                std.fmt.fmtSliceEscapeLower(&hdr.ar_fmag),
+            });
+            return error.MalformedArchive;
         }
 
         const size = try hdr.size();

--- a/src/link/Elf/LdScript.zig
+++ b/src/link/Elf/LdScript.zig
@@ -32,7 +32,7 @@ pub fn parse(scr: *LdScript, data: []const u8, elf_file: *Elf) Error!void {
         switch (tok.id) {
             .invalid => {
                 try elf_file.reportParseError(scr.path, "invalid token in LD script: '{s}' ({d}:{d})", .{
-                    tok.get(data),
+                    std.fmt.fmtSliceEscapeLower(tok.get(data)),
                     line,
                     column,
                 });

--- a/src/link/Elf/LdScript.zig
+++ b/src/link/Elf/LdScript.zig
@@ -1,3 +1,4 @@
+path: []const u8,
 cpu_arch: ?std.Target.Cpu.Arch = null,
 args: std.ArrayListUnmanaged(Elf.SystemLib) = .{},
 
@@ -6,7 +7,7 @@ pub fn deinit(scr: *LdScript, allocator: Allocator) void {
 }
 
 pub const Error = error{
-    InvalidScript,
+    InvalidLdScript,
     UnexpectedToken,
     UnknownCpuArch,
     OutOfMemory,
@@ -30,13 +31,12 @@ pub fn parse(scr: *LdScript, data: []const u8, elf_file: *Elf) Error!void {
         try line_col.append(.{ .line = line, .column = column });
         switch (tok.id) {
             .invalid => {
-                // TODO errors
-                // elf_file.base.fatal("invalid token in ld script: '{s}' ({d}:{d})", .{
-                //     tok.get(data),
-                //     line,
-                //     column,
-                // });
-                return error.InvalidScript;
+                try elf_file.reportParseError(scr.path, "invalid token in LD script: '{s}' ({d}:{d})", .{
+                    tok.get(data),
+                    line,
+                    column,
+                });
+                return error.InvalidLdScript;
             },
             .new_line => {
                 line += 1;
@@ -55,17 +55,16 @@ pub fn parse(scr: *LdScript, data: []const u8, elf_file: *Elf) Error!void {
         .args = &args,
     }) catch |err| switch (err) {
         error.UnexpectedToken => {
-            // const last_token_id = parser.it.pos - 1;
-            // const last_token = parser.it.get(last_token_id);
-            // const lcol = line_col.items[last_token_id];
-            // TODO errors
-            // elf_file.base.fatal("unexpected token in ld script: {s} : '{s}' ({d}:{d})", .{
-            //     @tagName(last_token.id),
-            //     last_token.get(data),
-            //     lcol.line,
-            //     lcol.column,
-            // });
-            return error.InvalidScript;
+            const last_token_id = parser.it.pos - 1;
+            const last_token = parser.it.get(last_token_id);
+            const lcol = line_col.items[last_token_id];
+            try elf_file.reportParseError(scr.path, "unexpected token in LD script: {s}: '{s}' ({d}:{d})", .{
+                @tagName(last_token.id),
+                last_token.get(data),
+                lcol.line,
+                lcol.column,
+            });
+            return error.InvalidLdScript;
         },
         else => |e| return e,
     };

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -68,7 +68,7 @@ pub fn parse(self: *Object, elf_file: *Elf) !void {
     const gpa = elf_file.base.allocator;
 
     if (self.data.len < self.header.?.e_shoff or
-        self.data.len < self.header.?.e_shoff + self.header.?.e_shnum * @sizeOf(elf.Elf64_Shdr))
+        self.data.len < self.header.?.e_shoff + @as(u64, @intCast(self.header.?.e_shnum)) * @sizeOf(elf.Elf64_Shdr))
     {
         try elf_file.reportParseError2(
             self.index,

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -75,7 +75,7 @@ pub fn parse(self: *Object, elf_file: *Elf) !void {
             "corrupted header: section header table extends past the end of file",
             .{},
         );
-        return error.LinkFail;
+        return error.MalformedObject;
     }
 
     const shoff = math.cast(usize, self.header.?.e_shoff) orelse return error.Overflow;
@@ -88,7 +88,7 @@ pub fn parse(self: *Object, elf_file: *Elf) !void {
     for (shdrs) |shdr| {
         if (self.data.len < shdr.sh_offset or self.data.len < shdr.sh_offset + shdr.sh_size) {
             try elf_file.reportParseError2(self.index, "corrupted section header", .{});
-            return error.LinkFail;
+            return error.MalformedObject;
         }
         self.shdrs.appendAssumeCapacity(try ElfShdr.fromElf64Shdr(shdr));
     }

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -54,6 +54,15 @@ pub fn parse(self: *Object, elf_file: *Elf) !void {
 
     self.header = try reader.readStruct(elf.Elf64_Ehdr);
 
+    if (elf_file.base.options.target.cpu.arch != self.header.?.e_machine.toTargetCpuArch().?) {
+        try elf_file.reportParseError2(
+            self.index,
+            "invalid cpu architecture: {s}",
+            .{@tagName(self.header.?.e_machine.toTargetCpuArch().?)},
+        );
+        return error.InvalidCpuArch;
+    }
+
     if (self.header.?.e_shnum == 0) return;
 
     const gpa = elf_file.base.allocator;

--- a/src/link/Elf/SharedObject.zig
+++ b/src/link/Elf/SharedObject.zig
@@ -63,7 +63,7 @@ pub fn parse(self: *SharedObject, elf_file: *Elf) !void {
     }
 
     if (self.data.len < self.header.?.e_shoff or
-        self.data.len < self.header.?.e_shoff + self.header.?.e_shnum * @sizeOf(elf.Elf64_Shdr))
+        self.data.len < self.header.?.e_shoff + @as(u64, @intCast(self.header.?.e_shnum)) * @sizeOf(elf.Elf64_Shdr))
     {
         try elf_file.reportParseError2(
             self.index,

--- a/src/link/Elf/SharedObject.zig
+++ b/src/link/Elf/SharedObject.zig
@@ -70,7 +70,7 @@ pub fn parse(self: *SharedObject, elf_file: *Elf) !void {
             "corrupted header: section header table extends past the end of file",
             .{},
         );
-        return error.LinkFail;
+        return error.MalformedObject;
     }
 
     const shoff = std.math.cast(usize, self.header.?.e_shoff) orelse return error.Overflow;
@@ -84,7 +84,7 @@ pub fn parse(self: *SharedObject, elf_file: *Elf) !void {
     for (shdrs, 0..) |shdr, i| {
         if (self.data.len < shdr.sh_offset or self.data.len < shdr.sh_offset + shdr.sh_size) {
             try elf_file.reportParseError2(self.index, "corrupted section header", .{});
-            return error.LinkFail;
+            return error.MalformedObject;
         }
         self.shdrs.appendAssumeCapacity(try ElfShdr.fromElf64Shdr(shdr));
         switch (shdr.sh_type) {

--- a/src/link/Elf/SharedObject.zig
+++ b/src/link/Elf/SharedObject.zig
@@ -52,6 +52,27 @@ pub fn parse(self: *SharedObject, elf_file: *Elf) !void {
     const reader = stream.reader();
 
     self.header = try reader.readStruct(elf.Elf64_Ehdr);
+
+    if (elf_file.base.options.target.cpu.arch != self.header.?.e_machine.toTargetCpuArch().?) {
+        try elf_file.reportParseError2(
+            self.index,
+            "invalid cpu architecture: {s}",
+            .{@tagName(self.header.?.e_machine.toTargetCpuArch().?)},
+        );
+        return error.InvalidCpuArch;
+    }
+
+    if (self.data.len < self.header.?.e_shoff or
+        self.data.len < self.header.?.e_shoff + self.header.?.e_shnum * @sizeOf(elf.Elf64_Shdr))
+    {
+        try elf_file.reportParseError2(
+            self.index,
+            "corrupted header: section header table extends past the end of file",
+            .{},
+        );
+        return error.LinkFail;
+    }
+
     const shoff = std.math.cast(usize, self.header.?.e_shoff) orelse return error.Overflow;
 
     const shdrs = @as(
@@ -61,6 +82,10 @@ pub fn parse(self: *SharedObject, elf_file: *Elf) !void {
     try self.shdrs.ensureTotalCapacityPrecise(gpa, shdrs.len);
 
     for (shdrs, 0..) |shdr, i| {
+        if (self.data.len < shdr.sh_offset or self.data.len < shdr.sh_offset + shdr.sh_size) {
+            try elf_file.reportParseError2(self.index, "corrupted section header", .{});
+            return error.LinkFail;
+        }
         self.shdrs.appendAssumeCapacity(try ElfShdr.fromElf64Shdr(shdr));
         switch (shdr.sh_type) {
             elf.SHT_DYNSYM => self.dynsym_sect_index = @as(u16, @intCast(i)),

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -162,17 +162,17 @@ pub const File = union(enum) {
         state.name_off = try ar_strtab.insert(allocator, path);
     }
 
-    pub fn updateArSize(file: File, elf_file: *Elf) void {
+    pub fn updateArSize(file: File) void {
         return switch (file) {
-            .zig_object => |x| x.updateArSize(elf_file),
+            .zig_object => |x| x.updateArSize(),
             .object => |x| x.updateArSize(),
             inline else => unreachable,
         };
     }
 
-    pub fn writeAr(file: File, elf_file: *Elf, writer: anytype) !void {
+    pub fn writeAr(file: File, writer: anytype) !void {
         return switch (file) {
-            .zig_object => |x| x.writeAr(elf_file, writer),
+            .zig_object => |x| x.writeAr(writer),
             .object => |x| x.writeAr(writer),
             inline else => unreachable,
         };

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -1877,8 +1877,6 @@ fn testMismatchedCpuArchitectureError(b: *Build, opts: Options) *Step {
     expectLinkErrors(exe, test_step, .{ .exact = &.{
         "invalid cpu architecture: aarch64",
         "note: while parsing /?/a.o",
-        "undefined symbol: foo",
-        "note: referenced by /?/a.o:.text",
     } });
 
     return test_step;
@@ -3309,10 +3307,8 @@ fn testUnknownFileTypeError(b: *Build, opts: Options) *Step {
     expectLinkErrors(exe, test_step, .{ .exact = &.{
         "invalid token in LD script: '\\x00\\x00\\x00\\x0c\\x00\\x00\\x00/usr/lib/dyld\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0d' (0:829)",
         "note: while parsing /?/liba.dylib",
-        "error: unexpected error: parsing input file failed with error InvalidLdScript",
+        "unexpected error: parsing input file failed with error InvalidLdScript",
         "note: while parsing /?/liba.dylib",
-        "undefined symbol: foo",
-        "note: referenced by /?/a.o:.text",
     } });
 
     return test_step;

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -1875,8 +1875,10 @@ fn testMismatchedCpuArchitectureError(b: *Build, opts: Options) *Step {
     exe.linkLibC();
 
     expectLinkErrors(exe, test_step, .{ .exact = &.{
-        "invalid cpu architecture: expected 'x86_64', but found 'aarch64'",
+        "invalid cpu architecture: aarch64",
         "note: while parsing /?/a.o",
+        "undefined symbol: foo",
+        "note: referenced by /?/a.o:.text",
     } });
 
     return test_step;
@@ -3305,7 +3307,9 @@ fn testUnknownFileTypeError(b: *Build, opts: Options) *Step {
     exe.linkLibC();
 
     expectLinkErrors(exe, test_step, .{ .exact = &.{
-        "unknown file type",
+        "invalid token in LD script: '\\x00\\x00\\x00\\x0c\\x00\\x00\\x00/usr/lib/dyld\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0d' (0:829)",
+        "note: while parsing /?/liba.dylib",
+        "error: unexpected error: parsing input file failed with error InvalidLdScript",
         "note: while parsing /?/liba.dylib",
         "undefined symbol: foo",
         "note: referenced by /?/a.o:.text",


### PR DESCRIPTION
Fixes #18205

Although it fixes the above issue, it's just the beginning of proper error handling in the linker. I will be adding better error catching and reporting incrementally as it's quite an involved task.

This PR also addresses a latent bug in writing a static library when one source is incrementally compiled Zig source - an example of this could be generating `libcompiler_rt.a` without LLVM. The bug would incorrectly calculate the total size of the incrementally compiled Zig source and thus it would fail to correctly re-encode it in the output archive file.