### PR TITLE
Refactor callMain function in start.zig

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -521,7 +521,7 @@ pub inline fn callMain() u8 {
         },
         else => {
             const return_info = @typeInfo(ReturnType);
-            if (comptime std.meta.activeTag(return_info) != .ErrorUnion) @compileError(bad_main_ret);
+            if (return_info != .ErrorUnion) @compileError(bad_main_ret);
 
             switch (return_info.ErrorUnion.payload) {
                 void => {

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -510,7 +510,6 @@ pub inline fn callMain() u8 {
     const main_info = @typeInfo(@TypeOf(root.main)).Fn;
     const ReturnType = main_info.return_type.?;
 
-    // We could return from this switch with a bunch of labeled blocks but that is ugly
     switch (ReturnType) {
         void => {
             root.main();


### PR DESCRIPTION
Improves callMain in start.zig by switching on the main function's return type instead of doing a novemdecillion comparisons on the return type info.