### PR TITLE
Fix slight deviation from spec in handling Elf*_Rela relative relocations

### DIFF
--- a/lib/std/os/linux/start_pie.zig
+++ b/lib/std/os/linux/start_pie.zig
@@ -113,7 +113,7 @@ pub fn relocate(phdrs: []elf.Phdr) void {
         const rela = std.mem.bytesAsSlice(elf.Rela, @as([*]u8, @ptrFromInt(rela_addr))[0..rela_size]);
         for (rela) |r| {
             if (r.r_type() != R_RELATIVE) continue;
-            @as(*usize, @ptrFromInt(base_addr + r.r_offset)).* += base_addr + @as(usize, @bitCast(r.r_addend));
+            @as(*usize, @ptrFromInt(base_addr + r.r_offset)).* = base_addr + @as(usize, @bitCast(r.r_addend));
         }
     }
 }


### PR DESCRIPTION
`Elf*_Rela` relocations store their argument in `r_addend`, including for `R_*_RELATIVE` relocations.  Unlike `Elf*_Rel` relocations, they are not applied as a delta to the destination virtual address.  Instead, they are computed from `base_address + r_addend` directly.

This is a very small fixup to make this follow the spec.  For supporting evidence for this change, see the glibc source code below that handles this type of relocation on x86_64:

https://github.com/bminor/glibc/blob/master/sysdeps/x86_64/dl-machine.h#L258

And on musl:

https://github.com/kraj/musl/blob/9f1842d38a02f9a213d3405ee0f767a1db385823/ldso/dynlink.c#L483

It is unlikely anyone would have even noticed this because the linker generally initializes these areas to 0, which ends up having the same effect.