### PR TITLE
test/link/glibc_compat: fix incorrect strlcpy result

### DIFF
--- a/test/link/glibc_compat/glibc_runtime_check.zig
+++ b/test/link/glibc_compat/glibc_runtime_check.zig
@@ -91,7 +91,7 @@ fn checkStrlcpy() !void {
 fn checkStrlcpy_v2_38() !void {
     var buf: [99]u8 = undefined;
     const used = c_string.strlcpy(&buf, "strlcpy works!", buf.len);
-    assert(used == 15);
+    assert(used == 14);
 }
 
 // atexit is part of libc_nonshared, so ensure its linked in correctly


### PR DESCRIPTION
This is causing the 0.12 release to fail to pass tests on archlinux where glibc is 2.39.

```
-- Install configuration: "None"
test
+- test-link
   +- link_test_cases
      +- link_test_cases.glibc_compat
         +- run native-linux-gnu.2.38 failure
thread 98682 panic: reached unreachable code
/build/zig/src/zig-0.12.0/testinstall/usr/lib/zig/std/debug.zig:403:14: 0x103125c in assert (native-linux-gnu.2.38)
    if (!ok) unreachable; // assertion failure
             ^
/build/zig/src/zig-0.12.0/test/link/glibc_compat/glibc_runtime_check.zig:94:11: 0x10313d0 in checkStrlcpy_v2_38 (native-linux-gnu.2.38)
    assert(used == 15);
          ^
/build/zig/src/zig-0.12.0/test/link/glibc_compat/glibc_runtime_check.zig:87:31: 0x1031408 in checkStrlcpy (native-linux-gnu.2.38)
        try checkStrlcpy_v2_38();
                              ^
/build/zig/src/zig-0.12.0/test/link/glibc_compat/glibc_runtime_check.zig:110:21: 0x1031509 in main (native-linux-gnu.2.38)
    try checkStrlcpy();
                    ^
/build/zig/src/zig-0.12.0/testinstall/usr/lib/zig/std/start.zig:511:37: 0x1031957 in main (native-linux-gnu.2.38)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x7602eb6d7ccf in ??? (libc.so.6)
Unwind information for `libc.so.6:0x7602eb6d7ccf` was not available, trace may be incomplete

error: the following command terminated with signal 6 (expected exited with code 0):
/build/zig/src/zig-0.12.0/zig-cache/o/45b02e331a9aa2c4fef7d9f787bae3e1/native-linux-gnu.2.38 
Build Summary: 6293/6469 steps succeeded; 171 skipped; 1 failed; 83654/86550 tests passed; 2896 skipped (disable with --summary none)
test transitive failure
+- test-link transitive failure
   +- link_test_cases transitive failure
      +- link_test_cases.glibc_compat transitive failure
         +- run native-linux-gnu.2.38 failure
error: the following build command failed with exit code 1:
/build/zig/src/zig-0.12.0/zig-cache/o/866e0c4f08ea7d3640d71005a5639683/build /build/zig/src/zig-0.12.0/testinstall/usr/bin/zig /build/zig/src/zig-0.12.0 /build/zig/src/zig-0.12.0/zig-cache /build/.cache/zig --seed 0x4e6c3d61 -Z80f2300259ea3a5b test -Dconfig_h=build/config.h -Dstatic-llvm=false -Denable-llvm=true -Dskip-non-native=true
```

You can see in the glibc source code that the result does *not* include the nul terminator: https://github.com/bminor/glibc/blob/ef321e23c20eebc6d6fb4044425c00e6df27b05f/string/strlcpy.c#L43

Introduced via https://github.com/ziglang/zig/pull/17702/files#r1582479339