### PR TITLE
Zir: remove legacy `error_set_decl` variants

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -2728,8 +2728,6 @@ fn addEnsureResult(gz: *GenZir, maybe_unused_result: Zir.Inst.Ref, statement: As
             .union_init,
             .field_type_ref,
             .error_set_decl,
-            .error_set_decl_anon,
-            .error_set_decl_func,
             .enum_from_int,
             .int_from_enum,
             .type_info,

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -372,8 +372,6 @@ pub const Inst = struct {
         /// An error set type definition. Contains a list of field names.
         /// Uses the `pl_node` union field. Payload is `ErrorSetDecl`.
         error_set_decl,
-        error_set_decl_anon,
-        error_set_decl_func,
         /// Declares the beginning of a statement. Used for debug info.
         /// Uses the `dbg_stmt` union field. The line and column are offset
         /// from the parent declaration.
@@ -1078,8 +1076,6 @@ pub const Inst = struct {
                 .cmp_gt,
                 .cmp_neq,
                 .error_set_decl,
-                .error_set_decl_anon,
-                .error_set_decl_func,
                 .dbg_stmt,
                 .dbg_var_ptr,
                 .dbg_var_val,
@@ -1385,8 +1381,6 @@ pub const Inst = struct {
                 .cmp_gt,
                 .cmp_neq,
                 .error_set_decl,
-                .error_set_decl_anon,
-                .error_set_decl_func,
                 .decl_ref,
                 .decl_val,
                 .load,
@@ -1624,8 +1618,6 @@ pub const Inst = struct {
                 .@"try" = .pl_node,
                 .try_ptr = .pl_node,
                 .error_set_decl = .pl_node,
-                .error_set_decl_anon = .pl_node,
-                .error_set_decl_func = .pl_node,
                 .dbg_stmt = .dbg_stmt,
                 .dbg_var_ptr = .str_op,
                 .dbg_var_val = .str_op,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1156,9 +1156,7 @@ fn analyzeBodyInner(
             .round => try sema.zirUnaryMath(block, inst, .round, Value.round),
             .trunc => try sema.zirUnaryMath(block, inst, .trunc_float, Value.trunc),
 
-            .error_set_decl      => try sema.zirErrorSetDecl(block, inst, .parent),
-            .error_set_decl_anon => try sema.zirErrorSetDecl(block, inst, .anon),
-            .error_set_decl_func => try sema.zirErrorSetDecl(block, inst, .func),
+            .error_set_decl => try sema.zirErrorSetDecl(inst),
 
             .add        => try sema.zirArithmetic(block, inst, .add,        true),
             .addwrap    => try sema.zirArithmetic(block, inst, .addwrap,    true),
@@ -3468,9 +3466,7 @@ fn zirOpaqueDecl(
 
 fn zirErrorSetDecl(
     sema: *Sema,
-    block: *Block,
     inst: Zir.Inst.Index,
-    name_strategy: Zir.Inst.NameStrategy,
 ) CompileError!Air.Inst.Ref {
     const tracy = trace(@src());
     defer tracy.end();
@@ -3478,7 +3474,6 @@ fn zirErrorSetDecl(
     const mod = sema.mod;
     const gpa = sema.gpa;
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
-    const src = inst_data.src();
     const extra = sema.code.extraData(Zir.Inst.ErrorSetDecl, inst_data.payload_index);
 
     var names: InferredErrorSet.NameMap = .{};
@@ -3495,23 +3490,7 @@ fn zirErrorSetDecl(
         assert(!result.found_existing); // verified in AstGen
     }
 
-    const error_set_ty = try mod.errorSetFromUnsortedNames(names.keys());
-
-    const new_decl_index = try sema.createAnonymousDeclTypeNamed(
-        block,
-        src,
-        error_set_ty.toValue(),
-        name_strategy,
-        "error",
-        inst,
-    );
-    const new_decl = mod.declPtr(new_decl_index);
-    new_decl.owns_tv = true;
-    errdefer mod.abortAnonDecl(new_decl_index);
-
-    const decl_val = sema.analyzeDeclVal(block, src, new_decl_index);
-    try mod.finalizeAnonDecl(new_decl_index);
-    return decl_val;
+    return Air.internedToRef((try mod.errorSetFromUnsortedNames(names.keys())).toIntern());
 }
 
 fn zirRetPtr(sema: *Sema, block: *Block) CompileError!Air.Inst.Ref {

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -452,9 +452,7 @@ const Writer = struct {
             .try_ptr,
             => try self.writeTry(stream, inst),
 
-            .error_set_decl => try self.writeErrorSetDecl(stream, inst, .parent),
-            .error_set_decl_anon => try self.writeErrorSetDecl(stream, inst, .anon),
-            .error_set_decl_func => try self.writeErrorSetDecl(stream, inst, .func),
+            .error_set_decl => try self.writeErrorSetDecl(stream, inst),
 
             .switch_block,
             .switch_block_ref,
@@ -1968,12 +1966,9 @@ const Writer = struct {
         self: *Writer,
         stream: anytype,
         inst: Zir.Inst.Index,
-        name_strategy: Zir.Inst.NameStrategy,
     ) !void {
         const inst_data = self.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
         const extra = self.code.extraData(Zir.Inst.ErrorSetDecl, inst_data.payload_index);
-
-        try stream.print("{s}, ", .{@tagName(name_strategy)});
 
         try stream.writeAll("{\n");
         self.indent += 2;


### PR DESCRIPTION
These instructions are not emitted by AstGen. They also would have no effect even if they did appear in ZIR: the Sema handling for these instructions creates a Decl which the name strategy is applied to, and proceeds to never use it. This pointless CPU heater is now gone, saving 2 ZIR tags in the process.