### PR TITLE
std-docs: use `open` for macOS.

### DIFF
--- a/lib/compiler/std-docs.zig
+++ b/lib/compiler/std-docs.zig
@@ -116,20 +116,21 @@ const Context = struct {
 };
 
 fn serveRequest(request: *std.http.Server.Request, context: *Context) !void {
-    if (std.mem.eql(u8, request.head.target, "/") or
-        std.mem.eql(u8, request.head.target, "/debug/"))
+    const target = std.mem.trimRight(u8, request.head.target, "/");
+    if (std.mem.eql(u8, target, "") or
+        std.mem.eql(u8, target, "/debug"))
     {
         try serveDocsFile(request, context, "docs/index.html", "text/html");
-    } else if (std.mem.eql(u8, request.head.target, "/main.js") or
-        std.mem.eql(u8, request.head.target, "/debug/main.js"))
+    } else if (std.mem.eql(u8, target, "/main.js") or
+        std.mem.eql(u8, target, "/debug/main.js"))
     {
         try serveDocsFile(request, context, "docs/main.js", "application/javascript");
-    } else if (std.mem.eql(u8, request.head.target, "/main.wasm")) {
+    } else if (std.mem.eql(u8, target, "/main.wasm")) {
         try serveWasm(request, context, .ReleaseFast);
-    } else if (std.mem.eql(u8, request.head.target, "/debug/main.wasm")) {
+    } else if (std.mem.eql(u8, target, "/debug/main.wasm")) {
         try serveWasm(request, context, .Debug);
-    } else if (std.mem.eql(u8, request.head.target, "/sources.tar") or
-        std.mem.eql(u8, request.head.target, "/debug/sources.tar"))
+    } else if (std.mem.eql(u8, target, "/sources.tar") or
+        std.mem.eql(u8, target, "/debug/sources.tar"))
     {
         try serveSourcesTar(request, context);
     } else {

--- a/lib/compiler/std-docs.zig
+++ b/lib/compiler/std-docs.zig
@@ -117,9 +117,7 @@ const Context = struct {
 
 fn serveRequest(request: *std.http.Server.Request, context: *Context) !void {
     const target = std.mem.trimRight(u8, request.head.target, "/");
-    if (std.mem.eql(u8, target, "") or
-        std.mem.eql(u8, target, "/debug"))
-    {
+    if (target.len == 0 or std.mem.eql(u8, target, "/debug")) {
         try serveDocsFile(request, context, "docs/index.html", "text/html");
     } else if (std.mem.eql(u8, target, "/main.js") or
         std.mem.eql(u8, target, "/debug/main.js"))

--- a/lib/compiler/std-docs.zig
+++ b/lib/compiler/std-docs.zig
@@ -433,6 +433,7 @@ fn openBrowserTab(gpa: Allocator, url: []const u8) !void {
 fn openBrowserTabThread(gpa: Allocator, url: []const u8) !void {
     const main_exe = switch (builtin.os.tag) {
         .windows => "explorer",
+        .macos => "open",
         else => "xdg-open",
     };
     var child = std.ChildProcess.init(&.{ main_exe, url }, gpa);


### PR DESCRIPTION
```
$ zig std 
http://127.0.0.1:59993/
error: FileNotFound
```

0.12.0 will output an error on macOS, it should be `open`.
- https://superuser.com/questions/911735/how-do-i-use-xdg-open-from-xdg-utils-on-mac-osx


Also, this PR make `/debug` endpoint works, previously it will return 404...