### PR TITLE
std.Thread: fix off-by-one in PosixThreadImpl

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -674,11 +674,6 @@ const PosixThreadImpl = struct {
 
         const Instance = struct {
             fn entryFn(raw_arg: ?*anyopaque) callconv(.C) ?*anyopaque {
-                // @alignCast() below doesn't support zero-sized-types (ZST)
-                if (@sizeOf(Args) < 1) {
-                    return callFn(f, @as(Args, undefined));
-                }
-
                 const args_ptr: *Args = @ptrCast(@alignCast(raw_arg));
                 defer allocator.destroy(args_ptr);
                 return callFn(f, args_ptr.*);
@@ -703,7 +698,7 @@ const PosixThreadImpl = struct {
             &handle,
             &attr,
             Instance.entryFn,
-            if (@sizeOf(Args) > 0) @as(*anyopaque, @ptrCast(args_ptr)) else undefined,
+            @ptrCast(args_ptr),
         )) {
             .SUCCESS => return Impl{ .handle = handle },
             .AGAIN => return error.SystemResources,

--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -703,7 +703,7 @@ const PosixThreadImpl = struct {
             &handle,
             &attr,
             Instance.entryFn,
-            if (@sizeOf(Args) > 1) @as(*anyopaque, @ptrCast(args_ptr)) else undefined,
+            if (@sizeOf(Args) > 0) @as(*anyopaque, @ptrCast(args_ptr)) else undefined,
         )) {
             .SUCCESS => return Impl{ .handle = handle },
             .AGAIN => return error.SystemResources,


### PR DESCRIPTION
The current implementation of POSIX threads contains an off-by-one error, causing arguments that are exactly 1 byte in size to result in a segmentation fault.

Fixes #17774.