### PR TITLE
make `math.degreesToRadians` and `math.radiansToDegrees` infer type from argument

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -322,18 +322,16 @@ test "radiansToDegrees" {
     try std.testing.expectApproxEqAbs(@as(f32, 180), radiansToDegrees(one_pi), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 360), radiansToDegrees(two_pi), 1e-6);
 
-    const result = radiansToDegrees(@Vector(5, f32){
-        zero,
+    const result = radiansToDegrees(@Vector(4, f32){
         half_pi,
         neg_quart_pi,
         one_pi,
         two_pi,
     });
-    try std.testing.expectApproxEqAbs(@as(f32, 0), result[0], 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 90), result[1], 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, -45), result[2], 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 180), result[3], 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 360), result[4], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 90), result[0], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -45), result[1], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 180), result[2], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 360), result[3], 1e-6);
 }
 
 /// Converts an angle in degrees to radians. T must be a float or comptime number or a vector of floats.

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -300,11 +300,11 @@ pub inline fn tan(value: anytype) @TypeOf(value) {
 }
 
 /// Converts an angle in radians to degrees. T must be a float or comptime number or a vector of floats.
-pub fn radiansToDegrees(ang: anytype) (if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang)) {
+pub fn radiansToDegrees(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang) {
     const T = @TypeOf(ang);
     switch (@typeInfo(T)) {
         .Float, .ComptimeFloat, .ComptimeInt => return ang * deg_per_rad,
-        .Vector => |V| if (V.child == .Float) return ang * @as(T, @splat(deg_per_rad)),
+        .Vector => |V| if (@typeInfo(V.child) == .Float) return ang * @as(T, @splat(deg_per_rad)),
         else => {},
     }
     @compileError("Input must be float or a comptime number, or a vector of floats.");
@@ -336,11 +336,11 @@ test "radiansToDegrees" {
 }
 
 /// Converts an angle in degrees to radians. T must be a float or comptime number or a vector of floats.
-pub fn degreesToRadians(ang: anytype) (if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang)) {
+pub fn degreesToRadians(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang) {
     const T = @TypeOf(ang);
     switch (@typeInfo(T)) {
         .Float, .ComptimeFloat, .ComptimeInt => return ang * rad_per_deg,
-        .Vector => |V| if (V.child == .Float) return ang * @as(@TypeOf(ang), @splat(rad_per_deg)),
+        .Vector => |V| if (@typeInfo(V.child) == .Float) return ang * @as(@TypeOf(ang), @splat(rad_per_deg)),
         else => {},
     }
     @compileError("Input must be float or a comptime number, or a vector of floats.");

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -299,28 +299,8 @@ pub inline fn tan(value: anytype) @TypeOf(value) {
     return @tan(value);
 }
 
-/// output type of radiansToDegrees and degreesToRadians
-fn AngleType(comptime T: type) type {
-    return switch (@typeInfo(T)) {
-        .Float, .ComptimeFloat => T,
-        .ComptimeInt => comptime_float,
-        .Vector => |V| {
-            switch (V.child) {
-                .Float, .ComptimeFloat => T,
-                .ComptimeInt => do: {
-                    var U = V;
-                    U.child = comptime_float;
-                    break :do @Type(U);
-                },
-                else => @compileError("Input must be float or a comptime type, or a vector of such."),
-            }
-        },
-        else => @compileError("Input must be float or a comptime type, or a vector of such."),
-    };
-}
-
 /// Converts an angle in radians to degrees. T must be a float type.
-pub fn radiansToDegrees(ang: anytype) AngleType(@TypeOf(ang)) {
+pub fn radiansToDegrees(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang) {
     const T = @TypeOf(ang);
     switch (@typeInfo(T)) {
         .Float, .ComptimeFloat, .ComptimeInt => {
@@ -328,7 +308,8 @@ pub fn radiansToDegrees(ang: anytype) AngleType(@TypeOf(ang)) {
         },
         .Vector => |V| {
             switch (V.child) {
-                .Float, .ComptimeFloat, .ComptimeInt => {
+                .Float,
+                => {
                     return ang * @as(T, @splat(deg_per_rad));
                 },
                 else => {},
@@ -336,7 +317,7 @@ pub fn radiansToDegrees(ang: anytype) AngleType(@TypeOf(ang)) {
         },
         else => {},
     }
-    @compileError("Input must be float or a comptime type, or a vector of such.");
+    @compileError("Input must be float or a comptime type, or a vector of floats.");
 }
 
 test "radiansToDegrees" {
@@ -353,7 +334,7 @@ test "radiansToDegrees" {
 }
 
 /// Converts an angle in degrees to radians. T must be a float type.
-pub fn degreesToRadians(ang: anytype) AngleType(@TypeOf(ang)) {
+pub fn degreesToRadians(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang) {
     const T = @TypeOf(ang);
     switch (@typeInfo(T)) {
         .Float, .ComptimeFloat, .ComptimeInt => {
@@ -361,7 +342,8 @@ pub fn degreesToRadians(ang: anytype) AngleType(@TypeOf(ang)) {
         },
         .Vector => |V| {
             switch (V.child) {
-                .Float, .ComptimeFloat, .ComptimeInt => {
+                .Float,
+                => {
                     return ang * @as(T, @splat(rad_per_deg));
                 },
                 else => {},
@@ -369,7 +351,7 @@ pub fn degreesToRadians(ang: anytype) AngleType(@TypeOf(ang)) {
         },
         else => {},
     }
-    @compileError("Input must be float or a comptime type, or a vector of such.");
+    @compileError("Input must be float or a comptime type, or a vector of floats.");
 }
 
 test "degreesToRadians" {

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -316,6 +316,12 @@ test "radiansToDegrees" {
     const neg_quart_pi: f32 = -pi / 4.0;
     const one_pi: f32 = pi;
     const two_pi: f32 = 2.0 * pi;
+    try std.testing.expectApproxEqAbs(@as(f32, 0), radiansToDegrees(zero), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 90), radiansToDegrees(half_pi), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -45), radiansToDegrees(neg_quart_pi), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 180), radiansToDegrees(one_pi), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 360), radiansToDegrees(two_pi), 1e-6);
+
     const result = radiansToDegrees(@Vector(5, f32){
         zero,
         half_pi,
@@ -323,11 +329,6 @@ test "radiansToDegrees" {
         one_pi,
         two_pi,
     });
-    try std.testing.expectApproxEqAbs(@as(f32, 0), radiansToDegrees(zero), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 90), radiansToDegrees(half_pi), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, -45), radiansToDegrees(neg_quart_pi), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 180), radiansToDegrees(one_pi), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 360), radiansToDegrees(two_pi), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 0), result[0], 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 90), result[1], 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, -45), result[2], 1e-6);
@@ -340,7 +341,7 @@ pub fn degreesToRadians(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime
     const T = @TypeOf(ang);
     switch (@typeInfo(T)) {
         .Float, .ComptimeFloat, .ComptimeInt => return ang * rad_per_deg,
-        .Vector => |V| if (@typeInfo(V.child) == .Float) return ang * @as(@TypeOf(ang), @splat(rad_per_deg)),
+        .Vector => |V| if (@typeInfo(V.child) == .Float) return ang * @as(T, @splat(rad_per_deg)),
         else => {},
     }
     @compileError("Input must be float or a comptime number, or a vector of floats.");
@@ -350,14 +351,15 @@ test "degreesToRadians" {
     const ninety: f32 = 90;
     const neg_two_seventy: f32 = -270;
     const three_sixty: f32 = 360;
-    const result = @Vector(3, f32){
-        ninety,
-        neg_two_seventy,
-        three_sixty,
-    };
     try std.testing.expectApproxEqAbs(@as(f32, pi / 2.0), degreesToRadians(ninety), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, -3 * pi / 2.0), degreesToRadians(neg_two_seventy), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 2 * pi), degreesToRadians(three_sixty), 1e-6);
+
+    const result = degreesToRadians(@Vector(3, f32){
+        ninety,
+        neg_two_seventy,
+        three_sixty,
+    });
     try std.testing.expectApproxEqAbs(@as(f32, pi / 2.0), result[0], 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, -3 * pi / 2.0), result[1], 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 2 * pi), result[2], 1e-6);

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -37,6 +37,12 @@ pub const sqrt2 = 1.414213562373095048801688724209698079;
 /// 1/sqrt(2)
 pub const sqrt1_2 = 0.707106781186547524400844362104849039;
 
+/// pi/180.0
+pub const rad_per_deg = 0.0174532925199432957692369076848861271344287188854172545609719144;
+
+/// 180.0/pi
+pub const deg_per_rad = 57.295779513082320876798154814105170332405472466564321549160243861;
+
 pub const floatExponentBits = @import("math/float.zig").floatExponentBits;
 pub const floatMantissaBits = @import("math/float.zig").floatMantissaBits;
 pub const floatFractionalBits = @import("math/float.zig").floatFractionalBits;
@@ -297,7 +303,7 @@ pub inline fn tan(value: anytype) @TypeOf(value) {
 pub fn radiansToDegrees(comptime T: type, angle_in_radians: T) T {
     if (@typeInfo(T) != .Float and @typeInfo(T) != .ComptimeFloat)
         @compileError("T must be a float type");
-    return angle_in_radians * 180.0 / pi;
+    return angle_in_radians * deg_per_rad;
 }
 
 test "radiansToDegrees" {
@@ -312,7 +318,7 @@ test "radiansToDegrees" {
 pub fn degreesToRadians(comptime T: type, angle_in_degrees: T) T {
     if (@typeInfo(T) != .Float and @typeInfo(T) != .ComptimeFloat)
         @compileError("T must be a float type");
-    return angle_in_degrees * pi / 180.0;
+    return angle_in_degrees * rad_per_deg;
 }
 
 test "degreesToRadians" {

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -300,31 +300,43 @@ pub inline fn tan(value: anytype) @TypeOf(value) {
 }
 
 /// Converts an angle in radians to degrees. T must be a float type.
-pub fn radiansToDegrees(comptime T: type, angle_in_radians: T) T {
-    if (@typeInfo(T) != .Float and @typeInfo(T) != .ComptimeFloat)
-        @compileError("T must be a float type");
-    return angle_in_radians * deg_per_rad;
+pub fn radiansToDegrees(rad: anytype) if (@TypeOf(rad) == comptime_int) comptime_float else @TypeOf(rad) {
+    const T = @TypeOf(rad);
+    return switch (@typeInfo(T)) {
+        .Float, .ComptimeFloat, .ComptimeInt => rad * deg_per_rad,
+        else => @compileError("rad must be float or a comptime type"),
+    };
 }
 
 test "radiansToDegrees" {
-    try std.testing.expectApproxEqAbs(@as(f32, 0), radiansToDegrees(f32, 0), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 90), radiansToDegrees(f32, pi / 2.0), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, -45), radiansToDegrees(f32, -pi / 4.0), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 180), radiansToDegrees(f32, pi), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 360), radiansToDegrees(f32, 2.0 * pi), 1e-6);
+    const zero: f32 = 0;
+    const half_pi: f32 = pi / 2.0;
+    const neg_quart_pi: f32 = -pi / 4.0;
+    const one_pi: f32 = pi;
+    const two_pi: f32 = 2.0 * pi;
+    try std.testing.expectApproxEqAbs(@as(f32, 0), radiansToDegrees(zero), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 90), radiansToDegrees(half_pi), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -45), radiansToDegrees(neg_quart_pi), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 180), radiansToDegrees(one_pi), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 360), radiansToDegrees(two_pi), 1e-6);
 }
 
 /// Converts an angle in degrees to radians. T must be a float type.
-pub fn degreesToRadians(comptime T: type, angle_in_degrees: T) T {
-    if (@typeInfo(T) != .Float and @typeInfo(T) != .ComptimeFloat)
-        @compileError("T must be a float type");
-    return angle_in_degrees * rad_per_deg;
+pub fn degreesToRadians(deg: anytype) if (@TypeOf(deg) == comptime_int) comptime_float else @TypeOf(deg) {
+    const T = @TypeOf(deg);
+    return switch (@typeInfo(T)) {
+        .Float, .ComptimeFloat, .ComptimeInt => deg * rad_per_deg,
+        else => @compileError("deg must be float or a comptime type"),
+    };
 }
 
 test "degreesToRadians" {
-    try std.testing.expectApproxEqAbs(@as(f32, pi / 2.0), degreesToRadians(f32, 90), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, -3 * pi / 2.0), degreesToRadians(f32, -270), 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 2 * pi), degreesToRadians(f32, 360), 1e-6);
+    const ninety: f32 = 90;
+    const neg_two_seventy: f32 = -270;
+    const three_sixty: f32 = 360;
+    try std.testing.expectApproxEqAbs(@as(f32, pi / 2.0), degreesToRadians(ninety), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -3 * pi / 2.0), degreesToRadians(neg_two_seventy), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 2 * pi), degreesToRadians(three_sixty), 1e-6);
 }
 
 /// Base-e exponential function on a floating point number.

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -299,7 +299,7 @@ pub inline fn tan(value: anytype) @TypeOf(value) {
     return @tan(value);
 }
 
