### PR TITLE
macho: correctly find N_GSYM symbols when parsing symbol stabs

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -4320,8 +4320,6 @@ const is_hot_update_compatible = switch (builtin.target.os.tag) {
 const default_entry_symbol_name = "_main";
 
 pub const base_tag: link.File.Tag = link.File.Tag.macho;
-pub const N_DEAD: u16 = @as(u16, @bitCast(@as(i16, -1)));
-pub const N_BOUNDARY: u16 = @as(u16, @bitCast(@as(i16, -2)));
 
 const Section = struct {
     header: macho.section_64,


### PR DESCRIPTION
In `ld -r` mode, the linker will emit `N_GSYM` for any defined external symbols as well as private externals. In the former case, the thing is easy since `N_EXT` bit will be set in the nlist's type. In the latter however we will encounter a local symbol with `N_PEXT` bit set (non-extern, but was private external) which we also need to include when resolving symbol stabs.

The major change in the logic for parsing symbol stabs per input object file is that we no longer try to force-resolve a `N_GSYM` as a global symbol. This was a mistake since every symbol stab always describes a symbol defined within the parsed input object file. We then work out if we should forward `N_GSYM` in the output symtab after we have resolved all symbols, but never before - intel we lack when initially parsing symbol stabs. Therefore, we simply record which symbol has a debug symbol stab, and work out its precise type when emitting output symtab after symbol resolution has been done.

Fixes #19133 