### PR TITLE
init: clarify .paths usage in build.zig.zon

### DIFF
--- a/lib/init/build.zig.zon
+++ b/lib/init/build.zig.zon
@@ -47,20 +47,17 @@
 
     // Specifies the set of files and directories that are included in this package.
     // Only files and directories listed here are included in the `hash` that
-    // is computed for this package.
+    // is computed for this package. Only files listed here will remain on disk
+    // when using the zig package manager. As a rule of thumb, one should list
+    // files required for compilation plus any license(s).
     // Paths are relative to the build root. Use the empty string (`""`) to refer to
     // the build root itself.
     // A directory listed here means that all files within, recursively, are included.
     .paths = .{
-        // This makes *all* files, recursively, included in this package. It is generally
-        // better to explicitly list the files and directories instead, to insure that
-        // fetching from tarballs, file system paths, and version control all result
-        // in the same contents hash.
-        "",
+        "build.zig",
+        "build.zig.zon",
+        "src",
         // For example...
-        //"build.zig",
-        //"build.zig.zon",
-        //"src",
         //"LICENSE",
         //"README.md",
     },


### PR DESCRIPTION
Clarify the usage of .paths in build.zig.zon. Follow the recommendation
of the comments to explicitly list paths by explicitly listing the paths
in the init project.
