### PR TITLE
rework std.Progress

### DIFF
--- a/lib/compiler/aro/aro/Diagnostics.zig
+++ b/lib/compiler/aro/aro/Diagnostics.zig
@@ -528,7 +528,7 @@ const MsgWriter = struct {
     config: std.io.tty.Config,
 
     fn init(config: std.io.tty.Config) MsgWriter {
-        std.debug.getStderrMutex().lock();
+        std.debug.lockStdErr();
         return .{
             .w = std.io.bufferedWriter(std.io.getStdErr().writer()),
             .config = config,
@@ -537,7 +537,7 @@ const MsgWriter = struct {
 
     pub fn deinit(m: *MsgWriter) void {
         m.w.flush() catch {};
-        std.debug.getStderrMutex().unlock();
+        std.debug.unlockStdErr();
     }
 
     pub fn print(m: *MsgWriter, comptime fmt: []const u8, args: anytype) void {

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -294,7 +294,7 @@ pub fn main() !void {
     builder.debug_log_scopes = debug_log_scopes.items;
     builder.resolveInstallPrefix(install_prefix, dir_list);
     {
-        var prog_node = main_progress_node.start("user build.zig logic", 0);
+        var prog_node = main_progress_node.start("Configure", 0);
         defer prog_node.end();
         try builder.runBuild(root);
     }

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -289,7 +289,9 @@ pub fn main() !void {
         .windows_api => {},
     }
 
-    const main_progress_node = std.Progress.start(.{});
+    const main_progress_node = std.Progress.start(.{
+        .disable_printing = (color == .off),
+    });
 
     builder.debug_log_scopes = debug_log_scopes.items;
     builder.resolveInstallPrefix(install_prefix, dir_list);
@@ -1223,7 +1225,7 @@ fn cleanExit() void {
     process.exit(0);
 }
 
-const Color = enum { auto, off, on };
+const Color = std.zig.Color;
 const Summary = enum { all, new, failures, none };
 
 fn get_tty_conf(color: Color, stderr: File) std.io.tty.Config {

--- a/lib/compiler/resinator/cli.zig
+++ b/lib/compiler/resinator/cli.zig
@@ -108,8 +108,8 @@ pub const Diagnostics = struct {
     }
 
     pub fn renderToStdErr(self: *Diagnostics, args: []const []const u8, config: std.io.tty.Config) void {
-        std.debug.getStderrMutex().lock();
-        defer std.debug.getStderrMutex().unlock();
+        std.debug.lockStdErr();
+        defer std.debug.unlockStdErr();
         const stderr = std.io.getStdErr().writer();
         self.renderToWriter(args, stderr, config) catch return;
     }

--- a/lib/compiler/resinator/errors.zig
+++ b/lib/compiler/resinator/errors.zig
@@ -60,8 +60,8 @@ pub const Diagnostics = struct {
     }
 
     pub fn renderToStdErr(self: *Diagnostics, cwd: std.fs.Dir, source: []const u8, tty_config: std.io.tty.Config, source_mappings: ?SourceMappings) void {
-        std.debug.getStderrMutex().lock();
-        defer std.debug.getStderrMutex().unlock();
+        std.debug.lockStdErr();
+        defer std.debug.unlockStdErr();
         const stderr = std.io.getStdErr().writer();
         for (self.errors.items) |err_details| {
             renderErrorMessage(self.allocator, stderr, tty_config, cwd, err_details, source, self.strings.items, source_mappings) catch return;

--- a/lib/compiler/resinator/main.zig
+++ b/lib/compiler/resinator/main.zig
@@ -50,12 +50,6 @@ pub fn main() !void {
         },
     };
 
-    if (zig_integration) {
-        // Send progress with a special string to indicate that the building of the
-        // resinator binary is finished and we've moved on to actually compiling the .rc file
-        try error_handler.server.serveStringMessage(.progress, "<resinator>");
-    }
-
     var options = options: {
         var cli_diagnostics = cli.Diagnostics.init(allocator);
         defer cli_diagnostics.deinit();

--- a/lib/compiler/test_runner.zig
+++ b/lib/compiler/test_runner.zig
@@ -129,12 +129,11 @@ fn mainTerminal() void {
     var ok_count: usize = 0;
     var skip_count: usize = 0;
     var fail_count: usize = 0;
-    var progress = std.Progress{
-        .dont_print_on_dumb = true,
-    };
-    const root_node = progress.start("Test", test_fn_list.len);
-    const have_tty = progress.terminal != null and
-        (progress.supports_ansi_escape_codes or progress.is_windows_terminal);
+    const root_node = std.Progress.start(.{
+        .root_name = "Test",
+        .estimated_total_items = test_fn_list.len,
+    });
+    const have_tty = std.io.getStdErr().isTty();
 
     var async_frame_buffer: []align(builtin.target.stackAlignment()) u8 = undefined;
     // TODO this is on the next line (using `undefined` above) because otherwise zig incorrectly
@@ -151,11 +150,9 @@ fn mainTerminal() void {
         }
         std.testing.log_level = .warn;
 
-        var test_node = root_node.start(test_fn.name, 0);
-        test_node.activate();
-        progress.refresh();
+        const test_node = root_node.start(test_fn.name, 0);
         if (!have_tty) {
-            std.debug.print("{d}/{d} {s}... ", .{ i + 1, test_fn_list.len, test_fn.name });
+            std.debug.print("{d}/{d} {s}...", .{ i + 1, test_fn_list.len, test_fn.name });
         }
         if (test_fn.func()) |_| {
             ok_count += 1;
@@ -164,12 +161,22 @@ fn mainTerminal() void {
         } else |err| switch (err) {
             error.SkipZigTest => {
                 skip_count += 1;
-                progress.log("SKIP\n", .{});
+                if (have_tty) {
+                    std.debug.print("{d}/{d} {s}...SKIP\n", .{ i + 1, test_fn_list.len, test_fn.name });
+                } else {
+                    std.debug.print("SKIP\n", .{});
+                }
                 test_node.end();
             },
             else => {
                 fail_count += 1;
-                progress.log("FAIL ({s})\n", .{@errorName(err)});
+                if (have_tty) {
+                    std.debug.print("{d}/{d} {s}...FAIL ({s})\n", .{
+                        i + 1, test_fn_list.len, test_fn.name, @errorName(err),
+                    });
+                } else {
+                    std.debug.print("FAIL ({s})\n", .{@errorName(err)});
+                }
                 if (@errorReturnTrace()) |trace| {
                     std.debug.dumpStackTrace(trace.*);
                 }

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1059,7 +1059,7 @@ pub fn getUninstallStep(b: *Build) *Step {
     return &b.uninstall_tls.step;
 }
 
-fn makeUninstall(uninstall_step: *Step, prog_node: *std.Progress.Node) anyerror!void {
+fn makeUninstall(uninstall_step: *Step, prog_node: std.Progress.Node) anyerror!void {
     _ = prog_node;
     const uninstall_tls: *TopLevelStep = @fieldParentPtr("step", uninstall_step);
     const b: *Build = @fieldParentPtr("uninstall_tls", uninstall_tls);
@@ -2281,10 +2281,10 @@ pub const LazyPath = union(enum) {
             .cwd_relative => |p| return src_builder.pathFromCwd(p),
             .generated => |gen| {
                 var file_path: []const u8 = gen.file.step.owner.pathFromRoot(gen.file.path orelse {
-                    std.debug.getStderrMutex().lock();
+                    std.debug.lockStdErr();
                     const stderr = std.io.getStdErr();
                     dumpBadGetPathHelp(gen.file.step, stderr, src_builder, asking_step) catch {};
-                    std.debug.getStderrMutex().unlock();
+                    std.debug.unlockStdErr();
                     @panic("misconfigured build script");
                 });
 
@@ -2351,8 +2351,8 @@ fn dumpBadDirnameHelp(
     comptime msg: []const u8,
     args: anytype,
 ) anyerror!void {
-    debug.getStderrMutex().lock();
-    defer debug.getStderrMutex().unlock();
+    debug.lockStdErr();
+    defer debug.unlockStdErr();
 
     const stderr = io.getStdErr();
     const w = stderr.writer();

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -58,7 +58,7 @@ pub const TestResults = struct {
     }
 };
 
-pub const MakeFn = *const fn (step: *Step, prog_node: *std.Progress.Node) anyerror!void;
+pub const MakeFn = *const fn (step: *Step, prog_node: std.Progress.Node) anyerror!void;
 
 pub const State = enum {
     precheck_unstarted,
@@ -176,7 +176,7 @@ pub fn init(options: StepOptions) Step {
 /// If the Step's `make` function reports `error.MakeFailed`, it indicates they
 /// have already reported the error. Otherwise, we add a simple error report
 /// here.
-pub fn make(s: *Step, prog_node: *std.Progress.Node) error{ MakeFailed, MakeSkipped }!void {
+pub fn make(s: *Step, prog_node: std.Progress.Node) error{ MakeFailed, MakeSkipped }!void {
     const arena = s.owner.allocator;
 
     s.makeFn(s, prog_node) catch |err| switch (err) {
@@ -217,7 +217,7 @@ pub fn getStackTrace(s: *Step) ?std.builtin.StackTrace {
     };
 }
 
-fn makeNoOp(step: *Step, prog_node: *std.Progress.Node) anyerror!void {
+fn makeNoOp(step: *Step, prog_node: std.Progress.Node) anyerror!void {
     _ = prog_node;
 
     var all_cached = true;
@@ -303,7 +303,7 @@ pub fn addError(step: *Step, comptime fmt: []const u8, args: anytype) error{OutO
 pub fn evalZigProcess(
     s: *Step,
     argv: []const []const u8,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
 ) !?[]const u8 {
     assert(argv.len != 0);
     const b = s.owner;
@@ -313,12 +313,16 @@ pub fn evalZigProcess(
     try handleChildProcUnsupported(s, null, argv);
     try handleVerbose(s.owner, null, argv);
 
+    const sub_prog_node = prog_node.start("", 0);
+    defer sub_prog_node.end();
+
     var child = std.process.Child.init(argv, arena);
     child.env_map = &b.graph.env_map;
     child.stdin_behavior = .Pipe;
     child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Pipe;
     child.request_resource_usage_statistics = true;
+    child.progress_node = sub_prog_node;
 
     child.spawn() catch |err| return s.fail("unable to spawn {s}: {s}", .{
         argv[0], @errorName(err),
@@ -336,11 +340,6 @@ pub fn evalZigProcess(
 
     const Header = std.zig.Server.Message.Header;
     var result: ?[]const u8 = null;
-
-    var node_name: std.ArrayListUnmanaged(u8) = .{};
-    defer node_name.deinit(gpa);
-    var sub_prog_node = prog_node.start("", 0);
-    defer sub_prog_node.end();
 
     const stdout = poller.fifo(.stdout);
 
@@ -378,11 +377,6 @@ pub fn evalZigProcess(
                     .string_bytes = try arena.dupe(u8, string_bytes),
                     .extra = extra_array,
                 };
-            },
-            .progress => {
-                node_name.clearRetainingCapacity();
-                try node_name.appendSlice(gpa, body);
-                sub_prog_node.setName(node_name.items);
             },
             .emit_bin_path => {
                 const EbpHdr = std.zig.Server.Message.EmitBinPath;

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -313,16 +313,13 @@ pub fn evalZigProcess(
     try handleChildProcUnsupported(s, null, argv);
     try handleVerbose(s.owner, null, argv);
 
-    const sub_prog_node = prog_node.start("", 0);
-    defer sub_prog_node.end();
-
     var child = std.process.Child.init(argv, arena);
     child.env_map = &b.graph.env_map;
     child.stdin_behavior = .Pipe;
     child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Pipe;
     child.request_resource_usage_statistics = true;
-    child.progress_node = sub_prog_node;
+    child.progress_node = prog_node;
 
     child.spawn() catch |err| return s.fail("unable to spawn {s}: {s}", .{
         argv[0], @errorName(err),

--- a/lib/std/Build/Step/CheckFile.zig
+++ b/lib/std/Build/Step/CheckFile.zig
@@ -46,7 +46,7 @@ pub fn setName(check_file: *CheckFile, name: []const u8) void {
     check_file.step.name = name;
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const b = step.owner;
     const check_file: *CheckFile = @fieldParentPtr("step", step);

--- a/lib/std/Build/Step/CheckObject.zig
+++ b/lib/std/Build/Step/CheckObject.zig
@@ -550,7 +550,7 @@ pub fn checkComputeCompare(
     check_object.checks.append(check) catch @panic("OOM");
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const b = step.owner;
     const gpa = b.allocator;

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -967,7 +967,7 @@ fn getGeneratedFilePath(compile: *Compile, comptime tag_name: []const u8, asking
     const maybe_path: ?*GeneratedFile = @field(compile, tag_name);
 
     const generated_file = maybe_path orelse {
-        std.debug.getStderrMutex().lock();
+        std.debug.lockStdErr();
         const stderr = std.io.getStdErr();
 
         std.Build.dumpBadGetPathHelp(&compile.step, stderr, compile.step.owner, asking_step) catch {};
@@ -976,7 +976,7 @@ fn getGeneratedFilePath(compile: *Compile, comptime tag_name: []const u8, asking
     };
 
     const path = generated_file.path orelse {
-        std.debug.getStderrMutex().lock();
+        std.debug.lockStdErr();
         const stderr = std.io.getStdErr();
 
         std.Build.dumpBadGetPathHelp(&compile.step, stderr, compile.step.owner, asking_step) catch {};
@@ -987,7 +987,7 @@ fn getGeneratedFilePath(compile: *Compile, comptime tag_name: []const u8, asking
     return path;
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     const b = step.owner;
     const arena = b.allocator;
     const compile: *Compile = @fieldParentPtr("step", step);

--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -164,7 +164,7 @@ fn putValue(config_header: *ConfigHeader, field_name: []const u8, comptime T: ty
     }
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const b = step.owner;
     const config_header: *ConfigHeader = @fieldParentPtr("step", step);

--- a/lib/std/Build/Step/Fmt.zig
+++ b/lib/std/Build/Step/Fmt.zig
@@ -36,7 +36,7 @@ pub fn create(owner: *std.Build, options: Options) *Fmt {
     return fmt;
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     // zig fmt is fast enough that no progress is needed.
     _ = prog_node;
 

--- a/lib/std/Build/Step/InstallArtifact.zig
+++ b/lib/std/Build/Step/InstallArtifact.zig
@@ -115,7 +115,7 @@ pub fn create(owner: *std.Build, artifact: *Step.Compile, options: Options) *Ins
     return install_artifact;
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const install_artifact: *InstallArtifact = @fieldParentPtr("step", step);
     const b = step.owner;

--- a/lib/std/Build/Step/InstallDir.zig
+++ b/lib/std/Build/Step/InstallDir.zig
@@ -56,7 +56,7 @@ pub fn create(owner: *std.Build, options: Options) *InstallDir {
     return install_dir;
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const b = step.owner;
     const install_dir: *InstallDir = @fieldParentPtr("step", step);

--- a/lib/std/Build/Step/InstallFile.zig
+++ b/lib/std/Build/Step/InstallFile.zig
@@ -36,7 +36,7 @@ pub fn create(
     return install_file;
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const b = step.owner;
     const install_file: *InstallFile = @fieldParentPtr("step", step);

--- a/lib/std/Build/Step/ObjCopy.zig
+++ b/lib/std/Build/Step/ObjCopy.zig
@@ -90,7 +90,7 @@ pub fn getOutputSeparatedDebug(objcopy: *const ObjCopy) ?std.Build.LazyPath {
     return if (objcopy.output_file_debug) |*file| .{ .generated = .{ .file = file } } else null;
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     const b = step.owner;
     const objcopy: *ObjCopy = @fieldParentPtr("step", step);
 

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -410,7 +410,7 @@ pub fn getOutput(options: *Options) LazyPath {
     return .{ .generated = .{ .file = &options.generated_file } };
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     // This step completes so quickly that no progress is necessary.
     _ = prog_node;
 

--- a/lib/std/Build/Step/RemoveDir.zig
+++ b/lib/std/Build/Step/RemoveDir.zig
@@ -22,7 +22,7 @@ pub fn create(owner: *std.Build, dir_path: []const u8) *RemoveDir {
     return remove_dir;
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     // TODO update progress node while walking file system.
     // Should the standard library support this use case??
     _ = prog_node;

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -23,6 +23,11 @@ cwd: ?Build.LazyPath,
 /// Override this field to modify the environment, or use setEnvironmentVariable
 env_map: ?*EnvMap,
 
+/// When `true` prevents `ZIG_PROGRESS` environment variable from being passed
+/// to the child process, which otherwise would be used for the child to send
+/// progress updates to the parent.
+disable_zig_progress: bool,
+
 /// Configures whether the Run step is considered to have side-effects, and also
 /// whether the Run step will inherit stdio streams, forwarding them to the
 /// parent process, in which case will require a global lock to prevent other
@@ -152,6 +157,7 @@ pub fn create(owner: *std.Build, name: []const u8) *Run {
         .argv = .{},
         .cwd = null,
         .env_map = null,
+        .disable_zig_progress = false,
         .stdio = .infer_from_args,
         .stdin = .none,
         .extra_file_dependencies = &.{},
@@ -1235,7 +1241,7 @@ fn spawnChildAndCollect(
         child.stdin_behavior = .Pipe;
     }
 
-    if (run.stdio != .zig_test) {
+    if (run.stdio != .zig_test and !run.disable_zig_progress) {
         child.progress_node = prog_node;
     }
 

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -1236,7 +1236,7 @@ fn spawnChildAndCollect(
     }
 
     if (run.stdio != .zig_test) {
-        child.progress_node = prog_node.start("", 0);
+        child.progress_node = prog_node;
     }
 
     try child.spawn();

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -574,7 +574,7 @@ const IndexedOutput = struct {
     tag: @typeInfo(Arg).Union.tag_type.?,
     output: *Output,
 };
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     const b = step.owner;
     const arena = b.allocator;
     const run: *Run = @fieldParentPtr("step", step);
@@ -878,7 +878,7 @@ fn runCommand(
     argv: []const []const u8,
     has_side_effects: bool,
     output_dir_path: []const u8,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
 ) !void {
     const step = &run.step;
     const b = step.owner;
@@ -1195,7 +1195,7 @@ fn spawnChildAndCollect(
     run: *Run,
     argv: []const []const u8,
     has_side_effects: bool,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
 ) !ChildProcResult {
     const b = run.step.owner;
     const arena = b.allocator;
@@ -1235,6 +1235,10 @@ fn spawnChildAndCollect(
         child.stdin_behavior = .Pipe;
     }
 
+    if (run.stdio != .zig_test) {
+        child.progress_node = prog_node.start("", 0);
+    }
+
     try child.spawn();
     var timer = try std.time.Timer.start();
 
@@ -1264,7 +1268,7 @@ const StdIoResult = struct {
 fn evalZigTest(
     run: *Run,
     child: *std.process.Child,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
 ) !StdIoResult {
     const gpa = run.step.owner.allocator;
     const arena = run.step.owner.allocator;
@@ -1291,7 +1295,7 @@ fn evalZigTest(
     var metadata: ?TestMetadata = null;
 
     var sub_prog_node: ?std.Progress.Node = null;
-    defer if (sub_prog_node) |*n| n.end();
+    defer if (sub_prog_node) |n| n.end();
 
     poll: while (true) {
         while (stdout.readableLength() < @sizeOf(Header)) {
@@ -1406,7 +1410,7 @@ const TestMetadata = struct {
     expected_panic_msgs: []const u32,
     string_bytes: []const u8,
     next_index: u32,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
 
     fn testName(tm: TestMetadata, index: u32) []const u8 {
         return std.mem.sliceTo(tm.string_bytes[tm.names[index]..], 0);
@@ -1421,7 +1425,7 @@ fn requestNextTest(in: fs.File, metadata: *TestMetadata, sub_prog_node: *?std.Pr
         if (metadata.expected_panic_msgs[i] != 0) continue;
 
         const name = metadata.testName(i);
-        if (sub_prog_node.*) |*n| n.end();
+        if (sub_prog_node.*) |n| n.end();
         sub_prog_node.* = metadata.prog_node.start(name, 0);
 
         try sendRunTestMessage(in, i);

--- a/lib/std/Build/Step/TranslateC.zig
+++ b/lib/std/Build/Step/TranslateC.zig
@@ -116,7 +116,7 @@ pub fn defineCMacroRaw(translate_c: *TranslateC, name_and_value: []const u8) voi
     translate_c.c_macros.append(translate_c.step.owner.dupe(name_and_value)) catch @panic("OOM");
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     const b = step.owner;
     const translate_c: *TranslateC = @fieldParentPtr("step", step);
 

--- a/lib/std/Build/Step/WriteFile.zig
+++ b/lib/std/Build/Step/WriteFile.zig
@@ -198,7 +198,7 @@ fn maybeUpdateName(write_file: *WriteFile) void {
     }
 }
 
-fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const b = step.owner;
     const write_file: *WriteFile = @fieldParentPtr("step", step);

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -908,19 +908,24 @@ fn computeNode(
         global_progress.newline_count += 1;
     }
 
-    if (global_progress.newline_count < global_progress.rows) {
+    if (global_progress.withinRowLimit()) {
         if (children[@intFromEnum(node_index)].child.unwrap()) |child| {
             i = computeNode(buf, i, serialized, children, child);
         }
     }
 
-    if (global_progress.newline_count < global_progress.rows) {
+    if (global_progress.withinRowLimit()) {
         if (children[@intFromEnum(node_index)].sibling.unwrap()) |sibling| {
             i = computeNode(buf, i, serialized, children, sibling);
         }
     }
 
     return i;
+}
+
+fn withinRowLimit(p: *Progress) bool {
+    // The +1 here is so that the PS1 is not scrolled off the top of the terminal.
+    return p.newline_count + 1 < p.rows;
 }
 
 fn write(buf: []const u8) void {

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -128,12 +128,12 @@ pub const Node = struct {
         }
     };
 
-    const OptionalIndex = enum(u8) {
+    pub const OptionalIndex = enum(u8) {
         none = std.math.maxInt(u8),
         /// Index into `node_storage`.
         _,
 
-        fn unwrap(i: @This()) ?Index {
+        pub fn unwrap(i: @This()) ?Index {
             if (i == .none) return null;
             return @enumFromInt(@intFromEnum(i));
         }
@@ -145,7 +145,7 @@ pub const Node = struct {
     };
 
     /// Index into `node_storage`.
-    const Index = enum(u8) {
+    pub const Index = enum(u8) {
         _,
 
         fn toParent(i: @This()) Parent {
@@ -154,7 +154,7 @@ pub const Node = struct {
             return @enumFromInt(@intFromEnum(i));
         }
 
-        fn toOptional(i: @This()) OptionalIndex {
+        pub fn toOptional(i: @This()) OptionalIndex {
             return @enumFromInt(@intFromEnum(i));
         }
     };

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -635,7 +635,7 @@ fn serializeIpc(start_serialized_len: usize, serialized_buffer: *Serialized.Buff
             const n = posix.read(fd, pipe_buf[bytes_read..]) catch |err| switch (err) {
                 error.WouldBlock => break,
                 else => |e| {
-                    std.log.warn("failed to read child progress data: {s}", .{@errorName(e)});
+                    std.log.debug("failed to read child progress data: {s}", .{@errorName(e)});
                     main_storage.completed_count = 0;
                     main_storage.estimated_total_count = 0;
                     continue :main_loop;
@@ -964,13 +964,13 @@ fn writeIpc(fd: posix.fd_t, serialized: Serialized) error{BrokenPipe}!void {
     if (posix.writev(fd, &vecs)) |written| {
         const total = header.len + storage.len + parents.len;
         if (written < total) {
-            std.log.warn("short write: {d} out of {d}", .{ written, total });
+            std.log.debug("short write: {d} out of {d}", .{ written, total });
         }
     } else |err| switch (err) {
         error.WouldBlock => {},
         error.BrokenPipe => return error.BrokenPipe,
         else => |e| {
-            std.log.warn("failed to send progress to parent process: {s}", .{@errorName(e)});
+            std.log.debug("failed to send progress to parent process: {s}", .{@errorName(e)});
             return error.BrokenPipe;
         },
     }

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -879,6 +879,11 @@ fn computePrefix(
     var i = start_i;
     const parent_index = serialized.parents[@intFromEnum(node_index)].unwrap() orelse return i;
     if (serialized.parents[@intFromEnum(parent_index)] == .none) return i;
+    if (@intFromEnum(serialized.parents[@intFromEnum(parent_index)]) == 0 and
+        serialized.storage[0].name[0] == 0)
+    {
+        return i;
+    }
     i = computePrefix(buf, i, serialized, children, parent_index);
     if (children[@intFromEnum(parent_index)].sibling == .none) {
         const prefix = "   ";
@@ -917,7 +922,10 @@ fn computeNode(
     const name = if (std.mem.indexOfScalar(u8, &storage.name, 0)) |end| storage.name[0..end] else &storage.name;
     const parent = serialized.parents[@intFromEnum(node_index)];
 
-    if (parent != .none) {
+    if (parent != .none) p: {
+        if (@intFromEnum(parent) == 0 and serialized.storage[0].name[0] == 0) {
+            break :p;
+        }
         if (children[@intFromEnum(node_index)].sibling == .none) {
             buf[i..][0..tree_langle.len].* = tree_langle.*;
             i += tree_langle.len;

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -22,14 +22,10 @@ is_windows_terminal: bool,
 /// Whether the terminal supports ANSI escape codes.
 supports_ansi_escape_codes: bool,
 
-root: Node,
-
 update_thread: ?std.Thread,
 
 /// Atomically set by SIGWINCH as well as the root done() function.
 redraw_event: std.Thread.ResetEvent,
-/// Ensure there is only 1 global Progress object.
-initialized: bool,
 /// Indicates a request to shut down and reset global state.
 /// Accessed atomically.
 done: bool,
@@ -43,13 +39,22 @@ cols: u16,
 /// Accessed only by the update thread.
 draw_buffer: []u8,
 
+/// This is in a separate array from `node_storage` but with the same length so
+/// that it can be iterated over efficiently without trashing too much of the
+/// CPU cache.
+node_parents: []Node.Parent,
+node_storage: []Node.Storage,
+node_freelist: []Node.OptionalIndex,
+node_freelist_first: Node.OptionalIndex,
+node_end_index: u32,
+
 pub const Options = struct {
     /// User-provided buffer with static lifetime.
     ///
     /// Used to store the entire write buffer sent to the terminal. Progress output will be truncated if it
     /// cannot fit into this buffer which will look bad but not cause any malfunctions.
     ///
-    /// Must be at least 100 bytes.
+    /// Must be at least 200 bytes.
     draw_buffer: []u8,
     /// How many nanoseconds between writing updates to the terminal.
     refresh_rate_ns: u64 = 50 * std.time.ns_per_ms,
@@ -64,66 +69,128 @@ pub const Options = struct {
 /// Represents one unit of progress. Each node can have children nodes, or
 /// one can use integers with `update`.
 pub const Node = struct {
-    mutex: std.Thread.Mutex,
-    /// Links to the parent and child nodes.
-    parent_list_node: std.DoublyLinkedList(void).Node,
-    /// Links to the prev and next sibling nodes.
-    sibling_list_node: std.DoublyLinkedList(void).Node,
+    index: OptionalIndex,
 
-    name: []const u8,
-    /// Must be handled atomically to be thread-safe. 0 means null.
-    unprotected_estimated_total_items: usize,
-    /// Must be handled atomically to be thread-safe.
-    unprotected_completed_items: usize,
+    pub const max_name_len = 38;
 
-    pub const ListNode = std.DoublyLinkedList(void);
+    const Storage = extern struct {
+        /// Little endian.
+        completed_count: u32,
+        /// 0 means unknown.
+        /// Little endian.
+        estimated_total_count: u32,
+        name: [max_name_len]u8,
+    };
+
+    const Parent = enum(u16) {
+        /// Unallocated storage.
+        unused = std.math.maxInt(u16) - 1,
+        /// Indicates root node.
+        none = std.math.maxInt(u16),
+        /// Index into `node_storage`.
+        _,
+
+        fn unwrap(i: @This()) ?Index {
+            return switch (i) {
+                .unused, .none => return null,
+                else => @enumFromInt(@intFromEnum(i)),
+            };
+        }
+    };
+
+    const OptionalIndex = enum(u16) {
+        none = std.math.maxInt(u16),
+        /// Index into `node_storage`.
+        _,
+
+        fn unwrap(i: @This()) ?Index {
+            if (i == .none) return null;
+            return @enumFromInt(@intFromEnum(i));
+        }
+
+        fn toParent(i: @This()) Parent {
+            assert(@intFromEnum(i) != @intFromEnum(Parent.unused));
+            return @enumFromInt(@intFromEnum(i));
+        }
+    };
+
+    /// Index into `node_storage`.
+    const Index = enum(u16) {
+        _,
+
+        fn toParent(i: @This()) Parent {
+            assert(@intFromEnum(i) != @intFromEnum(Parent.unused));
+            assert(@intFromEnum(i) != @intFromEnum(Parent.none));
+            return @enumFromInt(@intFromEnum(i));
+        }
+
+        fn toOptional(i: @This()) OptionalIndex {
+            return @enumFromInt(@intFromEnum(i));
+        }
+    };
 
     /// Create a new child progress node. Thread-safe.
     ///
-    /// It is expected for the memory of the result to be stored in the
-    /// caller's stack and therefore is required to call `activate` immediately
-    /// on the result after initializing the memory location and `end` when done.
-    ///
     /// Passing 0 for `estimated_total_items` means unknown.
-    pub fn start(self: *Node, name: []const u8, estimated_total_items: usize) Node {
-        return .{
-            .mutex = .{},
-            .parent_list_node = .{
-                .prev = &self.parent_list_node,
-                .next = null,
-                .data = {},
-            },
-            .sibling_list_node = .{ .data = {} },
-            .name = name,
-            .unprotected_estimated_total_items = estimated_total_items,
-            .unprotected_completed_items = 0,
-        };
-    }
+    pub fn start(node: Node, name: []const u8, estimated_total_items: usize) Node {
+        const node_index = node.index.unwrap() orelse return .{ .index = .none };
+        const parent = node_index.toParent();
 
-    /// To be called exactly once after `start`.
-    pub fn activate(n: *Node) void {
-        const p = n.parent().?;
-        p.mutex.lock();
-        defer p.mutex.unlock();
-        assert(p.parent_list_node.next == null);
-        p.parent_list_node.next = &n.parent_list_node;
+        const freelist_head = &global_progress.node_freelist_first;
+        var opt_free_index = @atomicLoad(Node.OptionalIndex, freelist_head, .seq_cst);
+        while (opt_free_index.unwrap()) |free_index| {
+            const freelist_ptr = freelistByIndex(free_index);
+            opt_free_index = @cmpxchgWeak(Node.OptionalIndex, freelist_head, opt_free_index, freelist_ptr.*, .seq_cst, .seq_cst) orelse {
+                // We won the allocation race.
+                return init(free_index, parent, name, estimated_total_items);
+            };
+        }
+
+        const free_index = @atomicRmw(u32, &global_progress.node_end_index, .Add, 1, .monotonic);
+        if (free_index >= global_progress.node_storage.len) {
+            // Ran out of node storage memory. Progress for this node will not be tracked.
+            _ = @atomicRmw(u32, &global_progress.node_end_index, .Sub, 1, .monotonic);
+            return .{ .index = .none };
+        }
+
+        return init(@enumFromInt(free_index), parent, name, estimated_total_items);
     }
 
     /// This is the same as calling `start` and then `end` on the returned `Node`. Thread-safe.
-    pub fn completeOne(self: *Node) void {
-        _ = @atomicRmw(usize, &self.unprotected_completed_items, .Add, 1, .monotonic);
+    pub fn completeOne(n: Node) void {
+        const index = n.index.unwrap() orelse return;
+        const storage = storageByIndex(index);
+        _ = @atomicRmw(u32, &storage.completed_count, .Add, 1, .monotonic);
+    }
+
+    /// Thread-safe.
+    pub fn setCompletedItems(n: Node, completed_items: usize) void {
+        const index = n.index.unwrap() orelse return;
+        const storage = storageByIndex(index);
+        @atomicStore(u32, &storage.completed_count, std.math.lossyCast(u32, completed_items), .monotonic);
+    }
+
+    /// Thread-safe. 0 means unknown.
+    pub fn setEstimatedTotalItems(n: Node, count: usize) void {
+        const index = n.index.unwrap() orelse return;
+        const storage = storageByIndex(index);
+        @atomicStore(u32, &storage.estimated_total_count, std.math.lossyCast(u32, count), .monotonic);
     }
 
     /// Finish a started `Node`. Thread-safe.
-    pub fn end(child: *Node) void {
-        if (child.parent()) |p| {
-            // Make sure the other thread doesn't access this memory that is
-            // about to be released.
-            child.mutex.lock();
+    pub fn end(n: Node) void {
+        const index = n.index.unwrap() orelse return;
+        const parent_ptr = parentByIndex(index);
+        if (parent_ptr.unwrap()) |parent_index| {
+            _ = @atomicRmw(u32, &storageByIndex(parent_index).completed_count, .Add, 1, .monotonic);
+            @atomicStore(Node.Parent, parent_ptr, .unused, .seq_cst);
 
-            const other = if (child.sibling_list_node.next) |n| n else child.sibling_list_node.prev;
-            _ = @cmpxchgStrong(std.DoublyLinkedList(void).Node, &p.parent_list_node.next, child, other, .seq_cst, .seq_cst);
-            p.completeOne();
+            const freelist_head = &global_progress.node_freelist_first;
+            var first = @atomicLoad(Node.OptionalIndex, freelist_head, .seq_cst);
+            while (true) {
+                freelistByIndex(index).* = first;
+                first = @cmpxchgWeak(Node.OptionalIndex, freelist_head, first, index.toOptional(), .seq_cst, .seq_cst) orelse break;
+            }
         } else {
             @atomicStore(bool, &global_progress.done, true, .seq_cst);
             global_progress.redraw_event.set();
@@ -131,19 +198,35 @@ pub const Node = struct {
         }
     }
 
-    /// Thread-safe. 0 means unknown.
-    pub fn setEstimatedTotalItems(self: *Node, count: usize) void {
-        @atomicStore(usize, &self.unprotected_estimated_total_items, count, .monotonic);
+    fn storageByIndex(index: Node.Index) *Node.Storage {
+        return &global_progress.node_storage[@intFromEnum(index)];
     }
 
-    /// Thread-safe.
-    pub fn setCompletedItems(self: *Node, completed_items: usize) void {
-        @atomicStore(usize, &self.unprotected_completed_items, completed_items, .monotonic);
+    fn parentByIndex(index: Node.Index) *Node.Parent {
+        return &global_progress.node_parents[@intFromEnum(index)];
     }
 
-    fn parent(child: *Node) ?*Node {
-        const parent_node = child.parent_list_node.prev orelse return null;
-        return @fieldParentPtr("parent_list_node", parent_node);
+    fn freelistByIndex(index: Node.Index) *Node.OptionalIndex {
+        return &global_progress.node_freelist[@intFromEnum(index)];
+    }
+
+    fn init(free_index: Index, parent: Parent, name: []const u8, estimated_total_items: usize) Node {
+        assert(parent != .unused);
+
+        const storage = storageByIndex(free_index);
+        storage.* = .{
+            .completed_count = 0,
+            .estimated_total_count = std.math.lossyCast(u32, estimated_total_items),
+            .name = [1]u8{0} ** max_name_len,
+        };
+        const name_len = @min(max_name_len, name.len);
+        @memcpy(storage.name[0..name_len], name[0..name_len]);
+
+        const parent_ptr = parentByIndex(free_index);
+        assert(parent_ptr.* == .unused);
+        @atomicStore(Node.Parent, parent_ptr, parent, .release);
+
+        return .{ .index = free_index.toOptional() };
     }
 };
 
@@ -151,25 +234,36 @@ var global_progress: Progress = .{
     .terminal = null,
     .is_windows_terminal = false,
     .supports_ansi_escape_codes = false,
-    .root = undefined,
     .update_thread = null,
     .redraw_event = .{},
-    .initialized = false,
     .refresh_rate_ns = undefined,
     .initial_delay_ns = undefined,
     .rows = 0,
     .cols = 0,
     .draw_buffer = undefined,
     .done = false,
+
+    // TODO: make these configurable and avoid including the globals in .data if unused
+    .node_parents = &node_parents_buffer,
+    .node_storage = &node_storage_buffer,
+    .node_freelist = &node_freelist_buffer,
+    .node_freelist_first = .none,
+    .node_end_index = 0,
 };
+
+const default_node_storage_buffer_len = 100;
+var node_parents_buffer: [default_node_storage_buffer_len]Node.Parent = undefined;
+var node_storage_buffer: [default_node_storage_buffer_len]Node.Storage = undefined;
+var node_freelist_buffer: [default_node_storage_buffer_len]Node.OptionalIndex = undefined;
 
 /// Initializes a global Progress instance.
 ///
 /// Asserts there is only one global Progress instance.
 ///
 /// Call `Node.end` when done.
-pub fn start(options: Options) *Node {
-    assert(!global_progress.initialized);
+pub fn start(options: Options) Node {
+    // Ensure there is only 1 global Progress object.
+    assert(global_progress.node_end_index == 0);
     const stderr = std.io.getStdErr();
     if (stderr.supportsAnsiEscapeCodes()) {
         global_progress.terminal = stderr;
@@ -181,18 +275,12 @@ pub fn start(options: Options) *Node {
         // we are in a "dumb" terminal like in acme or writing to a file
         global_progress.terminal = stderr;
     }
-    global_progress.root = .{
-        .mutex = .{},
-        .parent_list_node = .{ .data = {} },
-        .sibling_list_node = .{ .data = {} },
-        .name = options.root_name,
-        .unprotected_estimated_total_items = options.estimated_total_items,
-        .unprotected_completed_items = 0,
-    };
+    @memset(global_progress.node_parents, .unused);
+    const root_node = Node.init(@enumFromInt(0), .none, options.root_name, options.estimated_total_items);
     global_progress.done = false;
-    global_progress.initialized = true;
+    global_progress.node_end_index = 1;
 
-    assert(options.draw_buffer.len >= 100);
+    assert(options.draw_buffer.len >= 200);
     global_progress.draw_buffer = options.draw_buffer;
     global_progress.refresh_rate_ns = options.refresh_rate_ns;
     global_progress.initial_delay_ns = options.initial_delay_ns;
@@ -204,7 +292,7 @@ pub fn start(options: Options) *Node {
     };
     posix.sigaction(posix.SIG.WINCH, &act, null) catch {
         global_progress.terminal = null;
-        return &global_progress.root;
+        return root_node;
     };
 
     if (global_progress.terminal != null) {
@@ -215,7 +303,7 @@ pub fn start(options: Options) *Node {
         }
     }
 
-    return &global_progress.root;
+    return root_node;
 }
 
 /// Returns whether a resize is needed to learn the terminal size.
@@ -263,11 +351,85 @@ const save = "\x1b7";
 const restore = "\x1b8";
 const finish_sync = "\x1b[?2026l";
 
+const tree_tee = "\x1B\x28\x30\x74\x71\x1B\x28\x42 "; // ├─
+const tree_line = "\x1B\x28\x30\x78\x1B\x28\x42  "; // │
+const tree_langle = "\x1B\x28\x30\x6d\x71\x1B\x28\x42 "; // └─
+
 fn clearTerminal() void {
     write(clear);
 }
 
+const Children = struct {
+    child: Node.OptionalIndex,
+    sibling: Node.OptionalIndex,
+};
+
 fn computeRedraw() []u8 {
+    // TODO make this configurable
+    var serialized_node_parents_buffer: [default_node_storage_buffer_len]Node.Parent = undefined;
+    var serialized_node_storage_buffer: [default_node_storage_buffer_len]Node.Storage = undefined;
+    var serialized_node_map_buffer: [default_node_storage_buffer_len]Node.Index = undefined;
+    var serialized_len: usize = 0;
+
+    // Iterate all of the nodes and construct a serializable copy of the state that can be examined
+    // without atomics.
+    const end_index = @atomicLoad(u32, &global_progress.node_end_index, .monotonic);
+    const node_parents = global_progress.node_parents[0..end_index];
+    const node_storage = global_progress.node_storage[0..end_index];
+    for (node_parents, node_storage, 0..) |*parent_ptr, *storage_ptr, i| {
+        var begin_parent = @atomicLoad(Node.Parent, parent_ptr, .seq_cst);
+        while (begin_parent != .unused) {
+            const dest_storage = &serialized_node_storage_buffer[serialized_len];
+            @memcpy(&dest_storage.name, &storage_ptr.name);
+            dest_storage.completed_count = @atomicLoad(u32, &storage_ptr.completed_count, .monotonic);
+            dest_storage.estimated_total_count = @atomicLoad(u32, &storage_ptr.estimated_total_count, .monotonic);
+
+            const end_parent = @atomicLoad(Node.Parent, parent_ptr, .seq_cst);
+            if (begin_parent == end_parent) {
+                serialized_node_parents_buffer[serialized_len] = begin_parent;
+                serialized_node_map_buffer[i] = @enumFromInt(serialized_len);
+                serialized_len += 1;
+                break;
+            }
+
+            begin_parent = end_parent;
+        }
+    }
+
+    // Now we can analyze our copy of the graph without atomics, reconstructing
+    // children lists which do not exist in the canonical data. These are
+    // needed for tree traversal below.
+    const serialized_node_parents = serialized_node_parents_buffer[0..serialized_len];
+    const serialized_node_storage = serialized_node_storage_buffer[0..serialized_len];
+
+    // Remap parents to point inside serialized arrays.
+    for (serialized_node_parents) |*parent| {
+        parent.* = switch (parent.*) {
+            .unused => unreachable,
+            .none => .none,
+            _ => |p| serialized_node_map_buffer[@intFromEnum(p)].toParent(),
+        };
+    }
+
+    var children_buffer: [default_node_storage_buffer_len]Children = undefined;
+    const children = children_buffer[0..serialized_len];
+
+    @memset(children, .{ .child = .none, .sibling = .none });
+
+    for (serialized_node_parents, 0..) |parent, child_index_usize| {
+        const child_index: Node.Index = @enumFromInt(child_index_usize);
+        assert(parent != .unused);
+        const parent_index = parent.unwrap() orelse continue;
+        const children_node = &children[@intFromEnum(parent_index)];
+        if (children_node.child.unwrap()) |existing_child_index| {
+            const existing_child = &children[@intFromEnum(existing_child_index)];
+            existing_child.sibling = child_index.toOptional();
+            children[@intFromEnum(child_index)].sibling = existing_child.sibling;
+        } else {
+            children_node.child = child_index.toOptional();
+        }
+    }
+
     // The strategy is: keep the cursor at the beginning, and then with every redraw:
     // erase, save, write, restore
 
@@ -280,32 +442,91 @@ fn computeRedraw() []u8 {
     buf[0..prefix.len].* = prefix.*;
     i = prefix.len;
 
-    // Walk the tree and write the progress output to the buffer.
-    var node: *Node = &global_progress.root;
-    while (true) {
-        const eti = @atomicLoad(usize, &node.unprotected_estimated_total_items, .monotonic);
-        const completed_items = @atomicLoad(usize, &node.unprotected_completed_items, .monotonic);
-
-        if (node.name.len != 0 or eti > 0) {
-            if (node.name.len != 0) {
-                i += (std.fmt.bufPrint(buf[i..], "{s}", .{node.name}) catch @panic("TODO")).len;
-            }
-            if (eti > 0) {
-                i += (std.fmt.bufPrint(buf[i..], "[{d}/{d}] ", .{ completed_items, eti }) catch @panic("TODO")).len;
-            } else if (completed_items != 0) {
-                i += (std.fmt.bufPrint(buf[i..], "[{d}] ", .{completed_items}) catch @panic("TODO")).len;
-            }
-        }
-
-        node = @atomicLoad(?*Node, &node.recently_updated_child, .acquire) orelse break;
-    }
-
-    i = @min(global_progress.cols + prefix.len, i);
+    const root_node_index: Node.Index = @enumFromInt(0);
+    i = computeNode(buf, i, serialized_node_storage, serialized_node_parents, children, root_node_index);
 
     buf[i..][0..suffix.len].* = suffix.*;
     i += suffix.len;
 
     return buf[0..i];
+}
+
+fn computePrefix(
+    buf: []u8,
+    start_i: usize,
+    serialized_node_storage: []const Node.Storage,
+    serialized_node_parents: []const Node.Parent,
+    children: []const Children,
+    node_index: Node.Index,
+) usize {
+    var i = start_i;
+    const parent_index = serialized_node_parents[@intFromEnum(node_index)].unwrap() orelse return i;
+    if (serialized_node_parents[@intFromEnum(parent_index)] == .none) return i;
+    i = computePrefix(buf, i, serialized_node_storage, serialized_node_parents, children, parent_index);
+    if (children[@intFromEnum(parent_index)].sibling == .none) {
+        buf[i..][0..3].* = "   ".*;
+        i += 3;
+    } else {
+        buf[i..][0..tree_line.len].* = tree_line.*;
+        i += tree_line.len;
+    }
+    return i;
+}
+
+fn computeNode(
+    buf: []u8,
+    start_i: usize,
+    serialized_node_storage: []const Node.Storage,
+    serialized_node_parents: []const Node.Parent,
+    children: []const Children,
+    node_index: Node.Index,
+) usize {
+    var i = start_i;
+    i = computePrefix(buf, i, serialized_node_storage, serialized_node_parents, children, node_index);
+
+    const storage = &serialized_node_storage[@intFromEnum(node_index)];
+    const estimated_total = storage.estimated_total_count;
+    const completed_items = storage.completed_count;
+    const name = if (std.mem.indexOfScalar(u8, &storage.name, 0)) |end| storage.name[0..end] else &storage.name;
+    const parent = serialized_node_parents[@intFromEnum(node_index)];
+
+    if (parent != .none) {
+        if (children[@intFromEnum(node_index)].sibling == .none) {
+            buf[i..][0..tree_langle.len].* = tree_langle.*;
+            i += tree_langle.len;
+        } else {
+            buf[i..][0..tree_tee.len].* = tree_tee.*;
+            i += tree_tee.len;
+        }
+    }
+
+    if (name.len != 0 or estimated_total > 0) {
+        if (estimated_total > 0) {
+            i += (std.fmt.bufPrint(buf[i..], "[{d}/{d}] ", .{ completed_items, estimated_total }) catch &.{}).len;
+        } else if (completed_items != 0) {
+            i += (std.fmt.bufPrint(buf[i..], "[{d}] ", .{completed_items}) catch &.{}).len;
+        }
+        if (name.len != 0) {
+            i += (std.fmt.bufPrint(buf[i..], "{s}", .{name}) catch &.{}).len;
+        }
+    }
+
+    i = @min(global_progress.cols + start_i, i);
+    buf[i] = '\n';
+    i += 1;
+
+    if (children[@intFromEnum(node_index)].child.unwrap()) |child| {
+        i = computeNode(buf, i, serialized_node_storage, serialized_node_parents, children, child);
+    }
+
+    {
+        var opt_sibling = children[@intFromEnum(node_index)].sibling;
+        while (opt_sibling.unwrap()) |sibling| {
+            i = computeNode(buf, i, serialized_node_storage, serialized_node_parents, children, sibling);
+        }
+    }
+
+    return i;
 }
 
 fn write(buf: []const u8) void {

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -1,7 +1,4 @@
-//! This API is non-allocating, non-fallible, and thread-safe.
-//!
-//! The tradeoff is that users of this API must provide the storage
-//! for each `Progress.Node`.
+//! This API is non-allocating, non-fallible, thread-safe, and lock-free.
 
 const std = @import("std");
 const builtin = @import("builtin");

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -59,9 +59,9 @@ pub const Options = struct {
     /// Must be at least 200 bytes.
     draw_buffer: []u8 = &default_draw_buffer,
     /// How many nanoseconds between writing updates to the terminal.
-    refresh_rate_ns: u64 = 60 * std.time.ns_per_ms,
+    refresh_rate_ns: u64 = 80 * std.time.ns_per_ms,
     /// How many nanoseconds to keep the output hidden
-    initial_delay_ns: u64 = 500 * std.time.ns_per_ms,
+    initial_delay_ns: u64 = 200 * std.time.ns_per_ms,
     /// If provided, causes the progress item to have a denominator.
     /// 0 means unknown.
     estimated_total_items: usize = 0,

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -592,7 +592,7 @@ const SavedMetadata = extern struct {
 
 fn serializeIpc(start_serialized_len: usize) usize {
     var serialized_len = start_serialized_len;
-    var pipe_buf: [4096]u8 align(4) = undefined;
+    var pipe_buf: [2 * 4096]u8 align(4) = undefined;
 
     main_loop: for (
         serialized_node_parents_buffer[0..serialized_len],
@@ -836,10 +836,13 @@ fn computeNode(
         }
     }
 
-    i = @min(global_progress.cols + start_i, i);
-    buf[i] = '\n';
-    i += 1;
-    global_progress.newline_count += 1;
+    const is_empty_root = @intFromEnum(node_index) == 0 and serialized.storage[0].name[0] == 0;
+    if (!is_empty_root) {
+        i = @min(global_progress.cols + start_i, i);
+        buf[i] = '\n';
+        i += 1;
+        global_progress.newline_count += 1;
+    }
 
     if (global_progress.newline_count < global_progress.rows) {
         if (children[@intFromEnum(node_index)].child.unwrap()) |child| {

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -2759,12 +2759,18 @@ pub const Trace = ConfigurableTrace(2, 4, builtin.mode == .Debug);
 
 pub fn ConfigurableTrace(comptime size: usize, comptime stack_frame_count: usize, comptime is_enabled: bool) type {
     return struct {
-        addrs: [actual_size][stack_frame_count]usize = undefined,
-        notes: [actual_size][]const u8 = undefined,
-        index: Index = 0,
+        addrs: [actual_size][stack_frame_count]usize,
+        notes: [actual_size][]const u8,
+        index: Index,
 
         const actual_size = if (enabled) size else 0;
         const Index = if (enabled) usize else u0;
+
+        pub const init: @This() = .{
+            .addrs = undefined,
+            .notes = undefined,
+            .index = 0,
+        };
 
         pub const enabled = is_enabled;
 

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -9,7 +9,7 @@ const assert = std.debug.assert;
 const mem = std.mem;
 const unicode = std.unicode;
 const meta = std.meta;
-const lossyCast = std.math.lossyCast;
+const lossyCast = math.lossyCast;
 const expectFmt = std.testing.expectFmt;
 
 pub const default_max_depth = 3;
@@ -1494,10 +1494,20 @@ pub fn Formatter(comptime format_fn: anytype) type {
 /// Ignores '_' character in `buf`.
 /// See also `parseUnsigned`.
 pub fn parseInt(comptime T: type, buf: []const u8, base: u8) ParseIntError!T {
+    return parseIntWithGenericCharacter(T, u8, buf, base);
+}
+
+/// Like `parseInt`, but with a generic `Character` type.
+pub fn parseIntWithGenericCharacter(
+    comptime Result: type,
+    comptime Character: type,
+    buf: []const Character,
+    base: u8,
+) ParseIntError!Result {
     if (buf.len == 0) return error.InvalidCharacter;
-    if (buf[0] == '+') return parseWithSign(T, buf[1..], base, .pos);
-    if (buf[0] == '-') return parseWithSign(T, buf[1..], base, .neg);
-    return parseWithSign(T, buf, base, .pos);
+    if (buf[0] == '+') return parseIntWithSign(Result, Character, buf[1..], base, .pos);
+    if (buf[0] == '-') return parseIntWithSign(Result, Character, buf[1..], base, .neg);
+    return parseIntWithSign(Result, Character, buf, base, .pos);
 }
 
 test parseInt {
@@ -1560,12 +1570,13 @@ test parseInt {
     try std.testing.expectEqual(@as(i5, -16), try std.fmt.parseInt(i5, "-10", 16));
 }
 
-fn parseWithSign(
-    comptime T: type,
-    buf: []const u8,
+fn parseIntWithSign(
+    comptime Result: type,
+    comptime Character: type,
+    buf: []const Character,
     base: u8,
     comptime sign: enum { pos, neg },
-) ParseIntError!T {
+) ParseIntError!Result {
     if (buf.len == 0) return error.InvalidCharacter;
 
     var buf_base = base;
@@ -1575,7 +1586,7 @@ fn parseWithSign(
         buf_base = 10;
         // Detect the base by looking at buf prefix.
         if (buf.len > 2 and buf[0] == '0') {
-            switch (std.ascii.toLower(buf[1])) {
+            if (math.cast(u8, buf[1])) |c| switch (std.ascii.toLower(c)) {
                 'b' => {
                     buf_base = 2;
                     buf_start = buf[2..];
@@ -1589,7 +1600,7 @@ fn parseWithSign(
                     buf_start = buf[2..];
                 },
                 else => {},
-            }
+            };
         }
     }
 
@@ -1598,33 +1609,33 @@ fn parseWithSign(
         .neg => math.sub,
     };
 
-    // accumulate into U which is always 8 bits or larger.  this prevents
-    // `buf_base` from overflowing T.
-    const info = @typeInfo(T);
-    const U = std.meta.Int(info.Int.signedness, @max(8, info.Int.bits));
-    var x: U = 0;
+    // accumulate into Accumulate which is always 8 bits or larger.  this prevents
+    // `buf_base` from overflowing Result.
+    const info = @typeInfo(Result);
+    const Accumulate = std.meta.Int(info.Int.signedness, @max(8, info.Int.bits));
+    var accumulate: Accumulate = 0;
 
     if (buf_start[0] == '_' or buf_start[buf_start.len - 1] == '_') return error.InvalidCharacter;
 
     for (buf_start) |c| {
         if (c == '_') continue;
-        const digit = try charToDigit(c, buf_base);
-        if (x != 0) {
-            x = try math.mul(U, x, math.cast(U, buf_base) orelse return error.Overflow);
+        const digit = try charToDigit(math.cast(u8, c) orelse return error.InvalidCharacter, buf_base);
+        if (accumulate != 0) {
+            accumulate = try math.mul(Accumulate, accumulate, math.cast(Accumulate, buf_base) orelse return error.Overflow);
         } else if (sign == .neg) {
             // The first digit of a negative number.
             // Consider parsing "-4" as an i3.
             // This should work, but positive 4 overflows i3, so we can't cast the digit to T and subtract.
-            x = math.cast(U, -@as(i8, @intCast(digit))) orelse return error.Overflow;
+            accumulate = math.cast(Accumulate, -@as(i8, @intCast(digit))) orelse return error.Overflow;
             continue;
         }
-        x = try add(U, x, math.cast(U, digit) orelse return error.Overflow);
+        accumulate = try add(Accumulate, accumulate, math.cast(Accumulate, digit) orelse return error.Overflow);
     }
 
-    return if (T == U)
-        x
+    return if (Result == Accumulate)
+        accumulate
     else
-        math.cast(T, x) orelse return error.Overflow;
+        math.cast(Result, accumulate) orelse return error.Overflow;
 }
 
 /// Parses the string `buf` as unsigned representation in the specified base
@@ -1639,7 +1650,7 @@ fn parseWithSign(
 /// Ignores '_' character in `buf`.
 /// See also `parseInt`.
 pub fn parseUnsigned(comptime T: type, buf: []const u8, base: u8) ParseIntError!T {
-    return parseWithSign(T, buf, base, .pos);
+    return parseIntWithSign(T, u8, buf, base, .pos);
 }
 
 test parseUnsigned {

--- a/lib/std/io/tty.zig
+++ b/lib/std/io/tty.zig
@@ -24,7 +24,7 @@ pub fn detectConfig(file: File) Config {
 
     if (native_os == .windows and file.isTty()) {
         var info: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
-        if (windows.kernel32.GetConsoleScreenBufferInfo(file.handle, &info) != windows.TRUE) {
+        if (windows.kernel32.GetConsoleScreenBufferInfo(file.handle, &info) == windows.FALSE) {
             return if (force_color == true) .escape_codes else .no_color;
         }
         return .{ .windows_api = .{

--- a/lib/std/json/dynamic.zig
+++ b/lib/std/json/dynamic.zig
@@ -52,8 +52,8 @@ pub const Value = union(enum) {
     }
 
     pub fn dump(self: Value) void {
-        std.debug.getStderrMutex().lock();
-        defer std.debug.getStderrMutex().unlock();
+        std.debug.lockStdErr();
+        defer std.debug.unlockStdErr();
 
         const stderr = std.io.getStdErr().writer();
         stringify(self, .{}, stderr) catch return;

--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -45,8 +45,8 @@
 //!     const prefix = "[" ++ comptime level.asText() ++ "] " ++ scope_prefix;
 //!
 //!     // Print the message to stderr, silently ignoring any errors
-//!     std.debug.getStderrMutex().lock();
-//!     defer std.debug.getStderrMutex().unlock();
+//!     std.debug.lockStdErr();
+//!     defer std.debug.unlockStdErr();
 //!     const stderr = std.io.getStdErr().writer();
 //!     nosuspend stderr.print(prefix ++ format ++ "\n", args) catch return;
 //! }
@@ -152,8 +152,8 @@ pub fn defaultLog(
     var bw = std.io.bufferedWriter(stderr);
     const writer = bw.writer();
 
-    std.debug.getStderrMutex().lock();
-    defer std.debug.getStderrMutex().unlock();
+    std.debug.lockStdErr();
+    defer std.debug.unlockStdErr();
     nosuspend {
         writer.print(level_txt ++ prefix2 ++ format ++ "\n", args) catch return;
         bw.flush() catch return;

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -175,6 +175,15 @@ pub extern "kernel32" fn FillConsoleOutputCharacterW(hConsoleOutput: HANDLE, cCh
 pub extern "kernel32" fn FillConsoleOutputAttribute(hConsoleOutput: HANDLE, wAttribute: WORD, nLength: DWORD, dwWriteCoord: COORD, lpNumberOfAttrsWritten: *DWORD) callconv(WINAPI) BOOL;
 pub extern "kernel32" fn SetConsoleCursorPosition(hConsoleOutput: HANDLE, dwCursorPosition: COORD) callconv(WINAPI) BOOL;
 
+pub extern "kernel32" fn WriteConsoleW(hConsoleOutput: HANDLE, lpBuffer: [*]const u16, nNumberOfCharsToWrite: DWORD, lpNumberOfCharsWritten: ?*DWORD, lpReserved: ?LPVOID) callconv(WINAPI) BOOL;
+pub extern "kernel32" fn ReadConsoleOutputCharacterW(
+    hConsoleOutput: windows.HANDLE,
+    lpCharacter: [*]u16,
+    nLength: windows.DWORD,
+    dwReadCoord: windows.COORD,
+    lpNumberOfCharsRead: *windows.DWORD,
+) callconv(windows.WINAPI) windows.BOOL;
+
 pub extern "kernel32" fn GetCurrentDirectoryW(nBufferLength: DWORD, lpBuffer: ?[*]WCHAR) callconv(WINAPI) DWORD;
 
 pub extern "kernel32" fn GetCurrentThread() callconv(WINAPI) HANDLE;

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1760,6 +1760,7 @@ pub fn cleanExit() void {
     if (builtin.mode == .Debug) {
         return;
     } else {
+        std.debug.lockStdErr();
         exit(0);
     }
 }

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -442,10 +442,7 @@ pub fn parseEnvVarInt(comptime key: []const u8, comptime I: type, base: u8) Pars
     if (native_os == .windows) {
         const key_w = comptime std.unicode.utf8ToUtf16LeStringLiteral(key);
         const text = getenvW(key_w) orelse return error.EnvironmentVariableNotFound;
-        // For this implementation perhaps std.fmt.parseInt can be expanded to be generic across
-        // []u8 and []u16 like how many std.mem functions work.
-        _ = text;
-        @compileError("TODO implement this");
+        return std.fmt.parseIntWithGenericCharacter(I, u16, text, base);
     } else if (native_os == .wasi and !builtin.link_libc) {
         @compileError("parseEnvVarInt is not supported for WASI without libc");
     } else {

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1836,11 +1836,15 @@ pub fn createEnvironFromMap(
         break :a .nothing;
     };
 
-    const envp_count: usize = @intCast(@as(isize, map.count()) + @as(isize, switch (zig_progress_action) {
-        .add => 1,
-        .delete => -1,
-        .nothing, .edit => 0,
-    }));
+    const envp_count: usize = c: {
+        var count: usize = map.count();
+        switch (zig_progress_action) {
+            .add => count += 1,
+            .delete => count -= 1,
+            .nothing, .edit => {},
+        }
+        break :c count;
+    };
 
     const envp_buf = try arena.allocSentinel(?[*:0]u8, envp_count, null);
     var i: usize = 0;
@@ -1901,11 +1905,15 @@ pub fn createEnvironFromExisting(
         break :a .nothing;
     };
 
-    const envp_count: usize = @intCast(@as(isize, @intCast(existing_count)) + @as(isize, switch (zig_progress_action) {
-        .add => 1,
-        .delete => -1,
-        .nothing, .edit => 0,
-    }));
+    const envp_count: usize = c: {
+        var count: usize = existing_count;
+        switch (zig_progress_action) {
+            .add => count += 1,
+            .delete => count -= 1,
+            .nothing, .edit => {},
+        }
+        break :c count;
+    };
 
     const envp_buf = try arena.allocSentinel(?[*:0]u8, envp_count, null);
     var i: usize = 0;

--- a/lib/std/process/Child.zig
+++ b/lib/std/process/Child.zig
@@ -610,6 +610,7 @@ fn spawnPosix(self: *ChildProcess) SpawnError!void {
     for (self.argv, 0..) |arg, i| argv_buf[i] = (try arena.dupeZ(u8, arg)).ptr;
 
     const prog_fileno = 3;
+    comptime assert(@max(posix.STDIN_FILENO, posix.STDOUT_FILENO, posix.STDERR_FILENO) + 1 == prog_fileno);
 
     const envp: [*:null]const ?[*:0]const u8 = m: {
         const prog_fd: i32 = if (prog_pipe[1] == -1) -1 else prog_fileno;

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -718,7 +718,7 @@ pub const LazySrcLoc = union(enum) {
     /// where in semantic analysis the value got set.
     pub const TracedOffset = struct {
         x: i32,
-        trace: std.debug.Trace = .{},
+        trace: std.debug.Trace = std.debug.Trace.init,
 
         const want_tracing = false;
     };

--- a/lib/std/zig/ErrorBundle.zig
+++ b/lib/std/zig/ErrorBundle.zig
@@ -155,8 +155,8 @@ pub const RenderOptions = struct {
 };
 
 pub fn renderToStdErr(eb: ErrorBundle, options: RenderOptions) void {
-    std.debug.getStderrMutex().lock();
-    defer std.debug.getStderrMutex().unlock();
+    std.debug.lockStdErr();
+    defer std.debug.unlockStdErr();
     const stderr = std.io.getStdErr();
     return renderToWriter(eb, options, stderr.writer()) catch return;
 }

--- a/lib/std/zig/Server.zig
+++ b/lib/std/zig/Server.zig
@@ -14,8 +14,6 @@ pub const Message = struct {
         zig_version,
         /// Body is an ErrorBundle.
         error_bundle,
-        /// Body is a UTF-8 string.
-        progress,
         /// Body is a EmitBinPath.
         emit_bin_path,
         /// Body is a TestMetadata

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5968,7 +5968,7 @@ pub fn updateSubCompilation(
         const sub_node = prog_node.start(@tagName(misc_task), 0);
         defer sub_node.end();
 
-        try sub_comp.update(prog_node);
+        try sub_comp.update(sub_node);
     }
 
     // Look for compilation errors in this sub compilation

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3331,10 +3331,13 @@ pub fn performAllTheWork(
         try reportMultiModuleErrors(mod);
         try mod.flushRetryableFailures();
         mod.sema_prog_node = main_progress_node.start("Semantic Analysis", 0);
+        mod.codegen_prog_node = main_progress_node.start("Code Generation", 0);
     }
     defer if (comp.module) |mod| {
         mod.sema_prog_node.end();
         mod.sema_prog_node = undefined;
+        mod.codegen_prog_node.end();
+        mod.codegen_prog_node = undefined;
     };
 
     while (true) {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1273,8 +1273,8 @@ pub fn create(gpa: Allocator, arena: Allocator, options: CreateOptions) !*Compil
         if (options.verbose_llvm_cpu_features) {
             if (options.root_mod.resolved_target.llvm_cpu_features) |cf| print: {
                 const target = options.root_mod.resolved_target.result;
-                std.debug.getStderrMutex().lock();
-                defer std.debug.getStderrMutex().unlock();
+                std.debug.lockStdErr();
+                defer std.debug.unlockStdErr();
                 const stderr = std.io.getStdErr().writer();
                 nosuspend {
                     stderr.print("compilation: {s}\n", .{options.root_name}) catch break :print;
@@ -1934,7 +1934,7 @@ pub fn getTarget(self: Compilation) Target {
 /// Only legal to call when cache mode is incremental and a link file is present.
 pub fn hotCodeSwap(
     comp: *Compilation,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
     pid: std.process.Child.Id,
 ) !void {
     const lf = comp.bin_file.?;
@@ -1966,7 +1966,7 @@ fn cleanupAfterUpdate(comp: *Compilation) void {
 }
 
 /// Detect changes to source files, perform semantic analysis, and update the output files.
-pub fn update(comp: *Compilation, main_progress_node: *std.Progress.Node) !void {
+pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) !void {
     const tracy_trace = trace(@src());
     defer tracy_trace.end();
 
@@ -2256,7 +2256,7 @@ pub fn update(comp: *Compilation, main_progress_node: *std.Progress.Node) !void 
     }
 }
 
-fn flush(comp: *Compilation, arena: Allocator, prog_node: *std.Progress.Node) !void {
+fn flush(comp: *Compilation, arena: Allocator, prog_node: std.Progress.Node) !void {
     if (comp.bin_file) |lf| {
         // This is needed before reading the error flags.
         lf.flush(arena, prog_node) catch |err| switch (err) {
@@ -2566,13 +2566,11 @@ pub fn emitLlvmObject(
     default_emit: Emit,
     bin_emit_loc: ?EmitLoc,
     llvm_object: *LlvmObject,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
 ) !void {
     if (build_options.only_c) @compileError("unreachable");
 
-    var sub_prog_node = prog_node.start("LLVM Emit Object", 0);
-    sub_prog_node.activate();
-    sub_prog_node.context.refresh();
+    const sub_prog_node = prog_node.start("LLVM Emit Object", 0);
     defer sub_prog_node.end();
 
     try llvm_object.emit(.{
@@ -3249,23 +3247,23 @@ pub fn addZirErrorMessages(eb: *ErrorBundle.Wip, file: *Module.File) !void {
 
 pub fn performAllTheWork(
     comp: *Compilation,
-    main_progress_node: *std.Progress.Node,
+    main_progress_node: std.Progress.Node,
 ) error{ TimerUnsupported, OutOfMemory }!void {
     // Here we queue up all the AstGen tasks first, followed by C object compilation.
     // We wait until the AstGen tasks are all completed before proceeding to the
     // (at least for now) single-threaded main work queue. However, C object compilation
     // only needs to be finished by the end of this function.
 
-    var zir_prog_node = main_progress_node.start("AST Lowering", 0);
+    const zir_prog_node = main_progress_node.start("AST Lowering", 0);
     defer zir_prog_node.end();
 
-    var wasm_prog_node = main_progress_node.start("Compile Autodocs", 0);
+    const wasm_prog_node = main_progress_node.start("Compile Autodocs", 0);
     defer wasm_prog_node.end();
 
-    var c_obj_prog_node = main_progress_node.start("Compile C Objects", comp.c_source_files.len);
+    const c_obj_prog_node = main_progress_node.start("Compile C Objects", comp.c_source_files.len);
     defer c_obj_prog_node.end();
 
-    var win32_resource_prog_node = main_progress_node.start("Compile Win32 Resources", comp.rc_source_files.len);
+    const win32_resource_prog_node = main_progress_node.start("Compile Win32 Resources", comp.rc_source_files.len);
     defer win32_resource_prog_node.end();
 
     comp.work_queue_wait_group.reset();
@@ -3274,7 +3272,7 @@ pub fn performAllTheWork(
     if (!build_options.only_c and !build_options.only_core_functionality) {
         if (comp.docs_emit != null) {
             comp.thread_pool.spawnWg(&comp.work_queue_wait_group, workerDocsCopy, .{comp});
-            comp.work_queue_wait_group.spawnManager(workerDocsWasm, .{ comp, &wasm_prog_node });
+            comp.work_queue_wait_group.spawnManager(workerDocsWasm, .{ comp, wasm_prog_node });
         }
     }
 
@@ -3313,7 +3311,7 @@ pub fn performAllTheWork(
 
         while (comp.astgen_work_queue.readItem()) |file| {
             comp.thread_pool.spawnWg(&comp.astgen_wait_group, workerAstGenFile, .{
-                comp, file, &zir_prog_node, &comp.astgen_wait_group, .root,
+                comp, file, zir_prog_node, &comp.astgen_wait_group, .root,
             });
         }
 
@@ -3325,14 +3323,14 @@ pub fn performAllTheWork(
 
         while (comp.c_object_work_queue.readItem()) |c_object| {
             comp.thread_pool.spawnWg(&comp.work_queue_wait_group, workerUpdateCObject, .{
-                comp, c_object, &c_obj_prog_node,
+                comp, c_object, c_obj_prog_node,
             });
         }
 
         if (!build_options.only_core_functionality) {
             while (comp.win32_resource_work_queue.readItem()) |win32_resource| {
                 comp.thread_pool.spawnWg(&comp.work_queue_wait_group, workerUpdateWin32Resource, .{
-                    comp, win32_resource, &win32_resource_prog_node,
+                    comp, win32_resource, win32_resource_prog_node,
                 });
             }
         }
@@ -3342,7 +3340,6 @@ pub fn performAllTheWork(
         try reportMultiModuleErrors(mod);
         try mod.flushRetryableFailures();
         mod.sema_prog_node = main_progress_node.start("Semantic Analysis", 0);
-        mod.sema_prog_node.activate();
     }
     defer if (comp.module) |mod| {
         mod.sema_prog_node.end();
@@ -3379,7 +3376,7 @@ pub fn performAllTheWork(
     }
 }
 
-fn processOneJob(comp: *Compilation, job: Job, prog_node: *std.Progress.Node) !void {
+fn processOneJob(comp: *Compilation, job: Job, prog_node: std.Progress.Node) !void {
     switch (job) {
         .codegen_decl => |decl_index| {
             const module = comp.module.?;
@@ -3803,7 +3800,7 @@ fn docsCopyModule(comp: *Compilation, module: *Package.Module, name: []const u8,
     }
 }
 
-fn workerDocsWasm(comp: *Compilation, prog_node: *std.Progress.Node) void {
+fn workerDocsWasm(comp: *Compilation, prog_node: std.Progress.Node) void {
     workerDocsWasmFallible(comp, prog_node) catch |err| {
         comp.lockAndSetMiscFailure(.docs_wasm, "unable to build autodocs: {s}", .{
             @errorName(err),
@@ -3811,7 +3808,7 @@ fn workerDocsWasm(comp: *Compilation, prog_node: *std.Progress.Node) void {
     };
 }
 
-fn workerDocsWasmFallible(comp: *Compilation, prog_node: *std.Progress.Node) anyerror!void {
+fn workerDocsWasmFallible(comp: *Compilation, prog_node: std.Progress.Node) anyerror!void {
     const gpa = comp.gpa;
 
     var arena_allocator = std.heap.ArenaAllocator.init(gpa);
@@ -3952,12 +3949,11 @@ const AstGenSrc = union(enum) {
 fn workerAstGenFile(
     comp: *Compilation,
     file: *Module.File,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
     wg: *WaitGroup,
     src: AstGenSrc,
 ) void {
-    var child_prog_node = prog_node.start(file.sub_file_path, 0);
-    child_prog_node.activate();
+    const child_prog_node = prog_node.start(file.sub_file_path, 0);
     defer child_prog_node.end();
 
     const mod = comp.module.?;
@@ -4265,7 +4261,7 @@ pub fn cImport(comp: *Compilation, c_src: []const u8, owner_mod: *Package.Module
 fn workerUpdateCObject(
     comp: *Compilation,
     c_object: *CObject,
-    progress_node: *std.Progress.Node,
+    progress_node: std.Progress.Node,
 ) void {
     comp.updateCObject(c_object, progress_node) catch |err| switch (err) {
         error.AnalysisFail => return,
@@ -4282,7 +4278,7 @@ fn workerUpdateCObject(
 fn workerUpdateWin32Resource(
     comp: *Compilation,
     win32_resource: *Win32Resource,
-    progress_node: *std.Progress.Node,
+    progress_node: std.Progress.Node,
 ) void {
     comp.updateWin32Resource(win32_resource, progress_node) catch |err| switch (err) {
         error.AnalysisFail => return,
@@ -4300,7 +4296,7 @@ fn buildCompilerRtOneShot(
     comp: *Compilation,
     output_mode: std.builtin.OutputMode,
     out: *?CRTFile,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
 ) void {
     comp.buildOutputFromZig(
         "compiler_rt.zig",
@@ -4427,7 +4423,7 @@ fn reportRetryableEmbedFileError(
     }
 }
 
-fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.Progress.Node) !void {
+fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Progress.Node) !void {
     if (comp.config.c_frontend == .aro) {
         return comp.failCObj(c_object, "aro does not support compiling C objects yet", .{});
     }
@@ -4467,9 +4463,7 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.P
 
     const c_source_basename = std.fs.path.basename(c_object.src.src_path);
 
-    c_obj_prog_node.activate();
-    var child_progress_node = c_obj_prog_node.start(c_source_basename, 0);
-    child_progress_node.activate();
+    const child_progress_node = c_obj_prog_node.start(c_source_basename, 0);
     defer child_progress_node.end();
 
     // Special case when doing build-obj for just one C file. When there are more than one object
@@ -4731,7 +4725,7 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: *std.P
     };
 }
 
-fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32_resource_prog_node: *std.Progress.Node) !void {
+fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32_resource_prog_node: std.Progress.Node) !void {
     if (!std.process.can_spawn) {
         return comp.failWin32Resource(win32_resource, "{s} does not support spawning a child process", .{@tagName(builtin.os.tag)});
     }
@@ -4763,9 +4757,7 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
         _ = comp.failed_win32_resources.swapRemove(win32_resource);
     }
 
-    win32_resource_prog_node.activate();
-    var child_progress_node = win32_resource_prog_node.start(src_basename, 0);
-    child_progress_node.activate();
+    const child_progress_node = win32_resource_prog_node.start(src_basename, 0);
     defer child_progress_node.end();
 
     var man = comp.obtainWin32ResourceCacheManifest();
@@ -4833,7 +4825,7 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
             });
             try argv.appendSlice(&.{ "--", in_rc_path, out_res_path });
 
-            try spawnZigRc(comp, win32_resource, src_basename, arena, argv.items, &child_progress_node);
+            try spawnZigRc(comp, win32_resource, arena, argv.items, child_progress_node);
 
             break :blk digest;
         };
@@ -4901,7 +4893,7 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
         try argv.appendSlice(rc_src.extra_flags);
         try argv.appendSlice(&.{ "--", rc_src.src_path, out_res_path });
 
-        try spawnZigRc(comp, win32_resource, src_basename, arena, argv.items, &child_progress_node);
+        try spawnZigRc(comp, win32_resource, arena, argv.items, child_progress_node);
 
         // Read depfile and update cache manifest
         {
@@ -4966,10 +4958,9 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
 fn spawnZigRc(
     comp: *Compilation,
     win32_resource: *Win32Resource,
-    src_basename: []const u8,
     arena: Allocator,
     argv: []const []const u8,
-    child_progress_node: *std.Progress.Node,
+    child_progress_node: std.Progress.Node,
 ) !void {
     var node_name: std.ArrayListUnmanaged(u8) = .{};
     defer node_name.deinit(arena);
@@ -4978,6 +4969,7 @@ fn spawnZigRc(
     child.stdin_behavior = .Ignore;
     child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Pipe;
+    child.progress_node = child_progress_node;
 
     child.spawn() catch |err| {
         return comp.failWin32Resource(win32_resource, "unable to spawn {s} rc: {s}", .{ argv[0], @errorName(err) });
@@ -5018,22 +5010,6 @@ fn spawnZigRc(
                     .extra = extra_array,
                 };
                 return comp.failWin32ResourceWithOwnedBundle(win32_resource, error_bundle);
-            },
-            .progress => {
-                node_name.clearRetainingCapacity();
-                // <resinator> is a special string that indicates that the child
-                // process has reached resinator's main function
-                if (std.mem.eql(u8, body, "<resinator>")) {
-                    child_progress_node.setName(src_basename);
-                }
-                // Ignore 0-length strings since if multiple zig rc commands
-                // are executed at the same time, only one will send progress strings
-                // while the other(s) will send empty strings.
-                else if (body.len > 0) {
-                    try node_name.appendSlice(arena, "build 'zig rc'... ");
-                    try node_name.appendSlice(arena, body);
-                    child_progress_node.setName(node_name.items);
-                }
             },
             else => {}, // ignore other messages
         }
@@ -5937,8 +5913,8 @@ pub fn lockAndParseLldStderr(comp: *Compilation, prefix: []const u8, stderr: []c
 }
 
 pub fn dump_argv(argv: []const []const u8) void {
-    std.debug.getStderrMutex().lock();
-    defer std.debug.getStderrMutex().unlock();
+    std.debug.lockStdErr();
+    defer std.debug.unlockStdErr();
     const stderr = std.io.getStdErr().writer();
     for (argv[0 .. argv.len - 1]) |arg| {
         nosuspend stderr.print("{s} ", .{arg}) catch return;
@@ -5989,11 +5965,10 @@ pub fn updateSubCompilation(
     parent_comp: *Compilation,
     sub_comp: *Compilation,
     misc_task: MiscTask,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
 ) !void {
     {
-        var sub_node = prog_node.start(@tagName(misc_task), 0);
-        sub_node.activate();
+        const sub_node = prog_node.start(@tagName(misc_task), 0);
         defer sub_node.end();
 
         try sub_comp.update(prog_node);
@@ -6024,7 +5999,7 @@ fn buildOutputFromZig(
     output_mode: std.builtin.OutputMode,
     out: *?CRTFile,
     misc_task_tag: MiscTask,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
 ) !void {
     const tracy_trace = trace(@src());
     defer tracy_trace.end();
@@ -6131,7 +6106,7 @@ pub fn build_crt_file(
     root_name: []const u8,
     output_mode: std.builtin.OutputMode,
     misc_task_tag: MiscTask,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
     /// These elements have to get mutated to add the owner module after it is
     /// created within this function.
     c_source_files: []CSourceFile,

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -4504,7 +4504,7 @@ pub fn analyzeFnBody(mod: *Module, func_index: InternPool.Index, arena: Allocato
         log.debug("finish func name '{}'", .{(decl.fullyQualifiedName(mod) catch break :blk).fmt(ip)});
     }
 
-    const decl_prog_node = mod.sema_prog_ndoe.start((try decl.fullyQualifiedName(mod)).toSlice(ip), 0);
+    const decl_prog_node = mod.sema_prog_node.start((try decl.fullyQualifiedName(mod)).toSlice(ip), 0);
     defer decl_prog_node.end();
 
     mod.intern_pool.removeDependenciesForDepender(gpa, InternPool.Depender.wrap(.{ .func = func_index }));

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -2991,8 +2991,7 @@ pub fn ensureDeclAnalyzed(mod: *Module, decl_index: Decl.Index) SemaError!void {
         try mod.deleteDeclExports(decl_index);
     }
 
-    var decl_prog_node = mod.sema_prog_node.start("", 0);
-    decl_prog_node.activate();
+    const decl_prog_node = mod.sema_prog_node.start("", 0);
     defer decl_prog_node.end();
 
     const sema_result: SemaDeclResult = blk: {
@@ -5316,7 +5315,7 @@ fn handleUpdateExports(
 
 pub fn populateTestFunctions(
     mod: *Module,
-    main_progress_node: *std.Progress.Node,
+    main_progress_node: std.Progress.Node,
 ) !void {
     const gpa = mod.gpa;
     const ip = &mod.intern_pool;
@@ -5333,7 +5332,6 @@ pub fn populateTestFunctions(
         // We have to call `ensureDeclAnalyzed` here in case `builtin.test_functions`
         // was not referenced by start code.
         mod.sema_prog_node = main_progress_node.start("Semantic Analysis", 0);
-        mod.sema_prog_node.activate();
         defer {
             mod.sema_prog_node.end();
             mod.sema_prog_node = undefined;

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -5340,15 +5340,13 @@ pub fn populateTestFunctions(
         // We have to call `ensureDeclAnalyzed` here in case `builtin.test_functions`
         // was not referenced by start code.
         mod.sema_prog_node = main_progress_node.start("Semantic Analysis", 0);
-        mod.codegen_prog_node = main_progress_node.start("Code Generation", 0);
         defer {
             mod.sema_prog_node.end();
             mod.sema_prog_node = undefined;
-            mod.codegen_prog_node.end();
-            mod.codegen_prog_node = undefined;
         }
         try mod.ensureDeclAnalyzed(decl_index);
     }
+
     const decl = mod.declPtr(decl_index);
     const test_fn_ty = decl.typeOf(mod).slicePtrFieldType(mod).childType(mod);
 
@@ -5449,7 +5447,15 @@ pub fn populateTestFunctions(
         decl.val = new_val;
         decl.has_tv = true;
     }
-    try mod.linkerUpdateDecl(decl_index);
+    {
+        mod.codegen_prog_node = main_progress_node.start("Code Generation", 0);
+        defer {
+            mod.codegen_prog_node.end();
+            mod.codegen_prog_node = undefined;
+        }
+
+        try mod.linkerUpdateDecl(decl_index);
+    }
 }
 
 pub fn linkerUpdateDecl(zcu: *Zcu, decl_index: Decl.Index) !void {

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -160,7 +160,7 @@ pub const CRTFile = enum {
     libc_nonshared_a,
 };
 
-pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: *std.Progress.Node) !void {
+pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progress.Node) !void {
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }
@@ -658,7 +658,7 @@ pub const BuiltSharedObjects = struct {
 
 const all_map_basename = "all.map";
 
-pub fn buildSharedObjects(comp: *Compilation, prog_node: *std.Progress.Node) !void {
+pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -1065,7 +1065,7 @@ fn buildSharedLib(
     bin_directory: Compilation.Directory,
     asm_file_basename: []const u8,
     lib: Lib,
-    prog_node: *std.Progress.Node,
+    prog_node: std.Progress.Node,
 ) !void {
     const tracy = trace(@src());
     defer tracy.end();

--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -113,7 +113,7 @@ pub const BuildError = error{
     ZigCompilerNotBuiltWithLLVMExtensions,
 };
 
-pub fn buildLibCXX(comp: *Compilation, prog_node: *std.Progress.Node) BuildError!void {
+pub fn buildLibCXX(comp: *Compilation, prog_node: std.Progress.Node) BuildError!void {
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }
@@ -357,7 +357,7 @@ pub fn buildLibCXX(comp: *Compilation, prog_node: *std.Progress.Node) BuildError
     comp.libcxx_static_lib = try sub_compilation.toCrtFile();
 }
 
-pub fn buildLibCXXABI(comp: *Compilation, prog_node: *std.Progress.Node) BuildError!void {
+pub fn buildLibCXXABI(comp: *Compilation, prog_node: std.Progress.Node) BuildError!void {
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }

--- a/src/libtsan.zig
+++ b/src/libtsan.zig
@@ -13,7 +13,7 @@ pub const BuildError = error{
     TSANUnsupportedCPUArchitecture,
 };
 
-pub fn buildTsan(comp: *Compilation, prog_node: *std.Progress.Node) BuildError!void {
+pub fn buildTsan(comp: *Compilation, prog_node: std.Progress.Node) BuildError!void {
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }

--- a/src/libunwind.zig
+++ b/src/libunwind.zig
@@ -14,7 +14,7 @@ pub const BuildError = error{
     ZigCompilerNotBuiltWithLLVMExtensions,
 };
 
-pub fn buildStaticLib(comp: *Compilation, prog_node: *std.Progress.Node) BuildError!void {
+pub fn buildStaticLib(comp: *Compilation, prog_node: std.Progress.Node) BuildError!void {
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }

--- a/src/link.zig
+++ b/src/link.zig
@@ -535,7 +535,7 @@ pub const File = struct {
     /// Commit pending changes and write headers. Takes into account final output mode
     /// and `use_lld`, not only `effectiveOutputMode`.
     /// `arena` has the lifetime of the call to `Compilation.update`.
-    pub fn flush(base: *File, arena: Allocator, prog_node: *std.Progress.Node) FlushError!void {
+    pub fn flush(base: *File, arena: Allocator, prog_node: std.Progress.Node) FlushError!void {
         if (build_options.only_c) {
             assert(base.tag == .c);
             return @as(*C, @fieldParentPtr("base", base)).flush(arena, prog_node);
@@ -572,7 +572,7 @@ pub const File = struct {
 
     /// Commit pending changes and write headers. Works based on `effectiveOutputMode`
     /// rather than final output mode.
-    pub fn flushModule(base: *File, arena: Allocator, prog_node: *std.Progress.Node) FlushError!void {
+    pub fn flushModule(base: *File, arena: Allocator, prog_node: std.Progress.Node) FlushError!void {
         switch (base.tag) {
             inline else => |tag| {
                 if (tag != .c and build_options.only_c) unreachable;
@@ -688,7 +688,7 @@ pub const File = struct {
         }
     }
 
-    pub fn linkAsArchive(base: *File, arena: Allocator, prog_node: *std.Progress.Node) FlushError!void {
+    pub fn linkAsArchive(base: *File, arena: Allocator, prog_node: std.Progress.Node) FlushError!void {
         const tracy = trace(@src());
         defer tracy.end();
 
@@ -966,7 +966,7 @@ pub const File = struct {
         base: File,
         arena: Allocator,
         llvm_object: *LlvmObject,
-        prog_node: *std.Progress.Node,
+        prog_node: std.Progress.Node,
     ) !void {
         return base.comp.emitLlvmObject(arena, base.emit, .{
             .directory = null,

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -370,7 +370,7 @@ pub fn updateDeclLineNumber(self: *C, zcu: *Zcu, decl_index: InternPool.DeclInde
     _ = decl_index;
 }
 
-pub fn flush(self: *C, arena: Allocator, prog_node: *std.Progress.Node) !void {
+pub fn flush(self: *C, arena: Allocator, prog_node: std.Progress.Node) !void {
     return self.flushModule(arena, prog_node);
 }
 
@@ -389,14 +389,13 @@ fn abiDefines(self: *C, target: std.Target) !std.ArrayList(u8) {
     return defines;
 }
 
-pub fn flushModule(self: *C, arena: Allocator, prog_node: *std.Progress.Node) !void {
+pub fn flushModule(self: *C, arena: Allocator, prog_node: std.Progress.Node) !void {
     _ = arena; // Has the same lifetime as the call to Compilation.update.
 
     const tracy = trace(@src());
     defer tracy.end();
 
-    var sub_prog_node = prog_node.start("Flush Module", 0);
-    sub_prog_node.activate();
+    const sub_prog_node = prog_node.start("Flush Module", 0);
     defer sub_prog_node.end();
 
     const comp = self.base.comp;

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1702,7 +1702,7 @@ fn resolveGlobalSymbol(self: *Coff, current: SymbolWithLoc) !void {
     gop.value_ptr.* = current;
 }
 
-pub fn flush(self: *Coff, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flush(self: *Coff, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     const comp = self.base.comp;
     const use_lld = build_options.have_llvm and comp.config.use_lld;
     if (use_lld) {
@@ -1714,7 +1714,7 @@ pub fn flush(self: *Coff, arena: Allocator, prog_node: *std.Progress.Node) link.
     }
 }
 
-pub fn flushModule(self: *Coff, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flushModule(self: *Coff, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -1726,8 +1726,7 @@ pub fn flushModule(self: *Coff, arena: Allocator, prog_node: *std.Progress.Node)
         return;
     }
 
-    var sub_prog_node = prog_node.start("COFF Flush", 0);
-    sub_prog_node.activate();
+    const sub_prog_node = prog_node.start("COFF Flush", 0);
     defer sub_prog_node.end();
 
     const module = comp.module orelse return error.LinkingWithoutZigSourceUnimplemented;

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -16,7 +16,7 @@ const Allocator = mem.Allocator;
 const Coff = @import("../Coff.zig");
 const Compilation = @import("../../Compilation.zig");
 
-pub fn linkWithLLD(self: *Coff, arena: Allocator, prog_node: *std.Progress.Node) !void {
+pub fn linkWithLLD(self: *Coff, arena: Allocator, prog_node: std.Progress.Node) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -38,9 +38,7 @@ pub fn linkWithLLD(self: *Coff, arena: Allocator, prog_node: *std.Progress.Node)
         }
     } else null;
 
-    var sub_prog_node = prog_node.start("LLD Link", 0);
-    sub_prog_node.activate();
-    sub_prog_node.context.refresh();
+    const sub_prog_node = prog_node.start("LLD Link", 0);
     defer sub_prog_node.end();
 
     const is_lib = comp.config.output_mode == .Lib;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1064,7 +1064,7 @@ pub fn markDirty(self: *Elf, shdr_index: u32) void {
     }
 }
 
-pub fn flush(self: *Elf, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flush(self: *Elf, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     const use_lld = build_options.have_llvm and self.base.comp.config.use_lld;
     if (use_lld) {
         return self.linkWithLLD(arena, prog_node);
@@ -1072,7 +1072,7 @@ pub fn flush(self: *Elf, arena: Allocator, prog_node: *std.Progress.Node) link.F
     try self.flushModule(arena, prog_node);
 }
 
-pub fn flushModule(self: *Elf, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flushModule(self: *Elf, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -1085,8 +1085,7 @@ pub fn flushModule(self: *Elf, arena: Allocator, prog_node: *std.Progress.Node) 
         if (use_lld) return;
     }
 
-    var sub_prog_node = prog_node.start("ELF Flush", 0);
-    sub_prog_node.activate();
+    const sub_prog_node = prog_node.start("ELF Flush", 0);
     defer sub_prog_node.end();
 
     const target = comp.root_mod.resolved_target.result;
@@ -2147,7 +2146,7 @@ fn scanRelocs(self: *Elf) !void {
     }
 }
 
-fn linkWithLLD(self: *Elf, arena: Allocator, prog_node: *std.Progress.Node) !void {
+fn linkWithLLD(self: *Elf, arena: Allocator, prog_node: std.Progress.Node) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -2169,9 +2168,7 @@ fn linkWithLLD(self: *Elf, arena: Allocator, prog_node: *std.Progress.Node) !voi
         }
     } else null;
 
-    var sub_prog_node = prog_node.start("LLD Link", 0);
-    sub_prog_node.activate();
-    sub_prog_node.context.refresh();
+    const sub_prog_node = prog_node.start("LLD Link", 0);
     defer sub_prog_node.end();
 
     const output_mode = comp.config.output_mode;

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -360,11 +360,11 @@ pub fn deinit(self: *MachO) void {
     self.unwind_records.deinit(gpa);
 }
 
-pub fn flush(self: *MachO, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flush(self: *MachO, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     try self.flushModule(arena, prog_node);
 }
 
-pub fn flushModule(self: *MachO, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flushModule(self: *MachO, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -375,8 +375,7 @@ pub fn flushModule(self: *MachO, arena: Allocator, prog_node: *std.Progress.Node
         try self.base.emitLlvmObject(arena, llvm_object, prog_node);
     }
 
-    var sub_prog_node = prog_node.start("MachO Flush", 0);
-    sub_prog_node.activate();
+    const sub_prog_node = prog_node.start("MachO Flush", 0);
     defer sub_prog_node.end();
 
     const directory = self.base.emit.directory;

--- a/src/link/NvPtx.zig
+++ b/src/link/NvPtx.zig
@@ -106,11 +106,11 @@ pub fn freeDecl(self: *NvPtx, decl_index: InternPool.DeclIndex) void {
     return self.llvm_object.freeDecl(decl_index);
 }
 
-pub fn flush(self: *NvPtx, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flush(self: *NvPtx, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     return self.flushModule(arena, prog_node);
 }
 
-pub fn flushModule(self: *NvPtx, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flushModule(self: *NvPtx, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     if (build_options.skip_non_native)
         @panic("Attempted to compile for architecture that was disabled by build configuration");
 

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -604,7 +604,7 @@ fn allocateGotIndex(self: *Plan9) usize {
     }
 }
 
-pub fn flush(self: *Plan9, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flush(self: *Plan9, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     const comp = self.base.comp;
     const use_lld = build_options.have_llvm and comp.config.use_lld;
     assert(!use_lld);
@@ -663,7 +663,7 @@ fn atomCount(self: *Plan9) usize {
     return data_decl_count + fn_decl_count + unnamed_const_count + lazy_atom_count + extern_atom_count + anon_atom_count;
 }
 
-pub fn flushModule(self: *Plan9, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flushModule(self: *Plan9, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     if (build_options.skip_non_native and builtin.object_format != .plan9) {
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
@@ -677,8 +677,7 @@ pub fn flushModule(self: *Plan9, arena: Allocator, prog_node: *std.Progress.Node
     const tracy = trace(@src());
     defer tracy.end();
 
-    var sub_prog_node = prog_node.start("Flush Module", 0);
-    sub_prog_node.activate();
+    const sub_prog_node = prog_node.start("Flush Module", 0);
     defer sub_prog_node.end();
 
     log.debug("flushModule", .{});

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -193,11 +193,11 @@ pub fn freeDecl(self: *SpirV, decl_index: InternPool.DeclIndex) void {
     _ = decl_index;
 }
 
-pub fn flush(self: *SpirV, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flush(self: *SpirV, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     return self.flushModule(arena, prog_node);
 }
 
-pub fn flushModule(self: *SpirV, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flushModule(self: *SpirV, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     if (build_options.skip_non_native) {
         @panic("Attempted to compile for architecture that was disabled by build configuration");
     }
@@ -205,8 +205,7 @@ pub fn flushModule(self: *SpirV, arena: Allocator, prog_node: *std.Progress.Node
     const tracy = trace(@src());
     defer tracy.end();
 
-    var sub_prog_node = prog_node.start("Flush Module", 0);
-    sub_prog_node.activate();
+    const sub_prog_node = prog_node.start("Flush Module", 0);
     defer sub_prog_node.end();
 
     const spv = &self.object.spv;
@@ -253,7 +252,7 @@ pub fn flushModule(self: *SpirV, arena: Allocator, prog_node: *std.Progress.Node
     const module = try spv.finalize(arena, target);
     errdefer arena.free(module);
 
-    const linked_module = self.linkModule(arena, module, &sub_prog_node) catch |err| switch (err) {
+    const linked_module = self.linkModule(arena, module, sub_prog_node) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => |other| {
             log.err("error while linking: {s}\n", .{@errorName(other)});
@@ -264,7 +263,7 @@ pub fn flushModule(self: *SpirV, arena: Allocator, prog_node: *std.Progress.Node
     try self.base.file.?.writeAll(std.mem.sliceAsBytes(linked_module));
 }
 
-fn linkModule(self: *SpirV, a: Allocator, module: []Word, progress: *std.Progress.Node) ![]Word {
+fn linkModule(self: *SpirV, a: Allocator, module: []Word, progress: std.Progress.Node) ![]Word {
     _ = self;
 
     const lower_invocation_globals = @import("SpirV/lower_invocation_globals.zig");

--- a/src/link/SpirV/deduplicate.zig
+++ b/src/link/SpirV/deduplicate.zig
@@ -418,9 +418,8 @@ const EntityHashContext = struct {
     }
 };
 
-pub fn run(parser: *BinaryModule.Parser, binary: *BinaryModule, progress: *std.Progress.Node) !void {
-    var sub_node = progress.start("deduplicate", 0);
-    sub_node.activate();
+pub fn run(parser: *BinaryModule.Parser, binary: *BinaryModule, progress: std.Progress.Node) !void {
+    const sub_node = progress.start("deduplicate", 0);
     defer sub_node.end();
 
     var arena = std.heap.ArenaAllocator.init(parser.a);

--- a/src/link/SpirV/lower_invocation_globals.zig
+++ b/src/link/SpirV/lower_invocation_globals.zig
@@ -682,9 +682,8 @@ const ModuleBuilder = struct {
     }
 };
 
-pub fn run(parser: *BinaryModule.Parser, binary: *BinaryModule, progress: *std.Progress.Node) !void {
-    var sub_node = progress.start("Lower invocation globals", 6);
-    sub_node.activate();
+pub fn run(parser: *BinaryModule.Parser, binary: *BinaryModule, progress: std.Progress.Node) !void {
+    const sub_node = progress.start("Lower invocation globals", 6);
     defer sub_node.end();
 
     var arena = std.heap.ArenaAllocator.init(parser.a);

--- a/src/link/SpirV/prune_unused.zig
+++ b/src/link/SpirV/prune_unused.zig
@@ -255,9 +255,8 @@ fn removeIdsFromMap(a: Allocator, map: anytype, info: ModuleInfo, alive_marker: 
     }
 }
 
-pub fn run(parser: *BinaryModule.Parser, binary: *BinaryModule, progress: *std.Progress.Node) !void {
-    var sub_node = progress.start("Prune unused IDs", 0);
-    sub_node.activate();
+pub fn run(parser: *BinaryModule.Parser, binary: *BinaryModule, progress: std.Progress.Node) !void {
+    const sub_node = progress.start("Prune unused IDs", 0);
     defer sub_node.end();
 
     var arena = std.heap.ArenaAllocator.init(parser.a);

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -2464,7 +2464,7 @@ fn appendDummySegment(wasm: *Wasm) !void {
     });
 }
 
-pub fn flush(wasm: *Wasm, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flush(wasm: *Wasm, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     const comp = wasm.base.comp;
     const use_lld = build_options.have_llvm and comp.config.use_lld;
 
@@ -2475,7 +2475,7 @@ pub fn flush(wasm: *Wasm, arena: Allocator, prog_node: *std.Progress.Node) link.
 }
 
 /// Uses the in-house linker to link one or multiple object -and archive files into a WebAssembly binary.
-pub fn flushModule(wasm: *Wasm, arena: Allocator, prog_node: *std.Progress.Node) link.File.FlushError!void {
+pub fn flushModule(wasm: *Wasm, arena: Allocator, prog_node: std.Progress.Node) link.File.FlushError!void {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -2486,8 +2486,7 @@ pub fn flushModule(wasm: *Wasm, arena: Allocator, prog_node: *std.Progress.Node)
         if (use_lld) return;
     }
 
-    var sub_prog_node = prog_node.start("Wasm Flush", 0);
-    sub_prog_node.activate();
+    const sub_prog_node = prog_node.start("Wasm Flush", 0);
     defer sub_prog_node.end();
 
     const directory = wasm.base.emit.directory; // Just an alias to make it shorter to type.
@@ -3323,7 +3322,7 @@ fn emitImport(wasm: *Wasm, writer: anytype, import: types.Import) !void {
     }
 }
 
-fn linkWithLLD(wasm: *Wasm, arena: Allocator, prog_node: *std.Progress.Node) !void {
+fn linkWithLLD(wasm: *Wasm, arena: Allocator, prog_node: std.Progress.Node) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -3350,9 +3349,7 @@ fn linkWithLLD(wasm: *Wasm, arena: Allocator, prog_node: *std.Progress.Node) !vo
         }
     } else null;
 
-    var sub_prog_node = prog_node.start("LLD Link", 0);
-    sub_prog_node.activate();
-    sub_prog_node.context.refresh();
+    const sub_prog_node = prog_node.start("LLD Link", 0);
     defer sub_prog_node.end();
 
     const is_obj = comp.config.output_mode == .Obj;

--- a/src/main.zig
+++ b/src/main.zig
@@ -5151,7 +5151,12 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
             child.stdout_behavior = .Inherit;
             child.stderr_behavior = .Inherit;
 
-            const term = try child.spawnAndWait();
+            const term = t: {
+                std.debug.lockStdErr();
+                defer std.debug.unlockStdErr();
+                break :t try child.spawnAndWait();
+            };
+
             switch (term) {
                 .Exited => |code| {
                     if (code == 0) return cleanExit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -4795,6 +4795,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     const color: Color = .auto;
     const root_prog_node = std.Progress.start(.{
         .disable_printing = (color == .off),
+        .root_name = "Compile Build Script",
     });
     defer root_prog_node.end();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -5251,7 +5251,7 @@ const JitCmdOptions = struct {
     capture: ?*[]u8 = null,
     /// Send error bundles via std.zig.Server over stdout
     server: bool = false,
-    progress_node: std.Progress.Node = .{ .index = .none },
+    progress_node: ?std.Progress.Node = null,
 };
 
 fn jitCmd(
@@ -5261,12 +5261,9 @@ fn jitCmd(
     options: JitCmdOptions,
 ) !void {
     const color: Color = .auto;
-    const root_prog_node = if (options.progress_node.index != .none)
-        options.progress_node
-    else
-        std.Progress.start(.{
-            .disable_printing = (color == .off),
-        });
+    const root_prog_node = if (options.progress_node) |node| node else std.Progress.start(.{
+        .disable_printing = (color == .off),
+    });
 
     const target_query: std.Target.Query = .{};
     const resolved_target: Package.Module.ResolvedTarget = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -3411,6 +3411,7 @@ fn buildOutputType(
     const root_prog_node = std.Progress.start(.{
         .disable_printing = (color == .off),
     });
+    defer root_prog_node.end();
 
     updateModule(comp, color, root_prog_node) catch |err| switch (err) {
         error.SemanticAnalyzeFail => {

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -16,7 +16,7 @@ pub const CRTFile = enum {
     mingw32_lib,
 };
 
-pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: *std.Progress.Node) !void {
+pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progress.Node) !void {
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }
@@ -234,8 +234,8 @@ pub fn buildImportLib(comp: *Compilation, lib_name: []const u8) !void {
     const include_dir = try comp.zig_lib_directory.join(arena, &[_][]const u8{ "libc", "mingw", "def-include" });
 
     if (comp.verbose_cc) print: {
-        std.debug.getStderrMutex().lock();
-        defer std.debug.getStderrMutex().unlock();
+        std.debug.lockStdErr();
+        defer std.debug.unlockStdErr();
         const stderr = std.io.getStdErr().writer();
         nosuspend stderr.print("def file: {s}\n", .{def_file_path}) catch break :print;
         nosuspend stderr.print("include dir: {s}\n", .{include_dir}) catch break :print;

--- a/src/musl.zig
+++ b/src/musl.zig
@@ -19,7 +19,7 @@ pub const CRTFile = enum {
     libc_so,
 };
 
-pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: *std.Progress.Node) !void {
+pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progress.Node) !void {
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }

--- a/src/wasi_libc.zig
+++ b/src/wasi_libc.zig
@@ -57,7 +57,7 @@ pub fn execModelCrtFileFullName(wasi_exec_model: std.builtin.WasiExecModel) []co
     };
 }
 
-pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: *std.Progress.Node) !void {
+pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progress.Node) !void {
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -561,7 +561,7 @@ pub fn lowerToTranslateCSteps(
     for (self.translate.items) |case| switch (case.kind) {
         .run => |output| {
             if (translate_c_options.skip_run_translated_c) continue;
-            const annotated_case_name = b.fmt("run-translated-c  {s}", .{case.name});
+            const annotated_case_name = b.fmt("run-translated-c {s}", .{case.name});
             for (test_filters) |test_filter| {
                 if (std.mem.indexOf(u8, annotated_case_name, test_filter)) |_| break;
             } else if (test_filters.len > 0) continue;

--- a/test/src/RunTranslatedC.zig
+++ b/test/src/RunTranslatedC.zig
@@ -91,6 +91,7 @@ pub fn addCase(self: *RunTranslatedCContext, case: *const TestCase) void {
         run.expectStdErrEqual("");
     }
     run.expectStdOutEqual(case.expected_stdout);
+    run.skip_foreign_checks = true;
 
     self.step.dependOn(&run.step);
 }

--- a/test/standalone/cmakedefine/build.zig
+++ b/test/standalone/cmakedefine/build.zig
@@ -80,7 +80,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&wrapper_header.step);
 }
 
-fn compare_headers(step: *std.Build.Step, prog_node: *std.Progress.Node) !void {
+fn compare_headers(step: *std.Build.Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const allocator = step.owner.allocator;
     const expected_fmt = "expected_{s}";

--- a/test/standalone/empty_env/build.zig
+++ b/test/standalone/empty_env/build.zig
@@ -21,6 +21,7 @@ pub fn build(b: *std.Build) void {
 
     const run = b.addRunArtifact(main);
     run.clearEnvironment();
+    run.disable_zig_progress = true;
 
     test_step.dependOn(&run.step);
 }


### PR DESCRIPTION
## Demo

[simple asciinema demo](https://asciinema.org/a/gDna9RnicwYjDRIDn4e07NFSc) [source](https://gist.github.com/andrewrk/b22b4f663cef6b4672d7097de95ea343)

[demo: building a music player with zig build](https://asciinema.org/a/Hld34XJAS2enQZVCsh7WeVAlq) [source](https://codeberg.org/andrewrk/player)

## Motivation

The previous implementation of `std.Progress` had the design limitation that it could not assume ownership of the terminal. This meant that it had to play nicely with sub-processes purely via what was printed to the terminal, and it had to play nicely with progress-unaware stderr writes to the terminal. It also was forbidden from installing a SIGWINCH handler, or running ioctl to find out the rows and cols of the terminal.

This implementation is designed around the idea that a single process will be the sole owner of the terminal, and all other progress reports will be communicated back to that process. With this change in the requirements, it becomes possible to make a much more useful progress bar.

## Strategy

This creates a standard "Zig Progress Protocol" and uses it so that the same `std.Progress` API works both when an application is the main owner of a terminal, and when an application is a child process. In the latter case, progress information is communicated semantically over a pipe to the parent process.

The file descriptor is given in the `ZIG_PROGRESS` environment variable. `std.process.Child` integrates with this, so attaching a child's progress subtree in a parent process is as easy as setting the `child.progress_node` field before calling `spawn`.

In order to avoid performance penalty for using this API, the `Node.start` and `Node.end` APIs are thread-safe, lock-free, infallible, and do minimal amount of memory loads and stores. In order to accomplish this, a statically allocated buffer of `Node` storage is used - one array for parents, and one array for the rest of the data. Children are not stored. The statically allocated buffer is used for a bespoke `Node` allocator implementation. A static buffer is sufficient because we can set an upper bound on supported terminal width and height. If the terminal size exceeds this, the progress bar output will be truncated regardless.

A separate thread periodically refreshes the terminal on a timer. This progress update thread iterates over the entire preallocated parents array, looking for used nodes. This is efficient because the parents array is only 200 8-bit integers, or about 4 cache lines. When iterating, this thread "serializes" the data into a separate preallocated array by atomically loading from the shared data into data that is only touched by a single thread - the progress update thread. It then looks for nodes that are marked with a file descriptor that is a pipe to a child process. Such nodes are replaced during the serialization process with the data from reading from the pipe. The data can be memcpy'd into place except for the parents array which needs to be relocated. Once this serialization process is complete, there are two paths, one for a child process, and one for the root process that owns the terminal.

The root process that owns the terminal scans the serialized data, computing children and sibling pointers. The canonical data only stores parents, so this is where the tree structure is computed. Then the tree is walked, appending to a static buffer that will be sent to the terminal with a single write() syscall. During this process, the detected rows and cols of the terminal are respected. If the user resizes the terminal, it will cause a SIGWINCH which signals the update thread to wake up and redraw with the new rows and cols.

A child process, instead of drawing to the terminal, takes the same serialized data and sends it across a pipe. The pipe is in non-blocking mode, so if it fills up, the child drops the message; a future update will contain the new progress information. Likewise when the parent reads from the pipe, it discards all messages in the buffer except for the last one. If there are no messages in the pipe, the parent uses the data from the last update.

## Performance Data Points

Building the self-hosted compiler as a sub-process. This measures the cost of the new API implementations, primarily `Node.start`, `Node.end`, and the disappearance of `Node.activate`. In this case, standard error is not a terminal, and thus an update thread is never spawned.

```
Benchmark 1 (3 runs): master branch zig build-exe self-hosted compiler
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          51.8s  ±  138ms    51.6s  … 51.9s           0 ( 0%)        0%
  peak_rss           4.57GB ±  286KB    4.57GB … 4.57GB          0 ( 0%)        0%
  cpu_cycles          273G  ±  360M      273G  …  274G           0 ( 0%)        0%
  instructions        487G  ±  105M      487G  …  487G           0 ( 0%)        0%
  cache_references   19.0G  ± 31.8M     19.0G  … 19.1G           0 ( 0%)        0%
  cache_misses       3.87G  ± 12.0M     3.86G  … 3.88G           0 ( 0%)        0%
  branch_misses      2.22G  ± 3.44M     2.21G  … 2.22G           0 ( 0%)        0%
Benchmark 2 (3 runs): this branch zig build-exe self-hosted compiler
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          51.5s  ±  115ms    51.4s  … 51.7s           0 ( 0%)          -  0.4% ±  0.6%
  peak_rss           4.58GB ±  190KB    4.58GB … 4.58GB          0 ( 0%)          +  0.1% ±  0.0%
  cpu_cycles          272G  ±  494M      272G  …  273G           0 ( 0%)          -  0.4% ±  0.4%
  instructions        487G  ± 63.5M      487G  …  487G           0 ( 0%)          -  0.1% ±  0.0%
  cache_references   19.1G  ± 16.9M     19.1G  … 19.1G           0 ( 0%)          +  0.3% ±  0.3%
  cache_misses       3.86G  ± 17.1M     3.84G  … 3.88G           0 ( 0%)          -  0.2% ±  0.9%
  branch_misses      2.23G  ± 5.82M     2.22G  … 2.23G           0 ( 0%)          +  0.4% ±  0.5%
```

Building the self-hosted compiler, with `time zig build-exe -fno-emit-bin ...` so that the progress is updating the terminal on a regular interval.

* Old:
  * 0m4.115s
  * 0m4.216s
  * 0m4.221s
  * 0m4.227s
  * 0m4.234s
* New (1% slower):
  * 0m4.231s
  * 0m4.240s
  * 0m4.271s
  * 0m4.339s
  * 0m4.340s

Building my music player application with `zig build`, with the project-local cache cleared. This displays a lot of progress information to the terminal. This data point accounts for many sub processes sending progress information over a pipe to the parent process for aggregation.

* Old
  * 65.74s
  * 66.39s
  * 71.09s
* New (1% faster)
  * 65.51s
  * 65.88s
  * 66.09s

## Upgrade Guide

* Pass around `std.Progress.Node` instead of `*std.Progress.Node` (no longer a pointer).
* Remove calls to `node.activate()`. Those are not needed anymore.
* It's now safe to pass short-lived strings to `Node.start` since the data will be copied.
* It is illegal to initialize `std.Progress` more than once. Do that in main() and nowhere else.
* Use `std.debug.lockStdErr` and `std.debug.unlockStdErr` before writing to stderr to integrate properly with `std.Progress` (`std.debug.print` already does this for you).

```diff
-    var progress = std.Progress{
-        ...
-    };
-    const root_node = progress.start("Test", test_fn_list.len);
+    const root_node = std.Progress.start(.{
+        .root_name = "Test",
+        .estimated_total_items = test_fn_list.len,
+    });
```

All the options to `start` are optional.

Finally, when spawning a child process, populate the `progress_node` field first:

```zig
child.progress_node = node;
try child.spawn();
```

## Merge Checklist

* follow-up work
  * implement single-threaded mode
  * add the concept of byte unit flag and resource scope; support throughput calculation
  * on WASI use `/ZIG_PROGRESS` preopen instead of env var
  * show (+ X more nodes) when truncating based on rows?
  * Windows IPC support

closes #9633
closes #17821