### PR TITLE
std.Build.Step.Compile: fix link object paths

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -993,7 +993,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                 switch (link_object) {
                     .static_path => |static_path| {
                         if (my_responsibility) {
-                            try zig_args.append(static_path.getPath(b));
+                            try zig_args.append(static_path.getPath2(module.owner, step));
                             total_linker_objects += 1;
                         }
                     },
@@ -1113,7 +1113,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                             try zig_args.append("--");
                             prev_has_cflags = false;
                         }
-                        try zig_args.append(asm_file.getPath(b));
+                        try zig_args.append(asm_file.getPath2(module.owner, step));
                         total_linker_objects += 1;
                     },
 
@@ -1134,7 +1134,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                             try zig_args.append("--");
                             prev_has_cflags = true;
                         }
-                        try zig_args.append(c_source_file.file.getPath(b));
+                        try zig_args.append(c_source_file.file.getPath2(module.owner, step));
                         total_linker_objects += 1;
                     },
 
@@ -1185,7 +1185,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                             try zig_args.append("--");
                             prev_has_rcflags = true;
                         }
-                        try zig_args.append(rc_source_file.file.getPath(b));
+                        try zig_args.append(rc_source_file.file.getPath2(module.owner, step));
                         total_linker_objects += 1;
                     },
                 }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2056,11 +2056,11 @@ pub fn update(comp: *Compilation, main_progress_node: *std.Progress.Node) !void 
             const is_hit = man.hit() catch |err| {
                 const i = man.failed_file_index orelse return err;
                 const pp = man.files.items[i].prefixed_path orelse return err;
-                const prefix = man.cache.prefixes()[pp.prefix].path orelse "";
+                const prefix = man.cache.prefixes()[pp.prefix];
                 return comp.setMiscFailure(
                     .check_whole_cache,
-                    "unable to check cache: stat file '{}{s}{s}' failed: {s}",
-                    .{ comp.local_cache_directory, prefix, pp.sub_path, @errorName(err) },
+                    "unable to check cache: stat file '{}{s}' failed: {s}",
+                    .{ prefix, pp.sub_path, @errorName(err) },
                 );
             };
             if (is_hit) {


### PR DESCRIPTION
They were being resolved relative to the wrong owner.

closes #18460

Tested via https://github.com/ziglang/contrib-testing/commit/b10e253b4b07bcb56a34940226ac2fe331cede56
