### PR TITLE
ip: use `getExternFunc` in `getCoerced`

### DIFF
--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -9433,12 +9433,11 @@ pub fn getCoerced(
     switch (ip.indexToKey(val)) {
         .undef => return ip.get(gpa, tid, .{ .undef = new_ty }),
         .extern_func => |extern_func| if (ip.isFunctionType(new_ty))
-            return ip.get(gpa, tid, .{ .extern_func = .{
+            return ip.getExternFunc(gpa, tid, .{
                 .ty = new_ty,
                 .decl = extern_func.decl,
                 .lib_name = extern_func.lib_name,
-            } }),
-
+            }),
         .func => unreachable,
 
         .int => |int| switch (ip.indexToKey(new_ty)) {

--- a/test/behavior/extern.zig
+++ b/test/behavior/extern.zig
@@ -45,3 +45,16 @@ test "function extern symbol matches extern decl" {
 export fn another_mystery_function() u32 {
     return 12345;
 }
+
+extern fn c_extern_function() [*c]u32;
+
+test "coerce extern function types" {
+    const S = struct {
+        export fn c_extern_function() [*c]u32 {
+            return null;
+        }
+    };
+    _ = S;
+
+    _ = @as(fn () callconv(.C) ?*u32, c_extern_function);
+}


### PR DESCRIPTION
fixes #20651