### PR TITLE
spirv: add support for GPU builtins

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -26488,7 +26488,7 @@ fn zirWorkItem(
 
     switch (target.cpu.arch) {
         // TODO: Allow for other GPU targets.
-        .amdgcn => {},
+        .amdgcn, .spirv64, .spirv32 => {},
         else => {
             return sema.fail(block, builtin_src, "builtin only available on GPU targets; targeted architecture is {s}", .{@tagName(target.cpu.arch)});
         },


### PR DESCRIPTION
This should probably have been done a while ago :)

It turns out that OpenCL returns `usize` for all of these. For now I've inserted a cast, but perhaps its better to change the signature, at least for `@workGroupId()`. The others can't realistically be larger than u32. Usually platforms limits these to 1024, in fact, so I don't think there is an issue there.