### PR TITLE
Sema: cap depth of value printing in type names

### DIFF
--- a/src/Value.zig
+++ b/src/Value.zig
@@ -44,7 +44,12 @@ pub fn fmtValue(val: Value, mod: *Module, opt_sema: ?*Sema) std.fmt.Formatter(pr
         .val = val,
         .mod = mod,
         .opt_sema = opt_sema,
+        .depth = 3,
     } };
+}
+
+pub fn fmtValueFull(ctx: print_value.FormatContext) std.fmt.Formatter(print_value.format) {
+    return .{ .data = ctx };
 }
 
 /// Converts `val` to a null-terminated string stored in the InternPool.

--- a/src/print_value.zig
+++ b/src/print_value.zig
@@ -14,10 +14,11 @@ const Target = std.Target;
 const max_aggregate_items = 100;
 const max_string_len = 256;
 
-const FormatContext = struct {
+pub const FormatContext = struct {
     val: Value,
     mod: *Module,
     opt_sema: ?*Sema,
+    depth: u8,
 };
 
 pub fn format(
@@ -28,7 +29,7 @@ pub fn format(
 ) !void {
     _ = options;
     comptime std.debug.assert(fmt.len == 0);
-    return print(ctx.val, writer, 3, ctx.mod, ctx.opt_sema) catch |err| switch (err) {
+    return print(ctx.val, writer, ctx.depth, ctx.mod, ctx.opt_sema) catch |err| switch (err) {
         error.OutOfMemory => @panic("OOM"), // We're not allowed to return this from a format function
         error.ComptimeBreak, error.ComptimeReturn => unreachable,
         error.AnalysisFail, error.NeededSourceLocation => unreachable, // TODO: re-evaluate when we use `opt_sema` more fully


### PR DESCRIPTION
Certain types (notably, `std.ComptimeStringMap`) were resulting in excessively long type names when instantiated, which in turn resulted in excessively long symbol names. These are problematic for two reasons:

* Symbol names are sometimes read by humans -- they ought to be readable.
* Some other applications (looking at you, xcode) trip on very long symbol names.

To work around this for now, we cap the depth of value printing at 1, as opposed to the normal 3. This doesn't guarantee anything -- there could still be, for instance, an incredibly long aggregate -- but it works around the issue in practice for the time being.