### PR TITLE
std.Build.LazyPath: upgrade API usages of source-relative path

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -34,7 +34,7 @@ pub fn build(b: *std.Build) !void {
 
     const docgen_exe = b.addExecutable(.{
         .name = "docgen",
-        .root_source_file = .{ .path = "tools/docgen.zig" },
+        .root_source_file = b.path("tools/docgen.zig"),
         .target = b.host,
         .optimize = .Debug,
         .single_threaded = single_threaded,
@@ -46,7 +46,7 @@ pub fn build(b: *std.Build) !void {
         docgen_cmd.addArg("--zig-lib-dir");
         docgen_cmd.addDirectoryArg(p);
     }
-    docgen_cmd.addFileArg(.{ .path = "doc/langref.html.in" });
+    docgen_cmd.addFileArg(b.path("doc/langref.html.in"));
     const langref_file = docgen_cmd.addOutputFileArg("langref.html");
     const install_langref = b.addInstallFileWithDir(langref_file, .prefix, "doc/langref.html");
     if (!skip_install_langref) {
@@ -55,9 +55,9 @@ pub fn build(b: *std.Build) !void {
 
     const autodoc_test = b.addObject(.{
         .name = "std",
-        .root_source_file = .{ .path = "lib/std/std.zig" },
+        .root_source_file = b.path("lib/std/std.zig"),
         .target = target,
-        .zig_lib_dir = .{ .path = "lib" },
+        .zig_lib_dir = b.path("lib"),
         .optimize = .Debug,
     });
     const install_std_docs = b.addInstallDirectory(.{
@@ -86,7 +86,7 @@ pub fn build(b: *std.Build) !void {
 
     const check_case_exe = b.addExecutable(.{
         .name = "check-case",
-        .root_source_file = .{ .path = "test/src/Cases.zig" },
+        .root_source_file = b.path("test/src/Cases.zig"),
         .target = b.host,
         .optimize = optimize,
         .single_threaded = single_threaded,
@@ -135,7 +135,7 @@ pub fn build(b: *std.Build) !void {
 
     if (!skip_install_lib_files) {
         b.installDirectory(.{
-            .source_dir = .{ .path = "lib" },
+            .source_dir = b.path("lib"),
             .install_dir = if (flat) .prefix else .lib,
             .install_subdir = if (flat) "lib" else "zig",
             .exclude_extensions = &[_][]const u8{
@@ -552,10 +552,10 @@ pub fn build(b: *std.Build) !void {
     const update_mingw_exe = b.addExecutable(.{
         .name = "update_mingw",
         .target = b.host,
-        .root_source_file = .{ .path = "tools/update_mingw.zig" },
+        .root_source_file = b.path("tools/update_mingw.zig"),
     });
     const update_mingw_run = b.addRunArtifact(update_mingw_exe);
-    update_mingw_run.addDirectoryArg(.{ .path = "lib" });
+    update_mingw_run.addDirectoryArg(b.path("lib"));
     if (opt_mingw_src_path) |mingw_src_path| {
         update_mingw_run.addDirectoryArg(.{ .cwd_relative = mingw_src_path });
     } else {
@@ -606,10 +606,10 @@ fn addWasiUpdateStep(b: *std.Build, version: [:0]const u8) !void {
     });
     run_opt.addArtifactArg(exe);
     run_opt.addArg("-o");
-    run_opt.addFileArg(.{ .path = "stage1/zig1.wasm" });
+    run_opt.addFileArg(b.path("stage1/zig1.wasm"));
 
     const copy_zig_h = b.addWriteFiles();
-    copy_zig_h.addCopyFileToSource(.{ .path = "lib/zig.h" }, "stage1/zig.h");
+    copy_zig_h.addCopyFileToSource(b.path("lib/zig.h"), "stage1/zig.h");
 
     const update_zig1_step = b.step("update-zig1", "Update stage1/zig1.wasm");
     update_zig1_step.dependOn(&run_opt.step);
@@ -627,7 +627,7 @@ const AddCompilerStepOptions = struct {
 fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "zig",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = options.target,
         .optimize = options.optimize,
         .max_rss = 7_000_000_000,
@@ -638,11 +638,11 @@ fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.St
     exe.stack_size = stack_size;
 
     const aro_module = b.createModule(.{
-        .root_source_file = .{ .path = "lib/compiler/aro/aro.zig" },
+        .root_source_file = b.path("lib/compiler/aro/aro.zig"),
     });
 
     const aro_translate_c_module = b.createModule(.{
-        .root_source_file = .{ .path = "lib/compiler/aro_translate_c.zig" },
+        .root_source_file = b.path("lib/compiler/aro_translate_c.zig"),
         .imports = &.{
             .{
                 .name = "aro",

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -264,20 +264,8 @@ pub const HeaderInstallation = union(enum) {
         dest_rel_path: []const u8,
 
         pub fn dupe(self: File, b: *std.Build) File {
-            // 'path' lazy paths are relative to the build root of some step, inferred from the step
-            // in which they are used. This means that we can't dupe such paths, because they may
-            // come from dependencies with their own build roots and duping the paths as is might
-            // cause the build script to search for the file relative to the wrong root.
-            // As a temporary workaround, we convert build root-relative paths to absolute paths.
-            // If/when the build-root relative paths are updated to encode which build root they are
-            // relative to, this workaround should be removed.
-            const duped_source: LazyPath = switch (self.source) {
-                .path => |root_rel| .{ .cwd_relative = b.pathFromRoot(root_rel) },
-                else => self.source.dupe(b),
-            };
-
             return .{
-                .source = duped_source,
+                .source = self.source.dupe(b),
                 .dest_rel_path = b.dupePath(self.dest_rel_path),
             };
         }
@@ -305,20 +293,8 @@ pub const HeaderInstallation = union(enum) {
         };
 
         pub fn dupe(self: Directory, b: *std.Build) Directory {
-            // 'path' lazy paths are relative to the build root of some step, inferred from the step
-            // in which they are used. This means that we can't dupe such paths, because they may
-            // come from dependencies with their own build roots and duping the paths as is might
-            // cause the build script to search for the file relative to the wrong root.
-            // As a temporary workaround, we convert build root-relative paths to absolute paths.
-            // If/when the build-root relative paths are updated to encode which build root they are
-            // relative to, this workaround should be removed.
-            const duped_source: LazyPath = switch (self.source) {
-                .path => |root_rel| .{ .cwd_relative = b.pathFromRoot(root_rel) },
-                else => self.source.dupe(b),
-            };
-
             return .{
-                .source = duped_source,
+                .source = self.source.dupe(b),
                 .dest_rel_path = b.dupePath(self.dest_rel_path),
                 .options = self.options.dupe(b),
             };

--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -59,6 +59,7 @@ pub fn create(owner: *std.Build, options: Options) *ConfigHeader {
     if (options.style.getPath()) |s| default_include_path: {
         const sub_path = switch (s) {
             .src_path => |sp| sp.sub_path,
+            .path => |path| path,
             .generated, .generated_dirname => break :default_include_path,
             .cwd_relative => |sub_path| sub_path,
             .dependency => |dependency| dependency.sub_path,

--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -59,7 +59,6 @@ pub fn create(owner: *std.Build, options: Options) *ConfigHeader {
     if (options.style.getPath()) |s| default_include_path: {
         const sub_path = switch (s) {
             .src_path => |sp| sp.sub_path,
-            .path => |path| path,
             .generated, .generated_dirname => break :default_include_path,
             .cwd_relative => |sub_path| sub_path,
             .dependency => |dependency| dependency.sub_path,

--- a/test/link/bss/build.zig
+++ b/test/link/bss/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "bss",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .target = b.host,
         .optimize = .Debug,
     });

--- a/test/link/common_symbols/build.zig
+++ b/test/link/common_symbols/build.zig
@@ -22,7 +22,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     });
 
     const test_exe = b.addTest(.{
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
     });
     test_exe.linkLibrary(lib_a);

--- a/test/link/common_symbols_alignment/build.zig
+++ b/test/link/common_symbols_alignment/build.zig
@@ -22,7 +22,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     });
 
     const test_exe = b.addTest(.{
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
     });
     test_exe.linkLibrary(lib_a);

--- a/test/link/glibc_compat/build.zig
+++ b/test/link/glibc_compat/build.zig
@@ -21,7 +21,7 @@ pub fn build(b: *std.Build) void {
                 .{ .arch_os_abi = t },
             ) catch unreachable),
         });
-        exe.addCSourceFile(.{ .file = .{ .path = "main.c" } });
+        exe.addCSourceFile(.{ .file = b.path("main.c") });
         exe.linkLibC();
         // TODO: actually test the output
         _ = exe.getEmittedBin();
@@ -45,7 +45,7 @@ pub fn build(b: *std.Build) void {
 
         const exe = b.addExecutable(.{
             .name = t,
-            .root_source_file = .{ .path = "glibc_runtime_check.zig" },
+            .root_source_file = b.path("glibc_runtime_check.zig"),
             .target = target,
         });
         exe.linkLibC();

--- a/test/link/interdependent_static_c_libs/build.zig
+++ b/test/link/interdependent_static_c_libs/build.zig
@@ -16,24 +16,24 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
         .optimize = optimize,
         .target = b.host,
     });
-    lib_a.addCSourceFile(.{ .file = .{ .path = "a.c" }, .flags = &[_][]const u8{} });
-    lib_a.addIncludePath(.{ .path = "." });
+    lib_a.addCSourceFile(.{ .file = b.path("a.c"), .flags = &[_][]const u8{} });
+    lib_a.addIncludePath(b.path("."));
 
     const lib_b = b.addStaticLibrary(.{
         .name = "b",
         .optimize = optimize,
         .target = b.host,
     });
-    lib_b.addCSourceFile(.{ .file = .{ .path = "b.c" }, .flags = &[_][]const u8{} });
-    lib_b.addIncludePath(.{ .path = "." });
+    lib_b.addCSourceFile(.{ .file = b.path("b.c"), .flags = &[_][]const u8{} });
+    lib_b.addIncludePath(b.path("."));
 
     const test_exe = b.addTest(.{
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
     });
     test_exe.linkLibrary(lib_a);
     test_exe.linkLibrary(lib_b);
-    test_exe.addIncludePath(.{ .path = "." });
+    test_exe.addIncludePath(b.path("."));
 
     test_step.dependOn(&b.addRunArtifact(test_exe).step);
 }

--- a/test/link/macho.zig
+++ b/test/link/macho.zig
@@ -836,9 +836,9 @@ fn testLinkDirectlyCppTbd(b: *Build, opts: Options) *Step {
         ,
         .cpp_source_flags = &.{ "-nostdlib++", "-nostdinc++" },
     });
-    exe.root_module.addSystemIncludePath(.{ .path = b.pathJoin(&.{ sdk, "/usr/include" }) });
-    exe.root_module.addIncludePath(.{ .path = b.pathJoin(&.{ sdk, "/usr/include/c++/v1" }) });
-    exe.root_module.addObjectFile(.{ .path = b.pathJoin(&.{ sdk, "/usr/lib/libc++.tbd" }) });
+    exe.root_module.addSystemIncludePath(b.path(b.pathJoin(&.{ sdk, "/usr/include" })));
+    exe.root_module.addIncludePath(b.path(b.pathJoin(&.{ sdk, "/usr/include/c++/v1" })));
+    exe.root_module.addObjectFile(b.path(b.pathJoin(&.{ sdk, "/usr/lib/libc++.tbd" })));
 
     const check = exe.checkObject();
     check.checkInSymtab();

--- a/test/link/static_libs_from_object_files/build.zig
+++ b/test/link/static_libs_from_object_files/build.zig
@@ -57,7 +57,7 @@ fn add(b: *Build, test_step: *Step, files: []const LazyPath, optimize: std.built
     {
         const exe = b.addExecutable(.{
             .name = "test1",
-            .root_source_file = .{ .path = "main.zig" },
+            .root_source_file = b.path("main.zig"),
             .optimize = optimize,
             .target = b.host,
         });
@@ -93,7 +93,7 @@ fn add(b: *Build, test_step: *Step, files: []const LazyPath, optimize: std.built
 
         const exe = b.addExecutable(.{
             .name = "test2",
-            .root_source_file = .{ .path = "main.zig" },
+            .root_source_file = b.path("main.zig"),
             .target = b.host,
             .optimize = optimize,
         });
@@ -134,7 +134,7 @@ fn add(b: *Build, test_step: *Step, files: []const LazyPath, optimize: std.built
 
         const exe = b.addExecutable(.{
             .name = "test3",
-            .root_source_file = .{ .path = "main.zig" },
+            .root_source_file = b.path("main.zig"),
             .target = b.host,
             .optimize = optimize,
         });

--- a/test/link/wasm/archive/build.zig
+++ b/test/link/wasm/archive/build.zig
@@ -17,7 +17,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     // and therefore link with its archive file.
     const lib = b.addExecutable(.{
         .name = "main",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
         .strip = false,

--- a/test/link/wasm/basic-features/build.zig
+++ b/test/link/wasm/basic-features/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
     // Library with explicitly set cpu features
     const lib = b.addExecutable(.{
         .name = "lib",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = .Debug,
         .target = b.resolveTargetQuery(.{
             .cpu_arch = .wasm32,

--- a/test/link/wasm/bss/build.zig
+++ b/test/link/wasm/bss/build.zig
@@ -16,7 +16,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.Opt
     {
         const lib = b.addExecutable(.{
             .name = "lib",
-            .root_source_file = .{ .path = "lib.zig" },
+            .root_source_file = b.path("lib.zig"),
             .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
             .optimize = optimize_mode,
             .strip = false,
@@ -64,7 +64,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.Opt
     {
         const lib = b.addExecutable(.{
             .name = "lib",
-            .root_source_file = .{ .path = "lib2.zig" },
+            .root_source_file = b.path("lib2.zig"),
             .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
             .optimize = optimize_mode,
             .strip = false,

--- a/test/link/wasm/export-data/build.zig
+++ b/test/link/wasm/export-data/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build) void {
 
     const lib = b.addExecutable(.{
         .name = "lib",
-        .root_source_file = .{ .path = "lib.zig" },
+        .root_source_file = b.path("lib.zig"),
         .optimize = .ReleaseSafe, // to make the output deterministic in address positions
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
     });

--- a/test/link/wasm/export/build.zig
+++ b/test/link/wasm/export/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
     const no_export = b.addExecutable(.{
         .name = "no-export",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
     });
@@ -25,7 +25,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
 
     const dynamic_export = b.addExecutable(.{
         .name = "dynamic",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
     });
@@ -36,7 +36,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
 
     const force_export = b.addExecutable(.{
         .name = "force",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
     });

--- a/test/link/wasm/extern-mangle/build.zig
+++ b/test/link/wasm/extern-mangle/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build) void {
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
     const lib = b.addExecutable(.{
         .name = "lib",
-        .root_source_file = .{ .path = "lib.zig" },
+        .root_source_file = b.path("lib.zig"),
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
         .optimize = optimize,
     });

--- a/test/link/wasm/extern/build.zig
+++ b/test/link/wasm/extern/build.zig
@@ -15,11 +15,11 @@ pub fn build(b: *std.Build) void {
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
     const exe = b.addExecutable(.{
         .name = "extern",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .wasi }),
     });
-    exe.addCSourceFile(.{ .file = .{ .path = "foo.c" }, .flags = &.{} });
+    exe.addCSourceFile(.{ .file = b.path("foo.c"), .flags = &.{} });
     exe.use_llvm = false;
     exe.use_lld = false;
 

--- a/test/link/wasm/function-table/build.zig
+++ b/test/link/wasm/function-table/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
     const import_table = b.addExecutable(.{
         .name = "import_table",
-        .root_source_file = .{ .path = "lib.zig" },
+        .root_source_file = b.path("lib.zig"),
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
         .optimize = optimize,
     });
@@ -27,7 +27,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
 
     const export_table = b.addExecutable(.{
         .name = "export_table",
-        .root_source_file = .{ .path = "lib.zig" },
+        .root_source_file = b.path("lib.zig"),
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
         .optimize = optimize,
     });
@@ -39,7 +39,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
 
     const regular_table = b.addExecutable(.{
         .name = "regular_table",
-        .root_source_file = .{ .path = "lib.zig" },
+        .root_source_file = b.path("lib.zig"),
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
         .optimize = optimize,
     });

--- a/test/link/wasm/infer-features/build.zig
+++ b/test/link/wasm/infer-features/build.zig
@@ -13,13 +13,13 @@ pub fn build(b: *std.Build) void {
             .os_tag = .freestanding,
         }),
     });
-    c_obj.addCSourceFile(.{ .file = .{ .path = "foo.c" }, .flags = &.{} });
+    c_obj.addCSourceFile(.{ .file = b.path("foo.c"), .flags = &.{} });
 
     // Wasm library that doesn't have any features specified. This will
     // infer its featureset from other linked object files.
     const lib = b.addExecutable(.{
         .name = "lib",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = .Debug,
         .target = b.resolveTargetQuery(.{
             .cpu_arch = .wasm32,

--- a/test/link/wasm/producers/build.zig
+++ b/test/link/wasm/producers/build.zig
@@ -16,7 +16,7 @@ pub fn build(b: *std.Build) void {
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
     const lib = b.addExecutable(.{
         .name = "lib",
-        .root_source_file = .{ .path = "lib.zig" },
+        .root_source_file = b.path("lib.zig"),
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
         .optimize = optimize,
         .strip = false,

--- a/test/link/wasm/segments/build.zig
+++ b/test/link/wasm/segments/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
     const lib = b.addExecutable(.{
         .name = "lib",
-        .root_source_file = .{ .path = "lib.zig" },
+        .root_source_file = b.path("lib.zig"),
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
         .optimize = optimize,
         .strip = false,

--- a/test/link/wasm/shared-memory/build.zig
+++ b/test/link/wasm/shared-memory/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build) void {
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize_mode: std.builtin.OptimizeMode) void {
     const exe = b.addExecutable(.{
         .name = "lib",
-        .root_source_file = .{ .path = "lib.zig" },
+        .root_source_file = b.path("lib.zig"),
         .target = b.resolveTargetQuery(.{
             .cpu_arch = .wasm32,
             .cpu_model = .{ .explicit = &std.Target.wasm.cpu.mvp },

--- a/test/link/wasm/stack_pointer/build.zig
+++ b/test/link/wasm/stack_pointer/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
     const lib = b.addExecutable(.{
         .name = "lib",
-        .root_source_file = .{ .path = "lib.zig" },
+        .root_source_file = b.path("lib.zig"),
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
         .optimize = optimize,
         .strip = false,

--- a/test/link/wasm/type/build.zig
+++ b/test/link/wasm/type/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
     const exe = b.addExecutable(.{
         .name = "lib",
-        .root_source_file = .{ .path = "lib.zig" },
+        .root_source_file = b.path("lib.zig"),
         .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding }),
         .optimize = optimize,
         .strip = false,

--- a/test/standalone/build.zig
+++ b/test/standalone/build.zig
@@ -44,7 +44,7 @@ pub fn build(b: *std.Build) void {
     }) |tool_src_path| {
         const tool = b.addTest(.{
             .name = std.fs.path.stem(tool_src_path),
-            .root_source_file = .{ .path = tool_src_path },
+            .root_source_file = b.path(tool_src_path),
             .optimize = .Debug,
             .target = tools_target,
         });

--- a/test/standalone/c_compiler/build.zig
+++ b/test/standalone/c_compiler/build.zig
@@ -30,7 +30,7 @@ fn add(
         .optimize = optimize,
         .target = target,
     });
-    exe_c.addCSourceFile(.{ .file = .{ .path = "test.c" }, .flags = &[0][]const u8{} });
+    exe_c.addCSourceFile(.{ .file = b.path("test.c"), .flags = &[0][]const u8{} });
     exe_c.linkLibC();
 
     const exe_cpp = b.addExecutable(.{
@@ -39,7 +39,7 @@ fn add(
         .target = target,
     });
     b.default_step.dependOn(&exe_cpp.step);
-    exe_cpp.addCSourceFile(.{ .file = .{ .path = "test.cpp" }, .flags = &[0][]const u8{} });
+    exe_cpp.addCSourceFile(.{ .file = b.path("test.cpp"), .flags = &[0][]const u8{} });
     exe_cpp.linkLibCpp();
 
     switch (target.result.os.tag) {

--- a/test/standalone/child_process/build.zig
+++ b/test/standalone/child_process/build.zig
@@ -12,14 +12,14 @@ pub fn build(b: *std.Build) void {
 
     const child = b.addExecutable(.{
         .name = "child",
-        .root_source_file = .{ .path = "child.zig" },
+        .root_source_file = b.path("child.zig"),
         .optimize = optimize,
         .target = target,
     });
 
     const main = b.addExecutable(.{
         .name = "main",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .target = target,
     });

--- a/test/standalone/cmakedefine/build.zig
+++ b/test/standalone/cmakedefine/build.zig
@@ -4,7 +4,7 @@ const ConfigHeader = std.Build.Step.ConfigHeader;
 pub fn build(b: *std.Build) void {
     const config_header = b.addConfigHeader(
         .{
-            .style = .{ .cmake = .{ .path = "config.h.in" } },
+            .style = .{ .cmake = b.path("config.h.in") },
             .include_path = "config.h",
         },
         .{
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build) void {
 
     const pwd_sh = b.addConfigHeader(
         .{
-            .style = .{ .cmake = .{ .path = "pwd.sh.in" } },
+            .style = .{ .cmake = b.path("pwd.sh.in") },
             .include_path = "pwd.sh",
         },
         .{ .DIR = "${PWD}" },
@@ -36,7 +36,7 @@ pub fn build(b: *std.Build) void {
 
     const sigil_header = b.addConfigHeader(
         .{
-            .style = .{ .cmake = .{ .path = "sigil.h.in" } },
+            .style = .{ .cmake = b.path("sigil.h.in") },
             .include_path = "sigil.h",
         },
         .{},
@@ -44,7 +44,7 @@ pub fn build(b: *std.Build) void {
 
     const stack_header = b.addConfigHeader(
         .{
-            .style = .{ .cmake = .{ .path = "stack.h.in" } },
+            .style = .{ .cmake = b.path("stack.h.in") },
             .include_path = "stack.h",
         },
         .{
@@ -57,7 +57,7 @@ pub fn build(b: *std.Build) void {
 
     const wrapper_header = b.addConfigHeader(
         .{
-            .style = .{ .cmake = .{ .path = "wrapper.h.in" } },
+            .style = .{ .cmake = b.path("wrapper.h.in") },
             .include_path = "wrapper.h",
         },
         .{

--- a/test/standalone/compiler_rt_panic/build.zig
+++ b/test/standalone/compiler_rt_panic/build.zig
@@ -17,7 +17,7 @@ pub fn build(b: *std.Build) void {
     });
     exe.linkLibC();
     exe.addCSourceFile(.{
-        .file = .{ .path = "main.c" },
+        .file = b.path("main.c"),
         .flags = &.{},
     });
     exe.link_gc_sections = false;

--- a/test/standalone/dep_diamond/build.zig
+++ b/test/standalone/dep_diamond/build.zig
@@ -7,21 +7,21 @@ pub fn build(b: *std.Build) void {
     const optimize: std.builtin.OptimizeMode = .Debug;
 
     const shared = b.createModule(.{
-        .root_source_file = .{ .path = "shared.zig" },
+        .root_source_file = b.path("shared.zig"),
     });
 
     const exe = b.addExecutable(.{
         .name = "test",
-        .root_source_file = .{ .path = "test.zig" },
+        .root_source_file = b.path("test.zig"),
         .target = b.host,
         .optimize = optimize,
     });
     exe.root_module.addAnonymousImport("foo", .{
-        .root_source_file = .{ .path = "foo.zig" },
+        .root_source_file = b.path("foo.zig"),
         .imports = &.{.{ .name = "shared", .module = shared }},
     });
     exe.root_module.addAnonymousImport("bar", .{
-        .root_source_file = .{ .path = "bar.zig" },
+        .root_source_file = b.path("bar.zig"),
         .imports = &.{.{ .name = "shared", .module = shared }},
     });
 

--- a/test/standalone/dep_mutually_recursive/build.zig
+++ b/test/standalone/dep_mutually_recursive/build.zig
@@ -7,17 +7,17 @@ pub fn build(b: *std.Build) void {
     const optimize: std.builtin.OptimizeMode = .Debug;
 
     const foo = b.createModule(.{
-        .root_source_file = .{ .path = "foo.zig" },
+        .root_source_file = b.path("foo.zig"),
     });
     const bar = b.createModule(.{
-        .root_source_file = .{ .path = "bar.zig" },
+        .root_source_file = b.path("bar.zig"),
     });
     foo.addImport("bar", bar);
     bar.addImport("foo", foo);
 
     const exe = b.addExecutable(.{
         .name = "test",
-        .root_source_file = .{ .path = "test.zig" },
+        .root_source_file = b.path("test.zig"),
         .target = b.host,
         .optimize = optimize,
     });

--- a/test/standalone/dep_recursive/build.zig
+++ b/test/standalone/dep_recursive/build.zig
@@ -7,13 +7,13 @@ pub fn build(b: *std.Build) void {
     const optimize: std.builtin.OptimizeMode = .Debug;
 
     const foo = b.createModule(.{
-        .root_source_file = .{ .path = "foo.zig" },
+        .root_source_file = b.path("foo.zig"),
     });
     foo.addImport("foo", foo);
 
     const exe = b.addExecutable(.{
         .name = "test",
-        .root_source_file = .{ .path = "test.zig" },
+        .root_source_file = b.path("test.zig"),
         .target = b.host,
         .optimize = optimize,
     });

--- a/test/standalone/dep_shared_builtin/build.zig
+++ b/test/standalone/dep_shared_builtin/build.zig
@@ -8,12 +8,12 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "test",
-        .root_source_file = .{ .path = "test.zig" },
+        .root_source_file = b.path("test.zig"),
         .target = b.host,
         .optimize = optimize,
     });
     exe.root_module.addAnonymousImport("foo", .{
-        .root_source_file = .{ .path = "foo.zig" },
+        .root_source_file = b.path("foo.zig"),
     });
 
     const run = b.addRunArtifact(exe);

--- a/test/standalone/dep_triangle/build.zig
+++ b/test/standalone/dep_triangle/build.zig
@@ -7,17 +7,17 @@ pub fn build(b: *std.Build) void {
     const optimize: std.builtin.OptimizeMode = .Debug;
 
     const shared = b.createModule(.{
-        .root_source_file = .{ .path = "shared.zig" },
+        .root_source_file = b.path("shared.zig"),
     });
 
     const exe = b.addExecutable(.{
         .name = "test",
-        .root_source_file = .{ .path = "test.zig" },
+        .root_source_file = b.path("test.zig"),
         .target = b.host,
         .optimize = optimize,
     });
     exe.root_module.addAnonymousImport("foo", .{
-        .root_source_file = .{ .path = "foo.zig" },
+        .root_source_file = b.path("foo.zig"),
         .imports = &.{.{ .name = "shared", .module = shared }},
     });
     exe.root_module.addImport("shared", shared);

--- a/test/standalone/depend_on_main_mod/build.zig
+++ b/test/standalone/depend_on_main_mod/build.zig
@@ -9,13 +9,13 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "depend_on_main_mod",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const foo_module = b.addModule("foo", .{
-        .root_source_file = .{ .path = "src/foo.zig" },
+        .root_source_file = b.path("src/foo.zig"),
     });
 
     foo_module.addImport("root2", &exe.root_module);

--- a/test/standalone/dirname/build.zig
+++ b/test/standalone/dirname/build.zig
@@ -6,9 +6,7 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Test it");
     b.default_step = test_step;
 
-    const touch_src = std.Build.LazyPath{
-        .path = "touch.zig",
-    };
+    const touch_src = b.path("touch.zig");
 
     const touch = b.addExecutable(.{
         .name = "touch",
@@ -20,14 +18,14 @@ pub fn build(b: *std.Build) void {
 
     const exists_in = b.addExecutable(.{
         .name = "exists_in",
-        .root_source_file = .{ .path = "exists_in.zig" },
+        .root_source_file = b.path("exists_in.zig"),
         .optimize = .Debug,
         .target = target,
     });
 
     const has_basename = b.addExecutable(.{
         .name = "has_basename",
-        .root_source_file = .{ .path = "has_basename.zig" },
+        .root_source_file = b.path("has_basename.zig"),
         .optimize = .Debug,
         .target = target,
     });

--- a/test/standalone/embed_generated_file/build.zig
+++ b/test/standalone/embed_generated_file/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
 
     const bootloader = b.addExecutable(.{
         .name = "bootloader",
-        .root_source_file = .{ .path = "bootloader.zig" },
+        .root_source_file = b.path("bootloader.zig"),
         .target = b.resolveTargetQuery(.{
             .cpu_arch = .x86,
             .os_tag = .freestanding,
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const exe = b.addTest(.{
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = .Debug,
     });
     exe.root_module.addAnonymousImport("bootloader.elf", .{

--- a/test/standalone/empty_env/build.zig
+++ b/test/standalone/empty_env/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.Build) void {
 
     const main = b.addExecutable(.{
         .name = "main",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .target = b.host,
         .optimize = optimize,
     });

--- a/test/standalone/extern/build.zig
+++ b/test/standalone/extern/build.zig
@@ -5,12 +5,12 @@ pub fn build(b: *std.Build) void {
 
     const obj = b.addObject(.{
         .name = "exports",
-        .root_source_file = .{ .path = "exports.zig" },
+        .root_source_file = b.path("exports.zig"),
         .target = b.host,
         .optimize = optimize,
     });
     const main = b.addTest(.{
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
     });
     main.addObject(obj);

--- a/test/standalone/global_linkage/build.zig
+++ b/test/standalone/global_linkage/build.zig
@@ -9,20 +9,20 @@ pub fn build(b: *std.Build) void {
 
     const obj1 = b.addStaticLibrary(.{
         .name = "obj1",
-        .root_source_file = .{ .path = "obj1.zig" },
+        .root_source_file = b.path("obj1.zig"),
         .optimize = optimize,
         .target = target,
     });
 
     const obj2 = b.addStaticLibrary(.{
         .name = "obj2",
-        .root_source_file = .{ .path = "obj2.zig" },
+        .root_source_file = b.path("obj2.zig"),
         .optimize = optimize,
         .target = target,
     });
 
     const main = b.addTest(.{
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
     });
     main.linkLibrary(obj1);

--- a/test/standalone/install_headers/build.zig
+++ b/test/standalone/install_headers/build.zig
@@ -32,7 +32,7 @@ pub fn build(b: *std.Build) void {
         \\}
     ) });
 
-    libfoo.installHeadersDirectory(.{ .path = "include" }, "foo", .{ .exclude_extensions = &.{".ignore_me.h"} });
+    libfoo.installHeadersDirectory(b.path("include"), "foo", .{ .exclude_extensions = &.{".ignore_me.h"} });
     libfoo.installHeader(b.addWriteFiles().add("d.h",
         \\#define FOO_D "D"
         \\
@@ -78,7 +78,7 @@ pub fn build(b: *std.Build) void {
     });
     const check_exists = b.addExecutable(.{
         .name = "check_exists",
-        .root_source_file = .{ .path = "check_exists.zig" },
+        .root_source_file = b.path("check_exists.zig"),
         .target = b.resolveTargetQuery(.{}),
         .optimize = .Debug,
     });

--- a/test/standalone/install_raw_hex/build.zig
+++ b/test/standalone/install_raw_hex/build.zig
@@ -16,7 +16,7 @@ pub fn build(b: *std.Build) void {
 
     const elf = b.addExecutable(.{
         .name = "zig-nrf52-blink.elf",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/test/standalone/ios/build.zig
+++ b/test/standalone/ios/build.zig
@@ -21,10 +21,10 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .target = target,
     });
-    exe.addCSourceFile(.{ .file = .{ .path = "main.m" }, .flags = &.{} });
-    exe.addSystemIncludePath(.{ .path = b.pathJoin(&.{ sdk, "/usr/include" }) });
-    exe.addSystemFrameworkPath(.{ .path = b.pathJoin(&.{ sdk, "/System/Library/Frameworks" }) });
-    exe.addLibraryPath(.{ .path = b.pathJoin(&.{ sdk, "/usr/lib" }) });
+    exe.addCSourceFile(.{ .file = b.path("main.m"), .flags = &.{} });
+    exe.addSystemIncludePath(b.path(b.pathJoin(&.{ sdk, "/usr/include" })));
+    exe.addSystemFrameworkPath(b.path(b.pathJoin(&.{ sdk, "/System/Library/Frameworks" })));
+    exe.addLibraryPath(b.path(b.pathJoin(&.{ sdk, "/usr/lib" })));
     exe.linkFramework("Foundation");
     exe.linkFramework("UIKit");
     exe.linkLibC();

--- a/test/standalone/issue_11595/build.zig
+++ b/test/standalone/issue_11595/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "zigtest",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/test/standalone/issue_12706/build.zig
+++ b/test/standalone/issue_12706/build.zig
@@ -10,7 +10,7 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "main",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .target = target,
     });

--- a/test/standalone/issue_339/build.zig
+++ b/test/standalone/issue_339/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
 
     const obj = b.addObject(.{
         .name = "test",
-        .root_source_file = .{ .path = "test.zig" },
+        .root_source_file = b.path("test.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/test/standalone/issue_794/build.zig
+++ b/test/standalone/issue_794/build.zig
@@ -5,9 +5,9 @@ pub fn build(b: *std.Build) void {
     b.default_step = test_step;
 
     const test_artifact = b.addTest(.{
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
     });
-    test_artifact.addIncludePath(.{ .path = "a_directory" });
+    test_artifact.addIncludePath(b.path("a_directory"));
 
     // TODO: actually check the output
     _ = test_artifact.getEmittedBin();

--- a/test/standalone/issue_8550/build.zig
+++ b/test/standalone/issue_8550/build.zig
@@ -15,12 +15,12 @@ pub fn build(b: *std.Build) !void {
 
     const kernel = b.addExecutable(.{
         .name = "kernel",
-        .root_source_file = .{ .path = "./main.zig" },
+        .root_source_file = b.path("./main.zig"),
         .optimize = optimize,
         .target = target,
     });
-    kernel.addObjectFile(.{ .path = "./boot.S" });
-    kernel.setLinkerScript(.{ .path = "./linker.ld" });
+    kernel.addObjectFile(b.path("./boot.S"));
+    kernel.setLinkerScript(b.path("./linker.ld"));
     b.installArtifact(kernel);
 
     test_step.dependOn(&kernel.step);

--- a/test/standalone/load_dynamic_library/build.zig
+++ b/test/standalone/load_dynamic_library/build.zig
@@ -17,7 +17,7 @@ pub fn build(b: *std.Build) void {
 
     const lib = b.addSharedLibrary(.{
         .name = "add",
-        .root_source_file = .{ .path = "add.zig" },
+        .root_source_file = b.path("add.zig"),
         .version = .{ .major = 1, .minor = 0, .patch = 0 },
         .optimize = optimize,
         .target = target,
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) void {
 
     const main = b.addExecutable(.{
         .name = "main",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .target = target,
     });

--- a/test/standalone/mix_c_files/build.zig
+++ b/test/standalone/mix_c_files/build.zig
@@ -18,11 +18,11 @@ pub fn build(b: *std.Build) void {
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
     const exe = b.addExecutable(.{
         .name = "test",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .target = b.host,
         .optimize = optimize,
     });
-    exe.addCSourceFile(.{ .file = .{ .path = "test.c" }, .flags = &[_][]const u8{"-std=c11"} });
+    exe.addCSourceFile(.{ .file = b.path("test.c"), .flags = &[_][]const u8{"-std=c11"} });
     exe.linkLibC();
 
     const run_cmd = b.addRunArtifact(exe);

--- a/test/standalone/mix_o_files/build.zig
+++ b/test/standalone/mix_o_files/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
 
     const obj = b.addObject(.{
         .name = "base64",
-        .root_source_file = .{ .path = "base64.zig" },
+        .root_source_file = b.path("base64.zig"),
         .optimize = optimize,
         .target = target,
     });
@@ -20,7 +20,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
     });
     exe.addCSourceFile(.{
-        .file = .{ .path = "test.c" },
+        .file = b.path("test.c"),
         .flags = &[_][]const u8{"-std=c99"},
     });
     exe.addObject(obj);

--- a/test/standalone/pie/build.zig
+++ b/test/standalone/pie/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const main = b.addTest(.{
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .target = target,
     });

--- a/test/standalone/pkg_import/build.zig
+++ b/test/standalone/pkg_import/build.zig
@@ -8,11 +8,11 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "test",
-        .root_source_file = .{ .path = "test.zig" },
+        .root_source_file = b.path("test.zig"),
         .optimize = optimize,
         .target = b.host,
     });
-    exe.root_module.addAnonymousImport("my_pkg", .{ .root_source_file = .{ .path = "pkg.zig" } });
+    exe.root_module.addAnonymousImport("my_pkg", .{ .root_source_file = b.path("pkg.zig") });
 
     const run = b.addRunArtifact(exe);
     test_step.dependOn(&run.step);

--- a/test/standalone/self_exe_symlink/build.zig
+++ b/test/standalone/self_exe_symlink/build.zig
@@ -15,14 +15,14 @@ pub fn build(b: *std.Build) void {
 
     const main = b.addExecutable(.{
         .name = "main",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .target = target,
     });
 
     const create_symlink_exe = b.addExecutable(.{
         .name = "create-symlink",
-        .root_source_file = .{ .path = "create-symlink.zig" },
+        .root_source_file = b.path("create-symlink.zig"),
         .optimize = optimize,
         .target = target,
     });

--- a/test/standalone/shared_library/build.zig
+++ b/test/standalone/shared_library/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build) void {
     const target = b.host;
     const lib = b.addSharedLibrary(.{
         .name = "mathtest",
-        .root_source_file = .{ .path = "mathtest.zig" },
+        .root_source_file = b.path("mathtest.zig"),
         .version = .{ .major = 1, .minor = 0, .patch = 0 },
         .target = target,
         .optimize = optimize,
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     exe.addCSourceFile(.{
-        .file = .{ .path = "test.c" },
+        .file = b.path("test.c"),
         .flags = &[_][]const u8{"-std=c99"},
     });
     exe.linkLibrary(lib);

--- a/test/standalone/simple/build.zig
+++ b/test/standalone/simple/build.zig
@@ -42,7 +42,7 @@ pub fn build(b: *std.Build) void {
             if (case.is_exe) {
                 const exe = b.addExecutable(.{
                     .name = std.fs.path.stem(case.src_path),
-                    .root_source_file = .{ .path = case.src_path },
+                    .root_source_file = b.path(case.src_path),
                     .optimize = optimize,
                     .target = resolved_target,
                 });
@@ -56,7 +56,7 @@ pub fn build(b: *std.Build) void {
             if (case.is_test) {
                 const exe = b.addTest(.{
                     .name = std.fs.path.stem(case.src_path),
-                    .root_source_file = .{ .path = case.src_path },
+                    .root_source_file = b.path(case.src_path),
                     .optimize = optimize,
                     .target = resolved_target,
                 });

--- a/test/standalone/stack_iterator/build.zig
+++ b/test/standalone/stack_iterator/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) void {
     {
         const exe = b.addExecutable(.{
             .name = "unwind_fp",
-            .root_source_file = .{ .path = "unwind.zig" },
+            .root_source_file = b.path("unwind.zig"),
             .target = target,
             .optimize = optimize,
             .unwind_tables = if (target.result.isDarwin()) true else null,
@@ -42,7 +42,7 @@ pub fn build(b: *std.Build) void {
     {
         const exe = b.addExecutable(.{
             .name = "unwind_nofp",
-            .root_source_file = .{ .path = "unwind.zig" },
+            .root_source_file = b.path("unwind.zig"),
             .target = target,
             .optimize = optimize,
             .unwind_tables = true,
@@ -74,14 +74,14 @@ pub fn build(b: *std.Build) void {
             c_shared_lib.defineCMacro("LIB_API", "__declspec(dllexport)");
 
         c_shared_lib.addCSourceFile(.{
-            .file = .{ .path = "shared_lib.c" },
+            .file = b.path("shared_lib.c"),
             .flags = &.{"-fomit-frame-pointer"},
         });
         c_shared_lib.linkLibC();
 
         const exe = b.addExecutable(.{
             .name = "shared_lib_unwind",
-            .root_source_file = .{ .path = "shared_lib_unwind.zig" },
+            .root_source_file = b.path("shared_lib_unwind.zig"),
             .target = target,
             .optimize = optimize,
             .unwind_tables = if (target.result.isDarwin()) true else null,

--- a/test/standalone/static_c_lib/build.zig
+++ b/test/standalone/static_c_lib/build.zig
@@ -11,15 +11,15 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .target = b.host,
     });
-    foo.addCSourceFile(.{ .file = .{ .path = "foo.c" }, .flags = &[_][]const u8{} });
-    foo.addIncludePath(.{ .path = "." });
+    foo.addCSourceFile(.{ .file = b.path("foo.c"), .flags = &[_][]const u8{} });
+    foo.addIncludePath(b.path("."));
 
     const test_exe = b.addTest(.{
-        .root_source_file = .{ .path = "foo.zig" },
+        .root_source_file = b.path("foo.zig"),
         .optimize = optimize,
     });
     test_exe.linkLibrary(foo);
-    test_exe.addIncludePath(.{ .path = "." });
+    test_exe.addIncludePath(b.path("."));
 
     test_step.dependOn(&b.addRunArtifact(test_exe).step);
 }

--- a/test/standalone/strip_empty_loop/build.zig
+++ b/test/standalone/strip_empty_loop/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
 
     const main = b.addExecutable(.{
         .name = "main",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .target = target,
         .strip = true,

--- a/test/standalone/strip_struct_init/build.zig
+++ b/test/standalone/strip_struct_init/build.zig
@@ -7,7 +7,7 @@ pub fn build(b: *std.Build) void {
     const optimize: std.builtin.OptimizeMode = .Debug;
 
     const main = b.addTest(.{
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
         .strip = true,
     });

--- a/test/standalone/test_runner_module_imports/build.zig
+++ b/test/standalone/test_runner_module_imports/build.zig
@@ -2,13 +2,13 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     const t = b.addTest(.{
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .test_runner = b.path("test_runner/main.zig"),
     });
 
-    const module1 = b.createModule(.{ .root_source_file = .{ .path = "module1/main.zig" } });
+    const module1 = b.createModule(.{ .root_source_file = b.path("module1/main.zig") });
     const module2 = b.createModule(.{
-        .root_source_file = .{ .path = "module2/main.zig" },
+        .root_source_file = b.path("module2/main.zig"),
         .imports = &.{.{ .name = "module1", .module = module1 }},
     });
 

--- a/test/standalone/test_runner_path/build.zig
+++ b/test/standalone/test_runner_path/build.zig
@@ -7,7 +7,7 @@ pub fn build(b: *std.Build) void {
     b.default_step = test_step;
 
     const test_exe = b.addTest(.{
-        .root_source_file = .{ .path = "test.zig" },
+        .root_source_file = b.path("test.zig"),
     });
     test_exe.test_runner = b.path("test_runner.zig");
 

--- a/test/standalone/use_alias/build.zig
+++ b/test/standalone/use_alias/build.zig
@@ -7,10 +7,10 @@ pub fn build(b: *std.Build) void {
     const optimize: std.builtin.OptimizeMode = .Debug;
 
     const main = b.addTest(.{
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .optimize = optimize,
     });
-    main.addIncludePath(.{ .path = "." });
+    main.addIncludePath(b.path("."));
 
     test_step.dependOn(&b.addRunArtifact(main).step);
 }

--- a/test/standalone/windows_entry_points/build.zig
+++ b/test/standalone/windows_entry_points/build.zig
@@ -17,7 +17,7 @@ pub fn build(b: *std.Build) void {
             .optimize = .Debug,
             .link_libc = true,
         });
-        exe.addCSourceFile(.{ .file = .{ .path = "main.c" } });
+        exe.addCSourceFile(.{ .file = b.path("main.c") });
 
         _ = exe.getEmittedBin();
         test_step.dependOn(&exe.step);
@@ -31,7 +31,7 @@ pub fn build(b: *std.Build) void {
             .link_libc = true,
         });
         exe.mingw_unicode_entry_point = true;
-        exe.addCSourceFile(.{ .file = .{ .path = "wmain.c" } });
+        exe.addCSourceFile(.{ .file = b.path("wmain.c") });
 
         _ = exe.getEmittedBin();
         test_step.dependOn(&exe.step);
@@ -45,7 +45,7 @@ pub fn build(b: *std.Build) void {
             .link_libc = true,
         });
         // Note: `exe.subsystem = .Windows;` is not necessary
-        exe.addCSourceFile(.{ .file = .{ .path = "winmain.c" } });
+        exe.addCSourceFile(.{ .file = b.path("winmain.c") });
 
         _ = exe.getEmittedBin();
         test_step.dependOn(&exe.step);
@@ -60,7 +60,7 @@ pub fn build(b: *std.Build) void {
         });
         exe.mingw_unicode_entry_point = true;
         // Note: `exe.subsystem = .Windows;` is not necessary
-        exe.addCSourceFile(.{ .file = .{ .path = "wwinmain.c" } });
+        exe.addCSourceFile(.{ .file = b.path("wwinmain.c") });
 
         _ = exe.getEmittedBin();
         test_step.dependOn(&exe.step);

--- a/test/standalone/windows_resources/build.zig
+++ b/test/standalone/windows_resources/build.zig
@@ -25,12 +25,12 @@ fn add(
 ) void {
     const exe = b.addExecutable(.{
         .name = "zig_resource_test",
-        .root_source_file = .{ .path = "main.zig" },
+        .root_source_file = b.path("main.zig"),
         .target = target,
         .optimize = .Debug,
     });
     exe.addWin32ResourceFile(.{
-        .file = .{ .path = "res/zig.rc" },
+        .file = b.path("res/zig.rc"),
         .flags = &.{"/c65001"}, // UTF-8 code page
     });
     exe.rc_includes = switch (rc_includes) {

--- a/test/standalone/zerolength_check/build.zig
+++ b/test/standalone/zerolength_check/build.zig
@@ -12,7 +12,7 @@ pub fn build(b: *std.Build) void {
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
     const unit_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = b.resolveTargetQuery(.{
             .os_tag = .wasi,
             .cpu_arch = .wasm32,

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -641,7 +641,7 @@ pub fn addStackTraceTests(
 ) *Step {
     const check_exe = b.addExecutable(.{
         .name = "check-stack-trace",
-        .root_source_file = .{ .path = "test/src/check-stack-trace.zig" },
+        .root_source_file = b.path("test/src/check-stack-trace.zig"),
         .target = b.host,
         .optimize = .Debug,
     });
@@ -879,7 +879,7 @@ pub fn addCliTests(b: *std.Build) *Step {
         run6.step.dependOn(&write6.step);
 
         // TODO change this to an exact match
-        const check6 = b.addCheckFile(.{ .path = fmt6_path }, .{
+        const check6 = b.addCheckFile(.{ .cwd_relative = fmt6_path }, .{
             .expected_matches = &.{
                 "// no reason",
             },
@@ -1037,7 +1037,7 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
             options.max_rss;
 
         const these_tests = b.addTest(.{
-            .root_source_file = .{ .path = options.root_src },
+            .root_source_file = b.path(options.root_src),
             .optimize = test_target.optimize_mode,
             .target = resolved_target,
             .max_rss = max_rss,
@@ -1046,7 +1046,7 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
             .single_threaded = test_target.single_threaded,
             .use_llvm = test_target.use_llvm,
             .use_lld = test_target.use_lld,
-            .zig_lib_dir = .{ .path = "lib" },
+            .zig_lib_dir = b.path("lib"),
             .pic = test_target.pic,
             .strip = test_target.strip,
         });
@@ -1062,7 +1062,7 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
         const use_lld = if (test_target.use_lld == false) "-no-lld" else "";
         const use_pic = if (test_target.pic == true) "-pic" else "";
 
-        for (options.include_paths) |include_path| these_tests.addIncludePath(.{ .path = include_path });
+        for (options.include_paths) |include_path| these_tests.addIncludePath(b.path(include_path));
 
         const qualified_name = b.fmt("{s}-{s}-{s}-{s}{s}{s}{s}{s}{s}", .{
             options.name,
@@ -1084,7 +1084,7 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
                 .name = qualified_name,
                 .link_libc = test_target.link_libc,
                 .target = b.resolveTargetQuery(altered_query),
-                .zig_lib_dir = .{ .path = "lib" },
+                .zig_lib_dir = b.path("lib"),
             });
             compile_c.addCSourceFile(.{
                 .file = these_tests.getEmittedBin(),
@@ -1113,7 +1113,7 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
                     "-Wno-absolute-value",
                 },
             });
-            compile_c.addIncludePath(.{ .path = "lib" }); // for zig.h
+            compile_c.addIncludePath(b.path("lib")); // for zig.h
             if (target.os.tag == .windows) {
                 if (true) {
                     // Unfortunately this requires about 8G of RAM for clang to compile
@@ -1189,7 +1189,7 @@ pub fn addCAbiTests(b: *std.Build, skip_non_native: bool, skip_release: bool) *S
                     if (c_abi_target.use_lld == false) "-no-lld" else "",
                     if (c_abi_target.pic == true) "-pic" else "",
                 }),
-                .root_source_file = .{ .path = "test/c_abi/main.zig" },
+                .root_source_file = b.path("test/c_abi/main.zig"),
                 .target = resolved_target,
                 .optimize = optimize_mode,
                 .link_libc = true,
@@ -1199,7 +1199,7 @@ pub fn addCAbiTests(b: *std.Build, skip_non_native: bool, skip_release: bool) *S
                 .strip = c_abi_target.strip,
             });
             test_step.addCSourceFile(.{
-                .file = .{ .path = "test/c_abi/cfuncs.c" },
+                .file = b.path("test/c_abi/cfuncs.c"),
                 .flags = &.{"-std=c99"},
             });
             for (c_abi_target.c_defines) |define| test_step.defineCMacro(define, null);


### PR DESCRIPTION
The first commit deletes the deprecated API and then makes all the upgrades needed to pass the standalone tests.

The second commit reverts the API breakage. The second commit can be reverted once 0.12.0 is tagged.

@castholm re:
> 'path' lazy paths are relative to the build root of some step, inferred from the step
> in which they are used. This means that we can't dupe such paths, because they may
> come from dependencies with their own build roots and duping the paths as is might
> cause the build script to search for the file relative to the wrong root.
> As a temporary workaround, we convert build root-relative paths to absolute paths.
> If/when the build-root relative paths are updated to encode which build root they are
> relative to, this workaround should be removed.

The `*Build` argument to LazyPath.dupe was only being used for its allocator, and all instances share the same allocator. So converting a path prematurely to an absolute path was unnecessary and introduced unwanted absolute paths.

```diff
-    /// Duplicates the file source for a given builder.
+    /// Copies the internal strings.
+    ///
+    /// The `b` parameter is only used for its allocator. All *Build instances
+    /// share the same allocator.
     pub fn dupe(self: LazyPath, b: *Build) LazyPath {
```