### PR TITLE
Optimize binarySearch

### DIFF
--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -413,20 +413,19 @@ pub fn binarySearch(
     context: anytype,
     comptime compareFn: fn (context: @TypeOf(context), key: @TypeOf(key), mid_item: T) math.Order,
 ) ?usize {
-    var left: usize = 0;
-    var right: usize = items.len;
-
-    while (left < right) {
-        // Avoid overflowing in the midpoint calculation
-        const mid = left + (right - left) / 2;
-        // Compare the key with the midpoint element
-        switch (compareFn(context, key, items[mid])) {
-            .eq => return mid,
-            .gt => left = mid + 1,
-            .lt => right = mid,
+    // This implementation is based on this article: https://orlp.net/blog/bitwise-binary-search/
+    var b: usize = 0;
+    var bit = std.math.floorPowerOfTwo(usize, items.len);
+    while (bit != 0) : (bit >>= 1) {
+        const i: usize = (b | bit) - 1;
+        if (i < items.len) {
+            switch (compareFn(context, key, items[i])) {
+                .gt => b |= bit,
+                .eq => return i,
+                .lt => {},
+            }
         }
     }
-
     return null;
 }
 


### PR DESCRIPTION
While reading [this](https://orlp.net/blog/bitwise-binary-search/) blog post I have tried to implement it in zig. It turned out to be faster than the current std version by 15% in `Debug` mode, but also a bit more cryptic.

Benchmarked with this:
```zig
pub fn main() !void {
    const nums = try random(i32, std.heap.page_allocator, 1_111_111);
    defer std.heap.page_allocator.free(nums);

    var timer = try std.time.Timer.start();
    for (1..111) |_| {
        _ = binarySearch(i32, @as(i32, 98), nums, {}, order_i32);
    }
    std.debug.print("{d} ns\n", .{timer.read()});
}
```

I have tried to compare in `ReleaseFast`, but this one gets ridiculously fast, the compiler probably optimizes the whole thing away.