### PR TITLE
translate-c: support goto statements

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -612,6 +612,11 @@ pub const GenericSelectionExpr = opaque {
     extern fn ZigClangGenericSelectionExpr_getResultExpr(*const GenericSelectionExpr) *const Expr;
 };
 
+pub const GotoStmt = opaque {
+    pub const getLabel = ZigClangGotoStmt_getLabel;
+    extern fn ZigClangGotoStmt_getLabel(*const GotoStmt) *NamedDecl;
+};
+
 pub const IfStmt = opaque {
     pub const getThen = ZigClangIfStmt_getThen;
     extern fn ZigClangIfStmt_getThen(*const IfStmt) *const Stmt;
@@ -648,6 +653,14 @@ pub const IntegerLiteral = opaque {
 
     pub const getSignum = ZigClangIntegerLiteral_getSignum;
     extern fn ZigClangIntegerLiteral_getSignum(*const IntegerLiteral, *c_int, *const ASTContext) bool;
+};
+
+pub const LabelStmt = opaque {
+    pub const getName = ZigClangLabelStmt_getName;
+    extern fn ZigClangLabelStmt_getName(*const LabelStmt) [*:0]const u8;
+
+    pub const getSubStmt = ZigClangLabelStmt_getSubStmt;
+    extern fn ZigClangLabelStmt_getSubStmt(*const LabelStmt) *const Stmt;
 };
 
 /// This is just used as a namespace for a static method on clang's Lexer class; we don't directly

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -7059,9 +7059,23 @@ fn createGotoContext(
     block: *Scope.Block,
 ) Error!GotoContext {
     var label_branches: std.StringArrayHashMapUnmanaged(std.ArrayListUnmanaged(*const clang.Stmt)) = .{};
+    defer {
+        for (label_branches.values()) |*label_branch| {
+            label_branch.deinit(c.gpa);
+        }
+        label_branches.deinit(c.gpa);
+    }
+
     var goto_branches: std.ArrayListUnmanaged(std.ArrayListUnmanaged(*const clang.Stmt)) = .{};
+    defer {
+        for (goto_branches.items) |*goto_branch| {
+            goto_branch.deinit(c.gpa);
+        }
+        goto_branches.deinit(c.gpa);
+    }
 
     var transformations: std.AutoArrayHashMapUnmanaged(*const clang.Stmt, std.ArrayListUnmanaged(GotoContext.Transformation)) = .{};
+    defer transformations.deinit(c.gpa);
 
     var goto: GotoContext = .{};
 

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -1659,7 +1659,7 @@ fn transCompoundStmtInline(
     var it = stmt.body_begin();
     const end_it = stmt.body_end();
     if (c.goto.?.transformations.get(@ptrCast(stmt))) |transformations| {
-        var first_inner_stmt_after_if_to_variables: std.AutoHashMapUnmanaged(*const clang.Stmt, std.ArrayListUnmanaged([]const u8)) = .{};
+        var first_inner_stmt_after_if_to_variables: std.AutoArrayHashMapUnmanaged(*const clang.Stmt, std.ArrayListUnmanaged([]const u8)) = .{};
         defer first_inner_stmt_after_if_to_variables.deinit(c.gpa);
 
         var upwards_inner_stmt_break_target_transformations: std.AutoHashMapUnmanaged(*const clang.Stmt, std.ArrayListUnmanaged(*const GotoContext.Transformation)) = .{};
@@ -1772,9 +1772,8 @@ fn transCompoundStmtInline(
 
             if (end_if or (it + 1 != end_it and first_inner_stmt_after_if_to_variables.contains((it + 1)[0]))) {
                 if (if_block.?.statements.items.len != 0) {
-                    var iter = first_inner_stmt_after_if_to_variables.valueIterator();
                     var ncond: ?Node = null;
-                    while (iter.next()) |variables| {
+                    for (first_inner_stmt_after_if_to_variables.values()) |*variables| {
                         for (variables.items) |variable| {
                             const ident = try Tag.identifier.create(c.arena, variable);
                             ncond = if (ncond) |nc|
@@ -1822,7 +1821,7 @@ fn transCompoundStmtInline(
                 if (it + 1 != end_it) {
                     if (first_inner_stmt_after_if_to_variables.getPtr((it + 1)[0])) |variables| {
                         variables.deinit(c.gpa);
-                        assert(first_inner_stmt_after_if_to_variables.remove((it + 1)[0]));
+                        assert(first_inner_stmt_after_if_to_variables.swapRemove((it + 1)[0]));
                     }
                 }
             }

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -5471,7 +5471,7 @@ fn transLabelStmt(c: *Context, scope: *Scope, stmt: *const clang.LabelStmt) Tran
         ));
     }
 
-    try block.?.statements.append(try transStmt(c, scope, inner_stmt, .unused));
+    try block.?.statements.append(try transStmt(c, &block.?.base, inner_stmt, .unused));
 
     if (is_break_target) {
         try block.?.statements.append(try Tag.if_not_break.create(c.arena, cond.?));

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -7201,7 +7201,7 @@ const GotoContext = struct {
         variable: []const u8,
         inner_stmt: *const clang.Stmt,
         type: union(enum) {
-            simple: void,
+            simple,
 
             break_target: struct {
                 /// zig-label for the `from` statement (initialized late)
@@ -7629,7 +7629,7 @@ fn createGotoContextCombineStmts(
                     try branch_transformations.value_ptr.append(c.arena, GotoContext.Transformation{
                         .variable = variable.value_ptr.*,
                         .inner_stmt = label_branch.items[i],
-                        .type = .{ .simple = {} },
+                        .type = .simple,
                     });
                 }
 

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -4045,6 +4045,20 @@ const struct ZigClangAPSInt *ZigClangEnumConstantDecl_getInitVal(const struct Zi
     return reinterpret_cast<const ZigClangAPSInt *>(result);
 }
 
+struct ZigClangNamedDecl *ZigClangGotoStmt_getLabel(const struct ZigClangGotoStmt *self) {
+    auto casted = reinterpret_cast<const clang::GotoStmt *>(self);
+    return reinterpret_cast<struct ZigClangNamedDecl *>(casted->getLabel());
+}
+
+const char *ZigClangLabelStmt_getName(const struct ZigClangLabelStmt *self) {
+    return reinterpret_cast<const clang::LabelStmt *>(self)->getName();
+}
+
+const struct ZigClangStmt *ZigClangLabelStmt_getSubStmt(const struct ZigClangLabelStmt *self) {
+    auto casted = reinterpret_cast<const clang::LabelStmt *>(self);
+    return reinterpret_cast<const struct ZigClangStmt *>(casted->getSubStmt());
+}
+
 // Get a pointer to a static variable in libc++ from LLVM and make sure that
 // it matches our own.
 //

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -173,6 +173,8 @@ struct ZigClangValueDecl;
 struct ZigClangVarDecl;
 struct ZigClangWhileStmt;
 struct ZigClangInitListExpr;
+struct ZigClangGotoStmt;
+struct ZigClangLabelStmt;
 
 typedef struct ZigClangStmt *const * ZigClangCompoundStmt_const_body_iterator;
 typedef struct ZigClangDecl *const * ZigClangDeclStmt_const_decl_iterator;
@@ -1715,4 +1717,10 @@ ZIG_EXTERN_C unsigned ZigClangFieldDecl_getFieldIndex(const struct ZigClangField
 
 ZIG_EXTERN_C const struct ZigClangAPSInt *ZigClangEnumConstantDecl_getInitVal(const struct ZigClangEnumConstantDecl *);
 ZIG_EXTERN_C bool ZigClangIsLLVMUsingSeparateLibcxx();
+
+ZIG_EXTERN_C struct ZigClangNamedDecl *ZigClangGotoStmt_getLabel(const struct ZigClangGotoStmt *);
+
+ZIG_EXTERN_C const char *ZigClangLabelStmt_getName(const struct ZigClangLabelStmt *);
+ZIG_EXTERN_C const struct ZigClangStmt *ZigClangLabelStmt_getSubStmt(const struct ZigClangLabelStmt *);
+
 #endif

--- a/test/cases/run_translated_c/goto_tests.c
+++ b/test/cases/run_translated_c/goto_tests.c
@@ -1,0 +1,596 @@
+int downwards_0(void)
+{
+    goto l;
+    return 1;
+l:
+    return 0;
+}
+
+int downwards_1(void)
+{
+    int ret = 0;
+    goto l;
+    ret = 1;
+l:
+    return ret;
+}
+
+int upwards(void)
+{
+    int ret = 1;
+l:
+    if (ret != 1)
+    {
+        return ret;
+    }
+
+    ret--;
+    goto l;
+}
+
+int two_labels(void)
+{
+    int ret = 1;
+    goto l;
+    return 1;
+k:
+    return ret;
+l:
+    ret = 0;
+    goto k;
+}
+
+int simple_scope_0(void)
+{
+    goto l;
+    return 1;
+    {
+        return 1;
+    l:
+        return 0;
+    }
+    return 1;
+}
+
+int simple_scope_1(void)
+{
+    {
+        goto l;
+        return 1;
+    }
+    return 1;
+l:
+    return 0;
+}
+
+int into_if_0(void)
+{
+    int b = 0;
+    goto l;
+    return 1;
+    if (b)
+    {
+        return 1;
+    l:
+        return 0;
+    }
+    return 1;
+}
+
+int into_if_1(void)
+{
+    int b = 0;
+    if (b)
+    {
+        return 1;
+    l:
+        return 0;
+    }
+    goto l;
+}
+
+int out_of_if_0(void)
+{
+    if (1)
+    {
+        goto l;
+        return 1;
+    }
+    return 1;
+l:
+    return 0;
+}
+
+int out_of_if_1(void)
+{
+    goto l;
+k:
+    return 0;
+l:
+    if (1)
+    {
+        goto k;
+        return 1;
+    }
+    return 1;
+}
+
+int in_and_out_of_if(void)
+{
+    if (1)
+    {
+        goto l;
+    k:
+        return 0;
+    }
+    return 1;
+l:
+    goto k;
+    return 1;
+}
+
+int many_labels_and_gotos(void)
+{
+    int i = 1;
+    int j = 1;
+l:
+    if (i)
+    {
+        goto k;
+    }
+    if (j)
+    {
+        j = 0;
+        goto k;
+    }
+
+    return i || j;
+
+k:
+    if (j)
+    {
+        i = 0;
+        goto l;
+    }
+    goto l;
+
+    return 1;
+}
+
+int into_else(void)
+{
+    int i = 1;
+    goto l;
+    if (i)
+        return 1;
+    else
+    l:
+        return 0;
+    return 1;
+}
+
+int if_to_else(void)
+{
+    int ret = 1;
+    if (ret = 0, 1)
+    {
+        goto l;
+        return 1;
+    }
+    else
+    {
+        return 1;
+    l:
+        return ret;
+    }
+    return 1;
+}
+
+int else_to_if(void)
+{
+    if (0)
+    {
+        return 1;
+    l:
+        return 0;
+    }
+    else
+    {
+        goto l;
+        return 1;
+    }
+    return 1;
+}
+
+int if_cond(void)
+{
+    int ret = 0;
+    goto l;
+    if (ret = 1)
+    {
+        return 1;
+    l:
+        return ret;
+    }
+    return 1;
+}
+
+int else_cond(void)
+{
+    int ret = 0;
+    goto l;
+    if (ret = 1, 0)
+    {
+        return 1;
+    }
+    else
+    {
+        return 1;
+    l:
+        return ret;
+    }
+    return 1;
+}
+
+int into_while_loop_0(void)
+{
+    int ret = 0;
+    goto l;
+    while (ret = 1, 0)
+    {
+        return 1;
+    l:
+        return 0;
+    }
+    return 1;
+}
+
+int into_while_loop_1(void)
+{
+    while (0)
+    {
+        return 1;
+    l:
+        return 0;
+    }
+    goto l;
+    return 1;
+}
+
+int out_of_while_loop_0(void)
+{
+    while (1)
+    {
+        goto l;
+        return 1;
+    }
+    return 1;
+l:
+    return 0;
+}
+
+int out_of_while_loop_1(void)
+{
+    int i = 1;
+l:
+    while (i)
+    {
+        i = 0;
+        goto l;
+        return 1;
+    }
+    return 0;
+}
+
+int into_for_loop_0(void)
+{
+    int ret = 0;
+    goto l;
+    for (ret = 1; ret = 1, 0; ret = 1)
+    {
+        return 1;
+    l:
+        return ret;
+    }
+    return 1;
+}
+
+int into_for_loop_1(void)
+{
+    int ret = 2;
+    for (ret = 2; ret = 1, 0; ret = 2)
+    {
+        return 1;
+    l:
+        return ret;
+    }
+
+    if (ret != 1)
+    {
+        return 1;
+    }
+    ret = 0;
+
+    goto l;
+    return 1;
+}
+
+int out_of_for_loop_0(void)
+{
+    int ret0 = 1;
+    int ret1 = 1;
+    int ret2 = 0;
+    for (ret0 = 0; ret1 = 0, 1; ret2 = 1)
+    {
+        goto l;
+        return 1;
+    }
+    return 1;
+l:
+    return ret0 || ret1 || ret2;
+}
+
+int out_of_for_loop_1(void)
+{
+    int i = 1;
+    int ret0 = 1;
+    int ret1 = 1;
+    int ret2 = 0;
+l:
+    for (ret0 = 0; ret1 = 0, i; ret2 = 1)
+    {
+        i = 0;
+        goto l;
+        return 1;
+    }
+    return i == 0 && (ret0 || ret1 || ret2);
+}
+
+int into_switch_case(void)
+{
+    goto l;
+    switch (0)
+    {
+        return 1;
+    case 1:
+    l:
+        return 0;
+    default:
+        return 1;
+    }
+    return 1;
+}
+
+int into_switch_case_not_at_the_beginning(void)
+{
+    int ret = 0;
+    goto l;
+    switch (0)
+    {
+        return 1;
+    case 1:
+        ret = 1;
+    l:
+        return ret;
+    default:
+        return 1;
+    }
+    return 1;
+}
+
+int into_switch_between_cases(void)
+{
+    int ret = 0;
+    goto l;
+    switch (0)
+    {
+        return 1;
+    case 1:
+        return 1;
+    l:
+        return ret;
+    default:
+        return 1;
+    }
+    return 1;
+}
+
+int into_switch_start(void)
+{
+    goto l;
+    switch (0)
+    {
+    l:
+        return 0;
+    default:
+        return 1;
+    }
+    return 1;
+}
+
+int into_switch_default(void)
+{
+    goto l;
+    switch (0)
+    {
+    case 0:
+        return 1;
+    default:
+    l:
+        return 0;
+    }
+    return 1;
+}
+
+int switch_from_case_to_case(void)
+{
+    switch (0)
+    {
+    case 0:
+        goto l;
+        return 1;
+    case 1:
+    l:
+        return 0;
+    default:
+        return 1;
+    }
+    return 1;
+}
+
+int switch_from_case_to_same_case(void)
+{
+    int i = 1;
+    switch (0)
+    {
+    case 0:
+    l:;
+        if (i)
+        {
+            i = 0;
+            goto l;
+        }
+        return 0;
+    default:
+        return 1;
+    }
+    return 1;
+}
+
+int switch_from_case_to_case_not_at_the_beginning(void)
+{
+    int ret = 1;
+    switch (0)
+    {
+    case 0:
+        ret = 0;
+        goto l;
+        return 1;
+    case 1:
+        ret = 1;
+    l:
+        return ret;
+    default:
+        return 1;
+    }
+    return 1;
+}
+
+int switch_from_case_to_between_cases(void)
+{
+    int ret = 1;
+    switch (0)
+    {
+    case 0:
+        ret = 0;
+        goto l;
+        return 1;
+    case 1:
+        return 1;
+    l:
+        return ret;
+    default:
+        return 1;
+    }
+    return 1;
+}
+
+int switch_from_case_to_start(void)
+{
+    int ret = 1;
+    switch (0)
+    {
+    l:
+        return ret;
+    case 0:
+        ret = 0;
+        goto l;
+        return 1;
+    default:
+        return 1;
+    }
+    return 1;
+}
+
+int switch_from_case_to_default(void)
+{
+    switch (0)
+    {
+    case 0:
+        goto l;
+        return 1;
+    default:
+    l:
+        return 0;
+    }
+    return 1;
+}
+
+int gcd(void)
+{
+    int a = 48;
+    int b = 18;
+
+loop:
+    if (a == b)
+        goto finish;
+
+    if (a < b)
+        goto b_minus_a;
+
+    a = a - b;
+    goto loop;
+
+b_minus_a:
+    b = b - a;
+
+    goto loop;
+
+finish:
+
+    return a == 6 ? 0 : 1;
+}
+
+int main()
+{
+    return downwards_0() ||
+           downwards_1() ||
+           upwards() ||
+           two_labels() ||
+           simple_scope_0() ||
+           simple_scope_1() ||
+           into_if_0() ||
+           into_if_1() ||
+           out_of_if_0() ||
+           out_of_if_1() ||
+           in_and_out_of_if() ||
+           many_labels_and_gotos() ||
+           into_else() ||
+           if_to_else() ||
+           else_to_if() ||
+           if_cond() ||
+           else_cond() ||
+           into_while_loop_0() ||
+           into_while_loop_1() ||
+           out_of_while_loop_0() ||
+           out_of_while_loop_1() ||
+           into_for_loop_0() ||
+           into_for_loop_1() ||
+           out_of_for_loop_0() ||
+           out_of_for_loop_1() ||
+           into_switch_case() ||
+           into_switch_case_not_at_the_beginning() ||
+           into_switch_between_cases() ||
+           into_switch_start() ||
+           into_switch_default() ||
+           switch_from_case_to_case() ||
+           switch_from_case_to_same_case() ||
+           switch_from_case_to_case_not_at_the_beginning() ||
+           switch_from_case_to_between_cases() ||
+           switch_from_case_to_start() ||
+           switch_from_case_to_default() ||
+           gcd();
+}
+
+// run-translated-c
+// c_frontend=clang

--- a/test/cases/translate_c/goto_tests.c
+++ b/test/cases/translate_c/goto_tests.c
@@ -1,0 +1,217 @@
+void cleanup1(void);
+void cleanup2(void);
+void cleanup3(void);
+
+int doSth(void);
+void doSth2(void);
+int getState(void);
+int getIters(void);
+
+void foo(void)
+{
+
+    if (doSth() != 0)
+    {
+        goto cleanup_3;
+    }
+
+loop:;
+    int state = getState();
+
+    switch (state)
+    {
+    label:
+        if (doSth() != 0)
+            goto cleanup_2;
+    case 0:
+        if (doSth() != 0)
+        {
+            goto cleanup_3;
+        }
+        break;
+    case 1:;
+        int iters = getIters();
+        for (int i = 0; i < iters; i++)
+        {
+        label2:
+            doSth2();
+        }
+
+        goto label;
+    case 2:
+        iters = 2048;
+        goto label2;
+    }
+
+    goto loop;
+
+a_unused_label:
+cleanup_1:
+    cleanup1();
+cleanup_2:
+    cleanup2();
+cleanup_3:
+    cleanup3();
+}
+// translate-c
+// target=x86_64-linux
+// c_frontend=clang
+//
+// pub export fn foo() void {
+//     var goto_label: bool = false;
+//     var goto_label2: bool = false;
+//     var goto_cleanup_3: bool = false;
+//     var goto_loop: bool = false;
+//     var goto_cleanup_2: bool = false;
+//     if (!(goto_cleanup_2 or (goto_loop or (goto_cleanup_3 or goto_cleanup_3)))) {
+//         blk: {
+//             if (doSth() != @as(c_int, 0)) {
+//                 {
+//                     goto_cleanup_3 = true;
+//                     break :blk;
+//                 }
+//             }
+//         }
+//     }
+//     var state: c_int = undefined;
+//     _ = &state;
+//     while (true) blk: {
+//         if (!(goto_cleanup_2 or (goto_cleanup_3 or goto_cleanup_3))) {
+//             {
+//                 goto_loop = false;
+//                 {}
+//             }
+//             state = getState();
+//             blk_1: {
+//                 {
+//                     var iters: c_int = undefined;
+//                     _ = &iters;
+//                     while (true) blk_2: {
+//                         switch (@as(enum {
+//                             goto_case_1,
+//                             case_1,
+//                             case_2,
+//                             goto_case_2,
+//                             case_4,
+//                         }, if (goto_label2) .goto_case_2 else if (goto_label) .goto_case_1 else switch (state) {
+//                             @as(c_int, 0) => .case_1,
+//                             @as(c_int, 1) => .case_2,
+//                             @as(c_int, 2) => .case_4,
+//                             else => break,
+//                         })) {
+//                             .goto_case_1 => {
+//                                 {
+//                                     goto_label = false;
+//                                     if (doSth() != @as(c_int, 0)) {
+//                                         {
+//                                             goto_cleanup_2 = true;
+//                                             break :blk_1;
+//                                         }
+//                                     }
+//                                 }
+//                                 if (doSth() != @as(c_int, 0)) {
+//                                     {
+//                                         goto_cleanup_3 = true;
+//                                         break :blk_1;
+//                                     }
+//                                 }
+//                                 break;
+//                             },
+//                             .case_1 => {
+//                                 if (doSth() != @as(c_int, 0)) {
+//                                     {
+//                                         goto_cleanup_3 = true;
+//                                         break :blk_1;
+//                                     }
+//                                 }
+//                                 break;
+//                             },
+//                             .case_2 => {
+//                                 {}
+//                                 iters = getIters();
+//                                 {
+//                                     var i: c_int = undefined;
+//                                     _ = &i;
+//                                     if (!goto_label2) {
+//                                         i = 0;
+//                                     }
+//                                     while (goto_label2 or (i < iters)) : (i += 1) {
+//                                         {
+//                                             goto_label2 = false;
+//                                             doSth2();
+//                                         }
+//                                     }
+//                                 }
+//                                 {
+//                                     goto_label = true;
+//                                     break :blk_2;
+//                                 }
+//                                 iters = 2048;
+//                                 {
+//                                     goto_label2 = true;
+//                                     break :blk_2;
+//                                 }
+//                             },
+//                             .goto_case_2 => {
+//                                 {
+//                                     var i: c_int = undefined;
+//                                     _ = &i;
+//                                     if (!goto_label2) {
+//                                         i = 0;
+//                                     }
+//                                     while (goto_label2 or (i < iters)) : (i += 1) {
+//                                         {
+//                                             goto_label2 = false;
+//                                             doSth2();
+//                                         }
+//                                     }
+//                                 }
+//                                 {
+//                                     goto_label = true;
+//                                     break :blk_2;
+//                                 }
+//                                 iters = 2048;
+//                                 {
+//                                     goto_label2 = true;
+//                                     break :blk_2;
+//                                 }
+//                             },
+//                             .case_4 => {
+//                                 iters = 2048;
+//                                 {
+//                                     goto_label2 = true;
+//                                     break :blk_2;
+//                                 }
+//                             },
+//                         }
+//                         break;
+//                     }
+//                 }
+//             }
+//         }
+//         if (!(goto_cleanup_2 or (goto_cleanup_3 or goto_cleanup_3))) {
+//             {
+//                 goto_loop = true;
+//                 break :blk;
+//             }
+//         }
+//         break;
+//     }
+//     if (!(goto_cleanup_2 or (goto_cleanup_3 or goto_cleanup_3))) {
+//         {
+//             {
+//                 cleanup1();
+//             }
+//         }
+//     }
+//     if (!(goto_cleanup_3 or goto_cleanup_3)) {
+//         {
+//             goto_cleanup_2 = false;
+//             cleanup2();
+//         }
+//     }
+//     {
+//         goto_cleanup_3 = false;
+//         cleanup3();
+//     }
+// }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2024,49 +2024,53 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    _ = &i;
         \\    var res: c_int = 0;
         \\    _ = &res;
-        \\    while (true) {
-        \\        switch (i) {
-        \\            @as(c_int, 0) => {
-        \\                res = 1;
-        \\                res = 2;
-        \\                res = @as(c_int, 3) * i;
-        \\                break;
-        \\            },
-        \\            @as(c_int, 1)...@as(c_int, 3) => {
-        \\                res = 2;
-        \\                res = @as(c_int, 3) * i;
-        \\                break;
-        \\            },
-        \\            else => {
-        \\                res = @as(c_int, 3) * i;
-        \\                break;
-        \\            },
-        \\            @as(c_int, 7) => {
-        \\                {
-        \\                    res = 7;
+        \\    {
+        \\        while (true) {
+        \\            switch (i) {
+        \\                @as(c_int, 0) => {
+        \\                    res = 1;
+        \\                    res = 2;
+        \\                    res = @as(c_int, 3) * i;
         \\                    break;
-        \\                }
-        \\            },
-        \\            @as(c_int, 4), @as(c_int, 5) => {
-        \\                res = 69;
-        \\                {
-        \\                    res = 5;
-        \\                    return;
-        \\                }
-        \\            },
-        \\            @as(c_int, 6) => {
-        \\                while (true) {
-        \\                    switch (res) {
-        \\                        @as(c_int, 9) => break,
-        \\                        else => {},
+        \\                },
+        \\                @as(c_int, 1)...@as(c_int, 3) => {
+        \\                    res = 2;
+        \\                    res = @as(c_int, 3) * i;
+        \\                    break;
+        \\                },
+        \\                else => {
+        \\                    res = @as(c_int, 3) * i;
+        \\                    break;
+        \\                },
+        \\                @as(c_int, 7) => {
+        \\                    {
+        \\                        res = 7;
+        \\                        break;
         \\                    }
-        \\                    break;
-        \\                }
-        \\                res = 1;
-        \\                return;
-        \\            },
+        \\                },
+        \\                @as(c_int, 4), @as(c_int, 5) => {
+        \\                    res = 69;
+        \\                    {
+        \\                        res = 5;
+        \\                        return;
+        \\                    }
+        \\                },
+        \\                @as(c_int, 6) => {
+        \\                    {
+        \\                        while (true) {
+        \\                            switch (res) {
+        \\                                @as(c_int, 9) => break,
+        \\                                else => break,
+        \\                            }
+        \\                            break;
+        \\                        }
+        \\                    }
+        \\                    res = 1;
+        \\                    return;
+        \\                },
+        \\            }
+        \\            break;
         \\        }
-        \\        break;
         \\    }
         \\}
     });


### PR DESCRIPTION
Goto support works by creating a boolean variable per label, which is false by default. A goto changes this variable to `true` and breaks to the highest common scope of the goto and the label. Now, `if` and `while` statements, which are controlled by the boolean variable, jump over the execution part of the code to get to the label.


closes #11992