### PR TITLE
Faster fill functions in implementations of std.Random

### DIFF
--- a/lib/std/Random/Isaac64.zig
+++ b/lib/std/Random/Isaac64.zig
@@ -150,24 +150,19 @@ fn seed(self: *Isaac64, init_s: u64, comptime rounds: usize) void {
 }
 
 pub fn fill(self: *Isaac64, buf: []u8) void {
-    var i: usize = 0;
     const aligned_len = buf.len - (buf.len & 7);
 
-    // Fill complete 64-byte segments
-    while (i < aligned_len) : (i += 8) {
-        var n = self.next();
-        comptime var j: usize = 0;
-        inline while (j < 8) : (j += 1) {
-            buf[i + j] = @as(u8, @truncate(n));
-            n >>= 8;
-        }
+    // Complete 8 byte segments.
+    const buf64 = std.mem.bytesAsSlice(u64, buf[0..aligned_len]);
+    for (buf64) |*b| {
+        b.* = self.next();
     }
 
-    // Fill trailing, ignoring excess (cut the stream).
-    if (i != buf.len) {
+    // Remaining. (cuts the stream)
+    if (aligned_len != buf.len) {
         var n = self.next();
-        while (i < buf.len) : (i += 1) {
-            buf[i] = @as(u8, @truncate(n));
+        for (buf[aligned_len..]) |*b| {
+            b.* = @as(u8, @truncate(n));
             n >>= 8;
         }
     }

--- a/lib/std/Random/Pcg.zig
+++ b/lib/std/Random/Pcg.zig
@@ -49,24 +49,19 @@ fn seedTwo(self: *Pcg, init_s: u64, init_i: u64) void {
 }
 
 pub fn fill(self: *Pcg, buf: []u8) void {
-    var i: usize = 0;
     const aligned_len = buf.len - (buf.len & 3);
 
     // Complete 4 byte segments.
-    while (i < aligned_len) : (i += 4) {
-        var n = self.next();
-        comptime var j: usize = 0;
-        inline while (j < 4) : (j += 1) {
-            buf[i + j] = @as(u8, @truncate(n));
-            n >>= 8;
-        }
+    const buf32 = std.mem.bytesAsSlice(u32, buf[0..aligned_len]);
+    for (buf32) |*b| {
+        b.* = self.next();
     }
 
     // Remaining. (cuts the stream)
-    if (i != buf.len) {
+    if (aligned_len != buf.len) {
         var n = self.next();
-        while (i < buf.len) : (i += 1) {
-            buf[i] = @as(u8, @truncate(n));
+        for (buf[aligned_len..]) |*b| {
+            b.* = @as(u8, @truncate(n));
             n >>= 8;
         }
     }

--- a/lib/std/Random/RomuTrio.zig
+++ b/lib/std/Random/RomuTrio.zig
@@ -49,24 +49,19 @@ pub fn seed(self: *RomuTrio, init_s: u64) void {
 }
 
 pub fn fill(self: *RomuTrio, buf: []u8) void {
-    var i: usize = 0;
     const aligned_len = buf.len - (buf.len & 7);
 
     // Complete 8 byte segments.
-    while (i < aligned_len) : (i += 8) {
-        var n = self.next();
-        comptime var j: usize = 0;
-        inline while (j < 8) : (j += 1) {
-            buf[i + j] = @as(u8, @truncate(n));
-            n >>= 8;
-        }
+    const buf64 = std.mem.bytesAsSlice(u64, buf[0..aligned_len]);
+    for (buf64) |*b| {
+        b.* = self.next();
     }
 
     // Remaining. (cuts the stream)
-    if (i != buf.len) {
+    if (aligned_len != buf.len) {
         var n = self.next();
-        while (i < buf.len) : (i += 1) {
-            buf[i] = @as(u8, @truncate(n));
+        for (buf[aligned_len..]) |*b| {
+            b.* = @as(u8, @truncate(n));
             n >>= 8;
         }
     }

--- a/lib/std/Random/Sfc64.zig
+++ b/lib/std/Random/Sfc64.zig
@@ -47,24 +47,19 @@ fn seed(self: *Sfc64, init_s: u64) void {
 }
 
 pub fn fill(self: *Sfc64, buf: []u8) void {
-    var i: usize = 0;
     const aligned_len = buf.len - (buf.len & 7);
 
     // Complete 8 byte segments.
-    while (i < aligned_len) : (i += 8) {
-        var n = self.next();
-        comptime var j: usize = 0;
-        inline while (j < 8) : (j += 1) {
-            buf[i + j] = @as(u8, @truncate(n));
-            n >>= 8;
-        }
+    const buf64 = std.mem.bytesAsSlice(u64, buf[0..aligned_len]);
+    for (buf64) |*b| {
+        b.* = self.next();
     }
 
     // Remaining. (cuts the stream)
-    if (i != buf.len) {
+    if (aligned_len != buf.len) {
         var n = self.next();
-        while (i < buf.len) : (i += 1) {
-            buf[i] = @as(u8, @truncate(n));
+        for (buf[aligned_len..]) |*b| {
+            b.* = @as(u8, @truncate(n));
             n >>= 8;
         }
     }

--- a/lib/std/Random/Xoroshiro128.zig
+++ b/lib/std/Random/Xoroshiro128.zig
@@ -65,24 +65,19 @@ pub fn seed(self: *Xoroshiro128, init_s: u64) void {
 }
 
 pub fn fill(self: *Xoroshiro128, buf: []u8) void {
-    var i: usize = 0;
     const aligned_len = buf.len - (buf.len & 7);
 
     // Complete 8 byte segments.
-    while (i < aligned_len) : (i += 8) {
-        var n = self.next();
-        comptime var j: usize = 0;
-        inline while (j < 8) : (j += 1) {
-            buf[i + j] = @as(u8, @truncate(n));
-            n >>= 8;
-        }
+    const buf64 = std.mem.bytesAsSlice(u64, buf[0..aligned_len]);
+    for (buf64) |*b| {
+        b.* = self.next();
     }
 
     // Remaining. (cuts the stream)
-    if (i != buf.len) {
+    if (aligned_len != buf.len) {
         var n = self.next();
-        while (i < buf.len) : (i += 1) {
-            buf[i] = @as(u8, @truncate(n));
+        for (buf[aligned_len..]) |*b| {
+            b.* = @as(u8, @truncate(n));
             n >>= 8;
         }
     }

--- a/lib/std/Random/Xoshiro256.zig
+++ b/lib/std/Random/Xoshiro256.zig
@@ -65,24 +65,19 @@ pub fn seed(self: *Xoshiro256, init_s: u64) void {
 }
 
 pub fn fill(self: *Xoshiro256, buf: []u8) void {
-    var i: usize = 0;
     const aligned_len = buf.len - (buf.len & 7);
 
     // Complete 8 byte segments.
-    while (i < aligned_len) : (i += 8) {
-        var n = self.next();
-        comptime var j: usize = 0;
-        inline while (j < 8) : (j += 1) {
-            buf[i + j] = @as(u8, @truncate(n));
-            n >>= 8;
-        }
+    const buf64 = std.mem.bytesAsSlice(u64, buf[0..aligned_len]);
+    for (buf64) |*b| {
+        b.* = self.next();
     }
 
     // Remaining. (cuts the stream)
-    if (i != buf.len) {
+    if (aligned_len != buf.len) {
         var n = self.next();
-        while (i < buf.len) : (i += 1) {
-            buf[i] = @as(u8, @truncate(n));
+        for (buf[aligned_len..]) |*b| {
+            b.* = @as(u8, @truncate(n));
             n >>= 8;
         }
     }


### PR DESCRIPTION
`std.Random.int()` with `std.Random.DefaultPrng` does not generate optimal assembly for all types, at least on x86-64, anything above u56 is not optimized into simple calls to `Xoshiro256.next()`, skipping the serialization step in `Xoshiro256.fill()` and is instead being filled byte by byte.

Comparison of `std.Random.int(u32)` with `std.Random.int(u64)`: <https://zig.godbolt.org/z/czqxoM64b>.

This `std.Random.int()` behaviour also happens with `Sfc64` and `Isaac64`, but other engines that share the same fill function do the same on `std.Random.bytes()`, they generate a result from the `next` function then uses it to fill the buffer a byte at a time.

Calling `std.Random.bytes()` with different engines: <https://zig.godbolt.org/z/8z9dj4eK4>.

Modifying the fill function from `Xoshiro256` such that it doesn't serialize the `next` function result into byte sizes yields these results from poop when benchmarking `std.Random.int(u64)`:

```
$ zig build-exe stdlib.zig -OReleaseFast -fstrip
$ zig build-exe modified.zig -OReleaseFast -fstrip
$ sudo ~/.local/bin/poop "./stdlib" "./modified"
Benchmark 1 (753 runs): ./stdlib
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          6.54ms ±  203us    6.28ms … 7.96ms         74 (10%)        0%
  peak_rss            131KB ±    0       131KB …  131KB          0 ( 0%)        0%
  cpu_cycles            0   ±    0         0   …    0            0 ( 0%)        0%
  instructions          0   ±    0         0   …    0            0 ( 0%)        0%
  cache_references      0   ±    0         0   …    0            0 ( 0%)        0%
  cache_misses          0   ±    0         0   …    0            0 ( 0%)        0%
  branch_misses         0   ±    0         0   …    0            0 ( 0%)        0%
Benchmark 2 (3817 runs): ./modified
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.27ms ± 95.6us    1.09ms … 2.43ms         34 ( 1%)        ⚡- 80.5% ±  0.1%
  peak_rss            290KB ± 87.3KB     131KB …  373KB          0 ( 0%)        💩+121.5% ±  4.8%
  cpu_cycles            0   ±    0         0   …    0            0 ( 0%)          -  nan% ± -nan%
  instructions          0   ±    0         0   …    0            0 ( 0%)          -  nan% ± -nan%
  cache_references      0   ±    0         0   …    0            0 ( 0%)          -  nan% ± -nan%
  cache_misses          0   ±    0         0   …    0            0 ( 0%)          -  nan% ± -nan%
  branch_misses         0   ±    0         0   …    0            0 ( 0%)          -  nan% ± -nan%
```

Files for the benchmark: <https://gist.github.com/PauloCampana/b78ed6cf5c42cc323b4a406b7f3f9c38>

And more optimal assembly after the patch: <https://zig.godbolt.org/z/snWYehrWY>


