### PR TITLE
llvm: fix debug info when running tests

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -865,7 +865,7 @@ pub const Object = struct {
             // a terrible tragedy.
             const compile_unit_dir = blk: {
                 if (comp.module) |zcu| m: {
-                    const d = try zcu.root_mod.root.joinString(arena, "");
+                    const d = try zcu.main_mod.root.joinString(arena, "");
                     if (d.len == 0) break :m;
                     if (std.fs.path.isAbsolute(d)) break :blk d;
                     break :blk std.fs.realpathAlloc(arena, d) catch break :blk d;


### PR DESCRIPTION
After this change, both the main source file and the test runner root file have the correct paths.