### PR TITLE
std: set standard dynamic linker path for loongarch64 on linux.

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -1730,7 +1730,7 @@ pub const DynamicLinker = struct {
                     else => "",
                 }}) catch unreachable,
 
-                .loongarch64 => init("/lib/ld-linux-loongarch-lp64d.so.1")
+                .loongarch64 => init("/lib64/ld-linux-loongarch-lp64d.so.1")
 
                 .mips,
                 .mipsel,

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -1730,7 +1730,7 @@ pub const DynamicLinker = struct {
                     else => "",
                 }}) catch unreachable,
 
-                .loongarch64 => init("/lib64/ld-linux-loongarch-lp64d.so.1")
+                .loongarch64 => init("/lib64/ld-linux-loongarch-lp64d.so.1"),
 
                 .mips,
                 .mipsel,

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -1730,6 +1730,8 @@ pub const DynamicLinker = struct {
                     else => "",
                 }}) catch unreachable,
 
+                .loongarch64 => init("/lib/ld-linux-loongarch-lp64d.so.1")
+
                 .mips,
                 .mipsel,
                 .mips64,
@@ -1799,7 +1801,6 @@ pub const DynamicLinker = struct {
                 .ve,
                 .dxil,
                 .loongarch32,
-                .loongarch64,
                 .xtensa,
                 => none,
             },


### PR DESCRIPTION
See: https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html#_program_interpreter_path