### PR TITLE
Respect error return trace

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -3059,7 +3059,7 @@ pub fn getKernError(err: kern_return_t) KernE {
 }
 
 pub fn unexpectedKernError(err: KernE) std.os.UnexpectedError {
-    if (std.os.unexpected_error_tracing) {
+    if (std.options.unexpected_error_tracing) {
         std.debug.print("unexpected error: {d}\n", .{@intFromEnum(err)});
         std.debug.dumpCurrentStackTrace(null);
     }

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -5989,12 +5989,6 @@ pub fn toPosixPath(file_path: []const u8) ![MAX_PATH_BYTES - 1:0]u8 {
     return path_with_null;
 }
 
-/// Whether or not error.Unexpected will print its value and a stack trace.
-/// if this happens the fix is to add the error code to the corresponding
-/// switch expression, possibly introduce a new error in the error set, and
-/// send a patch to Zig.
-pub const unexpected_error_tracing = builtin.zig_backend == .stage2_llvm and builtin.mode == .Debug;
-
 pub const UnexpectedError = error{
     /// The Operating System returned an undocumented error code.
     /// This error is in theory not possible, but it would be better
@@ -6005,7 +5999,7 @@ pub const UnexpectedError = error{
 /// Call this when you made a syscall or something that sets errno
 /// and you get an unexpected error.
 pub fn unexpectedErrno(err: E) UnexpectedError {
-    if (unexpected_error_tracing) {
+    if (std.options.unexpected_error_tracing) {
         std.debug.print("unexpected errno: {d}\n", .{@intFromEnum(err)});
         std.debug.dumpCurrentStackTrace(null);
     }

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2540,7 +2540,7 @@ pub fn loadWinsockExtensionFunction(comptime T: type, sock: ws2_32.SOCKET, guid:
 /// Call this when you made a windows DLL call or something that does SetLastError
 /// and you get an unexpected error.
 pub fn unexpectedError(err: Win32Error) std.os.UnexpectedError {
-    if (std.os.unexpected_error_tracing) {
+    if (std.options.unexpected_error_tracing) {
         // 614 is the length of the longest windows error description
         var buf_wstr: [614]WCHAR = undefined;
         const len = kernel32.FormatMessageW(
@@ -2568,7 +2568,7 @@ pub fn unexpectedWSAError(err: ws2_32.WinsockError) std.os.UnexpectedError {
 /// Call this when you made a windows NtDll call
 /// and you get an unexpected status.
 pub fn unexpectedStatus(status: NTSTATUS) std.os.UnexpectedError {
-    if (std.os.unexpected_error_tracing) {
+    if (std.options.unexpected_error_tracing) {
         std.debug.print("error.Unexpected NTSTATUS=0x{x}\n", .{@intFromEnum(status)});
         std.debug.dumpCurrentStackTrace(@returnAddress());
     }

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -252,6 +252,12 @@ pub const Options = struct {
     http_disable_tls: bool = false,
 
     side_channels_mitigations: crypto.SideChannelsMitigations = crypto.default_side_channels_mitigations,
+
+    /// Whether or not error.Unexpected will print its value and a stack trace.
+    /// if this happens the fix is to add the error code to the corresponding
+    /// switch expression, possibly introduce a new error in the error set, and
+    /// send a patch to Zig.
+    unexpected_error_tracing: bool = @import("builtin").zig_backend == .stage2_llvm and @import("builtin").mode == .Debug,
 };
 
 // This forces the start.zig file to be imported, and the comptime logic inside that


### PR DESCRIPTION
Without this patch, the stack trace code would still be pulled to the binary, increasing the binary size by a huge amount and thus increasing compilation time. Now the user's choice is respected and no stack trace code is being pulled when the user choses not to have error traces