### PR TITLE
Rename `Dir.writeFile2` -> `Dir.writeFile` and update all callsites

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -308,7 +308,7 @@ pub fn main() !void {
         }
         const s = std.fs.path.sep_str;
         const tmp_sub_path = "tmp" ++ s ++ (output_tmp_nonce orelse fatal("missing -Z arg", .{}));
-        local_cache_directory.handle.writeFile2(.{
+        local_cache_directory.handle.writeFile(.{
             .sub_path = tmp_sub_path,
             .data = buffer.items,
             .flags = .{ .exclusive = true },

--- a/lib/compiler/reduce.zig
+++ b/lib/compiler/reduce.zig
@@ -233,7 +233,7 @@ pub fn main() !void {
                 }
             }
 
-            try std.fs.cwd().writeFile(root_source_file_path, rendered.items);
+            try std.fs.cwd().writeFile(.{ .sub_path = root_source_file_path, .data = rendered.items });
             // std.debug.print("trying this code:\n{s}\n", .{rendered.items});
 
             const interestingness = try runCheck(arena, interestingness_argv.items);
@@ -274,7 +274,7 @@ pub fn main() !void {
         fixups.clearRetainingCapacity();
         rendered.clearRetainingCapacity();
         try tree.renderToArrayList(&rendered, fixups);
-        try std.fs.cwd().writeFile(root_source_file_path, rendered.items);
+        try std.fs.cwd().writeFile(.{ .sub_path = root_source_file_path, .data = rendered.items });
 
         return std.process.cleanExit();
     }

--- a/lib/compiler/resinator/main.zig
+++ b/lib/compiler/resinator/main.zig
@@ -178,7 +178,7 @@ pub fn main() !void {
     defer allocator.free(full_input);
 
     if (options.preprocess == .only) {
-        try std.fs.cwd().writeFile(options.output_filename, full_input);
+        try std.fs.cwd().writeFile(.{ .sub_path = options.output_filename, .data = full_input });
         return;
     }
 

--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -1005,7 +1005,7 @@ pub fn readSmallFile(dir: fs.Dir, sub_path: []const u8, buffer: []u8) ![]u8 {
 pub fn writeSmallFile(dir: fs.Dir, sub_path: []const u8, data: []const u8) !void {
     assert(data.len <= 255);
     if (builtin.os.tag == .windows) {
-        return dir.writeFile(sub_path, data);
+        return dir.writeFile(.{ .sub_path = sub_path, .data = data });
     } else {
         return dir.symLink(data, sub_path, .{});
     }
@@ -1052,7 +1052,7 @@ test "cache file and then recall it" {
     const temp_file = "test.txt";
     const temp_manifest_dir = "temp_manifest_dir";
 
-    try tmp.dir.writeFile(temp_file, "Hello, world!\n");
+    try tmp.dir.writeFile(.{ .sub_path = temp_file, .data = "Hello, world!\n" });
 
     // Wait for file timestamps to tick
     const initial_time = try testGetCurrentFileTimestamp(tmp.dir);
@@ -1120,7 +1120,7 @@ test "check that changing a file makes cache fail" {
     const original_temp_file_contents = "Hello, world!\n";
     const updated_temp_file_contents = "Hello, world; but updated!\n";
 
-    try tmp.dir.writeFile(temp_file, original_temp_file_contents);
+    try tmp.dir.writeFile(.{ .sub_path = temp_file, .data = original_temp_file_contents });
 
     // Wait for file timestamps to tick
     const initial_time = try testGetCurrentFileTimestamp(tmp.dir);
@@ -1156,7 +1156,7 @@ test "check that changing a file makes cache fail" {
             try ch.writeManifest();
         }
 
-        try tmp.dir.writeFile(temp_file, updated_temp_file_contents);
+        try tmp.dir.writeFile(.{ .sub_path = temp_file, .data = updated_temp_file_contents });
 
         {
             var ch = cache.obtain();
@@ -1241,8 +1241,8 @@ test "Manifest with files added after initial hash work" {
     const temp_file2 = "cache_hash_post_file_test2.txt";
     const temp_manifest_dir = "cache_hash_post_file_manifest_dir";
 
-    try tmp.dir.writeFile(temp_file1, "Hello, world!\n");
-    try tmp.dir.writeFile(temp_file2, "Hello world the second!\n");
+    try tmp.dir.writeFile(.{ .sub_path = temp_file1, .data = "Hello, world!\n" });
+    try tmp.dir.writeFile(.{ .sub_path = temp_file2, .data = "Hello world the second!\n" });
 
     // Wait for file timestamps to tick
     const initial_time = try testGetCurrentFileTimestamp(tmp.dir);
@@ -1292,7 +1292,7 @@ test "Manifest with files added after initial hash work" {
         try testing.expect(mem.eql(u8, &digest1, &digest2));
 
         // Modify the file added after initial hash
-        try tmp.dir.writeFile(temp_file2, "Hello world the second, updated\n");
+        try tmp.dir.writeFile(.{ .sub_path = temp_file2, .data = "Hello world the second, updated\n" });
 
         // Wait for file timestamps to tick
         const initial_time2 = try testGetCurrentFileTimestamp(tmp.dir);

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1715,7 +1715,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         );
 
         const args_file = "args" ++ fs.path.sep_str ++ args_hex_hash;
-        try b.cache_root.handle.writeFile(args_file, args);
+        try b.cache_root.handle.writeFile(.{ .sub_path = args_file, .data = args });
 
         const resolved_args_file = try mem.concat(arena, u8, &.{
             "@",

--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -246,7 +246,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         });
     };
 
-    b.cache_root.handle.writeFile(sub_path, output.items) catch |err| {
+    b.cache_root.handle.writeFile(.{ .sub_path = sub_path, .data = output.items }) catch |err| {
         return step.fail("unable to write file '{}{s}': {s}", .{
             b.cache_root, sub_path, @errorName(err),
         });

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -464,7 +464,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                 });
             };
 
-            b.cache_root.handle.writeFile(tmp_sub_path, self.contents.items) catch |err| {
+            b.cache_root.handle.writeFile(.{ .sub_path = tmp_sub_path, .data = self.contents.items }) catch |err| {
                 return step.fail("unable to write options to '{}{s}': {s}", .{
                     b.cache_root, tmp_sub_path, @errorName(err),
                 });

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -930,7 +930,7 @@ fn runCommand(
                     b.cache_root, sub_path_dirname, @errorName(err),
                 });
             };
-            b.cache_root.handle.writeFile(sub_path, stream.bytes.?) catch |err| {
+            b.cache_root.handle.writeFile(.{ .sub_path = sub_path, .data = stream.bytes.? }) catch |err| {
                 return step.fail("unable to write file '{}{s}': {s}", .{
                     b.cache_root, sub_path, @errorName(err),
                 });

--- a/lib/std/Build/Step/WriteFile.zig
+++ b/lib/std/Build/Step/WriteFile.zig
@@ -218,7 +218,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         }
         switch (output_source_file.contents) {
             .bytes => |bytes| {
-                b.build_root.handle.writeFile(output_source_file.sub_path, bytes) catch |err| {
+                b.build_root.handle.writeFile(.{ .sub_path = output_source_file.sub_path, .data = bytes }) catch |err| {
                     return step.fail("unable to write file '{}{s}': {s}", .{
                         b.build_root, output_source_file.sub_path, @errorName(err),
                     });
@@ -311,7 +311,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         }
         switch (file.contents) {
             .bytes => |bytes| {
-                cache_dir.writeFile(file.sub_path, bytes) catch |err| {
+                cache_dir.writeFile(.{ .sub_path = file.sub_path, .data = bytes }) catch |err| {
                     return step.fail("unable to write file '{}{s}{c}{s}': {s}", .{
                         b.cache_root, cache_path, fs.path.sep, file.sub_path, @errorName(err),
                     });

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1524,7 +1524,7 @@ test printLineFromFileAnyOs {
     {
         const path = try join(allocator, &.{ test_dir_path, "one_line.zig" });
         defer allocator.free(path);
-        try test_dir.dir.writeFile("one_line.zig", "no new lines in this file, but one is printed anyway");
+        try test_dir.dir.writeFile(.{ .sub_path = "one_line.zig", .data = "no new lines in this file, but one is printed anyway" });
 
         try expectError(error.EndOfFile, printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 2, .column = 0 }));
 
@@ -1535,11 +1535,14 @@ test printLineFromFileAnyOs {
     {
         const path = try fs.path.join(allocator, &.{ test_dir_path, "three_lines.zig" });
         defer allocator.free(path);
-        try test_dir.dir.writeFile("three_lines.zig",
+        try test_dir.dir.writeFile(.{
+            .sub_path = "three_lines.zig",
+            .data =
             \\1
             \\2
             \\3
-        );
+            ,
+        });
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 1, .column = 0 });
         try expectEqualStrings("1\n", output.items);

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -2339,18 +2339,6 @@ fn deleteTreeOpenInitialSubpath(self: Dir, sub_path: []const u8, kind_hint: File
 
 pub const WriteFileError = File.WriteError || File.OpenError;
 
-/// Deprecated: use `writeFile2`.
-/// On Windows, `sub_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
-/// On WASI, `sub_path` should be encoded as valid UTF-8.
-/// On other platforms, `sub_path` is an opaque sequence of bytes with no particular encoding.
-pub fn writeFile(self: Dir, sub_path: []const u8, data: []const u8) WriteFileError!void {
-    return writeFile2(self, .{
-        .sub_path = sub_path,
-        .data = data,
-        .flags = .{},
-    });
-}
-
 pub const WriteFileOptions = struct {
     /// On Windows, `sub_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
     /// On WASI, `sub_path` should be encoded as valid UTF-8.
@@ -2361,11 +2349,13 @@ pub const WriteFileOptions = struct {
 };
 
 /// Writes content to the file system, using the file creation flags provided.
-pub fn writeFile2(self: Dir, options: WriteFileOptions) WriteFileError!void {
+pub fn writeFile(self: Dir, options: WriteFileOptions) WriteFileError!void {
     var file = try self.createFile(options.sub_path, options.flags);
     defer file.close();
     try file.writeAll(options.data);
 }
+
+pub const writeFile2 = @compileError("deprecated; renamed to writeFile");
 
 pub const AccessError = posix.AccessError;
 

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -178,7 +178,7 @@ test "Dir.readLink" {
         fn impl(ctx: *TestContext) !void {
             // Create some targets
             const file_target_path = try ctx.transformPath("file.txt");
-            try ctx.dir.writeFile(file_target_path, "nonsense");
+            try ctx.dir.writeFile(.{ .sub_path = file_target_path, .data = "nonsense" });
             const dir_target_path = try ctx.transformPath("subdir");
             try ctx.dir.makeDir(dir_target_path);
 
@@ -398,7 +398,7 @@ test "readLinkAbsolute" {
     defer tmp.cleanup();
 
     // Create some targets
-    try tmp.dir.writeFile("file.txt", "nonsense");
+    try tmp.dir.writeFile(.{ .sub_path = "file.txt", .data = "nonsense" });
     try tmp.dir.makeDir("subdir");
 
     // Get base abs path
@@ -620,7 +620,7 @@ test "Dir.realpath smoke test" {
             try testing.expectError(error.FileNotFound, ctx.dir.realpath(test_dir_path, &buf));
 
             // Now create the file and dir
-            try ctx.dir.writeFile(test_file_path, "");
+            try ctx.dir.writeFile(.{ .sub_path = test_file_path, .data = "" });
             try ctx.dir.makeDir(test_dir_path);
 
             const base_path = try ctx.transformPath(".");
@@ -695,7 +695,7 @@ test "Dir.statFile" {
 
             try testing.expectError(error.FileNotFound, ctx.dir.statFile(test_file_name));
 
-            try ctx.dir.writeFile(test_file_name, "");
+            try ctx.dir.writeFile(.{ .sub_path = test_file_name, .data = "" });
 
             const stat = try ctx.dir.statFile(test_file_name);
             try testing.expectEqual(File.Kind.file, stat.kind);
@@ -803,7 +803,7 @@ test "deleteDir" {
 
             // deleting a non-empty directory
             try ctx.dir.makeDir(test_dir_path);
-            try ctx.dir.writeFile(test_file_path, "");
+            try ctx.dir.writeFile(.{ .sub_path = test_file_path, .data = "" });
             try testing.expectError(error.DirNotEmpty, ctx.dir.deleteDir(test_dir_path));
 
             // deleting an empty directory
@@ -1071,7 +1071,7 @@ test "deleteTree on a symlink" {
     defer tmp.cleanup();
 
     // Symlink to a file
-    try tmp.dir.writeFile("file", "");
+    try tmp.dir.writeFile(.{ .sub_path = "file", .data = "" });
     try setupSymlink(tmp.dir, "file", "filelink", .{});
 
     try tmp.dir.deleteTree("filelink");
@@ -1094,8 +1094,14 @@ test "makePath, put some files in it, deleteTree" {
             const dir_path = try ctx.transformPath("os_test_tmp");
 
             try ctx.dir.makePath(try fs.path.join(allocator, &.{ "os_test_tmp", "b", "c" }));
-            try ctx.dir.writeFile(try fs.path.join(allocator, &.{ "os_test_tmp", "b", "c", "file.txt" }), "nonsense");
-            try ctx.dir.writeFile(try fs.path.join(allocator, &.{ "os_test_tmp", "b", "file2.txt" }), "blah");
+            try ctx.dir.writeFile(.{
+                .sub_path = try fs.path.join(allocator, &.{ "os_test_tmp", "b", "c", "file.txt" }),
+                .data = "nonsense",
+            });
+            try ctx.dir.writeFile(.{
+                .sub_path = try fs.path.join(allocator, &.{ "os_test_tmp", "b", "file2.txt" }),
+                .data = "blah",
+            });
 
             try ctx.dir.deleteTree(dir_path);
             try testing.expectError(error.FileNotFound, ctx.dir.openDir(dir_path, .{}));
@@ -1110,8 +1116,14 @@ test "makePath, put some files in it, deleteTreeMinStackSize" {
             const dir_path = try ctx.transformPath("os_test_tmp");
 
             try ctx.dir.makePath(try fs.path.join(allocator, &.{ "os_test_tmp", "b", "c" }));
-            try ctx.dir.writeFile(try fs.path.join(allocator, &.{ "os_test_tmp", "b", "c", "file.txt" }), "nonsense");
-            try ctx.dir.writeFile(try fs.path.join(allocator, &.{ "os_test_tmp", "b", "file2.txt" }), "blah");
+            try ctx.dir.writeFile(.{
+                .sub_path = try fs.path.join(allocator, &.{ "os_test_tmp", "b", "c", "file.txt" }),
+                .data = "nonsense",
+            });
+            try ctx.dir.writeFile(.{
+                .sub_path = try fs.path.join(allocator, &.{ "os_test_tmp", "b", "file2.txt" }),
+                .data = "blah",
+            });
 
             try ctx.dir.deleteTreeMinStackSize(dir_path);
             try testing.expectError(error.FileNotFound, ctx.dir.openDir(dir_path, .{}));
@@ -1134,7 +1146,7 @@ test "makePath but sub_path contains pre-existing file" {
     defer tmp.cleanup();
 
     try tmp.dir.makeDir("foo");
-    try tmp.dir.writeFile("foo/bar", "");
+    try tmp.dir.writeFile(.{ .sub_path = "foo/bar", .data = "" });
 
     try testing.expectError(error.NotDir, tmp.dir.makePath("foo/bar/baz"));
 }
@@ -1227,7 +1239,7 @@ fn testFilenameLimits(iterable_dir: Dir, maxed_filename: []const u8) !void {
         var maxed_dir = try iterable_dir.makeOpenPath(maxed_filename, .{});
         defer maxed_dir.close();
 
-        try maxed_dir.writeFile(maxed_filename, "");
+        try maxed_dir.writeFile(.{ .sub_path = maxed_filename, .data = "" });
 
         var walker = try iterable_dir.walk(testing.allocator);
         defer walker.deinit();
@@ -1357,7 +1369,7 @@ test "access file" {
             try ctx.dir.makePath(dir_path);
             try testing.expectError(error.FileNotFound, ctx.dir.access(file_path, .{}));
 
-            try ctx.dir.writeFile(file_path, "");
+            try ctx.dir.writeFile(.{ .sub_path = file_path, .data = "" });
             try ctx.dir.access(file_path, .{});
             try ctx.dir.deleteTree(dir_path);
         }
@@ -1463,7 +1475,7 @@ test "copyFile" {
             const dest_file = try ctx.transformPath("tmp_test_copy_file2.txt");
             const dest_file2 = try ctx.transformPath("tmp_test_copy_file3.txt");
 
-            try ctx.dir.writeFile(src_file, data);
+            try ctx.dir.writeFile(.{ .sub_path = src_file, .data = data });
             defer ctx.dir.deleteFile(src_file) catch {};
 
             try ctx.dir.copyFile(src_file, ctx.dir, dest_file, .{});
@@ -1740,7 +1752,7 @@ test "'.' and '..' in fs.Dir functions" {
             renamed_file.close();
             try ctx.dir.deleteFile(rename_path);
 
-            try ctx.dir.writeFile(update_path, "something");
+            try ctx.dir.writeFile(.{ .sub_path = update_path, .data = "something" });
             const prev_status = try ctx.dir.updateFile(file_path, ctx.dir, update_path, .{});
             try testing.expectEqual(fs.Dir.PrevStatus.stale, prev_status);
 
@@ -2009,11 +2021,7 @@ test "invalid UTF-8/WTF-8 paths" {
             try testing.expectError(expected_err, ctx.dir.deleteTree(invalid_path));
             try testing.expectError(expected_err, ctx.dir.deleteTreeMinStackSize(invalid_path));
 
-            try testing.expectError(expected_err, ctx.dir.writeFile(invalid_path, ""));
-            try testing.expectError(expected_err, ctx.dir.writeFile2(.{
-                .sub_path = invalid_path,
-                .data = "",
-            }));
+            try testing.expectError(expected_err, ctx.dir.writeFile(.{ .sub_path = invalid_path, .data = "" }));
 
             try testing.expectError(expected_err, ctx.dir.access(invalid_path, .{}));
             try testing.expectError(expected_err, ctx.dir.accessZ(invalid_path, .{}));

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -209,7 +209,7 @@ test "symlink with relative paths" {
     cwd.deleteFile("symlinked") catch {};
 
     // First, try relative paths in cwd
-    try cwd.writeFile("file.txt", "nonsense");
+    try cwd.writeFile(.{ .sub_path = "file.txt", .data = "nonsense" });
 
     if (native_os == .windows) {
         std.os.windows.CreateSymbolicLink(
@@ -268,7 +268,7 @@ test "link with relative paths" {
     cwd.deleteFile("example.txt") catch {};
     cwd.deleteFile("new.txt") catch {};
 
-    try cwd.writeFile("example.txt", "example");
+    try cwd.writeFile(.{ .sub_path = "example.txt", .data = "example" });
     try posix.link("example.txt", "new.txt", 0);
 
     const efd = try cwd.openFile("example.txt", .{});
@@ -312,7 +312,7 @@ test "linkat with different directories" {
     cwd.deleteFile("example.txt") catch {};
     tmp.dir.deleteFile("new.txt") catch {};
 
-    try cwd.writeFile("example.txt", "example");
+    try cwd.writeFile(.{ .sub_path = "example.txt", .data = "example" });
     try posix.linkat(cwd.fd, "example.txt", tmp.dir.fd, "new.txt", 0);
 
     const efd = try cwd.openFile("example.txt", .{});
@@ -348,7 +348,7 @@ test "fstatat" {
 
     // create dummy file
     const contents = "nonsense";
-    try tmp.dir.writeFile("file.txt", contents);
+    try tmp.dir.writeFile(.{ .sub_path = "file.txt", .data = contents });
 
     // fetch file's info on the opened fd directly
     const file = try tmp.dir.openFile("file.txt", .{});
@@ -366,7 +366,7 @@ test "readlinkat" {
     defer tmp.cleanup();
 
     // create file
-    try tmp.dir.writeFile("file.txt", "nonsense");
+    try tmp.dir.writeFile(.{ .sub_path = "file.txt", .data = "nonsense" });
 
     // create a symbolic link
     if (native_os == .windows) {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4175,7 +4175,7 @@ pub fn cImport(comp: *Compilation, c_src: []const u8, owner_mod: *Package.Module
         });
         const out_dep_path = try std.fmt.allocPrint(arena, "{s}.d", .{out_h_path});
 
-        try zig_cache_tmp_dir.writeFile(cimport_basename, c_src);
+        try zig_cache_tmp_dir.writeFile(.{ .sub_path = cimport_basename, .data = c_src });
         if (comp.verbose_cimport) {
             log.info("C import source: {s}", .{out_h_path});
         }
@@ -4840,7 +4840,7 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
             // 1 is CREATEPROCESS_MANIFEST_RESOURCE_ID which is the default ID used for RT_MANIFEST resources
             // 24 is RT_MANIFEST
             const input = try std.fmt.allocPrint(arena, "1 24 \"{s}\"", .{fmtRcEscape(src_path)});
-            try o_dir.writeFile(rc_basename, input);
+            try o_dir.writeFile(.{ .sub_path = rc_basename, .data = input });
 
             var argv = std.ArrayList([]const u8).init(comp.gpa);
             defer argv.deinit();

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -755,7 +755,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: *std.Progress.Node) !vo
                 try map_contents.writer().print("GLIBC_{d}.{d}.{d} {{ }};\n", .{ ver.major, ver.minor, ver.patch });
             }
         }
-        try o_directory.handle.writeFile(all_map_basename, map_contents.items);
+        try o_directory.handle.writeFile(.{ .sub_path = all_map_basename, .data = map_contents.items });
         map_contents.deinit(); // The most recent allocation of an arena can be freed :)
     }
 
@@ -1040,7 +1040,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: *std.Progress.Node) !vo
 
         var lib_name_buf: [32]u8 = undefined; // Larger than each of the names "c", "pthread", etc.
         const asm_file_basename = std.fmt.bufPrint(&lib_name_buf, "{s}.s", .{lib.name}) catch unreachable;
-        try o_directory.handle.writeFile(asm_file_basename, stubs_asm.items);
+        try o_directory.handle.writeFile(.{ .sub_path = asm_file_basename, .data = stubs_asm.items });
 
         try buildSharedLib(comp, arena, comp.global_cache_directory, o_directory, asm_file_basename, lib, prog_node);
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -6966,7 +6966,7 @@ fn cmdFetch(
     defer rendered.deinit();
     try ast.renderToArrayList(&rendered, fixups);
 
-    build_root.directory.handle.writeFile(Package.Manifest.basename, rendered.items) catch |err| {
+    build_root.directory.handle.writeFile(.{ .sub_path = Package.Manifest.basename, .data = rendered.items }) catch |err| {
         fatal("unable to write {s} file: {s}", .{ Package.Manifest.basename, @errorName(err) });
     };
 
@@ -7013,7 +7013,7 @@ fn createDependenciesModule(
     {
         var tmp_dir = try local_cache_directory.handle.makeOpenPath(tmp_dir_sub_path, .{});
         defer tmp_dir.close();
-        try tmp_dir.writeFile(basename, source);
+        try tmp_dir.writeFile(.{ .sub_path = basename, .data = source });
     }
 
     var hh: Cache.HashHelper = .{};
@@ -7225,7 +7225,7 @@ const Templates = struct {
             }
         }
 
-        return out_dir.writeFile2(.{
+        return out_dir.writeFile(.{
             .sub_path = template_path,
             .data = templates.buffer.items,
             .flags = .{ .exclusive = true },

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -1641,7 +1641,7 @@ fn runOneCase(
         var sync_node = update_node.start("write", 0);
         sync_node.activate();
         for (update.files.items) |file| {
-            try tmp.dir.writeFile(file.path, file.src);
+            try tmp.dir.writeFile(.{ .sub_path = file.path, .data = file.src });
         }
         sync_node.end();
 

--- a/test/standalone/windows_bat_args/fuzz.zig
+++ b/test/standalone/windows_bat_args/fuzz.zig
@@ -51,15 +51,15 @@ pub fn main() anyerror!void {
     const preamble_len = buf.items.len;
 
     try buf.appendSlice(" %*");
-    try tmp.dir.writeFile("args1.bat", buf.items);
+    try tmp.dir.writeFile(.{ .sub_path = "args1.bat", .data = buf.items });
     buf.shrinkRetainingCapacity(preamble_len);
 
     try buf.appendSlice(" %1 %2 %3 %4 %5 %6 %7 %8 %9");
-    try tmp.dir.writeFile("args2.bat", buf.items);
+    try tmp.dir.writeFile(.{ .sub_path = "args2.bat", .data = buf.items });
     buf.shrinkRetainingCapacity(preamble_len);
 
     try buf.appendSlice(" \"%~1\" \"%~2\" \"%~3\" \"%~4\" \"%~5\" \"%~6\" \"%~7\" \"%~8\" \"%~9\"");
-    try tmp.dir.writeFile("args3.bat", buf.items);
+    try tmp.dir.writeFile(.{ .sub_path = "args3.bat", .data = buf.items });
     buf.shrinkRetainingCapacity(preamble_len);
 
     var i: u64 = 0;

--- a/test/standalone/windows_bat_args/test.zig
+++ b/test/standalone/windows_bat_args/test.zig
@@ -25,15 +25,15 @@ pub fn main() anyerror!void {
     const preamble_len = buf.items.len;
 
     try buf.appendSlice(" %*");
-    try tmp.dir.writeFile("args1.bat", buf.items);
+    try tmp.dir.writeFile(.{ .sub_path = "args1.bat", .data = buf.items });
     buf.shrinkRetainingCapacity(preamble_len);
 
     try buf.appendSlice(" %1 %2 %3 %4 %5 %6 %7 %8 %9");
-    try tmp.dir.writeFile("args2.bat", buf.items);
+    try tmp.dir.writeFile(.{ .sub_path = "args2.bat", .data = buf.items });
     buf.shrinkRetainingCapacity(preamble_len);
 
     try buf.appendSlice(" \"%~1\" \"%~2\" \"%~3\" \"%~4\" \"%~5\" \"%~6\" \"%~7\" \"%~8\" \"%~9\"");
-    try tmp.dir.writeFile("args3.bat", buf.items);
+    try tmp.dir.writeFile(.{ .sub_path = "args3.bat", .data = buf.items });
     buf.shrinkRetainingCapacity(preamble_len);
 
     // Test cases are from https://github.com/rust-lang/rust/blob/master/tests/ui/std/windows-bat-args.rs

--- a/test/standalone/windows_spawn/main.zig
+++ b/test/standalone/windows_spawn/main.zig
@@ -53,9 +53,9 @@ pub fn main() anyerror!void {
     try testExec(allocator, "heLLo", "hello from exe\n");
 
     // now add a .bat
-    try tmp.dir.writeFile("hello.bat", "@echo hello from bat");
+    try tmp.dir.writeFile(.{ .sub_path = "hello.bat", .data = "@echo hello from bat" });
     // and a .cmd
-    try tmp.dir.writeFile("hello.cmd", "@echo hello from cmd");
+    try tmp.dir.writeFile(.{ .sub_path = "hello.cmd", .data = "@echo hello from cmd" });
 
     // with extension should find the .bat (case insensitive)
     try testExec(allocator, "heLLo.bat", "hello from bat\r\n");
@@ -87,7 +87,7 @@ pub fn main() anyerror!void {
     try testExec(allocator, "heLLo", "hello from bat\r\n");
 
     // Add a hello.exe that is not a valid executable
-    try tmp.dir.writeFile("hello.exe", "invalid");
+    try tmp.dir.writeFile(.{ .sub_path = "hello.exe", .data = "invalid" });
 
     // Trying to execute it with extension will give InvalidExe. This is a special
     // case for .EXE extensions, where if they ever try to get executed but they are

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -823,12 +823,12 @@ pub fn addCliTests(b: *std.Build) *Step {
 
         var dir = std.fs.cwd().openDir(tmp_path, .{}) catch @panic("unhandled");
         defer dir.close();
-        dir.writeFile("fmt1.zig", unformatted_code) catch @panic("unhandled");
-        dir.writeFile("fmt2.zig", unformatted_code) catch @panic("unhandled");
+        dir.writeFile(.{ .sub_path = "fmt1.zig", .data = unformatted_code }) catch @panic("unhandled");
+        dir.writeFile(.{ .sub_path = "fmt2.zig", .data = unformatted_code }) catch @panic("unhandled");
         dir.makeDir("subdir") catch @panic("unhandled");
         var subdir = dir.openDir("subdir", .{}) catch @panic("unhandled");
         defer subdir.close();
-        subdir.writeFile("fmt3.zig", unformatted_code) catch @panic("unhandled");
+        subdir.writeFile(.{ .sub_path = "fmt3.zig", .data = unformatted_code }) catch @panic("unhandled");
 
         // Test zig fmt affecting only the appropriate files.
         const run1 = b.addSystemCommand(&.{ b.graph.zig_exe, "fmt", "fmt1.zig" });

--- a/tools/process_headers.zig
+++ b/tools/process_headers.zig
@@ -467,7 +467,7 @@ pub fn main() !void {
             // worth it to make it generic
             const full_path = try std.fs.path.join(allocator, &[_][]const u8{ out_dir, generic_name, path_kv.key_ptr.* });
             try std.fs.cwd().makePath(std.fs.path.dirname(full_path).?);
-            try std.fs.cwd().writeFile(full_path, best_contents.bytes);
+            try std.fs.cwd().writeFile(.{ .sub_path = full_path, .data = best_contents.bytes });
             best_contents.is_generic = true;
             while (contents_list.popOrNull()) |contender| {
                 if (contender.hit_count > 1) {
@@ -497,7 +497,7 @@ pub fn main() !void {
             });
             const full_path = try std.fs.path.join(allocator, &[_][]const u8{ out_dir, out_subpath, path_kv.key_ptr.* });
             try std.fs.cwd().makePath(std.fs.path.dirname(full_path).?);
-            try std.fs.cwd().writeFile(full_path, contents.bytes);
+            try std.fs.cwd().writeFile(.{ .sub_path = full_path, .data = contents.bytes });
         }
     }
 }

--- a/tools/update-linux-headers.zig
+++ b/tools/update-linux-headers.zig
@@ -275,7 +275,7 @@ pub fn main() !void {
             // worth it to make it generic
             const full_path = try std.fs.path.join(arena, &[_][]const u8{ out_dir, generic_name, path_kv.key_ptr.* });
             try std.fs.cwd().makePath(std.fs.path.dirname(full_path).?);
-            try std.fs.cwd().writeFile(full_path, best_contents.bytes);
+            try std.fs.cwd().writeFile(.{ .sub_path = full_path, .data = best_contents.bytes });
             best_contents.is_generic = true;
             while (contents_list.popOrNull()) |contender| {
                 if (contender.hit_count > 1) {
@@ -301,7 +301,7 @@ pub fn main() !void {
             const out_subpath = try std.fmt.allocPrint(arena, "{s}-linux-any", .{arch_name});
             const full_path = try std.fs.path.join(arena, &[_][]const u8{ out_dir, out_subpath, path_kv.key_ptr.* });
             try std.fs.cwd().makePath(std.fs.path.dirname(full_path).?);
-            try std.fs.cwd().writeFile(full_path, contents.bytes);
+            try std.fs.cwd().writeFile(.{ .sub_path = full_path, .data = contents.bytes });
         }
     }
 


### PR DESCRIPTION
`writeFile` was deprecated in favor of `writeFile2` in f645022d16361865e24582d28f1e62312fbc73bb. This commit renames `writeFile2` to `writeFile` and makes `writeFile2` a compile error.