### PR TITLE
Replace some dynamic functions with static ones.

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -484,7 +484,7 @@ const WindowsThreadImpl = struct {
     pub const ThreadHandle = windows.HANDLE;
 
     fn getCurrentId() windows.DWORD {
-        return windows.kernel32.GetCurrentThreadId();
+        return windows.GetCurrentThreadId();
     }
 
     fn getCpuCount() !usize {

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1750,7 +1750,7 @@ pub const WindowsModuleInfo = struct {
         section_view: []const u8,
 
         pub fn deinit(self: @This()) void {
-            const process_handle = windows.kernel32.GetCurrentProcess();
+            const process_handle = windows.GetCurrentProcess();
             assert(windows.ntdll.NtUnmapViewOfSection(process_handle, @constCast(@ptrCast(self.section_view.ptr))) == .SUCCESS);
             windows.CloseHandle(self.section_handle);
             self.file.close();
@@ -1980,7 +1980,7 @@ pub const DebugInfo = struct {
                     // openFileAbsoluteW requires the prefix to be present
                     @memcpy(name_buffer[0..4], &[_]u16{ '\\', '?', '?', '\\' });
 
-                    const process_handle = windows.kernel32.GetCurrentProcess();
+                    const process_handle = windows.GetCurrentProcess();
                     const len = windows.kernel32.GetModuleFileNameExW(
                         process_handle,
                         module.handle,


### PR DESCRIPTION
PR [19271](https://github.com/ziglang/zig/pull/19271) added some static function implementations from kernel32, but some parts of the library still used the dynamically loaded versions.