### PR TITLE
translate-c: fixed casting between pointers and ints

### DIFF
--- a/lib/std/zig/c_translation.zig
+++ b/lib/std/zig/c_translation.zig
@@ -121,6 +121,10 @@ test "cast" {
     try testing.expectEqual(@as(u32, 4), cast(u32, @as(?*u32, @ptrFromInt(4))));
     try testing.expectEqual(@as(u32, 10), cast(u32, @as(u64, 10)));
 
+    try testing.expectEqual(@as(i32, 4), cast(i32, @as(*u32, @ptrFromInt(4))));
+    try testing.expectEqual(@as(i32, 4), cast(i32, @as(?*u32, @ptrFromInt(4))));
+    try testing.expectEqual(@as(i32, 10), cast(i32, @as(u64, 10)));
+
     try testing.expectEqual(@as(i32, @bitCast(@as(u32, 0x8000_0000))), cast(i32, @as(u32, 0x8000_0000)));
 
     try testing.expectEqual(@as(*u8, @ptrFromInt(2)), cast(*u8, @as(*const u8, @ptrFromInt(2))));
@@ -128,8 +132,7 @@ test "cast" {
 
     try testing.expectEqual(@as(?*anyopaque, @ptrFromInt(2)), cast(?*anyopaque, @as(*u8, @ptrFromInt(2))));
 
-    var foo: c_int = -1;
-    _ = &foo;
+    const foo: c_int = -1;
     try testing.expect(cast(*anyopaque, -1) == @as(*anyopaque, @ptrFromInt(@as(usize, @bitCast(@as(isize, -1))))));
     try testing.expect(cast(*anyopaque, foo) == @as(*anyopaque, @ptrFromInt(@as(usize, @bitCast(@as(isize, -1))))));
     try testing.expect(cast(?*anyopaque, -1) == @as(?*anyopaque, @ptrFromInt(@as(usize, @bitCast(@as(isize, -1))))));

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -2376,7 +2376,6 @@ fn transCCast(
         //      else {
         //          break :blk @as(c_ulong, @intFromPtr(expr));
         //      }
-        //      break blk: _tmp
         //  })
 
         var block_scope = try Scope.Block.init(c, scope, true);
@@ -2450,10 +2449,10 @@ fn transCCast(
         // Example:
         //  blk: {
         //      if(@sizeOf(src_int_type) > @sizeOf(dst_ptr_type)) {
-        //          break :blk @truncate(expr)
+        //          break :blk @as([*c]c_long, @ptrFromInt(@as(usize, @truncate(expr))));
         //      }
         //      else {
-        //          break :blk expr
+        //          break :blk @as([*c]c_long, @ptrFromInt(@as(usize, expr)));
         //      }
         //  }
 

--- a/test/cases/run_translated_c/int_and_ptr_casts.c
+++ b/test/cases/run_translated_c/int_and_ptr_casts.c
@@ -1,0 +1,51 @@
+#include <stdint.h>
+
+int main() {
+  int8_t foo8;
+  uint8_t ufoo8;
+  void* void_ptr;
+  intptr_t i_ptr;
+  uintptr_t u_ptr;
+  __int128 bigint;
+  unsigned __int128 biguint;
+
+  foo8 = -1;
+  void_ptr = (void *)foo8;
+  i_ptr = (intptr_t)void_ptr;
+  if (i_ptr != -1) return 1;
+
+  ufoo8 = 255;
+  void_ptr = (void *)ufoo8;
+  u_ptr = (uintptr_t)void_ptr;
+  if (u_ptr != 255) return 2;
+
+  i_ptr = -1;
+  void_ptr = (void *)i_ptr;
+  i_ptr = (intptr_t)void_ptr;
+  if (i_ptr != -1) return 3;
+
+  u_ptr = -1;
+  void_ptr = (void *)u_ptr;
+  u_ptr = (uintptr_t)void_ptr;
+  if (u_ptr != -1) return 4;
+  
+  bigint = -1;
+  void_ptr = (void *)bigint;
+  bigint = (__int128)void_ptr;
+  u_ptr = -1;
+  __int128 bigint_compare = u_ptr;
+  if (bigint != bigint_compare) return 5;
+
+  biguint = -1;
+  void_ptr = (void *)biguint;
+  biguint = (unsigned __int128)void_ptr;
+  u_ptr = -1;
+  unsigned __int128 biguint_compare = u_ptr;
+  if (biguint != biguint_compare) return 6;
+
+  return 0;
+}
+
+// run-translated-c
+// c_frontends=clang
+// targets=x86_64-linux-none,x86_64-macos-none,x86_64-windows-none,

--- a/test/cases/run_translated_c/int_and_ptr_casts.c
+++ b/test/cases/run_translated_c/int_and_ptr_casts.c
@@ -48,4 +48,4 @@ int main() {
 
 // run-translated-c
 // c_frontends=clang
-// targets=x86_64-linux-none,x86_64-macos-none,x86_64-windows-none,
+// targets=x86_64-linux

--- a/test/cases/translate_c/int_and_ptr_casts.c
+++ b/test/cases/translate_c/int_and_ptr_casts.c
@@ -13,7 +13,7 @@ int main() {
 
 // translate-c
 // c_frontends=clang
-// targets=x86_64-linux-none,x86_64-macos-none,x86_64-windows-non
+// targets=x86_64-linux
 // 
 //     var ptr: ?*anyopaque = blk: {
 //         if (@sizeOf(c_int) > @sizeOf(?*anyopaque)) {

--- a/test/cases/translate_c/int_and_ptr_casts.c
+++ b/test/cases/translate_c/int_and_ptr_casts.c
@@ -1,0 +1,56 @@
+#include <stdint.h>
+
+int main() {
+  void* ptr = (void *)-1;
+  short s = (short)ptr;
+  unsigned short us = (unsigned short)ptr;
+  __int128 bigint = -1;
+  unsigned __int128 biguint = -1;
+  ptr = (void *)bigint;
+  ptr = (void *)biguint;
+  return 0;
+}
+
+// translate-c
+// c_frontends=clang
+// targets=x86_64-linux-none,x86_64-macos-none,x86_64-windows-non
+// 
+//     var ptr: ?*anyopaque = blk: {
+//         if (@sizeOf(c_int) > @sizeOf(?*anyopaque)) {
+//             break :blk @as(?*anyopaque, @ptrFromInt(@as(usize, @bitCast(@as(isize, @truncate(-@as(c_int, 1)))))));
+//         } else {
+//             break :blk @as(?*anyopaque, @ptrFromInt(@as(usize, @bitCast(@as(isize, -@as(c_int, 1))))));
+//         }
+//     };
+//     
+//     var s: c_short = blk: {
+//         if (@sizeOf(?*anyopaque) > @sizeOf(c_short)) {
+//             break :blk @as(c_short, @bitCast(@as(c_ushort, @truncate(@intFromPtr(ptr)))));
+//         } else {
+//             break :blk @as(c_short, @bitCast(@as(c_ushort, @intFromPtr(ptr))));
+//         }
+//     };
+//     
+//     var us: c_ushort = blk: {
+//         if (@sizeOf(?*anyopaque) > @sizeOf(c_ushort)) {
+//             break :blk @as(c_ushort, @truncate(@intFromPtr(ptr)));
+//         } else {
+//             break :blk @as(c_ushort, @intFromPtr(ptr));
+//         }
+//     };
+//     
+//     ptr = blk: {
+//         if (@sizeOf(i128) > @sizeOf(?*anyopaque)) {
+//             break :blk @as(?*anyopaque, @ptrFromInt(@as(usize, @bitCast(@as(isize, @truncate(bigint))))));
+//         } else {
+//             break :blk @as(?*anyopaque, @ptrFromInt(@as(usize, @bitCast(@as(isize, bigint)))));
+//         }
+//     };
+//    
+//     ptr = blk: {
+//         if (@sizeOf(u128) > @sizeOf(?*anyopaque)) {
+//             break :blk @as(?*anyopaque, @ptrFromInt(@as(usize, @truncate(biguint))));
+//         } else {
+//             break :blk @as(?*anyopaque, @ptrFromInt(@as(usize, biguint)));
+//         }
+//     };

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -932,19 +932,19 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    _ = &func_ptr;
         \\    var typed_func_ptr: ?*const fn () callconv(.C) void = blk: {
         \\        if (@sizeOf(c_ulong) > @sizeOf(?*const fn () callconv(.C) void)) {
-        \\            break :blk @as(?*const fn () callconv(.C) void, @ptrFromInt(@as(usize, @truncate(blk: {
+        \\            break :blk @as(?*const fn () callconv(.C) void, @ptrFromInt(@as(usize, @truncate(blk_1: {
         \\                if (@sizeOf(?*anyopaque) > @sizeOf(c_ulong)) {
-        \\                    break :blk @as(c_ulong, @truncate(@intFromPtr(func_ptr)));
+        \\                    break :blk_1 @as(c_ulong, @truncate(@intFromPtr(func_ptr)));
         \\                } else {
-        \\                    break :blk @as(c_ulong, @intFromPtr(func_ptr));
+        \\                    break :blk_1 @as(c_ulong, @intFromPtr(func_ptr));
         \\                }
         \\            }))));
         \\        } else {
-        \\            break :blk @as(?*const fn () callconv(.C) void, @ptrFromInt(@as(usize, blk: {
+        \\            break :blk @as(?*const fn () callconv(.C) void, @ptrFromInt(@as(usize, blk_1: {
         \\                if (@sizeOf(?*anyopaque) > @sizeOf(c_ulong)) {
-        \\                    break :blk @as(c_ulong, @truncate(@intFromPtr(func_ptr)));
+        \\                    break :blk_1 @as(c_ulong, @truncate(@intFromPtr(func_ptr)));
         \\                } else {
-        \\                    break :blk @as(c_ulong, @intFromPtr(func_ptr));
+        \\                    break :blk_1 @as(c_ulong, @intFromPtr(func_ptr));
         \\                }
         \\            })));
         \\        }


### PR DESCRIPTION
Fixes an issue where translate-c would not create the correct cast between pointers and non-usize types (or int types that don't coerce to usize). This fix generates correct code that casts between pointers and C integer types of any width or signedness. 

My previous PR produced non-portable code. This PR includes a check in the generated code for the sizes of the int and pointer types.

Closes #18543, closes #18178, closes #17427.

Supersedes #18595.