### PR TITLE
fix termios containing undefined bytes after tcgetattr

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -2002,6 +2002,7 @@ pub fn getrusage(who: i32, usage: *rusage) usize {
 }
 
 pub fn tcgetattr(fd: fd_t, termios_p: *termios) usize {
+    termios_p.* =  std.mem.zeroes(termios);
     return syscall3(.ioctl, @as(usize, @bitCast(@as(isize, fd))), T.CGETS, @intFromPtr(termios_p));
 }
 


### PR DESCRIPTION
fix [#20205 ](https://github.com/ziglang/zig/issues/20205)
ensure mem pointed to by``` termios_p``` is zero initialized to prevent ```termios.ospeed``` and ```termios.ispeed``` from having invalid enum values incase they are not set.
```zig 
pub fn tcgetattr(fd: fd_t, termios_p: *termios) usize {
    termios_p.* =  std.mem.zeroes(termios);
    return syscall3(.ioctl, @as(usize, @bitCast(@as(isize, fd))), T.CGETS, @intFromPtr(termios_p));
}
```