### PR TITLE
translate-c: fix translation of "ptr += uint"

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -3824,8 +3824,9 @@ fn transCreateCompoundAssign(
     const lhs_qt = getExprQualType(c, lhs);
     const rhs_qt = getExprQualType(c, rhs);
     const is_signed = cIsSignedInteger(lhs_qt);
+    const is_ptr_arithmetic = qualTypeIsPtr(lhs_qt) and cIsInteger(rhs_qt);
     const is_ptr_op_signed = qualTypeIsPtr(lhs_qt) and cIsSignedInteger(rhs_qt);
-    const requires_cast = !lhs_qt.eq(rhs_qt) and !is_ptr_op_signed;
+    const requires_cast = !lhs_qt.eq(rhs_qt) and !is_ptr_arithmetic;
 
     if (used == .unused) {
         // common case

--- a/test/cases/run_translated_c/compound_assignments_with_pointer_arithmetic.c
+++ b/test/cases/run_translated_c/compound_assignments_with_pointer_arithmetic.c
@@ -1,0 +1,21 @@
+int main() {
+  const char *s = "forgreatjustice";
+  unsigned int add = 1;
+  
+  s += add;
+  if (*s != 'o') return 1;
+
+  s += 1UL;
+  if (*s != 'r') return 2;
+
+  const char *s2 = (s += add);
+  if (*s2 != 'g') return 3;
+
+  s2 -= add;
+  if (*s2 != 'r') return 4;
+
+  return 0;
+}
+
+// run-translated-c
+// c_frontend=clang


### PR DESCRIPTION
The right-hand side was incorrectly cast to a pointer, since only signed ints were being interpreted correctly as pointer arithmetic.

Fixes #20285.