### PR TITLE
start: Initialize `gp` to `__global_pointer$` on riscv.

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -273,6 +273,14 @@ fn _start() callconv(.Naked) noreturn {
             \\ b %[posixCallMainAndExit]
             ,
             .riscv32, .riscv64 =>
+            // The RISC-V ELF ABI assumes that `gp` is set to the value of `__global_pointer$` at
+            // startup in order for GP relaxation to work, even in static builds.
+            \\ .weak __global_pointer$
+            \\ .hidden __global_pointer$
+            \\ .option push
+            \\ .option norelax
+            \\ lla gp, __global_pointer$
+            \\ .option pop
             \\ li s0, 0
             \\ li ra, 0
             \\ mv a0, sp

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -272,21 +272,27 @@ fn _start() callconv(.Naked) noreturn {
             \\ bstrins.d $sp, $zero, 3, 0
             \\ b %[posixCallMainAndExit]
             ,
+            // zig fmt: off
             .riscv32, .riscv64 =>
-            // The RISC-V ELF ABI assumes that `gp` is set to the value of `__global_pointer$` at
-            // startup in order for GP relaxation to work, even in static builds.
-            \\ .weak __global_pointer$
-            \\ .hidden __global_pointer$
-            \\ .option push
-            \\ .option norelax
-            \\ lla gp, __global_pointer$
-            \\ .option pop
+            // The self-hosted riscv64 backend is not able to assemble this yet.
+            if (builtin.zig_backend != .stage2_riscv64)
+                // The RISC-V ELF ABI assumes that `gp` is set to the value of `__global_pointer$` at
+                // startup in order for GP relaxation to work, even in static builds.
+                \\ .weak __global_pointer$
+                \\ .hidden __global_pointer$
+                \\ .option push
+                \\ .option norelax
+                \\ lla gp, __global_pointer$
+                \\ .option pop
+            else ""
+            ++
             \\ li s0, 0
             \\ li ra, 0
             \\ mv a0, sp
             \\ andi sp, sp, -16
             \\ tail %[posixCallMainAndExit]@plt
             ,
+            // zig fmt: off
             .m68k =>
             // Note that the - 8 is needed because pc in the jsr instruction points into the middle
             // of the jsr instruction. (The lea is 6 bytes, the jsr is 4 bytes.)

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -293,6 +293,7 @@ fn _start() callconv(.Naked) noreturn {
             \\ .gpword .
             \\ .gpword %[posixCallMainAndExit]
             \\ 1:
+            // The `gp` register on MIPS serves a similar purpose to `r2` (ToC pointer) on PPC64.
             \\ lw $gp, 0($ra)
             \\ subu $gp, $ra, $gp
             \\ lw $25, 4($ra)
@@ -314,8 +315,6 @@ fn _start() callconv(.Naked) noreturn {
             \\ .gpdword %[posixCallMainAndExit]
             \\ 1:
             // The `gp` register on MIPS serves a similar purpose to `r2` (ToC pointer) on PPC64.
-            // We need to set it up in order for dynamically-linked / position-independent code to
-            // work.
             \\ ld $gp, 0($ra)
             \\ dsubu $gp, $ra, $gp
             \\ ld $25, 8($ra)


### PR DESCRIPTION
https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#calculation-symbols