### PR TITLE
std lib: add std.debug.assertDebug

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -342,6 +342,15 @@ pub fn assert(ok: bool) void {
     if (!ok) unreachable; // assertion failure
 }
 
+/// This function panics in Debug mode when `ok` is false. It does not generate
+/// any code in any release mode. It is functionally equivalent to C's assert
+/// macro when used in conjunction with NDEBUG.
+pub fn assertDebug(ok: bool) void {
+    if (builtin.mode == .Debug) {
+        if (!ok) @panic("Assertion failed");
+    }
+}
+
 pub fn panic(comptime format: []const u8, args: anytype) noreturn {
     @setCold(true);
 


### PR DESCRIPTION
TIL that `std.debug.assert` generates panics in ReleaseSafe and generates undefined behaviour in ReleaseFast and ReleaseSmall, causing the optimiser to eagerly eliminate entire branches. Until now I have been assuming that it behaved like C's assert macro. This is a very bad assumption to make!

This PR adds a new function `std.debug.assertDebug` which is functionally equivalent to C's assert macro when used in conjunction with NDEBUG.

It can be used in cases where the user wants to quickly catch mistakes or broken assumptions during development but doesn't want to affect execution in any way in release modes. This is very useful in some domains, such as live music performance systems and video games (which happen to be the 2 domains I am currently involved with).