### PR TITLE
emscripten: fix compilation issues with getSymbolAtAddress and getDwarfInfoForAddress

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -2444,7 +2444,7 @@ pub const ModuleDebugInfo = switch (native_os) {
             return &self.dwarf;
         }
     },
-    .wasi => struct {
+    .wasi, .emscripten => struct {
         pub fn deinit(self: *@This(), allocator: mem.Allocator) void {
             _ = self;
             _ = allocator;


### PR DESCRIPTION
**Description**
This change follows `wasi` and stops trying to use DwarfInfo for emscripten builds

It stops the following compilation error from happening:
```
C:\zig\current\lib\std\debug.zig:726:23: error: no field or member function named 'getDwarfInfoForAddress' in 'dwarf.DwarfInfo'
        if (try module.getDwarfInfoForAddress(unwind_state.debug_info.allocator, unwind_state.dwarf_context.pc)) |di| {
                ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
C:\zig\current\lib\std\dwarf.zig:663:23: note: struct declared here pub const DwarfInfo = struct {
                      ^~~~~~
referenced by:
    next_internal: C:\zig\current\lib\std\debug.zig:737:29
    next: C:\zig\current\lib\std\debug.zig:654:31
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
C:\zig\current\lib\std\debug.zig:970:31: error: no field or member function named 'getSymbolAtAddress' in 'dwarf.DwarfInfo'
    const symbol_info = module.getSymbolAtAddress(debug_info.allocator, address) catch |err| switch (err) {
                        ~~~~~~^~~~~~~~~~~~~~~~~~~
C:\zig\current\lib\std\dwarf.zig:663:23: note: struct declared here pub const DwarfInfo = struct {
```

However it's worth noting that after this change is applied, a runtime error occurs when checking if memory is valid, the call to `msync` gets an `INVAL` error code. (For my local copy, line 4708 mapped to `.INVAL => unreachable`).

I'm investigating to see if I can perhaps find a better / alternative function for Emscripten to check if the memory is valid but I haven't come across anything yet.

```
Uncaught RuntimeError: unreachable
    at map-editor.wasm.os.abort (os.zig:746:54)
    at map-editor.wasm.debug.panicImpl (debug.zig:501:13)
    at map-editor.wasm.builtin.default_panic (builtin.zig:844:32)
    at map-editor.wasm.os.msync (os.zig:4708:19)
    at map-editor.wasm.debug.StackIterator.isValidMemory (debug.zig:692:21)
    at map-editor.wasm.debug.StackIterator.next_internal (debug.zig:758:77)
    at map-editor.wasm.debug.StackIterator.next (debug.zig:650:41)
    at map-editor.wasm.debug.captureStackTrace (debug.zig:356:29)
    at map-editor.wasm.heap.general_purpose_allocator.GeneralPurposeAllocator(.{.stack_trace_frames = 6, .enable_memory_limit = true, .safety = true, .thread_safe = false, .MutexType = null, .never_unmap = false, .retain_metadata = false, .verbose_log = false}).collectStackTrace (http://localhost:6931/map-editor.wasm)
    at map-editor.wasm.heap.general_purpose_allocator.GeneralPurposeAllocator(.{.stack_trace_frames = 6, .enable_memory_limit = true, .safety = true, .thread_safe = false, .MutexType = null, .never_unmap = false, .retain_metadata = false, .verbose_log = false}).BucketHeader.captureStackTrace (http://localhost:6931/map-editor.wasm)
```