### PR TITLE
build: fix WriteFile and addCSourceFiles not adding LazyPath deps

### DIFF
--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -484,6 +484,7 @@ pub fn addCSourceFiles(m: *Module, options: AddCSourceFilesOptions) void {
         .flags = b.dupeStrings(options.flags),
     };
     m.link_objects.append(allocator, .{ .c_source_files = c_source_files }) catch @panic("OOM");
+    addLazyPathDependenciesOnly(m, c_source_files.root);
 }
 
 pub fn addCSourceFile(m: *Module, source: CSourceFile) void {

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -665,10 +665,12 @@ pub fn lowerToBuildSteps(
         const writefiles = b.addWriteFiles();
         var file_sources = std.StringHashMap(std.Build.LazyPath).init(b.allocator);
         defer file_sources.deinit();
-        for (update.files.items) |file| {
+        const first_file = update.files.items[0];
+        const root_source_file = writefiles.add(first_file.path, first_file.src);
+        file_sources.put(first_file.path, root_source_file) catch @panic("OOM");
+        for (update.files.items[1..]) |file| {
             file_sources.put(file.path, writefiles.add(file.path, file.src)) catch @panic("OOM");
         }
-        const root_source_file = writefiles.files.items[0].getPath();
 
         const artifact = if (case.is_test) b.addTest(.{
             .root_source_file = root_source_file,

--- a/test/src/CompareOutput.zig
+++ b/test/src/CompareOutput.zig
@@ -81,7 +81,9 @@ pub fn addCase(self: *CompareOutput, case: TestCase) void {
     const b = self.b;
 
     const write_src = b.addWriteFiles();
-    for (case.sources.items) |src_file| {
+    const first_src = case.sources.items[0];
+    const first_file = write_src.add(first_src.filename, first_src.source);
+    for (case.sources.items[1..]) |src_file| {
         _ = write_src.add(src_file.filename, src_file.source);
     }
 
@@ -99,7 +101,7 @@ pub fn addCase(self: *CompareOutput, case: TestCase) void {
                 .target = b.graph.host,
                 .optimize = .Debug,
             });
-            exe.addAssemblyFile(write_src.files.items[0].getPath());
+            exe.addAssemblyFile(first_file);
 
             const run = b.addRunArtifact(exe);
             run.setName(annotated_case_name);
@@ -119,7 +121,7 @@ pub fn addCase(self: *CompareOutput, case: TestCase) void {
 
                 const exe = b.addExecutable(.{
                     .name = "test",
-                    .root_source_file = write_src.files.items[0].getPath(),
+                    .root_source_file = first_file,
                     .optimize = optimize,
                     .target = b.graph.host,
                 });
@@ -145,7 +147,7 @@ pub fn addCase(self: *CompareOutput, case: TestCase) void {
 
             const exe = b.addExecutable(.{
                 .name = "test",
-                .root_source_file = write_src.files.items[0].getPath(),
+                .root_source_file = first_file,
                 .target = b.graph.host,
                 .optimize = .Debug,
             });

--- a/test/src/RunTranslatedC.zig
+++ b/test/src/RunTranslatedC.zig
@@ -72,11 +72,13 @@ pub fn addCase(self: *RunTranslatedCContext, case: *const TestCase) void {
     } else if (self.test_filters.len > 0) return;
 
     const write_src = b.addWriteFiles();
-    for (case.sources.items) |src_file| {
+    const first_case = case.sources.items[0];
+    const root_source_file = write_src.add(first_case.filename, first_case.source);
+    for (case.sources.items[1..]) |src_file| {
         _ = write_src.add(src_file.filename, src_file.source);
     }
     const translate_c = b.addTranslateC(.{
-        .root_source_file = write_src.files.items[0].getPath(),
+        .root_source_file = root_source_file,
         .target = b.graph.host,
         .optimize = .Debug,
     });

--- a/test/src/StackTrace.zig
+++ b/test/src/StackTrace.zig
@@ -51,10 +51,11 @@ fn addExpect(
         if (mem.indexOf(u8, annotated_case_name, test_filter)) |_| break;
     } else if (self.test_filters.len > 0) return;
 
-    const write_src = b.addWriteFile("source.zig", source);
+    const write_files = b.addWriteFiles();
+    const source_zig = write_files.add("source.zig", source);
     const exe = b.addExecutable(.{
         .name = "test",
-        .root_source_file = write_src.files.items[0].getPath(),
+        .root_source_file = source_zig,
         .optimize = optimize_mode,
         .target = b.graph.host,
         .error_tracing = mode_config.error_tracing,

--- a/test/src/TranslateC.zig
+++ b/test/src/TranslateC.zig
@@ -93,12 +93,14 @@ pub fn addCase(self: *TranslateCContext, case: *const TestCase) void {
     } else if (self.test_filters.len > 0) return;
 
     const write_src = b.addWriteFiles();
-    for (case.sources.items) |src_file| {
+    const first_src = case.sources.items[0];
+    const root_source_file = write_src.add(first_src.filename, first_src.source);
+    for (case.sources.items[1..]) |src_file| {
         _ = write_src.add(src_file.filename, src_file.source);
     }
 
     const translate_c = b.addTranslateC(.{
-        .root_source_file = write_src.files.items[0].getPath(),
+        .root_source_file = root_source_file,
         .target = b.resolveTargetQuery(case.target),
         .optimize = .Debug,
     });

--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -83,6 +83,9 @@
         .dep_shared_builtin = .{
             .path = "dep_shared_builtin",
         },
+        .dep_lazypath = .{
+            .path = "dep_lazypath",
+        },
         .dirname = .{
             .path = "dirname",
         },

--- a/test/standalone/dep_lazypath/build.zig
+++ b/test/standalone/dep_lazypath/build.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    const optimize: std.builtin.OptimizeMode = .Debug;
+
+    {
+        const write_files = b.addWriteFiles();
+        const generated_main_c = write_files.add("main.c", "");
+        const exe = b.addExecutable(.{
+            .name = "test",
+            .target = b.graph.host,
+            .optimize = optimize,
+        });
+        exe.addCSourceFiles(.{
+            .root = generated_main_c.dirname(),
+            .files = &.{"main.c"},
+        });
+        b.step("csourcefiles", "").dependOn(&exe.step);
+        test_step.dependOn(&exe.step);
+    }
+    {
+        const write_files = b.addWriteFiles();
+        const dir = write_files.addCopyDirectory(b.path("inc"), "", .{});
+        const exe = b.addExecutable(.{
+            .name = "test",
+            .root_source_file = b.path("inctest.zig"),
+            .target = b.graph.host,
+            .optimize = optimize,
+        });
+        exe.addIncludePath(dir);
+        b.step("copydir", "").dependOn(&exe.step);
+        test_step.dependOn(&exe.step);
+    }
+}

--- a/test/standalone/dep_lazypath/inc/foo.h
+++ b/test/standalone/dep_lazypath/inc/foo.h
@@ -1,0 +1,1 @@
+#define foo_value 42

--- a/test/standalone/dep_lazypath/inctest.zig
+++ b/test/standalone/dep_lazypath/inctest.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const c = @cImport({
+    @cInclude("foo.h");
+});
+comptime {
+    std.debug.assert(c.foo_value == 42);
+}
+pub fn main() void {}

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -783,7 +783,7 @@ pub fn addCliTests(b: *std.Build) *Step {
     if (builtin.os.tag == .linux and builtin.cpu.arch == .x86_64) {
         const tmp_path = b.makeTempPath();
 
-        const writefile = b.addWriteFile("example.zig",
+        const example_zig = b.addWriteFiles().add("example.zig",
             \\// Type your code here, or load an example.
             \\export fn square(num: i32) i32 {
             \\    return num * num;
@@ -804,7 +804,7 @@ pub fn addCliTests(b: *std.Build) *Step {
             "-fno-emit-bin", "-fno-emit-h",
             "-fstrip",       "-OReleaseFast",
         });
-        run.addFileArg(writefile.files.items[0].getPath());
+        run.addFileArg(example_zig);
         const example_s = run.addPrefixedOutputFileArg("-femit-asm=", "example.s");
 
         const checkfile = b.addCheckFile(example_s, .{


### PR DESCRIPTION
Adds a missing call to addLazyPathDependenciesOnly in std.Build.Module.addCSourceFiles.  Also fixes an issue in std.Build.Step.WriteFile where it wasn't updating all the GeneratedFile instances for every directory.  To fix the second issue, I removed all the GeneratedFile instances and now all files/directories reference the steps main GeneratedFile via sub paths.