### PR TITLE
Sema: add declared here notes in `fail`

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -130,7 +130,9 @@ pub const Type = struct {
         @compileError("do not format types directly; use either ty.fmtDebug() or ty.fmt()");
     }
 
-    pub fn fmt(ty: Type, module: *Module) std.fmt.Formatter(format2) {
+    pub const Formatter = std.fmt.Formatter(format2);
+
+    pub fn fmt(ty: Type, module: *Module) Formatter {
         return .{ .data = .{
             .ty = ty,
             .module = module,

--- a/test/cases/compile_errors/directly_embedding_opaque_type_in_struct_and_union.zig
+++ b/test/cases/compile_errors/directly_embedding_opaque_type_in_struct_and_union.zig
@@ -34,4 +34,6 @@ export fn d() void {
 // :7:10: error: opaque types have unknown size and therefore cannot be directly embedded in unions
 // :1:11: note: opaque declared here
 // :19:22: error: cannot load opaque type 'tmp.O'
+// :1:11: note: opaque declared here
 // :24:28: error: cannot load opaque type 'tmp.O'
+// :1:11: note: opaque declared here

--- a/test/cases/compile_errors/illegal_comparison_of_types.zig
+++ b/test/cases/compile_errors/illegal_comparison_of_types.zig
@@ -22,3 +22,4 @@ export fn entry2() usize {
 //
 // :2:14: error: operator == not allowed for type '[]u8'
 // :9:16: error: operator == not allowed for type 'tmp.EnumWithData'
+// :4:22: note: union declared here

--- a/test/cases/compile_errors/int_from_enum_undefined.zig
+++ b/test/cases/compile_errors/int_from_enum_undefined.zig
@@ -10,3 +10,4 @@ export fn a() void {
 // target=native
 //
 // :5:22: error: cannot use @intFromEnum on empty enum 'tmp.a.E'
+// :2:15: note: enum declared here

--- a/test/cases/compile_errors/invalid_deref_on_switch_target.zig
+++ b/test/cases/compile_errors/invalid_deref_on_switch_target.zig
@@ -15,3 +15,4 @@ const Tile = enum {
 // target=native
 //
 // :3:17: error: cannot dereference non-pointer type 'tmp.Tile'
+// :8:14: note: enum declared here

--- a/test/cases/compile_errors/invalid_inline_else_type.zig
+++ b/test/cases/compile_errors/invalid_inline_else_type.zig
@@ -27,4 +27,5 @@ pub export fn entry3() void {
 //
 // :5:21: error: cannot enumerate values of type 'anyerror' for 'inline else'
 // :13:21: error: cannot enumerate values of type 'tmp.E' for 'inline else'
+// :8:11: note: enum declared here
 // :20:21: error: cannot enumerate values of type '*u32' for 'inline else'

--- a/test/cases/compile_errors/invalid_multiple_dereferences.zig
+++ b/test/cases/compile_errors/invalid_multiple_dereferences.zig
@@ -17,4 +17,6 @@ pub const Box = struct {
 // target=native
 //
 // :4:8: error: cannot dereference non-pointer type 'tmp.Box'
+// :11:17: note: struct declared here
 // :9:14: error: cannot dereference non-pointer type 'tmp.Box'
+// :11:17: note: struct declared here

--- a/test/cases/compile_errors/non-const_variables_of_things_that_require_const_variables.zig
+++ b/test/cases/compile_errors/non-const_variables_of_things_that_require_const_variables.zig
@@ -44,6 +44,8 @@ export fn entry8() void {
 // :14:9: note: to modify this variable at runtime, it must be given an explicit fixed-size number type
 // :18:9: error: variable of type '@TypeOf(null)' must be const or comptime
 // :22:20: error: cannot load opaque type 'tmp.Opaque'
+// :29:16: note: opaque declared here
 // :26:9: error: variable of type 'type' must be const or comptime
 // :26:9: note: types are not available at runtime
 // :31:12: error: non-extern variable with opaque type 'tmp.Opaque'
+// :29:16: note: opaque declared here


### PR DESCRIPTION
This ensures that the note is added in more places and that `errMsg` needs to be used in fewer places.