### PR TITLE
Delete compile errors for deprecated decls

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -545,14 +545,6 @@ pub fn addObjCopy(cs: *Compile, options: Step.ObjCopy.Options) *Step.ObjCopy {
     return b.addObjCopy(cs.getEmittedBin(), copy);
 }
 
-/// This function would run in the context of the package that created the executable,
-/// which is undesirable when running an executable provided by a dependency package.
-pub const run = @compileError("deprecated; use std.Build.addRunArtifact");
-
-/// This function would install in the context of the package that created the artifact,
-/// which is undesirable when installing an artifact provided by a dependency package.
-pub const install = @compileError("deprecated; use std.Build.installArtifact");
-
 pub fn checkObject(self: *Compile) *Step.CheckObject {
     return Step.CheckObject.create(self.step.owner, self.getEmittedBin(), self.rootModuleTarget().ofmt);
 }

--- a/lib/std/crypto/sha3.zig
+++ b/lib/std/crypto/sha3.zig
@@ -12,8 +12,6 @@ pub const Sha3_512 = Keccak(1600, 512, 0x06, 24);
 
 pub const Keccak256 = Keccak(1600, 256, 0x01, 24);
 pub const Keccak512 = Keccak(1600, 512, 0x01, 24);
-pub const Keccak_256 = @compileError("Deprecated: use `Keccak256` instead");
-pub const Keccak_512 = @compileError("Deprecated: use `Keccak512` instead");
 
 pub const Shake128 = Shake(128);
 pub const Shake256 = Shake(256);

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -686,8 +686,6 @@ pub fn selfExePath(out_buffer: []u8) SelfExePathError![]u8 {
     }
 }
 
-pub const selfExePathW = @compileError("deprecated; use selfExePath instead");
-
 /// `selfExeDirPath` except allocates the result on the heap.
 /// Caller owns returned memory.
 pub fn selfExeDirPathAlloc(allocator: Allocator) ![]u8 {

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -114,14 +114,6 @@ pub const encodeJsonStringChars = @import("json/stringify.zig").encodeJsonString
 pub const Formatter = @import("json/fmt.zig").Formatter;
 pub const fmt = @import("json/fmt.zig").fmt;
 
-// Deprecations
-pub const parse = @compileError("Deprecated; use parseFromSlice() or parseFromTokenSource() instead.");
-pub const parseFree = @compileError("Deprecated; call Parsed(T).deinit() instead.");
-pub const Parser = @compileError("Deprecated; use parseFromSlice(Value) or parseFromTokenSource(Value) instead.");
-pub const ValueTree = @compileError("Deprecated; use Parsed(Value) instead.");
-pub const StreamingParser = @compileError("Deprecated; use json.Scanner or json.Reader instead.");
-pub const TokenStream = @compileError("Deprecated; use json.Scanner or json.Reader instead.");
-
 test {
     _ = @import("json/test.zig");
     _ = @import("json/scanner.zig");

--- a/lib/std/json/stringify.zig
+++ b/lib/std/json/stringify.zig
@@ -591,14 +591,6 @@ pub fn WriteStream(
             try encodeJsonString(s, self.options, self.stream);
             self.valueDone();
         }
-
-        pub const arrayElem = @compileError("Deprecated; You don't need to call this anymore.");
-        pub const emitNull = @compileError("Deprecated; Use .write(null) instead.");
-        pub const emitBool = @compileError("Deprecated; Use .write() instead.");
-        pub const emitNumber = @compileError("Deprecated; Use .write() instead.");
-        pub const emitString = @compileError("Deprecated; Use .write() instead.");
-        pub const emitJson = @compileError("Deprecated; Use .write() instead.");
-        pub const writePreformatted = @compileError("Deprecated; Use .print(\"{s}\", .{s}) instead.");
     };
 }
 

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -56,65 +56,6 @@ pub const inf = @import("math/float.zig").inf;
 pub const nan = @import("math/float.zig").nan;
 pub const snan = @import("math/float.zig").snan;
 
