### PR TITLE
The tale of parallel MachO: part 2

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -618,7 +618,7 @@ fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.St
         .root_source_file = b.path("src/main.zig"),
         .target = options.target,
         .optimize = options.optimize,
-        .max_rss = 7_100_000_000,
+        .max_rss = 7_500_000_000,
         .strip = options.strip,
         .sanitize_thread = options.sanitize_thread,
         .single_threaded = options.single_threaded,

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -105,8 +105,9 @@ win32_resource_table: if (dev.env.supports(.win32_resource)) std.AutoArrayHashMa
     pub fn deinit(_: @This(), _: Allocator) void {}
 } = .{},
 
-link_error_flags: link.File.ErrorFlags = .{},
 link_errors: std.ArrayListUnmanaged(link.File.ErrorMsg) = .{},
+link_errors_mutex: std.Thread.Mutex = .{},
+link_error_flags: link.File.ErrorFlags = .{},
 lld_errors: std.ArrayListUnmanaged(LldError) = .{},
 
 work_queues: [
@@ -3067,7 +3068,6 @@ pub fn totalErrorCount(comp: *Compilation) u32 {
         total += @intFromBool(comp.link_error_flags.no_entry_point_found);
     }
     total += @intFromBool(comp.link_error_flags.missing_libc);
-
     total += comp.link_errors.items.len;
 
     // Compile log errors only count if there are no other errors.

--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -163,12 +163,12 @@ pub fn emitMir(emit: *Emit) Error!void {
                     const zo = macho_file.getZigObject().?;
                     const atom = zo.symbols.items[data.atom_index].getAtom(macho_file).?;
                     const sym = &zo.symbols.items[data.sym_index];
-                    if (sym.flags.needs_zig_got and !is_obj_or_static_lib) {
+                    if (sym.getSectionFlags().needs_zig_got and !is_obj_or_static_lib) {
                         _ = try sym.getOrCreateZigGotEntry(data.sym_index, macho_file);
                     }
-                    const @"type": link.File.MachO.Relocation.Type = if (sym.flags.needs_zig_got and !is_obj_or_static_lib)
+                    const @"type": link.File.MachO.Relocation.Type = if (sym.getSectionFlags().needs_zig_got and !is_obj_or_static_lib)
                         .zig_got_load
-                    else if (sym.flags.needs_got)
+                    else if (sym.getSectionFlags().needs_got)
                         // TODO: it is possible to emit .got_load here that can potentially be relaxed
                         // however this requires always to use a MOVQ mnemonic
                         .got

--- a/src/arch/x86_64/Lower.zig
+++ b/src/arch/x86_64/Lower.zig
@@ -451,7 +451,7 @@ fn emit(lower: *Lower, prefix: Prefix, mnemonic: Mnemonic, ops: []const Operand)
                                 break :op .{ .mem = Memory.rip(mem_op.sib.ptr_size, 0) };
                             },
                             .mov => {
-                                if (is_obj_or_static_lib and macho_sym.flags.needs_zig_got) emit_mnemonic = .lea;
+                                if (is_obj_or_static_lib and macho_sym.getSectionFlags().needs_zig_got) emit_mnemonic = .lea;
                                 break :op .{ .mem = Memory.rip(mem_op.sib.ptr_size, 0) };
                             },
                             else => unreachable,

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -924,7 +924,7 @@ fn genDeclRef(
             const name = decl.name.toSlice(ip);
             const lib_name = if (decl.getOwnedVariable(zcu)) |ov| ov.lib_name.toSlice(ip) else null;
             const sym_index = try macho_file.getGlobalSymbol(name, lib_name);
-            zo.symbols.items[sym_index].flags.needs_got = true;
+            zo.symbols.items[sym_index].setSectionFlags(.{ .needs_got = true });
             return GenResult.mcv(.{ .load_symbol = sym_index });
         }
         const sym_index = try zo.getOrCreateMetadataForDecl(macho_file, decl_index);

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -995,12 +995,12 @@ pub fn growAllocSection(self: *Elf, shdr_index: u32, needed_size: u64) !void {
     if (maybe_phdr) |phdr| {
         const mem_capacity = self.allocatedVirtualSize(phdr.p_vaddr);
         if (needed_size > mem_capacity) {
-            var err = try self.addErrorWithNotes(2);
-            try err.addMsg(self, "fatal linker error: cannot expand load segment phdr({d}) in virtual memory", .{
+            var err = try self.base.addErrorWithNotes(2);
+            try err.addMsg("fatal linker error: cannot expand load segment phdr({d}) in virtual memory", .{
                 self.phdr_to_shdr_table.get(shdr_index).?,
             });
-            try err.addNote(self, "TODO: emit relocations to memory locations in self-hosted backends", .{});
-            try err.addNote(self, "as a workaround, try increasing pre-allocated virtual memory of each segment", .{});
+            try err.addNote("TODO: emit relocations to memory locations in self-hosted backends", .{});
+            try err.addNote("as a workaround, try increasing pre-allocated virtual memory of each segment", .{});
         }
 
         phdr.p_memsz = needed_size;
@@ -1276,7 +1276,7 @@ pub fn flushModule(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_nod
         };
     }
 
-    if (comp.link_errors.items.len > 0) return error.FlushFailure;
+    if (self.base.hasErrors()) return error.FlushFailure;
 
     // Dedup shared objects
     {
@@ -1423,7 +1423,7 @@ pub fn flushModule(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_nod
         try self.writeElfHeader();
     }
 
-    if (comp.link_errors.items.len > 0) return error.FlushFailure;
+    if (self.base.hasErrors()) return error.FlushFailure;
 }
 
 /// --verbose-link output
@@ -2852,9 +2852,9 @@ fn writePhdrTable(self: *Elf) !void {
 }
 
 pub fn writeElfHeader(self: *Elf) !void {
-    const comp = self.base.comp;
-    if (comp.link_errors.items.len > 0) return; // We had errors, so skip flushing to render the output unusable
+    if (self.base.hasErrors()) return; // We had errors, so skip flushing to render the output unusable
 
+    const comp = self.base.comp;
     var hdr_buf: [@sizeOf(elf.Elf64_Ehdr)]u8 = undefined;
 
     var index: usize = 0;
@@ -4298,9 +4298,9 @@ fn allocatePhdrTable(self: *Elf) error{OutOfMemory}!void {
         //    (revisit getMaxNumberOfPhdrs())
         // 2. shift everything in file to free more space for EHDR + PHDR table
         // TODO verify `getMaxNumberOfPhdrs()` is accurate and convert this into no-op
-        var err = try self.addErrorWithNotes(1);
-        try err.addMsg(self, "fatal linker error: not enough space reserved for EHDR and PHDR table", .{});
-        try err.addNote(self, "required 0x{x}, available 0x{x}", .{ needed_size, available_space });
+        var err = try self.base.addErrorWithNotes(1);
+        try err.addMsg("fatal linker error: not enough space reserved for EHDR and PHDR table", .{});
+        try err.addNote("required 0x{x}, available 0x{x}", .{ needed_size, available_space });
     }
 
     phdr_table_load.p_filesz = needed_size + ehsize;
@@ -5863,56 +5863,6 @@ pub fn tlsAddress(self: *Elf) i64 {
     return @intCast(phdr.p_vaddr);
 }
 
-const ErrorWithNotes = struct {
-    /// Allocated index in comp.link_errors array.
-    index: usize,
-
-    /// Next available note slot.
-    note_slot: usize = 0,
-
-    pub fn addMsg(
-        err: ErrorWithNotes,
-        elf_file: *Elf,
-        comptime format: []const u8,
-        args: anytype,
-    ) error{OutOfMemory}!void {
-        const comp = elf_file.base.comp;
-        const gpa = comp.gpa;
-        const err_msg = &comp.link_errors.items[err.index];
-        err_msg.msg = try std.fmt.allocPrint(gpa, format, args);
-    }
-
-    pub fn addNote(
-        err: *ErrorWithNotes,
-        elf_file: *Elf,
-        comptime format: []const u8,
-        args: anytype,
-    ) error{OutOfMemory}!void {
-        const comp = elf_file.base.comp;
-        const gpa = comp.gpa;
-        const err_msg = &comp.link_errors.items[err.index];
-        assert(err.note_slot < err_msg.notes.len);
-        err_msg.notes[err.note_slot] = .{ .msg = try std.fmt.allocPrint(gpa, format, args) };
-        err.note_slot += 1;
-    }
-};
-
-pub fn addErrorWithNotes(self: *Elf, note_count: usize) error{OutOfMemory}!ErrorWithNotes {
-    const comp = self.base.comp;
-    const gpa = comp.gpa;
-    try comp.link_errors.ensureUnusedCapacity(gpa, 1);
-    return self.addErrorWithNotesAssumeCapacity(note_count);
-}
-
-fn addErrorWithNotesAssumeCapacity(self: *Elf, note_count: usize) error{OutOfMemory}!ErrorWithNotes {
-    const comp = self.base.comp;
-    const gpa = comp.gpa;
-    const index = comp.link_errors.items.len;
-    const err = comp.link_errors.addOneAssumeCapacity();
-    err.* = .{ .msg = undefined, .notes = try gpa.alloc(link.File.ErrorMsg, note_count) };
-    return .{ .index = index };
-}
-
 pub fn getShString(self: Elf, off: u32) [:0]const u8 {
     assert(off < self.shstrtab.items.len);
     return mem.sliceTo(@as([*:0]const u8, @ptrCast(self.shstrtab.items.ptr + off)), 0);
@@ -5940,11 +5890,10 @@ pub fn insertDynString(self: *Elf, name: []const u8) error{OutOfMemory}!u32 {
 }
 
 fn reportUndefinedSymbols(self: *Elf, undefs: anytype) !void {
-    const comp = self.base.comp;
-    const gpa = comp.gpa;
+    const gpa = self.base.comp.gpa;
     const max_notes = 4;
 
-    try comp.link_errors.ensureUnusedCapacity(gpa, undefs.count());
+    try self.base.comp.link_errors.ensureUnusedCapacity(gpa, undefs.count());
 
     var it = undefs.iterator();
     while (it.next()) |entry| {
@@ -5953,18 +5902,18 @@ fn reportUndefinedSymbols(self: *Elf, undefs: anytype) !void {
         const natoms = @min(atoms.len, max_notes);
         const nnotes = natoms + @intFromBool(atoms.len > max_notes);
 
-        var err = try self.addErrorWithNotesAssumeCapacity(nnotes);
-        try err.addMsg(self, "undefined symbol: {s}", .{self.symbol(undef_index).name(self)});
+        var err = try self.base.addErrorWithNotesAssumeCapacity(nnotes);
+        try err.addMsg("undefined symbol: {s}", .{self.symbol(undef_index).name(self)});
 
         for (atoms[0..natoms]) |atom_index| {
             const atom_ptr = self.atom(atom_index).?;
             const file_ptr = self.file(atom_ptr.file_index).?;
-            try err.addNote(self, "referenced by {s}:{s}", .{ file_ptr.fmtPath(), atom_ptr.name(self) });
+            try err.addNote("referenced by {s}:{s}", .{ file_ptr.fmtPath(), atom_ptr.name(self) });
         }
 
         if (atoms.len > max_notes) {
             const remaining = atoms.len - max_notes;
-            try err.addNote(self, "referenced {d} more times", .{remaining});
+            try err.addNote("referenced {d} more times", .{remaining});
         }
     }
 }
@@ -5978,19 +5927,19 @@ fn reportDuplicates(self: *Elf, dupes: anytype) error{ HasDuplicates, OutOfMemor
         const notes = entry.value_ptr.*;
         const nnotes = @min(notes.items.len, max_notes) + @intFromBool(notes.items.len > max_notes);
 
-        var err = try self.addErrorWithNotes(nnotes + 1);
-        try err.addMsg(self, "duplicate symbol definition: {s}", .{sym.name(self)});
-        try err.addNote(self, "defined by {}", .{sym.file(self).?.fmtPath()});
+        var err = try self.base.addErrorWithNotes(nnotes + 1);
+        try err.addMsg("duplicate symbol definition: {s}", .{sym.name(self)});
+        try err.addNote("defined by {}", .{sym.file(self).?.fmtPath()});
 
         var inote: usize = 0;
         while (inote < @min(notes.items.len, max_notes)) : (inote += 1) {
             const file_ptr = self.file(notes.items[inote]).?;
-            try err.addNote(self, "defined by {}", .{file_ptr.fmtPath()});
+            try err.addNote("defined by {}", .{file_ptr.fmtPath()});
         }
 
         if (notes.items.len > max_notes) {
             const remaining = notes.items.len - max_notes;
-            try err.addNote(self, "defined {d} more times", .{remaining});
+            try err.addNote("defined {d} more times", .{remaining});
         }
 
         has_dupes = true;
@@ -6005,16 +5954,16 @@ fn reportMissingLibraryError(
     comptime format: []const u8,
     args: anytype,
 ) error{OutOfMemory}!void {
-    var err = try self.addErrorWithNotes(checked_paths.len);
-    try err.addMsg(self, format, args);
+    var err = try self.base.addErrorWithNotes(checked_paths.len);
+    try err.addMsg(format, args);
     for (checked_paths) |path| {
-        try err.addNote(self, "tried {s}", .{path});
+        try err.addNote("tried {s}", .{path});
     }
 }
 
 pub fn reportUnsupportedCpuArch(self: *Elf) error{OutOfMemory}!void {
-    var err = try self.addErrorWithNotes(0);
-    try err.addMsg(self, "fatal linker error: unsupported CPU architecture {s}", .{
+    var err = try self.base.addErrorWithNotes(0);
+    try err.addMsg("fatal linker error: unsupported CPU architecture {s}", .{
         @tagName(self.getTarget().cpu.arch),
     });
 }
@@ -6025,9 +5974,9 @@ pub fn reportParseError(
     comptime format: []const u8,
     args: anytype,
 ) error{OutOfMemory}!void {
-    var err = try self.addErrorWithNotes(1);
-    try err.addMsg(self, format, args);
-    try err.addNote(self, "while parsing {s}", .{path});
+    var err = try self.base.addErrorWithNotes(1);
+    try err.addMsg(format, args);
+    try err.addNote("while parsing {s}", .{path});
 }
 
 pub fn reportParseError2(
@@ -6036,9 +5985,9 @@ pub fn reportParseError2(
     comptime format: []const u8,
     args: anytype,
 ) error{OutOfMemory}!void {
-    var err = try self.addErrorWithNotes(1);
-    try err.addMsg(self, format, args);
-    try err.addNote(self, "while parsing {}", .{self.file(file_index).?.fmtPath()});
+    var err = try self.base.addErrorWithNotes(1);
+    try err.addMsg(format, args);
+    try err.addNote("while parsing {}", .{self.file(file_index).?.fmtPath()});
 }
 
 const FormatShdrCtx = struct {

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -631,15 +631,12 @@ fn dataType(symbol: *const Symbol, elf_file: *Elf) u2 {
 }
 
 fn reportUnhandledRelocError(self: Atom, rel: elf.Elf64_Rela, elf_file: *Elf) RelocError!void {
-    var err = try elf_file.addErrorWithNotes(1);
-    try err.addMsg(elf_file, "fatal linker error: unhandled relocation type {} at offset 0x{x}", .{
+    var err = try elf_file.base.addErrorWithNotes(1);
+    try err.addMsg("fatal linker error: unhandled relocation type {} at offset 0x{x}", .{
         relocation.fmtRelocType(rel.r_type(), elf_file.getTarget().cpu.arch),
         rel.r_offset,
     });
-    try err.addNote(elf_file, "in {}:{s}", .{
-        self.file(elf_file).?.fmtPath(),
-        self.name(elf_file),
-    });
+    try err.addNote("in {}:{s}", .{ self.file(elf_file).?.fmtPath(), self.name(elf_file) });
     return error.RelocFailure;
 }
 
@@ -649,15 +646,12 @@ fn reportTextRelocError(
     rel: elf.Elf64_Rela,
     elf_file: *Elf,
 ) RelocError!void {
-    var err = try elf_file.addErrorWithNotes(1);
-    try err.addMsg(elf_file, "relocation at offset 0x{x} against symbol '{s}' cannot be used", .{
+    var err = try elf_file.base.addErrorWithNotes(1);
+    try err.addMsg("relocation at offset 0x{x} against symbol '{s}' cannot be used", .{
         rel.r_offset,
         symbol.name(elf_file),
     });
-    try err.addNote(elf_file, "in {}:{s}", .{
-        self.file(elf_file).?.fmtPath(),
-        self.name(elf_file),
-    });
+    try err.addNote("in {}:{s}", .{ self.file(elf_file).?.fmtPath(), self.name(elf_file) });
     return error.RelocFailure;
 }
 
@@ -667,16 +661,13 @@ fn reportPicError(
     rel: elf.Elf64_Rela,
     elf_file: *Elf,
 ) RelocError!void {
-    var err = try elf_file.addErrorWithNotes(2);
-    try err.addMsg(elf_file, "relocation at offset 0x{x} against symbol '{s}' cannot be used", .{
+    var err = try elf_file.base.addErrorWithNotes(2);
+    try err.addMsg("relocation at offset 0x{x} against symbol '{s}' cannot be used", .{
         rel.r_offset,
         symbol.name(elf_file),
     });
-    try err.addNote(elf_file, "in {}:{s}", .{
-        self.file(elf_file).?.fmtPath(),
-        self.name(elf_file),
-    });
-    try err.addNote(elf_file, "recompile with -fPIC", .{});
+    try err.addNote("in {}:{s}", .{ self.file(elf_file).?.fmtPath(), self.name(elf_file) });
+    try err.addNote("recompile with -fPIC", .{});
     return error.RelocFailure;
 }
 
@@ -686,16 +677,13 @@ fn reportNoPicError(
     rel: elf.Elf64_Rela,
     elf_file: *Elf,
 ) RelocError!void {
-    var err = try elf_file.addErrorWithNotes(2);
-    try err.addMsg(elf_file, "relocation at offset 0x{x} against symbol '{s}' cannot be used", .{
+    var err = try elf_file.base.addErrorWithNotes(2);
+    try err.addMsg("relocation at offset 0x{x} against symbol '{s}' cannot be used", .{
         rel.r_offset,
         symbol.name(elf_file),
     });
-    try err.addNote(elf_file, "in {}:{s}", .{
-        self.file(elf_file).?.fmtPath(),
-        self.name(elf_file),
-    });
-    try err.addNote(elf_file, "recompile with -fno-PIC", .{});
+    try err.addNote("in {}:{s}", .{ self.file(elf_file).?.fmtPath(), self.name(elf_file) });
+    try err.addNote("recompile with -fno-PIC", .{});
     return error.RelocFailure;
 }
 
@@ -1332,9 +1320,9 @@ const x86_64 = struct {
                     try cwriter.writeInt(i32, @as(i32, @intCast(S_ + A - P)), .little);
                 } else {
                     x86_64.relaxGotPcTlsDesc(code[r_offset - 3 ..]) catch {
-                        var err = try elf_file.addErrorWithNotes(1);
-                        try err.addMsg(elf_file, "could not relax {s}", .{@tagName(r_type)});
-                        try err.addNote(elf_file, "in {}:{s} at offset 0x{x}", .{
+                        var err = try elf_file.base.addErrorWithNotes(1);
+                        try err.addMsg("could not relax {s}", .{@tagName(r_type)});
+                        try err.addNote("in {}:{s} at offset 0x{x}", .{
                             atom.file(elf_file).?.fmtPath(),
                             atom.name(elf_file),
                             rel.r_offset,
@@ -1479,12 +1467,12 @@ const x86_64 = struct {
             },
 
             else => {
-                var err = try elf_file.addErrorWithNotes(1);
-                try err.addMsg(elf_file, "TODO: rewrite {} when followed by {}", .{
+                var err = try elf_file.base.addErrorWithNotes(1);
+                try err.addMsg("TODO: rewrite {} when followed by {}", .{
                     relocation.fmtRelocType(rels[0].r_type(), .x86_64),
                     relocation.fmtRelocType(rels[1].r_type(), .x86_64),
                 });
-                try err.addNote(elf_file, "in {}:{s} at offset 0x{x}", .{
+                try err.addNote("in {}:{s} at offset 0x{x}", .{
                     self.file(elf_file).?.fmtPath(),
                     self.name(elf_file),
                     rels[0].r_offset,
@@ -1534,12 +1522,12 @@ const x86_64 = struct {
             },
 
             else => {
-                var err = try elf_file.addErrorWithNotes(1);
-                try err.addMsg(elf_file, "TODO: rewrite {} when followed by {}", .{
+                var err = try elf_file.base.addErrorWithNotes(1);
+                try err.addMsg("TODO: rewrite {} when followed by {}", .{
                     relocation.fmtRelocType(rels[0].r_type(), .x86_64),
                     relocation.fmtRelocType(rels[1].r_type(), .x86_64),
                 });
-                try err.addNote(elf_file, "in {}:{s} at offset 0x{x}", .{
+                try err.addNote("in {}:{s} at offset 0x{x}", .{
                     self.file(elf_file).?.fmtPath(),
                     self.name(elf_file),
                     rels[0].r_offset,
@@ -1630,12 +1618,12 @@ const x86_64 = struct {
             },
 
             else => {
-                var err = try elf_file.addErrorWithNotes(1);
-                try err.addMsg(elf_file, "fatal linker error: rewrite {} when followed by {}", .{
+                var err = try elf_file.base.addErrorWithNotes(1);
+                try err.addMsg("fatal linker error: rewrite {} when followed by {}", .{
                     relocation.fmtRelocType(rels[0].r_type(), .x86_64),
                     relocation.fmtRelocType(rels[1].r_type(), .x86_64),
                 });
-                try err.addNote(elf_file, "in {}:{s} at offset 0x{x}", .{
+                try err.addNote("in {}:{s} at offset 0x{x}", .{
                     self.file(elf_file).?.fmtPath(),
                     self.name(elf_file),
                     rels[0].r_offset,
@@ -1824,9 +1812,9 @@ const aarch64 = struct {
                 aarch64_util.writeAdrpInst(pages, code);
             } else {
                 // TODO: relax
-                var err = try elf_file.addErrorWithNotes(1);
-                try err.addMsg(elf_file, "TODO: relax ADR_GOT_PAGE", .{});
-                try err.addNote(elf_file, "in {}:{s} at offset 0x{x}", .{
+                var err = try elf_file.base.addErrorWithNotes(1);
+                try err.addMsg("TODO: relax ADR_GOT_PAGE", .{});
+                try err.addNote("in {}:{s} at offset 0x{x}", .{
                     atom.file(elf_file).?.fmtPath(),
                     atom.name(elf_file),
                     r_offset,
@@ -2118,9 +2106,9 @@ const riscv = struct {
                     if (S == atom_addr + @as(i64, @intCast(pair.r_offset))) break pair;
                 } else {
                     // TODO: implement searching forward
-                    var err = try elf_file.addErrorWithNotes(1);
-                    try err.addMsg(elf_file, "TODO: find HI20 paired reloc scanning forward", .{});
-                    try err.addNote(elf_file, "in {}:{s} at offset 0x{x}", .{
+                    var err = try elf_file.base.addErrorWithNotes(1);
+                    try err.addMsg("TODO: find HI20 paired reloc scanning forward", .{});
+                    try err.addNote("in {}:{s} at offset 0x{x}", .{
                         atom.file(elf_file).?.fmtPath(),
                         atom.name(elf_file),
                         rel.r_offset,

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -704,9 +704,9 @@ pub fn initMergeSections(self: *Object, elf_file: *Elf) !void {
                 var end = start;
                 while (end < data.len - sh_entsize and !isNull(data[end .. end + sh_entsize])) : (end += sh_entsize) {}
                 if (!isNull(data[end .. end + sh_entsize])) {
-                    var err = try elf_file.addErrorWithNotes(1);
-                    try err.addMsg(elf_file, "string not null terminated", .{});
-                    try err.addNote(elf_file, "in {}:{s}", .{ self.fmtPath(), atom_ptr.name(elf_file) });
+                    var err = try elf_file.base.addErrorWithNotes(1);
+                    try err.addMsg("string not null terminated", .{});
+                    try err.addNote("in {}:{s}", .{ self.fmtPath(), atom_ptr.name(elf_file) });
                     return error.MalformedObject;
                 }
                 end += sh_entsize;
@@ -719,9 +719,9 @@ pub fn initMergeSections(self: *Object, elf_file: *Elf) !void {
             const sh_entsize: u32 = @intCast(shdr.sh_entsize);
             if (sh_entsize == 0) continue; // Malformed, don't split but don't error out
             if (shdr.sh_size % sh_entsize != 0) {
-                var err = try elf_file.addErrorWithNotes(1);
-                try err.addMsg(elf_file, "size not a multiple of sh_entsize", .{});
-                try err.addNote(elf_file, "in {}:{s}", .{ self.fmtPath(), atom_ptr.name(elf_file) });
+                var err = try elf_file.base.addErrorWithNotes(1);
+                try err.addMsg("size not a multiple of sh_entsize", .{});
+                try err.addNote("in {}:{s}", .{ self.fmtPath(), atom_ptr.name(elf_file) });
                 return error.MalformedObject;
             }
 
@@ -779,10 +779,10 @@ pub fn resolveMergeSubsections(self: *Object, elf_file: *Elf) !void {
         const imsec = elf_file.inputMergeSection(imsec_index) orelse continue;
         if (imsec.offsets.items.len == 0) continue;
         const msub_index, const offset = imsec.findSubsection(@intCast(esym.st_value)) orelse {
-            var err = try elf_file.addErrorWithNotes(2);
-            try err.addMsg(elf_file, "invalid symbol value: {x}", .{esym.st_value});
-            try err.addNote(elf_file, "for symbol {s}", .{sym.name(elf_file)});
-            try err.addNote(elf_file, "in {}", .{self.fmtPath()});
+            var err = try elf_file.base.addErrorWithNotes(2);
+            try err.addMsg("invalid symbol value: {x}", .{esym.st_value});
+            try err.addNote("for symbol {s}", .{sym.name(elf_file)});
+            try err.addNote("in {}", .{self.fmtPath()});
             return error.MalformedObject;
         };
 
@@ -804,9 +804,9 @@ pub fn resolveMergeSubsections(self: *Object, elf_file: *Elf) !void {
             const imsec = elf_file.inputMergeSection(imsec_index) orelse continue;
             if (imsec.offsets.items.len == 0) continue;
             const msub_index, const offset = imsec.findSubsection(@intCast(@as(i64, @intCast(esym.st_value)) + rel.r_addend)) orelse {
-                var err = try elf_file.addErrorWithNotes(1);
-                try err.addMsg(elf_file, "invalid relocation at offset 0x{x}", .{rel.r_offset});
-                try err.addNote(elf_file, "in {}:{s}", .{ self.fmtPath(), atom_ptr.name(elf_file) });
+                var err = try elf_file.base.addErrorWithNotes(1);
+                try err.addMsg("invalid relocation at offset 0x{x}", .{rel.r_offset});
+                try err.addNote("in {}:{s}", .{ self.fmtPath(), atom_ptr.name(elf_file) });
                 return error.MalformedObject;
             };
             const msub = elf_file.mergeSubsection(msub_index);

--- a/src/link/Elf/eh_frame.zig
+++ b/src/link/Elf/eh_frame.zig
@@ -591,12 +591,12 @@ const riscv = struct {
 };
 
 fn reportInvalidReloc(rec: anytype, elf_file: *Elf, rel: elf.Elf64_Rela) !void {
-    var err = try elf_file.addErrorWithNotes(1);
-    try err.addMsg(elf_file, "invalid relocation type {} at offset 0x{x}", .{
+    var err = try elf_file.base.addErrorWithNotes(1);
+    try err.addMsg("invalid relocation type {} at offset 0x{x}", .{
         relocation.fmtRelocType(rel.r_type(), elf_file.getTarget().cpu.arch),
         rel.r_offset,
     });
-    try err.addNote(elf_file, "in {}:.eh_frame", .{elf_file.file(rec.file_index).?.fmtPath()});
+    try err.addNote("in {}:.eh_frame", .{elf_file.file(rec.file_index).?.fmtPath()});
     return error.RelocFailure;
 }
 

--- a/src/link/Elf/relocatable.zig
+++ b/src/link/Elf/relocatable.zig
@@ -29,7 +29,7 @@ pub fn flushStaticLib(elf_file: *Elf, comp: *Compilation, module_obj_path: ?[]co
         };
     }
 
-    if (comp.link_errors.items.len > 0) return error.FlushFailure;
+    if (elf_file.base.hasErrors()) return error.FlushFailure;
 
     // First, we flush relocatable object file generated with our backends.
     if (elf_file.zigObjectPtr()) |zig_object| {
@@ -146,7 +146,7 @@ pub fn flushStaticLib(elf_file: *Elf, comp: *Compilation, module_obj_path: ?[]co
     try elf_file.base.file.?.setEndPos(total_size);
     try elf_file.base.file.?.pwriteAll(buffer.items, 0);
 
-    if (comp.link_errors.items.len > 0) return error.FlushFailure;
+    if (elf_file.base.hasErrors()) return error.FlushFailure;
 }
 
 pub fn flushObject(elf_file: *Elf, comp: *Compilation, module_obj_path: ?[]const u8) link.File.FlushError!void {
@@ -177,7 +177,7 @@ pub fn flushObject(elf_file: *Elf, comp: *Compilation, module_obj_path: ?[]const
         };
     }
 
-    if (comp.link_errors.items.len > 0) return error.FlushFailure;
+    if (elf_file.base.hasErrors()) return error.FlushFailure;
 
     // Now, we are ready to resolve the symbols across all input files.
     // We will first resolve the files in the ZigObject, next in the parsed
@@ -216,7 +216,7 @@ pub fn flushObject(elf_file: *Elf, comp: *Compilation, module_obj_path: ?[]const
     try elf_file.writeShdrTable();
     try elf_file.writeElfHeader();
 
-    if (comp.link_errors.items.len > 0) return error.FlushFailure;
+    if (elf_file.base.hasErrors()) return error.FlushFailure;
 }
 
 fn parsePositional(elf_file: *Elf, path: []const u8) Elf.ParseError!void {

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -4578,6 +4578,11 @@ pub const SymbolResolver = struct {
     pub const Index = u32;
 };
 
+pub const String = struct {
+    pos: u32 = 0,
+    len: u32 = 0,
+};
+
 const MachO = @This();
 
 const std = @import("std");

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2387,6 +2387,9 @@ fn resizeSections(self: *MachO) !void {
 }
 
 fn writeSectionsAndUpdateLinkeditSizes(self: *MachO) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     const gpa = self.base.comp.gpa;
 
     const cmd = self.symtab_cmd;
@@ -3513,6 +3516,8 @@ pub fn getTarget(self: MachO) std.Target {
 /// the original file. This is super messy, but there doesn't seem any other
 /// way to please the XNU.
 pub fn invalidateKernelCache(dir: fs.Dir, sub_path: []const u8) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
     if (comptime builtin.target.isDarwin() and builtin.target.cpu.arch == .aarch64) {
         try dir.copyFile(sub_path, dir, sub_path, .{});
     }

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -914,6 +914,7 @@ fn parseInputFileWorker(self: *MachO, file: File) void {
         switch (err) {
             error.MalformedObject,
             error.MalformedDylib,
+            error.MalformedTbd,
             error.InvalidCpuArch,
             error.InvalidTarget,
             => {}, // already reported
@@ -4637,7 +4638,6 @@ const ObjcStubsSection = synthetic.ObjcStubsSection;
 const Object = @import("MachO/Object.zig");
 const LazyBind = bind.LazyBind;
 const LaSymbolPtrSection = synthetic.LaSymbolPtrSection;
-const LibStub = tapi.LibStub;
 const Liveness = @import("../Liveness.zig");
 const LlvmObject = @import("../codegen/llvm.zig").Object;
 const Md5 = std.crypto.hash.Md5;

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -2475,7 +2475,7 @@ fn writeThunkWorker(self: *MachO, thunk: Thunk) void {
     defer tracy.end();
     const doWork = struct {
         fn doWork(th: Thunk, buffer: []u8, macho_file: *MachO) !void {
-            const off = th.value;
+            const off = math.cast(usize, th.value) orelse return error.Overflow;
             const size = th.size();
             var stream = std.io.fixedBufferStream(buffer[off..][0..size]);
             try th.write(macho_file, stream.writer());

--- a/src/link/MachO/Archive.zig
+++ b/src/link/MachO/Archive.zig
@@ -1,21 +1,10 @@
 objects: std.ArrayListUnmanaged(Object) = .{},
 
-pub fn isArchive(path: []const u8, fat_arch: ?fat.Arch) !bool {
-    const file = try std.fs.cwd().openFile(path, .{});
-    defer file.close();
-    if (fat_arch) |arch| {
-        try file.seekTo(arch.offset);
-    }
-    const magic = file.reader().readBytesNoEof(SARMAG) catch return false;
-    if (!mem.eql(u8, &magic, ARMAG)) return false;
-    return true;
-}
-
 pub fn deinit(self: *Archive, allocator: Allocator) void {
     self.objects.deinit(allocator);
 }
 
-pub fn parse(self: *Archive, macho_file: *MachO, path: []const u8, handle_index: File.HandleIndex, fat_arch: ?fat.Arch) !void {
+pub fn unpack(self: *Archive, macho_file: *MachO, path: []const u8, handle_index: File.HandleIndex, fat_arch: ?fat.Arch) !void {
     const gpa = macho_file.base.comp.gpa;
 
     var arena = std.heap.ArenaAllocator.init(gpa);

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -42,7 +42,6 @@ extra: u32 = 0,
 pub fn getName(self: Atom, macho_file: *MachO) [:0]const u8 {
     return switch (self.getFile(macho_file)) {
         .dylib => unreachable,
-        .zig_object => |x| x.strtab.buffer.items[self.name.pos..][0 .. self.name.len - 1 :0],
         inline else => |x| x.getString(self.name),
     };
 }

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -906,15 +906,15 @@ const x86_64 = struct {
                 encode(&.{inst}, code) catch return error.RelaxFail;
             },
             else => |x| {
-                var err = try macho_file.addErrorWithNotes(2);
-                try err.addMsg(macho_file, "{s}: 0x{x}: 0x{x}: failed to relax relocation of type {}", .{
+                var err = try macho_file.base.addErrorWithNotes(2);
+                try err.addMsg("{s}: 0x{x}: 0x{x}: failed to relax relocation of type {}", .{
                     self.getName(macho_file),
                     self.getAddress(macho_file),
                     rel.offset,
                     rel.fmtPretty(.x86_64),
                 });
-                try err.addNote(macho_file, "expected .mov instruction but found .{s}", .{@tagName(x)});
-                try err.addNote(macho_file, "while parsing {}", .{self.getFile(macho_file).fmtPath()});
+                try err.addNote("expected .mov instruction but found .{s}", .{@tagName(x)});
+                try err.addNote("while parsing {}", .{self.getFile(macho_file).fmtPath()});
                 return error.RelaxFailUnexpectedInstruction;
             },
         }

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -2,7 +2,7 @@
 value: u64 = 0,
 
 /// Name of this Atom.
-name: u32 = 0,
+name: MachO.String = .{},
 
 /// Index into linker's input file table.
 file: File.Index = 0,
@@ -42,7 +42,7 @@ extra: u32 = 0,
 pub fn getName(self: Atom, macho_file: *MachO) [:0]const u8 {
     return switch (self.getFile(macho_file)) {
         .dylib => unreachable,
-        .zig_object => |x| x.strtab.getAssumeExists(self.name),
+        .zig_object => |x| x.strtab.buffer.items[self.name.pos..][0 .. self.name.len - 1 :0],
         inline else => |x| x.getString(self.name),
     };
 }

--- a/src/link/MachO/CodeSignature.zig
+++ b/src/link/MachO/CodeSignature.zig
@@ -7,6 +7,7 @@ const log = std.log.scoped(.link);
 const macho = std.macho;
 const mem = std.mem;
 const testing = std.testing;
+const trace = @import("../../tracy.zig").trace;
 const Allocator = mem.Allocator;
 const Hasher = @import("hasher.zig").ParallelHasher;
 const MachO = @import("../MachO.zig");
@@ -264,6 +265,9 @@ pub fn writeAdhocSignature(
     opts: WriteOpts,
     writer: anytype,
 ) !void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
     const allocator = macho_file.base.comp.gpa;
 
     var header: macho.SuperBlob = .{

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -610,15 +610,18 @@ pub inline fn getUmbrella(self: Dylib, macho_file: *MachO) *Dylib {
     return macho_file.getFile(self.umbrella).?.dylib;
 }
 
-fn addString(self: *Dylib, allocator: Allocator, name: []const u8) !u32 {
+fn addString(self: *Dylib, allocator: Allocator, name: []const u8) !MachO.String {
     const off = @as(u32, @intCast(self.strtab.items.len));
-    try self.strtab.writer(allocator).print("{s}\x00", .{name});
-    return off;
+    try self.strtab.ensureUnusedCapacity(allocator, name.len + 1);
+    self.strtab.appendSliceAssumeCapacity(name);
+    self.strtab.appendAssumeCapacity(0);
+    return .{ .pos = off, .len = @intCast(name.len + 1) };
 }
 
-pub fn getString(self: Dylib, off: u32) [:0]const u8 {
-    assert(off < self.strtab.items.len);
-    return mem.sliceTo(@as([*:0]const u8, @ptrCast(self.strtab.items.ptr + off)), 0);
+pub fn getString(self: Dylib, string: MachO.String) [:0]const u8 {
+    assert(string.pos < self.strtab.items.len and string.pos + string.len <= self.strtab.items.len);
+    if (string.len == 0) return "";
+    return self.strtab.items[string.pos..][0 .. string.len - 1 :0];
 }
 
 pub fn asFile(self: *Dylib) File {
@@ -932,7 +935,7 @@ pub const Id = struct {
 };
 
 const Export = struct {
-    name: u32,
+    name: MachO.String,
     flags: Flags,
 
     const Flags = packed struct {

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -270,7 +270,10 @@ fn parseTbd(self: *Dylib, macho_file: *MachO) !void {
     log.debug("parsing dylib from stub: {s}", .{self.path});
 
     const file = macho_file.getFileHandle(self.file_handle);
-    var lib_stub = LibStub.loadFromFile(gpa, file) catch return error.NotLibStub;
+    var lib_stub = LibStub.loadFromFile(gpa, file) catch |err| {
+        try macho_file.reportParseError2(self.index, "failed to parse TBD file: {s}", .{@errorName(err)});
+        return error.MalformedTbd;
+    };
     defer lib_stub.deinit();
     const umbrella_lib = lib_stub.inner[0];
 

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -1,5 +1,9 @@
+/// Non-zero for fat dylibs
+offset: u64,
 path: []const u8,
 index: File.Index,
+file_handle: File.HandleIndex,
+tag: enum { dylib, tbd },
 
 exports: std.MultiArrayList(Export) = .{},
 strtab: std.ArrayListUnmanaged(u8) = .{},
@@ -11,7 +15,7 @@ symbols_extra: std.ArrayListUnmanaged(u32) = .{},
 globals: std.ArrayListUnmanaged(MachO.SymbolResolver.Index) = .{},
 dependents: std.ArrayListUnmanaged(Id) = .{},
 rpaths: std.StringArrayHashMapUnmanaged(void) = .{},
-umbrella: File.Index = 0,
+umbrella: File.Index,
 platform: ?MachO.Platform = null,
 
 needed: bool,
@@ -22,16 +26,6 @@ hoisted: bool = true,
 referenced: bool = false,
 
 output_symtab_ctx: MachO.SymtabCtx = .{},
-
-pub fn isDylib(path: []const u8, fat_arch: ?fat.Arch) !bool {
-    const file = try std.fs.cwd().openFile(path, .{});
-    defer file.close();
-    if (fat_arch) |arch| {
-        try file.seekTo(arch.offset);
-    }
-    const header = file.reader().readStruct(macho.mach_header_64) catch return false;
-    return header.filetype == macho.MH_DYLIB;
-}
 
 pub fn deinit(self: *Dylib, allocator: Allocator) void {
     allocator.free(self.path);
@@ -51,12 +45,21 @@ pub fn deinit(self: *Dylib, allocator: Allocator) void {
     self.rpaths.deinit(allocator);
 }
 
-pub fn parse(self: *Dylib, macho_file: *MachO, file: std.fs.File, fat_arch: ?fat.Arch) !void {
+pub fn parse(self: *Dylib, macho_file: *MachO) !void {
+    switch (self.tag) {
+        .tbd => try self.parseTbd(macho_file),
+        .dylib => try self.parseBinary(macho_file),
+    }
+    try self.initSymbols(macho_file);
+}
+
+fn parseBinary(self: *Dylib, macho_file: *MachO) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
     const gpa = macho_file.base.comp.gpa;
-    const offset = if (fat_arch) |ar| ar.offset else 0;
+    const file = macho_file.getFileHandle(self.file_handle);
+    const offset = self.offset;
 
     log.debug("parsing dylib from binary: {s}", .{self.path});
 
@@ -258,13 +261,7 @@ fn parseTrie(self: *Dylib, data: []const u8, macho_file: *MachO) !void {
     try self.parseTrieNode(&it, gpa, arena.allocator(), "");
 }
 
-pub fn parseTbd(
-    self: *Dylib,
-    cpu_arch: std.Target.Cpu.Arch,
-    platform: MachO.Platform,
-    lib_stub: LibStub,
-    macho_file: *MachO,
-) !void {
+fn parseTbd(self: *Dylib, macho_file: *MachO) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -272,6 +269,9 @@ pub fn parseTbd(
 
     log.debug("parsing dylib from stub: {s}", .{self.path});
 
+    const file = macho_file.getFileHandle(self.file_handle);
+    var lib_stub = LibStub.loadFromFile(gpa, file) catch return error.NotLibStub;
+    defer lib_stub.deinit();
     const umbrella_lib = lib_stub.inner[0];
 
     {
@@ -290,7 +290,8 @@ pub fn parseTbd(
 
     log.debug("  (install_name '{s}')", .{umbrella_lib.installName()});
 
-    self.platform = platform;
+    const cpu_arch = macho_file.getTarget().cpu.arch;
+    self.platform = macho_file.platform;
 
     var matcher = try TargetMatcher.init(gpa, cpu_arch, self.platform.?.toApplePlatform());
     defer matcher.deinit();
@@ -495,7 +496,7 @@ fn addObjCExport(
     try self.addExport(allocator, full_name, .{});
 }
 
-pub fn initSymbols(self: *Dylib, macho_file: *MachO) !void {
+fn initSymbols(self: *Dylib, macho_file: *MachO) !void {
     const gpa = macho_file.base.comp.gpa;
 
     const nsyms = self.exports.items(.name).len;

--- a/src/link/MachO/InternalObject.zig
+++ b/src/link/MachO/InternalObject.zig
@@ -53,7 +53,7 @@ pub fn init(self: *InternalObject, allocator: Allocator) !void {
 
 pub fn initSymbols(self: *InternalObject, macho_file: *MachO) !void {
     const newSymbolAssumeCapacity = struct {
-        fn newSymbolAssumeCapacity(obj: *InternalObject, name: u32, args: struct {
+        fn newSymbolAssumeCapacity(obj: *InternalObject, name: MachO.String, args: struct {
             type: u8 = macho.N_UNDF | macho.N_EXT,
             desc: u16 = 0,
         }) Symbol.Index {
@@ -69,7 +69,7 @@ pub fn initSymbols(self: *InternalObject, macho_file: *MachO) !void {
             const nlist_idx: u32 = @intCast(obj.symtab.items.len);
             const nlist = obj.symtab.addOneAssumeCapacity();
             nlist.* = .{
-                .n_strx = name,
+                .n_strx = name.pos,
                 .n_type = args.type,
                 .n_sect = 0,
                 .n_desc = args.desc,
@@ -197,16 +197,16 @@ pub fn resolveBoundarySymbols(self: *InternalObject, macho_file: *MachO) !void {
     try self.globals.ensureUnusedCapacity(gpa, nsyms);
 
     for (boundary_symbols.keys(), boundary_symbols.values()) |name, ref| {
-        const name_off = try self.addString(gpa, name);
+        const name_str = try self.addString(gpa, name);
         const sym_index = self.addSymbolAssumeCapacity();
         self.boundary_symbols.appendAssumeCapacity(sym_index);
         const sym = &self.symbols.items[sym_index];
-        sym.name = name_off;
+        sym.name = name_str;
         sym.visibility = .local;
         const nlist_idx: u32 = @intCast(self.symtab.items.len);
         const nlist = self.symtab.addOneAssumeCapacity();
         nlist.* = .{
-            .n_strx = name_off,
+            .n_strx = name_str.pos,
             .n_type = macho.N_SECT,
             .n_sect = 0,
             .n_desc = 0,
@@ -273,7 +273,7 @@ fn addObjcMethnameSection(self: *InternalObject, methname: []const u8, macho_fil
     const nlist_idx: u32 = @intCast(self.symtab.items.len);
     const nlist = try self.symtab.addOne(gpa);
     nlist.* = .{
-        .n_strx = name_str,
+        .n_strx = name_str.pos,
         .n_type = macho.N_SECT,
         .n_sect = @intCast(n_sect + 1),
         .n_desc = 0,
@@ -373,15 +373,15 @@ pub fn resolveObjcMsgSendSymbols(self: *InternalObject, macho_file: *MachO) !voi
         const name = MachO.eatPrefix(sym_name, "_objc_msgSend$").?;
         const selrefs_index = try self.addObjcMsgsendSections(name, macho_file);
 
-        const name_off = try self.addString(gpa, sym_name);
+        const name_str = try self.addString(gpa, sym_name);
         const sym_index = try self.addSymbol(gpa);
         const sym = &self.symbols.items[sym_index];
-        sym.name = name_off;
+        sym.name = name_str;
         sym.visibility = .hidden;
         const nlist_idx: u32 = @intCast(self.symtab.items.len);
         const nlist = try self.symtab.addOne(gpa);
         nlist.* = .{
-            .n_strx = name_off,
+            .n_strx = name_str.pos,
             .n_type = macho.N_SECT | macho.N_EXT | macho.N_PEXT,
             .n_sect = 0,
             .n_desc = 0,
@@ -624,17 +624,18 @@ fn getSectionData(self: *const InternalObject, index: u32) error{Overflow}![]con
         @panic("ref to non-existent section");
 }
 
-pub fn addString(self: *InternalObject, allocator: Allocator, name: []const u8) !u32 {
+pub fn addString(self: *InternalObject, allocator: Allocator, string: []const u8) !MachO.String {
     const off: u32 = @intCast(self.strtab.items.len);
-    try self.strtab.ensureUnusedCapacity(allocator, name.len + 1);
-    self.strtab.appendSliceAssumeCapacity(name);
+    try self.strtab.ensureUnusedCapacity(allocator, string.len + 1);
+    self.strtab.appendSliceAssumeCapacity(string);
     self.strtab.appendAssumeCapacity(0);
-    return off;
+    return .{ .pos = off, .len = @intCast(string.len + 1) };
 }
 
-pub fn getString(self: InternalObject, off: u32) [:0]const u8 {
-    assert(off < self.strtab.items.len);
-    return mem.sliceTo(@as([*:0]const u8, @ptrCast(self.strtab.items.ptr + off)), 0);
+pub fn getString(self: InternalObject, string: MachO.String) [:0]const u8 {
+    assert(string.pos < self.strtab.items.len and string.pos + string.len <= self.strtab.items.len);
+    if (string.len == 0) return "";
+    return self.strtab.items[string.pos..][0 .. string.len - 1 :0];
 }
 
 pub fn asFile(self: *InternalObject) File {

--- a/src/link/MachO/Symbol.zig
+++ b/src/link/MachO/Symbol.zig
@@ -4,7 +4,7 @@
 value: u64 = 0,
 
 /// Offset into the linker's intern table.
-name: u32 = 0,
+name: MachO.String = .{},
 
 /// File where this symbol is defined.
 file: File.Index = 0,
@@ -57,7 +57,7 @@ pub fn weakRef(symbol: Symbol, macho_file: *MachO) bool {
 
 pub fn getName(symbol: Symbol, macho_file: *MachO) [:0]const u8 {
     return switch (symbol.getFile(macho_file).?) {
-        .zig_object => |x| x.strtab.getAssumeExists(symbol.name),
+        .zig_object => |x| x.strtab.buffer.items[symbol.name.pos..][0 .. symbol.name.len - 1 :0],
         inline else => |x| x.getString(symbol.name),
     };
 }

--- a/src/link/MachO/Symbol.zig
+++ b/src/link/MachO/Symbol.zig
@@ -57,7 +57,6 @@ pub fn weakRef(symbol: Symbol, macho_file: *MachO) bool {
 
 pub fn getName(symbol: Symbol, macho_file: *MachO) [:0]const u8 {
     return switch (symbol.getFile(macho_file).?) {
-        .zig_object => |x| x.strtab.buffer.items[symbol.name.pos..][0 .. symbol.name.len - 1 :0],
         inline else => |x| x.getString(symbol.name),
     };
 }

--- a/src/link/MachO/Symbol.zig
+++ b/src/link/MachO/Symbol.zig
@@ -23,6 +23,8 @@ nlist_idx: u32 = 0,
 /// Misc flags for the symbol packaged as packed struct for compression.
 flags: Flags = .{},
 
+sect_flags: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+
 visibility: Visibility = .local,
 
 extra: u32 = 0,
@@ -67,6 +69,14 @@ pub fn getAtom(symbol: Symbol, macho_file: *MachO) ?*Atom {
 pub fn getOutputSectionIndex(symbol: Symbol, macho_file: *MachO) u8 {
     if (symbol.getAtom(macho_file)) |atom| return atom.out_n_sect;
     return symbol.out_n_sect;
+}
+
+pub fn getSectionFlags(symbol: Symbol) SectionFlags {
+    return @bitCast(symbol.sect_flags.load(.seq_cst));
+}
+
+pub fn setSectionFlags(symbol: *Symbol, flags: SectionFlags) void {
+    _ = symbol.sect_flags.fetchOr(@bitCast(flags), .seq_cst);
 }
 
 pub fn getFile(symbol: Symbol, macho_file: *MachO) ?File {
@@ -116,9 +126,9 @@ pub fn getAddress(symbol: Symbol, opts: struct {
     stubs: bool = true,
 }, macho_file: *MachO) u64 {
     if (opts.stubs) {
-        if (symbol.flags.stubs) {
+        if (symbol.getSectionFlags().stubs) {
             return symbol.getStubsAddress(macho_file);
-        } else if (symbol.flags.objc_stubs) {
+        } else if (symbol.getSectionFlags().objc_stubs) {
             return symbol.getObjcStubsAddress(macho_file);
         }
     }
@@ -127,25 +137,25 @@ pub fn getAddress(symbol: Symbol, opts: struct {
 }
 
 pub fn getGotAddress(symbol: Symbol, macho_file: *MachO) u64 {
-    if (!symbol.flags.has_got) return 0;
+    if (!symbol.getSectionFlags().has_got) return 0;
     const extra = symbol.getExtra(macho_file);
     return macho_file.got.getAddress(extra.got, macho_file);
 }
 
 pub fn getStubsAddress(symbol: Symbol, macho_file: *MachO) u64 {
-    if (!symbol.flags.stubs) return 0;
+    if (!symbol.getSectionFlags().stubs) return 0;
     const extra = symbol.getExtra(macho_file);
     return macho_file.stubs.getAddress(extra.stubs, macho_file);
 }
 
 pub fn getObjcStubsAddress(symbol: Symbol, macho_file: *MachO) u64 {
-    if (!symbol.flags.objc_stubs) return 0;
+    if (!symbol.getSectionFlags().objc_stubs) return 0;
     const extra = symbol.getExtra(macho_file);
     return macho_file.objc_stubs.getAddress(extra.objc_stubs, macho_file);
 }
 
 pub fn getObjcSelrefsAddress(symbol: Symbol, macho_file: *MachO) u64 {
-    if (!symbol.flags.objc_stubs) return 0;
+    if (!symbol.getSectionFlags().objc_stubs) return 0;
     const extra = symbol.getExtra(macho_file);
     const file = symbol.getFile(macho_file).?;
     return switch (file) {
@@ -155,7 +165,7 @@ pub fn getObjcSelrefsAddress(symbol: Symbol, macho_file: *MachO) u64 {
 }
 
 pub fn getTlvPtrAddress(symbol: Symbol, macho_file: *MachO) u64 {
-    if (!symbol.flags.tlv_ptr) return 0;
+    if (!symbol.getSectionFlags().tlv_ptr) return 0;
     const extra = symbol.getExtra(macho_file);
     return macho_file.tlv_ptr.getAddress(extra.tlv_ptr, macho_file);
 }
@@ -167,14 +177,14 @@ const GetOrCreateZigGotEntryResult = struct {
 
 pub fn getOrCreateZigGotEntry(symbol: *Symbol, symbol_index: Index, macho_file: *MachO) !GetOrCreateZigGotEntryResult {
     assert(!macho_file.base.isRelocatable());
-    assert(symbol.flags.needs_zig_got);
-    if (symbol.flags.has_zig_got) return .{ .found_existing = true, .index = symbol.getExtra(macho_file).zig_got };
+    assert(symbol.getSectionFlags().needs_zig_got);
+    if (symbol.getSectionFlags().has_zig_got) return .{ .found_existing = true, .index = symbol.getExtra(macho_file).zig_got };
     const index = try macho_file.zig_got.addSymbol(symbol_index, macho_file);
     return .{ .found_existing = false, .index = index };
 }
 
 pub fn getZigGotAddress(symbol: Symbol, macho_file: *MachO) u64 {
-    if (!symbol.flags.has_zig_got) return 0;
+    if (!symbol.getSectionFlags().has_zig_got) return 0;
     const extras = symbol.getExtra(macho_file);
     return macho_file.zig_got.entryAddress(extras.zig_got, macho_file);
 }
@@ -384,7 +394,9 @@ pub const Flags = packed struct {
 
     /// Whether the symbol makes into the output symtab or not.
     output_symtab: bool = false,
+};
 
+pub const SectionFlags = packed struct(u8) {
     /// Whether the symbol contains __got indirection.
     needs_got: bool = false,
     has_got: bool = false,
@@ -401,6 +413,8 @@ pub const Flags = packed struct {
 
     /// Whether the symbol contains __objc_stubs indirection.
     objc_stubs: bool = false,
+
+    _: u1 = 0,
 };
 
 pub const Visibility = enum {

--- a/src/link/MachO/UnwindInfo.zig
+++ b/src/link/MachO/UnwindInfo.zig
@@ -53,7 +53,7 @@ pub fn generate(info: *UnwindInfo, macho_file: *MachO) !void {
     for (macho_file.sections.items(.atoms)) |atoms| {
         for (atoms.items) |ref| {
             const atom = ref.getAtom(macho_file) orelse continue;
-            if (!atom.flags.alive) continue;
+            if (!atom.isAlive()) continue;
             const recs = atom.getUnwindRecords(macho_file);
             const file = atom.getFile(macho_file);
             try info.records.ensureUnusedCapacity(gpa, recs.len);

--- a/src/link/MachO/ZigObject.zig
+++ b/src/link/MachO/ZigObject.zig
@@ -1767,6 +1767,11 @@ fn addString(self: *ZigObject, allocator: Allocator, string: []const u8) !MachO.
     return .{ .pos = off, .len = @intCast(string.len + 1) };
 }
 
+pub fn getString(self: ZigObject, string: MachO.String) [:0]const u8 {
+    if (string.len == 0) return "";
+    return self.strtab.buffer.items[string.pos..][0 .. string.len - 1 :0];
+}
+
 pub fn asFile(self: *ZigObject) File {
     return .{ .zig_object = self };
 }

--- a/src/link/MachO/dyld_info/Rebase.zig
+++ b/src/link/MachO/dyld_info/Rebase.zig
@@ -35,7 +35,7 @@ pub fn updateSize(rebase: *Rebase, macho_file: *MachO) !void {
         const file = macho_file.getFile(index).?;
         for (file.getAtoms()) |atom_index| {
             const atom = file.getAtom(atom_index) orelse continue;
-            if (!atom.flags.alive) continue;
+            if (!atom.isAlive()) continue;
             if (atom.getInputSection(macho_file).isZerofill()) continue;
             const atom_addr = atom.getAddress(macho_file);
             const seg_id = macho_file.sections.items(.segment_id)[atom.out_n_sect];

--- a/src/link/MachO/dyld_info/Trie.zig
+++ b/src/link/MachO/dyld_info/Trie.zig
@@ -102,7 +102,7 @@ pub fn updateSize(self: *Trie, macho_file: *MachO) !void {
         if (ref.getFile(macho_file) == null) continue;
         const sym = ref.getSymbol(macho_file).?;
         if (!sym.flags.@"export") continue;
-        if (sym.getAtom(macho_file)) |atom| if (!atom.flags.alive) continue;
+        if (sym.getAtom(macho_file)) |atom| if (!atom.isAlive()) continue;
         var flags: u64 = if (sym.flags.abs)
             macho.EXPORT_SYMBOL_FLAGS_KIND_ABSOLUTE
         else if (sym.flags.tlv)
@@ -111,8 +111,8 @@ pub fn updateSize(self: *Trie, macho_file: *MachO) !void {
             macho.EXPORT_SYMBOL_FLAGS_KIND_REGULAR;
         if (sym.flags.weak) {
             flags |= macho.EXPORT_SYMBOL_FLAGS_WEAK_DEFINITION;
-            macho_file.weak_defines = true;
-            macho_file.binds_to_weak = true;
+            macho_file.weak_defines.store(true, .seq_cst);
+            macho_file.binds_to_weak.store(true, .seq_cst);
         }
         try self.put(gpa, .{
             .name = sym.getName(macho_file),

--- a/src/link/MachO/dyld_info/bind.zig
+++ b/src/link/MachO/dyld_info/bind.zig
@@ -10,10 +10,7 @@ pub const Entry = struct {
             if (entry.target.eql(other.target)) {
                 return entry.offset < other.offset;
             }
-            if (entry.target.file == other.target.file) {
-                return entry.target.index < other.target.index;
-            }
-            return entry.target.file < other.target.file;
+            return entry.target.lessThan(other.target);
         }
         return entry.segment_id < other.segment_id;
     }
@@ -47,7 +44,7 @@ pub const Bind = struct {
             const file = macho_file.getFile(index).?;
             for (file.getAtoms()) |atom_index| {
                 const atom = file.getAtom(atom_index) orelse continue;
-                if (!atom.flags.alive) continue;
+                if (!atom.isAlive()) continue;
                 if (atom.getInputSection(macho_file).isZerofill()) continue;
                 const atom_addr = atom.getAddress(macho_file);
                 const relocs = atom.getRelocs(macho_file);
@@ -299,7 +296,7 @@ pub const WeakBind = struct {
             const file = macho_file.getFile(index).?;
             for (file.getAtoms()) |atom_index| {
                 const atom = file.getAtom(atom_index) orelse continue;
-                if (!atom.flags.alive) continue;
+                if (!atom.isAlive()) continue;
                 if (atom.getInputSection(macho_file).isZerofill()) continue;
                 const atom_addr = atom.getAddress(macho_file);
                 const relocs = atom.getRelocs(macho_file);

--- a/src/link/MachO/file.zig
+++ b/src/link/MachO/file.zig
@@ -302,6 +302,13 @@ pub const File = union(enum) {
         };
     }
 
+    pub fn writeAtomsRelocatable(file: File, macho_file: *MachO) !void {
+        return switch (file) {
+            .dylib, .internal => unreachable,
+            inline else => |x| x.writeAtomsRelocatable(macho_file),
+        };
+    }
+
     pub fn calcSymtabSize(file: File, macho_file: *MachO) void {
         return switch (file) {
             inline else => |x| x.calcSymtabSize(macho_file),

--- a/src/link/MachO/file.zig
+++ b/src/link/MachO/file.zig
@@ -335,6 +335,21 @@ pub const File = union(enum) {
         };
     }
 
+    pub fn parse(file: File, macho_file: *MachO) !void {
+        return switch (file) {
+            .internal, .zig_object => unreachable,
+            .object => |x| x.parse(macho_file),
+            .dylib => |x| x.parse(macho_file),
+        };
+    }
+
+    pub fn parseAr(file: File, macho_file: *MachO) !void {
+        return switch (file) {
+            .internal, .zig_object, .dylib => unreachable,
+            .object => |x| x.parseAr(macho_file),
+        };
+    }
+
     pub const Index = u32;
 
     pub const Entry = union(enum) {

--- a/src/link/MachO/file.zig
+++ b/src/link/MachO/file.zig
@@ -37,11 +37,10 @@ pub const File = union(enum) {
     }
 
     pub fn scanRelocs(file: File, macho_file: *MachO) !void {
-        switch (file) {
+        return switch (file) {
             .dylib => unreachable,
-            .internal => |x| x.scanRelocs(macho_file),
             inline else => |x| x.scanRelocs(macho_file),
-        }
+        };
     }
 
     /// Encodes symbol rank so that the following ordering applies:
@@ -182,19 +181,19 @@ pub const File = union(enum) {
             if (ref.getFile(macho_file) == null) continue;
             if (ref.file != file.getIndex()) continue;
             const sym = ref.getSymbol(macho_file).?;
-            if (sym.flags.needs_got) {
+            if (sym.getSectionFlags().needs_got) {
                 log.debug("'{s}' needs GOT", .{sym.getName(macho_file)});
                 try macho_file.got.addSymbol(ref, macho_file);
             }
-            if (sym.flags.stubs) {
+            if (sym.getSectionFlags().stubs) {
                 log.debug("'{s}' needs STUBS", .{sym.getName(macho_file)});
                 try macho_file.stubs.addSymbol(ref, macho_file);
             }
-            if (sym.flags.tlv_ptr) {
+            if (sym.getSectionFlags().tlv_ptr) {
                 log.debug("'{s}' needs TLV pointer", .{sym.getName(macho_file)});
                 try macho_file.tlv_ptr.addSymbol(ref, macho_file);
             }
-            if (sym.flags.objc_stubs) {
+            if (sym.getSectionFlags().objc_stubs) {
                 log.debug("'{s}' needs OBJC STUBS", .{sym.getName(macho_file)});
                 try macho_file.objc_stubs.addSymbol(ref, macho_file);
             }
@@ -268,6 +267,9 @@ pub const File = union(enum) {
             const ref_file = ref.getFile(macho_file) orelse continue;
             if (ref_file.getIndex() == file.getIndex()) continue;
 
+            macho_file.dupes_mutex.lock();
+            defer macho_file.dupes_mutex.unlock();
+
             const gop = try macho_file.dupes.getOrPut(gpa, file.getGlobals()[i]);
             if (!gop.found_existing) {
                 gop.value_ptr.* = .{};
@@ -281,7 +283,7 @@ pub const File = union(enum) {
         defer tracy.end();
         for (file.getAtoms()) |atom_index| {
             const atom = file.getAtom(atom_index) orelse continue;
-            if (!atom.flags.alive) continue;
+            if (!atom.isAlive()) continue;
             atom.out_n_sect = try Atom.initOutputSection(atom.getInputSection(macho_file), macho_file);
         }
     }
@@ -295,7 +297,7 @@ pub const File = union(enum) {
 
     pub fn writeAtoms(file: File, macho_file: *MachO) !void {
         return switch (file) {
-            .dylib, .zig_object => unreachable,
+            .dylib => unreachable,
             inline else => |x| x.writeAtoms(macho_file),
         };
     }

--- a/src/link/MachO/hasher.zig
+++ b/src/link/MachO/hasher.zig
@@ -55,6 +55,8 @@ pub fn ParallelHasher(comptime Hasher: type) type {
             out: *[hash_size]u8,
             err: *fs.File.PReadError!usize,
         ) void {
+            const tracy = trace(@src());
+            defer tracy.end();
             err.* = file.preadAll(buffer, fstart);
             Hasher.hash(buffer, out, .{});
         }

--- a/src/link/MachO/relocatable.zig
+++ b/src/link/MachO/relocatable.zig
@@ -27,22 +27,21 @@ pub fn flushObject(macho_file: *MachO, comp: *Compilation, module_obj_path: ?[]c
     }
 
     for (positionals.items) |obj| {
-        macho_file.parsePositional(obj.path, obj.must_link) catch |err| switch (err) {
-            error.MalformedObject,
-            error.MalformedArchive,
-            error.InvalidCpuArch,
-            error.InvalidTarget,
-            => continue, // already reported
-            error.UnknownFileType => try macho_file.reportParseError(obj.path, "unknown file type for an object file", .{}),
+        macho_file.classifyInputFile(obj.path, .{ .path = obj.path }, obj.must_link) catch |err| switch (err) {
+            error.UnknownFileType => try macho_file.reportParseError(obj.path, "unknown file type for an input file", .{}),
             else => |e| try macho_file.reportParseError(
                 obj.path,
-                "unexpected error: parsing input file failed with error {s}",
+                "unexpected error: reading input file failed with error {s}",
                 .{@errorName(e)},
             ),
         };
     }
 
-    if (comp.link_errors.items.len > 0) return error.FlushFailure;
+    if (macho_file.base.hasErrors()) return error.FlushFailure;
+
+    try macho_file.parseInputFiles();
+
+    if (macho_file.base.hasErrors()) return error.FlushFailure;
 
     try macho_file.resolveSymbols();
     try macho_file.dedupLiterals();
@@ -93,22 +92,21 @@ pub fn flushStaticLib(macho_file: *MachO, comp: *Compilation, module_obj_path: ?
     }
 
     for (positionals.items) |obj| {
-        parsePositional(macho_file, obj.path) catch |err| switch (err) {
-            error.MalformedObject,
-            error.MalformedArchive,
-            error.InvalidCpuArch,
-            error.InvalidTarget,
-            => continue, // already reported
-            error.UnknownFileType => try macho_file.reportParseError(obj.path, "unknown file type for an object file", .{}),
+        macho_file.classifyInputFile(obj.path, .{ .path = obj.path }, obj.must_link) catch |err| switch (err) {
+            error.UnknownFileType => try macho_file.reportParseError(obj.path, "unknown file type for an input file", .{}),
             else => |e| try macho_file.reportParseError(
                 obj.path,
-                "unexpected error: parsing input file failed with error {s}",
+                "unexpected error: reading input file failed with error {s}",
                 .{@errorName(e)},
             ),
         };
     }
 
-    if (comp.link_errors.items.len > 0) return error.FlushFailure;
+    if (macho_file.base.hasErrors()) return error.FlushFailure;
+
+    try parseInputFilesAr(macho_file);
+
+    if (macho_file.base.hasErrors()) return error.FlushFailure;
 
     // First, we flush relocatable object file generated with our backends.
     if (macho_file.getZigObject()) |zo| {
@@ -225,79 +223,19 @@ pub fn flushStaticLib(macho_file: *MachO, comp: *Compilation, module_obj_path: ?
     try macho_file.base.file.?.setEndPos(total_size);
     try macho_file.base.file.?.pwriteAll(buffer.items, 0);
 
-    if (comp.link_errors.items.len > 0) return error.FlushFailure;
+    if (macho_file.base.hasErrors()) return error.FlushFailure;
 }
 
-fn parsePositional(macho_file: *MachO, path: []const u8) MachO.ParseError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
-    if (try Object.isObject(path)) {
-        try parseObject(macho_file, path);
-    } else if (try fat.isFatLibrary(path)) {
-        const fat_arch = try macho_file.parseFatLibrary(path);
-        if (try Archive.isArchive(path, fat_arch)) {
-            try parseArchive(macho_file, path, fat_arch);
-        } else return error.UnknownFileType;
-    } else if (try Archive.isArchive(path, null)) {
-        try parseArchive(macho_file, path, null);
-    } else return error.UnknownFileType;
-}
-
-fn parseObject(macho_file: *MachO, path: []const u8) MachO.ParseError!void {
+fn parseInputFilesAr(macho_file: *MachO) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
-    const gpa = macho_file.base.comp.gpa;
-    const file = try std.fs.cwd().openFile(path, .{});
-    errdefer file.close();
-    const handle = try macho_file.addFileHandle(file);
-    const mtime: u64 = mtime: {
-        const stat = file.stat() catch break :mtime 0;
-        break :mtime @as(u64, @intCast(@divFloor(stat.mtime, 1_000_000_000)));
-    };
-    const index = @as(File.Index, @intCast(try macho_file.files.addOne(gpa)));
-    macho_file.files.set(index, .{
-        .object = .{
-            .offset = 0, // TODO FAT objects
-            .path = try gpa.dupe(u8, path),
-            .file_handle = handle,
-            .mtime = mtime,
-            .index = index,
-        },
-    });
-    try macho_file.objects.append(gpa, index);
-
-    const object = macho_file.getFile(index).?.object;
-    try object.parseAr(macho_file);
-}
-
-fn parseArchive(macho_file: *MachO, path: []const u8, fat_arch: ?fat.Arch) MachO.ParseError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
-
-    const gpa = macho_file.base.comp.gpa;
-
-    const file = try std.fs.cwd().openFile(path, .{});
-    errdefer file.close();
-    const handle = try macho_file.addFileHandle(file);
-
-    var archive = Archive{};
-    defer archive.deinit(gpa);
-    try archive.parse(macho_file, path, handle, fat_arch);
-
-    var has_parse_error = false;
-    for (archive.objects.items) |extracted| {
-        const index = @as(File.Index, @intCast(try macho_file.files.addOne(gpa)));
-        macho_file.files.set(index, .{ .object = extracted });
-        const object = &macho_file.files.items(.data)[index].object;
-        object.index = index;
-        object.parseAr(macho_file) catch |err| switch (err) {
-            error.InvalidCpuArch => has_parse_error = true,
-            else => |e| return e,
+    for (macho_file.objects.items) |index| {
+        macho_file.getFile(index).?.parseAr(macho_file) catch |err| switch (err) {
+            error.InvalidCpuArch => {}, // already reported
+            else => |e| try macho_file.reportParseError2(index, "unexpected error: parsing input file failed with error {s}", .{@errorName(e)}),
         };
-        try macho_file.objects.append(gpa, index);
     }
-    if (has_parse_error) return error.MalformedArchive;
 }
 
 fn markExports(macho_file: *MachO) void {

--- a/src/link/MachO/relocatable.zig
+++ b/src/link/MachO/relocatable.zig
@@ -261,7 +261,7 @@ fn initOutputSections(macho_file: *MachO) !void {
         const file = macho_file.getFile(index).?;
         for (file.getAtoms()) |atom_index| {
             const atom = file.getAtom(atom_index) orelse continue;
-            if (!atom.flags.alive) continue;
+            if (!atom.isAlive()) continue;
             atom.out_n_sect = try Atom.initOutputSection(atom.getInputSection(macho_file), macho_file);
         }
     }

--- a/src/link/MachO/synthetic.zig
+++ b/src/link/MachO/synthetic.zig
@@ -24,8 +24,8 @@ pub const ZigGotSection = struct {
         const entry = &zig_got.entries.items[index];
         entry.* = sym_index;
         const symbol = &zo.symbols.items[sym_index];
-        assert(symbol.flags.needs_zig_got);
-        symbol.flags.has_zig_got = true;
+        assert(symbol.getSectionFlags().needs_zig_got);
+        symbol.setSectionFlags(.{ .has_zig_got = true });
         symbol.addExtra(.{ .zig_got = index }, macho_file);
         return index;
     }
@@ -121,7 +121,7 @@ pub const GotSection = struct {
         const entry = try got.symbols.addOne(gpa);
         entry.* = ref;
         const symbol = ref.getSymbol(macho_file).?;
-        symbol.flags.has_got = true;
+        symbol.setSectionFlags(.{ .has_got = true });
         symbol.addExtra(.{ .got = index }, macho_file);
     }
 
@@ -689,7 +689,7 @@ pub const DataInCode = struct {
                     dices[next_dice].offset < end_off) : (next_dice += 1)
                 {}
 
-                if (atom.flags.alive) for (dices[start_dice..next_dice]) |d| {
+                if (atom.isAlive()) for (dices[start_dice..next_dice]) |d| {
                     dice.entries.appendAssumeCapacity(.{
                         .atom_ref = .{ .index = atom_index, .file = index },
                         .offset = @intCast(d.offset - start_off),

--- a/src/link/MachO/thunks.zig
+++ b/src/link/MachO/thunks.zig
@@ -17,7 +17,7 @@ pub fn createThunks(sect_id: u8, macho_file: *MachO) !void {
     while (i < atoms.len) {
         const start = i;
         const start_atom = atoms[start].getAtom(macho_file).?;
-        assert(start_atom.flags.alive);
+        assert(start_atom.isAlive());
         start_atom.value = advance(header, start_atom.size, start_atom.alignment);
         i += 1;
 
@@ -25,7 +25,7 @@ pub fn createThunks(sect_id: u8, macho_file: *MachO) !void {
             header.size - start_atom.value < max_allowed_distance) : (i += 1)
         {
             const atom = atoms[i].getAtom(macho_file).?;
-            assert(atom.flags.alive);
+            assert(atom.isAlive());
             atom.value = advance(header, atom.size, atom.alignment);
         }
 
@@ -71,7 +71,7 @@ fn scanRelocs(thunk_index: Thunk.Index, gpa: Allocator, atoms: []const MachO.Ref
 
 fn isReachable(atom: *const Atom, rel: Relocation, macho_file: *MachO) bool {
     const target = rel.getTargetSymbol(atom.*, macho_file);
-    if (target.flags.stubs or target.flags.objc_stubs) return false;
+    if (target.getSectionFlags().stubs or target.getSectionFlags().objc_stubs) return false;
     if (atom.out_n_sect != target.getOutputSectionIndex(macho_file)) return false;
     const target_atom = target.getAtom(macho_file).?;
     if (target_atom.value == @as(u64, @bitCast(@as(i64, -1)))) return false;

--- a/src/link/Wasm/Object.zig
+++ b/src/link/Wasm/Object.zig
@@ -235,27 +235,27 @@ fn checkLegacyIndirectFunctionTable(object: *Object, wasm_file: *const Wasm) !?S
     if (object.imported_tables_count == table_count) return null;
 
     if (table_count != 0) {
-        var err = try wasm_file.addErrorWithNotes(1);
-        try err.addMsg(wasm_file, "Expected a table entry symbol for each of the {d} table(s), but instead got {d} symbols.", .{
+        var err = try wasm_file.base.addErrorWithNotes(1);
+        try err.addMsg("Expected a table entry symbol for each of the {d} table(s), but instead got {d} symbols.", .{
             object.imported_tables_count,
             table_count,
         });
-        try err.addNote(wasm_file, "defined in '{s}'", .{object.path});
+        try err.addNote("defined in '{s}'", .{object.path});
         return error.MissingTableSymbols;
     }
 
     // MVP object files cannot have any table definitions, only imports (for the indirect function table).
     if (object.tables.len > 0) {
-        var err = try wasm_file.addErrorWithNotes(1);
-        try err.addMsg(wasm_file, "Unexpected table definition without representing table symbols.", .{});
-        try err.addNote(wasm_file, "defined in '{s}'", .{object.path});
+        var err = try wasm_file.base.addErrorWithNotes(1);
+        try err.addMsg("Unexpected table definition without representing table symbols.", .{});
+        try err.addNote("defined in '{s}'", .{object.path});
         return error.UnexpectedTable;
     }
 
     if (object.imported_tables_count != 1) {
-        var err = try wasm_file.addErrorWithNotes(1);
-        try err.addMsg(wasm_file, "Found more than one table import, but no representing table symbols", .{});
-        try err.addNote(wasm_file, "defined in '{s}'", .{object.path});
+        var err = try wasm_file.base.addErrorWithNotes(1);
+        try err.addMsg("Found more than one table import, but no representing table symbols", .{});
+        try err.addNote("defined in '{s}'", .{object.path});
         return error.MissingTableSymbols;
     }
 
@@ -266,9 +266,9 @@ fn checkLegacyIndirectFunctionTable(object: *Object, wasm_file: *const Wasm) !?S
     } else unreachable;
 
     if (!std.mem.eql(u8, object.string_table.get(table_import.name), "__indirect_function_table")) {
-        var err = try wasm_file.addErrorWithNotes(1);
-        try err.addMsg(wasm_file, "Non-indirect function table import '{s}' is missing a corresponding symbol", .{object.string_table.get(table_import.name)});
-        try err.addNote(wasm_file, "defined in '{s}'", .{object.path});
+        var err = try wasm_file.base.addErrorWithNotes(1);
+        try err.addMsg("Non-indirect function table import '{s}' is missing a corresponding symbol", .{object.string_table.get(table_import.name)});
+        try err.addNote("defined in '{s}'", .{object.path});
         return error.MissingTableSymbols;
     }
 
@@ -596,9 +596,9 @@ fn Parser(comptime ReaderType: type) type {
                 try reader.readNoEof(name);
 
                 const tag = types.known_features.get(name) orelse {
-                    var err = try parser.wasm_file.addErrorWithNotes(1);
-                    try err.addMsg(parser.wasm_file, "Object file contains unknown feature: {s}", .{name});
-                    try err.addNote(parser.wasm_file, "defined in '{s}'", .{parser.object.path});
+                    var err = try parser.wasm_file.base.addErrorWithNotes(1);
+                    try err.addMsg("Object file contains unknown feature: {s}", .{name});
+                    try err.addNote("defined in '{s}'", .{parser.object.path});
                     return error.UnknownFeature;
                 };
                 feature.* = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -211,6 +211,9 @@ fn verifyLibcxxCorrectlyLinked() void {
 }
 
 fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
+    const tr = tracy.trace(@src());
+    defer tr.end();
+
     if (args.len <= 1) {
         std.log.info("{s}", .{usage});
         fatal("expected command argument", .{});


### PR DESCRIPTION
Finish upstreaming parallelized MachO linker. Benchmarked linking of https://github.com/kubkon/zld/issues/138:

<img width="758" alt="Screenshot 2024-07-22 at 11 52 40" src="https://github.com/user-attachments/assets/76c7ed95-7114-4126-8df4-b4abfc94f429">

Legend:
* `clang+ld` - `xcrun clang++ -o ld_foo objs/*`
* `clang+lld` - `xcrun clang++ -o lld_foo objs/* -fuse-ld=/Users/kubkon/opt/llvm18-release/bin/ld64.lld`
* `clang+zld` - `xcrun clang++ -o new_foo objs/* -fuse-ld=/Users/kubkon/dev/zld/zig-out/bin/ld64.zld`
* `zig-branch` (this branch) - `xcrun zig c++ -o new_zig_foo objs/*`
* `zig-master` (master branch) - `xcrun zig c++ -o old_zig_foo objs/*`

Sadly I had to increase the max rss but this will drop down once I implement mmaping output file since we won't have to alloc output sections in full for the threads to write to concurrently, or we won't have to re-read the entire file for UUID and code signature hashing.

EDIT: while here I have also extracted error reporting logic into `link.File` so that we don't duplicate this logic across all linkers.