### PR TITLE
fix integer overflow in IoUring buffer ring size calculation

### DIFF
--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -1559,7 +1559,7 @@ pub fn setup_buf_ring(fd: posix.fd_t, entries: u16, group_id: u16) !*align(mem.p
     if (entries == 0 or entries > 1 << 15) return error.EntriesNotInRange;
     if (!std.math.isPowerOfTwo(entries)) return error.EntriesNotPowerOfTwo;
 
-    const mmap_size = entries * @sizeOf(linux.io_uring_buf);
+    const mmap_size = @as(usize, entries) * @sizeOf(linux.io_uring_buf);
     const mmap = try posix.mmap(
         null,
         mmap_size,


### PR DESCRIPTION
`entries` can be up to `32768`, so the result does not fit into the 16bits given by peer type resolution.

@ianic, can you take a look?