### PR TITLE
Musl mistranslation fix in math.complex (partial subset from #20346)

### DIFF
--- a/lib/std/math/complex/cosh.zig
+++ b/lib/std/math/complex/cosh.zig
@@ -7,24 +7,14 @@
 const std = @import("../../std.zig");
 const testing = std.testing;
 const math = std.math;
-const cmath = math.complex;
-const Complex = cmath.Complex;
 
-const ldexp_cexp = @import("ldexp.zig").ldexp_cexp;
+const ldexp_cexp32 = @import("ldexp.zig").ldexp_cexp32;
+const ldexp_cexp64 = @import("ldexp.zig").ldexp_cexp64;
 
-/// Returns the hyperbolic arc-cosine of z.
-pub fn cosh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
-    const T = @TypeOf(z.re, z.im);
-    return switch (T) {
-        f32 => cosh32(z),
-        f64 => cosh64(z),
-        else => @compileError("cosh not implemented for " ++ @typeName(z)),
-    };
-}
-
-fn cosh32(z: Complex(f32)) Complex(f32) {
-    const x = z.re;
-    const y = z.im;
+pub fn cosh32(x: f32, y: f32) [2]f32 {
+    const huge: f32 = 0x1p127;
+    const zero: f32 = 0;
+    const one: f32 = 1;
 
     const hx: u32 = @bitCast(x);
     const ix = hx & 0x7fffffff;
@@ -32,141 +22,179 @@ fn cosh32(z: Complex(f32)) Complex(f32) {
     const hy: u32 = @bitCast(y);
     const iy = hy & 0x7fffffff;
 
-    if (ix < 0x7f800000 and iy < 0x7f800000) {
-        if (iy == 0) {
-            return Complex(f32).init(math.cosh(x), y);
-        }
+    if (ix < 0x7f800000 and iy < 0x7f800000) return ret: {
+        if (iy == 0) break :ret .{
+            math.cosh(x),
+            x * y,
+        };
+
         // small x: normal case
-        if (ix < 0x41100000) {
-            return Complex(f32).init(math.cosh(x) * @cos(y), math.sinh(x) * @sin(y));
-        }
+        if (ix < 0x41100000) break :ret .{
+            math.cosh(x) * @cos(y),
+            math.sinh(x) * @sin(y),
+        };
 
         // |x|>= 9, so cosh(x) ~= exp(|x|)
         if (ix < 0x42b17218) {
             // x < 88.7: exp(|x|) won't overflow
             const h = @exp(@abs(x)) * 0.5;
-            return Complex(f32).init(math.copysign(h, x) * @cos(y), h * @sin(y));
+            break :ret .{
+                @cos(y) * h,
+                @sin(y) * math.copysign(h, x),
+            };
         }
-        // x < 192.7: scale to avoid overflow
-        else if (ix < 0x4340b1e7) {
-            const v = Complex(f32).init(@abs(x), y);
-            const r = ldexp_cexp(v, -1);
-            return Complex(f32).init(r.re, r.im * math.copysign(@as(f32, 1.0), x));
+
+        if (ix < 0x4340b1e7) {
+            // x < 192.7: scale to avoid overflow
+            const r = ldexp_cexp32(@abs(x), y, -1);
+            break :ret .{
+                r[0],
+                r[1] * math.copysign(one, x),
+            };
         }
+
         // x >= 192.7: result always overflows
-        else {
-            const h = 0x1p127 * x;
-            return Complex(f32).init(h * h * @cos(y), h * @sin(y));
-        }
-    }
+        const h = huge * x;
+        break :ret .{
+            @cos(y) * (h * h),
+            @sin(y) * h,
+        };
+    };
 
-    if (ix == 0 and iy >= 0x7f800000) {
-        return Complex(f32).init(y - y, math.copysign(@as(f32, 0.0), x * (y - y)));
-    }
+    if (ix == 0 and iy >= 0x7f800000) return .{
+        y - y,
+        math.copysign(zero, x * (y - y)),
+    };
 
-    if (iy == 0 and ix >= 0x7f800000) {
-        if (hx & 0x7fffff == 0) {
-            return Complex(f32).init(x * x, math.copysign(@as(f32, 0.0), x) * y);
-        }
-        return Complex(f32).init(x, math.copysign(@as(f32, 0.0), (x + x) * y));
-    }
+    if (iy == 0 and ix >= 0x7f800000) return .{
+        x * x,
+        if (hx & 0x7fffff == 0)
+            math.copysign(zero, x) * y
+        else
+            math.copysign(zero, (x + x) * y),
+    };
 
-    if (ix < 0x7f800000 and iy >= 0x7f800000) {
-        return Complex(f32).init(y - y, x * (y - y));
-    }
+    if (ix < 0x7f800000 and iy >= 0x7f800000) return .{
+        (y - y),
+        (y - y) * x,
+    };
 
     if (ix >= 0x7f800000 and (hx & 0x7fffff) == 0) {
-        if (iy >= 0x7f800000) {
-            return Complex(f32).init(x * x, x * (y - y));
-        }
-        return Complex(f32).init((x * x) * @cos(y), x * @sin(y));
+        return if (iy >= 0x7f800000) .{
+            (x * x),
+            (y - y) * x,
+        } else .{
+            (x * x) * @cos(y),
+            @sin(y) * x,
+        };
     }
 
-    return Complex(f32).init((x * x) * (y - y), (x + x) * (y - y));
+    return .{
+        (x * x) * (y - y),
+        (x + x) * (y - y),
+    };
 }
 
-fn cosh64(z: Complex(f64)) Complex(f64) {
-    const x = z.re;
-    const y = z.im;
+pub fn cosh64(x: f64, y: f64) [2]f64 {
+    const huge: f64 = 0x1p1023;
+    const zero: f64 = 0;
+    const one: f64 = 1;
 
     const fx: u64 = @bitCast(x);
-    const hx: u32 = @intCast(fx >> 32);
-    const lx: u32 = @truncate(fx);
-    const ix = hx & 0x7fffffff;
-
     const fy: u64 = @bitCast(y);
+    const hx: u32 = @intCast(fx >> 32);
     const hy: u32 = @intCast(fy >> 32);
+    const lx: u32 = @truncate(fx);
     const ly: u32 = @truncate(fy);
+    const ix = hx & 0x7fffffff;
     const iy = hy & 0x7fffffff;
 
     // nearly non-exceptional case where x, y are finite
-    if (ix < 0x7ff00000 and iy < 0x7ff00000) {
-        if (iy | ly == 0) {
-            return Complex(f64).init(math.cosh(x), x * y);
-        }
+    if (ix < 0x7ff00000 and iy < 0x7ff00000) return ret: {
+        if (iy | ly == 0) break :ret .{
+            math.cosh(x),
+            x * y,
+        };
+
         // small x: normal case
-        if (ix < 0x40360000) {
-            return Complex(f64).init(math.cosh(x) * @cos(y), math.sinh(x) * @sin(y));
-        }
+        if (ix < 0x40360000) break :ret .{
+            math.cosh(x) * @cos(y),
+            math.sinh(x) * @sin(y),
+        };
 
         // |x|>= 22, so cosh(x) ~= exp(|x|)
         if (ix < 0x40862e42) {
             // x < 710: exp(|x|) won't overflow
             const h = @exp(@abs(x)) * 0.5;
-            return Complex(f64).init(h * @cos(y), math.copysign(h, x) * @sin(y));
+            break :ret .{
+                @cos(y) * h,
+                @sin(y) * math.copysign(h, x),
+            };
         }
+
         // x < 1455: scale to avoid overflow
-        else if (ix < 0x4096bbaa) {
-            const v = Complex(f64).init(@abs(x), y);
-            const r = ldexp_cexp(v, -1);
-            return Complex(f64).init(r.re, r.im * math.copysign(@as(f64, 1.0), x));
+        if (ix < 0x4096bbaa) {
+            const r = ldexp_cexp64(@abs(x), y, -1);
+            break :ret .{
+                r[0],
+                r[1] * math.copysign(one, x),
+            };
         }
+
         // x >= 1455: result always overflows
-        else {
-            const h = 0x1p1023;
-            return Complex(f64).init(h * h * @cos(y), h * @sin(y));
-        }
-    }
+        const h = huge * x;
+        break :ret .{
+            @cos(y) * (h * h),
+            @sin(y) * h,
+        };
+    };
 
-    if (ix | lx == 0 and iy >= 0x7ff00000) {
-        return Complex(f64).init(y - y, math.copysign(@as(f64, 0.0), x * (y - y)));
-    }
+    if (ix | lx == 0 and iy >= 0x7ff00000) return .{
+        y - y,
+        math.copysign(zero, x * (y - y)),
+    };
 
-    if (iy | ly == 0 and ix >= 0x7ff00000) {
-        if ((hx & 0xfffff) | lx == 0) {
-            return Complex(f64).init(x * x, math.copysign(@as(f64, 0.0), x) * y);
-        }
-        return Complex(f64).init(x * x, math.copysign(@as(f64, 0.0), (x + x) * y));
-    }
+    if (iy | ly == 0 and ix >= 0x7ff00000) return .{
+        x * x,
+        if ((hx & 0xfffff) | lx == 0)
+            math.copysign(zero, x) * y
+        else
+            math.copysign(zero, (x + x) * y),
+    };
 
-    if (ix < 0x7ff00000 and iy >= 0x7ff00000) {
-        return Complex(f64).init(y - y, x * (y - y));
-    }
+    if (ix < 0x7ff00000 and iy >= 0x7ff00000) return .{
+        (y - y),
+        (y - y) * x,
+    };
 
     if (ix >= 0x7ff00000 and (hx & 0xfffff) | lx == 0) {
-        if (iy >= 0x7ff00000) {
-            return Complex(f64).init(x * x, x * (y - y));
-        }
-        return Complex(f64).init(x * x * @cos(y), x * @sin(y));
+        return if (iy >= 0x7ff00000) .{
+            (x * x),
+            (y - y) * x,
+        } else .{
+            (x * x) * @cos(y),
+            @sin(y) * x,
+        };
     }
 
-    return Complex(f64).init((x * x) * (y - y), (x + x) * (y - y));
+    return .{
+        (x * x) * (y - y),
+        (x + x) * (y - y),
+    };
 }
 
-const epsilon = 0.0001;
-
 test cosh32 {
-    const a = Complex(f32).init(5, 3);
-    const c = cosh(a);
-
-    try testing.expect(math.approxEqAbs(f32, c.re, -73.467300, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 10.471557, epsilon));
+    const z = cosh32(5, 3);
+    const re: f32 = -73.46729221264526;
+    const im: f32 = 10.471557674805572;
+    try testing.expect(math.approxEqAbs(f32, z[0], re, @sqrt(math.floatEpsAt(f32, re))));
+    try testing.expect(math.approxEqAbs(f32, z[1], im, @sqrt(math.floatEpsAt(f32, im))));
 }
 
 test cosh64 {
-    const a = Complex(f64).init(5, 3);
-    const c = cosh(a);
-
-    try testing.expect(math.approxEqAbs(f64, c.re, -73.467300, epsilon));
-    try testing.expect(math.approxEqAbs(f64, c.im, 10.471557, epsilon));
+    const z = cosh64(5, 3);
+    const re: f64 = -73.46729221264526;
+    const im: f64 = 10.471557674805572;
+    try testing.expect(math.approxEqAbs(f64, z[0], re, @sqrt(math.floatEpsAt(f64, re))));
+    try testing.expect(math.approxEqAbs(f64, z[1], im, @sqrt(math.floatEpsAt(f64, im))));
 }

--- a/lib/std/math/complex/exp.zig
+++ b/lib/std/math/complex/exp.zig
@@ -7,154 +7,148 @@
 const std = @import("../../std.zig");
 const testing = std.testing;
 const math = std.math;
-const cmath = math.complex;
-const Complex = cmath.Complex;
 
-const ldexp_cexp = @import("ldexp.zig").ldexp_cexp;
+const ldexp_cexp32 = @import("ldexp.zig").ldexp_cexp32;
+const ldexp_cexp64 = @import("ldexp.zig").ldexp_cexp64;
 
-/// Returns e raised to the power of z (e^z).
-pub fn exp(z: anytype) Complex(@TypeOf(z.re, z.im)) {
-    const T = @TypeOf(z.re, z.im);
-
-    return switch (T) {
-        f32 => exp32(z),
-        f64 => exp64(z),
-        else => @compileError("exp not implemented for " ++ @typeName(z)),
-    };
-}
-
-fn exp32(z: Complex(f32)) Complex(f32) {
+pub fn exp32(x: f32, y: f32) [2]f32 {
     const exp_overflow = 0x42b17218; // max_exp * ln2 ~= 88.72283955
     const cexp_overflow = 0x43400074; // (max_exp - min_denom_exp) * ln2
 
-    const x = z.re;
-    const y = z.im;
-
     const hy = @as(u32, @bitCast(y)) & 0x7fffffff;
     // cexp(x + i0) = exp(x) + i0
-    if (hy == 0) {
-        return Complex(f32).init(@exp(x), y);
-    }
+    if (hy == 0) return .{ @exp(x), y };
 
-    const hx = @as(u32, @bitCast(x));
+    const hx: u32 = @bitCast(x);
     // cexp(0 + iy) = cos(y) + isin(y)
-    if ((hx & 0x7fffffff) == 0) {
-        return Complex(f32).init(@cos(y), @sin(y));
-    }
+    if ((hx & 0x7fffffff) == 0) return .{ @cos(y), @sin(y) };
 
     if (hy >= 0x7f800000) {
         // cexp(finite|nan +- i inf|nan) = nan + i nan
-        if ((hx & 0x7fffffff) != 0x7f800000) {
-            return Complex(f32).init(y - y, y - y);
-        } // cexp(-inf +- i inf|nan) = 0 + i0
-        else if (hx & 0x80000000 != 0) {
-            return Complex(f32).init(0, 0);
-        } // cexp(+inf +- i inf|nan) = inf + i nan
-        else {
-            return Complex(f32).init(x, y - y);
-        }
+        if ((hx & 0x7fffffff) != 0x7f800000) return .{ y - y, y - y };
+        // cexp(-inf +- i inf|nan) = 0 + i0
+        if (hx & 0x80000000 != 0) return .{ 0, 0 };
+        // cexp(+inf +- i inf|nan) = inf + i nan
+        return .{ x, y - y };
     }
 
     // 88.7 <= x <= 192 so must scale
-    if (hx >= exp_overflow and hx <= cexp_overflow) {
-        return ldexp_cexp(z, 0);
-    } // - x < exp_overflow => exp(x) won't overflow (common)
+    if (hx >= exp_overflow and hx <= cexp_overflow) return ldexp_cexp32(x, y, 0);
+
+    // - x < exp_overflow => exp(x) won't overflow (common)
     // - x > cexp_overflow, so exp(x) * s overflows for s > 0
     // - x = +-inf
     // - x = nan
-    else {
-        const exp_x = @exp(x);
-        return Complex(f32).init(exp_x * @cos(y), exp_x * @sin(y));
-    }
+    const exp_x = @exp(x);
+    return .{
+        exp_x * @cos(y),
+        exp_x * @sin(y),
+    };
 }
 
-fn exp64(z: Complex(f64)) Complex(f64) {
+pub fn exp64(x: f64, y: f64) [2]f64 {
     const exp_overflow = 0x40862e42; // high bits of max_exp * ln2 ~= 710
     const cexp_overflow = 0x4096b8e4; // (max_exp - min_denorm_exp) * ln2
-
-    const x = z.re;
-    const y = z.im;
 
     const fy: u64 = @bitCast(y);
     const hy: u32 = @intCast((fy >> 32) & 0x7fffffff);
     const ly: u32 = @truncate(fy);
 
     // cexp(x + i0) = exp(x) + i0
-    if (hy | ly == 0) {
-        return Complex(f64).init(@exp(x), y);
-    }
+    if (hy | ly == 0) return .{ @exp(x), y };
 
     const fx: u64 = @bitCast(x);
     const hx: u32 = @intCast(fx >> 32);
     const lx: u32 = @truncate(fx);
 
     // cexp(0 + iy) = cos(y) + isin(y)
-    if ((hx & 0x7fffffff) | lx == 0) {
-        return Complex(f64).init(@cos(y), @sin(y));
-    }
+    if ((hx & 0x7fffffff) | lx == 0) return .{ @cos(y), @sin(y) };
 
     if (hy >= 0x7ff00000) {
         // cexp(finite|nan +- i inf|nan) = nan + i nan
-        if (lx != 0 or (hx & 0x7fffffff) != 0x7ff00000) {
-            return Complex(f64).init(y - y, y - y);
-        } // cexp(-inf +- i inf|nan) = 0 + i0
-        else if (hx & 0x80000000 != 0) {
-            return Complex(f64).init(0, 0);
-        } // cexp(+inf +- i inf|nan) = inf + i nan
-        else {
-            return Complex(f64).init(x, y - y);
-        }
+        if (lx != 0 or (hx & 0x7fffffff) != 0x7ff00000) return .{ y - y, y - y };
+        // cexp(-inf +- i inf|nan) = 0 + i0
+        if (hx & 0x80000000 != 0) return .{ 0, 0 };
+        // cexp(+inf +- i inf|nan) = inf + i nan
+        return .{ x, y - y };
     }
 
     // 709.7 <= x <= 1454.3 so must scale
-    if (hx >= exp_overflow and hx <= cexp_overflow) {
-        return ldexp_cexp(z, 0);
-    } // - x < exp_overflow => exp(x) won't overflow (common)
+    if (hx >= exp_overflow and hx <= cexp_overflow) return ldexp_cexp64(x, y, 0);
+
+    // - x < exp_overflow => exp(x) won't overflow (common)
     // - x > cexp_overflow, so exp(x) * s overflows for s > 0
     // - x = +-inf
     // - x = nan
-    else {
-        const exp_x = @exp(x);
-        return Complex(f64).init(exp_x * @cos(y), exp_x * @sin(y));
+    const exp_x = @exp(x);
+    return .{
+        exp_x * @cos(y),
+        exp_x * @sin(y),
+    };
+}
+
+pub fn expFallback(comptime T: type, x: T, y: T) [2]T {
+    const nan = math.nan(T);
+    const inf = math.inf(T);
+    if (y == 0) return .{ @exp(x), y }; //           exp(x +- 0i) = exp(x) +- 0i
+    if (x == 0) return .{ @cos(y), @sin(y) }; //     exp(0 +  iy) = cos(y) + isin(y)
+    if (!math.isFinite(y)) {
+        if (!math.isInf(x)) return .{ nan, nan }; // exp(!inf +- i!fin) = nan + i nan
+        if (x < 0) return .{ 0, 0 }; //              exp(-inf +- i!fin) = 0 + i0
+        return .{ inf, nan }; //                     exp(+inf +- i!fin) = inf + i nan
     }
+    const exp_x = @exp(x);
+    return .{
+        exp_x * @cos(y),
+        exp_x * @sin(y),
+    };
 }
 
 test exp32 {
-    const tolerance_f32 = @sqrt(math.floatEps(f32));
-
     {
-        const a = Complex(f32).init(5, 3);
-        const c = exp(a);
-
-        try testing.expectApproxEqRel(@as(f32, -1.46927917e+02), c.re, tolerance_f32);
-        try testing.expectApproxEqRel(@as(f32, 2.0944065e+01), c.im, tolerance_f32);
+        const z = exp32(5, 3);
+        const re: f32 = -146.92791390831894;
+        const im: f32 = 20.944066208745966;
+        try testing.expect(math.approxEqAbs(f32, z[0], re, @sqrt(math.floatEpsAt(f32, re))));
+        try testing.expect(math.approxEqAbs(f32, z[1], im, @sqrt(math.floatEpsAt(f32, im))));
     }
-
     {
-        const a = Complex(f32).init(88.8, 0x1p-149);
-        const c = exp(a);
-
-        try testing.expectApproxEqAbs(math.inf(f32), c.re, tolerance_f32);
-        try testing.expectApproxEqAbs(@as(f32, 5.15088629e-07), c.im, tolerance_f32);
+        const z = exp32(88.8, 0x1p-149);
+        const re: f32 = math.inf(f32);
+        const im: f32 = 5.15088629e-07;
+        try testing.expect(math.approxEqAbs(f32, z[0], re, @sqrt(math.floatEps(f32))));
+        try testing.expect(math.approxEqAbs(f32, z[1], im, @sqrt(math.floatEps(f32))));
     }
 }
 
 test exp64 {
-    const tolerance_f64 = @sqrt(math.floatEps(f64));
-
     {
-        const a = Complex(f64).init(5, 3);
-        const c = exp(a);
-
-        try testing.expectApproxEqRel(@as(f64, -1.469279139083189e+02), c.re, tolerance_f64);
-        try testing.expectApproxEqRel(@as(f64, 2.094406620874596e+01), c.im, tolerance_f64);
+        const z = exp64(5, 3);
+        const re: f64 = -146.92791390831894;
+        const im: f64 = 20.944066208745966;
+        try testing.expect(math.approxEqAbs(f64, z[0], re, @sqrt(math.floatEpsAt(f64, re))));
+        try testing.expect(math.approxEqAbs(f64, z[1], im, @sqrt(math.floatEpsAt(f64, im))));
     }
-
     {
-        const a = Complex(f64).init(709.8, 0x1p-1074);
-        const c = exp(a);
+        const z = exp64(709.8, 0x1p-1074);
+        const re: f64 = math.inf(f64);
+        const im: f64 = 9.036659362159884e-16;
+        try testing.expectApproxEqAbs(re, z[0], @sqrt(math.floatEps(f64)));
+        try testing.expectApproxEqAbs(im, z[1], @sqrt(math.floatEps(f64)));
+    }
+}
 
-        try testing.expectApproxEqAbs(math.inf(f64), c.re, tolerance_f64);
-        try testing.expectApproxEqAbs(@as(f64, 9.036659362159884e-16), c.im, tolerance_f64);
+test expFallback {
+    const re = -146.92791390831894;
+    const im = 20.944066208745966;
+    inline for (.{ f16, f32, f64 }) |F| {
+        const z = expFallback(F, 5, 3);
+        try testing.expect(math.approxEqAbs(F, z[0], re, @sqrt(math.floatEpsAt(F, re))));
+        try testing.expect(math.approxEqAbs(F, z[1], im, @sqrt(math.floatEpsAt(F, im))));
+    }
+    { // separate f128 test with less strict tolerance
+        const z = expFallback(f128, 5, 3);
+        try testing.expect(math.approxEqAbs(f128, z[0], re, @sqrt(math.floatEpsAt(f64, re))));
+        try testing.expect(math.approxEqAbs(f128, z[1], im, @sqrt(math.floatEpsAt(f64, im))));
     }
 }

--- a/lib/std/math/complex/ldexp.zig
+++ b/lib/std/math/complex/ldexp.zig
@@ -4,81 +4,55 @@
 // https://git.musl-libc.org/cgit/musl/tree/src/complex/__cexpf.c
 // https://git.musl-libc.org/cgit/musl/tree/src/complex/__cexp.c
 
-const std = @import("../../std.zig");
-const debug = std.debug;
-const math = std.math;
-const testing = std.testing;
-const cmath = math.complex;
-const Complex = cmath.Complex;
-
-/// Returns exp(z) scaled to avoid overflow.
-pub fn ldexp_cexp(z: anytype, expt: i32) Complex(@TypeOf(z.re, z.im)) {
-    const T = @TypeOf(z.re, z.im);
-
-    return switch (T) {
-        f32 => ldexp_cexp32(z, expt),
-        f64 => ldexp_cexp64(z, expt),
-        else => unreachable,
-    };
-}
-
 fn frexp_exp32(x: f32, expt: *i32) f32 {
     const k = 235; // reduction constant
     const kln2 = 162.88958740; // k * ln2
-
     const exp_x = @exp(x - kln2);
-    const hx = @as(u32, @bitCast(exp_x));
+    const hx: u32 = @bitCast(exp_x);
     // TODO zig should allow this cast implicitly because it should know the value is in range
     expt.* = @as(i32, @intCast(hx >> 23)) - (0x7f + 127) + k;
-    return @as(f32, @bitCast((hx & 0x7fffff) | ((0x7f + 127) << 23)));
+    return @bitCast((hx & 0x7fffff) | ((0x7f + 127) << 23));
 }
 
-fn ldexp_cexp32(z: Complex(f32), expt: i32) Complex(f32) {
+pub fn ldexp_cexp32(x: f32, y: f32, expt: i32) [2]f32 {
     var ex_expt: i32 = undefined;
-    const exp_x = frexp_exp32(z.re, &ex_expt);
+    const exp_x = frexp_exp32(x, &ex_expt);
     const exptf = expt + ex_expt;
-
     const half_expt1 = @divTrunc(exptf, 2);
-    const scale1 = @as(f32, @bitCast((0x7f + half_expt1) << 23));
-
     const half_expt2 = exptf - half_expt1;
-    const scale2 = @as(f32, @bitCast((0x7f + half_expt2) << 23));
-
-    return Complex(f32).init(
-        @cos(z.im) * exp_x * scale1 * scale2,
-        @sin(z.im) * exp_x * scale1 * scale2,
-    );
+    const scale1: f32 = @bitCast((0x7f + half_expt1) << 23);
+    const scale2: f32 = @bitCast((0x7f + half_expt2) << 23);
+    return .{
+        @cos(y) * exp_x * scale1 * scale2,
+        @sin(y) * exp_x * scale1 * scale2,
+    };
 }
 
 fn frexp_exp64(x: f64, expt: *i32) f64 {
     const k = 1799; // reduction constant
     const kln2 = 1246.97177782734161156; // k * ln2
-
     const exp_x = @exp(x - kln2);
 
-    const fx = @as(u64, @bitCast(exp_x));
-    const hx = @as(u32, @intCast(fx >> 32));
-    const lx = @as(u32, @truncate(fx));
+    const fx: u64 = @bitCast(exp_x);
+    const hx: u32 = @intCast(fx >> 32);
+    const lx: u32 = @truncate(fx);
 
     expt.* = @as(i32, @intCast(hx >> 20)) - (0x3ff + 1023) + k;
 
     const high_word = (hx & 0xfffff) | ((0x3ff + 1023) << 20);
-    return @as(f64, @bitCast((@as(u64, high_word) << 32) | lx));
+    return @bitCast((@as(u64, high_word) << 32) | lx);
 }
 
-fn ldexp_cexp64(z: Complex(f64), expt: i32) Complex(f64) {
+pub fn ldexp_cexp64(x: f64, y: f64, expt: i32) [2]f64 {
     var ex_expt: i32 = undefined;
-    const exp_x = frexp_exp64(z.re, &ex_expt);
-    const exptf = @as(i64, expt + ex_expt);
-
+    const exp_x = frexp_exp64(x, &ex_expt);
+    const exptf: i64 = expt + ex_expt;
     const half_expt1 = @divTrunc(exptf, 2);
-    const scale1 = @as(f64, @bitCast((0x3ff + half_expt1) << (20 + 32)));
-
     const half_expt2 = exptf - half_expt1;
-    const scale2 = @as(f64, @bitCast((0x3ff + half_expt2) << (20 + 32)));
-
-    return Complex(f64).init(
-        @cos(z.im) * exp_x * scale1 * scale2,
-        @sin(z.im) * exp_x * scale1 * scale2,
-    );
+    const scale1: f64 = @bitCast((0x3ff + half_expt1) << (20 + 32));
+    const scale2: f64 = @bitCast((0x3ff + half_expt2) << (20 + 32));
+    return .{
+        @cos(y) * exp_x * scale1 * scale2,
+        @sin(y) * exp_x * scale1 * scale2,
+    };
 }

--- a/lib/std/math/complex/sinh.zig
+++ b/lib/std/math/complex/sinh.zig
@@ -7,87 +7,97 @@
 const std = @import("../../std.zig");
 const testing = std.testing;
 const math = std.math;
-const cmath = math.complex;
-const Complex = cmath.Complex;
 
-const ldexp_cexp = @import("ldexp.zig").ldexp_cexp;
+const ldexp_cexp32 = @import("ldexp.zig").ldexp_cexp32;
+const ldexp_cexp64 = @import("ldexp.zig").ldexp_cexp64;
 
-/// Returns the hyperbolic sine of z.
-pub fn sinh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
-    const T = @TypeOf(z.re, z.im);
-    return switch (T) {
-        f32 => sinh32(z),
-        f64 => sinh64(z),
-        else => @compileError("tan not implemented for " ++ @typeName(z)),
-    };
-}
+pub fn sinh32(x: f32, y: f32) [2]f32 {
+    const huge: f32 = 0x1p127;
+    const zero: f32 = 0;
+    const one: f32 = 1;
+    const inf: f32 = math.inf(f32);
 
-fn sinh32(z: Complex(f32)) Complex(f32) {
-    const x = z.re;
-    const y = z.im;
-
-    const hx = @as(u32, @bitCast(x));
+    const hx: u32 = @bitCast(x);
     const ix = hx & 0x7fffffff;
 
-    const hy = @as(u32, @bitCast(y));
+    const hy: u32 = @bitCast(y);
     const iy = hy & 0x7fffffff;
 
-    if (ix < 0x7f800000 and iy < 0x7f800000) {
-        if (iy == 0) {
-            return Complex(f32).init(math.sinh(x), y);
-        }
+    if (ix < 0x7f800000 and iy < 0x7f800000) return ret: {
+        if (iy == 0) break :ret .{
+            math.sinh(x),
+            y,
+        };
+
         // small x: normal case
-        if (ix < 0x41100000) {
-            return Complex(f32).init(math.sinh(x) * @cos(y), math.cosh(x) * @sin(y));
-        }
+        if (ix < 0x41100000) break :ret .{
+            math.sinh(x) * @cos(y),
+            math.cosh(x) * @sin(y),
+        };
 
         // |x|>= 9, so cosh(x) ~= exp(|x|)
         if (ix < 0x42b17218) {
             // x < 88.7: exp(|x|) won't overflow
             const h = @exp(@abs(x)) * 0.5;
-            return Complex(f32).init(math.copysign(h, x) * @cos(y), h * @sin(y));
+            break :ret .{
+                @cos(y) * math.copysign(h, x),
+                @sin(y) * h,
+            };
         }
+
         // x < 192.7: scale to avoid overflow
-        else if (ix < 0x4340b1e7) {
-            const v = Complex(f32).init(@abs(x), y);
-            const r = ldexp_cexp(v, -1);
-            return Complex(f32).init(r.re * math.copysign(@as(f32, 1.0), x), r.im);
+        if (ix < 0x4340b1e7) {
+            const z = ldexp_cexp32(@abs(x), y, -1);
+            break :ret .{
+                z[0] * math.copysign(one, x),
+                z[1],
+            };
         }
+
         // x >= 192.7: result always overflows
-        else {
-            const h = 0x1p127 * x;
-            return Complex(f32).init(h * @cos(y), h * h * @sin(y));
-        }
-    }
+        const h = huge * x;
+        break :ret .{
+            @cos(y) * h,
+            @sin(y) * (h * h),
+        };
+    };
 
-    if (ix == 0 and iy >= 0x7f800000) {
-        return Complex(f32).init(math.copysign(@as(f32, 0.0), x * (y - y)), y - y);
-    }
+    if (ix == 0 and iy >= 0x7f800000) return .{
+        math.copysign(zero, (y - y) * x),
+        (y - y),
+    };
 
-    if (iy == 0 and ix >= 0x7f800000) {
-        if (hx & 0x7fffff == 0) {
-            return Complex(f32).init(x, y);
-        }
-        return Complex(f32).init(x, math.copysign(@as(f32, 0.0), y));
-    }
+    if (iy == 0 and ix >= 0x7f800000) return .{
+        x,
+        if (hx & 0x7fffff == 0) y else math.copysign(zero, y),
+    };
 
-    if (ix < 0x7f800000 and iy >= 0x7f800000) {
-        return Complex(f32).init(y - y, x * (y - y));
-    }
+    if (ix < 0x7f800000 and iy >= 0x7f800000) return .{
+        (y - y),
+        (y - y) * x,
+    };
 
     if (ix >= 0x7f800000 and (hx & 0x7fffff) == 0) {
-        if (iy >= 0x7f800000) {
-            return Complex(f32).init(x * x, x * (y - y));
-        }
-        return Complex(f32).init(x * @cos(y), math.inf(f32) * @sin(y));
+        return if (iy >= 0x7f800000) .{
+            (x * x),
+            (y - y) * x,
+        } else .{
+            @cos(y) * x,
+            @sin(y) * inf,
+        };
     }
 
-    return Complex(f32).init((x * x) * (y - y), (x + x) * (y - y));
+    return .{
+        (x * x) * (y - y),
+        (x + x) * (y - y),
+    };
 }
 
-fn sinh64(z: Complex(f64)) Complex(f64) {
-    const x = z.re;
-    const y = z.im;
+pub fn sinh64(x: f64, y: f64) [2]f64 {
+    const huge: f64 = 0x1p1023;
+    const zero: f64 = 0;
+    const one: f64 = 1;
+    const inf: f64 = math.inf(f64);
 
     const fx: u64 = @bitCast(x);
     const hx: u32 = @intCast(fx >> 32);
@@ -99,73 +109,88 @@ fn sinh64(z: Complex(f64)) Complex(f64) {
     const ly: u32 = @truncate(fy);
     const iy = hy & 0x7fffffff;
 
-    if (ix < 0x7ff00000 and iy < 0x7ff00000) {
-        if (iy | ly == 0) {
-            return Complex(f64).init(math.sinh(x), y);
-        }
+    if (ix < 0x7ff00000 and iy < 0x7ff00000) return ret: {
+        if (iy | ly == 0) break :ret .{
+            math.sinh(x),
+            y,
+        };
+
         // small x: normal case
-        if (ix < 0x40360000) {
-            return Complex(f64).init(math.sinh(x) * @cos(y), math.cosh(x) * @sin(y));
-        }
+        if (ix < 0x40360000) break :ret .{
+            math.sinh(x) * @cos(y),
+            math.cosh(x) * @sin(y),
+        };
 
         // |x|>= 22, so cosh(x) ~= exp(|x|)
         if (ix < 0x40862e42) {
             // x < 710: exp(|x|) won't overflow
             const h = @exp(@abs(x)) * 0.5;
-            return Complex(f64).init(math.copysign(h, x) * @cos(y), h * @sin(y));
+            break :ret .{
+                @cos(y) * math.copysign(h, x),
+                @sin(y) * h,
+            };
         }
+
         // x < 1455: scale to avoid overflow
-        else if (ix < 0x4096bbaa) {
-            const v = Complex(f64).init(@abs(x), y);
-            const r = ldexp_cexp(v, -1);
-            return Complex(f64).init(r.re * math.copysign(@as(f64, 1.0), x), r.im);
+        if (ix < 0x4096bbaa) {
+            const z = ldexp_cexp64(@abs(x), y, -1);
+            break :ret .{
+                z[0] * math.copysign(one, x),
+                z[1],
+            };
         }
+
         // x >= 1455: result always overflows
-        else {
-            const h = 0x1p1023 * x;
-            return Complex(f64).init(h * @cos(y), h * h * @sin(y));
-        }
-    }
+        const h = huge * x;
+        break :ret .{
+            @cos(y) * h,
+            @sin(y) * (h * h),
+        };
+    };
 
-    if (ix | lx == 0 and iy >= 0x7ff00000) {
-        return Complex(f64).init(math.copysign(@as(f64, 0.0), x * (y - y)), y - y);
-    }
+    if (ix | lx == 0 and iy >= 0x7ff00000) return .{
+        math.copysign(zero, (y - y) * x),
+        (y - y),
+    };
 
-    if (iy | ly == 0 and ix >= 0x7ff00000) {
-        if ((hx & 0xfffff) | lx == 0) {
-            return Complex(f64).init(x, y);
-        }
-        return Complex(f64).init(x, math.copysign(@as(f64, 0.0), y));
-    }
+    if (iy | ly == 0 and ix >= 0x7ff00000) return .{
+        x,
+        if ((hx & 0xfffff) | lx == 0) y else math.copysign(zero, y),
+    };
 
-    if (ix < 0x7ff00000 and iy >= 0x7ff00000) {
-        return Complex(f64).init(y - y, x * (y - y));
-    }
+    if (ix < 0x7ff00000 and iy >= 0x7ff00000) return .{
+        (y - y),
+        (y - y) * x,
+    };
 
     if (ix >= 0x7ff00000 and (hx & 0xfffff) | lx == 0) {
-        if (iy >= 0x7ff00000) {
-            return Complex(f64).init(x * x, x * (y - y));
-        }
-        return Complex(f64).init(x * @cos(y), math.inf(f64) * @sin(y));
+        return if (iy >= 0x7ff00000) .{
+            x * x,
+            x * (y - y),
+        } else .{
+            @cos(y) * x,
+            @sin(y) * inf,
+        };
     }
 
-    return Complex(f64).init((x * x) * (y - y), (x + x) * (y - y));
+    return .{
+        (x * x) * (y - y),
+        (x + x) * (y - y),
+    };
 }
 
-const epsilon = 0.0001;
-
 test sinh32 {
-    const a = Complex(f32).init(5, 3);
-    const c = sinh(a);
-
-    try testing.expect(math.approxEqAbs(f32, c.re, -73.460617, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 10.472508, epsilon));
+    const z = sinh32(5, 3);
+    const re: f32 = -73.46062169567367;
+    const im: f32 = 10.472508533940392;
+    try testing.expect(math.approxEqAbs(f32, z[0], re, @sqrt(math.floatEpsAt(f32, re))));
+    try testing.expect(math.approxEqAbs(f32, z[1], im, @sqrt(math.floatEpsAt(f32, im))));
 }
 
 test sinh64 {
-    const a = Complex(f64).init(5, 3);
-    const c = sinh(a);
-
-    try testing.expect(math.approxEqAbs(f64, c.re, -73.460617, epsilon));
-    try testing.expect(math.approxEqAbs(f64, c.im, 10.472508, epsilon));
+    const z = sinh64(5, 3);
+    const re: f64 = -73.46062169567367;
+    const im: f64 = 10.472508533940392;
+    try testing.expect(math.approxEqAbs(f64, z[0], re, @sqrt(math.floatEpsAt(f64, re))));
+    try testing.expect(math.approxEqAbs(f64, z[1], im, @sqrt(math.floatEpsAt(f64, im))));
 }

--- a/lib/std/math/complex/sqrt.zig
+++ b/lib/std/math/complex/sqrt.zig
@@ -7,97 +7,83 @@
 const std = @import("../../std.zig");
 const testing = std.testing;
 const math = std.math;
-const cmath = math.complex;
-const Complex = cmath.Complex;
 
-/// Returns the square root of z. The real and imaginary parts of the result have the same sign
-/// as the imaginary part of z.
-pub fn sqrt(z: anytype) Complex(@TypeOf(z.re, z.im)) {
-    const T = @TypeOf(z.re, z.im);
+// TODO: this seems to have ported over musl's gcc-specific
+// workaround for incorrectly handled special cases in
+// complex multiplications. Do we still need this in Zig?
+pub fn sqrt32(x: f32, y: f32) [2]f32 {
+    if (x == 0 and y == 0) return .{ 0, y };
 
-    return switch (T) {
-        f32 => sqrt32(z),
-        f64 => sqrt64(z),
-        else => @compileError("sqrt not implemented for " ++ @typeName(T)),
+    if (math.isInf(y)) return .{ math.inf(f32), y };
+
+    if (math.isNan(x)) return .{
+        x,
+        (y - y) / (y - y), // raise invalid if y is not nan
     };
-}
 
-fn sqrt32(z: Complex(f32)) Complex(f32) {
-    const x = z.re;
-    const y = z.im;
-
-    if (x == 0 and y == 0) {
-        return Complex(f32).init(0, y);
-    }
-    if (math.isInf(y)) {
-        return Complex(f32).init(math.inf(f32), y);
-    }
-    if (math.isNan(x)) {
-        // raise invalid if y is not nan
-        const t = (y - y) / (y - y);
-        return Complex(f32).init(x, t);
-    }
     if (math.isInf(x)) {
         // sqrt(inf + i nan)    = inf + nan i
         // sqrt(inf + iy)       = inf + i0
         // sqrt(-inf + i nan)   = nan +- inf i
         // sqrt(-inf + iy)      = 0 + inf i
-        if (math.signbit(x)) {
-            return Complex(f32).init(@abs(x - y), math.copysign(x, y));
-        } else {
-            return Complex(f32).init(x, math.copysign(y - y, y));
-        }
+        return if (math.signbit(x)) .{
+            @abs(y - y),
+            math.copysign(x, y),
+        } else .{
+            x,
+            math.copysign(y - y, y),
+        };
     }
 
     // y = nan special case is handled fine below
 
     // double-precision avoids overflow with correct rounding.
-    const dx = @as(f64, x);
-    const dy = @as(f64, y);
+    const dx: f64 = x;
+    const dy: f64 = y;
 
     if (dx >= 0) {
-        const t = @sqrt((dx + math.hypot(dx, dy)) * 0.5);
-        return Complex(f32).init(
-            @as(f32, @floatCast(t)),
-            @as(f32, @floatCast(dy / (2.0 * t))),
-        );
+        const t = @sqrt(0.5 * (math.hypot(dx, dy) + dx));
+        return .{
+            @floatCast(t),
+            @floatCast(dy / (2.0 * t)),
+        };
     } else {
-        const t = @sqrt((-dx + math.hypot(dx, dy)) * 0.5);
-        return Complex(f32).init(
-            @as(f32, @floatCast(@abs(y) / (2.0 * t))),
-            @as(f32, @floatCast(math.copysign(t, y))),
-        );
+        const t = @sqrt(0.5 * (math.hypot(dx, dy) - dx));
+        return .{
+            @floatCast(@abs(y) / (2.0 * t)),
+            @floatCast(math.copysign(t, y)),
+        };
     }
 }
 
-fn sqrt64(z: Complex(f64)) Complex(f64) {
+pub fn sqrt64(z_re: f64, z_im: f64) [2]f64 {
     // may encounter overflow for im,re >= DBL_MAX / (1 + sqrt(2))
     const threshold = 0x1.a827999fcef32p+1022;
 
-    var x = z.re;
-    var y = z.im;
+    var x = z_re;
+    var y = z_im;
 
-    if (x == 0 and y == 0) {
-        return Complex(f64).init(0, y);
-    }
-    if (math.isInf(y)) {
-        return Complex(f64).init(math.inf(f64), y);
-    }
-    if (math.isNan(x)) {
-        // raise invalid if y is not nan
-        const t = (y - y) / (y - y);
-        return Complex(f64).init(x, t);
-    }
+    if (x == 0 and y == 0) return .{ 0, y };
+
+    if (math.isInf(y)) return .{ math.inf(f64), y };
+
+    if (math.isNan(x)) return .{
+        x,
+        (y - y) / (y - y), // raise invalid if y is not nan
+    };
+
     if (math.isInf(x)) {
         // sqrt(inf + i nan)    = inf + nan i
         // sqrt(inf + iy)       = inf + i0
         // sqrt(-inf + i nan)   = nan +- inf i
         // sqrt(-inf + iy)      = 0 + inf i
-        if (math.signbit(x)) {
-            return Complex(f64).init(@abs(x - y), math.copysign(x, y));
-        } else {
-            return Complex(f64).init(x, math.copysign(y - y, y));
-        }
+        return if (math.signbit(x)) .{
+            @abs(y - y),
+            math.copysign(x, y),
+        } else .{
+            x,
+            math.copysign(y - y, y),
+        };
     }
 
     // y = nan special case is handled fine below
@@ -110,37 +96,58 @@ fn sqrt64(z: Complex(f64)) Complex(f64) {
         scale = true;
     }
 
-    var result: Complex(f64) = undefined;
+    var re: f64 = undefined;
+    var im: f64 = undefined;
     if (x >= 0) {
-        const t = @sqrt((x + math.hypot(x, y)) * 0.5);
-        result = Complex(f64).init(t, y / (2.0 * t));
+        const t = @sqrt(0.5 * (math.hypot(x, y) + x));
+        re = t;
+        im = y / (2.0 * t);
     } else {
-        const t = @sqrt((-x + math.hypot(x, y)) * 0.5);
-        result = Complex(f64).init(@abs(y) / (2.0 * t), math.copysign(t, y));
+        const t = @sqrt(0.5 * (math.hypot(x, y) - x));
+        re = @abs(y) / (2.0 * t);
+        im = math.copysign(t, y);
     }
 
     if (scale) {
-        result.re *= 2;
-        result.im *= 2;
+        re *= 2;
+        im *= 2;
     }
 
-    return result;
+    return .{ re, im };
 }
 
-const epsilon = 0.0001;
+pub fn sqrtFallback(comptime T: type, x: T, y: T) [2]T {
+    if (y == 0) return if (x > 0) .{ @sqrt(x), y } else .{ 0, math.copysign(@sqrt(-x), y) };
+    const r = math.hypot(x, y);
+    const a = 0.5 * x + 0.5 * r;
+    const b = 0.5 * y;
+    const c = math.hypot(a, b);
+    const d = @sqrt(r);
+    return .{ a * d / c, b * d / c };
+}
 
 test sqrt32 {
-    const a = Complex(f32).init(5, 3);
-    const c = sqrt(a);
-
-    try testing.expect(math.approxEqAbs(f32, c.re, 2.327117, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 0.644574, epsilon));
+    const z = sqrt32(5, 3);
+    const re: f32 = 2.3271175190399496;
+    const im: f32 = 0.6445742373246469;
+    try testing.expect(math.approxEqAbs(f32, z[0], re, @sqrt(math.floatEpsAt(f32, re))));
+    try testing.expect(math.approxEqAbs(f32, z[1], im, @sqrt(math.floatEpsAt(f32, im))));
 }
 
 test sqrt64 {
-    const a = Complex(f64).init(5, 3);
-    const c = sqrt(a);
+    const z = sqrt64(5, 3);
+    const re: f64 = 2.3271175190399496;
+    const im: f64 = 0.6445742373246469;
+    try testing.expect(math.approxEqAbs(f64, z[0], re, @sqrt(math.floatEpsAt(f64, re))));
+    try testing.expect(math.approxEqAbs(f64, z[1], im, @sqrt(math.floatEpsAt(f64, im))));
+}
 
-    try testing.expect(math.approxEqAbs(f64, c.re, 2.3271175190399496, epsilon));
-    try testing.expect(math.approxEqAbs(f64, c.im, 0.6445742373246469, epsilon));
+test sqrtFallback {
+    const re = 2.3271175190399496;
+    const im = 0.6445742373246469;
+    inline for (.{ f16, f32, f64, f128 }) |F| {
+        const z = sqrtFallback(F, 5, 3);
+        try testing.expect(math.approxEqAbs(F, z[0], re, @sqrt(math.floatEpsAt(F, re))));
+        try testing.expect(math.approxEqAbs(F, z[1], im, @sqrt(math.floatEpsAt(F, im))));
+    }
 }


### PR DESCRIPTION
@tiehuis 

Also copied over the straight changes to ldexp, exp, and sinh so as to not conflict due to change in the inner impl signatures.