### PR TITLE
A loose collection of random enhancements

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -12918,20 +12918,20 @@ const GenZir = struct {
         const astgen = gz.astgen;
         const gpa = astgen.gpa;
 
+        // Node 0 is valid for the root `struct_decl` of a file!
+        assert(args.src_node != 0 or gz.parent.tag == .top);
+
         const fields_hash_arr: [4]u32 = @bitCast(args.fields_hash);
 
-        try astgen.extra.ensureUnusedCapacity(gpa, @typeInfo(Zir.Inst.StructDecl).Struct.fields.len + 6);
+        try astgen.extra.ensureUnusedCapacity(gpa, @typeInfo(Zir.Inst.StructDecl).Struct.fields.len + 4);
         const payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.StructDecl{
             .fields_hash_0 = fields_hash_arr[0],
             .fields_hash_1 = fields_hash_arr[1],
             .fields_hash_2 = fields_hash_arr[2],
             .fields_hash_3 = fields_hash_arr[3],
+            .src_node = gz.nodeIndexToRelative(args.src_node),
         });
 
-        if (args.src_node != 0) {
-            const node_offset = gz.nodeIndexToRelative(args.src_node);
-            astgen.extra.appendAssumeCapacity(@bitCast(node_offset));
-        }
         if (args.fields_len != 0) {
             astgen.extra.appendAssumeCapacity(args.fields_len);
         }
