### PR TITLE
Follow-up: `zig fetch`: resolve branch/tag names to commit SHA

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -61,7 +61,9 @@ actual_hash: Manifest.Digest,
 has_build_zig: bool,
 /// Indicates whether the task aborted due to an out-of-memory condition.
 oom_flag: bool,
-/// If `use_latest_commit` was true, this will be the commit that was used.
+/// If `use_latest_commit` was true, this will be set to the commit that was used.
+/// If the resource pointed to by the location is not a Git-repository, this
+/// will be left unchanged.
 latest_commit: ?git.Oid,
 
 // This field is used by the CLI only, untouched by this file.
@@ -712,7 +714,7 @@ fn queueJobsForDeps(f: *Fetch) RunError!void {
                 .actual_hash = undefined,
                 .has_build_zig = false,
                 .oom_flag = false,
-                .latest_commit = undefined,
+                .latest_commit = null,
 
                 .module = null,
             };

--- a/src/main.zig
+++ b/src/main.zig
@@ -5106,7 +5106,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
                     .actual_hash = undefined,
                     .has_build_zig = true,
                     .oom_flag = false,
-                    .latest_commit = undefined,
+                    .latest_commit = null,
 
                     .module = build_mod,
                 };
@@ -7009,7 +7009,7 @@ fn cmdFetch(
         .actual_hash = undefined,
         .has_build_zig = false,
         .oom_flag = false,
-        .latest_commit = undefined,
+        .latest_commit = null,
 
         .module = null,
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -5097,6 +5097,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
                     .job_queue = &job_queue,
                     .omit_missing_hash_error = true,
                     .allow_missing_paths_field = false,
+                    .use_latest_commit = false,
 
                     .package_root = undefined,
                     .error_bundle = undefined,
@@ -5105,6 +5106,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
                     .actual_hash = undefined,
                     .has_build_zig = true,
                     .oom_flag = false,
+                    .latest_commit = undefined,
 
                     .module = build_mod,
                 };
@@ -6894,6 +6896,7 @@ const usage_fetch =
     \\  --debug-hash                  Print verbose hash information to stdout
     \\  --save                        Add the fetched package to build.zig.zon
     \\  --save=[name]                 Add the fetched package to build.zig.zon as name
+    \\  --preserve-url                Store a verbatim copy of the URL in build.zig.zon
     \\
 ;
 
@@ -6909,6 +6912,7 @@ fn cmdFetch(
     var override_global_cache_dir: ?[]const u8 = try EnvVar.ZIG_GLOBAL_CACHE_DIR.get(arena);
     var debug_hash: bool = false;
     var save: union(enum) { no, yes, name: []const u8 } = .no;
+    var preserve_url: bool = false;
 
     {
         var i: usize = 0;
@@ -6929,6 +6933,8 @@ fn cmdFetch(
                     save = .yes;
                 } else if (mem.startsWith(u8, arg, "--save=")) {
                     save = .{ .name = arg["--save=".len..] };
+                } else if (mem.startsWith(u8, arg, "--preserve-url")) {
+                    preserve_url = true;
                 } else {
                     fatal("unrecognized parameter: '{s}'", .{arg});
                 }
@@ -6939,6 +6945,8 @@ fn cmdFetch(
             }
         }
     }
+
+    if (preserve_url and save == .no) fatal("use of '--preserve-url' requires '--save'", .{});
 
     const path_or_url = opt_path_or_url orelse fatal("missing url or path parameter", .{});
 
@@ -6988,6 +6996,7 @@ fn cmdFetch(
         .job_queue = &job_queue,
         .omit_missing_hash_error = true,
         .allow_missing_paths_field = false,
+        .use_latest_commit = true,
 
         .package_root = undefined,
         .error_bundle = undefined,
@@ -6996,6 +7005,7 @@ fn cmdFetch(
         .actual_hash = undefined,
         .has_build_zig = false,
         .oom_flag = false,
+        .latest_commit = undefined,
 
         .module = null,
     };
@@ -7052,13 +7062,43 @@ fn cmdFetch(
     var fixups: Ast.Fixups = .{};
     defer fixups.deinit(gpa);
 
+    var saved_path_or_url = path_or_url;
+
+    if (fetch.latest_commit) |*latest_commit| {
+        var uri = try std.Uri.parse(path_or_url);
+        const target_ref = uri.fragment orelse "";
+        if (!std.mem.eql(u8, target_ref, latest_commit)) {
+            std.log.info("resolved ref '{s}' to commit {s}", .{
+                target_ref,
+                std.fmt.fmtSliceHexLower(latest_commit),
+            });
+
+            if (!preserve_url) {
+                if (target_ref.len != 0) {
+                    // include the target ref in a query parameter
+                    var query = try std.ArrayList(u8).initCapacity(arena, 4 + target_ref.len);
+                    try std.Uri.writeEscapedQuery(query.writer(), "ref=");
+                    try std.Uri.writeEscapedQuery(query.writer(), target_ref);
+                    uri.query = try query.toOwnedSlice();
+                }
+
+                // replace the refspec with the resolved commit SHA
+                uri.fragment = try std.fmt.allocPrint(arena, "{}", .{
+                    std.fmt.fmtSliceHexLower(latest_commit),
+                });
+
+                saved_path_or_url = try std.fmt.allocPrint(arena, "{}", .{uri});
+            }
+        }
+    }
+
     const new_node_init = try std.fmt.allocPrint(arena,
         \\.{{
         \\            .url = "{}",
         \\            .hash = "{}",
         \\        }}
     , .{
-        std.zig.fmtEscapes(path_or_url),
+        std.zig.fmtEscapes(saved_path_or_url),
         std.zig.fmtEscapes(&hex_digest),
     });
 
@@ -7078,7 +7118,7 @@ fn cmdFetch(
         if (dep.hash) |h| {
             switch (dep.location) {
                 .url => |u| {
-                    if (mem.eql(u8, h, &hex_digest) and mem.eql(u8, u, path_or_url)) {
+                    if (mem.eql(u8, h, &hex_digest) and mem.eql(u8, u, saved_path_or_url)) {
                         std.log.info("existing dependency named '{s}' is up-to-date", .{name});
                         process.exit(0);
                     }


### PR DESCRIPTION
Resolves the issues raised by @andrewrk in the original PR https://github.com/ziglang/zig/pull/19349 (reverted):

- reduced nesting/indentation
- use new flags `--save-exact=[name]`
- use `std.Uri.Component.format`