### PR TITLE
aro translate-c: support for record type translation

### DIFF
--- a/lib/compiler/aro/aro/Type.zig
+++ b/lib/compiler/aro/aro/Type.zig
@@ -1142,12 +1142,14 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
     };
 }
 
+pub const QualHandling = enum { standard, preserve_quals };
+
 /// Canonicalize a possibly-typeof() type. If the type is not a typeof() type, simply
 /// return it. Otherwise, determine the actual qualified type.
 /// The `qual_handling` parameter can be used to return the full set of qualifiers
 /// added by typeof() operations, which is useful when determining the elemType of
 /// arrays and pointers.
-pub fn canonicalize(ty: Type, qual_handling: enum { standard, preserve_quals }) Type {
+pub fn canonicalize(ty: Type, qual_handling: QualHandling) Type {
     var cur = ty;
     if (cur.specifier == .attributed) {
         cur = cur.data.attributed.base;

--- a/test/cases/translate_c/circular_struct_definitions.c
+++ b/test/cases/translate_c/circular_struct_definitions.c
@@ -1,0 +1,20 @@
+struct Bar;
+
+struct Foo {
+    struct Bar *next;
+};
+
+struct Bar {
+    struct Foo *next;
+};
+
+// translate-c
+// c_frontend=clang
+//
+// pub const struct_Bar = extern struct {
+//     next: [*c]struct_Foo = @import("std").mem.zeroes([*c]struct_Foo),
+// };
+// 
+// pub const struct_Foo = extern struct {
+//     next: [*c]struct_Bar = @import("std").mem.zeroes([*c]struct_Bar),
+// };

--- a/test/cases/translate_c/double_define_struct.c
+++ b/test/cases/translate_c/double_define_struct.c
@@ -1,0 +1,25 @@
+typedef struct Bar Bar;
+typedef struct Foo Foo;
+
+struct Foo {
+    Foo *a;
+};
+
+struct Bar {
+    Foo *a;
+};
+
+// translate-c
+// c_frontend=clang
+//
+// pub const struct_Foo = extern struct {
+//     a: [*c]Foo = @import("std").mem.zeroes([*c]Foo),
+// };
+// 
+// pub const Foo = struct_Foo;
+// 
+// pub const struct_Bar = extern struct {
+//     a: [*c]Foo = @import("std").mem.zeroes([*c]Foo),
+// };
+// 
+// pub const Bar = struct_Bar;

--- a/test/cases/translate_c/field_access_is_grouped_if_necessary.c
+++ b/test/cases/translate_c/field_access_is_grouped_if_necessary.c
@@ -1,0 +1,18 @@
+unsigned long foo(unsigned long x) {
+    return ((union{unsigned long _x}){x})._x;
+}
+
+// translate-c
+// c_frontend=clang
+//
+// pub export fn foo(arg_x: c_ulong) c_ulong {
+//     var x = arg_x;
+//     _ = &x;
+//     const union_unnamed_1 = extern union {
+//         _x: c_ulong,
+//     };
+//     _ = &union_unnamed_1;
+//     return (union_unnamed_1{
+//         ._x = x,
+//     })._x;
+// }

--- a/test/cases/translate_c/global_struct_whose_default_name_conflicts_with_global_is_mangled.c
+++ b/test/cases/translate_c/global_struct_whose_default_name_conflicts_with_global_is_mangled.c
@@ -1,0 +1,15 @@
+struct foo {
+    int x;
+};
+const char *struct_foo = "hello world";
+
+// translate-c
+// c_frontend=clang
+//
+// pub const struct_foo_1 = extern struct {
+//     x: c_int = @import("std").mem.zeroes(c_int),
+// };
+// 
+// pub const foo = struct_foo_1;
+// 
+// pub export var struct_foo: [*c]const u8 = "hello world";

--- a/test/cases/translate_c/large_packed_struct.c
+++ b/test/cases/translate_c/large_packed_struct.c
@@ -1,0 +1,20 @@
+struct __attribute__((packed)) bar {
+  short a;
+  float b;
+  double c;
+  short x;
+  float y;
+  double z;
+};
+
+// translate-c
+// c_frontend=aro,clang
+//
+// pub const struct_bar = extern struct {
+//     a: c_short align(1) = @import("std").mem.zeroes(c_short),
+//     b: f32 align(1) = @import("std").mem.zeroes(f32),
+//     c: f64 align(1) = @import("std").mem.zeroes(f64),
+//     x: c_short align(1) = @import("std").mem.zeroes(c_short),
+//     y: f32 align(1) = @import("std").mem.zeroes(f32),
+//     z: f64 align(1) = @import("std").mem.zeroes(f64),
+// };

--- a/test/cases/translate_c/packed_union_nested_unpacked.c
+++ b/test/cases/translate_c/packed_union_nested_unpacked.c
@@ -1,0 +1,25 @@
+// NOTE: The nested struct is *not* packed/aligned,
+// even though the parent struct is
+// this is consistent with GCC docs
+union Foo{
+  short x;
+  double y;
+  struct {
+      int b;
+  } z;
+} __attribute__((packed));
+
+// translate-c
+// c_frontend=aro,clang
+//
+// const struct_unnamed_1 = extern struct {
+//     b: c_int = @import("std").mem.zeroes(c_int),
+// };
+// 
+// pub const union_Foo = extern union {
+//     x: c_short align(1),
+//     y: f64 align(1),
+//     z: struct_unnamed_1 align(1),
+// };
+// 
+// pub const Foo = union_Foo;

--- a/test/cases/translate_c/packed_union_simple.c
+++ b/test/cases/translate_c/packed_union_simple.c
@@ -1,0 +1,14 @@
+union Foo {
+  short x;
+  double y;
+} __attribute__((packed));
+
+// translate-c
+// c_frontend=aro,clang
+//
+// pub const union_Foo = extern union {
+//     x: c_short align(1),
+//     y: f64 align(1),
+// };
+// 
+// pub const Foo = union_Foo;

--- a/test/cases/translate_c/pointer_to_struct_demoted_opaque_due_to_bit_fields.c
+++ b/test/cases/translate_c/pointer_to_struct_demoted_opaque_due_to_bit_fields.c
@@ -1,0 +1,15 @@
+struct Foo {
+    unsigned int: 1;
+};
+struct Bar {
+    struct Foo *foo;
+};
+
+// translate-c
+// c_frontend=clang
+//
+// pub const struct_Foo = opaque {};
+// 
+// pub const struct_Bar = extern struct {
+//     foo: ?*struct_Foo = @import("std").mem.zeroes(?*struct_Foo),
+// };

--- a/test/cases/translate_c/qualified_struct_and_enum.c
+++ b/test/cases/translate_c/qualified_struct_and_enum.c
@@ -1,0 +1,25 @@
+struct Foo {
+    int x;
+    int y;
+};
+enum Bar {
+    BarA,
+    BarB,
+};
+void func(struct Foo *a, enum Bar **b);
+
+// translate-c
+// c_frontend=clang
+// target=x86_64-linux,x86_64-macos
+//
+// pub const struct_Foo = extern struct {
+//     x: c_int = @import("std").mem.zeroes(c_int),
+//     y: c_int = @import("std").mem.zeroes(c_int),
+// };
+// pub const BarA: c_int = 0;
+// pub const BarB: c_int = 1;
+// pub const enum_Bar = c_uint;
+// pub extern fn func(a: [*c]struct_Foo, b: [*c][*c]enum_Bar) void;
+//
+// pub const Foo = struct_Foo;
+// pub const Bar = enum_Bar;

--- a/test/cases/translate_c/qualified_struct_and_enum_msvc.c
+++ b/test/cases/translate_c/qualified_struct_and_enum_msvc.c
@@ -1,0 +1,25 @@
+struct Foo {
+    int x;
+    int y;
+};
+enum Bar {
+    BarA,
+    BarB,
+};
+void func(struct Foo *a, enum Bar **b);
+
+// translate-c
+// c_frontend=clang
+// target=x86_64-windows-msvc
+//
+// pub const struct_Foo = extern struct {
+//     x: c_int = @import("std").mem.zeroes(c_int),
+//     y: c_int = @import("std").mem.zeroes(c_int),
+// };
+// pub const BarA: c_int = 0;
+// pub const BarB: c_int = 1;
+// pub const enum_Bar = c_int;
+// pub extern fn func(a: [*c]struct_Foo, b: [*c][*c]enum_Bar) void;
+//
+// pub const Foo = struct_Foo;
+// pub const Bar = enum_Bar;

--- a/test/cases/translate_c/scoped_record.c
+++ b/test/cases/translate_c/scoped_record.c
@@ -1,0 +1,49 @@
+void foo() {
+	struct Foo {
+		int A;
+		int B;
+		int C;
+	};
+	struct Foo a = {0};
+	{
+		struct Foo {
+			int A;
+			int B;
+			int C;
+		};
+		struct Foo a = {0};
+	}
+}
+
+// translate-c
+// c_frontend=clang
+//
+// pub export fn foo() void {
+//     const struct_Foo = extern struct {
+//         A: c_int = @import("std").mem.zeroes(c_int),
+//         B: c_int = @import("std").mem.zeroes(c_int),
+//         C: c_int = @import("std").mem.zeroes(c_int),
+//     };
+//     _ = &struct_Foo;
+//     var a: struct_Foo = struct_Foo{
+//         .A = @as(c_int, 0),
+//         .B = 0,
+//         .C = 0,
+//     };
+//     _ = &a;
+//     {
+//         const struct_Foo_1 = extern struct {
+//             A: c_int = @import("std").mem.zeroes(c_int),
+//             B: c_int = @import("std").mem.zeroes(c_int),
+//             C: c_int = @import("std").mem.zeroes(c_int),
+//         };
+//         _ = &struct_Foo_1;
+//         var a_2: struct_Foo_1 = struct_Foo_1{
+//             .A = @as(c_int, 0),
+//             .B = 0,
+//             .C = 0,
+//         };
+//         _ = &a_2;
+//     }
+// }
+

--- a/test/cases/translate_c/simple_struct.c
+++ b/test/cases/translate_c/simple_struct.c
@@ -1,0 +1,12 @@
+struct Foo {
+    int x;
+};
+
+// translate-c
+// c_frontend=aro,clang
+//
+// const struct_Foo = extern struct {
+//     x: c_int = @import("std").mem.zeroes(c_int),
+// };
+// 
+// pub const Foo = struct_Foo;

--- a/test/cases/translate_c/simple_union.c
+++ b/test/cases/translate_c/simple_union.c
@@ -1,0 +1,12 @@
+union Foo {
+    int x;
+};
+
+// translate-c
+// c_frontend=aro,clang
+//
+// pub const union_Foo = extern union {
+//     x: c_int,
+// };
+// 
+// pub const Foo = union_Foo;

--- a/test/cases/translate_c/struct_in_struct_init_to_zero.c
+++ b/test/cases/translate_c/struct_in_struct_init_to_zero.c
@@ -1,0 +1,24 @@
+struct Foo {
+    int a;
+    struct Bar {
+        int a;
+    } b;
+} a = {};
+#define PTR void *
+
+// translate-c
+// c_frontend=clang
+//
+// pub const struct_Bar_1 = extern struct {
+//     a: c_int = @import("std").mem.zeroes(c_int),
+// };
+// pub const struct_Foo = extern struct {
+//     a: c_int = @import("std").mem.zeroes(c_int),
+//     b: struct_Bar_1 = @import("std").mem.zeroes(struct_Bar_1),
+// };
+// pub export var a: struct_Foo = struct_Foo{
+//     .a = 0,
+//     .b = @import("std").mem.zeroes(struct_Bar_1),
+// };
+// 
+// pub const PTR = ?*anyopaque;

--- a/test/cases/translate_c/struct_with_aligned_fields.c
+++ b/test/cases/translate_c/struct_with_aligned_fields.c
@@ -1,0 +1,10 @@
+struct foo {
+    __attribute__((aligned(4))) short bar;
+};
+
+// translate-c
+// c_frontend=aro,clang
+// 
+// pub const struct_foo = extern struct {
+//     bar: c_short align(4) = @import("std").mem.zeroes(c_short),
+// };

--- a/test/cases/translate_c/struct_with_invalid_field_alignment.c
+++ b/test/cases/translate_c/struct_with_invalid_field_alignment.c
@@ -1,0 +1,35 @@
+// The aligned attribute cannot decrease the alignment of a field. The packed attribute is required 
+// for decreasing the alignment. gcc and clang will compile these structs without error 
+// (and possibly without warning), but checking the alignment will reveal a different value than 
+// what was requested. This is consistent with the gcc documentation on type attributes.
+//
+// This test is currently broken for the clang frontend. See issue #19307.
+
+struct foo {
+  __attribute__((aligned(1)))int x;
+};
+
+struct bar {
+  __attribute__((aligned(2)))float y;
+};
+
+struct baz {
+  __attribute__((aligned(4)))double z;
+};
+
+// translate-c
+// c_frontend=aro
+// target=x86_64-linux
+//
+// pub const struct_foo = extern struct {
+//     x: c_int = @import("std").mem.zeroes(c_int),
+// };
+//
+// pub const struct_bar = extern struct {
+//     y: f32 = @import("std").mem.zeroes(f32),
+// };
+//
+// pub const struct_baz = extern struct {
+//     z: f64 = @import("std").mem.zeroes(f64),
+// };
+//

--- a/test/cases/translate_c/type_referenced_struct.c
+++ b/test/cases/translate_c/type_referenced_struct.c
@@ -1,0 +1,19 @@
+// When clang uses the <arch>-windows-none, triple it behaves as MSVC and
+// interprets the inner `struct Bar` as an anonymous structure
+struct Foo {
+    struct Bar{
+        int b;
+    };
+    struct Bar c;
+};
+
+// translate-c
+// c_frontend=aro,clang
+// target=x86_64-linux-gnu
+//
+// pub const struct_Bar_1 = extern struct {
+//     b: c_int = @import("std").mem.zeroes(c_int),
+// };
+// pub const struct_Foo = extern struct {
+//     c: struct_Bar_1 = @import("std").mem.zeroes(struct_Bar_1),
+// };

--- a/test/cases/translate_c/union_initializer.c
+++ b/test/cases/translate_c/union_initializer.c
@@ -1,0 +1,22 @@
+union { int x; char c[4]; }
+  ua = {1},
+  ub = {.c={'a','b','b','a'}};
+
+// translate-c
+// c_frontend=clang
+//
+// const union_unnamed_1 = extern union {
+//     x: c_int,
+//     c: [4]u8,
+// };
+// pub export var ua: union_unnamed_1 = union_unnamed_1{
+//     .x = @as(c_int, 1),
+// };
+// pub export var ub: union_unnamed_1 = union_unnamed_1{
+//     .c = [4]u8{
+//         'a',
+//         'b',
+//         'b',
+//         'a',
+//     },
+// };

--- a/test/cases/translate_c/union_struct_forward_decl.c
+++ b/test/cases/translate_c/union_struct_forward_decl.c
@@ -1,0 +1,37 @@
+struct A;
+union B;
+enum C;
+
+struct A {
+  short x;
+  double y;
+};
+
+union B {
+  short x;
+  double y;
+};
+
+struct Foo {
+  struct A a;
+  union B b;
+};
+
+
+// translate-c
+// c_frontend=aro,clang
+//
+// pub const struct_A = extern struct {
+//     x: c_short = @import("std").mem.zeroes(c_short),
+//     y: f64 = @import("std").mem.zeroes(f64),
+// };
+//
+// pub const union_B = extern union {
+//     x: c_short,
+//     y: f64,
+// };
+// 
+// pub const struct_Foo = extern struct {
+//     a: struct_A = @import("std").mem.zeroes(struct_A),
+//     b: union_B = @import("std").mem.zeroes(union_B),
+// };

--- a/test/cases/translate_c/unnamed_fields_have_predictable_names.c
+++ b/test/cases/translate_c/unnamed_fields_have_predictable_names.c
@@ -1,0 +1,22 @@
+struct a {
+    struct { int x; };
+};
+struct b {
+    struct { int y; };
+};
+
+// translate-c
+// c_frontend=aro,clang
+//
+// const struct_unnamed_1 = extern struct {
+//     x: c_int = @import("std").mem.zeroes(c_int),
+// };
+// pub const struct_a = extern struct {
+//     unnamed_0: struct_unnamed_1 = @import("std").mem.zeroes(struct_unnamed_1),
+// };
+// const struct_unnamed_2 = extern struct {
+//     y: c_int = @import("std").mem.zeroes(c_int),
+// };
+// pub const struct_b = extern struct {
+//     unnamed_0: struct_unnamed_2 = @import("std").mem.zeroes(struct_unnamed_2),
+// };

--- a/test/cases/translate_c/zero_width_field_alignment.c
+++ b/test/cases/translate_c/zero_width_field_alignment.c
@@ -1,0 +1,18 @@
+struct __attribute__((packed)) foo {
+  int x;
+  struct {};
+  float y;
+  union {};
+};
+
+// translate-c
+// c_frontend=aro
+//
+// const struct_unnamed_1 = extern struct {};
+// const union_unnamed_2 = extern union {};
+// pub const struct_foo = extern struct {
+//     x: c_int align(1) = @import("std").mem.zeroes(c_int),
+//     unnamed_0: struct_unnamed_1 align(1) = @import("std").mem.zeroes(struct_unnamed_1),
+//     y: f32 align(1) = @import("std").mem.zeroes(f32),
+//     unnamed_1: union_unnamed_2 align(1) = @import("std").mem.zeroes(union_unnamed_2),
+// };

--- a/test/cases/translate_c/zig_keywords_in_c_code.c
+++ b/test/cases/translate_c/zig_keywords_in_c_code.c
@@ -1,0 +1,12 @@
+struct comptime {
+    int defer;
+};
+
+// translate-c
+// c_frontend=aro,clang
+//
+// pub const struct_comptime = extern struct {
+//     @"defer": c_int = @import("std").mem.zeroes(c_int),
+// };
+// 
+// pub const @"comptime" = struct_comptime;

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -74,24 +74,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub extern fn main() c_int;
     });
 
-    cases.add("field access is grouped if necessary",
-        \\unsigned long foo(unsigned long x) {
-        \\    return ((union{unsigned long _x}){x})._x;
-        \\}
-    , &[_][]const u8{
-        \\pub export fn foo(arg_x: c_ulong) c_ulong {
-        \\    var x = arg_x;
-        \\    _ = &x;
-        \\    const union_unnamed_1 = extern union {
-        \\        _x: c_ulong,
-        \\    };
-        \\    _ = &union_unnamed_1;
-        \\    return (union_unnamed_1{
-        \\        ._x = x,
-        \\    })._x;
-        \\}
-    });
-
     cases.add("unnamed child types of typedef receive typedef's name",
         \\typedef enum {
         \\    FooA,
@@ -146,78 +128,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    var a: c_int = undefined;
         \\    _ = &a;
         \\    if (a != 0) a = 2 else _ = bar();
-        \\}
-    });
-
-    cases.add("struct in struct init to zero",
-        \\struct Foo {
-        \\    int a;
-        \\    struct Bar {
-        \\        int a;
-        \\    } b;
-        \\} a = {};
-        \\#define PTR void *
-    , &[_][]const u8{
-        \\pub const struct_Bar_1 = extern struct {
-        \\    a: c_int = @import("std").mem.zeroes(c_int),
-        \\};
-        \\pub const struct_Foo = extern struct {
-        \\    a: c_int = @import("std").mem.zeroes(c_int),
-        \\    b: struct_Bar_1 = @import("std").mem.zeroes(struct_Bar_1),
-        \\};
-        \\pub export var a: struct_Foo = struct_Foo{
-        \\    .a = 0,
-        \\    .b = @import("std").mem.zeroes(struct_Bar_1),
-        \\};
-        ,
-        \\pub const PTR = ?*anyopaque;
-    });
-
-    cases.add("scoped record",
-        \\void foo() {
-        \\	struct Foo {
-        \\		int A;
-        \\		int B;
-        \\		int C;
-        \\	};
-        \\	struct Foo a = {0};
-        \\	{
-        \\		struct Foo {
-        \\			int A;
-        \\			int B;
-        \\			int C;
-        \\		};
-        \\		struct Foo a = {0};
-        \\	}
-        \\}
-    , &[_][]const u8{
-        \\pub export fn foo() void {
-        \\    const struct_Foo = extern struct {
-        \\        A: c_int = @import("std").mem.zeroes(c_int),
-        \\        B: c_int = @import("std").mem.zeroes(c_int),
-        \\        C: c_int = @import("std").mem.zeroes(c_int),
-        \\    };
-        \\    _ = &struct_Foo;
-        \\    var a: struct_Foo = struct_Foo{
-        \\        .A = @as(c_int, 0),
-        \\        .B = 0,
-        \\        .C = 0,
-        \\    };
-        \\    _ = &a;
-        \\    {
-        \\        const struct_Foo_1 = extern struct {
-        \\            A: c_int = @import("std").mem.zeroes(c_int),
-        \\            B: c_int = @import("std").mem.zeroes(c_int),
-        \\            C: c_int = @import("std").mem.zeroes(c_int),
-        \\        };
-        \\        _ = &struct_Foo_1;
-        \\        var a_2: struct_Foo_1 = struct_Foo_1{
-        \\            .A = @as(c_int, 0),
-        \\            .B = 0,
-        \\            .C = 0,
-        \\        };
-        \\        _ = &a_2;
-        \\    }
         \\}
     });
 
