### PR TITLE
llvm: truncate `ptr` in `@cmpxchg*` when needed

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9114,6 +9114,11 @@ pub const FuncGen = struct {
                 if (operand_ty.isSignedInt(mod)) .signed else .unsigned;
             expected_value = try self.wip.conv(signedness, expected_value, llvm_abi_ty, "");
             new_value = try self.wip.conv(signedness, new_value, llvm_abi_ty, "");
+
+            // ptr needs truncating as well
+            const result_align = ptr_ty.abiAlignment(mod).toLlvm();
+            const op = try self.load(ptr, ptr_ty);
+            _ = try self.wip.store(.normal, op, ptr, result_align);
         }
 
         const result = try self.wip.cmpxchg(

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9101,7 +9101,7 @@ pub const FuncGen = struct {
         const mod = o.module;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.Cmpxchg, ty_pl.payload).data;
-        const ptr = try self.resolveInst(extra.ptr);
+        var ptr = try self.resolveInst(extra.ptr);
         const ptr_ty = self.typeOf(extra.ptr);
         var expected_value = try self.resolveInst(extra.expected_value);
         var new_value = try self.resolveInst(extra.new_value);
@@ -9116,9 +9116,14 @@ pub const FuncGen = struct {
             new_value = try self.wip.conv(signedness, new_value, llvm_abi_ty, "");
 
             // ptr needs truncating as well
-            const result_align = ptr_ty.abiAlignment(mod).toLlvm();
-            const op = try self.load(ptr, ptr_ty);
-            _ = try self.wip.store(.normal, op, ptr, result_align);
+            const alignment = operand_ty.abiAlignment(mod).toLlvm();
+            const ptr_alloca = try self.buildAllocaWorkaround(operand_ty, alignment);
+
+            const ptr_val = try self.load(ptr, ptr_ty);
+            const ext_val = try self.wip.conv(signedness, ptr_val, llvm_abi_ty, "");
+            _ = try self.wip.store(.normal, ext_val, ptr_alloca, alignment);
+
+            ptr = ptr_alloca;
         }
 
         const result = try self.wip.cmpxchg(

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9101,7 +9101,7 @@ pub const FuncGen = struct {
         const mod = o.module;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.Cmpxchg, ty_pl.payload).data;
-        var ptr = try self.resolveInst(extra.ptr);
+        const ptr = try self.resolveInst(extra.ptr);
         const ptr_ty = self.typeOf(extra.ptr);
         var expected_value = try self.resolveInst(extra.expected_value);
         var new_value = try self.resolveInst(extra.new_value);
@@ -9117,13 +9117,10 @@ pub const FuncGen = struct {
 
             // ptr needs truncating as well
             const alignment = operand_ty.abiAlignment(mod).toLlvm();
-            const ptr_alloca = try self.buildAllocaWorkaround(operand_ty, alignment);
 
             const ptr_val = try self.load(ptr, ptr_ty);
             const ext_val = try self.wip.conv(signedness, ptr_val, llvm_abi_ty, "");
-            _ = try self.wip.store(.normal, ext_val, ptr_alloca, alignment);
-
-            ptr = ptr_alloca;
+            _ = try self.wip.store(.normal, ext_val, ptr, alignment);
         }
 
         const result = try self.wip.cmpxchg(

--- a/test/behavior/atomics.zig
+++ b/test/behavior/atomics.zig
@@ -44,6 +44,7 @@ test "@cmpxchg truncates ptr" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
     const S = struct {
         fn doTest(T: type) !void {


### PR DESCRIPTION
closes #20184