### PR TITLE
Sema: replace uses of `toUnsignedInt` with `toUnsignedIntAdvanced`

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -1380,12 +1380,15 @@ pub const Type = struct {
                         },
                         .eager => {},
                     }
-                    return switch (struct_type.layout) {
-                        .Packed => .{
+                    switch (struct_type.layout) {
+                        .Packed => return .{
                             .scalar = Type.fromInterned(struct_type.backingIntType(ip).*).abiSize(mod),
                         },
-                        .Auto, .Extern => .{ .scalar = struct_type.size(ip).* },
-                    };
+                        .Auto, .Extern => {
+                            assert(struct_type.haveLayout(ip));
+                            return .{ .scalar = struct_type.size(ip).* };
+                        },
+                    }
                 },
                 .anon_struct_type => |tuple| {
                     switch (strat) {
@@ -1411,6 +1414,7 @@ pub const Type = struct {
                         .eager => {},
                     }
 
+                    assert(union_type.haveLayout(ip));
                     return .{ .scalar = union_type.size(ip).* };
                 },
                 .opaque_type => unreachable, // no size available

--- a/src/value.zig
+++ b/src/value.zig
@@ -575,6 +575,11 @@ pub const Value = struct {
         return getUnsignedInt(val, mod).?;
     }
 
+    /// Asserts the value is an integer and it fits in a u64
+    pub fn toUnsignedIntAdvanced(val: Value, sema: *Sema) !u64 {
+        return (try getUnsignedIntAdvanced(val, sema.mod, sema)).?;
+    }
+
     /// Asserts the value is an integer and it fits in a i64
     pub fn toSignedInt(val: Value, mod: *Module) i64 {
         return switch (val.toIntern()) {

--- a/test/behavior/sizeof_and_typeof.zig
+++ b/test/behavior/sizeof_and_typeof.zig
@@ -429,3 +429,12 @@ test "Extern function calls, dereferences and field access in @TypeOf" {
     try Test.doTheTest();
     try comptime Test.doTheTest();
 }
+
+test "@sizeOf struct is resolved when used as operand of slicing" {
+    const dummy = struct {};
+    const S = struct {
+        var buf: [1]u8 = undefined;
+    };
+    S.buf[@sizeOf(dummy)..][0] = 0;
+    try expect(S.buf[0] == 0);
+}


### PR DESCRIPTION
During semantic analysis the value may be an unresolved lazy value which makes using `toUnsignedInt` invalid.

Add assertions to detect similar issues in the future.

Closes #18624