### PR TITLE
translate-c: handle string concatenation of function calls

### DIFF
--- a/test/cases/translate_c/macro_function_string_concat.c
+++ b/test/cases/translate_c/macro_function_string_concat.c
@@ -1,0 +1,11 @@
+#define bar() ""
+#define FOO bar() "," bar()
+
+// translate-c
+// target=x86_64-linux
+// c_frontend=clang
+//
+// pub inline fn bar() @TypeOf("") {
+//     return "";
+// }
+// pub const FOO = bar() ++ "," ++ bar();


### PR DESCRIPTION
Closes #19355 .

I promoted the code handling string concatenations from parseCPrimaryExpr to parseCPostfixExpr, making its precedence higher than postfix expressions (including functions). This solves the problem.
I've added a corresponding test, and all tests are passed.