### PR TITLE
Expose `-f(no-)formatted-panics` to the build system (again)

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -33,6 +33,7 @@ version: ?std.SemanticVersion,
 kind: Kind,
 major_only_filename: ?[]const u8,
 name_only_filename: ?[]const u8,
+formatted_panics: ?bool = null,
 // keep in sync with src/link.zig:CompressDebugSections
 compress_debug_sections: enum { none, zlib, zstd } = .none,
 verbose_link: bool,
@@ -1304,6 +1305,8 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     if (self.generated_llvm_bc != null) try zig_args.append("-femit-llvm-bc");
     if (self.generated_llvm_ir != null) try zig_args.append("-femit-llvm-ir");
     if (self.generated_h != null) try zig_args.append("-femit-h");
+
+    try addFlag(&zig_args, "formatted-panics", self.formatted_panics);
 
     switch (self.compress_debug_sections) {
         .none => {},


### PR DESCRIPTION
I only just now got to updating one of my projects and noticed that this option was nowhere to be found. Looks like c20ad51c621ba18d2c90cc96d1b550831dc5d7a3 inadvertently removed it.

Formatted panics still appear to be a compilation option and not a module option, so they still belong in `Step.Compile`.

Related: #18287