### PR TITLE
introduce file system watching features to the zig build system

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1261,7 +1261,9 @@ fn generateLangRef(b: *std.Build) std.Build.LazyPath {
     });
 
     var dir = b.build_root.handle.openDir("doc/langref", .{ .iterate = true }) catch |err| {
-        std.debug.panic("unable to open 'doc/langref' directory: {s}", .{@errorName(err)});
+        std.debug.panic("unable to open '{}doc/langref' directory: {s}", .{
+            b.build_root, @errorName(err),
+        });
     };
     defer dir.close();
 
@@ -1280,10 +1282,7 @@ fn generateLangRef(b: *std.Build) std.Build.LazyPath {
             // in a temporary directory
             "--cache-root", b.cache_root.path orelse ".",
         });
-        if (b.zig_lib_dir) |p| {
-            cmd.addArg("--zig-lib-dir");
-            cmd.addDirectoryArg(p);
-        }
+        cmd.addArgs(&.{ "--zig-lib-dir", b.fmt("{}", .{b.graph.zig_lib_directory}) });
         cmd.addArgs(&.{"-i"});
         cmd.addFileArg(b.path(b.fmt("doc/langref/{s}", .{entry.name})));
 

--- a/build.zig
+++ b/build.zig
@@ -595,7 +595,7 @@ fn addWasiUpdateStep(b: *std.Build, version: [:0]const u8) !void {
     run_opt.addArg("-o");
     run_opt.addFileArg(b.path("stage1/zig1.wasm"));
 
-    const copy_zig_h = b.addWriteFiles();
+    const copy_zig_h = b.addUpdateSourceFiles();
     copy_zig_h.addCopyFileToSource(b.path("lib/zig.h"), "stage1/zig.h");
 
     const update_zig1_step = b.step("update-zig1", "Update stage1/zig1.wasm");

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -419,7 +419,7 @@ pub fn main() !void {
                         std.posix.fanotify_mark(w.fan_fd, .{
                             .ADD = true,
                             .ONLYDIR = true,
-                        }, Watch.fan_mask, path.root_dir.handle.fd, path.subPathOpt()) catch |err| {
+                        }, Watch.fan_mask, path.root_dir.handle.fd, path.subPathOrDot()) catch |err| {
                             fatal("unable to watch {}: {s}", .{ path, @errorName(err) });
                         };
 
@@ -471,7 +471,7 @@ pub fn main() !void {
                 try std.posix.fanotify_mark(w.fan_fd, .{
                     .REMOVE = true,
                     .ONLYDIR = true,
-                }, Watch.fan_mask, path.root_dir.handle.fd, path.subPathOpt());
+                }, Watch.fan_mask, path.root_dir.handle.fd, path.subPathOrDot());
 
                 w.dir_table.swapRemoveAt(i);
                 w.handle_table.swapRemoveAt(i);

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -682,9 +682,12 @@ fn runStepNames(
     }
 
     const ttyconf = run.ttyconf;
-    const stderr = run.stderr;
 
     if (run.summary != .none) {
+        std.debug.lockStdErr();
+        defer std.debug.unlockStdErr();
+        const stderr = run.stderr;
+
         const total_count = success_count + failure_count + pending_count + skipped_count;
         ttyconf.setColor(stderr, .cyan) catch {};
         stderr.writeAll("Build Summary:") catch {};

--- a/lib/compiler/objcopy.zig
+++ b/lib/compiler/objcopy.zig
@@ -198,20 +198,14 @@ fn cmdObjCopy(
                     return std.process.cleanExit();
                 },
                 .update => {
-                    if (seen_update) {
-                        std.debug.print("zig objcopy only supports 1 update for now\n", .{});
-                        std.process.exit(1);
-                    }
+                    if (seen_update) fatal("zig objcopy only supports 1 update for now", .{});
                     seen_update = true;
 
                     try server.serveEmitBinPath(output, .{
                         .flags = .{ .cache_hit = false },
                     });
                 },
-                else => {
-                    std.debug.print("unsupported message: {s}", .{@tagName(hdr.tag)});
-                    std.process.exit(1);
-                },
+                else => fatal("unsupported message: {s}", .{@tagName(hdr.tag)}),
             }
         }
     }

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -20,6 +20,7 @@ const Build = @This();
 pub const Cache = @import("Build/Cache.zig");
 pub const Step = @import("Build/Step.zig");
 pub const Module = @import("Build/Module.zig");
+pub const Watch = @import("Build/Watch.zig");
 
 /// Shared state among all Build instances.
 graph: *Graph,

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -119,61 +119,6 @@ pub const Graph = struct {
     needed_lazy_dependencies: std.StringArrayHashMapUnmanaged(void) = .{},
     /// Information about the native target. Computed before build() is invoked.
     host: ResolvedTarget,
-    /// When `--watch` is provided, collects the set of files that should be
-    /// watched and the state to required to poll the system for changes.
-    watch: ?*Watch,
-};
-
-pub const Watch = struct {
-    table: Table,
-
-    pub const init: Watch = .{
-        .table = .{},
-    };
-
-    /// Key is the directory to watch which contains one or more files we are
-    /// interested in noticing changes to.
-    pub const Table = std.ArrayHashMapUnmanaged(Cache.Path, ReactionSet, TableContext, false);
-
-    const Hash = std.hash.Wyhash;
-
-    pub const TableContext = struct {
-        pub fn hash(self: TableContext, a: Cache.Path) u32 {
-            _ = self;
-            const seed: u32 = @bitCast(a.root_dir.handle.fd);
-            return @truncate(Hash.hash(seed, a.sub_path));
-        }
-        pub fn eql(self: TableContext, a: Cache.Path, b: Cache.Path, b_index: usize) bool {
-            _ = self;
-            _ = b_index;
-            return a.eql(b);
-        }
-    };
-
-    pub const ReactionSet = std.ArrayHashMapUnmanaged(Match, void, Match.Context, false);
-
-    pub const Match = struct {
-        /// Relative to the watched directory, the file path that triggers this
-        /// match.
-        basename: []const u8,
-        /// The step to re-run when file corresponding to `basename` is changed.
-        step: *Step,
-
-        pub const Context = struct {
-            pub fn hash(self: Context, a: Match) u32 {
-                _ = self;
-                var hasher = Hash.init(0);
-                std.hash.autoHash(&hasher, a.step);
-                hasher.update(a.basename);
-                return @truncate(hasher.final());
-            }
-            pub fn eql(self: Context, a: Match, b: Match, b_index: usize) bool {
-                _ = self;
-                _ = b_index;
-                return a.step == b.step and mem.eql(u8, a.basename, b.basename);
-            }
-        };
-    };
 };
 
 const AvailableDeps = []const struct { []const u8, []const u8 };

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -120,6 +120,61 @@ pub const Graph = struct {
     needed_lazy_dependencies: std.StringArrayHashMapUnmanaged(void) = .{},
     /// Information about the native target. Computed before build() is invoked.
     host: ResolvedTarget,
+    /// When `--watch` is provided, collects the set of files that should be
+    /// watched and the state to required to poll the system for changes.
+    watch: ?*Watch,
+};
+
+pub const Watch = struct {
+    table: Table,
+
+    pub const init: Watch = .{
+        .table = .{},
+    };
+
+    /// Key is the directory to watch which contains one or more files we are
+    /// interested in noticing changes to.
+    pub const Table = std.ArrayHashMapUnmanaged(Cache.Path, ReactionSet, TableContext, false);
+
+    const Hash = std.hash.Wyhash;
+
+    pub const TableContext = struct {
+        pub fn hash(self: TableContext, a: Cache.Path) u32 {
+            _ = self;
+            const seed: u32 = @bitCast(a.root_dir.handle.fd);
+            return @truncate(Hash.hash(seed, a.sub_path));
+        }
+        pub fn eql(self: TableContext, a: Cache.Path, b: Cache.Path, b_index: usize) bool {
+            _ = self;
+            _ = b_index;
+            return a.eql(b);
+        }
+    };
+
+    pub const ReactionSet = std.ArrayHashMapUnmanaged(Match, void, Match.Context, false);
+
+    pub const Match = struct {
+        /// Relative to the watched directory, the file path that triggers this
+        /// match.
+        basename: []const u8,
+        /// The step to re-run when file corresponding to `basename` is changed.
+        step: *Step,
+
+        pub const Context = struct {
+            pub fn hash(self: Context, a: Match) u32 {
+                _ = self;
+                var hasher = Hash.init(0);
+                std.hash.autoHash(&hasher, a.step);
+                hasher.update(a.basename);
+                return @truncate(hasher.final());
+            }
+            pub fn eql(self: Context, a: Match, b: Match, b_index: usize) bool {
+                _ = self;
+                _ = b_index;
+                return a.step == b.step and mem.eql(u8, a.basename, b.basename);
+            }
+        };
+    };
 };
 
 const AvailableDeps = []const struct { []const u8, []const u8 };

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -54,7 +54,6 @@ libc_file: ?[]const u8 = null,
 /// Path to the directory containing build.zig.
 build_root: Cache.Directory,
 cache_root: Cache.Directory,
