### PR TITLE
`std.os.linux.start_pie`: Implement `getDynamicSymbol()` for loongarch64, m68k, and s390x

### DIFF
--- a/lib/std/os/linux/start_pie.zig
+++ b/lib/std/os/linux/start_pie.zig
@@ -10,6 +10,7 @@ const R_AARCH64_RELATIVE = 1027;
 const R_LARCH_RELATIVE = 3;
 const R_68K_RELATIVE = 22;
 const R_RISCV_RELATIVE = 3;
+const R_390_RELATIVE = 12;
 const R_SPARC_RELATIVE = 22;
 
 const R_RELATIVE = switch (builtin.cpu.arch) {
@@ -20,6 +21,7 @@ const R_RELATIVE = switch (builtin.cpu.arch) {
     .loongarch32, .loongarch64 => R_LARCH_RELATIVE,
     .m68k => R_68K_RELATIVE,
     .riscv64 => R_RISCV_RELATIVE,
+    .s390x => R_390_RELATIVE,
     else => @compileError("Missing R_RELATIVE definition for this target"),
 };
 
@@ -80,6 +82,16 @@ fn getDynamicSymbol() [*]elf.Dyn {
             \\ .weak _DYNAMIC
             \\ .hidden _DYNAMIC
             \\ lla %[ret], _DYNAMIC
+            : [ret] "=r" (-> [*]elf.Dyn),
+        ),
+        .s390x => asm volatile (
+            \\ .weak _DYNAMIC
+            \\ .hidden _DYNAMIC
+            \\ larl %[ret], 1f
+            \\ agf %[ret], 0(%[ret])
+            \\ b 2f
+            \\ 1: .long _DYNAMIC - .
+            \\ 2:
             : [ret] "=r" (-> [*]elf.Dyn),
         ),
         else => {

--- a/lib/std/os/linux/start_pie.zig
+++ b/lib/std/os/linux/start_pie.zig
@@ -7,6 +7,7 @@ const R_AMD64_RELATIVE = 8;
 const R_386_RELATIVE = 8;
 const R_ARM_RELATIVE = 23;
 const R_AARCH64_RELATIVE = 1027;
+const R_LARCH_RELATIVE = 3;
 const R_RISCV_RELATIVE = 3;
 const R_SPARC_RELATIVE = 22;
 
@@ -15,6 +16,7 @@ const R_RELATIVE = switch (builtin.cpu.arch) {
     .x86_64 => R_AMD64_RELATIVE,
     .arm => R_ARM_RELATIVE,
     .aarch64 => R_AARCH64_RELATIVE,
+    .loongarch32, .loongarch64 => R_LARCH_RELATIVE,
     .riscv64 => R_RISCV_RELATIVE,
     else => @compileError("Missing R_RELATIVE definition for this target"),
 };
@@ -55,6 +57,12 @@ fn getDynamicSymbol() [*]elf.Dyn {
             \\ .hidden _DYNAMIC
             \\ adrp %[ret], _DYNAMIC
             \\ add %[ret], %[ret], #:lo12:_DYNAMIC
+            : [ret] "=r" (-> [*]elf.Dyn),
+        ),
+        .loongarch32, .loongarch64 => asm volatile (
+            \\ .weak _DYNAMIC
+            \\ .hidden _DYNAMIC
+            \\ la.local %[ret], _DYNAMIC
             : [ret] "=r" (-> [*]elf.Dyn),
         ),
         .riscv64 => asm volatile (

--- a/lib/std/os/linux/start_pie.zig
+++ b/lib/std/os/linux/start_pie.zig
@@ -8,6 +8,7 @@ const R_386_RELATIVE = 8;
 const R_ARM_RELATIVE = 23;
 const R_AARCH64_RELATIVE = 1027;
 const R_LARCH_RELATIVE = 3;
+const R_68K_RELATIVE = 22;
 const R_RISCV_RELATIVE = 3;
 const R_SPARC_RELATIVE = 22;
 
@@ -17,6 +18,7 @@ const R_RELATIVE = switch (builtin.cpu.arch) {
     .arm => R_ARM_RELATIVE,
     .aarch64 => R_AARCH64_RELATIVE,
     .loongarch32, .loongarch64 => R_LARCH_RELATIVE,
+    .m68k => R_68K_RELATIVE,
     .riscv64 => R_RISCV_RELATIVE,
     else => @compileError("Missing R_RELATIVE definition for this target"),
 };
@@ -63,6 +65,15 @@ fn getDynamicSymbol() [*]elf.Dyn {
             \\ .weak _DYNAMIC
             \\ .hidden _DYNAMIC
             \\ la.local %[ret], _DYNAMIC
+            : [ret] "=r" (-> [*]elf.Dyn),
+        ),
+        // Note that the - 8 is needed because pc in the second lea instruction points into the
+        // middle of that instruction. (The first lea is 6 bytes, the second is 4 bytes.)
+        .m68k => asm volatile (
+            \\ .weak _DYNAMIC
+            \\ .hidden _DYNAMIC
+            \\ lea _DYNAMIC - . - 8, %[ret]
+            \\ lea (%[ret], %%pc), %[ret]
             : [ret] "=r" (-> [*]elf.Dyn),
         ),
         .riscv64 => asm volatile (


### PR DESCRIPTION
As with #20733, this is untested, but straightforwardly adapted from musl:

* https://git.musl-libc.org/cgit/musl/tree/arch/loongarch64/crt_arch.h
* https://git.musl-libc.org/cgit/musl/tree/arch/m68k/crt_arch.h
* https://git.musl-libc.org/cgit/musl/tree/arch/s390x/crt_arch.h