### PR TITLE
Revert "tests: add -Dskip-cross-glibc option"

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -101,7 +101,6 @@ pub fn build(b: *std.Build) !void {
     const skip_release_fast = b.option(bool, "skip-release-fast", "Main test suite skips release-fast builds") orelse skip_release;
     const skip_release_safe = b.option(bool, "skip-release-safe", "Main test suite skips release-safe builds") orelse skip_release;
     const skip_non_native = b.option(bool, "skip-non-native", "Main test suite skips non-native builds") orelse false;
-    const skip_cross_glibc = b.option(bool, "skip-cross-glibc", "Main test suite skips builds that require cross glibc") orelse false;
     const skip_libc = b.option(bool, "skip-libc", "Main test suite skips tests that link libc") orelse false;
     const skip_single_threaded = b.option(bool, "skip-single-threaded", "Main test suite skips tests that are single-threaded") orelse false;
     const skip_run_translated_c = b.option(bool, "skip-run-translated-c", "Main test suite skips run-translated-c tests") orelse false;
@@ -400,7 +399,6 @@ pub fn build(b: *std.Build) !void {
     test_cases_options.addOption(bool, "enable_logging", enable_logging);
     test_cases_options.addOption(bool, "enable_link_snapshots", enable_link_snapshots);
     test_cases_options.addOption(bool, "skip_non_native", skip_non_native);
-    test_cases_options.addOption(bool, "skip_cross_glibc", skip_cross_glibc);
     test_cases_options.addOption(bool, "have_llvm", enable_llvm);
     test_cases_options.addOption(bool, "llvm_has_m68k", llvm_has_m68k);
     test_cases_options.addOption(bool, "llvm_has_csky", llvm_has_csky);
@@ -474,7 +472,6 @@ pub fn build(b: *std.Build) !void {
         .include_paths = &.{},
         .skip_single_threaded = skip_single_threaded,
         .skip_non_native = skip_non_native,
-        .skip_cross_glibc = skip_cross_glibc,
         .skip_libc = skip_libc,
         .max_rss = 1 * 1024 * 1024 * 1024,
     }));
@@ -488,7 +485,6 @@ pub fn build(b: *std.Build) !void {
         .include_paths = &.{"test/c_import"},
         .skip_single_threaded = true,
         .skip_non_native = skip_non_native,
-        .skip_cross_glibc = skip_cross_glibc,
         .skip_libc = skip_libc,
     }));
 
@@ -501,7 +497,6 @@ pub fn build(b: *std.Build) !void {
         .include_paths = &.{},
         .skip_single_threaded = true,
         .skip_non_native = skip_non_native,
-        .skip_cross_glibc = skip_cross_glibc,
         .skip_libc = true,
     }));
 
@@ -514,7 +509,6 @@ pub fn build(b: *std.Build) !void {
         .include_paths = &.{},
         .skip_single_threaded = true,
         .skip_non_native = skip_non_native,
-        .skip_cross_glibc = skip_cross_glibc,
         .skip_libc = true,
     }));
 
@@ -546,7 +540,6 @@ pub fn build(b: *std.Build) !void {
         .include_paths = &.{},
         .skip_single_threaded = skip_single_threaded,
         .skip_non_native = skip_non_native,
-        .skip_cross_glibc = skip_cross_glibc,
         .skip_libc = skip_libc,
         // I observed a value of 4572626944 on the M2 CI.
         .max_rss = 5029889638,

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1040,7 +1040,6 @@ const ModuleTestOptions = struct {
     include_paths: []const []const u8,
     skip_single_threaded: bool,
     skip_non_native: bool,
-    skip_cross_glibc: bool,
     skip_libc: bool,
     max_rss: usize = 0,
 };
@@ -1058,10 +1057,6 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
 
         const resolved_target = b.resolveTargetQuery(test_target.target);
         const target = resolved_target.result;
-
-        if (options.skip_cross_glibc and !test_target.target.isNative() and
-            target.isGnuLibC() and test_target.link_libc == true)
-            continue;
 
         if (options.skip_libc and test_target.link_libc == true)
             continue;


### PR DESCRIPTION
This was added as a workaround for a bug that has since been fixed.