### PR TITLE
Add `std.io.tty.setInterruptSignalHandler` and use it in `std.Progress`

### DIFF
--- a/lib/std/io/tty.zig
+++ b/lib/std/io/tty.zig
@@ -5,6 +5,46 @@ const process = std.process;
 const windows = std.os.windows;
 const native_os = builtin.os.tag;
 
+/// Registers a global handler function to run if an interrupt signal is catched.
+/// An interrupt signal is usually fired if Ctrl+C is pressed in the terminal that controls the process.
+///
+/// Because this handler won't run if Ctrl+C isn't pressed by the user, registering this handler failed,
+/// or the handler was overwritten by another setInterruptSignalHandler call,
+/// this should be used only for non-critical cleanups or resets of terminal state and such.
+///
+/// A program can only have one handler at a time.
+///
+/// The handler will not exit the program after it runs.
+pub fn setInterruptSignalHandler(comptime handler: *const fn () void) error{Unexpected}!void {
+    if (builtin.os.tag == .windows) {
+        const handler_routine = struct {
+            fn handler_routine(dwCtrlType: windows.DWORD) callconv(windows.WINAPI) windows.BOOL {
+                if (dwCtrlType == windows.CTRL_C_EVENT) {
+                    handler();
+                    return windows.TRUE;
+                } else {
+                    // Ignore this event.
+                    return windows.FALSE;
+                }
+            }
+        }.handler_routine;
+        try windows.SetConsoleCtrlHandler(handler_routine, true);
+    } else {
+        const internal_handler = struct {
+            fn internal_handler(sig: c_int) callconv(.C) void {
+                std.debug.assert(sig == std.posix.SIG.INT);
+                handler();
+            }
+        }.internal_handler;
+        const act = std.posix.Sigaction{
+            .handler = .{ .handler = internal_handler },
+            .mask = std.posix.empty_sigset,
+            .flags = 0,
+        };
+        std.posix.sigaction(std.posix.SIG.INT, &act, null);
+    }
+}
+
 /// Detect suitable TTY configuration options for the given file (commonly stdout/stderr).
 /// This includes feature checks for ANSI escape codes and the Windows console API, as well as
 /// respecting the `NO_COLOR` and `CLICOLOR_FORCE` environment variables to override the default.


### PR DESCRIPTION
Closes #20266
Closes #13045

When doing things that involve printing something to the terminal and then clearing it or having any kind of state in form of content printed to the terminal, it's very useful if you can handle the case of interruption. Even the standard library finds a use case for this: `std.Progress`.

Before:
```
~/zig@abort$ zig-out/bin/zig test ../x.zig --zig-lib-dir lib
^C05] AST Lowering
~/zig@abort$ zig-out/bin/zig test ../x.zig --zig-lib-dir lib
^C36] AST Lowering
~/zig@abort$ tificate/Bundle.zig
├─ math/cbrt.zig
├─ tar/output.zig
├─ io.zig
├─ tar/test.zig
├─ math.zig
├─ crypto/Certificate/Bundle/macos.zig
└─ std.zig
```

After:
```
~/zig@abort$ zig-out/bin/zig test ../x.zig --zig-lib-dir lib
^C~/zig@abort$ zig-out/bin/zig test ../x.zig --zig-lib-dir lib
^C~/zig@abort$
```

Ctrl+C is the most common way to abort the compiler while it is running.
Aborting it because of not needing it to run anymore is common, so why not handle this case if we can and keep output clean?