### PR TITLE
Add missing comptime fail in `zirBlock`

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5920,7 +5920,14 @@ fn zirBlock(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index, force_compt
     defer child_block.instructions.deinit(gpa);
     defer label.merges.deinit(gpa);
 
-    return sema.resolveBlockBody(parent_block, src, &child_block, body, inst, &label.merges);
+    const result = try sema.resolveBlockBody(parent_block, src, &child_block, body, inst, &label.merges);
+    if (null == try sema.resolveValue(result)) {
+        // Couldn't resolve at comptime.
+        if (child_block.is_comptime) {
+            return sema.fail(parent_block, src, "unable to resolve comptime value", .{});
+        }
+    }
+    return result;
 }
 
 fn resolveBlockBody(

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5922,7 +5922,6 @@ fn zirBlock(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index, force_compt
 
     const result = try sema.resolveBlockBody(parent_block, src, &child_block, body, inst, &label.merges);
     if (null == try sema.resolveValue(result)) {
-        // Couldn't resolve at comptime.
         if (child_block.is_comptime) {
             return sema.fail(parent_block, src, "unable to resolve comptime value", .{});
         }

--- a/test/cases/compile_errors/comptime_keyword.zig
+++ b/test/cases/compile_errors/comptime_keyword.zig
@@ -1,0 +1,11 @@
+export fn a() void {
+    var x: u8 = 10;
+    _ = &x;
+    switch (comptime x) {}
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:22: error: unable to resolve comptime value

--- a/test/cases/compile_errors/comptime_keyword.zig
+++ b/test/cases/compile_errors/comptime_keyword.zig
@@ -1,11 +1,11 @@
 export fn a() void {
-    var x: u8 = 10;
+    var x: bool = false;
     _ = &x;
-    switch (comptime x) {}
+    if (comptime x) {}
 }
 
 // error
 // backend=stage2
 // target=native
 //
-// :4:22: error: unable to resolve comptime value
+// :4:18: error: unable to resolve comptime value


### PR DESCRIPTION
fixes #16775

This fixes code like in the ^issue, and in general any use of `comptime X`.  Like this:
```zig
const args = try std.process.argsAlloc(allocator);
const arg = args[1];
const number = try std.fmt.parseInt(u32, arg, 10);

switch (comptime number) { // This wouldn't error before.
    1 => std.debug.print("Test\n", .{}),
    else => {},
}
```