### PR TITLE
`zig fetch`: resolve branch/tag names to commit SHA

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -44,6 +44,8 @@ omit_missing_hash_error: bool,
 /// which specifies inclusion rules. This is intended to be true for the first
 /// fetch task and false for the recursive dependencies.
 allow_missing_paths_field: bool,
+/// If true and URL points to a Git repository, will use the latest commit.
+use_latest_commit: bool,
 
 // Above this are fields provided as inputs to `run`.
 // Below this are fields populated by `run`.
@@ -59,6 +61,8 @@ actual_hash: Manifest.Digest,
 has_build_zig: bool,
 /// Indicates whether the task aborted due to an out-of-memory condition.
 oom_flag: bool,
+/// If `use_latest_commit` was true, this will be the commit that was used.
+latest_commit: ?git.Oid,
 
 // This field is used by the CLI only, untouched by this file.
 
@@ -687,6 +691,7 @@ fn queueJobsForDeps(f: *Fetch) RunError!void {
                 .job_queue = f.job_queue,
                 .omit_missing_hash_error = false,
                 .allow_missing_paths_field = true,
+                .use_latest_commit = false,
 
                 .package_root = undefined,
                 .error_bundle = undefined,
@@ -695,6 +700,7 @@ fn queueJobsForDeps(f: *Fetch) RunError!void {
                 .actual_hash = undefined,
                 .has_build_zig = false,
                 .oom_flag = false,
+                .latest_commit = undefined,
 
                 .module = null,
             };
@@ -987,7 +993,9 @@ fn initResource(f: *Fetch, uri: std.Uri, server_header_buffer: []u8) RunError!Re
             }
             return f.fail(f.location_tok, try eb.printString("ref not found: {s}", .{want_ref}));
         };
-        if (uri.fragment == null) {
+        if (f.use_latest_commit) {
+            f.latest_commit = want_oid;
+        } else if (uri.fragment == null) {
             const notes_len = 1;
             try eb.addRootErrorMessage(.{
                 .msg = try eb.addString("url field is missing an explicit ref"),


### PR DESCRIPTION
When adding a dependency using `zig fetch --save` I usually just want the latest thing on the `master`/`main` branch. However, when running `zig fetch --save git+https://github/abc/def#master` this gets saved verbatim in `build.zig.zon`:
```zig
.@"def" = .{
    .url = "git+https://github.com/abc/def#master",
    .hash = "...",
},
```
Now, when compiling this in the future, the branch may point to another commit, leading to a hash-mismatch.

## Old Proposal

> Context for the discussion below

<details>
<summary>Old Proposal</summary>

This PR adds the new flag `--resolve-commit` to `zig fetch` which instead saves whatever commit the refspec points at instead:
```zig
.@"def" = .{
    .url = "git+https://github.com/abc/def#123403399058fd83f7fbb597f3f8304007ff6a3c",
    .hash = "...",
},
```

### Naming
I'm open to other names for this flag. Some alternatives I've come up with:
-  `--save-commit`
- `--latest`

### Open Questions
Are there any drawbacks to making this the default behavior and instead add a flag to restore the old behaviour?

</details>

## New Proposal

This PR makes it so that `zig fetch --save <URI>#<ref>` now replaces the `<ref>` with the commit SHA in `build.zig.zon`. The old `<ref>` is moved to a query parameter `?ref=<ref>` so that automated tooling still can check for changes upstream. See the discussion below for the rationale behind this decision. The example above would now become:

```zig
.@"def" = .{
    .url = "git+https://github.com/abc/def?ref=master#123403399058fd83f7fbb597f3f8304007ff6a3c",
    .hash = "...",
},
```

It is possible to restore the old behavior by adding the `--preserve-url` flag to the `zig fetch` invocation. This saves the URL verbatim to `build.zig.zon`.