### PR TITLE
std.json: add Value.fromAnytype[Leaky]

### DIFF
--- a/lib/std/json/dynamic.zig
+++ b/lib/std/json/dynamic.zig
@@ -222,7 +222,7 @@ pub const Value = union(enum) {
                 } else {
                     var map = ObjectMap.init(allocator);
                     inline for (S.fields) |Field| {
-                        if (options.emit_null_optional_fields == false and @field(value, Field.name) == null) {
+                        if (@typeInfo(Field.type) == .Optional and options.emit_null_optional_fields == false and @field(value, Field.name) == null) {
                             // skip field
                         } else {
                             const field_value = try fromAnytypeLeaky(allocator, @field(value, Field.name));

--- a/lib/std/json/dynamic.zig
+++ b/lib/std/json/dynamic.zig
@@ -142,7 +142,7 @@ pub const Value = union(enum) {
         parsed.arena.* = ArenaAllocator.init(allocator);
         errdefer parsed.arena.deinit();
 
-        parsed.value = try fromAnytypeLeaky(arena.allocator(), value, options);
+        parsed.value = try fromAnytypeLeaky(parsed.arena.allocator(), value, options);
 
         return parsed;
     }

--- a/lib/std/json/dynamic.zig
+++ b/lib/std/json/dynamic.zig
@@ -133,7 +133,7 @@ pub const Value = union(enum) {
         return source;
     }
 
-    pub fn fromAnytype(allocator: std.mem.Allocator, value: anytype, options: StringifyOptions) (std.json.Error || std.mem.Allocator.Error)!Parsed(Value) {
+    pub fn fromAnytype(allocator: Allocator, value: anytype, options: StringifyOptions) (std.json.Error || Allocator.Error)!Parsed(Value) {
         var parsed = Parsed(Value){
             .arena = try allocator.create(ArenaAllocator),
             .value = undefined,
@@ -147,7 +147,7 @@ pub const Value = union(enum) {
         return parsed;
     }
 
-    pub fn fromAnytypeLeaky(allocator: std.mem.Allocator, value: anytype, options: StringifyOptions) (std.json.Error || std.mem.Allocator.Error)!Value {
+    pub fn fromAnytypeLeaky(allocator: Allocator, value: anytype, options: StringifyOptions) (std.json.Error || Allocator.Error)!Value {
         const T = @TypeOf(value);
         switch (@typeInfo(T)) {
             .Void => {
@@ -173,7 +173,7 @@ pub const Value = union(enum) {
                 if (@as(f64, @floatCast(value)) == value) {
                     return Value{ .float = @as(f64, @floatCast(value)) };
                 }
-                return Value{ .number_string = std.fmt.allocPrint(allocator, "{}", .{value}) };
+                return Value{ .number_string = try std.fmt.allocPrint(allocator, "{}", .{value}) };
             },
             .Bool => {
                 return Value{ .bool = value };
@@ -183,7 +183,7 @@ pub const Value = union(enum) {
             },
             .Optional => {
                 if (value) |payload| {
-                    return fromAnytypeLeaky(allocator, payload);
+                    return fromAnytypeLeaky(allocator, payload, options);
                 } else {
                     return Value.null;
                 }
@@ -199,7 +199,7 @@ pub const Value = union(enum) {
                         if (value == @field(UnionTagType, u_field.name)) {
                             try map.put(
                                 u_field.name,
-                                try fromAnytypeLeaky(allocator, @field(value, u_field.name)),
+                                try fromAnytypeLeaky(allocator, @field(value, u_field.name), options),
                             );
                             break;
                         }
@@ -215,7 +215,7 @@ pub const Value = union(enum) {
                 if (S.is_tuple) {
                     var array = Array.init(allocator);
                     inline for (S.fields) |Field| {
-                        const field_value = try fromAnytypeLeaky(allocator, @field(value, Field.name));
+                        const field_value = try fromAnytypeLeaky(allocator, @field(value, Field.name), options);
                         try array.append(field_value);
                     }
                     return Value{ .array = array };
@@ -225,7 +225,7 @@ pub const Value = union(enum) {
                         if (@typeInfo(Field.type) == .Optional and options.emit_null_optional_fields == false and @field(value, Field.name) == null) {
                             // skip field
                         } else {
-                            const field_value = try fromAnytypeLeaky(allocator, @field(value, Field.name));
+                            const field_value = try fromAnytypeLeaky(allocator, @field(value, Field.name), options);
                             try map.put(Field.name, field_value);
                         }
                     }
@@ -233,16 +233,16 @@ pub const Value = union(enum) {
                 }
                 return;
             },
-            .ErrorSet => return fromAnytypeLeaky(allocator, @errorName(value)),
+            .ErrorSet => return fromAnytypeLeaky(allocator, @errorName(value), options),
             .Pointer => |ptr_info| switch (ptr_info.size) {
                 .One => switch (@typeInfo(ptr_info.child)) {
                     .Array => {
                         // Coerce `*[N]T` to `[]const T`.
                         const Slice = []const std.meta.Elem(ptr_info.child);
-                        return fromAnytypeLeaky(allocator, @as(Slice, value));
+                        return fromAnytypeLeaky(allocator, @as(Slice, value), options);
                     },
                     else => {
-                        return fromAnytypeLeaky(allocator, value.*);
+                        return fromAnytypeLeaky(allocator, value.*, options);
                     },
                 },
                 .Many, .Slice => {
@@ -259,7 +259,7 @@ pub const Value = union(enum) {
 
                     var array = Array.init(allocator);
                     for (slice) |x| {
-                        const x_value = try fromAnytypeLeaky(allocator, x);
+                        const x_value = try fromAnytypeLeaky(allocator, x, options);
                         try array.append(x_value);
                     }
                     return Value{ .array = array };
@@ -268,11 +268,11 @@ pub const Value = union(enum) {
             },
             .Array => {
                 // Coerce `[N]T` to `*const [N]T` (and then to `[]const T`).
-                return fromAnytypeLeaky(allocator, &value);
+                return fromAnytypeLeaky(allocator, &value, options);
             },
             .Vector => |info| {
                 const array: [info.len]info.child = value;
-                return fromAnytypeLeaky(allocator, &array);
+                return fromAnytypeLeaky(allocator, &array, options);
             },
             else => @compileError("Unable to stringify type '" ++ @typeName(T) ++ "'"),
         }

--- a/lib/std/json/dynamic.zig
+++ b/lib/std/json/dynamic.zig
@@ -131,6 +131,138 @@ pub const Value = union(enum) {
         _ = options;
         return source;
     }
+
+    pub fn fromAnytypeLeaky(a: std.mem.Allocator, value: anytype, options: StringifyOptions) (std.json.Error || std.mem.Allocator.Error)!Value {
+        const T = @TypeOf(value);
+        switch (@typeInfo(T)) {
+            .Void => {
+                return Value{ .object = ObjectMap.init(a) };
+            },
+            .Int => |info| {
+                _ = info;
+
+                if (std.math.cast(i64, value)) |x| {
+                    return Value{ .integer = x };
+                } else {
+                    return Value{ .number_string = try std.fmt.allocPrint(a, "{}", .{value}) };
+                }
+            },
+            .ComptimeInt => {
+                if (std.math.cast(i64, value)) |x| {
+                    return Value{ .integer = x };
+                } else {
+                    return Value{ .number_string = std.fmt.allocPrint(a, "{}", .{value}) };
+                }
+            },
+            .Float, .ComptimeFloat => {
+                if (@as(f64, @floatCast(value)) == value) {
+                    return Value{ .float = @as(f64, @floatCast(value)) };
+                }
+                return Value{ .number_string = std.fmt.allocPrint(a, "{}", .{value}) };
+            },
+            .Bool => {
+                return Value{ .bool = value };
+            },
+            .Null => {
+                return Value.null;
+            },
+            .Optional => {
+                if (value) |payload| {
+                    return fromAnytypeLeaky(a, payload);
+                } else {
+                    return Value.null;
+                }
+            },
+            .Enum => {
+                return Value{ .string = @tagName(value) };
+            },
+            .Union => {
+                var map = ObjectMap.init(a);
+                const info = @typeInfo(T).Union;
+                if (info.tag_type) |UnionTagType| {
+                    inline for (info.fields) |u_field| {
+                        if (value == @field(UnionTagType, u_field.name)) {
+                            try map.put(
+                                u_field.name,
+                                try fromAnytypeLeaky(a, @field(value, u_field.name)),
+                            );
+                            break;
+                        }
+                    } else {
+                        unreachable; // No active tag?
+                    }
+                    return Value{ .object = map };
+                } else {
+                    @compileError("Unable to stringify untagged union '" ++ @typeName(T) ++ "'");
+                }
+            },
+            .Struct => |S| {
+                if (S.is_tuple) {
+                    var array = Array.init(a);
+                    inline for (S.fields) |Field| {
+                        const field_value = try fromAnytypeLeaky(a, @field(value, Field.name));
+                        try array.append(field_value);
+                    }
+                    return Value{ .array = array };
+                } else {
+                    var map = ObjectMap.init(a);
+                    inline for (S.fields) |Field| {
+                        if (options.emit_null_optional_fields == false and @field(value, Field.name) == null) {
+                            // skip field
+                        } else {
+                            const field_value = try fromAnytypeLeaky(a, @field(value, Field.name));
+                            try map.put(Field.name, field_value);
+                        }
+                    }
+                    return Value{ .object = map };
+                }
+                return;
+            },
+            .ErrorSet => return fromAnytypeLeaky(a, @errorName(value)),
+            .Pointer => |ptr_info| switch (ptr_info.size) {
+                .One => switch (@typeInfo(ptr_info.child)) {
+                    .Array => {
+                        // Coerce `*[N]T` to `[]const T`.
+                        const Slice = []const std.meta.Elem(ptr_info.child);
+                        return fromAnytypeLeaky(a, @as(Slice, value));
+                    },
+                    else => {
+                        return fromAnytypeLeaky(a, value.*);
+                    },
+                },
+                .Many, .Slice => {
+                    if (ptr_info.size == .Many and ptr_info.sentinel == null)
+                        @compileError("unable to stringify type '" ++ @typeName(T) ++ "' without sentinel");
+                    const slice = if (ptr_info.size == .Many) std.mem.span(value) else value;
+
+                    if (ptr_info.child == u8) {
+                        // This is a []const u8, or some similar Zig string.
+                        if (!options.emit_strings_as_arrays and std.unicode.utf8ValidateSlice(slice)) {
+                            return Value{ .string = slice };
+                        }
+                    }
+
+                    var array = Array.init(a);
+                    for (slice) |x| {
+                        const x_value = try fromAnytypeLeaky(a, x);
+                        try array.append(x_value);
+                    }
+                    return Value{ .array = array };
+                },
+                else => @compileError("Unable to stringify type '" ++ @typeName(T) ++ "'"),
+            },
+            .Array => {
+                // Coerce `[N]T` to `*const [N]T` (and then to `[]const T`).
+                return fromAnytypeLeaky(a, &value);
+            },
+            .Vector => |info| {
+                const array: [info.len]info.child = value;
+                return fromAnytypeLeaky(a, &array);
+            },
+            else => @compileError("Unable to stringify type '" ++ @typeName(T) ++ "'"),
+        }
+        unreachable;
+    }
 };
 
 fn handleCompleteValue(stack: *Array, allocator: Allocator, source: anytype, value_: Value, options: ParseOptions) !?Value {

--- a/lib/std/json/dynamic_test.zig
+++ b/lib/std/json/dynamic_test.zig
@@ -69,12 +69,12 @@ test "parse from string" {
     var parsed = try parseFromSlice(Value, testing.allocator, s, .{});
     defer parsed.deinit();
 
-    var root = parsed.value;
+    const root = parsed.value;
     try validate_image_object(root);
 }
 
 test "parse from zig value" {
-    const Root = struct {
+    const Data = struct {
         Image: struct {
             Width: i32 = 800,
             Height: i32 = 600,
@@ -89,12 +89,14 @@ test "parse from zig value" {
             ArrayOfObject: []const struct { n: []const u8 = "m" } = &.{.{}},
             double: f64 = 1.3412,
             LargeInt: u128 = 18446744073709551615,
-        },
+        } = .{},
     };
-    const root = Root{};
-    const parsed = try Value.fromAnytype(std.testing.allocator, root, .{});
+    const data = Data{};
+    const parsed = try Value.fromAnytype(std.testing.allocator, data, .{});
     defer parsed.deinit();
-    try validate_image_object(parsed.value);
+
+    const root = parsed.value;
+    try validate_image_object(root);
 }
 
 const writeStream = @import("./stringify.zig").writeStream;

--- a/lib/std/json/dynamic_test.zig
+++ b/lib/std/json/dynamic_test.zig
@@ -85,7 +85,7 @@ test "parse from zig value" {
                 Width: i32 = 100,
             } = .{},
             Animated: bool = false,
-            IDs: []const u32 = .{ 116, 943, 234, 38793 },
+            IDs: []const u32 = &.{ 116, 943, 234, 38793 },
             ArrayOfObject: []const struct { n: []const u8 = "m" } = &.{.{}},
             double: f64 = 1.3412,
             LargeInt: u128 = 18446744073709551615,

--- a/lib/std/json/stringify.zig
+++ b/lib/std/json/stringify.zig
@@ -498,7 +498,7 @@ pub fn WriteStream(
                     }
                     inline for (S.fields) |Field| {
                         // don't include void fields
-                        if (Field.type == void) continue;
+                        if (!S.is_tuple and Field.type == void) continue;
 
                         var emit_field = true;
 


### PR DESCRIPTION
Added 2 new functions.

- `std.json.Value.fromAnytype` turns a term of `anytype` into `std.json.Value`.
- `std.json.Value.fromAnytypeLeaky` does the same but leaks memory.