### PR TITLE
Add internal type-alias type for improved error messages

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2459,6 +2459,11 @@ pub fn fail(
     args: anytype,
 ) CompileError {
     const err_msg = try sema.errMsg(block, src, format, args);
+    inline for (args) |arg| {
+        if (@TypeOf(arg) == Type.Formatter) {
+            try addDeclaredHereNote(sema, err_msg, arg.data.ty);
+        }
+    }
     return sema.failWithOwnedErrorMsg(block, err_msg);
 }
 
@@ -5250,24 +5255,15 @@ fn failWithBadMemberAccess(
         .Enum => "enum",
         else => unreachable,
     };
-    const msg = msg: {
-        const msg = blk: {
-            if (agg_ty.getOwnerDeclOrNull(mod)) |some| if (mod.declIsRoot(some)) {
-                break :blk try sema.errMsg(block, field_src, "root struct of file '{}' has no member named '{}'", .{
-                    agg_ty.fmt(mod), field_name.fmt(&mod.intern_pool),
-                });
-            };
-
-            break :blk try sema.errMsg(block, field_src, "{s} '{}' has no member named '{}'", .{
-                kw_name, agg_ty.fmt(mod), field_name.fmt(&mod.intern_pool),
-            });
-        };
-
-        errdefer msg.destroy(sema.gpa);
-        try sema.addDeclaredHereNote(msg, agg_ty);
-        break :msg msg;
+    if (agg_ty.getOwnerDeclOrNull(mod)) |some| if (mod.declIsRoot(some)) {
+        return sema.fail(block, field_src, "root struct of file '{}' has no member named '{}'", .{
+            agg_ty.fmt(mod), field_name.fmt(&mod.intern_pool),
+        });
     };
-    return sema.failWithOwnedErrorMsg(block, msg);
+
+    return sema.fail(block, field_src, "{s} '{}' has no member named '{}'", .{
+        kw_name, agg_ty.fmt(mod), field_name.fmt(&mod.intern_pool),
+    });
 }
 
 fn failWithBadStructFieldAccess(
@@ -8570,35 +8566,17 @@ fn zirEnumFromInt(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
             if (try sema.intFitsInType(int_val, int_tag_ty, null)) {
                 return Air.internedToRef((try mod.getCoerced(int_val, dest_ty)).toIntern());
             }
-            const msg = msg: {
-                const msg = try sema.errMsg(
-                    block,
-                    src,
-                    "int value '{}' out of range of non-exhaustive enum '{}'",
-                    .{ int_val.fmtValue(sema.typeOf(operand), mod), dest_ty.fmt(mod) },
-                );
-                errdefer msg.destroy(sema.gpa);
-                try sema.addDeclaredHereNote(msg, dest_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(block, msg);
+            return sema.fail(block, src, "int value '{}' out of range of non-exhaustive enum '{}'", .{
+                int_val.fmtValue(sema.typeOf(operand), mod), dest_ty.fmt(mod),
+            });
         }
         if (int_val.isUndef(mod)) {
             return sema.failWithUseOfUndef(block, operand_src);
         }
         if (!(try sema.enumHasInt(dest_ty, int_val))) {
-            const msg = msg: {
-                const msg = try sema.errMsg(
-                    block,
-                    src,
-                    "enum '{}' has no tag with value '{}'",
-                    .{ dest_ty.fmt(mod), int_val.fmtValue(sema.typeOf(operand), mod) },
-                );
-                errdefer msg.destroy(sema.gpa);
-                try sema.addDeclaredHereNote(msg, dest_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(block, msg);
+            return sema.fail(block, src, "enum '{}' has no tag with value '{}'", .{
+                dest_ty.fmt(mod), int_val.fmtValue(sema.typeOf(operand), mod),
+            });
         }
         return Air.internedToRef((try mod.getCoerced(int_val, dest_ty)).toIntern());
     }
@@ -9276,16 +9254,9 @@ fn funcCommon(
         }
         if (!param_ty.isValidParamType(mod)) {
             const opaque_str = if (param_ty.zigTypeTag(mod) == .Opaque) "opaque " else "";
-            const msg = msg: {
-                const msg = try sema.errMsg(block, param_src, "parameter of {s}type '{}' not allowed", .{
-                    opaque_str, param_ty.fmt(mod),
-                });
-                errdefer msg.destroy(sema.gpa);
-
-                try sema.addDeclaredHereNote(msg, param_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(block, msg);
+            return sema.fail(block, param_src, "parameter of {s}type '{}' not allowed", .{
+                opaque_str, param_ty.fmt(mod),
+            });
         }
         if (!this_generic and !target_util.fnCallConvAllowsZigTypes(target, cc_resolved) and !try sema.validateExternType(param_ty, .param_ty)) {
             const msg = msg: {
@@ -9566,16 +9537,9 @@ fn finishFunc(
 
     if (!return_type.isValidReturnType(mod)) {
         const opaque_str = if (return_type.zigTypeTag(mod) == .Opaque) "opaque " else "";
-        const msg = msg: {
-            const msg = try sema.errMsg(block, ret_ty_src, "{s}return type '{}' not allowed", .{
-                opaque_str, return_type.fmt(mod),
-            });
-            errdefer msg.destroy(gpa);
-
-            try sema.addDeclaredHereNote(msg, return_type);
-            break :msg msg;
-        };
-        return sema.failWithOwnedErrorMsg(block, msg);
+        return sema.fail(block, ret_ty_src, "{s}return type '{}' not allowed", .{
+            opaque_str, return_type.fmt(mod),
+        });
     }
     if (!ret_poison and !target_util.fnCallConvAllowsZigTypes(target, cc_resolved) and
         !try sema.validateExternType(return_type, .ret_ty))
@@ -10720,15 +10684,9 @@ const SwitchProngAnalysis = struct {
                 else => unreachable,
             };
             const capture_src = raw_tag_capture_src.resolve(mod, mod.declPtr(block.src_decl), switch_node_offset, .none);
-            const msg = msg: {
-                const msg = try sema.errMsg(block, capture_src, "cannot capture tag of non-union type '{}'", .{
-                    operand_ty.fmt(mod),
-                });
-                errdefer msg.destroy(sema.gpa);
-                try sema.addDeclaredHereNote(msg, operand_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(block, msg);
+            return sema.fail(block, capture_src, "cannot capture tag of non-union type '{}'", .{
+                operand_ty.fmt(mod),
+            });
         }
         assert(inline_case_capture != .none);
         return inline_case_capture;
@@ -19608,13 +19566,7 @@ fn zirUnionInit(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
     const extra = sema.code.extraData(Zir.Inst.UnionInit, inst_data.payload_index).data;
     const union_ty = try sema.resolveType(block, ty_src, extra.union_type);
     if (union_ty.zigTypeTag(sema.mod) != .Union) {
-        const msg = msg: {
-            const msg = try sema.errMsg(block, ty_src, "expected union type, found '{}'", .{union_ty.fmt(sema.mod)});
-            errdefer msg.destroy(sema.gpa);
-            try sema.addDeclaredHereNote(msg, union_ty);
-            break :msg msg;
-        };
-        return sema.failWithOwnedErrorMsg(block, msg);
+        return sema.fail(block, ty_src, "expected union type, found '{}'", .{union_ty.fmt(sema.mod)});
     }
     const field_name = try sema.resolveConstStringIntern(block, field_src, extra.field_name, .{
         .needed_comptime_reason = "name of field being initialized must be comptime-known",
@@ -20040,16 +19992,9 @@ fn structInitAnon(
             const init = try sema.resolveInst(item.data.init);
             field_ty.* = sema.typeOf(init).toIntern();
             if (Type.fromInterned(field_ty.*).zigTypeTag(mod) == .Opaque) {
-                const msg = msg: {
-                    const decl = mod.declPtr(block.src_decl);
-                    const field_src = mod.initSrc(src.node_offset.x, decl, @intCast(i_usize));
-                    const msg = try sema.errMsg(block, field_src, "opaque types have unknown size and therefore cannot be directly embedded in structs", .{});
-                    errdefer msg.destroy(sema.gpa);
-
-                    try sema.addDeclaredHereNote(msg, Type.fromInterned(field_ty.*));
-                    break :msg msg;
-                };
-                return sema.failWithOwnedErrorMsg(block, msg);
+                const decl = mod.declPtr(block.src_decl);
+                const field_src = mod.initSrc(src.node_offset.x, decl, @intCast(i_usize));
+                return sema.fail(block, field_src, "opaque types have unknown size and therefore cannot be directly embedded in structs", .{});
             }
             if (try sema.resolveValue(init)) |init_val| {
                 field_val.* = try init_val.intern(Type.fromInterned(field_ty.*), mod);
@@ -20332,14 +20277,7 @@ fn arrayInitAnon(
             const elem = try sema.resolveInst(operand);
             types[i] = sema.typeOf(elem).toIntern();
             if (Type.fromInterned(types[i]).zigTypeTag(mod) == .Opaque) {
-                const msg = msg: {
-                    const msg = try sema.errMsg(block, operand_src, "opaque types have unknown size and therefore cannot be directly embedded in structs", .{});
-                    errdefer msg.destroy(gpa);
-
-                    try sema.addDeclaredHereNote(msg, Type.fromInterned(types[i]));
-                    break :msg msg;
-                };
-                return sema.failWithOwnedErrorMsg(block, msg);
+                return sema.fail(block, operand_src, "opaque types have unknown size and therefore cannot be directly embedded in structs", .{});
             }
             if (try sema.resolveValue(elem)) |val| {
                 values[i] = val.toIntern();
@@ -20715,17 +20653,8 @@ fn zirTagName(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air
             return sema.addStrLit(ip.stringToSlice(tag_name));
         },
         .Enum => operand_ty,
-        .Union => operand_ty.unionTagType(mod) orelse {
-            const msg = msg: {
-                const msg = try sema.errMsg(block, src, "union '{}' is untagged", .{
-                    operand_ty.fmt(sema.mod),
-                });
-                errdefer msg.destroy(sema.gpa);
-                try sema.addDeclaredHereNote(msg, operand_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(block, msg);
-        },
+        .Union => operand_ty.unionTagType(mod) orelse
+            return sema.fail(block, src, "union '{}' is untagged", .{operand_ty.fmt(sema.mod)}),
         else => return sema.fail(block, operand_src, "expected enum or union; found '{}'", .{
             operand_ty.fmt(mod),
         }),
@@ -21338,16 +21267,9 @@ fn zirReify(
                 if (enum_tag_ty != .none) {
                     const tag_info = ip.indexToKey(enum_tag_ty).enum_type;
                     const enum_index = tag_info.nameIndex(ip, field_name) orelse {
-                        const msg = msg: {
-                            const msg = try sema.errMsg(block, src, "no field named '{}' in enum '{}'", .{
-                                field_name.fmt(ip),
-                                Type.fromInterned(enum_tag_ty).fmt(mod),
-                            });
-                            errdefer msg.destroy(gpa);
-                            try sema.addDeclaredHereNote(msg, Type.fromInterned(enum_tag_ty));
-                            break :msg msg;
-                        };
-                        return sema.failWithOwnedErrorMsg(block, msg);
+                        return sema.fail(block, src, "no field named '{}' in enum '{}'", .{
+                            field_name.fmt(ip), Type.fromInterned(enum_tag_ty).fmt(mod),
+                        });
                     };
                     assert(explicit_tags_seen.len == tag_info.names.len);
                     // No check for duplicate because the check already happened in order
@@ -21379,14 +21301,7 @@ fn zirReify(
                 });
 
                 if (field_ty.zigTypeTag(mod) == .Opaque) {
-                    const msg = msg: {
-                        const msg = try sema.errMsg(block, src, "opaque types have unknown size and therefore cannot be directly embedded in unions", .{});
-                        errdefer msg.destroy(gpa);
-
-                        try sema.addDeclaredHereNote(msg, field_ty);
-                        break :msg msg;
-                    };
-                    return sema.failWithOwnedErrorMsg(block, msg);
+                    return sema.fail(block, src, "opaque types have unknown size and therefore cannot be directly embedded in unions", .{});
                 }
                 if (layout == .Extern and !try sema.validateExternType(field_ty, .union_field)) {
                     const msg = msg: {
@@ -21738,24 +21653,10 @@ fn reifyStruct(
             struct_type.setFieldComptime(ip, i);
 
         if (field_ty.zigTypeTag(mod) == .Opaque) {
-            const msg = msg: {
-                const msg = try sema.errMsg(block, src, "opaque types have unknown size and therefore cannot be directly embedded in structs", .{});
-                errdefer msg.destroy(gpa);
-
-                try sema.addDeclaredHereNote(msg, field_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(block, msg);
+            return sema.fail(block, src, "opaque types have unknown size and therefore cannot be directly embedded in structs", .{});
         }
         if (field_ty.zigTypeTag(mod) == .NoReturn) {
-            const msg = msg: {
-                const msg = try sema.errMsg(block, src, "struct fields cannot be 'noreturn'", .{});
-                errdefer msg.destroy(gpa);
-
-                try sema.addDeclaredHereNote(msg, field_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(block, msg);
+            return sema.fail(block, src, "struct fields cannot be 'noreturn'", .{});
         }
         if (layout == .Extern and !try sema.validateExternType(field_ty, .struct_field)) {
             const msg = msg: {
@@ -22218,19 +22119,9 @@ fn zirErrorCast(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstData
         break :disjoint true;
     };
     if (disjoint and dest_tag != .ErrorUnion) {
-        const msg = msg: {
-            const msg = try sema.errMsg(
-                block,
-                src,
-                "error sets '{}' and '{}' have no common errors",
-                .{ operand_ty.fmt(sema.mod), dest_ty.fmt(sema.mod) },
-            );
-            errdefer msg.destroy(sema.gpa);
-            try sema.addDeclaredHereNote(msg, operand_ty);
-            try sema.addDeclaredHereNote(msg, dest_ty);
-            break :msg msg;
-        };
-        return sema.failWithOwnedErrorMsg(block, msg);
+        return sema.fail(block, src, "error sets '{}' and '{}' have no common errors", .{
+            operand_ty.fmt(sema.mod), dest_ty.fmt(sema.mod),
+        });
     }
 
     if (maybe_operand_val) |val| {
@@ -22244,18 +22135,9 @@ fn zirErrorCast(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstData
                 error_name = operand_val.err.name;
             }
             if (!Type.errorSetHasFieldIp(ip, dest_ty.toIntern(), error_name)) {
-                const msg = msg: {
-                    const msg = try sema.errMsg(
-                        block,
-                        src,
-                        "'error.{}' not a member of error set '{}'",
-                        .{ error_name.fmt(ip), dest_ty.fmt(sema.mod) },
-                    );
-                    errdefer msg.destroy(sema.gpa);
-                    try sema.addDeclaredHereNote(msg, dest_ty);
-                    break :msg msg;
-                };
-                return sema.failWithOwnedErrorMsg(block, msg);
+                return sema.fail(block, src, "'error.{}' not a member of error set '{}'", .{
+                    error_name.fmt(ip), dest_ty.fmt(sema.mod),
+                });
             }
         }
 
@@ -23015,15 +22897,7 @@ fn bitOffsetOf(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!u6
     try sema.resolveTypeLayout(ty);
     switch (ty.zigTypeTag(mod)) {
         .Struct => {},
-        else => {
-            const msg = msg: {
-                const msg = try sema.errMsg(block, lhs_src, "expected struct type, found '{}'", .{ty.fmt(mod)});
-                errdefer msg.destroy(sema.gpa);
-                try sema.addDeclaredHereNote(msg, ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(block, msg);
-        },
+        else => return sema.fail(block, lhs_src, "expected struct type, found '{}'", .{ty.fmt(mod)}),
     }
 
     const field_index = if (ty.isTuple(mod)) blk: {
@@ -24465,23 +24339,9 @@ fn zirFieldParentPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileEr
         } orelse return sema.fail(block, ptr_src, "pointer value not based on parent struct", .{});
 
         if (field.index != field_index) {
-            const msg = msg: {
-                const msg = try sema.errMsg(
-                    block,
-                    src,
-                    "field '{}' has index '{d}' but pointer value is index '{d}' of struct '{}'",
-                    .{
-                        field_name.fmt(ip),
-                        field_index,
-                        field.index,
-                        parent_ty.fmt(sema.mod),
-                    },
-                );
-                errdefer msg.destroy(sema.gpa);
-                try sema.addDeclaredHereNote(msg, parent_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(block, msg);
+            return sema.fail(block, src, "field '{}' has index '{d}' but pointer value is index '{d}' of struct '{}'", .{
+                field_name.fmt(ip), field_index, field.index, parent_ty.fmt(sema.mod),
+            });
         }
         return Air.internedToRef(field.base);
     }
@@ -26666,15 +26526,9 @@ fn fieldVal(
                     switch (ip.indexToKey(child_type.toIntern())) {
                         .error_set_type => |error_set_type| blk: {
                             if (error_set_type.nameIndex(ip, field_name) != null) break :blk;
-                            const msg = msg: {
-                                const msg = try sema.errMsg(block, src, "no error named '{}' in '{}'", .{
-                                    field_name.fmt(ip), child_type.fmt(mod),
-                                });
-                                errdefer msg.destroy(sema.gpa);
-                                try sema.addDeclaredHereNote(msg, child_type);
-                                break :msg msg;
-                            };
-                            return sema.failWithOwnedErrorMsg(block, msg);
+                            return sema.fail(block, src, "no error named '{}' in '{}'", .{
+                                field_name.fmt(ip), child_type.fmt(mod),
+                            });
                         },
                         .inferred_error_set_type => {
                             return sema.fail(block, src, "TODO handle inferred error sets here", .{});
@@ -27601,18 +27455,11 @@ fn unionFieldPtr(
                 const field_tag = try mod.enumValueFieldIndex(Type.fromInterned(union_obj.enum_tag_ty), enum_field_index);
                 const tag_matches = un.tag == field_tag.toIntern();
                 if (!tag_matches) {
-                    const msg = msg: {
-                        const active_index = Type.fromInterned(union_obj.enum_tag_ty).enumTagFieldIndex(Value.fromInterned(un.tag), mod).?;
-                        const active_field_name = Type.fromInterned(union_obj.enum_tag_ty).enumFieldName(active_index, mod);
-                        const msg = try sema.errMsg(block, src, "access of union field '{}' while field '{}' is active", .{
-                            field_name.fmt(ip),
-                            active_field_name.fmt(ip),
-                        });
-                        errdefer msg.destroy(sema.gpa);
-                        try sema.addDeclaredHereNote(msg, union_ty);
-                        break :msg msg;
-                    };
-                    return sema.failWithOwnedErrorMsg(block, msg);
+                    const active_index = Type.fromInterned(union_obj.enum_tag_ty).enumTagFieldIndex(Value.fromInterned(un.tag), mod).?;
+                    const active_field_name = Type.fromInterned(union_obj.enum_tag_ty).enumFieldName(active_index, mod);
+                    return sema.fail(block, src, "access of union field '{}' while field '{}' is active", .{
+                        field_name.fmt(ip), active_field_name.fmt(ip),
+                    });
                 }
             },
             .Packed, .Extern => {},
@@ -27674,17 +27521,11 @@ fn unionFieldVal(
                 if (tag_matches) {
                     return Air.internedToRef(un.val);
                 } else {
-                    const msg = msg: {
-                        const active_index = Type.fromInterned(union_obj.enum_tag_ty).enumTagFieldIndex(Value.fromInterned(un.tag), mod).?;
-                        const active_field_name = Type.fromInterned(union_obj.enum_tag_ty).enumFieldName(active_index, mod);
-                        const msg = try sema.errMsg(block, src, "access of union field '{}' while field '{}' is active", .{
-                            field_name.fmt(ip), active_field_name.fmt(ip),
-                        });
-                        errdefer msg.destroy(sema.gpa);
-                        try sema.addDeclaredHereNote(msg, union_ty);
-                        break :msg msg;
-                    };
-                    return sema.failWithOwnedErrorMsg(block, msg);
+                    const active_index = Type.fromInterned(union_obj.enum_tag_ty).enumTagFieldIndex(Value.fromInterned(un.tag), mod).?;
+                    const active_field_name = Type.fromInterned(union_obj.enum_tag_ty).enumFieldName(active_index, mod);
+                    return sema.fail(block, src, "access of union field '{}' while field '{}' is active", .{
+                        field_name.fmt(ip), active_field_name.fmt(ip),
+                    });
                 }
             },
             .Packed, .Extern => |layout| {
@@ -28812,18 +28653,9 @@ fn coerceExtra(
                 const val = try sema.resolveConstDefinedValue(block, .unneeded, inst, undefined);
                 const string = mod.intern_pool.indexToKey(val.toIntern()).enum_literal;
                 const field_index = dest_ty.enumFieldIndex(string, mod) orelse {
-                    const msg = msg: {
-                        const msg = try sema.errMsg(
-                            block,
-                            inst_src,
-                            "no field named '{}' in enum '{}'",
-                            .{ string.fmt(&mod.intern_pool), dest_ty.fmt(mod) },
-                        );
-                        errdefer msg.destroy(sema.gpa);
-                        try sema.addDeclaredHereNote(msg, dest_ty);
-                        break :msg msg;
-                    };
-                    return sema.failWithOwnedErrorMsg(block, msg);
+                    return sema.fail(block, inst_src, "no field named '{}' in enum '{}'", .{
+                        string.fmt(&mod.intern_pool), dest_ty.fmt(mod),
+                    });
                 };
                 return Air.internedToRef((try mod.enumValueFieldIndex(dest_ty, @intCast(field_index))).toIntern());
             },
@@ -31449,15 +31281,9 @@ fn coerceEnumToUnion(
     const enum_tag = try sema.coerce(block, tag_ty, inst, inst_src);
     if (try sema.resolveDefinedValue(block, inst_src, enum_tag)) |val| {
         const field_index = union_ty.unionTagFieldIndex(val, sema.mod) orelse {
-            const msg = msg: {
-                const msg = try sema.errMsg(block, inst_src, "union '{}' has no tag with value '{}'", .{
-                    union_ty.fmt(sema.mod), val.fmtValue(tag_ty, sema.mod),
-                });
-                errdefer msg.destroy(sema.gpa);
-                try sema.addDeclaredHereNote(msg, union_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(block, msg);
+            return sema.fail(block, inst_src, "union '{}' has no tag with value '{}'", .{
+                union_ty.fmt(sema.mod), val.fmtValue(tag_ty, sema.mod),
+            });
         };
 
         const union_obj = mod.typeToUnion(union_ty).?;
@@ -31501,15 +31327,9 @@ fn coerceEnumToUnion(
     try sema.requireRuntimeBlock(block, inst_src, null);
 
     if (tag_ty.isNonexhaustiveEnum(mod)) {
-        const msg = msg: {
-            const msg = try sema.errMsg(block, inst_src, "runtime coercion to union '{}' from non-exhaustive enum", .{
-                union_ty.fmt(sema.mod),
-            });
-            errdefer msg.destroy(sema.gpa);
-            try sema.addDeclaredHereNote(msg, tag_ty);
-            break :msg msg;
-        };
-        return sema.failWithOwnedErrorMsg(block, msg);
+        return sema.fail(block, inst_src, "runtime coercion to union '{}' from non-exhaustive enum", .{
+            union_ty.fmt(sema.mod),
+        });
     }
 
     const union_obj = mod.typeToUnion(union_ty).?;
@@ -36423,32 +36243,18 @@ fn semaStructFields(
         struct_type.field_types.get(ip)[field_i] = field_ty.toIntern();
 
         if (field_ty.zigTypeTag(mod) == .Opaque) {
-            const msg = msg: {
-                const ty_src = mod.fieldSrcLoc(decl_index, .{
-                    .index = field_i,
-                    .range = .type,
-                }).lazy;
-                const msg = try sema.errMsg(&block_scope, ty_src, "opaque types have unknown size and therefore cannot be directly embedded in structs", .{});
-                errdefer msg.destroy(sema.gpa);
-
-                try sema.addDeclaredHereNote(msg, field_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(&block_scope, msg);
+            const ty_src = mod.fieldSrcLoc(decl_index, .{
+                .index = field_i,
+                .range = .type,
+            }).lazy;
+            return sema.fail(&block_scope, ty_src, "opaque types have unknown size and therefore cannot be directly embedded in structs", .{});
         }
         if (field_ty.zigTypeTag(mod) == .NoReturn) {
-            const msg = msg: {
-                const ty_src = mod.fieldSrcLoc(decl_index, .{
-                    .index = field_i,
-                    .range = .type,
-                }).lazy;
-                const msg = try sema.errMsg(&block_scope, ty_src, "struct fields cannot be 'noreturn'", .{});
-                errdefer msg.destroy(sema.gpa);
-
-                try sema.addDeclaredHereNote(msg, field_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(&block_scope, msg);
+            const ty_src = mod.fieldSrcLoc(decl_index, .{
+                .index = field_i,
+                .range = .type,
+            }).lazy;
+            return sema.fail(&block_scope, ty_src, "struct fields cannot be 'noreturn'", .{});
         }
         switch (struct_type.layout) {
             .Extern => if (!try sema.validateExternType(field_ty, .struct_field)) {
@@ -36951,19 +36757,13 @@ fn semaUnionFields(mod: *Module, arena: Allocator, union_type: InternPool.Key.Un
         if (explicit_tags_seen.len > 0) {
             const tag_info = ip.indexToKey(union_type.tagTypePtr(ip).*).enum_type;
             const enum_index = tag_info.nameIndex(ip, field_name) orelse {
-                const msg = msg: {
-                    const ty_src = mod.fieldSrcLoc(union_type.decl, .{
-                        .index = field_i,
-                        .range = .type,
-                    }).lazy;
-                    const msg = try sema.errMsg(&block_scope, ty_src, "no field named '{}' in enum '{}'", .{
-                        field_name.fmt(ip), Type.fromInterned(union_type.tagTypePtr(ip).*).fmt(mod),
-                    });
-                    errdefer msg.destroy(sema.gpa);
-                    try sema.addDeclaredHereNote(msg, Type.fromInterned(union_type.tagTypePtr(ip).*));
-                    break :msg msg;
-                };
-                return sema.failWithOwnedErrorMsg(&block_scope, msg);
+                const ty_src = mod.fieldSrcLoc(union_type.decl, .{
+                    .index = field_i,
+                    .range = .type,
+                }).lazy;
+                return sema.fail(&block_scope, ty_src, "no field named '{}' in enum '{}'", .{
+                    field_name.fmt(ip), Type.fromInterned(union_type.tagTypePtr(ip).*).fmt(mod),
+                });
             };
             // No check for duplicate because the check already happened in order
             // to create the enum type in the first place.
@@ -36990,18 +36790,11 @@ fn semaUnionFields(mod: *Module, arena: Allocator, union_type: InternPool.Key.Un
         }
 
         if (field_ty.zigTypeTag(mod) == .Opaque) {
-            const msg = msg: {
-                const ty_src = mod.fieldSrcLoc(union_type.decl, .{
-                    .index = field_i,
-                    .range = .type,
-                }).lazy;
-                const msg = try sema.errMsg(&block_scope, ty_src, "opaque types have unknown size and therefore cannot be directly embedded in unions", .{});
-                errdefer msg.destroy(sema.gpa);
-
-                try sema.addDeclaredHereNote(msg, field_ty);
-                break :msg msg;
-            };
-            return sema.failWithOwnedErrorMsg(&block_scope, msg);
+            const ty_src = mod.fieldSrcLoc(union_type.decl, .{
+                .index = field_i,
+                .range = .type,
+            }).lazy;
+            return sema.fail(&block_scope, ty_src, "opaque types have unknown size and therefore cannot be directly embedded in unions", .{});
         }
         const layout = union_type.getLayout(ip);
         if (layout == .Extern and

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -28749,6 +28749,11 @@ fn coerceExtra(
                 };
             }
         },
+        .Type => {
+            if (inst_ty.zigTypeTag(mod) == .Type) {
+                return inst;
+            }
+        },
         else => {},
     }
 
@@ -37234,6 +37239,13 @@ pub fn typeHasOnePossibleValue(sema: *Sema, ty: Type) CompileError!?Value {
             // memoized value, not types
             .memoized_call,
             => unreachable,
+            
+            .type_alias => {
+                const data_index = ip.items.items(.data)[@intFromEnum(ty.toIntern())];
+                const ty_index = ip.extra.items[data_index + std.meta.fieldIndex(InternPool.Key.TypeAlias, "ty").?];
+                // Recurses once.
+                return sema.typeHasOnePossibleValue(Type.fromInterned(@enumFromInt(ty_index)));
+            },
 
             .type_array_big,
             .type_array_small,

--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -446,6 +446,7 @@ pub fn print(
                 return writer.writeAll(" }");
             },
             .memoized_call => unreachable,
+            .type_alias => unreachable,
         },
     };
 }

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3253,6 +3253,7 @@ fn lowerConstant(func: *CodeGen, val: Value, ty: Type) InnerError!WValue {
         .func_type,
         .error_set_type,
         .inferred_error_set_type,
+        .type_alias,
         => unreachable, // types, not values
 
         .undef => unreachable, // handled above

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -212,6 +212,7 @@ pub fn generateSymbol(
         .func_type,
         .error_set_type,
         .inferred_error_set_type,
+        .type_alias,
         => unreachable, // types, not values
 
         .undef => unreachable, // handled above

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1020,6 +1020,7 @@ pub const DeclGen = struct {
             .func_type,
             .error_set_type,
             .inferred_error_set_type,
+            .type_alias,
             // memoization, not values
             .memoized_call,
             => unreachable,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3315,7 +3315,7 @@ pub const Object = struct {
             .var_args_param_type,
             .none,
             => unreachable,
-            else => switch (ip.indexToKey(t.toIntern())) {
+            else => switch (ip.indexToKeyExtra(t.toIntern(), true)) {
                 .int_type => |int_type| try o.builder.intType(int_type.bits),
                 .ptr_type => |ptr_type| type: {
                     const ptr_ty = try o.builder.ptrType(
@@ -3630,6 +3630,10 @@ pub const Object = struct {
                 .enum_type => |enum_type| try o.lowerType(Type.fromInterned(enum_type.tag_ty)),
                 .func_type => |func_type| try o.lowerTypeFn(func_type),
                 .error_set_type, .inferred_error_set_type => try o.errorIntType(),
+                .type_alias => |alias| {
+                    // Recurses once.
+                    return o.lowerTypeInner(Type.fromInterned(alias.ty));
+                },
                 // values, not types
                 .undef,
                 .simple_value,
@@ -3768,6 +3772,7 @@ pub const Object = struct {
             .func_type,
             .error_set_type,
             .inferred_error_set_type,
+            .type_alias,
             => unreachable, // types, not values
 
             .undef => unreachable, // handled above

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -768,6 +768,7 @@ const DeclGen = struct {
             .func_type,
             .error_set_type,
             .inferred_error_set_type,
+            .type_alias,
             => unreachable, // types, not values
 
             .undef => unreachable, // handled above

--- a/src/type.zig
+++ b/src/type.zig
@@ -129,7 +129,9 @@ pub const Type = struct {
         @compileError("do not format types directly; use either ty.fmtDebug() or ty.fmt()");
     }
 
-    pub fn fmt(ty: Type, module: *Module) std.fmt.Formatter(format2) {
+    pub const Formatter = std.fmt.Formatter(format2);
+
+    pub fn fmt(ty: Type, module: *Module) Formatter {
         return .{ .data = .{
             .ty = ty,
             .module = module,

--- a/src/value.zig
+++ b/src/value.zig
@@ -411,6 +411,8 @@ pub const Value = struct {
             }),
 
             .memoized_call => unreachable,
+            // never returned from indexToKey
+            .type_alias => unreachable,
         };
     }
 


### PR DESCRIPTION
This doesn't work yet as I'd like to get approval for the concept before continuing but the goal is to (at least partially) solve #12401 by making error messages refer to the types the same way as the programmer does:
```zig
const Foo = u32; // note: type alias declared here
comptime {
    const b: Foo = 32;
    b and true; // error: expected type 'bool', found 'Foo'
}
```

The first commit is a general improvement required for this feature but also works separately.