### PR TITLE
std: fuzz test sort stability

### DIFF
--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -384,8 +384,7 @@ test "sort fuzz testing" {
     const test_case_count = 10;
 
     inline for (sort_funcs) |sortFn| {
-        var i: usize = 0;
-        while (i < test_case_count) : (i += 1) {
+        for (0..test_case_count) |_| {
             const array_size = random.intRangeLessThan(usize, 0, 1000);
             const array = try testing.allocator.alloc(i32, array_size);
             defer testing.allocator.free(array);

--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -222,6 +222,35 @@ test "stable sort" {
     }
 }
 
+test "stable sort fuzz testing" {
+    var prng = std.Random.DefaultPrng.init(0x12345678);
+    const random = prng.random();
+    const test_case_count = 10;
+
+    for (0..test_case_count) |_| {
+        const array_size = random.intRangeLessThan(usize, 0, 1000);
+        const array = try testing.allocator.alloc(IdAndValue, array_size);
+        defer testing.allocator.free(array);
+        // Value is a small random numbers to create collisions.
+        // Id is a  reverse index to make sure sorting function only uses provided `lessThan`.
+        for (array, 0..) |*item, index| {
+            item.* = .{
+                .value = random.intRangeLessThan(i32, 0, 100),
+                .id = array_size - index,
+            };
+        }
+        block(IdAndValue, array, {}, IdAndValue.lessThan);
+        if (array_size > 0) {
+            for (array[0 .. array_size - 1], array[1..]) |x, y| {
+                try testing.expect(x.value <= y.value);
+                if (x.value == y.value) {
+                    try testing.expect(x.id > y.id);
+                }
+            }
+        }
+    }
+}
+
 test "sort" {
     const u8cases = [_][]const []const u8{
         &[_][]const u8{


### PR DESCRIPTION
Stability of std sort was undertested before this change. Add a fuzz
test for more confidence.

Specifically, we used to have a single example test that used an array
of eight elements. That ends up exercising only a tiny fraction of
sorting logic, as it hits a hard-coded sorting network due to small
size.

EDIT: I've run this test for a million iterations locally, so it seems like there aren't actual problem with sort stability!