### PR TITLE
windows: clarify CREATE_UNICODE_ENVIRONMENT, add errors of CreateProcessW, LoadLibraryW

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1755,6 +1755,7 @@ pub fn CreateProcessW(
             .PATH_NOT_FOUND => return error.FileNotFound,
             .ACCESS_DENIED => return error.AccessDenied,
             .INVALID_PARAMETER => unreachable,
+            .NOACCESS => unreachable,
             .INVALID_NAME => return error.InvalidName,
             .FILENAME_EXCED_RANGE => return error.NameTooLong,
             // These are all the system errors that are mapped to ENOEXEC by
@@ -1789,6 +1790,8 @@ pub fn CreateProcessW(
 pub const LoadLibraryError = error{
     FileNotFound,
     Unexpected,
+    InitFailed,
+    SystemResources,
 };
 
 pub fn LoadLibraryW(lpLibFileName: [*:0]const u16) LoadLibraryError!HMODULE {
@@ -1797,6 +1800,8 @@ pub fn LoadLibraryW(lpLibFileName: [*:0]const u16) LoadLibraryError!HMODULE {
             .FILE_NOT_FOUND => return error.FileNotFound,
             .PATH_NOT_FOUND => return error.FileNotFound,
             .MOD_NOT_FOUND => return error.FileNotFound,
+            .DLL_INIT_FAILED => return error.InitFailed,
+            .NOT_ENOUGH_MEMORY => return error.SystemResources,
             else => |err| return unexpectedError(err),
         }
     };


### PR DESCRIPTION
These are the non-controversial parts of implementing #14251 from https://github.com/matu3ba/win32k-mitigation.

NOACCESS can occur, if the process is not permitted to access memory provided to UpdateProcThreadAttribute.

DLL_INIT_FAILED occurs on first failure to load restricted libraries with win32k mitigation with followup failing loads returning nonsensical NOT_ENOUGH_MEMORY.