### PR TITLE
std.os.linux: enforce null-terminated path arguments

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1060,7 +1060,7 @@ pub fn rename(old: [*:0]const u8, new: [*:0]const u8) usize {
     }
 }
 
-pub fn renameat(oldfd: i32, oldpath: [*]const u8, newfd: i32, newpath: [*]const u8) usize {
+pub fn renameat(oldfd: i32, oldpath: [*:0]const u8, newfd: i32, newpath: [*:0]const u8) usize {
     if (@hasField(SYS, "renameat")) {
         return syscall4(
             .renameat,
@@ -1819,7 +1819,7 @@ pub fn fstatat(dirfd: i32, path: [*:0]const u8, stat_buf: *Stat, flags: u32) usi
     }
 }
 
-pub fn statx(dirfd: i32, path: [*]const u8, flags: u32, mask: u32, statx_buf: *Statx) usize {
+pub fn statx(dirfd: i32, path: [*:0]const u8, flags: u32, mask: u32, statx_buf: *Statx) usize {
     if (@hasField(SYS, "statx")) {
         return syscall5(
             .statx,


### PR DESCRIPTION
The functions `renameat` and `statx` accept `[*]const u8` values for path names, which may lead to undefined behavior at run time. For example, given a path to a file, I may want to inspect (every component of) the parent directory before operating on that file per CERT C rec. [FIO15]. I decide to use statx(2) to avoid copying irrelevant data:

```zig
const std = @import("std");
const debug = std.debug;
const fs = std.fs;
const mem = std.mem;
const linux = std.os.linux;

pub fn main() !void {
    const dir_name = fs.path.dirnamePosix("/usr/bin/vi").?;
    debug.assert(mem.eql(u8, dir_name, "/usr/bin"));

    var statx_buf: linux.Statx = undefined;
    debug.assert(linux.getErrno(linux.statx(
        linux.AT.FDCWD,
        dir_name.ptr,
        linux.AT.SYMLINK_NOFOLLOW,
        linux.STATX_TYPE | linux.STATX_MODE,
        &statx_buf,
    )) == .SUCCESS);
    debug.print("mode({s}) = {o}\n", .{ dir_name, statx_buf.mode });
    debug.assert(linux.S.ISDIR(statx_buf.mode));
}
```

This program compiles but fails at run time:

```console
user@localhost:~$ zig run ./statx.zig
```

```
mode(/usr/bin) = 100755
thread 4704 panic: reached unreachable code
/home/user/zig/lib/std/debug.zig:403:14: 0x1033dbd in assert (statx)
    if (!ok) unreachable; // assertion failure
             ^
/home/user/statx.zig:20:14: 0x1033960 in main (statx)
 debug.assert(linux.S.ISDIR(statx_buf.mode));
             ^
/home/user/zig/lib/std/start.zig:511:37: 0x10337d6 in posixCallMainAndExit (statx)
            const result = root.main() catch |err| {
                                    ^
/home/user/zig/lib/std/start.zig:253:5: 0x1033351 in _start (statx)
    asm volatile (switch (native_arch) {
    ^
???:?:?: 0x0 in ??? (???)
Aborted (core dumped)
```

The reported mode of */usr/bin* is 100755 but the expected mode is 40555:

```console
user@localhost:~$ ls -dl /usr/bin
```

```
dr-xr-xr-x. 1 root root 39196 Jan 01 00:00 /usr/bin
```

When I use `std.os.toPosixPath` to create a null-terminated slice on the stack, the program exhibits the expected behavior and exits with code zero. The compiler should have rejected the original program code in the first place. Here’s what happens after implementing this change set:

```console
user@localhost:~$ zig run ./statx.zig
```

```
statx.zig:14:11: error: expected type '[*:0]const u8', found '[*]const u8'
  dir_name.ptr,
  ~~~~~~~~^~~~
statx.zig:14:11: note: destination pointer requires '0' sentinel
zig/lib/std/os/linux.zig:1822:33: note: parameter type declared here
pub fn statx(dirfd: i32, path: [*:0]const u8, flags: u32, mask: u32, statx_buf: *Statx) usize {
                               ~^~~~~~~~~~~~
referenced by:
    callMain: zig/lib/std/start.zig:511:32
    callMainWithArgs: zig/lib/std/start.zig:469:12
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```

I have changed only the signatures of `renameat` and `statx` since all callers in the standard library already supply null-terminated strings to these functions. This change set is especially relevant for `statx`, which has no higher-level wrapper in `std.os` and must therefore be called directly.

[FIO15]: https://wiki.sei.cmu.edu/confluence/display/c/FIO15-C.+Ensure+that+file+operations+are+performed+in+a+secure+directory