### PR TITLE
std.fmt: fix incorrect rounding on 0 precision of a decimal

### DIFF
--- a/lib/std/fmt/ryu128.zig
+++ b/lib/std/fmt/ryu128.zig
@@ -2,6 +2,7 @@
 //! https://dl.acm.org/doi/pdf/10.1145/3360595
 
 const std = @import("std");
+const expectFmt = std.testing.expectFmt;
 
 const special_exponent = 0x7fffffff;
 
@@ -1130,15 +1131,9 @@ test "format f128" {
     try check(f128, 1.2345678, "1.2345678e0");
 }
 
-fn checkFormatDecimalWithZeroPrecision(comptime T: type, value: T, comptime expected: []const u8) !void {
-    var buf: [6000]u8 = undefined;
-    const s = try format(&buf, value, .{ .mode = .decimal, .precision = 0 });
-    try std.testing.expectEqualStrings(expected, s);
-}
-
-test "format f128 decimal zero precision" {
-    try checkFormatDecimalWithZeroPrecision(f32, 5, "5");
-    try checkFormatDecimalWithZeroPrecision(f64, 6, "6");
-    try checkFormatDecimalWithZeroPrecision(f80, 7, "7");
-    try checkFormatDecimalWithZeroPrecision(f128, 8, "8");
+test "format float to decimal with zero precision" {
+    try expectFmt("5", "{d:.0}", .{5});
+    try expectFmt("6", "{d:.0}", .{6});
+    try expectFmt("7", "{d:.0}", .{7});
+    try expectFmt("8", "{d:.0}", .{8});
 }

--- a/lib/std/fmt/ryu128.zig
+++ b/lib/std/fmt/ryu128.zig
@@ -211,7 +211,7 @@ pub fn formatScientific(buf: []u8, f_: FloatDecimal128, precision: ?usize) RyuEr
         index += 1;
     }
 
-    // 1.12345
+    // 2345
     writeDecimal(buf[index + 2 ..], &output, olength - 1);
     buf[index] = '0' + @as(u8, @intCast(output % 10));
     buf[index + 1] = '.';
@@ -1128,4 +1128,17 @@ test "format f128" {
     try check(f128, 4.708356024711512e18, "4.708356024711512e18");
     try check(f128, 9.409340012568248e18, "9.409340012568248e18");
     try check(f128, 1.2345678, "1.2345678e0");
+}
+
+fn checkFormatDecimalWithZeroPrecision(comptime T: type, value: T, comptime expected: []const u8) !void {
+    var buf: [6000]u8 = undefined;
+    const s = try format(&buf, value, .{ .mode = .decimal, .precision = 0 });
+    try std.testing.expectEqualStrings(expected, s);
+}
+
+test "format f128 decimal zero precision" {
+    try checkFormatDecimalWithZeroPrecision(f32, 5, "5");
+    try checkFormatDecimalWithZeroPrecision(f64, 6, "6");
+    try checkFormatDecimalWithZeroPrecision(f80, 7, "7");
+    try checkFormatDecimalWithZeroPrecision(f128, 8, "8");
 }

--- a/lib/std/fmt/ryu128.zig
+++ b/lib/std/fmt/ryu128.zig
@@ -211,7 +211,7 @@ pub fn formatScientific(buf: []u8, f_: FloatDecimal128, precision: ?usize) RyuEr
         index += 1;
     }
 
-    // 2345
+    // 1.12345
     writeDecimal(buf[index + 2 ..], &output, olength - 1);
     buf[index] = '0' + @as(u8, @intCast(output % 10));
     buf[index + 1] = '.';

--- a/lib/std/fmt/ryu128.zig
+++ b/lib/std/fmt/ryu128.zig
@@ -131,7 +131,7 @@ fn round(f: FloatDecimal128, mode: RoundMode, precision: usize) FloatDecimal128 
 
     switch (mode) {
         .decimal => {
-            if (f.exponent >= 0) {
+            if (f.exponent > 0) {
                 round_digit = (olength - 1) + precision + @as(usize, @intCast(f.exponent));
             } else {
                 const min_exp_required = @as(usize, @intCast(-f.exponent));


### PR DESCRIPTION
closes #19314

All original tests have passed. Given example with new output:

```
info: 0 == 0 == 0
info: 1 == 1 == 1
info: 2 == 2 == 2
info: 3 == 3 == 3
info: 4 == 4 == 4
info: 5 != 5 != 5
info: 6 != 6 != 6
info: 7 != 7 != 7
info: 8 != 8 != 8
info: 9 != 9 != 9
```
