### PR TITLE
emscripten: use c_allocator as default page_allocator

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -216,6 +216,8 @@ pub const page_allocator = if (@hasDecl(root, "os") and
     @hasDecl(root.os, "heap") and
     @hasDecl(root.os.heap, "page_allocator"))
     root.os.heap.page_allocator
+else if (builtin.target.os.tag == .emscripten)
+    c_allocator
 else if (builtin.target.isWasm())
     Allocator{
         .ptr = undefined,


### PR DESCRIPTION
**Description**

When I tried to allocate memory for both SDL2, Wasm3 and Zig code, I'd end up with crashes occurring when allocating memory. My assumption is that because Zig uses `WasmPageAllocator` for WASM builds, it ends up stomping over Emscripten allocated memory (ie. SDL2/Wasm3's allocations) and vice-versa.

**My current workaround**

I use the following. I also target "wasi" as well because I'm building my Zig code using the `wasi` target for the time-being, as that mostly "just works".

```zig
pub const os = if (builtin.os.tag != .wasi and builtin.os.tag != .emscripten) std.os else struct {
    pub const heap = struct {
        pub const page_allocator = std.heap.c_allocator;
    };
};
```

**How did I confirm if Zig is calling Emscripten allocation functions?**

If I purposefully set the heap memory to be low without enabling `ALLOW_MEMORY_GROWTH` and setting `MAXIMUM_MEMORY` like so:
```zig
"-sINITIAL_MEMORY=2Mb",
"-sMALLOC='dlmalloc'",
```

Then I get this crash on start-up, you can see it attempt to call `dlmalloc` which is the allocator I've asked Emscripten to use.
```sh
 at abortOnCannotGrowMemory (index.js:7723:2)
    at _emscripten_resize_heap (index.js:7729:2)
    at imports.<computed> (index.js:8417:14)
    at index.wasm.sbrk (index.wasm:0x3fff)
    at index.wasm.dlmalloc (index.wasm:0x5610)
    at index.wasm.heap.CAllocator.alignedAlloc (index.wasm:0x2d964c)
    at index.wasm.heap.CAllocator.alloc (index.wasm:0x2d8d67)
    at index.wasm.mem.Allocator.allocBytesWithAlignment__anon_15580 (index.wasm:0x5ca659)
    at index.wasm.mem.Allocator.allocWithSizeAndAlignment__anon_15366 (index.wasm:0x51e340)
```
