### PR TITLE
wasm2c: avoid indexing null pointer triggering undefined behavior

### DIFF
--- a/stage1/FuncGen.h
+++ b/stage1/FuncGen.h
@@ -179,8 +179,10 @@ static void FuncGen_blockBegin(struct FuncGen *self, FILE *out, enum WasmOpcode 
         self->reuse = realloc(self->reuse, sizeof(uint32_t) * self->reuse_len);
         if (self->reuse == NULL) panic("out of memory");
     }
-    memcpy(&self->reuse[self->reuse_i], &self->reuse[reuse_top], sizeof(uint32_t) * reuse_n);
-    self->reuse_i += reuse_n;
+    if (reuse_n != 0) {
+        memcpy(&self->reuse[self->reuse_i], &self->reuse[reuse_top], sizeof(uint32_t) * reuse_n);
+        self->reuse_i += reuse_n;
+    }
 }
 
 static enum WasmOpcode FuncGen_blockKind(const struct FuncGen *self, uint32_t label_idx) {


### PR DESCRIPTION
Using zig cc to compile and run wasm2c on zig1.wasm triggers what appears to be a sanitizer crash, i.e.

```sh
$ zig cc -o wasm2c stage1/wasm2c.c 
$ ./wasm2c stage1/zig1.wasm zig.c
Illegal instruction (core dumped)
```

The `FuncGen` struct field `reuse` (an array pointer) is initialized to null and at some point is resized to a length of zero, which triggers this code to execute:

```c
memcpy(&self->reuse[self->reuse_i], &self->reuse[reuse_top], sizeof(uint32_t) * reuse_n);
```

Given the current values, this equates to:

```c
memcpy(&(NULL)[0], &(NULL)[0], 0);
```

Taking the address of the first element of a null pointer doesn't trigger any actual runtime problem, since the pointer won't be dereferenced because were passing 0 as the length to memcpy, however, it seems that the C spec considers indexing a null pointer to be undefined behavior even if you don't use the resulting value (or are just taking the address of an indexed pointer) so it does trigger a sanitizer.