### PR TITLE
test: reenable some behavior vector tests

### DIFF
--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -717,19 +717,14 @@ test "vector shift operators" {
     };
 
     switch (builtin.target.cpu.arch) {
-        .x86,
-        .aarch64,
         .aarch64_be,
         .aarch64_32,
-        .arm,
         .armeb,
         .thumb,
         .thumbeb,
         .mips,
-        .mipsel,
         .mips64,
         .mips64el,
-        .riscv64,
         .sparc64,
         => {
             // LLVM miscompiles on this architecture


### PR DESCRIPTION
tested manually with qemu

Cc: https://github.com/ziglang/zig/issues/4951