### PR TITLE
emscripten: fix crash when calling StackIterator.isValidMemory with emscripten

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -688,7 +688,7 @@ pub const StackIterator = struct {
             }
 
             return true;
-        } else if (@hasDecl(os.system, "msync") and native_os != .wasi) {
+        } else if (@hasDecl(os.system, "msync") and native_os != .wasi and native_os != .emscripten) {
             os.msync(aligned_memory, os.MSF.ASYNC) catch |err| {
                 switch (err) {
                     os.MSyncError.UnmappedMemory => {


### PR DESCRIPTION
**Description**

Following the pattern with Wasi for the time-being and considering the memory valid.

**Crash that can occur without this change**

![image](https://github.com/ziglang/zig/assets/3859574/20df7bec-e5a1-4a6c-8d47-528445f9dbbf)

**Potential future improvement**

*Please note: I'm very new to Emscripten / C-isms in general, so if anything I say below doesn't make sense, then it probably doesn't.*

Emscripten provides functions that give you the stacks range in memory here, if StackIterator is only iterating over stack addresses, we could valid the range with these:
https://github.com/emscripten-core/emscripten/blob/5441b40acb9a751ae03b61fd1c85949971826b64/system/include/emscripten/stack.h

Also it's my understanding that we could see if dynamic heap allocations are out of bounds by making sure they're below the sbrk value (I only just became aware of what sbrk is yesterday, so might be wrong here):
https://github.com/emscripten-core/emscripten/blob/5441b40acb9a751ae03b61fd1c85949971826b64/system/include/emscripten/heap.h

Finally it's worth noting that `emscripten_get_heap_size` gets the current total heap size (initial memory), not consumed memory, ie.
https://github.com/emscripten-core/emscripten/blob/5441b40acb9a751ae03b61fd1c85949971826b64/system/lib/libc/emscripten_get_heap_size.c#L11-L13