### PR TITLE
std.start.callMain: make error exit status configurable

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -513,7 +513,7 @@ pub inline fn callMain() u8 {
                 if (@errorReturnTrace()) |trace| {
                     std.debug.dumpStackTrace(trace.*);
                 }
-                return 1;
+                return std.options.error_exit_status;
             };
             switch (@typeInfo(@TypeOf(result))) {
                 .Void => return 0,

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -158,6 +158,9 @@ pub const Options = struct {
     http_disable_tls: bool = false,
 
     side_channels_mitigations: crypto.SideChannelsMitigations = crypto.default_side_channels_mitigations,
+
+    /// The exit status used when an error is returned from main
+    error_exit_status: u8 = 1,
 };
 
 // This forces the start.zig file to be imported, and the comptime logic inside that


### PR DESCRIPTION
Closes #19628.

The linked issue isn't yet accepted, but given how small the required change is, I thought I'd just make a PR in the proposed issue is deemed acceptable.

