### PR TITLE
std.mem: implement countScalar

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1502,7 +1502,7 @@ test "indexOfPos empty needle" {
 pub fn count(comptime T: type, haystack: []const T, needle: []const T) usize {
     assert(needle.len > 0);
     // Remove this check when the native x86_64 backend is able to handle vectors.
-    if (needle.len == 1 and builtin.zig_backend != .stage2_x86_64) return countScalar(T, haystack, needle[0]);
+    if (needle.len == 1 and haystack.len >= 1 << 10 and builtin.zig_backend != .stage2_x86_64) return countScalar(T, haystack, needle[0]);
 
     var i: usize = 0;
     var found: usize = 0;
@@ -1562,7 +1562,7 @@ fn countScalarNaive(comptime T: type, buffer: []const u8, scalar: T) usize {
 }
 
 test countScalar {
-    // Remove this skip when the native x86_64 backend is able to handle vectors..
+    // Remove this skip when the native x86_64 backend is able to handle vectors.
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     try testing.expect(countScalar(u8, "", 'h') == 0);
@@ -1572,7 +1572,7 @@ test countScalar {
 }
 
 test "countScalar random data" {
-    // Remove this skip when the native x86_64 backend is able to handle vectors..
+    // Remove this skip when the native x86_64 backend is able to handle vectors.
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     var random_buf: [(8 << 10) - 1]u8 = undefined;

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1501,6 +1501,8 @@ test "indexOfPos empty needle" {
 /// does not count overlapping needles
 pub fn count(comptime T: type, haystack: []const T, needle: []const T) usize {
     assert(needle.len > 0);
+    if (needle.len == 1) return countScalar(T, haystack, needle[0]);
+
     var i: usize = 0;
     var found: usize = 0;
 
@@ -1512,7 +1514,10 @@ pub fn count(comptime T: type, haystack: []const T, needle: []const T) usize {
     return found;
 }
 
-test "count" {
+test count {
+    // Remove this skip when the native x86_64 backend is able to handle vectors..
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     try testing.expect(count(u8, "", "h") == 0);
     try testing.expect(count(u8, "h", "h") == 1);
     try testing.expect(count(u8, "hh", "h") == 2);
@@ -1556,6 +1561,19 @@ fn countScalarNaive(comptime T: type, buffer: []const u8, scalar: T) usize {
 }
 
 test countScalar {
+    // Remove this skip when the native x86_64 backend is able to handle vectors..
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
+    try testing.expect(countScalar(u8, "", 'h') == 0);
+    try testing.expect(countScalar(u8, "h", 'h') == 1);
+    try testing.expect(countScalar(u8, "hh", 'h') == 2);
+    try testing.expect(countScalar(u8, "hahaha", 'h') == 3);
+}
+
+test "countScalar random data" {
+    // Remove this skip when the native x86_64 backend is able to handle vectors..
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+
     var random_buf: [(8 << 10) - 1]u8 = undefined;
 
     var r = std.rand.DefaultPrng.init(420);


### PR DESCRIPTION
It's `count`, but it counts scalars. This implementation is pretty naive, I invite anyone who actually knows what they're doing to improve it.

![benchmark_large](https://github.com/ziglang/zig/assets/119271574/e226b8b2-590a-4f24-85b5-d7f376c78746)
![benchmark_small](https://github.com/ziglang/zig/assets/119271574/61c79b0f-ca91-4250-88ff-afbef5965dac)


<details>
<summary>Full benchmark and code for reproduction</summary>

# Benchmark results

| size | countScalar (ours)      | std.mem.indexOfScalarPos | for loop                | std.mem.count           |
|---- |----------------------- |------------------------ |----------------------- |----------------------- |
| 2    | 0.000023464900000023144 | 0.000023196530000003262  | 0.00002150838999999774  | 0.00002248372000000395  |
| 3    | 0.0000253960400000197   | 0.0000237048000000119    | 0.000023026310000010728 | 0.000024475020000017405 |
| 4    | 0.000025047879999986505 | 0.000024263720000022955  | 0.00002297577000000891  | 0.000024049800000023867 |
| 6    | 0.000025573229999997896 | 0.000023923830000016468  | 0.000023576160000018906 | 0.000023569790000012182 |
| 8    | 0.000027832260000036577 | 0.00002588705999998711   | 0.000025209989999988318 | 0.000024756409999990994 |
| 11   | 0.000029385179999996764 | 0.000025670159999997968  | 0.00002689584000002754  | 0.000026181020000005323 |
| 14   | 0.0000305596500000049   | 0.000027058660000033776  | 0.00002839323999999727  | 0.000027671220000034483 |
| 18   | 0.00002645515000003057  | 0.0000236872900000164    | 0.00002454112999998872  | 0.000024090340000012978 |
| 23   | 0.00003190487000002585  | 0.00002580250999998167   | 0.000029585980000011675 | 0.000026339359999976467 |
| 29   | 0.000034974120000014267 | 0.000028013460000030804  | 0.000034224929999991726 | 0.000028184770000031282 |
| 37   | 0.00004046995999998005  | 0.00003217519999998683   | 0.00003056049999999651  | 0.00003242046999998755  |
| 47   | 0.000039558299999994664 | 0.000027417050000036428  | 0.000035000490000006706 | 0.000027204120000035457 |
| 59   | 0.00004587453999999755  | 0.000027417300000005488  | 0.00003678387000000039  | 0.000027535100000005577 |
| 74   | 0.000044418680000001885 | 0.000028810130000038095  | 0.00003812865000001577  | 0.000029422820000043033 |
| 93   | 0.00004914570999998921  | 0.00002933253000002262   | 0.00004350905000000571  | 0.000029815830000025078 |
| 117  | 0.000048521719999996396 | 0.000026975779999997993  | 0.00004246816999999797  | 0.00002702771999999412  |
| 147  | 0.0000454115199999552   | 0.000025611149999986576  | 0.00004418860999998741  | 0.000025736049999985342 |
| 184  | 0.00004742859999998364  | 0.00002880539000003851   | 0.000054125199999974394 | 0.000028983070000036614 |
| 231  | 0.00004607115999996334  | 0.000029875050000021858  | 0.00006161076999995921  | 0.00003044100000001927  |
| 289  | 0.000044804639999973875 | 0.00006920610999992582   | 0.00006730696999990579  | 0.00006952417999994126  |
| 362  | 0.00005089566000006024  | 0.00003207629999999802   | 0.00008378686000001096  | 0.000033451569999994546 |
| 453  | 0.00004918478000006019  | 0.000051961619999984315  | 0.00009673751999991871  | 0.00005265608999998486  |
| 567  | 0.00005456517000003895  | 0.0000733465100000812    | 0.0001144898099999582   | 0.00007385244000006343  |
| 709  | 0.00005504592000003613  | 0.000048653980000042125  | 0.0001366550600000918   | 0.00004996640000000278  |
| 887  | 0.00006136773000001086  | 0.00006186500000004917   | 0.0001633145999999      | 0.00006205890000004952  |
| 1109 | 0.00006674127999992447  | 0.00010829309999996535   | 0.00019821557000004032  | 0.00010810837999999801  |
| 1387 | 0.00006891603000008192  | 0.00008709395000001266   | 0.00024082457999999023  | 0.00008687308000002016  |
| 1734 | 0.00007493533000002507  | 0.00010686133000002643   | 0.00028604895000012713  | 0.00010465643000001417  |
| 2168 | 0.00008735432000007343  | 0.00015419600000002008   | 0.0003504982600000014   | 0.00015267519000002923  |
| 2711 | 0.00009832611999997633  | 0.0002332012699999387    | 0.0004285871500001532   | 0.0002331817999999769   |
| 3389 | 0.00011221696000004505  | 0.00022791100999996412   | 0.0005352495900001555   | 0.00022713536999995813  |
| 4237 | 0.00012929028000011004  | 0.0002787040499999516    | 0.0006571959700003532   | 0.000278118969999979    |
| 5297 | 0.00015022465999999022  | 0.00031032641999995656   | 0.0008097280100003221   | 0.0003099293499999375   |
| 6622 | 0.00018385745999989456  | 0.00048815489999995073   | 0.0010236344099996113   | 0.0004810720399999241   |
| 8278 | 0.0002143495799999892   | 0.000587665020000018     | 0.0012455940499999432   | 0.0005959378499998925   |

| size       | countScalar (ours)    | with std.mem.indexOfScalarPos | for loop              | std.mem.count         |
|---------- |--------------------- |----------------------------- |--------------------- |--------------------- |
| 10348      | 0.0002605869000002587 | 0.0006106022599999865         | 0.001583000240000024  | 0.0006120705600000114 |
| 12936      | 0.0003174527299997453 | 0.0007204952200000542         | 0.0019412980599992494 | 0.0007118463500000117 |
| 16171      | 0.0003863564099997878 | 0.0010528252799999452         | 0.0024174177399996946 | 0.0010531298899999024 |
| 20214      | 0.0004764090300001129 | 0.001238656700000136          | 0.003022947649998648  | 0.0012366303200001159 |
| 25268      | 0.000582295880000115  | 0.0015457653799999386         | 0.003776248939998401  | 0.0015449768999999441 |
| 31586      | 0.0007135841000000162 | 0.0019145418299999805         | 0.004722941839999735  | 0.0019123274300000429 |
| 39483      | 0.0008851652299999671 | 0.002784876059999961          | 0.005899676150000759  | 0.0027942092399999728 |
| 49354      | 0.0010912714000002243 | 0.0038421264499998733         | 0.007347238629997974  | 0.0038775501699999946 |
| 61693      | 0.0013551211000004605 | 0.004164382330000205          | 0.009155072239998908  | 0.004181737600000086  |
| 77117      | 0.001724970509999618  | 0.0053712125199998784         | 0.011700261670001266  | 0.005409542909999768  |
| 96397      | 0.0020975012800001484 | 0.006995042920000171          | 0.014317153119999116  | 0.007086825300000025  |
| 120497     | 0.0026252741700000673 | 0.008815821749999618          | 0.017888972619998823  | 0.008878448479999664  |
| 150622     | 0.0033245986000000004 | 0.01057155909999977           | 0.022408292529999152  | 0.010669637909999915  |
| 188278     | 0.0042047071500001705 | 0.013543070740000208          | 0.028243332710002473  | 0.013770348870000164  |
| 235348     | 0.005279465989999921  | 0.016931470300000372          | 0.035210344279998265  | 0.017480044739999884  |
| 294186     | 0.006804251890000462  | 0.023139174160000713          | 0.043879674379999845  | 0.02391872945999924   |
| 367733     | 0.0088259481299996    | 0.030705722659999678          | 0.055187999350000454  | 0.032358359399999696  |
| 459667     | 0.011411703620000185  | 0.041169198510000435          | 0.0692848512200006    | 0.04247426390000033   |
| 574584     | 0.01439268079999955   | 0.05369120311999937           | 0.0864807222799972    | 0.055442042190000665  |
| 718231     | 0.01804814953999935   | 0.06838918764000085           | 0.10806686325999573   | 0.069972429999999     |
| 897789     | 0.022661784480000075  | 0.08567686910999872           | 0.1349755047899962    | 0.0877149495100017    |
| 1122237    | 0.03416207999999999   | 0.11247004000000001           | 0.1732163200000001    | 0.11508615999999998   |
| 1402797    | 0.04345729999999999   | 0.14402474999999998           | 0.22761666999999997   | 0.14678084            |
| 1753497    | 0.05620708999999998   | 0.17839082                    | 0.28254294999999996   | 0.18727466999999995   |
| 2191872    | 0.07644564000000002   | 0.23247176999999994           | 0.35890789000000006   | 0.23710119999999996   |
| 2739841    | 0.10687799999999999   | 0.29515779999999997           | 0.45260366000000035   | 0.30082067999999995   |
| 3424802    | 0.14367637000000003   | 0.37755215000000014           | 0.5756861499999998    | 0.38210157999999983   |
| 4281003    | 0.19658524            | 0.4746530200000001            | 0.73020794            | 0.48417689999999985   |
| 5351254    | 0.25432821000000005   | 0.6080374799999999            | 0.9297898599999997    | 0.6214180300000001    |
| 6689068    | 0.3422022400000001    | 0.7644100699999998            | 1.1623745900000002    | 0.77783003            |
| 8361336    | 0.4226677400000001    | 0.9563037                     | 1.4408941799999997    | 0.97516586            |
| 10451671   | 0.5655789900000001    | 1.23273752                    | 1.9021402299999999    | 1.25796862            |
| 13064589   | 0.6918097600000004    | 1.52092094                    | 2.283415520000001     | 1.5558013499999999    |
| 16330737   | 0.86098559            | 1.8974571199999997            | 2.8510246800000005    | 1.9323465             |
| 20413422   | 1.11271663            | 2.4088533500000002            | 3.693907469999999     | 2.4594567600000006    |
| 25516778   | 1.3405323900000001    | 2.962251240000002             | 4.448140119999999     | 3.0224632699999994    |
| 31895973   | 1.6868844199999997    | 3.6971971199999984            | 5.544416299999998     | 3.7636381800000005    |
| 39869967   | 2.106003730000001     | 4.6225226500000005            | 6.917443109999999     | 4.706147100000001     |
| 49837459   | 2.637303879999999     | 5.783021750000001             | 8.664598789999998     | 5.878742029999999     |
| 62296824   | 3.2970310199999977    | 7.22207831                    | 10.794350690000003    | 7.366879089999998     |
| 77871031   | 4.13655058            | 9.040970880000001             | 13.518773239999998    | 9.217422350000003     |
| 97338789   | 5.18470277            | 11.313772530000001            | 16.91996838           | 11.541721240000005    |
| 121673487  | 6.4682869499999995    | 14.093169790000006            | 21.150735020000003    | 14.339632799999999    |
| 152091859  | 8.061907310000004     | 17.585131460000003            | 26.387820400000013    | 17.937712660000003    |
| 190114824  | 10.177184399999998    | 22.099823810000018            | 33.31034668999999     | 22.497376059999997    |
| 237643531  | 12.659882489999996    | 27.550444270000003            | 41.27648912999999     | 28.07405706000001     |
| 297054414  | 15.766334719999998    | 34.33639417999998             | 51.54654476999999     | 34.99725516000003     |
| 371318018  | 19.95141591000001     | 43.2480749                    | 64.72809937999999     | 44.013470339999984    |
| 464147523  | 24.645009889999997    | 53.77329816999999             | 80.55318559999999     | 54.737607139999994    |
| 580184404  | 30.786373700000002    | 67.04087507                   | 100.51151740000002    | 68.38568397999998     |
| 725230506  | 38.639134680000005    | 83.82778145999997             | 126.49855235          | 85.73139887           |
| 906538133  | 48.10593943           | 104.83934490000001            | 157.21558964000002    | 107.20410599999995    |
| 1133172667 | 60.22556732           | 130.93807725999994            | 196.53765958          | 133.44189920999997    |
| 1416465834 | 75.29611336999999     | 163.69610600000007            | 245.41637989000006    | 166.75386866000008    |
| 1770582293 | 94.11104758000002     | 204.81170289000005            | 306.91474422000005    | 208.53155693          |

# Benchmark code

`count_scalar.zig`

```zig
const std = @import("std");

fn countScalar(comptime T: type, buffer: []const u8, scalar: T) usize {
    const v_len = std.simd.suggestVectorLength(T) orelse return countScalarNaive(T, buffer, scalar);
    const V = @Vector(v_len, T);

    const aligned = std.mem.alignInSlice(@as([]T, @constCast(buffer)), @alignOf(V)) orelse return countScalarNaive(T, buffer, scalar);
    const v_aligned_ptr: [*]const V = @ptrCast(aligned.ptr);
    const v_aligned = v_aligned_ptr[0..aligned.len / v_len];

    var count = countScalarNaive(T, buffer[0..buffer.len - aligned.len], scalar);

    for (v_aligned) |vec| {
        count += std.simd.countTrues(vec == @as(V, @splat(scalar)));

    }

    return count + countScalarNaive(T, aligned[v_aligned.len * v_len..], scalar);
}

fn countScalarNaive(comptime T: type, buffer: []const u8, scalar: T) usize {
    var count: usize = 0;
    for (buffer) |x| {
        count += @intFromBool(x == scalar);
    }
    return count;
}

fn countScalarIndexOfScalarPos(comptime T: type, haystack: []const u8, needle: T) usize {
    var i: usize = 0;
    var found: usize = 0;

    while (std.mem.indexOfScalarPos(T, haystack, i, needle)) |idx| {
        i = idx + 1;
        found += 1;
    }

    return found;
}

export fn count_scalar_simd(buffer: [*]const u8, len: usize, scalar: u8) usize {
    return countScalar(u8, buffer[0..len], scalar);
}

export fn count_scalar_naive(buffer: [*]const u8, len: usize, scalar: u8) usize {
    return countScalarNaive(u8, buffer[0..len], scalar);
}

export fn count_scalar_iosp(buffer: [*]const u8, len: usize, scalar: u8) usize {
    return countScalarIndexOfScalarPos(u8, buffer[0..len], scalar);
}

export fn count_std(buffer: [*]const u8, len: usize, scalar: u8) usize {
    return std.mem.count(u8, buffer[0..len], &.{scalar});
}


test "countScalar" {
    var x: [(32 << 10) - 1]u8 = undefined;
    var r = std.rand.Sfc64.init(420);
    r.random().bytes(&x);
    const scalar = r.random().int(u8);
    x[x.len - 1] = scalar;
    const correct_count = std.mem.count(u8, &x, &.{scalar});
    const correct_count_2 = countScalarNaive(u8, &x, scalar);
    const our_count = countScalar(u8, &x, scalar);
    try std.testing.expectEqual(correct_count_2, our_count);
    try std.testing.expectEqual(correct_count, our_count);
}
```

`count_scalar_bench.zig`

```zig
const std = @import("std");

extern fn count_scalar_simd(buffer: [*]const u8, len: usize, scalar: u8) usize;
extern fn count_scalar_naive(buffer: [*]const u8, len: usize, scalar: u8) usize;
extern fn count_std(buffer: [*]const u8, len: usize, scalar: u8) usize;
extern fn count_scalar_iosp(buffer: [*]const u8, len: usize, scalar: u8) usize;

pub fn main() !void {
    const so = std.io.getStdOut().writer();

    try so.writeAll("nb_bytes,ms_ours,ms_iosp,ms_naive,ms_std\n");

    const memory_limit = 2 << 30;

    var nb_bytes: usize = 2;
    while(nb_bytes < memory_limit) : (nb_bytes = nb_bytes * 5 / 4 + 1) {
        const x_aligned = try std.heap.page_allocator.alloc(u8, nb_bytes + 1);
        defer std.heap.page_allocator.free(x_aligned);
        // unalign
        const x = x_aligned[1..];
        var r = std.rand.Sfc64.init(420);
        r.random().bytes(x);
        const scalar = r.random().int(u8);
        x[x.len - 1] = scalar;

        var results: [4]f64 = .{0.0} ** 4;
        const reps: usize = if (nb_bytes < 1 << 20) 100000 else 100;
        for(0..reps) |_| {
            inline for (.{count_scalar_simd, count_scalar_iosp, count_scalar_naive, count_std}, &results) |func, *time_ms| {
                var timer = std.time.Timer.start() catch unreachable;
                _ = func(x.ptr, x.len, scalar);
                const time_ns: f64 = @floatFromInt(timer.read());

                time_ms.* += time_ns / std.time.ns_per_ms;
            }
        }

        inline for (&results) |*time_ms| time_ms.* /= @floatFromInt(reps);

        try so.print("{d},{d},{d},{d},{d}\n", .{nb_bytes, results[0], results[1], results[2], results[3]});
    }
}
```

```sh
zig build-obj -fno-lto -OReleaseFast count_scalar.zig
zig build-exe -fno-lto -OReleaseFast count_scalar_bench.zig count_scalar.o
```
</details>
