### PR TITLE
llvm: update current debug location scope when entering debug scope

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -5202,6 +5202,16 @@ pub const FuncGen = struct {
             self.prev_dbg_line,
             self.prev_dbg_column,
         );
+
+        switch (self.wip.debug_location) {
+            .location => |*l| l.scope = self.scope,
+            .no_location => {},
+        }
+        defer switch (self.wip.debug_location) {
+            .location => |*l| l.scope = old_scope,
+            .no_location => {},
+        };
+
         try self.genBody(body);
     }
 


### PR DESCRIPTION
This issue was causing debug information to sometimes not function correctly for some local variables, with debuggers simply reporting that the variable does not exist. What was happening was that after an AIR body - and thus debug lexical scope - begins, but before any `dbg_stmt` within it, the `scope` on `self.wip.debug_location` refers to the parent scope, but the `scope` field on the `DILocalVariable` metadata passed to `@llvm.dbg.declare` points, correctly, to the nested scope. I haven't looked into precisely what happens here, but in short, it would appear that LLVM Doesn't Like It (tm).

The fix is simple: when we change `self.scope` at the start or end of an AIR body, also modify the scope on `self.wip.debug_location`. This is correct as we always want the debug info for an instruction to be associated with the block it is within, even if the line/column are slightly outdated for any reason.