### PR TITLE
Buffer the logging function

### DIFF
--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -149,9 +149,15 @@ pub fn defaultLog(
     const level_txt = comptime message_level.asText();
     const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
     const stderr = std.io.getStdErr().writer();
+    var bw = std.io.bufferedWriter(stderr);
+    const writer = bw.writer();
+
     std.debug.getStderrMutex().lock();
     defer std.debug.getStderrMutex().unlock();
-    nosuspend stderr.print(level_txt ++ prefix2 ++ format ++ "\n", args) catch return;
+    nosuspend {
+        writer.print(level_txt ++ prefix2 ++ format ++ "\n", args) catch return;
+        bw.flush() catch return;
+    }
 }
 
 /// Returns a scoped logging namespace that logs all messages using the scope


### PR DESCRIPTION
The default logging function used to have no buffer. So a single log statement could result in many individual write syscalls each writing only a couple of bytes.

After this change the logging function now has a 4kb buffer. Only log statements longer than 4kb now do multiple write syscalls.

4kb is the default bufferedWriter size and was choosen arbitrarily.

The downside of this is that the log function now allocates 4kb more stack space but I think that is an acceptable trade-off.

example:
```zig
const std = @import("std");

pub fn main() void {
    std.log.info("Hello {s}!", .{"World"});
}
```

strace before:

```
...
write(2, "info: Hello ", 12info: Hello )            = 12
write(2, "World", 5World)                    = 5
write(2, "!\n", 2!
)                      = 2
...
```

strace after:
```
...
write(2, "info: Hello World!\n", 19info: Hello World!
)    = 19
...
```