### PR TITLE
Make `@intFromEnum` an error for empty enums

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -8599,6 +8599,7 @@ fn zirIntFromEnum(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
         },
     };
     const enum_tag_ty = sema.typeOf(enum_tag);
+    const int_tag_ty = enum_tag_ty.intTagType(mod);
 
     // TODO: use correct solution
     // https://github.com/ziglang/zig/issues/15909
@@ -8608,19 +8609,15 @@ fn zirIntFromEnum(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
         });
     }
 
-    const int_tag_ty = enum_tag_ty.intTagType(mod);
-
-    if (try sema.resolveValue(operand)) |resolved_op| {
-        if (resolved_op.isUndef(mod)) {
-            return mod.undefRef(int_tag_ty);
-        }
-    }
-
     if (try sema.typeHasOnePossibleValue(enum_tag_ty)) |opv| {
         return Air.internedToRef((try mod.getCoerced(opv, int_tag_ty)).toIntern());
     }
 
     if (try sema.resolveValue(enum_tag)) |enum_tag_val| {
+        if (enum_tag_val.isUndef(mod)) {
+            return mod.undefRef(int_tag_ty);
+        }
+
         const val = try enum_tag_val.intFromEnum(enum_tag_ty, mod);
         return Air.internedToRef(val.toIntern());
     }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -8606,7 +8606,7 @@ fn zirIntFromEnum(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
     };
     const enum_tag_ty = sema.typeOf(enum_tag);
 
-    if (enum_tag_ty.enumFieldCount(mod) == 0) {
+    if (enum_tag_ty.enumFieldCount(mod) == 0 and !enum_tag_ty.isNonexhaustiveEnum(mod)) {
         return sema.fail(block, operand_src, "cannot use @intFromEnum on empty enum '{}'", .{
             enum_tag_ty.fmt(mod),
         });

--- a/test/cases/compile_errors/int_from_enum_undefined.zig
+++ b/test/cases/compile_errors/int_from_enum_undefined.zig
@@ -1,0 +1,22 @@
+export fn a() void {
+    const E = enum {};
+    var e: E = undefined;
+    _ = &e;
+    _ = @intFromEnum(e);
+}
+
+comptime {
+    const E = union(enum(u16)) {
+        a: u32,
+        b: u32,
+    };
+    const e: E = undefined;
+    _ = @intFromEnum(e);
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :14:22: error: use of undefined value here causes undefined behavior
+// :5:22: error: cannot use @intFromEnum on empty enum 'tmp.a.E'

--- a/test/cases/compile_errors/int_from_enum_undefined.zig
+++ b/test/cases/compile_errors/int_from_enum_undefined.zig
@@ -5,18 +5,8 @@ export fn a() void {
     _ = @intFromEnum(e);
 }
 
-comptime {
-    const E = union(enum(u16)) {
-        a: u32,
-        b: u32,
-    };
-    const e: E = undefined;
-    _ = @intFromEnum(e);
-}
-
 // error
 // backend=stage2
 // target=native
 //
-// :14:22: error: use of undefined value here causes undefined behavior
 // :5:22: error: cannot use @intFromEnum on empty enum 'tmp.a.E'


### PR DESCRIPTION
fixes #18767

+ makes running `@intFromEnum` on undefined return undefined
+ makes running `@intFromEnum` on empty enums (that are exhaustive) an error.

~~should we reconsider empty enums in general? they have no actual value representation, and so i'm confused why we have them.~~