### PR TITLE
github action: allow manual workflow dispatch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - llvm18
+  workflow_dispatch:
 concurrency:
   # Cancels pending runs when a PR gets updated.
   group: ${{ github.head_ref || github.run_id }}-${{ github.actor }}


### PR DESCRIPTION
Allows workflows to be triggered manually.  This is especially useful for contributors because it allows them to manually trigger workflows on their own forks to test things before creating a pull request.

Here's an example: https://github.com/marler8997/zig/actions/runs/9812284719

By pushing this commit to my fork's main branch, it populates the "Actions" tab with the various workflows.  Then any commit that also has the `workflow_dispatch` option can be manually triggered.  The link above is a branch of mine that I rebased on top of this commit so I'm now able to start the workflow on it.