### PR TITLE
Use mem.zeroes for empty union initializer list

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -2505,6 +2505,11 @@ fn transInitListExprRecord(
     var field_inits = std.ArrayList(ast.Payload.ContainerInit.Initializer).init(c.gpa);
     defer field_inits.deinit();
 
+    if (init_count == 0) {
+        const source_loc = @as(*const clang.Expr, @ptrCast(expr)).getBeginLoc();
+        return transZeroInitExpr(c, scope, source_loc, ty);
+    }
+
     var init_i: c_uint = 0;
     var it = record_def.field_begin();
     const end_it = record_def.field_end();

--- a/test/cases/translate_c/empty union initializer list.c
+++ b/test/cases/translate_c/empty union initializer list.c
@@ -1,0 +1,20 @@
+union U {
+    int x;
+    long y;
+};
+
+void foo(void) {
+    union U u = {};
+}
+// translate-c
+// target=x86_64-linux
+// c_frontend=clang
+//
+// pub const union_U = extern union {
+//     x: c_int,
+//     y: c_long,
+// };
+// pub export fn foo() void {
+//     var u: union_U = @import("std").mem.zeroes(union_U);
+//     _ = &u;
+// }

--- a/test/cases/translate_c/static empty struct.c
+++ b/test/cases/translate_c/static empty struct.c
@@ -11,7 +11,7 @@ static inline void foo() {
 // pub const struct_empty_struct = extern struct {};
 // pub fn foo() callconv(.C) void {
 //     const bar = struct {
-//         var static: struct_empty_struct = struct_empty_struct{};
+//         var static: struct_empty_struct = @import("std").mem.zeroes(struct_empty_struct);
 //     };
 //     _ = &bar;
 // }


### PR DESCRIPTION
resolve #12658
Empty union initializer list is allowed since C23, but gcc and clang allow it to compile in non pedantic code as zero initialized.

Added a condition in transInitListExprRecord to call transZeroInitExpr when the number of initialization expressions is zero.
Also added as a test case for translate_c the example from the bug report.