### PR TITLE
handle -x language flag without spaces

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1703,8 +1703,11 @@ fn buildOutputType(
                         try cc_argv.append(arena, arg);
                     } else if (mem.startsWith(u8, arg, "-I")) {
                         try cssan.addIncludePath(arena, &cc_argv, .I, arg, arg[2..], true);
-                    } else if (mem.eql(u8, arg, "-x")) {
-                        const lang = args_iter.nextOrFatal();
+                    } else if (mem.startsWith(u8, arg, "-x")) {
+                        const lang = if (arg.len == "-x".len)
+                            args_iter.nextOrFatal()
+                        else
+                            arg["-x".len..];
                         if (mem.eql(u8, lang, "none")) {
                             file_ext = null;
                         } else if (Compilation.LangToExt.get(lang)) |got_ext| {


### PR DESCRIPTION
gcc and clang both handle this flag with and without a space so it seems reasonable to replicate that