### PR TITLE
InternPool: fix more races blocking a separate codegen/linker thread

### DIFF
--- a/src/Air.zig
+++ b/src/Air.zig
@@ -1034,7 +1034,12 @@ pub const Inst = struct {
         ty: Type,
         arg: struct {
             ty: Ref,
-            src_index: u32,
+            /// Index into `extra` of a null-terminated string representing the parameter name.
+            /// This is `.none` if debug info is stripped.
+            name: enum(u32) {
+                none = std.math.maxInt(u32),
+                _,
+            },
         },
         ty_op: struct {
             ty: Ref,

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2784,7 +2784,7 @@ const Header = extern struct {
         first_dependency_len: u32,
         dep_entries_len: u32,
         free_dep_entries_len: u32,
-        files_len: u32,
+        //files_len: u32,
     },
 };
 
@@ -2813,7 +2813,7 @@ pub fn saveState(comp: *Compilation) !void {
                 .first_dependency_len = @intCast(ip.first_dependency.count()),
                 .dep_entries_len = @intCast(ip.dep_entries.items.len),
                 .free_dep_entries_len = @intCast(ip.free_dep_entries.items.len),
-                .files_len = @intCast(ip.files.entries.len),
+                //.files_len = @intCast(ip.files.entries.len),
             },
         };
         addBuf(&bufs_list, &bufs_len, mem.asBytes(&header));
@@ -2838,8 +2838,8 @@ pub fn saveState(comp: *Compilation) !void {
         addBuf(&bufs_list, &bufs_len, mem.sliceAsBytes(ip.dep_entries.items));
         addBuf(&bufs_list, &bufs_len, mem.sliceAsBytes(ip.free_dep_entries.items));
 
-        addBuf(&bufs_list, &bufs_len, mem.sliceAsBytes(ip.files.keys()));
-        addBuf(&bufs_list, &bufs_len, mem.sliceAsBytes(ip.files.values()));
+        //addBuf(&bufs_list, &bufs_len, mem.sliceAsBytes(ip.files.keys()));
+        //addBuf(&bufs_list, &bufs_len, mem.sliceAsBytes(ip.files.values()));
 
         // TODO: compilation errors
         // TODO: namespaces

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2943,7 +2943,7 @@ pub fn totalErrorCount(comp: *Compilation) u32 {
             }
         }
 
-        if (zcu.global_error_set.entries.len - 1 > zcu.error_limit) {
+        if (zcu.intern_pool.global_error_set.mutate.list.len > zcu.error_limit) {
             total += 1;
         }
     }
@@ -3072,7 +3072,7 @@ pub fn getAllErrorsAlloc(comp: *Compilation) !ErrorBundle {
             try addModuleErrorMsg(zcu, &bundle, value.*, &all_references);
         }
 
