### PR TITLE
Use the global cache dir for the manifests of generated mingw `.lib`s

### DIFF
--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -178,13 +178,15 @@ pub fn buildImportLib(comp: *Compilation, lib_name: []const u8) !void {
 
     const target = comp.getTarget();
 
+    // Use the global cache directory.
     var cache: Cache = .{
         .gpa = comp.gpa,
-        .manifest_dir = comp.cache_parent.manifest_dir,
+        .manifest_dir = try comp.global_cache_directory.handle.makeOpenPath("h", .{}),
     };
-    for (comp.cache_parent.prefixes()) |prefix| {
-        cache.addPrefix(prefix);
-    }
+    cache.addPrefix(.{ .path = null, .handle = std.fs.cwd() });
+    cache.addPrefix(comp.zig_lib_directory);
+    cache.addPrefix(comp.global_cache_directory);
+    defer cache.manifest_dir.close();
 
     cache.hash.addBytes(build_options.version);
     cache.hash.addOptionalBytes(comp.zig_lib_directory.path);


### PR DESCRIPTION
Fixes a mismatch where the manifests would be written to the local cache dir, but the .def/.lib files themselves would be written to the global cache dir. This meant that if you cleared your global cache, your local cache would still think that the .lib files existed in the cache and it'd lead to 'No such file or directory' errors at linktime.

This local/global cache mismatch was introduced in the stage1 -> stage2 transition of this code.

---

This is something I've run into many times but never looked into the root cause until now.

Note: The `mingw.zig` code now matches what's done in `glibc.zig`:

https://github.com/ziglang/zig/blob/90c1a2c41aafb1e35e075fb7d0bdcf04c00db913/src/glibc.zig#L676-L684