### PR TITLE
std.os: make access respect EPERM; make AccessError consistent

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1283,7 +1283,7 @@ pub fn GetFileSizeEx(hFile: HANDLE) GetFileSizeError!u64 {
 
 pub const GetFileAttributesError = error{
     FileNotFound,
-    PermissionDenied,
+    AccessDenied,
     Unexpected,
 };
 
@@ -1298,7 +1298,7 @@ pub fn GetFileAttributesW(lpFileName: [*:0]const u16) GetFileAttributesError!DWO
         switch (kernel32.GetLastError()) {
             .FILE_NOT_FOUND => return error.FileNotFound,
             .PATH_NOT_FOUND => return error.FileNotFound,
-            .ACCESS_DENIED => return error.PermissionDenied,
+            .ACCESS_DENIED => return error.AccessDenied,
             else => |err| return unexpectedError(err),
         }
     }
@@ -1513,12 +1513,12 @@ pub fn GetModuleFileNameW(hModule: ?HMODULE, buf_ptr: [*]u16, buf_len: DWORD) Ge
     return buf_ptr[0..rc :0];
 }
 
-pub const TerminateProcessError = error{ PermissionDenied, Unexpected };
+pub const TerminateProcessError = error{ AccessDenied, Unexpected };
 
 pub fn TerminateProcess(hProcess: HANDLE, uExitCode: UINT) TerminateProcessError!void {
     if (kernel32.TerminateProcess(hProcess, uExitCode) == 0) {
         switch (kernel32.GetLastError()) {
-            Win32Error.ACCESS_DENIED => return error.PermissionDenied,
+            Win32Error.ACCESS_DENIED => return error.AccessDenied,
             else => |err| return unexpectedError(err),
         }
     }


### PR DESCRIPTION
Resolves #19162 

access and accessat family of functions:
- recognize EPERM as AccessError.PermissionDenied
- recognize EACCES as AccessError.AccessDenied, which is consistent with other functions in std.os