### PR TITLE
std: eliminate some uses of `usingnamespace`

### DIFF
--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -46,38 +46,41 @@ pub fn LinearFifo(
         // returned a slice into a copy on the stack
         const SliceSelfArg = if (buffer_type == .Static) *Self else Self;
 
-        pub usingnamespace switch (buffer_type) {
-            .Static => struct {
-                pub fn init() Self {
-                    return .{
-                        .allocator = {},
-                        .buf = undefined,
-                        .head = 0,
-                        .count = 0,
-                    };
-                }
-            },
-            .Slice => struct {
-                pub fn init(buf: []T) Self {
-                    return .{
-                        .allocator = {},
-                        .buf = buf,
-                        .head = 0,
-                        .count = 0,
-                    };
-                }
-            },
-            .Dynamic => struct {
-                pub fn init(allocator: Allocator) Self {
-                    return .{
-                        .allocator = allocator,
-                        .buf = &[_]T{},
-                        .head = 0,
-                        .count = 0,
-                    };
-                }
-            },
+        pub const init = switch (buffer_type) {
+            .Static => initStatic,
+            .Slice => initSlice,
+            .Dynamic => initDynamic,
         };
+
+        fn initStatic() Self {
+            comptime assert(buffer_type == .Static);
+            return .{
+                .allocator = {},
+                .buf = undefined,
+                .head = 0,
+                .count = 0,
+            };
+        }
+
+        fn initSlice(buf: []T) Self {
+            comptime assert(buffer_type == .Slice);
+            return .{
+                .allocator = {},
+                .buf = buf,
+                .head = 0,
+                .count = 0,
+            };
+        }
+
+        fn initDynamic(allocator: Allocator) Self {
+            comptime assert(buffer_type == .Dynamic);
+            return .{
+                .allocator = allocator,
+                .buf = &.{},
+                .head = 0,
+                .count = 0,
+            };
+        }
 
         pub fn deinit(self: Self) void {
             if (buffer_type == .Dynamic) self.allocator.free(self.buf);

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -38,25 +38,14 @@ const CAllocator = struct {
         }
     }
 
-    usingnamespace if (@hasDecl(c, "malloc_size"))
-        struct {
-            pub const supports_malloc_size = true;
-            pub const malloc_size = c.malloc_size;
-        }
+    pub const supports_malloc_size = @TypeOf(malloc_size) != void;
+    pub const malloc_size = if (@hasDecl(c, "malloc_size"))
+        c.malloc_size
     else if (@hasDecl(c, "malloc_usable_size"))
-        struct {
-            pub const supports_malloc_size = true;
-            pub const malloc_size = c.malloc_usable_size;
-        }
+        c.malloc_usable_size
     else if (@hasDecl(c, "_msize"))
-        struct {
-            pub const supports_malloc_size = true;
-            pub const malloc_size = c._msize;
-        }
-    else
-        struct {
-            pub const supports_malloc_size = false;
-        };
+        c._msize
+    else {};
 
     pub const supports_posix_memalign = @hasDecl(c, "posix_memalign");
 

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -454,18 +454,19 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
             }
         }
 
