### PR TITLE
std.os.termios: fix tc flag types for macos

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -842,7 +842,7 @@ pub const termios = switch (native_os) {
 
 pub const tc_iflag_t = switch (native_os) {
     .linux => std.os.linux.tc_iflag_t,
-    .macos, .ios, .tvos, .watchos => packed struct(u32) {
+    .macos, .ios, .tvos, .watchos => packed struct(u64) {
         IGNBRK: bool = false,
         BRKINT: bool = false,
         IGNPAR: bool = false,
@@ -858,7 +858,7 @@ pub const tc_iflag_t = switch (native_os) {
         _12: u1 = 0,
         IMAXBEL: bool = false,
         IUTF8: bool = false,
-        _: u17 = 0,
+        _: u49 = 0,
     },
     .netbsd, .freebsd, .kfreebsd, .dragonfly => packed struct(u32) {
         IGNBRK: bool = false,
@@ -952,7 +952,7 @@ pub const tc_iflag_t = switch (native_os) {
 
 pub const tc_oflag_t = switch (native_os) {
     .linux => std.os.linux.tc_oflag_t,
-    .macos, .ios, .tvos, .watchos => packed struct(u32) {
+    .macos, .ios, .tvos, .watchos => packed struct(u64) {
         OPOST: bool = false,
         ONLCR: bool = false,
         OXTABS: bool = false,
@@ -968,7 +968,7 @@ pub const tc_oflag_t = switch (native_os) {
         BSDLY: u1 = 0,
         VTDLY: u1 = 0,
         OFDEL: bool = false,
-        _: u14 = 0,
+        _: u46 = 0,
     },
     .netbsd => packed struct(u32) {
         OPOST: bool = false,
@@ -1049,7 +1049,7 @@ pub const CSIZE = switch (native_os) {
 
 pub const tc_cflag_t = switch (native_os) {
     .linux => std.os.linux.tc_cflag_t,
-    .macos, .ios, .tvos, .watchos => packed struct(u32) {
+    .macos, .ios, .tvos, .watchos => packed struct(u64) {
         CIGNORE: bool = false,
         _1: u5 = 0,
         CSTOPB: bool = false,
@@ -1066,7 +1066,7 @@ pub const tc_cflag_t = switch (native_os) {
         CDTR_IFLOW: bool = false,
         CDSR_OFLOW: bool = false,
         CCAR_OFLOW: bool = false,
-        _: u11 = 0,
+        _: u43 = 0,
     },
     .freebsd, .kfreebsd => packed struct(u32) {
         CIGNORE: bool = false,
@@ -1185,7 +1185,31 @@ pub const tc_cflag_t = switch (native_os) {
 
 pub const tc_lflag_t = switch (native_os) {
     .linux => std.os.linux.tc_lflag_t,
-    .macos, .ios, .tvos, .watchos, .netbsd, .freebsd, .kfreebsd, .dragonfly => packed struct(u32) {
+    .macos, .ios, .tvos, .watchos => packed struct(u64) {
+        ECHOKE: bool = false,
+        ECHOE: bool = false,
+        ECHOK: bool = false,
+        ECHO: bool = false,
+        ECHONL: bool = false,
+        ECHOPRT: bool = false,
+        ECHOCTL: bool = false,
+        ISIG: bool = false,
+        ICANON: bool = false,
+        ALTWERASE: bool = false,
+        IEXTEN: bool = false,
+        EXTPROC: bool = false,
+        _12: u10 = 0,
+        TOSTOP: bool = false,
+        FLUSHO: bool = false,
+        _24: u1 = 0,
+        NOKERNINFO: bool = false,
+        _26: u3 = 0,
+        PENDIN: bool = false,
+        _30: u1 = 0,
+        NOFLSH: bool = false,
+        _: u32 = 0,
+    },
+    .netbsd, .freebsd, .kfreebsd, .dragonfly => packed struct(u32) {
         ECHOKE: bool = false,
         ECHOE: bool = false,
         ECHOK: bool = false,

--- a/lib/std/c/dragonfly.zig
+++ b/lib/std/c/dragonfly.zig
@@ -557,6 +557,13 @@ pub const NOTE_FFCTRLMASK = 3221225472;
 pub const NOTE_FFCOPY = 3221225472;
 pub const NOTE_PCTRLMASK = 4026531840;
 
+pub const TCSA = enum(c_uint) {
+    NOW,
+    DRAIN,
+    FLUSH,
+    _,
+};
+
 pub const stack_t = extern struct {
     sp: [*]u8,
     size: isize,

--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -1153,6 +1153,13 @@ pub const T = struct {
     pub const IOCSIG = 0x2004745f;
 };
 
+pub const TCSA = enum(c_uint) {
+    NOW,
+    DRAIN,
+    FLUSH,
+    _,
+};
+
 pub const winsize = extern struct {
     ws_row: u16,
     ws_col: u16,

--- a/lib/std/c/netbsd.zig
+++ b/lib/std/c/netbsd.zig
@@ -806,12 +806,11 @@ pub const T = struct {
     pub const IOCXMTFRAME = 0x80087444;
 };
 
-// Commands passed to tcsetattr() for setting the termios structure.
-pub const TCSA = struct {
-    pub const NOW = 0; // make change immediate
-    pub const DRAIN = 1; // drain output, then chage
-    pub const FLUSH = 2; // drain output, flush input
-    pub const SOFT = 0x10; // flag - don't alter h.w. state
+pub const TCSA = enum(c_uint) {
+    NOW,
+    DRAIN,
+    FLUSH,
+    _,
 };
 
 pub const TCIFLUSH = 1;

--- a/lib/std/c/openbsd.zig
+++ b/lib/std/c/openbsd.zig
@@ -768,12 +768,11 @@ pub const AUTH = struct {
     pub const ALLOW: c_int = (OKAY | ROOTOKAY | SECURE);
 };
 
-// Commands passed to tcsetattr() for setting the termios structure.
-pub const TCSA = struct {
-    pub const NOW = 0; // make change immediate
-    pub const DRAIN = 1; // drain output, then change
-    pub const FLUSH = 2; // drain output, flush input
-    pub const SOFT = 0x10; // flag - don't alter h.w. state
+pub const TCSA = enum(c_uint) {
+    NOW,
+    DRAIN,
+    FLUSH,
+    _,
 };
 
 pub const TCIFLUSH = 1;


### PR DESCRIPTION
- macos uses 64-bits for the flag types.
- also add/fix `std.c.TCSA` for the BSDs
- code example in #18942 now works for macos and BSDs

closes https://github.com/ziglang/zig/issues/18942
