### PR TITLE
std.os: export T struct and winsize struct

### DIFF
--- a/lib/std/c/linux.zig
+++ b/lib/std/c/linux.zig
@@ -48,6 +48,7 @@ pub const STDIN_FILENO = linux.STDIN_FILENO;
 pub const STDOUT_FILENO = linux.STDOUT_FILENO;
 pub const SYS = linux.SYS;
 pub const Sigaction = linux.Sigaction;
+pub const T = linux.T;
 pub const TCP = linux.TCP;
 pub const TCSA = linux.TCSA;
 pub const VDSO = linux.VDSO;
@@ -93,6 +94,7 @@ pub const ucontext_t = linux.ucontext_t;
 pub const uid_t = linux.uid_t;
 pub const user_desc = linux.user_desc;
 pub const utsname = linux.utsname;
+pub const winsize = linux.winsize;
 pub const PR = linux.PR;
 
 pub const _errno = switch (native_abi) {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -132,6 +132,7 @@ pub const STDOUT_FILENO = system.STDOUT_FILENO;
 pub const SYS = system.SYS;
 pub const Sigaction = system.Sigaction;
 pub const Stat = system.Stat;
+pub const T = system.T;
 pub const TCSA = system.TCSA;
 pub const TCP = system.TCP;
 pub const VDSO = system.VDSO;
@@ -181,6 +182,7 @@ pub const ucontext_t = system.ucontext_t;
 pub const uid_t = system.uid_t;
 pub const user_desc = system.user_desc;
 pub const utsname = system.utsname;
+pub const winsize = system.winsize;
 
 pub const termios = system.termios;
 pub const CSIZE = system.CSIZE;


### PR DESCRIPTION
Export the T struct and winsize struct for targets which have it defined
in std.c. The T struct defines libc constants for ioctl syscalls.

Exporting these as part of `os.zig` allows callers to access these fields in a portable way, preventing the need to call into each std.c implementation to get the constants or winsize struct definition.
