### PR TITLE
linked_list.zig: remove unused constant declaration

### DIFF
--- a/lib/std/linked_list.zig
+++ b/lib/std/linked_list.zig
@@ -19,8 +19,6 @@ pub fn SinglyLinkedList(comptime T: type) type {
             next: ?*Node = null,
             data: T,
 
-            pub const Data = T;
-
             /// Insert a new node after the current one.
             ///
             /// Arguments:


### PR DESCRIPTION
While reading the source code of the linked list implementation I got confused with this constant declaration. It looks like it might be unused.