### PR TITLE
`musl`: Align `CFLAGS` with upstream

### DIFF
--- a/src/musl.zig
+++ b/src/musl.zig
@@ -395,6 +395,7 @@ fn addCcArgs(
         // Musl adds these args to builds with gcc but clang does not support them.
         //"-fexcess-precision=standard",
         //"-frounding-math",
+        "-fno-strict-aliasing",
         "-Wa,--noexecstack",
         "-D_XOPEN_SOURCE=700",
 

--- a/src/musl.zig
+++ b/src/musl.zig
@@ -392,9 +392,8 @@ fn addCcArgs(
     try args.appendSlice(&[_][]const u8{
         "-std=c99",
         "-ffreestanding",
-        // Musl adds these args to builds with gcc but clang does not support them.
-        //"-fexcess-precision=standard",
-        //"-frounding-math",
+        "-fexcess-precision=standard",
+        "-frounding-math",
         "-fno-strict-aliasing",
         "-Wa,--noexecstack",
         "-D_XOPEN_SOURCE=700",


### PR DESCRIPTION
* https://git.musl-libc.org/cgit/musl/tree/configure#n358
* https://clang.llvm.org/docs/UsersManual.html#cmdoption-fexcess-precision
* https://clang.llvm.org/docs/UsersManual.html#cmdoption-f-no-rounding-math