### PR TITLE
format: do not force user to provide an alignment field when it's not necessary

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -258,8 +258,8 @@ pub const Placeholder = struct {
         const alignment: ?Alignment = comptime if (parser.peek(0)) |ch| init: {
             switch (ch) {
                 '<', '^', '>' => {
-                    _ = parser.char(); // consume the character
-                    break :init switch (ch) {
+                    // consume the character
+                    break :init switch (parser.char().?) {
                         '<' => .left,
                         '^' => .center,
                         else => .right,

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -242,9 +242,10 @@ pub const Placeholder = struct {
             }
         }
 
-        // Parse the fill character, if present
-        // The fill character must be followed by an alignment specifier unless
-        // it's zero, in which case it's handled as part of the width specifier
+        // Parse the fill character, if present.
+        // When the width field is also specified, the fill character must
+        // be followed by an alignment specifier, unless it's '0' (zero)
+        // (in which case it's handled as part of the width specifier)
         var fill: ?u21 = comptime if (parser.peek(1)) |ch|
             switch (ch) {
                 '<', '^', '>' => parser.char(),

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -20,11 +20,14 @@ pub const Alignment = enum {
     right,
 };
 
+const default_alignment = .right;
+const default_fill_char = ' ';
+
 pub const FormatOptions = struct {
     precision: ?usize = null,
     width: ?usize = null,
-    alignment: Alignment = .right,
-    fill: u21 = ' ',
+    alignment: Alignment = default_alignment,
+    fill: u21 = default_fill_char,
 };
 
 /// Renders fmt string with args, calling `writer` with slices of bytes.
@@ -48,6 +51,8 @@ pub const FormatOptions = struct {
 ///
 /// Note that most of the parameters are optional and may be omitted. Also you can leave out separators like `:` and `.` when
 /// all parameters after the separator are omitted.
+/// Only exception is the *fill* parameter. If a non-zero *fill* character is required at the same time as *width* is specified,
+/// one has to specify *alignment* as well, as otherwise the digit following `:` is interpreted as *width*, not *fill*.
 ///
 /// The *specifier* has several options for types:
 /// - `x` and `X`: output numeric value in hexadecimal notation
@@ -237,29 +242,37 @@ pub const Placeholder = struct {
             }
         }
 
-        // Parse the fill character
-        // The fill parameter requires the alignment parameter to be specified
-        // too
-        const fill = comptime if (parser.peek(1)) |ch|
+        // Parse the fill character, if present
+        // The fill character must be followed by an alignment specifier unless
+        // it's zero, in which case it's handled as part of the width specifier
+        var fill: ?u21 = comptime if (parser.peek(1)) |ch|
             switch (ch) {
-                '<', '^', '>' => parser.char().?,
-                else => parser.char() orelse ' ',
+                '<', '^', '>' => parser.char(),
+                else => null,
             }
         else
-            ' ';
+            null;
 
         // Parse the alignment parameter
-        const alignment: Alignment = comptime if (parser.peek(0)) |ch| init: {
+        const alignment: ?Alignment = comptime if (parser.peek(0)) |ch| init: {
             switch (ch) {
-                '<', '^', '>' => _ = parser.char(),
-                else => {},
+                '<', '^', '>' => {
+                    _ = parser.char(); // consume the character
+                    break :init switch (ch) {
+                        '<' => .left,
+                        '^' => .center,
+                        else => .right,
+                    };
+                },
+                else => break :init null,
             }
-            break :init switch (ch) {
-                '<' => .left,
-                '^' => .center,
-                else => .right,
-            };
-        } else .right;
+        } else null;
+
+        // When none of the fill character and the alignment specifier have
+        // been provided, check whether the width starts with a zero.
+        if (fill == null and alignment == null) {
+            fill = comptime if (parser.peek(0)) |ch| (if (ch == '0') ch else null) else null;
+        }
 
         // Parse the width parameter
         const width = comptime parser.specifier() catch |err|
@@ -282,8 +295,8 @@ pub const Placeholder = struct {
 
         return Placeholder{
             .specifier_arg = cacheString(specifier_arg[0..specifier_arg.len].*),
-            .fill = fill,
-            .alignment = alignment,
+            .fill = fill orelse default_fill_char,
+            .alignment = alignment orelse default_alignment,
             .arg = arg,
             .width = width,
             .precision = precision,
@@ -2644,6 +2657,15 @@ test "sci float padding" {
     try expectFmt("left-pad:   ****3.142e0\n", "left-pad:   {e:*>11.3}\n", .{number});
     try expectFmt("center-pad: **3.142e0**\n", "center-pad: {e:*^11.3}\n", .{number});
     try expectFmt("right-pad:  3.142e0****\n", "right-pad:  {e:*<11.3}\n", .{number});
+}
+
+test "padding.zero" {
+    try expectFmt("zero-pad: '0042'", "zero-pad: '{:04}'", .{42});
+    try expectFmt("std-pad: '        42'", "std-pad: '{:10}'", .{42});
+    try expectFmt("std-pad-1: '001'", "std-pad-1: '{:0>3}'", .{1});
+    try expectFmt("std-pad-2: '911'", "std-pad-2: '{:1<03}'", .{9});
+    try expectFmt("std-pad-3: '  1'", "std-pad-3: '{:>03}'", .{1});
+    try expectFmt("center-pad: '515'", "center-pad: '{:5^03}'", .{1});
 }
 
 test "null" {

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -48,8 +48,6 @@ pub const FormatOptions = struct {
 ///
 /// Note that most of the parameters are optional and may be omitted. Also you can leave out separators like `:` and `.` when
 /// all parameters after the separator are omitted.
-/// Only exception is the *fill* parameter. If *fill* is required, one has to specify *alignment* as well, as otherwise
-/// the digits after `:` is interpreted as *width*, not *fill*.
 ///
 /// The *specifier* has several options for types:
 /// - `x` and `X`: output numeric value in hexadecimal notation
@@ -245,7 +243,7 @@ pub const Placeholder = struct {
         const fill = comptime if (parser.peek(1)) |ch|
             switch (ch) {
                 '<', '^', '>' => parser.char().?,
-                else => ' ',
+                else => parser.char() orelse ' ',
             }
         else
             ' ';

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -272,7 +272,7 @@ pub const Placeholder = struct {
         // When none of the fill character and the alignment specifier have
         // been provided, check whether the width starts with a zero.
         if (fill == null and alignment == null) {
-            fill = comptime if (parser.peek(0)) |ch| (if (ch == '0') ch else null) else null;
+            fill = comptime if (parser.peek(0) == '0') '0' else null;
         }
 
         // Parse the width parameter


### PR DESCRIPTION
Hi guys,

In this changelist I'm suggesting to improve upon the existing Format Options parsing to make it a little more flexible, closer actually to the defaults that C programmers are used to and that most languages implement. To me, it follows the following principles from the Zen:

* _Incremental improvements_,
* _Edge cases matter_,
* _Minimize energy spent on coding style_,
* _Together we serve end users_.

Padding with `0` is very common for hexadecimal output: in many languages `04x` left-pads with zeroes, but in Zig `{x:04}` left-pads with blanks. However for most fill characters like zero, adding an alignment specifier is actually not necessary (it's only necessary for `1`-`9` and `.`)

The new behaviour is non-breaking (e.g current unit tests pass) and feels more natural and closer to how other languages handle zero-padding in their format options:
```zig
    std.debug.print("{:04}",   .{42}); // "0042"
    std.debug.print("{:10}",   .{42}); // "        42"
    std.debug.print("{:0>3}",  .{1});  // "001"
    std.debug.print("{:1<03}", .{9});  // "911"
    std.debug.print("{:>03}" , .{1});  // "  1"
    std.debug.print("{:5^03}", .{1});  // "515"
    std.debug.print("{:_4}",   .{42}); // "__42"
    std.debug.print("{: 4}",   .{42}); // "  42"
    std.debug.print("{d:.3}", .{1.2345});  // "1.234"
```

I've also added new unit tests for the new cases.