### PR TITLE
build: retry when nested lazy dependency causes missing artifact

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1806,6 +1806,10 @@ pub const Dependency = struct {
             }
         }
         return found orelse {
+            if (d.builder.graph.needed_lazy_dependencies.entries.len != 0) {
+                // The artifact might become available after missing lazy dependencies have been resolved.
+                process.exit(3);
+            }
             for (d.builder.install_tls.step.dependencies.items) |dep_step| {
                 const inst = dep_step.cast(Step.InstallArtifact) orelse continue;
                 log.info("available artifact: '{s}'", .{inst.artifact.name});


### PR DESCRIPTION
Consider root build.zig having a mandatory dependency on package A which in turns has a lazy dependency on package B.

When the root build.zig calls

    const artifact = dep_a.artifact("a_artifact");

This might cause an error, as package B needs to be fetched before the artifact can be built. However, the hard panic in Dependency.artifact() is seen as a fatal error which _prevents_ the parent `zig build` process from fetching missing dependencies and trying once more.

Handle this more gracefully by checking if we already know there were missing lazy dependencies, which might come from package A. In the case we still reach a fixed point with a missing artifact, panic as before.

For reference, this happened when depending upon https://github.com/natecraddock/ziglua/blob/486f51d3acc61d805783f5f07aee34c75ab59a25/build.zig and using the `ziglua.artifact("lua")` artifact before its lazy dependencies were fetched. 