### PR TITLE
stage2-wasm: store signed integers with extended sign bit + minor changes

### DIFF
--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -6,8 +6,6 @@ const std = @import("std");
 const Mir = @import("Mir.zig");
 const link = @import("../../link.zig");
 const Zcu = @import("../../Zcu.zig");
-/// Deprecated.
-const Module = Zcu;
 const InternPool = @import("../../InternPool.zig");
 const codegen = @import("../../codegen.zig");
 const leb128 = std.leb;
@@ -18,7 +16,7 @@ mir: Mir,
 bin_file: *link.File.Wasm,
 /// Possible error message. When set, the value is allocated and
 /// must be freed manually.
-error_msg: ?*Module.ErrorMsg = null,
+error_msg: ?*Zcu.ErrorMsg = null,
 /// The binary representation that will be emit by this module.
 code: *std.ArrayList(u8),
 /// List of allocated locals.
@@ -259,7 +257,7 @@ fn fail(emit: *Emit, comptime format: []const u8, args: anytype) InnerError {
     const comp = emit.bin_file.base.comp;
     const zcu = comp.module.?;
     const gpa = comp.gpa;
-    emit.error_msg = try Module.ErrorMsg.create(gpa, zcu.declPtr(emit.decl_index).navSrcLoc(zcu).upgrade(zcu), format, args);
+    emit.error_msg = try Zcu.ErrorMsg.create(gpa, zcu.declPtr(emit.decl_index).navSrcLoc(zcu).upgrade(zcu), format, args);
     return error.EmitFail;
 }
 

--- a/src/arch/wasm/abi.zig
+++ b/src/arch/wasm/abi.zig
@@ -10,8 +10,6 @@ const assert = std.debug.assert;
 
 const Type = @import("../../type.zig").Type;
 const Zcu = @import("../../Zcu.zig");
-/// Deprecated.
-const Module = Zcu;
 
 /// Defines how to pass a type as part of a function signature,
 /// both for parameters as well as return values.
@@ -24,7 +22,7 @@ const direct: [2]Class = .{ .direct, .none };
 /// Classifies a given Zig type to determine how they must be passed
 /// or returned as value within a wasm function.
 /// When all elements result in `.none`, no value must be passed in or returned.
