### PR TITLE
update root.os.system override to require "system" field, this allows easier overriding of os.heap.page_allocator

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -59,7 +59,7 @@ test {
 /// Applications can override the `system` API layer in their root source file.
 /// Otherwise, when linking libc, this is the C API.
 /// When not linking libc, it is the OS-specific system interface.
-pub const system = if (@hasDecl(root, "os") and root.os != @This())
+pub const system = if (@hasDecl(root, "os") and @hasDecl(root.os, "system") and root.os != @This())
     root.os.system
 else if (use_libc)
     std.c


### PR DESCRIPTION
## Changes

- update root.os.system override to require "system" field

## Why?

- this allows easier overriding of `os.heap.page_allocator` in a users `main.zig`, which I'm currently using to fix allocations with Emscripten
   - https://github.com/ziglang/zig/pull/18999