### PR TITLE
Rename isASCII to isAscii

### DIFF
--- a/lib/compiler/aro/aro/Parser.zig
+++ b/lib/compiler/aro/aro/Parser.zig
@@ -8011,7 +8011,7 @@ fn charLiteral(p: *Parser) Error!Result {
     const slice = char_kind.contentSlice(p.tokSlice(p.tok_i));
 
     var is_multichar = false;
-    if (slice.len == 1 and std.ascii.isASCII(slice[0])) {
+    if (slice.len == 1 and std.ascii.isAscii(slice[0])) {
         // fast path: single unescaped ASCII char
         val = slice[0];
     } else {

--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -130,7 +130,7 @@ pub fn isLower(c: u8) bool {
 /// Returns whether the character is printable and has some graphical representation,
 /// including the space character.
 pub fn isPrint(c: u8) bool {
-    return isASCII(c) and !isControl(c);
+    return isAscii(c) and !isControl(c);
 }
 
 /// Returns whether this character is included in `whitespace`.
@@ -151,7 +151,7 @@ test whitespace {
     for (whitespace) |char| try std.testing.expect(isWhitespace(char));
 
     var i: u8 = 0;
-    while (isASCII(i)) : (i += 1) {
+    while (isAscii(i)) : (i += 1) {
         if (isWhitespace(i)) try std.testing.expect(std.mem.indexOfScalar(u8, &whitespace, i) != null);
     }
 }
@@ -173,9 +173,12 @@ pub fn isHex(c: u8) bool {
 }
 
 /// Returns whether the character is a 7-bit ASCII character.
-pub fn isASCII(c: u8) bool {
+pub fn isAscii(c: u8) bool {
     return c < 128;
 }
+
+/// /// Deprecated: use `isAscii`
+pub const isASCII = isAscii;
 
 /// Uppercases the character and returns it as-is if already uppercase or not a letter.
 pub fn toUpper(c: u8) u8 {

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1363,7 +1363,7 @@ pub fn isValidHostName(hostname: []const u8) bool {
     if (hostname.len >= 254) return false;
     if (!std.unicode.utf8ValidateSlice(hostname)) return false;
     for (hostname) |byte| {
-        if (!std.ascii.isASCII(byte) or byte == '.' or byte == '-' or std.ascii.isAlphanumeric(byte)) {
+        if (!std.ascii.isAscii(byte) or byte == '.' or byte == '-' or std.ascii.isAlphanumeric(byte)) {
             continue;
         }
         return false;

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -1270,7 +1270,7 @@ pub const Tokenizer = struct {
 
     fn getInvalidCharacterLength(self: *Tokenizer) u3 {
         const c0 = self.buffer[self.index];
-        if (std.ascii.isASCII(c0)) {
+        if (std.ascii.isAscii(c0)) {
             if (c0 == '\r') {
                 if (self.index + 1 < self.buffer.len and self.buffer[self.index + 1] == '\n') {
                     // Carriage returns are *only* allowed just before a linefeed as part of a CRLF pair, otherwise


### PR DESCRIPTION
"ASCII" should be treated as a normal word according to [the style guide](https://ziglang.org/documentation/0.13.0/#Names), and thus `isASCII` should be cased as `isAscii`.

This keeps `isASCII` as a deprecated alias for `isAscii` to ease the transition for users.