### PR TITLE
ld.lld: fix -m option for big-endian arm/aarch64

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -5097,9 +5097,9 @@ fn getLDMOption(target: std.Target) ?[]const u8 {
     switch (target.cpu.arch) {
         .x86 => return "elf_i386",
         .aarch64 => return "aarch64linux",
-        .aarch64_be => return "aarch64_be_linux",
+        .aarch64_be => return "aarch64linuxb",
         .arm, .thumb => return "armelf_linux_eabi",
-        .armeb, .thumbeb => return "armebelf_linux_eabi",
+        .armeb, .thumbeb => return "armelfb_linux_eabi",
         .powerpc => return "elf32ppclinux",
         .powerpc64 => return "elf64ppc",
         .powerpc64le => return "elf64lppc",


### PR DESCRIPTION
### expecting this to link:
```sh
$ zig build-exe main.zig -target armeb-freestanding --verbose-link
ld.lld --error-limit=0 --entry _start -z stack-size=16777216 --image-base=65536 -znow -m armebelf_linux_eabi -Bstatic -o main main.o /home/mike/project/zig/work/main/zig-cache/o/51a4a9fec86fe30c9e4f35333430c0a0/libc.a --as-needed /home/mike/project/zig/work/main/zig-cache/o/f0ca07dea4b8c61005af6a4a6b771faa/libcompiler_rt.a --allow-shlib-undefined
error: ld.lld: unknown emulation: armebelf_linux_eabi
```

### and:
```sh
$ zig build-exe main.zig -target aarch64_be-freestanding --verbose-link
ld.lld --error-limit=0 --entry _start -z stack-size=16777216 --image-base=16777216 -znow -m aarch64_be_linux -static -o main main.o /home/mike/project/zig/work/main/zig-cache/o/b17128ff5fbcce92dd6be944ba510aa5/libc.a --as-needed /home/mike/project/zig/work/main/zig-cache/o/b417486d14dc505b537f8d1ecd8a47e5/libcompiler_rt.a --allow-shlib-undefined
error: ld.lld: unknown emulation: aarch64_be_linux
```

### main.zig:
```zig
export fn _start() void {}
```

### after patch:
```sh
$ ./stage4/bin/zig build-exe main.zig -target aarch64_be-freestanding --verbose-link
ld.lld --error-limit=0 --entry _start -z stack-size=16777216 --image-base=16777216 -znow -m aarch64linuxb -static -o main main.o /home/mike/project/zig/work/main/zig-cache/o/b17128ff5fbcce92dd6be944ba510aa5/libc.a --as-needed /home/mike/project/zig/work/main/zig-cache/o/b417486d14dc505b537f8d1ecd8a47e5/libcompiler_rt.a --allow-shlib-undefined

$ file main
main: ELF 32-bit MSB executable, ARM, EABI5 version 1 (SYSV), statically linked, with debug_info, not stripped

$ ./stage4/bin/zig build-exe main.zig -target armeb-freestanding --verbose-link
ld.lld --error-limit=0 --entry _start -z stack-size=16777216 --image-base=65536 -znow -m armelfb_linux_eabi -Bstatic -o main main.o /home/mike/project/zig/work/main/zig-cache/o/51a4a9fec86fe30c9e4f35333430c0a0/libc.a --as-needed /home/mike/project/zig/work/main/zig-cache/o/f0ca07dea4b8c61005af6a4a6b771faa/libcompiler_rt.a --allow-shlib-undefined

$ file main
main: ELF 64-bit MSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
```