### PR TITLE
fix typo in wasm atomic opcodes doc comment

### DIFF
--- a/lib/std/wasm.zig
+++ b/lib/std/wasm.zig
@@ -518,7 +518,7 @@ pub fn simdOpcode(op: SimdOpcode) u32 {
     return @intFromEnum(op);
 }
 
-/// Simd opcodes that require a prefix `0xFE`.
+/// Atomic opcodes that require a prefix `0xFE`.
 /// Each opcode represents a varuint32, meaning
 /// they are encoded as leb128 in binary.
 pub const AtomicsOpcode = enum(u32) {


### PR DESCRIPTION
Looks like the doc comment was initially copied from the `SimdOpcode`, fixes the typo