### PR TITLE
langref: Fix example for Generic Data Structures

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7369,12 +7369,12 @@ const Node = struct {
 
 var node_a = Node{
     .next = null,
-    .name = &"Node A",
+    .name = "Node A",
 };
 
 var node_b = Node{
     .next = &node_a,
-    .name = &"Node B",
+    .name = "Node B",
 };
       {#code_end#}
       <p>


### PR DESCRIPTION
Small fix by removing the &-Operator in front of the string literals. The expected type is `[]const u8`.