### PR TITLE
std.Build: revert --host-target, --host-cpu, --host-dynamic-linker

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -70,6 +70,10 @@ pub fn main() !void {
         .zig_exe = zig_exe,
         .env_map = try process.getEnvMap(arena),
         .global_cache_root = global_cache_directory,
+        .host = .{
+            .query = .{},
+            .result = try std.zig.system.resolveTargetQuery(.{}),
+        },
     };
 
     graph.cache.addPrefix(.{ .path = null, .handle = std.fs.cwd() });
@@ -142,12 +146,6 @@ pub fn main() !void {
                         arg, text,
                     });
                 };
-            } else if (mem.eql(u8, arg, "--host-target")) {
-                graph.host_query_options.arch_os_abi = nextArgOrFatal(args, &arg_idx);
-            } else if (mem.eql(u8, arg, "--host-cpu")) {
-                graph.host_query_options.cpu_features = nextArgOrFatal(args, &arg_idx);
-            } else if (mem.eql(u8, arg, "--host-dynamic-linker")) {
-                graph.host_query_options.dynamic_linker = nextArgOrFatal(args, &arg_idx);
             } else if (mem.eql(u8, arg, "--prefix-lib-dir")) {
                 dir_list.lib_dir = nextArgOrFatal(args, &arg_idx);
             } else if (mem.eql(u8, arg, "--prefix-exe-dir")) {
@@ -282,14 +280,6 @@ pub fn main() !void {
             try targets.append(arg);
         }
     }
-
-    const host_query = std.Build.parseTargetQuery(graph.host_query_options) catch |err| switch (err) {
-        error.ParseFailed => process.exit(1),
-    };
-    builder.host = .{
-        .query = .{},
-        .result = try std.zig.system.resolveTargetQuery(host_query),
-    };
 
     const stderr = std.io.getStdErr();
     const ttyconf = get_tty_conf(color, stderr);
@@ -1170,10 +1160,6 @@ fn usage(b: *std.Build, out_stream: anytype) !void {
         \\  --search-prefix [path]       Add a path to look for binaries, libraries, headers
         \\  --sysroot [path]             Set the system root directory (usually /)
         \\  --libc [file]                Provide a file which specifies libc paths
-        \\
-        \\  --host-target [triple]       Use the provided target as the host
-        \\  --host-cpu [cpu]             Use the provided CPU as the host
-        \\  --host-dynamic-linker [path] Use the provided dynamic linker as the host
         \\
         \\  --system [pkgdir]            Disable package fetching; enable all integrations
         \\  -fsys=[name]                 Enable a system integration

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1011,16 +1011,6 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     };
     try zig_args.append(cmd);
 
