### PR TITLE
`std.posix`: Make `sigaction()` infallible

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -414,9 +414,7 @@ pub fn start(options: Options) Node {
                     .mask = posix.empty_sigset,
                     .flags = (posix.SA.SIGINFO | posix.SA.RESTART),
                 };
-                posix.sigaction(posix.SIG.WINCH, &act, null) catch |err| {
-                    std.log.warn("failed to install SIGWINCH signal handler for noticing terminal resizes: {s}", .{@errorName(err)});
-                };
+                posix.sigaction(posix.SIG.WINCH, &act, null);
             }
 
             if (switch (global_progress.terminal_mode) {

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -2601,11 +2601,11 @@ pub fn maybeEnableSegfaultHandler() void {
 
 var windows_segfault_handle: ?windows.HANDLE = null;
 
-pub fn updateSegfaultHandler(act: ?*const posix.Sigaction) error{OperationNotSupported}!void {
-    try posix.sigaction(posix.SIG.SEGV, act, null);
-    try posix.sigaction(posix.SIG.ILL, act, null);
-    try posix.sigaction(posix.SIG.BUS, act, null);
-    try posix.sigaction(posix.SIG.FPE, act, null);
+pub fn updateSegfaultHandler(act: ?*const posix.Sigaction) void {
+    posix.sigaction(posix.SIG.SEGV, act, null);
+    posix.sigaction(posix.SIG.ILL, act, null);
+    posix.sigaction(posix.SIG.BUS, act, null);
+    posix.sigaction(posix.SIG.FPE, act, null);
 }
 
 /// Attaches a global SIGSEGV handler which calls `@panic("segmentation fault");`
@@ -2623,9 +2623,7 @@ pub fn attachSegfaultHandler() void {
         .flags = (posix.SA.SIGINFO | posix.SA.RESTART | posix.SA.RESETHAND),
     };
 
-    updateSegfaultHandler(&act) catch {
-        @panic("unable to install segfault handler, maybe adjust have_segfault_handling_support in std/debug.zig");
-    };
+    updateSegfaultHandler(&act);
 }
 
 fn resetSegfaultHandler() void {
@@ -2641,8 +2639,7 @@ fn resetSegfaultHandler() void {
         .mask = posix.empty_sigset,
         .flags = 0,
     };
-    // To avoid a double-panic, do nothing if an error happens here.
-    updateSegfaultHandler(&act) catch {};
+    updateSegfaultHandler(&act);
 }
 
 fn handleSegfaultPosix(sig: i32, info: *const posix.siginfo_t, ctx_ptr: ?*anyopaque) callconv(.C) noreturn {

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -5661,7 +5661,7 @@ pub fn sigaltstack(ss: ?*stack_t, old_ss: ?*stack_t) SigaltstackError!void {
 pub fn sigaction(sig: u6, noalias act: ?*const Sigaction, noalias oact: ?*Sigaction) error{OperationNotSupported}!void {
     switch (errno(system.sigaction(sig, act, oact))) {
         .SUCCESS => return,
-        .INVAL, .NOSYS => return error.OperationNotSupported,
+        .INVAL => return error.OperationNotSupported,
         else => unreachable,
     }
 }

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -862,10 +862,10 @@ test "sigaction" {
     var old_sa: posix.Sigaction = undefined;
 
     // Install the new signal handler.
-    try posix.sigaction(posix.SIG.USR1, &sa, null);
+    posix.sigaction(posix.SIG.USR1, &sa, null);
 
     // Check that we can read it back correctly.
-    try posix.sigaction(posix.SIG.USR1, null, &old_sa);
+    posix.sigaction(posix.SIG.USR1, null, &old_sa);
     try testing.expectEqual(&S.handler, old_sa.handler.sigaction.?);
     try testing.expect((old_sa.flags & posix.SA.SIGINFO) != 0);
 
@@ -874,26 +874,26 @@ test "sigaction" {
     try testing.expect(S.handler_called_count == 1);
 
     // Check if passing RESETHAND correctly reset the handler to SIG_DFL
-    try posix.sigaction(posix.SIG.USR1, null, &old_sa);
+    posix.sigaction(posix.SIG.USR1, null, &old_sa);
     try testing.expectEqual(posix.SIG.DFL, old_sa.handler.handler);
 
     // Reinstall the signal w/o RESETHAND and re-raise
     sa.flags = posix.SA.SIGINFO;
-    try posix.sigaction(posix.SIG.USR1, &sa, null);
+    posix.sigaction(posix.SIG.USR1, &sa, null);
     try posix.raise(posix.SIG.USR1);
     try testing.expect(S.handler_called_count == 2);
 
     // Now set the signal to ignored
     sa.handler = .{ .handler = posix.SIG.IGN };
     sa.flags = 0;
-    try posix.sigaction(posix.SIG.USR1, &sa, null);
+    posix.sigaction(posix.SIG.USR1, &sa, null);
 
     // Re-raise to ensure handler is actually ignored
     try posix.raise(posix.SIG.USR1);
     try testing.expect(S.handler_called_count == 2);
 
     // Ensure that ignored state is returned when querying
-    try posix.sigaction(posix.SIG.USR1, null, &old_sa);
+    posix.sigaction(posix.SIG.USR1, null, &old_sa);
     try testing.expectEqual(posix.SIG.IGN, old_sa.handler.handler.?);
 }
 

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -609,8 +609,7 @@ fn maybeIgnoreSigpipe() void {
             .mask = posix.empty_sigset,
             .flags = 0,
         };
-        posix.sigaction(posix.SIG.PIPE, &act, null) catch |err|
-            std.debug.panic("failed to set noop SIGPIPE handler: {s}", .{@errorName(err)});
+        posix.sigaction(posix.SIG.PIPE, &act, null);
     }
 }
 

--- a/src/crash_report.zig
+++ b/src/crash_report.zig
@@ -163,9 +163,7 @@ pub fn attachSegfaultHandler() void {
         .flags = (posix.SA.SIGINFO | posix.SA.RESTART | posix.SA.RESETHAND),
     };
 
-    debug.updateSegfaultHandler(&act) catch {
-        @panic("unable to install segfault handler, maybe adjust have_segfault_handling_support in std/debug.zig");
-    };
+    debug.updateSegfaultHandler(&act);
 }
 
 fn handleSegfaultPosix(sig: i32, info: *const posix.siginfo_t, ctx_ptr: ?*anyopaque) callconv(.C) noreturn {


### PR DESCRIPTION
See commit messages for justification.

Closes #20704.