### PR TITLE
Rename *[UI]LEB128 functions to *[UI]leb128

### DIFF
--- a/lib/std/Build/Step/CheckObject.zig
+++ b/lib/std/Build/Step/CheckObject.zig
@@ -1229,17 +1229,17 @@ const MachODumper = struct {
                     macho.REBASE_OPCODE_SET_TYPE_IMM => {},
                     macho.REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB => {
                         seg_id = imm;
-                        offset = try std.leb.readULEB128(u64, reader);
+                        offset = try std.leb.readUleb128(u64, reader);
                     },
                     macho.REBASE_OPCODE_ADD_ADDR_IMM_SCALED => {
                         offset += imm * @sizeOf(u64);
                     },
                     macho.REBASE_OPCODE_ADD_ADDR_ULEB => {
-                        const addend = try std.leb.readULEB128(u64, reader);
+                        const addend = try std.leb.readUleb128(u64, reader);
                         offset += addend;
                     },
                     macho.REBASE_OPCODE_DO_REBASE_ADD_ADDR_ULEB => {
-                        const addend = try std.leb.readULEB128(u64, reader);
+                        const addend = try std.leb.readUleb128(u64, reader);
                         const seg = ctx.segments.items[seg_id.?];
                         const addr = seg.vmaddr + offset;
                         try rebases.append(addr);
@@ -1256,11 +1256,11 @@ const MachODumper = struct {
                                 ntimes = imm;
                             },
                             macho.REBASE_OPCODE_DO_REBASE_ULEB_TIMES => {
-                                ntimes = try std.leb.readULEB128(u64, reader);
+                                ntimes = try std.leb.readUleb128(u64, reader);
                             },
                             macho.REBASE_OPCODE_DO_REBASE_ULEB_TIMES_SKIPPING_ULEB => {
-                                ntimes = try std.leb.readULEB128(u64, reader);
-                                skip = try std.leb.readULEB128(u64, reader);
+                                ntimes = try std.leb.readUleb128(u64, reader);
+                                skip = try std.leb.readUleb128(u64, reader);
                             },
                             else => unreachable,
                         }
@@ -1361,7 +1361,7 @@ const MachODumper = struct {
                     },
                     macho.BIND_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB => {
                         seg_id = imm;
-                        offset = try std.leb.readULEB128(u64, reader);
+                        offset = try std.leb.readUleb128(u64, reader);
                     },
                     macho.BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM => {
                         name_buf.clearRetainingCapacity();
@@ -1369,10 +1369,10 @@ const MachODumper = struct {
                         try name_buf.append(0);
                     },
                     macho.BIND_OPCODE_SET_ADDEND_SLEB => {
-                        addend = try std.leb.readILEB128(i64, reader);
+                        addend = try std.leb.readIleb128(i64, reader);
                     },
                     macho.BIND_OPCODE_ADD_ADDR_ULEB => {
-                        const x = try std.leb.readULEB128(u64, reader);
+                        const x = try std.leb.readUleb128(u64, reader);
                         offset = @intCast(@as(i64, @intCast(offset)) + @as(i64, @bitCast(x)));
                     },
                     macho.BIND_OPCODE_DO_BIND,
@@ -1387,14 +1387,14 @@ const MachODumper = struct {
                         switch (opc) {
                             macho.BIND_OPCODE_DO_BIND => {},
                             macho.BIND_OPCODE_DO_BIND_ADD_ADDR_ULEB => {
-                                add_addr = try std.leb.readULEB128(u64, reader);
+                                add_addr = try std.leb.readUleb128(u64, reader);
                             },
                             macho.BIND_OPCODE_DO_BIND_ADD_ADDR_IMM_SCALED => {
                                 add_addr = imm * @sizeOf(u64);
                             },
                             macho.BIND_OPCODE_DO_BIND_ULEB_TIMES_SKIPPING_ULEB => {
-                                count = try std.leb.readULEB128(u64, reader);
-                                skip = try std.leb.readULEB128(u64, reader);
+                                count = try std.leb.readUleb128(u64, reader);
+                                skip = try std.leb.readUleb128(u64, reader);
                             },
                             else => unreachable,
                         }
@@ -1463,11 +1463,11 @@ const MachODumper = struct {
                 return std.io.fixedBufferStream(it.data[it.pos..]);
             }
 
-            fn readULEB128(it: *TrieIterator) !u64 {
+            fn readUleb128(it: *TrieIterator) !u64 {
                 var stream = it.getStream();
                 var creader = std.io.countingReader(stream.reader());
                 const reader = creader.reader();
-                const value = try std.leb.readULEB128(u64, reader);
+                const value = try std.leb.readUleb128(u64, reader);
                 it.pos += creader.bytes_read;
                 return value;
             }
@@ -1538,12 +1538,12 @@ const MachODumper = struct {
             prefix: []const u8,
             exports: *std.ArrayList(Export),
         ) !void {
-            const size = try it.readULEB128();
+            const size = try it.readUleb128();
             if (size > 0) {
-                const flags = try it.readULEB128();
+                const flags = try it.readUleb128();
                 switch (flags) {
                     macho.EXPORT_SYMBOL_FLAGS_REEXPORT => {
-                        const ord = try it.readULEB128();
+                        const ord = try it.readUleb128();
                         const name = try arena.dupe(u8, try it.readString());
                         try exports.append(.{
                             .name = if (name.len > 0) name else prefix,
@@ -1552,8 +1552,8 @@ const MachODumper = struct {
                         });
                     },
                     macho.EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER => {
-                        const stub_offset = try it.readULEB128();
-                        const resolver_offset = try it.readULEB128();
+                        const stub_offset = try it.readUleb128();
+                        const resolver_offset = try it.readUleb128();
                         try exports.append(.{
                             .name = prefix,
                             .tag = .stub_resolver,
@@ -1564,7 +1564,7 @@ const MachODumper = struct {
                         });
                     },
                     else => {
-                        const vmoff = try it.readULEB128();
+                        const vmoff = try it.readUleb128();
                         try exports.append(.{
                             .name = prefix,
                             .tag = .@"export",
@@ -1586,7 +1586,7 @@ const MachODumper = struct {
             const nedges = try it.readByte();
             for (0..nedges) |_| {
                 const label = try it.readString();
-                const off = try it.readULEB128();
+                const off = try it.readUleb128();
                 const prefix_label = try std.fmt.allocPrint(arena, "{s}{s}", .{ prefix, label });
                 const curr = it.pos;
                 it.pos = off;
@@ -2413,7 +2413,7 @@ const WasmDumper = struct {
                         return step.fail("Found invalid section id '{d}'", .{current_byte});
                     };
 
-                    const section_length = try std.leb.readULEB128(u32, reader);
+                    const section_length = try std.leb.readUleb128(u32, reader);
                     try parseAndDumpSection(step, section, bytes[fbs.pos..][0..section_length], writer);
                     fbs.pos += section_length;
                 } else |_| {} // reached end of stream
@@ -2451,12 +2451,12 @@ const WasmDumper = struct {
             .code,
             .data,
             => {
-                const entries = try std.leb.readULEB128(u32, reader);
+                const entries = try std.leb.readUleb128(u32, reader);
                 try writer.print("\nentries {d}\n", .{entries});
                 try parseSection(step, section, data[fbs.pos..], entries, writer);
             },
             .custom => {
-                const name_length = try std.leb.readULEB128(u32, reader);
+                const name_length = try std.leb.readUleb128(u32, reader);
                 const name = data[fbs.pos..][0..name_length];
                 fbs.pos += name_length;
                 try writer.print("\nname {s}\n", .{name});
@@ -2471,11 +2471,11 @@ const WasmDumper = struct {
                 // TODO: Implement parsing and dumping other custom sections (such as relocations)
             },
             .start => {
-                const start = try std.leb.readULEB128(u32, reader);
+                const start = try std.leb.readUleb128(u32, reader);
                 try writer.print("\nstart {d}\n", .{start});
             },
             .data_count => {
-                const count = try std.leb.readULEB128(u32, reader);
+                const count = try std.leb.readUleb128(u32, reader);
                 try writer.print("\ncount {d}\n", .{count});
             },
             else => {}, // skip unknown sections
@@ -2494,13 +2494,13 @@ const WasmDumper = struct {
                     if (func_type != std.wasm.function_type) {
                         return step.fail("expected function type, found byte '{d}'", .{func_type});
                     }
-                    const params = try std.leb.readULEB128(u32, reader);
+                    const params = try std.leb.readUleb128(u32, reader);
                     try writer.print("params {d}\n", .{params});
                     var index: u32 = 0;
                     while (index < params) : (index += 1) {
                         _ = try parseDumpType(step, std.wasm.Valtype, reader, writer);
                     } else index = 0;
-                    const returns = try std.leb.readULEB128(u32, reader);
+                    const returns = try std.leb.readUleb128(u32, reader);
                     try writer.print("returns {d}\n", .{returns});
                     while (index < returns) : (index += 1) {
                         _ = try parseDumpType(step, std.wasm.Valtype, reader, writer);
@@ -2510,10 +2510,10 @@ const WasmDumper = struct {
             .import => {
                 var i: u32 = 0;
                 while (i < entries) : (i += 1) {
-                    const module_name_len = try std.leb.readULEB128(u32, reader);
+                    const module_name_len = try std.leb.readUleb128(u32, reader);
                     const module_name = data[fbs.pos..][0..module_name_len];
                     fbs.pos += module_name_len;
-                    const name_len = try std.leb.readULEB128(u32, reader);
+                    const name_len = try std.leb.readUleb128(u32, reader);
                     const name = data[fbs.pos..][0..name_len];
                     fbs.pos += name_len;
 
@@ -2529,14 +2529,14 @@ const WasmDumper = struct {
                     try writer.writeByte('\n');
                     switch (kind) {
                         .function => {
-                            try writer.print("index {d}\n", .{try std.leb.readULEB128(u32, reader)});
+                            try writer.print("index {d}\n", .{try std.leb.readUleb128(u32, reader)});
                         },
                         .memory => {
                             try parseDumpLimits(reader, writer);
                         },
                         .global => {
                             _ = try parseDumpType(step, std.wasm.Valtype, reader, writer);
-                            try writer.print("mutable {}\n", .{0x01 == try std.leb.readULEB128(u32, reader)});
+                            try writer.print("mutable {}\n", .{0x01 == try std.leb.readUleb128(u32, reader)});
                         },
                         .table => {
                             _ = try parseDumpType(step, std.wasm.RefType, reader, writer);
@@ -2548,7 +2548,7 @@ const WasmDumper = struct {
             .function => {
                 var i: u32 = 0;
                 while (i < entries) : (i += 1) {
-                    try writer.print("index {d}\n", .{try std.leb.readULEB128(u32, reader)});
+                    try writer.print("index {d}\n", .{try std.leb.readUleb128(u32, reader)});
                 }
             },
             .table => {
@@ -2568,21 +2568,21 @@ const WasmDumper = struct {
                 var i: u32 = 0;
                 while (i < entries) : (i += 1) {
                     _ = try parseDumpType(step, std.wasm.Valtype, reader, writer);
-                    try writer.print("mutable {}\n", .{0x01 == try std.leb.readULEB128(u1, reader)});
+                    try writer.print("mutable {}\n", .{0x01 == try std.leb.readUleb128(u1, reader)});
                     try parseDumpInit(step, reader, writer);
                 }
             },
             .@"export" => {
                 var i: u32 = 0;
                 while (i < entries) : (i += 1) {
-                    const name_len = try std.leb.readULEB128(u32, reader);
+                    const name_len = try std.leb.readUleb128(u32, reader);
                     const name = data[fbs.pos..][0..name_len];
                     fbs.pos += name_len;
-                    const kind_byte = try std.leb.readULEB128(u8, reader);
+                    const kind_byte = try std.leb.readUleb128(u8, reader);
                     const kind = std.meta.intToEnum(std.wasm.ExternalKind, kind_byte) catch {
                         return step.fail("invalid export kind value '{d}'", .{kind_byte});
                     };
-                    const index = try std.leb.readULEB128(u32, reader);
+                    const index = try std.leb.readUleb128(u32, reader);
                     try writer.print(
                         \\name {s}
                         \\kind {s}
@@ -2594,14 +2594,14 @@ const WasmDumper = struct {
             .element => {
                 var i: u32 = 0;
                 while (i < entries) : (i += 1) {
-                    try writer.print("table index {d}\n", .{try std.leb.readULEB128(u32, reader)});
+                    try writer.print("table index {d}\n", .{try std.leb.readUleb128(u32, reader)});
                     try parseDumpInit(step, reader, writer);
 
-                    const function_indexes = try std.leb.readULEB128(u32, reader);
+                    const function_indexes = try std.leb.readUleb128(u32, reader);
                     var function_index: u32 = 0;
                     try writer.print("indexes {d}\n", .{function_indexes});
                     while (function_index < function_indexes) : (function_index += 1) {
-                        try writer.print("index {d}\n", .{try std.leb.readULEB128(u32, reader)});
+                        try writer.print("index {d}\n", .{try std.leb.readUleb128(u32, reader)});
                     }
                 }
             },
@@ -2609,9 +2609,9 @@ const WasmDumper = struct {
             .data => {
                 var i: u32 = 0;
                 while (i < entries) : (i += 1) {
-                    const flags = try std.leb.readULEB128(u32, reader);
+                    const flags = try std.leb.readUleb128(u32, reader);
                     const index = if (flags & 0x02 != 0)
-                        try std.leb.readULEB128(u32, reader)
+                        try std.leb.readUleb128(u32, reader)
                     else
                         0;
                     try writer.print("memory index 0x{x}\n", .{index});
@@ -2619,7 +2619,7 @@ const WasmDumper = struct {
                         try parseDumpInit(step, reader, writer);
                     }
 
-                    const size = try std.leb.readULEB128(u32, reader);
+                    const size = try std.leb.readUleb128(u32, reader);
                     try writer.print("size {d}\n", .{size});
                     try reader.skipBytes(size, .{}); // we do not care about the content of the segments
                 }
@@ -2638,12 +2638,12 @@ const WasmDumper = struct {
     }
 
     fn parseDumpLimits(reader: anytype, writer: anytype) !void {
-        const flags = try std.leb.readULEB128(u8, reader);
-        const min = try std.leb.readULEB128(u32, reader);
+        const flags = try std.leb.readUleb128(u8, reader);
+        const min = try std.leb.readUleb128(u32, reader);
 
         try writer.print("min {x}\n", .{min});
         if (flags != 0) {
-            try writer.print("max {x}\n", .{try std.leb.readULEB128(u32, reader)});
+            try writer.print("max {x}\n", .{try std.leb.readUleb128(u32, reader)});
         }
     }
 
@@ -2653,14 +2653,14 @@ const WasmDumper = struct {
             return step.fail("invalid wasm opcode '{d}'", .{byte});
         };
         switch (opcode) {
-            .i32_const => try writer.print("i32.const {x}\n", .{try std.leb.readILEB128(i32, reader)}),
-            .i64_const => try writer.print("i64.const {x}\n", .{try std.leb.readILEB128(i64, reader)}),
+            .i32_const => try writer.print("i32.const {x}\n", .{try std.leb.readIleb128(i32, reader)}),
+            .i64_const => try writer.print("i64.const {x}\n", .{try std.leb.readIleb128(i64, reader)}),
             .f32_const => try writer.print("f32.const {x}\n", .{@as(f32, @bitCast(try reader.readInt(u32, .little)))}),
             .f64_const => try writer.print("f64.const {x}\n", .{@as(f64, @bitCast(try reader.readInt(u64, .little)))}),
-            .global_get => try writer.print("global.get {x}\n", .{try std.leb.readULEB128(u32, reader)}),
+            .global_get => try writer.print("global.get {x}\n", .{try std.leb.readUleb128(u32, reader)}),
             else => unreachable,
         }
-        const end_opcode = try std.leb.readULEB128(u8, reader);
+        const end_opcode = try std.leb.readUleb128(u8, reader);
         if (end_opcode != std.wasm.opcode(.end)) {
             return step.fail("expected 'end' opcode in init expression", .{});
         }
@@ -2673,8 +2673,8 @@ const WasmDumper = struct {
                 // The module name subsection ... consists of a single name
                 // that is assigned to the module itself.
                 .module => {
-                    const size = try std.leb.readULEB128(u32, reader);
-                    const name_len = try std.leb.readULEB128(u32, reader);
+                    const size = try std.leb.readUleb128(u32, reader);
+                    const name_len = try std.leb.readUleb128(u32, reader);
                     if (size != name_len + 1) return error.BadSubsectionSize;
                     if (reader.context.pos + name_len > data.len) return error.UnexpectedEndOfStream;
                     try writer.print("name {s}\n", .{data[reader.context.pos..][0..name_len]});
@@ -2684,16 +2684,16 @@ const WasmDumper = struct {
                 // The function name subsection ... consists of a name map
                 // assigning function names to function indices.
                 .function, .global, .data_segment => {
-                    const size = try std.leb.readULEB128(u32, reader);
-                    const entries = try std.leb.readULEB128(u32, reader);
+                    const size = try std.leb.readUleb128(u32, reader);
+                    const entries = try std.leb.readUleb128(u32, reader);
                     try writer.print(
                         \\size {d}
                         \\names {d}
                         \\
                     , .{ size, entries });
                     for (0..entries) |_| {
-                        const index = try std.leb.readULEB128(u32, reader);
-                        const name_len = try std.leb.readULEB128(u32, reader);
+                        const index = try std.leb.readUleb128(u32, reader);
+                        const name_len = try std.leb.readUleb128(u32, reader);
                         if (reader.context.pos + name_len > data.len) return error.UnexpectedEndOfStream;
                         const name = data[reader.context.pos..][0..name_len];
                         reader.context.pos += name.len;
@@ -2719,15 +2719,15 @@ const WasmDumper = struct {
     }
 
     fn parseDumpProducers(reader: anytype, writer: anytype, data: []const u8) !void {
-        const field_count = try std.leb.readULEB128(u32, reader);
+        const field_count = try std.leb.readUleb128(u32, reader);
         try writer.print("fields {d}\n", .{field_count});
         var current_field: u32 = 0;
         while (current_field < field_count) : (current_field += 1) {
-            const field_name_length = try std.leb.readULEB128(u32, reader);
+            const field_name_length = try std.leb.readUleb128(u32, reader);
             const field_name = data[reader.context.pos..][0..field_name_length];
             reader.context.pos += field_name_length;
 
-            const value_count = try std.leb.readULEB128(u32, reader);
+            const value_count = try std.leb.readUleb128(u32, reader);
             try writer.print(
                 \\field_name {s}
                 \\values {d}
@@ -2735,11 +2735,11 @@ const WasmDumper = struct {
             try writer.writeByte('\n');
             var current_value: u32 = 0;
             while (current_value < value_count) : (current_value += 1) {
-                const value_length = try std.leb.readULEB128(u32, reader);
+                const value_length = try std.leb.readUleb128(u32, reader);
                 const value = data[reader.context.pos..][0..value_length];
                 reader.context.pos += value_length;
 
-                const version_length = try std.leb.readULEB128(u32, reader);
+                const version_length = try std.leb.readUleb128(u32, reader);
                 const version = data[reader.context.pos..][0..version_length];
                 reader.context.pos += version_length;
 
@@ -2753,13 +2753,13 @@ const WasmDumper = struct {
     }
 
     fn parseDumpFeatures(reader: anytype, writer: anytype, data: []const u8) !void {
-        const feature_count = try std.leb.readULEB128(u32, reader);
+        const feature_count = try std.leb.readUleb128(u32, reader);
         try writer.print("features {d}\n", .{feature_count});
 
         var index: u32 = 0;
         while (index < feature_count) : (index += 1) {
-            const prefix_byte = try std.leb.readULEB128(u8, reader);
-            const name_length = try std.leb.readULEB128(u32, reader);
+            const prefix_byte = try std.leb.readUleb128(u8, reader);
+            const name_length = try std.leb.readUleb128(u32, reader);
             const feature_name = data[reader.context.pos..][0..name_length];
             reader.context.pos += name_length;
 

--- a/lib/std/compress/xz.zig
+++ b/lib/std/compress/xz.zig
@@ -88,15 +88,15 @@ pub fn Decompress(comptime ReaderType: type) type {
 
                 const counting_reader = counter.reader();
 
-                const record_count = try std.leb.readULEB128(u64, counting_reader);
+                const record_count = try std.leb.readUleb128(u64, counting_reader);
                 if (record_count != self.block_decoder.block_count)
                     return error.CorruptInput;
 
                 var i: usize = 0;
                 while (i < record_count) : (i += 1) {
                     // TODO: validate records
-                    _ = try std.leb.readULEB128(u64, counting_reader);
-                    _ = try std.leb.readULEB128(u64, counting_reader);
+                    _ = try std.leb.readUleb128(u64, counting_reader);
+                    _ = try std.leb.readUleb128(u64, counting_reader);
                 }
 
                 while (counter.bytes_read % 4 != 0) {

--- a/lib/std/compress/xz/block.zig
+++ b/lib/std/compress/xz/block.zig
@@ -111,10 +111,10 @@ pub fn Decoder(comptime ReaderType: type) type {
                     return error.Unsupported;
 
                 if (flags.has_packed_size)
-                    packed_size = try std.leb.readULEB128(u64, header_reader);
+                    packed_size = try std.leb.readUleb128(u64, header_reader);
 
                 if (flags.has_unpacked_size)
-                    unpacked_size = try std.leb.readULEB128(u64, header_reader);
+                    unpacked_size = try std.leb.readUleb128(u64, header_reader);
 
                 const FilterId = enum(u64) {
                     lzma2 = 0x21,
@@ -123,7 +123,7 @@ pub fn Decoder(comptime ReaderType: type) type {
 
                 const filter_id = @as(
                     FilterId,
-                    @enumFromInt(try std.leb.readULEB128(u64, header_reader)),
+                    @enumFromInt(try std.leb.readUleb128(u64, header_reader)),
                 );
 
                 if (@intFromEnum(filter_id) >= 0x4000_0000_0000_0000)
@@ -132,7 +132,7 @@ pub fn Decoder(comptime ReaderType: type) type {
                 if (filter_id != .lzma2)
                     return error.Unsupported;
 
-                const properties_size = try std.leb.readULEB128(u64, header_reader);
+                const properties_size = try std.leb.readUleb128(u64, header_reader);
                 if (properties_size != 1)
                     return error.CorruptInput;
 

--- a/lib/std/dwarf.zig
+++ b/lib/std/dwarf.zig
@@ -2762,11 +2762,11 @@ pub const FixedBufferReader = struct {
     }
 
     fn readUleb128(fbr: *FixedBufferReader, comptime T: type) Error!T {
-        return std.leb.readULEB128(T, fbr);
+        return std.leb.readUleb128(T, fbr);
     }
 
     fn readIleb128(fbr: *FixedBufferReader, comptime T: type) Error!T {
-        return std.leb.readILEB128(T, fbr);
+        return std.leb.readIleb128(T, fbr);
     }
 
     fn readAddress(fbr: *FixedBufferReader, format: Format) Error!u64 {

--- a/lib/std/dwarf/call_frame.zig
+++ b/lib/std/dwarf/call_frame.zig
@@ -53,7 +53,7 @@ const Opcode = enum(u8) {
 
 fn readBlock(stream: *std.io.FixedBufferStream([]const u8)) ![]const u8 {
     const reader = stream.reader();
-    const block_len = try leb.readULEB128(usize, reader);
+    const block_len = try leb.readUleb128(usize, reader);
     if (stream.pos + block_len > stream.buffer.len) return error.InvalidOperand;
 
     const block = stream.buffer[stream.pos..][0..block_len];
@@ -163,7 +163,7 @@ pub const Instruction = union(Opcode) {
                     .offset => .{
                         .offset = .{
                             .register = value,
-                            .offset = try leb.readULEB128(u64, reader),
+                            .offset = try leb.readUleb128(u64, reader),
                         },
                     },
                     .restore => .{
@@ -201,47 +201,47 @@ pub const Instruction = union(Opcode) {
                     },
                     .offset_extended => .{
                         .offset_extended = .{
-                            .register = try leb.readULEB128(u8, reader),
-                            .offset = try leb.readULEB128(u64, reader),
+                            .register = try leb.readUleb128(u8, reader),
+                            .offset = try leb.readUleb128(u64, reader),
                         },
                     },
                     .restore_extended => .{
                         .restore_extended = .{
-                            .register = try leb.readULEB128(u8, reader),
+                            .register = try leb.readUleb128(u8, reader),
                         },
                     },
                     .undefined => .{
                         .undefined = .{
-                            .register = try leb.readULEB128(u8, reader),
+                            .register = try leb.readUleb128(u8, reader),
                         },
                     },
                     .same_value => .{
                         .same_value = .{
-                            .register = try leb.readULEB128(u8, reader),
+                            .register = try leb.readUleb128(u8, reader),
                         },
                     },
                     .register => .{
                         .register = .{
-                            .register = try leb.readULEB128(u8, reader),
-                            .target_register = try leb.readULEB128(u8, reader),
+                            .register = try leb.readUleb128(u8, reader),
+                            .target_register = try leb.readUleb128(u8, reader),
                         },
                     },
                     .remember_state => .{ .remember_state = {} },
                     .restore_state => .{ .restore_state = {} },
                     .def_cfa => .{
                         .def_cfa = .{
-                            .register = try leb.readULEB128(u8, reader),
-                            .offset = try leb.readULEB128(u64, reader),
+                            .register = try leb.readUleb128(u8, reader),
+                            .offset = try leb.readUleb128(u64, reader),
                         },
                     },
                     .def_cfa_register => .{
                         .def_cfa_register = .{
-                            .register = try leb.readULEB128(u8, reader),
+                            .register = try leb.readUleb128(u8, reader),
                         },
                     },
                     .def_cfa_offset => .{
                         .def_cfa_offset = .{
-                            .offset = try leb.readULEB128(u64, reader),
+                            .offset = try leb.readUleb128(u64, reader),
                         },
                     },
                     .def_cfa_expression => .{
@@ -251,42 +251,42 @@ pub const Instruction = union(Opcode) {
                     },
                     .expression => .{
                         .expression = .{
-                            .register = try leb.readULEB128(u8, reader),
+                            .register = try leb.readUleb128(u8, reader),
                             .block = try readBlock(stream),
                         },
                     },
                     .offset_extended_sf => .{
                         .offset_extended_sf = .{
-                            .register = try leb.readULEB128(u8, reader),
-                            .offset = try leb.readILEB128(i64, reader),
+                            .register = try leb.readUleb128(u8, reader),
+                            .offset = try leb.readIleb128(i64, reader),
                         },
                     },
                     .def_cfa_sf => .{
                         .def_cfa_sf = .{
-                            .register = try leb.readULEB128(u8, reader),
-                            .offset = try leb.readILEB128(i64, reader),
+                            .register = try leb.readUleb128(u8, reader),
+                            .offset = try leb.readIleb128(i64, reader),
                         },
                     },
                     .def_cfa_offset_sf => .{
                         .def_cfa_offset_sf = .{
-                            .offset = try leb.readILEB128(i64, reader),
+                            .offset = try leb.readIleb128(i64, reader),
                         },
                     },
                     .val_offset => .{
                         .val_offset = .{
-                            .register = try leb.readULEB128(u8, reader),
-                            .offset = try leb.readULEB128(u64, reader),
+                            .register = try leb.readUleb128(u8, reader),
+                            .offset = try leb.readUleb128(u64, reader),
                         },
                     },
                     .val_offset_sf => .{
                         .val_offset_sf = .{
-                            .register = try leb.readULEB128(u8, reader),
-                            .offset = try leb.readILEB128(i64, reader),
+                            .register = try leb.readUleb128(u8, reader),
+                            .offset = try leb.readIleb128(i64, reader),
                         },
                     },
                     .val_expression => .{
                         .val_expression = .{
-                            .register = try leb.readULEB128(u8, reader),
+                            .register = try leb.readUleb128(u8, reader),
                             .block = try readBlock(stream),
                         },
                     },

--- a/lib/std/leb128.zig
+++ b/lib/std/leb128.zig
@@ -3,7 +3,7 @@ const testing = std.testing;
 
 /// Read a single unsigned LEB128 value from the given reader as type T,
 /// or error.Overflow if the value cannot fit.
-pub fn readULEB128(comptime T: type, reader: anytype) !T {
+pub fn readUleb128(comptime T: type, reader: anytype) !T {
     const U = if (@typeInfo(T).Int.bits < 8) u8 else T;
     const ShiftT = std.math.Log2Int(U);
 
@@ -32,8 +32,11 @@ pub fn readULEB128(comptime T: type, reader: anytype) !T {
     return @as(T, @truncate(value));
 }
 
+/// Deprecated: use `readUleb128`
+pub const readULEB128 = readUleb128;
+
 /// Write a single unsigned integer as unsigned LEB128 to the given writer.
-pub fn writeULEB128(writer: anytype, uint_value: anytype) !void {
+pub fn writeUleb128(writer: anytype, uint_value: anytype) !void {
     const T = @TypeOf(uint_value);
     const U = if (@typeInfo(T).Int.bits < 8) u8 else T;
     var value: U = @intCast(uint_value);
@@ -50,9 +53,12 @@ pub fn writeULEB128(writer: anytype, uint_value: anytype) !void {
     }
 }
 
+/// Deprecated: use `writeUleb128`
+pub const writeULEB128 = writeUleb128;
+
 /// Read a single signed LEB128 value from the given reader as type T,
 /// or error.Overflow if the value cannot fit.
-pub fn readILEB128(comptime T: type, reader: anytype) !T {
+pub fn readIleb128(comptime T: type, reader: anytype) !T {
     const S = if (@typeInfo(T).Int.bits < 8) i8 else T;
     const U = std.meta.Int(.unsigned, @typeInfo(S).Int.bits);
     const ShiftU = std.math.Log2Int(U);
@@ -108,8 +114,11 @@ pub fn readILEB128(comptime T: type, reader: anytype) !T {
     return @as(T, @truncate(result));
 }
 
+/// Deprecated: use `readIleb128`
+pub const readILEB128 = readIleb128;
+
 /// Write a single signed integer as signed LEB128 to the given writer.
-pub fn writeILEB128(writer: anytype, int_value: anytype) !void {
+pub fn writeIleb128(writer: anytype, int_value: anytype) !void {
     const T = @TypeOf(int_value);
     const S = if (@typeInfo(T).Int.bits < 8) i8 else T;
     const U = std.meta.Int(.unsigned, @typeInfo(S).Int.bits);
@@ -150,6 +159,9 @@ pub fn writeUnsignedFixed(comptime l: usize, ptr: *[l]u8, int: std.meta.Int(.uns
     }
     ptr[i] = @truncate(value);
 }
+
+/// Deprecated: use `writeIleb128`
+pub const writeILEB128 = writeIleb128;
 
 test writeUnsignedFixed {
     {
@@ -236,23 +248,23 @@ test writeSignedFixed {
 // tests
 fn test_read_stream_ileb128(comptime T: type, encoded: []const u8) !T {
     var reader = std.io.fixedBufferStream(encoded);
-    return try readILEB128(T, reader.reader());
+    return try readIleb128(T, reader.reader());
 }
 
 fn test_read_stream_uleb128(comptime T: type, encoded: []const u8) !T {
     var reader = std.io.fixedBufferStream(encoded);
-    return try readULEB128(T, reader.reader());
+    return try readUleb128(T, reader.reader());
 }
 
 fn test_read_ileb128(comptime T: type, encoded: []const u8) !T {
     var reader = std.io.fixedBufferStream(encoded);
-    const v1 = try readILEB128(T, reader.reader());
+    const v1 = try readIleb128(T, reader.reader());
     return v1;
 }
 
 fn test_read_uleb128(comptime T: type, encoded: []const u8) !T {
     var reader = std.io.fixedBufferStream(encoded);
-    const v1 = try readULEB128(T, reader.reader());
+    const v1 = try readUleb128(T, reader.reader());
     return v1;
 }
 
@@ -260,7 +272,7 @@ fn test_read_ileb128_seq(comptime T: type, comptime N: usize, encoded: []const u
     var reader = std.io.fixedBufferStream(encoded);
     var i: usize = 0;
     while (i < N) : (i += 1) {
-        _ = try readILEB128(T, reader.reader());
+        _ = try readIleb128(T, reader.reader());
     }
 }
 
@@ -268,7 +280,7 @@ fn test_read_uleb128_seq(comptime T: type, comptime N: usize, encoded: []const u
     var reader = std.io.fixedBufferStream(encoded);
     var i: usize = 0;
     while (i < N) : (i += 1) {
-        _ = try readULEB128(T, reader.reader());
+        _ = try readUleb128(T, reader.reader());
     }
 }
 
@@ -364,8 +376,8 @@ fn test_write_leb128(value: anytype) !void {
     const signedness = @typeInfo(T).Int.signedness;
     const t_signed = signedness == .signed;
 
-    const writeStream = if (t_signed) writeILEB128 else writeULEB128;
-    const readStream = if (t_signed) readILEB128 else readULEB128;
+    const writeStream = if (t_signed) writeIleb128 else writeUleb128;
+    const readStream = if (t_signed) readIleb128 else readUleb128;
 
     // decode to a larger bit size too, to ensure sign extension
     // is working as expected

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -7241,7 +7241,7 @@ fn getTagNameFunction(func: *CodeGen, enum_ty: Type) InnerError!u32 {
     var writer = body_list.writer();
 
     // The locals of the function body (always 0)
-    try leb.writeULEB128(writer, @as(u32, 0));
+    try leb.writeUleb128(writer, @as(u32, 0));
 
     // outer block
     try writer.writeByte(std.wasm.opcode(.block));
@@ -7275,7 +7275,7 @@ fn getTagNameFunction(func: *CodeGen, enum_ty: Type) InnerError!u32 {
 
         // get actual tag value (stored in 2nd parameter);
         try writer.writeByte(std.wasm.opcode(.local_get));
-        try leb.writeULEB128(writer, @as(u32, 1));
+        try leb.writeUleb128(writer, @as(u32, 1));
 
         const tag_val = try mod.enumValueFieldIndex(enum_ty, @intCast(tag_index));
         const tag_value = try func.lowerConstant(tag_val, enum_ty);
@@ -7283,26 +7283,26 @@ fn getTagNameFunction(func: *CodeGen, enum_ty: Type) InnerError!u32 {
         switch (tag_value) {
             .imm32 => |value| {
                 try writer.writeByte(std.wasm.opcode(.i32_const));
-                try leb.writeILEB128(writer, @as(i32, @bitCast(value)));
+                try leb.writeIleb128(writer, @as(i32, @bitCast(value)));
                 try writer.writeByte(std.wasm.opcode(.i32_ne));
             },
             .imm64 => |value| {
                 try writer.writeByte(std.wasm.opcode(.i64_const));
-                try leb.writeILEB128(writer, @as(i64, @bitCast(value)));
+                try leb.writeIleb128(writer, @as(i64, @bitCast(value)));
                 try writer.writeByte(std.wasm.opcode(.i64_ne));
             },
             else => unreachable,
         }
         // if they're not equal, break out of current branch
         try writer.writeByte(std.wasm.opcode(.br_if));
-        try leb.writeULEB128(writer, @as(u32, 0));
+        try leb.writeUleb128(writer, @as(u32, 0));
 
         // store the address of the tagname in the pointer field of the slice
         // get the address twice so we can also store the length.
         try writer.writeByte(std.wasm.opcode(.local_get));
-        try leb.writeULEB128(writer, @as(u32, 0));
+        try leb.writeUleb128(writer, @as(u32, 0));
         try writer.writeByte(std.wasm.opcode(.local_get));
-        try leb.writeULEB128(writer, @as(u32, 0));
+        try leb.writeUleb128(writer, @as(u32, 0));
 
         // get address of tagname and emit a relocation to it
         if (func.arch() == .wasm32) {
@@ -7317,15 +7317,15 @@ fn getTagNameFunction(func: *CodeGen, enum_ty: Type) InnerError!u32 {
 
             // store pointer
             try writer.writeByte(std.wasm.opcode(.i32_store));
-            try leb.writeULEB128(writer, encoded_alignment);
-            try leb.writeULEB128(writer, @as(u32, 0));
+            try leb.writeUleb128(writer, encoded_alignment);
+            try leb.writeUleb128(writer, @as(u32, 0));
 
             // store length
             try writer.writeByte(std.wasm.opcode(.i32_const));
-            try leb.writeULEB128(writer, @as(u32, @intCast(tag_name_len)));
+            try leb.writeUleb128(writer, @as(u32, @intCast(tag_name_len)));
             try writer.writeByte(std.wasm.opcode(.i32_store));
-            try leb.writeULEB128(writer, encoded_alignment);
-            try leb.writeULEB128(writer, @as(u32, 4));
+            try leb.writeUleb128(writer, encoded_alignment);
+            try leb.writeUleb128(writer, @as(u32, 4));
         } else {
             const encoded_alignment = @ctz(@as(u32, 8));
             try writer.writeByte(std.wasm.opcode(.i64_const));
@@ -7338,20 +7338,20 @@ fn getTagNameFunction(func: *CodeGen, enum_ty: Type) InnerError!u32 {
 
             // store pointer
             try writer.writeByte(std.wasm.opcode(.i64_store));
-            try leb.writeULEB128(writer, encoded_alignment);
-            try leb.writeULEB128(writer, @as(u32, 0));
+            try leb.writeUleb128(writer, encoded_alignment);
+            try leb.writeUleb128(writer, @as(u32, 0));
 
             // store length
             try writer.writeByte(std.wasm.opcode(.i64_const));
-            try leb.writeULEB128(writer, @as(u64, @intCast(tag_name_len)));
+            try leb.writeUleb128(writer, @as(u64, @intCast(tag_name_len)));
             try writer.writeByte(std.wasm.opcode(.i64_store));
-            try leb.writeULEB128(writer, encoded_alignment);
-            try leb.writeULEB128(writer, @as(u32, 8));
+            try leb.writeUleb128(writer, encoded_alignment);
+            try leb.writeUleb128(writer, @as(u32, 8));
         }
 
         // break outside blocks
         try writer.writeByte(std.wasm.opcode(.br));
-        try leb.writeULEB128(writer, @as(u32, 1));
+        try leb.writeUleb128(writer, @as(u32, 1));
 
         // end the block for this case
         try writer.writeByte(std.wasm.opcode(.end));

--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -263,10 +263,10 @@ fn fail(emit: *Emit, comptime format: []const u8, args: anytype) InnerError {
 
 fn emitLocals(emit: *Emit) !void {
     const writer = emit.code.writer();
-    try leb128.writeULEB128(writer, @as(u32, @intCast(emit.locals.len)));
+    try leb128.writeUleb128(writer, @as(u32, @intCast(emit.locals.len)));
     // emit the actual locals amount
     for (emit.locals) |local| {
-        try leb128.writeULEB128(writer, @as(u32, 1));
+        try leb128.writeUleb128(writer, @as(u32, 1));
         try writer.writeByte(local);
     }
 }
@@ -288,16 +288,16 @@ fn emitBrTable(emit: *Emit, inst: Mir.Inst.Index) !void {
     const writer = emit.code.writer();
 
     try emit.code.append(std.wasm.opcode(.br_table));
-    try leb128.writeULEB128(writer, extra.data.length - 1); // Default label is not part of length/depth
+    try leb128.writeUleb128(writer, extra.data.length - 1); // Default label is not part of length/depth
     for (labels) |label| {
-        try leb128.writeULEB128(writer, label);
+        try leb128.writeUleb128(writer, label);
     }
 }
 
 fn emitLabel(emit: *Emit, tag: Mir.Inst.Tag, inst: Mir.Inst.Index) !void {
     const label = emit.mir.instructions.items(.data)[inst].label;
     try emit.code.append(@intFromEnum(tag));
-    try leb128.writeULEB128(emit.code.writer(), label);
+    try leb128.writeUleb128(emit.code.writer(), label);
 }
 
 fn emitGlobal(emit: *Emit, tag: Mir.Inst.Tag, inst: Mir.Inst.Index) !void {
@@ -322,14 +322,14 @@ fn emitGlobal(emit: *Emit, tag: Mir.Inst.Tag, inst: Mir.Inst.Index) !void {
 fn emitImm32(emit: *Emit, inst: Mir.Inst.Index) !void {
     const value: i32 = emit.mir.instructions.items(.data)[inst].imm32;
     try emit.code.append(std.wasm.opcode(.i32_const));
-    try leb128.writeILEB128(emit.code.writer(), value);
+    try leb128.writeIleb128(emit.code.writer(), value);
 }
 
 fn emitImm64(emit: *Emit, inst: Mir.Inst.Index) !void {
     const extra_index = emit.mir.instructions.items(.data)[inst].payload;
     const value = emit.mir.extraData(Mir.Imm64, extra_index);
     try emit.code.append(std.wasm.opcode(.i64_const));
-    try leb128.writeILEB128(emit.code.writer(), @as(i64, @bitCast(value.data.toU64())));
+    try leb128.writeIleb128(emit.code.writer(), @as(i64, @bitCast(value.data.toU64())));
 }
 
 fn emitFloat32(emit: *Emit, inst: Mir.Inst.Index) !void {
@@ -355,8 +355,8 @@ fn emitMemArg(emit: *Emit, tag: Mir.Inst.Tag, inst: Mir.Inst.Index) !void {
 fn encodeMemArg(mem_arg: Mir.MemArg, writer: anytype) !void {
     // wasm encodes alignment as power of 2, rather than natural alignment
     const encoded_alignment = @ctz(mem_arg.alignment);
-    try leb128.writeULEB128(writer, encoded_alignment);
-    try leb128.writeULEB128(writer, mem_arg.offset);
+    try leb128.writeUleb128(writer, encoded_alignment);
+    try leb128.writeUleb128(writer, mem_arg.offset);
 }
 
 fn emitCall(emit: *Emit, inst: Mir.Inst.Index) !void {
@@ -398,7 +398,7 @@ fn emitCallIndirect(emit: *Emit, inst: Mir.Inst.Index) !void {
             .relocation_type = .R_WASM_TYPE_INDEX_LEB,
         });
     }
-    try leb128.writeULEB128(emit.code.writer(), @as(u32, 0)); // TODO: Emit relocation for table index
+    try leb128.writeUleb128(emit.code.writer(), @as(u32, 0)); // TODO: Emit relocation for table index
 }
 
 fn emitFunctionIndex(emit: *Emit, inst: Mir.Inst.Index) !void {
@@ -459,24 +459,24 @@ fn emitExtended(emit: *Emit, inst: Mir.Inst.Index) !void {
     const opcode = emit.mir.extra[extra_index];
     const writer = emit.code.writer();
     try emit.code.append(std.wasm.opcode(.misc_prefix));
-    try leb128.writeULEB128(writer, opcode);
+    try leb128.writeUleb128(writer, opcode);
     switch (@as(std.wasm.MiscOpcode, @enumFromInt(opcode))) {
         // bulk-memory opcodes
         .data_drop => {
             const segment = emit.mir.extra[extra_index + 1];
-            try leb128.writeULEB128(writer, segment);
+            try leb128.writeUleb128(writer, segment);
         },
         .memory_init => {
             const segment = emit.mir.extra[extra_index + 1];
-            try leb128.writeULEB128(writer, segment);
-            try leb128.writeULEB128(writer, @as(u32, 0)); // memory index
+            try leb128.writeUleb128(writer, segment);
+            try leb128.writeUleb128(writer, @as(u32, 0)); // memory index
         },
         .memory_fill => {
-            try leb128.writeULEB128(writer, @as(u32, 0)); // memory index
+            try leb128.writeUleb128(writer, @as(u32, 0)); // memory index
         },
         .memory_copy => {
-            try leb128.writeULEB128(writer, @as(u32, 0)); // dst memory index
-            try leb128.writeULEB128(writer, @as(u32, 0)); // src memory index
+            try leb128.writeUleb128(writer, @as(u32, 0)); // dst memory index
+            try leb128.writeUleb128(writer, @as(u32, 0)); // src memory index
         },
 
         // nontrapping-float-to-int-conversion opcodes
@@ -498,7 +498,7 @@ fn emitSimd(emit: *Emit, inst: Mir.Inst.Index) !void {
     const opcode = emit.mir.extra[extra_index];
     const writer = emit.code.writer();
     try emit.code.append(std.wasm.opcode(.simd_prefix));
-    try leb128.writeULEB128(writer, opcode);
+    try leb128.writeUleb128(writer, opcode);
     switch (@as(std.wasm.SimdOpcode, @enumFromInt(opcode))) {
         .v128_store,
         .v128_load,
@@ -549,7 +549,7 @@ fn emitAtomic(emit: *Emit, inst: Mir.Inst.Index) !void {
     const opcode = emit.mir.extra[extra_index];
     const writer = emit.code.writer();
     try emit.code.append(std.wasm.opcode(.atomics_prefix));
-    try leb128.writeULEB128(writer, opcode);
+    try leb128.writeUleb128(writer, opcode);
     switch (@as(std.wasm.AtomicsOpcode, @enumFromInt(opcode))) {
         .i32_atomic_load,
         .i64_atomic_load,
@@ -623,7 +623,7 @@ fn emitAtomic(emit: *Emit, inst: Mir.Inst.Index) !void {
             // TODO: When multi-memory proposal is accepted and implemented in the compiler,
             // change this to (user-)specified index, rather than hardcode it to memory index 0.
             const memory_index: u32 = 0;
-            try leb128.writeULEB128(writer, memory_index);
+            try leb128.writeUleb128(writer, memory_index);
         },
         else => |tag| return emit.fail("TODO: Implement atomic instruction: {s}", .{@tagName(tag)}),
     }
@@ -635,7 +635,7 @@ fn emitMemFill(emit: *Emit) !void {
     // When multi-memory proposal reaches phase 4, we
     // can emit a different memory index here.
     // For now we will always emit index 0.
-    try leb128.writeULEB128(emit.code.writer(), @as(u32, 0));
+    try leb128.writeUleb128(emit.code.writer(), @as(u32, 0));
 }
 
 fn emitDbgLine(emit: *Emit, inst: Mir.Inst.Index) !void {

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -148,7 +148,7 @@ pub const DeclState = struct {
                 // DW.AT.encoding, DW.FORM.data1
                 dbg_info_buffer.appendAssumeCapacity(DW.ATE.boolean);
                 // DW.AT.byte_size, DW.FORM.udata
-                try leb128.writeULEB128(dbg_info_buffer.writer(), ty.abiSize(mod));
+                try leb128.writeUleb128(dbg_info_buffer.writer(), ty.abiSize(mod));
                 // DW.AT.name, DW.FORM.string
                 try dbg_info_buffer.writer().print("{}\x00", .{ty.fmt(mod)});
             },
@@ -162,7 +162,7 @@ pub const DeclState = struct {
                     .unsigned => DW.ATE.unsigned,
                 });
                 // DW.AT.byte_size, DW.FORM.udata
-                try leb128.writeULEB128(dbg_info_buffer.writer(), ty.abiSize(mod));
+                try leb128.writeUleb128(dbg_info_buffer.writer(), ty.abiSize(mod));
                 // DW.AT.name, DW.FORM.string
                 try dbg_info_buffer.writer().print("{}\x00", .{ty.fmt(mod)});
             },
@@ -173,7 +173,7 @@ pub const DeclState = struct {
                     // DW.AT.encoding, DW.FORM.data1
                     dbg_info_buffer.appendAssumeCapacity(DW.ATE.address);
                     // DW.AT.byte_size, DW.FORM.udata
-                    try leb128.writeULEB128(dbg_info_buffer.writer(), ty.abiSize(mod));
+                    try leb128.writeUleb128(dbg_info_buffer.writer(), ty.abiSize(mod));
                     // DW.AT.name, DW.FORM.string
                     try dbg_info_buffer.writer().print("{}\x00", .{ty.fmt(mod)});
                 } else {
@@ -183,7 +183,7 @@ pub const DeclState = struct {
                     try dbg_info_buffer.append(@intFromEnum(AbbrevCode.struct_type));
                     // DW.AT.byte_size, DW.FORM.udata
                     const abi_size = ty.abiSize(mod);
-                    try leb128.writeULEB128(dbg_info_buffer.writer(), abi_size);
+                    try leb128.writeUleb128(dbg_info_buffer.writer(), abi_size);
                     // DW.AT.name, DW.FORM.string
                     try dbg_info_buffer.writer().print("{}\x00", .{ty.fmt(mod)});
                     // DW.AT.member
@@ -209,7 +209,7 @@ pub const DeclState = struct {
                     try self.addTypeRelocGlobal(atom_index, payload_ty, @intCast(index));
                     // DW.AT.data_member_location, DW.FORM.udata
                     const offset = abi_size - payload_ty.abiSize(mod);
-                    try leb128.writeULEB128(dbg_info_buffer.writer(), offset);
+                    try leb128.writeUleb128(dbg_info_buffer.writer(), offset);
                     // DW.AT.structure_type delimit children
                     try dbg_info_buffer.append(0);
                 }
@@ -223,7 +223,7 @@ pub const DeclState = struct {
                     try dbg_info_buffer.ensureUnusedCapacity(2);
                     dbg_info_buffer.appendAssumeCapacity(@intFromEnum(AbbrevCode.struct_type));
                     // DW.AT.byte_size, DW.FORM.udata
-                    try leb128.writeULEB128(dbg_info_buffer.writer(), ty.abiSize(mod));
+                    try leb128.writeUleb128(dbg_info_buffer.writer(), ty.abiSize(mod));
                     // DW.AT.name, DW.FORM.string
                     try dbg_info_buffer.writer().print("{}\x00", .{ty.fmt(mod)});
                     // DW.AT.member
@@ -279,7 +279,7 @@ pub const DeclState = struct {
                 try self.addTypeRelocGlobal(atom_index, Type.usize, @intCast(index));
                 // DW.AT.count, DW.FORM.udata
                 const len = ty.arrayLenIncludingSentinel(mod);
-                try leb128.writeULEB128(dbg_info_buffer.writer(), len);
+                try leb128.writeUleb128(dbg_info_buffer.writer(), len);
                 // DW.AT.array_type delimit children
                 try dbg_info_buffer.append(0);
             },
@@ -287,7 +287,7 @@ pub const DeclState = struct {
                 // DW.AT.structure_type
                 try dbg_info_buffer.append(@intFromEnum(AbbrevCode.struct_type));
                 // DW.AT.byte_size, DW.FORM.udata
-                try leb128.writeULEB128(dbg_info_buffer.writer(), ty.abiSize(mod));
+                try leb128.writeUleb128(dbg_info_buffer.writer(), ty.abiSize(mod));
 
                 blk: {
                     switch (ip.indexToKey(ty.ip_index)) {
@@ -306,7 +306,7 @@ pub const DeclState = struct {
                                 try self.addTypeRelocGlobal(atom_index, Type.fromInterned(field_ty), @intCast(index));
                                 // DW.AT.data_member_location, DW.FORM.udata
                                 const field_off = ty.structFieldOffset(field_index, mod);
-                                try leb128.writeULEB128(dbg_info_buffer.writer(), field_off);
+                                try leb128.writeUleb128(dbg_info_buffer.writer(), field_off);
                             }
                         },
                         .struct_type => {
@@ -332,7 +332,7 @@ pub const DeclState = struct {
                                     try dbg_info_buffer.appendNTimes(0, 4);
                                     try self.addTypeRelocGlobal(atom_index, Type.fromInterned(field_ty), @intCast(index));
                                     // DW.AT.data_member_location, DW.FORM.udata
-                                    try leb128.writeULEB128(dbg_info_buffer.writer(), field_off);
+                                    try leb128.writeUleb128(dbg_info_buffer.writer(), field_off);
                                 }
                             } else {
                                 for (
@@ -352,7 +352,7 @@ pub const DeclState = struct {
                                     try dbg_info_buffer.appendNTimes(0, 4);
                                     try self.addTypeRelocGlobal(atom_index, Type.fromInterned(field_ty), @intCast(index));
                                     // DW.AT.data_member_location, DW.FORM.udata
-                                    try leb128.writeULEB128(dbg_info_buffer.writer(), field_off);
+                                    try leb128.writeUleb128(dbg_info_buffer.writer(), field_off);
                                 }
                             }
                         },
@@ -367,7 +367,7 @@ pub const DeclState = struct {
                 // DW.AT.enumeration_type
                 try dbg_info_buffer.append(@intFromEnum(AbbrevCode.enum_type));
                 // DW.AT.byte_size, DW.FORM.udata
-                try leb128.writeULEB128(dbg_info_buffer.writer(), ty.abiSize(mod));
+                try leb128.writeUleb128(dbg_info_buffer.writer(), ty.abiSize(mod));
                 // DW.AT.name, DW.FORM.string
                 try ty.print(dbg_info_buffer.writer(), mod);
                 try dbg_info_buffer.append(0);
@@ -408,7 +408,7 @@ pub const DeclState = struct {
                     // DW.AT.structure_type
                     try dbg_info_buffer.append(@intFromEnum(AbbrevCode.struct_type));
                     // DW.AT.byte_size, DW.FORM.udata
-                    try leb128.writeULEB128(dbg_info_buffer.writer(), layout.abi_size);
+                    try leb128.writeUleb128(dbg_info_buffer.writer(), layout.abi_size);
                     // DW.AT.name, DW.FORM.string
                     try ty.print(dbg_info_buffer.writer(), mod);
                     try dbg_info_buffer.append(0);
@@ -424,13 +424,13 @@ pub const DeclState = struct {
                     dbg_info_buffer.appendNTimesAssumeCapacity(0, 4);
                     try self.addTypeRelocLocal(atom_index, @intCast(inner_union_index), 5);
                     // DW.AT.data_member_location, DW.FORM.udata
-                    try leb128.writeULEB128(dbg_info_buffer.writer(), payload_offset);
+                    try leb128.writeUleb128(dbg_info_buffer.writer(), payload_offset);
                 }
 
                 // DW.AT.union_type
                 try dbg_info_buffer.append(@intFromEnum(AbbrevCode.union_type));
                 // DW.AT.byte_size, DW.FORM.udata,
-                try leb128.writeULEB128(dbg_info_buffer.writer(), layout.payload_size);
+                try leb128.writeUleb128(dbg_info_buffer.writer(), layout.payload_size);
                 // DW.AT.name, DW.FORM.string
                 if (is_tagged) {
                     try dbg_info_buffer.writer().print("AnonUnion\x00", .{});
@@ -468,7 +468,7 @@ pub const DeclState = struct {
                     dbg_info_buffer.appendNTimesAssumeCapacity(0, 4);
                     try self.addTypeRelocGlobal(atom_index, Type.fromInterned(union_obj.enum_tag_ty), @intCast(index));
                     // DW.AT.data_member_location, DW.FORM.udata
-                    try leb128.writeULEB128(dbg_info_buffer.writer(), tag_offset);
+                    try leb128.writeUleb128(dbg_info_buffer.writer(), tag_offset);
 
                     // DW.AT.structure_type delimit children
                     try dbg_info_buffer.append(0);
@@ -487,7 +487,7 @@ pub const DeclState = struct {
                 // DW.AT.structure_type
                 try dbg_info_buffer.append(@intFromEnum(AbbrevCode.struct_type));
                 // DW.AT.byte_size, DW.FORM.udata
-                try leb128.writeULEB128(dbg_info_buffer.writer(), abi_size);
+                try leb128.writeUleb128(dbg_info_buffer.writer(), abi_size);
                 // DW.AT.name, DW.FORM.string
                 try ty.print(dbg_info_buffer.writer(), mod);
                 try dbg_info_buffer.append(0);
@@ -504,7 +504,7 @@ pub const DeclState = struct {
                     dbg_info_buffer.appendNTimesAssumeCapacity(0, 4);
                     try self.addTypeRelocGlobal(atom_index, payload_ty, @intCast(index));
                     // DW.AT.data_member_location, DW.FORM.udata
-                    try leb128.writeULEB128(dbg_info_buffer.writer(), payload_off);
+                    try leb128.writeUleb128(dbg_info_buffer.writer(), payload_off);
                 }
 
                 {
@@ -519,7 +519,7 @@ pub const DeclState = struct {
                     dbg_info_buffer.appendNTimesAssumeCapacity(0, 4);
                     try self.addTypeRelocGlobal(atom_index, error_ty, @intCast(index));
                     // DW.AT.data_member_location, DW.FORM.udata
-                    try leb128.writeULEB128(dbg_info_buffer.writer(), error_off);
+                    try leb128.writeUleb128(dbg_info_buffer.writer(), error_off);
                 }
 
                 // DW.AT.structure_type delimit children
@@ -569,14 +569,14 @@ pub const DeclState = struct {
                     expr_len.writer().writeByte(DW.OP.reg0 + reg) catch unreachable;
                 } else {
                     expr_len.writer().writeByte(DW.OP.regx) catch unreachable;
-                    leb128.writeULEB128(expr_len.writer(), reg) catch unreachable;
+                    leb128.writeUleb128(expr_len.writer(), reg) catch unreachable;
                 }
-                leb128.writeULEB128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
+                leb128.writeUleb128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
                 if (reg < 32) {
                     dbg_info.appendAssumeCapacity(DW.OP.reg0 + reg);
                 } else {
                     dbg_info.appendAssumeCapacity(DW.OP.regx);
-                    leb128.writeULEB128(dbg_info.writer(), reg) catch unreachable;
+                    leb128.writeUleb128(dbg_info.writer(), reg) catch unreachable;
                 }
             },
             .register_pair => |regs| {
@@ -592,24 +592,24 @@ pub const DeclState = struct {
                         expr_len.writer().writeByte(DW.OP.reg0 + reg) catch unreachable;
                     } else {
                         expr_len.writer().writeByte(DW.OP.regx) catch unreachable;
-                        leb128.writeULEB128(expr_len.writer(), reg) catch unreachable;
+                        leb128.writeUleb128(expr_len.writer(), reg) catch unreachable;
                     }
                     expr_len.writer().writeByte(DW.OP.piece) catch unreachable;
-                    leb128.writeULEB128(
+                    leb128.writeUleb128(
                         expr_len.writer(),
                         @min(abi_size - reg_i * reg_bytes, reg_bytes),
                     ) catch unreachable;
                 }
-                leb128.writeULEB128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
+                leb128.writeUleb128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
                 for (regs, 0..) |reg, reg_i| {
                     if (reg < 32) {
                         dbg_info.appendAssumeCapacity(DW.OP.reg0 + reg);
                     } else {
                         dbg_info.appendAssumeCapacity(DW.OP.regx);
-                        leb128.writeULEB128(dbg_info.writer(), reg) catch unreachable;
+                        leb128.writeUleb128(dbg_info.writer(), reg) catch unreachable;
                     }
                     dbg_info.appendAssumeCapacity(DW.OP.piece);
-                    leb128.writeULEB128(
+                    leb128.writeUleb128(
                         dbg_info.writer(),
                         @min(abi_size - reg_i * reg_bytes, reg_bytes),
                     ) catch unreachable;
@@ -624,20 +624,20 @@ pub const DeclState = struct {
                     expr_len.writer().writeByte(DW.OP.breg0 + info.fp_register) catch unreachable;
                 } else {
                     expr_len.writer().writeByte(DW.OP.bregx) catch unreachable;
-                    leb128.writeULEB128(expr_len.writer(), info.fp_register) catch unreachable;
+                    leb128.writeUleb128(expr_len.writer(), info.fp_register) catch unreachable;
                 }
-                leb128.writeILEB128(expr_len.writer(), info.offset) catch unreachable;
-                leb128.writeULEB128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
+                leb128.writeIleb128(expr_len.writer(), info.offset) catch unreachable;
+                leb128.writeUleb128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
                 if (info.fp_register < 32) {
                     dbg_info.appendAssumeCapacity(DW.OP.breg0 + info.fp_register);
                 } else {
                     dbg_info.appendAssumeCapacity(DW.OP.bregx);
-                    leb128.writeULEB128(dbg_info.writer(), info.fp_register) catch unreachable;
+                    leb128.writeUleb128(dbg_info.writer(), info.fp_register) catch unreachable;
                 }
-                leb128.writeILEB128(dbg_info.writer(), info.offset) catch unreachable;
+                leb128.writeIleb128(dbg_info.writer(), info.offset) catch unreachable;
             },
             .wasm_local => |value| {
-                const leb_size = link.File.Wasm.getULEB128Size(value);
+                const leb_size = link.File.Wasm.getUleb128Size(value);
                 try dbg_info.ensureUnusedCapacity(3 + leb_size);
                 // wasm locations are encoded as follow:
                 // DW_OP_WASM_location wasm-op
@@ -650,7 +650,7 @@ pub const DeclState = struct {
                     DW.OP.WASM_location,
                     DW.OP.WASM_local,
                 });
-                leb128.writeULEB128(dbg_info.writer(), value) catch unreachable;
+                leb128.writeUleb128(dbg_info.writer(), value) catch unreachable;
             },
             else => unreachable,
         }
@@ -689,14 +689,14 @@ pub const DeclState = struct {
                     expr_len.writer().writeByte(DW.OP.reg0 + reg) catch unreachable;
                 } else {
                     expr_len.writer().writeByte(DW.OP.regx) catch unreachable;
-                    leb128.writeULEB128(expr_len.writer(), reg) catch unreachable;
+                    leb128.writeUleb128(expr_len.writer(), reg) catch unreachable;
                 }
-                leb128.writeULEB128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
+                leb128.writeUleb128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
                 if (reg < 32) {
                     dbg_info.appendAssumeCapacity(DW.OP.reg0 + reg);
                 } else {
                     dbg_info.appendAssumeCapacity(DW.OP.regx);
-                    leb128.writeULEB128(dbg_info.writer(), reg) catch unreachable;
+                    leb128.writeUleb128(dbg_info.writer(), reg) catch unreachable;
                 }
             },
 
@@ -712,24 +712,24 @@ pub const DeclState = struct {
                         expr_len.writer().writeByte(DW.OP.reg0 + reg) catch unreachable;
                     } else {
                         expr_len.writer().writeByte(DW.OP.regx) catch unreachable;
-                        leb128.writeULEB128(expr_len.writer(), reg) catch unreachable;
+                        leb128.writeUleb128(expr_len.writer(), reg) catch unreachable;
                     }
                     expr_len.writer().writeByte(DW.OP.piece) catch unreachable;
-                    leb128.writeULEB128(
+                    leb128.writeUleb128(
                         expr_len.writer(),
                         @min(abi_size - reg_i * reg_bytes, reg_bytes),
                     ) catch unreachable;
                 }
-                leb128.writeULEB128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
+                leb128.writeUleb128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
                 for (regs, 0..) |reg, reg_i| {
                     if (reg < 32) {
                         dbg_info.appendAssumeCapacity(DW.OP.reg0 + reg);
                     } else {
                         dbg_info.appendAssumeCapacity(DW.OP.regx);
-                        leb128.writeULEB128(dbg_info.writer(), reg) catch unreachable;
+                        leb128.writeUleb128(dbg_info.writer(), reg) catch unreachable;
                     }
                     dbg_info.appendAssumeCapacity(DW.OP.piece);
-                    leb128.writeULEB128(
+                    leb128.writeUleb128(
                         dbg_info.writer(),
                         @min(abi_size - reg_i * reg_bytes, reg_bytes),
                     ) catch unreachable;
@@ -744,21 +744,21 @@ pub const DeclState = struct {
                     expr_len.writer().writeByte(DW.OP.breg0 + info.fp_register) catch unreachable;
                 } else {
                     expr_len.writer().writeByte(DW.OP.bregx) catch unreachable;
-                    leb128.writeULEB128(expr_len.writer(), info.fp_register) catch unreachable;
+                    leb128.writeUleb128(expr_len.writer(), info.fp_register) catch unreachable;
                 }
-                leb128.writeILEB128(expr_len.writer(), info.offset) catch unreachable;
-                leb128.writeULEB128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
+                leb128.writeIleb128(expr_len.writer(), info.offset) catch unreachable;
+                leb128.writeUleb128(dbg_info.writer(), expr_len.bytes_written) catch unreachable;
                 if (info.fp_register < 32) {
                     dbg_info.appendAssumeCapacity(DW.OP.breg0 + info.fp_register);
                 } else {
                     dbg_info.appendAssumeCapacity(DW.OP.bregx);
-                    leb128.writeULEB128(dbg_info.writer(), info.fp_register) catch unreachable;
+                    leb128.writeUleb128(dbg_info.writer(), info.fp_register) catch unreachable;
                 }
-                leb128.writeILEB128(dbg_info.writer(), info.offset) catch unreachable;
+                leb128.writeIleb128(dbg_info.writer(), info.offset) catch unreachable;
             },
 
             .wasm_local => |value| {
-                const leb_size = link.File.Wasm.getULEB128Size(value);
+                const leb_size = link.File.Wasm.getUleb128Size(value);
                 try dbg_info.ensureUnusedCapacity(2 + leb_size);
                 // wasm locals are encoded as follow:
                 // DW_OP_WASM_location wasm-op
@@ -770,7 +770,7 @@ pub const DeclState = struct {
                     DW.OP.WASM_location,
                     DW.OP.WASM_local,
                 });
-                leb128.writeULEB128(dbg_info.writer(), value) catch unreachable;
+                leb128.writeUleb128(dbg_info.writer(), value) catch unreachable;
             },
 
             .memory,
@@ -832,9 +832,9 @@ pub const DeclState = struct {
                     if (child_ty.isSignedInt(mod)) DW.OP.consts else DW.OP.constu,
                 });
                 if (child_ty.isSignedInt(mod)) {
-                    try leb128.writeILEB128(dbg_info.writer(), @as(i64, @bitCast(x)));
+                    try leb128.writeIleb128(dbg_info.writer(), @as(i64, @bitCast(x)));
                 } else {
-                    try leb128.writeULEB128(dbg_info.writer(), x);
+                    try leb128.writeUleb128(dbg_info.writer(), x);
                 }
                 try dbg_info.append(DW.OP.stack_value);
                 dbg_info.items[fixup] += @intCast(dbg_info.items.len - fixup - 2);
@@ -847,9 +847,9 @@ pub const DeclState = struct {
                 const abi_size: u32 = @intCast(child_ty.abiSize(mod));
                 var implicit_value_len = std.ArrayList(u8).init(gpa);
                 defer implicit_value_len.deinit();
-                try leb128.writeULEB128(implicit_value_len.writer(), abi_size);
+                try leb128.writeUleb128(implicit_value_len.writer(), abi_size);
                 const total_exprloc_len = 1 + implicit_value_len.items.len + abi_size;
-                try leb128.writeULEB128(dbg_info.writer(), total_exprloc_len);
+                try leb128.writeUleb128(dbg_info.writer(), total_exprloc_len);
                 try dbg_info.ensureUnusedCapacity(total_exprloc_len);
                 dbg_info.appendAssumeCapacity(DW.OP.implicit_value);
                 dbg_info.appendSliceAssumeCapacity(implicit_value_len.items);
@@ -895,7 +895,7 @@ pub const DeclState = struct {
         remaining: {
             assert(delta_line != 0);
             dbg_line.appendAssumeCapacity(DW.LNS.advance_line);
-            leb128.writeILEB128(dbg_line.writer(), delta_line) catch unreachable;
+            leb128.writeIleb128(dbg_line.writer(), delta_line) catch unreachable;
             break :remaining 0;
         } else delta_line);
 
@@ -904,7 +904,7 @@ pub const DeclState = struct {
         const max_op_advance: u9 = (std.math.maxInt(u8) - header.opcode_base) / header.line_range;
         const remaining_op_advance: u8 = @intCast(if (op_advance >= 2 * max_op_advance) remaining: {
             dbg_line.appendAssumeCapacity(DW.LNS.advance_pc);
-            leb128.writeULEB128(dbg_line.writer(), op_advance) catch unreachable;
+            leb128.writeUleb128(dbg_line.writer(), op_advance) catch unreachable;
             break :remaining 0;
         } else if (op_advance >= max_op_advance) remaining: {
             dbg_line.appendAssumeCapacity(DW.LNS.const_add_pc);
@@ -922,7 +922,7 @@ pub const DeclState = struct {
     pub fn setColumn(self: *DeclState, column: u32) error{OutOfMemory}!void {
         try self.dbg_line.ensureUnusedCapacity(1 + 5);
         self.dbg_line.appendAssumeCapacity(DW.LNS.set_column);
-        leb128.writeULEB128(self.dbg_line.writer(), column + 1) catch unreachable;
+        leb128.writeUleb128(self.dbg_line.writer(), column + 1) catch unreachable;
     }
 
     pub fn setPrologueEnd(self: *DeclState) error{OutOfMemory}!void {
@@ -1146,7 +1146,7 @@ pub fn initDeclState(self: *Dwarf, mod: *Module, decl_index: InternPool.DeclInde
             leb128.writeUnsignedFixed(4, dbg_line_buffer.addManyAsArrayAssumeCapacity(4), file_index);
 
             dbg_line_buffer.appendAssumeCapacity(DW.LNS.set_column);
-            leb128.writeULEB128(dbg_line_buffer.writer(), func.lbrace_column + 1) catch unreachable;
+            leb128.writeUleb128(dbg_line_buffer.writer(), func.lbrace_column + 1) catch unreachable;
 
             // Emit a line for the begin curly with prologue_end=false. The codegen will
             // do the work of setting prologue_end=true and epilogue_begin=true.
@@ -2849,7 +2849,7 @@ fn addDbgInfoErrorSetNames(
     try dbg_info_buffer.append(@intFromEnum(AbbrevCode.enum_type));
     // DW.AT.byte_size, DW.FORM.udata
     const abi_size = Type.anyerror.abiSize(mod);
-    try leb128.writeULEB128(dbg_info_buffer.writer(), abi_size);
+    try leb128.writeUleb128(dbg_info_buffer.writer(), abi_size);
     // DW.AT.name, DW.FORM.string
     try ty.print(dbg_info_buffer.writer(), mod);
     try dbg_info_buffer.append(0);

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -159,11 +159,11 @@ const TrieIterator = struct {
         return std.io.fixedBufferStream(it.data[it.pos..]);
     }
 
-    fn readULEB128(it: *TrieIterator) !u64 {
+    fn readUleb128(it: *TrieIterator) !u64 {
         var stream = it.getStream();
         var creader = std.io.countingReader(stream.reader());
         const reader = creader.reader();
-        const value = try std.leb.readULEB128(u64, reader);
+        const value = try std.leb.readUleb128(u64, reader);
         it.pos += math.cast(usize, creader.bytes_read) orelse return error.Overflow;
         return value;
     }
@@ -207,9 +207,9 @@ fn parseTrieNode(
 ) !void {
     const tracy = trace(@src());
     defer tracy.end();
-    const size = try it.readULEB128();
+    const size = try it.readUleb128();
     if (size > 0) {
-        const flags = try it.readULEB128();
+        const flags = try it.readUleb128();
         const kind = flags & macho.EXPORT_SYMBOL_FLAGS_KIND_MASK;
         const out_flags = Export.Flags{
             .abs = kind == macho.EXPORT_SYMBOL_FLAGS_KIND_ABSOLUTE,
@@ -217,15 +217,15 @@ fn parseTrieNode(
             .weak = flags & macho.EXPORT_SYMBOL_FLAGS_WEAK_DEFINITION != 0,
         };
         if (flags & macho.EXPORT_SYMBOL_FLAGS_REEXPORT != 0) {
-            _ = try it.readULEB128(); // dylib ordinal
+            _ = try it.readUleb128(); // dylib ordinal
             const name = try it.readString();
             try self.addExport(allocator, if (name.len > 0) name else prefix, out_flags);
         } else if (flags & macho.EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER != 0) {
-            _ = try it.readULEB128(); // stub offset
-            _ = try it.readULEB128(); // resolver offset
+            _ = try it.readUleb128(); // stub offset
+            _ = try it.readUleb128(); // resolver offset
             try self.addExport(allocator, prefix, out_flags);
         } else {
-            _ = try it.readULEB128(); // VM offset
+            _ = try it.readUleb128(); // VM offset
             try self.addExport(allocator, prefix, out_flags);
         }
     }
@@ -234,7 +234,7 @@ fn parseTrieNode(
 
     for (0..nedges) |_| {
         const label = try it.readString();
-        const off = try it.readULEB128();
+        const off = try it.readUleb128();
         const prefix_label = try std.fmt.allocPrint(arena, "{s}{s}", .{ prefix, label });
         const curr = it.pos;
         it.pos = math.cast(usize, off) orelse return error.Overflow;

--- a/src/link/MachO/dwarf.zig
+++ b/src/link/MachO/dwarf.zig
@@ -26,7 +26,7 @@ pub const InfoReader = struct {
             .dwarf64 => 12,
         } + cuh_length;
         while (p.pos < end_pos) {
-            const di_code = try p.readULEB128(u64);
+            const di_code = try p.readUleb128(u64);
             if (di_code == 0) return error.Eof;
             if (di_code == code) return;
 
@@ -92,14 +92,14 @@ pub const InfoReader = struct {
             dwarf.FORM.block1 => try p.readByte(),
             dwarf.FORM.block2 => try p.readInt(u16),
             dwarf.FORM.block4 => try p.readInt(u32),
-            dwarf.FORM.block => try p.readULEB128(u64),
+            dwarf.FORM.block => try p.readUleb128(u64),
             else => unreachable,
         };
         return p.readNBytes(len);
     }
 
     pub fn readExprLoc(p: *InfoReader) ![]const u8 {
-        const len: u64 = try p.readULEB128(u64);
+        const len: u64 = try p.readUleb128(u64);
         return p.readNBytes(len);
     }
 
@@ -109,8 +109,8 @@ pub const InfoReader = struct {
             dwarf.FORM.data2, dwarf.FORM.ref2 => try p.readInt(u16),
             dwarf.FORM.data4, dwarf.FORM.ref4 => try p.readInt(u32),
             dwarf.FORM.data8, dwarf.FORM.ref8, dwarf.FORM.ref_sig8 => try p.readInt(u64),
-            dwarf.FORM.udata, dwarf.FORM.ref_udata => try p.readULEB128(u64),
-            dwarf.FORM.sdata => @bitCast(try p.readILEB128(i64)),
+            dwarf.FORM.udata, dwarf.FORM.ref_udata => try p.readUleb128(u64),
+            dwarf.FORM.sdata => @bitCast(try p.readIleb128(i64)),
             else => return error.UnhandledConstantForm,
         };
     }
@@ -160,18 +160,18 @@ pub const InfoReader = struct {
         };
     }
 
-    pub fn readULEB128(p: *InfoReader, comptime Type: type) !Type {
+    pub fn readUleb128(p: *InfoReader, comptime Type: type) !Type {
         var stream = std.io.fixedBufferStream(p.bytes[p.pos..]);
         var creader = std.io.countingReader(stream.reader());
-        const value: Type = try leb.readULEB128(Type, creader.reader());
+        const value: Type = try leb.readUleb128(Type, creader.reader());
         p.pos += math.cast(usize, creader.bytes_read) orelse return error.Overflow;
         return value;
     }
 
-    pub fn readILEB128(p: *InfoReader, comptime Type: type) !Type {
+    pub fn readIleb128(p: *InfoReader, comptime Type: type) !Type {
         var stream = std.io.fixedBufferStream(p.bytes[p.pos..]);
         var creader = std.io.countingReader(stream.reader());
-        const value: Type = try leb.readILEB128(Type, creader.reader());
+        const value: Type = try leb.readIleb128(Type, creader.reader());
         p.pos += math.cast(usize, creader.bytes_read) orelse return error.Overflow;
         return value;
     }
@@ -191,10 +191,10 @@ pub const AbbrevReader = struct {
 
     pub fn readDecl(p: *AbbrevReader) !?AbbrevDecl {
         const pos = p.pos;
-        const code = try p.readULEB128(Code);
+        const code = try p.readUleb128(Code);
         if (code == 0) return null;
 
-        const tag = try p.readULEB128(Tag);
+        const tag = try p.readUleb128(Tag);
         const has_children = (try p.readByte()) > 0;
         return .{
             .code = code,
@@ -207,8 +207,8 @@ pub const AbbrevReader = struct {
 
     pub fn readAttr(p: *AbbrevReader) !?AbbrevAttr {
         const pos = p.pos;
-        const at = try p.readULEB128(At);
-        const form = try p.readULEB128(Form);
+        const at = try p.readUleb128(At);
+        const form = try p.readUleb128(Form);
         return if (at == 0 and form == 0) null else .{
             .at = at,
             .form = form,
@@ -223,10 +223,10 @@ pub const AbbrevReader = struct {
         return p.bytes[p.pos];
     }
 
-    pub fn readULEB128(p: *AbbrevReader, comptime Type: type) !Type {
+    pub fn readUleb128(p: *AbbrevReader, comptime Type: type) !Type {
         var stream = std.io.fixedBufferStream(p.bytes[p.pos..]);
         var creader = std.io.countingReader(stream.reader());
-        const value: Type = try leb.readULEB128(Type, creader.reader());
+        const value: Type = try leb.readUleb128(Type, creader.reader());
         p.pos += math.cast(usize, creader.bytes_read) orelse return error.Overflow;
         return value;
     }

--- a/src/link/MachO/dyld_info/Rebase.zig
+++ b/src/link/MachO/dyld_info/Rebase.zig
@@ -153,13 +153,13 @@ fn setTypePointer(writer: anytype) !void {
 fn setSegmentOffset(segment_id: u8, offset: u64, writer: anytype) !void {
     log.debug(">>> set segment: {d} and offset: {x}", .{ segment_id, offset });
     try writer.writeByte(macho.REBASE_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | @as(u4, @truncate(segment_id)));
-    try std.leb.writeULEB128(writer, offset);
+    try std.leb.writeUleb128(writer, offset);
 }
 
 fn rebaseAddAddr(addr: u64, writer: anytype) !void {
     log.debug(">>> rebase with add: {x}", .{addr});
     try writer.writeByte(macho.REBASE_OPCODE_DO_REBASE_ADD_ADDR_ULEB);
-    try std.leb.writeULEB128(writer, addr);
+    try std.leb.writeUleb128(writer, addr);
 }
 
 fn rebaseTimes(count: usize, writer: anytype) !void {
@@ -168,15 +168,15 @@ fn rebaseTimes(count: usize, writer: anytype) !void {
         try writer.writeByte(macho.REBASE_OPCODE_DO_REBASE_IMM_TIMES | @as(u4, @truncate(count)));
     } else {
         try writer.writeByte(macho.REBASE_OPCODE_DO_REBASE_ULEB_TIMES);
-        try std.leb.writeULEB128(writer, count);
+        try std.leb.writeUleb128(writer, count);
     }
 }
 
 fn rebaseTimesSkip(count: usize, skip: u64, writer: anytype) !void {
     log.debug(">>> rebase with count: {d} and skip: {x}", .{ count, skip });
     try writer.writeByte(macho.REBASE_OPCODE_DO_REBASE_ULEB_TIMES_SKIPPING_ULEB);
-    try std.leb.writeULEB128(writer, count);
-    try std.leb.writeULEB128(writer, skip);
+    try std.leb.writeUleb128(writer, count);
+    try std.leb.writeUleb128(writer, skip);
 }
 
 fn addAddr(addr: u64, writer: anytype) !void {
@@ -189,7 +189,7 @@ fn addAddr(addr: u64, writer: anytype) !void {
         }
     }
     try writer.writeByte(macho.REBASE_OPCODE_ADD_ADDR_ULEB);
-    try std.leb.writeULEB128(writer, addr);
+    try std.leb.writeUleb128(writer, addr);
 }
 
 fn done(writer: anytype) !void {

--- a/src/link/MachO/dyld_info/Trie.zig
+++ b/src/link/MachO/dyld_info/Trie.zig
@@ -133,14 +133,14 @@ pub const Node = struct {
 
         var nread: usize = 0;
 
-        const node_size = try leb.readULEB128(u64, reader);
+        const node_size = try leb.readUleb128(u64, reader);
         if (node_size > 0) {
-            const export_flags = try leb.readULEB128(u64, reader);
+            const export_flags = try leb.readUleb128(u64, reader);
             // TODO Parse special flags.
             assert(export_flags & macho.EXPORT_SYMBOL_FLAGS_REEXPORT == 0 and
                 export_flags & macho.EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER == 0);
 
-            const vmaddr_offset = try leb.readULEB128(u64, reader);
+            const vmaddr_offset = try leb.readUleb128(u64, reader);
 
             self.terminal_info = .{
                 .export_flags = export_flags,
@@ -168,7 +168,7 @@ pub const Node = struct {
                 break :blk try label_buf.toOwnedSlice();
             };
 
-            const seek_to = try leb.readULEB128(u64, reader);
+            const seek_to = try leb.readUleb128(u64, reader);
             const return_pos = try reader.context.getPos();
 
             nread += return_pos - edge_start_pos;
@@ -204,13 +204,13 @@ pub const Node = struct {
             // TODO Implement for special flags.
             assert(info.export_flags & macho.EXPORT_SYMBOL_FLAGS_REEXPORT == 0 and
                 info.export_flags & macho.EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER == 0);
-            try leb.writeULEB128(info_stream.writer(), info.export_flags);
-            try leb.writeULEB128(info_stream.writer(), info.vmaddr_offset);
+            try leb.writeUleb128(info_stream.writer(), info.export_flags);
+            try leb.writeUleb128(info_stream.writer(), info.vmaddr_offset);
 
             // Encode the size of the terminal node info.
             var size_buf: [@sizeOf(u64)]u8 = undefined;
             var size_stream = std.io.fixedBufferStream(&size_buf);
-            try leb.writeULEB128(size_stream.writer(), info_stream.pos);
+            try leb.writeUleb128(size_stream.writer(), info_stream.pos);
 
             // Now, write them to the output stream.
             try writer.writeAll(size_buf[0..size_stream.pos]);
@@ -226,7 +226,7 @@ pub const Node = struct {
             // Write edge label and offset to next node in trie.
             try writer.writeAll(edge.label);
             try writer.writeByte(0);
-            try leb.writeULEB128(writer, edge.to.trie_offset.?);
+            try leb.writeUleb128(writer, edge.to.trie_offset.?);
         }
     }
 
@@ -246,9 +246,9 @@ pub const Node = struct {
 
         var node_size: u64 = 0;
         if (self.terminal_info) |info| {
-            try leb.writeULEB128(writer, info.export_flags);
-            try leb.writeULEB128(writer, info.vmaddr_offset);
-            try leb.writeULEB128(writer, stream.bytes_written);
+            try leb.writeUleb128(writer, info.export_flags);
+            try leb.writeUleb128(writer, info.vmaddr_offset);
+            try leb.writeUleb128(writer, stream.bytes_written);
         } else {
             node_size += 1; // 0x0 for non-terminal nodes
         }
@@ -257,7 +257,7 @@ pub const Node = struct {
         for (self.edges.items) |edge| {
             const next_node_offset = edge.to.trie_offset orelse 0;
             node_size += edge.label.len + 1;
-            try leb.writeULEB128(writer, next_node_offset);
+            try leb.writeUleb128(writer, next_node_offset);
         }
 
         const trie_offset = self.trie_offset orelse 0;

--- a/src/link/MachO/dyld_info/bind.zig
+++ b/src/link/MachO/dyld_info/bind.zig
@@ -392,7 +392,7 @@ pub const LazyBind = struct {
 fn setSegmentOffset(segment_id: u8, offset: u64, writer: anytype) !void {
     log.debug(">>> set segment: {d} and offset: {x}", .{ segment_id, offset });
     try writer.writeByte(macho.BIND_OPCODE_SET_SEGMENT_AND_OFFSET_ULEB | @as(u4, @truncate(segment_id)));
-    try std.leb.writeULEB128(writer, offset);
+    try std.leb.writeUleb128(writer, offset);
 }
 
 fn setSymbol(name: []const u8, flags: u8, writer: anytype) !void {
@@ -426,7 +426,7 @@ fn setDylibOrdinal(ordinal: i16, writer: anytype) !void {
             try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_ORDINAL_IMM | @as(u4, @truncate(cast)));
         } else {
             try writer.writeByte(macho.BIND_OPCODE_SET_DYLIB_ORDINAL_ULEB);
-            try std.leb.writeULEB128(writer, cast);
+            try std.leb.writeUleb128(writer, cast);
         }
     }
 }
@@ -434,7 +434,7 @@ fn setDylibOrdinal(ordinal: i16, writer: anytype) !void {
 fn setAddend(addend: i64, writer: anytype) !void {
     log.debug(">>> set addend: {x}", .{addend});
     try writer.writeByte(macho.BIND_OPCODE_SET_ADDEND_SLEB);
-    try std.leb.writeILEB128(writer, addend);
+    try std.leb.writeIleb128(writer, addend);
 }
 
 fn doBind(writer: anytype) !void {
@@ -454,20 +454,20 @@ fn doBindAddAddr(addr: u64, writer: anytype) !void {
         }
     }
     try writer.writeByte(macho.BIND_OPCODE_DO_BIND_ADD_ADDR_ULEB);
-    try std.leb.writeULEB128(writer, addr);
+    try std.leb.writeUleb128(writer, addr);
 }
 
 fn doBindTimesSkip(count: usize, skip: u64, writer: anytype) !void {
     log.debug(">>> bind with count: {d} and skip: {x}", .{ count, skip });
     try writer.writeByte(macho.BIND_OPCODE_DO_BIND_ULEB_TIMES_SKIPPING_ULEB);
-    try std.leb.writeULEB128(writer, count);
-    try std.leb.writeULEB128(writer, skip);
+    try std.leb.writeUleb128(writer, count);
+    try std.leb.writeUleb128(writer, skip);
 }
 
 fn addAddr(addr: u64, writer: anytype) !void {
     log.debug(">>> add: {x}", .{addr});
     try writer.writeByte(macho.BIND_OPCODE_ADD_ADDR_ULEB);
-    try std.leb.writeULEB128(writer, addr);
+    try std.leb.writeUleb128(writer, addr);
 }
 
 fn done(writer: anytype) !void {

--- a/src/link/MachO/eh_frame.zig
+++ b/src/link/MachO/eh_frame.zig
@@ -21,10 +21,10 @@ pub const Cie = struct {
         var creader = std.io.countingReader(stream.reader());
         const reader = creader.reader();
 
-        _ = try leb.readULEB128(u64, reader); // code alignment factor
-        _ = try leb.readULEB128(u64, reader); // data alignment factor
-        _ = try leb.readULEB128(u64, reader); // return address register
-        _ = try leb.readULEB128(u64, reader); // augmentation data length
+        _ = try leb.readUleb128(u64, reader); // code alignment factor
+        _ = try leb.readUleb128(u64, reader); // data alignment factor
+        _ = try leb.readUleb128(u64, reader); // return address register
+        _ = try leb.readUleb128(u64, reader); // augmentation data length
 
         for (aug[1..]) |ch| switch (ch) {
             'R' => {
@@ -185,7 +185,7 @@ pub const Fde = struct {
             var stream = std.io.fixedBufferStream(data[24..]);
             var creader = std.io.countingReader(stream.reader());
             const reader = creader.reader();
-            _ = try leb.readULEB128(u64, reader); // augmentation length
+            _ = try leb.readUleb128(u64, reader); // augmentation length
             fde.lsda_ptr_offset = @intCast(creader.bytes_read + 24);
             const lsda_ptr = switch (lsda_size) {
                 .p32 => try reader.readInt(i32, .little),

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -950,7 +950,7 @@ fn resolveSymbolsInArchives(wasm: *Wasm) !void {
 /// Writes an unsigned 32-bit integer as a LEB128-encoded 'i32.const' value.
 fn writeI32Const(writer: anytype, val: u32) !void {
     try writer.writeByte(std.wasm.opcode(.i32_const));
-    try leb.writeILEB128(writer, @as(i32, @bitCast(val)));
+    try leb.writeIleb128(writer, @as(i32, @bitCast(val)));
 }
 
 fn setupInitMemoryFunction(wasm: *Wasm) !void {
@@ -982,7 +982,7 @@ fn setupInitMemoryFunction(wasm: *Wasm) !void {
     const writer = function_body.writer();
 
     // we have 0 locals
-    try leb.writeULEB128(writer, @as(u32, 0));
+    try leb.writeUleb128(writer, @as(u32, 0));
 
     if (shared_memory) {
         // destination blocks
@@ -1001,16 +1001,16 @@ fn setupInitMemoryFunction(wasm: *Wasm) !void {
         try writeI32Const(writer, 0);
         try writeI32Const(writer, 1);
         try writer.writeByte(std.wasm.opcode(.atomics_prefix));
-        try leb.writeULEB128(writer, std.wasm.atomicsOpcode(.i32_atomic_rmw_cmpxchg));
-        try leb.writeULEB128(writer, @as(u32, 2)); // alignment
-        try leb.writeULEB128(writer, @as(u32, 0)); // offset
+        try leb.writeUleb128(writer, std.wasm.atomicsOpcode(.i32_atomic_rmw_cmpxchg));
+        try leb.writeUleb128(writer, @as(u32, 2)); // alignment
+        try leb.writeUleb128(writer, @as(u32, 0)); // offset
 
         // based on the value from the atomic check, jump to the label.
         try writer.writeByte(std.wasm.opcode(.br_table));
-        try leb.writeULEB128(writer, @as(u32, 2)); // length of the table (we have 3 blocks but because of the mandatory default the length is 2).
-        try leb.writeULEB128(writer, @as(u32, 0)); // $init
-        try leb.writeULEB128(writer, @as(u32, 1)); // $wait
-        try leb.writeULEB128(writer, @as(u32, 2)); // $drop
+        try leb.writeUleb128(writer, @as(u32, 2)); // length of the table (we have 3 blocks but because of the mandatory default the length is 2).
+        try leb.writeUleb128(writer, @as(u32, 0)); // $init
+        try leb.writeUleb128(writer, @as(u32, 1)); // $wait
+        try leb.writeUleb128(writer, @as(u32, 2)); // $drop
         try writer.writeByte(std.wasm.opcode(.end));
     }
 
@@ -1032,7 +1032,7 @@ fn setupInitMemoryFunction(wasm: *Wasm) !void {
                 try writeI32Const(writer, segment.offset);
                 try writer.writeByte(std.wasm.opcode(.global_set));
                 const loc = wasm.findGlobalSymbol("__tls_base").?;
-                try leb.writeULEB128(writer, loc.getSymbol(wasm).index);
+                try leb.writeUleb128(writer, loc.getSymbol(wasm).index);
             }
 
             try writeI32Const(writer, 0);
@@ -1040,11 +1040,11 @@ fn setupInitMemoryFunction(wasm: *Wasm) !void {
             try writer.writeByte(std.wasm.opcode(.misc_prefix));
             if (std.mem.eql(u8, entry.key_ptr.*, ".bss")) {
                 // fill bss segment with zeroes
-                try leb.writeULEB128(writer, std.wasm.miscOpcode(.memory_fill));
+                try leb.writeUleb128(writer, std.wasm.miscOpcode(.memory_fill));
             } else {
                 // initialize the segment
-                try leb.writeULEB128(writer, std.wasm.miscOpcode(.memory_init));
-                try leb.writeULEB128(writer, segment_index);
+                try leb.writeUleb128(writer, std.wasm.miscOpcode(.memory_init));
+                try leb.writeUleb128(writer, segment_index);
             }
             try writer.writeByte(0); // memory index immediate
         }
@@ -1055,34 +1055,34 @@ fn setupInitMemoryFunction(wasm: *Wasm) !void {
         try writeI32Const(writer, flag_address);
         try writeI32Const(writer, 2);
         try writer.writeByte(std.wasm.opcode(.atomics_prefix));
-        try leb.writeULEB128(writer, std.wasm.atomicsOpcode(.i32_atomic_store));
-        try leb.writeULEB128(writer, @as(u32, 2)); // alignment
-        try leb.writeULEB128(writer, @as(u32, 0)); // offset
+        try leb.writeUleb128(writer, std.wasm.atomicsOpcode(.i32_atomic_store));
+        try leb.writeUleb128(writer, @as(u32, 2)); // alignment
+        try leb.writeUleb128(writer, @as(u32, 0)); // offset
 
         // notify any waiters for segment initialization completion
         try writeI32Const(writer, flag_address);
         try writer.writeByte(std.wasm.opcode(.i32_const));
-        try leb.writeILEB128(writer, @as(i32, -1)); // number of waiters
+        try leb.writeIleb128(writer, @as(i32, -1)); // number of waiters
         try writer.writeByte(std.wasm.opcode(.atomics_prefix));
-        try leb.writeULEB128(writer, std.wasm.atomicsOpcode(.memory_atomic_notify));
-        try leb.writeULEB128(writer, @as(u32, 2)); // alignment
-        try leb.writeULEB128(writer, @as(u32, 0)); // offset
+        try leb.writeUleb128(writer, std.wasm.atomicsOpcode(.memory_atomic_notify));
+        try leb.writeUleb128(writer, @as(u32, 2)); // alignment
+        try leb.writeUleb128(writer, @as(u32, 0)); // offset
         try writer.writeByte(std.wasm.opcode(.drop));
 
         // branch and drop segments
         try writer.writeByte(std.wasm.opcode(.br));
-        try leb.writeULEB128(writer, @as(u32, 1));
+        try leb.writeUleb128(writer, @as(u32, 1));
 
         // wait for thread to initialize memory segments
         try writer.writeByte(std.wasm.opcode(.end)); // end $wait
         try writeI32Const(writer, flag_address);
         try writeI32Const(writer, 1); // expected flag value
         try writer.writeByte(std.wasm.opcode(.i64_const));
-        try leb.writeILEB128(writer, @as(i64, -1)); // timeout
+        try leb.writeIleb128(writer, @as(i64, -1)); // timeout
         try writer.writeByte(std.wasm.opcode(.atomics_prefix));
-        try leb.writeULEB128(writer, std.wasm.atomicsOpcode(.memory_atomic_wait32));
-        try leb.writeULEB128(writer, @as(u32, 2)); // alignment
-        try leb.writeULEB128(writer, @as(u32, 0)); // offset
+        try leb.writeUleb128(writer, std.wasm.atomicsOpcode(.memory_atomic_wait32));
+        try leb.writeUleb128(writer, @as(u32, 2)); // alignment
+        try leb.writeUleb128(writer, @as(u32, 0)); // offset
         try writer.writeByte(std.wasm.opcode(.drop));
 
         try writer.writeByte(std.wasm.opcode(.end)); // end $drop
@@ -1103,8 +1103,8 @@ fn setupInitMemoryFunction(wasm: *Wasm) !void {
             }
 
             try writer.writeByte(std.wasm.opcode(.misc_prefix));
-            try leb.writeULEB128(writer, std.wasm.miscOpcode(.data_drop));
-            try leb.writeULEB128(writer, segment_index);
+            try leb.writeUleb128(writer, std.wasm.miscOpcode(.data_drop));
+            try leb.writeUleb128(writer, segment_index);
         }
     }
 
@@ -1145,18 +1145,18 @@ fn setupTLSRelocationsFunction(wasm: *Wasm) !void {
         if (sym.tag == .data and sym.isDefined()) {
             // get __tls_base
             try writer.writeByte(std.wasm.opcode(.global_get));
-            try leb.writeULEB128(writer, wasm.findGlobalSymbol("__tls_base").?.getSymbol(wasm).index);
+            try leb.writeUleb128(writer, wasm.findGlobalSymbol("__tls_base").?.getSymbol(wasm).index);
 
             // add the virtual address of the symbol
             try writer.writeByte(std.wasm.opcode(.i32_const));
-            try leb.writeULEB128(writer, sym.virtual_address);
+            try leb.writeUleb128(writer, sym.virtual_address);
         } else if (sym.tag == .function) {
             @panic("TODO: relocate GOT entry of function");
         } else continue;
 
         try writer.writeByte(std.wasm.opcode(.i32_add));
         try writer.writeByte(std.wasm.opcode(.global_set));
-        try leb.writeULEB128(writer, wasm.imported_globals_count + @as(u32, @intCast(wasm.wasm_globals.items.len + got_index)));
+        try leb.writeUleb128(writer, wasm.imported_globals_count + @as(u32, @intCast(wasm.wasm_globals.items.len + got_index)));
     }
     try writer.writeByte(std.wasm.opcode(.end));
 
@@ -1799,7 +1799,7 @@ fn initializeCallCtorsFunction(wasm: *Wasm) !void {
     // Create the function body
     {
         // Write locals count (we have none)
-        try leb.writeULEB128(writer, @as(u32, 0));
+        try leb.writeUleb128(writer, @as(u32, 0));
 
         // call constructors
         for (wasm.init_funcs.items) |init_func_loc| {
@@ -1809,7 +1809,7 @@ fn initializeCallCtorsFunction(wasm: *Wasm) !void {
 
             // Call function by its function index
             try writer.writeByte(std.wasm.opcode(.call));
-            try leb.writeULEB128(writer, symbol.index);
+            try leb.writeUleb128(writer, symbol.index);
 
             // drop all returned values from the stack as __wasm_call_ctors has no return value
             for (ty.returns) |_| {
@@ -1903,31 +1903,31 @@ fn initializeTLSFunction(wasm: *Wasm) !void {
         const param_local: u32 = 0;
 
         try writer.writeByte(std.wasm.opcode(.local_get));
-        try leb.writeULEB128(writer, param_local);
+        try leb.writeUleb128(writer, param_local);
 
         const tls_base_loc = wasm.findGlobalSymbol("__tls_base").?;
         try writer.writeByte(std.wasm.opcode(.global_set));
-        try leb.writeULEB128(writer, tls_base_loc.getSymbol(wasm).index);
+        try leb.writeUleb128(writer, tls_base_loc.getSymbol(wasm).index);
 
         // load stack values for the bulk-memory operation
         {
             try writer.writeByte(std.wasm.opcode(.local_get));
-            try leb.writeULEB128(writer, param_local);
+            try leb.writeUleb128(writer, param_local);
 
             try writer.writeByte(std.wasm.opcode(.i32_const));
-            try leb.writeULEB128(writer, @as(u32, 0)); //segment offset
+            try leb.writeUleb128(writer, @as(u32, 0)); //segment offset
 
             try writer.writeByte(std.wasm.opcode(.i32_const));
-            try leb.writeULEB128(writer, @as(u32, segment.size)); //segment offset
+            try leb.writeUleb128(writer, @as(u32, segment.size)); //segment offset
         }
 
         // perform the bulk-memory operation to initialize the data segment
         try writer.writeByte(std.wasm.opcode(.misc_prefix));
-        try leb.writeULEB128(writer, std.wasm.miscOpcode(.memory_init));
+        try leb.writeUleb128(writer, std.wasm.miscOpcode(.memory_init));
         // segment immediate
-        try leb.writeULEB128(writer, @as(u32, @intCast(data_index)));
+        try leb.writeUleb128(writer, @as(u32, @intCast(data_index)));
         // memory index immediate (always 0)
-        try leb.writeULEB128(writer, @as(u32, 0));
+        try leb.writeUleb128(writer, @as(u32, 0));
     }
 
     // If we have to perform any TLS relocations, call the corresponding function
@@ -1935,7 +1935,7 @@ fn initializeTLSFunction(wasm: *Wasm) !void {
     // generated by the linker.
     if (wasm.findGlobalSymbol("__wasm_apply_global_tls_relocs")) |loc| {
         try writer.writeByte(std.wasm.opcode(.call));
-        try leb.writeULEB128(writer, loc.getSymbol(wasm).index);
+        try leb.writeUleb128(writer, loc.getSymbol(wasm).index);
         loc.getSymbol(wasm).mark();
     }
 
@@ -2640,14 +2640,14 @@ fn writeToFile(
         const header_offset = try reserveVecSectionHeader(&binary_bytes);
         log.debug("Writing type section. Count: ({d})", .{wasm.func_types.items.len});
         for (wasm.func_types.items) |func_type| {
-            try leb.writeULEB128(binary_writer, std.wasm.function_type);
-            try leb.writeULEB128(binary_writer, @as(u32, @intCast(func_type.params.len)));
+            try leb.writeUleb128(binary_writer, std.wasm.function_type);
+            try leb.writeUleb128(binary_writer, @as(u32, @intCast(func_type.params.len)));
             for (func_type.params) |param_ty| {
-                try leb.writeULEB128(binary_writer, std.wasm.valtype(param_ty));
+                try leb.writeUleb128(binary_writer, std.wasm.valtype(param_ty));
             }
-            try leb.writeULEB128(binary_writer, @as(u32, @intCast(func_type.returns.len)));
+            try leb.writeUleb128(binary_writer, @as(u32, @intCast(func_type.returns.len)));
             for (func_type.returns) |ret_ty| {
-                try leb.writeULEB128(binary_writer, std.wasm.valtype(ret_ty));
+                try leb.writeUleb128(binary_writer, std.wasm.valtype(ret_ty));
             }
         }
 
@@ -2696,7 +2696,7 @@ fn writeToFile(
     if (wasm.functions.count() != 0) {
         const header_offset = try reserveVecSectionHeader(&binary_bytes);
         for (wasm.functions.values()) |function| {
-            try leb.writeULEB128(binary_writer, function.func.type_index);
+            try leb.writeUleb128(binary_writer, function.func.type_index);
         }
 
         try writeVecSectionHeader(
@@ -2714,7 +2714,7 @@ fn writeToFile(
         const header_offset = try reserveVecSectionHeader(&binary_bytes);
 
         for (wasm.tables.items) |table| {
-            try leb.writeULEB128(binary_writer, std.wasm.reftype(table.reftype));
+            try leb.writeUleb128(binary_writer, std.wasm.reftype(table.reftype));
             try emitLimits(binary_writer, table.limits);
         }
 
@@ -2769,17 +2769,17 @@ fn writeToFile(
 
         for (wasm.exports.items) |exp| {
             const name = wasm.string_table.get(exp.name);
-            try leb.writeULEB128(binary_writer, @as(u32, @intCast(name.len)));
+            try leb.writeUleb128(binary_writer, @as(u32, @intCast(name.len)));
             try binary_writer.writeAll(name);
-            try leb.writeULEB128(binary_writer, @intFromEnum(exp.kind));
-            try leb.writeULEB128(binary_writer, exp.index);
+            try leb.writeUleb128(binary_writer, @intFromEnum(exp.kind));
+            try leb.writeUleb128(binary_writer, exp.index);
         }
 
         if (export_memory) {
-            try leb.writeULEB128(binary_writer, @as(u32, @intCast("memory".len)));
+            try leb.writeUleb128(binary_writer, @as(u32, @intCast("memory".len)));
             try binary_writer.writeAll("memory");
             try binary_writer.writeByte(std.wasm.externalKind(.memory));
-            try leb.writeULEB128(binary_writer, @as(u32, 0));
+            try leb.writeUleb128(binary_writer, @as(u32, 0));
         }
 
         try writeVecSectionHeader(
@@ -2811,21 +2811,21 @@ fn writeToFile(
         const table_sym = table_loc.getSymbol(wasm);
 
         const flags: u32 = if (table_sym.index == 0) 0x0 else 0x02; // passive with implicit 0-index table or set table index manually
-        try leb.writeULEB128(binary_writer, flags);
+        try leb.writeUleb128(binary_writer, flags);
         if (flags == 0x02) {
-            try leb.writeULEB128(binary_writer, table_sym.index);
+            try leb.writeUleb128(binary_writer, table_sym.index);
         }
         try emitInit(binary_writer, .{ .i32_const = 1 }); // We start at index 1, so unresolved function pointers are invalid
         if (flags == 0x02) {
-            try leb.writeULEB128(binary_writer, @as(u8, 0)); // represents funcref
+            try leb.writeUleb128(binary_writer, @as(u8, 0)); // represents funcref
         }
-        try leb.writeULEB128(binary_writer, @as(u32, @intCast(wasm.function_table.count())));
+        try leb.writeUleb128(binary_writer, @as(u32, @intCast(wasm.function_table.count())));
         var symbol_it = wasm.function_table.keyIterator();
         while (symbol_it.next()) |symbol_loc_ptr| {
             const sym = symbol_loc_ptr.getSymbol(wasm);
             std.debug.assert(sym.isAlive());
             std.debug.assert(sym.index < wasm.functions.count() + wasm.imported_functions_count);
-            try leb.writeULEB128(binary_writer, sym.index);
+            try leb.writeUleb128(binary_writer, sym.index);
         }
 
         try writeVecSectionHeader(
@@ -2866,7 +2866,7 @@ fn writeToFile(
                 atom.resolveRelocs(wasm);
             }
             atom.offset = @intCast(binary_bytes.items.len - start_offset);
-            try leb.writeULEB128(binary_writer, atom.size);
+            try leb.writeUleb128(binary_writer, atom.size);
             try binary_writer.writeAll(atom.code.items);
         }
 
@@ -2897,16 +2897,16 @@ fn writeToFile(
             segment_count += 1;
             var atom_index = wasm.atoms.get(segment_index).?;
 
-            try leb.writeULEB128(binary_writer, segment.flags);
+            try leb.writeUleb128(binary_writer, segment.flags);
             if (segment.flags & @intFromEnum(Wasm.Segment.Flag.WASM_DATA_SEGMENT_HAS_MEMINDEX) != 0) {
-                try leb.writeULEB128(binary_writer, @as(u32, 0)); // memory is always index 0 as we only have 1 memory entry
+                try leb.writeUleb128(binary_writer, @as(u32, 0)); // memory is always index 0 as we only have 1 memory entry
             }
             // when a segment is passive, it's initialized during runtime.
             if (!segment.isPassive()) {
                 try emitInit(binary_writer, .{ .i32_const = @as(i32, @bitCast(segment.offset)) });
             }
             // offset into data section
-            try leb.writeULEB128(binary_writer, segment.size);
+            try leb.writeUleb128(binary_writer, segment.size);
 
             // fill in the offset table and the data segments
             var current_offset: u32 = 0;
@@ -3056,7 +3056,7 @@ fn emitDebugSection(binary_bytes: *std.ArrayList(u8), data: []const u8, name: []
     if (data.len == 0) return;
     const header_offset = try reserveCustomSectionHeader(binary_bytes);
     const writer = binary_bytes.writer();
-    try leb.writeULEB128(writer, @as(u32, @intCast(name.len)));
+    try leb.writeUleb128(writer, @as(u32, @intCast(name.len)));
     try writer.writeAll(name);
 
     const start = binary_bytes.items.len - header_offset;
@@ -3075,10 +3075,10 @@ fn emitProducerSection(binary_bytes: *std.ArrayList(u8)) !void {
 
     const writer = binary_bytes.writer();
     const producers = "producers";
-    try leb.writeULEB128(writer, @as(u32, @intCast(producers.len)));
+    try leb.writeUleb128(writer, @as(u32, @intCast(producers.len)));
     try writer.writeAll(producers);
 
-    try leb.writeULEB128(writer, @as(u32, 2)); // 2 fields: Language + processed-by
+    try leb.writeUleb128(writer, @as(u32, 2)); // 2 fields: Language + processed-by
 
     // used for the Zig version
     var version_buf: [100]u8 = undefined;
@@ -3087,18 +3087,18 @@ fn emitProducerSection(binary_bytes: *std.ArrayList(u8)) !void {
     // language field
     {
         const language = "language";
-        try leb.writeULEB128(writer, @as(u32, @intCast(language.len)));
+        try leb.writeUleb128(writer, @as(u32, @intCast(language.len)));
         try writer.writeAll(language);
 
         // field_value_count (TODO: Parse object files for producer sections to detect their language)
-        try leb.writeULEB128(writer, @as(u32, 1));
+        try leb.writeUleb128(writer, @as(u32, 1));
 
         // versioned name
         {
-            try leb.writeULEB128(writer, @as(u32, 3)); // len of "Zig"
+            try leb.writeUleb128(writer, @as(u32, 3)); // len of "Zig"
             try writer.writeAll("Zig");
 
-            try leb.writeULEB128(writer, @as(u32, @intCast(version.len)));
+            try leb.writeUleb128(writer, @as(u32, @intCast(version.len)));
             try writer.writeAll(version);
         }
     }
@@ -3106,18 +3106,18 @@ fn emitProducerSection(binary_bytes: *std.ArrayList(u8)) !void {
     // processed-by field
     {
         const processed_by = "processed-by";
-        try leb.writeULEB128(writer, @as(u32, @intCast(processed_by.len)));
+        try leb.writeUleb128(writer, @as(u32, @intCast(processed_by.len)));
         try writer.writeAll(processed_by);
 
         // field_value_count (TODO: Parse object files for producer sections to detect other used tools)
-        try leb.writeULEB128(writer, @as(u32, 1));
+        try leb.writeUleb128(writer, @as(u32, 1));
 
         // versioned name
         {
-            try leb.writeULEB128(writer, @as(u32, 3)); // len of "Zig"
+            try leb.writeUleb128(writer, @as(u32, 3)); // len of "Zig"
             try writer.writeAll("Zig");
 
-            try leb.writeULEB128(writer, @as(u32, @intCast(version.len)));
+            try leb.writeUleb128(writer, @as(u32, @intCast(version.len)));
             try writer.writeAll(version);
         }
     }
@@ -3134,11 +3134,11 @@ fn emitBuildIdSection(binary_bytes: *std.ArrayList(u8), build_id: []const u8) !v
 
     const writer = binary_bytes.writer();
     const hdr_build_id = "build_id";
-    try leb.writeULEB128(writer, @as(u32, @intCast(hdr_build_id.len)));
+    try leb.writeUleb128(writer, @as(u32, @intCast(hdr_build_id.len)));
     try writer.writeAll(hdr_build_id);
 
-    try leb.writeULEB128(writer, @as(u32, 1));
-    try leb.writeULEB128(writer, @as(u32, @intCast(build_id.len)));
+    try leb.writeUleb128(writer, @as(u32, 1));
+    try leb.writeUleb128(writer, @as(u32, @intCast(build_id.len)));
     try writer.writeAll(build_id);
 
     try writeCustomSectionHeader(
@@ -3153,17 +3153,17 @@ fn emitFeaturesSection(binary_bytes: *std.ArrayList(u8), enabled_features: []con
 
     const writer = binary_bytes.writer();
     const target_features = "target_features";
-    try leb.writeULEB128(writer, @as(u32, @intCast(target_features.len)));
+    try leb.writeUleb128(writer, @as(u32, @intCast(target_features.len)));
     try writer.writeAll(target_features);
 
-    try leb.writeULEB128(writer, features_count);
+    try leb.writeUleb128(writer, features_count);
     for (enabled_features, 0..) |enabled, feature_index| {
         if (enabled) {
             const feature: types.Feature = .{ .prefix = .used, .tag = @as(types.Feature.Tag, @enumFromInt(feature_index)) };
-            try leb.writeULEB128(writer, @intFromEnum(feature.prefix));
+            try leb.writeUleb128(writer, @intFromEnum(feature.prefix));
             var buf: [100]u8 = undefined;
             const string = try std.fmt.bufPrint(&buf, "{}", .{feature.tag});
-            try leb.writeULEB128(writer, @as(u32, @intCast(string.len)));
+            try leb.writeUleb128(writer, @as(u32, @intCast(string.len)));
             try writer.writeAll(string);
         }
     }
@@ -3226,7 +3226,7 @@ fn emitNameSection(wasm: *Wasm, binary_bytes: *std.ArrayList(u8), arena: std.mem
 
     const header_offset = try reserveCustomSectionHeader(binary_bytes);
     const writer = binary_bytes.writer();
-    try leb.writeULEB128(writer, @as(u32, @intCast("name".len)));
+    try leb.writeUleb128(writer, @as(u32, @intCast("name".len)));
     try writer.writeAll("name");
 
     try wasm.emitNameSubsection(.function, funcs.values(), writer);
@@ -3248,25 +3248,25 @@ fn emitNameSubsection(wasm: *Wasm, section_id: std.wasm.NameSubsection, names: a
     defer section_list.deinit();
     const sub_writer = section_list.writer();
 
-    try leb.writeULEB128(sub_writer, @as(u32, @intCast(names.len)));
+    try leb.writeUleb128(sub_writer, @as(u32, @intCast(names.len)));
     for (names) |name| {
         log.debug("Emit symbol '{s}' type({s})", .{ name.name, @tagName(section_id) });
-        try leb.writeULEB128(sub_writer, name.index);
-        try leb.writeULEB128(sub_writer, @as(u32, @intCast(name.name.len)));
+        try leb.writeUleb128(sub_writer, name.index);
+        try leb.writeUleb128(sub_writer, @as(u32, @intCast(name.name.len)));
         try sub_writer.writeAll(name.name);
     }
 
     // From now, write to the actual writer
-    try leb.writeULEB128(writer, @intFromEnum(section_id));
-    try leb.writeULEB128(writer, @as(u32, @intCast(section_list.items.len)));
+    try leb.writeUleb128(writer, @intFromEnum(section_id));
+    try leb.writeUleb128(writer, @as(u32, @intCast(section_list.items.len)));
     try writer.writeAll(section_list.items);
 }
 
 fn emitLimits(writer: anytype, limits: std.wasm.Limits) !void {
     try writer.writeByte(limits.flags);
-    try leb.writeULEB128(writer, limits.min);
+    try leb.writeUleb128(writer, limits.min);
     if (limits.hasFlag(.WASM_LIMITS_FLAG_HAS_MAX)) {
-        try leb.writeULEB128(writer, limits.max);
+        try leb.writeUleb128(writer, limits.max);
     }
 }
 
@@ -3274,11 +3274,11 @@ fn emitInit(writer: anytype, init_expr: std.wasm.InitExpression) !void {
     switch (init_expr) {
         .i32_const => |val| {
             try writer.writeByte(std.wasm.opcode(.i32_const));
-            try leb.writeILEB128(writer, val);
+            try leb.writeIleb128(writer, val);
         },
         .i64_const => |val| {
             try writer.writeByte(std.wasm.opcode(.i64_const));
-            try leb.writeILEB128(writer, val);
+            try leb.writeIleb128(writer, val);
         },
         .f32_const => |val| {
             try writer.writeByte(std.wasm.opcode(.f32_const));
@@ -3290,7 +3290,7 @@ fn emitInit(writer: anytype, init_expr: std.wasm.InitExpression) !void {
         },
         .global_get => |val| {
             try writer.writeByte(std.wasm.opcode(.global_get));
-            try leb.writeULEB128(writer, val);
+            try leb.writeUleb128(writer, val);
         },
     }
     try writer.writeByte(std.wasm.opcode(.end));
@@ -3298,22 +3298,22 @@ fn emitInit(writer: anytype, init_expr: std.wasm.InitExpression) !void {
 
 fn emitImport(wasm: *Wasm, writer: anytype, import: types.Import) !void {
     const module_name = wasm.string_table.get(import.module_name);
-    try leb.writeULEB128(writer, @as(u32, @intCast(module_name.len)));
+    try leb.writeUleb128(writer, @as(u32, @intCast(module_name.len)));
     try writer.writeAll(module_name);
 
     const name = wasm.string_table.get(import.name);
-    try leb.writeULEB128(writer, @as(u32, @intCast(name.len)));
+    try leb.writeUleb128(writer, @as(u32, @intCast(name.len)));
     try writer.writeAll(name);
 
     try writer.writeByte(@intFromEnum(import.kind));
     switch (import.kind) {
-        .function => |type_index| try leb.writeULEB128(writer, type_index),
+        .function => |type_index| try leb.writeUleb128(writer, type_index),
         .global => |global_type| {
-            try leb.writeULEB128(writer, std.wasm.valtype(global_type.valtype));
+            try leb.writeUleb128(writer, std.wasm.valtype(global_type.valtype));
             try writer.writeByte(@intFromBool(global_type.mutable));
         },
         .table => |table| {
-            try leb.writeULEB128(writer, std.wasm.reftype(table.reftype));
+            try leb.writeUleb128(writer, std.wasm.reftype(table.reftype));
             try emitLimits(writer, table.limits);
         },
         .memory => |limits| {
@@ -3765,11 +3765,11 @@ fn emitLinkSection(wasm: *Wasm, binary_bytes: *std.ArrayList(u8), symbol_table: 
     const writer = binary_bytes.writer();
     // emit "linking" custom section name
     const section_name = "linking";
-    try leb.writeULEB128(writer, section_name.len);
+    try leb.writeUleb128(writer, section_name.len);
     try writer.writeAll(section_name);
 
     // meta data version, which is currently '2'
-    try leb.writeULEB128(writer, @as(u32, 2));
+    try leb.writeUleb128(writer, @as(u32, 2));
 
     // For each subsection type (found in types.Subsection) we can emit a section.
     // Currently, we only support emitting segment info and the symbol table.
@@ -3783,7 +3783,7 @@ fn emitLinkSection(wasm: *Wasm, binary_bytes: *std.ArrayList(u8), symbol_table: 
 fn emitSymbolTable(wasm: *Wasm, binary_bytes: *std.ArrayList(u8), symbol_table: *std.AutoArrayHashMap(SymbolLoc, u32)) !void {
     const writer = binary_bytes.writer();
 
-    try leb.writeULEB128(writer, @intFromEnum(types.SubsectionType.WASM_SYMBOL_TABLE));
+    try leb.writeUleb128(writer, @intFromEnum(types.SubsectionType.WASM_SYMBOL_TABLE));
     const table_offset = binary_bytes.items.len;
 
     var symbol_count: u32 = 0;
@@ -3793,30 +3793,30 @@ fn emitSymbolTable(wasm: *Wasm, binary_bytes: *std.ArrayList(u8), symbol_table: 
         try symbol_table.putNoClobber(sym_loc, symbol_count);
         symbol_count += 1;
         log.debug("Emit symbol: {}", .{symbol});
-        try leb.writeULEB128(writer, @intFromEnum(symbol.tag));
-        try leb.writeULEB128(writer, symbol.flags);
+        try leb.writeUleb128(writer, @intFromEnum(symbol.tag));
+        try leb.writeUleb128(writer, symbol.flags);
 
         const sym_name = sym_loc.getName(wasm);
         switch (symbol.tag) {
             .data => {
-                try leb.writeULEB128(writer, @as(u32, @intCast(sym_name.len)));
+                try leb.writeUleb128(writer, @as(u32, @intCast(sym_name.len)));
                 try writer.writeAll(sym_name);
 
                 if (symbol.isDefined()) {
-                    try leb.writeULEB128(writer, symbol.index);
+                    try leb.writeUleb128(writer, symbol.index);
                     const atom_index = wasm.symbol_atom.get(sym_loc).?;
                     const atom = wasm.getAtom(atom_index);
-                    try leb.writeULEB128(writer, @as(u32, atom.offset));
-                    try leb.writeULEB128(writer, @as(u32, atom.size));
+                    try leb.writeUleb128(writer, @as(u32, atom.offset));
+                    try leb.writeUleb128(writer, @as(u32, atom.size));
                 }
             },
             .section => {
-                try leb.writeULEB128(writer, symbol.index);
+                try leb.writeUleb128(writer, symbol.index);
             },
             else => {
-                try leb.writeULEB128(writer, symbol.index);
+                try leb.writeUleb128(writer, symbol.index);
                 if (symbol.isDefined()) {
-                    try leb.writeULEB128(writer, @as(u32, @intCast(sym_name.len)));
+                    try leb.writeUleb128(writer, @as(u32, @intCast(sym_name.len)));
                     try writer.writeAll(sym_name);
                 }
             },
@@ -3831,20 +3831,20 @@ fn emitSymbolTable(wasm: *Wasm, binary_bytes: *std.ArrayList(u8), symbol_table: 
 
 fn emitSegmentInfo(wasm: *Wasm, binary_bytes: *std.ArrayList(u8)) !void {
     const writer = binary_bytes.writer();
-    try leb.writeULEB128(writer, @intFromEnum(types.SubsectionType.WASM_SEGMENT_INFO));
+    try leb.writeUleb128(writer, @intFromEnum(types.SubsectionType.WASM_SEGMENT_INFO));
     const segment_offset = binary_bytes.items.len;
 
-    try leb.writeULEB128(writer, @as(u32, @intCast(wasm.segment_info.count())));
+    try leb.writeUleb128(writer, @as(u32, @intCast(wasm.segment_info.count())));
     for (wasm.segment_info.values()) |segment_info| {
         log.debug("Emit segment: {s} align({d}) flags({b})", .{
             segment_info.name,
             segment_info.alignment,
             segment_info.flags,
         });
-        try leb.writeULEB128(writer, @as(u32, @intCast(segment_info.name.len)));
+        try leb.writeUleb128(writer, @as(u32, @intCast(segment_info.name.len)));
         try writer.writeAll(segment_info.name);
-        try leb.writeULEB128(writer, segment_info.alignment.toLog2Units());
-        try leb.writeULEB128(writer, segment_info.flags);
+        try leb.writeUleb128(writer, segment_info.alignment.toLog2Units());
+        try leb.writeUleb128(writer, segment_info.flags);
     }
 
     var buf: [5]u8 = undefined;
@@ -3852,7 +3852,7 @@ fn emitSegmentInfo(wasm: *Wasm, binary_bytes: *std.ArrayList(u8)) !void {
     try binary_bytes.insertSlice(segment_offset, &buf);
 }
 
-pub fn getULEB128Size(uint_value: anytype) u32 {
+pub fn getUleb128Size(uint_value: anytype) u32 {
     const T = @TypeOf(uint_value);
     const U = if (@typeInfo(T).Int.bits < 8) u8 else T;
     var value = @as(U, @intCast(uint_value));
@@ -3877,9 +3877,9 @@ fn emitCodeRelocations(
 
     // write custom section information
     const name = "reloc.CODE";
-    try leb.writeULEB128(writer, @as(u32, @intCast(name.len)));
+    try leb.writeUleb128(writer, @as(u32, @intCast(name.len)));
     try writer.writeAll(name);
-    try leb.writeULEB128(writer, section_index);
+    try leb.writeUleb128(writer, section_index);
     const reloc_start = binary_bytes.items.len;
 
     var count: u32 = 0;
@@ -3887,17 +3887,17 @@ fn emitCodeRelocations(
     // for each atom, we calculate the uleb size and append that
     var size_offset: u32 = 5; // account for code section size leb128
     while (true) {
-        size_offset += getULEB128Size(atom.size);
+        size_offset += getUleb128Size(atom.size);
         for (atom.relocs.items) |relocation| {
             count += 1;
             const sym_loc: SymbolLoc = .{ .file = atom.file, .index = @enumFromInt(relocation.index) };
             const symbol_index = symbol_table.get(sym_loc).?;
-            try leb.writeULEB128(writer, @intFromEnum(relocation.relocation_type));
+            try leb.writeUleb128(writer, @intFromEnum(relocation.relocation_type));
             const offset = atom.offset + relocation.offset + size_offset;
-            try leb.writeULEB128(writer, offset);
-            try leb.writeULEB128(writer, symbol_index);
+            try leb.writeUleb128(writer, offset);
+            try leb.writeUleb128(writer, symbol_index);
             if (relocation.relocation_type.addendIsPresent()) {
-                try leb.writeILEB128(writer, relocation.addend);
+                try leb.writeIleb128(writer, relocation.addend);
             }
             log.debug("Emit relocation: {}", .{relocation});
         }
@@ -3924,9 +3924,9 @@ fn emitDataRelocations(
 
     // write custom section information
     const name = "reloc.DATA";
-    try leb.writeULEB128(writer, @as(u32, @intCast(name.len)));
+    try leb.writeUleb128(writer, @as(u32, @intCast(name.len)));
     try writer.writeAll(name);
-    try leb.writeULEB128(writer, section_index);
+    try leb.writeUleb128(writer, section_index);
     const reloc_start = binary_bytes.items.len;
 
     var count: u32 = 0;
@@ -3935,17 +3935,17 @@ fn emitDataRelocations(
     for (wasm.data_segments.values()) |segment_index| {
         var atom: *Atom = wasm.getAtomPtr(wasm.atoms.get(segment_index).?);
         while (true) {
-            size_offset += getULEB128Size(atom.size);
+            size_offset += getUleb128Size(atom.size);
             for (atom.relocs.items) |relocation| {
                 count += 1;
                 const sym_loc: SymbolLoc = .{ .file = atom.file, .index = @enumFromInt(relocation.index) };
                 const symbol_index = symbol_table.get(sym_loc).?;
-                try leb.writeULEB128(writer, @intFromEnum(relocation.relocation_type));
+                try leb.writeUleb128(writer, @intFromEnum(relocation.relocation_type));
                 const offset = atom.offset + relocation.offset + size_offset;
-                try leb.writeULEB128(writer, offset);
-                try leb.writeULEB128(writer, symbol_index);
+                try leb.writeUleb128(writer, offset);
+                try leb.writeUleb128(writer, symbol_index);
                 if (relocation.relocation_type.addendIsPresent()) {
-                    try leb.writeILEB128(writer, relocation.addend);
+                    try leb.writeIleb128(writer, relocation.addend);
                 }
                 log.debug("Emit relocation: {}", .{relocation});
             }

--- a/src/link/Wasm/Object.zig
+++ b/src/link/Wasm/Object.zig
@@ -590,7 +590,7 @@ fn Parser(comptime ReaderType: type) type {
             const reader = parser.reader.reader();
             for (try readVec(&parser.object.features, reader, gpa)) |*feature| {
                 const prefix = try readEnum(types.Feature.Prefix, reader);
-                const name_len = try leb.readULEB128(u32, reader);
+                const name_len = try leb.readUleb128(u32, reader);
                 const name = try gpa.alloc(u8, name_len);
                 defer gpa.free(name);
                 try reader.readNoEof(name);
@@ -613,8 +613,8 @@ fn Parser(comptime ReaderType: type) type {
         /// they apply to.
         fn parseRelocations(parser: *ObjectParser, gpa: Allocator) !void {
             const reader = parser.reader.reader();
-            const section = try leb.readULEB128(u32, reader);
-            const count = try leb.readULEB128(u32, reader);
+            const section = try leb.readUleb128(u32, reader);
+            const count = try leb.readUleb128(u32, reader);
             const relocations = try gpa.alloc(types.Relocation, count);
             errdefer gpa.free(relocations);
 
@@ -628,9 +628,9 @@ fn Parser(comptime ReaderType: type) type {
                 const rel_type_enum = std.meta.intToEnum(types.Relocation.RelocationType, rel_type) catch return error.MalformedSection;
                 relocation.* = .{
                     .relocation_type = rel_type_enum,
-                    .offset = try leb.readULEB128(u32, reader),
-                    .index = try leb.readULEB128(u32, reader),
-                    .addend = if (rel_type_enum.addendIsPresent()) try leb.readILEB128(i32, reader) else 0,
+                    .offset = try leb.readUleb128(u32, reader),
+                    .index = try leb.readUleb128(u32, reader),
+                    .addend = if (rel_type_enum.addendIsPresent()) try leb.readIleb128(i32, reader) else 0,
                 };
                 log.debug("Found relocation: type({s}) offset({d}) index({d}) addend({?d})", .{
                     @tagName(relocation.relocation_type),
@@ -651,7 +651,7 @@ fn Parser(comptime ReaderType: type) type {
             var limited = std.io.limitedReader(parser.reader.reader(), payload_size);
             const limited_reader = limited.reader();
 
-            const version = try leb.readULEB128(u32, limited_reader);
+            const version = try leb.readUleb128(u32, limited_reader);
             log.debug("Link meta data version: {d}", .{version});
             if (version != 2) return error.UnsupportedVersion;
 
@@ -667,30 +667,30 @@ fn Parser(comptime ReaderType: type) type {
         /// `parser` is used to provide access to other sections that may be needed,
         /// such as access to the `import` section to find the name of a symbol.
         fn parseSubsection(parser: *ObjectParser, gpa: Allocator, reader: anytype) !void {
-            const sub_type = try leb.readULEB128(u8, reader);
+            const sub_type = try leb.readUleb128(u8, reader);
             log.debug("Found subsection: {s}", .{@tagName(@as(types.SubsectionType, @enumFromInt(sub_type)))});
-            const payload_len = try leb.readULEB128(u32, reader);
+            const payload_len = try leb.readUleb128(u32, reader);
             if (payload_len == 0) return;
 
             var limited = std.io.limitedReader(reader, payload_len);
             const limited_reader = limited.reader();
 
             // every subsection contains a 'count' field
-            const count = try leb.readULEB128(u32, limited_reader);
+            const count = try leb.readUleb128(u32, limited_reader);
 
             switch (@as(types.SubsectionType, @enumFromInt(sub_type))) {
                 .WASM_SEGMENT_INFO => {
                     const segments = try gpa.alloc(types.Segment, count);
                     errdefer gpa.free(segments);
                     for (segments) |*segment| {
-                        const name_len = try leb.readULEB128(u32, reader);
+                        const name_len = try leb.readUleb128(u32, reader);
                         const name = try gpa.alloc(u8, name_len);
                         errdefer gpa.free(name);
                         try reader.readNoEof(name);
                         segment.* = .{
                             .name = name,
-                            .alignment = @enumFromInt(try leb.readULEB128(u32, reader)),
-                            .flags = try leb.readULEB128(u32, reader),
+                            .alignment = @enumFromInt(try leb.readUleb128(u32, reader)),
+                            .flags = try leb.readUleb128(u32, reader),
                         };
                         log.debug("Found segment: {s} align({d}) flags({b})", .{
                             segment.name,
@@ -711,8 +711,8 @@ fn Parser(comptime ReaderType: type) type {
                     errdefer gpa.free(funcs);
                     for (funcs) |*func| {
                         func.* = .{
-                            .priority = try leb.readULEB128(u32, reader),
-                            .symbol_index = try leb.readULEB128(u32, reader),
+                            .priority = try leb.readUleb128(u32, reader),
+                            .symbol_index = try leb.readUleb128(u32, reader),
                         };
                         log.debug("Found function - prio: {d}, index: {d}", .{ func.priority, func.symbol_index });
                     }
@@ -722,23 +722,23 @@ fn Parser(comptime ReaderType: type) type {
                     const comdats = try gpa.alloc(types.Comdat, count);
                     errdefer gpa.free(comdats);
                     for (comdats) |*comdat| {
-                        const name_len = try leb.readULEB128(u32, reader);
+                        const name_len = try leb.readUleb128(u32, reader);
                         const name = try gpa.alloc(u8, name_len);
                         errdefer gpa.free(name);
                         try reader.readNoEof(name);
 
-                        const flags = try leb.readULEB128(u32, reader);
+                        const flags = try leb.readUleb128(u32, reader);
                         if (flags != 0) {
                             return error.UnexpectedValue;
                         }
 
-                        const symbol_count = try leb.readULEB128(u32, reader);
+                        const symbol_count = try leb.readUleb128(u32, reader);
                         const symbols = try gpa.alloc(types.ComdatSym, symbol_count);
                         errdefer gpa.free(symbols);
                         for (symbols) |*symbol| {
                             symbol.* = .{
-                                .kind = @as(types.ComdatSym.Type, @enumFromInt(try leb.readULEB128(u8, reader))),
-                                .index = try leb.readULEB128(u32, reader),
+                                .kind = @as(types.ComdatSym.Type, @enumFromInt(try leb.readUleb128(u8, reader))),
+                                .index = try leb.readUleb128(u32, reader),
                             };
                         }
 
@@ -799,8 +799,8 @@ fn Parser(comptime ReaderType: type) type {
         /// requires access to `Object` to find the name of a symbol when it's
         /// an import and flag `WASM_SYM_EXPLICIT_NAME` is not set.
         fn parseSymbol(parser: *ObjectParser, gpa: Allocator, reader: anytype) !Symbol {
-            const tag = @as(Symbol.Tag, @enumFromInt(try leb.readULEB128(u8, reader)));
-            const flags = try leb.readULEB128(u32, reader);
+            const tag = @as(Symbol.Tag, @enumFromInt(try leb.readUleb128(u8, reader)));
+            const flags = try leb.readUleb128(u32, reader);
             var symbol: Symbol = .{
                 .flags = flags,
                 .tag = tag,
@@ -811,7 +811,7 @@ fn Parser(comptime ReaderType: type) type {
 
             switch (tag) {
                 .data => {
-                    const name_len = try leb.readULEB128(u32, reader);
+                    const name_len = try leb.readUleb128(u32, reader);
                     const name = try gpa.alloc(u8, name_len);
                     defer gpa.free(name);
                     try reader.readNoEof(name);
@@ -819,14 +819,14 @@ fn Parser(comptime ReaderType: type) type {
 
                     // Data symbols only have the following fields if the symbol is defined
                     if (symbol.isDefined()) {
-                        symbol.index = try leb.readULEB128(u32, reader);
+                        symbol.index = try leb.readUleb128(u32, reader);
                         // @TODO: We should verify those values
-                        _ = try leb.readULEB128(u32, reader);
-                        _ = try leb.readULEB128(u32, reader);
+                        _ = try leb.readUleb128(u32, reader);
+                        _ = try leb.readUleb128(u32, reader);
                     }
                 },
                 .section => {
-                    symbol.index = try leb.readULEB128(u32, reader);
+                    symbol.index = try leb.readUleb128(u32, reader);
                     const section_data = parser.object.relocatable_data.get(.custom).?;
                     for (section_data) |*data| {
                         if (data.section_index == symbol.index) {
@@ -837,11 +837,11 @@ fn Parser(comptime ReaderType: type) type {
                     }
                 },
                 else => {
-                    symbol.index = try leb.readULEB128(u32, reader);
+                    symbol.index = try leb.readUleb128(u32, reader);
                     const is_undefined = symbol.isUndefined();
                     const explicit_name = symbol.hasFlag(.WASM_SYM_EXPLICIT_NAME);
                     symbol.name = if (!is_undefined or (is_undefined and explicit_name)) name: {
-                        const name_len = try leb.readULEB128(u32, reader);
+                        const name_len = try leb.readUleb128(u32, reader);
                         const name = try gpa.alloc(u8, name_len);
                         defer gpa.free(name);
                         try reader.readNoEof(name);
@@ -867,13 +867,13 @@ fn ElementType(comptime ptr: type) type {
     return meta.Elem(meta.Child(ptr));
 }
 
-/// Uses either `readILEB128` or `readULEB128` depending on the
+/// Uses either `readIleb128` or `readUleb128` depending on the
 /// signedness of the given type `T`.
 /// Asserts `T` is an integer.
 fn readLeb(comptime T: type, reader: anytype) !T {
     return switch (@typeInfo(T).Int.signedness) {
-        .signed => try leb.readILEB128(T, reader),
-        .unsigned => try leb.readULEB128(T, reader),
+        .signed => try leb.readIleb128(T, reader),
+        .unsigned => try leb.readUleb128(T, reader),
     };
 }
 


### PR DESCRIPTION
From Zig's style guide, names like `readULEB128` and `writeILEB128` should be cased as `readUleb128` and `writeIleb128`, respectively.