### PR TITLE
Autodoc: include all modules in output

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3693,6 +3693,9 @@ fn workerDocsCopy(comp: *Compilation, wg: *WaitGroup) void {
 }
 
 fn docsCopyFallible(comp: *Compilation) anyerror!void {
+    const zcu = comp.module orelse
+        return comp.lockAndSetMiscFailure(.docs_copy, "no Zig code to document", .{});
+
     const emit = comp.docs_emit.?;
     var out_dir = emit.directory.handle.makeOpenPath(emit.sub_path, .{}) catch |err| {
         return comp.lockAndSetMiscFailure(
@@ -3723,7 +3726,25 @@ fn docsCopyFallible(comp: *Compilation) anyerror!void {
     };
     defer tar_file.close();
 
-    const root = comp.root_mod.root;
+    var seen_table: std.AutoArrayHashMapUnmanaged(*Package.Module, void) = .{};
+    defer seen_table.deinit(comp.gpa);
+
+    try seen_table.put(comp.gpa, zcu.main_mod, {});
+    try seen_table.put(comp.gpa, zcu.std_mod, {});
+
+    var i: usize = 0;
+    while (i < seen_table.count()) : (i += 1) {
+        const mod = seen_table.keys()[i];
+        try comp.docsCopyModule(mod, tar_file);
+
+        const deps = mod.deps.values();
+        try seen_table.ensureUnusedCapacity(comp.gpa, deps.len);
+        for (deps) |dep| seen_table.putAssumeCapacity(dep, {});
+    }
+}
+
+fn docsCopyModule(comp: *Compilation, module: *Package.Module, tar_file: std.fs.File) !void {
+    const root = module.root;
     const sub_path = if (root.sub_path.len == 0) "." else root.sub_path;
     var mod_dir = root.root_dir.handle.openDir(sub_path, .{ .iterate = true }) catch |err| {
         return comp.lockAndSetMiscFailure(.docs_copy, "unable to open directory '{}': {s}", .{
@@ -3762,7 +3783,7 @@ fn docsCopyFallible(comp: *Compilation) anyerror!void {
 
         var file_header = std.tar.output.Header.init();
         file_header.typeflag = .regular;
-        try file_header.setPath(comp.root_name, entry.path);
+        try file_header.setPath(module.fully_qualified_name, entry.path);
         try file_header.setSize(stat.size);
         try file_header.updateChecksum();
 


### PR DESCRIPTION
Closes #19403

There are two commits in this PR: the first one updates the logic of `-femit-docs` to include all modules in the compilation in the output `sources.tar` (and while I was at it, fixes #19403), and the second one applies the same effect to `zig std` by including the builtin module in its custom generated `sources.tar`.

There is also this comment on #17334 which is related to this change: https://github.com/ziglang/zig/issues/17334#issuecomment-2010992633 This PR fixes the first limitation mentioned, and the solution to the second limitation is that the root module of the compilation is the first one to appear in `sources.tar`, which I think is the most intuitive behavior. I don't know whether this change fully resolves (GitHub don't auto-close the issue please) #17334 or whether more changes are desired to address its stated use-case.

The item "implement renderHome for multiple modules" from #19249 would also be a good follow-up to this change, but that isn't included here.