### PR TITLE
Args including and after `--` get passed to build runner directly

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4846,6 +4846,11 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
                     i += 1;
                     child_argv.items[argv_index_seed] = args[i];
                     continue;
+                } else if (mem.eql(u8, arg, "--")) {
+                    // The rest of the args are supposed to get passed onto
+                    // build runner's `build.args`
+                    try child_argv.appendSlice(args[i..]);
+                    break;
                 }
             }
             try child_argv.append(arg);


### PR DESCRIPTION
Resolves #20553 

It's a breaking change since now `zig build --debug-log smth -- arg` and `zig build -- arg --debug-log smth` have different meaning