### PR TITLE
Fix handle leaks in `Dir.makeOpenPathAccessMaskW` and a `fs` test

### DIFF
--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -1217,10 +1217,13 @@ fn makeOpenPathAccessMaskW(self: Dir, sub_path: []const u8, access_mask: u32, no
             },
             else => |e| return e,
         };
-        // Don't leak the intermediate file handles
-        errdefer if (result) |*dir| dir.close();
 
         component = it.next() orelse return result.?;
+
+        // Don't leak the intermediate file handles
+        if (result) |*dir| {
+            dir.close();
+        }
     }
 }
 

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1161,7 +1161,8 @@ test "makepath existing directories" {
     defer tmp.cleanup();
 
     try tmp.dir.makeDir("A");
-    const tmpA = try tmp.dir.openDir("A", .{});
+    var tmpA = try tmp.dir.openDir("A", .{});
+    defer tmpA.close();
     try tmpA.makeDir("B");
 
     const testPath = "A" ++ fs.path.sep_str ++ "B" ++ fs.path.sep_str ++ "C";


### PR DESCRIPTION
- Fixes a regression introduced in https://github.com/ziglang/zig/commit/67455c5e70e86dbb7805ff9a415f1b13b14f36da (cc @jacobly0). The `errdefer` cannot run since its not possible for an error to occur past that point, and we don't want it to run on the last handle, so we move the closing back down to where it was before https://github.com/ziglang/zig/commit/67455c5e70e86dbb7805ff9a415f1b13b14f36da.
- Fixes leaking a directory handle in "makepath existing directories" test in `fs/test.zig`

Should fix the cause of https://github.com/ziglang/zig/issues/20079 but does not close it, since `DELETE_PENDING` should still be handled in `makeOpenDirAccessMaskW`