### PR TITLE
Added `std.testing` output writer

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -24,11 +24,13 @@ pub var log_level = std.log.Level.warn;
 // Disable printing in tests for simple backends.
 pub const backend_can_print = builtin.zig_backend != .stage2_spirv64;
 
+pub var output: std.io.AnyWriter = std.io.getStdErr().writer().any();
+
 fn print(comptime fmt: []const u8, args: anytype) void {
     if (@inComptime()) {
         @compileError(std.fmt.comptimePrint(fmt, args));
     } else if (backend_can_print) {
-        std.debug.print(fmt, args);
+        output.print(fmt, args) catch return;
     }
 }
 


### PR DESCRIPTION
Test runners can modify `std.testing.output` to have the `std.testing` functions output somewhere else, in a similar manner to `allocator_instance`.

Fixes #14245