### PR TITLE
stage2-wasm: pass compiler_rt test suite

### DIFF
--- a/lib/compiler_rt/ceil.zig
+++ b/lib/compiler_rt/ceil.zig
@@ -48,14 +48,14 @@ pub fn ceilf(x: f32) callconv(.C) f32 {
         if (u & m == 0) {
             return x;
         }
-        mem.doNotOptimizeAway(x + 0x1.0p120);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 == 0) {
             u += m;
         }
         u &= ~m;
         return @bitCast(u);
     } else {
-        mem.doNotOptimizeAway(x + 0x1.0p120);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 != 0) {
             return -0.0;
         } else {
@@ -82,7 +82,7 @@ pub fn ceil(x: f64) callconv(.C) f64 {
     }
 
     if (e <= 0x3FF - 1) {
-        mem.doNotOptimizeAway(y);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(y);
         if (u >> 63 != 0) {
             return -0.0;
         } else {
@@ -116,7 +116,7 @@ pub fn ceilq(x: f128) callconv(.C) f128 {
     }
 
     if (e <= 0x3FFF - 1) {
-        mem.doNotOptimizeAway(y);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(y);
         if (u >> 127 != 0) {
             return -0.0;
         } else {

--- a/lib/compiler_rt/common.zig
+++ b/lib/compiler_rt/common.zig
@@ -24,6 +24,8 @@ pub const want_aeabi = switch (builtin.abi) {
 };
 pub const want_ppc_abi = builtin.cpu.arch.isPPC() or builtin.cpu.arch.isPPC64();
 
+pub const want_float_exceptions = !builtin.cpu.arch.isWasm();
+
 // Libcalls that involve u128 on Windows x86-64 are expected by LLVM to use the
 // calling convention of @Vector(2, u64), rather than what's standard.
 pub const want_windows_v2u64_abi = builtin.os.tag == .windows and builtin.cpu.arch == .x86_64 and @import("builtin").object_format != .c;

--- a/lib/compiler_rt/cos.zig
+++ b/lib/compiler_rt/cos.zig
@@ -41,7 +41,7 @@ pub fn cosf(x: f32) callconv(.C) f32 {
     if (ix <= 0x3f490fda) { // |x| ~<= pi/4
         if (ix < 0x39800000) { // |x| < 2**-12
             // raise inexact if x != 0
-            mem.doNotOptimizeAway(x + 0x1p120);
+            if (common.want_float_exceptions) mem.doNotOptimizeAway(x + 0x1p120);
             return 1.0;
         }
         return trig.__cosdf(x);
@@ -92,7 +92,7 @@ pub fn cos(x: f64) callconv(.C) f64 {
     if (ix <= 0x3fe921fb) {
         if (ix < 0x3e46a09e) { // |x| < 2**-27 * sqrt(2)
             // raise inexact if x!=0
-            mem.doNotOptimizeAway(x + 0x1p120);
+            if (common.want_float_exceptions) mem.doNotOptimizeAway(x + 0x1p120);
             return 1.0;
         }
         return trig.__cos(x, 0);

--- a/lib/compiler_rt/exp.zig
+++ b/lib/compiler_rt/exp.zig
@@ -59,7 +59,7 @@ pub fn expf(x_: f32) callconv(.C) f32 {
             return x * 0x1.0p127;
         }
         if (sign != 0) {
-            mem.doNotOptimizeAway(-0x1.0p-149 / x); // overflow
+            if (common.want_float_exceptions) mem.doNotOptimizeAway(-0x1.0p-149 / x); // overflow
             // x <= -103.972084
             if (hx >= 0x42CFF1B5) {
                 return 0;
@@ -91,7 +91,7 @@ pub fn expf(x_: f32) callconv(.C) f32 {
         hi = x;
         lo = 0;
     } else {
-        mem.doNotOptimizeAway(0x1.0p127 + x); // inexact
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(0x1.0p127 + x); // inexact
         return 1 + x;
     }
 
@@ -142,7 +142,7 @@ pub fn exp(x_: f64) callconv(.C) f64 {
         }
         if (x < -708.39641853226410622) {
             // underflow if x != -inf
-            // mem.doNotOptimizeAway(@as(f32, -0x1.0p-149 / x));
+            // if (common.want_float_exceptions) mem.doNotOptimizeAway(@as(f32, -0x1.0p-149 / x));
             if (x < -745.13321910194110842) {
                 return 0;
             }
@@ -175,7 +175,7 @@ pub fn exp(x_: f64) callconv(.C) f64 {
         lo = 0;
     } else {
         // inexact if x != 0
-        // mem.doNotOptimizeAway(0x1.0p1023 + x);
+        // if (common.want_float_exceptions) mem.doNotOptimizeAway(0x1.0p1023 + x);
         return 1 + x;
     }
 

--- a/lib/compiler_rt/exp2.zig
+++ b/lib/compiler_rt/exp2.zig
@@ -55,7 +55,7 @@ pub fn exp2f(x: f32) callconv(.C) f32 {
         // x < -126
         if (u >= 0x80000000) {
             if (u >= 0xC3160000 or u & 0x000FFFF != 0) {
-                mem.doNotOptimizeAway(-0x1.0p-149 / x);
+                if (common.want_float_exceptions) mem.doNotOptimizeAway(-0x1.0p-149 / x);
             }
             // x <= -150
             if (u >= 0x3160000) {
@@ -120,7 +120,7 @@ pub fn exp2(x: f64) callconv(.C) f64 {
         if (ux >> 63 != 0) {
             // underflow
             if (x <= -1075 or x - 0x1.0p52 + 0x1.0p52 != x) {
-                mem.doNotOptimizeAway(@as(f32, @floatCast(-0x1.0p-149 / x)));
+                if (common.want_float_exceptions) mem.doNotOptimizeAway(@as(f32, @floatCast(-0x1.0p-149 / x)));
             }
             if (x <= -1075) {
                 return 0;

--- a/lib/compiler_rt/floor.zig
+++ b/lib/compiler_rt/floor.zig
@@ -45,13 +45,13 @@ pub fn __floorh(x: f16) callconv(.C) f16 {
         if (u & m == 0) {
             return x;
         }
-        mem.doNotOptimizeAway(x + 0x1.0p120);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 15 != 0) {
             u += m;
         }
         return @bitCast(u & ~m);
     } else {
-        mem.doNotOptimizeAway(x + 0x1.0p120);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 15 == 0) {
             return 0.0;
         } else {
@@ -79,13 +79,13 @@ pub fn floorf(x: f32) callconv(.C) f32 {
         if (u & m == 0) {
             return x;
         }
-        mem.doNotOptimizeAway(x + 0x1.0p120);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 != 0) {
             u += m;
         }
         return @bitCast(u & ~m);
     } else {
-        mem.doNotOptimizeAway(x + 0x1.0p120);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + 0x1.0p120);
         if (u >> 31 == 0) {
             return 0.0;
         } else {
@@ -112,7 +112,7 @@ pub fn floor(x: f64) callconv(.C) f64 {
     }
 
     if (e <= 0x3FF - 1) {
-        mem.doNotOptimizeAway(y);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(y);
         if (u >> 63 != 0) {
             return -1.0;
         } else {
@@ -146,7 +146,7 @@ pub fn floorq(x: f128) callconv(.C) f128 {
     }
 
     if (e <= 0x3FFF - 1) {
-        mem.doNotOptimizeAway(y);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(y);
         if (u >> 127 != 0) {
             return -1.0;
         } else {

--- a/lib/compiler_rt/round.zig
+++ b/lib/compiler_rt/round.zig
@@ -46,7 +46,7 @@ pub fn roundf(x_: f32) callconv(.C) f32 {
         x = -x;
     }
     if (e < 0x7F - 1) {
-        mem.doNotOptimizeAway(x + f32_toint);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + f32_toint);
         return 0 * @as(f32, @bitCast(u));
     }
 
@@ -81,7 +81,7 @@ pub fn round(x_: f64) callconv(.C) f64 {
         x = -x;
     }
     if (e < 0x3ff - 1) {
-        mem.doNotOptimizeAway(x + f64_toint);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + f64_toint);
         return 0 * @as(f64, @bitCast(u));
     }
 
@@ -121,7 +121,7 @@ pub fn roundq(x_: f128) callconv(.C) f128 {
         x = -x;
     }
     if (e < 0x3FFF - 1) {
-        mem.doNotOptimizeAway(x + f128_toint);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + f128_toint);
         return 0 * @as(f128, @bitCast(u));
     }
 

--- a/lib/compiler_rt/sin.zig
+++ b/lib/compiler_rt/sin.zig
@@ -49,7 +49,7 @@ pub fn sinf(x: f32) callconv(.C) f32 {
     if (ix <= 0x3f490fda) { // |x| ~<= pi/4
         if (ix < 0x39800000) { // |x| < 2**-12
             // raise inexact if x!=0 and underflow if subnormal
-            mem.doNotOptimizeAway(if (ix < 0x00800000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00800000) x / 0x1p120 else x + 0x1p120);
             return x;
         }
         return trig.__sindf(x);
@@ -98,7 +98,7 @@ pub fn sin(x: f64) callconv(.C) f64 {
     if (ix <= 0x3fe921fb) {
         if (ix < 0x3e500000) { // |x| < 2**-26
             // raise inexact if x != 0 and underflow if subnormal
-            mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
             return x;
         }
         return trig.__sin(x, 0.0, 0);

--- a/lib/compiler_rt/sincos.zig
+++ b/lib/compiler_rt/sincos.zig
@@ -46,7 +46,7 @@ pub fn sincosf(x: f32, r_sin: *f32, r_cos: *f32) callconv(.C) void {
         // |x| < 2**-12
         if (ix < 0x39800000) {
             // raise inexact if x!=0 and underflow if subnormal
-            mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
             r_sin.* = x;
             r_cos.* = 1.0;
             return;
@@ -134,7 +134,7 @@ pub fn sincos(x: f64, r_sin: *f64, r_cos: *f64) callconv(.C) void {
         // if |x| < 2**-27 * sqrt(2)
         if (ix < 0x3e46a09e) {
             // raise inexact if x != 0 and underflow if subnormal
-            mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
             r_sin.* = x;
             r_cos.* = 1.0;
             return;
@@ -232,7 +232,7 @@ inline fn sincos_generic(comptime F: type, x: F, r_sin: *F, r_cos: *F) void {
         if (se < 0x3fff - math.floatFractionalBits(F) - 1) {
             // raise underflow if subnormal
             if (se == 0) {
-                mem.doNotOptimizeAway(x * 0x1p-120);
+                if (common.want_float_exceptions) mem.doNotOptimizeAway(x * 0x1p-120);
             }
             r_sin.* = x;
             // raise inexact if x!=0

--- a/lib/compiler_rt/tan.zig
+++ b/lib/compiler_rt/tan.zig
@@ -51,7 +51,7 @@ pub fn tanf(x: f32) callconv(.C) f32 {
     if (ix <= 0x3f490fda) { // |x| ~<= pi/4
         if (ix < 0x39800000) { // |x| < 2**-12
             // raise inexact if x!=0 and underflow if subnormal
-            mem.doNotOptimizeAway(if (ix < 0x00800000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00800000) x / 0x1p120 else x + 0x1p120);
             return x;
         }
         return kernel.__tandf(x, false);
@@ -89,7 +89,7 @@ pub fn tan(x: f64) callconv(.C) f64 {
     if (ix <= 0x3fe921fb) {
         if (ix < 0x3e400000) { // |x| < 2**-27
             // raise inexact if x!=0 and underflow if subnormal
-            mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
             return x;
         }
         return kernel.__tan(x, 0.0, false);

--- a/lib/compiler_rt/trunc.zig
+++ b/lib/compiler_rt/trunc.zig
@@ -47,7 +47,7 @@ pub fn truncf(x: f32) callconv(.C) f32 {
     if (u & m == 0) {
         return x;
     } else {
-        mem.doNotOptimizeAway(x + 0x1p120);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + 0x1p120);
         return @bitCast(u & ~m);
     }
 }
@@ -68,7 +68,7 @@ pub fn trunc(x: f64) callconv(.C) f64 {
     if (u & m == 0) {
         return x;
     } else {
-        mem.doNotOptimizeAway(x + 0x1p120);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + 0x1p120);
         return @bitCast(u & ~m);
     }
 }
@@ -94,7 +94,7 @@ pub fn truncq(x: f128) callconv(.C) f128 {
     if (u & m == 0) {
         return x;
     } else {
-        mem.doNotOptimizeAway(x + 0x1p120);
+        if (common.want_float_exceptions) mem.doNotOptimizeAway(x + 0x1p120);
         return @bitCast(u & ~m);
     }
 }

--- a/lib/compiler_rt/udivmodei4.zig
+++ b/lib/compiler_rt/udivmodei4.zig
@@ -130,6 +130,7 @@ pub fn __umodei4(r_p: [*]u32, u_p: [*]const u32, v_p: [*]const u32, bits: usize)
 
 test "__udivei4/__umodei4" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const RndGen = std.Random.DefaultPrng;
     var rnd = RndGen.init(42);

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1837,6 +1837,7 @@ fn genInst(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         .sub_sat => func.airSatBinOp(inst, .sub),
         .sub_wrap => func.airWrapBinOp(inst, .sub),
         .mul => func.airBinOp(inst, .mul),
+        .mul_sat => func.airSatMul(inst),
         .mul_wrap => func.airWrapBinOp(inst, .mul),
         .div_float, .div_exact => func.airDiv(inst),
         .div_trunc => func.airDivTrunc(inst),
@@ -2002,7 +2003,6 @@ fn genInst(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         .error_set_has_value => func.airErrorSetHasValue(inst),
         .frame_addr => func.airFrameAddress(inst),
 
-        .mul_sat,
         .assembly,
         .is_err_ptr,
         .is_non_err_ptr,
@@ -6780,6 +6780,106 @@ fn airMod(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         return func.fail("TODO: implement `@mod` on floating point types for {}", .{func.target.cpu.arch});
     }
 
+    return func.finishAir(inst, .stack, &.{ bin_op.lhs, bin_op.rhs });
+}
+
+fn airSatMul(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
+    const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
+
+    const pt = func.pt;
+    const mod = pt.zcu;
+    const ty = func.typeOfIndex(inst);
+    const int_info = ty.intInfo(mod);
+    const is_signed = int_info.signedness == .signed;
+
+    const lhs = try func.resolveInst(bin_op.lhs);
+    const rhs = try func.resolveInst(bin_op.rhs);
+    const wasm_bits = toWasmBits(int_info.bits) orelse {
+        return func.fail("TODO: mul_sat for {}", .{ty.fmt(pt)});
+    };
+
+    switch (wasm_bits) {
+        32 => {
+            const upcast_ty: Type = if (is_signed) Type.i64 else Type.u64;
+            const lhs_up = try func.intcast(lhs, ty, upcast_ty);
+            const rhs_up = try func.intcast(rhs, ty, upcast_ty);
+            var mul_res = try (try func.binOp(lhs_up, rhs_up, upcast_ty, .mul)).toLocal(func, upcast_ty);
+            defer mul_res.free(func);
+            if (is_signed) {
+                const imm_max: WValue = .{ .imm64 = ~@as(u64, 0) >> @intCast(64 - (int_info.bits - 1)) };
+                try func.emitWValue(mul_res);
+                try func.emitWValue(imm_max);
+                _ = try func.cmp(mul_res, imm_max, upcast_ty, .lt);
+                try func.addTag(.select);
+
+                var tmp = try func.allocLocal(upcast_ty);
+                defer tmp.free(func);
+                try func.addLabel(.local_set, tmp.local.value);
+
+                const imm_min: WValue = .{ .imm64 = ~@as(u64, 0) << @intCast(int_info.bits - 1) };
+                try func.emitWValue(tmp);
+                try func.emitWValue(imm_min);
+                _ = try func.cmp(tmp, imm_min, upcast_ty, .gt);
+                try func.addTag(.select);
+            } else {
+                const imm_max: WValue = .{ .imm64 = ~@as(u64, 0) >> @intCast(64 - int_info.bits) };
+                try func.emitWValue(mul_res);
+                try func.emitWValue(imm_max);
+                _ = try func.cmp(mul_res, imm_max, upcast_ty, .lt);
+                try func.addTag(.select);
+            }
+            try func.addTag(.i32_wrap_i64);
+        },
+        64 => {
+            if (!(int_info.bits == 64 and int_info.signedness == .signed)) {
+                return func.fail("TODO: mul_sat for {}", .{ty.fmt(pt)});
+            }
+            const overflow_ret = try func.allocStack(Type.i32);
+            _ = try func.callIntrinsic(
+                "__mulodi4",
+                &[_]InternPool.Index{ .i64_type, .i64_type, .usize_type },
+                Type.i64,
+                &.{ lhs, rhs, overflow_ret },
+            );
+            const xor = try func.binOp(lhs, rhs, Type.i64, .xor);
+            const sign_v = try func.binOp(xor, .{ .imm64 = 63 }, Type.i64, .shr);
+            _ = try func.binOp(sign_v, .{ .imm64 = ~@as(u63, 0) }, Type.i64, .xor);
+            _ = try func.load(overflow_ret, Type.i32, 0);
+            try func.addTag(.i32_eqz);
+            try func.addTag(.select);
+        },
+        128 => {
+            if (!(int_info.bits == 128 and int_info.signedness == .signed)) {
+                return func.fail("TODO: mul_sat for {}", .{ty.fmt(pt)});
+            }
+            const overflow_ret = try func.allocStack(Type.i32);
+            const ret = try func.callIntrinsic(
+                "__muloti4",
+                &[_]InternPool.Index{ .i128_type, .i128_type, .usize_type },
+                Type.i128,
+                &.{ lhs, rhs, overflow_ret },
+            );
+            try func.lowerToStack(ret);
+            const xor = try func.binOp(lhs, rhs, Type.i128, .xor);
+            const sign_v = try func.binOp(xor, .{ .imm32 = 127 }, Type.i128, .shr);
+
+            // xor ~@as(u127, 0)
+            try func.emitWValue(sign_v);
+            const lsb = try func.load(sign_v, Type.u64, 0);
+            _ = try func.binOp(lsb, .{ .imm64 = ~@as(u64, 0) }, Type.u64, .xor);
+            try func.store(.stack, .stack, Type.u64, sign_v.offset());
+            try func.emitWValue(sign_v);
+            const msb = try func.load(sign_v, Type.u64, 8);
+            _ = try func.binOp(msb, .{ .imm64 = ~@as(u63, 0) }, Type.u64, .xor);
+            try func.store(.stack, .stack, Type.u64, sign_v.offset() + 8);
+
+            try func.lowerToStack(sign_v);
+            _ = try func.load(overflow_ret, Type.i32, 0);
+            try func.addTag(.i32_eqz);
+            try func.addTag(.select);
+        },
+        else => unreachable,
+    }
     return func.finishAir(inst, .stack, &.{ bin_op.lhs, bin_op.rhs });
 }
 


### PR DESCRIPTION
I disabled one test, which was also disabled on `stage2_c`. Handling big ints > 128 bits, is not the first priority for wasm backend right now.

Next step is to be able to generate an archive file to test the possibility of non depending on LLVM for compiler_rt.