### PR TITLE
Mark .zon as eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.zig text eol=lf
+*.zon text eol=lf
 *.txt text eol=lf
 langref.html.in text eol=lf
 lib/std/compress/testdata/** binary


### PR DESCRIPTION
Fixes git autocrlf issues with .zon files on Windows

Without this change I was hitting line ending mismatches for https://github.com/ziglang/zig/blob/master/lib/init/build.zig.zon locally since git checked it out as CRLF and then `zig fmt` changed it to LF.