### PR TITLE
enhance `std.Build.Step.Fmt` and use it more

### DIFF
--- a/ci/aarch64-linux-debug.sh
+++ b/ci/aarch64-linux-debug.sh
@@ -49,13 +49,6 @@ unset CXX
 
 ninja install
 
-# TODO: move this to a build.zig step (check-fmt)
-echo "Looking for non-conforming code formatting..."
-stage3-debug/bin/zig fmt --check .. \
-  --exclude ../test/cases/ \
-  --exclude ../doc/ \
-  --exclude ../build-debug
-
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
 stage3-debug/bin/zig build \
   -Dtarget=arm-linux-musleabihf \

--- a/ci/aarch64-linux-release.sh
+++ b/ci/aarch64-linux-release.sh
@@ -49,13 +49,6 @@ unset CXX
 
 ninja install
 
-# TODO: move this to a build.zig step (check-fmt)
-echo "Looking for non-conforming code formatting..."
-stage3-release/bin/zig fmt --check .. \
-  --exclude ../test/cases/ \
-  --exclude ../doc/ \
-  --exclude ../build-release
-
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
 stage3-release/bin/zig build \
   -Dtarget=arm-linux-musleabihf \

--- a/ci/x86_64-linux-debug.sh
+++ b/ci/x86_64-linux-debug.sh
@@ -57,13 +57,6 @@ unset CXX
 
 ninja install
 
-# TODO: move this to a build.zig step (check-fmt)
-echo "Looking for non-conforming code formatting..."
-stage3-debug/bin/zig fmt --check .. \
-  --exclude ../test/cases/ \
-  --exclude ../doc/ \
-  --exclude ../build-debug
-
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
 stage3-debug/bin/zig build \
   -Dtarget=arm-linux-musleabihf \

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -57,14 +57,6 @@ unset CXX
 
 ninja install
 
-# TODO: move this to a build.zig step (check-fmt)
-echo "Looking for non-conforming code formatting..."
-stage3-release/bin/zig fmt --check .. \
-  --exclude ../test/cases/ \
-  --exclude ../doc/ \
-  --exclude ../build-debug \
-  --exclude ../build-release
-
 # simultaneously test building self-hosted without LLVM and with 32-bit arm
 stage3-release/bin/zig build \
   -Dtarget=arm-linux-musleabihf \

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -269,7 +269,17 @@ const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const builtin = @import("builtin");
 
-pub fn evalChildProcess(s: *Step, argv: []const []const u8) !void {
+pub fn evalChildProcess(s: *Step, argv: []const []const u8) ![]u8 {
+    const run_result = try captureChildProcess(s, std.Progress.Node.none, argv);
+    try handleChildProcessTerm(s, run_result.term, null, argv);
+    return run_result.stdout;
+}
+
+pub fn captureChildProcess(
+    s: *Step,
+    progress_node: std.Progress.Node,
+    argv: []const []const u8,
+) !std.process.Child.RunResult {
     const arena = s.owner.allocator;
 
     try handleChildProcUnsupported(s, null, argv);
@@ -278,13 +288,14 @@ pub fn evalChildProcess(s: *Step, argv: []const []const u8) !void {
     const result = std.process.Child.run(.{
         .allocator = arena,
         .argv = argv,
+        .progress_node = progress_node,
     }) catch |err| return s.fail("unable to spawn {s}: {s}", .{ argv[0], @errorName(err) });
 
     if (result.stderr.len > 0) {
         try s.result_error_msgs.append(arena, result.stderr);
     }
 
-    try handleChildProcessTerm(s, result.term, null, argv);
+    return result;
 }
 
 pub fn fail(step: *Step, comptime fmt: []const u8, args: anytype) error{ OutOfMemory, MakeFailed } {

--- a/lib/std/Build/Step/Fmt.zig
+++ b/lib/std/Build/Step/Fmt.zig
@@ -37,9 +37,6 @@ pub fn create(owner: *std.Build, options: Options) *Fmt {
 }
 
 fn make(step: *Step, prog_node: std.Progress.Node) !void {
-    // zig fmt is fast enough that no progress is needed.
-    _ = prog_node;
-
     // TODO: if check=false, this means we are modifying source files in place, which
     // is an operation that could race against other operations also modifying source files
     // in place. In this case, this step should obtain a write lock while making those
@@ -68,5 +65,15 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
         argv.appendAssumeCapacity(b.pathFromRoot(p));
     }
 
-    return step.evalChildProcess(argv.items);
+    const run_result = try step.captureChildProcess(prog_node, argv.items);
+    if (fmt.check) switch (run_result.term) {
+        .Exited => |code| if (code != 0 and run_result.stdout.len != 0) {
+            var it = std.mem.tokenizeScalar(u8, run_result.stdout, '\n');
+            while (it.next()) |bad_file_name| {
+                try step.addError("{s}: non-conforming formatting", .{bad_file_name});
+            }
+        },
+        else => {},
+    };
+    try step.handleChildProcessTerm(run_result.term, null, argv.items);
 }

--- a/lib/std/process/Child.zig
+++ b/lib/std/process/Child.zig
@@ -101,7 +101,7 @@ resource_usage_statistics: ResourceUsageStatistics = .{},
 ///
 /// The child's progress tree will be grafted into the parent's progress tree,
 /// by substituting this node with the child's root node.
-progress_node: std.Progress.Node = .{ .index = .none },
+progress_node: std.Progress.Node = std.Progress.Node.none,
 
 pub const ResourceUsageStatistics = struct {
     rusage: @TypeOf(rusage_init) = rusage_init,
@@ -376,6 +376,7 @@ pub fn run(args: struct {
     env_map: ?*const EnvMap = null,
     max_output_bytes: usize = 50 * 1024,
     expand_arg0: Arg0Expand = .no_expand,
+    progress_node: std.Progress.Node = std.Progress.Node.none,
 }) RunError!RunResult {
     var child = ChildProcess.init(args.argv, args.allocator);
     child.stdin_behavior = .Ignore;
@@ -385,6 +386,7 @@ pub fn run(args: struct {
     child.cwd_dir = args.cwd_dir;
     child.env_map = args.env_map;
     child.expand_arg0 = args.expand_arg0;
+    child.progress_node = args.progress_node;
 
     var stdout = std.ArrayList(u8).init(args.allocator);
     var stderr = std.ArrayList(u8).init(args.allocator);


### PR DESCRIPTION
Example of a zig fmt failure with this branch:

```console
[nix-shell:~/dev/zig/build-release]$ stage3/bin/zig build test-fmt
test-fmt
└─ zig fmt --check failure
error: /home/andy/dev/zig/src/main.zig: non-conforming formatting
error: the following command exited with error code 1:
/home/andy/dev/zig/build-release/stage3/bin/zig fmt --check /home/andy/dev/zig/lib /home/andy/dev/zig/src /home/andy/dev/zig/test /home/andy/dev/zig/tools /home/andy/dev/zig/build.zig /home/andy/dev/zig/build.zig.zon --exclude /home/andy/dev/zig/test/cases 
Build Summary: 0/2 steps succeeded; 1 failed (disable with --summary none)
test-fmt transitive failure
└─ zig fmt --check failure
error: the following build command failed with exit code 1:
/home/andy/dev/zig/.zig-cache/o/3ac7a20af5c73e65a83d2e9b65218673/build /home/andy/dev/zig/build-release/stage3/bin/zig /home/andy/dev/zig /home/andy/dev/zig/.zig-cache /home/andy/.cache/zig --seed 0x8b717bd6 -Z1af88b3aa2fcdad6 test-fmt
```

See individual commit messages for more details.