### PR TITLE
std.os.windows.OpenFile: add missing error

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -668,13 +668,14 @@ pub const ChildProcess = struct {
                 .sa = &saAttr,
                 .creation = windows.OPEN_EXISTING,
             }) catch |err| switch (err) {
-                error.PathAlreadyExists => unreachable, // not possible for "NUL"
-                error.PipeBusy => unreachable, // not possible for "NUL"
-                error.FileNotFound => unreachable, // not possible for "NUL"
-                error.AccessDenied => unreachable, // not possible for "NUL"
-                error.NameTooLong => unreachable, // not possible for "NUL"
-                error.WouldBlock => unreachable, // not possible for "NUL"
-                error.NetworkNotFound => unreachable, // not possible for "NUL"
+                error.PathAlreadyExists => return error.Unexpected, // not possible for "NUL"
+                error.PipeBusy => return error.Unexpected, // not possible for "NUL"
+                error.FileNotFound => return error.Unexpected, // not possible for "NUL"
+                error.AccessDenied => return error.Unexpected, // not possible for "NUL"
+                error.NameTooLong => return error.Unexpected, // not possible for "NUL"
+                error.WouldBlock => return error.Unexpected, // not possible for "NUL"
+                error.NetworkNotFound => return error.Unexpected, // not possible for "NUL"
+                error.AntivirusInterference => return error.Unexpected, // not possible for "NUL"
                 else => |e| return e,
             }
         else

--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -48,6 +48,12 @@ pub const OpenError = error{
     Unexpected,
     /// On Windows, `\\server` or `\\server\share` was not found.
     NetworkNotFound,
+    /// On Windows, antivirus software is enabled by default. It can be
+    /// disabled, but Windows Update sometimes ignores the user's preference
+    /// and re-enables it. When enabled, antivirus software on Windows
+    /// intercepts file system operations and makes them significantly slower
+    /// in addition to possibly failing with this error code.
+    AntivirusInterference,
 } || posix.OpenError || posix.FlockError;
 
 pub const OpenMode = enum {

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -766,6 +766,7 @@ fn glibcVerFromRPath(rpath: []const u8) !std.SemanticVersion {
         error.PipeBusy => unreachable, // Windows-only
         error.SharingViolation => unreachable, // Windows-only
         error.NetworkNotFound => unreachable, // Windows-only
+        error.AntivirusInterference => unreachable, // Windows-only
         error.FileLocksNotSupported => unreachable, // No lock requested.
         error.NoSpaceLeft => unreachable, // read-only
         error.PathAlreadyExists => unreachable, // read-only
@@ -1003,6 +1004,7 @@ fn detectAbiAndDynamicLinker(
                 error.FileLocksNotSupported => unreachable,
                 error.WouldBlock => unreachable,
                 error.FileBusy => unreachable, // opened without write permissions
+                error.AntivirusInterference => unreachable, // Windows-only error
 
                 error.IsDir,
                 error.NotDir,


### PR DESCRIPTION
Encountered in a recent CI run on an aarch64-windows dev kit.

Pretty sure I disabled the virus scanner but it looks like it turned itself back on with a Windows Update.