### PR TITLE
compiler: more progress on incremental

### DIFF
--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -67,6 +67,9 @@ src_hash_deps: std.AutoArrayHashMapUnmanaged(TrackedInst.Index, DepEntry.Index) 
 /// Dependencies on the value of a Decl.
 /// Value is index into `dep_entries` of the first dependency on this Decl value.
 decl_val_deps: std.AutoArrayHashMapUnmanaged(DeclIndex, DepEntry.Index) = .{},
+/// Dependencies on the IES of a runtime function.
+/// Value is index into `dep_entries` of the first dependency on this Decl value.
+func_ies_deps: std.AutoArrayHashMapUnmanaged(Index, DepEntry.Index) = .{},
 /// Dependencies on the full set of names in a ZIR namespace.
 /// Key refers to a `struct_decl`, `union_decl`, etc.
 /// Value is index into `dep_entries` of the first dependency on this namespace.
@@ -167,6 +170,7 @@ pub const Depender = enum(u32) {
 pub const Dependee = union(enum) {
     src_hash: TrackedInst.Index,
     decl_val: DeclIndex,
+    func_ies: Index,
     namespace: TrackedInst.Index,
     namespace_name: NamespaceNameKey,
 };
@@ -212,6 +216,7 @@ pub fn dependencyIterator(ip: *const InternPool, dependee: Dependee) DependencyI
     const first_entry = switch (dependee) {
         .src_hash => |x| ip.src_hash_deps.get(x),
         .decl_val => |x| ip.decl_val_deps.get(x),
+        .func_ies => |x| ip.func_ies_deps.get(x),
         .namespace => |x| ip.namespace_deps.get(x),
         .namespace_name => |x| ip.namespace_name_deps.get(x),
     } orelse return .{
@@ -251,6 +256,7 @@ pub fn addDependency(ip: *InternPool, gpa: Allocator, depender: Depender, depend
             const gop = try switch (tag) {
                 .src_hash => ip.src_hash_deps,
                 .decl_val => ip.decl_val_deps,
+                .func_ies => ip.func_ies_deps,
                 .namespace => ip.namespace_deps,
                 .namespace_name => ip.namespace_name_deps,
             }.getOrPut(gpa, dependee_payload);
@@ -4324,6 +4330,7 @@ pub fn deinit(ip: *InternPool, gpa: Allocator) void {
 
     ip.src_hash_deps.deinit(gpa);
     ip.decl_val_deps.deinit(gpa);
+    ip.func_ies_deps.deinit(gpa);
     ip.namespace_deps.deinit(gpa);
     ip.namespace_name_deps.deinit(gpa);
 

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -9223,7 +9223,7 @@ pub fn funcTypeParamsLen(ip: *const InternPool, i: Index) u32 {
     return ip.extra.items[start + std.meta.fieldIndex(Tag.TypeFunction, "params_len").?];
 }
 
-fn unwrapCoercedFunc(ip: *const InternPool, i: Index) Index {
+pub fn unwrapCoercedFunc(ip: *const InternPool, i: Index) Index {
     const tags = ip.items.items(.tag);
     return switch (tags[@intFromEnum(i)]) {
         .func_coerced => {

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -7103,7 +7103,7 @@ pub fn getGeneratedTagEnumType(ip: *InternPool, gpa: Allocator, ini: GeneratedTa
     return @enumFromInt(gop.index);
 }
 
-pub const OpaqueTypeIni = struct {
+pub const OpaqueTypeInit = struct {
     has_namespace: bool,
     key: union(enum) {
         declared: struct {
@@ -7117,7 +7117,7 @@ pub const OpaqueTypeIni = struct {
     },
 };
 
-pub fn getOpaqueType(ip: *InternPool, gpa: Allocator, ini: OpaqueTypeIni) Allocator.Error!WipNamespaceType.Result {
+pub fn getOpaqueType(ip: *InternPool, gpa: Allocator, ini: OpaqueTypeInit) Allocator.Error!WipNamespaceType.Result {
     const adapter: KeyAdapter = .{ .intern_pool = ip };
     const gop = try ip.map.getOrPutAdapted(gpa, Key{ .opaque_type = switch (ini.key) {
         .declared => |d| .{ .declared = .{

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4358,7 +4358,10 @@ fn scanDecl(iter: *ScanDeclIter, decl_inst: Zir.Inst.Index) Allocator.Error!void
             };
         },
         .@"usingnamespace" => info: {
-            if (iter.pass != .unnamed) return;
+            // TODO: this isn't right! These should be considered unnamed. Name conflicts can happen here.
+            // The problem is, we need to preserve the decl ordering for `@typeInfo`.
+            // I'm not bothering to fix this now, since some upcoming changes will change this code significantly anyway.
+            if (iter.pass != .named) return;
             const i = iter.usingnamespace_index;
             iter.usingnamespace_index += 1;
             break :info .{

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4103,6 +4103,21 @@ pub fn scanNamespace(
     for (decls) |decl_inst| {
         try scanDecl(&scan_decl_iter, decl_inst);
     }
+
+    if (seen_decls.count() != namespace.decls.count()) {
+        // Do a pass over the namespace contents and remove any decls from the last update
+        // which were removed in this one.
+        var i: usize = 0;
+        while (i < namespace.decls.count()) {
+            const decl_index = namespace.decls.keys()[i];
+            const decl = zcu.declPtr(decl_index);
+            if (!seen_decls.contains(decl.name)) {
+                // We must preserve namespace ordering for @typeInfo.
+                namespace.decls.orderedRemoveAt(i);
+                i -= 1;
+            }
+        }
+    }
 }
 
 const ScanDeclIter = struct {

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -3113,13 +3113,18 @@ pub fn ensureDeclAnalyzed(mod: *Module, decl_index: Decl.Index) SemaError!void {
     }
 }
 
-pub fn ensureFuncBodyAnalyzed(zcu: *Zcu, func_index: InternPool.Index) SemaError!void {
+pub fn ensureFuncBodyAnalyzed(zcu: *Zcu, maybe_coerced_func_index: InternPool.Index) SemaError!void {
     const tracy = trace(@src());
     defer tracy.end();
 
     const gpa = zcu.gpa;
     const ip = &zcu.intern_pool;
-    const func = zcu.funcInfo(func_index);
+
+    // We only care about the uncoerced function.
+    // We need to do this for the "orphaned function" check below to be valid.
+    const func_index = ip.unwrapCoercedFunc(maybe_coerced_func_index);
+
+    const func = zcu.funcInfo(maybe_coerced_func_index);
     const decl_index = func.owner_decl;
     const decl = zcu.declPtr(decl_index);
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2705,6 +2705,37 @@ fn getCaptures(sema: *Sema, block: *Block, extra_index: usize, captures_len: u32
     return captures;
 }
 
+/// Given an `InternPool.WipNamespaceType` or `InternPool.WipEnumType`, apply
+/// `sema.builtin_type_target_index` to it if necessary.
+fn wrapWipTy(sema: *Sema, wip_ty: anytype) @TypeOf(wip_ty) {
+    if (sema.builtin_type_target_index == .none) return wip_ty;
+    var new = wip_ty;
+    new.index = sema.builtin_type_target_index;
+    sema.mod.intern_pool.resolveBuiltinType(new.index, wip_ty.index);
+    return new;
+}
+
+/// Given a type just looked up in the `InternPool`, check whether it is
+/// considered outdated on this update. If so, remove it from the pool
+/// and return `true`.
+fn maybeRemoveOutdatedType(sema: *Sema, ty: InternPool.Index) !bool {
+    const zcu = sema.mod;
+
+    if (!zcu.comp.debug_incremental) return false;
+
+    const decl_index = Type.fromInterned(ty).getOwnerDecl(zcu);
+    const decl_as_depender = InternPool.Depender.wrap(.{ .decl = decl_index });
+    const was_outdated = zcu.outdated.swapRemove(decl_as_depender) or
+        zcu.potentially_outdated.swapRemove(decl_as_depender);
+    if (!was_outdated) return false;
+    _ = zcu.outdated_ready.swapRemove(decl_as_depender);
+    zcu.intern_pool.removeDependenciesForDepender(zcu.gpa, InternPool.Depender.wrap(.{ .decl = decl_index }));
+    zcu.intern_pool.remove(ty);
+    zcu.declPtr(decl_index).analysis = .dependency_failure;
+    try zcu.markDependeeOutdated(.{ .decl_val = decl_index });
+    return true;
+}
+
 fn zirStructDecl(
     sema: *Sema,
     block: *Block,
@@ -2748,7 +2779,7 @@ fn zirStructDecl(
         }
     }
 
-    const wip_ty = switch (try ip.getStructType(gpa, .{
+    const struct_init: InternPool.StructTypeInit = .{
         .layout = small.layout,
         .fields_len = fields_len,
         .known_non_opv = small.known_non_opv,
@@ -2763,16 +2794,14 @@ fn zirStructDecl(
             .zir_index = try ip.trackZir(gpa, block.getFileScope(mod), inst),
             .captures = captures,
         } },
-    })) {
-        .existing => |ty| return Air.internedToRef(ty),
-        .wip => |wip| wip: {
-            if (sema.builtin_type_target_index == .none) break :wip wip;
-            var new = wip;
-            new.index = sema.builtin_type_target_index;
-            ip.resolveBuiltinType(new.index, wip.index);
-            break :wip new;
-        },
     };
+    const wip_ty = sema.wrapWipTy(switch (try ip.getStructType(gpa, struct_init)) {
+        .existing => |ty| wip: {
+            if (!try sema.maybeRemoveOutdatedType(ty)) return Air.internedToRef(ty);
+            break :wip (try ip.getStructType(gpa, struct_init)).wip;
+        },
+        .wip => |wip| wip,
+    });
     errdefer wip_ty.cancel(ip);
 
     const new_decl_index = try sema.createAnonymousDeclTypeNamed(block, src, .{
@@ -2969,7 +2998,7 @@ fn zirEnumDecl(
         if (bag != 0) break true;
     } else false;
 
-    const wip_ty = switch (try ip.getEnumType(gpa, .{
+    const enum_init: InternPool.EnumTypeInit = .{
         .has_namespace = true or decls_len > 0, // TODO: see below
         .has_values = any_values,
         .tag_mode = if (small.nonexhaustive)
@@ -2983,16 +3012,14 @@ fn zirEnumDecl(
             .zir_index = try mod.intern_pool.trackZir(sema.gpa, block.getFileScope(mod), inst),
             .captures = captures,
         } },
-    })) {
-        .wip => |wip| wip: {
-            if (sema.builtin_type_target_index == .none) break :wip wip;
-            var new = wip;
-            new.index = sema.builtin_type_target_index;
-            ip.resolveBuiltinType(new.index, wip.index);
-            break :wip new;
-        },
-        .existing => |ty| return Air.internedToRef(ty),
     };
+    const wip_ty = sema.wrapWipTy(switch (try ip.getEnumType(gpa, enum_init)) {
+        .existing => |ty| wip: {
+            if (!try sema.maybeRemoveOutdatedType(ty)) return Air.internedToRef(ty);
+            break :wip (try ip.getEnumType(gpa, enum_init)).wip;
+        },
+        .wip => |wip| wip,
+    });
 
     // Once this is `true`, we will not delete the decl or type even upon failure, since we
     // have finished constructing the type and are in the process of analyzing it.
@@ -3230,7 +3257,7 @@ fn zirUnionDecl(
     const captures = try sema.getCaptures(block, extra_index, captures_len);
     extra_index += captures_len;
 
-    const wip_ty = switch (try ip.getUnionType(gpa, .{
+    const union_init: InternPool.UnionTypeInit = .{
         .flags = .{
             .layout = small.layout,
             .status = .none,
@@ -3257,16 +3284,14 @@ fn zirUnionDecl(
             .zir_index = try ip.trackZir(gpa, block.getFileScope(mod), inst),
             .captures = captures,
         } },
-    })) {
-        .wip => |wip| wip: {
-            if (sema.builtin_type_target_index == .none) break :wip wip;
-            var new = wip;
-            new.index = sema.builtin_type_target_index;
-            ip.resolveBuiltinType(new.index, wip.index);
-            break :wip new;
-        },
-        .existing => |ty| return Air.internedToRef(ty),
     };
+    const wip_ty = sema.wrapWipTy(switch (try ip.getUnionType(gpa, union_init)) {
+        .existing => |ty| wip: {
+            if (!try sema.maybeRemoveOutdatedType(ty)) return Air.internedToRef(ty);
+            break :wip (try ip.getUnionType(gpa, union_init)).wip;
+        },
+        .wip => |wip| wip,
+    });
     errdefer wip_ty.cancel(ip);
 
     const new_decl_index = try sema.createAnonymousDeclTypeNamed(block, src, .{
@@ -3336,15 +3361,20 @@ fn zirOpaqueDecl(
     const captures = try sema.getCaptures(block, extra_index, captures_len);
     extra_index += captures_len;
 
-    const wip_ty = switch (try ip.getOpaqueType(gpa, .{
+    const opaque_init: InternPool.OpaqueTypeInit = .{
         .has_namespace = decls_len != 0,
         .key = .{ .declared = .{
             .zir_index = try ip.trackZir(gpa, block.getFileScope(mod), inst),
             .captures = captures,
         } },
-    })) {
+    };
+    // No `wrapWipTy` needed as no std.builtin types are opaque.
+    const wip_ty = switch (try ip.getOpaqueType(gpa, opaque_init)) {
+        .existing => |ty| wip: {
+            if (!try sema.maybeRemoveOutdatedType(ty)) return Air.internedToRef(ty);
+            break :wip (try ip.getOpaqueType(gpa, opaque_init)).wip;
+        },
         .wip => |wip| wip,
-        .existing => |ty| return Air.internedToRef(ty),
     };
     errdefer wip_ty.cancel(ip);
 
@@ -39052,6 +39082,15 @@ fn ptrType(sema: *Sema, info: InternPool.Key.PtrType) CompileError!Type {
 
 pub fn declareDependency(sema: *Sema, dependee: InternPool.Dependee) !void {
     if (!sema.mod.comp.debug_incremental) return;
+
+    // Avoid creating dependencies on ourselves. This situation can arise when we analyze the fields
+    // of a type and they use `@This()`. This dependency would be unnecessary, and in fact would
+    // just result in over-analysis since `Zcu.findOutdatedToAnalyze` would never be able to resolve
+    // the loop.
+    if (sema.owner_func_index == .none and dependee == .decl_val and dependee.decl_val == sema.owner_decl_index) {
+        return;
+    }
+
     const depender = InternPool.Depender.wrap(
         if (sema.owner_func_index != .none)
             .{ .func = sema.owner_func_index }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -36462,8 +36462,14 @@ fn resolveInferredErrorSet(
     const ip = &mod.intern_pool;
     const func_index = ip.iesFuncIndex(ies_index);
     const func = mod.funcInfo(func_index);
+
+    try sema.declareDependency(.{ .func_ies = func_index });
+
+    // TODO: during an incremental update this might not be `.none`, but the
+    // function might be out-of-date!
     const resolved_ty = func.resolvedErrorSet(ip).*;
     if (resolved_ty != .none) return resolved_ty;
+
     if (func.analysis(ip).state == .in_progress)
         return sema.fail(block, src, "unable to resolve inferred error set", .{});
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5883,7 +5883,7 @@ fn zirCImport(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileEr
     mod.astGenFile(result.file) catch |err|
         return sema.fail(&child_block, src, "C import failed: {s}", .{@errorName(err)});
 
-    try mod.semaFile(result.file);
+    try mod.ensureFileAnalyzed(result.file);
     const file_root_decl_index = result.file.root_decl.unwrap().?;
     return sema.analyzeDeclVal(parent_block, src, file_root_decl_index);
 }
@@ -13705,7 +13705,7 @@ fn zirImport(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
             return sema.fail(block, operand_src, "unable to open '{s}': {s}", .{ operand, @errorName(err) });
         },
     };
-    try mod.semaFile(result.file);
+    try mod.ensureFileAnalyzed(result.file);
     const file_root_decl_index = result.file.root_decl.unwrap().?;
     return sema.analyzeDeclVal(block, operand_src, file_root_decl_index);
 }

--- a/test/cases/compile_errors/comptime_decl_name_conflict_resolved.zig
+++ b/test/cases/compile_errors/comptime_decl_name_conflict_resolved.zig
@@ -1,0 +1,8 @@
+comptime {
+    @compileError("should be reached");
+}
+const comptime_0 = {};
+
+// error
+//
+// :2:5: error: should be reached

--- a/test/cases/compile_errors/invalid_duplicate_test_decl_name.zig
+++ b/test/cases/compile_errors/invalid_duplicate_test_decl_name.zig
@@ -6,5 +6,5 @@ test "thingy" {}
 // target=native
 // is_test=true
 //
-// :1:6: error: duplicate test name: test.thingy
-// :2:6: note: other test here
+// :2:1: error: duplicate test name 'thingy'
+// :1:1: note: other test here


### PR DESCRIPTION
We're deep in the weeds now. As of this PR trivial updates are blocked on linker progress (or CBE/LLVM backend progress), but I can still make progress in the meantime.

Before I make more steps towards incremental, I need to have a stern talking-to with `Zcu.Decl` (see [my proposed refactor](https://gist.github.com/mlugg/d0dcb0025dbfd7145b66d0ada6060024)) - but I think we're very close to something usable on the frontend.