### PR TITLE
fix(cache): handle missing cache hits when chaining two run steps

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -2148,6 +2148,9 @@ pub const LazyPath = union(enum) {
 
         /// Applied after `up`.
         sub_path: []const u8 = "",
+
+        /// If true, the file is hashed only on the suffix, not the full absolute path
+        content_hashed: bool = false,
     },
 
     /// An absolute path or a path relative to the current working directory of
@@ -2339,6 +2342,7 @@ pub const LazyPath = union(enum) {
                 .file = gen.file,
                 .up = gen.up,
                 .sub_path = b.dupePath(gen.sub_path),
+                .content_hashed = gen.content_hashed,
             } },
             .dependency => |dep| .{ .dependency = dep },
         };

--- a/lib/std/Build/Step/ObjCopy.zig
+++ b/lib/std/Build/Step/ObjCopy.zig
@@ -102,7 +102,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     man.hash.add(@as(u32, 0xe18b7baf));
 
     const full_src_path = objcopy.input_file.getPath2(b, step);
-    _ = try man.addFile(full_src_path, null);
+    _ = try man.addFile(full_src_path, null, false);
     man.hash.addOptionalListOfBytes(objcopy.only_sections);
     man.hash.addOptional(objcopy.pad_to);
     man.hash.addOptional(objcopy.format);

--- a/lib/std/Build/Step/WriteFile.zig
+++ b/lib/std/Build/Step/WriteFile.zig
@@ -265,7 +265,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
                 man.hash.addBytes(bytes);
             },
             .copy => |file_source| {
-                _ = try man.addFile(file_source.getPath2(b, step), null);
+                _ = try man.addFile(file_source.getPath2(b, step), null, true);
             },
         }
     }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -861,7 +861,7 @@ pub const cache_helpers = struct {
     }
 
     pub fn hashCSource(self: *Cache.Manifest, c_source: CSourceFile) !void {
-        _ = try self.addFile(c_source.src_path, null);
+        _ = try self.addFile(c_source.src_path, null, false);
         // Hash the extra flags, with special care to call addFile for file parameters.
         // TODO this logic can likely be improved by utilizing clang_options_data.zig.
         const file_args = [_][]const u8{"-include"};
@@ -872,7 +872,7 @@ pub const cache_helpers = struct {
             for (file_args) |file_arg| {
                 if (mem.eql(u8, file_arg, arg) and arg_i + 1 < c_source.extra_flags.len) {
                     arg_i += 1;
-                    _ = try self.addFile(c_source.extra_flags[arg_i], null);
+                    _ = try self.addFile(c_source.extra_flags[arg_i], null, false);
                 }
             }
         }
@@ -1179,7 +1179,7 @@ fn addModuleTableToCacheHash(
             },
             .files => |man| if (mod.root_src_path.len != 0) {
                 const pkg_zig_file = try mod.root.joinString(arena, mod.root_src_path);
-                _ = try man.addFile(pkg_zig_file, null);
+                _ = try man.addFile(pkg_zig_file, null, false);
             },
         }
 
@@ -2403,13 +2403,13 @@ fn addNonIncrementalStuffToCacheManifest(
     }
 
     for (comp.objects) |obj| {
-        _ = try man.addFile(obj.path, null);
+        _ = try man.addFile(obj.path, null, false);
         man.hash.add(obj.must_link);
         man.hash.add(obj.loption);
     }
 
     for (comp.c_object_table.keys()) |key| {
-        _ = try man.addFile(key.src.src_path, null);
+        _ = try man.addFile(key.src.src_path, null, false);
         man.hash.addOptional(key.src.ext);
         man.hash.addListOfBytes(key.src.extra_flags);
     }
