### PR TITLE
autodoc: Preserve whitespace in inline code spans

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -26,6 +26,9 @@
         margin: 0;
         overflow-x: auto;
       }
+      :not(pre) > code {
+        white-space: break-spaces;
+      }
       code {
         font-family:"Source Code Pro",monospace;
         font-size: 0.9em;


### PR DESCRIPTION
Fixes #20754

Before:

![Screenshot 2024-07-22 at 22-42-06 std mem tokenizeScalar - Zig Documentation](https://github.com/user-attachments/assets/f5959342-c5c4-4600-9a5c-1f1bb316fd0a)

After:

![Screenshot 2024-07-22 at 22-41-29 std mem tokenizeScalar - Zig Documentation](https://github.com/user-attachments/assets/fdf372fa-b8b2-49d9-8a0f-bdc739cb7746)
