### PR TITLE
macho: emit relocatable with self-hosted x86_64 backend

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -615,6 +615,7 @@ pub fn flushModule(self: *MachO, arena: Allocator, prog_node: *std.Progress.Node
             const sect = &self.sections.items(.header)[atom.out_n_sect];
             if (sect.isZerofill()) continue;
             if (mem.indexOf(u8, sect.segName(), "ZIG") == null) continue; // Non-Zig sections are handled separately
+            if (atom.getRelocs(self).len == 0) continue;
             // TODO: we will resolve and write ZigObject's TLS data twice:
             // once here, and once in writeAtoms
             const atom_size = math.cast(usize, atom.size) orelse return error.Overflow;
@@ -4107,10 +4108,13 @@ fn formatSections(
     _ = unused_fmt_string;
     const slice = self.sections.slice();
     for (slice.items(.header), slice.items(.segment_id), 0..) |header, seg_id, i| {
-        try writer.print("sect({d}) : seg({d}) : {s},{s} : @{x} ({x}) : align({x}) : size({x})\n", .{
-            i,               seg_id,      header.segName(), header.sectName(), header.addr, header.offset,
-            header.@"align", header.size,
-        });
+        try writer.print(
+            "sect({d}) : seg({d}) : {s},{s} : @{x} ({x}) : align({x}) : size({x}) : relocs({x};{d})\n",
+            .{
+                i,               seg_id,      header.segName(), header.sectName(), header.addr, header.offset,
+                header.@"align", header.size, header.reloff,    header.nreloc,
+            },
+        );
     }
 }
 

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -596,7 +596,6 @@ pub fn flushModule(self: *MachO, arena: Allocator, prog_node: *std.Progress.Node
 
     try self.allocateSections();
     self.allocateSegments();
-    self.allocateAtoms();
     self.allocateSyntheticSymbols();
     try self.allocateLinkeditSegment();
 
@@ -2392,14 +2391,6 @@ fn allocateSegments(self: *MachO) void {
     }
 }
 
-pub fn allocateAtoms(self: *MachO) void {
-    // TODO: redo this like atoms
-    for (self.thunks.items) |*thunk| {
-        const header = self.sections.items(.header)[thunk.out_n_sect];
-        thunk.value += header.addr;
-    }
-}
-
 fn allocateSyntheticSymbols(self: *MachO) void {
     const text_seg = self.getTextSegment();
 
@@ -2608,7 +2599,7 @@ fn writeAtoms(self: *MachO) !void {
 
     for (self.thunks.items) |thunk| {
         const header = slice.items(.header)[thunk.out_n_sect];
-        const offset = thunk.value - header.addr + header.offset;
+        const offset = thunk.value + header.offset;
         const buffer = try gpa.alloc(u8, thunk.size());
         defer gpa.free(buffer);
         var stream = std.io.fixedBufferStream(buffer);

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -1143,10 +1143,10 @@ fn format2(
     _ = unused_fmt_string;
     const atom = ctx.atom;
     const macho_file = ctx.macho_file;
-    try writer.print("atom({d}) : {s} : @{x} : sect({d}) : align({x}) : size({x}) : thunk({d})", .{
-        atom.atom_index,  atom.getName(macho_file), atom.value,
-        atom.out_n_sect,  atom.alignment,           atom.size,
-        atom.thunk_index,
+    try writer.print("atom({d}) : {s} : @{x} : sect({d}) : align({x}) : size({x}) : nreloc({d}) : thunk({d})", .{
+        atom.atom_index,                atom.getName(macho_file), atom.value,
+        atom.out_n_sect,                atom.alignment,           atom.size,
+        atom.getRelocs(macho_file).len, atom.thunk_index,
     });
     if (!atom.flags.alive) try writer.writeAll(" : [*]");
     if (atom.unwind_records.len > 0) {

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -119,9 +119,19 @@ pub fn getThunk(self: Atom, macho_file: *MachO) *Thunk {
 
 pub fn initOutputSection(sect: macho.section_64, macho_file: *MachO) !u8 {
     const segname, const sectname, const flags = blk: {
+        // Sanitize names produced by Zig self-hosted backends.
+        // TODO perhaps we simply should emit different names instead?
+        const segname = if (mem.indexOf(u8, sect.segName(), "_ZIG")) |idx|
+            sect.segName()[0..idx]
+        else
+            sect.segName();
+        const sectname = if (mem.indexOf(u8, sect.sectName(), "_zig")) |idx|
+            sect.sectName()[0..idx]
+        else
+            sect.sectName();
         if (sect.isCode()) break :blk .{
             "__TEXT",
-            sect.sectName(),
+            sectname,
             macho.S_REGULAR | macho.S_ATTR_PURE_INSTRUCTIONS | macho.S_ATTR_SOME_INSTRUCTIONS,
         };
 
@@ -132,15 +142,15 @@ pub fn initOutputSection(sect: macho.section_64, macho_file: *MachO) !u8 {
             => break :blk .{ "__TEXT", "__const", macho.S_REGULAR },
 
             macho.S_CSTRING_LITERALS => {
-                if (mem.startsWith(u8, sect.sectName(), "__objc")) break :blk .{
-                    sect.segName(), sect.sectName(), macho.S_REGULAR,
+                if (mem.startsWith(u8, sectname, "__objc")) break :blk .{
+                    segname, sectname, macho.S_REGULAR,
                 };
                 break :blk .{ "__TEXT", "__cstring", macho.S_CSTRING_LITERALS };
             },
 
             macho.S_MOD_INIT_FUNC_POINTERS,
             macho.S_MOD_TERM_FUNC_POINTERS,
-            => break :blk .{ "__DATA_CONST", sect.sectName(), sect.flags },
+            => break :blk .{ "__DATA_CONST", sectname, sect.flags },
 
             macho.S_LITERAL_POINTERS,
             macho.S_ZEROFILL,
@@ -149,17 +159,15 @@ pub fn initOutputSection(sect: macho.section_64, macho_file: *MachO) !u8 {
             macho.S_THREAD_LOCAL_VARIABLE_POINTERS,
             macho.S_THREAD_LOCAL_REGULAR,
             macho.S_THREAD_LOCAL_ZEROFILL,
-            => break :blk .{ sect.segName(), sect.sectName(), sect.flags },
+            => break :blk .{ segname, sectname, sect.flags },
 
             macho.S_COALESCED => break :blk .{
-                sect.segName(),
-                sect.sectName(),
+                segname,
+                sectname,
                 macho.S_REGULAR,
             },
 
             macho.S_REGULAR => {
-                const segname = sect.segName();
-                const sectname = sect.sectName();
                 if (mem.eql(u8, segname, "__DATA")) {
                     if (mem.eql(u8, sectname, "__const") or
                         mem.eql(u8, sectname, "__cfstring") or
@@ -173,7 +181,7 @@ pub fn initOutputSection(sect: macho.section_64, macho_file: *MachO) !u8 {
                 break :blk .{ segname, sectname, sect.flags };
             },
 
-            else => break :blk .{ sect.segName(), sect.sectName(), sect.flags },
+            else => break :blk .{ segname, sectname, sect.flags },
         }
     };
     const osec = macho_file.getSectionByName(segname, sectname) orelse try macho_file.addSection(

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -706,7 +706,7 @@ fn resolveRelocInner(
                 .aarch64 => {
                     const disp: i28 = math.cast(i28, S + A - P) orelse blk: {
                         const thunk = self.getThunk(macho_file);
-                        const S_: i64 = @intCast(thunk.getAddress(rel.target));
+                        const S_: i64 = @intCast(thunk.getTargetAddress(rel.target, macho_file));
                         break :blk math.cast(i28, S_ + A - P) orelse return error.Overflow;
                     };
                     var inst = aarch64.Instruction{

--- a/src/link/MachO/Relocation.zig
+++ b/src/link/MachO/Relocation.zig
@@ -22,7 +22,7 @@ pub fn getTargetAtom(rel: Relocation, macho_file: *MachO) *Atom {
 
 pub fn getTargetAddress(rel: Relocation, macho_file: *MachO) u64 {
     return switch (rel.tag) {
-        .local => rel.getTargetAtom(macho_file).value,
+        .local => rel.getTargetAtom(macho_file).getAddress(macho_file),
         .@"extern" => rel.getTargetSymbol(macho_file).getAddress(.{}, macho_file),
     };
 }

--- a/src/link/MachO/Symbol.zig
+++ b/src/link/MachO/Symbol.zig
@@ -118,7 +118,7 @@ pub fn getAddress(symbol: Symbol, opts: struct {
             return symbol.getObjcStubsAddress(macho_file);
         }
     }
-    if (symbol.getAtom(macho_file)) |atom| return atom.value + symbol.value;
+    if (symbol.getAtom(macho_file)) |atom| return atom.getAddress(macho_file) + symbol.value;
     return symbol.value;
 }
 
@@ -145,7 +145,7 @@ pub fn getObjcSelrefsAddress(symbol: Symbol, macho_file: *MachO) u64 {
     const extra = symbol.getExtra(macho_file).?;
     const atom = macho_file.getAtom(extra.objc_selrefs).?;
     assert(atom.flags.alive);
-    return atom.value;
+    return atom.getAddress(macho_file);
 }
 
 pub fn getTlvPtrAddress(symbol: Symbol, macho_file: *MachO) u64 {

--- a/src/link/MachO/UnwindInfo.zig
+++ b/src/link/MachO/UnwindInfo.zig
@@ -490,12 +490,12 @@ pub const Record = struct {
 
     pub fn getAtomAddress(rec: Record, macho_file: *MachO) u64 {
         const atom = rec.getAtom(macho_file);
-        return atom.value + rec.atom_offset;
+        return atom.getAddress(macho_file) + rec.atom_offset;
     }
 
     pub fn getLsdaAddress(rec: Record, macho_file: *MachO) u64 {
         const lsda = rec.getLsdaAtom(macho_file) orelse return 0;
-        return lsda.value + rec.lsda_offset;
+        return lsda.getAddress(macho_file) + rec.lsda_offset;
     }
 
     pub fn format(

--- a/src/link/MachO/ZigObject.zig
+++ b/src/link/MachO/ZigObject.zig
@@ -196,8 +196,10 @@ pub fn resolveSymbols(self: *ZigObject, macho_file: *MachO) void {
                 const atom = macho_file.getAtom(atom_index).?;
                 break :blk nlist.n_value - atom.getInputAddress(macho_file);
             } else nlist.n_value;
+            const out_n_sect = if (nlist.sect()) macho_file.getAtom(atom_index).?.out_n_sect else 0;
             symbol.value = value;
             symbol.atom = atom_index;
+            symbol.out_n_sect = out_n_sect;
             symbol.nlist_idx = nlist_idx;
             symbol.file = self.index;
             symbol.flags.weak = nlist.weakDef();

--- a/src/link/MachO/ZigObject.zig
+++ b/src/link/MachO/ZigObject.zig
@@ -154,7 +154,7 @@ pub fn getAtomData(self: ZigObject, macho_file: *MachO, atom: Atom, buffer: []u8
             @memset(buffer, 0);
         },
         else => {
-            const file_offset = sect.offset + atom.value - sect.addr;
+            const file_offset = sect.offset + atom.value;
             const amt = try macho_file.base.file.?.preadAll(buffer, file_offset);
             if (amt != buffer.len) return error.InputOutput;
         },
@@ -715,7 +715,7 @@ fn updateDeclCode(
         } else if (code.len < old_size) {
             atom.shrink(macho_file);
         } else if (macho_file.getAtom(atom.next_index) == null) {
-            const needed_size = atom.value + code.len - sect.addr;
+            const needed_size = atom.value + code.len;
             sect.size = needed_size;
         }
     } else {
@@ -733,7 +733,7 @@ fn updateDeclCode(
     }
 
     if (!sect.isZerofill()) {
-        const file_offset = sect.offset + atom.value - sect.addr;
+        const file_offset = sect.offset + atom.value;
         try macho_file.base.file.?.pwriteAll(code, file_offset);
     }
 }
@@ -1036,7 +1036,7 @@ fn lowerConst(
     nlist.n_value = 0;
 
     const sect = macho_file.sections.items(.header)[output_section_index];
-    const file_offset = sect.offset + atom.value - sect.addr;
+    const file_offset = sect.offset + atom.value;
     try macho_file.base.file.?.pwriteAll(code, file_offset);
 
     return .{ .ok = sym_index };
@@ -1213,7 +1213,7 @@ fn updateLazySymbol(
     }
 
     const sect = macho_file.sections.items(.header)[output_section_index];
-    const file_offset = sect.offset + atom.value - sect.addr;
+    const file_offset = sect.offset + atom.value;
     try macho_file.base.file.?.pwriteAll(code, file_offset);
 }
 

--- a/src/link/MachO/eh_frame.zig
+++ b/src/link/MachO/eh_frame.zig
@@ -416,7 +416,7 @@ pub fn write(macho_file: *MachO, buffer: []u8) void {
             {
                 const offset = fde.out_offset + 8;
                 const saddr = sect.addr + offset;
-                const taddr = fde.getAtom(macho_file).value;
+                const taddr = fde.getAtom(macho_file).getAddress(macho_file);
                 std.mem.writeInt(
                     i64,
                     buffer[offset..][0..8],
@@ -428,7 +428,7 @@ pub fn write(macho_file: *MachO, buffer: []u8) void {
             if (fde.getLsdaAtom(macho_file)) |atom| {
                 const offset = fde.out_offset + fde.lsda_ptr_offset;
                 const saddr = sect.addr + offset;
-                const taddr = atom.value + fde.lsda_offset;
+                const taddr = atom.getAddress(macho_file) + fde.lsda_offset;
                 switch (fde.getCie(macho_file).lsda_size.?) {
                     .p32 => std.mem.writeInt(
                         i32,
@@ -501,7 +501,7 @@ pub fn writeRelocs(macho_file: *MachO, code: []u8, relocs: *std.ArrayList(macho.
             {
                 const offset = fde.out_offset + 8;
                 const saddr = sect.addr + offset;
-                const taddr = fde.getAtom(macho_file).value;
+                const taddr = fde.getAtom(macho_file).getAddress(macho_file);
                 std.mem.writeInt(
                     i64,
                     code[offset..][0..8],
@@ -513,7 +513,7 @@ pub fn writeRelocs(macho_file: *MachO, code: []u8, relocs: *std.ArrayList(macho.
             if (fde.getLsdaAtom(macho_file)) |atom| {
                 const offset = fde.out_offset + fde.lsda_ptr_offset;
                 const saddr = sect.addr + offset;
-                const taddr = atom.value + fde.lsda_offset;
+                const taddr = atom.getAddress(macho_file) + fde.lsda_offset;
                 switch (fde.getCie(macho_file).lsda_size.?) {
                     .p32 => std.mem.writeInt(
                         i32,

--- a/src/link/MachO/relocatable.zig
+++ b/src/link/MachO/relocatable.zig
@@ -61,7 +61,6 @@ pub fn flush(macho_file: *MachO, comp: *Compilation, module_obj_path: ?[]const u
     try createSegment(macho_file);
     try allocateSections(macho_file);
     allocateSegment(macho_file);
-    macho_file.allocateAtoms();
 
     var off = off: {
         const seg = macho_file.segments.items[0];

--- a/src/link/MachO/relocatable.zig
+++ b/src/link/MachO/relocatable.zig
@@ -328,7 +328,7 @@ fn writeAtoms(macho_file: *MachO) !void {
         for (atoms.items) |atom_index| {
             const atom = macho_file.getAtom(atom_index).?;
             assert(atom.flags.alive);
-            const off = math.cast(usize, atom.value - header.addr) orelse return error.Overflow;
+            const off = math.cast(usize, atom.value) orelse return error.Overflow;
             const atom_size = math.cast(usize, atom.size) orelse return error.Overflow;
             try atom.getData(macho_file, code[off..][0..atom_size]);
             try atom.writeRelocs(macho_file, code[off..][0..atom_size], &relocs);
@@ -386,7 +386,7 @@ fn writeAtoms(macho_file: *MachO) !void {
                     return error.FlushFailure;
                 },
             };
-            const file_offset = header.offset + atom.value - header.addr;
+            const file_offset = header.offset + atom.value;
             const rels = relocs.getPtr(atom.out_n_sect).?;
             try atom.writeRelocs(macho_file, code, rels);
             try macho_file.base.file.?.pwriteAll(code, file_offset);

--- a/src/link/MachO/relocatable.zig
+++ b/src/link/MachO/relocatable.zig
@@ -26,11 +26,6 @@ pub fn flush(macho_file: *MachO, comp: *Compilation, module_obj_path: ?[]const u
         return;
     }
 
-    if (macho_file.getZigObject() != null and positionals.items.len > 0) {
-        try macho_file.reportUnexpectedError("TODO: build-obj for ZigObject and input object files", .{});
-        return error.FlushFailure;
-    }
-
     for (positionals.items) |obj| {
         macho_file.parsePositional(obj.path, obj.must_link) catch |err| switch (err) {
             error.MalformedObject,

--- a/test/link/macho.zig
+++ b/test/link/macho.zig
@@ -1242,9 +1242,10 @@ fn testRelocatableZig(b: *Build, opts: Options) *Step {
     if (opts.use_llvm) {
         // TODO: enable this once self-hosted can print panics and stack traces
         run.addCheck(.{ .expect_stderr_match = b.dupe("panic: Oh no!") });
-        run.addCheck(.{ .expect_term = .{ .Signal = std.os.darwin.SIG.ABRT } });
-    } else {
-        run.addCheck(.{ .expect_term = .{ .Signal = std.os.darwin.SIG.TRAP } });
+    }
+    if (builtin.os.tag == .macos) {
+        const signal: u32 = if (opts.use_llvm) std.os.darwin.SIG.ABRT else std.os.darwin.SIG.TRAP;
+        run.addCheck(.{ .expect_term = .{ .Signal = signal } });
     }
     test_step.dependOn(&run.step);
 
@@ -2318,6 +2319,7 @@ fn addTestStep(b: *Build, comptime prefix: []const u8, opts: Options) *Step {
     return link.addTestStep(b, "macho-" ++ prefix, opts);
 }
 
+const builtin = @import("builtin");
 const addAsmSourceBytes = link.addAsmSourceBytes;
 const addCSourceBytes = link.addCSourceBytes;
 const addRunArtifact = link.addRunArtifact;

--- a/test/link/macho.zig
+++ b/test/link/macho.zig
@@ -15,6 +15,11 @@ pub fn testAll(b: *Build, build_opts: BuildOptions) *Step {
         .os_tag = .macos,
     });
 
+    // Exercise linker with self-hosted backend (no LLVM)
+    macho_step.dependOn(testHelloZig(b, .{ .use_llvm = false, .target = x86_64_target }));
+    macho_step.dependOn(testRelocatableZig(b, .{ .use_llvm = false, .strip = true, .target = x86_64_target }));
+
+    // Exercise linker with LLVM backend
     macho_step.dependOn(testDeadStrip(b, .{ .target = default_target }));
     macho_step.dependOn(testEmptyObject(b, .{ .target = default_target }));
     macho_step.dependOn(testEmptyZig(b, .{ .target = default_target }));
@@ -1234,7 +1239,13 @@ fn testRelocatableZig(b: *Build, opts: Options) *Step {
     const run = addRunArtifact(exe);
     run.addCheck(.{ .expect_stderr_match = b.dupe("incrFoo=1") });
     run.addCheck(.{ .expect_stderr_match = b.dupe("decrFoo=0") });
-    run.addCheck(.{ .expect_stderr_match = b.dupe("panic: Oh no!") });
+    if (opts.use_llvm) {
+        // TODO: enable this once self-hosted can print panics and stack traces
+        run.addCheck(.{ .expect_stderr_match = b.dupe("panic: Oh no!") });
+        run.addCheck(.{ .expect_term = .{ .Signal = std.os.darwin.SIG.ABRT } });
+    } else {
+        run.addCheck(.{ .expect_term = .{ .Signal = std.os.darwin.SIG.TRAP } });
+    }
     test_step.dependOn(&run.step);
 
     return test_step;


### PR DESCRIPTION
Implements `zig build-obj hello.zig -fno-llvm -fstrip`.

Closes #18668 

Emitting DWARF sections is still a TODO.