### PR TITLE
`std.os.linux.start_pie`: Add mips and powerpc support

### DIFF
--- a/lib/std/os/linux/start_pie.zig
+++ b/lib/std/os/linux/start_pie.zig
@@ -38,7 +38,7 @@ const R_RELATIVE = switch (builtin.cpu.arch) {
 // Obtain a pointer to the _DYNAMIC array.
 // We have to compute its address as a PC-relative quantity not to require a
 // relocation that, at this point, is not yet applied.
-fn getDynamicSymbol() [*]elf.Dyn {
+inline fn getDynamicSymbol() [*]elf.Dyn {
     return switch (builtin.cpu.arch) {
         .x86 => asm volatile (
             \\ .weak _DYNAMIC

--- a/lib/std/os/linux/start_pie.zig
+++ b/lib/std/os/linux/start_pie.zig
@@ -176,9 +176,9 @@ inline fn getDynamicSymbol() [*]elf.Dyn {
             \\ .weak _DYNAMIC
             \\ .hidden _DYNAMIC
             \\ larl %[ret], 1f
-            \\ agf %[ret], 0(%[ret])
+            \\ ag %[ret], 0(%[ret])
             \\ b 2f
-            \\ 1: .long _DYNAMIC - .
+            \\ 1: .quad _DYNAMIC - .
             \\ 2:
             : [ret] "=r" (-> [*]elf.Dyn),
         ),


### PR DESCRIPTION
Requires #20822 to actually work.