### PR TITLE
std.Build.Step.ConfigHeader (cmake): fix offset calculation for multiple substitutions on a single line

### DIFF
--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -537,7 +537,7 @@ fn replace_variables(
             switch (value) {
                 .boolean => |b| {
                     const buf = try std.fmt.allocPrint(allocator, "{s}{}{s}", .{ beginline, @intFromBool(b), endline });
-                    last_index = start_index + 1;
+                    last_index = prefix_index + 1;
 
                     allocator.free(content_buf);
                     content_buf = buf;
@@ -546,14 +546,14 @@ fn replace_variables(
                     const buf = try std.fmt.allocPrint(allocator, "{s}{}{s}", .{ beginline, i, endline });
                     const isNegative = i < 0;
                     const digits = (if (0 < i) std.math.log10(@abs(i)) else 0) + 1;
-                    last_index = start_index + @intFromBool(isNegative) + digits + 1;
+                    last_index = prefix_index + @intFromBool(isNegative) + digits;
 
                     allocator.free(content_buf);
                     content_buf = buf;
                 },
                 .string, .ident => |x| {
                     const buf = try std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ beginline, x, endline });
-                    last_index = start_index + x.len + 1;
+                    last_index = prefix_index + x.len;
 
                     allocator.free(content_buf);
                     content_buf = buf;
@@ -561,7 +561,7 @@ fn replace_variables(
 
                 else => {
                     const buf = try std.fmt.allocPrint(allocator, "{s}{s}", .{ beginline, endline });
-                    last_index = start_index + 1;
+                    last_index = prefix_index;
 
                     allocator.free(content_buf);
                     content_buf = buf;

--- a/test/standalone/cmakedefine/config.h.cmake
+++ b/test/standalone/cmakedefine/config.h.cmake
@@ -49,11 +49,23 @@
 // no substition
 // @noval@
 
+// no substition
+// @noval@@noval@
+
+// no substition
+// @noval@.@noval@
+
 // 1
 // @trueval@
 
 // 0
 // @falseval@
+
+// 10
+// @trueval@@falseval@
+
+// 0.1
+// @falseval@.@trueval@
 
 // 0
 // @zeroval@
@@ -64,20 +76,46 @@
 // 10
 // @tenval@
 
+// 01
+// @zeroval@@oneval@
+
+// 0.10
+// @zeroval@.@tenval@
+
 // test
 // @stringval@
 
+// testtest
+// @stringval@@stringval@
+
+// test.test
+// @stringval@.@stringval@
+
+// test10
+// @noval@@stringval@@trueval@@zeroval@
 
 // ${} substition
 
-// removal
+// no substition
 // ${noval}
+
+// no substition
+// ${noval}${noval}
+
+// no substition
+// ${noval}.${noval}
 
 // 1
 // ${trueval}
 
 // 0
 // ${falseval}
+
+// 10
+// ${trueval}${falseval}
+
+// 0.1
+// ${falseval}.${trueval}
 
 // 0
 // ${zeroval}
@@ -88,6 +126,20 @@
 // 10
 // ${tenval}
 
+// 01
+// ${zeroval}${oneval}
+
+// 0.10
+// ${zeroval}.${tenval}
+
 // test
 // ${stringval}
 
+// testtest
+// ${stringval}${stringval}
+
+// test.test
+// ${stringval}.${stringval}
+
+// test10
+// ${noval}${stringval}${trueval}${zeroval}

--- a/test/standalone/cmakedefine/expected.h
+++ b/test/standalone/cmakedefine/expected.h
@@ -49,11 +49,23 @@
 // no substition
 // 
 
+// no substition
+// 
+
+// no substition
+// .
+
 // 1
 // 1
 
 // 0
 // 0
+
+// 10
+// 10
+
+// 0.1
+// 0.1
 
 // 0
 // 0
@@ -64,20 +76,46 @@
 // 10
 // 10
 
+// 01
+// 01
+
+// 0.10
+// 0.10
+
 // test
 // test
 
+// testtest
+// testtest
+
+// test.test
+// test.test
+
+// test10
+// test10
 
 //  substition
 
-// removal
+// no substition
 // 
 
+// no substition
+// 
+
+// no substition
+// .
+
 // 1
 // 1
 
 // 0
 // 0
+
+// 10
+// 10
+
+// 0.1
+// 0.1
 
 // 0
 // 0
@@ -88,6 +126,20 @@
 // 10
 // 10
 
+// 01
+// 01
+
+// 0.10
+// 0.10
+
 // test
 // test
 
+// testtest
+// testtest
+
+// test.test
+// test.test
+
+// test10
+// test10


### PR DESCRIPTION
Iterative passes should start at the end of the previous substitution. Previous implementation was "off-by-one" and referred to the start of the variable name (after the prefix character) and mangled neighboring variables.

Also extended test cases to cover this use case.

Closes #18633