### PR TITLE
stage2-wasm: enum bigint <= 128 bits

### DIFF
--- a/test/behavior/enum.zig
+++ b/test/behavior/enum.zig
@@ -1284,7 +1284,6 @@ test "matching captures causes enum equivalence" {
 }
 
 test "large enum field values" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 


### PR DESCRIPTION
Seems, when big ints handling was added, code related to enums was not touched.

I re-enable assertion in `lowerConstant`, which was hitted by the `behavior/enum.zig` test.