-/// Converts an angle in radians to degrees. T must be a float type.
+/// Converts an angle in radians to degrees. T must be a float or comptime number or a vector of floats.
 pub fn radiansToDegrees(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang) {
     const T = @TypeOf(ang);
     switch (@typeInfo(T)) {
@@ -309,14 +309,14 @@ pub fn radiansToDegrees(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime
         .Vector => |V| {
             switch (V.child) {
                 .Float => {
-                    return ang * @as(T, @splat(deg_per_rad));
+                    return ang * @as(@TypeOf(ang), @splat(deg_per_rad));
                 },
                 else => {},
             }
         },
         else => {},
     }
-    @compileError("Input must be float or a comptime type, or a vector of floats.");
+    @compileError("Input must be float or a comptime number, or a vector of floats.");
 }
 
 test "radiansToDegrees" {
@@ -344,7 +344,7 @@ test "radiansToDegrees" {
     try std.testing.expectApproxEqAbs(@as(f32, 360), result[4], 1e-6);
 }
 
-/// Converts an angle in degrees to radians. T must be a float type.
+/// Converts an angle in degrees to radians. T must be a float or comptime number or a vector of floats.
 pub fn degreesToRadians(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang) {
     const T = @TypeOf(ang);
     switch (@typeInfo(T)) {
@@ -354,14 +354,14 @@ pub fn degreesToRadians(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime
         .Vector => |V| {
             switch (V.child) {
                 .Float => {
-                    return ang * @as(T, @splat(rad_per_deg));
+                    return ang * @as(@TypeOf(ang), @splat(rad_per_deg));
                 },
                 else => {},
             }
         },
         else => {},
     }
-    @compileError("Input must be float or a comptime type, or a vector of floats.");
+    @compileError("Input must be float or a comptime number, or a vector of floats.");
 }
 
 test "degreesToRadians" {

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -300,20 +300,11 @@ pub inline fn tan(value: anytype) @TypeOf(value) {
 }
 
 /// Converts an angle in radians to degrees. T must be a float or comptime number or a vector of floats.
-pub fn radiansToDegrees(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang) {
+pub fn radiansToDegrees(ang: anytype) (if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang)) {
     const T = @TypeOf(ang);
     switch (@typeInfo(T)) {
-        .Float, .ComptimeFloat, .ComptimeInt => {
-            return ang * deg_per_rad;
-        },
-        .Vector => |V| {
-            switch (V.child) {
-                .Float => {
-                    return ang * @as(@TypeOf(ang), @splat(deg_per_rad));
-                },
-                else => {},
-            }
-        },
+        .Float, .ComptimeFloat, .ComptimeInt => return ang * deg_per_rad,
+        .Vector => |V| if (V.child == .Float) return ang * @as(T, @splat(deg_per_rad)),
         else => {},
     }
     @compileError("Input must be float or a comptime number, or a vector of floats.");
@@ -345,20 +336,11 @@ test "radiansToDegrees" {
 }
 
 /// Converts an angle in degrees to radians. T must be a float or comptime number or a vector of floats.
-pub fn degreesToRadians(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang) {
+pub fn degreesToRadians(ang: anytype) (if (@TypeOf(ang) == comptime_int) comptime_float else @TypeOf(ang)) {
     const T = @TypeOf(ang);
     switch (@typeInfo(T)) {
-        .Float, .ComptimeFloat, .ComptimeInt => {
-            return ang * rad_per_deg;
-        },
-        .Vector => |V| {
-            switch (V.child) {
-                .Float => {
-                    return ang * @as(@TypeOf(ang), @splat(rad_per_deg));
-                },
-                else => {},
-            }
-        },
+        .Float, .ComptimeFloat, .ComptimeInt => return ang * rad_per_deg,
+        .Vector => |V| if (V.child == .Float) return ang * @as(@TypeOf(ang), @splat(rad_per_deg)),
         else => {},
     }
     @compileError("Input must be float or a comptime number, or a vector of floats.");

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -308,8 +308,7 @@ pub fn radiansToDegrees(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime
         },
         .Vector => |V| {
             switch (V.child) {
-                .Float,
-                => {
+                .Float => {
                     return ang * @as(T, @splat(deg_per_rad));
                 },
                 else => {},
@@ -342,8 +341,7 @@ pub fn degreesToRadians(ang: anytype) if (@TypeOf(ang) == comptime_int) comptime
         },
         .Vector => |V| {
             switch (V.child) {
-                .Float,
-                => {
+                .Float => {
                     return ang * @as(T, @splat(rad_per_deg));
                 },
                 else => {},

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -325,11 +325,23 @@ test "radiansToDegrees" {
     const neg_quart_pi: f32 = -pi / 4.0;
     const one_pi: f32 = pi;
     const two_pi: f32 = 2.0 * pi;
+    const result = radiansToDegrees(@Vector(5, f32){
+        zero,
+        half_pi,
+        neg_quart_pi,
+        one_pi,
+        two_pi,
+    });
     try std.testing.expectApproxEqAbs(@as(f32, 0), radiansToDegrees(zero), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 90), radiansToDegrees(half_pi), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, -45), radiansToDegrees(neg_quart_pi), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 180), radiansToDegrees(one_pi), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 360), radiansToDegrees(two_pi), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 0), result[0], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 90), result[1], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -45), result[2], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 180), result[3], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 360), result[4], 1e-6);
 }
 
 /// Converts an angle in degrees to radians. T must be a float type.
@@ -356,9 +368,17 @@ test "degreesToRadians" {
     const ninety: f32 = 90;
     const neg_two_seventy: f32 = -270;
     const three_sixty: f32 = 360;
+    const result = @Vector(3, f32){
+        ninety,
+        neg_two_seventy,
+        three_sixty,
+    };
     try std.testing.expectApproxEqAbs(@as(f32, pi / 2.0), degreesToRadians(ninety), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, -3 * pi / 2.0), degreesToRadians(neg_two_seventy), 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 2 * pi), degreesToRadians(three_sixty), 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, pi / 2.0), result[0], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, -3 * pi / 2.0), result[1], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 2 * pi), result[2], 1e-6);
 }
 
 /// Base-e exponential function on a floating point number.


### PR DESCRIPTION
and make `degreesToRadians` and `radiansToDegrees` use the precomputed comptime float that potentially has marginally better post-rounding precision.

This also enables them to operate on a vector of floats, rather than just being a clunky way of multiplying conversion factors.

```zig
const rad = std.math.degreesToRadians;
const latitudes: @Vector(13, f32) = .{-90, -75, -60, -45, -30, -15, 0, 15, 30, 45, 60, 75, 90};
const xs, const ys = .{
    @cos(rad(latitudes)),
    @sin(rad(latitudes)),
};
for(xs,ys)|x,y|{
    plot(x,y);
}
```

