### PR TITLE
std.os.wasi | Fix comment links

### DIFF
--- a/lib/std/os/wasi.zig
+++ b/lib/std/os/wasi.zig
@@ -1,6 +1,6 @@
 // wasi_snapshot_preview1 spec available (in witx format) here:
-// * typenames -- https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/witx/typenames.witx
-// * module -- https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/witx/wasi_snapshot_preview1.witx
+// * typenames -- https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/witx/typenames.witx
+// * module -- https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/witx/wasi_snapshot_preview1.witx
 const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;


### PR DESCRIPTION
Branch was renamed: master -> main
Preview 1 was moved to legacy