### PR TITLE
std: add support for getting the time in UEFI

### DIFF
--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -153,7 +153,8 @@ pub const Time = extern struct {
         days += daysInYear(self.year, @as(u4, @intCast(self.month)) - 1) + self.day;
         const hours = self.hour + (days * 24);
         const minutes = self.minute + (hours * 60);
-        return self.second + (minutes * 60);
+        const seconds = self.second + (minutes * std.time.s_per_min);
+        return self.nanosecond + (seconds * std.time.ns_per_s);
     }
 };
 

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -114,6 +114,13 @@ pub fn nanoTimestamp() i128 {
         return ns;
     }
 
+    if (builtin.os.tag == .uefi) {
+        var value: std.os.uefi.Time = undefined;
+        const status = std.os.uefi.system_table.runtime_services.getTime(&value, null);
+        assert(status == .Success);
+        return @as(i128, @intCast(value.toEpoch())) * ms_per_s;
+    }
+
     var ts: os.timespec = undefined;
     os.clock_gettime(os.CLOCK.REALTIME, &ts) catch |err| switch (err) {
         error.UnsupportedClock, error.Unexpected => return 0, // "Precision of timing depends on hardware and OS".
@@ -176,7 +183,7 @@ pub const Instant = struct {
     // true if we should use clock_gettime()
     const is_posix = switch (builtin.os.tag) {
         .wasi => builtin.link_libc,
-        .windows => false,
+        .windows, .uefi => false,
         else => true,
     };
 
@@ -195,6 +202,13 @@ pub const Instant = struct {
             const rc = os.wasi.clock_time_get(os.wasi.CLOCK.MONOTONIC, 1, &ns);
             if (rc != .SUCCESS) return error.Unsupported;
             return Instant{ .timestamp = ns };
+        }
+
+        if (builtin.os.tag == .uefi) {
+            var value: std.os.uefi.Time = undefined;
+            const status = std.os.uefi.system_table.runtime_services.getTime(&value, null);
+            if (status != .Success) return error.Unsupported;
+            return Instant{ .timestamp = value.toEpoch() };
         }
 
         // On darwin, use UPTIME_RAW instead of MONOTONIC as it ticks while suspended.

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -118,7 +118,7 @@ pub fn nanoTimestamp() i128 {
         var value: std.os.uefi.Time = undefined;
         const status = std.os.uefi.system_table.runtime_services.getTime(&value, null);
         assert(status == .Success);
-        return @as(i128, @intCast(value.toEpoch())) * ms_per_s;
+        return value.toEpoch();
     }
 
     var ts: os.timespec = undefined;


### PR DESCRIPTION
Adds some extra logic and things to make time work with UEFI. It may not be optimal but should do its job.