### PR TITLE
std.Build.Step: make result returning correctly with evalZigProcess

### DIFF
--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -458,7 +458,8 @@ pub fn evalZigProcess(
                 // Note that the exit code may be 0 in this case due to the
                 // compiler server protocol.
                 if (compile.expect_errors != null) {
-                    return error.NeedCompileErrorCheck;
+                    try compile.checkCompileErrors();
+                    return result;
                 }
             },
             else => {},

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1766,18 +1766,11 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
 
     const zig_args = try getZigArgs(compile, false);
 
-    const maybe_output_dir = step.evalZigProcess(
+    const maybe_output_dir = try step.evalZigProcess(
         zig_args,
         options.progress_node,
         (b.graph.incremental == true) and options.watch,
-    ) catch |err| switch (err) {
-        error.NeedCompileErrorCheck => {
-            assert(compile.expect_errors != null);
-            try checkCompileErrors(compile);
-            return;
-        },
-        else => |e| return e,
-    };
+    );
 
     // Update generated files
     if (maybe_output_dir) |output_dir| {
@@ -1929,7 +1922,7 @@ fn addFlag(args: *ArrayList([]const u8), comptime name: []const u8, opt: ?bool) 
     }
 }
 
-fn checkCompileErrors(compile: *Compile) !void {
+pub fn checkCompileErrors(compile: *Compile) !void {
     // Clear this field so that it does not get printed by the build runner.
     const actual_eb = compile.step.result_error_bundle;
     compile.step.result_error_bundle = std.zig.ErrorBundle.empty;


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/18941 by moving the `checkCompileErrors` call from `Build.Step.Compile` to `Build.Step` and returning result if the errors match as expected.

Continued from #18943

Tested by building https://github.com/MidstallSoftware/apparmor.zig/tree/4f32b90f540769d37879e23cb85e0e1c4fb10dcb