@@ -2418,11 +2418,11 @@ fn addNonIncrementalStuffToCacheManifest(
         for (comp.win32_resource_table.keys()) |key| {
             switch (key.src) {
                 .rc => |rc_src| {
-                    _ = try man.addFile(rc_src.src_path, null);
+                    _ = try man.addFile(rc_src.src_path, null, false);
                     man.hash.addListOfBytes(rc_src.extra_flags);
                 },
                 .manifest => |manifest_path| {
-                    _ = try man.addFile(manifest_path, null);
+                    _ = try man.addFile(manifest_path, null, false);
                 },
             }
         }
@@ -4770,7 +4770,7 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
     // the XML data as a RT_MANIFEST resource. This means we can skip preprocessing,
     // include paths, CLI options, etc.
     if (win32_resource.src == .manifest) {
-        _ = try man.addFile(src_path, null);
+        _ = try man.addFile(src_path, null, false);
 
         const rc_basename = try std.fmt.allocPrint(arena, "{s}.rc", .{src_basename});
         const res_basename = try std.fmt.allocPrint(arena, "{s}.res", .{src_basename});
@@ -4853,7 +4853,7 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
     // We now know that we're compiling an .rc file
     const rc_src = win32_resource.src.rc;
 
-    _ = try man.addFile(rc_src.src_path, null);
+    _ = try man.addFile(rc_src.src_path, null, false);
     man.hash.addListOfBytes(rc_src.extra_flags);
 
     const rc_basename_noext = src_basename[0 .. src_basename.len - std.fs.path.extension(src_basename).len];

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -691,7 +691,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: *std.Progress.Node) !vo
     man.hash.add(target_version);
 
     const full_abilists_path = try comp.zig_lib_directory.join(arena, &.{abilists_path});
-    const abilists_index = try man.addFile(full_abilists_path, abilists_max_size);
+    const abilists_index = try man.addFile(full_abilists_path, abilists_max_size, false);
 
     if (try man.hit()) {
         const digest = man.final();

--- a/src/link.zig
+++ b/src/link.zig
@@ -44,7 +44,7 @@ pub fn hashAddSystemLibs(
     for (hm.values()) |value| {
         man.hash.add(value.needed);
         man.hash.add(value.weak);
-        if (value.path) |p| _ = try man.addFile(p, null);
+        if (value.path) |p| _ = try man.addFile(p, null, false);
     }
 }
 
@@ -736,16 +736,16 @@ pub const File = struct {
             base.releaseLock();
 
             for (objects) |obj| {
-                _ = try man.addFile(obj.path, null);
+                _ = try man.addFile(obj.path, null, false);
                 man.hash.add(obj.must_link);
                 man.hash.add(obj.loption);
             }
             for (comp.c_object_table.keys()) |key| {
-                _ = try man.addFile(key.status.success.object_path, null);
+                _ = try man.addFile(key.status.success.object_path, null, false);
             }
             if (!build_options.only_core_functionality) {
                 for (comp.win32_resource_table.keys()) |key| {
-                    _ = try man.addFile(key.status.success.res_path, null);
+                    _ = try man.addFile(key.status.success.res_path, null, false);
                 }
             }
             try man.addOptionalFile(zcu_obj_path);

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -72,15 +72,15 @@ pub fn linkWithLLD(self: *Coff, arena: Allocator, prog_node: *std.Progress.Node)
         comptime assert(Compilation.link_hash_implementation_version == 13);
 
         for (comp.objects) |obj| {
-            _ = try man.addFile(obj.path, null);
+            _ = try man.addFile(obj.path, null, false);
             man.hash.add(obj.must_link);
         }
         for (comp.c_object_table.keys()) |key| {
-            _ = try man.addFile(key.status.success.object_path, null);
+            _ = try man.addFile(key.status.success.object_path, null, false);
         }
         if (!build_options.only_core_functionality) {
             for (comp.win32_resource_table.keys()) |key| {
-                _ = try man.addFile(key.status.success.res_path, null);
+                _ = try man.addFile(key.status.success.res_path, null, false);
             }
         }
         try man.addOptionalFile(module_obj_path);

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2217,12 +2217,12 @@ fn linkWithLLD(self: *Elf, arena: Allocator, prog_node: *std.Progress.Node) !voi
         man.hash.add(self.allow_undefined_version);
         man.hash.addOptional(self.enable_new_dtags);
         for (comp.objects) |obj| {
-            _ = try man.addFile(obj.path, null);
+            _ = try man.addFile(obj.path, null, false);
             man.hash.add(obj.must_link);
             man.hash.add(obj.loption);
         }
         for (comp.c_object_table.keys()) |key| {
-            _ = try man.addFile(key.status.success.object_path, null);
+            _ = try man.addFile(key.status.success.object_path, null, false);
         }
         try man.addOptionalFile(module_obj_path);
         try man.addOptionalFile(compiler_rt_path);

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -165,7 +165,7 @@ pub fn hashAddFrameworks(man: *Cache.Manifest, hm: []const Framework) !void {
     for (hm) |value| {
         man.hash.add(value.needed);
         man.hash.add(value.weak);
-        _ = try man.addFile(value.path, null);
+        _ = try man.addFile(value.path, null, false);
     }
 }
 

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -3378,11 +3378,11 @@ fn linkWithLLD(wasm: *Wasm, arena: Allocator, prog_node: *std.Progress.Node) !vo
         comptime assert(Compilation.link_hash_implementation_version == 13);
 
         for (comp.objects) |obj| {
-            _ = try man.addFile(obj.path, null);
+            _ = try man.addFile(obj.path, null, false);
             man.hash.add(obj.must_link);
         }
         for (comp.c_object_table.keys()) |key| {
-            _ = try man.addFile(key.status.success.object_path, null);
+            _ = try man.addFile(key.status.success.object_path, null, false);
         }
         try man.addOptionalFile(module_obj_path);
         try man.addOptionalFile(compiler_rt_path);

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -191,7 +191,7 @@ pub fn buildImportLib(comp: *Compilation, lib_name: []const u8) !void {
     var man = cache.obtain();
     defer man.deinit();
 
-    _ = try man.addFile(def_file_path, null);
+    _ = try man.addFile(def_file_path, null, false);
 
     const final_lib_basename = try std.fmt.allocPrint(comp.gpa, "{s}.lib", .{lib_name});
     errdefer comp.gpa.free(final_lib_basename);


### PR DESCRIPTION
fixes #19817

This improves the efficiency of the cache when chaining muliple commands like

    const step1 = b.addRunArtifact(tool_fast);
    step1.addFileArg(b.path("src/input.c"));
    const output1 = step1.addOutputFileArg("output1.h");

    const step2 = b.addRunArtifact(tool_slow);
    step2.addFileArg(output1);
    const chained_output = step2.addOutputFileArg("output2.h");

assume that step2 takes much long time than step1
if we make a change to "src/input.c" which produces an identical "output1.h" as a previous input, one would expect step2 not to rerun as the cached output2.h only depends on the content of output1.h

However, this does not work yet as the hash of src/input.c leaks into the file name of the cached output1.h, which the second run step interprets as a different cache key. Erasing the "zig-build/o/{HASH}" part of the file name in the hash key fixes this.