### PR TITLE
Link: Add natvis file support

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -743,6 +743,9 @@ pub const File = struct {
             for (comp.c_object_table.keys()) |key| {
                 _ = try man.addFile(key.status.success.object_path, null);
             }
+            for (comp.natvis_source_files) |nv| {
+                _ = try man.addFile(nv.src_path, null);
+            }
             if (!build_options.only_core_functionality) {
                 for (comp.win32_resource_table.keys()) |key| {
                     _ = try man.addFile(key.status.success.res_path, null);

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -78,6 +78,9 @@ pub fn linkWithLLD(self: *Coff, arena: Allocator, prog_node: *std.Progress.Node)
         for (comp.c_object_table.keys()) |key| {
             _ = try man.addFile(key.status.success.object_path, null);
         }
+        for (comp.natvis_source_files) |nv| {
+            _ = try man.addFile(nv.src_path, null);
+        }
         if (!build_options.only_core_functionality) {
             for (comp.win32_resource_table.keys()) |key| {
                 _ = try man.addFile(key.status.success.res_path, null);
@@ -269,6 +272,11 @@ pub fn linkWithLLD(self: *Coff, arena: Allocator, prog_node: *std.Progress.Node)
             } else {
                 argv.appendAssumeCapacity(obj.path);
             }
+        }
+
+        try argv.ensureUnusedCapacity(comp.natvis_source_files.len);
+        for (comp.natvis_source_files) |nv| {
+            argv.appendAssumeCapacity(try allocPrint(arena, "-NATVIS:{s}", .{nv.src_path}));
         }
 
         for (comp.c_object_table.keys()) |key| {


### PR DESCRIPTION
This PR the ability to include Natvis files into a module's PDB using `Compile.addObjectFile`. This is eventually passed to the linker via the `-NATVIS:[file]` flag. Fixes: #19646.

This is my first PR that touches the compiler, so review by people working in that area would be great.

## Features:

- [x] Link `natvis` files for executables.
- [ ] Include `natvis` files specified by any dependency using `Compile.linkLibrary`.
- [ ] Create a set of visualisations for the language & standard library and add them to every PDB by default.

## Reasons for Inclusion

- Enhances the ability for the Zig build system to be used to build existing C/C++ projects on Windows.
- Improves the debugging experience for Zig devs on windows, which is already an underserved market.
- Doesn't modify/bloat the code as it only add a named stream to PDBs.

## Issues

There is no way to add visualizers for slices as they have square brackets in their type name, which isn't allowed for C++ types. This is an issue the Rust devs [ran into](https://github.com/rust-lang/rust/issues/36503#issuecomment-247558629) and AFAIK still hasn't been fixed. Note that it is still possible to do `(char*)buf.ptr,[buf.len]s8` for a `[]u8` slice when in the debugger.

Some types like packed structs/comptime known enums are lowered to their integer representation when debugging, and these base types cannot be selected for visualization.