### PR TITLE
Implement `@typeId`

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -9691,6 +9691,14 @@ fn builtinCall(
             });
             return rvalue(gz, ri, result, node);
         },
+        .type_id => {
+            const operand = try comptimeExpr(gz, scope, .{ .rl = .{ .ty = .type_type } }, params[0]);
+            const result = try gz.addExtendedPayload(.type_id, Zir.Inst.UnNode{
+                .node = gz.nodeIndexToRelative(node),
+                .operand = operand,
+            });
+            return rvalue(gz, ri, result, node);
+        },
     }
 }
 

--- a/lib/std/zig/AstRlAnnotate.zig
+++ b/lib/std/zig/AstRlAnnotate.zig
@@ -912,6 +912,7 @@ fn builtinCall(astrl: *AstRlAnnotate, block: ?*Block, ri: ResultInfo, node: Ast.
         .work_group_size,
         .work_group_id,
         .field_parent_ptr,
+        .type_id,
         => {
             _ = try astrl.expr(args[0], block, ResultInfo.type_only);
             return false;

--- a/lib/std/zig/BuiltinFn.zig
+++ b/lib/std/zig/BuiltinFn.zig
@@ -122,6 +122,7 @@ pub const Tag = enum {
     work_item_id,
     work_group_size,
     work_group_id,
+    type_id,
 };
 
 pub const MemLocRequirement = enum {
@@ -1026,6 +1027,13 @@ pub const list = list: {
                 .tag = .work_group_id,
                 .param_count = 1,
                 .illegal_outside_function = true,
+            },
+        },
+        .{
+            "@typeId",
+            .{
+                .tag = .type_id,
+                .param_count = 1,
             },
         },
     });

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -2060,6 +2060,9 @@ pub const Inst = struct {
         /// Guaranteed to not have the `ptr_cast` flag.
         /// Uses the `pl_node` union field with payload `FieldParentPtr`.
         field_parent_ptr,
+        /// Implements the `@typeId` builtin.
+        /// `operand` is payload index to `UnNode`.
+        type_id,
 
         pub const InstData = struct {
             opcode: Extended,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1257,6 +1257,7 @@ fn analyzeBodyInner(
                     .work_item_id       => try sema.zirWorkItem(          block, extended, extended.opcode),
                     .work_group_size    => try sema.zirWorkItem(          block, extended, extended.opcode),
                     .work_group_id      => try sema.zirWorkItem(          block, extended, extended.opcode),
+                    .type_id            => try sema.zirTypeId(            block, extended),
                     .in_comptime        => try sema.zirInComptime(        block),
                     .closure_get        => try sema.zirClosureGet(        block, extended),
                     // zig fmt: on
@@ -26484,6 +26485,19 @@ fn zirWorkItem(
             .payload = dimension,
         } },
     });
+}
+
+fn zirTypeId(
+    sema: *Sema,
+    block: *Block,
+    extended: Zir.Inst.Extended.InstData,
+) CompileError!Air.Inst.Ref {
+    const extra = sema.code.extraData(Zir.Inst.UnNode, extended.operand).data;
+    const ty_src: LazySrcLoc = .{ .node_offset_builtin_call_arg0 = extra.node };
+
+    const ty = try sema.resolveType(block, ty_src, extra.operand);
+
+    return sema.mod.intRef(Type.u32, @intFromEnum(ty.ip_index));
 }
 
 fn zirInComptime(

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -577,6 +577,7 @@ const Writer = struct {
             .work_item_id,
             .work_group_size,
             .work_group_id,
+            .type_id,
             => {
                 const inst_data = self.code.extraData(Zir.Inst.UnNode, extended.operand).data;
                 const src = LazySrcLoc.nodeOffset(inst_data.node);


### PR DESCRIPTION
Implementation for #19858 if approved. Uses the `InternPool.Index`, but can be modified to not expose the `InternPool.Index` via a `AutoArrayHashMapUnmanaged(InternPool.Index, void)` for example.