### PR TITLE
linux: support :filename syntax on libs

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -822,6 +822,10 @@ pub fn addRPath(self: *Compile, directory_path: LazyPath) void {
     self.root_module.addRPath(directory_path);
 }
 
+pub fn addRPathSpecial(self: *Compile, bytes: []const u8) void {
+    self.root_module.addRPathSpecial(bytes);
+}
+
 pub fn addSystemFrameworkPath(self: *Compile, directory_path: LazyPath) void {
     self.root_module.addSystemFrameworkPath(directory_path);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -7155,6 +7155,12 @@ fn accessLibPath(
 ) !bool {
     const sep = fs.path.sep_str;
 
+    if (mem.startsWith(u8, lib_name, ":")) {
+        try test_path.writer().print("{s}" ++ sep ++ "{s}", .{ lib_dir_path, lib_name[1..] });
+        try checked_paths.writer().print("\n  {s}", .{test_path.items});
+        return true;
+    }
+
     if (target.isDarwin() and link_mode == .Dynamic) tbd: {
         // Prefer .tbd over .dylib.
         test_path.clearRetainingCapacity();


### PR DESCRIPTION
Solves https://github.com/ziglang/zig/issues/18373

This PR allow users to do `exe.linkSystemLibrary(":libEDSDK.so")` and `exe.addRPathSpecial("$ORIGIN")` preserving the library name.

`zig build-exe` already support this notation:
```bash
$ zig build-exe src/main.zig -I ./include -DTARGET_OS_LINUX -L ./lib -l:libEDSDK.so -lc -rpath \$ORIGIN -target arm-linux-gnueabihf --name zig-shared-obj
```

Trying with `zig build`

**build.zig**
```zig
const std = @import("std");

pub fn build(b: *std.Build) void {
    const default_target = std.zig.CrossTarget.parse(.{
        .arch_os_abi = "arm-linux-gnueabihf",
    }) catch @panic("unknown target");

    const target = b.standardTargetOptions(.{
        .default_target = default_target,
    });

    const optimize = b.standardOptimizeOption(.{});

    const exe = b.addExecutable(.{
        .name = "zig-shared-obj",
        .root_source_file = .{ .path = "src/main.zig" },
        .target = target,
        .optimize = optimize,
    });

    exe.addLibraryPath(.{ .path = "lib" });
    exe.addIncludePath(.{ .path = "include" });
    exe.defineCMacro("TARGET_OS_LINUX", null);
    exe.linkLibC();

    exe.linkSystemLibrary(":libEDSDK.so");
    exe.addRPathSpecial("$ORIGIN");

    b.installArtifact(exe);
}
```

**src/main.zig**
```zig
const std = @import("std");

const c = @cImport({
    @cInclude("stdbool.h");
    @cInclude("EDSDK.h");
});

pub fn main() void {
    if (c.EdsInitializeSDK() != c.EDS_ERR_OK) {
        std.debug.print("Error initializing the library\n", .{});
    }

    std.debug.print("Hello World\n", .{});

    if (c.EdsTerminateSDK() != c.EDS_ERR_OK) {
        std.debug.print("Error terminating the library\n", .{});
    }
}
```

Both `zig build` and `zig build-exe` produced the same result below:

```bash
$ readelf -d zig-shared-obj

Dynamic section at offset 0x894dc contains 26 entries:
  Tag        Type                         Name/Value
 0x0000001d (RUNPATH)                    Library runpath: [$ORIGIN]
 0x00000001 (NEEDED)                     Shared library: [libEDSDK.so]
 0x00000001 (NEEDED)                     Shared library: [libpthread.so.0]
 0x00000001 (NEEDED)                     Shared library: [libc.so.6]
  ....
```

