### PR TITLE
std: don't do BYOS at the POSIX API layer

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -2264,7 +2264,7 @@ pub fn map_shadow_stack(addr: u64, size: u64, flags: u32) usize {
 }
 
 pub const E = switch (native_arch) {
-    .mips, .mipsel => enum(i32) {
+    .mips, .mipsel => enum(u16) {
         /// No error occurred.
         SUCCESS = 0,
 
@@ -2406,7 +2406,7 @@ pub const E = switch (native_arch) {
 
         pub const init = errnoFromSyscall;
     },
-    .sparc, .sparcel, .sparc64 => enum(i32) {
+    .sparc, .sparcel, .sparc64 => enum(u16) {
         /// No error occurred.
         SUCCESS = 0,
 

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -39,12 +39,8 @@ const linux = std.os.linux;
 const windows = std.os.windows;
 const wasi = std.os.wasi;
 
-/// Applications can override the `system` API layer in their root source file.
-/// Otherwise, when linking libc, this is the C API.
-/// When not linking libc, it is the OS-specific system interface.
-pub const system = if (@hasDecl(root, "os") and @hasDecl(root.os, "system") and root.os != @This())
-    root.os.system
-else if (use_libc)
+/// A libc-compatible API layer.
+pub const system = if (use_libc)
     std.c
 else switch (native_os) {
     .linux => linux,


### PR DESCRIPTION
This was a mistake from day one. This is the wrong abstraction layer to do this in.

My alternate plan for this is to make all I/O operations require an IO interface parameter, similar to how allocations require an Allocator interface parameter today.

I tried to do something more ambitious in this branch but it turned into too deep of a rabbit hole, so I aborted mission and this is what is left.
