### PR TITLE
std.time.epoch isLeapYear optimization

### DIFF
--- a/lib/std/time/epoch.zig
+++ b/lib/std/time/epoch.zig
@@ -45,12 +45,30 @@ pub const Year = u16;
 pub const epoch_year = 1970;
 pub const secs_per_day: u17 = 24 * 60 * 60;
 
+/// Returns true for years with 366 days
+/// and false for years with 365 days.
 pub fn isLeapYear(year: Year) bool {
-    if (@mod(year, 4) != 0)
-        return false;
-    if (@mod(year, 100) != 0)
-        return true;
-    return (0 == @mod(year, 400));
+    // In the western Gregorian Calendar leap a year is
+    // a multiple of 4, excluding multiples of 100, and
+    // adding multiples of 400. In code:
+    //
+    // if (@mod(year, 4) != 0)
+    //     return false;
+    // if (@mod(year, 100) != 0)
+    //     return true;
+    // return (0 == @mod(year, 400));
+
+    // The following is equivalent to the above
+    // but uses bitwise operations when testing
+    // for divisibility, masking with 3 as test
+    // for multiples of 4 and with 15 as a test
+    // for multiples of 16. Multiples of 16 and
+    // 100 are, conveniently, multiples of 400.
+    const mask: Year = switch (year % 100) {
+        0 => 0b1111,
+        else => 0b11,
+    };
+    return 0 == year & mask;
 }
 
 test "isLeapYear" {


### PR DESCRIPTION
I recently benchmarked leap year implementations and found the one in this PR is much faster than the usual one. I'd love some feedback from the zig community.