### PR TITLE
AstGen: fix OoB crash on `ast-check -t`

### DIFF
--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -4298,7 +4298,7 @@ fn fnDecl(
 
         if (!fn_gz.endsWithNoReturn()) {
             // As our last action before the return, "pop" the error trace if needed
-            _ = try gz.addRestoreErrRetIndex(.ret, .always, decl_node);
+            _ = try fn_gz.addRestoreErrRetIndex(.ret, .always, decl_node);
 
             // Add implicit return at end of function.
             _ = try fn_gz.addUnTok(.ret_implicit, .void_value, tree.lastToken(body_node));
@@ -4746,7 +4746,7 @@ fn testDecl(
     if (fn_block.isEmpty() or !fn_block.refIsNoReturn(block_result)) {
 
         // As our last action before the return, "pop" the error trace if needed
-        _ = try gz.addRestoreErrRetIndex(.ret, .always, node);
+        _ = try fn_block.addRestoreErrRetIndex(.ret, .always, node);
 
         // Add implicit return at end of function.
         _ = try fn_block.addUnTok(.ret_implicit, .void_value, tree.lastToken(body_node));


### PR DESCRIPTION
Running `zig ast-check -t` on this code crashes for me on `master` branch:

```zig
const std = @import("std");

pub fn foo() void {}
```

with this error (full stack trace below):

```
thread 6563100 panic: index out of bounds: index 10, len 8
/Users/user/repos/zig/lib/std/zig/Ast.zig:478:30: 0x1102f8be0 in firstToken (zig)
    while (true) switch (tags[n]) {
```

As far as I can tell it was introduced in https://github.com/ziglang/zig/commit/434537213e406191959818f573b24ca45c1b0e45. `ast-check -t` works for me with this fix but I'm not sure if this has other implications, cc @mlugg 🙏 

<details>

```
# Source bytes:       49B
# Tokens:             17 (109B)
# AST Nodes:          8 (232B)
# Total ZIR bytes:    393B
# Instructions:       12 (108B)
# String Table Bytes: 9B
# Extra Data Items:   53 (212B)
thread 6563100 panic: index out of bounds: index 10, len 8
/Users/user/repos/zig/lib/std/zig/Ast.zig:478:30: 0x1102f8be0 in firstToken (zig)
    while (true) switch (tags[n]) {
                             ^
/Users/user/repos/zig/src/Module.zig:1908:28: 0x1102ecdb1 in nodeToSpan (zig)
            tree.firstToken(node),
                           ^
/Users/user/repos/zig/src/Module.zig:1189:34: 0x1102eda51 in span (zig)
                return nodeToSpan(tree, node);
                                 ^
/Users/user/repos/zig/src/print_zir.zig:2777:42: 0x11040a8ea in writeSrc__anon_61180 (zig)
            const src_span = src_loc.span(self.gpa) catch unreachable;
                                         ^
/Users/user/repos/zig/src/print_zir.zig:641:26: 0x1107127e8 in writeUnNode__anon_81809 (zig)
        try self.writeSrc(stream, inst_data.src());
                         ^
/Users/user/repos/zig/src/print_zir.zig:281:36: 0x11040e0b1 in writeInstToStream__anon_61171 (zig)
            => try self.writeUnNode(stream, inst),
                                   ^
/Users/user/repos/zig/src/print_zir.zig:2846:39: 0x1106da4df in writeBody__anon_81630 (zig)
            try self.writeInstToStream(stream, inst);
                                      ^
/Users/user/repos/zig/src/print_zir.zig:2808:31: 0x1106daa7d in writeBracedBodyConditional__anon_81629 (zig)
            try self.writeBody(stream, body);
                              ^
/Users/user/repos/zig/src/print_zir.zig:2799:44: 0x1106dbc20 in writeBracedBody__anon_81628 (zig)
        try self.writeBracedBodyConditional(stream, body, self.recurse_blocks);
                                           ^
/Users/user/repos/zig/src/print_zir.zig:2619:33: 0x1106ed5fc in writeFuncCommon__anon_81713 (zig)
        try self.writeBracedBody(stream, body);
                                ^
/Users/user/repos/zig/src/print_zir.zig:2278:36: 0x1106ee00a in writeFunc__anon_81705 (zig)
        return self.writeFuncCommon(
                                   ^
/Users/user/repos/zig/src/print_zir.zig:505:40: 0x11040dc2d in writeInstToStream__anon_61171 (zig)
            .func => try self.writeFunc(stream, inst, false),
                                       ^
/Users/user/repos/zig/src/print_zir.zig:2846:39: 0x1106da4df in writeBody__anon_81630 (zig)
            try self.writeInstToStream(stream, inst);
                                      ^
/Users/user/repos/zig/src/print_zir.zig:2808:31: 0x1106daa7d in writeBracedBodyConditional__anon_81629 (zig)
            try self.writeBody(stream, body);
                              ^
/Users/user/repos/zig/src/print_zir.zig:2795:44: 0x1106f0f00 in writeBracedDecl__anon_81737 (zig)
        try self.writeBracedBodyConditional(stream, body, self.recurse_decls);
                                           ^
/Users/user/repos/zig/src/print_zir.zig:2691:37: 0x1106f21a1 in writeDeclaration__anon_81731 (zig)
            try self.writeBracedDecl(stream, bodies.value_body);
                                    ^
/Users/user/repos/zig/src/print_zir.zig:522:54: 0x11040dfcb in writeInstToStream__anon_61171 (zig)
            .declaration => try self.writeDeclaration(stream, inst),
                                                     ^
/Users/user/repos/zig/src/print_zir.zig:2846:39: 0x1106da4df in writeBody__anon_81630 (zig)
            try self.writeInstToStream(stream, inst);
                                      ^
/Users/user/repos/zig/src/print_zir.zig:1455:31: 0x1106f9d4b in writeStructDecl__anon_81777 (zig)
            try self.writeBody(stream, self.code.bodySlice(extra_index, decls_len));
                              ^
/Users/user/repos/zig/src/print_zir.zig:567:53: 0x1107069c9 in writeExtended__anon_81738 (zig)
            .struct_decl => try self.writeStructDecl(stream, extended),
                                                    ^
/Users/user/repos/zig/src/print_zir.zig:524:48: 0x11040e03e in writeInstToStream__anon_61171 (zig)
            .extended => try self.writeExtended(stream, inst),
                                               ^
/Users/user/repos/zig/src/print_zir.zig:37:33: 0x11040bcef in renderAsTextToFile (zig)
    try writer.writeInstToStream(stream, main_struct_inst);
                                ^
/Users/user/repos/zig/src/main.zig:6813:55: 0x110410644 in cmdAstCheck (zig)
    return @import("print_zir.zig").renderAsTextToFile(gpa, &file, io.getStdOut());
                                                      ^
/Users/user/repos/zig/src/main.zig:343:27: 0x110132fb2 in mainArgs (zig)
        return cmdAstCheck(gpa, arena, cmd_args);
                          ^
/Users/user/repos/zig/src/main.zig:223:20: 0x11012eee7 in main (zig)
    return mainArgs(gpa, arena, args);
                   ^
/Users/user/repos/zig/lib/std/start.zig:511:37: 0x11012eb36 in main (zig)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x12063952d in ??? (???)
Unwind information for `???:0x12063952d` was not available, trace may be incomplete

???:?:?: 0x0 in ??? (???)
zsh: abort      ~/repos/zig/build/stage4/bin/zig ast-check -t main.zig
~/o/z/zig-i/18556 main !1 ?22 ↯  tw compiler proj zig ~/repos/zig/build/ast-gen-fix/bin/zig ast-check -t main.zig
# Source bytes:       49B
# Tokens:             17 (109B)
# AST Nodes:          8 (232B)
# Total ZIR bytes:    393B
# Instructions:       12 (108B)
# String Table Bytes: 9B
# Extra Data Items:   53 (212B)
%0 = extended(struct_decl(hash(e7babd02130359ee9e0ad27d7ed7dee4) parent, Auto, {
  %1 = declaration('std' line(+0) hash(c9cf6ee7a5ad2804a9114568f721d663) value={
    %2 = import("std") token_offset:1:21 to :1:26
    %3 = break_inline(%1, %2)
  }) node_offset:1:1 to :1:27
  %4 = declaration(pub 'foo' line(+2) hash(a46823d571bdb65f8e1b2183bff088c4) value={
    %10 = func(ret_ty=@void_type, body={
      %5 = block({
        %6 = restore_err_ret_index_unconditional(%5) node_offset:3:19 to :3:19
        %7 = break(%5, @void_value)
      }) node_offset:3:19 to :3:19
      %8 = restore_err_ret_index_unconditional(.none) node_offset:3:1 to :3:1
      %9 = ret_implicit(@void_value) token_offset:3:20 to :3:20
    }) (lbrace=1:19,rbrace=1:20) node_offset:3:1 to :3:1
    %11 = break_inline(%4, %10)
  }) node_offset:3:1 to :3:18
}, {}, {}) node_offset:1:1 to :1:6
Imports:
  @import("std") token_abs:1:21 to :1:26
~/o/z/zig-i/18556 main !1 ?22 ↯  tw compiler proj zig gd
~/o/z/zig-i/18556 main !1 ?22 ↯  tw compiler proj zig ~/repos/zig/build/stage3/bin/zig ast-check -t main.zig
error: -t option only available in debug builds of zig
~/o/z/zig-i/18556 main !1 ?22 ↯  tw compiler proj zig ~/repos/zig/build/stage3/bin/zig ast-check -t main.zig
~/o/z/zig-i/18556 main !1 ?22 ↯  tw compiler proj zig
~/o/z/zig-i/18556 main !1 ?22 ↯  tw compiler proj zig ~/repos/zig/build/stage4/bin/zig ast-check -t main.zig
# Source bytes:       49B
# Tokens:             17 (109B)
# AST Nodes:          8 (232B)
# Total ZIR bytes:    393B
# Instructions:       12 (108B)
# String Table Bytes: 9B
# Extra Data Items:   53 (212B)
thread 6566331 panic: index out of bounds: index 10, len 8
/Users/user/repos/zig/lib/std/zig/Ast.zig:478:30: 0x113b17be0 in firstToken (zig)
    while (true) switch (tags[n]) {
                             ^
/Users/user/repos/zig/src/Module.zig:1908:28: 0x113b0bdb1 in nodeToSpan (zig)
            tree.firstToken(node),
                           ^
/Users/user/repos/zig/src/Module.zig:1189:34: 0x113b0ca51 in span (zig)
                return nodeToSpan(tree, node);
                                 ^
/Users/user/repos/zig/src/print_zir.zig:2777:42: 0x113c298ea in writeSrc__anon_61180 (zig)
            const src_span = src_loc.span(self.gpa) catch unreachable;
                                         ^
/Users/user/repos/zig/src/print_zir.zig:641:26: 0x113f317e8 in writeUnNode__anon_81809 (zig)
        try self.writeSrc(stream, inst_data.src());
                         ^
/Users/user/repos/zig/src/print_zir.zig:281:36: 0x113c2d0b1 in writeInstToStream__anon_61171 (zig)
            => try self.writeUnNode(stream, inst),
                                   ^
/Users/user/repos/zig/src/print_zir.zig:2846:39: 0x113ef94df in writeBody__anon_81630 (zig)
            try self.writeInstToStream(stream, inst);
                                      ^
/Users/user/repos/zig/src/print_zir.zig:2808:31: 0x113ef9a7d in writeBracedBodyConditional__anon_81629 (zig)
            try self.writeBody(stream, body);
                              ^
/Users/user/repos/zig/src/print_zir.zig:2799:44: 0x113efac20 in writeBracedBody__anon_81628 (zig)
        try self.writeBracedBodyConditional(stream, body, self.recurse_blocks);
                                           ^
/Users/user/repos/zig/src/print_zir.zig:2619:33: 0x113f0c5fc in writeFuncCommon__anon_81713 (zig)
        try self.writeBracedBody(stream, body);
                                ^
/Users/user/repos/zig/src/print_zir.zig:2278:36: 0x113f0d00a in writeFunc__anon_81705 (zig)
        return self.writeFuncCommon(
                                   ^
/Users/user/repos/zig/src/print_zir.zig:505:40: 0x113c2cc2d in writeInstToStream__anon_61171 (zig)
            .func => try self.writeFunc(stream, inst, false),
                                       ^
/Users/user/repos/zig/src/print_zir.zig:2846:39: 0x113ef94df in writeBody__anon_81630 (zig)
            try self.writeInstToStream(stream, inst);
                                      ^
/Users/user/repos/zig/src/print_zir.zig:2808:31: 0x113ef9a7d in writeBracedBodyConditional__anon_81629 (zig)
            try self.writeBody(stream, body);
                              ^
/Users/user/repos/zig/src/print_zir.zig:2795:44: 0x113f0ff00 in writeBracedDecl__anon_81737 (zig)
        try self.writeBracedBodyConditional(stream, body, self.recurse_decls);
                                           ^
/Users/user/repos/zig/src/print_zir.zig:2691:37: 0x113f111a1 in writeDeclaration__anon_81731 (zig)
            try self.writeBracedDecl(stream, bodies.value_body);
                                    ^
/Users/user/repos/zig/src/print_zir.zig:522:54: 0x113c2cfcb in writeInstToStream__anon_61171 (zig)
            .declaration => try self.writeDeclaration(stream, inst),
                                                     ^
/Users/user/repos/zig/src/print_zir.zig:2846:39: 0x113ef94df in writeBody__anon_81630 (zig)
            try self.writeInstToStream(stream, inst);
                                      ^
/Users/user/repos/zig/src/print_zir.zig:1455:31: 0x113f18d4b in writeStructDecl__anon_81777 (zig)
            try self.writeBody(stream, self.code.bodySlice(extra_index, decls_len));
                              ^
/Users/user/repos/zig/src/print_zir.zig:567:53: 0x113f259c9 in writeExtended__anon_81738 (zig)
            .struct_decl => try self.writeStructDecl(stream, extended),
                                                    ^
/Users/user/repos/zig/src/print_zir.zig:524:48: 0x113c2d03e in writeInstToStream__anon_61171 (zig)
            .extended => try self.writeExtended(stream, inst),
                                               ^
/Users/user/repos/zig/src/print_zir.zig:37:33: 0x113c2acef in renderAsTextToFile (zig)
    try writer.writeInstToStream(stream, main_struct_inst);
                                ^
/Users/user/repos/zig/src/main.zig:6813:55: 0x113c2f644 in cmdAstCheck (zig)
    return @import("print_zir.zig").renderAsTextToFile(gpa, &file, io.getStdOut());
                                                      ^
/Users/user/repos/zig/src/main.zig:343:27: 0x113951fb2 in mainArgs (zig)
        return cmdAstCheck(gpa, arena, cmd_args);
                          ^
/Users/user/repos/zig/src/main.zig:223:20: 0x11394dee7 in main (zig)
    return mainArgs(gpa, arena, args);
                   ^
/Users/user/repos/zig/lib/std/start.zig:511:37: 0x11394db36 in main (zig)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x12c4ca52d in ??? (???)
Unwind information for `???:0x12c4ca52d` was not available, trace may be incomplete

???:?:?: 0x0 in ??? (???)
zsh: abort      ~/repos/zig/build/stage4/bin/zig ast-check -t main.zig
```

</details>