### PR TITLE
build: use absolute path for global cache dir

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4855,7 +4855,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
         const p = override_global_cache_dir orelse try introspect.resolveGlobalCacheDir(arena);
         break :l .{
             .handle = try fs.cwd().makeOpenPath(p, .{}),
-            .path = p,
+            .path = try fs.path.resolve(arena, &.{ cwd_path, p }),
         };
     };
     defer global_cache_directory.handle.close();


### PR DESCRIPTION
fixes #20129
`p` is resolved instead of `override_global_cache_dir` because `resolveGlobalCacheDir` checks `XDG_CACHE_HOME` which may not be an absolute path.