-    if (!mem.eql(u8, b.graph.host_query_options.arch_os_abi, "native")) {
-        try zig_args.appendSlice(&.{ "--host-target", b.graph.host_query_options.arch_os_abi });
-    }
-    if (b.graph.host_query_options.cpu_features) |cpu| {
-        try zig_args.appendSlice(&.{ "--host-cpu", cpu });
-    }
-    if (b.graph.host_query_options.dynamic_linker) |dl| {
-        try zig_args.appendSlice(&.{ "--host-dynamic-linker", dl });
-    }
-
     if (b.reference_trace) |some| {
         try zig_args.append(try std.fmt.allocPrint(arena, "-freference-trace={d}", .{some}));
     }

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -516,6 +516,10 @@ test Options {
         .zig_exe = "test",
         .env_map = std.process.EnvMap.init(arena.allocator()),
         .global_cache_root = .{ .path = "test", .handle = std.fs.cwd() },
+        .host = .{
+            .query = .{},
+            .result = try std.zig.system.resolveTargetQuery(.{}),
+        },
     };
 
     var builder = try std.Build.create(
@@ -524,11 +528,6 @@ test Options {
         .{ .path = "test", .handle = std.fs.cwd() },
         &.{},
     );
-
-    builder.host = .{
-        .query = .{},
-        .result = try std.zig.system.resolveTargetQuery(.{}),
-    };
 
     const options = builder.addOptions();
 

--- a/lib/std/Target/Query.zig
+++ b/lib/std/Target/Query.zig
@@ -362,12 +362,16 @@ pub fn isNativeAbi(self: Query) bool {
     return self.os_tag == null and self.abi == null;
 }
 
-pub fn isNative(self: Query) bool {
+pub fn isNativeTriple(self: Query) bool {
     return self.isNativeCpu() and self.isNativeOs() and self.isNativeAbi();
 }
 
+pub fn isNative(self: Query) bool {
+    return self.isNativeTriple() and self.ofmt == null;
+}
+
 pub fn canDetectLibC(self: Query) bool {
-    if (self.isNative()) return true;
+    if (self.isNativeOs()) return true;
     if (self.os_tag) |os| {
         if (builtin.os.tag == .macos and os.isDarwin()) return true;
         if (os == .linux and self.abi == .android) return true;
@@ -386,9 +390,8 @@ fn formatVersion(version: SemanticVersion, writer: anytype) !void {
 }
 
 pub fn zigTriple(self: Query, allocator: Allocator) Allocator.Error![]u8 {
-    if (self.isNative()) {
+    if (self.isNativeTriple())
         return allocator.dupe(u8, "native");
-    }
 
     const arch_name = if (self.cpu_arch) |arch| @tagName(arch) else "native";
     const os_name = if (self.os_tag) |os_tag| @tagName(os_tag) else "native";

--- a/src/main.zig
+++ b/src/main.zig
@@ -985,9 +985,6 @@ fn buildOutputType(
         .libc_paths_file = try EnvVar.ZIG_LIBC.get(arena),
         .link_objects = .{},
         .native_system_include_paths = &.{},
-        .host_triple = null,
-        .host_cpu = null,
-        .host_dynamic_linker = null,
     };
 
     // before arg parsing, check for the NO_COLOR environment variable
@@ -1285,12 +1282,6 @@ fn buildOutputType(
                         mod_opts.optimize_mode = parseOptimizeMode(arg["-O".len..]);
                     } else if (mem.eql(u8, arg, "--dynamic-linker")) {
                         create_module.dynamic_linker = args_iter.nextOrFatal();
-                    } else if (mem.eql(u8, arg, "--host-target")) {
-                        create_module.host_triple = args_iter.nextOrFatal();
-                    } else if (mem.eql(u8, arg, "--host-cpu")) {
-                        create_module.host_cpu = args_iter.nextOrFatal();
-                    } else if (mem.eql(u8, arg, "--host-dynamic-linker")) {
-                        create_module.host_dynamic_linker = args_iter.nextOrFatal();
                     } else if (mem.eql(u8, arg, "--sysroot")) {
                         const next_arg = args_iter.nextOrFatal();
                         create_module.sysroot = next_arg;
@@ -3521,9 +3512,6 @@ const CreateModule = struct {
     each_lib_rpath: ?bool,
     libc_paths_file: ?[]const u8,
     link_objects: std.ArrayListUnmanaged(Compilation.LinkObject),
-    host_triple: ?[]const u8,
-    host_cpu: ?[]const u8,
-    host_dynamic_linker: ?[]const u8,
 };
 
 fn createModule(
@@ -3605,15 +3593,7 @@ fn createModule(
         }
 
         const target_query = std.zig.parseTargetQueryOrReportFatalError(arena, target_parse_options);
-        const adjusted_target_query = a: {
-            if (!target_query.isNative()) break :a target_query;
-            if (create_module.host_triple) |triple| target_parse_options.arch_os_abi = triple;
-            if (create_module.host_cpu) |cpu| target_parse_options.cpu_features = cpu;
-            if (create_module.host_dynamic_linker) |dl| target_parse_options.dynamic_linker = dl;
-            break :a std.zig.parseTargetQueryOrReportFatalError(arena, target_parse_options);
-        };
-
-        const target = std.zig.resolveTargetQueryOrFatal(adjusted_target_query);
+        const target = std.zig.resolveTargetQueryOrFatal(target_query);
         break :t .{
             .result = target,
             .is_native_os = target_query.isNativeOs(),


### PR DESCRIPTION
This is a partial revert of 105db13536b4dc2affe130cb8d2eee6c97c89bcd.

As we learned from Chimera Linux packaging, these options are not actually helpful since the distribution package manager may very well want to cross-compile the packages that it is building.

So, let's not overcomplicate things. There are already the options `-Dtarget`, `-Dcpu`, and `-Ddynamic-linker` created by [standardTargetOptions](https://ziglang.org/documentation/master/std/#std.Build.standardTargetOptions).

These options are generally provided when the project generates machine code artifacts, however, there may be a project that does no such thing, in which case it makes sense for these options to be missing. The Zig Build System is a general-purpose build system, after all.

cc @ifreund 