### PR TITLE
macho: implement our own archiver

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -926,7 +926,7 @@ pub fn resolveLibSystem(
     });
 }
 
-const ParseError = error{
+pub const ParseError = error{
     MalformedObject,
     MalformedArchive,
     MalformedDylib,
@@ -1003,7 +1003,7 @@ fn parseObject(self: *MachO, path: []const u8) ParseError!void {
     try object.parse(self);
 }
 
-fn parseFatLibrary(self: *MachO, path: []const u8) !fat.Arch {
+pub fn parseFatLibrary(self: *MachO, path: []const u8) !fat.Arch {
     var buffer: [2]fat.Arch = undefined;
     const fat_archs = try fat.parseArchs(path, &buffer);
     const cpu_arch = self.getTarget().cpu.arch;

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -417,8 +417,8 @@ pub fn flushModule(self: *MachO, arena: Allocator, prog_node: *std.Progress.Node
     if (comp.verbose_link) try self.dumpArgv(comp);
 
     if (self.getZigObject()) |zo| try zo.flushModule(self);
-    if (self.base.isStaticLib()) return Archive.flush(self, comp, module_obj_path);
-    if (self.base.isObject()) return relocatable.flush(self, comp, module_obj_path);
+    if (self.base.isStaticLib()) return relocatable.flushStaticLib(self, comp, module_obj_path);
+    if (self.base.isObject()) return relocatable.flushObject(self, comp, module_obj_path);
 
     var positionals = std.ArrayList(Compilation.LinkObject).init(gpa);
     defer positionals.deinit();

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -380,7 +380,7 @@ pub fn deinit(self: *MachO) void {
 
 pub fn flush(self: *MachO, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
     // TODO: I think this is just a temp and can be removed once we can emit static archives
-    if (self.base.isStaticLib() and build_options.have_llvm) {
+    if (self.base.isStaticLib() and build_options.have_llvm and self.base.comp.config.use_llvm) {
         return self.base.linkAsArchive(arena, prog_node);
     }
     try self.flushModule(arena, prog_node);
@@ -396,7 +396,7 @@ pub fn flushModule(self: *MachO, arena: Allocator, prog_node: *std.Progress.Node
     if (self.llvm_object) |llvm_object| {
         try self.base.emitLlvmObject(arena, llvm_object, prog_node);
         // TODO: I think this is just a temp and can be removed once we can emit static archives
-        if (self.base.isStaticLib() and build_options.have_llvm) return;
+        if (self.base.isStaticLib() and build_options.have_llvm and self.base.comp.config.use_llvm) return;
     }
 
     var sub_prog_node = prog_node.start("MachO Flush", 0);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -606,7 +606,9 @@ pub fn flushModule(self: *MachO, arena: Allocator, prog_node: *std.Progress.Node
     self.allocateSyntheticSymbols();
     try self.allocateLinkeditSegment();
 
-    state_log.debug("{}", .{self.dumpState()});
+    if (build_options.enable_logging) {
+        state_log.debug("{}", .{self.dumpState()});
+    }
 
     try self.initDyldInfoSections();
 

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -379,10 +379,6 @@ pub fn deinit(self: *MachO) void {
 }
 
 pub fn flush(self: *MachO, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
-    // TODO: I think this is just a temp and can be removed once we can emit static archives
-    if (self.base.isStaticLib() and build_options.have_llvm and self.base.comp.config.use_llvm) {
-        return self.base.linkAsArchive(arena, prog_node);
-    }
     try self.flushModule(arena, prog_node);
 }
 
@@ -395,8 +391,6 @@ pub fn flushModule(self: *MachO, arena: Allocator, prog_node: *std.Progress.Node
 
     if (self.llvm_object) |llvm_object| {
         try self.base.emitLlvmObject(arena, llvm_object, prog_node);
-        // TODO: I think this is just a temp and can be removed once we can emit static archives
-        if (self.base.isStaticLib() and build_options.have_llvm and self.base.comp.config.use_llvm) return;
     }
 
     var sub_prog_node = prog_node.start("MachO Flush", 0);

--- a/src/link/MachO/Archive.zig
+++ b/src/link/MachO/Archive.zig
@@ -143,7 +143,18 @@ pub fn parse(self: *Archive, macho_file: *MachO, path: []const u8, handle_index:
     }
 }
 
+pub fn flush(macho_file: *MachO, comp: *Compilation, module_obj_path: ?[]const u8) link.File.FlushError!void {
+    _ = comp;
+    _ = module_obj_path;
+
+    var err = try macho_file.addErrorWithNotes(0);
+    try err.addMsg(macho_file, "TODO implement flushStaticLib", .{});
+
+    return error.FlushFailure;
+}
+
 const fat = @import("fat.zig");
+const link = @import("../../link.zig");
 const log = std.log.scoped(.link);
 const macho = std.macho;
 const mem = std.mem;
@@ -151,6 +162,7 @@ const std = @import("std");
 
 const Allocator = mem.Allocator;
 const Archive = @This();
+const Compilation = @import("../../Compilation.zig");
 const File = @import("file.zig").File;
 const MachO = @import("../MachO.zig");
 const Object = @import("Object.zig");

--- a/src/link/MachO/Archive.zig
+++ b/src/link/MachO/Archive.zig
@@ -231,7 +231,7 @@ pub const ArSymtab = struct {
             try writeInt(format, file_off, writer);
         }
         // Strtab size
-        const strtab_size = mem.alignForward(u64, ar.strtab.buffer.items.len, ptr_width);
+        const strtab_size = mem.alignForward(usize, ar.strtab.buffer.items.len, ptr_width);
         const padding = strtab_size - ar.strtab.buffer.items.len;
         try writeInt(format, strtab_size, writer);
         // Strtab

--- a/src/link/MachO/Archive.zig
+++ b/src/link/MachO/Archive.zig
@@ -213,10 +213,11 @@ pub const ArSymtab = struct {
     }
 
     pub fn write(ar: ArSymtab, format: Format, macho_file: *MachO, writer: anytype) !void {
+        const ptr_width = ptrWidth(format);
         // Header
         try writeHeader(SYMDEF, ar.size(format), format, writer);
         // Symtab size
-        try writeInt(format, ar.entries.items.len * 2, writer);
+        try writeInt(format, ar.entries.items.len * 2 * ptr_width, writer);
         // Symtab entries
         for (ar.entries.items) |entry| {
             const file_off = switch (macho_file.getFile(entry.file).?) {
@@ -230,7 +231,7 @@ pub const ArSymtab = struct {
             try writeInt(format, file_off, writer);
         }
         // Strtab size
-        const strtab_size = mem.alignForward(u64, ar.strtab.buffer.items.len, ptrWidth(format));
+        const strtab_size = mem.alignForward(u64, ar.strtab.buffer.items.len, ptr_width);
         const padding = strtab_size - ar.strtab.buffer.items.len;
         try writeInt(format, strtab_size, writer);
         // Strtab

--- a/src/link/MachO/Archive.zig
+++ b/src/link/MachO/Archive.zig
@@ -143,51 +143,15 @@ pub fn parse(self: *Archive, macho_file: *MachO, path: []const u8, handle_index:
     }
 }
 
-pub fn flush(macho_file: *MachO, comp: *Compilation, module_obj_path: ?[]const u8) link.File.FlushError!void {
-    const gpa = comp.gpa;
-
-    var positionals = std.ArrayList(Compilation.LinkObject).init(gpa);
-    defer positionals.deinit();
-
-    try positionals.ensureUnusedCapacity(comp.objects.len);
-    positionals.appendSliceAssumeCapacity(comp.objects);
-
-    for (comp.c_object_table.keys()) |key| {
-        try positionals.append(.{ .path = key.status.success.object_path });
-    }
-
-    if (module_obj_path) |path| try positionals.append(.{ .path = path });
-
-    for (positionals.items) |obj| {
-        // TODO: parse for archive meaning don't unpack objects
-        _ = obj;
-    }
-
-    if (comp.link_errors.items.len > 0) return error.FlushFailure;
-
-    // First, we flush relocatable object file generated with our backends.
-    if (macho_file.getZigObject()) |zo| {
-        zo.resolveSymbols(macho_file);
-        zo.asFile().claimUnresolvedRelocatable(macho_file);
-    }
-
-    var err = try macho_file.addErrorWithNotes(0);
-    try err.addMsg(macho_file, "TODO implement flushStaticLib", .{});
-
-    return error.FlushFailure;
-}
-
 const fat = @import("fat.zig");
 const link = @import("../../link.zig");
 const log = std.log.scoped(.link);
 const macho = std.macho;
 const mem = std.mem;
-const relocatable = @import("relocatable.zig");
 const std = @import("std");
 
 const Allocator = mem.Allocator;
 const Archive = @This();
-const Compilation = @import("../../Compilation.zig");
 const File = @import("file.zig").File;
 const MachO = @import("../MachO.zig");
 const Object = @import("Object.zig");

--- a/src/link/MachO/Archive.zig
+++ b/src/link/MachO/Archive.zig
@@ -1,5 +1,136 @@
 objects: std.ArrayListUnmanaged(Object) = .{},
 
+pub fn isArchive(path: []const u8, fat_arch: ?fat.Arch) !bool {
+    const file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+    if (fat_arch) |arch| {
+        try file.seekTo(arch.offset);
+    }
+    const magic = file.reader().readBytesNoEof(SARMAG) catch return false;
+    if (!mem.eql(u8, &magic, ARMAG)) return false;
+    return true;
+}
+
+pub fn deinit(self: *Archive, allocator: Allocator) void {
+    self.objects.deinit(allocator);
+}
+
+pub fn parse(self: *Archive, macho_file: *MachO, path: []const u8, handle_index: File.HandleIndex, fat_arch: ?fat.Arch) !void {
+    const gpa = macho_file.base.comp.gpa;
+
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+
+    const handle = macho_file.getFileHandle(handle_index);
+    const offset = if (fat_arch) |ar| ar.offset else 0;
+    const size = if (fat_arch) |ar| ar.size else (try handle.stat()).size;
+    try handle.seekTo(offset);
+
+    const reader = handle.reader();
+    _ = try reader.readBytesNoEof(SARMAG);
+
+    var pos: usize = SARMAG;
+    while (true) {
+        if (pos >= size) break;
+        if (!mem.isAligned(pos, 2)) {
+            try handle.seekBy(1);
+            pos += 1;
+        }
+
+        const hdr = try reader.readStruct(ar_hdr);
+        pos += @sizeOf(ar_hdr);
+
+        if (!mem.eql(u8, &hdr.ar_fmag, ARFMAG)) {
+            try macho_file.reportParseError(path, "invalid header delimiter: expected '{s}', found '{s}'", .{
+                std.fmt.fmtSliceEscapeLower(ARFMAG), std.fmt.fmtSliceEscapeLower(&hdr.ar_fmag),
+            });
+            return error.MalformedArchive;
+        }
+
+        var hdr_size = try hdr.size();
+        const name = name: {
+            if (hdr.name()) |n| break :name n;
+            if (try hdr.nameLength()) |len| {
+                hdr_size -= len;
+                const buf = try arena.allocator().alloc(u8, len);
+                try reader.readNoEof(buf);
+                pos += len;
+                const actual_len = mem.indexOfScalar(u8, buf, @as(u8, 0)) orelse len;
+                break :name buf[0..actual_len];
+            }
+            unreachable;
+        };
+        defer {
+            _ = handle.seekBy(hdr_size) catch {};
+            pos += hdr_size;
+        }
+
+        if (mem.eql(u8, name, SYMDEF) or
+            mem.eql(u8, name, SYMDEF64) or
+            mem.eql(u8, name, SYMDEF_SORTED) or
+            mem.eql(u8, name, SYMDEF64_SORTED)) continue;
+
+        const object = Object{
+            .archive = .{
+                .path = try gpa.dupe(u8, path),
+                .offset = offset + pos,
+            },
+            .path = try gpa.dupe(u8, name),
+            .file_handle = handle_index,
+            .index = undefined,
+            .alive = false,
+            .mtime = hdr.date() catch 0,
+        };
+
+        log.debug("extracting object '{s}' from archive '{s}'", .{ object.path, path });
+
+        try self.objects.append(gpa, object);
+    }
+}
+
+pub fn writeHeader(
+    object_name: []const u8,
+    object_size: u32,
+    format: Format,
+    writer: anytype,
+) !void {
+    var hdr: ar_hdr = .{
+        .ar_name = undefined,
+        .ar_date = undefined,
+        .ar_uid = undefined,
+        .ar_gid = undefined,
+        .ar_mode = undefined,
+        .ar_size = undefined,
+        .ar_fmag = undefined,
+    };
+    @memset(mem.asBytes(&hdr), 0x20);
+    inline for (@typeInfo(ar_hdr).Struct.fields) |field| {
+        var stream = std.io.fixedBufferStream(&@field(hdr, field.name));
+        stream.writer().print("0", .{}) catch unreachable;
+    }
+    @memcpy(&hdr.ar_fmag, ARFMAG);
+
+    const object_name_len = mem.alignForward(u32, object_name.len + 1, format.ptrWidth());
+    const total_object_size = object_size + object_name_len;
+
+    {
+        var stream = std.io.fixedBufferStream(&hdr.ar_name);
+        stream.writer().print("#1/{d}", .{object_name_len}) catch unreachable;
+    }
+    {
+        var stream = std.io.fixedBufferStream(&hdr.ar_size);
+        stream.writer().print("{d}", .{total_object_size}) catch unreachable;
+    }
+
+    try writer.writeAll(mem.asBytes(&hdr));
+    try writer.print("{s}\x00", .{object_name});
+
+    const padding = object_name_len - object_name.len - 1;
+    if (padding > 0) {
+        try writer.writeByteNTimes(0, padding);
+    }
+}
+
 // Archive files start with the ARMAG identifying string.  Then follows a
 // `struct ar_hdr', and as many bytes of member file data as its `ar_size'
 // member indicates, for each member file.
@@ -10,6 +141,11 @@ pub const SARMAG: u4 = 8;
 
 /// String in ar_fmag at the end of each header.
 const ARFMAG: *const [2:0]u8 = "`\n";
+
+const SYMDEF = "__.SYMDEF";
+const SYMDEF64 = "__.SYMDEF_64";
+const SYMDEF_SORTED = "__.SYMDEF SORTED";
+const SYMDEF64_SORTED = "__.SYMDEF_64 SORTED";
 
 const ar_hdr = extern struct {
     /// Member file name, sometimes / terminated.
@@ -58,90 +194,120 @@ const ar_hdr = extern struct {
     }
 };
 
-pub fn isArchive(path: []const u8, fat_arch: ?fat.Arch) !bool {
-    const file = try std.fs.cwd().openFile(path, .{});
-    defer file.close();
-    if (fat_arch) |arch| {
-        try file.seekTo(arch.offset);
+pub const ArSymtab = struct {
+    entries: std.ArrayListUnmanaged(Entry) = .{},
+    strtab: StringTable = .{},
+    format: Format = .p32,
+
+    pub fn deinit(ar: *ArSymtab, allocator: Allocator) void {
+        ar.entries.deinit(allocator);
+        ar.strtab.deinit(allocator);
     }
-    const magic = file.reader().readBytesNoEof(SARMAG) catch return false;
-    if (!mem.eql(u8, &magic, ARMAG)) return false;
-    return true;
-}
 
-pub fn deinit(self: *Archive, allocator: Allocator) void {
-    self.objects.deinit(allocator);
-}
-
-pub fn parse(self: *Archive, macho_file: *MachO, path: []const u8, handle_index: File.HandleIndex, fat_arch: ?fat.Arch) !void {
-    const gpa = macho_file.base.comp.gpa;
-
-    var arena = std.heap.ArenaAllocator.init(gpa);
-    defer arena.deinit();
-
-    const handle = macho_file.getFileHandle(handle_index);
-    const offset = if (fat_arch) |ar| ar.offset else 0;
-    const size = if (fat_arch) |ar| ar.size else (try handle.stat()).size;
-    try handle.seekTo(offset);
-
-    const reader = handle.reader();
-    _ = try reader.readBytesNoEof(Archive.SARMAG);
-
-    var pos: usize = Archive.SARMAG;
-    while (true) {
-        if (pos >= size) break;
-        if (!mem.isAligned(pos, 2)) {
-            try handle.seekBy(1);
-            pos += 1;
-        }
-
-        const hdr = try reader.readStruct(ar_hdr);
-        pos += @sizeOf(ar_hdr);
-
-        if (!mem.eql(u8, &hdr.ar_fmag, ARFMAG)) {
-            try macho_file.reportParseError(path, "invalid header delimiter: expected '{s}', found '{s}'", .{
-                std.fmt.fmtSliceEscapeLower(ARFMAG), std.fmt.fmtSliceEscapeLower(&hdr.ar_fmag),
-            });
-            return error.MalformedArchive;
-        }
-
-        var hdr_size = try hdr.size();
-        const name = name: {
-            if (hdr.name()) |n| break :name n;
-            if (try hdr.nameLength()) |len| {
-                hdr_size -= len;
-                const buf = try arena.allocator().alloc(u8, len);
-                try reader.readNoEof(buf);
-                pos += len;
-                const actual_len = mem.indexOfScalar(u8, buf, @as(u8, 0)) orelse len;
-                break :name buf[0..actual_len];
-            }
-            unreachable;
-        };
-        defer {
-            _ = handle.seekBy(hdr_size) catch {};
-            pos += hdr_size;
-        }
-
-        if (mem.eql(u8, name, "__.SYMDEF") or mem.eql(u8, name, "__.SYMDEF SORTED")) continue;
-
-        const object = Object{
-            .archive = .{
-                .path = try gpa.dupe(u8, path),
-                .offset = offset + pos,
-            },
-            .path = try gpa.dupe(u8, name),
-            .file_handle = handle_index,
-            .index = undefined,
-            .alive = false,
-            .mtime = hdr.date() catch 0,
-        };
-
-        log.debug("extracting object '{s}' from archive '{s}'", .{ object.path, path });
-
-        try self.objects.append(gpa, object);
+    pub fn sort(ar: *ArSymtab) void {
+        mem.sort(Entry, ar.entries.items, {}, Entry.lessThan);
     }
-}
+
+    pub fn size(ar: ArSymtab) usize {
+        const ptr_width = ar.format.ptrWidth();
+        return ptr_width + ar.entries.items.len * 2 * ptr_width + ptr_width + mem.alignForward(usize, ar.strtab.buffer.items.len, ptr_width);
+    }
+
+    pub fn write(ar: ArSymtab, macho_file: *MachO, writer: anytype) !void {
+        // Header
+        try writeHeader(SYMDEF, ar.size());
+        // Symtab size
+        try ar.writeInt(ar.entries.items.len * 2);
+        // Symtab entries
+        for (ar.entries.items) |entry| {
+            const file_off = switch (macho_file.getFile(entry.file).?) {
+                .zig_object => |x| x.output_ar_state.file_off,
+                .object => |x| x.output_ar_state.file_off,
+                else => unreachable,
+            };
+            // Name offset
+            try ar.writeInt(entry.off);
+            // File offset
+            try ar.writeInt(file_off);
+        }
+        // Strtab size
+        const strtab_size = mem.alignForward(u64, ar.strtab.buffer.items.len, ar.format.ptrWidth());
+        const padding = strtab_size - ar.strtab.buffer.items.len;
+        try ar.writeInt(strtab_size);
+        // Strtab
+        try writer.writeAll(ar.strtab.buffer.items);
+        if (padding > 0) {
+            try writer.writeByteNTimes(0, padding);
+        }
+    }
+
+    fn writeInt(ar: ArSymtab, value: u64, writer: anytype) !void {
+        switch (ar.format) {
+            .p32 => try writer.writeInt(u32, std.math.cast(u32, value) orelse return error.Overflow, .little),
+            .p64 => try writer.writeInt(u64, value, .little),
+        }
+    }
+
+    const FormatContext = struct {
+        ar: ArSymtab,
+        macho_file: *MachO,
+    };
+
+    pub fn fmt(ar: ArSymtab, macho_file: *MachO) std.fmt.Formatter(format2) {
+        return .{ .data = .{ .ar = ar, .macho_file = macho_file } };
+    }
+
+    fn format2(
+        ctx: FormatContext,
+        comptime unused_fmt_string: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        _ = unused_fmt_string;
+        _ = options;
+        const ar = ctx.ar;
+        const macho_file = ctx.macho_file;
+        for (ar.entries.items, 0..) |entry, i| {
+            const name = ar.strtab.getAssumeExists(entry.off);
+            const file = macho_file.getFile(entry.file).?;
+            try writer.print("  {d}: {s} in file({d})({})\n", .{ i, name, entry.file, file.fmtPath() });
+        }
+    }
+
+    const Entry = struct {
+        /// Symbol name offset
+        off: u32,
+        /// Exporting file
+        file: File.Index,
+
+        pub fn lessThan(ctx: void, lhs: Entry, rhs: Entry) bool {
+            _ = ctx;
+            if (lhs.off == rhs.off) return lhs.file < rhs.file;
+            return lhs.off < rhs.off;
+        }
+    };
+};
+
+const Format = enum {
+    p32,
+    p64,
+
+    fn ptrWidth(self: Format) usize {
+        return switch (self) {
+            .p32 => @as(usize, 4),
+            .p64 => 8,
+        };
+    }
+};
+
+pub const ArState = struct {
+    /// File offset of the ar_hdr describing the contributing
+    /// object in the archive.
+    file_off: u64 = 0,
+
+    /// Total size of the contributing object (excludes ar_hdr and long name with padding).
+    size: u64 = 0,
+};
 
 const fat = @import("fat.zig");
 const link = @import("../../link.zig");
@@ -155,3 +321,4 @@ const Archive = @This();
 const File = @import("file.zig").File;
 const MachO = @import("../MachO.zig");
 const Object = @import("Object.zig");
+const StringTable = @import("../StringTable.zig");

--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -1332,8 +1332,10 @@ pub fn writeAr(self: Object, ar_format: Archive.Format, macho_file: *MachO, writ
     const file = macho_file.getFileHandle(self.file_handle);
     // TODO try using copyRangeAll
     const gpa = macho_file.base.comp.gpa;
-    const data = try file.readToEndAlloc(gpa, size);
+    const data = try gpa.alloc(u8, size);
     defer gpa.free(data);
+    const amt = try file.preadAll(data, 0);
+    if (amt != size) return error.InputOutput;
     try writer.writeAll(data);
 }
 

--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -1248,14 +1248,15 @@ pub fn updateArSize(self: *Object, macho_file: *MachO) !void {
     self.output_ar_state.size = size;
 }
 
-pub fn writeAr(self: Object, macho_file: *MachO, writer: anytype) !void {
+pub fn writeAr(self: Object, ar_format: Archive.Format, macho_file: *MachO, writer: anytype) !void {
     // Header
-    try Archive.writeHeader(self.path, self.output_ar_state.size, writer);
+    const size = std.math.cast(usize, self.output_ar_state.size) orelse return error.Overflow;
+    try Archive.writeHeader(self.path, size, ar_format, writer);
     // Data
     const file = macho_file.getFileHandle(self.file_handle);
     // TODO try using copyRangeAll
     const gpa = macho_file.base.comp.gpa;
-    const data = try file.readToEndAlloc(gpa, self.output_ar_state.size);
+    const data = try file.readToEndAlloc(gpa, size);
     defer gpa.free(data);
     try writer.writeAll(data);
 }

--- a/src/link/MachO/ZigObject.zig
+++ b/src/link/MachO/ZigObject.zig
@@ -314,9 +314,10 @@ pub fn updateArSize(self: *ZigObject) void {
     self.output_ar_state.size = self.data.items.len;
 }
 
-pub fn writeAr(self: ZigObject, writer: anytype) !void {
+pub fn writeAr(self: ZigObject, ar_format: Archive.Format, writer: anytype) !void {
     // Header
-    try Archive.writeHeader(self.path, self.output_ar_state.size, writer);
+    const size = std.math.cast(usize, self.output_ar_state.size) orelse return error.Overflow;
+    try Archive.writeHeader(self.path, size, ar_format, writer);
     // Data
     try writer.writeAll(self.data.items);
 }

--- a/src/link/MachO/ZigObject.zig
+++ b/src/link/MachO/ZigObject.zig
@@ -285,15 +285,9 @@ pub fn checkDuplicates(self: *ZigObject, dupes: anytype, macho_file: *MachO) !vo
 /// This is just a temporary helper function that allows us to re-read what we wrote to file into a buffer.
 /// We need this so that we can write to an archive.
 /// TODO implement writing ZigObject data directly to a buffer instead.
-pub fn readFileContents(self: *ZigObject, macho_file: *MachO) !void {
+pub fn readFileContents(self: *ZigObject, size: usize, macho_file: *MachO) !void {
     const gpa = macho_file.base.comp.gpa;
-    var end_pos: u64 = 0;
-    for (macho_file.segments.items) |seg| {
-        end_pos = @max(end_pos, seg.fileoff + seg.filesize);
-    }
-    const size = std.math.cast(usize, end_pos) orelse return error.Overflow;
     try self.data.resize(gpa, size);
-
     const amt = try macho_file.base.file.?.preadAll(self.data.items, 0);
     if (amt != size) return error.InputOutput;
 }

--- a/src/link/MachO/file.zig
+++ b/src/link/MachO/file.zig
@@ -44,6 +44,97 @@ pub const File = union(enum) {
         }
     }
 
+    pub fn claimUnresolved(file: File, macho_file: *MachO) error{OutOfMemory}!void {
+        assert(file == .object or file == .zig_object);
+
+        for (file.getSymbols(), 0..) |sym_index, i| {
+            const nlist_idx = @as(Symbol.Index, @intCast(i));
+            const nlist = switch (file) {
+                .object => |x| x.symtab.items(.nlist)[nlist_idx],
+                .zig_object => |x| x.symtab.items(.nlist)[nlist_idx],
+                else => unreachable,
+            };
+            if (!nlist.ext()) continue;
+            if (!nlist.undf()) continue;
+
+            const sym = macho_file.getSymbol(sym_index);
+            if (sym.getFile(macho_file) != null) continue;
+
+            const is_import = switch (macho_file.undefined_treatment) {
+                .@"error" => false,
+                .warn, .suppress => nlist.weakRef(),
+                .dynamic_lookup => true,
+            };
+            if (is_import) {
+                sym.value = 0;
+                sym.atom = 0;
+                sym.nlist_idx = 0;
+                sym.file = macho_file.internal_object.?;
+                sym.flags.weak = false;
+                sym.flags.weak_ref = nlist.weakRef();
+                sym.flags.import = is_import;
+                sym.visibility = .global;
+                try macho_file.getInternalObject().?.symbols.append(macho_file.base.comp.gpa, sym_index);
+            }
+        }
+    }
+
+    pub fn claimUnresolvedRelocatable(file: File, macho_file: *MachO) void {
+        assert(file == .object or file == .zig_object);
+
+        for (file.getSymbols(), 0..) |sym_index, i| {
+            const nlist_idx = @as(Symbol.Index, @intCast(i));
+            const nlist = switch (file) {
+                .object => |x| x.symtab.items(.nlist)[nlist_idx],
+                .zig_object => |x| x.symtab.items(.nlist)[nlist_idx],
+                else => unreachable,
+            };
+            if (!nlist.ext()) continue;
+            if (!nlist.undf()) continue;
+
+            const sym = macho_file.getSymbol(sym_index);
+            if (sym.getFile(macho_file) != null) continue;
+
+            sym.value = 0;
+            sym.atom = 0;
+            sym.nlist_idx = nlist_idx;
+            sym.file = file.getIndex();
+            sym.flags.weak_ref = nlist.weakRef();
+            sym.flags.import = true;
+            sym.visibility = .global;
+        }
+    }
+
+    pub fn markImportsExports(file: File, macho_file: *MachO) void {
+        assert(file == .object or file == .zig_object);
+
+        for (file.getSymbols()) |sym_index| {
+            const sym = macho_file.getSymbol(sym_index);
+            const other_file = sym.getFile(macho_file) orelse continue;
+            if (sym.visibility != .global) continue;
+            if (other_file == .dylib and !sym.flags.abs) {
+                sym.flags.import = true;
+                continue;
+            }
+            if (other_file.getIndex() == file.getIndex()) {
+                sym.flags.@"export" = true;
+            }
+        }
+    }
+
+    pub fn markExportsRelocatable(file: File, macho_file: *MachO) void {
+        assert(file == .object or file == .zig_object);
+
+        for (file.getSymbols()) |sym_index| {
+            const sym = macho_file.getSymbol(sym_index);
+            const other_file = sym.getFile(macho_file) orelse continue;
+            if (sym.visibility != .global) continue;
+            if (other_file.getIndex() == file.getIndex()) {
+                sym.flags.@"export" = true;
+            }
+        }
+    }
+
     /// Encodes symbol rank so that the following ordering applies:
     /// * strong in object
     /// * weak in object
@@ -110,6 +201,7 @@ pub const File = union(enum) {
     pub const HandleIndex = Index;
 };
 
+const assert = std.debug.assert;
 const macho = std.macho;
 const std = @import("std");
 

--- a/src/link/MachO/file.zig
+++ b/src/link/MachO/file.zig
@@ -175,6 +175,13 @@ pub const File = union(enum) {
         };
     }
 
+    pub fn updateArSymtab(file: File, ar_symtab: *Archive.ArSymtab, macho_file: *MachO) error{OutOfMemory}!void {
+        return switch (file) {
+            .dylib, .internal => unreachable,
+            inline else => |x| x.updateArSymtab(ar_symtab, macho_file),
+        };
+    }
+
     pub fn calcSymtabSize(file: File, macho_file: *MachO) !void {
         return switch (file) {
             inline else => |x| x.calcSymtabSize(macho_file),
@@ -206,6 +213,7 @@ const macho = std.macho;
 const std = @import("std");
 
 const Allocator = std.mem.Allocator;
+const Archive = @import("Archive.zig");
 const Atom = @import("Atom.zig");
 const InternalObject = @import("InternalObject.zig");
 const MachO = @import("../MachO.zig");

--- a/src/link/MachO/file.zig
+++ b/src/link/MachO/file.zig
@@ -182,6 +182,22 @@ pub const File = union(enum) {
         };
     }
 
+    pub fn updateArSize(file: File, macho_file: *MachO) !void {
+        return switch (file) {
+            .dylib, .internal => unreachable,
+            .zig_object => |x| x.updateArSize(),
+            .object => |x| x.updateArSize(macho_file),
+        };
+    }
+
+    pub fn writeAr(file: File, ar_format: Archive.Format, macho_file: *MachO, writer: anytype) !void {
+        return switch (file) {
+            .dylib, .internal => unreachable,
+            .zig_object => |x| x.writeAr(ar_format, writer),
+            .object => |x| x.writeAr(ar_format, macho_file, writer),
+        };
+    }
+
     pub fn calcSymtabSize(file: File, macho_file: *MachO) !void {
         return switch (file) {
             inline else => |x| x.calcSymtabSize(macho_file),

--- a/src/link/MachO/relocatable.zig
+++ b/src/link/MachO/relocatable.zig
@@ -144,6 +144,10 @@ pub fn flushStaticLib(macho_file: *MachO, comp: *Compilation, module_obj_path: ?
 
         const ncmds, const sizeofcmds = try writeLoadCommands(macho_file);
         try writeHeader(macho_file, ncmds, sizeofcmds);
+
+        // TODO we can avoid reading in the file contents we just wrote if we give the linker
+        // ability to write directly to a buffer.
+        try zo.readFileContents(macho_file);
     }
 
     var err = try macho_file.addErrorWithNotes(0);

--- a/src/link/MachO/relocatable.zig
+++ b/src/link/MachO/relocatable.zig
@@ -152,7 +152,7 @@ pub fn flushStaticLib(macho_file: *MachO, comp: *Compilation, module_obj_path: ?
 
         // TODO we can avoid reading in the file contents we just wrote if we give the linker
         // ability to write directly to a buffer.
-        try zo.readFileContents(macho_file);
+        try zo.readFileContents(off, macho_file);
     }
 
     var files = std.ArrayList(File.Index).init(gpa);


### PR DESCRIPTION
This removes any fallback to `llvm-ar` for all MachO codepaths.

Closes #18667