### PR TITLE
Remove unneccessary parameters on SemanticVersion.format

### DIFF
--- a/lib/std/SemanticVersion.zig
+++ b/lib/std/SemanticVersion.zig
@@ -152,12 +152,8 @@ fn parseNum(text: []const u8) error{ InvalidVersion, Overflow }!usize {
 
 pub fn format(
     self: Version,
-    comptime fmt: []const u8,
-    options: std.fmt.FormatOptions,
     out_stream: anytype,
 ) !void {
-    _ = options;
-    if (fmt.len != 0) std.fmt.invalidFmtError(fmt, self);
     try std.fmt.format(out_stream, "{d}.{d}.{d}", .{ self.major, self.minor, self.patch });
     if (self.pre) |pre| try std.fmt.format(out_stream, "-{s}", .{pre});
     if (self.build) |build| try std.fmt.format(out_stream, "+{s}", .{build});


### PR DESCRIPTION
Also I think we should have a function that directly converts the version to its string equivalent without the use of a stream.