### PR TITLE
std.Build: Install Windows DLLs to `<prefix>/bin/` by default

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -614,6 +614,10 @@ pub fn isStaticLibrary(self: *const Compile) bool {
     return self.kind == .lib and self.linkage != .dynamic;
 }
 
+pub fn isDll(self: *Compile) bool {
+    return self.isDynamicLibrary() and self.rootModuleTarget().os.tag == .windows;
+}
+
 pub fn producesPdbFile(self: *Compile) bool {
     const target = self.rootModuleTarget();
     // TODO: Is this right? Isn't PDB for *any* PE/COFF file?
@@ -632,7 +636,7 @@ pub fn producesPdbFile(self: *Compile) bool {
 }
 
 pub fn producesImplib(self: *Compile) bool {
-    return self.isDynamicLibrary() and self.rootModuleTarget().os.tag == .windows;
+    return self.isDll();
 }
 
 pub fn linkLibC(self: *Compile) void {

--- a/lib/std/Build/Step/InstallArtifact.zig
+++ b/lib/std/Build/Step/InstallArtifact.zig
@@ -57,8 +57,8 @@ pub fn create(owner: *std.Build, artifact: *Step.Compile, options: Options) *Ins
         .disabled => null,
         .default => switch (artifact.kind) {
             .obj => @panic("object files have no standard installation procedure"),
-            .exe, .@"test" => InstallDir{ .bin = {} },
-            .lib => InstallDir{ .lib = {} },
+            .exe, .@"test" => .bin,
+            .lib => if (artifact.isDll()) .bin else .lib,
         },
         .override => |o| o,
     };
@@ -77,15 +77,12 @@ pub fn create(owner: *std.Build, artifact: *Step.Compile, options: Options) *Ins
         },
         .h_dir = switch (options.h_dir) {
             .disabled => null,
-            .default => switch (artifact.kind) {
-                .lib => .header,
-                else => null,
-            },
+            .default => if (artifact.kind == .lib) .header else null,
             .override => |o| o,
         },
         .implib_dir = switch (options.implib_dir) {
             .disabled => null,
-            .default => if (artifact.producesImplib()) dest_dir else null,
+            .default => if (artifact.producesImplib()) .lib else null,
             .override => |o| o,
         },
 


### PR DESCRIPTION
Windows does not support RPATH and only searches for DLLs in a small number of predetermined paths by default, with one of them being the directory from which the application loaded.

Currently, if you build an executable and a DLL, link them and install them with the default settings, the exe will go in `bin/` and the DLL in `lib/`, which makes the exe unable to find the DLL at runtime without manually adding `lib/` to the `PATH` environment variable.

Installing both executables and DLLs to `bin/` by default helps ensure that the executable can find any DLL artifacts it has linked to. DLL import libraries are still installed to `lib/`.

[These defaults match CMake's behavior](https://cmake.org/cmake/help/latest/command/install.html#artifact-kind) (emphasis mine):

> ARCHIVE
> Target artifacts of this kind include:
> - Static libraries (except on macOS when marked as FRAMEWORK, see below);
> - **DLL import libraries** (on all Windows-based systems including Cygwin; they have extension .lib, in contrast to the .dll libraries that go to RUNTIME);
>
> LIBRARY
> Target artifacts of this kind include:
> - Shared libraries, **except**
>   - **DLLs** (these go to RUNTIME, see below),
>
> RUNTIME
> Target artifacts of this kind include:
>
> - Executables (except on macOS when marked as MACOSX_BUNDLE, see BUNDLE below);
> - **DLLs** (on all Windows-based systems including Cygwin; note that the accompanying import libraries are of kind ARCHIVE).
>
> Target Type | GNUInstallDirs Variable | Built-In Default
> -- | -- | --
> RUNTIME | ${CMAKE_INSTALL_BINDIR} | bin
> LIBRARY | ${CMAKE_INSTALL_LIBDIR} | lib
> ARCHIVE | ${CMAKE_INSTALL_LIBDIR} | lib

Illustrative example:

```zig
exe.root_module.linkLibrary(sdl3_lib);

b.installArtifact(exe);
b.installArtifact(sdl3_lib);
```
``` 
zig-out/
├───bin/
│   ├───example.exe
│   ├───example.pdb
│   ├───SDL3.dll
│   └───SDL3.pdb
├───include/
│   └───SDL3/
│       ├───SDL.h
│       └───<omitted>
└───lib/
    └───SDL3.lib
```