### PR TITLE
package manager: handle archives without leading root folder

### DIFF
--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -29,6 +29,9 @@ pub const Diagnostics = struct {
     allocator: std.mem.Allocator,
     errors: std.ArrayListUnmanaged(Error) = .{},
 
+    root_entries: usize = 0,
+    root_dir: ?[]const u8 = null,
+
     pub const Error = union(enum) {
         unable_to_create_sym_link: struct {
             code: anyerror,
@@ -44,6 +47,45 @@ pub const Diagnostics = struct {
             file_type: Header.Kind,
         },
     };
+
+    fn findRoot(d: *Diagnostics, path: []const u8, kind: FileKind) !void {
+        if (rootDir(path)) |root_dir| {
+            d.root_entries += 1;
+            if (kind == .directory and d.root_entries == 1) {
+                d.root_dir = try d.allocator.dupe(u8, root_dir);
+                return;
+            }
+            if (d.root_dir) |r| {
+                d.allocator.free(r);
+                d.root_dir = null;
+            }
+        }
+    }
+
+    // If path is package root returns root_dir name, otherwise null.
+    fn rootDir(path: []const u8) ?[]const u8 {
+        if (path.len == 0) return null;
+
+        const start_index: usize = if (path[0] == '/') 1 else 0;
+        const end_index: usize = if (path[path.len - 1] == '/') path.len - 1 else path.len;
+        const buf = path[start_index..end_index];
+        return if (std.mem.indexOfScalarPos(u8, buf, 0, '/') == null)
+            buf
+        else
+            null;
+    }
+
+    test rootDir {
+        const expectEqualStrings = testing.expectEqualStrings;
+        const expect = testing.expect;
+
+        try expectEqualStrings("a", rootDir("a").?);
+        try expectEqualStrings("b", rootDir("b").?);
+        try expectEqualStrings("c", rootDir("/c").?);
+        try expectEqualStrings("d", rootDir("/d/").?);
+        try expect(rootDir("a/b") == null);
+        try expect(rootDir("") == null);
+    }
 
     pub fn deinit(d: *Diagnostics) void {
         for (d.errors.items) |item| {
@@ -61,6 +103,10 @@ pub const Diagnostics = struct {
             }
         }
         d.errors.deinit(d.allocator);
+        if (d.root_dir) |r| {
+            d.allocator.free(r);
+            d.root_dir = null;
+        }
         d.* = undefined;
     }
 };
@@ -580,19 +626,21 @@ pub fn pipeToFileSystem(dir: std.fs.Dir, reader: anytype, options: PipeOptions) 
         .link_name_buffer = &link_name_buffer,
         .diagnostics = options.diagnostics,
     });
