### PR TITLE
Fix `Stat.ctime` docs, and correct its value on Windows

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -315,11 +315,11 @@ pub const Stat = struct {
     mode: Mode,
     kind: Kind,
 
-    /// Access time in nanoseconds, relative to UTC 1970-01-01.
+    /// Last access time in nanoseconds, relative to UTC 1970-01-01.
     atime: i128,
     /// Last modification time in nanoseconds, relative to UTC 1970-01-01.
     mtime: i128,
-    /// Creation time in nanoseconds, relative to UTC 1970-01-01.
+    /// Last status/metadata change time in nanoseconds, relative to UTC 1970-01-01.
     ctime: i128,
 
     pub fn fromSystem(st: posix.system.Stat) Stat {
@@ -369,6 +369,8 @@ pub const Stat = struct {
 
 pub const StatError = posix.FStatError;
 
+/// Returns `Stat` containing basic information about the `File`.
+/// Use `metadata` to retrieve more detailed information (e.g. creation time, permissions).
 /// TODO: integrate with async I/O
 pub fn stat(self: File) StatError!Stat {
     if (builtin.os.tag == .windows) {
@@ -392,7 +394,7 @@ pub fn stat(self: File) StatError!Stat {
             .kind = if (info.StandardInformation.Directory == 0) .file else .directory,
             .atime = windows.fromSysTime(info.BasicInformation.LastAccessTime),
             .mtime = windows.fromSysTime(info.BasicInformation.LastWriteTime),
-            .ctime = windows.fromSysTime(info.BasicInformation.CreationTime),
+            .ctime = windows.fromSysTime(info.BasicInformation.ChangeTime),
         };
     }
 


### PR DESCRIPTION
ctime is last file status/metadata change, not creation time.

https://linux.die.net/man/2/fstat
```
    time_t    st_ctime;   /* time of last status change */
```

Note that this mistake was not made in the `File.metadata`/`File.Metadata` implementation, which allows getting the actual creation time.

Closes #18290, see that issue for a more detailed writeup of the problems addressed here.

---

- There are no uses of the `ctime` field within Zig itself, so nothing internal was relying on this mistake. It still might make sense to rename the field to alert users that their usage of the field could have been buggy, though.
- `Stat` not containing creation time when it's available in `FILE_BASIC_INFORMATION` on Windows feels a bit strange, and there's definitely overlap between `stat`/`metadata` that probably should be resolved in the future. I'm just focusing on fixing the immediate bug with this PR and kicking the API design can down the road.