### PR TITLE
std.math.complex fixes

### DIFF
--- a/lib/std/math/complex/abs.zig
+++ b/lib/std/math/complex/abs.zig
@@ -9,10 +9,9 @@ pub fn abs(z: anytype) @TypeOf(z.re, z.im) {
     return math.hypot(z.re, z.im);
 }
 
-const epsilon = 0.0001;
-
 test abs {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = abs(a);
-    try testing.expect(math.approxEqAbs(f32, c, 5.83095, epsilon));
+    try testing.expectApproxEqAbs(5.8309517, c, epsilon);
 }

--- a/lib/std/math/complex/acos.zig
+++ b/lib/std/math/complex/acos.zig
@@ -11,12 +11,11 @@ pub fn acos(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     return Complex(T).init(@as(T, math.pi) / 2 - q.re, -q.im);
 }
 
-const epsilon = 0.0001;
-
 test acos {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = acos(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, 0.546975, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, -2.452914, epsilon));
+    try testing.expectApproxEqAbs(0.5469737, c.re, epsilon);
+    try testing.expectApproxEqAbs(-2.4529128, c.im, epsilon);
 }

--- a/lib/std/math/complex/acosh.zig
+++ b/lib/std/math/complex/acosh.zig
@@ -15,12 +15,11 @@ pub fn acosh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
         Complex(T).init(-q.im, q.re);
 }
 
-const epsilon = 0.0001;
-
 test acosh {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = acosh(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, 2.452914, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 0.546975, epsilon));
+    try testing.expectApproxEqAbs(2.4529128, c.re, epsilon);
+    try testing.expectApproxEqAbs(0.5469737, c.im, epsilon);
 }

--- a/lib/std/math/complex/acosh.zig
+++ b/lib/std/math/complex/acosh.zig
@@ -8,7 +8,11 @@ const Complex = cmath.Complex;
 pub fn acosh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     const T = @TypeOf(z.re, z.im);
     const q = cmath.acos(z);
-    return Complex(T).init(-q.im, q.re);
+
+    return if (math.signbit(z.im))
+        Complex(T).init(q.im, -q.re)
+    else
+        Complex(T).init(-q.im, q.re);
 }
 
 const epsilon = 0.0001;

--- a/lib/std/math/complex/arg.zig
+++ b/lib/std/math/complex/arg.zig
@@ -9,10 +9,9 @@ pub fn arg(z: anytype) @TypeOf(z.re, z.im) {
     return math.atan2(z.im, z.re);
 }
 
-const epsilon = 0.0001;
-
 test arg {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = arg(a);
-    try testing.expect(math.approxEqAbs(f32, c, 0.540420, epsilon));
+    try testing.expectApproxEqAbs(0.5404195, c, epsilon);
 }

--- a/lib/std/math/complex/asin.zig
+++ b/lib/std/math/complex/asin.zig
@@ -17,12 +17,11 @@ pub fn asin(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     return Complex(T).init(r.im, -r.re);
 }
 
-const epsilon = 0.0001;
-
 test asin {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = asin(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, 1.023822, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 2.452914, epsilon));
+    try testing.expectApproxEqAbs(1.0238227, c.re, epsilon);
+    try testing.expectApproxEqAbs(2.4529128, c.im, epsilon);
 }

--- a/lib/std/math/complex/asinh.zig
+++ b/lib/std/math/complex/asinh.zig
@@ -12,12 +12,11 @@ pub fn asinh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     return Complex(T).init(r.im, -r.re);
 }
 
-const epsilon = 0.0001;
-
 test asinh {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = asinh(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, 2.459831, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 0.533999, epsilon));
+    try testing.expectApproxEqAbs(2.4598298, c.re, epsilon);
+    try testing.expectApproxEqAbs(0.5339993, c.im, epsilon);
 }

--- a/lib/std/math/complex/atan.zig
+++ b/lib/std/math/complex/atan.zig
@@ -32,37 +32,22 @@ fn redupif32(x: f32) f32 {
         t -= 0.5;
     }
 