@@ -466,16 +376,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub const BAR = (@as(c_int, 1) != 0) and (@as(c_int, 2) > @as(c_int, 4));
     });
 
-    cases.add("struct with aligned fields",
-        \\struct foo {
-        \\    __attribute__((aligned(1))) short bar;
-        \\};
-    , &[_][]const u8{
-        \\pub const struct_foo = extern struct {
-        \\    bar: c_short align(1) = @import("std").mem.zeroes(c_short),
-        \\};
-    });
-
     cases.add("struct with flexible array",
         \\struct foo { int x; int y[]; };
         \\struct bar { int x; int y[0]; };
@@ -659,28 +559,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    _ = &x;
         \\    x.*.unnamed_0.unnamed_0.y = @as(c_int, @bitCast(@as(c_uint, x.*.unnamed_0.x)));
         \\}
-    });
-
-    cases.add("union initializer",
-        \\union { int x; char c[4]; }
-        \\  ua = {1},
-        \\  ub = {.c={'a','b','b','a'}};
-    , &[_][]const u8{
-        \\const union_unnamed_1 = extern union {
-        \\    x: c_int,
-        \\    c: [4]u8,
-        \\};
-        \\pub export var ua: union_unnamed_1 = union_unnamed_1{
-        \\    .x = @as(c_int, 1),
-        \\};
-        \\pub export var ub: union_unnamed_1 = union_unnamed_1{
-        \\    .c = [4]u8{
-        \\        'a',
-        \\        'b',
-        \\        'b',
-        \\        'a',
-        \\    },
-        \\};
     });
 
     cases.add("struct initializer - simple",
@@ -1013,21 +891,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\};
     });
 
