### PR TITLE
objcopy: ofmt=hex iterates through segments instead of sections

### DIFF
--- a/src/objcopy.zig
+++ b/src/objcopy.zig
@@ -284,10 +284,8 @@ fn emitElf(
             }
 
             var hex_writer = HexWriter{ .out_file = out_file };
-            for (binary_elf_output.sections.items) |section| {
-                if (section.segment) |segment| {
-                    try hex_writer.writeSegment(segment, in_file);
-                }
+            for (binary_elf_output.segments.items) |segment| {
+                try hex_writer.writeSegment(segment, in_file);
             }
             if (options.pad_to) |_| {
                 // Padding to a size in hex files isn't applicable


### PR DESCRIPTION
The issue this change proposes to address is specifically the ofmt=hex. Based on the checks prior to calling hex_writer.writeSegment() it is not difficult assume the original intention was to iterate through segments instead of through each section. Fixes #18545.