### PR TITLE
fix #17142, wrong comptime log_int computation

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -672,6 +672,7 @@ test "rotl" {
 /// - 1. Suitable for 0-based bit indices of T.
 pub fn Log2Int(comptime T: type) type {
     // comptime ceil log2
+    if (T == comptime_int) return comptime_int;
     comptime var count = 0;
     comptime var s = @typeInfo(T).Int.bits - 1;
     inline while (s != 0) : (s >>= 1) {
@@ -684,6 +685,7 @@ pub fn Log2Int(comptime T: type) type {
 /// Returns an unsigned int type that can hold the number of bits in T.
 pub fn Log2IntCeil(comptime T: type) type {
     // comptime ceil log2
+    if (T == comptime_int) return comptime_int;
     comptime var count = 0;
     comptime var s = @typeInfo(T).Int.bits;
     inline while (s != 0) : (s >>= 1) {

--- a/lib/std/math/log.zig
+++ b/lib/std/math/log.zig
@@ -24,11 +24,8 @@ pub fn log(comptime T: type, base: T, x: T) T {
             return @as(comptime_float, @log(@as(f64, x)) / @log(float_base));
         },
 
-        // TODO: implement integer log without using float math.
-        // The present implementation is incorrect, for example
-        // `log(comptime_int, 9, 59049)` should return `5` and not `4`.
         .ComptimeInt => {
-            return @as(comptime_int, @floor(@log(@as(f64, x)) / @log(float_base)));
+            return @as(comptime_int, math.log_int(comptime_int, base, x));
         },
 
         .Int => |IntType| switch (IntType.signedness) {


### PR DESCRIPTION
small follow up on #17143 , which will allow to close #17142

The `log_int` function should also be called at compile time. To allow this, I made the compile time check a little more permissive.

@matu3ba can you please review this one, since you accepted the previous one ? Thanks.