### PR TITLE
Do not run asserts for WASI alignment when not targeting WASI

### DIFF
--- a/lib/std/os/wasi.zig
+++ b/lib/std/os/wasi.zig
@@ -14,8 +14,8 @@ comptime {
         assert(@alignOf(u16) == 2);
         assert(@alignOf(i32) == 4);
         assert(@alignOf(u32) == 4);
-        // assert(@alignOf(i64) == 8);
-        // assert(@alignOf(u64) == 8);
+        assert(@alignOf(i64) == 8);
+        assert(@alignOf(u64) == 8);
     }
 }
 

--- a/lib/std/os/wasi.zig
+++ b/lib/std/os/wasi.zig
@@ -7,14 +7,16 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 comptime {
-    assert(@alignOf(i8) == 1);
-    assert(@alignOf(u8) == 1);
-    assert(@alignOf(i16) == 2);
-    assert(@alignOf(u16) == 2);
-    assert(@alignOf(i32) == 4);
-    assert(@alignOf(u32) == 4);
-    assert(@alignOf(i64) == 8);
-    assert(@alignOf(u64) == 8);
+    if (builtin.os.tag == .wasi) {
+        assert(@alignOf(i8) == 1);
+        assert(@alignOf(u8) == 1);
+        assert(@alignOf(i16) == 2);
+        assert(@alignOf(u16) == 2);
+        assert(@alignOf(i32) == 4);
+        assert(@alignOf(u32) == 4);
+        assert(@alignOf(i64) == 8);
+        assert(@alignOf(u64) == 8);
+    }
 }
 
 pub const iovec_t = std.posix.iovec;

--- a/lib/std/os/wasi.zig
+++ b/lib/std/os/wasi.zig
@@ -7,16 +7,14 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 comptime {
-    if (builtin.os.tag == .wasi) {
-        assert(@alignOf(i8) == 1);
-        assert(@alignOf(u8) == 1);
-        assert(@alignOf(i16) == 2);
-        assert(@alignOf(u16) == 2);
-        assert(@alignOf(i32) == 4);
-        assert(@alignOf(u32) == 4);
-        assert(@alignOf(i64) == 8);
-        assert(@alignOf(u64) == 8);
-    }
+    assert(@alignOf(i8) == 1);
+    assert(@alignOf(u8) == 1);
+    assert(@alignOf(i16) == 2);
+    assert(@alignOf(u16) == 2);
+    assert(@alignOf(i32) == 4);
+    assert(@alignOf(u32) == 4);
+    assert(@alignOf(i64) == 8);
+    assert(@alignOf(u64) == 8);
 }
 
 pub const iovec_t = std.posix.iovec;

--- a/lib/std/os/wasi.zig
+++ b/lib/std/os/wasi.zig
@@ -7,14 +7,16 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 comptime {
-    assert(@alignOf(i8) == 1);
-    assert(@alignOf(u8) == 1);
-    assert(@alignOf(i16) == 2);
-    assert(@alignOf(u16) == 2);
-    assert(@alignOf(i32) == 4);
-    assert(@alignOf(u32) == 4);
-    // assert(@alignOf(i64) == 8);
-    // assert(@alignOf(u64) == 8);
+    if (builtin.os.tag == .wasi) {
+        assert(@alignOf(i8) == 1);
+        assert(@alignOf(u8) == 1);
+        assert(@alignOf(i16) == 2);
+        assert(@alignOf(u16) == 2);
+        assert(@alignOf(i32) == 4);
+        assert(@alignOf(u32) == 4);
+        // assert(@alignOf(i64) == 8);
+        // assert(@alignOf(u64) == 8);
+    }
 }
 
 pub const iovec_t = std.posix.iovec;

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -116,8 +116,7 @@ pub const Options = struct {
     enable_segfault_handler: bool = debug.default_enable_segfault_handler,
 
     /// Function used to implement `std.fs.cwd` for WASI.
-    wasiCwd: if (@import("builtin").os.tag == .wasi) fn () os.wasi.fd_t else void =
-        if (@import("builtin").os.tag == .wasi) fs.defaultWasiCwd else {},
+    wasiCwd: fn () os.wasi.fd_t = fs.defaultWasiCwd,
 
     /// The current log level.
     log_level: log.Level = log.default_level,

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -116,7 +116,8 @@ pub const Options = struct {
     enable_segfault_handler: bool = debug.default_enable_segfault_handler,
 
     /// Function used to implement `std.fs.cwd` for WASI.
-    wasiCwd: fn () os.wasi.fd_t = fs.defaultWasiCwd,
+    wasiCwd: if (@import("builtin").os.tag == .wasi) fn () os.wasi.fd_t else void =
+        if (@import("builtin").os.tag == .wasi) fs.defaultWasiCwd else {},
 
     /// The current log level.
     log_level: log.Level = log.default_level,


### PR DESCRIPTION
Fixes #19665

It seems possible that the last two asserts should now be uncommented as well. I don't know enough about why they were commented in the first place.