### PR TITLE
math.float: fully qualified namespace cleanup

### DIFF
--- a/doc/langref/float_special_values.zig
+++ b/doc/langref/float_special_values.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 
-const inf = std.math.inf(f32);
-const negative_inf = -std.math.inf(f64);
-const nan = std.math.nan(f128);
+const inf = std.math.float.inf(f32);
+const negative_inf = -std.math.float.inf(f64);
+const nan = std.math.float.nan(f128);
 
 // syntax

--- a/lib/compiler_rt/addf3.zig
+++ b/lib/compiler_rt/addf3.zig
@@ -23,14 +23,14 @@ pub inline fn addf3(comptime T: type, a: T, b: T) T {
     const significandMask = (@as(Z, 1) << significandBits) - 1;
 
     const absMask = signBit - 1;
-    const qnanRep = @as(Z, @bitCast(math.nan(T))) | quietBit;
+    const qnanRep = @as(Z, @bitCast(math.float.nan(T))) | quietBit;
 
     var aRep: Z = @bitCast(a);
     var bRep: Z = @bitCast(b);
     const aAbs = aRep & absMask;
     const bAbs = bRep & absMask;
 
-    const infRep: Z = @bitCast(math.inf(T));
+    const infRep: Z = @bitCast(math.float.inf(T));
 
     // Detect if a or b is zero, infinity, or NaN.
     if (aAbs -% @as(Z, 1) >= infRep - @as(Z, 1) or

--- a/lib/compiler_rt/addf3.zig
+++ b/lib/compiler_rt/addf3.zig
@@ -11,9 +11,9 @@ pub inline fn addf3(comptime T: type, a: T, b: T) T {
     const Z = std.meta.Int(.unsigned, bits);
 
     const typeWidth = bits;
-    const significandBits = math.floatMantissaBits(T);
-    const fractionalBits = math.floatFractionalBits(T);
-    const exponentBits = math.floatExponentBits(T);
+    const significandBits = math.float.mantissaBits(T);
+    const fractionalBits = math.float.fractionalBits(T);
+    const exponentBits = math.float.exponentBits(T);
 
     const signBit = (@as(Z, 1) << (significandBits + exponentBits));
     const maxExponent = ((1 << exponentBits) - 1);

--- a/lib/compiler_rt/addf3_test.zig
+++ b/lib/compiler_rt/addf3_test.zig
@@ -41,10 +41,10 @@ test "addtf3" {
     try test__addtf3(@as(f128, @bitCast((@as(u128, 0x7fff000000000000) << 64) | @as(u128, 0x800030000000))), 0x1.23456789abcdefp+5, 0x7fff800000000000, 0x0);
 
     // inf + inf = inf
-    try test__addtf3(math.inf(f128), math.inf(f128), 0x7fff000000000000, 0x0);
+    try test__addtf3(math.float.inf(f128), math.float.inf(f128), 0x7fff000000000000, 0x0);
 
     // inf + any = inf
-    try test__addtf3(math.inf(f128), 0x1.2335653452436234723489432abcdefp+5, 0x7fff000000000000, 0x0);
+    try test__addtf3(math.float.inf(f128), 0x1.2335653452436234723489432abcdefp+5, 0x7fff000000000000, 0x0);
 
     // any + any
     try test__addtf3(0x1.23456734245345543849abcdefp+5, 0x1.edcba52449872455634654321fp-1, 0x40042afc95c8b579, 0x61e58dd6c51eb77c);
@@ -81,14 +81,14 @@ test "subtf3" {
     try test__subtf3(@as(f128, @bitCast((@as(u128, 0x7fff000000000000) << 64) | @as(u128, 0x800030000000))), 0x1.23456789abcdefp+5, 0x7fff800000000000, 0x0);
 
     // inf - any = inf
-    try test__subtf3(math.inf(f128), 0x1.23456789abcdefp+5, 0x7fff000000000000, 0x0);
+    try test__subtf3(math.float.inf(f128), 0x1.23456789abcdefp+5, 0x7fff000000000000, 0x0);
 
     // any + any
     try test__subtf3(0x1.234567829a3bcdef5678ade36734p+5, 0x1.ee9d7c52354a6936ab8d7654321fp-1, 0x40041b8af1915166, 0xa44a7bca780a166c);
     try test__subtf3(0x1.ee9d7c52354a6936ab8d7654321fp-1, 0x1.234567829a3bcdef5678ade36734p+5, 0xc0041b8af1915166, 0xa44a7bca780a166c);
 }
 
-const qnan80: f80 = @bitCast(@as(u80, @bitCast(math.nan(f80))) | (1 << (math.float.fractionalBits(f80) - 1)));
+const qnan80: f80 = @bitCast(@as(u80, @bitCast(math.float.nan(f80))) | (1 << (math.float.fractionalBits(f80) - 1)));
 
 fn test__addxf3(a: f80, b: f80, expected: u80) !void {
     const x = __addxf3(a, b);
@@ -113,25 +113,25 @@ test "addxf3" {
     try test__addxf3(0x1.23456789abcdefp+5, @as(f80, @bitCast(@as(u80, 0x7fff_8000_8000_3000_0000))), @as(u80, @bitCast(qnan80)));
 
     // NaN + inf = NaN
-    try test__addxf3(qnan80, math.inf(f80), @as(u80, @bitCast(qnan80)));
+    try test__addxf3(qnan80, math.float.inf(f80), @as(u80, @bitCast(qnan80)));
 
     // inf + NaN = NaN
-    try test__addxf3(math.inf(f80), qnan80, @as(u80, @bitCast(qnan80)));
+    try test__addxf3(math.float.inf(f80), qnan80, @as(u80, @bitCast(qnan80)));
 
     // inf + inf = inf
-    try test__addxf3(math.inf(f80), math.inf(f80), @as(u80, @bitCast(math.inf(f80))));
+    try test__addxf3(math.float.inf(f80), math.float.inf(f80), @as(u80, @bitCast(math.float.inf(f80))));
 
     // inf + -inf = NaN
-    try test__addxf3(math.inf(f80), -math.inf(f80), @as(u80, @bitCast(qnan80)));
+    try test__addxf3(math.float.inf(f80), -math.float.inf(f80), @as(u80, @bitCast(qnan80)));
 
     // -inf + inf = NaN
-    try test__addxf3(-math.inf(f80), math.inf(f80), @as(u80, @bitCast(qnan80)));
+    try test__addxf3(-math.float.inf(f80), math.float.inf(f80), @as(u80, @bitCast(qnan80)));
 
     // inf + any = inf
-    try test__addxf3(math.inf(f80), 0x1.2335653452436234723489432abcdefp+5, @as(u80, @bitCast(math.inf(f80))));
+    try test__addxf3(math.float.inf(f80), 0x1.2335653452436234723489432abcdefp+5, @as(u80, @bitCast(math.float.inf(f80))));
 
     // any + inf = inf
-    try test__addxf3(0x1.2335653452436234723489432abcdefp+5, math.inf(f80), @as(u80, @bitCast(math.inf(f80))));
+    try test__addxf3(0x1.2335653452436234723489432abcdefp+5, math.float.inf(f80), @as(u80, @bitCast(math.float.inf(f80))));
 
     // any + any
     try test__addxf3(0x1.23456789abcdp+5, 0x1.dcba987654321p+5, 0x4005_BFFFFFFFFFFFC400);

--- a/lib/compiler_rt/addf3_test.zig
+++ b/lib/compiler_rt/addf3_test.zig
@@ -88,7 +88,7 @@ test "subtf3" {
     try test__subtf3(0x1.ee9d7c52354a6936ab8d7654321fp-1, 0x1.234567829a3bcdef5678ade36734p+5, 0xc0041b8af1915166, 0xa44a7bca780a166c);
 }
 
-const qnan80: f80 = @bitCast(@as(u80, @bitCast(math.nan(f80))) | (1 << (math.floatFractionalBits(f80) - 1)));
+const qnan80: f80 = @bitCast(@as(u80, @bitCast(math.nan(f80))) | (1 << (math.float.fractionalBits(f80) - 1)));
 
 fn test__addxf3(a: f80, b: f80, expected: u80) !void {
     const x = __addxf3(a, b);

--- a/lib/compiler_rt/arm.zig
+++ b/lib/compiler_rt/arm.zig
@@ -207,7 +207,7 @@ fn __aeabi_drsub(a: f64, b: f64) callconv(.AAPCS) f64 {
 test "__aeabi_frsub" {
     if (!builtin.cpu.arch.isARM()) return error.SkipZigTest;
     const inf32 = std.math.inf(f32);
-    const maxf32 = std.math.floatMax(f32);
+    const maxf32 = std.math.float.max(f32);
     const frsub_data = [_][3]f32{
         [_]f32{ 0.0, 0.0, -0.0 },
         [_]f32{ 0.0, -0.0, -0.0 },
@@ -234,7 +234,7 @@ test "__aeabi_frsub" {
 test "__aeabi_drsub" {
     if (!builtin.cpu.arch.isARM()) return error.SkipZigTest;
     const inf64 = std.math.inf(f64);
-    const maxf64 = std.math.floatMax(f64);
+    const maxf64 = std.math.float.max(f64);
     const frsub_data = [_][3]f64{
         [_]f64{ 0.0, 0.0, -0.0 },
         [_]f64{ 0.0, -0.0, -0.0 },

--- a/lib/compiler_rt/arm.zig
+++ b/lib/compiler_rt/arm.zig
@@ -206,7 +206,7 @@ fn __aeabi_drsub(a: f64, b: f64) callconv(.AAPCS) f64 {
 
 test "__aeabi_frsub" {
     if (!builtin.cpu.arch.isARM()) return error.SkipZigTest;
-    const inf32 = std.math.inf(f32);
+    const inf32 = std.math.float.inf(f32);
     const maxf32 = std.math.float.max(f32);
     const frsub_data = [_][3]f32{
         [_]f32{ 0.0, 0.0, -0.0 },
@@ -233,7 +233,7 @@ test "__aeabi_frsub" {
 
 test "__aeabi_drsub" {
     if (!builtin.cpu.arch.isARM()) return error.SkipZigTest;
-    const inf64 = std.math.inf(f64);
+    const inf64 = std.math.float.inf(f64);
     const maxf64 = std.math.float.max(f64);
     const frsub_data = [_][3]f64{
         [_]f64{ 0.0, 0.0, -0.0 },

--- a/lib/compiler_rt/ceil.zig
+++ b/lib/compiler_rt/ceil.zig
@@ -161,23 +161,23 @@ test "ceil128" {
 test "ceil32.special" {
     try expect(ceilf(0.0) == 0.0);
     try expect(ceilf(-0.0) == -0.0);
-    try expect(math.isPositiveInf(ceilf(math.inf(f32))));
-    try expect(math.isNegativeInf(ceilf(-math.inf(f32))));
-    try expect(math.isNan(ceilf(math.nan(f32))));
+    try expect(math.isPositiveInf(ceilf(math.float.inf(f32))));
+    try expect(math.isNegativeInf(ceilf(-math.float.inf(f32))));
+    try expect(math.isNan(ceilf(math.float.nan(f32))));
 }
 
 test "ceil64.special" {
     try expect(ceil(0.0) == 0.0);
     try expect(ceil(-0.0) == -0.0);
-    try expect(math.isPositiveInf(ceil(math.inf(f64))));
-    try expect(math.isNegativeInf(ceil(-math.inf(f64))));
-    try expect(math.isNan(ceil(math.nan(f64))));
+    try expect(math.isPositiveInf(ceil(math.float.inf(f64))));
+    try expect(math.isNegativeInf(ceil(-math.float.inf(f64))));
+    try expect(math.isNan(ceil(math.float.nan(f64))));
 }
 
 test "ceil128.special" {
     try expect(ceilq(0.0) == 0.0);
     try expect(ceilq(-0.0) == -0.0);
-    try expect(math.isPositiveInf(ceilq(math.inf(f128))));
-    try expect(math.isNegativeInf(ceilq(-math.inf(f128))));
-    try expect(math.isNan(ceilq(math.nan(f128))));
+    try expect(math.isPositiveInf(ceilq(math.float.inf(f128))));
+    try expect(math.isNegativeInf(ceilq(-math.float.inf(f128))));
+    try expect(math.isNan(ceilq(math.float.nan(f128))));
 }

--- a/lib/compiler_rt/ceil.zig
+++ b/lib/compiler_rt/ceil.zig
@@ -65,7 +65,7 @@ pub fn ceilf(x: f32) callconv(.C) f32 {
 }
 
 pub fn ceil(x: f64) callconv(.C) f64 {
-    const f64_toint = 1.0 / math.floatEps(f64);
+    const f64_toint = 1.0 / math.float.eps(f64);
 
     const u: u64 = @bitCast(x);
     const e = (u >> 52) & 0x7FF;
@@ -101,7 +101,7 @@ pub fn __ceilx(x: f80) callconv(.C) f80 {
 }
 
 pub fn ceilq(x: f128) callconv(.C) f128 {
-    const f128_toint = 1.0 / math.floatEps(f128);
+    const f128_toint = 1.0 / math.float.eps(f128);
 
     const u: u128 = @bitCast(x);
     const e = (u >> 112) & 0x7FFF;

--- a/lib/compiler_rt/common.zig
+++ b/lib/compiler_rt/common.zig
@@ -219,7 +219,7 @@ pub fn wideMultiply(comptime Z: type, a: Z, b: Z, hi: *Z, lo: *Z) void {
 
 pub fn normalize(comptime T: type, significand: *std.meta.Int(.unsigned, @typeInfo(T).Float.bits)) i32 {
     const Z = std.meta.Int(.unsigned, @typeInfo(T).Float.bits);
-    const integerBit = @as(Z, 1) << std.math.floatFractionalBits(T);
+    const integerBit = @as(Z, 1) << std.math.float.fractionalBits(T);
 
     const shift = @clz(significand.*) - @clz(integerBit);
     significand.* <<= @as(std.math.Log2Int(Z), @intCast(shift));

--- a/lib/compiler_rt/comparedf2_test.zig
+++ b/lib/compiler_rt/comparedf2_test.zig
@@ -54,8 +54,8 @@ fn test__cmpdf2(vector: TestVector) bool {
 }
 
 const arguments = [_]f64{
-    std.math.nan(f64),
-    -std.math.inf(f64),
+    std.math.float.nan(f64),
+    -std.math.float.inf(f64),
     -0x1.fffffffffffffp1023,
     -0x1.0000000000001p0 - 0x1.0000000000000p0,
     -0x1.fffffffffffffp-1,
@@ -71,7 +71,7 @@ const arguments = [_]f64{
     0x1.0000000000000p0,
     0x1.0000000000001p0,
     0x1.fffffffffffffp1023,
-    std.math.inf(f64),
+    std.math.float.inf(f64),
 };
 
 fn generateVector(comptime a: f64, comptime b: f64) TestVector {

--- a/lib/compiler_rt/comparef.zig
+++ b/lib/compiler_rt/comparef.zig
@@ -25,7 +25,7 @@ pub inline fn cmpf2(comptime T: type, comptime RT: type, a: T, b: T) RT {
     const exponentBits = std.math.float.exponentBits(T);
     const signBit = (@as(rep_t, 1) << (significandBits + exponentBits));
     const absMask = signBit - 1;
-    const infT = comptime std.math.inf(T);
+    const infT = comptime std.math.float.inf(T);
     const infRep = @as(rep_t, @bitCast(infT));
 
     const aInt = @as(srep_t, @bitCast(a));
@@ -115,7 +115,7 @@ pub inline fn unordcmp(comptime T: type, a: T, b: T) i32 {
     const exponentBits = std.math.float.exponentBits(T);
     const signBit = (@as(rep_t, 1) << (significandBits + exponentBits));
     const absMask = signBit - 1;
-    const infRep = @as(rep_t, @bitCast(std.math.inf(T)));
+    const infRep = @as(rep_t, @bitCast(std.math.float.inf(T)));
 
     const aAbs: rep_t = @as(rep_t, @bitCast(a)) & absMask;
     const bAbs: rep_t = @as(rep_t, @bitCast(b)) & absMask;

--- a/lib/compiler_rt/comparef.zig
+++ b/lib/compiler_rt/comparef.zig
@@ -21,8 +21,8 @@ pub inline fn cmpf2(comptime T: type, comptime RT: type, a: T, b: T) RT {
     const srep_t = std.meta.Int(.signed, bits);
     const rep_t = std.meta.Int(.unsigned, bits);
 
-    const significandBits = std.math.floatMantissaBits(T);
-    const exponentBits = std.math.floatExponentBits(T);
+    const significandBits = std.math.float.mantissaBits(T);
+    const exponentBits = std.math.float.exponentBits(T);
     const signBit = (@as(rep_t, 1) << (significandBits + exponentBits));
     const absMask = signBit - 1;
     const infT = comptime std.math.inf(T);
@@ -63,7 +63,7 @@ pub inline fn cmpf2(comptime T: type, comptime RT: type, a: T, b: T) RT {
 pub inline fn cmp_f80(comptime RT: type, a: f80, b: f80) RT {
     const a_rep = std.math.break_f80(a);
     const b_rep = std.math.break_f80(b);
-    const sig_bits = std.math.floatMantissaBits(f80);
+    const sig_bits = std.math.float.mantissaBits(f80);
     const int_bit = 0x8000000000000000;
     const sign_bit = 0x8000;
     const special_exp = 0x7FFF;
@@ -111,8 +111,8 @@ test "cmp_f80" {
 pub inline fn unordcmp(comptime T: type, a: T, b: T) i32 {
     const rep_t = std.meta.Int(.unsigned, @typeInfo(T).Float.bits);
 
-    const significandBits = std.math.floatMantissaBits(T);
-    const exponentBits = std.math.floatExponentBits(T);
+    const significandBits = std.math.float.mantissaBits(T);
+    const exponentBits = std.math.float.exponentBits(T);
     const signBit = (@as(rep_t, 1) << (significandBits + exponentBits));
     const absMask = signBit - 1;
     const infRep = @as(rep_t, @bitCast(std.math.inf(T)));

--- a/lib/compiler_rt/comparesf2_test.zig
+++ b/lib/compiler_rt/comparesf2_test.zig
@@ -54,8 +54,8 @@ fn test__cmpsf2(vector: TestVector) bool {
 }
 
 const arguments = [_]f32{
-    std.math.nan(f32),
-    -std.math.inf(f32),
+    std.math.float.nan(f32),
+    -std.math.float.inf(f32),
     -0x1.fffffep127,
     -0x1.000002p0 - 0x1.000000p0,
     -0x1.fffffep-1,
@@ -71,7 +71,7 @@ const arguments = [_]f32{
     0x1.000000p0,
     0x1.000002p0,
     0x1.fffffep127,
-    std.math.inf(f32),
+    std.math.float.inf(f32),
 };
 
 fn generateVector(comptime a: f32, comptime b: f32) TestVector {

--- a/lib/compiler_rt/cos.zig
+++ b/lib/compiler_rt/cos.zig
@@ -159,13 +159,13 @@ test "cos64" {
 }
 
 test "cos32.special" {
-    try expect(math.isNan(cosf(math.inf(f32))));
-    try expect(math.isNan(cosf(-math.inf(f32))));
-    try expect(math.isNan(cosf(math.nan(f32))));
+    try expect(math.isNan(cosf(math.float.inf(f32))));
+    try expect(math.isNan(cosf(-math.float.inf(f32))));
+    try expect(math.isNan(cosf(math.float.nan(f32))));
 }
 
 test "cos64.special" {
-    try expect(math.isNan(cos(math.inf(f64))));
-    try expect(math.isNan(cos(-math.inf(f64))));
-    try expect(math.isNan(cos(math.nan(f64))));
+    try expect(math.isNan(cos(math.float.inf(f64))));
+    try expect(math.isNan(cos(-math.float.inf(f64))));
+    try expect(math.isNan(cos(math.float.nan(f64))));
 }

--- a/lib/compiler_rt/divc3.zig
+++ b/lib/compiler_rt/divc3.zig
@@ -36,15 +36,15 @@ pub inline fn divc3(comptime T: type, a: T, b: T, c_in: T, d_in: T) Complex(T) {
 
         if ((denom == 0.0) and (!isNan(a) or !isNan(b))) {
             return .{
-                .real = copysign(std.math.inf(T), c) * a,
-                .imag = copysign(std.math.inf(T), c) * b,
+                .real = copysign(std.math.float.inf(T), c) * a,
+                .imag = copysign(std.math.float.inf(T), c) * b,
             };
         } else if ((isInf(a) or isInf(b)) and isFinite(c) and isFinite(d)) {
             const boxed_a = copysign(if (isInf(a)) one else zero, a);
             const boxed_b = copysign(if (isInf(b)) one else zero, b);
             return .{
-                .real = std.math.inf(T) * (boxed_a * c - boxed_b * d),
-                .imag = std.math.inf(T) * (boxed_b * c - boxed_a * d),
+                .real = std.math.float.inf(T) * (boxed_a * c - boxed_b * d),
+                .imag = std.math.float.inf(T) * (boxed_b * c - boxed_a * d),
             };
         } else if (logbw == maxInt(i32) and isFinite(a) and isFinite(b)) {
             const boxed_c = copysign(if (isInf(c)) one else zero, c);

--- a/lib/compiler_rt/divc3_test.zig
+++ b/lib/compiler_rt/divc3_test.zig
@@ -41,21 +41,21 @@ fn testDiv(comptime T: type, comptime f: fn (T, T, T, T) callconv(.C) Complex(T)
     {
         // if the first operand is an infinity and the second operand is a finite number, then the
         // result of the / operator is an infinity;
-        const a: T = -math.inf(T);
+        const a: T = -math.float.inf(T);
         const b: T = 0.0;
         const c: T = -4.0;
         const d: T = 1.0;
 
         const result = f(a, b, c, d);
-        try expect(result.real == math.inf(T));
-        try expect(result.imag == math.inf(T));
+        try expect(result.real == math.float.inf(T));
+        try expect(result.imag == math.float.inf(T));
     }
     {
         // if the first operand is a finite number and the second operand is an infinity, then the
         // result of the / operator is a zero;
         const a: T = 17.2;
         const b: T = 0.0;
-        const c: T = -math.inf(T);
+        const c: T = -math.float.inf(T);
         const d: T = 0.0;
 
         const result = f(a, b, c, d);
@@ -71,7 +71,7 @@ fn testDiv(comptime T: type, comptime f: fn (T, T, T, T) callconv(.C) Complex(T)
         const d: T = 0.0;
 
         const result = f(a, b, c, d);
-        try expect(result.real == math.inf(T));
-        try expect(result.imag == math.inf(T));
+        try expect(result.real == math.float.inf(T));
+        try expect(result.imag == math.float.inf(T));
     }
 }

--- a/lib/compiler_rt/divdf3.zig
+++ b/lib/compiler_rt/divdf3.zig
@@ -47,7 +47,7 @@ inline fn div(a: f64, b: f64) f64 {
     const absMask = signBit - 1;
     const exponentMask = absMask ^ significandMask;
     const qnanRep = exponentMask | quietBit;
-    const infRep = @as(Z, @bitCast(std.math.inf(f64)));
+    const infRep = @as(Z, @bitCast(std.math.float.inf(f64)));
 
     const aExponent: u32 = @truncate((@as(Z, @bitCast(a)) >> significandBits) & maxExponent);
     const bExponent: u32 = @truncate((@as(Z, @bitCast(b)) >> significandBits) & maxExponent);

--- a/lib/compiler_rt/divdf3.zig
+++ b/lib/compiler_rt/divdf3.zig
@@ -33,8 +33,8 @@ inline fn div(a: f64, b: f64) f64 {
     const Z = std.meta.Int(.unsigned, 64);
     const SignedZ = std.meta.Int(.signed, 64);
 
-    const significandBits = std.math.floatMantissaBits(f64);
-    const exponentBits = std.math.floatExponentBits(f64);
+    const significandBits = std.math.float.mantissaBits(f64);
+    const exponentBits = std.math.float.exponentBits(f64);
 
     const signBit = (@as(Z, 1) << (significandBits + exponentBits));
     const maxExponent = ((1 << exponentBits) - 1);

--- a/lib/compiler_rt/divsf3.zig
+++ b/lib/compiler_rt/divsf3.zig
@@ -44,7 +44,7 @@ inline fn div(a: f32, b: f32) f32 {
     const absMask = signBit - 1;
     const exponentMask = absMask ^ significandMask;
     const qnanRep = exponentMask | quietBit;
-    const infRep: Z = @bitCast(std.math.inf(f32));
+    const infRep: Z = @bitCast(std.math.float.inf(f32));
 
     const aExponent: u32 = @truncate((@as(Z, @bitCast(a)) >> significandBits) & maxExponent);
     const bExponent: u32 = @truncate((@as(Z, @bitCast(b)) >> significandBits) & maxExponent);

--- a/lib/compiler_rt/divsf3.zig
+++ b/lib/compiler_rt/divsf3.zig
@@ -30,8 +30,8 @@ fn __aeabi_fdiv(a: f32, b: f32) callconv(.AAPCS) f32 {
 inline fn div(a: f32, b: f32) f32 {
     const Z = std.meta.Int(.unsigned, 32);
 
-    const significandBits = std.math.floatMantissaBits(f32);
-    const exponentBits = std.math.floatExponentBits(f32);
+    const significandBits = std.math.float.mantissaBits(f32);
+    const exponentBits = std.math.float.exponentBits(f32);
 
     const signBit = (@as(Z, 1) << (significandBits + exponentBits));
     const maxExponent = ((1 << exponentBits) - 1);

--- a/lib/compiler_rt/divtf3.zig
+++ b/lib/compiler_rt/divtf3.zig
@@ -41,7 +41,7 @@ inline fn div(a: f128, b: f128) f128 {
     const absMask = signBit - 1;
     const exponentMask = absMask ^ significandMask;
     const qnanRep = exponentMask | quietBit;
-    const infRep: Z = @bitCast(std.math.inf(f128));
+    const infRep: Z = @bitCast(std.math.float.inf(f128));
 
     const aExponent: u32 = @truncate((@as(Z, @bitCast(a)) >> significandBits) & maxExponent);
     const bExponent: u32 = @truncate((@as(Z, @bitCast(b)) >> significandBits) & maxExponent);

--- a/lib/compiler_rt/divtf3.zig
+++ b/lib/compiler_rt/divtf3.zig
@@ -27,8 +27,8 @@ fn _Qp_div(c: *f128, a: *const f128, b: *const f128) callconv(.C) void {
 inline fn div(a: f128, b: f128) f128 {
     const Z = std.meta.Int(.unsigned, 128);
 
-    const significandBits = std.math.floatMantissaBits(f128);
-    const exponentBits = std.math.floatExponentBits(f128);
+    const significandBits = std.math.float.mantissaBits(f128);
+    const exponentBits = std.math.float.exponentBits(f128);
 
     const signBit = (@as(Z, 1) << (significandBits + exponentBits));
     const maxExponent = ((1 << exponentBits) - 1);

--- a/lib/compiler_rt/divtf3_test.zig
+++ b/lib/compiler_rt/divtf3_test.zig
@@ -31,13 +31,13 @@ fn test__divtf3(a: f128, b: f128, expectedHi: u64, expectedLo: u64) !void {
 
 test "divtf3" {
     // NaN / any = NaN
-    try test__divtf3(math.nan(f128), 0x1.23456789abcdefp+5, 0x7fff800000000000, 0);
+    try test__divtf3(math.float.nan(f128), 0x1.23456789abcdefp+5, 0x7fff800000000000, 0);
     // inf / any(except inf and nan) = inf
-    try test__divtf3(math.inf(f128), 0x1.23456789abcdefp+5, 0x7fff000000000000, 0);
+    try test__divtf3(math.float.inf(f128), 0x1.23456789abcdefp+5, 0x7fff000000000000, 0);
     // inf / inf = nan
-    try test__divtf3(math.inf(f128), math.inf(f128), 0x7fff800000000000, 0);
+    try test__divtf3(math.float.inf(f128), math.float.inf(f128), 0x7fff800000000000, 0);
     // inf / nan = nan
-    try test__divtf3(math.inf(f128), math.nan(f128), 0x7fff800000000000, 0);
+    try test__divtf3(math.float.inf(f128), math.float.nan(f128), 0x7fff800000000000, 0);
 
     try test__divtf3(0x1.a23b45362464523375893ab4cdefp+5, 0x1.eedcbaba3a94546558237654321fp-1, 0x4004b0b72924d407, 0x0717e84356c6eba2);
     try test__divtf3(0x1.a2b34c56d745382f9abf2c3dfeffp-50, 0x1.ed2c3ba15935332532287654321fp-9, 0x3fd5b2af3f828c9b, 0x40e51f64cde8b1f2);

--- a/lib/compiler_rt/divxf3.zig
+++ b/lib/compiler_rt/divxf3.zig
@@ -29,8 +29,8 @@ pub fn __divxf3(a: f80, b: f80) callconv(.C) f80 {
     const significandMask = (@as(Z, 1) << significandBits) - 1;
 
     const absMask = signBit - 1;
-    const qnanRep = @as(Z, @bitCast(std.math.nan(T))) | quietBit;
-    const infRep: Z = @bitCast(std.math.inf(T));
+    const qnanRep = @as(Z, @bitCast(std.math.float.nan(T))) | quietBit;
+    const infRep: Z = @bitCast(std.math.float.inf(T));
 
     const aExponent: u32 = @truncate((@as(Z, @bitCast(a)) >> significandBits) & maxExponent);
     const bExponent: u32 = @truncate((@as(Z, @bitCast(b)) >> significandBits) & maxExponent);

--- a/lib/compiler_rt/divxf3.zig
+++ b/lib/compiler_rt/divxf3.zig
@@ -16,9 +16,9 @@ pub fn __divxf3(a: f80, b: f80) callconv(.C) f80 {
     const T = f80;
     const Z = std.meta.Int(.unsigned, @bitSizeOf(T));
 
-    const significandBits = std.math.floatMantissaBits(T);
-    const fractionalBits = std.math.floatFractionalBits(T);
-    const exponentBits = std.math.floatExponentBits(T);
+    const significandBits = std.math.float.mantissaBits(T);
+    const fractionalBits = std.math.float.fractionalBits(T);
+    const exponentBits = std.math.float.exponentBits(T);
 
     const signBit = (@as(Z, 1) << (significandBits + exponentBits));
     const maxExponent = ((1 << exponentBits) - 1);
@@ -188,7 +188,7 @@ pub fn __divxf3(a: f80, b: f80) callconv(.C) f80 {
             // Check whether the rounded result is normal.
             if (residual > (bSignificand >> 1)) { // round
                 if (quotient == (integerBit - 1)) // If the rounded result is normal, return it
-                    return @bitCast(@as(Z, @bitCast(std.math.floatMin(T))) | quotientSign);
+                    return @bitCast(@as(Z, @bitCast(std.math.float.min(T))) | quotientSign);
             }
         }
         // Flush denormals to zero.  In the future, it would be nice to add

--- a/lib/compiler_rt/divxf3_test.zig
+++ b/lib/compiler_rt/divxf3_test.zig
@@ -21,7 +21,7 @@ fn expect__divxf3_result(a: f80, b: f80, expected: u80) !void {
 }
 
 fn test__divxf3(a: f80, b: f80) !void {
-    const integerBit = 1 << math.floatFractionalBits(f80);
+    const integerBit = 1 << math.float.fractionalBits(f80);
     const x = __divxf3(a, b);
 
     // Next float (assuming normal, non-zero result)

--- a/lib/compiler_rt/divxf3_test.zig
+++ b/lib/compiler_rt/divxf3_test.zig
@@ -40,13 +40,13 @@ fn test__divxf3(a: f80, b: f80) !void {
 
 test "divxf3" {
     // NaN / any = NaN
-    try expect__divxf3_result(math.nan(f80), 0x1.23456789abcdefp+5, 0x7fffC000000000000000);
+    try expect__divxf3_result(math.float.nan(f80), 0x1.23456789abcdefp+5, 0x7fffC000000000000000);
     // inf / any(except inf and nan) = inf
-    try expect__divxf3_result(math.inf(f80), 0x1.23456789abcdefp+5, 0x7fff8000000000000000);
+    try expect__divxf3_result(math.float.inf(f80), 0x1.23456789abcdefp+5, 0x7fff8000000000000000);
     // inf / inf = nan
-    try expect__divxf3_result(math.inf(f80), math.inf(f80), 0x7fffC000000000000000);
+    try expect__divxf3_result(math.float.inf(f80), math.float.inf(f80), 0x7fffC000000000000000);
     // inf / nan = nan
-    try expect__divxf3_result(math.inf(f80), math.nan(f80), 0x7fffC000000000000000);
+    try expect__divxf3_result(math.float.inf(f80), math.float.nan(f80), 0x7fffC000000000000000);
 
     try test__divxf3(0x1.a23b45362464523375893ab4cdefp+5, 0x1.eedcbaba3a94546558237654321fp-1);
     try test__divxf3(0x1.a2b34c56d745382f9abf2c3dfeffp-50, 0x1.ed2c3ba15935332532287654321fp-9);

--- a/lib/compiler_rt/exp.zig
+++ b/lib/compiler_rt/exp.zig
@@ -138,7 +138,7 @@ pub fn exp(x_: f64) callconv(.C) f64 {
             if (!math.isInf(x)) {
                 math.raiseOverflow();
             }
-            return math.inf(f64);
+            return math.float.inf(f64);
         }
         if (x < -708.39641853226410622) {
             // underflow if x != -inf
@@ -232,11 +232,11 @@ test "exp64" {
 }
 
 test "exp32.special" {
-    try expect(math.isPositiveInf(expf(math.inf(f32))));
-    try expect(math.isNan(expf(math.nan(f32))));
+    try expect(math.isPositiveInf(expf(math.float.inf(f32))));
+    try expect(math.isNan(expf(math.float.nan(f32))));
 }
 
 test "exp64.special" {
-    try expect(math.isPositiveInf(exp(math.inf(f64))));
-    try expect(math.isNan(exp(math.nan(f64))));
+    try expect(math.isPositiveInf(exp(math.float.inf(f64))));
+    try expect(math.isNan(exp(math.float.nan(f64))));
 }

--- a/lib/compiler_rt/exp2.zig
+++ b/lib/compiler_rt/exp2.zig
@@ -102,7 +102,7 @@ pub fn exp2(x: f64) callconv(.C) f64 {
 
     // TODO: This should be handled beneath.
     if (math.isNan(x)) {
-        return math.nan(f64);
+        return math.float.nan(f64);
     }
 
     // |x| >= 1022 or nan
@@ -110,7 +110,7 @@ pub fn exp2(x: f64) callconv(.C) f64 {
         // x >= 1024 or nan
         if (ix >= 0x40900000 and ux >> 63 == 0) {
             math.raiseOverflow();
-            return math.inf(f64);
+            return math.float.inf(f64);
         }
         // -inf or -nan
         if (ix >= 0x7FF00000) {
@@ -480,11 +480,11 @@ test "exp2_64" {
 }
 
 test "exp2_32.special" {
-    try expect(math.isPositiveInf(exp2f(math.inf(f32))));
-    try expect(math.isNan(exp2f(math.nan(f32))));
+    try expect(math.isPositiveInf(exp2f(math.float.inf(f32))));
+    try expect(math.isNan(exp2f(math.float.nan(f32))));
 }
 
 test "exp2_64.special" {
-    try expect(math.isPositiveInf(exp2(math.inf(f64))));
-    try expect(math.isNan(exp2(math.nan(f64))));
+    try expect(math.isPositiveInf(exp2(math.float.inf(f64))));
+    try expect(math.isNan(exp2(math.float.nan(f64))));
 }

--- a/lib/compiler_rt/extendf.zig
+++ b/lib/compiler_rt/extendf.zig
@@ -7,8 +7,8 @@ pub inline fn extendf(
 ) dst_t {
     const src_rep_t = std.meta.Int(.unsigned, @typeInfo(src_t).Float.bits);
     const dst_rep_t = std.meta.Int(.unsigned, @typeInfo(dst_t).Float.bits);
-    const srcSigBits = std.math.floatMantissaBits(src_t);
-    const dstSigBits = std.math.floatMantissaBits(dst_t);
+    const srcSigBits = std.math.float.mantissaBits(src_t);
+    const dstSigBits = std.math.float.mantissaBits(dst_t);
 
     // Various constants whose values follow from the type parameters.
     // Any reasonable optimizer will fold and propagate all of these.
@@ -72,9 +72,9 @@ pub inline fn extendf(
 
 pub inline fn extend_f80(comptime src_t: type, a: std.meta.Int(.unsigned, @typeInfo(src_t).Float.bits)) f80 {
     const src_rep_t = std.meta.Int(.unsigned, @typeInfo(src_t).Float.bits);
-    const src_sig_bits = std.math.floatMantissaBits(src_t);
+    const src_sig_bits = std.math.float.mantissaBits(src_t);
     const dst_int_bit = 0x8000000000000000;
-    const dst_sig_bits = std.math.floatMantissaBits(f80) - 1; // -1 for the integer bit
+    const dst_sig_bits = std.math.float.mantissaBits(f80) - 1; // -1 for the integer bit
 
     const dst_exp_bias = 16383;
 

--- a/lib/compiler_rt/extendxftf2.zig
+++ b/lib/compiler_rt/extendxftf2.zig
@@ -10,8 +10,8 @@ comptime {
 fn __extendxftf2(a: f80) callconv(.C) f128 {
     const src_int_bit: u64 = 0x8000000000000000;
     const src_sig_mask = ~src_int_bit;
-    const src_sig_bits = std.math.floatMantissaBits(f80) - 1; // -1 for the integer bit
-    const dst_sig_bits = std.math.floatMantissaBits(f128);
+    const src_sig_bits = std.math.float.mantissaBits(f80) - 1; // -1 for the integer bit
+    const dst_sig_bits = std.math.float.mantissaBits(f128);
 
     const dst_bits = @bitSizeOf(f128);
 

--- a/lib/compiler_rt/fixint_test.zig
+++ b/lib/compiler_rt/fixint_test.zig
@@ -11,7 +11,7 @@ fn test__fixint(comptime fp_t: type, comptime fixint_t: type, a: fp_t, expected:
 }
 
 test "fixint.i1" {
-    try test__fixint(f32, i1, -math.inf(f32), -1);
+    try test__fixint(f32, i1, -math.float.inf(f32), -1);
     try test__fixint(f32, i1, -math.float.max(f32), -1);
     try test__fixint(f32, i1, -2.0, -1);
     try test__fixint(f32, i1, -1.1, -1);
@@ -27,11 +27,11 @@ test "fixint.i1" {
     try test__fixint(f32, i1, 1.0, 0);
     try test__fixint(f32, i1, 2.0, 0);
     try test__fixint(f32, i1, math.float.max(f32), 0);
-    try test__fixint(f32, i1, math.inf(f32), 0);
+    try test__fixint(f32, i1, math.float.inf(f32), 0);
 }
 
 test "fixint.i2" {
-    try test__fixint(f32, i2, -math.inf(f32), -2);
+    try test__fixint(f32, i2, -math.float.inf(f32), -2);
     try test__fixint(f32, i2, -math.float.max(f32), -2);
     try test__fixint(f32, i2, -2.0, -2);
     try test__fixint(f32, i2, -1.9, -1);
@@ -48,11 +48,11 @@ test "fixint.i2" {
     try test__fixint(f32, i2, 1.0, 1);
     try test__fixint(f32, i2, 2.0, 1);
     try test__fixint(f32, i2, math.float.max(f32), 1);
-    try test__fixint(f32, i2, math.inf(f32), 1);
+    try test__fixint(f32, i2, math.float.inf(f32), 1);
 }
 
 test "fixint.i3" {
-    try test__fixint(f32, i3, -math.inf(f32), -4);
+    try test__fixint(f32, i3, -math.float.inf(f32), -4);
     try test__fixint(f32, i3, -math.float.max(f32), -4);
     try test__fixint(f32, i3, -4.0, -4);
     try test__fixint(f32, i3, -3.0, -3);
@@ -73,11 +73,11 @@ test "fixint.i3" {
     try test__fixint(f32, i3, 3.0, 3);
     try test__fixint(f32, i3, 4.0, 3);
     try test__fixint(f32, i3, math.float.max(f32), 3);
-    try test__fixint(f32, i3, math.inf(f32), 3);
+    try test__fixint(f32, i3, math.float.inf(f32), 3);
 }
 
 test "fixint.i32" {
-    try test__fixint(f64, i32, -math.inf(f64), math.minInt(i32));
+    try test__fixint(f64, i32, -math.float.inf(f64), math.minInt(i32));
     try test__fixint(f64, i32, -math.float.max(f64), math.minInt(i32));
     try test__fixint(f64, i32, @as(f64, math.minInt(i32)), math.minInt(i32));
     try test__fixint(f64, i32, @as(f64, math.minInt(i32)) + 1, math.minInt(i32) + 1);
@@ -97,11 +97,11 @@ test "fixint.i32" {
     try test__fixint(f64, i32, @as(f64, math.maxInt(i32)) - 1, math.maxInt(i32) - 1);
     try test__fixint(f64, i32, @as(f64, math.maxInt(i32)), math.maxInt(i32));
     try test__fixint(f64, i32, math.float.max(f64), math.maxInt(i32));
-    try test__fixint(f64, i32, math.inf(f64), math.maxInt(i32));
+    try test__fixint(f64, i32, math.float.inf(f64), math.maxInt(i32));
 }
 
 test "fixint.i64" {
-    try test__fixint(f64, i64, -math.inf(f64), math.minInt(i64));
+    try test__fixint(f64, i64, -math.float.inf(f64), math.minInt(i64));
     try test__fixint(f64, i64, -math.float.max(f64), math.minInt(i64));
     try test__fixint(f64, i64, @as(f64, math.minInt(i64)), math.minInt(i64));
     try test__fixint(f64, i64, @as(f64, math.minInt(i64)) + 1, math.minInt(i64));
@@ -122,11 +122,11 @@ test "fixint.i64" {
     try test__fixint(f64, i64, @as(f64, math.maxInt(i64)) - 1, math.maxInt(i64));
     try test__fixint(f64, i64, @as(f64, math.maxInt(i64)), math.maxInt(i64));
     try test__fixint(f64, i64, math.float.max(f64), math.maxInt(i64));
-    try test__fixint(f64, i64, math.inf(f64), math.maxInt(i64));
+    try test__fixint(f64, i64, math.float.inf(f64), math.maxInt(i64));
 }
 
 test "fixint.i128" {
-    try test__fixint(f64, i128, -math.inf(f64), math.minInt(i128));
+    try test__fixint(f64, i128, -math.float.inf(f64), math.minInt(i128));
     try test__fixint(f64, i128, -math.float.max(f64), math.minInt(i128));
     try test__fixint(f64, i128, @as(f64, math.minInt(i128)), math.minInt(i128));
     try test__fixint(f64, i128, @as(f64, math.minInt(i128)) + 1, math.minInt(i128));
@@ -146,5 +146,5 @@ test "fixint.i128" {
     try test__fixint(f64, i128, @as(f64, math.maxInt(i128)) - 1, math.maxInt(i128));
     try test__fixint(f64, i128, @as(f64, math.maxInt(i128)), math.maxInt(i128));
     try test__fixint(f64, i128, math.float.max(f64), math.maxInt(i128));
-    try test__fixint(f64, i128, math.inf(f64), math.maxInt(i128));
+    try test__fixint(f64, i128, math.float.inf(f64), math.maxInt(i128));
 }

--- a/lib/compiler_rt/fixint_test.zig
+++ b/lib/compiler_rt/fixint_test.zig
@@ -12,48 +12,48 @@ fn test__fixint(comptime fp_t: type, comptime fixint_t: type, a: fp_t, expected:
 
 test "fixint.i1" {
     try test__fixint(f32, i1, -math.inf(f32), -1);
-    try test__fixint(f32, i1, -math.floatMax(f32), -1);
+    try test__fixint(f32, i1, -math.float.max(f32), -1);
     try test__fixint(f32, i1, -2.0, -1);
     try test__fixint(f32, i1, -1.1, -1);
     try test__fixint(f32, i1, -1.0, -1);
     try test__fixint(f32, i1, -0.9, 0);
     try test__fixint(f32, i1, -0.1, 0);
-    try test__fixint(f32, i1, -math.floatMin(f32), 0);
+    try test__fixint(f32, i1, -math.float.min(f32), 0);
     try test__fixint(f32, i1, -0.0, 0);
     try test__fixint(f32, i1, 0.0, 0);
-    try test__fixint(f32, i1, math.floatMin(f32), 0);
+    try test__fixint(f32, i1, math.float.min(f32), 0);
     try test__fixint(f32, i1, 0.1, 0);
     try test__fixint(f32, i1, 0.9, 0);
     try test__fixint(f32, i1, 1.0, 0);
     try test__fixint(f32, i1, 2.0, 0);
-    try test__fixint(f32, i1, math.floatMax(f32), 0);
+    try test__fixint(f32, i1, math.float.max(f32), 0);
     try test__fixint(f32, i1, math.inf(f32), 0);
 }
 
 test "fixint.i2" {
     try test__fixint(f32, i2, -math.inf(f32), -2);
-    try test__fixint(f32, i2, -math.floatMax(f32), -2);
+    try test__fixint(f32, i2, -math.float.max(f32), -2);
     try test__fixint(f32, i2, -2.0, -2);
     try test__fixint(f32, i2, -1.9, -1);
     try test__fixint(f32, i2, -1.1, -1);
     try test__fixint(f32, i2, -1.0, -1);
     try test__fixint(f32, i2, -0.9, 0);
     try test__fixint(f32, i2, -0.1, 0);
-    try test__fixint(f32, i2, -math.floatMin(f32), 0);
+    try test__fixint(f32, i2, -math.float.min(f32), 0);
     try test__fixint(f32, i2, -0.0, 0);
     try test__fixint(f32, i2, 0.0, 0);
-    try test__fixint(f32, i2, math.floatMin(f32), 0);
+    try test__fixint(f32, i2, math.float.min(f32), 0);
     try test__fixint(f32, i2, 0.1, 0);
     try test__fixint(f32, i2, 0.9, 0);
     try test__fixint(f32, i2, 1.0, 1);
     try test__fixint(f32, i2, 2.0, 1);
-    try test__fixint(f32, i2, math.floatMax(f32), 1);
+    try test__fixint(f32, i2, math.float.max(f32), 1);
     try test__fixint(f32, i2, math.inf(f32), 1);
 }
 
 test "fixint.i3" {
     try test__fixint(f32, i3, -math.inf(f32), -4);
-    try test__fixint(f32, i3, -math.floatMax(f32), -4);
+    try test__fixint(f32, i3, -math.float.max(f32), -4);
     try test__fixint(f32, i3, -4.0, -4);
     try test__fixint(f32, i3, -3.0, -3);
     try test__fixint(f32, i3, -2.0, -2);
@@ -62,23 +62,23 @@ test "fixint.i3" {
     try test__fixint(f32, i3, -1.0, -1);
     try test__fixint(f32, i3, -0.9, 0);
     try test__fixint(f32, i3, -0.1, 0);
-    try test__fixint(f32, i3, -math.floatMin(f32), 0);
+    try test__fixint(f32, i3, -math.float.min(f32), 0);
     try test__fixint(f32, i3, -0.0, 0);
     try test__fixint(f32, i3, 0.0, 0);
-    try test__fixint(f32, i3, math.floatMin(f32), 0);
+    try test__fixint(f32, i3, math.float.min(f32), 0);
     try test__fixint(f32, i3, 0.1, 0);
     try test__fixint(f32, i3, 0.9, 0);
     try test__fixint(f32, i3, 1.0, 1);
     try test__fixint(f32, i3, 2.0, 2);
     try test__fixint(f32, i3, 3.0, 3);
     try test__fixint(f32, i3, 4.0, 3);
-    try test__fixint(f32, i3, math.floatMax(f32), 3);
+    try test__fixint(f32, i3, math.float.max(f32), 3);
     try test__fixint(f32, i3, math.inf(f32), 3);
 }
 
 test "fixint.i32" {
     try test__fixint(f64, i32, -math.inf(f64), math.minInt(i32));
-    try test__fixint(f64, i32, -math.floatMax(f64), math.minInt(i32));
+    try test__fixint(f64, i32, -math.float.max(f64), math.minInt(i32));
     try test__fixint(f64, i32, @as(f64, math.minInt(i32)), math.minInt(i32));
     try test__fixint(f64, i32, @as(f64, math.minInt(i32)) + 1, math.minInt(i32) + 1);
     try test__fixint(f64, i32, -2.0, -2);
@@ -87,22 +87,22 @@ test "fixint.i32" {
     try test__fixint(f64, i32, -1.0, -1);
     try test__fixint(f64, i32, -0.9, 0);
     try test__fixint(f64, i32, -0.1, 0);
-    try test__fixint(f64, i32, -@as(f64, math.floatMin(f32)), 0);
+    try test__fixint(f64, i32, -@as(f64, math.float.min(f32)), 0);
     try test__fixint(f64, i32, -0.0, 0);
     try test__fixint(f64, i32, 0.0, 0);
-    try test__fixint(f64, i32, @as(f64, math.floatMin(f32)), 0);
+    try test__fixint(f64, i32, @as(f64, math.float.min(f32)), 0);
     try test__fixint(f64, i32, 0.1, 0);
     try test__fixint(f64, i32, 0.9, 0);
     try test__fixint(f64, i32, 1.0, 1);
     try test__fixint(f64, i32, @as(f64, math.maxInt(i32)) - 1, math.maxInt(i32) - 1);
     try test__fixint(f64, i32, @as(f64, math.maxInt(i32)), math.maxInt(i32));
-    try test__fixint(f64, i32, math.floatMax(f64), math.maxInt(i32));
+    try test__fixint(f64, i32, math.float.max(f64), math.maxInt(i32));
     try test__fixint(f64, i32, math.inf(f64), math.maxInt(i32));
 }
 
 test "fixint.i64" {
     try test__fixint(f64, i64, -math.inf(f64), math.minInt(i64));
-    try test__fixint(f64, i64, -math.floatMax(f64), math.minInt(i64));
+    try test__fixint(f64, i64, -math.float.max(f64), math.minInt(i64));
     try test__fixint(f64, i64, @as(f64, math.minInt(i64)), math.minInt(i64));
     try test__fixint(f64, i64, @as(f64, math.minInt(i64)) + 1, math.minInt(i64));
     try test__fixint(f64, i64, @as(f64, math.minInt(i64) / 2), math.minInt(i64) / 2);
@@ -112,22 +112,22 @@ test "fixint.i64" {
     try test__fixint(f64, i64, -1.0, -1);
     try test__fixint(f64, i64, -0.9, 0);
     try test__fixint(f64, i64, -0.1, 0);
-    try test__fixint(f64, i64, -@as(f64, math.floatMin(f32)), 0);
+    try test__fixint(f64, i64, -@as(f64, math.float.min(f32)), 0);
     try test__fixint(f64, i64, -0.0, 0);
     try test__fixint(f64, i64, 0.0, 0);
-    try test__fixint(f64, i64, @as(f64, math.floatMin(f32)), 0);
+    try test__fixint(f64, i64, @as(f64, math.float.min(f32)), 0);
     try test__fixint(f64, i64, 0.1, 0);
     try test__fixint(f64, i64, 0.9, 0);
     try test__fixint(f64, i64, 1.0, 1);
     try test__fixint(f64, i64, @as(f64, math.maxInt(i64)) - 1, math.maxInt(i64));
     try test__fixint(f64, i64, @as(f64, math.maxInt(i64)), math.maxInt(i64));
-    try test__fixint(f64, i64, math.floatMax(f64), math.maxInt(i64));
+    try test__fixint(f64, i64, math.float.max(f64), math.maxInt(i64));
     try test__fixint(f64, i64, math.inf(f64), math.maxInt(i64));
 }
 
 test "fixint.i128" {
     try test__fixint(f64, i128, -math.inf(f64), math.minInt(i128));
-    try test__fixint(f64, i128, -math.floatMax(f64), math.minInt(i128));
+    try test__fixint(f64, i128, -math.float.max(f64), math.minInt(i128));
     try test__fixint(f64, i128, @as(f64, math.minInt(i128)), math.minInt(i128));
     try test__fixint(f64, i128, @as(f64, math.minInt(i128)) + 1, math.minInt(i128));
     try test__fixint(f64, i128, -2.0, -2);
@@ -136,15 +136,15 @@ test "fixint.i128" {
     try test__fixint(f64, i128, -1.0, -1);
     try test__fixint(f64, i128, -0.9, 0);
     try test__fixint(f64, i128, -0.1, 0);
-    try test__fixint(f64, i128, -@as(f64, math.floatMin(f32)), 0);
+    try test__fixint(f64, i128, -@as(f64, math.float.min(f32)), 0);
     try test__fixint(f64, i128, -0.0, 0);
     try test__fixint(f64, i128, 0.0, 0);
-    try test__fixint(f64, i128, @as(f64, math.floatMin(f32)), 0);
+    try test__fixint(f64, i128, @as(f64, math.float.min(f32)), 0);
     try test__fixint(f64, i128, 0.1, 0);
     try test__fixint(f64, i128, 0.9, 0);
     try test__fixint(f64, i128, 1.0, 1);
     try test__fixint(f64, i128, @as(f64, math.maxInt(i128)) - 1, math.maxInt(i128));
     try test__fixint(f64, i128, @as(f64, math.maxInt(i128)), math.maxInt(i128));
-    try test__fixint(f64, i128, math.floatMax(f64), math.maxInt(i128));
+    try test__fixint(f64, i128, math.float.max(f64), math.maxInt(i128));
     try test__fixint(f64, i128, math.inf(f64), math.maxInt(i128));
 }

--- a/lib/compiler_rt/float_from_int.zig
+++ b/lib/compiler_rt/float_from_int.zig
@@ -11,8 +11,8 @@ pub fn floatFromInt(comptime T: type, x: anytype) T {
     const inf = math.inf(T);
     const float_bits = @bitSizeOf(T);
     const int_bits = @bitSizeOf(@TypeOf(x));
-    const exp_bits = math.floatExponentBits(T);
-    const fractional_bits = math.floatFractionalBits(T);
+    const exp_bits = math.float.exponentBits(T);
+    const fractional_bits = math.float.fractionalBits(T);
     const exp_bias = math.maxInt(Int(.unsigned, exp_bits - 1));
     const implicit_bit = if (T != f80) @as(uT, 1) << fractional_bits else 0;
     const max_exp = exp_bias;
@@ -45,7 +45,7 @@ pub fn floatFromInt(comptime T: type, x: anytype) T {
     if ((int_bits > max_exp) and (exp > max_exp)) // If exponent too large, overflow to infinity
         return @bitCast(sign_bit | @as(uT, @bitCast(inf)));
 
-    result += (@as(uT, exp) + exp_bias) << math.floatMantissaBits(T);
+    result += (@as(uT, exp) + exp_bias) << math.float.mantissaBits(T);
 
     // If the result included a carry, we need to restore the explicit integer bit
     if (T == f80) result |= 1 << fractional_bits;

--- a/lib/compiler_rt/float_from_int.zig
+++ b/lib/compiler_rt/float_from_int.zig
@@ -8,7 +8,7 @@ pub fn floatFromInt(comptime T: type, x: anytype) T {
     // Any reasonable optimizer will fold and propagate all of these.
     const Z = Int(.unsigned, @bitSizeOf(@TypeOf(x)));
     const uT = Int(.unsigned, @bitSizeOf(T));
-    const inf = math.inf(T);
+    const inf = math.float.inf(T);
     const float_bits = @bitSizeOf(T);
     const int_bits = @bitSizeOf(@TypeOf(x));
     const exp_bits = math.float.exponentBits(T);

--- a/lib/compiler_rt/float_from_int_test.zig
+++ b/lib/compiler_rt/float_from_int_test.zig
@@ -228,7 +228,7 @@ test "floatuntisf" {
     try test__floatuntisf(make_uti(0x0000000000001FED, 0xCBE0000000000000), 0x1.FEDCBEp+76);
 
     // Test overflow to infinity
-    try test__floatuntisf(math.maxInt(u128), @bitCast(math.inf(f32)));
+    try test__floatuntisf(math.maxInt(u128), @bitCast(math.float.inf(f32)));
 }
 
 fn test_one_floatsidf(a: i32, expected: u64) !void {
@@ -794,7 +794,7 @@ test "conversion to f16" {
     try testing.expect(__floatunsihf(@as(u32, 0)) == 0.0);
     try testing.expect(__floatunsihf(@as(u32, 1)) == 1.0);
     try testing.expect(__floatunsihf(@as(u32, 65504)) == 65504);
-    try testing.expect(__floatunsihf(@as(u32, 65504 + (1 << 4))) == math.inf(f16));
+    try testing.expect(__floatunsihf(@as(u32, 65504 + (1 << 4))) == math.float.inf(f16));
 }
 
 test "conversion to f32" {

--- a/lib/compiler_rt/floor.zig
+++ b/lib/compiler_rt/floor.zig
@@ -95,7 +95,7 @@ pub fn floorf(x: f32) callconv(.C) f32 {
 }
 
 pub fn floor(x: f64) callconv(.C) f64 {
-    const f64_toint = 1.0 / math.floatEps(f64);
+    const f64_toint = 1.0 / math.float.eps(f64);
 
     const u: u64 = @bitCast(x);
     const e = (u >> 52) & 0x7FF;
@@ -131,7 +131,7 @@ pub fn __floorx(x: f80) callconv(.C) f80 {
 }
 
 pub fn floorq(x: f128) callconv(.C) f128 {
-    const f128_toint = 1.0 / math.floatEps(f128);
+    const f128_toint = 1.0 / math.float.eps(f128);
 
     const u: u128 = @bitCast(x);
     const e = (u >> 112) & 0x7FFF;

--- a/lib/compiler_rt/floor.zig
+++ b/lib/compiler_rt/floor.zig
@@ -197,31 +197,31 @@ test "floor128" {
 test "floor16.special" {
     try expect(__floorh(0.0) == 0.0);
     try expect(__floorh(-0.0) == -0.0);
-    try expect(math.isPositiveInf(__floorh(math.inf(f16))));
-    try expect(math.isNegativeInf(__floorh(-math.inf(f16))));
-    try expect(math.isNan(__floorh(math.nan(f16))));
+    try expect(math.isPositiveInf(__floorh(math.float.inf(f16))));
+    try expect(math.isNegativeInf(__floorh(-math.float.inf(f16))));
+    try expect(math.isNan(__floorh(math.float.nan(f16))));
 }
 
 test "floor32.special" {
     try expect(floorf(0.0) == 0.0);
     try expect(floorf(-0.0) == -0.0);
-    try expect(math.isPositiveInf(floorf(math.inf(f32))));
-    try expect(math.isNegativeInf(floorf(-math.inf(f32))));
-    try expect(math.isNan(floorf(math.nan(f32))));
+    try expect(math.isPositiveInf(floorf(math.float.inf(f32))));
+    try expect(math.isNegativeInf(floorf(-math.float.inf(f32))));
+    try expect(math.isNan(floorf(math.float.nan(f32))));
 }
 
 test "floor64.special" {
     try expect(floor(0.0) == 0.0);
     try expect(floor(-0.0) == -0.0);
-    try expect(math.isPositiveInf(floor(math.inf(f64))));
-    try expect(math.isNegativeInf(floor(-math.inf(f64))));
-    try expect(math.isNan(floor(math.nan(f64))));
+    try expect(math.isPositiveInf(floor(math.float.inf(f64))));
+    try expect(math.isNegativeInf(floor(-math.float.inf(f64))));
+    try expect(math.isNan(floor(math.float.nan(f64))));
 }
 
 test "floor128.special" {
     try expect(floorq(0.0) == 0.0);
     try expect(floorq(-0.0) == -0.0);
-    try expect(math.isPositiveInf(floorq(math.inf(f128))));
-    try expect(math.isNegativeInf(floorq(-math.inf(f128))));
-    try expect(math.isNan(floorq(math.nan(f128))));
+    try expect(math.isPositiveInf(floorq(math.float.inf(f128))));
+    try expect(math.isNegativeInf(floorq(-math.float.inf(f128))));
+    try expect(math.isNan(floorq(math.float.nan(f128))));
 }

--- a/lib/compiler_rt/fma.zig
+++ b/lib/compiler_rt/fma.zig
@@ -72,7 +72,7 @@ pub fn fma(x: f64, y: f64, z: f64) callconv(.C) f64 {
     if (spread <= 53 * 2) {
         zs = math.scalbn(zs, -spread);
     } else {
-        zs = math.copysign(math.floatMin(f64), zs);
+        zs = math.copysign(math.float.min(f64), zs);
     }
 
     const xy = dd_mul(xs, ys);
@@ -131,7 +131,7 @@ pub fn fmaq(x: f128, y: f128, z: f128) callconv(.C) f128 {
     if (spread <= 113 * 2) {
         zs = math.scalbn(zs, -spread);
     } else {
-        zs = math.copysign(math.floatMin(f128), zs);
+        zs = math.copysign(math.float.min(f128), zs);
     }
 
     const xy = dd_mul128(xs, ys);

--- a/lib/compiler_rt/fmax.zig
+++ b/lib/compiler_rt/fmax.zig
@@ -59,7 +59,7 @@ inline fn generic_fmax(comptime T: type, x: T, y: T) T {
 
 test "generic_fmax" {
     inline for ([_]type{ f32, f64, c_longdouble, f80, f128 }) |T| {
-        const nan_val = math.nan(T);
+        const nan_val = math.float.nan(T);
 
         try std.testing.expect(math.isNan(generic_fmax(T, nan_val, nan_val)));
         try std.testing.expectEqual(@as(T, 1.0), generic_fmax(T, nan_val, 1.0));

--- a/lib/compiler_rt/fmin.zig
+++ b/lib/compiler_rt/fmin.zig
@@ -59,7 +59,7 @@ inline fn generic_fmin(comptime T: type, x: T, y: T) T {
 
 test "generic_fmin" {
     inline for ([_]type{ f32, f64, c_longdouble, f80, f128 }) |T| {
-        const nan_val = math.nan(T);
+        const nan_val = math.float.nan(T);
 
         try std.testing.expect(math.isNan(generic_fmin(T, nan_val, nan_val)));
         try std.testing.expectEqual(@as(T, 1.0), generic_fmin(T, nan_val, 1.0));

--- a/lib/compiler_rt/fmod.zig
+++ b/lib/compiler_rt/fmod.zig
@@ -39,9 +39,9 @@ pub fn __fmodx(a: f80, b: f80) callconv(.C) f80 {
     const T = f80;
     const Z = std.meta.Int(.unsigned, @bitSizeOf(T));
 
-    const significandBits = math.floatMantissaBits(T);
-    const fractionalBits = math.floatFractionalBits(T);
-    const exponentBits = math.floatExponentBits(T);
+    const significandBits = math.float.mantissaBits(T);
+    const fractionalBits = math.float.fractionalBits(T);
+    const exponentBits = math.float.exponentBits(T);
 
     const signBit = (@as(Z, 1) << (significandBits + exponentBits));
     const maxExponent = ((1 << exponentBits) - 1);

--- a/lib/compiler_rt/fmod.zig
+++ b/lib/compiler_rt/fmod.zig
@@ -346,8 +346,8 @@ inline fn generic_fmod(comptime T: type, x: T, y: T) T {
 }
 
 test "fmodf" {
-    const nan_val = math.nan(f32);
-    const inf_val = math.inf(f32);
+    const nan_val = math.float.nan(f32);
+    const inf_val = math.float.inf(f32);
 
     try std.testing.expect(math.isNan(fmodf(nan_val, 1.0)));
     try std.testing.expect(math.isNan(fmodf(1.0, nan_val)));
@@ -365,8 +365,8 @@ test "fmodf" {
 }
 
 test "fmod" {
-    const nan_val = math.nan(f64);
-    const inf_val = math.inf(f64);
+    const nan_val = math.float.nan(f64);
+    const inf_val = math.float.inf(f64);
 
     try std.testing.expect(math.isNan(fmod(nan_val, 1.0)));
     try std.testing.expect(math.isNan(fmod(1.0, nan_val)));

--- a/lib/compiler_rt/fmodq_test.zig
+++ b/lib/compiler_rt/fmodq_test.zig
@@ -8,17 +8,17 @@ fn test_fmodq(a: f128, b: f128, exp: f128) !void {
 }
 
 fn test_fmodq_nans() !void {
-    try testing.expect(std.math.isNan(fmod.fmodq(1.0, std.math.nan(f128))));
-    try testing.expect(std.math.isNan(fmod.fmodq(1.0, -std.math.nan(f128))));
-    try testing.expect(std.math.isNan(fmod.fmodq(std.math.nan(f128), 1.0)));
-    try testing.expect(std.math.isNan(fmod.fmodq(-std.math.nan(f128), 1.0)));
+    try testing.expect(std.math.isNan(fmod.fmodq(1.0, std.math.float.nan(f128))));
+    try testing.expect(std.math.isNan(fmod.fmodq(1.0, -std.math.float.nan(f128))));
+    try testing.expect(std.math.isNan(fmod.fmodq(std.math.float.nan(f128), 1.0)));
+    try testing.expect(std.math.isNan(fmod.fmodq(-std.math.float.nan(f128), 1.0)));
 }
 
 fn test_fmodq_infs() !void {
-    try testing.expect(fmod.fmodq(1.0, std.math.inf(f128)) == 1.0);
-    try testing.expect(fmod.fmodq(1.0, -std.math.inf(f128)) == 1.0);
-    try testing.expect(std.math.isNan(fmod.fmodq(std.math.inf(f128), 1.0)));
-    try testing.expect(std.math.isNan(fmod.fmodq(-std.math.inf(f128), 1.0)));
+    try testing.expect(fmod.fmodq(1.0, std.math.float.inf(f128)) == 1.0);
+    try testing.expect(fmod.fmodq(1.0, -std.math.float.inf(f128)) == 1.0);
+    try testing.expect(std.math.isNan(fmod.fmodq(std.math.float.inf(f128), 1.0)));
+    try testing.expect(std.math.isNan(fmod.fmodq(-std.math.float.inf(f128), 1.0)));
 }
 
 test "fmodq" {

--- a/lib/compiler_rt/fmodx_test.zig
+++ b/lib/compiler_rt/fmodx_test.zig
@@ -9,17 +9,17 @@ fn test_fmodx(a: f80, b: f80, exp: f80) !void {
 }
 
 fn test_fmodx_nans() !void {
-    try testing.expect(std.math.isNan(fmod.__fmodx(1.0, std.math.nan(f80))));
-    try testing.expect(std.math.isNan(fmod.__fmodx(1.0, -std.math.nan(f80))));
-    try testing.expect(std.math.isNan(fmod.__fmodx(std.math.nan(f80), 1.0)));
-    try testing.expect(std.math.isNan(fmod.__fmodx(-std.math.nan(f80), 1.0)));
+    try testing.expect(std.math.isNan(fmod.__fmodx(1.0, std.math.float.nan(f80))));
+    try testing.expect(std.math.isNan(fmod.__fmodx(1.0, -std.math.float.nan(f80))));
+    try testing.expect(std.math.isNan(fmod.__fmodx(std.math.float.nan(f80), 1.0)));
+    try testing.expect(std.math.isNan(fmod.__fmodx(-std.math.float.nan(f80), 1.0)));
 }
 
 fn test_fmodx_infs() !void {
-    try testing.expect(fmod.__fmodx(1.0, std.math.inf(f80)) == 1.0);
-    try testing.expect(fmod.__fmodx(1.0, -std.math.inf(f80)) == 1.0);
-    try testing.expect(std.math.isNan(fmod.__fmodx(std.math.inf(f80), 1.0)));
-    try testing.expect(std.math.isNan(fmod.__fmodx(-std.math.inf(f80), 1.0)));
+    try testing.expect(fmod.__fmodx(1.0, std.math.float.inf(f80)) == 1.0);
+    try testing.expect(fmod.__fmodx(1.0, -std.math.float.inf(f80)) == 1.0);
+    try testing.expect(std.math.isNan(fmod.__fmodx(std.math.float.inf(f80), 1.0)));
+    try testing.expect(std.math.isNan(fmod.__fmodx(-std.math.float.inf(f80), 1.0)));
 }
 
 test "fmodx" {

--- a/lib/compiler_rt/int_from_float.zig
+++ b/lib/compiler_rt/int_from_float.zig
@@ -7,9 +7,9 @@ pub inline fn intFromFloat(comptime I: type, a: anytype) I {
     const float_bits = @typeInfo(F).Float.bits;
     const int_bits = @typeInfo(I).Int.bits;
     const rep_t = Int(.unsigned, float_bits);
-    const sig_bits = math.floatMantissaBits(F);
-    const exp_bits = math.floatExponentBits(F);
-    const fractional_bits = math.floatFractionalBits(F);
+    const sig_bits = math.float.mantissaBits(F);
+    const exp_bits = math.float.exponentBits(F);
+    const fractional_bits = math.float.fractionalBits(F);
 
     const implicit_bit = if (F != f80) (@as(rep_t, 1) << sig_bits) else 0;
     const max_exp = (1 << (exp_bits - 1));

--- a/lib/compiler_rt/int_from_float_test.zig
+++ b/lib/compiler_rt/int_from_float_test.zig
@@ -340,7 +340,7 @@ test "fixunssfti" {
     try test__fixunssfti(-0x1.FFFFFEp+126, 0x0000000000000000);
     try test__fixunssfti(-0x1.FFFFFCp+126, 0x0000000000000000);
     try test__fixunssfti(math.float.max(f32), 0xffffff00000000000000000000000000);
-    try test__fixunssfti(math.inf(f32), math.maxInt(u128));
+    try test__fixunssfti(math.float.inf(f32), math.maxInt(u128));
 }
 
 fn test__fixdfsi(a: f64, expected: i32) !void {
@@ -717,7 +717,7 @@ test "fixtfsi" {
 }
 
 test "fixunstfsi" {
-    try test__fixunstfsi(math.inf(f128), 0xffffffff);
+    try test__fixunstfsi(math.float.inf(f128), 0xffffffff);
     try test__fixunstfsi(0, 0x0);
     try test__fixunstfsi(0x1.23456789abcdefp+5, 0x24);
     try test__fixunstfsi(0x1.23456789abcdefp-3, 0x0);
@@ -908,7 +908,7 @@ test "fixtfti" {
 }
 
 test "fixunstfti" {
-    try test__fixunstfti(math.inf(f128), 0xffffffffffffffffffffffffffffffff);
+    try test__fixunstfti(math.float.inf(f128), 0xffffffffffffffffffffffffffffffff);
 
     try test__fixunstfti(0.0, 0);
 
@@ -936,7 +936,7 @@ fn test__fixunshfti(a: f16, expected: u128) !void {
 }
 
 test "fixunshfti for f16" {
-    try test__fixunshfti(math.inf(f16), math.maxInt(u128));
+    try test__fixunshfti(math.float.inf(f16), math.maxInt(u128));
     try test__fixunshfti(math.float.max(f16), 65504);
 }
 
@@ -946,7 +946,7 @@ fn test__fixunsxfti(a: f80, expected: u128) !void {
 }
 
 test "fixunsxfti for f80" {
-    try test__fixunsxfti(math.inf(f80), math.maxInt(u128));
+    try test__fixunsxfti(math.float.inf(f80), math.maxInt(u128));
     try test__fixunsxfti(math.float.max(f80), math.maxInt(u128));
     try test__fixunsxfti(math.maxInt(u64), math.maxInt(u64));
 }

--- a/lib/compiler_rt/int_from_float_test.zig
+++ b/lib/compiler_rt/int_from_float_test.zig
@@ -41,7 +41,7 @@ fn test__fixunssfsi(a: f32, expected: u32) !void {
 }
 
 test "fixsfsi" {
-    try test__fixsfsi(-math.floatMax(f32), math.minInt(i32));
+    try test__fixsfsi(-math.float.max(f32), math.minInt(i32));
 
     try test__fixsfsi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i32));
     try test__fixsfsi(-0x1.FFFFFFFFFFFFFp+1023, -0x80000000);
@@ -70,9 +70,9 @@ test "fixsfsi" {
     try test__fixsfsi(-0.99, 0);
     try test__fixsfsi(-0.5, 0);
 
-    try test__fixsfsi(-math.floatMin(f32), 0);
+    try test__fixsfsi(-math.float.min(f32), 0);
     try test__fixsfsi(0.0, 0);
-    try test__fixsfsi(math.floatMin(f32), 0);
+    try test__fixsfsi(math.float.min(f32), 0);
     try test__fixsfsi(0.5, 0);
     try test__fixsfsi(0.99, 0);
     try test__fixsfsi(1.0, 1);
@@ -101,7 +101,7 @@ test "fixsfsi" {
     try test__fixsfsi(0x1.FFFFFFFFFFFFFp+1023, 0x7FFFFFFF);
     try test__fixsfsi(0x1.FFFFFFFFFFFFFp+1023, math.maxInt(i32));
 
-    try test__fixsfsi(math.floatMax(f32), math.maxInt(i32));
+    try test__fixsfsi(math.float.max(f32), math.maxInt(i32));
 }
 
 test "fixunssfsi" {
@@ -144,7 +144,7 @@ fn test__fixunssfdi(a: f32, expected: u64) !void {
 }
 
 test "fixsfdi" {
-    try test__fixsfdi(-math.floatMax(f32), math.minInt(i64));
+    try test__fixsfdi(-math.float.max(f32), math.minInt(i64));
 
     try test__fixsfdi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i64));
     try test__fixsfdi(-0x1.FFFFFFFFFFFFFp+1023, -0x8000000000000000);
@@ -168,9 +168,9 @@ test "fixsfdi" {
     try test__fixsfdi(-1.0, -1);
     try test__fixsfdi(-0.99, 0);
     try test__fixsfdi(-0.5, 0);
-    try test__fixsfdi(-math.floatMin(f32), 0);
+    try test__fixsfdi(-math.float.min(f32), 0);
     try test__fixsfdi(0.0, 0);
-    try test__fixsfdi(math.floatMin(f32), 0);
+    try test__fixsfdi(math.float.min(f32), 0);
     try test__fixsfdi(0.5, 0);
     try test__fixsfdi(0.99, 0);
     try test__fixsfdi(1.0, 1);
@@ -195,7 +195,7 @@ test "fixsfdi" {
     try test__fixsfdi(0x1.FFFFFFFFFFFFFp+1023, 0x7FFFFFFFFFFFFFFF);
     try test__fixsfdi(0x1.FFFFFFFFFFFFFp+1023, math.maxInt(i64));
 
-    try test__fixsfdi(math.floatMax(f32), math.maxInt(i64));
+    try test__fixsfdi(math.float.max(f32), math.maxInt(i64));
 }
 
 test "fixunssfdi" {
@@ -237,7 +237,7 @@ fn test__fixunssfti(a: f32, expected: u128) !void {
 }
 
 test "fixsfti" {
-    try test__fixsfti(-math.floatMax(f32), math.minInt(i128));
+    try test__fixsfti(-math.float.max(f32), math.minInt(i128));
 
     try test__fixsfti(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i128));
     try test__fixsfti(-0x1.FFFFFFFFFFFFFp+1023, -0x80000000000000000000000000000000);
@@ -269,9 +269,9 @@ test "fixsfti" {
     try test__fixsfti(-1.0, -1);
     try test__fixsfti(-0.99, 0);
     try test__fixsfti(-0.5, 0);
-    try test__fixsfti(-math.floatMin(f32), 0);
+    try test__fixsfti(-math.float.min(f32), 0);
     try test__fixsfti(0.0, 0);
-    try test__fixsfti(math.floatMin(f32), 0);
+    try test__fixsfti(math.float.min(f32), 0);
     try test__fixsfti(0.5, 0);
     try test__fixsfti(0.99, 0);
     try test__fixsfti(1.0, 1);
@@ -304,7 +304,7 @@ test "fixsfti" {
     try test__fixsfti(0x1.FFFFFFFFFFFFFp+1023, 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
     try test__fixsfti(0x1.FFFFFFFFFFFFFp+1023, math.maxInt(i128));
 
-    try test__fixsfti(math.floatMax(f32), math.maxInt(i128));
+    try test__fixsfti(math.float.max(f32), math.maxInt(i128));
 }
 
 test "fixunssfti" {
@@ -339,7 +339,7 @@ test "fixunssfti" {
     try test__fixunssfti(-0x1.FFFFFCp+62, 0x0000000000000000);
     try test__fixunssfti(-0x1.FFFFFEp+126, 0x0000000000000000);
     try test__fixunssfti(-0x1.FFFFFCp+126, 0x0000000000000000);
-    try test__fixunssfti(math.floatMax(f32), 0xffffff00000000000000000000000000);
+    try test__fixunssfti(math.float.max(f32), 0xffffff00000000000000000000000000);
     try test__fixunssfti(math.inf(f32), math.maxInt(u128));
 }
 
@@ -354,7 +354,7 @@ fn test__fixunsdfsi(a: f64, expected: u32) !void {
 }
 
 test "fixdfsi" {
-    try test__fixdfsi(-math.floatMax(f64), math.minInt(i32));
+    try test__fixdfsi(-math.float.max(f64), math.minInt(i32));
 
     try test__fixdfsi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i32));
     try test__fixdfsi(-0x1.FFFFFFFFFFFFFp+1023, -0x80000000);
@@ -381,9 +381,9 @@ test "fixdfsi" {
     try test__fixdfsi(-1.0, -1);
     try test__fixdfsi(-0.99, 0);
     try test__fixdfsi(-0.5, 0);
-    try test__fixdfsi(-math.floatMin(f64), 0);
+    try test__fixdfsi(-math.float.min(f64), 0);
     try test__fixdfsi(0.0, 0);
-    try test__fixdfsi(math.floatMin(f64), 0);
+    try test__fixdfsi(math.float.min(f64), 0);
     try test__fixdfsi(0.5, 0);
     try test__fixdfsi(0.99, 0);
     try test__fixdfsi(1.0, 1);
@@ -411,7 +411,7 @@ test "fixdfsi" {
     try test__fixdfsi(0x1.FFFFFFFFFFFFFp+1023, 0x7FFFFFFF);
     try test__fixdfsi(0x1.FFFFFFFFFFFFFp+1023, math.maxInt(i32));
 
-    try test__fixdfsi(math.floatMax(f64), math.maxInt(i32));
+    try test__fixdfsi(math.float.max(f64), math.maxInt(i32));
 }
 
 test "fixunsdfsi" {
@@ -457,7 +457,7 @@ fn test__fixunsdfdi(a: f64, expected: u64) !void {
 }
 
 test "fixdfdi" {
-    try test__fixdfdi(-math.floatMax(f64), math.minInt(i64));
+    try test__fixdfdi(-math.float.max(f64), math.minInt(i64));
 
     try test__fixdfdi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i64));
     try test__fixdfdi(-0x1.FFFFFFFFFFFFFp+1023, -0x8000000000000000);
@@ -480,9 +480,9 @@ test "fixdfdi" {
     try test__fixdfdi(-1.0, -1);
     try test__fixdfdi(-0.99, 0);
     try test__fixdfdi(-0.5, 0);
-    try test__fixdfdi(-math.floatMin(f64), 0);
+    try test__fixdfdi(-math.float.min(f64), 0);
     try test__fixdfdi(0.0, 0);
-    try test__fixdfdi(math.floatMin(f64), 0);
+    try test__fixdfdi(math.float.min(f64), 0);
     try test__fixdfdi(0.5, 0);
     try test__fixdfdi(0.99, 0);
     try test__fixdfdi(1.0, 1);
@@ -506,7 +506,7 @@ test "fixdfdi" {
     try test__fixdfdi(0x1.FFFFFFFFFFFFFp+1023, 0x7FFFFFFFFFFFFFFF);
     try test__fixdfdi(0x1.FFFFFFFFFFFFFp+1023, math.maxInt(i64));
 
-    try test__fixdfdi(math.floatMax(f64), math.maxInt(i64));
+    try test__fixdfdi(math.float.max(f64), math.maxInt(i64));
 }
 
 test "fixunsdfdi" {
@@ -552,7 +552,7 @@ fn test__fixunsdfti(a: f64, expected: u128) !void {
 }
 
 test "fixdfti" {
-    try test__fixdfti(-math.floatMax(f64), math.minInt(i128));
+    try test__fixdfti(-math.float.max(f64), math.minInt(i128));
 
     try test__fixdfti(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i128));
     try test__fixdfti(-0x1.FFFFFFFFFFFFFp+1023, -0x80000000000000000000000000000000);
@@ -575,9 +575,9 @@ test "fixdfti" {
     try test__fixdfti(-1.0, -1);
     try test__fixdfti(-0.99, 0);
     try test__fixdfti(-0.5, 0);
-    try test__fixdfti(-math.floatMin(f64), 0);
+    try test__fixdfti(-math.float.min(f64), 0);
     try test__fixdfti(0.0, 0);
-    try test__fixdfti(math.floatMin(f64), 0);
+    try test__fixdfti(math.float.min(f64), 0);
     try test__fixdfti(0.5, 0);
     try test__fixdfti(0.99, 0);
     try test__fixdfti(1.0, 1);
@@ -601,7 +601,7 @@ test "fixdfti" {
     try test__fixdfti(0x1.FFFFFFFFFFFFFp+1023, 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
     try test__fixdfti(0x1.FFFFFFFFFFFFFp+1023, math.maxInt(i128));
 
-    try test__fixdfti(math.floatMax(f64), math.maxInt(i128));
+    try test__fixdfti(math.float.max(f64), math.maxInt(i128));
 }
 
 test "fixunsdfti" {
@@ -654,7 +654,7 @@ fn test__fixunstfsi(a: f128, expected: u32) !void {
 }
 
 test "fixtfsi" {
-    try test__fixtfsi(-math.floatMax(f128), math.minInt(i32));
+    try test__fixtfsi(-math.float.max(f128), math.minInt(i32));
 
     try test__fixtfsi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i32));
     try test__fixtfsi(-0x1.FFFFFFFFFFFFFp+1023, -0x80000000);
@@ -682,9 +682,9 @@ test "fixtfsi" {
     try test__fixtfsi(-1.0, -1);
     try test__fixtfsi(-0.99, 0);
     try test__fixtfsi(-0.5, 0);
-    try test__fixtfsi(-math.floatMin(f32), 0);
+    try test__fixtfsi(-math.float.min(f32), 0);
     try test__fixtfsi(0.0, 0);
-    try test__fixtfsi(math.floatMin(f32), 0);
+    try test__fixtfsi(math.float.min(f32), 0);
     try test__fixtfsi(0.5, 0);
     try test__fixtfsi(0.99, 0);
     try test__fixtfsi(1.0, 1);
@@ -713,7 +713,7 @@ test "fixtfsi" {
     try test__fixtfsi(0x1.FFFFFFFFFFFFFp+1023, 0x7FFFFFFF);
     try test__fixtfsi(0x1.FFFFFFFFFFFFFp+1023, math.maxInt(i32));
 
-    try test__fixtfsi(math.floatMax(f128), math.maxInt(i32));
+    try test__fixtfsi(math.float.max(f128), math.maxInt(i32));
 }
 
 test "fixunstfsi" {
@@ -740,7 +740,7 @@ fn test__fixunstfdi(a: f128, expected: u64) !void {
 }
 
 test "fixtfdi" {
-    try test__fixtfdi(-math.floatMax(f128), math.minInt(i64));
+    try test__fixtfdi(-math.float.max(f128), math.minInt(i64));
 
     try test__fixtfdi(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i64));
     try test__fixtfdi(-0x1.FFFFFFFFFFFFFp+1023, -0x8000000000000000);
@@ -768,9 +768,9 @@ test "fixtfdi" {
     try test__fixtfdi(-1.0, -1);
     try test__fixtfdi(-0.99, 0);
     try test__fixtfdi(-0.5, 0);
-    try test__fixtfdi(-math.floatMin(f64), 0);
+    try test__fixtfdi(-math.float.min(f64), 0);
     try test__fixtfdi(0.0, 0);
-    try test__fixtfdi(math.floatMin(f64), 0);
+    try test__fixtfdi(math.float.min(f64), 0);
     try test__fixtfdi(0.5, 0);
     try test__fixtfdi(0.99, 0);
     try test__fixtfdi(1.0, 1);
@@ -799,7 +799,7 @@ test "fixtfdi" {
     try test__fixtfdi(0x1.FFFFFFFFFFFFFp+1023, 0x7FFFFFFFFFFFFFFF);
     try test__fixtfdi(0x1.FFFFFFFFFFFFFp+1023, math.maxInt(i64));
 
-    try test__fixtfdi(math.floatMax(f128), math.maxInt(i64));
+    try test__fixtfdi(math.float.max(f128), math.maxInt(i64));
 }
 
 test "fixunstfdi" {
@@ -855,7 +855,7 @@ fn test__fixunstfti(a: f128, expected: u128) !void {
 }
 
 test "fixtfti" {
-    try test__fixtfti(-math.floatMax(f128), math.minInt(i128));
+    try test__fixtfti(-math.float.max(f128), math.minInt(i128));
 
     try test__fixtfti(-0x1.FFFFFFFFFFFFFp+1023, math.minInt(i128));
     try test__fixtfti(-0x1.FFFFFFFFFFFFFp+1023, -0x80000000000000000000000000000000);
@@ -878,9 +878,9 @@ test "fixtfti" {
     try test__fixtfti(-1.0, -1);
     try test__fixtfti(-0.99, 0);
     try test__fixtfti(-0.5, 0);
-    try test__fixtfti(-math.floatMin(f128), 0);
+    try test__fixtfti(-math.float.min(f128), 0);
     try test__fixtfti(0.0, 0);
-    try test__fixtfti(math.floatMin(f128), 0);
+    try test__fixtfti(math.float.min(f128), 0);
     try test__fixtfti(0.5, 0);
     try test__fixtfti(0.99, 0);
     try test__fixtfti(1.0, 1);
@@ -904,7 +904,7 @@ test "fixtfti" {
     try test__fixtfti(0x1.FFFFFFFFFFFFFp+1023, 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
     try test__fixtfti(0x1.FFFFFFFFFFFFFp+1023, math.maxInt(i128));
 
-    try test__fixtfti(math.floatMax(f128), math.maxInt(i128));
+    try test__fixtfti(math.float.max(f128), math.maxInt(i128));
 }
 
 test "fixunstfti" {
@@ -937,7 +937,7 @@ fn test__fixunshfti(a: f16, expected: u128) !void {
 
 test "fixunshfti for f16" {
     try test__fixunshfti(math.inf(f16), math.maxInt(u128));
-    try test__fixunshfti(math.floatMax(f16), 65504);
+    try test__fixunshfti(math.float.max(f16), 65504);
 }
 
 fn test__fixunsxfti(a: f80, expected: u128) !void {
@@ -947,6 +947,6 @@ fn test__fixunsxfti(a: f80, expected: u128) !void {
 
 test "fixunsxfti for f80" {
     try test__fixunsxfti(math.inf(f80), math.maxInt(u128));
-    try test__fixunsxfti(math.floatMax(f80), math.maxInt(u128));
+    try test__fixunsxfti(math.float.max(f80), math.maxInt(u128));
     try test__fixunsxfti(math.maxInt(u64), math.maxInt(u64));
 }

--- a/lib/compiler_rt/log.zig
+++ b/lib/compiler_rt/log.zig
@@ -46,11 +46,11 @@ pub fn logf(x_: f32) callconv(.C) f32 {
     if (ix < 0x00800000 or ix >> 31 != 0) {
         // log(+-0) = -inf
         if (ix << 1 == 0) {
-            return -math.inf(f32);
+            return -math.float.inf(f32);
         }
         // log(-#) = nan
         if (ix >> 31 != 0) {
-            return math.nan(f32);
+            return math.float.nan(f32);
         }
 
         // subnormal, scale x
@@ -101,11 +101,11 @@ pub fn log(x_: f64) callconv(.C) f64 {
     if (hx < 0x00100000 or hx >> 31 != 0) {
         // log(+-0) = -inf
         if (ix << 1 == 0) {
-            return -math.inf(f64);
+            return -math.float.inf(f64);
         }
         // log(-#) = nan
         if (hx >> 31 != 0) {
-            return math.nan(f64);
+            return math.float.nan(f64);
         }
 
         // subnormal, scale x
@@ -182,15 +182,15 @@ test "ln64" {
 }
 
 test "ln32.special" {
-    try testing.expect(math.isPositiveInf(logf(math.inf(f32))));
+    try testing.expect(math.isPositiveInf(logf(math.float.inf(f32))));
     try testing.expect(math.isNegativeInf(logf(0.0)));
     try testing.expect(math.isNan(logf(-1.0)));
-    try testing.expect(math.isNan(logf(math.nan(f32))));
+    try testing.expect(math.isNan(logf(math.float.nan(f32))));
 }
 
 test "ln64.special" {
-    try testing.expect(math.isPositiveInf(log(math.inf(f64))));
+    try testing.expect(math.isPositiveInf(log(math.float.inf(f64))));
     try testing.expect(math.isNegativeInf(log(0.0)));
     try testing.expect(math.isNan(log(-1.0)));
-    try testing.expect(math.isNan(log(math.nan(f64))));
+    try testing.expect(math.isNan(log(math.float.nan(f64))));
 }

--- a/lib/compiler_rt/log10.zig
+++ b/lib/compiler_rt/log10.zig
@@ -50,11 +50,11 @@ pub fn log10f(x_: f32) callconv(.C) f32 {
     if (ix < 0x00800000 or ix >> 31 != 0) {
         // log(+-0) = -inf
         if (ix << 1 == 0) {
-            return -math.inf(f32);
+            return -math.float.inf(f32);
         }
         // log(-#) = nan
         if (ix >> 31 != 0) {
-            return math.nan(f32);
+            return math.float.nan(f32);
         }
 
         k -= 25;
@@ -112,11 +112,11 @@ pub fn log10(x_: f64) callconv(.C) f64 {
     if (hx < 0x00100000 or hx >> 31 != 0) {
         // log(+-0) = -inf
         if (ix << 1 == 0) {
-            return -math.inf(f64);
+            return -math.float.inf(f64);
         }
         // log(-#) = nan
         if (hx >> 31 != 0) {
-            return math.nan(f64);
+            return math.float.nan(f64);
         }
 
         // subnormal, scale x
@@ -210,15 +210,15 @@ test "log10_64" {
 }
 
 test "log10_32.special" {
-    try testing.expect(math.isPositiveInf(log10f(math.inf(f32))));
+    try testing.expect(math.isPositiveInf(log10f(math.float.inf(f32))));
     try testing.expect(math.isNegativeInf(log10f(0.0)));
     try testing.expect(math.isNan(log10f(-1.0)));
-    try testing.expect(math.isNan(log10f(math.nan(f32))));
+    try testing.expect(math.isNan(log10f(math.float.nan(f32))));
 }
 
 test "log10_64.special" {
-    try testing.expect(math.isPositiveInf(log10(math.inf(f64))));
+    try testing.expect(math.isPositiveInf(log10(math.float.inf(f64))));
     try testing.expect(math.isNegativeInf(log10(0.0)));
     try testing.expect(math.isNan(log10(-1.0)));
-    try testing.expect(math.isNan(log10(math.nan(f64))));
+    try testing.expect(math.isNan(log10(math.float.nan(f64))));
 }

--- a/lib/compiler_rt/log2.zig
+++ b/lib/compiler_rt/log2.zig
@@ -48,11 +48,11 @@ pub fn log2f(x_: f32) callconv(.C) f32 {
     if (ix < 0x00800000 or ix >> 31 != 0) {
         // log(+-0) = -inf
         if (ix << 1 == 0) {
-            return -math.inf(f32);
+            return -math.float.inf(f32);
         }
         // log(-#) = nan
         if (ix >> 31 != 0) {
-            return math.nan(f32);
+            return math.float.nan(f32);
         }
 
         k -= 25;
@@ -106,11 +106,11 @@ pub fn log2(x_: f64) callconv(.C) f64 {
     if (hx < 0x00100000 or hx >> 31 != 0) {
         // log(+-0) = -inf
         if (ix << 1 == 0) {
-            return -math.inf(f64);
+            return -math.float.inf(f64);
         }
         // log(-#) = nan
         if (hx >> 31 != 0) {
-            return math.nan(f64);
+            return math.float.nan(f64);
         }
 
         // subnormal, scale x
@@ -200,15 +200,15 @@ test "log2_64" {
 }
 
 test "log2_32.special" {
-    try expect(math.isPositiveInf(log2f(math.inf(f32))));
+    try expect(math.isPositiveInf(log2f(math.float.inf(f32))));
     try expect(math.isNegativeInf(log2f(0.0)));
     try expect(math.isNan(log2f(-1.0)));
-    try expect(math.isNan(log2f(math.nan(f32))));
+    try expect(math.isNan(log2f(math.float.nan(f32))));
 }
 
 test "log2_64.special" {
-    try expect(math.isPositiveInf(log2(math.inf(f64))));
+    try expect(math.isPositiveInf(log2(math.float.inf(f64))));
     try expect(math.isNegativeInf(log2(0.0)));
     try expect(math.isNan(log2(-1.0)));
-    try expect(math.isNan(log2(math.nan(f64))));
+    try expect(math.isNan(log2(math.float.nan(f64))));
 }

--- a/lib/compiler_rt/mulc3.zig
+++ b/lib/compiler_rt/mulc3.zig
@@ -70,8 +70,8 @@ pub inline fn mulc3(comptime T: type, a_in: T, b_in: T, c_in: T, d_in: T) Comple
         }
         if (recalc) {
             return .{
-                .real = std.math.inf(T) * (a * c - b * d),
-                .imag = std.math.inf(T) * (a * d + b * c),
+                .real = std.math.float.inf(T) * (a * c - b * d),
+                .imag = std.math.float.inf(T) * (a * d + b * c),
             };
         }
     }

--- a/lib/compiler_rt/mulc3_test.zig
+++ b/lib/compiler_rt/mulc3_test.zig
@@ -41,25 +41,25 @@ fn testMul(comptime T: type, comptime f: fn (T, T, T, T) callconv(.C) Complex(T)
     {
         // if one operand is an infinity and the other operand is a nonzero finite number or an infinity,
         // then the result of the * operator is an infinity;
-        const a: T = math.inf(T);
-        const b: T = -math.inf(T);
+        const a: T = math.float.inf(T);
+        const b: T = -math.float.inf(T);
         const c: T = 1.0;
         const d: T = 0.0;
 
         const result = f(a, b, c, d);
-        try expect(result.real == math.inf(T));
-        try expect(result.imag == -math.inf(T));
+        try expect(result.real == math.float.inf(T));
+        try expect(result.imag == -math.float.inf(T));
     }
     {
         // if one operand is an infinity and the other operand is a nonzero finite number or an infinity,
         // then the result of the * operator is an infinity;
-        const a: T = math.inf(T);
+        const a: T = math.float.inf(T);
         const b: T = -1.0;
         const c: T = 1.0;
-        const d: T = math.inf(T);
+        const d: T = math.float.inf(T);
 
         const result = f(a, b, c, d);
-        try expect(result.real == math.inf(T));
-        try expect(result.imag == math.inf(T));
+        try expect(result.real == math.float.inf(T));
+        try expect(result.imag == math.float.inf(T));
     }
 }

--- a/lib/compiler_rt/mulf3.zig
+++ b/lib/compiler_rt/mulf3.zig
@@ -8,9 +8,9 @@ const common = @import("./common.zig");
 pub inline fn mulf3(comptime T: type, a: T, b: T) T {
     @setRuntimeSafety(builtin.is_test);
     const typeWidth = @typeInfo(T).Float.bits;
-    const significandBits = math.floatMantissaBits(T);
-    const fractionalBits = math.floatFractionalBits(T);
-    const exponentBits = math.floatExponentBits(T);
+    const significandBits = math.float.mantissaBits(T);
+    const fractionalBits = math.float.fractionalBits(T);
+    const exponentBits = math.float.exponentBits(T);
 
     const Z = std.meta.Int(.unsigned, typeWidth);
 
@@ -30,7 +30,7 @@ pub inline fn mulf3(comptime T: type, a: T, b: T) T {
     const absMask = signBit - 1;
     const qnanRep = @as(Z, @bitCast(math.nan(T))) | quietBit;
     const infRep: Z = @bitCast(math.inf(T));
-    const minNormalRep: Z = @bitCast(math.floatMin(T));
+    const minNormalRep: Z = @bitCast(math.float.min(T));
 
     const ZExp = if (typeWidth >= 32) u32 else Z;
     const aExponent: ZExp = @truncate((@as(Z, @bitCast(a)) >> significandBits) & maxExponent);
@@ -184,7 +184,7 @@ fn wideShrWithTruncation(comptime Z: type, hi: *Z, lo: *Z, count: u32) bool {
 
 fn normalize(comptime T: type, significand: *PowerOfTwoSignificandZ(T)) i32 {
     const Z = PowerOfTwoSignificandZ(T);
-    const integerBit = @as(Z, 1) << math.floatFractionalBits(T);
+    const integerBit = @as(Z, 1) << math.float.fractionalBits(T);
 
     const shift = @clz(significand.*) - @clz(integerBit);
     significand.* <<= @intCast(shift);
@@ -194,7 +194,7 @@ fn normalize(comptime T: type, significand: *PowerOfTwoSignificandZ(T)) i32 {
 /// Returns a power-of-two integer type that is large enough to contain
 /// the significand of T, including an explicit integer bit
 fn PowerOfTwoSignificandZ(comptime T: type) type {
-    const bits = math.ceilPowerOfTwoAssert(u16, math.floatFractionalBits(T) + 1);
+    const bits = math.ceilPowerOfTwoAssert(u16, math.float.fractionalBits(T) + 1);
     return std.meta.Int(.unsigned, bits);
 }
 

--- a/lib/compiler_rt/mulf3.zig
+++ b/lib/compiler_rt/mulf3.zig
@@ -28,8 +28,8 @@ pub inline fn mulf3(comptime T: type, a: T, b: T) T {
     const significandMask = (@as(Z, 1) << significandBits) - 1;
 
     const absMask = signBit - 1;
-    const qnanRep = @as(Z, @bitCast(math.nan(T))) | quietBit;
-    const infRep: Z = @bitCast(math.inf(T));
+    const qnanRep = @as(Z, @bitCast(math.float.nan(T))) | quietBit;
+    const infRep: Z = @bitCast(math.float.inf(T));
     const minNormalRep: Z = @bitCast(math.float.min(T));
 
     const ZExp = if (typeWidth >= 32) u32 else Z;

--- a/lib/compiler_rt/mulf3_test.zig
+++ b/lib/compiler_rt/mulf3_test.zig
@@ -107,7 +107,7 @@ test "multf3" {
     try test__multf3(2.0, math.float.trueMin(f128), 0x0000_0000_0000_0000, 0x0000_0000_0000_0002);
 }
 
-const qnan80: f80 = @bitCast(@as(u80, @bitCast(math.nan(f80))) | (1 << (math.float.fractionalBits(f80) - 1)));
+const qnan80: f80 = @bitCast(@as(u80, @bitCast(math.float.nan(f80))) | (1 << (math.float.fractionalBits(f80) - 1)));
 
 fn test__mulxf3(a: f80, b: f80, expected: u80) !void {
     const x = __mulxf3(a, b);
@@ -132,25 +132,25 @@ test "mulxf3" {
     try test__mulxf3(0x1.23456789abcdefp+5, @as(f80, @bitCast(@as(u80, 0x7fff_8000_8000_3000_0000))), @as(u80, @bitCast(qnan80)));
 
     // NaN * inf = NaN
-    try test__mulxf3(qnan80, math.inf(f80), @as(u80, @bitCast(qnan80)));
+    try test__mulxf3(qnan80, math.float.inf(f80), @as(u80, @bitCast(qnan80)));
 
     // inf * NaN = NaN
-    try test__mulxf3(math.inf(f80), qnan80, @as(u80, @bitCast(qnan80)));
+    try test__mulxf3(math.float.inf(f80), qnan80, @as(u80, @bitCast(qnan80)));
 
     // inf * inf = inf
-    try test__mulxf3(math.inf(f80), math.inf(f80), @as(u80, @bitCast(math.inf(f80))));
+    try test__mulxf3(math.float.inf(f80), math.float.inf(f80), @as(u80, @bitCast(math.float.inf(f80))));
 
     // inf * -inf = -inf
-    try test__mulxf3(math.inf(f80), -math.inf(f80), @as(u80, @bitCast(-math.inf(f80))));
+    try test__mulxf3(math.float.inf(f80), -math.float.inf(f80), @as(u80, @bitCast(-math.float.inf(f80))));
 
     // -inf + inf = -inf
-    try test__mulxf3(-math.inf(f80), math.inf(f80), @as(u80, @bitCast(-math.inf(f80))));
+    try test__mulxf3(-math.float.inf(f80), math.float.inf(f80), @as(u80, @bitCast(-math.float.inf(f80))));
 
     // inf * any = inf
-    try test__mulxf3(math.inf(f80), 0x1.2335653452436234723489432abcdefp+5, @as(u80, @bitCast(math.inf(f80))));
+    try test__mulxf3(math.float.inf(f80), 0x1.2335653452436234723489432abcdefp+5, @as(u80, @bitCast(math.float.inf(f80))));
 
     // any * inf = inf
-    try test__mulxf3(0x1.2335653452436234723489432abcdefp+5, math.inf(f80), @as(u80, @bitCast(math.inf(f80))));
+    try test__mulxf3(0x1.2335653452436234723489432abcdefp+5, math.float.inf(f80), @as(u80, @bitCast(math.float.inf(f80))));
 
     // any * any
     try test__mulxf3(0x1.0p+0, 0x1.dcba987654321p+5, 0x4004_ee5d_4c3b_2a19_0800);

--- a/lib/compiler_rt/mulf3_test.zig
+++ b/lib/compiler_rt/mulf3_test.zig
@@ -104,10 +104,10 @@ test "multf3" {
 
     try test__multf3(0x1.0000_0000_0000_0000_0000_0000_0001p+0, 0x1.8p+5, 0x4004_8000_0000_0000, 0x0000_0000_0000_0002);
     try test__multf3(0x1.0000_0000_0000_0000_0000_0000_0002p+0, 0x1.8p+5, 0x4004_8000_0000_0000, 0x0000_0000_0000_0003);
-    try test__multf3(2.0, math.floatTrueMin(f128), 0x0000_0000_0000_0000, 0x0000_0000_0000_0002);
+    try test__multf3(2.0, math.float.trueMin(f128), 0x0000_0000_0000_0000, 0x0000_0000_0000_0002);
 }
 
-const qnan80: f80 = @bitCast(@as(u80, @bitCast(math.nan(f80))) | (1 << (math.floatFractionalBits(f80) - 1)));
+const qnan80: f80 = @bitCast(@as(u80, @bitCast(math.nan(f80))) | (1 << (math.float.fractionalBits(f80) - 1)));
 
 fn test__mulxf3(a: f80, b: f80, expected: u80) !void {
     const x = __mulxf3(a, b);

--- a/lib/compiler_rt/powiXf2_test.zig
+++ b/lib/compiler_rt/powiXf2_test.zig
@@ -34,7 +34,7 @@ fn test__powixf2(a: f80, b: i32, expected: f80) !void {
 }
 
 test "powihf2" {
-    const inf_f16 = math.inf(f16);
+    const inf_f16 = math.float.inf(f16);
     try test__powisf2(0, 0, 1);
     try test__powihf2(1, 0, 1);
     try test__powihf2(1.5, 0, 1);
@@ -143,7 +143,7 @@ test "powihf2" {
 }
 
 test "powisf2" {
-    const inf_f32 = math.inf(f32);
+    const inf_f32 = math.float.inf(f32);
     try test__powisf2(0, 0, 1);
     try test__powisf2(1, 0, 1);
     try test__powisf2(1.5, 0, 1);
@@ -248,7 +248,7 @@ test "powisf2" {
 }
 
 test "powidf2" {
-    const inf_f64 = math.inf(f64);
+    const inf_f64 = math.float.inf(f64);
     try test__powidf2(0, 0, 1);
     try test__powidf2(1, 0, 1);
     try test__powidf2(1.5, 0, 1);
@@ -353,7 +353,7 @@ test "powidf2" {
 }
 
 test "powitf2" {
-    const inf_f128 = math.inf(f128);
+    const inf_f128 = math.float.inf(f128);
     try test__powitf2(0, 0, 1);
     try test__powitf2(1, 0, 1);
     try test__powitf2(1.5, 0, 1);
@@ -458,7 +458,7 @@ test "powitf2" {
 }
 
 test "powixf2" {
-    const inf_f80 = math.inf(f80);
+    const inf_f80 = math.float.inf(f80);
     try test__powixf2(0, 0, 1);
     try test__powixf2(1, 0, 1);
     try test__powixf2(1.5, 0, 1);

--- a/lib/compiler_rt/rem_pio2.zig
+++ b/lib/compiler_rt/rem_pio2.zig
@@ -7,7 +7,7 @@ const std = @import("std");
 const rem_pio2_large = @import("rem_pio2_large.zig").rem_pio2_large;
 const math = std.math;
 
-const toint = 1.5 / math.floatEps(f64);
+const toint = 1.5 / math.float.eps(f64);
 // pi/4
 const pio4 = 0x1.921fb54442d18p-1;
 // invpio2:  53 bits of 2/pi

--- a/lib/compiler_rt/rem_pio2f.zig
+++ b/lib/compiler_rt/rem_pio2f.zig
@@ -7,7 +7,7 @@ const std = @import("std");
 const rem_pio2_large = @import("rem_pio2_large.zig").rem_pio2_large;
 const math = std.math;
 
-const toint = 1.5 / math.floatEps(f64);
+const toint = 1.5 / math.float.eps(f64);
 // pi/4
 const pio4 = 0x1.921fb6p-1;
 // invpio2:  53 bits of 2/pi

--- a/lib/compiler_rt/round.zig
+++ b/lib/compiler_rt/round.zig
@@ -176,23 +176,23 @@ test "round128" {
 test "round32.special" {
     try expect(roundf(0.0) == 0.0);
     try expect(roundf(-0.0) == -0.0);
-    try expect(math.isPositiveInf(roundf(math.inf(f32))));
-    try expect(math.isNegativeInf(roundf(-math.inf(f32))));
-    try expect(math.isNan(roundf(math.nan(f32))));
+    try expect(math.isPositiveInf(roundf(math.float.inf(f32))));
+    try expect(math.isNegativeInf(roundf(-math.float.inf(f32))));
+    try expect(math.isNan(roundf(math.float.nan(f32))));
 }
 
 test "round64.special" {
     try expect(round(0.0) == 0.0);
     try expect(round(-0.0) == -0.0);
-    try expect(math.isPositiveInf(round(math.inf(f64))));
-    try expect(math.isNegativeInf(round(-math.inf(f64))));
-    try expect(math.isNan(round(math.nan(f64))));
+    try expect(math.isPositiveInf(round(math.float.inf(f64))));
+    try expect(math.isNegativeInf(round(-math.float.inf(f64))));
+    try expect(math.isNan(round(math.float.nan(f64))));
 }
 
 test "round128.special" {
     try expect(roundq(0.0) == 0.0);
     try expect(roundq(-0.0) == -0.0);
-    try expect(math.isPositiveInf(roundq(math.inf(f128))));
-    try expect(math.isNegativeInf(roundq(-math.inf(f128))));
-    try expect(math.isNan(roundq(math.nan(f128))));
+    try expect(math.isPositiveInf(roundq(math.float.inf(f128))));
+    try expect(math.isNegativeInf(roundq(-math.float.inf(f128))));
+    try expect(math.isNan(roundq(math.float.nan(f128))));
 }

--- a/lib/compiler_rt/round.zig
+++ b/lib/compiler_rt/round.zig
@@ -32,7 +32,7 @@ pub fn __roundh(x: f16) callconv(.C) f16 {
 }
 
 pub fn roundf(x_: f32) callconv(.C) f32 {
-    const f32_toint = 1.0 / math.floatEps(f32);
+    const f32_toint = 1.0 / math.float.eps(f32);
 
     var x = x_;
     const u: u32 = @bitCast(x);
@@ -67,7 +67,7 @@ pub fn roundf(x_: f32) callconv(.C) f32 {
 }
 
 pub fn round(x_: f64) callconv(.C) f64 {
-    const f64_toint = 1.0 / math.floatEps(f64);
+    const f64_toint = 1.0 / math.float.eps(f64);
 
     var x = x_;
     const u: u64 = @bitCast(x);
@@ -107,7 +107,7 @@ pub fn __roundx(x: f80) callconv(.C) f80 {
 }
 
 pub fn roundq(x_: f128) callconv(.C) f128 {
-    const f128_toint = 1.0 / math.floatEps(f128);
+    const f128_toint = 1.0 / math.float.eps(f128);
 
     var x = x_;
     const u: u128 = @bitCast(x);

--- a/lib/compiler_rt/sin.zig
+++ b/lib/compiler_rt/sin.zig
@@ -167,17 +167,17 @@ test "sin64" {
 test "sin32.special" {
     try expect(sinf(0.0) == 0.0);
     try expect(sinf(-0.0) == -0.0);
-    try expect(math.isNan(sinf(math.inf(f32))));
-    try expect(math.isNan(sinf(-math.inf(f32))));
-    try expect(math.isNan(sinf(math.nan(f32))));
+    try expect(math.isNan(sinf(math.float.inf(f32))));
+    try expect(math.isNan(sinf(-math.float.inf(f32))));
+    try expect(math.isNan(sinf(math.float.nan(f32))));
 }
 
 test "sin64.special" {
     try expect(sin(0.0) == 0.0);
     try expect(sin(-0.0) == -0.0);
-    try expect(math.isNan(sin(math.inf(f64))));
-    try expect(math.isNan(sin(-math.inf(f64))));
-    try expect(math.isNan(sin(math.nan(f64))));
+    try expect(math.isNan(sin(math.float.inf(f64))));
+    try expect(math.isNan(sin(-math.float.inf(f64))));
+    try expect(math.isNan(sin(math.float.nan(f64))));
 }
 
 test "sin32 #9901" {

--- a/lib/compiler_rt/sincos.zig
+++ b/lib/compiler_rt/sincos.zig
@@ -229,7 +229,7 @@ inline fn sincos_generic(comptime F: type, x: F, r_sin: *F, r_cos: *F) void {
     }
 
     if (@as(F, @bitCast(ix)) < sc1pio4) {
-        if (se < 0x3fff - math.floatFractionalBits(F) - 1) {
+        if (se < 0x3fff - math.float.fractionalBits(F) - 1) {
             // raise underflow if subnormal
             if (se == 0) {
                 mem.doNotOptimizeAway(x * 0x1p-120);

--- a/lib/compiler_rt/sqrt.zig
+++ b/lib/compiler_rt/sqrt.zig
@@ -38,7 +38,7 @@ pub fn sqrtf(x: f32) callconv(.C) f32 {
             return x; // sqrt (+-0) = +-0
         }
         if (ix < 0) {
-            return math.nan(f32);
+            return math.float.nan(f32);
         }
     }
 
@@ -121,7 +121,7 @@ pub fn sqrt(x: f64) callconv(.C) f64 {
     }
     // sqrt(-ve) = nan
     if (ix0 & sign != 0) {
-        return math.nan(f64);
+        return math.float.nan(f64);
     }
 
     // normalize x
@@ -275,11 +275,11 @@ test "sqrtf" {
 }
 
 test "sqrtf special" {
-    try std.testing.expect(math.isPositiveInf(sqrtf(math.inf(f32))));
+    try std.testing.expect(math.isPositiveInf(sqrtf(math.float.inf(f32))));
     try std.testing.expect(sqrtf(0.0) == 0.0);
     try std.testing.expect(sqrtf(-0.0) == -0.0);
     try std.testing.expect(math.isNan(sqrtf(-1.0)));
-    try std.testing.expect(math.isNan(sqrtf(math.nan(f32))));
+    try std.testing.expect(math.isNan(sqrtf(math.float.nan(f32))));
 }
 
 test "sqrt" {
@@ -304,9 +304,9 @@ test "sqrt" {
 }
 
 test "sqrt special" {
-    try std.testing.expect(math.isPositiveInf(sqrt(math.inf(f64))));
+    try std.testing.expect(math.isPositiveInf(sqrt(math.float.inf(f64))));
     try std.testing.expect(sqrt(0.0) == 0.0);
     try std.testing.expect(sqrt(-0.0) == -0.0);
     try std.testing.expect(math.isNan(sqrt(-1.0)));
-    try std.testing.expect(math.isNan(sqrt(math.nan(f64))));
+    try std.testing.expect(math.isNan(sqrt(math.float.nan(f64))));
 }

--- a/lib/compiler_rt/tan.zig
+++ b/lib/compiler_rt/tan.zig
@@ -156,15 +156,15 @@ test "tan64" {
 test "tan32.special" {
     try expect(tanf(0.0) == 0.0);
     try expect(tanf(-0.0) == -0.0);
-    try expect(math.isNan(tanf(math.inf(f32))));
-    try expect(math.isNan(tanf(-math.inf(f32))));
-    try expect(math.isNan(tanf(math.nan(f32))));
+    try expect(math.isNan(tanf(math.float.inf(f32))));
+    try expect(math.isNan(tanf(-math.float.inf(f32))));
+    try expect(math.isNan(tanf(math.float.nan(f32))));
 }
 
 test "tan64.special" {
     try expect(tan(0.0) == 0.0);
     try expect(tan(-0.0) == -0.0);
-    try expect(math.isNan(tan(math.inf(f64))));
-    try expect(math.isNan(tan(-math.inf(f64))));
-    try expect(math.isNan(tan(math.nan(f64))));
+    try expect(math.isNan(tan(math.float.inf(f64))));
+    try expect(math.isNan(tan(-math.float.inf(f64))));
+    try expect(math.isNan(tan(math.float.nan(f64))));
 }

--- a/lib/compiler_rt/trunc.zig
+++ b/lib/compiler_rt/trunc.zig
@@ -131,23 +131,23 @@ test "trunc128" {
 test "trunc32.special" {
     try expect(truncf(0.0) == 0.0); // 0x3F800000
     try expect(truncf(-0.0) == -0.0);
-    try expect(math.isPositiveInf(truncf(math.inf(f32))));
-    try expect(math.isNegativeInf(truncf(-math.inf(f32))));
-    try expect(math.isNan(truncf(math.nan(f32))));
+    try expect(math.isPositiveInf(truncf(math.float.inf(f32))));
+    try expect(math.isNegativeInf(truncf(-math.float.inf(f32))));
+    try expect(math.isNan(truncf(math.float.nan(f32))));
 }
 
 test "trunc64.special" {
     try expect(trunc(0.0) == 0.0);
     try expect(trunc(-0.0) == -0.0);
-    try expect(math.isPositiveInf(trunc(math.inf(f64))));
-    try expect(math.isNegativeInf(trunc(-math.inf(f64))));
-    try expect(math.isNan(trunc(math.nan(f64))));
+    try expect(math.isPositiveInf(trunc(math.float.inf(f64))));
+    try expect(math.isNegativeInf(trunc(-math.float.inf(f64))));
+    try expect(math.isNan(trunc(math.float.nan(f64))));
 }
 
 test "trunc128.special" {
     try expect(truncq(0.0) == 0.0);
     try expect(truncq(-0.0) == -0.0);
-    try expect(math.isPositiveInf(truncq(math.inf(f128))));
-    try expect(math.isNegativeInf(truncq(-math.inf(f128))));
-    try expect(math.isNan(truncq(math.nan(f128))));
+    try expect(math.isPositiveInf(truncq(math.float.inf(f128))));
+    try expect(math.isNegativeInf(truncq(-math.float.inf(f128))));
+    try expect(math.isNan(truncq(math.float.nan(f128))));
 }

--- a/lib/compiler_rt/truncf.zig
+++ b/lib/compiler_rt/truncf.zig
@@ -3,8 +3,8 @@ const std = @import("std");
 pub inline fn truncf(comptime dst_t: type, comptime src_t: type, a: src_t) dst_t {
     const src_rep_t = std.meta.Int(.unsigned, @typeInfo(src_t).Float.bits);
     const dst_rep_t = std.meta.Int(.unsigned, @typeInfo(dst_t).Float.bits);
-    const srcSigBits = std.math.floatMantissaBits(src_t);
-    const dstSigBits = std.math.floatMantissaBits(dst_t);
+    const srcSigBits = std.math.float.mantissaBits(src_t);
+    const dstSigBits = std.math.float.mantissaBits(dst_t);
 
     // Various constants whose values follow from the type parameters.
     // Any reasonable optimizer will fold and propagate all of these.
@@ -101,8 +101,8 @@ pub inline fn truncf(comptime dst_t: type, comptime src_t: type, a: src_t) dst_t
 
 pub inline fn trunc_f80(comptime dst_t: type, a: f80) dst_t {
     const dst_rep_t = std.meta.Int(.unsigned, @typeInfo(dst_t).Float.bits);
-    const src_sig_bits = std.math.floatMantissaBits(f80) - 1; // -1 for the integer bit
-    const dst_sig_bits = std.math.floatMantissaBits(dst_t);
+    const src_sig_bits = std.math.float.mantissaBits(f80) - 1; // -1 for the integer bit
+    const dst_sig_bits = std.math.float.mantissaBits(dst_t);
 
     const src_exp_bias = 16383;
 

--- a/lib/compiler_rt/trunctfxf2.zig
+++ b/lib/compiler_rt/trunctfxf2.zig
@@ -9,8 +9,8 @@ comptime {
 }
 
 pub fn __trunctfxf2(a: f128) callconv(.C) f80 {
-    const src_sig_bits = math.floatMantissaBits(f128);
-    const dst_sig_bits = math.floatMantissaBits(f80) - 1; // -1 for the integer bit
+    const src_sig_bits = math.float.mantissaBits(f128);
+    const dst_sig_bits = math.float.mantissaBits(f80) - 1; // -1 for the integer bit
 
     // Various constants whose values follow from the type parameters.
     // Any reasonable optimizer will fold and propagate all of these.

--- a/lib/libc/include/any-windows-any/d2d1helper.h
+++ b/lib/libc/include/any-windows-any/d2d1helper.h
@@ -24,7 +24,7 @@ template<> struct TypeTraits<UINT32> {
     typedef D2D1_RECT_U    Rect;
 };
 
-static inline FLOAT FloatMax() {
+static inline FLOAT float.max() {
     return 3.402823466e+38f;
 }
 
@@ -68,7 +68,7 @@ D2D1FORCEINLINE D2D1_RECT_U RectU(UINT32 left = 0, UINT32 top = 0, UINT32 right 
 }
 
 D2D1FORCEINLINE D2D1_RECT_F InfiniteRect() {
-    D2D1_RECT_F r = {-FloatMax(), -FloatMax(), FloatMax(),  FloatMax()};
+    D2D1_RECT_F r = {-float.max(), -float.max(), float.max(),  float.max()};
     return r;
 }
 

--- a/lib/std/Random.zig
+++ b/lib/std/Random.zig
@@ -397,7 +397,7 @@ pub fn weightedIndex(r: Random, comptime T: type, proportions: []const T) usize 
             .unsigned => r.uintLessThan(T, sum),
         },
         // take care that imprecision doesn't lead to a value slightly greater than sum
-        .Float => @min(r.float(T) * sum, sum - std.math.floatEps(T)),
+        .Float => @min(r.float(T) * sum, sum - std.math.float.eps(T)),
         else => @compileError("weightedIndex does not support proportions of type " ++
             @typeName(T)),
     };

--- a/lib/std/Random/ziggurat.zig
+++ b/lib/std/Random/ziggurat.zig
@@ -27,7 +27,7 @@ pub fn next_f64(random: Random, comptime tables: ZigTable) f64 {
             } else {
                 // Generate a value in the range [1, 2) and scale into (0, 1)
                 const repr = (0x3ff << 52) | (bits >> 12);
-                break :blk @as(f64, @bitCast(repr)) - (1.0 - math.floatEps(f64) / 2.0);
+                break :blk @as(f64, @bitCast(repr)) - (1.0 - math.float.eps(f64) / 2.0);
             }
         };
 

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2218,25 +2218,25 @@ test "float.scientific.precision" {
 }
 
 test "float.special" {
-    try expectFmt("f64: nan", "f64: {}", .{math.nan(f64)});
+    try expectFmt("f64: nan", "f64: {}", .{math.float.nan(f64)});
     // negative nan is not defined by IEE 754,
     // and ARM thus normalizes it to positive nan
     if (builtin.target.cpu.arch != .arm) {
-        try expectFmt("f64: -nan", "f64: {}", .{-math.nan(f64)});
+        try expectFmt("f64: -nan", "f64: {}", .{-math.float.nan(f64)});
     }
-    try expectFmt("f64: inf", "f64: {}", .{math.inf(f64)});
-    try expectFmt("f64: -inf", "f64: {}", .{-math.inf(f64)});
+    try expectFmt("f64: inf", "f64: {}", .{math.float.inf(f64)});
+    try expectFmt("f64: -inf", "f64: {}", .{-math.float.inf(f64)});
 }
 
 test "float.hexadecimal.special" {
-    try expectFmt("f64: nan", "f64: {x}", .{math.nan(f64)});
+    try expectFmt("f64: nan", "f64: {x}", .{math.float.nan(f64)});
     // negative nan is not defined by IEE 754,
     // and ARM thus normalizes it to positive nan
     if (builtin.target.cpu.arch != .arm) {
-        try expectFmt("f64: -nan", "f64: {x}", .{-math.nan(f64)});
+        try expectFmt("f64: -nan", "f64: {x}", .{-math.float.nan(f64)});
     }
-    try expectFmt("f64: inf", "f64: {x}", .{math.inf(f64)});
-    try expectFmt("f64: -inf", "f64: {x}", .{-math.inf(f64)});
+    try expectFmt("f64: inf", "f64: {x}", .{math.float.inf(f64)});
+    try expectFmt("f64: -inf", "f64: {x}", .{-math.float.inf(f64)});
 
     try expectFmt("f64: 0x0.0p0", "f64: {x}", .{@as(f64, 0)});
     try expectFmt("f64: -0x0.0p0", "f64: {x}", .{-@as(f64, 0)});

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1062,9 +1062,9 @@ pub fn formatFloatHexadecimal(
     const T = @TypeOf(value);
     const TU = std.meta.Int(.unsigned, @bitSizeOf(T));
 
-    const mantissa_bits = math.floatMantissaBits(T);
-    const fractional_bits = math.floatFractionalBits(T);
-    const exponent_bits = math.floatExponentBits(T);
+    const mantissa_bits = math.float.mantissaBits(T);
+    const fractional_bits = math.float.fractionalBits(T);
+    const exponent_bits = math.float.exponentBits(T);
     const mantissa_mask = (1 << mantissa_bits) - 1;
     const exponent_mask = (1 << exponent_bits) - 1;
     const exponent_bias = (1 << (exponent_bits - 1)) - 1;
@@ -2249,23 +2249,23 @@ test "float.hexadecimal" {
     try expectFmt("f80: 0x1.5555555555555556p-2", "f80: {x}", .{@as(f80, 1.0 / 3.0)});
     try expectFmt("f128: 0x1.5555555555555555555555555555p-2", "f128: {x}", .{@as(f128, 1.0 / 3.0)});
 
-    try expectFmt("f16: 0x1p-14", "f16: {x}", .{math.floatMin(f16)});
-    try expectFmt("f32: 0x1p-126", "f32: {x}", .{math.floatMin(f32)});
-    try expectFmt("f64: 0x1p-1022", "f64: {x}", .{math.floatMin(f64)});
-    try expectFmt("f80: 0x1p-16382", "f80: {x}", .{math.floatMin(f80)});
-    try expectFmt("f128: 0x1p-16382", "f128: {x}", .{math.floatMin(f128)});
+    try expectFmt("f16: 0x1p-14", "f16: {x}", .{math.float.min(f16)});
+    try expectFmt("f32: 0x1p-126", "f32: {x}", .{math.float.min(f32)});
+    try expectFmt("f64: 0x1p-1022", "f64: {x}", .{math.float.min(f64)});
+    try expectFmt("f80: 0x1p-16382", "f80: {x}", .{math.float.min(f80)});
+    try expectFmt("f128: 0x1p-16382", "f128: {x}", .{math.float.min(f128)});
 
-    try expectFmt("f16: 0x0.004p-14", "f16: {x}", .{math.floatTrueMin(f16)});
-    try expectFmt("f32: 0x0.000002p-126", "f32: {x}", .{math.floatTrueMin(f32)});
-    try expectFmt("f64: 0x0.0000000000001p-1022", "f64: {x}", .{math.floatTrueMin(f64)});
-    try expectFmt("f80: 0x0.0000000000000002p-16382", "f80: {x}", .{math.floatTrueMin(f80)});
-    try expectFmt("f128: 0x0.0000000000000000000000000001p-16382", "f128: {x}", .{math.floatTrueMin(f128)});
+    try expectFmt("f16: 0x0.004p-14", "f16: {x}", .{math.float.trueMin(f16)});
+    try expectFmt("f32: 0x0.000002p-126", "f32: {x}", .{math.float.trueMin(f32)});
+    try expectFmt("f64: 0x0.0000000000001p-1022", "f64: {x}", .{math.float.trueMin(f64)});
+    try expectFmt("f80: 0x0.0000000000000002p-16382", "f80: {x}", .{math.float.trueMin(f80)});
+    try expectFmt("f128: 0x0.0000000000000000000000000001p-16382", "f128: {x}", .{math.float.trueMin(f128)});
 
-    try expectFmt("f16: 0x1.ffcp15", "f16: {x}", .{math.floatMax(f16)});
-    try expectFmt("f32: 0x1.fffffep127", "f32: {x}", .{math.floatMax(f32)});
-    try expectFmt("f64: 0x1.fffffffffffffp1023", "f64: {x}", .{math.floatMax(f64)});
-    try expectFmt("f80: 0x1.fffffffffffffffep16383", "f80: {x}", .{math.floatMax(f80)});
-    try expectFmt("f128: 0x1.ffffffffffffffffffffffffffffp16383", "f128: {x}", .{math.floatMax(f128)});
+    try expectFmt("f16: 0x1.ffcp15", "f16: {x}", .{math.float.max(f16)});
+    try expectFmt("f32: 0x1.fffffep127", "f32: {x}", .{math.float.max(f32)});
+    try expectFmt("f64: 0x1.fffffffffffffp1023", "f64: {x}", .{math.float.max(f64)});
+    try expectFmt("f80: 0x1.fffffffffffffffep16383", "f80: {x}", .{math.float.max(f80)});
+    try expectFmt("f128: 0x1.ffffffffffffffffffffffffffffp16383", "f128: {x}", .{math.float.max(f128)});
 }
 
 test "float.hexadecimal.precision" {

--- a/lib/std/fmt/format_float.zig
+++ b/lib/std/fmt/format_float.zig
@@ -70,8 +70,8 @@ pub fn formatFloat(buf: []u8, v_: anytype, options: FormatOptions) FormatError![
         else => unreachable,
     };
 
-    const has_explicit_leading_bit = std.math.floatMantissaBits(T) - std.math.floatFractionalBits(T) != 0;
-    const d = binaryToDecimal(DT, @as(I, @bitCast(v)), std.math.floatMantissaBits(T), std.math.floatExponentBits(T), has_explicit_leading_bit, tables);
+    const has_explicit_leading_bit = std.math.float.mantissaBits(T) - std.math.float.fractionalBits(T) != 0;
+    const d = binaryToDecimal(DT, @as(I, @bitCast(v)), std.math.float.mantissaBits(T), std.math.float.exponentBits(T), has_explicit_leading_bit, tables);
 
     return switch (options.mode) {
         .scientific => formatScientific(DT, buf, d, options.precision),

--- a/lib/std/fmt/format_float.zig
+++ b/lib/std/fmt/format_float.zig
@@ -1538,9 +1538,9 @@ test "format f32" {
     try check(f32, -0.0, "-0e0");
     try check(f32, 1.0, "1e0");
     try check(f32, -1.0, "-1e0");
-    try check(f32, std.math.nan(f32), "nan");
-    try check(f32, std.math.inf(f32), "inf");
-    try check(f32, -std.math.inf(f32), "-inf");
+    try check(f32, std.math.float.nan(f32), "nan");
+    try check(f32, std.math.float.inf(f32), "inf");
+    try check(f32, -std.math.float.inf(f32), "-inf");
     try check(f32, 1.1754944e-38, "1.1754944e-38");
     try check(f32, @bitCast(@as(u32, 0x7f7fffff)), "3.4028235e38");
     try check(f32, @bitCast(@as(u32, 1)), "1e-45");
@@ -1599,9 +1599,9 @@ test "format f64" {
     try check(f64, -0.0, "-0e0");
     try check(f64, 1.0, "1e0");
     try check(f64, -1.0, "-1e0");
-    try check(f64, std.math.nan(f64), "nan");
-    try check(f64, std.math.inf(f64), "inf");
-    try check(f64, -std.math.inf(f64), "-inf");
+    try check(f64, std.math.float.nan(f64), "nan");
+    try check(f64, std.math.float.inf(f64), "inf");
+    try check(f64, -std.math.float.inf(f64), "-inf");
     try check(f64, 2.2250738585072014e-308, "2.2250738585072014e-308");
     try check(f64, @bitCast(@as(u64, 0x7fefffffffffffff)), "1.7976931348623157e308");
     try check(f64, @bitCast(@as(u64, 1)), "5e-324");
@@ -1648,9 +1648,9 @@ test "format f80" {
     try check(f80, -0.0, "-0e0");
     try check(f80, 1.0, "1e0");
     try check(f80, -1.0, "-1e0");
-    try check(f80, std.math.nan(f80), "nan");
-    try check(f80, std.math.inf(f80), "inf");
-    try check(f80, -std.math.inf(f80), "-inf");
+    try check(f80, std.math.float.nan(f80), "nan");
+    try check(f80, std.math.float.inf(f80), "inf");
+    try check(f80, -std.math.float.inf(f80), "-inf");
 
     try check(f80, 2.2250738585072014e-308, "2.2250738585072014e-308");
     try check(f80, 2.98023223876953125e-8, "2.98023223876953125e-8");
@@ -1669,9 +1669,9 @@ test "format f128" {
     try check(f128, -0.0, "-0e0");
     try check(f128, 1.0, "1e0");
     try check(f128, -1.0, "-1e0");
-    try check(f128, std.math.nan(f128), "nan");
-    try check(f128, std.math.inf(f128), "inf");
-    try check(f128, -std.math.inf(f128), "-inf");
+    try check(f128, std.math.float.nan(f128), "nan");
+    try check(f128, std.math.float.inf(f128), "inf");
+    try check(f128, -std.math.float.inf(f128), "-inf");
 
     try check(f128, 2.2250738585072014e-308, "2.2250738585072014e-308");
     try check(f128, 2.98023223876953125e-8, "2.98023223876953125e-8");

--- a/lib/std/fmt/parse_float.zig
+++ b/lib/std/fmt/parse_float.zig
@@ -171,14 +171,14 @@ test "hex.f16" {
     try testing.expectEqual(try parseFloat(f16, "0x10p+10"), 16384.0);
     try testing.expectEqual(try parseFloat(f16, "0x10p-10"), 0.015625);
     // Max normalized value.
-    try testing.expectEqual(try parseFloat(f16, "0x1.ffcp+15"), math.floatMax(f16));
-    try testing.expectEqual(try parseFloat(f16, "-0x1.ffcp+15"), -math.floatMax(f16));
+    try testing.expectEqual(try parseFloat(f16, "0x1.ffcp+15"), math.float.max(f16));
+    try testing.expectEqual(try parseFloat(f16, "-0x1.ffcp+15"), -math.float.max(f16));
     // Min normalized value.
-    try testing.expectEqual(try parseFloat(f16, "0x1p-14"), math.floatMin(f16));
-    try testing.expectEqual(try parseFloat(f16, "-0x1p-14"), -math.floatMin(f16));
+    try testing.expectEqual(try parseFloat(f16, "0x1p-14"), math.float.min(f16));
+    try testing.expectEqual(try parseFloat(f16, "-0x1p-14"), -math.float.min(f16));
     // Min denormal value.
-    try testing.expectEqual(try parseFloat(f16, "0x1p-24"), math.floatTrueMin(f16));
-    try testing.expectEqual(try parseFloat(f16, "-0x1p-24"), -math.floatTrueMin(f16));
+    try testing.expectEqual(try parseFloat(f16, "0x1p-24"), math.float.trueMin(f16));
+    try testing.expectEqual(try parseFloat(f16, "-0x1p-24"), -math.float.trueMin(f16));
 }
 
 test "hex.f32" {
@@ -190,14 +190,14 @@ test "hex.f32" {
     try testing.expectEqual(try parseFloat(f32, "0x0.ffffffp128"), 0x0.ffffffp128);
     try testing.expectEqual(try parseFloat(f32, "0x0.1234570p-125"), 0x0.1234570p-125);
     // Max normalized value.
-    try testing.expectEqual(try parseFloat(f32, "0x1.fffffeP+127"), math.floatMax(f32));
-    try testing.expectEqual(try parseFloat(f32, "-0x1.fffffeP+127"), -math.floatMax(f32));
+    try testing.expectEqual(try parseFloat(f32, "0x1.fffffeP+127"), math.float.max(f32));
+    try testing.expectEqual(try parseFloat(f32, "-0x1.fffffeP+127"), -math.float.max(f32));
     // Min normalized value.
-    try testing.expectEqual(try parseFloat(f32, "0x1p-126"), math.floatMin(f32));
-    try testing.expectEqual(try parseFloat(f32, "-0x1p-126"), -math.floatMin(f32));
+    try testing.expectEqual(try parseFloat(f32, "0x1p-126"), math.float.min(f32));
+    try testing.expectEqual(try parseFloat(f32, "-0x1p-126"), -math.float.min(f32));
     // Min denormal value.
-    try testing.expectEqual(try parseFloat(f32, "0x1P-149"), math.floatTrueMin(f32));
-    try testing.expectEqual(try parseFloat(f32, "-0x1P-149"), -math.floatTrueMin(f32));
+    try testing.expectEqual(try parseFloat(f32, "0x1P-149"), math.float.trueMin(f32));
+    try testing.expectEqual(try parseFloat(f32, "-0x1P-149"), -math.float.trueMin(f32));
 }
 
 test "hex.f64" {
@@ -206,14 +206,14 @@ test "hex.f64" {
     try testing.expectEqual(try parseFloat(f64, "0x10p+10"), 16384.0);
     try testing.expectEqual(try parseFloat(f64, "0x10p-10"), 0.015625);
     // Max normalized value.
-    try testing.expectEqual(try parseFloat(f64, "0x1.fffffffffffffp+1023"), math.floatMax(f64));
-    try testing.expectEqual(try parseFloat(f64, "-0x1.fffffffffffffp1023"), -math.floatMax(f64));
+    try testing.expectEqual(try parseFloat(f64, "0x1.fffffffffffffp+1023"), math.float.max(f64));
+    try testing.expectEqual(try parseFloat(f64, "-0x1.fffffffffffffp1023"), -math.float.max(f64));
     // Min normalized value.
-    try testing.expectEqual(try parseFloat(f64, "0x1p-1022"), math.floatMin(f64));
-    try testing.expectEqual(try parseFloat(f64, "-0x1p-1022"), -math.floatMin(f64));
+    try testing.expectEqual(try parseFloat(f64, "0x1p-1022"), math.float.min(f64));
+    try testing.expectEqual(try parseFloat(f64, "-0x1p-1022"), -math.float.min(f64));
     // Min denormalized value.
-    try testing.expectEqual(try parseFloat(f64, "0x1p-1074"), math.floatTrueMin(f64));
-    try testing.expectEqual(try parseFloat(f64, "-0x1p-1074"), -math.floatTrueMin(f64));
+    try testing.expectEqual(try parseFloat(f64, "0x1p-1074"), math.float.trueMin(f64));
+    try testing.expectEqual(try parseFloat(f64, "-0x1p-1074"), -math.float.trueMin(f64));
 }
 test "hex.f128" {
     try testing.expectEqual(try parseFloat(f128, "0x1p0"), 1.0);
@@ -221,14 +221,14 @@ test "hex.f128" {
     try testing.expectEqual(try parseFloat(f128, "0x10p+10"), 16384.0);
     try testing.expectEqual(try parseFloat(f128, "0x10p-10"), 0.015625);
     // Max normalized value.
-    try testing.expectEqual(try parseFloat(f128, "0xf.fffffffffffffffffffffffffff8p+16380"), math.floatMax(f128));
-    try testing.expectEqual(try parseFloat(f128, "-0xf.fffffffffffffffffffffffffff8p+16380"), -math.floatMax(f128));
+    try testing.expectEqual(try parseFloat(f128, "0xf.fffffffffffffffffffffffffff8p+16380"), math.float.max(f128));
+    try testing.expectEqual(try parseFloat(f128, "-0xf.fffffffffffffffffffffffffff8p+16380"), -math.float.max(f128));
     // Min normalized value.
-    try testing.expectEqual(try parseFloat(f128, "0x1p-16382"), math.floatMin(f128));
-    try testing.expectEqual(try parseFloat(f128, "-0x1p-16382"), -math.floatMin(f128));
+    try testing.expectEqual(try parseFloat(f128, "0x1p-16382"), math.float.min(f128));
+    try testing.expectEqual(try parseFloat(f128, "-0x1p-16382"), -math.float.min(f128));
     // // Min denormalized value.
-    try testing.expectEqual(try parseFloat(f128, "0x1p-16494"), math.floatTrueMin(f128));
-    try testing.expectEqual(try parseFloat(f128, "-0x1p-16494"), -math.floatTrueMin(f128));
+    try testing.expectEqual(try parseFloat(f128, "0x1p-16494"), math.float.trueMin(f128));
+    try testing.expectEqual(try parseFloat(f128, "-0x1p-16494"), -math.float.trueMin(f128));
     // ensure round-to-even
     try testing.expectEqual(try parseFloat(f128, "0x1.edcb34a235253948765432134674fp-1"), 0x1.edcb34a235253948765432134674fp-1);
 }

--- a/lib/std/fmt/parse_float.zig
+++ b/lib/std/fmt/parse_float.zig
@@ -98,9 +98,9 @@ test parseFloat {
         try expect(approxEqAbs(T, try parseFloat(T, "-3.141"), -3.141, epsilon));
 
         try expectEqual(try parseFloat(T, "1e-5000"), 0);
-        try expectEqual(try parseFloat(T, "1e+5000"), std.math.inf(T));
+        try expectEqual(try parseFloat(T, "1e+5000"), std.math.float.inf(T));
 
-        try expectEqual(try parseFloat(T, "0.4e0066999999999999999999999999999999999999999999999999999"), std.math.inf(T));
+        try expectEqual(try parseFloat(T, "0.4e0066999999999999999999999999999999999999999999999999999"), std.math.float.inf(T));
         try expect(approxEqAbs(T, try parseFloat(T, "0_1_2_3_4_5_6.7_8_9_0_0_0e0_0_1_0"), @as(T, 123456.789000e10), epsilon));
 
         // underscore rule is simple and reduces to "can only occur between two digits" and multiple are not supported.
@@ -134,9 +134,9 @@ test "nan and inf" {
     inline for ([_]type{ f16, f32, f64, f128 }) |T| {
         const Z = std.meta.Int(.unsigned, @typeInfo(T).Float.bits);
 
-        try expectEqual(@as(Z, @bitCast(try parseFloat(T, "nAn"))), @as(Z, @bitCast(std.math.nan(T))));
-        try expectEqual(try parseFloat(T, "inF"), std.math.inf(T));
-        try expectEqual(try parseFloat(T, "-INF"), -std.math.inf(T));
+        try expectEqual(@as(Z, @bitCast(try parseFloat(T, "nAn"))), @as(Z, @bitCast(std.math.float.nan(T))));
+        try expectEqual(try parseFloat(T, "inF"), std.math.float.inf(T));
+        try expectEqual(try parseFloat(T, "-INF"), -std.math.float.inf(T));
     }
 }
 

--- a/lib/std/fmt/parse_float/FloatInfo.zig
+++ b/lib/std/fmt/parse_float/FloatInfo.zig
@@ -58,9 +58,9 @@ pub fn from(comptime T: type) Self {
             .min_exponent_fast_path = -4,
             .max_exponent_fast_path = 4,
             .max_exponent_fast_path_disguised = 7,
-            .max_mantissa_fast_path = 2 << std.math.floatMantissaBits(T),
+            .max_mantissa_fast_path = 2 << std.math.float.mantissaBits(T),
             // Slow + Eisel-Lemire
-            .mantissa_explicit_bits = std.math.floatMantissaBits(T),
+            .mantissa_explicit_bits = std.math.float.mantissaBits(T),
             .infinite_power = 0x1f,
             // Eisel-Lemire
             .smallest_power_of_ten = -26, // TODO: refine, fails one test
@@ -79,9 +79,9 @@ pub fn from(comptime T: type) Self {
             .min_exponent_fast_path = -10,
             .max_exponent_fast_path = 10,
             .max_exponent_fast_path_disguised = 17,
-            .max_mantissa_fast_path = 2 << std.math.floatMantissaBits(T),
+            .max_mantissa_fast_path = 2 << std.math.float.mantissaBits(T),
             // Slow + Eisel-Lemire
-            .mantissa_explicit_bits = std.math.floatMantissaBits(T),
+            .mantissa_explicit_bits = std.math.float.mantissaBits(T),
             .infinite_power = 0xff,
             // Eisel-Lemire
             .smallest_power_of_ten = -65,
@@ -95,9 +95,9 @@ pub fn from(comptime T: type) Self {
             .min_exponent_fast_path = -22,
             .max_exponent_fast_path = 22,
             .max_exponent_fast_path_disguised = 37,
-            .max_mantissa_fast_path = 2 << std.math.floatMantissaBits(T),
+            .max_mantissa_fast_path = 2 << std.math.float.mantissaBits(T),
             // Slow + Eisel-Lemire
-            .mantissa_explicit_bits = std.math.floatMantissaBits(T),
+            .mantissa_explicit_bits = std.math.float.mantissaBits(T),
             .infinite_power = 0x7ff,
             // Eisel-Lemire
             .smallest_power_of_ten = -342,
@@ -111,9 +111,9 @@ pub fn from(comptime T: type) Self {
             .min_exponent_fast_path = -48,
             .max_exponent_fast_path = 48,
             .max_exponent_fast_path_disguised = 82,
-            .max_mantissa_fast_path = 2 << std.math.floatMantissaBits(T),
+            .max_mantissa_fast_path = 2 << std.math.float.mantissaBits(T),
             // Slow + Eisel-Lemire
-            .mantissa_explicit_bits = std.math.floatMantissaBits(T),
+            .mantissa_explicit_bits = std.math.float.mantissaBits(T),
             .infinite_power = 0x7fff,
             // Eisel-Lemire.
             // NOTE: Not yet tested (no f128 eisel-lemire implementation)

--- a/lib/std/fmt/parse_float/common.zig
+++ b/lib/std/fmt/parse_float/common.zig
@@ -23,7 +23,7 @@ pub fn BiasedFp(comptime T: type) type {
         }
 
         pub fn inf(comptime FloatT: type) Self {
-            return .{ .f = 0, .e = (1 << std.math.floatExponentBits(FloatT)) - 1 };
+            return .{ .f = 0, .e = (1 << std.math.float.exponentBits(FloatT)) - 1 };
         }
 
         pub fn eql(self: Self, other: Self) bool {
@@ -32,7 +32,7 @@ pub fn BiasedFp(comptime T: type) type {
 
         pub fn toFloat(self: Self, comptime FloatT: type, negative: bool) FloatT {
             var word = self.f;
-            word |= @as(MantissaT, @intCast(self.e)) << std.math.floatMantissaBits(FloatT);
+            word |= @as(MantissaT, @intCast(self.e)) << std.math.float.mantissaBits(FloatT);
             var f = floatFromUnsigned(FloatT, MantissaT, word);
             if (negative) f = -f;
             return f;

--- a/lib/std/fmt/parse_float/convert_hex.zig
+++ b/lib/std/fmt/parse_float/convert_hex.zig
@@ -77,7 +77,7 @@ pub fn convertHex(comptime T: type, n_: Number(T)) T {
 
     // Infinity and range error
     if (n.exponent > max_exp) {
-        return math.inf(T);
+        return math.float.inf(T);
     }
 
     var bits = n.mantissa & ((1 << mantissa_bits) - 1);

--- a/lib/std/fmt/parse_float/convert_hex.zig
+++ b/lib/std/fmt/parse_float/convert_hex.zig
@@ -22,10 +22,10 @@ pub fn convertHex(comptime T: type, n_: Number(T)) T {
         return if (n.negative) -0.0 else 0.0;
     }
 
-    const max_exp = math.floatExponentMax(T);
-    const min_exp = math.floatExponentMin(T);
-    const mantissa_bits = math.floatMantissaBits(T);
-    const exp_bits = math.floatExponentBits(T);
+    const max_exp = math.float.exponentMax(T);
+    const min_exp = math.float.exponentMin(T);
+    const mantissa_bits = math.float.mantissaBits(T);
+    const exp_bits = math.float.exponentBits(T);
     const exp_bias = min_exp - 1;
 
     // mantissa now implicitly divided by 2^mantissa_bits

--- a/lib/std/fmt/parse_float/convert_slow.zig
+++ b/lib/std/fmt/parse_float/convert_slow.zig
@@ -39,9 +39,9 @@ pub fn convertSlow(comptime T: type, s: []const u8) BiasedFp(T) {
     @setCold(true);
 
     const MantissaT = mantissaType(T);
-    const min_exponent = -(1 << (math.floatExponentBits(T) - 1)) + 1;
-    const infinite_power = (1 << math.floatExponentBits(T)) - 1;
-    const mantissa_explicit_bits = math.floatMantissaBits(T);
+    const min_exponent = -(1 << (math.float.exponentBits(T) - 1)) + 1;
+    const infinite_power = (1 << math.float.exponentBits(T)) - 1;
+    const mantissa_explicit_bits = math.float.mantissaBits(T);
 
     var d = Decimal(T).parse(s); // no need to recheck underscores
     if (d.num_digits == 0 or d.decimal_point < Decimal(T).min_exponent) {

--- a/lib/std/fmt/parse_float/parse.zig
+++ b/lib/std/fmt/parse_float/parse.zig
@@ -250,12 +250,12 @@ fn parsePartialInfOrNan(comptime T: type, s: []const u8, negative: bool, n: *usi
             n.* = 8;
         }
 
-        return if (!negative) std.math.inf(T) else -std.math.inf(T);
+        return if (!negative) std.math.float.inf(T) else -std.math.float.inf(T);
     }
 
     if (std.ascii.startsWithIgnoreCase(s, "nan")) {
         n.* = 3;
-        return std.math.nan(T);
+        return std.math.float.nan(T);
     }
 
     return null;

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -1,6 +1,5 @@
 const builtin = @import("builtin");
 const std = @import("std.zig");
-const float = @import("math/float.zig");
 const assert = std.debug.assert;
 const mem = std.mem;
 const testing = std.testing;
@@ -44,19 +43,10 @@ pub const rad_per_deg = 0.017453292519943295769236907684886127134428718885417254
 /// 180.0/pi
 pub const deg_per_rad = 57.295779513082320876798154814105170332405472466564321549160243861;
 
-pub const floatExponentBits = float.floatExponentBits;
-pub const floatMantissaBits = float.floatMantissaBits;
-pub const floatFractionalBits = float.floatFractionalBits;
-pub const floatExponentMin = float.floatExponentMin;
-pub const floatExponentMax = float.floatExponentMax;
-pub const floatTrueMin = float.floatTrueMin;
-pub const floatMin = float.floatMin;
-pub const floatMax = float.floatMax;
-pub const floatEps = float.floatEps;
-pub const floatEpsAt = float.floatEpsAt;
-pub const inf = float.inf;
-pub const nan = float.nan;
-pub const snan = float.snan;
+pub const float = @import("math/float.zig");
+const inf = float.inf;
+const nan = float.nan;
+const snan = float.snan;
 
 /// Performs an approximate comparison of two floating point values `x` and `y`.
 /// Returns true if the absolute difference between them is less or equal than
@@ -64,7 +54,7 @@ pub const snan = float.snan;
 ///
 /// The `tolerance` parameter is the absolute tolerance used when determining if
 /// the two numbers are close enough; a good value for this parameter is a small
-/// multiple of `floatEps(T)`.
+/// multiple of `float.eps(T)`.
 ///
 /// Note that this function is recommended for comparing small numbers
 /// around zero; using `approxEqRel` is suggested otherwise.
@@ -91,7 +81,7 @@ pub fn approxEqAbs(comptime T: type, x: T, y: T, tolerance: T) bool {
 ///
 /// The `tolerance` parameter is the relative tolerance used when determining if
 /// the two numbers are close enough; a good value for this parameter is usually
-/// `sqrt(floatEps(T))`, meaning that the two numbers are considered equal if at
+/// `sqrt(float.eps(T))`, meaning that the two numbers are considered equal if at
 /// least half of the digits are equal.
 ///
 /// Note that for comparisons of small numbers around zero this function won't
@@ -114,8 +104,8 @@ pub fn approxEqRel(comptime T: type, x: T, y: T, tolerance: T) bool {
 
 test approxEqAbs {
     inline for ([_]type{ f16, f32, f64, f128 }) |T| {
-        const eps_value = comptime floatEps(T);
-        const min_value = comptime floatMin(T);
+        const eps_value = comptime float.eps(T);
+        const min_value = comptime float.min(T);
 
         try testing.expect(approxEqAbs(T, 0.0, 0.0, eps_value));
         try testing.expect(approxEqAbs(T, -0.0, -0.0, eps_value));
@@ -144,11 +134,11 @@ test approxEqAbs {
 
 test approxEqRel {
     inline for ([_]type{ f16, f32, f64, f128 }) |T| {
-        const eps_value = comptime floatEps(T);
+        const eps_value = comptime float.eps(T);
         const sqrt_eps_value = comptime sqrt(eps_value);
         const nan_value = comptime nan(T);
         const inf_value = comptime inf(T);
-        const min_value = comptime floatMin(T);
+        const min_value = comptime float.min(T);
 
         try testing.expect(approxEqRel(T, 1.0, 1.0, sqrt_eps_value));
         try testing.expect(!approxEqRel(T, 1.0, 0.0, sqrt_eps_value));
@@ -343,15 +333,15 @@ pub const Complex = complex.Complex;
 pub const big = @import("math/big.zig");
 
 test {
-    _ = floatExponentBits;
-    _ = floatMantissaBits;
-    _ = floatFractionalBits;
-    _ = floatExponentMin;
-    _ = floatExponentMax;
-    _ = floatTrueMin;
-    _ = floatMin;
-    _ = floatMax;
-    _ = floatEps;
+    _ = float.exponentBits;
+    _ = float.mantissaBits;
+    _ = float.fractionalBits;
+    _ = float.exponentMin;
+    _ = float.exponentMax;
+    _ = float.trueMin;
+    _ = float.min;
+    _ = float.max;
+    _ = float.eps;
     _ = inf;
     _ = nan;
     _ = snan;

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -43,6 +43,20 @@ pub const rad_per_deg = 0.017453292519943295769236907684886127134428718885417254
 /// 180.0/pi
 pub const deg_per_rad = 57.295779513082320876798154814105170332405472466564321549160243861;
 
+pub const floatExponentBits = @compileError("Deprecated, use float.exponentBits instead.");
+pub const floatMantissaBits = @compileError("Deprecated, use float.mantissaBits instead.");
+pub const floatFractionalBits = @compileError("Deprecated, use float.fractionalBits instead.");
+pub const floatExponentMin = @compileError("Deprecated, use float.exponentMin instead.");
+pub const floatExponentMax = @compileError("Deprecated, use float.exponentMax instead.");
+pub const floatTrueMin = @compileError("Deprecated, use float.trueMin instead.");
+pub const floatMin = @compileError("Deprecated, use float.min instead.");
+pub const floatMax = @compileError("Deprecated, use float.max instead.");
+pub const floatEps = @compileError("Deprecated, use float.eps instead.");
+pub const floatEpsAt = @compileError("Deprecated, use float.epsAt instead.");
+pub const inf = @compileError("Deprecated, use float.inf instead.");
+pub const nan = @compileError("Deprecated, use float.nan instead.");
+pub const snan = @compileError("Deprecated, use float.snan instead.");
+
 /// Performs an approximate comparison of two floating point values `x` and `y`.
 /// Returns true if the absolute difference between them is less or equal than
 /// the specified tolerance.

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -43,11 +43,6 @@ pub const rad_per_deg = 0.017453292519943295769236907684886127134428718885417254
 /// 180.0/pi
 pub const deg_per_rad = 57.295779513082320876798154814105170332405472466564321549160243861;
 
-pub const float = @import("math/float.zig");
-const inf = float.inf;
-const nan = float.nan;
-const snan = float.snan;
-
 /// Performs an approximate comparison of two floating point values `x` and `y`.
 /// Returns true if the absolute difference between them is less or equal than
 /// the specified tolerance.
@@ -136,8 +131,8 @@ test approxEqRel {
     inline for ([_]type{ f16, f32, f64, f128 }) |T| {
         const eps_value = comptime float.eps(T);
         const sqrt_eps_value = comptime sqrt(eps_value);
-        const nan_value = comptime nan(T);
-        const inf_value = comptime inf(T);
+        const nan_value = comptime float.nan(T);
+        const inf_value = comptime float.inf(T);
         const min_value = comptime float.min(T);
 
         try testing.expect(approxEqRel(T, 1.0, 1.0, sqrt_eps_value));
@@ -329,7 +324,7 @@ pub inline fn exp2(value: anytype) @TypeOf(value) {
 
 pub const complex = @import("math/complex.zig");
 pub const Complex = complex.Complex;
-
+pub const float = @import("math/float.zig");
 pub const big = @import("math/big.zig");
 
 test {
@@ -342,9 +337,9 @@ test {
     _ = float.min;
     _ = float.max;
     _ = float.eps;
-    _ = inf;
-    _ = nan;
-    _ = snan;
+    _ = float.inf;
+    _ = float.nan;
+    _ = float.snan;
     _ = isNan;
     _ = isSignalNan;
     _ = frexp;
@@ -1345,7 +1340,7 @@ test lossyCast {
     try testing.expect(lossyCast(u32, @as(i16, -255)) == @as(u32, 0));
     try testing.expect(lossyCast(i9, @as(u32, 200)) == @as(i9, 200));
     try testing.expect(lossyCast(u32, @as(f32, maxInt(u32))) == maxInt(u32));
-    try testing.expect(lossyCast(u32, nan(f32)) == 0);
+    try testing.expect(lossyCast(u32, float.nan(f32)) == 0);
 }
 
 /// Performs linear interpolation between *a* and *b* based on *t*.

--- a/lib/std/math/acos.zig
+++ b/lib/std/math/acos.zig
@@ -48,7 +48,7 @@ fn acos32(x: f32) f32 {
                 return 0.0;
             }
         } else {
-            return math.nan(f32);
+            return math.float.nan(f32);
         }
     }
 
@@ -117,7 +117,7 @@ fn acos64(x: f64) f64 {
             }
         }
 
-        return math.nan(f64);
+        return math.float.nan(f64);
     }
 
     // |x| < 0.5

--- a/lib/std/math/acosh.zig
+++ b/lib/std/math/acosh.zig
@@ -83,11 +83,11 @@ test acosh64 {
 }
 
 test "acosh32.special" {
-    try expect(math.isNan(acosh32(math.nan(f32))));
+    try expect(math.isNan(acosh32(math.float.nan(f32))));
     try expect(math.isNan(acosh32(0.5)));
 }
 
 test "acosh64.special" {
-    try expect(math.isNan(acosh64(math.nan(f64))));
+    try expect(math.isNan(acosh64(math.float.nan(f64))));
     try expect(math.isNan(acosh64(0.5)));
 }

--- a/lib/std/math/asin.zig
+++ b/lib/std/math/asin.zig
@@ -45,7 +45,7 @@ fn asin32(x: f32) f32 {
         if (ix == 0x3F800000) {
             return x * pio2 + 0x1.0p-120; // asin(+-1) = +-pi/2 with inexact
         } else {
-            return math.nan(f32); // asin(|x| > 1) is nan
+            return math.float.nan(f32); // asin(|x| > 1) is nan
         }
     }
 
@@ -104,7 +104,7 @@ fn asin64(x: f64) f64 {
         if ((ix - 0x3FF00000) | lx == 0) {
             return x * pio2_hi + 0x1.0p-120;
         } else {
-            return math.nan(f64);
+            return math.float.nan(f64);
         }
     }
 

--- a/lib/std/math/asinh.zig
+++ b/lib/std/math/asinh.zig
@@ -114,15 +114,15 @@ test asinh64 {
 test "asinh32.special" {
     try expect(math.isPositiveZero(asinh32(0.0)));
     try expect(math.isNegativeZero(asinh32(-0.0)));
-    try expect(math.isPositiveInf(asinh32(math.inf(f32))));
-    try expect(math.isNegativeInf(asinh32(-math.inf(f32))));
-    try expect(math.isNan(asinh32(math.nan(f32))));
+    try expect(math.isPositiveInf(asinh32(math.float.inf(f32))));
+    try expect(math.isNegativeInf(asinh32(-math.float.inf(f32))));
+    try expect(math.isNan(asinh32(math.float.nan(f32))));
 }
 
 test "asinh64.special" {
     try expect(math.isPositiveZero(asinh64(0.0)));
     try expect(math.isNegativeZero(asinh64(-0.0)));
-    try expect(math.isPositiveInf(asinh64(math.inf(f64))));
-    try expect(math.isNegativeInf(asinh64(-math.inf(f64))));
-    try expect(math.isNan(asinh64(math.nan(f64))));
+    try expect(math.isPositiveInf(asinh64(math.float.inf(f64))));
+    try expect(math.isNegativeInf(asinh64(-math.float.inf(f64))));
+    try expect(math.isNan(asinh64(math.float.nan(f64))));
 }

--- a/lib/std/math/atan.zig
+++ b/lib/std/math/atan.zig
@@ -242,8 +242,8 @@ test "atan32.special" {
 
     try expect(math.isPositiveZero(atan32(0.0)));
     try expect(math.isNegativeZero(atan32(-0.0)));
-    try expect(math.approxEqAbs(f32, atan32(math.inf(f32)), math.pi / 2.0, epsilon));
-    try expect(math.approxEqAbs(f32, atan32(-math.inf(f32)), -math.pi / 2.0, epsilon));
+    try expect(math.approxEqAbs(f32, atan32(math.float.inf(f32)), math.pi / 2.0, epsilon));
+    try expect(math.approxEqAbs(f32, atan32(-math.float.inf(f32)), -math.pi / 2.0, epsilon));
 }
 
 test "atan64.special" {
@@ -251,6 +251,6 @@ test "atan64.special" {
 
     try expect(math.isPositiveZero(atan64(0.0)));
     try expect(math.isNegativeZero(atan64(-0.0)));
-    try expect(math.approxEqAbs(f64, atan64(math.inf(f64)), math.pi / 2.0, epsilon));
-    try expect(math.approxEqAbs(f64, atan64(-math.inf(f64)), -math.pi / 2.0, epsilon));
+    try expect(math.approxEqAbs(f64, atan64(math.float.inf(f64)), math.pi / 2.0, epsilon));
+    try expect(math.approxEqAbs(f64, atan64(-math.float.inf(f64)), -math.pi / 2.0, epsilon));
 }

--- a/lib/std/math/atan2.zig
+++ b/lib/std/math/atan2.zig
@@ -250,8 +250,8 @@ test atan2_64 {
 test "atan2_32.special" {
     const epsilon = 0.000001;
 
-    try expect(math.isNan(atan2_32(1.0, math.nan(f32))));
-    try expect(math.isNan(atan2_32(math.nan(f32), 1.0)));
+    try expect(math.isNan(atan2_32(1.0, math.float.nan(f32))));
+    try expect(math.isNan(atan2_32(math.float.nan(f32), 1.0)));
     try expect(atan2_32(0.0, 5.0) == 0.0);
     try expect(atan2_32(-0.0, 5.0) == -0.0);
     try expect(math.approxEqAbs(f32, atan2_32(0.0, -5.0), math.pi, epsilon));
@@ -260,22 +260,22 @@ test "atan2_32.special" {
     try expect(math.approxEqAbs(f32, atan2_32(1.0, -0.0), math.pi / 2.0, epsilon));
     try expect(math.approxEqAbs(f32, atan2_32(-1.0, 0.0), -math.pi / 2.0, epsilon));
     try expect(math.approxEqAbs(f32, atan2_32(-1.0, -0.0), -math.pi / 2.0, epsilon));
-    try expect(math.approxEqAbs(f32, atan2_32(math.inf(f32), math.inf(f32)), math.pi / 4.0, epsilon));
-    try expect(math.approxEqAbs(f32, atan2_32(-math.inf(f32), math.inf(f32)), -math.pi / 4.0, epsilon));
-    try expect(math.approxEqAbs(f32, atan2_32(math.inf(f32), -math.inf(f32)), 3.0 * math.pi / 4.0, epsilon));
-    try expect(math.approxEqAbs(f32, atan2_32(-math.inf(f32), -math.inf(f32)), -3.0 * math.pi / 4.0, epsilon));
-    try expect(atan2_32(1.0, math.inf(f32)) == 0.0);
-    try expect(math.approxEqAbs(f32, atan2_32(1.0, -math.inf(f32)), math.pi, epsilon));
-    try expect(math.approxEqAbs(f32, atan2_32(-1.0, -math.inf(f32)), -math.pi, epsilon));
-    try expect(math.approxEqAbs(f32, atan2_32(math.inf(f32), 1.0), math.pi / 2.0, epsilon));
-    try expect(math.approxEqAbs(f32, atan2_32(-math.inf(f32), 1.0), -math.pi / 2.0, epsilon));
+    try expect(math.approxEqAbs(f32, atan2_32(math.float.inf(f32), math.float.inf(f32)), math.pi / 4.0, epsilon));
+    try expect(math.approxEqAbs(f32, atan2_32(-math.float.inf(f32), math.float.inf(f32)), -math.pi / 4.0, epsilon));
+    try expect(math.approxEqAbs(f32, atan2_32(math.float.inf(f32), -math.float.inf(f32)), 3.0 * math.pi / 4.0, epsilon));
+    try expect(math.approxEqAbs(f32, atan2_32(-math.float.inf(f32), -math.float.inf(f32)), -3.0 * math.pi / 4.0, epsilon));
+    try expect(atan2_32(1.0, math.float.inf(f32)) == 0.0);
+    try expect(math.approxEqAbs(f32, atan2_32(1.0, -math.float.inf(f32)), math.pi, epsilon));
+    try expect(math.approxEqAbs(f32, atan2_32(-1.0, -math.float.inf(f32)), -math.pi, epsilon));
+    try expect(math.approxEqAbs(f32, atan2_32(math.float.inf(f32), 1.0), math.pi / 2.0, epsilon));
+    try expect(math.approxEqAbs(f32, atan2_32(-math.float.inf(f32), 1.0), -math.pi / 2.0, epsilon));
 }
 
 test "atan2_64.special" {
     const epsilon = 0.000001;
 
-    try expect(math.isNan(atan2_64(1.0, math.nan(f64))));
-    try expect(math.isNan(atan2_64(math.nan(f64), 1.0)));
+    try expect(math.isNan(atan2_64(1.0, math.float.nan(f64))));
+    try expect(math.isNan(atan2_64(math.float.nan(f64), 1.0)));
     try expect(atan2_64(0.0, 5.0) == 0.0);
     try expect(atan2_64(-0.0, 5.0) == -0.0);
     try expect(math.approxEqAbs(f64, atan2_64(0.0, -5.0), math.pi, epsilon));
@@ -284,13 +284,13 @@ test "atan2_64.special" {
     try expect(math.approxEqAbs(f64, atan2_64(1.0, -0.0), math.pi / 2.0, epsilon));
     try expect(math.approxEqAbs(f64, atan2_64(-1.0, 0.0), -math.pi / 2.0, epsilon));
     try expect(math.approxEqAbs(f64, atan2_64(-1.0, -0.0), -math.pi / 2.0, epsilon));
-    try expect(math.approxEqAbs(f64, atan2_64(math.inf(f64), math.inf(f64)), math.pi / 4.0, epsilon));
-    try expect(math.approxEqAbs(f64, atan2_64(-math.inf(f64), math.inf(f64)), -math.pi / 4.0, epsilon));
-    try expect(math.approxEqAbs(f64, atan2_64(math.inf(f64), -math.inf(f64)), 3.0 * math.pi / 4.0, epsilon));
-    try expect(math.approxEqAbs(f64, atan2_64(-math.inf(f64), -math.inf(f64)), -3.0 * math.pi / 4.0, epsilon));
-    try expect(atan2_64(1.0, math.inf(f64)) == 0.0);
-    try expect(math.approxEqAbs(f64, atan2_64(1.0, -math.inf(f64)), math.pi, epsilon));
-    try expect(math.approxEqAbs(f64, atan2_64(-1.0, -math.inf(f64)), -math.pi, epsilon));
-    try expect(math.approxEqAbs(f64, atan2_64(math.inf(f64), 1.0), math.pi / 2.0, epsilon));
-    try expect(math.approxEqAbs(f64, atan2_64(-math.inf(f64), 1.0), -math.pi / 2.0, epsilon));
+    try expect(math.approxEqAbs(f64, atan2_64(math.float.inf(f64), math.float.inf(f64)), math.pi / 4.0, epsilon));
+    try expect(math.approxEqAbs(f64, atan2_64(-math.float.inf(f64), math.float.inf(f64)), -math.pi / 4.0, epsilon));
+    try expect(math.approxEqAbs(f64, atan2_64(math.float.inf(f64), -math.float.inf(f64)), 3.0 * math.pi / 4.0, epsilon));
+    try expect(math.approxEqAbs(f64, atan2_64(-math.float.inf(f64), -math.float.inf(f64)), -3.0 * math.pi / 4.0, epsilon));
+    try expect(atan2_64(1.0, math.float.inf(f64)) == 0.0);
+    try expect(math.approxEqAbs(f64, atan2_64(1.0, -math.float.inf(f64)), math.pi, epsilon));
+    try expect(math.approxEqAbs(f64, atan2_64(-1.0, -math.float.inf(f64)), -math.pi, epsilon));
+    try expect(math.approxEqAbs(f64, atan2_64(math.float.inf(f64), 1.0), math.pi / 2.0, epsilon));
+    try expect(math.approxEqAbs(f64, atan2_64(-math.float.inf(f64), 1.0), -math.pi / 2.0, epsilon));
 }

--- a/lib/std/math/atanh.zig
+++ b/lib/std/math/atanh.zig
@@ -34,7 +34,7 @@ fn atanh_32(x: f32) f32 {
     var y = @as(f32, @bitCast(i)); // |x|
 
     if (y == 1.0) {
-        return math.copysign(math.inf(f32), x);
+        return math.copysign(math.float.inf(f32), x);
     }
 
     if (u < 0x3F800000 - (1 << 23)) {
@@ -63,7 +63,7 @@ fn atanh_64(x: f64) f64 {
     var y: f64 = @bitCast(u & (maxInt(u64) >> 1)); // |x|
 
     if (y == 1.0) {
-        return math.copysign(math.inf(f64), x);
+        return math.copysign(math.float.inf(f64), x);
     }
 
     if (e < 0x3FF - 1) {
@@ -110,7 +110,7 @@ test "atanh32.special" {
     try expect(math.isNegativeInf(atanh_32(-1)));
     try expect(math.isNan(atanh_32(1.5)));
     try expect(math.isNan(atanh_32(-1.5)));
-    try expect(math.isNan(atanh_32(math.nan(f32))));
+    try expect(math.isNan(atanh_32(math.float.nan(f32))));
 }
 
 test "atanh64.special" {
@@ -118,5 +118,5 @@ test "atanh64.special" {
     try expect(math.isNegativeInf(atanh_64(-1)));
     try expect(math.isNan(atanh_64(1.5)));
     try expect(math.isNan(atanh_64(-1.5)));
-    try expect(math.isNan(atanh_64(math.nan(f64))));
+    try expect(math.isNan(atanh_64(math.float.nan(f64))));
 }

--- a/lib/std/math/big/rational.zig
+++ b/lib/std/math/big/rational.zig
@@ -140,9 +140,9 @@ pub const Rational = struct {
         const UnsignedInt = std.meta.Int(.unsigned, @typeInfo(T).Float.bits);
         const f_bits = @as(UnsignedInt, @bitCast(f));
 
-        const exponent_bits = math.floatExponentBits(T);
+        const exponent_bits = math.float.exponentBits(T);
         const exponent_bias = (1 << (exponent_bits - 1)) - 1;
-        const mantissa_bits = math.floatMantissaBits(T);
+        const mantissa_bits = math.float.mantissaBits(T);
 
         const exponent_mask = (1 << exponent_bits) - 1;
         const mantissa_mask = (1 << mantissa_bits) - 1;
@@ -198,11 +198,11 @@ pub const Rational = struct {
         const fsize = @typeInfo(T).Float.bits;
         const BitReprType = std.meta.Int(.unsigned, fsize);
 
-        const msize = math.floatMantissaBits(T);
+        const msize = math.float.mantissaBits(T);
         const msize1 = msize + 1;
         const msize2 = msize1 + 1;
 
-        const esize = math.floatExponentBits(T);
+        const esize = math.float.exponentBits(T);
         const ebias = (1 << (esize - 1)) - 1;
         const emin = 1 - ebias;
 

--- a/lib/std/math/cbrt.zig
+++ b/lib/std/math/cbrt.zig
@@ -149,15 +149,15 @@ test cbrt64 {
 test "cbrt.special" {
     try expect(math.isPositiveZero(cbrt32(0.0)));
     try expect(@as(u32, @bitCast(cbrt32(-0.0))) == @as(u32, 0x80000000));
-    try expect(math.isPositiveInf(cbrt32(math.inf(f32))));
-    try expect(math.isNegativeInf(cbrt32(-math.inf(f32))));
-    try expect(math.isNan(cbrt32(math.nan(f32))));
+    try expect(math.isPositiveInf(cbrt32(math.float.inf(f32))));
+    try expect(math.isNegativeInf(cbrt32(-math.float.inf(f32))));
+    try expect(math.isNan(cbrt32(math.float.nan(f32))));
 }
 
 test "cbrt64.special" {
     try expect(math.isPositiveZero(cbrt64(0.0)));
     try expect(math.isNegativeZero(cbrt64(-0.0)));
-    try expect(math.isPositiveInf(cbrt64(math.inf(f64))));
-    try expect(math.isNegativeInf(cbrt64(-math.inf(f64))));
-    try expect(math.isNan(cbrt64(math.nan(f64))));
+    try expect(math.isPositiveInf(cbrt64(math.float.inf(f64))));
+    try expect(math.isNegativeInf(cbrt64(-math.float.inf(f64))));
+    try expect(math.isNan(cbrt64(math.float.nan(f64))));
 }

--- a/lib/std/math/complex/exp.zig
+++ b/lib/std/math/complex/exp.zig
@@ -120,7 +120,7 @@ fn exp64(z: Complex(f64)) Complex(f64) {
 }
 
 test exp32 {
-    const tolerance_f32 = @sqrt(math.floatEps(f32));
+    const tolerance_f32 = @sqrt(math.float.eps(f32));
 
     {
         const a = Complex(f32).init(5, 3);
@@ -140,7 +140,7 @@ test exp32 {
 }
 
 test exp64 {
-    const tolerance_f64 = @sqrt(math.floatEps(f64));
+    const tolerance_f64 = @sqrt(math.float.eps(f64));
 
     {
         const a = Complex(f64).init(5, 3);

--- a/lib/std/math/complex/exp.zig
+++ b/lib/std/math/complex/exp.zig
@@ -134,7 +134,7 @@ test exp32 {
         const a = Complex(f32).init(88.8, 0x1p-149);
         const c = exp(a);
 
-        try testing.expectApproxEqAbs(math.inf(f32), c.re, tolerance_f32);
+        try testing.expectApproxEqAbs(math.float.inf(f32), c.re, tolerance_f32);
         try testing.expectApproxEqAbs(@as(f32, 5.15088629e-07), c.im, tolerance_f32);
     }
 }
@@ -154,7 +154,7 @@ test exp64 {
         const a = Complex(f64).init(709.8, 0x1p-1074);
         const c = exp(a);
 
-        try testing.expectApproxEqAbs(math.inf(f64), c.re, tolerance_f64);
+        try testing.expectApproxEqAbs(math.float.inf(f64), c.re, tolerance_f64);
         try testing.expectApproxEqAbs(@as(f64, 9.036659362159884e-16), c.im, tolerance_f64);
     }
 }

--- a/lib/std/math/complex/proj.zig
+++ b/lib/std/math/complex/proj.zig
@@ -9,7 +9,7 @@ pub fn proj(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     const T = @TypeOf(z.re, z.im);
 
     if (math.isInf(z.re) or math.isInf(z.im)) {
-        return Complex(T).init(math.inf(T), math.copysign(@as(T, 0.0), z.re));
+        return Complex(T).init(math.float.inf(T), math.copysign(@as(T, 0.0), z.re));
     }
 
     return Complex(T).init(z.re, z.im);

--- a/lib/std/math/complex/sinh.zig
+++ b/lib/std/math/complex/sinh.zig
@@ -79,7 +79,7 @@ fn sinh32(z: Complex(f32)) Complex(f32) {
         if (iy >= 0x7f800000) {
             return Complex(f32).init(x * x, x * (y - y));
         }
-        return Complex(f32).init(x * @cos(y), math.inf(f32) * @sin(y));
+        return Complex(f32).init(x * @cos(y), math.float.inf(f32) * @sin(y));
     }
 
     return Complex(f32).init((x * x) * (y - y), (x + x) * (y - y));
@@ -146,7 +146,7 @@ fn sinh64(z: Complex(f64)) Complex(f64) {
         if (iy >= 0x7ff00000) {
             return Complex(f64).init(x * x, x * (y - y));
         }
-        return Complex(f64).init(x * @cos(y), math.inf(f64) * @sin(y));
+        return Complex(f64).init(x * @cos(y), math.float.inf(f64) * @sin(y));
     }
 
     return Complex(f64).init((x * x) * (y - y), (x + x) * (y - y));

--- a/lib/std/math/complex/sqrt.zig
+++ b/lib/std/math/complex/sqrt.zig
@@ -30,7 +30,7 @@ fn sqrt32(z: Complex(f32)) Complex(f32) {
         return Complex(f32).init(0, y);
     }
     if (math.isInf(y)) {
-        return Complex(f32).init(math.inf(f32), y);
+        return Complex(f32).init(math.float.inf(f32), y);
     }
     if (math.isNan(x)) {
         // raise invalid if y is not nan
@@ -81,7 +81,7 @@ fn sqrt64(z: Complex(f64)) Complex(f64) {
         return Complex(f64).init(0, y);
     }
     if (math.isInf(y)) {
-        return Complex(f64).init(math.inf(f64), y);
+        return Complex(f64).init(math.float.inf(f64), y);
     }
     if (math.isNan(x)) {
         // raise invalid if y is not nan

--- a/lib/std/math/copysign.zig
+++ b/lib/std/math/copysign.zig
@@ -19,7 +19,7 @@ test copysign {
         try expect(copysign(@as(T, -3.0), @as(T, 3.0)) == 3.0);
         try expect(copysign(@as(T, -4.0), @as(T, -4.0)) == -4.0);
         try expect(copysign(@as(T, 5.0), @as(T, -500.0)) == -5.0);
-        try expect(copysign(math.inf(T), @as(T, -0.0)) == -math.inf(T));
-        try expect(copysign(@as(T, 6.0), -math.nan(T)) == -6.0);
+        try expect(copysign(math.float.inf(T), @as(T, -0.0)) == -math.float.inf(T));
+        try expect(copysign(@as(T, 6.0), -math.float.nan(T)) == -6.0);
     }
 }

--- a/lib/std/math/cosh.zig
+++ b/lib/std/math/cosh.zig
@@ -120,15 +120,15 @@ test cosh64 {
 test "cosh32.special" {
     try expect(cosh32(0.0) == 1.0);
     try expect(cosh32(-0.0) == 1.0);
-    try expect(math.isPositiveInf(cosh32(math.inf(f32))));
-    try expect(math.isPositiveInf(cosh32(-math.inf(f32))));
-    try expect(math.isNan(cosh32(math.nan(f32))));
+    try expect(math.isPositiveInf(cosh32(math.float.inf(f32))));
+    try expect(math.isPositiveInf(cosh32(-math.float.inf(f32))));
+    try expect(math.isNan(cosh32(math.float.nan(f32))));
 }
 
 test "cosh64.special" {
     try expect(cosh64(0.0) == 1.0);
     try expect(cosh64(-0.0) == 1.0);
-    try expect(math.isPositiveInf(cosh64(math.inf(f64))));
-    try expect(math.isPositiveInf(cosh64(-math.inf(f64))));
-    try expect(math.isNan(cosh64(math.nan(f64))));
+    try expect(math.isPositiveInf(cosh64(math.float.inf(f64))));
+    try expect(math.isPositiveInf(cosh64(-math.float.inf(f64))));
+    try expect(math.isNan(cosh64(math.float.nan(f64))));
 }

--- a/lib/std/math/expm1.zig
+++ b/lib/std/math/expm1.zig
@@ -29,7 +29,7 @@ pub fn expm1(x: anytype) @TypeOf(x) {
 
 fn expm1_32(x_: f32) f32 {
     if (math.isNan(x_))
-        return math.nan(f32);
+        return math.float.nan(f32);
 
     const o_threshold: f32 = 8.8721679688e+01;
     const ln2_hi: f32 = 6.9313812256e-01;
@@ -157,7 +157,7 @@ fn expm1_32(x_: f32) f32 {
 
 fn expm1_64(x_: f64) f64 {
     if (math.isNan(x_))
-        return math.nan(f64);
+        return math.float.nan(f64);
 
     const o_threshold: f64 = 7.09782712893383973096e+02;
     const ln2_hi: f64 = 6.93147180369123816490e-01;
@@ -190,7 +190,7 @@ fn expm1_64(x_: f64) f64 {
         }
         if (x > o_threshold) {
             math.raiseOverflow();
-            return math.inf(f64);
+            return math.float.inf(f64);
         }
     }
 
@@ -312,13 +312,13 @@ test expm1_64 {
 }
 
 test "expm1_32.special" {
-    try expect(math.isPositiveInf(expm1_32(math.inf(f32))));
-    try expect(expm1_32(-math.inf(f32)) == -1.0);
-    try expect(math.isNan(expm1_32(math.nan(f32))));
+    try expect(math.isPositiveInf(expm1_32(math.float.inf(f32))));
+    try expect(expm1_32(-math.float.inf(f32)) == -1.0);
+    try expect(math.isNan(expm1_32(math.float.nan(f32))));
 }
 
 test "expm1_64.special" {
-    try expect(math.isPositiveInf(expm1_64(math.inf(f64))));
-    try expect(expm1_64(-math.inf(f64)) == -1.0);
-    try expect(math.isNan(expm1_64(math.nan(f64))));
+    try expect(math.isPositiveInf(expm1_64(math.float.inf(f64))));
+    try expect(expm1_64(-math.float.inf(f64)) == -1.0);
+    try expect(math.isNan(expm1_64(math.float.nan(f64))));
 }

--- a/lib/std/math/frexp.zig
+++ b/lib/std/math/frexp.zig
@@ -139,16 +139,16 @@ fn FrexpTests(comptime Float: type) type {
         test "inf" {
             var r: Frexp(T) = undefined;
 
-            r = frexp(math.inf(T));
+            r = frexp(math.float.inf(T));
             try expectEqual(0, r.exponent);
             try expect(math.isPositiveInf(r.significand));
 
-            r = frexp(-math.inf(T));
+            r = frexp(-math.float.inf(T));
             try expectEqual(0, r.exponent);
             try expect(math.isNegativeInf(r.significand));
         }
         test "nan" {
-            const r: Frexp(T) = frexp(math.nan(T));
+            const r: Frexp(T) = frexp(math.float.nan(T));
             try expect(math.isNan(r.significand));
         }
     };
@@ -202,12 +202,12 @@ test frexp {
         try expectEqual(x, math.ldexp(result.significand, result.exponent));
 
         // infinity -> {infinity, zero} (+)
-        result = frexp(math.inf(T));
+        result = frexp(math.float.inf(T));
         try expectEqual(0, result.exponent);
         try expect(math.isPositiveInf(result.significand));
 
         // infinity -> {infinity, zero} (-)
-        result = frexp(-math.inf(T));
+        result = frexp(-math.float.inf(T));
         try expectEqual(0, result.exponent);
         try expect(math.isNegativeInf(result.significand));
 
@@ -222,7 +222,7 @@ test frexp {
         try expect(math.isNegativeZero(result.significand));
 
         // nan -> {nan, undefined}
-        result = frexp(math.nan(T));
+        result = frexp(math.float.nan(T));
         try expect(math.isNan(result.significand));
     }
 }

--- a/lib/std/math/frexp.zig
+++ b/lib/std/math/frexp.zig
@@ -24,10 +24,10 @@ pub fn frexp(x: anytype) Frexp(@TypeOf(x)) {
     const bits: comptime_int = @typeInfo(T).Float.bits;
     const Int: type = std.meta.Int(.unsigned, bits);
 
-    const exp_bits: comptime_int = math.floatExponentBits(T);
-    const mant_bits: comptime_int = math.floatMantissaBits(T);
-    const frac_bits: comptime_int = math.floatFractionalBits(T);
-    const exp_min: comptime_int = math.floatExponentMin(T);
+    const exp_bits: comptime_int = math.float.exponentBits(T);
+    const mant_bits: comptime_int = math.float.mantissaBits(T);
+    const frac_bits: comptime_int = math.float.fractionalBits(T);
+    const exp_min: comptime_int = math.float.exponentMin(T);
 
     const ExpInt: type = std.meta.Int(.unsigned, exp_bits);
     const MantInt: type = std.meta.Int(.unsigned, mant_bits);
@@ -106,22 +106,22 @@ fn FrexpTests(comptime Float: type) type {
             try expectApproxEqAbs(-0.602816, r.significand, epsilon);
         }
         test "max" {
-            const exponent = math.floatExponentMax(T) + 1;
-            const significand = 1.0 - math.floatEps(T) / 2;
-            const r: Frexp(T) = frexp(math.floatMax(T));
+            const exponent = math.float.exponentMax(T) + 1;
+            const significand = 1.0 - math.float.eps(T) / 2;
+            const r: Frexp(T) = frexp(math.float.max(T));
             try expectEqual(exponent, r.exponent);
             try expectEqual(significand, r.significand);
         }
         test "min" {
-            const exponent = math.floatExponentMin(T) + 1;
-            const r: Frexp(T) = frexp(math.floatMin(T));
+            const exponent = math.float.exponentMin(T) + 1;
+            const r: Frexp(T) = frexp(math.float.min(T));
             try expectEqual(exponent, r.exponent);
             try expectEqual(0.5, r.significand);
         }
         test "subnormal" {
-            const normal_min_exponent = math.floatExponentMin(T) + 1;
-            const exponent = normal_min_exponent - math.floatFractionalBits(T);
-            const r: Frexp(T) = frexp(math.floatTrueMin(T));
+            const normal_min_exponent = math.float.exponentMin(T) + 1;
+            const exponent = normal_min_exponent - math.float.fractionalBits(T);
+            const r: Frexp(T) = frexp(math.float.trueMin(T));
             try expectEqual(exponent, r.exponent);
             try expectEqual(0.5, r.significand);
         }
@@ -163,9 +163,9 @@ comptime {
 
 test frexp {
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
-        const max_exponent = math.floatExponentMax(T) + 1;
-        const min_exponent = math.floatExponentMin(T) + 1;
-        const truemin_exponent = min_exponent - math.floatFractionalBits(T);
+        const max_exponent = math.float.exponentMax(T) + 1;
+        const min_exponent = math.float.exponentMin(T) + 1;
+        const truemin_exponent = min_exponent - math.float.fractionalBits(T);
 
         var result: Frexp(T) = undefined;
         comptime var x: T = undefined;
@@ -180,14 +180,14 @@ test frexp {
         try expectEqual(x, math.ldexp(result.significand, result.exponent));
 
         // float maximum
-        x = math.floatMax(T);
+        x = math.float.max(T);
         result = frexp(x);
         try expectEqual(max_exponent, result.exponent);
-        try expectEqual(1.0 - math.floatEps(T) / 2, result.significand);
+        try expectEqual(1.0 - math.float.eps(T) / 2, result.significand);
         try expectEqual(x, math.ldexp(result.significand, result.exponent));
 
         // float minimum
-        x = math.floatMin(T);
+        x = math.float.min(T);
         result = frexp(x);
         try expectEqual(min_exponent, result.exponent);
         try expectEqual(0.5, result.significand);
@@ -195,7 +195,7 @@ test frexp {
 
         // float true minimum
         // subnormal -> {normal, exponent}
-        x = math.floatTrueMin(T);
+        x = math.float.trueMin(T);
         result = frexp(x);
         try expectEqual(truemin_exponent, result.exponent);
         try expectEqual(0.5, result.significand);

--- a/lib/std/math/gamma.zig
+++ b/lib/std/math/gamma.zig
@@ -242,7 +242,7 @@ const expectApproxEqRel = std.testing.expectApproxEqRel;
 
 test gamma {
     inline for (&.{ f32, f64 }) |T| {
-        const eps = @sqrt(std.math.floatEps(T));
+        const eps = @sqrt(std.math.float.eps(T));
         try expectApproxEqRel(@as(T, 120), gamma(T, 6), eps);
         try expectApproxEqRel(@as(T, 362880), gamma(T, 10), eps);
         try expectApproxEqRel(@as(T, 6402373705728000), gamma(T, 19), eps);
@@ -288,7 +288,7 @@ test "gamma.special" {
 
 test lgamma {
     inline for (&.{ f32, f64 }) |T| {
-        const eps = @sqrt(std.math.floatEps(T));
+        const eps = @sqrt(std.math.float.eps(T));
         try expectApproxEqRel(@as(T, @log(24.0)), lgamma(T, 5), eps);
         try expectApproxEqRel(@as(T, @log(20922789888000.0)), lgamma(T, 17), eps);
         try expectApproxEqRel(@as(T, @log(2432902008176640000.0)), lgamma(T, 21), eps);

--- a/lib/std/math/gamma.zig
+++ b/lib/std/math/gamma.zig
@@ -24,7 +24,7 @@ pub fn gamma(comptime T: type, x: T) T {
         // gamma(-inf) = nan
         // gamma(n)    = nan for negative integers
         if (x < 0) {
-            return std.math.nan(T);
+            return std.math.float.nan(T);
         }
         // gamma(-0.0) = -inf
         // gamma(+0.0) = +inf
@@ -49,7 +49,7 @@ pub fn gamma(comptime T: type, x: T) T {
     // gamma(+inf) = +inf
     const upper_bound = if (T == f64) 172 else 36;
     if (x > upper_bound) {
-        return std.math.inf(T);
+        return std.math.float.inf(T);
     }
 
     const abs = @abs(x);
@@ -101,7 +101,7 @@ pub fn lgamma(comptime T: type, x: T) T {
         // lgamma(n)     = +inf for negative integers
         // lgamma(+-0.0) = +inf
         if (x <= 0) {
-            return std.math.inf(T);
+            return std.math.float.inf(T);
         }
         // lgamma(1) = +0.0
         // lgamma(2) = +0.0
@@ -142,7 +142,7 @@ pub fn lgamma(comptime T: type, x: T) T {
 // table of factorials for integer early return
 // stops at 22 because 23 isn't representable with full precision on f64
 const integer_result_table = [_]f64{
-    std.math.inf(f64), // gamma(+0.0)
+    std.math.float.inf(f64), // gamma(+0.0)
     1, // gamma(1)
     1, // ...
     2,
@@ -263,26 +263,26 @@ test gamma {
 
 test "gamma.special" {
     inline for (&.{ f32, f64 }) |T| {
-        try expect(std.math.isNan(gamma(T, -std.math.nan(T))));
-        try expect(std.math.isNan(gamma(T, std.math.nan(T))));
-        try expect(std.math.isNan(gamma(T, -std.math.inf(T))));
+        try expect(std.math.isNan(gamma(T, -std.math.float.nan(T))));
+        try expect(std.math.isNan(gamma(T, std.math.float.nan(T))));
+        try expect(std.math.isNan(gamma(T, -std.math.float.inf(T))));
 
         try expect(std.math.isNan(gamma(T, -4)));
         try expect(std.math.isNan(gamma(T, -11)));
         try expect(std.math.isNan(gamma(T, -78)));
 
-        try expectEqual(-std.math.inf(T), gamma(T, -0.0));
-        try expectEqual(std.math.inf(T), gamma(T, 0.0));
+        try expectEqual(-std.math.float.inf(T), gamma(T, -0.0));
+        try expectEqual(std.math.float.inf(T), gamma(T, 0.0));
 
         try expect(std.math.isNegativeZero(gamma(T, -200.5)));
         try expect(std.math.isPositiveZero(gamma(T, -201.5)));
         try expect(std.math.isNegativeZero(gamma(T, -202.5)));
 
-        try expectEqual(std.math.inf(T), gamma(T, 200));
-        try expectEqual(std.math.inf(T), gamma(T, 201));
-        try expectEqual(std.math.inf(T), gamma(T, 202));
+        try expectEqual(std.math.float.inf(T), gamma(T, 200));
+        try expectEqual(std.math.float.inf(T), gamma(T, 201));
+        try expectEqual(std.math.float.inf(T), gamma(T, 202));
 
-        try expectEqual(std.math.inf(T), gamma(T, std.math.inf(T)));
+        try expectEqual(std.math.float.inf(T), gamma(T, std.math.float.inf(T)));
     }
 }
 
@@ -309,18 +309,18 @@ test lgamma {
 
 test "lgamma.special" {
     inline for (&.{ f32, f64 }) |T| {
-        try expect(std.math.isNan(lgamma(T, -std.math.nan(T))));
-        try expect(std.math.isNan(lgamma(T, std.math.nan(T))));
+        try expect(std.math.isNan(lgamma(T, -std.math.float.nan(T))));
+        try expect(std.math.isNan(lgamma(T, std.math.float.nan(T))));
 
-        try expectEqual(std.math.inf(T), lgamma(T, -std.math.inf(T)));
-        try expectEqual(std.math.inf(T), lgamma(T, std.math.inf(T)));
+        try expectEqual(std.math.float.inf(T), lgamma(T, -std.math.float.inf(T)));
+        try expectEqual(std.math.float.inf(T), lgamma(T, std.math.float.inf(T)));
 
-        try expectEqual(std.math.inf(T), lgamma(T, -5));
-        try expectEqual(std.math.inf(T), lgamma(T, -8));
-        try expectEqual(std.math.inf(T), lgamma(T, -15));
+        try expectEqual(std.math.float.inf(T), lgamma(T, -5));
+        try expectEqual(std.math.float.inf(T), lgamma(T, -8));
+        try expectEqual(std.math.float.inf(T), lgamma(T, -15));
 
-        try expectEqual(std.math.inf(T), lgamma(T, -0.0));
-        try expectEqual(std.math.inf(T), lgamma(T, 0.0));
+        try expectEqual(std.math.float.inf(T), lgamma(T, -0.0));
+        try expectEqual(std.math.float.inf(T), lgamma(T, 0.0));
 
         try expect(std.math.isPositiveZero(lgamma(T, 1)));
         try expect(std.math.isPositiveZero(lgamma(T, 2)));

--- a/lib/std/math/hypot.zig
+++ b/lib/std/math/hypot.zig
@@ -3,12 +3,12 @@ const math = std.math;
 const expect = std.testing.expect;
 const isNan = math.isNan;
 const isInf = math.isInf;
-const inf = math.inf;
-const nan = math.nan;
-const floatEpsAt = math.floatEpsAt;
-const floatEps = math.floatEps;
-const floatMin = math.floatMin;
-const floatMax = math.floatMax;
+const inf = math.float.inf;
+const nan = math.float.nan;
+const epsAt = math.float.epsAt;
+const eps = math.float.eps;
+const min = math.float.min;
+const max = math.float.max;
 
 /// Returns sqrt(x * x + y * y), avoiding unnecessary overflow and underflow.
 ///
@@ -27,10 +27,10 @@ pub fn hypot(x: anytype, y: anytype) @TypeOf(x, y) {
         .ComptimeFloat => return @sqrt(x * x + y * y),
         else => @compileError("hypot not implemented for " ++ @typeName(T)),
     }
-    const lower = @sqrt(floatMin(T));
-    const upper = @sqrt(floatMax(T) / 2);
-    const incre = @sqrt(floatEps(T) / 2);
-    const scale = floatEpsAt(T, incre);
+    const lower = @sqrt(min(T));
+    const upper = @sqrt(max(T) / 2);
+    const incre = @sqrt(eps(T) / 2);
+    const scale = epsAt(T, incre);
     const hypfn = if (emulateFma(T)) hypotUnfused else hypotFused;
     var major: T = x;
     var minor: T = y;
@@ -99,7 +99,7 @@ test "hypot.correct" {
     inline for (.{ f16, f32, f64, f128 }) |T| {
         inline for (hypot_test_cases) |v| {
             const a: T, const b: T, const c: T = v;
-            try expect(math.approxEqRel(T, hypot(a, b), c, @sqrt(floatEps(T))));
+            try expect(math.approxEqRel(T, hypot(a, b), c, @sqrt(eps(T))));
         }
     }
 }
@@ -108,7 +108,7 @@ test "hypot.precise" {
     inline for (.{ f16, f32, f64 }) |T| { // f128 seems to be 5 ulp
         inline for (hypot_test_cases) |v| {
             const a: T, const b: T, const c: T = v;
-            try expect(math.approxEqRel(T, hypot(a, b), c, floatEps(T)));
+            try expect(math.approxEqRel(T, hypot(a, b), c, eps(T)));
         }
     }
 }

--- a/lib/std/math/ilogb.zig
+++ b/lib/std/math/ilogb.zig
@@ -54,7 +54,7 @@ fn ilogbX(comptime T: type, x: T) i32 {
 
     if (e == maxExponent) {
         math.raiseInvalid();
-        if (u > @as(Z, @bitCast(math.inf(T)))) {
+        if (u > @as(Z, @bitCast(math.float.inf(T)))) {
             return fp_ilogbnan; // u is a NaN
         } else return maxInt(i32);
     }
@@ -136,36 +136,36 @@ test "128" {
 }
 
 test "16 special" {
-    try expect(ilogbX(f16, math.inf(f16)) == maxInt(i32));
-    try expect(ilogbX(f16, -math.inf(f16)) == maxInt(i32));
+    try expect(ilogbX(f16, math.float.inf(f16)) == maxInt(i32));
+    try expect(ilogbX(f16, -math.float.inf(f16)) == maxInt(i32));
     try expect(ilogbX(f16, 0.0) == minInt(i32));
-    try expect(ilogbX(f16, math.nan(f16)) == fp_ilogbnan);
+    try expect(ilogbX(f16, math.float.nan(f16)) == fp_ilogbnan);
 }
 
 test "32 special" {
-    try expect(ilogbX(f32, math.inf(f32)) == maxInt(i32));
-    try expect(ilogbX(f32, -math.inf(f32)) == maxInt(i32));
+    try expect(ilogbX(f32, math.float.inf(f32)) == maxInt(i32));
+    try expect(ilogbX(f32, -math.float.inf(f32)) == maxInt(i32));
     try expect(ilogbX(f32, 0.0) == minInt(i32));
-    try expect(ilogbX(f32, math.nan(f32)) == fp_ilogbnan);
+    try expect(ilogbX(f32, math.float.nan(f32)) == fp_ilogbnan);
 }
 
 test "64 special" {
-    try expect(ilogbX(f64, math.inf(f64)) == maxInt(i32));
-    try expect(ilogbX(f64, -math.inf(f64)) == maxInt(i32));
+    try expect(ilogbX(f64, math.float.inf(f64)) == maxInt(i32));
+    try expect(ilogbX(f64, -math.float.inf(f64)) == maxInt(i32));
     try expect(ilogbX(f64, 0.0) == minInt(i32));
-    try expect(ilogbX(f64, math.nan(f64)) == fp_ilogbnan);
+    try expect(ilogbX(f64, math.float.nan(f64)) == fp_ilogbnan);
 }
 
 test "80 special" {
-    try expect(ilogbX(f80, math.inf(f80)) == maxInt(i32));
-    try expect(ilogbX(f80, -math.inf(f80)) == maxInt(i32));
+    try expect(ilogbX(f80, math.float.inf(f80)) == maxInt(i32));
+    try expect(ilogbX(f80, -math.float.inf(f80)) == maxInt(i32));
     try expect(ilogbX(f80, 0.0) == minInt(i32));
-    try expect(ilogbX(f80, math.nan(f80)) == fp_ilogbnan);
+    try expect(ilogbX(f80, math.float.nan(f80)) == fp_ilogbnan);
 }
 
 test "128 special" {
-    try expect(ilogbX(f128, math.inf(f128)) == maxInt(i32));
-    try expect(ilogbX(f128, -math.inf(f128)) == maxInt(i32));
+    try expect(ilogbX(f128, math.float.inf(f128)) == maxInt(i32));
+    try expect(ilogbX(f128, -math.float.inf(f128)) == maxInt(i32));
     try expect(ilogbX(f128, 0.0) == minInt(i32));
-    try expect(ilogbX(f128, math.nan(f128)) == fp_ilogbnan);
+    try expect(ilogbX(f128, math.float.nan(f128)) == fp_ilogbnan);
 }

--- a/lib/std/math/ilogb.zig
+++ b/lib/std/math/ilogb.zig
@@ -27,8 +27,8 @@ pub const fp_ilogb0 = minInt(i32);
 
 fn ilogbX(comptime T: type, x: T) i32 {
     const typeWidth = @typeInfo(T).Float.bits;
-    const significandBits = math.floatMantissaBits(T);
-    const exponentBits = math.floatExponentBits(T);
+    const significandBits = math.float.mantissaBits(T);
+    const exponentBits = math.float.exponentBits(T);
 
     const Z = std.meta.Int(.unsigned, typeWidth);
 

--- a/lib/std/math/isfinite.zig
+++ b/lib/std/math/isfinite.zig
@@ -19,11 +19,11 @@ test isFinite {
         // zero & subnormals
         try expect(isFinite(@as(T, 0.0)));
         try expect(isFinite(@as(T, -0.0)));
-        try expect(isFinite(math.floatTrueMin(T)));
+        try expect(isFinite(math.float.trueMin(T)));
 
         // other float limits
-        try expect(isFinite(math.floatMin(T)));
-        try expect(isFinite(math.floatMax(T)));
+        try expect(isFinite(math.float.min(T)));
+        try expect(isFinite(math.float.max(T)));
 
         // inf & nan
         try expect(!isFinite(math.inf(T)));

--- a/lib/std/math/isfinite.zig
+++ b/lib/std/math/isfinite.zig
@@ -7,7 +7,7 @@ pub fn isFinite(x: anytype) bool {
     const T = @TypeOf(x);
     const TBits = std.meta.Int(.unsigned, @typeInfo(T).Float.bits);
     const remove_sign = ~@as(TBits, 0) >> 1;
-    return @as(TBits, @bitCast(x)) & remove_sign < @as(TBits, @bitCast(math.inf(T)));
+    return @as(TBits, @bitCast(x)) & remove_sign < @as(TBits, @bitCast(math.float.inf(T)));
 }
 
 test isFinite {
@@ -26,9 +26,9 @@ test isFinite {
         try expect(isFinite(math.float.max(T)));
 
         // inf & nan
-        try expect(!isFinite(math.inf(T)));
-        try expect(!isFinite(-math.inf(T)));
-        try expect(!isFinite(math.nan(T)));
-        try expect(!isFinite(-math.nan(T)));
+        try expect(!isFinite(math.float.inf(T)));
+        try expect(!isFinite(-math.float.inf(T)));
+        try expect(!isFinite(math.float.nan(T)));
+        try expect(!isFinite(-math.float.nan(T)));
     }
 }

--- a/lib/std/math/isinf.zig
+++ b/lib/std/math/isinf.zig
@@ -7,27 +7,27 @@ pub inline fn isInf(x: anytype) bool {
     const T = @TypeOf(x);
     const TBits = std.meta.Int(.unsigned, @typeInfo(T).Float.bits);
     const remove_sign = ~@as(TBits, 0) >> 1;
-    return @as(TBits, @bitCast(x)) & remove_sign == @as(TBits, @bitCast(math.inf(T)));
+    return @as(TBits, @bitCast(x)) & remove_sign == @as(TBits, @bitCast(math.float.inf(T)));
 }
 
 /// Returns whether x is an infinity with a positive sign.
 pub inline fn isPositiveInf(x: anytype) bool {
-    return x == math.inf(@TypeOf(x));
+    return x == math.float.inf(@TypeOf(x));
 }
 
 /// Returns whether x is an infinity with a negative sign.
 pub inline fn isNegativeInf(x: anytype) bool {
-    return x == -math.inf(@TypeOf(x));
+    return x == -math.float.inf(@TypeOf(x));
 }
 
 test isInf {
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         try expect(!isInf(@as(T, 0.0)));
         try expect(!isInf(@as(T, -0.0)));
-        try expect(isInf(math.inf(T)));
-        try expect(isInf(-math.inf(T)));
-        try expect(!isInf(math.nan(T)));
-        try expect(!isInf(-math.nan(T)));
+        try expect(isInf(math.float.inf(T)));
+        try expect(isInf(-math.float.inf(T)));
+        try expect(!isInf(math.float.nan(T)));
+        try expect(!isInf(-math.float.nan(T)));
     }
 }
 
@@ -35,10 +35,10 @@ test isPositiveInf {
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         try expect(!isPositiveInf(@as(T, 0.0)));
         try expect(!isPositiveInf(@as(T, -0.0)));
-        try expect(isPositiveInf(math.inf(T)));
-        try expect(!isPositiveInf(-math.inf(T)));
-        try expect(!isInf(math.nan(T)));
-        try expect(!isInf(-math.nan(T)));
+        try expect(isPositiveInf(math.float.inf(T)));
+        try expect(!isPositiveInf(-math.float.inf(T)));
+        try expect(!isInf(math.float.nan(T)));
+        try expect(!isInf(-math.float.nan(T)));
     }
 }
 
@@ -46,9 +46,9 @@ test isNegativeInf {
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         try expect(!isNegativeInf(@as(T, 0.0)));
         try expect(!isNegativeInf(@as(T, -0.0)));
-        try expect(!isNegativeInf(math.inf(T)));
-        try expect(isNegativeInf(-math.inf(T)));
-        try expect(!isInf(math.nan(T)));
-        try expect(!isInf(-math.nan(T)));
+        try expect(!isNegativeInf(math.float.inf(T)));
+        try expect(isNegativeInf(-math.float.inf(T)));
+        try expect(!isInf(math.float.nan(T)));
+        try expect(!isInf(-math.float.nan(T)));
     }
 }

--- a/lib/std/math/isnan.zig
+++ b/lib/std/math/isnan.zig
@@ -19,11 +19,11 @@ pub fn isSignalNan(x: anytype) bool {
 
 test isNan {
     inline for ([_]type{ f16, f32, f64, f80, f128, c_longdouble }) |T| {
-        try expect(isNan(math.nan(T)));
-        try expect(isNan(-math.nan(T)));
-        try expect(isNan(math.snan(T)));
+        try expect(isNan(math.float.nan(T)));
+        try expect(isNan(-math.float.nan(T)));
+        try expect(isNan(math.float.snan(T)));
         try expect(!isNan(@as(T, 1.0)));
-        try expect(!isNan(@as(T, math.inf(T))));
+        try expect(!isNan(@as(T, math.float.inf(T))));
     }
 }
 
@@ -32,9 +32,9 @@ test isSignalNan {
         // TODO: Signalling NaN values get converted to quiet NaN values in
         //       some cases where they shouldn't such that this can fail.
         //       See https://github.com/ziglang/zig/issues/14366
-        // try expect(isSignalNan(math.snan(T)));
-        try expect(!isSignalNan(math.nan(T)));
+        // try expect(isSignalNan(math.float.snan(T)));
+        try expect(!isSignalNan(math.float.nan(T)));
         try expect(!isSignalNan(@as(T, 1.0)));
-        try expect(!isSignalNan(math.inf(T)));
+        try expect(!isSignalNan(math.float.inf(T)));
     }
 }

--- a/lib/std/math/isnan.zig
+++ b/lib/std/math/isnan.zig
@@ -13,7 +13,7 @@ pub fn isNan(x: anytype) bool {
 pub fn isSignalNan(x: anytype) bool {
     const T = @TypeOf(x);
     const U = meta.Int(.unsigned, @bitSizeOf(T));
-    const quiet_signal_bit_mask = 1 << (math.floatFractionalBits(T) - 1);
+    const quiet_signal_bit_mask = 1 << (math.float.fractionalBits(T) - 1);
     return isNan(x) and (@as(U, @bitCast(x)) & quiet_signal_bit_mask == 0);
 }
 

--- a/lib/std/math/isnormal.zig
+++ b/lib/std/math/isnormal.zig
@@ -20,7 +20,7 @@ pub fn isNormal(x: anytype) bool {
 }
 
 test isNormal {
-    // TODO add `c_longdouble' when math.inf(T) supports it
+    // TODO add `c_longdouble' when math.float.inf(T) supports it
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         const TBits = std.meta.Int(.unsigned, @bitSizeOf(T));
 
@@ -38,9 +38,9 @@ test isNormal {
         try expect(!isNormal(@as(T, @bitCast(~(~@as(TBits, 0) << math.float.fractionalBits(T))))));
 
         // non-finite numbers
-        try expect(!isNormal(-math.inf(T)));
-        try expect(!isNormal(math.inf(T)));
-        try expect(!isNormal(math.nan(T)));
+        try expect(!isNormal(-math.float.inf(T)));
+        try expect(!isNormal(math.float.inf(T)));
+        try expect(!isNormal(math.float.nan(T)));
 
         // overflow edge-case (described in implementation, also see #10133)
         try expect(!isNormal(@as(T, @bitCast(~@as(TBits, 0)))));

--- a/lib/std/math/isnormal.zig
+++ b/lib/std/math/isnormal.zig
@@ -7,7 +7,7 @@ pub fn isNormal(x: anytype) bool {
     const T = @TypeOf(x);
     const TBits = std.meta.Int(.unsigned, @typeInfo(T).Float.bits);
 
-    const increment_exp = 1 << math.floatMantissaBits(T);
+    const increment_exp = 1 << math.float.mantissaBits(T);
     const remove_sign = ~@as(TBits, 0) >> 1;
 
     // We add 1 to the exponent, and if it overflows to 0 or becomes 1,
@@ -26,16 +26,16 @@ test isNormal {
 
         // normals
         try expect(isNormal(@as(T, 1.0)));
-        try expect(isNormal(math.floatMin(T)));
-        try expect(isNormal(math.floatMax(T)));
+        try expect(isNormal(math.float.min(T)));
+        try expect(isNormal(math.float.max(T)));
 
         // subnormals
         try expect(!isNormal(@as(T, -0.0)));
         try expect(!isNormal(@as(T, 0.0)));
-        try expect(!isNormal(@as(T, math.floatTrueMin(T))));
+        try expect(!isNormal(@as(T, math.float.trueMin(T))));
 
         // largest subnormal
-        try expect(!isNormal(@as(T, @bitCast(~(~@as(TBits, 0) << math.floatFractionalBits(T))))));
+        try expect(!isNormal(@as(T, @bitCast(~(~@as(TBits, 0) << math.float.fractionalBits(T))))));
 
         // non-finite numbers
         try expect(!isNormal(-math.inf(T)));

--- a/lib/std/math/iszero.zig
+++ b/lib/std/math/iszero.zig
@@ -24,8 +24,8 @@ test isPositiveZero {
         try expect(!isPositiveZero(@as(T, -0.0)));
         try expect(!isPositiveZero(math.float.min(T)));
         try expect(!isPositiveZero(math.float.max(T)));
-        try expect(!isPositiveZero(math.inf(T)));
-        try expect(!isPositiveZero(-math.inf(T)));
+        try expect(!isPositiveZero(math.float.inf(T)));
+        try expect(!isPositiveZero(-math.float.inf(T)));
     }
 }
 
@@ -35,7 +35,7 @@ test isNegativeZero {
         try expect(!isNegativeZero(@as(T, 0.0)));
         try expect(!isNegativeZero(math.float.min(T)));
         try expect(!isNegativeZero(math.float.max(T)));
-        try expect(!isNegativeZero(math.inf(T)));
-        try expect(!isNegativeZero(-math.inf(T)));
+        try expect(!isNegativeZero(math.float.inf(T)));
+        try expect(!isNegativeZero(-math.float.inf(T)));
     }
 }

--- a/lib/std/math/iszero.zig
+++ b/lib/std/math/iszero.zig
@@ -22,8 +22,8 @@ test isPositiveZero {
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         try expect(isPositiveZero(@as(T, 0.0)));
         try expect(!isPositiveZero(@as(T, -0.0)));
-        try expect(!isPositiveZero(math.floatMin(T)));
-        try expect(!isPositiveZero(math.floatMax(T)));
+        try expect(!isPositiveZero(math.float.min(T)));
+        try expect(!isPositiveZero(math.float.max(T)));
         try expect(!isPositiveZero(math.inf(T)));
         try expect(!isPositiveZero(-math.inf(T)));
     }
@@ -33,8 +33,8 @@ test isNegativeZero {
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
         try expect(isNegativeZero(@as(T, -0.0)));
         try expect(!isNegativeZero(@as(T, 0.0)));
-        try expect(!isNegativeZero(math.floatMin(T)));
-        try expect(!isNegativeZero(math.floatMax(T)));
+        try expect(!isNegativeZero(math.float.min(T)));
+        try expect(!isNegativeZero(math.float.max(T)));
         try expect(!isNegativeZero(math.inf(T)));
         try expect(!isNegativeZero(-math.inf(T)));
     }

--- a/lib/std/math/ldexp.zig
+++ b/lib/std/math/ldexp.zig
@@ -29,7 +29,7 @@ pub fn ldexp(x: anytype, n: i32) @TypeOf(x) {
     if (n >= 0) {
         if (n > max_biased_exponent - exponent) {
             // Overflow. Return +/- inf
-            return @as(T, @bitCast(@as(TBits, @bitCast(math.inf(T))) | sign_bit));
+            return @as(T, @bitCast(@as(TBits, @bitCast(math.float.inf(T))) | sign_bit));
         } else if (exponent + n <= 0) {
             // Result is subnormal
             return @as(T, @bitCast((repr << @as(Log2Int(TBits), @intCast(n))) | sign_bit));
@@ -122,25 +122,25 @@ test ldexp {
 
         // subnormals -> float limits (+inf)
         try expect(math.isFinite(ldexp(math.float.trueMin(T), max_exponent + exponent_bias + fractional_bits - 1)));
-        try expect(ldexp(math.float.trueMin(T), max_exponent + exponent_bias + fractional_bits) == math.inf(T));
+        try expect(ldexp(math.float.trueMin(T), max_exponent + exponent_bias + fractional_bits) == math.float.inf(T));
 
         // subnormals -> float limits (-inf)
         try expect(math.isFinite(ldexp(-math.float.trueMin(T), max_exponent + exponent_bias + fractional_bits - 1)));
-        try expect(ldexp(-math.float.trueMin(T), max_exponent + exponent_bias + fractional_bits) == -math.inf(T));
+        try expect(ldexp(-math.float.trueMin(T), max_exponent + exponent_bias + fractional_bits) == -math.float.inf(T));
 
         // infinity -> infinity
-        try expect(ldexp(math.inf(T), math.maxInt(i32)) == math.inf(T));
-        try expect(ldexp(math.inf(T), math.minInt(i32)) == math.inf(T));
-        try expect(ldexp(math.inf(T), max_exponent) == math.inf(T));
-        try expect(ldexp(math.inf(T), min_exponent) == math.inf(T));
-        try expect(ldexp(-math.inf(T), math.maxInt(i32)) == -math.inf(T));
-        try expect(ldexp(-math.inf(T), math.minInt(i32)) == -math.inf(T));
+        try expect(ldexp(math.float.inf(T), math.maxInt(i32)) == math.float.inf(T));
+        try expect(ldexp(math.float.inf(T), math.minInt(i32)) == math.float.inf(T));
+        try expect(ldexp(math.float.inf(T), max_exponent) == math.float.inf(T));
+        try expect(ldexp(math.float.inf(T), min_exponent) == math.float.inf(T));
+        try expect(ldexp(-math.float.inf(T), math.maxInt(i32)) == -math.float.inf(T));
+        try expect(ldexp(-math.float.inf(T), math.minInt(i32)) == -math.float.inf(T));
 
         // extremely large n
-        try expect(ldexp(math.float.max(T), math.maxInt(i32)) == math.inf(T));
+        try expect(ldexp(math.float.max(T), math.maxInt(i32)) == math.float.inf(T));
         try expect(ldexp(math.float.max(T), -math.maxInt(i32)) == 0.0);
         try expect(ldexp(math.float.max(T), math.minInt(i32)) == 0.0);
-        try expect(ldexp(math.float.trueMin(T), math.maxInt(i32)) == math.inf(T));
+        try expect(ldexp(math.float.trueMin(T), math.maxInt(i32)) == math.float.inf(T));
         try expect(ldexp(math.float.trueMin(T), -math.maxInt(i32)) == 0.0);
         try expect(ldexp(math.float.trueMin(T), math.minInt(i32)) == 0.0);
     }

--- a/lib/std/math/log1p.zig
+++ b/lib/std/math/log1p.zig
@@ -46,11 +46,11 @@ fn log1p_32(x: f32) f32 {
         if (ix >= 0xBF800000) {
             // log1p(-1) = -inf
             if (x == -1.0) {
-                return -math.inf(f32);
+                return -math.float.inf(f32);
             }
             // log1p(x < -1) = nan
             else {
-                return math.nan(f32);
+                return math.float.nan(f32);
             }
         }
         // |x| < 2^(-24)
@@ -125,11 +125,11 @@ fn log1p_64(x: f64) f64 {
         if (hx >= 0xBFF00000) {
             // log1p(-1) = -inf
             if (x == -1.0) {
-                return -math.inf(f64);
+                return -math.float.inf(f64);
             }
             // log1p(x < -1) = nan
             else {
-                return math.nan(f64);
+                return math.float.nan(f64);
             }
         }
         // |x| < 2^(-53)
@@ -212,19 +212,19 @@ test log1p_64 {
 }
 
 test "log1p_32.special" {
-    try expect(math.isPositiveInf(log1p_32(math.inf(f32))));
+    try expect(math.isPositiveInf(log1p_32(math.float.inf(f32))));
     try expect(math.isPositiveZero(log1p_32(0.0)));
     try expect(math.isNegativeZero(log1p_32(-0.0)));
     try expect(math.isNegativeInf(log1p_32(-1.0)));
     try expect(math.isNan(log1p_32(-2.0)));
-    try expect(math.isNan(log1p_32(math.nan(f32))));
+    try expect(math.isNan(log1p_32(math.float.nan(f32))));
 }
 
 test "log1p_64.special" {
-    try expect(math.isPositiveInf(log1p_64(math.inf(f64))));
+    try expect(math.isPositiveInf(log1p_64(math.float.inf(f64))));
     try expect(math.isPositiveZero(log1p_64(0.0)));
     try expect(math.isNegativeZero(log1p_64(-0.0)));
     try expect(math.isNegativeInf(log1p_64(-1.0)));
     try expect(math.isNan(log1p_64(-2.0)));
-    try expect(math.isNan(log1p_64(math.nan(f64))));
+    try expect(math.isNan(log1p_64(math.float.nan(f64))));
 }

--- a/lib/std/math/modf.zig
+++ b/lib/std/math/modf.zig
@@ -28,7 +28,7 @@ pub fn modf(x: anytype) Modf(@TypeOf(x)) {
 
 test modf {
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
-        const epsilon: comptime_float = @max(1e-6, math.floatEps(T));
+        const epsilon: comptime_float = @max(1e-6, math.float.eps(T));
 
         var r: Modf(T) = undefined;
 
@@ -54,7 +54,7 @@ test modf {
 fn ModfTests(comptime T: type) type {
     return struct {
         test "normal" {
-            const epsilon: comptime_float = @max(1e-6, math.floatEps(T));
+            const epsilon: comptime_float = @max(1e-6, math.float.eps(T));
             var r: Modf(T) = undefined;
 
             r = modf(@as(T, 1.0));

--- a/lib/std/math/modf.zig
+++ b/lib/std/math/modf.zig
@@ -121,14 +121,14 @@ fn ModfTests(comptime T: type) type {
         test "inf" {
             var r: Modf(T) = undefined;
 
-            r = modf(math.inf(T));
+            r = modf(math.float.inf(T));
             try expect(math.isPositiveInf(r.ipart) and math.isNan(r.fpart));
 
-            r = modf(-math.inf(T));
+            r = modf(-math.float.inf(T));
             try expect(math.isNegativeInf(r.ipart) and math.isNan(r.fpart));
         }
         test "nan" {
-            const r: Modf(T) = modf(math.nan(T));
+            const r: Modf(T) = modf(math.float.nan(T));
             try expect(math.isNan(r.ipart) and math.isNan(r.fpart));
         }
     };

--- a/lib/std/math/nextafter.zig
+++ b/lib/std/math/nextafter.zig
@@ -48,18 +48,18 @@ fn nextAfterFloat(comptime T: type, x: T, y: T) T {
     }
     if (x == 0.0) {
         return if (y > 0.0)
-            math.floatTrueMin(T)
+            math.float.trueMin(T)
         else
-            -math.floatTrueMin(T);
+            -math.float.trueMin(T);
     }
     if (@bitSizeOf(T) == 80) {
         // Unlike other floats, `f80` has an explicitly stored integer bit between the fractional
         // part and the exponent and thus requires special handling. This integer bit *must* be set
         // when the value is normal, an infinity or a NaN and *should* be cleared otherwise.
 
-        const fractional_bits_mask = (1 << math.floatFractionalBits(f80)) - 1;
-        const integer_bit_mask = 1 << math.floatFractionalBits(f80);
-        const exponent_bits_mask = (1 << math.floatExponentBits(f80)) - 1;
+        const fractional_bits_mask = (1 << math.float.fractionalBits(f80)) - 1;
+        const integer_bit_mask = 1 << math.float.fractionalBits(f80);
+        const exponent_bits_mask = (1 << math.float.exponentBits(f80)) - 1;
 
         var x_parts = math.break_f80(x);
 
@@ -292,22 +292,22 @@ test "float" {
         try expect(bitwiseEqual(T, nextAfter(T, 0.0, -0.0), -0.0));
         try expect(bitwiseEqual(T, nextAfter(T, -0.0, -0.0), -0.0));
         try expect(bitwiseEqual(T, nextAfter(T, -0.0, 0.0), 0.0));
-        try expect(nextAfter(T, 0.0, math.inf(T)) == math.floatTrueMin(T));
-        try expect(nextAfter(T, 0.0, -math.inf(T)) == -math.floatTrueMin(T));
-        try expect(nextAfter(T, -0.0, -math.inf(T)) == -math.floatTrueMin(T));
-        try expect(nextAfter(T, -0.0, math.inf(T)) == math.floatTrueMin(T));
-        try expect(bitwiseEqual(T, nextAfter(T, math.floatTrueMin(T), 0.0), 0.0));
-        try expect(bitwiseEqual(T, nextAfter(T, math.floatTrueMin(T), -0.0), 0.0));
-        try expect(bitwiseEqual(T, nextAfter(T, math.floatTrueMin(T), -math.inf(T)), 0.0));
-        try expect(bitwiseEqual(T, nextAfter(T, -math.floatTrueMin(T), -0.0), -0.0));
-        try expect(bitwiseEqual(T, nextAfter(T, -math.floatTrueMin(T), 0.0), -0.0));
-        try expect(bitwiseEqual(T, nextAfter(T, -math.floatTrueMin(T), math.inf(T)), -0.0));
+        try expect(nextAfter(T, 0.0, math.inf(T)) == math.float.trueMin(T));
+        try expect(nextAfter(T, 0.0, -math.inf(T)) == -math.float.trueMin(T));
+        try expect(nextAfter(T, -0.0, -math.inf(T)) == -math.float.trueMin(T));
+        try expect(nextAfter(T, -0.0, math.inf(T)) == math.float.trueMin(T));
+        try expect(bitwiseEqual(T, nextAfter(T, math.float.trueMin(T), 0.0), 0.0));
+        try expect(bitwiseEqual(T, nextAfter(T, math.float.trueMin(T), -0.0), 0.0));
+        try expect(bitwiseEqual(T, nextAfter(T, math.float.trueMin(T), -math.inf(T)), 0.0));
+        try expect(bitwiseEqual(T, nextAfter(T, -math.float.trueMin(T), -0.0), -0.0));
+        try expect(bitwiseEqual(T, nextAfter(T, -math.float.trueMin(T), 0.0), -0.0));
+        try expect(bitwiseEqual(T, nextAfter(T, -math.float.trueMin(T), math.inf(T)), -0.0));
         try expect(nextAfter(T, math.inf(T), math.inf(T)) == math.inf(T));
-        try expect(nextAfter(T, math.inf(T), -math.inf(T)) == math.floatMax(T));
-        try expect(nextAfter(T, math.floatMax(T), math.inf(T)) == math.inf(T));
+        try expect(nextAfter(T, math.inf(T), -math.inf(T)) == math.float.max(T));
+        try expect(nextAfter(T, math.float.max(T), math.inf(T)) == math.inf(T));
         try expect(nextAfter(T, -math.inf(T), -math.inf(T)) == -math.inf(T));
-        try expect(nextAfter(T, -math.inf(T), math.inf(T)) == -math.floatMax(T));
-        try expect(nextAfter(T, -math.floatMax(T), -math.inf(T)) == -math.inf(T));
+        try expect(nextAfter(T, -math.inf(T), math.inf(T)) == -math.float.max(T));
+        try expect(nextAfter(T, -math.float.max(T), -math.inf(T)) == -math.inf(T));
         try expect(math.isNan(nextAfter(T, 1.0, math.nan(T))));
         try expect(math.isNan(nextAfter(T, math.nan(T), 1.0)));
         try expect(math.isNan(nextAfter(T, math.nan(T), math.nan(T))));

--- a/lib/std/math/nextafter.zig
+++ b/lib/std/math/nextafter.zig
@@ -44,7 +44,7 @@ fn nextAfterFloat(comptime T: type, x: T, y: T) T {
         return y;
     }
     if (math.isNan(x) or math.isNan(y)) {
-        return math.nan(T);
+        return math.float.nan(T);
     }
     if (x == 0.0) {
         return if (y > 0.0)
@@ -223,67 +223,67 @@ test "float" {
     }
 
     // normal -> normal (change in exponent)
-    try expect(nextAfter(f16, 0x1.FFCp3, math.inf(f16)) == 0x1p4);
-    try expect(nextAfter(f16, 0x1p4, -math.inf(f16)) == 0x1.FFCp3);
-    try expect(nextAfter(f16, -0x1.FFCp3, -math.inf(f16)) == -0x1p4);
-    try expect(nextAfter(f16, -0x1p4, math.inf(f16)) == -0x1.FFCp3);
-    try expect(nextAfter(f32, 0x1.FFFFFEp3, math.inf(f32)) == 0x1p4);
-    try expect(nextAfter(f32, 0x1p4, -math.inf(f32)) == 0x1.FFFFFEp3);
-    try expect(nextAfter(f32, -0x1.FFFFFEp3, -math.inf(f32)) == -0x1p4);
-    try expect(nextAfter(f32, -0x1p4, math.inf(f32)) == -0x1.FFFFFEp3);
+    try expect(nextAfter(f16, 0x1.FFCp3, math.float.inf(f16)) == 0x1p4);
+    try expect(nextAfter(f16, 0x1p4, -math.float.inf(f16)) == 0x1.FFCp3);
+    try expect(nextAfter(f16, -0x1.FFCp3, -math.float.inf(f16)) == -0x1p4);
+    try expect(nextAfter(f16, -0x1p4, math.float.inf(f16)) == -0x1.FFCp3);
+    try expect(nextAfter(f32, 0x1.FFFFFEp3, math.float.inf(f32)) == 0x1p4);
+    try expect(nextAfter(f32, 0x1p4, -math.float.inf(f32)) == 0x1.FFFFFEp3);
+    try expect(nextAfter(f32, -0x1.FFFFFEp3, -math.float.inf(f32)) == -0x1p4);
+    try expect(nextAfter(f32, -0x1p4, math.float.inf(f32)) == -0x1.FFFFFEp3);
     inline for (.{f64} ++ if (@bitSizeOf(c_longdouble) == 64) .{c_longdouble} else .{}) |T64| {
-        try expect(nextAfter(T64, 0x1.FFFFFFFFFFFFFp3, math.inf(T64)) == 0x1p4);
-        try expect(nextAfter(T64, 0x1p4, -math.inf(T64)) == 0x1.FFFFFFFFFFFFFp3);
-        try expect(nextAfter(T64, -0x1.FFFFFFFFFFFFFp3, -math.inf(T64)) == -0x1p4);
-        try expect(nextAfter(T64, -0x1p4, math.inf(T64)) == -0x1.FFFFFFFFFFFFFp3);
+        try expect(nextAfter(T64, 0x1.FFFFFFFFFFFFFp3, math.float.inf(T64)) == 0x1p4);
+        try expect(nextAfter(T64, 0x1p4, -math.float.inf(T64)) == 0x1.FFFFFFFFFFFFFp3);
+        try expect(nextAfter(T64, -0x1.FFFFFFFFFFFFFp3, -math.float.inf(T64)) == -0x1p4);
+        try expect(nextAfter(T64, -0x1p4, math.float.inf(T64)) == -0x1.FFFFFFFFFFFFFp3);
     }
     inline for (.{f80} ++ if (@bitSizeOf(c_longdouble) == 80) .{c_longdouble} else .{}) |T80| {
-        try expect(nextAfter(T80, 0x1.FFFFFFFFFFFFFFFEp3, math.inf(T80)) == 0x1p4);
-        try expect(nextAfter(T80, 0x1p4, -math.inf(T80)) == 0x1.FFFFFFFFFFFFFFFEp3);
-        try expect(nextAfter(T80, -0x1.FFFFFFFFFFFFFFFEp3, -math.inf(T80)) == -0x1p4);
-        try expect(nextAfter(T80, -0x1p4, math.inf(T80)) == -0x1.FFFFFFFFFFFFFFFEp3);
+        try expect(nextAfter(T80, 0x1.FFFFFFFFFFFFFFFEp3, math.float.inf(T80)) == 0x1p4);
+        try expect(nextAfter(T80, 0x1p4, -math.float.inf(T80)) == 0x1.FFFFFFFFFFFFFFFEp3);
+        try expect(nextAfter(T80, -0x1.FFFFFFFFFFFFFFFEp3, -math.float.inf(T80)) == -0x1p4);
+        try expect(nextAfter(T80, -0x1p4, math.float.inf(T80)) == -0x1.FFFFFFFFFFFFFFFEp3);
     }
     inline for (.{f128} ++ if (@bitSizeOf(c_longdouble) == 128) .{c_longdouble} else .{}) |T128| {
-        try expect(nextAfter(T128, 0x1.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp3, math.inf(T128)) == 0x1p4);
-        try expect(nextAfter(T128, 0x1p4, -math.inf(T128)) == 0x1.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp3);
-        try expect(nextAfter(T128, -0x1.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp3, -math.inf(T128)) == -0x1p4);
-        try expect(nextAfter(T128, -0x1p4, math.inf(T128)) == -0x1.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp3);
+        try expect(nextAfter(T128, 0x1.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp3, math.float.inf(T128)) == 0x1p4);
+        try expect(nextAfter(T128, 0x1p4, -math.float.inf(T128)) == 0x1.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp3);
+        try expect(nextAfter(T128, -0x1.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp3, -math.float.inf(T128)) == -0x1p4);
+        try expect(nextAfter(T128, -0x1p4, math.float.inf(T128)) == -0x1.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp3);
     }
 
     // normal -> subnormal
-    try expect(nextAfter(f16, 0x1p-14, -math.inf(f16)) == 0x0.FFCp-14);
-    try expect(nextAfter(f16, -0x1p-14, math.inf(f16)) == -0x0.FFCp-14);
-    try expect(nextAfter(f32, 0x1p-126, -math.inf(f32)) == 0x0.FFFFFEp-126);
-    try expect(nextAfter(f32, -0x1p-126, math.inf(f32)) == -0x0.FFFFFEp-126);
+    try expect(nextAfter(f16, 0x1p-14, -math.float.inf(f16)) == 0x0.FFCp-14);
+    try expect(nextAfter(f16, -0x1p-14, math.float.inf(f16)) == -0x0.FFCp-14);
+    try expect(nextAfter(f32, 0x1p-126, -math.float.inf(f32)) == 0x0.FFFFFEp-126);
+    try expect(nextAfter(f32, -0x1p-126, math.float.inf(f32)) == -0x0.FFFFFEp-126);
     inline for (.{f64} ++ if (@bitSizeOf(c_longdouble) == 64) .{c_longdouble} else .{}) |T64| {
-        try expect(nextAfter(T64, 0x1p-1022, -math.inf(T64)) == 0x0.FFFFFFFFFFFFFp-1022);
-        try expect(nextAfter(T64, -0x1p-1022, math.inf(T64)) == -0x0.FFFFFFFFFFFFFp-1022);
+        try expect(nextAfter(T64, 0x1p-1022, -math.float.inf(T64)) == 0x0.FFFFFFFFFFFFFp-1022);
+        try expect(nextAfter(T64, -0x1p-1022, math.float.inf(T64)) == -0x0.FFFFFFFFFFFFFp-1022);
     }
     inline for (.{f80} ++ if (@bitSizeOf(c_longdouble) == 80) .{c_longdouble} else .{}) |T80| {
-        try expect(nextAfter(T80, 0x1p-16382, -math.inf(T80)) == 0x0.FFFFFFFFFFFFFFFEp-16382);
-        try expect(nextAfter(T80, -0x1p-16382, math.inf(T80)) == -0x0.FFFFFFFFFFFFFFFEp-16382);
+        try expect(nextAfter(T80, 0x1p-16382, -math.float.inf(T80)) == 0x0.FFFFFFFFFFFFFFFEp-16382);
+        try expect(nextAfter(T80, -0x1p-16382, math.float.inf(T80)) == -0x0.FFFFFFFFFFFFFFFEp-16382);
     }
     inline for (.{f128} ++ if (@bitSizeOf(c_longdouble) == 128) .{c_longdouble} else .{}) |T128| {
-        try expect(nextAfter(T128, 0x1p-16382, -math.inf(T128)) == 0x0.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp-16382);
-        try expect(nextAfter(T128, -0x1p-16382, math.inf(T128)) == -0x0.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp-16382);
+        try expect(nextAfter(T128, 0x1p-16382, -math.float.inf(T128)) == 0x0.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp-16382);
+        try expect(nextAfter(T128, -0x1p-16382, math.float.inf(T128)) == -0x0.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp-16382);
     }
 
     // subnormal -> normal
-    try expect(nextAfter(f16, 0x0.FFCp-14, math.inf(f16)) == 0x1p-14);
-    try expect(nextAfter(f16, -0x0.FFCp-14, -math.inf(f16)) == -0x1p-14);
-    try expect(nextAfter(f32, 0x0.FFFFFEp-126, math.inf(f32)) == 0x1p-126);
-    try expect(nextAfter(f32, -0x0.FFFFFEp-126, -math.inf(f32)) == -0x1p-126);
+    try expect(nextAfter(f16, 0x0.FFCp-14, math.float.inf(f16)) == 0x1p-14);
+    try expect(nextAfter(f16, -0x0.FFCp-14, -math.float.inf(f16)) == -0x1p-14);
+    try expect(nextAfter(f32, 0x0.FFFFFEp-126, math.float.inf(f32)) == 0x1p-126);
+    try expect(nextAfter(f32, -0x0.FFFFFEp-126, -math.float.inf(f32)) == -0x1p-126);
     inline for (.{f64} ++ if (@bitSizeOf(c_longdouble) == 64) .{c_longdouble} else .{}) |T64| {
-        try expect(nextAfter(T64, 0x0.FFFFFFFFFFFFFp-1022, math.inf(T64)) == 0x1p-1022);
-        try expect(nextAfter(T64, -0x0.FFFFFFFFFFFFFp-1022, -math.inf(T64)) == -0x1p-1022);
+        try expect(nextAfter(T64, 0x0.FFFFFFFFFFFFFp-1022, math.float.inf(T64)) == 0x1p-1022);
+        try expect(nextAfter(T64, -0x0.FFFFFFFFFFFFFp-1022, -math.float.inf(T64)) == -0x1p-1022);
     }
     inline for (.{f80} ++ if (@bitSizeOf(c_longdouble) == 80) .{c_longdouble} else .{}) |T80| {
-        try expect(nextAfter(T80, 0x0.FFFFFFFFFFFFFFFEp-16382, math.inf(T80)) == 0x1p-16382);
-        try expect(nextAfter(T80, -0x0.FFFFFFFFFFFFFFFEp-16382, -math.inf(T80)) == -0x1p-16382);
+        try expect(nextAfter(T80, 0x0.FFFFFFFFFFFFFFFEp-16382, math.float.inf(T80)) == 0x1p-16382);
+        try expect(nextAfter(T80, -0x0.FFFFFFFFFFFFFFFEp-16382, -math.float.inf(T80)) == -0x1p-16382);
     }
     inline for (.{f128} ++ if (@bitSizeOf(c_longdouble) == 128) .{c_longdouble} else .{}) |T128| {
-        try expect(nextAfter(T128, 0x0.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp-16382, math.inf(T128)) == 0x1p-16382);
-        try expect(nextAfter(T128, -0x0.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp-16382, -math.inf(T128)) == -0x1p-16382);
+        try expect(nextAfter(T128, 0x0.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp-16382, math.float.inf(T128)) == 0x1p-16382);
+        try expect(nextAfter(T128, -0x0.FFFFFFFFFFFFFFFFFFFFFFFFFFFFp-16382, -math.float.inf(T128)) == -0x1p-16382);
     }
 
     // special values
@@ -292,29 +292,29 @@ test "float" {
         try expect(bitwiseEqual(T, nextAfter(T, 0.0, -0.0), -0.0));
         try expect(bitwiseEqual(T, nextAfter(T, -0.0, -0.0), -0.0));
         try expect(bitwiseEqual(T, nextAfter(T, -0.0, 0.0), 0.0));
-        try expect(nextAfter(T, 0.0, math.inf(T)) == math.float.trueMin(T));
-        try expect(nextAfter(T, 0.0, -math.inf(T)) == -math.float.trueMin(T));
-        try expect(nextAfter(T, -0.0, -math.inf(T)) == -math.float.trueMin(T));
-        try expect(nextAfter(T, -0.0, math.inf(T)) == math.float.trueMin(T));
+        try expect(nextAfter(T, 0.0, math.float.inf(T)) == math.float.trueMin(T));
+        try expect(nextAfter(T, 0.0, -math.float.inf(T)) == -math.float.trueMin(T));
+        try expect(nextAfter(T, -0.0, -math.float.inf(T)) == -math.float.trueMin(T));
+        try expect(nextAfter(T, -0.0, math.float.inf(T)) == math.float.trueMin(T));
         try expect(bitwiseEqual(T, nextAfter(T, math.float.trueMin(T), 0.0), 0.0));
         try expect(bitwiseEqual(T, nextAfter(T, math.float.trueMin(T), -0.0), 0.0));
-        try expect(bitwiseEqual(T, nextAfter(T, math.float.trueMin(T), -math.inf(T)), 0.0));
+        try expect(bitwiseEqual(T, nextAfter(T, math.float.trueMin(T), -math.float.inf(T)), 0.0));
         try expect(bitwiseEqual(T, nextAfter(T, -math.float.trueMin(T), -0.0), -0.0));
         try expect(bitwiseEqual(T, nextAfter(T, -math.float.trueMin(T), 0.0), -0.0));
-        try expect(bitwiseEqual(T, nextAfter(T, -math.float.trueMin(T), math.inf(T)), -0.0));
-        try expect(nextAfter(T, math.inf(T), math.inf(T)) == math.inf(T));
-        try expect(nextAfter(T, math.inf(T), -math.inf(T)) == math.float.max(T));
-        try expect(nextAfter(T, math.float.max(T), math.inf(T)) == math.inf(T));
-        try expect(nextAfter(T, -math.inf(T), -math.inf(T)) == -math.inf(T));
-        try expect(nextAfter(T, -math.inf(T), math.inf(T)) == -math.float.max(T));
-        try expect(nextAfter(T, -math.float.max(T), -math.inf(T)) == -math.inf(T));
-        try expect(math.isNan(nextAfter(T, 1.0, math.nan(T))));
-        try expect(math.isNan(nextAfter(T, math.nan(T), 1.0)));
-        try expect(math.isNan(nextAfter(T, math.nan(T), math.nan(T))));
-        try expect(math.isNan(nextAfter(T, math.inf(T), math.nan(T))));
-        try expect(math.isNan(nextAfter(T, -math.inf(T), math.nan(T))));
-        try expect(math.isNan(nextAfter(T, math.nan(T), math.inf(T))));
-        try expect(math.isNan(nextAfter(T, math.nan(T), -math.inf(T))));
+        try expect(bitwiseEqual(T, nextAfter(T, -math.float.trueMin(T), math.float.inf(T)), -0.0));
+        try expect(nextAfter(T, math.float.inf(T), math.float.inf(T)) == math.float.inf(T));
+        try expect(nextAfter(T, math.float.inf(T), -math.float.inf(T)) == math.float.max(T));
+        try expect(nextAfter(T, math.float.max(T), math.float.inf(T)) == math.float.inf(T));
+        try expect(nextAfter(T, -math.float.inf(T), -math.float.inf(T)) == -math.float.inf(T));
+        try expect(nextAfter(T, -math.float.inf(T), math.float.inf(T)) == -math.float.max(T));
+        try expect(nextAfter(T, -math.float.max(T), -math.float.inf(T)) == -math.float.inf(T));
+        try expect(math.isNan(nextAfter(T, 1.0, math.float.nan(T))));
+        try expect(math.isNan(nextAfter(T, math.float.nan(T), 1.0)));
+        try expect(math.isNan(nextAfter(T, math.float.nan(T), math.float.nan(T))));
+        try expect(math.isNan(nextAfter(T, math.float.inf(T), math.float.nan(T))));
+        try expect(math.isNan(nextAfter(T, -math.float.inf(T), math.float.nan(T))));
+        try expect(math.isNan(nextAfter(T, math.float.nan(T), math.float.inf(T))));
+        try expect(math.isNan(nextAfter(T, math.float.nan(T), -math.float.inf(T))));
     }
 }
 

--- a/lib/std/math/pow.zig
+++ b/lib/std/math/pow.zig
@@ -48,7 +48,7 @@ pub fn pow(comptime T: type, x: T, y: T) T {
     // pow(nan, y) = nan    for all y
     // pow(x, nan) = nan    for all x
     if (math.isNan(x) or math.isNan(y)) {
-        return math.nan(T);
+        return math.float.nan(T);
     }
 
     // pow(x, 1) = x        for all x
@@ -60,11 +60,11 @@ pub fn pow(comptime T: type, x: T, y: T) T {
         if (y < 0) {
             // pow(+-0, y) = +- 0   for y an odd integer
             if (isOddInteger(y)) {
-                return math.copysign(math.inf(T), x);
+                return math.copysign(math.float.inf(T), x);
             }
             // pow(+-0, y) = +inf   for y an even integer
             else {
-                return math.inf(T);
+                return math.float.inf(T);
             }
         } else {
             if (isOddInteger(y)) {
@@ -88,7 +88,7 @@ pub fn pow(comptime T: type, x: T, y: T) T {
         // pow(x, -inf) = +inf  for |x| < 1
         // pow(x, +inf) = +inf  for |x| > 1
         else {
-            return math.inf(T);
+            return math.float.inf(T);
         }
     }
 
@@ -102,7 +102,7 @@ pub fn pow(comptime T: type, x: T, y: T) T {
         }
         // pow(+inf, y) = +0    for y > 0
         else if (y > 0) {
-            return math.inf(T);
+            return math.float.inf(T);
         }
     }
 
@@ -120,7 +120,7 @@ pub fn pow(comptime T: type, x: T, y: T) T {
     var yf = r1.fpart;
 
     if (yf != 0 and x < 0) {
-        return math.nan(T);
+        return math.float.nan(T);
     }
     if (yi >= 1 << (@typeInfo(T).Float.bits - 1)) {
         return @exp(y * @log(x));
@@ -223,37 +223,37 @@ test "special" {
     try expect(pow(f32, 7, -0.0) == 1.0);
     try expect(pow(f32, 45, 1.0) == 45);
     try expect(pow(f32, -45, 1.0) == -45);
-    try expect(math.isNan(pow(f32, math.nan(f32), 5.0)));
-    try expect(math.isPositiveInf(pow(f32, -math.inf(f32), 0.5)));
+    try expect(math.isNan(pow(f32, math.float.nan(f32), 5.0)));
+    try expect(math.isPositiveInf(pow(f32, -math.float.inf(f32), 0.5)));
     try expect(math.isPositiveInf(pow(f32, -0.0, -0.5)));
     try expect(pow(f32, -0.0, 0.5) == 0);
-    try expect(math.isNan(pow(f32, 5.0, math.nan(f32))));
+    try expect(math.isNan(pow(f32, 5.0, math.float.nan(f32))));
     try expect(math.isPositiveInf(pow(f32, 0.0, -1.0)));
     //expect(math.isNegativeInf(pow(f32, -0.0, -3.0))); TODO is this required?
-    try expect(math.isPositiveInf(pow(f32, 0.0, -math.inf(f32))));
-    try expect(math.isPositiveInf(pow(f32, -0.0, -math.inf(f32))));
-    try expect(pow(f32, 0.0, math.inf(f32)) == 0.0);
-    try expect(pow(f32, -0.0, math.inf(f32)) == 0.0);
+    try expect(math.isPositiveInf(pow(f32, 0.0, -math.float.inf(f32))));
+    try expect(math.isPositiveInf(pow(f32, -0.0, -math.float.inf(f32))));
+    try expect(pow(f32, 0.0, math.float.inf(f32)) == 0.0);
+    try expect(pow(f32, -0.0, math.float.inf(f32)) == 0.0);
     try expect(math.isPositiveInf(pow(f32, 0.0, -2.0)));
     try expect(math.isPositiveInf(pow(f32, -0.0, -2.0)));
     try expect(pow(f32, 0.0, 1.0) == 0.0);
     try expect(pow(f32, -0.0, 1.0) == -0.0);
     try expect(pow(f32, 0.0, 2.0) == 0.0);
     try expect(pow(f32, -0.0, 2.0) == 0.0);
-    try expect(math.approxEqAbs(f32, pow(f32, -1.0, math.inf(f32)), 1.0, epsilon));
-    try expect(math.approxEqAbs(f32, pow(f32, -1.0, -math.inf(f32)), 1.0, epsilon));
-    try expect(math.isPositiveInf(pow(f32, 1.2, math.inf(f32))));
-    try expect(math.isPositiveInf(pow(f32, -1.2, math.inf(f32))));
-    try expect(pow(f32, 1.2, -math.inf(f32)) == 0.0);
-    try expect(pow(f32, -1.2, -math.inf(f32)) == 0.0);
-    try expect(pow(f32, 0.2, math.inf(f32)) == 0.0);
-    try expect(pow(f32, -0.2, math.inf(f32)) == 0.0);
-    try expect(math.isPositiveInf(pow(f32, 0.2, -math.inf(f32))));
-    try expect(math.isPositiveInf(pow(f32, -0.2, -math.inf(f32))));
-    try expect(math.isPositiveInf(pow(f32, math.inf(f32), 1.0)));
-    try expect(pow(f32, math.inf(f32), -1.0) == 0.0);
-    //expect(pow(f32, -math.inf(f32), 5.0) == pow(f32, -0.0, -5.0)); TODO support negative 0?
-    try expect(pow(f32, -math.inf(f32), -5.2) == pow(f32, -0.0, 5.2));
+    try expect(math.approxEqAbs(f32, pow(f32, -1.0, math.float.inf(f32)), 1.0, epsilon));
+    try expect(math.approxEqAbs(f32, pow(f32, -1.0, -math.float.inf(f32)), 1.0, epsilon));
+    try expect(math.isPositiveInf(pow(f32, 1.2, math.float.inf(f32))));
+    try expect(math.isPositiveInf(pow(f32, -1.2, math.float.inf(f32))));
+    try expect(pow(f32, 1.2, -math.float.inf(f32)) == 0.0);
+    try expect(pow(f32, -1.2, -math.float.inf(f32)) == 0.0);
+    try expect(pow(f32, 0.2, math.float.inf(f32)) == 0.0);
+    try expect(pow(f32, -0.2, math.float.inf(f32)) == 0.0);
+    try expect(math.isPositiveInf(pow(f32, 0.2, -math.float.inf(f32))));
+    try expect(math.isPositiveInf(pow(f32, -0.2, -math.float.inf(f32))));
+    try expect(math.isPositiveInf(pow(f32, math.float.inf(f32), 1.0)));
+    try expect(pow(f32, math.float.inf(f32), -1.0) == 0.0);
+    //expect(pow(f32, -math.float.inf(f32), 5.0) == pow(f32, -0.0, -5.0)); TODO support negative 0?
+    try expect(pow(f32, -math.float.inf(f32), -5.2) == pow(f32, -0.0, 5.2));
     try expect(math.isNan(pow(f32, -1.0, 1.2)));
     try expect(math.isNan(pow(f32, -12.4, 78.5)));
 }

--- a/lib/std/math/pow.zig
+++ b/lib/std/math/pow.zig
@@ -146,7 +146,7 @@ pub fn pow(comptime T: type, x: T, y: T) T {
 
     var i = @as(std.meta.Int(.signed, @typeInfo(T).Float.bits), @intFromFloat(yi));
     while (i != 0) : (i >>= 1) {
-        const overflow_shift = math.floatExponentBits(T) + 1;
+        const overflow_shift = math.float.exponentBits(T) + 1;
         if (xe < -(1 << overflow_shift) or (1 << overflow_shift) < xe) {
             // catch xe before it overflows the left shift below
             // Since i != 0 it has at least one bit still set, so ae will accumulate xe

--- a/lib/std/math/signbit.zig
+++ b/lib/std/math/signbit.zig
@@ -15,9 +15,9 @@ test signbit {
         try expect(!signbit(@as(T, 1.0)));
         try expect(signbit(@as(T, -2.0)));
         try expect(signbit(@as(T, -0.0)));
-        try expect(!signbit(math.inf(T)));
-        try expect(signbit(-math.inf(T)));
-        try expect(!signbit(math.nan(T)));
-        try expect(signbit(-math.nan(T)));
+        try expect(!signbit(math.float.inf(T)));
+        try expect(signbit(-math.float.inf(T)));
+        try expect(!signbit(math.float.nan(T)));
+        try expect(signbit(-math.float.nan(T)));
     }
 }

--- a/lib/std/math/sinh.zig
+++ b/lib/std/math/sinh.zig
@@ -125,15 +125,15 @@ test sinh64 {
 test "sinh32.special" {
     try expect(math.isPositiveZero(sinh32(0.0)));
     try expect(math.isNegativeZero(sinh32(-0.0)));
-    try expect(math.isPositiveInf(sinh32(math.inf(f32))));
-    try expect(math.isNegativeInf(sinh32(-math.inf(f32))));
-    try expect(math.isNan(sinh32(math.nan(f32))));
+    try expect(math.isPositiveInf(sinh32(math.float.inf(f32))));
+    try expect(math.isNegativeInf(sinh32(-math.float.inf(f32))));
+    try expect(math.isNan(sinh32(math.float.nan(f32))));
 }
 
 test "sinh64.special" {
     try expect(math.isPositiveZero(sinh64(0.0)));
     try expect(math.isNegativeZero(sinh64(-0.0)));
-    try expect(math.isPositiveInf(sinh64(math.inf(f64))));
-    try expect(math.isNegativeInf(sinh64(-math.inf(f64))));
-    try expect(math.isNan(sinh64(math.nan(f64))));
+    try expect(math.isPositiveInf(sinh64(math.float.inf(f64))));
+    try expect(math.isNegativeInf(sinh64(-math.float.inf(f64))));
+    try expect(math.isNan(sinh64(math.float.nan(f64))));
 }

--- a/lib/std/math/tanh.zig
+++ b/lib/std/math/tanh.zig
@@ -138,15 +138,15 @@ test tanh64 {
 test "tanh32.special" {
     try expect(math.isPositiveZero(tanh32(0.0)));
     try expect(math.isNegativeZero(tanh32(-0.0)));
-    try expect(tanh32(math.inf(f32)) == 1.0);
-    try expect(tanh32(-math.inf(f32)) == -1.0);
-    try expect(math.isNan(tanh32(math.nan(f32))));
+    try expect(tanh32(math.float.inf(f32)) == 1.0);
+    try expect(tanh32(-math.float.inf(f32)) == -1.0);
+    try expect(math.isNan(tanh32(math.float.nan(f32))));
 }
 
 test "tanh64.special" {
     try expect(math.isPositiveZero(tanh64(0.0)));
     try expect(math.isNegativeZero(tanh64(-0.0)));
-    try expect(tanh64(math.inf(f64)) == 1.0);
-    try expect(tanh64(-math.inf(f64)) == -1.0);
-    try expect(math.isNan(tanh64(math.nan(f64))));
+    try expect(tanh64(math.float.inf(f64)) == 1.0);
+    try expect(tanh64(-math.float.inf(f64)) == -1.0);
+    try expect(math.isNan(tanh64(math.float.nan(f64))));
 }

--- a/lib/std/simd.zig
+++ b/lib/std/simd.zig
@@ -406,10 +406,10 @@ pub fn prefixScan(comptime op: std.builtin.ReduceOp, comptime hop: isize, vec: a
             .And, .Min => std.math.maxInt(Child),
         },
         .Float => switch (op) {
-            .Max => -std.math.inf(Child),
+            .Max => -std.math.float.inf(Child),
             .Add => 0,
             .Mul => 1,
-            .Min => std.math.inf(Child),
+            .Min => std.math.float.inf(Child),
             else => @compileError("Invalid prefixScan operation " ++ @tagName(op) ++ " for vector of floats."),
         },
         else => @compileError("Invalid type " ++ @typeName(VecType) ++ " for prefixScan."),

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -280,7 +280,7 @@ fn expectApproxEqRelInner(comptime T: type, expected: T, actual: T, tolerance: T
 
 test expectApproxEqRel {
     inline for ([_]type{ f16, f32, f64, f128 }) |T| {
-        const eps_value = comptime math.floatEps(T);
+        const eps_value = comptime math.float.eps(T);
         const sqrt_eps_value = comptime @sqrt(eps_value);
 
         const pos_x: T = 12.0;

--- a/lib/std/zig/c_builtins.zig
+++ b/lib/std/zig/c_builtins.zig
@@ -213,15 +213,15 @@ pub inline fn __builtin_expect(expr: c_long, c: c_long) c_long {
 pub inline fn __builtin_nanf(tagp: []const u8) f32 {
     const parsed = std.fmt.parseUnsigned(c_ulong, tagp, 0) catch 0;
     const bits: u23 = @truncate(parsed); // single-precision float trailing significand is 23 bits
-    return @bitCast(@as(u32, bits) | @as(u32, @bitCast(std.math.nan(f32))));
+    return @bitCast(@as(u32, bits) | @as(u32, @bitCast(std.math.float.nan(f32))));
 }
 
 pub inline fn __builtin_huge_valf() f32 {
-    return std.math.inf(f32);
+    return std.math.float.inf(f32);
 }
 
 pub inline fn __builtin_inff() f32 {
-    return std.math.inf(f32);
+    return std.math.float.inf(f32);
 }
 
 pub inline fn __builtin_isnan(x: anytype) c_int {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -16708,7 +16708,7 @@ fn analyzeArithmetic(
                                     return Air.internedToRef(rhs_val.toIntern());
                                 }
                                 if (rhs_val.isInf(mod)) {
-                                    return Air.internedToRef((try mod.floatValue(resolved_type, std.math.nan(f128))).toIntern());
+                                    return Air.internedToRef((try mod.floatValue(resolved_type, std.math.float.nan(f128))).toIntern());
                                 }
                             } else if (resolved_type.isAnyFloat()) {
                                 break :lz;
@@ -16736,7 +16736,7 @@ fn analyzeArithmetic(
                     if (try rhs_val.compareAllWithZeroAdvanced(.eq, sema)) rz: {
                         if (maybe_lhs_val) |lhs_val| {
                             if (lhs_val.isInf(mod)) {
-                                return Air.internedToRef((try mod.floatValue(resolved_type, std.math.nan(f128))).toIntern());
+                                return Air.internedToRef((try mod.floatValue(resolved_type, std.math.float.nan(f128))).toIntern());
                             }
                         } else if (resolved_type.isAnyFloat()) {
                             break :rz;

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1032,7 +1032,7 @@ pub const DeclGen = struct {
                         // MSVC doesn't have a way to define a custom or signaling NaN value in a constant expression
 
                         // TODO: Re-enable this check, otherwise we're writing qnan bit patterns on msvc incorrectly
-                        // if (std.math.isNan(f128_val) and f128_val != std.math.nan(f128))
+                        // if (std.math.isNan(f128_val) and f128_val != std.math.float.nan(f128))
                         //     return dg.fail("Only quiet nans are supported in global variable initializers", .{});
                     }
 
@@ -7080,13 +7080,13 @@ fn airReduce(f: *Function, inst: Air.Inst.Index) !CValue {
         .Min => switch (scalar_ty.zigTypeTag(zcu)) {
             .Bool => Value.true,
             .Int => try scalar_ty.maxIntScalar(zcu, scalar_ty),
-            .Float => try zcu.floatValue(scalar_ty, std.math.nan(f128)),
+            .Float => try zcu.floatValue(scalar_ty, std.math.float.nan(f128)),
             else => unreachable,
         },
         .Max => switch (scalar_ty.zigTypeTag(zcu)) {
             .Bool => Value.false,
             .Int => try scalar_ty.minIntScalar(zcu, scalar_ty),
-            .Float => try zcu.floatValue(scalar_ty, std.math.nan(f128)),
+            .Float => try zcu.floatValue(scalar_ty, std.math.float.nan(f128)),
             else => unreachable,
         },
     }, .Initializer);

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9953,7 +9953,7 @@ pub const FuncGen = struct {
         const init_val = switch (llvm_scalar_ty) {
             .i16 => try o.builder.intValue(.i16, @as(i16, @bitCast(
                 @as(f16, switch (reduce.operation) {
-                    .Min, .Max => std.math.nan(f16),
+                    .Min, .Max => std.math.float.nan(f16),
                     .Add => -0.0,
                     .Mul => 1.0,
                     else => unreachable,
@@ -9961,7 +9961,7 @@ pub const FuncGen = struct {
             ))),
             .i80 => try o.builder.intValue(.i80, @as(i80, @bitCast(
                 @as(f80, switch (reduce.operation) {
-                    .Min, .Max => std.math.nan(f80),
+                    .Min, .Max => std.math.float.nan(f80),
                     .Add => -0.0,
                     .Mul => 1.0,
                     else => unreachable,
@@ -9969,7 +9969,7 @@ pub const FuncGen = struct {
             ))),
             .i128 => try o.builder.intValue(.i128, @as(i128, @bitCast(
                 @as(f128, switch (reduce.operation) {
-                    .Min, .Max => std.math.nan(f128),
+                    .Min, .Max => std.math.float.nan(f128),
                     .Add => -0.0,
                     .Mul => 1.0,
                     else => unreachable,

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -7298,8 +7298,8 @@ pub const Constant = enum(u32) {
                         const Float = struct {
                             fn Repr(comptime T: type) type {
                                 return packed struct(std.meta.Int(.unsigned, @bitSizeOf(T))) {
-                                    mantissa: std.meta.Int(.unsigned, std.math.floatMantissaBits(T)),
-                                    exponent: std.meta.Int(.unsigned, std.math.floatExponentBits(T)),
+                                    mantissa: std.meta.Int(.unsigned, std.math.float.mantissaBits(T)),
+                                    exponent: std.meta.Int(.unsigned, std.math.float.exponentBits(T)),
                                     sign: u1,
                                 };
                             }
@@ -7320,17 +7320,17 @@ pub const Constant = enum(u32) {
                             .mantissa = std.math.shl(
                                 Mantissa64,
                                 repr.mantissa,
-                                std.math.floatMantissaBits(f64) - std.math.floatMantissaBits(f32) +
+                                std.math.float.mantissaBits(f64) - std.math.float.mantissaBits(f32) +
                                     denormal_shift,
                             ),
                             .exponent = switch (repr.exponent) {
                                 std.math.minInt(Exponent32) => if (repr.mantissa > 0)
-                                    @as(Exponent64, std.math.floatExponentMin(f32) +
-                                        std.math.floatExponentMax(f64)) - denormal_shift
+                                    @as(Exponent64, std.math.float.exponentMin(f32) +
+                                        std.math.float.exponentMax(f64)) - denormal_shift
                                 else
                                     std.math.minInt(Exponent64),
                                 else => @as(Exponent64, repr.exponent) +
-                                    (std.math.floatExponentMax(f64) - std.math.floatExponentMax(f32)),
+                                    (std.math.float.exponentMax(f64) - std.math.float.exponentMax(f32)),
                                 std.math.maxInt(Exponent32) => std.math.maxInt(Exponent64),
                             },
                             .sign = repr.sign,

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -8923,13 +8923,13 @@ pub fn fpValue(self: *Builder, ty: Type, comptime value: comptime_float) Allocat
 
 pub fn nanConst(self: *Builder, ty: Type) Allocator.Error!Constant {
     return switch (ty) {
-        .half => try self.halfConst(std.math.nan(f16)),
-        .bfloat => try self.bfloatConst(std.math.nan(f32)),
-        .float => try self.floatConst(std.math.nan(f32)),
-        .double => try self.doubleConst(std.math.nan(f64)),
-        .fp128 => try self.fp128Const(std.math.nan(f128)),
-        .x86_fp80 => try self.x86_fp80Const(std.math.nan(f80)),
-        .ppc_fp128 => try self.ppc_fp128Const(.{std.math.nan(f64)} ** 2),
+        .half => try self.halfConst(std.math.float.nan(f16)),
+        .bfloat => try self.bfloatConst(std.math.float.nan(f32)),
+        .float => try self.floatConst(std.math.float.nan(f32)),
+        .double => try self.doubleConst(std.math.float.nan(f64)),
+        .fp128 => try self.fp128Const(std.math.float.nan(f128)),
+        .x86_fp80 => try self.x86_fp80Const(std.math.float.nan(f80)),
+        .ppc_fp128 => try self.ppc_fp128Const(.{std.math.float.nan(f64)} ** 2),
         else => unreachable,
     };
 }

--- a/test/behavior/abs.zig
+++ b/test/behavior/abs.zig
@@ -130,14 +130,14 @@ fn testAbsFloats(comptime T: type) !void {
     }
 
     {
-        var x: T = -std.math.inf(T);
+        var x: T = -std.math.float.inf(T);
         _ = &x;
-        try expect(@abs(x) == std.math.inf(T));
+        try expect(@abs(x) == std.math.float.inf(T));
     }
     {
-        var x: T = std.math.inf(T);
+        var x: T = std.math.float.inf(T);
         _ = &x;
-        try expect(@abs(x) == std.math.inf(T));
+        try expect(@abs(x) == std.math.float.inf(T));
     }
     comptime {
         try expect(@abs(@as(T, -std.math.e)) == std.math.e);

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -452,41 +452,41 @@ test "bitcast nan float does not modify signaling bit" {
     const snan_u128: u128 = 0x7FFF4000000000000000000000000000;
 
     // 16 bit
-    const snan_f16_const = math.snan(f16);
+    const snan_f16_const = math.float.snan(f16);
     try expectEqual(snan_u16, @as(u16, @bitCast(snan_f16_const)));
     try expectEqual(snan_u16, bitCastWrapper16(snan_f16_const));
 
-    var snan_f16_var = math.snan(f16);
+    var snan_f16_var = math.float.snan(f16);
     _ = &snan_f16_var;
     try expectEqual(snan_u16, @as(u16, @bitCast(snan_f16_var)));
     try expectEqual(snan_u16, bitCastWrapper16(snan_f16_var));
 
     // 32 bit
-    const snan_f32_const = math.snan(f32);
+    const snan_f32_const = math.float.snan(f32);
     try expectEqual(snan_u32, @as(u32, @bitCast(snan_f32_const)));
     try expectEqual(snan_u32, bitCastWrapper32(snan_f32_const));
 
-    var snan_f32_var = math.snan(f32);
+    var snan_f32_var = math.float.snan(f32);
     _ = &snan_f32_var;
     try expectEqual(snan_u32, @as(u32, @bitCast(snan_f32_var)));
     try expectEqual(snan_u32, bitCastWrapper32(snan_f32_var));
 
     // 64 bit
-    const snan_f64_const = math.snan(f64);
+    const snan_f64_const = math.float.snan(f64);
     try expectEqual(snan_u64, @as(u64, @bitCast(snan_f64_const)));
     try expectEqual(snan_u64, bitCastWrapper64(snan_f64_const));
 
-    var snan_f64_var = math.snan(f64);
+    var snan_f64_var = math.float.snan(f64);
     _ = &snan_f64_var;
     try expectEqual(snan_u64, @as(u64, @bitCast(snan_f64_var)));
     try expectEqual(snan_u64, bitCastWrapper64(snan_f64_var));
 
     // 128 bit
-    const snan_f128_const = math.snan(f128);
+    const snan_f128_const = math.float.snan(f128);
     try expectEqual(snan_u128, @as(u128, @bitCast(snan_f128_const)));
     try expectEqual(snan_u128, bitCastWrapper128(snan_f128_const));
 
-    var snan_f128_var = math.snan(f128);
+    var snan_f128_var = math.float.snan(f128);
     _ = &snan_f128_var;
     try expectEqual(snan_u128, @as(u128, @bitCast(snan_f128_var)));
     try expectEqual(snan_u128, bitCastWrapper128(snan_f128_var));

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -196,15 +196,15 @@ fn testCmp(comptime T: type) !void {
     @setEvalBranchQuota(2_000);
     var edges = [_]T{
         -math.inf(T),
-        -math.floatMax(T),
-        -math.floatMin(T),
-        -math.floatTrueMin(T),
+        -math.float.max(T),
+        -math.float.min(T),
+        -math.float.trueMin(T),
         -0.0,
         math.nan(T),
         0.0,
-        math.floatTrueMin(T),
-        math.floatMin(T),
-        math.floatMax(T),
+        math.float.trueMin(T),
+        math.float.min(T),
+        math.float.max(T),
         math.inf(T),
     };
     _ = &edges;
@@ -1072,24 +1072,24 @@ fn testFabs(comptime T: type) !void {
     try expect(@abs(one) == 1.0);
     var neg_one: T = -1.0;
     try expect(@abs(neg_one) == 1.0);
-    var min: T = math.floatMin(T);
-    try expect(@abs(min) == math.floatMin(T));
-    var neg_min: T = -math.floatMin(T);
-    try expect(@abs(neg_min) == math.floatMin(T));
-    var max: T = math.floatMax(T);
-    try expect(@abs(max) == math.floatMax(T));
-    var neg_max: T = -math.floatMax(T);
-    try expect(@abs(neg_max) == math.floatMax(T));
+    var min: T = math.float.min(T);
+    try expect(@abs(min) == math.float.min(T));
+    var neg_min: T = -math.float.min(T);
+    try expect(@abs(neg_min) == math.float.min(T));
+    var max: T = math.float.max(T);
+    try expect(@abs(max) == math.float.max(T));
+    var neg_max: T = -math.float.max(T);
+    try expect(@abs(neg_max) == math.float.max(T));
 
     // subnormals
     var zero: T = 0.0;
     try expect(@abs(zero) == 0.0);
     var neg_zero: T = -0.0;
     try expect(@abs(neg_zero) == 0.0);
-    var true_min: T = math.floatTrueMin(T);
-    try expect(@abs(true_min) == math.floatTrueMin(T));
-    var neg_true_min: T = -math.floatTrueMin(T);
-    try expect(@abs(neg_true_min) == math.floatTrueMin(T));
+    var true_min: T = math.float.trueMin(T);
+    try expect(@abs(true_min) == math.float.trueMin(T));
+    var neg_true_min: T = -math.float.trueMin(T);
+    try expect(@abs(neg_true_min) == math.float.trueMin(T));
 
     // non-finite numbers
     var inf: T = math.inf(T);
@@ -1515,24 +1515,24 @@ fn testNeg(comptime T: type) !void {
     try expect(-one == -1.0);
     var neg_one: T = -1.0;
     try expect(-neg_one == 1.0);
-    var min: T = math.floatMin(T);
-    try expect(-min == -math.floatMin(T));
-    var neg_min: T = -math.floatMin(T);
-    try expect(-neg_min == math.floatMin(T));
-    var max: T = math.floatMax(T);
-    try expect(-max == -math.floatMax(T));
-    var neg_max: T = -math.floatMax(T);
-    try expect(-neg_max == math.floatMax(T));
+    var min: T = math.float.min(T);
+    try expect(-min == -math.float.min(T));
+    var neg_min: T = -math.float.min(T);
+    try expect(-neg_min == math.float.min(T));
+    var max: T = math.float.max(T);
+    try expect(-max == -math.float.max(T));
+    var neg_max: T = -math.float.max(T);
+    try expect(-neg_max == math.float.max(T));
 
     // subnormals
     var zero: T = 0.0;
     try expect(-zero == -0.0);
     var neg_zero: T = -0.0;
     try expect(-neg_zero == 0.0);
-    var true_min: T = math.floatTrueMin(T);
-    try expect(-true_min == -math.floatTrueMin(T));
-    var neg_true_min: T = -math.floatTrueMin(T);
-    try expect(-neg_true_min == math.floatTrueMin(T));
+    var true_min: T = math.float.trueMin(T);
+    try expect(-true_min == -math.float.trueMin(T));
+    var neg_true_min: T = -math.float.trueMin(T);
+    try expect(-neg_true_min == math.float.trueMin(T));
 
     // non-finite numbers
     var inf: T = math.inf(T);

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -195,17 +195,17 @@ fn testCmp(comptime T: type) !void {
 
     @setEvalBranchQuota(2_000);
     var edges = [_]T{
-        -math.inf(T),
+        -math.float.inf(T),
         -math.float.max(T),
         -math.float.min(T),
         -math.float.trueMin(T),
         -0.0,
-        math.nan(T),
+        math.float.nan(T),
         0.0,
         math.float.trueMin(T),
         math.float.min(T),
         math.float.max(T),
-        math.inf(T),
+        math.float.inf(T),
     };
     _ = &edges;
     for (edges, 0..) |rhs, rhs_i| {
@@ -351,7 +351,7 @@ fn testSqrt(comptime T: type) !void {
     try expect(math.approxEqAbs(T, @sqrt(c), 94.5633674791671111, eps));
 
     // special cases
-    var inf: T = math.inf(T);
+    var inf: T = math.float.inf(T);
     try expect(math.isPositiveInf(@sqrt(inf)));
     var zero: T = 0.0;
     try expect(@sqrt(zero) == 0.0);
@@ -359,7 +359,7 @@ fn testSqrt(comptime T: type) !void {
     try expect(@sqrt(neg_zero) == 0.0);
     var neg_one: T = -1.0;
     try expect(math.isNan(@sqrt(neg_one)));
-    var nan: T = math.nan(T);
+    var nan: T = math.float.nan(T);
     try expect(math.isNan(@sqrt(nan)));
 
     _ = .{
@@ -1092,11 +1092,11 @@ fn testFabs(comptime T: type) !void {
     try expect(@abs(neg_true_min) == math.float.trueMin(T));
 
     // non-finite numbers
-    var inf: T = math.inf(T);
+    var inf: T = math.float.inf(T);
     try expect(math.isPositiveInf(@abs(inf)));
-    var neg_inf: T = -math.inf(T);
+    var neg_inf: T = -math.float.inf(T);
     try expect(math.isPositiveInf(@abs(neg_inf)));
-    var nan: T = math.nan(T);
+    var nan: T = math.float.nan(T);
     try expect(math.isNan(@abs(nan)));
 
     _ = .{
@@ -1535,14 +1535,14 @@ fn testNeg(comptime T: type) !void {
     try expect(-neg_true_min == math.float.trueMin(T));
 
     // non-finite numbers
-    var inf: T = math.inf(T);
+    var inf: T = math.float.inf(T);
     try expect(math.isNegativeInf(-inf));
-    var neg_inf: T = -math.inf(T);
+    var neg_inf: T = -math.float.inf(T);
     try expect(math.isPositiveInf(-neg_inf));
-    var nan: T = math.nan(T);
+    var nan: T = math.float.nan(T);
     try expect(math.isNan(-nan));
     try expect(math.signbit(-nan));
-    var neg_nan: T = -math.nan(T);
+    var neg_nan: T = -math.float.nan(T);
     try expect(math.isNan(-neg_nan));
     try expect(!math.signbit(-neg_nan));
 
@@ -1630,25 +1630,25 @@ test "comptime float compared with runtime int" {
     try std.testing.expect(i < f);
 }
 test "comptime nan < runtime 0" {
-    const f = comptime std.math.nan(f64);
+    const f = comptime std.math.float.nan(f64);
     var i: usize = 0;
     _ = &i;
     try std.testing.expect(!(f < i));
 }
 test "comptime inf > runtime 0" {
-    const f = comptime std.math.inf(f64);
+    const f = comptime std.math.float.inf(f64);
     var i: usize = 0;
     _ = &i;
     try std.testing.expect(f > i);
 }
 test "comptime -inf < runtime 0" {
-    const f = comptime -std.math.inf(f64);
+    const f = comptime -std.math.float.inf(f64);
     var i: usize = 0;
     _ = &i;
     try std.testing.expect(f < i);
 }
 test "comptime inf >= runtime 1" {
-    const f = comptime std.math.inf(f64);
+    const f = comptime std.math.float.inf(f64);
     var i: usize = 1;
     _ = &i;
     try std.testing.expect(f >= i);
@@ -1658,7 +1658,7 @@ test "comptime isNan(nan * 1)" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    const nan_times_one = comptime std.math.nan(f64) * 1;
+    const nan_times_one = comptime std.math.float.nan(f64) * 1;
     try std.testing.expect(std.math.isNan(nan_times_one));
 }
 test "runtime isNan(nan * 1)" {
@@ -1666,7 +1666,7 @@ test "runtime isNan(nan * 1)" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    const nan_times_one = std.math.nan(f64) * 1;
+    const nan_times_one = std.math.float.nan(f64) * 1;
     try std.testing.expect(std.math.isNan(nan_times_one));
 }
 test "comptime isNan(nan * 0)" {
@@ -1674,9 +1674,9 @@ test "comptime isNan(nan * 0)" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    const nan_times_zero = comptime std.math.nan(f64) * 0;
+    const nan_times_zero = comptime std.math.float.nan(f64) * 0;
     try std.testing.expect(std.math.isNan(nan_times_zero));
-    const zero_times_nan = 0 * comptime std.math.nan(f64);
+    const zero_times_nan = 0 * comptime std.math.float.nan(f64);
     try std.testing.expect(std.math.isNan(zero_times_nan));
 }
 test "runtime isNan(nan * 0)" {
@@ -1684,9 +1684,9 @@ test "runtime isNan(nan * 0)" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    const nan_times_zero = std.math.nan(f64) * 0;
+    const nan_times_zero = std.math.float.nan(f64) * 0;
     try std.testing.expect(std.math.isNan(nan_times_zero));
-    const zero_times_nan = 0 * std.math.nan(f64);
+    const zero_times_nan = 0 * std.math.float.nan(f64);
     try std.testing.expect(std.math.isNan(zero_times_nan));
 }
 test "comptime isNan(inf * 0)" {
@@ -1694,9 +1694,9 @@ test "comptime isNan(inf * 0)" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    const inf_times_zero = comptime std.math.inf(f64) * 0;
+    const inf_times_zero = comptime std.math.float.inf(f64) * 0;
     try std.testing.expect(std.math.isNan(inf_times_zero));
-    const zero_times_inf = 0 * comptime std.math.inf(f64);
+    const zero_times_inf = 0 * comptime std.math.float.inf(f64);
     try std.testing.expect(std.math.isNan(zero_times_inf));
 }
 test "runtime isNan(inf * 0)" {
@@ -1704,9 +1704,9 @@ test "runtime isNan(inf * 0)" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    const inf_times_zero = std.math.inf(f64) * 0;
+    const inf_times_zero = std.math.float.inf(f64) * 0;
     try std.testing.expect(std.math.isNan(inf_times_zero));
-    const zero_times_inf = 0 * std.math.inf(f64);
+    const zero_times_inf = 0 * std.math.float.inf(f64);
     try std.testing.expect(std.math.isNan(zero_times_inf));
 }
 

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -1692,8 +1692,8 @@ test "NaN comparison f80" {
 }
 
 fn testNanEqNan(comptime F: type) !void {
-    var nan1 = math.nan(F);
-    var nan2 = math.nan(F);
+    var nan1 = math.float.nan(F);
+    var nan2 = math.float.nan(F);
     _ = .{ &nan1, &nan2 };
     try expect(nan1 != nan2);
     try expect(!(nan1 == nan2));

--- a/test/behavior/maximum_minimum.zig
+++ b/test/behavior/maximum_minimum.zig
@@ -15,7 +15,7 @@ test "@max" {
         fn doTheTest() !void {
             var x: i32 = 10;
             var y: f32 = 0.68;
-            var nan: f32 = std.math.nan(f32);
+            var nan: f32 = std.math.float.nan(f32);
             _ = .{ &x, &y, &nan };
             try expect(@as(i32, 10) == @max(@as(i32, -3), x));
             try expect(@as(f32, 3.2) == @max(@as(f32, 3.2), y));
@@ -50,8 +50,8 @@ test "@max on vectors" {
             _ = .{ &c, &d };
             try expect(mem.eql(f32, &@as([4]f32, y), &[4]f32{ 0, 0.42, -0.64, 7.8 }));
 
-            var e: @Vector(2, f32) = [2]f32{ 0, std.math.nan(f32) };
-            var f: @Vector(2, f32) = [2]f32{ std.math.nan(f32), 0 };
+            var e: @Vector(2, f32) = [2]f32{ 0, std.math.float.nan(f32) };
+            var f: @Vector(2, f32) = [2]f32{ std.math.float.nan(f32), 0 };
             const z = @max(e, f);
             _ = .{ &e, &f };
             try expect(mem.eql(f32, &@as([2]f32, z), &[2]f32{ 0, 0 }));
@@ -71,7 +71,7 @@ test "@min" {
         fn doTheTest() !void {
             var x: i32 = 10;
             var y: f32 = 0.68;
-            var nan: f32 = std.math.nan(f32);
+            var nan: f32 = std.math.float.nan(f32);
             _ = .{ &x, &y, &nan };
             try expect(@as(i32, -3) == @min(@as(i32, -3), x));
             try expect(@as(f32, 0.68) == @min(@as(f32, 3.2), y));
@@ -106,8 +106,8 @@ test "@min for vectors" {
             const y = @min(c, d);
             try expect(mem.eql(f32, &@as([4]f32, y), &[4]f32{ -0.23, 0.4, -2.4, 0.9 }));
 
-            var e: @Vector(2, f32) = [2]f32{ 0, std.math.nan(f32) };
-            var f: @Vector(2, f32) = [2]f32{ std.math.nan(f32), 0 };
+            var e: @Vector(2, f32) = [2]f32{ 0, std.math.float.nan(f32) };
+            var f: @Vector(2, f32) = [2]f32{ std.math.float.nan(f32), 0 };
             _ = .{ &e, &f };
             const z = @max(e, f);
             try expect(mem.eql(f32, &@as([2]f32, z), &[2]f32{ 0, 0 }));
@@ -137,7 +137,7 @@ test "@min/max for floats" {
             try expectEqual(y, @max(y, x));
 
             if (T != comptime_float) {
-                var nan: T = std.math.nan(T);
+                var nan: T = std.math.float.nan(T);
                 _ = &nan;
                 try expectEqual(y, @max(nan, y));
                 try expectEqual(y, @max(y, nan));

--- a/test/behavior/nan.zig
+++ b/test/behavior/nan.zig
@@ -12,14 +12,14 @@ const qnan_u64: u64 = 0x7FF8000000000000;
 const snan_u64: u64 = 0x7FF4000000000000;
 const qnan_u128: u128 = 0x7FFF8000000000000000000000000000;
 const snan_u128: u128 = 0x7FFF4000000000000000000000000000;
-const qnan_f16: f16 = math.nan(f16);
-const snan_f16: f16 = math.snan(f16);
-const qnan_f32: f32 = math.nan(f32);
-const snan_f32: f32 = math.snan(f32);
-const qnan_f64: f64 = math.nan(f64);
-const snan_f64: f64 = math.snan(f64);
-const qnan_f128: f128 = math.nan(f128);
-const snan_f128: f128 = math.snan(f128);
+const qnan_f16: f16 = math.float.nan(f16);
+const snan_f16: f16 = math.float.snan(f16);
+const qnan_f32: f32 = math.float.nan(f32);
+const snan_f32: f32 = math.float.snan(f32);
+const qnan_f64: f64 = math.float.nan(f64);
+const snan_f64: f64 = math.float.snan(f64);
+const qnan_f128: f128 = math.float.nan(f128);
+const snan_f128: f128 = math.float.snan(f128);
 
 test "nan memory equality" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -368,7 +368,7 @@ test "pointer sentinel with +inf" {
 
     const S = struct {
         fn doTheTest() !void {
-            const inf_f32 = comptime std.math.inf(f32);
+            const inf_f32 = comptime std.math.float.inf(f32);
             var ptr: [*:inf_f32]const f32 = &[_:inf_f32]f32{ 1.1, 2.2, 3.3, 4.4 };
             _ = &ptr;
             try expect(ptr[4] == inf_f32); // TODO this should be comptime assert, see #3731

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -781,7 +781,7 @@ test "vector reduce operation" {
                         // equal.
                     } else {
                         const F = @TypeOf(expected);
-                        const tolerance = @sqrt(math.floatEps(TX));
+                        const tolerance = @sqrt(math.float.eps(TX));
                         try expect(std.math.approxEqRel(F, expected, r, tolerance));
                     }
                 },

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -870,9 +870,9 @@ test "vector reduce operation" {
             try testReduce(.Xor, [4]u128{ 0x00000000, 0x33333333, 0x88888888, 0x44444444 }, @as(u128, 0xffffffff));
 
             // Test the reduction on vectors containing NaNs.
-            const f16_nan = math.nan(f16);
-            const f32_nan = math.nan(f32);
-            const f64_nan = math.nan(f64);
+            const f16_nan = math.float.nan(f16);
+            const f32_nan = math.float.nan(f32);
+            const f64_nan = math.float.nan(f64);
 
             try testReduce(.Add, [4]f16{ -1.9, 5.1, f16_nan, 100.0 }, f16_nan);
             try testReduce(.Add, [4]f32{ -1.9, 5.1, f32_nan, 100.0 }, f32_nan);


### PR DESCRIPTION
Per https://github.com/ziglang/zig/pull/20125#discussion_r1621473815.  

(was also getting annoyed at having to write `floatEps` in its entirety rather than just `eps` like Julia.)