### PR TITLE
Add FreeBSD to bootstrap.c to make building from source easier in FreeBSD 14

### DIFF
--- a/bootstrap.c
+++ b/bootstrap.c
@@ -60,6 +60,8 @@ static const char *get_host_os(void) {
     return "macos";
 #elif defined(__linux__)
     return "linux";
+#elif defined(__FreeBSD__)
+    return "freebsd";
 #else
 #error TODO implement get_host_os in this build script for this target
 #endif


### PR DESCRIPTION
Minor change to add support for FreeBSD in the bootstrap.c file. This makes it easier to build Zig on FreeBSD from source.