### PR TITLE
`std.Build.TranslateC`: replace `addIncludeDir` with variants with LazyPath/library names

### DIFF
--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -134,6 +134,44 @@ pub const IncludeDir = union(enum) {
     framework_path_system: LazyPath,
     other_step: *Step.Compile,
     config_header_step: *Step.ConfigHeader,
+
+    pub fn appendZigProcessFlags(
+        include_dir: IncludeDir,
+        b: *std.Build,
+        zig_args: *std.ArrayList([]const u8),
+        asking_step: ?*Step,
+    ) !void {
+        switch (include_dir) {
+            .path => |include_path| {
+                try zig_args.appendSlice(&.{ "-I", include_path.getPath2(b, asking_step) });
+            },
+            .path_system => |include_path| {
+                try zig_args.appendSlice(&.{ "-isystem", include_path.getPath2(b, asking_step) });
+            },
+            .path_after => |include_path| {
+                try zig_args.appendSlice(&.{ "-idirafter", include_path.getPath2(b, asking_step) });
+            },
+            .framework_path => |include_path| {
+                try zig_args.appendSlice(&.{ "-F", include_path.getPath2(b, asking_step) });
+            },
+            .framework_path_system => |include_path| {
+                try zig_args.appendSlice(&.{ "-iframework", include_path.getPath2(b, asking_step) });
+            },
+            .other_step => |other| {
+                if (other.generated_h) |header| {
+                    try zig_args.appendSlice(&.{ "-isystem", std.fs.path.dirname(header.getPath()).? });
+                }
+                if (other.installed_headers_include_tree) |include_tree| {
+                    try zig_args.appendSlice(&.{ "-I", include_tree.generated_directory.getPath() });
+                }
+            },
+            .config_header_step => |config_header| {
+                const full_file_path = config_header.output_file.getPath();
+                const header_dir_path = full_file_path[0 .. full_file_path.len - config_header.include_path.len];
+                try zig_args.appendSlice(&.{ "-I", header_dir_path });
+            },
+        }
+    }
 };
 
 pub const LinkFrameworkOptions = struct {
@@ -686,36 +724,7 @@ pub fn appendZigProcessFlags(
     }
 
     for (m.include_dirs.items) |include_dir| {
-        switch (include_dir) {
-            .path => |include_path| {
-                try zig_args.appendSlice(&.{ "-I", include_path.getPath2(b, asking_step) });
-            },
-            .path_system => |include_path| {
-                try zig_args.appendSlice(&.{ "-isystem", include_path.getPath2(b, asking_step) });
-            },
-            .path_after => |include_path| {
-                try zig_args.appendSlice(&.{ "-idirafter", include_path.getPath2(b, asking_step) });
-            },
-            .framework_path => |include_path| {
-                try zig_args.appendSlice(&.{ "-F", include_path.getPath2(b, asking_step) });
-            },
-            .framework_path_system => |include_path| {
-                try zig_args.appendSlice(&.{ "-iframework", include_path.getPath2(b, asking_step) });
-            },
-            .other_step => |other| {
-                if (other.generated_h) |header| {
-                    try zig_args.appendSlice(&.{ "-isystem", std.fs.path.dirname(header.getPath()).? });
-                }
-                if (other.installed_headers_include_tree) |include_tree| {
-                    try zig_args.appendSlice(&.{ "-I", include_tree.generated_directory.getPath() });
-                }
-            },
-            .config_header_step => |config_header| {
-                const full_file_path = config_header.output_file.getPath();
-                const header_dir_path = full_file_path[0 .. full_file_path.len - config_header.include_path.len];
-                try zig_args.appendSlice(&.{ "-I", header_dir_path });
-            },
-        }
+        try include_dir.appendZigProcessFlags(b, zig_args, asking_step);
     }
 
     try zig_args.appendSlice(m.c_macros.items);

--- a/lib/std/Build/Step/TranslateC.zig
+++ b/lib/std/Build/Step/TranslateC.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Step = std.Build.Step;
+const LazyPath = std.Build.LazyPath;
 const fs = std.fs;
 const mem = std.mem;
 
@@ -9,7 +10,7 @@ pub const base_id: Step.Id = .translate_c;
 
 step: Step,
 source: std.Build.LazyPath,
-include_dirs: std.ArrayList([]const u8),
+include_dirs: std.ArrayList(std.Build.Module.IncludeDir),
 c_macros: std.ArrayList([]const u8),
 out_basename: []const u8,
 target: std.Build.ResolvedTarget,
@@ -37,7 +38,7 @@ pub fn create(owner: *std.Build, options: Options) *TranslateC {
             .makeFn = make,
         }),
         .source = source,
