### PR TITLE
autodoc: fix tokenizer

### DIFF
--- a/lib/docs/wasm/markdown/Parser.zig
+++ b/lib/docs/wasm/markdown/Parser.zig
@@ -1540,7 +1540,7 @@ const InlineParser = struct {
                         iter.pos += 1;
                         return .{ .text = replacement };
                     };
-                    const is_valid = iter.pos + cp_len < iter.content.len and
+                    const is_valid = iter.pos + cp_len <= iter.content.len and
                         std.unicode.utf8ValidateSlice(iter.content[iter.pos..][0..cp_len]);
                     const cp_encoded = if (is_valid)
                         iter.content[iter.pos..][0..cp_len]


### PR DESCRIPTION
Function description was tokenized incorrectly and it resulted in replacement character in [std.math.big.int.Managed.sqrt](https://ziglang.org/documentation/master/std/#std.math.big.int.Managed.sqrt) description.
![image](https://github.com/ziglang/zig/assets/75577902/4b6de75f-b474-4771-8bf2-4df8ea567bda).
