### PR TITLE
zig std: use open on macOS

### DIFF
--- a/lib/compiler/std-docs.zig
+++ b/lib/compiler/std-docs.zig
@@ -433,6 +433,7 @@ fn openBrowserTab(gpa: Allocator, url: []const u8) !void {
 fn openBrowserTabThread(gpa: Allocator, url: []const u8) !void {
     const main_exe = switch (builtin.os.tag) {
         .windows => "explorer",
+        .macos => "open",
         else => "xdg-open",
     };
     var child = std.ChildProcess.init(&.{ main_exe, url }, gpa);


### PR DESCRIPTION
xdg-open does not exist on macOS. `open` is the macOS equivalent.

Currently on macOS, `zig std` prints:

```
http://127.0.0.1:63776/
error: FileNotFound
```

(modulo port number) and does not open a browser. With this patch, the `error` message is gone and the browser opens as expected.