### PR TITLE
std.posix.iovec: use .base and .len instead of .iov_base and .iov_len

### DIFF
--- a/lib/compiler/objcopy.zig
+++ b/lib/compiler/objcopy.zig
@@ -1285,7 +1285,7 @@ const ElfFileHelper = struct {
         for (consolidated.items) |cmd| {
             switch (cmd) {
                 .write_data => |data| {
-                    var iovec = [_]std.posix.iovec_const{.{ .iov_base = data.data.ptr, .iov_len = data.data.len }};
+                    var iovec = [_]std.posix.iovec_const{.{ .base = data.data.ptr, .len = data.data.len }};
                     try out_file.pwritevAll(&iovec, data.out_offset);
                 },
                 .copy_range => |range| {

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1276,22 +1276,22 @@ test "writev, readv" {
     var buf2: [line2.len]u8 = undefined;
     var write_vecs = [_]posix.iovec_const{
         .{
-            .iov_base = line1,
-            .iov_len = line1.len,
+            .base = line1,
+            .len = line1.len,
         },
         .{
-            .iov_base = line2,
-            .iov_len = line2.len,
+            .base = line2,
+            .len = line2.len,
         },
     };
     var read_vecs = [_]posix.iovec{
         .{
-            .iov_base = &buf2,
-            .iov_len = buf2.len,
+            .base = &buf2,
+            .len = buf2.len,
         },
         .{
-            .iov_base = &buf1,
-            .iov_len = buf1.len,
+            .base = &buf1,
+            .len = buf1.len,
         },
     };
 
@@ -1318,22 +1318,22 @@ test "pwritev, preadv" {
     var buf2: [line2.len]u8 = undefined;
     var write_vecs = [_]posix.iovec_const{
         .{
-            .iov_base = line1,
-            .iov_len = line1.len,
+            .base = line1,
+            .len = line1.len,
         },
         .{
-            .iov_base = line2,
-            .iov_len = line2.len,
+            .base = line2,
+            .len = line2.len,
         },
     };
     var read_vecs = [_]posix.iovec{
         .{
-            .iov_base = &buf2,
-            .iov_len = buf2.len,
+            .base = &buf2,
+            .len = buf2.len,
         },
         .{
-            .iov_base = &buf1,
-            .iov_len = buf1.len,
+            .base = &buf1,
+            .len = buf1.len,
         },
     };
 
@@ -1378,12 +1378,12 @@ test "sendfile" {
     const line2 = "second line\n";
     var vecs = [_]posix.iovec_const{
         .{
-            .iov_base = line1,
-            .iov_len = line1.len,
+            .base = line1,
+            .len = line1.len,
         },
         .{
-            .iov_base = line2,
-            .iov_len = line2.len,
+            .base = line2,
+            .len = line2.len,
         },
     };
 
@@ -1401,20 +1401,20 @@ test "sendfile" {
     const trailer2 = "second trailer\n";
     var hdtr = [_]posix.iovec_const{
         .{
-            .iov_base = header1,
-            .iov_len = header1.len,
+            .base = header1,
+            .len = header1.len,
         },
         .{
-            .iov_base = header2,
-            .iov_len = header2.len,
+            .base = header2,
+            .len = header2.len,
         },
         .{
-            .iov_base = trailer1,
-            .iov_len = trailer1.len,
+            .base = trailer1,
+            .len = trailer1.len,
         },
         .{
-            .iov_base = trailer2,
-            .iov_len = trailer2.len,
+            .base = trailer2,
+            .len = trailer2.len,
         },
     };
 

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -253,7 +253,7 @@ pub const Connection = struct {
         if (conn.read_end != conn.read_start) return;
 
         var iovecs = [1]std.posix.iovec{
-            .{ .iov_base = &conn.read_buf, .iov_len = conn.read_buf.len },
+            .{ .base = &conn.read_buf, .len = conn.read_buf.len },
         };
         const nread = try conn.readvDirect(&iovecs);
         if (nread == 0) return error.EndOfStream;
@@ -289,8 +289,8 @@ pub const Connection = struct {
         }
 
         var iovecs = [2]std.posix.iovec{
-            .{ .iov_base = buffer.ptr, .iov_len = buffer.len },
-            .{ .iov_base = &conn.read_buf, .iov_len = conn.read_buf.len },
+            .{ .base = buffer.ptr, .len = buffer.len },
+            .{ .base = &conn.read_buf, .len = conn.read_buf.len },
         };
         const nread = try conn.readvDirect(&iovecs);
 

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -442,42 +442,42 @@ pub const Request = struct {
         var iovecs_len: usize = 0;
 
         iovecs[iovecs_len] = .{
-            .iov_base = h.items.ptr,
-            .iov_len = h.items.len,
+            .base = h.items.ptr,
+            .len = h.items.len,
         };
         iovecs_len += 1;
 
         for (options.extra_headers) |header| {
             iovecs[iovecs_len] = .{
-                .iov_base = header.name.ptr,
-                .iov_len = header.name.len,
+                .base = header.name.ptr,
+                .len = header.name.len,
             };
             iovecs_len += 1;
 
             iovecs[iovecs_len] = .{
-                .iov_base = ": ",
-                .iov_len = 2,
+                .base = ": ",
+                .len = 2,
             };
             iovecs_len += 1;
 
             if (header.value.len != 0) {
                 iovecs[iovecs_len] = .{
-                    .iov_base = header.value.ptr,
-                    .iov_len = header.value.len,
+                    .base = header.value.ptr,
+                    .len = header.value.len,
                 };
                 iovecs_len += 1;
             }
 
             iovecs[iovecs_len] = .{
-                .iov_base = "\r\n",
-                .iov_len = 2,
+                .base = "\r\n",
+                .len = 2,
             };
             iovecs_len += 1;
         }
 
         iovecs[iovecs_len] = .{
-            .iov_base = "\r\n",
-            .iov_len = 2,
+            .base = "\r\n",
+            .len = 2,
         };
         iovecs_len += 1;
 
@@ -492,33 +492,33 @@ pub const Request = struct {
                     ) catch unreachable;
 
                     iovecs[iovecs_len] = .{
-                        .iov_base = chunk_header.ptr,
-                        .iov_len = chunk_header.len,
+                        .base = chunk_header.ptr,
+                        .len = chunk_header.len,
                     };
                     iovecs_len += 1;
 
                     iovecs[iovecs_len] = .{
-                        .iov_base = content.ptr,
-                        .iov_len = content.len,
+                        .base = content.ptr,
+                        .len = content.len,
                     };
                     iovecs_len += 1;
 
                     iovecs[iovecs_len] = .{
-                        .iov_base = "\r\n",
-                        .iov_len = 2,
+                        .base = "\r\n",
+                        .len = 2,
                     };
                     iovecs_len += 1;
                 }
 
                 iovecs[iovecs_len] = .{
-                    .iov_base = "0\r\n\r\n",
-                    .iov_len = 5,
+                    .base = "0\r\n\r\n",
+                    .len = 5,
                 };
                 iovecs_len += 1;
             } else if (content.len > 0) {
                 iovecs[iovecs_len] = .{
-                    .iov_base = content.ptr,
-                    .iov_len = content.len,
+                    .base = content.ptr,
+                    .len = content.len,
                 };
                 iovecs_len += 1;
             }
@@ -912,12 +912,12 @@ pub const Response = struct {
             const send_buffer_len = r.send_buffer_end - r.send_buffer_start;
             var iovecs: [2]std.posix.iovec_const = .{
                 .{
-                    .iov_base = r.send_buffer.ptr + r.send_buffer_start,
-                    .iov_len = send_buffer_len,
+                    .base = r.send_buffer.ptr + r.send_buffer_start,
+                    .len = send_buffer_len,
                 },
                 .{
-                    .iov_base = bytes.ptr,
-                    .iov_len = bytes.len,
+                    .base = bytes.ptr,
+                    .len = bytes.len,
                 },
             };
             const n = try r.stream.writev(&iovecs);
@@ -959,24 +959,24 @@ pub const Response = struct {
 
             var iovecs: [5]std.posix.iovec_const = .{
                 .{
-                    .iov_base = r.send_buffer.ptr + r.send_buffer_start,
-                    .iov_len = send_buffer_len - r.chunk_len,
+                    .base = r.send_buffer.ptr + r.send_buffer_start,
+                    .len = send_buffer_len - r.chunk_len,
                 },
                 .{
-                    .iov_base = chunk_header.ptr,
-                    .iov_len = chunk_header.len,
+                    .base = chunk_header.ptr,
+                    .len = chunk_header.len,
                 },
                 .{
-                    .iov_base = r.send_buffer.ptr + r.send_buffer_end - r.chunk_len,
-                    .iov_len = r.chunk_len,
+                    .base = r.send_buffer.ptr + r.send_buffer_end - r.chunk_len,
+                    .len = r.chunk_len,
                 },
                 .{
-                    .iov_base = bytes.ptr,
-                    .iov_len = bytes.len,
+                    .base = bytes.ptr,
+                    .len = bytes.len,
                 },
                 .{
-                    .iov_base = "\r\n",
-                    .iov_len = 2,
+                    .base = "\r\n",
+                    .len = 2,
                 },
             };
             // TODO make this writev instead of writevAll, which involves
@@ -1042,69 +1042,69 @@ pub const Response = struct {
         var iovecs_len: usize = 0;
 
         iovecs[iovecs_len] = .{
-            .iov_base = http_headers.ptr,
-            .iov_len = http_headers.len,
+            .base = http_headers.ptr,
+            .len = http_headers.len,
         };
         iovecs_len += 1;
 
         if (r.chunk_len > 0) {
             iovecs[iovecs_len] = .{
-                .iov_base = chunk_header.ptr,
-                .iov_len = chunk_header.len,
+                .base = chunk_header.ptr,
+                .len = chunk_header.len,
             };
             iovecs_len += 1;
 
             iovecs[iovecs_len] = .{
-                .iov_base = r.send_buffer.ptr + r.send_buffer_end - r.chunk_len,
-                .iov_len = r.chunk_len,
+                .base = r.send_buffer.ptr + r.send_buffer_end - r.chunk_len,
+                .len = r.chunk_len,
             };
             iovecs_len += 1;
 
             iovecs[iovecs_len] = .{
-                .iov_base = "\r\n",
-                .iov_len = 2,
+                .base = "\r\n",
+                .len = 2,
             };
             iovecs_len += 1;
         }
 
         if (end_trailers) |trailers| {
             iovecs[iovecs_len] = .{
-                .iov_base = "0\r\n",
-                .iov_len = 3,
+                .base = "0\r\n",
+                .len = 3,
             };
             iovecs_len += 1;
 
             for (trailers) |trailer| {
                 iovecs[iovecs_len] = .{
-                    .iov_base = trailer.name.ptr,
-                    .iov_len = trailer.name.len,
+                    .base = trailer.name.ptr,
+                    .len = trailer.name.len,
                 };
                 iovecs_len += 1;
 
                 iovecs[iovecs_len] = .{
-                    .iov_base = ": ",
-                    .iov_len = 2,
+                    .base = ": ",
+                    .len = 2,
                 };
                 iovecs_len += 1;
 
                 if (trailer.value.len != 0) {
                     iovecs[iovecs_len] = .{
-                        .iov_base = trailer.value.ptr,
-                        .iov_len = trailer.value.len,
+                        .base = trailer.value.ptr,
+                        .len = trailer.value.len,
                     };
                     iovecs_len += 1;
                 }
 
                 iovecs[iovecs_len] = .{
-                    .iov_base = "\r\n",
-                    .iov_len = 2,
+                    .base = "\r\n",
+                    .len = 2,
                 };
                 iovecs_len += 1;
             }
 
             iovecs[iovecs_len] = .{
-                .iov_base = "\r\n",
-                .iov_len = 2,
+                .base = "\r\n",
+                .len = 2,
             };
             iovecs_len += 1;
         }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1826,7 +1826,7 @@ pub const Stream = struct {
             // TODO improve this to use ReadFileScatter
             if (iovecs.len == 0) return @as(usize, 0);
             const first = iovecs[0];
-            return windows.ReadFile(s.handle, first.iov_base[0..first.iov_len], null);
+            return windows.ReadFile(s.handle, first.base[0..first.len], null);
         }
 
         return posix.readv(s.handle, iovecs);
@@ -1889,13 +1889,13 @@ pub const Stream = struct {
         var i: usize = 0;
         while (true) {
             var amt = try self.writev(iovecs[i..]);
-            while (amt >= iovecs[i].iov_len) {
-                amt -= iovecs[i].iov_len;
+            while (amt >= iovecs[i].len) {
+                amt -= iovecs[i].len;
                 i += 1;
                 if (i >= iovecs.len) return;
             }
-            iovecs[i].iov_base += amt;
-            iovecs[i].iov_len -= amt;
+            iovecs[i].base += amt;
+            iovecs[i].len -= amt;
         }
     }
 };

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1644,7 +1644,7 @@ pub fn sendmmsg(fd: i32, msgvec: [*]mmsghdr_const, vlen: u32, flags: u32) usize 
             var size: i32 = 0;
             const msg_iovlen = @as(usize, @intCast(msg.msg_hdr.msg_iovlen)); // kernel side this is treated as unsigned
             for (msg.msg_hdr.msg_iov[0..msg_iovlen]) |iov| {
-                if (iov.iov_len > std.math.maxInt(i32) or @addWithOverflow(size, @as(i32, @intCast(iov.iov_len)))[1] != 0) {
+                if (iov.len > std.math.maxInt(i32) or @addWithOverflow(size, @as(i32, @intCast(iov.len)))[1] != 0) {
                     // batch-send all messages up to the current message
                     if (next_unsent < i) {
                         const batch_size = i - next_unsent;
@@ -1660,7 +1660,7 @@ pub fn sendmmsg(fd: i32, msgvec: [*]mmsghdr_const, vlen: u32, flags: u32) usize 
                     next_unsent = i + 1;
                     break;
                 }
-                size += iov.iov_len;
+                size += iov.len;
             }
         }
         if (next_unsent < kvlen or next_unsent == 0) { // want to make sure at least one syscall occurs (e.g. to trigger MSG.EOR)

--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -1766,7 +1766,7 @@ test "readv" {
     try ring.register_files(registered_fds[0..]);
 
     var buffer = [_]u8{42} ** 128;
-    var iovecs = [_]posix.iovec{posix.iovec{ .iov_base = &buffer, .iov_len = buffer.len }};
+    var iovecs = [_]posix.iovec{posix.iovec{ .base = &buffer, .len = buffer.len }};
     const sqe = try ring.read(0xcccccccc, fd_index, .{ .iovecs = iovecs[0..] }, 0);
     try testing.expectEqual(linux.IORING_OP.READV, sqe.opcode);
     sqe.flags |= linux.IOSQE_FIXED_FILE;
@@ -1803,11 +1803,11 @@ test "writev/fsync/readv" {
 
     const buffer_write = [_]u8{42} ** 128;
     const iovecs_write = [_]posix.iovec_const{
-        posix.iovec_const{ .iov_base = &buffer_write, .iov_len = buffer_write.len },
+        posix.iovec_const{ .base = &buffer_write, .len = buffer_write.len },
     };
     var buffer_read = [_]u8{0} ** 128;
     var iovecs_read = [_]posix.iovec{
-        posix.iovec{ .iov_base = &buffer_read, .iov_len = buffer_read.len },
+        posix.iovec{ .base = &buffer_read, .len = buffer_read.len },
     };
 
     const sqe_writev = try ring.writev(0xdddddddd, fd, iovecs_write[0..], 17);
@@ -1995,8 +1995,8 @@ test "write_fixed/read_fixed" {
     raw_buffers[0][0.."foobar".len].* = "foobar".*;
 
     var buffers = [2]posix.iovec{
-        .{ .iov_base = &raw_buffers[0], .iov_len = raw_buffers[0].len },
-        .{ .iov_base = &raw_buffers[1], .iov_len = raw_buffers[1].len },
+        .{ .base = &raw_buffers[0], .len = raw_buffers[0].len },
+        .{ .base = &raw_buffers[1], .len = raw_buffers[1].len },
     };
     ring.register_buffers(&buffers) catch |err| switch (err) {
         error.SystemResources => {
@@ -2022,18 +2022,18 @@ test "write_fixed/read_fixed" {
 
     try testing.expectEqual(linux.io_uring_cqe{
         .user_data = 0x45454545,
-        .res = @as(i32, @intCast(buffers[0].iov_len)),
+        .res = @as(i32, @intCast(buffers[0].len)),
         .flags = 0,
     }, cqe_write);
     try testing.expectEqual(linux.io_uring_cqe{
         .user_data = 0x12121212,
-        .res = @as(i32, @intCast(buffers[1].iov_len)),
+        .res = @as(i32, @intCast(buffers[1].len)),
         .flags = 0,
     }, cqe_read);
 
-    try testing.expectEqualSlices(u8, "\x00\x00\x00", buffers[1].iov_base[0..3]);
-    try testing.expectEqualSlices(u8, "foobar", buffers[1].iov_base[3..9]);
-    try testing.expectEqualSlices(u8, "zz", buffers[1].iov_base[9..11]);
+    try testing.expectEqualSlices(u8, "\x00\x00\x00", buffers[1].base[0..3]);
+    try testing.expectEqualSlices(u8, "foobar", buffers[1].base[3..9]);
+    try testing.expectEqualSlices(u8, "zz", buffers[1].base[9..11]);
 }
 
 test "openat" {
@@ -2189,7 +2189,7 @@ test "sendmsg/recvmsg" {
 
     const buffer_send = [_]u8{42} ** 128;
     const iovecs_send = [_]posix.iovec_const{
-        posix.iovec_const{ .iov_base = &buffer_send, .iov_len = buffer_send.len },
+        posix.iovec_const{ .base = &buffer_send, .len = buffer_send.len },
     };
     const msg_send: posix.msghdr_const = .{
         .name = &address_server.any,
@@ -2207,7 +2207,7 @@ test "sendmsg/recvmsg" {
 
     var buffer_recv = [_]u8{0} ** 128;
     var iovecs_recv = [_]posix.iovec{
-        posix.iovec{ .iov_base = &buffer_recv, .iov_len = buffer_recv.len },
+        posix.iovec{ .base = &buffer_recv, .len = buffer_recv.len },
     };
     const addr = [_]u8{0} ** 4;
     var address_recv = net.Address.initIp4(addr, 0);

--- a/lib/std/os/linux/io_uring_sqe.zig
+++ b/lib/std/os/linux/io_uring_sqe.zig
@@ -117,12 +117,12 @@ pub const io_uring_sqe = extern struct {
     }
 
     pub fn prep_read_fixed(sqe: *linux.io_uring_sqe, fd: linux.fd_t, buffer: *std.posix.iovec, offset: u64, buffer_index: u16) void {
-        sqe.prep_rw(.READ_FIXED, fd, @intFromPtr(buffer.iov_base), buffer.iov_len, offset);
+        sqe.prep_rw(.READ_FIXED, fd, @intFromPtr(buffer.base), buffer.len, offset);
         sqe.buf_index = buffer_index;
     }
 
     pub fn prep_write_fixed(sqe: *linux.io_uring_sqe, fd: linux.fd_t, buffer: *std.posix.iovec, offset: u64, buffer_index: u16) void {
-        sqe.prep_rw(.WRITE_FIXED, fd, @intFromPtr(buffer.iov_base), buffer.iov_len, offset);
+        sqe.prep_rw(.WRITE_FIXED, fd, @intFromPtr(buffer.base), buffer.len, offset);
         sqe.buf_index = buffer_index;
     }
 

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -173,13 +173,13 @@ pub const W_OK = system.W_OK;
 pub const X_OK = system.X_OK;
 
 pub const iovec = extern struct {
-    iov_base: [*]u8,
-    iov_len: usize,
+    base: [*]u8,
+    len: usize,
 };
 
 pub const iovec_const = extern struct {
-    iov_base: [*]const u8,
-    iov_len: usize,
+    base: [*]const u8,
+    len: usize,
 };
 
 pub const ACCMODE = enum(u2) {
@@ -796,8 +796,8 @@ pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
     }
     if (native_os == .wasi and !builtin.link_libc) {
         const iovs = [1]iovec{iovec{
-            .iov_base = buf.ptr,
-            .iov_len = buf.len,
+            .base = buf.ptr,
+            .len = buf.len,
         }};
 
         var nread: usize = undefined;
@@ -865,7 +865,7 @@ pub fn readv(fd: fd_t, iov: []const iovec) ReadError!usize {
         // TODO improve this to use ReadFileScatter
         if (iov.len == 0) return 0;
         const first = iov[0];
-        return read(fd, first.iov_base[0..first.iov_len]);
+        return read(fd, first.base[0..first.len]);
     }
     if (native_os == .wasi and !builtin.link_libc) {
         var nread: usize = undefined;
@@ -932,8 +932,8 @@ pub fn pread(fd: fd_t, buf: []u8, offset: u64) PReadError!usize {
     }
     if (native_os == .wasi and !builtin.link_libc) {
         const iovs = [1]iovec{iovec{
-            .iov_base = buf.ptr,
-            .iov_len = buf.len,
+            .base = buf.ptr,
+            .len = buf.len,
         }};
 
         var nread: usize = undefined;
@@ -1077,7 +1077,7 @@ pub fn preadv(fd: fd_t, iov: []const iovec, offset: u64) PReadError!usize {
         // So we simply read into the first vector only.
         if (iov.len == 0) return 0;
         const first = iov[0];
-        return pread(fd, first.iov_base[0..first.iov_len], offset);
+        return pread(fd, first.base[0..first.len], offset);
     }
     if (native_os == .wasi and !builtin.link_libc) {
         var nread: usize = undefined;
@@ -1186,8 +1186,8 @@ pub fn write(fd: fd_t, bytes: []const u8) WriteError!usize {
 
     if (native_os == .wasi and !builtin.link_libc) {
         const ciovs = [_]iovec_const{iovec_const{
-            .iov_base = bytes.ptr,
-            .iov_len = bytes.len,
+            .base = bytes.ptr,
+            .len = bytes.len,
         }};
         var nwritten: usize = undefined;
         switch (wasi.fd_write(fd, &ciovs, ciovs.len, &nwritten)) {
@@ -1263,7 +1263,7 @@ pub fn writev(fd: fd_t, iov: []const iovec_const) WriteError!usize {
         // TODO improve this to use WriteFileScatter
         if (iov.len == 0) return 0;
         const first = iov[0];
-        return write(fd, first.iov_base[0..first.iov_len]);
+        return write(fd, first.base[0..first.len]);
     }
     if (native_os == .wasi and !builtin.link_libc) {
         var nwritten: usize = undefined;
@@ -1340,8 +1340,8 @@ pub fn pwrite(fd: fd_t, bytes: []const u8, offset: u64) PWriteError!usize {
     }
     if (native_os == .wasi and !builtin.link_libc) {
         const ciovs = [1]iovec_const{iovec_const{
-            .iov_base = bytes.ptr,
-            .iov_len = bytes.len,
+            .base = bytes.ptr,
+            .len = bytes.len,
         }};
 
         var nwritten: usize = undefined;
@@ -1432,7 +1432,7 @@ pub fn pwritev(fd: fd_t, iov: []const iovec_const, offset: u64) PWriteError!usiz
         // So we simply write the first vector only.
         if (iov.len == 0) return 0;
         const first = iov[0];
-        return pwrite(fd, first.iov_base[0..first.iov_len], offset);
+        return pwrite(fd, first.base[0..first.len], offset);
     }
     if (native_os == .wasi and !builtin.link_libc) {
         var nwritten: usize = undefined;
@@ -6361,7 +6361,7 @@ pub fn sendfile(
 fn count_iovec_bytes(iovs: []const iovec_const) usize {
     var count: usize = 0;
     for (iovs) |iov| {
-        count += iov.iov_len;
+        count += iov.len;
     }
     return count;
 }

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -939,7 +939,7 @@ test "writev longer than IOV_MAX" {
     var file = try tmp.dir.createFile("pwritev", .{});
     defer file.close();
 
-    const iovecs = [_]posix.iovec_const{.{ .iov_base = "a", .iov_len = 1 }} ** (posix.IOV_MAX + 1);
+    const iovecs = [_]posix.iovec_const{.{ .base = "a", .len = 1 }} ** (posix.IOV_MAX + 1);
     const amt = try file.writev(&iovecs);
     try testing.expectEqual(@as(usize, posix.IOV_MAX), amt);
 }

--- a/lib/std/zig/Server.zig
+++ b/lib/std/zig/Server.zig
@@ -149,13 +149,13 @@ pub fn serveMessage(
     var iovecs: [10]std.posix.iovec_const = undefined;
     const header_le = bswap(header);
     iovecs[0] = .{
-        .iov_base = @as([*]const u8, @ptrCast(&header_le)),
-        .iov_len = @sizeOf(OutMessage.Header),
+        .base = @as([*]const u8, @ptrCast(&header_le)),
+        .len = @sizeOf(OutMessage.Header),
     };
     for (bufs, iovecs[1 .. bufs.len + 1]) |buf, *iovec| {
         iovec.* = .{
-            .iov_base = buf.ptr,
-            .iov_len = buf.len,
+            .base = buf.ptr,
+            .len = buf.len,
         };
     }
     try s.out.writevAll(iovecs[0 .. bufs.len + 1]);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2811,8 +2811,8 @@ fn addBuf(bufs_list: []std.posix.iovec_const, bufs_len: *usize, buf: []const u8)
     const i = bufs_len.*;
     bufs_len.* = i + 1;
     bufs_list[i] = .{
-        .iov_base = buf.ptr,
-        .iov_len = buf.len,
+        .base = buf.ptr,
+        .len = buf.len,
     };
 }
 
@@ -3800,8 +3800,8 @@ fn docsCopyModule(comp: *Compilation, module: *Package.Module, name: []const u8,
         };
 
         var header_and_trailer: [2]std.posix.iovec_const = .{
-            .{ .iov_base = header_bytes.ptr, .iov_len = header_bytes.len },
-            .{ .iov_base = padding.ptr, .iov_len = padding.len },
+            .{ .base = header_bytes.ptr, .len = header_bytes.len },
+            .{ .base = padding.ptr, .len = padding.len },
         };
 
         try tar_file.writeFileAll(file, .{

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -2336,24 +2336,24 @@ pub fn astGenFile(mod: *Module, file: *File) !void {
     };
     var iovecs = [_]std.posix.iovec_const{
         .{
-            .iov_base = @as([*]const u8, @ptrCast(&header)),
-            .iov_len = @sizeOf(Zir.Header),
+            .base = @as([*]const u8, @ptrCast(&header)),
+            .len = @sizeOf(Zir.Header),
         },
         .{
-            .iov_base = @as([*]const u8, @ptrCast(file.zir.instructions.items(.tag).ptr)),
-            .iov_len = file.zir.instructions.len,
+            .base = @as([*]const u8, @ptrCast(file.zir.instructions.items(.tag).ptr)),
+            .len = file.zir.instructions.len,
         },
         .{
-            .iov_base = data_ptr,
-            .iov_len = file.zir.instructions.len * 8,
+            .base = data_ptr,
+            .len = file.zir.instructions.len * 8,
         },
         .{
-            .iov_base = file.zir.string_bytes.ptr,
-            .iov_len = file.zir.string_bytes.len,
+            .base = file.zir.string_bytes.ptr,
+            .len = file.zir.string_bytes.len,
         },
         .{
-            .iov_base = @as([*]const u8, @ptrCast(file.zir.extra.ptr)),
-            .iov_len = file.zir.extra.len * 4,
+            .base = @as([*]const u8, @ptrCast(file.zir.extra.ptr)),
+            .len = file.zir.extra.len * 4,
         },
     };
     cache_file.writevAll(&iovecs) catch |err| {
@@ -2424,20 +2424,20 @@ fn loadZirCacheBody(gpa: Allocator, header: Zir.Header, cache_file: std.fs.File)
 
     var iovecs = [_]std.posix.iovec{
         .{
-            .iov_base = @as([*]u8, @ptrCast(zir.instructions.items(.tag).ptr)),
-            .iov_len = header.instructions_len,
+            .base = @as([*]u8, @ptrCast(zir.instructions.items(.tag).ptr)),
+            .len = header.instructions_len,
         },
         .{
-            .iov_base = data_ptr,
-            .iov_len = header.instructions_len * 8,
+            .base = data_ptr,
+            .len = header.instructions_len * 8,
         },
         .{
-            .iov_base = zir.string_bytes.ptr,
-            .iov_len = header.string_bytes_len,
+            .base = zir.string_bytes.ptr,
+            .len = header.string_bytes_len,
         },
         .{
-            .iov_base = @as([*]u8, @ptrCast(zir.extra.ptr)),
-            .iov_len = header.extra_len * 4,
+            .base = @as([*]u8, @ptrCast(zir.extra.ptr)),
+            .len = header.extra_len * 4,
         },
     };
     const amt_read = try cache_file.readvAll(&iovecs);

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -483,15 +483,15 @@ pub fn flushModule(self: *C, arena: Allocator, prog_node: *std.Progress.Node) !v
     }
 
     f.all_buffers.items[ctypes_index] = .{
-        .iov_base = if (f.ctypes_buf.items.len > 0) f.ctypes_buf.items.ptr else "",
-        .iov_len = f.ctypes_buf.items.len,
+        .base = if (f.ctypes_buf.items.len > 0) f.ctypes_buf.items.ptr else "",
+        .len = f.ctypes_buf.items.len,
     };
     f.file_size += f.ctypes_buf.items.len;
 
     const lazy_fwd_decl_len = self.lazy_fwd_decl_buf.items.len;
     f.all_buffers.items[lazy_index] = .{
-        .iov_base = if (lazy_fwd_decl_len > 0) self.lazy_fwd_decl_buf.items.ptr else "",
-        .iov_len = lazy_fwd_decl_len,
+        .base = if (lazy_fwd_decl_len > 0) self.lazy_fwd_decl_buf.items.ptr else "",
+        .len = lazy_fwd_decl_len,
     };
     f.file_size += lazy_fwd_decl_len;
 
@@ -527,7 +527,7 @@ const Flush = struct {
 
     fn appendBufAssumeCapacity(f: *Flush, buf: []const u8) void {
         if (buf.len == 0) return;
-        f.all_buffers.appendAssumeCapacity(.{ .iov_base = buf.ptr, .iov_len = buf.len });
+        f.all_buffers.appendAssumeCapacity(.{ .base = buf.ptr, .len = buf.len });
         f.file_size += buf.len;
     }
 
@@ -747,8 +747,8 @@ pub fn flushEmitH(zcu: *Zcu) !void {
     var file_size: u64 = zig_h.len;
     if (zig_h.len != 0) {
         all_buffers.appendAssumeCapacity(.{
-            .iov_base = zig_h,
-            .iov_len = zig_h.len,
+            .base = zig_h,
+            .len = zig_h.len,
         });
     }
 
@@ -757,8 +757,8 @@ pub fn flushEmitH(zcu: *Zcu) !void {
         const buf = decl_emit_h.fwd_decl.items;
         if (buf.len != 0) {
             all_buffers.appendAssumeCapacity(.{
-                .iov_base = buf.ptr,
-                .iov_len = buf.len,
+                .base = buf.ptr,
+                .len = buf.len,
             });
             file_size += buf.len;
         }

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -2120,32 +2120,32 @@ fn pwriteDbgLineNops(
         var padding_left = prev_padding_size;
         if (padding_left % 2 != 0) {
             vecs[vec_index] = .{
-                .iov_base = &three_byte_nop,
-                .iov_len = three_byte_nop.len,
+                .base = &three_byte_nop,
+                .len = three_byte_nop.len,
             };
             vec_index += 1;
             padding_left -= three_byte_nop.len;
         }
         while (padding_left > page_of_nops.len) {
             vecs[vec_index] = .{
-                .iov_base = &page_of_nops,
-                .iov_len = page_of_nops.len,
+                .base = &page_of_nops,
+                .len = page_of_nops.len,
             };
             vec_index += 1;
             padding_left -= page_of_nops.len;
         }
         if (padding_left > 0) {
             vecs[vec_index] = .{
-                .iov_base = &page_of_nops,
-                .iov_len = padding_left,
+                .base = &page_of_nops,
+                .len = padding_left,
             };
             vec_index += 1;
         }
     }
 
     vecs[vec_index] = .{
-        .iov_base = buf.ptr,
-        .iov_len = buf.len,
+        .base = buf.ptr,
+        .len = buf.len,
     };
     if (buf.len > 0) vec_index += 1;
 
@@ -2153,24 +2153,24 @@ fn pwriteDbgLineNops(
         var padding_left = next_padding_size;
         if (padding_left % 2 != 0) {
             vecs[vec_index] = .{
-                .iov_base = &three_byte_nop,
-                .iov_len = three_byte_nop.len,
+                .base = &three_byte_nop,
+                .len = three_byte_nop.len,
             };
             vec_index += 1;
             padding_left -= three_byte_nop.len;
         }
         while (padding_left > page_of_nops.len) {
             vecs[vec_index] = .{
-                .iov_base = &page_of_nops,
-                .iov_len = page_of_nops.len,
+                .base = &page_of_nops,
+                .len = page_of_nops.len,
             };
             vec_index += 1;
             padding_left -= page_of_nops.len;
         }
         if (padding_left > 0) {
             vecs[vec_index] = .{
-                .iov_base = &page_of_nops,
-                .iov_len = padding_left,
+                .base = &page_of_nops,
+                .len = padding_left,
             };
             vec_index += 1;
         }
@@ -2237,24 +2237,24 @@ fn pwriteDbgInfoNops(
         var padding_left = prev_padding_size;
         while (padding_left > page_of_nops.len) {
             vecs[vec_index] = .{
-                .iov_base = &page_of_nops,
-                .iov_len = page_of_nops.len,
+                .base = &page_of_nops,
+                .len = page_of_nops.len,
             };
             vec_index += 1;
             padding_left -= page_of_nops.len;
         }
         if (padding_left > 0) {
             vecs[vec_index] = .{
-                .iov_base = &page_of_nops,
-                .iov_len = padding_left,
+                .base = &page_of_nops,
+                .len = padding_left,
             };
             vec_index += 1;
         }
     }
 
     vecs[vec_index] = .{
-        .iov_base = buf.ptr,
-        .iov_len = buf.len,
+        .base = buf.ptr,
+        .len = buf.len,
     };
     if (buf.len > 0) vec_index += 1;
 
@@ -2262,16 +2262,16 @@ fn pwriteDbgInfoNops(
         var padding_left = next_padding_size;
         while (padding_left > page_of_nops.len) {
             vecs[vec_index] = .{
-                .iov_base = &page_of_nops,
-                .iov_len = page_of_nops.len,
+                .base = &page_of_nops,
+                .len = page_of_nops.len,
             };
             vec_index += 1;
             padding_left -= page_of_nops.len;
         }
         if (padding_left > 0) {
             vecs[vec_index] = .{
-                .iov_base = &page_of_nops,
-                .iov_len = padding_left,
+                .base = &page_of_nops,
+                .len = padding_left,
             };
             vec_index += 1;
         }
@@ -2280,8 +2280,8 @@ fn pwriteDbgInfoNops(
     if (trailing_zero) {
         var zbuf = [1]u8{0};
         vecs[vec_index] = .{
-            .iov_base = &zbuf,
-            .iov_len = zbuf.len,
+            .base = &zbuf,
+            .len = zbuf.len,
         };
         vec_index += 1;
     }

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -965,12 +965,12 @@ fn updateDeclCode(
         switch (builtin.os.tag) {
             .linux => {
                 var code_vec: [1]std.posix.iovec_const = .{.{
-                    .iov_base = code.ptr,
-                    .iov_len = code.len,
+                    .base = code.ptr,
+                    .len = code.len,
                 }};
                 var remote_vec: [1]std.posix.iovec_const = .{.{
-                    .iov_base = @as([*]u8, @ptrFromInt(@as(usize, @intCast(sym.address(.{}, elf_file))))),
-                    .iov_len = code.len,
+                    .base = @as([*]u8, @ptrFromInt(@as(usize, @intCast(sym.address(.{}, elf_file))))),
+                    .len = code.len,
                 }};
                 const rc = std.os.linux.process_vm_writev(pid, &code_vec, &remote_vec, 0);
                 switch (std.os.linux.E.init(rc)) {

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -314,12 +314,12 @@ pub const ZigGotSection = struct {
                     switch (builtin.os.tag) {
                         .linux => {
                             var local_vec: [1]std.posix.iovec_const = .{.{
-                                .iov_base = &buf,
-                                .iov_len = buf.len,
+                                .base = &buf,
+                                .len = buf.len,
                             }};
                             var remote_vec: [1]std.posix.iovec_const = .{.{
-                                .iov_base = @as([*]u8, @ptrFromInt(@as(usize, @intCast(vaddr)))),
-                                .iov_len = buf.len,
+                                .base = @as([*]u8, @ptrFromInt(@as(usize, @intCast(vaddr)))),
+                                .len = buf.len,
                             }};
                             const rc = std.os.linux.process_vm_writev(pid, &local_vec, &remote_vec, 0);
                             switch (std.os.linux.E.init(rc)) {

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -3047,8 +3047,8 @@ fn writeToFile(
 
     // finally, write the entire binary into the file.
     var iovec = [_]std.posix.iovec_const{.{
-        .iov_base = binary_bytes.items.ptr,
-        .iov_len = binary_bytes.items.len,
+        .base = binary_bytes.items.ptr,
+        .len = binary_bytes.items.len,
     }};
     try wasm.base.file.?.writevAll(&iovec);
 }


### PR DESCRIPTION
~~Also uses the opportunity to apply this change to windows' WSABUF.~~

This removes the posix-y field names in favor of more concise names.