### PR TITLE
Sema: fix comptime struct{}/union{} pass extern check

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -2700,6 +2700,12 @@ pub const Type = struct {
                         try sema.resolveTypeFieldsUnion(ty, union_type);
 
                         const union_obj = ip.loadUnionType(union_type);
+
+                        if (try Type.fromInterned(union_obj.enum_tag_ty).comptimeOnlyAdvanced(mod, opt_sema)) {
+                            union_obj.flagsPtr(ip).requires_comptime = .yes;
+                            return true;
+                        }
+
                         for (0..union_obj.field_types.len) |field_idx| {
                             const field_ty = union_obj.field_types.get(ip)[field_idx];
                             if (try Type.fromInterned(field_ty).comptimeOnlyAdvanced(mod, opt_sema)) {

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -727,8 +727,7 @@ test "union with only 1 field casted to its enum type which has enum value speci
         Literal: Literal,
     };
 
-    var e = Expr{ .Literal = Literal{ .Bool = true } };
-    _ = &e;
+    const e = Expr{ .Literal = Literal{ .Bool = true } };
     comptime assert(Tag(ExprTag) == comptime_int);
     const t = comptime @as(ExprTag, e);
     try expect(t == Expr.Literal);

--- a/test/cases/compile_errors/C_pointer_pointing_to_non_C_ABI_compatible_type_or_has_align_attr.zig
+++ b/test/cases/compile_errors/C_pointer_pointing_to_non_C_ABI_compatible_type_or_has_align_attr.zig
@@ -10,5 +10,5 @@ export fn a() void {
 // target=native
 //
 // :3:19: error: C pointers cannot point to non-C-ABI-compatible type 'tmp.Foo'
-// :3:19: note: only extern structs and ABI sized packed structs are extern compatible
+// :3:19: note: only empty struct without comptime dependency are extern compatible
 // :1:13: note: struct declared here

--- a/test/cases/compile_errors/C_pointer_pointing_to_non_C_ABI_compatible_type_or_has_align_attr.zig
+++ b/test/cases/compile_errors/C_pointer_pointing_to_non_C_ABI_compatible_type_or_has_align_attr.zig
@@ -10,5 +10,5 @@ export fn a() void {
 // target=native
 //
 // :3:19: error: C pointers cannot point to non-C-ABI-compatible type 'tmp.Foo'
-// :3:19: note: only empty struct without comptime dependency are extern compatible
+// :3:19: note: only extern structs, ABI sized packed structs and empty structs are extern compatible
 // :1:13: note: struct declared here

--- a/test/cases/compile_errors/extern_packed_struct_union_size_error.zig
+++ b/test/cases/compile_errors/extern_packed_struct_union_size_error.zig
@@ -1,0 +1,20 @@
+const PU = packed union { a: u33, b: u32 };
+export fn entry1(v: PU) void {
+    _ = v;
+}
+
+const PS = packed struct { a: u33, b: u32 };
+export fn entry2(v: PS) void {
+    _ = v;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:18: error: parameter of type 'tmp.PU' not allowed in function with calling convention 'C'
+// :2:18: note: only 0, 8, 16, 32, 64 and 128 bits sized packed unions are extern compatible
+// :1:19: note: union declared here
+// :7:18: error: parameter of type 'tmp.PS' not allowed in function with calling convention 'C'
+// :7:18: note: only 0, 8, 16, 32, 64 and 128 bits sized packed structs are extern compatible
+// :6:19: note: struct declared here

--- a/test/cases/compile_errors/extern_packed_struct_union_size_error.zig
+++ b/test/cases/compile_errors/extern_packed_struct_union_size_error.zig
@@ -13,8 +13,8 @@ export fn entry2(v: PS) void {
 // target=native
 //
 // :2:18: error: parameter of type 'tmp.PU' not allowed in function with calling convention 'C'
-// :2:18: note: only 0, 8, 16, 32, 64 and 128 bits sized packed unions are extern compatible
+// :2:18: note: only extern unions, ABI sized packed unions and empty unions are extern compatible
 // :1:19: note: union declared here
 // :7:18: error: parameter of type 'tmp.PS' not allowed in function with calling convention 'C'
-// :7:18: note: only 0, 8, 16, 32, 64 and 128 bits sized packed structs are extern compatible
+// :7:18: note: only extern structs, ABI sized packed structs and empty structs are extern compatible
 // :6:19: note: struct declared here

--- a/test/cases/compile_errors/extern_type_must_not_require_comptime.zig
+++ b/test/cases/compile_errors/extern_type_must_not_require_comptime.zig
@@ -1,0 +1,28 @@
+const UE = union(enum(comptime_int)) { a, b };
+export fn entry1(v: UE) void {
+    _ = v;
+}
+
+const U = union { a: comptime_int, b: void };
+export fn entry2(v: U) void {
+    _ = v;
+}
+
+const S = struct { a: comptime_int, b: void };
+export fn entry3(v: S) void {
+    _ = v;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:18: error: parameter of type 'tmp.UE' not allowed in function with calling convention 'C'
+// :2:18: note: only empty union without comptime dependency are extern compatible
+// :1:14: note: union declared here
+// :7:18: error: parameter of type 'tmp.U' not allowed in function with calling convention 'C'
+// :7:18: note: only empty union without comptime dependency are extern compatible
+// :6:14: note: union declared here
+// :12:18: error: parameter of type 'tmp.S' not allowed in function with calling convention 'C'
+// :12:18: note: only empty struct without comptime dependency are extern compatible
+// :11:14: note: struct declared here

--- a/test/cases/compile_errors/extern_type_must_not_require_comptime.zig
+++ b/test/cases/compile_errors/extern_type_must_not_require_comptime.zig
@@ -18,11 +18,17 @@ export fn entry3(v: S) void {
 // target=native
 //
 // :2:18: error: parameter of type 'tmp.UE' not allowed in function with calling convention 'C'
-// :2:18: note: only empty union without comptime dependency are extern compatible
+// :2:18: note: only extern unions, ABI sized packed unions and empty unions are extern compatible
+// :2:18: note: extern compatible unions cannot have comptime dependency
+// :1:12: note: union requires comptime because of its tag
 // :1:12: note: union declared here
 // :7:18: error: parameter of type 'tmp.U' not allowed in function with calling convention 'C'
-// :7:18: note: only empty union without comptime dependency are extern compatible
+// :7:18: note: only extern unions, ABI sized packed unions and empty unions are extern compatible
+// :7:18: note: extern compatible unions cannot have comptime dependency
+// :6:22: note: union requires comptime because of this field
 // :6:11: note: union declared here
 // :12:18: error: parameter of type 'tmp.S' not allowed in function with calling convention 'C'
-// :12:18: note: only empty struct without comptime dependency are extern compatible
+// :12:18: note: only extern structs, ABI sized packed structs and empty structs are extern compatible
+// :12:18: note: extern compatible structs cannot have comptime dependency
+// :11:23: note: struct requires comptime because of this field
 // :11:11: note: struct declared here

--- a/test/cases/compile_errors/extern_type_must_not_require_comptime.zig
+++ b/test/cases/compile_errors/extern_type_must_not_require_comptime.zig
@@ -19,10 +19,10 @@ export fn entry3(v: S) void {
 //
 // :2:18: error: parameter of type 'tmp.UE' not allowed in function with calling convention 'C'
 // :2:18: note: only empty union without comptime dependency are extern compatible
-// :1:14: note: union declared here
+// :1:12: note: union declared here
 // :7:18: error: parameter of type 'tmp.U' not allowed in function with calling convention 'C'
 // :7:18: note: only empty union without comptime dependency are extern compatible
-// :6:14: note: union declared here
+// :6:11: note: union declared here
 // :12:18: error: parameter of type 'tmp.S' not allowed in function with calling convention 'C'
 // :12:18: note: only empty struct without comptime dependency are extern compatible
-// :11:14: note: struct declared here
+// :11:11: note: struct declared here

--- a/test/cases/compile_errors/function_with_non-extern_non-packed_struct_parameter.zig
+++ b/test/cases/compile_errors/function_with_non-extern_non-packed_struct_parameter.zig
@@ -12,5 +12,5 @@ export fn entry(foo: Foo) void {
 // target=native
 //
 // :6:17: error: parameter of type 'tmp.Foo' not allowed in function with calling convention 'C'
-// :6:17: note: only extern structs and ABI sized packed structs are extern compatible
+// :6:17: note: only empty struct without comptime dependency are extern compatible
 // :1:13: note: struct declared here

--- a/test/cases/compile_errors/function_with_non-extern_non-packed_struct_parameter.zig
+++ b/test/cases/compile_errors/function_with_non-extern_non-packed_struct_parameter.zig
@@ -12,5 +12,5 @@ export fn entry(foo: Foo) void {
 // target=native
 //
 // :6:17: error: parameter of type 'tmp.Foo' not allowed in function with calling convention 'C'
-// :6:17: note: only empty struct without comptime dependency are extern compatible
+// :6:17: note: only extern structs, ABI sized packed structs and empty structs are extern compatible
 // :1:13: note: struct declared here

--- a/test/cases/compile_errors/function_with_non-extern_non-packed_union_parameter.zig
+++ b/test/cases/compile_errors/function_with_non-extern_non-packed_union_parameter.zig
@@ -12,5 +12,5 @@ export fn entry(foo: Foo) void {
 // target=native
 //
 // :6:17: error: parameter of type 'tmp.Foo' not allowed in function with calling convention 'C'
-// :6:17: note: only extern unions and ABI sized packed unions are extern compatible
+// :6:17: note: only empty union without comptime dependency are extern compatible
 // :1:13: note: union declared here

--- a/test/cases/compile_errors/function_with_non-extern_non-packed_union_parameter.zig
+++ b/test/cases/compile_errors/function_with_non-extern_non-packed_union_parameter.zig
@@ -12,5 +12,5 @@ export fn entry(foo: Foo) void {
 // target=native
 //
 // :6:17: error: parameter of type 'tmp.Foo' not allowed in function with calling convention 'C'
-// :6:17: note: only empty union without comptime dependency are extern compatible
+// :6:17: note: only extern unions, ABI sized packed unions and empty unions are extern compatible
 // :1:13: note: union declared here

--- a/test/cases/compile_errors/union_enum_with_comptime_int_tag_must_be_comptime.zig
+++ b/test/cases/compile_errors/union_enum_with_comptime_int_tag_must_be_comptime.zig
@@ -1,0 +1,12 @@
+export fn entry() void {
+    const UE = union(enum(comptime_int)) { a: f32, b: i32, c: void };
+    var ue: UE = .{ .b = 1 };
+    _ = &ue;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:13: error: variable of type 'tmp.entry.UE' must be const or comptime
+// :2:16: note: union requires comptime because of its tag


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/17570.
Note that the issue above was a regression introduced by https://github.com/ziglang/zig/pull/16404.

Main fix: checking empty unions and structs for comptime during the extern validation. I slightly changed the error message for that case.

I also fixed `comptimeOnly` to return `true` for `union(enum(comptime_int))`. 

Tests was added under `cases/compile_errors`.
