### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This will cause dependabot to open a pull request when it detects some actions have been updated, such as 'checkout' or other actions registered on the GitHub marketplace.

An example of this can be seen at https://github.com/curl/curl/pulls?q=is%3Apr+is%3Aclosed+dependabot

The docs for it are at https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file