-        const actual_error_count = zcu.global_error_set.entries.len - 1;
+        const actual_error_count = zcu.intern_pool.global_error_set.mutate.list.len;
         if (actual_error_count > zcu.error_limit) {
             try bundle.addRootErrorMessage(.{
                 .msg = try bundle.printString("ZCU used more errors than possible: used {d}, max {d}", .{

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1877,6 +1877,7 @@ pub fn destroy(comp: *Compilation) void {
     if (comp.module) |zcu| zcu.deinit();
     comp.cache_use.deinit();
     comp.work_queue.deinit();
+    if (!InternPool.single_threaded) comp.codegen_work.queue.deinit();
     comp.c_object_work_queue.deinit();
     if (!build_options.only_core_functionality) {
         comp.win32_resource_work_queue.deinit();

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -8030,6 +8030,8 @@ fn finishFuncInstance(
     decl.name = try ip.getOrPutStringFmt(gpa, tid, "{}__anon_{d}", .{
         fn_owner_decl.name.fmt(ip), @intFromEnum(decl_index),
     }, .no_embedded_nulls);
+    decl.fqn = try ip.namespacePtr(fn_owner_decl.src_namespace)
+        .internFullyQualifiedName(ip, gpa, tid, decl.name);
 }
 
 pub const EnumTypeInit = struct {

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -7955,6 +7955,7 @@ fn finishFuncInstance(
     const fn_owner_decl = ip.declPtr(ip.funcDeclOwner(generic_owner));
     const decl_index = try ip.createDecl(gpa, tid, .{
         .name = undefined,
+        .fqn = undefined,
         .src_namespace = fn_owner_decl.src_namespace,
         .has_tv = true,
         .owns_tv = true,

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -10969,7 +10969,8 @@ const GlobalErrorSet = struct {
 
     /// Not thread-safe, may only be called from the main thread.
     pub fn getNamesFromMainThread(ges: *const GlobalErrorSet) []const NullTerminatedString {
-        return ges.shared.names.view().items(.@"0")[0..ges.mutate.list.len];
+        const len = ges.mutate.list.len;
+        return if (len > 0) ges.shared.names.view().items(.@"0")[0..len] else &.{};
     }
 
     fn getErrorValue(

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9737,9 +9737,6 @@ fn funcCommon(
             .generic_owner = sema.generic_owner,
             .comptime_args = sema.comptime_args,
         });
-        const func_decl = mod.declPtr(ip.indexToKey(func_index).func.owner_decl);
-        func_decl.fqn =
-            try ip.namespacePtr(func_decl.src_namespace).internFullyQualifiedName(pt, func_decl.name);
         return finishFunc(
             sema,
             block,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -835,12 +835,11 @@ pub const Block = struct {
     }
 
     fn trackZir(block: *Block, inst: Zir.Inst.Index) Allocator.Error!InternPool.TrackedInst.Index {
-        const sema = block.sema;
-        const gpa = sema.gpa;
-        const zcu = sema.pt.zcu;
-        const ip = &zcu.intern_pool;
-        const file_index = block.getFileScopeIndex(zcu);
-        return ip.trackZir(gpa, file_index, inst);
+        const pt = block.sema.pt;
+        return pt.zcu.intern_pool.trackZir(pt.zcu.gpa, pt.tid, .{
+            .file = block.getFileScopeIndex(pt.zcu),
+            .inst = inst,
+        });
     }
 };
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6056,7 +6056,7 @@ fn zirCImport(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileEr
         else => |e| return e,
     };
 
-    const result = zcu.importPkg(c_import_mod) catch |err|
+    const result = pt.importPkg(c_import_mod) catch |err|
         return sema.fail(&child_block, src, "C import failed: {s}", .{@errorName(err)});
 
     const path_digest = zcu.filePathDigest(result.file_index);
@@ -13950,7 +13950,7 @@ fn zirImport(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
     const operand_src = block.tokenOffset(inst_data.src_tok);
     const operand = inst_data.get(sema.code);
 
-    const result = zcu.importFile(block.getFileScope(zcu), operand) catch |err| switch (err) {
+    const result = pt.importFile(block.getFileScope(zcu), operand) catch |err| switch (err) {
         error.ImportOutsideModulePath => {
             return sema.fail(block, operand_src, "import of file outside module path: '{s}'", .{operand});
         },

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -268,10 +268,10 @@ pub fn print(ty: Type, writer: anytype, pt: Zcu.PerThread) @TypeOf(writer).Error
             return;
         },
         .inferred_error_set_type => |func_index| {
-            try writer.writeAll("@typeInfo(@typeInfo(@TypeOf(");
             const owner_decl = mod.funcOwnerDeclPtr(func_index);
-            try owner_decl.renderFullyQualifiedName(mod, writer);
-            try writer.writeAll(")).Fn.return_type.?).ErrorUnion.error_set");
+            try writer.print("@typeInfo(@typeInfo(@TypeOf({})).Fn.return_type.?).ErrorUnion.error_set", .{
+                owner_decl.fqn.fmt(ip),
+            });
         },
         .error_set_type => |error_set_type| {
             const names = error_set_type.names;
@@ -334,7 +334,7 @@ pub fn print(ty: Type, writer: anytype, pt: Zcu.PerThread) @TypeOf(writer).Error
             const struct_type = ip.loadStructType(ty.toIntern());
             if (struct_type.decl.unwrap()) |decl_index| {
                 const decl = mod.declPtr(decl_index);
-                try decl.renderFullyQualifiedName(mod, writer);
+                try writer.print("{}", .{decl.fqn.fmt(ip)});
             } else if (ip.loadStructType(ty.toIntern()).namespace.unwrap()) |namespace_index| {
                 const namespace = mod.namespacePtr(namespace_index);
                 try namespace.renderFullyQualifiedName(mod, .empty, writer);
@@ -367,15 +367,15 @@ pub fn print(ty: Type, writer: anytype, pt: Zcu.PerThread) @TypeOf(writer).Error
 
         .union_type => {
             const decl = mod.declPtr(ip.loadUnionType(ty.toIntern()).decl);
-            try decl.renderFullyQualifiedName(mod, writer);
+            try writer.print("{}", .{decl.fqn.fmt(ip)});
         },
         .opaque_type => {
             const decl = mod.declPtr(ip.loadOpaqueType(ty.toIntern()).decl);
-            try decl.renderFullyQualifiedName(mod, writer);
+            try writer.print("{}", .{decl.fqn.fmt(ip)});
         },
         .enum_type => {
             const decl = mod.declPtr(ip.loadEnumType(ty.toIntern()).decl);
-            try decl.renderFullyQualifiedName(mod, writer);
+            try writer.print("{}", .{decl.fqn.fmt(ip)});
         },
         .func_type => |fn_info| {
             if (fn_info.is_noinline) {

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -337,7 +337,7 @@ pub fn print(ty: Type, writer: anytype, pt: Zcu.PerThread) @TypeOf(writer).Error
                 try writer.print("{}", .{decl.fqn.fmt(ip)});
             } else if (ip.loadStructType(ty.toIntern()).namespace.unwrap()) |namespace_index| {
                 const namespace = mod.namespacePtr(namespace_index);
-                try namespace.renderFullyQualifiedName(mod, .empty, writer);
+                try namespace.renderFullyQualifiedName(ip, .empty, writer);
             } else {
                 try writer.writeAll("@TypeOf(.{})");
             }

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -3451,7 +3451,7 @@ pub fn typeDeclInst(ty: Type, zcu: *const Zcu) ?InternPool.TrackedInst.Index {
     };
 }
 
-pub fn typeDeclSrcLine(ty: Type, zcu: *const Zcu) ?u32 {
+pub fn typeDeclSrcLine(ty: Type, zcu: *Zcu) ?u32 {
     const ip = &zcu.intern_pool;
     const tracked = switch (ip.indexToKey(ty.toIntern())) {
         .struct_type, .union_type, .opaque_type, .enum_type => |info| switch (info) {

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -2287,6 +2287,17 @@ pub fn allocateNewDecl(pt: Zcu.PerThread, namespace: Zcu.Namespace.Index) !Zcu.D
     return decl_index;
 }
 
+pub fn getErrorValue(
+    pt: Zcu.PerThread,
+    name: InternPool.NullTerminatedString,
+) Allocator.Error!Zcu.ErrorInt {
+    return pt.zcu.intern_pool.getErrorValue(pt.zcu.gpa, pt.tid, name);
+}
+
+pub fn getErrorValueFromSlice(pt: Zcu.PerThread, name: []const u8) Allocator.Error!Zcu.ErrorInt {
+    return pt.getErrorValue(try pt.zcu.intern_pool.getOrPutString(pt.zcu.gpa, name));
+}
+
 pub fn initNewAnonDecl(
     pt: Zcu.PerThread,
     new_decl_index: Zcu.Decl.Index,

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -1896,7 +1896,7 @@ const ScanDeclIter = struct {
             const was_exported = decl.is_exported;
             assert(decl.kind == kind); // ZIR tracking should preserve this
             decl.name = decl_name;
-            decl.fqn = try namespace.internFullyQualifiedName(pt, decl_name);
+            decl.fqn = try namespace.internFullyQualifiedName(ip, gpa, pt.tid, decl_name);
             decl.is_pub = declaration.flags.is_pub;
             decl.is_exported = declaration.flags.is_export;
             break :decl_index .{ was_exported, decl_index };
@@ -1906,7 +1906,7 @@ const ScanDeclIter = struct {
             const new_decl = zcu.declPtr(new_decl_index);
             new_decl.kind = kind;
             new_decl.name = decl_name;
-            new_decl.fqn = try namespace.internFullyQualifiedName(pt, decl_name);
+            new_decl.fqn = try namespace.internFullyQualifiedName(ip, gpa, pt.tid, decl_name);
             new_decl.is_pub = declaration.flags.is_pub;
             new_decl.is_exported = declaration.flags.is_export;
             new_decl.zir_decl_index = tracked_inst.toOptional();
@@ -2279,8 +2279,8 @@ pub fn initNewAnonDecl(
     const new_decl = pt.zcu.declPtr(new_decl_index);
 
     new_decl.name = name;
-    new_decl.fqn = fqn.unwrap() orelse
-        try pt.zcu.namespacePtr(new_decl.src_namespace).internFullyQualifiedName(pt, name);
+    new_decl.fqn = fqn.unwrap() orelse try pt.zcu.namespacePtr(new_decl.src_namespace)
+        .internFullyQualifiedName(&pt.zcu.intern_pool, pt.zcu.gpa, pt.tid, name);
     new_decl.val = val;
     new_decl.alignment = .none;
     new_decl.@"linksection" = .none;

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -4231,19 +4231,19 @@ fn airArg(self: *Self, inst: Air.Inst.Index) !void {
     while (self.args[arg_index] == .none) arg_index += 1;
     self.arg_index = arg_index + 1;
 
-    const pt = self.pt;
-    const mod = pt.zcu;
     const ty = self.typeOfIndex(inst);
     const tag = self.air.instructions.items(.tag)[@intFromEnum(inst)];
-    const src_index = self.air.instructions.items(.data)[@intFromEnum(inst)].arg.src_index;
-    const name = mod.getParamName(self.func_index, src_index);
 
-    try self.dbg_info_relocs.append(self.gpa, .{
-        .tag = tag,
-        .ty = ty,
-        .name = name,
-        .mcv = self.args[arg_index],
-    });
+    const name_nts = self.air.instructions.items(.data)[@intFromEnum(inst)].arg.name;
+    if (name_nts != .none) {
+        const name = self.air.nullTerminatedString(@intFromEnum(name_nts));
+        try self.dbg_info_relocs.append(self.gpa, .{
+            .tag = tag,
+            .ty = ty,
+            .name = name,
+            .mcv = self.args[arg_index],
+        });
+    }
 
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else self.args[arg_index];
     return self.finishAir(inst, result, .{ .none, .none, .none });

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -4206,19 +4206,19 @@ fn airArg(self: *Self, inst: Air.Inst.Index) !void {
     while (self.args[arg_index] == .none) arg_index += 1;
     self.arg_index = arg_index + 1;
 
-    const pt = self.pt;
-    const mod = pt.zcu;
     const ty = self.typeOfIndex(inst);
     const tag = self.air.instructions.items(.tag)[@intFromEnum(inst)];
-    const src_index = self.air.instructions.items(.data)[@intFromEnum(inst)].arg.src_index;
-    const name = mod.getParamName(self.func_index, src_index);
 
-    try self.dbg_info_relocs.append(self.gpa, .{
-        .tag = tag,
-        .ty = ty,
-        .name = name,
-        .mcv = self.args[arg_index],
-    });
+    const name_nts = self.air.instructions.items(.data)[@intFromEnum(inst)].arg.name;
+    if (name_nts != .none) {
+        const name = self.air.nullTerminatedString(@intFromEnum(name_nts));
+        try self.dbg_info_relocs.append(self.gpa, .{
+            .tag = tag,
+            .ty = ty,
+            .name = name,
+            .mcv = self.args[arg_index],
+        });
+    }
 
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else self.args[arg_index];
     return self.finishAir(inst, result, .{ .none, .none, .none });

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -4051,7 +4051,8 @@ fn genArgDbgInfo(func: Func, inst: Air.Inst.Index, mcv: MCValue) !void {
     const arg = func.air.instructions.items(.data)[@intFromEnum(inst)].arg;
     const ty = arg.ty.toType();
     const owner_decl = zcu.funcOwnerDeclIndex(func.func_index);
-    const name = zcu.getParamName(func.func_index, arg.src_index);
+    if (arg.name == .none) return;
+    const name = func.air.nullTerminatedString(@intFromEnum(arg.name));
 
     switch (func.debug_output) {
         .dwarf => |dw| switch (mcv) {

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -933,7 +933,7 @@ fn formatDecl(
     _: std.fmt.FormatOptions,
     writer: anytype,
 ) @TypeOf(writer).Error!void {
-    try data.mod.declPtr(data.decl_index).renderFullyQualifiedName(data.mod, writer);
+    try writer.print("{}", .{data.mod.declPtr(data.decl_index).fqn.fmt(&data.mod.intern_pool)});
 }
 fn fmtDecl(func: *Func, decl_index: InternPool.DeclIndex) std.fmt.Formatter(formatDecl) {
     return .{ .data = .{

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -3614,7 +3614,8 @@ fn genArgDbgInfo(self: Self, inst: Air.Inst.Index, mcv: MCValue) !void {
     const arg = self.air.instructions.items(.data)[@intFromEnum(inst)].arg;
     const ty = arg.ty.toType();
     const owner_decl = mod.funcOwnerDeclIndex(self.func_index);
-    const name = mod.getParamName(self.func_index, arg.src_index);
+    if (arg.name == .none) return;
+    const name = self.air.nullTerminatedString(@intFromEnum(arg.name));
 
     switch (self.debug_output) {
         .dwarf => |dw| switch (mcv) {

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -2585,11 +2585,13 @@ fn airArg(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
     switch (func.debug_output) {
         .dwarf => |dwarf| {
-            const src_index = func.air.instructions.items(.data)[@intFromEnum(inst)].arg.src_index;
-            const name = mod.getParamName(func.func_index, src_index);
-            try dwarf.genArgDbgInfo(name, arg_ty, mod.funcOwnerDeclIndex(func.func_index), .{
-                .wasm_local = arg.local.value,
-            });
+            const name_nts = func.air.instructions.items(.data)[@intFromEnum(inst)].arg.name;
+            if (name_nts != .none) {
+                const name = func.air.nullTerminatedString(@intFromEnum(name_nts));
+                try dwarf.genArgDbgInfo(name, arg_ty, mod.funcOwnerDeclIndex(func.func_index), .{
+                    .wasm_local = arg.local.value,
+                });
+            }
         },
         else => {},
     }

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -7284,8 +7284,8 @@ fn getTagNameFunction(func: *CodeGen, enum_ty: Type) InnerError!u32 {
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
-    const fqn = try mod.declPtr(enum_decl_index).fullyQualifiedName(pt);
-    const func_name = try std.fmt.allocPrintZ(arena, "__zig_tag_name_{}", .{fqn.fmt(ip)});
+    const decl = mod.declPtr(enum_decl_index);
+    const func_name = try std.fmt.allocPrintZ(arena, "__zig_tag_name_{}", .{decl.fqn.fmt(ip)});
 
     // check if we already generated code for this.
     if (func.bin_file.findGlobalSymbol(func_name)) |loc| {

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -1077,7 +1077,7 @@ fn formatDecl(
     _: std.fmt.FormatOptions,
     writer: anytype,
 ) @TypeOf(writer).Error!void {
-    try data.zcu.declPtr(data.decl_index).renderFullyQualifiedName(data.zcu, writer);
+    try writer.print("{}", .{data.zcu.declPtr(data.decl_index).fqn.fmt(&data.zcu.intern_pool)});
 }
 fn fmtDecl(self: *Self, decl_index: InternPool.DeclIndex) std.fmt.Formatter(formatDecl) {
     return .{ .data = .{

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -16435,7 +16435,7 @@ fn airErrorName(self: *Self, inst: Air.Inst.Index) !void {
                 .size = .dword,
                 .index = err_reg.to64(),
                 .scale = .@"4",
-                .disp = 4,
+                .disp = (1 - 1) * 4,
             } },
         },
     );
@@ -16448,7 +16448,7 @@ fn airErrorName(self: *Self, inst: Air.Inst.Index) !void {
                 .size = .dword,
                 .index = err_reg.to64(),
                 .scale = .@"4",
-                .disp = 8,
+                .disp = (2 - 1) * 4,
             } },
         },
     );

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -11920,9 +11920,11 @@ fn airArg(self: *Self, inst: Air.Inst.Index) !void {
             else => return self.fail("TODO implement arg for {}", .{src_mcv}),
         };
 
-        const src_index = self.air.instructions.items(.data)[@intFromEnum(inst)].arg.src_index;
-        const name = mod.getParamName(self.owner.func_index, src_index);
-        try self.genArgDbgInfo(arg_ty, name, src_mcv);
+        const name_nts = self.air.instructions.items(.data)[@intFromEnum(inst)].arg.name;
+        switch (name_nts) {
+            .none => {},
+            _ => try self.genArgDbgInfo(arg_ty, self.air.nullTerminatedString(@intFromEnum(name_nts)), src_mcv),
+        }
 
         break :result dst_mcv;
     };

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -8859,19 +8859,21 @@ pub const FuncGen = struct {
         self.arg_index += 1;
 
         // llvm does not support debug info for naked function arguments
-        if (self.wip.strip or self.is_naked) return arg_val;
+        if (self.is_naked) return arg_val;
 
         const inst_ty = self.typeOfIndex(inst);
         if (needDbgVarWorkaround(o)) return arg_val;
 
-        const src_index = self.air.instructions.items(.data)[@intFromEnum(inst)].arg.src_index;
+        const name = self.air.instructions.items(.data)[@intFromEnum(inst)].arg.name;
+        if (name == .none) return arg_val;
+
         const func_index = self.dg.decl.getOwnedFunctionIndex();
         const func = mod.funcInfo(func_index);
         const lbrace_line = mod.declPtr(func.owner_decl).navSrcLine(mod) + func.lbrace_line + 1;
         const lbrace_col = func.lbrace_column + 1;
 
         const debug_parameter = try o.builder.debugParameter(
-            try o.builder.metadataString(mod.getParamName(func_index, src_index)),
+            try o.builder.metadataString(self.air.nullTerminatedString(@intFromEnum(name))),
             self.file,
             self.scope,
             lbrace_line,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2811,7 +2811,7 @@ pub const Object = struct {
         const zcu = pt.zcu;
 
         const std_mod = zcu.std_mod;
-        const std_file_imported = zcu.importPkg(std_mod) catch unreachable;
+        const std_file_imported = pt.importPkg(std_mod) catch unreachable;
 
         const builtin_str = try zcu.intern_pool.getOrPutString(zcu.gpa, pt.tid, "builtin", .no_embedded_nulls);
         const std_file_root_decl = zcu.fileRootDecl(std_file_imported.file_index);

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -3012,12 +3012,11 @@ const DeclGen = struct {
                 // Append the actual code into the functions section.
                 try self.spv.addFunction(spv_decl_index, self.func);
 
-                const fqn = try decl.fullyQualifiedName(self.pt);
-                try self.spv.debugName(result_id, fqn.toSlice(ip));
+                try self.spv.debugName(result_id, decl.fqn.toSlice(ip));
 
                 // Temporarily generate a test kernel declaration if this is a test function.
                 if (self.pt.zcu.test_functions.contains(self.decl_index)) {
-                    try self.generateTestEntryPoint(fqn.toSlice(ip), spv_decl_index);
+                    try self.generateTestEntryPoint(decl.fqn.toSlice(ip), spv_decl_index);
                 }
             },
             .global => {
@@ -3041,8 +3040,7 @@ const DeclGen = struct {
                     .storage_class = final_storage_class,
                 });
 
-                const fqn = try decl.fullyQualifiedName(self.pt);
-                try self.spv.debugName(result_id, fqn.toSlice(ip));
+                try self.spv.debugName(result_id, decl.fqn.toSlice(ip));
                 try self.spv.declareDeclDeps(spv_decl_index, &.{});
             },
             .invocation_global => {
@@ -3086,8 +3084,7 @@ const DeclGen = struct {
                     try self.func.body.emit(self.spv.gpa, .OpFunctionEnd, {});
                     try self.spv.addFunction(spv_decl_index, self.func);
 
-                    const fqn = try decl.fullyQualifiedName(self.pt);
-                    try self.spv.debugNameFmt(initializer_id, "initializer of {}", .{fqn.fmt(ip)});
+                    try self.spv.debugNameFmt(initializer_id, "initializer of {}", .{decl.fqn.fmt(ip)});
 
                     try self.spv.sections.types_globals_constants.emit(self.spv.gpa, .OpExtInst, .{
                         .id_result_type = ptr_ty_id,

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -963,7 +963,7 @@ const DeclGen = struct {
                     break :cache result_id;
                 },
                 .err => |err| {
-                    const value = try mod.getErrorValue(err.name);
+                    const value = try pt.getErrorValue(err.name);
                     break :cache try self.constInt(ty, value, repr);
                 },
                 .error_union => |error_union| {

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -2698,7 +2698,7 @@ pub fn flushModule(self: *Dwarf, pt: Zcu.PerThread) !void {
         try addDbgInfoErrorSetNames(
             pt,
             Type.anyerror,
-            pt.zcu.global_error_set.keys(),
+            pt.zcu.intern_pool.global_error_set.getNamesFromMainThread(),
             target,
             &dbg_info_buffer,
         );
@@ -2867,7 +2867,7 @@ fn addDbgInfoErrorSetNames(
     mem.writeInt(u64, dbg_info_buffer.addManyAsArrayAssumeCapacity(8), 0, target_endian);
 
     for (error_names) |error_name| {
-        const int = try pt.zcu.getErrorValue(error_name);
+        const int = try pt.getErrorValue(error_name);
         const error_name_slice = error_name.toSlice(&pt.zcu.intern_pool);
         // DW.AT.enumerator
         try dbg_info_buffer.ensureUnusedCapacity(error_name_slice.len + 2 + @sizeOf(u64));

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -1082,9 +1082,7 @@ pub fn initDeclState(self: *Dwarf, pt: Zcu.PerThread, decl_index: InternPool.Dec
     defer tracy.end();
 
     const decl = pt.zcu.declPtr(decl_index);
-    const decl_linkage_name = try decl.fullyQualifiedName(pt);
-
-    log.debug("initDeclState {}{*}", .{ decl_linkage_name.fmt(&pt.zcu.intern_pool), decl });
+    log.debug("initDeclState {}{*}", .{ decl.fqn.fmt(&pt.zcu.intern_pool), decl });
 
     const gpa = self.allocator;
     var decl_state: DeclState = .{
@@ -1157,7 +1155,7 @@ pub fn initDeclState(self: *Dwarf, pt: Zcu.PerThread, decl_index: InternPool.Dec
 
             // .debug_info subprogram
             const decl_name_slice = decl.name.toSlice(&pt.zcu.intern_pool);
-            const decl_linkage_name_slice = decl_linkage_name.toSlice(&pt.zcu.intern_pool);
+            const decl_linkage_name_slice = decl.fqn.toSlice(&pt.zcu.intern_pool);
             try dbg_info_buffer.ensureUnusedCapacity(1 + ptr_width_bytes + 4 + 4 +
                 (decl_name_slice.len + 1) + (decl_linkage_name_slice.len + 1));
 

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -483,11 +483,9 @@ pub fn lowerUnnamedConst(self: *Plan9, pt: Zcu.PerThread, val: Value, decl_index
     }
     const unnamed_consts = gop.value_ptr;
 
-    const decl_name = try decl.fullyQualifiedName(pt);
-
     const index = unnamed_consts.items.len;
     // name is freed when the unnamed const is freed
-    const name = try std.fmt.allocPrint(gpa, "__unnamed_{}_{d}", .{ decl_name.fmt(&mod.intern_pool), index });
+    const name = try std.fmt.allocPrint(gpa, "__unnamed_{}_{d}", .{ decl.fqn.fmt(&mod.intern_pool), index });
 
     const sym_index = try self.allocateSymbolIndex();
     const new_atom_idx = try self.createAtom();

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -227,9 +227,9 @@ pub fn flushModule(self: *SpirV, arena: Allocator, tid: Zcu.PerThread.Id, prog_n
     var error_info = std.ArrayList(u8).init(self.object.gpa);
     defer error_info.deinit();
 
-    try error_info.appendSlice("zig_errors");
-    const mod = self.base.comp.module.?;
-    for (mod.global_error_set.keys()) |name| {
+    try error_info.appendSlice("zig_errors:");
+    const ip = &self.base.comp.module.?.intern_pool;
+    for (ip.global_error_set.getNamesFromMainThread()) |name| {
         // Errors can contain pretty much any character - to encode them in a string we must escape
         // them somehow. Easiest here is to use some established scheme, one which also preseves the
         // name if it contains no strange characters is nice for debugging. URI encoding fits the bill.
@@ -238,7 +238,7 @@ pub fn flushModule(self: *SpirV, arena: Allocator, tid: Zcu.PerThread.Id, prog_n
         try error_info.append(':');
         try std.Uri.Component.percentEncode(
             error_info.writer(),
-            name.toSlice(&mod.intern_pool),
+            name.toSlice(ip),
             struct {
                 fn isValidChar(c: u8) bool {
                     return switch (c) {

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -356,7 +356,13 @@ const Writer = struct {
     fn writeArg(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
         const arg = w.air.instructions.items(.data)[@intFromEnum(inst)].arg;
         try w.writeType(s, arg.ty.toType());
-        try s.print(", {d}", .{arg.src_index});
+        switch (arg.name) {
+            .none => {},
+            _ => {
+                const name = w.air.nullTerminatedString(@intFromEnum(arg.name));
+                try s.print(", \"{}\"", .{std.zig.fmtEscapes(name)});
+            },
+        }
     }
 
     fn writeTyOp(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {

--- a/src/print_value.zig
+++ b/src/print_value.zig
@@ -299,8 +299,8 @@ fn printPtrDerivation(derivation: Value.PointerDeriveStep, writer: anytype, leve
             int.ptr_ty.fmt(pt),
             int.addr,
         }),
-        .decl_ptr => |decl| {
-            try zcu.declPtr(decl).renderFullyQualifiedName(zcu, writer);
+        .decl_ptr => |decl_index| {
+            try writer.print("{}", .{zcu.declPtr(decl_index).fqn.fmt(ip)});
         },
         .anon_decl_ptr => |anon| {
             const ty = Value.fromInterned(anon.val).typeOf(zcu);


### PR DESCRIPTION
Main races fixed:
 * [X] `global_error_set`
 * [X] `tracked_insts`
 * [X] `import_table`
 * [X] `maps`