### PR TITLE
improve Status to EfiError conversion

### DIFF
--- a/lib/std/os/uefi/status.zig
+++ b/lib/std/os/uefi/status.zig
@@ -186,12 +186,15 @@ pub const Status = enum(usize) {
     };
 
     pub fn err(self: Status) EfiError!void {
-        inline for (@typeInfo(EfiError).ErrorSet.?) |efi_err| {
-            if (self == @field(Status, efi_err.name)) {
-                return @field(EfiError, efi_err.name);
-            }
+        switch(self) {
+            inline else => |tag| return @field(EfiError, @tagName(tag)),
         }
-        // self is .Success or Warning
+    }
+
+    pub fn status(Error: EfiError) Status {
+        switch(Error) {
+            inline else => |tag| return @field(Status, @errorName(tag)),
+        }
     }
 };
 


### PR DESCRIPTION
This improves the conversion between `std.os.uefi.Status` and the `std.os.uefi.Status.EfiError` (enum to error set) and adds the option to revert from `std.os.uefi.Status.EfiError` back into `std.os.uefi.Status` (error set to enum).

The addition of the `status()` function would allow to convert the `Status` returned by UEFI function into an error set, to leverage and effectively make use of Zigs type system, as currently the UEFI target doesn't support a main function with an error tuple return type, making `EfiError` barely useable.

The addition of this function would allow to use an error tuple up until the main function, where it would be converted back into the `Status` enum and returned.

For example:
```zig
pub fn fails() !void {
    return uefi.Status.EfiError.Aborted;
}

pub fn someOther() !u16 {
    try fails();

    return 420;
}

pub fn main() uefi.Status {
    someOther() catch |err| return err.status();
}
```