### PR TITLE
std: Make FixedBufferReader public and fix compile-error

### DIFF
--- a/lib/std/dwarf.zig
+++ b/lib/std/dwarf.zig
@@ -2435,7 +2435,7 @@ pub const EntryHeader = struct {
 
     /// The length of the entry including the ID field, but not the length field itself
     pub fn entryLength(self: EntryHeader) usize {
-        return self.entry_bytes.len + @as(u8, if (self.is_64) 8 else 4);
+        return self.entry_bytes.len + @as(u8, if (self.format == .@"64") 8 else 4);
     }
 
     /// Reads a header for either an FDE or a CIE, then advances the fbr to the position after the trailing structure.
@@ -2733,7 +2733,7 @@ fn pcRelBase(field_ptr: usize, pc_rel_offset: i64) !usize {
 
 // Reading debug info needs to be fast, even when compiled in debug mode,
 // so avoid using a `std.io.FixedBufferStream` which is too slow.
-const FixedBufferReader = struct {
+pub const FixedBufferReader = struct {
     buf: []const u8,
     pos: usize = 0,
     endian: std.builtin.Endian,


### PR DESCRIPTION
`std.dwarf.EntryHeader.read` requires an `std.dwarf.FixedBufferReader`, which is non-public and therefore cannot be initialized. This makes said struct public. Also fixes a compile error as the field `is_64` no longer exists.