@@ -12949,7 +12949,6 @@ const GenZir = struct {
             .data = .{ .extended = .{
                 .opcode = .struct_decl,
                 .small = @bitCast(Zir.Inst.StructDecl.Small{
-                    .has_src_node = args.src_node != 0,
                     .has_fields_len = args.fields_len != 0,
                     .has_decls_len = args.decls_len != 0,
                     .has_backing_int = args.backing_int_ref != .none,
@@ -12981,20 +12980,19 @@ const GenZir = struct {
         const astgen = gz.astgen;
         const gpa = astgen.gpa;
 
+        assert(args.src_node != 0);
+
         const fields_hash_arr: [4]u32 = @bitCast(args.fields_hash);
 
-        try astgen.extra.ensureUnusedCapacity(gpa, @typeInfo(Zir.Inst.UnionDecl).Struct.fields.len + 5);
+        try astgen.extra.ensureUnusedCapacity(gpa, @typeInfo(Zir.Inst.UnionDecl).Struct.fields.len + 4);
         const payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.UnionDecl{
             .fields_hash_0 = fields_hash_arr[0],
             .fields_hash_1 = fields_hash_arr[1],
             .fields_hash_2 = fields_hash_arr[2],
             .fields_hash_3 = fields_hash_arr[3],
+            .src_node = gz.nodeIndexToRelative(args.src_node),
         });
 
-        if (args.src_node != 0) {
-            const node_offset = gz.nodeIndexToRelative(args.src_node);
-            astgen.extra.appendAssumeCapacity(@bitCast(node_offset));
-        }
         if (args.tag_type != .none) {
             astgen.extra.appendAssumeCapacity(@intFromEnum(args.tag_type));
         }
@@ -13012,7 +13010,6 @@ const GenZir = struct {
             .data = .{ .extended = .{
                 .opcode = .union_decl,
                 .small = @bitCast(Zir.Inst.UnionDecl.Small{
-                    .has_src_node = args.src_node != 0,
                     .has_tag_type = args.tag_type != .none,
                     .has_body_len = args.body_len != 0,
                     .has_fields_len = args.fields_len != 0,
@@ -13039,20 +13036,19 @@ const GenZir = struct {
         const astgen = gz.astgen;
         const gpa = astgen.gpa;
 
+        assert(args.src_node != 0);
+
         const fields_hash_arr: [4]u32 = @bitCast(args.fields_hash);
 
-        try astgen.extra.ensureUnusedCapacity(gpa, @typeInfo(Zir.Inst.EnumDecl).Struct.fields.len + 5);
+        try astgen.extra.ensureUnusedCapacity(gpa, @typeInfo(Zir.Inst.EnumDecl).Struct.fields.len + 4);
         const payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.EnumDecl{
             .fields_hash_0 = fields_hash_arr[0],
             .fields_hash_1 = fields_hash_arr[1],
             .fields_hash_2 = fields_hash_arr[2],
             .fields_hash_3 = fields_hash_arr[3],
+            .src_node = gz.nodeIndexToRelative(args.src_node),
         });
 
-        if (args.src_node != 0) {
-            const node_offset = gz.nodeIndexToRelative(args.src_node);
-            astgen.extra.appendAssumeCapacity(@bitCast(node_offset));
-        }
         if (args.tag_type != .none) {
             astgen.extra.appendAssumeCapacity(@intFromEnum(args.tag_type));
         }
@@ -13070,7 +13066,6 @@ const GenZir = struct {
             .data = .{ .extended = .{
                 .opcode = .enum_decl,
                 .small = @bitCast(Zir.Inst.EnumDecl.Small{
-                    .has_src_node = args.src_node != 0,
                     .has_tag_type = args.tag_type != .none,
                     .has_body_len = args.body_len != 0,
                     .has_fields_len = args.fields_len != 0,
@@ -13090,13 +13085,13 @@ const GenZir = struct {
         const astgen = gz.astgen;
         const gpa = astgen.gpa;
 
-        try astgen.extra.ensureUnusedCapacity(gpa, 2);
-        const payload_index: u32 = @intCast(astgen.extra.items.len);
+        assert(args.src_node != 0);
 
-        if (args.src_node != 0) {
-            const node_offset = gz.nodeIndexToRelative(args.src_node);
-            astgen.extra.appendAssumeCapacity(@bitCast(node_offset));
-        }
+        try astgen.extra.ensureUnusedCapacity(gpa, @typeInfo(Zir.Inst.OpaqueDecl).Struct.fields.len + 1);
+        const payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.OpaqueDecl{
+            .src_node = gz.nodeIndexToRelative(args.src_node),
+        });
+
         if (args.decls_len != 0) {
             astgen.extra.appendAssumeCapacity(args.decls_len);
         }
@@ -13105,7 +13100,6 @@ const GenZir = struct {
             .data = .{ .extended = .{
                 .opcode = .opaque_decl,
                 .small = @bitCast(Zir.Inst.OpaqueDecl.Small{
-                    .has_src_node = args.src_node != 0,
                     .has_decls_len = args.decls_len != 0,
                     .name_strategy = gz.anon_name_strategy,
                 }),

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -360,16 +360,11 @@ const ResultInfo = struct {
     };
 };
 
-/// TODO: modify Sema to remove in favour of `coerced_align_ri`
-const align_ri: ResultInfo = .{ .rl = .{ .ty = .u29_type } };
 const coerced_align_ri: ResultInfo = .{ .rl = .{ .coerced_ty = .u29_type } };
-/// TODO: modify Sema to remove in favour of `coerced_addrspace_ri`
-const addrspace_ri: ResultInfo = .{ .rl = .{ .ty = .address_space_type } };
 const coerced_addrspace_ri: ResultInfo = .{ .rl = .{ .coerced_ty = .address_space_type } };
 const coerced_linksection_ri: ResultInfo = .{ .rl = .{ .coerced_ty = .slice_const_u8_type } };
-const bool_ri: ResultInfo = .{ .rl = .{ .ty = .bool_type } };
-const type_ri: ResultInfo = .{ .rl = .{ .ty = .type_type } };
 const coerced_type_ri: ResultInfo = .{ .rl = .{ .coerced_ty = .type_type } };
+const coerced_bool_ri: ResultInfo = .{ .rl = .{ .coerced_ty = .bool_type } };
 
 fn typeExpr(gz: *GenZir, scope: *Scope, type_node: Ast.Node.Index) InnerError!Zir.Inst.Ref {
     return comptimeExpr(gz, scope, coerced_type_ri, type_node);
@@ -786,7 +781,7 @@ fn expr(gz: *GenZir, scope: *Scope, ri: ResultInfo, node: Ast.Node.Index) InnerE
         .bool_and => return boolBinOp(gz, scope, ri, node, .bool_br_and),
         .bool_or  => return boolBinOp(gz, scope, ri, node, .bool_br_or),
 
-        .bool_not => return simpleUnOp(gz, scope, ri, node, bool_ri, node_datas[node].lhs, .bool_not),
+        .bool_not => return simpleUnOp(gz, scope, ri, node, coerced_bool_ri, node_datas[node].lhs, .bool_not),
         .bit_not  => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none }, node_datas[node].lhs, .bit_not),
 
         .negation      => return   negation(gz, scope, ri, node),
@@ -1372,7 +1367,7 @@ fn fnProtoExpr(
     };
 
     const align_ref: Zir.Inst.Ref = if (fn_proto.ast.align_expr == 0) .none else inst: {
-        break :inst try expr(&block_scope, scope, align_ri, fn_proto.ast.align_expr);
+        break :inst try expr(&block_scope, scope, coerced_align_ri, fn_proto.ast.align_expr);
     };
 
     if (fn_proto.ast.addrspace_expr != 0) {
@@ -1387,7 +1382,7 @@ fn fnProtoExpr(
         try expr(
             &block_scope,
             scope,
-            .{ .rl = .{ .ty = .calling_convention_type } },
+            .{ .rl = .{ .coerced_ty = .calling_convention_type } },
             fn_proto.ast.callconv_expr,
         )
     else
@@ -3136,7 +3131,7 @@ fn varDecl(
     }
 
     const align_inst: Zir.Inst.Ref = if (var_decl.ast.align_node != 0)
-        try expr(gz, scope, align_ri, var_decl.ast.align_node)
+        try expr(gz, scope, coerced_align_ri, var_decl.ast.align_node)
     else
         .none;
 
@@ -3505,7 +3500,7 @@ fn assignDestructureMaybeDecls(
                 const this_lhs_comptime = is_comptime or (is_const and rhs_is_comptime);
 
                 const align_inst: Zir.Inst.Ref = if (full.ast.align_node != 0)
-                    try expr(gz, scope, align_ri, full.ast.align_node)
+                    try expr(gz, scope, coerced_align_ri, full.ast.align_node)
                 else
                     .none;
 
@@ -3783,7 +3778,7 @@ fn ptrType(
         gz.astgen.source_line = source_line;
         gz.astgen.source_column = source_column;
 
-        addrspace_ref = try expr(gz, scope, addrspace_ri, ptr_info.ast.addrspace_node);
+        addrspace_ref = try expr(gz, scope, coerced_addrspace_ri, ptr_info.ast.addrspace_node);
         trailing_count += 1;
     }
     if (ptr_info.ast.align_node != 0) {
@@ -4176,7 +4171,7 @@ fn fnDecl(
     var addrspace_gz = decl_gz.makeSubBlock(params_scope);
     defer addrspace_gz.unstack();
     const addrspace_ref: Zir.Inst.Ref = if (fn_proto.ast.addrspace_expr == 0) .none else inst: {
-        const inst = try expr(&decl_gz, params_scope, addrspace_ri, fn_proto.ast.addrspace_expr);
+        const inst = try expr(&decl_gz, params_scope, coerced_addrspace_ri, fn_proto.ast.addrspace_expr);
         if (addrspace_gz.instructionsSlice().len == 0) {
             // In this case we will send a len=0 body which can be encoded more efficiently.
             break :inst inst;
@@ -4431,7 +4426,7 @@ fn globalVarDecl(
             try expr(
                 &block_scope,
                 &block_scope.base,
-                .{ .rl = .{ .ty = .type_type } },
+                coerced_type_ri,
                 var_decl.ast.type_node,
             )
         else
@@ -5254,7 +5249,7 @@ fn unionDeclInner(
             return astgen.failNode(member_node, "union field missing type", .{});
         }
         if (have_align) {
-            const align_inst = try expr(&block_scope, &block_scope.base, .{ .rl = .{ .ty = .u32_type } }, member.ast.align_expr);
+            const align_inst = try expr(&block_scope, &block_scope.base, coerced_align_ri, member.ast.align_expr);
             wip_members.appendToField(@intFromEnum(align_inst));
             any_aligned_fields = true;
         }
@@ -5522,7 +5517,7 @@ fn containerDecl(
             namespace.base.tag = .enum_namespace;
 
             const arg_inst: Zir.Inst.Ref = if (container_decl.ast.arg != 0)
-                try comptimeExpr(&block_scope, &namespace.base, .{ .rl = .{ .ty = .type_type } }, container_decl.ast.arg)
+                try comptimeExpr(&block_scope, &namespace.base, coerced_type_ri, container_decl.ast.arg)
             else
                 .none;
 
@@ -6079,7 +6074,7 @@ fn arrayAccess(
 
             const cursor = maybeAdvanceSourceCursorToMainToken(gz, node);
 
-            const rhs = try expr(gz, scope, .{ .rl = .{ .ty = .usize_type } }, node_datas[node].rhs);
+            const rhs = try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, node_datas[node].rhs);
             try emitDbgStmt(gz, cursor);
 
             return gz.addPlNode(.elem_ptr_node, node, Zir.Inst.Bin{ .lhs = lhs, .rhs = rhs });
@@ -6089,7 +6084,7 @@ fn arrayAccess(
 
             const cursor = maybeAdvanceSourceCursorToMainToken(gz, node);
 
-            const rhs = try expr(gz, scope, .{ .rl = .{ .ty = .usize_type } }, node_datas[node].rhs);
+            const rhs = try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, node_datas[node].rhs);
             try emitDbgStmt(gz, cursor);
 
             return rvalue(gz, ri, try gz.addPlNode(.elem_val_node, node, Zir.Inst.Bin{ .lhs = lhs, .rhs = rhs }), node);
@@ -6157,12 +6152,12 @@ fn boolBinOp(
     const tree = astgen.tree;
     const node_datas = tree.nodes.items(.data);
 
-    const lhs = try expr(gz, scope, bool_ri, node_datas[node].lhs);
+    const lhs = try expr(gz, scope, coerced_bool_ri, node_datas[node].lhs);
     const bool_br = (try gz.addPlNodePayloadIndex(zir_tag, node, undefined)).toIndex().?;
 
     var rhs_scope = gz.makeSubBlock(scope);
     defer rhs_scope.unstack();
-    const rhs = try expr(&rhs_scope, &rhs_scope.base, bool_ri, node_datas[node].rhs);
+    const rhs = try expr(&rhs_scope, &rhs_scope.base, coerced_bool_ri, node_datas[node].rhs);
     if (!gz.refIsNoReturn(rhs)) {
         _ = try rhs_scope.addBreakWithSrcNode(.break_inline, bool_br, rhs, node_datas[node].rhs);
     }
@@ -6230,7 +6225,7 @@ fn ifExpr(
                 .bool_bit = try block_scope.addUnNode(tag, optional, if_full.ast.cond_expr),
             };
         } else {
-            const cond = try expr(&block_scope, &block_scope.base, bool_ri, if_full.ast.cond_expr);
+            const cond = try expr(&block_scope, &block_scope.base, coerced_bool_ri, if_full.ast.cond_expr);
             break :c .{
                 .inst = cond,
                 .bool_bit = cond,
@@ -6476,7 +6471,7 @@ fn whileExpr(
                 .bool_bit = try cond_scope.addUnNode(tag, optional, while_full.ast.cond_expr),
             };
         } else {
-            const cond = try expr(&cond_scope, &cond_scope.base, bool_ri, while_full.ast.cond_expr);
+            const cond = try expr(&cond_scope, &cond_scope.base, coerced_bool_ri, while_full.ast.cond_expr);
             break :c .{
                 .inst = cond,
                 .bool_bit = cond,
@@ -8052,7 +8047,7 @@ fn ret(gz: *GenZir, scope: *Scope, node: Ast.Node.Index) InnerError!Zir.Inst.Ref
         .rl = .{ .ptr = .{ .inst = try gz.addNode(.ret_ptr, node) } },
         .ctx = .@"return",
     } else .{
-        .rl = .{ .ty = astgen.fn_ret_ty },
+        .rl = .{ .coerced_ty = astgen.fn_ret_ty },
         .ctx = .@"return",
     };
     const prev_anon_name_strategy = gz.anon_name_strategy;
@@ -8688,7 +8683,7 @@ fn unionInit(
     params: []const Ast.Node.Index,
 ) InnerError!Zir.Inst.Ref {
     const union_type = try typeExpr(gz, scope, params[0]);
-    const field_name = try comptimeExpr(gz, scope, .{ .rl = .{ .ty = .slice_const_u8_type } }, params[1]);
+    const field_name = try comptimeExpr(gz, scope, .{ .rl = .{ .coerced_ty = .slice_const_u8_type } }, params[1]);
     const field_type = try gz.addPlNode(.field_type_ref, node, Zir.Inst.FieldTypeRef{
         .container_type = union_type,
         .field_name = field_name,
@@ -9001,12 +8996,12 @@ fn builtinCall(
             if (ri.rl == .ref or ri.rl == .ref_coerced_ty) {
                 return gz.addPlNode(.field_ptr_named, node, Zir.Inst.FieldNamed{
                     .lhs = try expr(gz, scope, .{ .rl = .ref }, params[0]),
-                    .field_name = try comptimeExpr(gz, scope, .{ .rl = .{ .ty = .slice_const_u8_type } }, params[1]),
+                    .field_name = try comptimeExpr(gz, scope, .{ .rl = .{ .coerced_ty = .slice_const_u8_type } }, params[1]),
                 });
             }
             const result = try gz.addPlNode(.field_val_named, node, Zir.Inst.FieldNamed{
                 .lhs = try expr(gz, scope, .{ .rl = .none }, params[0]),
-                .field_name = try comptimeExpr(gz, scope, .{ .rl = .{ .ty = .slice_const_u8_type } }, params[1]),
+                .field_name = try comptimeExpr(gz, scope, .{ .rl = .{ .coerced_ty = .slice_const_u8_type } }, params[1]),
             });
             return rvalue(gz, ri, result, node);
         },
@@ -9133,7 +9128,7 @@ fn builtinCall(
             return rvalue(gz, ri, .void_value, node);
         },
         .set_align_stack => {
-            const order = try expr(gz, scope, align_ri, params[0]);
+            const order = try expr(gz, scope, coerced_align_ri, params[0]);
             _ = try gz.addExtendedPayload(.set_align_stack, Zir.Inst.UnNode{
                 .node = gz.nodeIndexToRelative(node),
                 .operand = order,
@@ -9175,32 +9170,32 @@ fn builtinCall(
         .bit_size_of => return simpleUnOpType(gz, scope, ri, node, params[0], .bit_size_of),
         .align_of    => return simpleUnOpType(gz, scope, ri, node, params[0], .align_of),
 
-        .int_from_ptr          => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .int_from_ptr),
-        .compile_error         => return simpleUnOp(gz, scope, ri, node, .{ .rl = .{ .ty = .slice_const_u8_type } }, params[0], .compile_error),
-        .set_eval_branch_quota => return simpleUnOp(gz, scope, ri, node, .{ .rl = .{ .coerced_ty = .u32_type } },    params[0], .set_eval_branch_quota),
-        .int_from_enum         => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .int_from_enum),
-        .int_from_bool         => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .int_from_bool),
-        .embed_file            => return simpleUnOp(gz, scope, ri, node, .{ .rl = .{ .ty = .slice_const_u8_type } }, params[0], .embed_file),
-        .error_name            => return simpleUnOp(gz, scope, ri, node, .{ .rl = .{ .ty = .anyerror_type } },       params[0], .error_name),
-        .set_runtime_safety    => return simpleUnOp(gz, scope, ri, node, bool_ri,                                    params[0], .set_runtime_safety),
-        .sqrt                  => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .sqrt),
-        .sin                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .sin),
-        .cos                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .cos),
-        .tan                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .tan),
-        .exp                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .exp),
-        .exp2                  => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .exp2),
-        .log                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .log),
-        .log2                  => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .log2),
-        .log10                 => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .log10),
-        .abs                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .abs),
-        .floor                 => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .floor),
-        .ceil                  => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .ceil),
-        .trunc                 => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .trunc),
-        .round                 => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .round),
-        .tag_name              => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .tag_name),
-        .type_name             => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .type_name),
-        .Frame                 => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .frame_type),
-        .frame_size            => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                           params[0], .frame_size),
+        .int_from_ptr          => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .int_from_ptr),
+        .compile_error         => return simpleUnOp(gz, scope, ri, node, .{ .rl = .{ .coerced_ty = .slice_const_u8_type } },   params[0], .compile_error),
+        .set_eval_branch_quota => return simpleUnOp(gz, scope, ri, node, .{ .rl = .{ .coerced_ty = .u32_type } },              params[0], .set_eval_branch_quota),
+        .int_from_enum         => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .int_from_enum),
+        .int_from_bool         => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .int_from_bool),
+        .embed_file            => return simpleUnOp(gz, scope, ri, node, .{ .rl = .{ .coerced_ty = .slice_const_u8_type } },   params[0], .embed_file),
+        .error_name            => return simpleUnOp(gz, scope, ri, node, .{ .rl = .{ .coerced_ty = .anyerror_type } },         params[0], .error_name),
+        .set_runtime_safety    => return simpleUnOp(gz, scope, ri, node, coerced_bool_ri,                                      params[0], .set_runtime_safety),
+        .sqrt                  => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .sqrt),
+        .sin                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .sin),
+        .cos                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .cos),
+        .tan                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .tan),
+        .exp                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .exp),
+        .exp2                  => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .exp2),
+        .log                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .log),
+        .log2                  => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .log2),
+        .log10                 => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .log10),
+        .abs                   => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .abs),
+        .floor                 => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .floor),
+        .ceil                  => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .ceil),
+        .trunc                 => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .trunc),
+        .round                 => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .round),
+        .tag_name              => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .tag_name),
+        .type_name             => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .type_name),
+        .Frame                 => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .frame_type),
+        .frame_size            => return simpleUnOp(gz, scope, ri, node, .{ .rl = .none },                                     params[0], .frame_size),
 
         .int_from_float => return typeCast(gz, scope, ri, node, params[0], .int_from_float, builtin_name),
         .float_from_int => return typeCast(gz, scope, ri, node, params[0], .float_from_int, builtin_name),
