### PR TITLE
posix.renameW: Handle DIRECTORY_NOT_EMPTY more generally

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -2770,9 +2770,6 @@ pub fn renameatW(
             .SUCCESS => return,
             // INVALID_PARAMETER here means that the filesystem does not support FileRenameInformationEx
             .INVALID_PARAMETER => {},
-            .DIRECTORY_NOT_EMPTY => return error.PathAlreadyExists,
-            .FILE_IS_A_DIRECTORY => return error.IsDir,
-            .NOT_A_DIRECTORY => return error.NotDir,
             // For all other statuses, fall down to the switch below to handle them.
             else => need_fallback = false,
         }
@@ -2815,6 +2812,9 @@ pub fn renameatW(
         .OBJECT_PATH_NOT_FOUND => return error.FileNotFound,
         .NOT_SAME_DEVICE => return error.RenameAcrossMountPoints,
         .OBJECT_NAME_COLLISION => return error.PathAlreadyExists,
+        .DIRECTORY_NOT_EMPTY => return error.PathAlreadyExists,
+        .FILE_IS_A_DIRECTORY => return error.IsDir,
+        .NOT_A_DIRECTORY => return error.NotDir,
         else => return windows.unexpectedStatus(rc),
     }
 }


### PR DESCRIPTION
Before this commit, the DIRECTORY_NOT_EMPTY/FILE_IS_A_DIRECTORY/NOT_A_DIRECTORY statuses were assumed only to be possible when using `FILE_RENAME_INFORMATION_EX` and `FILE_RENAME_POSIX_SEMANTICS`, but that has empirically been shown to be false; a networked samba share can return the DIRECTORY_NOT_EMPTY status from `FILE_RENAME_INFORMATION` (which doesn't support `FILE_RENAME_POSIX_SEMANTICS`).

`FILE_IS_A_DIRECTORY` and `NOT_A_DIRECTORY` were not proven to be possible (from my testing, `OBJECT_NAME_COLLISION` is returned when trying to name a file onto a directory or vice versa), but they were also moved to the outer switch just in case.

Fixes #19785