### PR TITLE
introduce a new tool for testing incremental compilation

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -2522,7 +2522,7 @@ pub const InstallDir = union(enum) {
 /// function.
 pub fn makeTempPath(b: *Build) []const u8 {
     const rand_int = std.crypto.random.int(u64);
-    const tmp_dir_sub_path = "tmp" ++ fs.path.sep_str ++ hex64(rand_int);
+    const tmp_dir_sub_path = "tmp" ++ fs.path.sep_str ++ std.fmt.hex(rand_int);
     const result_path = b.cache_root.join(b.allocator, &.{tmp_dir_sub_path}) catch @panic("OOM");
     b.cache_root.handle.makePath(tmp_dir_sub_path) catch |err| {
         std.debug.print("unable to make tmp path '{s}': {s}\n", .{
@@ -2532,18 +2532,9 @@ pub fn makeTempPath(b: *Build) []const u8 {
     return result_path;
 }
 
-/// There are a few copies of this function in miscellaneous places. Would be nice to find
-/// a home for them.
+/// Deprecated; use `std.fmt.hex` instead.
 pub fn hex64(x: u64) [16]u8 {
-    const hex_charset = "0123456789abcdef";
-    var result: [16]u8 = undefined;
-    var i: usize = 0;
-    while (i < 8) : (i += 1) {
-        const byte: u8 = @truncate(x >> @as(u6, @intCast(8 * i)));
-        result[i * 2 + 0] = hex_charset[byte >> 4];
-        result[i * 2 + 1] = hex_charset[byte & 15];
-    }
-    return result;
+    return std.fmt.hex(x);
 }
 
 /// A pair of target query and fully resolved target.

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -457,7 +457,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
 
             const rand_int = std.crypto.random.int(u64);
             const tmp_sub_path = "tmp" ++ fs.path.sep_str ++
-                std.Build.hex64(rand_int) ++ fs.path.sep_str ++
+                std.fmt.hex(rand_int) ++ fs.path.sep_str ++
                 basename;
             const tmp_sub_path_dirname = fs.path.dirname(tmp_sub_path).?;
 

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -743,7 +743,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
 
     // We do not know the final output paths yet, use temp paths to run the command.
     const rand_int = std.crypto.random.int(u64);
-    const tmp_dir_path = "tmp" ++ fs.path.sep_str ++ std.Build.hex64(rand_int);
+    const tmp_dir_path = "tmp" ++ fs.path.sep_str ++ std.fmt.hex(rand_int);
 
     for (output_placeholders.items) |placeholder| {
         const output_components = .{ tmp_dir_path, placeholder.output.basename };

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2722,7 +2722,7 @@ test "recursive format function" {
 pub const hex_charset = "0123456789abcdef";
 
 /// Converts an unsigned integer of any multiple of u8 to an array of lowercase
-/// hex bytes.
+/// hex bytes, little endian.
 pub fn hex(x: anytype) [@sizeOf(@TypeOf(x)) * 2]u8 {
     comptime assert(@typeInfo(@TypeOf(x)).Int.signedness == .unsigned);
     var result: [@sizeOf(@TypeOf(x)) * 2]u8 = undefined;
@@ -2739,17 +2739,11 @@ test hex {
     {
         const x = hex(@as(u32, 0xdeadbeef));
         try std.testing.expect(x.len == 8);
-        switch (builtin.cpu.arch.endian()) {
-            .little => try std.testing.expectEqualStrings("efbeadde", &x),
-            .big => try std.testing.expectEqualStrings("deadbeef", &x),
-        }
+        try std.testing.expectEqualStrings("efbeadde", &x);
     }
     {
         const s = "[" ++ hex(@as(u64, 0x12345678_abcdef00)) ++ "]";
         try std.testing.expect(s.len == 18);
-        switch (builtin.cpu.arch.endian()) {
-            .little => try std.testing.expectEqualStrings("[00efcdab78563412]", s),
-            .big => try std.testing.expectEqualStrings("[12345678abcdef00]", s),
-        }
+        try std.testing.expectEqualStrings("[00efcdab78563412]", s);
     }
 }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2718,3 +2718,38 @@ test "recursive format function" {
     var r = R{ .Leaf = 1 };
     try expectFmt("Leaf(1)\n", "{}\n", .{&r});
 }
+
+pub const hex_charset = "0123456789abcdef";
+
+/// Converts an unsigned integer of any multiple of u8 to an array of lowercase
+/// hex bytes.
+pub fn hex(x: anytype) [@sizeOf(@TypeOf(x)) * 2]u8 {
+    comptime assert(@typeInfo(@TypeOf(x)).Int.signedness == .unsigned);
+    var result: [@sizeOf(@TypeOf(x)) * 2]u8 = undefined;
+    var i: usize = 0;
+    while (i < result.len / 2) : (i += 1) {
+        const byte: u8 = @truncate(x >> @intCast(8 * i));
+        result[i * 2 + 0] = hex_charset[byte >> 4];
+        result[i * 2 + 1] = hex_charset[byte & 15];
+    }
+    return result;
+}
+
+test hex {
+    {
+        const x = hex(@as(u32, 0xdeadbeef));
+        try std.testing.expect(x.len == 8);
+        switch (builtin.cpu.arch.endian()) {
+            .little => try std.testing.expectEqualStrings("efbeadde", &x),
+            .big => try std.testing.expectEqualStrings("deadbeef", &x),
+        }
+    }
+    {
+        const s = "[" ++ hex(@as(u64, 0x12345678_abcdef00)) ++ "]";
+        try std.testing.expect(s.len == 18);
+        switch (builtin.cpu.arch.endian()) {
+            .little => try std.testing.expectEqualStrings("[00efcdab78563412]", s),
+            .big => try std.testing.expectEqualStrings("[12345678abcdef00]", s),
+        }
+    }
+}

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -2032,3 +2032,9 @@ pub fn createWindowsEnvBlock(allocator: mem.Allocator, env_map: *const EnvMap) !
     i += 1;
     return try allocator.realloc(result, i);
 }
+
+/// Logs an error and then terminates the process with exit code 1.
+pub fn fatal(comptime format: []const u8, format_arguments: anytype) noreturn {
+    std.log.err(format, format_arguments);
+    exit(1);
+}

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -667,10 +667,8 @@ pub fn parseTargetQueryOrReportFatalError(
     };
 }
 
-pub fn fatal(comptime format: []const u8, args: anytype) noreturn {
-    std.log.err(format, args);
-    std.process.exit(1);
-}
+/// Deprecated; see `std.process.fatal`.
+pub const fatal = std.process.fatal;
 
 /// Collects all the environment variables that Zig could possibly inspect, so
 /// that we can do reflection on this and print them with `zig env`.

--- a/lib/std/zig/Server.zig
+++ b/lib/std/zig/Server.zig
@@ -109,6 +109,7 @@ pub fn deinit(s: *Server) void {
 pub fn receiveMessage(s: *Server) !InMessage.Header {
     const Header = InMessage.Header;
     const fifo = &s.receive_fifo;
+    var last_amt_zero = false;
 
     while (true) {
         const buf = fifo.readableSlice(0);
@@ -136,6 +137,10 @@ pub fn receiveMessage(s: *Server) !InMessage.Header {
         const write_buffer = try fifo.writableWithSize(256);
         const amt = try s.in.read(write_buffer);
         fifo.update(amt);
+        if (amt == 0) {
+            if (last_amt_zero) return error.BrokenPipe;
+            last_amt_zero = true;
+        }
     }
 }
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2106,7 +2106,7 @@ pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) !void {
             const tmp_artifact_directory = d: {
                 const s = std.fs.path.sep_str;
                 tmp_dir_rand_int = std.crypto.random.int(u64);
-                const tmp_dir_sub_path = "tmp" ++ s ++ Package.Manifest.hex64(tmp_dir_rand_int);
+                const tmp_dir_sub_path = "tmp" ++ s ++ std.fmt.hex(tmp_dir_rand_int);
 
                 const path = try comp.local_cache_directory.join(gpa, &.{tmp_dir_sub_path});
                 errdefer gpa.free(path);
@@ -2298,7 +2298,7 @@ pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) !void {
             } else unreachable;
 
             const s = std.fs.path.sep_str;
-            const tmp_dir_sub_path = "tmp" ++ s ++ Package.Manifest.hex64(tmp_dir_rand_int);
+            const tmp_dir_sub_path = "tmp" ++ s ++ std.fmt.hex(tmp_dir_rand_int);
             const o_sub_path = "o" ++ s ++ digest;
 
             // Work around windows `AccessDenied` if any files within this

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -445,7 +445,7 @@ fn runResource(
     const s = fs.path.sep_str;
     const cache_root = f.job_queue.global_cache;
     const rand_int = std.crypto.random.int(u64);
-    const tmp_dir_sub_path = "tmp" ++ s ++ Manifest.hex64(rand_int);
+    const tmp_dir_sub_path = "tmp" ++ s ++ std.fmt.hex(rand_int);
 
     const package_sub_path = blk: {
         const tmp_directory_path = try cache_root.join(arena, &.{tmp_dir_sub_path});

--- a/src/Package/Manifest.zig
+++ b/src/Package/Manifest.zig
@@ -1,3 +1,12 @@
+const Manifest = @This();
+const std = @import("std");
+const mem = std.mem;
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
+const Ast = std.zig.Ast;
+const testing = std.testing;
+const hex_charset = std.fmt.hex_charset;
+
 pub const max_bytes = 10 * 1024 * 1024;
 pub const basename = "build.zig.zon";
 pub const Hash = std.crypto.hash.sha2.Sha256;
@@ -151,24 +160,6 @@ pub fn copyErrorsIntoBundle(
             }),
         });
     }
-}
-
-const hex_charset = "0123456789abcdef";
-
-pub fn hex64(x: u64) [16]u8 {
-    var result: [16]u8 = undefined;
-    var i: usize = 0;
-    while (i < 8) : (i += 1) {
-        const byte = @as(u8, @truncate(x >> @as(u6, @intCast(8 * i))));
-        result[i * 2 + 0] = hex_charset[byte >> 4];
-        result[i * 2 + 1] = hex_charset[byte & 15];
-    }
-    return result;
-}
-
-test hex64 {
-    const s = "[" ++ hex64(0x12345678_abcdef00) ++ "]";
-    try std.testing.expectEqualStrings("[00efcdab78563412]", s);
 }
 
 pub fn hexDigest(digest: Digest) MultiHashHexDigest {
@@ -589,14 +580,6 @@ const Parse = struct {
         });
     }
 };
-
-const Manifest = @This();
-const std = @import("std");
-const mem = std.mem;
-const Allocator = std.mem.Allocator;
-const assert = std.debug.assert;
-const Ast = std.zig.Ast;
-const testing = std.testing;
 
 test "basic" {
     const gpa = testing.allocator;

--- a/src/link.zig
+++ b/src/link.zig
@@ -1031,7 +1031,7 @@ pub fn spawnLld(
             error.NameTooLong => err: {
                 const s = fs.path.sep_str;
                 const rand_int = std.crypto.random.int(u64);
-                const rsp_path = "tmp" ++ s ++ Package.Manifest.hex64(rand_int) ++ ".rsp";
+                const rsp_path = "tmp" ++ s ++ std.fmt.hex(rand_int) ++ ".rsp";
 
                 const rsp_file = try comp.local_cache_directory.handle.createFileZ(rsp_path, .{});
                 defer comp.local_cache_directory.handle.deleteFileZ(rsp_path) catch |err|

--- a/src/main.zig
+++ b/src/main.zig
@@ -4746,7 +4746,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     // the strategy is to choose a temporary file name ahead of time, and then
     // read this file in the parent to obtain the results, in the case the child
     // exits with code 3.
-    const results_tmp_file_nonce = Package.Manifest.hex64(std.crypto.random.int(u64));
+    const results_tmp_file_nonce = std.fmt.hex(std.crypto.random.int(u64));
     try child_argv.append("-Z" ++ results_tmp_file_nonce);
 
     var color: Color = .auto;
@@ -7196,8 +7196,7 @@ fn createDependenciesModule(
     // Atomically create the file in a directory named after the hash of its contents.
     const basename = "dependencies.zig";
     const rand_int = std.crypto.random.int(u64);
-    const tmp_dir_sub_path = "tmp" ++ fs.path.sep_str ++
-        Package.Manifest.hex64(rand_int);
+    const tmp_dir_sub_path = "tmp" ++ fs.path.sep_str ++ std.fmt.hex(rand_int);
     {
         var tmp_dir = try local_cache_directory.handle.makeOpenPath(tmp_dir_sub_path, .{});
         defer tmp_dir.close();

--- a/test/incremental/hello
+++ b/test/incremental/hello
@@ -1,12 +1,14 @@
 #target=x86_64-linux
 #update=initial version
 #file=main.zig
+const std = @import("std");
 pub fn main() !void {
     try std.io.getStdOut().writeAll("good morning\n");
 }
 #expect_stdout="good morning\n"
 #update=change the string
 #file=main.zig
+const std = @import("std");
 pub fn main() !void {
     try std.io.getStdOut().writeAll("おはようございます\n");
 }

--- a/test/incremental/hello
+++ b/test/incremental/hello
@@ -1,0 +1,13 @@
+#target=x86_64-linux
+#update=initial version
+#file=main.zig
+pub fn main() !void {
+    try std.io.getStdOut().writeAll("good morning\n");
+}
+#expect_stdout="good morning\n"
+#update=change the string
+#file=main.zig
+pub fn main() !void {
+    try std.io.getStdOut().writeAll("おはようございます\n");
+}
+#expect_stdout="おはようございます\n"

--- a/tools/incr-check.zig
+++ b/tools/incr-check.zig
@@ -1,0 +1,215 @@
+const std = @import("std");
+const fatal = std.process.fatal;
+const Allocator = std.mem.Allocator;
+
+pub fn main() !void {
+    var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_instance.deinit();
+    const arena = arena_instance.allocator();
+
+    const args = try std.process.argsAlloc(arena);
+    const zig_exe = args[1];
+    const input_file_name = args[2];
+
+    const input_file_bytes = try std.fs.cwd().readFileAlloc(arena, input_file_name, std.math.maxInt(u32));
+    const case = try Case.parse(arena, input_file_bytes);
+
+    const prog_node = std.Progress.start(.{});
+    defer prog_node.end();
+
+    const rand_int = std.crypto.random.int(u64);
+    const tmp_dir_path = "tmp_" ++ std.fmt.hex(rand_int);
+    const local_cache_path = tmp_dir_path ++ std.fs.path.sep_str ++ ".local-cache";
+    const global_cache_path = tmp_dir_path ++ std.fs.path.sep_str ++ ".global-cache";
+    const tmp_dir = try std.fs.cwd().makeOpenPath(tmp_dir_path, .{});
+
+    const child_prog_node = prog_node.start("zig build-exe", 0);
+    defer child_prog_node.end();
+
+    var child = std.process.Child.init(&.{
+        zig_exe,
+        "build-exe",
+        case.root_source_file,
+        "-fno-llvm",
+        "-fno-lld",
+        "-fincremental",
+        "--listen=-",
+        "-target",
+        case.target_query,
+        "--cache-dir",
+        local_cache_path,
+        "--global-cache-dir",
+        global_cache_path,
+    }, arena);
+
+    child.stdin_behavior = .Pipe;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    child.progress_node = child_prog_node;
+
+    var eval: Eval = .{
+        .case = case,
+        .tmp_dir = tmp_dir,
+        .child = &child,
+    };
+
+    eval.write(case.updates[0]);
+
+    try child.spawn();
+
+    var poller = std.io.poll(arena, enum { stdout, stderr }, .{
+        .stdout = child.stdout.?,
+        .stderr = child.stderr.?,
+    });
+    defer poller.deinit();
+
+    try eval.check(case.updates[0]);
+
+    for (case.updates[1..]) |update| {
+        eval.write(update);
+        try eval.requestIncrementalUpdate();
+        try eval.check(update);
+    }
+}
+
+const Eval = struct {
+    case: Case,
+    tmp_dir: std.fs.Dir,
+    child: *std.process.Child,
+
+    /// Currently this function assumes the previous updates have already been written.
+    fn write(eval: *Eval, update: Case.Update) void {
+        for (update.changes) |full_contents| {
+            eval.tmp_dir.writeFile(.{
+                .sub_path = full_contents.name,
+                .data = full_contents.bytes,
+            }) catch |err| {
+                fatal("failed to update '{s}': {s}", .{ full_contents.name, @errorName(err) });
+            };
+        }
+        for (update.deletes) |doomed_name| {
+            eval.tmp_dir.deleteFile(doomed_name) catch |err| {
+                fatal("failed to delete '{s}': {s}", .{ doomed_name, @errorName(err) });
+            };
+        }
+    }
+
+    fn check(eval: *Eval, update: Case.Update) !void {
+        _ = eval;
+        _ = update;
+        @panic("TODO: read messages from the compiler");
+    }
+
+    fn requestIncrementalUpdate(eval: *Eval) !void {
+        _ = eval;
+        @panic("TODO: send update request to the compiler");
+    }
+};
+
+const Case = struct {
+    updates: []Update,
+    root_source_file: []const u8,
+    target_query: []const u8,
+
+    const Update = struct {
+        name: []const u8,
+        outcome: Outcome,
+        changes: []const FullContents = &.{},
+        deletes: []const []const u8 = &.{},
+    };
+
+    const FullContents = struct {
+        name: []const u8,
+        bytes: []const u8,
+    };
+
+    const Outcome = union(enum) {
+        unknown,
+        compile_errors: []const ExpectedError,
+        stdout: []const u8,
+        exit_code: u8,
+    };
+
+    const ExpectedError = struct {
+        file_name: ?[]const u8 = null,
+        line: ?u32 = null,
+        column: ?u32 = null,
+        msg_exact: ?[]const u8 = null,
+        msg_substring: ?[]const u8 = null,
+    };
+
+    fn parse(arena: Allocator, bytes: []const u8) !Case {
+        var updates: std.ArrayListUnmanaged(Update) = .{};
+        var changes: std.ArrayListUnmanaged(FullContents) = .{};
+        var target_query: ?[]const u8 = null;
+        var it = std.mem.splitScalar(u8, bytes, '\n');
+        var line_n: usize = 1;
+        var root_source_file: ?[]const u8 = null;
+        while (it.next()) |line| : (line_n += 1) {
+            if (std.mem.startsWith(u8, line, "#")) {
+                var line_it = std.mem.splitScalar(u8, line, '=');
+                const key = line_it.first()[1..];
+                const val = line_it.rest();
+                if (val.len == 0) {
+                    fatal("line {d}: missing value", .{line_n});
+                } else if (std.mem.eql(u8, key, "target")) {
+                    if (target_query != null) fatal("line {d}: duplicate target", .{line_n});
+                    target_query = val;
+                } else if (std.mem.eql(u8, key, "update")) {
+                    if (updates.items.len > 0) {
+                        const last_update = &updates.items[updates.items.len - 1];
+                        last_update.changes = try changes.toOwnedSlice(arena);
+                    }
+                    try updates.append(arena, .{
+                        .name = val,
+                        .outcome = .unknown,
+                    });
+                } else if (std.mem.eql(u8, key, "file")) {
+                    if (updates.items.len == 0) fatal("line {d}: expect directive before update", .{line_n});
+
+                    if (root_source_file == null)
+                        root_source_file = val;
+
+                    const start_index = it.index.?;
+                    const src = while (true) : (line_n += 1) {
+                        const old = it;
+                        const next_line = it.next() orelse fatal("line {d}: unexpected EOF", .{line_n});
+                        if (std.mem.startsWith(u8, next_line, "#")) {
+                            const end_index = old.index.?;
+                            const src = bytes[start_index..end_index];
+                            it = old;
+                            break src;
+                        }
+                    };
+
+                    try changes.append(arena, .{
+                        .name = val,
+                        .bytes = src,
+                    });
+                } else if (std.mem.eql(u8, key, "expect_stdout")) {
+                    if (updates.items.len == 0) fatal("line {d}: expect directive before update", .{line_n});
+                    const last_update = &updates.items[updates.items.len - 1];
+                    if (last_update.outcome != .unknown) fatal("line {d}: conflicting expect directive", .{line_n});
+                    last_update.outcome = .{
+                        .stdout = std.zig.string_literal.parseAlloc(arena, val) catch |err| {
+                            fatal("line {d}: bad string literal: {s}", .{ line_n, @errorName(err) });
+                        },
+                    };
+                } else {
+                    fatal("line {d}: unrecognized key '{s}'", .{ line_n, key });
+                }
+            }
+        }
+
+        if (changes.items.len > 0) {
+            const last_update = &updates.items[updates.items.len - 1];
+            last_update.changes = try changes.toOwnedSlice(arena);
+        }
+
+        return .{
+            .updates = updates.items,
+            .root_source_file = root_source_file orelse fatal("missing root source file", .{}),
+            .target_query = target_query orelse fatal("missing target", .{}),
+        };
+    }
+};


### PR DESCRIPTION
This is a tiny component of an overall testing strategy. This provides the ability to have compact test cases that can be run with a single command which are then tested in isolation, aiding reproducibility. For example, I have included one test case along with this tool:

```
#target=x86_64-linux
#update=initial version
#file=main.zig
const std = @import("std");
pub fn main() !void {
    try std.io.getStdOut().writeAll("good morning\n");
}
#expect_stdout="good morning\n"
#update=change the string
#file=main.zig
const std = @import("std");
pub fn main() !void {
    try std.io.getStdOut().writeAll("おはようございます\n");
}
#expect_stdout="おはようございます\n"
```

You can run it like this:

```
$ stage3/bin/zig run ../tools/incr-check.zig -- stage4/bin/zig ../test/incremental/hello 
error: update 'change the string' failed:
thread 619922 panic: reached unreachable code
/home/andy/dev/zig/lib/std/debug.zig:404:14: 0x18c18ad in assert (zig)
    if (!ok) unreachable; // assertion failure
             ^
/home/andy/dev/zig/src/InternPool.zig:698:27: 0x1f94180 in view (zig)
                    assert(capacity > 0); // optimizes `MultiArrayList.Slice.items`
                          ^
/home/andy/dev/zig/src/Zcu/PerThread.zig:373:37: 0x1d3d9ea in updateZirRefs (zig)
        for (tracked_insts_list.view().items(.@"0"), 0..) |*tracked_inst, tracked_inst_unwrapped_index| {
                                    ^
/home/andy/dev/zig/src/Compilation.zig:3602:33: 0x1b0f249 in performAllTheWorkInner (zig)
            try pt.updateZirRefs();
                                ^
/home/andy/dev/zig/src/Compilation.zig:3496:36: 0x19d2b53 in performAllTheWork (zig)
    try comp.performAllTheWorkInner(main_progress_node);
                                   ^
/home/andy/dev/zig/src/Compilation.zig:2231:31: 0x19cf318 in update (zig)
    try comp.performAllTheWork(main_progress_node);
                              ^
/home/andy/dev/zig/src/main.zig:4104:32: 0x1a13cf3 in serve (zig)
                try comp.update(main_progress_node);
                               ^
/home/andy/dev/zig/src/main.zig:3399:22: 0x1a316c6 in buildOutputType (zig)
            try serve(
                     ^
/home/andy/dev/zig/src/main.zig:263:31: 0x18c387a in mainArgs (zig)
        return buildOutputType(gpa, arena, args, .{ .build = .Exe });
                              ^
/home/andy/dev/zig/src/main.zig:209:20: 0x18bf9fa in main (zig)
    return mainArgs(gpa, arena, args);
                   ^
/home/andy/dev/zig/lib/std/start.zig:532:37: 0x18bf0f5 in posixCallMainAndExit (zig)
            const result = root.main() catch |err| {
                                    ^
/home/andy/dev/zig/lib/std/start.zig:277:5: 0x18bec11 in _start (zig)
    asm volatile (switch (native_arch) {
    ^
???:?:?: 0xc in ??? (???)
Unwind information for `???:0xc` was not available, trace may be incomplete
```

You can see how once this patchset is merged, this will become our first incremental compilation bug report, and it comes with a reduction.

A future enhancement will provide the ability to generate these test cases using fuzzer input and test various properties, such as path independence.