### PR TITLE
bsd: add missing os.IFNAMESIZE

### DIFF
--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -901,6 +901,8 @@ pub const EAI = enum(c_int) {
     _,
 };
 
+pub const IFNAMESIZE = 16;
+
 pub const AI = struct {
     pub const PASSIVE = 0x00000001;
     pub const CANONNAME = 0x00000002;

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -525,6 +525,8 @@ pub const sockaddr = extern struct {
     };
 };
 
+pub const IFNAMESIZE = 16;
+
 pub const AI = struct {
     /// get address to use bind()
     pub const PASSIVE = 0x00000001;

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -401,6 +401,8 @@ pub const sockaddr = extern struct {
     };
 };
 
+pub const IFNAMESIZE = 16;
+
 pub const AI = struct {
     /// get address to use bind()
     pub const PASSIVE = 1;


### PR DESCRIPTION
- based on system API value IF_NAMESIZE
- unblocks `zig test lib/std/std.zig`