### PR TITLE
std: expose Config struct of GeneralPurposeAllocator

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -14,6 +14,7 @@ pub const ScopedLoggingAllocator = @import("heap/logging_allocator.zig").ScopedL
 pub const LogToWriterAllocator = @import("heap/log_to_writer_allocator.zig").LogToWriterAllocator;
 pub const logToWriterAllocator = @import("heap/log_to_writer_allocator.zig").logToWriterAllocator;
 pub const ArenaAllocator = @import("heap/arena_allocator.zig").ArenaAllocator;
+pub const GeneralPurposeAllocatorConfig = @import("heap/general_purpose_allocator.zig").Config;
 pub const GeneralPurposeAllocator = @import("heap/general_purpose_allocator.zig").GeneralPurposeAllocator;
 pub const Check = @import("heap/general_purpose_allocator.zig").Check;
 pub const WasmAllocator = @import("heap/WasmAllocator.zig");


### PR DESCRIPTION
The `Config` struct of `GeneralPurposeAllocator` was previously not accessible in the `std.heap` namespace.

I also noticed that the return type of the `std.heap.GeneralPurposeAllocator().deinit` function was accessible as `std.heap.Check` instead of something like `std.heap.GeneralPurposeAllocatorCheck` but I didn't want to add a potential breaking change that may not be necessary. Should this also be changed?