### PR TITLE
coff: only store PDB basename

### DIFF
--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -184,9 +184,10 @@ pub fn linkWithLLD(self: *Coff, arena: Allocator, prog_node: *std.Progress.Node)
             const out_pdb = self.pdb_out_path orelse try allocPrint(arena, "{s}.pdb", .{
                 full_out_path[0 .. full_out_path.len - out_ext.len],
             });
+            const out_pdb_basename = std.fs.path.basename(out_pdb);
 
             try argv.append(try allocPrint(arena, "-PDB:{s}", .{out_pdb}));
-            try argv.append(try allocPrint(arena, "-PDBALTPATH:{s}", .{out_pdb}));
+            try argv.append(try allocPrint(arena, "-PDBALTPATH:{s}", .{out_pdb_basename}));
         }
         if (comp.version) |version| {
             try argv.append(try allocPrint(arena, "-VERSION:{}.{}", .{ version.major, version.minor }));


### PR DESCRIPTION
Moves towards reproducible builds on Windows and makes stack traces independent of cwd and zig-cache.
Helps #12729, but doesn't solve paths in the PDB.