### PR TITLE
std.fmt: Clarify that width is measured in Unicode Codepoints.

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -42,7 +42,7 @@ pub const FormatOptions = struct {
 /// - *specifier* is a type-dependent formatting option that determines how a type should formatted (see below)
 /// - *fill* is a single character which is used to pad the formatted text
 /// - *alignment* is one of the three characters `<`, `^`, or `>` to make the text left-, center-, or right-aligned, respectively
-/// - *width* is the total width of the field in characters
+/// - *width* is the total width of the field in "characters" (unicode codepoints)
 /// - *precision* specifies how many decimals a formatted number should have
 ///
 /// Note that most of the parameters are optional and may be omitted. Also you can leave out separators like `:` and `.` when


### PR DESCRIPTION
According to the current implementation of `formatBuf()`, we measure the "number of characters" taken up by a slice given for rendering using `unicode.utf8CountCodepoints`.  Currently the fill `character` is a single ASCII byte.  Hence, "width" today means number of unicode codepoints.

Given more advanced terminals like *ghostty* it's arguable we might want to count grapheme clusters when providing width and alignment, but then that would bring much heaviness in the form of a library like ziglyph into a very core part of zig, so probably not.  Better to just say what we're doing today.