### PR TITLE
Shorten coercion error messages by eliding non-conflicting parts of types

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -29733,7 +29733,7 @@ fn coerceExtra(
     }
 
     const msg = msg: {
-        const msg = try sema.errMsg(inst_src, "expected type '{}', found '{}'", .{ dest_ty.fmt(pt), inst_ty.fmt(pt) });
+        const msg = try sema.errMsg(inst_src, "expected type '{}', found '{}'", .{ dest_ty.fmtCoerceFail(pt, in_memory_result), inst_ty.fmtCoerceFail(pt, in_memory_result) });
         errdefer msg.destroy(sema.gpa);
 
         // E!T to T
@@ -29788,7 +29788,7 @@ fn coerceInMemory(
     return Air.internedToRef((try sema.pt.getCoerced(val, dst_ty)).toIntern());
 }
 
-const InMemoryCoercionResult = union(enum) {
+pub const InMemoryCoercionResult = union(enum) {
     ok,
     no_match: Pair,
     int_not_coercible: Int,
@@ -29828,7 +29828,7 @@ const InMemoryCoercionResult = union(enum) {
         wanted: Type,
     };
 
-    const PairAndChild = struct {
+    pub const PairAndChild = struct {
         child: *InMemoryCoercionResult,
         actual: Type,
         wanted: Type,


### PR DESCRIPTION
Attempt to address #12401 by printing only the components of types that are mismatched. As far as I can tell, Rustc and Clang do similar things to prevent error message blowup.

So far, this only covers Type.print(), and results in messages like this:
```zig
test {
    var a: error{Boo}!u32 = 2;
    _ = &a;
    _ = @as(error{Baz}!u32, a);
}
fn funcA(_: u32) u32 { return 2; }
test { _ = @as(*fn(u32) u32, &funcA); }
test { _ = @as(fn(u32, u32) u32, funcA); }
test { _ = @as(fn(u32) u8, funcA); }
```
```
/tmp/d.zig:4:29: error: expected type 'error{Baz}!…', found 'error{Boo}!…'
    _ = @as(error{Baz}!u32, a);
                            ^
/tmp/d.zig:4:29: note: 'error.Boo' not a member of destination error set
/tmp/d.zig:7:30: error: expected type '*…', found '*const …'
test { _ = @as(*fn(u32) u32, &funcA); }
                             ^~~~~~
/tmp/d.zig:7:30: note: cast discards const qualifier
/tmp/d.zig:8:34: error: expected type 'fn (u32, u32) …', found 'fn (u32) …'
test { _ = @as(fn(u32, u32) u32, funcA); }
                                 ^~~~~
/tmp/d.zig:8:34: note: function with 1 parameters cannot cast into a function with 2 parameters
/tmp/d.zig:9:28: error: expected type 'fn (…) u8', found 'fn (…) u32'
test { _ = @as(fn(u32) u8, funcA); }
                           ^~~~~
/tmp/d.zig:9:28: note: return type 'u32' cannot cast into return type 'u8'
/tmp/d.zig:9:28: note: unsigned 8-bit int cannot represent all possible unsigned 32-bit values
```

I made this draft to check to check whether this sounds like a decent strategy for Zig error messages. If you think it is, I'll expand this to cover the actually really long type names mentioned in #12401, which are produced by createAnonymousDeclNamed for NameStrategy.func. To solve that, I will probably need to preserve the function name and argument values in the anonymous type's Decl and then implement similar diffing logic in Value.print().