### PR TITLE
build system: add addOtherIncludePath helper

### DIFF
--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -539,6 +539,14 @@ pub fn addIncludePath(m: *Module, lazy_path: LazyPath) void {
     addLazyPathDependenciesOnly(m, lazy_path);
 }
 
+pub fn addOtherIncludePath(m: *Module, other: *Step.Compile) void {
+    const b = m.owner;
+    m.include_dirs.append(b.allocator, .{ .other_step = other }) catch @panic("OOM");
+    for (other.installed_headers.items) |install_step| {
+        addStepDependenciesOnly(m, install_step);
+    }
+}
+
 pub fn addConfigHeader(m: *Module, config_header: *Step.ConfigHeader) void {
     const allocator = m.owner.allocator;
     m.include_dirs.append(allocator, .{ .config_header_step = config_header }) catch @panic("OOM");

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -824,6 +824,10 @@ pub fn addIncludePath(self: *Compile, lazy_path: LazyPath) void {
     self.root_module.addIncludePath(lazy_path);
 }
 
+pub fn addOtherIncludePath(self: *Compile, other: *Step.Compile) void {
+    self.root_module.addOtherIncludePath(other);
+}
+
 pub fn addConfigHeader(self: *Compile, config_header: *Step.ConfigHeader) void {
     self.root_module.addConfigHeader(config_header);
 }


### PR DESCRIPTION
Sometimes, we only want to include the header of a library, for example, bpf programs only includes headers from libbpf but do not link with it.  This PR adds a helper function that would do exactly that, currently I am using some ugly code to achieve it in my own code:

```zig
    const bpf_dep = b.dependency("bpf", .{
        .target = target,
        .optimize = optimize,
    });
    const bpf_artifact = bpf_dep.artifact("bpf");
    const obj = b.addObject(.{
        .name = "exechijack.bpf",
        .target = b.resolveTargetQuery(.{
            .cpu_arch = switch (t.cpu.arch.endian()) {
                .big => .bpfeb,
                .little => .bpfel,
            },
            .os_tag = .freestanding,
        }),
        .optimize = .ReleaseFast,
    });
    obj.addIncludePath(.{ .path = "include" });
    obj.addCSourceFile(.{
        .file = .{ .path = "src/exechijack.bpf.c" },
        .flags = &.{"-g"},
    });
    obj.root_module.include_dirs.append(
        b.allocator,
        .{ .other_step = bpf_artifact },
    ) catch @panic("OOM");
    for (bpf_artifact.installed_headers.items) |step| {
        obj.step.dependOn(step);
    }
```