### PR TITLE
Elf: fix unaligned segments on non-linux

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -623,7 +623,7 @@ pub fn initMetadata(self: *Elf, options: InitMetadataOptions) !void {
     const ptr_size = self.ptrWidthBytes();
     const target = self.base.comp.root_mod.resolved_target.result;
     const ptr_bit_width = target.ptrBitWidth();
-    const is_linux = target.os.tag == .linux;
+    const has_os = target.os.tag != .freestanding;
     const zig_object = self.zigObjectPtr().?;
 
     const fillSection = struct {
@@ -661,7 +661,7 @@ pub fn initMetadata(self: *Elf, options: InitMetadataOptions) !void {
         if (self.phdr_zig_got_index == null) {
             // We really only need ptr alignment but since we are using PROGBITS, linux requires
             // page align.
-            const alignment = if (is_linux) self.page_size else @as(u16, ptr_size);
+            const alignment = if (has_os) self.page_size else @as(u16, ptr_size);
             const filesz = @as(u64, ptr_size) * options.symbol_count_hint;
             const off = self.findFreeSpace(filesz, alignment);
             self.phdr_zig_got_index = try self.addPhdr(.{
@@ -676,7 +676,7 @@ pub fn initMetadata(self: *Elf, options: InitMetadataOptions) !void {
         }
 
         if (self.phdr_zig_load_ro_index == null) {
-            const alignment = if (is_linux) self.page_size else @as(u16, ptr_size);
+            const alignment = if (has_os) self.page_size else @as(u16, ptr_size);
             const filesz: u64 = 1024;
             const off = self.findFreeSpace(filesz, alignment);
             self.phdr_zig_load_ro_index = try self.addPhdr(.{
@@ -691,7 +691,7 @@ pub fn initMetadata(self: *Elf, options: InitMetadataOptions) !void {
         }
 
         if (self.phdr_zig_load_rw_index == null) {
-            const alignment = if (is_linux) self.page_size else @as(u16, ptr_size);
+            const alignment = if (has_os) self.page_size else @as(u16, ptr_size);
             const filesz: u64 = 1024;
             const off = self.findFreeSpace(filesz, alignment);
             self.phdr_zig_load_rw_index = try self.addPhdr(.{
@@ -706,7 +706,7 @@ pub fn initMetadata(self: *Elf, options: InitMetadataOptions) !void {
         }
 
         if (self.phdr_zig_load_zerofill_index == null) {
-            const alignment = if (is_linux) self.page_size else @as(u16, ptr_size);
+            const alignment = if (has_os) self.page_size else @as(u16, ptr_size);
             self.phdr_zig_load_zerofill_index = try self.addPhdr(.{
                 .type = elf.PT_LOAD,
                 .addr = if (ptr_bit_width >= 32) 0x14000000 else 0xf000,

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -601,7 +601,10 @@ fn outputType(elf_file: *Elf) u2 {
     return switch (elf_file.base.comp.config.output_mode) {
         .Obj => unreachable,
         .Lib => 0,
-        .Exe => if (comp.config.pie) 1 else 2,
+        .Exe => switch (elf_file.getTarget().os.tag) {
+            .haiku => 0,
+            else => if (comp.config.pie) 1 else 2,
+        },
     };
 }
 


### PR DESCRIPTION
Linux isn't the only OS that `mmap`s segments.