### PR TITLE
Fix setFloatMode in LLVM backend

### DIFF
--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -14721,10 +14721,10 @@ pub fn toBitcode(self: *Builder, allocator: Allocator) bitcode_writer.Error![]co
                             try function_block.writeAbbrevAdapted(FunctionBlock.CallFast{
                                 .attributes = extra.data.attributes,
                                 .call_type = switch (kind) {
-                                    .call => .{ .call_conv = call_conv },
-                                    .@"tail call" => .{ .tail = true, .call_conv = call_conv },
-                                    .@"musttail call" => .{ .must_tail = true, .call_conv = call_conv },
-                                    .@"notail call" => .{ .no_tail = true, .call_conv = call_conv },
+                                    .@"call fast" => .{ .call_conv = call_conv },
+                                    .@"tail call fast" => .{ .tail = true, .call_conv = call_conv },
+                                    .@"musttail call fast" => .{ .must_tail = true, .call_conv = call_conv },
+                                    .@"notail call fast" => .{ .no_tail = true, .call_conv = call_conv },
                                     else => unreachable,
                                 },
                                 .fast_math = .{},

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -14727,7 +14727,7 @@ pub fn toBitcode(self: *Builder, allocator: Allocator) bitcode_writer.Error![]co
                                     .@"notail call fast" => .{ .no_tail = true, .call_conv = call_conv },
                                     else => unreachable,
                                 },
-                                .fast_math = .{},
+                                .fast_math = FastMath.fast,
                                 .type_id = extra.data.ty,
                                 .callee = extra.data.callee,
                                 .args = args,
@@ -14786,7 +14786,7 @@ pub fn toBitcode(self: *Builder, allocator: Allocator) bitcode_writer.Error![]co
                                 .opcode = kind.toBinaryOpcode(),
                                 .lhs = adapter.getOffsetValueIndex(extra.lhs),
                                 .rhs = adapter.getOffsetValueIndex(extra.rhs),
-                                .fast_math = .{},
+                                .fast_math = FastMath.fast,
                             });
                         },
                         .alloca,
@@ -14884,7 +14884,7 @@ pub fn toBitcode(self: *Builder, allocator: Allocator) bitcode_writer.Error![]co
                                 .lhs = adapter.getOffsetValueIndex(extra.lhs),
                                 .rhs = adapter.getOffsetValueIndex(extra.rhs),
                                 .pred = kind.toCmpPredicate(),
-                                .fast_math = .{},
+                                .fast_math = FastMath.fast,
                             });
                         },
                         .fneg => try function_block.writeAbbrev(FunctionBlock.FNeg{
@@ -14892,7 +14892,7 @@ pub fn toBitcode(self: *Builder, allocator: Allocator) bitcode_writer.Error![]co
                         }),
                         .@"fneg fast" => try function_block.writeAbbrev(FunctionBlock.FNegFast{
                             .val = adapter.getOffsetValueIndex(@enumFromInt(datas[instr_index])),
-                            .fast_math = .{},
+                            .fast_math = FastMath.fast,
                         }),
                         .extractvalue => {
                             var extra = func.extraDataTrail(Function.Instruction.ExtractValue, datas[instr_index]);
@@ -14940,7 +14940,7 @@ pub fn toBitcode(self: *Builder, allocator: Allocator) bitcode_writer.Error![]co
                                 .lhs = adapter.getOffsetValueIndex(extra.lhs),
                                 .rhs = adapter.getOffsetValueIndex(extra.rhs),
                                 .cond = adapter.getOffsetValueIndex(extra.cond),
-                                .fast_math = .{},
+                                .fast_math = FastMath.fast,
                             });
                         },
                         .shufflevector => {

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -6839,7 +6839,7 @@ pub const FastMath = packed struct(u8) {
         .arcp = true,
         .contract = true,
         .afn = true,
-        .realloc = true,
+        .reassoc = true,
     };
 };
 

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -1636,3 +1636,24 @@ test "runtime isNan(inf * 0)" {
     const zero_times_inf = 0 * std.math.inf(f64);
     try std.testing.expect(std.math.isNan(zero_times_inf));
 }
+
+test "optimized float mode" {
+    if (builtin.mode == .Debug) return error.SkipZigTest;
+
+    const big = 0x1p40;
+    const small = 0.001;
+    const tiny = 0x1p-10;
+
+    const S = struct {
+        fn strict(x: f64) f64 {
+            @setFloatMode(.strict);
+            return x + big - big;
+        }
+        fn optimized(x: f64) f64 {
+            @setFloatMode(.optimized);
+            return x + big - big;
+        }
+    };
+    try expect(S.optimized(small) == small);
+    try expect(S.strict(small) == tiny);
+}

--- a/test/cases/float_mode_optimized_reduce.zig
+++ b/test/cases/float_mode_optimized_reduce.zig
@@ -1,0 +1,12 @@
+pub fn main() void {
+    var a: @Vector(2, f32) = @splat(5.0);
+    _ = &a;
+
+    @setFloatMode(.optimized);
+    var b = @reduce(.Add, a);
+    _ = &b;
+}
+
+// run
+// backend=llvm
+//


### PR DESCRIPTION
Fixes #19331

In addition to fixing #19331, this PR also fixes using fast math on individual instructions in the LLVM backend, all the fast math flags where emitted as disabled before. 