### PR TITLE
improve @enumFromInt doc

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4702,8 +4702,11 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       Converts an integer into an {#link|enum#} value. The return type is the inferred result type.
       </p>
       <p>
-      Attempting to convert an integer which represents no value in the chosen enum type invokes
+      Attempting to convert an integer with no corresponding value in the enum invokes 
       safety-checked {#link|Undefined Behavior#}.
+      Note that a {#link|non-exhaustive enum|Non-exhaustive enum#} has corresponding values for all
+      integers in the enum's integer tag type: the {#syntax#}_{#endsyntax#} value represents all 
+      the remaining unnamed integers in the enum's tag type.
       </p>
       {#see_also|@intFromEnum#}
       {#header_close#}


### PR DESCRIPTION
Attempts to resolve https://github.com/ziglang/zig/issues/19123

This is my first time contributing, open to any and all feedback!

The changes to the docs look like this (the sentence beginning "Integers captured..." was added):

![image](https://github.com/ziglang/zig/assets/56497124/58a91101-9d1f-4e6f-bff9-c9ede0deb8ae)

I tested it by running `zig build langref` and opening `zig-out/doc/langref.html` in Firefox. I also tested the link to non-exhaustive enum and it does jump to it.