### PR TITLE
added a read() function which allows listing the zip.

### DIFF
--- a/lib/std/zip.zig
+++ b/lib/std/zip.zig
@@ -510,7 +510,7 @@ pub fn Iterator(comptime SeekableStream: type) type {
 
                 // All entries that end in '/' are directories
                 if (filename[filename.len - 1] == '/') {
-                    try dest.makeDir(filename_buf[0..self.filename_len]);
+                    try dest.makePath(filename_buf[0..self.filename_len]);
                     return std.hash.Crc32.hash(&.{});
                 }
 


### PR DESCRIPTION
Previously the new `std.zip` module only allowed extracting a Zip archive to a directory. It didn't provide a method to just iterate through the file/folder names (as that wasn't needed for `zig fetch` support.)

I wanted to work on a project that used directory structures and zipped directory structures and prefer to use standard library when possible.

If you attempted to copy the relevant part of the `extract()` code loop and print out the filenames you would get a `u8` slice but it referred to uninitialized memory since that wasn't filled in until the first part of the `extract` function. I found a minimal way to add support.

----

extract() now uses read()

`read()` returns `local_data_header_offset` which is needed by `extract()`
example Zig program using the new functionality to list the filenames in a zip

```rs
const std = @import("std");

pub fn main() !u8 {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    const al = gpa.allocator();
    defer _ = gpa.deinit();

    const args = try std.process.argsAlloc(al);
    defer std.process.argsFree(al, args);

    if (args.len < 2) {
        std.debug.print("usage: {s} <file>\n", .{args[0]});
        return 1;
    }

    const file = try std.fs.cwd().openFile(args[1], .{});
    defer file.close();

    var diag = std.zip.Diagnostics{ .allocator = al };
    defer diag.deinit();
    const options = std.zip.ExtractOptions{ .diagnostics = &diag };

    const seekable_stream = file.seekableStream();

    const SeekableStream = @TypeOf(seekable_stream);
    var iter = try std.zip.Iterator(SeekableStream).init(seekable_stream);

    var filename_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
    while (try iter.next()) |entry| {
        _ = try entry.read(seekable_stream, options, &filename_buf);
        try std.io.getStdOut().writer().print("{s}\n", .{filename_buf[0..entry.filename_len]});
        if (options.diagnostics) |d| {
            try d.nextFilename(filename_buf[0..entry.filename_len]);
        }
    }

    return 0;
}
```
