### PR TITLE
Add getppid to std.c and std.os.linux.

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -9351,6 +9351,7 @@ pub extern "c" fn setlogmask(maskpri: c_int) c_int;
 pub extern "c" fn if_nametoindex([*:0]const u8) c_int;
 
 pub extern "c" fn getpid() pid_t;
+pub extern "c" fn getppid() pid_t;
 
 /// These are implementation defined but share identical values in at least musl and glibc:
 /// - https://git.musl-libc.org/cgit/musl/tree/include/locale.h?id=ab31e9d6a0fa7c5c408856c89df2dfb12c344039#n18

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1579,6 +1579,10 @@ pub fn getpid() pid_t {
     return @bitCast(@as(u32, @truncate(syscall0(.getpid))));
 }
 
+pub fn getppid() pid_t {
+    return @bitCast(@as(u32, @truncate(syscall0(.getppid))));
+}
+
 pub fn gettid() pid_t {
     return @bitCast(@as(u32, @truncate(syscall0(.gettid))));
 }

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -32,6 +32,10 @@ test "getpid" {
     try expect(linux.getpid() != 0);
 }
 
+test "getppid" {
+    try expect(linux.getppid() != 0);
+}
+
 test "timer" {
     const epoll_fd = linux.epoll_create();
     var err: linux.E = linux.E.init(epoll_fd);


### PR DESCRIPTION
The std lib is missing getppid, this patch adds it.