### PR TITLE
Report path when Cache.addDepFilePost fails to open a file

### DIFF
--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -684,8 +684,12 @@ pub const Manifest = struct {
 
     fn populateFileHash(self: *Manifest, ch_file: *File) !void {
         const pp = ch_file.prefixed_path;
-        const dir = self.cache.prefixes()[pp.prefix].handle;
-        const file = try dir.openFile(pp.sub_path, .{});
+        const directory = self.cache.prefixes()[pp.prefix];
+        const dir = directory.handle;
+        const file = dir.openFile(pp.sub_path, .{}) catch |err| {
+            log.err("Failed to open file for hashing: {s} in directory: {?s}", .{ pp.sub_path, directory.path });
+            return err;
+        };
         defer file.close();
 
         const actual_stat = try file.stat();


### PR DESCRIPTION
If a depfile is added with `Cache.addDepFilePost` and it lists a path that doesn't actually exist (or that can't be accessed for some other reason), the error is currently propagated up to the caller, who doesn't have the context of what file failed in order to report a good error.

This change reports the error in `addDepFileMaybePost` and returns `error.InvalidDepFile` instead.

The original real world case that triggered this (see #20099) no longer errors, as it was fixed in #20100, but it's still easy to end up with this when using `Step.Run.addDepFileOutputArg` if the program being run is buggy.  A minimal reproduction can be found [here](https://github.com/bcrist/zig-pr20206).

Old output:
```
> zig build repro
repro
└─ run make_depfile failure
error: FileNotFound
Build Summary: 1/3 steps succeeded; 1 failed (disable with --summary none)
repro transitive failure
└─ run make_depfile failure
error: the following build command failed with exit code 1:
C:\repo\zig-pr20206\zig-cache\o\464141af60c3a2dfb16d1e49a4c361c0\build.exe C:\portable-app\zig\zig.exe C:\repo\zig-pr20206 C:\repo\zig-pr20206\zig-cache C:\Users\Ben\AppData\Local\zig --seed 0x180c5a33 -Z3478892049bdfc46 repro
```

New output:
```
> C:\repo\zig\stage3\bin\zig build repro
error(cache): failed to add prereq this_file_does_not_exist.c from C:\repo\zig-pr20206\.zig-cache\tmp\0d3f796eb21b9cc4\deps.d: FileNotFound
repro
└─ run make_depfile failure
error: InvalidDepFile
Build Summary: 1/3 steps succeeded; 1 failed (disable with --summary none)
repro transitive failure
└─ run make_depfile failure
error: the following build command failed with exit code 1:
C:\repo\zig-pr20206\.zig-cache\o\13edd01f1813576f6452c1a5ece8aedf\build.exe C:\repo\zig\stage3\bin\zig.exe C:\repo\zig-pr20206 C:\repo\zig-pr20206\.zig-cache C:\Users\Ben\AppData\Local\zig --seed 0x16715a8e -Z9949e7b430679722 repro
```