### PR TITLE
Don't enable optional ARM Cortex-M series CPU features by default

### DIFF
--- a/lib/std/Target/arm.zig
+++ b/lib/std/Target/arm.zig
@@ -2204,9 +2204,7 @@ pub const cpu = struct {
         .name = "cortex_m33",
         .llvm_name = "cortex-m33",
         .features = featureSet(&[_]Feature{
-            .dsp,
             .fix_cmse_cve_2021_35465,
-            .fp_armv8d16sp,
             .loop_align,
             .no_branch_predictor,
             .slowfpvfmx,
@@ -2219,9 +2217,7 @@ pub const cpu = struct {
         .name = "cortex_m35p",
         .llvm_name = "cortex-m35p",
         .features = featureSet(&[_]Feature{
-            .dsp,
             .fix_cmse_cve_2021_35465,
-            .fp_armv8d16sp,
             .loop_align,
             .no_branch_predictor,
             .slowfpvfmx,
@@ -2240,17 +2236,15 @@ pub const cpu = struct {
             .slowfpvmlx,
             .use_misched,
             .v7em,
-            .vfp4d16sp,
         }),
     };
     pub const cortex_m55 = CpuModel{
         .name = "cortex_m55",
         .llvm_name = "cortex-m55",
         .features = featureSet(&[_]Feature{
+            .dsp,
             .fix_cmse_cve_2021_35465,
-            .fp_armv8d16,
             .loop_align,
-            .mve_fp,
             .no_branch_predictor,
             .slowfpvmlx,
             .use_misched,
@@ -2261,7 +2255,6 @@ pub const cpu = struct {
         .name = "cortex_m7",
         .llvm_name = "cortex-m7",
         .features = featureSet(&[_]Feature{
-            .fp_armv8d16,
             .use_mipipeliner,
             .use_misched,
             .v7em,
@@ -2271,9 +2264,8 @@ pub const cpu = struct {
         .name = "cortex_m85",
         .llvm_name = "cortex-m85",
         .features = featureSet(&[_]Feature{
-            .fp_armv8d16,
-            .mve_fp,
-            .pacbti,
+            .dsp,
+            .trustzone,
             .use_misched,
             .v8_1m_main,
         }),

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -380,6 +380,31 @@ const llvm_targets = [_]LlvmTarget{
                 .flatten = true,
             },
             .{
+                .llvm_name = "cortex-m4",
+                .omit_deps = &.{"vfp4d16sp"},
+            },
+            .{
+                .llvm_name = "cortex-m7",
+                .omit_deps = &.{"fp_armv8d16"},
+            },
+            .{
+                .llvm_name = "cortex-m33",
+                .omit_deps = &.{ "fp_armv8d16sp", "dsp" },
+            },
+            .{
+                .llvm_name = "cortex-m35p",
+                .omit_deps = &.{ "fp_armv8d16sp", "dsp" },
+            },
+            .{
+                .llvm_name = "cortex-m55",
+                .omit_deps = &.{ "mve_fp", "fp_armv8d16" },
+            },
+            .{
+                .llvm_name = "cortex-m85",
+                .omit_deps = &.{ "mve_fp", "pacbti", "fp_armv8d16" },
+                .extra_deps = &.{"trustzone"},
+            },
+            .{
                 .llvm_name = "cortex-x1c",
                 .flatten = true,
             },


### PR DESCRIPTION
Closes #17374

Updates `update_cpu_features.zig` to support omitting deps and adds overrides for incorrect ARM Cortex-M series CPU definitions, most of them optional features that should not be enabled by default.

Based on the official [Arm Cortex-M Processor Comparison Table](https://developer.arm.com/documentation/102787/0300/?lang=en). Specifically the following highlighted features were incorrect:

![image](https://github.com/ziglang/zig/assets/54114156/cc580339-0629-4d6f-947d-0dd1d49e2d6b)

I then re-ran `update_cpu_features.zig` using a `llvm-tblgen` built from https://github.com/llvm/llvm-project/commit/8f4dd44097c9ae25dd203d5ac87f3b48f854bba8, the exact same revision as the last time CPU features were updated (3ed40b114020ff774279a5af993851d74da64b52).