### PR TITLE
std.debug.panic: pass the args

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -406,7 +406,7 @@ pub fn assert(ok: bool) void {
 pub fn panic(comptime format: []const u8, args: anytype) noreturn {
     @setCold(true);
 
-    panicExtra(null, null, format, args);
+    panicExtra(@errorReturnTrace(), @returnAddress(), format, args);
 }
 
 /// `panicExtra` is useful when you want to print out an `@errorReturnTrace`


### PR DESCRIPTION
Why was this passing null? These values are available and useful.

#### Before

```
thread 464075 panic: sub_path is expected to be relative to the build root, but was this absolute path: '/home/andy/dev/zig/zig-cache/tmp/4284db75167f415d/fmt6.zig'
/home/andy/dev/zig/lib/std/debug.zig:434:22: 0x1231726 in panicExtra__anon_17736 (build)
    std.builtin.panic(msg, trace, ret_addr);
                     ^
/home/andy/dev/zig/lib/std/debug.zig:409:15: 0x11e6d79 in panic__anon_16238 (build)
    panicExtra(null, null, format, args);
              ^
/home/andy/dev/zig/lib/std/Build.zig:1641:24: 0x118b74d in path (build)
        std.debug.panic("sub_path is expected to be relative to the build root, but was this absolute path: '{s}'", .{
                       ^
/home/andy/dev/zig/test/tests.zig:882:45: 0x119c0bc in addCliTests (build)
        const check6 = b.addCheckFile(b.path(fmt6_path), .{
                                            ^
```

#### After

```
thread 464343 panic: sub_path is expected to be relative to the build root, but was this absolute path: '/home/andy/dev/zig/zig-cache/tmp/bd0f446c57c40e6e/fmt6.zig'
/home/andy/dev/zig/lib/std/Build.zig:1641:24: 0x118b75d in path (build)
        std.debug.panic("sub_path is expected to be relative to the build root, but was this absolute path: '{s}'", .{
                       ^
/home/andy/dev/zig/test/tests.zig:882:45: 0x119c0cc in addCliTests (build)
        const check6 = b.addCheckFile(b.path(fmt6_path), .{
                                            ^
```