### PR TITLE
package manager: allow overriding dependencies with local cache

### DIFF
--- a/ci/aarch64-linux-debug.sh
+++ b/ci/aarch64-linux-debug.sh
@@ -58,6 +58,15 @@ stage3-debug/bin/zig build test docs \
   --zig-lib-dir "$PWD/../lib" \
   -Denable-superhtml
 
+# Ensure that dependency overrides function correctly
+wd=$PWD
+
+cd ../test/dependency_override
+./run-tests.sh ../../build-debug/stage3-debug/bin/zig
+cd $wd
+
+unset wd
+
 stage3-debug/bin/zig build \
   --prefix stage4-debug \
   -Denable-llvm \

--- a/ci/aarch64-linux-release.sh
+++ b/ci/aarch64-linux-release.sh
@@ -73,3 +73,12 @@ stage3-release/bin/zig build \
 echo "If the following command fails, it means nondeterminism has been"
 echo "introduced, making stage3 and stage4 no longer byte-for-byte identical."
 diff stage3-release/bin/zig stage4-release/bin/zig
+
+# Ensure that dependency overrides function correctly
+wd=$PWD
+
+cd ../test/dependency_override
+./run-tests.sh ../../build-release/stage3-release/bin/zig
+cd $wd
+
+unset wd

--- a/ci/aarch64-macos-debug.sh
+++ b/ci/aarch64-macos-debug.sh
@@ -55,3 +55,12 @@ stage3-debug/bin/zig build test docs \
   -Dstatic-llvm \
   -Dskip-non-native \
   --search-prefix "$PREFIX"
+
+# Ensure that dependency overrides function correctly
+wd=$PWD
+
+cd ../test/dependency_override
+./run-tests.sh ../../build-debug/stage3-debug/bin/zig
+cd $wd
+
+unset wd

--- a/ci/aarch64-macos-release.sh
+++ b/ci/aarch64-macos-release.sh
@@ -56,6 +56,15 @@ stage3-release/bin/zig build test docs \
   -Dskip-non-native \
   --search-prefix "$PREFIX"
 
+# Ensure that dependency overrides function correctly
+wd=$PWD
+
+cd ../test/dependency_override
+./run-tests.sh ../../build-release/stage3-release/bin/zig
+cd $wd
+
+unset wd
+
 # Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3-release/bin/zig build \
   --prefix stage4-release \

--- a/ci/x86_64-linux-debug.sh
+++ b/ci/x86_64-linux-debug.sh
@@ -68,3 +68,12 @@ stage3-debug/bin/zig build test docs \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$PWD/../lib" \
   -Denable-superhtml
+
+# Ensure that dependency overrides function correctly
+wd=$PWD
+
+cd ../test/dependency_override
+./run-tests.sh ../../build-debug/stage3-debug/bin/zig
+cd $wd
+
+unset wd

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -70,6 +70,15 @@ stage3-release/bin/zig build test docs \
   --zig-lib-dir "$PWD/../lib" \
   -Denable-superhtml
 
+# Ensure that dependency overrides function correctly
+wd=$PWD
+
+cd ../test/dependency_override
+./run-tests.sh ../../build-release/stage3-release/bin/zig
+cd $wd
+
+unset wd
+
 # Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3-release/bin/zig build \
   --prefix stage4-release \

--- a/ci/x86_64-macos-release.sh
+++ b/ci/x86_64-macos-release.sh
@@ -73,3 +73,12 @@ stage3/bin/zig build \
 echo "If the following command fails, it means nondeterminism has been"
 echo "introduced, making stage3 and stage4 no longer byte-for-byte identical."
 diff stage3/bin/zig stage4/bin/zig
+
+# Ensure that dependency overrides function correctly
+wd=$PWD
+
+cd ../test/dependency_override
+./run-tests.sh ../../build/stage3/bin/zig
+cd $wd
+
+unset wd

--- a/src/main.zig
+++ b/src/main.zig
@@ -5067,6 +5067,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
                     .http_client = &http_client,
                     .thread_pool = &thread_pool,
                     .global_cache = dirs.global_cache,
+                    .local_cache = dirs.local_cache,
                     .read_only = false,
                     .recursive = true,
                     .debug_hash = false,
@@ -5114,6 +5115,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
                     .use_latest_commit = false,
 
                     .package_root = undefined,
+                    .local_override = false,
                     .error_bundle = undefined,
                     .manifest = null,
                     .manifest_ast = undefined,
