### PR TITLE
zig build: handle stderr more elegantly

### DIFF
--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -31,6 +31,7 @@ max_rss: usize,
 
 result_error_msgs: std.ArrayListUnmanaged([]const u8),
 result_error_bundle: std.zig.ErrorBundle,
+result_stderr: []const u8,
 result_cached: bool,
 result_duration_ns: ?u64,
 /// 0 means unavailable or not reported.
@@ -164,6 +165,7 @@ pub fn init(options: StepOptions) Step {
         },
         .result_error_msgs = .{},
         .result_error_bundle = std.zig.ErrorBundle.empty,
+        .result_stderr = "",
         .result_cached = false,
         .result_duration_ns = null,
         .result_peak_rss = 0,

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -1214,7 +1214,7 @@ fn evalZigTest(
 
     if (stderr.readableLength() > 0) {
         const msg = std.mem.trim(u8, try stderr.toOwnedSlice(), "\n");
-        if (msg.len > 0) try self.step.result_error_msgs.append(arena, msg);
+        if (msg.len > 0) self.step.result_stderr = msg;
     }
 
     // Send EOF to stdin.
@@ -1344,7 +1344,7 @@ fn evalGeneric(self: *Run, child: *std.process.Child) !StdIoResult {
             else => true,
         };
         if (stderr_is_diagnostic) {
-            try self.step.result_error_msgs.append(arena, bytes);
+            self.step.result_stderr = bytes;
         }
     };
 


### PR DESCRIPTION
* Specifically recognize stderr as a different concept than an error message in Step results.
* Display it differently when only stderr occurs but the build proceeds successfully.

closes #18473