### PR TITLE
std.mem.reverse: Improve performance

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3470,17 +3470,22 @@ test reverse {
     {
         var arr = [_]i32{ 5, 3, 1, 2, 4 };
         reverse(i32, arr[0..]);
-        try testing.expectEqualSlices(i32, &arr, &[_]i32{ 4, 2, 1, 3, 5 });
+        try testing.expectEqualSlices(i32, &arr, &.{ 4, 2, 1, 3, 5 });
+    }
+    {
+        var arr = [_]u0{};
+        reverse(u0, arr[0..]);
+        try testing.expectEqualSlices(u0, &arr, &.{});
     }
     {
         var arr = [_]i64{ 19, 17, 15, 13, 11, 9, 7, 5, 3, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18 };
         reverse(i64, arr[0..]);
-        try testing.expectEqualSlices(i64, &arr, &[_]i64{ 18, 16, 14, 12, 10, 8, 6, 4, 2, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19 });
+        try testing.expectEqualSlices(i64, &arr, &.{ 18, 16, 14, 12, 10, 8, 6, 4, 2, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19 });
     }
     {
         var arr = [_][]const u8{ "a", "b", "c", "d" };
         reverse([]const u8, arr[0..]);
-        try testing.expectEqualSlices([]const u8, &arr, &[_][]const u8{ "d", "c", "b", "a" });
+        try testing.expectEqualSlices([]const u8, &arr, &.{ "d", "c", "b", "a" });
     }
     {
         const MyType = union(enum) {
@@ -3493,7 +3498,6 @@ test reverse {
         try testing.expectEqualSlices(MyType, &arr, &([_]MyType{ .c, .{ .b = 0 }, .{ .a = .{ 0, 0, 0 } } }));
     }
 }
-
 fn ReverseIterator(comptime T: type) type {
     const Pointer = blk: {
         switch (@typeInfo(T)) {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3488,9 +3488,9 @@ test reverse {
             b: u24,
             c,
         };
-        var arr = [_]MyType{ .{ .a = .{0, 0, 0} }, .{ .b = 0 }, .c };
+        var arr = [_]MyType{ .{ .a = .{ 0, 0, 0 } }, .{ .b = 0 }, .c };
         reverse(MyType, arr[0..]);
-        try testing.expectEqualSlices(MyType, &arr, &([_]MyType{ .c, .{ .b = 0 }, .{ .a = .{0, 0, 0} } }));
+        try testing.expectEqualSlices(MyType, &arr, &([_]MyType{ .c, .{ .b = 0 }, .{ .a = .{ 0, 0, 0 } } }));
     }
 }
 

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3427,20 +3427,57 @@ pub fn swap(comptime T: type, a: *T, b: *T) void {
     b.* = tmp;
 }
 
+inline fn reverseVector(comptime N: usize, comptime T: type, a: []T) [N]T {
+    var res: [N]T = undefined;
+    inline for (0..N) |i| {
+        res[i] = a[N - i - 1];
+    }
+    return res;
+}
+
 /// In-place order reversal of a slice
 pub fn reverse(comptime T: type, items: []T) void {
+    if (@sizeOf(T) == 0) return;
     var i: usize = 0;
     const end = items.len / 2;
+
+    if (std.simd.suggestVectorLength(T)) |simd_size| {
+        if (simd_size <= end) {
+            const simd_end = end - (simd_size - 1);
+            while (i < simd_end) : (i += simd_size) {
+                const left_slice = items[i .. i + simd_size];
+                const right_slice = items[items.len - i - simd_size .. items.len - i];
+
+                const left_shuffled: [simd_size]T = reverseVector(simd_size, T, left_slice);
+                const right_shuffled: [simd_size]T = reverseVector(simd_size, T, right_slice);
+
+                @memcpy(right_slice, &left_shuffled);
+                @memcpy(left_slice, &right_shuffled);
+            }
+        }
+    }
+
     while (i < end) : (i += 1) {
         swap(T, &items[i], &items[items.len - i - 1]);
     }
 }
 
 test reverse {
-    var arr = [_]i32{ 5, 3, 1, 2, 4 };
-    reverse(i32, arr[0..]);
-
-    try testing.expect(eql(i32, &arr, &[_]i32{ 4, 2, 1, 3, 5 }));
+    {
+        var arr = [_]i32{ 5, 3, 1, 2, 4 };
+        reverse(i32, arr[0..]);
+        try testing.expectEqualSlices(i32, &arr, &[_]i32{ 4, 2, 1, 3, 5 });
+    }
+    {
+        var arr = [_]i64{ 19, 17, 15, 13, 11, 9, 7, 5, 3, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18 };
+        reverse(i64, arr[0..]);
+        try testing.expectEqualSlices(i64, &arr, &[_]i64{ 18, 16, 14, 12, 10, 8, 6, 4, 2, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19 });
+    }
+    {
+        var arr = [_][]const u8{ "a", "b", "c", "d" };
+        reverse([]const u8, arr[0..]);
+        try testing.expectEqualSlices([]const u8, &arr, &[_][]const u8{ "d", "c", "b", "a" });
+    }
 }
 
 fn ReverseIterator(comptime T: type) type {


### PR DESCRIPTION
I noticed that std.mem.reverse wasn't getting optimized to use SIMD while optimizing a program a while ago, and decided to make my own faster implementation. After refining it a bit this is my best effort at making it as efficient and readable as possible. For benchmarks see [this repo](https://github.com/jonathanHallstrom/array_reversing/). Any feedback is very welcome