### PR TITLE
`link.Coff`: Basic support for `/Brepro` in the self-hosted linker.

### DIFF
--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -2289,7 +2289,7 @@ fn writeHeader(self: *Coff) !void {
         flags.DLL = 1;
     }
 
-    const timestamp = std.time.timestamp();
+    const timestamp = if (self.repro) 0 else std.time.timestamp();
     const size_of_optional_header = @as(u16, @intCast(self.getOptionalHeaderSize() + self.getDataDirectoryHeadersSize()));
     var coff_header = coff.CoffHeader{
         .machine = coff.MachineType.fromTargetCpuArch(target.cpu.arch),


### PR DESCRIPTION
Just keep things simple and zero the timestamp. It's not obvious that there's any real benefit to adding complexity and harming performance by computing a hash of the whole file for the timestamp value.

See:

* https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#general-concepts
* https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#debug-type

In the future, we should at least add an empty `IMAGE_DEBUG_TYPE_REPRO` entry to the debug data directory for this case, but I didn't want to do too much surgery right now since it's early days for COFF support in the self-hosted linker.