### PR TITLE
Disallow @ptrCast from casting comptime only types to non-comptime only types.

### DIFF
--- a/test/cases/compile_errors/@ptrCast_inline_fn_to_fn_ptr.zig
+++ b/test/cases/compile_errors/@ptrCast_inline_fn_to_fn_ptr.zig
@@ -1,0 +1,14 @@
+inline fn x() bool {
+    return true;
+}
+
+export fn entry() void {
+    const y: *const fn () bool = @ptrCast(&x);
+    _ = y;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :6:34: error: Cannot @ptrCast comptime type '*const fn () callconv(.Inline) bool' to non-comptime type '*const fn () bool'

--- a/test/cases/compile_errors/@ptrCast_inline_fn_to_fn_ptr.zig
+++ b/test/cases/compile_errors/@ptrCast_inline_fn_to_fn_ptr.zig
@@ -11,4 +11,4 @@ export fn entry() void {
 // backend=stage2
 // target=native
 //
-// :6:34: error: Cannot @ptrCast comptime type '*const fn () callconv(.Inline) bool' to non-comptime type '*const fn () bool'
+// :6:34: error: Cannot @ptrCast comptime only type '*const fn () callconv(.Inline) bool' to non-comptime only type '*const fn () bool'


### PR DESCRIPTION
Fixes #18446

This check is implemented similar to how `@intFromPtr()` forbids comptime only types.