### PR TITLE
`std.os.linux.AUDIT`: Rewrite ARCH in terms of std.elf.EM.

### DIFF
--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -1531,6 +1531,9 @@ pub const EM = enum(u16) {
     /// Tilera TILEPro multicore architecture family
     TILEPRO = 188,
 
+    /// Xilinx MicroBlaze
+    MICROBLAZE = 189,
+
     /// NVIDIA CUDA architecture
     CUDA = 190,
 


### PR DESCRIPTION
Closes #20743.

Source: https://github.com/torvalds/linux/blob/7a3fad30fd8b4b5e370906b3c554f64026f56c2f/include/uapi/linux/audit.h#L377-L443