### PR TITLE
WindowsSdk: Fix index-of-out-bounds when no versions are found in the sdk lib dir

### DIFF
--- a/lib/std/zig/WindowsSdk.zig
+++ b/lib/std/zig/WindowsSdk.zig
@@ -476,6 +476,7 @@ pub const Installation = struct {
 
             var iterator = sdk_lib_dir.iterate();
             const versions = try iterateAndFilterByVersion(&iterator, allocator, prefix);
+            if (versions.len == 0) return error.InstallationNotFound;
             defer {
                 for (versions[1..]) |version| allocator.free(version);
                 allocator.free(versions);


### PR DESCRIPTION
The current code wrongly assumes that versions[0] will always exist after the iterateAndFilterByVersion call.

Seen in the wild here: https://ziggit.dev/t/segmentation-fault-at-address-0x4-using-c-library/4468/29