### PR TITLE
Fix first-time package fetches

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -1448,7 +1448,7 @@ fn computeHash(
                 )),
             };
 
-            if (std.mem.eql(u8, entry.path, Package.build_zig_basename))
+            if (std.mem.eql(u8, entry_pkg_path, Package.build_zig_basename))
                 f.has_build_zig = true;
 
             const fs_path = try arena.dupe(u8, entry.path);


### PR DESCRIPTION
Closes #19557
Closes #19561

Previously, `build.zig` was not being detected correctly by `computeHash` for packages where there is a containing root directory.

Tested on:
- https://github.com/kubkon/zld (#19561)
- https://codeberg.org/kiesel-js/kiesel/ (#19557)