### PR TITLE
std.Build: fix regression in Step.ConfigHeader

### DIFF
--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -694,7 +694,9 @@ pub fn appendZigProcessFlags(
                 }
             },
             .config_header_step => |config_header| {
-                try zig_args.appendSlice(&.{ "-I", std.fs.path.dirname(config_header.output_file.getPath()).? });
+                const full_file_path = config_header.output_file.getPath();
+                const header_dir_path = full_file_path[0 .. full_file_path.len - config_header.include_path.len];
+                try zig_args.appendSlice(&.{ "-I", header_dir_path });
             },
         }
     }


### PR DESCRIPTION
Commit 0b7123f41d66bdda4da29d59623299d47b29aefb regressed the `include_path` option of ConfigHeader which is intended to set the path, including subdirectories, that C code would pass to an include directive.

For example if it passes

    .include_path = "config/config.h",

Then the C code should be able to have

    #include "config/config.h"

This regressed https://github.com/andrewrk/nasm/ because the build-exe command ends up being:

`-I /home/andy/dev/nasm/zig-cache/o/3e761af6a001bf60071c3f2b8c1a92c1/config`

However the desired path does not include the directory at the end:

```
andy@bark ~> find /home/andy/dev/nasm/zig-cache/o/3e761af6a001bf60071c3f2b8c1a92c1/ -type f
/home/andy/dev/nasm/zig-cache/o/3e761af6a001bf60071c3f2b8c1a92c1/config/config.h
```

```
/home/andy/dev/nasm/include/compiler.h:58:11: error: 'config/config.h' file not found
# include "config/config.h"
          ^~~~~~~~~~~~~~~~~~
```

Fixed by this commit.

cc @castholm 