### PR TITLE
mark anondecls as constants in llvm ir

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3115,6 +3115,7 @@ pub const Object = struct {
 
         try variable_index.setInitializer(try o.lowerValue(decl_val), &o.builder);
         variable_index.setLinkage(.internal, &o.builder);
+        variable_index.setMutability(.constant, &o.builder);
         variable_index.setUnnamedAddr(.unnamed_addr, &o.builder);
         variable_index.setAlignment(alignment.toLlvm(), &o.builder);
         return variable_index;


### PR DESCRIPTION
Fixes #18404 and #20046.

Output from #18404 is now sequential:
```
array1: { 1, 2, 3, 4 } [4]u8@1021a37dc
array2: { 5, 6, 7, 8 } [4]u8@1021a37e0
slice1: { 9, 10, 11, 12 } u8@1021a37e4
slice2: { 13, 14, 15, 16 } u8@1021a37e8

```

#20046
```
zig init
zig build -Dtarget=x86_64-windows -Doptimize=ReleaseSmall
objdump --section=.data --full-contents zig-out/bin/coff.exe

Contents of section .rdata:
 402000 22f9ffff 97f9ffff 2bf9ffff 60f9ffff  ".......+...`...
 402010 52756e20 607a6967 20627569 6c642074  Run `zig build t
 402020 65737460 20746f20 72756e20 74686520  est` to run the
 402030 74657374 732e0a00 416c6c20 796f7572  tests...All your
 402040 207b737d 20617265 2062656c 6f6e6720   {s} are belong
 402050 746f2075 732e0a00 636f6465 62617365  to us...codebase
 402060 00000000 00000000 00000000 00000000  ................

```

Since I'm new to Zig project, I'm not sure about the fix. If all anon decls immutable, then it should be ok. I tested with `zig build test-behavior -Dskip-release` and `zig build test-std -Dskip-release` and it did not find any issues. Also, zig compiler compiled with stage4 zig is able to compile and seems to work normally.