### PR TITLE
Add error hint when looping over `ErrorUnion`

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -4221,6 +4221,11 @@ fn zirForLen(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
                     const msg = try sema.errMsg(block, arg_src, "type '{}' is not indexable and not a range", .{object_ty.fmt(sema.mod)});
                     errdefer msg.destroy(sema.gpa);
                     try sema.errNote(block, arg_src, msg, "for loop operand must be a range, array, slice, tuple, or vector", .{});
+
+                    if (object_ty.zigTypeTag(mod) == .ErrorUnion) {
+                        try sema.errNote(block, arg_src, msg, "consider using 'try', 'catch', or 'if'", .{});
+                    }
+
                     break :msg msg;
                 };
                 return sema.failWithOwnedErrorMsg(block, msg);

--- a/test/cases/compile_errors/for_loop_error_union.zig
+++ b/test/cases/compile_errors/for_loop_error_union.zig
@@ -10,6 +10,6 @@ export fn a() void {
 // backend=stage2
 // target=native
 //
-// :6:11: error: type '@typeInfo(@typeInfo(@TypeOf(empty.b)).Fn.return_type.?).ErrorUnion.error_set!u32' is not indexable and not a range
+// :6:11: error: type '@typeInfo(@typeInfo(@TypeOf(tmp.b)).Fn.return_type.?).ErrorUnion.error_set!u32' is not indexable and not a range
 // :6:11: note: for loop operand must be a range, array, slice, tuple, or vector
 // :6:11: note: consider using 'try', 'catch', or 'if'

--- a/test/cases/compile_errors/for_loop_error_union.zig
+++ b/test/cases/compile_errors/for_loop_error_union.zig
@@ -1,0 +1,15 @@
+fn b() !u32 {
+    return 2;
+}
+
+export fn a() void {
+    for (b()) |_| {}
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :6:11: error: type '@typeInfo(@typeInfo(@TypeOf(empty.b)).Fn.return_type.?).ErrorUnion.error_set!u32' is not indexable and not a range
+// :6:11: note: for loop operand must be a range, array, slice, tuple, or vector
+// :6:11: note: consider using 'try', 'catch', or 'if'


### PR DESCRIPTION
fixes #18745
supersedes #18759, no action for 2 days.