### PR TITLE
build: pass --abbrev to git rather than relying on global config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if("${ZIG_VERSION}" STREQUAL "")
     find_program(GIT_EXE NAMES git NAMES_PER_DIR)
     if(GIT_EXE)
         execute_process(
-            COMMAND ${GIT_EXE} -C ${CMAKE_SOURCE_DIR} describe --match *.*.* --tags
+            COMMAND ${GIT_EXE} -C ${CMAKE_SOURCE_DIR} describe --match *.*.* --tags --abbrev=9
             RESULT_VARIABLE EXIT_STATUS
             OUTPUT_VARIABLE GIT_DESCRIBE
             OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/build.zig
+++ b/build.zig
@@ -263,7 +263,14 @@ pub fn build(b: *std.Build) !void {
 
         var code: u8 = undefined;
         const git_describe_untrimmed = b.runAllowFail(&[_][]const u8{
-            "git", "-C", b.build_root.path orelse ".", "describe", "--match", "*.*.*", "--tags",
+            "git",
+            "-C",
+            b.build_root.path orelse ".",
+            "describe",
+            "--match",
+            "*.*.*",
+            "--tags",
+            "--abbrev=9",
         }, &code, .Ignore) catch {
             break :v version_string;
         };

--- a/ci/aarch64-linux-debug.sh
+++ b/ci/aarch64-linux-debug.sh
@@ -16,7 +16,6 @@ export PATH="$HOME/deps/wasmtime-v2.0.2-$ARCH-linux:$PATH"
 
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.
-git config core.abbrev 9
 git fetch --unshallow || true
 git fetch --tags
 

--- a/ci/aarch64-linux-release.sh
+++ b/ci/aarch64-linux-release.sh
@@ -16,7 +16,6 @@ export PATH="$HOME/deps/wasmtime-v2.0.2-$ARCH-linux:$PATH"
 
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.
-git config core.abbrev 9
 git fetch --unshallow || true
 git fetch --tags
 

--- a/ci/aarch64-macos-debug.sh
+++ b/ci/aarch64-macos-debug.sh
@@ -17,7 +17,6 @@ cd $ZIGDIR
 
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.
-git config core.abbrev 9
 git fetch --unshallow || true
 git fetch --tags
 

--- a/ci/aarch64-macos-release.sh
+++ b/ci/aarch64-macos-release.sh
@@ -17,7 +17,6 @@ cd $ZIGDIR
 
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.
-git config core.abbrev 9
 git fetch --unshallow || true
 git fetch --tags
 

--- a/ci/aarch64-windows.ps1
+++ b/ci/aarch64-windows.ps1
@@ -24,7 +24,6 @@ function CheckLastExitCode {
 
 # Make the `zig version` number consistent.
 # This will affect the `zig build` command below which uses `git describe`.
-git config core.abbrev 9
 git fetch --tags
 
 if ((git rev-parse --is-shallow-repository) -eq "true") {

--- a/ci/x86_64-linux-debug.sh
+++ b/ci/x86_64-linux-debug.sh
@@ -16,7 +16,6 @@ export PATH="$HOME/deps/wasmtime-v2.0.2-$ARCH-linux:$HOME/deps/qemu-linux-x86_64
 
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.
-git config core.abbrev 9
 git fetch --unshallow || true
 git fetch --tags
 

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -16,7 +16,6 @@ export PATH="$HOME/deps/wasmtime-v2.0.2-$ARCH-linux:$HOME/deps/qemu-linux-x86_64
 
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.
-git config core.abbrev 9
 git fetch --unshallow || true
 git fetch --tags
 

--- a/ci/x86_64-macos-release.sh
+++ b/ci/x86_64-macos-release.sh
@@ -22,7 +22,6 @@ cd $ZIGDIR
 
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.
-git config core.abbrev 9
 git fetch --unshallow || true
 git fetch --tags
 

--- a/ci/x86_64-windows-debug.ps1
+++ b/ci/x86_64-windows-debug.ps1
@@ -23,7 +23,6 @@ function CheckLastExitCode {
 
 # Make the `zig version` number consistent.
 # This will affect the `zig build` command below which uses `git describe`.
-git config core.abbrev 9
 git fetch --tags
 
 if ((git rev-parse --is-shallow-repository) -eq "true") {

--- a/ci/x86_64-windows-release.ps1
+++ b/ci/x86_64-windows-release.ps1
@@ -23,7 +23,6 @@ function CheckLastExitCode {
 
 # Make the `zig version` number consistent.
 # This will affect the `zig build` command below which uses `git describe`.
-git config core.abbrev 9
 git fetch --tags
 
 if ((git rev-parse --is-shallow-repository) -eq "true") {


### PR DESCRIPTION
For computing the zig version number, pass --abbrev=9 rather than requiring the user to set their git configuration in order to make zig versions match the standard.