-pub fn classifyType(ty: Type, mod: *Module) [2]Class {
+pub fn classifyType(ty: Type, mod: *Zcu) [2]Class {
     const ip = &mod.intern_pool;
     const target = mod.getTarget();
     if (!ty.hasRuntimeBitsIgnoreComptime(mod)) return none;
@@ -102,7 +100,7 @@ pub fn classifyType(ty: Type, mod: *Module) [2]Class {
 /// Returns the scalar type a given type can represent.
 /// Asserts given type can be represented as scalar, such as
 /// a struct with a single scalar field.
-pub fn scalarType(ty: Type, mod: *Module) Type {
+pub fn scalarType(ty: Type, mod: *Zcu) Type {
     const ip = &mod.intern_pool;
     switch (ty.zigTypeTag(mod)) {
         .Struct => {

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -393,8 +393,38 @@ fn comptimeAdd(comptime a: comptime_int, comptime b: comptime_int) comptime_int 
     return a + b;
 }
 
+fn not(comptime T: type, a: T) T {
+    return ~a;
+}
+
 test "binary not" {
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+
+    try expect(not(u0, 0) == 0);
+    try expect(not(u1, 0) == 1);
+    try expect(not(u1, 1) == 0);
+    try expect(not(u5, 0b01001) == 0b10110);
+    try expect(not(u5, 0b10110) == 0b01001);
+    try expect(not(u16, 0b10101010_10101010) == 0b01010101_01010101);
+    try expect(not(u16, 0b01010101_01010101) == 0b10101010_10101010);
+    try expect(not(u32, 0xAAAA_3333) == 0x5555_CCCC);
+    try expect(not(u32, 0x5555_CCCC) == 0xAAAA_3333);
+    try expect(not(u35, 0x4_1111_FFFF) == 0x3_EEEE_0000);
+    try expect(not(u35, 0x3_EEEE_0000) == 0x4_1111_FFFF);
+    try expect(not(u48, 0x4567_89AB_CDEF) == 0xBA98_7654_3210);
+    try expect(not(u48, 0xBA98_7654_3210) == 0x4567_89AB_CDEF);
+    try expect(not(u64, 0x0123_4567_89AB_CDEF) == 0xFEDC_BA98_7654_3210);
+    try expect(not(u64, 0xFEDC_BA98_7654_3210) == 0x0123_4567_89AB_CDEF);
+
+    try expect(not(i0, 0) == 0);
+    try expect(not(i1, 0) == -1);
+    try expect(not(i1, -1) == 0);
+    try expect(not(i5, -2) == 1);
+    try expect(not(i5, 3) == -4);
+    try expect(not(i32, 0) == -1);
+    try expect(not(i32, -2147483648) == 2147483647);
+    try expect(not(i64, -1) == 0);
+    try expect(not(i64, 0) == -1);
 
     try expect(comptime x: {
         break :x ~@as(u16, 0b1010101010101010) == 0b0101010101010101;
@@ -405,20 +435,33 @@ test "binary not" {
     try expect(comptime x: {
         break :x ~@as(u0, 0) == 0;
     });
-    try testBinaryNot(0b1010101010101010);
 }
 
-fn testBinaryNot(x: u16) !void {
-    try expect(~x == 0b0101010101010101);
-}
-
-test "binary not 128-bit" {
-    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
+test "binary not big int <= 128 bits" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+
+    try expect(not(u65, 1) == 0x1_FFFFFFFF_FFFFFFFE);
+    try expect(not(u65, 0x1_FFFFFFFF_FFFFFFFE) == 1);
+
+    try expect(not(u96, 0x01234567_89ABCDEF_00000001) == 0xFEDCBA98_76543210_FFFFFFFE);
+    try expect(not(u96, 0xFEDCBA98_76543210_FFFFFFFE) == 0x01234567_89ABCDEF_00000001);
+
+    try expect(not(u128, 0xAAAAAAAA_AAAAAAAA_AAAAAAAA_AAAAAAAA) == 0x55555555_55555555_55555555_55555555);
+    try expect(not(u128, 0x55555555_55555555_55555555_55555555) == 0xAAAAAAAA_AAAAAAAA_AAAAAAAA_AAAAAAAA);
+
+    try expect(not(i65, -1) == 0);
+    try expect(not(i65, 0) == -1);
+    try expect(not(i65, -18446744073709551616) == 18446744073709551615);
+    try expect(not(i65, 18446744073709551615) == -18446744073709551616);
+
+    try expect(not(i128, -1) == 0);
+    try expect(not(i128, 0) == -1);
+    try expect(not(i128, -200) == 199);
+    try expect(not(i128, 199) == -200);
 
     try expect(comptime x: {
         break :x ~@as(u128, 0x55555555_55555555_55555555_55555555) == 0xaaaaaaaa_aaaaaaaa_aaaaaaaa_aaaaaaaa;
@@ -426,13 +469,6 @@ test "binary not 128-bit" {
     try expect(comptime x: {
         break :x ~@as(i128, 0x55555555_55555555_55555555_55555555) == @as(i128, @bitCast(@as(u128, 0xaaaaaaaa_aaaaaaaa_aaaaaaaa_aaaaaaaa)));
     });
-
-    try testBinaryNot128(u128, 0xaaaaaaaa_aaaaaaaa_aaaaaaaa_aaaaaaaa);
-    try testBinaryNot128(i128, @as(i128, @bitCast(@as(u128, 0xaaaaaaaa_aaaaaaaa_aaaaaaaa_aaaaaaaa))));
-}
-
-fn testBinaryNot128(comptime Type: type, x: Type) !void {
-    try expect(~x == @as(Type, 0x55555555_55555555_55555555_55555555));
 }
 
 test "division" {


### PR DESCRIPTION
See commit names for additional changes.

~~When migrating sign extension strategy, I encountered some Heisenbug related to bitcasting, ultimately I was able to pass all behavior tests, except one test (inside `int_cast.zig`), while this test seems to be related to strategy migration, it actually not (see code comment).~~ Fixed.

While I think migration was successful, there are places across `Codegen.zig` where wrapping is redundant. I also found a dozen bugs (ex: how `@mulWithOverflow` handles non-native ints), which I did not fix intentionally. This is the next PRs problem, because of the amount of tests I need to add for them.

Related #20404.