### PR TITLE
zig build: add env_map entries to hash for Step.Run

### DIFF
--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -630,6 +630,35 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     var man = b.graph.cache.obtain();
     defer man.deinit();
 
+    if (run.env_map) |env_map| {
+        const KV = struct { []const u8, []const u8 };
+        var kv_pairs = try std.ArrayList(KV).initCapacity(arena, env_map.count());
+        var iter = env_map.iterator();
+        while (iter.next()) |entry| {
+            kv_pairs.appendAssumeCapacity(.{ entry.key_ptr.*, entry.value_ptr.* });
+        }
+
+        std.mem.sortUnstable(KV, kv_pairs.items, {}, struct {
+            fn lessThan(_: void, kv1: KV, kv2: KV) bool {
+                const k1 = kv1[0];
+                const k2 = kv2[0];
+
+                if (k1.len != k2.len) return k1.len < k2.len;
+
+                for (k1, k2) |c1, c2| {
+                    if (c1 == c2) continue;
+                    return c1 < c2;
+                }
+                unreachable; // two keys cannot be equal
+            }
+        }.lessThan);
+
+        for (kv_pairs.items) |kv| {
+            man.hash.addBytes(kv[0]);
+            man.hash.addBytes(kv[1]);
+        }
+    }
+
     for (run.argv.items) |arg| {
         switch (arg) {
             .bytes => |bytes| {


### PR DESCRIPTION
This change fixes false-positive cache hits for run steps that get run with different sets of environment variables due the the environment map being excluded from the cache hash.

I assume the exclusion of the `env_map` field from the cache hash of a `Step.Run` was an oversight as it is important for use cases where environment variables are used to control program behaviour (I encountered this issue when using AFLPlusPlus where environment variables are used to enable different instrumentation options). If it was intentional I can open an issue to discuss changing this behaviour.

The implementation in this PR sorts the environment variables by the variable name to ensure that any reordering does not cause a cache miss. I have not implemented special-case logic for windows to normalise environment variable name case before hashing, so you can get cache misses if different codes paths in `build.zig` add the same environment variable (and value) but use different casing for the variable name.