@@ -9238,7 +9233,7 @@ fn builtinCall(
         },
         .panic => {
             try emitDbgNode(gz, node);
-            return simpleUnOp(gz, scope, ri, node, .{ .rl = .{ .ty = .slice_const_u8_type } }, params[0], .panic);
+            return simpleUnOp(gz, scope, ri, node, .{ .rl = .{ .coerced_ty = .slice_const_u8_type } }, params[0], .panic);
         },
         .trap => {
             try emitDbgNode(gz, node);
@@ -9327,7 +9322,7 @@ fn builtinCall(
         },
         .c_define => {
             if (!gz.c_import) return gz.astgen.failNode(node, "C define valid only inside C import block", .{});
-            const name = try comptimeExpr(gz, scope, .{ .rl = .{ .ty = .slice_const_u8_type } }, params[0]);
+            const name = try comptimeExpr(gz, scope, .{ .rl = .{ .coerced_ty = .slice_const_u8_type } }, params[0]);
             const value = try comptimeExpr(gz, scope, .{ .rl = .none }, params[1]);
             const result = try gz.addExtendedPayload(.c_define, Zir.Inst.BinNode{
                 .node = gz.nodeIndexToRelative(node),
@@ -9348,7 +9343,7 @@ fn builtinCall(
             return rvalue(gz, ri, result, node);
         },
         .reduce => {
-            const op = try expr(gz, scope, .{ .rl = .{ .ty = .reduce_op_type } }, params[0]);
+            const op = try expr(gz, scope, .{ .rl = .{ .coerced_ty = .reduce_op_type } }, params[0]);
             const scalar = try expr(gz, scope, .{ .rl = .none }, params[1]);
             const result = try gz.addPlNode(.reduce, node, Zir.Inst.Bin{
                 .lhs = op,
@@ -9424,7 +9419,7 @@ fn builtinCall(
         },
         .field_parent_ptr => {
             const parent_type = try typeExpr(gz, scope, params[0]);
-            const field_name = try comptimeExpr(gz, scope, .{ .rl = .{ .ty = .slice_const_u8_type } }, params[1]);
+            const field_name = try comptimeExpr(gz, scope, .{ .rl = .{ .coerced_ty = .slice_const_u8_type } }, params[1]);
             const result = try gz.addPlNode(.field_parent_ptr, node, Zir.Inst.FieldParentPtr{
                 .parent_type = parent_type,
                 .field_name = field_name,
@@ -9561,7 +9556,7 @@ fn hasDeclOrField(
     tag: Zir.Inst.Tag,
 ) InnerError!Zir.Inst.Ref {
     const container_type = try typeExpr(gz, scope, lhs_node);
-    const name = try comptimeExpr(gz, scope, .{ .rl = .{ .ty = .slice_const_u8_type } }, rhs_node);
+    const name = try comptimeExpr(gz, scope, .{ .rl = .{ .coerced_ty = .slice_const_u8_type } }, rhs_node);
     const result = try gz.addPlNode(tag, node, Zir.Inst.Bin{
         .lhs = container_type,
         .rhs = name,
@@ -9711,7 +9706,7 @@ fn simpleCBuiltin(
 ) InnerError!Zir.Inst.Ref {
     const name: []const u8 = if (tag == .c_undef) "C undef" else "C include";
     if (!gz.c_import) return gz.astgen.failNode(node, "{s} valid only inside C import block", .{name});
-    const operand = try comptimeExpr(gz, scope, .{ .rl = .{ .ty = .slice_const_u8_type } }, operand_node);
+    const operand = try comptimeExpr(gz, scope, .{ .rl = .{ .coerced_ty = .slice_const_u8_type } }, operand_node);
     _ = try gz.addExtendedPayload(tag, Zir.Inst.UnNode{
         .node = gz.nodeIndexToRelative(node),
         .operand = operand,
@@ -9729,7 +9724,7 @@ fn offsetOf(
     tag: Zir.Inst.Tag,
 ) InnerError!Zir.Inst.Ref {
     const type_inst = try typeExpr(gz, scope, lhs_node);
-    const field_name = try comptimeExpr(gz, scope, .{ .rl = .{ .ty = .slice_const_u8_type } }, rhs_node);
+    const field_name = try comptimeExpr(gz, scope, .{ .rl = .{ .coerced_ty = .slice_const_u8_type } }, rhs_node);
     const result = try gz.addPlNode(tag, node, Zir.Inst.Bin{
         .lhs = type_inst,
         .rhs = field_name,
@@ -13148,7 +13143,7 @@ const GenZir = struct {
     fn addRet(gz: *GenZir, ri: ResultInfo, operand: Zir.Inst.Ref, node: Ast.Node.Index) !void {
         switch (ri.rl) {
             .ptr => |ptr_res| _ = try gz.addUnNode(.ret_load, ptr_res.inst, node),
-            .ty => _ = try gz.addUnNode(.ret_node, operand, node),
+            .coerced_ty => _ = try gz.addUnNode(.ret_node, operand, node),
             else => unreachable,
         }
     }

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -3395,19 +3395,10 @@ fn walkInstruction(
                         .enclosing_type = type_slot_index,
                     };
 
-                    const small = @as(Zir.Inst.OpaqueDecl.Small, @bitCast(extended.small));
-                    var extra_index: usize = extended.operand;
+                    const extra = file.zir.extraData(Zir.Inst.OpaqueDecl, extended.operand);
+                    var extra_index: usize = extra.end;
 
-                    const src_node: ?i32 = if (small.has_src_node) blk: {
-                        const src_node = @as(i32, @bitCast(file.zir.extra[extra_index]));
-                        extra_index += 1;
-                        break :blk src_node;
-                    } else null;
-
-                    const src_info = if (src_node) |sn|
-                        try self.srcLocInfo(file, sn, parent_src)
-                    else
-                        parent_src;
+                    const src_info = try self.srcLocInfo(file, extra.data.src_node, parent_src);
 
                     var decl_indexes: std.ArrayListUnmanaged(usize) = .{};
                     var priv_decl_indexes: std.ArrayListUnmanaged(usize) = .{};
@@ -3498,18 +3489,10 @@ fn walkInstruction(
                     };
 
                     const small = @as(Zir.Inst.UnionDecl.Small, @bitCast(extended.small));
-                    var extra_index: usize = extended.operand + @typeInfo(Zir.Inst.UnionDecl).Struct.fields.len;
+                    const extra = file.zir.extraData(Zir.Inst.UnionDecl, extended.operand);
+                    var extra_index: usize = extra.end;
 
-                    const src_node: ?i32 = if (small.has_src_node) blk: {
-                        const src_node = @as(i32, @bitCast(file.zir.extra[extra_index]));
-                        extra_index += 1;
-                        break :blk src_node;
-                    } else null;
-
-                    const src_info = if (src_node) |sn|
-                        try self.srcLocInfo(file, sn, parent_src)
-                    else
-                        parent_src;
+                    const src_info = try self.srcLocInfo(file, extra.data.src_node, parent_src);
 
                     // We delay analysis because union tags can refer to
                     // decls defined inside the union itself.
@@ -3628,18 +3611,10 @@ fn walkInstruction(
                     };
 
                     const small = @as(Zir.Inst.EnumDecl.Small, @bitCast(extended.small));
-                    var extra_index: usize = extended.operand + @typeInfo(Zir.Inst.EnumDecl).Struct.fields.len;
+                    const extra = file.zir.extraData(Zir.Inst.EnumDecl, extended.operand);
+                    var extra_index: usize = extra.end;
 
-                    const src_node: ?i32 = if (small.has_src_node) blk: {
-                        const src_node = @as(i32, @bitCast(file.zir.extra[extra_index]));
-                        extra_index += 1;
-                        break :blk src_node;
-                    } else null;
-
-                    const src_info = if (src_node) |sn|
-                        try self.srcLocInfo(file, sn, parent_src)
-                    else
-                        parent_src;
+                    const src_info = try self.srcLocInfo(file, extra.data.src_node, parent_src);
 
                     const tag_type: ?DocData.Expr = if (small.has_tag_type) blk: {
                         const tag_type = file.zir.extra[extra_index];
@@ -3779,18 +3754,10 @@ fn walkInstruction(
                     };
 
                     const small = @as(Zir.Inst.StructDecl.Small, @bitCast(extended.small));
-                    var extra_index: usize = extended.operand + @typeInfo(Zir.Inst.StructDecl).Struct.fields.len;
+                    const extra = file.zir.extraData(Zir.Inst.StructDecl, extended.operand);
+                    var extra_index: usize = extra.end;
 
-                    const src_node: ?i32 = if (small.has_src_node) blk: {
-                        const src_node = @as(i32, @bitCast(file.zir.extra[extra_index]));
-                        extra_index += 1;
-                        break :blk src_node;
-                    } else null;
-
-                    const src_info = if (src_node) |sn|
-                        try self.srcLocInfo(file, sn, parent_src)
-                    else
-                        parent_src;
+                    const src_info = try self.srcLocInfo(file, extra.data.src_node, parent_src);
 
                     const fields_len = if (small.has_fields_len) blk: {
                         const fields_len = file.zir.extra[extra_index];

--- a/src/Autodoc.zig
+++ b/src/Autodoc.zig
@@ -1799,7 +1799,8 @@ fn walkInstruction(
             };
         },
         .bool_br_and, .bool_br_or => {
-            const bool_br = data[@intFromEnum(inst)].bool_br;
+            const pl_node = data[@intFromEnum(inst)].pl_node;
+            const extra = file.zir.extraData(Zir.Inst.BoolBr, pl_node.payload_index);
 
             const bin_index = self.exprs.items.len;
             try self.exprs.append(self.arena, .{ .binOp = .{ .lhs = 0, .rhs = 0 } });
@@ -1808,14 +1809,13 @@ fn walkInstruction(
                 file,
                 parent_scope,
                 parent_src,
-                bool_br.lhs,
+                extra.data.lhs,
                 false,
                 call_ctx,
             );
             const lhs_index = self.exprs.items.len;
             try self.exprs.append(self.arena, lhs.expr);
 
-            const extra = file.zir.extraData(Zir.Inst.Block, bool_br.payload_index);
             const rhs = try self.walkInstruction(
                 file,
                 parent_scope,

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -1867,6 +1867,16 @@ pub const SrcLoc = struct {
                     else => return nodeToSpan(tree, node),
                 }
             },
+            .node_offset_return_operand => |node_off| {
+                const tree = try src_loc.file_scope.getTree(gpa);
+                const node = src_loc.declRelativeToNodeIndex(node_off);
+                const node_tags = tree.nodes.items(.tag);
+                const node_datas = tree.nodes.items(.data);
+                if (node_tags[node] == .@"return" and node_datas[node].lhs != 0) {
+                    return nodeToSpan(tree, node_datas[node].lhs);
+                }
+                return nodeToSpan(tree, node);
+            },
         }
     }
 
@@ -2221,6 +2231,10 @@ pub const LazySrcLoc = union(enum) {
     /// The source location points to the RHS of an assignment.
     /// The Decl is determined contextually.
     node_offset_store_operand: i32,
+    /// The source location points to the operand of a `return` statement, or
+    /// the `return` itself if there is no explicit operand.
+    /// The Decl is determined contextually.
+    node_offset_return_operand: i32,
     /// The source location points to a for loop input.
     /// The Decl is determined contextually.
     for_input: struct {
@@ -2347,6 +2361,7 @@ pub const LazySrcLoc = union(enum) {
             .node_offset_init_ty,
             .node_offset_store_ptr,
             .node_offset_store_operand,
+            .node_offset_return_operand,
             .for_input,
             .for_capture_from_input,
             .array_cat_lhs,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5671,10 +5671,14 @@ fn zirPanic(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Zir.I
     const src = inst_data.src();
     const msg_inst = try sema.resolveInst(inst_data.operand);
 
+    // `panicWithMsg` would perform this coercion for us, but we can get a better
+    // source location if we do it here.
+    const coerced_msg = try sema.coerce(block, Type.slice_const_u8, msg_inst, .{ .node_offset_builtin_call_arg0 = inst_data.src_node });
+
     if (block.is_comptime) {
         return sema.fail(block, src, "encountered @panic at comptime", .{});
     }
-    try sema.panicWithMsg(block, src, msg_inst, .@"@panic");
+    try sema.panicWithMsg(block, src, coerced_msg, .@"@panic");
     return always_noreturn;
 }
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2725,7 +2725,6 @@ pub fn getStructType(
     const small: Zir.Inst.StructDecl.Small = @bitCast(extended.small);
 
     var extra_index: usize = extended.operand + @typeInfo(Zir.Inst.StructDecl).Struct.fields.len;
-    extra_index += @intFromBool(small.has_src_node);
     const fields_len = if (small.has_fields_len) blk: {
         const fields_len = sema.code.extra[extra_index];
         extra_index += 1;
@@ -2778,10 +2777,7 @@ fn zirStructDecl(
     const mod = sema.mod;
     const ip = &mod.intern_pool;
     const small: Zir.Inst.StructDecl.Small = @bitCast(extended.small);
-    const src: LazySrcLoc = if (small.has_src_node) blk: {
-        const node_offset: i32 = @bitCast(sema.code.extra[extended.operand + @typeInfo(Zir.Inst.StructDecl).Struct.fields.len]);
-        break :blk LazySrcLoc.nodeOffset(node_offset);
-    } else unreachable; // MLUGG TODO
+    const src = sema.code.extraData(Zir.Inst.StructDecl, extended.operand).data.src();
 
     // Because these three things each reference each other, `undefined`
     // placeholders are used before being set after the struct type gains an
@@ -2941,13 +2937,10 @@ fn zirEnumDecl(
     const mod = sema.mod;
     const gpa = sema.gpa;
     const small: Zir.Inst.EnumDecl.Small = @bitCast(extended.small);
-    var extra_index: usize = extended.operand + @typeInfo(Zir.Inst.EnumDecl).Struct.fields.len;
+    const extra = sema.code.extraData(Zir.Inst.EnumDecl, extended.operand);
+    var extra_index: usize = extra.end;
 
-    const src: LazySrcLoc = if (small.has_src_node) blk: {
-        const node_offset: i32 = @bitCast(sema.code.extra[extra_index]);
-        extra_index += 1;
-        break :blk LazySrcLoc.nodeOffset(node_offset);
-    } else unreachable; // MLUGG TODO
+    const src = extra.data.src();
     const tag_ty_src: LazySrcLoc = .{ .node_offset_container_tag = src.node_offset.x };
 
     const tag_type_ref = if (small.has_tag_type) blk: {
@@ -3214,13 +3207,10 @@ fn zirUnionDecl(
     const mod = sema.mod;
     const gpa = sema.gpa;
     const small: Zir.Inst.UnionDecl.Small = @bitCast(extended.small);
-    var extra_index: usize = extended.operand + @typeInfo(Zir.Inst.UnionDecl).Struct.fields.len;
+    const extra = sema.code.extraData(Zir.Inst.UnionDecl, extended.operand);
+    var extra_index: usize = extra.end;
 
-    const src: LazySrcLoc = if (small.has_src_node) blk: {
-        const node_offset: i32 = @bitCast(sema.code.extra[extra_index]);
-        extra_index += 1;
-        break :blk LazySrcLoc.nodeOffset(node_offset);
-    } else unreachable; // MLUGG TODO
+    const src = extra.data.src();
 
     extra_index += @intFromBool(small.has_tag_type);
     extra_index += @intFromBool(small.has_body_len);
@@ -3323,13 +3313,10 @@ fn zirOpaqueDecl(
 
     const mod = sema.mod;
     const small: Zir.Inst.OpaqueDecl.Small = @bitCast(extended.small);
-    var extra_index: usize = extended.operand;
+    const extra = sema.code.extraData(Zir.Inst.OpaqueDecl, extended.operand);
+    var extra_index: usize = extra.end;
 
-    const src: LazySrcLoc = if (small.has_src_node) blk: {
-        const node_offset: i32 = @bitCast(sema.code.extra[extra_index]);
-        extra_index += 1;
-        break :blk LazySrcLoc.nodeOffset(node_offset);
-    } else unreachable; // MLUGG TODO
+    const src = extra.data.src();
 
     const decls_len = if (small.has_decls_len) blk: {
         const decls_len = sema.code.extra[extra_index];
@@ -35662,7 +35649,6 @@ fn semaBackingIntType(mod: *Module, struct_type: InternPool.Key.StructType) Comp
 
     if (small.has_backing_int) {
         var extra_index: usize = extended.operand + @typeInfo(Zir.Inst.StructDecl).Struct.fields.len;
-        extra_index += @intFromBool(small.has_src_node);
         extra_index += @intFromBool(small.has_fields_len);
         extra_index += @intFromBool(small.has_decls_len);
 
@@ -36374,8 +36360,6 @@ fn structZirInfo(zir: Zir, zir_index: Zir.Inst.Index) struct {
     const small: Zir.Inst.StructDecl.Small = @bitCast(extended.small);
     var extra_index: usize = extended.operand + @typeInfo(Zir.Inst.StructDecl).Struct.fields.len;
 
-    extra_index += @intFromBool(small.has_src_node);
-
     const fields_len = if (small.has_fields_len) blk: {
         const fields_len = zir.extra[extra_index];
         extra_index += 1;
@@ -36843,7 +36827,6 @@ fn semaUnionFields(mod: *Module, arena: Allocator, union_type: InternPool.Key.Un
     var extra_index: usize = extended.operand + @typeInfo(Zir.Inst.UnionDecl).Struct.fields.len;
 
     const src = LazySrcLoc.nodeOffset(0);
-    extra_index += @intFromBool(small.has_src_node);
 
     const tag_type_ref: Zir.Inst.Ref = if (small.has_tag_type) blk: {
         const ty_ref: Zir.Inst.Ref = @enumFromInt(zir.extra[extra_index]);

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -3022,20 +3022,19 @@ pub const Inst = struct {
     };
 
     /// Trailing:
-    /// 0. src_node: i32, // if has_src_node
-    /// 1. fields_len: u32, // if has_fields_len
-    /// 2. decls_len: u32, // if has_decls_len
-    /// 3. backing_int_body_len: u32, // if has_backing_int
-    /// 4. backing_int_ref: Ref, // if has_backing_int and backing_int_body_len is 0
-    /// 5. backing_int_body_inst: Inst, // if has_backing_int and backing_int_body_len is > 0
-    /// 6. decl: Index, // for every decls_len; points to a `declaration` instruction
-    /// 7. flags: u32 // for every 8 fields
+    /// 0. fields_len: u32, // if has_fields_len
+    /// 1. decls_len: u32, // if has_decls_len
+    /// 2. backing_int_body_len: u32, // if has_backing_int
+    /// 3. backing_int_ref: Ref, // if has_backing_int and backing_int_body_len is 0
+    /// 4. backing_int_body_inst: Inst, // if has_backing_int and backing_int_body_len is > 0
+    /// 5. decl: Index, // for every decls_len; points to a `declaration` instruction
+    /// 6. flags: u32 // for every 8 fields
     ///    - sets of 4 bits:
     ///      0b000X: whether corresponding field has an align expression
     ///      0b00X0: whether corresponding field has a default expression
     ///      0b0X00: whether corresponding field is comptime
     ///      0bX000: whether corresponding field has a type expression
-    /// 8. fields: { // for every fields_len
+    /// 7. fields: { // for every fields_len
     ///        field_name: u32, // if !is_tuple
     ///        doc_comment: NullTerminatedString, // .empty if no doc comment
     ///        field_type: Ref, // if corresponding bit is not set. none means anytype.
@@ -3043,7 +3042,7 @@ pub const Inst = struct {
     ///        align_body_len: u32, // if corresponding bit is set
     ///        init_body_len: u32, // if corresponding bit is set
     ///    }
-    /// 10. bodies: { // for every fields_len
+    /// 8. bodies: { // for every fields_len
     ///        field_type_body_inst: Inst, // for each field_type_body_len
     ///        align_body_inst: Inst, // for each align_body_len
     ///        init_body_inst: Inst, // for each init_body_len
@@ -3055,8 +3054,13 @@ pub const Inst = struct {
         fields_hash_1: u32,
         fields_hash_2: u32,
         fields_hash_3: u32,
+        src_node: i32,
+
+        pub fn src(self: StructDecl) LazySrcLoc {
+            return LazySrcLoc.nodeOffset(self.src_node);
+        }
+
         pub const Small = packed struct {
-            has_src_node: bool,
             has_fields_len: bool,
             has_decls_len: bool,
             has_backing_int: bool,
@@ -3068,7 +3072,7 @@ pub const Inst = struct {
             any_default_inits: bool,
             any_comptime_fields: bool,
             any_aligned_fields: bool,
-            _: u2 = undefined,
+            _: u3 = undefined,
         };
     };
 
@@ -3102,16 +3106,15 @@ pub const Inst = struct {
     };
 
     /// Trailing:
-    /// 0. src_node: i32, // if has_src_node
-    /// 1. tag_type: Ref, // if has_tag_type
-    /// 2. body_len: u32, // if has_body_len
-    /// 3. fields_len: u32, // if has_fields_len
-    /// 4. decls_len: u32, // if has_decls_len
-    /// 5. decl: Index, // for every decls_len; points to a `declaration` instruction
-    /// 6. inst: Index // for every body_len
-    /// 7. has_bits: u32 // for every 32 fields
+    /// 0. tag_type: Ref, // if has_tag_type
+    /// 1. body_len: u32, // if has_body_len
+    /// 2. fields_len: u32, // if has_fields_len
+    /// 3. decls_len: u32, // if has_decls_len
+    /// 4. decl: Index, // for every decls_len; points to a `declaration` instruction
+    /// 5. inst: Index // for every body_len
+    /// 6. has_bits: u32 // for every 32 fields
     ///    - the bit is whether corresponding field has an value expression
-    /// 8. fields: { // for every fields_len
+    /// 7. fields: { // for every fields_len
     ///        field_name: u32,
     ///        doc_comment: u32, // .empty if no doc_comment
     ///        value: Ref, // if corresponding bit is set
@@ -3123,33 +3126,37 @@ pub const Inst = struct {
         fields_hash_1: u32,
         fields_hash_2: u32,
         fields_hash_3: u32,
+        src_node: i32,
+
+        pub fn src(self: EnumDecl) LazySrcLoc {
+            return LazySrcLoc.nodeOffset(self.src_node);
+        }
+
         pub const Small = packed struct {
-            has_src_node: bool,
             has_tag_type: bool,
             has_body_len: bool,
             has_fields_len: bool,
             has_decls_len: bool,
             name_strategy: NameStrategy,
             nonexhaustive: bool,
-            _: u8 = undefined,
+            _: u9 = undefined,
         };
     };
 
     /// Trailing:
-    /// 0. src_node: i32, // if has_src_node
-    /// 1. tag_type: Ref, // if has_tag_type
-    /// 2. body_len: u32, // if has_body_len
-    /// 3. fields_len: u32, // if has_fields_len
-    /// 4. decls_len: u32, // if has_decls_len
-    /// 5. decl: Index, // for every decls_len; points to a `declaration` instruction
-    /// 6. inst: Index // for every body_len
-    /// 7. has_bits: u32 // for every 8 fields
+    /// 0. tag_type: Ref, // if has_tag_type
+    /// 1. body_len: u32, // if has_body_len
+    /// 2. fields_len: u32, // if has_fields_len
+    /// 3. decls_len: u32, // if has_decls_len
+    /// 4. decl: Index, // for every decls_len; points to a `declaration` instruction
+    /// 5. inst: Index // for every body_len
+    /// 6. has_bits: u32 // for every 8 fields
     ///    - sets of 4 bits:
     ///      0b000X: whether corresponding field has a type expression
     ///      0b00X0: whether corresponding field has a align expression
     ///      0b0X00: whether corresponding field has a tag value expression
     ///      0bX000: unused
-    /// 8. fields: { // for every fields_len
+    /// 7. fields: { // for every fields_len
     ///        field_name: NullTerminatedString, // null terminated string index
     ///        doc_comment: NullTerminatedString, // .empty if no doc comment
     ///        field_type: Ref, // if corresponding bit is set
@@ -3164,8 +3171,13 @@ pub const Inst = struct {
         fields_hash_1: u32,
         fields_hash_2: u32,
         fields_hash_3: u32,
+        src_node: i32,
+
+        pub fn src(self: UnionDecl) LazySrcLoc {
+            return LazySrcLoc.nodeOffset(self.src_node);
+        }
+
         pub const Small = packed struct {
-            has_src_node: bool,
             has_tag_type: bool,
             has_body_len: bool,
             has_fields_len: bool,
@@ -3180,20 +3192,24 @@ pub const Inst = struct {
             ///    true      | false         |  union(T) { }
             auto_enum_tag: bool,
             any_aligned_fields: bool,
-            _: u5 = undefined,
+            _: u6 = undefined,
         };
     };
 
     /// Trailing:
-    /// 0. src_node: i32, // if has_src_node
-    /// 1. decls_len: u32, // if has_decls_len
-    /// 2. decl: Index, // for every decls_len; points to a `declaration` instruction
+    /// 0. decls_len: u32, // if has_decls_len
+    /// 1. decl: Index, // for every decls_len; points to a `declaration` instruction
     pub const OpaqueDecl = struct {
+        src_node: i32,
+
+        pub fn src(self: OpaqueDecl) LazySrcLoc {
+            return LazySrcLoc.nodeOffset(self.src_node);
+        }
+
         pub const Small = packed struct {
-            has_src_node: bool,
             has_decls_len: bool,
             name_strategy: NameStrategy,
-            _: u12 = undefined,
+            _: u13 = undefined,
         };
     };
 
@@ -3495,7 +3511,6 @@ pub fn declIterator(zir: Zir, decl_inst: Zir.Inst.Index) DeclIterator {
                 .struct_decl => {
                     const small: Inst.StructDecl.Small = @bitCast(extended.small);
                     var extra_index: u32 = @intCast(extended.operand + @typeInfo(Inst.StructDecl).Struct.fields.len);
-                    extra_index += @intFromBool(small.has_src_node);
                     extra_index += @intFromBool(small.has_fields_len);
                     const decls_len = if (small.has_decls_len) decls_len: {
                         const decls_len = zir.extra[extra_index];
@@ -3522,7 +3537,6 @@ pub fn declIterator(zir: Zir, decl_inst: Zir.Inst.Index) DeclIterator {
                 .enum_decl => {
                     const small: Inst.EnumDecl.Small = @bitCast(extended.small);
                     var extra_index: u32 = @intCast(extended.operand + @typeInfo(Inst.EnumDecl).Struct.fields.len);
-                    extra_index += @intFromBool(small.has_src_node);
                     extra_index += @intFromBool(small.has_tag_type);
                     extra_index += @intFromBool(small.has_body_len);
                     extra_index += @intFromBool(small.has_fields_len);
@@ -3541,7 +3555,6 @@ pub fn declIterator(zir: Zir, decl_inst: Zir.Inst.Index) DeclIterator {
                 .union_decl => {
                     const small: Inst.UnionDecl.Small = @bitCast(extended.small);
                     var extra_index: u32 = @intCast(extended.operand + @typeInfo(Inst.UnionDecl).Struct.fields.len);
-                    extra_index += @intFromBool(small.has_src_node);
                     extra_index += @intFromBool(small.has_tag_type);
                     extra_index += @intFromBool(small.has_body_len);
                     extra_index += @intFromBool(small.has_fields_len);
@@ -3559,8 +3572,7 @@ pub fn declIterator(zir: Zir, decl_inst: Zir.Inst.Index) DeclIterator {
                 },
                 .opaque_decl => {
                     const small: Inst.OpaqueDecl.Small = @bitCast(extended.small);
-                    var extra_index: u32 = extended.operand;
-                    extra_index += @intFromBool(small.has_src_node);
+                    var extra_index: u32 = @intCast(extended.operand + @typeInfo(Inst.OpaqueDecl).Struct.fields.len);
                     const decls_len = if (small.has_decls_len) decls_len: {
                         const decls_len = zir.extra[extra_index];
                         extra_index += 1;

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -1405,12 +1405,6 @@ const Writer = struct {
 
         var extra_index: usize = extra.end;
 
-        const src_node: ?i32 = if (small.has_src_node) blk: {
-            const src_node = @as(i32, @bitCast(self.code.extra[extra_index]));
-            extra_index += 1;
-            break :blk src_node;
-        } else null;
-
         const fields_len = if (small.has_fields_len) blk: {
             const fields_len = self.code.extra[extra_index];
             extra_index += 1;
@@ -1453,7 +1447,7 @@ const Writer = struct {
             try stream.writeAll("{}, ");
         } else {
             const prev_parent_decl_node = self.parent_decl_node;
-            if (src_node) |off| self.parent_decl_node = self.relativeToNodeIndex(off);
+            self.parent_decl_node = self.relativeToNodeIndex(extra.data.src_node);
             defer self.parent_decl_node = prev_parent_decl_node;
 
             try stream.writeAll("{\n");
@@ -1534,7 +1528,7 @@ const Writer = struct {
             }
 
             const prev_parent_decl_node = self.parent_decl_node;
-            if (src_node) |off| self.parent_decl_node = self.relativeToNodeIndex(off);
+            self.parent_decl_node = self.relativeToNodeIndex(extra.data.src_node);
             try stream.writeAll("{\n");
             self.indent += 2;
 
@@ -1587,7 +1581,7 @@ const Writer = struct {
             try stream.writeByteNTimes(' ', self.indent);
             try stream.writeAll("})");
         }
-        try self.writeSrcNode(stream, src_node);
+        try self.writeSrcNode(stream, extra.data.src_node);
     }
 
     fn writeUnionDecl(self: *Writer, stream: anytype, extended: Zir.Inst.Extended.InstData) !void {
@@ -1604,12 +1598,6 @@ const Writer = struct {
         try stream.print("hash({}) ", .{std.fmt.fmtSliceHexLower(&fields_hash)});
 
         var extra_index: usize = extra.end;
-
-        const src_node: ?i32 = if (small.has_src_node) blk: {
-            const src_node = @as(i32, @bitCast(self.code.extra[extra_index]));
-            extra_index += 1;
-            break :blk src_node;
-        } else null;
 
         const tag_type_ref = if (small.has_tag_type) blk: {
             const tag_type_ref = @as(Zir.Inst.Ref, @enumFromInt(self.code.extra[extra_index]));
@@ -1644,7 +1632,7 @@ const Writer = struct {
             try stream.writeAll("{}");
         } else {
             const prev_parent_decl_node = self.parent_decl_node;
-            if (src_node) |off| self.parent_decl_node = self.relativeToNodeIndex(off);
+            self.parent_decl_node = self.relativeToNodeIndex(extra.data.src_node);
             defer self.parent_decl_node = prev_parent_decl_node;
 
             try stream.writeAll("{\n");
@@ -1663,7 +1651,7 @@ const Writer = struct {
 
         if (fields_len == 0) {
             try stream.writeAll("})");
-            try self.writeSrcNode(stream, src_node);
+            try self.writeSrcNode(stream, extra.data.src_node);
             return;
         }
         try stream.writeAll(", ");
@@ -1672,7 +1660,7 @@ const Writer = struct {
         extra_index += body.len;
 
         const prev_parent_decl_node = self.parent_decl_node;
-        if (src_node) |off| self.parent_decl_node = self.relativeToNodeIndex(off);
+        self.parent_decl_node = self.relativeToNodeIndex(extra.data.src_node);
         try self.writeBracedDecl(stream, body);
         try stream.writeAll(", {\n");
 
@@ -1740,7 +1728,7 @@ const Writer = struct {
         self.indent -= 2;
         try stream.writeByteNTimes(' ', self.indent);
         try stream.writeAll("})");
-        try self.writeSrcNode(stream, src_node);
+        try self.writeSrcNode(stream, extra.data.src_node);
     }
 
     fn writeEnumDecl(self: *Writer, stream: anytype, extended: Zir.Inst.Extended.InstData) !void {
@@ -1757,12 +1745,6 @@ const Writer = struct {
         try stream.print("hash({}) ", .{std.fmt.fmtSliceHexLower(&fields_hash)});
 
         var extra_index: usize = extra.end;
-
-        const src_node: ?i32 = if (small.has_src_node) blk: {
-            const src_node = @as(i32, @bitCast(self.code.extra[extra_index]));
-            extra_index += 1;
-            break :blk src_node;
-        } else null;
 
         const tag_type_ref = if (small.has_tag_type) blk: {
             const tag_type_ref = @as(Zir.Inst.Ref, @enumFromInt(self.code.extra[extra_index]));
@@ -1795,7 +1777,7 @@ const Writer = struct {
             try stream.writeAll("{}, ");
         } else {
             const prev_parent_decl_node = self.parent_decl_node;
-            if (src_node) |off| self.parent_decl_node = self.relativeToNodeIndex(off);
+            self.parent_decl_node = self.relativeToNodeIndex(extra.data.src_node);
             defer self.parent_decl_node = prev_parent_decl_node;
 
             try stream.writeAll("{\n");
@@ -1816,7 +1798,7 @@ const Writer = struct {
         extra_index += body.len;
 
         const prev_parent_decl_node = self.parent_decl_node;
-        if (src_node) |off| self.parent_decl_node = self.relativeToNodeIndex(off);
+        self.parent_decl_node = self.relativeToNodeIndex(extra.data.src_node);
         try self.writeBracedDecl(stream, body);
         if (fields_len == 0) {
             try stream.writeAll(", {})");
@@ -1864,7 +1846,7 @@ const Writer = struct {
             try stream.writeByteNTimes(' ', self.indent);
             try stream.writeAll("})");
         }
-        try self.writeSrcNode(stream, src_node);
+        try self.writeSrcNode(stream, extra.data.src_node);
     }
 
     fn writeOpaqueDecl(
@@ -1873,13 +1855,8 @@ const Writer = struct {
         extended: Zir.Inst.Extended.InstData,
     ) !void {
         const small = @as(Zir.Inst.OpaqueDecl.Small, @bitCast(extended.small));
-        var extra_index: usize = extended.operand;
-
-        const src_node: ?i32 = if (small.has_src_node) blk: {
-            const src_node = @as(i32, @bitCast(self.code.extra[extra_index]));
-            extra_index += 1;
-            break :blk src_node;
-        } else null;
+        const extra = self.code.extraData(Zir.Inst.OpaqueDecl, extended.operand);
+        var extra_index: usize = extra.end;
 
         const decls_len = if (small.has_decls_len) blk: {
             const decls_len = self.code.extra[extra_index];
@@ -1893,7 +1870,7 @@ const Writer = struct {
             try stream.writeAll("{})");
         } else {
             const prev_parent_decl_node = self.parent_decl_node;
-            if (src_node) |off| self.parent_decl_node = self.relativeToNodeIndex(off);
+            self.parent_decl_node = self.relativeToNodeIndex(extra.data.src_node);
             defer self.parent_decl_node = prev_parent_decl_node;
 
             try stream.writeAll("{\n");
@@ -1903,7 +1880,7 @@ const Writer = struct {
             try stream.writeByteNTimes(' ', self.indent);
             try stream.writeAll("})");
         }
-        try self.writeSrcNode(stream, src_node);
+        try self.writeSrcNode(stream, extra.data.src_node);
     }
 
     fn writeErrorSetDecl(

--- a/test/cases/compile_errors/non_constant_expression_in_array_size.zig
+++ b/test/cases/compile_errors/non_constant_expression_in_array_size.zig
@@ -14,6 +14,6 @@ export fn entry() usize {
 // backend=stage2
 // target=native
 //
-// :6:5: error: unable to resolve comptime value
-// :6:5: note: value being returned at comptime must be comptime-known
+// :6:12: error: unable to resolve comptime value
+// :6:12: note: value being returned at comptime must be comptime-known
 // :2:12: note: called from here


### PR DESCRIPTION
This PR doesn't have a single direction, sorry - it was just a chain of me noticing things to improve. The changes fall into two broad categories.

The first is the elimination of `Sema.src`. This field was a failed experiment, complicating the frontend and making unwarranted assumptions about the existence of source-location-providing instructions. Eliminating this did require adding source nodes to a handful of ZIR instructions and changing a few encodings. This slightly increased ZIR bytes, but that is mitigated by...

The second thing is a series of optimizations in `AstGen` to minimize the size of generated ZIR. The logic for eliding consecutive `dbg_stmt` instructions has been fixed, since it didn't previously work in some cases. In addition, the `ret_type` instruction no longer appears more than once in any function: if the return type is not a trivial `Ref`, it is immediately fetched (and the corresponding `Ref` stored) at the start of the function, and this same ref is reused. The logic here is that the return type isn't a trivial `Ref`, it probably isn't `void` or `noreturn`, so we more than likely need a `ret_type` instruction at some point to apply RLS to `return` statements. The final, and most significant, optimization is the migration of a bunch of `ty` result locations to `coerced_ty`. Adding explicit coercions to fixed types (like `u29`, `type`, `bool`, etc) is generally unnecessary; instead, Sema has been enhanced where necessary to implicitly perform these coercions, avoiding a whole bunch of instructions, including in some common cases like the conditions of `if` and `while` statements.

Total ZIR bytes for `Sema.zig` in this branch dropped from 4.877 MiB to 4.551 MiB. That's a 6.7% reduction!