### PR TITLE
std.http: fix http field parsing

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -551,6 +551,43 @@ pub const Response = struct {
         return error.HttpHeadersInvalid; // missing empty line
     }
 
+    test parse {
+        const response_bytes = "HTTP/1.1 200 OK\r\n" ++
+            "LOcation:url\r\n" ++
+            "content-tYpe: text/plain\r\n" ++
+            "content-disposition:attachment; filename=example.txt \r\n" ++
+            "content-Length:10\r\n" ++
+            "TRansfer-encoding:\tdeflate, chunked \r\n" ++
+            "connectioN:\t keep-alive \r\n\r\n";
+
+        var header_buffer: [1024]u8 = undefined;
+        var res = Response{
+            .status = undefined,
+            .reason = undefined,
+            .version = undefined,
+            .keep_alive = false,
+            .parser = proto.HeadersParser.init(&header_buffer),
+        };
+
+        @memcpy(header_buffer[0..response_bytes.len], response_bytes);
+        res.parser.header_bytes_len = response_bytes.len;
+
+        try res.parse(response_bytes);
+
+        try testing.expectEqual(.@"HTTP/1.1", res.version);
+        try testing.expectEqualStrings("OK", res.reason);
+        try testing.expectEqual(.ok, res.status);
+
+        try testing.expectEqualStrings("url", res.location.?);
+        try testing.expectEqualStrings("text/plain", res.content_type.?);
+        try testing.expectEqualStrings("attachment; filename=example.txt", res.content_disposition.?);
+
+        try testing.expectEqual(true, res.keep_alive);
+        try testing.expectEqual(10, res.content_length.?);
+        try testing.expectEqual(.chunked, res.transfer_encoding);
+        try testing.expectEqual(.deflate, res.transfer_compression);
+    }
+
     inline fn int64(array: *const [8]u8) u64 {
         return @bitCast(array.*);
     }
@@ -574,6 +611,67 @@ pub const Response = struct {
 
     pub fn iterateHeaders(r: Response) http.HeaderIterator {
         return http.HeaderIterator.init(r.parser.get());
+    }
+
+    test iterateHeaders {
+        const response_bytes = "HTTP/1.1 200 OK\r\n" ++
+            "LOcation:url\r\n" ++
+            "content-tYpe: text/plain\r\n" ++
+            "content-disposition:attachment; filename=example.txt \r\n" ++
+            "content-Length:10\r\n" ++
+            "TRansfer-encoding:\tdeflate, chunked \r\n" ++
+            "connectioN:\t keep-alive \r\n\r\n";
+
+        var header_buffer: [1024]u8 = undefined;
+        var res = Response{
+            .status = undefined,
+            .reason = undefined,
+            .version = undefined,
+            .keep_alive = false,
+            .parser = proto.HeadersParser.init(&header_buffer),
+        };
+
+        @memcpy(header_buffer[0..response_bytes.len], response_bytes);
+        res.parser.header_bytes_len = response_bytes.len;
+
+        var it = res.iterateHeaders();
+        {
+            const header = it.next().?;
+            try testing.expectEqualStrings("LOcation", header.name);
+            try testing.expectEqualStrings("url", header.value);
+            try testing.expect(!it.is_trailer);
+        }
+        {
+            const header = it.next().?;
+            try testing.expectEqualStrings("content-tYpe", header.name);
+            try testing.expectEqualStrings("text/plain", header.value);
+            try testing.expect(!it.is_trailer);
+        }
+        {
+            const header = it.next().?;
+            try testing.expectEqualStrings("content-disposition", header.name);
+            try testing.expectEqualStrings("attachment; filename=example.txt", header.value);
+            try testing.expect(!it.is_trailer);
+        }
+        {
+            const header = it.next().?;
+            try testing.expectEqualStrings("content-Length", header.name);
+            try testing.expectEqualStrings("10", header.value);
+            try testing.expect(!it.is_trailer);
+        }
+        {
+            const header = it.next().?;
+            try testing.expectEqualStrings("TRansfer-encoding", header.name);
+            try testing.expectEqualStrings("deflate, chunked", header.value);
+            try testing.expect(!it.is_trailer);
+        }
+        {
+            const header = it.next().?;
+            try testing.expectEqualStrings("connectioN", header.name);
+            try testing.expectEqualStrings("keep-alive", header.value);
+            try testing.expect(!it.is_trailer);
+        }
+        try testing.expectEqual(null, it.next());
     }
 };
 

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -489,9 +489,9 @@ pub const Response = struct {
                 else => {},
             }
 
-            var line_it = mem.splitSequence(u8, line, ": ");
+            var line_it = mem.splitScalar(u8, line, ':');
             const header_name = line_it.next().?;
