### PR TITLE
Better implementation of GetLastError.

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -554,7 +554,7 @@ const WindowsThreadImpl = struct {
             0,
             null,
         ) orelse {
-            const errno = windows.kernel32.GetLastError();
+            const errno = windows.GetLastError();
             return windows.unexpectedError(errno);
         };
 

--- a/lib/std/Thread/Condition.zig
+++ b/lib/std/Thread/Condition.zig
@@ -178,7 +178,7 @@ const WindowsImpl = struct {
 
         // Return error.Timeout if we know the timeout elapsed correctly.
         if (rc == os.windows.FALSE) {
-            assert(os.windows.kernel32.GetLastError() == .TIMEOUT);
+            assert(os.windows.GetLastError() == .TIMEOUT);
             if (!timeout_overflowed) return error.Timeout;
         }
     }

--- a/lib/std/crypto/Certificate/Bundle.zig
+++ b/lib/std/crypto/Certificate/Bundle.zig
@@ -132,7 +132,7 @@ fn rescanWindows(cb: *Bundle, gpa: Allocator) RescanWindowsError!void {
     cb.map.clearRetainingCapacity();
 
     const w = std.os.windows;
-    const GetLastError = w.kernel32.GetLastError;
+    const GetLastError = w.GetLastError;
     const root = [4:0]u16{ 'R', 'O', 'O', 'T' };
     const store = w.crypt32.CertOpenSystemStoreW(null, &root) orelse switch (GetLastError()) {
         .FILE_NOT_FOUND => return error.FileNotFound,

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1781,7 +1781,7 @@ pub const DebugInfo = struct {
 
             const handle = windows.kernel32.CreateToolhelp32Snapshot(windows.TH32CS_SNAPMODULE | windows.TH32CS_SNAPMODULE32, 0);
             if (handle == windows.INVALID_HANDLE_VALUE) {
-                switch (windows.kernel32.GetLastError()) {
+                switch (windows.GetLastError()) {
                     else => |err| return windows.unexpectedError(err),
                 }
             }

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -567,7 +567,7 @@ pub fn Poller(comptime StreamEnum: type) type {
                         windows.INFINITE,
                 );
                 if (status == windows.WAIT_FAILED)
-                    return windows.unexpectedError(windows.kernel32.GetLastError());
+                    return windows.unexpectedError(windows.GetLastError());
                 if (status == windows.WAIT_TIMEOUT)
                     return true;
 
@@ -584,7 +584,7 @@ pub fn Poller(comptime StreamEnum: type) type {
                     &self.windows.overlapped[stream_idx],
                     &read_bytes,
                     0,
-                )) switch (windows.kernel32.GetLastError()) {
+                )) switch (windows.GetLastError()) {
                     .BROKEN_PIPE => {
                         self.windows.active.removeAt(active_idx);
                         continue;
@@ -664,7 +664,7 @@ fn windowsAsyncRead(
         const buf = try fifo.writableWithSize(bump_amt);
         var read_bytes: u32 = undefined;
         const read_result = windows.kernel32.ReadFile(handle, buf.ptr, math.cast(u32, buf.len) orelse math.maxInt(u32), &read_bytes, overlapped);
-        if (read_result == 0) return switch (windows.kernel32.GetLastError()) {
+        if (read_result == 0) return switch (windows.GetLastError()) {
             .IO_PENDING => .pending,
             .BROKEN_PIPE => .closed,
             else => |err| windows.unexpectedError(err),

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -61,7 +61,7 @@ pub fn accessW(path: [*:0]const u16) windows.GetFileAttributesError!void {
     if (ret != windows.INVALID_FILE_ATTRIBUTES) {
         return;
     }
-    switch (windows.kernel32.GetLastError()) {
+    switch (windows.GetLastError()) {
         .FILE_NOT_FOUND => return error.FileNotFound,
         .PATH_NOT_FOUND => return error.FileNotFound,
         .ACCESS_DENIED => return error.PermissionDenied,

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -172,6 +172,17 @@ pub fn GetCurrentThreadId() DWORD {
     return @truncate(@intFromPtr(teb().ClientId.UniqueThread));
 }
 
+pub fn GetLastError() Win32Error {
+    const offset = comptime switch (builtin.target.ptrBitWidth()) {
+        32 => 0x34,
+        64 => 0x68,
+        else => @compileError("Unkown target."),
+    };
+    const addr = @intFromPtr(teb());
+    const ptr: *const u32 = @ptrFromInt(addr + offset);
+    return @enumFromInt(ptr.*);
+}
+
 pub const CreatePipeError = error{ Unexpected, SystemResources };
 
 var npfs: ?HANDLE = null;
@@ -309,7 +320,7 @@ pub fn CreateEventExW(attributes: ?*SECURITY_ATTRIBUTES, nameW: ?LPCWSTR, flags:
     if (handle) |h| {
         return h;
     } else {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     }
@@ -385,7 +396,7 @@ pub fn DeviceIoControl(
 pub fn GetOverlappedResult(h: HANDLE, overlapped: *OVERLAPPED, wait: bool) !DWORD {
     var bytes: DWORD = undefined;
     if (kernel32.GetOverlappedResult(h, overlapped, &bytes, @intFromBool(wait)) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .IO_INCOMPLETE => if (!wait) return error.WouldBlock else unreachable,
             else => |err| return unexpectedError(err),
         }
@@ -397,7 +408,7 @@ pub const SetHandleInformationError = error{Unexpected};
 
 pub fn SetHandleInformation(h: HANDLE, mask: DWORD, flags: DWORD) SetHandleInformationError!void {
     if (kernel32.SetHandleInformation(h, mask, flags) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     }
@@ -417,7 +428,7 @@ pub fn RtlGenRandom(output: []u8) RtlGenRandomError!void {
         const to_read: ULONG = @min(buff.len, max_read_size);
 
         if (advapi32.RtlGenRandom(buff.ptr, to_read) == 0) {
-            return unexpectedError(kernel32.GetLastError());
+            return unexpectedError(GetLastError());
         }
 
         total_read += to_read;
@@ -440,7 +451,7 @@ pub fn WaitForSingleObjectEx(handle: HANDLE, milliseconds: DWORD, alertable: boo
         WAIT_ABANDONED => return error.WaitAbandoned,
         WAIT_OBJECT_0 => return,
         WAIT_TIMEOUT => return error.WaitTimeOut,
-        WAIT_FAILED => switch (kernel32.GetLastError()) {
+        WAIT_FAILED => switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         },
         else => return error.Unexpected,
@@ -468,7 +479,7 @@ pub fn WaitForMultipleObjectsEx(handles: []const HANDLE, waitAll: bool, millisec
             return error.WaitAbandoned;
         },
         WAIT_TIMEOUT => return error.WaitTimeOut,
-        WAIT_FAILED => switch (kernel32.GetLastError()) {
+        WAIT_FAILED => switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         },
         else => return error.Unexpected,
@@ -484,7 +495,7 @@ pub fn CreateIoCompletionPort(
     concurrent_thread_count: DWORD,
 ) CreateIoCompletionPortError!HANDLE {
     const handle = kernel32.CreateIoCompletionPort(file_handle, existing_completion_port, completion_key, concurrent_thread_count) orelse {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .INVALID_PARAMETER => unreachable,
             else => |err| return unexpectedError(err),
         }
@@ -501,7 +512,7 @@ pub fn PostQueuedCompletionStatus(
     lpOverlapped: ?*OVERLAPPED,
 ) PostQueuedCompletionStatusError!void {
     if (kernel32.PostQueuedCompletionStatus(completion_port, bytes_transferred_count, completion_key, lpOverlapped) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     }
@@ -528,7 +539,7 @@ pub fn GetQueuedCompletionStatus(
         lpOverlapped,
         dwMilliseconds,
     ) == FALSE) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .ABANDONED_WAIT_0 => return GetQueuedCompletionStatusResult.Aborted,
             .OPERATION_ABORTED => return GetQueuedCompletionStatusResult.Cancelled,
             .HANDLE_EOF => return GetQueuedCompletionStatusResult.EOF,
@@ -568,7 +579,7 @@ pub fn GetQueuedCompletionStatusEx(
     );
 
     if (success == FALSE) {
-        return switch (kernel32.GetLastError()) {
+        return switch (GetLastError()) {
             .ABANDONED_WAIT_0 => error.Aborted,
             .OPERATION_ABORTED => error.Cancelled,
             .HANDLE_EOF => error.EOF,
@@ -618,7 +629,7 @@ pub fn ReadFile(in_hFile: HANDLE, buffer: []u8, offset: ?u64) ReadFileError!usiz
             break :blk &overlapped_data;
         } else null;
         if (kernel32.ReadFile(in_hFile, buffer.ptr, want_read_count, &amt_read, overlapped) == 0) {
-            switch (kernel32.GetLastError()) {
+            switch (GetLastError()) {
                 .IO_PENDING => unreachable,
                 .OPERATION_ABORTED => continue,
                 .BROKEN_PIPE => return 0,
@@ -667,7 +678,7 @@ pub fn WriteFile(
     } else null;
     const adjusted_len = math.cast(u32, bytes.len) orelse maxInt(u32);
     if (kernel32.WriteFile(handle, bytes.ptr, adjusted_len, &bytes_written, overlapped) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .INVALID_USER_BUFFER => return error.SystemResources,
             .NOT_ENOUGH_MEMORY => return error.SystemResources,
             .OPERATION_ABORTED => return error.OperationAborted,
@@ -728,7 +739,7 @@ pub fn GetCurrentDirectory(buffer: []u8) GetCurrentDirectoryError![]u8 {
     var wtf16le_buf: [PATH_MAX_WIDE]u16 = undefined;
     const result = kernel32.GetCurrentDirectoryW(wtf16le_buf.len, &wtf16le_buf);
     if (result == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     }
@@ -1109,7 +1120,7 @@ pub fn MoveFileEx(old_path: []const u8, new_path: []const u8, flags: DWORD) Move
 
 pub fn MoveFileExW(old_path: [*:0]const u16, new_path: [*:0]const u16, flags: DWORD) MoveFileError!void {
     if (kernel32.MoveFileExW(old_path, new_path, flags) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .FILE_NOT_FOUND => return error.FileNotFound,
             .ACCESS_DENIED => return error.AccessDenied,
             else => |err| return unexpectedError(err),
@@ -1125,7 +1136,7 @@ pub const GetStdHandleError = error{
 pub fn GetStdHandle(handle_id: DWORD) GetStdHandleError!HANDLE {
     const handle = kernel32.GetStdHandle(handle_id) orelse return error.NoStandardHandleAttached;
     if (handle == INVALID_HANDLE_VALUE) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     }
@@ -1141,7 +1152,7 @@ pub fn SetFilePointerEx_BEGIN(handle: HANDLE, offset: u64) SetFilePointerError!v
     // https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-setfilepointerex
     const ipos = @as(LARGE_INTEGER, @bitCast(offset));
     if (kernel32.SetFilePointerEx(handle, ipos, null, FILE_BEGIN) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .INVALID_PARAMETER => unreachable,
             .INVALID_HANDLE => unreachable,
             else => |err| return unexpectedError(err),
@@ -1152,7 +1163,7 @@ pub fn SetFilePointerEx_BEGIN(handle: HANDLE, offset: u64) SetFilePointerError!v
 /// The SetFilePointerEx function with the `dwMoveMethod` parameter set to `FILE_CURRENT`.
 pub fn SetFilePointerEx_CURRENT(handle: HANDLE, offset: i64) SetFilePointerError!void {
     if (kernel32.SetFilePointerEx(handle, offset, null, FILE_CURRENT) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .INVALID_PARAMETER => unreachable,
             .INVALID_HANDLE => unreachable,
             else => |err| return unexpectedError(err),
@@ -1163,7 +1174,7 @@ pub fn SetFilePointerEx_CURRENT(handle: HANDLE, offset: i64) SetFilePointerError
 /// The SetFilePointerEx function with the `dwMoveMethod` parameter set to `FILE_END`.
 pub fn SetFilePointerEx_END(handle: HANDLE, offset: i64) SetFilePointerError!void {
     if (kernel32.SetFilePointerEx(handle, offset, null, FILE_END) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .INVALID_PARAMETER => unreachable,
             .INVALID_HANDLE => unreachable,
             else => |err| return unexpectedError(err),
@@ -1175,7 +1186,7 @@ pub fn SetFilePointerEx_END(handle: HANDLE, offset: i64) SetFilePointerError!voi
 pub fn SetFilePointerEx_CURRENT_get(handle: HANDLE) SetFilePointerError!u64 {
     var result: LARGE_INTEGER = undefined;
     if (kernel32.SetFilePointerEx(handle, 0, &result, FILE_CURRENT) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .INVALID_PARAMETER => unreachable,
             .INVALID_HANDLE => unreachable,
             else => |err| return unexpectedError(err),
@@ -1489,7 +1500,7 @@ pub const GetFileSizeError = error{Unexpected};
 pub fn GetFileSizeEx(hFile: HANDLE) GetFileSizeError!u64 {
     var file_size: LARGE_INTEGER = undefined;
     if (kernel32.GetFileSizeEx(hFile, &file_size) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     }
@@ -1510,7 +1521,7 @@ pub fn GetFileAttributes(filename: []const u8) GetFileAttributesError!DWORD {
 pub fn GetFileAttributesW(lpFileName: [*:0]const u16) GetFileAttributesError!DWORD {
     const rc = kernel32.GetFileAttributesW(lpFileName);
     if (rc == INVALID_FILE_ATTRIBUTES) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .FILE_NOT_FOUND => return error.FileNotFound,
             .PATH_NOT_FOUND => return error.FileNotFound,
             .ACCESS_DENIED => return error.PermissionDenied,
@@ -1721,7 +1732,7 @@ const GetModuleFileNameError = error{Unexpected};
 pub fn GetModuleFileNameW(hModule: ?HMODULE, buf_ptr: [*]u16, buf_len: DWORD) GetModuleFileNameError![:0]u16 {
     const rc = kernel32.GetModuleFileNameW(hModule, buf_ptr, buf_len);
     if (rc == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     }
@@ -1732,7 +1743,7 @@ pub const TerminateProcessError = error{ PermissionDenied, Unexpected };
 
 pub fn TerminateProcess(hProcess: HANDLE, uExitCode: UINT) TerminateProcessError!void {
     if (kernel32.TerminateProcess(hProcess, uExitCode) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             Win32Error.ACCESS_DENIED => return error.PermissionDenied,
             else => |err| return unexpectedError(err),
         }
@@ -1743,7 +1754,7 @@ pub const VirtualAllocError = error{Unexpected};
 
 pub fn VirtualAlloc(addr: ?LPVOID, size: usize, alloc_type: DWORD, flProtect: DWORD) VirtualAllocError!LPVOID {
     return kernel32.VirtualAlloc(addr, size, alloc_type, flProtect) orelse {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     };
@@ -1792,7 +1803,7 @@ pub const VirtualQueryError = error{Unexpected};
 pub fn VirtualQuery(lpAddress: ?LPVOID, lpBuffer: PMEMORY_BASIC_INFORMATION, dwLength: SIZE_T) VirtualQueryError!SIZE_T {
     const rc = kernel32.VirtualQuery(lpAddress, lpBuffer, dwLength);
     if (rc == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     }
@@ -1804,7 +1815,7 @@ pub const SetConsoleTextAttributeError = error{Unexpected};
 
 pub fn SetConsoleTextAttribute(hConsoleOutput: HANDLE, wAttributes: WORD) SetConsoleTextAttributeError!void {
     if (kernel32.SetConsoleTextAttribute(hConsoleOutput, wAttributes) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     }
@@ -1817,7 +1828,7 @@ pub fn SetConsoleCtrlHandler(handler_routine: ?HANDLER_ROUTINE, add: bool) !void
     );
 
     if (success == FALSE) {
-        return switch (kernel32.GetLastError()) {
+        return switch (GetLastError()) {
             else => |err| unexpectedError(err),
         };
     }
@@ -1826,7 +1837,7 @@ pub fn SetConsoleCtrlHandler(handler_routine: ?HANDLER_ROUTINE, add: bool) !void
 pub fn SetFileCompletionNotificationModes(handle: HANDLE, flags: UCHAR) !void {
     const success = kernel32.SetFileCompletionNotificationModes(handle, flags);
     if (success == FALSE) {
-        return switch (kernel32.GetLastError()) {
+        return switch (GetLastError()) {
             else => |err| unexpectedError(err),
         };
     }
@@ -1850,7 +1861,7 @@ pub const GetEnvironmentVariableError = error{
 pub fn GetEnvironmentVariableW(lpName: LPWSTR, lpBuffer: [*]u16, nSize: DWORD) GetEnvironmentVariableError!DWORD {
     const rc = kernel32.GetEnvironmentVariableW(lpName, lpBuffer, nSize);
     if (rc == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .ENVVAR_NOT_FOUND => return error.EnvironmentVariableNotFound,
             else => |err| return unexpectedError(err),
         }
@@ -1891,7 +1902,7 @@ pub fn CreateProcessW(
         lpStartupInfo,
         lpProcessInformation,
     ) == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .FILE_NOT_FOUND => return error.FileNotFound,
             .PATH_NOT_FOUND => return error.FileNotFound,
             .ACCESS_DENIED => return error.AccessDenied,
@@ -1934,7 +1945,7 @@ pub const LoadLibraryError = error{
 
 pub fn LoadLibraryW(lpLibFileName: [*:0]const u16) LoadLibraryError!HMODULE {
     return kernel32.LoadLibraryW(lpLibFileName) orelse {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .FILE_NOT_FOUND => return error.FileNotFound,
             .PATH_NOT_FOUND => return error.FileNotFound,
             .MOD_NOT_FOUND => return error.FileNotFound,
@@ -1962,7 +1973,7 @@ pub const LoadLibraryFlags = enum(DWORD) {
 
 pub fn LoadLibraryExW(lpLibFileName: [*:0]const u16, dwFlags: LoadLibraryFlags) LoadLibraryError!HMODULE {
     return kernel32.LoadLibraryExW(lpLibFileName, null, @intFromEnum(dwFlags)) orelse {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             .FILE_NOT_FOUND => return error.FileNotFound,
             .PATH_NOT_FOUND => return error.FileNotFound,
             .MOD_NOT_FOUND => return error.FileNotFound,
@@ -2019,7 +2030,7 @@ pub fn SetFileTime(
 ) SetFileTimeError!void {
     const rc = kernel32.SetFileTime(hFile, lpCreationTime, lpLastAccessTime, lpLastWriteTime);
     if (rc == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     }
@@ -2709,7 +2720,7 @@ fn testNtToWin32Namespace(expected: []const u16, path: []const u16) !void {
 fn getFullPathNameW(path: [*:0]const u16, out: []u16) !usize {
     const result = kernel32.GetFullPathNameW(path, @as(u32, @intCast(out.len)), out.ptr, null);
     if (result == 0) {
-        switch (kernel32.GetLastError()) {
+        switch (GetLastError()) {
             else => |err| return unexpectedError(err),
         }
     }

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -6912,7 +6912,7 @@ pub fn fsync(fd: fd_t) SyncError!void {
     if (native_os == .windows) {
         if (windows.kernel32.FlushFileBuffers(fd) != 0)
             return;
-        switch (windows.kernel32.GetLastError()) {
+        switch (windows.GetLastError()) {
             .SUCCESS => return,
             .INVALID_HANDLE => unreachable,
             .ACCESS_DENIED => return error.AccessDenied, // a sync was performed but the system couldn't update the access time

--- a/lib/std/process/Child.zig
+++ b/lib/std/process/Child.zig
@@ -1358,7 +1358,7 @@ fn windowsMakeAsyncPipe(rd: *?windows.HANDLE, wr: *?windows.HANDLE, sattr: *cons
         sattr,
     );
     if (read_handle == windows.INVALID_HANDLE_VALUE) {
-        switch (windows.kernel32.GetLastError()) {
+        switch (windows.GetLastError()) {
             else => |err| return windows.unexpectedError(err),
         }
     }
@@ -1375,7 +1375,7 @@ fn windowsMakeAsyncPipe(rd: *?windows.HANDLE, wr: *?windows.HANDLE, sattr: *cons
         null,
     );
     if (write_handle == windows.INVALID_HANDLE_VALUE) {
-        switch (windows.kernel32.GetLastError()) {
+        switch (windows.GetLastError()) {
             else => |err| return windows.unexpectedError(err),
         }
     }
@@ -1529,7 +1529,7 @@ fn windowsCmdExePath(allocator: mem.Allocator) error{ OutOfMemory, Unexpected }!
         // TODO: Get the system directory from PEB.ReadOnlyStaticServerData
         const len = windows.kernel32.GetSystemDirectoryW(@ptrCast(unused_slice), @intCast(unused_slice.len));
         if (len == 0) {
-            switch (windows.kernel32.GetLastError()) {
+            switch (windows.GetLastError()) {
                 else => |err| return windows.unexpectedError(err),
             }
         }


### PR DESCRIPTION
Instead of calling the dynamically loaded kernel32.GetLastError, we can extract it from the TEB. As shown by [Wine](https://github.com/wine-mirror/wine/blob/34b1606019982b71818780bc84b76460f650af31/include/winternl.h#L439), the last error lives at offset 0x34 of the TEB in 32-bit Windows and at offset 0x68 in 64-bit Windows.