### PR TITLE
std.Build.Step: make result returning correctly with evalZigProcess

### DIFF
--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -417,7 +417,8 @@ pub fn evalZigProcess(
             // Note that the exit code may be 0 in this case due to the
             // compiler server protocol.
             if (compile.expect_errors != null) {
-                return error.NeedCompileErrorCheck;
+                try compile.checkCompileErrors();
+                return result;
             }
         },
         else => {},

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1647,14 +1647,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         try zig_args.append(resolved_args_file);
     }
 
-    const maybe_output_bin_path = step.evalZigProcess(zig_args.items, prog_node) catch |err| switch (err) {
-        error.NeedCompileErrorCheck => {
-            assert(self.expect_errors != null);
-            try checkCompileErrors(self);
-            return;
-        },
-        else => |e| return e,
-    };
+    const maybe_output_bin_path = try step.evalZigProcess(zig_args.items, prog_node);
 
     // Update generated files
     if (maybe_output_bin_path) |output_bin_path| {
@@ -1793,7 +1786,7 @@ fn addFlag(args: *ArrayList([]const u8), comptime name: []const u8, opt: ?bool) 
     }
 }
 
-fn checkCompileErrors(self: *Compile) !void {
+pub fn checkCompileErrors(self: *Compile) !void {
     // Clear this field so that it does not get printed by the build runner.
     const actual_eb = self.step.result_error_bundle;
     self.step.result_error_bundle = std.zig.ErrorBundle.empty;


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/18941 by moving the `checkCompileErrors` call from `Build.Step.Compile` to `Build.Step` and returning result if the errors match as expected.