### PR TITLE
Ast: fix comptime destructure

### DIFF
--- a/lib/compiler/reduce/Walk.zig
+++ b/lib/compiler/reduce/Walk.zig
@@ -345,12 +345,8 @@ fn walkExpression(w: *Walk, node: Ast.Node.Index) Error!void {
         },
 
         .assign_destructure => {
-            const lhs_count = ast.extra_data[datas[node].lhs];
-            assert(lhs_count > 1);
-            const lhs_exprs = ast.extra_data[datas[node].lhs + 1 ..][0..lhs_count];
-            const rhs = datas[node].rhs;
-
-            for (lhs_exprs) |lhs_node| {
+            const full = tree.assignDestructure(node);
+            for (full.ast.variables) |variable_node| {
                 switch (node_tags[lhs_node]) {
                     .global_var_decl,
                     .local_var_decl,
@@ -358,10 +354,10 @@ fn walkExpression(w: *Walk, node: Ast.Node.Index) Error!void {
                     .aligned_var_decl,
                     => try walkLocalVarDecl(w, ast.fullVarDecl(lhs_node).?),
 
-                    else => try walkExpression(w, lhs_node),
+                    else => try walkExpression(w, variable_node),
                 }
             }
-            return walkExpression(w, rhs);
+            return walkExpression(w, full.ast.assign_expr);
         },
 
         .bit_not,

--- a/lib/docs/wasm/Walk.zig
+++ b/lib/docs/wasm/Walk.zig
@@ -699,12 +699,9 @@ fn expr(w: *Walk, scope: *Scope, parent_decl: Decl.Index, node: Ast.Node.Index) 
         },
 
         .assign_destructure => {
-            const extra_index = node_datas[node].lhs;
-            const lhs_count = ast.extra_data[extra_index];
-            const lhs_nodes: []const Ast.Node.Index = @ptrCast(ast.extra_data[extra_index + 1 ..][0..lhs_count]);
-            const rhs = node_datas[node].rhs;
-            for (lhs_nodes) |lhs_node| try expr(w, scope, parent_decl, lhs_node);
-            _ = try expr(w, scope, parent_decl, rhs);
+            const full = ast.assignDestructure(node);
+            for (full.ast.variables) |variable_node| try expr(w, scope, parent_decl, variable_node);
+            _ = try expr(w, scope, parent_decl, full.ast.value_expr);
         },
 
         .bool_not,

--- a/lib/std/zig/AstRlAnnotate.zig
+++ b/lib/std/zig/AstRlAnnotate.zig
@@ -204,13 +204,12 @@ fn expr(astrl: *AstRlAnnotate, node: Ast.Node.Index, block: ?*Block, ri: ResultI
             }
         },
         .assign_destructure => {
-            const lhs_count = tree.extra_data[node_datas[node].lhs];
-            const all_lhs = tree.extra_data[node_datas[node].lhs + 1 ..][0..lhs_count];
-            for (all_lhs) |lhs| {
-                _ = try astrl.expr(lhs, block, ResultInfo.none);
+            const full = tree.assignDestructure(node);
+            for (full.ast.variables) |variable_node| {
+                _ = try astrl.expr(variable_node, block, ResultInfo.none);
             }
             // We don't need to gather any meaningful data here, because destructures always use RLS
-            _ = try astrl.expr(node_datas[node].rhs, block, ResultInfo.none);
+            _ = try astrl.expr(full.ast.value_expr, block, ResultInfo.none);
             return false;
         },
         .assign => {

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -2914,6 +2914,25 @@ test "zig fmt: test declaration" {
     );
 }
 
+test "zig fmt: destructure" {
+    try testCanonical(
+        \\comptime {
+        \\    var w: u8, var x: u8 = .{ 1, 2 };
+        \\    w, var y: u8 = .{ 3, 4 };
+        \\    var z: u8, x = .{ 5, 6 };
+        \\    y, z = .{ 7, 8 };
+        \\}
+        \\
+        \\comptime {
+        \\    comptime var w, var x = .{ 1, 2 };
+        \\    comptime w, var y = .{ 3, 4 };
+        \\    comptime var z, x = .{ 5, 6 };
+        \\    comptime y, z = .{ 7, 8 };
+        \\}
+        \\
+    );
+}
+
 test "zig fmt: infix operators" {
     try testCanonical(
         \\test {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -569,39 +569,33 @@ fn renderExpression(r: *Render, node: Ast.Node.Index, space: Space) Error!void {
         },
 
         .assign_destructure => {
-            const lhs_count = tree.extra_data[datas[node].lhs];
-            assert(lhs_count > 1);
-            const lhs_exprs = tree.extra_data[datas[node].lhs + 1 ..][0..lhs_count];
-            const rhs = datas[node].rhs;
-
-            const maybe_comptime_token = tree.firstToken(node) - 1;
-            if (token_tags[maybe_comptime_token] == .keyword_comptime) {
-                try renderToken(r, maybe_comptime_token, .space);
+            const full = tree.assignDestructure(node);
+            if (full.comptime_token) |comptime_token| {
+                try renderToken(r, comptime_token, .space);
             }
 
-            for (lhs_exprs, 0..) |lhs_node, i| {
-                const lhs_space: Space = if (i == lhs_exprs.len - 1) .space else .comma_space;
-                switch (node_tags[lhs_node]) {
+            for (full.ast.variables, 0..) |variable_node, i| {
+                const variable_space: Space = if (i == full.ast.variables.len - 1) .space else .comma_space;
+                switch (node_tags[variable_node]) {
                     .global_var_decl,
                     .local_var_decl,
                     .simple_var_decl,
                     .aligned_var_decl,
                     => {
-                        try renderVarDecl(r, tree.fullVarDecl(lhs_node).?, true, lhs_space);
+                        try renderVarDecl(r, tree.fullVarDecl(variable_node).?, true, variable_space);
                     },
-                    else => try renderExpression(r, lhs_node, lhs_space),
+                    else => try renderExpression(r, variable_node, variable_space),
                 }
             }
-            const equal_token = main_tokens[node];
-            if (tree.tokensOnSameLine(equal_token, equal_token + 1)) {
-                try renderToken(r, equal_token, .space);
+            if (tree.tokensOnSameLine(full.ast.equal_token, full.ast.equal_token + 1)) {
+                try renderToken(r, full.ast.equal_token, .space);
             } else {
                 ais.pushIndent();
-                try renderToken(r, equal_token, .newline);
+                try renderToken(r, full.ast.equal_token, .newline);
                 ais.popIndent();
             }
             ais.pushIndentOneShot();
-            return renderExpression(r, rhs, space);
+            return renderExpression(r, full.ast.value_expr, space);
         },
 
         .bit_not,

--- a/test/behavior/destructure.zig
+++ b/test/behavior/destructure.zig
@@ -24,21 +24,55 @@ test "simple destructure" {
 
 test "destructure with comptime syntax" {
     const S = struct {
-        fn doTheTest() void {
-            comptime var x: f32 = undefined;
-            comptime x, const y, var z = .{ 0.5, 123, 456 }; // z is a comptime var
-            _ = &z;
+        fn doTheTest() !void {
+            {
+                comptime var x: f32 = undefined;
+                comptime x, const y, var z = .{ 0.5, 123, 456 }; // z is a comptime var
+                _ = &z;
 
-            comptime assert(@TypeOf(y) == comptime_int);
-            comptime assert(@TypeOf(z) == comptime_int);
-            comptime assert(x == 0.5);
-            comptime assert(y == 123);
-            comptime assert(z == 456);
+                comptime assert(@TypeOf(y) == comptime_int);
+                comptime assert(@TypeOf(z) == comptime_int);
+                comptime assert(x == 0.5);
+                comptime assert(y == 123);
+                comptime assert(z == 456);
+            }
+            {
+                var w: u8, var x: u8 = .{ 1, 2 };
+                w, var y: u8 = .{ 3, 4 };
+                var z: u8, x = .{ 5, 6 };
+                y, z = .{ 7, 8 };
+                {
+                    w += 1;
+                    x -= 2;
+                    y *= 3;
+                    z /= 4;
+                }
+                try expect(w == 4);
+                try expect(x == 4);
+                try expect(y == 21);
+                try expect(z == 2);
+            }
+            {
+                comptime var w, var x = .{ 1, 2 };
+                comptime w, var y = .{ 3, 4 };
+                comptime var z, x = .{ 5, 6 };
+                comptime y, z = .{ 7, 8 };
+                comptime {
+                    w += 1;
+                    x -= 2;
+                    y *= 3;
+                    z /= 4;
+                }
+                comptime assert(w == 4);
+                comptime assert(x == 4);
+                comptime assert(y == 21);
+                comptime assert(z == 2);
+            }
         }
     };
 
-    S.doTheTest();
-    comptime S.doTheTest();
+    try S.doTheTest();
+    try comptime S.doTheTest();
 }
 
 test "destructure from labeled block" {


### PR DESCRIPTION
A preceding `comptime` keyword was being ignored if the first destructure variable was an expression.