### PR TITLE
zig ld: handle -v linker arg

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2475,6 +2475,8 @@ fn buildOutputType(
                         fatal("unable to parse /version '{s}': {s}", .{ arg, @errorName(err) });
                     };
                     have_version = true;
+                } else if (mem.eql(u8, arg, "-v")) {
+                    try std.io.getStdOut().writeAll("zig ld " ++ build_options.version ++ "\n");
                 } else if (mem.eql(u8, arg, "--version")) {
                     try std.io.getStdOut().writeAll("zig ld " ++ build_options.version ++ "\n");
                     process.exit(0);

--- a/src/main.zig
+++ b/src/main.zig
@@ -2475,6 +2475,8 @@ fn buildOutputType(
                         fatal("unable to parse /version '{s}': {s}", .{ arg, @errorName(err) });
                     };
                     have_version = true;
+                } else if (mem.eql(u8, arg, "-V")) {
+                    warn("ignoring request for supported emulations: unimplemented", .{});
                 } else if (mem.eql(u8, arg, "-v")) {
                     try std.io.getStdOut().writeAll("zig ld " ++ build_options.version ++ "\n");
                 } else if (mem.eql(u8, arg, "--version")) {


### PR DESCRIPTION
The "-v" argument is the same as "--version", but the linker should not exit after the version is printed.
CMake passes this argument during ABI info detection, and currently zig cc fails because this flag is not supported.

Fixes #20493