### PR TITLE
Fix typos in code comments in `src/`

### DIFF
--- a/src/Air.zig
+++ b/src/Air.zig
@@ -271,7 +271,7 @@ pub const Inst = struct {
         /// Uses the `ty_pl` field with payload `Block`.  A block runs its body which always ends
         /// with a `noreturn` instruction, so the only way to proceed to the code after the `block`
         /// is to encounter a `br` that targets this `block`.  If the `block` type is `noreturn`,
-        /// then there do not exist any `br` instructions targetting this `block`.
+        /// then there do not exist any `br` instructions targeting this `block`.
         block,
         /// A labeled block of code that loops forever. At the end of the body it is implied
         /// to repeat; no explicit "repeat" instruction terminates loop bodies.
@@ -357,7 +357,7 @@ pub const Inst = struct {
         /// Base 10 logarithm of a floating point number.
         /// Uses the `un_op` field.
         log10,
-        /// Aboslute value of an integer, floating point number or vector.
+        /// Absolute value of an integer, floating point number or vector.
         /// Result type is always unsigned if the operand is an integer.
         /// Uses the `ty_op` field.
         abs,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -239,7 +239,7 @@ pub const InferredErrorSet = struct {
 /// Stores the mapping from `Zir.Inst.Index -> Air.Inst.Ref`, which is used by sema to resolve
 /// instructions during analysis.
 /// Instead of a hash table approach, InstMap is simply a slice that is indexed into using the
-/// zir instruction index and a start offset. An index is not pressent in the map if the value
+/// zir instruction index and a start offset. An index is not present in the map if the value
 /// at the index is `Air.Inst.Ref.none`.
 /// `ensureSpaceForInstructions` can be called to force InstMap to have a mapped range that
 /// includes all instructions in a slice. After calling this function, `putAssumeCapacity*` can

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -692,7 +692,7 @@ mir_extra: std.ArrayListUnmanaged(u32) = .{},
 /// When a function is executing, we store the the current stack pointer's value within this local.
 /// This value is then used to restore the stack pointer to the original value at the return of the function.
 initial_stack_value: WValue = .none,
-/// The current stack pointer substracted with the stack size. From this value, we will calculate
+/// The current stack pointer subtracted with the stack size. From this value, we will calculate
 /// all offsets of the stack values.
 bottom_stack_value: WValue = .none,
 /// Arguments of this function declaration
@@ -1294,7 +1294,7 @@ fn genFunc(func: *CodeGen) InnerError!void {
         try prologue.append(.{ .tag = .i32_const, .data = .{ .imm32 = @intCast(aligned_stack) } });
         // subtract it from the current stack pointer
         try prologue.append(.{ .tag = .i32_sub, .data = .{ .tag = {} } });
-        // Get negative stack aligment
+        // Get negative stack alignment
         try prologue.append(.{ .tag = .i32_const, .data = .{ .imm32 = @as(i32, @intCast(func.stack_alignment.toByteUnits().?)) * -1 } });
         // Bitwise-and the value to get the new stack pointer to ensure the pointers are aligned with the abi alignment
         try prologue.append(.{ .tag = .i32_and, .data = .{ .tag = {} } });
@@ -4921,7 +4921,7 @@ fn memset(func: *CodeGen, elem_ty: Type, ptr: WValue, len: WValue, value: WValue
     try func.startBlock(.block, wasm.block_empty);
     try func.startBlock(.loop, wasm.block_empty);
 
-    // check for codition for loop end
+    // check for condition for loop end
     try func.emitWValue(new_ptr);
     try func.emitWValue(end_ptr);
     switch (func.arch()) {

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -2685,7 +2685,7 @@ pub fn spillInstruction(self: *Self, reg: Register, inst: Air.Inst.Index) !void 
     const tracking = self.inst_tracking.getPtr(inst) orelse return;
     for (tracking.getRegs()) |tracked_reg| {
         if (tracked_reg.id() == reg.id()) break;
-    } else unreachable; // spilled reg not tracked with spilled instruciton
+    } else unreachable; // spilled reg not tracked with spilled instruction
     try tracking.spill(self, inst);
     try tracking.trackSpill(self, inst);
 }

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -1014,7 +1014,7 @@ pub const DeclGen = struct {
                     try writer.writeAll(", ");
                     empty = false;
                 } else {
-                    // isSignalNan is equivalent to isNan currently, and MSVC doens't have nans, so prefer nan
+                    // isSignalNan is equivalent to isNan currently, and MSVC doesn't have nans, so prefer nan
                     const operation = if (std.math.isNan(f128_val))
                         "nan"
                     else if (std.math.isSignalNan(f128_val))

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -855,7 +855,7 @@ pub const Object = struct {
     /// table for every zig source field of the struct that has a corresponding
     /// LLVM struct field. comptime fields are not included. Zero-bit fields are
     /// mapped to a field at the correct byte, which may be a padding field, or
-    /// are not mapped, in which case they are sematically at the end of the
+    /// are not mapped, in which case they are semantically at the end of the
     /// struct.
     /// The value is the LLVM struct field index.
     /// This is denormalized data.

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -3845,7 +3845,7 @@ const DeclGen = struct {
                     const result = try self.normalize(low_bits, info);
 
                     // Now, we need to check the overflow bits AND the sign
-                    // bit for the expceted overflow bits.
+                    // bit for the expected overflow bits.
                     // To do that, shift out everything bit the sign bit and
                     // then check what remains.
                     const shift = Temporary.init(full_result.ty, try self.constInt(full_result.ty, info.bits - 1, .direct));

--- a/src/link/SpirV/lower_invocation_globals.zig
+++ b/src/link/SpirV/lower_invocation_globals.zig
@@ -403,7 +403,7 @@ const ModuleBuilder = struct {
                 .OpTypeFunction => {
                     // Re-emitted in `emitFunctionTypes()`. We can do this because
                     // OpTypeFunction's may not currently be used anywhere that is not
-                    // directly with an OpFunction. For now we igore Intels function
+                    // directly with an OpFunction. For now we ignore Intels function
                     // pointers extension, that is not a problem with a generalized
                     // pass anyway.
                     continue;

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -1314,7 +1314,7 @@ fn validateFeatures(
 /// Creates synthetic linker-symbols, but only if they are being referenced from
 /// any object file. For instance, the `__heap_base` symbol will only be created,
 /// if one or multiple undefined references exist. When none exist, the symbol will
-/// not be created, ensuring we don't unneccesarily emit unreferenced symbols.
+/// not be created, ensuring we don't unnecessarily emit unreferenced symbols.
 fn resolveLazySymbols(wasm: *Wasm) !void {
     const comp = wasm.base.comp;
     const gpa = comp.gpa;
@@ -2340,10 +2340,10 @@ fn setupMemory(wasm: *Wasm) !void {
             try wasm.addErrorWithoutNotes("Maximum memory must be {d}-byte aligned", .{page_size});
         }
         if (memory_ptr > max_memory) {
-            try wasm.addErrorWithoutNotes("Maxmimum memory too small, must be at least {d} bytes", .{memory_ptr});
+            try wasm.addErrorWithoutNotes("Maximum memory too small, must be at least {d} bytes", .{memory_ptr});
         }
         if (max_memory > max_memory_allowed) {
-            try wasm.addErrorWithoutNotes("Maximum memory exceeds maxmium amount {d}", .{max_memory_allowed});
+            try wasm.addErrorWithoutNotes("Maximum memory exceeds maximum amount {d}", .{max_memory_allowed});
         }
         wasm.memories.limits.max = @as(u32, @intCast(max_memory / page_size));
         wasm.memories.limits.setFlag(.WASM_LIMITS_FLAG_HAS_MAX);

--- a/src/link/Wasm/Atom.zig
+++ b/src/link/Wasm/Atom.zig
@@ -14,7 +14,7 @@ alignment: Wasm.Alignment = .@"1",
 /// Offset into the section where the atom lives, this already accounts
 /// for alignment.
 offset: u32 = 0,
-/// The original offset within the object file. This value is substracted from
+/// The original offset within the object file. This value is subtracted from
 /// relocation offsets to determine where in the `data` to rewrite the value
 original_offset: u32 = 0,
 /// Previous atom in relation to this atom.

--- a/src/link/Wasm/Object.zig
+++ b/src/link/Wasm/Object.zig
@@ -220,7 +220,7 @@ pub fn findImport(object: *const Object, sym: Symbol) types.Import {
 }
 
 /// Checks if the object file is an MVP version.
-/// When that's the case, we check if there's an import table definiton with its name
+/// When that's the case, we check if there's an import table definition with its name
 /// set to '__indirect_function_table". When that's also the case,
 /// we initialize a new table symbol that corresponds to that import and return that symbol.
 ///
@@ -315,7 +315,7 @@ pub const ParseError = error{
     Overflow,
     /// Found table definitions but no corresponding table symbols
     MissingTableSymbols,
-    /// Did not expect a table definiton, but did find one
+    /// Did not expect a table definition, but did find one
     UnexpectedTable,
     /// Object file contains a feature that is unknown to the linker
     UnknownFeature,

--- a/src/link/Wasm/Symbol.zig
+++ b/src/link/Wasm/Symbol.zig
@@ -57,7 +57,7 @@ pub const Tag = enum {
 pub const Flag = enum(u32) {
     /// Indicates a weak symbol.
     /// When linking multiple modules defining the same symbol, all weak definitions are discarded
-    /// in favourite of the strong definition. When no strong definition exists, all weak but one definiton is discarded.
+    /// in favourite of the strong definition. When no strong definition exists, all weak but one definition is discarded.
     /// If multiple definitions remain, we get an error: symbol collision.
     WASM_SYM_BINDING_WEAK = 0x1,
     /// Indicates a local, non-exported, non-module-linked symbol.

--- a/src/link/Wasm/ZigObject.zig
+++ b/src/link/Wasm/ZigObject.zig
@@ -1053,7 +1053,7 @@ fn setupErrorsLen(zig_object: *ZigObject, wasm_file: *Wasm) !void {
 
     const errors_len = 1 + wasm_file.base.comp.module.?.intern_pool.global_error_set.getNamesFromMainThread().len;
     // overwrite existing atom if it already exists (maybe the error set has increased)
-    // if not, allcoate a new atom.
+    // if not, allocate a new atom.
     const atom_index = if (wasm_file.symbol_atom.get(.{ .file = zig_object.index, .index = sym_index })) |index| blk: {
         const atom = wasm_file.getAtomPtr(index);
         atom.prev = .null;
@@ -1179,7 +1179,7 @@ pub fn storeDeclType(zig_object: *ZigObject, gpa: std.mem.Allocator, decl_index:
 }
 
 /// The symbols in ZigObject are already represented by an atom as we need to store its data.
-/// So rather than creating a new Atom and returning its index, we use this oppertunity to scan
+/// So rather than creating a new Atom and returning its index, we use this opportunity to scan
 /// its relocations and create any GOT symbols or function table indexes it may require.
 pub fn parseSymbolIntoAtom(zig_object: *ZigObject, wasm_file: *Wasm, index: Symbol.Index) !Atom.Index {
     const gpa = wasm_file.base.comp.gpa;


### PR DESCRIPTION
I've been reading some parts of the source code, because I wanted to know if CPython can be compiled with `zig cc -Wall -Werror -Wextra -fsanitize=undefined` (`address` did not work for some reason). And I found a typo in the source. Then I executed `codespell` and here are the results :)

What a ride! 😆 