### PR TITLE
cmake: correct PIE support detection, add error output for debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,8 @@ check_pie_supported(
   OUTPUT_VARIABLE ZIG_PIE_SUPPORTED_BY_CMAKE
   LANGUAGES C CXX
 )
-if(ZIG_PIE AND NOT ZIG_PIE_SUPPORTED_BY_CMAKE)
-  message(SEND_ERROR "ZIG_PIE was requested but CMake does not support it for \"zigcpp\" target")
+if(ZIG_PIE AND NOT CMAKE_CXX_LINK_PIE_SUPPORTED)
+  message(SEND_ERROR "ZIG_PIE was requested but CMake does not support it for \"zigcpp\" target: ${ZIG_PIE_SUPPORTED_BY_CMAKE}")
 endif()
 
 


### PR DESCRIPTION
`check_pie_supported` only uses the `OUTPUT_VARIABLE` to to signify errors if PIE is actually supported is signaled by `CMAKE_<lang>_LINK_PIE_SUPPORTED`.

Checking if `OUTPUT_VARIABLE` is empty is not enough either since the check is bypassed if its results are cached but the output variable is not cached.