### PR TITLE
init: add a missing comment in build.zig.zon

### DIFF
--- a/lib/init/build.zig.zon
+++ b/lib/init/build.zig.zon
@@ -45,7 +45,7 @@
         //    // build root. In this case the package's hash is irrelevant and therefore not
         //    // computed. This field and `url` are mutually exclusive.
         //    .path = "foo",
-
+        //
         //    // When this is set to `true`, a package is declared to be lazily
         //    // fetched. This makes the dependency only get fetched if it is
         //    // actually used.


### PR DESCRIPTION
Useful when uncommenting