### PR TITLE
[std.c] Add eventfd and dup3 functions to FreeBSD

### DIFF
--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -1870,3 +1870,5 @@ pub const MFD = struct {
 
 pub extern "c" fn memfd_create(name: [*:0]const u8, flags: c_uint) c_int;
 pub extern "c" fn copy_file_range(fd_in: fd_t, off_in: ?*off_t, fd_out: fd_t, off_out: ?*off_t, len: usize, flags: u32) usize;
+pub extern "c" fn eventfd(initval: c_uint, flags: c_uint) c_int;
+pub extern "c" fn dup3(old: c_int, new: c_int, flags: c_uint) c_int;


### PR DESCRIPTION
The eventfd system call and dup3 library function have been available since FreeBSD 13 and 10 respectively, and are thus available in all [FreeBSD releases not deemed EOL](<https://endoflife.date/freebsd>)

The lack of these were discovered when porting a terminal emulator to FreeBSD. It would be nice to have them included in Zig's stdlib.

Man pages:
[eventfd, FreeBSD 13](<https://man.freebsd.org/cgi/man.cgi?query=eventfd&apropos=0&sektion=2&manpath=FreeBSD+13.0-RELEASE&arch=default&format=html>)
[dup3, FreeBSD 10](<https://man.freebsd.org/cgi/man.cgi?query=dup3&apropos=0&sektion=0&manpath=FreeBSD+10.0-RELEASE&arch=default&format=html>)
