### PR TITLE
Add a `@compileError` hint when trying to print from comptime

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -541,6 +541,8 @@ fn windowsApiUpdateThreadRun() void {
 ///
 /// The lock is recursive; the same thread may hold the lock multiple times.
 pub fn lockStdErr() void {
+    if (@inComptime())
+        @compileError("I/O cannot be used from comptime. Consider using @compileError() or @compileLog().");
     stderr_mutex.lock();
     clearWrittenWithEscapeCodes() catch {};
 }


### PR DESCRIPTION
Fixes #14238.

While we can't cover every I/O function like this, lockStdErr covers std.debug.print and std.log.*, probably the most important places to leave a useful hint for newcomers to Zig.