### PR TITLE
fix compiler crash when breaking from runtime loop at comptime #20588

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1226,7 +1226,7 @@ pub fn indexOfScalarPos(comptime T: type, slice: []const T, start_index: usize, 
             // {block_len, block_len / 2} check
             inline for (0..2) |j| {
                 const block_x_len = block_len / (1 << j);
-                comptime if (block_x_len < 4) break;
+                if (comptime block_x_len < 4) break;
 
                 const BlockX = @Vector(block_x_len, T);
                 if (i + block_x_len < slice.len) {

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -2166,6 +2166,11 @@ fn breakExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) Inn
                     continue;
                 };
                 // If we made it here, this block is the target of the break expr
+                
+                if (parent_gz.is_comptime and !block_gz.is_comptime) {
+                    const block_type = if (block_gz.is_inline) "inline" else "runtime";
+                    return astgen.failNode(node, "cannot comptime break out of {s} block", .{block_type});
+                }
 
                 const break_tag: Zir.Inst.Tag = if (block_gz.is_inline)
                     .break_inline
@@ -2259,6 +2264,11 @@ fn continueExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) 
                     // found continue but either it has a different label, or no label
                     scope = gen_zir.parent;
                     continue;
+                }
+
+                if (parent_gz.is_comptime and !gen_zir.is_comptime) {
+                    const block_type = if (gen_zir.is_inline) "inline" else "runtime";
+                    return astgen.failNode(node, "cannot comptime continue out of {s} block", .{block_type});
                 }
 
                 const break_tag: Zir.Inst.Tag = if (gen_zir.is_inline)

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -2167,9 +2167,8 @@ fn breakExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) Inn
                 };
                 // If we made it here, this block is the target of the break expr
 
-                if (parent_gz.is_comptime and !block_gz.is_comptime) {
-                    const block_type = if (block_gz.is_inline) "inline" else "runtime";
-                    return astgen.failNode(node, "cannot comptime break out of {s} block", .{block_type});
+                if (parent_gz.is_comptime and !(block_gz.is_comptime or block_gz.is_inline)) {
+                    return astgen.failNode(node, "cannot comptime break out of runtime block", .{});
                 }
 
                 const break_tag: Zir.Inst.Tag = if (block_gz.is_inline)
@@ -2266,9 +2265,8 @@ fn continueExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) 
                     continue;
                 }
 
-                if (parent_gz.is_comptime and !gen_zir.is_comptime) {
-                    const block_type = if (gen_zir.is_inline) "inline" else "runtime";
-                    return astgen.failNode(node, "cannot comptime continue out of {s} block", .{block_type});
+                if (parent_gz.is_comptime and !(gen_zir.is_comptime or gen_zir.is_inline)) {
+                    return astgen.failNode(node, "cannot comptime continue out of inline block", .{});
                 }
 
                 const break_tag: Zir.Inst.Tag = if (gen_zir.is_inline)

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -2166,7 +2166,7 @@ fn breakExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) Inn
                     continue;
                 };
                 // If we made it here, this block is the target of the break expr
-                
+
                 if (parent_gz.is_comptime and !block_gz.is_comptime) {
                     const block_type = if (block_gz.is_inline) "inline" else "runtime";
                     return astgen.failNode(node, "cannot comptime break out of {s} block", .{block_type});

--- a/test/cases/compile_errors/comptime_break_inside_runtime_loop.zig
+++ b/test/cases/compile_errors/comptime_break_inside_runtime_loop.zig
@@ -1,0 +1,11 @@
+export fn entry() void {
+    while (true) {
+        comptime break;
+    }
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:18: error: cannot comptime break out of runtime loop


### PR DESCRIPTION
also fix usage of `comptime` break in std.mem.indexOfScalarPos

fixes #20588