### PR TITLE
compress: activate flate tests in wasm32

### DIFF
--- a/lib/std/compress/flate.zig
+++ b/lib/std/compress/flate.zig
@@ -85,8 +85,6 @@ test {
 }
 
 test "compress/decompress" {
-    if (builtin.target.cpu.arch == .wasm32) return error.SkipZigTest;
-
     var cmp_buf: [64 * 1024]u8 = undefined; // compressed data buffer
     var dcm_buf: [64 * 1024]u8 = undefined; // decompressed data buffer
 
@@ -354,8 +352,6 @@ test "gzip header" {
 }
 
 test "public interface" {
-    if (builtin.target.cpu.arch == .wasm32) return error.SkipZigTest;
-
     const plain_data = [_]u8{ 'H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', 0x0a };
 
     // deflate final stored block, header + plain (stored) data


### PR DESCRIPTION
They were disabled because insufficient stack size. 
That is [changed](https://github.com/ziglang/zig/commit/d51aa9748f9e4e3616328a207a8047ff37d81f8b) now.