### PR TITLE
fix: Add error notes for method calls on double pointers

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -28026,7 +28026,7 @@ fn fieldCallBind(
         }
         if (is_double_ptr) {
             try sema.errNote(src, msg, "method invocation only supports up to one level of implicit pointer dereferencing", .{});
-            try sema.errNote(src, msg, "the dereference operator is '.*'", .{});
+            try sema.errNote(src, msg, "use '.*' to dereference pointer", .{});
         }
         break :msg msg;
     };

--- a/test/cases/compile_errors/call_from_double_ptr.zig
+++ b/test/cases/compile_errors/call_from_double_ptr.zig
@@ -10,5 +10,6 @@ export fn entry(a: **S) void {
 // backend=stage2
 // target=native
 //
-// 6:10: error: type '*const **tmp.S' does not support member function invocation
-// 6:10: note: consider dereferencing using '.*'
+// 6:10: error: no field or member function named 'b' in '*tmp.S'
+// 6:10: note: method invocation only supports up to one level of implicit pointer dereferencing
+// 6:10: note: the dereference operator is '.*'

--- a/test/cases/compile_errors/call_from_double_ptr.zig
+++ b/test/cases/compile_errors/call_from_double_ptr.zig
@@ -1,0 +1,14 @@
+const S = struct {
+    fn b() void {}
+};
+
+export fn entry(a: **S) void {
+    _ = a.b();
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// 6:10: error: type '*const **tmp.S' does not support member function invocation
+// 6:10: note: consider dereferencing using '.*'

--- a/test/cases/compile_errors/call_from_double_ptr.zig
+++ b/test/cases/compile_errors/call_from_double_ptr.zig
@@ -12,4 +12,4 @@ export fn entry(a: **S) void {
 //
 // 6:10: error: no field or member function named 'b' in '*tmp.S'
 // 6:10: note: method invocation only supports up to one level of implicit pointer dereferencing
-// 6:10: note: the dereference operator is '.*'
+// 6:10: note: use '.*' to dereference pointer


### PR DESCRIPTION
Fixes the error message and adds a note when an attempt is made to invoke a method on a double pointer. Consider the following code:

```zig
const S = struct {
    fn b() void {}
};

export fn entry(a: **S) void {
    _ = a.b();
}
```

Before:

```shell
install
└─ install test_zig
   └─ zig build-exe test_zig Debug native 2 errors
src/main.zig:6:10: error: no field or member function named 'b' in '*main.S'
    _ = a.b();
        ~^~
```

After:

```shell
install
└─ install test_zig
   └─ zig build-exe test_zig Debug native 2 errors
src/main.zig:6:10: error: no field or member function named 'b' in '*main.S'
    _ = a.b();
        ~^~
src/main.zig:6:10: note: method invocation only supports up to one level of implicit pointer dereferencing
src/main.zig:6:10: note: use '.*' to dereference pointer
```

<details>
<Summary>Original revised messages </Summary>

```shell
install
└─ install test_zig
   └─ zig build-exe test_zig Debug native 2 errors
src/main.zig:6:10: error: type '*const **main.S' does not support member function invocation
    _ = a.b();
        ~^~
src/main.zig:6:10: note: consider dereferencing using '.*'
```
</details>

Closes #19963 