### PR TITLE
CMake fixes for MSVC and LLVM 18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,6 +728,9 @@ if(NOT MSVC)
     -Wno-missing-braces
     -Wno-comment
   )
+else()
+target_compile_options(zigcpp PRIVATE /Zc:preprocessor)
+set_property(TARGET zigcpp PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
 endif()
 
 target_include_directories(zigcpp PUBLIC


### PR DESCRIPTION
- cmake: add `/Zc:preprocessor` to handle new OptTable macros
  - See: https://github.com/llvm/llvm-project/commit/12d8e7c6ade55bba241259312e3e4bdcf6aeab81
  - See: https://github.com/llvm/llvm-project/commit/3f092f37b7362447cbb13f5502dae4bdd5762afd
  - See: https://github.com/llvm/llvm-project/issues/86028#issuecomment-2019193306
- cmake: set `MSVC_RUNTIME_LIBRARY` for zigcpp

Related: https://github.com/ziglang/zig-bootstrap/pull/171