### PR TITLE
Fixed struct 'posix.system__struct_6652' has no member named 'MSF' compile error for other OS target

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -844,7 +844,7 @@ pub const StackIterator = struct {
 
 const have_msync = switch (native_os) {
     .wasi, .emscripten, .windows => false,
-    else => true,
+    else => posix.system.ucontext_t != void,
 };
 
 pub fn writeCurrentStackTrace(


### PR DESCRIPTION
In my OS project, which has a target of `x86_64-other-gnu`  I am parsing DWARF debug symbols and with the latest pull of 0.14 I am getting this compile error:

```
/Users/danielbokser/zig/lib/std/posix.zig:80:23: error: struct 'posix.system__struct_6652' has no member named 'MSF'
pub const MSF = system.MSF;
                ~~~~~~^~~~
/Users/danielbokser/zig/lib/std/posix.zig:48:13: note: struct declared here
    else => struct {
            ^~~~~~
referenced by:
    isValidMemory: /Users/danielbokser/zig/lib/std/debug.zig:697:46
    read: /Users/danielbokser/zig/lib/std/debug.zig:767:31
    load__anon_6654: /Users/danielbokser/zig/lib/std/debug.zig:773:31
    readIntChecked__anon_4363: /Users/danielbokser/zig/lib/std/dwarf.zig:2787:20
    readUnitHeader: /Users/danielbokser/zig/lib/std/dwarf.zig:479:59
    scanAllFunctions: /Users/danielbokser/zig/lib/std/dwarf.zig:666:51
    openDwarfDebugInfo: /Users/danielbokser/zig/lib/std/dwarf.zig:2191:28
```

It seems that on `zig/lib/std/debug.zig:697:46` Zig erroneously thinks this a POSIX target based on the `have_msync` constant, which it is not.  This PR attempts to fix this.

Not sure if this is the best fix, but it does fix my compile error.