### PR TITLE
Fix invalid bytes error messages and improve utf-8 handling in tokenizer

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -188,9 +188,8 @@ pub fn tokenSlice(tree: Ast, token_index: TokenIndex) []const u8 {
     var tokenizer: std.zig.Tokenizer = .{
         .buffer = tree.source,
         .index = token_starts[token_index],
-        .pending_invalid_token = null,
     };
-    const token = tokenizer.findTagAtCurrentIndex(token_tag);
+    const token = tokenizer.next();
     assert(token.tag == token_tag);
     return tree.source[token.loc.start..token.loc.end];
 }

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -13824,10 +13824,10 @@ fn lowerAstErrors(astgen: *AstGen) !void {
     var notes: std.ArrayListUnmanaged(u32) = .{};
     defer notes.deinit(gpa);
 
-    if (token_tags[parse_err.token + @intFromBool(parse_err.token_is_prev)] == .invalid) {
-        const tok = parse_err.token + @intFromBool(parse_err.token_is_prev);
-        const bad_off: u32 = @intCast(tree.tokenSlice(parse_err.token + @intFromBool(parse_err.token_is_prev)).len);
-        const byte_abs = token_starts[parse_err.token + @intFromBool(parse_err.token_is_prev)] + bad_off;
+    const tok = parse_err.token + @intFromBool(parse_err.token_is_prev);
+    if (token_tags[tok] == .invalid) {
+        const bad_off: u32 = @intCast(tree.tokenSlice(tok).len);
+        const byte_abs = token_starts[tok] + bad_off;
         try notes.append(gpa, try astgen.errNoteTokOff(tok, bad_off, "invalid byte: '{'}'", .{
             std.zig.fmtEscapes(tree.source[byte_abs..][0..1]),
         }));

--- a/test/cases/compile_errors/invalid_unicode_escape.zig
+++ b/test/cases/compile_errors/invalid_unicode_escape.zig
@@ -1,0 +1,11 @@
+export fn entry() void {
+    const a = '\u{12z34}';
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:15: error: expected expression, found 'invalid bytes'
+// :2:21: note: invalid byte: 'z'
+

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -42,8 +42,8 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
         const case = ctx.obj("isolated carriage return in multiline string literal", b.graph.host);
 
         case.addError("const foo = \\\\\test\r\r rogue carriage return\n;", &[_][]const u8{
-            ":1:19: error: expected ';' after declaration",
-            ":1:20: note: invalid byte: '\\r'",
+            ":1:13: error: expected expression, found 'invalid bytes'",
+            ":1:19: note: invalid byte: '\\r'",
         });
     }
 
@@ -216,5 +216,41 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
             \\pub fn comptimeAnytypeFunction(comptime _: anytype) void {}
             \\pub fn anytypeFunction(_: anytype) void {}
         );
+    }
+
+    {
+        const case = ctx.obj("invalid byte in string", b.graph.host);
+
+        case.addError("_ = \"\x01Q\";", &[_][]const u8{
+            ":1:5: error: expected expression, found 'invalid bytes'",
+            ":1:6: note: invalid byte: '\\x01'",
+        });
+    }
+
+    {
+        const case = ctx.obj("invalid byte in comment", b.graph.host);
+
+        case.addError("//\x01Q", &[_][]const u8{
+            ":1:1: error: expected type expression, found 'invalid bytes'",
+            ":1:3: note: invalid byte: '\\x01'",
+        });
+    }
+
+    {
+        const case = ctx.obj("control character in character literal", b.graph.host);
+
+        case.addError("const c = '\x01';", &[_][]const u8{
+            ":1:11: error: expected expression, found 'invalid bytes'",
+            ":1:12: note: invalid byte: '\\x01'",
+        });
+    }
+
+    {
+        const case = ctx.obj("invalid byte at start of token", b.graph.host);
+
+        case.addError("x = \x00Q", &[_][]const u8{
+            ":1:5: error: expected expression, found 'invalid bytes'",
+            ":1:5: note: invalid byte: '\\x00'",
+        });
     }
 }


### PR DESCRIPTION
Fixes many error messages corresponding to invalid bytes displaying the wrong byte. Additionaly improves handling of UTF-8 in some places.

Fixes #13809
Fixes #17437