### PR TITLE
LLVM lowerDebugType: Lower union types without a layout into an empty namespace 

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2598,7 +2598,10 @@ pub const Object = struct {
                 defer gpa.free(name);
 
                 const union_type = ip.loadUnionType(ty.toIntern());
-                if (!union_type.haveFieldTypes(ip) or !ty.hasRuntimeBitsIgnoreComptime(mod)) {
+                if (!union_type.haveFieldTypes(ip) or
+                    !ty.hasRuntimeBitsIgnoreComptime(mod) or
+                    !union_type.haveLayout(ip))
+                {
                     const debug_union_type = try o.makeEmptyNamespaceDebugType(owner_decl_index);
                     try o.debug_type_map.put(gpa, ty, debug_union_type);
                     return debug_union_type;

--- a/test/cases/union_unresolved_layout.zig
+++ b/test/cases/union_unresolved_layout.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+
+const U = union(enum) {
+    foo: u8,
+    bar: f64,
+};
+
+pub fn main() !void {
+    const t = U.foo;
+    _ = t;
+}
+
+// run
+// backend=llvm
+//


### PR DESCRIPTION
Fixes  #18518

I think the bug is actually in the llvm backend and not the frontend as the union type actually isn't used at runtime, only the field type is referenced and thus the union does not get a layout. The fix implemented here just emits an empty namespace as a debug type for unions without layout. I don't think this fix should have any real consequences on the debugability of programs as there won't ever be values with that debug type.