### PR TITLE
fix ast gen failure to catch incorrect by ref error captures

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -7219,7 +7219,9 @@ fn switchExprErrUnion(
             };
 
             const capture_token = case.payload_token orelse break :blk &err_scope.base;
-            assert(token_tags[capture_token] == .identifier);
+            if (token_tags[capture_token] != .identifier) {
+                return astgen.failTok(capture_token + 1, "error set cannot be captured by reference", .{});
+            }
 
             const capture_slice = tree.tokenSlice(capture_token);
             if (mem.eql(u8, capture_slice, "_")) {

--- a/test/cases/compile_errors/error_set_cannot_capture_by_reference.zig
+++ b/test/cases/compile_errors/error_set_cannot_capture_by_reference.zig
@@ -1,0 +1,15 @@
+export fn entry() void {
+    const err: error{Foo} = error.Foo;
+
+    switch (err) {
+        error.Foo => |*foo| {
+            foo catch {};
+        },
+    }
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :5:23: error: error set cannot be captured by reference

--- a/test/cases/compile_errors/switch_on_error_union_discard.zig
+++ b/test/cases/compile_errors/switch_on_error_union_discard.zig
@@ -1,9 +1,7 @@
 export fn entry() void {
     const x: error{}!u32 = 0;
-    if (x) |v| v else |_| switch (_) {
-    }
+    if (x) |v| v else |_| switch (_) {}
 }
-
 
 // error
 // backend=stage2

--- a/test/cases/compile_errors/switch_on_error_with_capture_by_reference.zig
+++ b/test/cases/compile_errors/switch_on_error_with_capture_by_reference.zig
@@ -1,0 +1,24 @@
+comptime {
+    const e: error{Foo}!u32 = error.Foo;
+    e catch |err| switch (err) {
+        error.Foo => |*foo| {
+            foo catch {};
+        },
+    };
+}
+
+comptime {
+    const e: error{Foo}!u32 = error.Foo;
+    if (e) {} else |err| switch (err) {
+        error.Foo => |*foo| {
+            foo catch {};
+        },
+    }
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:24: error: error set cannot be captured by reference
+// :13:24: error: error set cannot be captured by reference

--- a/test/cases/compile_errors/switch_on_error_with_non_trivial_switch_operand.zig
+++ b/test/cases/compile_errors/switch_on_error_with_non_trivial_switch_operand.zig
@@ -1,0 +1,22 @@
+export fn entry1() void {
+    var x: error{Foo}!u32 = 0;
+    _ = &x;
+    if (x) |_| {} else |err| switch (err + 1) {
+        else => {},
+    }
+}
+
+export fn entry2() void {
+    var x: error{Foo}!u32 = 0;
+    _ = &x;
+    _ = x catch |err| switch (err + 1) {
+        else => {},
+    };
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:42: error: invalid operands to binary expression: 'ErrorSet' and 'ComptimeInt'
+// :12:35: error: invalid operands to binary expression: 'ErrorSet' and 'ComptimeInt'


### PR DESCRIPTION
fixes #18583

The old code that tried to detect the "switch on error" was just looking at the token relative to the payload to find what is the switch operand. This is incorrect when the switch operand is an expression like in `catch |err| switch (err + 1) {}`.