-pub const f16_true_min = @compileError("Deprecated: use `floatTrueMin(f16)` instead");
-pub const f32_true_min = @compileError("Deprecated: use `floatTrueMin(f32)` instead");
-pub const f64_true_min = @compileError("Deprecated: use `floatTrueMin(f64)` instead");
-pub const f80_true_min = @compileError("Deprecated: use `floatTrueMin(f80)` instead");
-pub const f128_true_min = @compileError("Deprecated: use `floatTrueMin(f128)` instead");
-pub const f16_min = @compileError("Deprecated: use `floatMin(f16)` instead");
-pub const f32_min = @compileError("Deprecated: use `floatMin(f32)` instead");
-pub const f64_min = @compileError("Deprecated: use `floatMin(f64)` instead");
-pub const f80_min = @compileError("Deprecated: use `floatMin(f80)` instead");
-pub const f128_min = @compileError("Deprecated: use `floatMin(f128)` instead");
-pub const f16_max = @compileError("Deprecated: use `floatMax(f16)` instead");
-pub const f32_max = @compileError("Deprecated: use `floatMax(f32)` instead");
-pub const f64_max = @compileError("Deprecated: use `floatMax(f64)` instead");
-pub const f80_max = @compileError("Deprecated: use `floatMax(f80)` instead");
-pub const f128_max = @compileError("Deprecated: use `floatMax(f128)` instead");
-pub const f16_epsilon = @compileError("Deprecated: use `floatEps(f16)` instead");
-pub const f32_epsilon = @compileError("Deprecated: use `floatEps(f32)` instead");
-pub const f64_epsilon = @compileError("Deprecated: use `floatEps(f64)` instead");
-pub const f80_epsilon = @compileError("Deprecated: use `floatEps(f80)` instead");
-pub const f128_epsilon = @compileError("Deprecated: use `floatEps(f128)` instead");
-pub const f16_toint = @compileError("Deprecated: use `1.0 / floatEps(f16)` instead");
-pub const f32_toint = @compileError("Deprecated: use `1.0 / floatEps(f32)` instead");
-pub const f64_toint = @compileError("Deprecated: use `1.0 / floatEps(f64)` instead");
-pub const f80_toint = @compileError("Deprecated: use `1.0 / floatEps(f80)` instead");
-pub const f128_toint = @compileError("Deprecated: use `1.0 / floatEps(f128)` instead");
-pub const inf_u16 = @compileError("Deprecated: use `@as(u16, @bitCast(inf(f16)))` instead");
-pub const inf_f16 = @compileError("Deprecated: use `inf(f16)` instead");
-pub const inf_u32 = @compileError("Deprecated: use `@as(u32, @bitCast(inf(f32)))` instead");
-pub const inf_f32 = @compileError("Deprecated: use `inf(f32)` instead");
-pub const inf_u64 = @compileError("Deprecated: use `@as(u64, @bitCast(inf(f64)))` instead");
-pub const inf_f64 = @compileError("Deprecated: use `inf(f64)` instead");
-pub const inf_u80 = @compileError("Deprecated: use `@as(u80, @bitCast(inf(f80)))` instead");
-pub const inf_f80 = @compileError("Deprecated: use `inf(f80)` instead");
-pub const inf_u128 = @compileError("Deprecated: use `@as(u128, @bitCast(inf(f128)))` instead");
-pub const inf_f128 = @compileError("Deprecated: use `inf(f128)` instead");
-pub const nan_u16 = @compileError("Deprecated: use `@as(u16, @bitCast(nan(f16)))` instead");
-pub const nan_f16 = @compileError("Deprecated: use `nan(f16)` instead");
-pub const nan_u32 = @compileError("Deprecated: use `@as(u32, @bitCast(nan(f32)))` instead");
-pub const nan_f32 = @compileError("Deprecated: use `nan(f32)` instead");
-pub const nan_u64 = @compileError("Deprecated: use `@as(u64, @bitCast(nan(f64)))` instead");
-pub const nan_f64 = @compileError("Deprecated: use `nan(f64)` instead");
-pub const nan_u80 = @compileError("Deprecated: use `@as(u80, @bitCast(nan(f80)))` instead");
-pub const nan_f80 = @compileError("Deprecated: use `nan(f80)` instead");
-pub const nan_u128 = @compileError("Deprecated: use `@as(u128, @bitCast(nan(f128)))` instead");
-pub const nan_f128 = @compileError("Deprecated: use `nan(f128)` instead");
-pub const qnan_u16 = @compileError("Deprecated: use `@as(u16, @bitCast(nan(f16)))` instead");
-pub const qnan_f16 = @compileError("Deprecated: use `nan(f16)` instead");
-pub const qnan_u32 = @compileError("Deprecated: use `@as(u32, @bitCast(nan(f32)))` instead");
-pub const qnan_f32 = @compileError("Deprecated: use `nan(f32)` instead");
-pub const qnan_u64 = @compileError("Deprecated: use `@as(u64, @bitCast(nan(f64)))` instead");
-pub const qnan_f64 = @compileError("Deprecated: use `nan(f64)` instead");
-pub const qnan_u80 = @compileError("Deprecated: use `@as(u80, @bitCast(nan(f80)))` instead");
-pub const qnan_f80 = @compileError("Deprecated: use `nan(f80)` instead");
-pub const qnan_u128 = @compileError("Deprecated: use `@as(u128, @bitCast(nan(f128)))` instead");
-pub const qnan_f128 = @compileError("Deprecated: use `nan(f128)` instead");
-pub const epsilon = @compileError("Deprecated: use `floatEps` instead");
-pub const modf32_result = @compileError("Deprecated: use `Modf(f32)` instead");
-pub const modf64_result = @compileError("Deprecated: use `Modf(f64)` instead");
-
 /// Performs an approximate comparison of two floating point values `x` and `y`.
 /// Returns true if the absolute difference between them is less or equal than
 /// the specified tolerance.
