### PR TITLE
langref: tentative documentation of destructure syntax

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -941,7 +941,7 @@ pub fn main() void {
       {#header_open|Destructured Assignment#}
       <p>
       If an expression produces a compound type comprised of positional components exclusively (arrays, vectors, and tuples), 
-      they can be assigned to multiple identifiers via destructuring syntax:
+      they can be assigned inside a block to multiple identifiers via destructuring syntax:
       </p>
       {#code_begin|syntax|destructure_matrix#}
 test {

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -938,6 +938,33 @@ pub fn main() void {
       implementation feature, not a language semantic, so it is not guaranteed to be observable to code.
       </p>
       {#header_close#}
+      {#header_open|Destructured Assignment#}
+      <p>
+      If an expression produces a compound type comprised of positional components exclusively (arrays, vectors, and tuples), 
+      they can be assigned to multiple identifiers via destructuring syntax:
+      </p>
+      {#code_begin|syntax|destructure_matrix#}
+const a, const b, const c,
+const d, const e, const f, 
+const g, const h, const i = makeTransform(scale, rotate);
+var xs: [num]f32 = undefined;
+var ys: [num]f32 = undefined;
+var zs: [num]f32 = undefined;
+inline for (verts, 0..) |v, n| {
+    xs[n], ys[n], zs[n] = .{
+        a*v.x + b*v.y + c*v.z,
+        d*v.x + e*v.y + f*v.z,
+        g*v.x + h*v.y + i*v.z,
+    };
+}
+      {#code_end#}
+      <p>
+      Mixture of var/const declarations and reassignments are permitted, as well as type coercions:
+      </p>
+      {#code_begin|syntax|destructure_mixed#}
+current_index, const flags: u32, var payload: []u8 = getData();
+      {#code_end#}
+      {#header_close#}
       {#header_close#}
       {#header_close#}
       {#header_open|Zig Test#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -945,28 +945,52 @@ pub fn main() void {
       </p>
       {#code_begin|syntax|destructure_matrix#}
 test {
-	const a, const b, const c,
-	const d, const e, const f, 
-	const g, const h, const i = makeTransform(scale, rotate);
-	var xs: [num]f32 = undefined;
-	var ys: [num]f32 = undefined;
-	var zs: [num]f32 = undefined;
-	inline for (verts, 0..) |v, n| {
-	    xs[n], ys[n], zs[n] = .{
-	        a*v.x + b*v.y + c*v.z,
-	        d*v.x + e*v.y + f*v.z,
-	        g*v.x + h*v.y + i*v.z,
-	    };
-	}
+    const a, const b, const c, 
+    const d, const e, const f, 
+    const g, const h, const i = matrix;
+    var xs: [8]f32, 
+    var ys: [8]f32, 
+    var zs: [8]f32 = .{ undefined, undefined, undefined };
+    inline for (verts, 0..) |v, n| {
+        xs[n], ys[n], zs[n] = .{
+            a*v[0] + b*v[1] + c*v[2],
+            d*v[0] + e*v[1] + f*v[2],
+            g*v[0] + h*v[1] + i*v[2],
+        };
+    }
 }
+
+const matrix = [9]f32{
+    3, 0, 0,
+    0, 2, 0,
+    0, 0, 1,
+};
+
+const verts = [8][3]f32{
+    .{ 0, 0, 0 }, .{ 0, 0, 1 }, .{ 0, 1, 0 }, .{ 0, 1, 1 },
+    .{ 1, 0, 0 }, .{ 1, 0, 1 }, .{ 1, 1, 0 }, .{ 1, 1, 1 },
+};
       {#code_end#}
       <p>
       Mixture of var/const declarations and reassignments are permitted, as well as type coercions:
       </p>
       {#code_begin|syntax|destructure_mixed#}
 test {
-    current_index, const flags: u32, var payload: []u8 = getData();
+    var txt = ("a"**256).*;
+    var current_index: usize = 0;
+    current_index, const flags: u32, var payload: []u8 = Data{
+        0xFF, 0x80, &txt,
+    };
+    payload[0] = 'A';
+    try expect(txt[0] == 'A');
+    try expect(flags == 0x80);
 }
+
+const Data = struct {
+    u32, u8, *[256]u8,
+};
+
+const expect = @import("std").testing.expect;
       {#code_end#}
       {#header_close#}
       {#header_close#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -940,7 +940,7 @@ pub fn main() void {
       {#header_close#}
       {#header_open|Destructured Assignment#}
       <p>
-      If an expression produces a compound type comprised of positional components exclusively (arrays, vectors, and tuples), 
+      If an expression produces an indexable aggregate (arrays, vectors, and tuples), 
       they can be assigned inside a block to multiple identifiers via destructuring syntax:
       </p>
       {#code_begin|syntax|destructure_matrix#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -940,8 +940,7 @@ pub fn main() void {
       {#header_close#}
       {#header_open|Destructured Assignment#}
       <p>
-      If an expression produces an indexable aggregate (arrays, vectors, and tuples), 
-      they can be assigned inside a block to multiple identifiers via destructuring syntax:
+      Sequences of identifiers can be assigned to receive the elements of an indexable aggregate (arrays, vectors, or tuples) of matching length when inside an imperative block:
       </p>
       {#code_begin|syntax|destructure_matrix#}
 test {

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -951,8 +951,8 @@ test {
     var xs: [8]f32, 
     var ys: [8]f32, 
     var zs: [8]f32 = .{ undefined, undefined, undefined };
-    inline for (verts, 0..) |v, n| {
-        xs[n], ys[n], zs[n] = .{
+    inline for (verts, &xs, &ys, &zs) |v, *x, *y, *z| {
+        x.*, y.*, z.* = .{
             a*v[0] + b*v[1] + c*v[2],
             d*v[0] + e*v[1] + f*v[2],
             g*v[0] + h*v[1] + i*v[2],

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -944,25 +944,29 @@ pub fn main() void {
       they can be assigned to multiple identifiers via destructuring syntax:
       </p>
       {#code_begin|syntax|destructure_matrix#}
-const a, const b, const c,
-const d, const e, const f, 
-const g, const h, const i = makeTransform(scale, rotate);
-var xs: [num]f32 = undefined;
-var ys: [num]f32 = undefined;
-var zs: [num]f32 = undefined;
-inline for (verts, 0..) |v, n| {
-    xs[n], ys[n], zs[n] = .{
-        a*v.x + b*v.y + c*v.z,
-        d*v.x + e*v.y + f*v.z,
-        g*v.x + h*v.y + i*v.z,
-    };
+test {
+	const a, const b, const c,
+	const d, const e, const f, 
+	const g, const h, const i = makeTransform(scale, rotate);
+	var xs: [num]f32 = undefined;
+	var ys: [num]f32 = undefined;
+	var zs: [num]f32 = undefined;
+	inline for (verts, 0..) |v, n| {
+	    xs[n], ys[n], zs[n] = .{
+	        a*v.x + b*v.y + c*v.z,
+	        d*v.x + e*v.y + f*v.z,
+	        g*v.x + h*v.y + i*v.z,
+	    };
+	}
 }
       {#code_end#}
       <p>
       Mixture of var/const declarations and reassignments are permitted, as well as type coercions:
       </p>
       {#code_begin|syntax|destructure_mixed#}
-current_index, const flags: u32, var payload: []u8 = getData();
+test {
+    current_index, const flags: u32, var payload: []u8 = getData();
+}
       {#code_end#}
       {#header_close#}
       {#header_close#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -952,10 +952,11 @@ test {
     var ys: [8]f32, 
     var zs: [8]f32 = .{ undefined, undefined, undefined };
     inline for (verts, &xs, &ys, &zs) |v, *x, *y, *z| {
+        const vx, const vy, const vz = v;
         x.*, y.*, z.* = .{
-            a*v[0] + b*v[1] + c*v[2],
-            d*v[0] + e*v[1] + f*v[2],
-            g*v[0] + h*v[1] + i*v[2],
+            a*vx + b*vy + c*vz,
+            d*vx + e*vy + f*vz,
+            g*vx + h*vy + i*vz,
         };
     }
 }


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/18523

I've put it as a subsection under the Values -> Assignment heading as it seems to be the most relevant spot for this.

c.c. @perillo 