### PR TITLE
astgen: fix result info for catch switch_block_err_union

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -7071,8 +7071,10 @@ fn switchExprErrUnion(
         .ctx = ri.ctx,
     };
 
-    const payload_is_ref = node_ty == .@"if" and
-        if_full.payload_token != null and token_tags[if_full.payload_token.?] == .asterisk;
+    const payload_is_ref = switch (node_ty) {
+        .@"if" => if_full.payload_token != null and token_tags[if_full.payload_token.?] == .asterisk,
+        .@"catch" => ri.rl == .ref or ri.rl == .ref_coerced_ty,
+    };
 
     // We need to call `rvalue` to write through to the pointer only if we had a
     // result pointer and aren't forwarding it.

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -89,6 +89,7 @@ test {
     _ = @import("behavior/switch.zig");
     _ = @import("behavior/switch_prong_err_enum.zig");
     _ = @import("behavior/switch_prong_implicit_cast.zig");
+    _ = @import("behavior/switch_on_captured_error.zig");
     _ = @import("behavior/this.zig");
     _ = @import("behavior/threadlocal.zig");
     _ = @import("behavior/truncate.zig");

--- a/test/behavior/switch_on_captured_error.zig
+++ b/test/behavior/switch_on_captured_error.zig
@@ -3,6 +3,7 @@ const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectError = std.testing.expectError;
 const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
 
 test "switch on error union catch capture" {
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;

--- a/test/behavior/switch_on_captured_error.zig
+++ b/test/behavior/switch_on_captured_error.zig
@@ -7,6 +7,7 @@ const builtin = @import("builtin");
 
 test "switch on error union catch capture" {
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const S = struct {
         const Error = error{ A, B, C };
@@ -261,6 +262,7 @@ test "switch on error union catch capture" {
 
 test "switch on error union if else capture" {
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const S = struct {
         const Error = error{ A, B, C };


### PR DESCRIPTION
Fixes #19881.

### Todo
  - [x] add behaviour tests to catch any future regressions