### PR TITLE
Sema: perform codegen for anon decl created by `@extern`

### DIFF
--- a/test/behavior/extern.zig
+++ b/test/behavior/extern.zig
@@ -27,3 +27,21 @@ test "function extern symbol" {
 export fn a_mystery_function() i32 {
     return 4567;
 }
+
+test "function extern symbol matches extern decl" {
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    const S = struct {
+        extern fn another_mystery_function() u32;
+        const same_thing = @extern(*const fn () callconv(.C) u32, .{ .name = "another_mystery_function" });
+    };
+    try expect(S.another_mystery_function() == 12345);
+    try expect(S.same_thing() == 12345);
+}
+
+export fn another_mystery_function() u32 {
+    return 12345;
+}


### PR DESCRIPTION
Follow-up to #18554.

This fixes a bug where, at least with the LLVM backend, `@extern` calls which had the same name as a normal `extern` in the same Zcu would result in the `@extern` incorrectly suffixing the identifier `.2`. Usually, the LLVM backend has a system to change the generated globals to "collapse" them all together, but it only works if `updateDecl` is called!