### PR TITLE
std.os.windows: add POLL.IN and POLL.OUT

### DIFF
--- a/lib/std/os/windows/ws2_32.zig
+++ b/lib/std/os/windows/ws2_32.zig
@@ -850,6 +850,8 @@ pub const POLL = struct {
     pub const ERR = 1;
     pub const HUP = 2;
     pub const NVAL = 4;
+    pub const IN = RDNORM | RDBAND;
+    pub const OUT = WRNORM;
 };
 
 pub const TF_DISCONNECT = 1;


### PR DESCRIPTION
Fix for:

`error: struct 'os.windows.ws2_32.POLL' has no member named 'IN'`

```
var pfd = [1]os.posix.pollfd{posix.pollfd{
        .fd = socket,
        .events = posix.POLL.IN,
        .revents = undefined,
    }};
os.posix.poll(&pfd, 0);
```

See:

https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsapoll