### PR TITLE
fix(std): Use const self pointer for hashmap capacity method

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -542,7 +542,7 @@ pub fn HashMap(
 
         /// Returns the number of total elements which may be present before it is
         /// no longer guaranteed that no allocations will be performed.
-        pub fn capacity(self: *Self) Size {
+        pub fn capacity(self: *const Self) Size {
             return self.unmanaged.capacity();
         }
 


### PR DESCRIPTION
Noticed that this could be changed to a const pointer while reading through the source for ziglang-set. I'm still relatively new to the language so if I'm misunderstanding something my apologies.