### PR TITLE
InternPool: implement thread-safe allocated lists

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2830,7 +2830,7 @@ fn zirStructDecl(
         inst,
     );
     mod.declPtr(new_decl_index).owns_tv = true;
-    errdefer mod.abortAnonDecl(new_decl_index);
+    errdefer pt.abortAnonDecl(new_decl_index);
 
     if (pt.zcu.comp.debug_incremental) {
         try ip.addDependency(
@@ -2841,12 +2841,12 @@ fn zirStructDecl(
     }
 
     // TODO: if AstGen tells us `@This` was not used in the fields, we can elide the namespace.
-    const new_namespace_index: InternPool.OptionalNamespaceIndex = if (true or decls_len > 0) (try mod.createNamespace(.{
+    const new_namespace_index: InternPool.OptionalNamespaceIndex = if (true or decls_len > 0) (try pt.createNamespace(.{
         .parent = block.namespace.toOptional(),
         .decl_index = new_decl_index,
         .file_scope = block.getFileScopeIndex(mod),
     })).toOptional() else .none;
-    errdefer if (new_namespace_index.unwrap()) |ns| mod.destroyNamespace(ns);
+    errdefer if (new_namespace_index.unwrap()) |ns| pt.destroyNamespace(ns);
 
     if (new_namespace_index.unwrap()) |ns| {
         const decls = sema.code.bodySlice(extra_index, decls_len);
@@ -2872,8 +2872,8 @@ fn createAnonymousDeclTypeNamed(
     const ip = &zcu.intern_pool;
     const gpa = sema.gpa;
     const namespace = block.namespace;
-    const new_decl_index = try zcu.allocateNewDecl(namespace);
-    errdefer zcu.destroyDecl(new_decl_index);
+    const new_decl_index = try pt.allocateNewDecl(namespace);
+    errdefer pt.destroyDecl(new_decl_index);
 
     switch (name_strategy) {
         .anon => {}, // handled after switch
@@ -3068,7 +3068,7 @@ fn zirEnumDecl(
     );
     const new_decl = mod.declPtr(new_decl_index);
     new_decl.owns_tv = true;
-    errdefer if (!done) mod.abortAnonDecl(new_decl_index);
+    errdefer if (!done) pt.abortAnonDecl(new_decl_index);
 
     if (pt.zcu.comp.debug_incremental) {
         try mod.intern_pool.addDependency(
@@ -3079,12 +3079,12 @@ fn zirEnumDecl(
     }
 
     // TODO: if AstGen tells us `@This` was not used in the fields, we can elide the namespace.
-    const new_namespace_index: InternPool.OptionalNamespaceIndex = if (true or decls_len > 0) (try mod.createNamespace(.{
+    const new_namespace_index: InternPool.OptionalNamespaceIndex = if (true or decls_len > 0) (try pt.createNamespace(.{
         .parent = block.namespace.toOptional(),
         .decl_index = new_decl_index,
         .file_scope = block.getFileScopeIndex(mod),
     })).toOptional() else .none;
-    errdefer if (!done) if (new_namespace_index.unwrap()) |ns| mod.destroyNamespace(ns);
+    errdefer if (!done) if (new_namespace_index.unwrap()) |ns| pt.destroyNamespace(ns);
 
     if (new_namespace_index.unwrap()) |ns| {
         try pt.scanNamespace(ns, decls, new_decl);
@@ -3335,7 +3335,7 @@ fn zirUnionDecl(
         inst,
     );
     mod.declPtr(new_decl_index).owns_tv = true;
-    errdefer mod.abortAnonDecl(new_decl_index);
+    errdefer pt.abortAnonDecl(new_decl_index);
 
     if (pt.zcu.comp.debug_incremental) {
         try mod.intern_pool.addDependency(
@@ -3346,12 +3346,12 @@ fn zirUnionDecl(
     }
 
     // TODO: if AstGen tells us `@This` was not used in the fields, we can elide the namespace.
-    const new_namespace_index: InternPool.OptionalNamespaceIndex = if (true or decls_len > 0) (try mod.createNamespace(.{
+    const new_namespace_index: InternPool.OptionalNamespaceIndex = if (true or decls_len > 0) (try pt.createNamespace(.{
         .parent = block.namespace.toOptional(),
         .decl_index = new_decl_index,
         .file_scope = block.getFileScopeIndex(mod),
     })).toOptional() else .none;
-    errdefer if (new_namespace_index.unwrap()) |ns| mod.destroyNamespace(ns);
+    errdefer if (new_namespace_index.unwrap()) |ns| pt.destroyNamespace(ns);
 
     if (new_namespace_index.unwrap()) |ns| {
         const decls = sema.code.bodySlice(extra_index, decls_len);
@@ -3425,7 +3425,7 @@ fn zirOpaqueDecl(
         inst,
     );
     mod.declPtr(new_decl_index).owns_tv = true;
-    errdefer mod.abortAnonDecl(new_decl_index);
+    errdefer pt.abortAnonDecl(new_decl_index);
 
     if (pt.zcu.comp.debug_incremental) {
         try ip.addDependency(
@@ -3435,12 +3435,12 @@ fn zirOpaqueDecl(
         );
     }
 
-    const new_namespace_index: InternPool.OptionalNamespaceIndex = if (decls_len > 0) (try mod.createNamespace(.{
+    const new_namespace_index: InternPool.OptionalNamespaceIndex = if (decls_len > 0) (try pt.createNamespace(.{
         .parent = block.namespace.toOptional(),
         .decl_index = new_decl_index,
         .file_scope = block.getFileScopeIndex(mod),
     })).toOptional() else .none;
-    errdefer if (new_namespace_index.unwrap()) |ns| mod.destroyNamespace(ns);
+    errdefer if (new_namespace_index.unwrap()) |ns| pt.destroyNamespace(ns);
 
     if (new_namespace_index.unwrap()) |ns| {
         const decls = sema.code.bodySlice(extra_index, decls_len);
@@ -21716,7 +21716,7 @@ fn zirReify(
                 inst,
             );
             mod.declPtr(new_decl_index).owns_tv = true;
-            errdefer mod.abortAnonDecl(new_decl_index);
+            errdefer pt.abortAnonDecl(new_decl_index);
 
             try pt.finalizeAnonDecl(new_decl_index);
 
@@ -21916,7 +21916,7 @@ fn reifyEnum(
         inst,
     );
     mod.declPtr(new_decl_index).owns_tv = true;
-    errdefer mod.abortAnonDecl(new_decl_index);
+    errdefer pt.abortAnonDecl(new_decl_index);
 
     wip_ty.prepare(ip, new_decl_index, .none);
     wip_ty.setTagTy(ip, tag_ty.toIntern());
@@ -22063,7 +22063,7 @@ fn reifyUnion(
         inst,
     );
     mod.declPtr(new_decl_index).owns_tv = true;
-    errdefer mod.abortAnonDecl(new_decl_index);
+    errdefer pt.abortAnonDecl(new_decl_index);
 
     const field_types = try sema.arena.alloc(InternPool.Index, fields_len);
     const field_aligns = if (any_aligns) try sema.arena.alloc(InternPool.Alignment, fields_len) else undefined;
@@ -22322,7 +22322,7 @@ fn reifyStruct(
         inst,
     );
     mod.declPtr(new_decl_index).owns_tv = true;
-    errdefer mod.abortAnonDecl(new_decl_index);
+    errdefer pt.abortAnonDecl(new_decl_index);
 
     const struct_type = ip.loadStructType(wip_ty.index);
 
@@ -26497,8 +26497,8 @@ fn zirBuiltinExtern(
     }
     const ptr_info = ty.ptrInfo(mod);
 
-    const new_decl_index = try mod.allocateNewDecl(sema.owner_decl.src_namespace);
-    errdefer mod.destroyDecl(new_decl_index);
+    const new_decl_index = try pt.allocateNewDecl(sema.owner_decl.src_namespace);
+    errdefer pt.destroyDecl(new_decl_index);
     const new_decl = mod.declPtr(new_decl_index);
     try mod.initNewAnonDecl(
         new_decl_index,
@@ -36733,8 +36733,8 @@ fn generateUnionTagTypeNumbered(
     const gpa = sema.gpa;
     const ip = &mod.intern_pool;
 
-    const new_decl_index = try mod.allocateNewDecl(block.namespace);
-    errdefer mod.destroyDecl(new_decl_index);
+    const new_decl_index = try pt.allocateNewDecl(block.namespace);
+    errdefer pt.destroyDecl(new_decl_index);
     const fqn = try union_owner_decl.fullyQualifiedName(pt);
     const name = try ip.getOrPutStringFmt(
         gpa,
@@ -36748,7 +36748,7 @@ fn generateUnionTagTypeNumbered(
         Value.@"unreachable",
         name,
     );
-    errdefer mod.abortAnonDecl(new_decl_index);
+    errdefer pt.abortAnonDecl(new_decl_index);
 
     const new_decl = mod.declPtr(new_decl_index);
     new_decl.owns_tv = true;
@@ -36785,8 +36785,8 @@ fn generateUnionTagTypeSimple(
 
     const new_decl_index = new_decl_index: {
         const fqn = try union_owner_decl.fullyQualifiedName(pt);
-        const new_decl_index = try mod.allocateNewDecl(block.namespace);
-        errdefer mod.destroyDecl(new_decl_index);
+        const new_decl_index = try pt.allocateNewDecl(block.namespace);
+        errdefer pt.destroyDecl(new_decl_index);
         const name = try ip.getOrPutStringFmt(
             gpa,
             pt.tid,
@@ -36802,7 +36802,7 @@ fn generateUnionTagTypeSimple(
         mod.declPtr(new_decl_index).name_fully_qualified = true;
         break :new_decl_index new_decl_index;
     };
-    errdefer mod.abortAnonDecl(new_decl_index);
+    errdefer pt.abortAnonDecl(new_decl_index);
 
     const enum_ty = try ip.getGeneratedTagEnumType(gpa, pt.tid, .{
         .decl = new_decl_index,

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -5,6 +5,58 @@ tid: Id,
 
 pub const Id = if (InternPool.single_threaded) enum { main } else enum(u8) { main, _ };
 
+pub fn destroyDecl(pt: Zcu.PerThread, decl_index: Zcu.Decl.Index) void {
+    const zcu = pt.zcu;
+    const gpa = zcu.gpa;
+
+    {
+        _ = zcu.test_functions.swapRemove(decl_index);
+        if (zcu.global_assembly.fetchSwapRemove(decl_index)) |kv| {
+            gpa.free(kv.value);
+        }
+    }
+
+    pt.zcu.intern_pool.destroyDecl(pt.tid, decl_index);
+
+    if (zcu.emit_h) |zcu_emit_h| {
+        const decl_emit_h = zcu_emit_h.declPtr(decl_index);
+        decl_emit_h.fwd_decl.deinit(gpa);
+        decl_emit_h.* = undefined;
+    }
+}
+
+fn deinitFile(pt: Zcu.PerThread, file_index: Zcu.File.Index) void {
+    const zcu = pt.zcu;
+    const gpa = zcu.gpa;
+    const file = zcu.fileByIndex(file_index);
+    const is_builtin = file.mod.isBuiltin();
+    log.debug("deinit File {s}", .{file.sub_file_path});
+    if (is_builtin) {
+        file.unloadTree(gpa);
+        file.unloadZir(gpa);
+    } else {
+        gpa.free(file.sub_file_path);
+        file.unload(gpa);
+    }
+    file.references.deinit(gpa);
+    if (zcu.fileRootDecl(file_index).unwrap()) |root_decl| {
+        pt.zcu.intern_pool.destroyDecl(pt.tid, root_decl);
+    }
+    if (file.prev_zir) |prev_zir| {
+        prev_zir.deinit(gpa);
+        gpa.destroy(prev_zir);
+    }
+    file.* = undefined;
+}
+
+pub fn destroyFile(pt: Zcu.PerThread, file_index: Zcu.File.Index) void {
+    const gpa = pt.zcu.gpa;
+    const file = pt.zcu.fileByIndex(file_index);
+    const is_builtin = file.mod.isBuiltin();
+    pt.deinitFile(file_index);
+    if (!is_builtin) gpa.destroy(file);
+}
+
 pub fn astGenFile(
     pt: Zcu.PerThread,
     file: *Zcu.File,
@@ -930,14 +982,14 @@ fn semaFile(pt: Zcu.PerThread, file_index: Zcu.File.Index) Zcu.SemaError!void {
     // Because these three things each reference each other, `undefined`
     // placeholders are used before being set after the struct type gains an
     // InternPool index.
-    const new_namespace_index = try zcu.createNamespace(.{
+    const new_namespace_index = try pt.createNamespace(.{
         .parent = .none,
         .decl_index = undefined,
         .file_scope = file_index,
     });
-    errdefer zcu.destroyNamespace(new_namespace_index);
+    errdefer pt.destroyNamespace(new_namespace_index);
 
-    const new_decl_index = try zcu.allocateNewDecl(new_namespace_index);
+    const new_decl_index = try pt.allocateNewDecl(new_namespace_index);
     const new_decl = zcu.declPtr(new_decl_index);
     errdefer @panic("TODO error handling");
 
@@ -1380,6 +1432,13 @@ pub fn embedFile(
     return pt.newEmbedFile(cur_file.mod, sub_file_path, resolved_path, gop.value_ptr, src_loc);
 }
 
+/// Cancel the creation of an anon decl and delete any references to it.
+/// If other decls depend on this decl, they must be aborted first.
+pub fn abortAnonDecl(pt: Zcu.PerThread, decl_index: Zcu.Decl.Index) void {
+    assert(!pt.zcu.declIsRoot(decl_index));
+    pt.destroyDecl(decl_index);
+}
+
 /// Finalize the creation of an anon decl.
 pub fn finalizeAnonDecl(pt: Zcu.PerThread, decl_index: Zcu.Decl.Index) Allocator.Error!void {
     if (pt.zcu.declPtr(decl_index).typeOf(pt.zcu).isFnOrHasRuntimeBits(pt)) {
@@ -1674,7 +1733,7 @@ const ScanDeclIter = struct {
             break :decl_index .{ was_exported, decl_index };
         } else decl_index: {
             // Create and set up a new Decl.
-            const new_decl_index = try zcu.allocateNewDecl(namespace_index);
+            const new_decl_index = try pt.allocateNewDecl(namespace_index);
             const new_decl = zcu.declPtr(new_decl_index);
             new_decl.kind = kind;
             new_decl.name = decl_name;
@@ -1979,6 +2038,43 @@ pub fn analyzeFnBody(pt: Zcu.PerThread, func_index: InternPool.Index, arena: All
         .instructions = sema.air_instructions.toOwnedSlice(),
         .extra = try sema.air_extra.toOwnedSlice(gpa),
     };
+}
+
+pub fn createNamespace(pt: Zcu.PerThread, initialization: Zcu.Namespace) !Zcu.Namespace.Index {
+    return pt.zcu.intern_pool.createNamespace(pt.zcu.gpa, pt.tid, initialization);
+}
+
+pub fn destroyNamespace(pt: Zcu.PerThread, namespace_index: Zcu.Namespace.Index) void {
+    return pt.zcu.intern_pool.destroyNamespace(pt.tid, namespace_index);
+}
+
+pub fn allocateNewDecl(pt: Zcu.PerThread, namespace: Zcu.Namespace.Index) !Zcu.Decl.Index {
+    const zcu = pt.zcu;
+    const gpa = zcu.gpa;
+    const decl_index = try zcu.intern_pool.createDecl(gpa, pt.tid, .{
+        .name = undefined,
+        .src_namespace = namespace,
+        .has_tv = false,
+        .owns_tv = false,
+        .val = undefined,
+        .alignment = undefined,
+        .@"linksection" = .none,
+        .@"addrspace" = .generic,
+        .analysis = .unreferenced,
+        .zir_decl_index = .none,
+        .is_pub = false,
+        .is_exported = false,
+        .kind = .anon,
+    });
+
+    if (zcu.emit_h) |zcu_emit_h| {
+        if (@intFromEnum(decl_index) >= zcu_emit_h.allocated_emit_h.len) {
+            try zcu_emit_h.allocated_emit_h.append(gpa, .{});
+            assert(@intFromEnum(decl_index) == zcu_emit_h.allocated_emit_h.len);
+        }
+    }
+
+    return decl_index;
 }
 
 fn lockAndClearFileCompileError(pt: Zcu.PerThread, file: *Zcu.File) void {


### PR DESCRIPTION
This fixes 2/5 of the remaining races before Sema and codegen/linking can be on separate threads.