### PR TITLE
suggest --save=name/--save-exact=name when fetched pkg has no build.zig.zon file

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -6960,7 +6960,7 @@ fn cmdFetch(
         .yes, .exact => |name| name: {
             if (name) |n| break :name n;
             const fetched_manifest = fetch.manifest orelse
-                fatal("unable to determine name; fetched package has no build.zig.zon file", .{});
+                fatal("unable to determine name; fetched package has no build.zig.zon file; use the --name option", .{});
             break :name fetched_manifest.name;
         },
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -6960,7 +6960,7 @@ fn cmdFetch(
         .yes, .exact => |name| name: {
             if (name) |n| break :name n;
             const fetched_manifest = fetch.manifest orelse
-                fatal("unable to determine name; fetched package has no build.zig.zon file; use the --name option", .{});
+                fatal("unable to determine name; fetched package has no build.zig.zon file; use --save=[name] or --save-exact=[name] to provide a dependency name", .{});
             break :name fetched_manifest.name;
         },
     };


### PR DESCRIPTION
When trying to `zig fetch` a package that lacks a `build.zig.zon`, the error message is currently:
```
% zig fetch --save git+https://github.com/Foo/bar.git
error: unable to determine name; fetched package has no build.zig.zon file
```
The user may not know how to proceed, which is to supply a name using a `zig fetch` option. This changes the error message to:
```
error: unable to determine name; fetched package has no build.zig.zon file; use --save=[name] or --save-exact=[name] to provide a dependency name
```
----
(Edit: Originally I had the wording `unable to determine name; fetched package has no build.zig.zon file; use the --name option`)