### PR TITLE
More accurate argv parsing/serialization on Windows

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -744,9 +744,6 @@ pub const ChildProcess = struct {
             windowsDestroyPipe(g_hChildStd_ERR_Rd, g_hChildStd_ERR_Wr);
         };
 
-        const cmd_line = try windowsCreateCommandLine(self.allocator, self.argv);
-        defer self.allocator.free(cmd_line);
-
         var siStartInfo = windows.STARTUPINFOW{
             .cb = @sizeOf(windows.STARTUPINFOW),
             .hStdError = g_hChildStd_ERR_Wr,
@@ -818,7 +815,11 @@ pub const ChildProcess = struct {
         const app_name_w = try unicode.utf8ToUtf16LeWithNull(self.allocator, app_basename_utf8);
         defer self.allocator.free(app_name_w);
 
-        const cmd_line_w = try unicode.utf8ToUtf16LeWithNull(self.allocator, cmd_line);
+        const cmd_line_w = argvToCommandLineWindows(self.allocator, self.argv) catch |err| switch (err) {
+            // argv[0] contains unsupported characters that will never resolve to a valid exe.
+            error.InvalidArg0 => return error.FileNotFound,
+            else => |e| return e,
+        };
         defer self.allocator.free(cmd_line_w);
 
         run: {
@@ -1236,39 +1237,159 @@ test "windowsCreateProcessSupportsExtension" {
     try std.testing.expect(windowsCreateProcessSupportsExtension(&[_]u16{ '.', 'e', 'X', 'e', 'c' }) == null);
 }
 
-/// Caller must dealloc.
-fn windowsCreateCommandLine(allocator: mem.Allocator, argv: []const []const u8) ![:0]u8 {
+pub const ArgvToCommandLineError = error{ OutOfMemory, InvalidUtf8, InvalidArg0 };
+
+/// Serializes `argv` to a Windows command-line string suitable for passing to a child process and
+/// parsing by the `CommandLineToArgvW` algorithm. The caller owns the returned slice.
+pub fn argvToCommandLineWindows(
+    allocator: mem.Allocator,
+    argv: []const []const u8,
+) ArgvToCommandLineError![:0]u16 {
     var buf = std.ArrayList(u8).init(allocator);
     defer buf.deinit();
 
-    for (argv, 0..) |arg, arg_i| {
-        if (arg_i != 0) try buf.append(' ');
-        if (mem.indexOfAny(u8, arg, " \t\n\"") == null) {
-            try buf.appendSlice(arg);
-            continue;
-        }
-        try buf.append('"');
-        var backslash_count: usize = 0;
-        for (arg) |byte| {
-            switch (byte) {
-                '\\' => backslash_count += 1,
-                '"' => {
-                    try buf.appendNTimes('\\', backslash_count * 2 + 1);
-                    try buf.append('"');
-                    backslash_count = 0;
-                },
-                else => {
-                    try buf.appendNTimes('\\', backslash_count);
-                    try buf.append(byte);
-                    backslash_count = 0;
-                },
+    if (argv.len != 0) {
+        const arg0 = argv[0];
+
+        // The first argument must be quoted if it contains spaces or ASCII control characters
+        // (excluding DEL). It also follows special quoting rules where backslashes have no special
+        // interpretation, which makes it impossible to pass certain first arguments containing
+        // double quotes to a child process without characters from the first argument leaking into
+        // subsequent ones (which could have security implications).
+        //
+        // Empty arguments technically don't need quotes, but we quote them anyway for maximum
+        // compatibility with different implementations of the 'CommandLineToArgvW' algorithm.
+        //
+        // Double quotes are illegal in paths on Windows, so for the sake of simplicity we reject
+        // all first arguments containing double quotes, even ones that we could theoretically
+        // serialize in unquoted form.
+        var needs_quotes = arg0.len == 0;
+        for (arg0) |c| {
+            if (c <= ' ') {
+                needs_quotes = true;
+            } else if (c == '"') {
+                return error.InvalidArg0;
             }
         }
-        try buf.appendNTimes('\\', backslash_count * 2);
-        try buf.append('"');
+        if (needs_quotes) {
+            try buf.append('"');
+            try buf.appendSlice(arg0);
+            try buf.append('"');
+        } else {
+            try buf.appendSlice(arg0);
+        }
+
+        for (argv[1..]) |arg| {
+            try buf.append(' ');
+
+            // Subsequent arguments must be quoted if they contain spaces, tabs or double quotes,
+            // or if they are empty. For simplicity and for maximum compatibility with different
+            // implementations of the 'CommandLineToArgvW' algorithm, we also quote all ASCII
+            // control characters (again, excluding DEL).
+            needs_quotes = for (arg) |c| {
+                if (c <= ' ' or c == '"') {
+                    break true;
+                }
+            } else arg.len == 0;
+            if (!needs_quotes) {
+                try buf.appendSlice(arg);
+                continue;
+            }
+
+            try buf.append('"');
+            var backslash_count: usize = 0;
+            for (arg) |byte| {
+                switch (byte) {
+                    '\\' => {
+                        backslash_count += 1;
+                    },
+                    '"' => {
+                        try buf.appendNTimes('\\', backslash_count * 2 + 1);
+                        try buf.append('"');
+                        backslash_count = 0;
+                    },
+                    else => {
+                        try buf.appendNTimes('\\', backslash_count);
+                        try buf.append(byte);
+                        backslash_count = 0;
+                    },
+                }
+            }
+            try buf.appendNTimes('\\', backslash_count * 2);
+            try buf.append('"');
+        }
     }
 
-    return buf.toOwnedSliceSentinel(0);
+    return try unicode.utf8ToUtf16LeWithNull(allocator, buf.items);
+}
+
+test "argvToCommandLineWindows" {
+    const t = testArgvToCommandLineWindows;
+
+    try t(&.{
+        \\C:\Program Files\zig\zig.exe
+        ,
+        \\run
+        ,
+        \\.\src\main.zig
+        ,
+        \\-target
+        ,
+        \\x86_64-windows-gnu
+        ,
+        \\-O
+        ,
+        \\ReleaseSafe
+        ,
+        \\--
+        ,
+        \\--emoji=🗿
+        ,
+        \\--eval=new Regex("Dwayne \"The Rock\" Johnson")
+        ,
+    },
+        \\"C:\Program Files\zig\zig.exe" run .\src\main.zig -target x86_64-windows-gnu -O ReleaseSafe -- --emoji=🗿 "--eval=new Regex(\"Dwayne \\\"The Rock\\\" Johnson\")"
+    );
+
+    try t(&.{}, "");
+    try t(&.{""}, "\"\"");
+    try t(&.{" "}, "\" \"");
+    try t(&.{"\t"}, "\"\t\"");
+    try t(&.{"\x07"}, "\"\x07\"");
+    try t(&.{"🦎"}, "🦎");
+
+    try t(
+        &.{ "zig", "aa aa", "bb\tbb", "cc\ncc", "dd\r\ndd", "ee\x7Fee" },
+        "zig \"aa aa\" \"bb\tbb\" \"cc\ncc\" \"dd\r\ndd\" ee\x7Fee",
+    );
+
+    try t(
+        &.{ "\\\\foo bar\\foo bar\\", "\\\\zig zag\\zig zag\\" },
+        "\"\\\\foo bar\\foo bar\\\" \"\\\\zig zag\\zig zag\\\\\"",
+    );
+
+    try std.testing.expectError(
+        error.InvalidArg0,
+        argvToCommandLineWindows(std.testing.allocator, &.{"\"quotes\"quotes\""}),
+    );
+    try std.testing.expectError(
+        error.InvalidArg0,
+        argvToCommandLineWindows(std.testing.allocator, &.{"quotes\"quotes"}),
+    );
+    try std.testing.expectError(
+        error.InvalidArg0,
+        argvToCommandLineWindows(std.testing.allocator, &.{"q u o t e s \" q u o t e s"}),
+    );
+}
+
+fn testArgvToCommandLineWindows(argv: []const []const u8, expected_cmd_line: []const u8) !void {
+    const cmd_line_w = try argvToCommandLineWindows(std.testing.allocator, argv);
+    defer std.testing.allocator.free(cmd_line_w);
+
+    const cmd_line = try unicode.utf16leToUtf8Alloc(std.testing.allocator, cmd_line_w);
+    defer std.testing.allocator.free(cmd_line);
+
+    try std.testing.expectEqualStrings(expected_cmd_line, cmd_line);
 }
 
 fn windowsDestroyPipe(rd: ?windows.HANDLE, wr: ?windows.HANDLE) void {


### PR DESCRIPTION
The first commit adds `ArgIteratorWindows`, which faithfully replicates the quoting and escaping behavior observed in `CommandLineToArgvW` and should make Zig applications play better with processes that abuse these quirks. `ArgIterator` is updated to use this implementation on Windows.

The new implementation used `ArgIteratorGeneral` as a base but the new rules were written by me, from scratch, by following public documentation and manually observing the behavior of `CommandLineToArgvW` on Windows 10; they weren't ported from a different project or based on disassembly.

I left `ArgIteratorGeneral` as is, but since it is now only used for response files it might make sense to rename it `ArgIteratorResponseFile` and remove the Windows-specific wide string `init` overload.

The second commit updates the argv-to-command-line serialization in `ChildProcess` on Windows to follow these rules properly (including the special quoting rules for the first argument), which fixes a bug where empty arguments weren't quoted and thus ignored by child processes.

The PR includes test cases for both parsing and serialization. If you would like to independently verify that the argv parsing matches `CommandLineToArgvW` you can paste the test cases from `test "ArgIteratorWindows"` into this program and run it (only works on Windows for obvious reasons):

```zig
//! test_argv.zig

const std = @import("std");

var arena: std.heap.ArenaAllocator = undefined;
var allocator: std.mem.Allocator = undefined;

pub fn main() !void {
    arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
    defer arena.deinit();

    allocator = arena.allocator();

    const t = testCommandLine;

    // PASTE TEST CASES HERE
}

fn testCommandLine(cmd_line: []const u8, expected_args: []const []const u8) !void {
    const cmd_line_w = try std.unicode.utf8ToUtf16LeWithNull(allocator, cmd_line);

    const cmd_line_esc = try std.Uri.escapeStringWithFn(allocator, cmd_line, keepUnescaped);
    std.debug.print("cmd_line: ({s})\n", .{cmd_line_esc});

    std.debug.print("exp:", .{});
    for (expected_args) |arg| {
        const arg_esc = try std.Uri.escapeStringWithFn(allocator, arg, keepUnescaped);
        std.debug.print(" ({s})", .{arg_esc});
    }
    std.debug.print("\n", .{});

    std.debug.print("win:", .{});
    const win_args = try windowsParseCommandLine(cmd_line_w);
    for (win_args) |arg| {
        const arg_esc = try std.Uri.escapeStringWithFn(allocator, arg, keepUnescaped);
        std.debug.print(" ({s})", .{arg_esc});
    }
    std.debug.print("\n", .{});

    std.debug.print("zig:", .{});
    var zig_args = try std.process.ArgIteratorWindows.init(allocator, cmd_line_w);
    while (zig_args.next()) |arg| {
        const arg_esc = try std.Uri.escapeStringWithFn(allocator, arg, keepUnescaped);
        std.debug.print(" ({s})", .{arg_esc});
    }
    std.debug.print("\n", .{});

    std.debug.print("----\n", .{});
}

fn keepUnescaped(c: u8) bool {
    return std.ascii.isPrint(c) and c != ' ' and c != '(' and c != ')';
}

fn windowsParseCommandLine(cmd_line_w: [:0]const u16) ![][:0]u8 {
    var argc: c_int = undefined;
    const argv_w = CommandLineToArgvW(cmd_line_w, &argc) orelse return error.Unexpected;
    defer std.os.windows.LocalFree(@ptrCast(argv_w));

    const args = try allocator.alloc([:0]u8, @intCast(argc));
    for (argv_w, 0..@intCast(argc)) |arg_w, i| {
        args[i] = try std.unicode.utf16leToUtf8AllocZ(allocator, std.mem.span(arg_w));
    }

    return args;
}

extern "shell32" fn CommandLineToArgvW(lpCmdLine: std.os.windows.LPCWSTR, pNumArgs: *c_int) ?[*]std.os.windows.LPCWSTR;
```

```sh
zig run ./test_argv.zig
```

This program will print out URI-escaped lines that help you compare the output of the Windows and Zig implementations to the expected result.

```
cmd_line: ("C:\Program%20Files\zig\zig.exe"%20run%20.\src\main.zig)
exp: (C:\Program%20Files\zig\zig.exe) (run) (.\src\main.zig)
win: (C:\Program%20Files\zig\zig.exe) (run) (.\src\main.zig)
zig: (C:\Program%20Files\zig\zig.exe) (run) (.\src\main.zig)
----
cmd_line: (foo.exe%20bar)
exp: (foo.exe) (bar)
win: (foo.exe) (bar)
zig: (foo.exe) (bar)
----
```

Happy to answer any questions or concerns you may have.