@@ -6860,6 +6862,7 @@ fn cmdFetch(
         .http_client = &http_client,
         .thread_pool = &thread_pool,
         .global_cache = global_cache_directory,
+        .local_cache = null,
         .recursive = false,
         .read_only = false,
         .debug_hash = debug_hash,
@@ -6886,6 +6889,7 @@ fn cmdFetch(
         .use_latest_commit = true,
 
         .package_root = undefined,
+        .local_override = false,
         .error_bundle = undefined,
         .manifest = null,
         .manifest_ast = undefined,

--- a/test/dependency_override/build.zig
+++ b/test/dependency_override/build.zig
@@ -1,0 +1,49 @@
+pub fn build(b: *std.Build) !void {
+    const optimize = b.standardOptimizeOption(.{});
+    const target = b.standardTargetOptions(.{});
+
+    const overridden_runtime_pkg = b.dependency("overridden_runtime", .{});
+    const overridden_buildtime_pkg = b.dependency("overridden_buildtime", .{});
+
+    const overridden_runtime_module = overridden_runtime_pkg.module("module");
+    const overridden_buildtime_module = overridden_buildtime_pkg.module("module");
+
+    const test_step = b.step("test", "check package override behavior");
+    b.default_step = test_step;
+
+    {
+        const exe = b.addExecutable(.{
+            .name = "dep-override-test-runtime",
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        exe.root_module.addImport("module", overridden_runtime_module);
+
+        const run = b.addRunArtifact(exe);
+
+        const step = b.step("runtime", "check error package is overridden at runtime");
+        step.dependOn(&run.step);
+
+        test_step.dependOn(&run.step);
+    }
+
+    {
+        const exe = b.addExecutable(.{
+            .name = "dep-override-test-buildtime",
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        exe.root_module.addImport("module", overridden_buildtime_module);
+
+        const run = b.addRunArtifact(exe);
+
+        const step = b.step("buildtime", "check error package is overridden at buildtime");
+        step.dependOn(&run.step);
+
+        test_step.dependOn(&run.step);
+    }
+}
+
+const std = @import("std");

--- a/test/dependency_override/build.zig.zon
+++ b/test/dependency_override/build.zig.zon
@@ -1,0 +1,16 @@
+.{
+    .name = .dependency_override,
+    .fingerprint = 0x1d52eb5bc39f2664,
+    .version = "0.0.0",
+    .paths = .{""},
+    .dependencies = .{
+        .overridden_runtime = .{
+            .url = "https://example.com",
+            .hash = "overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX",
+        },
+        .overridden_buildtime = .{
+            .url = "https://example.com",
+            .hash = "overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN",
+        },
+    },
+}

--- a/test/dependency_override/cache-with-bad-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/build.zig
+++ b/test/dependency_override/cache-with-bad-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/build.zig
@@ -1,0 +1,8 @@
+pub fn build(b: *std.Build) !void {
+    _ = b.addModule("module", .{
+        .root_source_file = b.path("src/root.zig"),
+    });
+    @panic("overridden-buildtime package has not been overridden");
+}
+
+const std = @import("std");

--- a/test/dependency_override/cache-with-bad-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/build.zig.zon
+++ b/test/dependency_override/cache-with-bad-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = .overridden_buildtime_pkg,
+    .version = "0.0.0",
+    .paths = .{""},
+}

--- a/test/dependency_override/cache-with-bad-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/src/root.zig
+++ b/test/dependency_override/cache-with-bad-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/src/root.zig
@@ -1,0 +1,5 @@
+pub fn run() void {
+    @panic("the overridden-buildtime package has not been overridden");
+}
+
+const std = @import("std");

--- a/test/dependency_override/cache-with-bad-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/build.zig
+++ b/test/dependency_override/cache-with-bad-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/build.zig
@@ -1,0 +1,7 @@
+pub fn build(b: *std.Build) !void {
+    _ = b.addModule("module", .{
+        .root_source_file = b.path("src/root.zig"),
+    });
+}
+
+const std = @import("std");

--- a/test/dependency_override/cache-with-bad-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/build.zig.zon
+++ b/test/dependency_override/cache-with-bad-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = .overridden_runtime_pkg,
+    .version = "0.0.0",
+    .paths = .{""},
+}

--- a/test/dependency_override/cache-with-bad-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/src/root.zig
+++ b/test/dependency_override/cache-with-bad-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/src/root.zig
@@ -1,0 +1,5 @@
+pub fn run() void {
+    @panic("the overridden-runtime package has not been overridden");
+}
+
+const std = @import("std");

--- a/test/dependency_override/cache-with-good-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/build.zig
+++ b/test/dependency_override/cache-with-good-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/build.zig
@@ -1,0 +1,7 @@
+pub fn build(b: *std.Build) !void {
+    _ = b.addModule("module", .{
+        .root_source_file = b.path("src/root.zig"),
+    });
+}
+
+const std = @import("std");

--- a/test/dependency_override/cache-with-good-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/build.zig.zon
+++ b/test/dependency_override/cache-with-good-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = .overridden_buildtime_pkg,
+    .version = "0.0.0",
+    .paths = .{""},
+}

--- a/test/dependency_override/cache-with-good-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/src/root.zig
+++ b/test/dependency_override/cache-with-good-pkgs/p/overridden_buildtime_pkg-0.0.0-AAAAALcBAABxm1t_JaDEv2JAbqTxTR7030GYiuw3tGUN/src/root.zig
@@ -1,0 +1,5 @@
+pub fn run() void {
+    std.debug.print("this is the overridden-buildtime package\n", .{});
+}
+
+const std = @import("std");

--- a/test/dependency_override/cache-with-good-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/build.zig
+++ b/test/dependency_override/cache-with-good-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/build.zig
@@ -1,0 +1,7 @@
+pub fn build(b: *std.Build) !void {
+    _ = b.addModule("module", .{
+        .root_source_file = b.path("src/root.zig"),
+    });
+}
+
+const std = @import("std");

--- a/test/dependency_override/cache-with-good-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/build.zig.zon
+++ b/test/dependency_override/cache-with-good-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = .overridden_runtime_pkg,
+    .version = "0.0.0",
+    .paths = .{""},
+}

--- a/test/dependency_override/cache-with-good-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/src/root.zig
+++ b/test/dependency_override/cache-with-good-pkgs/p/overridden_runtime_pkg-0.0.0-AAAAAG8BAADm054BUibxV6D-KNadKUJKOmpavQp3xJkX/src/root.zig
@@ -1,0 +1,5 @@
+pub fn run() void {
+    std.debug.print("this is the overridden-runtime package\n", .{});
+}
+
+const std = @import("std");

--- a/test/dependency_override/run-tests.sh
+++ b/test/dependency_override/run-tests.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+ZIG=$1
+
+if [ -d local-cache ]; then rm local-cache; fi
+if [ -d global-cache ]; then rm global-cache; fi
+
+cp -r cache-with-good-pkgs local-cache
+cp -r cache-with-bad-pkgs global-cache
+
+$ZIG build test --global-cache-dir global-cache --cache-dir local-cache && \
+$ZIG build test --cache-dir local-cache && \
+$ZIG build test --system cache-with-good-pkgs/p --cache-dir global-cache
+
+rm -r local-cache global-cache
+cp -r cache-with-bad-pkgs local-cache
+cp -r cache-with-good-pkgs global-cache
+
+$ZIG build test --global-cache-dir global-cache --cache-dir local-cache
+if [ $? -eq 0 ]; then exit 1; fi
+$ZIG build test --cache-dir local-cache
+if [ $? -eq 0 ]; then exit 1; fi
+
+rm -r local-cache global-cache

--- a/test/dependency_override/src/main.zig
+++ b/test/dependency_override/src/main.zig
@@ -1,0 +1,5 @@
+pub fn main() void {
+    @import("module").run();
+}
+
+const std = @import("std");


### PR DESCRIPTION
This resolves #20180 (the package overriding portion not the proposed command for examining the dependency tree). While the issue is not accepted I've found this very useful myself and should be mergeable (sans any issues with the testing approach explained [below](https://github.com/ziglang/zig/pull/20348#issuecomment-2191249046)), so I expect to continue updating/rebasing this PR until the issue is either accepted or rejected.

The approach taken is to change the package root written to the generated `dependencies.zig` file to point into the local cache. In addition a new `.local_override` field is added to facilitate warning messages produced by the build runner.

I have some tests for verifying the behaviour of the package overriding at configure time (i.e. that the correct `build.zig` is used for the package) and compile time (that the correct version of the package is used), but I'm not sure at the moment how to integrate them into the test system as I don't think there is a way to get the effect of passing the `--global-cache-dir`, `--cache-dir` and `--system` flags to standalone tests, which would be needed for checking that the right thing happens when these flags are passed to `zig build`.

PR #20281 implements the tool described in #20180 for examining the hashes of dependencies - it could be merged into this PR, but it is also useful separately and the two PRs are not inter-dependant.