### PR TITLE
Default std.posix.system.ucontext_t is void

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -45,7 +45,9 @@ pub const system = if (use_libc)
 else switch (native_os) {
     .linux => linux,
     .plan9 => std.os.plan9,
-    else => struct {},
+    else => struct {
+        pub const ucontext_t = void;
+    },
 };
 
 pub const AF = system.AF;

--- a/test/standalone/stack_iterator/unwind_freestanding.zig
+++ b/test/standalone/stack_iterator/unwind_freestanding.zig
@@ -1,0 +1,64 @@
+/// Test StackIterator on 'freestanding' target.  Based on unwind.zig.
+const std = @import("std");
+const builtin = @import("builtin");
+const debug = std.debug;
+
+noinline fn frame3(expected: *[4]usize, unwound: *[4]usize) void {
+    expected[0] = @returnAddress();
+
+    var it = debug.StackIterator.init(@returnAddress(), @frameAddress());
+    defer it.deinit();
+
+    // Save StackIterator's frame addresses into `unwound`:
+    for (unwound) |*addr| {
+        if (it.next()) |return_address| addr.* = return_address;
+    }
+}
+
+noinline fn frame2(expected: *[4]usize, unwound: *[4]usize) void {
+    expected[1] = @returnAddress();
+    frame3(expected, unwound);
+}
+
+noinline fn frame1(expected: *[4]usize, unwound: *[4]usize) void {
+    expected[2] = @returnAddress();
+
+    // Use a stack frame that is too big to encode in __unwind_info's stack-immediate encoding
+    // to exercise the stack-indirect encoding path
+    var pad: [std.math.maxInt(u8) * @sizeOf(usize) + 1]u8 = undefined;
+    _ = std.mem.doNotOptimizeAway(&pad);
+
+    frame2(expected, unwound);
+}
+
+noinline fn frame0(expected: *[4]usize, unwound: *[4]usize) void {
+    expected[3] = @returnAddress();
+    frame1(expected, unwound);
+}
+
+// Freestanding entrypoint
+export fn _start() callconv(.C) noreturn {
+    var expected: [4]usize = undefined;
+    var unwound: [4]usize = undefined;
+    frame0(&expected, &unwound);
+
+    // Verify result (no std.testing in freestanding)
+    var missed: c_int = 0;
+    for (expected, unwound) |expectFA, actualFA| {
+        if (expectFA != actualFA) {
+            missed += 1;
+        }
+    }
+
+    // Need to compile as "freestanding" to exercise the StackIterator code, but when run as a
+    // regression test need to actually exit.  So assume we're running on x86_64-linux ...
+    asm volatile (
+        \\movl $60, %%eax
+        \\syscall
+        :
+        : [missed] "{edi}" (missed),
+        : "edi", "eax"
+    );
+
+    while (true) {} // unreached
+}


### PR DESCRIPTION
PR https://github.com/ziglang/zig/pull/20679 ("std.c reorganization") switched feature-detection code to use `T != void` checks in place of `@hasDecl`.  However, the default std.posix.system struct (used by freestanding targets) is empty, so compile-time feature detection against symbols in there (specifically `std.posix.system.ucontext_t` in this case), fail at compile time.

This PR adds a void ucontext_t into the std.posix.system default.  While I'm confident this fixes the particular problem, it may not be the right approach (it seems like this struct will eventually have to be padded out with a lot of void symbols).  I'm not sure if deeper fixes to std.debug are in order, or something else entirely.

This PR also adds pseudo-"freestanding" variation of the existing StackIterator "unwind" test.  The new test is somewhat hacky (its freestanding, but assumes it can invoke a Linux exit syscall), but it does detect this problem.

Fixes #20710