### PR TITLE
build runner: add missing 'new' option to --summary error hint

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -181,7 +181,7 @@ pub fn main() !void {
                 const next_arg = nextArg(args, &arg_idx) orelse
                     fatalWithHint("expected [all|new|failures|none] after '{s}'", .{arg});
                 summary = std.meta.stringToEnum(Summary, next_arg) orelse {
-                    fatalWithHint("expected [all|failures|none] after '{s}', found '{s}'", .{
+                    fatalWithHint("expected [all|new|failures|none] after '{s}', found '{s}'", .{
                         arg, next_arg,
                     });
                 };


### PR DESCRIPTION
The error message for the --summary command line option did not list 'new' as a valid choice, potentially confusing users.

This commit updates the error hint to accurately reflect all available options.