### PR TITLE
io_uring: add waitid operation

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -4151,6 +4151,13 @@ pub const IORING_OP = enum(u8) {
     URING_CMD,
     SEND_ZC,
     SENDMSG_ZC,
+    READ_MULTISHOT,
+    WAITID,
+    FUTEX_WAIT,
+    FUTEX_WAKE,
+    FUTEX_WAITV,
+    FIXED_FD_INSTALL,
+    FTRUNCATE,
 
     _,
 };


### PR DESCRIPTION
This implements the IORING_OP_WAITID operation. It is the equivalent of a waitid(2) syscall and can be used to be notified about child process state changes.

Available since kernel 6.7

liburing reference:
- https://github.com/axboe/liburing/blob/master/src/include/liburing/io_uring.h#L252-L258
- https://github.com/axboe/liburing/blob/master/src/include/liburing.h#L1157-L1167