### PR TITLE
compiler: implement analysis-local comptime-mutable memory

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -1317,7 +1317,8 @@ pub const Cpu = struct {
             for (decls, 0..) |decl, i| {
                 array[i] = &@field(cpus, decl.name);
             }
-            return &array;
+            const finalized = array;
+            return &finalized;
         }
     };
 

--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -41,7 +41,8 @@ pub inline fn valuesFromFields(comptime E: type, comptime fields: []const EnumFi
         for (&result, fields) |*r, f| {
             r.* = @enumFromInt(f.value);
         }
-        return &result;
+        const final = result;
+        return &final;
     }
 }
 

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1829,7 +1829,8 @@ pub inline fn comptimePrint(comptime fmt: []const u8, args: anytype) *const [cou
         var buf: [count(fmt, args):0]u8 = undefined;
         _ = bufPrint(&buf, fmt, args) catch unreachable;
         buf[buf.len] = 0;
-        return &buf;
+        const final = buf;
+        return &final;
     }
 }
 

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -465,7 +465,8 @@ pub fn fieldNames(comptime T: type) *const [fields(T).len][:0]const u8 {
         var names: [fieldInfos.len][:0]const u8 = undefined;
         // This concat can be removed with the next zig1 update.
         for (&names, fieldInfos) |*name, field| name.* = field.name ++ "";
-        break :blk &names;
+        const final = names;
+        break :blk &final;
     };
 }
 
@@ -506,7 +507,8 @@ pub fn tags(comptime T: type) *const [fields(T).len]T {
         for (fieldInfos, 0..) |field, i| {
             res[i] = @field(T, field.name);
         }
-        break :blk &res;
+        const final = res;
+        break :blk &final;
     };
 }
 

