### PR TITLE
fix the ComptimeStringMap fails with comptime-only value type

### DIFF
--- a/lib/std/comptime_string_map.zig
+++ b/lib/std/comptime_string_map.zig
@@ -61,11 +61,11 @@ pub fn ComptimeStringMapWithEql(
         const SortContext = struct {
             kvs: []KV,
 
-            pub fn lessThan(ctx: @This(), a: usize, b: usize) bool {
+            pub fn lessThan(comptime ctx: @This(), a: usize, b: usize) bool {
                 return ctx.kvs[a].key.len < ctx.kvs[b].key.len;
             }
 
-            pub fn swap(ctx: @This(), a: usize, b: usize) void {
+            pub fn swap(comptime ctx: @This(), a: usize, b: usize) void {
                 return std.mem.swap(KV, &ctx.kvs[a], &ctx.kvs[b]);
             }
         };
@@ -97,12 +97,12 @@ pub fn ComptimeStringMapWithEql(
         pub const kvs = precomputed.sorted_kvs;
 
         /// Checks if the map has a value for the key.
-        pub fn has(str: []const u8) bool {
+        pub fn has(comptime str: []const u8) bool {
             return get(str) != null;
         }
 
         /// Returns the value for the key if any, else null.
-        pub fn get(str: []const u8) ?V {
+        pub fn get(comptime str: []const u8) ?V {
             if (str.len < precomputed.min_len or str.len > precomputed.max_len)
                 return null;
 

--- a/lib/std/comptime_string_map.zig
+++ b/lib/std/comptime_string_map.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("std.zig");
 const mem = std.mem;
 
 /// Comptime string map optimized for small sets of disparate string keys.

--- a/lib/std/comptime_string_map.zig
+++ b/lib/std/comptime_string_map.zig
@@ -1,4 +1,4 @@
-const std = @import("std.zig");
+const std = @import("std");
 const mem = std.mem;
 
 /// Comptime string map optimized for small sets of disparate string keys.
@@ -231,4 +231,39 @@ test "ComptimeStringMapWithEql" {
     try std.testing.expect(null == map.get("SameLength"));
 
     try std.testing.expect(map.has("ThESe"));
+}
+
+
+
+test "ComptimeStringMap Value is type" {
+    const extensions = ComptimeStringMap(type, .{
+        .{ "bmp", struct {
+            pub const foo = 1;
+        } },
+        .{ "qoi", struct {
+            pub const foo = 2;
+        } },
+        .{ "png", struct {
+            pub const foo = 3;
+        } },
+        .{ "jpg", struct {
+            pub const foo = 4;
+        } },
+        .{ "gif", struct {
+            pub const foo = 5;
+        } },
+    });
+
+    const T = comptime extensions.get("bmp").?;
+    const T2 = comptime extensions.get("qoi").?;
+    const T3 = comptime extensions.get("png").?;
+    const T4 = comptime extensions.get("jpg").?;
+    const T5 = comptime extensions.get("gif").?;
+
+    try std.testing.expect(T.foo == 1);
+    try std.testing.expect(T2.foo == 2);
+    try std.testing.expect(T3.foo == 3);
+    try std.testing.expect(T4.foo == 4);
+    try std.testing.expect(T5.foo == 5);
+    
 }


### PR DESCRIPTION
fix the ComptimeStringMap fails with comptime-only value   #18321 

Zig Version
0.12.0-dev.1802+56deb5b05