### PR TITLE
std.http.Server: fix use case of streaming both reading and writing

### DIFF
--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -716,10 +716,14 @@ pub const Request = struct {
             },
             .receiving_body, .ready => return true,
             else => unreachable,
-        } else {
-            s.state = .closing;
-            return false;
+        };
+
+        // Avoid clobbering the state in case a reading stream already exists.
+        switch (s.state) {
+            .received_head => s.state = .closing,
+            else => {},
         }
+        return false;
     }
 };
 


### PR DESCRIPTION
Previously this would trip an assertion failure:

```
Test [41/58] http.test.test.stream read/write... thread 220203 panic: reached unreachable code
/home/andy/dev/zig/lib/std/debug.zig:403:14: 0x147c10d in assert (test)
    if (!ok) unreachable; // assertion failure
             ^
/home/andy/dev/zig/lib/std/http/Server.zig:587:27: 0x16a14c8 in read_chunked (test)
                    assert(s.state == .receiving_body);
                          ^
/home/andy/dev/zig/lib/std/io/Reader.zig:10:23: 0x150bdcb in read (test)
    return self.readFn(self.context, buffer);
                      ^
/home/andy/dev/zig/lib/std/http/test.zig:910:42: 0x156a921 in run (test)
                const n = try reader.read(&buf);
                                         ^
/home/andy/dev/zig/lib/std/Thread.zig:427:13: 0x155466a in callFn__anon_22868 (test)
            @call(.auto, f, args) catch |err| {
            ^
/home/andy/dev/zig/lib/std/Thread.zig:1199:30: 0x1525bd7 in entryFn (test)
                return callFn(f, self.fn_args);
                             ^
/home/andy/dev/zig/lib/c.zig:239:13: 0x1905f70 in clone (c)
            asm volatile (
            ^
```