### PR TITLE
fix(fmt): pointer type syntax to index

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5915,6 +5915,14 @@ test "zig fmt: error for ptr mod on array child type" {
     });
 }
 
+test "zig fmt: pointer type syntax to index" {
+    try testCanonical(
+        \\test {
+        \\    _ = .{}[*0];
+        \\}
+    );
+}
+
 test "recovery: top level" {
     try testError(
         \\test "" {inline}

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -668,7 +668,7 @@ fn renderExpression(r: *Render, node: Ast.Node.Index, space: Space) Error!void {
 
         .array_access => {
             const suffix = datas[node];
-            const lbracket = tree.firstToken(suffix.rhs) - 1;
+            const lbracket = tree.firstToken(suffix.rhs) - @intFromBool(tree.lastToken(suffix.lhs) + 1 != tree.firstToken(suffix.rhs));
             const rbracket = tree.lastToken(suffix.rhs) + 1;
             const one_line = tree.tokensOnSameLine(lbracket, rbracket);
             const inner_space = if (one_line) Space.none else Space.newline;


### PR DESCRIPTION
Fixes #19440 

The render code is currently written with the expectation of the following sequence for array accesses:

- last token of `lhs` (`}` in the issue's case)
- `.l_bracket`
- first token of `rhs` ('*' in the issue's case)

When the malformed input is parsed, the index for first token of `rhs` is directly adjacent to the last token of `lhs`, clobbering the left bracket. The added check prevents this from happening.