### PR TITLE
LLVM Builder: Pass correct argument to ensureUnusedMetadataCapacity

### DIFF
--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -12007,7 +12007,7 @@ pub fn debugExpression(
     self: *Builder,
     elements: []const u32,
 ) Allocator.Error!Metadata {
-    try self.ensureUnusedMetadataCapacity(1, Metadata.Expression, elements.len * @sizeOf(u32));
+    try self.ensureUnusedMetadataCapacity(1, Metadata.Expression, elements.len);
     return self.debugExpressionAssumeCapacity(elements);
 }
 
@@ -12015,7 +12015,7 @@ pub fn debugTuple(
     self: *Builder,
     elements: []const Metadata,
 ) Allocator.Error!Metadata {
-    try self.ensureUnusedMetadataCapacity(1, Metadata.Tuple, elements.len * @sizeOf(Metadata));
+    try self.ensureUnusedMetadataCapacity(1, Metadata.Tuple, elements.len);
     return self.debugTupleAssumeCapacity(elements);
 }
 


### PR DESCRIPTION
The trail_len was being multiplied by the size of the type before.

Pointed out by @jacobly0 here: https://github.com/ziglang/zig/pull/19031#discussion_r1664093634