### PR TITLE
some GPU fixes

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -37186,7 +37186,7 @@ pub fn analyzeAddressSpace(
         // TODO: check that .shared and .local are left uninitialized
         .param => is_nv,
         .global, .shared, .local => is_gpu,
-        .constant => is_gpu and (ctx == .constant),
+        .constant => is_gpu and (ctx == .constant or ctx == .pointer),
         // TODO this should also check how many flash banks the cpu has
         .flash, .flash1, .flash2, .flash3, .flash4, .flash5 => arch == .avr,
     };

--- a/src/codegen/spirv/Cache.zig
+++ b/src/codegen/spirv/Cache.zig
@@ -66,15 +66,6 @@ const Tag = enum {
     /// Function (proto)type
     /// data is payload to FunctionType
     type_function,
-    // /// Pointer type in the CrossWorkgroup storage class
-    // /// data is child type
-    // type_ptr_generic,
-    // /// Pointer type in the CrossWorkgroup storage class
-    // /// data is child type
-    // type_ptr_crosswgp,
-    // /// Pointer type in the Function storage class
-    // /// data is child type
-    // type_ptr_function,
     /// Simple pointer type that does not have any decorations.
     /// data is payload to SimplePointerType
     type_ptr_simple,


### PR DESCRIPTION
This resolves https://github.com/ziglang/zig/issues/18208. The following kernel now compiles properly:
```zig
pub extern fn printf(format: [*:0]addrspace(.constant) const u8, ...) c_int;

export fn kernel() callconv(.Kernel) void {
    if (@workGroupId(0) == 0 and @workItemId(0) == 0) {
        _ = printf(@addrSpaceCast("Hello from kernel!\n".ptr));
    }
}
```
Note that the `@addrSpaceCast` is required here because string literals return a generic pointer, which does not automatically cast to a constant one.

Note that this only includes compilation support. To actually use `printf`, the ROCm-Device-Libs must be included in the binary, and for that we need to emulate the work that [comgr](https://github.com/ROCm/ROCm-CompilerSupport/tree/amd-stg-open/lib/comgr) does OR implement the relevant parts of the HIP GPU runtime ourself.