### PR TITLE
Use tcc for zig bootstrap in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install tcc
       - name: Build and Test
         run: sh ci/x86_64-linux-debug.sh
   x86_64-linux-release:
@@ -23,6 +27,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install tcc
       - name: Build and Test
         run: sh ci/x86_64-linux-release.sh
   aarch64-linux-debug:

--- a/ci/x86_64-linux-debug.sh
+++ b/ci/x86_64-linux-debug.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Requires cmake ninja-build
+# Requires cmake ninja-build tcc
 
 set -x
 set -e
@@ -11,6 +11,7 @@ MCPU="baseline"
 CACHE_BASENAME="zig+llvm+lld+clang-$TARGET-0.12.0-dev.203+d3bc1cfc4"
 PREFIX="$HOME/deps/$CACHE_BASENAME"
 ZIG="$PREFIX/bin/zig"
+export CC="tcc"
 
 export PATH="$HOME/deps/wasmtime-v10.0.2-$ARCH-linux:$HOME/deps/qemu-linux-x86_64-8.2.1/bin:$PATH"
 
@@ -22,7 +23,7 @@ git fetch --tags
 # Test building from source without LLVM.
 git clean -fd
 rm -rf zig-out
-cc -o bootstrap bootstrap.c
+$CC -o bootstrap bootstrap.c
 ./bootstrap
 ./zig2 build -Dno-lib
 ./zig-out/bin/zig test test/behavior.zig

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Requires cmake ninja-build
+# Requires cmake ninja-build tcc
 
 set -x
 set -e
@@ -11,6 +11,7 @@ MCPU="baseline"
 CACHE_BASENAME="zig+llvm+lld+clang-$TARGET-0.12.0-dev.203+d3bc1cfc4"
 PREFIX="$HOME/deps/$CACHE_BASENAME"
 ZIG="$PREFIX/bin/zig"
+export CC="tcc"
 
 export PATH="$HOME/deps/wasmtime-v10.0.2-$ARCH-linux:$HOME/deps/qemu-linux-x86_64-8.2.1/bin:$PATH"
 
@@ -22,7 +23,7 @@ git fetch --tags
 # Test building from source without LLVM.
 git clean -fd
 rm -rf zig-out
-cc -o bootstrap bootstrap.c
+$CC -o bootstrap bootstrap.c
 ./bootstrap
 ./zig2 build -Dno-lib
 ./zig-out/bin/zig test test/behavior.zig


### PR DESCRIPTION
tcc is fast:
```sh
tcc -o zig1 zig1.c stage1/wasi.c -std=c99 -Os -lm  1.20s user 0.08s system 99% cpu 1.281 total
gcc -o zig1 zig1.c stage1/wasi.c -std=c99 -Os -lm  122.82s user 15.81s system 99% cpu 2:19.76 total
clang -o zig1 zig1.c stage1/wasi.c -std=c99 -Os -lm  0.03s user 0.02s system 0% cpu 13:25.35 total # didnt finish
```