### PR TITLE
std.fmt: add option to explicitly show positive number signs; show sign before leading zeroes

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1273,7 +1273,7 @@ pub fn formatInt(
     }
 
     if (value_info.signedness == .signed) {
-        if (options.fill == '0') {
+        if (options.fill == '0' and options.alignment == .right) {
             // If the fill character is '0' and the alignment is right, we need to
             // put the sign in front of padding zeros
             var width = options.width;
@@ -1285,8 +1285,8 @@ pub fn formatInt(
                 if (width != null and width.? > 0) width.? -= 1;
             }
             return formatBuf(buf[index..], .{
-                .alignment = options.alignment,
-                .fill = options.fill,
+                .alignment = .right,
+                .fill = '0',
                 .width = width,
             }, writer);
         }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1272,34 +1272,32 @@ pub fn formatInt(
         }
     }
 
-    if (value_info.signedness == .signed) {
-        if (options.fill == '0' and options.alignment == .right) {
-            // If the fill character is '0' and the alignment is right, we need to
-            // put the sign in front of padding zeros
-            var width = options.width;
-            if (value < 0) {
-                try writer.writeByte('-');
-                if (width != null and width.? > 0) width.? -= 1;
-            } else if (options.signed and value > 0) {
-                try writer.writeByte('+');
-                if (width != null and width.? > 0) width.? -= 1;
-            }
-            return formatBuf(buf[index..], .{
-                .alignment = .right,
-                .fill = '0',
-                .width = width,
-            }, writer);
-        }
-
+    if (options.fill == '0' and options.alignment == .right) {
+        // If the fill character is '0' and the alignment is right, we need to
+        // put the sign in front of padding zeros
+        var width = options.width;
         if (value < 0) {
-            // Negative integer
-            index -= 1;
-            buf[index] = '-';
+            try writer.writeByte('-');
+            if (width != null and width.? > 0) width.? -= 1;
         } else if (options.signed and value > 0) {
-            // Positive integer, sign explicitly requested
-            index -= 1;
-            buf[index] = '+';
+            try writer.writeByte('+');
+            if (width != null and width.? > 0) width.? -= 1;
         }
+        return formatBuf(buf[index..], .{
+            .alignment = .right,
+            .fill = '0',
+            .width = width,
+        }, writer);
+    }
+
+    if (value < 0) {
+        // Negative integer
+        index -= 1;
+        buf[index] = '-';
+    } else if (options.signed and value > 0) {
+        // Positive integer, sign explicitly requested
+        index -= 1;
+        buf[index] = '+';
     }
 
     return formatBuf(buf[index..], options, writer);
@@ -2025,9 +2023,12 @@ test "int.specifier" {
 
 test "int.padded" {
     try expectFmt("u8: '   1'", "u8: '{:4}'", .{@as(u8, 1)});
+    try expectFmt("u8: '  +1'", "u8: '{:+4}'", .{@as(u8, 1)});
     try expectFmt("u8: '1000'", "u8: '{:0<4}'", .{@as(u8, 1)});
     try expectFmt("u8: '0001'", "u8: '{:0>4}'", .{@as(u8, 1)});
     try expectFmt("u8: '0100'", "u8: '{:0^4}'", .{@as(u8, 1)});
+    try expectFmt("u8: '0+10'", "u8: '{:+0^4}'", .{@as(u8, 1)});
+    try expectFmt("u8: '+001'", "u8: '{:+0>4}'", .{@as(u8, 1)});
     try expectFmt("i8: '-1  '", "i8: '{:<4}'", .{@as(i8, -1)});
     try expectFmt("i8: '  -1'", "i8: '{:>4}'", .{@as(i8, -1)});
     try expectFmt("i8: ' -1 '", "i8: '{:^4}'", .{@as(i8, -1)});


### PR DESCRIPTION
Closes #14436 .
This PR implemented following features:
- Added an option to explicitly show `+` sign when formatting positive numbers;
- When the fill character is `0` and number aligned to right, they will be recognized as leading zeroes, and the sign will be appended before the leading zeroes;
- For hexadecimal floating point numbers, leading zeroes will be inserted after `0x`.
e.g.
```zig
try std.testing.expectFmt("  +1", "{:+>4}", .{1});
try std.testing.expectFmt("+001", "{:+0>4}", .{1});
try std.testing.expectFmt("+0x001p0", "{x:+0>8}", .{1.0});
```

Points worth discussing:
- How to specify `+` as the fill character when the signed option is not present?  Currently I use `\\+` as the indentifier for such.
- What should be the behaviour when formating `inf` and `nan` with leading zeroes and a sign? Currently the sign is still placed before leading zeroes.
e.g.
```zig
try std.testing.expectFmt("1+++", "{:\\+<4}", .{1});
try std.testing.expectFmt("+00nan", "{:+0>6}", .{std.math.nan(f64)});
```