### PR TITLE
llvm: always include debug information for global variables

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -4744,8 +4744,8 @@ pub const DeclGen = struct {
                 debug_global_var,
                 debug_expression,
             );
-            if (!is_internal_linkage or decl.isExtern(zcu))
-                variable_index.setGlobalVariableExpression(debug_global_var_expression, &o.builder);
+
+            variable_index.setGlobalVariableExpression(debug_global_var_expression, &o.builder);
             try o.debug_globals.append(o.gpa, debug_global_var_expression);
         }
     }


### PR DESCRIPTION
Fixes #15095

Somebody who knows these compiler internals should verify my logic here, but the conditional here does not make sense to me. Consider the following piece of code `example.zig`:

```zig
var globl: i32 = 0;

pub fn main() void {
    var hello: i32 = 1;
    hello += 1;
    globl += 124;
}
```

`globl` is the variable that debuggers cannot find. On master this is the relevant LLVM IR:
```llvm
@example.globl = internal unnamed_addr global i32 0, align 4
```

With my fix this becomes:
```llvm
@example.globl = internal unnamed_addr global i32 0, align 4, !dbg !13
```

Note the `!dbg` that was speculated to be the cause in the issue as well. I've verified that this fix allows debuggers to see non-exported global variables, but I'm still confused as to why this check ever existed.