### PR TITLE
Eliminate `error.InvalidHandle` from OpenError and RealPathError

### DIFF
--- a/lib/std/child_process.zig
+++ b/lib/std/child_process.zig
@@ -519,7 +519,6 @@ pub const ChildProcess = struct {
                 error.DeviceBusy => unreachable,
                 error.FileLocksNotSupported => unreachable,
                 error.BadPathName => unreachable, // Windows-only
-                error.InvalidHandle => unreachable, // WASI-only
                 error.WouldBlock => unreachable,
                 error.NetworkNotFound => unreachable, // Windows-only
                 else => |e| return e,

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -526,7 +526,6 @@ pub const SelfExePathError = error{
     PipeBusy,
     NotLink,
     PathAlreadyExists,
-    InvalidHandle,
 
     /// On Windows, `\\server` or `\\server\share` was not found.
     NetworkNotFound,

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -742,7 +742,6 @@ pub fn walk(self: Dir, allocator: Allocator) !Walker {
 pub const OpenError = error{
     FileNotFound,
     NotDir,
-    InvalidHandle,
     AccessDenied,
     SymLinkLoop,
     ProcessFdQuotaExceeded,
@@ -1847,7 +1846,6 @@ pub fn readFileAllocOptions(
 }
 
 pub const DeleteTreeError = error{
-    InvalidHandle,
     AccessDenied,
     FileTooBig,
     SymLinkLoop,
@@ -1930,7 +1928,6 @@ pub fn deleteTree(self: Dir, sub_path: []const u8) DeleteTreeError!void {
                                 break :handle_entry;
                             },
 
-                            error.InvalidHandle,
                             error.AccessDenied,
                             error.SymLinkLoop,
                             error.ProcessFdQuotaExceeded,
@@ -2026,7 +2023,6 @@ pub fn deleteTree(self: Dir, sub_path: []const u8) DeleteTreeError!void {
                                 continue :process_stack;
                             },
 
-                            error.InvalidHandle,
                             error.AccessDenied,
                             error.SymLinkLoop,
                             error.ProcessFdQuotaExceeded,
@@ -2132,7 +2128,6 @@ fn deleteTreeMinStackSizeWithKindHint(self: Dir, sub_path: []const u8, kind_hint
                                 continue :dir_it;
                             },
 
-                            error.InvalidHandle,
                             error.AccessDenied,
                             error.SymLinkLoop,
                             error.ProcessFdQuotaExceeded,
@@ -2231,7 +2226,6 @@ fn deleteTreeOpenInitialSubpath(self: Dir, sub_path: []const u8, kind_hint: File
                         return null;
                     },
 
-                    error.InvalidHandle,
                     error.AccessDenied,
                     error.SymLinkLoop,
                     error.ProcessFdQuotaExceeded,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -1573,9 +1573,6 @@ pub fn pwritev(fd: fd_t, iov: []const iovec_const, offset: u64) PWriteError!usiz
 }
 
 pub const OpenError = error{
-    /// In WASI, this error may occur when the provided file handle is invalid.
-    InvalidHandle,
-
     /// In WASI, this error may occur when the file descriptor does
     /// not hold the required rights to open a new resource relative to it.
     AccessDenied,
@@ -5543,9 +5540,6 @@ pub const RealPathError = error{
     SharingViolation,
     PipeBusy,
 
-    /// On WASI, the current CWD may not be associated with an absolute path.
-    InvalidHandle,
-
     /// Windows-only; file paths provided by the user must be valid WTF-8.
     /// https://simonsapin.github.io/wtf-8/
     InvalidWtf8,
@@ -5613,7 +5607,6 @@ pub fn realpathZ(pathname: [*:0]const u8, out_buffer: *[MAX_PATH_BYTES]u8) RealP
             error.FileLocksNotSupported => unreachable,
             error.WouldBlock => unreachable,
             error.FileBusy => unreachable, // not asking for write permissions
-            error.InvalidHandle => unreachable, // WASI-only
             error.InvalidUtf8 => unreachable, // WASI-only
             else => |e| return e,
         };
@@ -5797,7 +5790,7 @@ pub fn getFdPath(fd: fd_t, out_buffer: *[MAX_PATH_BYTES]u8) RealPathError![]u8 {
                     }
                     i += @as(usize, @intCast(kf.structsize));
                 }
-                return error.InvalidHandle;
+                return error.FileNotFound;
             }
         },
         .dragonfly => {

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -739,7 +739,6 @@ fn glibcVerFromRPath(rpath: []const u8) !std.SemanticVersion {
 
         error.FileNotFound,
         error.NotDir,
-        error.InvalidHandle,
         error.AccessDenied,
         error.NoDevice,
         => return error.GLibCNotFound,
@@ -775,7 +774,6 @@ fn glibcVerFromRPath(rpath: []const u8) !std.SemanticVersion {
         error.PathAlreadyExists => unreachable, // read-only
         error.DeviceBusy => unreachable, // read-only
         error.FileBusy => unreachable, // read-only
-        error.InvalidHandle => unreachable, // should not be in the error set
         error.WouldBlock => unreachable, // not using O_NONBLOCK
         error.NoDevice => unreachable, // not asking for a special device
 
@@ -1012,7 +1010,6 @@ fn detectAbiAndDynamicLinker(
 
                 error.IsDir,
                 error.NotDir,
-                error.InvalidHandle,
                 error.AccessDenied,
                 error.NoDevice,
                 error.FileNotFound,


### PR DESCRIPTION
`InvalidHandle` in `OpenError` is no longer a possible error on any platform. In the past it was able to be returned in `openOptionsFromFlagsWasi`, but the implementation was changed in 7680c5330cbc9141b9a5444e30c512b6068ab50d to make it no longer possible.

`InvalidHandle` in `RealPathError` was a holdover from before d5312d53a066092ba9efd687e25b29a87eb6290c, which (re)made realpath a compile error on WASI. However, InvalidHandle was also a possible error in the FreeBSD fallback implementation added in 537624734c4db9e0cdbdc0ebce57375d17172a70. This commit changes the FreeBSD fallback implementation to return FileNotFound instead of InvalidHandle which matches how EBADF is handled in all the other `realpath` implementations (including the FreeBSD non-fallback implementation).

Closes #19084