### PR TITLE
std.Build.Step.ConfigHeader: better error message

### DIFF
--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -203,7 +203,11 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         .cmake => |file_source| {
             try output.appendSlice(c_generated_line);
             const src_path = file_source.getPath(b);
-            const contents = try std.fs.cwd().readFileAlloc(arena, src_path, self.max_bytes);
+            const contents = std.fs.cwd().readFileAlloc(arena, src_path, self.max_bytes) catch |err| {
+                return step.fail("unable to read cmake input file '{s}': {s}", .{
+                    src_path, @errorName(err),
+                });
+            };
             try render_cmake(step, contents, &output, self.values, src_path);
         },
         .blank => {


### PR DESCRIPTION
Following in the steps of https://github.com/ziglang/zig/pull/19642