### PR TITLE
std.Build+autodoc: allow configurable html, js and additional static files

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -46,7 +46,7 @@ pub fn build(b: *std.Build) !void {
         .optimize = .Debug,
     });
     const install_std_docs = b.addInstallDirectory(.{
-        .source_dir = autodoc_test.getEmittedDocs(),
+        .source_dir = autodoc_test.getEmittedDocs(.{}),
         .install_dir = .prefix,
         .install_subdir = "doc/std",
     });

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -848,9 +848,40 @@ pub fn getEmittedPdb(compile: *Compile) LazyPath {
     return compile.getEmittedFileGeneric(&compile.generated_pdb);
 }
 
+pub const DocEmitOptions = struct {
+    /// Override the default autodoc index.html file
+    index_html: ?LazyPath = null,
+    /// Override the default autodoc main.js file
+    main_js: ?LazyPath = null,
+    /// Include additional files in a "static" directory, to be combined with a custom index.html
+    static_dir: ?LazyPath = null,
+};
+
 /// Returns the path to the generated documentation directory.
-pub fn getEmittedDocs(compile: *Compile) LazyPath {
-    return compile.getEmittedFileGeneric(&compile.generated_docs);
+pub fn getEmittedDocs(compile: *Compile, options: DocEmitOptions) LazyPath {
+    const default_docs = compile.getEmittedFileGeneric(&compile.generated_docs);
+
+    const any_option_specified = o: {
+        inline for (@typeInfo(@TypeOf(options)).Struct.fields) |field| {
+            if (@field(options, field.name)) |_| break :o true;
+        } else break :o false;
+    };
+
+    if (!any_option_specified) {
+        return default_docs;
+    }
+
+    const b = compile.step.owner;
+    const final_docs = b.addWriteFiles();
+    final_docs.step.name = final_docs.step.owner.fmt("WriteFile autodoc custom emit {s}", .{compile.name});
+
+    _ = final_docs.addCopyDirectory(default_docs, ".", .{});
+
+    if (options.index_html) |index_html| _ = final_docs.addCopyFile(index_html, "index.html");
+    if (options.main_js) |main_js| _ = final_docs.addCopyFile(main_js, "main.js");
+    if (options.static_dir) |static_dir| _ = final_docs.addCopyDirectory(static_dir, "static", .{});
+
+    return final_docs.getDirectory();
 }
 
 /// Returns the path to the generated assembly code.

--- a/src/main.zig
+++ b/src/main.zig
@@ -354,7 +354,7 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
         return io.getStdOut().writeAll(usage);
     } else if (mem.eql(u8, cmd, "ast-check")) {
         return cmdAstCheck(gpa, arena, cmd_args);
-    } else if (mem.eql(u8, cmd, "detect-cpu")) {
+    } else if (build_options.enable_debug_extensions and mem.eql(u8, cmd, "detect-cpu")) {
         return cmdDetectCpu(gpa, arena, cmd_args);
     } else if (build_options.enable_debug_extensions and mem.eql(u8, cmd, "changelist")) {
         return cmdChangelist(gpa, arena, cmd_args);


### PR DESCRIPTION
As suggested in https://github.com/ziglang/zig/issues/19279#issuecomment-2043751183

The build system is kind of coupled with what autodoc emits since the filenames need to show up, but this enables custom index.html, main javascript file and extra static files.

Perhaps general "CopyFiles" and "CopyDirs" fields of the option struct could be used to avoid some filenames being forced. Let me know if that would be preferred.

Closes #19279

Also contains an extra commit changing the detect-cpu command to only be included when debug-extensions are enabled. The compiler already lists this command under debug_usage, so this is a fix of a previous (probable) copy paste error.