### PR TITLE
compiler: shorten the name of inferred error unions

### DIFF
--- a/src/type.zig
+++ b/src/type.zig
@@ -262,10 +262,7 @@ pub const Type = struct {
                 return;
             },
             .inferred_error_set_type => |func_index| {
-                try writer.writeAll("@typeInfo(@typeInfo(@TypeOf(");
-                const owner_decl = mod.funcOwnerDeclPtr(func_index);
-                try owner_decl.renderFullyQualifiedName(mod, writer);
-                try writer.writeAll(")).Fn.return_type.?).ErrorUnion.error_set");
+                _ = func_index;
             },
             .error_set_type => |error_set_type| {
                 const names = error_set_type.names;

--- a/test/cases/compile_errors/field_access_of_wrapped_type.zig
+++ b/test/cases/compile_errors/field_access_of_wrapped_type.zig
@@ -9,6 +9,18 @@ export fn f2() void {
     var foo: anyerror!Foo = undefined;
     foo.a += 1;
 }
+export fn f3() void {
+    var foo: error{ A, B }!Foo = undefined;
+    foo.a += 1;
+}
+export fn f4() void {
+    var foo = x4();
+    foo.a += 1;
+}
+
+fn x4() !Foo {
+    return undefined;
+}
 
 // error
 // backend=stage2
@@ -18,3 +30,7 @@ export fn f2() void {
 // :6:8: note: consider using '.?', 'orelse', or 'if'
 // :10:8: error: error union type 'anyerror!tmp.Foo' does not support field access
 // :10:8: note: consider using 'try', 'catch', or 'if'
+// :14:8: error: error union type 'error{A,B}!tmp.Foo' does not support field access
+// :14:8: note: consider using 'try', 'catch', or 'if'
+// :18:8: error: error union type '!tmp.Foo' does not support field access
+// :18:8: note: consider using 'try', 'catch', or 'if'


### PR DESCRIPTION
consider the following Zig code:

```zig
const std = @import("std");

pub fn main() !void {
    var x = foo("hello");
    x.len -= 1;

    std.debug.print("{d}\n", .{x});
}

fn foo(a: []const u8) ![]const u8 {
    return a;
}
```

under status quo you might get an error like so:

```
test2.zig:5:6: error: error union type '@typeInfo(@typeInfo(@TypeOf(test2.foo)).Fn.return_type.?).ErrorUnion.error_set![]const u8' does not support field access
    x.len -= 1;
    ~^~~~
test2.zig:5:6: note: consider using 'try', 'catch', or 'if'
```

this, while technically accurate, is extremely verbose and not practically useful in most cases (it doesnt even fit in the default width of the github view!). many advanced users see it as noise and beginners get overwhelmed while they are still grasping Zig's error system. alternatively, this patch reduces it to the following.

```
test2.zig:5:6: error: error union type '![]const u8' does not support field access
    x.len -= 1;
    ~^~~~
test2.zig:5:6: note: consider using 'try', 'catch', or 'if'
```

now the "error union type does not support field access" text is much more accessible and the `!` is retained to match the return types users see in functions that produce this message.

additionally added a test to ensure error messages with functions that have an explicit error set are retained.

further work would add a note where `x` in this example is defined but i decided to save that for a subsequent pr.
