### PR TITLE
cbe: do not set execute bits on emitted file

### DIFF
--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -114,7 +114,6 @@ pub fn createEmpty(
     const use_lld = build_options.have_llvm and comp.config.use_lld;
     const use_llvm = comp.config.use_llvm;
     const output_mode = comp.config.output_mode;
-    const link_mode = comp.config.link_mode;
 
     // These are caught by `Compilation.Config.resolve`.
     assert(!use_lld);
@@ -123,7 +122,6 @@ pub fn createEmpty(
     const file = try emit.directory.handle.createFile(emit.sub_path, .{
         // Truncation is done on `flush`.
         .truncate = false,
-        .mode = link.File.determineMode(use_lld, output_mode, link_mode),
     });
     errdefer file.close();
 


### PR DESCRIPTION
Previously, `zig build-exe foo.zig -ofmt=c` emits `foo.c` with `755` mode. This PR lets `createFile()` use default `.mode` and `foo.c` is emitted with `644` mode (assuming typical umask of 022).

Closes #13407