### PR TITLE
cmake/findllvm: fix incorrect lib dir setup for zig2

### DIFF
--- a/cmake/Findllvm.cmake
+++ b/cmake/Findllvm.cmake
@@ -176,7 +176,6 @@ if(ZIG_USE_LLVM_CONFIG)
       OUTPUT_STRIP_TRAILING_WHITESPACE)
   string(REPLACE " " ";" LLVM_INCLUDE_DIRS "${LLVM_INCLUDE_DIRS_SPACES}")
 
-  link_directories("${CMAKE_PREFIX_PATH}/lib")
   link_directories("${LLVM_LIBDIRS}")
 else()
   # Here we assume that we're cross compiling with Zig, of course. No reason


### PR DESCRIPTION
### Copy of commit msg
Line `link_directories("${CMAKE_PREFIX_PATH}/lib")` was evaluated as `link_directories("/lib")` in the default case of `CMAKE_PREFIX_PATH` being empty.
This caused cmake to add `-L/lib -Wl,-rpath,/lib` to the zig2 build flags.

This could result in errors on systems where libraries set via `CMAKE_LIBRARY_PATH` had conflicting versions in `/lib`:
- `-L/lib` could cause linking zig2 to fail
- `-Wl,-rpath,/lib` adds `/lib` as the first entry of the zig2 `RPATH`. This could cause running zig2 (to build zig3) to fail.

In case of conflicting lib dirs, cmake emitted this warning, which is now fixed:
```
Cannot generate a safe runtime search path for target zig2 because files in
  some directories may conflict with libraries in implicit directories:

    runtime library [libclang-cpp.so.18.1] in /nix/store/...-clang-18.1.5-lib/lib may be hidden by files in:
      /lib
```

### Reproduce
Use an Archlinux Docker image to repro a zig2 linking failure:
```bash
docker run -it archlinux /bin/bash
## Run the following inside the docker container shell

# Install pkg `clang` to cause a conflict for libclang-cpp.so between the nix build env (`CMAKE_LIBRARY_PATH`) and /usr/lib
pacman -Syu --noconfirm clang nix git
mkdir -p /tmp/zig /tmp/build
# Fetch Zig master as of 2024-07-06
curl -SL https://github.com/ziglang/zig/archive/bf588f67d8c6261105f81fd468c420d662541d2a.tar.gz | tar xz --strip-components=1 -C /tmp/zig
cd /tmp/build
echo 'experimental-features = nix-command flakes' >> /etc/nix/nix.conf
nix develop github:erikarvstedt/nix-zig-build/38946a3581d1250a24e932541c22ef1cce7f7321 -c bash -c '
  cmake /tmp/zig
  make VERBOSE=1 zig2
'
```
This results in the following error while linking zig2:
```
/nix/store/wwfrj9kvfi14xclc38qfwm71ah6aawdh-binutils-2.41/bin/ld: /nix/store/2ykf9vnwl6s3nvisgd9vpzm74wxabysd-clang-18.1.7-lib/lib/libclang-cpp.so: undefined reference to `getPollyPluginInfo()@LLVM_18.1'
```

### Discussion

@andrewrk, you've added line `link_directories("${CMAKE_PREFIX_PATH}/lib")`.
A first glance I'd guess that removing this line is fine given that `LLVM_LIBDIRS`, which should contain the actual LLVM libdirs, is still passed to `link_directories()`. But I don't know why this was added in the first place.

I've encountered this bug via https://github.com/erikarvstedt/nix-zig-build/pull/2. This PR also contains [an example](https://github.com/erikarvstedt/nix-zig-build/pull/2#issuecomment-2211112023) of a zig2 runtime error (due to `/lib` being at the front of `rpath`).