### PR TITLE
std.lib.http: ConnectionPool deinit method improvements

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -159,6 +159,7 @@ pub const ConnectionPool = struct {
 
     pub fn deinit(pool: *ConnectionPool, allocator: Allocator) void {
         pool.mutex.lock();
+        defer pool.mutex.unlock();
 
         var next = pool.free.first;
         while (next) |node| {


### PR DESCRIPTION
Added `mutex.unlock()` call on `ConnectionPool` `deinit()` method.