### PR TITLE
-freference-trace can work without colors

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -733,7 +733,7 @@ fn runStepNames(
     if (run.prominent_compile_errors and total_compile_errors > 0) {
         for (step_stack.keys()) |s| {
             if (s.result_error_bundle.errorMessageCount() > 0) {
-                s.result_error_bundle.renderToStdErr(renderOptions(ttyconf));
+                s.result_error_bundle.renderToStdErr(b.renderOptions(ttyconf));
             }
         }
 
@@ -1407,14 +1407,6 @@ fn get_tty_conf(color: Color, stderr: File) std.io.tty.Config {
         .auto => std.io.tty.detectConfig(stderr),
         .on => .escape_codes,
         .off => .no_color,
-    };
-}
-
-fn renderOptions(ttyconf: std.io.tty.Config) std.zig.ErrorBundle.RenderOptions {
-    return .{
-        .ttyconf = ttyconf,
-        .include_source_line = ttyconf != .no_color,
-        .include_reference_trace = ttyconf != .no_color,
     };
 }
 

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -2854,6 +2854,14 @@ pub fn systemIntegrationOption(
     }
 }
 
+pub fn renderOptions(b: Build, ttyconf: std.io.tty.Config) std.zig.ErrorBundle.RenderOptions {
+    return .{
+        .ttyconf = ttyconf,
+        .include_source_line = true,
+        .include_reference_trace = (b.reference_trace orelse 0) > 0,
+    };
+}
+
 test {
     _ = Cache;
     _ = Step;

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -2854,14 +2854,6 @@ pub fn systemIntegrationOption(
     }
 }
 
-pub fn renderOptions(b: Build, ttyconf: std.io.tty.Config) std.zig.ErrorBundle.RenderOptions {
-    return .{
-        .ttyconf = ttyconf,
-        .include_source_line = true,
-        .include_reference_trace = (b.reference_trace orelse 0) > 0,
-    };
-}
-
 test {
     _ = Cache;
     _ = Step;

--- a/lib/std/Build/Fuzz.zig
+++ b/lib/std/Build/Fuzz.zig
@@ -127,7 +127,7 @@ fn rebuildTestsWorkerRunFallible(run: *Step.Run, ttyconf: std.io.tty.Config, par
     if (show_error_msgs or show_compile_errors or show_stderr) {
         std.debug.lockStdErr();
         defer std.debug.unlockStdErr();
-        build_runner.printErrorMessages(gpa, &compile.step, ttyconf, stderr, false) catch {};
+        build_runner.printErrorMessages(gpa, &compile.step, .{ .ttyconf = ttyconf }, stderr, false) catch {};
     }
 
     const rebuilt_bin_path = result catch |err| switch (err) {
@@ -155,7 +155,7 @@ fn fuzzWorkerRun(
             const stderr = std.io.getStdErr();
             std.debug.lockStdErr();
             defer std.debug.unlockStdErr();
-            build_runner.printErrorMessages(gpa, &run.step, ttyconf, stderr, false) catch {};
+            build_runner.printErrorMessages(gpa, &run.step, .{ .ttyconf = ttyconf }, stderr, false) catch {};
             return;
         },
         else => {

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -54,11 +54,8 @@ pub const Color = enum {
     }
 
     pub fn renderOptions(color: Color) std.zig.ErrorBundle.RenderOptions {
-        const ttyconf = get_tty_conf(color);
         return .{
-            .ttyconf = ttyconf,
-            .include_source_line = ttyconf != .no_color,
-            .include_reference_trace = ttyconf != .no_color,
+            .ttyconf = get_tty_conf(color),
         };
     }
 };


### PR DESCRIPTION
Currently `-freference-trace` only works when running from a terminal.
This is annoying if you're running in another environment or if you redirect the output.
But `-freference-trace` also works fine without the color, so just changing how the build runner is interpreting this option.

main.zig:

```
const std = @import("std");
pub fn main() !void {
    f();
}

pub fn f() void {
    std.debug.print("Hello ", .{"world"});
}
```

console: 

```
> zig run main.zig
~/zig-macos-aarch64-0.14.0-dev.2851+b074fb7dd/lib/std/fmt.zig:206:18: error: unused argument in 'Hello '
            1 => @compileError("unused argument in '" ++ fmt ++ "'"),
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    print__anon_5159: ~/zig-macos-aarch64-0.14.0-dev.2851+b074fb7dd/lib/std/io/Writer.zig:24:26
    print__anon_2883: ~/zig-macos-aarch64-0.14.0-dev.2851+b074fb7dd/lib/std/io.zig:312:47
    6 reference(s) hidden; use '-freference-trace=8' to see all references
1

> zig run main.zig 2> log.txt ; cat log.txt
~/zig-macos-aarch64-0.14.0-dev.2851+b074fb7dd/lib/std/fmt.zig:206:18: error: unused argument in 'Hello '
```