### PR TITLE
`std.zig.target`: Handle m68k in muslArchName().

### DIFF
--- a/lib/std/zig/target.zig
+++ b/lib/std/zig/target.zig
@@ -105,6 +105,7 @@ pub fn muslArchName(arch: std.Target.Cpu.Arch) [:0]const u8 {
         .arm, .armeb, .thumb, .thumbeb => return "arm",
         .x86 => return "i386",
         .loongarch64 => return "loongarch64",
+        .m68k => return "m68k",
         .mips, .mipsel => return "mips",
         .mips64el, .mips64 => return "mips64",
         .powerpc => return "powerpc",


### PR DESCRIPTION
This was the only missing "proper" architecture, I think. This function also needs to be updated to handle N32 on MIPS and x32 on x86-64, but that's a problem for another day (we don't have musl-specific `std.Target.Abi` tags for these).