### PR TITLE
Compilation: cleanup hashmap usage

### DIFF
--- a/src/Package/Module.zig
+++ b/src/Package/Module.zig
@@ -14,7 +14,7 @@ fully_qualified_name: []const u8,
 /// responsible for detecting these names and using the correct package.
 deps: Deps = .{},
 
-pub const Deps = std.StringHashMapUnmanaged(*Module);
+pub const Deps = std.StringArrayHashMapUnmanaged(*Module);
 
 pub const Tree = struct {
     /// Each `Package` exposes a `Module` with build.zig as its root source file.

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -93,7 +93,7 @@ no_partial_func_ty: bool = false,
 
 /// The temporary arena is used for the memory of the `InferredAlloc` values
 /// here so the values can be dropped without any cleanup.
-unresolved_inferred_allocs: std.AutoHashMapUnmanaged(Air.Inst.Index, InferredAlloc) = .{},
+unresolved_inferred_allocs: std.AutoArrayHashMapUnmanaged(Air.Inst.Index, InferredAlloc) = .{},
 
 /// Indices of comptime-mutable decls created by this Sema. These decls' values
 /// should be interned after analysis completes, as they may refer to memory in
@@ -4040,7 +4040,7 @@ fn zirResolveInferredAlloc(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Com
         },
         .inferred_alloc => {
             const ia1 = sema.air_instructions.items(.data)[@intFromEnum(ptr_inst)].inferred_alloc;
-            const ia2 = sema.unresolved_inferred_allocs.fetchRemove(ptr_inst).?.value;
+            const ia2 = sema.unresolved_inferred_allocs.fetchSwapRemove(ptr_inst).?.value;
             const peer_vals = try sema.arena.alloc(Air.Inst.Ref, ia2.prongs.items.len);
             for (peer_vals, ia2.prongs.items) |*peer_val, store_inst| {
                 assert(sema.air_instructions.items(.tag)[@intFromEnum(store_inst)] == .store);

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9597,9 +9597,9 @@ pub const FuncGen = struct {
             try wip.@"switch"(tag_int_value, bad_value_block, @intCast(enum_type.names.len));
         defer wip_switch.finish(&wip);
 
-        for (enum_type.names.get(ip), 0..) |name, field_index| {
-            const name_string = try o.builder.string(ip.stringToSlice(name));
-            const name_init = try o.builder.stringNullConst(name_string);
+        for (0..enum_type.names.len) |field_index| {
+            const name = try o.builder.string(ip.stringToSlice(enum_type.names.get(ip)[field_index]));
+            const name_init = try o.builder.stringNullConst(name);
             const name_variable_index =
                 try o.builder.addVariable(.empty, name_init.typeOf(&o.builder), .default);
             try name_variable_index.setInitializer(name_init, &o.builder);
@@ -9610,7 +9610,7 @@ pub const FuncGen = struct {
 
             const name_val = try o.builder.structValue(ret_ty, &.{
                 name_variable_index.toConst(&o.builder),
-                try o.builder.intConst(usize_ty, name_string.slice(&o.builder).?.len),
+                try o.builder.intConst(usize_ty, name.slice(&o.builder).?.len),
             });
 
             const return_block = try wip.block(1, "Name");


### PR DESCRIPTION
Searching for "iterator" is a surprisingly efficient method for finding sus code. :grinning:

Justifications for `HashMap` &rightarrow; `ArrayHashMap` changes:
 - `Compilation.CObject.Diag.Bundle.*_names`: These may already be inserted in order, so could potentially be turned into `ArrayList`s with some additional checks.
 - `Module.embed_table`: Needs to be iterated while queuing work.
 - `Package.Module.Deps`: Needs to be cloned often, which is just iteration in a trenchcoat, and less data to copy around while sorting (and, in fact, could now be sorted in-place, with no extra allocations, if mutation could be allowed).
 - `Sema.unresolved_inferred_allocs`: Needs to be iterated to find unused allocs.