### PR TITLE
Allow for codesign on macos x86_64

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -3419,12 +3419,7 @@ pub fn requiresCodeSig(self: MachO) bool {
     // if (self.options.adhoc_codesign) |cs| return cs;
     const target = self.getTarget();
     return switch (target.cpu.arch) {
-        .aarch64 => switch (target.os.tag) {
-            .macos => true,
-            .watchos, .tvos, .ios, .visionos => target.abi == .simulator,
-            else => false,
-        },
-        .x86_64 => switch (target.os.tag) {
+        .aarch64, .x86_64 => switch (target.os.tag) {
             .macos => true,
             .watchos, .tvos, .ios, .visionos => target.abi == .simulator,
             else => false,

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -3424,7 +3424,11 @@ pub fn requiresCodeSig(self: MachO) bool {
             .watchos, .tvos, .ios, .visionos => target.abi == .simulator,
             else => false,
         },
-        .x86_64 => false,
+        .x86_64 => switch (target.os.tag) {
+            .macos => true,
+            .watchos, .tvos, .ios, .visionos => target.abi == .simulator,
+            else => false,
+        },
         else => unreachable,
     };
 }

--- a/test/link/macho.zig
+++ b/test/link/macho.zig
@@ -786,13 +786,12 @@ fn testLayout(b: *Build, opts: Options) *Step {
     check.checkExtract("nindirectsyms {dysymnsyms}");
 
     switch (opts.target.result.cpu.arch) {
-        .aarch64 => {
+        .aarch64, .x86_64 => {
             check.checkInHeaders();
             check.checkExact("cmd CODE_SIGNATURE");
             check.checkExtract("dataoff {codesigoff}");
             check.checkExtract("datasize {codesigsize}");
         },
-        .x86_64 => {},
         else => unreachable,
     }
 
@@ -829,7 +828,7 @@ fn testLayout(b: *Build, opts: Options) *Step {
     check.checkComputeCompare("dysymoff 8 %", .{ .op = .eq, .value = .{ .literal = 0 } });
 
     switch (opts.target.result.cpu.arch) {
-        .aarch64 => {
+        .aarch64, .x86_64 => {
             // LINKEDIT segment does not extend beyond, or does not include, CODE_SIGNATURE data
             check.checkComputeCompare("fileoff filesz codesigoff codesigsize + - -", .{
                 .op = .eq,
@@ -838,13 +837,6 @@ fn testLayout(b: *Build, opts: Options) *Step {
 
             // CODE_SIGNATURE data offset is 16-bytes aligned
             check.checkComputeCompare("codesigoff 16 %", .{ .op = .eq, .value = .{ .literal = 0 } });
-        },
-        .x86_64 => {
-            // LINKEDIT segment does not extend beyond, or does not include, strtab data
-            check.checkComputeCompare("fileoff filesz stroff strsize + - -", .{
-                .op = .eq,
-                .value = .{ .literal = 0 },
-            });
         },
         else => unreachable,
     }


### PR DESCRIPTION
This change creates space for a code signature on macos x86_64 executables. This allows apple's codesign utility to work as expected instead of overwriting something important.

main.zig
```
const std = @import("std");

pub fn main() void {
    std.debug.print("Hello, world!", .{});
}
```

Output
```
~/git/codesign-pr via ↯ v0.13.0
❯ zig build-exe main.zig -Dtarget=macos-x86_64
❯ ./main
Hello, world!
❯ codesign -f -v -s "..." main
main: signed Mach-O thin (x86_64) [main]
❯ ./main
Bus error: 10
```
