### PR TITLE
Sema: fix crash when casting runtime value to enum with comptime int tag type

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -8657,6 +8657,12 @@ fn zirEnumFromInt(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
         return Air.internedToRef((try mod.getCoerced(int_val, dest_ty)).toIntern());
     }
 
+    if (dest_ty.intTagType(mod).zigTypeTag(mod) == .ComptimeInt) {
+        return sema.failWithNeededComptime(block, operand_src, .{
+            .needed_comptime_reason = "value being casted to enum with 'comptime_int' tag type must be comptime-known",
+        });
+    }
+
     if (try sema.typeHasOnePossibleValue(dest_ty)) |opv| {
         const result = Air.internedToRef(opv.toIntern());
         // The operand is runtime-known but the result is comptime-known. In

--- a/test/cases/compile_errors/enum_backed_by_comptime_int_must_be_casted_from_comptime_value.zig
+++ b/test/cases/compile_errors/enum_backed_by_comptime_int_must_be_casted_from_comptime_value.zig
@@ -1,0 +1,14 @@
+export fn entry() void {
+    const Tag = enum(comptime_int) { a, b };
+
+    var v: u32 = 0;
+    _ = &v;
+    _ = @as(Tag, @enumFromInt(v));
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :6:31: error: unable to resolve comptime value
+// :6:31: note: value being casted to enum with 'comptime_int' tag type must be comptime-known


### PR DESCRIPTION
While investigating #17570, I encountered that such code will crash the compiler:
```zig
export fn entry() void {
    const Tag = enum(comptime_int) { a, b };

    var v: u32 = 0;
    _ = &v;
    _ = @as(Tag, @enumFromInt(v));
}
```

This is a bug in `Sema.zig`, during the evaluation of `@enumFromInt`, the case when the enum tag type is `comptime_int` is not handled. This seems to have been present since 0.10.0.

I added a test case under `test/cases/compile_errors`.