### PR TITLE
Sema: Check not in comptime before adding OOB check on array access

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -28779,8 +28779,8 @@ fn elemValArray(
 
     const runtime_src = if (maybe_undef_array_val != null) elem_index_src else array_src;
     if (oob_safety and block.wantSafety()) {
-        // Runtime check is only needed if unable to comptime check
-        if (maybe_index_val == null) {
+        // Runtime check is only needed if unable to comptime check.
+        if (maybe_index_val == null and !block.is_comptime) {
             const len_inst = try mod.intRef(Type.usize, array_len);
             const cmp_op: Air.Inst.Tag = if (array_sent != null) .cmp_lte else .cmp_lt;
             try sema.panicIndexOutOfBounds(block, src, elem_index, len_inst, cmp_op);

--- a/test/cases/compile_errors/safety_check_in_comptime_array_elem.zig
+++ b/test/cases/compile_errors/safety_check_in_comptime_array_elem.zig
@@ -1,0 +1,24 @@
+export fn a() void {
+    const s: [2]usize = .{ 2, 1 };
+    var arr: [2]*anyopaque = undefined;
+    for (0..2) |i| {
+        arr[i] = B(s[i]).c();
+    }
+}
+
+fn B(comptime N: usize) type {
+    return struct {
+        x: [N]u8 = undefined,
+
+        pub fn c() *@This() {
+            @trap();
+        }
+    };
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :5:21: error: unable to evaluate comptime expression
+// :5:22: note: operation is runtime due to this operand


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/20064, so that the compiler doesn't crash in that case and instead correctly outputs:
```
~/projects/zig (i20064?) $ build/stage4/bin/zig run reduce.zig
reduce.zig:12:55: error: unable to evaluate comptime expression
        arr[i] = std.heap.page_allocator.create(Foo(sz[i])) catch unreachable;
                                                    ~~^~~
reduce.zig:12:56: note: operation is runtime due to this operand
        arr[i] = std.heap.page_allocator.create(Foo(sz[i])) catch unreachable;
```

I also have a minimal case for this one but I'm not sure where to add it to the tests:
```zig
const std = @import("std");

fn Foo(comptime N: usize) type {
    return struct {
        inner: [N]u8 = undefined,
    };
}

pub fn main() !void {
    const sz: [2]usize = .{ 2, 1 };
    var arr: [2]*anyopaque = undefined;
    for (0..2) |i| {
        arr[i] = std.heap.page_allocator.create(Foo(sz[i])) catch unreachable;
    }
    _ = &arr;
}
```