### PR TITLE
NetBSD 10.0 fixes

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2480,7 +2480,7 @@ fn linkWithLLD(self: *Elf, arena: Allocator, prog_node: *std.Progress.Node) !voi
             try argv.append("-pie");
         }
 
-        if (is_dyn_lib and target.os.tag == .netbsd) {
+        if (is_exe_or_dyn_lib and target.os.tag == .netbsd) {
             // Add options to produce shared objects with only 2 PT_LOAD segments.
             // NetBSD expects 2 PT_LOAD segments in a shared object, otherwise
             // ld.elf_so fails loading dynamic libraries with "not found" error.


### PR DESCRIPTION
1. find local/pkg headers & libs
2. avoid ldd error on executables too:
    $ ldd -v main_4segs
    .../main_4segs: wrong number of segments (4 != 2)
    .../main_4segs: invalid ELF class 2; expected 1

related issue https://github.com/ziglang/zig/issues/9109 and PR https://github.com/ziglang/zig/pull/9131