-    const u = @as(f32, @floatFromInt(@as(i32, @intFromFloat(t))));
-    return ((x - u * DP1) - u * DP2) - t * DP3;
+    const u: f32 = @trunc(t);
+    return ((x - u * DP1) - u * DP2) - u * DP3;
 }
 
 fn atan32(z: Complex(f32)) Complex(f32) {
-    const maxnum = 1.0e38;
-
     const x = z.re;
     const y = z.im;
 
-    if ((x == 0.0) and (y > 1.0)) {
-        // overflow
-        return Complex(f32).init(maxnum, maxnum);
-    }
-
     const x2 = x * x;
     var a = 1.0 - x2 - (y * y);
-    if (a == 0.0) {
-        // overflow
-        return Complex(f32).init(maxnum, maxnum);
-    }
 
     var t = 0.5 * math.atan2(2.0 * x, a);
     const w = redupif32(t);
 
     t = y - 1.0;
     a = x2 + t * t;
-    if (a == 0.0) {
-        // overflow
-        return Complex(f32).init(maxnum, maxnum);
-    }
 
     t = y + 1.0;
     a = (x2 + (t * t)) / a;
@@ -81,37 +66,22 @@ fn redupif64(x: f64) f64 {
         t -= 0.5;
     }
 
-    const u = @as(f64, @floatFromInt(@as(i64, @intFromFloat(t))));
-    return ((x - u * DP1) - u * DP2) - t * DP3;
+    const u: f64 = @trunc(t);
+    return ((x - u * DP1) - u * DP2) - u * DP3;
 }
 
 fn atan64(z: Complex(f64)) Complex(f64) {
-    const maxnum = 1.0e308;
-
     const x = z.re;
     const y = z.im;
 
-    if ((x == 0.0) and (y > 1.0)) {
-        // overflow
-        return Complex(f64).init(maxnum, maxnum);
-    }
-
     const x2 = x * x;
     var a = 1.0 - x2 - (y * y);
-    if (a == 0.0) {
-        // overflow
-        return Complex(f64).init(maxnum, maxnum);
-    }
 
     var t = 0.5 * math.atan2(2.0 * x, a);
     const w = redupif64(t);
 
     t = y - 1.0;
     a = x2 + t * t;
-    if (a == 0.0) {
-        // overflow
-        return Complex(f64).init(maxnum, maxnum);
-    }
 
     t = y + 1.0;
     a = (x2 + (t * t)) / a;

--- a/lib/std/math/complex/atan.zig
+++ b/lib/std/math/complex/atan.zig
@@ -88,20 +88,20 @@ fn atan64(z: Complex(f64)) Complex(f64) {
     return Complex(f64).init(w, 0.25 * @log(a));
 }
 
-const epsilon = 0.0001;
-
 test atan32 {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = atan(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, 1.423679, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 0.086569, epsilon));
+    try testing.expectApproxEqAbs(1.423679, c.re, epsilon);
+    try testing.expectApproxEqAbs(0.086569, c.im, epsilon);
 }
 
 test atan64 {
+    const epsilon = math.floatEps(f64);
     const a = Complex(f64).init(5, 3);
     const c = atan(a);
 
-    try testing.expect(math.approxEqAbs(f64, c.re, 1.423679, epsilon));
-    try testing.expect(math.approxEqAbs(f64, c.im, 0.086569, epsilon));
+    try testing.expectApproxEqAbs(1.4236790442393028, c.re, epsilon);
+    try testing.expectApproxEqAbs(0.08656905917945844, c.im, epsilon);
 }

--- a/lib/std/math/complex/atanh.zig
+++ b/lib/std/math/complex/atanh.zig
@@ -12,12 +12,11 @@ pub fn atanh(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     return Complex(T).init(r.im, -r.re);
 }
 
-const epsilon = 0.0001;
-
 test atanh {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = atanh(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, 0.146947, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 1.480870, epsilon));
+    try testing.expectApproxEqAbs(0.14694665, c.re, epsilon);
+    try testing.expectApproxEqAbs(1.4808695, c.im, epsilon);
 }

