### PR TITLE
document C cast

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6338,6 +6338,9 @@ test "optional pointers" {
       There is also a third kind of type conversion called {#link|Peer Type Resolution#} for
       the case when a result type must be decided given multiple operand types.
       </p>
+      <p>
+	  If you want the casting behavior of C, use `std.zig.c_translation.cast`.
+      </p>
       {#header_open|Type Coercion#}
       <p>
       Type coercion occurs when one type is expected, but different type is provided:


### PR DESCRIPTION
Being a system programming language, I think it is important to include the C-style cast for programmers familiar with C. Sometimes, the C cast has less footgun than the Zig one.

I think, it would be better if the function is at `std.meta.c_cast`, so it is more easily discovered.

## Example

In the following code, I need to cast i128 into u64.

```zig
const std = @import("std");
const Prng = std.rand.DefaultPrng;

var prng = Prng.init(DO_CAST(std.time.nanoTimestamp());
```

This is a correct solution. It is long.

```zig
var prng = Prng.init(@truncate(@as(u128, @bitCast(std.time.nanoTimestamp()))));
```

Here is a solution that looks correct but isn't. This is conceptually like the Y2K problem.

```zig
var prng = Prng.init(@truncate(@as(u128, @intCast(std.time.nanoTimestamp()))));
```

This is correct, and much better.

```zig
const c_cast = std.zig.c_translation.cast;
var prng = Prng.init(c_cast(u64, std.time.nanoTimestamp()));
```
