### PR TITLE
http: fix fetching a github release

### DIFF
--- a/lib/std/Uri.zig
+++ b/lib/std/Uri.zig
@@ -367,7 +367,7 @@ pub const ResolveInplaceError = ParseError || error{OutOfMemory};
 /// If a merge needs to take place, the newly constructed path will be stored
 /// in `aux_buf` just after the copied `new`.
 pub fn resolve_inplace(base: Uri, new: []const u8, aux_buf: []u8) ResolveInplaceError!Uri {
-    std.mem.copyBackwards(u8, aux_buf, new);
+    std.mem.copyForwards(u8, aux_buf, new);
     // At this point, new is an invalid pointer.
     const new_mut = aux_buf[0..new.len];
 


### PR DESCRIPTION
 * Support different keep alive defaults with different http versions.
 * Fix incorrect usage of `copyBackwards`, which copies in a backwards direction allowing data to be moved forward in a buffer, not backwards in a buffer.