### PR TITLE
elf: clean up resource ownership in the linker

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -5472,11 +5472,6 @@ pub fn getOrPutGlobal(self: *Elf, name: []const u8) !GetOrPutGlobalResult {
     };
 }
 
-pub fn globalByName(self: *Elf, name: []const u8) ?Symbol.Index {
-    const name_off = self.strings.getOffset(name) orelse return null;
-    return self.resolver.get(name_off);
-}
-
 pub fn getGlobalSymbol(self: *Elf, name: []const u8, lib_name: ?[]const u8) !u32 {
     return self.zigObjectPtr().?.getGlobalSymbol(self, name, lib_name);
 }

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1372,7 +1372,7 @@ pub fn flushModule(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_nod
         for (zo.atoms_indexes.items) |atom_index| {
             const atom_ptr = zo.atom(atom_index) orelse continue;
             if (!atom_ptr.alive) continue;
-            const out_shndx = atom_ptr.outputShndx() orelse continue;
+            const out_shndx = atom_ptr.output_section_index;
             const shdr = &self.shdrs.items[out_shndx];
             if (shdr.sh_type == elf.SHT_NOBITS) continue;
             const code = try zo.codeAlloc(self, atom_index);

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1371,7 +1371,7 @@ pub fn flushModule(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_nod
         var has_reloc_errors = false;
         for (zo.atoms_indexes.items) |atom_index| {
             const atom_ptr = zo.atom(atom_index) orelse continue;
-            if (!atom_ptr.flags.alive) continue;
+            if (!atom_ptr.alive) continue;
             const out_shndx = atom_ptr.outputShndx() orelse continue;
             const shdr = &self.shdrs.items[out_shndx];
             if (shdr.sh_type == elf.SHT_NOBITS) continue;
@@ -4130,7 +4130,7 @@ fn resetShdrIndexes(self: *Elf, backlinks: []const u32) !void {
         for (zo.globals()) |global_index| {
             const global = self.symbol(global_index);
             const atom_ptr = global.atom(self) orelse continue;
-            if (!atom_ptr.flags.alive) continue;
+            if (!atom_ptr.alive) continue;
             // TODO claim unresolved for objects
             if (global.file(self).?.index() != zo.index) continue;
             const out_shndx = global.outputShndx() orelse continue;
@@ -4157,7 +4157,7 @@ fn updateSectionSizes(self: *Elf) !void {
         if (self.requiresThunks() and shdr.sh_flags & elf.SHF_EXECINSTR != 0) continue;
         for (atom_list.items) |ref| {
             const atom_ptr = self.atom(ref) orelse continue;
-            if (!atom_ptr.flags.alive) continue;
+            if (!atom_ptr.alive) continue;
             const offset = atom_ptr.alignment.forward(shdr.sh_size);
             const padding = offset - shdr.sh_size;
             atom_ptr.value = @intCast(offset);
@@ -4641,7 +4641,7 @@ fn writeAtoms(self: *Elf) !void {
 
         for (atom_list.items) |ref| {
             const atom_ptr = self.atom(ref).?;
-            assert(atom_ptr.flags.alive);
+            assert(atom_ptr.alive);
 
             const offset = math.cast(usize, atom_ptr.value - @as(i64, @intCast(base_offset))) orelse
                 return error.Overflow;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -4121,21 +4121,6 @@ fn resetShdrIndexes(self: *Elf, backlinks: []const u32) !void {
             const atom_ptr = zo.atom(atom_index) orelse continue;
             atom_ptr.output_section_index = backlinks[atom_ptr.output_section_index];
         }
-
-        for (zo.locals()) |local_index| {
-            const local = self.symbol(local_index);
-            local.output_section_index = backlinks[local.output_section_index];
-        }
-
-        for (zo.globals()) |global_index| {
-            const global = self.symbol(global_index);
-            const atom_ptr = global.atom(self) orelse continue;
-            if (!atom_ptr.alive) continue;
-            // TODO claim unresolved for objects
-            if (global.file(self).?.index() != zo.index) continue;
-            const out_shndx = global.outputShndx() orelse continue;
-            global.output_section_index = backlinks[out_shndx];
-        }
     }
 
     for (self.output_rela_sections.keys(), self.output_rela_sections.values()) |shndx, sec| {

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -337,12 +337,9 @@ pub fn writeRelocs(self: Atom, elf_file: *Elf, out_relocs: *std.ArrayList(elf.El
         var r_addend = rel.r_addend;
         var r_sym: u32 = 0;
         switch (target.type(elf_file)) {
-            elf.STT_SECTION => if (target.mergeSubsection(elf_file)) |msub| {
+            elf.STT_SECTION => {
                 r_addend += @intCast(target.address(.{}, elf_file));
-                r_sym = elf_file.sectionSymbolOutputSymtabIndex(msub.mergeSection(elf_file).output_section_index);
-            } else {
-                r_addend += @intCast(target.address(.{}, elf_file));
-                r_sym = if (target.outputShndx()) |osec|
+                r_sym = if (target.outputShndx(elf_file)) |osec|
                     elf_file.sectionSymbolOutputSymtabIndex(osec)
                 else
                     0;

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -40,7 +40,7 @@ extra_index: u32 = 0,
 
 pub const Alignment = @import("../../InternPool.zig").Alignment;
 
-pub fn name(self: Atom, elf_file: *Elf) []const u8 {
+pub fn name(self: Atom, elf_file: *Elf) [:0]const u8 {
     const file_ptr = self.file(elf_file).?;
     return switch (file_ptr) {
         inline else => |x| x.getString(self.name_offset),

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -346,7 +346,10 @@ pub fn writeRelocs(self: Atom, elf_file: *Elf, out_relocs: *std.ArrayList(elf.El
                 r_sym = elf_file.sectionSymbolOutputSymtabIndex(msub.mergeSection(elf_file).output_section_index);
             } else {
                 r_addend += @intCast(target.address(.{}, elf_file));
-                r_sym = elf_file.sectionSymbolOutputSymtabIndex(target.outputShndx().?);
+                r_sym = if (target.outputShndx()) |osec|
+                    elf_file.sectionSymbolOutputSymtabIndex(osec)
+                else
+                    0;
             },
             else => {
                 r_sym = target.outputSymtabIndex(elf_file) orelse 0;

--- a/src/link/Elf/LinkerDefined.zig
+++ b/src/link/Elf/LinkerDefined.zig
@@ -4,12 +4,31 @@ symtab: std.ArrayListUnmanaged(elf.Elf64_Sym) = .{},
 strtab: std.ArrayListUnmanaged(u8) = .{},
 symbols: std.ArrayListUnmanaged(Symbol.Index) = .{},
 
+dynamic_index: ?Symbol.Index = null,
+ehdr_start_index: ?Symbol.Index = null,
+init_array_start_index: ?Symbol.Index = null,
+init_array_end_index: ?Symbol.Index = null,
+fini_array_start_index: ?Symbol.Index = null,
+fini_array_end_index: ?Symbol.Index = null,
+preinit_array_start_index: ?Symbol.Index = null,
+preinit_array_end_index: ?Symbol.Index = null,
+got_index: ?Symbol.Index = null,
+plt_index: ?Symbol.Index = null,
+end_index: ?Symbol.Index = null,
+gnu_eh_frame_hdr_index: ?Symbol.Index = null,
+dso_handle_index: ?Symbol.Index = null,
+rela_iplt_start_index: ?Symbol.Index = null,
+rela_iplt_end_index: ?Symbol.Index = null,
+global_pointer_index: ?Symbol.Index = null,
+start_stop_indexes: std.ArrayListUnmanaged(u32) = .{},
+
 output_symtab_ctx: Elf.SymtabCtx = .{},
 
 pub fn deinit(self: *LinkerDefined, allocator: Allocator) void {
     self.symtab.deinit(allocator);
     self.strtab.deinit(allocator);
     self.symbols.deinit(allocator);
+    self.start_stop_indexes.deinit(allocator);
 }
 
 pub fn init(self: *LinkerDefined, allocator: Allocator) !void {
@@ -17,7 +36,55 @@ pub fn init(self: *LinkerDefined, allocator: Allocator) !void {
     try self.strtab.append(allocator, 0);
 }
 
-pub fn addGlobal(self: *LinkerDefined, name: [:0]const u8, elf_file: *Elf) !u32 {
+pub fn initSymbols(self: *LinkerDefined, elf_file: *Elf) !void {
+    const gpa = elf_file.base.comp.gpa;
+
+    self.dynamic_index = try self.addGlobal("_DYNAMIC", elf_file);
+    self.ehdr_start_index = try self.addGlobal("__ehdr_start", elf_file);
+    self.init_array_start_index = try self.addGlobal("__init_array_start", elf_file);
+    self.init_array_end_index = try self.addGlobal("__init_array_end", elf_file);
+    self.fini_array_start_index = try self.addGlobal("__fini_array_start", elf_file);
+    self.fini_array_end_index = try self.addGlobal("__fini_array_end", elf_file);
+    self.preinit_array_start_index = try self.addGlobal("__preinit_array_start", elf_file);
+    self.preinit_array_end_index = try self.addGlobal("__preinit_array_end", elf_file);
+    self.got_index = try self.addGlobal("_GLOBAL_OFFSET_TABLE_", elf_file);
+    self.plt_index = try self.addGlobal("_PROCEDURE_LINKAGE_TABLE_", elf_file);
+    self.end_index = try self.addGlobal("_end", elf_file);
+
+    if (elf_file.base.comp.link_eh_frame_hdr) {
+        self.gnu_eh_frame_hdr_index = try self.addGlobal("__GNU_EH_FRAME_HDR", elf_file);
+    }
+
+    if (elf_file.globalByName("__dso_handle")) |index| {
+        if (elf_file.symbol(index).file(elf_file) == null)
+            self.dso_handle_index = try self.addGlobal("__dso_handle", elf_file);
+    }
+
+    self.rela_iplt_start_index = try self.addGlobal("__rela_iplt_start", elf_file);
+    self.rela_iplt_end_index = try self.addGlobal("__rela_iplt_end", elf_file);
+
+    for (elf_file.shdrs.items) |shdr| {
+        if (elf_file.getStartStopBasename(shdr)) |name| {
+            try self.start_stop_indexes.ensureUnusedCapacity(gpa, 2);
+
+            const start = try std.fmt.allocPrintZ(gpa, "__start_{s}", .{name});
+            defer gpa.free(start);
+            const stop = try std.fmt.allocPrintZ(gpa, "__stop_{s}", .{name});
+            defer gpa.free(stop);
+
+            self.start_stop_indexes.appendAssumeCapacity(try self.addGlobal(start, elf_file));
+            self.start_stop_indexes.appendAssumeCapacity(try self.addGlobal(stop, elf_file));
+        }
+    }
+
+    if (elf_file.getTarget().cpu.arch.isRISCV() and elf_file.isEffectivelyDynLib()) {
+        self.global_pointer_index = try self.addGlobal("__global_pointer$", elf_file);
+    }
+
+    self.resolveSymbols(elf_file);
+}
+
+fn addGlobal(self: *LinkerDefined, name: [:0]const u8, elf_file: *Elf) !u32 {
     const comp = elf_file.base.comp;
     const gpa = comp.gpa;
     try self.symtab.ensureUnusedCapacity(gpa, 1);
@@ -51,6 +118,154 @@ pub fn resolveSymbols(self: *LinkerDefined, elf_file: *Elf) void {
             global.file_index = self.index;
             global.esym_index = sym_idx;
             global.version_index = elf_file.default_sym_version;
+        }
+    }
+}
+
+pub fn allocateSymbols(self: *LinkerDefined, elf_file: *Elf) void {
+    const comp = elf_file.base.comp;
+    const link_mode = comp.config.link_mode;
+
+    // _DYNAMIC
+    if (elf_file.dynamic_section_index) |shndx| {
+        const shdr = &elf_file.shdrs.items[shndx];
+        const symbol_ptr = elf_file.symbol(self.dynamic_index.?);
+        symbol_ptr.value = @intCast(shdr.sh_addr);
+        symbol_ptr.output_section_index = shndx;
+    }
+
+    // __ehdr_start
+    {
+        const symbol_ptr = elf_file.symbol(self.ehdr_start_index.?);
+        symbol_ptr.value = @intCast(elf_file.image_base);
+        symbol_ptr.output_section_index = 1;
+    }
+
+    // __init_array_start, __init_array_end
+    if (elf_file.sectionByName(".init_array")) |shndx| {
+        const start_sym = elf_file.symbol(self.init_array_start_index.?);
+        const end_sym = elf_file.symbol(self.init_array_end_index.?);
+        const shdr = &elf_file.shdrs.items[shndx];
+        start_sym.output_section_index = shndx;
+        start_sym.value = @intCast(shdr.sh_addr);
+        end_sym.output_section_index = shndx;
+        end_sym.value = @intCast(shdr.sh_addr + shdr.sh_size);
+    }
+
+    // __fini_array_start, __fini_array_end
+    if (elf_file.sectionByName(".fini_array")) |shndx| {
+        const start_sym = elf_file.symbol(self.fini_array_start_index.?);
+        const end_sym = elf_file.symbol(self.fini_array_end_index.?);
+        const shdr = &elf_file.shdrs.items[shndx];
+        start_sym.output_section_index = shndx;
+        start_sym.value = @intCast(shdr.sh_addr);
+        end_sym.output_section_index = shndx;
+        end_sym.value = @intCast(shdr.sh_addr + shdr.sh_size);
+    }
+
+    // __preinit_array_start, __preinit_array_end
+    if (elf_file.sectionByName(".preinit_array")) |shndx| {
+        const start_sym = elf_file.symbol(self.preinit_array_start_index.?);
+        const end_sym = elf_file.symbol(self.preinit_array_end_index.?);
+        const shdr = &elf_file.shdrs.items[shndx];
+        start_sym.output_section_index = shndx;
+        start_sym.value = @intCast(shdr.sh_addr);
+        end_sym.output_section_index = shndx;
+        end_sym.value = @intCast(shdr.sh_addr + shdr.sh_size);
+    }
+
+    // _GLOBAL_OFFSET_TABLE_
+    if (elf_file.getTarget().cpu.arch == .x86_64) {
+        if (elf_file.got_plt_section_index) |shndx| {
+            const shdr = elf_file.shdrs.items[shndx];
+            const sym = elf_file.symbol(self.got_index.?);
+            sym.value = @intCast(shdr.sh_addr);
+            sym.output_section_index = shndx;
+        }
+    } else {
+        if (elf_file.got_section_index) |shndx| {
+            const shdr = elf_file.shdrs.items[shndx];
+            const sym = elf_file.symbol(self.got_index.?);
+            sym.value = @intCast(shdr.sh_addr);
+            sym.output_section_index = shndx;
+        }
+    }
+
+    // _PROCEDURE_LINKAGE_TABLE_
+    if (elf_file.plt_section_index) |shndx| {
+        const shdr = &elf_file.shdrs.items[shndx];
+        const symbol_ptr = elf_file.symbol(self.plt_index.?);
+        symbol_ptr.value = @intCast(shdr.sh_addr);
+        symbol_ptr.output_section_index = shndx;
+    }
+
+    // __dso_handle
+    if (self.dso_handle_index) |index| {
+        const shdr = &elf_file.shdrs.items[1];
+        const symbol_ptr = elf_file.symbol(index);
+        symbol_ptr.value = @intCast(shdr.sh_addr);
+        symbol_ptr.output_section_index = 0;
+    }
+
+    // __GNU_EH_FRAME_HDR
+    if (elf_file.eh_frame_hdr_section_index) |shndx| {
+        const shdr = &elf_file.shdrs.items[shndx];
+        const symbol_ptr = elf_file.symbol(self.gnu_eh_frame_hdr_index.?);
+        symbol_ptr.value = @intCast(shdr.sh_addr);
+        symbol_ptr.output_section_index = shndx;
+    }
+
+    // __rela_iplt_start, __rela_iplt_end
+    if (elf_file.rela_dyn_section_index) |shndx| blk: {
+        if (link_mode != .static or comp.config.pie) break :blk;
+        const shdr = &elf_file.shdrs.items[shndx];
+        const end_addr = shdr.sh_addr + shdr.sh_size;
+        const start_addr = end_addr - elf_file.calcNumIRelativeRelocs() * @sizeOf(elf.Elf64_Rela);
+        const start_sym = elf_file.symbol(self.rela_iplt_start_index.?);
+        const end_sym = elf_file.symbol(self.rela_iplt_end_index.?);
+        start_sym.value = @intCast(start_addr);
+        start_sym.output_section_index = shndx;
+        end_sym.value = @intCast(end_addr);
+        end_sym.output_section_index = shndx;
+    }
+
+    // _end
+    {
+        const end_symbol = elf_file.symbol(self.end_index.?);
+        for (elf_file.shdrs.items, 0..) |shdr, shndx| {
+            if (shdr.sh_flags & elf.SHF_ALLOC != 0) {
+                end_symbol.value = @intCast(shdr.sh_addr + shdr.sh_size);
+                end_symbol.output_section_index = @intCast(shndx);
+            }
+        }
+    }
+
+    // __start_*, __stop_*
+    {
+        var index: usize = 0;
+        while (index < self.start_stop_indexes.items.len) : (index += 2) {
+            const start = elf_file.symbol(self.start_stop_indexes.items[index]);
+            const name = start.name(elf_file);
+            const stop = elf_file.symbol(self.start_stop_indexes.items[index + 1]);
+            const shndx = elf_file.sectionByName(name["__start_".len..]).?;
+            const shdr = &elf_file.shdrs.items[shndx];
+            start.value = @intCast(shdr.sh_addr);
+            start.output_section_index = shndx;
+            stop.value = @intCast(shdr.sh_addr + shdr.sh_size);
+            stop.output_section_index = shndx;
+        }
+    }
+
+    // __global_pointer$
+    if (self.global_pointer_index) |index| {
+        const sym = elf_file.symbol(index);
+        if (elf_file.sectionByName(".sdata")) |shndx| {
+            const shdr = elf_file.shdrs.items[shndx];
+            sym.value = @intCast(shdr.sh_addr + 0x800);
+            sym.output_section_index = shndx;
+        } else {
+            sym.value = 0;
+            sym.output_section_index = 0;
         }
     }
 }

--- a/src/link/Elf/LinkerDefined.zig
+++ b/src/link/Elf/LinkerDefined.zig
@@ -47,7 +47,7 @@ pub fn resolveSymbols(self: *LinkerDefined, elf_file: *Elf) void {
         const global = elf_file.symbol(index);
         if (self.asFile().symbolRank(this_sym, false) < global.symbolRank(elf_file)) {
             global.value = 0;
-            global.atom_ref = .{ .index = 0, .file = 0 };
+            global.ref = .{ .index = 0, .file = 0 };
             global.file_index = self.index;
             global.esym_index = sym_idx;
             global.version_index = elf_file.default_sym_version;

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -1036,12 +1036,12 @@ pub fn addAtomsToRelaSections(self: *Object, elf_file: *Elf) !void {
             break :blk self.initOutputSection(elf_file, shdr) catch unreachable;
         };
         const shdr = &elf_file.shdrs.items[shndx];
-        shdr.sh_info = atom_ptr.outputShndx().?;
+        shdr.sh_info = atom_ptr.output_section_index;
         shdr.sh_link = elf_file.symtab_section_index.?;
 
         const comp = elf_file.base.comp;
         const gpa = comp.gpa;
-        const gop = try elf_file.output_rela_sections.getOrPut(gpa, atom_ptr.outputShndx().?);
+        const gop = try elf_file.output_rela_sections.getOrPut(gpa, atom_ptr.output_section_index);
         if (!gop.found_existing) gop.value_ptr.* = .{ .shndx = shndx };
         try gop.value_ptr.atom_list.append(gpa, .{ .index = atom_index, .file = self.index });
     }

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -208,9 +208,9 @@ fn initAtoms(self: *Object, allocator: Allocator, handle: std.fs.File, elf_file:
                 const group_signature = blk: {
                     if (group_info_sym.st_name == 0 and group_info_sym.st_type() == elf.STT_SECTION) {
                         const sym_shdr = shdrs[group_info_sym.st_shndx];
-                        break :blk self.getString(sym_shdr.sh_name);
+                        break :blk sym_shdr.sh_name;
                     }
-                    break :blk self.getString(group_info_sym.st_name);
+                    break :blk group_info_sym.st_name;
                 };
 
                 const shndx = @as(u32, @intCast(i));
@@ -228,7 +228,10 @@ fn initAtoms(self: *Object, allocator: Allocator, handle: std.fs.File, elf_file:
                 const group_start = @as(u32, @intCast(self.comdat_group_data.items.len));
                 try self.comdat_group_data.appendUnalignedSlice(allocator, group_members[1..]);
 
-                const gop = try elf_file.getOrCreateComdatGroupOwner(group_signature);
+                const gop = try elf_file.getOrCreateComdatGroupOwner(.{
+                    .off = group_signature,
+                    .file_index = self.index,
+                });
                 const comdat_group_index = try self.addComdatGroup(allocator);
                 const comdat_group = self.comdatGroup(comdat_group_index);
                 comdat_group.* = .{

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -354,7 +354,7 @@ fn initOutputSection(self: Object, elf_file: *Elf, shdr: elf.Elf64_Shdr) error{O
     const out_shndx = elf_file.sectionByName(name) orelse try elf_file.addSection(.{
         .type = @"type",
         .flags = flags,
-        .name = name,
+        .name = try elf_file.insertShString(name),
     });
     return out_shndx;
 }

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -978,38 +978,6 @@ pub fn addAtomsToOutputSections(self: *Object, elf_file: *Elf) !void {
         if (!gop.found_existing) gop.value_ptr.* = .{};
         try gop.value_ptr.append(gpa, .{ .index = atom_index, .file = self.index });
     }
-
-    for (self.locals()) |local_index| {
-        const local = elf_file.symbol(local_index);
-        if (local.mergeSubsection(elf_file)) |msub| {
-            if (!msub.alive) continue;
-            local.output_section_index = msub.mergeSection(elf_file).output_section_index;
-            continue;
-        }
-        const atom_ptr = local.atom(elf_file) orelse continue;
-        if (!atom_ptr.alive) continue;
-        local.output_section_index = atom_ptr.output_section_index;
-    }
-
-    for (self.globals()) |global_index| {
-        const global = elf_file.symbol(global_index);
-        if (global.file(elf_file).?.index() != self.index) continue;
-        if (global.mergeSubsection(elf_file)) |msub| {
-            if (!msub.alive) continue;
-            global.output_section_index = msub.mergeSection(elf_file).output_section_index;
-            continue;
-        }
-        const atom_ptr = global.atom(elf_file) orelse continue;
-        if (!atom_ptr.alive) continue;
-        global.output_section_index = atom_ptr.output_section_index;
-    }
-
-    for (self.symbols.items[self.symtab.items.len..]) |local_index| {
-        const local = elf_file.symbol(local_index);
-        const msub = local.mergeSubsection(elf_file).?;
-        if (!msub.alive) continue;
-        local.output_section_index = msub.mergeSection(elf_file).output_section_index;
-    }
 }
 
 pub fn initRelaSections(self: *Object, elf_file: *Elf) !void {

--- a/src/link/Elf/SharedObject.zig
+++ b/src/link/Elf/SharedObject.zig
@@ -232,7 +232,7 @@ pub fn resolveSymbols(self: *SharedObject, elf_file: *Elf) void {
         const global = elf_file.symbol(index);
         if (self.asFile().symbolRank(this_sym, false) < global.symbolRank(elf_file)) {
             global.value = @intCast(this_sym.st_value);
-            global.atom_index = 0;
+            global.atom_ref = .{ .index = 0, .file = 0 };
             global.esym_index = esym_index;
             global.version_index = self.versyms.items[esym_index];
             global.file_index = self.index;

--- a/src/link/Elf/SharedObject.zig
+++ b/src/link/Elf/SharedObject.zig
@@ -232,7 +232,7 @@ pub fn resolveSymbols(self: *SharedObject, elf_file: *Elf) void {
         const global = elf_file.symbol(index);
         if (self.asFile().symbolRank(this_sym, false) < global.symbolRank(elf_file)) {
             global.value = @intCast(this_sym.st_value);
-            global.atom_ref = .{ .index = 0, .file = 0 };
+            global.ref = .{ .index = 0, .file = 0 };
             global.esym_index = esym_index;
             global.version_index = self.versyms.items[esym_index];
             global.file_index = self.index;

--- a/src/link/Elf/Symbol.zig
+++ b/src/link/Elf/Symbol.zig
@@ -116,7 +116,7 @@ pub fn address(symbol: Symbol, opts: struct { plt: bool = true }, elf_file: *Elf
         return symbol.pltAddress(elf_file);
     }
     if (symbol.atom(elf_file)) |atom_ptr| {
-        if (!atom_ptr.flags.alive) {
+        if (!atom_ptr.alive) {
             if (mem.eql(u8, atom_ptr.name(elf_file), ".eh_frame")) {
                 const sym_name = symbol.name(elf_file);
                 const sh_addr, const sh_size = blk: {

--- a/src/link/Elf/Symbol.zig
+++ b/src/link/Elf/Symbol.zig
@@ -9,10 +9,9 @@ name_offset: u32 = 0,
 /// Index of file where this symbol is defined.
 file_index: File.Index = 0,
 
-/// Index of atom containing this symbol.
-/// Index of 0 means there is no associated atom with this symbol.
+/// Reference to Atom containing this symbol if any.
 /// Use `atom` to get the pointer to the atom.
-atom_index: Atom.Index = 0,
+atom_ref: Elf.Ref = .{ .index = 0, .file = 0 },
 
 /// Assigned output section index for this symbol.
 output_section_index: u32 = 0,
@@ -68,7 +67,8 @@ pub fn name(symbol: Symbol, elf_file: *Elf) [:0]const u8 {
 }
 
 pub fn atom(symbol: Symbol, elf_file: *Elf) ?*Atom {
-    return elf_file.atom(symbol.atom_index);
+    const file_ptr = elf_file.file(symbol.atom_ref.file) orelse return null;
+    return file_ptr.atom(symbol.atom_ref.index);
 }
 
 pub fn mergeSubsection(symbol: Symbol, elf_file: *Elf) ?*MergeSubsection {

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -912,12 +912,13 @@ fn updateDeclCode(
     const sym = elf_file.symbol(sym_index);
     const esym = &self.local_esyms.items(.elf_sym)[sym.esym_index];
     const atom_ptr = sym.atom(elf_file).?;
+    const name_offset = try self.strtab.insert(gpa, decl.fqn.toSlice(ip));
 
     atom_ptr.alive = true;
-    atom_ptr.name_offset = sym.name_offset;
+    atom_ptr.name_offset = name_offset;
     atom_ptr.output_section_index = shdr_index;
-    sym.name_offset = try self.strtab.insert(gpa, decl.fqn.toSlice(ip));
-    esym.st_name = sym.name_offset;
+    sym.name_offset = name_offset;
+    esym.st_name = name_offset;
     esym.st_info |= stt_bits;
     esym.st_size = code.len;
 
@@ -1009,15 +1010,17 @@ fn updateTlv(
     const sym = elf_file.symbol(sym_index);
     const esym = &self.local_esyms.items(.elf_sym)[sym.esym_index];
     const atom_ptr = sym.atom(elf_file).?;
+    const name_offset = try self.strtab.insert(gpa, decl.fqn.toSlice(ip));
 
     sym.value = 0;
-    atom_ptr.output_section_index = shndx;
+    sym.name_offset = name_offset;
 
-    sym.name_offset = try self.strtab.insert(gpa, decl.fqn.toSlice(ip));
+    atom_ptr.output_section_index = shndx;
     atom_ptr.alive = true;
-    atom_ptr.name_offset = sym.name_offset;
+    atom_ptr.name_offset = name_offset;
+
     esym.st_value = 0;
-    esym.st_name = sym.name_offset;
+    esym.st_name = name_offset;
     esym.st_info = elf.STT_TLS;
     esym.st_size = code.len;
 

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -291,7 +291,7 @@ pub fn newAtom(self: *ZigObject, elf_file: *Elf) !Symbol.Index {
 
     const symbol_ptr = elf_file.symbol(symbol_index);
     symbol_ptr.file_index = self.index;
-    symbol_ptr.atom_ref = .{ .index = atom_index, .file = self.index };
+    symbol_ptr.ref = .{ .index = atom_index, .file = self.index };
 
     self.local_esyms.items(.shndx)[esym_index] = atom_index;
     self.local_esyms.items(.elf_sym)[esym_index].st_shndx = SHN_ATOM;
@@ -342,7 +342,7 @@ pub fn resolveSymbols(self: *ZigObject, elf_file: *Elf) void {
                 else => unreachable,
             };
             global.value = @intCast(esym.st_value);
-            global.atom_ref = .{ .index = atom_index, .file = self.index };
+            global.ref = .{ .index = atom_index, .file = self.index };
             global.esym_index = esym_index;
             global.file_index = self.index;
             global.version_index = elf_file.default_sym_version;
@@ -371,7 +371,7 @@ pub fn claimUnresolved(self: ZigObject, elf_file: *Elf) void {
         };
 
         global.value = 0;
-        global.atom_ref = .{ .index = 0, .file = 0 };
+        global.ref = .{ .index = 0, .file = 0 };
         global.esym_index = esym_index;
         global.file_index = self.index;
         global.version_index = if (is_import) elf.VER_NDX_LOCAL else elf_file.default_sym_version;
@@ -392,7 +392,7 @@ pub fn claimUnresolvedObject(self: ZigObject, elf_file: *Elf) void {
         }
 
         global.value = 0;
-        global.atom_ref = .{ .index = 0, .file = 0 };
+        global.ref = .{ .index = 0, .file = 0 };
         global.esym_index = esym_index;
         global.file_index = self.index;
     }

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -854,14 +854,14 @@ fn getDeclShdrIndex(
                     if (is_all_zeroes) break :blk elf_file.sectionByName(".tbss") orelse try elf_file.addSection(.{
                         .type = elf.SHT_NOBITS,
                         .flags = elf.SHF_ALLOC | elf.SHF_WRITE | elf.SHF_TLS,
-                        .name = ".tbss",
+                        .name = try elf_file.insertShString(".tbss"),
                         .offset = std.math.maxInt(u64),
                     });
 
                     break :blk elf_file.sectionByName(".tdata") orelse try elf_file.addSection(.{
                         .type = elf.SHT_PROGBITS,
                         .flags = elf.SHF_ALLOC | elf.SHF_WRITE | elf.SHF_TLS,
-                        .name = ".tdata",
+                        .name = try elf_file.insertShString(".tdata"),
                         .offset = std.math.maxInt(u64),
                     });
                 }

--- a/src/link/Elf/eh_frame.zig
+++ b/src/link/Elf/eh_frame.zig
@@ -421,7 +421,7 @@ fn emitReloc(elf_file: *Elf, rec: anytype, sym: *const Symbol, rel: elf.Elf64_Re
     switch (sym.type(elf_file)) {
         elf.STT_SECTION => {
             r_addend += @intCast(sym.address(.{}, elf_file));
-            r_sym = elf_file.sectionSymbolOutputSymtabIndex(sym.outputShndx().?);
+            r_sym = elf_file.sectionSymbolOutputSymtabIndex(sym.outputShndx(elf_file).?);
         },
         else => {
             r_sym = sym.outputSymtabIndex(elf_file) orelse 0;

--- a/src/link/Elf/eh_frame.zig
+++ b/src/link/Elf/eh_frame.zig
@@ -42,8 +42,8 @@ pub const Fde = struct {
         const object = elf_file.file(fde.file_index).?.object;
         const rel = fde.relocs(elf_file)[0];
         const sym = object.symtab.items[rel.r_sym()];
-        const atom_index = object.atoms.items[sym.st_shndx];
-        return elf_file.atom(atom_index).?;
+        const atom_index = object.atoms_indexes.items[sym.st_shndx];
+        return object.atom(atom_index).?;
     }
 
     pub fn relocs(fde: Fde, elf_file: *Elf) []align(1) const elf.Elf64_Rela {

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -98,11 +98,34 @@ pub const File = union(enum) {
         }
     }
 
+    pub fn atom(file: File, atom_index: Atom.Index) ?*Atom {
+        return switch (file) {
+            .shared_object => unreachable,
+            .linker_defined => null,
+            inline else => |x| x.atom(atom_index),
+        };
+    }
+
     pub fn atoms(file: File) []const Atom.Index {
         return switch (file) {
-            .linker_defined, .shared_object => &[0]Atom.Index{},
-            .zig_object => |x| x.atoms.items,
-            .object => |x| x.atoms.items,
+            .shared_object => unreachable,
+            .linker_defined => &[0]Atom.Index{},
+            .zig_object => |x| x.atoms_indexes.items,
+            .object => |x| x.atoms_indexes.items,
+        };
+    }
+
+    pub fn atomExtra(file: File, extra_index: u32) Atom.Extra {
+        return switch (file) {
+            .shared_object, .linker_defined => unreachable,
+            inline else => |x| x.atomExtra(extra_index),
+        };
+    }
+
+    pub fn setAtomExtra(file: File, extra_index: u32, extra: Atom.Extra) void {
+        return switch (file) {
+            .shared_object, .linker_defined => unreachable,
+            inline else => |x| x.setAtomExtra(extra_index, extra),
         };
     }
 

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -157,6 +157,12 @@ pub const File = union(enum) {
         };
     }
 
+    pub fn getString(file: File, off: u32) [:0]const u8 {
+        return switch (file) {
+            inline else => |x| x.getString(off),
+        };
+    }
+
     pub fn updateSymtabSize(file: File, elf_file: *Elf) !void {
         return switch (file) {
             inline else => |x| x.updateSymtabSize(elf_file),

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -137,6 +137,13 @@ pub const File = union(enum) {
         };
     }
 
+    pub fn comdatGroup(file: File, ind: Elf.ComdatGroup.Index) *Elf.ComdatGroup {
+        return switch (file) {
+            .linker_defined, .shared_object, .zig_object => unreachable,
+            .object => |x| x.comdatGroup(ind),
+        };
+    }
+
     pub fn symbol(file: File, ind: Symbol.Index) Symbol.Index {
         return switch (file) {
             .zig_object => |x| x.symbol(ind),

--- a/src/link/Elf/gc.zig
+++ b/src/link/Elf/gc.zig
@@ -16,9 +16,11 @@ pub fn gcAtoms(elf_file: *Elf) !void {
 }
 
 fn collectRoots(roots: *std.ArrayList(*Atom), files: []const File.Index, elf_file: *Elf) !void {
-    if (elf_file.entry_index) |index| {
-        const global = elf_file.symbol(index);
-        try markSymbol(global, roots, elf_file);
+    if (elf_file.linkerDefinedPtr()) |obj| {
+        if (obj.entry_index) |index| {
+            const global = elf_file.symbol(index);
+            try markSymbol(global, roots, elf_file);
+        }
     }
 
     for (files) |index| {

--- a/src/link/Elf/merge_section.zig
+++ b/src/link/Elf/merge_section.zig
@@ -21,7 +21,7 @@ pub const MergeSection = struct {
     }
 
     pub fn name(msec: MergeSection, elf_file: *Elf) [:0]const u8 {
-        return elf_file.strings.getAssumeExists(msec.name_offset);
+        return elf_file.getShString(msec.name_offset);
     }
 
     pub fn address(msec: MergeSection, elf_file: *Elf) i64 {

--- a/src/link/Elf/merge_section.zig
+++ b/src/link/Elf/merge_section.zig
@@ -60,9 +60,8 @@ pub const MergeSection = struct {
 
     /// Finalizes the merge section and clears hash table.
     /// Sorts all owned subsections.
-    pub fn finalize(msec: *MergeSection, elf_file: *Elf) !void {
-        const gpa = elf_file.base.comp.gpa;
-        try msec.finalized_subsections.ensureTotalCapacityPrecise(gpa, msec.subsections.items.len);
+    pub fn finalize(msec: *MergeSection, allocator: Allocator) !void {
+        try msec.finalized_subsections.ensureTotalCapacityPrecise(allocator, msec.subsections.items.len);
 
         var it = msec.table.iterator();
         while (it.next()) |entry| {
@@ -70,7 +69,7 @@ pub const MergeSection = struct {
             if (!msub.alive) continue;
             msec.finalized_subsections.appendAssumeCapacity(entry.value_ptr.*);
         }
-        msec.table.clearAndFree(gpa);
+        msec.table.clearAndFree(allocator);
 
         const sortFn = struct {
             pub fn sortFn(ctx: *MergeSection, lhs: MergeSubsection.Index, rhs: MergeSubsection.Index) bool {

--- a/src/link/Elf/relocatable.zig
+++ b/src/link/Elf/relocatable.zig
@@ -340,7 +340,7 @@ fn updateSectionSizes(elf_file: *Elf) !void {
         const shdr = &elf_file.shdrs.items[shndx];
         for (atom_list.items) |ref| {
             const atom_ptr = elf_file.atom(ref) orelse continue;
-            if (!atom_ptr.flags.alive) continue;
+            if (!atom_ptr.alive) continue;
             const offset = atom_ptr.alignment.forward(shdr.sh_size);
             const padding = offset - shdr.sh_size;
             atom_ptr.value = @intCast(offset);
@@ -353,7 +353,7 @@ fn updateSectionSizes(elf_file: *Elf) !void {
         const shdr = &elf_file.shdrs.items[sec.shndx];
         for (sec.atom_list.items) |ref| {
             const atom_ptr = elf_file.atom(ref) orelse continue;
-            if (!atom_ptr.flags.alive) continue;
+            if (!atom_ptr.alive) continue;
             const relocs = atom_ptr.relocs(elf_file);
             shdr.sh_size += shdr.sh_entsize * relocs.len;
         }
@@ -447,7 +447,7 @@ fn writeAtoms(elf_file: *Elf) !void {
 
         for (atom_list.items) |ref| {
             const atom_ptr = elf_file.atom(ref).?;
-            assert(atom_ptr.flags.alive);
+            assert(atom_ptr.alive);
 
             const offset = math.cast(usize, atom_ptr.value - @as(i64, @intCast(shdr.sh_addr - base_offset))) orelse
                 return error.Overflow;
@@ -489,7 +489,7 @@ fn writeSyntheticSections(elf_file: *Elf) !void {
 
         for (sec.atom_list.items) |ref| {
             const atom_ptr = elf_file.atom(ref) orelse continue;
-            if (!atom_ptr.flags.alive) continue;
+            if (!atom_ptr.alive) continue;
             try atom_ptr.writeRelocs(elf_file, &relocs);
         }
         assert(relocs.items.len == num_relocs);

--- a/src/link/Elf/relocatable.zig
+++ b/src/link/Elf/relocatable.zig
@@ -190,7 +190,7 @@ pub fn flushObject(elf_file: *Elf, comp: *Compilation, module_obj_path: ?[]const
     // Now, we are ready to resolve the symbols across all input files.
     // We will first resolve the files in the ZigObject, next in the parsed
     // input Object files.
-    elf_file.resolveSymbols();
+    try elf_file.resolveSymbols();
     elf_file.markEhFrameAtomsDead();
     try elf_file.resolveMergeSections();
     try elf_file.addCommentString();
@@ -318,11 +318,8 @@ fn initComdatGroups(elf_file: *Elf) !void {
 
     for (elf_file.objects.items) |index| {
         const object = elf_file.file(index).?.object;
-
         for (object.comdat_groups.items, 0..) |cg, cg_index| {
-            const cg_owner = elf_file.comdatGroupOwner(cg.owner);
-            if (cg_owner.file != index) continue;
-
+            if (!cg.alive) continue;
             const cg_sec = try elf_file.comdat_group_sections.addOne(gpa);
             cg_sec.* = .{
                 .shndx = try elf_file.addSection(.{

--- a/src/link/Elf/relocatable.zig
+++ b/src/link/Elf/relocatable.zig
@@ -299,13 +299,16 @@ fn initSections(elf_file: *Elf) !void {
     } else false;
     if (needs_eh_frame) {
         elf_file.eh_frame_section_index = try elf_file.addSection(.{
-            .name = ".eh_frame",
+            .name = try elf_file.insertShString(".eh_frame"),
             .type = elf.SHT_PROGBITS,
             .flags = elf.SHF_ALLOC,
             .addralign = ptr_size,
             .offset = std.math.maxInt(u64),
         });
-        elf_file.eh_frame_rela_section_index = try elf_file.addRelaShdr(".rela.eh_frame", elf_file.eh_frame_section_index.?);
+        elf_file.eh_frame_rela_section_index = try elf_file.addRelaShdr(
+            try elf_file.insertShString(".rela.eh_frame"),
+            elf_file.eh_frame_section_index.?,
+        );
     }
 
     try initComdatGroups(elf_file);
@@ -323,7 +326,7 @@ fn initComdatGroups(elf_file: *Elf) !void {
             const cg_sec = try elf_file.comdat_group_sections.addOne(gpa);
             cg_sec.* = .{
                 .shndx = try elf_file.addSection(.{
-                    .name = ".group",
+                    .name = try elf_file.insertShString(".group"),
                     .type = elf.SHT_GROUP,
                     .entsize = @sizeOf(u32),
                     .addralign = @alignOf(u32),

--- a/src/link/Elf/relocatable.zig
+++ b/src/link/Elf/relocatable.zig
@@ -319,8 +319,7 @@ fn initComdatGroups(elf_file: *Elf) !void {
     for (elf_file.objects.items) |index| {
         const object = elf_file.file(index).?.object;
 
-        for (object.comdat_groups.items) |cg_index| {
-            const cg = elf_file.comdatGroup(cg_index);
+        for (object.comdat_groups.items, 0..) |cg, cg_index| {
             const cg_owner = elf_file.comdatGroupOwner(cg.owner);
             if (cg_owner.file != index) continue;
 
@@ -333,7 +332,7 @@ fn initComdatGroups(elf_file: *Elf) !void {
                     .addralign = @alignOf(u32),
                     .offset = std.math.maxInt(u64),
                 }),
-                .cg_index = cg_index,
+                .cg_ref = .{ .index = @intCast(cg_index), .file = index },
             };
         }
     }

--- a/src/link/Elf/relocatable.zig
+++ b/src/link/Elf/relocatable.zig
@@ -382,7 +382,7 @@ fn updateComdatGroupsSizes(elf_file: *Elf) void {
 
         const sym = elf_file.symbol(cg.symbol(elf_file));
         shdr.sh_info = sym.outputSymtabIndex(elf_file) orelse
-            elf_file.sectionSymbolOutputSymtabIndex(sym.outputShndx().?);
+            elf_file.sectionSymbolOutputSymtabIndex(sym.outputShndx(elf_file).?);
     }
 }
 

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -1672,12 +1672,6 @@ pub const ComdatGroupSection = struct {
     shndx: u32,
     cg_ref: Elf.Ref,
 
-    fn ownerFile(cgs: ComdatGroupSection, elf_file: *Elf) ?File {
-        const cg = cgs.comdatGroup(elf_file);
-        const cg_owner = elf_file.comdatGroupOwner(cg.owner);
-        return elf_file.file(cg_owner.file);
-    }
-
     fn comdatGroup(cgs: ComdatGroupSection, elf_file: *Elf) *Elf.ComdatGroup {
         const cg_file = elf_file.file(cgs.cg_ref.file).?;
         return cg_file.object.comdatGroup(cgs.cg_ref.index);
@@ -1685,7 +1679,7 @@ pub const ComdatGroupSection = struct {
 
     pub fn symbol(cgs: ComdatGroupSection, elf_file: *Elf) Symbol.Index {
         const cg = cgs.comdatGroup(elf_file);
-        const object = cgs.ownerFile(elf_file).?.object;
+        const object = cg.file(elf_file).object;
         const shdr = object.shdrs.items[cg.shndx];
         return object.symbols.items[shdr.sh_info];
     }
@@ -1698,7 +1692,7 @@ pub const ComdatGroupSection = struct {
 
     pub fn write(cgs: ComdatGroupSection, elf_file: *Elf, writer: anytype) !void {
         const cg = cgs.comdatGroup(elf_file);
-        const object = cgs.ownerFile(elf_file).?.object;
+        const object = cg.file(elf_file).object;
         const members = cg.comdatGroupMembers(elf_file);
         try writer.writeInt(u32, elf.GRP_COMDAT, .little);
         for (members) |shndx| {

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -1701,13 +1701,13 @@ pub const ComdatGroupSection = struct {
                 elf.SHT_RELA => {
                     const atom_index = object.atoms_indexes.items[shdr.sh_info];
                     const atom = object.atom(atom_index).?;
-                    const rela = elf_file.output_rela_sections.get(atom.outputShndx().?).?;
+                    const rela = elf_file.output_rela_sections.get(atom.output_section_index).?;
                     try writer.writeInt(u32, rela.shndx, .little);
                 },
                 else => {
                     const atom_index = object.atoms_indexes.items[shndx];
                     const atom = object.atom(atom_index).?;
-                    try writer.writeInt(u32, atom.outputShndx().?, .little);
+                    try writer.writeInt(u32, atom.output_section_index, .little);
                 },
             }
         }

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -1075,7 +1075,7 @@ pub const GotPltSection = struct {
         _ = got_plt;
         {
             // [0]: _DYNAMIC
-            const symbol = elf_file.symbol(elf_file.dynamic_index.?);
+            const symbol = elf_file.symbol(elf_file.linkerDefinedPtr().?.dynamic_index.?);
             try writer.writeInt(u64, @intCast(symbol.address(.{}, elf_file)), .little);
         }
         // [1]: 0x0

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -1705,14 +1705,14 @@ pub const ComdatGroupSection = struct {
             const shdr = object.shdrs.items[shndx];
             switch (shdr.sh_type) {
                 elf.SHT_RELA => {
-                    const atom_index = object.atoms.items[shdr.sh_info];
-                    const atom = elf_file.atom(atom_index).?;
+                    const atom_index = object.atoms_indexes.items[shdr.sh_info];
+                    const atom = object.atom(atom_index).?;
                     const rela = elf_file.output_rela_sections.get(atom.outputShndx().?).?;
                     try writer.writeInt(u32, rela.shndx, .little);
                 },
                 else => {
-                    const atom_index = object.atoms.items[shndx];
-                    const atom = elf_file.atom(atom_index).?;
+                    const atom_index = object.atoms_indexes.items[shndx];
+                    const atom = object.atom(atom_index).?;
                     try writer.writeInt(u32, atom.outputShndx().?, .little);
                 },
             }

--- a/src/link/Elf/thunks.zig
+++ b/src/link/Elf/thunks.zig
@@ -14,13 +14,13 @@ pub fn createThunks(shndx: u32, elf_file: *Elf) !void {
     while (i < atoms.len) {
         const start = i;
         const start_atom = elf_file.atom(atoms[start]).?;
-        assert(start_atom.flags.alive);
+        assert(start_atom.alive);
         start_atom.value = try advance(shdr, start_atom.size, start_atom.alignment);
         i += 1;
 
         while (i < atoms.len) : (i += 1) {
             const atom = elf_file.atom(atoms[i]).?;
-            assert(atom.flags.alive);
+            assert(atom.alive);
             if (@as(i64, @intCast(atom.alignment.forward(shdr.sh_size))) - start_atom.value >= max_distance)
                 break;
             atom.value = try advance(shdr, atom.size, atom.alignment);
@@ -51,7 +51,6 @@ pub fn createThunks(shndx: u32, elf_file: *Elf) !void {
                 try thunk.symbols.put(gpa, target, {});
             }
             atom.addExtra(.{ .thunk = thunk_index }, elf_file);
-            atom.flags.thunk = true;
         }
 
         thunk.value = try advance(shdr, thunk.size(elf_file), Atom.Alignment.fromNonzeroByteUnits(2));

--- a/src/link/MachO/InternalObject.zig
+++ b/src/link/MachO/InternalObject.zig
@@ -45,8 +45,7 @@ pub fn deinit(self: *InternalObject, allocator: Allocator) void {
 
 pub fn init(self: *InternalObject, allocator: Allocator) !void {
     // Atom at index 0 is reserved as null atom.
-    try self.atoms.append(allocator, .{});
-    try self.atoms_extra.append(allocator, 0);
+    try self.atoms.append(allocator, .{ .extra = try self.addAtomExtra(allocator, .{}) });
     // Null byte in strtab
     try self.strtab.append(allocator, 0);
 }

--- a/src/link/MachO/ZigObject.zig
+++ b/src/link/MachO/ZigObject.zig
@@ -1634,7 +1634,7 @@ fn isThreadlocal(macho_file: *MachO, decl_index: InternPool.DeclIndex) bool {
 
 fn addAtom(self: *ZigObject, allocator: Allocator) !Atom.Index {
     try self.atoms.ensureUnusedCapacity(allocator, 1);
-    try self.atoms_extra.ensureUnusedCapacity(allocator, 1);
+    try self.atoms_extra.ensureUnusedCapacity(allocator, @sizeOf(Atom.Extra));
     return self.addAtomAssumeCapacity();
 }
 

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -416,16 +416,6 @@ fn testComdatElimination(b: *Build, opts: Options) *Step {
             \\
         );
         test_step.dependOn(&run.step);
-
-        const check = exe.checkObject();
-        check.checkInSymtab();
-        // This weird looking double assertion uses the fact that once we find the symbol in
-        // the symtab, we do not reset the cursor and do subsequent checks from that point onwards.
-        // If this is the case, and COMDAT elimination works correctly we should only have one instance
-        // of foo() function.
-        check.checkContains("_Z3foov");
-        check.checkNotPresent("_Z3foov");
-        test_step.dependOn(&check.step);
     }
 
     {
@@ -441,16 +431,6 @@ fn testComdatElimination(b: *Build, opts: Options) *Step {
             \\
         );
         test_step.dependOn(&run.step);
-
-        const check = exe.checkObject();
-        check.checkInSymtab();
-        // This weird looking double assertion uses the fact that once we find the symbol in
-        // the symtab, we do not reset the cursor and do subsequent checks from that point onwards.
-        // If this is the case, and COMDAT elimination works correctly we should only have one instance
-        // of foo() function.
-        check.checkContains("_Z3foov");
-        check.checkNotPresent("_Z3foov");
-        test_step.dependOn(&check.step);
     }
 
     {

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -404,9 +404,7 @@ fn testComdatElimination(b: *Build, opts: Options) *Step {
     main_o.linkLibCpp();
 
     {
-        const exe = addExecutable(b, opts, .{
-            .name = "main1",
-        });
+        const exe = addExecutable(b, opts, .{ .name = "main1" });
         exe.addObject(a_o);
         exe.addObject(main_o);
         exe.linkLibCpp();
@@ -431,9 +429,7 @@ fn testComdatElimination(b: *Build, opts: Options) *Step {
     }
 
     {
-        const exe = addExecutable(b, opts, .{
-            .name = "main2",
-        });
+        const exe = addExecutable(b, opts, .{ .name = "main2" });
         exe.addObject(main_o);
         exe.addObject(a_o);
         exe.linkLibCpp();
@@ -455,6 +451,42 @@ fn testComdatElimination(b: *Build, opts: Options) *Step {
         check.checkContains("_Z3foov");
         check.checkNotPresent("_Z3foov");
         test_step.dependOn(&check.step);
+    }
+
+    {
+        const c_o = addObject(b, opts, .{ .name = "c" });
+        c_o.addObject(main_o);
+        c_o.addObject(a_o);
+
+        const exe = addExecutable(b, opts, .{ .name = "main3" });
+        exe.addObject(c_o);
+        exe.linkLibCpp();
+
+        const run = addRunArtifact(exe);
+        run.expectStdOutEqual(
+            \\calling foo in main
+            \\calling foo in main
+            \\
+        );
+        test_step.dependOn(&run.step);
+    }
+
+    {
+        const d_o = addObject(b, opts, .{ .name = "d" });
+        d_o.addObject(a_o);
+        d_o.addObject(main_o);
+
+        const exe = addExecutable(b, opts, .{ .name = "main4" });
+        exe.addObject(d_o);
+        exe.linkLibCpp();
+
+        const run = addRunArtifact(exe);
+        run.expectStdOutEqual(
+            \\calling foo in a
+            \\calling foo in a
+            \\
+        );
+        test_step.dependOn(&run.step);
     }
 
     return test_step;


### PR DESCRIPTION
Moves ownership of all resources into owning objects except symbols - this will come in a subsequent PR.