### PR TITLE
Update `__chkstk_ms` to have weak linkage

### DIFF
--- a/lib/compiler_rt/stack_probe.zig
+++ b/lib/compiler_rt/stack_probe.zig
@@ -17,7 +17,7 @@ comptime {
         // Default stack-probe functions emitted by LLVM
         if (is_mingw) {
             @export(_chkstk, .{ .name = "_alloca", .linkage = strong_linkage });
-            @export(___chkstk_ms, .{ .name = "___chkstk_ms", .linkage = strong_linkage });
+            @export(___chkstk_ms, .{ .name = "___chkstk_ms", .linkage = linkage });
 
             if (arch.isAARCH64()) {
                 @export(__chkstk, .{ .name = "__chkstk", .linkage = strong_linkage });

--- a/lib/compiler_rt/stack_probe.zig
+++ b/lib/compiler_rt/stack_probe.zig
@@ -16,16 +16,16 @@ comptime {
     if (builtin.os.tag == .windows) {
         // Default stack-probe functions emitted by LLVM
         if (is_mingw) {
-            @export(_chkstk, .{ .name = "_alloca", .linkage = strong_linkage });
+            @export(_chkstk, .{ .name = "_alloca", .linkage = linkage });
             @export(___chkstk_ms, .{ .name = "___chkstk_ms", .linkage = linkage });
 
             if (arch.isAARCH64()) {
-                @export(__chkstk, .{ .name = "__chkstk", .linkage = strong_linkage });
+                @export(__chkstk, .{ .name = "__chkstk", .linkage = linkage });
             }
         } else if (!builtin.link_libc) {
             // This symbols are otherwise exported by MSVCRT.lib
-            @export(_chkstk, .{ .name = "_chkstk", .linkage = strong_linkage });
-            @export(__chkstk, .{ .name = "__chkstk", .linkage = strong_linkage });
+            @export(_chkstk, .{ .name = "_chkstk", .linkage = linkage });
+            @export(__chkstk, .{ .name = "__chkstk", .linkage = linkage });
         }
     }
 


### PR DESCRIPTION
@kubkon mentioned that `compiler_rt` symbols should have weak linkage, but that wasn't the case for `__chkstk_ms` which was causing conflicts during linking in some circumstances (specifically with linking object files from Rust sources). This PR switches `__chkstk_ms` to have weak linkage.

https://github.com/ziglang/zig/issues/15107