### PR TITLE
lib/docs/index.html: fix a typo

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -614,7 +614,7 @@
       #listFns dt {
         font-family: var(--mono);
         display: flex;
-        flex-direction: colunm;
+        flex-direction: column;
         justify-content: space-between;
       }
       


### PR DESCRIPTION
Fix a typo in the CSS from commit 201dca323.

### TODO
I checked the new rendering and the change is subtle, so I'm not sure if `flex-direction` should be `row` instead of `column`.
@kristoff-it, can you check it?