### PR TITLE
Improved error message

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4221,6 +4221,10 @@ fn zirForLen(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
                     const msg = try sema.errMsg(block, arg_src, "type '{}' is not indexable and not a range", .{object_ty.fmt(sema.mod)});
                     errdefer msg.destroy(sema.gpa);
                     try sema.errNote(block, arg_src, msg, "for loop operand must be a range, array, slice, tuple, or vector", .{});
+                    if (object_ty.zigTypeTag(mod) == .ErrorUnion) {
+                        try sema.errNote(block, arg_src, msg, "cannot convert error union to indexable type", .{});
+                        try sema.errNote(block, arg_src, msg, "consider using 'try', 'catch', or 'if'", .{});
+                    }
                     break :msg msg;
                 };
                 return sema.failWithOwnedErrorMsg(block, msg);


### PR DESCRIPTION
Addresses #18745

 Added better error message for error unions being used as the argument in a for loop