### PR TITLE
Sema: support coercing ref to anonymous array init to many-pointer

### DIFF
--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -804,6 +804,52 @@ test "slice initialized through reference to anonymous array init provides resul
     try std.testing.expectEqualSlices(u16, &.{ 123, 456, 123, 456 }, foo);
 }
 
+test "sentinel-terminated slice initialized through reference to anonymous array init provides result types" {
+    var my_u32: u32 = 123;
+    var my_u64: u64 = 456;
+    _ = .{ &my_u32, &my_u64 };
+    const foo: [:999]const u16 = &.{
+        @intCast(my_u32),
+        @intCast(my_u64),
+        @truncate(my_u32),
+        @truncate(my_u64),
+    };
+    try std.testing.expectEqualSentinel(u16, 999, &.{ 123, 456, 123, 456 }, foo);
+}
+
+test "many-item pointer initialized through reference to anonymous array init provides result types" {
+    var my_u32: u32 = 123;
+    var my_u64: u64 = 456;
+    _ = .{ &my_u32, &my_u64 };
+    const foo: [*]const u16 = &.{
+        @intCast(my_u32),
+        @intCast(my_u64),
+        @truncate(my_u32),
+        @truncate(my_u64),
+    };
+    try expectEqual(123, foo[0]);
+    try expectEqual(456, foo[1]);
+    try expectEqual(123, foo[2]);
+    try expectEqual(456, foo[3]);
+}
+
+test "many-item sentinel-terminated pointer initialized through reference to anonymous array init provides result types" {
+    var my_u32: u32 = 123;
+    var my_u64: u64 = 456;
+    _ = .{ &my_u32, &my_u64 };
+    const foo: [*:999]const u16 = &.{
+        @intCast(my_u32),
+        @intCast(my_u64),
+        @truncate(my_u32),
+        @truncate(my_u64),
+    };
+    try expectEqual(123, foo[0]);
+    try expectEqual(456, foo[1]);
+    try expectEqual(123, foo[2]);
+    try expectEqual(456, foo[3]);
+    try expectEqual(999, foo[4]);
+}
+
 test "pointer to array initialized through reference to anonymous array init provides result types" {
     var my_u32: u32 = 123;
     var my_u64: u64 = 456;
@@ -815,6 +861,19 @@ test "pointer to array initialized through reference to anonymous array init pro
         @truncate(my_u64),
     };
     try std.testing.expectEqualSlices(u16, &.{ 123, 456, 123, 456 }, foo);
+}
+
+test "pointer to sentinel-terminated array initialized through reference to anonymous array init provides result types" {
+    var my_u32: u32 = 123;
+    var my_u64: u64 = 456;
+    _ = .{ &my_u32, &my_u64 };
+    const foo: *const [4:999]u16 = &.{
+        @intCast(my_u32),
+        @intCast(my_u64),
+        @truncate(my_u32),
+        @truncate(my_u64),
+    };
+    try std.testing.expectEqualSentinel(u16, 999, &.{ 123, 456, 123, 456 }, foo);
 }
 
 test "tuple initialized through reference to anonymous array init provides result types" {


### PR DESCRIPTION
Fixes #18924

Makes `&.{ a, b, c }` coerce to `[*]const T`/`[*:x]const T`:

```zig
const std = @import("std");
const expectEqual = std.testing.expectEqual;

const Foo = struct { bar: [*]const i32 };

test "ref to anon array init coerced to many-ptr" {
    const foo: Foo = .{ .bar = &.{ 1, -2 } };
    try expectEqual(1, foo.bar[0]);
    try expectEqual(-2, foo.bar[1]);
}

fn checkSentinelManyPtr(values: [*:0]const i32) !void {
    try expectEqual(3, values[0]);
    try expectEqual(-4, values[1]);
    try expectEqual(0, values[2]);
}

test "ref to anon array init coerced to sentinel many-ptr" {
    try checkSentinelManyPtr(&.{ 3, -4 });
}
```