### PR TITLE
various Emscripten support improvements, including stopping memory crashes caused by allocations between Zig + C libraries

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -39,7 +39,7 @@ pub const GetAppDataDirError = @import("fs/get_app_data_dir.zig").GetAppDataDirE
 /// fit into a UTF-8 encoded array of this length.
 /// The byte count includes room for a null sentinel byte.
 pub const MAX_PATH_BYTES = switch (builtin.os.tag) {
-    .linux, .macos, .ios, .freebsd, .openbsd, .netbsd, .dragonfly, .haiku, .solaris, .illumos, .plan9 => os.PATH_MAX,
+    .linux, .macos, .ios, .freebsd, .openbsd, .netbsd, .dragonfly, .haiku, .solaris, .illumos, .plan9, .emscripten => os.PATH_MAX,
     // Each UTF-16LE character may be expanded to 3 UTF-8 bytes.
     // If it would require 4 UTF-8 bytes, then there would be a surrogate
     // pair in the UTF-16LE, and we (over)account 3 bytes for it that way.

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -216,6 +216,10 @@ pub const page_allocator = if (@hasDecl(root, "os") and
     @hasDecl(root.os, "heap") and
     @hasDecl(root.os.heap, "page_allocator"))
     root.os.heap.page_allocator
+else if (builtin.target.os.tag == .emscripten and builtin.link_libc)
+    // NOTE: memory for C libraries seems to stomp over WasmPageAllocator allocated memory, and vice-versa
+    // so we use the C allocator so it uses memory functions Emscripten is aware of.
+    c_allocator
 else if (builtin.target.isWasm())
     Allocator{
         .ptr = undefined,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -752,7 +752,7 @@ pub fn abort() noreturn {
         exit(127); // Pid 1 might not be signalled in some containers.
     }
     switch (builtin.os.tag) {
-        .uefi, .wasi, .cuda, .amdhsa => @trap(),
+        .uefi, .wasi, .cuda, .amdhsa, .emscripten => @trap(),
         else => system.abort(),
     }
 }


### PR DESCRIPTION
## Closing in favour of smaller seperate PRs

- https://github.com/ziglang/zig/pull/19055
- https://github.com/ziglang/zig/pull/19056
- https://github.com/ziglang/zig/pull/19057
- https://github.com/ziglang/zig/pull/19058

**Changelog**

- stop memory crashes due to Zig allocation clashing with C libraries
- setup PATH_MAX for emscripten
- disable `captureStackTrace` for emscripten as it gets a segfault
- update emscripten to call @trap rather than just abort

**How am I sure Emscripten uses the C allocator in Zig?**

If I purposefully set the heap memory to be low without enabling `ALLOW_MEMORY_GROWTH` and setting `MAXIMUM_MEMORY` like so:
```zig
"-sINITIAL_MEMORY=2Mb",
"-sMALLOC='dlmalloc'",
```

Then I get this crash on start-up, you can see it attempt to call `dlmalloc` which is the allocator I've asked Emscripten to use.
```sh
 at abortOnCannotGrowMemory (index.js:7723:2)
    at _emscripten_resize_heap (index.js:7729:2)
    at imports.<computed> (index.js:8417:14)
    at index.wasm.sbrk (index.wasm:0x3fff)
    at index.wasm.dlmalloc (index.wasm:0x5610)
    at index.wasm.heap.CAllocator.alignedAlloc (index.wasm:0x2d964c)
    at index.wasm.heap.CAllocator.alloc (index.wasm:0x2d8d67)
    at index.wasm.mem.Allocator.allocBytesWithAlignment__anon_15580 (index.wasm:0x5ca659)
    at index.wasm.mem.Allocator.allocWithSizeAndAlignment__anon_15366 (index.wasm:0x51e340)
```

**Why disable captureStackTrace for emscripten?**

It currently crashes and gets a segmentation fault. I'm not sure what to do about properly resolving this, but if I just disable this logic then my application works without issues.

```sh
at segfault (index.js:332:2)
at index.wasm.SAFE_HEAP_LOAD_i32_4_4 (index.wasm:0x66d4df)
at index.wasm.debug.StackIterator.next_internal (index.wasm:0x3f7f85)
at index.wasm.debug.StackIterator.next (index.wasm:0x303559)
at index.wasm.debug.captureStackTrace (index.wasm:0x2e90c6)
at index.wasm.heap.general_purpose_allocator.GeneralPurposeAllocator(.{
    .stack_trace_frames = 6, .enable_memory_limit = true, .safety = true,
    .thread_safe = false, .MutexType = null, .never_unmap = false, .retain_metadata = false,
    .verbose_log = false}).collectStackTrace (http://localhost:6931/index.wasm)
```