-    cases.add("pointer to struct demoted to opaque due to bit fields",
-        \\struct Foo {
-        \\    unsigned int: 1;
-        \\};
-        \\struct Bar {
-        \\    struct Foo *foo;
-        \\};
-    , &[_][]const u8{
-        \\pub const struct_Foo = opaque {};
-        ,
-        \\pub const struct_Bar = extern struct {
-        \\    foo: ?*struct_Foo = @import("std").mem.zeroes(?*struct_Foo),
-        \\};
-    });
-
     cases.add("macro with left shift",
         \\#define REDISMODULE_READ (1<<0)
     , &[_][]const u8{
@@ -1041,45 +904,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub const FLASH_SIZE = @as(c_ulong, 0x200000);
         ,
         \\pub const FLASH_BANK_SIZE = FLASH_SIZE >> @as(c_int, 1);
-    });
-
-    cases.add("double define struct",
-        \\typedef struct Bar Bar;
-        \\typedef struct Foo Foo;
-        \\
-        \\struct Foo {
-        \\    Foo *a;
-        \\};
-        \\
-        \\struct Bar {
-        \\    Foo *a;
-        \\};
-    , &[_][]const u8{
-        \\pub const struct_Foo = extern struct {
-        \\    a: [*c]Foo = @import("std").mem.zeroes([*c]Foo),
-        \\};
-        ,
-        \\pub const Foo = struct_Foo;
-        ,
-        \\pub const struct_Bar = extern struct {
-        \\    a: [*c]Foo = @import("std").mem.zeroes([*c]Foo),
-        \\};
-        ,
-        \\pub const Bar = struct_Bar;
-    });
-
-    cases.add("simple struct",
-        \\struct Foo {
-        \\    int x;
-        \\    char *y;
-        \\};
-    , &[_][]const u8{
-        \\const struct_Foo = extern struct {
-        \\    x: c_int = @import("std").mem.zeroes(c_int),
-        \\    y: [*c]u8 = @import("std").mem.zeroes([*c]u8),
-        \\};
-        ,
-        \\pub const Foo = struct_Foo;
     });
 
     cases.add("self referential struct with function pointer",
@@ -1120,42 +944,10 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub const THING2 = THING1;
     });
 
