### PR TITLE
Package.Fetch: fix Git package fetching

### DIFF
--- a/lib/std/compress/flate/inflate.zig
+++ b/lib/std/compress/flate/inflate.zig
@@ -288,6 +288,14 @@ pub fn Inflate(comptime container: Container, comptime ReaderType: type) type {
             }
         }
 
+        /// Returns the number of bytes that have been read from the internal
+        /// reader but not yet consumed by the decompressor.
+        pub fn unreadBytes(self: Self) usize {
+            // There can be no error here: the denominator is not zero, and
+            // overflow is not possible since the type is unsigned.
+            return std.math.divCeil(usize, self.bits.nbits, 8) catch unreachable;
+        }
+
         // Iterator interface
 
         /// Can be used in iterator like loop without memcpy to another buffer:


### PR DESCRIPTION
This commit works around #18967 by adding an `AccumulatingReader`, which accumulates data read from the underlying packfile, and by keeping track of the position in the packfile and hash/checksum information separately rather than using reader composition. That is, the packfile position and hashes/checksums are updated with the accumulated read history data only after we can determine what data has actually been used by the decompressor rather than merely being buffered.

The only addition to the standard library APIs to support this change is the `unreadBytes` function in `std.compress.flate.Inflate`, which allows the user to determine how many bytes have been read only for buffering and not used as part of compressed data.

These changes can be reverted if #18967 is resolved with a decompressor that reads precisely only the number of bytes needed for decompression.