### PR TITLE
math.complex: prefer coercion over explicit T{} or type constructor

### DIFF
--- a/lib/std/math/complex.zig
+++ b/lib/std/math/complex.zig
@@ -36,7 +36,7 @@ pub fn Complex(comptime T: type) type {
 
         /// Create a new Complex number from the given real and imaginary parts.
         pub fn init(re: T, im: T) Self {
-            return Self{
+            return .{
                 .re = re,
                 .im = im,
             };
@@ -44,7 +44,7 @@ pub fn Complex(comptime T: type) type {
 
         /// Returns the sum of two complex numbers.
         pub fn add(self: Self, other: Self) Self {
-            return Self{
+            return .{
                 .re = self.re + other.re,
                 .im = self.im + other.im,
             };
@@ -52,7 +52,7 @@ pub fn Complex(comptime T: type) type {
 
         /// Returns the subtraction of two complex numbers.
         pub fn sub(self: Self, other: Self) Self {
-            return Self{
+            return .{
                 .re = self.re - other.re,
                 .im = self.im - other.im,
             };
@@ -60,7 +60,7 @@ pub fn Complex(comptime T: type) type {
 
         /// Returns the product of two complex numbers.
         pub fn mul(self: Self, other: Self) Self {
-            return Self{
+            return .{
                 .re = self.re * other.re - self.im * other.im,
                 .im = self.im * other.re + self.re * other.im,
             };
@@ -72,7 +72,7 @@ pub fn Complex(comptime T: type) type {
             const im_num = self.im * other.re - self.re * other.im;
             const den = other.re * other.re + other.im * other.im;
 
-            return Self{
+            return .{
                 .re = re_num / den,
                 .im = im_num / den,
             };
@@ -80,7 +80,7 @@ pub fn Complex(comptime T: type) type {
 
         /// Returns the complex conjugate of a number.
         pub fn conjugate(self: Self) Self {
-            return Self{
+            return .{
                 .re = self.re,
                 .im = -self.im,
             };
@@ -88,7 +88,7 @@ pub fn Complex(comptime T: type) type {
 
         /// Returns the negation of a complex number.
         pub fn neg(self: Self) Self {
-            return Self{
+            return .{
                 .re = -self.re,
                 .im = -self.im,
             };
@@ -96,7 +96,7 @@ pub fn Complex(comptime T: type) type {
 
         /// Returns the product of complex number and i=sqrt(-1)
         pub fn mulbyi(self: Self) Self {
-            return Self{
+            return .{
                 .re = -self.im,
                 .im = self.re,
             };
@@ -105,7 +105,7 @@ pub fn Complex(comptime T: type) type {
         /// Returns the reciprocal of a complex number.
         pub fn reciprocal(self: Self) Self {
             const m = self.re * self.re + self.im * self.im;
-            return Self{
+            return .{
                 .re = self.re / m,
                 .im = -self.im / m,
             };

--- a/lib/std/math/complex/acos.zig
+++ b/lib/std/math/complex/acos.zig
@@ -6,9 +6,11 @@ const Complex = cmath.Complex;
 
 /// Returns the arc-cosine of z.
 pub fn acos(z: anytype) Complex(@TypeOf(z.re, z.im)) {
-    const T = @TypeOf(z.re, z.im);
     const q = cmath.asin(z);
-    return Complex(T).init(@as(T, math.pi) / 2 - q.re, -q.im);
+    return .{
+        .re = -q.re + math.pi * 0.5,
+        .im = -q.im,
+    };
 }
 
 const epsilon = 0.0001;

--- a/lib/std/math/complex/acosh.zig
+++ b/lib/std/math/complex/acosh.zig
@@ -6,9 +6,11 @@ const Complex = cmath.Complex;
 
 /// Returns the hyperbolic arc-cosine of z.
 pub fn acosh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
-    const T = @TypeOf(z.re, z.im);
     const q = cmath.acos(z);
-    return Complex(T).init(-q.im, q.re);
+    return .{
+        .re = -q.im,
+        .im = q.re,
+    };
 }
 
 const epsilon = 0.0001;

--- a/lib/std/math/complex/asin.zig
+++ b/lib/std/math/complex/asin.zig
@@ -14,7 +14,10 @@ pub fn asin(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     const q = Complex(T).init(-y, x);
     const r = cmath.log(q.add(cmath.sqrt(p)));
 
-    return Complex(T).init(r.im, -r.re);
+    return .{
+        .re = r.im,
+        .im = -r.re,
+    };
 }
 
 const epsilon = 0.0001;

--- a/lib/std/math/complex/asinh.zig
+++ b/lib/std/math/complex/asinh.zig
@@ -7,9 +7,11 @@ const Complex = cmath.Complex;
 /// Returns the hyperbolic arc-sine of z.
 pub fn asinh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     const T = @TypeOf(z.re, z.im);
-    const q = Complex(T).init(-z.im, z.re);
-    const r = cmath.asin(q);
-    return Complex(T).init(r.im, -r.re);
+    const r = cmath.asin(Complex(T).init(-z.im, z.re));
+    return .{
+        .re = r.im,
+        .im = -r.re,
+    };
 }
 
 const epsilon = 0.0001;

--- a/lib/std/math/complex/atan.zig
+++ b/lib/std/math/complex/atan.zig
@@ -38,35 +38,30 @@ fn redupif32(x: f32) f32 {
 
 fn atan32(z: Complex(f32)) Complex(f32) {
     const maxnum = 1.0e38;
+    const overflow = Complex(f32).init(maxnum, maxnum);
 
     const x = z.re;
     const y = z.im;
 
-    if ((x == 0.0) and (y > 1.0)) {
-        // overflow
-        return Complex(f32).init(maxnum, maxnum);
-    }
+    if ((x == 0.0) and (y > 1.0)) return overflow;
 
     const x2 = x * x;
     var a = 1.0 - x2 - (y * y);
-    if (a == 0.0) {
-        // overflow
-        return Complex(f32).init(maxnum, maxnum);
-    }
+    if (a == 0.0) return overflow;
 
     var t = 0.5 * math.atan2(2.0 * x, a);
     const w = redupif32(t);
 
     t = y - 1.0;
     a = x2 + t * t;
-    if (a == 0.0) {
-        // overflow
-        return Complex(f32).init(maxnum, maxnum);
-    }
+    if (a == 0.0) return overflow;
 
     t = y + 1.0;
     a = (x2 + (t * t)) / a;
-    return Complex(f32).init(w, 0.25 * @log(a));
+    return .{
+        .re = w,
+        .im = @log(a) * 0.25,
+    };
 }
 
 fn redupif64(x: f64) f64 {
@@ -87,35 +82,30 @@ fn redupif64(x: f64) f64 {
 
 fn atan64(z: Complex(f64)) Complex(f64) {
     const maxnum = 1.0e308;
+    const overflow = Complex(f64).init(maxnum, maxnum);
 
     const x = z.re;
     const y = z.im;
 
-    if ((x == 0.0) and (y > 1.0)) {
-        // overflow
-        return Complex(f64).init(maxnum, maxnum);
-    }
+    if ((x == 0.0) and (y > 1.0)) return overflow;
 
     const x2 = x * x;
     var a = 1.0 - x2 - (y * y);
-    if (a == 0.0) {
-        // overflow
-        return Complex(f64).init(maxnum, maxnum);
-    }
+    if (a == 0.0) return overflow;
 
     var t = 0.5 * math.atan2(2.0 * x, a);
     const w = redupif64(t);
 
     t = y - 1.0;
     a = x2 + t * t;
-    if (a == 0.0) {
-        // overflow
-        return Complex(f64).init(maxnum, maxnum);
-    }
+    if (a == 0.0) return overflow;
 
     t = y + 1.0;
     a = (x2 + (t * t)) / a;
-    return Complex(f64).init(w, 0.25 * @log(a));
+    return .{
+        .re = w,
+        .im = @log(a) * 0.25,
+    };
 }
 
 const epsilon = 0.0001;

--- a/lib/std/math/complex/atanh.zig
+++ b/lib/std/math/complex/atanh.zig
@@ -7,9 +7,11 @@ const Complex = cmath.Complex;
 /// Returns the hyperbolic arc-tangent of z.
 pub fn atanh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     const T = @TypeOf(z.re, z.im);
-    const q = Complex(T).init(-z.im, z.re);
-    const r = cmath.atan(q);
-    return Complex(T).init(r.im, -r.re);
+    const r = cmath.atan(Complex(T).init(-z.im, z.re));
+    return .{
+        .re = r.im,
+        .im = -r.re,
+    };
 }
 
 const epsilon = 0.0001;

--- a/lib/std/math/complex/conj.zig
+++ b/lib/std/math/complex/conj.zig
@@ -6,13 +6,15 @@ const Complex = cmath.Complex;
 
 /// Returns the complex conjugate of z.
 pub fn conj(z: anytype) Complex(@TypeOf(z.re, z.im)) {
-    const T = @TypeOf(z.re, z.im);
-    return Complex(T).init(z.re, -z.im);
+    return .{
+        .re = z.re,
+        .im = -z.im,
+    };
 }
 
 test conj {
     const a = Complex(f32).init(5, 3);
-    const c = a.conjugate();
+    const c = conj(a);
 
     try testing.expect(c.re == 5 and c.im == -3);
 }

--- a/lib/std/math/complex/cos.zig
+++ b/lib/std/math/complex/cos.zig
@@ -7,8 +7,7 @@ const Complex = cmath.Complex;
 /// Returns the cosine of z.
 pub fn cos(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     const T = @TypeOf(z.re, z.im);
-    const p = Complex(T).init(-z.im, z.re);
-    return cmath.cosh(p);
+    return cmath.cosh(Complex(T).init(-z.im, z.re));
 }
 
 const epsilon = 0.0001;

--- a/lib/std/math/complex/ldexp.zig
+++ b/lib/std/math/complex/ldexp.zig
@@ -14,7 +14,6 @@ const Complex = cmath.Complex;
 /// Returns exp(z) scaled to avoid overflow.
 pub fn ldexp_cexp(z: anytype, expt: i32) Complex(@TypeOf(z.re, z.im)) {
     const T = @TypeOf(z.re, z.im);
-
     return switch (T) {
         f32 => ldexp_cexp32(z, expt),
         f64 => ldexp_cexp64(z, expt),
@@ -27,10 +26,10 @@ fn frexp_exp32(x: f32, expt: *i32) f32 {
     const kln2 = 162.88958740; // k * ln2
 
     const exp_x = @exp(x - kln2);
-    const hx = @as(u32, @bitCast(exp_x));
+    const hx: u32 = @bitCast(exp_x);
     // TODO zig should allow this cast implicitly because it should know the value is in range
     expt.* = @as(i32, @intCast(hx >> 23)) - (0x7f + 127) + k;
-    return @as(f32, @bitCast((hx & 0x7fffff) | ((0x7f + 127) << 23)));
+    return @bitCast((hx & 0x7fffff) | ((0x7f + 127) << 23));
 }
 
 fn ldexp_cexp32(z: Complex(f32), expt: i32) Complex(f32) {
@@ -39,15 +38,15 @@ fn ldexp_cexp32(z: Complex(f32), expt: i32) Complex(f32) {
     const exptf = expt + ex_expt;
 
     const half_expt1 = @divTrunc(exptf, 2);
-    const scale1 = @as(f32, @bitCast((0x7f + half_expt1) << 23));
+    const scale1: f32 = @bitCast((0x7f + half_expt1) << 23);
 
     const half_expt2 = exptf - half_expt1;
-    const scale2 = @as(f32, @bitCast((0x7f + half_expt2) << 23));
+    const scale2: f32 = @bitCast((0x7f + half_expt2) << 23);
 
-    return Complex(f32).init(
-        @cos(z.im) * exp_x * scale1 * scale2,
-        @sin(z.im) * exp_x * scale1 * scale2,
-    );
+    return .{
+        .re = @cos(z.im) * exp_x * scale1 * scale2,
+        .im = @sin(z.im) * exp_x * scale1 * scale2,
+    };
 }
 
 fn frexp_exp64(x: f64, expt: *i32) f64 {
@@ -56,29 +55,29 @@ fn frexp_exp64(x: f64, expt: *i32) f64 {
 
     const exp_x = @exp(x - kln2);
 
-    const fx = @as(u64, @bitCast(exp_x));
-    const hx = @as(u32, @intCast(fx >> 32));
-    const lx = @as(u32, @truncate(fx));
+    const fx: u64 = @bitCast(exp_x);
+    const hx: u32 = @intCast(fx >> 32);
+    const lx: u32 = @truncate(fx);
 
     expt.* = @as(i32, @intCast(hx >> 20)) - (0x3ff + 1023) + k;
 
     const high_word = (hx & 0xfffff) | ((0x3ff + 1023) << 20);
-    return @as(f64, @bitCast((@as(u64, high_word) << 32) | lx));
+    return @bitCast((@as(u64, high_word) << 32) | lx);
 }
 
 fn ldexp_cexp64(z: Complex(f64), expt: i32) Complex(f64) {
     var ex_expt: i32 = undefined;
     const exp_x = frexp_exp64(z.re, &ex_expt);
-    const exptf = @as(i64, expt + ex_expt);
+    const exptf: i64 = expt + ex_expt;
 
     const half_expt1 = @divTrunc(exptf, 2);
-    const scale1 = @as(f64, @bitCast((0x3ff + half_expt1) << (20 + 32)));
+    const scale1: f64 = @bitCast((0x3ff + half_expt1) << (20 + 32));
 
     const half_expt2 = exptf - half_expt1;
-    const scale2 = @as(f64, @bitCast((0x3ff + half_expt2) << (20 + 32)));
+    const scale2: f64 = @bitCast((0x3ff + half_expt2) << (20 + 32));
 
-    return Complex(f64).init(
-        @cos(z.im) * exp_x * scale1 * scale2,
-        @sin(z.im) * exp_x * scale1 * scale2,
-    );
+    return .{
+        .re = @cos(z.im) * exp_x * scale1 * scale2,
+        .im = @sin(z.im) * exp_x * scale1 * scale2,
+    };
 }

--- a/lib/std/math/complex/log.zig
+++ b/lib/std/math/complex/log.zig
@@ -6,11 +6,10 @@ const Complex = cmath.Complex;
 
 /// Returns the natural logarithm of z.
 pub fn log(z: anytype) Complex(@TypeOf(z.re, z.im)) {
-    const T = @TypeOf(z.re, z.im);
-    const r = cmath.abs(z);
-    const phi = cmath.arg(z);
-
-    return Complex(T).init(@log(r), phi);
+    return .{
+        .re = @log(math.hypot(z.re, z.im)),
+        .im = math.atan2(z.im, z.re),
+    };
 }
 
 const epsilon = 0.0001;

--- a/lib/std/math/complex/proj.zig
+++ b/lib/std/math/complex/proj.zig
@@ -7,12 +7,13 @@ const Complex = cmath.Complex;
 /// Returns the projection of z onto the riemann sphere.
 pub fn proj(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     const T = @TypeOf(z.re, z.im);
-
-    if (math.isInf(z.re) or math.isInf(z.im)) {
-        return Complex(T).init(math.inf(T), math.copysign(@as(T, 0.0), z.re));
-    }
-
-    return Complex(T).init(z.re, z.im);
+    return if (math.isInf(z.re) or math.isInf(z.im)) .{
+        .re = math.inf(T),
+        .im = math.copysign(@as(T, 0.0), z.re),
+    } else .{
+        .re = z.re,
+        .im = z.im,
+    };
 }
 
 test proj {

--- a/lib/std/math/complex/sin.zig
+++ b/lib/std/math/complex/sin.zig
@@ -7,9 +7,11 @@ const Complex = cmath.Complex;
 /// Returns the sine of z.
 pub fn sin(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     const T = @TypeOf(z.re, z.im);
-    const p = Complex(T).init(-z.im, z.re);
-    const q = cmath.sinh(p);
-    return Complex(T).init(q.im, -q.re);
+    const q = cmath.sinh(Complex(T).init(-z.im, z.re));
+    return .{
+        .re = q.im,
+        .im = -q.re,
+    };
 }
 
 const epsilon = 0.0001;

--- a/lib/std/math/complex/sinh.zig
+++ b/lib/std/math/complex/sinh.zig
@@ -26,63 +26,80 @@ fn sinh32(z: Complex(f32)) Complex(f32) {
     const x = z.re;
     const y = z.im;
 
-    const hx = @as(u32, @bitCast(x));
+    const hx: u32 = @bitCast(x);
     const ix = hx & 0x7fffffff;
 
-    const hy = @as(u32, @bitCast(y));
+    const hy: u32 = @bitCast(y);
     const iy = hy & 0x7fffffff;
 
-    if (ix < 0x7f800000 and iy < 0x7f800000) {
-        if (iy == 0) {
-            return Complex(f32).init(math.sinh(x), y);
-        }
+    if (ix < 0x7f800000 and iy < 0x7f800000) return ret: {
+        if (iy == 0) break :ret .{
+            .re = math.sinh(x),
+            .im = y,
+        };
+
         // small x: normal case
-        if (ix < 0x41100000) {
-            return Complex(f32).init(math.sinh(x) * @cos(y), math.cosh(x) * @sin(y));
-        }
+        if (ix < 0x41100000) break :ret .{
+            .re = math.sinh(x) * @cos(y),
+            .im = math.cosh(x) * @sin(y),
+        };
 
         // |x|>= 9, so cosh(x) ~= exp(|x|)
         if (ix < 0x42b17218) {
             // x < 88.7: exp(|x|) won't overflow
             const h = @exp(@abs(x)) * 0.5;
-            return Complex(f32).init(math.copysign(h, x) * @cos(y), h * @sin(y));
+            break :ret .{
+                .re = @cos(y) * math.copysign(h, x),
+                .im = @sin(y) * h,
+            };
         }
+
         // x < 192.7: scale to avoid overflow
-        else if (ix < 0x4340b1e7) {
-            const v = Complex(f32).init(@abs(x), y);
-            const r = ldexp_cexp(v, -1);
-            return Complex(f32).init(r.re * math.copysign(@as(f32, 1.0), x), r.im);
+        if (ix < 0x4340b1e7) {
+            const r = ldexp_cexp(Complex(f32).init(@abs(x), y), -1);
+            break :ret .{
+                .re = r.re * math.copysign(@as(f32, 1.0), x),
+                .im = r.im,
+            };
         }
+
         // x >= 192.7: result always overflows
-        else {
-            const h = 0x1p127 * x;
-            return Complex(f32).init(h * @cos(y), h * h * @sin(y));
-        }
-    }
+        const h = 0x1p127 * x;
+        break :ret .{
+            .re = @cos(y) * h,
+            .im = @sin(y) * h * h,
+        };
+    };
 
-    if (ix == 0 and iy >= 0x7f800000) {
-        return Complex(f32).init(math.copysign(@as(f32, 0.0), x * (y - y)), y - y);
-    }
+    if (ix == 0 and iy >= 0x7f800000) return .{
+        .re = math.copysign(@as(f32, 0.0), x * (y - y)),
+        .im = y - y,
+    };
 
-    if (iy == 0 and ix >= 0x7f800000) {
-        if (hx & 0x7fffff == 0) {
-            return Complex(f32).init(x, y);
-        }
-        return Complex(f32).init(x, math.copysign(@as(f32, 0.0), y));
-    }
+    if (iy == 0 and ix >= 0x7f800000) return .{
+        .re = x,
+        .im = if (hx & 0x7fffff == 0) y else math.copysign(@as(f32, 0.0), y),
+    };
 
-    if (ix < 0x7f800000 and iy >= 0x7f800000) {
-        return Complex(f32).init(y - y, x * (y - y));
-    }
+    if (ix < 0x7f800000 and iy >= 0x7f800000) return .{
+        .re = y - y,
+        .im = x * (y - y),
+    };
 
     if (ix >= 0x7f800000 and (hx & 0x7fffff) == 0) {
-        if (iy >= 0x7f800000) {
-            return Complex(f32).init(x * x, x * (y - y));
-        }
-        return Complex(f32).init(x * @cos(y), math.inf(f32) * @sin(y));
+        return if (iy >= 0x7f800000) .{
+            .re = x * x,
+            .im = x * (y - y),
+        } else .{
+            .re = @cos(y) * x,
+            .im = @sin(y) * math.inf(f32),
+        };
     }
 
-    return Complex(f32).init((x * x) * (y - y), (x + x) * (y - y));
+    return .{
+        .re = (x * x) * (y - y),
+        .im = (x + x) * (y - y),
+    };
 }
 
 fn sinh64(z: Complex(f64)) Complex(f64) {
@@ -99,57 +116,74 @@ fn sinh64(z: Complex(f64)) Complex(f64) {
     const ly: u32 = @truncate(fy);
     const iy = hy & 0x7fffffff;
 
-    if (ix < 0x7ff00000 and iy < 0x7ff00000) {
-        if (iy | ly == 0) {
-            return Complex(f64).init(math.sinh(x), y);
-        }
+    if (ix < 0x7ff00000 and iy < 0x7ff00000) return ret: {
+        if (iy | ly == 0) break :ret .{
+            .re = math.sinh(x),
+            .im = y,
+        };
+
         // small x: normal case
-        if (ix < 0x40360000) {
-            return Complex(f64).init(math.sinh(x) * @cos(y), math.cosh(x) * @sin(y));
-        }
+        if (ix < 0x40360000) break :ret .{
+            .re = math.sinh(x) * @cos(y),
+            .im = math.cosh(x) * @sin(y),
+        };
 
         // |x|>= 22, so cosh(x) ~= exp(|x|)
         if (ix < 0x40862e42) {
             // x < 710: exp(|x|) won't overflow
             const h = @exp(@abs(x)) * 0.5;
-            return Complex(f64).init(math.copysign(h, x) * @cos(y), h * @sin(y));
+            break :ret .{
+                .re = @cos(y) * math.copysign(h, x),
+                .im = @sin(y) * h,
+            };
         }
+
         // x < 1455: scale to avoid overflow
-        else if (ix < 0x4096bbaa) {
-            const v = Complex(f64).init(@abs(x), y);
-            const r = ldexp_cexp(v, -1);
-            return Complex(f64).init(r.re * math.copysign(@as(f64, 1.0), x), r.im);
+        if (ix < 0x4096bbaa) {
+            const r = ldexp_cexp(Complex(f64).init(@abs(x), y), -1);
+            break :ret .{
+                .re = r.re * math.copysign(@as(f64, 1.0), x),
+                .im = r.im,
+            };
         }
+
         // x >= 1455: result always overflows
-        else {
-            const h = 0x1p1023 * x;
-            return Complex(f64).init(h * @cos(y), h * h * @sin(y));
-        }
-    }
+        const h = 0x1p1023 * x;
+        break :ret .{
+            .re = @cos(y) * h,
+            .im = @sin(y) * h * h,
+        };
+    };
 
-    if (ix | lx == 0 and iy >= 0x7ff00000) {
-        return Complex(f64).init(math.copysign(@as(f64, 0.0), x * (y - y)), y - y);
-    }
+    if (ix | lx == 0 and iy >= 0x7ff00000) return .{
+        .re = math.copysign(@as(f64, 0.0), x * (y - y)),
+        .im = y - y,
+    };
 
-    if (iy | ly == 0 and ix >= 0x7ff00000) {
-        if ((hx & 0xfffff) | lx == 0) {
-            return Complex(f64).init(x, y);
-        }
-        return Complex(f64).init(x, math.copysign(@as(f64, 0.0), y));
-    }
+    if (iy | ly == 0 and ix >= 0x7ff00000) return .{
+        .re = x,
+        .im = if ((hx & 0xfffff) | lx == 0) y else math.copysign(@as(f64, 0.0), y),
+    };
 
-    if (ix < 0x7ff00000 and iy >= 0x7ff00000) {
-        return Complex(f64).init(y - y, x * (y - y));
-    }
+    if (ix < 0x7ff00000 and iy >= 0x7ff00000) return .{
+        .re = y - y,
+        .im = x * (y - y),
+    };
 
     if (ix >= 0x7ff00000 and (hx & 0xfffff) | lx == 0) {
-        if (iy >= 0x7ff00000) {
-            return Complex(f64).init(x * x, x * (y - y));
-        }
-        return Complex(f64).init(x * @cos(y), math.inf(f64) * @sin(y));
+        return if (iy >= 0x7ff00000) .{
+            .re = x * x,
+            .im = x * (y - y),
+        } else .{
+            .re = @cos(y) * x,
+            .im = @sin(y) * math.inf(f64),
+        };
     }
 
-    return Complex(f64).init((x * x) * (y - y), (x + x) * (y - y));
+    return .{
+        .re = (x * x) * (y - y),
+        .im = (x + x) * (y - y),
+    };
 }
 
 const epsilon = 0.0001;

--- a/lib/std/math/complex/tan.zig
+++ b/lib/std/math/complex/tan.zig
@@ -7,9 +7,11 @@ const Complex = cmath.Complex;
 /// Returns the tangent of z.
 pub fn tan(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     const T = @TypeOf(z.re, z.im);
-    const q = Complex(T).init(-z.im, z.re);
-    const r = cmath.tanh(q);
-    return Complex(T).init(r.im, -r.re);
+    const r = cmath.tanh(Complex(T).init(-z.im, z.re));
+    return .{
+        .re = r.im,
+        .im = -r.re,
+    };
 }
 
 const epsilon = 0.0001;


### PR DESCRIPTION
this is a housekeeping/styling PR that makes return statements use coerced tuples rather than explicit type constructors. Functionally they are identical, however this makes it easier to potentially refactor the library functions to be generic over any re+im tuples in the future.