### PR TITLE
std.Build: add `lazyImport` (`@import` for lazy dependencies)

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -1,4 +1,3 @@
-const root = @import("@build");
 const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
@@ -10,6 +9,7 @@ const ArrayList = std.ArrayList;
 const File = std.fs.File;
 const Step = std.Build.Step;
 
+pub const root = @import("@build");
 pub const dependencies = @import("@dependencies");
 
 pub fn main() !void {

--- a/lib/std/math/nextafter.zig
+++ b/lib/std/math/nextafter.zig
@@ -144,7 +144,7 @@ test "int" {
 }
 
 test "float" {
-    @setEvalBranchQuota(2000);
+    @setEvalBranchQuota(3000);
 
     // normal -> normal
     try expect(nextAfter(f16, 0x1.234p0, 2.0) == 0x1.238p0);

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7525,10 +7525,12 @@ fn analyzeCall(
 
     var is_generic_call = func_ty_info.is_generic;
     var is_comptime_call = block.is_comptime or modifier == .compile_time;
+    var is_inline_call = is_comptime_call or modifier == .always_inline or func_ty_info.cc == .Inline;
     var comptime_reason: ?*const Block.ComptimeReason = null;
-    if (!is_comptime_call) {
+    if (!is_inline_call and !is_comptime_call) {
         if (sema.typeRequiresComptime(Type.fromInterned(func_ty_info.return_type))) |ct| {
             is_comptime_call = ct;
+            is_inline_call = ct;
             if (ct) {
                 comptime_reason = &.{ .comptime_ret_ty = .{
                     .block = block,
@@ -7542,8 +7544,6 @@ fn analyzeCall(
             else => |e| return e,
         }
     }
-    var is_inline_call = is_comptime_call or modifier == .always_inline or
-        func_ty_info.cc == .Inline;
 
     if (sema.func_is_naked and !is_inline_call and !is_comptime_call) {
         const msg = msg: {

--- a/test/behavior/fn.zig
+++ b/test/behavior/fn.zig
@@ -604,3 +604,17 @@ test "comptime parameters don't have to be marked comptime if only called at com
     };
     comptime std.debug.assert(S.foo(5, 6) == 11);
 }
+
+test "inline function with comptime-known comptime-only return type called at runtime" {
+    const S = struct {
+        inline fn foo(x: *i32, y: *const i32) type {
+            x.* = y.*;
+            return f32;
+        }
+    };
+    var a: i32 = 0;
+    const b: i32 = 111;
+    const T = S.foo(&a, &b);
+    try expectEqual(111, a);
+    try expectEqual(f32, T);
+}


### PR DESCRIPTION
Closes #18987
Follow-up to #18778 (which added lazy dependencies) and the discussion in #18808 that followed

This adds `b.lazyImport`, which (in the context of a build script) is to `@import` what `b.lazyDependency` is to `b.dependency` and can be used to import a lazy dependency's build.zig struct.

It enables the use case where a package wants to lazily depend on an `@import`-style dependency and not fetch it until it is first needed, for example when building for a specific target.

```zig
// build.zig of lazy dependency 'foo'
const std = @import("std");

pub fn build(_: *std.Build) void {}

pub const bytes = "Hello!";
```
```zig
// build.zig of consumer
const std = @import("std");

pub fn build(b: *std.Build) void {
    const wf = b.addWriteFiles();

    // the non-lazy way, which won't work for our lazy dependency
    //_ = wf.add("foo.txt", @import("foo").bytes);

    // if 'foo' has not yet been fetched, 'lazyImport' returns 'null' and
    // triggers a recompile of the build script
    if (b.lazyImport(@This(), "foo")) |foo| {
        // 'foo' here is the build.zig struct of the dependency
        // we can access its public decls
        _ = wf.add("foo.txt", foo.bytes);
    }

    b.installDirectory(.{
        .source_dir = wf.getDirectory(),
        .install_dir = .prefix,
        .install_subdir = "",
    });
}
```

## Implementation details

Given the `name` of a dependency, we want to locate that package.

Just like with `dependency` and `lazyDependency`, in order to find the package we need to first obtain a list over which dependencies are available to the dependee, then find the package with the matching name in that list. For `dependency`/`lazyDependency`, this list is `b.available_deps`.

However, because `lazyImport` returns a comptime-only return type, we can't use runtime arguments like `b.available_deps`.

All the lists of dependencies of all participating packages can be found in `@import("root").dependencies`, but given only the `name` of the package have no way to know at comptime for which package we are calling `lazyImport`.

The only "clean" solution to this problem that I can come up with is to take a build.zig struct as the second argument:

```zig
pub inline fn lazyImport(
    b: *Build,
    /// The build.zig struct of the package importing the dependency.
    /// When calling this function from the `build` function of a build.zig file's, you normally
    /// pass `@This()`.
    comptime asking_build_zig: type,
    comptime dep_name: []const u8,
) ?type
```

This enables us to compare `asking_build_zig` against the build.zig struct of every package in `@import("root").dependencies` to figure out for which package we are calling `lazyImport`, then search through that package's dependencies as usual.

For good measure we can also throw in a runtime safety check that asserts that the `b` instance and the build.zig struct both represent the same package.

In practice this means that you almost always invoke the function with `@This()` as the second argument, such as in `b.lazyImport(@This(), "foo")`. 

## Testing

This API can't currently easily be tested by the compiler's test suite.

If any maintainers would like to check out this branch and test it locally, I have prepared a little test project that uses `lazyImport` up to two levels of indirection, which I used myself to test the changes:

[test.tar.gz](https://github.com/ziglang/zig/files/14324329/test.tar.gz)

The project is set up as follows:

- `root` lazily depends on `alfa`
- `root` lazily depends on `bravo`
- `bravo` lazily depends on `charlie`

I used `python -m http.server` to serve the packages over `http://localhost:8000/`; you might need to edit them if you want to serve them in a different way.

Running `zig build` will trigger one initial compile of the build script + two recompiles, then install two plaintext files.