### PR TITLE
std.process.Child: Mitigate arbitrary command execution vulnerability on Windows (BatBadBut)

### DIFF
--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -243,6 +243,8 @@ pub extern "kernel32" fn GetSystemInfo(lpSystemInfo: *SYSTEM_INFO) callconv(WINA
 pub extern "kernel32" fn GetSystemTimeAsFileTime(*FILETIME) callconv(WINAPI) void;
 pub extern "kernel32" fn IsProcessorFeaturePresent(ProcessorFeature: DWORD) BOOL;
 
+pub extern "kernel32" fn GetSystemDirectoryW(lpBuffer: LPWSTR, uSize: UINT) callconv(WINAPI) UINT;
+
 pub extern "kernel32" fn HeapCreate(flOptions: DWORD, dwInitialSize: SIZE_T, dwMaximumSize: SIZE_T) callconv(WINAPI) ?HANDLE;
 pub extern "kernel32" fn HeapDestroy(hHeap: HANDLE) callconv(WINAPI) BOOL;
 pub extern "kernel32" fn HeapReAlloc(hHeap: HANDLE, dwFlags: DWORD, lpMem: *anyopaque, dwBytes: SIZE_T) callconv(WINAPI) ?*anyopaque;

--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -107,6 +107,9 @@
         .windows_argv = .{
             .path = "windows_argv",
         },
+        .windows_bat_args = .{
+            .path = "windows_bat_args",
+        },
         .self_exe_symlink = .{
             .path = "self_exe_symlink",
         },

--- a/test/standalone/windows_bat_args/build.zig
+++ b/test/standalone/windows_bat_args/build.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub fn build(b: *std.Build) !void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    const optimize: std.builtin.OptimizeMode = .Debug;
+    const target = b.host;
+
+    if (builtin.os.tag != .windows) return;
+
+    const echo_args = b.addExecutable(.{
+        .name = "echo-args",
+        .root_source_file = b.path("echo-args.zig"),
+        .optimize = optimize,
+        .target = target,
+    });
+
+    const test_exe = b.addExecutable(.{
+        .name = "test",
+        .root_source_file = b.path("test.zig"),
+        .optimize = optimize,
+        .target = target,
+    });
+
+    const run = b.addRunArtifact(test_exe);
+    run.addArtifactArg(echo_args);
+    run.expectExitCode(0);
+    run.skip_foreign_checks = true;
+
+    test_step.dependOn(&run.step);
+
+    const fuzz = b.addExecutable(.{
+        .name = "fuzz",
+        .root_source_file = b.path("fuzz.zig"),
+        .optimize = optimize,
+        .target = target,
+    });
+
+    const fuzz_max_iterations = b.option(u64, "iterations", "The max fuzz iterations (default: 100)") orelse 100;
+    const fuzz_iterations_arg = std.fmt.allocPrint(b.allocator, "{}", .{fuzz_max_iterations}) catch @panic("oom");
+
+    const fuzz_seed = b.option(u64, "seed", "Seed to use for the PRNG (default: random)") orelse seed: {
+        var buf: [8]u8 = undefined;
+        try std.posix.getrandom(&buf);
+        break :seed std.mem.readInt(u64, &buf, builtin.cpu.arch.endian());
+    };
+    const fuzz_seed_arg = std.fmt.allocPrint(b.allocator, "{}", .{fuzz_seed}) catch @panic("oom");
+
+    const fuzz_run = b.addRunArtifact(fuzz);
+    fuzz_run.addArtifactArg(echo_args);
+    fuzz_run.addArgs(&.{ fuzz_iterations_arg, fuzz_seed_arg });
+    fuzz_run.expectExitCode(0);
+    fuzz_run.skip_foreign_checks = true;
+
+    test_step.dependOn(&fuzz_run.step);
+}

--- a/test/standalone/windows_bat_args/echo-args.zig
+++ b/test/standalone/windows_bat_args/echo-args.zig
@@ -1,0 +1,14 @@
+const std = @import("std");
+
+pub fn main() !void {
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const stdout = std.io.getStdOut().writer();
+    var args = try std.process.argsAlloc(arena);
+    for (args[1..], 1..) |arg, i| {
+        try stdout.writeAll(arg);
+        if (i != args.len - 1) try stdout.writeByte('\x00');
+    }
+}

