### PR TITLE
Sema: check for inactive union field when calling fn at comptime

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -27304,10 +27304,10 @@ fn fieldCallBind(
             .Union => {
                 try sema.resolveTypeFields(concrete_ty);
                 const union_obj = mod.typeToUnion(concrete_ty).?;
-                const field_index = union_obj.nameIndex(ip, field_name) orelse break :find_field;
-                const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
+                _ = union_obj.nameIndex(ip, field_name) orelse break :find_field;
 
-                return sema.finishFieldCallBind(block, src, ptr_ty, field_ty, field_index, object_ptr);
+                const field_ptr = try unionFieldPtr(sema, block, src, object_ptr, field_name, field_name_src, concrete_ty, false);
+                return .{ .direct = try sema.analyzeLoad(block, src, field_ptr, src) };
             },
             .Type => {
                 const namespace = try sema.analyzeLoad(block, src, object_ptr, src);

--- a/test/cases/compile_errors/union_calling_inactive_field_as_fn.zig
+++ b/test/cases/compile_errors/union_calling_inactive_field_as_fn.zig
@@ -1,0 +1,16 @@
+const U = union(enum) {
+    int: isize,
+    float: f64,
+};
+
+export fn entry() void {
+    const f = U{ .int = 20 };
+    _ = f.float();
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :8:10: error: access of union field 'float' while field 'int' is active
+// :1:11: note: union declared here


### PR DESCRIPTION
Reuse `unionFieldPtr` here to ensure that all the safety checks are included.

Closes https://github.com/ziglang/zig/issues/18546.
Closes https://github.com/ziglang/zig/issues/18625.