### PR TITLE
InternPool: make more use of `NullTerminatedString.Slice`

### DIFF
--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -119,6 +119,7 @@ pub fn generateLazySymbol(
 
     const comp = bin_file.comp;
     const zcu = comp.module.?;
+    const ip = &zcu.intern_pool;
     const target = comp.root_mod.resolved_target.result;
     const endian = target.cpu.arch.endian();
     const gpa = comp.gpa;
@@ -151,8 +152,9 @@ pub fn generateLazySymbol(
         return Result.ok;
     } else if (lazy_sym.ty.zigTypeTag(zcu) == .Enum) {
         alignment.* = .@"1";
-        for (lazy_sym.ty.enumFields(zcu)) |tag_name_ip| {
-            const tag_name = zcu.intern_pool.stringToSlice(tag_name_ip);
+        const tag_names = lazy_sym.ty.enumFields(zcu);
+        for (0..tag_names.len) |tag_index| {
+            const tag_name = zcu.intern_pool.stringToSlice(tag_names.get(ip)[tag_index]);
             try code.ensureUnusedCapacity(tag_name.len + 1);
             code.appendSliceAssumeCapacity(tag_name);
             code.appendAssumeCapacity(0);

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9574,6 +9574,7 @@ pub const FuncGen = struct {
     fn airErrorSetHasValue(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.dg.object;
         const mod = o.module;
+        const ip = &mod.intern_pool;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
         const error_set_ty = ty_op.ty.toType();
@@ -9585,8 +9586,8 @@ pub const FuncGen = struct {
         var wip_switch = try self.wip.@"switch"(operand, invalid_block, @intCast(names.len));
         defer wip_switch.finish(&self.wip);
 
-        for (names) |name| {
-            const err_int = mod.global_error_set.getIndex(name).?;
+        for (0..names.len) |name_index| {
+            const err_int = mod.global_error_set.getIndex(names.get(ip)[name_index]).?;
             const this_tag_int_value = try o.builder.intConst(try o.errorIntType(), err_int);
             try wip_switch.addCase(this_tag_int_value, valid_block, &self.wip);
         }

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -2828,7 +2828,7 @@ fn addDbgInfoErrorSet(
     target: std.Target,
     dbg_info_buffer: *std.ArrayList(u8),
 ) !void {
-    return addDbgInfoErrorSetNames(mod, ty, ty.errorSetNames(mod), target, dbg_info_buffer);
+    return addDbgInfoErrorSetNames(mod, ty, ty.errorSetNames(mod).get(&mod.intern_pool), target, dbg_info_buffer);
 }
 
 fn addDbgInfoErrorSetNames(

--- a/src/type.zig
+++ b/src/type.zig
@@ -2908,22 +2908,21 @@ pub const Type = struct {
 
     // Asserts that `ty` is an error set and not `anyerror`.
     // Asserts that `ty` is resolved if it is an inferred error set.
-    pub fn errorSetNames(ty: Type, mod: *Module) []const InternPool.NullTerminatedString {
+    pub fn errorSetNames(ty: Type, mod: *Module) InternPool.NullTerminatedString.Slice {
         const ip = &mod.intern_pool;
         return switch (ip.indexToKey(ty.toIntern())) {
-            .error_set_type => |x| x.names.get(ip),
+            .error_set_type => |x| x.names,
             .inferred_error_set_type => |i| switch (ip.funcIesResolved(i).*) {
                 .none => unreachable, // unresolved inferred error set
                 .anyerror_type => unreachable,
-                else => |t| ip.indexToKey(t).error_set_type.names.get(ip),
+                else => |t| ip.indexToKey(t).error_set_type.names,
             },
             else => unreachable,
         };
     }
 
-    pub fn enumFields(ty: Type, mod: *Module) []const InternPool.NullTerminatedString {
-        const ip = &mod.intern_pool;
-        return ip.indexToKey(ty.toIntern()).enum_type.names.get(ip);
+    pub fn enumFields(ty: Type, mod: *Module) InternPool.NullTerminatedString.Slice {
+        return mod.intern_pool.indexToKey(ty.toIntern()).enum_type.names;
     }
 
     pub fn enumFieldCount(ty: Type, mod: *Module) usize {

--- a/test/cbe.zig
+++ b/test/cbe.zig
@@ -219,23 +219,22 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
         , "");
     }
 
-    // https://github.com/ziglang/zig/issues/18954
-    //{
-    //    var case = ctx.exeFromCompiledC("inferred local const and var", .{}, b);
+    {
+        var case = ctx.exeFromCompiledC("inferred local const and var", .{}, b);
 
-    //    case.addCompareOutput(
-    //        \\fn add(a: i32, b: i32) i32 {
-    //        \\    return a + b;
-    //        \\}
-    //        \\
-    //        \\pub export fn main() c_int {
-    //        \\    const x = add(1, 2);
-    //        \\    var y = add(3, 0);
-    //        \\    y -= x;
-    //        \\    return y;
-    //        \\}
-    //    , "");
-    //}
+        case.addCompareOutput(
+            \\fn add(a: i32, b: i32) i32 {
+            \\    return a + b;
+            \\}
+            \\
+            \\pub export fn main() c_int {
+            \\    const x = add(1, 2);
+            \\    var y = add(3, 0);
+            \\    y -= x;
+            \\    return y;
+            \\}
+        , "");
+    }
     {
         var case = ctx.exeFromCompiledC("control flow", .{}, b);
 


### PR DESCRIPTION
This should avoid the random pointer invalidation crashes.

Closes #18954