### PR TITLE
fix(std.mem): add assertion for using correct direction in std.mem copy functions

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -194,6 +194,7 @@ test "Allocator.resize" {
 /// dest.len must be >= source.len.
 /// If the slices overlap, dest.ptr must be <= src.ptr.
 pub fn copyForwards(comptime T: type, dest: []T, source: []const T) void {
+    assert(@intFromPtr(dest.ptr) <= @intFromPtr(source.ptr));
     for (dest[0..source.len], source) |*d, s| d.* = s;
 }
 
@@ -205,6 +206,7 @@ pub fn copyBackwards(comptime T: type, dest: []T, source: []const T) void {
     // and turning off runtime safety, the compiler should detect loops like
     // this and automatically omit safety checks for loops
     @setRuntimeSafety(false);
+    assert(@intFromPtr(dest.ptr) >= @intFromPtr(source.ptr));
     assert(dest.len >= source.len);
     var i = source.len;
     while (i > 0) {


### PR DESCRIPTION
Fixes #2970

This missing assert cost me 30min of debugging. Now your are instantly told if you use the incorrect copy direction.

First time contributing; Do I need to/can I write a test that tests an assertion failure?

Tested manually in my current project, where the assertion triggers in my incorrect code.