### PR TITLE
change `addCSourceFiles` to use `LazyPath` instead `Dependency`

### DIFF
--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -80,7 +80,7 @@ pub const SystemLib = struct {
 
 pub const CSourceFiles = struct {
     root: LazyPath,
-    /// `files` is  relative to `root`, which is
+    /// `files` is relative to `root`, which is
     /// the build root by default
     files: []const []const u8,
     flags: []const []const u8,

--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -79,7 +79,7 @@ pub const SystemLib = struct {
 };
 
 pub const CSourceFiles = struct {
-    dependency: ?*std.Build.Dependency,
+    root: LazyPath = .{ .path = "" },
     /// If `dependency` is not null relative to it,
     /// else relative to the build root.
     files: []const []const u8,
@@ -455,7 +455,7 @@ pub fn linkFramework(m: *Module, name: []const u8, options: LinkFrameworkOptions
 pub const AddCSourceFilesOptions = struct {
     /// When provided, `files` are relative to `dependency` rather than the
     /// package that owns the `Compile` step.
-    dependency: ?*std.Build.Dependency = null,
+    root: LazyPath = .{ .path = "" },
     files: []const []const u8,
     flags: []const []const u8 = &.{},
 };
@@ -466,7 +466,7 @@ pub fn addCSourceFiles(m: *Module, options: AddCSourceFilesOptions) void {
     const allocator = b.allocator;
     const c_source_files = allocator.create(CSourceFiles) catch @panic("OOM");
     c_source_files.* = .{
-        .dependency = options.dependency,
+        .root = options.root,
         .files = b.dupeStrings(options.files),
         .flags = b.dupeStrings(options.flags),
     };

--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -79,7 +79,7 @@ pub const SystemLib = struct {
 };
 
 pub const CSourceFiles = struct {
-    root: LazyPath = .{ .path = "" },
+    root: LazyPath,
     /// `files` is  relative to `root`, which is
     /// the build root by default
     files: []const []const u8,

--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -80,8 +80,8 @@ pub const SystemLib = struct {
 
 pub const CSourceFiles = struct {
     root: LazyPath = .{ .path = "" },
-    /// If `dependency` is not null relative to it,
-    /// else relative to the build root.
+    /// `files` is  relative to `root`, which is
+    /// the build root by default
     files: []const []const u8,
     flags: []const []const u8,
 };
@@ -453,7 +453,7 @@ pub fn linkFramework(m: *Module, name: []const u8, options: LinkFrameworkOptions
 }
 
 pub const AddCSourceFilesOptions = struct {
-    /// When provided, `files` are relative to `dependency` rather than the
+    /// When provided, `files` are relative to `root` rather than the
     /// package that owns the `Compile` step.
     root: LazyPath = .{ .path = "" },
     files: []const []const u8,

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1197,15 +1197,11 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                             prev_has_cflags = true;
                         }
 
-                        if (c_source_files.dependency) |dep| {
-                            for (c_source_files.files) |file| {
-                                try zig_args.append(dep.builder.pathFromRoot(file));
-                            }
-                        } else {
-                            for (c_source_files.files) |file| {
-                                try zig_args.append(b.pathFromRoot(file));
-                            }
+                        const root_path = c_source_files.root.getPath2(b, step);
+                        for (c_source_files.files) |file| {
+                            try zig_args.append(b.pathJoin(&.{ root_path, file }));
                         }
+
                         total_linker_objects += c_source_files.files.len;
                     },
 

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1197,7 +1197,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                             prev_has_cflags = true;
                         }
 
-                        const root_path = c_source_files.root.getPath2(b, module.owner);
+                        const root_path = c_source_files.root.getPath2(module.owner, step);
                         for (c_source_files.files) |file| {
                             try zig_args.append(b.pathJoin(&.{ root_path, file }));
                         }

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1197,7 +1197,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                             prev_has_cflags = true;
                         }
 
-                        const root_path = c_source_files.root.getPath2(b, step);
+                        const root_path = c_source_files.root.getPath2(b, module.owner);
                         for (c_source_files.files) |file| {
                             try zig_args.append(b.pathJoin(&.{ root_path, file }));
                         }


### PR DESCRIPTION
cc @jacobly0 

Makes it possible to prepend a LazyPath that might have been derived from a `zig-cache` dep, and prepend it to a list of files.

## Use Case:

I was adding `libgit2` as a dep to my project by downloading the tar ball from Github archive and since, (submodules bad) I used the build system. This leaves me with a `LazyPath` to the location in `zig-cache`, and a large list of files I need to add to the exe with the same flags. Since `addCSourceFiles` takes a "hardcoded" list of relative paths, I had no way to access things inside the `zig-cache`
