### PR TITLE
Add skip reason to build summary

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -985,7 +985,12 @@ fn printStepStatus(
         },
         .skipped, .skipped_oom => |skip| {
             try ttyconf.setColor(stderr, .yellow);
-            try stderr.writeAll(" skipped");
+            try stderr.writeAll(" skipped: ");
+            if (s.result_skip_reason) |reason| {
+                try stderr.writeAll(reason);
+            } else {
+                try stderr.writeAll("Unspecified");
+            }
             if (skip == .skipped_oom) {
                 try stderr.writeAll(" (not enough memory)");
                 try ttyconf.setColor(stderr, .dim);

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -985,11 +985,10 @@ fn printStepStatus(
         },
         .skipped, .skipped_oom => |skip| {
             try ttyconf.setColor(stderr, .yellow);
-            try stderr.writeAll(" skipped: ");
+            try stderr.writeAll(" skipped");
             if (s.result_skip_reason) |reason| {
+                try stderr.writeAll(": ");
                 try stderr.writeAll(reason);
-            } else {
-                try stderr.writeAll("Unspecified");
             }
             if (skip == .skipped_oom) {
                 try stderr.writeAll(" (not enough memory)");

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -50,6 +50,7 @@ state: State,
 max_rss: usize,
 
 result_error_msgs: ArrayList([]const u8),
+result_skip_reason: ?[]const u8 = null,
 result_error_bundle: std.zig.ErrorBundle,
 result_stderr: []const u8,
 result_cached: bool,


### PR DESCRIPTION
Solves ziglang/zig#14965 by adding an optional `result_skip_reason` field to Step, and setting it whenever the `MakeSkipped` error is returned.

A good example of this is 
```
zig build test-compiler-rt --summary all
Build Summary: 27/35 steps succeeded; 8 skipped; 732/765 tests passed; 33 skipped
test-compiler-rt success
├─ run test compiler-rt-x86_64-linux.6.9.3...6.9.3-gnu.2.39-znver3-Debug cached
│  └─ zig test Debug native cached 22ms MaxRSS:63M
├─ run test compiler-rt-x86_64-linux.6.9.3...6.9.3-gnu.2.39-znver3-ReleaseFast cached
│  └─ zig test ReleaseFast native cached 13ms MaxRSS:63M
├─ run test compiler-rt-x86_64-linux.6.9.3...6.9.3-gnu.2.39-znver3-ReleaseSafe cached
│  └─ zig test ReleaseSafe native cached 17ms MaxRSS:63M
├─ run test compiler-rt-x86_64-linux.6.9.3...6.9.3-gnu.2.39-znver3-ReleaseSmall cached
│  └─ zig test ReleaseSmall native cached 13ms MaxRSS:63M
├─ run test compiler-rt-x86_64-linux.4.19...6.5.7-none-x86_64-Debug-selfhosted-no-lld 244 passed 11 skipped 433ms MaxRSS:63M
│  └─ zig test Debug x86_64-linux-none success 9s MaxRSS:171M
├─ run test compiler-rt-x86_64-linux.4.19...6.5.7-none-x86_64_v2-Debug-selfhosted-no-lld-pic 244 passed 11 skipped 434ms MaxRSS:63M
│  └─ zig test Debug x86_64-linux-none success 9s MaxRSS:165M
├─ run test compiler-rt-x86_64-linux.4.19...6.5.7-none-x86_64_v3-Debug-selfhosted-no-lld 244 passed 11 skipped 442ms MaxRSS:63M
│  └─ zig test Debug x86_64-linux-none success 8s MaxRSS:166M
├─ run test compiler-rt-x86_64-linux.4.19...6.5.7-none-x86_64-Debug cached
│  └─ zig test Debug x86_64-linux-none cached 8ms MaxRSS:63M
├─ run test compiler-rt-x86-linux.4.19...6.5.7-none-pentium4-Debug cached
│  └─ zig test Debug x86-linux-none cached 19ms MaxRSS:63M
├─ run test compiler-rt-aarch64-linux.4.19...6.5.7-none-generic-Debug skipped: Foreign binary failed
│  └─ zig test Debug aarch64-linux-none cached 15ms MaxRSS:63M
├─ run test compiler-rt-arm-linux.4.19...6.5.7-none-generic-Debug skipped: Foreign binary failed
│  └─ zig test Debug arm-linux-none cached 11ms MaxRSS:63M
├─ run test compiler-rt-powerpc-linux.4.19...6.5.7-none-ppc-Debug skipped: Foreign binary failed
│  └─ zig test Debug powerpc-linux-none cached 13ms MaxRSS:63M
├─ run test compiler-rt-powerpc64le-linux.4.19...6.5.7-none-ppc64le-Debug skipped: Foreign binary failed
│  └─ zig test Debug powerpc64le-linux-none cached 13ms MaxRSS:63M
├─ run test compiler-rt-x86_64-macos.11.7.1...14.1-none-x86_64-Debug skipped: Foreign binary failed
│  └─ zig test Debug x86_64-macos-none cached 18ms MaxRSS:63M
├─ run test compiler-rt-aarch64-macos.11.7.1...14.1-none-generic-Debug skipped: Invalid os or cpu
│  └─ zig test Debug aarch64-macos-none cached 20ms MaxRSS:63M
├─ run test compiler-rt-x86-windows.win8_1...win10_fe-msvc-pentium4-Debug skipped: Invalid os or cpu
│  └─ zig test Debug x86-windows-msvc cached 22ms MaxRSS:63M
└─ run test compiler-rt-x86_64-windows.win8_1...win10_fe-msvc-x86_64-Debug skipped: Foreign binary failed
   └─ zig test Debug x86_64-windows-msvc cached 14ms MaxRSS:63M
```

The specific reason messages might require editing