### PR TITLE
fix: remove misleading error note for failed array assignments

### DIFF
--- a/test/cases/compile_errors/invalid_array_assignment_with_valid_elems.zig
+++ b/test/cases/compile_errors/invalid_array_assignment_with_valid_elems.zig
@@ -1,0 +1,11 @@
+export fn a() void {
+    const x = [_]u16{ 1, 2, 3 };
+    const y: [3]i32 = x;
+    _ = y;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// 3:23: error: expected type '[3]i32', found '[3]u16'


### PR DESCRIPTION
Prevents a misleading error note from being printed when an attempt is made to assign one array to another with coercible (but different!) element types. Taking the example from the #19541:

```zig
const std = @import("std");

test {
    const a = [_]u16{ 1, 2, 3 };
    const b: [3]i32 = a;
    try std.testing.expectEqual([_]i32{ 1, 2, 3 }, b);
}
```

Any `u16` value could indeed be represented by an `i32`, however the compiler's notes indicate otherwise:

Before:

```shell
❯ zig build test
test
└─ run test
   └─ zig test Debug native 1 errors
src/main.zig:21:23: error: expected type '[3]i32', found '[3]u16'
    const b: [3]i32 = a;
                      ^
src/main.zig:21:23: note: array element type 'u16' cannot cast into array element type 'i32'
src/main.zig:21:23: note: signed 32-bit int cannot represent all possible unsigned 16-bit values
```

After the fix:

```shell
❯ zig build test
test
└─ run test
   └─ zig test Debug native 1 errors
src/main.zig:21:23: error: expected type '[3]i32', found '[3]u16'
    const b: [3]i32 = a;
                      ^
```

I wanted to note that that there are similar code paths in `coerceInMemoryAllowed` for Vectors and Arrays <-> Vectors, but testing out the analogous cases doesn't lead to any compiler errors.

<details>
<Summary>Vectors</Summary>

```zig
const std = @import("std");

test {
    const a = @Vector(3, u16){ 1, 2, 3 };
    const b: @Vector(3, i32) = a; // this is fine
    _ = b;
}
```
</details>

<details>
<Summary>Arrays<->Vectors</Summary>

```zig
const std = @import("std");

test {
    const a = @Vector(3, u16){ 1, 2, 3 };
    const b: [3]i32 = a; // fine
    _ = b;

    const c = [_]u16{ 1, 2, 3 };
    const d: @Vector(3, i32) = c; // also fine
    _ = d;
}
```
</details>

Closes #19541