### PR TITLE
`compiler`: Enable -Werror=date-time for C/C++ code in release builds

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5731,6 +5731,10 @@ pub fn addCCArgs(
                 },
             }
 
+            if (mod.optimize_mode != .Debug) {
+                try argv.append("-Werror=date-time");
+            }
+
             if (target_util.supports_fpic(target) and mod.pic) {
                 try argv.append("-fPIC");
             }


### PR DESCRIPTION
We advertise reproducible builds for release modes, so let's help users achieve that in C/C++ code. Users can still override this manually if they really want.