### PR TITLE
Autodoc: only group structs under "namespaces"

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -1,14 +1,15 @@
 (function() {
     const CAT_namespace = 0;
-    const CAT_global_variable = 1;
-    const CAT_function = 2;
-    const CAT_primitive = 3;
-    const CAT_error_set = 4;
-    const CAT_global_const = 5;
-    const CAT_alias = 6;
-    const CAT_type = 7;
-    const CAT_type_type = 8;
-    const CAT_type_function = 9;
+    const CAT_container = 1;
+    const CAT_global_variable = 2;
+    const CAT_function = 3;
+    const CAT_primitive = 4;
+    const CAT_error_set = 5;
+    const CAT_global_const = 6;
+    const CAT_alias = 7;
+    const CAT_type = 8;
+    const CAT_type_type = 9;
+    const CAT_type_function = 10;
 
     const domDocTestsCode = document.getElementById("docTestsCode");
     const domFnErrorsAnyError = document.getElementById("fnErrorsAnyError");
@@ -184,6 +185,7 @@
       const category = wasm_exports.categorize_decl(decl_index, 0);
       switch (category) {
         case CAT_namespace:
+        case CAT_container:
           return renderNamespacePage(decl_index);
         case CAT_global_variable:
         case CAT_primitive:
@@ -427,14 +429,10 @@
           const member_category = wasm_exports.categorize_decl(member, 0);
           switch (member_category) {
             case CAT_namespace:
-              if (wasm_exports.decl_field_count(member) > 0) {
-                typesList.push({original: original, member: member});
-              } else {
-                namespacesList.push({original: original, member: member});
-              }
-              continue member_loop;
-            case CAT_namespace:
               namespacesList.push({original: original, member: member});
+              continue member_loop;
+            case CAT_container:
+              typesList.push({original: original, member: member});
               continue member_loop;
             case CAT_global_variable:
               varsList.push(member);

--- a/lib/docs/wasm/Decl.zig
+++ b/lib/docs/wasm/Decl.zig
@@ -115,7 +115,7 @@ pub fn categorize(decl: *const Decl) Walk.Category {
 pub fn get_child(decl: *const Decl, name: []const u8) ?Decl.Index {
     switch (decl.categorize()) {
         .alias => |aliasee| return aliasee.get().get_child(name),
-        .namespace => |node| {
+        .namespace, .container => |node| {
             const file = decl.file.get();
             const scope = file.scopes.get(node) orelse return null;
             const child_node = scope.get_child(name) orelse return null;
@@ -128,7 +128,7 @@ pub fn get_child(decl: *const Decl, name: []const u8) ?Decl.Index {
 /// Looks up a decl by name accessible in `decl`'s namespace.
 pub fn lookup(decl: *const Decl, name: []const u8) ?Decl.Index {
     const namespace_node = switch (decl.categorize()) {
-        .namespace => |node| node,
+        .namespace, .container => |node| node,
         else => decl.parent.get().ast_node,
     };
     const file = decl.file.get();

--- a/lib/docs/wasm/main.zig
+++ b/lib/docs/wasm/main.zig
@@ -274,13 +274,6 @@ export fn fn_error_set_decl(decl_index: Decl.Index, node: Ast.Node.Index) Decl.I
     };
 }
 
-export fn decl_field_count(decl_index: Decl.Index) u32 {
-    switch (decl_index.get().categorize()) {
-        .namespace => |node| return decl_index.get().file.get().field_count(node),
-        else => return 0,
-    }
-}
-
 fn decl_error_set_fallible(decl_index: Decl.Index) Oom![]ErrorIdentifier {
     error_set_result.clearRetainingCapacity();
     try addErrorsFromDecl(decl_index, &error_set_result);
@@ -583,7 +576,7 @@ export fn decl_category_name(decl_index: Decl.Index) String {
     const ast = decl.file.get_ast();
     const token_tags = ast.tokens.items(.tag);
     const name = switch (decl.categorize()) {
-        .namespace => |node| {
+        .namespace, .container => |node| {
             const node_tags = ast.nodes.items(.tag);
             if (node_tags[decl.ast_node] == .root)
                 return String.init("struct");


### PR DESCRIPTION
The old heuristic of checking only for the number of fields has the downside of classifying all opaque types, such as `std.c.FILE`, as "namespaces" rather than "types".

Before:

![`std.c` before this change](https://github.com/ziglang/zig/assets/5870990/2bfa8698-4840-4151-a3f5-dd5a181c4624)

After:

![`std.c` after this change](https://github.com/ziglang/zig/assets/5870990/43b98ec8-0340-47fd-955e-94f26618ccc4)
