### PR TITLE
fix large f128 values being incorrectly parsed as inf

### DIFF
--- a/lib/std/fmt/parse_float.zig
+++ b/lib/std/fmt/parse_float.zig
@@ -78,6 +78,13 @@ test "fmt.parseFloat nan and inf" {
     }
 }
 
+test "fmt.parseFloat largest normals" {
+    try expectEqual(@as(u16, @bitCast(try parseFloat(f16, "65504"))), 0x7bff);
+    try expectEqual(@as(u32, @bitCast(try parseFloat(f32, "3.4028234664E38"))), 0x7f7f_ffff);
+    try expectEqual(@as(u64, @bitCast(try parseFloat(f64, "1.7976931348623157E308"))), 0x7fef_ffff_ffff_ffff);
+    try expectEqual(@as(u128, @bitCast(try parseFloat(f128, "1.1897314953572317650857593266280070162E4932"))), 0x7ffe_ffff_ffff_ffff_ffff_ffff_ffff_ffff);
+}
+
 test "fmt.parseFloat #11169" {
     try expectEqual(try parseFloat(f128, "9007199254740993.0"), 9007199254740993.0);
 }

--- a/lib/std/fmt/parse_float/decimal.zig
+++ b/lib/std/fmt/parse_float/decimal.zig
@@ -63,7 +63,7 @@ pub fn Decimal(comptime T: type) type {
         pub const max_digits_without_overflow = if (MantissaT == u64) 19 else 38;
         pub const decimal_point_range = if (MantissaT == u64) 2047 else 32767;
         pub const min_exponent = if (MantissaT == u64) -324 else -4966;
-        pub const max_exponent = if (MantissaT == u64) 310 else 4933;
+        pub const max_exponent = if (MantissaT == u64) 310 else 4934;
         pub const max_decimal_digits = if (MantissaT == u64) 18 else 37;
 
         /// The number of significant digits in the decimal.


### PR DESCRIPTION
Found while fuzzing. Previously `1.1897314953572317650857593266280070162E4932` was parsed as `+inf`, which caused issues for round-trip serialization of floats. Only f128 had issues, but have added other tests for all floating point large normals.

The max_exponent for f128 was wrong, it is subtly different in the decimal code-path as it is based on where the decimal digit should go. This needs to be 2 greater than the max exponent (e.g. 308 or 4932) to work correctly (greater by 1, then we use a >= comparision).

In addition, I've removed the redundant `optimize` constant which was only use for testing the slow path locally.