### PR TITLE
wasm: allow non-int vectors

### DIFF
--- a/src/arch/wasm/abi.zig
+++ b/src/arch/wasm/abi.zig
@@ -45,7 +45,7 @@ pub fn classifyType(ty: Type, mod: *Module) [2]Class {
             }
             return classifyType(field_ty, mod);
         },
-        .Int, .Enum, .ErrorSet, .Vector => {
+        .Int, .Enum, .ErrorSet => {
             const int_bits = ty.intInfo(mod).bits;
             if (int_bits <= 64) return direct;
             if (int_bits <= 128) return .{ .direct, .direct };
@@ -58,6 +58,7 @@ pub fn classifyType(ty: Type, mod: *Module) [2]Class {
             return memory;
         },
         .Bool => return direct,
+        .Vector => return direct,
         .Array => return memory,
         .Optional => {
             assert(ty.isPtrLikeOptional(mod));

--- a/test/c_abi/cfuncs.c
+++ b/test/c_abi/cfuncs.c
@@ -236,7 +236,7 @@ struct SplitStructMixed zig_ret_split_struct_mixed();
 
 struct BigStruct zig_big_struct_both(struct BigStruct);
 
-#if defined(ZIG_BACKEND_STAGE2_X86_64) || defined(ZIG_PPC32)
+#if defined(ZIG_BACKEND_STAGE2_X86_64) || defined(ZIG_PPC32) || defined(__wasm__)
 
 typedef bool Vector2Bool __attribute__((ext_vector_type(2)));
 typedef bool Vector4Bool __attribute__((ext_vector_type(4)));
@@ -522,6 +522,9 @@ void c_vector_128_bool(Vector128Bool vec) {
     assert_or_panic(vec[126] == true);
     assert_or_panic(vec[127] == true);
 }
+
+// WASM: The following vector functions define too many Wasm locals for wasmtime in debug mode and are therefore disabled for the wasm target.
+#if !defined(__wasm__)
 
 void c_vector_256_bool(Vector256Bool vec) {
     assert_or_panic(vec[0] == false);
@@ -1296,6 +1299,8 @@ void c_vector_512_bool(Vector512Bool vec) {
     assert_or_panic(vec[510] == false);
     assert_or_panic(vec[511] == true);
 }
+
+#endif
 
 Vector2Bool c_ret_vector_2_bool(void) {
     return (Vector2Bool){

--- a/test/c_abi/cfuncs.c
+++ b/test/c_abi/cfuncs.c
@@ -236,6 +236,36 @@ struct SplitStructMixed zig_ret_split_struct_mixed();
 
 struct BigStruct zig_big_struct_both(struct BigStruct);
 
+typedef float Vector2Float __attribute__((ext_vector_type(2)));
+typedef float Vector4Float __attribute__((ext_vector_type(4)));
+
+void c_vector_2_float(Vector2Float vec) {
+    assert_or_panic(vec[0] == 1.0);
+    assert_or_panic(vec[1] == 2.0);
+}
+
+void c_vector_4_float(Vector4Float vec) {
+    assert_or_panic(vec[0] == 1.0);
+    assert_or_panic(vec[1] == 2.0);
+    assert_or_panic(vec[2] == 3.0);
+    assert_or_panic(vec[3] == 4.0);
+}
+
+Vector2Float c_ret_vector_2_float(void) {
+    return (Vector2Float){
+        1.0,
+        2.0,
+    };
+}
+Vector4Float c_ret_vector_4_float(void) {
+    return (Vector4Float){
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+    };
+}
+
 #if defined(ZIG_BACKEND_STAGE2_X86_64) || defined(ZIG_PPC32) || defined(__wasm__)
 
 typedef bool Vector2Bool __attribute__((ext_vector_type(2)));

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -890,6 +890,34 @@ test "big simd vector" {
     try expect(x[7] == 16);
 }
 
+const Vector2Float = @Vector(2, f32);
+const Vector4Float = @Vector(4, f32);
+
+extern fn c_vector_2_float(Vector2Float) void;
+extern fn c_vector_4_float(Vector4Float) void;
+
+extern fn c_ret_vector_2_float() Vector2Float;
+extern fn c_ret_vector_4_float() Vector4Float;
+
+test "float simd vectors" {
+    if (builtin.cpu.arch == .powerpc or builtin.cpu.arch == .powerpc64le) return error.SkipZigTest;
+
+    {
+        c_vector_2_float(.{ 1.0, 2.0 });
+        const vec = c_ret_vector_2_float();
+        try expect(vec[0] == 1.0);
+        try expect(vec[1] == 2.0);
+    }
+    {
+        c_vector_4_float(.{ 1.0, 2.0, 3.0, 4.0 });
+        const vec = c_ret_vector_4_float();
+        try expect(vec[0] == 1.0);
+        try expect(vec[1] == 2.0);
+        try expect(vec[2] == 3.0);
+        try expect(vec[3] == 4.0);
+    }
+}
+
 const Vector2Bool = @Vector(2, bool);
 const Vector4Bool = @Vector(4, bool);
 const Vector8Bool = @Vector(8, bool);

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -921,7 +921,7 @@ extern fn c_ret_vector_256_bool() Vector256Bool;
 extern fn c_ret_vector_512_bool() Vector512Bool;
 
 test "bool simd vector" {
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch != .powerpc) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_llvm and (builtin.cpu.arch != .powerpc and builtin.cpu.arch != .wasm32)) return error.SkipZigTest;
 
     {
         c_vector_2_bool(.{
@@ -1473,8 +1473,9 @@ test "bool simd vector" {
         try expect(vec[126] == false);
         try expect(vec[127] == true);
     }
+
     {
-        c_vector_256_bool(.{
+        if (builtin.target.cpu.arch != .wasm32) c_vector_256_bool(.{
             false,
             true,
             true,
@@ -1992,7 +1993,7 @@ test "bool simd vector" {
         try expect(vec[255] == false);
     }
     {
-        c_vector_512_bool(.{
+        if (builtin.target.cpu.arch != .wasm32) c_vector_512_bool(.{
             true,
             true,
             true,
@@ -3025,7 +3026,6 @@ test "bool simd vector" {
 
 comptime {
     skip: {
-        if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .wasm32) break :skip;
         if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .x86_64) break :skip;
 
         _ = struct {


### PR DESCRIPTION
The wasm backend ABI classification for vectors is currently surprising. It only works for int types and classifies based on the size of element type which is not in line with how the self-hosted wasm backend represents vectors in [`determineSimdStoreStrategy`](https://github.com/ziglang/zig/blob/63de8a59891f2c342d1a51b808cf04a895ba54d6/src/arch/wasm/CodeGen.zig#L1793-L1803).

~~With this change, the ABI use a v128 when the size is 128 and use a reference to memory instead otherwise. This works for non integer vectors (bool, float, and pointers).~~

~~This change means that instead of unrolling vectors as parameters, they are passed as reference (for the llvm backend since they were passed as reference already in the self-hosted backend):~~

```zig
const T = i32;
const V = @Vector(5, T);

pub export fn makeTest(v: V) callconv(.C) V {
    return v;
}
```

```diff
- (func $makeTest (type 0) (param i32 i32 i32 i32 i32 i32)
+ (func $makeTest (type 0) (param i32 i32)
```

~~The main goal of this change is to enable passing bool, float and ptr vectors as parameter/return type so I may be missing some context about the current classification and maybe it would be preferred to update the self-hosted backend to unroll vectors as multiple parameters?~~