### PR TITLE
{aegis,aes_gcm}: fix overflow with huge inputs on 32-bit systems

### DIFF
--- a/lib/std/crypto/aegis.zig
+++ b/lib/std/crypto/aegis.zig
@@ -106,8 +106,8 @@ const State128L = struct {
     fn mac(state: *State128L, comptime tag_bits: u9, adlen: usize, mlen: usize) [tag_bits / 8]u8 {
         const blocks = &state.blocks;
         var sizes: [16]u8 = undefined;
-        mem.writeInt(u64, sizes[0..8], adlen * 8, .little);
-        mem.writeInt(u64, sizes[8..16], mlen * 8, .little);
+        mem.writeInt(u64, sizes[0..8], @as(u64, adlen) * 8, .little);
+        mem.writeInt(u64, sizes[8..16], @as(u64, mlen) * 8, .little);
         const tmp = AesBlock.fromBytes(&sizes).xorBlocks(blocks[2]);
         var i: usize = 0;
         while (i < 7) : (i += 1) {
@@ -284,8 +284,8 @@ const State256 = struct {
     fn mac(state: *State256, comptime tag_bits: u9, adlen: usize, mlen: usize) [tag_bits / 8]u8 {
         const blocks = &state.blocks;
         var sizes: [16]u8 = undefined;
-        mem.writeInt(u64, sizes[0..8], adlen * 8, .little);
-        mem.writeInt(u64, sizes[8..16], mlen * 8, .little);
+        mem.writeInt(u64, sizes[0..8], @as(u64, adlen) * 8, .little);
+        mem.writeInt(u64, sizes[8..16], @as(u64, mlen) * 8, .little);
         const tmp = AesBlock.fromBytes(&sizes).xorBlocks(blocks[3]);
         var i: usize = 0;
         while (i < 7) : (i += 1) {

--- a/lib/std/crypto/aes_gcm.zig
+++ b/lib/std/crypto/aes_gcm.zig
@@ -46,8 +46,8 @@ fn AesGcm(comptime Aes: anytype) type {
             mac.pad();
 
             var final_block = h;
-            mem.writeInt(u64, final_block[0..8], ad.len * 8, .big);
-            mem.writeInt(u64, final_block[8..16], m.len * 8, .big);
+            mem.writeInt(u64, final_block[0..8], @as(u64, ad.len) * 8, .big);
+            mem.writeInt(u64, final_block[8..16], @as(u64, m.len) * 8, .big);
             mac.update(&final_block);
             mac.final(tag);
             for (t, 0..) |x, i| {
@@ -86,8 +86,8 @@ fn AesGcm(comptime Aes: anytype) type {
             mac.pad();
 
             var final_block = h;
-            mem.writeInt(u64, final_block[0..8], ad.len * 8, .big);
-            mem.writeInt(u64, final_block[8..16], m.len * 8, .big);
+            mem.writeInt(u64, final_block[0..8], @as(u64, ad.len) * 8, .big);
+            mem.writeInt(u64, final_block[8..16], @as(u64, m.len) * 8, .big);
             mac.update(&final_block);
             var computed_tag: [Ghash.mac_length]u8 = undefined;
             mac.final(&computed_tag);


### PR DESCRIPTION
These systems write the number of *bits* of their inputs as a u64.

However if `@sizeOf(usize) == 4`, an input message or associated data whose size is > 512 MiB could overflow.

On 64-bit systems, it is safe to assume that no machine has more than 2 EiB of memory.