### PR TITLE
Add option to specify language of CSourceFiles

### DIFF
--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -78,15 +78,28 @@ pub const SystemLib = struct {
     pub const SearchStrategy = enum { paths_first, mode_first, no_fallback };
 };
 
-pub const ForeignSourceLanguage = enum {
+pub const CSourceLanguage = enum {
     c,
     cpp,
-    assembly,
-    assembly_with_cpp,
-    objc,
-    objcpp,
 
-    find_by_file_extension,
+    objective_c,
+    objective_cpp,
+
+    /// Standard assembly
+    assembly,
+    /// Assembly with the C preprocessor
+    assembly_with_preprocessor,
+
+    pub fn internalIdentifier(self: CSourceLanguage) []const u8 {
+        return switch (self) {
+            .c => "c",
+            .cpp => "c++",
+            .objective_c => "objective-c",
+            .objective_cpp => "objective-c++",
+            .assembly => "assembler",
+            .assembly_with_preprocessor => "assembler-with-cpp",
+        };
+    }
 };
 
 pub const CSourceFiles = struct {
@@ -95,13 +108,15 @@ pub const CSourceFiles = struct {
     /// the build root by default
     files: []const []const u8,
     flags: []const []const u8,
-    language: ForeignSourceLanguage,
+    /// By default, determines language of each file individually based on its file extension
+    language: ?CSourceLanguage,
 };
 
 pub const CSourceFile = struct {
     file: LazyPath,
     flags: []const []const u8 = &.{},
-    language: ForeignSourceLanguage = .find_by_file_extension,
+    /// By default, determines language of each file individually based on its file extension
+    language: ?CSourceLanguage = null,
 
     pub fn dupe(file: CSourceFile, b: *std.Build) CSourceFile {
         return .{
@@ -392,7 +407,8 @@ pub const AddCSourceFilesOptions = struct {
     root: ?LazyPath = null,
     files: []const []const u8,
     flags: []const []const u8 = &.{},
-    language: ForeignSourceLanguage = .find_by_file_extension,
+    /// By default, determines language of each file individually based on its file extension
+    language: ?CSourceLanguage = null,
 };
 
 /// Handy when you have many non-Zig source files and want them all to have the same flags.

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1254,22 +1254,14 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                             }
                             prev_has_cflags = (c_source_file.flags.len != 0);
 
-                            if (c_source_file.language != .find_by_file_extension) {
+                            if (c_source_file.language) |lang| {
                                 try zig_args.append("-x");
-                                try zig_args.append(switch (c_source_file.language) {
-                                    .find_by_file_extension => unreachable,
-                                    .c => "c",
-                                    .cpp => "c++",
-                                    .assembly => "assembler",
-                                    .assembly_with_cpp => "assembler-with-cpp",
-                                    .objc => "objective-c",
-                                    .objcpp => "objective-c++",
-                                });
+                                try zig_args.append(lang.internalIdentifier());
                             }
 
                             try zig_args.append(c_source_file.file.getPath2(mod.owner, step));
 
-                            if (c_source_file.language != .find_by_file_extension) {
+                            if (c_source_file.language != null) {
                                 try zig_args.append("-x");
                                 try zig_args.append("none");
                             }
@@ -1288,17 +1280,9 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                             }
                             prev_has_cflags = (c_source_files.flags.len != 0);
 
-                            if (c_source_files.language != .find_by_file_extension) {
+                            if (c_source_files.language) |lang| {
                                 try zig_args.append("-x");
-                                try zig_args.append(switch (c_source_files.language) {
-                                    .find_by_file_extension => unreachable,
-                                    .c => "c",
-                                    .cpp => "c++",
-                                    .assembly => "assembler",
-                                    .assembly_with_cpp => "assembler-with-cpp",
-                                    .objc => "objective-c",
-                                    .objcpp => "objective-c++",
-                                });
+                                try zig_args.append(lang.internalIdentifier());
                             }
 
                             const root_path = c_source_files.root.getPath2(mod.owner, step);
@@ -1306,7 +1290,7 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                                 try zig_args.append(b.pathJoin(&.{ root_path, file }));
                             }
 
-                            if (c_source_files.language != .find_by_file_extension) {
+                            if (c_source_files.language != null) {
                                 try zig_args.append("-x");
                                 try zig_args.append("none");
                             }

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1245,45 +1245,70 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                         .c_source_file => |c_source_file| l: {
                             if (!my_responsibility) break :l;
 
-                            if (c_source_file.flags.len == 0) {
-                                if (prev_has_cflags) {
-                                    try zig_args.append("-cflags");
-                                    try zig_args.append("--");
-                                    prev_has_cflags = false;
-                                }
-                            } else {
+                            if (prev_has_cflags or c_source_file.flags.len != 0) {
                                 try zig_args.append("-cflags");
                                 for (c_source_file.flags) |arg| {
                                     try zig_args.append(arg);
                                 }
                                 try zig_args.append("--");
-                                prev_has_cflags = true;
                             }
+                            prev_has_cflags = (c_source_file.flags.len != 0);
+
+                            if (c_source_file.language != .find_by_file_extension) {
+                                try zig_args.append("-x");
+                                try zig_args.append(switch (c_source_file.language) {
+                                    .find_by_file_extension => unreachable,
+                                    .c => "c",
+                                    .cpp => "c++",
+                                    .assembly => "assembler",
+                                    .assembly_with_cpp => "assembler-with-cpp",
+                                    .objc => "objective-c",
+                                    .objcpp => "objective-c++",
+                                });
+                            }
+
                             try zig_args.append(c_source_file.file.getPath2(mod.owner, step));
+
+                            if (c_source_file.language != .find_by_file_extension) {
+                                try zig_args.append("-x");
+                                try zig_args.append("none");
+                            }
                             total_linker_objects += 1;
                         },
 
                         .c_source_files => |c_source_files| l: {
                             if (!my_responsibility) break :l;
 
-                            if (c_source_files.flags.len == 0) {
-                                if (prev_has_cflags) {
-                                    try zig_args.append("-cflags");
-                                    try zig_args.append("--");
-                                    prev_has_cflags = false;
-                                }
-                            } else {
+                            if (prev_has_cflags or c_source_files.flags.len != 0) {
                                 try zig_args.append("-cflags");
-                                for (c_source_files.flags) |flag| {
-                                    try zig_args.append(flag);
+                                for (c_source_files.flags) |arg| {
+                                    try zig_args.append(arg);
                                 }
                                 try zig_args.append("--");
-                                prev_has_cflags = true;
+                            }
+                            prev_has_cflags = (c_source_files.flags.len != 0);
+
+                            if (c_source_files.language != .find_by_file_extension) {
+                                try zig_args.append("-x");
+                                try zig_args.append(switch (c_source_files.language) {
+                                    .find_by_file_extension => unreachable,
+                                    .c => "c",
+                                    .cpp => "c++",
+                                    .assembly => "assembler",
+                                    .assembly_with_cpp => "assembler-with-cpp",
+                                    .objc => "objective-c",
+                                    .objcpp => "objective-c++",
+                                });
                             }
 
                             const root_path = c_source_files.root.getPath2(mod.owner, step);
                             for (c_source_files.files) |file| {
                                 try zig_args.append(b.pathJoin(&.{ root_path, file }));
+                            }
+
+                            if (c_source_files.language != .find_by_file_extension) {
+                                try zig_args.append("-x");
+                                try zig_args.append("none");
                             }
 
                             total_linker_objects += c_source_files.files.len;


### PR DESCRIPTION
Closes #20655

The `addCSourceFile` functions gain an optional `language` field which defaults to the current behavior (find the language by the file extension of each input).

This does not add support for any new languages beyond what `addCSourceFile` already supports: the C languages and assembly.