### PR TITLE
`start`: Avoid needlessly aligning the stack pointer on some architectures.

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -276,13 +276,11 @@ fn _start() callconv(.Naked) noreturn {
             .x86_64 =>
             \\ xorl %%ebp, %%ebp
             \\ movq %%rsp, %%rdi
-            \\ andq $-16, %%rsp
             \\ callq %[posixCallMainAndExit:P]
             ,
             .x86 =>
             \\ xorl %%ebp, %%ebp
             \\ movl %%esp, %%eax
-            \\ andl $-16, %%esp
             \\ subl $12, %%esp
             \\ pushl %%eax
             \\ calll %[posixCallMainAndExit:P]
@@ -307,26 +305,10 @@ fn _start() callconv(.Naked) noreturn {
             \\ andi sp, sp, -16
             \\ tail %[posixCallMainAndExit]@plt
             ,
-            .mips, .mipsel =>
+            .mips, .mipsel, .mips64, .mips64el =>
             // The lr is already zeroed on entry, as specified by the ABI.
             \\ addiu $fp, $zero, 0
             \\ move $a0, $sp
-            \\ .set push
-            \\ .set noat
-            \\ addiu $1, $zero, -16
-            \\ and $sp, $sp, $1
-            \\ .set pop
-            \\ j %[posixCallMainAndExit]
-            ,
-            .mips64, .mips64el =>
-            // The lr is already zeroed on entry, as specified by the ABI.
-            \\ addiu $fp, $zero, 0
-            \\ move $a0, $sp
-            \\ .set push
-            \\ .set noat
-            \\ daddiu $1, $zero, -16
-            \\ and $sp, $sp, $1
-            \\ .set pop
             \\ j %[posixCallMainAndExit]
             ,
             .powerpc, .powerpcle =>
@@ -343,7 +325,6 @@ fn _start() callconv(.Naked) noreturn {
             \\ addis 2, 12, .TOC. - _start@ha
             \\ addi 2, 2, .TOC. - _start@l
             \\ mr 3, 1
-            \\ clrrdi 1, 1, 4
             \\ li 0, 0
             \\ stdu 0, -32(1)
             \\ mtlr 0


### PR DESCRIPTION
For these, the relevant ABIs already guarantee that it is aligned appropriately when the kernel transfers control to `_start()`. Rather than potentially hiding ABI bugs, let's actually assume that the OS works properly unless/until we have evidence to the contrary.

* This effectively reverts 81232f7c91ca8e0969e9d3f92cc11caeedc017d0.
* Arm32, LoongArch, and RISC-V continue to do stack alignment because their ABIs specify absolutely nothing about stack alignment upon entry to `_start()`, and I can find no evidence that the Linux kernel performs explicit stack alignment for them.
* Arm64 is a bit of a question mark. The ABI likewise says nothing, but the Linux kernel [does](https://github.com/torvalds/linux/blob/933069701c1b507825b514317d4edd5d3fd9d417/arch/arm64/kernel/process.c#L591-L596) align the stack to a 16-byte boundary. Leaving it as it was (no alignment) for now.
    * My impression here is that the process initialization ABI for Arm on Linux is, in general, informal. Which is weird, considering [how much ABI documentation otherwise exists](https://github.com/ARM-software/abi-aa/tree/main).

Marking as draft initially because I wouldn't be surprised if there's breakage.