### PR TITLE
`std.Target`: Use hexagonv60 as the baseline CPU model for hexagon.

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -1505,6 +1505,7 @@ pub const Cpu = struct {
         pub fn baseline(arch: Arch) *const Model {
             return switch (arch) {
                 .arm, .armeb, .thumb, .thumbeb => &arm.cpu.baseline,
+                .hexagon => &hexagon.cpu.hexagonv60,
                 .riscv32 => &riscv.cpu.baseline_rv32,
                 .riscv64 => &riscv.cpu.baseline_rv64,
                 .x86 => &x86.cpu.pentium4,


### PR DESCRIPTION
Similar situation to #20451:

```console
❯ zig cc test.c -target hexagon-linux-none
error: unknown target CPU 'generic'
note: valid target CPU values are: hexagonv5, hexagonv55, hexagonv60, hexagonv62, hexagonv65, hexagonv66, hexagonv67, hexagonv67t, hexagonv68, hexagonv69, hexagonv71, hexagonv71t, hexagonv73
```

Clang uses `hexagonv60` by default: https://github.com/llvm/llvm-project/blob/25f9415713f9f57760a5322876906dc11385ef8e/clang/lib/Driver/ToolChains/Hexagon.cpp#L800-L806