### PR TITLE
fix(fmt): pointer type syntax to index (take 2)

### DIFF
--- a/lib/compiler/aro_translate_c/ast.zig
+++ b/lib/compiler/aro_translate_c/ast.zig
@@ -1495,11 +1495,11 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
         .c_pointer, .single_pointer => {
             const payload = @as(*Payload.Pointer, @alignCast(@fieldParentPtr("base", node.ptr_otherwise))).data;
 
-            const asterisk = if (node.tag() == .single_pointer)
+            const main_token = if (node.tag() == .single_pointer)
                 try c.addToken(.asterisk, "*")
             else blk: {
-                _ = try c.addToken(.l_bracket, "[");
-                const res = try c.addToken(.asterisk, "*");
+                const res = try c.addToken(.l_bracket, "[");
+                _ = try c.addToken(.asterisk, "*");
                 _ = try c.addIdentifier("c");
                 _ = try c.addToken(.r_bracket, "]");
                 break :blk res;
@@ -1510,7 +1510,7 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
 
             return c.addNode(.{
                 .tag = .ptr_type_aligned,
-                .main_token = asterisk,
+                .main_token = main_token,
                 .data = .{
                     .lhs = 0,
                     .rhs = elem_type,

--- a/lib/std/zig/Parse.zig
+++ b/lib/std/zig/Parse.zig
@@ -1905,8 +1905,8 @@ fn parseTypeExpr(p: *Parse) Error!Node.Index {
         },
         .l_bracket => switch (p.token_tags[p.tok_i + 1]) {
             .asterisk => {
+                const l_bracket = p.nextToken();
                 _ = p.nextToken();
-                const asterisk = p.nextToken();
                 var sentinel: Node.Index = 0;
                 if (p.eatToken(.identifier)) |ident| {
                     const ident_slice = p.source[p.token_starts[ident]..p.token_starts[ident + 1]];
@@ -1923,7 +1923,7 @@ fn parseTypeExpr(p: *Parse) Error!Node.Index {
                     if (sentinel == 0 and mods.addrspace_node == 0) {
                         return p.addNode(.{
                             .tag = .ptr_type_aligned,
-                            .main_token = asterisk,
+                            .main_token = l_bracket,
                             .data = .{
                                 .lhs = mods.align_node,
                                 .rhs = elem_type,
@@ -1932,7 +1932,7 @@ fn parseTypeExpr(p: *Parse) Error!Node.Index {
                     } else if (mods.align_node == 0 and mods.addrspace_node == 0) {
                         return p.addNode(.{
                             .tag = .ptr_type_sentinel,
-                            .main_token = asterisk,
+                            .main_token = l_bracket,
                             .data = .{
                                 .lhs = sentinel,
                                 .rhs = elem_type,
@@ -1941,7 +1941,7 @@ fn parseTypeExpr(p: *Parse) Error!Node.Index {
                     } else {
                         return p.addNode(.{
                             .tag = .ptr_type,
-                            .main_token = asterisk,
+                            .main_token = l_bracket,
                             .data = .{
                                 .lhs = try p.addExtra(Node.PtrType{
                                     .sentinel = sentinel,
@@ -1955,7 +1955,7 @@ fn parseTypeExpr(p: *Parse) Error!Node.Index {
                 } else {
                     return p.addNode(.{
                         .tag = .ptr_type_bit_range,
-                        .main_token = asterisk,
+                        .main_token = l_bracket,
                         .data = .{
                             .lhs = try p.addExtra(Node.PtrTypeBitRange{
                                 .sentinel = sentinel,

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5915,6 +5915,15 @@ test "zig fmt: error for ptr mod on array child type" {
     });
 }
 
+test "zig fmt: pointer type syntax to index" {
+    try testCanonical(
+        \\test {
+        \\    _ = .{}[*0];
+        \\}
+        \\
+    );
+}
+
 test "recovery: top level" {
     try testError(
         \\test "" {inline}

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -961,22 +961,22 @@ fn renderPtrType(r: *Render, ptr_type: Ast.full.PtrType, space: Space) Error!voi
         },
         .Many => {
             if (ptr_type.ast.sentinel == 0) {
-                try renderToken(r, ptr_type.ast.main_token - 1, .none); // lbracket
-                try renderToken(r, ptr_type.ast.main_token, .none); // asterisk
-                try renderToken(r, ptr_type.ast.main_token + 1, .none); // rbracket
+                try renderToken(r, ptr_type.ast.main_token, .none); // lbracket
+                try renderToken(r, ptr_type.ast.main_token + 1, .none); // asterisk
+                try renderToken(r, ptr_type.ast.main_token + 2, .none); // rbracket
             } else {
-                try renderToken(r, ptr_type.ast.main_token - 1, .none); // lbracket
-                try renderToken(r, ptr_type.ast.main_token, .none); // asterisk
-                try renderToken(r, ptr_type.ast.main_token + 1, .none); // colon
+                try renderToken(r, ptr_type.ast.main_token, .none); // lbracket
+                try renderToken(r, ptr_type.ast.main_token + 1, .none); // asterisk
+                try renderToken(r, ptr_type.ast.main_token + 2, .none); // colon
                 try renderExpression(r, ptr_type.ast.sentinel, .none);
                 try renderToken(r, tree.lastToken(ptr_type.ast.sentinel) + 1, .none); // rbracket
             }
         },
         .C => {
-            try renderToken(r, ptr_type.ast.main_token - 1, .none); // lbracket
-            try renderToken(r, ptr_type.ast.main_token, .none); // asterisk
-            try renderToken(r, ptr_type.ast.main_token + 1, .none); // c
-            try renderToken(r, ptr_type.ast.main_token + 2, .none); // rbracket
+            try renderToken(r, ptr_type.ast.main_token, .none); // lbracket
+            try renderToken(r, ptr_type.ast.main_token + 1, .none); // asterisk
+            try renderToken(r, ptr_type.ast.main_token + 2, .none); // c
+            try renderToken(r, ptr_type.ast.main_token + 3, .none); // rbracket
         },
         .Slice => {
             if (ptr_type.ast.sentinel == 0) {

--- a/test/cases/compile_errors/disallow_coercion_from_non-null-terminated_pointer_to_null-terminated_pointer.zig
+++ b/test/cases/compile_errors/disallow_coercion_from_non-null-terminated_pointer_to_null-terminated_pointer.zig
@@ -11,4 +11,4 @@ pub export fn entry() void {
 //
 // :5:14: error: expected type '[*:0]const u8', found '[*]const u8'
 // :5:14: note: destination pointer requires '0' sentinel
-// :1:20: note: parameter type declared here
+// :1:19: note: parameter type declared here

--- a/test/cases/compile_errors/incompatible_sentinels.zig
+++ b/test/cases/compile_errors/incompatible_sentinels.zig
@@ -21,10 +21,10 @@ export fn entry4() void {
 //
 // :4:12: error: expected type '[*:0]u8', found '[*:255]u8'
 // :4:12: note: pointer sentinel '255' cannot cast into pointer sentinel '0'
-// :3:35: note: function return type declared here
+// :3:34: note: function return type declared here
 // :7:12: error: expected type '[*:0]u8', found '[*]u8'
 // :7:12: note: destination pointer requires '0' sentinel
-// :6:31: note: function return type declared here
+// :6:30: note: function return type declared here
 // :10:35: error: expected type '[2:0]u8', found '[2:255]u8'
 // :10:35: note: array sentinel '255' cannot cast into array sentinel '0'
 // :14:31: error: expected type '[2:0]u8', found '[2]u8'

--- a/test/cases/compile_errors/issue_4207_coerce_from_non-terminated-slice_to_terminated-pointer.zig
+++ b/test/cases/compile_errors/issue_4207_coerce_from_non-terminated-slice_to_terminated-pointer.zig
@@ -9,4 +9,4 @@ export fn foo() [*:0]const u8 {
 //
 // :3:18: error: expected type '[*:0]const u8', found '*[64]u8'
 // :3:18: note: destination pointer requires '0' sentinel
-// :1:18: note: function return type declared here
+// :1:17: note: function return type declared here

--- a/test/cases/compile_errors/using_an_unknown_len_ptr_type_instead_of_array.zig
+++ b/test/cases/compile_errors/using_an_unknown_len_ptr_type_instead_of_array.zig
@@ -10,4 +10,4 @@ comptime {
 // backend=stage2
 // target=native
 //
-// :1:22: error: type '[*][*]const u8' does not support array initialization syntax
+// :1:21: error: type '[*][*]const u8' does not support array initialization syntax


### PR DESCRIPTION
Fixes #19440

Rework of #20323 

As suggested in my original PR, I dug into the parser for this issue and believe I have diagnosed the issue. With the following input...

```zig
test {
    _ = .{}[*0];
}
```

...the brackets would first be parsed as an `.array_access` on `.{}`, and then *reused* [here](https://github.com/ziglang/zig/blob/04e08ea883f94d2de7a91daee72ccc9613a18a43/lib/std/zig/Parse.zig#L3529) to allow `[*0]` to be parsed as a `.ptr_type_aligned`. This "sharing" of  the left bracket then caused the odd behavior with zig fmt. I added a check in the parsing code to disambiguate the `.ptr_type_aligned` and `.ptr_type` cases, and also updated `Ast.firstToken()` to reflect this change. 