### PR TITLE
Improve compile error when using std.io.getStdOutHandle

### DIFF
--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -62,6 +62,9 @@ pub fn getStdErr() File {
 
 fn getStdInHandle() posix.fd_t {
     if (is_windows) {
+        if (@inComptime()) @compileError(
+            \\Unable to get windows stdin at compile time. This is not a bug, but simply not possible on windows.
+        );
         if (builtin.zig_backend == .stage2_aarch64) {
             // TODO: this is just a temporary workaround until we advance aarch64 backend further along.
             return windows.GetStdHandle(windows.STD_INPUT_HANDLE) catch windows.INVALID_HANDLE_VALUE;

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -39,6 +39,9 @@ pub fn getStdOut() File {
 
 fn getStdErrHandle() posix.fd_t {
     if (is_windows) {
+        if (@inComptime()) @compileError(
+            \\Unable to get windows stderr at compile time. This is not a bug, but simply not possible on windows.
+        );
         if (builtin.zig_backend == .stage2_aarch64) {
             // TODO: this is just a temporary workaround until we advance aarch64 backend further along.
             return windows.GetStdHandle(windows.STD_ERROR_HANDLE) catch windows.INVALID_HANDLE_VALUE;

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -16,6 +16,9 @@ const Allocator = std.mem.Allocator;
 
 fn getStdOutHandle() posix.fd_t {
     if (is_windows) {
+        if (@inComptime()) @compileError(
+            \\Unable to get windows stdout at compile time. This is not a bug, but simply not possible on windows.
+        );
         if (builtin.zig_backend == .stage2_aarch64) {
             // TODO: this is just a temporary workaround until we advance aarch64 backend further along.
             return windows.GetStdHandle(windows.STD_OUTPUT_HANDLE) catch windows.INVALID_HANDLE_VALUE;


### PR DESCRIPTION
After noticing that there are >4 issues made by people thinking this is a bug I thought it might be useful to improve the compile error to avoid more redundant issues. I would have liked to open a proposal issue for this, but that's not possible as of now. It is, however not breaking any code that isn't already broken, so I decided to make a pr anyways.

Related:
https://github.com/ziglang/zig/issues/19864
https://github.com/ziglang/zig/issues/17186
https://github.com/ziglang/zig/issues/6845
https://github.com/ziglang/zig/issues/14203