### PR TITLE
zig cc: add linker -Map flag

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -33,6 +33,7 @@ version: ?std.SemanticVersion,
 kind: Kind,
 major_only_filename: ?[]const u8,
 name_only_filename: ?[]const u8,
+linker_map_file: ?[]const u8,
 // keep in sync with src/link.zig:CompressDebugSections
 compress_debug_sections: enum { none, zlib, zstd } = .none,
 verbose_link: bool,
@@ -310,6 +311,7 @@ pub fn create(owner: *std.Build, options: Options) *Compile {
         .rdynamic = false,
         .installed_path = null,
         .force_undefined_symbols = StringHashMap(void).init(owner.allocator),
+        .linker_map_file = null,
 
         .emit_directory = null,
         .generated_docs = null,
@@ -1431,6 +1433,9 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     }
     if (self.global_base) |global_base| {
         try zig_args.append(b.fmt("--global-base={d}", .{global_base}));
+    }
+    if (self.linker_map_file) |map_file| {
+        try zig_args.append(b.fmt("-Map={s}", .{map_file}));
     }
 
     if (self.wasi_exec_model) |model| {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1048,6 +1048,7 @@ pub const CreateOptions = struct {
     linker_print_icf_sections: bool = false,
     linker_print_map: bool = false,
     llvm_opt_bisect_limit: i32 = -1,
+    linker_map_file: ?[]const u8 = null,
     each_lib_rpath: ?bool = null,
     build_id: ?std.zig.BuildId = null,
     disable_c_depfile: bool = false,
@@ -1591,6 +1592,7 @@ pub fn create(gpa: Allocator, arena: Allocator, options: CreateOptions) !*Compil
             .pdb_source_path = options.pdb_source_path,
             .pdb_out_path = options.pdb_out_path,
             .entry_addr = null, // CLI does not expose this option (yet?)
+            .map_file = options.linker_map_file,
         };
 
         switch (options.cache_mode) {

--- a/src/link.zig
+++ b/src/link.zig
@@ -119,7 +119,10 @@ pub const File = struct {
         soname: ?[]const u8,
         print_gc_sections: bool,
         print_icf_sections: bool,
+        /// Print a link map to the standard output
         print_map: bool,
+        /// Print a link map to the specified file
+        map_file: ?[]const u8,
 
         /// Use a wrapper function for symbol. Any undefined reference to symbol
         /// will be resolved to __wrap_symbol. Any undefined reference to

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2472,6 +2472,7 @@ fn linkWithLLD(self: *Elf, arena: Allocator, prog_node: *std.Progress.Node) !voi
         man.hash.add(self.compress_debug_sections);
         man.hash.add(comp.config.any_sanitize_thread);
         man.hash.addOptionalBytes(comp.sysroot);
+        man.hash.addOptionalBytes(self.base.options.map_file);
 
         // We don't actually care whether it's a cache hit or miss; we just need the digest and the lock.
         _ = try man.hit();
@@ -2730,6 +2731,10 @@ fn linkWithLLD(self: *Elf, arena: Allocator, prog_node: *std.Progress.Node) !voi
                 try argv.append("-rpath");
                 try argv.append(rpath);
             }
+        }
+
+        if (self.base.options.map_file) |map_file| {
+            try argv.appendSlice(&.{ "-Map", map_file });
         }
 
         for (self.symbol_wrap_set.keys()) |symbol_name| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -856,6 +856,7 @@ fn buildOutputType(
     var linker_dynamicbase = true;
     var linker_optimization: ?[]const u8 = null;
     var linker_module_definition_file: ?[]const u8 = null;
+    var linker_map_file: ?[]const u8 = null;
     var test_no_exec = false;
     var entry: Compilation.CreateOptions.Entry = .default;
     var force_undefined_symbols: std.StringArrayHashMapUnmanaged(void) = .{};
@@ -2440,6 +2441,8 @@ fn buildOutputType(
                 } else if (mem.eql(u8, arg, "--version")) {
                     try std.io.getStdOut().writeAll("zig ld " ++ build_options.version ++ "\n");
                     process.exit(0);
+                } else if (mem.startsWith(u8, arg, "-Map=")) {
+                    linker_map_file = arg["-Map=".len..];
                 } else {
                     fatal("unsupported linker arg: {s}", .{arg});
                 }
@@ -3197,6 +3200,7 @@ fn buildOutputType(
         .linker_dynamicbase = linker_dynamicbase,
         .linker_compress_debug_sections = linker_compress_debug_sections,
         .linker_module_definition_file = linker_module_definition_file,
+        .linker_map_file = linker_map_file,
         .major_subsystem_version = major_subsystem_version,
         .minor_subsystem_version = minor_subsystem_version,
         .link_eh_frame_hdr = link_eh_frame_hdr,


### PR DESCRIPTION
Linker maps are a diagnostic/debugging feature. It causes the linker to write out memory ranges (similar to the runtime content of `/proc/self/map` on Linux) and some such info. I need this because a program I want to compile with `zig cc` uses this.

Fixes #18356