### PR TITLE
Fix "unable to generate DLL import .lib file"

### DIFF
--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -268,7 +268,7 @@ pub fn buildImportLib(comp: *Compilation, lib_name: []const u8) !void {
 
     {
         // new scope to ensure definition file is written before passing the path to WriteImportLibrary
-        const def_final_file = try comp.global_cache_directory.handle.createFile(def_final_path, .{ .truncate = true });
+        const def_final_file = try o_dir.createFile(final_def_basename, .{ .truncate = true });
         defer def_final_file.close();
         try pp.prettyPrintTokens(def_final_file.writer());
     }


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/19284

As of 9f2cb920c055bc990cc9d593b8dc9eaa450d07b9 configuring the global cache directory to a relative path causes errors of the following form when cross compiling to `windows-gnu`.
```
error: unable to generate DLL import .lib file for kernel32: FileNotFound
```

The issue occurred because the `def_final_path` included the global cache path as a prefix and later on the `def_final_file` was created using that path with the global cache directory handle.
