### PR TITLE
Add .inc file ext to behave like a C header

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5073,7 +5073,7 @@ pub fn addCCArgs(
     try argv.appendSlice(&[_][]const u8{ "-target", llvm_triple });
 
     if (target.os.tag == .windows) switch (ext) {
-        .c, .cpp, .m, .mm, .h, .hpp, .hm, .hmm, .cu, .rc, .assembly, .assembly_with_cpp => {
+        .c, .cpp, .m, .mm, .inc, .h, .hpp, .hm, .hmm, .cu, .rc, .assembly, .assembly_with_cpp => {
             const minver: u16 = @truncate(@intFromEnum(target.os.getVersionRange().windows.min) >> 16);
             try argv.append(
                 try std.fmt.allocPrint(arena, "-D_WIN32_WINNT=0x{x:0>4}", .{minver}),
@@ -5083,7 +5083,7 @@ pub fn addCCArgs(
     };
 
     switch (ext) {
-        .c, .cpp, .m, .mm, .h, .hpp, .hm, .hmm, .cu, .rc => {
+        .c, .cpp, .m, .mm, .inc, .h, .hpp, .hm, .hmm, .cu, .rc => {
             try argv.appendSlice(&[_][]const u8{
                 "-nostdinc",
                 "-fno-spell-checking",
@@ -5651,6 +5651,7 @@ pub const FileExt = enum {
     cpp,
     cu,
     h,
+    inc,
     hpp,
     hm,
     hmm,
@@ -5672,7 +5673,7 @@ pub const FileExt = enum {
 
     pub fn clangSupportsDepFile(ext: FileExt) bool {
         return switch (ext) {
-            .c, .cpp, .h, .hpp, .hm, .hmm, .m, .mm, .cu => true,
+            .c, .cpp, .inc, .h, .hpp, .hm, .hmm, .m, .mm, .cu => true,
 
             .ll,
             .bc,
@@ -5696,6 +5697,7 @@ pub const FileExt = enum {
             .c => ".c",
             .cpp => ".cpp",
             .cu => ".cu",
+            .inc => ".inc",
             .h => ".h",
             .hpp => ".h",
             .hm => ".h",
@@ -5793,6 +5795,8 @@ pub fn classifyFileExt(filename: []const u8) FileExt {
         return .assembly_with_cpp;
     } else if (mem.endsWith(u8, filename, ".h")) {
         return .h;
+    } else if (mem.endsWith(u8, filename, ".inc")){
+        return .inc;
     } else if (mem.endsWith(u8, filename, ".zig")) {
         return .zig;
     } else if (hasSharedLibraryExt(filename)) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1679,7 +1679,7 @@ fn buildOutputType(
                             fatal("only one manifest file can be specified, found '{s}' after '{s}'", .{ arg, other });
                         } else manifest_file = arg;
                     },
-                    .assembly, .assembly_with_cpp, .c, .cpp, .h, .hpp, .hm, .hmm, .ll, .bc, .m, .mm, .cu => {
+                    .assembly, .assembly_with_cpp, .c, .cpp, .inc, .h, .hpp, .hm, .hmm, .ll, .bc, .m, .mm, .cu => {
                         try create_module.c_source_files.append(arena, .{
                             // Populated after module creation.
                             .owner = undefined,
@@ -1774,7 +1774,7 @@ fn buildOutputType(
                         try cc_argv.appendSlice(arena, it.other_args);
                     },
                     .positional => switch (file_ext orelse Compilation.classifyFileExt(mem.sliceTo(it.only_arg, 0))) {
-                        .assembly, .assembly_with_cpp, .c, .cpp, .ll, .bc, .h, .hpp, .hm, .hmm, .m, .mm, .cu => {
+                        .assembly, .assembly_with_cpp, .c, .cpp, .ll, .bc, .inc, .h, .hpp, .hm, .hmm, .m, .mm, .cu => {
                             try create_module.c_source_files.append(arena, .{
                                 // Populated after module creation.
                                 .owner = undefined,


### PR DESCRIPTION
There are C projects that for some reason use `.inc` file extensions and use them as header files ([nanomsg](https://github.com/nanomsg/nanomsg) for example). `.inc` files are unrecognized file extension currently.

The patch adds `.inc` file ext to behave like an `.h` as I understand it. 

Please comment if this is unreasonable and suggest a way to handle `.inc` ext when dealing with 3rd party C projects.