### PR TITLE
Sema: fix union init with zero size field

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4624,6 +4624,8 @@ fn validateUnionInit(
     // If the union is comptime, we want `first_block_index`
     // to point at %c so that the bitcast becomes the last instruction in the block.
     //
+    // Store instruction may be missing; if field type has only one possible value, this case is handled below.
+    //
     // In the case of a comptime-known pointer to a union, the
     // the field_ptr instruction is missing, so we have to pattern-match
     // based only on the store instructions.
@@ -4634,6 +4636,10 @@ fn validateUnionInit(
     var init_val: ?Value = null;
     while (block_index > 0) : (block_index -= 1) {
         const store_inst = block.instructions.items[block_index];
+        if (store_inst.toRef() == field_ptr_ref) {
+            first_block_index = block_index;
+            break;
+        }
         if (store_inst.toRef() == field_ptr_ref) break;
         switch (air_tags[@intFromEnum(store_inst)]) {
             .store, .store_safe => {},
@@ -4659,6 +4665,11 @@ fn validateUnionInit(
 
     const tag_ty = union_ty.unionTagTypeHypothetical(mod);
     const tag_val = try mod.enumValueFieldIndex(tag_ty, field_index);
+    const field_type = union_ty.unionFieldType(tag_val, mod).?;
+
+    if (try sema.typeHasOnePossibleValue(field_type)) |field_only_value| {
+        init_val = field_only_value;
+    }
 
     if (init_val) |val| {
         // Our task is to delete all the `field_ptr` and `store` instructions, and insert

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4640,7 +4640,6 @@ fn validateUnionInit(
             first_block_index = block_index;
             break;
         }
-        if (store_inst.toRef() == field_ptr_ref) break;
         switch (air_tags[@intFromEnum(store_inst)]) {
             .store, .store_safe => {},
             else => continue,

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -381,6 +381,26 @@ test "union with only 1 field which is void should be zero bits" {
     comptime assert(@sizeOf(ZeroBits) == 0);
 }
 
+test "assigning to union with zero size field" {
+    const U = union {
+        a: u32,
+        b: void,
+        c: f32,
+    };
+
+    const u: U = .{ .b = {} };
+    _ = u;
+
+    const UE = union(enum) {
+        a: f32,
+        b: u32,
+        c: u0,
+    };
+
+    const ue: UE = .{ .c = 0 };
+    _ = ue;
+}
+
 test "tagged union initialization with runtime void" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/18732.

###  Problem

During `validateUnionInit` in `Sema.zig`, when trying to determine if a union is comptime known, the `store` AIR instruction is being searched for. However, it will not be emitted if storing is done of zero sized type.
Because the `set_union_tag` AIR instruction is compile-time known, it will be saved in the comptime alloc map, but the `resolveComptimeKnownAllocValue` function has logic for a simple case which will be hit because we have only one store for this union (its tag), but there will be a type mismatch causing the assertion described in the issue, I linked.


There are 2 solutions:
- Convert the `assert` to an if statement, branching out of the simple case.
- Change `validateUnionInit` to handle the case when `store` instruction is _not_ present.

I chose the latter one, because it will emit smaller AIR due to the deletion of the `struct_field_ptr` instructions, that is done in `validateUnionInit`.

I added test case in `behavior/union.zig`
