### PR TITLE
`c`: Handle armeb and thumbeb in clone().

### DIFF
--- a/lib/c.zig
+++ b/lib/c.zig
@@ -289,7 +289,7 @@ fn clone() callconv(.Naked) void {
                 \\      svc #0
             );
         },
-        .arm, .thumb => {
+        .arm, .armeb, .thumb, .thumbeb => {
             // __clone(func, stack, flags, arg, ptid, tls, ctid)
             //           r0,    r1,    r2,  r3,   +0,  +4,   +8
 


### PR DESCRIPTION
Accidentally deleted #20809 earlier. :facepalm: