### PR TITLE
Fix Content-Type header parsing when fetching dependencies

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -962,23 +962,27 @@ fn unpackResource(
             const content_type = req.response.headers.getFirstValue("Content-Type") orelse
                 return f.fail(f.location_tok, try eb.addString("missing 'Content-Type' header"));
 
-            if (ascii.eqlIgnoreCase(content_type, "application/x-tar"))
+            // Extract the MIME type, ignoring charset and boundary directives
+            const mime_type_end = if (std.mem.indexOf(u8, content_type, ";")) |i| i else content_type.len;
+            const mime_type = content_type[0..mime_type_end];
+
+            if (ascii.eqlIgnoreCase(mime_type, "application/x-tar"))
                 break :ft .tar;
 
-            if (ascii.eqlIgnoreCase(content_type, "application/gzip") or
-                ascii.eqlIgnoreCase(content_type, "application/x-gzip") or
-                ascii.eqlIgnoreCase(content_type, "application/tar+gzip"))
+            if (ascii.eqlIgnoreCase(mime_type, "application/gzip") or
+                ascii.eqlIgnoreCase(mime_type, "application/x-gzip") or
+                ascii.eqlIgnoreCase(mime_type, "application/tar+gzip"))
             {
                 break :ft .@"tar.gz";
             }
 
-            if (ascii.eqlIgnoreCase(content_type, "application/x-xz"))
+            if (ascii.eqlIgnoreCase(mime_type, "application/x-xz"))
                 break :ft .@"tar.xz";
 
-            if (ascii.eqlIgnoreCase(content_type, "application/zstd"))
+            if (ascii.eqlIgnoreCase(mime_type, "application/zstd"))
                 break :ft .@"tar.zst";
 
-            if (!ascii.eqlIgnoreCase(content_type, "application/octet-stream")) {
+            if (!ascii.eqlIgnoreCase(mime_type, "application/octet-stream")) {
                 return f.fail(f.location_tok, try eb.printString(
                     "unrecognized 'Content-Type' header: '{s}'",
                     .{content_type},

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -963,7 +963,7 @@ fn unpackResource(
                 return f.fail(f.location_tok, try eb.addString("missing 'Content-Type' header"));
 
             // Extract the MIME type, ignoring charset and boundary directives
-            const mime_type_end = if (std.mem.indexOf(u8, content_type, ";")) |i| i else content_type.len;
+            const mime_type_end = std.mem.indexOf(u8, content_type, ";") orelse content_type.len;
             const mime_type = content_type[0..mime_type_end];
 
             if (ascii.eqlIgnoreCase(mime_type, "application/x-tar"))


### PR DESCRIPTION
Currently, when fetching dependencies, `src/Package/Fetch.zig` uses case-insensitive equality on the entire value of the Content-Type header to determine MIME type. However, Content-Type headers may include additional directives after the MIME type, most commonly `charset=utf-8`, delimited by a semicolon.

For example, this issue arises when trying to fetch SQLite sources from the official mirrors:

```
joel@Joels-MBP:~/Projects/zig-sqlite$ zig build
/Users/joel/Projects/zig-sqlite/build.zig.zon:7:20: error: unrecognized 'Content-Type' header: 'application/x-gzip; charset=utf-8'
            .url = "https://www.sqlite.org/2023/sqlite-autoconf-3440200.tar.gz",
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fixes #16963

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type