### PR TITLE
Don't set default value for translated C structs to be zero

### DIFF
--- a/lib/compiler/aro_translate_c.zig
+++ b/lib/compiler/aro_translate_c.zig
@@ -417,19 +417,10 @@ fn transRecordDecl(c: *Context, scope: *Scope, record_node: NodeIndex, field_nod
             else
                 null;
 
-            // C99 introduced designated initializers for structs. Omitted fields are implicitly
-            // initialized to zero. Some C APIs are designed with this in mind. Defaulting to zero
-            // values for translated struct fields permits Zig code to comfortably use such an API.
-            const default_value = if (container_kind == .@"struct")
-                try ZigTag.std_mem_zeroes.create(c.arena, field_type)
-            else
-                null;
-
             fields.appendAssumeCapacity(.{
                 .name = field_name,
                 .type = field_type,
                 .alignment = field_alignment,
-                .default_value = default_value,
             });
         }
 

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -976,14 +976,6 @@ fn transRecordDecl(c: *Context, scope: *Scope, record_decl: *const clang.RecordD
             else
                 ClangAlignment.forField(c, field_decl, record_def).zigAlignment();
 
-            // C99 introduced designated initializers for structs. Omitted fields are implicitly
-            // initialized to zero. Some C APIs are designed with this in mind. Defaulting to zero
-            // values for translated struct fields permits Zig code to comfortably use such an API.
-            const default_value = if (record_decl.isStruct())
-                try Tag.std_mem_zeroes.create(c.arena, field_type)
-            else
-                null;
-
             if (is_anon) {
                 try c.decl_table.putNoClobber(c.gpa, @intFromPtr(field_decl.getCanonicalDecl()), field_name);
             }
@@ -992,7 +984,6 @@ fn transRecordDecl(c: *Context, scope: *Scope, record_decl: *const clang.RecordD
                 .name = field_name,
                 .type = field_type,
                 .alignment = alignment,
-                .default_value = default_value,
             });
         }
 

