### PR TITLE
codegen+wasm: change non-native sized signed integer lowering

### DIFF
--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -126,6 +126,7 @@ test "@floatFromInt(f80)" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c and comptime builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;


### PR DESCRIPTION
Currently there is divergence of how LLVM and `codegen.zig` lowers signed integers with non-native size.

For example: let say we have `var x: i25 = -1`, if this integer will be placed in the data section, `codegen.zig` will use 4 bytes of memory placing `0xFFFF_FFFF` (-1 in `i32`) there. LLVM will also use 4 bytes, but the remaining 7 padding bits will be zeroed. See [godbolt](https://godbolt.org/z/Tscs7fszq) on how `-1` is stored.

Wasm backend (same can be said for LLVM) maintains invariant that non-native sized integer have their top padding bits being always zeroed, this strategy have its own positives (simplicity, bitcast is free) and negatives (some operations require sign extension, but any strategy will suffer from this).

Such behaviour (in `codegen.zig`) is a hidden bug and blocker for  wasm backend. It does not manifest itself earlier, because integer constants smaller than 64 bits are lowered directly and behavior tests do not use global variables, but it appears when working with big ints.

~~Of course, I could just make `generateSymbol` to change its strategy based on the backend, but _maybe_ the current behaviour is a bug and not intended. This PR, skips some tests that started to fail on `x86_64` and `wasm` backend.~~

Only applies for wasm backend