### PR TITLE
libcxx: fix building when -fsingle-threaded

### DIFF
--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -92,6 +92,9 @@
         .issue_11595 = .{
             .path = "issue_11595",
         },
+        .libcxx = .{
+            .path = "libcxx",
+        },
         .load_dynamic_library = .{
             .path = "load_dynamic_library",
         },

--- a/test/standalone/libcxx/build.zig
+++ b/test/standalone/libcxx/build.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const link_step = b.step("link", "Link with libcxx");
+    const run_step = b.step("run", "Run executables");
+    b.default_step = link_step;
+
+    {
+        const exe = b.addExecutable(.{
+            .name = "mt",
+            .root_source_file = b.path("mt.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        exe.linkLibCpp();
+        exe.addCSourceFile(.{ .file = b.path("mt_doit.cpp") });
+        link_step.dependOn(&exe.step);
+        b.installArtifact(exe);
+        run_step.dependOn(&b.addRunArtifact(exe).step);
+    }
+    {
+        const exe = b.addExecutable(.{
+            .name = "st",
+            .root_source_file = b.path("st.zig"),
+            .target = target,
+            .optimize = optimize,
+            .single_threaded = true,
+        });
+        exe.linkLibCpp();
+        exe.addCSourceFile(.{ .file = b.path("st_doit.cpp") });
+        link_step.dependOn(&exe.step);
+        b.installArtifact(exe);
+        run_step.dependOn(&b.addRunArtifact(exe).step);
+    }
+}

--- a/test/standalone/libcxx/mt.zig
+++ b/test/standalone/libcxx/mt.zig
@@ -1,0 +1,5 @@
+extern fn doit() void;
+
+pub fn main() void {
+    doit();
+}

--- a/test/standalone/libcxx/mt_doit.cpp
+++ b/test/standalone/libcxx/mt_doit.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+#include <thread>
+
+extern "C" void doit() {
+    std::cout << "mt: thread=" << std::this_thread::get_id() << std::endl;
+}

--- a/test/standalone/libcxx/st.zig
+++ b/test/standalone/libcxx/st.zig
@@ -1,0 +1,5 @@
+extern fn doit() void;
+
+pub fn main() void {
+    doit();
+}

--- a/test/standalone/libcxx/st_doit.cpp
+++ b/test/standalone/libcxx/st_doit.cpp
@@ -1,0 +1,5 @@
+#include <iostream>
+
+extern "C" void doit() {
+    std::cout << "st: hello" << std::endl;
+}


### PR DESCRIPTION
* Skip building libcxx mt-only source files when single-threaded.
* This change is required for llvm18 libcxx.
* Add standalone test to link a trivial:
    - mt-executable with libcxx
    - st-executable with libcxx

### motivating reduction which fails prior to PR:
```
zig build-exe main.zig -lc++ -fsingle-threaded
```