--- a/test/cases/translate_c/circular_struct_definitions.c
+++ b/test/cases/translate_c/circular_struct_definitions.c
@@ -12,9 +12,9 @@ struct Bar {
 // c_frontend=clang
 //
 // pub const struct_Bar = extern struct {
-//     next: [*c]struct_Foo = @import("std").mem.zeroes([*c]struct_Foo),
+//     next: [*c]struct_Foo,
 // };
 // 
 // pub const struct_Foo = extern struct {
-//     next: [*c]struct_Bar = @import("std").mem.zeroes([*c]struct_Bar),
+//     next: [*c]struct_Bar,
 // };

--- a/test/cases/translate_c/double_define_struct.c
+++ b/test/cases/translate_c/double_define_struct.c
@@ -13,13 +13,13 @@ struct Bar {
 // c_frontend=clang
 //
 // pub const struct_Foo = extern struct {
-//     a: [*c]Foo = @import("std").mem.zeroes([*c]Foo),
+//     a: [*c]Foo,
 // };
 // 
 // pub const Foo = struct_Foo;
 // 
 // pub const struct_Bar = extern struct {
-//     a: [*c]Foo = @import("std").mem.zeroes([*c]Foo),
+//     a: [*c]Foo,
 // };
 // 
 // pub const Bar = struct_Bar;

--- a/test/cases/translate_c/global_struct_whose_default_name_conflicts_with_global_is_mangled.c
+++ b/test/cases/translate_c/global_struct_whose_default_name_conflicts_with_global_is_mangled.c
@@ -7,7 +7,7 @@ const char *struct_foo = "hello world";
 // c_frontend=clang
 //
 // pub const struct_foo_1 = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int,
 // };
 // 
 // pub const foo = struct_foo_1;

--- a/test/cases/translate_c/large_packed_struct.c
+++ b/test/cases/translate_c/large_packed_struct.c
@@ -11,10 +11,10 @@ struct __attribute__((packed)) bar {
 // c_frontend=aro,clang
 //
 // pub const struct_bar = extern struct {
-//     a: c_short align(1) = @import("std").mem.zeroes(c_short),
-//     b: f32 align(1) = @import("std").mem.zeroes(f32),
-//     c: f64 align(1) = @import("std").mem.zeroes(f64),
-//     x: c_short align(1) = @import("std").mem.zeroes(c_short),
-//     y: f32 align(1) = @import("std").mem.zeroes(f32),
-//     z: f64 align(1) = @import("std").mem.zeroes(f64),
+//     a: c_short align(1),
+//     b: f32 align(1),
+//     c: f64 align(1),
+//     x: c_short align(1),
+//     y: f32 align(1),
+//     z: f64 align(1),
 // };

--- a/test/cases/translate_c/packed_union_nested_unpacked.c
+++ b/test/cases/translate_c/packed_union_nested_unpacked.c
@@ -13,7 +13,7 @@ union Foo{
 // c_frontend=aro,clang
 //
 // const struct_unnamed_1 = extern struct {
-//     b: c_int = @import("std").mem.zeroes(c_int),
+//     b: c_int,
 // };
 // 
 // pub const union_Foo = extern union {

--- a/test/cases/translate_c/pointer_to_struct_demoted_opaque_due_to_bit_fields.c
+++ b/test/cases/translate_c/pointer_to_struct_demoted_opaque_due_to_bit_fields.c
@@ -11,5 +11,5 @@ struct Bar {
 // pub const struct_Foo = opaque {};
 // 
 // pub const struct_Bar = extern struct {
-//     foo: ?*struct_Foo = @import("std").mem.zeroes(?*struct_Foo),
+//     foo: ?*struct_Foo,
 // };

--- a/test/cases/translate_c/qualified_struct_and_enum.c
+++ b/test/cases/translate_c/qualified_struct_and_enum.c
@@ -13,8 +13,8 @@ void func(struct Foo *a, enum Bar **b);
 // target=x86_64-linux,x86_64-macos
 //
 // pub const struct_Foo = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
-//     y: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int,
+//     y: c_int,
 // };
 // pub const BarA: c_int = 0;
 // pub const BarB: c_int = 1;

--- a/test/cases/translate_c/qualified_struct_and_enum_msvc.c
+++ b/test/cases/translate_c/qualified_struct_and_enum_msvc.c
@@ -13,8 +13,8 @@ void func(struct Foo *a, enum Bar **b);
 // target=x86_64-windows-msvc
 //
 // pub const struct_Foo = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
-//     y: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int,
+//     y: c_int,
 // };
 // pub const BarA: c_int = 0;
 // pub const BarB: c_int = 1;

--- a/test/cases/translate_c/scoped_record.c
+++ b/test/cases/translate_c/scoped_record.c
@@ -20,9 +20,9 @@ void foo() {
 //
 // pub export fn foo() void {
 //     const struct_Foo = extern struct {
-//         A: c_int = @import("std").mem.zeroes(c_int),
-//         B: c_int = @import("std").mem.zeroes(c_int),
-//         C: c_int = @import("std").mem.zeroes(c_int),
+//         A: c_int,
+//         B: c_int,
+//         C: c_int,
 //     };
 //     _ = &struct_Foo;
 //     var a: struct_Foo = struct_Foo{
@@ -33,9 +33,9 @@ void foo() {
 //     _ = &a;
 //     {
 //         const struct_Foo_1 = extern struct {
-//             A: c_int = @import("std").mem.zeroes(c_int),
-//             B: c_int = @import("std").mem.zeroes(c_int),
-//             C: c_int = @import("std").mem.zeroes(c_int),
+//             A: c_int,
+//             B: c_int,
+//             C: c_int,
 //         };
 //         _ = &struct_Foo_1;
 //         var a_2: struct_Foo_1 = struct_Foo_1{

--- a/test/cases/translate_c/simple_struct.c
+++ b/test/cases/translate_c/simple_struct.c
@@ -6,7 +6,7 @@ struct Foo {
 // c_frontend=aro,clang
 //
 // const struct_Foo = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int,
 // };
 // 
 // pub const Foo = struct_Foo;

--- a/test/cases/translate_c/struct_in_struct_init_to_zero.c
+++ b/test/cases/translate_c/struct_in_struct_init_to_zero.c
@@ -10,11 +10,11 @@ struct Foo {
 // c_frontend=clang
 //
 // pub const struct_Bar_1 = extern struct {
-//     a: c_int = @import("std").mem.zeroes(c_int),
+//     a: c_int,
 // };
 // pub const struct_Foo = extern struct {
-//     a: c_int = @import("std").mem.zeroes(c_int),
-//     b: struct_Bar_1 = @import("std").mem.zeroes(struct_Bar_1),
+//     a: c_int,
+//     b: struct_Bar_1,
 // };
 // pub export var a: struct_Foo = struct_Foo{
 //     .a = 0,

--- a/test/cases/translate_c/struct_with_aligned_fields.c
+++ b/test/cases/translate_c/struct_with_aligned_fields.c
@@ -6,5 +6,5 @@ struct foo {
 // c_frontend=aro,clang
 // 
 // pub const struct_foo = extern struct {
-//     bar: c_short align(4) = @import("std").mem.zeroes(c_short),
+//     bar: c_short align(4),
 // };

--- a/test/cases/translate_c/struct_with_invalid_field_alignment.c
+++ b/test/cases/translate_c/struct_with_invalid_field_alignment.c
@@ -22,14 +22,14 @@ struct baz {
 // target=x86_64-linux
 //
 // pub const struct_foo = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int,
 // };
 //
 // pub const struct_bar = extern struct {
-//     y: f32 = @import("std").mem.zeroes(f32),
+//     y: f32,
 // };
 //
 // pub const struct_baz = extern struct {
-//     z: f64 = @import("std").mem.zeroes(f64),
+//     z: f64,
 // };
 //

--- a/test/cases/translate_c/type_referenced_struct.c
+++ b/test/cases/translate_c/type_referenced_struct.c
@@ -12,8 +12,8 @@ struct Foo {
 // target=x86_64-linux-gnu
 //
 // pub const struct_Bar_1 = extern struct {
-//     b: c_int = @import("std").mem.zeroes(c_int),
+//     b: c_int,
 // };
 // pub const struct_Foo = extern struct {
-//     c: struct_Bar_1 = @import("std").mem.zeroes(struct_Bar_1),
+//     c: struct_Bar_1,
 // };

--- a/test/cases/translate_c/union_struct_forward_decl.c
+++ b/test/cases/translate_c/union_struct_forward_decl.c
@@ -22,8 +22,8 @@ struct Foo {
 // c_frontend=aro,clang
 //
 // pub const struct_A = extern struct {
-//     x: c_short = @import("std").mem.zeroes(c_short),
-//     y: f64 = @import("std").mem.zeroes(f64),
+//     x: c_short,
+//     y: f64,
 // };
 //
 // pub const union_B = extern union {
@@ -32,6 +32,6 @@ struct Foo {
 // };
 // 
 // pub const struct_Foo = extern struct {
-//     a: struct_A = @import("std").mem.zeroes(struct_A),
-//     b: union_B = @import("std").mem.zeroes(union_B),
+//     a: struct_A,
+//     b: union_B,
 // };

--- a/test/cases/translate_c/unnamed_fields_have_predictable_names.c
+++ b/test/cases/translate_c/unnamed_fields_have_predictable_names.c
@@ -9,14 +9,14 @@ struct b {
 // c_frontend=aro,clang
 //
 // const struct_unnamed_1 = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int,
 // };
 // pub const struct_a = extern struct {
-//     unnamed_0: struct_unnamed_1 = @import("std").mem.zeroes(struct_unnamed_1),
+//     unnamed_0: struct_unnamed_1,
 // };
 // const struct_unnamed_2 = extern struct {
-//     y: c_int = @import("std").mem.zeroes(c_int),
+//     y: c_int,
 // };
 // pub const struct_b = extern struct {
-//     unnamed_0: struct_unnamed_2 = @import("std").mem.zeroes(struct_unnamed_2),
+//     unnamed_0: struct_unnamed_2,
 // };

--- a/test/cases/translate_c/zero_width_field_alignment.c
+++ b/test/cases/translate_c/zero_width_field_alignment.c
@@ -11,8 +11,8 @@ struct __attribute__((packed)) foo {
 // const struct_unnamed_1 = extern struct {};
 // const union_unnamed_2 = extern union {};
 // pub const struct_foo = extern struct {
-//     x: c_int align(1) = @import("std").mem.zeroes(c_int),
-//     unnamed_0: struct_unnamed_1 align(1) = @import("std").mem.zeroes(struct_unnamed_1),
-//     y: f32 align(1) = @import("std").mem.zeroes(f32),
-//     unnamed_1: union_unnamed_2 align(1) = @import("std").mem.zeroes(union_unnamed_2),
+//     x: c_int align(1),
+//     unnamed_0: struct_unnamed_1 align(1),
+//     y: f32 align(1),
+//     unnamed_1: union_unnamed_2 align(1),
 // };

--- a/test/cases/translate_c/zig_keywords_in_c_code.c
+++ b/test/cases/translate_c/zig_keywords_in_c_code.c
@@ -6,7 +6,7 @@ struct comptime {
 // c_frontend=aro,clang
 //
 // pub const struct_comptime = extern struct {
-//     @"defer": c_int = @import("std").mem.zeroes(c_int),
+//     @"defer": c_int,
 // };
 // 
 // pub const @"comptime" = struct_comptime;


### PR DESCRIPTION
Fixes #19471

> C99 introduced designated initializers for structs. Omitted fields are
implicitly initialized to zero. Some C APIs are designed with this in
mind. Defaulting to zero values for translated struct fields permits Zig
code to comfortably use such an API.

Zig is C with the problems fixed. While this earlier commit improves comfort working with some C APIs, I think we're inheriting footguns by replicating C semantics. It's okay that working with some C code is clunky, it should be because Zig is making you face the consequences of non-obvious behavior. I've used this fact extensively to confidently use C libraries from Zig. Unfortunately I don't get to have the same confidence with 0.12.0.