### PR TITLE
Heavily Optimized `std.mem.eql` with SIMD

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -634,11 +634,12 @@ test "lessThan" {
 
 /// Compares two slices and returns whether they are equal.
 pub fn eql(comptime T: type, a: []const T, b: []const T) bool {
-    if (@sizeOf(T) == 0) return true;
-    if (std.meta.hasUniqueRepresentation(T)) return eqlBytes(sliceAsBytes(a), sliceAsBytes(b));
-
     if (a.len != b.len) return false;
     if (a.len == 0 or a.ptr == b.ptr) return true;
+
+    if (@sizeOf(T) == 0) return true;
+
+    if (!@inComptime() and std.meta.hasUniqueRepresentation(T)) return eqlBytes(sliceAsBytes(a), sliceAsBytes(b));
 
     for (a, b) |a_elem, b_elem| {
         if (a_elem != b_elem) return false;

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -639,7 +639,7 @@ pub fn eql(comptime T: type, a: []const T, b: []const T) bool {
 
     // No vectorization in stage2 x86_64 or x86
     // https://github.com/ziglang/zig/issues/17748
-    if (builtin.zig_backend != .stage2_x86_64 or builtin.zig_backend != .stage2_x86) {
+    if (builtin.zig_backend != .stage2_x86_64 and builtin.zig_backend != .stage2_x86) {
         if (@typeInfo(T) == .Int and std.math.isPowerOfTwo(@bitSizeOf(T))) return eqlBytes(std.mem.sliceAsBytes(a), std.mem.sliceAsBytes(b));
     }
 

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -634,11 +634,11 @@ test "lessThan" {
 
 /// Compares two slices and returns whether they are equal.
 pub fn eql(comptime T: type, a: []const T, b: []const T) bool {
+    if (@sizeOf(T) == 0) return true;
+    if (std.meta.hasUniqueRepresentation(T)) return eqlBytes(sliceAsBytes(a), sliceAsBytes(b));
+
     if (a.len != b.len) return false;
     if (a.len == 0 or a.ptr == b.ptr) return true;
-    if (@sizeOf(T) == 0) return true;
-
-    if (std.meta.hasUniqueRepresentation(T)) return eqlBytes(std.mem.sliceAsBytes(a), std.mem.sliceAsBytes(b));
 
     for (a, b) |a_elem, b_elem| {
         if (a_elem != b_elem) return false;
@@ -647,7 +647,7 @@ pub fn eql(comptime T: type, a: []const T, b: []const T) bool {
 }
 
 /// std.mem.eql heavily optimized for slices of bytes.
-pub fn eqlBytes(a: []const u8, b: []const u8) bool {
+fn eqlBytes(a: []const u8, b: []const u8) bool {
     if (a.len != b.len) return false;
     if (a.len == 0 or a.ptr == b.ptr) return true;
 

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -636,7 +636,12 @@ test "lessThan" {
 pub fn eql(comptime T: type, a: []const T, b: []const T) bool {
     if (a.len != b.len) return false;
     if (a.len == 0 or a.ptr == b.ptr) return true;
-    if (@typeInfo(T) == .Int and std.math.isPowerOfTwo(@bitSizeOf(T))) return eqlBytes(std.mem.sliceAsBytes(a), std.mem.sliceAsBytes(b));
+
+    // No vectorization in stage2 x86_64 or x86
+    // https://github.com/ziglang/zig/issues/17748
+    if (builtin.zig_backend != .stage2_x86_64 or builtin.zig_backend != .stage2_x86) {
+        if (@typeInfo(T) == .Int and std.math.isPowerOfTwo(@bitSizeOf(T))) return eqlBytes(std.mem.sliceAsBytes(a), std.mem.sliceAsBytes(b));
+    }
 
     for (a, b) |a_elem, b_elem| {
         if (a_elem != b_elem) return false;

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -634,12 +634,11 @@ test "lessThan" {
 
 /// Compares two slices and returns whether they are equal.
 pub fn eql(comptime T: type, a: []const T, b: []const T) bool {
+    if (@sizeOf(T) == 0) return true;
+    if (!@inComptime() and std.meta.hasUniqueRepresentation(T)) return eqlBytes(sliceAsBytes(a), sliceAsBytes(b));
+
     if (a.len != b.len) return false;
     if (a.len == 0 or a.ptr == b.ptr) return true;
-
-    if (@sizeOf(T) == 0) return true;
-
-    if (!@inComptime() and std.meta.hasUniqueRepresentation(T)) return eqlBytes(sliceAsBytes(a), sliceAsBytes(b));
 
     for (a, b) |a_elem, b_elem| {
         if (a_elem != b_elem) return false;

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1553,6 +1553,16 @@ pub fn sched_getaffinity(pid: pid_t, size: usize, set: *cpu_set_t) usize {
     return 0;
 }
 
+pub fn sched_setaffinity(pid: pid_t, set: *const cpu_set_t) !void {
+    const size = @sizeOf(cpu_set_t);
+    const rc = syscall3(.sched_setaffinity, @as(usize, @bitCast(@as(isize, pid))), size, @intFromPtr(set));
+
+    switch (std.os.errno(rc)) {
+        .SUCCESS => return,
+        else => |err| return std.os.unexpectedErrno(err),
+    }
+}
+
 pub fn epoll_create() usize {
     return epoll_create1(0);
 }


### PR DESCRIPTION
The current stdlib implementation is not as good as it can be for `u8`, which is the most commonly used one by far. @kprotty and I have taken the task of vectorizing and accelerating this function by orders of magnitude. The idea here is to split this api into 2 different functions. The normal `eql` function, which works on anything, and the much more optimized `eqlBytes`, which specifically optimizes bytes. `eql` calls `eqlBytes` if `T` is `u8`.

For any other integers, we still use a much faster xor accumulator design, see benchmarks below.

## Benchmarks

The benchmarks are run in as good of a script as I was able to make, including using cpu counters, pinning the process to 1 core, and clearing caches between different function runs. Warmups happen for each function, as well as at least 1000 runs.

The CPU the benchmarks were run on:
```
AMD Ryzen 9 6900HS Creator Edition (16) @ 3.293GHz
```

Important to note that the cpu does have `constant_tsc` enabled.

There are 3 benchmarks for the 3 categories, `start`, `middle`, `same`.

`start` is when the difference is at the first byte. This is meant to show the start-up cost, and how fast it exists.
`middle` shows a sort of "middle" case. Is it able to find it faster in smaller inputs? Does it have an early exit?
`same` is the worst case scenario. Here the entire input must be checked, and is actually the most common input. People will usually use equality to see it's true rather than false.

Run with: `zig build-exe benchmark.zig -lc -OReleaseFast`
<details>
  <summary>benchmarks</summary>

![plot](https://github.com/ziglang/zig/assets/87927264/ac37033d-4e76-4a87-998c-d1083e1b9394)

</details>

The `start` on both versions is measured under 100 cycles, which I consider to be starting to get close to the error margin. At this level, there isn't any point to comparing them, and both running this fast will have virtually no performance difference for the user.

Another benchmark I tried was running the `perf_test.zig` inside of `lib/std/zig`. I felt that the parser and tokenizer would be good spot with many `mem.eql` usages.

| stdlib | xor eql |
|--------|--------|
| `parsing speed: 117.96MiB/s` | `parsing speed: 124.25MiB/s` | 

that is a solid 6% speed increase on average. Note that I up the iteration count from 100 to 10000, to get the most precise readings.

I also added `sched_setaffinity` , as it seems the `getaffinity` was present, but there was no `setaffinity` and I needed it for the benchmarking.