### PR TITLE
Sema: ensure `slice_ptr` produces the correct type

### DIFF
--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -136,6 +136,8 @@ pub fn deinit(self: *C) void {
     self.string_bytes.deinit(gpa);
     self.fwd_decl_buf.deinit(gpa);
     self.code_buf.deinit(gpa);
+    self.lazy_fwd_decl_buf.deinit(gpa);
+    self.lazy_code_buf.deinit(gpa);
 }
 
 pub fn freeDecl(self: *C, decl_index: InternPool.DeclIndex) void {

--- a/test/behavior/memcpy.zig
+++ b/test/behavior/memcpy.zig
@@ -66,6 +66,27 @@ fn testMemcpyDestManyPtr() !void {
     try expect(buf[4] == 'o');
 }
 
+test "@memcpy slice" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
+
+    try testMemcpySlice();
+    try comptime testMemcpySlice();
+}
+
+fn testMemcpySlice() !void {
+    var buf: [5]u8 = undefined;
+    const dst: []u8 = &buf;
+    const src: []const u8 = "hello";
+    @memcpy(dst, src);
+    try expect(buf[0] == 'h');
+    try expect(buf[1] == 'e');
+    try expect(buf[2] == 'l');
+    try expect(buf[3] == 'l');
+    try expect(buf[4] == 'o');
+}
+
 comptime {
     const S = struct {
         buffer: [8]u8 = undefined,


### PR DESCRIPTION
```
  %9 = slice_ptr(*const [3]u8, <[]const u8, "src">)
```
&downarrow;
```
  %9 = slice_ptr([*]const u8, <[]const u8, "src">)
  %10 = bitcast(*const [3]u8, %9!)
```

Closes #18345