### PR TITLE
link to Tuples section in Hello World docs, and give an example of an empty tuple

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -375,9 +375,9 @@
 
       <p>
       In this case, the {#syntax#}!{#endsyntax#} may be omitted from the return
-      type because no errors are returned from the function.
+      type of <code>main</code> because no errors are returned from the function.
       </p>
-      {#see_also|Values|@import|Errors|Root Source File|Source Encoding#}
+      {#see_also|Values|Tuples|@import|Errors|Root Source File|Source Encoding|try#}
       {#header_close#}
       {#header_open|Comments#}
       <p>
@@ -2281,7 +2281,7 @@ or
 
       {#header_open|Tuples#}
       <p>
-      Anonymous structs can be created without specifying field names, and are referred to as "tuples".
+      Anonymous structs can be created without specifying field names, and are referred to as "tuples". An empty tuple looks like <code>.{}</code> and can be seen in one of the {#link|Hello World examples|Hello World#}.
       </p>
       <p>
       The fields are implicitly named using numbers starting from 0. Because their names are integers,


### PR DESCRIPTION
This PR hopefully addresses the documentation issue pointed out in #14231, which is: tuples (e.g. `.{}`) are used in the [Hello World docs example](https://ziglang.org/documentation/master/#Hello-World) (usually the first thing a newcomer sees) without explaining what they are or mentioning what they're called.

To keep the Hello World section short, I opted to only mention the "Tuple" in the "See also" right underneath the Hello World example. Also, in the Tuples section, I mentioned that `.{}` is an empty tuple and linked to the Hello World example that uses it.