### PR TITLE
Update lib/std/enums.zig EnumMap to include getKey()

### DIFF
--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -527,6 +527,18 @@ pub fn EnumMap(comptime E: type, comptime V: type) type {
             return if (self.bits.isSet(index)) self.values[index] else null;
         }
 
+        /// Gets the key associated with a value.
+        /// Compares values with .eq() if defined, otherwise ==
+        /// If the value is not in the map, returns null.
+        pub fn getKey(self: Self, value: Value) ?Key {
+            for (self.values, 0..) |v, i| {
+                if ((@hasDecl(V, "eq") and v.eq(value)) or (!@hasDecl(V, "eq") and v == value)) {
+                    return Indexer.keyForIndex(i);
+                }
+            }
+            return null;
+        }
+
         /// Gets the value associated with a key, which must
         /// exist in the map.
         pub fn getAssertContains(self: Self, key: Key) Value {


### PR DESCRIPTION
I found it very useful for my Game Engine to use an EnumMap() which has a getKey() function that also optionally allows to compare with .eq() for unions.