### PR TITLE
`ArgIteratorWindows`: Cleanup and some optimizations

### DIFF
--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -161,9 +161,6 @@ pub extern "kernel32" fn FormatMessageW(dwFlags: DWORD, lpSource: ?LPVOID, dwMes
 
 pub extern "kernel32" fn FreeEnvironmentStringsW(penv: [*:0]u16) callconv(WINAPI) BOOL;
 
-pub extern "kernel32" fn GetCommandLineA() callconv(WINAPI) LPSTR;
-pub extern "kernel32" fn GetCommandLineW() callconv(WINAPI) LPWSTR;
-
 pub extern "kernel32" fn GetConsoleMode(in_hConsoleHandle: HANDLE, out_lpMode: *DWORD) callconv(WINAPI) BOOL;
 pub extern "kernel32" fn SetConsoleMode(in_hConsoleHandle: HANDLE, in_dwMode: DWORD) callconv(WINAPI) BOOL;
 

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -683,10 +683,12 @@ pub const ArgIteratorWindows = struct {
         const wtf8_len = unicode.calcWtf8Len(cmd_line);
 
         // This buffer must be large enough to contain contiguous NUL-terminated slices
-        // of each argument. For arguments past the first one, space for the NUL-terminator
-        // is guaranteed due to the necessary whitespace between arugments. However, we need
-        // one extra byte to guarantee enough room for the NUL terminator if the command line
-        // ends up being exactly 1 argument long with no quotes, etc.
+        // of each argument.
+        // - During parsing, the length of a parsed argument will always be equal to
+        //   to less than its unparsed length
+        // - The first argument needs one extra byte of space allocated for its NUL
+        //   terminator, but for each subsequent argument the necessary whitespace
+        //   between arguments guarantees room for their NUL terminator(s).
         const buffer = try allocator.alloc(u8, wtf8_len + 1);
         errdefer allocator.free(buffer);
 

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -717,14 +717,20 @@ pub const ArgIteratorWindows = struct {
 
         const eof = null;
 
-        fn emitBackslashes(self: *ArgIteratorWindows, count: usize) void {
-            for (0..count) |_| emitCharacter(self, '\\');
+        /// Returns '\' if any backslashes are emitted, otherwise returns `last_emitted_code_unit`.
+        fn emitBackslashes(self: *ArgIteratorWindows, count: usize, last_emitted_code_unit: ?u16) ?u16 {
+            for (0..count) |_| {
+                self.buffer[self.end] = '\\';
+                self.end += 1;
+            }
+            return if (count != 0) '\\' else last_emitted_code_unit;
         }
 
-        fn emitCharacter(self: *ArgIteratorWindows, code_unit: u16) void {
-            const wtf8_len = std.unicode.wtf8Encode(code_unit, self.buffer[self.end..]) catch unreachable;
-            self.end += wtf8_len;
-
+        /// If `last_emitted_code_unit` and `code_unit` form a surrogate pair, then
+        /// the previously emitted high surrogate is overwritten by the codepoint encoded
+        /// by the surrogate pair, and `null` is returned.
+        /// Otherwise, `code_unit` is emitted and returned.
+        fn emitCharacter(self: *ArgIteratorWindows, code_unit: u16, last_emitted_code_unit: ?u16) ?u16 {
             // Because we are emitting WTF-8, we need to
             // check to see if we've emitted two consecutive surrogate
             // codepoints that form a valid surrogate pair in order
@@ -745,28 +751,24 @@ pub const ArgIteratorWindows = struct {
             // and emit the codepoint it encodes, which in this
             // example is U+10437 (𐐷), which is encoded in UTF-8 as:
             // <0xF0><0x90><0x90><0xB7>
-            concatSurrogatePair(self);
-        }
+            if (last_emitted_code_unit != null and
+                std.unicode.utf16IsLowSurrogate(code_unit) and
+                std.unicode.utf16IsHighSurrogate(last_emitted_code_unit.?))
+            {
+                const codepoint = std.unicode.utf16DecodeSurrogatePair(&.{ last_emitted_code_unit.?, code_unit }) catch unreachable;
 
-        fn concatSurrogatePair(self: *ArgIteratorWindows) void {
-            // Surrogate codepoints are always encoded as 3 bytes, so there
-            // must be 6 bytes for a surrogate pair to exist.
-            if (self.end - self.start >= 6) {
-                const window = self.buffer[self.end - 6 .. self.end];
-                const view = unicode.Wtf8View.init(window) catch return;
-                var it = view.iterator();
-                var pair: [2]u16 = undefined;
-                pair[0] = std.mem.nativeToLittle(u16, std.math.cast(u16, it.nextCodepoint().?) orelse return);
-                if (!unicode.utf16IsHighSurrogate(std.mem.littleToNative(u16, pair[0]))) return;
-                pair[1] = std.mem.nativeToLittle(u16, std.math.cast(u16, it.nextCodepoint().?) orelse return);
-                if (!unicode.utf16IsLowSurrogate(std.mem.littleToNative(u16, pair[1]))) return;
-                // We know we have a valid surrogate pair, so convert
-                // it to UTF-8, overwriting the surrogate pair's bytes
-                // and then chop off the extra bytes.
-                const len = unicode.utf16LeToUtf8(window, &pair) catch unreachable;
-                const delta = 6 - len;
-                self.end -= delta;
+                // Unpaired surrogate is 3 bytes long
+                const dest = self.buffer[self.end - 3 ..];
+                const len = unicode.utf8Encode(codepoint, dest) catch unreachable;
+                // All codepoints that require a surrogate pair (> U+FFFF) are encoded as 4 bytes
+                assert(len == 4);
+                self.end += 1;
+                return null;
             }
+
+            const wtf8_len = std.unicode.wtf8Encode(code_unit, self.buffer[self.end..]) catch unreachable;
+            self.end += wtf8_len;
+            return code_unit;
         }
 
         fn yieldArg(self: *ArgIteratorWindows) [:0]const u8 {
@@ -783,9 +785,13 @@ pub const ArgIteratorWindows = struct {
 
         const eof = false;
 
-        fn emitBackslashes(_: *ArgIteratorWindows, _: usize) void {}
+        fn emitBackslashes(_: *ArgIteratorWindows, _: usize, last_emitted_code_unit: ?u16) ?u16 {
+            return last_emitted_code_unit;
+        }
 
-        fn emitCharacter(_: *ArgIteratorWindows, _: u16) void {}
+        fn emitCharacter(_: *ArgIteratorWindows, _: u16, last_emitted_code_unit: ?u16) ?u16 {
+            return last_emitted_code_unit;
+        }
 
         fn yieldArg(_: *ArgIteratorWindows) bool {
             return true;
@@ -793,6 +799,7 @@ pub const ArgIteratorWindows = struct {
     };
 
     fn nextWithStrategy(self: *ArgIteratorWindows, comptime strategy: type) strategy.T {
+        var last_emitted_code_unit: ?u16 = null;
         // The first argument (the executable name) uses different parsing rules.
         if (self.index == 0) {
             if (self.cmd_line.len == 0 or self.cmd_line[0] == 0) {
@@ -815,15 +822,15 @@ pub const ArgIteratorWindows = struct {
                         inside_quotes = !inside_quotes;
                     },
                     ' ', '\t' => {
-                        if (inside_quotes)
-                            strategy.emitCharacter(self, char)
-                        else {
+                        if (inside_quotes) {
+                            last_emitted_code_unit = strategy.emitCharacter(self, char, last_emitted_code_unit);
+                        } else {
                             self.index += 1;
                             return strategy.yieldArg(self);
                         }
                     },
                     else => {
-                        strategy.emitCharacter(self, char);
+                        last_emitted_code_unit = strategy.emitCharacter(self, char, last_emitted_code_unit);
                     },
                 }
             }
@@ -861,29 +868,28 @@ pub const ArgIteratorWindows = struct {
                 0;
             switch (char) {
                 0 => {
-                    strategy.emitBackslashes(self, backslash_count);
+                    last_emitted_code_unit = strategy.emitBackslashes(self, backslash_count, last_emitted_code_unit);
                     return strategy.yieldArg(self);
                 },
                 ' ', '\t' => {
-                    strategy.emitBackslashes(self, backslash_count);
+                    last_emitted_code_unit = strategy.emitBackslashes(self, backslash_count, last_emitted_code_unit);
                     backslash_count = 0;
-                    if (inside_quotes)
-                        strategy.emitCharacter(self, char)
-                    else
-                        return strategy.yieldArg(self);
+                    if (inside_quotes) {
+                        last_emitted_code_unit = strategy.emitCharacter(self, char, last_emitted_code_unit);
+                    } else return strategy.yieldArg(self);
                 },
                 '"' => {
                     const char_is_escaped_quote = backslash_count % 2 != 0;
-                    strategy.emitBackslashes(self, backslash_count / 2);
+                    last_emitted_code_unit = strategy.emitBackslashes(self, backslash_count / 2, last_emitted_code_unit);
                     backslash_count = 0;
                     if (char_is_escaped_quote) {
-                        strategy.emitCharacter(self, '"');
+                        last_emitted_code_unit = strategy.emitCharacter(self, '"', last_emitted_code_unit);
                     } else {
                         if (inside_quotes and
                             self.index + 1 != self.cmd_line.len and
                             mem.littleToNative(u16, self.cmd_line[self.index + 1]) == '"')
                         {
-                            strategy.emitCharacter(self, '"');
+                            last_emitted_code_unit = strategy.emitCharacter(self, '"', last_emitted_code_unit);
                             self.index += 1;
                         } else {
                             inside_quotes = !inside_quotes;
@@ -894,9 +900,9 @@ pub const ArgIteratorWindows = struct {
                     backslash_count += 1;
                 },
                 else => {
-                    strategy.emitBackslashes(self, backslash_count);
+                    last_emitted_code_unit = strategy.emitBackslashes(self, backslash_count, last_emitted_code_unit);
                     backslash_count = 0;
-                    strategy.emitCharacter(self, char);
+                    last_emitted_code_unit = strategy.emitCharacter(self, char, last_emitted_code_unit);
                 },
             }
         }

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1150,8 +1150,9 @@ pub const ArgIterator = struct {
             return ArgIterator{ .inner = try InnerType.init(allocator) };
         }
         if (native_os == .windows) {
-            const cmd_line_w = windows.kernel32.GetCommandLineW();
-            return ArgIterator{ .inner = try InnerType.init(allocator, cmd_line_w) };
+            const cmd_line = std.os.windows.peb().ProcessParameters.CommandLine;
+            const cmd_line_w = cmd_line.Buffer.?[0 .. cmd_line.Length / 2 :0];
+            return ArgIterator{ .inner = try InnerType.init(allocator, cmd_line_w.ptr) };
         }
 
         return ArgIterator{ .inner = InnerType.init() };


### PR DESCRIPTION
Follow up to some comments made in #20592 (cc @T-727 and @castholm)

The main changes here are:

- More efficient method of ensuring well-formed WTF-8 output in `ArgIteratorWindows`
- Removal of `GetCommandLineW` call (and removal of the `std.os.windows.kernel32.GetCommandLineW` binding since it's no longer used anywhere)
- `[*:0]const u16` -> `[]const u16` in `ArgIteratorWindows.init` and therefore a removal of a `sliceTo` call

Details for each are in the commit messages, but here's some additional benchmarking info:

> [!NOTE]
> Don't take these benchmarks too seriously, they are not even close to emulating real-world scenarios, especially since they test generated command lines with (way) more than the maximum number of code units allowed by `CreateProcess` (32,766 technically due to the `UNICODE_STRING` struct, but practically the limit might be 8191 due to `cmd.exe` limitations)

<details>
<summary>Benchmark code</summary>

```zig
const std = @import("std");
const Allocator = std.mem.Allocator;

pub fn main() !void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    defer std.debug.assert(gpa.deinit() == .ok);
    const allocator = gpa.allocator();

    var random = std.Random.DefaultPrng.init(0x1234);
    const rand = random.random();

    for (&[_]usize{ 100, 1_000, 10_000, 100_000, 1_000_000 }) |len| {
        const cmd_line_w = try randomCommandLineW(allocator, rand, len);
        defer allocator.free(cmd_line_w);

        var timer = try std.time.Timer.start();

        var it = try std.process.ArgIteratorWindows.init(allocator, cmd_line_w);
        defer it.deinit();

        var count: usize = 0;
        while (it.next()) |arg| {
            std.mem.doNotOptimizeAway(&arg);
            count += 1;
        }

        const elapsed_ns = timer.read();
        std.debug.print("len={}: took {}, arg count: {}\n", .{ len, std.fmt.fmtDuration(elapsed_ns), count });
    }
}

fn randomCommandLineW(allocator: Allocator, rand: std.Random, choices_len: usize) ![:0]const u16 {
    const Choice = enum {
        backslash,
        quote,
        space,
        tab,
        control_except_null,
        printable,
        non_ascii,
        unpaired_surrogate,
        surrogate_pair,
    };

    var buf = try std.ArrayList(u16).initCapacity(allocator, choices_len);
    errdefer buf.deinit();

    // Prepend some valid stuff so that argv[0] doesn't end up empty which
    // halts parsing
    const start_with_quote = rand.boolean();
    if (start_with_quote) try buf.append('"');
    try buf.append('z');

    for (0..choices_len) |_| {
        const choice = rand.enumValue(Choice);
        const code_unit = switch (choice) {
            .backslash => '\\',
            .quote => '"',
            .space => ' ',
            .tab => '\t',
            .control_except_null => switch (rand.uintAtMostBiased(u8, 0x20)) {
                0x00 => '\x7F',
                else => |b| b + 1,
            },
            .printable => '!' + rand.uintAtMostBiased(u8, '~' - '!'),
            .non_ascii => rand.intRangeAtMostBiased(u16, 0x80, 0xFFFF),
            .unpaired_surrogate => rand.intRangeAtMostBiased(u16, 0xD800, 0xDFFF),
            .surrogate_pair => low_surrogate: {
                const high_surrogate = rand.intRangeAtMostBiased(u16, 0xD800, 0xDBFF);
                try buf.append(std.mem.nativeToLittle(u16, high_surrogate));
                break :low_surrogate rand.intRangeAtMostBiased(u16, 0xDC00, 0xDFFF);
            },
        };
        try buf.append(std.mem.nativeToLittle(u16, code_unit));
    }

    return buf.toOwnedSliceSentinel(0);
}
```

</details>

---

Benchmarks only up to the 'store the last emitted code unit' commit

- `-master` is master branch with #20592 included
- `-storelast` is with the 'store last emitted code unit' commit applied
- `-onlylow` is using an alternate optimization where the previous lookback strategy is kept, but only used when emitting a low surrogate (see the 'store last emitted code unit' commit message for details)
- `-pre20592` is a pre-#20592 benchmark, included to give a better idea of the effects of that PR

```
Benchmark 1 (111 runs): benchargv-master.exe
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          45.2ms ±  532us    44.5ms … 49.4ms          2 ( 2%)        0%
  peak_rss           6.49MB ± 3.94KB    6.46MB … 6.49MB         10 ( 9%)        0%
Benchmark 2 (154 runs): benchargv-storelast.exe
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          32.6ms ±  293us    32.2ms … 34.2ms          8 ( 5%)        ⚡- 27.8% ±  0.2%
  peak_rss           6.49MB ± 5.15KB    6.46MB … 6.49MB         15 (10%)          -  0.0% ±  0.0%
Benchmark 3 (131 runs): benchargv-onlylow.exe
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          38.4ms ±  257us    37.9ms … 39.6ms          5 ( 4%)        ⚡- 15.1% ±  0.2%
  peak_rss           6.49MB ± 5.70KB    6.46MB … 6.49MB          9 ( 7%)          -  0.0% ±  0.0%
Benchmark 4 (109 runs): benchargv-pre20592.exe
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          45.9ms ±  397us    45.2ms … 47.9ms          2 ( 2%)        💩+  1.6% ±  0.3%
  peak_rss           8.10MB ± 1.13KB    8.09MB … 8.10MB          9 ( 8%)        💩+ 24.7% ±  0.0%
```

---

Benchmark comparing the 'store the last emitted code unit' commit to the HEAD of this branch (this shows the effect of the `sliceTo` call removal):

```
Benchmark 1 (153 runs): benchargv-storelast.exe
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          32.7ms ±  429us    32.1ms … 36.9ms          1 ( 1%)        0%
  peak_rss           6.49MB ± 5.62KB    6.46MB … 6.49MB         14 ( 9%)        0%
Benchmark 2 (157 runs): benchargv-peb.exe
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          31.9ms ±  236us    31.4ms … 32.7ms          4 ( 3%)        ⚡-  2.4% ±  0.2%
  peak_rss           6.49MB ± 4.77KB    6.46MB … 6.49MB         14 ( 9%)          +  0.0% ±  0.0%
```

EDIT: I previously had an additional 'removal of GetCommandLineW call only' benchmark here but have now realized it wasn't actually benchmarking anything, since the benchmark uses a generated command line. Whoops.

---

Benchmark comparing `master` to the HEAD of this branch:

```
Benchmark 1 (111 runs): benchargv-master.exe
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          45.3ms ±  354us    44.6ms … 47.2ms          2 ( 2%)        0%
  peak_rss           6.49MB ± 3.91KB    6.46MB … 6.49MB          8 ( 7%)        0%
Benchmark 2 (157 runs): benchargv-branch.exe
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          32.0ms ±  260us    31.5ms … 34.0ms          3 ( 2%)        ⚡- 29.3% ±  0.2%
  peak_rss           6.49MB ± 18.8KB    6.46MB … 6.72MB         12 ( 8%)          +  0.0% ±  0.1%
```

Benchmark output to show that the parsed arg count is the same before and after:

```shellsession
> benchargv-master.exe
len=100: took 10.5us, arg count: 10
len=1000: took 36us, arg count: 97
len=10000: took 305us, arg count: 922
len=100000: took 2.884ms, arg count: 8817
len=1000000: took 27.829ms, arg count: 88056

> benchargv-branch.exe
len=100: took 8us, arg count: 10
len=1000: took 24.7us, arg count: 97
len=10000: took 201.7us, arg count: 922
len=100000: took 1.887ms, arg count: 8817
len=1000000: took 15.811ms, arg count: 88056
```