### PR TITLE
[WIP] Better error diagnostics from json parsing

### DIFF
--- a/lib/std/json/scanner.zig
+++ b/lib/std/json/scanner.zig
@@ -270,8 +270,11 @@ pub const Diagnostics = struct {
         try writer.writeByteNTimes(' ', start_elipsis.len + self.cursor_in_current_input - start);
         try writer.writeAll("^\n");
 
-        for (self.context_stack.slice()) |item| {
-            try writer.print("  in {s}\n", .{item});
+        if (self.context_stack.len > 0) {
+            try writer.print("{s}\n", .{self.context_stack.slice()[0]});
+            for (self.context_stack.slice()[1..]) |item| {
+                try writer.print("  in {s}\n", .{item});
+            }
         }
     }
 };

--- a/lib/std/json/scanner.zig
+++ b/lib/std/json/scanner.zig
@@ -227,7 +227,7 @@ pub const Diagnostics = struct {
     /// file_name if non-null will be printed in a line with the line and column numbers;
     /// it is purely aesthetic and is not touched on any actual file system.
     pub fn dump(self: *const @This(), writer: anytype, err: anyerror, file_name: ?[]const u8) !void {
-        try writer.print("{s}:{}:{}: {s}\n", .{file_name orelse "<json>", self.getLine(), self.getColumn(), @errorName(err)});
+        try writer.print("{s}:{}:{}: {s}\n", .{ file_name orelse "<json>", self.getLine(), self.getColumn(), @errorName(err) });
 
         // Show a "line" of context, or in case of very long lines, just an excerpt of the line.
         // (Very long lines are common in minified JSON such as in an HTTP API or other machine-to-machine contexts.)
@@ -258,7 +258,7 @@ pub const Diagnostics = struct {
             }
             end += 1;
         }
-        try writer.print("{s}{s}{s}\n", .{start_elipsis, self.current_input[start..end], end_elipsis});
+        try writer.print("{s}{s}{s}\n", .{ start_elipsis, self.current_input[start..end], end_elipsis });
         try writer.writeByteNTimes(' ', start_elipsis.len + self.cursor_in_current_input - start);
         try writer.writeAll("^\n");
 
@@ -268,9 +268,9 @@ pub const Diagnostics = struct {
     }
 };
 
