### PR TITLE
Add context to CodeGen crashes

### DIFF
--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -52,6 +52,34 @@ pub fn write(stream: anytype, pt: Zcu.PerThread, air: Air, liveness: ?Liveness) 
     writer.writeBody(stream, air.getMainBody()) catch return;
 }
 
+pub fn writeContext(
+    stream: anytype,
+    pt: Zcu.PerThread,
+    block: []const Air.Inst.Index,
+    block_index: usize,
+    air: Air,
+    liveness: ?Liveness,
+) !void {
+    var writer: Writer = .{
+        .pt = pt,
+        .gpa = pt.zcu.gpa,
+        .air = air,
+        .liveness = liveness,
+        .indent = 6,
+        .skip_body = false,
+    };
+
+    try writer.writeBody(stream, block[0..block_index]);
+    try stream.writeAll("    > ");
+    writer.indent = 0;
+    try writer.writeInst(stream, block[block_index]);
+    writer.indent = 6;
+    try stream.writeByte('\n');
+    if (block_index + 1 < block.len) {
+        try writer.writeBody(stream, block[block_index + 1 ..]);
+    }
+}
+
 pub fn writeInst(
     stream: anytype,
     inst: Air.Inst.Index,


### PR DESCRIPTION
Same as what is done for Zir but for Air, example from #20084:

```sh-session
$ zig-dev build-obj a.zig
thread 42125 panic: attempt to use null value
CodeGen a.zig: a.zig:callbackFin
      %23!= dbg_stmt(4:17)
      %24 = is_non_null(%8)
      %27!= block(void, {
        %28!= cond_br(%24!, {
          %29!= br(%27, @Air.Inst.Ref.void_value)
        }, {
          %0! %8!
          %25!= call(<fn ([]const u8, ?*builtin.StackTrace, ?usize) noreturn, (function 'default_panic')>, [<[]const u8, "attempt to use null value"[0..25]>, <?*builtin.StackTrace, null>, <?usize, null>])
          %26!= unreach()
        })
      } %24!)
      %30 = optional_payload(*a.GuSettings, %8!)
      %31!= dbg_stmt(4:19)
      %32 = struct_field_ptr_index_0(*?fn (c_int) callconv(.C) void, %30!)
      %33 = load(?fn (c_int) callconv(.C) void, %32!)
      %34!= dbg_stmt(4:23)
      %35 = is_non_null(%33)
      %38!= block(void, {
        %39!= cond_br(%35!, {
          %40!= br(%38, @Air.Inst.Ref.void_value)
        }, {
          %0! %33!
          %36!= call(<fn ([]const u8, ?*builtin.StackTrace, ?usize) noreturn, (function 'default_panic')>, [<[]const u8, "attempt to use null value"[0..25]>, <?*builtin.StackTrace, null>, <?usize, null>])
          %37!= unreach()
        })
      } %35!)
      %41 = optional_payload(fn (c_int) callconv(.C) void, %33!)
      %42!= dbg_stmt(4:25)
      %43 = bit_and(%0!, <c_int, 65535>)
      %44!= dbg_stmt(4:25)
    > %45!= call(%41!, [%43!])
      %46!= br(%10, @Air.Inst.Ref.void_value)
    For full context, use the --verbose-air flag

/home/vexu/Documents/zig/zig/src/codegen/llvm.zig:4858:79: 0xa8a7398 in resolveInst (zig)
        const llvm_val = try self.resolveValue((try self.air.value(inst, mod)).?);
                                                                              ^
/home/vexu/Documents/zig/zig/src/codegen/llvm.zig:5267:45: 0xa8eebf0 in airCall (zig)
        const llvm_fn = try self.resolveInst(pl_op.operand);
                                            ^
/home/vexu/Documents/zig/zig/src/codegen/llvm.zig:5048:55: 0xa540cc5 in genBody (zig)
                .call              => try self.airCall(inst, .auto),
                                                      ^
/home/vexu/Documents/zig/zig/src/codegen/llvm.zig:5241:25: 0xa8d460f in genBodyDebugScope (zig)
        try self.genBody(body);
                        ^
/home/vexu/Documents/zig/zig/src/codegen/llvm.zig:6016:35: 0xa8d940f in airCondBr (zig)
        try self.genBodyDebugScope(null, then_body);
                                  ^
/home/vexu/Documents/zig/zig/src/codegen/llvm.zig:5028:54: 0xa53ffe4 in genBody (zig)
                .cond_br        => try self.airCondBr(inst),
                                                     ^
/home/vexu/Documents/zig/zig/src/codegen/llvm.zig:5241:25: 0xa8d460f in genBodyDebugScope (zig)
        try self.genBody(body);
                        ^
/home/vexu/Documents/zig/zig/src/codegen/llvm.zig:5957:35: 0xa8d2b33 in lowerBlock (zig)
        try self.genBodyDebugScope(maybe_inline_func, body);
                                  ^
/home/vexu/Documents/zig/zig/src/codegen/llvm.zig:5927:31: 0xa8d5348 in airBlock (zig)
        return self.lowerBlock(inst, null, @ptrCast(self.air.extra[extra.end..][0..extra.data.body_len]));
                              ^
/home/vexu/Documents/zig/zig/src/codegen/llvm.zig:5021:53: 0xa53fbd1 in genBody (zig)
                .block          => try self.airBlock(inst),
                                                    ^
/home/vexu/Documents/zig/zig/src/codegen/llvm.zig:1741:19: 0xa539dc8 in updateFunc (zig)
        fg.genBody(air.getMainBody()) catch |err| switch (err) {
                  ^
/home/vexu/Documents/zig/zig/src/link/Elf.zig:2990:70: 0xa8932d9 in updateFunc (zig)
    if (self.llvm_object) |llvm_object| return llvm_object.updateFunc(mod, func_index, air, liveness);
                                                                     ^
/home/vexu/Documents/zig/zig/src/link.zig:422:82: 0xa549438 in updateFunc (zig)
                return @as(*tag.Type(), @fieldParentPtr("base", base)).updateFunc(module, func_index, air, liveness);
                                                                                 ^
/home/vexu/Documents/zig/zig/src/Module.zig:3223:22: 0xa2969e1 in ensureFuncBodyAnalyzed (zig)
        lf.updateFunc(zcu, func_index, air, liveness) catch |err| switch (err) {
                     ^
```