### PR TITLE
std: fix Thread.Pool.spawn

### DIFF
--- a/lib/std/Thread/Pool.zig
+++ b/lib/std/Thread/Pool.zig
@@ -89,7 +89,7 @@ pub fn spawn(pool: *Pool, comptime func: anytype, args: anytype) !void {
 
         fn runFn(runnable: *Runnable) void {
             const run_node: *RunQueue.Node = @fieldParentPtr("data", runnable);
-            const closure: *@This() = @fieldParentPtr("run_node", run_node);
+            const closure: *@This() = @alignCast(@fieldParentPtr("run_node", run_node));
             @call(.auto, func, closure.arguments);
 
             // The thread pool's allocator is protected by the mutex.


### PR DESCRIPTION
`@alignCast` was required for args with greater alignment than that of a pointer.