### PR TITLE
test manifest key checking and other fixes

### DIFF
--- a/test/cases/run_translated_c/compound_assignments_with_implicit_casts.c
+++ b/test/cases/run_translated_c/compound_assignments_with_implicit_casts.c
@@ -17,4 +17,4 @@ int main() {
 }
 
 // run-translated-c
-// c_frontends=aro,clang
+// c_frontend=clang

--- a/test/cases/run_translated_c/explicit_cast_bool_from_float.c
+++ b/test/cases/run_translated_c/explicit_cast_bool_from_float.c
@@ -7,4 +7,4 @@ int main() {
 }
 
 // run-translated-c
-// c_frontends=aro,clang
+// c_frontend=clang


### PR DESCRIPTION
This PR adds several fixes and improvements for the Zig compiler test harness.

1. -Dskip-translate-c option added for skipping the translate-c tests.
2. translate-c and run-translated-c tests in test/cases/* have been added to the `test-translate-c` and `test-run-translated-c` steps. Closes #18224.
3. Custom name added to the CheckFile step for the translate-c tests to better communicate which test failed.
4. Test manifest key validation added to return an error if a manifest contains an invalid key.