### PR TITLE
frontend: fix updateZirRefs

### DIFF
--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -1,5 +1,7 @@
-//! Zig Intermediate Representation. Astgen.zig converts AST nodes to these
-//! untyped IR instructions. Next, Sema.zig processes these into AIR.
+//! Zig Intermediate Representation.
+//!
+//! Astgen.zig converts AST nodes to these untyped IR instructions. Next,
+//! Sema.zig processes these into AIR.
 //! The minimum amount of information needed to represent a list of ZIR instructions.
 //! Once this structure is completed, it can be used to generate AIR, followed by
 //! machine code, without any memory access into the AST tree token list, node list,
@@ -4024,8 +4026,8 @@ pub fn getAssociatedSrcHash(zir: Zir, inst: Zir.Inst.Index) ?std.zig.SrcHash {
     const data = zir.instructions.items(.data);
     switch (tag[@intFromEnum(inst)]) {
         .declaration => {
-            const pl_node = data[@intFromEnum(inst)].pl_node;
-            const extra = zir.extraData(Inst.Declaration, pl_node.payload_index);
+            const declaration = data[@intFromEnum(inst)].declaration;
+            const extra = zir.extraData(Inst.Declaration, declaration.payload_index);
             return @bitCast([4]u32{
                 extra.data.src_hash_0,
                 extra.data.src_hash_1,

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -1,4 +1,5 @@
 //! Analyzed Intermediate Representation.
+//!
 //! This data is produced by Sema and consumed by codegen.
 //! Unlike ZIR where there is one instance for an entire source file, each function
 //! gets its own `Air` instance.
@@ -12,8 +13,6 @@ const Value = @import("Value.zig");
 const Type = @import("Type.zig");
 const InternPool = @import("InternPool.zig");
 const Zcu = @import("Zcu.zig");
-/// Deprecated.
-const Module = Zcu;
 
 instructions: std.MultiArrayList(Inst).Slice,
 /// The meaning of this data is determined by `Inst.Tag` value.

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3596,6 +3596,11 @@ fn performAllTheWorkInner(
 
     if (comp.module) |zcu| {
         const pt: Zcu.PerThread = .{ .zcu = comp.module.?, .tid = .main };
+        if (comp.incremental) {
+            const update_zir_refs_node = main_progress_node.start("Update ZIR References", 0);
+            defer update_zir_refs_node.end();
+            try pt.updateZirRefs();
+        }
         try reportMultiModuleErrors(pt);
         try zcu.flushRetryableFailures();
         zcu.sema_prog_node = main_progress_node.start("Semantic Analysis", 0);
@@ -4306,7 +4311,7 @@ fn workerAstGenFile(
     defer child_prog_node.end();
 
     const pt: Zcu.PerThread = .{ .zcu = comp.module.?, .tid = @enumFromInt(tid) };
-    pt.astGenFile(file, file_index, path_digest, root_decl) catch |err| switch (err) {
+    pt.astGenFile(file, path_digest, root_decl) catch |err| switch (err) {
         error.AnalysisFail => return,
         else => {
             file.status = .retryable_failure;

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3595,7 +3595,7 @@ fn performAllTheWorkInner(
     }
 
     if (comp.module) |zcu| {
-        const pt: Zcu.PerThread = .{ .zcu = comp.module.?, .tid = .main };
+        const pt: Zcu.PerThread = .{ .zcu = zcu, .tid = .main };
         if (comp.incremental) {
             const update_zir_refs_node = main_progress_node.start("Update ZIR References", 0);
             defer update_zir_refs_node.end();

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -283,10 +283,12 @@ pub const DependencyIterator = struct {
     ip: *const InternPool,
     next_entry: DepEntry.Index.Optional,
     pub fn next(it: *DependencyIterator) ?AnalUnit {
-        const idx = it.next_entry.unwrap() orelse return null;
-        const entry = it.ip.dep_entries.items[@intFromEnum(idx)];
-        it.next_entry = entry.next;
-        return entry.depender.unwrap().?;
+        while (true) {
+            const idx = it.next_entry.unwrap() orelse return null;
+            const entry = it.ip.dep_entries.items[@intFromEnum(idx)];
+            it.next_entry = entry.next;
+            if (entry.depender.unwrap()) |depender| return depender;
+        }
     }
 };
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6065,7 +6065,7 @@ fn zirCImport(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileEr
 
     const path_digest = zcu.filePathDigest(result.file_index);
     const root_decl = zcu.fileRootDecl(result.file_index);
-    pt.astGenFile(result.file, result.file_index, path_digest, root_decl) catch |err|
+    pt.astGenFile(result.file, path_digest, root_decl) catch |err|
         return sema.fail(&child_block, src, "C import failed: {s}", .{@errorName(err)});
 
     try pt.ensureFileAnalyzed(result.file_index);

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -1,5 +1,8 @@
-//! Compilation of all Zig source code is represented by one `Module`.
-//! Each `Compilation` has exactly one or zero `Module`, depending on whether
+//! Zig Compilation Unit
+//!
+//! Compilation of all Zig source code is represented by one `Zcu`.
+//!
+//! Each `Compilation` has exactly one or zero `Zcu`, depending on whether
 //! there is or is not any zig source code, respectively.
 
 const std = @import("std");
@@ -13,8 +16,6 @@ const BigIntMutable = std.math.big.int.Mutable;
 const Target = std.Target;
 const Ast = std.zig.Ast;
 
-/// Deprecated, use `Zcu`.
-const Module = Zcu;
 const Zcu = @This();
 const Compilation = @import("Compilation.zig");
 const Cache = std.Build.Cache;
@@ -2393,7 +2394,7 @@ pub const CompileError = error{
     ComptimeBreak,
 };
 
-pub fn init(mod: *Module, thread_count: usize) !void {
+pub fn init(mod: *Zcu, thread_count: usize) !void {
     const gpa = mod.gpa;
     try mod.intern_pool.init(gpa, thread_count);
 }
@@ -2487,20 +2488,20 @@ pub fn deinit(zcu: *Zcu) void {
     zcu.intern_pool.deinit(gpa);
 }
 
-pub fn declPtr(mod: *Module, index: Decl.Index) *Decl {
+pub fn declPtr(mod: *Zcu, index: Decl.Index) *Decl {
     return mod.intern_pool.declPtr(index);
 }
 
-pub fn namespacePtr(mod: *Module, index: Namespace.Index) *Namespace {
+pub fn namespacePtr(mod: *Zcu, index: Namespace.Index) *Namespace {
     return mod.intern_pool.namespacePtr(index);
 }
 
-pub fn namespacePtrUnwrap(mod: *Module, index: Namespace.OptionalIndex) ?*Namespace {
+pub fn namespacePtrUnwrap(mod: *Zcu, index: Namespace.OptionalIndex) ?*Namespace {
     return mod.namespacePtr(index.unwrap() orelse return null);
 }
 
 /// Returns true if and only if the Decl is the top level struct associated with a File.
-pub fn declIsRoot(mod: *Module, decl_index: Decl.Index) bool {
+pub fn declIsRoot(mod: *Zcu, decl_index: Decl.Index) bool {
     const decl = mod.declPtr(decl_index);
     const namespace = mod.namespacePtr(decl.src_namespace);
     if (namespace.parent != .none) return false;
@@ -2940,7 +2941,7 @@ pub fn mapOldZirToNew(
 /// analyzed, and for ensuring it can exist at runtime (see
 /// `sema.fnHasRuntimeBits`). This function does *not* guarantee that the body
 /// will be analyzed when it returns: for that, see `ensureFuncBodyAnalyzed`.
-pub fn ensureFuncBodyAnalysisQueued(mod: *Module, func_index: InternPool.Index) !void {
+pub fn ensureFuncBodyAnalysisQueued(mod: *Zcu, func_index: InternPool.Index) !void {
     const ip = &mod.intern_pool;
     const func = mod.funcInfo(func_index);
     const decl_index = func.owner_decl;
@@ -3102,13 +3103,13 @@ pub fn addUnitReference(zcu: *Zcu, src_unit: AnalUnit, referenced_unit: AnalUnit
     gop.value_ptr.* = @intCast(ref_idx);
 }
 
-pub fn errorSetBits(mod: *Module) u16 {
+pub fn errorSetBits(mod: *Zcu) u16 {
     if (mod.error_limit == 0) return 0;
     return std.math.log2_int_ceil(ErrorInt, mod.error_limit + 1); // +1 for no error
 }
 
 pub fn errNote(
-    mod: *Module,
+    mod: *Zcu,
     src_loc: LazySrcLoc,
     parent: *ErrorMsg,
     comptime format: []const u8,
@@ -3138,7 +3139,7 @@ pub fn optimizeMode(zcu: *const Zcu) std.builtin.OptimizeMode {
     return zcu.root_mod.optimize_mode;
 }
 
-fn lockAndClearFileCompileError(mod: *Module, file: *File) void {
+fn lockAndClearFileCompileError(mod: *Zcu, file: *File) void {
     switch (file.status) {
         .success_zir, .retryable_failure => {},
         .never_loaded, .parse_failure, .astgen_failure => {
@@ -3172,7 +3173,7 @@ pub fn handleUpdateExports(
     };
 }
 
-pub fn addGlobalAssembly(mod: *Module, decl_index: Decl.Index, source: []const u8) !void {
+pub fn addGlobalAssembly(mod: *Zcu, decl_index: Decl.Index, source: []const u8) !void {
     const gop = try mod.global_assembly.getOrPut(mod.gpa, decl_index);
     if (gop.found_existing) {
         const new_value = try std.fmt.allocPrint(mod.gpa, "{s}\n{s}", .{ gop.value_ptr.*, source });
@@ -3226,7 +3227,7 @@ pub const AtomicPtrAlignmentDiagnostics = struct {
 // TODO this function does not take into account CPU features, which can affect
 // this value. Audit this!
 pub fn atomicPtrAlignment(
-    mod: *Module,
+    mod: *Zcu,
     ty: Type,
     diags: *AtomicPtrAlignmentDiagnostics,
 ) AtomicPtrAlignmentError!Alignment {
@@ -3332,7 +3333,7 @@ pub fn atomicPtrAlignment(
     return error.BadType;
 }
 
-pub fn declFileScope(mod: *Module, decl_index: Decl.Index) *File {
+pub fn declFileScope(mod: *Zcu, decl_index: Decl.Index) *File {
     return mod.declPtr(decl_index).getFileScope(mod);
 }
 
@@ -3340,7 +3341,7 @@ pub fn declFileScope(mod: *Module, decl_index: Decl.Index) *File {
 /// * `@TypeOf(.{})`
 /// * A struct which has no fields (`struct {}`).
 /// * Not a struct.
-pub fn typeToStruct(mod: *Module, ty: Type) ?InternPool.LoadedStructType {
+pub fn typeToStruct(mod: *Zcu, ty: Type) ?InternPool.LoadedStructType {
     if (ty.ip_index == .none) return null;
     const ip = &mod.intern_pool;
     return switch (ip.indexToKey(ty.ip_index)) {
@@ -3349,13 +3350,13 @@ pub fn typeToStruct(mod: *Module, ty: Type) ?InternPool.LoadedStructType {
     };
 }
 
-pub fn typeToPackedStruct(mod: *Module, ty: Type) ?InternPool.LoadedStructType {
+pub fn typeToPackedStruct(mod: *Zcu, ty: Type) ?InternPool.LoadedStructType {
     const s = mod.typeToStruct(ty) orelse return null;
     if (s.layout != .@"packed") return null;
     return s;
 }
 
-pub fn typeToUnion(mod: *Module, ty: Type) ?InternPool.LoadedUnionType {
+pub fn typeToUnion(mod: *Zcu, ty: Type) ?InternPool.LoadedUnionType {
     if (ty.ip_index == .none) return null;
     const ip = &mod.intern_pool;
     return switch (ip.indexToKey(ty.ip_index)) {
@@ -3364,32 +3365,32 @@ pub fn typeToUnion(mod: *Module, ty: Type) ?InternPool.LoadedUnionType {
     };
 }
 
-pub fn typeToFunc(mod: *Module, ty: Type) ?InternPool.Key.FuncType {
+pub fn typeToFunc(mod: *Zcu, ty: Type) ?InternPool.Key.FuncType {
     if (ty.ip_index == .none) return null;
     return mod.intern_pool.indexToFuncType(ty.toIntern());
 }
 
-pub fn funcOwnerDeclPtr(mod: *Module, func_index: InternPool.Index) *Decl {
+pub fn funcOwnerDeclPtr(mod: *Zcu, func_index: InternPool.Index) *Decl {
     return mod.declPtr(mod.funcOwnerDeclIndex(func_index));
 }
 
-pub fn funcOwnerDeclIndex(mod: *Module, func_index: InternPool.Index) Decl.Index {
+pub fn funcOwnerDeclIndex(mod: *Zcu, func_index: InternPool.Index) Decl.Index {
     return mod.funcInfo(func_index).owner_decl;
 }
 
-pub fn iesFuncIndex(mod: *const Module, ies_index: InternPool.Index) InternPool.Index {
+pub fn iesFuncIndex(mod: *const Zcu, ies_index: InternPool.Index) InternPool.Index {
     return mod.intern_pool.iesFuncIndex(ies_index);
 }
 
-pub fn funcInfo(mod: *Module, func_index: InternPool.Index) InternPool.Key.Func {
+pub fn funcInfo(mod: *Zcu, func_index: InternPool.Index) InternPool.Key.Func {
     return mod.intern_pool.indexToKey(func_index).func;
 }
 
-pub fn toEnum(mod: *Module, comptime E: type, val: Value) E {
+pub fn toEnum(mod: *Zcu, comptime E: type, val: Value) E {
     return mod.intern_pool.toEnum(E, val.toIntern());
 }
 
-pub fn isAnytypeParam(mod: *Module, func: InternPool.Index, index: u32) bool {
+pub fn isAnytypeParam(mod: *Zcu, func: InternPool.Index, index: u32) bool {
     const file = mod.declPtr(func.owner_decl).getFileScope(mod);
 
     const tags = file.zir.instructions.items(.tag);
@@ -3404,7 +3405,7 @@ pub fn isAnytypeParam(mod: *Module, func: InternPool.Index, index: u32) bool {
     };
 }
 
-pub fn getParamName(mod: *Module, func_index: InternPool.Index, index: u32) [:0]const u8 {
+pub fn getParamName(mod: *Zcu, func_index: InternPool.Index, index: u32) [:0]const u8 {
     const func = mod.funcInfo(func_index);
     const file = mod.declPtr(func.owner_decl).getFileScope(mod);
 
@@ -3441,7 +3442,7 @@ pub const UnionLayout = struct {
 };
 
 /// Returns the index of the active field, given the current tag value
-pub fn unionTagFieldIndex(mod: *Module, loaded_union: InternPool.LoadedUnionType, enum_tag: Value) ?u32 {
+pub fn unionTagFieldIndex(mod: *Zcu, loaded_union: InternPool.LoadedUnionType, enum_tag: Value) ?u32 {
     const ip = &mod.intern_pool;
     if (enum_tag.toIntern() == .none) return null;
     assert(ip.typeOf(enum_tag.toIntern()) == loaded_union.enum_tag_ty);

--- a/src/main.zig
+++ b/src/main.zig
@@ -4230,6 +4230,9 @@ fn serveUpdateResults(s: *Server, comp: *Compilation) !void {
         });
         return;
     }
+
+    // Serve empty error bundle to indicate the update is done.
+    try s.serveErrorBundle(std.zig.ErrorBundle.empty);
 }
 
 fn runOrTest(


### PR DESCRIPTION
Moves `updateZirRefs` to be single-threaded for simplicity's sake. This makes it O(M) instead of O(N*M) where N is tracked insts and M is number of changed source files.

Also fix wrong union field access for declarations.

----

Next incremental compilation problem after this appears to be in the ELF linker:

```
error: thread 145898 panic: attempt to use null value
/home/andy/dev/zig/src/link/Elf/ZigObject.zig:702:89: 0x66e20c4 in lowerAnonDecl (zig)
        const existing_alignment = elf_file.symbol(metadata.symbol_index).atom(elf_file).?.alignment;
                                                                                        ^
/home/andy/dev/zig/src/link/Elf.zig:558:47: 0x66e27e6 in lowerAnonDecl (zig)
    return self.zigObjectPtr().?.lowerAnonDecl(self, pt, decl_val, explicit_alignment, src_loc);
                                              ^
/home/andy/dev/zig/src/link.zig:656:85: 0x66e8300 in lowerAnonDecl (zig)
                return @as(*tag.Type(), @fieldParentPtr("base", base)).lowerAnonDecl(pt, decl_val, decl_align, src_loc);
                                                                                    ^
/home/andy/dev/zig/src/codegen.zig:713:37: 0x61b27cc in lowerAnonDeclRef (zig)
    const res = try lf.lowerAnonDecl(pt, decl_val, decl_align, src_loc);
                                    ^
/home/andy/dev/zig/src/codegen.zig:635:48: 0x5e75959 in lowerPtr (zig)
        .anon_decl => |ad| try lowerAnonDeclRef(bin_file, pt, src_loc, ad, code, debug_output, reloc_info, offset),
                                               ^
/home/andy/dev/zig/src/codegen.zig:320:37: 0x5bc0f4c in generateSymbol (zig)
        .ptr => switch (try lowerPtr(bin_file, pt, src_loc, val.toIntern(), code, debug_output, reloc_info, 0)) {
                                    ^
/home/andy/dev/zig/src/codegen.zig:325:39: 0x5bc1126 in generateSymbol (zig)
            switch (try generateSymbol(bin_file, pt, src_loc, Value.fromInterned(slice.ptr), code, debug_output, reloc_info)) {
                                      ^
/home/andy/dev/zig/src/link/Elf/ZigObject.zig:1337:43: 0x66e0f03 in lowerConst (zig)
    const res = try codegen.generateSymbol(&elf_file.base, pt, src_loc, val, &code_buffer, .{
                                          ^
/home/andy/dev/zig/src/link/Elf/ZigObject.zig:1293:50: 0x7dfccd0 in lowerUnnamedConst (zig)
    const sym_index = switch (try self.lowerConst(
                                                 ^
/home/andy/dev/zig/src/link/Elf.zig:3008:51: 0x7dfd1a5 in lowerUnnamedConst (zig)
    return self.zigObjectPtr().?.lowerUnnamedConst(self, pt, val, decl_index);
                                                  ^
/home/andy/dev/zig/src/link.zig:375:87: 0x7c5f63f in lowerUnnamedConst (zig)
                return @as(*t.Type(), @fieldParentPtr("base", base)).lowerUnnamedConst(pt, val, decl_index);
                                                                                      ^
/home/andy/dev/zig/src/codegen.zig:948:49: 0x7948bde in genUnnamedConst (zig)
    const local_sym_index = lf.lowerUnnamedConst(pt, val, owner_decl_index) catch |err| {
                                                ^
/home/andy/dev/zig/src/codegen.zig:1104:27: 0x76653f1 in genTypedValue (zig)
    return genUnnamedConst(lf, pt, src_loc, val, owner_decl_index);
                          ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:18809:45: 0x73672c0 in genTypedValue (zig)
    return switch (try codegen.genTypedValue(self.bin_file, pt, self.src_loc, val, self.owner.getDecl(pt.zcu))) {
                                            ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:18742:53: 0x7365231 in resolveInst (zig)
            const const_mcv = try self.genTypedValue(Value.fromInterned(ip_index));
                                                    ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:15242:86: 0x73695f3 in genSetMem (zig)
        .air_ref => |src_ref| try self.genSetMem(base, disp, ty, try self.resolveInst(src_ref), opts),
                                                                                     ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:14723:55: 0x7359827 in genCopy (zig)
        .load_frame => |frame_addr| try self.genSetMem(
                                                      ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:12180:33: 0x7a92ff9 in genCall (zig)
                try self.genCopy(arg_ty, dst_arg, src_arg, .{});
                                ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:12073:33: 0x7ba050d in airCall (zig)
    const ret = try self.genCall(.{ .air = pl_op.operand }, arg_tys, arg_vals);
                                ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:2114:51: 0x7824580 in genBody (zig)
            .call              => try self.airCall(inst, .auto),
                                                  ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:13123:21: 0x7b35374 in airCondBr (zig)
    try self.genBody(else_body);
                    ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:2052:51: 0x7822e12 in genBody (zig)
            .cond_br         => try self.airCondBr(inst),
                                                  ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:13502:21: 0x7b317bf in lowerBlock (zig)
    try self.genBody(body);
                    ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:13489:24: 0x7b31fb5 in airBlock (zig)
    try self.lowerBlock(inst, @ptrCast(self.air.extra[extra.end..][0..extra.data.body_len]));
                       ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:2045:50: 0x7822b31 in genBody (zig)
            .block           => try self.airBlock(inst),
                                                 ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:13112:21: 0x7b351ac in airCondBr (zig)
    try self.genBody(then_body);
                    ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:2052:51: 0x7822e12 in genBody (zig)
            .cond_br         => try self.airCondBr(inst),
                                                  ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:13502:21: 0x7b317bf in lowerBlock (zig)
    try self.genBody(body);
                    ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:13489:24: 0x7b31fb5 in airBlock (zig)
    try self.lowerBlock(inst, @ptrCast(self.air.extra[extra.end..][0..extra.data.body_len]));
                       ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:2045:50: 0x7822b31 in genBody (zig)
            .block           => try self.airBlock(inst),
                                                 ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:13474:21: 0x7b473a7 in airLoop (zig)
    try self.genBody(body);
                    ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:2067:49: 0x7823457 in genBody (zig)
            .loop            => try self.airLoop(inst),
                                                ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:13502:21: 0x7b317bf in lowerBlock (zig)
    try self.genBody(body);
                    ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:13489:24: 0x7b31fb5 in airBlock (zig)
    try self.lowerBlock(inst, @ptrCast(self.air.extra[extra.end..][0..extra.data.body_len]));
                       ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:2045:50: 0x7822b31 in genBody (zig)
            .block           => try self.airBlock(inst),
                                                 ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:1825:25: 0x74caae5 in gen (zig)
        try self.genBody(self.air.getMainBody());
                        ^
/home/andy/dev/zig/src/arch/x86_64/CodeGen.zig:914:17: 0x720fc37 in generate (zig)
    function.gen() catch |err| switch (err) {
                ^
/home/andy/dev/zig/src/codegen.zig:71:70: 0x6e454f7 in generateFunction (zig)
        .x86_64 => return @import("arch/x86_64/CodeGen.zig").generate(lf, pt, src_loc, func_index, air, liveness, code, debug_output),
                                                                     ^
/home/andy/dev/zig/src/link/Elf/ZigObject.zig:1082:45: 0x6e45ce0 in updateFunc (zig)
    const res = try codegen.generateFunction(
                                            ^
/home/andy/dev/zig/src/link/Elf.zig:2992:44: 0x6e46627 in updateFunc (zig)
    return self.zigObjectPtr().?.updateFunc(self, pt, func_index, air, liveness);
                                           ^
/home/andy/dev/zig/src/link.zig:422:82: 0x69e942b in updateFunc (zig)
                return @as(*tag.Type(), @fieldParentPtr("base", base)).updateFunc(pt, func_index, air, liveness);
                                                                                 ^
/home/andy/dev/zig/src/Zcu/PerThread.zig:820:22: 0x6568ee9 in linkerUpdateFunc (zig)
        lf.updateFunc(pt, func_index, air, liveness) catch |err| switch (err) {
                     ^
/home/andy/dev/zig/src/Compilation.zig:4028:36: 0x60b556e in processOneCodegenJob (zig)
            try pt.linkerUpdateFunc(func.func, func.air);
                                   ^
/home/andy/dev/zig/src/Compilation.zig:3981:36: 0x60b5323 in queueCodegenJob (zig)
        return processOneCodegenJob(tid, comp, codegen_job);
                                   ^
/home/andy/dev/zig/src/Compilation.zig:3683:37: 0x5de65f0 in processOneJob (zig)
            try comp.queueCodegenJob(tid, .{ .func = .{
                                    ^
/home/andy/dev/zig/src/Compilation.zig:3622:30: 0x5b5dc9e in performAllTheWorkInner (zig)
            try processOneJob(@intFromEnum(Zcu.PerThread.Id.main), comp, job, main_progress_node);
                             ^
/home/andy/dev/zig/src/Compilation.zig:3496:36: 0x59d542d in performAllTheWork (zig)
    try comp.performAllTheWorkInner(main_progress_node);
                                   ^
/home/andy/dev/zig/src/Compilation.zig:2231:31: 0x59d14f0 in update (zig)
    try comp.performAllTheWork(main_progress_node);
                              ^
/home/andy/dev/zig/src/main.zig:4104:32: 0x5a4d03e in serve (zig)
                try comp.update(main_progress_node);
                               ^
/home/andy/dev/zig/src/main.zig:3399:22: 0x5a6bf4d in buildOutputType (zig)
            try serve(
                     ^
/home/andy/dev/zig/src/main.zig:263:31: 0x58afc31 in mainArgs (zig)
        return buildOutputType(gpa, arena, args, .{ .build = .Exe });
                              ^
/home/andy/dev/zig/src/main.zig:209:20: 0x58acbc5 in main (zig)
    return mainArgs(gpa, arena, args);
                   ^
/home/andy/dev/zig/lib/std/start.zig:513:37: 0x58ac65e in main (zig)
            const result = root.main() catch |err| {
                                    ^
```