### PR TITLE
std.crypto.pwhash: Set default parameters

### DIFF
--- a/lib/std/crypto/argon2.zig
+++ b/lib/std/crypto/argon2.zig
@@ -51,18 +51,20 @@ pub const Mode = enum {
 };
 
 /// Argon2 parameters
+// Default parameters ​​are according to the OWASP password storage cheat sheet:
+// https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
 pub const Params = struct {
     const Self = @This();
 
     /// A [t]ime cost, which defines the amount of computation realized and therefore the execution
     /// time, given in number of iterations.
-    t: u32,
+    t: u32 = 2,
 
     /// A [m]emory cost, which defines the memory usage, given in kibibytes.
-    m: u32,
+    m: u32 = 19456,
 
     /// A [p]arallelism degree, which defines the number of parallel threads.
-    p: u24,
+    p: u24 = 1,
 
     /// The [secret] parameter, which is used for keyed hashing. This allows a secret key to be input
     /// at hashing time (from some external location) and be folded into the value of the hash. This

--- a/lib/std/crypto/bcrypt.zig
+++ b/lib/std/crypto/bcrypt.zig
@@ -407,9 +407,11 @@ pub const State = struct {
 };
 
 /// bcrypt parameters
+// Default parameters ​​are according to the OWASP password storage cheat sheet:
+// https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
 pub const Params = struct {
     /// log2 of the number of rounds
-    rounds_log: u6,
+    rounds_log: u6 = 10,
 };
 
 /// Compute a hash of a password using 2^rounds_log rounds of the bcrypt key stretching function.

--- a/lib/std/crypto/scrypt.zig
+++ b/lib/std/crypto/scrypt.zig
@@ -121,19 +121,21 @@ fn smix(b: []align(16) u8, r: u30, n: usize, v: []align(16) u32, xy: []align(16)
 }
 
 /// Scrypt parameters
+// Default parameters ​​are according to the OWASP password storage cheat sheet:
+// https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
 pub const Params = struct {
     const Self = @This();
 
     /// The CPU/Memory cost parameter [ln] is log2(N).
-    ln: u6,
+    ln: u6 = 17,
 
     /// The [r]esource usage parameter specifies the block size.
-    r: u30,
+    r: u30 = 8,
 
     /// The [p]arallelization parameter.
     /// A large value of [p] can be used to increase the computational cost of scrypt without
     /// increasing the memory usage.
-    p: u30,
+    p: u30 = 1,
 
     /// Baseline parameters for interactive logins
     pub const interactive = Self.fromLimits(524288, 16777216);


### PR DESCRIPTION
These values ​​are according to the [OWASP cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html).

> - Use [Argon2id](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id) with a minimum configuration of 19 MiB of memory, an iteration count of 2, and 1 degree of parallelism.
> - If [Argon2id](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id) is not available, use [scrypt](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#scrypt) with a minimum CPU/memory cost parameter of (2^17), a minimum block size of 8 (1024 bytes), and a parallelization parameter of 1.
> - For legacy systems using [bcrypt](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#bcrypt), use a work factor of 10 or more and with a password limit of 72 bytes.

If necessary, change the values ​​according to <https://datatracker.ietf.org/doc/html/draft-ietf-kitten-password-storage-07#section-5>.