### PR TITLE
Fix doc - Language Reference - Table of Operators

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1643,7 +1643,7 @@ a -|= b{#endsyntax#}</pre></td>
             </ul>
           </td>
           <td>
-            <pre>{#syntax#}-%@as(i8, -127) == -127{#endsyntax#}</pre>
+            <pre>{#syntax#}-%@as(i8, -128) == -128{#endsyntax#}</pre>
           </td>
         </tr>
         <tr>
@@ -2111,7 +2111,7 @@ unwrapped == 1234{#endsyntax#}</pre>
             Invokes {#link|Peer Type Resolution#} for the operands.
           </td>
           <td>
-            <pre>{#syntax#}(1 < 2) == true{#endsyntax#}></pre>
+            <pre>{#syntax#}(1 < 2) == true{#endsyntax#}</pre>
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
Fix doc for "Wrapping Negation", which happens for minInt(i8), which is `-128`, not `-127`

Also fix surplus char `>`