### PR TITLE
Fix emscripten exports

### DIFF
--- a/lib/std/os/emscripten.zig
+++ b/lib/std/os/emscripten.zig
@@ -17,8 +17,8 @@ comptime {
     if (builtin.os.tag == .emscripten) {
         if (builtin.mode == .Debug or builtin.mode == .ReleaseSafe) {
             // Emscripten does not provide these symbols, so we must export our own
-            @export(__stack_chk_guard, .{ .name = "__stack_chk_guard", .linkage = .Strong });
-            @export(__stack_chk_fail, .{ .name = "__stack_chk_fail", .linkage = .Strong });
+            @export(__stack_chk_guard, .{ .name = "__stack_chk_guard", .linkage = .strong });
+            @export(__stack_chk_fail, .{ .name = "__stack_chk_fail", .linkage = .strong });
         }
     }
 }


### PR DESCRIPTION
These were missing in https://github.com/ziglang/zig/pull/18994