### PR TITLE
Enables dynamic linking for `.os_tag == .other` again

### DIFF
--- a/src/target.zig
+++ b/src/target.zig
@@ -8,7 +8,7 @@ pub const default_stack_protector_buffer_size = 4;
 
 pub fn cannotDynamicLink(target: std.Target) bool {
     return switch (target.os.tag) {
-        .freestanding, .other => true,
+        .freestanding => true,
         else => target.isSpirV(),
     };
 }


### PR DESCRIPTION
Closes #20355