### PR TITLE
macos: re-enable vector tests for @split, @abs

### DIFF
--- a/test/behavior/abs.zig
+++ b/test/behavior/abs.zig
@@ -283,11 +283,6 @@ test "@abs float vectors" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
-    // https://github.com/ziglang/zig/issues/12827
-    if (builtin.zig_backend == .stage2_llvm and
-        builtin.os.tag == .macos and
-        builtin.target.cpu.arch == .x86_64) return error.SkipZigTest;
-
     @setEvalBranchQuota(2000);
     try comptime testAbsFloatVectors(f16, 1);
     try testAbsFloatVectors(f16, 1);

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -327,13 +327,6 @@ test "vector @splat" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
-    if (builtin.zig_backend == .stage2_llvm and
-        builtin.os.tag == .macos)
-    {
-        // LLVM 15 regression: https://github.com/ziglang/zig/issues/12827
-        return error.SkipZigTest;
-    }
-
     const S = struct {
         fn testForT(comptime N: comptime_int, v: anytype) !void {
             const T = @TypeOf(v);


### PR DESCRIPTION
- originally disabled per llvm 15 regression manifesting on macos x86_64

closes #12827