### PR TITLE
align naming and fix module creation from TranslateC

### DIFF
--- a/lib/std/Build/Step/TranslateC.zig
+++ b/lib/std/Build/Step/TranslateC.zig
@@ -19,7 +19,7 @@ link_libc: bool,
 use_clang: bool,
 
 pub const Options = struct {
-    source_file: std.Build.LazyPath,
+    root_source_file: std.Build.LazyPath,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
     link_libc: bool = true,
@@ -28,7 +28,7 @@ pub const Options = struct {
 
 pub fn create(owner: *std.Build, options: Options) *TranslateC {
     const self = owner.allocator.create(TranslateC) catch @panic("OOM");
-    const source = options.source_file.dupe(owner);
+    const source = options.root_source_file.dupe(owner);
     self.* = TranslateC{
         .step = Step.init(.{
             .id = .translate_c,
@@ -79,7 +79,7 @@ pub fn addExecutable(self: *TranslateC, options: AddExecutableOptions) *Step.Com
 /// `createModule` can be used instead to create a private module.
 pub fn addModule(self: *TranslateC, name: []const u8) *std.Build.Module {
     return self.step.owner.addModule(name, .{
-        .source_file = self.getOutput(),
+        .root_source_file = self.getOutput(),
     });
 }
 
@@ -92,7 +92,7 @@ pub fn createModule(self: *TranslateC) *std.Build.Module {
 
     module.* = .{
         .builder = b,
-        .source_file = self.getOutput(),
+        .root_source_file = self.getOutput(),
         .dependencies = std.StringArrayHashMap(*std.Build.Module).init(b.allocator),
     };
     return module;

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -702,7 +702,7 @@ pub fn lowerToBuildSteps(
             const file_source = write_src.add("tmp.c", case.input);
 
             const translate_c = b.addTranslateC(.{
-                .source_file = file_source,
+                .root_source_file = file_source,
                 .optimize = .Debug,
                 .target = case.target,
                 .link_libc = case.link_libc,
@@ -729,7 +729,7 @@ pub fn lowerToBuildSteps(
             const file_source = write_src.add("tmp.c", case.input);
 
             const translate_c = b.addTranslateC(.{
-                .source_file = file_source,
+                .root_source_file = file_source,
                 .optimize = .Debug,
                 .target = case.target,
                 .link_libc = case.link_libc,

--- a/test/src/run_translated_c.zig
+++ b/test/src/run_translated_c.zig
@@ -85,7 +85,7 @@ pub const RunTranslatedCContext = struct {
             _ = write_src.add(src_file.filename, src_file.source);
         }
         const translate_c = b.addTranslateC(.{
-            .source_file = write_src.files.items[0].getPath(),
+            .root_source_file = write_src.files.items[0].getPath(),
             .target = b.host,
             .optimize = .Debug,
         });

--- a/test/src/translate_c.zig
+++ b/test/src/translate_c.zig
@@ -107,7 +107,7 @@ pub const TranslateCContext = struct {
         }
 
         const translate_c = b.addTranslateC(.{
-            .source_file = write_src.files.items[0].getPath(),
+            .root_source_file = write_src.files.items[0].getPath(),
             .target = b.resolveTargetQuery(case.target),
             .optimize = .Debug,
         });


### PR DESCRIPTION
fixes the following snippet since Module.source_file was renamed, and aligns `Step.TranslateC.Options`

```zig
const zig_source = b.addTranslateC(.{
    .root_source_file=.{.path="source.h"},
    .target=target,
    .optimize=optimize,
});
const zig_mod = zig_source.addModule("source");
```