-        pub usingnamespace if (config.retain_metadata) struct {
-            pub fn flushRetainedMetadata(self: *Self) void {
-                self.freeRetainedMetadata();
-                // also remove entries from large_allocations
-                var it = self.large_allocations.iterator();
-                while (it.next()) |large| {
-                    if (large.value_ptr.freed) {
-                        _ = self.large_allocations.remove(@intFromPtr(large.value_ptr.bytes.ptr));
-                    }
+        pub fn flushRetainedMetadata(self: *Self) void {
+            if (!config.retain_metadata) {
+                @compileError("'flushRetainedMetadata' requires 'config.retain_metadata = true'");
+            }
+            self.freeRetainedMetadata();
+            // also remove entries from large_allocations
+            var it = self.large_allocations.iterator();
+            while (it.next()) |large| {
+                if (large.value_ptr.freed) {
+                    _ = self.large_allocations.remove(@intFromPtr(large.value_ptr.bytes.ptr));
                 }
             }
-        } else struct {};
+        }
 
         /// Returns `Check.leak` if there were leaks; `Check.ok` otherwise.
         pub fn deinit(self: *Self) Check {

--- a/lib/std/os/uefi/tables.zig
+++ b/lib/std/os/uefi/tables.zig
@@ -1,9 +1,137 @@
-pub usingnamespace @import("tables/boot_services.zig");
-pub usingnamespace @import("tables/runtime_services.zig");
-pub usingnamespace @import("tables/configuration_table.zig");
-pub usingnamespace @import("tables/system_table.zig");
-pub usingnamespace @import("tables/table_header.zig");
+pub const BootServices = @import("tables/boot_services.zig").BootServices;
+pub const RuntimeServices = @import("tables/runtime_services.zig").RuntimeServices;
+pub const ConfigurationTable = @import("tables/configuration_table.zig").ConfigurationTable;
+pub const SystemTable = @import("tables/system_table.zig").SystemTable;
+pub const TableHeader = @import("tables/table_header.zig").TableHeader;
+
+pub const EfiEventNotify = *const fn (event: Event, ctx: *anyopaque) callconv(cc) void;
+
+pub const TimerDelay = enum(u32) {
+    TimerCancel,
+    TimerPeriodic,
+    TimerRelative,
+};
+
+pub const MemoryType = enum(u32) {
+    ReservedMemoryType,
+    LoaderCode,
+    LoaderData,
+    BootServicesCode,
+    BootServicesData,
+    RuntimeServicesCode,
+    RuntimeServicesData,
+    ConventionalMemory,
+    UnusableMemory,
+    ACPIReclaimMemory,
+    ACPIMemoryNVS,
+    MemoryMappedIO,
+    MemoryMappedIOPortSpace,
+    PalCode,
+    PersistentMemory,
+    MaxMemoryType,
+    _,
+};
+
+pub const MemoryDescriptorAttribute = packed struct(u64) {
+    uc: bool,
+    wc: bool,
+    wt: bool,
+    wb: bool,
+    uce: bool,
+    _pad1: u7 = 0,
+    wp: bool,
+    rp: bool,
+    xp: bool,
+    nv: bool,
+    more_reliable: bool,
+    ro: bool,
+    sp: bool,
+    cpu_crypto: bool,
+    _pad2: u43 = 0,
+    memory_runtime: bool,
+};
+
+pub const MemoryDescriptor = extern struct {
+    type: MemoryType,
+    physical_start: u64,
+    virtual_start: u64,
+    number_of_pages: u64,
+    attribute: MemoryDescriptorAttribute,
+};
+
+pub const LocateSearchType = enum(u32) {
+    AllHandles,
+    ByRegisterNotify,
+    ByProtocol,
+};
+
+pub const OpenProtocolAttributes = packed struct(u32) {
+    by_handle_protocol: bool = false,
+    get_protocol: bool = false,
+    test_protocol: bool = false,
+    by_child_controller: bool = false,
+    by_driver: bool = false,
+    exclusive: bool = false,
+    reserved: u26 = 0,
+};
+
+pub const ProtocolInformationEntry = extern struct {
+    agent_handle: ?Handle,
+    controller_handle: ?Handle,
+    attributes: OpenProtocolAttributes,
+    open_count: u32,
+};
+
+pub const EfiInterfaceType = enum(u32) {
+    EfiNativeInterface,
+};
+
+pub const AllocateType = enum(u32) {
+    AllocateAnyPages,
+    AllocateMaxAddress,
+    AllocateAddress,
+};
+
+const EfiPhysicalAddress = u64;
+
+pub const CapsuleHeader = extern struct {
+    capsuleGuid: Guid align(8),
+    headerSize: u32,
+    flags: u32,
+    capsuleImageSize: u32,
+};
+
+pub const UefiCapsuleBlockDescriptor = extern struct {
+    length: u64,
+    address: extern union {
+        dataBlock: EfiPhysicalAddress,
+        continuationPointer: EfiPhysicalAddress,
+    },
+};
+
+pub const ResetType = enum(u32) {
+    ResetCold,
+    ResetWarm,
+    ResetShutdown,
+    ResetPlatformSpecific,
+};
+
+pub const global_variable align(8) = Guid{
+    .time_low = 0x8be4df61,
+    .time_mid = 0x93ca,
+    .time_high_and_version = 0x11d2,
+    .clock_seq_high_and_reserved = 0xaa,
+    .clock_seq_low = 0x0d,
+    .node = [_]u8{ 0x00, 0xe0, 0x98, 0x03, 0x2b, 0x8c },
+};
 
 test {
-    @import("std").testing.refAllDeclsRecursive(@This());
+    std.testing.refAllDeclsRecursive(@This());
 }
+
+const std = @import("std");
+const uefi = std.os.uefi;
+const Handle = uefi.Handle;
+const Event = uefi.Event;
+const Guid = uefi.Guid;
+const cc = uefi.cc;

--- a/lib/std/os/uefi/tables/boot_services.zig
+++ b/lib/std/os/uefi/tables/boot_services.zig
@@ -6,6 +6,15 @@ const Handle = uefi.Handle;
 const Status = uefi.Status;
 const TableHeader = uefi.tables.TableHeader;
 const DevicePathProtocol = uefi.protocol.DevicePath;
+const AllocateType = uefi.tables.AllocateType;
+const MemoryType = uefi.tables.MemoryType;
+const MemoryDescriptor = uefi.tables.MemoryDescriptor;
+const TimerDelay = uefi.tables.TimerDelay;
+const EfiInterfaceType = uefi.tables.EfiInterfaceType;
+const LocateSearchType = uefi.tables.LocateSearchType;
+const OpenProtocolAttributes = uefi.tables.OpenProtocolAttributes;
+const ProtocolInformationEntry = uefi.tables.ProtocolInformationEntry;
+const EfiEventNotify = uefi.tables.EfiEventNotify;
 const cc = uefi.cc;
 
 /// Boot services are services provided by the system's firmware until the operating system takes
@@ -192,92 +201,4 @@ pub const BootServices = extern struct {
     pub const tpl_callback: usize = 8;
     pub const tpl_notify: usize = 16;
     pub const tpl_high_level: usize = 31;
-};
-
-pub const EfiEventNotify = *const fn (event: Event, ctx: *anyopaque) callconv(cc) void;
-
-pub const TimerDelay = enum(u32) {
-    TimerCancel,
-    TimerPeriodic,
-    TimerRelative,
-};
-
-pub const MemoryType = enum(u32) {
-    ReservedMemoryType,
-    LoaderCode,
-    LoaderData,
-    BootServicesCode,
-    BootServicesData,
-    RuntimeServicesCode,
-    RuntimeServicesData,
-    ConventionalMemory,
-    UnusableMemory,
-    ACPIReclaimMemory,
-    ACPIMemoryNVS,
-    MemoryMappedIO,
-    MemoryMappedIOPortSpace,
-    PalCode,
-    PersistentMemory,
-    MaxMemoryType,
-    _,
-};
-
-pub const MemoryDescriptorAttribute = packed struct(u64) {
-    uc: bool,
-    wc: bool,
-    wt: bool,
-    wb: bool,
-    uce: bool,
-    _pad1: u7 = 0,
-    wp: bool,
-    rp: bool,
-    xp: bool,
-    nv: bool,
-    more_reliable: bool,
-    ro: bool,
-    sp: bool,
-    cpu_crypto: bool,
-    _pad2: u43 = 0,
-    memory_runtime: bool,
-};
-
-pub const MemoryDescriptor = extern struct {
-    type: MemoryType,
-    physical_start: u64,
-    virtual_start: u64,
-    number_of_pages: u64,
-    attribute: MemoryDescriptorAttribute,
-};
-
-pub const LocateSearchType = enum(u32) {
-    AllHandles,
-    ByRegisterNotify,
-    ByProtocol,
-};
-
-pub const OpenProtocolAttributes = packed struct(u32) {
-    by_handle_protocol: bool = false,
-    get_protocol: bool = false,
-    test_protocol: bool = false,
-    by_child_controller: bool = false,
-    by_driver: bool = false,
-    exclusive: bool = false,
-    reserved: u26 = 0,
-};
-
-pub const ProtocolInformationEntry = extern struct {
-    agent_handle: ?Handle,
-    controller_handle: ?Handle,
-    attributes: OpenProtocolAttributes,
-    open_count: u32,
-};
-
-pub const EfiInterfaceType = enum(u32) {
-    EfiNativeInterface,
-};
-
-pub const AllocateType = enum(u32) {
-    AllocateAnyPages,
-    AllocateMaxAddress,
-    AllocateAddress,
 };

--- a/lib/std/os/uefi/tables/runtime_services.zig
+++ b/lib/std/os/uefi/tables/runtime_services.zig
@@ -6,6 +6,9 @@ const Time = uefi.Time;
 const TimeCapabilities = uefi.TimeCapabilities;
 const Status = uefi.Status;
 const MemoryDescriptor = uefi.tables.MemoryDescriptor;
+const ResetType = uefi.tables.ResetType;
+const CapsuleHeader = uefi.tables.CapsuleHeader;
+const EfiPhysicalAddress = uefi.tables.EfiPhysicalAddress;
 const cc = uefi.cc;
 
 /// Runtime services are provided by the firmware before and after exitBootServices has been called.
@@ -66,37 +69,4 @@ pub const RuntimeServices = extern struct {
     queryVariableInfo: *const fn (attributes: *u32, maximum_variable_storage_size: *u64, remaining_variable_storage_size: *u64, maximum_variable_size: *u64) callconv(cc) Status,
 
     pub const signature: u64 = 0x56524553544e5552;
-};
-
-const EfiPhysicalAddress = u64;
-
-pub const CapsuleHeader = extern struct {
-    capsuleGuid: Guid align(8),
-    headerSize: u32,
-    flags: u32,
-    capsuleImageSize: u32,
-};
-
-pub const UefiCapsuleBlockDescriptor = extern struct {
-    length: u64,
-    address: extern union {
-        dataBlock: EfiPhysicalAddress,
-        continuationPointer: EfiPhysicalAddress,
-    },
-};
-
-pub const ResetType = enum(u32) {
-    ResetCold,
-    ResetWarm,
-    ResetShutdown,
-    ResetPlatformSpecific,
-};
-
-pub const global_variable align(8) = Guid{
-    .time_low = 0x8be4df61,
-    .time_mid = 0x93ca,
-    .time_high_and_version = 0x11d2,
-    .clock_seq_high_and_reserved = 0xaa,
-    .clock_seq_low = 0x0d,
-    .node = [_]u8{ 0x00, 0xe0, 0x98, 0x03, 0x2b, 0x8c },
 };


### PR DESCRIPTION
This eliminates some simple usages of `usingnamespace` in the standard library. This construct may in future be removed from the language, and is generally an inappropriate way to formulate code. It is also problematic for incremental compilation, which may not initially support projects using it.

I wasn't entirely sure what the appropriate namespacing for the types in `std.os.uefi.tables` would be, so I ofted to preserve the current namespacing, meaning this is not a breaking change. It's possible some of the moved types should instead be namespaced under `BootServices` etc, but this can be a future enhancement.