### PR TITLE
Sema: fix compile error for switching on undefined union

### DIFF
--- a/test/cases/compile_errors/switch_on_undefined_union.zig
+++ b/test/cases/compile_errors/switch_on_undefined_union.zig
@@ -1,0 +1,12 @@
+export fn entry() void {
+    const U = union(enum) { a: bool, b: bool };
+    switch (@as(U, undefined)) {
+        .a, .b => {},
+    }
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:5: error: use of undefined value here causes undefined behavior


### PR DESCRIPTION
Before this fix, passing an undefined union value to `Sema.switchCond` returned an undefined value of the union type, not the tag type, since `Value.unionTag` forwards undefined values unchanged. This leads us into the `.Union` branch in `Sema.zirSwitchBlock` which is unreachable, now we take the `.Enum` branch instead.

Closes https://github.com/ziglang/zig/issues/18297.