### PR TITLE
implement `@expect`

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4800,6 +4800,14 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       {#see_also|@export#}
       {#header_close#}
 
+      {#header_open|@expect#}
+      <pre>{#syntax#}@expect(operand: bool, comptime expected: bool) bool{#endsyntax#}</pre>
+      <p>
+      Informs the optimizer that {#syntax#}operand{#endsyntax#} will likely be {#syntax#}expected{#endsyntax#}, which influences branch compilation to prefer generating the true branch first.
+      </p>
+      {#code|expect_if.zig#}
+      {#header_close#}
+
       {#header_open|@fence#}
       <pre>{#syntax#}@fence(order: AtomicOrder) void{#endsyntax#}</pre>
       <p>

--- a/doc/langref/expect_if.zig
+++ b/doc/langref/expect_if.zig
@@ -1,0 +1,15 @@
+pub fn a(x: u32) void {
+    if (@expect(x == 0, false)) {
+        // condition is branched to at runtime
+        return;
+    } else {
+        // condition check falls through
+        return;
+    }
+}
+
+test "expect" {
+    a(10);
+}
+
+// test

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -2821,6 +2821,7 @@ fn addEnsureResult(gz: *GenZir, maybe_unused_result: Zir.Inst.Ref, statement: As
                 .set_float_mode,
                 .set_align_stack,
                 .set_cold,
+                .expect,
                 => break :b true,
                 else => break :b false,
             },
@@ -9291,7 +9292,14 @@ fn builtinCall(
             });
             return rvalue(gz, ri, .void_value, node);
         },
-
+        .expect => {
+            const val = try gz.addExtendedPayload(.expect, Zir.Inst.BinNode{
+                .node = gz.nodeIndexToRelative(node),
+                .lhs = try expr(gz, scope, .{ .rl = .{ .ty = .bool_type } }, params[0]),
+                .rhs = try expr(gz, scope, .{ .rl = .{ .ty = .bool_type } }, params[1]),
+            });
+            return rvalue(gz, ri, val, node);
+        },
         .src => {
             const token_starts = tree.tokens.items(.start);
             const node_start = token_starts[tree.firstToken(node)];

--- a/lib/std/zig/AstRlAnnotate.zig
+++ b/lib/std/zig/AstRlAnnotate.zig
@@ -1100,5 +1100,10 @@ fn builtinCall(astrl: *AstRlAnnotate, block: ?*Block, ri: ResultInfo, node: Ast.
             _ = try astrl.expr(args[4], block, ResultInfo.type_only);
             return false;
         },
+        .expect => {
+            _ = try astrl.expr(args[0], block, ResultInfo.none);
+            _ = try astrl.expr(args[1], block, ResultInfo.none);
+            return false;
+        },
     }
 }

--- a/lib/std/zig/BuiltinFn.zig
+++ b/lib/std/zig/BuiltinFn.zig
@@ -82,6 +82,7 @@ pub const Tag = enum {
     select,
     set_align_stack,
     set_cold,
+    expect,
     set_eval_branch_quota,
     set_float_mode,
     set_runtime_safety,
@@ -741,6 +742,13 @@ pub const list = list: {
                 .tag = .set_cold,
                 .param_count = 1,
                 .illegal_outside_function = true,
+            },
+        },
+        .{
+            "@expect",
+            .{
+                .tag = .expect,
+                .param_count = 2,
             },
         },
         .{

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -2051,6 +2051,9 @@ pub const Inst = struct {
         /// Guaranteed to not have the `ptr_cast` flag.
         /// Uses the `pl_node` union field with payload `FieldParentPtr`.
         field_parent_ptr,
+        /// Implements the `@expect` builtin.
+        /// `operand` is BinOp
+        expect,
 
         pub const InstData = struct {
             opcode: Extended,

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -318,6 +318,12 @@ typedef char bool;
 #define zig_noreturn
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+#define zig_expect(op, exp) __builtin_expect(op, exp)
+#else
+#define zig_expect(op, exp) (op)
+#endif
+
 #define zig_bitSizeOf(T) (CHAR_BIT * sizeof(T))
 
 #define zig_compiler_rt_abbrev_uint32_t si

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -850,6 +850,10 @@ pub const Inst = struct {
         /// Operand is unused and set to Ref.none
         work_group_id,
 
+        /// Implements @expect builtin.
+        /// Uses the `bin_op` field.
+        expect,
+
         pub fn fromCmpOp(op: std.math.CompareOperator, optimized: bool) Tag {
             switch (op) {
                 .lt => return if (optimized) .cmp_lt_optimized else .cmp_lt,
@@ -1519,6 +1523,8 @@ pub fn typeOfIndex(air: *const Air, inst: Air.Inst.Index, ip: *const InternPool)
         .work_group_id,
         => return Type.u32,
 
+        .expect => return Type.bool,
+
         .inferred_alloc => unreachable,
         .inferred_alloc_comptime => unreachable,
     }
@@ -1636,6 +1642,7 @@ pub fn mustLower(air: Air, inst: Air.Inst.Index, ip: *const InternPool) bool {
         .add_safe,
         .sub_safe,
         .mul_safe,
+        .expect,
         => true,
 
         .add,

--- a/src/Air/types_resolved.zig
+++ b/src/Air/types_resolved.zig
@@ -87,6 +87,7 @@ fn checkBody(air: Air, body: []const Air.Inst.Index, zcu: *Zcu) bool {
             .atomic_store_monotonic,
             .atomic_store_release,
             .atomic_store_seq_cst,
+            .expect,
             => {
                 if (!checkRef(data.bin_op.lhs, zcu)) return false;
                 if (!checkRef(data.bin_op.rhs, zcu)) return false;

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -286,6 +286,7 @@ pub fn categorizeOperand(
         .cmp_gte_optimized,
         .cmp_gt_optimized,
         .cmp_neq_optimized,
+        .expect,
         => {
             const o = air_datas[@intFromEnum(inst)].bin_op;
             if (o.lhs == operand_ref) return matchOperandSmallIndex(l, inst, 0, .none);
@@ -955,6 +956,7 @@ fn analyzeInst(
         .memset,
         .memset_safe,
         .memcpy,
+        .expect,
         => {
             const o = inst_datas[@intFromEnum(inst)].bin_op;
             return analyzeOperands(a, pass, data, inst, .{ o.lhs, o.rhs, .none });

--- a/src/Liveness/Verify.zig
+++ b/src/Liveness/Verify.zig
@@ -257,6 +257,7 @@ fn verifyBody(self: *Verify, body: []const Air.Inst.Index) Error!void {
             .memset,
             .memset_safe,
             .memcpy,
+            .expect,
             => {
                 const bin_op = data[@intFromEnum(inst)].bin_op;
                 try self.verifyInstOperands(inst, .{ bin_op.lhs, bin_op.rhs, .none });

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -3458,6 +3458,7 @@ pub const Feature = enum {
     safety_checked_instructions,
     /// If the backend supports running from another thread.
     separate_thread,
+    can_expect,
 };
 
 pub fn backendSupportsFeature(zcu: Module, comptime feature: Feature) bool {

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -808,6 +808,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .@"try"          => try self.airTry(inst),
             .try_ptr         => try self.airTryPtr(inst),
 
+            .expect => unreachable,
+
             .dbg_stmt         => try self.airDbgStmt(inst),
             .dbg_inline_block => try self.airDbgInlineBlock(inst),
             .dbg_var_ptr,

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -847,6 +847,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .wrap_errunion_payload => try self.airWrapErrUnionPayload(inst),
             .wrap_errunion_err     => try self.airWrapErrUnionErr(inst),
 
+            .expect => unreachable,
+
             .add_optimized,
             .sub_optimized,
             .mul_optimized,

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1378,6 +1378,8 @@ fn genBody(func: *Func, body: []const Air.Inst.Index) InnerError!void {
             .@"try"          =>  try func.airTry(inst),
             .try_ptr         =>  return func.fail("TODO: try_ptr", .{}),
 
+            .expect => unreachable,
+
             .dbg_var_ptr,
             .dbg_var_val,
             => try func.airDbgVar(inst),

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -641,6 +641,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .@"try"          => try self.airTry(inst),
             .try_ptr         => @panic("TODO try self.airTryPtr(inst)"),
 
+            .expect => unreachable,
+
             .dbg_stmt         => try self.airDbgStmt(inst),
             .dbg_inline_block => try self.airDbgInlineBlock(inst),
             .dbg_var_ptr,

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -2027,6 +2027,8 @@ fn genInst(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         .c_va_start,
         => |tag| return func.fail("TODO: Implement wasm inst: {s}", .{@tagName(tag)}),
 
+        .expect => unreachable,
+
         .atomic_load => func.airAtomicLoad(inst),
         .atomic_store_unordered,
         .atomic_store_monotonic,

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -2020,6 +2020,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
 
             .abs => try self.airAbs(inst),
 
+            .expect => unreachable,
+
             .add_with_overflow => try self.airAddSubWithOverflow(inst),
             .sub_with_overflow => try self.airAddSubWithOverflow(inst),
             .mul_with_overflow => try self.airMulWithOverflow(inst),

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -3266,6 +3266,8 @@ fn genBodyInner(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail,
 
             .@"try"  => try airTry(f, inst),
             .try_ptr => try airTryPtr(f, inst),
+            
+            .expect => try airExpect(f, inst),
 
             .dbg_stmt => try airDbgStmt(f, inst),
             .dbg_inline_block => try airDbgInlineBlock(f, inst),
@@ -4645,6 +4647,27 @@ fn airTryPtr(f: *Function, inst: Air.Inst.Index) !CValue {
     const body: []const Air.Inst.Index = @ptrCast(f.air.extra[extra.end..][0..extra.data.body_len]);
     const err_union_ty = f.typeOf(extra.data.ptr).childType(zcu);
     return lowerTry(f, inst, extra.data.ptr, body, err_union_ty, true);
+}
+
+fn airExpect(f: *Function, inst: Air.Inst.Index) !CValue {
+    const bin_op = f.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
+    const operand = try f.resolveInst(bin_op.lhs);
+    const expected = try f.resolveInst(bin_op.rhs);
+
+    const writer = f.object.writer();
+    const local = try f.allocLocal(inst, Type.bool);
+    const a = try Assignment.start(f, writer, CType.bool);
+    try f.writeCValue(writer, local, .Other);
+    try a.assign(f, writer);
+
+    try writer.writeAll("zig_expect(");
+    try f.writeCValue(writer, operand, .FunctionArgument);
+    try writer.writeAll(", ");
+    try f.writeCValue(writer, expected, .FunctionArgument);
+    try writer.writeAll(")");
+
+    try a.end(f, writer);
+    return local;
 }
 
 fn lowerTry(

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -5034,6 +5034,8 @@ pub const FuncGen = struct {
                 .slice_ptr      => try self.airSliceField(inst, 0),
                 .slice_len      => try self.airSliceField(inst, 1),
 
+                .expect => try self.airExpect(inst),
+
                 .call              => try self.airCall(inst, .auto),
                 .call_always_tail  => try self.airCall(inst, .always_tail),
                 .call_never_tail   => try self.airCall(inst, .never_tail),
@@ -6368,6 +6370,27 @@ pub const FuncGen = struct {
         if (libc_ret_ty != ret_ty) result = try self.wip.cast(.bitcast, result, ret_ty, "");
         if (ret_ty != dest_llvm_ty) result = try self.wip.cast(.trunc, result, dest_llvm_ty, "");
         return result;
+    }
+
+    // Note that the LowerExpectPass only runs in Release modes
+    fn airExpect(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
+        assert(self.dg.ownerModule().optimize_mode != .Debug);
+        const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
+
+        const operand = try self.resolveInst(bin_op.lhs);
+        const expected = try self.resolveInst(bin_op.rhs);
+
+        return try self.wip.callIntrinsic(
+            .normal,
+            .none,
+            .expect,
+            &.{operand.typeOfWip(&self.wip)},
+            &.{
+                operand,
+                expected,
+            },
+            "",
+        );
     }
 
     fn sliceOrArrayPtr(fg: *FuncGen, ptr: Builder.Value, ty: Type) Allocator.Error!Builder.Value {

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -162,6 +162,7 @@ const Writer = struct {
             .memcpy,
             .memset,
             .memset_safe,
+            .expect,
             => try w.writeBinOp(s, inst),
 
             .is_null,

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -597,6 +597,7 @@ const Writer = struct {
             .wasm_memory_grow,
             .prefetch,
             .c_va_arg,
+            .expect,
             => {
                 const inst_data = self.code.extraData(Zir.Inst.BinNode, extended.operand).data;
                 try self.writeInstRef(stream, inst_data.lhs);

--- a/src/target.zig
+++ b/src/target.zig
@@ -574,5 +574,9 @@ pub inline fn backendSupportsFeature(backend: std.builtin.CompilerBackend, compt
         .separate_thread => switch (backend) {
             else => false,
         },
+        .can_expect => switch (backend) {
+            .stage2_c, .stage2_llvm => true,
+            else => false,
+        },
     };
 }

--- a/test/behavior/expect.zig
+++ b/test/behavior/expect.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const expect = std.testing.expect;
+
+test "@expect if-statement" {
+    const x: u32 = 10;
+    _ = &x;
+    if (@expect(x == 20, true)) {}
+}
+
+test "@expect runtime if-statement" {
+    var x: u32 = 10;
+    var y: u32 = 20;
+    _ = &x;
+    _ = &y;
+    if (@expect(x != y, false)) {}
+}
+
+test "@expect bool input/output" {
+    const b: bool = true;
+    try expect(@TypeOf(@expect(b, false)) == bool);
+}
+
+test "@expect bool is transitive" {
+    const a: bool = true;
+    const b = @expect(a, false);
+
+    const c = @intFromBool(!b);
+    std.mem.doNotOptimizeAway(c);
+
+    try expect(c == 0);
+    try expect(@expect(c != 0, false) == false);
+}
+
+test "@expect at comptime" {
+    const a: bool = true;
+    comptime try expect(@expect(a, true) == true);
+}

--- a/test/cases/compile_errors/@expect_non_bool.zig
+++ b/test/cases/compile_errors/@expect_non_bool.zig
@@ -1,0 +1,11 @@
+export fn a() void {
+    var x: u32 = 10;
+    _ = &x;
+    _ = @expect(x, true);
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:17: error: expected type 'bool', found 'u32'


### PR DESCRIPTION
closes #489 

---

### Why this implementation differs from the approved language proposal

#### Why it takes a bool
The `@expect` built-in affects the generation of branching control flow and you can only branch on a bool. To branch on any other value requires an existing comparison. The built-in expect from C, `built_expect`, compares two values producing a bool to the same effect as `@expect(x == y, true)`.

#### Why it doesn't have a probability
Probabilities/weights serve to re-arrange multiple branches such as a switch statement. However, there's no way to predict branching codegen in a switch control flow use case. The most likely branch could be a fallthrough, but it could also be a jump table. Only single target branches guarantee predictable branching (`if`, `while`, etc.).

---

### Testing

The `@expect` built-in should always be transitive and have no semantic effect on the condition. The tests added for the built-in include these transitive properties. A compile-error test ensures the required result type of the built-in is always a `bool`.

---

### What does it do?

This built-in is useful in code where an unwanted branch can be bad for performance. A useful example is hashing, memcpy, and similarly i-cache-sensitive applications.

The `if`'s `true` branch usually falls through, but it's not guaranteed. The `@expect` built-in can be used to guarantee this.

Here is a comparison of the function `foo`:
```zig
export fn foo(arg: *u32) u32 {
    if (@expect(arg.* == 10, true)) {
        arg.* = 10;
        return 0;
    } else {
        return arg.*;
    }
}
```
where one has `@expect` set to true, and the other has it set to false.

`true`:
```asm
; 0000000000000000 <foo>:
;     if (@expect(arg.* == 10, true)) {
       movl    (%rdi), %eax
       cmpl    $0xa, %eax
       jne    0xf <foo+0xf>
       xorl    %eax, %eax
;         arg.* = 10;
       movl    $0xa, (%rdi)
       retq
```

`false`:
```asm
; 0000000000000000 <foo>:
;     if (@expect(arg.* == 10, false)) {
       movl    (%rdi), %eax
       cmpl    $0xa, %eax
       je    0x8 <foo+0x8>
       retq
       xorl    %eax, %eax
;         arg.* = 10;
       movl    $0xa, (%rdi)
       retq
```

you can see that LLVM has generated the branch such that it falls through the jump when it's `true` or `false` respectively.

---

### Real-world use-case

A real-world example of this built-in is in implementing a better `@memcpy`. The current compiler-rt implementation isn't as fast as it could be and produces varying results. Facebook has an open-source library called "Folly," and inside there is a very fast and clean memcpy that also doubles as a memmove. They have done the tough part of figuring out an optimal branching tree, however, it is currently very hard to guarantee this in Zig. Given that the order of the branches is crucial to the performance of the implementation, we need the `@expect` built-in to influence the codegen.

Here I've implemented Folly's memcpy in Zig using the `@expect` builtin:
https://gist.github.com/Rexicon226/80048f4ccd68d0e5fce927bbbad44226

A couple of unique things to note about the usages of `@expect` here.

First, you might notice that almost every `@expect` usage is false. This is because we try to write if statements as if they are branches, not as if they are fallthroughs. It's easier to see the code flow that way and makes it easier to understand where potential branching costs could happen.

Second, there is a special part of the code that we still cannot fully emulate. This branch from the original implementation:
https://github.com/facebook/folly/blob/2d9c0a3c720238ae2ef1337348b6a72778024961/folly/memcpy.S#L131-L178

is almost possible to implement. Without the `@expect` built-in this might be possible using switch continues (#8220), however I'm not sure.

```asm
; check for len > 256, expected to be false so the case jumps away
cmp     rdx, 0x100
ja      <sinon_memcpy+0x10a>

; first 2 32-byte chunks are loaded
vmovups ymm2, ymmword ptr [rsi]
vmovups ymm0, ymmword ptr [rsi + rdx - 0x20]

; we expect the length being <= $64 here to be false, so the case jumps away
cmp     rdx, 0x41
jb      .FINAL_64

; the pattern continues here, all nicely generated from an inline for loop
vmovups ymm3, ymmword ptr [rsi + 0x20]
vmovups ymm1, ymmword ptr [rsi + rdx - 0x40]
cmp     rdx, 0x80
jbe     .FINAL_128

vmovups ymm5, ymmword ptr [rsi + 0x40]
vmovups ymm4, ymmword ptr [rsi + rdx - 0x60]
cmp     rdx, 0xc0
jbe     .FINAL_192
; ...

; the $64 case jumps to here, and finalizes the loads with these stores and returns
.FINAL_64:
vmovups ymmword ptr [rax], ymm2
vmovups ymmword ptr [rax + rdx - 0x20], ymm0
vzeroupper
ret

; the $128 case jumps to here and does a more stores to finialize the 2 pairs of loads
; that would have happened before the branch to here
.FINAL_128:
vmovups ymmword ptr [rax], ymm2
vmovups ymmword ptr [rax + rdx - 0x20], ymm0
vmovups ymmword ptr [rax + 0x20], ymm3
vmovups ymmword ptr [rax + rdx - 0x40], ymm1
vzeroupper
ret

.FINAL_192:
vmovups ymmword ptr [rax], ymm2
vmovups ymmword ptr [rax + rdx - 0x20], ymm0
vmovups ymmword ptr [rax + 0x20], ymm3
vmovups ymmword ptr [rax + rdx - 0x40], ymm1
vmovups ymmword ptr [rax + 0x40], ymm5
vmovups ymmword ptr [rax + rdx - 0x60], ymm4
vzeroupper
ret
 ```

you can see that LLVM doesn't see that it's generating the same stores 3 times, where it could have generated it a single time and simply jumped to different parts of the fallthrough tree.

In conclusion, the `@expect` built-in was crucial to porting this implementation and provided positive results in relation to the current `@memcpy` implementation.
