### PR TITLE
std: fix consts value for stack size on linux for loongarch64.

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -4784,12 +4784,13 @@ pub fn CPU_COUNT(set: cpu_set_t) cpu_count_t {
 
 pub const MINSIGSTKSZ = switch (native_arch) {
     .x86, .x86_64, .arm, .mipsel => 2048,
+    .loongarch64 => 4096,
     .aarch64 => 5120,
     else => @compileError("MINSIGSTKSZ not defined for this architecture"),
 };
 pub const SIGSTKSZ = switch (native_arch) {
     .x86, .x86_64, .arm, .mipsel => 8192,
-    .aarch64 => 16384,
+    .aarch64, .loongarch64 => 16384,
     else => @compileError("SIGSTKSZ not defined for this architecture"),
 };
 


### PR DESCRIPTION
See: https://github.com/ziglang/zig/blob/179a6e61e8be2e5736e9cab9661f04269907247c/lib/libc/include/loongarch-linux-any/asm/signal.h#L8-L9