@@ -229,8 +170,6 @@ test approxEqRel {
         try testing.expect(!approxEqRel(comptime_float, 1.0, 0.0, sqrt_eps_value));
     }
 }
-
-pub const doNotOptimizeAway = @compileError("Deprecated: use `std.mem.doNotOptimizeAway` instead");
 
 pub fn raiseInvalid() void {
     // Raise INVALID fpu exception
@@ -481,12 +420,6 @@ pub fn Min(comptime A: type, comptime B: type) type {
     }
     return @TypeOf(@as(A, 0) + @as(B, 0));
 }
-
-pub const min = @compileError("deprecated; use @min instead");
-pub const max = @compileError("deprecated; use @max instead");
-pub const min3 = @compileError("deprecated; use @min instead");
-pub const max3 = @compileError("deprecated; use @max instead");
-pub const ln = @compileError("deprecated; use @log instead");
 
 /// Odd sawtooth function
 /// ```

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -13,10 +13,6 @@ test {
     _ = TrailerFlags;
 }
 
-pub const tagName = @compileError("deprecated; use @tagName or @errorName directly");
-
-pub const isTag = @compileError("deprecated; use 'tagged_value == @field(E, tag_name)' directly");
-
 /// Returns the variant of an enum type, `T`, which is named `str`, or `null` if no such variant exists.
 pub fn stringToEnum(comptime T: type, str: []const u8) ?T {
     // Using StaticStringMap here is more performant, but it will start to take too

--- a/lib/std/simd.zig
+++ b/lib/std/simd.zig
@@ -8,8 +8,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-pub const suggestVectorSizeForCpu = @compileError("deprecated; use 'suggestVectorLengthForCpu'");
-
 pub fn suggestVectorLengthForCpu(comptime T: type, comptime cpu: std.Target.Cpu) ?comptime_int {
     // This is guesswork, if you have better suggestions can add it or edit the current here
     // This can run in comptime only, but stage 1 fails at it, stage 2 can understand it
@@ -56,8 +54,6 @@ pub fn suggestVectorLengthForCpu(comptime T: type, comptime cpu: std.Target.Cpu)
 
     return @divExact(vector_bit_size, element_bit_size);
 }
-
-pub const suggestVectorSize = @compileError("deprecated; use 'suggestVectorLength'");
 
 /// Suggests a target-dependant vector length for a given type, or null if scalars are recommended.
 /// Not yet implemented for every CPU architecture.


### PR DESCRIPTION
All of these compile errors have been around since before the 0.12.0 release.