### PR TITLE
integrate fuzz testing into the build system

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -208,6 +208,8 @@ pub fn main() !void {
                 try debug_log_scopes.append(next_arg);
             } else if (mem.eql(u8, arg, "--debug-pkg-config")) {
                 builder.debug_pkg_config = true;
+            } else if (mem.eql(u8, arg, "--debug-rt")) {
+                graph.debug_compiler_runtime_libs = true;
             } else if (mem.eql(u8, arg, "--debug-compile-errors")) {
                 builder.debug_compile_errors = true;
             } else if (mem.eql(u8, arg, "--system")) {
@@ -1072,7 +1074,8 @@ fn workerMakeOneStep(
         std.debug.lockStdErr();
         defer std.debug.unlockStdErr();
 
-        printErrorMessages(b, s, run.ttyconf, run.stderr, run.prominent_compile_errors) catch {};
+        const gpa = b.allocator;
+        printErrorMessages(gpa, s, run.ttyconf, run.stderr, run.prominent_compile_errors) catch {};
     }
 
     handle_result: {
@@ -1126,14 +1129,12 @@ fn workerMakeOneStep(
 }
 
 pub fn printErrorMessages(
-    b: *std.Build,
+    gpa: Allocator,
     failing_step: *Step,
     ttyconf: std.io.tty.Config,
     stderr: File,
     prominent_compile_errors: bool,
 ) !void {
-    const gpa = b.allocator;
-
     // Provide context for where these error messages are coming from by
     // printing the corresponding Step subtree.
 
@@ -1313,6 +1314,7 @@ fn usage(b: *std.Build, out_stream: anytype) !void {
         \\  --seed [integer]             For shuffling dependency traversal order (default: random)
         \\  --debug-log [scope]          Enable debugging the compiler
         \\  --debug-pkg-config           Fail if unknown pkg-config flags encountered
+        \\  --debug-rt                   Debug compiler runtime libraries
         \\  --verbose-link               Enable compiler debug output for linking
         \\  --verbose-air                Enable compiler debug output for Zig AIR
         \\  --verbose-llvm-ir[=file]     Enable compiler debug output for LLVM IR

--- a/lib/compiler/test_runner.zig
+++ b/lib/compiler/test_runner.zig
@@ -143,6 +143,7 @@ fn mainTerminal() void {
     var ok_count: usize = 0;
     var skip_count: usize = 0;
     var fail_count: usize = 0;
+    var fuzz_count: usize = 0;
     const root_node = std.Progress.start(.{
         .root_name = "Test",
         .estimated_total_items = test_fn_list.len,
@@ -168,7 +169,7 @@ fn mainTerminal() void {
         if (!have_tty) {
             std.debug.print("{d}/{d} {s}...", .{ i + 1, test_fn_list.len, test_fn.name });
         }
-        // Track in a global variable so that `fuzzInput` can see it.
+        is_fuzz_test = false;
         if (test_fn.func()) |_| {
             ok_count += 1;
             test_node.end();
@@ -198,6 +199,7 @@ fn mainTerminal() void {
                 test_node.end();
             },
         }
+        fuzz_count += @intFromBool(is_fuzz_test);
     }
     root_node.end();
     if (ok_count == test_fn_list.len) {
@@ -210,6 +212,9 @@ fn mainTerminal() void {
     }
     if (leaks != 0) {
         std.debug.print("{d} tests leaked memory.\n", .{leaks});
+    }
+    if (fuzz_count != 0) {
+        std.debug.print("{d} fuzz tests found.\n", .{fuzz_count});
     }
     if (leaks != 0 or log_err_count != 0 or fail_count != 0) {
         std.process.exit(1);

--- a/lib/compiler/test_runner.zig
+++ b/lib/compiler/test_runner.zig
@@ -325,18 +325,11 @@ extern fn fuzzer_next() FuzzerSlice;
 
 pub fn fuzzInput(options: testing.FuzzInputOptions) []const u8 {
     @disableInstrumentation();
-    if (crippled) {
-        return "";
-    } else if (builtin.fuzz) {
-        return fuzzer_next().toSlice();
-    } else {
-        is_fuzz_test = true;
-        if (options.corpus.len == 0) {
-            return "";
-        } else {
-            var prng = std.Random.DefaultPrng.init(testing.random_seed);
-            const random = prng.random();
-            return options.corpus[random.uintLessThan(usize, options.corpus.len)];
-        }
-    }
+    if (crippled) return "";
+    is_fuzz_test = true;
+    if (builtin.fuzz) return fuzzer_next().toSlice();
+    if (options.corpus.len == 0) return "";
+    var prng = std.Random.DefaultPrng.init(testing.random_seed);
+    const random = prng.random();
+    return options.corpus[random.uintLessThan(usize, options.corpus.len)];
 }

--- a/lib/fuzzer.zig
+++ b/lib/fuzzer.zig
@@ -1,14 +1,40 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
+pub const std_options = .{
+    .logFn = logOverride,
+};
+
+var log_file: ?std.fs.File = null;
+
+fn logOverride(
+    comptime level: std.log.Level,
+    comptime scope: @TypeOf(.EnumLiteral),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    const f = if (log_file) |f| f else f: {
+        const f = std.fs.cwd().createFile("libfuzzer.log", .{}) catch @panic("failed to open fuzzer log file");
+        log_file = f;
+        break :f f;
+    };
+    const prefix1 = comptime level.asText();
+    const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
+    f.writer().print(prefix1 ++ prefix2 ++ format ++ "\n", args) catch @panic("failed to write to fuzzer log");
+}
+
 export threadlocal var __sancov_lowest_stack: usize = 0;
 
 export fn __sanitizer_cov_8bit_counters_init(start: [*]u8, stop: [*]u8) void {
     std.log.debug("__sanitizer_cov_8bit_counters_init start={*}, stop={*}", .{ start, stop });
 }
 
-export fn __sanitizer_cov_pcs_init(pcs_beg: [*]const usize, pcs_end: [*]const usize) void {
-    std.log.debug("__sanitizer_cov_pcs_init pcs_beg={*}, pcs_end={*}", .{ pcs_beg, pcs_end });
+export fn __sanitizer_cov_pcs_init(pc_start: [*]const usize, pc_end: [*]const usize) void {
+    std.log.debug("__sanitizer_cov_pcs_init pc_start={*}, pc_end={*}", .{ pc_start, pc_end });
+    fuzzer.pc_range = .{
+        .start = @intFromPtr(pc_start),
+        .end = @intFromPtr(pc_start),
+    };
 }
 
 export fn __sanitizer_cov_trace_const_cmp1(arg1: u8, arg2: u8) void {
@@ -48,34 +74,45 @@ export fn __sanitizer_cov_trace_switch(val: u64, cases_ptr: [*]u64) void {
     const len = cases_ptr[0];
     const val_size_in_bits = cases_ptr[1];
     const cases = cases_ptr[2..][0..len];
-    std.log.debug("0x{x}: switch on value {d} ({d} bits) with {d} cases", .{
-        pc, val, val_size_in_bits, cases.len,
-    });
+    _ = val;
+    _ = pc;
+    _ = val_size_in_bits;
+    _ = cases;
+    //std.log.debug("0x{x}: switch on value {d} ({d} bits) with {d} cases", .{
+    //    pc, val, val_size_in_bits, cases.len,
+    //});
 }
 
 export fn __sanitizer_cov_trace_pc_indir(callee: usize) void {
     const pc = @returnAddress();
-    std.log.debug("0x{x}: indirect call to 0x{x}", .{ pc, callee });
+    _ = callee;
+    _ = pc;
+    //std.log.debug("0x{x}: indirect call to 0x{x}", .{ pc, callee });
 }
 
 fn handleCmp(pc: usize, arg1: u64, arg2: u64) void {
-    std.log.debug("0x{x}: comparison of {d} and {d}", .{ pc, arg1, arg2 });
+    _ = pc;
+    _ = arg1;
+    _ = arg2;
+    //std.log.debug("0x{x}: comparison of {d} and {d}", .{ pc, arg1, arg2 });
 }
 
 const Fuzzer = struct {
     gpa: Allocator,
     rng: std.Random.DefaultPrng,
     input: std.ArrayListUnmanaged(u8),
+    pc_range: PcRange,
+    count: usize,
 
     const Slice = extern struct {
         ptr: [*]const u8,
         len: usize,
 
-        fn toSlice(s: Slice) []const u8 {
+        fn toZig(s: Slice) []const u8 {
             return s.ptr[0..s.len];
         }
 
-        fn fromSlice(s: []const u8) Slice {
+        fn fromZig(s: []const u8) Slice {
             return .{
                 .ptr = s.ptr,
                 .len = s.len,
@@ -83,13 +120,26 @@ const Fuzzer = struct {
         }
     };
 
+    const PcRange = struct {
+        start: usize,
+        end: usize,
+    };
+
     fn next(f: *Fuzzer) ![]const u8 {
         const gpa = f.gpa;
+
+        // Prepare next input.
         const rng = fuzzer.rng.random();
         const len = rng.uintLessThan(usize, 64);
         try f.input.resize(gpa, len);
         rng.bytes(f.input.items);
+        f.resetCoverage();
+        f.count += 1;
         return f.input.items;
+    }
+
+    fn resetCoverage(f: *Fuzzer) void {
+        _ = f;
     }
 };
 
@@ -99,10 +149,12 @@ var fuzzer: Fuzzer = .{
     .gpa = general_purpose_allocator.allocator(),
     .rng = std.Random.DefaultPrng.init(0),
     .input = .{},
+    .pc_range = .{ .start = 0, .end = 0 },
+    .count = 0,
 };
 
 export fn fuzzer_next() Fuzzer.Slice {
-    return Fuzzer.Slice.fromSlice(fuzzer.next() catch |err| switch (err) {
+    return Fuzzer.Slice.fromZig(fuzzer.next() catch |err| switch (err) {
         error.OutOfMemory => @panic("out of memory"),
     });
 }

--- a/lib/fuzzer.zig
+++ b/lib/fuzzer.zig
@@ -1,13 +1,14 @@
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 
 export threadlocal var __sancov_lowest_stack: usize = 0;
 
 export fn __sanitizer_cov_8bit_counters_init(start: [*]u8, stop: [*]u8) void {
-    std.debug.print("__sanitizer_cov_8bit_counters_init start={*}, stop={*}\n", .{ start, stop });
+    std.log.debug("__sanitizer_cov_8bit_counters_init start={*}, stop={*}", .{ start, stop });
 }
 
 export fn __sanitizer_cov_pcs_init(pcs_beg: [*]const usize, pcs_end: [*]const usize) void {
-    std.debug.print("__sanitizer_cov_pcs_init pcs_beg={*}, pcs_end={*}\n", .{ pcs_beg, pcs_end });
+    std.log.debug("__sanitizer_cov_pcs_init pcs_beg={*}, pcs_end={*}", .{ pcs_beg, pcs_end });
 }
 
 export fn __sanitizer_cov_trace_const_cmp1(arg1: u8, arg2: u8) void {
@@ -47,16 +48,61 @@ export fn __sanitizer_cov_trace_switch(val: u64, cases_ptr: [*]u64) void {
     const len = cases_ptr[0];
     const val_size_in_bits = cases_ptr[1];
     const cases = cases_ptr[2..][0..len];
-    std.debug.print("0x{x}: switch on value {d} ({d} bits) with {d} cases\n", .{
+    std.log.debug("0x{x}: switch on value {d} ({d} bits) with {d} cases", .{
         pc, val, val_size_in_bits, cases.len,
     });
 }
 
 export fn __sanitizer_cov_trace_pc_indir(callee: usize) void {
     const pc = @returnAddress();
-    std.debug.print("0x{x}: indirect call to 0x{x}\n", .{ pc, callee });
+    std.log.debug("0x{x}: indirect call to 0x{x}", .{ pc, callee });
 }
 
 fn handleCmp(pc: usize, arg1: u64, arg2: u64) void {
-    std.debug.print("0x{x}: comparison of {d} and {d}\n", .{ pc, arg1, arg2 });
+    std.log.debug("0x{x}: comparison of {d} and {d}", .{ pc, arg1, arg2 });
+}
+
+const Fuzzer = struct {
+    gpa: Allocator,
+    rng: std.Random.DefaultPrng,
+    input: std.ArrayListUnmanaged(u8),
+
+    const Slice = extern struct {
+        ptr: [*]const u8,
+        len: usize,
+
+        fn toSlice(s: Slice) []const u8 {
+            return s.ptr[0..s.len];
+        }
+
+        fn fromSlice(s: []const u8) Slice {
+            return .{
+                .ptr = s.ptr,
+                .len = s.len,
+            };
+        }
+    };
+
+    fn next(f: *Fuzzer) ![]const u8 {
+        const gpa = f.gpa;
+        const rng = fuzzer.rng.random();
+        const len = rng.uintLessThan(usize, 64);
+        try f.input.resize(gpa, len);
+        rng.bytes(f.input.items);
+        return f.input.items;
+    }
+};
+
+var general_purpose_allocator: std.heap.GeneralPurposeAllocator(.{}) = .{};
+
+var fuzzer: Fuzzer = .{
+    .gpa = general_purpose_allocator.allocator(),
+    .rng = std.Random.DefaultPrng.init(0),
+    .input = .{},
+};
+
+export fn fuzzer_next() Fuzzer.Slice {
+    return Fuzzer.Slice.fromSlice(fuzzer.next() catch |err| switch (err) {
+        error.OutOfMemory => @panic("out of memory"),
+    });
 }

--- a/lib/fuzzer.zig
+++ b/lib/fuzzer.zig
@@ -1,5 +1,7 @@
+const builtin = @import("builtin");
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
 
 pub const std_options = .{
     .logFn = logOverride,
@@ -13,6 +15,7 @@ fn logOverride(
     comptime format: []const u8,
     args: anytype,
 ) void {
+    if (builtin.mode != .Debug) return;
     const f = if (log_file) |f| f else f: {
         const f = std.fs.cwd().createFile("libfuzzer.log", .{}) catch @panic("failed to open fuzzer log file");
         log_file = f;
@@ -75,7 +78,7 @@ export fn __sanitizer_cov_trace_switch(val: u64, cases_ptr: [*]u64) void {
     const val_size_in_bits = cases_ptr[1];
     const cases = cases_ptr[2..][0..len];
     _ = val;
-    _ = pc;
+    fuzzer.visitPc(pc);
     _ = val_size_in_bits;
     _ = cases;
     //std.log.debug("0x{x}: switch on value {d} ({d} bits) with {d} cases", .{
@@ -86,14 +89,14 @@ export fn __sanitizer_cov_trace_switch(val: u64, cases_ptr: [*]u64) void {
 export fn __sanitizer_cov_trace_pc_indir(callee: usize) void {
     const pc = @returnAddress();
     _ = callee;
-    _ = pc;
+    fuzzer.visitPc(pc);
     //std.log.debug("0x{x}: indirect call to 0x{x}", .{ pc, callee });
 }
 
 fn handleCmp(pc: usize, arg1: u64, arg2: u64) void {
-    _ = pc;
     _ = arg1;
     _ = arg2;
+    fuzzer.visitPc(pc);
     //std.log.debug("0x{x}: comparison of {d} and {d}", .{ pc, arg1, arg2 });
 }
 
@@ -103,6 +106,46 @@ const Fuzzer = struct {
     input: std.ArrayListUnmanaged(u8),
     pc_range: PcRange,
     count: usize,
+    recent_cases: RunMap,
+    deduplicated_runs: usize,
+    coverage: Coverage,
+
+    const RunMap = std.ArrayHashMapUnmanaged(Run, void, Run.HashContext, false);
+
+    const Coverage = struct {
+        pc_table: std.AutoArrayHashMapUnmanaged(usize, void),
+        run_id_hasher: std.hash.Wyhash,
+
+        fn reset(cov: *Coverage) void {
+            cov.pc_table.clearRetainingCapacity();
+            cov.run_id_hasher = std.hash.Wyhash.init(0);
+        }
+    };
+
+    const Run = struct {
+        id: Id,
+        input: []const u8,
+        score: usize,
+
+        const Id = u64;
+
+        const HashContext = struct {
+            pub fn eql(ctx: HashContext, a: Run, b: Run, b_index: usize) bool {
+                _ = b_index;
+                _ = ctx;
+                return a.id == b.id;
+            }
+            pub fn hash(ctx: HashContext, a: Run) u32 {
+                _ = ctx;
+                return @truncate(a.id);
+            }
+        };
+
+        fn deinit(run: *Run, gpa: Allocator) void {
+            gpa.free(run.input);
+            run.* = undefined;
+        }
+    };
 
     const Slice = extern struct {
         ptr: [*]const u8,
@@ -125,23 +168,136 @@ const Fuzzer = struct {
         end: usize,
     };
 
+    const Analysis = struct {
+        score: usize,
+        id: Run.Id,
+    };
+
+    fn analyzeLastRun(f: *Fuzzer) Analysis {
+        return .{
+            .id = f.coverage.run_id_hasher.final(),
+            .score = f.coverage.pc_table.count(),
+        };
+    }
+
     fn next(f: *Fuzzer) ![]const u8 {
         const gpa = f.gpa;
-
-        // Prepare next input.
         const rng = fuzzer.rng.random();
-        const len = rng.uintLessThan(usize, 64);
-        try f.input.resize(gpa, len);
-        rng.bytes(f.input.items);
-        f.resetCoverage();
+
+        if (f.recent_cases.entries.len == 0) {
+            // Prepare initial input.
+            try f.recent_cases.ensureUnusedCapacity(gpa, 100);
+            const len = rng.uintLessThanBiased(usize, 80);
+            try f.input.resize(gpa, len);
+            rng.bytes(f.input.items);
+            f.recent_cases.putAssumeCapacity(.{
+                .id = 0,
+                .input = try gpa.dupe(u8, f.input.items),
+                .score = 0,
+            }, {});
+        } else {
+            if (f.count % 1000 == 0) f.dumpStats();
+
+            const analysis = f.analyzeLastRun();
+            const gop = f.recent_cases.getOrPutAssumeCapacity(.{
+                .id = analysis.id,
+                .input = undefined,
+                .score = undefined,
+            });
+            if (gop.found_existing) {
+                //std.log.info("duplicate analysis: score={d} id={d}", .{ analysis.score, analysis.id });
+                f.deduplicated_runs += 1;
+                if (f.input.items.len < gop.key_ptr.input.len or gop.key_ptr.score == 0) {
+                    gpa.free(gop.key_ptr.input);
+                    gop.key_ptr.input = try gpa.dupe(u8, f.input.items);
+                    gop.key_ptr.score = analysis.score;
+                }
+            } else {
+                std.log.info("unique analysis: score={d} id={d}", .{ analysis.score, analysis.id });
+                gop.key_ptr.* = .{
+                    .id = analysis.id,
+                    .input = try gpa.dupe(u8, f.input.items),
+                    .score = analysis.score,
+                };
+            }
+
+            if (f.recent_cases.entries.len >= 100) {
+                const Context = struct {
+                    values: []const Run,
+                    pub fn lessThan(ctx: @This(), a_index: usize, b_index: usize) bool {
+                        return ctx.values[b_index].score < ctx.values[a_index].score;
+                    }
+                };
+                f.recent_cases.sortUnstable(Context{ .values = f.recent_cases.keys() });
+                const cap = 50;
+                // This has to be done before deinitializing the deleted items.
+                const doomed_runs = f.recent_cases.keys()[cap..];
+                f.recent_cases.shrinkRetainingCapacity(cap);
+                for (doomed_runs) |*run| {
+                    std.log.info("culling score={d} id={d}", .{ run.score, run.id });
+                    run.deinit(gpa);
+                }
+            }
+        }
+
+        const chosen_index = rng.uintLessThanBiased(usize, f.recent_cases.entries.len);
+        const run = &f.recent_cases.keys()[chosen_index];
+        f.input.clearRetainingCapacity();
+        f.input.appendSliceAssumeCapacity(run.input);
+        try f.mutate();
+
+        f.coverage.reset();
         f.count += 1;
         return f.input.items;
     }
 
-    fn resetCoverage(f: *Fuzzer) void {
-        _ = f;
+    fn visitPc(f: *Fuzzer, pc: usize) void {
+        errdefer |err| oom(err);
+        try f.coverage.pc_table.put(f.gpa, pc, {});
+        f.coverage.run_id_hasher.update(std.mem.asBytes(&pc));
+    }
+
+    fn dumpStats(f: *Fuzzer) void {
+        std.log.info("stats: runs={d} deduplicated={d}", .{
+            f.count,
+            f.deduplicated_runs,
+        });
+        for (f.recent_cases.keys()[0..@min(f.recent_cases.entries.len, 5)], 0..) |run, i| {
+            std.log.info("best[{d}] id={x} score={d} input: '{}'", .{
+                i, run.id, run.score, std.zig.fmtEscapes(run.input),
+            });
+        }
+    }
+
+    fn mutate(f: *Fuzzer) !void {
+        const gpa = f.gpa;
+        const rng = fuzzer.rng.random();
+
+        if (f.input.items.len == 0) {
+            const len = rng.uintLessThanBiased(usize, 80);
+            try f.input.resize(gpa, len);
+            rng.bytes(f.input.items);
+            return;
+        }
+
+        const index = rng.uintLessThanBiased(usize, f.input.items.len * 3);
+        if (index < f.input.items.len) {
+            f.input.items[index] = rng.int(u8);
+        } else if (index < f.input.items.len * 2) {
+            _ = f.input.orderedRemove(index - f.input.items.len);
+        } else if (index < f.input.items.len * 3) {
+            try f.input.insert(gpa, index - f.input.items.len * 2, rng.int(u8));
+        } else {
+            unreachable;
+        }
     }
 };
+
+fn oom(err: anytype) noreturn {
+    switch (err) {
+        error.OutOfMemory => @panic("out of memory"),
+    }
+}
 
 var general_purpose_allocator: std.heap.GeneralPurposeAllocator(.{}) = .{};
 
@@ -151,6 +307,9 @@ var fuzzer: Fuzzer = .{
     .input = .{},
     .pc_range = .{ .start = 0, .end = 0 },
     .count = 0,
+    .deduplicated_runs = 0,
+    .recent_cases = .{},
+    .coverage = undefined,
 };
 
 export fn fuzzer_next() Fuzzer.Slice {

--- a/lib/fuzzer.zig
+++ b/lib/fuzzer.zig
@@ -94,9 +94,7 @@ export fn __sanitizer_cov_trace_pc_indir(callee: usize) void {
 }
 
 fn handleCmp(pc: usize, arg1: u64, arg2: u64) void {
-    _ = arg1;
-    _ = arg2;
-    fuzzer.visitPc(pc);
+    fuzzer.visitPc(pc ^ arg1 ^ arg2);
     //std.log.debug("0x{x}: comparison of {d} and {d}", .{ pc, arg1, arg2 });
 }
 

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -21,6 +21,7 @@ pub const Cache = @import("Build/Cache.zig");
 pub const Step = @import("Build/Step.zig");
 pub const Module = @import("Build/Module.zig");
 pub const Watch = @import("Build/Watch.zig");
+pub const Fuzz = @import("Build/Fuzz.zig");
 
 /// Shared state among all Build instances.
 graph: *Graph,

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -113,6 +113,7 @@ pub const Graph = struct {
     arena: Allocator,
     system_library_options: std.StringArrayHashMapUnmanaged(SystemLibraryMode) = .{},
     system_package_mode: bool = false,
+    debug_compiler_runtime_libs: bool = false,
     cache: Cache,
     zig_exe: [:0]const u8,
     env_map: EnvMap,

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -977,6 +977,7 @@ pub fn addRunArtifact(b: *Build, exe: *Step.Compile) *Step.Run {
     // Consider that this is declarative; the run step may not be run unless a user
     // option is supplied.
     const run_step = Step.Run.create(b, b.fmt("run {s}", .{exe.name}));
+    run_step.producer = exe;
     if (exe.kind == .@"test") {
         if (exe.exec_cmd_args) |exec_cmd_args| {
             for (exec_cmd_args) |cmd_arg| {

--- a/lib/std/Build/Fuzz.zig
+++ b/lib/std/Build/Fuzz.zig
@@ -3,9 +3,15 @@ const Fuzz = @This();
 const Step = std.Build.Step;
 const assert = std.debug.assert;
 const fatal = std.process.fatal;
+const build_runner = @import("root");
 
-pub fn start(thread_pool: *std.Thread.Pool, all_steps: []const *Step, prog_node: std.Progress.Node) void {
-    {
+pub fn start(
+    thread_pool: *std.Thread.Pool,
+    all_steps: []const *Step,
+    ttyconf: std.io.tty.Config,
+    prog_node: std.Progress.Node,
+) void {
+    const count = block: {
         const rebuild_node = prog_node.start("Rebuilding Unit Tests", 0);
         defer rebuild_node.end();
         var count: usize = 0;
@@ -14,13 +20,14 @@ pub fn start(thread_pool: *std.Thread.Pool, all_steps: []const *Step, prog_node:
         for (all_steps) |step| {
             const run = step.cast(Step.Run) orelse continue;
             if (run.fuzz_tests.items.len > 0 and run.producer != null) {
-                thread_pool.spawnWg(&wait_group, rebuildTestsWorkerRun, .{ run, prog_node });
+                thread_pool.spawnWg(&wait_group, rebuildTestsWorkerRun, .{ run, ttyconf, rebuild_node });
                 count += 1;
             }
         }
         if (count == 0) fatal("no fuzz tests found", .{});
         rebuild_node.setEstimatedTotalItems(count);
-    }
+        break :block count;
+    };
 
     // Detect failure.
     for (all_steps) |step| {
@@ -29,18 +36,69 @@ pub fn start(thread_pool: *std.Thread.Pool, all_steps: []const *Step, prog_node:
             fatal("one or more unit tests failed to be rebuilt in fuzz mode", .{});
     }
 
-    @panic("TODO do something with the rebuilt unit tests");
+    {
+        const rebuild_node = prog_node.start("Fuzzing", count);
+        defer rebuild_node.end();
+        var wait_group: std.Thread.WaitGroup = .{};
+        defer wait_group.wait();
+
+        for (all_steps) |step| {
+            const run = step.cast(Step.Run) orelse continue;
+            for (run.fuzz_tests.items) |unit_test_index| {
+                assert(run.rebuilt_executable != null);
+                thread_pool.spawnWg(&wait_group, fuzzWorkerRun, .{ run, unit_test_index, ttyconf, prog_node });
+            }
+        }
+    }
+
+    fatal("all fuzz workers crashed", .{});
 }
 
-fn rebuildTestsWorkerRun(run: *Step.Run, parent_prog_node: std.Progress.Node) void {
+fn rebuildTestsWorkerRun(run: *Step.Run, ttyconf: std.io.tty.Config, parent_prog_node: std.Progress.Node) void {
     const compile_step = run.producer.?;
     const prog_node = parent_prog_node.start(compile_step.step.name, 0);
     defer prog_node.end();
-    const rebuilt_bin_path = compile_step.rebuildInFuzzMode(prog_node) catch |err| {
-        std.debug.print("failed to rebuild {s} in fuzz mode: {s}", .{
-            compile_step.step.name, @errorName(err),
-        });
-        return;
+    if (compile_step.rebuildInFuzzMode(prog_node)) |rebuilt_bin_path| {
+        run.rebuilt_executable = rebuilt_bin_path;
+    } else |err| switch (err) {
+        error.MakeFailed => {
+            const b = run.step.owner;
+            const stderr = std.io.getStdErr();
+            std.debug.lockStdErr();
+            defer std.debug.unlockStdErr();
+            build_runner.printErrorMessages(b, &compile_step.step, ttyconf, stderr, false) catch {};
+        },
+        else => {
+            std.debug.print("step '{s}': failed to rebuild in fuzz mode: {s}\n", .{
+                compile_step.step.name, @errorName(err),
+            });
+        },
+    }
+}
+
+fn fuzzWorkerRun(
+    run: *Step.Run,
+    unit_test_index: u32,
+    ttyconf: std.io.tty.Config,
+    parent_prog_node: std.Progress.Node,
+) void {
+    const test_name = run.cached_test_metadata.?.testName(unit_test_index);
+
+    const prog_node = parent_prog_node.start(test_name, 0);
+    defer prog_node.end();
+
+    run.rerunInFuzzMode(unit_test_index, prog_node) catch |err| switch (err) {
+        error.MakeFailed => {
+            const b = run.step.owner;
+            const stderr = std.io.getStdErr();
+            std.debug.lockStdErr();
+            defer std.debug.unlockStdErr();
+            build_runner.printErrorMessages(b, &run.step, ttyconf, stderr, false) catch {};
+        },
+        else => {
+            std.debug.print("step '{s}': failed to rebuild '{s}' in fuzz mode: {s}\n", .{
+                run.step.name, test_name, @errorName(err),
+            });
+        },
     };
-    run.rebuilt_executable = rebuilt_bin_path;
 }

--- a/lib/std/Build/Fuzz.zig
+++ b/lib/std/Build/Fuzz.zig
@@ -55,22 +55,32 @@ pub fn start(
 }
 
 fn rebuildTestsWorkerRun(run: *Step.Run, ttyconf: std.io.tty.Config, parent_prog_node: std.Progress.Node) void {
-    const compile_step = run.producer.?;
-    const prog_node = parent_prog_node.start(compile_step.step.name, 0);
+    const gpa = run.step.owner.allocator;
+    const stderr = std.io.getStdErr();
+
+    const compile = run.producer.?;
+    const prog_node = parent_prog_node.start(compile.step.name, 0);
     defer prog_node.end();
-    if (compile_step.rebuildInFuzzMode(prog_node)) |rebuilt_bin_path| {
+
+    const result = compile.rebuildInFuzzMode(prog_node);
+
+    const show_compile_errors = compile.step.result_error_bundle.errorMessageCount() > 0;
+    const show_error_msgs = compile.step.result_error_msgs.items.len > 0;
+    const show_stderr = compile.step.result_stderr.len > 0;
+
+    if (show_error_msgs or show_compile_errors or show_stderr) {
+        std.debug.lockStdErr();
+        defer std.debug.unlockStdErr();
+        build_runner.printErrorMessages(gpa, &compile.step, ttyconf, stderr, false) catch {};
+    }
+
+    if (result) |rebuilt_bin_path| {
         run.rebuilt_executable = rebuilt_bin_path;
     } else |err| switch (err) {
-        error.MakeFailed => {
-            const b = run.step.owner;
-            const stderr = std.io.getStdErr();
-            std.debug.lockStdErr();
-            defer std.debug.unlockStdErr();
-            build_runner.printErrorMessages(b, &compile_step.step, ttyconf, stderr, false) catch {};
-        },
+        error.MakeFailed => {},
         else => {
             std.debug.print("step '{s}': failed to rebuild in fuzz mode: {s}\n", .{
-                compile_step.step.name, @errorName(err),
+                compile.step.name, @errorName(err),
             });
         },
     }
@@ -82,6 +92,7 @@ fn fuzzWorkerRun(
     ttyconf: std.io.tty.Config,
     parent_prog_node: std.Progress.Node,
 ) void {
+    const gpa = run.step.owner.allocator;
     const test_name = run.cached_test_metadata.?.testName(unit_test_index);
 
     const prog_node = parent_prog_node.start(test_name, 0);
@@ -89,11 +100,10 @@ fn fuzzWorkerRun(
 
     run.rerunInFuzzMode(unit_test_index, prog_node) catch |err| switch (err) {
         error.MakeFailed => {
-            const b = run.step.owner;
             const stderr = std.io.getStdErr();
             std.debug.lockStdErr();
             defer std.debug.unlockStdErr();
-            build_runner.printErrorMessages(b, &run.step, ttyconf, stderr, false) catch {};
+            build_runner.printErrorMessages(gpa, &run.step, ttyconf, stderr, false) catch {};
         },
         else => {
             std.debug.print("step '{s}': failed to rebuild '{s}' in fuzz mode: {s}\n", .{

--- a/lib/std/Build/Fuzz.zig
+++ b/lib/std/Build/Fuzz.zig
@@ -37,8 +37,8 @@ pub fn start(
     }
 
     {
-        const rebuild_node = prog_node.start("Fuzzing", count);
-        defer rebuild_node.end();
+        const fuzz_node = prog_node.start("Fuzzing", count);
+        defer fuzz_node.end();
         var wait_group: std.Thread.WaitGroup = .{};
         defer wait_group.wait();
 
@@ -46,7 +46,7 @@ pub fn start(
             const run = step.cast(Step.Run) orelse continue;
             for (run.fuzz_tests.items) |unit_test_index| {
                 assert(run.rebuilt_executable != null);
-                thread_pool.spawnWg(&wait_group, fuzzWorkerRun, .{ run, unit_test_index, ttyconf, prog_node });
+                thread_pool.spawnWg(&wait_group, fuzzWorkerRun, .{ run, unit_test_index, ttyconf, fuzz_node });
             }
         }
     }

--- a/lib/std/Build/Fuzz.zig
+++ b/lib/std/Build/Fuzz.zig
@@ -1,0 +1,46 @@
+const std = @import("../std.zig");
+const Fuzz = @This();
+const Step = std.Build.Step;
+const assert = std.debug.assert;
+const fatal = std.process.fatal;
+
+pub fn start(thread_pool: *std.Thread.Pool, all_steps: []const *Step, prog_node: std.Progress.Node) void {
+    {
+        const rebuild_node = prog_node.start("Rebuilding Unit Tests", 0);
+        defer rebuild_node.end();
+        var count: usize = 0;
+        var wait_group: std.Thread.WaitGroup = .{};
+        defer wait_group.wait();
+        for (all_steps) |step| {
+            const run = step.cast(Step.Run) orelse continue;
+            if (run.fuzz_tests.items.len > 0 and run.producer != null) {
+                thread_pool.spawnWg(&wait_group, rebuildTestsWorkerRun, .{ run, prog_node });
+                count += 1;
+            }
+        }
+        if (count == 0) fatal("no fuzz tests found", .{});
+        rebuild_node.setEstimatedTotalItems(count);
+    }
+
+    // Detect failure.
+    for (all_steps) |step| {
+        const run = step.cast(Step.Run) orelse continue;
+        if (run.fuzz_tests.items.len > 0 and run.rebuilt_executable == null)
+            fatal("one or more unit tests failed to be rebuilt in fuzz mode", .{});
+    }
+
+    @panic("TODO do something with the rebuilt unit tests");
+}
+
+fn rebuildTestsWorkerRun(run: *Step.Run, parent_prog_node: std.Progress.Node) void {
+    const compile_step = run.producer.?;
+    const prog_node = parent_prog_node.start(compile_step.step.name, 0);
+    defer prog_node.end();
+    const rebuilt_bin_path = compile_step.rebuildInFuzzMode(prog_node) catch |err| {
+        std.debug.print("failed to rebuild {s} in fuzz mode: {s}", .{
+            compile_step.step.name, @errorName(err),
+        });
+        return;
+    };
+    run.rebuilt_executable = rebuilt_bin_path;
+}

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1483,6 +1483,8 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
     try zig_args.append("--global-cache-dir");
     try zig_args.append(b.graph.global_cache_root.path orelse ".");
 
+    if (b.graph.debug_compiler_runtime_libs) try zig_args.append("--debug-rt");
+
     try zig_args.append("--name");
     try zig_args.append(compile.name);
 
@@ -1840,6 +1842,14 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
 }
 
 pub fn rebuildInFuzzMode(c: *Compile, progress_node: std.Progress.Node) ![]const u8 {
+    const gpa = c.step.owner.allocator;
+
+    c.step.result_error_msgs.clearRetainingCapacity();
+    c.step.result_stderr = "";
+
+    c.step.result_error_bundle.deinit(gpa);
+    c.step.result_error_bundle = std.zig.ErrorBundle.empty;
+
     const zig_args = try getZigArgs(c, true);
     const maybe_output_bin_path = try c.step.evalZigProcess(zig_args, progress_node, false);
     return maybe_output_bin_path.?;

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -89,6 +89,8 @@ has_side_effects: bool,
 /// If this is a Zig unit test binary, this tracks the indexes of the unit
 /// tests that are also fuzz tests.
 fuzz_tests: std.ArrayListUnmanaged(u32),
+cached_test_metadata: ?CachedTestMetadata = null,
+
 /// Populated during the fuzz phase if this run step corresponds to a unit test
 /// executable that contains fuzz tests.
 rebuilt_executable: ?[]const u8,
@@ -754,7 +756,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
                 b.fmt("{s}{s}", .{ placeholder.output.prefix, output_path });
         }
 
-        try runCommand(run, argv_list.items, has_side_effects, output_dir_path, prog_node);
+        try runCommand(run, argv_list.items, has_side_effects, output_dir_path, prog_node, null);
         if (!has_side_effects) try step.writeManifestAndWatch(&man);
         return;
     };
@@ -784,7 +786,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
             b.fmt("{s}{s}", .{ placeholder.output.prefix, output_path });
     }
 
-    try runCommand(run, argv_list.items, has_side_effects, tmp_dir_path, prog_node);
+    try runCommand(run, argv_list.items, has_side_effects, tmp_dir_path, prog_node, null);
 
     const dep_file_dir = std.fs.cwd();
     const dep_file_basename = dep_output_file.generated_file.getPath();
@@ -841,6 +843,38 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
         b.cache_root,
         &digest,
     );
+}
+
+pub fn rerunInFuzzMode(run: *Run, unit_test_index: u32, prog_node: std.Progress.Node) !void {
+    const step = &run.step;
+    const b = step.owner;
+    const arena = b.allocator;
+    var argv_list: std.ArrayListUnmanaged([]const u8) = .{};
+    for (run.argv.items) |arg| {
+        switch (arg) {
+            .bytes => |bytes| {
+                try argv_list.append(arena, bytes);
+            },
+            .lazy_path => |file| {
+                const file_path = file.lazy_path.getPath2(b, step);
+                try argv_list.append(arena, b.fmt("{s}{s}", .{ file.prefix, file_path }));
+            },
+            .directory_source => |file| {
+                const file_path = file.lazy_path.getPath2(b, step);
+                try argv_list.append(arena, b.fmt("{s}{s}", .{ file.prefix, file_path }));
+            },
+            .artifact => |pa| {
+                const artifact = pa.artifact;
+                const file_path = artifact.installed_path orelse artifact.generated_bin.?.path.?;
+                try argv_list.append(arena, b.fmt("{s}{s}", .{ pa.prefix, file_path }));
+            },
+            .output_file, .output_directory => unreachable,
+        }
+    }
+    const has_side_effects = false;
+    const rand_int = std.crypto.random.int(u64);
+    const tmp_dir_path = "tmp" ++ fs.path.sep_str ++ std.fmt.hex(rand_int);
+    try runCommand(run, argv_list.items, has_side_effects, tmp_dir_path, prog_node, unit_test_index);
 }
 
 fn populateGeneratedPaths(
@@ -921,6 +955,7 @@ fn runCommand(
     has_side_effects: bool,
     output_dir_path: []const u8,
     prog_node: std.Progress.Node,
+    fuzz_unit_test_index: ?u32,
 ) !void {
     const step = &run.step;
     const b = step.owner;
@@ -939,7 +974,7 @@ fn runCommand(
     var interp_argv = std.ArrayList([]const u8).init(b.allocator);
     defer interp_argv.deinit();
 
-    const result = spawnChildAndCollect(run, argv, has_side_effects, prog_node) catch |err| term: {
+    const result = spawnChildAndCollect(run, argv, has_side_effects, prog_node, fuzz_unit_test_index) catch |err| term: {
         // InvalidExe: cpu arch mismatch
         // FileNotFound: can happen with a wrong dynamic linker path
         if (err == error.InvalidExe or err == error.FileNotFound) interpret: {
@@ -1075,7 +1110,7 @@ fn runCommand(
 
             try Step.handleVerbose2(step.owner, cwd, run.env_map, interp_argv.items);
 
-            break :term spawnChildAndCollect(run, interp_argv.items, has_side_effects, prog_node) catch |e| {
+            break :term spawnChildAndCollect(run, interp_argv.items, has_side_effects, prog_node, fuzz_unit_test_index) catch |e| {
                 if (!run.failing_to_execute_foreign_is_an_error) return error.MakeSkipped;
 
                 return step.fail("unable to spawn interpreter {s}: {s}", .{
@@ -1090,6 +1125,15 @@ fn runCommand(
     step.result_duration_ns = result.elapsed_ns;
     step.result_peak_rss = result.peak_rss;
     step.test_results = result.stdio.test_results;
+    if (result.stdio.test_metadata) |tm|
+        run.cached_test_metadata = tm.toCachedTestMetadata();
+
+    const final_argv = if (interp_argv.items.len == 0) argv else interp_argv.items;
+
+    if (fuzz_unit_test_index != null) {
+        try step.handleChildProcessTerm(result.term, cwd, final_argv);
+        return;
+    }
 
     // Capture stdout and stderr to GeneratedFile objects.
     const Stream = struct {
@@ -1125,8 +1169,6 @@ fn runCommand(
             };
         }
     }
-
-    const final_argv = if (interp_argv.items.len == 0) argv else interp_argv.items;
 
     switch (run.stdio) {
         .check => |checks| for (checks.items) |check| switch (check) {
@@ -1253,9 +1295,15 @@ fn spawnChildAndCollect(
     argv: []const []const u8,
     has_side_effects: bool,
     prog_node: std.Progress.Node,
+    fuzz_unit_test_index: ?u32,
 ) !ChildProcResult {
     const b = run.step.owner;
     const arena = b.allocator;
+
+    if (fuzz_unit_test_index != null) {
+        assert(!has_side_effects);
+        assert(run.stdio == .zig_test);
+    }
 
     var child = std.process.Child.init(argv, arena);
     if (run.cwd) |lazy_cwd| {
@@ -1306,7 +1354,7 @@ fn spawnChildAndCollect(
         var timer = try std.time.Timer.start();
 
         const result = if (run.stdio == .zig_test)
-            evalZigTest(run, &child, prog_node)
+            evalZigTest(run, &child, prog_node, fuzz_unit_test_index)
         else
             evalGeneric(run, &child);
 
@@ -1332,6 +1380,7 @@ fn evalZigTest(
     run: *Run,
     child: *std.process.Child,
     prog_node: std.Progress.Node,
+    fuzz_unit_test_index: ?u32,
 ) !StdIoResult {
     const gpa = run.step.owner.allocator;
     const arena = run.step.owner.allocator;
@@ -1342,7 +1391,12 @@ fn evalZigTest(
     });
     defer poller.deinit();
 
-    try sendMessage(child.stdin.?, .query_test_metadata);
+    if (fuzz_unit_test_index) |index| {
+        try sendRunTestMessage(child.stdin.?, .start_fuzzing, index);
+    } else {
+        run.fuzz_tests.clearRetainingCapacity();
+        try sendMessage(child.stdin.?, .query_test_metadata);
+    }
 
     const Header = std.zig.Server.Message.Header;
 
@@ -1359,8 +1413,6 @@ fn evalZigTest(
 
     var sub_prog_node: ?std.Progress.Node = null;
     defer if (sub_prog_node) |n| n.end();
-
-    run.fuzz_tests.clearRetainingCapacity();
 
     poll: while (true) {
         while (stdout.readableLength() < @sizeOf(Header)) {
@@ -1382,6 +1434,7 @@ fn evalZigTest(
                 }
             },
             .test_metadata => {
+                assert(fuzz_unit_test_index == null);
                 const TmHdr = std.zig.Server.Message.TestMetadata;
                 const tm_hdr = @as(*align(1) const TmHdr, @ptrCast(body));
                 test_count = tm_hdr.tests_len;
@@ -1410,6 +1463,7 @@ fn evalZigTest(
                 try requestNextTest(child.stdin.?, &metadata.?, &sub_prog_node);
             },
             .test_results => {
+                assert(fuzz_unit_test_index == null);
                 const md = metadata.?;
 
                 const TrHdr = std.zig.Server.Message.TestResults;
@@ -1479,7 +1533,23 @@ const TestMetadata = struct {
     next_index: u32,
     prog_node: std.Progress.Node,
 
+    fn toCachedTestMetadata(tm: TestMetadata) CachedTestMetadata {
+        return .{
+            .names = tm.names,
+            .string_bytes = tm.string_bytes,
+        };
+    }
+
     fn testName(tm: TestMetadata, index: u32) []const u8 {
+        return tm.toCachedTestMetadata().testName(index);
+    }
+};
+
+pub const CachedTestMetadata = struct {
+    names: []const u32,
+    string_bytes: []const u8,
+
+    pub fn testName(tm: CachedTestMetadata, index: u32) []const u8 {
         return std.mem.sliceTo(tm.string_bytes[tm.names[index]..], 0);
     }
 };
@@ -1495,7 +1565,7 @@ fn requestNextTest(in: fs.File, metadata: *TestMetadata, sub_prog_node: *?std.Pr
         if (sub_prog_node.*) |n| n.end();
         sub_prog_node.* = metadata.prog_node.start(name, 0);
 
-        try sendRunTestMessage(in, i);
+        try sendRunTestMessage(in, .run_test, i);
         return;
     } else {
         try sendMessage(in, .exit);
@@ -1510,9 +1580,9 @@ fn sendMessage(file: std.fs.File, tag: std.zig.Client.Message.Tag) !void {
     try file.writeAll(std.mem.asBytes(&header));
 }
 
-fn sendRunTestMessage(file: std.fs.File, index: u32) !void {
+fn sendRunTestMessage(file: std.fs.File, tag: std.zig.Client.Message.Tag, index: u32) !void {
     const header: std.zig.Client.Message.Header = .{
-        .tag = .run_test,
+        .tag = tag,
         .bytes_len = 4,
     };
     const full_msg = std.mem.asBytes(&header) ++ std.mem.asBytes(&index);

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -865,7 +865,10 @@ pub fn rerunInFuzzMode(run: *Run, unit_test_index: u32, prog_node: std.Progress.
             },
             .artifact => |pa| {
                 const artifact = pa.artifact;
-                const file_path = artifact.installed_path orelse artifact.generated_bin.?.path.?;
+                const file_path = if (artifact == run.producer.?)
+                    run.rebuilt_executable.?
+                else
+                    (artifact.installed_path orelse artifact.generated_bin.?.path.?);
                 try argv_list.append(arena, b.fmt("{s}{s}", .{ pa.prefix, file_path }));
             },
             .output_file, .output_directory => unreachable,

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -89,6 +89,9 @@ has_side_effects: bool,
 /// If this is a Zig unit test binary, this tracks the indexes of the unit
 /// tests that are also fuzz tests.
 fuzz_tests: std.ArrayListUnmanaged(u32),
+/// Populated during the fuzz phase if this run step corresponds to a unit test
+/// executable that contains fuzz tests.
+rebuilt_executable: ?[]const u8,
 
 /// If this Run step was produced by a Compile step, it is tracked here.
 producer: ?*Step.Compile,
@@ -183,6 +186,7 @@ pub fn create(owner: *std.Build, name: []const u8) *Run {
         .dep_output_file = null,
         .has_side_effects = false,
         .fuzz_tests = .{},
+        .rebuilt_executable = null,
         .producer = null,
     };
     return run;

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -16,7 +16,7 @@ test "write a file, read it, then delete it" {
     defer tmp.cleanup();
 
     var data: [1024]u8 = undefined;
-    var prng = DefaultPrng.init(1234);
+    var prng = DefaultPrng.init(std.testing.random_seed);
     const random = prng.random();
     random.bytes(data[0..]);
     const tmp_file_name = "temp_test_file.txt";

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -1137,32 +1137,10 @@ pub fn refAllDeclsRecursive(comptime T: type) void {
     }
 }
 
-const FuzzerSlice = extern struct {
-    ptr: [*]const u8,
-    len: usize,
-
-    fn toSlice(s: FuzzerSlice) []const u8 {
-        return s.ptr[0..s.len];
-    }
-};
-
-extern fn fuzzer_next() FuzzerSlice;
-
 pub const FuzzInputOptions = struct {
     corpus: []const []const u8 = &.{},
 };
 
-pub fn fuzzInput(options: FuzzInputOptions) []const u8 {
-    @disableInstrumentation();
-    if (builtin.fuzz) {
-        return fuzzer_next().toSlice();
-    } else {
-        if (options.corpus.len == 0) {
-            return "";
-        } else {
-            var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
-            const random = prng.random();
-            return options.corpus[random.uintLessThan(usize, options.corpus.len)];
-        }
-    }
+pub inline fn fuzzInput(options: FuzzInputOptions) []const u8 {
+    return @import("root").fuzzInput(options);
 }

--- a/lib/std/zig/Client.zig
+++ b/lib/std/zig/Client.zig
@@ -33,6 +33,9 @@ pub const Message = struct {
         /// Ask the test runner to run a particular test.
         /// The message body is a u32 test index.
         run_test,
+        /// Ask the test runner to start fuzzing a particular test.
+        /// The message body is a u32 test index.
+        start_fuzzing,
 
         _,
     };

--- a/lib/std/zig/Server.zig
+++ b/lib/std/zig/Server.zig
@@ -53,7 +53,7 @@ pub const Message = struct {
     ///   - null-terminated string_bytes index
     /// * expected_panic_msg: [tests_len]u32,
     ///   - null-terminated string_bytes index
-    ///   - 0 means does not expect pani
+    ///   - 0 means does not expect panic
     /// * string_bytes: [string_bytes_len]u8,
     pub const TestMetadata = extern struct {
         string_bytes_len: u32,
@@ -68,7 +68,8 @@ pub const Message = struct {
             fail: bool,
             skip: bool,
             leak: bool,
-            log_err_count: u29 = 0,
+            fuzz: bool,
+            log_err_count: u28 = 0,
         };
     };
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2180,7 +2180,9 @@ pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) !void {
                 comp.bin_file = try link.File.createEmpty(arena, comp, emit, whole.lf_open_opts);
             }
         },
-        .incremental => {},
+        .incremental => {
+            log.debug("Compilation.update for {s}, CacheMode.incremental", .{comp.root_name});
+        },
     }
 
     // From this point we add a preliminary set of file system inputs that

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1392,16 +1392,12 @@ pub const Object = struct {
         }
         if (owner_mod.fuzz and !func_analysis.disable_instrumentation) {
             try attributes.addFnAttr(.optforfuzzing, &o.builder);
-            if (comp.config.any_fuzz) {
-                _ = try attributes.removeFnAttr(.skipprofile);
-                _ = try attributes.removeFnAttr(.nosanitize_coverage);
-            }
+            _ = try attributes.removeFnAttr(.skipprofile);
+            _ = try attributes.removeFnAttr(.nosanitize_coverage);
         } else {
             _ = try attributes.removeFnAttr(.optforfuzzing);
-            if (comp.config.any_fuzz) {
-                try attributes.addFnAttr(.skipprofile, &o.builder);
-                try attributes.addFnAttr(.nosanitize_coverage, &o.builder);
-            }
+            try attributes.addFnAttr(.skipprofile, &o.builder);
+            try attributes.addFnAttr(.nosanitize_coverage, &o.builder);
         }
 
         // TODO: disable this if safety is off for the function scope

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -2286,6 +2286,8 @@ fn linkWithLLD(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: s
         }
         try man.addOptionalFile(module_obj_path);
         try man.addOptionalFile(compiler_rt_path);
+        try man.addOptionalFile(if (comp.tsan_lib) |l| l.full_object_path else null);
+        try man.addOptionalFile(if (comp.fuzzer_lib) |l| l.full_object_path else null);
 
         // We can skip hashing libc and libc++ components that we are in charge of building from Zig
         // installation sources because they are always a product of the compiler version + target information.

--- a/src/main.zig
+++ b/src/main.zig
@@ -655,6 +655,7 @@ const usage_build_generic =
     \\  --debug-log [scope]          Enable printing debug/info log messages for scope
     \\  --debug-compile-errors       Crash with helpful diagnostics at the first compile error
     \\  --debug-link-snapshot        Enable dumping of the linker's state in JSON format
+    \\  --debug-rt                   Debug compiler runtime libraries
     \\
 ;
 
@@ -912,6 +913,7 @@ fn buildOutputType(
     var minor_subsystem_version: ?u16 = null;
     var mingw_unicode_entry_point: bool = false;
     var enable_link_snapshots: bool = false;
+    var debug_compiler_runtime_libs = false;
     var opt_incremental: ?bool = null;
     var install_name: ?[]const u8 = null;
     var hash_style: link.File.Elf.HashStyle = .both;
@@ -1367,6 +1369,8 @@ fn buildOutputType(
                         } else {
                             enable_link_snapshots = true;
                         }
+                    } else if (mem.eql(u8, arg, "--debug-rt")) {
+                        debug_compiler_runtime_libs = true;
                     } else if (mem.eql(u8, arg, "-fincremental")) {
                         dev.check(.incremental);
                         opt_incremental = true;
@@ -3408,6 +3412,7 @@ fn buildOutputType(
         // noise when --search-prefix and --mod are combined.
         .global_cc_argv = try cc_argv.toOwnedSlice(arena),
         .file_system_inputs = &file_system_inputs,
+        .debug_compiler_runtime_libs = debug_compiler_runtime_libs,
     }) catch |err| switch (err) {
         error.LibCUnavailable => {
             const triple_name = try target.zigTriple(arena);


### PR DESCRIPTION
Adds a `--fuzz` CLI option to the build runner. When this is used it rebuilds any unit test binaries which contained at least one fuzz test with `-ffuzz` and then tells it to start fuzzing, which does in-process fuzzing.

Adds `std.testing.fuzzInput`, which is how unit tests mark themselves as fuzz tests.

This contains only a rudimentary implementation of fuzzer logic, really just some early, early experiments, but already it makes this test case fail in 65 milliseconds on my machine:

```zig
test "fuzz example" {
    const input_bytes = std.testing.fuzzInput(.{});
    try std.testing.expect(!std.mem.eql(u8, "canyoufindme", input_bytes));
}
```

```
andy@bark ~/t/abc [1]> ~/dev/zig/build-release/stage4/bin/zig build test --fuzz --debug-rt
test
└─ run test failure
/home/andy/dev/zig/lib/std/testing.zig:546:14: 0x1183a59 in expect (test)
    if (!ok) return error.TestUnexpectedResult;
             ^
/home/andy/tmp/abc/src/main.zig:28:5: 0x1183b21 in test.fuzz example (test)
    try std.testing.expect(!std.mem.eql(u8, "canyoufindme", input_bytes));
    ^
failed with error.TestUnexpectedResult
error: the following command exited with error code 1:
/home/andy/tmp/abc/.zig-cache/o/15697f80a9140388803537517083788c/test --seed=0x93a767fd --listen=- 
error: all fuzz workers crashed
error: the following build command failed with exit code 1:
/home/andy/tmp/abc/.zig-cache/o/12ab17aae32a6d5d6c9fba7b28ba3167/build /home/andy/dev/zig/build-release/stage4/bin/zig /home/andy/dev/zig/lib /home/andy/tmp/abc /home/andy/tmp/abc/.zig-cache /home/andy/.cache/zig --seed 0x93a767fd -Zb1f080d4c8ac26d5 test --fuzz --debug-rt
```

[asciinema demo](https://asciinema.org/a/asgN7rIr6LFeMhQMOXI825wGe)

Closes #20702.

## Follow-Up Tasks

 * #20782
 * #352
 * #1356
 * #15953
 * #19821
 * write fuzz inputs to a shared memory region before running a task
 * introduce a genetic algorithm to fuzz inputs based on code coverage instrumentation
 * add a UI to fuzzing to report progress, code coverage, interesting inputs, and other stats
 * introduce an input corpus. when provided, that is what runs during unit test mode
 * ability to choose whether timing out is considered a fail or a pass (eg timing out when fuzzing an interpreter is expected)
 * unique failure detection
 * corpus minimization mode
 * some way to export and merge coverage reports
 * more flags to the build runner such as timed fuzzing
 * investigate adding [sometimes assertions](https://antithesis.com/docs/best_practices/sometimes_assertions.html), perhaps with scopes
 * investigate coordination between multiple `zig build --fuzz` instances running on different machines
 * integrate `--fuzz` with `--watch`