### PR TITLE
Enable gnu_f16_abi on x86_64

### DIFF
--- a/lib/compiler_rt/common.zig
+++ b/lib/compiler_rt/common.zig
@@ -51,10 +51,9 @@ pub const gnu_f16_abi = switch (builtin.cpu.arch) {
     .wasm64,
     .riscv64,
     .riscv32,
-    .x86_64,
     => false,
 
-    .x86 => true,
+    .x86, .x86_64 => true,
 
     .arm, .armeb, .thumb, .thumbeb => switch (builtin.abi) {
         .eabi, .eabihf => false,


### PR DESCRIPTION
This fixes undefined reference to `__gnu_h2f_ieee` and `__gnu_f2h_ieee` on use of the `std.fmt` functions for example when building with: `-target x86_64-freestanding-none -mcpu x86_64_v3-avx-avx2-f16c-fma-fxsr-mmx+soft_float-sse-sse2-sse3-sse4_1-sse4_2-ssse3-vzeroupper-x87-xsave -rdynamic`
Example code:
```zig
const std = @import("std");

var buffer: [1024 * 1024]u8 = undefined;
var alloc = std.heap.FixedBufferAllocator.init(buffer[0..buffer.len]);

pub export fn _start() void {
    const str = std.fmt.allocPrint(alloc.allocator(), "Hello", .{}) catch unreachable;
    defer alloc.allocator().free(str);
}
```

Thanks @matu3ba 
Related: #13333