### PR TITLE
Sema: Don't generate runtime instructions on zirSplat if dest_ty doesn't have runtime bits

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -24295,6 +24295,14 @@ fn zirSplat(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.I
 
     if (!dest_ty.isVector(mod)) return sema.fail(block, src, "expected vector type, found '{}'", .{dest_ty.fmt(mod)});
 
+    if (!dest_ty.hasRuntimeBits(mod)) {
+        const empty_aggregate = try mod.intern(.{ .aggregate = .{
+            .ty = dest_ty.toIntern(),
+            .storage = .{ .elems = &[_]InternPool.Index{} },
+        } });
+        return Air.internedToRef(empty_aggregate);
+    }
+
     const operand = try sema.resolveInst(extra.rhs);
     const scalar_ty = dest_ty.childType(mod);
     const scalar = try sema.coerce(block, scalar_ty, operand, scalar_src);


### PR DESCRIPTION
Attempt to fix #19455

Example to reproduce:

```
const std = @import("std");

fn splat(comptime n: comptime_int, value: anytype) @Vector(n, @TypeOf(value)) {
    return @splat(value);
}

test {
    _ = splat(0, @as(u8, 0));
}
```