### PR TITLE
std.os.windows: handle OBJECT_NAME_INVALID in OpenFile

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -42,6 +42,7 @@ pub const OpenError = error{
     WouldBlock,
     NetworkNotFound,
     AntivirusInterference,
+    BadPathName,
 };
 
 pub const OpenFileOptions = struct {
@@ -120,7 +121,7 @@ pub fn OpenFile(sub_path_w: []const u16, options: OpenFileOptions) OpenError!HAN
         );
         switch (rc) {
             .SUCCESS => return result,
-            .OBJECT_NAME_INVALID => unreachable,
+            .OBJECT_NAME_INVALID => return error.BadPathName,
             .OBJECT_NAME_NOT_FOUND => return error.FileNotFound,
             .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
             .BAD_NETWORK_PATH => return error.NetworkNotFound, // \\server was not found


### PR DESCRIPTION
It's been seen on Windows 11 (22H2) Build 22621.3155 that NtCreateFile will return the OBJECT_NAME_INVALID error code with certain path names. The path name we saw this with started with `C:Users` (rather than `C:\Users`) and also contained a `$` character.  This PR updates our OpenFile wrapper to propagate this error code as `error.BadPathName` instead of making it `unreachable`.

> NOTE: not all versions of windows will return this error code, some will return `OBJECT_PATH_NOT_FOUND` instead

see https://github.com/marler8997/zigup/issues/114#issuecomment-1994420791