### PR TITLE
std.ComptimeStringMap: allow getting kv index

### DIFF
--- a/lib/std/comptime_string_map.zig
+++ b/lib/std/comptime_string_map.zig
@@ -103,6 +103,10 @@ pub fn ComptimeStringMapWithEql(
 
         /// Returns the value for the key if any, else null.
         pub fn get(str: []const u8) ?V {
+            return precomputed.sorted_kvs[getIndex(str) orelse return null].value;
+        }
+
+        pub fn getIndex(str: []const u8) ?usize {
             if (str.len < precomputed.min_len or str.len > precomputed.max_len)
                 return null;
 
@@ -112,7 +116,7 @@ pub fn ComptimeStringMapWithEql(
                 if (kv.key.len != str.len)
                     return null;
                 if (eql(kv.key, str))
-                    return kv.value;
+                    return i;
                 i += 1;
                 if (i >= precomputed.sorted_kvs.len)
                     return null;


### PR DESCRIPTION
this allows getting the index of `str` into `kvs`. this is useful because `kvs[index].key` will be a comptime stable string and `str` might not always be, so if you want it to persist pulling the string out of the CSM is better.