### PR TITLE
Replace the `YES_COLOR` env variable with `CLICOLOR_FORCE`

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -285,7 +285,7 @@ pub fn main() !void {
     const ttyconf = get_tty_conf(color, stderr);
     switch (ttyconf) {
         .no_color => try graph.env_map.put("NO_COLOR", "1"),
-        .escape_codes => try graph.env_map.put("YES_COLOR", "1"),
+        .escape_codes => try graph.env_map.put("CLICOLOR_FORCE", "1"),
         .windows_api => {},
     }
 

--- a/lib/std/io/tty.zig
+++ b/lib/std/io/tty.zig
@@ -7,13 +7,13 @@ const native_os = builtin.os.tag;
 
 /// Detect suitable TTY configuration options for the given file (commonly stdout/stderr).
 /// This includes feature checks for ANSI escape codes and the Windows console API, as well as
-/// respecting the `NO_COLOR` and `YES_COLOR` environment variables to override the default.
+/// respecting the `NO_COLOR` and `CLICOLOR_FORCE` environment variables to override the default.
 pub fn detectConfig(file: File) Config {
     const force_color: ?bool = if (builtin.os.tag == .wasi)
         null // wasi does not support environment variables
     else if (process.hasEnvVarConstant("NO_COLOR"))
         false
-    else if (process.hasEnvVarConstant("YES_COLOR"))
+    else if (process.hasEnvVarConstant("CLICOLOR_FORCE"))
         true
     else
         null;

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -1060,6 +1060,7 @@ pub const EnvVar = enum {
     ZIG_DEBUG_CMD,
     CC,
     NO_COLOR,
+    CLICOLOR_FORCE,
     XDG_CACHE_HOME,
     HOME,
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -994,11 +994,16 @@ fn buildOutputType(
         .native_system_include_paths = &.{},
     };
 
-    // before arg parsing, check for the NO_COLOR environment variable
-    // if it exists, default the color setting to .off
+    // before arg parsing, check for the NO_COLOR and CLICOLOR_FORCE environment variables
+    // if set, default the color setting to .off or .on, respectively
     // explicit --color arguments will still override this setting.
     // Disable color on WASI per https://github.com/WebAssembly/WASI/issues/162
-    var color: Color = if (native_os == .wasi or EnvVar.NO_COLOR.isSet()) .off else .auto;
+    var color: Color = if (native_os == .wasi or EnvVar.NO_COLOR.isSet())
+        .off
+    else if (EnvVar.CLICOLOR_FORCE.isSet())
+        .on
+    else
+        .auto;
 
     switch (arg_mode) {
         .build, .translate_c, .zig_test, .run => {

--- a/test/src/StackTrace.zig
+++ b/test/src/StackTrace.zig
@@ -61,7 +61,7 @@ fn addExpect(
     });
 
     const run = b.addRunArtifact(exe);
-    run.removeEnvironmentVariable("YES_COLOR");
+    run.removeEnvironmentVariable("CLICOLOR_FORCE");
     run.setEnvironmentVariable("NO_COLOR", "1");
     run.expectExitCode(1);
     run.expectStdOutEqual("");

--- a/tools/doctest.zig
+++ b/tools/doctest.zig
@@ -104,7 +104,7 @@ fn printOutput(
     tmp_dir_path: []const u8,
 ) !void {
     var env_map = try process.getEnvMap(arena);
-    try env_map.put("YES_COLOR", "1");
+    try env_map.put("CLICOLOR_FORCE", "1");
 
     const host = try std.zig.system.resolveTargetQuery(.{});
     const obj_ext = builtin.object_format.fileExt(builtin.cpu.arch);


### PR DESCRIPTION
Detecting the [`NO_COLOR`](https://no-color.org/) environment variable and disabling color output if set is a standard practice respected by most CLI tools.

When it comes to the inverse task of forcing color output even when not writing to a terminal, there exist two standards, [`CLICOLOR_FORCE`](https://bixense.com/clicolors/) and [`FORCE_COLOR`](https://force-color.org/). Neither of these two standards come even close to being as ubiquitous as `NO_COLOR`, but they both have some precedence and are respected by a handful of CLI tools.

Prior to e45d24c0de29eb6668e56ea927e15505674833a6, Zig used the `ZIG_DEBUG_COLOR` env variable to force color output, but that commit changed it to `YES_COLOR`. 

`YES_COLOR` seemingly has next to no precedent in existing software ([a search for `/(?-i)\bYES_COLOR\b/` on GitHub returned 142 files](https://github.com/search?q=%2F%28%3F-i%29%5CbYES_COLOR%5Cb%2F&type=code)).

Instead of throwing a third standard into the mix and making it even harder for users to manage colored output in CLI tooling, I think it would make more sense to instead tag along with one of `CLICOLOR_FORCE` or `FORCE_COLOR`.

I picked `CLICOLOR_FORCE` over `FORCE_COLOR` for the following reasons:

- https://bixense.com/clicolors/, which attempts to standardize `CLICOLOR_FORCE`, was created in 2015. The corresponding https://force-color.org/ for `FORCE_COLOR` was created in 2023.
- `CLICOLOR_FORCE` appears to have been introduced by [`ls` in FreeBSD 4.1.1](https://man.freebsd.org/cgi/man.cgi?query=ls&manpath=FreeBSD+4.1.1-RELEASE) in 2000. `FORCE_COLOR` appears to have been introduced by the [chalk JavaScript library](https://github.com/chalk/chalk/releases/tag/v1.0.0) in 2015.
- `CLICOLOR_FORCE` is supported by CMake and Ninja.
- While a search for [`/(?-i)\bCLICOLOR_FORCE\b/`](https://github.com/search?q=%2F%28%3F-i%29%5CbCLICOLOR_FORCE%5Cb%2F&type=code) returns 28.9k files and [`/(?-i)\bFORCE_COLOR\b/`](https://github.com/search?q=%2F%28%3F-i%29%5CbFORCE_COLOR%5Cb%2F&type=code) 39k files, the former seems more common with software written in C/C++ while the latter seems more tied to Node.js and Python ecosystems.

And yes, I recognize that in a better universe, someone would have established a convention like `CLICOLOR=ON` or `CLICOLOR=OFF` way back in time so that we wouldn't have to juggle multiple environemnt variables, but that ship has sailed.

---

This PR also adds `CLICOLOR_FORCE` to the output of `zig env`.