### PR TITLE
test/link: actually run tests requiring symlinks on non-Win

### DIFF
--- a/test/link/build.zig
+++ b/test/link/build.zig
@@ -9,12 +9,12 @@ pub fn build(b: *std.Build) void {
     const enable_ios_sdk = b.option(bool, "enable_ios_sdk", "Run tests requiring presence of iOS SDK and frameworks") orelse false;
     const enable_macos_sdk = b.option(bool, "enable_macos_sdk", "Run tests requiring presence of macOS SDK and frameworks") orelse enable_ios_sdk;
     const enable_symlinks_windows = b.option(bool, "enable_symlinks_windows", "Run tests requiring presence of symlinks on Windows") orelse false;
-    const omit_symlinks = builtin.os.tag == .windows and !enable_symlinks_windows;
+    const has_symlinks = builtin.os.tag != .windows or enable_symlinks_windows;
 
     const build_opts: link.BuildOptions = .{
         .has_ios_sdk = enable_ios_sdk,
         .has_macos_sdk = enable_macos_sdk,
-        .has_symlinks_windows = omit_symlinks,
+        .has_symlinks = has_symlinks,
     };
     step.dependOn(@import("elf.zig").testAll(b, build_opts));
     step.dependOn(@import("macho.zig").testAll(b, build_opts));
@@ -36,7 +36,7 @@ pub fn build(b: *std.Build) void {
                     pkg.build_zig.requires_macos_sdk;
                 const requires_symlinks = @hasDecl(pkg.build_zig, "requires_symlinks") and
                     pkg.build_zig.requires_symlinks;
-                if ((requires_symlinks and omit_symlinks) or
+                if ((requires_symlinks and !has_symlinks) or
                     (requires_macos_sdk and !enable_macos_sdk) or
                     (requires_ios_sdk and !enable_ios_sdk))
                 {

--- a/test/link/link.zig
+++ b/test/link/link.zig
@@ -1,7 +1,7 @@
 pub const BuildOptions = struct {
     has_macos_sdk: bool,
     has_ios_sdk: bool,
-    has_symlinks_windows: bool,
+    has_symlinks: bool,
 };
 
 pub const Options = struct {

--- a/test/link/macho.zig
+++ b/test/link/macho.zig
@@ -62,8 +62,8 @@ pub fn testAll(b: *Build, build_opts: BuildOptions) *Step {
         .os_version_min = .{ .semver = .{ .major = 10, .minor = 13, .patch = 0 } },
     }) }));
 
-    // Tests requiring symlinks when tested on Windows
-    if (build_opts.has_symlinks_windows) {
+    // Tests requiring symlinks
+    if (build_opts.has_symlinks) {
         macho_step.dependOn(testEntryPointArchive(b, .{ .target = default_target }));
         macho_step.dependOn(testEntryPointDylib(b, .{ .target = default_target }));
         macho_step.dependOn(testDylib(b, .{ .target = default_target }));
@@ -836,9 +836,9 @@ fn testLinkDirectlyCppTbd(b: *Build, opts: Options) *Step {
         ,
         .cpp_source_flags = &.{ "-nostdlib++", "-nostdinc++" },
     });
-    exe.root_module.addSystemIncludePath(b.path(b.pathJoin(&.{ sdk, "/usr/include" })));
-    exe.root_module.addIncludePath(b.path(b.pathJoin(&.{ sdk, "/usr/include/c++/v1" })));
-    exe.root_module.addObjectFile(b.path(b.pathJoin(&.{ sdk, "/usr/lib/libc++.tbd" })));
+    exe.root_module.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ sdk, "/usr/include" }) });
+    exe.root_module.addIncludePath(.{ .cwd_relative = b.pathJoin(&.{ sdk, "/usr/include/c++/v1" }) });
+    exe.root_module.addObjectFile(.{ .cwd_relative = b.pathJoin(&.{ sdk, "/usr/lib/libc++.tbd" }) });
 
     const check = exe.checkObject();
     check.checkInSymtab();


### PR DESCRIPTION
Fixes regression introduced by https://github.com/ziglang/zig/commit/5d5e89aa8d5a454bce2c93555d3bc7c7ae1aa162

Turns out since landing that PR we haven't run any tests requiring symlinks or any Apple SDK on a macOS host. Not great.