### PR TITLE
Sema: Fixing segfaults on mutually recursive structs

### DIFF
--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -2256,7 +2256,10 @@ pub const LoadedStructType = struct {
 
     pub fn haveFieldTypes(s: LoadedStructType, ip: *const InternPool) bool {
         const types = s.field_types.get(ip);
-        return types.len == 0 or types[0] != .none;
+        for (types) |ty| {
+            if (ty == .none) return false;
+        }
+        return true;
     }
 
     pub fn haveFieldInits(s: LoadedStructType, ip: *const InternPool) bool {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6743,6 +6743,7 @@ fn addDbgVar(
         .dbg_var_val => operand_ty,
         else => unreachable,
     };
+    try sema.resolveTypeFully(val_ty);
     if (try sema.typeRequiresComptime(val_ty)) return;
     if (!(try sema.typeHasRuntimeBits(val_ty))) return;
     if (try sema.resolveValue(operand)) |operand_val| {


### PR DESCRIPTION
Trying to fix both #19920 and #18556 
Not sure those are the best approaches.

4d580afbdb23969b1508d4788c53266a1b7fd0c6 Solves the following issue:
```
const A = struct {
    a: A,
};

pub fn main() !void {
    const a: A = undefined;
    _ = a;
}
```
On addDbgVar, it keeps caling hasRuntimeBitsAdvanced infinitely on the struct type. 
I've tried to add resolveTypeFully to get the compiler error first.



7170203647b2b278865e1eae40fd1d5deb974e87 Solves the following issue:
```
const A = struct {
    unused: void,
    bad_field: [@sizeOf(A)]u8 align(@alignOf(A)),
};

pub fn main() !void {
    const a: A = undefined;
    _ = a;
}
```
In this example, only the first field of the struct is non-null when calling haveFieldTypes which causes it to return `true` when it shouldn't.