### PR TITLE
parser: fix "else" followed by "comptime"

### DIFF
--- a/lib/std/zig/Parse.zig
+++ b/lib/std/zig/Parse.zig
@@ -956,7 +956,14 @@ fn expectStatement(p: *Parse, allow_defer_var: bool) Error!Node.Index {
         } else {
             const assign = try p.expectAssignExpr();
             try p.expectSemicolon(.expected_semi_after_stmt, true);
-            return assign;
+            return p.addNode(.{
+                .tag = .@"comptime",
+                .main_token = comptime_token,
+                .data = .{
+                    .lhs = assign,
+                    .rhs = undefined,
+                },
+            });
         }
     }
 

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -4376,6 +4376,21 @@ test "zig fmt: invalid doc comments on comptime and test blocks" {
     });
 }
 
+test "zig fmt: else comptime expr" {
+    try testCanonical(
+        \\comptime {
+        \\    if (true) {} else comptime foo();
+        \\}
+        \\comptime {
+        \\    while (true) {} else comptime foo();
+        \\}
+        \\comptime {
+        \\    for ("") |_| {} else comptime foo();
+        \\}
+        \\
+    );
+}
+
 test "zig fmt: invalid else branch statement" {
     try testError(
         \\comptime {


### PR DESCRIPTION
Currently, `zig fmt` deletes `comptime` keyword from code like this:
```zig
if (true) {} else comptime foo();
```
This is also true for `else` after `while` and `for`. The problem lies not in rendering, but in parsing the Zig source file.

This wrong behaviour was introduced in #17156, file: `Parse.zig`. @mlugg

I added a test in `parser_test.zig`, it currently fails on the master branch.

Closes #18656.