### PR TITLE
debug.zig: Make it build with 'other' target OS

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -480,7 +480,7 @@ pub fn defaultPanic(
     }
 
     switch (builtin.os.tag) {
-        .freestanding => {
+        .freestanding, .other => {
             @trap();
         },
         .uefi => {

--- a/lib/std/debug/MemoryAccessor.zig
+++ b/lib/std/debug/MemoryAccessor.zig
@@ -80,7 +80,7 @@ pub fn load(ma: *MemoryAccessor, comptime Type: type, address: usize) ?Type {
 
 pub fn isValidMemory(address: usize) bool {
     // We are unable to determine validity of memory for freestanding targets
-    if (native_os == .freestanding or native_os == .uefi) return true;
+    if (native_os == .freestanding or native_os == .other or native_os == .uefi) return true;
 
     const aligned_address = address & ~@as(usize, @intCast((page_size - 1)));
     if (aligned_address == 0) return false;

--- a/test/standalone/stack_iterator/build.zig
+++ b/test/standalone/stack_iterator/build.zig
@@ -113,13 +113,14 @@ pub fn build(b: *std.Build) void {
     // Unwinding without libc/posix
     //
     // No "getcontext" or "ucontext_t"
-    {
+    const no_os_targets = [_]std.Target.Os.Tag{ .freestanding, .other };
+    inline for (no_os_targets) |os_tag| {
         const exe = b.addExecutable(.{
             .name = "unwind_freestanding",
             .root_source_file = b.path("unwind_freestanding.zig"),
             .target = b.resolveTargetQuery(.{
                 .cpu_arch = .x86_64,
-                .os_tag = .freestanding,
+                .os_tag = os_tag,
             }),
             .optimize = optimize,
             .unwind_tables = null,

--- a/test/standalone/stack_iterator/unwind_freestanding.zig
+++ b/test/standalone/stack_iterator/unwind_freestanding.zig
@@ -36,7 +36,7 @@ noinline fn frame0(expected: *[4]usize, unwound: *[4]usize) void {
     frame1(expected, unwound);
 }
 
-// Freestanding entrypoint
+// No-OS entrypoint
 export fn _start() callconv(.C) noreturn {
     var expected: [4]usize = undefined;
     var unwound: [4]usize = undefined;
@@ -50,8 +50,9 @@ export fn _start() callconv(.C) noreturn {
         }
     }
 
-    // Need to compile as "freestanding" to exercise the StackIterator code, but when run as a
-    // regression test need to actually exit.  So assume we're running on x86_64-linux ...
+    // Need to compile with the target OS as "freestanding" or "other" to
+    // exercise the StackIterator code, but when run as a regression test
+    // need to actually exit.  So assume we're running on x86_64-linux ...
     asm volatile (
         \\movl $60, %%eax
         \\syscall


### PR DESCRIPTION
Make `std.debug.StackIterator` compile on the `other` OS target, and port the "unwind_freestanding" test case to the `other` OS target.

Inspired by #20833 which reported the original problem and pin-pointed the issue.

[Edited summary and PR a couple times.]