### PR TITLE
llvm: force `TargetOptions.UseInitArray` to `true`

### DIFF
--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -129,6 +129,7 @@ LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, const char *Tri
 
     TargetOptions opt;
 
+    opt.UseInitArray = true;
     opt.FunctionSections = function_sections;
     opt.DataSections = data_sections;
     switch (float_abi) {


### PR DESCRIPTION
The `TargetOptions` default constructor initializes all `bool`s to `false`, yet clang defaults to setting this option to `true`.  Since recent glibc versions on linux do not appear to support this being set to `false`, just changing the default for now unless a use case for making it configurable is found.