### PR TITLE
translate-c: allow str literals in bool expressions

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -2086,6 +2086,11 @@ fn finishBoolExpr(
             }
         },
         .Pointer => {
+            if (node.tag() == .string_literal) {
+                // @intFromPtr(node) != 0
+                const int_from_ptr = try Tag.int_from_ptr.create(c.arena, node);
+                return Tag.not_equal.create(c.arena, .{ .lhs = int_from_ptr, .rhs = Tag.zero_literal.init() });
+            }
             // node != null
             return Tag.not_equal.create(c.arena, .{ .lhs = node, .rhs = Tag.null_literal.init() });
         },
@@ -5794,10 +5799,11 @@ fn macroIntToBool(c: *Context, node: Node) !Node {
         return node;
     }
     if (node.tag() == .string_literal) {
+        // @intFromPtr(node) != 0
         const int_from_ptr = try Tag.int_from_ptr.create(c.arena, node);
         return Tag.not_equal.create(c.arena, .{ .lhs = int_from_ptr, .rhs = Tag.zero_literal.init() });
     }
-
+    // node != 0
     return Tag.not_equal.create(c.arena, .{ .lhs = node, .rhs = Tag.zero_literal.init() });
 }
 

--- a/test/cases/translate_c/strlit_as_bool.c
+++ b/test/cases/translate_c/strlit_as_bool.c
@@ -1,0 +1,8 @@
+void foo() { if(0 && "error message") {} }
+
+// translate-c
+// c_frontend=clang
+//
+// pub export fn foo() void {
+//     if (false and (@intFromPtr("error message") != 0)) {}
+// }


### PR DESCRIPTION
this is a follow up to #19610 with fix suggested by @Vexu in https://github.com/ziglang/zig/issues/14642#issuecomment-2048999384