### PR TITLE
zig cc: expose clang precompiled C header support

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -554,7 +554,7 @@ pub const File = struct {
             return @fieldParentPtr(C, "base", base).flush(arena, prog_node);
         }
         const comp = base.comp;
-        if (comp.clang_preprocessor_mode == .yes) {
+        if (comp.clang_preprocessor_mode == .yes or comp.clang_preprocessor_mode == .pch) {
             const gpa = comp.gpa;
             const emit = base.emit;
             // TODO: avoid extra link step when it's just 1 object file (the `zig cc -c` case)


### PR DESCRIPTION
see https://releases.llvm.org/17.0.1/tools/clang/docs/UsersManual.html#generating-a-pch-file

syntax examples:
`zig cc -x c-header test.h -o test.pch`
`zig cc -include-pch test.pch main.c`

`zig c++ -x c++-header test.h -o test.pch`
`zig c++ -include-pch test.pch main.cpp`


compiling `mold` now works:
`CC="zig cc" CXX="zig c++" ASM="zig cc" cmake .. -G Ninja && ninja`
closes https://github.com/ziglang/zig/issues/18343


extracted from https://github.com/ziglang/zig/pull/17956 as a first step.