### PR TITLE
std.fmt: fix formatting slices of structs with custom formatting

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2255,6 +2255,24 @@ test "slice" {
         try expectFmt("int: { 1, 1000, 5fad3, 423a35c7 }", "int: {x}", .{int_slice[runtime_zero..]});
         try expectFmt("int: { 00001, 01000, 5fad3, 423a35c7 }", "int: {x:0>5}", .{int_slice[runtime_zero..]});
     }
+    {
+        const S1 = struct {
+            x: u8,
+        };
+        const struct_slice: []const S1 = &[_]S1{ S1{ .x = 8 }, S1{ .x = 42 } };
+        try expectFmt("slice: { fmt.test.slice.S1{ .x = 8 }, fmt.test.slice.S1{ .x = 42 } }", "slice: {any}", .{struct_slice});
+    }
+    {
+        const S2 = struct {
+            x: u8,
+
+            pub fn format(s: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+                try writer.print("S2({})", .{s.x});
+            }
+        };
+        const struct_slice: []const S2 = &[_]S2{ S2{ .x = 8 }, S2{ .x = 42 } };
+        try expectFmt("slice: { S2(8), S2(42) }", "slice: {any}", .{struct_slice});
+    }
 }
 
 test "escape non-printable" {

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -1126,7 +1126,10 @@ pub inline fn hasFn(comptime T: type, comptime name: []const u8) bool {
 /// Result is always comptime-known.
 pub inline fn hasMethod(comptime T: type, comptime name: []const u8) bool {
     return switch (@typeInfo(T)) {
-        .Pointer => |P| hasFn(P.child, name),
+        .Pointer => |P| switch (P.size) {
+            .One => hasFn(P.child, name),
+            else => false,
+        },
         else => hasFn(T, name),
     };
 }

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -1136,12 +1136,6 @@ test "hasFn" {
     };
 
     try std.testing.expect(!hasFn(S2, "foo"));
-
-    const S3 = struct {
-        fn foo() void {}
-    };
-
-    try std.testing.expect(!hasFn(S3, "foo"));
 }
 
 /// Returns true if a type has a `name` method; `false` otherwise.
@@ -1178,12 +1172,6 @@ test "hasMethod" {
     };
 
     try std.testing.expect(!hasMethod(S2, "foo"));
-
-    const S3 = struct {
-        fn foo() void {}
-    };
-
-    try std.testing.expect(!hasMethod(S3, "foo"));
 
     const U = union {
         pub fn foo() void {}

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -1150,7 +1150,7 @@ pub inline fn hasMethod(comptime T: type, comptime name: []const u8) bool {
     return switch (@typeInfo(T)) {
         .Pointer => |P| switch (P.size) {
             .One => hasFn(P.child, name),
-            else => false,
+            .Many, .Slice, .C => false,
         },
         else => hasFn(T, name),
     };

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -1122,6 +1122,28 @@ pub inline fn hasFn(comptime T: type, comptime name: []const u8) bool {
     return @typeInfo(@TypeOf(@field(T, name))) == .Fn;
 }
 
+test "hasFn" {
+    const S1 = struct {
+        pub fn foo() void {}
+    };
+
+    try std.testing.expect(hasFn(S1, "foo"));
+    try std.testing.expect(!hasFn(S1, "bar"));
+    try std.testing.expect(!hasFn(*S1, "foo"));
+
+    const S2 = struct {
+        foo: fn () void,
+    };
+
+    try std.testing.expect(!hasFn(S2, "foo"));
+
+    const S3 = struct {
+        fn foo() void {}
+    };
+
+    try std.testing.expect(!hasFn(S3, "foo"));
+}
+
 /// Returns true if a type has a `name` method; `false` otherwise.
 /// Result is always comptime-known.
 pub inline fn hasMethod(comptime T: type, comptime name: []const u8) bool {
@@ -1132,6 +1154,44 @@ pub inline fn hasMethod(comptime T: type, comptime name: []const u8) bool {
         },
         else => hasFn(T, name),
     };
+}
+
+test "hasMethod" {
+    try std.testing.expect(!hasMethod(u32, "foo"));
+    try std.testing.expect(!hasMethod([]u32, "len"));
+    try std.testing.expect(!hasMethod(struct { u32, u64 }, "len"));
+
+    const S1 = struct {
+        pub fn foo() void {}
+    };
+
+    try std.testing.expect(hasMethod(S1, "foo"));
+    try std.testing.expect(hasMethod(*S1, "foo"));
+
+    try std.testing.expect(!hasMethod(S1, "bar"));
+    try std.testing.expect(!hasMethod(*[1]S1, "foo"));
+    try std.testing.expect(!hasMethod(*[10]S1, "foo"));
+    try std.testing.expect(!hasMethod([]S1, "foo"));
+
+    const S2 = struct {
+        foo: fn () void,
+    };
+
+    try std.testing.expect(!hasMethod(S2, "foo"));
+
+    const S3 = struct {
+        fn foo() void {}
+    };
+
+    try std.testing.expect(!hasMethod(S3, "foo"));
+
+    const U = union {
+        pub fn foo() void {}
+    };
+
+    try std.testing.expect(hasMethod(U, "foo"));
+    try std.testing.expect(hasMethod(*U, "foo"));
+    try std.testing.expect(!hasMethod(U, "bar"));
 }
 
 /// True if every value of the type `T` has a unique bit pattern representing it.


### PR DESCRIPTION
Fixes `hasMethod` which was introduced in #18636 
It should return false for pointers to more than one item.