### PR TITLE
Update std to use pointer subtraction when appropriate

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1483,15 +1483,10 @@ pub fn HashMapUnmanaged(
         /// key_ptr is assumed to be a valid pointer to a key that is present
         /// in the hash map.
         pub fn removeByPtr(self: *Self, key_ptr: *K) void {
-            // TODO: replace with pointer subtraction once supported by zig
             // if @sizeOf(K) == 0 then there is at most one item in the hash
             // map, which is assumed to exist as key_ptr must be valid.  This
             // item must be at index 0.
-            const idx = if (@sizeOf(K) > 0)
-                (@intFromPtr(key_ptr) - @intFromPtr(self.keys())) / @sizeOf(K)
-            else
-                0;
-
+            const idx = if (@sizeOf(K) == 0) 0 else key_ptr - self.keys();
             self.removeByIndex(idx);
         }
 

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1486,7 +1486,7 @@ pub fn HashMapUnmanaged(
             // if @sizeOf(K) == 0 then there is at most one item in the hash
             // map, which is assumed to exist as key_ptr must be valid.  This
             // item must be at index 0.
-            const idx = if (@sizeOf(K) == 0) 0 else key_ptr - self.keys();
+            const idx = if (@sizeOf(K) == 0) 0 else @as([*]K, @ptrCast(key_ptr)) - self.keys();
             self.removeByIndex(idx);
         }
 

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1486,7 +1486,7 @@ pub fn HashMapUnmanaged(
             // if @sizeOf(K) == 0 then there is at most one item in the hash
             // map, which is assumed to exist as key_ptr must be valid.  This
             // item must be at index 0.
-            const idx = if (@sizeOf(K) == 0) 0 else @as([*]K, @ptrCast(key_ptr)) - self.keys();
+            const idx = if (@sizeOf(K) == 0) 0 else key_ptr - self.keys();
             self.removeByIndex(idx);
         }
 

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -363,7 +363,7 @@ pub const HeapAllocator = switch (builtin.os.tag) {
 };
 
 fn sliceContainsPtr(container: []u8, ptr: [*]u8) bool {
-    // TODO: refactor for a single, efficient solution for
+    // TODO: refactor for a single, constant time solution for
     // both comptime and runtime once a way to safely compare
     // pointers at comptime is implemented
 
@@ -379,7 +379,7 @@ fn sliceContainsPtr(container: []u8, ptr: [*]u8) bool {
 }
 
 fn sliceContainsSlice(container: []u8, slice: []u8) bool {
-    // TODO: refactor for a single, efficient solution for
+    // TODO: refactor for a single, constant time solution for
     // both comptime and runtime once a way to safely compare
     // pointers at comptime is implemented
 

--- a/lib/std/heap/arena_allocator.zig
+++ b/lib/std/heap/arena_allocator.zig
@@ -214,7 +214,7 @@ pub const ArenaAllocator = struct {
 
         const cur_node = self.state.buffer_list.first orelse return false;
         const cur_buf = @as([*]u8, @ptrCast(cur_node))[@sizeOf(BufNode)..cur_node.data];
-        if (@intFromPtr(cur_buf.ptr) + self.state.end_index != @intFromPtr(buf.ptr) + buf.len) {
+        if (cur_buf.ptr + self.state.end_index != buf.ptr + buf.len) {
             // It's not the most recent allocation, so it cannot be expanded,
             // but it's fine if they want to make it smaller.
             return new_len <= buf.len;
@@ -240,7 +240,7 @@ pub const ArenaAllocator = struct {
         const cur_node = self.state.buffer_list.first orelse return;
         const cur_buf = @as([*]u8, @ptrCast(cur_node))[@sizeOf(BufNode)..cur_node.data];
 
-        if (@intFromPtr(cur_buf.ptr) + self.state.end_index == @intFromPtr(buf.ptr) + buf.len) {
+        if (cur_buf.ptr + self.state.end_index == buf.ptr + buf.len) {
             self.state.end_index -= buf.len;
         }
     }

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -255,7 +255,9 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
             used_count: SlotIndex,
 
             fn usedBits(bucket: *BucketHeader, index: usize) *u8 {
-                return @as(*u8, @ptrFromInt(@intFromPtr(bucket) + @sizeOf(BucketHeader) + index));
+                const bucket_bytes: [*]u8 = @ptrCast(bucket);
+                const after_header = bucket_bytes + @sizeOf(BucketHeader);
+                return &after_header[index];
             }
 
             fn requestedSizes(bucket: *BucketHeader, size_class: usize) []LargestSizeClassInt {
@@ -745,7 +747,7 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
                 }
                 return self.resizeLarge(old_mem, log2_old_align, new_size, ret_addr);
             };
-            const byte_offset = @intFromPtr(old_mem.ptr) - @intFromPtr(bucket.page);
+            const byte_offset = old_mem.ptr - bucket.page;
             const slot_index = @as(SlotIndex, @intCast(byte_offset / size_class));
             const used_byte_index = slot_index / 8;
             const used_bit_index = @as(u3, @intCast(slot_index % 8));
@@ -865,7 +867,7 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
                 self.freeLarge(old_mem, log2_old_align, ret_addr);
                 return;
             };
-            const byte_offset = @intFromPtr(old_mem.ptr) - @intFromPtr(bucket.page);
+            const byte_offset = old_mem.ptr - bucket.page;
             const slot_index = @as(SlotIndex, @intCast(byte_offset / size_class));
             const used_byte_index = slot_index / 8;
             const used_bit_index = @as(u3, @intCast(slot_index % 8));

--- a/lib/std/heap/sbrk_allocator.zig
+++ b/lib/std/heap/sbrk_allocator.zig
@@ -126,14 +126,14 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
             const class = math.log2(slot_size) - min_class;
             const addr = @intFromPtr(buf.ptr);
             if (class < size_class_count) {
-                const node = @as(*usize, @ptrFromInt(addr + (slot_size - @sizeOf(usize))));
+                const node: *usize = @ptrCast(@alignCast(buf.ptr + slot_size - @sizeOf(usize)));
                 node.* = frees[class];
                 frees[class] = addr;
             } else {
                 const bigpages_needed = bigPagesNeeded(actual_len);
                 const pow2_pages = math.ceilPowerOfTwoAssert(usize, bigpages_needed);
                 const big_slot_size_bytes = pow2_pages * bigpage_size;
-                const node = @as(*usize, @ptrFromInt(addr + (big_slot_size_bytes - @sizeOf(usize))));
+                const node: *usize = @ptrCast(@alignCast(buf.ptr + big_slot_size_bytes - @sizeOf(usize)));
                 const big_class = math.log2(pow2_pages);
                 node.* = big_frees[big_class];
                 big_frees[big_class] = addr;

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1737,19 +1737,19 @@ fn dnsParse(
     if (qdcount + ancount > 64) return error.InvalidDnsPacket;
     while (qdcount != 0) {
         qdcount -= 1;
-        while (@intFromPtr(p) - @intFromPtr(r.ptr) < r.len and p[0] -% 1 < 127) p += 1;
-        if (p[0] > 193 or (p[0] == 193 and p[1] > 254) or @intFromPtr(p) > @intFromPtr(r.ptr) + r.len - 6)
+        while (p - r.ptr < r.len and p[0] -% 1 < 127) p += 1;
+        if (p[0] > 193 or (p[0] == 193 and p[1] > 254) or p - r.ptr > r.len - 6)
             return error.InvalidDnsPacket;
         p += @as(usize, 5) + @intFromBool(p[0] != 0);
     }
     while (ancount != 0) {
         ancount -= 1;
-        while (@intFromPtr(p) - @intFromPtr(r.ptr) < r.len and p[0] -% 1 < 127) p += 1;
-        if (p[0] > 193 or (p[0] == 193 and p[1] > 254) or @intFromPtr(p) > @intFromPtr(r.ptr) + r.len - 6)
+        while (p - r.ptr < r.len and p[0] -% 1 < 127) p += 1;
+        if (p[0] > 193 or (p[0] == 193 and p[1] > 254) or p - r.ptr > r.len - 6)
             return error.InvalidDnsPacket;
         p += @as(usize, 1) + @intFromBool(p[0] != 0);
         const len = p[8] * @as(usize, 256) + p[9];
-        if (@intFromPtr(p) + len > @intFromPtr(r.ptr) + r.len) return error.InvalidDnsPacket;
+        if (p - r.ptr + len > r.len) return error.InvalidDnsPacket;
         try callback(ctx, p[1], p[10..][0..len], r);
         p += 10 + len;
     }


### PR DESCRIPTION
In many placed in std, there are a few instances where we take the results of two `@intFromPtr` values and subtract them to perform pointer subtraction, which is now unnecessary (and suboptimal given `@intFromPtr` is not usable at comptime) with the addition of pointer subtraction as a language feature in #20089. This PR aims to replace instances of `@intFromPtr`  subtraction with pointer subtraction.