-zig_lib_dir: ?LazyPath,
 pkg_config_pkg_list: ?(PkgConfigError![]const PkgConfigPkg) = null,
 args: ?[]const []const u8 = null,
 debug_log_scopes: []const []const u8 = &.{},
@@ -117,6 +116,7 @@ pub const Graph = struct {
     zig_exe: [:0]const u8,
     env_map: EnvMap,
     global_cache_root: Cache.Directory,
+    zig_lib_directory: Cache.Directory,
     needed_lazy_dependencies: std.StringArrayHashMapUnmanaged(void) = .{},
     /// Information about the native target. Computed before build() is invoked.
     host: ResolvedTarget,
@@ -293,7 +293,6 @@ pub fn create(
             }),
             .description = "Remove build artifacts from prefix path",
         },
-        .zig_lib_dir = null,
         .install_path = undefined,
         .args = null,
         .host = graph.host,
@@ -379,7 +378,6 @@ fn createChildOnly(
         .libc_file = parent.libc_file,
         .build_root = build_root,
         .cache_root = parent.cache_root,
-        .zig_lib_dir = parent.zig_lib_dir,
         .debug_log_scopes = parent.debug_log_scopes,
         .debug_compile_errors = parent.debug_compile_errors,
         .debug_pkg_config = parent.debug_pkg_config,
@@ -687,7 +685,7 @@ pub fn addExecutable(b: *Build, options: ExecutableOptions) *Step.Compile {
         .max_rss = options.max_rss,
         .use_llvm = options.use_llvm,
         .use_lld = options.use_lld,
-        .zig_lib_dir = options.zig_lib_dir orelse b.zig_lib_dir,
+        .zig_lib_dir = options.zig_lib_dir,
         .win32_manifest = options.win32_manifest,
     });
 }
@@ -735,7 +733,7 @@ pub fn addObject(b: *Build, options: ObjectOptions) *Step.Compile {
         .max_rss = options.max_rss,
         .use_llvm = options.use_llvm,
         .use_lld = options.use_lld,
-        .zig_lib_dir = options.zig_lib_dir orelse b.zig_lib_dir,
+        .zig_lib_dir = options.zig_lib_dir,
     });
 }
 
@@ -791,7 +789,7 @@ pub fn addSharedLibrary(b: *Build, options: SharedLibraryOptions) *Step.Compile 
         .max_rss = options.max_rss,
         .use_llvm = options.use_llvm,
         .use_lld = options.use_lld,
-        .zig_lib_dir = options.zig_lib_dir orelse b.zig_lib_dir,
+        .zig_lib_dir = options.zig_lib_dir,
         .win32_manifest = options.win32_manifest,
     });
 }
@@ -842,7 +840,7 @@ pub fn addStaticLibrary(b: *Build, options: StaticLibraryOptions) *Step.Compile 
         .max_rss = options.max_rss,
         .use_llvm = options.use_llvm,
         .use_lld = options.use_lld,
-        .zig_lib_dir = options.zig_lib_dir orelse b.zig_lib_dir,
+        .zig_lib_dir = options.zig_lib_dir,
     });
 }
 
@@ -905,7 +903,7 @@ pub fn addTest(b: *Build, options: TestOptions) *Step.Compile {
         .test_runner = options.test_runner,
         .use_llvm = options.use_llvm,
         .use_lld = options.use_lld,
-        .zig_lib_dir = options.zig_lib_dir orelse b.zig_lib_dir,
+        .zig_lib_dir = options.zig_lib_dir,
     });
 }
 
@@ -929,7 +927,7 @@ pub fn addAssembly(b: *Build, options: AssemblyOptions) *Step.Compile {
             .optimize = options.optimize,
         },
         .max_rss = options.max_rss,
-        .zig_lib_dir = options.zig_lib_dir orelse b.zig_lib_dir,
+        .zig_lib_dir = options.zig_lib_dir,
     });
     obj_step.addAssemblyFile(options.source_file);
     return obj_step;

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1052,6 +1052,10 @@ pub fn addWriteFiles(b: *Build) *Step.WriteFile {
     return Step.WriteFile.create(b);
 }
 
+pub fn addUpdateSourceFiles(b: *Build) *Step.UpdateSourceFiles {
+    return Step.UpdateSourceFiles.create(b);
+}
+
 pub fn addRemoveDirTree(b: *Build, dir_path: LazyPath) *Step.RemoveDir {
     return Step.RemoveDir.create(b, dir_path);
 }

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1052,7 +1052,7 @@ pub fn addWriteFiles(b: *Build) *Step.WriteFile {
     return Step.WriteFile.create(b);
 }
 
-pub fn addRemoveDirTree(b: *Build, dir_path: []const u8) *Step.RemoveDir {
+pub fn addRemoveDirTree(b: *Build, dir_path: LazyPath) *Step.RemoveDir {
     return Step.RemoveDir.create(b, dir_path);
 }
 

--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -1007,6 +1007,22 @@ pub const Manifest = struct {
         }
         self.files.deinit(self.cache.gpa);
     }
+
+    pub fn populateFileSystemInputs(man: *Manifest, buf: *std.ArrayListUnmanaged(u8)) Allocator.Error!void {
+        assert(@typeInfo(std.zig.Server.Message.PathPrefix).Enum.fields.len == man.cache.prefixes_len);
+        const gpa = man.cache.gpa;
+        const files = man.files.keys();
+        if (files.len > 0) {
+            for (files) |file| {
+                try buf.ensureUnusedCapacity(gpa, file.prefixed_path.sub_path.len + 2);
+                buf.appendAssumeCapacity(file.prefixed_path.prefix + 1);
+                buf.appendSliceAssumeCapacity(file.prefixed_path.sub_path);
+                buf.appendAssumeCapacity(0);
+            }
+            // The null byte is a separator, not a terminator.
+            buf.items.len -= 1;
+        }
+    }
 };
 
 /// On operating systems that support symlinks, does a readlink. On other operating systems,

