### PR TITLE
Fix `Interrupt` callconv LLVM code generation

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9618,6 +9618,15 @@ fn funcCommon(
         {
             return sema.fail(block, param_src, "non-pointer parameter declared noalias", .{});
         }
+
+        if (cc_resolved == .Interrupt) {
+            const err_code_size = target.ptrBitWidth();
+            switch (i) {
+                0 => if (param_ty.zigTypeTag(mod) != .Pointer) return sema.fail(block, param_src, "parameter must be a pointer type", .{}),
+                1 => if (param_ty.bitSize(mod) != err_code_size) return sema.fail(block, param_src, "parameter must have a bit size of {d}", .{err_code_size}),
+                else => return sema.fail(block, param_src, "Interrupt calling convention supports up to 2 parameters, found {d}", .{i + 1}),
+            }
+        }
     }
 
     var ret_ty_requires_comptime = false;
@@ -9964,6 +9973,22 @@ fn finishFunc(
             allowed_platform,
             @tagName(arch),
         });
+    }
+
+    if (cc_resolved == .Interrupt and return_type.zigTypeTag(mod) != .Void) {
+        const msg = msg: {
+            const msg = try sema.errMsg(
+                block,
+                ret_ty_src,
+                "non-void return type '{}' not allowed in function with calling convention 'Interrupt'",
+                .{return_type.fmt(mod)},
+            );
+            errdefer msg.destroy(gpa);
+
+            try sema.addDeclaredHereNote(msg, return_type);
+            break :msg msg;
+        };
+        return sema.failWithOwnedErrorMsg(block, msg);
     }
 
     if (cc_resolved == .Inline and is_noinline) {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -11343,25 +11343,6 @@ const ParamTypeIterator = struct {
                     return .byref;
                 }
             },
-            .Interrupt => {
-                switch (target.cpu.arch) {
-                    .x86 => switch (it.zig_index) {
-                        0 => if (ty.zigTypeTag(mod) != .Pointer) @panic("first argument must be a pointer"),
-                        1 => if (ty.zigTypeTag(mod) != .Int or ty.bitSize(mod) != 32) @panic("second argument must be a u32"),
-                        else => @panic("too many arguments"),
-                    },
-                    .x86_64 => switch (it.zig_index) {
-                        0 => if (ty.zigTypeTag(mod) != .Pointer) @panic("first argument must be a pointer"),
-                        1 => if (ty.zigTypeTag(mod) != .Int or ty.bitSize(mod) != 64) @panic("second argument must be a u64"),
-                        else => @panic("too many arguments"),
-                    },
-                    else => @panic("TODO: handle Interrupt callconv parameters for other architectures."),
-                }
-
-                it.zig_index += 1;
-                it.llvm_index += 1;
-                return .byval;
-            },
             else => {
                 it.zig_index += 1;
                 it.llvm_index += 1;


### PR DESCRIPTION
Closes #11661
Closes #4998

This PR adds the missing `byval` parameter attribute in the LLVM IR, and adds some safety checks to the function signature using [clang's documentation](https://clang.llvm.org/docs/AttributeReference.html#interrupt-x86) as a reference. I've also tested these changes on a hobby OS project.

This is my first time working with the LLVM codegen, and I'm not quite sure that I've done things correctly (especially error handling). Pointers from anyone more familiar with the codebase is appreciated!