### PR TITLE
std: disable flaky test on Windows

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1712,7 +1712,7 @@ test "walker without fully iterating" {
 test "'.' and '..' in fs.Dir functions" {
     if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest;
 
-    if (native_os == .windows and builtin.cpu.arch == .aarch64) {
+    if (native_os == .windows) {
         // https://github.com/ziglang/zig/issues/17134
         return error.SkipZigTest;
     }


### PR DESCRIPTION
It turns out this is also flaky on x86_64-windows. Tracked by #17134.