### PR TITLE
Sema: Don't ignore current declaration if it's not ambiguous

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6882,7 +6882,7 @@ fn lookupInNamespace(
             }
         }
 
-        {
+        if (candidates.items.len > 1) {
             var i: usize = 0;
             while (i < candidates.items.len) {
                 if (candidates.items[i] == sema.owner_decl_index) {

--- a/test/behavior/usingnamespace.zig
+++ b/test/behavior/usingnamespace.zig
@@ -106,3 +106,15 @@ usingnamespace @Type(.{ .Struct = .{
     .decls = &.{},
     .is_tuple = false,
 } });
+
+pub const Recursion = struct {
+    usingnamespace struct {};
+
+    pub fn foo() void {
+        _ = Recursion.foo;
+    }
+};
+
+test "method is visible to itself when struct includes usingnamespace" {
+    Recursion.foo();
+}


### PR DESCRIPTION
This fixes #17872.

Previous logic was introduced in https://github.com/ziglang/zig/commit/c17793b4875cc9e1ccb605431142ffecb0b6f3f2 by @Vexu to address issue #12429. For the following piece of code there's no ambiguity and no reason to ignore the only declaration.

```zig
pub const Example = struct {
    usingnamespace struct {}; // works without this line

    pub fn foo() void {
        _ = Example.foo;  // error: struct 'main.Example' has no member named 'foo'
    }
};

pub fn main() !void {
    Example.foo();
}
```