### PR TITLE
lib/std/Build/CheckObject: introduce scoped checks

### DIFF
--- a/lib/std/Build/Step/CheckObject.zig
+++ b/lib/std/Build/Step/CheckObject.zig
@@ -2018,7 +2018,7 @@ const ElfDumper = struct {
             const symtab = switch (@"type") {
                 .symtab => ctx.symtab,
                 .dysymtab => ctx.dysymtab,
-            } orelse return;
+            };
 
             try writer.writeAll(switch (@"type") {
                 .symtab => symtab_label,

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -506,7 +506,7 @@ fn testCopyrelAlignment(b: *Build, opts: Options) *Step {
         test_step.dependOn(&run.step);
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("section headers");
         check.checkExact("name .copyrel");
         check.checkExact("addralign 20");
@@ -525,7 +525,7 @@ fn testCopyrelAlignment(b: *Build, opts: Options) *Step {
         test_step.dependOn(&run.step);
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("section headers");
         check.checkExact("name .copyrel");
         check.checkExact("addralign 8");
@@ -544,7 +544,7 @@ fn testCopyrelAlignment(b: *Build, opts: Options) *Step {
         test_step.dependOn(&run.step);
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("section headers");
         check.checkExact("name .copyrel");
         check.checkExact("addralign 100");
@@ -815,7 +815,7 @@ fn testEntryPoint(b: *Build, opts: Options) *Step {
         exe.entry = .{ .symbol_name = "foo" };
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("header");
         check.checkExact("entry 1000");
         test_step.dependOn(&check.step);
@@ -831,7 +831,7 @@ fn testEntryPoint(b: *Build, opts: Options) *Step {
         exe.entry = .{ .symbol_name = "bar" };
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("header");
         check.checkExact("entry 2000");
         test_step.dependOn(&check.step);
@@ -1460,13 +1460,13 @@ fn testIFuncStaticPie(b: *Build, opts: Options) *Step {
     test_step.dependOn(&run.step);
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("header");
     check.checkExact("type DYN");
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("section headers");
     check.checkExact("name .dynamic");
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("section headers");
     check.checkNotPresent("name .interp");
     test_step.dependOn(&check.step);
@@ -1494,7 +1494,7 @@ fn testImageBase(b: *Build, opts: Options) *Step {
         test_step.dependOn(&run.step);
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("header");
         check.checkExtract("entry {addr}");
         check.checkComputeCompare("addr", .{ .op = .gte, .value = .{ .literal = 0x8000000 } });
@@ -1507,7 +1507,7 @@ fn testImageBase(b: *Build, opts: Options) *Step {
         exe.image_base = 0xffffffff8000000;
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("header");
         check.checkExtract("entry {addr}");
         check.checkComputeCompare("addr", .{ .op = .gte, .value = .{ .literal = 0xffffffff8000000 } });
@@ -1937,10 +1937,10 @@ fn testLinkingC(b: *Build, opts: Options) *Step {
     test_step.dependOn(&run.step);
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("header");
     check.checkExact("type EXEC");
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("section headers");
     check.checkNotPresent("name .dynamic");
     test_step.dependOn(&check.step);
@@ -1967,10 +1967,10 @@ fn testLinkingCpp(b: *Build, opts: Options) *Step {
     test_step.dependOn(&run.step);
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("header");
     check.checkExact("type EXEC");
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("section headers");
     check.checkNotPresent("name .dynamic");
     test_step.dependOn(&check.step);
@@ -2055,10 +2055,10 @@ fn testLinkingZig(b: *Build, opts: Options) *Step {
     test_step.dependOn(&run.step);
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("header");
     check.checkExact("type EXEC");
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("section headers");
     check.checkNotPresent("name .dynamic");
     test_step.dependOn(&check.step);
@@ -2075,7 +2075,7 @@ fn testNoEhFrameHdr(b: *Build, opts: Options) *Step {
     exe.linkLibC();
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("section headers");
     check.checkNotPresent("name .eh_frame_hdr");
     test_step.dependOn(&check.step);
@@ -2103,10 +2103,10 @@ fn testPie(b: *Build, opts: Options) *Step {
     test_step.dependOn(&run.step);
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("header");
     check.checkExact("type DYN");
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("section headers");
     check.checkExact("name .dynamic");
     test_step.dependOn(&check.step);
@@ -2326,13 +2326,13 @@ fn testRelocatableNoEhFrame(b: *Build, opts: Options) *Step {
     obj2.addObject(obj1);
 
     const check1 = obj1.checkObject();
-    check1.checkStart();
+    check1.checkInHeaders();
     check1.checkExact("section headers");
     check1.checkNotPresent(".eh_frame");
     test_step.dependOn(&check1.step);
 
     const check2 = obj2.checkObject();
-    check2.checkStart();
+    check2.checkInHeaders();
     check2.checkExact("section headers");
     check2.checkNotPresent(".eh_frame");
     test_step.dependOn(&check2.step);
@@ -2369,7 +2369,7 @@ fn testSharedAbsSymbol(b: *Build, opts: Options) *Step {
         test_step.dependOn(&run.step);
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("header");
         check.checkExact("type DYN");
         // TODO fix/improve in CheckObject
@@ -2390,7 +2390,7 @@ fn testSharedAbsSymbol(b: *Build, opts: Options) *Step {
     //     test_step.dependOn(&run.step);
 
     //     const check = exe.checkObject();
-    //     check.checkStart();
+    //     check.checkInHeaders();
     //     check.checkExact("header");
     //     check.checkExact("type EXEC");
     //     // TODO fix/improve in CheckObject
@@ -2422,7 +2422,7 @@ fn testStrip(b: *Build, opts: Options) *Step {
         exe.linkLibC();
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("section headers");
         check.checkExact("name .debug_info");
         test_step.dependOn(&check.step);
@@ -2435,7 +2435,7 @@ fn testStrip(b: *Build, opts: Options) *Step {
         exe.linkLibC();
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("section headers");
         check.checkNotPresent("name .debug_info");
         test_step.dependOn(&check.step);
@@ -3521,7 +3521,7 @@ fn testZStackSize(b: *Build, opts: Options) *Step {
     exe.linkLibC();
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("program headers");
     check.checkExact("type GNU_STACK");
     check.checkExact("memsz 800000");

--- a/test/link/macho/dead_strip_dylibs/build.zig
+++ b/test/link/macho/dead_strip_dylibs/build.zig
@@ -19,11 +19,11 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         const exe = createScenario(b, optimize, "no-dead-strip");
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("cmd LOAD_DYLIB");
         check.checkContains("Cocoa");
 
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("cmd LOAD_DYLIB");
         check.checkContains("libobjc");
 

--- a/test/link/macho/dylib/build.zig
+++ b/test/link/macho/dylib/build.zig
@@ -25,7 +25,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     dylib.linkLibC();
 
     const check_dylib = dylib.checkObject();
-    check_dylib.checkStart();
+    check_dylib.checkInHeaders();
     check_dylib.checkExact("cmd ID_DYLIB");
     check_dylib.checkExact("name @rpath/liba.dylib");
     check_dylib.checkExact("timestamp 2");
@@ -46,14 +46,14 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.linkLibC();
 
     const check_exe = exe.checkObject();
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("cmd LOAD_DYLIB");
     check_exe.checkExact("name @rpath/liba.dylib");
     check_exe.checkExact("timestamp 2");
     check_exe.checkExact("current version 10000");
     check_exe.checkExact("compatibility version 10000");
 
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("cmd RPATH");
     check_exe.checkExactPath("path", dylib.getOutputDirectorySource());
     test_step.dependOn(&check_exe.step);

--- a/test/link/macho/entry/build.zig
+++ b/test/link/macho/entry/build.zig
@@ -24,11 +24,11 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
 
     const check_exe = exe.checkObject();
 
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("segname __TEXT");
     check_exe.checkExtract("vmaddr {vmaddr}");
 
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("cmd MAIN");
     check_exe.checkExtract("entryoff {entryoff}");
 

--- a/test/link/macho/entry_in_dylib/build.zig
+++ b/test/link/macho/entry_in_dylib/build.zig
@@ -34,15 +34,15 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.forceUndefinedSymbol("_my_main");
 
     const check_exe = exe.checkObject();
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("segname __TEXT");
     check_exe.checkExtract("vmaddr {text_vmaddr}");
 
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("sectname __stubs");
     check_exe.checkExtract("addr {stubs_vmaddr}");
 
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("cmd MAIN");
     check_exe.checkExtract("entryoff {entryoff}");
 

--- a/test/link/macho/headerpad/build.zig
+++ b/test/link/macho/headerpad/build.zig
@@ -21,7 +21,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         exe.headerpad_max_install_names = true;
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("sectname __text");
         check.checkExtract("offset {offset}");
 
@@ -47,7 +47,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         exe.headerpad_size = 0x10000;
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("sectname __text");
         check.checkExtract("offset {offset}");
         check.checkComputeCompare("offset", .{ .op = .gte, .value = .{ .literal = 0x10000 } });
@@ -65,7 +65,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         exe.headerpad_size = 0x10000;
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("sectname __text");
         check.checkExtract("offset {offset}");
         check.checkComputeCompare("offset", .{ .op = .gte, .value = .{ .literal = 0x10000 } });
@@ -83,7 +83,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         exe.headerpad_max_install_names = true;
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("sectname __text");
         check.checkExtract("offset {offset}");
 

--- a/test/link/macho/needed_framework/build.zig
+++ b/test/link/macho/needed_framework/build.zig
@@ -26,7 +26,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.dead_strip_dylibs = true;
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("cmd LOAD_DYLIB");
     check.checkContains("Cocoa");
     test_step.dependOn(&check.step);

--- a/test/link/macho/needed_library/build.zig
+++ b/test/link/macho/needed_library/build.zig
@@ -39,7 +39,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.dead_strip_dylibs = true;
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("cmd LOAD_DYLIB");
     check.checkExact("name @rpath/liba.dylib");
     test_step.dependOn(&check.step);

--- a/test/link/macho/pagezero/build.zig
+++ b/test/link/macho/pagezero/build.zig
@@ -20,13 +20,13 @@ pub fn build(b: *std.Build) void {
         exe.pagezero_size = 0x4000;
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("LC 0");
         check.checkExact("segname __PAGEZERO");
         check.checkExact("vmaddr 0");
         check.checkExact("vmsize 4000");
 
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("segname __TEXT");
         check.checkExact("vmaddr 4000");
 
@@ -44,7 +44,7 @@ pub fn build(b: *std.Build) void {
         exe.pagezero_size = 0;
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("LC 0");
         check.checkExact("segname __TEXT");
         check.checkExact("vmaddr 0");

--- a/test/link/macho/search_strategy/build.zig
+++ b/test/link/macho/search_strategy/build.zig
@@ -20,7 +20,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         const exe = createScenario(b, optimize, target, "search_dylibs_first", .mode_first);
 
         const check = exe.checkObject();
-        check.checkStart();
+        check.checkInHeaders();
         check.checkExact("cmd LOAD_DYLIB");
         check.checkExact("name @rpath/libsearch_dylibs_first.dylib");
         test_step.dependOn(&check.step);

--- a/test/link/macho/stack_size/build.zig
+++ b/test/link/macho/stack_size/build.zig
@@ -25,7 +25,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.stack_size = 0x100000000;
 
     const check_exe = exe.checkObject();
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("cmd MAIN");
     check_exe.checkExact("stacksize 100000000");
     test_step.dependOn(&check_exe.step);

--- a/test/link/macho/strict_validation/build.zig
+++ b/test/link/macho/strict_validation/build.zig
@@ -26,13 +26,13 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
 
     const check_exe = exe.checkObject();
 
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("cmd SEGMENT_64");
     check_exe.checkExact("segname __LINKEDIT");
     check_exe.checkExtract("fileoff {fileoff}");
     check_exe.checkExtract("filesz {filesz}");
 
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("cmd DYLD_INFO_ONLY");
     check_exe.checkExtract("rebaseoff {rebaseoff}");
     check_exe.checkExtract("rebasesize {rebasesize}");
@@ -43,31 +43,31 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     check_exe.checkExtract("exportoff {exportoff}");
     check_exe.checkExtract("exportsize {exportsize}");
 
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("cmd FUNCTION_STARTS");
     check_exe.checkExtract("dataoff {fstartoff}");
     check_exe.checkExtract("datasize {fstartsize}");
 
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("cmd DATA_IN_CODE");
     check_exe.checkExtract("dataoff {diceoff}");
     check_exe.checkExtract("datasize {dicesize}");
 
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("cmd SYMTAB");
     check_exe.checkExtract("symoff {symoff}");
     check_exe.checkExtract("nsyms {symnsyms}");
     check_exe.checkExtract("stroff {stroff}");
     check_exe.checkExtract("strsize {strsize}");
 
-    check_exe.checkStart();
+    check_exe.checkInHeaders();
     check_exe.checkExact("cmd DYSYMTAB");
     check_exe.checkExtract("indirectsymoff {dysymoff}");
     check_exe.checkExtract("nindirectsyms {dysymnsyms}");
 
     switch (builtin.cpu.arch) {
         .aarch64 => {
-            check_exe.checkStart();
+            check_exe.checkInHeaders();
             check_exe.checkExact("cmd CODE_SIGNATURE");
             check_exe.checkExtract("dataoff {codesigoff}");
             check_exe.checkExtract("datasize {codesigsize}");

--- a/test/link/macho/unwind_info/build.zig
+++ b/test/link/macho/unwind_info/build.zig
@@ -32,7 +32,7 @@ fn testUnwindInfo(
     exe.link_gc_sections = dead_strip;
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("segname __TEXT");
     check.checkExact("sectname __gcc_except_tab");
     check.checkExact("sectname __unwind_info");

--- a/test/link/macho/weak_framework/build.zig
+++ b/test/link/macho/weak_framework/build.zig
@@ -23,7 +23,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.linkFrameworkWeak("Cocoa");
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("cmd LOAD_WEAK_DYLIB");
     check.checkContains("Cocoa");
     test_step.dependOn(&check.step);

--- a/test/link/macho/weak_library/build.zig
+++ b/test/link/macho/weak_library/build.zig
@@ -37,7 +37,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     exe.addRPath(dylib.getEmittedBinDirectory());
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("cmd LOAD_WEAK_DYLIB");
     check.checkExact("name @rpath/liba.dylib");
 

--- a/test/link/wasm/archive/build.zig
+++ b/test/link/wasm/archive/build.zig
@@ -27,7 +27,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     lib.strip = false;
 
     const check = lib.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("Section custom");
     check.checkExact("name __trunch"); // Ensure it was imported and resolved
 

--- a/test/link/wasm/basic-features/build.zig
+++ b/test/link/wasm/basic-features/build.zig
@@ -21,7 +21,7 @@ pub fn build(b: *std.Build) void {
 
     // Verify the result contains the features explicitly set on the target for the library.
     const check = lib.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("name target_features");
     check.checkExact("features 1");
     check.checkExact("+ atomics");

--- a/test/link/wasm/bss/build.zig
+++ b/test/link/wasm/bss/build.zig
@@ -31,18 +31,18 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.Opt
         const check_lib = lib.checkObject();
 
         // since we import memory, make sure it exists with the correct naming
-        check_lib.checkStart();
+        check_lib.checkInHeaders();
         check_lib.checkExact("Section import");
         check_lib.checkExact("entries 1");
         check_lib.checkExact("module env"); // default module name is "env"
         check_lib.checkExact("name memory"); // as per linker specification
 
         // since we are importing memory, ensure it's not exported
-        check_lib.checkStart();
+        check_lib.checkInHeaders();
         check_lib.checkNotPresent("Section export");
 
         // validate the name of the stack pointer
-        check_lib.checkStart();
+        check_lib.checkInHeaders();
         check_lib.checkExact("Section custom");
         check_lib.checkExact("type data_segment");
         check_lib.checkExact("names 2");
@@ -77,7 +77,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.Opt
         lib.link_gc_sections = false;
 
         const check_lib = lib.checkObject();
-        check_lib.checkStart();
+        check_lib.checkInHeaders();
         check_lib.checkExact("Section custom");
         check_lib.checkExact("type data_segment");
         check_lib.checkExact("names 2");

--- a/test/link/wasm/export-data/build.zig
+++ b/test/link/wasm/export-data/build.zig
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build) void {
 
     const check_lib = lib.checkObject();
 
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("Section global");
     check_lib.checkExact("entries 3");
     check_lib.checkExact("type i32"); // stack pointer so skip other fields
@@ -35,7 +35,7 @@ pub fn build(b: *std.Build) void {
     check_lib.checkComputeCompare("foo_address", .{ .op = .eq, .value = .{ .literal = 4 } });
     check_lib.checkComputeCompare("bar_address", .{ .op = .eq, .value = .{ .literal = 0 } });
 
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("Section export");
     check_lib.checkExact("entries 3");
     check_lib.checkExact("name foo");

--- a/test/link/wasm/export/build.zig
+++ b/test/link/wasm/export/build.zig
@@ -46,21 +46,21 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     force_export.use_lld = false;
 
     const check_no_export = no_export.checkObject();
-    check_no_export.checkStart();
+    check_no_export.checkInHeaders();
     check_no_export.checkExact("Section export");
     check_no_export.checkExact("entries 1");
     check_no_export.checkExact("name memory");
     check_no_export.checkExact("kind memory");
 
     const check_dynamic_export = dynamic_export.checkObject();
-    check_dynamic_export.checkStart();
+    check_dynamic_export.checkInHeaders();
     check_dynamic_export.checkExact("Section export");
     check_dynamic_export.checkExact("entries 2");
     check_dynamic_export.checkExact("name foo");
     check_dynamic_export.checkExact("kind function");
 
     const check_force_export = force_export.checkObject();
-    check_force_export.checkStart();
+    check_force_export.checkInHeaders();
     check_force_export.checkExact("Section export");
     check_force_export.checkExact("entries 2");
     check_force_export.checkExact("name foo");

--- a/test/link/wasm/extern-mangle/build.zig
+++ b/test/link/wasm/extern-mangle/build.zig
@@ -22,7 +22,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     lib.rdynamic = true; // export `foo`
 
     const check_lib = lib.checkObject();
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("Section import");
     check_lib.checkExact("entries 2"); // a.hello & b.hello
     check_lib.checkExact("module a");

--- a/test/link/wasm/function-table/build.zig
+++ b/test/link/wasm/function-table/build.zig
@@ -52,7 +52,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     const check_export = export_table.checkObject();
     const check_regular = regular_table.checkObject();
 
-    check_import.checkStart();
+    check_import.checkInHeaders();
     check_import.checkExact("Section import");
     check_import.checkExact("entries 1");
     check_import.checkExact("module env");
@@ -63,20 +63,20 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     check_import.checkNotPresent("max"); // when importing, we do not provide a max
     check_import.checkNotPresent("Section table"); // we're importing it
 
-    check_export.checkStart();
+    check_export.checkInHeaders();
     check_export.checkExact("Section export");
     check_export.checkExact("entries 2");
     check_export.checkExact("name __indirect_function_table"); // as per linker specification
     check_export.checkExact("kind table");
 
-    check_regular.checkStart();
+    check_regular.checkInHeaders();
     check_regular.checkExact("Section table");
     check_regular.checkExact("entries 1");
     check_regular.checkExact("type funcref");
     check_regular.checkExact("min 2"); // index starts at 1 & 1 function pointer = 2.
     check_regular.checkExact("max 2");
 
-    check_regular.checkStart();
+    check_regular.checkInHeaders();
     check_regular.checkExact("Section element");
     check_regular.checkExact("entries 1");
     check_regular.checkExact("table index 0");

--- a/test/link/wasm/infer-features/build.zig
+++ b/test/link/wasm/infer-features/build.zig
@@ -34,7 +34,7 @@ pub fn build(b: *std.Build) void {
 
     // Verify the result contains the features from the C Object file.
     const check = lib.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("name target_features");
     check.checkExact("features 7");
     check.checkExact("+ atomics");

--- a/test/link/wasm/producers/build.zig
+++ b/test/link/wasm/producers/build.zig
@@ -29,7 +29,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     const version_fmt = "version " ++ builtin.zig_version_string;
 
     const check_lib = lib.checkObject();
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("name producers");
     check_lib.checkExact("fields 2");
     check_lib.checkExact("field_name language");

--- a/test/link/wasm/segments/build.zig
+++ b/test/link/wasm/segments/build.zig
@@ -27,15 +27,15 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     b.installArtifact(lib);
 
     const check_lib = lib.checkObject();
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("Section data");
     check_lib.checkExact("entries 2"); // rodata & data, no bss because we're exporting memory
 
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("Section custom");
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("name name"); // names custom section
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("type data_segment");
     check_lib.checkExact("names 2");
     check_lib.checkExact("index 0");

--- a/test/link/wasm/stack_pointer/build.zig
+++ b/test/link/wasm/stack_pointer/build.zig
@@ -30,7 +30,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     const check_lib = lib.checkObject();
 
     // ensure global exists and its initial value is equal to explitic stack size
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("Section global");
     check_lib.checkExact("entries 1");
     check_lib.checkExact("type i32"); // on wasm32 the stack pointer must be i32
@@ -39,13 +39,13 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     check_lib.checkComputeCompare("stack_pointer", .{ .op = .eq, .value = .{ .literal = lib.stack_size.? } });
 
     // validate memory section starts after virtual stack
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("Section data");
     check_lib.checkExtract("i32.const {data_start}");
     check_lib.checkComputeCompare("data_start", .{ .op = .eq, .value = .{ .variable = "stack_pointer" } });
 
     // validate the name of the stack pointer
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("Section custom");
     check_lib.checkExact("type global");
     check_lib.checkExact("names 1");

--- a/test/link/wasm/type/build.zig
+++ b/test/link/wasm/type/build.zig
@@ -26,7 +26,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     b.installArtifact(lib);
 
     const check_lib = lib.checkObject();
-    check_lib.checkStart();
+    check_lib.checkInHeaders();
     check_lib.checkExact("Section type");
     // only 2 entries, although we have more functions.
     // This is to test functions with the same function signature

--- a/test/standalone/ios/build.zig
+++ b/test/standalone/ios/build.zig
@@ -30,7 +30,7 @@ pub fn build(b: *std.Build) void {
     exe.linkLibC();
 
     const check = exe.checkObject();
-    check.checkStart();
+    check.checkInHeaders();
     check.checkExact("cmd BUILD_VERSION");
     check.checkExact("platform IOS");
     test_step.dependOn(&check.step);


### PR DESCRIPTION
Doing

```zig
const check = exe.checkObject();
check.checkInSymtab();
//...
```

will now only dump the symbol table avoiding a possible false positive where a tested statement ends up being true because it was found in any of the following sections of the parsed object file. For example, prior to this change, this would succeed even though `_bar` is actually not present in MachO indirect symtab but it is present in the exports info of dyld info section:

```zig
const check = exe.checkObject();
check.checkInIndirectSymtab();
check.checkContains("_bar");
```

The change is breaking since `checkStart` is no longer public. Instead, it has been renamed to `checkInHeaders`.