### PR TITLE
std.crypto.pwhash: Add recommended parameters

### DIFF
--- a/lib/std/crypto/argon2.zig
+++ b/lib/std/crypto/argon2.zig
@@ -91,6 +91,10 @@ pub const Params = struct {
     /// Baseline parameters for offline usage using argon2id type
     pub const sensitive_2id = Self.fromLimits(4, 1073741824);
 
+    /// Recommended parameters for argon2id type according to the
+    /// [OWASP cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html).
+    pub const owasp_2id = Self{ .t = 2, .m = 19 * 1024, .p = 1 };
+
     /// Create parameters from ops and mem limits, where mem_limit given in bytes
     pub fn fromLimits(ops_limit: u32, mem_limit: usize) Self {
         const m = mem_limit / 1024;

--- a/lib/std/crypto/bcrypt.zig
+++ b/lib/std/crypto/bcrypt.zig
@@ -408,8 +408,14 @@ pub const State = struct {
 
 /// bcrypt parameters
 pub const Params = struct {
+    const Self = @This();
+
     /// log2 of the number of rounds
     rounds_log: u6,
+
+    /// Minimum recommended parameters according to the
+    /// [OWASP cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html).
+    pub const owasp = Self{ .rounds_log = 10 };
 };
 
 /// Compute a hash of a password using 2^rounds_log rounds of the bcrypt key stretching function.

--- a/lib/std/crypto/scrypt.zig
+++ b/lib/std/crypto/scrypt.zig
@@ -141,6 +141,10 @@ pub const Params = struct {
     /// Baseline parameters for offline usage
     pub const sensitive = Self.fromLimits(33554432, 1073741824);
 
+    /// Recommended parameters according to the
+    /// [OWASP cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html).
+    pub const owasp = Self{ .ln = 17, .r = 8, .p = 1 };
+
     /// Create parameters from ops and mem limits, where mem_limit given in bytes
     pub fn fromLimits(ops_limit: u64, mem_limit: usize) Self {
         const ops = @max(32768, ops_limit);


### PR DESCRIPTION
These parameters according to the [OWASP cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html).

See also: #20503