### PR TITLE
IoUring: fix an issue in tests where InvalidVersion might get thrown

### DIFF
--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -3886,7 +3886,13 @@ inline fn skipKernelLessThan(required: std.SemanticVersion) !void {
     }
 
     const release = mem.sliceTo(&uts.release, 0);
-    var current = try std.SemanticVersion.parse(release);
+    // Strips potential extra, as kernel version might not be semver compliant, example "6.8.9-300.fc40.x86_64"
+    const extra_index = std.mem.indexOfAny(u8, release, "-+");
+    const stripped = release[0..(extra_index orelse release.len)];
+    // Make sure the input don't rely on the extra we just stripped
+    try testing.expect(required.pre == null and required.build == null);
+
+    var current = try std.SemanticVersion.parse(stripped);
     current.pre = null; // don't check pre field
     if (required.order(current) == .gt) return error.SkipZigTest;
 }


### PR DESCRIPTION
InvalidVersion might get thrown by skipKernelLessThan, due to some kernel versions not being SemVer compliant.

Which result in a bunch of InvalidVersion errors during unit tests:
```
error: 'os.linux.IoUring.test.accept/connect/send_zc/recv' failed: /home/jiboo/Projects/zig-fork/lib/std/SemanticVersion.zig:117:73: 0x1be34e3 in parse (test)
            for (id) |c| if (!std.ascii.isAlphanumeric(c) and c != '-') return error.InvalidVersion;
                                                                        ^
/home/jiboo/Projects/zig-fork/lib/std/os/linux/IoUring.zig:3506:5: 0x2bc9aea in test.accept/connect/send_zc/recv (test)
    try skipKernelLessThan(.{ .major = 6, .minor = 0, .patch = 0 });
    ^
```
Here's the result of my `uname -r`: `6.8.9-300.fc40.x86_64` the underscore makes this non compliant, I'm don't believe I've changed anything and I'm on a vanilla Fedora 40 setup.

I've attempted to fix this by stripping any extra from the `release` string returned from the `uname` call, prior to passing it to `SemanticVersion.parse`.

Closes #21166