-pub inline fn maybeRecordDiagnosticContext(allocator: Allocator, maybe_diagnostics: ?*Diagnostics, context: []const u8) Allocator.Error!void {
+pub inline fn maybeRecordDiagnosticContext(allocator: Allocator, maybe_diagnostics: ?*Diagnostics, context: []const u8) void {
     if (maybe_diagnostics) |diag| {
-        try diag.recordContext(allocator, context);
+        diag.recordContext(allocator, context) catch {};
     }
 }
 

--- a/lib/std/json/scanner.zig
+++ b/lib/std/json/scanner.zig
@@ -204,6 +204,8 @@ pub const Diagnostics = struct {
     cursor_in_current_input: usize = undefined,
     current_input: []const u8 = undefined,
 
+    // updated setMessage().
+    message: []const u8 = "",
     // updated by recordContext().
     context_stack: BoundedArray([]const u8, 8) = .{},
 
@@ -220,6 +222,13 @@ pub const Diagnostics = struct {
         return self.total_bytes_before_current_input + self.cursor_in_current_input;
     }
 
+    /// Set the headline message of the problem.
+    /// Must not be called multiple times.
+    pub fn setMessage(self: *@This(), message: []const u8) void {
+        assert(message.len != 0);
+        assert(self.message.len == 0); // already set message.
+        self.message = message;
+    }
     /// Attemps to push a human-readable string onto the context stack.
     /// Only works up to a maximum number of times, after which this does nothing.
     pub fn recordContext(self: *@This(), context: []const u8) void {
@@ -270,11 +279,11 @@ pub const Diagnostics = struct {
         try writer.writeByteNTimes(' ', start_elipsis.len + self.cursor_in_current_input - start);
         try writer.writeAll("^\n");
 
-        if (self.context_stack.len > 0) {
-            try writer.print("{s}\n", .{self.context_stack.slice()[0]});
-            for (self.context_stack.slice()[1..]) |item| {
-                try writer.print("  in {s}\n", .{item});
-            }
+        if (self.message.len > 0) {
+            try writer.print("{s}\n", .{self.message});
+        }
+        for (self.context_stack.slice()) |item| {
+            try writer.print("  in {s}\n", .{item});
         }
     }
 };

--- a/lib/std/json/static.zig
+++ b/lib/std/json/static.zig
@@ -7,6 +7,7 @@ const ArrayList = std.ArrayList;
 const Scanner = @import("./scanner.zig").Scanner;
 const Token = @import("./scanner.zig").Token;
 const AllocWhen = @import("./scanner.zig").AllocWhen;
+const Diagnostics = @import("./scanner.zig").Diagnostics;
 const default_max_value_len = @import("./scanner.zig").default_max_value_len;
 const isNumberFormattedLikeAnInteger = @import("./scanner.zig").isNumberFormattedLikeAnInteger;
 
@@ -42,6 +43,10 @@ pub const ParseOptions = struct {
     /// The default with a `*std.json.Reader` input is `.alloc_always`.
     /// Ignored for `parseFromValue` and `parseFromValueLeaky`.
     allocate: ?AllocWhen = null,
+
+    /// Enable diagnostics with `var diagnostics: json.Diagnostics = undefined;`,
+    /// and set this option to `&diagnostics`.
+    diagnostics: ?*Diagnostics = null,
 };
 
 pub fn Parsed(comptime T: type) type {
@@ -134,6 +139,14 @@ pub fn parseFromTokenSourceLeaky(
             resolved_options.allocate = .alloc_if_needed;
         } else {
             resolved_options.allocate = .alloc_always;
+        }
+    }
+    if (resolved_options.diagnostics) |diag| {
+        scanner_or_reader.enableDiagnostics(diag);
+    }
+    defer {
+        if (resolved_options.diagnostics) |_| {
+            scanner_or_reader.saveDiagnostics();
         }
     }
 

--- a/lib/std/json/static_test.zig
+++ b/lib/std/json/static_test.zig
@@ -925,3 +925,18 @@ test "parse at comptime" {
     };
     comptime testing.expectEqual(@as(u64, 9999), config.uptime) catch unreachable;
 }
+
+test "parse with diagnostics" {
+    const doc =
+        \\{
+        \\  "common": "mistake",
+        \\}
+    ;
+    var diagnostics: Diagnostics = undefined;
+    try testing.expectError(error.SyntaxError, parseFromSlice(Value, testing.allocator, doc, .{
+        .diagnostics = &diagnostics,
+    }));
+    try std.testing.expectEqual(3, diagnostics.getLine());
+    try std.testing.expectEqual(1, diagnostics.getColumn());
+    try std.testing.expectEqual(25, diagnostics.getByteOffset());
+}


### PR DESCRIPTION
Closes #16936.

The idea here is that you can print the diagnostics to a stream, such as stderr. Something like this:

```
<json>:6:13: Overflow
   "a": 1123
        ^^^^
  in u8
  in test.MyStruct.a
  in test.MyStruct
```

I would also like to make it easier to provide diagnostics in the `options` parameters to many of the higher level APIs instead of needing to construct your own source object.

The memory management with this gets pretty tricky. The arena allocator for deserializing json into a struct is inappropriate to use, because it gets destroyed before the diagnostics get read sometimes. My current strategy is to use no allocator, but that's pretty limiting.

* [x] source snippet
* [x] messages for `parseFromTokenSource` errors
* [ ] messages for `parseFromValue` errors
* [x] context lines
* [ ] re-evaluate decision to not use an allocator. Currently requiring all error messages be comptime strings means we're pretty limited in what we can complain about.
* [ ] fix off-by-1 error in line snippet printing
* [ ] point the line snippet cursor back one token when it's not a syntax error.
* [ ] what do we do when the line snippet spans input slices in a really awkward way?
* [ ] change all `json/static.zig` errors to just `error.JsonDeserializationTypeError` instead of the current `error.{UnexpectedToken, InvalidNumber, Overflow, InvalidEnumTag, DuplicateField, UnknownField, MissingField, LengthMismatch}`. The detailed string message will tell you what the specific problem is instead of the integer error code.
* [ ] tests

I'm open to suggestions on how to go about this PR if anyone has opinions. i'm particularly dissatisfied with the allocator situation.
