### PR TITLE
aarch64: reenable tests that are no longer regressed

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -614,11 +614,6 @@ pub fn shl(comptime T: type, a: T, shift_amt: anytype) T {
 }
 
 test shl {
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .aarch64) {
-        // https://github.com/ziglang/zig/issues/12012
-        return error.SkipZigTest;
-    }
-
     try testing.expect(shl(u8, 0b11111111, @as(usize, 3)) == 0b11111000);
     try testing.expect(shl(u8, 0b11111111, @as(usize, 8)) == 0);
     try testing.expect(shl(u8, 0b11111111, @as(usize, 9)) == 0);
@@ -659,11 +654,6 @@ pub fn shr(comptime T: type, a: T, shift_amt: anytype) T {
 }
 
 test shr {
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .aarch64) {
-        // https://github.com/ziglang/zig/issues/12012
-        return error.SkipZigTest;
-    }
-
     try testing.expect(shr(u8, 0b11111111, @as(usize, 3)) == 0b00011111);
     try testing.expect(shr(u8, 0b11111111, @as(usize, 8)) == 0);
     try testing.expect(shr(u8, 0b11111111, @as(usize, 9)) == 0);
@@ -705,11 +695,6 @@ pub fn rotr(comptime T: type, x: T, r: anytype) T {
 }
 
 test rotr {
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .aarch64) {
-        // https://github.com/ziglang/zig/issues/12012
-        return error.SkipZigTest;
-    }
-
     try testing.expect(rotr(u0, 0b0, @as(usize, 3)) == 0b0);
     try testing.expect(rotr(u5, 0b00001, @as(usize, 0)) == 0b00001);
     try testing.expect(rotr(u6, 0b000001, @as(usize, 7)) == 0b100000);
@@ -751,11 +736,6 @@ pub fn rotl(comptime T: type, x: T, r: anytype) T {
 }
 
 test rotl {
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .aarch64) {
-        // https://github.com/ziglang/zig/issues/12012
-        return error.SkipZigTest;
-    }
-
     try testing.expect(rotl(u0, 0b0, @as(usize, 3)) == 0b0);
     try testing.expect(rotl(u5, 0b00001, @as(usize, 0)) == 0b00001);
     try testing.expect(rotl(u6, 0b000001, @as(usize, 7)) == 0b000010);
@@ -1862,10 +1842,6 @@ fn testSign() !void {
 }
 
 test sign {
-    if (builtin.zig_backend == .stage2_llvm) {
-        // https://github.com/ziglang/zig/issues/12012
-        return error.SkipZigTest;
-    }
     try testSign();
     try comptime testSign();
 }

--- a/lib/std/simd.zig
+++ b/lib/std/simd.zig
@@ -233,11 +233,6 @@ pub fn extract(
 test "vector patterns" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .aarch64) {
-        // https://github.com/ziglang/zig/issues/12012
-        return error.SkipZigTest;
-    }
-
     const base = @Vector(4, u32){ 10, 20, 30, 40 };
     const other_base = @Vector(4, u32){ 55, 66, 77, 88 };
 

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -286,12 +286,6 @@ test "tuple to vector" {
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .aarch64) {
-        // Regressed with LLVM 14:
-        // https://github.com/ziglang/zig/issues/12012
-        return error.SkipZigTest;
-    }
-
     const S = struct {
         fn doTheTest() !void {
             const Vec3 = @Vector(3, i32);


### PR DESCRIPTION
Closes #12012

As already commented in https://github.com/ziglang/zig/issues/12012#issuecomment-2246375845 this tests are no longer regressed and can be re-enabled.