### PR TITLE
build system: fix missing step dependencies on lib

### DIFF
--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -263,7 +263,11 @@ fn addShallowDependencies(m: *Module, dependee: *Module) void {
     };
 
     for (dependee.link_objects.items) |link_object| switch (link_object) {
-        .other_step => |compile| addStepDependencies(m, dependee, &compile.step),
+        .other_step => |compile| {
+            addStepDependencies(m, dependee, &compile.step);
+            for (compile.installed_headers.items) |install_step|
+                addStepDependenciesOnly(m, install_step);
+        },
 
         .static_path,
         .assembly_file,


### PR DESCRIPTION
When depending on a module that depends on a static library, there was a missing step dependency on the static library, which caused a compile error due to missing header file.

This fixes the problem by adding the proper step dependencies.

Reviewing this code, I'm starting to wonder if it might be simpler to have Module instances create dummy Step objects to better model dependencies and dependees, rather than trying to maintain this graph without an actual node. That would be an improvement for a future commit.

I thought about how best to test this, since it depends on the fetching code of `zig build` and therefore is ineligible for becoming a new test/standalone/* case. I thought about combining efforts with another idea I've been kicking around for a while now and created [a new contrib-testing project](https://github.com/ziglang/contrib-testing).

```
andy@ark ~/d/contrib-testing> zig-old build
install
└─ install
   └─ install exe
      └─ zig build-exe exe Debug native 2 errors
/home/andy/.cache/zig/p/12200bc414a73a5f6fe8e49cc2f4e4eb0b26067f18189ea1a77671243cb0e285325e/deps/foo/src/mod.zig:1:11: error: C import failed
const c = @cImport({
          ^~~~~~~~
/home/andy/.cache/zig/p/12200bc414a73a5f6fe8e49cc2f4e4eb0b26067f18189ea1a77671243cb0e285325e/deps/foo/src/mod.zig:1:11: note: libc headers not available; compilation does not link against libc
referenced by:
    callFoo: /home/andy/.cache/zig/p/12200bc414a73a5f6fe8e49cc2f4e4eb0b26067f18189ea1a77671243cb0e285325e/deps/foo/src/mod.zig:6:5
    main: /home/andy/.cache/zig/p/12200bc414a73a5f6fe8e49cc2f4e4eb0b26067f18189ea1a77671243cb0e285325e/src/main.zig:5:8
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
/home/andy/dev/contrib-testing/zig-cache/o/489e9845966821d36ee38dc911481a48/cimport.h:1:10: error: 'foo.h' file not found
#include <foo.h>
         ^
error: the following command failed with 2 compilation errors:
/home/andy/dev/zig/build-release/stage3/bin/zig build-exe -ODebug --dep mod --mod root /home/andy/.cache/zig/p/12200bc414a73a5f6fe8e49cc2f4e4eb0b26067f18189ea1a77671243cb0e285325e/src/main.zig /home/andy/dev/contrib-testing/zig-cache/o/8c6847a30bcb287e2388c382ee58d237/liblib.a -ODebug -I /home/andy/dev/contrib-testing/zig-cache/i/638b1b4f66bebab2670392d1647e4e31/include --mod mod /home/andy/.cache/zig/p/12200bc414a73a5f6fe8e49cc2f4e4eb0b26067f18189ea1a77671243cb0e285325e/deps/foo/src/mod.zig --cache-dir /home/andy/dev/contrib-testing/zig-cache --global-cache-dir /home/andy/.cache/zig --name exe --listen=- 
Build Summary: 1/5 steps succeeded; 1 failed (disable with --summary none)
install transitive failure
└─ install transitive failure
   └─ install exe transitive failure
      └─ zig build-exe exe Debug native 2 errors
error: the following build command failed with exit code 1:
/home/andy/dev/contrib-testing/zig-cache/o/135bdb39a75187dd75154ffb32c50beb/build /home/andy/dev/zig/build-release/stage3/bin/zig /home/andy/dev/contrib-testing /home/andy/dev/contrib-testing/zig-cache /home/andy/.cache/zig --seed 0x9b63698f
andy@ark ~/d/contrib-testing (main) [1]> zig-new build
andy@ark ~/d/contrib-testing (main)>
```