### PR TITLE
langref: Make pointer_coerce_const_optional test less obfuscated

### DIFF
--- a/doc/langref/test_pointer_coerce_const_optional.zig
+++ b/doc/langref/test_pointer_coerce_const_optional.zig
@@ -2,10 +2,10 @@ const std = @import("std");
 const expect = std.testing.expect;
 const mem = std.mem;
 
-test "cast *[1][*]const u8 to [*]const ?[*]const u8" {
-    const window_name = [1][*]const u8{"window name"};
-    const x: [*]const ?[*]const u8 = &window_name;
-    try expect(mem.eql(u8, std.mem.sliceTo(@as([*:0]const u8, @ptrCast(x[0].?)), 0), "window name"));
+test "cast *[1][*:0]const u8 to []const ?[*:0]const u8" {
+    const window_name = [1][*:0]const u8{"window name"};
+    const x: []const ?[*:0]const u8 = &window_name;
+    try expect(mem.eql(u8, mem.span(x[0].?), "window name"));
 }
 
 // test


### PR DESCRIPTION
This test was originally introduced in 5f38d6e2e97829ed74f06a96b5d07a2c68516063, where it looked like this:

```zig
test "cast *[1][*]const u8 to [*]const ?[*]const u8" {
    const window_name = [1][*]const u8{c"window name"};
    const x: [*]const ?[*]const u8 = &window_name;
    assert(mem.eql(u8, std.cstr.toSliceConst(x[0].?), "window name"));
}
```

Over the years, this has become more and more obfuscated, to the point that the verbosity of the `expect` call overshadows the point of the example. This commit intends to update this test to match the spirit of the original version of the test, while shedding the obfuscation.