### PR TITLE
objcopy build step: don't accept multiple sections

### DIFF
--- a/lib/std/Build/Step/ObjCopy.zig
+++ b/lib/std/Build/Step/ObjCopy.zig
@@ -33,7 +33,7 @@ output_file: std.Build.GeneratedFile,
 output_file_debug: ?std.Build.GeneratedFile,
 
 format: ?RawFormat,
-only_sections: ?[]const []const u8,
+only_section: ?[]const u8,
 pad_to: ?u64,
 strip: Strip,
 compress_debug: bool,
@@ -41,7 +41,7 @@ compress_debug: bool,
 pub const Options = struct {
     basename: ?[]const u8 = null,
     format: ?RawFormat = null,
-    only_sections: ?[]const []const u8 = null,
+    only_section: ?[]const u8 = null,
     pad_to: ?u64 = null,
 
     compress_debug: bool = false,
@@ -71,7 +71,7 @@ pub fn create(
         .output_file = std.Build.GeneratedFile{ .step = &objcopy.step },
         .output_file_debug = if (options.strip != .none and options.extract_to_separate_file) std.Build.GeneratedFile{ .step = &objcopy.step } else null,
         .format = options.format,
-        .only_sections = options.only_sections,
+        .only_section = options.only_section,
         .pad_to = options.pad_to,
         .strip = options.strip,
         .compress_debug = options.compress_debug,
@@ -103,7 +103,7 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
 
     const full_src_path = objcopy.input_file.getPath2(b, step);
     _ = try man.addFile(full_src_path, null);
-    man.hash.addOptionalListOfBytes(objcopy.only_sections);
+    man.hash.addOptionalBytes(objcopy.only_section);
     man.hash.addOptional(objcopy.pad_to);
     man.hash.addOptional(objcopy.format);
     man.hash.add(objcopy.compress_debug);
@@ -135,10 +135,8 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
     var argv = std.ArrayList([]const u8).init(b.allocator);
     try argv.appendSlice(&.{ b.graph.zig_exe, "objcopy" });
 
-    if (objcopy.only_sections) |only_sections| {
-        for (only_sections) |only_section| {
-            try argv.appendSlice(&.{ "-j", only_section });
-        }
+    if (objcopy.only_section) |only_section| {
+        try argv.appendSlice(&.{ "-j", only_section });
     }
     switch (objcopy.strip) {
         .none => {},


### PR DESCRIPTION
The actual `zig objcopy` does not accept keeping multiple sections. If you pass multiple `-j .section` arguments to `zig objcopy`, it will only respect the last one passed.

Originally I changed `zig objcopy` to accept multiple sections and then concatenate them instead of returning after outputting the first section (see emitElf) but I realized concatenating probably doesn't make sense.
