### PR TITLE
update list of missing features in no-LLVM built zig2

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ therefore lacking these features:
 - [Some ELF linking features](https://github.com/ziglang/zig/issues/17749)
 - [Most COFF/PE linking features](https://github.com/ziglang/zig/issues/17751)
 - [Some WebAssembly linking features](https://github.com/ziglang/zig/issues/17750)
-- [Ability to output LLVM bitcode](https://github.com/ziglang/zig/issues/13265)
-- [Windows resource file compilation](https://github.com/ziglang/zig/issues/17752)
 - [Ability to create import libs from def files](https://github.com/ziglang/zig/issues/17807)
 - [Automatic importlib file generation for Windows DLLs](https://github.com/ziglang/zig/issues/17753)
 - [Ability to create static archives from object files](https://github.com/ziglang/zig/issues/9828)


### PR DESCRIPTION
The README, in the section "Building from Source without LLVM", lists some missing features of `zig2` built without LLVM.

A few links in this list refer to closed issues, and 0.12.0 release notes confirm that at least a couple of these are in fact now available features.