### PR TITLE
17944 followup

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -28657,7 +28657,7 @@ fn coerceExtra(
                     if (!dest_info.flags.is_const) {
                         const err_msg = err_msg: {
                             const err_msg = try sema.errMsg(block, inst_src, "cannot cast pointer to tuple to '{}'", .{dest_ty.fmt(mod)});
-                            errdefer err_msg.deinit(sema.gpa);
+                            errdefer err_msg.destroy(sema.gpa);
                             try sema.errNote(block, dest_ty_src, err_msg, "pointers to tuples can only coerce to constant pointers", .{});
                             break :err_msg err_msg;
                         };
@@ -32599,31 +32599,39 @@ fn analyzeSlice(
 
                     if (try sema.compareScalar(start_value, .neq, end_value, Type.comptime_int)) {
                         if (try sema.compareScalar(start_value, .neq, Value.zero_comptime_int, Type.comptime_int)) {
-                            const err_msg = try sema.errMsg(block, start_src, bounds_error_message, .{});
-                            try sema.errNote(
-                                block,
-                                start_src,
-                                err_msg,
-                                "expected '{}', found '{}'",
-                                .{
-                                    Value.zero_comptime_int.fmtValue(Type.comptime_int, mod),
-                                    start_value.fmtValue(Type.comptime_int, mod),
-                                },
-                            );
-                            return sema.failWithOwnedErrorMsg(block, err_msg);
+                            const msg = msg: {
+                                const msg = try sema.errMsg(block, start_src, bounds_error_message, .{});
+                                errdefer msg.destroy(sema.gpa);
+                                try sema.errNote(
+                                    block,
+                                    start_src,
+                                    msg,
+                                    "expected '{}', found '{}'",
+                                    .{
+                                        Value.zero_comptime_int.fmtValue(Type.comptime_int, mod),
+                                        start_value.fmtValue(Type.comptime_int, mod),
+                                    },
+                                );
+                                break :msg msg;
+                            };
+                            return sema.failWithOwnedErrorMsg(block, msg);
                         } else if (try sema.compareScalar(end_value, .neq, Value.one_comptime_int, Type.comptime_int)) {
-                            const err_msg = try sema.errMsg(block, end_src, bounds_error_message, .{});
-                            try sema.errNote(
-                                block,
-                                end_src,
-                                err_msg,
-                                "expected '{}', found '{}'",
-                                .{
-                                    Value.one_comptime_int.fmtValue(Type.comptime_int, mod),
-                                    end_value.fmtValue(Type.comptime_int, mod),
-                                },
-                            );
-                            return sema.failWithOwnedErrorMsg(block, err_msg);
+                            const msg = msg: {
+                                const msg = try sema.errMsg(block, end_src, bounds_error_message, .{});
+                                errdefer msg.destroy(sema.gpa);
+                                try sema.errNote(
+                                    block,
+                                    end_src,
+                                    msg,
+                                    "expected '{}', found '{}'",
+                                    .{
+                                        Value.one_comptime_int.fmtValue(Type.comptime_int, mod),
+                                        end_value.fmtValue(Type.comptime_int, mod),
+                                    },
+                                );
+                                break :msg msg;
+                            };
+                            return sema.failWithOwnedErrorMsg(block, msg);
                         }
                     } else {
                         if (try sema.compareScalar(end_value, .gt, Value.one_comptime_int, Type.comptime_int)) {

--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -7,11 +7,11 @@ const assert = std.debug.assert;
 var foo: u8 align(4) = 100;
 
 test "global variable alignment" {
-    try comptime expect(@typeInfo(@TypeOf(&foo)).Pointer.alignment == 4);
-    try comptime expect(@TypeOf(&foo) == *align(4) u8);
+    comptime assert(@typeInfo(@TypeOf(&foo)).Pointer.alignment == 4);
+    comptime assert(@TypeOf(&foo) == *align(4) u8);
     {
         const slice = @as(*align(4) [1]u8, &foo)[0..];
-        try comptime expect(@TypeOf(slice) == *align(4) [1]u8);
+        comptime assert(@TypeOf(slice) == *align(4) [1]u8);
     }
 }
 
@@ -455,10 +455,10 @@ test "runtime-known array index has best alignment possible" {
     try testIndex2(&array, 3, *u8);
 }
 fn testIndex(smaller: [*]align(2) u32, index: usize, comptime T: type) !void {
-    try comptime expect(@TypeOf(&smaller[index]) == T);
+    comptime assert(@TypeOf(&smaller[index]) == T);
 }
 fn testIndex2(ptr: [*]align(4) u8, index: usize, comptime T: type) !void {
-    try comptime expect(@TypeOf(&ptr[index]) == T);
+    comptime assert(@TypeOf(&ptr[index]) == T);
 }
 
 test "alignment of function with c calling convention" {
@@ -524,7 +524,7 @@ test "struct field explicit alignment" {
     var node: S.Node = undefined;
     node.massive_byte = 100;
     try expect(node.massive_byte == 100);
-    try comptime expect(@TypeOf(&node.massive_byte) == *align(64) u8);
+    comptime assert(@TypeOf(&node.massive_byte) == *align(64) u8);
     try expect(@intFromPtr(&node.massive_byte) % 64 == 0);
 }
 

--- a/test/behavior/alignof.zig
+++ b/test/behavior/alignof.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 const builtin = @import("builtin");
 const native_arch = builtin.target.cpu.arch;
@@ -11,9 +12,9 @@ const Foo = struct {
 };
 
 test "@alignOf(T) before referencing T" {
-    try comptime expect(@alignOf(Foo) != maxInt(usize));
+    comptime assert(@alignOf(Foo) != maxInt(usize));
     if (native_arch == .x86_64) {
-        try comptime expect(@alignOf(Foo) == 4);
+        comptime assert(@alignOf(Foo) == 4);
     }
 }
 

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const testing = std.testing;
 const mem = std.mem;
+const assert = std.debug.assert;
 const expect = testing.expect;
 const expectEqual = testing.expectEqual;
 
@@ -149,9 +150,9 @@ test "array len field" {
     var arr = [4]u8{ 0, 0, 0, 0 };
     const ptr = &arr;
     try expect(arr.len == 4);
-    try comptime expect(arr.len == 4);
+    comptime assert(arr.len == 4);
     try expect(ptr.len == 4);
-    try comptime expect(ptr.len == 4);
+    comptime assert(ptr.len == 4);
     try expect(@TypeOf(arr.len) == usize);
 }
 
@@ -904,7 +905,7 @@ test "store array of array of structs at comptime" {
     };
 
     try expect(S.storeArrayOfArrayOfStructs() == 15);
-    try comptime expect(S.storeArrayOfArrayOfStructs() == 15);
+    comptime assert(S.storeArrayOfArrayOfStructs() == 15);
 }
 
 test "accessing multidimensional global array at comptime" {

--- a/test/behavior/async_fn.zig
+++ b/test/behavior/async_fn.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const expectEqualStrings = std.testing.expectEqualStrings;
@@ -221,7 +222,7 @@ var a_promise: anyframe = undefined;
 var global_result = false;
 fn testSuspendBlock() callconv(.Async) void {
     suspend {
-        comptime expect(@TypeOf(@frame()) == *@Frame(testSuspendBlock)) catch unreachable;
+        comptime assert(@TypeOf(@frame()) == *@Frame(testSuspendBlock)) catch unreachable;
         a_promise = @frame();
     }
 
@@ -334,7 +335,7 @@ test "async fn pointer in a struct field" {
     _ = &foo;
     var bytes: [64]u8 align(16) = undefined;
     const f = @asyncCall(&bytes, {}, foo.bar, .{&data});
-    try comptime expect(@TypeOf(f) == anyframe->void);
+    comptime assert(@TypeOf(f) == anyframe->void);
     try expect(data == 2);
     resume f;
     try expect(data == 4);
@@ -1150,7 +1151,7 @@ test "@asyncCall using the result location inside the frame" {
     _ = &foo;
     var bytes: [64]u8 align(16) = undefined;
     const f = @asyncCall(&bytes, {}, foo.bar, .{&data});
-    try comptime expect(@TypeOf(f) == anyframe->i32);
+    comptime assert(@TypeOf(f) == anyframe->i32);
     try expect(data == 2);
     resume f;
     try expect(data == 4);
@@ -1165,7 +1166,7 @@ test "@TypeOf an async function call of generic fn with error union type" {
     const S = struct {
         fn func(comptime x: anytype) anyerror!i32 {
             const T = @TypeOf(async func(x));
-            try comptime expect(T == @typeInfo(@TypeOf(@frame())).Pointer.child);
+            comptime assert(T == @typeInfo(@TypeOf(@frame())).Pointer.child);
             return undefined;
         }
     };

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -17,7 +17,7 @@ test "empty function with comments" {
 
 test "truncate" {
     try expect(testTruncate(0x10fd) == 0xfd);
-    try comptime expect(testTruncate(0x10fd) == 0xfd);
+    comptime assert(testTruncate(0x10fd) == 0xfd);
 }
 fn testTruncate(x: u32) u8 {
     return @as(u8, @truncate(x));
@@ -568,7 +568,7 @@ fn emptyFn() void {}
 const addr1 = @as(*const u8, @ptrCast(&emptyFn));
 test "comptime cast fn to ptr" {
     const addr2 = @as(*const u8, @ptrCast(&emptyFn));
-    try comptime expect(addr1 == addr2);
+    comptime assert(addr1 == addr2);
 }
 
 test "equality compare fn ptrs" {
@@ -678,8 +678,8 @@ test "string concatenation" {
     const a = "OK" ++ " IT " ++ "WORKED";
     const b = "OK IT WORKED";
 
-    try comptime expect(@TypeOf(a) == *const [12:0]u8);
-    try comptime expect(@TypeOf(b) == *const [12:0]u8);
+    comptime assert(@TypeOf(a) == *const [12:0]u8);
+    comptime assert(@TypeOf(b) == *const [12:0]u8);
 
     const len = b.len;
     const len_with_null = len + 1;
@@ -747,7 +747,7 @@ test "auto created variables have correct alignment" {
         }
     };
     try expect(S.foo("\x7a\x7a\x7a\x7a") == 0x7a7a7a7a);
-    try comptime expect(S.foo("\x7a\x7a\x7a\x7a") == 0x7a7a7a7a);
+    comptime assert(S.foo("\x7a\x7a\x7a\x7a") == 0x7a7a7a7a);
 }
 
 test "extern variable with non-pointer opaque type" {

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const math = std.math;
@@ -273,7 +274,7 @@ test "comptime bitcast used in expression has the correct type" {
 test "bitcast passed as tuple element" {
     const S = struct {
         fn foo(args: anytype) !void {
-            try comptime expect(@TypeOf(args[0]) == f32);
+            comptime assert(@TypeOf(args[0]) == f32);
             try expect(args[0] == 12.34);
         }
     };
@@ -283,7 +284,7 @@ test "bitcast passed as tuple element" {
 test "triple level result location with bitcast sandwich passed as tuple element" {
     const S = struct {
         fn foo(args: anytype) !void {
-            try comptime expect(@TypeOf(args[0]) == f64);
+            comptime assert(@TypeOf(args[0]) == f64);
             try expect(args[0] > 12.33 and args[0] < 12.35);
         }
     };

--- a/test/behavior/call.zig
+++ b/test/behavior/call.zig
@@ -1,5 +1,6 @@
 const builtin = @import("builtin");
 const std = @import("std");
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 
@@ -10,11 +11,11 @@ test "super basic invocations" {
         }
     }.foo;
     try expect(@call(.auto, foo, .{}) == 1234);
-    try comptime expect(@call(.always_inline, foo, .{}) == 1234);
+    comptime assert(@call(.always_inline, foo, .{}) == 1234);
     {
         // comptime call without comptime keyword
         const result = @call(.compile_time, foo, .{}) == 1234;
-        try comptime expect(result);
+        comptime assert(result);
     }
 }
 
@@ -42,7 +43,7 @@ test "basic invocations" {
     {
         // comptime call without comptime keyword
         const result = @call(.compile_time, foo, .{}) == 1234;
-        try comptime expect(result);
+        comptime assert(result);
     }
     {
         // call of non comptime-known function
@@ -73,7 +74,7 @@ test "tuple parameters" {
     try expect(@call(.auto, add, .{ a, b }) == 46);
     try expect(@call(.auto, add, .{ 12, 34 }) == 46);
     if (false) {
-        try comptime expect(@call(.auto, add, .{ 12, 34 }) == 46); // TODO
+        comptime assert(@call(.auto, add, .{ 12, 34 }) == 46); // TODO
     }
     try expect(comptime @call(.auto, add, .{ 12, 34 }) == 46);
     {

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -63,7 +63,7 @@ test "implicit cast comptime numbers to any type when the value fits" {
 }
 
 test "implicit cast comptime_int to comptime_float" {
-    try comptime expect(@as(comptime_float, 10) == @as(f32, 10));
+    comptime assert(@as(comptime_float, 10) == @as(f32, 10));
     try expect(2 == 2.0);
 }
 
@@ -313,11 +313,11 @@ test "peer result null and comptime_int" {
     };
 
     try expect(S.blah(0) == null);
-    try comptime expect(S.blah(0) == null);
+    comptime assert(S.blah(0) == null);
     try expect(S.blah(10).? == 1);
-    try comptime expect(S.blah(10).? == 1);
+    comptime assert(S.blah(10).? == 1);
     try expect(S.blah(-10).? == -1);
-    try comptime expect(S.blah(-10).? == -1);
+    comptime assert(S.blah(-10).? == -1);
 }
 
 test "*const ?[*]const T to [*c]const [*c]const T" {
@@ -393,7 +393,7 @@ test "peer type unsigned int to signed" {
     var y: i32 = -5;
     _ = .{ &w, &x, &y };
     const a = w + y + x;
-    try comptime expect(@TypeOf(a) == i32);
+    comptime assert(@TypeOf(a) == i32);
     try expect(a == 7);
 }
 
@@ -542,9 +542,9 @@ test "peer type resolution: error and [N]T" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     try expect(mem.eql(u8, try testPeerErrorAndArray(0), "OK"));
-    try comptime expect(mem.eql(u8, try testPeerErrorAndArray(0), "OK"));
+    comptime assert(mem.eql(u8, try testPeerErrorAndArray(0), "OK"));
     try expect(mem.eql(u8, try testPeerErrorAndArray2(1), "OKK"));
-    try comptime expect(mem.eql(u8, try testPeerErrorAndArray2(1), "OKK"));
+    comptime assert(mem.eql(u8, try testPeerErrorAndArray2(1), "OKK"));
 }
 
 fn testPeerErrorAndArray(x: u8) anyerror![]const u8 {
@@ -1038,15 +1038,15 @@ test "peer type resolve string lit with sentinel-terminated mutable slice" {
     var array: [4:0]u8 = undefined;
     array[4] = 0; // TODO remove this when #4372 is solved
     const slice: [:0]u8 = array[0..4 :0];
-    try comptime expect(@TypeOf(slice, "hi") == [:0]const u8);
-    try comptime expect(@TypeOf("hi", slice) == [:0]const u8);
+    comptime assert(@TypeOf(slice, "hi") == [:0]const u8);
+    comptime assert(@TypeOf("hi", slice) == [:0]const u8);
 }
 
 test "peer type resolve array pointers, one of them const" {
     var array1: [4]u8 = undefined;
     const array2: [5]u8 = undefined;
-    try comptime expect(@TypeOf(&array1, &array2) == []const u8);
-    try comptime expect(@TypeOf(&array2, &array1) == []const u8);
+    comptime assert(@TypeOf(&array1, &array2) == []const u8);
+    comptime assert(@TypeOf(&array2, &array1) == []const u8);
 }
 
 test "peer type resolve array pointer and unknown pointer" {
@@ -1056,17 +1056,17 @@ test "peer type resolve array pointer and unknown pointer" {
     var ptr: [*]u8 = undefined;
     _ = .{ &const_ptr, &ptr };
 
-    try comptime expect(@TypeOf(&array, ptr) == [*]u8);
-    try comptime expect(@TypeOf(ptr, &array) == [*]u8);
+    comptime assert(@TypeOf(&array, ptr) == [*]u8);
+    comptime assert(@TypeOf(ptr, &array) == [*]u8);
 
-    try comptime expect(@TypeOf(&const_array, ptr) == [*]const u8);
-    try comptime expect(@TypeOf(ptr, &const_array) == [*]const u8);
+    comptime assert(@TypeOf(&const_array, ptr) == [*]const u8);
+    comptime assert(@TypeOf(ptr, &const_array) == [*]const u8);
 
-    try comptime expect(@TypeOf(&array, const_ptr) == [*]const u8);
-    try comptime expect(@TypeOf(const_ptr, &array) == [*]const u8);
+    comptime assert(@TypeOf(&array, const_ptr) == [*]const u8);
+    comptime assert(@TypeOf(const_ptr, &array) == [*]const u8);
 
-    try comptime expect(@TypeOf(&const_array, const_ptr) == [*]const u8);
-    try comptime expect(@TypeOf(const_ptr, &const_array) == [*]const u8);
+    comptime assert(@TypeOf(&const_array, const_ptr) == [*]const u8);
+    comptime assert(@TypeOf(const_ptr, &const_array) == [*]const u8);
 }
 
 test "comptime float casts" {
@@ -1214,7 +1214,7 @@ test "implicitly cast from [N]T to ?[]const T" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     try expect(mem.eql(u8, castToOptionalSlice().?, "hi"));
-    try comptime expect(mem.eql(u8, castToOptionalSlice().?, "hi"));
+    comptime assert(mem.eql(u8, castToOptionalSlice().?, "hi"));
 }
 
 fn castToOptionalSlice() ?[]const u8 {
@@ -1351,8 +1351,8 @@ test "peer resolve arrays of different size to const slice" {
 
     try expect(mem.eql(u8, boolToStr(true), "true"));
     try expect(mem.eql(u8, boolToStr(false), "false"));
-    try comptime expect(mem.eql(u8, boolToStr(true), "true"));
-    try comptime expect(mem.eql(u8, boolToStr(false), "false"));
+    comptime assert(mem.eql(u8, boolToStr(true), "true"));
+    comptime assert(mem.eql(u8, boolToStr(false), "false"));
 }
 fn boolToStr(b: bool) []const u8 {
     return if (b) "true" else "false";

--- a/test/behavior/enum.zig
+++ b/test/behavior/enum.zig
@@ -773,12 +773,12 @@ test "set enum tag type" {
     {
         var x = Small.One;
         x = Small.Two;
-        try comptime expect(Tag(Small) == u2);
+        comptime assert(Tag(Small) == u2);
     }
     {
         var x = Small2.One;
         x = Small2.Two;
-        try comptime expect(Tag(Small2) == u2);
+        comptime assert(Tag(Small2) == u2);
     }
 }
 
@@ -795,7 +795,7 @@ test "enum with 1 field but explicit tag type should still have the tag type" {
     const Enum = enum(u8) {
         B = 2,
     };
-    try comptime expect(@sizeOf(Enum) == @sizeOf(u8));
+    comptime assert(@sizeOf(Enum) == @sizeOf(u8));
 }
 
 test "signed integer as enum tag" {
@@ -834,12 +834,12 @@ test "enum with comptime_int tag type" {
         Two = 2,
         Three = 1,
     };
-    try comptime expect(Tag(Enum) == comptime_int);
+    comptime assert(Tag(Enum) == comptime_int);
 }
 
 test "enum with one member default to u0 tag type" {
     const E0 = enum { X };
-    try comptime expect(Tag(E0) == u0);
+    comptime assert(Tag(E0) == u0);
 }
 
 const EnumWithOneMember = enum { Eof };
@@ -989,7 +989,7 @@ test "@tagName" {
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try expect(mem.eql(u8, testEnumTagNameBare(BareNumber.Three), "Three"));
-    try comptime expect(mem.eql(u8, testEnumTagNameBare(BareNumber.Three), "Three"));
+    comptime assert(mem.eql(u8, testEnumTagNameBare(BareNumber.Three), "Three"));
 }
 
 fn testEnumTagNameBare(n: anytype) []const u8 {
@@ -1005,7 +1005,7 @@ test "@tagName non-exhaustive enum" {
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     try expect(mem.eql(u8, testEnumTagNameBare(NonExhaustive.B), "B"));
-    try comptime expect(mem.eql(u8, testEnumTagNameBare(NonExhaustive.B), "B"));
+    comptime assert(mem.eql(u8, testEnumTagNameBare(NonExhaustive.B), "B"));
 }
 const NonExhaustive = enum(u8) { A, B, _ };
 
@@ -1044,7 +1044,7 @@ test "@tagName on enum literals" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     try expect(mem.eql(u8, @tagName(.FooBar), "FooBar"));
-    try comptime expect(mem.eql(u8, @tagName(.FooBar), "FooBar"));
+    comptime assert(mem.eql(u8, @tagName(.FooBar), "FooBar"));
 }
 
 test "tag name with signed enum values" {
@@ -1101,7 +1101,7 @@ test "bit field access with enum fields" {
     try expect(getA(&data) == A.Two);
     try expect(getB(&data) == B.Three3);
     try expect(getC(&data) == C.Four4);
-    try comptime expect(@sizeOf(BitFieldOfEnums) == 1);
+    comptime assert(@sizeOf(BitFieldOfEnums) == 1);
 
     data.b = B.Four3;
     try expect(data.b == B.Four3);

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -1,5 +1,6 @@
 const builtin = @import("builtin");
 const std = @import("std");
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const mem = std.mem;
@@ -458,7 +459,7 @@ test "return function call to error set from error union function" {
         }
     };
     try expectError(error.Failure, S.errorable());
-    try comptime expectError(error.Failure, S.errorable());
+    comptime assert(error.Failure == S.errorable());
 }
 
 test "optional error set is the same size as error set" {
@@ -466,15 +467,15 @@ test "optional error set is the same size as error set" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
-    try comptime expect(@sizeOf(?anyerror) == @sizeOf(anyerror));
-    try comptime expect(@alignOf(?anyerror) == @alignOf(anyerror));
+    comptime assert(@sizeOf(?anyerror) == @sizeOf(anyerror));
+    comptime assert(@alignOf(?anyerror) == @alignOf(anyerror));
     const S = struct {
         fn returnsOptErrSet() ?anyerror {
             return null;
         }
     };
     try expect(S.returnsOptErrSet() == null);
-    try comptime expect(S.returnsOptErrSet() == null);
+    comptime assert(S.returnsOptErrSet() == null);
 }
 
 test "nested catch" {

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -55,7 +55,7 @@ fn staticAdd(a: i32, b: i32) i32 {
 
 test "const expr eval on single expr blocks" {
     try expect(constExprEvalOnSingleExprBlocksFn(1, true) == 3);
-    try comptime expect(constExprEvalOnSingleExprBlocksFn(1, true) == 3);
+    comptime assert(constExprEvalOnSingleExprBlocksFn(1, true) == 3);
 }
 
 fn constExprEvalOnSingleExprBlocksFn(x: i32, b: bool) i32 {
@@ -426,7 +426,7 @@ test "f64 at compile time is lossy" {
 }
 
 test {
-    try comptime expect(@as(f128, 1 << 113) == 10384593717069655257060992658440192);
+    comptime assert(@as(f128, 1 << 113) == 10384593717069655257060992658440192);
 }
 
 fn copyWithPartialInline(s: []u32, b: []u8) void {
@@ -613,7 +613,7 @@ test "const global shares pointer with other same one" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     try assertEqualPtrs(&hi1[0], &hi2[0]);
-    try comptime expect(&hi1[0] == &hi2[0]);
+    comptime assert(&hi1[0] == &hi2[0]);
 }
 fn assertEqualPtrs(ptr1: *const u8, ptr2: *const u8) !void {
     try expect(ptr1 == ptr2);
@@ -634,8 +634,8 @@ fn assertEqualPtrs(ptr1: *const u8, ptr2: *const u8) !void {
 test "string literal used as comptime slice is memoized" {
     const a = "link";
     const b = "link";
-    try comptime expect(TypeWithCompTimeSlice(a).Node == TypeWithCompTimeSlice(b).Node);
-    try comptime expect(TypeWithCompTimeSlice("link").Node == TypeWithCompTimeSlice("link").Node);
+    comptime assert(TypeWithCompTimeSlice(a).Node == TypeWithCompTimeSlice(b).Node);
+    comptime assert(TypeWithCompTimeSlice("link").Node == TypeWithCompTimeSlice("link").Node);
 }
 
 pub fn TypeWithCompTimeSlice(comptime field_name: []const u8) type {
@@ -953,7 +953,7 @@ test "const local with comptime init through array init" {
         S.declarations(E1),
     };
 
-    try comptime expect(decls[0][0].name[0] == 'a');
+    comptime assert(decls[0][0].name[0] == 'a');
 }
 
 test "closure capture type of runtime-known parameter" {
@@ -1339,7 +1339,7 @@ test "value in if block is comptime-known" {
         const s = if (false) S{ .str = "a" } else S{ .str = "b" };
         break :blk "foo" ++ s.str;
     };
-    try comptime expect(std.mem.eql(u8, first, second));
+    comptime assert(std.mem.eql(u8, first, second));
 }
 
 test "lazy sizeof is resolved in division" {
@@ -1561,7 +1561,7 @@ test "comptime function turns function value to function pointer" {
             fnPtr(Nil),
         };
     };
-    try comptime expect(S.foo[0] == &S.Nil);
+    comptime assert(S.foo[0] == &S.Nil);
 }
 
 test "container level const and var have unique addresses" {

--- a/test/behavior/fn.zig
+++ b/test/behavior/fn.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const testing = std.testing;
+const assert = std.debug.assert;
 const expect = testing.expect;
 const expectEqual = testing.expectEqual;
 
@@ -207,7 +208,7 @@ test "pass by non-copying value through var arg" {
 }
 
 fn addPointCoordsVar(pt: anytype) !i32 {
-    try comptime expect(@TypeOf(pt) == Point);
+    comptime assert(@TypeOf(pt) == Point);
     return pt.x + pt.y;
 }
 

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -1,5 +1,6 @@
 const builtin = @import("builtin");
 const std = @import("std");
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const expectEqualSlices = std.testing.expectEqualSlices;
@@ -246,7 +247,7 @@ fn testFloatEqualityImpl(x: f64, y: f64) !void {
 }
 
 test "hex float literal parsing" {
-    try comptime expect(0x1.0 == 1.0);
+    comptime assert(0x1.0 == 1.0);
 }
 
 test "hex float literal within range" {
@@ -1530,7 +1531,7 @@ test "@round f32/f64" {
     const x = 14.0;
     const y = x + 0.4;
     const z = @round(y);
-    try comptime expect(x == z);
+    comptime assert(x == z);
 }
 
 test "@round f80" {

--- a/test/behavior/optional.zig
+++ b/test/behavior/optional.zig
@@ -1,6 +1,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 const testing = std.testing;
+const assert = std.debug.assert;
 const expect = testing.expect;
 const expectEqual = testing.expectEqual;
 const expectEqualStrings = std.testing.expectEqualStrings;
@@ -20,7 +21,7 @@ test "passing an optional integer as a parameter" {
         }
     };
     try expect(S.entry());
-    try comptime expect(S.entry());
+    comptime assert(S.entry());
 }
 
 pub const EmptyStruct = struct {};

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -1,6 +1,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 const testing = std.testing;
+const assert = std.debug.assert;
 const expect = testing.expect;
 const expectError = testing.expectError;
 
@@ -42,7 +43,7 @@ test "pointer arithmetic" {
 }
 
 test "double pointer parsing" {
-    try comptime expect(PtrOf(PtrOf(i32)) == **i32);
+    comptime assert(PtrOf(PtrOf(i32)) == **i32);
 }
 
 fn PtrOf(comptime T: type) type {
@@ -62,7 +63,7 @@ test "implicit cast single item pointer to C pointer and back" {
 test "initialize const optional C pointer to null" {
     const a: ?[*c]i32 = null;
     try expect(a == null);
-    try comptime expect(a == null);
+    comptime assert(a == null);
 }
 
 test "assigning integer to C pointer" {
@@ -204,11 +205,11 @@ test "allowzero pointer and slice" {
     var runtime_zero: usize = 0;
     _ = &runtime_zero;
     var slice = ptr[runtime_zero..10];
-    try comptime expect(@TypeOf(slice) == []allowzero i32);
+    comptime assert(@TypeOf(slice) == []allowzero i32);
     try expect(@intFromPtr(&slice[5]) == 20);
 
-    try comptime expect(@typeInfo(@TypeOf(ptr)).Pointer.is_allowzero);
-    try comptime expect(@typeInfo(@TypeOf(slice)).Pointer.is_allowzero);
+    comptime assert(@typeInfo(@TypeOf(ptr)).Pointer.is_allowzero);
+    comptime assert(@typeInfo(@TypeOf(slice)).Pointer.is_allowzero);
 }
 
 test "assign null directly to C pointer and test null equality" {
@@ -230,17 +231,17 @@ test "assign null directly to C pointer and test null equality" {
     try expect((x orelse &otherx) == &otherx);
 
     const y: [*c]i32 = null;
-    try comptime expect(y == null);
-    try comptime expect(null == y);
-    try comptime expect(!(y != null));
-    try comptime expect(!(null != y));
+    comptime assert(y == null);
+    comptime assert(null == y);
+    comptime assert(!(y != null));
+    comptime assert(!(null != y));
     if (y) |same_y| {
         _ = same_y;
         @panic("fail");
     }
     const othery: i32 = undefined;
     const ptr_othery = &othery;
-    try comptime expect((y orelse ptr_othery) == ptr_othery);
+    comptime assert((y orelse ptr_othery) == ptr_othery);
 
     var n: i32 = 1234;
     const x1: [*c]i32 = &n;
@@ -258,17 +259,17 @@ test "assign null directly to C pointer and test null equality" {
 
     const nc: i32 = 1234;
     const y1: [*c]const i32 = &nc;
-    try comptime expect(!(y1 == null));
-    try comptime expect(!(null == y1));
-    try comptime expect(y1 != null);
-    try comptime expect(null != y1);
-    try comptime expect(y1.?.* == 1234);
+    comptime assert(!(y1 == null));
+    comptime assert(!(null == y1));
+    comptime assert(y1 != null);
+    comptime assert(null != y1);
+    comptime assert(y1.?.* == 1234);
     if (y1) |same_y1| {
         try expect(same_y1.* == 1234);
     } else {
         @compileError("fail");
     }
-    try comptime expect((y1 orelse &othery) == y1);
+    comptime assert((y1 orelse &othery) == y1);
 }
 
 test "array initialization types" {
@@ -325,7 +326,7 @@ test "pointer sentinel with enums" {
         fn doTheTest() !void {
             var ptr: [*:.sentinel]const Number = &[_:.sentinel]Number{ .one, .two, .two, .one };
             _ = &ptr;
-            try expect(ptr[4] == .sentinel); // TODO this should be try comptime expect, see #3731
+            try expect(ptr[4] == .sentinel); // TODO this should be comptime assert, see #3731
         }
     };
     try S.doTheTest();
@@ -341,7 +342,7 @@ test "pointer sentinel with optional element" {
         fn doTheTest() !void {
             var ptr: [*:null]const ?i32 = &[_:null]?i32{ 1, 2, 3, 4 };
             _ = &ptr;
-            try expect(ptr[4] == null); // TODO this should be try comptime expect, see #3731
+            try expect(ptr[4] == null); // TODO this should be comptime assert, see #3731
         }
     };
     try S.doTheTest();
@@ -358,7 +359,7 @@ test "pointer sentinel with +inf" {
             const inf_f32 = comptime std.math.inf(f32);
             var ptr: [*:inf_f32]const f32 = &[_:inf_f32]f32{ 1.1, 2.2, 3.3, 4.4 };
             _ = &ptr;
-            try expect(ptr[4] == inf_f32); // TODO this should be try comptime expect, see #3731
+            try expect(ptr[4] == inf_f32); // TODO this should be comptime assert, see #3731
         }
     };
     try S.doTheTest();
@@ -409,11 +410,11 @@ test "@intFromPtr on null optional at comptime" {
         const pointer = @as(?*u8, @ptrFromInt(0x000));
         const x = @intFromPtr(pointer);
         _ = x;
-        try comptime expect(0 == @intFromPtr(pointer));
+        comptime assert(0 == @intFromPtr(pointer));
     }
     {
         const pointer = @as(?*u8, @ptrFromInt(0xf00));
-        try comptime expect(0xf00 == @intFromPtr(pointer));
+        comptime assert(0xf00 == @intFromPtr(pointer));
     }
 }
 

--- a/test/behavior/sizeof_and_typeof.zig
+++ b/test/behavior/sizeof_and_typeof.zig
@@ -1,5 +1,6 @@
 const builtin = @import("builtin");
 const std = @import("std");
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 
@@ -23,24 +24,24 @@ test "@TypeOf() with multiple arguments" {
         var var_2: u8 = undefined;
         var var_3: u64 = undefined;
         _ = .{ &var_1, &var_2, &var_3 };
-        try comptime expect(@TypeOf(var_1, var_2, var_3) == u64);
+        comptime assert(@TypeOf(var_1, var_2, var_3) == u64);
     }
     {
         var var_1: f16 = undefined;
         var var_2: f32 = undefined;
         var var_3: f64 = undefined;
         _ = .{ &var_1, &var_2, &var_3 };
-        try comptime expect(@TypeOf(var_1, var_2, var_3) == f64);
+        comptime assert(@TypeOf(var_1, var_2, var_3) == f64);
     }
     {
         var var_1: u16 = undefined;
         _ = &var_1;
-        try comptime expect(@TypeOf(var_1, 0xffff) == u16);
+        comptime assert(@TypeOf(var_1, 0xffff) == u16);
     }
     {
         var var_1: f32 = undefined;
         _ = &var_1;
-        try comptime expect(@TypeOf(var_1, 3.1415) == f32);
+        comptime assert(@TypeOf(var_1, 3.1415) == f32);
     }
 }
 
@@ -150,7 +151,7 @@ test "@TypeOf() has no runtime side effects" {
     };
     var data: i32 = 0;
     const T = @TypeOf(S.foo(i32, &data));
-    try comptime expect(T == i32);
+    comptime assert(T == i32);
     try expect(data == 0);
 }
 
@@ -165,7 +166,7 @@ test "branching logic inside @TypeOf" {
         }
     };
     const T = @TypeOf(S.foo() catch undefined);
-    try comptime expect(T == i32);
+    comptime assert(T == i32);
     try expect(S.data == 0);
 }
 
@@ -238,7 +239,7 @@ test "hardcoded address in typeof expression" {
         }
     };
     try expect(S.func() == 0);
-    try comptime expect(S.func() == 0);
+    comptime assert(S.func() == 0);
 }
 
 test "array access of generic param in typeof expression" {
@@ -248,7 +249,7 @@ test "array access of generic param in typeof expression" {
         }
     };
     try expect(S.first("a") == 'a');
-    try comptime expect(S.first("a") == 'a');
+    comptime assert(S.first("a") == 'a');
 }
 
 test "lazy size cast to float" {

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -376,9 +376,8 @@ test "slice multi-pointer without end" {
             var array = [5:0]u8{ 1, 2, 3, 4, 5 };
             const pointer: [*:0]u8 = &array;
 
-            comptime assert(@TypeOf(pointer[1..3]) == *[2]u8);
-            comptime assert(@TypeOf(pointer[1..3 :4]) == *[2:4]u8);
-            comptime assert(@TypeOf(pointer[1..5 :0]) == *[4:0]u8);
+            comptime assert(@TypeOf(pointer[1..]) == [*:0]u8);
+            comptime assert(@TypeOf(pointer[1.. :0]) == [*:0]u8);
 
             const slice = pointer[1..];
             comptime assert(@TypeOf(slice) == [*:0]u8);

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -1,5 +1,6 @@
 const builtin = @import("builtin");
 const std = @import("std");
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqualSlices = std.testing.expectEqualSlices;
 const expectEqualStrings = std.testing.expectEqualStrings;
@@ -137,7 +138,7 @@ test "slice of hardcoded address to pointer" {
     const S = struct {
         fn doTheTest() !void {
             const pointer = @as([*]u8, @ptrFromInt(0x04))[0..2];
-            try comptime expect(@TypeOf(pointer) == *[2]u8);
+            comptime assert(@TypeOf(pointer) == *[2]u8);
             const slice: []const u8 = pointer;
             try expect(@intFromPtr(slice.ptr) == 4);
             try expect(slice.len == 2);
@@ -210,9 +211,9 @@ test "slice string literal has correct type" {
     }
     var runtime_zero: usize = 0;
     _ = &runtime_zero;
-    try comptime expect(@TypeOf("aoeu"[runtime_zero..]) == [:0]const u8);
+    comptime assert(@TypeOf("aoeu"[runtime_zero..]) == [:0]const u8);
     const array = [_]i32{ 1, 2, 3, 4 };
-    try comptime expect(@TypeOf(array[runtime_zero..]) == []const i32);
+    comptime assert(@TypeOf(array[runtime_zero..]) == []const i32);
 }
 
 test "result location zero sized array inside struct field implicit cast to slice" {
@@ -260,8 +261,8 @@ test "C pointer slice access" {
 
     var runtime_zero: usize = 0;
     _ = &runtime_zero;
-    try comptime expectEqual([]const u32, @TypeOf(c_ptr[runtime_zero..1]));
-    try comptime expectEqual(*const [1]u32, @TypeOf(c_ptr[0..1]));
+    comptime assert(@TypeOf(c_ptr[runtime_zero..1]) == []const u32);
+    comptime assert(@TypeOf(c_ptr[0..1]) == *const [1]u32);
 
     for (c_ptr[0..5]) |*cl| {
         try expect(@as(u32, 42) == cl.*);
@@ -314,11 +315,11 @@ test "obtaining a null terminated slice" {
     _ = &runtime_len;
     const ptr2 = buf[0..runtime_len :0];
     // ptr2 is a null-terminated slice
-    try comptime expect(@TypeOf(ptr2) == [:0]u8);
-    try comptime expect(@TypeOf(ptr2[0..2]) == *[2]u8);
+    comptime assert(@TypeOf(ptr2) == [:0]u8);
+    comptime assert(@TypeOf(ptr2[0..2]) == *[2]u8);
     var runtime_zero: usize = 0;
     _ = &runtime_zero;
-    try comptime expect(@TypeOf(ptr2[runtime_zero..2]) == []u8);
+    comptime assert(@TypeOf(ptr2[runtime_zero..2]) == []u8);
 }
 
 test "empty array to slice" {
@@ -366,7 +367,7 @@ test "slice multi-pointer without end" {
             var array = [5]u8{ 1, 2, 3, 4, 5 };
             const pointer: [*]u8 = &array;
             const slice = pointer[1..];
-            try comptime expect(@TypeOf(slice) == [*]u8);
+            comptime assert(@TypeOf(slice) == [*]u8);
             try expect(slice[0] == 2);
             try expect(slice[1] == 3);
         }
@@ -375,12 +376,12 @@ test "slice multi-pointer without end" {
             var array = [5:0]u8{ 1, 2, 3, 4, 5 };
             const pointer: [*:0]u8 = &array;
 
-            try comptime expect(@TypeOf(pointer[1..3]) == *[2]u8);
-            try comptime expect(@TypeOf(pointer[1..3 :4]) == *[2:4]u8);
-            try comptime expect(@TypeOf(pointer[1..5 :0]) == *[4:0]u8);
+            comptime assert(@TypeOf(pointer[1..3]) == *[2]u8);
+            comptime assert(@TypeOf(pointer[1..3 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(pointer[1..5 :0]) == *[4:0]u8);
 
             const slice = pointer[1..];
-            try comptime expect(@TypeOf(slice) == [*:0]u8);
+            comptime assert(@TypeOf(slice) == [*:0]u8);
             try expect(slice[0] == 2);
             try expect(slice[1] == 3);
         }
@@ -422,29 +423,29 @@ test "slice syntax resulting in pointer-to-array" {
         fn testArray() !void {
             var array = [5]u8{ 1, 2, 3, 4, 5 };
             const slice = array[1..3];
-            try comptime expect(@TypeOf(slice) == *[2]u8);
+            comptime assert(@TypeOf(slice) == *[2]u8);
             try expect(slice[0] == 2);
             try expect(slice[1] == 3);
         }
 
         fn testArrayZ() !void {
             var array = [5:0]u8{ 1, 2, 3, 4, 5 };
-            try comptime expect(@TypeOf(array[1..3]) == *[2]u8);
-            try comptime expect(@TypeOf(array[1..5]) == *[4:0]u8);
-            try comptime expect(@TypeOf(array[1..]) == *[4:0]u8);
-            try comptime expect(@TypeOf(array[1..3 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(array[1..3]) == *[2]u8);
+            comptime assert(@TypeOf(array[1..5]) == *[4:0]u8);
+            comptime assert(@TypeOf(array[1..]) == *[4:0]u8);
+            comptime assert(@TypeOf(array[1..3 :4]) == *[2:4]u8);
         }
 
         fn testArray0() !void {
             {
                 var array = [0]u8{};
                 const slice = array[0..0];
-                try comptime expect(@TypeOf(slice) == *[0]u8);
+                comptime assert(@TypeOf(slice) == *[0]u8);
             }
             {
                 var array = [0:0]u8{};
                 const slice = array[0..0];
-                try comptime expect(@TypeOf(slice) == *[0:0]u8);
+                comptime assert(@TypeOf(slice) == *[0:0]u8);
                 try expect(slice[0] == 0);
             }
         }
@@ -452,16 +453,16 @@ test "slice syntax resulting in pointer-to-array" {
         fn testArrayAlign() !void {
             var array align(4) = [5]u8{ 1, 2, 3, 4, 5 };
             const slice = array[4..5];
-            try comptime expect(@TypeOf(slice) == *align(4) [1]u8);
+            comptime assert(@TypeOf(slice) == *align(4) [1]u8);
             try expect(slice[0] == 5);
-            try comptime expect(@TypeOf(array[0..2]) == *align(4) [2]u8);
+            comptime assert(@TypeOf(array[0..2]) == *align(4) [2]u8);
         }
 
         fn testPointer() !void {
             var array = [5]u8{ 1, 2, 3, 4, 5 };
             var pointer: [*]u8 = &array;
             const slice = pointer[1..3];
-            try comptime expect(@TypeOf(slice) == *[2]u8);
+            comptime assert(@TypeOf(slice) == *[2]u8);
             try expect(slice[0] == 2);
             try expect(slice[1] == 3);
         }
@@ -469,14 +470,14 @@ test "slice syntax resulting in pointer-to-array" {
         fn testPointerZ() !void {
             var array = [5:0]u8{ 1, 2, 3, 4, 5 };
             var pointer: [*:0]u8 = &array;
-            try comptime expect(@TypeOf(pointer[1..3]) == *[2]u8);
-            try comptime expect(@TypeOf(pointer[1..3 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(pointer[1..3]) == *[2]u8);
+            comptime assert(@TypeOf(pointer[1..3 :4]) == *[2:4]u8);
         }
 
         fn testPointer0() !void {
             var pointer: [*]const u0 = &[1]u0{0};
             const slice = pointer[0..1];
-            try comptime expect(@TypeOf(slice) == *const [1]u0);
+            comptime assert(@TypeOf(slice) == *const [1]u0);
             try expect(slice[0] == 0);
         }
 
@@ -484,16 +485,16 @@ test "slice syntax resulting in pointer-to-array" {
             var array align(4) = [5]u8{ 1, 2, 3, 4, 5 };
             var pointer: [*]align(4) u8 = &array;
             const slice = pointer[4..5];
-            try comptime expect(@TypeOf(slice) == *align(4) [1]u8);
+            comptime assert(@TypeOf(slice) == *align(4) [1]u8);
             try expect(slice[0] == 5);
-            try comptime expect(@TypeOf(pointer[0..2]) == *align(4) [2]u8);
+            comptime assert(@TypeOf(pointer[0..2]) == *align(4) [2]u8);
         }
 
         fn testSlice() !void {
             var array = [5]u8{ 1, 2, 3, 4, 5 };
             var src_slice: []u8 = &array;
             const slice = src_slice[1..3];
-            try comptime expect(@TypeOf(slice) == *[2]u8);
+            comptime assert(@TypeOf(slice) == *[2]u8);
             try expect(slice[0] == 2);
             try expect(slice[1] == 3);
         }
@@ -501,30 +502,30 @@ test "slice syntax resulting in pointer-to-array" {
         fn testSliceZ() !void {
             var array = [5:0]u8{ 1, 2, 3, 4, 5 };
             var slice: [:0]u8 = &array;
-            try comptime expect(@TypeOf(slice[1..3]) == *[2]u8);
-            try comptime expect(@TypeOf(slice[1..3 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(slice[1..3]) == *[2]u8);
+            comptime assert(@TypeOf(slice[1..3 :4]) == *[2:4]u8);
             if (@inComptime()) {
-                try comptime expect(@TypeOf(slice[1..]) == *[4:0]u8);
+                comptime assert(@TypeOf(slice[1..]) == *[4:0]u8);
             } else {
-                try comptime expect(@TypeOf(slice[1..]) == [:0]u8);
+                comptime assert(@TypeOf(slice[1..]) == [:0]u8);
             }
         }
 
         fn testSliceOpt() !void {
             var array: [2]u8 = [2]u8{ 1, 2 };
             var slice: ?[]u8 = &array;
-            try comptime expect(@TypeOf(&array, slice) == ?[]u8);
-            try comptime expect(@TypeOf(slice, &array) == ?[]u8);
-            try comptime expect(@TypeOf(slice.?[0..2]) == *[2]u8);
+            comptime assert(@TypeOf(&array, slice) == ?[]u8);
+            comptime assert(@TypeOf(slice, &array) == ?[]u8);
+            comptime assert(@TypeOf(slice.?[0..2]) == *[2]u8);
         }
 
         fn testSliceAlign() !void {
             var array align(4) = [5]u8{ 1, 2, 3, 4, 5 };
             var src_slice: []align(4) u8 = &array;
             const slice = src_slice[4..5];
-            try comptime expect(@TypeOf(slice) == *align(4) [1]u8);
+            comptime assert(@TypeOf(slice) == *align(4) [1]u8);
             try expect(slice[0] == 5);
-            try comptime expect(@TypeOf(src_slice[0..2]) == *align(4) [2]u8);
+            comptime assert(@TypeOf(src_slice[0..2]) == *align(4) [2]u8);
         }
 
         fn testConcatStrLiterals() !void {
@@ -535,62 +536,62 @@ test "slice syntax resulting in pointer-to-array" {
         fn testSliceLength() !void {
             var array = [5]u8{ 1, 2, 3, 4, 5 };
             var slice: []u8 = &array;
-            try comptime expect(@TypeOf(slice[1..][0..2]) == *[2]u8);
-            try comptime expect(@TypeOf(slice[1..][0..4]) == *[4]u8);
-            try comptime expect(@TypeOf(slice[1..][0..2 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(slice[1..][0..2]) == *[2]u8);
+            comptime assert(@TypeOf(slice[1..][0..4]) == *[4]u8);
+            comptime assert(@TypeOf(slice[1..][0..2 :4]) == *[2:4]u8);
         }
 
         fn testSliceLengthZ() !void {
             var array = [5:0]u8{ 1, 2, 3, 4, 5 };
             var slice: [:0]u8 = &array;
-            try comptime expect(@TypeOf(slice[1..][0..2]) == *[2]u8);
-            try comptime expect(@TypeOf(slice[1..][0..2 :4]) == *[2:4]u8);
-            try comptime expect(@TypeOf(slice[1.. :0][0..2]) == *[2]u8);
-            try comptime expect(@TypeOf(slice[1.. :0][0..2 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(slice[1..][0..2]) == *[2]u8);
+            comptime assert(@TypeOf(slice[1..][0..2 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(slice[1.. :0][0..2]) == *[2]u8);
+            comptime assert(@TypeOf(slice[1.. :0][0..2 :4]) == *[2:4]u8);
         }
 
         fn testArrayLength() !void {
             var array = [5]u8{ 1, 2, 3, 4, 5 };
-            try comptime expect(@TypeOf(array[1..][0..2]) == *[2]u8);
-            try comptime expect(@TypeOf(array[1..][0..4]) == *[4]u8);
-            try comptime expect(@TypeOf(array[1..][0..2 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(array[1..][0..2]) == *[2]u8);
+            comptime assert(@TypeOf(array[1..][0..4]) == *[4]u8);
+            comptime assert(@TypeOf(array[1..][0..2 :4]) == *[2:4]u8);
         }
 
         fn testArrayLengthZ() !void {
             var array = [5:0]u8{ 1, 2, 3, 4, 5 };
-            try comptime expect(@TypeOf(array[1..][0..2]) == *[2]u8);
-            try comptime expect(@TypeOf(array[1..][0..4]) == *[4:0]u8);
-            try comptime expect(@TypeOf(array[1..][0..2 :4]) == *[2:4]u8);
-            try comptime expect(@TypeOf(array[1.. :0][0..2]) == *[2]u8);
-            try comptime expect(@TypeOf(array[1.. :0][0..4]) == *[4:0]u8);
-            try comptime expect(@TypeOf(array[1.. :0][0..2 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(array[1..][0..2]) == *[2]u8);
+            comptime assert(@TypeOf(array[1..][0..4]) == *[4:0]u8);
+            comptime assert(@TypeOf(array[1..][0..2 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(array[1.. :0][0..2]) == *[2]u8);
+            comptime assert(@TypeOf(array[1.. :0][0..4]) == *[4:0]u8);
+            comptime assert(@TypeOf(array[1.. :0][0..2 :4]) == *[2:4]u8);
         }
 
         fn testMultiPointer() !void {
             var array = [5]u8{ 1, 2, 3, 4, 5 };
             var ptr: [*]u8 = &array;
-            try comptime expect(@TypeOf(ptr[1..][0..2]) == *[2]u8);
-            try comptime expect(@TypeOf(ptr[1..][0..4]) == *[4]u8);
-            try comptime expect(@TypeOf(ptr[1..][0..2 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(ptr[1..][0..2]) == *[2]u8);
+            comptime assert(@TypeOf(ptr[1..][0..4]) == *[4]u8);
+            comptime assert(@TypeOf(ptr[1..][0..2 :4]) == *[2:4]u8);
         }
 
         fn testMultiPointerLengthZ() !void {
             var array = [5:0]u8{ 1, 2, 3, 4, 5 };
             var ptr: [*]u8 = &array;
-            try comptime expect(@TypeOf(ptr[1..][0..2]) == *[2]u8);
-            try comptime expect(@TypeOf(ptr[1..][0..4]) == *[4]u8);
-            try comptime expect(@TypeOf(ptr[1..][0..2 :4]) == *[2:4]u8);
-            try comptime expect(@TypeOf(ptr[1.. :0][0..2]) == *[2]u8);
-            try comptime expect(@TypeOf(ptr[1.. :0][0..4]) == *[4]u8);
-            try comptime expect(@TypeOf(ptr[1.. :0][0..2 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(ptr[1..][0..2]) == *[2]u8);
+            comptime assert(@TypeOf(ptr[1..][0..4]) == *[4]u8);
+            comptime assert(@TypeOf(ptr[1..][0..2 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(ptr[1.. :0][0..2]) == *[2]u8);
+            comptime assert(@TypeOf(ptr[1.. :0][0..4]) == *[4]u8);
+            comptime assert(@TypeOf(ptr[1.. :0][0..2 :4]) == *[2:4]u8);
 
             var ptr_z: [*:0]u8 = &array;
-            try comptime expect(@TypeOf(ptr_z[1..][0..2]) == *[2]u8);
-            try comptime expect(@TypeOf(ptr_z[1..][0..4]) == *[4]u8);
-            try comptime expect(@TypeOf(ptr_z[1..][0..2 :4]) == *[2:4]u8);
-            try comptime expect(@TypeOf(ptr_z[1.. :0][0..2]) == *[2]u8);
-            try comptime expect(@TypeOf(ptr_z[1.. :0][0..4]) == *[4]u8);
-            try comptime expect(@TypeOf(ptr_z[1.. :0][0..2 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(ptr_z[1..][0..2]) == *[2]u8);
+            comptime assert(@TypeOf(ptr_z[1..][0..4]) == *[4]u8);
+            comptime assert(@TypeOf(ptr_z[1..][0..2 :4]) == *[2:4]u8);
+            comptime assert(@TypeOf(ptr_z[1.. :0][0..2]) == *[2]u8);
+            comptime assert(@TypeOf(ptr_z[1.. :0][0..4]) == *[4]u8);
+            comptime assert(@TypeOf(ptr_z[1.. :0][0..2 :4]) == *[2:4]u8);
         }
 
         fn testSingleItemPointer() !void {
@@ -598,10 +599,10 @@ test "slice syntax resulting in pointer-to-array" {
             var ptr = &value;
 
             const slice = ptr[0..1];
-            try comptime expect(@TypeOf(slice) == *[1]u8);
+            comptime assert(@TypeOf(slice) == *[1]u8);
             try expect(slice[0] == 1);
 
-            try comptime expect(@TypeOf(ptr[0..0]) == *[0]u8);
+            comptime assert(@TypeOf(ptr[0..0]) == *[0]u8);
         }
     };
 
@@ -623,9 +624,9 @@ test "slice pointer-to-array null terminated" {
 
     var array = [5:0]u8{ 1, 2, 3, 4, 5 };
     var slice: [:0]u8 = &array;
-    try comptime expect(@TypeOf(slice[1..3]) == *[2]u8);
-    try comptime expect(@TypeOf(slice[1..3 :4]) == *[2:4]u8);
-    try comptime expect(@TypeOf(slice[1..]) == [:0]u8);
+    comptime assert(@TypeOf(slice[1..3]) == *[2]u8);
+    comptime assert(@TypeOf(slice[1..3 :4]) == *[2:4]u8);
+    comptime assert(@TypeOf(slice[1..]) == [:0]u8);
 }
 
 test "slice pointer-to-array zero length" {
@@ -650,13 +651,13 @@ test "slice pointer-to-array zero length" {
         var array = [0]u8{};
         var src_slice: []u8 = &array;
         const slice = src_slice[0..0];
-        try comptime expect(@TypeOf(slice) == *[0]u8);
+        comptime assert(@TypeOf(slice) == *[0]u8);
     }
     {
         var array = [0:0]u8{};
         var src_slice: [:0]u8 = &array;
         const slice = src_slice[0..0];
-        try comptime expect(@TypeOf(slice) == *[0]u8);
+        comptime assert(@TypeOf(slice) == *[0]u8);
     }
 }
 

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -591,7 +591,7 @@ test "bit field access" {
     try expect(getA(&data) == 1);
     try expect(getB(&data) == 2);
     try expect(getC(&data) == 3);
-    try comptime expect(@sizeOf(BitField1) == 1);
+    comptime assert(@sizeOf(BitField1) == 1);
 
     data.b += 1;
     try expect(data.b == 3);
@@ -730,7 +730,7 @@ test "packed struct with u0 field access" {
     };
     var s = S{ .f0 = 0 };
     _ = &s;
-    try comptime expect(s.f0 == 0);
+    comptime assert(s.f0 == 0);
 }
 
 test "access to global struct fields" {
@@ -947,7 +947,7 @@ test "comptime struct field" {
 
     var foo: T = undefined;
     _ = &foo;
-    try comptime expect(foo.b == 1234);
+    comptime assert(foo.b == 1234);
 }
 
 test "tuple element initialized with fn call" {

--- a/test/behavior/switch.zig
+++ b/test/behavior/switch.zig
@@ -600,9 +600,9 @@ test "switch on pointer type" {
     try expect(1 == S.doTheTest(S.P1));
     try expect(2 == S.doTheTest(S.P2));
     try expect(3 == S.doTheTest(S.P3));
-    try comptime expect(1 == S.doTheTest(S.P1));
-    try comptime expect(2 == S.doTheTest(S.P2));
-    try comptime expect(3 == S.doTheTest(S.P3));
+    comptime assert(1 == S.doTheTest(S.P1));
+    comptime assert(2 == S.doTheTest(S.P2));
+    comptime assert(3 == S.doTheTest(S.P3));
 }
 
 test "switch on error set with single else" {

--- a/test/behavior/truncate.zig
+++ b/test/behavior/truncate.zig
@@ -1,12 +1,13 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 
 test "truncate u0 to larger integer allowed and has comptime-known result" {
     var x: u0 = 0;
     _ = &x;
     const y = @as(u8, @truncate(x));
-    try comptime expect(y == 0);
+    comptime assert(y == 0);
 }
 
 test "truncate.u0.literal" {
@@ -31,7 +32,7 @@ test "truncate i0 to larger integer allowed and has comptime-known result" {
     var x: i0 = 0;
     _ = &x;
     const y: i8 = @truncate(x);
-    try comptime expect(y == 0);
+    comptime assert(y == 0);
 }
 
 test "truncate.i0.literal" {

--- a/test/behavior/type_info.zig
+++ b/test/behavior/type_info.zig
@@ -5,6 +5,7 @@ const mem = std.mem;
 const Type = std.builtin.Type;
 const TypeId = std.builtin.TypeId;
 
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqualStrings = std.testing.expectEqualStrings;
 
@@ -484,7 +485,7 @@ test "@typeInfo does not force declarations into existence" {
             @compileError("test failed");
         }
     };
-    try comptime expect(@typeInfo(S).Struct.fields.len == 1);
+    comptime assert(@typeInfo(S).Struct.fields.len == 1);
 }
 
 fn add(a: i32, b: i32) i32 {

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -109,7 +109,7 @@ const ExternPtrOrInt = extern union {
     int: u64,
 };
 test "extern union size" {
-    try comptime expect(@sizeOf(ExternPtrOrInt) == 8);
+    comptime assert(@sizeOf(ExternPtrOrInt) == 8);
 }
 
 test "0-sized extern union definition" {
@@ -161,7 +161,7 @@ test "access a member of tagged union with conflicting enum tag name" {
         const B = void;
     };
 
-    try comptime expect(Bar.A == u8);
+    comptime assert(Bar.A == u8);
 }
 
 test "constant tagged union with payload" {
@@ -371,14 +371,14 @@ const PackedPtrOrInt = packed union {
     int: u64,
 };
 test "packed union size" {
-    try comptime expect(@sizeOf(PackedPtrOrInt) == 8);
+    comptime assert(@sizeOf(PackedPtrOrInt) == 8);
 }
 
 const ZeroBits = union {
     OnlyField: void,
 };
 test "union with only 1 field which is void should be zero bits" {
-    try comptime expect(@sizeOf(ZeroBits) == 0);
+    comptime assert(@sizeOf(ZeroBits) == 0);
 }
 
 test "tagged union initialization with runtime void" {
@@ -428,7 +428,7 @@ test "union with only 1 field casted to its enum type" {
     var e = Expr{ .Literal = Literal{ .Bool = true } };
     _ = &e;
     const ExprTag = Tag(Expr);
-    try comptime expect(Tag(ExprTag) == u0);
+    comptime assert(Tag(ExprTag) == u0);
     var t = @as(ExprTag, e);
     _ = &t;
     try expect(t == Expr.Literal);
@@ -438,7 +438,7 @@ test "union with one member defaults to u0 tag type" {
     const U0 = union(enum) {
         X: u32,
     };
-    try comptime expect(Tag(Tag(U0)) == u0);
+    comptime assert(Tag(Tag(U0)) == u0);
 }
 
 const Foo1 = union(enum) {
@@ -629,7 +629,7 @@ test "union(enum(u32)) with specified and unspecified tag values" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
-    try comptime expect(Tag(Tag(MultipleChoice2)) == u32);
+    comptime assert(Tag(Tag(MultipleChoice2)) == u32);
     try testEnumWithSpecifiedAndUnspecifiedTagValues(MultipleChoice2{ .C = 123 });
     try comptime testEnumWithSpecifiedAndUnspecifiedTagValues(MultipleChoice2{ .C = 123 });
 }
@@ -709,11 +709,11 @@ test "union with only 1 field casted to its enum type which has enum value speci
 
     var e = Expr{ .Literal = Literal{ .Bool = true } };
     _ = &e;
-    try comptime expect(Tag(ExprTag) == comptime_int);
+    comptime assert(Tag(ExprTag) == comptime_int);
     const t = comptime @as(ExprTag, e);
     try expect(t == Expr.Literal);
     try expect(@intFromEnum(t) == 33);
-    try comptime expect(@intFromEnum(t) == 33);
+    comptime assert(@intFromEnum(t) == 33);
 }
 
 test "@intFromEnum works on unions" {
@@ -894,7 +894,7 @@ test "union with comptime_int tag" {
         Y: u16,
         Z: u8,
     };
-    try comptime expect(Tag(Tag(Union)) == comptime_int);
+    comptime assert(Tag(Tag(Union)) == comptime_int);
 }
 
 test "extern union doesn't trigger field check at comptime" {
@@ -904,7 +904,7 @@ test "extern union doesn't trigger field check at comptime" {
     };
 
     const x = U{ .x = 0x55AAAA55 };
-    try comptime expect(x.y == 0x55);
+    comptime assert(x.y == 0x55);
 }
 
 test "anonymous union literal syntax" {

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -904,9 +904,9 @@ test "vector @reduce comptime" {
     const value = V{ 1, -1, 1, -1 };
     const result = value > @as(V, @splat(0));
     // result is { true, false, true, false };
-    try comptime expect(@TypeOf(result) == @Vector(4, bool));
+    comptime assert(@TypeOf(result) == @Vector(4, bool));
     const is_all_true = @reduce(.And, result);
-    try comptime expect(@TypeOf(is_all_true) == bool);
+    comptime assert(@TypeOf(is_all_true) == bool);
     try expect(is_all_true == false);
 }
 


### PR DESCRIPTION
Fixes an OOM bug introduced in #17944 when constructing error messages. All usages of `comptime expect` in `test/behavior` are also replaced with `comptime assert`. In addition a behaviour test for slicing multi-pointers was checking the types of some irrelevant slices - these type checks have been fixed up.