### PR TITLE
std: Avoid overflowing in the midpoint calculation in upperBound

### DIFF
--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -616,7 +616,7 @@ pub fn upperBound(
     var right: usize = items.len;
 
     while (left < right) {
-        const mid = (right + left) / 2;
+        const mid = left + (right - left) / 2;
         if (!lessThan(context, key, items[mid])) {
             left = mid + 1;
         } else {


### PR DESCRIPTION
The line that calculates the midpoint in the upperBound function didn't take into account overflows from large arrays like in other binary search functions.