### PR TITLE
std.posix: handle INVAL in openZ, openatZ and openatWasi

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -1598,7 +1598,7 @@ pub fn openZ(file_path: [*:0]const u8, flags: O, perm: mode_t) OpenError!fd_t {
             .INTR => continue,
 
             .FAULT => unreachable,
-            .INVAL => unreachable,
+            .INVAL => return error.BadPathName,
             .ACCES => return error.AccessDenied,
             .FBIG => return error.FileTooBig,
             .OVERFLOW => return error.FileTooBig,
@@ -1676,6 +1676,9 @@ pub fn openatWasi(
             .INTR => continue,
 
             .FAULT => unreachable,
+            // FIXME: It is worth looking into returning a `error.BadPathName`
+            // here if wasi follows other posix behavior
+            // see: https://github.com/ziglang/zig/issues/15607
             .INVAL => unreachable,
             .BADF => unreachable,
             .ACCES => return error.AccessDenied,
@@ -1767,7 +1770,7 @@ pub fn openatZ(dir_fd: fd_t, file_path: [*:0]const u8, flags: O, mode: mode_t) O
             .INTR => continue,
 
             .FAULT => unreachable,
-            .INVAL => unreachable,
+            .INVAL => return error.BadPathName,
             .BADF => unreachable,
             .ACCES => return error.AccessDenied,
             .FBIG => return error.FileTooBig,

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -1676,10 +1676,8 @@ pub fn openatWasi(
             .INTR => continue,
 
             .FAULT => unreachable,
-            // FIXME: It is worth looking into returning a `error.BadPathName`
-            // here if wasi follows other posix behavior
-            // see: https://github.com/ziglang/zig/issues/15607
-            .INVAL => unreachable,
+            // Provides INVAL with a linux host on a bad path name, but NOENT on Windows
+            .INVAL => return error.BadPathName,
             .BADF => unreachable,
             .ACCES => return error.AccessDenied,
             .FBIG => return error.FileTooBig,


### PR DESCRIPTION
Contributes to #15607

~~Although the case is not handled in `openatWasi` (as I could not get a
working wasi environment to test the change) I have added a FIXME
addressing it and linking to the issue.~~

Edit: Handled case in openatWasi too