### PR TITLE
macho: fix logic for parsing dependent dylibs aka re-exports

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1257,23 +1257,15 @@ fn parseDependentDylibs(self: *MachO) !void {
             const full_path = full_path: {
                 fail: {
                     const stem = std.fs.path.stem(id.name);
-                    const framework_name = try std.fmt.allocPrint(gpa, "{s}.framework" ++ std.fs.path.sep_str ++ "{s}", .{
-                        stem,
-                        stem,
-                    });
-                    defer gpa.free(framework_name);
 
-                    if (mem.endsWith(u8, id.name, framework_name)) {
-                        // Framework
-                        if (try resolveFramework(
-                            arena,
-                            &test_path,
-                            &checked_paths,
-                            framework_dirs,
-                            stem,
-                        )) break :full_path test_path.items;
-                        break :fail;
-                    }
+                    // Framework
+                    if (try resolveFramework(
+                        arena,
+                        &test_path,
+                        &checked_paths,
+                        framework_dirs,
+                        stem,
+                    )) break :full_path test_path.items;
 
                     // Library
                     const lib_name = eatPrefix(stem, "lib") orelse stem;

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -844,6 +844,11 @@ fn dumpArgv(self: *MachO, comp: *Compilation) !void {
             try argv.append(arg);
         }
 
+        for (self.lib_dirs) |lib_dir| {
+            const arg = try std.fmt.allocPrint(arena, "-L{s}", .{lib_dir});
+            try argv.append(arg);
+        }
+
         for (self.frameworks) |framework| {
             const name = std.fs.path.stem(framework.path);
             const arg = if (framework.needed)
@@ -853,6 +858,11 @@ fn dumpArgv(self: *MachO, comp: *Compilation) !void {
             else
                 try std.fmt.allocPrint(arena, "-framework {s}", .{name});
             try argv.append(arg);
+        }
+
+        for (self.framework_dirs) |f_dir| {
+            try argv.append("-F");
+            try argv.append(f_dir);
         }
 
         if (self.base.isDynLib() and self.base.allow_shlib_undefined) {


### PR DESCRIPTION
Fixes #17130 

@slimsag @menduz I would appreciate if you double check this indeed fixes your issue. I did verify locally but want to make sure I didn't have to check out a specific version of `mach-glfw` project or something.

@andrewrk a couple of comments regarding having lib and framework search dirs available in `Compilation`:
1. ~~I have added dumping those dirs when `--verbose-link` is passed which I find invaluable for debugging any path-related linker issues. That said, I would like to discuss this with you if perhaps we could handle this in the frontend if possible; the point here being having the entire linker line invocation available for dumping when required.~~ EDIT: Turns out I forgot that we already do that for ELF linker. Still, my point stands.
2. I think with these changes landing we will be at a point when we can look at the possibility of having the frontend do the actual path resolution and searching for dylib re-exports - this is non-blocking for this issue but I think it's a good point to have this discussion and figure out what is possible and what isn't.