### PR TITLE
std.fs: Get some more rename tests passing on Windows

### DIFF
--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -1626,7 +1626,10 @@ pub const RenameError = posix.RenameError;
 /// Change the name or location of a file or directory.
 /// If new_sub_path already exists, it will be replaced.
 /// Renaming a file over an existing directory or a directory
-/// over an existing file will fail with `error.IsDir` or `error.NotDir`
+/// over an existing file will fail with `error.IsDir` or `error.NotDir`.
+/// Renaming a directory over an existing directory will succeed if
+/// new_sub_path is an empty directory, or fail with `error.PathAlreadyExists`
+/// if new_sub_path not an empty directory.
 pub fn rename(self: Dir, old_sub_path: []const u8, new_sub_path: []const u8) RenameError!void {
     return posix.renameat(self.fd, old_sub_path, self.fd, new_sub_path);
 }

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -852,9 +852,6 @@ test "Dir.rename directories" {
 }
 
 test "Dir.rename directory onto empty dir" {
-    // TODO: Fix on Windows, see https://github.com/ziglang/zig/issues/6364
-    if (builtin.os.tag == .windows) return error.SkipZigTest;
-
     try testWithAllSupportedPathTypes(struct {
         fn impl(ctx: *TestContext) !void {
             const test_dir_path = try ctx.transformPath("test_dir");
@@ -873,9 +870,6 @@ test "Dir.rename directory onto empty dir" {
 }
 
 test "Dir.rename directory onto non-empty dir" {
-    // TODO: Fix on Windows, see https://github.com/ziglang/zig/issues/6364
-    if (builtin.os.tag == .windows) return error.SkipZigTest;
-
     try testWithAllSupportedPathTypes(struct {
         fn impl(ctx: *TestContext) !void {
             const test_dir_path = try ctx.transformPath("test_dir");
@@ -899,9 +893,6 @@ test "Dir.rename directory onto non-empty dir" {
 }
 
 test "Dir.rename file <-> dir" {
-    // TODO: Fix on Windows, see https://github.com/ziglang/zig/issues/6364
-    if (builtin.os.tag == .windows) return error.SkipZigTest;
-
     try testWithAllSupportedPathTypes(struct {
         fn impl(ctx: *TestContext) !void {
             const test_file_path = try ctx.transformPath("test_file");


### PR DESCRIPTION
Most of these tests were made to pass by https://github.com/ziglang/zig/pull/16717, but there were a few loose ends to tie up with regards to the 'fallback' behavior (when FILE_RENAME_POSIX_SEMANTICS either isn't available or isn't supported by the underlying filesystem).

We now do a bit of extra work to get POSIX-like renaming in the fallback path. This feels a bit bad, but the Windows behavior around renaming a directory to the path of a file (it succeeds and replaces the file with the directory) sort of forces our hand, and allows making the rest of the fallback conform to POSIX rename behavior without *too* much additional trouble.

Closes #6364