### PR TITLE
fix(Sema): patch segfault in `finishStructInit` take 2

### DIFF
--- a/test/cases/compile_errors/compile_time_struct_field.zig
+++ b/test/cases/compile_errors/compile_time_struct_field.zig
@@ -1,0 +1,19 @@
+const S = struct {
+    comptime_field: comptime_int = 2,
+    normal_ptr: *u32,
+};
+
+export fn a() void {
+  var value: u32 = 3;
+  const comptimeStruct = S {
+    .normal_ptr = &value,
+  };
+  _ = comptimeStruct;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// 9:6: error: unable to resolve comptime value
+// 9:6: note: initializer of comptime only struct must be comptime-known


### PR DESCRIPTION
Rework of #20791

Modifies `zirStructInit` to pass an array of `?usize`s to `finishStructInit`, mapping each initialized field's index in the struct declaration to the index in the initialization expression. Having the correct index then prevents the current out of bounds access behavior. I provided some additional detail for the bug in the original PR's description.

Closes #20629