### PR TITLE
std.Thread.Pool: process tree cooperation via a new jobserver protocol

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -120,6 +120,8 @@ pub const Graph = struct {
     needed_lazy_dependencies: std.StringArrayHashMapUnmanaged(void) = .{},
     /// Information about the native target. Computed before build() is invoked.
     host: ResolvedTarget,
+    /// Uninitialized until the make phase.
+    thread_pool: std.Thread.Pool,
 };
 
 const AvailableDeps = []const struct { []const u8, []const u8 };

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -1246,6 +1246,7 @@ fn spawnChildAndCollect(
     if (run.stdio != .zig_test and !run.disable_zig_progress and !inherit) {
         child.progress_node = prog_node;
     }
+    child.thread_pool = &b.graph.thread_pool;
 
     const term, const result, const elapsed_ns = t: {
         if (inherit) std.debug.lockStdErr();

--- a/lib/std/Thread/Pool.zig
+++ b/lib/std/Thread/Pool.zig
@@ -2,13 +2,18 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Pool = @This();
 const WaitGroup = @import("WaitGroup.zig");
+const assert = std.debug.assert;
 
-mutex: std.Thread.Mutex = .{},
-cond: std.Thread.Condition = .{},
-run_queue: RunQueue = .{},
-is_running: bool = true,
+mutex: std.Thread.Mutex,
+cond: std.Thread.Condition,
+run_queue: RunQueue,
+run_queue_len: usize,
+end_flag: bool,
 allocator: std.mem.Allocator,
-threads: []std.Thread,
+threads_buffer: []std.Thread,
+threads_len: usize,
+job_server_options: Options.JobServer,
+job_server: ?*JobServer,
 
 const RunQueue = std.SinglyLinkedList(Runnable);
 const Runnable = struct {
@@ -18,62 +23,186 @@ const Runnable = struct {
 const RunProto = *const fn (*Runnable) void;
 
 pub const Options = struct {
-    allocator: std.mem.Allocator,
+    /// Max number of threads to be actively working at the same time.
+    ///
+    /// `null` means to use the logical core count, leaving the main thread to
+    /// fill in the last slot.
+    ///
+    /// `0` is an illegal value.
     n_jobs: ?u32 = null,
+
+    /// For coordinating amongst an entire process tree.
+    job_server: Options.JobServer = .abstain,
+
+    pub const JobServer = union(enum) {
+        /// The thread pool neither hosts a jobserver nor connects to an existing one.
+        abstain,
+        /// The thread pool uses the Jobserver2 protocol to coordinate a global
+        /// thread pool across the entire process tree, avoiding cache
+        /// thrashing.
+        connect: std.net.Address,
+        /// The thread pool assumes the role of the root process and spawns a
+        /// dedicated thread for hosting the Jobserver2 protocol.
+        ///
+        /// Suggested to use a UNIX domain socket.
+        host: std.net.Address,
+    };
 };
 
-pub fn init(pool: *Pool, options: Options) !void {
-    const allocator = options.allocator;
-
-    pool.* = .{
+/// After initializing the thread pool and spawning work, the main thread must
+/// call `waitAndWork`.
+pub fn init(
+    /// Not required to be thread-safe; protected by the pool's mutex.
+    allocator: std.mem.Allocator,
+    options: Options,
+) !Pool {
+    var pool: Pool = .{
+        .mutex = .{},
+        .cond = .{},
+        .run_queue = .{},
+        .run_queue_len = 0,
+        .end_flag = false,
         .allocator = allocator,
-        .threads = &[_]std.Thread{},
+        .threads_buffer = &.{},
+        .threads_len = 0,
+        .job_server_options = options.job_server,
+        .job_server = null,
     };
 
-    if (builtin.single_threaded) {
+    if (builtin.single_threaded)
         return;
-    }
 
     const thread_count = options.n_jobs orelse @max(1, std.Thread.getCpuCount() catch 1);
+    assert(thread_count > 0);
 
-    // kill and join any threads we spawned and free memory on error.
-    pool.threads = try allocator.alloc(std.Thread, thread_count);
-    var spawned: usize = 0;
-    errdefer pool.join(spawned);
+    pool.threads_buffer = try allocator.alloc(std.Thread, thread_count);
+    errdefer allocator.free(pool.threads_buffer);
 
-    for (pool.threads) |*thread| {
-        thread.* = try std.Thread.spawn(.{}, worker, .{pool});
-        spawned += 1;
+    switch (options.job_server) {
+        .abstain, .connect => {},
+        .host => |addr| {
+            var server = try addr.listen(.{});
+            errdefer server.deinit();
+
+            const pollfds = try allocator.alloc(std.posix.pollfd, thread_count);
+            errdefer allocator.free(pollfds);
+
+            const job_server = try allocator.create(JobServer);
+            errdefer allocator.destroy(job_server);
+
+            job_server.* = .{
+                .server = server,
+                .pollfds = pollfds,
+                .thread = try std.Thread.spawn(.{}, JobServer.run, .{job_server}),
+            };
+
+            pool.job_server = job_server;
+        },
     }
+
+    return pool;
 }
 
 pub fn deinit(pool: *Pool) void {
-    pool.join(pool.threads.len); // kill and join all threads.
-    pool.* = undefined;
-}
-
-fn join(pool: *Pool, spawned: usize) void {
-    if (builtin.single_threaded) {
+    if (builtin.single_threaded)
         return;
-    }
 
     {
         pool.mutex.lock();
         defer pool.mutex.unlock();
 
-        // ensure future worker threads exit the dequeue loop
-        pool.is_running = false;
+        // Ensure future worker threads exit the dequeue loop.
+        pool.end_flag = true;
     }
 
-    // wake up any sleeping threads (this can be done outside the mutex)
-    // then wait for all the threads we know are spawned to complete.
+    // Wake up any sleeping threads (this can be done outside the mutex) then
+    // wait for all the threads we know are spawned to complete.
     pool.cond.broadcast();
-    for (pool.threads[0..spawned]) |thread| {
-        thread.join();
+
+    if (pool.job_server) |job_server| {
+        // Interrupt the jobserver thread from accepting connections.
+        // Since the server fd is also in the poll set, this handles both
+        // places where control flow could be blocked.
+        std.posix.shutdown(job_server.server.stream.handle, .both) catch {};
+        job_server.thread.join();
     }
 
-    pool.allocator.free(pool.threads);
+    // Since we set end_flag with the mutex locked, no more threads could have
+    // been created.
+    const threads = pool.threads_buffer[0..pool.threads_len];
+
+    for (threads) |thread|
+        thread.join();
+
+    pool.allocator.free(pool.threads_buffer);
+    pool.* = undefined;
 }
+
+pub const JobServer = struct {
+    server: std.net.Server,
+    /// Has length n_jobs + 1. The first entry contains the server socket
+    /// itself, so that calling shutdown() in the other thread will both cause
+    /// the accept to return error.SocketNotListening and cause the poll() to
+    /// return.
+    pollfds: []std.posix.pollfd,
+    thread: std.Thread,
+
+    pub fn run(js: *JobServer) void {
+        @memset(js.pollfds, .{
+            .fd = -1,
+            // Only interested in errors and hangups.
+            .events = 0,
+            .revents = 0,
+        });
+
+        js.pollfds[0].fd = js.server.stream.handle;
+
+        main_loop: while (true) {
+            for (js.pollfds[1..]) |*pollfd| {
+                const err_event = (pollfd.revents & std.posix.POLL.ERR) != 0;
+                const hup_event = (pollfd.revents & std.posix.POLL.HUP) != 0;
+                if (err_event or hup_event) {
+                    std.posix.close(pollfd.fd);
+                    pollfd.fd = -1;
+                    pollfd.revents = 0;
+                }
+
+                if (pollfd.fd >= 0) continue;
+
+                const connection = js.server.accept() catch |err| switch (err) {
+                    error.SocketNotListening => break :main_loop, // Indicates a shutdown request.
+                    else => |e| {
+                        std.log.debug("job server accept failure: {s}", .{@errorName(e)});
+                        continue;
+                    },
+                };
+                _ = std.posix.send(connection.stream.handle, &.{0}, std.posix.MSG.NOSIGNAL) catch {
+                    connection.stream.close();
+                    continue;
+                };
+                pollfd.fd = connection.stream.handle;
+            }
+
+            _ = std.posix.poll(js.pollfds, -1) catch continue;
+        }
+
+        // Closes the active connections as well as the server itself.
+        for (js.pollfds) |pollfd| {
+            if (pollfd.fd >= 0) {
+                std.posix.close(pollfd.fd);
+            }
+        }
+
+        // Delete the UNIX domain socket.
+        switch (js.server.listen_address.any.family) {
+            std.posix.AF.UNIX => {
+                const path = std.mem.sliceTo(&js.server.listen_address.un.path, 0);
+                std.fs.cwd().deleteFile(path) catch {};
+            },
+            else => {},
+        }
+    }
+};
 
 /// Runs `func` in the thread pool, calling `WaitGroup.start` beforehand, and
 /// `WaitGroup.finish` after it returns.
@@ -127,6 +256,22 @@ pub fn spawnWg(pool: *Pool, wait_group: *WaitGroup, comptime func: anytype, args
         };
 
         pool.run_queue.prepend(&closure.run_node);
+        pool.run_queue_len += 1;
+
+        // If there was already any queued work, spawn a new thread if we are
+        // under the max.
+        if (pool.run_queue_len > 1 and pool.threads_len < pool.threads_buffer.len) {
+            if (std.Thread.spawn(.{}, worker, .{pool})) |new_thread| {
+                pool.threads_buffer[pool.threads_len] = new_thread;
+                pool.threads_len += 1;
+            } else |_| if (pool.threads_len == 0) {
+                pool.mutex.unlock();
+                @call(.auto, func, args);
+                wait_group.finish();
+                return;
+            }
+        }
+
         pool.mutex.unlock();
     }
 
@@ -134,7 +279,7 @@ pub fn spawnWg(pool: *Pool, wait_group: *WaitGroup, comptime func: anytype, args
     pool.cond.signal();
 }
 
-pub fn spawn(pool: *Pool, comptime func: anytype, args: anytype) !void {
+pub fn spawn(pool: *Pool, comptime func: anytype, args: anytype) void {
     if (builtin.single_threaded) {
         @call(.auto, func, args);
         return;
@@ -162,15 +307,34 @@ pub fn spawn(pool: *Pool, comptime func: anytype, args: anytype) !void {
 
     {
         pool.mutex.lock();
-        defer pool.mutex.unlock();
 
-        const closure = try pool.allocator.create(Closure);
+        const closure = pool.allocator.create(Closure) catch {
+            pool.mutex.unlock();
+            @call(.auto, func, args);
+            return;
+        };
         closure.* = .{
             .arguments = args,
             .pool = pool,
         };
 
         pool.run_queue.prepend(&closure.run_node);
+        pool.run_queue_len += 1;
+
+        // If there was already any queued work, spawn a new thread if we are
+        // under the max.
+        if (pool.run_queue_len > 1 and pool.threads_len < pool.threads_buffer.len) {
+            if (std.Thread.spawn(.{}, worker, .{pool})) |new_thread| {
+                pool.threads_buffer[pool.threads_len] = new_thread;
+                pool.threads_len += 1;
+            } else |_| if (pool.threads_len == 0) {
+                pool.mutex.unlock();
+                @call(.auto, func, args);
+                return;
+            }
+        }
+
+        pool.mutex.unlock();
     }
 
     // Notify waiting threads outside the lock to try and keep the critical section small.
@@ -178,25 +342,45 @@ pub fn spawn(pool: *Pool, comptime func: anytype, args: anytype) !void {
 }
 
 fn worker(pool: *Pool) void {
+    var trash_buf: [1]u8 = undefined;
+    var connection: ?std.net.Stream = null;
+    defer if (connection) |stream| stream.close();
+
     pool.mutex.lock();
     defer pool.mutex.unlock();
 
     while (true) {
         while (pool.run_queue.popFirst()) |run_node| {
-            // Temporarily unlock the mutex in order to execute the run_node
+            pool.run_queue_len -= 1;
+
+            // Temporarily unlock the mutex in order to execute the run_node.
             pool.mutex.unlock();
             defer pool.mutex.lock();
+
+            if (connection == null) switch (pool.job_server_options) {
+                .abstain => {},
+                .connect, .host => |addr| {
+                    if (std.net.tcpConnectToAddress(addr)) |stream| {
+                        connection = stream;
+                        _ = stream.readAll(&trash_buf) catch 1;
+                    } else |_| {}
+                },
+            };
 
             const runFn = run_node.data.runFn;
             runFn(&run_node.data);
         }
 
         // Stop executing instead of waiting if the thread pool is no longer running.
-        if (pool.is_running) {
-            pool.cond.wait(&pool.mutex);
-        } else {
+        if (pool.end_flag)
             break;
+
+        if (connection) |stream| {
+            stream.close();
+            connection = null;
         }
+
+        pool.cond.wait(&pool.mutex);
     }
 }
 
@@ -207,6 +391,7 @@ pub fn waitAndWork(pool: *Pool, wait_group: *WaitGroup) void {
             defer pool.mutex.unlock();
             break :blk pool.run_queue.popFirst();
         }) |run_node| {
+            pool.run_queue_len -= 1;
             run_node.data.runFn(&run_node.data);
             continue;
         }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4604,6 +4604,7 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
         };
         if (std.process.can_spawn) {
             var child = std.process.Child.init(argv.items, arena);
+            child.thread_pool = comp.thread_pool;
             if (comp.clang_passthrough_mode) {
                 child.stdin_behavior = .Inherit;
                 child.stdout_behavior = .Inherit;
@@ -4964,6 +4965,7 @@ fn spawnZigRc(
     child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Pipe;
     child.progress_node = child_progress_node;
+    child.thread_pool = comp.thread_pool;
 
     child.spawn() catch |err| {
         return comp.failWin32Resource(win32_resource, "unable to spawn {s} rc: {s}", .{ argv[0], @errorName(err) });

--- a/src/link.zig
+++ b/src/link.zig
@@ -1011,6 +1011,7 @@ pub fn spawnLld(
     defer comp.gpa.free(stderr);
 
     var child = std.process.Child.init(argv, arena);
+    child.thread_pool = comp.thread_pool;
     const term = (if (comp.clang_passthrough_mode) term: {
         child.stdin_behavior = .Inherit;
         child.stdout_behavior = .Inherit;

--- a/src/link/MachO/hasher.zig
+++ b/src/link/MachO/hasher.zig
@@ -12,8 +12,6 @@ pub fn ParallelHasher(comptime Hasher: type) type {
             const tracy = trace(@src());
             defer tracy.end();
 
-            var wg: WaitGroup = .{};
-
             const file_size = blk: {
                 const file_size = opts.max_file_size orelse try file.getEndPos();
                 break :blk std.math.cast(usize, file_size) orelse return error.Overflow;
@@ -27,8 +25,8 @@ pub fn ParallelHasher(comptime Hasher: type) type {
             defer self.allocator.free(results);
 
             {
-                wg.reset();
-                defer wg.wait();
+                var wg: WaitGroup = .{};
+                defer self.thread_pool.waitAndWork(&wg);
 
                 for (out, results, 0..) |*out_buf, *result, i| {
                     const fstart = i * chunk_size;

--- a/src/main.zig
+++ b/src/main.zig
@@ -5062,7 +5062,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
                 job_queue.thread_pool.spawnWg(&job_queue.wait_group, Package.Fetch.workerRun, .{
                     &fetch, "root",
                 });
-                job_queue.wait_group.wait();
+                job_queue.thread_pool.waitAndWork(&job_queue.wait_group);
 
                 try job_queue.consolidateErrors();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3136,7 +3136,9 @@ fn buildOutputType(
         break :l global_cache_directory;
     };
 
-    var thread_pool = try std.zig.initThreadPool(gpa, .{
+    var thread_pool: std.Thread.Pool = undefined;
+    try std.zig.initThreadPool(&thread_pool, .{
+        .allocator = gpa,
         .cache_directory = local_cache_directory,
     });
     defer thread_pool.deinit();
@@ -4250,6 +4252,7 @@ fn runOrTest(
         child.stdin_behavior = .Inherit;
         child.stdout_behavior = .Inherit;
         child.stderr_behavior = .Inherit;
+        child.thread_pool = comp.thread_pool;
 
         // Here we release all the locks associated with the Compilation so
         // that whatever this child process wants to do won't deadlock.
@@ -4395,6 +4398,7 @@ fn runOrTestHotSwap(
             child.stdin_behavior = .Inherit;
             child.stdout_behavior = .Inherit;
             child.stderr_behavior = .Inherit;
+            child.thread_pool = comp.thread_pool;
 
             try child.spawn();
 
@@ -4896,7 +4900,9 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
 
     child_argv.items[argv_index_cache_dir] = local_cache_directory.path orelse cwd_path;
 
-    var thread_pool = try std.zig.initThreadPool(gpa, .{
+    var thread_pool: std.Thread.Pool = undefined;
+    try std.zig.initThreadPool(&thread_pool, .{
+        .allocator = gpa,
         .cache_directory = local_cache_directory,
     });
     defer thread_pool.deinit();
@@ -5185,6 +5191,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
             child.stdin_behavior = .Inherit;
             child.stdout_behavior = .Inherit;
             child.stderr_behavior = .Inherit;
+            child.thread_pool = &thread_pool;
 
             const term = t: {
                 std.debug.lockStdErr();
@@ -5331,7 +5338,9 @@ fn jitCmd(
     };
     defer global_cache_directory.handle.close();
 
-    var thread_pool = try std.zig.initThreadPool(gpa, .{
+    var thread_pool: std.Thread.Pool = undefined;
+    try std.zig.initThreadPool(&thread_pool, .{
+        .allocator = gpa,
         .cache_directory = global_cache_directory,
     });
     defer thread_pool.deinit();
@@ -5474,6 +5483,7 @@ fn jitCmd(
     child.stdin_behavior = .Inherit;
     child.stdout_behavior = if (options.capture == null) .Inherit else .Pipe;
     child.stderr_behavior = .Inherit;
+    child.thread_pool = &thread_pool;
 
     try child.spawn();
 
@@ -6897,7 +6907,9 @@ fn cmdFetch(
     };
     defer global_cache_directory.handle.close();
 
-    var thread_pool = try std.zig.initThreadPool(gpa, .{
+    var thread_pool: std.Thread.Pool = undefined;
+    try std.zig.initThreadPool(&thread_pool, .{
+        .allocator = gpa,
         .cache_directory = global_cache_directory,
     });
     defer thread_pool.deinit();


### PR DESCRIPTION
I'm tentatively calling this new standard "Jobserver V2" and it uses the environment variable `JOBSERVERV2`. The idea is to change the environment variable name with any ABI-breaking changes that need to be made after the protocol starts being used.

In summary, the root process in a process tree finds out that it is the root process because of the lack of `JOBSERVERV2` environment variable. In this case it spawns a thread with the same lifetime as its `std.Thread.Pool`, which acts as a daemon, accepting up to N simultaneous connections where N is the thread pool size. It also writes 1 byte to each connection, in order to ensure blocking read() on the other side of the socket.

When a thread pool finds the `JOBSERVERV2` environment variable, instead of being a host, it uses that path to obtain thread tokens before doing work. Before starting work, it connects to the daemon and reads 1 byte. Then it proceeds to do as much work as possible before closing the connection and going back to sleep. Crucially, when a process dies, the operating system closes all the connections it had open.

closes #20274

Related:
* https://github.com/rust-lang/cargo/issues/14102

## Testing

### Simple Example

demo: https://asciinema.org/a/lMKZ0YZceqBLsww419YxFxjxT
source: https://gist.github.com/andrewrk/985de049693100d30e15ab3940bf601f

### real world example: my music player project

It's fun to look at but performance wise it seems to be a wash. 66 seconds to build before, 66 seconds to build after. But, I suppose since it does not spawn as many concurrent processes, it is using fewer resources during that time, so maybe that's a tiny win after all.

demo: https://asciinema.org/a/dDfUwIH78FQSegQakp3y5WXDC
source: https://codeberg.org/andrewrk/player

### behavior tests

before: 1m5s, 889 MiB peak RSS
after: 1m4s, 893 MiB peak RSS
demo: https://asciinema.org/a/MEkXcmpBkPejfc0BngYsjRLDk

In the demo you can see that it does not give more thread tokens out when it should. Perhaps a symptom of the implicit global token problem.

## Justification for choosing `JOBSERVERV2`

Point 1: it is project-neutral, so other projects hopefully will consider it

Point 2: it implies a versioning scheme; if we have to break the ABI in the future, the 2 can become a 3.

Point 3: it is unique:

![image](https://github.com/ziglang/zig/assets/106511/806c5650-5215-4307-a529-71ef54ce846c)

![image](https://github.com/ziglang/zig/assets/106511/5385e4a7-ee61-41d8-8525-25b3fd1adb90)

## Merge Checklist

* [x] Call `shutdown` on the read socket to stop blocked workers on deinit
  - can a sockfd which has been `shutdown` be reused with `connect` ?
* [ ] Solve the implicit global token problem
  - `waitAndWork` is implemented poorly - after it starts waiting, it won't see any newly queued work
  - spawn N threads instead of N - 1, but have one of the workers be special
* [ ] Performance testing
* [ ] Fix the dependencies on posix that I added in various places
* [ ] Implement Windows support
* [ ] Should we use libdispatch on macOS?
* [ ] Get feedback from third party projects such as GNU make, ninja, Meson, etc.