### PR TITLE
json: respect duplicate_field_behavior in std.json.Value.jsonParse

### DIFF
--- a/lib/std/json/test.zig
+++ b/lib/std/json/test.zig
@@ -28,7 +28,9 @@ fn testLowLevelScanner(s: []const u8) !void {
     }
 }
 fn testHighLevelDynamicParser(s: []const u8) !void {
-    var parsed = try parseFromSlice(Value, testing.allocator, s, .{});
+    var parsed = try parseFromSlice(Value, testing.allocator, s, .{
+        .duplicate_field_behavior = .use_first,
+    });
     defer parsed.deinit();
 }
 


### PR DESCRIPTION
This test would previously pass successfully even though it shouldn't:
```zig
const std = @import("std");
test {
    const parsed_value = try std.json.parseFromSlice(std.json.Value, std.testing.allocator,
        \\{
        \\  "foo": 1,
        \\  "foo": 2
        \\}
    , .{ .duplicate_field_behavior = .@"error" });
    defer parsed_value.deinit();
    try std.testing.expectEqual(2, parsed_value.value.object.get("foo").?.integer);
}
```