### PR TITLE
Update styles in std docs to correct display glitch

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -255,7 +255,7 @@
       /* docs section */
       .docs {
         flex-grow: 2;
-        padding: 0rem 0.7rem 2.4rem 1.4rem;
+        padding: 0rem 0.7rem 0rem 1.4rem;
         font-size: 1rem;
         background-color: var(--bg-color);
         overflow-wrap: break-word;
@@ -746,7 +746,6 @@
         }
         .flex-main {
           flex-direction: column;
-          display: block;
         }
         .sidebar {
           min-width: calc(100vw - 2.8rem);


### PR DESCRIPTION
This is to address a small glitch in the std docs styles, where the bottom section gets cutoff on the mobile viewport. Also on the desktop, at the regular or narrow viewport, the scroll bar indicator overflows the bottom of the page.

**Regular desktop at wide viewport--**
![desktop-scrollbar-overflows-window](https://github.com/ziglang/zig/assets/33229051/b4c66ffc-278b-4380-b743-b88c77ff6f3f)

**Regular desktop at wide viewport with corrections--**
![desktop-corrected](https://github.com/ziglang/zig/assets/33229051/e1c45670-eb14-4f7c-9453-22f308ee8b80)

**Regular desktop at narrow viewport--**
![desktop-narrow-bottom-cutoff](https://github.com/ziglang/zig/assets/33229051/aa684b6d-8d8e-488a-b245-f6a981ed0636)

**Regular desktop at narrow viewport with correcctions--**
![desktop-narrow-corrected](https://github.com/ziglang/zig/assets/33229051/712ea586-3ce8-41c6-b2ba-096c2fd2bac3)

**Mobile screen vertical--**
![mobile-vertical-cutoff-at-bottom](https://github.com/ziglang/zig/assets/33229051/b4f476d2-2d8c-4c85-a9c0-e9de1d052513)

**Mobile screen vertical with corretions--**
![mobile-corrected](https://github.com/ziglang/zig/assets/33229051/b49b8279-aae9-45ca-95ae-ddb73864d4a8)

**Mobile screen horizontal is not affected by the glitch--**
![mobile-horizontal-not-affected](https://github.com/ziglang/zig/assets/33229051/ce394f6a-06ae-4f94-a867-d74b39fdaf2f)


I tried to find the most basic way to patch this without interfering with the layout. Thankfully I was able to patch the styles directly, in just 2 places. The first will remove the bottom padding from the .docs container. This corrects the issue on regular desktop view but not mobile. The second removes the display: block from the .flex-main container at the mobile viewport. Since this is a flex container, the display: block will negate the flex properties, as display: flex is already being used here. So a combination of these two line edits corrected the problem for me in all views.