### PR TITLE
zig build: replace src_path with LazyPath for install functions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -72,8 +72,8 @@ pub fn build(b: *std.Build) !void {
     }
 
     if (flat) {
-        b.installFile("LICENSE", "LICENSE");
-        b.installFile("README.md", "README.md");
+        b.installFile(.{ .path = "LICENSE" }, "LICENSE");
+        b.installFile(.{ .path = "README.md" }, "README.md");
     }
 
     const langref_step = b.step("langref", "Build and install the language reference");

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1472,8 +1472,8 @@ pub fn addInstallArtifact(
 }
 
 ///`dest_rel_path` is relative to prefix path
-pub fn installFile(self: *Build, src_path: []const u8, dest_rel_path: []const u8) void {
-    self.getInstallStep().dependOn(&self.addInstallFileWithDir(.{ .path = src_path }, .prefix, dest_rel_path).step);
+pub fn installFile(self: *Build, source: LazyPath, dest_rel_path: []const u8) void {
+    self.getInstallStep().dependOn(&self.addInstallFileWithDir(source.dupe(self), .prefix, dest_rel_path).step);
 }
 
 pub fn installDirectory(self: *Build, options: Step.InstallDir.Options) void {
@@ -1481,13 +1481,13 @@ pub fn installDirectory(self: *Build, options: Step.InstallDir.Options) void {
 }
 
 ///`dest_rel_path` is relative to bin path
-pub fn installBinFile(self: *Build, src_path: []const u8, dest_rel_path: []const u8) void {
-    self.getInstallStep().dependOn(&self.addInstallFileWithDir(.{ .path = src_path }, .bin, dest_rel_path).step);
+pub fn installBinFile(self: *Build, source: LazyPath, dest_rel_path: []const u8) void {
+    self.getInstallStep().dependOn(&self.addInstallFileWithDir(source.dupe(self), .bin, dest_rel_path).step);
 }
 
 ///`dest_rel_path` is relative to lib path
-pub fn installLibFile(self: *Build, src_path: []const u8, dest_rel_path: []const u8) void {
-    self.getInstallStep().dependOn(&self.addInstallFileWithDir(.{ .path = src_path }, .lib, dest_rel_path).step);
+pub fn installLibFile(self: *Build, source: LazyPath, dest_rel_path: []const u8) void {
+    self.getInstallStep().dependOn(&self.addInstallFileWithDir(source.dupe(self), .lib, dest_rel_path).step);
 }
 
 pub fn addObjCopy(b: *Build, source: LazyPath, options: Step.ObjCopy.Options) *Step.ObjCopy {
@@ -1509,8 +1509,8 @@ pub fn addInstallLibFile(self: *Build, source: LazyPath, dest_rel_path: []const 
     return self.addInstallFileWithDir(source.dupe(self), .lib, dest_rel_path);
 }
 
-pub fn addInstallHeaderFile(b: *Build, src_path: []const u8, dest_rel_path: []const u8) *Step.InstallFile {
-    return b.addInstallFileWithDir(.{ .path = src_path }, .header, dest_rel_path);
+pub fn addInstallHeaderFile(b: *Build, source: LazyPath, dest_rel_path: []const u8) *Step.InstallFile {
+    return b.addInstallFileWithDir(source.dupe(b), .header, dest_rel_path);
 }
 
 pub fn addInstallFileWithDir(

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -377,9 +377,9 @@ pub fn create(owner: *std.Build, options: Options) *Compile {
     return self;
 }
 
-pub fn installHeader(cs: *Compile, src_path: []const u8, dest_rel_path: []const u8) void {
+pub fn installHeader(cs: *Compile, source: LazyPath, dest_rel_path: []const u8) void {
     const b = cs.step.owner;
-    const install_file = b.addInstallHeaderFile(src_path, dest_rel_path);
+    const install_file = b.addInstallHeaderFile(source, dest_rel_path);
     b.getInstallStep().dependOn(&install_file.step);
     cs.installed_headers.append(&install_file.step) catch @panic("OOM");
 }


### PR DESCRIPTION
Most install related functions in the build system use LazyPaths. This replaces the few remaining src_path uses with LazyPath for consistency.

This is motivated by a workaround I used in Ziglua: https://github.com/natecraddock/ziglua/blob/db29119d23f1c540fe2b9656001eb53f522ccd0b/build.zig#L199-L214

I use the package manager for the Lua source code rather than vendoring it, so I need to use a `dependency.path()` to access the header files. The current `installHeader()` function only accepts a string path, so I wrote my own `installHeader()` using `b.addInstallFileWithDir` so I could use the LazyPath from the dependency.

I also changed the other install related functions because most of the existing Build.zig install functions already use a LazyPath for the source. I think this is a reasonable change to include.