### PR TITLE
skip `standalone/empty_env` test in ConEmu terminal sessions

### DIFF
--- a/test/standalone/empty_env/build.zig
+++ b/test/standalone/empty_env/build.zig
@@ -7,8 +7,10 @@ pub fn build(b: *std.Build) void {
 
     const optimize: std.builtin.OptimizeMode = .Debug;
 
-    if (builtin.os.tag == .windows and builtin.cpu.arch == .aarch64) {
-        // https://github.com/ziglang/zig/issues/13685
+    if (builtin.os.tag == .windows and std.process.hasEnvVarConstant("ConEmuHWND")) {
+        // ConEmu injects environment variables into processes before they are executed
+        // depending on user settings. This obviously invalidates the test, so skipping
+        // it is the best option.
         return;
     }
 

--- a/test/standalone/empty_env/build.zig
+++ b/test/standalone/empty_env/build.zig
@@ -7,14 +7,15 @@ pub fn build(b: *std.Build) void {
 
     const optimize: std.builtin.OptimizeMode = .Debug;
 
-    if (builtin.os.tag == .windows and
-        // https://github.com/ziglang/zig/issues/13685
-        (builtin.cpu.arch == .aarch64 or
+    if (builtin.os.tag == .windows and std.process.hasEnvVarConstant("ConEmuHWND")) {
         // ConEmu injects environment variables into processes before they are executed
         // depending on user settings. This obviously invalidates the test, so skipping
         // it is the best option.
-        std.process.hasEnvVarConstant("ConEmuHWND")))
-    {
+        return;
+    }
+
+    if (builtin.os.tag == .windows and builtin.cpu.arch == .aarch64) {
+        // https://github.com/ziglang/zig/issues/13685
         return;
     }
 

--- a/test/standalone/empty_env/build.zig
+++ b/test/standalone/empty_env/build.zig
@@ -7,10 +7,14 @@ pub fn build(b: *std.Build) void {
 
     const optimize: std.builtin.OptimizeMode = .Debug;
 
-    if (builtin.os.tag == .windows and std.process.hasEnvVarConstant("ConEmuHWND")) {
+    if (builtin.os.tag == .windows and
+        // https://github.com/ziglang/zig/issues/13685
+        (builtin.cpu.arch == .aarch64 or
         // ConEmu injects environment variables into processes before they are executed
         // depending on user settings. This obviously invalidates the test, so skipping
         // it is the best option.
+        std.process.hasEnvVarConstant("ConEmuHWND")))
+    {
         return;
     }
 


### PR DESCRIPTION
Closes #3168

The problem seems to be ConEmu setting environment variables before executing the test process (the test passes when run in Windows CMD). These variables can differ depending on user configuration too. This PR skips the test if the host environment has the [`ConEmuHWND`](https://conemu.github.io/en/ConEmuEnvironment.html) variable set; i.e. we're running inside a ConEmu terminal session.