### PR TITLE
bounded array: mention better way to initialize empty instance

### DIFF
--- a/lib/std/bounded_array.zig
+++ b/lib/std/bounded_array.zig
@@ -32,7 +32,6 @@ pub fn BoundedArrayAligned(
 
         /// Set the actual length of the slice.
         /// Returns error.Overflow if it exceeds the length of the backing array.
-        /// Use std.BoundedArray(T, N){} to initialize an empty BoundedArray
         pub fn init(len: usize) error{Overflow}!Self {
             if (len > buffer_capacity) return error.Overflow;
             return Self{ .len = @intCast(len) };
@@ -283,6 +282,11 @@ pub fn BoundedArrayAligned(
 }
 
 test BoundedArray {
+    const empty = BoundedArray(u8, 8){}; // empty bounded array with capacity 8
+    try testing.expectEqual(empty.capacity(), 8);
+    try testing.expectEqual(empty.slice().len, 0);
+    try testing.expectEqual(empty.constSlice().len, 0);
+
     var a = try BoundedArray(u8, 64).init(32);
 
     try testing.expectEqual(a.capacity(), 64);

--- a/lib/std/bounded_array.zig
+++ b/lib/std/bounded_array.zig
@@ -26,7 +26,7 @@ pub fn BoundedArray(comptime T: type, comptime buffer_capacity: usize) type {
 /// only known at runtime, but whose maximum size is known at comptime, without
 /// requiring an `Allocator`.
 /// ```zig
-//  var a = try BoundedArrayAligned(u8, 16, 2).init(0);
+//  var a = BoundedArrayAligned(u8, 16, 2){};
 //  try a.append(255);
 //  try a.append(255);
 //  const b = @ptrCast(*const [1]u16, a.constSlice().ptr);
@@ -415,7 +415,7 @@ test "BoundedArray sizeOf" {
 }
 
 test "BoundedArrayAligned" {
-    var a = try BoundedArrayAligned(u8, 16, 4).init(0);
+    var a = BoundedArrayAligned(u8, 16, 4){};
     try a.append(0);
     try a.append(0);
     try a.append(255);

--- a/lib/std/bounded_array.zig
+++ b/lib/std/bounded_array.zig
@@ -46,6 +46,7 @@ pub fn BoundedArrayAligned(
 
         /// Set the actual length of the slice.
         /// Returns error.Overflow if it exceeds the length of the backing array.
+        /// Use std.BoundedArray(T, N){} to initialize an empty BoundedArray
         pub fn init(len: usize) error{Overflow}!Self {
             if (len > buffer_capacity) return error.Overflow;
             return Self{ .len = @intCast(len) };


### PR DESCRIPTION
I used `.init(0) catch unreachable` before i realised there is a better way.