### PR TITLE
add missing export symbol names to whole mode wasm cache hash

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2584,10 +2584,7 @@ fn addNonIncrementalStuffToCacheManifest(
     man.hash.addOptional(opts.initial_memory);
     man.hash.addOptional(opts.max_memory);
     man.hash.addOptional(opts.global_base);
-    man.hash.add(opts.export_symbol_names.len);
-    for (opts.export_symbol_names) |symbol_name| {
-        man.hash.addBytes(symbol_name);
-    }
+    man.hash.addListOfBytes(opts.export_symbol_names);
 
     // Mach-O specific stuff
     try link.File.MachO.hashAddFrameworks(man, opts.frameworks);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2584,6 +2584,10 @@ fn addNonIncrementalStuffToCacheManifest(
     man.hash.addOptional(opts.initial_memory);
     man.hash.addOptional(opts.max_memory);
     man.hash.addOptional(opts.global_base);
+    man.hash.add(opts.export_symbol_names.len);
+    for (opts.export_symbol_names) |symbol_name| {
+        man.hash.addBytes(symbol_name);
+    }
 
     // Mach-O specific stuff
     try link.File.MachO.hashAddFrameworks(man, opts.frameworks);

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -3535,11 +3535,8 @@ fn linkWithZld(wasm: *Wasm, arena: Allocator, prog_node: *std.Progress.Node) lin
         man.hash.addOptional(wasm.initial_memory);
         man.hash.addOptional(wasm.max_memory);
         man.hash.addOptional(wasm.global_base);
-        man.hash.add(wasm.export_symbol_names.len);
+        man.hash.addListOfBytes(wasm.export_symbol_names);
         // strip does not need to go into the linker hash because it is part of the hash namespace
-        for (wasm.export_symbol_names) |symbol_name| {
-            man.hash.addBytes(symbol_name);
-        }
 
         // We don't actually care whether it's a cache hit or miss; we just need the digest and the lock.
         _ = try man.hit();
@@ -4605,11 +4602,8 @@ fn linkWithLLD(wasm: *Wasm, arena: Allocator, prog_node: *std.Progress.Node) !vo
         man.hash.addOptional(wasm.max_memory);
         man.hash.add(shared_memory);
         man.hash.addOptional(wasm.global_base);
-        man.hash.add(wasm.export_symbol_names.len);
+        man.hash.addListOfBytes(wasm.export_symbol_names);
         // strip does not need to go into the linker hash because it is part of the hash namespace
-        for (wasm.export_symbol_names) |symbol_name| {
-            man.hash.addBytes(symbol_name);
-        }
 
         // We don't actually care whether it's a cache hit or miss; we just need the digest and the lock.
         _ = try man.hit();


### PR DESCRIPTION
Fixes false positive cache hit.