### PR TITLE
Sema: evaluate generic instantiations in fn decls capture scope

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7960,7 +7960,7 @@ fn instantiateGenericCall(
         .sema = &child_sema,
         .src_decl = generic_owner_func.owner_decl,
         .namespace = namespace_index,
-        .wip_capture_scope = try mod.createCaptureScope(sema.owner_decl.src_scope),
+        .wip_capture_scope = try mod.createCaptureScope(fn_owner_decl.src_scope),
         .instructions = .{},
         .inlining = null,
         .is_comptime = true,

--- a/test/behavior/generics.zig
+++ b/test/behavior/generics.zig
@@ -558,3 +558,19 @@ test "call generic function with from function called by the generic function" {
 
     ArgSerializer.serializeCommand(GET{ .key = "banana" });
 }
+
+fn StructCapture(comptime T: type) type {
+    return struct {
+        pub fn foo(comptime x: usize) struct { T } {
+            return .{x};
+        }
+    };
+}
+
+test "call generic function that uses capture from function declaration's scope" {
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
+
+    const S = StructCapture(f64);
+    const s = S.foo(123);
+    try expectEqual(123.0, s[0]);
+}


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/17086.
Closes https://github.com/ziglang/zig/issues/18433.
Closes https://github.com/ziglang/zig/issues/19015.

The problem in these issues can be reduced to:

```zig
pub fn Struct(comptime T: type) type {
    return struct {
        pub fn foo(comptime x: usize) struct { T } {
            _ = x;
            unreachable;
        }
    };
}


test "foo" {
    const S = Struct(f64);
    _ = S.foo(1);
}
```

The generic call `S.foo()` was evaluated with the capture scope of the owner decl (i.e the `test` block), when it needs to use the capture scope of the function declaration.