### PR TITLE
introduce std.Build.path; deprecate LazyPath.relative

### DIFF
--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -58,6 +58,7 @@ pub fn create(owner: *std.Build, options: Options) *ConfigHeader {
 
     if (options.style.getPath()) |s| default_include_path: {
         const sub_path = switch (s) {
+            .src_path => |sp| sp.sub_path,
             .path => |path| path,
             .generated, .generated_dirname => break :default_include_path,
             .cwd_relative => |sub_path| sub_path,

--- a/test/standalone/test_runner_module_imports/build.zig
+++ b/test/standalone/test_runner_module_imports/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const t = b.addTest(.{
         .root_source_file = .{ .path = "src/main.zig" },
-        .test_runner = "test_runner/main.zig",
+        .test_runner = b.path("test_runner/main.zig"),
     });
 
     const module1 = b.createModule(.{ .root_source_file = .{ .path = "module1/main.zig" } });

--- a/test/standalone/test_runner_path/build.zig
+++ b/test/standalone/test_runner_path/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
     const test_exe = b.addTest(.{
         .root_source_file = .{ .path = "test.zig" },
     });
-    test_exe.test_runner = "test_runner.zig";
+    test_exe.test_runner = b.path("test_runner.zig");
 
     const test_run = b.addRunArtifact(test_exe);
     test_step.dependOn(&test_run.step);


### PR DESCRIPTION
This adds the `*std.Build` owner to LazyPath so that lazy paths returned from a dependency can be used in the application without friction or footguns.

This is technically a breaking change due to `test_runner` taking a LazyPath rather than a string but it does not do the massive breaking change yet. The breakage can happen during the 0.13.0 release cycle.

closes #19313

## Upgrade Guide

### Source-Relative LazyPath (deprecated only)

```zig
.root_source_file = .{ .path = "src/main.zig" },
```
:arrow_down: 
```zig
.root_source_file = b.path("src/main.zig"),
```

### LazyPath.relative  (deprecated only)

```zig
.root_source_file = LazyPath.relative("src/main.zig"),
```
:arrow_down: 
```zig
.root_source_file = b.path("src/main.zig"),
```

### Test Runner (breaking)

```zig
.test_runner = "path/to/test_runner.zig",
```
:arrow_down: 
```zig
.test_runner = b.path("path/to/test_runner.zig"),
```