### PR TITLE
macos: add zippered support

### DIFF
--- a/lib/compiler/libc.zig
+++ b/lib/compiler/libc.zig
@@ -113,7 +113,7 @@ pub fn main() !void {
         };
         defer libc.deinit(gpa);
     } else {
-        if (!target_query.isNative()) {
+        if (!target_query.canDetectLibC()) {
             fatal("unable to detect libc for non-native target", .{});
         }
         var libc = LibCInstallation.findNative(.{

--- a/lib/std/Target/Query.zig
+++ b/lib/std/Target/Query.zig
@@ -415,6 +415,15 @@ pub fn isNative(self: Query) bool {
     return self.isNativeCpu() and self.isNativeOs() and self.isNativeAbi();
 }
 
+pub fn canDetectLibC(self: Query) bool {
+    if (self.isNative()) return true;
+    if (self.os_tag) |os| {
+        if (builtin.os.tag == .macos and os.isDarwin()) return true;
+        if (os == .linux and self.abi == .android) return true;
+    }
+    return false;
+}
+
 /// Formats a version with the patch component omitted if it is zero,
 /// unlike SemanticVersion.format which formats all its version components regardless.
 fn formatVersion(version: SemanticVersion, writer: anytype) !void {

--- a/lib/std/zig/system/darwin.zig
+++ b/lib/std/zig/system/darwin.zig
@@ -38,7 +38,11 @@ pub fn getSdk(allocator: Allocator, target: Target) ?[]const u8 {
     const is_simulator_abi = target.abi == .simulator;
     const sdk = switch (target.os.tag) {
         .macos => "macosx",
-        .ios => if (is_simulator_abi) "iphonesimulator" else "iphoneos",
+        .ios => switch (target.abi) {
+            .simulator => "iphonesimulator",
+            .macabi => "macosx",
+            else => "iphoneos",
+        },
         .watchos => if (is_simulator_abi) "watchsimulator" else "watchos",
         .tvos => if (is_simulator_abi) "appletvsimulator" else "appletvos",
         else => return null,

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -4376,9 +4376,11 @@ pub const Platform = struct {
                         .IOS, .IOSSIMULATOR => .ios,
                         .TVOS, .TVOSSIMULATOR => .tvos,
                         .WATCHOS, .WATCHOSSIMULATOR => .watchos,
+                        .MACCATALYST => .ios,
                         else => @panic("TODO"),
                     },
                     .abi = switch (cmd.platform) {
+                        .MACCATALYST => .macabi,
                         .IOSSIMULATOR,
                         .TVOSSIMULATOR,
                         .WATCHOSSIMULATOR,
@@ -4425,7 +4427,11 @@ pub const Platform = struct {
     pub fn toApplePlatform(plat: Platform) macho.PLATFORM {
         return switch (plat.os_tag) {
             .macos => .MACOS,
-            .ios => if (plat.abi == .simulator) .IOSSIMULATOR else .IOS,
+            .ios => switch (plat.abi) {
+                .simulator => .IOSSIMULATOR,
+                .macabi => .MACCATALYST,
+                else => .IOS,
+            },
             .tvos => if (plat.abi == .simulator) .TVOSSIMULATOR else .TVOS,
             .watchos => if (plat.abi == .simulator) .WATCHOSSIMULATOR else .WATCHOS,
             else => unreachable,

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -751,8 +751,14 @@ pub const TargetMatcher = struct {
             .v3 => |v3| blk: {
                 var targets = std.ArrayList([]const u8).init(arena.allocator());
                 for (v3.archs) |arch| {
-                    const target = try std.fmt.allocPrint(arena.allocator(), "{s}-{s}", .{ arch, v3.platform });
-                    try targets.append(target);
+                    if (mem.eql(u8, v3.platform, "zippered")) {
+                        // From Xcode 10.3 → 11.3.1, macos SDK .tbd files specify platform as 'zippered'
+                        // which should map to [ '<arch>-macos', '<arch>-maccatalyst' ]
+                        try targets.append(try std.fmt.allocPrint(arena.allocator(), "{s}-macos", .{arch}));
+                        try targets.append(try std.fmt.allocPrint(arena.allocator(), "{s}-maccatalyst", .{arch}));
+                    } else {
+                        try targets.append(try std.fmt.allocPrint(arena.allocator(), "{s}-{s}", .{ arch, v3.platform }));
+                    }
                 }
                 break :blk targets.items;
             },

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -54,7 +54,7 @@ pub fn parse(self: *Dylib, macho_file: *MachO, file: std.fs.File, fat_arch: ?fat
     const gpa = macho_file.base.comp.gpa;
     const offset = if (fat_arch) |ar| ar.offset else 0;
 
-    log.debug("parsing dylib from binary", .{});
+    log.debug("parsing dylib from binary: {s}", .{self.path});
 
     var header_buffer: [@sizeOf(macho.mach_header_64)]u8 = undefined;
     {
@@ -266,7 +266,7 @@ pub fn parseTbd(
 
     const gpa = macho_file.base.comp.gpa;
 
-    log.debug("parsing dylib from stub", .{});
+    log.debug("parsing dylib from stub: {s}", .{self.path});
 
     const umbrella_lib = lib_stub.inner[0];
 


### PR DESCRIPTION
- Map target os=`ios` and abi=`macabi` to macho.PLATFORM.MACCATALYST.
  This allows for matches against tbdv4 targets, eg. `x86_64-maccatalyst`.

- When parsing old tbdv3 files with `zippered` platform, we append
  [`ARCH-macos`, `ARCH-maccatalyst`] to list of "tbd" targets. This
  enables linking for standard targets like `ARCH-macos-none` and
  MacCatalyst targets `ARCH-ios-macabi`.

closes #19110