-            const header_value = line_it.rest();
+            const header_value = mem.trim(u8, line_it.rest(), " \t");
             if (header_name.len == 0) return error.HttpHeadersInvalid;
 
             if (std.ascii.eqlIgnoreCase(header_name, "connection")) {

--- a/lib/std/http/HeaderIterator.zig
+++ b/lib/std/http/HeaderIterator.zig
@@ -12,26 +12,39 @@ pub fn init(bytes: []const u8) HeaderIterator {
 
 pub fn next(it: *HeaderIterator) ?std.http.Header {
     const end = std.mem.indexOfPosLinear(u8, it.bytes, it.index, "\r\n").?;
-    var kv_it = std.mem.splitSequence(u8, it.bytes[it.index..end], ": ");
-    const name = kv_it.next().?;
-    const value = kv_it.rest();
-    if (name.len == 0 and value.len == 0) {
+    if (it.index == end) { // found the trailer boundary (\r\n\r\n)
         if (it.is_trailer) return null;
+
         const next_end = std.mem.indexOfPosLinear(u8, it.bytes, end + 2, "\r\n") orelse
             return null;
+
+        var kv_it = std.mem.splitScalar(u8, it.bytes[end + 2 .. next_end], ':');
+        const name = kv_it.first();
+        const value = kv_it.rest();
+
         it.is_trailer = true;
         it.index = next_end + 2;
-        kv_it = std.mem.splitSequence(u8, it.bytes[end + 2 .. next_end], ": ");
+        if (name.len == 0)
+            return null;
+
         return .{
-            .name = kv_it.next().?,
-            .value = kv_it.rest(),
+            .name = name,
+            .value = std.mem.trim(u8, value, " \t"),
+        };
+    } else { // normal header
+        var kv_it = std.mem.splitScalar(u8, it.bytes[it.index..end], ':');
+        const name = kv_it.first();
+        const value = kv_it.rest();
+
+        it.index = end + 2;
+        if (name.len == 0)
+            return null;
+
+        return .{
+            .name = name,
+            .value = std.mem.trim(u8, value, " \t"),
         };
     }
-    it.index = end + 2;
-    return .{
-        .name = name,
-        .value = value,
-    };
 }
 
 test next {
@@ -62,7 +75,23 @@ test next {
         try std.testing.expectEqualStrings("g", header.value);
     }
     try std.testing.expectEqual(null, it.next());
+
+    it = HeaderIterator.init("200 OK\r\n: ss\r\n\r\n");
+    try std.testing.expect(!it.is_trailer);
+    try std.testing.expectEqual(null, it.next());
+
+    it = HeaderIterator.init("200 OK\r\na: b\r\n\r\n: ss\r\n\r\n");
+    try std.testing.expect(!it.is_trailer);
+    {
+        const header = it.next().?;
+        try std.testing.expect(!it.is_trailer);
+        try std.testing.expectEqualStrings("a", header.name);
+        try std.testing.expectEqualStrings("b", header.value);
+    }
+    try std.testing.expectEqual(null, it.next());
+    try std.testing.expect(it.is_trailer);
 }
 
 const HeaderIterator = @This();
 const std = @import("../std.zig");
+const assert = std.debug.assert;

--- a/lib/std/http/HeaderIterator.zig
+++ b/lib/std/http/HeaderIterator.zig
@@ -48,7 +48,7 @@ pub fn next(it: *HeaderIterator) ?std.http.Header {
 }
 
 test next {
-    var it = HeaderIterator.init("200 OK\r\na: b\r\nc: \r\nd: e\r\n\r\nf: g\r\n\r\n");
+    var it = HeaderIterator.init("200 OK\r\na: b\r\nc:  \r\nd:e\r\n\r\nf: g\r\n\r\n");
     try std.testing.expect(!it.is_trailer);
     {
         const header = it.next().?;
@@ -80,7 +80,7 @@ test next {
     try std.testing.expect(!it.is_trailer);
     try std.testing.expectEqual(null, it.next());
 
-    it = HeaderIterator.init("200 OK\r\na: b\r\n\r\n: ss\r\n\r\n");
+    it = HeaderIterator.init("200 OK\r\na:b\r\n\r\n: ss\r\n\r\n");
     try std.testing.expect(!it.is_trailer);
     {
         const header = it.next().?;

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -211,9 +211,9 @@ pub const Request = struct {
                     else => {},
                 }
 
-                var line_it = mem.splitSequence(u8, line, ": ");
+                var line_it = mem.splitScalar(u8, line, ':');
                 const header_name = line_it.next().?;
-                const header_value = line_it.rest();
+                const header_value = mem.trim(u8, line_it.rest(), " \t");
                 if (header_name.len == 0) return error.HttpHeadersInvalid;
 
                 if (std.ascii.eqlIgnoreCase(header_name, "connection")) {

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -271,6 +271,29 @@ pub const Request = struct {
             return error.MissingFinalNewline;
         }
 
+        test parse {
+            const request_bytes = "GET /hi HTTP/1.0\r\n" ++
+                "content-tYpe: text/plain\r\n" ++
+                "content-Length:10\r\n" ++
+                "expeCt:   100-continue \r\n" ++
+                "TRansfer-encoding:\tdeflate, chunked \r\n" ++
+                "connectioN:\t keep-alive \r\n\r\n";
+
+            const req = try parse(request_bytes);
+
+            try testing.expectEqual(.GET, req.method);
+            try testing.expectEqual(.@"HTTP/1.0", req.version);
+            try testing.expectEqualStrings("/hi", req.target);
+
+            try testing.expectEqualStrings("text/plain", req.content_type.?);
+            try testing.expectEqualStrings("100-continue", req.expect.?);
+
+            try testing.expectEqual(true, req.keep_alive);
+            try testing.expectEqual(10, req.content_length.?);
+            try testing.expectEqual(.chunked, req.transfer_encoding);
+            try testing.expectEqual(.deflate, req.transfer_compression);
+        }
+
         inline fn int64(array: *const [8]u8) u64 {
             return @bitCast(array.*);
         }
@@ -278,6 +301,66 @@ pub const Request = struct {
 
     pub fn iterateHeaders(r: *Request) http.HeaderIterator {
         return http.HeaderIterator.init(r.server.read_buffer[0..r.head_end]);
+    }
+
+    test iterateHeaders {
+        const request_bytes = "GET /hi HTTP/1.0\r\n" ++
+            "content-tYpe: text/plain\r\n" ++
+            "content-Length:10\r\n" ++
+            "expeCt:   100-continue \r\n" ++
+            "TRansfer-encoding:\tdeflate, chunked \r\n" ++
+            "connectioN:\t keep-alive \r\n\r\n";
+
+        var read_buffer: [500]u8 = undefined;
+        @memcpy(read_buffer[0..request_bytes.len], request_bytes);
+
+        var server: Server = .{
+            .connection = undefined,
+            .state = .ready,
+            .read_buffer = &read_buffer,
+            .read_buffer_len = request_bytes.len,
+            .next_request_start = 0,
+        };
+
+        var request: Request = .{
+            .server = &server,
+            .head_end = request_bytes.len,
+            .head = undefined,
+            .reader_state = undefined,
+        };
+
+        var it = request.iterateHeaders();
+        {
+            const header = it.next().?;
+            try testing.expectEqualStrings("content-tYpe", header.name);
+            try testing.expectEqualStrings("text/plain", header.value);
+            try testing.expect(!it.is_trailer);
+        }
+        {
+            const header = it.next().?;
+            try testing.expectEqualStrings("content-Length", header.name);
+            try testing.expectEqualStrings("10", header.value);
+            try testing.expect(!it.is_trailer);
+        }
+        {
+            const header = it.next().?;
+            try testing.expectEqualStrings("expeCt", header.name);
+            try testing.expectEqualStrings("100-continue", header.value);
+            try testing.expect(!it.is_trailer);
+        }
+        {
+            const header = it.next().?;
+            try testing.expectEqualStrings("TRansfer-encoding", header.name);
+            try testing.expectEqualStrings("deflate, chunked", header.value);
+            try testing.expect(!it.is_trailer);
+        }
+        {
+            const header = it.next().?;
+            try testing.expectEqualStrings("connectioN", header.name);
+            try testing.expectEqualStrings("keep-alive", header.value);
+            try testing.expect(!it.is_trailer);
+        }
+        try testing.expectEqual(null, it.next());
     }
 
     pub const RespondOptions = struct {
@@ -1060,5 +1143,6 @@ const mem = std.mem;
 const net = std.net;
 const Uri = std.Uri;
 const assert = std.debug.assert;
+const testing = std.testing;
 
 const Server = @This();

--- a/lib/std/http/test.zig
+++ b/lib/std/http/test.zig
@@ -328,8 +328,8 @@ test "receiving arbitrary http headers from the client" {
     defer test_server.destroy();
 
     const request_bytes = "GET /bar HTTP/1.1\r\n" ++
-        "CoNneCtIoN: close\r\n" ++
-        "aoeu: asdf\r\n" ++
+        "CoNneCtIoN:close\r\n" ++
+        "aoeu:  asdf \r\n" ++
         "\r\n";
     const gpa = std.testing.allocator;
     const stream = try std.net.tcpConnectToHost(gpa, "127.0.0.1", test_server.port());


### PR DESCRIPTION
HTTP fields are defined as `field-line = field-name ":" OWS field-value OWS`. The whitespace following `:` is optional, and whitespace following the value is optional. This fixes std.http to not assume all headers are sent as `"Field: Value"`.

Additionally fixes up the trailer boundary check in the headers iterator, as checking for CRLF CRLF (the end of head fields) is much more sound than checking that name and value are 0 length. Also adds an assert that name.len is greater than zero.