### PR TITLE
translate-c test: print name of the C frontend used in the annotated test name

### DIFF
--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -561,7 +561,11 @@ pub fn lowerToTranslateCSteps(
     for (self.translate.items) |case| switch (case.kind) {
         .run => |output| {
             if (translate_c_options.skip_run_translated_c) continue;
-            const annotated_case_name = b.fmt("run-translated-c {s}", .{case.name});
+
+            const use_clang = case.c_frontend == .clang;
+            const frontend_str = if (use_clang) "clang" else "aro";
+            const annotated_case_name = b.fmt("run-translated-c c_frontend={s} {s}", .{ frontend_str, case.name });
+
             for (test_filters) |test_filter| {
                 if (std.mem.indexOf(u8, annotated_case_name, test_filter)) |_| break;
             } else if (test_filters.len > 0) continue;
@@ -578,7 +582,7 @@ pub fn lowerToTranslateCSteps(
                 .optimize = .Debug,
                 .target = case.target,
                 .link_libc = case.link_libc,
-                .use_clang = case.c_frontend == .clang,
+                .use_clang = use_clang,
             });
             translate_c.step.name = b.fmt("{s} translate-c", .{annotated_case_name});
 
@@ -594,7 +598,11 @@ pub fn lowerToTranslateCSteps(
         },
         .translate => |output| {
             if (translate_c_options.skip_translate_c) continue;
-            const annotated_case_name = b.fmt("zig translate-c {s}", .{case.name});
+
+            const use_clang = case.c_frontend == .clang;
+            const frontend_str = if (use_clang) "clang" else "aro";
+            const annotated_case_name = b.fmt("translate-c c_frontend={s} {s}", .{ frontend_str, case.name });
+
             for (test_filters) |test_filter| {
                 if (std.mem.indexOf(u8, annotated_case_name, test_filter)) |_| break;
             } else if (test_filters.len > 0) continue;
@@ -607,7 +615,7 @@ pub fn lowerToTranslateCSteps(
                 .optimize = .Debug,
                 .target = case.target,
                 .link_libc = case.link_libc,
-                .use_clang = case.c_frontend == .clang,
+                .use_clang = use_clang,
             });
             translate_c.step.name = b.fmt("{s} translate-c", .{annotated_case_name});
 


### PR DESCRIPTION
In the current code, failing tests for translate-c will produce output that looks like this:
```
test-translate-c transitive failure
├─ zig translate-c failing_test_0 CheckFile failure
└─ zig translate-c failing_test_1 CheckFile failure
test-run-translated-c transitive failure
├─ run-translated-c failing_test_2 run transitive failure
│  └─ run-translated-c failing_test_2 build-exe transitive failure
│     └─ run-translated-c failing_test_2 translate-c failure
└─ run-translated-c failing_test_3 run failure
```
Here, some tests failed for both frontends, but there's no indication which frontend was used.

With this change, the output would look like this:
```
test-translate-c transitive failure
├─ translate-c c_frontend=aro failing_test_0 CheckFile failure
└─ translate-c c_frontend=clang failing_test_1 CheckFile failure
test-run-translated-c transitive failure
├─ run-translated-c c_frontend=aro failing_test_2 run transitive failure
│  └─ run-translated-c c_frontend=aro failing_test_2 build-exe transitive failure
│     └─ run-translated-c c_frontend=aro failing_test_2 translate-c failure
└─ run-translated-c c_frontend=clang failing_test_3 run failure
```

This change also removes the string "zig" from the translate-c test names because it seems unnecessary.