### PR TITLE
std.heap.raw_c_allocator: use malloc_size for resize

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -196,7 +196,16 @@ fn rawCResize(
 ) bool {
     _ = log2_old_align;
     _ = ret_addr;
-    return new_len <= buf.len;
+
+    if (new_len <= buf.len)
+        return true;
+
+    if (CAllocator.supports_malloc_size) {
+        const full_len = CAllocator.malloc_size(buf.ptr);
+        if (new_len <= full_len) return true;
+    }
+
+    return false;
 }
 
 fn rawCFree(


### PR DESCRIPTION
std.heap.c_allocator was already doing this, however, std.heap.raw_c_allocator, which asserts no allocations more than 16 bytes aligned, was not.

The zig compiler uses std.heap.raw_c_allocator, so it is affected by this.

Using this example program:

```zig
const std = @import("std");

pub fn main() !void {
    const gpa = std.heap.raw_c_allocator;
    //var general_purpose_allocator: std.heap.GeneralPurposeAllocator(.{}) = .{};
    //const gpa = general_purpose_allocator.allocator();

    const stdout = std.io.getStdOut().writer();
    var slice = try gpa.alloc(u8, 1);
    for (2..100000) |i| {
        if (gpa.resize(slice, i)) {
            slice = slice.ptr[0..i];
            try stdout.print("{d} - resized\n", .{i});
        } else {
            try stdout.print("{d} - reallocated\n", .{i});
            const new_slice = try gpa.alloc(u8, i);
            gpa.free(slice);
            slice = new_slice;
        }
    }
}
```

Before this, you would observe `zig run grow.zig -lc` to print "reallocated" for all iterations. After this change it looks more like this:

```
99967 - resized
99968 - resized
99969 - resized
99970 - resized
99971 - resized
99972 - resized
99973 - resized
99974 - resized
99975 - resized
99976 - resized
99977 - reallocated
99978 - resized
99979 - resized
99980 - resized
99981 - resized
99982 - resized
99983 - resized
99984 - resized
99985 - resized
99986 - resized
99987 - resized
99988 - resized
99989 - resized
99990 - resized
99991 - resized
99992 - resized
99993 - reallocated
99994 - resized
99995 - resized
99996 - resized
99997 - resized
99998 - resized
99999 - resized
```

Since ArrayList already does superlinear growth, I expect this change to be almost meaningless. However it may perform better for small lists, since apparently glibc malloc allocation can grow up to 25 bytes:

```
2 - resized
3 - resized
4 - resized
5 - resized
6 - resized
7 - resized
8 - resized
9 - resized
10 - resized
11 - resized
12 - resized
13 - resized
14 - resized
15 - resized
16 - resized
17 - resized
18 - resized
19 - resized
20 - resized
21 - resized
22 - resized
23 - resized
24 - resized
25 - reallocated
```

On the other hand, looks like musl libc never reports growable memory. :shrug: 