### PR TITLE
Fix stuttering stderr in Zig test log

### DIFF
--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -1181,7 +1181,9 @@ fn evalZigTest(
 
                 if (tr_hdr.flags.fail or tr_hdr.flags.leak or tr_hdr.flags.log_err_count > 0) {
                     const name = std.mem.sliceTo(md.string_bytes[md.names[tr_hdr.index]..], 0);
-                    const msg = std.mem.trim(u8, stderr.readableSlice(0), "\n");
+                    const orig_msg = stderr.readableSlice(0);
+                    defer stderr.discard(orig_msg.len);
+                    const msg = std.mem.trim(u8, orig_msg, "\n");
                     const label = if (tr_hdr.flags.fail)
                         "failed"
                     else if (tr_hdr.flags.leak)
@@ -1195,7 +1197,6 @@ fn evalZigTest(
                     } else {
                         try self.step.addError("'{s}' {s}", .{ name, label });
                     }
-                    stderr.discard(msg.len);
                 }
 
                 try requestNextTest(child.stdin.?, &metadata.?, &sub_prog_node);


### PR DESCRIPTION
Before this fix, the stderr FIFO was advanced by the length of the trimmed message, thus the next error log contained the tail of that message.

Bug can be reproduced with a few failing tests run by std.Build, e.g. for this `build.zig`

```zig
const Build = @import("std").Build;

pub fn build(b: *Build) void {
    b.step("test", "Run tests").dependOn(&b.addRunArtifact(b.addTest(.{
        .root_source_file = .{ .path = "test.zig" },
        .target = b.standardTargetOptions(.{}),
        .optimize = b.standardOptimizeOption(.{}),
    })).step);
}
```

where `test.zig` has 3 failing tests (reproducible with just 2 on 0.11):

```zig
const expect = @import("std").testing.expect;
test { try expect(false); }
test { try expect(false); }
test { try expect(false); }
```

`)\n` at the end of `test_1`'s log is repeated on that of `test_2`:

```log
$ zig build test --color off
test
+- run test 0/3 passed, 3 failed
error: 'test.test_0' failed: .../lib/std/testing.zig:546:14: 0x103932f in expect (test)
    if (!ok) return error.TestUnexpectedResult;
             ^
.../lib/test.zig:2:8: 0x1039445 in test_0 (test)
error: 'test.test_1' failed: /.../lib/std/testing.zig:546:14: 0x103932f in expect (test)
    if (!ok) return error.TestUnexpectedResult;
             ^
.../lib/test.zig:3:8: 0x1039485 in test_1 (test)
error: 'test.test_2' failed: )
.../lib/std/testing.zig:546:14: 0x103932f in expect (test)
    if (!ok) return error.TestUnexpectedResult;
             ^
.../lib/test.zig:4:8: 0x10394c5 in test_2 (test)
error: while executing test 'test.test_2', the following test command failed:
.../zig-cache/o/.../test --listen=- 
Build Summary: 1/3 steps succeeded; 1 failed; 0/3 tests passed; 3 failed (disable with --summary none)
test transitive failure
+- run test 0/3 passed, 3 failed
```

Log format isn't stable across versions so I'm unsure how to write a test for this.