### PR TITLE
std.posix: read on timerfd can return error.Canceled

### DIFF
--- a/lib/compiler/fmt.zig
+++ b/lib/compiler/fmt.zig
@@ -185,6 +185,7 @@ const FmtError = error{
     BrokenPipe,
     Unexpected,
     WouldBlock,
+    Canceled,
     FileClosed,
     DestinationAddressRequired,
     DiskQuota,

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -791,6 +791,10 @@ pub const ReadError = error{
     /// and reading from the file descriptor would block.
     WouldBlock,
 
+    /// reading a timerfd with CANCEL_ON_SET will lead to this error
+    /// when the clock goes through a discontinuous change
+    Canceled,
+
     /// In WASI, this error occurs when the file descriptor does
     /// not hold the required rights to read from it.
     AccessDenied,
@@ -851,6 +855,7 @@ pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
             .INVAL => unreachable,
             .FAULT => unreachable,
             .AGAIN => return error.WouldBlock,
+            .CANCELED => return error.Canceled,
             .BADF => return error.NotOpenForReading, // Can be a race condition.
             .IO => return error.InputOutput,
             .ISDIR => return error.IsDir,

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -1141,6 +1141,7 @@ fn preadAtLeast(file: fs.File, buf: []u8, offset: u64, min_read_len: usize) !usi
         const len = file.pread(buf[i..], offset + i) catch |err| switch (err) {
             error.OperationAborted => unreachable, // Windows-only
             error.WouldBlock => unreachable, // Did not request blocking mode
+            error.Canceled => unreachable, // timerfd is unseekable
             error.NotOpenForReading => unreachable,
             error.SystemResources => return error.SystemResources,
             error.IsDir => return error.UnableToReadElfFile,

--- a/src/link.zig
+++ b/src/link.zig
@@ -350,6 +350,7 @@ pub const File = struct {
         SocketNotConnected,
         NotOpenForReading,
         WouldBlock,
+        Canceled,
         AccessDenied,
         Unexpected,
         DiskQuota,


### PR DESCRIPTION
When reading from a `timerfd` on `CLOCK_REALTIME` or `CLOCK_REALTIME_ALARM` with `TFD_TIMER_CANCEL_ON_SET` and `TFD_TIMER_ABSTIME` flags set, the syscall will return `ECANCELED`.
 See: https://man7.org/linux/man-pages/man2/timerfd_create.2.html