### PR TITLE
std.Build.Step.Compile: installHeader and friends depend on Compile step

### DIFF
--- a/test/standalone/install_header_dep/build.zig
+++ b/test/standalone/install_header_dep/build.zig
@@ -1,0 +1,35 @@
+//! Verify that Step.Compile.installHeader correctly declare a dependency on
+//! the Step itself.
+//!
+//! Test for https://github.com/ziglang/zig/issues/17204.
+
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+
+    const foo = b.addStaticLibrary(.{
+        .name = "foo",
+        .root_source_file = .{ .path = "foo.zig" },
+        .optimize = .Debug,
+        .target = target,
+    });
+    foo.installHeader("foo.h", "foo.h");
+
+    const exists_in = b.addExecutable(.{
+        .name = "exists_in",
+        .root_source_file = .{ .path = "exists_in.zig" },
+        .optimize = .Debug,
+        .target = target,
+    });
+
+    const run = b.addRunArtifact(exists_in);
+    run.addDirectoryArg(.{ .path = b.getInstallPath(.header, ".") });
+    run.addArgs(&.{"foo.h"});
+    run.expectExitCode(0);
+    run.step.dependOn(&foo.step);
+
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+    test_step.dependOn(&run.step);
+}

--- a/test/standalone/install_header_dep/exists_in.zig
+++ b/test/standalone/install_header_dep/exists_in.zig
@@ -1,0 +1,40 @@
+//! Verifies that a file exists in a directory.
+//!
+//! Usage:
+//!
+//! ```
+//! exists_in <dir> <path>
+//! ```
+//!
+//! Where `<dir>/<path>` is the full path to the file.
+
+const std = @import("std");
+
+pub fn main() !void {
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    const arena = arena_state.allocator();
+    defer arena_state.deinit();
+
+    try run(arena);
+}
+
+fn run(allocator: std.mem.Allocator) !void {
+    var args = try std.process.argsWithAllocator(allocator);
+    defer args.deinit();
+    _ = args.next() orelse unreachable; // skip binary name
+
+    const dir_path = args.next() orelse {
+        std.log.err("missing <dir> argument", .{});
+        return error.BadUsage;
+    };
+
+    const relpath = args.next() orelse {
+        std.log.err("missing <path> argument", .{});
+        return error.BadUsage;
+    };
+
+    var dir = try std.fs.cwd().openDir(dir_path, .{});
+    defer dir.close();
+
+    _ = try dir.statFile(relpath);
+}

--- a/test/standalone/install_header_dep/foo.h
+++ b/test/standalone/install_header_dep/foo.h
@@ -1,0 +1,1 @@
+// Header file

--- a/test/standalone/install_header_dep/foo.zig
+++ b/test/standalone/install_header_dep/foo.zig
@@ -1,0 +1,1 @@
+// Source file


### PR DESCRIPTION
Currently, `installHeader`, `installConfigHeader`, and friends all
add the installation step as a dependency of the root install step.
This means that if a library is installed with a custom top-level step,
then the headers are not installed.

To fix this, this commit changes these functions to instead have the
compile step depend on the header installation stpe.
This way, as long as the compile step for an artifact is consumed,
the headers will be installed.

Two sets of tests are included to verify this behavior:

- A unit test in std.Build.Step.Compile that verifies that dependencies
  are correctly connected.
- A standalone test that reproduces the issue reported in #17204, and
  verifies that the headers are installed even without the install step.

Resolves #17204

---

**Question**:
As demonstrated with the standalone test, the headers are now installed
in zig-out even without an explicit request to install anything.
Is this the desired behavior?
