### PR TITLE
Expose `-f(no-)formatted-panics` to the build system

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -37,6 +37,7 @@ kind: Kind,
 major_only_filename: ?[]const u8,
 name_only_filename: ?[]const u8,
 strip: ?bool,
+formatted_panics: ?bool = null,
 unwind_tables: ?bool,
 // keep in sync with src/link.zig:CompressDebugSections
 compress_debug_sections: enum { none, zlib, zstd } = .none,
@@ -1702,6 +1703,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     if (self.generated_h != null) try zig_args.append("-femit-h");
 
     try addFlag(&zig_args, "strip", self.strip);
+    try addFlag(&zig_args, "formatted-panics", self.formatted_panics);
     try addFlag(&zig_args, "unwind-tables", self.unwind_tables);
 
     if (self.dwarf_format) |dwarf_format| {


### PR DESCRIPTION
I suspect it might take some time before a fix to #17969 gets merged. I need to disable the formatted messages for debug builds for a severely stack-constrained embedded target, so I thought maybe it would be okay to expose these flags to the build system for a while until the new panic handler design is made available.