### PR TITLE
Dir.Iterator now stats unknown file kinds

### DIFF
--- a/deps/aro/aro/Driver/Filesystem.zig
+++ b/deps/aro/aro/Driver/Filesystem.zig
@@ -145,7 +145,7 @@ pub const Filesystem = union(enum) {
 
         pub fn iterate(self: Dir) Iterator {
             return switch (self) {
-                .dir => |dir| .{ .iterator = dir.iterate() },
+                .dir => |dir| .{ .iterator = dir.iterate(.{}) },
                 .fake => |fake| .{ .fake = fake.iterate() },
             };
         }

--- a/lib/std/crypto/Certificate/Bundle.zig
+++ b/lib/std/crypto/Certificate/Bundle.zig
@@ -179,7 +179,7 @@ pub fn addCertsFromDirPathAbsolute(
 pub const AddCertsFromDirError = AddCertsFromFilePathError;
 
 pub fn addCertsFromDir(cb: *Bundle, gpa: Allocator, iterable_dir: fs.Dir) AddCertsFromDirError!void {
-    var it = iterable_dir.iterate();
+    var it = iterable_dir.iterate(.{});
     while (try it.next()) |entry| {
         switch (entry.kind) {
             .file, .sym_link => {},

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -89,7 +89,7 @@ pub const Iterator = switch (builtin.os.tag) {
                     posix.DT.REG => .file,
                     posix.DT.SOCK => .unix_domain_socket,
                     posix.DT.WHT => .whiteout,
-                    else => query_kind: {
+                    posix.DT.UNKNOWN => query_kind: {
                         if (!self.opts.query_kind) {
                             break :query_kind .unknown;
                         }
@@ -99,6 +99,7 @@ pub const Iterator = switch (builtin.os.tag) {
                             break :query_kind .unknown;
                         }
                     },
+                    else => .unknown,
                 };
                 return Entry{
                     .name = name,
@@ -224,7 +225,7 @@ pub const Iterator = switch (builtin.os.tag) {
                     posix.DT.REG => .file,
                     posix.DT.SOCK => .unix_domain_socket,
                     posix.DT.WHT => .whiteout,
-                    else => query_kind: {
+                    posix.DT.UNKNOWN => query_kind: {
                         if (!self.opts.query_kind) {
                             break :query_kind .unknown;
                         }
@@ -234,6 +235,7 @@ pub const Iterator = switch (builtin.os.tag) {
                             break :query_kind .unknown;
                         }
                     },
+                    else => .unknown,
                 };
                 return Entry{
                     .name = name,
@@ -418,7 +420,7 @@ pub const Iterator = switch (builtin.os.tag) {
                     linux.DT.LNK => .sym_link,
                     linux.DT.REG => .file,
                     linux.DT.SOCK => .unix_domain_socket,
-                    else => query_kind: {
+                    linux.DT.UNKNOWN => query_kind: {
                         if (!self.opts.query_kind) {
                             break :query_kind .unknown;
                         }
@@ -428,6 +430,7 @@ pub const Iterator = switch (builtin.os.tag) {
                             break :query_kind .unknown;
                         }
                     },
+                    else => .unknown,
                 };
                 return Entry{
                     .name = name,

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -335,7 +335,7 @@ test "Dir.Iterator" {
     var entries = std.ArrayList(Dir.Entry).init(allocator);
 
     // Create iterator.
-    var iter = tmp_dir.dir.iterate();
+    var iter = tmp_dir.dir.iterate(.{});
     while (try iter.next()) |entry| {
         // We cannot just store `entry` as on Windows, we're re-using the name buffer
         // which means we'll actually share the `name` pointer between entries!
@@ -368,7 +368,7 @@ test "Dir.Iterator many entries" {
     var entries = std.ArrayList(Dir.Entry).init(allocator);
 
     // Create iterator.
-    var iter = tmp_dir.dir.iterate();
+    var iter = tmp_dir.dir.iterate(.{});
     while (try iter.next()) |entry| {
         // We cannot just store `entry` as on Windows, we're re-using the name buffer
         // which means we'll actually share the `name` pointer between entries!
@@ -402,7 +402,7 @@ test "Dir.Iterator twice" {
         var entries = std.ArrayList(Dir.Entry).init(allocator);
 
         // Create iterator.
-        var iter = tmp_dir.dir.iterate();
+        var iter = tmp_dir.dir.iterate(.{});
         while (try iter.next()) |entry| {
             // We cannot just store `entry` as on Windows, we're re-using the name buffer
             // which means we'll actually share the `name` pointer between entries!
@@ -431,7 +431,7 @@ test "Dir.Iterator reset" {
     const allocator = arena.allocator();
 
     // Create iterator.
-    var iter = tmp_dir.dir.iterate();
+    var iter = tmp_dir.dir.iterate(.{});
 
     var i: u8 = 0;
     while (i < 2) : (i += 1) {
@@ -460,7 +460,7 @@ test "Dir.Iterator but dir is deleted during iteration" {
     var subdir = try tmp.dir.makeOpenPath("subdir", .{ .iterate = true });
     defer subdir.close();
 
-    var iterator = subdir.iterate();
+    var iterator = subdir.iterate(.{});
 
     // Create something to iterate over within the subdir
     try tmp.dir.makePath("subdir/b");

--- a/src/main.zig
+++ b/src/main.zig
@@ -5644,7 +5644,7 @@ fn fmtPathDir(
     const stat = try dir.stat();
     if (try fmt.seen.fetchPut(stat.inode, {})) |_| return;
 
-    var dir_it = dir.iterate();
+    var dir_it = dir.iterate(.{});
     while (try dir_it.next()) |entry| {
         const is_dir = entry.kind == .directory;
 

--- a/src/windows_sdk.zig
+++ b/src/windows_sdk.zig
@@ -488,7 +488,7 @@ pub const Windows81Sdk = struct {
             };
             defer sdk_lib_dir.close();
 
-            var iterator = sdk_lib_dir.iterate();
+            var iterator = sdk_lib_dir.iterate(.{});
             const versions = iterateAndFilterBySemVer(&iterator, allocator, "winv") catch |err| switch (err) {
                 error.OutOfMemory => return error.OutOfMemory,
                 error.VersionNotFound => return error.Windows81SdkNotFound,
@@ -693,7 +693,7 @@ const MsvcLibDir = struct {
         errdefer latest_version_lib_dir.deinit(allocator);
 
         var latest_version: u64 = 0;
-        var instances_dir_it = instances_dir.iterateAssumeFirstIteration();
+        var instances_dir_it = instances_dir.iterate(.{ .reset_cursor = false });
         while (instances_dir_it.next() catch return error.PathNotFound) |entry| {
             if (entry.kind != .directory) continue;
 
@@ -794,7 +794,7 @@ const MsvcLibDir = struct {
             }) catch return error.PathNotFound;
             defer visualstudio_folder.close();
 
-            var iterator = visualstudio_folder.iterate();
+            var iterator = visualstudio_folder.iterate(.{});
             const versions = iterateAndFilterBySemVer(&iterator, allocator, null) catch |err| switch (err) {
                 error.OutOfMemory => return error.OutOfMemory,
                 error.VersionNotFound => return error.PathNotFound,

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -1251,7 +1251,7 @@ pub fn main() !void {
 
     if (std.mem.endsWith(u8, case_file_path, ".0.zig")) {
         const stem = case_file_path[case_dirname.len + 1 .. case_file_path.len - "0.zig".len];
-        var it = iterable_dir.iterate();
+        var it = iterable_dir.iterate(.{});
         while (try it.next()) |entry| {
             if (entry.kind != .file) continue;
             if (!std.mem.startsWith(u8, entry.name, stem)) continue;

--- a/tools/generate_JSONTestSuite.zig
+++ b/tools/generate_JSONTestSuite.zig
@@ -19,7 +19,7 @@ pub fn main() !void {
 
     var names = std.ArrayList([]const u8).init(allocator);
     var cwd = try std.fs.cwd().openDir(".", .{ .iterate = true });
-    var it = cwd.iterate();
+    var it = cwd.iterate(.{});
     while (try it.next()) |entry| {
         try names.append(try allocator.dupe(u8, entry.name));
     }

--- a/tools/process_headers.zig
+++ b/tools/process_headers.zig
@@ -389,7 +389,7 @@ pub fn main() !void {
                 };
                 defer dir.close();
 
-                var dir_it = dir.iterate();
+                var dir_it = dir.iterate(.{});
 
                 while (try dir_it.next()) |entry| {
                     const full_path = try std.fs.path.join(allocator, &[_][]const u8{ full_dir_name, entry.name });

--- a/tools/update-linux-headers.zig
+++ b/tools/update-linux-headers.zig
@@ -197,7 +197,7 @@ pub fn main() !void {
                 };
                 defer dir.close();
 
-                var dir_it = dir.iterate();
+                var dir_it = dir.iterate(.{});
 
                 while (try dir_it.next()) |entry| {
                     const full_path = try std.fs.path.join(arena, &[_][]const u8{ full_dir_name, entry.name });

--- a/tools/update_spirv_features.zig
+++ b/tools/update_spirv_features.zig
@@ -231,12 +231,12 @@ fn gather_extensions(allocator: Allocator, spirv_registry_root: []const u8) ![]c
 
     var extensions = std.ArrayList([]const u8).init(allocator);
 
-    var vendor_it = extensions_dir.iterate();
+    var vendor_it = extensions_dir.iterate(.{});
     while (try vendor_it.next()) |vendor_entry| {
         std.debug.assert(vendor_entry.kind == .directory); // If this fails, the structure of SPIRV-Registry has changed.
 
         const vendor_dir = try extensions_dir.openDir(vendor_entry.name, .{ .iterate = true });
-        var ext_it = vendor_dir.iterate();
+        var ext_it = vendor_dir.iterate(.{});
         while (try ext_it.next()) |ext_entry| {
             // There is both a HTML and asciidoc version of every spec (as well as some other directories),
             // we need just the name, but to avoid duplicates here we will just skip anything thats not asciidoc.


### PR DESCRIPTION
When using getdents64() (atleast on Linux), the d_type will be unknown if the filesystem doesn't support it. In this case a seperate stat call is necessary to determine the file kind.
This may cause additional overhead (e.g. network filesystem) and can be disabled by an option.

Fixes #5123