+
     while (try iter.next()) |file| {
+        const file_name = stripComponents(file.name, options.strip_components);
+        if (options.diagnostics) |d| {
+            try d.findRoot(file_name, file.kind);
+        }
+
         switch (file.kind) {
             .directory => {
-                const file_name = stripComponents(file.name, options.strip_components);
                 if (file_name.len != 0 and !options.exclude_empty_directories) {
                     try dir.makePath(file_name);
                 }
             },
             .file => {
-                if (file.size == 0 and file.name.len == 0) return;
-                const file_name = stripComponents(file.name, options.strip_components);
                 if (file_name.len == 0) return error.BadFileName;
-
                 if (createDirAndFile(dir, file_name, fileMode(file.mode, options))) |fs_file| {
                     defer fs_file.close();
                     try file.writeAll(fs_file);
@@ -605,12 +653,8 @@ pub fn pipeToFileSystem(dir: std.fs.Dir, reader: anytype, options: PipeOptions) 
                 }
             },
             .sym_link => {
-                // The file system path of the symbolic link.
-                const file_name = stripComponents(file.name, options.strip_components);
                 if (file_name.len == 0) return error.BadFileName;
-                // The data inside the symbolic link.
                 const link_name = file.link_name;
-
                 createDirAndSymlink(dir, link_name, file_name) catch |err| {
                     const d = options.diagnostics orelse return error.UnableToCreateSymLink;
                     try d.errors.append(d.allocator, .{ .unable_to_create_sym_link = .{
@@ -799,6 +843,7 @@ test PaxIterator {
 
 test {
     _ = @import("tar/test.zig");
+    _ = Diagnostics;
 }
 
 test "header parse size" {
@@ -991,6 +1036,55 @@ test pipeToFileSystem {
         "../a/file",
         normalizePath(try dir.readLink("b/symlink", &buf)),
     );
+}
+
+test "pipeToFileSystem root_dir" {
+    const data = @embedFile("tar/testdata/example.tar");
+    var fbs = std.io.fixedBufferStream(data);
+    const reader = fbs.reader();
+
+    // with strip_components = 1
+    {
+        var tmp = testing.tmpDir(.{ .no_follow = true });
+        defer tmp.cleanup();
+        var diagnostics: Diagnostics = .{ .allocator = testing.allocator };
+        defer diagnostics.deinit();
+
+        pipeToFileSystem(tmp.dir, reader, .{
+            .strip_components = 1,
+            .diagnostics = &diagnostics,
+        }) catch |err| {
+            // Skip on platform which don't support symlinks
+            if (err == error.UnableToCreateSymLink) return error.SkipZigTest;
+            return err;
+        };
+
+        // there is no root_dir
+        try testing.expect(diagnostics.root_dir == null);
+        try testing.expectEqual(3, diagnostics.root_entries);
+    }
+
+    // with strip_components = 0
+    {
+        fbs.reset();
+        var tmp = testing.tmpDir(.{ .no_follow = true });
+        defer tmp.cleanup();
+        var diagnostics: Diagnostics = .{ .allocator = testing.allocator };
+        defer diagnostics.deinit();
+
+        pipeToFileSystem(tmp.dir, reader, .{
+            .strip_components = 0,
+            .diagnostics = &diagnostics,
+        }) catch |err| {
+            // Skip on platform which don't support symlinks
+            if (err == error.UnableToCreateSymLink) return error.SkipZigTest;
+            return err;
+        };
+
+        // root_dir found
+        try testing.expectEqualStrings("example", diagnostics.root_dir.?);
+        try testing.expectEqual(1, diagnostics.root_entries);
+    }
 }
 
 fn normalizePath(bytes: []u8) []u8 {

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -532,8 +532,10 @@ fn runResource(
         ) });
         return error.FetchFailed;
     };
-    // Remove temporary directory root.
-    cache_root.handle.deleteTree(tmp_dir_sub_path) catch {};
+    // Remove temporary directory root if not already renamed to cache.
+    if (!std.mem.eql(u8, package_sub_path, tmp_dir_sub_path)) {
+        cache_root.handle.deleteDir(tmp_dir_sub_path) catch {};
+    }
 
     // Validate the computed hash against the expected hash. If invalid, this
     // job is done.
@@ -1059,6 +1061,10 @@ fn initResource(f: *Fetch, uri: std.Uri, server_header_buffer: []u8) RunError!Re
     ));
 }
 
+/// A `null` return value indicates the `tmp_directory` is populated directly
+/// with the package contents.
+/// A non-null return value means that the package contents are inside a
+/// sub-directory indicated by the named path.
 fn unpackResource(
     f: *Fetch,
     resource: *Resource,

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -536,7 +536,7 @@ fn runResource(
         ) });
         return error.FetchFailed;
     };
-    // Remove temporary directory root if that not already done in rename.
+    // Remove temporary directory root if that's not already done in rename.
     if (tmp_package_root_sub_path) |_| {
         cache_root.handle.deleteTree(tmp_dir_sub_path) catch {};
     }

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -867,9 +867,9 @@ const FileType = enum {
         try std.testing.expectEqual(@as(?FileType, .@"tar.xz"), fromContentDisposition("ATTACHMENT; filename=\"stuff.tar.xz\""));
         try std.testing.expectEqual(@as(?FileType, .@"tar.xz"), fromContentDisposition("attachment; FileName=\"stuff.tar.xz\""));
         try std.testing.expectEqual(@as(?FileType, .@"tar.gz"), fromContentDisposition("attachment; FileName*=UTF-8\'\'xyz%2Fstuff.tar.gz"));
+        try std.testing.expectEqual(@as(?FileType, .tar), fromContentDisposition("attachment; FileName=\"stuff.tar\""));
 
         try std.testing.expect(fromContentDisposition("attachment FileName=\"stuff.tar.gz\"") == null);
-        try std.testing.expect(fromContentDisposition("attachment; FileName=\"stuff.tar\"") == null);
         try std.testing.expect(fromContentDisposition("attachment; FileName\"stuff.gz\"") == null);
         try std.testing.expect(fromContentDisposition("attachment; size=42") == null);
         try std.testing.expect(fromContentDisposition("inline; size=42") == null);


### PR DESCRIPTION
Instead of striping leading root folder while unpacking tar, tar archive is unpacked as is into temporary directory. Then we check result and decide whether to skip root folder. That allows us to handle archives which don't have that leading root folder. 

This if follow up of PR #19090.

Fixes #17779