### PR TITLE
compress.xz: fix slow running read loop

### DIFF
--- a/lib/std/compress/xz/block.zig
+++ b/lib/std/compress/xz/block.zig
@@ -83,8 +83,6 @@ pub fn Decoder(comptime ReaderType: type) type {
         }
 
         fn readBlock(self: *Self) Error!void {
-            const unpacked_pos = self.to_read.items.len;
-
             var block_counter = std.io.countingReader(self.inner_reader);
             const block_reader = block_counter.reader();
 
@@ -165,7 +163,7 @@ pub fn Decoder(comptime ReaderType: type) type {
                     return error.CorruptInput;
             }
 
-            const unpacked_bytes = self.to_read.items[unpacked_pos..];
+            const unpacked_bytes = self.to_read.items;
             if (unpacked_size) |s| {
                 if (s != unpacked_bytes.len)
                     return error.CorruptInput;


### PR DESCRIPTION
In the example from the issue https://github.com/ziglang/zig/issues/19052 to_read holds 213_315_584
uncompressed bytes. Calling read with small output results in many
shifts of that big buffer.
This removes the need to shift to_read after each read.

The example from the issue which took almost 3 hours now finishes in less than a second. 

Fixes: #19052