-    cases.add("circular struct definitions",
-        \\struct Bar;
-        \\
-        \\struct Foo {
-        \\    struct Bar *next;
-        \\};
-        \\
-        \\struct Bar {
-        \\    struct Foo *next;
-        \\};
-    , &[_][]const u8{
-        \\pub const struct_Bar = extern struct {
-        \\    next: [*c]struct_Foo = @import("std").mem.zeroes([*c]struct_Foo),
-        \\};
-        ,
-        \\pub const struct_Foo = extern struct {
-        \\    next: [*c]struct_Bar = @import("std").mem.zeroes([*c]struct_Bar),
-        \\};
-    });
-
     cases.add("#define string",
         \\#define  foo  "a string"
     , &[_][]const u8{
         \\pub const foo = "a string";
-    });
-
-    cases.add("zig keywords in C code",
-        \\struct comptime {
-        \\    int defer;
-        \\};
-    , &[_][]const u8{
-        \\pub const struct_comptime = extern struct {
-        \\    @"defer": c_int = @import("std").mem.zeroes(c_int),
-        \\};
-        ,
-        \\pub const @"comptime" = struct_comptime;
     });
 
     cases.add("macro with parens around negative number",
@@ -1412,88 +1204,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub export fn foo() [*c]c_int {
         \\    return null;
         \\}
-    });
-
-    cases.add("simple union",
-        \\union Foo {
-        \\    int x;
-        \\    double y;
-        \\};
-    , &[_][]const u8{
-        \\pub const union_Foo = extern union {
-        \\    x: c_int,
-        \\    y: f64,
-        \\};
-        ,
-        \\pub const Foo = union_Foo;
-    });
-
-    cases.add("packed union - simple",
-        \\union Foo {
-        \\  char x;
-        \\  double y;
-        \\} __attribute__((packed));
-    , &[_][]const u8{
-        \\pub const union_Foo = extern union {
-        \\    x: u8 align(1),
-        \\    y: f64 align(1),
-        \\};
-        ,
-        \\pub const Foo = union_Foo;
-    });
-
-    cases.add("packed union - nested unpacked",
-        \\union Foo{
-        \\  char x;
-        \\  double y;
-        \\  struct {
-        \\      char a;
-        \\      int b;
-        \\  } z;
-        \\} __attribute__((packed));
-    , &[_][]const u8{
-        // NOTE: The nested struct is *not* packed/aligned,
-        // even though the parent struct is
-        // this is consistent with GCC docs
-        \\const struct_unnamed_1 = extern struct {
-        \\    a: u8 = @import("std").mem.zeroes(u8),
-        \\    b: c_int = @import("std").mem.zeroes(c_int),
-        \\};
-        ,
-        \\pub const union_Foo = extern union {
-        \\    x: u8 align(1),
-        \\    y: f64 align(1),
-        \\    z: struct_unnamed_1 align(1),
-        \\};
-        ,
-        \\pub const Foo = union_Foo;
-    });
-
-    cases.add("packed union - nested packed",
-        \\union Foo{
-        \\  char x;
-        \\  double y;
-        \\  struct {
-        \\      char a;
-        \\      int b;
-        \\  } __attribute__((packed)) z;
-        \\} __attribute__((packed));
-    , &[_][]const u8{
-        // in order for the nested struct to be packed, it must
-        // have an independent packed declaration on
-        // the nested type (see GCC docs for details)
-        \\const struct_unnamed_1 = extern struct {
-        \\    a: u8 align(1) = @import("std").mem.zeroes(u8),
-        \\    b: c_int align(1) = @import("std").mem.zeroes(c_int),
-        \\};
-        ,
-        \\pub const union_Foo = extern union {
-        \\    x: u8 align(1),
-        \\    y: f64 align(1),
-        \\    z: struct_unnamed_1 align(1),
-        \\};
-        ,
-        \\pub const Foo = union_Foo;
     });
 
     cases.add("string literal",
@@ -2416,27 +2126,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    }
         \\}
     });
-
-    if (builtin.os.tag != .windows) {
-        // When clang uses the <arch>-windows-none triple it behaves as MSVC and
-        // interprets the inner `struct Bar` as an anonymous structure
-        cases.add("type referenced struct",
-            \\struct Foo {
-            \\    struct Bar{
-            \\        int b;
-            \\    };
-            \\    struct Bar c;
-            \\};
-        , &[_][]const u8{
-            \\pub const struct_Bar_1 = extern struct {
-            \\    b: c_int = @import("std").mem.zeroes(c_int),
-            \\};
-            \\pub const struct_Foo = extern struct {
-            \\    c: struct_Bar_1 = @import("std").mem.zeroes(struct_Bar_1),
-            \\};
-        });
-    }
-
     cases.add("undefined array global",
         \\int array[100] = {};
     , &[_][]const u8{
@@ -2653,32 +2342,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
             \\}
         ,
         \\pub const Foo = enum_Foo;
-    });
-
-    cases.add("qualified struct and enum",
-        \\struct Foo {
-        \\    int x;
-        \\    int y;
-        \\};
-        \\enum Bar {
-        \\    BarA,
-        \\    BarB,
-        \\};
-        \\void func(struct Foo *a, enum Bar **b);
-    , &[_][]const u8{
-        \\pub const struct_Foo = extern struct {
-        \\    x: c_int = @import("std").mem.zeroes(c_int),
-        \\    y: c_int = @import("std").mem.zeroes(c_int),
-        \\};
-        \\pub const BarA: c_int = 0;
-        \\pub const BarB: c_int = 1;
-        \\pub const enum_Bar =
-        ++ " " ++ default_enum_type ++
-            \\;
-            \\pub extern fn func(a: [*c]struct_Foo, b: [*c][*c]enum_Bar) void;
-        ,
-        \\pub const Foo = struct_Foo;
-        \\pub const Bar = enum_Bar;
     });
 
     cases.add("bitwise binary operators, simpler parens",
@@ -3777,24 +3440,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         });
     }
 