--- a/lib/std/math/complex/conj.zig
+++ b/lib/std/math/complex/conj.zig
@@ -14,5 +14,6 @@ test conj {
     const a = Complex(f32).init(5, 3);
     const c = a.conjugate();
 
-    try testing.expect(c.re == 5 and c.im == -3);
+    try testing.expectEqual(5, c.re);
+    try testing.expectEqual(-3, c.im);
 }

--- a/lib/std/math/complex/cos.zig
+++ b/lib/std/math/complex/cos.zig
@@ -11,12 +11,11 @@ pub fn cos(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     return cmath.cosh(p);
 }
 
-const epsilon = 0.0001;
-
 test cos {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = cos(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, 2.855815, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 9.606383, epsilon));
+    try testing.expectApproxEqAbs(2.8558152, c.re, epsilon);
+    try testing.expectApproxEqAbs(9.606383, c.im, epsilon);
 }

--- a/lib/std/math/complex/cosh.zig
+++ b/lib/std/math/complex/cosh.zig
@@ -123,7 +123,7 @@ fn cosh64(z: Complex(f64)) Complex(f64) {
         }
         // x >= 1455: result always overflows
         else {
-            const h = 0x1p1023;
+            const h = 0x1p1023 * x;
             return Complex(f64).init(h * h * @cos(y), h * @sin(y));
         }
     }
@@ -169,4 +169,13 @@ test cosh64 {
 
     try testing.expectApproxEqAbs(-73.46729221264526, c.re, epsilon);
     try testing.expectApproxEqAbs(10.471557674805572, c.im, epsilon);
+}
+
+test "cosh64 musl" {
+    const epsilon = math.floatEps(f64);
+    const a = Complex(f64).init(7.44648873421389e17, 1.6008058402057622e19);
+    const c = cosh(a);
+
+    try testing.expectApproxEqAbs(std.math.inf(f64), c.re, epsilon);
+    try testing.expectApproxEqAbs(std.math.inf(f64), c.im, epsilon);
 }

