### PR TITLE
`start`: Add startup code for loongarch64, m68k, and s390x

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -363,6 +363,15 @@ fn _start() callconv(.Naked) noreturn {
             \\ mtlr 0
             \\ b %[posixCallMainAndExit]
             ,
+            .s390x =>
+            // Set up the stack frame (register save area and cleared back-chain slot).
+            // Note: Stack pointer is guaranteed by ABI to be 8-byte aligned as required.
+            \\ lgr %r2, %r15
+            \\ aghi %r15, -160
+            \\ lghi %r0, 0
+            \\ stg  %r0, 0(%r15)
+            \\ jg %[posixCallMainAndExit]
+            ,
             .sparc64 =>
             // argc is stored after a register window (16 registers) plus stack bias
             \\ mov %%g0, %%i6

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -307,6 +307,14 @@ fn _start() callconv(.Naked) noreturn {
             \\ andi sp, sp, -16
             \\ tail %[posixCallMainAndExit]@plt
             ,
+            .m68k =>
+            // Note that the - 8 is needed because pc in the jsr instruction points into the middle
+            // of the jsr instruction. (The lea is 6 bytes, the jsr is 4 bytes.)
+            \\ suba.l %%fp, %%fp
+            \\ move.l %%sp, -(%%sp)
+            \\ lea %[posixCallMainAndExit] - . - 8, %%a0
+            \\ jsr (%%pc, %%a0)
+            ,
             .mips, .mipsel =>
             // The lr is already zeroed on entry, as specified by the ABI.
             \\ addiu $fp, $zero, 0

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -300,6 +300,12 @@ fn _start() callconv(.Naked) noreturn {
             \\ and sp, #-16
             \\ b %[posixCallMainAndExit]
             ,
+            .loongarch64 =>
+            \\ move $fp, $zero
+            \\ move $a0, $sp
+            \\ bstrins.d $sp, $zero, 3, 0
+            \\ b %[posixCallMainAndExit]
+            ,
             .riscv64 =>
             \\ li s0, 0
             \\ li ra, 0

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -340,8 +340,8 @@ fn _start() callconv(.Naked) noreturn {
             ,
             .powerpc64, .powerpc64le =>
             // Setup the initial stack frame and clear the back chain pointer.
-            \\ addis 2, 12, .TOC. - _start@ha
-            \\ addi 2, 2, .TOC. - _start@l
+            \\ addis 2, 12, .TOC. - %[_start]@ha
+            \\ addi 2, 2, .TOC. - %[_start]@l
             \\ mr 3, 1
             \\ clrrdi 1, 1, 4
             \\ li 0, 0
@@ -359,7 +359,8 @@ fn _start() callconv(.Naked) noreturn {
             else => @compileError("unsupported arch"),
         }
         :
-        : [posixCallMainAndExit] "X" (&posixCallMainAndExit),
+        : [_start] "X" (_start),
+          [posixCallMainAndExit] "X" (&posixCallMainAndExit),
     );
 }
 


### PR DESCRIPTION
I should note that I haven't tested any of these as there are various other blocking issues for these ports to work. But the commits are fairly straightforward adaptations of this musl code:

* https://git.musl-libc.org/cgit/musl/tree/arch/loongarch64/crt_arch.h
* https://git.musl-libc.org/cgit/musl/tree/arch/m68k/crt_arch.h
* https://git.musl-libc.org/cgit/musl/tree/arch/s390x/crt_arch.h