### PR TITLE
Use `std.fs.path.relative` for `@import` and `@embedFile` sub paths

### DIFF
--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3976,15 +3976,11 @@ pub fn importFile(
     defer gpa.free(resolved_root_path);
 
     const sub_file_path = p: {
-        if (mem.startsWith(u8, resolved_path, resolved_root_path)) {
-            // +1 for the directory separator here.
-            break :p try gpa.dupe(u8, resolved_path[resolved_root_path.len + 1 ..]);
-        }
-        if (mem.eql(u8, resolved_root_path, ".") and
-            !isUpDir(resolved_path) and
-            !std.fs.path.isAbsolute(resolved_path))
-        {
-            break :p try gpa.dupe(u8, resolved_path);
+        const relative = try std.fs.path.relative(gpa, resolved_root_path, resolved_path);
+        errdefer gpa.free(relative);
+
+        if (!isUpDir(relative) and !std.fs.path.isAbsolute(relative)) {
+            break :p relative;
         }
         return error.ImportOutsideModulePath;
     };
@@ -4075,15 +4071,11 @@ pub fn embedFile(
     defer gpa.free(resolved_root_path);
 
     const sub_file_path = p: {
-        if (mem.startsWith(u8, resolved_path, resolved_root_path)) {
-            // +1 for the directory separator here.
-            break :p try gpa.dupe(u8, resolved_path[resolved_root_path.len + 1 ..]);
-        }
-        if (mem.eql(u8, resolved_root_path, ".") and
-            !isUpDir(resolved_path) and
-            !std.fs.path.isAbsolute(resolved_path))
-        {
-            break :p try gpa.dupe(u8, resolved_path);
+        const relative = try std.fs.path.relative(gpa, resolved_root_path, resolved_path);
+        errdefer gpa.free(relative);
+
+        if (!isUpDir(relative) and !std.fs.path.isAbsolute(relative)) {
+            break :p relative;
         }
         return error.ImportOutsideModulePath;
     };


### PR DESCRIPTION
Fixes edge cases where the `startsWith` that was used previously would return a false positive on a resolved path like `foo.zig` when the resolved root was `foo`. Before this commit, such a path would be treated as a sub path of 'foo' with a resolved sub file path of 'zig' (and the `.` would be assumed to be a path separator). After this commit, `foo.zig` will be correctly treated as outside of the root of `foo`.

Closes #18355

With this setup:

```zig
// foo.zig
pub fn foo() void {}
```

```zig
// foo/bar.zig
const foo = @import("../foo.zig");

pub fn main() void {
    foo.foo();
}
```


Before:

```
> zig build-exe foo/bar.zig
foo\bar.zig:1:21: error: unable to load 'foo\zig': FileNotFound
const foo = @import("../foo.zig");
                    ^~~~~~~~~~~~
```

After:

```
> zig build-exe foo/bar.zig
foo\bar.zig:1:21: error: import of file outside module path: '../foo.zig'
const foo = @import("../foo.zig");
                    ^~~~~~~~~~~~
```