--- a/lib/std/math/complex/cosh.zig
+++ b/lib/std/math/complex/cosh.zig
@@ -34,7 +34,7 @@ fn cosh32(z: Complex(f32)) Complex(f32) {
 
     if (ix < 0x7f800000 and iy < 0x7f800000) {
         if (iy == 0) {
-            return Complex(f32).init(math.cosh(x), y);
+            return Complex(f32).init(math.cosh(x), x * y);
         }
         // small x: normal case
         if (ix < 0x41100000) {
@@ -45,7 +45,7 @@ fn cosh32(z: Complex(f32)) Complex(f32) {
         if (ix < 0x42b17218) {
             // x < 88.7: exp(|x|) won't overflow
             const h = @exp(@abs(x)) * 0.5;
-            return Complex(f32).init(math.copysign(h, x) * @cos(y), h * @sin(y));
+            return Complex(f32).init(h * @cos(y), math.copysign(h, x) * @sin(y));
         }
         // x < 192.7: scale to avoid overflow
         else if (ix < 0x4340b1e7) {
@@ -68,7 +68,7 @@ fn cosh32(z: Complex(f32)) Complex(f32) {
         if (hx & 0x7fffff == 0) {
             return Complex(f32).init(x * x, math.copysign(@as(f32, 0.0), x) * y);
         }
-        return Complex(f32).init(x, math.copysign(@as(f32, 0.0), (x + x) * y));
+        return Complex(f32).init(x * x, math.copysign(@as(f32, 0.0), (x + x) * y));
     }
 
     if (ix < 0x7f800000 and iy >= 0x7f800000) {

--- a/lib/std/math/complex/cosh.zig
+++ b/lib/std/math/complex/cosh.zig
@@ -153,20 +153,20 @@ fn cosh64(z: Complex(f64)) Complex(f64) {
     return Complex(f64).init((x * x) * (y - y), (x + x) * (y - y));
 }
 
-const epsilon = 0.0001;
-
 test cosh32 {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = cosh(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, -73.467300, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 10.471557, epsilon));
+    try testing.expectApproxEqAbs(-73.467300, c.re, epsilon);
+    try testing.expectApproxEqAbs(10.471557, c.im, epsilon);
 }
 
 test cosh64 {
+    const epsilon = math.floatEps(f64);
     const a = Complex(f64).init(5, 3);
     const c = cosh(a);
 
-    try testing.expect(math.approxEqAbs(f64, c.re, -73.467300, epsilon));
-    try testing.expect(math.approxEqAbs(f64, c.im, 10.471557, epsilon));
+    try testing.expectApproxEqAbs(-73.46729221264526, c.re, epsilon);
+    try testing.expectApproxEqAbs(10.471557674805572, c.im, epsilon);
 }

--- a/lib/std/math/complex/log.zig
+++ b/lib/std/math/complex/log.zig
@@ -13,12 +13,11 @@ pub fn log(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     return Complex(T).init(@log(r), phi);
 }
 
-const epsilon = 0.0001;
-
 test log {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = log(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, 1.763180, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 0.540419, epsilon));
+    try testing.expectApproxEqAbs(1.7631803, c.re, epsilon);
+    try testing.expectApproxEqAbs(0.5404195, c.im, epsilon);
 }

--- a/lib/std/math/complex/pow.zig
+++ b/lib/std/math/complex/pow.zig
@@ -9,13 +9,12 @@ pub fn pow(z: anytype, s: anytype) Complex(@TypeOf(z.re, z.im, s.re, s.im)) {
     return cmath.exp(cmath.log(z).mul(s));
 }
 
-const epsilon = 0.0001;
-
 test pow {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const b = Complex(f32).init(2.3, -1.3);
     const c = pow(a, b);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, 58.049110, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, -101.003433, epsilon));
+    try testing.expectApproxEqAbs(58.049110, c.re, epsilon);
+    try testing.expectApproxEqAbs(-101.003433, c.im, epsilon);
 }

--- a/lib/std/math/complex/proj.zig
+++ b/lib/std/math/complex/proj.zig
@@ -19,5 +19,6 @@ test proj {
     const a = Complex(f32).init(5, 3);
     const c = proj(a);
 
-    try testing.expect(c.re == 5 and c.im == 3);
+    try testing.expectEqual(5, c.re);
+    try testing.expectEqual(3, c.im);
 }

--- a/lib/std/math/complex/sin.zig
+++ b/lib/std/math/complex/sin.zig
@@ -12,12 +12,11 @@ pub fn sin(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     return Complex(T).init(q.im, -q.re);
 }
 
-const epsilon = 0.0001;
-
 test sin {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = sin(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, -9.654126, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 2.841692, epsilon));
+    try testing.expectApproxEqAbs(-9.654126, c.re, epsilon);
+    try testing.expectApproxEqAbs(2.8416924, c.im, epsilon);
 }

--- a/lib/std/math/complex/sinh.zig
+++ b/lib/std/math/complex/sinh.zig
@@ -152,20 +152,20 @@ fn sinh64(z: Complex(f64)) Complex(f64) {
     return Complex(f64).init((x * x) * (y - y), (x + x) * (y - y));
 }
 
-const epsilon = 0.0001;
-
 test sinh32 {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = sinh(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, -73.460617, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 10.472508, epsilon));
+    try testing.expectApproxEqAbs(-73.460617, c.re, epsilon);
+    try testing.expectApproxEqAbs(10.472508, c.im, epsilon);
 }
 
 test sinh64 {
+    const epsilon = math.floatEps(f64);
     const a = Complex(f64).init(5, 3);
     const c = sinh(a);
 
-    try testing.expect(math.approxEqAbs(f64, c.re, -73.460617, epsilon));
-    try testing.expect(math.approxEqAbs(f64, c.im, 10.472508, epsilon));
+    try testing.expectApproxEqAbs(-73.46062169567367, c.re, epsilon);
+    try testing.expectApproxEqAbs(10.472508533940392, c.im, epsilon);
 }

