### PR TITLE
std.Build: fix --release=x when preferred mode set

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1259,10 +1259,16 @@ pub const StandardOptimizeOptionOptions = struct {
 
 pub fn standardOptimizeOption(b: *Build, options: StandardOptimizeOptionOptions) std.builtin.OptimizeMode {
     if (options.preferred_optimize_mode) |mode| {
-        if (b.option(bool, "release", "optimize for end users") orelse (b.release_mode != .off)) {
+        if (b.option(bool, "release", "optimize for end users") == true) {
             return mode;
         } else {
-            return .Debug;
+            return switch (b.release_mode) {
+                .off => .Debug,
+                .any => mode,
+                .fast => .ReleaseFast,
+                .safe => .ReleaseSafe,
+                .small => .ReleaseSmall,
+            };
         }
     }
 


### PR DESCRIPTION
Currently if the preferred_optimize_mode is set when calling standardOptimizeOption() then --release={safe,fast,small} will be silently ignored in favor of the preffered optimize mode.

This patch changes this behavior to honor the optimize mode chosen with --release={safe,fast,small} but still use the preferred mode for a bare --release flag.

Fixes https://github.com/ziglang/zig/issues/19732