### PR TITLE
child_process: deinit fifo memory before replacing

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -277,6 +277,7 @@ pub const ChildProcess = struct {
             .capacity = fifo.buf.len,
             .allocator = fifo.allocator,
         };
+        fifo.deinit();
         fifo.* = std.io.PollFifo.init(fifo.allocator);
         return result;
     }


### PR DESCRIPTION
`collectOutput`'s `fifoToOwnedArrayList` replaces an existing FIFO with a new one, but these are dynamic FIFO's which own their own memory so they must be `deinit`'d first.

Fixes a leak visible here:
```
const std = @import("std");

pub fn main() !void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    defer switch (gpa.deinit()) {
        .ok => {},
        .leak => @panic("memory leak"),
    };
    const allocator = gpa.allocator();

    const max_bytes = 1024;

    var child = std.ChildProcess.init(&[_][]const u8{ "echo", "foo" }, allocator);
    child.stdin_behavior = .Ignore;
    child.stdout_behavior = .Pipe;
    child.stderr_behavior = .Pipe;

    try child.spawn();

    var stdout = std.ArrayList(u8).init(allocator);
    var stderr = std.ArrayList(u8).init(allocator);

    try child.collectOutput(&stdout, &stderr, max_bytes);

    const term_result = try child.wait();
    _ = term_result;
}
```