### PR TITLE
Don't assume a write if an operand is not in function parameters

### DIFF
--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -489,7 +489,7 @@ pub fn categorizeOperand(
                 for (args, 0..) |arg, i| {
                     if (arg == operand_ref) return matchOperandSmallIndex(l, inst, @as(OperandInt, @intCast(i + 1)), .write);
                 }
-                return .write;
+                return .none;
             }
             var bt = l.iterateBigTomb(inst);
             if (bt.feed()) {
@@ -504,7 +504,7 @@ pub fn categorizeOperand(
                     if (arg == operand_ref) return .write;
                 }
             }
-            return .write;
+            return .none;
         },
         .select => {
             const pl_op = air_datas[@intFromEnum(inst)].pl_op;


### PR DESCRIPTION
Liveness mistakenly assumes that if the operand is not in the parameters of a function call it is being written to, resulting in pointless memcpies.

New IR from the test case in #17580 - no memcpy:
```
; Function Attrs: nounwind uwtable
define internal fastcc i1 @bad.Foo.method(ptr nonnull readonly align 1 %0, i64 %1) unnamed_addr #0 {
  %3 = getelementptr inbounds %bad.Foo, ptr %0, i32 0, i32 0
  %4 = call fastcc i64 @bad.Foo.noop(i64 %1)
  %5 = getelementptr inbounds [100 x i1], ptr %3, i64 0, i64 %4
  %6 = load i1, ptr %5, align 1
  ret i1 %6
}
```

Difference in performance from the test case in #15685:
```
❯ zig run test.zig
error: Time: 49296208 Sum: 536854528

❯ zig-dev run test.zig
error: Time: 764281 Sum: 536854528
```

Fixes #17580, #15685