### PR TITLE
dev: introduce dev environments that enable compiler feature sets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,7 @@ set(ZIG_STAGE2_SOURCES
     src/codegen/spirv/Section.zig
     src/codegen/spirv/spec.zig
     src/crash_report.zig
+    src/dev.zig
     src/glibc.zig
     src/introspect.zig
     src/libcxx.zig

--- a/bootstrap.c
+++ b/bootstrap.c
@@ -140,8 +140,7 @@ int main(int argc, char **argv) {
             "pub const value_tracing = false;\n"
             "pub const skip_non_native = false;\n"
             "pub const force_gpa = false;\n"
-            "pub const only_c = false;\n"
-            "pub const only_core_functionality = true;\n"
+            "pub const dev = .core;\n"
         , zig_version);
         if (written < 100)
             panic("unable to write to config.zig file");

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -38,6 +38,7 @@ const Alignment = InternPool.Alignment;
 const AnalUnit = InternPool.AnalUnit;
 const BuiltinFn = std.zig.BuiltinFn;
 const LlvmObject = @import("codegen/llvm.zig").Object;
+const dev = @import("dev.zig");
 
 comptime {
     @setEvalBranchQuota(4000);
@@ -57,7 +58,7 @@ comp: *Compilation,
 /// Usually, the LlvmObject is managed by linker code, however, in the case
 /// that -fno-emit-bin is specified, the linker code never executes, so we
 /// store the LlvmObject here.
-llvm_object: ?*LlvmObject,
+llvm_object: if (dev.env.supports(.llvm_backend)) ?*LlvmObject else ?noreturn,
 
 /// Pointer to externally managed resource.
 root_mod: *Package.Module,
@@ -2403,10 +2404,7 @@ pub fn deinit(zcu: *Zcu) void {
     const pt: Zcu.PerThread = .{ .tid = .main, .zcu = zcu };
     const gpa = zcu.gpa;
 
-    if (zcu.llvm_object) |llvm_object| {
-        if (build_options.only_c) unreachable;
-        llvm_object.deinit();
-    }
+    if (zcu.llvm_object) |llvm_object| llvm_object.deinit();
 
     for (zcu.import_table.keys()) |key| {
         gpa.free(key);
@@ -3041,7 +3039,7 @@ pub fn deleteUnitExports(zcu: *Zcu, anal_unit: AnalUnit) void {
     // `updateExports` on flush).
     // This case is needed because in some rare edge cases, `Sema` wants to add and delete exports
     // within a single update.
-    if (!build_options.only_c) {
+    if (dev.env.supports(.incremental)) {
         for (exports, exports_base..) |exp, export_idx| {
             if (zcu.comp.bin_file) |lf| {
                 lf.deleteExport(exp.exported, exp.opts.name);

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -868,7 +868,6 @@ pub const Object = struct {
     pub const TypeMap = std.AutoHashMapUnmanaged(InternPool.Index, Builder.Type);
 
     pub fn create(arena: Allocator, comp: *Compilation) !*Object {
-        if (build_options.only_c) unreachable;
         const gpa = comp.gpa;
         const target = comp.root_mod.resolved_target.result;
         const llvm_target_triple = try targetTriple(arena, target);

--- a/src/dev.zig
+++ b/src/dev.zig
@@ -1,0 +1,238 @@
+pub const Env = enum {
+    /// zig1 features
+    bootstrap,
+
+    /// zig2 features
+    core,
+
+    /// stage3 features
+    full,
+
+    /// - `zig cc`
+    /// - `zig c++`
+    /// - `zig translate-c`
+    c_source,
+
+    /// - `zig ast-check`
+    /// - `zig changelist`
+    /// - `zig dump-zir`
+    ast_gen,
+
+    /// - ast_gen
+    /// - `zig build-* -fno-emit-bin`
+    sema,
+
+    /// - sema
+    /// - jit command on x86_64-linux host
+    /// - `zig build-* -fno-llvm -fno-lld -target x86_64-linux`
+    @"x86_64-linux",
+
+    pub inline fn supports(comptime dev_env: Env, comptime feature: Feature) bool {
+        return switch (dev_env) {
+            .full => true,
+            .bootstrap => switch (feature) {
+                .build_exe_command,
+                .build_obj_command,
+                .ast_gen,
+                .sema,
+                .c_backend,
+                .c_linker,
+                => true,
+                else => false,
+            },
+            .core => switch (feature) {
+                .build_exe_command,
+                .build_lib_command,
+                .build_obj_command,
+                .test_command,
+                .run_command,
+                .ar_command,
+                .build_command,
+                .clang_command,
+                .stdio_listen,
+                .build_import_lib,
+                .make_executable,
+                .make_writable,
+                .incremental,
+                .ast_gen,
+                .sema,
+                .llvm_backend,
+                .c_backend,
+                .wasm_backend,
+                .arm_backend,
+                .x86_64_backend,
+                .aarch64_backend,
+                .x86_backend,
+                .riscv64_backend,
+                .sparc64_backend,
+                .spirv64_backend,
+                .lld_linker,
+                .coff_linker,
+                .elf_linker,
+                .macho_linker,
+                .c_linker,
+                .wasm_linker,
+                .spirv_linker,
+                .plan9_linker,
+                .nvptx_linker,
+                => true,
+                .cc_command,
+                .translate_c_command,
+                .jit_command,
+                .fetch_command,
+                .init_command,
+                .targets_command,
+                .version_command,
+                .env_command,
+                .zen_command,
+                .help_command,
+                .ast_check_command,
+                .detect_cpu_command,
+                .changelist_command,
+                .dump_zir_command,
+                .llvm_ints_command,
+                .docs_emit,
+                // Avoid dragging networking into zig2.c because it adds dependencies on some
+                // linker symbols that are annoying to satisfy while bootstrapping.
+                .network_listen,
+                .win32_resource,
+                => false,
+            },
+            .c_source => switch (feature) {
+                .clang_command,
+                .cc_command,
+                .translate_c_command,
+                => true,
+                else => false,
+            },
+            .ast_gen => switch (feature) {
+                .ast_check_command,
+                .changelist_command,
+                .dump_zir_command,
+                .make_executable,
+                .make_writable,
+                .incremental,
+                .ast_gen,
+                => true,
+                else => false,
+            },
+            .sema => switch (feature) {
+                .build_exe_command,
+                .build_lib_command,
+                .build_obj_command,
+                .test_command,
+                .run_command,
+                .sema,
+                => true,
+                else => Env.ast_gen.supports(feature),
+            },
+            .@"x86_64-linux" => switch (feature) {
+                .x86_64_backend,
+                .elf_linker,
+                => true,
+                else => Env.sema.supports(feature),
+            },
+        };
+    }
+
+    pub inline fn supportsAny(comptime dev_env: Env, comptime features: []const Feature) bool {
+        inline for (features) |feature| if (dev_env.supports(feature)) return true;
+        return false;
+    }
+
+    pub inline fn supportsAll(comptime dev_env: Env, comptime features: []const Feature) bool {
+        inline for (features) |feature| if (!dev_env.supports(feature)) return false;
+        return true;
+    }
+};
+
+pub const Feature = enum {
+    build_exe_command,
+    build_lib_command,
+    build_obj_command,
+    test_command,
+    run_command,
+    ar_command,
+    build_command,
+    clang_command,
+    cc_command,
+    translate_c_command,
+    jit_command,
+    fetch_command,
+    init_command,
+    targets_command,
+    version_command,
+    env_command,
+    zen_command,
+    help_command,
+    ast_check_command,
+    detect_cpu_command,
+    changelist_command,
+    dump_zir_command,
+    llvm_ints_command,
+
+    docs_emit,
+    stdio_listen,
+    network_listen,
+    build_import_lib,
+    win32_resource,
+    make_executable,
+    make_writable,
+    incremental,
+    ast_gen,
+    sema,
+
+    llvm_backend,
+    c_backend,
+    wasm_backend,
+    arm_backend,
+    x86_64_backend,
+    aarch64_backend,
+    x86_backend,
+    riscv64_backend,
+    sparc64_backend,
+    spirv64_backend,
+
+    lld_linker,
+    coff_linker,
+    elf_linker,
+    macho_linker,
+    c_linker,
+    wasm_linker,
+    spirv_linker,
+    plan9_linker,
+    nvptx_linker,
+};
+
+/// Makes the code following the call to this function unreachable if `feature` is disabled.
+pub fn check(comptime feature: Feature) if (env.supports(feature)) void else noreturn {
+    if (env.supports(feature)) return;
+    @panic("development environment " ++ @tagName(env) ++ " does not support feature " ++ @tagName(feature));
+}
+
+/// Makes the code following the call to this function unreachable if all of `features` are disabled.
+pub fn checkAny(comptime features: []const Feature) if (env.supportsAny(features)) void else noreturn {
+    if (env.supportsAny(features)) return;
+    comptime var feature_tags: []const u8 = "";
+    inline for (features[0 .. features.len - 1]) |feature| feature_tags = feature_tags ++ @tagName(feature) ++ ", ";
+    feature_tags = feature_tags ++ "or " ++ @tagName(features[features.len - 1]);
+    @panic("development environment " ++ @tagName(env) ++ " does not support feature " ++ feature_tags);
+}
+
+/// Makes the code following the call to this function unreachable if any of `features` are disabled.
+pub fn checkAll(comptime features: []const Feature) if (env.supportsAll(features)) void else noreturn {
+    if (env.supportsAll(features)) return;
+    inline for (features) |feature| if (!env.supports(feature))
+        @panic("development environment " ++ @tagName(env) ++ " does not support feature " ++ @tagName(feature));
+}
+
+const build_options = @import("build_options");
+
+pub const env: Env = if (@hasDecl(build_options, "dev"))
+    @field(Env, @tagName(build_options.dev))
+else if (@hasDecl(build_options, "only_c") and build_options.only_c)
+    .bootstrap
+else if (@hasDecl(build_options, "only_core_functionality") and build_options.only_core_functionality)
+    .core
+else
+    .full;

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const build_options = @import("build_options");
 const allocPrint = std.fmt.allocPrint;
 const assert = std.debug.assert;
+const dev = @import("../../dev.zig");
 const fs = std.fs;
 const log = std.log.scoped(.link);
 const mem = std.mem;
@@ -18,6 +19,8 @@ const Compilation = @import("../../Compilation.zig");
 const Zcu = @import("../../Zcu.zig");
 
 pub fn linkWithLLD(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) !void {
+    dev.check(.lld_linker);
+
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -77,10 +80,8 @@ pub fn linkWithLLD(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
         for (comp.c_object_table.keys()) |key| {
             _ = try man.addFile(key.status.success.object_path, null);
         }
-        if (!build_options.only_core_functionality) {
-            for (comp.win32_resource_table.keys()) |key| {
-                _ = try man.addFile(key.status.success.res_path, null);
-            }
+        for (comp.win32_resource_table.keys()) |key| {
+            _ = try man.addFile(key.status.success.res_path, null);
         }
         try man.addOptionalFile(module_obj_path);
         man.hash.addOptionalBytes(entry_name);
@@ -274,10 +275,8 @@ pub fn linkWithLLD(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
             try argv.append(key.status.success.object_path);
         }
 
-        if (!build_options.only_core_functionality) {
-            for (comp.win32_resource_table.keys()) |key| {
-                try argv.append(key.status.success.res_path);
-            }
+        for (comp.win32_resource_table.keys()) |key| {
+            try argv.append(key.status.success.res_path);
         }
 
         if (module_obj_path) |p| {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2148,6 +2148,8 @@ fn scanRelocs(self: *Elf) !void {
 }
 
 fn linkWithLLD(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) !void {
+    dev.check(.lld_linker);
+
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -6430,6 +6432,7 @@ const math = std.math;
 const mem = std.mem;
 
 const codegen = @import("../codegen.zig");
+const dev = @import("../dev.zig");
 const eh_frame = @import("Elf/eh_frame.zig");
 const gc = @import("Elf/gc.zig");
 const glibc = @import("../glibc.zig");

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -6,6 +6,7 @@ const assert = std.debug.assert;
 const build_options = @import("build_options");
 const builtin = @import("builtin");
 const codegen = @import("../codegen.zig");
+const dev = @import("../dev.zig");
 const fs = std.fs;
 const leb = std.leb;
 const link = @import("../link.zig");
@@ -3325,6 +3326,8 @@ fn emitImport(wasm: *Wasm, writer: anytype, import: types.Import) !void {
 }
 
 fn linkWithLLD(wasm: *Wasm, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) !void {
+    dev.check(.lld_linker);
+
     const tracy = trace(@src());
     defer tracy.end();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -30,6 +30,7 @@ const Zcu = @import("Zcu.zig");
 const AstGen = std.zig.AstGen;
 const mingw = @import("mingw.zig");
 const Server = std.zig.Server;
+const dev = @import("dev.zig");
 
 pub const std_options = .{
     .wasiCwd = wasi_cwd,
@@ -195,17 +196,6 @@ pub fn main() anyerror!void {
         wasi_preopens = try fs.wasi.preopensAlloc(arena);
     }
 
-    // Short circuit some of the other logic for bootstrapping.
-    if (build_options.only_c) {
-        if (mem.eql(u8, args[1], "build-exe")) {
-            return buildOutputType(gpa, arena, args, .{ .build = .Exe });
-        } else if (mem.eql(u8, args[1], "build-obj")) {
-            return buildOutputType(gpa, arena, args, .{ .build = .Obj });
-        } else {
-            @panic("only build-exe or build-obj is supported in a -Donly-c build");
-        }
-    }
-
     return mainArgs(gpa, arena, args);
 }
 
@@ -227,6 +217,7 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     }
 
     if (process.can_execv and std.posix.getenvZ("ZIG_IS_DETECTING_LIBC_PATHS") != null) {
+        dev.check(.cc_command);
         // In this case we have accidentally invoked ourselves as "the system C compiler"
         // to figure out where libc is installed. This is essentially infinite recursion
         // via child process execution due to the CC environment variable pointing to Zig.
@@ -260,39 +251,49 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     const cmd = args[1];
     const cmd_args = args[2..];
     if (mem.eql(u8, cmd, "build-exe")) {
+        dev.check(.build_exe_command);
         return buildOutputType(gpa, arena, args, .{ .build = .Exe });
     } else if (mem.eql(u8, cmd, "build-lib")) {
+        dev.check(.build_lib_command);
         return buildOutputType(gpa, arena, args, .{ .build = .Lib });
     } else if (mem.eql(u8, cmd, "build-obj")) {
+        dev.check(.build_obj_command);
         return buildOutputType(gpa, arena, args, .{ .build = .Obj });
     } else if (mem.eql(u8, cmd, "test")) {
+        dev.check(.test_command);
         return buildOutputType(gpa, arena, args, .zig_test);
     } else if (mem.eql(u8, cmd, "run")) {
+        dev.check(.run_command);
         return buildOutputType(gpa, arena, args, .run);
     } else if (mem.eql(u8, cmd, "dlltool") or
         mem.eql(u8, cmd, "ranlib") or
         mem.eql(u8, cmd, "lib") or
         mem.eql(u8, cmd, "ar"))
     {
+        dev.check(.ar_command);
         return process.exit(try llvmArMain(arena, args));
     } else if (mem.eql(u8, cmd, "build")) {
+        dev.check(.build_command);
         return cmdBuild(gpa, arena, cmd_args);
     } else if (mem.eql(u8, cmd, "clang") or
         mem.eql(u8, cmd, "-cc1") or mem.eql(u8, cmd, "-cc1as"))
     {
+        dev.check(.clang_command);
         return process.exit(try clangMain(arena, args));
     } else if (mem.eql(u8, cmd, "ld.lld") or
         mem.eql(u8, cmd, "lld-link") or
         mem.eql(u8, cmd, "wasm-ld"))
     {
+        dev.check(.lld_linker);
         return process.exit(try lldMain(arena, args, true));
-    } else if (build_options.only_core_functionality) {
-        @panic("only a few subcommands are supported in a zig2.c build");
     } else if (mem.eql(u8, cmd, "cc")) {
+        dev.check(.cc_command);
         return buildOutputType(gpa, arena, args, .cc);
     } else if (mem.eql(u8, cmd, "c++")) {
+        dev.check(.cc_command);
         return buildOutputType(gpa, arena, args, .cpp);
     } else if (mem.eql(u8, cmd, "translate-c")) {
+        dev.check(.translate_c_command);
         return buildOutputType(gpa, arena, args, .translate_c);
     } else if (mem.eql(u8, cmd, "rc")) {
         const use_server = cmd_args.len > 0 and std.mem.eql(u8, cmd_args[0], "--zig-integration");
@@ -332,16 +333,19 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     } else if (mem.eql(u8, cmd, "init")) {
         return cmdInit(gpa, arena, cmd_args);
     } else if (mem.eql(u8, cmd, "targets")) {
+        dev.check(.targets_command);
         const host = std.zig.resolveTargetQueryOrFatal(.{});
         const stdout = io.getStdOut().writer();
         return @import("print_targets.zig").cmdTargets(arena, cmd_args, stdout, host);
     } else if (mem.eql(u8, cmd, "version")) {
+        dev.check(.version_command);
         try std.io.getStdOut().writeAll(build_options.version ++ "\n");
         // Check libc++ linkage to make sure Zig was built correctly, but only
         // for "env" and "version" to avoid affecting the startup time for
         // build-critical commands (check takes about ~10 μs)
         return verifyLibcxxCorrectlyLinked();
     } else if (mem.eql(u8, cmd, "env")) {
+        dev.check(.env_command);
         verifyLibcxxCorrectlyLinked();
         return @import("print_env.zig").cmdEnv(arena, cmd_args, io.getStdOut().writer());
     } else if (mem.eql(u8, cmd, "reduce")) {
@@ -350,8 +354,10 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
             .root_src_path = "reduce.zig",
         });
     } else if (mem.eql(u8, cmd, "zen")) {
+        dev.check(.zen_command);
         return io.getStdOut().writeAll(info_zen);
     } else if (mem.eql(u8, cmd, "help") or mem.eql(u8, cmd, "-h") or mem.eql(u8, cmd, "--help")) {
+        dev.check(.help_command);
         return io.getStdOut().writeAll(usage);
     } else if (mem.eql(u8, cmd, "ast-check")) {
         return cmdAstCheck(gpa, arena, cmd_args);
@@ -726,14 +732,10 @@ const ArgMode = union(enum) {
     run,
 };
 
-/// Avoid dragging networking into zig2.c because it adds dependencies on some
-/// linker symbols that are annoying to satisfy while bootstrapping.
-const Ip4Address = if (build_options.only_core_functionality) void else std.net.Ip4Address;
-
 const Listen = union(enum) {
     none,
-    ip4: Ip4Address,
-    stdio,
+    stdio: if (dev.env.supports(.stdio_listen)) void else noreturn,
+    ip4: if (dev.env.supports(.network_listen)) std.net.Ip4Address else noreturn,
 };
 
 const ArgsIterator = struct {
@@ -1338,9 +1340,10 @@ fn buildOutputType(
                     } else if (mem.eql(u8, arg, "--listen")) {
                         const next_arg = args_iter.nextOrFatal();
                         if (mem.eql(u8, next_arg, "-")) {
+                            dev.check(.stdio_listen);
                             listen = .stdio;
                         } else {
-                            if (build_options.only_core_functionality) unreachable;
+                            dev.check(.network_listen);
                             // example: --listen 127.0.0.1:9000
                             var it = std.mem.splitScalar(u8, next_arg, ':');
                             const host = it.next().?;
@@ -1351,6 +1354,7 @@ fn buildOutputType(
                                 fatal("invalid host: '{s}': {s}", .{ host, @errorName(err) }) };
                         }
                     } else if (mem.eql(u8, arg, "--listen=-")) {
+                        dev.check(.stdio_listen);
                         listen = .stdio;
                     } else if (mem.eql(u8, arg, "--debug-link-snapshot")) {
                         if (!build_options.enable_link_snapshots) {
@@ -1359,6 +1363,7 @@ fn buildOutputType(
                             enable_link_snapshots = true;
                         }
                     } else if (mem.eql(u8, arg, "-fincremental")) {
+                        dev.check(.incremental);
                         opt_incremental = true;
                     } else if (mem.eql(u8, arg, "-fno-incremental")) {
                         opt_incremental = false;
@@ -1762,7 +1767,7 @@ fn buildOutputType(
             }
         },
         .cc, .cpp => {
-            if (build_options.only_c) unreachable;
+            dev.check(.cc_command);
 
             emit_h = .no;
             soname = .no;
@@ -3395,7 +3400,6 @@ fn buildOutputType(
     switch (listen) {
         .none => {},
         .stdio => {
-            if (build_options.only_c) unreachable;
             try serve(
                 comp,
                 std.io.getStdIn(),
@@ -3409,8 +3413,6 @@ fn buildOutputType(
             return cleanExit();
         },
         .ip4 => |ip4_addr| {
-            if (build_options.only_core_functionality) unreachable;
-
             const addr: std.net.Address = .{ .in = ip4_addr };
 
             var server = try addr.listen(.{
@@ -3454,50 +3456,50 @@ fn buildOutputType(
             else => |e| return e,
         };
     }
-    if (build_options.only_c) return cleanExit();
     try comp.makeBinFileExecutable();
     saveState(comp, incremental);
 
-    if (test_exec_args.items.len == 0 and target.ofmt == .c) default_exec_args: {
-        // Default to using `zig run` to execute the produced .c code from `zig test`.
-        const c_code_loc = emit_bin_loc orelse break :default_exec_args;
-        const c_code_directory = c_code_loc.directory orelse comp.bin_file.?.emit.directory;
-        const c_code_path = try fs.path.join(arena, &[_][]const u8{
-            c_code_directory.path orelse ".", c_code_loc.basename,
-        });
-        try test_exec_args.appendSlice(arena, &.{ self_exe_path, "run" });
-        if (zig_lib_directory.path) |p| {
-            try test_exec_args.appendSlice(arena, &.{ "-I", p });
-        }
-
-        if (create_module.resolved_options.link_libc) {
-            try test_exec_args.append(arena, "-lc");
-        } else if (target.os.tag == .windows) {
-            try test_exec_args.appendSlice(arena, &.{
-                "--subsystem", "console",
-                "-lkernel32",  "-lntdll",
-            });
-        }
-
-        const first_cli_mod = create_module.modules.values()[0];
-        if (first_cli_mod.target_arch_os_abi) |triple| {
-            try test_exec_args.appendSlice(arena, &.{ "-target", triple });
-        }
-        if (first_cli_mod.target_mcpu) |mcpu| {
-            try test_exec_args.append(arena, try std.fmt.allocPrint(arena, "-mcpu={s}", .{mcpu}));
-        }
-        if (create_module.dynamic_linker) |dl| {
-            try test_exec_args.appendSlice(arena, &.{ "--dynamic-linker", dl });
-        }
-        try test_exec_args.append(arena, c_code_path);
-    }
-
-    const run_or_test = switch (arg_mode) {
+    if (switch (arg_mode) {
         .run => true,
         .zig_test => !test_no_exec,
         else => false,
-    };
-    if (run_or_test) {
+    }) {
+        dev.checkAny(&.{ .run_command, .test_command });
+
+        if (test_exec_args.items.len == 0 and target.ofmt == .c) default_exec_args: {
+            // Default to using `zig run` to execute the produced .c code from `zig test`.
+            const c_code_loc = emit_bin_loc orelse break :default_exec_args;
+            const c_code_directory = c_code_loc.directory orelse comp.bin_file.?.emit.directory;
+            const c_code_path = try fs.path.join(arena, &[_][]const u8{
+                c_code_directory.path orelse ".", c_code_loc.basename,
+            });
+            try test_exec_args.appendSlice(arena, &.{ self_exe_path, "run" });
+            if (zig_lib_directory.path) |p| {
+                try test_exec_args.appendSlice(arena, &.{ "-I", p });
+            }
+
+            if (create_module.resolved_options.link_libc) {
+                try test_exec_args.append(arena, "-lc");
+            } else if (target.os.tag == .windows) {
+                try test_exec_args.appendSlice(arena, &.{
+                    "--subsystem", "console",
+                    "-lkernel32",  "-lntdll",
+                });
+            }
+
+            const first_cli_mod = create_module.modules.values()[0];
+            if (first_cli_mod.target_arch_os_abi) |triple| {
+                try test_exec_args.appendSlice(arena, &.{ "-target", triple });
+            }
+            if (first_cli_mod.target_mcpu) |mcpu| {
+                try test_exec_args.append(arena, try std.fmt.allocPrint(arena, "-mcpu={s}", .{mcpu}));
+            }
+            if (create_module.dynamic_linker) |dl| {
+                try test_exec_args.appendSlice(arena, &.{ "--dynamic-linker", dl });
+            }
+            try test_exec_args.append(arena, c_code_path);
+        }
+
         try runOrTest(
             comp,
             gpa,
@@ -4459,7 +4461,8 @@ fn cmdTranslateC(
     file_system_inputs: ?*std.ArrayListUnmanaged(u8),
     prog_node: std.Progress.Node,
 ) !void {
-    if (build_options.only_core_functionality) @panic("@translate-c is not available in a zig2.c build");
+    dev.check(.translate_c_command);
+
     const color: Color = .auto;
     assert(comp.c_source_files.len == 1);
     const c_source_file = comp.c_source_files[0];
@@ -4627,6 +4630,8 @@ const usage_init =
 ;
 
 fn cmdInit(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
+    dev.check(.init_command);
+
     {
         var i: usize = 0;
         while (i < args.len) : (i += 1) {
@@ -4678,6 +4683,8 @@ fn cmdInit(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
 }
 
 fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
+    dev.check(.build_command);
+
     var build_file: ?[]const u8 = null;
     var override_lib_dir: ?[]const u8 = try EnvVar.ZIG_LIB_DIR.get(arena);
     var override_global_cache_dir: ?[]const u8 = try EnvVar.ZIG_GLOBAL_CACHE_DIR.get(arena);
@@ -4969,16 +4976,12 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     });
     defer thread_pool.deinit();
 
-    // Dummy http client that is not actually used when only_core_functionality is enabled.
+    // Dummy http client that is not actually used when fetch_command is unsupported.
     // Prevents bootstrap from depending on a bunch of unnecessary stuff.
-    const HttpClient = if (build_options.only_core_functionality) struct {
+    var http_client: if (dev.env.supports(.fetch_command)) std.http.Client else struct {
         allocator: Allocator,
-        fn deinit(self: *@This()) void {
-            _ = self;
-        }
-    } else std.http.Client;
-
-    var http_client: HttpClient = .{ .allocator = gpa };
+        fn deinit(_: @This()) void {}
+    } = .{ .allocator = gpa };
     defer http_client.deinit();
 
     var unlazy_set: Package.Fetch.JobQueue.UnlazySet = .{};
@@ -5045,16 +5048,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
             var cleanup_build_dir: ?fs.Dir = null;
             defer if (cleanup_build_dir) |*dir| dir.close();
 
-            if (build_options.only_core_functionality) {
-                try createEmptyDependenciesModule(
-                    arena,
-                    root_mod,
-                    global_cache_directory,
-                    local_cache_directory,
-                    builtin_mod,
-                    config,
-                );
-            } else {
+            if (dev.env.supports(.fetch_command)) {
                 const fetch_prog_node = root_prog_node.start("Fetch Packages", 0);
                 defer fetch_prog_node.end();
 
@@ -5203,7 +5197,14 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
                         }
                     }
                 }
-            }
+            } else try createEmptyDependenciesModule(
+                arena,
+                root_mod,
+                global_cache_directory,
+                local_cache_directory,
+                builtin_mod,
+                config,
+            );
 
             try root_mod.deps.put(arena, "@build", build_mod);
 
@@ -5269,7 +5270,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
                     if (code == 2) process.exit(2);
 
                     if (code == 3) {
-                        if (build_options.only_core_functionality) process.exit(3);
+                        if (!dev.env.supports(.fetch_command)) process.exit(3);
                         // Indicates the configure phase failed due to missing lazy
                         // dependencies and stdout contains the hashes of the ones
                         // that are missing.
@@ -5346,6 +5347,8 @@ fn jitCmd(
     args: []const []const u8,
     options: JitCmdOptions,
 ) !void {
+    dev.check(.jit_command);
+
     const color: Color = .auto;
     const root_prog_node = if (options.progress_node) |node| node else std.Progress.start(.{
         .disable_printing = (color == .off),
@@ -5995,6 +5998,8 @@ fn cmdAstCheck(
     arena: Allocator,
     args: []const []const u8,
 ) !void {
+    dev.check(.ast_check_command);
+
     const Zir = std.zig.Zir;
 
     var color: Color = .auto;
@@ -6154,6 +6159,8 @@ fn cmdDetectCpu(
     arena: Allocator,
     args: []const []const u8,
 ) !void {
+    dev.check(.detect_cpu_command);
+
     _ = gpa;
     _ = arena;
 
@@ -6293,6 +6300,8 @@ fn cmdDumpLlvmInts(
     arena: Allocator,
     args: []const []const u8,
 ) !void {
+    dev.check(.llvm_ints_command);
+
     _ = gpa;
 
     if (!build_options.have_llvm)
@@ -6336,6 +6345,8 @@ fn cmdDumpZir(
     arena: Allocator,
     args: []const []const u8,
 ) !void {
+    dev.check(.dump_zir_command);
+
     _ = arena;
     const Zir = std.zig.Zir;
 
@@ -6395,6 +6406,8 @@ fn cmdChangelist(
     arena: Allocator,
     args: []const []const u8,
 ) !void {
+    dev.check(.changelist_command);
+
     const color: Color = .auto;
     const Zir = std.zig.Zir;
 
@@ -6895,6 +6908,8 @@ fn cmdFetch(
     arena: Allocator,
     args: []const []const u8,
 ) !void {
+    dev.check(.fetch_command);
+
     const color: Color = .auto;
     const work_around_btrfs_bug = native_os == .linux and
         EnvVar.ZIG_BTRFS_WORKAROUND.isSet();

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -9,6 +9,7 @@ const builtin = @import("builtin");
 const Compilation = @import("Compilation.zig");
 const build_options = @import("build_options");
 const Cache = std.Build.Cache;
+const dev = @import("dev.zig");
 
 pub const CRTFile = enum {
     crt2_o,
@@ -157,7 +158,8 @@ fn add_cc_args(
 }
 
 pub fn buildImportLib(comp: *Compilation, lib_name: []const u8) !void {
-    if (build_options.only_c) @compileError("building import libs not included in core functionality");
+    dev.check(.build_import_lib);
+
     var arena_allocator = std.heap.ArenaAllocator.init(comp.gpa);
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();

--- a/stage1/config.zig.in
+++ b/stage1/config.zig.in
@@ -12,5 +12,4 @@ pub const enable_tracy = false;
 pub const value_tracing = false;
 pub const skip_non_native = false;
 pub const force_gpa = false;
-pub const only_c = false;
-pub const only_core_functionality = true;
+pub const dev = .core;


### PR DESCRIPTION
This allows specifying a development environment for reducing compile times while building the compiler, each targeted at developing a specific part of the compiler.  The legacy options `build_options.only_c` and `build_options.only_core_functionality` have been replaced with the new system.  This system allows easily specifying new optional features and new environments independently.
```
$ time zig build -Dno-lib -Duse-llvm=false -Ddev=full

real	0m9.462s
user	0m13.092s
sys	0m1.371s
$ time zig build -Dno-lib -Duse-llvm=false -Ddev=x86_64-linux

real	0m5.578s
user	0m7.295s
sys	0m0.860s
$ zig-out/bin/zig build
thread 292207 panic: Development environment x86_64-linux does not support feature build_command
```