--- a/lib/std/math/complex/sqrt.zig
+++ b/lib/std/math/complex/sqrt.zig
@@ -43,7 +43,7 @@ fn sqrt32(z: Complex(f32)) Complex(f32) {
         // sqrt(-inf + i nan)   = nan +- inf i
         // sqrt(-inf + iy)      = 0 + inf i
         if (math.signbit(x)) {
-            return Complex(f32).init(@abs(x - y), math.copysign(x, y));
+            return Complex(f32).init(@abs(y - y), math.copysign(x, y));
         } else {
             return Complex(f32).init(x, math.copysign(y - y, y));
         }
@@ -94,7 +94,7 @@ fn sqrt64(z: Complex(f64)) Complex(f64) {
         // sqrt(-inf + i nan)   = nan +- inf i
         // sqrt(-inf + iy)      = 0 + inf i
         if (math.signbit(x)) {
-            return Complex(f64).init(@abs(x - y), math.copysign(x, y));
+            return Complex(f64).init(@abs(y - y), math.copysign(x, y));
         } else {
             return Complex(f64).init(x, math.copysign(y - y, y));
         }

--- a/lib/std/math/complex/sqrt.zig
+++ b/lib/std/math/complex/sqrt.zig
@@ -127,20 +127,20 @@ fn sqrt64(z: Complex(f64)) Complex(f64) {
     return result;
 }
 
-const epsilon = 0.0001;
-
 test sqrt32 {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = sqrt(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, 2.327117, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 0.644574, epsilon));
+    try testing.expectApproxEqAbs(2.3271174, c.re, epsilon);
+    try testing.expectApproxEqAbs(0.6445742, c.im, epsilon);
 }
 
 test sqrt64 {
+    const epsilon = math.floatEps(f64);
     const a = Complex(f64).init(5, 3);
     const c = sqrt(a);
 
-    try testing.expect(math.approxEqAbs(f64, c.re, 2.3271175190399496, epsilon));
-    try testing.expect(math.approxEqAbs(f64, c.im, 0.6445742373246469, epsilon));
+    try testing.expectApproxEqAbs(2.3271175190399496, c.re, epsilon);
+    try testing.expectApproxEqAbs(0.6445742373246469, c.im, epsilon);
 }

--- a/lib/std/math/complex/tan.zig
+++ b/lib/std/math/complex/tan.zig
@@ -12,12 +12,11 @@ pub fn tan(z: anytype) Complex(@TypeOf(z.re, z.im)) {
     return Complex(T).init(r.im, -r.re);
 }
 
-const epsilon = 0.0001;
-
 test tan {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = tan(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, -0.002708233, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, 1.004165, epsilon));
+    try testing.expectApproxEqAbs(-0.002708233, c.re, epsilon);
+    try testing.expectApproxEqAbs(1.0041647, c.im, epsilon);
 }

