### PR TITLE
autodoc: Use `code` for keyboard events

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -666,8 +666,8 @@
     }
 
     function onSearchKeyDown(ev) {
-      switch (ev.which) {
-        case 13:
+      switch (ev.code) {
+        case "Enter":
           if (ev.shiftKey || ev.ctrlKey || ev.altKey) return;
 
           clearAsyncSearch();
@@ -677,7 +677,7 @@
           ev.preventDefault();
           ev.stopPropagation();
           return;
-        case 27:
+        case "Escape":
           if (ev.shiftKey || ev.ctrlKey || ev.altKey) return;
 
           domSearch.value = "";
@@ -687,14 +687,14 @@
           ev.stopPropagation();
           startSearch();
           return;
-        case 38:
+        case "ArrowUp":
           if (ev.shiftKey || ev.ctrlKey || ev.altKey) return;
 
           moveSearchCursor(-1);
           ev.preventDefault();
           ev.stopPropagation();
           return;
-        case 40:
+        case "ArrowDown":
           if (ev.shiftKey || ev.ctrlKey || ev.altKey) return;
 
           moveSearchCursor(1);
@@ -732,8 +732,8 @@
     }
 
     function onWindowKeyDown(ev) {
-        switch (ev.which) {
-            case 27:
+        switch (ev.code) {
+            case "Escape":
                 if (ev.shiftKey || ev.ctrlKey || ev.altKey) return;
                 if (!domHelpModal.classList.contains("hidden")) {
                     domHelpModal.classList.add("hidden");
@@ -741,7 +741,7 @@
                     ev.stopPropagation();
                 }
                 break;
-            case 83:
+            case "KeyS":
                 if (ev.shiftKey || ev.ctrlKey || ev.altKey) return;
                 domSearch.focus();
                 domSearch.select();
@@ -749,13 +749,13 @@
                 ev.stopPropagation();
                 startAsyncSearch();
                 break;
-            case 85:
+            case "KeyU":
                 if (ev.shiftKey || ev.ctrlKey || ev.altKey) return;
                 ev.preventDefault();
                 ev.stopPropagation();
                 navigateToSource();
                 break;
-            case 191:
+            case "Slash":
                 if (!ev.shiftKey || ev.ctrlKey || ev.altKey) return;
                 ev.preventDefault();
                 ev.stopPropagation();


### PR DESCRIPTION
It is currently impossible to bring up the help dialog on certain non-English keyboard layouts. On my Swedish keyboard, neither pressing the key with the `?` glyph nor the key physically located where the `/?` key is on a US/UK keyboard works, with or without holding down `Shift`.

`which` is deprecated and web standards recommend using `key` for matching on locale-specific character produced and `code` for matching on the locale-independent physical key being pressed (see <https://www.w3.org/TR/uievents-key/> and <https://w3c.github.io/uievents-code/> if you care about the details).