### PR TITLE
std.Build: add `imports` field to `*Options` structs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -613,19 +613,6 @@ const AddCompilerStepOptions = struct {
 };
 
 fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.Step.Compile {
-    const exe = b.addExecutable(.{
-        .name = "zig",
-        .root_source_file = b.path("src/main.zig"),
-        .target = options.target,
-        .optimize = options.optimize,
-        .max_rss = 7_100_000_000,
-        .strip = options.strip,
-        .sanitize_thread = options.sanitize_thread,
-        .single_threaded = options.single_threaded,
-    });
-    exe.root_module.valgrind = options.valgrind;
-    exe.stack_size = stack_size;
-
     const aro_module = b.createModule(.{
         .root_source_file = b.path("lib/compiler/aro/aro.zig"),
     });
@@ -640,8 +627,22 @@ fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.St
         },
     });
 
-    exe.root_module.addImport("aro", aro_module);
-    exe.root_module.addImport("aro_translate_c", aro_translate_c_module);
+    const exe = b.addExecutable(.{
+        .name = "zig",
+        .root_source_file = b.path("src/main.zig"),
+        .target = options.target,
+        .optimize = options.optimize,
+        .max_rss = 7_100_000_000,
+        .strip = options.strip,
+        .sanitize_thread = options.sanitize_thread,
+        .single_threaded = options.single_threaded,
+        .imports = &.{
+            .{ .name = "aro", .module = aro_module },
+            .{ .name = "aro_translate_c", .module = aro_translate_c_module },
+        },
+    });
+    exe.root_module.valgrind = options.valgrind;
+    exe.stack_size = stack_size;
     return exe;
 }
 

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -668,6 +668,7 @@ pub const ExecutableOptions = struct {
     /// Can be set regardless of target. The `.manifest` file will be ignored
     /// if the target object format does not support embedded manifests.
     win32_manifest: ?LazyPath = null,
+    imports: []const Module.Import = &.{},
 };
 
 pub fn addExecutable(b: *Build, options: ExecutableOptions) *Step.Compile {
@@ -686,6 +687,7 @@ pub fn addExecutable(b: *Build, options: ExecutableOptions) *Step.Compile {
             .sanitize_thread = options.sanitize_thread,
             .error_tracing = options.error_tracing,
             .code_model = options.code_model,
+            .imports = options.imports,
         },
         .version = options.version,
         .kind = .exe,
@@ -718,6 +720,7 @@ pub const ObjectOptions = struct {
     use_llvm: ?bool = null,
     use_lld: ?bool = null,
     zig_lib_dir: ?LazyPath = null,
+    imports: []const Module.Import = &.{},
 };
 
 pub fn addObject(b: *Build, options: ObjectOptions) *Step.Compile {
@@ -736,6 +739,7 @@ pub fn addObject(b: *Build, options: ObjectOptions) *Step.Compile {
             .sanitize_thread = options.sanitize_thread,
             .error_tracing = options.error_tracing,
             .code_model = options.code_model,
+            .imports = options.imports,
         },
         .kind = .obj,
         .max_rss = options.max_rss,
@@ -772,6 +776,7 @@ pub const SharedLibraryOptions = struct {
     /// Can be set regardless of target. The `.manifest` file will be ignored
     /// if the target object format does not support embedded manifests.
     win32_manifest: ?LazyPath = null,
+    imports: []const Module.Import = &.{},
 };
 
 pub fn addSharedLibrary(b: *Build, options: SharedLibraryOptions) *Step.Compile {
@@ -790,6 +795,7 @@ pub fn addSharedLibrary(b: *Build, options: SharedLibraryOptions) *Step.Compile 
             .sanitize_thread = options.sanitize_thread,
             .error_tracing = options.error_tracing,
             .code_model = options.code_model,
+            .imports = options.imports,
         },
         .kind = .lib,
         .linkage = .dynamic,
@@ -823,6 +829,7 @@ pub const StaticLibraryOptions = struct {
     use_llvm: ?bool = null,
     use_lld: ?bool = null,
     zig_lib_dir: ?LazyPath = null,
+    imports: []const Module.Import = &.{},
 };
 
 pub fn addStaticLibrary(b: *Build, options: StaticLibraryOptions) *Step.Compile {
@@ -841,6 +848,7 @@ pub fn addStaticLibrary(b: *Build, options: StaticLibraryOptions) *Step.Compile 
             .sanitize_thread = options.sanitize_thread,
             .error_tracing = options.error_tracing,
             .code_model = options.code_model,
+            .imports = options.imports,
         },
         .kind = .lib,
         .linkage = .static,
@@ -874,6 +882,7 @@ pub const TestOptions = struct {
     use_llvm: ?bool = null,
     use_lld: ?bool = null,
     zig_lib_dir: ?LazyPath = null,
+    imports: []const Module.Import = &.{},
 };
 
 /// Creates an executable containing unit tests.
@@ -900,6 +909,7 @@ pub fn addTest(b: *Build, options: TestOptions) *Step.Compile {
             .omit_frame_pointer = options.omit_frame_pointer,
             .sanitize_thread = options.sanitize_thread,
             .error_tracing = options.error_tracing,
+            .imports = options.imports,
         },
         .max_rss = options.max_rss,
         .filters = if (options.filter != null and options.filters.len > 0) filters: {


### PR DESCRIPTION
Given the following `build.zig`:

```zig
const std = @import("std");

pub fn build(b: *std.Build) !void {
    const target = b.standardTargetOptions(.{});
    const optimize = b.standardOptimizeOption(.{});

    const datetime_dep = b.dependency("zig_datetime", .{
        .target = target,
        .optimize = optimize,
    });

    // ...

    const imports = &.{
        .{ .name = "zig-datetime", .module = datetime_dep.module("zig-datetime") },
        // ...
    };

    _ = b.addModule("subunit", .{
        .root_source_file = b.path("subunit.zig"),
        .target = target,
        .optimize = optimize,
        .imports = imports,
    });

    // ...

    const test_step = b.step("test", "Run tests");
    test_step.dependOn(&b.addRunArtifact(compile_tests).step);
}
```

we can replace this:

```zig
    const compile_tests = b.addTest(.{
        .root_source_file = b.path("subunit.zig"),
        .target = target,
        .optimize = optimize,
    });

    inline for (imports) |import|
        compile_tests.root_module.addImport(import.name, import.module);
```

with this:

```zig
    const compile_tests = b.addTest(.{
        .root_source_file = b.path("subunit.zig"),
        .target = target,
        .optimize = optimize,
        .imports = imports,
    });
```