### PR TITLE
Fix std.enums.values

### DIFF
--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -35,8 +35,8 @@ pub fn EnumFieldStruct(comptime E: type, comptime Data: type, comptime field_def
 pub inline fn valuesFromFields(comptime E: type, comptime fields: []const EnumField) []const E {
     comptime {
         var result: [fields.len]E = undefined;
-        for (fields, 0..) |f, i| {
-            result[i] = @field(E, f.name);
+        for (&result, fields) |*r, f| {
+            r.* = @enumFromInt(f.value);
         }
         return &result;
     }
@@ -1533,4 +1533,14 @@ test "std.enums.EnumIndexer empty" {
     ensureIndexer(Indexer);
     try testing.expectEqual(E, Indexer.Key);
     try testing.expectEqual(0, Indexer.count);
+}
+
+test "enumValues" {
+    const E = enum {
+        X,
+        Y,
+        Z,
+        pub const X = 1;
+    };
+    try testing.expectEqualSlices(E, &.{ .X, .Y, .Z }, values(E));
 }


### PR DESCRIPTION
Current implementation fails to handle the following enum

```zig
const E = enum {
  X,
  pub const X = 1;
}
```

because `@field(type, name)` prefers declarations over enum fields.