### PR TITLE
io_uring: fix regression

### DIFF
--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -282,19 +282,15 @@ fn copy_cqes_ready(self: *IoUring, cqes: []linux.io_uring_cqe) u32 {
     const ready = self.cq_ready();
     const count = @min(cqes.len, ready);
     const head = self.cq.head.* & self.cq.mask;
-    const tail = (self.cq.head.* +% count) & self.cq.mask;
 
-    if (head < tail) {
-        // head behind tail -> no wrapping
-        @memcpy(cqes[0..count], self.cq.cqes[head..tail]);
-    } else {
-        // head in front of tail -> buffer wraps
-        const two_copies_required: bool = self.cq.cqes.len - head < count;
-        const amount_to_copy_in_first = if (two_copies_required) self.cq.cqes.len - head else count;
-        @memcpy(cqes[0..amount_to_copy_in_first], self.cq.cqes[head .. head + amount_to_copy_in_first]);
-        if (two_copies_required) {
-            @memcpy(cqes[amount_to_copy_in_first..count], self.cq.cqes[0..tail]);
-        }
+    // before wrapping
+    const n = @min(self.cq.cqes.len - head, count);
+    @memcpy(cqes[0..n], self.cq.cqes[head..][0..n]);
+
+    if (count > n) {
+        // wrap self.cq.cqes
+        const w = count - n;
+        @memcpy(cqes[n..][0..w], self.cq.cqes[0..w]);
     }
 
     self.cq_advance(count);
@@ -4231,24 +4227,49 @@ fn expect_buf_grp_cqe(
     return cqe;
 }
 
-test "failing test for issue 19451" {
-    var ring = try IoUring.init(2, 0);
+test "copy_cqes with wrapping sq.cqes buffer" {
+    if (!is_linux) return error.SkipZigTest;
+
+    var ring = IoUring.init(2, 0) catch |err| switch (err) {
+        error.SystemOutdated => return error.SkipZigTest,
+        error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
     defer ring.deinit();
 
     try testing.expectEqual(2, ring.sq.sqes.len);
     try testing.expectEqual(4, ring.cq.cqes.len);
 
-    for (0..4) |i| {
-        const sqe = try ring.get_sqe();
-        sqe.prep_timeout(&.{ .tv_sec = 0, .tv_nsec = 10000 }, 0, 0);
-        sqe.user_data = i;
-        _ = try ring.submit();
+    // submit 2 entries, receive 2 completions
+    var cqes: [8]linux.io_uring_cqe = undefined;
+    {
+        for (0..2) |_| {
+            const sqe = try ring.get_sqe();
+            sqe.prep_timeout(&.{ .tv_sec = 0, .tv_nsec = 10000 }, 0, 0);
+            try testing.expect(try ring.submit() == 1);
+        }
+        var cqe_count: u32 = 0;
+        while (cqe_count < 2) {
+            cqe_count += try ring.copy_cqes(&cqes, 2 - cqe_count);
+        }
     }
 
-    var cqe_count: u32 = 0;
-    while (cqe_count < 4) {
-        var cqes: [8]linux.io_uring_cqe = undefined;
-        cqe_count += try ring.copy_cqes(&cqes, 4 - cqe_count);
+    try testing.expectEqual(2, ring.cq.head.*);
+
+    // sq.sqes len is 4, starting at position 2
+    // every 4 entries submit wraps completion buffer
+    // we are reading ring.cq.cqes at indexes 2,3,0,1
+    for (1..1024) |i| {
+        for (0..4) |_| {
+            const sqe = try ring.get_sqe();
+            sqe.prep_timeout(&.{ .tv_sec = 0, .tv_nsec = 10000 }, 0, 0);
+            try testing.expect(try ring.submit() == 1);
+        }
+        var cqe_count: u32 = 0;
+        while (cqe_count < 4) {
+            cqe_count += try ring.copy_cqes(&cqes, 4 - cqe_count);
+        }
+        try testing.expectEqual(4, cqe_count);
+        try testing.expectEqual(2 + 4 * i, ring.cq.head.*);
     }
-    try testing.expectEqual(4, cqe_count);
 }

--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -284,7 +284,7 @@ fn copy_cqes_ready(self: *IoUring, cqes: []linux.io_uring_cqe) u32 {
     const head = self.cq.head.* & self.cq.mask;
     const tail = (self.cq.head.* +% count) & self.cq.mask;
 
-    if (head <= tail) {
+    if (head < tail) {
         // head behind tail -> no wrapping
         @memcpy(cqes[0..count], self.cq.cqes[head..tail]);
     } else {


### PR DESCRIPTION
Fixes #19451 which describes io_uring regression introduced in #18757.

First commit adds failing test from the issue which fails with `panic: @memcpy arguments have non-equal lengths`.
```
1/1 IoUring.test.failing test for issue 19451... thread 248254 panic: @memcpy arguments have non-equal lengths
/usr/local/zig/zig-linux-x86_64-0.12.0-dev.3496+a2df84d0f/lib/std/os/linux/IoUring.zig:289:45: 0x103d50a in copy_cqes_ready (test)
        @memcpy(cqes[0..count], self.cq.cqes[head..tail]);
                                            ^
/usr/local/zig/zig-linux-x86_64-0.12.0-dev.3496+a2df84d0f/lib/std/os/linux/IoUring.zig:276:36: 0x103d1c4 in copy_cqes (test)
        return self.copy_cqes_ready(cqes);
                                   ^
/usr/local/zig/zig-linux-x86_64-0.12.0-dev.3496+a2df84d0f/lib/compiler/IoUring.zig:4251:40: 0x103df00 in test.failing test for issue 19451 (test)
/usr/local/zig/zig-linux-x86_64-0.12.0-dev.3496+a2df84d0f/lib/compiler/test_runner.zig:158:25: 0x107847c in mainTerminal (test)
        if (test_fn.func()) |_| {
                        ^
/usr/local/zig/zig-linux-x86_64-0.12.0-dev.3496+a2df84d0f/lib/compiler/test_runner.zig:35:28: 0x104088b in main (test)
        return mainTerminal();
                           ^
/usr/local/zig/zig-linux-x86_64-0.12.0-dev.3496+a2df84d0f/lib/std/start.zig:501:22: 0x103e579 in posixCallMainAndExit (test)
            root.main();
                     ^
/usr/local/zig/zig-linux-x86_64-0.12.0-dev.3496+a2df84d0f/lib/std/start.zig:253:5: 0x103e0e1 in _start (test)
    asm volatile (switch (native_arch) {
    ^
???:?:?: 0x0 in ??? (???)
error: the following test command crashed:
```

Second commit is one character fix.

Third simplifies logic in copy_sqes and adds test which touches both paths in copys_sqes.