### PR TITLE
`start`: Avoid going through the argc_argv_ptr global variable

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -340,10 +340,10 @@ fn _start() callconv(.Naked) noreturn {
             ,
             .powerpc64, .powerpc64le =>
             // Setup the initial stack frame and clear the back chain pointer.
-            // TODO: Support powerpc64 (big endian) on ELFv2.
             \\ addis 2, 12, .TOC. - _start@ha
             \\ addi 2, 2, .TOC. - _start@l
             \\ mr 3, 1
+            \\ clrrdi 1, 1, 4
             \\ li 0, 0
             \\ stdu 0, -32(1)
             \\ mtlr 0

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -341,6 +341,8 @@ fn _start() callconv(.Naked) noreturn {
             .powerpc64, .powerpc64le =>
             // Setup the initial stack frame and clear the back chain pointer.
             // TODO: Support powerpc64 (big endian) on ELFv2.
+            \\ addis 2, 12, .TOC. - _start@ha
+            \\ addi 2, 2, .TOC. - _start@l
             \\ mr 3, 1
             \\ li 0, 0
             \\ stdu 0, -32(1)


### PR DESCRIPTION
This is problematic for PIE. There's nothing but luck preventing the accesses to this global variable from requiring relocations. I've observed this being an issue on MIPS and PowerPC personally, but others may be affected.