### PR TITLE
dev: fix llvm backend checks

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1729,7 +1729,6 @@ pub fn create(gpa: Allocator, arena: Allocator, options: CreateOptions) !*Compil
             comp.emit_llvm_ir != null or
             comp.emit_llvm_bc != null))
         {
-            dev.check(.llvm_backend);
             if (opt_zcu) |zcu| zcu.llvm_object = try LlvmObject.create(arena, comp);
         }
 
@@ -2704,7 +2703,7 @@ pub fn emitLlvmObject(
     arena: Allocator,
     default_emit: Emit,
     bin_emit_loc: ?EmitLoc,
-    llvm_object: *LlvmObject,
+    llvm_object: LlvmObject.Ptr,
     prog_node: std.Progress.Node,
 ) !void {
     const sub_prog_node = prog_node.start("LLVM Emit Object", 0);

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -58,7 +58,7 @@ comp: *Compilation,
 /// Usually, the LlvmObject is managed by linker code, however, in the case
 /// that -fno-emit-bin is specified, the linker code never executes, so we
 /// store the LlvmObject here.
-llvm_object: if (dev.env.supports(.llvm_backend)) ?*LlvmObject else ?noreturn,
+llvm_object: ?LlvmObject.Ptr,
 
 /// Pointer to externally managed resource.
 root_mod: *Package.Module,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -26,6 +26,7 @@ const wasm_c_abi = @import("../arch/wasm/abi.zig");
 const aarch64_c_abi = @import("../arch/aarch64/abi.zig");
 const arm_c_abi = @import("../arch/arm/abi.zig");
 const riscv_c_abi = @import("../arch/riscv64/abi.zig");
+const dev = @import("../dev.zig");
 
 const target_util = @import("../target.zig");
 const libcFloatPrefix = target_util.libcFloatPrefix;
@@ -865,9 +866,12 @@ pub const Object = struct {
         field_index: u32,
     };
 
+    pub const Ptr = if (dev.env.supports(.llvm_backend)) *Object else noreturn;
+
     pub const TypeMap = std.AutoHashMapUnmanaged(InternPool.Index, Builder.Type);
 
-    pub fn create(arena: Allocator, comp: *Compilation) !*Object {
+    pub fn create(arena: Allocator, comp: *Compilation) !Ptr {
+        dev.check(.llvm_backend);
         const gpa = comp.gpa;
         const target = comp.root_mod.resolved_target.result;
         const llvm_target_triple = try targetTriple(arena, target);

--- a/src/dev.zig
+++ b/src/dev.zig
@@ -23,7 +23,6 @@ pub const Env = enum {
     sema,
 
     /// - sema
-    /// - jit command on x86_64-linux host
     /// - `zig build-* -fno-llvm -fno-lld -target x86_64-linux`
     @"x86_64-linux",
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -968,7 +968,7 @@ pub const File = struct {
     pub fn emitLlvmObject(
         base: File,
         arena: Allocator,
-        llvm_object: *LlvmObject,
+        llvm_object: LlvmObject.Ptr,
         prog_node: std.Progress.Node,
     ) !void {
         return base.comp.emitLlvmObject(arena, base.emit, .{

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -4,7 +4,7 @@
 //! LLD is also the default linker for LLVM.
 
 /// If this is not null, an object file is created by LLVM and emitted to zcu_object_sub_path.
-llvm_object: ?*LlvmObject = null,
+llvm_object: ?LlvmObject.Ptr = null,
 
 base: link.File,
 image_base: u64,
@@ -2765,6 +2765,7 @@ const StringTable = @import("StringTable.zig");
 const Type = @import("../Type.zig");
 const Value = @import("../Value.zig");
 const AnalUnit = InternPool.AnalUnit;
+const dev = @import("../dev.zig");
 
 pub const base_tag: link.File.Tag = .coff;
 

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -30,7 +30,7 @@ entry_name: ?[]const u8,
 ptr_width: PtrWidth,
 
 /// If this is not null, an object file is created by LLVM and emitted to zcu_object_sub_path.
-llvm_object: ?*LlvmObject = null,
+llvm_object: ?LlvmObject.Ptr = null,
 
 /// A list of all input files.
 /// Index of each input file also encodes the priority or precedence of one input file

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -1113,6 +1113,7 @@ const x86_64 = struct {
         code: ?[]const u8,
         it: *RelocsIterator,
     ) !void {
+        dev.check(.x86_64_backend);
         const is_static = elf_file.base.isStatic();
         const is_dyn_lib = elf_file.isEffectivelyDynLib();
 
@@ -1235,6 +1236,7 @@ const x86_64 = struct {
         code: []u8,
         stream: anytype,
     ) (error{ InvalidInstruction, CannotEncode } || RelocError)!void {
+        dev.check(.x86_64_backend);
         const r_type: elf.R_X86_64 = @enumFromInt(rel.r_type());
         const r_offset = std.math.cast(usize, rel.r_offset) orelse return error.Overflow;
 
@@ -1380,6 +1382,7 @@ const x86_64 = struct {
         code: []u8,
         stream: anytype,
     ) !void {
+        dev.check(.x86_64_backend);
         _ = code;
         _ = it;
         const r_type: elf.R_X86_64 = @enumFromInt(rel.r_type());
@@ -1420,6 +1423,7 @@ const x86_64 = struct {
     }
 
     fn relaxGotpcrelx(code: []u8) !void {
+        dev.check(.x86_64_backend);
         const old_inst = disassemble(code) orelse return error.RelaxFailure;
         const inst = switch (old_inst.encoding.mnemonic) {
             .call => try Instruction.new(old_inst.prefix, .call, &.{
@@ -1438,6 +1442,7 @@ const x86_64 = struct {
     }
 
     fn relaxRexGotpcrelx(code: []u8) !void {
+        dev.check(.x86_64_backend);
         const old_inst = disassemble(code) orelse return error.RelaxFailure;
         switch (old_inst.encoding.mnemonic) {
             .mov => {
@@ -1456,6 +1461,7 @@ const x86_64 = struct {
         elf_file: *Elf,
         stream: anytype,
     ) !void {
+        dev.check(.x86_64_backend);
         assert(rels.len == 2);
         const writer = stream.writer();
         const rel: elf.R_X86_64 = @enumFromInt(rels[1].r_type());
@@ -1495,6 +1501,7 @@ const x86_64 = struct {
         elf_file: *Elf,
         stream: anytype,
     ) !void {
+        dev.check(.x86_64_backend);
         assert(rels.len == 2);
         const writer = stream.writer();
         const rel: elf.R_X86_64 = @enumFromInt(rels[1].r_type());
@@ -1543,6 +1550,7 @@ const x86_64 = struct {
     }
 
     fn canRelaxGotTpOff(code: []const u8) bool {
+        dev.check(.x86_64_backend);
         const old_inst = disassemble(code) orelse return false;
         switch (old_inst.encoding.mnemonic) {
             .mov => if (Instruction.new(old_inst.prefix, .mov, &.{
@@ -1558,6 +1566,7 @@ const x86_64 = struct {
     }
 
     fn relaxGotTpOff(code: []u8) void {
+        dev.check(.x86_64_backend);
         const old_inst = disassemble(code) orelse unreachable;
         switch (old_inst.encoding.mnemonic) {
             .mov => {
@@ -1574,6 +1583,7 @@ const x86_64 = struct {
     }
 
     fn relaxGotPcTlsDesc(code: []u8) !void {
+        dev.check(.x86_64_backend);
         const old_inst = disassemble(code) orelse return error.RelaxFailure;
         switch (old_inst.encoding.mnemonic) {
             .lea => {
@@ -1596,6 +1606,7 @@ const x86_64 = struct {
         elf_file: *Elf,
         stream: anytype,
     ) !void {
+        dev.check(.x86_64_backend);
         assert(rels.len == 2);
         const writer = stream.writer();
         const rel: elf.R_X86_64 = @enumFromInt(rels[1].r_type());
@@ -2312,3 +2323,4 @@ const File = @import("file.zig").File;
 const Object = @import("Object.zig");
 const Symbol = @import("Symbol.zig");
 const Thunk = @import("thunks.zig").Thunk;
+const dev = @import("../../dev.zig");

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1,7 +1,7 @@
 base: link.File,
 
 /// If this is not null, an object file is created by LLVM and emitted to zcu_object_sub_path.
-llvm_object: ?*LlvmObject = null,
+llvm_object: ?LlvmObject.Ptr = null,
 
 /// Debug symbols bundle (or dSym).
 d_sym: ?DebugSymbols = null,
@@ -4510,7 +4510,6 @@ const dead_strip = @import("MachO/dead_strip.zig");
 const eh_frame = @import("MachO/eh_frame.zig");
 const fat = @import("MachO/fat.zig");
 const link = @import("../link.zig");
-const llvm_backend = @import("../codegen/llvm.zig");
 const load_commands = @import("MachO/load_commands.zig");
 const relocatable = @import("MachO/relocatable.zig");
 const tapi = @import("tapi.zig");
@@ -4562,6 +4561,7 @@ const UnwindInfo = @import("MachO/UnwindInfo.zig");
 const WeakBind = bind.WeakBind;
 const ZigGotSection = synthetic.ZigGotSection;
 const ZigObject = @import("MachO/ZigObject.zig");
+const dev = @import("../dev.zig");
 
 pub const MachError = error{
     /// Not enough permissions held to perform the requested kernel

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -897,6 +897,7 @@ fn resolveRelocInner(
 
 const x86_64 = struct {
     fn relaxGotLoad(self: Atom, code: []u8, rel: Relocation, macho_file: *MachO) ResolveError!void {
+        dev.check(.x86_64_backend);
         const old_inst = disassemble(code) orelse return error.RelaxFail;
         switch (old_inst.encoding.mnemonic) {
             .mov => {
@@ -920,6 +921,7 @@ const x86_64 = struct {
     }
 
     fn relaxTlv(code: []u8) error{RelaxFail}!void {
+        dev.check(.x86_64_backend);
         const old_inst = disassemble(code) orelse return error.RelaxFail;
         switch (old_inst.encoding.mnemonic) {
             .mov => {
@@ -1214,3 +1216,4 @@ const Relocation = @import("Relocation.zig");
 const Symbol = @import("Symbol.zig");
 const Thunk = @import("thunks.zig").Thunk;
 const UnwindInfo = @import("UnwindInfo.zig");
+const dev = @import("../../dev.zig");

--- a/src/link/NvPtx.zig
+++ b/src/link/NvPtx.zig
@@ -23,7 +23,7 @@ const Liveness = @import("../Liveness.zig");
 const LlvmObject = @import("../codegen/llvm.zig").Object;
 
 base: link.File,
-llvm_object: *LlvmObject,
+llvm_object: LlvmObject.Ptr,
 
 pub fn createEmpty(
     arena: Allocator,

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -61,7 +61,7 @@ export_table: bool,
 /// Output name of the file
 name: []const u8,
 /// If this is not null, an object file is created by LLVM and linked with LLD afterwards.
-llvm_object: ?*LlvmObject = null,
+llvm_object: ?LlvmObject.Ptr = null,
 /// The file index of a `ZigObject`. This will only contain a valid index when a zcu exists,
 /// and the chosen backend is the Wasm backend.
 zig_object_index: File.Index = .null,


### PR DESCRIPTION
I didn't notice there were `*LlvmObject` fields and other sus things in the linkers.
```
$ zig build -Dno-lib -Duse-llvm=false -Ddev=full

real	0m9.431s
user	0m13.153s
sys	0m1.196s
$ zig build -Dno-lib -Duse-llvm=false -Ddev=x86_64-linux

real	0m4.635s
user	0m6.017s
sys	0m0.740s
```