### PR TITLE
Fix reboot unexpected error

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1893,7 +1893,7 @@ pub fn sched_setaffinity(pid: pid_t, set: *const cpu_set_t) !void {
 
     switch (std.os.errno(rc)) {
         .SUCCESS => return,
-        else => |err| return std.os.unexpectedErrno(err),
+        else => |err| return std.posix.unexpectedErrno(err),
     }
 }
 

--- a/lib/std/os/linux/bpf.zig
+++ b/lib/std/os/linux/bpf.zig
@@ -1,6 +1,6 @@
 const std = @import("../../std.zig");
 const errno = linux.E.init;
-const unexpectedErrno = std.os.unexpectedErrno;
+const unexpectedErrno = std.posix.unexpectedErrno;
 const expectEqual = std.testing.expectEqual;
 const expectError = std.testing.expectError;
 const expect = std.testing.expect;

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -542,7 +542,7 @@ pub fn reboot(cmd: RebootCommand) RebootError!void {
             ))) {
                 .SUCCESS => {},
                 .PERM => return error.PermissionDenied,
-                else => |err| return std.os.unexpectedErrno(err),
+                else => |err| return std.posix.unexpectedErrno(err),
             }
             switch (cmd) {
                 .CAD_OFF => {},


### PR DESCRIPTION
`unexpectedErrno` comes from `posix`, not `os`.