### PR TITLE
std.meta: give TagPayloadByName unreachable a better @compileError message

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -719,7 +719,7 @@ pub fn TagPayloadByName(comptime U: type, comptime tag_name: []const u8) type {
             return field_info.type;
     }
 
-    unreachable;
+    @compileError("no field '" ++ tag_name ++ "' in union '" ++ @typeName(U) ++ "'");
 }
 
 /// Given a tagged union type, and an enum, return the type of the union field


### PR DESCRIPTION
Ran into this `unreachable` while developing and the reason wasn't immediately obvious.

This compile error should make it obvious.