### PR TITLE
std.http.Client: read response messages with no length until eof

### DIFF
--- a/lib/std/http/protocol.zig
+++ b/lib/std/http/protocol.zig
@@ -524,7 +524,7 @@ pub const HeadersParser = struct {
     ///
     /// If `skip` is true, the buffer will be unused and the body will be skipped.
     ///
-    /// See `std.http.Client.BufferedConnection for an example of `conn`.
+    /// See `std.http.Client.Connection for an example of `conn`.
     pub fn read(r: *HeadersParser, conn: anytype, buffer: []u8, skip: bool) !usize {
         assert(r.state.isContent());
         if (r.done) return 0;
@@ -543,7 +543,7 @@ pub const HeadersParser = struct {
                         conn.drop(@intCast(nread));
                         r.next_chunk_length -= nread;
 
-                        if (r.next_chunk_length == 0) r.done = true;
+                        if (r.next_chunk_length == 0 or nread == 0) r.done = true;
 
                         return out_index;
                     } else if (out_index < buffer.len) {
@@ -553,7 +553,7 @@ pub const HeadersParser = struct {
                         const nread = try conn.read(buffer[0..can_read]);
                         r.next_chunk_length -= nread;
 
-                        if (r.next_chunk_length == 0) r.done = true;
+                        if (r.next_chunk_length == 0 or nread == 0) r.done = true;
 
                         return nread;
                     } else {


### PR DESCRIPTION
Fixes #18367. Handles the edge case of a response with no transfer-encoding and no content-length needing to be read until the connection is closed. I also took the chance to fix no content responses to follow the spec word for word.

This problem does not apply to std.http.Server as a request message missing transfer-encoding is to be interpreted as a zero length body.