### PR TITLE
emscripten: use @trap instead of system.abort for emscripten

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -752,7 +752,7 @@ pub fn abort() noreturn {
         exit(127); // Pid 1 might not be signalled in some containers.
     }
     switch (builtin.os.tag) {
-        .uefi, .wasi, .cuda, .amdhsa => @trap(),
+        .uefi, .wasi, .emscripten, .cuda, .amdhsa => @trap(),
         else => system.abort(),
     }
 }


### PR DESCRIPTION
**Description**

Not actually sure if we want this change for Emscripten, but have documented in this PR the results in console when you make it. With @trap for emscripten, it seems to hit an unreachable state issue.

**Code used to test this change**
```zig
pub fn main() !void {
    if (true) @panic("my panic test");
}
```

**Before in Chrome DevTools console (short)**
- map-editor.js:4692 panic: my panic test
- map-editor.js:4692 Aborted(native code called abort())
- map-editor.js:20 Uncaught RuntimeError: Aborted(native code called abort())

**After in Chrome DevTools console (short)**
![image](https://github.com/ziglang/zig/assets/3859574/2f2fabed-a012-4914-9fc8-c2fec31d764c)

- map-editor.js:4687 panic: my panic test
- Uncaught RuntimeError: unreachable

## Console logs if you open up the navigation

**Before in Chrome DevTools console (long)**

- map-editor.js:4692 panic: my panic test
  - err @ map-editor.js:4692
- map-editor.js:4692 Aborted(native code called abort())
  - err @ map-editor.js:4692
- map-editor.js:20 Uncaught RuntimeError: Aborted(native code called abort())
    at abort (map-editor.js:591:40)
    at _abort (map-editor.js:3820:2)
    at imports.<computed> (map-editor.js:4198:23)
    at map-editor.wasm.os.abort (os.zig:747:29)
    at map-editor.wasm.debug.panicImpl (debug.zig:503:13)
    at map-editor.wasm.builtin.default_panic (builtin.zig:844:32)
    at map-editor.wasm.main.main (main.zig:249:15)
    at map-editor.wasm.main (start.zig:511:37)
    at ret.<computed> (map-editor.js:4217:23)
    at map-editor.js:613:12

**After in Chrome DevTools console (long)**
![image](https://github.com/ziglang/zig/assets/3859574/8ff3b8d9-be4e-4307-91de-69f7af5f3418)

- map-editor.js:4687 panic: my panic test
  - err @ map-editor.js:4687
  - put_char @ map-editor.js:1513
  - write @ map-editor.js:1465
  - write @ map-editor.js:3092
  - doWritev @ map-editor.js:4121
  - _fd_write @ map-editor.js:4134
  - imports.<computed> @ map-editor.js:4194
  - $write @ write.c:12
  - $os.write @ os.zig:1292
  - $fs.File.write @ File.zig:1131
  - $io.GenericWriter(fs.File,error{AccessDenied,SystemResources,DeviceBusy,Unexpected,DiskQuota,FileTooBig,InputOutput,NoSpaceLeft,InvalidArgument,BrokenPipe,OperationAborted,NotOpenForWriting,LockViolation,WouldBlock,ConnectionResetByPeer},(function 'write')).typeErasedWriteFn @ io.zig:354
  - $io.Writer.write @ Writer.zig:12
  - $io.Writer.writeAll @ Writer.zig:18
  - $fmt.format__anon_8580 @ fmt.zig:122
  - $io.Writer.print__anon_8514 @ Writer.zig:23
  - $debug.panicImpl @ io.zig:322
  - $builtin.default_panic @ builtin.zig:844
  - $main.main @ main.zig:249
  - $main @ start.zig:511
  - ret.<computed> @ map-editor.js:4213
  - (anonymous) @ map-editor.js:613
  - callMain @ map-editor.js:4578
  - doRun @ map-editor.js:4608
  - (anonymous) @ map-editor.js:4617
  - setTimeout (async)
  - run @ map-editor.js:4613
  - (goes deeper, not writing out)
- map-editor.js:20 Uncaught RuntimeError: unreachable
    at map-editor.wasm.os.abort (os.zig:746:54)
    at map-editor.wasm.debug.panicImpl (debug.zig:503:13)
    at map-editor.wasm.builtin.default_panic (builtin.zig:844:32)
    at map-editor.wasm.main.main (main.zig:249:15)
    at map-editor.wasm.main (start.zig:511:37)
    at ret.<computed> (map-editor.js:4213:23)
    at map-editor.js:613:12
    at callMain (map-editor.js:4578:13)
    at doRun (map-editor.js:4608:21)
    at map-editor.js:4617:4