### PR TITLE
Build.Step.Run: captureStdOutNamed

### DIFF
--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -500,13 +500,22 @@ pub fn captureStdOut(run: *Run) std.Build.LazyPath {
 
     if (run.captured_stdout) |output| return .{ .generated = .{ .file = &output.generated_file } };
 
+    const output = run.captureStdOutNamed("stdout");
+    run.captured_stdout = output;
+    return output;
+}
+
+pub fn captureStdOutNamed(run: *Run, name: []const u8) std.Build.LazyPath {
+    assert(run.stdio != .inherit);
+
+    assert(run.captured_stdout == null);
+
     const output = run.step.owner.allocator.create(Output) catch @panic("OOM");
     output.* = .{
         .prefix = "",
-        .basename = "stdout",
+        .basename = name,
         .generated_file = .{ .step = &run.step },
     };
-    run.captured_stdout = output;
     return .{ .generated = .{ .file = &output.generated_file } };
 }
 


### PR DESCRIPTION
This way, a command eg `echo 'int add(int a, int b) {return a + b;}'` can output stdout to a file named `main.c` so it can be used by `addCSourceFile()`

Used for real in zig3ds to capture `bin2s` output as a `.s` file and call `.addAssemblyFile`:

https://github.com/pfgithub/zig3ds/blob/36a3c18906c85caa73711d773f777a73538b8515/build.zig#L467-L470

---

Currently, calling captureStdOut() multiple times returns the same file reference multiple times, but captureStdOutNamed can't do that because each call might specify a different name. This preserves captureStdOut() being callable multiple times, but captureStdOutNamed() may only be called once, and must be called before any calls to captureStdOut().