### PR TITLE
Add support for `--(no-)undefined-version`

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -110,6 +110,9 @@ linker_dynamicbase: bool = true,
 
 linker_allow_shlib_undefined: ?bool = null,
 
+/// Allow version scripts to refer to undefined symbols.
+linker_allow_undefined_version: ?bool = null,
+
 /// Permit read-only relocations in read-only segments. Disallowed by default.
 link_z_notext: bool = false,
 
@@ -1450,6 +1453,9 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     if (self.version_script) |version_script| {
         try zig_args.append("--version-script");
         try zig_args.append(version_script.getPath(b));
+    }
+    if (self.linker_allow_undefined_version) |x| {
+        try zig_args.append(if (x) "--undefined-version" else "--no-undefined-version");
     }
 
     if (self.kind == .@"test") {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1033,6 +1033,7 @@ pub const CreateOptions = struct {
     link_emit_relocs: bool = false,
     linker_script: ?[]const u8 = null,
     version_script: ?[]const u8 = null,
+    linker_allow_undefined_version: bool = false,
     soname: ?[]const u8 = null,
     linker_gc_sections: ?bool = null,
     linker_allow_shlib_undefined: ?bool = null,
@@ -1572,6 +1573,7 @@ pub fn create(gpa: Allocator, arena: Allocator, options: CreateOptions) !*Compil
             .stack_size = options.stack_size,
             .image_base = options.image_base,
             .version_script = options.version_script,
+            .allow_undefined_version = options.linker_allow_undefined_version,
             .gc_sections = options.linker_gc_sections,
             .emit_relocs = options.link_emit_relocs,
             .soname = options.soname,
@@ -2458,7 +2460,7 @@ fn prepareWholeEmitSubPath(arena: Allocator, opt_emit: ?EmitLoc) error{OutOfMemo
 /// to remind the programmer to update multiple related pieces of code that
 /// are in different locations. Bump this number when adding or deleting
 /// anything from the link cache manifest.
-pub const link_hash_implementation_version = 10;
+pub const link_hash_implementation_version = 11;
 
 fn addNonIncrementalStuffToCacheManifest(
     comp: *Compilation,
@@ -2467,7 +2469,7 @@ fn addNonIncrementalStuffToCacheManifest(
 ) !void {
     const gpa = comp.gpa;
 
-    comptime assert(link_hash_implementation_version == 10);
+    comptime assert(link_hash_implementation_version == 11);
 
     if (comp.module) |mod| {
         const main_zig_file = try mod.main_mod.root.joinString(arena, mod.main_mod.root_src_path);
@@ -2541,6 +2543,7 @@ fn addNonIncrementalStuffToCacheManifest(
 
     try man.addOptionalFile(opts.linker_script);
     try man.addOptionalFile(opts.version_script);
+    man.hash.add(opts.allow_undefined_version);
 
     man.hash.addOptional(opts.stack_size);
     man.hash.addOptional(opts.image_base);

--- a/src/link.zig
+++ b/src/link.zig
@@ -113,6 +113,7 @@ pub const File = struct {
         minor_subsystem_version: ?u16,
         gc_sections: ?bool,
         allow_shlib_undefined: ?bool,
+        allow_undefined_version: bool,
         subsystem: ?std.Target.SubSystem,
         linker_script: ?[]const u8,
         version_script: ?[]const u8,

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -70,7 +70,7 @@ pub fn linkWithLLD(self: *Coff, arena: Allocator, prog_node: *std.Progress.Node)
         man = comp.cache_parent.obtain();
         self.base.releaseLock();
 
-        comptime assert(Compilation.link_hash_implementation_version == 10);
+        comptime assert(Compilation.link_hash_implementation_version == 11);
 
         for (comp.objects) |obj| {
             _ = try man.addFile(obj.path, null);

--- a/src/link/MachO/zld.zig
+++ b/src/link/MachO/zld.zig
@@ -55,7 +55,7 @@ pub fn linkWithZld(
         // We are about to obtain this lock, so here we give other processes a chance first.
         macho_file.base.releaseLock();
 
-        comptime assert(Compilation.link_hash_implementation_version == 10);
+        comptime assert(Compilation.link_hash_implementation_version == 11);
 
         for (objects) |obj| {
             _ = try man.addFile(obj.path, null);

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -3547,7 +3547,7 @@ fn linkWithZld(wasm: *Wasm, arena: Allocator, prog_node: *std.Progress.Node) lin
         // We are about to obtain this lock, so here we give other processes a chance first.
         wasm.base.releaseLock();
 
-        comptime assert(Compilation.link_hash_implementation_version == 10);
+        comptime assert(Compilation.link_hash_implementation_version == 11);
 
         for (objects) |obj| {
             _ = try man.addFile(obj.path, null);
@@ -4633,7 +4633,7 @@ fn linkWithLLD(wasm: *Wasm, arena: Allocator, prog_node: *std.Progress.Node) !vo
         // We are about to obtain this lock, so here we give other processes a chance first.
         wasm.base.releaseLock();
 
-        comptime assert(Compilation.link_hash_implementation_version == 10);
+        comptime assert(Compilation.link_hash_implementation_version == 11);
 
         for (comp.objects) |obj| {
             _ = try man.addFile(obj.path, null);


### PR DESCRIPTION
Closes #16855 (main issue)
Closes #17326 (abandoned PR)
Closes #18255 (forked PR)

Adds support for the `--(no-)undefined-version` option, which permits/forbids references to undefined symbols in version scripts. The default is `--no-undefined-version`.

I squashed the commit history and added linker tests (with `use_lld = true` for now), as was requested by https://github.com/ziglang/zig/pull/17326#issuecomment-1741776476