### PR TITLE
autodoc: fix misaligned table header when alignment is default

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2087,7 +2087,7 @@ or
       A slice is a pointer and a length. The difference between an array and
       a slice is that the array's length is part of the type and known at
       compile-time, whereas the slice's length is known at runtime.
-      Both can be accessed with the `len` field.
+      Both can be accessed with the {#syntax#}len{#endsyntax#} field.
       </p>
       {#code|test_basic_slices.zig#}
 

--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -167,7 +167,8 @@
           margin-top: 0.5em;
       }
 
-      td {
+      td, th {
+        text-align: unset;
         vertical-align: top;
         margin: 0;
         padding: 0.5em;


### PR DESCRIPTION
### Before
![Before](https://github.com/ziglang/zig/assets/77922942/25fe7ce3-34f4-449b-ab1f-483bf123b90d)

### After
![After](https://github.com/ziglang/zig/assets/77922942/17e4b595-8477-4cf1-b277-8339e3b9bb7b)

closes https://github.com/ziglang/zig/issues/20144