### PR TITLE
zig build: allow to choose "lazy mode" for fetching process

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -1293,7 +1293,9 @@ fn usage(b: *std.Build, out_stream: anytype) !void {
         \\  -j<N>                        Limit concurrent jobs (default is to use all CPU cores)
         \\  --maxrss <bytes>             Limit memory usage (default is to use available memory)
         \\  --skip-oom-steps             Instead of failing, skip steps that would exceed --maxrss
-        \\  --fetch                      Exit after fetching dependency tree
+        \\  --fetch[=mode]               Fetch dependency tree (optionally choose laziness) and exit
+        \\    needed                     (Default) Lazy dependencies are fetched as needed
+        \\    all                        Lazy dependencies are always fetched
         \\  --watch                      Continuously rebuild when source files are modified
         \\  --fuzz                       Continuously search for unit test failures
         \\  --debounce <ms>              Delay before rebuilding after changed file detected


### PR DESCRIPTION
`--fetch` flag now has additional optional parameter, which specifies how lazy dependencies should be fetched:
 * `needed` — lazy dependencies are fetched only if they are required for current build configuration to work. Default and works same as old `--fetch` flag.
 * `all` — lazy dependencies are always fetched. If `--system` flag is used after that, it's guaranteed that **any** build configuration will not require additional download of dependencies during build. Helpful for distro packagers and CI systems: https://github.com/ziglang/zig/issues/14597#issuecomment-1426827495

If none is passed, behaviour is same as if `needed` was passed.