### PR TITLE
Added comment about misleading return value of submit(), when used with sq_poll

### DIFF
--- a/lib/std/os/linux/io_uring.zig
+++ b/lib/std/os/linux/io_uring.zig
@@ -144,7 +144,10 @@ pub const IO_Uring = struct {
 
     /// Submits the SQEs acquired via get_sqe() to the kernel. You can call this once after you have
     /// called get_sqe() multiple times to setup multiple I/O requests.
-    /// Returns the number of SQEs submitted.
+    /// Returns the number of SQEs submitted, if not used alongside IORING_SETUP_SQPOLL.
+    /// If the io_uring instance is uses IORING_SETUP_SQPOLL, the value returned on success is not
+    /// guaranteed to match the amount of actually submitted sqes during this call. A value higher
+    /// or lower, including 0, may be returned.
     /// Matches the implementation of io_uring_submit() in liburing.
     pub fn submit(self: *IO_Uring) !u32 {
         return self.submit_and_wait(0);


### PR DESCRIPTION
The return value of submit() does not actually accurately report the amount of submitted sqes, when using sq_poll. ([see])(https://github.com/axboe/liburing/issues/88)
One can also see this in the zig implementation of liburing in sq_flush() / sq_ready. The kernel sq poll thread may modify the sq.head value "before" the atomic load in sq_ready, which e.g. could result in a return value of 0 after a successful submission of a single sqe.
In my opinion this is a pretty big footgun, when using sq polling in general and especially when preparing more then one sqe before a call to submit. The later case is arguably not actually usable, as the only thing that one does know if submit successfully returns is that one or more requests made it successfully. In this case it is e.g. both possible that all sqes have actually been submitted or that only a single one has been successfully submitted and an error occurred for the rest. Without sq polling this is not an issue, as one can rely on the return value and thus know if one should e.g. call submit again or if one ends up calling submit() multiple times and runs into an error on the last call, which sqe it actually is that caused the error.

Example:
1. call .read() 5 times
2. call .submit()
3. return value == 1
4. call .submit() 
5. return value == 0
6. call .submit()
7. return value == some_error

Which read failed and must be handled and what other reads made it through? As far as I understand it could be any of the reads besides the first 2.
Also one can not actually know if one should call submit again after 3. and if one calls submit again and again until the accumulated return value is 5 one can get stuck in an infinite loop.

In practice I have been dealing with this, via falling back to submitting requests one by one when using sq_poll.

As I said I think this is a pretty big footgun and in my opinion should at least be mentioned in a comment. One could also maybe change the return type of submit to encode this. E.g. returning smth. like

`pub const SubmitReturn union(SQPollConfig) { 
   no_sq_poll: u32,
   using_sq_poll: void,
};`

Or have another version of submit that should be used when the instances uses sq_poll.