### PR TITLE
`main`: Don't pass `--seed` for `zig run`.

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4309,10 +4309,12 @@ fn runOrTest(
     defer argv.deinit();
 
     if (test_exec_args.len == 0) {
-        try argv.appendSlice(&.{
-            exe_path,
-            try std.fmt.allocPrint(arena, "--seed=0x{x}", .{std.crypto.random.int(u32)}),
-        });
+        try argv.append(exe_path);
+        if (arg_mode == .zig_test) {
+            try argv.append(
+                try std.fmt.allocPrint(arena, "--seed=0x{x}", .{std.crypto.random.int(u32)}),
+            );
+        }
     } else {
         for (test_exec_args) |arg| {
             try argv.append(arg orelse exe_path);


### PR DESCRIPTION
Looks like an accidental effect introduced in #20750.

Had me questioning reality for a bit before I realized what was going on:

```
❯ zig run generate_linux_syscalls.zig -- $(which zig) /home/alexrp/Source/linux
error: NotDir
/home/alexrp/Source/zig/lib/std/posix.zig:1783:24: 0x108024f in openatZ (generate_linux_syscalls)
            .NOTDIR => return error.NotDir,
                       ^
/home/alexrp/Source/zig/lib/std/fs/Dir.zig:1565:21: 0x1090736 in openDirFlagsZ (generate_linux_syscalls)
        else => |e| return e,
                    ^
/home/alexrp/Source/zig/lib/std/fs/Dir.zig:1529:5: 0x107fef2 in openDirZ (generate_linux_syscalls)
    return self.openDirFlagsZ(sub_path_c, symlink_flags);
    ^
/home/alexrp/Source/zig/lib/std/fs/Dir.zig:1473:5: 0x104cace in openDir (generate_linux_syscalls)
    return self.openDirZ(&sub_path_c, args);
    ^
/home/alexrp/Source/zig/lib/std/fs.zig:283:5: 0x10460bb in openDirAbsolute (generate_linux_syscalls)
    return cwd().openDir(absolute_path, flags);
    ^
/home/alexrp/Source/zig/tools/generate_linux_syscalls.zig:66:23: 0x103d9f3 in main (generate_linux_syscalls)
    const linux_dir = try std.fs.openDirAbsolute(linux_path, .{});
```