### PR TITLE
package: allow setting tar_strip_components

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -867,9 +867,9 @@ const FileType = enum {
         try std.testing.expectEqual(@as(?FileType, .@"tar.xz"), fromContentDisposition("ATTACHMENT; filename=\"stuff.tar.xz\""));
         try std.testing.expectEqual(@as(?FileType, .@"tar.xz"), fromContentDisposition("attachment; FileName=\"stuff.tar.xz\""));
         try std.testing.expectEqual(@as(?FileType, .@"tar.gz"), fromContentDisposition("attachment; FileName*=UTF-8\'\'xyz%2Fstuff.tar.gz"));
+        try std.testing.expectEqual(@as(?FileType, .tar), fromContentDisposition("attachment; FileName=\"stuff.tar\""));
 
         try std.testing.expect(fromContentDisposition("attachment FileName=\"stuff.tar.gz\"") == null);
-        try std.testing.expect(fromContentDisposition("attachment; FileName=\"stuff.tar\"") == null);
         try std.testing.expect(fromContentDisposition("attachment; FileName\"stuff.gz\"") == null);
         try std.testing.expect(fromContentDisposition("attachment; size=42") == null);
         try std.testing.expect(fromContentDisposition("inline; size=42") == null);


### PR DESCRIPTION
in build.zig.zon.

That allows us to unpack tars which don't have leading root folder. Like
examples from #17779.

Trying to fetch
`https://chromium.googlesource.com/chromium/tools/depot_tools.git/+archive/refs/heads/main.tar.gz`
with default settings results in error. That archive has files in the root:
```
$ tar tvf main.tar | head
-rw-r--r-- 0/0            3848 2024-02-26 12:21 .cipd_impl.ps1
-rw-r--r-- 0/0              31 2024-02-26 12:21 .flake8
-rw-r--r-- 0/0            1682 2024-02-26 12:21 .gitattributes
-rw-r--r-- 0/0            2040 2024-02-26 12:21 .gitignore
-rw-r--r-- 0/0             857 2024-02-26 12:21 .isort.cfg
-rw-r--r-- 0/0              48 2024-02-26 12:21 .style.yapf
-rw-r--r-- 0/0            1978 2024-02-26 12:21 .vpython
-rw-r--r-- 0/0            2429 2024-02-26 12:21 .vpython3
-rw-r--r-- 0/0             128 2024-02-26 12:21 BUILD_OWNERS
-rw-r--r-- 0/0             156 2024-02-26 12:21 CROS_OWNERS
```

stripping one folder (default) results in empty files names.
Setting tar_strip_components = 0 in build.zig.zon enables fetching such
archives.

```
    .dependencies = .{
        .chromium = .{
            .url = "https://chromium.googlesource.com/chromium/tools/depot_tools.git/+archive/refs/heads/main.tar.gz",
            .hash = "122089fd900653f199701726fe43bf956d9613f2c7ef4e216d363700f5c7df0cb4d8",
            .tar_strip_components = 0,
        },
```

I'm not a fan of adding endless configuration options. Without configuration we can try with strip_components = 1 and if that fail with strip_components = 0, but I can imagine case where first will pass but right is the second. For example if we tar some source without root but it has inside just single src folder and we don't wont that src folder stripped.

In practice tar_strip_components will have only two values 1 (default) or 0. So it is only needed to set it to 0 in rare cases. Instead of int it could be some bool switch tar_dont_strip... But I keep it like this because shell tar has it same way.

Fixes #17779
