### PR TITLE
std.Uri: change specifier for printing with scheme to semicolon `;`

### DIFF
--- a/lib/std/Uri.zig
+++ b/lib/std/Uri.zig
@@ -318,7 +318,7 @@ pub fn format(
 ) @TypeOf(writer).Error!void {
     _ = options;
 
-    const scheme = comptime std.mem.indexOf(u8, fmt, ":") != null or fmt.len == 0;
+    const scheme = comptime std.mem.indexOf(u8, fmt, ";") != null or fmt.len == 0;
     const authentication = comptime std.mem.indexOf(u8, fmt, "@") != null or fmt.len == 0;
     const authority = comptime std.mem.indexOf(u8, fmt, "+") != null or fmt.len == 0;
     const path = comptime std.mem.indexOf(u8, fmt, "/") != null or fmt.len == 0;

--- a/lib/std/Uri.zig
+++ b/lib/std/Uri.zig
@@ -850,7 +850,7 @@ test "format" {
     };
     var buf = std.ArrayList(u8).init(std.testing.allocator);
     defer buf.deinit();
-    try uri.format(":/?#", .{}, buf.writer());
+    try buf.writer().print("{;/?#}", .{uri});
     try std.testing.expectEqualSlices(u8, "file:/foo/bar/baz", buf.items);
 }
 

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -915,7 +915,7 @@ fn initResource(f: *Fetch, uri: std.Uri) RunError!Resource {
             });
             const notes_start = try eb.reserveNotes(notes_len);
             eb.extra.items[notes_start] = @intFromEnum(try eb.addErrorMessage(.{
-                .msg = try eb.printString("try .url = \"{+/}#{}\",", .{
+                .msg = try eb.printString("try .url = \"{;+/}#{}\",", .{
                     uri, std.fmt.fmtSliceHexLower(&want_oid),
                 }),
             }));


### PR DESCRIPTION
This is because `std.fmt` doesn't pass `:` to `format` as it functions as a delimiter for format specifiers


Fetch: print scheme when suggesting adding a ref to git URIs

