### PR TITLE
Bring emit-h back to life!

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3445,7 +3445,7 @@ fn processOneJob(comp: *Compilation, job: Job, prog_node: std.Progress.Node) !vo
                         .error_msg = null,
                     };
 
-                    emitter.emitDecl() catch |err| switch (err) {
+                    emitter.renderDecl() catch |err| switch (err) {
                         error.AnalysisFail => {
                             try emit_h.failed_decls.put(gpa, decl_index, emitter.error_msg.?);
                             return;

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3429,6 +3429,7 @@ fn processOneJob(comp: *Compilation, job: Job, prog_node: std.Progress.Node) !vo
 
                     const gop = try emit_h.decl_table.getOrPut(gpa, decl_index);
 
+                    // TODO: support updating declarations
                     if (gop.found_existing) return;
 
                     const decl_emit_h = try emit_h.allocated_emit_h.addOne(gpa);

--- a/src/EmitH.zig
+++ b/src/EmitH.zig
@@ -12,7 +12,7 @@ const Error = error{ OutOfMemory, AnalysisFail };
 gpa: std.mem.Allocator,
 zcu: *Zcu,
 decl: *Zcu.Decl,
-decl_index: std.zig.DeclIndex,
+decl_index: InternPool.DeclIndex,
 emit_h: *Zcu.EmitH,
 error_msg: ?*Zcu.ErrorMsg,
 
@@ -662,7 +662,7 @@ const TrailingSpace = enum {
 };
 
 fn fail(emitter: *EmitH, comptime format: []const u8, args: anytype) Error {
-    emitter.error_msg = Zcu.ErrorMsg.create(emitter.gpa, emitter.decl.srcLoc(emitter.zcu), format, args) catch |err| return err;
+    emitter.error_msg = Zcu.ErrorMsg.create(emitter.gpa, emitter.decl.navSrcLoc(emitter.zcu).upgrade(emitter.zcu), format, args) catch |err| return err;
     return error.AnalysisFail;
 }
 

--- a/src/Module.zig
+++ b/src/Module.zig
@@ -572,6 +572,7 @@ pub const Decl = struct {
 /// This state is attached to every Decl when Module emit_h is non-null.
 pub const EmitH = struct {
     fwd_decl: ArrayListUnmanaged(u8) = .{},
+    header_section: @import("EmitH.zig").HeaderSection = .unknown,
 };
 
 pub const DeclAdapter = struct {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6505,6 +6505,7 @@ fn addExport(mod: *Module, export_init: Module.Export) error{OutOfMemory}!void {
             const de_gop = mod.decl_exports.getOrPutAssumeCapacity(decl_index);
             if (!de_gop.found_existing) de_gop.value_ptr.* = .{};
             try de_gop.value_ptr.append(gpa, new_export);
+            try mod.emitHDecl(decl_index);
         },
         .value => |value| {
             const ve_gop = mod.value_exports.getOrPutAssumeCapacity(value);

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -3087,16 +3087,10 @@ pub fn genHeader(dg: *DeclGen) error{ AnalysisFail, OutOfMemory }!void {
     const zcu = dg.zcu;
     const decl_index = dg.pass.decl;
     const decl = zcu.declPtr(decl_index);
+    _ = decl; // autofix
     const writer = dg.fwdDeclWriter();
+    _ = writer; // autofix
 
-    switch (decl.typeOf(zcu).zigTypeTag(zcu)) {
-        .Fn => if (dg.declIsGlobal(decl.val)) {
-            try writer.writeAll("zig_extern ");
-            try dg.renderFunctionSignature(writer, dg.pass.decl, .complete, .{ .export_index = 0 });
-            try dg.fwd_decl.appendSlice(";\n");
-        },
-        else => {},
-    }
 }
 
 /// Generate code for an entire body which ends with a `noreturn` instruction. The states of

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -3080,19 +3080,6 @@ pub fn genDeclValue(
     try w.writeAll(";\n");
 }
 
-pub fn genHeader(dg: *DeclGen) error{ AnalysisFail, OutOfMemory }!void {
-    const tracy = trace(@src());
-    defer tracy.end();
-
-    const zcu = dg.zcu;
-    const decl_index = dg.pass.decl;
-    const decl = zcu.declPtr(decl_index);
-    _ = decl; // autofix
-    const writer = dg.fwdDeclWriter();
-    _ = writer; // autofix
-
-}
-
 /// Generate code for an entire body which ends with a `noreturn` instruction. The states of
 /// `value_map` and `free_locals_map` are undefined after the generation, and new locals may not
 /// have been added to `free_locals_map`. For a version of this function that restores this state,

--- a/src/emit_h.zig
+++ b/src/emit_h.zig
@@ -1,0 +1,253 @@
+const std = @import("std");
+const Zcu = @import("Module.zig");
+const c = @import("codegen/c.zig");
+const trace = @import("tracy.zig").trace;
+const zig_h = @import("link/C.zig").zig_h;
+const InternPool = @import("InternPool.zig");
+const Type = @import("type.zig").Type;
+const Zir = std.zig.Zir;
+
+const Error = error{ OutOfMemory, AnalysisFail };
+
+pub fn emitH(gpa: std.mem.Allocator, zcu: *Zcu, decl: *Zcu.Decl, emit_h: *Zcu.EmitH, error_msg: *?*Zcu.ErrorMsg) Error!void {
+    _ = error_msg; // autofix
+
+    const ip = &zcu.intern_pool;
+    const ty = decl.typeOf(zcu);
+    const file = decl.getFileScope(zcu);
+
+    const writer = emit_h.fwd_decl.writer(gpa);
+
+    if (decl.zir_decl_index.unwrap()) |zir_index| {
+        const zir_decl, const extra_end = file.zir.getDeclaration(zir_index.resolve(ip));
+        if (zir_decl.flags.has_doc_comment) {
+            const doc_comment = file.zir.nullTerminatedString(@enumFromInt(file.zir.extra[extra_end]));
+            var it = std.mem.split(u8, doc_comment, "\n");
+            while (it.next()) |line| {
+                try writer.print("//{s}\n", .{line});
+            }
+        }
+    }
+
+    switch (ty.zigTypeTag(zcu)) {
+        .Fn => {
+            const info = zcu.typeToFunc(ty).?;
+
+            try writer.writeAll("zig_extern ");
+            try emitReferenceToType(writer, zcu, ip, info.return_type);
+            // TODO: Use exported decl name
+            try writer.print(" {s}(", .{decl.name.toSlice(ip)});
+
+            const params = info.param_types.get(ip);
+
+            for (params, 0..) |param, param_idx| {
+                try emitReferenceToType(writer, zcu, ip, param);
+                try writer.print(" a{d}", .{param_idx});
+                if (param_idx != params.len - 1) try writer.writeAll(", ");
+            }
+
+            try writer.writeAll(");\n");
+        },
+        .Type => {
+            const val = decl.valueOrFail() catch return error.AnalysisFail;
+            const tp = val.toType();
+
+            switch (tp.zigTypeTag(zcu)) {
+                .Struct => {
+                    const should_make_opaque = switch (tp.containerLayout(zcu)) {
+                        .@"extern" => false,
+                        .@"packed" => switch (tp.bitSizeAdvanced(zcu, null) catch unreachable) {
+                            0, 8, 16, 32, 64, 128 => false,
+                            else => true,
+                        },
+                        .auto => true,
+                    };
+
+                    const info = zcu.typeToStruct(tp).?;
+
+                    const name = decl.name.toSlice(ip);
+                    if (should_make_opaque) {
+                        try writer.print("typedef struct {s} {s};\n", .{ name, name });
+                    } else {
+                        try writer.writeAll("typedef struct ");
+                        try writer.print("{s} {{\n", .{name});
+
+                        for (info.field_names.get(ip), info.field_types.get(ip)) |field_name, field_type| {
+                            try writer.print("    ", .{});
+                            try emitReferenceToType(writer, zcu, ip, field_type);
+                            try writer.print(" {s};\n", .{field_name.toSlice(ip)});
+                        }
+
+                        try writer.print("}} {s};\n", .{name});
+                    }
+                },
+                .Union => {
+                    const should_make_opaque = switch (tp.containerLayout(zcu)) {
+                        .@"extern" => false,
+                        .@"packed" => switch (tp.bitSizeAdvanced(zcu, null) catch unreachable) {
+                            0, 8, 16, 32, 64, 128 => false,
+                            else => true,
+                        },
+                        .auto => true,
+                    };
+
+                    const info = zcu.typeToUnion(tp).?;
+                    const tag_type_info = info.loadTagType(ip);
+
+                    const name = decl.name.toSlice(ip);
+                    if (should_make_opaque) {
+                        try writer.print("typedef union {s} {s};\n", .{ name, name });
+                    } else {
+                        try writer.writeAll("typedef union ");
+                        try writer.print("{s} {{\n", .{name});
+
+                        for (tag_type_info.names.get(ip), info.field_types.get(ip)) |field_name, field_type| {
+                            try writer.print("    ", .{});
+                            try emitReferenceToType(writer, zcu, ip, field_type);
+                            try writer.print(" {s};\n", .{field_name.toSlice(ip)});
+                        }
+
+                        try writer.print("}} {s};\n", .{name});
+                    }
+                },
+                .Enum => {
+                    const info = ip.loadEnumType(tp.ip_index);
+
+                    const name = decl.name.toSlice(ip);
+                    try writer.writeAll("typedef enum {\n");
+
+                    const values = info.values.get(ip);
+
+                    if (values.len > 0) {
+                        for (info.names.get(ip), values) |tag_name, value| {
+                            try writer.print("    {s} = {d},\n", .{
+                                tag_name.toSlice(ip),
+                                switch (ip.indexToKey(value).int.storage) {
+                                    inline .u64, .i64 => |x| std.math.cast(u128, x) orelse unreachable,
+                                    .big_int => |x| x.to(u128) catch unreachable,
+                                    .lazy_align, .lazy_size => unreachable,
+                                },
+                            });
+                        }
+                    } else {
+                        // Auto-numbered
+                        for (info.names.get(ip), 0..) |tag_name, value| {
+                            try writer.print("    {s} = {d},\n", .{ tag_name.toSlice(ip), value });
+                        }
+                    }
+
+                    try writer.print("}} {s};\n", .{name});
+                },
+                else => unreachable,
+            }
+        },
+        else => {},
+    }
+}
+
+fn emitReferenceToType(
+    writer: anytype,
+    zcu: *Zcu,
+    ip: *const InternPool,
+    index: InternPool.Index,
+) Error!void {
+    switch (index) {
+        .f16_type => try writer.writeAll("zig_f16"),
+        .f32_type => try writer.writeAll("zig_f32"),
+        .f64_type => try writer.writeAll("zig_f64"),
+        .f80_type => try writer.writeAll("zig_f80"),
+        .f128_type => try writer.writeAll("zig_f128"),
+        .usize_type => try writer.writeAll("uintptr_t"),
+        .isize_type => try writer.writeAll("intptr_t"),
+        .c_char_type => try writer.writeAll("char"),
+        .c_short_type => try writer.writeAll("short"),
+        .c_ushort_type => try writer.writeAll("ushort"),
+        .c_int_type => try writer.writeAll("int"),
+        .c_uint_type => try writer.writeAll("uint"),
+        .c_long_type => try writer.writeAll("long"),
+        .c_ulong_type => try writer.writeAll("unsigned long"),
+        .c_longlong_type => try writer.writeAll("long long"),
+        .c_ulonglong_type => try writer.writeAll("unsigned long long"),
+        .c_longdouble_type => try writer.writeAll("long double"),
+        .anyopaque_type => try writer.writeAll("void"),
+        .bool_type => try writer.writeAll("_Bool"),
+        .void_type => try writer.writeAll("void"),
+
+        .u0_type => try writer.writeAll("void"), // TODO: skip this param
+        .u8_type => try writer.writeAll("uint8_t"),
+        .u16_type => try writer.writeAll("uint16_t"),
+        .u32_type => try writer.writeAll("uint32_t"),
+        .u64_type => try writer.writeAll("uint64_t"),
+        .u128_type => try writer.writeAll("zig_u128"),
+        else => switch (ip.indexToKey(index)) {
+            .struct_type => {
+                const info = zcu.typeToStruct(Type.fromInterned(index)).?;
+                const decl = info.decl.unwrap().?;
+                try writer.writeAll(ip.declPtrConst(decl).name.toSlice(ip));
+                try zcu.comp.work_queue.writeItem(.{ .emit_h_decl = decl });
+            },
+            .union_type => {
+                const info = zcu.typeToUnion(Type.fromInterned(index)).?;
+                try writer.writeAll(ip.declPtrConst(info.decl).name.toSlice(ip));
+                try zcu.comp.work_queue.writeItem(.{ .emit_h_decl = info.decl });
+            },
+            .enum_type => {
+                const info = ip.loadEnumType(index);
+                try emitReferenceToType(writer, zcu, ip, info.tag_ty);
+                try zcu.comp.work_queue.writeItem(.{ .emit_h_decl = info.decl });
+            },
+            .ptr_type => |info| {
+                std.debug.assert(info.flags.size != .Slice);
+                if (info.flags.is_const) {
+                    try writer.writeAll("const ");
+                }
+                try emitReferenceToType(writer, zcu, ip, info.child);
+                try writer.writeAll(" *");
+            },
+            else => unreachable,
+        },
+    }
+}
+
+pub fn flushEmitH(zcu: *Zcu) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
+    const emit_h = zcu.emit_h orelse return;
+
+    // We collect a list of buffers to write, and write them all at once with pwritev 😎
+    const num_buffers = emit_h.decl_table.count() + 1;
+    var all_buffers = try std.ArrayList(std.posix.iovec_const).initCapacity(zcu.gpa, num_buffers);
+    defer all_buffers.deinit();
+
+    var file_size: u64 = zig_h.len;
+    if (zig_h.len != 0) {
+        all_buffers.appendAssumeCapacity(.{
+            .base = zig_h,
+            .len = zig_h.len,
+        });
+    }
+
+    for (0..emit_h.decl_table.count()) |decl_table_index| {
+        const decl_emit_h = emit_h.allocated_emit_h.at(decl_table_index);
+        const buf = decl_emit_h.fwd_decl.items;
+        if (buf.len != 0) {
+            all_buffers.appendAssumeCapacity(.{
+                .base = buf.ptr,
+                .len = buf.len,
+            });
+            file_size += buf.len;
+        }
+    }
+
+    const directory = emit_h.loc.directory orelse zcu.comp.local_cache_directory;
+    const file = try directory.handle.createFile(emit_h.loc.basename, .{
+        // We set the end position explicitly below; by not truncating the file, we possibly
+        // make it easier on the file system by doing 1 reallocation instead of two.
+        .truncate = false,
+    });
+    defer file.close();
+
+    try file.setEndPos(file_size);
+    try file.pwritevAll(all_buffers.items, 0);
+}


### PR DESCRIPTION
See the current results here: https://zigbin.io/a90812

Some things I still need to do:
- [x] Use export names rather than the names of the exported decls (can be different w/ `@export` for example)
- [x] ~~Give structs better generated names(?)~~ Decided to keep simple, not fully-qualified names for now. Can definitely cause issues, but this requires a larger rethinking potentially that should be in a proposal issue.
- [x] Figure out why ZIR indices on structs, unions, and enums seem to disappear (there's probably a good reason for this that I'm not aware of, or a bug)
- [x] Add parent_fix from CBE logic I stole back to remove unnecessary parens
- [x] Extract param names from functions
- [x] Better styling for output code (a little cramped? maybe group functions together?)
- [x] ~~Probably add a couple tests~~ Not blocking for merge, can be added later.

But it does work 100% better than the current emit-h! :P