### PR TITLE
Progress: implement IPC for windows

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1935,7 +1935,13 @@ pub const DebugInfo = struct {
                     var section_handle: windows.HANDLE = undefined;
                     const create_section_rc = windows.ntdll.NtCreateSection(
                         &section_handle,
-                        windows.STANDARD_RIGHTS_REQUIRED | windows.SECTION_QUERY | windows.SECTION_MAP_READ,
+                        .{
+                            .STANDARD = windows.ACCESS_MASK.STANDARD.REQUIRED,
+                            .SPECIFIC = .{ .SECTION = .{
+                                .QUERY = true,
+                                .MAP_READ = true,
+                            } },
+                        },
                         null,
                         null,
                         windows.PAGE_READONLY,

--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -365,7 +365,7 @@ pub const WindowsDynLib = struct {
     /// WindowsDynLib specific
     /// Opens dynamic library with specified library loading flags.
     pub fn openEx(path: []const u8, flags: windows.LoadLibraryFlags) Error!WindowsDynLib {
-        const path_w = windows.sliceToPrefixedFileW(null, path) catch return error.InvalidPath;
+        const path_w = windows.sliceToPrefixedFileW(path, .{}) catch return error.InvalidPath;
         return openExW(path_w.span().ptr, flags);
     }
 
@@ -376,7 +376,7 @@ pub const WindowsDynLib = struct {
     /// WindowsDynLib specific
     /// Opens dynamic library with specified library loading flags.
     pub fn openExZ(path_c: [*:0]const u8, flags: windows.LoadLibraryFlags) Error!WindowsDynLib {
-        const path_w = try windows.cStrToPrefixedFileW(null, path_c);
+        const path_w = try windows.cStrToPrefixedFileW(path_c, .{});
         return openExW(path_w.span().ptr, flags);
     }
 

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -797,7 +797,7 @@ pub fn close(self: *Dir) void {
 /// On other platforms, `sub_path` is an opaque sequence of bytes with no particular encoding.
 pub fn openFile(self: Dir, sub_path: []const u8, flags: File.OpenFlags) File.OpenError!File {
     if (native_os == .windows) {
-        const path_w = try windows.sliceToPrefixedFileW(self.fd, sub_path);
+        const path_w = try windows.sliceToPrefixedFileW(sub_path, .{ .dir = .{ .handle = self.fd } });
         return self.openFileW(path_w.span(), flags);
     }
     if (native_os == .wasi and !builtin.link_libc) {
@@ -831,7 +831,7 @@ pub fn openFile(self: Dir, sub_path: []const u8, flags: File.OpenFlags) File.Ope
 pub fn openFileZ(self: Dir, sub_path: [*:0]const u8, flags: File.OpenFlags) File.OpenError!File {
     switch (native_os) {
         .windows => {
-            const path_w = try windows.cStrToPrefixedFileW(self.fd, sub_path);
+            const path_w = try windows.cStrToPrefixedFileW(sub_path, .{ .dir = .{ .handle = self.fd } });
             return self.openFileW(path_w.span(), flags);
         },
         // Use the libc API when libc is linked because it implements things
@@ -922,9 +922,13 @@ pub fn openFileW(self: Dir, sub_path_w: []const u16, flags: File.OpenFlags) File
     const file: File = .{
         .handle = try w.OpenFile(sub_path_w, .{
             .dir = self.fd,
-            .access_mask = w.SYNCHRONIZE |
-                (if (flags.isRead()) @as(u32, w.GENERIC_READ) else 0) |
-                (if (flags.isWrite()) @as(u32, w.GENERIC_WRITE) else 0),
+            .access_mask = .{
+                .SYNCHRONIZE = true,
+                .GENERIC = .{
+                    .READ = flags.isRead(),
+                    .WRITE = flags.isWrite(),
+                },
+            },
             .creation = w.FILE_OPEN,
         }),
     };
@@ -960,7 +964,7 @@ pub fn openFileW(self: Dir, sub_path_w: []const u16, flags: File.OpenFlags) File
 /// On other platforms, `sub_path` is an opaque sequence of bytes with no particular encoding.
 pub fn createFile(self: Dir, sub_path: []const u8, flags: File.CreateFlags) File.OpenError!File {
     if (native_os == .windows) {
-        const path_w = try windows.sliceToPrefixedFileW(self.fd, sub_path);
+        const path_w = try windows.sliceToPrefixedFileW(sub_path, .{ .dir = .{ .handle = self.fd } });
         return self.createFileW(path_w.span(), flags);
     }
     if (native_os == .wasi) {
@@ -993,7 +997,7 @@ pub fn createFile(self: Dir, sub_path: []const u8, flags: File.CreateFlags) File
 pub fn createFileZ(self: Dir, sub_path_c: [*:0]const u8, flags: File.CreateFlags) File.OpenError!File {
     switch (native_os) {
         .windows => {
-            const path_w = try windows.cStrToPrefixedFileW(self.fd, sub_path_c);
+            const path_w = try windows.cStrToPrefixedFileW(sub_path_c, .{ .dir = .{ .handle = self.fd } });
             return self.createFileW(path_w.span(), flags);
         },
         .wasi => {
@@ -1067,11 +1071,16 @@ pub fn createFileZ(self: Dir, sub_path_c: [*:0]const u8, flags: File.CreateFlags
 /// [WTF-16](https://simonsapin.github.io/wtf-8/#potentially-ill-formed-utf-16) encoded.
 pub fn createFileW(self: Dir, sub_path_w: []const u16, flags: File.CreateFlags) File.OpenError!File {
     const w = windows;
-    const read_flag = if (flags.read) @as(u32, w.GENERIC_READ) else 0;
     const file: File = .{
         .handle = try w.OpenFile(sub_path_w, .{
             .dir = self.fd,
-            .access_mask = w.SYNCHRONIZE | w.GENERIC_WRITE | read_flag,
+            .access_mask = .{
+                .SYNCHRONIZE = true,
+                .GENERIC = .{
+                    .READ = flags.read,
+                    .WRITE = true,
+                },
+            },
             .creation = if (flags.exclusive)
                 @as(u32, w.FILE_CREATE)
             else if (flags.truncate)
@@ -1180,7 +1189,7 @@ pub fn makePath(self: Dir, sub_path: []const u8) (MakeError || StatFileError)!vo
 /// This function is not atomic, and if it returns an error, the file system may
 /// have been modified regardless.
 /// `sub_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
-fn makeOpenPathAccessMaskW(self: Dir, sub_path: []const u8, access_mask: u32, no_follow: bool) (MakeError || OpenError || StatFileError)!Dir {
+fn makeOpenPathAccessMaskW(self: Dir, sub_path: []const u8, access_mask: windows.ACCESS_MASK, no_follow: bool) (MakeError || OpenError || StatFileError)!Dir {
     const w = windows;
     var it = try fs.path.componentIterator(sub_path);
     // If there are no components in the path, then create a dummy component with the full path.
@@ -1190,7 +1199,7 @@ fn makeOpenPathAccessMaskW(self: Dir, sub_path: []const u8, access_mask: u32, no
     };
 
     while (true) {
-        const sub_path_w = try w.sliceToPrefixedFileW(self.fd, component.path);
+        const sub_path_w = try w.sliceToPrefixedFileW(component.path, .{ .dir = .{ .handle = self.fd } });
         const is_last = it.peekNext() == null;
         var result = self.makeOpenDirAccessMaskW(sub_path_w.span().ptr, access_mask, .{
             .no_follow = no_follow,
@@ -1233,12 +1242,20 @@ fn makeOpenPathAccessMaskW(self: Dir, sub_path: []const u8, access_mask: u32, no
 pub fn makeOpenPath(self: Dir, sub_path: []const u8, open_dir_options: OpenDirOptions) (MakeError || OpenError || StatFileError)!Dir {
     return switch (native_os) {
         .windows => {
-            const w = windows;
-            const base_flags = w.STANDARD_RIGHTS_READ | w.FILE_READ_ATTRIBUTES | w.FILE_READ_EA |
-                w.SYNCHRONIZE | w.FILE_TRAVERSE |
-                (if (open_dir_options.iterate) w.FILE_LIST_DIRECTORY else @as(u32, 0));
-
-            return self.makeOpenPathAccessMaskW(sub_path, base_flags, open_dir_options.no_follow);
+            return self.makeOpenPathAccessMaskW(
+                sub_path,
+                .{
+                    .STANDARD = windows.ACCESS_MASK.STANDARD.READ,
+                    .SPECIFIC = .{ .DIRECTORY = .{
+                        .READ_ATTRIBUTES = true,
+                        .READ_EA = true,
+                        .TRAVERSE = true,
+                        .LIST = open_dir_options.iterate,
+                    } },
+                    .SYNCHRONIZE = true,
+                },
+                open_dir_options.no_follow,
+            );
         },
         else => {
             return self.openDir(sub_path, open_dir_options) catch |err| switch (err) {
@@ -1270,7 +1287,7 @@ pub fn realpath(self: Dir, pathname: []const u8, out_buffer: []u8) RealPathError
         @compileError("realpath is not available on WASI");
     }
     if (native_os == .windows) {
-        const pathname_w = try windows.sliceToPrefixedFileW(self.fd, pathname);
+        const pathname_w = try windows.sliceToPrefixedFileW(pathname, .{ .dir = .{ .handle = self.fd } });
         return self.realpathW(pathname_w.span(), out_buffer);
     }
     const pathname_c = try posix.toPosixPath(pathname);
@@ -1281,7 +1298,7 @@ pub fn realpath(self: Dir, pathname: []const u8, out_buffer: []u8) RealPathError
 /// See also `Dir.realpath`, `realpathZ`.
 pub fn realpathZ(self: Dir, pathname: [*:0]const u8, out_buffer: []u8) RealPathError![]u8 {
     if (native_os == .windows) {
-        const pathname_w = try windows.cStrToPrefixedFileW(self.fd, pathname);
+        const pathname_w = try windows.cStrToPrefixedFileW(pathname, .{ .dir = .{ .handle = self.fd } });
         return self.realpathW(pathname_w.span(), out_buffer);
     }
 
@@ -1324,14 +1341,15 @@ pub fn realpathZ(self: Dir, pathname: [*:0]const u8, out_buffer: []u8) RealPathE
 pub fn realpathW(self: Dir, pathname: []const u16, out_buffer: []u8) RealPathError![]u8 {
     const w = windows;
 
-    const access_mask = w.GENERIC_READ | w.SYNCHRONIZE;
-    const share_access = w.FILE_SHARE_READ | w.FILE_SHARE_WRITE | w.FILE_SHARE_DELETE;
     const creation = w.FILE_OPEN;
     const h_file = blk: {
         const res = w.OpenFile(pathname, .{
             .dir = self.fd,
-            .access_mask = access_mask,
-            .share_access = share_access,
+            .access_mask = .{
+                .GENERIC = .{ .READ = true },
+                .SYNCHRONIZE = true,
+            },
+            .share_access = .{},
             .creation = creation,
             .filter = .any,
         }) catch |err| switch (err) {
@@ -1415,7 +1433,7 @@ pub const OpenDirOptions = struct {
 pub fn openDir(self: Dir, sub_path: []const u8, args: OpenDirOptions) OpenError!Dir {
     switch (native_os) {
         .windows => {
-            const sub_path_w = try windows.sliceToPrefixedFileW(self.fd, sub_path);
+            const sub_path_w = try windows.sliceToPrefixedFileW(sub_path, .{ .dir = .{ .handle = self.fd } });
             return self.openDirW(sub_path_w.span().ptr, args);
         },
         .wasi => if (!builtin.link_libc) {
@@ -1473,7 +1491,7 @@ pub fn openDir(self: Dir, sub_path: []const u8, args: OpenDirOptions) OpenError!
 pub fn openDirZ(self: Dir, sub_path_c: [*:0]const u8, args: OpenDirOptions) OpenError!Dir {
     switch (native_os) {
         .windows => {
-            const sub_path_w = try windows.cStrToPrefixedFileW(self.fd, sub_path_c);
+            const sub_path_w = try windows.cStrToPrefixedFileW(sub_path_c, .{ .dir = .{ .handle = self.fd } });
             return self.openDirW(sub_path_w.span().ptr, args);
         },
         // Use the libc API when libc is linked because it implements things
@@ -1530,10 +1548,16 @@ pub fn openDirZ(self: Dir, sub_path_c: [*:0]const u8, args: OpenDirOptions) Open
 pub fn openDirW(self: Dir, sub_path_w: [*:0]const u16, args: OpenDirOptions) OpenError!Dir {
     const w = windows;
     // TODO remove some of these flags if args.access_sub_paths is false
-    const base_flags = w.STANDARD_RIGHTS_READ | w.FILE_READ_ATTRIBUTES | w.FILE_READ_EA |
-        w.SYNCHRONIZE | w.FILE_TRAVERSE;
-    const flags: u32 = if (args.iterate) base_flags | w.FILE_LIST_DIRECTORY else base_flags;
-    const dir = self.makeOpenDirAccessMaskW(sub_path_w, flags, .{
+    const dir = self.makeOpenDirAccessMaskW(sub_path_w, .{
+        .STANDARD = w.ACCESS_MASK.STANDARD.READ,
+        .SPECIFIC = .{ .DIRECTORY = .{
+            .READ_ATTRIBUTES = true,
+            .READ_EA = true,
+            .TRAVERSE = true,
+            .LIST = args.iterate,
+        } },
+        .SYNCHRONIZE = true,
+    }, .{
         .no_follow = args.no_follow,
         .create_disposition = w.FILE_OPEN,
     }) catch |err| switch (err) {
@@ -1568,7 +1592,7 @@ const MakeOpenDirAccessMaskWOptions = struct {
     create_disposition: u32,
 };
 
-fn makeOpenDirAccessMaskW(self: Dir, sub_path_w: [*:0]const u16, access_mask: u32, flags: MakeOpenDirAccessMaskWOptions) (MakeError || OpenError)!Dir {
+fn makeOpenDirAccessMaskW(self: Dir, sub_path_w: [*:0]const u16, access_mask: windows.ACCESS_MASK, flags: MakeOpenDirAccessMaskWOptions) (MakeError || OpenError)!Dir {
     const w = windows;
 
     var result = Dir{
@@ -1598,7 +1622,7 @@ fn makeOpenDirAccessMaskW(self: Dir, sub_path_w: [*:0]const u16, access_mask: u3
         &io,
         null,
         w.FILE_ATTRIBUTE_NORMAL,
-        w.FILE_SHARE_READ | w.FILE_SHARE_WRITE | w.FILE_SHARE_DELETE,
+        .{},
         flags.create_disposition,
         w.FILE_DIRECTORY_FILE | w.FILE_SYNCHRONOUS_IO_NONALERT | w.FILE_OPEN_FOR_BACKUP_INTENT | open_reparse_point,
         null,
@@ -1629,7 +1653,7 @@ pub const DeleteFileError = posix.UnlinkError;
 /// Asserts that the path parameter has no null bytes.
 pub fn deleteFile(self: Dir, sub_path: []const u8) DeleteFileError!void {
     if (native_os == .windows) {
-        const sub_path_w = try windows.sliceToPrefixedFileW(self.fd, sub_path);
+        const sub_path_w = try windows.sliceToPrefixedFileW(sub_path, .{ .dir = .{ .handle = self.fd } });
         return self.deleteFileW(sub_path_w.span());
     } else if (native_os == .wasi and !builtin.link_libc) {
         posix.unlinkat(self.fd, sub_path, 0) catch |err| switch (err) {
@@ -1699,7 +1723,7 @@ pub const DeleteDirError = error{
 /// Asserts that the path parameter has no null bytes.
 pub fn deleteDir(self: Dir, sub_path: []const u8) DeleteDirError!void {
     if (native_os == .windows) {
-        const sub_path_w = try windows.sliceToPrefixedFileW(self.fd, sub_path);
+        const sub_path_w = try windows.sliceToPrefixedFileW(sub_path, .{ .dir = .{ .handle = self.fd } });
         return self.deleteDirW(sub_path_w.span());
     } else if (native_os == .wasi and !builtin.link_libc) {
         posix.unlinkat(self.fd, sub_path, posix.AT.REMOVEDIR) catch |err| switch (err) {
@@ -1794,7 +1818,7 @@ pub fn symLink(
             mem.nativeToLittle(u16, '\\'),
         );
 
-        const sym_link_path_w = try windows.sliceToPrefixedFileW(self.fd, sym_link_path);
+        const sym_link_path_w = try windows.sliceToPrefixedFileW(sym_link_path, .{ .dir = .{ .handle = self.fd } });
         return self.symLinkW(target_path_w.span(), sym_link_path_w.span(), flags);
     }
     const target_path_c = try posix.toPosixPath(target_path);
@@ -1820,8 +1844,8 @@ pub fn symLinkZ(
     flags: SymLinkFlags,
 ) !void {
     if (native_os == .windows) {
-        const target_path_w = try windows.cStrToPrefixedFileW(self.fd, target_path_c);
-        const sym_link_path_w = try windows.cStrToPrefixedFileW(self.fd, sym_link_path_c);
+        const target_path_w = try windows.cStrToPrefixedFileW(target_path_c, .{ .dir = .{ .handle = self.fd } });
+        const sym_link_path_w = try windows.cStrToPrefixedFileW(sym_link_path_c, .{ .dir = .{ .handle = self.fd } });
         return self.symLinkW(target_path_w.span(), sym_link_path_w.span(), flags);
     }
     return posix.symlinkatZ(target_path_c, self.fd, sym_link_path_c);
@@ -1855,7 +1879,7 @@ pub fn readLink(self: Dir, sub_path: []const u8, buffer: []u8) ReadLinkError![]u
         return self.readLinkWasi(sub_path, buffer);
     }
     if (native_os == .windows) {
-        const sub_path_w = try windows.sliceToPrefixedFileW(self.fd, sub_path);
+        const sub_path_w = try windows.sliceToPrefixedFileW(sub_path, .{ .dir = .{ .handle = self.fd } });
         return self.readLinkW(sub_path_w.span(), buffer);
     }
     const sub_path_c = try posix.toPosixPath(sub_path);
@@ -1870,7 +1894,7 @@ pub fn readLinkWasi(self: Dir, sub_path: []const u8, buffer: []u8) ![]u8 {
 /// Same as `readLink`, except the `sub_path_c` parameter is null-terminated.
 pub fn readLinkZ(self: Dir, sub_path_c: [*:0]const u8, buffer: []u8) ![]u8 {
     if (native_os == .windows) {
-        const sub_path_w = try windows.cStrToPrefixedFileW(self.fd, sub_path_c);
+        const sub_path_w = try windows.cStrToPrefixedFileW(sub_path_c, .{ .dir = .{ .handle = self.fd } });
         return self.readLinkW(sub_path_w.span(), buffer);
     }
     return posix.readlinkatZ(self.fd, sub_path_c, buffer);
@@ -2393,7 +2417,7 @@ pub const AccessError = posix.AccessError;
 /// open it and handle the error for file not found.
 pub fn access(self: Dir, sub_path: []const u8, flags: File.OpenFlags) AccessError!void {
     if (native_os == .windows) {
-        const sub_path_w = windows.sliceToPrefixedFileW(self.fd, sub_path) catch |err| switch (err) {
+        const sub_path_w = windows.sliceToPrefixedFileW(sub_path, .{ .dir = .{ .handle = self.fd } }) catch |err| switch (err) {
             error.AccessDenied => return error.PermissionDenied,
             else => |e| return e,
         };
@@ -2406,7 +2430,7 @@ pub fn access(self: Dir, sub_path: []const u8, flags: File.OpenFlags) AccessErro
 /// Same as `access` except the path parameter is null-terminated.
 pub fn accessZ(self: Dir, sub_path: [*:0]const u8, flags: File.OpenFlags) AccessError!void {
     if (native_os == .windows) {
-        const sub_path_w = windows.cStrToPrefixedFileW(self.fd, sub_path) catch |err| switch (err) {
+        const sub_path_w = windows.cStrToPrefixedFileW(sub_path, .{ .dir = .{ .handle = self.fd } }) catch |err| switch (err) {
             error.AccessDenied => return error.PermissionDenied,
             else => |e| return e,
         };

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -20,7 +20,8 @@ fn getStdOutHandle() posix.fd_t {
             // TODO: this is just a temporary workaround until we advance aarch64 backend further along.
             return windows.GetStdHandle(windows.STD_OUTPUT_HANDLE) catch windows.INVALID_HANDLE_VALUE;
         }
-        return windows.peb().ProcessParameters.hStdOutput;
+        return windows.peb().ProcessParameters.hStdOutput orelse
+            windows.INVALID_HANDLE_VALUE;
     }
 
     if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdOutHandle")) {
@@ -40,7 +41,8 @@ fn getStdErrHandle() posix.fd_t {
             // TODO: this is just a temporary workaround until we advance aarch64 backend further along.
             return windows.GetStdHandle(windows.STD_ERROR_HANDLE) catch windows.INVALID_HANDLE_VALUE;
         }
-        return windows.peb().ProcessParameters.hStdError;
+        return windows.peb().ProcessParameters.hStdError orelse
+            windows.INVALID_HANDLE_VALUE;
     }
 
     if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdErrHandle")) {
@@ -60,7 +62,8 @@ fn getStdInHandle() posix.fd_t {
             // TODO: this is just a temporary workaround until we advance aarch64 backend further along.
             return windows.GetStdHandle(windows.STD_INPUT_HANDLE) catch windows.INVALID_HANDLE_VALUE;
         }
-        return windows.peb().ProcessParameters.hStdInput;
+        return windows.peb().ProcessParameters.hStdInput orelse
+            windows.INVALID_HANDLE_VALUE;
     }
 
     if (@hasDecl(root, "os") and @hasDecl(root.os, "io") and @hasDecl(root.os.io, "getStdInHandle")) {

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -68,6 +68,8 @@ const KNONVOLATILE_CONTEXT_POINTERS = windows.KNONVOLATILE_CONTEXT_POINTERS;
 const EXCEPTION_ROUTINE = windows.EXCEPTION_ROUTINE;
 const MODULEENTRY32 = windows.MODULEENTRY32;
 const ULONGLONG = windows.ULONGLONG;
+const ACCESS_MASK = windows.ACCESS_MASK;
+const PIPE = windows.PIPE;
 
 pub extern "kernel32" fn AddVectoredExceptionHandler(First: c_ulong, Handler: ?VECTORED_EXCEPTION_HANDLER) callconv(WINAPI) ?*anyopaque;
 pub extern "kernel32" fn RemoveVectoredExceptionHandler(Handle: HANDLE) callconv(WINAPI) c_ulong;
@@ -84,14 +86,14 @@ pub extern "kernel32" fn CreateEventExW(
     lpEventAttributes: ?*SECURITY_ATTRIBUTES,
     lpName: ?LPCWSTR,
     dwFlags: DWORD,
-    dwDesiredAccess: DWORD,
+    dwDesiredAccess: ACCESS_MASK,
 ) callconv(WINAPI) ?HANDLE;
 
 pub extern "kernel32" fn CreateFileW(
     lpFileName: [*:0]const u16,
-    dwDesiredAccess: DWORD,
+    dwDesiredAccess: ACCESS_MASK,
     dwShareMode: DWORD,
-    lpSecurityAttributes: ?*SECURITY_ATTRIBUTES,
+    lpSecurityAttributes: ?*const SECURITY_ATTRIBUTES,
     dwCreationDisposition: DWORD,
     dwFlagsAndAttributes: DWORD,
     hTemplateFile: ?HANDLE,
@@ -106,8 +108,8 @@ pub extern "kernel32" fn CreatePipe(
 
 pub extern "kernel32" fn CreateNamedPipeW(
     lpName: LPCWSTR,
-    dwOpenMode: DWORD,
-    dwPipeMode: DWORD,
+    dwOpenMode: PIPE.OPEN_MODE,
+    dwPipeMode: PIPE.MODE,
     nMaxInstances: DWORD,
     nOutBufferSize: DWORD,
     nInBufferSize: DWORD,
@@ -117,14 +119,14 @@ pub extern "kernel32" fn CreateNamedPipeW(
 
 pub extern "kernel32" fn CreateProcessW(
     lpApplicationName: ?LPCWSTR,
-    lpCommandLine: ?LPWSTR,
-    lpProcessAttributes: ?*SECURITY_ATTRIBUTES,
-    lpThreadAttributes: ?*SECURITY_ATTRIBUTES,
+    lpCommandLine: ?LPCWSTR,
+    lpProcessAttributes: ?*const SECURITY_ATTRIBUTES,
+    lpThreadAttributes: ?*const SECURITY_ATTRIBUTES,
     bInheritHandles: BOOL,
     dwCreationFlags: DWORD,
-    lpEnvironment: ?*anyopaque,
+    lpEnvironment: ?*const anyopaque,
     lpCurrentDirectory: ?LPCWSTR,
-    lpStartupInfo: *STARTUPINFOW,
+    lpStartupInfo: *const STARTUPINFOW,
     lpProcessInformation: *PROCESS_INFORMATION,
 ) callconv(WINAPI) BOOL;
 
@@ -149,7 +151,7 @@ pub extern "kernel32" fn DeviceIoControl(
 
 pub extern "kernel32" fn DeleteFileW(lpFileName: [*:0]const u16) callconv(WINAPI) BOOL;
 
-pub extern "kernel32" fn DuplicateHandle(hSourceProcessHandle: HANDLE, hSourceHandle: HANDLE, hTargetProcessHandle: HANDLE, lpTargetHandle: *HANDLE, dwDesiredAccess: DWORD, bInheritHandle: BOOL, dwOptions: DWORD) callconv(WINAPI) BOOL;
+pub extern "kernel32" fn DuplicateHandle(hSourceProcessHandle: HANDLE, hSourceHandle: HANDLE, hTargetProcessHandle: HANDLE, lpTargetHandle: *HANDLE, dwDesiredAccess: ACCESS_MASK, bInheritHandle: BOOL, dwOptions: DWORD) callconv(WINAPI) BOOL;
 
 pub extern "kernel32" fn ExitProcess(exit_code: UINT) callconv(WINAPI) noreturn;
 
@@ -464,3 +466,7 @@ pub extern "kernel32" fn RegOpenKeyExW(
 ) callconv(WINAPI) LSTATUS;
 
 pub extern "kernel32" fn GetPhysicallyInstalledSystemMemory(TotalMemoryInKilobytes: *ULONGLONG) BOOL;
+
+pub extern "kernel32" fn IsDebuggerPresent() BOOL;
+
+pub extern "kernel32" fn GetHandleInformation(hObject: HANDLE, lpdwFlags: *DWORD) BOOL;

--- a/lib/std/os/windows/ntdll.zig
+++ b/lib/std/os/windows/ntdll.zig
@@ -37,6 +37,11 @@ const PROCESSINFOCLASS = windows.PROCESSINFOCLASS;
 const LPVOID = windows.LPVOID;
 const LPCVOID = windows.LPCVOID;
 const SECTION_INHERIT = windows.SECTION_INHERIT;
+const RTL_USER_PROCESS_PARAMETERS = windows.RTL_USER_PROCESS_PARAMETERS;
+const PROCESS = windows.PROCESS;
+const THREAD = windows.THREAD;
+const PS = windows.PS;
+const FILE = windows.FILE;
 
 pub extern "ntdll" fn NtQueryInformationProcess(
     ProcessHandle: HANDLE,
@@ -127,7 +132,7 @@ pub extern "ntdll" fn NtCreateFile(
     IoStatusBlock: *IO_STATUS_BLOCK,
     AllocationSize: ?*LARGE_INTEGER,
     FileAttributes: ULONG,
-    ShareAccess: ULONG,
+    ShareAccess: FILE.SHARE,
     CreateDisposition: ULONG,
     CreateOptions: ULONG,
     EaBuffer: ?*anyopaque,
@@ -344,10 +349,10 @@ pub extern "ntdll" fn RtlExitUserProcess(
 
 pub extern "ntdll" fn NtCreateNamedPipeFile(
     FileHandle: *HANDLE,
-    DesiredAccess: ULONG,
+    DesiredAccess: ACCESS_MASK,
     ObjectAttributes: *OBJECT_ATTRIBUTES,
     IoStatusBlock: *IO_STATUS_BLOCK,
-    ShareAccess: ULONG,
+    ShareAccess: FILE.SHARE,
     CreateDisposition: ULONG,
     CreateOptions: ULONG,
     NamedPipeType: ULONG,
@@ -357,4 +362,18 @@ pub extern "ntdll" fn NtCreateNamedPipeFile(
     InboundQuota: ULONG,
     OutboundQuota: ULONG,
     DefaultTimeout: *LARGE_INTEGER,
+) callconv(WINAPI) NTSTATUS;
+
+pub extern "ntdll" fn NtCreateUserProcess(
+    ProcessHandle: *HANDLE,
+    ThreadHandle: *HANDLE,
+    ProcessDesiredAccess: ACCESS_MASK,
+    ThreadDesiredAccess: ACCESS_MASK,
+    ProcessObjectAttributes: ?*const OBJECT_ATTRIBUTES,
+    ThreadObjectAttributes: ?*const OBJECT_ATTRIBUTES,
+    ProcessFlags: PROCESS.CREATE_FLAGS,
+    ThreadFlags: THREAD.CREATE_FLAGS,
+    ProcessParameters: *const RTL_USER_PROCESS_PARAMETERS,
+    CreateInfo: *PS.CREATE_INFO,
+    AttributeList: *const PS.ATTRIBUTE.LIST,
 ) callconv(WINAPI) NTSTATUS;

--- a/lib/std/os/windows/test.zig
+++ b/lib/std/os/windows/test.zig
@@ -28,7 +28,7 @@ fn RtlDosPathNameToNtPathName_U(path: [:0]const u16) !windows.PathSpace {
 fn testToPrefixedFileNoOracle(comptime path: []const u8, comptime expected_path: []const u8) !void {
     const path_utf16 = std.unicode.utf8ToUtf16LeStringLiteral(path);
     const expected_path_utf16 = std.unicode.utf8ToUtf16LeStringLiteral(expected_path);
-    const actual_path = try windows.wToPrefixedFileW(null, path_utf16);
+    const actual_path = try windows.wToPrefixedFileW(path_utf16, .{});
     std.testing.expectEqualSlices(u16, expected_path_utf16, actual_path.span()) catch |e| {
         std.debug.print("got '{s}', expected '{s}'\n", .{ std.unicode.fmtUtf16Le(actual_path.span()), std.unicode.fmtUtf16le(expected_path_utf16) });
         return e;
@@ -45,7 +45,7 @@ fn testToPrefixedFileWithOracle(comptime path: []const u8, comptime expected_pat
 /// Test that the Zig conversion matches the conversion that RtlDosPathNameToNtPathName_U does.
 fn testToPrefixedFileOnlyOracle(comptime path: []const u8) !void {
     const path_utf16 = std.unicode.utf8ToUtf16LeStringLiteral(path);
-    const zig_result = try windows.wToPrefixedFileW(null, path_utf16);
+    const zig_result = try windows.wToPrefixedFileW(path_utf16, .{});
     const win32_api_result = try RtlDosPathNameToNtPathName_U(path_utf16);
     std.testing.expectEqualSlices(u16, win32_api_result.span(), zig_result.span()) catch |e| {
         std.debug.print("got '{s}', expected '{s}'\n", .{ std.unicode.fmtUtf16Le(zig_result.span()), std.unicode.fmtUtf16le(win32_api_result.span()) });

--- a/lib/std/zig/LibCInstallation.zig
+++ b/lib/std/zig/LibCInstallation.zig
@@ -269,7 +269,7 @@ fn findNativeIncludeDirPosix(self: *LibCInstallation, args: FindNativeOptions) F
         // Some C compilers, such as Clang, are known to rely on argv[0] to find the path
         // to their own executable, without even bothering to resolve PATH. This results in the message:
         // error: unable to execute command: Executable "" doesn't exist!
-        // So we use the expandArg0 variant of ChildProcess to give them a helping hand.
+        // So we use the expandArg0 variant of Child to give them a helping hand.
         .expand_arg0 = .expand,
     }) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
@@ -596,7 +596,7 @@ fn ccPrintFileName(args: CCPrintFileNameOptions) ![:0]u8 {
         // Some C compilers, such as Clang, are known to rely on argv[0] to find the path
         // to their own executable, without even bothering to resolve PATH. This results in the message:
         // error: unable to execute command: Executable "" doesn't exist!
-        // So we use the expandArg0 variant of ChildProcess to give them a helping hand.
+        // So we use the expandArg0 variant of Child to give them a helping hand.
         .expand_arg0 = .expand,
     }) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,

--- a/lib/std/zig/WindowsSdk.zig
+++ b/lib/std/zig/WindowsSdk.zig
@@ -249,8 +249,13 @@ const RegistryWtf16Le = struct {
     /// After finishing work, call `closeKey`.
     fn openKey(hkey: windows.HKEY, key_wtf16le: [:0]const u16, options: OpenOptions) error{KeyNotFound}!RegistryWtf16Le {
         var key: windows.HKEY = undefined;
-        var access: windows.REGSAM = windows.KEY_QUERY_VALUE | windows.KEY_ENUMERATE_SUB_KEYS;
-        if (options.wow64_32) access |= windows.KEY_WOW64_32KEY;
+        const access: windows.REGSAM = .{
+            .SPECIFIC = .{ .KEY = .{
+                .QUERY_VALUE = true,
+                .ENUMERATE_SUB_KEYS = true,
+                .WOW64_32KEY = options.wow64_32,
+            } },
+        };
         const return_code_int: windows.HRESULT = windows.advapi32.RegOpenKeyExW(
             hkey,
             key_wtf16le,
@@ -388,7 +393,10 @@ const RegistryWtf16Le = struct {
         const return_code_int: windows.HRESULT = std.os.windows.advapi32.RegLoadAppKeyW(
             absolute_path_as_wtf16le,
             &key,
-            windows.KEY_QUERY_VALUE | windows.KEY_ENUMERATE_SUB_KEYS,
+            .{ .SPECIFIC = .{ .KEY = .{
+                .QUERY_VALUE = true,
+                .ENUMERATE_SUB_KEYS = true,
+            } } },
             0,
             0,
         );

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -670,7 +670,7 @@ test "zig fmt: array types last token" {
 test "zig fmt: sentinel-terminated array type" {
     try testCanonical(
         \\pub fn cStrToPrefixedFileW(s: [*:0]const u8) ![PATH_MAX_WIDE:0]u16 {
-        \\    return sliceToPrefixedFileW(mem.toSliceConst(u8, s));
+        \\    return sliceToPrefixedFileW(mem.toSliceConst(u8, s), .{});
         \\}
         \\
     );

--- a/tools/docgen.zig
+++ b/tools/docgen.zig
@@ -3,7 +3,6 @@ const builtin = @import("builtin");
 const io = std.io;
 const fs = std.fs;
 const process = std.process;
-const ChildProcess = std.process.Child;
 const Progress = std.Progress;
 const print = std.debug.print;
 const mem = std.mem;


### PR DESCRIPTION
The nearby local maximum API surface that would have been required to implement this feature would have introduced a bunch of useless new kernel32 dependencies, so I instead fled two undocumented layers deep into ntdll for the identical functionality in a single syscall.

Closes #20105