### PR TITLE
test: add behavior coverage for global setter in function liveness

### DIFF
--- a/test/behavior/globals.zig
+++ b/test/behavior/globals.zig
@@ -46,3 +46,29 @@ test "slices pointing at the same address as global array." {
     try S.checkAddress(&S.a);
     try comptime S.checkAddress(&S.a);
 }
+
+test "global loads can affect liveness" {
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    const S = struct {
+        const ByRef = struct {
+            a: u32,
+        };
+
+        var global_ptr: *ByRef = undefined;
+
+        fn f() void {
+            global_ptr.* = .{ .a = 42 };
+        }
+    };
+
+    var x: ByRef = .{ .a = 1 };
+    S.global_ptr = &x;
+    const y = x;
+    S.f();
+    try std.testing.expect(y.a == 1);
+}

--- a/test/behavior/globals.zig
+++ b/test/behavior/globals.zig
@@ -66,7 +66,7 @@ test "global loads can affect liveness" {
         }
     };
 
-    var x: ByRef = .{ .a = 1 };
+    var x: S.ByRef = .{ .a = 1 };
     S.global_ptr = &x;
     const y = x;
     S.f();


### PR DESCRIPTION
Wanna make sure https://github.com/ziglang/zig/pull/18641#issuecomment-1907279096 doesn't get left behind for the next attempt.