### PR TITLE
fix(Sema): patch segfault in `finishStructInit`

### DIFF
--- a/test/cases/compile_errors/compile_time_struct_field.zig
+++ b/test/cases/compile_errors/compile_time_struct_field.zig
@@ -1,0 +1,19 @@
+const S = struct {
+    comptime_field: comptime_int = 2,
+    normal_ptr: *u32,
+};
+
+export fn a() void {
+  var value: u32 = 3;
+  const comptimeStruct = S {
+    .normal_ptr = &value,
+  };
+  _ = comptimeStruct;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// 9:6: error: unable to resolve comptime value
+// 9:6: note: initializer of comptime only struct must be comptime-known


### PR DESCRIPTION
Repro from #20629:

```zig
const std = @import("std");

const MyStruct = struct {
    comptime_field: comptime_int = 2,
    normal_pointer: *u32,
};

pub fn main() !void {

  var value: u32 = 3;
  const comptimeStruct = MyStruct {
    .normal_pointer = &value,
  };

  std.debug.print("runtime ptr value: {d}", .{comptimeStruct.normal_pointer.*});
}
```

This code causes `Sema.finishStructInit` to index the `normal_pointer` field in the `MyStruct` initializer based on the index in the `MyStruct` declaration. Since  `comptime_field` is given a default value in the declaration, it isn't specified in the initialization, leading to an off by one error. This incorrect index was then passed to `failWithNeededComptime`, where out of bounds index occurs when that function attempts to add an error note for the `normal_pointer` field at index `1` rather than index `0`.

Closes #20629 