### PR TITLE
glibc headers: arc4random* functions added in glibc 2.36

### DIFF
--- a/lib/libc/include/generic-glibc/stdlib.h
+++ b/lib/libc/include/generic-glibc/stdlib.h
@@ -653,6 +653,11 @@ extern int lcong48_r (unsigned short int __param[7],
 		      struct drand48_data *__buffer)
      __THROW __nonnull ((1, 2));
 
+/*
+ * arc4random* symbols introduced in glibc 2.36:
+ * https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;h=8420a65cd06874ee09518366b8fba746a557212a;hb=6f4e0fcfa2d2b0915816a3a3a1d48b4763a7dee2
+ */
+#  if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 36) || __GLIBC__ > 2
 /* Return a random integer between zero and 2**32-1 (inclusive).  */
 extern __uint32_t arc4random (void)
      __THROW __wur;
@@ -665,6 +670,7 @@ extern void arc4random_buf (void *__buf, size_t __size)
    limit (exclusive).  */
 extern __uint32_t arc4random_uniform (__uint32_t __upper_bound)
      __THROW __wur;
+#  endif /* glibc v2.36 and later */
 # endif	/* Use misc.  */
 #endif	/* Use misc or X/Open.  */
 


### PR DESCRIPTION
Hide the arc4random* prototypes when building against glibc targets before v2.36.

For context, here's the glibc v2.36 announcment noting the addition of arc4random, arc4random_buf and arc4random_uniform:

  https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;h=8420a65cd06874ee09518366b8fba746a557212a;hb=6f4e0fcfa2d2b0915816a3a3a1d48b4763a7dee2

Tested with the testcase from the bug report.  I get a compile-time error when building against older glibc (instead of a linker error), and no errors (as before) when compiling against v2.36 or later.  And the glibc_compat regression tests pass.

Fix #20426