### PR TITLE
std.hash.crc: simplify api

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1150,7 +1150,7 @@ pub fn readElfDebugInfo(
         };
 
         const mapped_mem = try mapWholeFile(elf_file);
-        if (expected_crc) |crc| if (crc != std.hash.crc.Crc32SmallWithPoly(.IEEE).hash(mapped_mem)) return error.InvalidDebugInfo;
+        if (expected_crc) |crc| if (crc != std.hash.crc.Crc32.hash(mapped_mem)) return error.InvalidDebugInfo;
 
         const hdr: *const elf.Ehdr = @ptrCast(&mapped_mem[0]);
         if (!mem.eql(u8, hdr.e_ident[0..4], elf.MAGIC)) return error.InvalidElfMagic;

--- a/lib/std/hash/benchmark.zig
+++ b/lib/std/hash/benchmark.zig
@@ -56,12 +56,8 @@ const hashes = [_]Hash{
         .name = "adler32",
     },
     Hash{
-        .ty = hash.crc.Crc32WithPoly(.IEEE),
-        .name = "crc32-slicing-by-8",
-    },
-    Hash{
-        .ty = hash.crc.Crc32SmallWithPoly(.IEEE),
-        .name = "crc32-half-byte-lookup",
+        .ty = hash.crc.Crc32,
+        .name = "crc32",
     },
     Hash{
         .ty = hash.CityHash32,

--- a/lib/std/hash/crc.zig
+++ b/lib/std/hash/crc.zig
@@ -7,8 +7,7 @@ pub const Polynomial = impl.Polynomial;
 pub const Crc32WithPoly = impl.Crc32WithPoly;
 pub const Crc32SmallWithPoly = impl.Crc32SmallWithPoly;
 
-// IEEE is by far the most common CRC and so is aliased by default.
-pub const Crc32 = Crc32WithPoly(.IEEE);
+pub const Crc32 = Crc32IsoHdlc;
 
 test {
     _ = @import("crc/test.zig");
@@ -820,6 +819,14 @@ pub const Crc32Jamcrc = Crc(u32, .{
     .reflect_input = true,
     .reflect_output = true,
     .xor_output = 0x00000000,
+});
+
+pub const Crc32Koopman = Crc(u32, .{
+    .polynomial = 0x741b8cd7,
+    .initial = 0xffffffff,
+    .reflect_input = true,
+    .reflect_output = true,
+    .xor_output = 0xffffffff,
 });
 
 pub const Crc32Mef = Crc(u32, .{

--- a/lib/std/hash/crc/test.zig
+++ b/lib/std/hash/crc/test.zig
@@ -5,22 +5,25 @@ const testing = std.testing;
 const verify = @import("../verify.zig");
 const crc = @import("../crc.zig");
 
-test "crc32 ieee" {
-    inline for ([2]type{ crc.Crc32WithPoly(.IEEE), crc.Crc32SmallWithPoly(.IEEE) }) |ieee| {
-        try testing.expect(ieee.hash("") == 0x00000000);
-        try testing.expect(ieee.hash("a") == 0xe8b7be43);
-        try testing.expect(ieee.hash("abc") == 0x352441c2);
-        try verify.iterativeApi(ieee);
-    }
+test "crc32 ieee regression" {
+    const crc32 = crc.Crc32IsoHdlc;
+    try testing.expectEqual(crc32.hash(""), 0x00000000);
+    try testing.expectEqual(crc32.hash("a"), 0xe8b7be43);
+    try testing.expectEqual(crc32.hash("abc"), 0x352441c2);
 }
 
-test "crc32 castagnoli" {
-    inline for ([2]type{ crc.Crc32WithPoly(.Castagnoli), crc.Crc32SmallWithPoly(.Castagnoli) }) |casta| {
-        try testing.expect(casta.hash("") == 0x00000000);
-        try testing.expect(casta.hash("a") == 0xc1d04330);
-        try testing.expect(casta.hash("abc") == 0x364b3fb7);
-        try verify.iterativeApi(casta);
-    }
+test "crc32 castagnoli regression" {
+    const crc32 = crc.Crc32Iscsi;
+    try testing.expectEqual(crc32.hash(""), 0x00000000);
+    try testing.expectEqual(crc32.hash("a"), 0xc1d04330);
+    try testing.expectEqual(crc32.hash("abc"), 0x364b3fb7);
+}
+
+test "crc32 koopman regression" {
+    const crc32 = crc.Crc32Koopman;
+    try testing.expectEqual(crc32.hash(""), 0x00000000);
+    try testing.expectEqual(crc32.hash("a"), 0x0da2aa8a);
+    try testing.expectEqual(crc32.hash("abc"), 0xba2322ac);
 }
 
 test "CRC-3/GSM" {
@@ -1132,6 +1135,17 @@ test "CRC-32/JAMCRC" {
     c.update("1234");
     c.update("56789");
     try testing.expectEqual(@as(u32, 0x340bc6d9), c.final());
+}
+
+test "CRC-32/KOOPMAN" {
+    const Crc32Koopman = crc.Crc32Koopman;
+
+    try testing.expectEqual(@as(u32, 0x2d3dd0ae), Crc32Koopman.hash("123456789"));
+
+    var c = Crc32Koopman.init();
+    c.update("1234");
+    c.update("56789");
+    try testing.expectEqual(@as(u32, 0x2d3dd0ae), c.final());
 }
 
 test "CRC-32/MEF" {

--- a/tools/crc/catalog.txt
+++ b/tools/crc/catalog.txt
@@ -100,6 +100,7 @@ width=32  poly=0x04c11db7  init=0x00000000  refin=false  refout=false  xorout=0x
 width=32  poly=0x1edc6f41  init=0xffffffff  refin=true  refout=true  xorout=0xffffffff  check=0xe3069283  residue=0xb798b438  name="CRC-32/ISCSI"
 width=32  poly=0x04c11db7  init=0xffffffff  refin=true  refout=true  xorout=0xffffffff  check=0xcbf43926  residue=0xdebb20e3  name="CRC-32/ISO-HDLC"
 width=32  poly=0x04c11db7  init=0xffffffff  refin=true  refout=true  xorout=0x00000000  check=0x340bc6d9  residue=0x00000000  name="CRC-32/JAMCRC"
+width=32  poly=0x741b8cd7  init=0xffffffff  refin=true  refout=true  xorout=0xffffffff  check=0x2d3dd0ae  residue=0x00000000  name="CRC-32/KOOPMAN"
 width=32  poly=0x741b8cd7  init=0xffffffff  refin=true  refout=true  xorout=0x00000000  check=0xd2c22f51  residue=0x00000000  name="CRC-32/MEF"
 width=32  poly=0x04c11db7  init=0xffffffff  refin=false  refout=false  xorout=0x00000000  check=0x0376e6e7  residue=0x00000000  name="CRC-32/MPEG-2"
 width=32  poly=0x000000af  init=0x00000000  refin=false  refout=false  xorout=0x00000000  check=0xbd0be338  residue=0x00000000  name="CRC-32/XFER"

--- a/tools/update_crc_catalog.zig
+++ b/tools/update_crc_catalog.zig
@@ -48,8 +48,7 @@ pub fn main() anyerror!void {
         \\pub const Crc32WithPoly = impl.Crc32WithPoly;
         \\pub const Crc32SmallWithPoly = impl.Crc32SmallWithPoly;
         \\
-        \\// IEEE is by far the most common CRC and so is aliased by default.
-        \\pub const Crc32 = Crc32WithPoly(.IEEE);
+        \\pub const Crc32 = Crc32IsoHdlc;
         \\
         \\test {
         \\    _ = @import("crc/test.zig");
@@ -72,22 +71,25 @@ pub fn main() anyerror!void {
         \\const verify = @import("../verify.zig");
         \\const crc = @import("../crc.zig");
         \\
-        \\test "crc32 ieee" {
-        \\    inline for ([2]type{ crc.Crc32WithPoly(.IEEE), crc.Crc32SmallWithPoly(.IEEE) }) |ieee| {
-        \\        try testing.expect(ieee.hash("") == 0x00000000);
-        \\        try testing.expect(ieee.hash("a") == 0xe8b7be43);
-        \\        try testing.expect(ieee.hash("abc") == 0x352441c2);
-        \\        try verify.iterativeApi(ieee);
-        \\    }
+        \\test "crc32 ieee regression" {
+        \\    const crc32 = crc.Crc32IsoHdlc;
+        \\    try testing.expectEqual(crc32.hash(""), 0x00000000);
+        \\    try testing.expectEqual(crc32.hash("a"), 0xe8b7be43);
+        \\    try testing.expectEqual(crc32.hash("abc"), 0x352441c2);
         \\}
         \\
-        \\test "crc32 castagnoli" {
-        \\    inline for ([2]type{ crc.Crc32WithPoly(.Castagnoli), crc.Crc32SmallWithPoly(.Castagnoli) }) |casta| {
-        \\        try testing.expect(casta.hash("") == 0x00000000);
-        \\        try testing.expect(casta.hash("a") == 0xc1d04330);
-        \\        try testing.expect(casta.hash("abc") == 0x364b3fb7);
-        \\        try verify.iterativeApi(casta);
-        \\    }
+        \\test "crc32 castagnoli regression" {
+        \\    const crc32 = crc.Crc32Iscsi;
+        \\    try testing.expectEqual(crc32.hash(""), 0x00000000);
+        \\    try testing.expectEqual(crc32.hash("a"), 0xc1d04330);
+        \\    try testing.expectEqual(crc32.hash("abc"), 0x364b3fb7);
+        \\}
+        \\
+        \\test "crc32 koopman regression" {
+        \\    const crc32 = crc.Koopman;
+        \\    try testing.expectEqual(crc32.hash(""), 0x00000000);
+        \\    try testing.expectEqual(crc32.hash("a"), 0x0da2aa8a);
+        \\    try testing.expectEqual(crc32.hash("abc"), 0xba2322ac);
         \\}
         \\
     );


### PR DESCRIPTION
This removes the two original implementations in favour of the single generic one based on the Algorithm type. Previously we had three, very similar implementations which was somewhat confusing when knowing what one should actually be used.

The previous polynomials all have equivalent variants available when using the Algorithm type.

---

The Koopman polynomial did not have an exact equivalent so one has been added to the catalog.txt file. This does mean we have patched this file but this will be clear if updated in future and tests will catch this.

This is a breaking change for direct users of the old polynomial api. Specifically when using a custom or non-standard polynomial (the `Crc32` alias will continue to work). There are clear compile errors indicating what is required in order to retain existing functionality, this may require a small code-change from the user.

```zig
const hash = Crc32WithPoly(.Castagnoli); // old
const hash = Crc(.Crc32Iscsi); // new
```

Custom polynomials require a bit more interaction and will require a user to define their own Algorithm type. If used note that the previous implementation expected a pre-reflected polynomial and used the following parameters:

```zig
.{
    .polynomial = 0x741b8cd7, // equivalent to the reflected polynomial: 0xeb31d82e
    .initial = 0xffffffff,
    .reflect_input = true,
    .reflect_output = true,
    .xor_output = 0xffffffff,
});
```

Loose performance measurements below. Table sizes are indicated to the right. Nothing new, helps rationalise the overlap that was present.

```
crc32-slicing-by-8 # 8K of tables
   iterative:  3074 MiB/s [2d191d9400000000]
  small keys:  32B  4650 MiB/s 152387950 Hashes/s [20024c446a99a300]
crc32-half-byte-lookup # 64b of tables
   iterative:   281 MiB/s [2d191d9400000000]
  small keys:  32B   389 MiB/s 12751954 Hashes/s [20024c446a99a300]
crc32 # 1K of tables
   iterative:  3077 MiB/s [2d191d9400000000]
  small keys:  32B  4660 MiB/s 152709182 Hashes/s [20024c446a99a300]
```