### PR TITLE
std.Build: Add Step.Fail and addFail() function.

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1058,6 +1058,10 @@ pub fn addRemoveDirTree(b: *Build, dir_path: []const u8) *Step.RemoveDir {
     return Step.RemoveDir.create(b, dir_path);
 }
 
+pub fn addFail(b: *Build, error_msg: []const u8) *Step.Fail {
+    return Step.Fail.create(b, error_msg);
+}
+
 pub fn addFmt(b: *Build, options: Step.Fmt.Options) *Step.Fmt {
     return Step.Fmt.create(b, options);
 }

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -83,6 +83,7 @@ pub const Id = enum {
     install_file,
     install_dir,
     remove_dir,
+    fail,
     fmt,
     translate_c,
     write_file,
@@ -102,6 +103,7 @@ pub const Id = enum {
             .install_file => InstallFile,
             .install_dir => InstallDir,
             .remove_dir => RemoveDir,
+            .fail => Fail,
             .fmt => Fmt,
             .translate_c => TranslateC,
             .write_file => WriteFile,
@@ -119,6 +121,7 @@ pub const Id = enum {
 pub const CheckFile = @import("Step/CheckFile.zig");
 pub const CheckObject = @import("Step/CheckObject.zig");
 pub const ConfigHeader = @import("Step/ConfigHeader.zig");
+pub const Fail = @import("Step/Fail.zig");
 pub const Fmt = @import("Step/Fmt.zig");
 pub const InstallArtifact = @import("Step/InstallArtifact.zig");
 pub const InstallDir = @import("Step/InstallDir.zig");
@@ -551,6 +554,7 @@ pub fn writeManifest(s: *Step, man: *std.Build.Cache.Manifest) !void {
 test {
     _ = CheckFile;
     _ = CheckObject;
+    _ = Fail;
     _ = Fmt;
     _ = InstallArtifact;
     _ = InstallDir;

--- a/lib/std/Build/Step/Fail.zig
+++ b/lib/std/Build/Step/Fail.zig
@@ -1,0 +1,35 @@
+//! Fail the build with a given message.
+const std = @import("std");
+const Step = std.Build.Step;
+const Fail = @This();
+
+step: Step,
+error_msg: []const u8,
+
+pub const base_id: Step.Id = .fail;
+
+pub fn create(owner: *std.Build, error_msg: []const u8) *Fail {
+    const fail = owner.allocator.create(Fail) catch @panic("OOM");
+
+    fail.* = .{
+        .step = Step.init(.{
+            .id = base_id,
+            .name = "fail",
+            .owner = owner,
+            .makeFn = make,
+        }),
+        .error_msg = owner.dupe(error_msg),
+    };
+
+    return fail;
+}
+
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
+    _ = prog_node; // No progress to report.
+
+    const fail: *Fail = @fieldParentPtr("step", step);
+
+    try step.result_error_msgs.append(step.owner.allocator, fail.error_msg);
+
+    return error.MakeFailed;
+}


### PR DESCRIPTION
Closes #15373.

Note that I didn't add the proposed `fail(step: *Step, comptime format: []const u8, args: anytype) *Step` to `std.Build.Step` as it seemed a bit non-idiomatic for `std.Build`. The same can be achieved with `step.dependOn(&b.addFail(b.fmt("...", .{...})).step)`. I can certainly add it if we really want it, though.