### PR TITLE
`std.zig.fmtId`: conditionally escape primitives/`_` (breaking)

### DIFF
--- a/lib/compiler/aro_translate_c/ast.zig
+++ b/lib/compiler/aro_translate_c/ast.zig
@@ -828,7 +828,7 @@ const Context = struct {
     fn addIdentifier(c: *Context, bytes: []const u8) Allocator.Error!TokenIndex {
         if (std.zig.primitives.isPrimitive(bytes))
             return c.addTokenFmt(.identifier, "@\"{s}\"", .{bytes});
-        return c.addTokenFmt(.identifier, "{s}", .{std.zig.fmtId(bytes)});
+        return c.addTokenFmt(.identifier, "{p}", .{std.zig.fmtId(bytes)});
     }
 
     fn listToSpan(c: *Context, list: []const NodeIndex) Allocator.Error!NodeSubRange {
@@ -2106,7 +2106,7 @@ fn renderRecord(c: *Context, node: Node) !NodeIndex {
     members[1] = 0;
 
     for (payload.fields, 0..) |field, i| {
-        const name_tok = try c.addTokenFmt(.identifier, "{s}", .{std.zig.fmtId(field.name)});
+        const name_tok = try c.addTokenFmt(.identifier, "{p}", .{std.zig.fmtId(field.name)});
         _ = try c.addToken(.colon, ":");
         const type_expr = try renderNode(c, field.type);
 
@@ -2199,7 +2199,7 @@ fn renderFieldAccess(c: *Context, lhs: NodeIndex, field_name: []const u8) !NodeI
         .main_token = try c.addToken(.period, "."),
         .data = .{
             .lhs = lhs,
-            .rhs = try c.addTokenFmt(.identifier, "{s}", .{std.zig.fmtId(field_name)}),
+            .rhs = try c.addTokenFmt(.identifier, "{p}", .{std.zig.fmtId(field_name)}),
         },
     });
 }

--- a/lib/compiler/test_runner.zig
+++ b/lib/compiler/test_runner.zig
@@ -106,10 +106,10 @@ fn mainServer() !void {
                         .fail = fail,
                         .skip = skip,
                         .leak = leak,
-                        .log_err_count = std.math.lossyCast(std.meta.FieldType(
-                            std.zig.Server.Message.TestResults.Flags,
-                            .log_err_count,
-                        ), log_err_count),
+                        .log_err_count = std.math.lossyCast(
+                            @TypeOf(@as(std.zig.Server.Message.TestResults.Flags, undefined).log_err_count),
+                            log_err_count,
+                        ),
                     },
                 });
             },

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -234,7 +234,7 @@ fn printType(self: *Options, out: anytype, comptime T: type, value: T, indent: u
             try printEnum(self, out, T, info, indent);
 
             if (name) |some| {
-                try out.print("pub const {}: {s} = .{s};\n", .{
+                try out.print("pub const {}: {} = .{p_};\n", .{
                     std.zig.fmtId(some),
                     std.zig.fmtId(@typeName(T)),
                     std.zig.fmtId(@tagName(value)),
@@ -246,7 +246,7 @@ fn printType(self: *Options, out: anytype, comptime T: type, value: T, indent: u
             try printStruct(self, out, T, info, indent);
 
             if (name) |some| {
-                try out.print("pub const {}: {s} = ", .{
+                try out.print("pub const {}: {} = ", .{
                     std.zig.fmtId(some),
                     std.zig.fmtId(@typeName(T)),
                 });
@@ -279,7 +279,7 @@ fn printEnum(self: *Options, out: anytype, comptime T: type, comptime val: std.b
 
     inline for (val.fields) |field| {
         try out.writeByteNTimes(' ', indent);
-        try out.print("    {} = {d},\n", .{ std.zig.fmtId(field.name), field.value });
+        try out.print("    {p} = {d},\n", .{ std.zig.fmtId(field.name), field.value });
     }
 
     if (!val.is_exhaustive) {
@@ -313,9 +313,9 @@ fn printStruct(self: *Options, out: anytype, comptime T: type, comptime val: std
 
         // If the type name doesn't contains a '.' the type is from zig builtins.
         if (std.mem.containsAtLeast(u8, type_name, 1, ".")) {
-            try out.print("    {}: {}", .{ std.zig.fmtId(field.name), std.zig.fmtId(type_name) });
+            try out.print("    {p_}: {}", .{ std.zig.fmtId(field.name), std.zig.fmtId(type_name) });
         } else {
-            try out.print("    {}: {s}", .{ std.zig.fmtId(field.name), type_name });
+            try out.print("    {p_}: {s}", .{ std.zig.fmtId(field.name), type_name });
         }
 
         if (field.default_value != null) {
@@ -355,7 +355,7 @@ fn printStructValue(self: *Options, out: anytype, comptime struct_val: std.built
     } else {
         inline for (struct_val.fields) |field| {
             try out.writeByteNTimes(' ', indent);
-            try out.print("    .{} = ", .{std.zig.fmtId(field.name)});
+            try out.print("    .{p_} = ", .{std.zig.fmtId(field.name)});
 
             const field_name = @field(val, field.name);
             switch (@typeInfo(@TypeOf(field_name))) {

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -10,6 +10,7 @@ pub const Tokenizer = tokenizer.Tokenizer;
 pub const string_literal = @import("zig/string_literal.zig");
 pub const number_literal = @import("zig/number_literal.zig");
 pub const primitives = @import("zig/primitives.zig");
+pub const isPrimitive = primitives.isPrimitive;
 pub const Ast = @import("zig/Ast.zig");
 pub const AstGen = @import("zig/AstGen.zig");
 pub const Zir = @import("zig/Zir.zig");
@@ -728,20 +729,87 @@ const tokenizer = @import("zig/tokenizer.zig");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 
-/// Return a Formatter for a Zig identifier
+/// Return a Formatter for a Zig identifier, escaping it with `@""` syntax if needed.
+///
+/// - An empty `{}` format specifier escapes invalid identifiers, identifiers that shadow primitives
+///   and the reserved `_` identifier.
+/// - Add `p` to the specifier to render identifiers that shadow primitives unescaped.
+/// - Add `_` to the specifier to render the reserved `_` identifier unescaped.
+/// - `p` and `_` can be combined, e.g. `{p_}`.
+///
 pub fn fmtId(bytes: []const u8) std.fmt.Formatter(formatId) {
     return .{ .data = bytes };
 }
 
-/// Print the string as a Zig identifier escaping it with @"" syntax if needed.
+test fmtId {
+    const expectFmt = std.testing.expectFmt;
+    try expectFmt("@\"while\"", "{}", .{fmtId("while")});
+    try expectFmt("@\"while\"", "{p}", .{fmtId("while")});
+    try expectFmt("@\"while\"", "{_}", .{fmtId("while")});
+    try expectFmt("@\"while\"", "{p_}", .{fmtId("while")});
+    try expectFmt("@\"while\"", "{_p}", .{fmtId("while")});
+
+    try expectFmt("hello", "{}", .{fmtId("hello")});
+    try expectFmt("hello", "{p}", .{fmtId("hello")});
+    try expectFmt("hello", "{_}", .{fmtId("hello")});
+    try expectFmt("hello", "{p_}", .{fmtId("hello")});
+    try expectFmt("hello", "{_p}", .{fmtId("hello")});
+
+    try expectFmt("@\"type\"", "{}", .{fmtId("type")});
+    try expectFmt("type", "{p}", .{fmtId("type")});
+    try expectFmt("@\"type\"", "{_}", .{fmtId("type")});
+    try expectFmt("type", "{p_}", .{fmtId("type")});
+    try expectFmt("type", "{_p}", .{fmtId("type")});
+
+    try expectFmt("@\"_\"", "{}", .{fmtId("_")});
+    try expectFmt("@\"_\"", "{p}", .{fmtId("_")});
+    try expectFmt("_", "{_}", .{fmtId("_")});
+    try expectFmt("_", "{p_}", .{fmtId("_")});
+    try expectFmt("_", "{_p}", .{fmtId("_")});
+
+    try expectFmt("@\"i123\"", "{}", .{fmtId("i123")});
+    try expectFmt("i123", "{p}", .{fmtId("i123")});
+    try expectFmt("@\"4four\"", "{}", .{fmtId("4four")});
+    try expectFmt("_underscore", "{}", .{fmtId("_underscore")});
+    try expectFmt("@\"11\\\"23\"", "{}", .{fmtId("11\"23")});
+    try expectFmt("@\"11\\x0f23\"", "{}", .{fmtId("11\x0F23")});
+
+    // These are technically not currently legal in Zig.
+    try expectFmt("@\"\"", "{}", .{fmtId("")});
+    try expectFmt("@\"\\x00\"", "{}", .{fmtId("\x00")});
+}
+
+/// Print the string as a Zig identifier, escaping it with `@""` syntax if needed.
 fn formatId(
     bytes: []const u8,
-    comptime unused_format_string: []const u8,
+    comptime fmt: []const u8,
     options: std.fmt.FormatOptions,
     writer: anytype,
 ) !void {
-    _ = unused_format_string;
-    if (isValidId(bytes)) {
+    const allow_primitive, const allow_underscore = comptime parse_fmt: {
+        var allow_primitive = false;
+        var allow_underscore = false;
+        for (fmt) |char| {
+            switch (char) {
+                'p' => if (!allow_primitive) {
+                    allow_primitive = true;
+                    continue;
+                },
+                '_' => if (!allow_underscore) {
+                    allow_underscore = true;
+                    continue;
+                },
+                else => {},
+            }
+            @compileError("expected {}, {p}, {_}, {p_} or {_p}, found {" ++ fmt ++ "}");
+        }
+        break :parse_fmt .{ allow_primitive, allow_underscore };
+    };
+
+    if (isValidId(bytes) and
+        (allow_primitive or !std.zig.isPrimitive(bytes)) and
+        (allow_underscore or !isUnderscore(bytes)))
+    {
         return writer.writeAll(bytes);
     }
     try writer.writeAll("@\"");
@@ -757,12 +825,8 @@ pub fn fmtEscapes(bytes: []const u8) std.fmt.Formatter(stringEscape) {
     return .{ .data = bytes };
 }
 
-test "escape invalid identifiers" {
+test fmtEscapes {
     const expectFmt = std.testing.expectFmt;
-    try expectFmt("@\"while\"", "{}", .{fmtId("while")});
-    try expectFmt("hello", "{}", .{fmtId("hello")});
-    try expectFmt("@\"11\\\"23\"", "{}", .{fmtId("11\"23")});
-    try expectFmt("@\"11\\x0f23\"", "{}", .{fmtId("11\x0F23")});
     try expectFmt("\\x0f", "{}", .{fmtEscapes("\x0f")});
     try expectFmt(
         \\" \\ hi \x07 \x11 " derp \'"
@@ -816,7 +880,6 @@ pub fn stringEscape(
 
 pub fn isValidId(bytes: []const u8) bool {
     if (bytes.len == 0) return false;
-    if (std.mem.eql(u8, bytes, "_")) return false;
     for (bytes, 0..) |c, i| {
         switch (c) {
             '_', 'a'...'z', 'A'...'Z' => {},
@@ -834,6 +897,18 @@ test isValidId {
     try std.testing.expect(!isValidId("3d"));
     try std.testing.expect(!isValidId("enum"));
     try std.testing.expect(isValidId("i386"));
+}
+
+pub fn isUnderscore(bytes: []const u8) bool {
+    return bytes.len == 1 and bytes[0] == '_';
+}
+
+test isUnderscore {
+    try std.testing.expect(isUnderscore("_"));
+    try std.testing.expect(!isUnderscore("__"));
+    try std.testing.expect(!isUnderscore("_foo"));
+    try std.testing.expect(isUnderscore("\x5f"));
+    try std.testing.expect(!isUnderscore("\\x5f"));
 }
 
 pub fn readSourceFileToEndAlloc(

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2847,8 +2847,8 @@ fn renderIdentifier(r: *Render, token_index: Ast.TokenIndex, space: Space, quote
         return renderQuotedIdentifier(r, token_index, space, false);
     }
 
-    // Special case for _ which would incorrectly be rejected by isValidId below.
-    if (contents.len == 1 and contents[0] == '_') switch (quote) {
+    // Special case for _.
+    if (std.zig.isUnderscore(contents)) switch (quote) {
         .eagerly_unquote => return renderQuotedIdentifier(r, token_index, space, true),
         .eagerly_unquote_except_underscore,
         .preserve_when_shadowing,

--- a/src/Builtin.zig
+++ b/src/Builtin.zig
@@ -35,17 +35,17 @@ pub fn append(opts: @This(), buffer: *std.ArrayList(u8)) Allocator.Error!void {
         \\/// feature detection (i.e. with `@hasDecl` or `@hasField`) over version checks.
         \\pub const zig_version = std.SemanticVersion.parse(zig_version_string) catch unreachable;
         \\pub const zig_version_string = "{s}";
-        \\pub const zig_backend = std.builtin.CompilerBackend.{};
+        \\pub const zig_backend = std.builtin.CompilerBackend.{p_};
         \\
-        \\pub const output_mode = std.builtin.OutputMode.{};
-        \\pub const link_mode = std.builtin.LinkMode.{};
+        \\pub const output_mode = std.builtin.OutputMode.{p_};
+        \\pub const link_mode = std.builtin.LinkMode.{p_};
         \\pub const is_test = {};
         \\pub const single_threaded = {};
-        \\pub const abi = std.Target.Abi.{};
+        \\pub const abi = std.Target.Abi.{p_};
         \\pub const cpu: std.Target.Cpu = .{{
-        \\    .arch = .{},
-        \\    .model = &std.Target.{}.cpu.{},
-        \\    .features = std.Target.{}.featureSet(&[_]std.Target.{}.Feature{{
+        \\    .arch = .{p_},
+        \\    .model = &std.Target.{p_}.cpu.{p_},
+        \\    .features = std.Target.{p_}.featureSet(&[_]std.Target.{p_}.Feature{{
         \\
     , .{
         build_options.version,
@@ -66,14 +66,14 @@ pub fn append(opts: @This(), buffer: *std.ArrayList(u8)) Allocator.Error!void {
         const index = @as(std.Target.Cpu.Feature.Set.Index, @intCast(index_usize));
         const is_enabled = target.cpu.features.isEnabled(index);
         if (is_enabled) {
-            try buffer.writer().print("        .{},\n", .{std.zig.fmtId(feature.name)});
+            try buffer.writer().print("        .{p_},\n", .{std.zig.fmtId(feature.name)});
         }
     }
     try buffer.writer().print(
         \\    }}),
         \\}};
         \\pub const os = std.Target.Os{{
-        \\    .tag = .{},
+        \\    .tag = .{p_},
         \\    .version_range = .{{
     ,
         .{std.zig.fmtId(@tagName(target.os.tag))},
@@ -180,8 +180,8 @@ pub fn append(opts: @This(), buffer: *std.ArrayList(u8)) Allocator.Error!void {
     const link_libc = opts.link_libc;
 
     try buffer.writer().print(
-        \\pub const object_format = std.Target.ObjectFormat.{};
-        \\pub const mode = std.builtin.OptimizeMode.{};
+        \\pub const object_format = std.Target.ObjectFormat.{p_};
+        \\pub const mode = std.builtin.OptimizeMode.{p_};
         \\pub const link_libc = {};
         \\pub const link_libcpp = {};
         \\pub const have_error_return_tracing = {};
@@ -190,7 +190,7 @@ pub fn append(opts: @This(), buffer: *std.ArrayList(u8)) Allocator.Error!void {
         \\pub const position_independent_code = {};
         \\pub const position_independent_executable = {};
         \\pub const strip_debug_info = {};
-        \\pub const code_model = std.builtin.CodeModel.{};
+        \\pub const code_model = std.builtin.CodeModel.{p_};
         \\pub const omit_frame_pointer = {};
         \\
     , .{
@@ -209,11 +209,10 @@ pub fn append(opts: @This(), buffer: *std.ArrayList(u8)) Allocator.Error!void {
     });
 
     if (target.os.tag == .wasi) {
-        const wasi_exec_model_fmt = std.zig.fmtId(@tagName(opts.wasi_exec_model));
         try buffer.writer().print(
-            \\pub const wasi_exec_model = std.builtin.WasiExecModel.{};
+            \\pub const wasi_exec_model = std.builtin.WasiExecModel.{p_};
             \\
-        , .{wasi_exec_model_fmt});
+        , .{std.zig.fmtId(@tagName(opts.wasi_exec_model))});
     }
 
     if (opts.is_test) {

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -488,7 +488,7 @@ pub const NullTerminatedString = enum(u32) {
         if (comptime std.mem.eql(u8, specifier, "")) {
             try writer.writeAll(s);
         } else if (comptime std.mem.eql(u8, specifier, "i")) {
-            try writer.print("{}", .{std.zig.fmtId(s)});
+            try writer.print("{p}", .{std.zig.fmtId(s)});
         } else @compileError("invalid format string '" ++ specifier ++ "' for '" ++ @typeName(NullTerminatedString) ++ "'");
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -6943,7 +6943,7 @@ fn cmdFetch(
         std.zig.fmtEscapes(&hex_digest),
     });
 
-    const new_node_text = try std.fmt.allocPrint(arena, ".{} = {s},\n", .{
+    const new_node_text = try std.fmt.allocPrint(arena, ".{p_} = {s},\n", .{
         std.zig.fmtId(name), new_node_init,
     });
 

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -1005,7 +1005,7 @@ const Writer = struct {
         const decl_name = self.code.nullTerminatedString(extra.decl_name);
 
         try self.writeInstRef(stream, extra.namespace);
-        try stream.print(", {}, ", .{std.zig.fmtId(decl_name)});
+        try stream.print(", {p}, ", .{std.zig.fmtId(decl_name)});
         try self.writeInstRef(stream, extra.options);
         try stream.writeAll(") ");
         try self.writeSrc(stream, inst_data.src());
@@ -1243,7 +1243,7 @@ const Writer = struct {
 
                 const name = self.code.nullTerminatedString(output.data.name);
                 const constraint = self.code.nullTerminatedString(output.data.constraint);
-                try stream.print("output({}, \"{}\", ", .{
+                try stream.print("output({p}, \"{}\", ", .{
                     std.zig.fmtId(name), std.zig.fmtEscapes(constraint),
                 });
                 try self.writeFlag(stream, "->", is_type);
@@ -1262,7 +1262,7 @@ const Writer = struct {
 
                 const name = self.code.nullTerminatedString(input.data.name);
                 const constraint = self.code.nullTerminatedString(input.data.constraint);
-                try stream.print("input({}, \"{}\", ", .{
+                try stream.print("input({p}, \"{}\", ", .{
                     std.zig.fmtId(name), std.zig.fmtEscapes(constraint),
                 });
                 try self.writeInstRef(stream, input.data.operand);
@@ -1278,7 +1278,7 @@ const Writer = struct {
                 const str_index = self.code.extra[extra_i];
                 extra_i += 1;
                 const clobber = self.code.nullTerminatedString(@enumFromInt(str_index));
-                try stream.print("{}", .{std.zig.fmtId(clobber)});
+                try stream.print("{p}", .{std.zig.fmtId(clobber)});
                 if (i + 1 < clobbers_len) {
                     try stream.writeAll(", ");
                 }
@@ -1559,7 +1559,7 @@ const Writer = struct {
                 try self.writeFlag(stream, "comptime ", field.is_comptime);
                 if (field.name != .empty) {
                     const field_name = self.code.nullTerminatedString(field.name);
-                    try stream.print("{}: ", .{std.zig.fmtId(field_name)});
+                    try stream.print("{p}: ", .{std.zig.fmtId(field_name)});
                 } else {
                     try stream.print("@\"{d}\": ", .{i});
                 }
@@ -1738,7 +1738,7 @@ const Writer = struct {
 
             try self.writeDocComment(stream, doc_comment_index);
             try stream.writeByteNTimes(' ', self.indent);
-            try stream.print("{}", .{std.zig.fmtId(field_name)});
+            try stream.print("{p}", .{std.zig.fmtId(field_name)});
 
             if (has_type) {
                 const field_type = @as(Zir.Inst.Ref, @enumFromInt(self.code.extra[extra_index]));
@@ -1891,7 +1891,7 @@ const Writer = struct {
                 try self.writeDocComment(stream, doc_comment_index);
 
                 try stream.writeByteNTimes(' ', self.indent);
-                try stream.print("{}", .{std.zig.fmtId(field_name)});
+                try stream.print("{p}", .{std.zig.fmtId(field_name)});
 
                 if (has_tag_value) {
                     const tag_value_ref = @as(Zir.Inst.Ref, @enumFromInt(self.code.extra[extra_index]));
@@ -1986,7 +1986,7 @@ const Writer = struct {
             const doc_comment_index: Zir.NullTerminatedString = @enumFromInt(self.code.extra[extra_index + 1]);
             try self.writeDocComment(stream, doc_comment_index);
             try stream.writeByteNTimes(' ', self.indent);
-            try stream.print("{},\n", .{std.zig.fmtId(name)});
+            try stream.print("{p},\n", .{std.zig.fmtId(name)});
         }
 
         self.indent -= 2;

--- a/tools/gen_spirv_spec.zig
+++ b/tools/gen_spirv_spec.zig
@@ -311,7 +311,7 @@ fn renderInstructionSet(
     );
 
     for (extensions) |ext| {
-        try writer.print("{},\n", .{std.zig.fmtId(ext.name)});
+        try writer.print("{p},\n", .{std.zig.fmtId(ext.name)});
     }
 
     try writer.writeAll(
@@ -344,7 +344,7 @@ fn renderInstructionsCase(
     // but there aren't so many total aliases and that would add more overhead in total. We will
     // just filter those out when needed.
 
-    try writer.print(".{} => &[_]Instruction{{\n", .{std.zig.fmtId(set_name)});
+    try writer.print(".{p_} => &[_]Instruction{{\n", .{std.zig.fmtId(set_name)});
 
     for (instructions) |inst| {
         try writer.print(
@@ -366,7 +366,7 @@ fn renderInstructionsCase(
 
             const kind = all_operand_kinds.get(.{ set_name, operand.kind }) orelse
                 all_operand_kinds.get(.{ "core", operand.kind }).?;
-            try writer.print(".{{.kind = .{}, .quantifier = .{s}}},\n", .{ std.zig.fmtId(kind.kind), quantifier });
+            try writer.print(".{{.kind = .{p_}, .quantifier = .{s}}},\n", .{ std.zig.fmtId(kind.kind), quantifier });
         }
 
         try writer.writeAll(
@@ -423,7 +423,7 @@ fn renderOperandKind(writer: anytype, operands: []const OperandKind) !void {
         \\
     );
     for (operands) |operand| {
-        try writer.print("{},\n", .{std.zig.fmtId(operand.kind)});
+        try writer.print("{p},\n", .{std.zig.fmtId(operand.kind)});
     }
     try writer.writeAll(
         \\
@@ -440,7 +440,7 @@ fn renderOperandKind(writer: anytype, operands: []const OperandKind) !void {
             .Literal => "literal",
             .Composite => "composite",
         };
-        try writer.print(".{} => .{s},\n", .{ std.zig.fmtId(operand.kind), cat });
+        try writer.print(".{p_} => .{s},\n", .{ std.zig.fmtId(operand.kind), cat });
     }
     try writer.writeAll(
         \\    };
@@ -454,12 +454,12 @@ fn renderOperandKind(writer: anytype, operands: []const OperandKind) !void {
         switch (operand.category) {
             .BitEnum, .ValueEnum => {},
             else => {
-                try writer.print(".{} => unreachable,\n", .{std.zig.fmtId(operand.kind)});
+                try writer.print(".{p_} => unreachable,\n", .{std.zig.fmtId(operand.kind)});
                 continue;
             },
         }
 
-        try writer.print(".{} => &[_]Enumerant{{", .{std.zig.fmtId(operand.kind)});
+        try writer.print(".{p_} => &[_]Enumerant{{", .{std.zig.fmtId(operand.kind)});
         for (operand.enumerants.?) |enumerant| {
             if (enumerant.value == .bitflag and std.mem.eql(u8, enumerant.enumerant, "None")) {
                 continue;
@@ -483,7 +483,7 @@ fn renderEnumerant(writer: anytype, enumerant: Enumerant) !void {
         if (i != 0)
             try writer.writeAll(", ");
         // Note, param.quantifier will always be one.
-        try writer.print(".{}", .{std.zig.fmtId(param.kind)});
+        try writer.print(".{p_}", .{std.zig.fmtId(param.kind)});
     }
     try writer.writeAll("}}");
 }
@@ -529,7 +529,7 @@ fn renderOpcodes(
     try writer.writeAll("pub const Opcode = enum(u16) {\n");
     for (instructions_indices) |i| {
         const inst = instructions[i];
-        try writer.print("{} = {},\n", .{ std.zig.fmtId(inst.opname), inst.opcode });
+        try writer.print("{p} = {},\n", .{ std.zig.fmtId(inst.opname), inst.opcode });
     }
 
     try writer.writeAll(
@@ -537,7 +537,7 @@ fn renderOpcodes(
     );
 
     for (aliases.items) |alias| {
-        try writer.print("pub const {} = Opcode.{};\n", .{
+        try writer.print("pub const {} = Opcode.{p_};\n", .{
             std.zig.fmtId(instructions[alias.inst].opname),
             std.zig.fmtId(instructions[alias.alias].opname),
         });
@@ -565,7 +565,7 @@ fn renderOpcodes(
 
     for (instructions_indices) |i| {
         const inst = instructions[i];
-        try writer.print(".{} => .", .{std.zig.fmtId(inst.opname)});
+        try writer.print(".{p_} => .", .{std.zig.fmtId(inst.opname)});
         try renderInstructionClass(writer, inst.class.?);
         try writer.writeAll(",\n");
     }
@@ -636,22 +636,22 @@ fn renderValueEnum(
 
     const enum_indices = enum_map.values();
 
-    try writer.print("pub const {s} = enum(u32) {{\n", .{std.zig.fmtId(enumeration.kind)});
+    try writer.print("pub const {} = enum(u32) {{\n", .{std.zig.fmtId(enumeration.kind)});
 
     for (enum_indices) |i| {
         const enumerant = enumerants[i];
         // if (enumerant.value != .int) return error.InvalidRegistry;
 
         switch (enumerant.value) {
-            .int => |value| try writer.print("{} = {},\n", .{ std.zig.fmtId(enumerant.enumerant), value }),
-            .bitflag => |value| try writer.print("{} = {s},\n", .{ std.zig.fmtId(enumerant.enumerant), value }),
+            .int => |value| try writer.print("{p} = {},\n", .{ std.zig.fmtId(enumerant.enumerant), value }),
+            .bitflag => |value| try writer.print("{p} = {s},\n", .{ std.zig.fmtId(enumerant.enumerant), value }),
         }
     }
 
     try writer.writeByte('\n');
 
     for (aliases.items) |alias| {
-        try writer.print("pub const {} = {}.{};\n", .{
+        try writer.print("pub const {} = {}.{p_};\n", .{
             std.zig.fmtId(enumerants[alias.enumerant].enumerant),
             std.zig.fmtId(enumeration.kind),
             std.zig.fmtId(enumerants[alias.alias].enumerant),
@@ -679,7 +679,7 @@ fn renderBitEnum(
     enumeration: OperandKind,
     extended_structs: ExtendedStructSet,
 ) !void {
-    try writer.print("pub const {s} = packed struct {{\n", .{std.zig.fmtId(enumeration.kind)});
+    try writer.print("pub const {} = packed struct {{\n", .{std.zig.fmtId(enumeration.kind)});
 
     var flags_by_bitpos = [_]?usize{null} ** 32;
     const enumerants = enumeration.enumerants orelse return error.InvalidRegistry;
@@ -719,7 +719,7 @@ fn renderBitEnum(
 
     for (flags_by_bitpos, 0..) |maybe_flag_index, bitpos| {
         if (maybe_flag_index) |flag_index| {
-            try writer.print("{}", .{std.zig.fmtId(enumerants[flag_index].enumerant)});
+            try writer.print("{p_}", .{std.zig.fmtId(enumerants[flag_index].enumerant)});
         } else {
             try writer.print("_reserved_bit_{}", .{bitpos});
         }
@@ -730,7 +730,7 @@ fn renderBitEnum(
     try writer.writeByte('\n');
 
     for (aliases.items) |alias| {
-        try writer.print("pub const {}: {} = .{{.{} = true}};\n", .{
+        try writer.print("pub const {}: {} = .{{.{p_} = true}};\n", .{
             std.zig.fmtId(enumerants[alias.flag].enumerant),
             std.zig.fmtId(enumeration.kind),
             std.zig.fmtId(enumerants[flags_by_bitpos[alias.alias].?].enumerant),
@@ -858,7 +858,7 @@ fn renderFieldName(writer: anytype, operands: []const Operand, field_index: usiz
         }
 
         // Assume there are no duplicate 'name' fields.
-        try writer.print("{}", .{std.zig.fmtId(name_buffer.items)});
+        try writer.print("{p_}", .{std.zig.fmtId(name_buffer.items)});
         return;
     }
 
@@ -876,7 +876,7 @@ fn renderFieldName(writer: anytype, operands: []const Operand, field_index: usiz
         }
     }
 
-    try writer.print("{}", .{std.zig.fmtId(name_buffer.items)});
+    try writer.print("{p_}", .{std.zig.fmtId(name_buffer.items)});
 
     // For fields derived from type name, there could be any amount.
     // Simply check against all other fields, and if another similar one exists, add a number.

--- a/tools/generate_linux_syscalls.zig
+++ b/tools/generate_linux_syscalls.zig
@@ -61,7 +61,7 @@ pub fn main() !void {
             _ = fields.next() orelse return error.Incomplete;
             const name = fields.next() orelse return error.Incomplete;
 
-            try writer.print("    {s} = {s},\n", .{ zig.fmtId(name), number });
+            try writer.print("    {p} = {s},\n", .{ zig.fmtId(name), number });
         }
 
         try writer.writeAll("};\n\n");
@@ -82,7 +82,7 @@ pub fn main() !void {
             const name = fields.next() orelse return error.Incomplete;
 
             const fixed_name = if (stdlib_renames.get(name)) |fixed| fixed else name;
-            try writer.print("    {s} = {s},\n", .{ zig.fmtId(fixed_name), number });
+            try writer.print("    {p} = {s},\n", .{ zig.fmtId(fixed_name), number });
         }
 
         try writer.writeAll("};\n\n");
@@ -107,7 +107,7 @@ pub fn main() !void {
             const name = fields.next() orelse return error.Incomplete;
 
             const fixed_name = if (stdlib_renames.get(name)) |fixed| fixed else name;
-            try writer.print("    {s} = {s},\n", .{ zig.fmtId(fixed_name), number });
+            try writer.print("    {p} = {s},\n", .{ zig.fmtId(fixed_name), number });
         }
 
         // TODO: maybe extract these from arch/arm/include/uapi/asm/unistd.h
@@ -137,7 +137,7 @@ pub fn main() !void {
             if (mem.eql(u8, abi, "32")) continue;
             const name = fields.next() orelse return error.Incomplete;
 
-            try writer.print("    {s} = {s},\n", .{ zig.fmtId(name), number });
+            try writer.print("    {p} = {s},\n", .{ zig.fmtId(name), number });
         }
 
         try writer.writeAll("};\n\n");
@@ -162,7 +162,7 @@ pub fn main() !void {
             const name = fields.next() orelse return error.Incomplete;
             if (mem.startsWith(u8, name, "unused")) continue;
 
-            try writer.print("    {s} = Linux + {s},\n", .{ zig.fmtId(name), number });
+            try writer.print("    {p} = Linux + {s},\n", .{ zig.fmtId(name), number });
         }
 
         try writer.writeAll("};\n\n");
@@ -187,7 +187,7 @@ pub fn main() !void {
             const name = fields.next() orelse return error.Incomplete;
             const fixed_name = if (stdlib_renames.get(name)) |fixed| fixed else name;
 
-            try writer.print("    {s} = Linux + {s},\n", .{ zig.fmtId(fixed_name), number });
+            try writer.print("    {p} = Linux + {s},\n", .{ zig.fmtId(fixed_name), number });
         }
 
         try writer.writeAll("};\n\n");
@@ -210,12 +210,12 @@ pub fn main() !void {
             if (mem.eql(u8, abi, "spu")) {
                 continue;
             } else if (mem.eql(u8, abi, "32")) {
-                try writer.print("    {s} = {s},\n", .{ zig.fmtId(fixed_name), number });
+                try writer.print("    {p} = {s},\n", .{ zig.fmtId(fixed_name), number });
             } else if (mem.eql(u8, abi, "64")) {
-                try list_64.writer().print("    {s} = {s},\n", .{ zig.fmtId(fixed_name), number });
+                try list_64.writer().print("    {p} = {s},\n", .{ zig.fmtId(fixed_name), number });
             } else { // common/nospu
-                try writer.print("    {s} = {s},\n", .{ zig.fmtId(fixed_name), number });
-                try list_64.writer().print("    {s} = {s},\n", .{ zig.fmtId(fixed_name), number });
+                try writer.print("    {p} = {s},\n", .{ zig.fmtId(fixed_name), number });
+                try list_64.writer().print("    {p} = {s},\n", .{ zig.fmtId(fixed_name), number });
             }
         }
 
@@ -291,7 +291,7 @@ pub fn main() !void {
             if (mem.eql(u8, name, "syscalls")) break :loop;
 
             const fixed_name = if (stdlib_renames.get(name)) |fixed| fixed else name;
-            try writer.print("    {s} = {s},\n", .{ zig.fmtId(fixed_name), number });
+            try writer.print("    {p} = {s},\n", .{ zig.fmtId(fixed_name), number });
         }
 
         try writer.writeAll("};\n\n");
@@ -352,7 +352,7 @@ pub fn main() !void {
             if (mem.eql(u8, name, "syscalls")) break :loop;
 
             const fixed_name = if (stdlib_renames.get(name)) |fixed| fixed else name;
-            try writer.print("    {s} = {s},\n", .{ zig.fmtId(fixed_name), number });
+            try writer.print("    {p} = {s},\n", .{ zig.fmtId(fixed_name), number });
         }
 
         try writer.writeAll(

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -1314,7 +1314,7 @@ fn processOneTarget(job: Job) anyerror!void {
     );
 
     for (all_features.items) |feature| {
-        try w.print("    {},\n", .{std.zig.fmtId(feature.zig_name)});
+        try w.print("    {p},\n", .{std.zig.fmtId(feature.zig_name)});
     }
 
     try w.writeAll(
@@ -1341,7 +1341,7 @@ fn processOneTarget(job: Job) anyerror!void {
     for (all_features.items) |feature| {
         if (feature.llvm_name) |llvm_name| {
             try w.print(
-                \\    result[@intFromEnum(Feature.{})] = .{{
+                \\    result[@intFromEnum(Feature.{p_})] = .{{
                 \\        .llvm_name = "{}",
                 \\        .description = "{}",
                 \\        .dependencies = featureSet(&[_]Feature{{
@@ -1354,7 +1354,7 @@ fn processOneTarget(job: Job) anyerror!void {
             );
         } else {
             try w.print(
-                \\    result[@intFromEnum(Feature.{})] = .{{
+                \\    result[@intFromEnum(Feature.{p_})] = .{{
                 \\        .llvm_name = null,
                 \\        .description = "{}",
                 \\        .dependencies = featureSet(&[_]Feature{{
@@ -1388,7 +1388,7 @@ fn processOneTarget(job: Job) anyerror!void {
         } else {
             try w.writeAll("\n");
             for (dependencies.items) |dep| {
-                try w.print("            .{},\n", .{std.zig.fmtId(dep)});
+                try w.print("            .{p_},\n", .{std.zig.fmtId(dep)});
             }
             try w.writeAll(
                 \\        }),
@@ -1454,7 +1454,7 @@ fn processOneTarget(job: Job) anyerror!void {
         } else {
             try w.writeAll("\n");
             for (cpu_features.items) |feature_zig_name| {
-                try w.print("            .{},\n", .{std.zig.fmtId(feature_zig_name)});
+                try w.print("            .{p_},\n", .{std.zig.fmtId(feature_zig_name)});
             }
             try w.writeAll(
                 \\        }),

--- a/tools/update_spirv_features.zig
+++ b/tools/update_spirv_features.zig
@@ -112,11 +112,11 @@ pub fn main() !void {
     }
 
     for (extensions) |ext| {
-        try w.print("    {},\n", .{std.zig.fmtId(ext)});
+        try w.print("    {p},\n", .{std.zig.fmtId(ext)});
     }
 
     for (capabilities) |cap| {
-        try w.print("    {},\n", .{std.zig.fmtId(cap.enumerant)});
+        try w.print("    {p},\n", .{std.zig.fmtId(cap.enumerant)});
     }
 
     try w.writeAll(
@@ -163,7 +163,7 @@ pub fn main() !void {
     // TODO: Extension dependencies.
     for (extensions) |ext| {
         try w.print(
-            \\    result[@intFromEnum(Feature.{s})] = .{{
+            \\    result[@intFromEnum(Feature.{p_})] = .{{
             \\        .llvm_name = null,
             \\        .description = "SPIR-V extension {s}",
             \\        .dependencies = featureSet(&[_]Feature{{}}),
@@ -178,7 +178,7 @@ pub fn main() !void {
     // TODO: Capability extension dependencies.
     for (capabilities) |cap| {
         try w.print(
-            \\    result[@intFromEnum(Feature.{s})] = .{{
+            \\    result[@intFromEnum(Feature.{p_})] = .{{
             \\        .llvm_name = null,
             \\        .description = "Enable SPIR-V capability {s}",
             \\        .dependencies = featureSet(&[_]Feature{{
@@ -196,7 +196,7 @@ pub fn main() !void {
         }
 
         for (cap.capabilities) |cap_dep| {
-            try w.print("            .{},\n", .{std.zig.fmtId(cap_dep)});
+            try w.print("            .{p_},\n", .{std.zig.fmtId(cap_dep)});
         }
 
         try w.writeAll(


### PR DESCRIPTION
This updates `std.zig.fmtId` to support conditionally `@""` escaping primitives and the reserved `_` identifier via format specifiers:

- `{}`: escape invalid identifiers, identifiers that shadow primitives and the reserved `_` identifier.
- `{p}`: same as `{}`, but don't escape identifiers that shadow primitives.
- `{_}`: same as `{}`, but don't escape the reserved `_` identifier.
- `{p_}` or `{_p}`: only escape invalid identifiers.

In other words, the default empty `{}` specifier is as conservative as possible and you add `p` and/or `_` to add primitives/`_` to the set of identifiers that can be rendered unescaped.

Any other format specifier is a compile error.

## Motivation

Correctly formatted and escaped code generation. Status quo `fmtId` is problematic because it doesn't escape primitives, which means programs that generate Zig code currently need to implement their own formatters that also check `std.zig.primitives.isPrimitive` for rendering declaration identifiers.

## Breaking changes and mitigations

- `print("{}", .{std.zig.fmtId(foo)})` did not `@""` escape primitives before, but now does. Use `{p}` for the old behavior.
- `print("{s}", .{std.zig.fmtId(foo)})` (or any other unrecognized specifier) is now a compile error. Again, use `{p}` for the old behavior.
- `isValidId` now considers `_` to be a valid identifier (which it is, in certain contexts). If this distinction is important, consider combining existing uses of this function with the new `isUnderscore` function; `std.zig.isValidId(foo)` should be replaced with `std.zig.isValidId(foo) and !std.zig.isUnderscore(foo)`.

## Additional considerations

`fmtId` can currently render illegal identifiers like `@""` and `@"\x00"`. It could be updated to return an error for these cases, but I would suggest accepting #14534 instead since it would ease the burden of code generators and mean that every possible identifier can be represented in Zig in some form, either escaped or unescaped.