### PR TITLE
std.Build: dupe provided paths for Step.Fmt.create()

### DIFF
--- a/lib/std/Build/Step/Fmt.zig
+++ b/lib/std/Build/Step/Fmt.zig
@@ -29,8 +29,8 @@ pub fn create(owner: *std.Build, options: Options) *Fmt {
             .owner = owner,
             .makeFn = make,
         }),
-        .paths = options.paths,
-        .exclude_paths = options.exclude_paths,
+        .paths = owner.dupeStrings(options.paths),
+        .exclude_paths = owner.dupeStrings(options.exclude_paths),
         .check = options.check,
     };
     return self;


### PR DESCRIPTION
This MR ensures the strings used in the Step.Fmt belong to the builder, which prevents a use-after-free footgun in certain cases.

e.g.
```zig
const std = @import("std");
pub fn build(b: *std.Build) void {
    const paths = [_][]const u8{b.build_root.path orelse "."};
    const fmt = b.addFmt(.{ .paths = &paths });
    b.step("fmt", "Test all files for correct formatting").dependOn(&fmt.step);
}

```