-    cases.add("unnamed fields have predictable names",
-        \\struct a {
-        \\    struct {};
-        \\};
-        \\struct b {
-        \\    struct {};
-        \\};
-    , &[_][]const u8{
-        \\const struct_unnamed_1 = extern struct {};
-        \\pub const struct_a = extern struct {
-        \\    unnamed_0: struct_unnamed_1 = @import("std").mem.zeroes(struct_unnamed_1),
-        \\};
-        \\const struct_unnamed_2 = extern struct {};
-        \\pub const struct_b = extern struct {
-        \\    unnamed_0: struct_unnamed_2 = @import("std").mem.zeroes(struct_unnamed_2),
-        \\};
-    });
-
     cases.add("integer literal promotion",
         \\#define GUARANTEED_TO_FIT_1 1024
         \\#define GUARANTEED_TO_FIT_2 10241024L
@@ -4302,21 +3947,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\#define FOO(x) struct x
     , &[_][]const u8{
         \\pub const FOO = @compileError("unable to translate macro: untranslatable usage of arg `x`");
-    });
-
-    cases.add("global struct whose default name conflicts with global is mangled",
-        \\struct foo {
-        \\    int x;
-        \\};
-        \\const char *struct_foo = "hello world";
-    , &[_][]const u8{
-        \\pub const struct_foo_1 = extern struct {
-        \\    x: c_int = @import("std").mem.zeroes(c_int),
-        \\};
-        ,
-        \\pub const foo = struct_foo_1;
-        ,
-        \\pub export var struct_foo: [*c]const u8 = "hello world";
     });
 
     cases.add("unsupport declare statement at the last of a compound statement which belongs to a statement expr",


### PR DESCRIPTION
Edit: Ready for review. See below for a summary of changes.

---

This PR adds support for translating C record types. The PR is still very much a work in progress, so it's probably not worth reviewing now. The only tests that have been added are `simple_struct.c` and `simple_union.c`. 

Tasks to complete before it's ready:

- [x] Add more tests.
- [x] Cleanup/refactor.