### PR TITLE
Add ZIG_SYSROOT env var

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -101,6 +101,10 @@ pub fn main() !void {
     var steps_menu: bool = false;
     var output_tmp_nonce: ?[16]u8 = null;
 
+    if (graph.env_map.get("ZIG_SYSROOT")) |sysroot| {
+        builder.sysroot = sysroot;
+    }
+
     while (nextArg(args, &arg_idx)) |arg| {
         if (mem.startsWith(u8, arg, "-Z")) {
             if (arg.len != 18) fatalWithHint("bad argument: '{s}'", .{arg});

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -983,6 +983,7 @@ pub const EnvVar = enum {
     ZIG_VERBOSE_CC,
     ZIG_BTRFS_WORKAROUND,
     ZIG_DEBUG_CMD,
+    ZIG_SYSROOT,
     CC,
     NO_COLOR,
     XDG_CACHE_HOME,

--- a/src/main.zig
+++ b/src/main.zig
@@ -970,7 +970,7 @@ fn buildOutputType(
         .rc_source_files = .{},
 
         .llvm_m_args = .{},
-        .sysroot = null,
+        .sysroot = try EnvVar.ZIG_SYSROOT.get(arena),
         .lib_dirs = .{}, // populated by createModule()
         .lib_dir_args = .{}, // populated from CLI arg parsing
         .libc_installation = null,


### PR DESCRIPTION
Allows Zig's sysroot to be set by `$ZIG_SYSROOT` env var, this is useful for wrapper scripts.