### PR TITLE
fmt: fix inline for loop in as switch prong #18172

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -3365,6 +3365,15 @@ test "zig fmt: switch multiline string" {
     );
 }
 
+test "zig fmt: switch inline for loop" {
+    try testCanonical(
+        \\const a = switch (1) {
+        \\    inline for (1) |_| 1 => 1,
+        \\};
+        \\
+    );
+}
+
 test "zig fmt: while" {
     try testCanonical(
         \\test "while" {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -1971,11 +1971,6 @@ fn renderSwitchCase(
         break :blk hasComment(tree, tree.firstToken(switch_case.ast.values[0]), switch_case.ast.arrow_token);
     };
 
-    // render inline keyword
-    if (switch_case.inline_token) |some| {
-        try renderToken(r, some, .space);
-    }
-
     // Render everything before the arrow
     if (switch_case.ast.values.len == 0) {
         try renderToken(r, switch_case.ast.arrow_token - 1, .space); // else keyword


### PR DESCRIPTION
Fixes #18172

The `inline` keyword is already rendered in code below, this is no longer need (if it ever was). 