### PR TITLE
ci: update x86_64-macos-release to macos-13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Build and Test
         run: sh ci/aarch64-linux-release.sh
   x86_64-macos-release:
-    runs-on: "macos-11"
+    runs-on: "macos-13"
     env:
       ARCH: "x86_64"
     steps:


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/20467