### PR TITLE
chore: correct non-standard comments.

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -733,46 +733,46 @@ pub const F = switch (native_os) {
         /// used in conjunction with F.NOCACHE to indicate that DIRECT, synchronous writes
         /// should not be used (i.e. its ok to temporarily create cached pages)
         pub const NODIRECT = 62;
-        ///Get the protection class of a file from the EA, returns int
+        /// Get the protection class of a file from the EA, returns int
         pub const GETPROTECTIONCLASS = 63;
-        ///Set the protection class of a file for the EA, requires int
+        /// Set the protection class of a file for the EA, requires int
         pub const SETPROTECTIONCLASS = 64;
-        ///file offset to device offset, extended
+        /// file offset to device offset, extended
         pub const LOG2PHYS_EXT = 65;
-        ///get record locking information, per-process
+        /// get record locking information, per-process
         pub const GETLKPID = 66;
-        ///Mark the file as being the backing store for another filesystem
+        /// Mark the file as being the backing store for another filesystem
         pub const SETBACKINGSTORE = 70;
-        ///return the full path of the FD, but error in specific mtmd circumstances
+        /// return the full path of the FD, but error in specific mtmd circumstances
         pub const GETPATH_MTMINFO = 71;
-        ///Returns the code directory, with associated hashes, to the caller
+        /// Returns the code directory, with associated hashes, to the caller
         pub const GETCODEDIR = 72;
-        ///No SIGPIPE generated on EPIPE
+        /// No SIGPIPE generated on EPIPE
         pub const SETNOSIGPIPE = 73;
-        ///Status of SIGPIPE for this fd
+        /// Status of SIGPIPE for this fd
         pub const GETNOSIGPIPE = 74;
-        ///For some cases, we need to rewrap the key for AKS/MKB
+        /// For some cases, we need to rewrap the key for AKS/MKB
         pub const TRANSCODEKEY = 75;
-        ///file being written to a by single writer... if throttling enabled, writes
-        ///may be broken into smaller chunks with throttling in between
+        /// file being written to a by single writer... if throttling enabled, writes
+        /// may be broken into smaller chunks with throttling in between
         pub const SINGLE_WRITER = 76;
-        ///Get the protection version number for this filesystem
+        /// Get the protection version number for this filesystem
         pub const GETPROTECTIONLEVEL = 77;
-        ///Add detached code signatures (used by dyld for shared libs)
+        /// Add detached code signatures (used by dyld for shared libs)
         pub const FINDSIGS = 78;
-        ///Add signature from same file, only if it is signed by Apple (used by dyld for simulator)
+        /// Add signature from same file, only if it is signed by Apple (used by dyld for simulator)
         pub const ADDFILESIGS_FOR_DYLD_SIM = 83;
-        ///fsync + issue barrier to drive
+        /// fsync + issue barrier to drive
         pub const BARRIERFSYNC = 85;
-        ///Add signature from same file, return end offset in structure on success
+        /// Add signature from same file, return end offset in structure on success
         pub const ADDFILESIGS_RETURN = 97;
-        ///Check if Library Validation allows this Mach-O file to be mapped into the calling process
+        /// Check if Library Validation allows this Mach-O file to be mapped into the calling process
         pub const CHECK_LV = 98;
-        ///Deallocate a range of the file
+        /// Deallocate a range of the file
         pub const PUNCHHOLE = 99;
-        ///Trim an active file
+        /// Trim an active file
         pub const TRIM_ACTIVE_FILE = 100;
-        ///mark the dup with FD_CLOEXEC
+        /// mark the dup with FD_CLOEXEC
         pub const DUPFD_CLOEXEC = 67;
         /// shared or read lock
         pub const RDLCK = 1;

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -681,7 +681,7 @@ test Tag {
     try testing.expect(Tag(U) == E);
 }
 
-///Returns the active tag of a tagged union
+/// Returns the active tag of a tagged union
 pub fn activeTag(u: anytype) Tag(@TypeOf(u)) {
     const T = @TypeOf(u);
     return @as(Tag(T), u);

--- a/lib/std/os/uefi/protocol/serial_io.zig
+++ b/lib/std/os/uefi/protocol/serial_io.zig
@@ -15,32 +15,32 @@ pub const SerialIo = extern struct {
     mode: *Mode,
     device_type_guid: ?*Guid,
 
-    ///Resets the serial device.
+    /// Resets the serial device.
     pub fn reset(self: *const SerialIo) Status {
         return self._reset(self);
     }
 
-    ///Sets the baud rate, receive FIFO depth, transmit/receive time out, parity, data bits, and stop bits on a serial device.
+    /// Sets the baud rate, receive FIFO depth, transmit/receive time out, parity, data bits, and stop bits on a serial device.
     pub fn setAttribute(self: *const SerialIo, baudRate: u64, receiverFifoDepth: u32, timeout: u32, parity: ParityType, dataBits: u8, stopBits: StopBitsType) Status {
         return self._set_attribute(self, baudRate, receiverFifoDepth, timeout, parity, dataBits, stopBits);
     }
 
-    ///Sets the control bits on a serial device.
+    /// Sets the control bits on a serial device.
     pub fn setControl(self: *const SerialIo, control: u32) Status {
         return self._set_control(self, control);
     }
 
-    ///Retrieves the status of the control bits on a serial device.
+    /// Retrieves the status of the control bits on a serial device.
     pub fn getControl(self: *const SerialIo, control: *u32) Status {
         return self._get_control(self, control);
     }
 
-    ///Writes data to a serial device.
+    /// Writes data to a serial device.
     pub fn write(self: *const SerialIo, bufferSize: *usize, buffer: *anyopaque) Status {
         return self._write(self, bufferSize, buffer);
     }
 
-    ///Reads data from a serial device.
+    /// Reads data from a serial device.
     pub fn read(self: *const SerialIo, bufferSize: *usize, buffer: *anyopaque) Status {
         return self._read(self, bufferSize, buffer);
     }

--- a/lib/std/packed_int_array.zig
+++ b/lib/std/packed_int_array.zig
@@ -231,7 +231,7 @@ pub fn PackedIntArrayEndian(comptime Int: type, comptime endian: Endian, comptim
             return Io.get(&self.bytes, index, 0);
         }
 
-        ///Copy the value of `int` into the array at `index`.
+        /// Copy the value of `int` into the array at `index`.
         pub fn set(self: *Self, index: usize, int: Int) void {
             debug.assert(index < int_count);
             return Io.set(&self.bytes, index, 0, int);


### PR DESCRIPTION
Comments throughout the codebase start with a space. This commit corrects comments that do not adhere to this norm.