### PR TITLE
syscall: use statx to provide functionality of fstat/fstatat if they are not provided.

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1584,7 +1584,7 @@ pub fn fstatat(dirfd: i32, path: [*:0]const u8, stat_buf: *Stat, flags: u32) usi
     } else if (@hasField(SYS, "fstatat")) {
         return syscall4(.fstatat, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), @intFromPtr(stat_buf), flags);
     } else if (@hasField(SYS, "statx")) {
-        const statx_buf: Statx = undefined;
+        var statx_buf: Statx = undefined;
         const rc = syscall5(
             .statx,
             @as(usize, @bitCast(@as(isize, dirfd))),
@@ -1598,13 +1598,13 @@ pub fn fstatat(dirfd: i32, path: [*:0]const u8, stat_buf: *Stat, flags: u32) usi
         }
 
         // fill in stat_buf with statx_buf
-        stat_buf.dev = @as(dev_t, makedev(statx_buf.dev_major, statx_buf.dev_minor));
+        stat_buf.dev = makedev(statx_buf.dev_major, statx_buf.dev_minor);
         stat_buf.ino = @as(ino_t, statx_buf.ino);
         stat_buf.mode = @as(mode_t, statx_buf.mode);
         stat_buf.nlink = statx_buf.nlink;
         stat_buf.uid = statx_buf.uid;
         stat_buf.gid = statx_buf.gid;
-        stat_buf.rdev = @as(dev_t, makedev(statx_buf.rdev_major, statx_buf.rdev_minor));
+        stat_buf.rdev = makedev(statx_buf.rdev_major, statx_buf.rdev_minor);
         // type conversions that might not be safe
         stat_buf.size = @as(off_t, @bitCast(statx_buf.size));
         stat_buf.blksize = @as(blksize_t, @bitCast(statx_buf.blksize));

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -4508,6 +4508,23 @@ pub const statx_timestamp = extern struct {
     __pad1: u32,
 };
 
+// makedev calculates a Stat's dev_t based on Statx's dev major and dev minor.
+fn makedev(major: u32, minor: u32) dev_t {
+    const majorH: dev_t = @as(dev_t, major >> 12);
+    const majorL: dev_t = @as(dev_t, major & 0xfff);
+    const minorH: dev_t = @as(dev_t, minor >> 8);
+    const minorL: dev_t = @as(dev_t, minor & 0xff);
+    return (majorH << 44) | (minorH << 20) | (majorL << 8) | minorL;
+}
+
+// timespecFrom creates a statx_timestamp to timespec.
+fn timespecFrom(ts: statx_timestamp) timespec {
+    return timespec{
+        .tv_sec = @as(isize, @bitCast(ts.tv_sec)),
+        .tv_nsec = @as(isize, ts.tv_nsec),
+    };
+}
+
 /// Renamed to `Statx` to not conflict with the `statx` function.
 pub const Statx = extern struct {
     /// Mask of bits indicating filled fields


### PR DESCRIPTION
For some platform (e.g. loongarch64), `fstat` and `fstatat` system calls are not implemented in Linux kernel. Use `statx` system call to implement `os.fstat` and `os.fstat` if it exists.

This will benefit adding loongarch64 support to zig. See patch here: https://github.com/yxd-ym/zig-bootstrap/pull/1

The implementation comes from the idea of golang's implementation https://go-review.googlesource.com/c/go/+/407694