### PR TITLE
Fix adding module arguments for Step.Compile

### DIFF
--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -86,6 +86,9 @@
         .dirname = .{
             .path = "dirname",
         },
+        .dep_duplicate_module = .{
+            .path = "dep_duplicate_module",
+        },
         .empty_env = .{
             .path = "empty_env",
         },

--- a/test/standalone/dep_duplicate_module/build.zig
+++ b/test/standalone/dep_duplicate_module/build.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const mod = b.addModule("mod", .{
+        .root_source_file = .{ .path = "mod.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const lib = b.addStaticLibrary(.{
+        .name = "lib",
+        .root_source_file = .{ .path = "lib.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    lib.root_module.addImport("mod", mod);
+
+    const exe = b.addExecutable(.{
+        .name = "app",
+        .root_source_file = .{ .path = "main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    exe.root_module.addImport("mod", mod);
+    exe.root_module.linkLibrary(lib);
+
+    b.installArtifact(exe);
+}

--- a/test/standalone/dep_duplicate_module/build.zig
+++ b/test/standalone/dep_duplicate_module/build.zig
@@ -5,14 +5,14 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const mod = b.addModule("mod", .{
-        .root_source_file = .{ .path = "mod.zig" },
+        .root_source_file = b.path("mod.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const lib = b.addStaticLibrary(.{
         .name = "lib",
-        .root_source_file = .{ .path = "lib.zig" },
+        .root_source_file = b.path("lib.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -20,7 +20,7 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "app",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/test/standalone/dep_duplicate_module/lib.zig
+++ b/test/standalone/dep_duplicate_module/lib.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+const mod = @import("mod");
+
+export fn work(x: u32) u32 {
+    return mod.double(x);
+}

--- a/test/standalone/dep_duplicate_module/main.zig
+++ b/test/standalone/dep_duplicate_module/main.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const mod = @import("mod");
+
+extern fn work(x: u32) u32;
+
+pub fn main() !void {
+    _ = work(mod.half(25));
+}

--- a/test/standalone/dep_duplicate_module/mod.zig
+++ b/test/standalone/dep_duplicate_module/mod.zig
@@ -1,0 +1,7 @@
+pub fn double(v: u32) u32 {
+    return v * 2;
+}
+
+pub fn half(v: u32) u32 {
+    return v / 2;
+}


### PR DESCRIPTION
The existing implementation adds the same module multiple times in the following case:

1. Module `app` depends on the static library `lib` and the module `mod`.

```zig
// file: app/build.zig.zon
.{
    .name = "app",
    .version = "0.0.0",
    .dependencies = .{
        .lib = .{ .path = "../lib", },
        .mod = .{ .path = "../mod", },
    },
    .paths = .{ "" },
}
```

2. Static library `lib` depends on the module `mod` too.

```zig
// file: lib/build.zig.zon
.{
    .name = "lib",
    .version = "0.0.0",
    .dependencies = .{
        .mod = .{ .path = "../mod", },
    },
    .paths = .{ "" },
}
```

The build fails with 
```
error: error: unable to add module 'mod': already exists as 'mod.zig'
```

This PR fixed the above problem. 

According to my limited understanding of the convoluted Zig build system, the proposed fix should not break any other uses of build dependencies.