### PR TITLE
support pointer subtraction

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1935,16 +1935,18 @@ or
           <li>{#syntax#}*T{#endsyntax#} - single-item pointer to exactly one item.
             <ul>
               <li>Supports deref syntax: {#syntax#}ptr.*{#endsyntax#}</li>
+              <li>Supports pointer subtraction: {#syntax#}ptr - ptr{#endsyntax#}</li>
             </ul>
           </li>
           <li>{#syntax#}[*]T{#endsyntax#} - many-item pointer to unknown number of items.
             <ul>
               <li>Supports index syntax: {#syntax#}ptr[i]{#endsyntax#}</li>
               <li>Supports slice syntax: {#syntax#}ptr[start..end]{#endsyntax#} and {#syntax#}ptr[start..]{#endsyntax#}</li>
-              <li>Supports pointer arithmetic: {#syntax#}ptr + x{#endsyntax#}, {#syntax#}ptr - x{#endsyntax#}</li>
-              <li>{#syntax#}T{#endsyntax#} must have a known size, which means that it cannot be
-              {#syntax#}anyopaque{#endsyntax#} or any other {#link|opaque type|opaque#}.</li>
+              <li>Supports pointer-integer arithmetic: {#syntax#}ptr + int{#endsyntax#}, {#syntax#}ptr - int{#endsyntax#}</li>
+              <li>Supports pointer subtraction: {#syntax#}ptr - ptr{#endsyntax#}</li>
             </ul>
+            {#syntax#}T{#endsyntax#} must have a known size, which means that it cannot be
+            {#syntax#}anyopaque{#endsyntax#} or any other {#link|opaque type|opaque#}.
           </li>
       </ul>
       <p>These types are closely related to {#link|Arrays#} and {#link|Slices#}:</p>
@@ -1954,6 +1956,7 @@ or
                 <li>Supports index syntax: {#syntax#}array_ptr[i]{#endsyntax#}</li>
                 <li>Supports slice syntax: {#syntax#}array_ptr[start..end]{#endsyntax#}</li>
                 <li>Supports len property: {#syntax#}array_ptr.len{#endsyntax#}</li>
+                <li>Supports pointer subtraction: {#syntax#}array_ptr - array_ptr{#endsyntax#}</li>
             </ul>
             </li>
         </ul>

--- a/doc/langref/test_pointer_arithmetic.zig
+++ b/doc/langref/test_pointer_arithmetic.zig
@@ -11,6 +11,9 @@ test "pointer arithmetic with many-item pointer" {
     // slicing a many-item pointer without an end is equivalent to
     // pointer arithmetic: `ptr[start..] == ptr + start`
     try expect(ptr[1..] == ptr + 1);
+
+    // subtraction between any two pointers except slices based on element size is supported
+    try expect(&ptr[1] - &ptr[0] == 1);
 }
 
 test "pointer arithmetic with slices" {

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -3752,7 +3752,7 @@ pub fn ptrField(parent_ptr: Value, field_idx: u32, pt: Zcu.PerThread) !Value {
     const parent_ptr_info = parent_ptr_ty.ptrInfo(zcu);
     assert(parent_ptr_info.flags.size == .One);
 
-    // Exiting this `switch` indicates that the `field` pointer repsentation should be used.
+    // Exiting this `switch` indicates that the `field` pointer representation should be used.
     // `field_align` may be `.none` to represent the natural alignment of `field_ty`, but is not necessarily.
     const field_ty: Type, const field_align: InternPool.Alignment = switch (aggregate_ty.zigTypeTag(zcu)) {
         .Struct => field: {

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -17,7 +17,7 @@ fn testDerefPtr() !void {
     try expect(x == 1235);
 }
 
-test "pointer arithmetic" {
+test "pointer-integer arithmetic" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
@@ -41,6 +41,62 @@ test "pointer arithmetic" {
     try expect(ptr[0] == 'b');
     ptr -= 1;
     try expect(ptr[0] == 'a');
+}
+
+test "pointer subtraction" {
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+
+    {
+        const a: *u8 = @ptrFromInt(100);
+        const b: *u8 = @ptrFromInt(50);
+        try expect(a - b == 50);
+    }
+    {
+        var ptr: [*]const u8 = "abc";
+        try expect(&ptr[1] - &ptr[0] == 1);
+        try expect(&ptr[2] - &ptr[0] == 2);
+    }
+    {
+        const a: *[100]u16 = @ptrFromInt(100);
+        const b: *[100]u16 = @ptrFromInt(50);
+        try expect(a - b == 25);
+    }
+    {
+        var x: struct { a: u32, b: u32 } = undefined;
+        const a = &x.a;
+        const b = &x.b;
+        try expect(a - a == 0);
+        try expect(b - b == 0);
+        try expect(b - a == 1);
+    }
+    comptime {
+        var x: packed struct { a: u1, b: u1 } = undefined;
+        const a = &x.a;
+        const b = &x.b;
+        try expect(a - a == 0);
+        try expect(b - b == 0);
+        try expect(b - a == 0);
+    }
+    comptime {
+        var x: extern struct { a: u32, b: u32 } = undefined;
+        const a = &x.a;
+        const b = &x.b;
+        try expect(a - a == 0);
+        try expect(b - b == 0);
+        try expect(b - a == 1);
+    }
+    comptime {
+        const a: *const [3]u8 = "abc";
+        const b: [*]const u8 = @ptrCast(a);
+        try expect(&a[1] - &b[0] == 1);
+    }
+    comptime {
+        var x: [64][64]u8 = undefined;
+        const a = &x[0][12];
+        const b = &x[15][3];
+        try expect(b - a == 951);
+    }
 }
 
 test "double pointer parsing" {
@@ -382,7 +438,7 @@ test "pointer to array at fixed address" {
     try expect(@intFromPtr(&array[1]) == 0x14);
 }
 
-test "pointer arithmetic affects the alignment" {
+test "pointer-integer arithmetic affects the alignment" {
     {
         var ptr: [*]align(8) u32 = undefined;
         var x: usize = 1;

--- a/test/cases/compile_errors/invalid_pointer_arithmetic.zig
+++ b/test/cases/compile_errors/invalid_pointer_arithmetic.zig
@@ -26,6 +26,17 @@ comptime {
     _ = x - y;
 }
 
+comptime {
+    const x: [*]u0 = @ptrFromInt(1);
+    _ = x + 1;
+}
+
+comptime {
+    const x: *u0 = @ptrFromInt(1);
+    const y: *u0 = @ptrFromInt(2);
+    _ = x - y;
+}
+
 // error
 // backend=stage2
 // target=native
@@ -35,5 +46,7 @@ comptime {
 // :6:11: error: invalid pointer-pointer arithmetic operator
 // :6:11: note: pointer-pointer arithmetic only supports subtraction
 // :12:11: error: invalid operands to binary expression: 'Pointer' and 'Pointer'
-// :21:15: error: pointer subtraction operand element types u8 and u16 are not equal
-// :28:11: error: pointer subtraction operand element types u8 and u16 are not equal
+// :20:11: error: incompatible pointer arithmetic operands '[*]u8' and '[*]u16'
+// :26:11: error: incompatible pointer arithmetic operands '*u8' and '*u16'
+// :31:11: error: pointer arithmetic requires element type 'u0' to have runtime bits
+// :37:11: error: pointer arithmetic requires element type 'u0' to have runtime bits

--- a/test/cases/compile_errors/invalid_pointer_arithmetic.zig
+++ b/test/cases/compile_errors/invalid_pointer_arithmetic.zig
@@ -1,0 +1,39 @@
+export fn a(x: [*]u8) void {
+    _ = x * 1;
+}
+
+export fn b(x: *u8) void {
+    _ = x * x;
+}
+
+export fn c() void {
+    const x: []u8 = undefined;
+    const y: []u8 = undefined;
+    _ = x - y;
+}
+
+export fn d() void {
+    var x: [*]u8 = undefined;
+    var y: [*]u16 = undefined;
+    _ = &x;
+    _ = &y;
+    _ = x - y;
+}
+
+comptime {
+    const x: *u8 = @ptrFromInt(1);
+    const y: *u16 = @ptrFromInt(2);
+    _ = x - y;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:11: error: invalid pointer-integer arithmetic operator
+// :2:11: note: pointer-integer arithmetic only supports addition and subtraction
+// :6:11: error: invalid pointer-pointer arithmetic operator
+// :6:11: note: pointer-pointer arithmetic only supports subtraction
+// :12:11: error: invalid operands to binary expression: 'Pointer' and 'Pointer'
+// :21:15: error: pointer subtraction operand element types u8 and u16 are not equal
+// :28:11: error: pointer subtraction operand element types u8 and u16 are not equal


### PR DESCRIPTION
Fixes #1738

I don't know if this should introduce a dedicated AIR instruction instead of emitting two `int_from_ptr` and a `sub_wrap`. This is also missing safety just like the existing pointer arithmetic but maybe that can be done as part of #1918? Otherwise, if those two things aren't a blocking issue I think this is more or less complete. It seems to work at least.

I also put an emphasis on introducing a clear distinction between "pointer-integer arithmetic" and "pointer subtraction" (pointer-pointer arithmetic) because both of those are "pointer arithmetic" so "pointer arithmetic" on its own becomes ambiguous.