### PR TITLE
Some compatibility improvements for linker option processing

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1300,7 +1300,7 @@ fn buildOutputType(
                         target_mcpu = arg["-mcpu=".len..];
                     } else if (mem.startsWith(u8, arg, "-O")) {
                         mod_opts.optimize_mode = parseOptimizeMode(arg["-O".len..]);
-                    } else if (mem.eql(u8, arg, "--dynamic-linker")) {
+                    } else if (mem.eql(u8, arg, "--dynamic-linker") or mem.eql(u8, arg, "-dynamic-linker")) {
                         create_module.dynamic_linker = args_iter.nextOrFatal();
                     } else if (mem.eql(u8, arg, "--sysroot")) {
                         const next_arg = args_iter.nextOrFatal();

--- a/src/main.zig
+++ b/src/main.zig
@@ -2435,7 +2435,9 @@ fn buildOutputType(
                     // -S, --strip-debug           Strip debugging symbols
                     mod_opts.strip = true;
                 } else if (mem.eql(u8, arg, "--start-group") or
-                    mem.eql(u8, arg, "--end-group"))
+                    mem.eql(u8, arg, "-start-group") or
+                    mem.eql(u8, arg, "--end-group") or
+                    mem.eql(u8, arg, "-end-group"))
                 {
                     // We don't need to care about these because these args are
                     // for resolving circular dependencies but our linker takes

--- a/src/main.zig
+++ b/src/main.zig
@@ -1630,9 +1630,9 @@ fn buildOutputType(
                         try linker_export_symbol_names.append(arena, arg["--export=".len..]);
                     } else if (mem.eql(u8, arg, "-Bsymbolic")) {
                         linker_bind_global_refs_locally = true;
-                    } else if (mem.eql(u8, arg, "--gc-sections")) {
+                    } else if (mem.eql(u8, arg, "--gc-sections") or mem.eql(u8, arg, "-gc-sections")) {
                         linker_gc_sections = true;
-                    } else if (mem.eql(u8, arg, "--no-gc-sections")) {
+                    } else if (mem.eql(u8, arg, "--no-gc-sections") or mem.eql(u8, arg, "-no-gc-sections")) {
                         linker_gc_sections = false;
                     } else if (mem.eql(u8, arg, "--build-id")) {
                         build_id = .fast;
@@ -2277,11 +2277,11 @@ fn buildOutputType(
                     force_load_objc = true;
                 } else if (mem.eql(u8, arg, "--no-undefined") or mem.eql(u8, arg, "-no-undefined")) {
                     linker_z_defs = true;
-                } else if (mem.eql(u8, arg, "--gc-sections")) {
+                } else if (mem.eql(u8, arg, "--gc-sections") or mem.eql(u8, arg, "-gc-sections")) {
                     linker_gc_sections = true;
-                } else if (mem.eql(u8, arg, "--no-gc-sections")) {
+                } else if (mem.eql(u8, arg, "--no-gc-sections") or mem.eql(u8, arg, "-no-gc-sections")) {
                     linker_gc_sections = false;
-                } else if (mem.eql(u8, arg, "--print-gc-sections")) {
+                } else if (mem.eql(u8, arg, "--print-gc-sections") or mem.eql(u8, arg, "-print-gc-sections")) {
                     linker_print_gc_sections = true;
                 } else if (mem.eql(u8, arg, "--print-icf-sections")) {
                     linker_print_icf_sections = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1981,7 +1981,10 @@ fn buildOutputType(
                                 needed = false;
                             } else if (mem.eql(u8, linker_arg, "--no-as-needed")) {
                                 needed = true;
-                            } else if (mem.eql(u8, linker_arg, "--no-pie") or mem.eql(u8, linker_arg, "-no-pie")) {
+                            } else if (mem.eql(u8, linker_arg, "--no-pie") or
+                                mem.eql(u8, linker_arg, "-no-pie") or
+                                mem.eql(u8, linker_arg, "-no_pie"))
+                            {
                                 create_module.opts.pie = false;
                             } else if (mem.eql(u8, linker_arg, "--sort-common")) {
                                 // from ld.lld(1): --sort-common is ignored for GNU compatibility,

--- a/src/main.zig
+++ b/src/main.zig
@@ -2287,7 +2287,7 @@ fn buildOutputType(
                     linker_print_icf_sections = true;
                 } else if (mem.eql(u8, arg, "--print-map") or mem.eql(u8, arg, "-print-map")) {
                     linker_print_map = true;
-                } else if (mem.eql(u8, arg, "--sort-section")) {
+                } else if (mem.eql(u8, arg, "--sort-section") or mem.eql(u8, arg, "-sort-section")) {
                     const arg1 = linker_args_it.nextOrFatal();
                     linker_sort_section = std.meta.stringToEnum(link.File.Elf.SortSection, arg1) orelse {
                         fatal("expected [name|alignment] after --sort-section, found '{s}'", .{arg1});

--- a/src/main.zig
+++ b/src/main.zig
@@ -2491,6 +2491,7 @@ fn buildOutputType(
                     };
                     have_version = true;
                 } else if (mem.eql(u8, arg, "--out-implib") or
+                    mem.eql(u8, arg, "-out-implib") or
                     mem.eql(u8, arg, "-implib"))
                 {
                     emit_implib = .{ .yes = linker_args_it.nextOrFatal() };

--- a/src/main.zig
+++ b/src/main.zig
@@ -2217,6 +2217,8 @@ fn buildOutputType(
                         }
                     }
                     provided_name = name[prefix..end];
+                } else if (mem.eql(u8, arg, "--pic-executable") or mem.eql(u8, arg, "-pic-executable")) {
+                    create_module.opts.pie = true;
                 } else if (mem.eql(u8, arg, "-rpath") or mem.eql(u8, arg, "--rpath") or mem.eql(u8, arg, "-R")) {
                     try create_module.rpath_list.append(arena, linker_args_it.nextOrFatal());
                 } else if (mem.eql(u8, arg, "--subsystem")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2382,6 +2382,12 @@ fn buildOutputType(
                     stack_size = parseStackSize(linker_args_it.nextOrFatal());
                 } else if (mem.eql(u8, arg, "--image-base")) {
                     image_base = parseImageBase(linker_args_it.nextOrFatal());
+                } else if (mem.eql(u8, arg, "--enable-auto-image-base") or
+                    mem.eql(u8, arg, "-enable-auto-image-base") or
+                    mem.eql(u8, arg, "--disable-auto-image-base") or
+                    mem.eql(u8, arg, "-disable-auto-image-base"))
+                {
+                    // These are ignored by LLD, but are used by Libtool for MinGW triples.
                 } else if (mem.eql(u8, arg, "-T") or mem.eql(u8, arg, "--script")) {
                     linker_script = linker_args_it.nextOrFatal();
                 } else if (mem.eql(u8, arg, "--eh-frame-hdr")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1230,9 +1230,9 @@ fn buildOutputType(
                         linker_allow_undefined_version = true;
                     } else if (mem.eql(u8, arg, "--no-undefined-version") or mem.eql(u8, arg, "-no-undefined-version")) {
                         linker_allow_undefined_version = false;
-                    } else if (mem.eql(u8, arg, "--enable-new-dtags")) {
+                    } else if (mem.eql(u8, arg, "--enable-new-dtags") or mem.eql(u8, arg, "-enable-new-dtags")) {
                         linker_enable_new_dtags = true;
-                    } else if (mem.eql(u8, arg, "--disable-new-dtags")) {
+                    } else if (mem.eql(u8, arg, "--disable-new-dtags") or mem.eql(u8, arg, "-disable-new-dtags")) {
                         linker_enable_new_dtags = false;
                     } else if (mem.eql(u8, arg, "--library") or mem.eql(u8, arg, "-l")) {
                         // We don't know whether this library is part of libc
@@ -2244,9 +2244,9 @@ fn buildOutputType(
                     linker_allow_undefined_version = true;
                 } else if (mem.eql(u8, arg, "--no-undefined-version") or mem.eql(u8, arg, "-no-undefined-version")) {
                     linker_allow_undefined_version = false;
-                } else if (mem.eql(u8, arg, "--enable-new-dtags")) {
+                } else if (mem.eql(u8, arg, "--enable-new-dtags") or mem.eql(u8, arg, "-enable-new-dtags")) {
                     linker_enable_new_dtags = true;
-                } else if (mem.eql(u8, arg, "--disable-new-dtags")) {
+                } else if (mem.eql(u8, arg, "--disable-new-dtags") or mem.eql(u8, arg, "-disable-new-dtags")) {
                     linker_enable_new_dtags = false;
                 } else if (mem.eql(u8, arg, "-O")) {
                     linker_optimization = linker_args_it.nextOrFatal();

--- a/src/main.zig
+++ b/src/main.zig
@@ -2001,6 +2001,7 @@ fn buildOutputType(
                                 mem.eql(u8, linker_arg, "-Bdynamic") or
                                 mem.eql(u8, linker_arg, "--dy") or
                                 mem.eql(u8, linker_arg, "-dy") or
+                                mem.eql(u8, linker_arg, "--call_shared") or
                                 mem.eql(u8, linker_arg, "-call_shared"))
                             {
                                 lib_search_strategy = .no_fallback;
@@ -2009,6 +2010,7 @@ fn buildOutputType(
                                 mem.eql(u8, linker_arg, "-Bstatic") or
                                 mem.eql(u8, linker_arg, "--dn") or
                                 mem.eql(u8, linker_arg, "-dn") or
+                                mem.eql(u8, linker_arg, "--non_shared") or
                                 mem.eql(u8, linker_arg, "-non_shared") or
                                 mem.eql(u8, linker_arg, "-static"))
                             {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2283,7 +2283,7 @@ fn buildOutputType(
                     linker_gc_sections = false;
                 } else if (mem.eql(u8, arg, "--print-gc-sections") or mem.eql(u8, arg, "-print-gc-sections")) {
                     linker_print_gc_sections = true;
-                } else if (mem.eql(u8, arg, "--print-icf-sections")) {
+                } else if (mem.eql(u8, arg, "--print-icf-sections") or mem.eql(u8, arg, "-print-icf-sections")) {
                     linker_print_icf_sections = true;
                 } else if (mem.eql(u8, arg, "--print-map")) {
                     linker_print_map = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -2410,7 +2410,7 @@ fn buildOutputType(
                     link_eh_frame_hdr = false;
                 } else if (mem.eql(u8, arg, "--tsaware") or mem.eql(u8, arg, "-tsaware")) {
                     linker_tsaware = true;
-                } else if (mem.eql(u8, arg, "--nxcompat")) {
+                } else if (mem.eql(u8, arg, "--nxcompat") or mem.eql(u8, arg, "-nxcompat")) {
                     linker_nxcompat = true;
                 } else if (mem.eql(u8, arg, "--dynamicbase") or mem.eql(u8, arg, "-dynamicbase")) {
                     linker_dynamicbase = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -2386,7 +2386,7 @@ fn buildOutputType(
                         fatal("unable to parse minor image version '{s}': {s}", .{ minor, @errorName(err) });
                     };
                     have_version = true;
-                } else if (mem.eql(u8, arg, "-e") or mem.eql(u8, arg, "--entry")) {
+                } else if (mem.eql(u8, arg, "-e") or mem.eql(u8, arg, "--entry") or mem.eql(u8, arg, "-entry")) {
                     entry = .{ .named = linker_args_it.nextOrFatal() };
                 } else if (mem.eql(u8, arg, "-u")) {
                     try force_undefined_symbols.put(arena, linker_args_it.nextOrFatal(), {});

--- a/src/main.zig
+++ b/src/main.zig
@@ -1981,7 +1981,7 @@ fn buildOutputType(
                                 needed = false;
                             } else if (mem.eql(u8, linker_arg, "--no-as-needed")) {
                                 needed = true;
-                            } else if (mem.eql(u8, linker_arg, "-no-pie")) {
+                            } else if (mem.eql(u8, linker_arg, "--no-pie") or mem.eql(u8, linker_arg, "-no-pie")) {
                                 create_module.opts.pie = false;
                             } else if (mem.eql(u8, linker_arg, "--sort-common")) {
                                 // from ld.lld(1): --sort-common is ignored for GNU compatibility,

--- a/src/main.zig
+++ b/src/main.zig
@@ -2388,7 +2388,7 @@ fn buildOutputType(
                     have_version = true;
                 } else if (mem.eql(u8, arg, "-e") or mem.eql(u8, arg, "--entry") or mem.eql(u8, arg, "-entry")) {
                     entry = .{ .named = linker_args_it.nextOrFatal() };
-                } else if (mem.eql(u8, arg, "-u")) {
+                } else if (mem.eql(u8, arg, "-u") or mem.eql(u8, arg, "--undefined")) {
                     try force_undefined_symbols.put(arena, linker_args_it.nextOrFatal(), {});
                 } else if (mem.eql(u8, arg, "--stack") or mem.eql(u8, arg, "-stack") or mem.eql(u8, arg, "-stack_size")) {
                     stack_size = parseStackSize(linker_args_it.nextOrFatal());

--- a/src/main.zig
+++ b/src/main.zig
@@ -2492,6 +2492,7 @@ fn buildOutputType(
                     have_version = true;
                 } else if (mem.eql(u8, arg, "--out-implib") or
                     mem.eql(u8, arg, "-out-implib") or
+                    mem.eql(u8, arg, "--implib") or
                     mem.eql(u8, arg, "-implib"))
                 {
                     emit_implib = .{ .yes = linker_args_it.nextOrFatal() };

--- a/src/main.zig
+++ b/src/main.zig
@@ -2388,6 +2388,8 @@ fn buildOutputType(
                     mem.eql(u8, arg, "-disable-auto-image-base"))
                 {
                     // These are ignored by LLD, but are used by Libtool for MinGW triples.
+                } else if (mem.eql(u8, arg, "--full-shutdown")) {
+                    // This is ignored by LLD.
                 } else if (mem.eql(u8, arg, "-T") or mem.eql(u8, arg, "--script")) {
                     linker_script = linker_args_it.nextOrFatal();
                 } else if (mem.eql(u8, arg, "--eh-frame-hdr")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1517,7 +1517,7 @@ fn buildOutputType(
                         create_module.opts.link_mode = .dynamic;
                         lib_preferred_mode = .dynamic;
                         lib_search_strategy = .mode_first;
-                    } else if (mem.eql(u8, arg, "-static")) {
+                    } else if (mem.eql(u8, arg, "--static") or mem.eql(u8, arg, "-static")) {
                         create_module.opts.link_mode = .static;
                         lib_preferred_mode = .static;
                         lib_search_strategy = .no_fallback;
@@ -2012,6 +2012,7 @@ fn buildOutputType(
                                 mem.eql(u8, linker_arg, "-dn") or
                                 mem.eql(u8, linker_arg, "--non_shared") or
                                 mem.eql(u8, linker_arg, "-non_shared") or
+                                mem.eql(u8, linker_arg, "--static") or
                                 mem.eql(u8, linker_arg, "-static"))
                             {
                                 lib_search_strategy = .no_fallback;

--- a/src/main.zig
+++ b/src/main.zig
@@ -2540,6 +2540,8 @@ fn buildOutputType(
                 } else if (mem.eql(u8, arg, "--wrap") or mem.eql(u8, arg, "-wrap")) {
                     const next_arg = linker_args_it.nextOrFatal();
                     try symbol_wrap_set.put(arena, next_arg, {});
+                } else if (mem.eql(u8, arg, "--stats") or mem.eql(u8, arg, "-stats")) {
+                    warn("ignoring request for linker statistics: unimplemented", .{});
                 } else if (mem.startsWith(u8, arg, "/subsystem:")) {
                     var split_it = mem.splitBackwardsScalar(u8, arg, ':');
                     subsystem = try parseSubSystem(split_it.first());

--- a/src/main.zig
+++ b/src/main.zig
@@ -2408,7 +2408,7 @@ fn buildOutputType(
                     link_eh_frame_hdr = true;
                 } else if (mem.eql(u8, arg, "--no-eh-frame-hdr") or mem.eql(u8, arg, "-no-eh-frame-hdr")) {
                     link_eh_frame_hdr = false;
-                } else if (mem.eql(u8, arg, "--tsaware")) {
+                } else if (mem.eql(u8, arg, "--tsaware") or mem.eql(u8, arg, "-tsaware")) {
                     linker_tsaware = true;
                 } else if (mem.eql(u8, arg, "--nxcompat")) {
                     linker_nxcompat = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -2418,7 +2418,7 @@ fn buildOutputType(
                     linker_dynamicbase = false;
                 } else if (mem.eql(u8, arg, "--high-entropy-va")) {
                     // This option does not do anything.
-                } else if (mem.eql(u8, arg, "--export-all-symbols")) {
+                } else if (mem.eql(u8, arg, "--export-all-symbols") or mem.eql(u8, arg, "-export-all-symbols")) {
                     create_module.opts.rdynamic = true;
                 } else if (mem.eql(u8, arg, "--color-diagnostics") or
                     mem.eql(u8, arg, "--color-diagnostics=always"))

--- a/src/main.zig
+++ b/src/main.zig
@@ -2421,11 +2421,15 @@ fn buildOutputType(
                 } else if (mem.eql(u8, arg, "--export-all-symbols") or mem.eql(u8, arg, "-export-all-symbols")) {
                     create_module.opts.rdynamic = true;
                 } else if (mem.eql(u8, arg, "--color-diagnostics") or
-                    mem.eql(u8, arg, "--color-diagnostics=always"))
+                    mem.eql(u8, arg, "-color-diagnostics") or
+                    mem.eql(u8, arg, "--color-diagnostics=always") or
+                    mem.eql(u8, arg, "-color-diagnostics=always"))
                 {
                     color = .on;
                 } else if (mem.eql(u8, arg, "--no-color-diagnostics") or
-                    mem.eql(u8, arg, "--color-diagnostics=never"))
+                    mem.eql(u8, arg, "-no-color-diagnostics") or
+                    mem.eql(u8, arg, "--color-diagnostics=never") or
+                    mem.eql(u8, arg, "-color-diagnostics=never"))
                 {
                     color = .off;
                 } else if (mem.eql(u8, arg, "-s") or mem.eql(u8, arg, "--strip-all") or mem.eql(u8, arg, "-strip-all") or

--- a/src/main.zig
+++ b/src/main.zig
@@ -1981,6 +1981,8 @@ fn buildOutputType(
                                 needed = false;
                             } else if (mem.eql(u8, linker_arg, "--no-as-needed") or mem.eql(u8, linker_arg, "-no-as-needed")) {
                                 needed = true;
+                            } else if (mem.eql(u8, linker_arg, "--pie") or mem.eql(u8, linker_arg, "-pie")) {
+                                create_module.opts.pie = true;
                             } else if (mem.eql(u8, linker_arg, "--no-pie") or
                                 mem.eql(u8, linker_arg, "-no-pie") or
                                 mem.eql(u8, linker_arg, "-no_pie"))

--- a/src/main.zig
+++ b/src/main.zig
@@ -1159,7 +1159,7 @@ fn buildOutputType(
                         try force_undefined_symbols.put(arena, args_iter.nextOrFatal(), {});
                     } else if (mem.eql(u8, arg, "--stack") or mem.eql(u8, arg, "-stack")) {
                         stack_size = parseStackSize(args_iter.nextOrFatal());
-                    } else if (mem.eql(u8, arg, "--image-base")) {
+                    } else if (mem.eql(u8, arg, "--image-base") or mem.eql(u8, arg, "-image-base")) {
                         image_base = parseImageBase(args_iter.nextOrFatal());
                     } else if (mem.eql(u8, arg, "--name")) {
                         provided_name = args_iter.nextOrFatal();
@@ -2392,7 +2392,7 @@ fn buildOutputType(
                     try force_undefined_symbols.put(arena, linker_args_it.nextOrFatal(), {});
                 } else if (mem.eql(u8, arg, "--stack") or mem.eql(u8, arg, "-stack") or mem.eql(u8, arg, "-stack_size")) {
                     stack_size = parseStackSize(linker_args_it.nextOrFatal());
-                } else if (mem.eql(u8, arg, "--image-base")) {
+                } else if (mem.eql(u8, arg, "--image-base") or mem.eql(u8, arg, "-image-base")) {
                     image_base = parseImageBase(linker_args_it.nextOrFatal());
                 } else if (mem.eql(u8, arg, "--enable-auto-image-base") or
                     mem.eql(u8, arg, "-enable-auto-image-base") or

--- a/src/main.zig
+++ b/src/main.zig
@@ -1977,9 +1977,9 @@ fn buildOutputType(
                             }
                             if (mem.eql(u8, linker_arg, "--build-id")) {
                                 build_id = .fast;
-                            } else if (mem.eql(u8, linker_arg, "--as-needed")) {
+                            } else if (mem.eql(u8, linker_arg, "--as-needed") or mem.eql(u8, linker_arg, "-as-needed")) {
                                 needed = false;
-                            } else if (mem.eql(u8, linker_arg, "--no-as-needed")) {
+                            } else if (mem.eql(u8, linker_arg, "--no-as-needed") or mem.eql(u8, linker_arg, "-no-as-needed")) {
                                 needed = true;
                             } else if (mem.eql(u8, linker_arg, "--no-pie") or
                                 mem.eql(u8, linker_arg, "-no-pie") or

--- a/src/main.zig
+++ b/src/main.zig
@@ -1222,7 +1222,7 @@ fn buildOutputType(
                         dead_strip_dylibs = true;
                     } else if (mem.eql(u8, arg, "-ObjC")) {
                         force_load_objc = true;
-                    } else if (mem.eql(u8, arg, "-T") or mem.eql(u8, arg, "--script")) {
+                    } else if (mem.eql(u8, arg, "-T") or mem.eql(u8, arg, "--script") or mem.eql(u8, arg, "-script")) {
                         linker_script = args_iter.nextOrFatal();
                     } else if (mem.eql(u8, arg, "-version-script") or mem.eql(u8, arg, "--version-script")) {
                         version_script = args_iter.nextOrFatal();
@@ -2402,7 +2402,7 @@ fn buildOutputType(
                     // These are ignored by LLD, but are used by Libtool for MinGW triples.
                 } else if (mem.eql(u8, arg, "--full-shutdown")) {
                     // This is ignored by LLD.
-                } else if (mem.eql(u8, arg, "-T") or mem.eql(u8, arg, "--script")) {
+                } else if (mem.eql(u8, arg, "-T") or mem.eql(u8, arg, "--script") or mem.eql(u8, arg, "-script")) {
                     linker_script = linker_args_it.nextOrFatal();
                 } else if (mem.eql(u8, arg, "--eh-frame-hdr")) {
                     link_eh_frame_hdr = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1562,9 +1562,9 @@ fn buildOutputType(
                             fatal("unable to parse '{s}': {s}", .{ arg, @errorName(err) });
                     } else if (mem.eql(u8, arg, "--eh-frame-hdr") or mem.eql(u8, arg, "-eh-frame-hdr")) {
                         link_eh_frame_hdr = true;
-                    } else if (mem.eql(u8, arg, "--dynamicbase")) {
+                    } else if (mem.eql(u8, arg, "--dynamicbase") or mem.eql(u8, arg, "-dynamicbase")) {
                         linker_dynamicbase = true;
-                    } else if (mem.eql(u8, arg, "--no-dynamicbase")) {
+                    } else if (mem.eql(u8, arg, "--no-dynamicbase") or mem.eql(u8, arg, "-no-dynamicbase")) {
                         linker_dynamicbase = false;
                     } else if (mem.eql(u8, arg, "--emit-relocs")) {
                         link_emit_relocs = true;
@@ -2412,9 +2412,9 @@ fn buildOutputType(
                     linker_tsaware = true;
                 } else if (mem.eql(u8, arg, "--nxcompat")) {
                     linker_nxcompat = true;
-                } else if (mem.eql(u8, arg, "--dynamicbase")) {
+                } else if (mem.eql(u8, arg, "--dynamicbase") or mem.eql(u8, arg, "-dynamicbase")) {
                     linker_dynamicbase = true;
-                } else if (mem.eql(u8, arg, "--no-dynamicbase")) {
+                } else if (mem.eql(u8, arg, "--no-dynamicbase") or mem.eql(u8, arg, "-no-dynamicbase")) {
                     linker_dynamicbase = false;
                 } else if (mem.eql(u8, arg, "--high-entropy-va") or mem.eql(u8, arg, "-high-entropy-va")) {
                     // This option does not do anything.

--- a/src/main.zig
+++ b/src/main.zig
@@ -1149,7 +1149,7 @@ fn buildOutputType(
                             fatal("number of jobs must be at least 1\n", .{});
                         }
                         n_jobs = num;
-                    } else if (mem.eql(u8, arg, "--subsystem")) {
+                    } else if (mem.eql(u8, arg, "--subsystem") or mem.eql(u8, arg, "-subsystem")) {
                         subsystem = try parseSubSystem(args_iter.nextOrFatal());
                     } else if (mem.eql(u8, arg, "-O")) {
                         mod_opts.optimize_mode = parseOptimizeMode(args_iter.nextOrFatal());
@@ -2226,7 +2226,7 @@ fn buildOutputType(
                     create_module.opts.pie = true;
                 } else if (mem.eql(u8, arg, "-rpath") or mem.eql(u8, arg, "--rpath") or mem.eql(u8, arg, "-R")) {
                     try create_module.rpath_list.append(arena, linker_args_it.nextOrFatal());
-                } else if (mem.eql(u8, arg, "--subsystem")) {
+                } else if (mem.eql(u8, arg, "--subsystem") or mem.eql(u8, arg, "-subsystem")) {
                     subsystem = try parseSubSystem(linker_args_it.nextOrFatal());
                 } else if (mem.eql(u8, arg, "-I") or
                     mem.eql(u8, arg, "--dynamic-linker") or

--- a/src/main.zig
+++ b/src/main.zig
@@ -1165,7 +1165,7 @@ fn buildOutputType(
                         provided_name = args_iter.nextOrFatal();
                         if (!mem.eql(u8, provided_name.?, fs.path.basename(provided_name.?)))
                             fatal("invalid package name '{s}': cannot contain folder separators", .{provided_name.?});
-                    } else if (mem.eql(u8, arg, "-rpath")) {
+                    } else if (mem.eql(u8, arg, "-rpath") or mem.eql(u8, arg, "--rpath") or mem.eql(u8, arg, "-R")) {
                         try create_module.rpath_list.append(arena, args_iter.nextOrFatal());
                     } else if (mem.eql(u8, arg, "--library-directory") or mem.eql(u8, arg, "-L")) {
                         try create_module.lib_dir_args.append(arena, args_iter.nextOrFatal());

--- a/src/main.zig
+++ b/src/main.zig
@@ -1997,13 +1997,15 @@ fn buildOutputType(
                                 mem.eql(u8, linker_arg, "-no-whole-archive"))
                             {
                                 must_link = false;
-                            } else if (mem.eql(u8, linker_arg, "-Bdynamic") or
+                            } else if (mem.eql(u8, linker_arg, "--Bdynamic") or
+                                mem.eql(u8, linker_arg, "-Bdynamic") or
                                 mem.eql(u8, linker_arg, "-dy") or
                                 mem.eql(u8, linker_arg, "-call_shared"))
                             {
                                 lib_search_strategy = .no_fallback;
                                 lib_preferred_mode = .dynamic;
-                            } else if (mem.eql(u8, linker_arg, "-Bstatic") or
+                            } else if (mem.eql(u8, linker_arg, "--Bstatic") or
+                                mem.eql(u8, linker_arg, "-Bstatic") or
                                 mem.eql(u8, linker_arg, "-dn") or
                                 mem.eql(u8, linker_arg, "-non_shared") or
                                 mem.eql(u8, linker_arg, "-static"))

--- a/src/main.zig
+++ b/src/main.zig
@@ -2285,7 +2285,7 @@ fn buildOutputType(
                     linker_print_gc_sections = true;
                 } else if (mem.eql(u8, arg, "--print-icf-sections") or mem.eql(u8, arg, "-print-icf-sections")) {
                     linker_print_icf_sections = true;
-                } else if (mem.eql(u8, arg, "--print-map")) {
+                } else if (mem.eql(u8, arg, "--print-map") or mem.eql(u8, arg, "-print-map")) {
                     linker_print_map = true;
                 } else if (mem.eql(u8, arg, "--sort-section")) {
                     const arg1 = linker_args_it.nextOrFatal();

--- a/src/main.zig
+++ b/src/main.zig
@@ -1226,9 +1226,9 @@ fn buildOutputType(
                         linker_script = args_iter.nextOrFatal();
                     } else if (mem.eql(u8, arg, "-version-script") or mem.eql(u8, arg, "--version-script")) {
                         version_script = args_iter.nextOrFatal();
-                    } else if (mem.eql(u8, arg, "--undefined-version")) {
+                    } else if (mem.eql(u8, arg, "--undefined-version") or mem.eql(u8, arg, "-undefined-version")) {
                         linker_allow_undefined_version = true;
-                    } else if (mem.eql(u8, arg, "--no-undefined-version")) {
+                    } else if (mem.eql(u8, arg, "--no-undefined-version") or mem.eql(u8, arg, "-no-undefined-version")) {
                         linker_allow_undefined_version = false;
                     } else if (mem.eql(u8, arg, "--enable-new-dtags")) {
                         linker_enable_new_dtags = true;
@@ -2240,9 +2240,9 @@ fn buildOutputType(
                     create_module.opts.rdynamic = true;
                 } else if (mem.eql(u8, arg, "-version-script") or mem.eql(u8, arg, "--version-script")) {
                     version_script = linker_args_it.nextOrFatal();
-                } else if (mem.eql(u8, arg, "--undefined-version")) {
+                } else if (mem.eql(u8, arg, "--undefined-version") or mem.eql(u8, arg, "-undefined-version")) {
                     linker_allow_undefined_version = true;
-                } else if (mem.eql(u8, arg, "--no-undefined-version")) {
+                } else if (mem.eql(u8, arg, "--no-undefined-version") or mem.eql(u8, arg, "-no-undefined-version")) {
                     linker_allow_undefined_version = false;
                 } else if (mem.eql(u8, arg, "--enable-new-dtags")) {
                     linker_enable_new_dtags = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -2531,7 +2531,7 @@ fn buildOutputType(
                             next_arg,
                         });
                     };
-                } else if (mem.eql(u8, arg, "-wrap")) {
+                } else if (mem.eql(u8, arg, "--wrap") or mem.eql(u8, arg, "-wrap")) {
                     const next_arg = linker_args_it.nextOrFatal();
                     try symbol_wrap_set.put(arena, next_arg, {});
                 } else if (mem.startsWith(u8, arg, "/subsystem:")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2275,7 +2275,7 @@ fn buildOutputType(
                     dead_strip_dylibs = true;
                 } else if (mem.eql(u8, arg, "-ObjC")) {
                     force_load_objc = true;
-                } else if (mem.eql(u8, arg, "--no-undefined")) {
+                } else if (mem.eql(u8, arg, "--no-undefined") or mem.eql(u8, arg, "-no-undefined")) {
                     linker_z_defs = true;
                 } else if (mem.eql(u8, arg, "--gc-sections")) {
                     linker_gc_sections = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1999,6 +1999,7 @@ fn buildOutputType(
                                 must_link = false;
                             } else if (mem.eql(u8, linker_arg, "--Bdynamic") or
                                 mem.eql(u8, linker_arg, "-Bdynamic") or
+                                mem.eql(u8, linker_arg, "--dy") or
                                 mem.eql(u8, linker_arg, "-dy") or
                                 mem.eql(u8, linker_arg, "-call_shared"))
                             {
@@ -2006,6 +2007,7 @@ fn buildOutputType(
                                 lib_preferred_mode = .dynamic;
                             } else if (mem.eql(u8, linker_arg, "--Bstatic") or
                                 mem.eql(u8, linker_arg, "-Bstatic") or
+                                mem.eql(u8, linker_arg, "--dn") or
                                 mem.eql(u8, linker_arg, "-dn") or
                                 mem.eql(u8, linker_arg, "-non_shared") or
                                 mem.eql(u8, linker_arg, "-static"))

--- a/src/main.zig
+++ b/src/main.zig
@@ -2416,7 +2416,7 @@ fn buildOutputType(
                     linker_dynamicbase = true;
                 } else if (mem.eql(u8, arg, "--no-dynamicbase")) {
                     linker_dynamicbase = false;
-                } else if (mem.eql(u8, arg, "--high-entropy-va")) {
+                } else if (mem.eql(u8, arg, "--high-entropy-va") or mem.eql(u8, arg, "-high-entropy-va")) {
                     // This option does not do anything.
                 } else if (mem.eql(u8, arg, "--export-all-symbols") or mem.eql(u8, arg, "-export-all-symbols")) {
                     create_module.opts.rdynamic = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1560,7 +1560,7 @@ fn buildOutputType(
                         const next_arg = arg["-fopt-bisect-limit=".len..];
                         llvm_opt_bisect_limit = std.fmt.parseInt(c_int, next_arg, 0) catch |err|
                             fatal("unable to parse '{s}': {s}", .{ arg, @errorName(err) });
-                    } else if (mem.eql(u8, arg, "--eh-frame-hdr")) {
+                    } else if (mem.eql(u8, arg, "--eh-frame-hdr") or mem.eql(u8, arg, "-eh-frame-hdr")) {
                         link_eh_frame_hdr = true;
                     } else if (mem.eql(u8, arg, "--dynamicbase")) {
                         linker_dynamicbase = true;
@@ -2404,9 +2404,9 @@ fn buildOutputType(
                     // This is ignored by LLD.
                 } else if (mem.eql(u8, arg, "-T") or mem.eql(u8, arg, "--script") or mem.eql(u8, arg, "-script")) {
                     linker_script = linker_args_it.nextOrFatal();
-                } else if (mem.eql(u8, arg, "--eh-frame-hdr")) {
+                } else if (mem.eql(u8, arg, "--eh-frame-hdr") or mem.eql(u8, arg, "-eh-frame-hdr")) {
                     link_eh_frame_hdr = true;
-                } else if (mem.eql(u8, arg, "--no-eh-frame-hdr")) {
+                } else if (mem.eql(u8, arg, "--no-eh-frame-hdr") or mem.eql(u8, arg, "-no-eh-frame-hdr")) {
                     link_eh_frame_hdr = false;
                 } else if (mem.eql(u8, arg, "--tsaware")) {
                     linker_tsaware = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -2428,11 +2428,11 @@ fn buildOutputType(
                     mem.eql(u8, arg, "--color-diagnostics=never"))
                 {
                     color = .off;
-                } else if (mem.eql(u8, arg, "-s") or mem.eql(u8, arg, "--strip-all") or
-                    mem.eql(u8, arg, "-S") or mem.eql(u8, arg, "--strip-debug"))
+                } else if (mem.eql(u8, arg, "-s") or mem.eql(u8, arg, "--strip-all") or mem.eql(u8, arg, "-strip-all") or
+                    mem.eql(u8, arg, "-S") or mem.eql(u8, arg, "--strip-debug") or mem.eql(u8, arg, "-strip-debug"))
                 {
-                    // -s, --strip-all             Strip all symbols
-                    // -S, --strip-debug           Strip debugging symbols
+                    // -s, -(-)strip-all             Strip all symbols
+                    // -S, -(-)strip-debug           Strip debugging symbols
                     mod_opts.strip = true;
                 } else if (mem.eql(u8, arg, "--start-group") or
                     mem.eql(u8, arg, "-start-group") or

--- a/src/main.zig
+++ b/src/main.zig
@@ -1628,7 +1628,7 @@ fn buildOutputType(
                         linker_global_base = parseIntSuffix(arg, "--global-base=".len);
                     } else if (mem.startsWith(u8, arg, "--export=")) {
                         try linker_export_symbol_names.append(arena, arg["--export=".len..]);
-                    } else if (mem.eql(u8, arg, "-Bsymbolic")) {
+                    } else if (mem.eql(u8, arg, "--Bsymbolic") or mem.eql(u8, arg, "-Bsymbolic")) {
                         linker_bind_global_refs_locally = true;
                     } else if (mem.eql(u8, arg, "--gc-sections") or mem.eql(u8, arg, "-gc-sections")) {
                         linker_gc_sections = true;
@@ -2300,7 +2300,7 @@ fn buildOutputType(
                     mem.eql(u8, arg, "-no-allow-shlib-undefined"))
                 {
                     linker_allow_shlib_undefined = false;
-                } else if (mem.eql(u8, arg, "-Bsymbolic")) {
+                } else if (mem.eql(u8, arg, "--Bsymbolic") or mem.eql(u8, arg, "-Bsymbolic")) {
                     linker_bind_global_refs_locally = true;
                 } else if (mem.eql(u8, arg, "--import-memory")) {
                     create_module.opts.import_memory = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1965,7 +1965,7 @@ fn buildOutputType(
                                             });
                                         };
                                         continue;
-                                    } else if (mem.eql(u8, key, "--sort-common")) {
+                                    } else if (mem.eql(u8, key, "--sort-common") or mem.eql(u8, key, "-sort-common")) {
                                         // this ignores --sort=common=<anything>; ignoring plain --sort-common
                                         // is done below.
                                         continue;
@@ -1986,7 +1986,7 @@ fn buildOutputType(
                                 mem.eql(u8, linker_arg, "-no_pie"))
                             {
                                 create_module.opts.pie = false;
-                            } else if (mem.eql(u8, linker_arg, "--sort-common")) {
+                            } else if (mem.eql(u8, linker_arg, "--sort-common") or mem.eql(u8, linker_arg, "-sort-common")) {
                                 // from ld.lld(1): --sort-common is ignored for GNU compatibility,
                                 // this ignores plain --sort-common
                             } else if (mem.eql(u8, linker_arg, "--whole-archive") or

--- a/src/main.zig
+++ b/src/main.zig
@@ -1157,7 +1157,7 @@ fn buildOutputType(
                         entry = .{ .named = arg["-fentry=".len..] };
                     } else if (mem.eql(u8, arg, "--force_undefined")) {
                         try force_undefined_symbols.put(arena, args_iter.nextOrFatal(), {});
-                    } else if (mem.eql(u8, arg, "--stack")) {
+                    } else if (mem.eql(u8, arg, "--stack") or mem.eql(u8, arg, "-stack")) {
                         stack_size = parseStackSize(args_iter.nextOrFatal());
                     } else if (mem.eql(u8, arg, "--image-base")) {
                         image_base = parseImageBase(args_iter.nextOrFatal());
@@ -2390,7 +2390,7 @@ fn buildOutputType(
                     entry = .{ .named = linker_args_it.nextOrFatal() };
                 } else if (mem.eql(u8, arg, "-u")) {
                     try force_undefined_symbols.put(arena, linker_args_it.nextOrFatal(), {});
-                } else if (mem.eql(u8, arg, "--stack") or mem.eql(u8, arg, "-stack_size")) {
+                } else if (mem.eql(u8, arg, "--stack") or mem.eql(u8, arg, "-stack") or mem.eql(u8, arg, "-stack_size")) {
                     stack_size = parseStackSize(linker_args_it.nextOrFatal());
                 } else if (mem.eql(u8, arg, "--image-base")) {
                     image_base = parseImageBase(linker_args_it.nextOrFatal());


### PR DESCRIPTION
Went through and made sure that most options have all their variants handled, and added handling for a few options that were missing.

This ended up being more commits than I initially expected. I can squash them if desired.

Closes https://github.com/ziglang/zig/issues/19613.
Alleviates https://github.com/ziglang/zig/issues/18750.

References:

* https://github.com/llvm/llvm-project/blob/main/lld/COFF/Options.td
* https://github.com/llvm/llvm-project/blob/main/lld/ELF/Options.td
* https://github.com/llvm/llvm-project/blob/main/lld/MachO/Options.td
* https://github.com/llvm/llvm-project/blob/main/lld/MinGW/Options.td
* https://github.com/llvm/llvm-project/blob/main/lld/wasm/Options.td