### PR TITLE
Sema: fix tuple default values

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -3043,8 +3043,8 @@ pub const Type = struct {
         const ip = &mod.intern_pool;
         switch (ip.indexToKey(ty.toIntern())) {
             .struct_type => |struct_type| {
-                assert(struct_type.haveFieldInits(ip));
                 if (struct_type.fieldIsComptime(ip, index)) {
+                    assert(struct_type.haveFieldInits(ip));
                     return Value.fromInterned(struct_type.field_inits.get(ip)[index]);
                 } else {
                     return Type.fromInterned(struct_type.field_types.get(ip)[index]).onePossibleValue(mod);

--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -560,3 +560,17 @@ test "comptime fields in tuple can be initialized" {
     var a: T = .{ 0, 0 };
     _ = &a;
 }
+
+test "tuple default values" {
+    const T = struct {
+        usize,
+        usize = 123,
+        usize = 456,
+    };
+
+    const t: T = .{1};
+
+    try expectEqual(1, t[0]);
+    try expectEqual(123, t[1]);
+    try expectEqual(456, t[2]);
+}


### PR DESCRIPTION
- Add default values to the list of comptime-known elements in `zirValidatePtrArrayInit`
- In `structFieldValueComptime`, only assert `haveFieldInits` if we enter the`fieldIsComptime` branch (otherwise they are not needed).

Closes https://github.com/ziglang/zig/issues/17349.