### PR TITLE
emscripten: set PATH_MAX to emscripten.os.PATH_MAX

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -39,7 +39,7 @@ pub const GetAppDataDirError = @import("fs/get_app_data_dir.zig").GetAppDataDirE
 /// fit into a UTF-8 encoded array of this length.
 /// The byte count includes room for a null sentinel byte.
 pub const MAX_PATH_BYTES = switch (builtin.os.tag) {
-    .linux, .macos, .ios, .freebsd, .openbsd, .netbsd, .dragonfly, .haiku, .solaris, .illumos, .plan9 => os.PATH_MAX,
+    .linux, .macos, .ios, .freebsd, .openbsd, .netbsd, .dragonfly, .haiku, .solaris, .illumos, .plan9, .emscripten => os.PATH_MAX,
     // Each UTF-16LE character may be expanded to 3 UTF-8 bytes.
     // If it would require 4 UTF-8 bytes, then there would be a surrogate
     // pair in the UTF-16LE, and we (over)account 3 bytes for it that way.


### PR DESCRIPTION
Currently when building with emscripten, file access functions will fail because PATH_MAX isn't defined so we set Emscripten to use std/os/emscripten.zig's PATH_MAX (currently 4096).

ie.
```sh
C:\zig\current\lib\std\fs.zig:53:9: error: PATH_MAX not implemented for emscripten
        @compileError("PATH_MAX not implemented for " ++ @tagName(builtin.os.tag)),
```