### PR TITLE
Add .gitignore file to "zig init" templates

### DIFF
--- a/lib/init/.gitignore
+++ b/lib/init/.gitignore
@@ -1,0 +1,2 @@
+zig-out/
+zig-cache/

--- a/src/main.zig
+++ b/src/main.zig
@@ -4700,6 +4700,7 @@ fn cmdInit(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     const template_paths = [_][]const u8{
         Package.build_zig_basename,
         Package.Manifest.basename,
+        ".gitignore",
         "src" ++ s ++ "main.zig",
         "src" ++ s ++ "root.zig",
     };


### PR DESCRIPTION
Just to eliminate one more repetitive aspect of new project generation.

I considered introducing a "--git-files" CLI argument in case it's preferred not to assume the project will go into a git repo, but thought I'd try this very simple suggestion first.

If adding in some git-related template files is desirable but should have different behavior, I'm happy to follow suggestions.
