### PR TITLE
package management: fix regression of printing expected hash

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -402,7 +402,7 @@ pub fn run(f: *Fetch) RunError!void {
                 return error.FetchFailed;
             },
         }
-    } else {
+    } else if (f.job_queue.read_only) {
         try eb.addRootErrorMessage(.{
             .msg = try eb.addString("dependency is missing hash field"),
             .src_loc = try f.srcLoc(f.location_tok),


### PR DESCRIPTION
Regressed in ed4ccea7bae99c1baa634716941f308d9f922985. The early exit path was only supposed to happen in case of --system mode.