### PR TITLE
bsd: followup to std.posix extraction from std.os

### DIFF
--- a/lib/compiler_rt/emutls.zig
+++ b/lib/compiler_rt/emutls.zig
@@ -7,7 +7,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const common = @import("common.zig");
 
-const abort = std.os.abort;
+const abort = std.posix.abort;
 const assert = std.debug.assert;
 const expect = std.testing.expect;
 

--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -624,7 +624,7 @@ const PosixThreadImpl = struct {
                 var count: c_int = undefined;
                 var count_size: usize = @sizeOf(c_int);
                 const mib = [_]c_int{ std.c.CTL.HW, std.c.HW.NCPUONLINE };
-                std.c.sysctl(&mib, &count, &count_size, null, 0) catch |err| switch (err) {
+                posix.sysctl(&mib, &count, &count_size, null, 0) catch |err| switch (err) {
                     error.NameTooLong, error.UnknownName => unreachable,
                     else => |e| return e,
                 };

--- a/lib/std/Thread/Futex.zig
+++ b/lib/std/Thread/Futex.zig
@@ -539,7 +539,7 @@ const PosixImpl = struct {
             // This can be changed with pthread_condattr_setclock, but it's an extension and may not be available everywhere.
             var ts: c.timespec = undefined;
             if (timeout) |timeout_ns| {
-                c.clock_gettime(c.CLOCK.REALTIME, &ts) catch unreachable;
+                std.posix.clock_gettime(c.CLOCK.REALTIME, &ts) catch unreachable;
                 ts.tv_sec +|= @as(@TypeOf(ts.tv_sec), @intCast(timeout_ns / std.time.ns_per_s));
                 ts.tv_nsec += @as(@TypeOf(ts.tv_nsec), @intCast(timeout_ns % std.time.ns_per_s));
 


### PR DESCRIPTION
netbsd fix:
- `Futex.zig:542:56: error: expected error union type, found 'c_int'`

openbsd fix:
- `emutls.zig:10:21: error: root struct of file 'os' has no member named 'abort'`
- `Thread.zig:627:22: error: expected 6 argument(s), found 5`