### PR TITLE
build: use absolute paths to local and global cache dirs

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4822,12 +4822,12 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
                 } else if (mem.eql(u8, arg, "--cache-dir")) {
                     if (i + 1 >= args.len) fatal("expected argument after '{s}'", .{arg});
                     i += 1;
-                    override_local_cache_dir = args[i];
+                    override_local_cache_dir = try fs.realpathAlloc(arena, args[i]);
                     continue;
                 } else if (mem.eql(u8, arg, "--global-cache-dir")) {
                     if (i + 1 >= args.len) fatal("expected argument after '{s}'", .{arg});
                     i += 1;
-                    override_global_cache_dir = args[i];
+                    override_global_cache_dir = try fs.realpathAlloc(arena, args[i]);
                     continue;
                 } else if (mem.eql(u8, arg, "-freference-trace")) {
                     reference_trace = 256;


### PR DESCRIPTION
This prevents issues where the current working directory is changed and relative path becomes invalid.

I've created a small project to reproduce this issue
https://github.com/Jan200101/zig-bug-local-cache-dep
simply compare the outputs of `zig build` and `zig build --global-cache-dir zig-gcache`

With 0.12: (this was also tested against master and results in the same behavior) 
```bash
$ /usr/bin/zig build --global-cache-dir zig-gcache
freetype_dep.path: zig-gcache/p/1220b81f6ecfb3fd222f76cf9106fecfa6554ab07ec7fdc4124b9bb063ae2adf969d
```

With this PR:
```bash
$ zig build --global-cache-dir zig-gcache
freetype_dep.path: /tmp/tmp.DRt3KNH1Yc/zig-gcache/p/1220b81f6ecfb3fd222f76cf9106fecfa6554ab07ec7fdc4124b9bb063ae2adf969d
```

I don't know if `zig fetch` or other commands could have the same issue, thus far I only ran into it with `zig build`.