### PR TITLE
Fix incompatibility with multi-config cmake generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -981,11 +981,7 @@ add_custom_command(
   WORKING_DIRECTORY "${ZIG2_WORKING_DIR}"
 )
 
-if(WIN32)
-  set(ZIG_EXECUTABLE "${PROJECT_BINARY_DIR}/zig2.exe")
-else()
-  set(ZIG_EXECUTABLE "${PROJECT_BINARY_DIR}/zig2")
-endif()
+set(ZIG_EXECUTABLE "$<TARGET_FILE:zig2>")
 
 install(CODE "set(ZIG_EXECUTABLE \"${ZIG_EXECUTABLE}\")")
 install(CODE "set(ZIG_BUILD_ARGS \"${ZIG_BUILD_ARGS}\")")


### PR DESCRIPTION
Avoid hard coding the path of zig2 relative to PROJECT_BINARY_DIR, which is instead located in PROJECT_BINARY_DIR/\<config\> for the Ninja Multi-Config generator(`-G"Ninja Multi-Config"`).