### PR TITLE
start code: implement __init_array_start, __init_array_end

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -435,6 +435,22 @@ fn posixCallMainAndExit(argc_argv_ptr: [*]usize) callconv(.C) noreturn {
         // Here we look for the stack size in our program headers and use setrlimit
         // to ask for more stack space.
         expandStackSize(phdrs);
+
+        {
+            const opt_init_array_start = @extern([*]*const fn () callconv(.C) void, .{
+                .name = "__init_array_start",
+                .linkage = .weak,
+            });
+            const opt_init_array_end = @extern([*]*const fn () callconv(.C) void, .{
+                .name = "__init_array_end",
+                .linkage = .weak,
+            });
+            if (opt_init_array_start) |init_array_start| {
+                const init_array_end = opt_init_array_end.?;
+                const slice = init_array_start[0 .. init_array_end - init_array_start];
+                for (slice) |func| func();
+            }
+        }
     }
 
     std.posix.exit(callMainWithArgs(argc, argv, envp));

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -436,7 +436,8 @@ fn posixCallMainAndExit(argc_argv_ptr: [*]usize) callconv(.C) noreturn {
         // to ask for more stack space.
         expandStackSize(phdrs);
 
-        {
+        // Disabled with the riscv backend because it cannot handle this code yet.
+        if (builtin.zig_backend != .stage2_riscv64) {
             const opt_init_array_start = @extern([*]*const fn () callconv(.C) void, .{
                 .name = "__init_array_start",
                 .linkage = .weak,


### PR DESCRIPTION
Tested by observing `__sanitizer_cov_8bit_counters_init` and `__sanitizer_cov_pcs_init` being called in a libc-less build.