### PR TITLE
langref: Rename std.fs.wasi.{PreopenList => Preopens}

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -11471,7 +11471,7 @@ pub fn main() !void {
 1: 123
 2: hello{#end_shell_samp#}
       <p>A more interesting example would be extracting the list of preopens from the runtime.
-      This is now supported in the standard library via {#syntax#}std.fs.wasi.PreopenList{#endsyntax#}:</p>
+      This is now supported in the standard library via {#syntax#}std.fs.wasi.Preopens{#endsyntax#}:</p>
       {#code_begin|exe|wasi_preopens#}
       {#target_wasi#}
 const std = @import("std");


### PR DESCRIPTION
This was renamed back in https://github.com/ziglang/zig/commit/d5312d53a066092ba9efd687e25b29a87eb6290c.