### PR TITLE
Accept more illegal characters in the lexer, report them in AstGen

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -11243,6 +11243,12 @@ fn appendIdentStr(
     assert(token_tags[token] == .identifier);
     const ident_name = tree.tokenSlice(token);
     if (!mem.startsWith(u8, ident_name, "@")) {
+        for (ident_name, 0..) |c, i| {
+            if (!std.ascii.isAlphanumeric(c) and c != '_') {
+                try astgen.appendErrorTokNotesOff(token, @intCast(i), "regular identifier cannot contain non-ASCII bytes", .{}, &.{});
+                return error.AnalysisFail;
+            }
+        }
         return buf.appendSlice(astgen.gpa, ident_name);
     } else {
         const start = buf.items.len;
@@ -11348,6 +11354,9 @@ fn failWithStrLitError(astgen: *AstGen, err: std.zig.string_literal.Error, token
                 "invalid byte in string or character literal: '{c}'",
                 .{raw_string[bad_index]},
             );
+        },
+        .empty => {
+            return astgen.failOff(token, offset + 1, "empty character literal", .{});
         },
     }
 }

--- a/lib/std/zig/ErrorBundle.zig
+++ b/lib/std/zig/ErrorBundle.zig
@@ -229,7 +229,7 @@ fn renderErrorMessageToWriter(
             try stderr.writeByteNTimes('~', measureLine(line[begin..src.data.column]));
             try stderr.writeByte('^');
             // -1 since span.main includes the caret
-            try stderr.writeByteNTimes('~', measureLine(line[src.data.column..end]) -| 1);
+            try stderr.writeByteNTimes('~', measureLine(line[src.data.column..@min(end, line.len)]) -| 1);
             try stderr.writeByte('\n');
             try ttyconf.setColor(stderr, .reset);
         }
@@ -489,7 +489,7 @@ pub const Wip = struct {
                 }
                 const token_starts = tree.tokens.items(.start);
                 const start = token_starts[item.data.token] + item.data.byte_offset;
-                const end = start + @as(u32, @intCast(tree.tokenSlice(item.data.token).len)) - item.data.byte_offset;
+                const end = token_starts[item.data.token] + @as(u32, @intCast(tree.tokenSlice(item.data.token).len));
                 break :blk std.zig.Ast.Span{ .start = start, .end = end, .main = start };
             };
             const err_loc = std.zig.findLineColumn(source, err_span.main);
@@ -524,7 +524,7 @@ pub const Wip = struct {
                         }
                         const token_starts = tree.tokens.items(.start);
                         const start = token_starts[note_item.data.token] + note_item.data.byte_offset;
-                        const end = start + @as(u32, @intCast(tree.tokenSlice(note_item.data.token).len)) - item.data.byte_offset;
+                        const end = token_starts[note_item.data.token] + @as(u32, @intCast(tree.tokenSlice(note_item.data.token).len));
                         break :blk std.zig.Ast.Span{ .start = start, .end = end, .main = start };
                     };
                     const loc = std.zig.findLineColumn(source, span.main);

--- a/src/Package/Manifest.zig
+++ b/src/Package/Manifest.zig
@@ -558,6 +558,9 @@ const Parse = struct {
                     .{raw_string[bad_index]},
                 );
             },
+            .empty => {
+                try p.appendErrorOff(token, offset + 1, "empty character literal", .{});
+            },
         }
     }
 

--- a/test/cases/compile_errors/invalid_legacy_unicode_escape.zig
+++ b/test/cases/compile_errors/invalid_legacy_unicode_escape.zig
@@ -6,5 +6,4 @@ export fn entry() void {
 // backend=stage2
 // target=native
 //
-// :2:15: error: expected expression, found 'invalid bytes'
-// :2:18: note: invalid byte: '1'
+// :2:17: error: invalid escape character: 'U'

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -43,7 +43,7 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
 
         case.addError("const foo = \\\\\test\r\r rogue carriage return\n;", &[_][]const u8{
             ":1:19: error: expected ';' after declaration",
-            ":1:20: note: invalid byte: '\\r'",
+            ":1:19: note: invalid byte: '\\r'",
         });
     }
 


### PR DESCRIPTION
Closes #12449 and #13809.

Generate `.invalid` tokens only in severe cases (illegal line break or null). This allows us to continue parsing a lot more often, allowing for more and better error messages.

The numeric literals mentioned in #12449 already had this treatment, this commit applies it to char literals and identifiers.

In error messages, count Unicode codepoints to line up the source highlight. Render tabs as four spaces, Zig's default indentation.