### PR TITLE
std: map NETNAME_DELETED to error.ConnectionResetByPeer

### DIFF
--- a/lib/std/http/test.zig
+++ b/lib/std/http/test.zig
@@ -142,6 +142,17 @@ test "HTTP server handles a chunked transfer coding request" {
     const stream = try std.net.tcpConnectToHost(gpa, "127.0.0.1", test_server.port());
     defer stream.close();
     try stream.writeAll(request_bytes);
+
+    const response = try stream.reader().readAllAlloc(gpa, 100);
+    defer gpa.free(response);
+
+    const expected_response =
+        "HTTP/1.1 200 OK\r\n" ++
+        "content-length: 21\r\n" ++
+        "content-type: text/plain\r\n" ++
+        "\r\n" ++
+        "message from server!\n";
+    try expectEqualStrings(expected_response, response);
 }
 
 test "echo content server" {

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -836,9 +836,6 @@ pub const ReadError = error{
     NotOpenForReading,
     SocketNotConnected,
 
-    // Windows only
-    NetNameDeleted,
-
     /// This error occurs when no global event loop is configured,
     /// and reading from the file descriptor would block.
     WouldBlock,

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -1103,7 +1103,6 @@ fn preadMin(file: fs.File, buf: []u8, offset: u64, min_read_len: usize) !usize {
             error.ConnectionResetByPeer => return error.UnableToReadElfFile,
             error.ConnectionTimedOut => return error.UnableToReadElfFile,
             error.SocketNotConnected => return error.UnableToReadElfFile,
-            error.NetNameDeleted => return error.UnableToReadElfFile,
             error.Unexpected => return error.Unexpected,
             error.InputOutput => return error.FileSystem,
             error.AccessDenied => return error.Unexpected,


### PR DESCRIPTION
Technically breaking since it removes NetNameDeleted from `std.os.read`. This error is now folded into ConnectionResetByPeer.

Fixes the CI failure observed in master branch:

```
test
+- test-std
   +- run test std-x86_64-windows.win10_fe...win10_fe-gnu-znver3-Debug stderr
error.Unexpected: GetLastError(64): The specified network name is no longer available.

D:\a\zig\zig\lib\std\os\windows.zig:539:49: 0x1080157 in WriteFile (test.exe.obj)
            else => |err| return unexpectedError(err),
                                                ^
D:\a\zig\zig\lib\std\os.zig:1265:33: 0x10956ce in write (test.exe.obj)
        return windows.WriteFile(fd, bytes, null);
                                ^
D:\a\zig\zig\lib\std\os.zig:1349:21: 0x15b050f in writev (test.exe.obj)
        return write(fd, first.iov_base[0..first.iov_len]);
                    ^
D:\a\zig\zig\lib\std\net.zig:1876:25: 0x18e9d93 in writev (test.exe.obj)
        return os.writev(self.handle, iovecs);
                        ^
D:\a\zig\zig\lib\std\net.zig:1888:38: 0x1b17bd5 in writevAll (test.exe.obj)
            var amt = try self.writev(iovecs[i..]);
                                     ^
D:\a\zig\zig\lib\std\http\Server.zig:435:55: 0x1999a6e in respond (test.exe.obj)
        try request.server.connection.stream.writevAll(iovecs[0..iovecs_len]);
                                                      ^
D:\a\zig\zig\lib\std\http\test.zig:117:32: 0x19979d8 in run (test.exe.obj)
            try request.respond("message from server!\n", .{
                               ^
D:\a\zig\zig\lib\std\Thread.zig:432:13: 0x1736088 in callFn__anon_213626 (test.exe.obj)
            @call(.auto, f, args) catch |err| {
            ^
D:\a\zig\zig\lib\std\Thread.zig:523:30: 0x15e26ce in entryFn (test.exe.obj)
                return callFn(f, self.fn_args);
                             ^
???:?:?: 0x7fff18434caf in ??? (KERNEL32.DLL)
???:?:?: 0x7fff195ee8aa in ??? (ntdll.dll)
error: Unexpected
D:\a\zig\zig\lib\std\os\windows.zig:2543:5: 0xc122d7 in unexpectedError (test.exe.obj)
    return error.Unexpected;
    ^
D:\a\zig\zig\lib\std\os\windows.zig:539:27: 0x1080167 in WriteFile (test.exe.obj)
            else => |err| return unexpectedError(err),
                          ^
D:\a\zig\zig\lib\std\os.zig:1265:9: 0x1095728 in write (test.exe.obj)
        return windows.WriteFile(fd, bytes, null);
        ^
D:\a\zig\zig\lib\std\os.zig:1349:9: 0x15b0550 in writev (test.exe.obj)
        return write(fd, first.iov_base[0..first.iov_len]);
        ^
D:\a\zig\zig\lib\std\net.zig:1876:9: 0x18e9dc0 in writev (test.exe.obj)
        return os.writev(self.handle, iovecs);
        ^
D:\a\zig\zig\lib\std\net.zig:1888:23: 0x1b17c04 in writevAll (test.exe.obj)
            var amt = try self.writev(iovecs[i..]);
                      ^
D:\a\zig\zig\lib\std\http\Server.zig:435:9: 0x1999a9b in respond (test.exe.obj)
        try request.server.connection.stream.writevAll(iovecs[0..iovecs_len]);
        ^
D:\a\zig\zig\lib\std\http\test.zig:117:13: 0x19979f7 in run (test.exe.obj)
            try request.respond("message from server!\n", .{
            ^
test
+- test-std
   +- run test std-x86_64-windows.win8_1...win10_fe-gnu-x86_64-Debug-libc stderr
error.Unexpected: GetLastError(64): The specified network name is no longer available.

D:\a\zig\zig\lib\std\os\windows.zig:539:49: 0x1083e49 in WriteFile (test.exe.obj)
            else => |err| return unexpectedError(err),
                                                ^
D:\a\zig\zig\lib\std\os.zig:1265:33: 0x11d8210 in write (test.exe.obj)
        return windows.WriteFile(fd, bytes, null);
                                ^
D:\a\zig\zig\lib\std\os.zig:1349:21: 0x176a013 in writev (test.exe.obj)
        return write(fd, first.iov_base[0..first.iov_len]);
                    ^
D:\a\zig\zig\lib\std\net.zig:1876:25: 0x1b2d154 in writev (test.exe.obj)
        return os.writev(self.handle, iovecs);
                        ^
D:\a\zig\zig\lib\std\net.zig:1888:38: 0x1d80c37 in writevAll (test.exe.obj)
            var amt = try self.writev(iovecs[i..]);
                                     ^
D:\a\zig\zig\lib\std\http\Server.zig:435:55: 0x1bdee00 in respond (test.exe.obj)
        try request.server.connection.stream.writevAll(iovecs[0..iovecs_len]);
                                                      ^
D:\a\zig\zig\lib\std\http\test.zig:117:32: 0x1bdcd74 in run (test.exe.obj)
            try request.respond("message from server!\n", .{
                               ^
D:\a\zig\zig\lib\std\Thread.zig:432:13: 0x19312d9 in callFn__anon_220320 (test.exe.obj)
            @call(.auto, f, args) catch |err| {
            ^
D:\a\zig\zig\lib\std\Thread.zig:523:30: 0x17a146f in entryFn (test.exe.obj)
                return callFn(f, self.fn_args);
                             ^
???:?:?: 0x7fff18434caf in ??? (KERNEL32.DLL)
???:?:?: 0x7fff195ee8aa in ??? (ntdll.dll)
error: Unexpected
D:\a\zig\zig\lib\std\os\windows.zig:2543:5: 0xb3f229 in unexpectedError (test.exe.obj)
    return error.Unexpected;
    ^
D:\a\zig\zig\lib\std\os\windows.zig:539:27: 0x1083e59 in WriteFile (test.exe.obj)
            else => |err| return unexpectedError(err),
                          ^
D:\a\zig\zig\lib\std\os.zig:1265:9: 0x11d829a in write (test.exe.obj)
        return windows.WriteFile(fd, bytes, null);
        ^
D:\a\zig\zig\lib\std\os.zig:1349:9: 0x176a06c in writev (test.exe.obj)
        return write(fd, first.iov_base[0..first.iov_len]);
        ^
D:\a\zig\zig\lib\std\net.zig:1876:9: 0x1b2d199 in writev (test.exe.obj)
        return os.writev(self.handle, iovecs);
        ^
D:\a\zig\zig\lib\std\net.zig:1888:23: 0x1d80c66 in writevAll (test.exe.obj)
            var amt = try self.writev(iovecs[i..]);
                      ^
D:\a\zig\zig\lib\std\http\Server.zig:435:9: 0x1bdee27 in respond (test.exe.obj)
        try request.server.connection.stream.writevAll(iovecs[0..iovecs_len]);
        ^
D:\a\zig\zig\lib\std\http\test.zig:117:13: 0x1bdcd93 in run (test.exe.obj)
            try request.respond("message from server!\n", .{
            ^
test
+- test-std
   +- run test std-x86_64-windows.win10_fe...win10_fe-gnu-znver3-Debug-libc stderr
error.Unexpected: GetLastError(64): The specified network name is no longer available.

D:\a\zig\zig\lib\std\os\windows.zig:539:49: 0x116bc49 in WriteFile (test.exe.obj)
            else => |err| return unexpectedError(err),
                                                ^
D:\a\zig\zig\lib\std\os.zig:1265:33: 0x12b7910 in write (test.exe.obj)
        return windows.WriteFile(fd, bytes, null);
                                ^
D:\a\zig\zig\lib\std\os.zig:1349:21: 0x1756383 in writev (test.exe.obj)
        return write(fd, first.iov_base[0..first.iov_len]);
                    ^
D:\a\zig\zig\lib\std\net.zig:1876:25: 0x1b078b4 in writev (test.exe.obj)
        return os.writev(self.handle, iovecs);
                        ^
D:\a\zig\zig\lib\std\net.zig:1888:38: 0x1d5b8a7 in writevAll (test.exe.obj)
            var amt = try self.writev(iovecs[i..]);
                                     ^
D:\a\zig\zig\lib\std\http\Server.zig:435:55: 0x1bb9314 in respond (test.exe.obj)
        try request.server.connection.stream.writevAll(iovecs[0..iovecs_len]);
                                                      ^
D:\a\zig\zig\lib\std\http\test.zig:117:32: 0x1bb6f73 in run (test.exe.obj)
            try request.respond("message from server!\n", .{
                               ^
D:\a\zig\zig\lib\std\Thread.zig:432:13: 0x190e3a9 in callFn__anon_213591 (test.exe.obj)
            @call(.auto, f, args) catch |err| {
            ^
D:\a\zig\zig\lib\std\Thread.zig:523:30: 0x178de1f in entryFn (test.exe.obj)
                return callFn(f, self.fn_args);
                             ^
???:?:?: 0x7fff18434caf in ??? (KERNEL32.DLL)
???:?:?: 0x7fff195ee8aa in ??? (ntdll.dll)
error: Unexpected
D:\a\zig\zig\lib\std\os\windows.zig:2543:5: 0xc1f609 in unexpectedError (test.exe.obj)
    return error.Unexpected;
    ^
D:\a\zig\zig\lib\std\os\windows.zig:539:27: 0x116bc59 in WriteFile (test.exe.obj)
            else => |err| return unexpectedError(err),
                          ^
D:\a\zig\zig\lib\std\os.zig:1265:9: 0x12b799a in write (test.exe.obj)
        return windows.WriteFile(fd, bytes, null);
        ^
D:\a\zig\zig\lib\std\os.zig:1349:9: 0x17563dc in writev (test.exe.obj)
        return write(fd, first.iov_base[0..first.iov_len]);
        ^
D:\a\zig\zig\lib\std\net.zig:1876:9: 0x1b078f9 in writev (test.exe.obj)
        return os.writev(self.handle, iovecs);
        ^
D:\a\zig\zig\lib\std\net.zig:1888:23: 0x1d5b8d6 in writevAll (test.exe.obj)
            var amt = try self.writev(iovecs[i..]);
                      ^
D:\a\zig\zig\lib\std\http\Server.zig:435:9: 0x1bb9341 in respond (test.exe.obj)
        try request.server.connection.stream.writevAll(iovecs[0..iovecs_len]);
        ^
D:\a\zig\zig\lib\std\http\test.zig:117:13: 0x1bb6f92 in run (test.exe.obj)
            try request.respond("message from server!\n", .{
            ^
test
+- test-std
   +- run test std-x86_64-windows.win8_1...win10_fe-msvc-x86_64-Debug stderr
error.Unexpected: GetLastError(64): The specified network name is no longer available.

D:\a\zig\zig\lib\std\os\windows.zig:539:49: 0xbcb516 in WriteFile (test.exe.obj)
            else => |err| return unexpectedError(err),
                                                ^
D:\a\zig\zig\lib\std\os.zig:1265:33: 0xbdfa4e in write (test.exe.obj)
        return windows.WriteFile(fd, bytes, null);
                                ^
D:\a\zig\zig\lib\std\os.zig:1349:21: 0x11c6bdf in writev (test.exe.obj)
        return write(fd, first.iov_base[0..first.iov_len]);
                    ^
D:\a\zig\zig\lib\std\net.zig:1876:25: 0x14b7f53 in writev (test.exe.obj)
        return os.writev(self.handle, iovecs);
                        ^
D:\a\zig\zig\lib\std\net.zig:1888:38: 0x168ade5 in writevAll (test.exe.obj)
            var amt = try self.writev(iovecs[i..]);
                                     ^
D:\a\zig\zig\lib\std\http\Server.zig:435:55: 0x156774c in respond (test.exe.obj)
        try request.server.connection.stream.writevAll(iovecs[0..iovecs_len]);
                                                      ^
D:\a\zig\zig\lib\std\http\test.zig:117:32: 0x1565ae6 in run (test.exe.obj)
            try request.respond("message from server!\n", .{
                               ^
D:\a\zig\zig\lib\std\Thread.zig:432:13: 0x1346ab8 in callFn__anon_220355 (test.exe.obj)
            @call(.auto, f, args) catch |err| {
            ^
D:\a\zig\zig\lib\std\Thread.zig:523:30: 0x11f811e in entryFn (test.exe.obj)
                return callFn(f, self.fn_args);
                             ^
???:?:?: 0x7fff18434caf in ??? (KERNEL32.DLL)
???:?:?: 0x7fff195ee8aa in ??? (ntdll.dll)
error: Unexpected
D:\a\zig\zig\lib\std\os\windows.zig:2543:5: 0x771382 in unexpectedError (test.exe.obj)
    return error.Unexpected;
    ^
D:\a\zig\zig\lib\std\os\windows.zig:539:27: 0xbcb523 in WriteFile (test.exe.obj)
            else => |err| return unexpectedError(err),
                          ^
D:\a\zig\zig\lib\std\os.zig:1265:9: 0xbdfaa8 in write (test.exe.obj)
        return windows.WriteFile(fd, bytes, null);
        ^
D:\a\zig\zig\lib\std\os.zig:1349:9: 0x11c6c20 in writev (test.exe.obj)
        return write(fd, first.iov_base[0..first.iov_len]);
        ^
D:\a\zig\zig\lib\std\net.zig:1876:9: 0x14b7f80 in writev (test.exe.obj)
        return os.writev(self.handle, iovecs);
        ^
D:\a\zig\zig\lib\std\net.zig:1888:23: 0x168ae14 in writevAll (test.exe.obj)
            var amt = try self.writev(iovecs[i..]);
                      ^
D:\a\zig\zig\lib\std\http\Server.zig:435:9: 0x1567773 in respond (test.exe.obj)
        try request.server.connection.stream.writevAll(iovecs[0..iovecs_len]);
        ^
D:\a\zig\zig\lib\std\http\test.zig:117:13: 0x1565b05 in run (test.exe.obj)
            try request.respond("message from server!\n", .{
            ^
test
+- test-cli
   +- RemoveDir D:\a\zig\zig\zig-cache\tmp\48fb0fb2a7ef033a
      +- zig build run failure
error: 
========= expected this stdout: =========
Run `zig build test` to run the tests.

========= but found: ====================

========= from the following command: ===
cd D:\a\zig\zig\zig-cache\tmp\48fb0fb2a7ef033a && D:\a\zig\zig\build-release\stage3-release\bin\zig.exe build run 
Build Summary: 5304/5508 steps succeeded; 200 skipped; 1 failed; 40834/43127 tests passed; 2293 skipped (disable with --summary none)
test transitive failure
+- test-cli transitive failure
   +- RemoveDir D:\a\zig\zig\zig-cache\tmp\48fb0fb2a7ef033a transitive failure
      +- zig build run failure
error: the following build command failed with exit code 1:
D:\a\zig\zig\zig-cache\o\a1dd0375adc7fb99c99218e000c9c89c\build.exe D:\a\zig\zig\build-release\stage3-release\bin\zig.exe D:\a\zig\zig D:\a\zig\zig\zig-cache C:\Users\runneradmin\AppData\Local\zig --seed 0xcfb277f2 -Z8ae0eaa3fb89902f test docs --zig-lib-dir D:\a\zig\zig\lib --search-prefix D:\a\zig\zig\zig+llvm+lld+clang-x86_64-windows-gnu-0.12.0-dev.2073+402fe565a -Dstatic-llvm -Dskip-non-native -Denable-symlinks-windows
```