### PR TITLE
std/c: allow overriding c imports for custom OS

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const root = @import("root");
 const builtin = @import("builtin");
 const c = @This();
 const page_size = std.mem.page_size;
@@ -32,7 +33,9 @@ pub inline fn versionCheck(comptime glibc_version: std.SemanticVersion) bool {
     };
 }
 
-pub usingnamespace switch (native_os) {
+pub usingnamespace if (@hasDecl(root, "os") and @hasDecl(root.os, "c") and @hasDecl(root.os.c, "os"))
+    root.os.c.os
+else switch (native_os) {
     .linux => @import("c/linux.zig"),
     .windows => @import("c/windows.zig"),
     .macos, .ios, .tvos, .watchos, .visionos => @import("c/darwin.zig"),
@@ -47,7 +50,9 @@ pub usingnamespace switch (native_os) {
     else => struct {},
 };
 
-pub const pthread_mutex_t = switch (native_os) {
+pub const pthread_mutex_t = if (@hasDecl(root, "os") and @hasDecl(root.os, "c") and @hasDecl(root.os.c, "pthread_mutex_t"))
+    root.os.c.pthread_mutex_t
+else switch (native_os) {
     .linux, .minix => extern struct {
         data: [data_len]u8 align(@alignOf(usize)) = [_]u8{0} ** data_len,
 
@@ -208,7 +213,9 @@ pub const pthread_rwlock_t = switch (native_os) {
     else => @compileError("target libc does not have pthread_rwlock_t"),
 };
 
-pub const AT = switch (native_os) {
+pub const AT = if (@hasDecl(root, "os") and @hasDecl(root.os, "c") and @hasDecl(root.os.c, "AT"))
+    root.os.c.AT
+else switch (native_os) {
     .linux => linux.AT,
     .windows => struct {
         /// Remove directory instead of unlinking file
@@ -326,7 +333,9 @@ pub const AT = switch (native_os) {
     else => @compileError("target libc does not have AT"),
 };
 
-pub const O = switch (native_os) {
+pub const O = if (@hasDecl(root, "os") and @hasDecl(root.os, "c") and @hasDecl(root.os.c, "O"))
+    root.os.c.O
+else switch (native_os) {
     .linux => linux.O,
     .emscripten => packed struct(u32) {
         ACCMODE: std.posix.ACCMODE = .RDONLY,


### PR DESCRIPTION
## Description

I've been experimenting with getting my app running on the Wii via the DevkitPro toolchain, and I've gotten various things working using the standard library which includes reading/writing files to an SD card.

However to make it work, it required patching upstream with something like this.

## How I use it

Used for Wii SDL2 application here:
- https://github.com/silbinarywolf/zig-wii-sdk/blob/7d5088ad5906c4d17077e9894f5aea0cf100de1f/examples/sdl-app/src/main.zig#L18

Example C OS zig files:
- https://github.com/silbinarywolf/zig-wii-sdk/tree/7d5088ad5906c4d17077e9894f5aea0cf100de1f/src/c

`main.zig`
```zig
pub const os = struct {
    pub const c = @import("c/os.zig");
};
```
`c/os.zig`
```zig
const std = @import("std");
const c = @import("c.zig");

/// os is the C operating system definitions, ie. c/wasi.zig
pub const os = @import("wii.zig");

pub const pthread_mutex_t = @compileError("pthread not supported by Wii library. Must compile single threaded unless we polyfill pthread functions");

// NOTE(jae): 2024-06-03
// AT is seemingly not supported for the Wii as it also doesn't support "openat"
// we polyfill "openat" ourselves.
pub const AT = struct {
    /// Special value used to indicate openat should use the current working directory
    pub const FDCWD = -2;
};

// NOTE(jae): 2024-06-03
// Copied from lib/std/os/linux.zig, section: .powerpc, .powerpcle, .powerpc64, .powerpc64le
pub const O = packed struct(u32) {
    ACCMODE: std.posix.ACCMODE = .RDONLY,
    _2: u4 = 0,
    CREAT: bool = false,
    EXCL: bool = false,
    NOCTTY: bool = false,
    TRUNC: bool = false,
    APPEND: bool = false,
    NONBLOCK: bool = false,
    DSYNC: bool = false,
    ASYNC: bool = false,
    DIRECTORY: bool = false,
    NOFOLLOW: bool = false,
    LARGEFILE: bool = false,
    DIRECT: bool = false,
    NOATIME: bool = false,
    CLOEXEC: bool = false,
    SYNC: bool = false,
    PATH: bool = false,
    TMPFILE: bool = false,
    _: u9 = 0,
};
```
`c/wii.zig`
```zig
const builtin = @import("builtin");
const std = @import("std");
const c = @import("c.zig");

pub const _errno = struct {
    extern fn __errno() *c_int;
}.__errno;

pub const PATH_MAX = 4096;

pub const mode_t = u32;
pub const time_t = i64;

pub const STDIN_FILENO = 0;
pub const STDOUT_FILENO = 1;
pub const STDERR_FILENO = 2;

const clockid_t = i32;

// ... much more things in here, etc ...
```
`c/c.zig`
```zig
pub usingnamespace @cImport({
    // OGC Library
    @cInclude("ogcsys.h");
    @cInclude("gccore.h");

    // C library
    @cInclude("stdio.h");
    @cInclude("errno.h");
    @cInclude("fcntl.h");
    @cInclude("dirent.h");
});
```

Seperate to this we also have a "runtime" we build to polyfill things.
`c/runtime.zig`
```zig
const root = @import("root");
const std = @import("std");
const builtin = @import("builtin");
const c = @import("c.zig");

comptime {
    @export(openat, .{ .name = "openat", .linkage = .strong });
    @export(write, .{ .name = "__wrap_write", .linkage = .strong });
    if (builtin.os.tag == .wasi) {
        @export(wasi_errno, .{ .name = "errno", .linkage = .strong });
    }
}

/// openat is polyfilled as it doesn't have an implementation for devkitPPC
fn openat(dirfd: c_int, pathname: [*c]const u8, flags: c_int) callconv(.C) c_int {
    // TODO(jae): 2024-06-02
    // Make this actually use dirfd
    _ = dirfd; // autofix
    const file = c.open(pathname, flags);
    return file;
}

/// wrap "write" to get printf debugging in Dolphin emulator, if the "fd" is STDOUT or STDERR we call print.
/// otherwise fallback to writing to the file descriptor
fn write(fd: i32, buf: [*]const u8, count: usize) callconv(.C) isize {
    const __real_write = struct {
        extern "c" fn __real_write(fd: std.c.fd_t, buf: [*]const u8, nbyte: usize) isize;
    }.__real_write;
    if (fd == std.c.STDOUT_FILENO or fd == std.c.STDERR_FILENO) {
        // https://stackoverflow.com/a/3767300
        return @intCast(c.printf("%.*s", count, buf));
    }
    return __real_write(fd, buf, count);
}

/// wasi_errno calls the underlying Wii toolchain errno for builds targetting .wasi
fn wasi_errno() callconv(.C) *c_int {
    const _errno = struct {
        extern fn __errno() *c_int;
    }.__errno;
    return _errno();
}
```