### PR TITLE
std.c: Add setlocale()

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -1895,6 +1895,27 @@ pub extern "c" fn setlogmask(maskpri: c_int) c_int;
 
 pub extern "c" fn if_nametoindex([*:0]const u8) c_int;
 
+/// These are implementation defined but share identical values in at least musl and glibc:
+/// - https://git.musl-libc.org/cgit/musl/tree/include/locale.h?id=ab31e9d6a0fa7c5c408856c89df2dfb12c344039#n18
+/// - https://sourceware.org/git/?p=glibc.git;a=blob;f=locale/bits/locale.h;h=0fcbb66114be5fef0577dc9047256eb508c45919;hb=c90cfce849d010474e8cccf3e5bff49a2c8b141f#l26
+pub const LC = enum(c_int) {
+    CTYPE = 0,
+    NUMERIC = 1,
+    TIME = 2,
+    COLLATE = 3,
+    MONETARY = 4,
+    MESSAGES = 5,
+    ALL = 6,
+    PAPER = 7,
+    NAME = 8,
+    ADDRESS = 9,
+    TELEPHONE = 10,
+    MEASUREMENT = 11,
+    IDENTIFICATION = 12,
+};
+
+pub extern "c" fn setlocale(category: LC, locale: ?[*:0]const u8) [*:0]const u8;
+
 pub const getcontext = if (builtin.target.isAndroid())
     @compileError("android bionic libc does not implement getcontext")
 else if (native_os == .linux and builtin.target.isMusl())


### PR DESCRIPTION
```zig
_ = std.c.setlocale(.ALL, null); // Get locale
_ = std.c.setlocale(.ALL, "en_GB.UTF-8"); // Set locale
```