### PR TITLE
lib/std/fs/File: enable VT seq support for Windows Console

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -219,9 +219,24 @@ pub fn isTty(self: File) bool {
 /// Test whether ANSI escape codes will be treated as such.
 pub fn supportsAnsiEscapeCodes(self: File) bool {
     if (builtin.os.tag == .windows) {
-        var console_mode: windows.DWORD = 0;
-        if (windows.kernel32.GetConsoleMode(self.handle, &console_mode) != 0) {
-            if (console_mode & windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0) return true;
+        var original_console_mode: windows.DWORD = 0;
+
+        // For Windows Terminal, VT Sequences processing is enabled by default.
+        if (windows.kernel32.GetConsoleMode(self.handle, &original_console_mode) != 0) {
+            if (original_console_mode & windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0) return true;
+
+            // For Windows Console, VT Sequences processing support was added in Windows 10 build 14361, but disabled by default.
+            // https://devblogs.microsoft.com/commandline/tmux-support-arrives-for-bash-on-ubuntu-on-windows/
+            // Use Microsoft's recommended way to enable virtual terminal processing.
+            // https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#example-of-enabling-virtual-terminal-processing
+            var requested_console_modes: windows.DWORD = windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING | windows.DISABLE_NEWLINE_AUTO_RETURN;
+            var console_mode = original_console_mode | requested_console_modes;
+            if (windows.kernel32.SetConsoleMode(self.handle, console_mode) != 0) return true;
+
+            // An application receiving ERROR_INVALID_PARAMETER with one of the newer console mode flags in the bit field should gracefully degrade behavior and try again.
+            requested_console_modes = windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            console_mode = original_console_mode | requested_console_modes;
+            if (windows.kernel32.SetConsoleMode(self.handle, console_mode) != 0) return true;
         }
 
         return posix.isCygwinPty(self.handle);

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -3733,6 +3733,7 @@ pub const CONSOLE_SCREEN_BUFFER_INFO = extern struct {
 };
 
 pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4;
+pub const DISABLE_NEWLINE_AUTO_RETURN = 0x8;
 
 pub const FOREGROUND_BLUE = 1;
 pub const FOREGROUND_GREEN = 2;

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -165,6 +165,7 @@ pub extern "kernel32" fn GetCommandLineA() callconv(WINAPI) LPSTR;
 pub extern "kernel32" fn GetCommandLineW() callconv(WINAPI) LPWSTR;
 
 pub extern "kernel32" fn GetConsoleMode(in_hConsoleHandle: HANDLE, out_lpMode: *DWORD) callconv(WINAPI) BOOL;
+pub extern "kernel32" fn SetConsoleMode(in_hConsoleHandle: HANDLE, in_dwMode: DWORD) callconv(WINAPI) BOOL;
 
 pub extern "kernel32" fn GetConsoleOutputCP() callconv(WINAPI) UINT;
 


### PR DESCRIPTION
# Rationale and changes

- Newer versions of Windows added VT seq support not only in Windows Terminal, but also in the old-fashioned Windows Console (standalone conhost.exe), though not enabled by default.
- Try setting the newer console mode flags provides better experience for Windows Console users.
- lib/std/os/windows/kernel32: add signature for SetConsoleMode
  - From lib/libc/include/any-windows-any/wincon.h#L235
  - See also https://learn.microsoft.com/en-us/windows/console/setconsolemode
  - Also add DISABLE_NEWLINE_AUTO_RETURN constant which will be used by SetConsoleMode in lib/std/os/windows.
- More detailed explanations in code comments.

# Examples from [BiscuitTin/zig-term-colors](https://github.com/BiscuitTin/zig-term-colors)

For Windows 10 Enterprise LTSC 2019, the app works as expected in Windows Console. Zig std library checks for (and enables) VT seq support during runtime.
![WinEnt2019](https://github.com/ziglang/zig/assets/8013154/324b9a2b-b655-4ea7-a003-9a18c0b954a3)

For Windows 10 Enterprise LTSB 2015, Zig std library behaves just like before, no VT seq outputted at runtime.
![WinEnt2015](https://github.com/ziglang/zig/assets/8013154/de4b5e0c-205a-4236-8423-d3eb146cbd1e)

For Windows 10 Enterprise LTSC 2016, things are a bit more complicated. cmd.exe just works like later Windows versions, but Windows PowerShell 5.1.14393.0 contains a [bug](https://github.com/PowerShell/PowerShell/pull/2991), accidentally enabling VT seq support for all applications invoked inside it.
![WinEnt2016](https://github.com/ziglang/zig/assets/8013154/15988a65-bc96-409a-9121-68698bd155f2)

For all other (newer) Windows versions currently Microsoft supports, Windows Console behaves the same as Windows 10 Enterprise LTSC 2019, but Windows Terminal is also available, makes it pointless to guide the user opening Windows Console.