### PR TITLE
std.os.linux: sched_setaffinity fix

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1891,7 +1891,7 @@ pub fn sched_setaffinity(pid: pid_t, set: *const cpu_set_t) !void {
     const size = @sizeOf(cpu_set_t);
     const rc = syscall3(.sched_setaffinity, @as(usize, @bitCast(@as(isize, pid))), size, @intFromPtr(set));
 
-    switch (std.os.errno(rc)) {
+    switch (std.posix.errno(rc)) {
         .SUCCESS => return,
         else => |err| return std.posix.unexpectedErrno(err),
     }

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1891,7 +1891,7 @@ pub fn sched_setaffinity(pid: pid_t, set: *const cpu_set_t) !void {
     const size = @sizeOf(cpu_set_t);
     const rc = syscall3(.sched_setaffinity, @as(usize, @bitCast(@as(isize, pid))), size, @intFromPtr(set));
 
-    switch (std.posix.errno(rc)) {
+    switch (E.init(rc)) {
         .SUCCESS => return,
         else => |err| return std.posix.unexpectedErrno(err),
     }


### PR DESCRIPTION
`std.os.linux.sched_setaffinity()` does not compile on x86_64, `std.os.errno` is missing:
```zig
const std = @import("std");

pub fn main() !void {
    const set = std.mem.zeroes(std.os.linux.cpu_set_t);
    try std.os.linux.sched_setaffinity(0, &set);
}
```

```sh
$ ~/zig-linux-x86_64-0.14.0-dev.91+a154d8da8/zig run main.zig
/home/leki/zig-linux-x86_64-0.14.0-dev.91+a154d8da8/lib/std/os/linux.zig:1894:19: error: root struct of file 'os' has no member named 'errno'
    switch (std.os.errno(rc)) {
            ~~~~~~^~~~~~
/home/leki/zig-linux-x86_64-0.14.0-dev.91+a154d8da8/lib/std/os.zig:1:1: note: struct declared here
//! This file contains thin wrappers around OS-specific APIs, with these
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    main: main.zig:5:21
    callMain: /home/leki/zig-linux-x86_64-0.14.0-dev.91+a154d8da8/lib/std/start.zig:515:32
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```