### PR TITLE
math.big.int: fix incorrect `bitAnd` behaviour

### DIFF
--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -1487,6 +1487,19 @@ test "bitAnd #10932" {
     try testing.expect((try res.to(i32)) == 0);
 }
 
+test "bit And #19235" {
+    var a = try Managed.initSet(testing.allocator, -0xffffffffffffffff);
+    defer a.deinit();
+    var b = try Managed.initSet(testing.allocator, 0x10000000000000000);
+    defer b.deinit();
+    var r = try Managed.init(testing.allocator);
+    defer r.deinit();
+
+    try r.bitAnd(&a, &b);
+
+    try testing.expect((try r.to(i128)) == 0x10000000000000000);
+}
+
 test "div floor single-single +/+" {
     const u: i32 = 5;
     const v: i32 = 3;


### PR DESCRIPTION
Fixes #19235.
The current `math.big.int.llsignedand(r, a, a_positive, b, b_positive)` implementation is not complete when `a` is positive and `b` is negative, resulting in the result not having higher bytes when `b.len < a.len`.
This is likely due to the wrong evaluation as written in this comment: 
https://github.com/ziglang/zig/blob/4ba4f94c93d5eb1945f1b2c8c53a45cbee609d3b/lib/std/math/big/int.zig#L3990-L3992
Context:
https://github.com/ziglang/zig/blob/4ba4f94c93d5eb1945f1b2c8c53a45cbee609d3b/lib/std/math/big/int.zig#L3974-L3977
It should be `a & ~(0 - 0) = a & ~0 = a`, so we should actually continue collecting `a[b.len..a.len]` into the higher part of the result.

From this little mistake, we had the wrong assumption that:
https://github.com/ziglang/zig/blob/4ba4f94c93d5eb1945f1b2c8c53a45cbee609d3b/lib/std/math/big/int.zig#L3935-L3937
(the function assumes `b.len <= a.len`)
And this propagates to places where this function is used as well.
I believe the correct one should be (assuming `b.len <= a.len`):
1. If `b` is positive, the least `limb` number of `r` should be `b.len()`.
2. Otherwise, if `a` is positive, the least `limb` number of `r` should be `a.len()`.
3. Otherwise, the least `limb` number of `r` should be `a.len() + 1`.