### PR TITLE
Fix Utf8View example to compile.

### DIFF
--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -312,7 +312,7 @@ pub fn utf8ValidateSlice(input: []const u8) bool {
 /// ```
 /// var utf8 = (try std.unicode.Utf8View.init("hi there")).iterator();
 /// while (utf8.nextCodepointSlice()) |codepoint| {
-///   std.debug.print("got codepoint {}\n", .{codepoint});
+///   std.debug.print("got codepoint {s}\n", .{codepoint});
 /// }
 /// ```
 pub const Utf8View = struct {


### PR DESCRIPTION
Updated Utf8View example to format the single codepoint UTF-8 slice with {s}