### PR TITLE
Add diagnostics for CMake ConfigHeader errors

### DIFF
--- a/test/standalone/cmakedefine/build.zig
+++ b/test/standalone/cmakedefine/build.zig
@@ -48,7 +48,6 @@ pub fn build(b: *std.Build) void {
             .include_path = "stack.h",
         },
         .{
-            .AT = "@",
             .UNDERSCORE = "_",
             .NEST_UNDERSCORE_PROXY = "UNDERSCORE",
             .NEST_PROXY = "NEST_UNDERSCORE_PROXY",
@@ -104,7 +103,7 @@ fn compare_headers(step: *std.Build.Step, options: std.Build.Step.MakeOptions) !
         const header_text_index = std.mem.indexOf(u8, zig_header, "\n") orelse @panic("Could not find comment in header filer");
 
         if (!std.mem.eql(u8, zig_header[header_text_index + 1 ..], cmake_header)) {
-            @panic("processed cmakedefine header does not match expected output");
+            std.debug.panic("processed cmakedefine header {s} does not match expected output", .{zig_header_path});
         }
     }
 }


### PR DESCRIPTION
Follow-up to #20234 

Closes #17263 by adding an error message about unused variables

```bash
> ls
build.zig  foo.h.in

> cat foo.h.in
#define a @b@
#define b ${#}
#define c ${}

> cat build.zig
const std = @import("std");

pub fn build(b: *std.Build) void {
    const out_h = b.addConfigHeader(.{
        .style = .{ .cmake = b.path("foo.h.in") },
    }, .{ .unused = .undef, .also_unused = "" });
    const install_file = b.addInstallFileWithDir(out_h.getOutput(), .header, "foo.h");
    b.getInstallStep().dependOn(&install_file.step);
}

> zig build
install
└─ install generated to foo.h
   └─ configure cmake header foo.h.in to foo.h failure
error: /home/dmitry/zig/17263/foo.h.in:1:11: unable to substitute variable: UndefinedVariable: b
error: /home/dmitry/zig/17263/foo.h.in:2:13: unable to substitute variable: InvalidCharacter: #
error: /home/dmitry/zig/17263/foo.h.in:3:11: unable to substitute variable: MissingName: 
error: /home/dmitry/zig/17263/foo.h.in: error: unused variables: { unused, also_unused }
error: HeaderConfigFailed
Build Summary: 0/3 steps succeeded; 1 failed (disable with --summary none)
install transitive failure
└─ install generated to foo.h transitive failure
   └─ configure cmake header foo.h.in to foo.h failure
error: the following build command failed with exit code 1:
...
```