### PR TITLE
Expose `ryu128` from `fmt` module

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -3,13 +3,14 @@
 const std = @import("std.zig");
 const builtin = @import("builtin");
 
+pub const ryu128 = @import("fmt/ryu128.zig");
+
 const io = std.io;
 const math = std.math;
 const assert = std.debug.assert;
 const mem = std.mem;
 const unicode = std.unicode;
 const meta = std.meta;
-const ryu128 = @import("fmt/ryu128.zig");
 const lossyCast = std.math.lossyCast;
 const expectFmt = std.testing.expectFmt;
 


### PR DESCRIPTION
Resolves #19366 .
Seems reasonable to expose `ryu128` if more specific `fmt` implementation is desired, whether `ryu128` or others added in the future.