--- a/lib/std/math/complex/tanh.zig
+++ b/lib/std/math/complex/tanh.zig
@@ -70,7 +70,7 @@ fn tanh64(z: Complex(f64)) Complex(f64) {
     const ix = hx & 0x7fffffff;
 
     if (ix >= 0x7ff00000) {
-        if ((ix & 0x7fffff) | lx != 0) {
+        if ((ix & 0xfffff) | lx != 0) {
             const r = if (y == 0) y else x * y;
             return Complex(f64).init(x, r);
         }
@@ -117,4 +117,13 @@ test tanh64 {
 
     try testing.expectApproxEqAbs(0.9999128201513536, c.re, epsilon);
     try testing.expectApproxEqAbs(-0.00002536867620767604, c.im, epsilon);
+}
+
+test "tanh64 musl" {
+    const epsilon = math.floatEps(f64);
+    const a = Complex(f64).init(std.math.inf(f64), std.math.inf(f64));
+    const c = tanh(a);
+
+    try testing.expectApproxEqAbs(1, c.re, epsilon);
+    try testing.expectApproxEqAbs(0, c.im, epsilon);
 }

--- a/lib/std/math/complex/tanh.zig
+++ b/lib/std/math/complex/tanh.zig
@@ -101,20 +101,20 @@ fn tanh64(z: Complex(f64)) Complex(f64) {
     return Complex(f64).init((beta * rho * s) / den, t / den);
 }
 
-const epsilon = 0.0001;
-
 test tanh32 {
+    const epsilon = math.floatEps(f32);
     const a = Complex(f32).init(5, 3);
     const c = tanh(a);
 
-    try testing.expect(math.approxEqAbs(f32, c.re, 0.999913, epsilon));
-    try testing.expect(math.approxEqAbs(f32, c.im, -0.000025, epsilon));
+    try testing.expectApproxEqAbs(0.99991274, c.re, epsilon);
+    try testing.expectApproxEqAbs(-0.00002536878, c.im, epsilon);
 }
 
 test tanh64 {
+    const epsilon = math.floatEps(f64);
     const a = Complex(f64).init(5, 3);
     const c = tanh(a);
 
-    try testing.expect(math.approxEqAbs(f64, c.re, 0.999913, epsilon));
-    try testing.expect(math.approxEqAbs(f64, c.im, -0.000025, epsilon));
+    try testing.expectApproxEqAbs(0.9999128201513536, c.re, epsilon);
+    try testing.expectApproxEqAbs(-0.00002536867620767604, c.im, epsilon);
 }


### PR DESCRIPTION
Fixes a few translation errors in the initial port and adds some fixes since changed upstream.

See #19476.

---

I have tested this predominantly using a simple fuzzing setup, comparing the results of zig vs musl (which is the primary source). Code for this can be seen at the bottom of this PR.

```
zig build-exe main.zig complex.c -target x86_64-linux-musl -lc --zig-lib-dir ../lib -O ReleaseSafe
```

For values in the range [0, 1) I'e fuzzed ~1 billion results with all matching to a small epsilon.

For larger values there are a few differences noted below, however this encompasses only ~5% of values max and generally the difference is small.

## Observations

There are some known failures still present. These are not introduced by this PR and likely have been present for quite a while.

The primary reason from what I can see has to do with some minor precision differences which balloon under certain circumstances. Specifically I would investigate the difference in behaviour between where we emit builtins `@log`, `@sqrt` vs. musl which use a software implementation.

e.g. a failing test case

```
!input     = (8.063326472751923e18, 5.343634481833767e18)
!iteration = 0
!seed      = 11911817038683360459
!
!c         = (-1.5707963267948966e0, -6.931471805599453e0)
!z         = (0e0, inf)
```

Tracing the Zig and C asin implementation we deviate marginally at a certain point which causes wildly different results:

```
C:asin:a -5343634481833766912.000000 8063326472751923200.000000
c:sqrt:r1 -36462804330739140062412635512147804160.000000 -86174938756160439949352376809912532992.000000
c:sqrt:r2 5343634481833766912.000000 -8063326472751924224.000000
C:asin:b 5343634481833766912.000000 -8063326472751924224.000000
C:asin:c 0.000000 -1024.000000
C: log = 0.000000 -1024.000000
C:asin:r 6.931472 -1.570796
Z:asin:a -5.343634481833767e18 8.063326472751923e18
z:sqrt:r1 -3.646280433073914e37 -8.617493875616044e37
z:sqrt:r2 5.343634481833767e18 -8.063326472751923e18
Z:asin:b 5.343634481833767e18 -8.063326472751923e18
Z:asin:c 0e0 0e0
Z: log = 0e0 0e0
Z:asin:r -inf 0e0
```

Note however that both of the above results are incorrect. The correct value is instead `0.98553904473616791... + 44.409042651917785... i`.

This looks to occur for values ~1e7 or greater for input to `asin`. `asin` is called by a few other hyperbolic functions so this can be observed in a few other places too.

---

Aside from this there are some other minor accuracy differences. Likely due to the aforementioned builtins but for which the errors do not grow exponentially.

```
clogf

|10000000
!input     = (2.9416764e-5, 3.3091966e-4)
!iteration = 19915237
!seed      = 857500210892449895
!
!c         = (-8.009699e0, 1.4821354e0)
!z         = (-8.0097e0, 1.4821354e0)
```

---

### Fuzzing Code

```zig
const std = @import("std");
const Z = std.math.complex;

pub fn main() !void {
    const seed = std.crypto.random.int(u64);
    var prng = std.Random.DefaultPrng.init(seed);
    var random = prng.random();

    const max_iterations = 100_000_000;

    inline for (.{
        .{ "cacosf", f32, zig_cacosf, Z.acos },
        .{ "cacoshf", f32, zig_cacoshf, Z.acosh },
        .{ "casinf", f32, zig_casinf, Z.asin },
        .{ "casinhf", f32, zig_casinhf, Z.asinh },
        .{ "catanf", f32, zig_catanf, Z.atan },
        .{ "ccosf", f32, zig_ccosf, Z.cos },
        .{ "ccoshf", f32, zig_ccoshf, Z.cosh },
        .{ "cexpf", f32, zig_cexpf, Z.exp },
        .{ "clogf", f32, zig_clogf, Z.log },
        .{ "csinf", f32, zig_csinf, Z.sin },
        .{ "csinhf", f32, zig_csinhf, Z.sinh },
        .{ "csqrtf", f32, zig_csqrtf, Z.sqrt },
        .{ "ctanf", f32, zig_ctanf, Z.tan },
        .{ "ctanhf", f32, zig_ctanhf, Z.tanh },

        .{ "cacos", f64, zig_cacos, Z.acos },
        .{ "ccosh", f64, zig_ccosh, Z.cosh },
        .{ "cacosh", f64, zig_cacosh, Z.acosh },
        .{ "casin", f64, zig_casin, Z.asin },
        .{ "casinh", f64, zig_casinh, Z.asinh },
        .{ "catan", f64, zig_catan, Z.atan },
        .{ "ccos", f64, zig_ccos, Z.cos },
        .{ "ccosh", f64, zig_ccosh, Z.cosh },
        .{ "cexp", f64, zig_cexp, Z.exp },
        .{ "clog", f64, zig_clog, Z.log },
        .{ "csin", f64, zig_csin, Z.sin },
        .{ "csinh", f64, zig_csinh, Z.sinh },
        .{ "csqrt", f64, zig_csqrt, Z.sqrt },
        .{ "ctan", f64, zig_ctan, Z.tan },
        .{ "ctanh", f64, zig_ctanh, Z.tanh },
    }) |def| {
        const funcName = def[0];
        const T = def[1];
        const func = def[2];
        const zigFunc = def[3];
        // Our log + sqrt uses builtins which may differ from musl, so we don't expect bit-identical
        // results. This affects asin,acos,asinh,acosh,log, other functions are within one epsilon.
        const eps = 5 * std.math.floatEps(T);
        var generator = RandomZ(T).init(&random);

        std.debug.print("{s}\n\n", .{funcName});
        var iteration: usize = 0;
        while (iteration <= max_iterations) : (iteration += 1) {
            if (iteration != 0 and iteration % 10_000_000 == 0) {
                std.debug.print("|{}\n", .{iteration});
            }

            const zzz = generator.next();
            const r = zzz[0];
            const i = zzz[1];
            const z = std.math.Complex(T).init(r, i);

            const c_val = blk: {
                var rr: T = undefined;
                var ri: T = undefined;
                func(&rr, &ri, r, i);
                break :blk std.math.Complex(T).init(rr, ri);
            };
            const z_val = zigFunc(z);

            // treat nan as equal
            const re_both_nan = std.math.isNan(c_val.re) and std.math.isNan(z_val.re);
            const im_both_nan = std.math.isNan(c_val.im) and std.math.isNan(z_val.im);

            if ((!re_both_nan and !std.math.approxEqAbs(T, c_val.re, z_val.re, eps) or
                (!im_both_nan and !std.math.approxEqAbs(T, c_val.im, z_val.im, eps))))
            {
                std.debug.print(
                    \\!input     = ({}, {})
                    \\!iteration = {}
                    \\!seed      = {}
                    \\!
                    \\!c         = ({}, {})
                    \\!z         = ({}, {})
                    \\
                , .{ z.re, z.im, iteration, seed, c_val.re, c_val.im, z_val.re, z_val.im });
                break;
            }
        }
        std.debug.print("\n{s}\n-----------\n", .{if (iteration > max_iterations) "OK" else "FAIL"});
    }
}

fn RandomZ(comptime T: type) type {
    return struct {
        i: usize,
        r: *std.Random,

        pub fn init(r: *std.Random) @This() {
            return .{ .i = 0, .r = r };
        }

        fn float(z: *@This()) T {
            const U = @Type(.{ .Int = .{ .signedness = .unsigned, .bits = @bitSizeOf(T) } });
            const r: T = @floatFromInt(z.r.int(U));
            return r;
        }

        pub fn next(z: *@This()) [2]T {
            const n = switch (z.i) {
                // Test special cases
                1 => .{ std.math.nan(T), std.math.nan(T) },
                0 => .{ std.math.inf(T), std.math.inf(T) },
                2 => .{ std.math.nan(T), std.math.inf(T) },
                3 => .{ std.math.inf(T), std.math.nan(T) },
                4...1000 => .{ std.math.nan(T), z.float() },
                1001...2000 => .{ std.math.inf(T), z.float() },
                2001...3000 => .{ z.float(), std.math.nan(T) },
                3001...4000 => .{ z.float(), std.math.inf(T) },
                4001...5000 => .{ 0, z.float() },
                5001...6000 => .{ 1, z.float() },
                6001...7000 => .{ -1, z.float() },
                7001...8000 => .{ z.float(), 0 },
                8001...9000 => .{ z.float(), -1 },
                9001...10000 => .{ z.float(), 1 },
                else => .{ z.float(), z.float() },
            };

            z.i += 1;
            return n;
        }
    };
}

extern fn zig_cacosf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_cacoshf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_casinf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_casinhf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_catanf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_catanhf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_ccosf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_ccoshf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_cexpf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_clogf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_csinf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_csinhf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_csqrtf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_ctanf(rr: *f32, ri: *f32, r: f32, i: f32) void;
extern fn zig_ctanhf(rr: *f32, ri: *f32, r: f32, i: f32) void;

extern fn zig_cacos(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_cacosh(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_casin(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_casinh(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_catan(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_catanh(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_ccos(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_ccosh(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_cexp(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_clog(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_csin(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_csinh(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_csqrt(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_ctan(rr: *f64, ri: *f64, r: f64, i: f64) void;
extern fn zig_ctanh(rr: *f64, ri: *f64, r: f64, i: f64) void;
```

```c
#include <complex.h>

#define def32(cname)                                    \
void zig_##cname(float *rr, float *ri, float r, float i)\
{                                                       \
    float complex z = CMPLXF(r, i);                     \
    float complex rz = cname(z);                        \
    *rr = crealf(rz);                                   \
    *ri = cimagf(rz);                                   \
}

#define def64(cname)                                    \
void zig_##cname(double *rr, double *ri, double r, double i)\
{                                                       \
    double complex z = CMPLX(r, i);                     \
    double complex rz = cname(z);                       \
    *rr = creal(rz);                                    \
    *ri = cimag(rz);                                    \
}

def32(cargf)
def32(cacosf)
def32(cacoshf)
def32(casinf)
def32(casinhf)
def32(catanf)
def32(catanhf)
def32(ccosf)
def32(ccoshf)
def32(cexpf)
def32(clogf)
def32(csinf)
def32(csinhf)
def32(csqrtf)
def32(ctanf)
def32(ctanhf)

def64(carg)
def64(cacos)
def64(cacosh)
def64(casin)
def64(casinh)
def64(catan)
def64(catanh)
def64(ccos)
def64(ccosh)
def64(cexp)
def64(clog)
def64(csin)
def64(csinh)
def64(csqrt)
def64(ctan)
def64(ctanh)
```