### PR TITLE
Fix compile error due to GetModuleFileNameW binding change

### DIFF
--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -585,7 +585,7 @@ pub extern "kernel32" fn GetProcessHeap() callconv(WINAPI) ?HANDLE;
 // TODO: Wrapper around LdrGetDllFullName.
 pub extern "kernel32" fn GetModuleFileNameW(
     hModule: ?HMODULE,
-    lpFilename: LPWSTR,
+    lpFilename: [*]WCHAR,
     nSize: DWORD,
 ) callconv(WINAPI) DWORD;
 


### PR DESCRIPTION
In https://github.com/ziglang/zig/pull/19641 (cc @The-King-of-Toasters), this binding changed from `[*]u16` to `LPWSTR` which made it a sentinel-terminated pointer. This introduced a compile error in the `std.os.windows.GetModuleFileNameW` wrapper since it takes a `[*]u16` pointer. This commit changes the binding back to what it was before instead of introducing a breaking change to `std.os.windows.GetModuleFileNameW`

Related: https://github.com/ziglang/zig/issues/20858

---

Note: Neither `std.os.windows.kernel32.GetModuleFileNameW` nor `std.os.windows.GetModuleFileNameW` is used by Zig internally (instead, `std.os.windows.kernel32.GetModuleFileNameExW` is used in `std.debug`). So an alternate fix here might be to just delete the binding and the wrapper in `std.os.windows`.