### PR TITLE
std.Build: take root module as a parameter when creating compile steps

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -638,11 +638,28 @@ pub const ExecutableOptions = struct {
     /// if the target object format does not support embedded manifests.
     win32_manifest: ?LazyPath = null,
 };
+pub const ExecutableOptions2 = struct {
+    name: []const u8,
+    root_module: *Module,
+    version: ?std.SemanticVersion = null,
+    linkage: ?Step.Compile.Linkage = null,
+    max_rss: usize = 0,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
+    zig_lib_dir: ?LazyPath = null,
+    /// Embed a `.manifest` file in the compilation if the object format supports it.
+    /// https://learn.microsoft.com/en-us/windows/win32/sbscs/manifest-files-reference
+    /// Manifest files must have the extension `.manifest`.
+    /// Can be set regardless of target. The `.manifest` file will be ignored
+    /// if the target object format does not support embedded manifests.
+    win32_manifest: ?LazyPath = null,
+};
 
+/// Deprecated; see `addExecutable2`.
 pub fn addExecutable(b: *Build, options: ExecutableOptions) *Step.Compile {
-    return Step.Compile.create(b, .{
+    return b.addExecutable2(.{
         .name = options.name,
-        .root_module = .{
+        .root_module = b.createModule(.{
             .root_source_file = options.root_source_file,
             .target = options.target,
             .optimize = options.optimize,
@@ -655,7 +672,20 @@ pub fn addExecutable(b: *Build, options: ExecutableOptions) *Step.Compile {
             .sanitize_thread = options.sanitize_thread,
             .error_tracing = options.error_tracing,
             .code_model = options.code_model,
-        },
+        }),
+        .version = options.version,
+        .linkage = options.linkage,
+        .max_rss = options.max_rss,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
+        .zig_lib_dir = options.zig_lib_dir,
+        .win32_manifest = options.win32_manifest,
+    });
+}
+pub fn addExecutable2(b: *Build, options: ExecutableOptions2) *Step.Compile {
+    return Step.Compile.create(b, .{
+        .name = options.name,
+        .root_module = options.root_module,
         .version = options.version,
         .kind = .exe,
         .linkage = options.linkage,
@@ -688,11 +718,20 @@ pub const ObjectOptions = struct {
     use_lld: ?bool = null,
     zig_lib_dir: ?LazyPath = null,
 };
+pub const ObjectOptions2 = struct {
+    name: []const u8,
+    root_module: *Module,
+    max_rss: usize = 0,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
+    zig_lib_dir: ?LazyPath = null,
+};
 
+/// Deprecated; see `addObject2`.
 pub fn addObject(b: *Build, options: ObjectOptions) *Step.Compile {
-    return Step.Compile.create(b, .{
+    return b.addObject2(.{
         .name = options.name,
-        .root_module = .{
+        .root_module = b.createModule(.{
             .root_source_file = options.root_source_file,
             .target = options.target,
             .optimize = options.optimize,
@@ -705,7 +744,17 @@ pub fn addObject(b: *Build, options: ObjectOptions) *Step.Compile {
             .sanitize_thread = options.sanitize_thread,
             .error_tracing = options.error_tracing,
             .code_model = options.code_model,
-        },
+        }),
+        .max_rss = options.max_rss,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
+        .zig_lib_dir = options.zig_lib_dir,
+    });
+}
+pub fn addObject2(b: *Build, options: ObjectOptions2) *Step.Compile {
+    return Step.Compile.create(b, .{
+        .name = options.name,
+        .root_module = options.root_module,
         .kind = .obj,
         .max_rss = options.max_rss,
         .use_llvm = options.use_llvm,
@@ -742,11 +791,27 @@ pub const SharedLibraryOptions = struct {
     /// if the target object format does not support embedded manifests.
     win32_manifest: ?LazyPath = null,
 };
+pub const SharedLibraryOptions2 = struct {
+    name: []const u8,
+    root_module: *Module,
+    version: ?std.SemanticVersion = null,
+    max_rss: usize = 0,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
+    zig_lib_dir: ?LazyPath = null,
+    /// Embed a `.manifest` file in the compilation if the object format supports it.
+    /// https://learn.microsoft.com/en-us/windows/win32/sbscs/manifest-files-reference
+    /// Manifest files must have the extension `.manifest`.
+    /// Can be set regardless of target. The `.manifest` file will be ignored
+    /// if the target object format does not support embedded manifests.
+    win32_manifest: ?LazyPath = null,
+};
 
+/// Deprecated; see `addSharedLibrary2`.
 pub fn addSharedLibrary(b: *Build, options: SharedLibraryOptions) *Step.Compile {
-    return Step.Compile.create(b, .{
+    return b.addSharedLibrary2(.{
         .name = options.name,
-        .root_module = .{
+        .root_module = b.createModule(.{
             .target = options.target,
             .optimize = options.optimize,
             .root_source_file = options.root_source_file,
@@ -759,7 +824,19 @@ pub fn addSharedLibrary(b: *Build, options: SharedLibraryOptions) *Step.Compile 
             .sanitize_thread = options.sanitize_thread,
             .error_tracing = options.error_tracing,
             .code_model = options.code_model,
-        },
+        }),
+        .version = options.version,
+        .max_rss = options.max_rss,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
+        .zig_lib_dir = options.zig_lib_dir,
+        .win32_manifest = options.win32_manifest,
+    });
+}
+pub fn addSharedLibrary2(b: *Build, options: SharedLibraryOptions2) *Step.Compile {
+    return Step.Compile.create(b, .{
+        .name = options.name,
+        .root_module = options.root_module,
         .kind = .lib,
         .linkage = .dynamic,
         .version = options.version,
@@ -793,11 +870,21 @@ pub const StaticLibraryOptions = struct {
     use_lld: ?bool = null,
     zig_lib_dir: ?LazyPath = null,
 };
+pub const StaticLibraryOptions2 = struct {
+    name: []const u8,
+    root_module: *Module,
+    version: ?std.SemanticVersion = null,
+    max_rss: usize = 0,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
+    zig_lib_dir: ?LazyPath = null,
+};
 
+/// Deprecated; see `addStaticLibrary2`.
 pub fn addStaticLibrary(b: *Build, options: StaticLibraryOptions) *Step.Compile {
-    return Step.Compile.create(b, .{
+    return b.addStaticLibrary2(.{
         .name = options.name,
-        .root_module = .{
+        .root_module = b.createModule(.{
             .target = options.target,
             .optimize = options.optimize,
             .root_source_file = options.root_source_file,
@@ -810,7 +897,18 @@ pub fn addStaticLibrary(b: *Build, options: StaticLibraryOptions) *Step.Compile 
             .sanitize_thread = options.sanitize_thread,
             .error_tracing = options.error_tracing,
             .code_model = options.code_model,
-        },
+        }),
+        .version = options.version,
+        .max_rss = options.max_rss,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
+        .zig_lib_dir = options.zig_lib_dir,
+    });
+}
+pub fn addStaticLibrary2(b: *Build, options: StaticLibraryOptions2) *Step.Compile {
+    return Step.Compile.create(b, .{
+        .name = options.name,
+        .root_module = options.root_module,
         .kind = .lib,
         .linkage = .static,
         .version = options.version,
@@ -842,12 +940,23 @@ pub const TestOptions = struct {
     use_lld: ?bool = null,
     zig_lib_dir: ?LazyPath = null,
 };
+pub const TestOptions2 = struct {
+    name: []const u8 = "test",
+    root_module: *Module,
+    version: ?std.SemanticVersion = null,
+    max_rss: usize = 0,
+    filter: ?[]const u8 = null,
+    test_runner: ?[]const u8 = null,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
+    zig_lib_dir: ?LazyPath = null,
+};
 
+/// Deprecated; see `addTest2`.
 pub fn addTest(b: *Build, options: TestOptions) *Step.Compile {
-    return Step.Compile.create(b, .{
+    return b.addTest2(.{
         .name = options.name,
-        .kind = .@"test",
-        .root_module = .{
+        .root_module = b.createModule(.{
             .root_source_file = options.root_source_file,
             .target = options.target orelse b.host,
             .optimize = options.optimize,
@@ -859,7 +968,22 @@ pub fn addTest(b: *Build, options: TestOptions) *Step.Compile {
             .omit_frame_pointer = options.omit_frame_pointer,
             .sanitize_thread = options.sanitize_thread,
             .error_tracing = options.error_tracing,
-        },
+        }),
+        .version = options.version,
+        .max_rss = options.max_rss,
+        .filter = options.filter,
+        .test_runner = options.test_runner,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
+        .zig_lib_dir = options.zig_lib_dir,
+    });
+}
+pub fn addTest2(b: *Build, options: TestOptions2) *Step.Compile {
+    return Step.Compile.create(b, .{
+        .name = options.name,
+        .root_module = options.root_module,
+        .kind = .@"test",
+        .version = options.version,
         .max_rss = options.max_rss,
         .filter = options.filter,
         .test_runner = options.test_runner,

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -92,6 +92,7 @@ pub const Id = enum {
     config_header,
     objcopy,
     options,
+    module,
     custom,
 
     pub fn Type(comptime id: Id) type {
@@ -111,6 +112,7 @@ pub const Id = enum {
             .config_header => ConfigHeader,
             .objcopy => ObjCopy,
             .options => Options,
+            .module => Module,
             .custom => @compileError("no type available for custom step"),
         };
     }
@@ -265,6 +267,7 @@ pub fn dump(step: *Step, file: std.fs.File) void {
 const Step = @This();
 const std = @import("../std.zig");
 const Build = std.Build;
+const Module = Build.Module;
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const builtin = @import("builtin");

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -216,7 +216,7 @@ pub const Entry = union(enum) {
 
 pub const Options = struct {
     name: []const u8,
-    root_module: Module.CreateOptions,
+    root_module: *Module,
     kind: Kind,
     linkage: ?Linkage = null,
     version: ?std.SemanticVersion = null,
@@ -255,7 +255,8 @@ pub fn create(owner: *std.Build, options: Options) *Compile {
     else
         owner.fmt("{s} ", .{name});
 
-    const resolved_target = options.root_module.target.?;
+    const resolved_target = options.root_module.resolved_target orelse
+        @panic("the root Module of a Compile step must be created with a known 'target' field");
     const target = resolved_target.result;
 
     const step_name = owner.fmt("{s} {s}{s} {s}", .{
@@ -287,7 +288,7 @@ pub fn create(owner: *std.Build, options: Options) *Compile {
 
     const self = owner.allocator.create(Compile) catch @panic("OOM");
     self.* = .{
-        .root_module = Module.create(owner, options.root_module),
+        .root_module = options.root_module,
         .verbose_link = false,
         .verbose_cc = false,
         .linkage = options.linkage,

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -1361,7 +1361,7 @@ fn addPathForDynLibs(self: *Run, artifact: *Step.Compile) void {
     var it = artifact.root_module.iterateDependencies(artifact, true);
     while (it.next()) |item| {
         const other = item.compile.?;
-        if (item.module == &other.root_module) {
+        if (item.module == other.root_module) {
             if (item.module.resolved_target.?.result.os.tag == .windows and
                 other.isDynamicLibrary())
             {

--- a/lib/std/Build/Step/TranslateC.zig
+++ b/lib/std/Build/Step/TranslateC.zig
@@ -87,15 +87,9 @@ pub fn addModule(self: *TranslateC, name: []const u8) *std.Build.Module {
 /// current package, but not exposed to other packages depending on this one.
 /// `addModule` can be used instead to create a public module.
 pub fn createModule(self: *TranslateC) *std.Build.Module {
-    const b = self.step.owner;
-    const module = b.allocator.create(std.Build.Module) catch @panic("OOM");
-
-    module.* = .{
-        .builder = b,
+    return self.step.owner.createModule(.{
         .root_source_file = self.getOutput(),
-        .dependencies = std.StringArrayHashMap(*std.Build.Module).init(b.allocator),
-    };
-    return module;
+    });
 }
 
 pub fn addIncludeDir(self: *TranslateC, include_dir: []const u8) void {

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -585,29 +585,27 @@ pub fn lowerToBuildSteps(
         }
         const root_source_file = writefiles.files.items[0].getPath();
 
-        const artifact = if (case.is_test) b.addTest(.{
+        const module = b.createModule(.{
             .root_source_file = root_source_file,
-            .name = case.name,
             .target = case.target,
             .optimize = case.optimize_mode,
+        });
+
+        const artifact = if (case.is_test) b.addTest2(.{
+            .name = case.name,
+            .root_module = module,
         }) else switch (case.output_mode) {
-            .Obj => b.addObject(.{
-                .root_source_file = root_source_file,
+            .Obj => b.addObject2(.{
                 .name = case.name,
-                .target = case.target,
-                .optimize = case.optimize_mode,
+                .root_module = module,
             }),
-            .Lib => b.addStaticLibrary(.{
-                .root_source_file = root_source_file,
+            .Lib => b.addStaticLibrary2(.{
                 .name = case.name,
-                .target = case.target,
-                .optimize = case.optimize_mode,
+                .root_module = module,
             }),
-            .Exe => b.addExecutable(.{
-                .root_source_file = root_source_file,
+            .Exe => b.addExecutable2(.{
                 .name = case.name,
-                .target = case.target,
-                .optimize = case.optimize_mode,
+                .root_module = module,
             }),
         };
 

--- a/test/src/StackTrace.zig
+++ b/test/src/StackTrace.zig
@@ -52,12 +52,14 @@ fn addExpect(
     }
 
     const write_src = b.addWriteFile("source.zig", source);
-    const exe = b.addExecutable(.{
+    const exe = b.addExecutable2(.{
         .name = "test",
-        .root_source_file = write_src.files.items[0].getPath(),
-        .optimize = optimize_mode,
-        .target = b.host,
-        .error_tracing = mode_config.error_tracing,
+        .root_module = b.createModule(.{
+            .root_source_file = write_src.files.items[0].getPath(),
+            .optimize = optimize_mode,
+            .target = b.host,
+            .error_tracing = mode_config.error_tracing,
+        }),
     });
 
     const run = b.addRunArtifact(exe);

--- a/test/standalone/dep_diamond/build.zig
+++ b/test/standalone/dep_diamond/build.zig
@@ -6,23 +6,29 @@ pub fn build(b: *std.Build) void {
 
     const optimize: std.builtin.OptimizeMode = .Debug;
 
-    const shared = b.createModule(.{
-        .root_source_file = .{ .path = "shared.zig" },
-    });
-
-    const exe = b.addExecutable(.{
-        .name = "test",
+    const main = b.createModule(.{
         .root_source_file = .{ .path = "test.zig" },
         .target = b.host,
         .optimize = optimize,
     });
-    exe.root_module.addAnonymousImport("foo", .{
+    const foo = b.createModule(.{
         .root_source_file = .{ .path = "foo.zig" },
-        .imports = &.{.{ .name = "shared", .module = shared }},
     });
-    exe.root_module.addAnonymousImport("bar", .{
-        .root_source_file = .{ .path = "bar.zig" },
-        .imports = &.{.{ .name = "shared", .module = shared }},
+    const bar = b.createModule(.{
+        .root_source_file = .{ .path = "foo.zig" },
+    });
+    const shared = b.createModule(.{
+        .root_source_file = .{ .path = "shared.zig" },
+    });
+
+    main.addImport("foo", foo);
+    main.addImport("bar", bar);
+    foo.addImport("shared", shared);
+    bar.addImport("shared", shared);
+
+    const exe = b.addExecutable2(.{
+        .name = "test",
+        .root_module = main,
     });
 
     const run = b.addRunArtifact(exe);

--- a/test/standalone/dep_mutually_recursive/build.zig
+++ b/test/standalone/dep_mutually_recursive/build.zig
@@ -15,11 +15,13 @@ pub fn build(b: *std.Build) void {
     foo.addImport("bar", bar);
     bar.addImport("foo", foo);
 
-    const exe = b.addExecutable(.{
+    const exe = b.addExecutable2(.{
         .name = "test",
-        .root_source_file = .{ .path = "test.zig" },
-        .target = b.host,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = .{ .path = "test.zig" },
+            .target = b.host,
+            .optimize = optimize,
+        }),
     });
     exe.root_module.addImport("foo", foo);
 

--- a/test/standalone/dep_recursive/build.zig
+++ b/test/standalone/dep_recursive/build.zig
@@ -11,11 +11,13 @@ pub fn build(b: *std.Build) void {
     });
     foo.addImport("foo", foo);
 
-    const exe = b.addExecutable(.{
+    const exe = b.addExecutable2(.{
         .name = "test",
-        .root_source_file = .{ .path = "test.zig" },
-        .target = b.host,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = .{ .path = "test.zig" },
+            .target = b.host,
+            .optimize = optimize,
+        }),
     });
     exe.root_module.addImport("foo", foo);
 

--- a/test/standalone/dep_shared_builtin/build.zig
+++ b/test/standalone/dep_shared_builtin/build.zig
@@ -6,14 +6,20 @@ pub fn build(b: *std.Build) void {
 
     const optimize: std.builtin.OptimizeMode = .Debug;
 
-    const exe = b.addExecutable(.{
-        .name = "test",
+    const main = b.createModule(.{
         .root_source_file = .{ .path = "test.zig" },
         .target = b.host,
         .optimize = optimize,
     });
-    exe.root_module.addAnonymousImport("foo", .{
+    const foo = b.createModule(.{
         .root_source_file = .{ .path = "foo.zig" },
+    });
+
+    main.addImport("foo", foo);
+
+    const exe = b.addExecutable2(.{
+        .name = "test",
+        .root_module = main,
     });
 
     const run = b.addRunArtifact(exe);

--- a/test/standalone/depend_on_main_mod/build.zig
+++ b/test/standalone/depend_on_main_mod/build.zig
@@ -7,19 +7,23 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable(.{
-        .name = "depend_on_main_mod",
+    const main = b.createModule(.{
         .root_source_file = .{ .path = "src/main.zig" },
         .target = target,
         .optimize = optimize,
     });
 
-    const foo_module = b.addModule("foo", .{
+    const foo = b.createModule(.{
         .root_source_file = .{ .path = "src/foo.zig" },
     });
 
-    foo_module.addImport("root2", exe.root_module);
-    exe.root_module.addImport("foo", foo_module);
+    main.addImport("foo", foo);
+    foo.addImport("root2", main);
+
+    const exe = b.addExecutable2(.{
+        .name = "depend_on_main_mod",
+        .root_module = main,
+    });
 
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.expectExitCode(0);

--- a/test/standalone/depend_on_main_mod/build.zig
+++ b/test/standalone/depend_on_main_mod/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = .{ .path = "src/foo.zig" },
     });
 
-    foo_module.addImport("root2", &exe.root_module);
+    foo_module.addImport("root2", exe.root_module);
     exe.root_module.addImport("foo", foo_module);
 
     const run_cmd = b.addRunArtifact(exe);


### PR DESCRIPTION
...aka, `The breakings will continue until morale improves (the second)`.

This PR introduces new APIs, `addExecutable2` etc, which - rather than constructing their own `std.Build.Module` - take a pre-existing one. This allows some module graphs to be correctly implemented without reaching into internal functions, and simplifies the construction of complex module graphs. Personally, I think this pattern is very nice to read, and it cleanly supports all practical use cases:
```zig
// Create all modules, with necessary options and source files
const main = b.createModule(.{
    // ...
});
const foo = b.createModule(.{
    // ...
});
const shared = b.createModule(.{
    // ...
});
// Declare all dependencies
main.addImport("shared", shared);
main.addImport("foo", foo);
foo.addImport("shared", shared);
// Create compile step
const exe = b.addExecutable2(.{
    // ...
    .root_module = main,
});
```

The legacy APIs remain, but have been soft deprecated. In future, the `addFoo2` variants will replace them. An alternative would be to retain the current APIs, renaming them `addSimpleExecutable` etc, but I don't think this is necessary, since a usage very similar to the old one can be trivially gotten just by adding `.root_module = b.createModule(.{` to the middle of your `addExecutable` logic.

One issue this raises is that the `CompileStep.addCSourceFile` etc APIs are now a little footgun-ey, since they mutate a module which you may use elsewhere. I think it would make sense to remove these APIs and require all module setup to be performed on the `Module` itself, but this can be a future enhancement.

I have begun migrating some parts of the compiler's build scripts; I particularly like how this affected `test/link/link.zig`,  which was previously reaching into build system internals to avoid code duplication.

The first commit of this PR also makes a change (suggested by @andrewrk) to `std.Build.Module`: it now participates directly in the step graph. This allows us to do away with a bunch of dependency tracking logic there, since it's all handled by the build runner!