### PR TITLE
objcopy: support multiple only sections

### DIFF
--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -245,6 +245,11 @@ pub const HashHelper = struct {
         for (list_of_bytes) |bytes| hh.addBytes(bytes);
     }
 
+    pub fn addOptionalListOfBytes(hh: *HashHelper, optional_list_of_bytes: ?[]const []const u8) void {
+        hh.add(optional_list_of_bytes != null);
+        hh.addListOfBytes(optional_list_of_bytes orelse return);
+    }
+
     /// Convert the input value into bytes and record it as a dependency of the process being cached.
     pub fn add(hh: *HashHelper, x: anytype) void {
         switch (@TypeOf(x)) {

--- a/lib/std/Build/Step/ObjCopy.zig
+++ b/lib/std/Build/Step/ObjCopy.zig
@@ -33,7 +33,7 @@ output_file: std.Build.GeneratedFile,
 output_file_debug: ?std.Build.GeneratedFile,
 
 format: ?RawFormat,
-only_section: ?[]const u8,
+only_sections: ?[]const []const u8,
 pad_to: ?u64,
 strip: Strip,
 compress_debug: bool,
@@ -41,7 +41,7 @@ compress_debug: bool,
 pub const Options = struct {
     basename: ?[]const u8 = null,
     format: ?RawFormat = null,
-    only_section: ?[]const u8 = null,
+    only_sections: ?[]const []const u8 = null,
     pad_to: ?u64 = null,
 
     compress_debug: bool = false,
@@ -71,7 +71,7 @@ pub fn create(
         .output_file = std.Build.GeneratedFile{ .step = &self.step },
         .output_file_debug = if (options.strip != .none and options.extract_to_separate_file) std.Build.GeneratedFile{ .step = &self.step } else null,
         .format = options.format,
-        .only_section = options.only_section,
+        .only_sections = options.only_sections,
         .pad_to = options.pad_to,
         .strip = options.strip,
         .compress_debug = options.compress_debug,
@@ -103,7 +103,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
 
     const full_src_path = self.input_file.getPath(b);
     _ = try man.addFile(full_src_path, null);
-    man.hash.addOptionalBytes(self.only_section);
+    man.hash.addOptionalListOfBytes(self.only_sections);
     man.hash.addOptional(self.pad_to);
     man.hash.addOptional(self.format);
     man.hash.add(self.compress_debug);
@@ -135,8 +135,10 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     var argv = std.ArrayList([]const u8).init(b.allocator);
     try argv.appendSlice(&.{ b.graph.zig_exe, "objcopy" });
 
-    if (self.only_section) |only_section| {
-        try argv.appendSlice(&.{ "-j", only_section });
+    if (self.only_sections) |only_sections| {
+        for (only_sections) |only_section| {
+            try argv.appendSlice(&.{ "-j", only_section });
+        }
     }
     switch (self.strip) {
         .none => {},


### PR DESCRIPTION
According to this man page: https://man7.org/linux/man-pages/man1/objcopy.1.html, only-section in objcopy supports copying multiple sections, this PR adapt current build system to support it.
>--only-section=sectionpattern
>     Copy only the indicated sections from the input file to the
>     output file.  This option may be given more than once.  Note
>     that using this option inappropriately may make the output
>     file unusable.  Wildcard characters are accepted in
>     sectionpattern.
>
>     If the first character of sectionpattern is the exclamation
>     point (!) then matching sections will not be copied, even if
>     earlier use of --only-section on the same command line would
>     otherwise copy it.  For example:
>
>               --only-section=.text.* --only-section=!.text.foo