### PR TITLE
Add `std.heap.static_allocator`

### DIFF
--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -53,6 +53,19 @@ pub const VTable = struct {
     free: *const fn (ctx: *anyopaque, buf: []u8, buf_align: u8, ret_addr: usize) void,
 };
 
+pub fn noAlloc(
+    self: *anyopaque,
+    len: usize,
+    ptr_align: u8,
+    ret_addr: usize,
+) ?[*]u8 {
+    _ = self;
+    _ = len;
+    _ = ptr_align;
+    _ = ret_addr;
+    return null;
+}
+
 pub fn noResize(
     self: *anyopaque,
     buf: []u8,


### PR DESCRIPTION
An allocator with a always failing alloc and resize, and a no-op free, for use with a statically allocated buffer being passed into an api that takes an `Allocator` in order to free its data.