### PR TITLE
improve messages for unused and too few args errors in std.fmt

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -10,6 +10,7 @@ const meta = std.meta;
 const errol = @import("fmt/errol.zig");
 const lossyCast = std.math.lossyCast;
 const expectFmt = std.testing.expectFmt;
+const fmtEscapes = std.zig.fmtEscapes;
 
 pub const default_max_depth = 3;
 
@@ -179,7 +180,7 @@ pub fn format(
         };
 
         const arg_to_print = comptime arg_state.nextArg(arg_pos) orelse
-            @compileError("too few arguments");
+            @compileError(comptimePrint("too few arguments in '{}'", .{fmtEscapes(fmt)}));
 
         try formatType(
             @field(args, fields_info[arg_to_print].name),
@@ -199,10 +200,10 @@ pub fn format(
         const missing_count = arg_state.args_len - @popCount(arg_state.used_args);
         switch (missing_count) {
             0 => unreachable,
-            1 => @compileError(comptimePrint("unused argument in '{}'", .{std.zig.fmtEscapes(fmt)})),
+            1 => @compileError(comptimePrint("unused argument in '{}'", .{fmtEscapes(fmt)})),
             else => @compileError(comptimePrint("{d} unused arguments in '{}'", .{
                 missing_count,
-                std.zig.fmtEscapes(fmt),
+                fmtEscapes(fmt),
             })),
         }
     }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -199,8 +199,11 @@ pub fn format(
         const missing_count = arg_state.args_len - @popCount(arg_state.used_args);
         switch (missing_count) {
             0 => unreachable,
-            1 => @compileError("unused argument in '" ++ fmt ++ "'"),
-            else => @compileError(comptimePrint("{d}", .{missing_count}) ++ " unused arguments in '" ++ fmt ++ "'"),
+            1 => @compileError(comptimePrint("unused argument in '{}'", .{std.zig.fmtEscapes(fmt)})),
+            else => @compileError(comptimePrint("{d} unused arguments in '{}'", .{
+                missing_count,
+                std.zig.fmtEscapes(fmt),
+            })),
         }
     }
 }

--- a/test/cases/compile_errors/std.fmt_error_for_too_few_arguments.zig
+++ b/test/cases/compile_errors/std.fmt_error_for_too_few_arguments.zig
@@ -1,10 +1,10 @@
 export fn entry() void {
     // we add extra garbage at the end of the format string to ensure they're properly escaped in the error message
-    @import("std").debug.print("{d} {d} {d} {d} {d}\n\x00\"", .{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
+    @import("std").debug.print("{d} {d} {d} {d} {d}\n\x00\"", .{ 1, 2, 3 });
 }
 
 // error
 // backend=llvm
 // target=native
 //
-// :?:?: error: 10 unused arguments in '{d} {d} {d} {d} {d}\n\x00\"'
+// :?:?: error: too few arguments in '{d} {d} {d} {d} {d}\n\x00\"'


### PR DESCRIPTION
currently the error from code like this
```zig
print("{}\n\"\x00", .{ 0, 0 });
```
yields this error
```
zig/lib/std/fmt.zig:202:18: error: unused argument in '{}
                                               "
            1 => @compileError("unused argument in '" ++ fmt ++ "'"),
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
this looks terrible and hurts readability, after this pr it gives
```
zig/lib/std/fmt.zig:202:18: error: unused argument in '{}\n\"\x00'
            1 => @compileError(comptimePrint("unused argument in '{}'", .{std.zig.fmtEscapes(fmt)})),
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
which matches the format string exactly

i feel like i remember there being an issue about this but i couldnt find anything, it couldve just been a random conversation i read. if it exists and someone can find it that would be wonderful :pray: