### PR TITLE
Rename MAX_NAME_BYTES to max_name_bytes

### DIFF
--- a/lib/compiler/aro/aro/Driver.zig
+++ b/lib/compiler/aro/aro/Driver.zig
@@ -730,8 +730,8 @@ fn processSource(
     defer obj.deinit();
 
     // If it's used, name_buf will either hold a filename or `/tmp/<12 random bytes with base-64 encoding>.<extension>`
-    // both of which should fit into MAX_NAME_BYTES for all systems
-    var name_buf: [std.fs.MAX_NAME_BYTES]u8 = undefined;
+    // both of which should fit into max_name_bytes for all systems
+    var name_buf: [std.fs.max_name_bytes]u8 = undefined;
 
     const out_file_name = if (d.only_compile) blk: {
         const fmt_template = "{s}{s}";

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -72,7 +72,7 @@ pub const max_path_bytes = switch (native_os) {
 /// On Windows, `[]u8` file name components are encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, file name components are encoded as valid UTF-8.
 /// On other platforms, `[]u8` components are an opaque sequence of bytes with no particular encoding.
-pub const MAX_NAME_BYTES = switch (native_os) {
+pub const max_name_bytes = switch (native_os) {
     .linux, .macos, .ios, .freebsd, .openbsd, .netbsd, .dragonfly, .solaris, .illumos => posix.NAME_MAX,
     // Haiku's NAME_MAX includes the null terminator, so subtract one.
     .haiku => posix.NAME_MAX - 1,
@@ -81,7 +81,7 @@ pub const MAX_NAME_BYTES = switch (native_os) {
     // pair in the WTF-16LE, and we (over)account 3 bytes for it that way.
     .windows => windows.NAME_MAX * 3,
     // For WASI, the MAX_NAME will depend on the host OS, so it needs to be
-    // as large as the largest MAX_NAME_BYTES (Windows) in order to work on any host OS.
+    // as large as the largest max_name_bytes (Windows) in order to work on any host OS.
     // TODO determine if this is a reasonable approach
     .wasi => windows.NAME_MAX * 3,
     else => if (@hasDecl(root, "os") and @hasDecl(root.os, "NAME_MAX"))
@@ -89,6 +89,9 @@ pub const MAX_NAME_BYTES = switch (native_os) {
     else
         @compileError("NAME_MAX not implemented for " ++ @tagName(native_os)),
 };
+
+/// Deprecated: use `max_name_bytes`
+pub const MAX_NAME_BYTES = max_name_bytes;
 
 pub const base64_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".*;
 

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -414,7 +414,7 @@ pub const Iterator = switch (native_os) {
         index: usize,
         end_index: usize,
         first_iter: bool,
-        name_data: [fs.MAX_NAME_BYTES]u8,
+        name_data: [fs.max_name_bytes]u8,
 
         const Self = @This();
 

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1269,11 +1269,11 @@ test "max file name component lengths" {
     } else if (native_os == .wasi) {
         // On WASI, the maxed filename depends on the host OS, so in order for this test to
         // work on any host, we need to use a length that will work for all platforms
-        // (i.e. the minimum MAX_NAME_BYTES of all supported platforms).
+        // (i.e. the minimum max_name_bytes of all supported platforms).
         const maxed_wasi_filename = [_]u8{'1'} ** 255;
         try testFilenameLimits(tmp.dir, &maxed_wasi_filename);
     } else {
-        const maxed_ascii_filename = [_]u8{'1'} ** std.fs.MAX_NAME_BYTES;
+        const maxed_ascii_filename = [_]u8{'1'} ** std.fs.max_name_bytes;
         try testFilenameLimits(tmp.dir, &maxed_ascii_filename);
     }
 }

--- a/lib/std/zig/WindowsSdk.zig
+++ b/lib/std/zig/WindowsSdk.zig
@@ -750,7 +750,7 @@ const MsvcLibDir = struct {
         var instances_dir = try findInstancesDir(allocator);
         defer instances_dir.close();
 
-        var state_subpath_buf: [std.fs.MAX_NAME_BYTES + 32]u8 = undefined;
+        var state_subpath_buf: [std.fs.max_name_bytes + 32]u8 = undefined;
         var latest_version_lib_dir = std.ArrayListUnmanaged(u8){};
         errdefer latest_version_lib_dir.deinit(allocator);
 


### PR DESCRIPTION
`MAX_PATH_BYTES` was renamed to `max_path_bytes`. `MAX_NAME_BYTES` should get the same treatment. This keeps `MAX_NAME_BYTES` as an alias for `max_name_bytes` to ease the transition.