### PR TITLE
Sema: fix merging store instructions from a comptime struct value with `-fstrip`

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4783,11 +4783,9 @@ fn validateStructInit(
 
             const field_ptr_ref = sema.inst_map.get(field_ptr).?;
 
-            //std.debug.print("validateStructInit (field_ptr_air_inst=%{d}):\n", .{
-            //    field_ptr_air_inst,
-            //});
+            //std.debug.print("validateStructInit (field_ptr_ref=%{d}):\n", .{field_ptr_ref});
             //for (block.instructions.items) |item| {
-            //    std.debug.print("  %{d} = {s}\n", .{item, @tagName(air_tags[item])});
+            //    std.debug.print("  %{d} = {s}\n", .{item, @tagName(air_tags[@intFromEnum(item)])});
             //}
 
             // We expect to see something like this in the current block AIR:
@@ -4804,8 +4802,9 @@ fn validateStructInit(
 
             // Possible performance enhancement: save the `block_index` between iterations
             // of the for loop.
-            var block_index = block.instructions.items.len -| 1;
-            while (block_index > 0) : (block_index -= 1) {
+            var block_index = block.instructions.items.len;
+            while (block_index > 0) {
+                block_index -= 1;
                 const store_inst = block.instructions.items[block_index];
                 if (store_inst.toRef() == field_ptr_ref) {
                     struct_is_comptime = false;
@@ -5060,8 +5059,9 @@ fn zirValidatePtrArrayInit(
 
         // Possible performance enhancement: save the `block_index` between iterations
         // of the for loop.
-        var block_index = block.instructions.items.len -| 1;
-        while (block_index > 0) : (block_index -= 1) {
+        var block_index = block.instructions.items.len;
+        while (block_index > 0) {
+            block_index -= 1;
             const store_inst = block.instructions.items[block_index];
             if (store_inst.toRef() == elem_ptr_ref) {
                 array_is_comptime = false;


### PR DESCRIPTION
The first instruction in the block was never checked resulting in `struct_is_comptime` being incorrectly cleared if there are no instructions before the first field of the comptime struct.

EDIT: Can a test check this kind of bugs? I haven't written one as I haven't found how to.

Fixes #17119

---

Normal behavior with `-fno-strip`:
```
block.instructions.items = {
  %Air.Inst.Index(2) = dbg_block_begin,
  %Air.Inst.Index(3) = dbg_stmt,
  %Air.Inst.Index(4) = store_safe,
  %Air.Inst.Index(5) = store_safe,
}
```
store_inst=Index(5) -> `continue` at line 4823 -> store_inst=Index(4) -> `continue :field` at 4842, `struct_is_comptime` check passes

Incorrect behavior with `-fstrip` / `-O ReleaseSmall`:
```
block.instructions.items = {
  %Air.Inst.Index(1) = store_safe,
  %Air.Inst.Index(2) = store_safe,
}
```
store_inst=Index(2) -> `continue` at line 4823 -> leaves the inner loop and sets `struct_is_comptime = false` = the stores are not merged