### PR TITLE
Fix compile error in std.fmt.Parser.peek()

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -386,7 +386,7 @@ pub const Parser = struct {
         const original_i = self.iter.i;
         defer self.iter.i = original_i;
 
-        var i = 0;
+        var i: usize = 0;
         var code_point: ?u21 = null;
         while (i <= n) : (i += 1) {
             code_point = self.iter.nextCodepoint();


### PR DESCRIPTION
I was playing around with `std.fmt.Parser` and got hit by a compile error when it was not used in comptime.

Fixes #20500, which I noticed as I was creating this PR.