### PR TITLE
std.Build.Step.ConfigHeader: add the lazy file styled input as a dependency

### DIFF
--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -97,6 +97,9 @@ pub fn create(owner: *std.Build, options: Options) *ConfigHeader {
         .output_file = .{ .step = &config_header.step },
     };
 
+    if (options.style.getPath()) |s| {
+        s.addStepDependencies(&config_header.step);
+    }
     return config_header;
 }
 


### PR DESCRIPTION
Fixes #16208 by adding the style's `LazyFile` (when it has one) to the step as a dependency.

Tested by building the example code in https://github.com/ziglang/zig/issues/16208#issuecomment-1606740868