### PR TITLE
std.Build: add support for passing comptime_int, float and comptime_f…

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -468,10 +468,17 @@ fn userInputOptionsFromArgs(allocator: Allocator, args: anytype) UserInputOption
                         .used = false,
                     }) catch @panic("OOM");
                 },
-                .Int => {
+                .ComptimeInt, .Int => {
                     user_input_options.put(field.name, .{
                         .name = field.name,
                         .value = .{ .scalar = std.fmt.allocPrint(allocator, "{d}", .{v}) catch @panic("OOM") },
+                        .used = false,
+                    }) catch @panic("OOM");
+                },
+                .ComptimeFloat, .Float => {
+                    user_input_options.put(field.name, .{
+                        .name = field.name,
+                        .value = .{ .scalar = std.fmt.allocPrint(allocator, "{e}", .{v}) catch @panic("OOM") },
                         .used = false,
                     }) catch @panic("OOM");
                 },


### PR DESCRIPTION
…loat options

Allows passing anonymous structs containing comptime integers with `Build.dependency` and `Build.lazyDependency`, and also adds support for floats, which were missing for some reason.

See https://github.com/ziglang/zig/pull/20435#discussion_r1663559461
