### PR TITLE
Translate Macros That Use Runtime Identifiers To Inline Functions

### DIFF
--- a/lib/compiler/aro_translate_c.zig
+++ b/lib/compiler/aro_translate_c.zig
@@ -1381,7 +1381,6 @@ pub fn ScopeExtra(comptime ScopeExtraContext: type, comptime ScopeExtraType: typ
         pub const Root = struct {
             base: ScopeExtraScope,
             sym_table: SymbolTable,
-            macro_table: SymbolTable,
             blank_macros: std.StringArrayHashMap(void),
             context: *ScopeExtraContext,
             nodes: std.ArrayList(ast.Node),
@@ -1393,7 +1392,6 @@ pub fn ScopeExtra(comptime ScopeExtraContext: type, comptime ScopeExtraType: typ
                         .parent = null,
                     },
                     .sym_table = SymbolTable.init(c.gpa),
-                    .macro_table = SymbolTable.init(c.gpa),
                     .blank_macros = std.StringArrayHashMap(void).init(c.gpa),
                     .context = c,
                     .nodes = std.ArrayList(ast.Node).init(c.gpa),
@@ -1402,7 +1400,6 @@ pub fn ScopeExtra(comptime ScopeExtraContext: type, comptime ScopeExtraType: typ
 
             pub fn deinit(scope: *Root) void {
                 scope.sym_table.deinit();
-                scope.macro_table.deinit();
                 scope.blank_macros.deinit();
                 scope.nodes.deinit();
             }
@@ -1410,7 +1407,7 @@ pub fn ScopeExtra(comptime ScopeExtraContext: type, comptime ScopeExtraType: typ
             /// Check if the global scope contains this name, without looking into the "future", e.g.
             /// ignore the preprocessed decl and macro names.
             pub fn containsNow(scope: *Root, name: []const u8) bool {
-                return scope.sym_table.contains(name) or scope.macro_table.contains(name);
+                return scope.sym_table.contains(name);
             }
 
             /// Check if the global scope contains the name, includes all decls that haven't been translated yet.

--- a/lib/compiler/aro_translate_c/ast.zig
+++ b/lib/compiler/aro_translate_c/ast.zig
@@ -875,6 +875,7 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
         .declaration => unreachable,
         .warning => {
             const payload = node.castTag(.warning).?.data;
+            try c.buf.append('\n');
             try c.buf.appendSlice(payload);
             try c.buf.append('\n');
             return @as(NodeIndex, 0); // error: integer value 0 cannot be coerced to type 'std.mem.Allocator.Error!u32'

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -6497,6 +6497,128 @@ fn getFnProto(c: *Context, ref: Node) ?*ast.Payload.Func {
     return null;
 }
 
+fn macroDependsOnRuntimeValue(c: *Context, ref: ast.Node) ?ast.Node {
+    const init = if (ref.castTag(.var_decl)) |v|
+        v.data.init orelse return null
+    else if (ref.castTag(.var_simple) orelse ref.castTag(.pub_var_simple)) |v|
+        v.data.init
+    else
+        return null;
+
+    if (analyzeNodeForRuntime(c, init)) {
+        return init;
+    } else {
+        return null;
+    }
+}
+
+fn analyzeNodeForRuntime(c: *Context, ref: ast.Node) bool {
+    switch (ref.tag()) {
+        .add,
+        .add_assign,
+        .add_wrap,
+        .add_wrap_assign,
+        .sub,
+        .sub_assign,
+        .sub_wrap,
+        .sub_wrap_assign,
+        .mul,
+        .mul_assign,
+        .mul_wrap,
+        .mul_wrap_assign,
+        .div,
+        .div_assign,
+        .shl,
+        .shl_assign,
+        .shr,
+        .shr_assign,
+        .mod,
+        .mod_assign,
+        .@"and",
+        .@"or",
+        .less_than,
+        .less_than_equal,
+        .greater_than,
+        .greater_than_equal,
+        .equal,
+        .not_equal,
+        .bit_and,
+        .bit_and_assign,
+        .bit_or,
+        .bit_or_assign,
+        .bit_xor,
+        .bit_xor_assign,
+        .div_trunc,
+        .signed_remainder,
+        .as,
+        .array_cat,
+        .ellipsis3,
+        .assign,
+        .array_access,
+        .std_mem_zeroinit,
+        .helpers_flexible_array_type,
+        .helpers_shuffle_vector_index,
+        .vector,
+        .div_exact,
+        .offset_of,
+        .helpers_cast,
+        => {
+            const bin_op: *ast.Payload.BinOp = @alignCast(@fieldParentPtr("base", ref.ptr_otherwise));
+            return analyzeNodeForRuntime(c, bin_op.data.lhs) or analyzeNodeForRuntime(c, bin_op.data.rhs);
+        },
+        .std_mem_zeroes,
+        .@"return",
+        .@"comptime",
+        .@"defer",
+        .asm_simple,
+        .negate,
+        .negate_wrap,
+        .bit_not,
+        .not,
+        .optional_type,
+        .address_of,
+        .unwrap,
+        .deref,
+        .int_from_ptr,
+        .empty_array,
+        .while_true,
+        .if_not_break,
+        .switch_else,
+        .block_single,
+        .helpers_sizeof,
+        .int_from_bool,
+        .sizeof,
+        .alignof,
+        .typeof,
+        .typeinfo,
+        .align_cast,
+        .truncate,
+        .bit_cast,
+        .float_cast,
+        .int_from_float,
+        .float_from_int,
+        .ptr_from_int,
+        .ptr_cast,
+        .int_cast,
+        .const_cast,
+        .volatile_cast,
+        .vector_zero_init,
+        => {
+            const un_op: *ast.Payload.UnOp = @alignCast(@fieldParentPtr("base", ref.ptr_otherwise));
+            return analyzeNodeForRuntime(c, un_op.data);
+        },
+        .identifier => {
+            const ident = ref.castTag(.identifier).?;
+            const ident_node = c.global_scope.sym_table.get(ident.data) orelse return false;
+            if (ident_node.castTag(.var_decl)) |var_decl_node| {
+                return !var_decl_node.data.is_const;
+            }
+        },
+        else => {},
+    }
+    return false;
+}
+
 fn addMacros(c: *Context) !void {
     var it = c.global_scope.macro_table.iterator();
     while (it.next()) |entry| {
@@ -6505,6 +6627,18 @@ fn addMacros(c: *Context) !void {
             // the macro is intended to represent a function that assumes the function pointer
             // variable is non-null and calls it.
             try addTopLevelDecl(c, entry.key_ptr.*, try transCreateNodeMacroFn(c, entry.key_ptr.*, entry.value_ptr.*, proto_node));
+        } else if (macroDependsOnRuntimeValue(c, entry.value_ptr.*)) |ret_value| {
+            // The macro references a var decl, promote it to an inline function
+            const return_type = try Tag.typeof.create(c.arena, ret_value);
+            const return_expr = try Tag.@"return".create(c.arena, ret_value);
+            const block = try Tag.block_single.create(c.arena, return_expr);
+
+            try addTopLevelDecl(c, entry.key_ptr.*, try Tag.pub_inline_fn.create(c.arena, .{
+                .name = entry.key_ptr.*,
+                .params = &.{},
+                .return_type = return_type,
+                .body = block,
+            }));
         } else {
             try addTopLevelDecl(c, entry.key_ptr.*, entry.value_ptr.*);
         }

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -6607,6 +6607,20 @@ fn analyzeNodeForRuntime(c: *Context, ref: ast.Node) bool {
             const un_op: *ast.Payload.UnOp = @alignCast(@fieldParentPtr("base", ref.ptr_otherwise));
             return analyzeNodeForRuntime(c, un_op.data);
         },
+        .field_access => {
+            const fcs: *ast.Payload.FieldAccess = @alignCast(@fieldParentPtr("base", ref.ptr_otherwise));
+            return analyzeNodeForRuntime(c, fcs.data.lhs);
+        },
+        .shuffle => {
+            const shuff: *ast.Payload.Shuffle = @alignCast(@fieldParentPtr("base", ref.ptr_otherwise));
+            return analyzeNodeForRuntime(c, shuff.data.a) or
+                analyzeNodeForRuntime(c, shuff.data.b) or
+                analyzeNodeForRuntime(c, shuff.data.mask_vector);
+        },
+        .macro_arithmetic => {
+            const mac_arith: *ast.Payload.MacroArithmetic = @alignCast(@fieldParentPtr("base", ref.ptr_otherwise));
+            return analyzeNodeForRuntime(c, mac_arith.data.lhs) or analyzeNodeForRuntime(c, mac_arith.data.rhs);
+        },
         .identifier => {
             const ident = ref.castTag(.identifier).?;
             const ident_node = c.global_scope.sym_table.get(ident.data) orelse return false;

--- a/test/cases/translate_c/macro_referencing_var.c
+++ b/test/cases/translate_c/macro_referencing_var.c
@@ -1,14 +1,20 @@
-extern float number;
-#define number_twice number * 2.0f
-#define number_negative -number
+extern float foo;
+#define FOO_TWICE foo * 2.0f
+#define FOO_NEGATIVE -foo
+
+#define BAR 10.0f
+#define BAR_TWICE BAR * 2.0f
 
 // translate-c
 // c_frontend=clang
 //
-// pub inline fn number_twice() @TypeOf(number * @as(f32, 2.0)) {
-//     return number * @as(f32, 2.0);
-// }
+// pub extern var foo: f32;
 //
-// pub inline fn number_negative() @TypeOf(-number) {
-//     return -number;
+// pub inline fn FOO_TWICE() @TypeOf(foo * @as(f32, 2.0)) {
+//     return foo * @as(f32, 2.0);
 // }
+// pub inline fn FOO_NEGATIVE() @TypeOf(-foo) {
+//     return -foo;
+// }
+// pub const BAR = @as(f32, 10.0);
+// pub const BAR_TWICE = BAR * @as(f32, 2.0);

--- a/test/cases/translate_c/macro_referencing_var.c
+++ b/test/cases/translate_c/macro_referencing_var.c
@@ -13,6 +13,7 @@ extern float foo;
 // pub inline fn FOO_TWICE() @TypeOf(foo * @as(f32, 2.0)) {
 //     return foo * @as(f32, 2.0);
 // }
+//
 // pub inline fn FOO_NEGATIVE() @TypeOf(-foo) {
 //     return -foo;
 // }

--- a/test/cases/translate_c/macro_referencing_var.c
+++ b/test/cases/translate_c/macro_referencing_var.c
@@ -1,0 +1,14 @@
+extern float number;
+#define number_twice number * 2.0f
+#define number_negative -number
+
+// translate-c
+// c_frontend=clang
+//
+// pub inline fn number_twice() @TypeOf(number * @as(f32, 2.0)) {
+//     return number * @as(f32, 2.0);
+// }
+//
+// pub inline fn number_negative() @TypeOf(-number) {
+//     return -number;
+// }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -2457,9 +2457,13 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    _ = c.*.b;
         \\}
         ,
-        \\pub const DOT = a.b;
+        \\pub inline fn ARROW() @TypeOf(a.*.b) {
+        \\    return a.*.b;
+        \\}
         ,
-        \\pub const ARROW = a.*.b;
+        \\pub inline fn DOT() @TypeOf(a.b) {
+        \\    return a.b;
+        \\}
     });
 
     cases.add("array access",
@@ -3136,7 +3140,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\ int a, b, c;
         \\#define FOO a ? b : c
     , &[_][]const u8{
-        \\pub const FOO = if (a) b else c;
+        \\pub inline fn FOO() @TypeOf(if (a) b else c) {
+        \\    return if (a) b else c;
+        \\}
     });
 
     cases.add("do while as expr",

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -223,7 +223,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\                             | (*((unsigned char *)(p) + 1) << 8)  \
         \\                             | (*((unsigned char *)(p) + 2) << 16))
     , &[_][]const u8{
-        \\pub const FOO = (foo + @as(c_int, 2)).*;
+        \\pub inline fn FOO() @TypeOf((foo + @as(c_int, 2)).*) {
+        \\    return (foo + @as(c_int, 2)).*;
+        \\}
         ,
         \\pub const VALUE = ((((@as(c_int, 1) + (@as(c_int, 2) * @as(c_int, 3))) + (@as(c_int, 4) * @as(c_int, 5))) + @as(c_int, 6)) << @as(c_int, 7)) | @intFromBool(@as(c_int, 8) == @as(c_int, 9));
         ,
@@ -452,7 +454,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\#define FOO -\
         \\BAR
     , &[_][]const u8{
-        \\pub const FOO = -BAR;
+        \\pub inline fn FOO() @TypeOf(-BAR) {
+        \\    return -BAR;
+        \\}
     });
 
     cases.add("struct with atomic field",
@@ -2472,7 +2476,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\    return array[@as(c_uint, @intCast(index))];
         \\}
         ,
-        \\pub const ACCESS = array[@as(usize, @intCast(@as(c_int, 2)))];
+        \\pub inline fn ACCESS() @TypeOf(array[@as(usize, @intCast(@as(c_int, 2)))]) {
+        \\    return array[@as(usize, @intCast(@as(c_int, 2)))];
+        \\}
     });
 
     cases.add("cast signed array index to unsigned",
@@ -3624,7 +3630,9 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\#define FOO _
         \\int _ = 42;
     , &[_][]const u8{
-        \\pub const FOO = @"_";
+        \\pub inline fn FOO() @TypeOf(@"_") {
+        \\    return @"_";
+        \\}
         ,
         \\pub export var @"_": c_int = 42;
     });


### PR DESCRIPTION
This PR changes how macros deemed to use runtime identifiers are generated. The current behavior generates decls that throw a compiler error upon being referenced:
`test.h`
```c
extern float foo;
#define FOO_TWICE foo * 2.0f
#define FOO_NEGATIVE -foo
#define BAR 10.0f
#define BAR_TWICE BAR * 2.0f
```
`zig translate-c test.h`
```zig
pub extern var foo: f32;
pub const FOO_TWICE = foo * @as(f32, 2.0);
pub const FOO_NEGATIVE = -foo;
pub const BAR = @as(f32, 10.0);
pub const BAR_TWICE = BAR * @as(f32, 2.0);
```
Referencing `FOO_TWICE` or `FOO_NEGATIVE` in your code will lead to a compile error:
`main.zig`
```zig
const std = @import("std");
const c = @cImport(@cInclude("test.h"));

export const foo: f32 = 10;

pub fn main() void {
    _ = c.FOO_TWICE;
}
```
```
~/zig/_test/.zig-cache/o/333d83848f7c681a55f06f92305dabbc/cimport.zig:499:27: error: unable to evaluate comptime expression
pub const FOO_TWICE = foo * @as(f32, 2.0);
                      ~~~~^~~~~~~~~~~~~~~
~/zig/_test/.zig-cache/o/333d83848f7c681a55f06f92305dabbc/cimport.zig:499:23: note: operation is runtime due to this operand
pub const FOO_TWICE = foo * @as(f32, 2.0);
                      ^~~
```
```
~/zig/_test/.zig-cache/o/333d83848f7c681a55f06f92305dabbc/cimport.zig:500:26: error: unable to evaluate comptime expression
pub const FOO_NEGATIVE = -foo;
                         ^~~~
```

With this PR, this code is generated:
```zig
pub extern var foo: f32;
pub inline fn FOO_TWICE() @TypeOf(foo * @as(f32, 2.0)) {
    return foo * @as(f32, 2.0);
}
pub inline fn FOO_NEGATIVE() @TypeOf(-foo) {
    return -foo;
}
pub const BAR = @as(f32, 10.0);
pub const BAR_TWICE = BAR * @as(f32, 2.0);
```
`main.zig` now runs, and if we print the result of calling `FOO_TWICE` we get the expected result:
```zig
std.log.info("{d}", .{c.FOO_TWICE()});
```
```
info: 20
```
The goal is to only change the behavior of previously unreferenceable macros.