### PR TITLE
Implement MT Analysis Tracing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,6 +579,7 @@ set(ZIG_STAGE2_SOURCES
     src/codegen/spirv/spec.zig
     src/crash_report.zig
     src/dev.zig
+    src/TimeTrace.zig
     src/glibc.zig
     src/introspect.zig
     src/libcxx.zig

--- a/src/TimeTrace.zig
+++ b/src/TimeTrace.zig
@@ -1,0 +1,134 @@
+const std = @import("std");
+const InternPool = @import("InternPool.zig");
+const Zcu = @import("Zcu.zig");
+const TimeTrace = @This();
+
+gpa: std.mem.Allocator,
+enabled: bool = false,
+start_time: std.time.Instant,
+events: std.ArrayListUnmanaged(Event) = .{},
+mutex: std.Thread.Mutex = .{},
+
+pub const EventDesc = union(enum) {
+    // Sema events:
+    fn_body: InternPool.Index,
+    decl: Zcu.Decl.Index,
+
+    // Codegen events:
+    codegen_func: InternPool.Index,
+    codegen_decl: Zcu.Decl.Index,
+
+    end: void,
+};
+
+const Event = struct {
+    time: std.time.Instant,
+    pt: Zcu.PerThread,
+    desc: EventDesc,
+};
+
+pub fn init(gpa: std.mem.Allocator) TimeTrace {
+    return .{
+        .gpa = gpa,
+        .start_time = undefined, // set in enable
+        .enabled = false,
+    };
+}
+
+pub fn enable(self: *TimeTrace) void {
+    std.debug.assert(!self.enabled);
+    self.start_time = std.time.Instant.now() catch @panic("Failed to record time");
+    self.enabled = true;
+}
+
+pub fn deinit(self: *TimeTrace) void {
+    self.clearData();
+    self.* = undefined;
+}
+
+fn clearData(self: *TimeTrace) void {
+    self.events.deinit(self.gpa);
+    self.events = .{};
+}
+
+pub fn dumpReportAndClear(self: *TimeTrace, path: []const u8) void {
+    if (self.enabled) {
+        self.dumpFlameGraph(path);
+        self.clearData();
+    }
+}
+
+fn dumpFlameGraph(self: *TimeTrace, path: []const u8) void {
+    const file = std.fs.cwd().createFile(path, .{}) catch @panic("Failed to create time-trace .json file");
+    defer file.close();
+
+    var buffered = std.io.bufferedWriter(file.writer());
+    self.writeFlameGraphOrError(buffered.writer()) catch @panic("Failed to write time-trace .json file");
+    buffered.flush() catch @panic("Failed to write time-trace .json file");
+}
+
+fn writeFlameGraphOrError(self: *TimeTrace, writer: anytype) @TypeOf(writer).Error!void {
+    try writer.writeAll("[");
+    for (self.events.items, 0..) |*evt, i| {
+        const time_us = evt.time.since(self.start_time) / 1000;
+        switch (evt.desc) {
+            .codegen_decl, .decl => |decl_idx| {
+                const decl = evt.pt.zcu.declPtr(decl_idx);
+                const cat = switch (evt.desc) {
+                    .decl => "sema,decl",
+                    .codegen_decl => "codegen,decl",
+                    else => unreachable,
+                };
+                try writeEvent(writer, cat, decl.fqn, time_us, evt.pt);
+            },
+            .fn_body, .codegen_func => |fn_index| {
+                const func = evt.pt.zcu.funcInfo(fn_index);
+                const decl_index = func.owner_decl;
+                const decl = evt.pt.zcu.declPtr(decl_index);
+                const cat = switch (evt.desc) {
+                    .fn_body => "sema,fn_body",
+                    .codegen_func => "codegen,func",
+                    else => unreachable,
+                };
+                try writeEvent(writer, cat, decl.fqn, time_us, evt.pt);
+            },
+            .end => {
+                try writer.print("{{\"ph\":\"E\",\"ts\":{},\"pid\":0,\"tid\":{d}}}{s}", .{
+                    time_us, @intFromEnum(evt.pt.tid), if (i == self.events.items.len) "" else ",",
+                });
+            },
+        }
+    }
+    try writer.writeAll("]");
+}
+
+fn writeEvent(
+    writer: anytype,
+    category: []const u8,
+    fq_index: InternPool.NullTerminatedString,
+    time_us: u64,
+    pt: Zcu.PerThread,
+) @TypeOf(writer).Error!void {
+    try writer.print("{{\"name\":\"{s} ", .{category});
+    try std.json.encodeJsonStringChars(fq_index.toSlice(&pt.zcu.intern_pool), .{}, writer);
+    try writer.print(
+        "\",\"cat\":\"{s}\",\"ph\":\"B\",\"ts\":{},\"pid\":0,\"tid\":{d}}},",
+        .{ category, time_us, @intFromEnum(pt.tid) },
+    );
+}
+
+pub inline fn event(
+    self: *TimeTrace,
+    evt: EventDesc,
+    pt: Zcu.PerThread,
+) void {
+    if (!self.enabled) return;
+
+    // it's rare that decls begin analysis/codegen at the exact same time
+    // so there shouldn't be much contention.
+    self.mutex.lock();
+    defer self.mutex.unlock();
+
+    const now = std.time.Instant.now() catch @panic("unsupported");
+    self.events.append(self.gpa, .{ .time = now, .desc = evt, .pt = pt }) catch @panic("out of memory");
+}

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -2395,9 +2395,9 @@ pub const CompileError = error{
     ComptimeBreak,
 };
 
-pub fn init(mod: *Zcu, thread_count: usize) !void {
-    const gpa = mod.gpa;
-    try mod.intern_pool.init(gpa, thread_count);
+pub fn init(zcu: *Zcu, thread_count: usize) !void {
+    const gpa = zcu.gpa;
+    try zcu.intern_pool.init(gpa, thread_count);
 }
 
 pub fn deinit(zcu: *Zcu) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -650,6 +650,7 @@ const usage_build_generic =
     \\  --debug-log [scope]          Enable printing debug/info log messages for scope
     \\  --debug-compile-errors       Crash with helpful diagnostics at the first compile error
     \\  --debug-link-snapshot        Enable dumping of the linker's state in JSON format
+    \\  --debug-timing=[path]        Dumps timing information in the Spall JSON format
     \\
 ;
 
@@ -837,6 +838,7 @@ fn buildOutputType(
     var verbose_llvm_bc: ?[]const u8 = null;
     var verbose_cimport = false;
     var verbose_llvm_cpu_features = false;
+    var debug_timing: ?[]const u8 = null;
     var time_report = false;
     var stack_report = false;
     var show_builtin = false;
@@ -1362,6 +1364,9 @@ fn buildOutputType(
                         } else {
                             enable_link_snapshots = true;
                         }
+                    } else if (mem.startsWith(u8, arg, "--debug-timing=")) {
+                        debug_timing = arg["--debug-timing=".len..];
+                        if (debug_timing.?.len == 0) fatal("--debug-timing expected a path", .{});
                     } else if (mem.eql(u8, arg, "-fincremental")) {
                         dev.check(.incremental);
                         opt_incremental = true;
@@ -3334,6 +3339,7 @@ fn buildOutputType(
         .verbose_generic_instances = verbose_generic_instances,
         .verbose_llvm_ir = verbose_llvm_ir,
         .verbose_llvm_bc = verbose_llvm_bc,
+        .debug_timing = debug_timing,
         .verbose_cimport = verbose_cimport,
         .verbose_llvm_cpu_features = verbose_llvm_cpu_features,
         .time_report = time_report,


### PR DESCRIPTION
EDIT: almost forgot to credit the original creator of the code, @SpexGuy! Thanks!

This PR implements creating [Spall](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.yr4qxyxotyw) time traces through the added `--debug-timing` option.

## Why is this useful?

As we focus more on optimization in the Zig compiler, and more importantly parallelization, it becomes nice to have an easy-to-use tracing system that works well with our multi-threading design. The current option for this is Tracy, which is more focused on tracing the specific functions inside the compiler and frankly is not easy to use.

This offers a much easier-to-use alternative that's focused on the analysis flow inside of the compiler, instead of tracing specific functions. 

- All you need to view the output is a browser, using a website such as [perfetto](https://ui.perfetto.dev/), [gravity moth](https://gravitymoth.com/spall/spall-web.html), or `chrome://tracing`.
- Doesn't require linking `libc`, so it can be used on a purely self-hosted build of the compiler.


If you need detailed traces of the internal function call stack, Tracy is the go-to.

## Examples:

![image](https://github.com/user-attachments/assets/c6e0711c-81ff-4872-9cdb-97c3b8278bc8)
This image is a bit zoomed out, but I hope it provides the basic idea of what an output trace looks like. This is using @jacobly0's multi-threaded codegen branch, so there are 33 total TIDs. Each time range is the start to the end of a decl/function being analyzed or codegen-ed.

## Follow-up questions

- Should this functionality be hidden behind a dev "`Env`"? 

As I see it, the pro is that this internal Zig debug flag couldn't be used in distributed builds. 
The con is that if someone wanted to trace for example the LLVM backend, they'd need to manually modify `dev.zig`.

- Any better names for the flag?

I choose this one because it's a debug, timing. Always open to better suggestions.

- Should there be `build.zig` support for the flag?

Also a pro and con question. Pro is that we could potentially revive `gotta-go-fast` and make the generation of such graphs automatic. Con is that again, it's a debug flag for internal use.
