### PR TITLE
LLVM: Fix debug info for enum field values

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2013,7 +2013,7 @@ pub const Object = struct {
 
                     enumerators[i] = try o.builder.debugEnumerator(
                         try o.builder.metadataString(ip.stringToSlice(field_name_ip)),
-                        int_ty.isUnsignedInt(mod),
+                        int_info.signedness == .unsigned,
                         int_info.bits,
                         bigint,
                     );

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -14367,7 +14367,6 @@ pub fn toBitcode(self: *Builder, allocator: Allocator) bitcode_writer.Error![]co
                             try metadata_block.writeAbbrevAdapted(MetadataBlock.Enumerator{
                                 .flags = .{
                                     .unsigned = unsigned,
-                                    .bigint = false,
                                 },
                                 .bit_width = extra.bit_width,
                                 .name = extra.name,
@@ -14379,7 +14378,6 @@ pub fn toBitcode(self: *Builder, allocator: Allocator) bitcode_writer.Error![]co
 
                             const flags: MetadataBlock.Enumerator.Flags = .{
                                 .unsigned = unsigned,
-                                .bigint = true,
                             };
 
                             const FlagsInt = @typeInfo(MetadataBlock.Enumerator.Flags).Struct.backing_integer.?;

--- a/src/codegen/llvm/ir.zig
+++ b/src/codegen/llvm/ir.zig
@@ -896,7 +896,7 @@ pub const MetadataBlock = struct {
         pub const Flags = packed struct(u3) {
             distinct: bool = false,
             unsigned: bool,
-            bigint: bool,
+            bigint: bool = true,
         };
 
         pub const ops = [_]AbbrevOp{


### PR DESCRIPTION
Fixes  #19131

The field values were emitted in the wrong integer format making LLVM parse the wrong values.