--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -1010,6 +1010,7 @@ pub const Manifest = struct {
 
     pub fn populateFileSystemInputs(man: *Manifest, buf: *std.ArrayListUnmanaged(u8)) Allocator.Error!void {
         assert(@typeInfo(std.zig.Server.Message.PathPrefix).Enum.fields.len == man.cache.prefixes_len);
+        buf.clearRetainingCapacity();
         const gpa = man.cache.gpa;
         const files = man.files.keys();
         if (files.len > 0) {

--- a/lib/std/Build/Cache/Path.zig
+++ b/lib/std/Build/Cache/Path.zig
@@ -151,6 +151,26 @@ pub fn eql(self: Path, other: Path) bool {
     return self.root_dir.eql(other.root_dir) and std.mem.eql(u8, self.sub_path, other.sub_path);
 }
 
+pub fn subPathOpt(self: Path) ?[]const u8 {
+    return if (self.sub_path.len == 0) null else self.sub_path;
+}
+
+/// Useful to make `Path` a key in `std.ArrayHashMap`.
+pub const TableAdapter = struct {
+    pub const Hash = std.hash.Wyhash;
+
+    pub fn hash(self: TableAdapter, a: Cache.Path) u32 {
+        _ = self;
+        const seed: u32 = @bitCast(a.root_dir.handle.fd);
+        return @truncate(Hash.hash(seed, a.sub_path));
+    }
+    pub fn eql(self: TableAdapter, a: Cache.Path, b: Cache.Path, b_index: usize) bool {
+        _ = self;
+        _ = b_index;
+        return a.eql(b);
+    }
+};
+
 const Path = @This();
 const std = @import("../../std.zig");
 const fs = std.fs;

--- a/lib/std/Build/Cache/Path.zig
+++ b/lib/std/Build/Cache/Path.zig
@@ -147,6 +147,10 @@ pub fn format(
     }
 }
 
+pub fn eql(self: Path, other: Path) bool {
+    return self.root_dir.eql(other.root_dir) and std.mem.eql(u8, self.sub_path, other.sub_path);
+}
+
 const Path = @This();
 const std = @import("../../std.zig");
 const fs = std.fs;

--- a/lib/std/Build/Cache/Path.zig
+++ b/lib/std/Build/Cache/Path.zig
@@ -157,12 +157,17 @@ pub fn format(
     }
     if (self.root_dir.path) |p| {
         try writer.writeAll(p);
-        try writer.writeAll(fs.path.sep_str);
+        if (self.sub_path.len > 0) {
+            try writer.writeAll(fs.path.sep_str);
+            try writer.writeAll(self.sub_path);
+        }
+        return;
     }
     if (self.sub_path.len > 0) {
         try writer.writeAll(self.sub_path);
-        try writer.writeAll(fs.path.sep_str);
+        return;
     }
+    try writer.writeByte('.');
 }
 
 pub fn eql(self: Path, other: Path) bool {

--- a/lib/std/Build/Cache/Path.zig
+++ b/lib/std/Build/Cache/Path.zig
@@ -183,7 +183,11 @@ pub const TableAdapter = struct {
 
     pub fn hash(self: TableAdapter, a: Cache.Path) u32 {
         _ = self;
-        const seed: u32 = @bitCast(a.root_dir.handle.fd);
+        const seed = switch (@typeInfo(@TypeOf(a.root_dir.handle.fd))) {
+            .Pointer => @intFromPtr(a.root_dir.handle.fd),
+            .Int => @as(u32, @bitCast(a.root_dir.handle.fd)),
+            else => @compileError("unimplemented hash function"),
+        };
         return @truncate(Hash.hash(seed, a.sub_path));
     }
     pub fn eql(self: TableAdapter, a: Cache.Path, b: Cache.Path, b_index: usize) bool {

--- a/lib/std/Build/Cache/Path.zig
+++ b/lib/std/Build/Cache/Path.zig
@@ -173,6 +173,10 @@ pub fn subPathOpt(self: Path) ?[]const u8 {
     return if (self.sub_path.len == 0) null else self.sub_path;
 }
 
+pub fn subPathOrDot(self: Path) []const u8 {
+    return if (self.sub_path.len == 0) "." else self.sub_path;
+}
+
 /// Useful to make `Path` a key in `std.ArrayHashMap`.
 pub const TableAdapter = struct {
     pub const Hash = std.hash.Wyhash;

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -102,6 +102,7 @@ pub const Id = enum {
     fmt,
     translate_c,
     write_file,
+    update_source_files,
     run,
     check_file,
     check_object,
@@ -122,6 +123,7 @@ pub const Id = enum {
             .fmt => Fmt,
             .translate_c => TranslateC,
             .write_file => WriteFile,
+            .update_source_files => UpdateSourceFiles,
             .run => Run,
             .check_file => CheckFile,
             .check_object => CheckObject,
@@ -148,6 +150,7 @@ pub const RemoveDir = @import("Step/RemoveDir.zig");
 pub const Run = @import("Step/Run.zig");
 pub const TranslateC = @import("Step/TranslateC.zig");
 pub const WriteFile = @import("Step/WriteFile.zig");
+pub const UpdateSourceFiles = @import("Step/UpdateSourceFiles.zig");
 
 pub const Inputs = struct {
     table: Table,
@@ -680,4 +683,5 @@ test {
     _ = Run;
     _ = TranslateC;
     _ = WriteFile;
+    _ = UpdateSourceFiles;
 }

--- a/lib/std/Build/Step/CheckFile.zig
+++ b/lib/std/Build/Step/CheckFile.zig
@@ -50,6 +50,7 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const b = step.owner;
     const check_file: *CheckFile = @fieldParentPtr("step", step);
+    try step.singleUnchangingWatchInput(check_file.source);
 
     const src_path = check_file.source.getPath2(b, step);
     const contents = fs.cwd().readFileAlloc(b.allocator, src_path, check_file.max_bytes) catch |err| {

--- a/lib/std/Build/Step/CheckObject.zig
+++ b/lib/std/Build/Step/CheckObject.zig
@@ -555,6 +555,7 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
     const b = step.owner;
     const gpa = b.allocator;
     const check_object: *CheckObject = @fieldParentPtr("step", step);
+    try step.singleUnchangingWatchInput(check_object.source);
 
     const src_path = check_object.source.getPath2(b, step);
     const contents = fs.cwd().readFileAllocOptions(

--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -168,6 +168,8 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const b = step.owner;
     const config_header: *ConfigHeader = @fieldParentPtr("step", step);
+    if (config_header.style.getPath()) |lp| try step.singleUnchangingWatchInput(lp);
+
     const gpa = b.allocator;
     const arena = b.allocator;
 

--- a/lib/std/Build/Step/InstallDir.zig
+++ b/lib/std/Build/Step/InstallDir.zig
@@ -41,7 +41,6 @@ pub const Options = struct {
 };
 
 pub fn create(owner: *std.Build, options: Options) *InstallDir {
-    owner.pushInstalledFile(options.install_dir, options.install_subdir);
     const install_dir = owner.allocator.create(InstallDir) catch @panic("OOM");
     install_dir.* = .{
         .step = Step.init(.{

--- a/lib/std/Build/Step/InstallDir.zig
+++ b/lib/std/Build/Step/InstallDir.zig
@@ -99,6 +99,7 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
                 const subdir_path = try src_dir_path.join(arena, entry.path);
                 try step.addDirectoryWatchInputFromPath(subdir_path);
                 try cwd.makePath(dest_path);
+                // TODO: set result_cached=false if the directory did not already exist.
             },
             .file => {
                 for (install_dir.options.blank_extensions) |ext| {

--- a/lib/std/Build/Step/InstallFile.zig
+++ b/lib/std/Build/Step/InstallFile.zig
@@ -39,9 +39,7 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const b = step.owner;
     const install_file: *InstallFile = @fieldParentPtr("step", step);
-
-    // Inputs never change when re-running `make`.
-    if (!step.inputs.populated()) step.addWatchInput(install_file.source);
+    try step.singleUnchangingWatchInput(install_file.source);
 
     const full_src_path = install_file.source.getPath2(b, step);
     const full_dest_path = b.getInstallPath(install_file.dir, install_file.dest_rel_path);

--- a/lib/std/Build/Step/InstallFile.zig
+++ b/lib/std/Build/Step/InstallFile.zig
@@ -40,6 +40,7 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const b = step.owner;
     const install_file: *InstallFile = @fieldParentPtr("step", step);
+    step.addWatchInput(install_file.source);
     const full_src_path = install_file.source.getPath2(b, step);
     const full_dest_path = b.getInstallPath(install_file.dir, install_file.dest_rel_path);
     const cwd = std.fs.cwd();

--- a/lib/std/Build/Step/InstallFile.zig
+++ b/lib/std/Build/Step/InstallFile.zig
@@ -39,7 +39,10 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
     _ = prog_node;
     const b = step.owner;
     const install_file: *InstallFile = @fieldParentPtr("step", step);
-    step.addWatchInput(install_file.source);
+
+    // Inputs never change when re-running `make`.
+    if (!step.inputs.populated()) step.addWatchInput(install_file.source);
+
     const full_src_path = install_file.source.getPath2(b, step);
     const full_dest_path = b.getInstallPath(install_file.dir, install_file.dest_rel_path);
     const cwd = std.fs.cwd();

--- a/lib/std/Build/Step/InstallFile.zig
+++ b/lib/std/Build/Step/InstallFile.zig
@@ -19,7 +19,6 @@ pub fn create(
     dest_rel_path: []const u8,
 ) *InstallFile {
     assert(dest_rel_path.len != 0);
-    owner.pushInstalledFile(dir, dest_rel_path);
     const install_file = owner.allocator.create(InstallFile) catch @panic("OOM");
     install_file.* = .{
         .step = Step.init(.{

--- a/lib/std/Build/Step/ObjCopy.zig
+++ b/lib/std/Build/Step/ObjCopy.zig
@@ -98,10 +98,6 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
     var man = b.graph.cache.obtain();
     defer man.deinit();
 
-    // Random bytes to make ObjCopy unique. Refresh this with new random
-    // bytes when ObjCopy implementation is modified incompatibly.
-    man.hash.add(@as(u32, 0xe18b7baf));
-
     const full_src_path = objcopy.input_file.getPath2(b, step);
     _ = try man.addFile(full_src_path, null);
     man.hash.addOptionalBytes(objcopy.only_section);

--- a/lib/std/Build/Step/ObjCopy.zig
+++ b/lib/std/Build/Step/ObjCopy.zig
@@ -93,6 +93,7 @@ pub fn getOutputSeparatedDebug(objcopy: *const ObjCopy) ?std.Build.LazyPath {
 fn make(step: *Step, prog_node: std.Progress.Node) !void {
     const b = step.owner;
     const objcopy: *ObjCopy = @fieldParentPtr("step", step);
+    try step.singleUnchangingWatchInput(objcopy.input_file);
 
     var man = b.graph.cache.obtain();
     defer man.deinit();

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -424,6 +424,9 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
             item.path.getPath2(b, step),
         );
     }
+    if (!step.inputs.populated()) for (options.args.items) |item| {
+        try step.addWatchInput(item.path);
+    };
 
     const basename = "options.zig";
 

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -523,6 +523,7 @@ test Options {
             .query = .{},
             .result = try std.zig.system.resolveTargetQuery(.{}),
         },
+        .zig_lib_directory = std.Build.Cache.Directory.cwd(),
     };
 
     var builder = try std.Build.create(

--- a/lib/std/Build/Step/RemoveDir.zig
+++ b/lib/std/Build/Step/RemoveDir.zig
@@ -2,22 +2,23 @@ const std = @import("std");
 const fs = std.fs;
 const Step = std.Build.Step;
 const RemoveDir = @This();
+const LazyPath = std.Build.LazyPath;
 
 pub const base_id: Step.Id = .remove_dir;
 
 step: Step,
-dir_path: []const u8,
+doomed_path: LazyPath,
 
-pub fn create(owner: *std.Build, dir_path: []const u8) *RemoveDir {
+pub fn create(owner: *std.Build, doomed_path: LazyPath) *RemoveDir {
     const remove_dir = owner.allocator.create(RemoveDir) catch @panic("OOM");
     remove_dir.* = .{
         .step = Step.init(.{
             .id = base_id,
-            .name = owner.fmt("RemoveDir {s}", .{dir_path}),
+            .name = owner.fmt("RemoveDir {s}", .{doomed_path.getDisplayName()}),
             .owner = owner,
             .makeFn = make,
         }),
-        .dir_path = owner.dupePath(dir_path),
+        .doomed_path = doomed_path.dupe(owner),
     };
     return remove_dir;
 }
@@ -30,14 +31,19 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
     const b = step.owner;
     const remove_dir: *RemoveDir = @fieldParentPtr("step", step);
 
-    b.build_root.handle.deleteTree(remove_dir.dir_path) catch |err| {
+    step.clearWatchInputs();
+    try step.addWatchInput(remove_dir.doomed_path);
+
+    const full_doomed_path = remove_dir.doomed_path.getPath2(b, step);
+
+    b.build_root.handle.deleteTree(full_doomed_path) catch |err| {
         if (b.build_root.path) |base| {
             return step.fail("unable to recursively delete path '{s}/{s}': {s}", .{
-                base, remove_dir.dir_path, @errorName(err),
+                base, full_doomed_path, @errorName(err),
             });
         } else {
             return step.fail("unable to recursively delete path '{s}': {s}", .{
-                remove_dir.dir_path, @errorName(err),
+                full_doomed_path, @errorName(err),
             });
         }
     };

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -615,7 +615,7 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
                     // On Windows we don't have rpaths so we have to add .dll search paths to PATH
                     run.addPathForDynLibs(artifact);
                 }
-                const file_path = artifact.installed_path orelse artifact.generated_bin.?.path.?; // the path is guaranteed to be set
+                const file_path = artifact.installed_path orelse artifact.generated_bin.?.path.?;
 
                 try argv_list.append(file_path);
 
@@ -665,7 +665,7 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
         _ = try man.addFile(lazy_path.getPath2(b, step), null);
     }
 
-    if (!has_side_effects and try step.cacheHit(&man)) {
+    if (!has_side_effects and try step.cacheHitAndWatch(&man)) {
         // cache hit, skip running command
         const digest = man.final();
 
@@ -719,7 +719,7 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
         }
 
         try runCommand(run, argv_list.items, has_side_effects, output_dir_path, prog_node);
-        if (!has_side_effects) try step.writeManifest(&man);
+        if (!has_side_effects) try step.writeManifestAndWatch(&man);
         return;
     };
 
@@ -795,7 +795,7 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
         };
     }
 
-    if (!has_side_effects) try step.writeManifest(&man);
+    if (!has_side_effects) try step.writeManifestAndWatch(&man);
 
     try populateGeneratedPaths(
         arena,

--- a/lib/std/Build/Step/UpdateSourceFiles.zig
+++ b/lib/std/Build/Step/UpdateSourceFiles.zig
@@ -1,0 +1,114 @@
+//! Writes data to paths relative to the package root, effectively mutating the
+//! package's source files. Be careful with the latter functionality; it should
+//! not be used during the normal build process, but as a utility run by a
+//! developer with intention to update source files, which will then be
+//! committed to version control.
+const std = @import("std");
+const Step = std.Build.Step;
+const fs = std.fs;
+const ArrayList = std.ArrayList;
+const UpdateSourceFiles = @This();
+
+step: Step,
+output_source_files: std.ArrayListUnmanaged(OutputSourceFile),
+
+pub const base_id: Step.Id = .update_source_files;
+
+pub const OutputSourceFile = struct {
+    contents: Contents,
+    sub_path: []const u8,
+};
+
+pub const Contents = union(enum) {
+    bytes: []const u8,
+    copy: std.Build.LazyPath,
+};
+
+pub fn create(owner: *std.Build) *UpdateSourceFiles {
+    const usf = owner.allocator.create(UpdateSourceFiles) catch @panic("OOM");
+    usf.* = .{
+        .step = Step.init(.{
+            .id = base_id,
+            .name = "UpdateSourceFiles",
+            .owner = owner,
+            .makeFn = make,
+        }),
+        .output_source_files = .{},
+    };
+    return usf;
+}
+
+/// A path relative to the package root.
+///
+/// Be careful with this because it updates source files. This should not be
+/// used as part of the normal build process, but as a utility occasionally
+/// run by a developer with intent to modify source files and then commit
+/// those changes to version control.
+pub fn addCopyFileToSource(usf: *UpdateSourceFiles, source: std.Build.LazyPath, sub_path: []const u8) void {
+    const b = usf.step.owner;
+    usf.output_source_files.append(b.allocator, .{
+        .contents = .{ .copy = source },
+        .sub_path = sub_path,
+    }) catch @panic("OOM");
+    source.addStepDependencies(&usf.step);
+}
+
+/// A path relative to the package root.
+///
+/// Be careful with this because it updates source files. This should not be
+/// used as part of the normal build process, but as a utility occasionally
+/// run by a developer with intent to modify source files and then commit
+/// those changes to version control.
+pub fn addBytesToSource(usf: *UpdateSourceFiles, bytes: []const u8, sub_path: []const u8) void {
+    const b = usf.step.owner;
+    usf.output_source_files.append(b.allocator, .{
+        .contents = .{ .bytes = bytes },
+        .sub_path = sub_path,
+    }) catch @panic("OOM");
+}
+
+fn make(step: *Step, prog_node: std.Progress.Node) !void {
+    _ = prog_node;
+    const b = step.owner;
+    const usf: *UpdateSourceFiles = @fieldParentPtr("step", step);
+
+    var any_miss = false;
+    for (usf.output_source_files.items) |output_source_file| {
+        if (fs.path.dirname(output_source_file.sub_path)) |dirname| {
+            b.build_root.handle.makePath(dirname) catch |err| {
+                return step.fail("unable to make path '{}{s}': {s}", .{
+                    b.build_root, dirname, @errorName(err),
+                });
+            };
+        }
+        switch (output_source_file.contents) {
+            .bytes => |bytes| {
+                b.build_root.handle.writeFile(.{ .sub_path = output_source_file.sub_path, .data = bytes }) catch |err| {
+                    return step.fail("unable to write file '{}{s}': {s}", .{
+                        b.build_root, output_source_file.sub_path, @errorName(err),
+                    });
+                };
+                any_miss = true;
+            },
+            .copy => |file_source| {
+                if (!step.inputs.populated()) try step.addWatchInput(file_source);
+
+                const source_path = file_source.getPath2(b, step);
+                const prev_status = fs.Dir.updateFile(
+                    fs.cwd(),
+                    source_path,
+                    b.build_root.handle,
+                    output_source_file.sub_path,
+                    .{},
+                ) catch |err| {
+                    return step.fail("unable to update file from '{s}' to '{}{s}': {s}", .{
+                        source_path, b.build_root, output_source_file.sub_path, @errorName(err),
+                    });
+                };
+                any_miss = any_miss or prev_status == .stale;
+            },
+        }
+    }
+
+    step.result_cached = !any_miss;
+}

--- a/lib/std/Build/Step/WriteFile.zig
+++ b/lib/std/Build/Step/WriteFile.zig
@@ -189,11 +189,6 @@ fn make(step: *Step, prog_node: std.Progress.Node) !void {
     var man = b.graph.cache.obtain();
     defer man.deinit();
 
-    // Random bytes to make WriteFile unique. Refresh this with
-    // new random bytes when WriteFile implementation is modified
-    // in a non-backwards-compatible way.
-    man.hash.add(@as(u32, 0xc2a287d0));
-
     for (write_file.files.items) |file| {
         man.hash.addBytes(file.sub_path);
 

--- a/lib/std/Build/Watch.zig
+++ b/lib/std/Build/Watch.zig
@@ -104,22 +104,6 @@ pub const LinuxFileHandle = struct {
     };
 };
 
-pub fn getFileHandle(gpa: Allocator, path: std.Build.Cache.Path, basename: []const u8) !LinuxFileHandle {
-    var file_handle_buffer: [@sizeOf(std.os.linux.file_handle) + 128]u8 align(@alignOf(std.os.linux.file_handle)) = undefined;
-    var mount_id: i32 = undefined;
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const joined_path = if (path.sub_path.len == 0) basename else path: {
-        break :path std.fmt.bufPrint(&buf, "{s}/{s}", .{
-            path.sub_path, basename,
-        }) catch return error.NameTooLong;
-    };
-    const stack_ptr: *std.os.linux.file_handle = @ptrCast(&file_handle_buffer);
-    stack_ptr.handle_bytes = file_handle_buffer.len - @sizeOf(std.os.linux.file_handle);
-    try std.posix.name_to_handle_at(path.root_dir.handle.fd, joined_path, stack_ptr, &mount_id, 0);
-    const stack_lfh: LinuxFileHandle = .{ .handle = stack_ptr };
-    return stack_lfh.clone(gpa);
-}
-
 pub fn getDirHandle(gpa: Allocator, path: std.Build.Cache.Path) !LinuxFileHandle {
     var file_handle_buffer: [@sizeOf(std.os.linux.file_handle) + 128]u8 align(@alignOf(std.os.linux.file_handle)) = undefined;
     var mount_id: i32 = undefined;

--- a/lib/std/Build/Watch.zig
+++ b/lib/std/Build/Watch.zig
@@ -1,33 +1,14 @@
+const builtin = @import("builtin");
 const std = @import("../std.zig");
 const Watch = @This();
 const Step = std.Build.Step;
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
+const fatal = std.zig.fatal;
 
 dir_table: DirTable,
-/// Keyed differently but indexes correspond 1:1 with `dir_table`.
-handle_table: HandleTable,
-fan_fd: std.posix.fd_t,
+os: Os,
 generation: Generation,
-
-pub const fan_mask: std.os.linux.fanotify.MarkMask = .{
-    .CLOSE_WRITE = true,
-    .CREATE = true,
-    .DELETE = true,
-    .DELETE_SELF = true,
-    .EVENT_ON_CHILD = true,
-    .MOVED_FROM = true,
-    .MOVED_TO = true,
-    .MOVE_SELF = true,
-    .ONDIR = true,
-};
-
-pub const init: Watch = .{
-    .dir_table = .{},
-    .handle_table = .{},
-    .fan_fd = -1,
-    .generation = 0,
-};
 
 /// Key is the directory to watch which contains one or more files we are
 /// interested in noticing changes to.
@@ -35,7 +16,6 @@ pub const init: Watch = .{
 /// Value is generation.
 const DirTable = std.ArrayHashMapUnmanaged(Cache.Path, void, Cache.Path.TableAdapter, false);
 
-const HandleTable = std.ArrayHashMapUnmanaged(LinuxFileHandle, ReactionSet, LinuxFileHandle.Adapter, false);
 /// Special key of "." means any changes in this directory trigger the steps.
 const ReactionSet = std.StringArrayHashMapUnmanaged(StepSet);
 const StepSet = std.AutoArrayHashMapUnmanaged(*Step, Generation);
@@ -44,6 +24,255 @@ const Generation = u8;
 
 const Hash = std.hash.Wyhash;
 const Cache = std.Build.Cache;
+
+const Os = switch (builtin.os.tag) {
+    .linux => struct {
+        const posix = std.posix;
+
+        /// Keyed differently but indexes correspond 1:1 with `dir_table`.
+        handle_table: HandleTable,
+        poll_fds: [1]posix.pollfd,
+
+        const HandleTable = std.ArrayHashMapUnmanaged(FileHandle, ReactionSet, FileHandle.Adapter, false);
+
+        const fan_mask: std.os.linux.fanotify.MarkMask = .{
+            .CLOSE_WRITE = true,
+            .CREATE = true,
+            .DELETE = true,
+            .DELETE_SELF = true,
+            .EVENT_ON_CHILD = true,
+            .MOVED_FROM = true,
+            .MOVED_TO = true,
+            .MOVE_SELF = true,
+            .ONDIR = true,
+        };
+
+        const FileHandle = struct {
+            handle: *align(1) std.os.linux.file_handle,
+
+            fn clone(lfh: FileHandle, gpa: Allocator) Allocator.Error!FileHandle {
+                const bytes = lfh.slice();
+                const new_ptr = try gpa.alignedAlloc(
+                    u8,
+                    @alignOf(std.os.linux.file_handle),
+                    @sizeOf(std.os.linux.file_handle) + bytes.len,
+                );
+                const new_header: *std.os.linux.file_handle = @ptrCast(new_ptr);
+                new_header.* = lfh.handle.*;
+                const new: FileHandle = .{ .handle = new_header };
+                @memcpy(new.slice(), lfh.slice());
+                return new;
+            }
+
+            fn destroy(lfh: FileHandle, gpa: Allocator) void {
+                const ptr: [*]u8 = @ptrCast(lfh.handle);
+                const allocated_slice = ptr[0 .. @sizeOf(std.os.linux.file_handle) + lfh.handle.handle_bytes];
+                return gpa.free(allocated_slice);
+            }
+
+            fn slice(lfh: FileHandle) []u8 {
+                const ptr: [*]u8 = &lfh.handle.f_handle;
+                return ptr[0..lfh.handle.handle_bytes];
+            }
+
+            const Adapter = struct {
+                pub fn hash(self: Adapter, a: FileHandle) u32 {
+                    _ = self;
+                    const unsigned_type: u32 = @bitCast(a.handle.handle_type);
+                    return @truncate(Hash.hash(unsigned_type, a.slice()));
+                }
+                pub fn eql(self: Adapter, a: FileHandle, b: FileHandle, b_index: usize) bool {
+                    _ = self;
+                    _ = b_index;
+                    return a.handle.handle_type == b.handle.handle_type and std.mem.eql(u8, a.slice(), b.slice());
+                }
+            };
+        };
+
+        fn getDirHandle(gpa: Allocator, path: std.Build.Cache.Path) !FileHandle {
+            var file_handle_buffer: [@sizeOf(std.os.linux.file_handle) + 128]u8 align(@alignOf(std.os.linux.file_handle)) = undefined;
+            var mount_id: i32 = undefined;
+            var buf: [std.fs.max_path_bytes]u8 = undefined;
+            const adjusted_path = if (path.sub_path.len == 0) "./" else std.fmt.bufPrint(&buf, "{s}/", .{
+                path.sub_path,
+            }) catch return error.NameTooLong;
+            const stack_ptr: *std.os.linux.file_handle = @ptrCast(&file_handle_buffer);
+            stack_ptr.handle_bytes = file_handle_buffer.len - @sizeOf(std.os.linux.file_handle);
+            try posix.name_to_handle_at(path.root_dir.handle.fd, adjusted_path, stack_ptr, &mount_id, std.os.linux.AT.HANDLE_FID);
+            const stack_lfh: FileHandle = .{ .handle = stack_ptr };
+            return stack_lfh.clone(gpa);
+        }
+
+        fn markDirtySteps(w: *Watch, gpa: Allocator) !bool {
+            const fan_fd = w.os.getFanFd();
+            const fanotify = std.os.linux.fanotify;
+            const M = fanotify.event_metadata;
+            var events_buf: [256 + 4096]u8 = undefined;
+            var any_dirty = false;
+            while (true) {
+                var len = posix.read(fan_fd, &events_buf) catch |err| switch (err) {
+                    error.WouldBlock => return any_dirty,
+                    else => |e| return e,
+                };
+                var meta: [*]align(1) M = @ptrCast(&events_buf);
+                while (len >= @sizeOf(M) and meta[0].event_len >= @sizeOf(M) and meta[0].event_len <= len) : ({
+                    len -= meta[0].event_len;
+                    meta = @ptrCast(@as([*]u8, @ptrCast(meta)) + meta[0].event_len);
+                }) {
+                    assert(meta[0].vers == M.VERSION);
+                    if (meta[0].mask.Q_OVERFLOW) {
+                        any_dirty = true;
+                        std.log.warn("file system watch queue overflowed; falling back to fstat", .{});
+                        markAllFilesDirty(w, gpa);
+                        return true;
+                    }
+                    const fid: *align(1) fanotify.event_info_fid = @ptrCast(meta + 1);
+                    switch (fid.hdr.info_type) {
+                        .DFID_NAME => {
+                            const file_handle: *align(1) std.os.linux.file_handle = @ptrCast(&fid.handle);
+                            const file_name_z: [*:0]u8 = @ptrCast((&file_handle.f_handle).ptr + file_handle.handle_bytes);
+                            const file_name = std.mem.span(file_name_z);
+                            const lfh: FileHandle = .{ .handle = file_handle };
+                            if (w.os.handle_table.getPtr(lfh)) |reaction_set| {
+                                if (reaction_set.getPtr(".")) |glob_set|
+                                    any_dirty = markStepSetDirty(gpa, glob_set, any_dirty);
+                                if (reaction_set.getPtr(file_name)) |step_set|
+                                    any_dirty = markStepSetDirty(gpa, step_set, any_dirty);
+                            }
+                        },
+                        else => |t| std.log.warn("unexpected fanotify event '{s}'", .{@tagName(t)}),
+                    }
+                }
+            }
+        }
+
+        fn getFanFd(os: *const @This()) posix.fd_t {
+            return os.poll_fds[0].fd;
+        }
+
+        fn update(w: *Watch, gpa: Allocator, steps: []const *Step) !void {
+            const fan_fd = w.os.getFanFd();
+            // Add missing marks and note persisted ones.
+            for (steps) |step| {
+                for (step.inputs.table.keys(), step.inputs.table.values()) |path, *files| {
+                    const reaction_set = rs: {
+                        const gop = try w.dir_table.getOrPut(gpa, path);
+                        if (!gop.found_existing) {
+                            const dir_handle = try Os.getDirHandle(gpa, path);
+                            // `dir_handle` may already be present in the table in
+                            // the case that we have multiple Cache.Path instances
+                            // that compare inequal but ultimately point to the same
+                            // directory on the file system.
+                            // In such case, we must revert adding this directory, but keep
+                            // the additions to the step set.
+                            const dh_gop = try w.os.handle_table.getOrPut(gpa, dir_handle);
+                            if (dh_gop.found_existing) {
+                                _ = w.dir_table.pop();
+                            } else {
+                                assert(dh_gop.index == gop.index);
+                                dh_gop.value_ptr.* = .{};
+                                posix.fanotify_mark(fan_fd, .{
+                                    .ADD = true,
+                                    .ONLYDIR = true,
+                                }, fan_mask, path.root_dir.handle.fd, path.subPathOrDot()) catch |err| {
+                                    fatal("unable to watch {}: {s}", .{ path, @errorName(err) });
+                                };
+                            }
+                            break :rs dh_gop.value_ptr;
+                        }
+                        break :rs &w.os.handle_table.values()[gop.index];
+                    };
+                    for (files.items) |basename| {
+                        const gop = try reaction_set.getOrPut(gpa, basename);
+                        if (!gop.found_existing) gop.value_ptr.* = .{};
+                        try gop.value_ptr.put(gpa, step, w.generation);
+                    }
+                }
+            }
+
+            {
+                // Remove marks for files that are no longer inputs.
+                var i: usize = 0;
+                while (i < w.os.handle_table.entries.len) {
+                    {
+                        const reaction_set = &w.os.handle_table.values()[i];
+                        var step_set_i: usize = 0;
+                        while (step_set_i < reaction_set.entries.len) {
+                            const step_set = &reaction_set.values()[step_set_i];
+                            var dirent_i: usize = 0;
+                            while (dirent_i < step_set.entries.len) {
+                                const generations = step_set.values();
+                                if (generations[dirent_i] == w.generation) {
+                                    dirent_i += 1;
+                                    continue;
+                                }
+                                step_set.swapRemoveAt(dirent_i);
+                            }
+                            if (step_set.entries.len > 0) {
+                                step_set_i += 1;
+                                continue;
+                            }
+                            reaction_set.swapRemoveAt(step_set_i);
+                        }
+                        if (reaction_set.entries.len > 0) {
+                            i += 1;
+                            continue;
+                        }
+                    }
+
+                    const path = w.dir_table.keys()[i];
+
+                    posix.fanotify_mark(fan_fd, .{
+                        .REMOVE = true,
+                        .ONLYDIR = true,
+                    }, fan_mask, path.root_dir.handle.fd, path.subPathOrDot()) catch |err| switch (err) {
+                        error.FileNotFound => {}, // Expected, harmless.
+                        else => |e| std.log.warn("unable to unwatch '{}': {s}", .{ path, @errorName(e) }),
+                    };
+
+                    w.dir_table.swapRemoveAt(i);
+                    w.os.handle_table.swapRemoveAt(i);
+                }
+                w.generation +%= 1;
+            }
+        }
+    },
+    else => void,
+};
+
+pub fn init() !Watch {
+    switch (builtin.os.tag) {
+        .linux => {
+            const fan_fd = try std.posix.fanotify_init(.{
+                .CLASS = .NOTIF,
+                .CLOEXEC = true,
+                .NONBLOCK = true,
+                .REPORT_NAME = true,
+                .REPORT_DIR_FID = true,
+                .REPORT_FID = true,
+                .REPORT_TARGET_FID = true,
+            }, 0);
+            return .{
+                .dir_table = .{},
+                .os = switch (builtin.os.tag) {
+                    .linux => .{
+                        .handle_table = .{},
+                        .poll_fds = .{
+                            .{
+                                .fd = fan_fd,
+                                .events = std.posix.POLL.IN,
+                                .revents = undefined,
+                            },
+                        },
+                    },
+                    else => {},
+                },
+                .generation = 0,
+            };
+        },
+        else => @panic("unimplemented"),
+    }
+}
 
 pub const Match = struct {
     /// Relative to the watched directory, the file path that triggers this
@@ -68,119 +297,8 @@ pub const Match = struct {
     };
 };
 
-pub const LinuxFileHandle = struct {
-    handle: *align(1) std.os.linux.file_handle,
-
-    pub fn clone(lfh: LinuxFileHandle, gpa: Allocator) Allocator.Error!LinuxFileHandle {
-        const bytes = lfh.slice();
-        const new_ptr = try gpa.alignedAlloc(
-            u8,
-            @alignOf(std.os.linux.file_handle),
-            @sizeOf(std.os.linux.file_handle) + bytes.len,
-        );
-        const new_header: *std.os.linux.file_handle = @ptrCast(new_ptr);
-        new_header.* = lfh.handle.*;
-        const new: LinuxFileHandle = .{ .handle = new_header };
-        @memcpy(new.slice(), lfh.slice());
-        return new;
-    }
-
-    pub fn destroy(lfh: LinuxFileHandle, gpa: Allocator) void {
-        const ptr: [*]u8 = @ptrCast(lfh.handle);
-        const allocated_slice = ptr[0 .. @sizeOf(std.os.linux.file_handle) + lfh.handle.handle_bytes];
-        return gpa.free(allocated_slice);
-    }
-
-    pub fn slice(lfh: LinuxFileHandle) []u8 {
-        const ptr: [*]u8 = &lfh.handle.f_handle;
-        return ptr[0..lfh.handle.handle_bytes];
-    }
-
-    pub const Adapter = struct {
-        pub fn hash(self: Adapter, a: LinuxFileHandle) u32 {
-            _ = self;
-            const unsigned_type: u32 = @bitCast(a.handle.handle_type);
-            return @truncate(Hash.hash(unsigned_type, a.slice()));
-        }
-        pub fn eql(self: Adapter, a: LinuxFileHandle, b: LinuxFileHandle, b_index: usize) bool {
-            _ = self;
-            _ = b_index;
-            return a.handle.handle_type == b.handle.handle_type and std.mem.eql(u8, a.slice(), b.slice());
-        }
-    };
-};
-
-pub fn getDirHandle(gpa: Allocator, path: std.Build.Cache.Path) !LinuxFileHandle {
-    var file_handle_buffer: [@sizeOf(std.os.linux.file_handle) + 128]u8 align(@alignOf(std.os.linux.file_handle)) = undefined;
-    var mount_id: i32 = undefined;
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const adjusted_path = if (path.sub_path.len == 0) "./" else std.fmt.bufPrint(&buf, "{s}/", .{
-        path.sub_path,
-    }) catch return error.NameTooLong;
-    const stack_ptr: *std.os.linux.file_handle = @ptrCast(&file_handle_buffer);
-    stack_ptr.handle_bytes = file_handle_buffer.len - @sizeOf(std.os.linux.file_handle);
-    try std.posix.name_to_handle_at(path.root_dir.handle.fd, adjusted_path, stack_ptr, &mount_id, std.os.linux.AT.HANDLE_FID);
-    const stack_lfh: LinuxFileHandle = .{ .handle = stack_ptr };
-    return stack_lfh.clone(gpa);
-}
-
-pub fn markDirtySteps(w: *Watch, gpa: Allocator) !bool {
-    const fanotify = std.os.linux.fanotify;
-    const M = fanotify.event_metadata;
-    var events_buf: [256 + 4096]u8 = undefined;
-    var any_dirty = false;
-    while (true) {
-        var len = std.posix.read(w.fan_fd, &events_buf) catch |err| switch (err) {
-            error.WouldBlock => return any_dirty,
-            else => |e| return e,
-        };
-        var meta: [*]align(1) M = @ptrCast(&events_buf);
-        while (len >= @sizeOf(M) and meta[0].event_len >= @sizeOf(M) and meta[0].event_len <= len) : ({
-            len -= meta[0].event_len;
-            meta = @ptrCast(@as([*]u8, @ptrCast(meta)) + meta[0].event_len);
-        }) {
-            assert(meta[0].vers == M.VERSION);
-            if (meta[0].mask.Q_OVERFLOW) {
-                any_dirty = true;
-                std.log.warn("file system watch queue overflowed; falling back to fstat", .{});
-                markAllFilesDirty(w, gpa);
-                return true;
-            }
-            const fid: *align(1) fanotify.event_info_fid = @ptrCast(meta + 1);
-            switch (fid.hdr.info_type) {
-                .DFID_NAME => {
-                    const file_handle: *align(1) std.os.linux.file_handle = @ptrCast(&fid.handle);
-                    const file_name_z: [*:0]u8 = @ptrCast((&file_handle.f_handle).ptr + file_handle.handle_bytes);
-                    const file_name = std.mem.span(file_name_z);
-                    const lfh: Watch.LinuxFileHandle = .{ .handle = file_handle };
-                    if (w.handle_table.getPtr(lfh)) |reaction_set| {
-                        if (reaction_set.getPtr(".")) |glob_set|
-                            any_dirty = markStepSetDirty(gpa, glob_set, any_dirty);
-                        if (reaction_set.getPtr(file_name)) |step_set|
-                            any_dirty = markStepSetDirty(gpa, step_set, any_dirty);
-                    }
-                },
-                else => |t| std.log.warn("unexpected fanotify event '{s}'", .{@tagName(t)}),
-            }
-        }
-    }
-}
-
-pub fn markFailedStepsDirty(gpa: Allocator, all_steps: []const *Step) void {
-    for (all_steps) |step| switch (step.state) {
-        .dependency_failure, .failure, .skipped => step.recursiveReset(gpa),
-        else => continue,
-    };
-    // Now that all dirty steps have been found, the remaining steps that
-    // succeeded from last run shall be marked "cached".
-    for (all_steps) |step| switch (step.state) {
-        .success => step.result_cached = true,
-        else => continue,
-    };
-}
-
 fn markAllFilesDirty(w: *Watch, gpa: Allocator) void {
-    for (w.handle_table.values()) |reaction_set| {
+    for (w.os.handle_table.values()) |reaction_set| {
         for (reaction_set.values()) |step_set| {
             for (step_set.keys()) |step| {
                 step.recursiveReset(gpa);
@@ -198,4 +316,48 @@ fn markStepSetDirty(gpa: Allocator, step_set: *StepSet, any_dirty: bool) bool {
         }
     }
     return any_dirty or this_any_dirty;
+}
+
+pub fn update(w: *Watch, gpa: Allocator, steps: []const *Step) !void {
+    switch (builtin.os.tag) {
+        .linux => return Os.update(w, gpa, steps),
+        else => @compileError("unimplemented"),
+    }
+}
+
+pub const Timeout = union(enum) {
+    none,
+    ms: u16,
+
+    pub fn to_i32_ms(t: Timeout) i32 {
+        return switch (t) {
+            .none => -1,
+            .ms => |ms| ms,
+        };
+    }
+};
+
+pub const WaitResult = enum {
+    timeout,
+    /// File system watching triggered on files that were marked as inputs to at least one Step.
+    /// Relevant steps have been marked dirty.
+    dirty,
+    /// File system watching triggered but none of the events were relevant to
+    /// what we are listening to. There is nothing to do.
+    clean,
+};
+
+pub fn wait(w: *Watch, gpa: Allocator, timeout: Timeout) !WaitResult {
+    switch (builtin.os.tag) {
+        .linux => {
+            const events_len = try std.posix.poll(&w.os.poll_fds, timeout.to_i32_ms());
+            return if (events_len == 0)
+                .timeout
+            else if (try Os.markDirtySteps(w, gpa))
+                .dirty
+            else
+                .clean;
+        },
+        else => @compileError("unimplemented"),
+    }
 }

--- a/lib/std/Build/Watch.zig
+++ b/lib/std/Build/Watch.zig
@@ -19,6 +19,7 @@ pub const fan_mask: std.os.linux.fanotify.MarkMask = .{
     .MOVED_FROM = true,
     .MOVED_TO = true,
     .MOVE_SELF = true,
+    .ONDIR = true,
 };
 
 pub const init: Watch = .{

--- a/lib/std/Build/Watch.zig
+++ b/lib/std/Build/Watch.zig
@@ -1,0 +1,135 @@
+const std = @import("../std.zig");
+const Watch = @This();
+const Step = std.Build.Step;
+const Allocator = std.mem.Allocator;
+
+dir_table: DirTable,
+/// Keyed differently but indexes correspond 1:1 with `dir_table`.
+handle_table: HandleTable,
+fan_fd: std.posix.fd_t,
+generation: Generation,
+
+pub const fan_mask: std.os.linux.fanotify.MarkMask = .{
+    .CLOSE_WRITE = true,
+    .DELETE = true,
+    .MOVED_FROM = true,
+    .MOVED_TO = true,
+    .EVENT_ON_CHILD = true,
+};
+
+pub const init: Watch = .{
+    .dir_table = .{},
+    .handle_table = .{},
+    .fan_fd = -1,
+    .generation = 0,
+};
+
+/// Key is the directory to watch which contains one or more files we are
+/// interested in noticing changes to.
+///
+/// Value is generation.
+const DirTable = std.ArrayHashMapUnmanaged(Cache.Path, void, Cache.Path.TableAdapter, false);
+
+const HandleTable = std.ArrayHashMapUnmanaged(LinuxFileHandle, ReactionSet, LinuxFileHandle.Adapter, false);
+const ReactionSet = std.StringArrayHashMapUnmanaged(StepSet);
+const StepSet = std.AutoArrayHashMapUnmanaged(*Step, Generation);
+
+const Generation = u8;
+
+const Hash = std.hash.Wyhash;
+const Cache = std.Build.Cache;
+
+pub const Match = struct {
+    /// Relative to the watched directory, the file path that triggers this
+    /// match.
+    basename: []const u8,
+    /// The step to re-run when file corresponding to `basename` is changed.
+    step: *Step,
+
+    pub const Context = struct {
+        pub fn hash(self: Context, a: Match) u32 {
+            _ = self;
+            var hasher = Hash.init(0);
+            std.hash.autoHash(&hasher, a.step);
+            hasher.update(a.basename);
+            return @truncate(hasher.final());
+        }
+        pub fn eql(self: Context, a: Match, b: Match, b_index: usize) bool {
+            _ = self;
+            _ = b_index;
+            return a.step == b.step and std.mem.eql(u8, a.basename, b.basename);
+        }
+    };
+};
+
+pub const LinuxFileHandle = struct {
+    handle: *align(1) std.os.linux.file_handle,
+
+    pub fn clone(lfh: LinuxFileHandle, gpa: Allocator) Allocator.Error!LinuxFileHandle {
+        const bytes = lfh.slice();
+        const new_ptr = try gpa.alignedAlloc(
+            u8,
+            @alignOf(std.os.linux.file_handle),
+            @sizeOf(std.os.linux.file_handle) + bytes.len,
+        );
+        const new_header: *std.os.linux.file_handle = @ptrCast(new_ptr);
+        new_header.* = lfh.handle.*;
+        const new: LinuxFileHandle = .{ .handle = new_header };
+        @memcpy(new.slice(), lfh.slice());
+        return new;
+    }
+
+    pub fn destroy(lfh: LinuxFileHandle, gpa: Allocator) void {
+        const ptr: [*]u8 = @ptrCast(lfh.handle);
+        const allocated_slice = ptr[0 .. @sizeOf(std.os.linux.file_handle) + lfh.handle.handle_bytes];
+        return gpa.free(allocated_slice);
+    }
+
+    pub fn slice(lfh: LinuxFileHandle) []u8 {
+        const ptr: [*]u8 = &lfh.handle.f_handle;
+        return ptr[0..lfh.handle.handle_bytes];
+    }
+
+    pub const Adapter = struct {
+        pub fn hash(self: Adapter, a: LinuxFileHandle) u32 {
+            _ = self;
+            const unsigned_type: u32 = @bitCast(a.handle.handle_type);
+            return @truncate(Hash.hash(unsigned_type, a.slice()));
+        }
+        pub fn eql(self: Adapter, a: LinuxFileHandle, b: LinuxFileHandle, b_index: usize) bool {
+            _ = self;
+            _ = b_index;
+            return a.handle.handle_type == b.handle.handle_type and std.mem.eql(u8, a.slice(), b.slice());
+        }
+    };
+};
+
+pub fn getFileHandle(gpa: Allocator, path: std.Build.Cache.Path, basename: []const u8) !LinuxFileHandle {
+    var file_handle_buffer: [@sizeOf(std.os.linux.file_handle) + 128]u8 align(@alignOf(std.os.linux.file_handle)) = undefined;
+    var mount_id: i32 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const joined_path = if (path.sub_path.len == 0) basename else path: {
+        break :path std.fmt.bufPrint(&buf, "{s}/{s}", .{
+            path.sub_path, basename,
+        }) catch return error.NameTooLong;
+    };
+    const stack_ptr: *std.os.linux.file_handle = @ptrCast(&file_handle_buffer);
+    stack_ptr.handle_bytes = file_handle_buffer.len - @sizeOf(std.os.linux.file_handle);
+    try std.posix.name_to_handle_at(path.root_dir.handle.fd, joined_path, stack_ptr, &mount_id, 0);
+    const stack_lfh: LinuxFileHandle = .{ .handle = stack_ptr };
+    return stack_lfh.clone(gpa);
+}
+
+pub fn getDirHandle(gpa: Allocator, path: std.Build.Cache.Path) !LinuxFileHandle {
+    var file_handle_buffer: [@sizeOf(std.os.linux.file_handle) + 128]u8 align(@alignOf(std.os.linux.file_handle)) = undefined;
+    var mount_id: i32 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const adjusted_path = if (path.sub_path.len == 0) "./" else std.fmt.bufPrint(&buf, "{s}/", .{
+        path.sub_path,
+    }) catch return error.NameTooLong;
+    const stack_ptr: *std.os.linux.file_handle = @ptrCast(&file_handle_buffer);
+    stack_ptr.handle_bytes = file_handle_buffer.len - @sizeOf(std.os.linux.file_handle);
+    try std.posix.name_to_handle_at(path.root_dir.handle.fd, adjusted_path, stack_ptr, &mount_id, std.os.linux.AT.HANDLE_FID);
+    const stack_lfh: LinuxFileHandle = .{ .handle = stack_ptr };
+    return stack_lfh.clone(gpa);
+}

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -4261,7 +4261,7 @@ pub const fanotify = struct {
         vers: u8,
         reserved: u8,
         metadata_len: u16,
-        mask: u64 align(8),
+        mask: MarkMask align(8),
         fd: i32,
         pid: i32,
 

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -2946,6 +2946,8 @@ pub const AT = struct {
 
     /// Apply to the entire subtree
     pub const RECURSIVE = 0x8000;
+
+    pub const HANDLE_FID = REMOVEDIR;
 };
 
 pub const FALLOC = struct {

--- a/lib/std/zig/Server.zig
+++ b/lib/std/zig/Server.zig
@@ -20,8 +20,22 @@ pub const Message = struct {
         test_metadata,
         /// Body is a TestResults
         test_results,
+        /// Body is a series of strings, delimited by null bytes.
+        /// Each string is a prefixed file path.
+        /// The first byte indicates the file prefix path (see prefixes fields
+        /// of Cache). This byte is sent over the wire incremented so that null
+        /// bytes are not confused with string terminators.
+        /// The remaining bytes is the file path relative to that prefix.
+        /// The prefixes are hard-coded in Compilation.create (cwd, zig lib dir, local cache dir)
+        file_system_inputs,
 
         _,
+    };
+
+    pub const PathPrefix = enum(u8) {
+        cwd,
+        zig_lib,
+        local_cache,
     };
 
     /// Trailing:
@@ -58,7 +72,7 @@ pub const Message = struct {
     };
 
     /// Trailing:
-    /// * the file system path the emitted binary can be found
+    /// * file system path where the emitted binary can be found
     pub const EmitBinPath = extern struct {
         flags: Flags,
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2180,7 +2180,8 @@ pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) !void {
             comp.astgen_work_queue.writeItemAssumeCapacity(file_index);
         }
         if (comp.file_system_inputs) |fsi| {
-            for (zcu.import_table.values()) |file| {
+            for (zcu.import_table.values()) |file_index| {
+                const file = zcu.fileByIndex(file_index);
                 try comp.appendFileSystemInput(fsi, file.mod.root, file.sub_file_path);
             }
         }

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -728,7 +728,7 @@ pub const File = struct {
     source_loaded: bool,
     tree_loaded: bool,
     zir_loaded: bool,
-    /// Relative to the owning package's root_src_dir.
+    /// Relative to the owning package's root source directory.
     /// Memory is stored in gpa, owned by File.
     sub_file_path: []const u8,
     /// Whether this is populated depends on `source_loaded`.

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -2666,7 +2666,7 @@ pub fn reportRetryableAstGenError(
         },
     };
 
-    const err_msg = try Zcu.ErrorMsg.create(gpa, src_loc, "unable to load '{}{s}': {s}", .{
+    const err_msg = try Zcu.ErrorMsg.create(gpa, src_loc, "unable to load '{}/{s}': {s}", .{
         file.mod.root, file.sub_file_path, @errorName(err),
     });
     errdefer err_msg.destroy(gpa);

--- a/src/main.zig
+++ b/src/main.zig
@@ -4649,31 +4649,6 @@ fn cmdInit(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     return cleanExit();
 }
 
-const usage_build =
-    \\Usage: zig build [steps] [options]
-    \\
-    \\   Build a project from build.zig.
-    \\
-    \\Options:
-    \\  -freference-trace[=num]       How many lines of reference trace should be shown per compile error
-    \\  -fno-reference-trace          Disable reference trace
-    \\  --summary [mode]              Control the printing of the build summary
-    \\    all                         Print the build summary in its entirety
-    \\    failures                    (Default) Only print failed steps
-    \\    none                        Do not print the build summary
-    \\  -j<N>                         Limit concurrent jobs (default is to use all CPU cores)
-    \\  --build-file [file]           Override path to build.zig
-    \\  --cache-dir [path]            Override path to local Zig cache directory
-    \\  --global-cache-dir [path]     Override path to global Zig cache directory
-    \\  --zig-lib-dir [arg]           Override path to Zig lib directory
-    \\  --build-runner [file]         Override path to build runner
-    \\  --prominent-compile-errors    Buffer compile errors and display at end
-    \\  --seed [integer]              For shuffling dependency traversal order (default: random)
-    \\  --fetch                       Exit after fetching dependency tree
-    \\  -h, --help                    Print this help and exit
-    \\
-;
-
 fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     var build_file: ?[]const u8 = null;
     var override_lib_dir: ?[]const u8 = try EnvVar.ZIG_LIB_DIR.get(arena);

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -771,7 +771,7 @@ pub fn addCliTests(b: *std.Build) *Step {
         run_run.expectStdErrEqual("All your codebase are belong to us.\n");
         run_run.step.dependOn(&init_exe.step);
 
-        const cleanup = b.addRemoveDirTree(tmp_path);
+        const cleanup = b.addRemoveDirTree(.{ .cwd_relative = tmp_path });
         cleanup.step.dependOn(&run_test.step);
         cleanup.step.dependOn(&run_run.step);
         cleanup.step.dependOn(&run_bad.step);
@@ -816,7 +816,7 @@ pub fn addCliTests(b: *std.Build) *Step {
         });
         checkfile.setName("check godbolt.org CLI usage generating valid asm");
 
-        const cleanup = b.addRemoveDirTree(tmp_path);
+        const cleanup = b.addRemoveDirTree(.{ .cwd_relative = tmp_path });
         cleanup.step.dependOn(&checkfile.step);
 
         step.dependOn(&cleanup.step);
@@ -902,7 +902,7 @@ pub fn addCliTests(b: *std.Build) *Step {
         });
         check6.step.dependOn(&run6.step);
 
-        const cleanup = b.addRemoveDirTree(tmp_path);
+        const cleanup = b.addRemoveDirTree(.{ .cwd_relative = tmp_path });
         cleanup.step.dependOn(&check6.step);
 
         step.dependOn(&cleanup.step);

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -882,7 +882,7 @@ pub fn addCliTests(b: *std.Build) *Step {
 
         const unformatted_code_utf16 = "\xff\xfe \x00 \x00 \x00 \x00/\x00/\x00 \x00n\x00o\x00 \x00r\x00e\x00a\x00s\x00o\x00n\x00";
         const fmt6_path = std.fs.path.join(b.allocator, &.{ tmp_path, "fmt6.zig" }) catch @panic("OOM");
-        const write6 = b.addWriteFiles();
+        const write6 = b.addUpdateSourceFiles();
         write6.addBytesToSource(unformatted_code_utf16, fmt6_path);
         write6.step.dependOn(&run5.step);
 


### PR DESCRIPTION
## Feature Explanation

```
  --watch                      Continuously rebuild when source files are modified
  --debounce <ms>              Delay before rebuilding after changed file detected
```

Uses the build system's perfect knowledge of all file system inputs to the pipeline to keep the build runner alive after completion, watching the minimal number of directories in order to trigger re-running only the dirty steps from the graph.

Default debounce time is 50ms but this is configurable. It helps prevent wasted rebuilds when source files are changed in rapid succession, for example when saving with vim it does not do an atomic rename into place but actually deletes the destination file before writing it again, causing a brief period of invalid state, which would cause a build failure without debouncing (it would be followed by a successful build, but it's annoying to experience the temporary build failure regardless).

The purpose of this feature is to reduce latency between editing and debugging in the development cycle. In large projects, the cache system must call `fstat` on a large number of files even when it is a cache hit. File system watching allows more efficient detection of stale pipeline steps.

Mainly this is motivated by incremental compilation landing soon, so that we can keep the compiler running and responding to source code changes as fast as possible. In this case, also keeping the rest of the build pipeline up-to-date is table stakes.

This also paves the road towards #68. A `Run` step combined with `--watch` connects file system updates directly to new code inside an already-running executable. It takes steps closer to more advanced use cases as well:

* IDE plugin running `zig build` as a child process, speaking a compiler protocol (#615) to learn about type information, perform refactors, request rebuilds, receive errors, etc. The protocol will multiplex between an arbitrary number of `Compile` steps, each with a running instance of the compiler.
* An application, compiled in debug mode, speaking the build runner protocol, able to poll on a file descriptor and learn when a hot swap is available, requesting it when it is convenient, or learning about new installed asset updates occurring.

[Run step asciinema demo](https://asciinema.org/a/WBcdJqzWCHPfG1zHFeK1iayQn) This demo only shows 1/2 terminals used, but in the other window I'm editing assembly files with vim and saving them.

[Compile step asciinema demo](https://asciinema.org/a/KAMDdrkh1fmUNOy3myVwGmOO3) - getting quick compile error feedback. Incremental compilation is not done yet, this is full compiler rebuilds, but skipping codegen.

[unit test workflow asciinema demo](https://asciinema.org/a/AApIUJ5nHZmiLjE41oUDueOr5)

## Follow-Up Work

* Windows implementation
* macOS implementation
* other posix implementation
* make --watch handled special with Compile Step, keep compiler running
* make sure compiler_rt and other sub compilations are invalidated properly
* give Run Step a special fd to communicate with build runner
* add `--listen=-` and build runner protocol
* make build runner detect modifications to itself and reexec itself
* audit memory allocations
  - use single-threaded arena for configure phase
  - use thread-safe GPA for make phase and fix leaks
  - use temporary arena for internal make() allocations
* zig build test-cases didn't notice a changed test case
  - because we iterate over the directory at configure time and load file contents at configure time
* improve Run step efficiency by making cache system integrate better with
  Cache.Path, making it avoid filesystem watches when a step dependency edge
  already tracks the dependency
* emit the file_system_inputs message early so that even when the compiler crashes,
  we still know the set of files that trigger recompilation.
* audit all file system watch directories and eliminate cases where
  zig-cache/o/ directories are watched because those are supposed to be handled
  instead by step dependencies. Except, incremental cache mode will mutate
  those artifacts.
  - should we use a different zig-cache subdirectory for incremental artifacts?
