### PR TITLE
Update wording for @cmpxchgStrong and @cmpxchgWeak in langref.html.in

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4489,7 +4489,10 @@ comptime {
       <pre>{#syntax#}@cmpxchgStrong(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a strong atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
-      if the underlying atomic value was successfully changed, otherwise it returns the current value of the atomic at the time of the operation. It's the equivalent of this code, except atomic:
+      if the value at {#syntax#}ptr{#endsyntax#} was equal to {#syntax#}expected_value{#endsyntax#}
+      at the time of the operation and therefore changed to {#syntax#}new_value{#endsyntax#};
+      otherwise, it returns the value at {#syntax#}ptr{#endsyntax#} at the time of the operation.
+      It's the equivalent of this code, except atomic:
       </p>
       {#code|not_atomic_cmpxchgStrong.zig#}
 

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4513,8 +4513,10 @@ comptime {
       <pre>{#syntax#}@cmpxchgWeak(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a weak atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
-      if the underlying atomic value was successfully changed, otherwise it returns the current value of the 
-      atomic at the time of the operation. It's the equivalent of this code, except atomic:
+      if the value at {#syntax#}ptr{#endsyntax#} was equal to {#syntax#}expected_value{#endsyntax#}
+      at the time of the operation and therefore changed to {#syntax#}new_value{#endsyntax#};
+      otherwise, it returns the value at {#syntax#}ptr{#endsyntax#} at the time of the operation.
+      It's the equivalent of this code, except atomic:
       </p>
       {#syntax_block|zig|cmpxchgWeakButNotAtomic#}
 fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_value: T) ?T {

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4489,10 +4489,7 @@ comptime {
       <pre>{#syntax#}@cmpxchgStrong(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a strong atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
-      if the underlying atomic value was successfully changed, otherwise it returns the current value of the 
-      atomic at the time of the operation. 
-      It's the equivalent of this code,
-      except atomic:
+      if the underlying atomic value was successfully changed, otherwise it returns the current value of the atomic at the time of the operation. It's the equivalent of this code, except atomic:
       </p>
       {#code|not_atomic_cmpxchgStrong.zig#}
 
@@ -4514,8 +4511,7 @@ comptime {
       <p>
       This function performs a weak atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
       if the underlying atomic value was successfully changed, otherwise it returns the current value of the 
-      atomic at the time of the operation. 
-      except atomic:
+      atomic at the time of the operation. It's the equivalent of this code, except atomic:
       </p>
       {#syntax_block|zig|cmpxchgWeakButNotAtomic#}
 fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_value: T) ?T {

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4489,7 +4489,9 @@ comptime {
       <pre>{#syntax#}@cmpxchgStrong(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a strong atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
-      if the current value is not the given expected value. It's the equivalent of this code,
+      if the underlying atomic value was successfully changed, otherwise it returns the current value of the 
+      atomic at the time of the operation. 
+      It's the equivalent of this code,
       except atomic:
       </p>
       {#code|not_atomic_cmpxchgStrong.zig#}
@@ -4511,7 +4513,8 @@ comptime {
       <pre>{#syntax#}@cmpxchgWeak(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a weak atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
-      if the current value is not the given expected value. It's the equivalent of this code,
+      if the underlying atomic value was successfully changed, otherwise it returns the current value of the 
+      atomic at the time of the operation. 
       except atomic:
       </p>
       {#syntax_block|zig|cmpxchgWeakButNotAtomic#}


### PR DESCRIPTION
The previous wording was incorrect as it indicated that `@cmpxchgStrong` and `@cmpxchgWeak` return `null` on "failure" even though it returns `null` on success and the current value of the atomic on "failure", closes #19979. 

Further documentation might be helpful as described in #1516.

