### PR TITLE
std.os.windows: add compileError warning against `TCHAR` & their corresponding string/pointer types

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2868,6 +2868,12 @@ pub const LRESULT = LONG_PTR;
 
 pub const va_list = *opaque {};
 
+pub const TCHAR = @compileError("Deprecated: choose between `CHAR` or `WCHAR` directly");
+pub const LPTSTR = @compileError("Deprecated: choose between `LPSTR` or `LPWSTR` directly");
+pub const LPCTSTR = @compileError("Deprecated: choose between `LPCSTR` or `LPCWSTR` directly");
+pub const PTSTR = @compileError("Deprecated: choose between `PSTR` or `PWSTR` directly");
+pub const PCTSTR = @compileError("Deprecated: choose between `PCSTR` or `PCWSTR` directly");
+
 pub const TRUE = 1;
 pub const FALSE = 0;
 

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2868,11 +2868,11 @@ pub const LRESULT = LONG_PTR;
 
 pub const va_list = *opaque {};
 
-pub const TCHAR = @compileError("Deprecated: choose between `CHAR` or `WCHAR` directly");
-pub const LPTSTR = @compileError("Deprecated: choose between `LPSTR` or `LPWSTR` directly");
-pub const LPCTSTR = @compileError("Deprecated: choose between `LPCSTR` or `LPCWSTR` directly");
-pub const PTSTR = @compileError("Deprecated: choose between `PSTR` or `PWSTR` directly");
-pub const PCTSTR = @compileError("Deprecated: choose between `PCSTR` or `PCWSTR` directly");
+pub const TCHAR = @compileError("Deprecated: choose between `CHAR` or `WCHAR` directly instead.");
+pub const LPTSTR = @compileError("Deprecated: choose between `LPSTR` or `LPWSTR` directly instead.");
+pub const LPCTSTR = @compileError("Deprecated: choose between `LPCSTR` or `LPCWSTR` directly instead.");
+pub const PTSTR = @compileError("Deprecated: choose between `PSTR` or `PWSTR` directly instead.");
+pub const PCTSTR = @compileError("Deprecated: choose between `PCSTR` or `PCWSTR` directly instead.");
 
 pub const TRUE = 1;
 pub const FALSE = 0;


### PR DESCRIPTION
According to WinAPI docs, `TCHAR` and their corresponding string typedefs are aliases for either 8-bit `CHAR` or 16-bit `WCHAR` based on a global compilation switch `UNICODE` in the macro, which also globally changes whether -A or -W functions are used.

In Zig we explicitly choose which version of the functions to use and their corresponding types. This means that references to those macro-dependent types are fundamentally incompatible, and they are rightly absent from `std.os.windows`.

However, their absence per se does not convey the intent of a forbidding _exclusion_, instead it can potentially be misinterpreted as an overlooked _omission_, especially considering that looking through the MSDN documentation and all their typedefs can be overwhelming unless one already has sufficient familiarity.

By defining them in a compileError accompanied by a didactic hint, it serves a dual purpose of signalling that this was not overlooked and their exclusions are deliberate, as well as opportunistically teaching coders of this quirk of the macro switch. 