### PR TITLE
std.mem.zeroes: make usage of .EnumLiteral a compile error

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -224,7 +224,7 @@ pub fn zeroes(comptime T: type) T {
         .ComptimeInt, .Int, .ComptimeFloat, .Float => {
             return @as(T, 0);
         },
-        .Enum, .EnumLiteral => {
+        .Enum => {
             return @as(T, @enumFromInt(0));
         },
         .Void => {
@@ -291,6 +291,7 @@ pub fn zeroes(comptime T: type) T {
             }
             @compileError("Can't set a " ++ @typeName(T) ++ " to zero.");
         },
+        .EnumLiteral,
         .ErrorUnion,
         .ErrorSet,
         .Fn,


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/20401