### PR TITLE
std: support detached child processes

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -3465,6 +3465,7 @@ pub const COORD = extern struct {
     Y: SHORT,
 };
 
+pub const DETACHED_PROCESS = 8;
 pub const CREATE_UNICODE_ENVIRONMENT = 1024;
 
 pub const TLS_OUT_OF_INDEXES = 4294967295;


### PR DESCRIPTION
Does what it says on the box.

TODO:

- [x] Test manually on macOS
- [ ] Test manually on Windows
- [ ] Test manually on Linux
- [x] Test suite locally on macOS
- [ ] Test suite locally on Windows
- [ ] Test suite locally on Linux
- [ ] Test failure cases and map any expected errors to something useful

### Testing

Existing tests ran via:

```sh
mkdir -p build
cd build
cmake .. -DZIG_STATIC_LLVM=ON -DCMAKE_PREFIX_PATH="$(brew --prefix llvm);$(brew --prefix zstd)"
make install
stage3/bin/zig build -p stage4 -Denable-llvm -Dno-lib
stage4/bin/zig build test-std -Dskip-release
```

Verified manually on macOS 14.3.1 (23D60).

Refs: https://github.com/ziglang/zig/issues/19205