### PR TITLE
Better formatting error.

### DIFF
--- a/doc/langref/test_print_too_many_args.zig
+++ b/doc/langref/test_print_too_many_args.zig
@@ -11,4 +11,4 @@ test "print too many arguments" {
     });
 }
 
-// test_error=unused argument in 'here is a string: '{s}' here is a number: {}
+// test_error=unused argument in "here is a string: '{s}' here is a number: {}

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -175,7 +175,7 @@ pub fn format(
             .named => |arg_name| blk: {
                 const arg_i = comptime meta.fieldIndex(ArgsType, arg_name) orelse
                     @compileError("no argument with name '" ++ arg_name ++ "'" ++ err_ctx);
-                _ = comptime arg_state.nextArg(arg_i) orelse @compileError("too fe ++ err_ctxw arguments");
+                _ = comptime arg_state.nextArg(arg_i) orelse @compileError("too few arguments" ++ err_ctx);
                 break :blk @field(args, arg_name);
             },
         };
@@ -673,13 +673,13 @@ pub fn formatType(
 /// * an error if the specifier doesn't match the given type
 pub fn checkSpecifier(T: type, comptime fmt: []const u8) union(enum) { ok: []const u8, err: []const u8 } {
     comptime {
+        if (std.mem.eql(u8, fmt, ANY)) {
+            return .{ .ok = defaultSpec(T) };
+        }
         if (std.meta.hasMethod(T, "format")) {
             // We don't know what are valid specifier for custom formatting,
             // accept everything.
             return .{ .ok = fmt };
-        }
-        if (std.mem.eql(u8, fmt, ANY)) {
-            return .{ .ok = defaultSpec(T) };
         }
         // TODO: I don't like that, because it allows extra '?' for non-optional type.
         const spec = if (fmt.len != 0 and (fmt[0] == '?' or fmt[0] == '!')) switch (@typeInfo(T)) {

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -84,7 +84,7 @@ pub fn format(
 ) !void {
     const ArgsType = @TypeOf(args);
     const args_type_info = @typeInfo(ArgsType);
-    const err_ctx = ", in: \"" ++ fmt ++ "\"";
+    const err_ctx = " in \"" ++ fmt ++ "\"";
     if (args_type_info != .Struct) {
         @compileError("expected tuple or struct argument, found " ++ @typeName(ArgsType) ++ err_ctx);
     }

--- a/test/cases/compile_errors/std.fmt_error_for_missing_slice_specifier.zig
+++ b/test/cases/compile_errors/std.fmt_error_for_missing_slice_specifier.zig
@@ -1,0 +1,9 @@
+export fn entry() void {
+    @import("std").debug.print("hello {}", .{"world"});
+}
+
+// error
+// backend=llvm
+// target=native
+//
+// :?:?: error: cannot format array without a specifier (i.e. {s} or {any}) in "hello {}"

--- a/test/cases/compile_errors/std.fmt_error_for_unused_arguments.zig
+++ b/test/cases/compile_errors/std.fmt_error_for_unused_arguments.zig
@@ -6,4 +6,4 @@ export fn entry() void {
 // backend=llvm
 // target=native
 //
-// :?:?: error: 10 unused arguments in '{d} {d} {d} {d} {d}'
+// :?:?: error: 10 unused arguments in "{d} {d} {d} {d} {d}"


### PR DESCRIPTION
Consider the following invalid Zig code.

```
const std = @import("std");
const assert = std.debug.assert;

pub fn main() !void {
    var z: []const u8 = "elllo";
    std.log.info("[]const u8: {}", .{z});
    z = "x";

    var ip4 = std.net.Ip4Address.init(.{128, 0, 0, 1}, 8080);
    std.log.info("Ip4Address: {any}", .{ip4});
    ip4 = undefined;
}

> zigup run 0.13.0 run .../main.zig -freference-trace --zig-lib-dir ./lib
lib/std/fmt.zig:632:21: error: cannot format slice without a specifier (i.e. {s} or {any})
                    @compileError("cannot format slice without a specifier (i.e. {s} or {any})");
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    format__anon_8118: lib/std/fmt.zig:185:23
    print__anon_7617: lib/std/io/Writer.zig:24:26
    print: lib/std/io.zig:324:47
    defaultLog__anon_3710: lib/std/log.zig:158:15
    log__anon_3344: lib/std/log.zig:125:22
    info__anon_2283: lib/std/log.zig:194:16
    main: .../main.zig:10:17
    callMain: lib/std/start.zig:524:32
    callMainWithArgs: lib/std/start.zig:482:12
    main: lib/std/start.zig:497:12
```

The error is on line 6, the format modifier should be `{s}` instead of `{}`.
But the stack trace points to line 4 about the ip4 formatting.

Maybe this could be fixed in Zig compiler itself, but I propose the following mitigation strategy:
* try to detect error earlier in `std.fmt.format` and print the full formatted string which is more easily searchable.

Resulting error:

```
zigup run 0.13.0 run .../main.zig -freference-trace --zig-lib-dir ./lib
lib/std/fmt.zig:188:31: error: cannot format slice without a specifier (i.e. {s} or {any}), in: "info: []const u8: {}"
            .err => |err_msg| @compileError(err_msg ++ err_ctx),
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    print__anon_7620: lib/std/io/Writer.zig:24:26
    print: lib/std/io.zig:324:47
    defaultLog__anon_3711: lib/std/log.zig:158:15
    log__anon_3345: lib/std/log.zig:125:22
    info__anon_2283: lib/std/log.zig:194:16
    main: /.../main.zig:10:17
    callMain: lib/std/start.zig:524:32
    callMainWithArgs: lib/std/start.zig:482:12
    main: lib/std/start.zig:497:12
```

The stacktrace is still wrong but at least the compile error contains the full formatting string.

I tried to minimize changes to avoid breaking changes, but it could be interesting to rethink the full `std.fmt.format` api.