### PR TITLE
std.fs.Dir.openFile: use wasi libc API when -lc

### DIFF
--- a/lib/std/c/wasi.zig
+++ b/lib/std/c/wasi.zig
@@ -40,12 +40,6 @@ pub const E = wasi.errno_t;
 
 pub const CLOCK = wasi.clockid_t;
 pub const IOV_MAX = 1024;
-pub const LOCK = struct {
-    pub const SH = 0x1;
-    pub const EX = 0x2;
-    pub const NB = 0x4;
-    pub const UN = 0x8;
-};
 pub const S = struct {
     pub const IEXEC = @compileError("TODO audit this");
     pub const IFBLK = 0x6000;

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -1602,6 +1602,10 @@ pub fn openZ(file_path: [*:0]const u8, flags: O, perm: mode_t) OpenError!fd_t {
             .PERM => return error.AccessDenied,
             .EXIST => return error.PathAlreadyExists,
             .BUSY => return error.DeviceBusy,
+            .ILSEQ => |err| if (native_os == .wasi)
+                return error.InvalidUtf8
+            else
+                return unexpectedErrno(err),
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -1771,6 +1775,10 @@ pub fn openatZ(dir_fd: fd_t, file_path: [*:0]const u8, flags: O, mode: mode_t) O
             .OPNOTSUPP => return error.FileLocksNotSupported,
             .AGAIN => return error.WouldBlock,
             .TXTBSY => return error.FileBusy,
+            .ILSEQ => |err| if (native_os == .wasi)
+                return error.InvalidUtf8
+            else
+                return unexpectedErrno(err),
             else => |err| return unexpectedErrno(err),
         }
     }


### PR DESCRIPTION
Also removes the LOCK namespace from std.c.wasi because wasi libc does not have flock.

closes #19336
related to #19352

```
[nix-shell:~/dev/zig/build-release]$ stage4/bin/zig build-exe test.zig -lc -target wasm32-wasi 

[nix-shell:~/dev/zig/build-release]$ wasmtime --dir /tmp --dir . ./test.wasm 
error: FileNotFound
Unable to dump stack trace: not implemented for Wasm
```