### PR TITLE
Fix CODEOWNERS path to resinator source files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /lib/std/Thread* @kprotty
 
 # resinator
-/src/resinator/* @squeek502
+/lib/compiler/resinator/* @squeek502
 
 # SPIR-V selfhosted backend
 /src/codegen/spirv* @Snektron


### PR DESCRIPTION
The resinator files were moved during #19174