### PR TITLE
CI: update macOS runner to 12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Build and Test
         run: sh ci/aarch64-linux-release.sh
   x86_64-macos-release:
-    runs-on: "macos-11"
+    runs-on: "macos-12"
     env:
       ARCH: "x86_64"
     steps:


### PR DESCRIPTION
Apple has already dropped support for macOS 11.
GitHub Actions is dropping macOS 11 support now.
The Zig project is also dropping macOS 11 support now.