### PR TITLE
Clarify the blocking behavior of `RwLock.lockShared()`.

### DIFF
--- a/lib/std/Thread/RwLock.zig
+++ b/lib/std/Thread/RwLock.zig
@@ -41,7 +41,9 @@ pub fn tryLockShared(rwl: *RwLock) bool {
     return rwl.impl.tryLockShared();
 }
 
-/// Blocks until shared lock ownership is acquired.
+/// Obtains shared lock ownership.
+/// Blocks if another thread has exclusive ownership.
+/// May block if another thread is attempting to get exclusive ownership.
 pub fn lockShared(rwl: *RwLock) void {
     return rwl.impl.lockShared();
 }


### PR DESCRIPTION
I just spend a few hours tracing a deadlock in my code, until I discovered that my mental model of the RwLock was wrong.
So I decided to clarify the behavior in the doc-comment.