### PR TITLE
add math.approxEqUlp and tweak math.approxEqRel

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -112,8 +112,10 @@ pub fn approxEqRel(comptime T: type, x: T, y: T, tolerance: T) bool {
 /// For example, two numbers with three representable values (points)
 /// between them are four intervals (gaps) apart from each other, i.e.
 ///
+/// ```
 /// ... a - * - * - * - b ...
 ///     | 1 | 2 | 3 | 4 |
+/// ```
 ///
 /// The `ulp` parameter is the maximum permissible number of representable
 /// floating point intervals between the two numbers being compared.
@@ -123,7 +125,9 @@ pub fn approxEqRel(comptime T: type, x: T, y: T, tolerance: T) bool {
 /// where positive and negative zeros are mapped to the same point and do not
 /// comprise an extraneous interval, i.e.
 ///
+/// ```
 /// | -NaN | -inf | -nor | -den | 0 | +den | +nor | +inf | +NaN |
+/// ```
 ///
 /// NaN values are never equal to any value, including themselves.
 pub fn approxEqUlp(comptime T: type, x: T, y: T, ulp: comptime_int) bool {

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -102,7 +102,7 @@ pub fn approxEqRel(comptime T: type, x: T, y: T, tolerance: T) bool {
     assert(tolerance >= 0);
     if (x == y) return true;
     if (isNan(x) or isNan(y)) return false;
-    return @abs(x - y) <= tolerance * 0.5 * @abs(x + y);
+    return @abs(x - y) <= tolerance * @abs(0.5 * x + 0.5 * y);
 }
 
 /// Performs an approximate comparison of two floating point values `x` and `y`.

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -4,6 +4,7 @@ const float = @import("math/float.zig");
 const assert = std.debug.assert;
 const mem = std.mem;
 const testing = std.testing;
+const Int = std.meta.Int;
 
 /// Euler's number (e)
 pub const e = 2.71828182845904523536028747135266249775724709369995;
@@ -107,7 +108,7 @@ pub fn approxEqRel(comptime T: type, x: T, y: T, tolerance: T) bool {
 
 /// Performs an approximate comparison of two floating point values `x` and `y`.
 /// Returns true if the number of representable intervals (gaps) between them is
-/// less or equal than the specified count.
+/// less or equal than the specified unit of least precision (ulp).
 ///
 /// For example, two numbers with three representable values (points)
 /// between them are four intervals (gaps) apart from each other, i.e.
@@ -130,10 +131,9 @@ pub fn approxEqRel(comptime T: type, x: T, y: T, tolerance: T) bool {
 /// ```
 ///
 /// NaN values are never equal to any value, including themselves.
-pub fn approxEqUlp(comptime T: type, x: T, y: T, ulp: comptime_int) bool {
+pub fn approxEqUlp(comptime T: type, x: T, y: T, ulp: Int(.unsigned, @bitSizeOf(T))) bool {
     if (.Float != @typeInfo(T)) @compileError("T must be float.");
     if (f80 == T) @compileError("f80 not implemented.");
-    if (ulp < 0) @compileError("ulp must not be negative.");
     if (ulp == 0) return x == y;
 
     const U = @Type(.{ .Int = .{ .signedness = .unsigned, .bits = @bitSizeOf(T) } });


### PR DESCRIPTION
## approxEqUlp

This implementation chooses ulp distance to be defined as as the number of increments traversed from one representable floating point value to another. This definition avoids the ambiguity of which of the two operand's local ulp size should the comparison be based on, and allows comparisons of denormalized numbers as well as two numbers of different signs. The tradeoff of this design choice is that the `ulp` tolerance parameter must be integral.

One caveat of this implementation is that it assumes an implicit leading bit for normalized numbers rather than storing the bit explicitly, since it uses a twos-compliment signed-integer recast, so adding f80 support in the future will require some extra bit shuffling to deal with its explicit significand.


<!--

Notes to self:

Two's compliment signed int encoding: https://www.desmos.com/calculator/4itf5eswnx


visualization of integer encoding of floats: https://www.desmos.com/calculator/uhv9onylx3

reading: https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/

-->

## approxEqRel

Two behavior changes:
1. Relaxed restriction of tolerance parameter to permit zero. I don't know why zero was excluded for rtol while allowed for atol, neither the original commit nor any comments explained this distinction.
2. Changed tolerance to be defined relative to the midpoint between two compared values, as opposed to to the maximum between the two, i.e. `delta = epsilon * abs(mean(x,y))` rather than `delta = epsilon * max(abs(x),abs(y))`. 

closes #20080 
