### PR TITLE
Cache: fix logic for retrying cache hits

### DIFF
--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -482,11 +482,11 @@ pub const Manifest = struct {
 
         self.want_refresh_timestamp = true;
 
-        while (true) {
+        const input_file_count = self.files.items.len;
+        while (true) : (self.unhit(bin_digest, input_file_count)) {
             const file_contents = try self.manifest_file.?.reader().readAllAlloc(gpa, manifest_file_size_max);
             defer gpa.free(file_contents);
 
-            const input_file_count = self.files.items.len;
             var any_file_changed = false;
             var line_iter = mem.tokenizeScalar(u8, file_contents, '\n');
             var idx: usize = 0;


### PR DESCRIPTION
I haven't been able to reproduce the `StreamTooLong` issue to verify, but based on when it was reported, and when I introduced the code this PR fixes, I suspect this may be the fix.

Extracted from #18792
Fixes potentially #16149