--- a/test/standalone/windows_bat_args/fuzz.zig
+++ b/test/standalone/windows_bat_args/fuzz.zig
@@ -1,0 +1,160 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+
+pub fn main() anyerror!void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer if (gpa.deinit() == .leak) @panic("found memory leaks");
+    const allocator = gpa.allocator();
+
+    var it = try std.process.argsWithAllocator(allocator);
+    defer it.deinit();
+    _ = it.next() orelse unreachable; // skip binary name
+    const child_exe_path = it.next() orelse unreachable;
+
+    const iterations: u64 = iterations: {
+        const arg = it.next() orelse "0";
+        break :iterations try std.fmt.parseUnsigned(u64, arg, 10);
+    };
+
+    var rand_seed = false;
+    const seed: u64 = seed: {
+        const seed_arg = it.next() orelse {
+            rand_seed = true;
+            var buf: [8]u8 = undefined;
+            try std.posix.getrandom(&buf);
+            break :seed std.mem.readInt(u64, &buf, builtin.cpu.arch.endian());
+        };
+        break :seed try std.fmt.parseUnsigned(u64, seed_arg, 10);
+    };
+    var random = std.rand.DefaultPrng.init(seed);
+    const rand = random.random();
+
+    // If the seed was not given via the CLI, then output the
+    // randomly chosen seed so that this run can be reproduced
+    if (rand_seed) {
+        std.debug.print("rand seed: {}\n", .{seed});
+    }
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.setAsCwd();
+    defer tmp.parent_dir.setAsCwd() catch {};
+
+    var buf = try std.ArrayList(u8).initCapacity(allocator, 128);
+    defer buf.deinit();
+    try buf.appendSlice("@echo off\n");
+    try buf.append('"');
+    try buf.appendSlice(child_exe_path);
+    try buf.append('"');
+    const preamble_len = buf.items.len;
+
+    try buf.appendSlice(" %*");
+    try tmp.dir.writeFile("args1.bat", buf.items);
+    buf.shrinkRetainingCapacity(preamble_len);
+
+    try buf.appendSlice(" %1 %2 %3 %4 %5 %6 %7 %8 %9");
+    try tmp.dir.writeFile("args2.bat", buf.items);
+    buf.shrinkRetainingCapacity(preamble_len);
+
+    try buf.appendSlice(" \"%~1\" \"%~2\" \"%~3\" \"%~4\" \"%~5\" \"%~6\" \"%~7\" \"%~8\" \"%~9\"");
+    try tmp.dir.writeFile("args3.bat", buf.items);
+    buf.shrinkRetainingCapacity(preamble_len);
+
+    var i: u64 = 0;
+    while (iterations == 0 or i < iterations) {
+        const rand_arg = try randomArg(allocator, rand);
+        defer allocator.free(rand_arg);
+
+        try testExec(allocator, &.{rand_arg}, null);
+
+        i += 1;
+    }
+}
+
+fn testExec(allocator: std.mem.Allocator, args: []const []const u8, env: ?*std.process.EnvMap) !void {
+    try testExecBat(allocator, "args1.bat", args, env);
+    try testExecBat(allocator, "args2.bat", args, env);
+    try testExecBat(allocator, "args3.bat", args, env);
+}
+
+fn testExecBat(allocator: std.mem.Allocator, bat: []const u8, args: []const []const u8, env: ?*std.process.EnvMap) !void {
+    var argv = try std.ArrayList([]const u8).initCapacity(allocator, 1 + args.len);
+    defer argv.deinit();
+    argv.appendAssumeCapacity(bat);
+    argv.appendSliceAssumeCapacity(args);
+
+    const can_have_trailing_empty_args = std.mem.eql(u8, bat, "args3.bat");
+
+    const result = try std.ChildProcess.run(.{
+        .allocator = allocator,
+        .env_map = env,
+        .argv = argv.items,
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    try std.testing.expectEqualStrings("", result.stderr);
+    var it = std.mem.splitScalar(u8, result.stdout, '\x00');
+    var i: usize = 0;
+    while (it.next()) |actual_arg| {
+        if (i >= args.len and can_have_trailing_empty_args) {
+            try std.testing.expectEqualStrings("", actual_arg);
+            continue;
+        }
+        const expected_arg = args[i];
+        try std.testing.expectEqualSlices(u8, expected_arg, actual_arg);
+        i += 1;
+    }
+}
+
+fn randomArg(allocator: Allocator, rand: std.rand.Random) ![]const u8 {
+    const Choice = enum {
+        backslash,
+        quote,
+        space,
+        control,
+        printable,
+        surrogate_half,
+        non_ascii,
+    };
+
+    const choices = rand.uintAtMostBiased(u16, 256);
+    var buf = try std.ArrayList(u8).initCapacity(allocator, choices);
+    errdefer buf.deinit();
+
+    var last_codepoint: u21 = 0;
+    for (0..choices) |_| {
+        const choice = rand.enumValue(Choice);
+        const codepoint: u21 = switch (choice) {
+            .backslash => '\\',
+            .quote => '"',
+            .space => ' ',
+            .control => switch (rand.uintAtMostBiased(u8, 0x21)) {
+                // NUL/CR/LF can't roundtrip
+                '\x00', '\r', '\n' => ' ',
+                0x21 => '\x7F',
+                else => |b| b,
+            },
+            .printable => '!' + rand.uintAtMostBiased(u8, '~' - '!'),
+            .surrogate_half => rand.intRangeAtMostBiased(u16, 0xD800, 0xDFFF),
+            .non_ascii => rand.intRangeAtMostBiased(u21, 0x80, 0x10FFFF),
+        };
+        // Ensure that we always return well-formed WTF-8.
+        // Instead of concatenating to ensure well-formed WTF-8,
+        // we just skip encoding the low surrogate.
+        if (std.unicode.isSurrogateCodepoint(last_codepoint) and std.unicode.isSurrogateCodepoint(codepoint)) {
+            if (std.unicode.utf16IsHighSurrogate(@intCast(last_codepoint)) and std.unicode.utf16IsLowSurrogate(@intCast(codepoint))) {
+                continue;
+            }
+        }
+        try buf.ensureUnusedCapacity(4);
+        const unused_slice = buf.unusedCapacitySlice();
+        const len = std.unicode.wtf8Encode(codepoint, unused_slice) catch unreachable;
+        buf.items.len += len;
+        last_codepoint = codepoint;
+    }
+
+    return buf.toOwnedSlice();
+}

--- a/test/standalone/windows_bat_args/test.zig
+++ b/test/standalone/windows_bat_args/test.zig
@@ -1,0 +1,132 @@
+const std = @import("std");
+
+pub fn main() anyerror!void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer if (gpa.deinit() == .leak) @panic("found memory leaks");
+    const allocator = gpa.allocator();
+
+    var it = try std.process.argsWithAllocator(allocator);
+    defer it.deinit();
+    _ = it.next() orelse unreachable; // skip binary name
+    const child_exe_path = it.next() orelse unreachable;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.setAsCwd();
+    defer tmp.parent_dir.setAsCwd() catch {};
+
+    var buf = try std.ArrayList(u8).initCapacity(allocator, 128);
+    defer buf.deinit();
+    try buf.appendSlice("@echo off\n");
+    try buf.append('"');
+    try buf.appendSlice(child_exe_path);
+    try buf.append('"');
+    const preamble_len = buf.items.len;
+
+    try buf.appendSlice(" %*");
+    try tmp.dir.writeFile("args1.bat", buf.items);
+    buf.shrinkRetainingCapacity(preamble_len);
+
+    try buf.appendSlice(" %1 %2 %3 %4 %5 %6 %7 %8 %9");
+    try tmp.dir.writeFile("args2.bat", buf.items);
+    buf.shrinkRetainingCapacity(preamble_len);
+
+    try buf.appendSlice(" \"%~1\" \"%~2\" \"%~3\" \"%~4\" \"%~5\" \"%~6\" \"%~7\" \"%~8\" \"%~9\"");
+    try tmp.dir.writeFile("args3.bat", buf.items);
+    buf.shrinkRetainingCapacity(preamble_len);
+
+    // Test cases are from https://github.com/rust-lang/rust/blob/master/tests/ui/std/windows-bat-args.rs
+    try testExecError(error.InvalidBatchScriptArg, allocator, &.{"\x00"});
+    try testExecError(error.InvalidBatchScriptArg, allocator, &.{"\n"});
+    try testExecError(error.InvalidBatchScriptArg, allocator, &.{"\r"});
+    try testExec(allocator, &.{ "a", "b" }, null);
+    try testExec(allocator, &.{ "c is for cat", "d is for dog" }, null);
+    try testExec(allocator, &.{ "\"", " \"" }, null);
+    try testExec(allocator, &.{ "\\", "\\" }, null);
+    try testExec(allocator, &.{">file.txt"}, null);
+    try testExec(allocator, &.{"whoami.exe"}, null);
+    try testExec(allocator, &.{"&a.exe"}, null);
+    try testExec(allocator, &.{"&echo hello "}, null);
+    try testExec(allocator, &.{ "&echo hello", "&whoami", ">file.txt" }, null);
+    try testExec(allocator, &.{"!TMP!"}, null);
+    try testExec(allocator, &.{"key=value"}, null);
+    try testExec(allocator, &.{"\"key=value\""}, null);
+    try testExec(allocator, &.{"key = value"}, null);
+    try testExec(allocator, &.{"key=[\"value\"]"}, null);
+    try testExec(allocator, &.{ "", "a=b" }, null);
+    try testExec(allocator, &.{"key=\"foo bar\""}, null);
+    try testExec(allocator, &.{"key=[\"my_value]"}, null);
+    try testExec(allocator, &.{"key=[\"my_value\",\"other-value\"]"}, null);
+    try testExec(allocator, &.{"key\\=value"}, null);
+    try testExec(allocator, &.{"key=\"&whoami\""}, null);
+    try testExec(allocator, &.{"key=\"value\"=5"}, null);
+    try testExec(allocator, &.{"key=[\">file.txt\"]"}, null);
+    try testExec(allocator, &.{"%hello"}, null);
+    try testExec(allocator, &.{"%PATH%"}, null);
+    try testExec(allocator, &.{"%%cd:~,%"}, null);
+    try testExec(allocator, &.{"%PATH%PATH%"}, null);
+    try testExec(allocator, &.{"\">file.txt"}, null);
+    try testExec(allocator, &.{"abc\"&echo hello"}, null);
+    try testExec(allocator, &.{"123\">file.txt"}, null);
+    try testExec(allocator, &.{"\"&echo hello&whoami.exe"}, null);
+    try testExec(allocator, &.{ "\"hello^\"world\"", "hello &echo oh no >file.txt" }, null);
+    try testExec(allocator, &.{"&whoami.exe"}, null);
+
+    var env = env: {
+        var env = try std.process.getEnvMap(allocator);
+        errdefer env.deinit();
+        // No escaping
+        try env.put("FOO", "123");
+        // Some possible escaping of %FOO% that could be expanded
+        // when escaping cmd.exe meta characters with ^
+        try env.put("FOO^", "123"); // only escaping %
+        try env.put("^F^O^O^", "123"); // escaping every char
+        break :env env;
+    };
+    defer env.deinit();
+    try testExec(allocator, &.{"%FOO%"}, &env);
+
+    // Ensure that none of the `>file.txt`s have caused file.txt to be created
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access("file.txt", .{}));
+}
+
+fn testExecError(err: anyerror, allocator: std.mem.Allocator, args: []const []const u8) !void {
+    return std.testing.expectError(err, testExec(allocator, args, null));
+}
+
+fn testExec(allocator: std.mem.Allocator, args: []const []const u8, env: ?*std.process.EnvMap) !void {
+    try testExecBat(allocator, "args1.bat", args, env);
+    try testExecBat(allocator, "args2.bat", args, env);
+    try testExecBat(allocator, "args3.bat", args, env);
+}
+
+fn testExecBat(allocator: std.mem.Allocator, bat: []const u8, args: []const []const u8, env: ?*std.process.EnvMap) !void {
+    var argv = try std.ArrayList([]const u8).initCapacity(allocator, 1 + args.len);
+    defer argv.deinit();
+    argv.appendAssumeCapacity(bat);
+    argv.appendSliceAssumeCapacity(args);
+
+    const can_have_trailing_empty_args = std.mem.eql(u8, bat, "args3.bat");
+
+    const result = try std.ChildProcess.run(.{
+        .allocator = allocator,
+        .env_map = env,
+        .argv = argv.items,
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    try std.testing.expectEqualStrings("", result.stderr);
+    var it = std.mem.splitScalar(u8, result.stdout, '\x00');
+    var i: usize = 0;
+    while (it.next()) |actual_arg| {
+        if (i >= args.len and can_have_trailing_empty_args) {
+            try std.testing.expectEqualStrings("", actual_arg);
+            continue;
+        }
+        const expected_arg = args[i];
+        try std.testing.expectEqualStrings(expected_arg, actual_arg);
+        i += 1;
+    }
+}


### PR DESCRIPTION
> Note: This first part is mostly a rephrasing of https://flatt.tech/research/posts/batbadbut-you-cant-securely-execute-commands-on-windows/
> See that article for more details

On Windows, it is possible to execute `.bat`/`.cmd` scripts via CreateProcessW. When this happens, `CreateProcessW` will (under-the-hood) spawn a `cmd.exe` process with the path to the script and the args like so:

    cmd.exe /c script.bat arg1 arg2

This is a problem because:

- `cmd.exe` has its own, separate, parsing/escaping rules for arguments
- Environment variables in arguments will be expanded before the `cmd.exe` parsing rules are applied

Together, this means that (1) maliciously constructed arguments can lead to arbitrary command execution via the APIs in `std.process.Child` and (2) escaping according to the rules of `cmd.exe` is not enough on its own.

A basic example argv field that reproduces the vulnerability (this will erroneously spawn `calc.exe`):

    .argv = &.{ "test.bat", "\"&calc.exe" },

And one that takes advantage of environment variable expansion to still spawn calc.exe even if the args are properly escaped for `cmd.exe`:

    .argv = &.{ "test.bat", "%CMDCMDLINE:~-1%&calc.exe" },

(note: if these spawned e.g. `test.exe` instead of `test.bat`, they wouldn't be vulnerable; it's only `.bat`/`.cmd` scripts that are vulnerable since they go through `cmd.exe`)

Zig allows passing `.bat`/`.cmd` scripts as `argv[0]` via `std.process.Child`, so the Zig API is affected by this vulnerability. Note also that Zig will search `PATH` for `.bat`/`.cmd` scripts, so spawning something like `foo` may end up executing `foo.bat` somewhere in the PATH (the PATH searching of Zig matches the behavior of cmd.exe).

> Side note to keep in mind: On Windows, the extension is significant in terms of how Windows will try to execute the command. If the extension is not `.bat`/`.cmd`, we know that it will not attempt to be executed as a `.bat`/`.cmd` script (and vice versa). This means that we can just look at the extension to know if we are trying to execute a `.bat`/`.cmd` script.

---

This general class of problem has been documented before in 2011 here:

https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way

and the course of action it suggests for escaping when executing .bat/.cmd files is:

- Escape first using the non-cmd.exe rules
- Then escape all cmd.exe 'metacharacters' (`(`, `)`, `%`, `!`, `^`, `"`, `<`, `>`, `&`, and `|`) with `^`

However, escaping with ^ on its own is insufficient because it does not stop cmd.exe from expanding environment variables. For example:

```
args.bat %PATH%
```

escaped with ^ (and wrapped in quotes that are also escaped), it *will* stop cmd.exe from expanding `%PATH%`:

```
> args.bat ^"^%PATH^%^"
"%PATH%"
```

but it will still try to expand `%PATH^%`:

```
set PATH^^=123
> args.bat ^"^%PATH^%^"
"123"
```

The goal is to stop *all* environment variable expansion, so this won't work.

Another problem with the ^ approach is that it does not seem to allow all possible command lines to round trip through cmd.exe (as far as I can tell at least).

One known example:

```
args.bat ^"\^"key^=value\^"^"
```

where args.bat is:

```
@echo %1 %2 %3 %4 %5 %6 %7 %8 %9
```

will print

```
"\"key value\""
```

(it will turn the `=` into a space for an unknown reason; other minor variations do roundtrip, e.g. `\^"key^=value\^"`, `^"key^=value^"`, so it's unclear what's going on)

It may actually be possible to escape with ^ such that every possible command line round trips correctly, but it's probably not worth the effort to figure it out, since the suggested mitigation for BatBadBut has better roundtripping and leads to less garbled command lines overall.

---

Ultimately, the mitigation used here is the same as the one suggested in:

https://flatt.tech/research/posts/batbadbut-you-cant-securely-execute-commands-on-windows/

The mitigation steps are reproduced here, noted with one deviation that Zig makes (following Rust's lead):

1. Replace percent sign (%) with %%cd:~,%.
2. Replace the backslash (\\) in front of the double quote (") with two backslashes (\\\\).
3. Replace the double quote (") with two double quotes ("").
4. ~~Remove newline characters (\\n).~~
    + Instead, `\n`, `\r`, and NUL are disallowed and will trigger `error.InvalidBatchScriptArg` if they are found in `argv`. These three characters do not roundtrip through a `.bat` file and therefore are of dubious/no use. It's unclear to me if `\n` in particular is relevant to the BatBadBut vulnerability (I wasn't able to find a reproduction with \n and the post doesn't mention anything about it except in the suggested mitigation steps); it just seems to act as a 'end of arguments' marker and therefore anything after the `\n` is lost (and same with NUL). `\r` seems to be stripped from the command line arguments when passed through a `.bat`/`.cmd`, so that is also disallowed to ensure that `argv` can always fully roundtrip through `.bat`/`.cmd`.
5. Enclose the argument with double quotes (").

The escaped command line is then run as something like:

    cmd.exe /d /e:ON /v:OFF /c "foo.bat arg1 arg2"

Note: Previously, we would pass `foo.bat arg1 arg2` as the command line and the path to `foo.bat` as the app name and let CreateProcessW handle the `cmd.exe` spawning for us, but because we need to pass `/e:ON` and `/v:OFF` to cmd.exe to ensure the mitigation is effective, that is no longer tenable. Instead, we now get the full path to `cmd.exe` and use that as the app name when executing `.bat`/`.cmd` files.

---

A standalone test has also been added that tests two things:

1. Known reproductions of the vulnerability are tested to ensure that they do not reproduce the vulnerability
2. Randomly generated command line arguments roundtrip when passed to a `.bat` file and then are passed from the `.bat` file to a `.exe`. This fuzz test is as thorough as possible--it tests that things like arbitrary Unicode codepoints and unpaired surrogates roundtrip successfully.

Note: In order for the `CreateProcessW` -> `.bat` -> `.exe` roundtripping to succeed, the .exe must split the arguments using the post-2008 C runtime argv splitting implementation, see https://github.com/ziglang/zig/pull/19655 for details on when that change was made in Zig.

---

Some notes:

- When this was discussed in Discord, one possibility that was brought up was to disallow spawning `.bat`/`.cmd` through `std.process.Child` and instead make users do something more explicit. I am not in favor of that for a few reasons:
    + Zig behaving "like Windows" on Windows when possible is a nice feature to have IMO and makes cross-platform Zig code nicer overall, e.g. with Zig's behavior around searching `PATH`, running `std.process.Child.run(.{ .argv = &.{"foo"} });` will find `foo.bat` or `foo.cmd` if it exists in the `PATH`, which matches what would happen if you tried to run `foo` in `cmd.exe`
    + Depending on how it's handled, Zig would either need to rely on the user to mitigate the BatBadBut vulnerability correctly themselves, or Zig would have to provide the mitigation anyway in whatever API would be used to spawn `.bat`/`.cmd` scripts. Neither of these options seems like an improvement over allowing `.bat`/`.cmd` scripts to be run via `std.process.Child.run` and having the correct BatBadBut mitigation in place automatically.
- This adds a call to `kernel32.GetSystemDirectoryW` which I know can be removed in favor of getting the data from the `PEB`, but I wasn't able to figure out how to interpret `PEB.ReadOnlyStaticServerData` in order to access the correct memory (I ran into this same problem in https://github.com/squeek502/get-known-folder-path/issues/2).