-        .include_dirs = std.ArrayList([]const u8).init(owner.allocator),
+        .include_dirs = std.ArrayList(std.Build.Module.IncludeDir).init(owner.allocator),
         .c_macros = std.ArrayList([]const u8).init(owner.allocator),
         .out_basename = undefined,
         .target = options.target,
@@ -92,8 +93,45 @@ pub fn createModule(translate_c: *TranslateC) *std.Build.Module {
     });
 }
 
-pub fn addIncludeDir(translate_c: *TranslateC, include_dir: []const u8) void {
-    translate_c.include_dirs.append(translate_c.step.owner.dupePath(include_dir)) catch @panic("OOM");
+pub fn addAfterIncludePath(translate_c: *TranslateC, lazy_path: LazyPath) void {
+    const b = translate_c.step.owner;
+    translate_c.include_dirs.append(.{ .path_after = lazy_path.dupe(b) }) catch
+        @panic("OOM");
+    lazy_path.addStepDependencies(&translate_c.step);
+}
+
+pub fn addSystemIncludePath(translate_c: *TranslateC, lazy_path: LazyPath) void {
+    const b = translate_c.step.owner;
+    translate_c.include_dirs.append(.{ .path_system = lazy_path.dupe(b) }) catch
+        @panic("OOM");
+    lazy_path.addStepDependencies(&translate_c.step);
+}
+
+pub fn addIncludePath(translate_c: *TranslateC, lazy_path: LazyPath) void {
+    const b = translate_c.step.owner;
+    translate_c.include_dirs.append(.{ .path = lazy_path.dupe(b) }) catch
+        @panic("OOM");
+    lazy_path.addStepDependencies(&translate_c.step);
+}
+
+pub fn addConfigHeader(translate_c: *TranslateC, config_header: *Step.ConfigHeader) void {
+    translate_c.include_dirs.append(.{ .config_header_step = config_header }) catch
+        @panic("OOM");
+    translate_c.step.dependOn(&config_header.step);
+}
+
+pub fn addSystemFrameworkPath(translate_c: *TranslateC, directory_path: LazyPath) void {
+    const b = translate_c.step.owner;
+    translate_c.include_dirs.append(.{ .framework_path_system = directory_path.dupe(b) }) catch
+        @panic("OOM");
+    directory_path.addStepDependencies(&translate_c.step);
+}
+
+pub fn addFrameworkPath(translate_c: *TranslateC, directory_path: LazyPath) void {
+    const b = translate_c.step.owner;
+    translate_c.include_dirs.append(.{ .framework_path = directory_path.dupe(b) }) catch
+        @panic("OOM");
+    directory_path.addStepDependencies(&translate_c.step);
 }
 
 pub fn addCheckFile(translate_c: *TranslateC, expected_matches: []const []const u8) *Step.CheckFile {
@@ -144,8 +182,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     }
 
     for (translate_c.include_dirs.items) |include_dir| {
-        try argv_list.append("-I");
-        try argv_list.append(include_dir);
+        try include_dir.appendZigProcessFlags(b, &argv_list, step);
     }
 
     for (translate_c.c_macros.items) |c_macro| {


### PR DESCRIPTION
`addIncludeDir` takes a string slice, and does not support LazyPath and other include dir params. To match with `Build.Module` and `Build.Step.Compile`, i've adapted the following definitions to TranslateC

- `addAfterIncludePath`
- `addSystemIncludePath`
- `addIncludePath` (changed from "dir" to "path" to match other apis)
- `addConfigHeader`
- `addSystemFrameworkPath`
- `addFrameworkPath`

possible solution for #20649, though motivated by my need to use addIncludePath but it taking a slice.

i haven't thoroughly tested these besides `addIncludePath` in my own project. i am assuming translate-c supports the same set of flags that `build-*` supports, and that the existing code for passing the flags works.