### PR TITLE
Integrate running zig tests with kcov through build.zig

### DIFF
--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -219,6 +219,7 @@ pub fn getEmittedCoverage(run: *Run, opt: CoverageOptions) std.Build.LazyPath {
         run.addArg(exclude.items);
     }
 
+    run.addArg("--");
     const cov_dir = run.addOutputDirectoryArg("coverage");
     run.argv.appendSlice(allocator, old_argv) catch @panic("OOM");
     return cov_dir;


### PR DESCRIPTION
Issue:  #8505

prefixes kcov as a runner before the argv on Step.Run, returns the directory LazyPath containing the report.

```
_ = run.getEmittedCoverage(.{.exclude_zig_lib = false});
```

most projects probably dont want to cover the zig standard library and compiler source code, so we need to ignore it by argument to kcov.

for multiple test binaries, modern [kcov](https://man.archlinux.org/man/kcov.1.en) has `--merge`, `--collect-only` and  `--report-only` options to generate a single report, these are not available on my OS (Ubuntu 22.04)  yet though ;-(.

maybe `zig test` could also have an option (by passing a directory output path) to run the compiled test with kcov.