--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -1358,7 +1358,8 @@ pub fn utf8ToUtf16LeStringLiteral(comptime utf8: []const u8) *const [calcUtf16Le
         var utf16le: [len:0]u16 = [_:0]u16{0} ** len;
         const utf16le_len = utf8ToUtf16Le(&utf16le, utf8[0..]) catch |err| @compileError(err);
         assert(len == utf16le_len);
-        break :blk &utf16le;
+        const final = utf16le;
+        break :blk &final;
     };
 }
 

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -3058,20 +3058,23 @@ pub const Inst = struct {
 
     /// Represents a single value being captured in a type declaration's closure.
     pub const Capture = packed struct(u32) {
-        tag: enum(u2) {
+        tag: enum(u3) {
             /// `data` is a `u16` index into the parent closure.
             nested,
             /// `data` is a `Zir.Inst.Index` to an instruction whose value is being captured.
             instruction,
+            /// `data` is a `Zir.Inst.Index` to an instruction representing an alloc whose contents is being captured.
+            instruction_load,
             /// `data` is a `NullTerminatedString` to a decl name.
             decl_val,
             /// `data` is a `NullTerminatedString` to a decl name.
             decl_ref,
         },
-        data: u30,
+        data: u29,
         pub const Unwrapped = union(enum) {
             nested: u16,
             instruction: Zir.Inst.Index,
+            instruction_load: Zir.Inst.Index,
             decl_val: NullTerminatedString,
             decl_ref: NullTerminatedString,
         };
@@ -3083,6 +3086,10 @@ pub const Inst = struct {
                 },
                 .instruction => |inst| .{
                     .tag = .instruction,
+                    .data = @intCast(@intFromEnum(inst)),
+                },
+                .instruction_load => |inst| .{
+                    .tag = .instruction_load,
                     .data = @intCast(@intFromEnum(inst)),
                 },
                 .decl_val => |str| .{
@@ -3099,6 +3106,7 @@ pub const Inst = struct {
             return switch (cap.tag) {
                 .nested => .{ .nested = @intCast(cap.data) },
                 .instruction => .{ .instruction = @enumFromInt(cap.data) },
+                .instruction_load => .{ .instruction_load = @enumFromInt(cap.data) },
                 .decl_val => .{ .decl_val = @enumFromInt(cap.data) },
                 .decl_ref => .{ .decl_ref = @enumFromInt(cap.data) },
             };

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -1084,9 +1084,11 @@ pub const Inst = struct {
         inferred_alloc: InferredAlloc,
 
         pub const InferredAllocComptime = struct {
-            decl_index: InternPool.DeclIndex,
             alignment: InternPool.Alignment,
             is_const: bool,
+            /// This is `undefined` until we encounter a `store_to_inferred_alloc`,
+            /// at which point the pointer is created and stored here.
+            ptr: InternPool.Index,
         };
 
         pub const InferredAlloc = struct {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1382,7 +1382,6 @@ pub fn create(gpa: Allocator, arena: Allocator, options: CreateOptions) !*Compil
                 .global_zir_cache = global_zir_cache,
                 .local_zir_cache = local_zir_cache,
                 .emit_h = emit_h,
-                .tmp_hack_arena = std.heap.ArenaAllocator.init(gpa),
                 .error_limit = error_limit,
                 .llvm_object = null,
             };

--- a/src/TypedValue.zig
+++ b/src/TypedValue.zig
@@ -329,13 +329,9 @@ pub fn print(
                             .val = Value.fromInterned(decl_val),
                         }, writer, level - 1, mod);
                     },
-                    .mut_decl => |mut_decl| {
-                        const decl = mod.declPtr(mut_decl.decl);
-                        if (level == 0) return writer.print("(mut decl '{}')", .{decl.name.fmt(ip)});
-                        return print(.{
-                            .ty = decl.ty,
-                            .val = decl.val,
-                        }, writer, level - 1, mod);
+                    .comptime_alloc => {
+                        // TODO: we need a Sema to print this!
+                        return writer.writeAll("(comptime alloc)");
                     },
                     .comptime_field => |field_val_ip| {
                         return print(.{

--- a/src/arch/x86_64/Encoding.zig
+++ b/src/arch/x86_64/Encoding.zig
@@ -818,7 +818,7 @@ fn estimateInstructionLength(prefix: Prefix, encoding: Encoding, ops: []const Op
 }
 
 const mnemonic_to_encodings_map = init: {
-    @setEvalBranchQuota(4_000);
+    @setEvalBranchQuota(5_000);
     const mnemonic_count = @typeInfo(Mnemonic).Enum.fields.len;
     var mnemonic_map: [mnemonic_count][]Data = .{&.{}} ** mnemonic_count;
     const encodings = @import("encodings.zig");
@@ -845,5 +845,13 @@ const mnemonic_to_encodings_map = init: {
         };
         i.* += 1;
     }
-    break :init mnemonic_map;
+    const final_storage = data_storage;
+    var final_map: [mnemonic_count][]const Data = .{&.{}} ** mnemonic_count;
+    storage_i = 0;
+    for (&final_map, mnemonic_map) |*value, wip_value| {
+        value.ptr = final_storage[storage_i..].ptr;
+        value.len = wip_value.len;
+        storage_i += value.len;
+    }
+    break :init final_map;
 };

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -680,7 +680,6 @@ fn lowerParentPtr(
     const ptr = mod.intern_pool.indexToKey(parent_ptr).ptr;
     return switch (ptr.addr) {
         .decl => |decl| try lowerDeclRef(bin_file, src_loc, decl, code, debug_output, reloc_info),
-        .mut_decl => |md| try lowerDeclRef(bin_file, src_loc, md.decl, code, debug_output, reloc_info),
         .anon_decl => |ad| try lowerAnonDeclRef(bin_file, src_loc, ad, code, debug_output, reloc_info),
         .int => |int| try generateSymbol(bin_file, src_loc, .{
             .ty = Type.usize,
@@ -756,7 +755,7 @@ fn lowerParentPtr(
                 }),
             );
         },
-        .comptime_field => unreachable,
+        .comptime_field, .comptime_alloc => unreachable,
     };
 }
 
@@ -1089,7 +1088,6 @@ pub fn genTypedValue(
     if (!typed_value.ty.isSlice(zcu)) switch (zcu.intern_pool.indexToKey(typed_value.val.toIntern())) {
         .ptr => |ptr| switch (ptr.addr) {
             .decl => |decl| return genDeclRef(lf, src_loc, typed_value, decl),
-            .mut_decl => |mut_decl| return genDeclRef(lf, src_loc, typed_value, mut_decl.decl),
             else => {},
         },
         else => {},

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -698,7 +698,6 @@ pub const DeclGen = struct {
         const ptr = mod.intern_pool.indexToKey(ptr_val).ptr;
         switch (ptr.addr) {
             .decl => |d| try dg.renderDeclValue(writer, ptr_ty, Value.fromInterned(ptr_val), d, location),
-            .mut_decl => |md| try dg.renderDeclValue(writer, ptr_ty, Value.fromInterned(ptr_val), md.decl, location),
             .anon_decl => |anon_decl| try dg.renderAnonDeclValue(writer, ptr_ty, Value.fromInterned(ptr_val), anon_decl, location),
             .int => |int| {
                 try writer.writeByte('(');
@@ -795,7 +794,7 @@ pub const DeclGen = struct {
                     },
                 }
             },
-            .comptime_field => unreachable,
+            .comptime_field, .comptime_alloc => unreachable,
         }
     }
 
@@ -1229,7 +1228,6 @@ pub const DeclGen = struct {
             },
             .ptr => |ptr| switch (ptr.addr) {
                 .decl => |d| try dg.renderDeclValue(writer, ty, val, d, location),
-                .mut_decl => |md| try dg.renderDeclValue(writer, ty, val, md.decl, location),
                 .anon_decl => |decl_val| try dg.renderAnonDeclValue(writer, ty, val, decl_val, location),
                 .int => |int| {
                     try writer.writeAll("((");
@@ -1243,7 +1241,7 @@ pub const DeclGen = struct {
                 .elem,
                 .field,
                 => try dg.renderParentPtr(writer, val.ip_index, location),
-                .comptime_field => unreachable,
+                .comptime_field, .comptime_alloc => unreachable,
             },
             .opt => |opt| {
                 const payload_ty = ty.optionalChild(mod);

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3808,7 +3808,6 @@ pub const Object = struct {
             },
             .ptr => |ptr| return switch (ptr.addr) {
                 .decl => |decl| try o.lowerDeclRefValue(ty, decl),
-                .mut_decl => |mut_decl| try o.lowerDeclRefValue(ty, mut_decl.decl),
                 .anon_decl => |anon_decl| try o.lowerAnonDeclRef(ty, anon_decl),
                 .int => |int| try o.lowerIntAsPtr(int),
                 .eu_payload,
@@ -3816,7 +3815,7 @@ pub const Object = struct {
                 .elem,
                 .field,
                 => try o.lowerParentPtr(val),
-                .comptime_field => unreachable,
+                .comptime_field, .comptime_alloc => unreachable,
             },
             .slice => |slice| return o.builder.structConst(try o.lowerType(ty), &.{
                 try o.lowerValue(slice.ptr),
@@ -4274,7 +4273,6 @@ pub const Object = struct {
         const ptr = ip.indexToKey(ptr_val.toIntern()).ptr;
         return switch (ptr.addr) {
             .decl => |decl| try o.lowerParentPtrDecl(decl),
-            .mut_decl => |mut_decl| try o.lowerParentPtrDecl(mut_decl.decl),
             .anon_decl => |ad| try o.lowerAnonDeclRef(Type.fromInterned(ad.orig_ty), ad),
             .int => |int| try o.lowerIntAsPtr(int),
             .eu_payload => |eu_ptr| {
@@ -4311,7 +4309,7 @@ pub const Object = struct {
 
                 return o.builder.gepConst(.inbounds, try o.lowerType(opt_ty), parent_ptr, null, &.{ .@"0", .@"0" });
             },
-            .comptime_field => unreachable,
+            .comptime_field, .comptime_alloc => unreachable,
             .elem => |elem_ptr| {
                 const parent_ptr = try o.lowerParentPtr(Value.fromInterned(elem_ptr.base));
                 const elem_ty = Type.fromInterned(ip.typeOf(elem_ptr.base)).elemType2(mod);

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -1105,7 +1105,6 @@ const DeclGen = struct {
         const mod = self.module;
         switch (mod.intern_pool.indexToKey(ptr_val.toIntern()).ptr.addr) {
             .decl => |decl| return try self.constantDeclRef(ptr_ty, decl),
-            .mut_decl => |decl_mut| return try self.constantDeclRef(ptr_ty, decl_mut.decl),
             .anon_decl => |anon_decl| return try self.constantAnonDeclRef(ptr_ty, anon_decl),
             .int => |int| {
                 const ptr_id = self.spv.allocId();
@@ -1121,7 +1120,7 @@ const DeclGen = struct {
             },
             .eu_payload => unreachable, // TODO
             .opt_payload => unreachable, // TODO
-            .comptime_field => unreachable,
+            .comptime_field, .comptime_alloc => unreachable,
             .elem => |elem_ptr| {
                 const parent_ptr_ty = Type.fromInterned(mod.intern_pool.typeOf(elem_ptr.base));
                 const parent_ptr_id = try self.constantPtr(parent_ptr_ty, Value.fromInterned(elem_ptr.base));

--- a/src/link/Elf/LdScript.zig
+++ b/src/link/Elf/LdScript.zig
@@ -109,11 +109,14 @@ const Command = enum {
 
     fn fromString(s: []const u8) ?Command {
         inline for (@typeInfo(Command).Enum.fields) |field| {
-            comptime var buf: [field.name.len]u8 = undefined;
-            inline for (field.name, 0..) |c, i| {
-                buf[i] = comptime std.ascii.toUpper(c);
-            }
-            if (std.mem.eql(u8, &buf, s)) return @field(Command, field.name);
+            const upper_name = n: {
+                comptime var buf: [field.name.len]u8 = undefined;
+                inline for (field.name, 0..) |c, i| {
+                    buf[i] = comptime std.ascii.toUpper(c);
+                }
+                break :n buf;
+            };
+            if (std.mem.eql(u8, &upper_name, s)) return @field(Command, field.name);
         }
         return null;
     }

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -2810,6 +2810,10 @@ const Writer = struct {
         switch (capture.unwrap()) {
             .nested => |i| return stream.print("[{d}]", .{i}),
             .instruction => |inst| return self.writeInstIndex(stream, inst),
+            .instruction_load => |ptr_inst| {
+                try stream.writeAll("load ");
+                try self.writeInstIndex(stream, ptr_inst);
+            },
             .decl_val => |str| try stream.print("decl_val \"{}\"", .{
                 std.zig.fmtEscapes(self.code.nullTerminatedString(str)),
             }),

--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -586,6 +586,8 @@ fn overaligned_fn() align(0x1000) i32 {
 }
 
 test "comptime alloc alignment" {
+    // TODO: it's impossible to test this in Zig today, since comptime vars do not have runtime addresses.
+    if (true) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO

--- a/test/behavior/comptime_memory.zig
+++ b/test/behavior/comptime_memory.zig
@@ -461,7 +461,7 @@ test "write empty array to end" {
     array[5..5].* = .{};
     array[5..5].* = [0]u8{};
     array[5..5].* = [_]u8{};
-    try testing.expectEqualStrings("hello", &array);
+    comptime std.debug.assert(std.mem.eql(u8, "hello", &array));
 }
 
 fn doublePtrTest() !void {

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -1211,7 +1211,7 @@ test "storing an array of type in a field" {
 
     const S = struct {
         fn doTheTest() void {
-            comptime var foobar = Foobar.foo();
+            const foobar = Foobar.foo();
             foo(foobar.str[0..10]);
         }
         const Foobar = struct {

--- a/test/behavior/extern.zig
+++ b/test/behavior/extern.zig
@@ -5,6 +5,7 @@ const expect = std.testing.expect;
 test "anyopaque extern symbol" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
     const a = @extern(*anyopaque, .{ .name = "a_mystery_symbol" });

--- a/test/cases/compile_errors/comptime_var_referenced_at_runtime.zig
+++ b/test/cases/compile_errors/comptime_var_referenced_at_runtime.zig
@@ -1,0 +1,65 @@
+var runtime_int: u32 = 123;
+
+export fn foo() void {
+    comptime var x: u32 = 123;
+    var runtime = &x;
+    _ = &runtime;
+}
+
+export fn bar() void {
+    const S = struct { u32, *const u32 };
+    comptime var x: u32 = 123;
+    const runtime: S = .{ runtime_int, &x };
+    _ = runtime;
+}
+
+export fn qux() void {
+    const S = struct { a: u32, b: *const u32 };
+    comptime var x: u32 = 123;
+    const runtime: S = .{ .a = runtime_int, .b = &x };
+    _ = runtime;
+}
+
+export fn baz() void {
+    const S = struct {
+        fn f(_: *const u32) void {}
+    };
+    comptime var x: u32 = 123;
+    S.f(&x);
+}
+
+export fn faz() void {
+    const S = struct {
+        fn f(_: anytype) void {}
+    };
+    comptime var x: u32 = 123;
+    S.f(&x);
+}
+
+export fn boo() *const u32 {
+    comptime var x: u32 = 123;
+    return &x;
+}
+
+export fn qar() void {
+    comptime var x: u32 = 123;
+    const y = if (runtime_int == 123) &x else undefined;
+    _ = y;
+}
+
+// error
+//
+// :5:19: error: runtime value contains reference to comptime var
+// :5:19: note: comptime var pointers are not available at runtime
+// :12:40: error: runtime value contains reference to comptime var
+// :12:40: note: comptime var pointers are not available at runtime
+// :19:50: error: runtime value contains reference to comptime var
+// :19:50: note: comptime var pointers are not available at runtime
+// :28:9: error: runtime value contains reference to comptime var
+// :28:9: note: comptime var pointers are not available at runtime
+// :36:9: error: runtime value contains reference to comptime var
+// :36:9: note: comptime var pointers are not available at runtime
+// :41:12: error: runtime value contains reference to comptime var
+// :41:12: note: comptime var pointers are not available at runtime
+// :46:39: error: runtime value contains reference to comptime var
+// :46:39: note: comptime var pointers are not available at runtime

--- a/test/cases/compile_errors/comptime_var_referenced_by_decl.zig
+++ b/test/cases/compile_errors/comptime_var_referenced_by_decl.zig
@@ -1,0 +1,49 @@
+export const a: *u32 = a: {
+    var x: u32 = 123;
+    break :a &x;
+};
+
+export const b: [1]*u32 = b: {
+    var x: u32 = 123;
+    break :b .{&x};
+};
+
+export const c: *[1]u32 = c: {
+    var x: u32 = 123;
+    break :c (&x)[0..1];
+};
+
+export const d: *anyopaque = d: {
+    var x: u32 = 123;
+    break :d &x;
+};
+
+const S = extern struct { ptr: *u32 };
+export const e: S = e: {
+    var x: u32 = 123;
+    break :e .{ .ptr = &x };
+};
+
+// The pointer constness shouldn't matter - *any* reference to a comptime var is illegal in a global's value.
+export const f: *const u32 = f: {
+    var x: u32 = 123;
+    break :f &x;
+};
+
+// The pointer itself doesn't refer to a comptime var, but from it you can derive a pointer which does.
+export const g: *const *const u32 = g: {
+    const valid: u32 = 123;
+    var invalid: u32 = 123;
+    const aggregate: [2]*const u32 = .{ &valid, &invalid };
+    break :g &aggregate[0];
+};
+
+// error
+//
+// :1:27: error: global variable contains reference to comptime var
+// :6:30: error: global variable contains reference to comptime var
+// :11:30: error: global variable contains reference to comptime var
+// :16:33: error: global variable contains reference to comptime var
+// :22:24: error: global variable contains reference to comptime var
+// :28:33: error: global variable contains reference to comptime var
+// :34:40: error: global variable contains reference to comptime var

--- a/test/cases/comptime_aggregate_print.zig
+++ b/test/cases/comptime_aggregate_print.zig
@@ -23,10 +23,13 @@ comptime {
 
 pub fn main() !void {}
 
+// TODO: the output here has been regressed by #19414.
+// Restoring useful output here will require providing a Sema to TypedValue.print.
+
 // error
 //
 // :20:5: error: found compile log statement
 //
 // Compile Log Output:
-// @as([]i32, .{ 1, 2 })
-// @as([]i32, .{ 3, 4 })
+// @as([]i32, .{ (reinterpreted data) })
+// @as([]i32, .{ (reinterpreted data) })


### PR DESCRIPTION
This commit changes how we represent comptime-mutable memory (`comptime var`) in the compiler in order to implement the intended behavior that references to such memory can only exist at comptime.

It does *not* clean up the representation of mutable values, improve the representation of comptime-known pointers, or fix the many bugs in the comptime pointer access code. These will be future enhancements.

Comptime memory lives for the duration of a single Sema, and is not permitted to escape that one analysis, either by becoming runtime-known or by becoming comptime-known to other analyses. These restrictions mean that we can represent comptime allocations not via Decl, but with state local to Sema - specifically, the new `Sema.comptime_allocs` field. All comptime-mutable allocations, as well as any comptime-known const allocs containing references to such memory, live in here. This allows for relatively fast checking of whether a value references any comptime-mtuable memory, since we need only traverse values up to pointers: pointers to Decls can never reference comptime-mutable memory, and pointers into `Sema.comptime_allocs` always do.

This change exposed some faulty pointer access logic in `Value.zig`. I've fixed the important cases, but there are some TODOs I've put in which are definitely possible to hit with sufficiently esoteric code. I plan to resolve these by auditing all direct accesses to pointers (most of them ought to use Sema to perform the pointer access!), but for now this is sufficient for all realistic code and to get tests passing.

This change eliminates `Zcu.tmp_hack_arena`, instead using the Sema arena for comptime memory mutations, which is possible since comptime memory is now local to the current Sema.

This change should allow `Decl` to store only an `InternPool.Index` rather than a full-blown `ty: Type, val: Value`. This commit does not perform this refactor.