### PR TITLE
std.zig.render.hasComment: skip contents of nested blocks

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -4226,6 +4226,44 @@ test "zig fmt: comments at several places in struct init" {
     );
 }
 
+test "zig fmt: comment in nested struct initializers" {
+    try testTransform(
+        \\var bar: Bar = .{
+        \\    .foo = .{
+        \\        .baz = .{
+        \\            // test
+        \\            .x = .{
+        \\                .y = 10
+        \\            }
+        \\        },
+        \\    }
+        \\};
+        \\
+    ,
+        \\var bar: Bar = .{ .foo = .{
+        \\    .baz = .{
+        \\        // test
+        \\        .x = .{ .y = 10 },
+        \\    },
+        \\} };
+        \\
+    );
+
+    try testCanonical(
+        \\var bar: Bar = .{
+        \\    .foo = .{
+        \\        .baz = .{
+        \\            // test
+        \\            .x = .{
+        \\                .y = 10,
+        \\            },
+        \\        },
+        \\    },
+        \\};
+        \\
+    );
+}
+
 test "zig fmt: container doc comments" {
     try testCanonical(
         \\//! tld 1

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2993,7 +2993,7 @@ fn hasComment(tree: Ast, start_tok: Ast.TokenIndex, end_tok: Ast.TokenIndex) boo
     while (current_tok < end_tok) {
         var next_tok = current_tok + 1;
 
-        const current_tok_len = tree.tokenSlice(@intCast(current_tok)).len;
+        const current_tok_len = tree.tokenSlice(current_tok).len;
         const src_start = token_starts[current_tok] + current_tok_len;
         const src_end = token_starts[next_tok];
         const source = tree.source[src_start..src_end];


### PR DESCRIPTION
Given this unformatted code:

```zig
const block = .{
    .foo = .{
        // comment
        .bar = 0,
    }
};
```

Current `zig fmt` formats it this way:

```zig
const block = .{
    .foo = .{
        // comment
        .bar = 0,
    },
};
```

A trailing comma is added even though the comment is within a nested block. Without the comment, the result is this:

```zig
const block = .{ .foo = .{
    .bar = 0,
} };
```

This branch's implementation of `std.zig.render.hasComment` skips any comment within nested blocks, giving the following result instead:

```zig
const block = .{ .foo = .{
    // comment
    .bar = 0,
} };
```

Note that in status quo (and in this branch), the following does not get changed:

```zig
const block = .{ // comment
    .foo = .{ .bar = 0 },
};
```

I am unsure whether this is intended or not, and in doubt I did not search to fix it.

Fixes #20529.

Redo of #20721; sorry again for failing to run the correct test suite in the original PR.