### PR TITLE
build_runner: fix oob access

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -1208,7 +1208,7 @@ fn nextArg(args: [][:0]const u8, idx: *usize) ?[:0]const u8 {
 
 fn nextArgOrFatal(args: [][:0]const u8, idx: *usize) [:0]const u8 {
     return nextArg(args, idx) orelse {
-        std.debug.print("expected argument after '{s}'\n  access the help menu with 'zig build -h'\n", .{args[idx.*]});
+        std.debug.print("expected argument after '{s}'\n  access the help menu with 'zig build -h'\n", .{args[idx.* - 1]});
         process.exit(1);
     };
 }


### PR DESCRIPTION
```
mkdir aaa
cd aaa
zig init
zig build --prefix
```

before:
```
thread 33711 panic: index out of bounds: index 9, len 9
/home/paulo/.local/lib/zig/lib/compiler/build_runner.zig:1211:110: 0x10f2e55 in nextArgOrFatal (build)
        std.debug.print("expected argument after '{s}'\n  access the help menu with 'zig build -h'\n", .{args[idx.*]});
                                                                                                             ^
/home/paulo/.local/lib/zig/lib/compiler/build_runner.zig:131:48: 0x10edd41 in main (build)
                install_prefix = nextArgOrFatal(args, &arg_idx);
                                               ^
...
error: the following build command crashed:
...
```

after:
```
expected argument after '--prefix'
  access the help menu with 'zig build -h'
error: the following build command failed with exit code 1:
...
```
