### PR TITLE
Fix futex2_waitv syscall

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -585,7 +585,7 @@ pub fn futex2_waitv(
     /// Clock to be used for the timeout, realtime or monotonic.
     clockid: i32,
 ) usize {
-    return syscall6(
+    return syscall5(
         .futex_waitv,
         @intFromPtr(waiters),
         nr_futexes,


### PR DESCRIPTION
The syscall gives immediate compile error in zig 0.12. This PR fix that.