### PR TITLE
Dir/createFile: detect "flock" using @hasDecl(posix.system, "LOCK") as we do for openFileZ

### DIFF
--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -1030,14 +1030,16 @@ pub fn createFileZ(self: Dir, sub_path_c: [*:0]const u8, flags: File.CreateFlags
     const fd = try posix.openatZ(self.fd, sub_path_c, os_flags, flags.mode);
     errdefer posix.close(fd);
 
-    if (!has_flock_open_flags and flags.lock != .none) {
-        // TODO: integrate async I/O
-        const lock_nonblocking: i32 = if (flags.lock_nonblocking) posix.LOCK.NB else 0;
-        try posix.flock(fd, switch (flags.lock) {
-            .none => unreachable,
-            .shared => posix.LOCK.SH | lock_nonblocking,
-            .exclusive => posix.LOCK.EX | lock_nonblocking,
-        });
+    if (@hasDecl(posix.system, "LOCK")) {
+        if (!has_flock_open_flags and flags.lock != .none) {
+            // TODO: integrate async I/O
+            const lock_nonblocking: i32 = if (flags.lock_nonblocking) posix.LOCK.NB else 0;
+            try posix.flock(fd, switch (flags.lock) {
+                .none => unreachable,
+                .shared => posix.LOCK.SH | lock_nonblocking,
+                .exclusive => posix.LOCK.EX | lock_nonblocking,
+            });
+        }
     }
 
     if (has_flock_open_flags and flags.lock_nonblocking) {


### PR DESCRIPTION
Uses same fix here as here: https://github.com/ziglang/zig/blob/084c2cd90f79d5e7edf76b7ddd390adb95a27f0c/lib/std/fs/Dir.zig#L883

So that if c runtime doesn't support `flock`, use of `createFile` will compile.

I understand it's not desireable to use @hasDecl but doing this now for consistency and because no direction has been agreed upon in this issue yet:
https://github.com/ziglang/zig/issues/19352

I've also put forward my own idea, not sure how viable that is though:
https://github.com/ziglang/zig/issues/19352#issuecomment-2144065753