### PR TITLE
simpler pch support for zig build

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -748,6 +748,31 @@ pub fn addObject(b: *Build, options: ObjectOptions) *Step.Compile {
     });
 }
 
+pub const PchOptions = struct {
+    name: []const u8,
+    target: ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    max_rss: usize = 0,
+    link_libc: ?bool = null,
+    link_libcpp: ?bool = null,
+};
+
+pub fn addPrecompiledCHeader(b: *Build, options: PchOptions, source: Module.CSourceFile) *Step.Compile {
+    const pch = Step.Compile.create(b, .{
+        .name = options.name,
+        .root_module = .{
+            .target = options.target,
+            .optimize = options.optimize,
+            .link_libc = options.link_libc,
+            .link_libcpp = options.link_libcpp,
+        },
+        .kind = .pch,
+        .max_rss = options.max_rss,
+    });
+    pch.addCSourceFile(source);
+    return pch;
+}
+
 pub const SharedLibraryOptions = struct {
     name: []const u8,
     /// To choose the same computer as the one building the package, pass the

--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -46,11 +46,36 @@ pub const RPath = union(enum) {
     special: []const u8,
 };
 
+// subset of Compilation.FileExt
+pub const AsmSourceLang = enum {
+    assembly,
+    assembly_with_cpp,
+
+    pub fn getLangName(lang: @This()) []const u8 {
+        return switch (lang) {
+            .assembly => "assembler",
+            .assembly_with_cpp => "assembler-with-cpp",
+        };
+    }
+};
+
+pub const AsmSourceFile = struct {
+    file: LazyPath,
+    lang: ?AsmSourceLang = null,
+
+    pub fn dupe(file: AsmSourceFile, b: *std.Build) AsmSourceFile {
+        return .{
+            .file = file.file.dupe(b),
+            .lang = file.lang,
+        };
+    }
+};
+
 pub const LinkObject = union(enum) {
     static_path: LazyPath,
     other_step: *Step.Compile,
     system_lib: SystemLib,
-    assembly_file: LazyPath,
+    assembly_file: *AsmSourceFile,
     c_source_file: *CSourceFile,
     c_source_files: *CSourceFiles,
     win32_resource_file: *RcSourceFile,
@@ -78,21 +103,67 @@ pub const SystemLib = struct {
     pub const SearchStrategy = enum { paths_first, mode_first, no_fallback };
 };
 
+/// Supported languages for "zig clang -x <lang>".
+// subset of Compilation.FileExt
+pub const CSourceLang = enum {
+    /// "c"
+    c,
+    /// "c-header"
+    h,
+    /// "c++"
+    cpp,
+    /// "c++-header"
+    hpp,
+    /// "objective-c"
+    m,
+    /// "objective-c-header"
+    hm,
+    /// "objective-c++"
+    mm,
+    /// "objective-c++-header"
+    hmm,
+    /// "assembler"
+    assembly,
+    /// "assembler-with-cpp"
+    assembly_with_cpp,
+    /// "cuda"
+    cu,
+
+    pub fn getLangName(lang: @This()) []const u8 {
+        return switch (lang) {
+            .assembly => "assembler",
+            .assembly_with_cpp => "assembler-with-cpp",
+            .c => "c",
+            .cpp => "c++",
+            .h => "c-header",
+            .hpp => "c++-header",
+            .hm => "objective-c-header",
+            .hmm => "objective-c++-header",
+            .cu => "cuda",
+            .m => "objective-c",
+            .mm => "objective-c++",
+        };
+    }
+};
+
 pub const CSourceFiles = struct {
     root: LazyPath,
     /// `files` is relative to `root`, which is
     /// the build root by default
     files: []const []const u8,
+    lang: ?CSourceLang = null,
     flags: []const []const u8,
 };
 
 pub const CSourceFile = struct {
     file: LazyPath,
+    lang: ?CSourceLang = null,
     flags: []const []const u8 = &.{},
 
     pub fn dupe(file: CSourceFile, b: *std.Build) CSourceFile {
         return .{
             .file = file.file.dupe(b),
+            .lang = file.lang,
             .flags = b.dupeStrings(file.flags),
         };
     }
@@ -286,10 +357,9 @@ fn addShallowDependencies(m: *Module, dependee: *Module) void {
             addLazyPathDependenciesOnly(m, compile.getEmittedIncludeTree());
         },
 
-        .static_path,
-        .assembly_file,
-        => |lp| addLazyPathDependencies(m, dependee, lp),
+        .static_path => |lp| addLazyPathDependencies(m, dependee, lp),
 
+        .assembly_file => |x| addLazyPathDependencies(m, dependee, x.file),
         .c_source_file => |x| addLazyPathDependencies(m, dependee, x.file),
         .win32_resource_file => |x| addLazyPathDependencies(m, dependee, x.file),
 
@@ -485,6 +555,7 @@ pub const AddCSourceFilesOptions = struct {
     /// package that owns the `Compile` step.
     root: ?LazyPath = null,
     files: []const []const u8,
+    lang: ?CSourceLang = null,
     flags: []const []const u8 = &.{},
 };
 
@@ -506,6 +577,7 @@ pub fn addCSourceFiles(m: *Module, options: AddCSourceFilesOptions) void {
     c_source_files.* = .{
         .root = options.root orelse b.path(""),
         .files = b.dupeStrings(options.files),
+        .lang = options.lang,
         .flags = b.dupeStrings(options.flags),
     };
     m.link_objects.append(allocator, .{ .c_source_files = c_source_files }) catch @panic("OOM");
@@ -541,10 +613,12 @@ pub fn addWin32ResourceFile(m: *Module, source: RcSourceFile) void {
     }
 }
 
-pub fn addAssemblyFile(m: *Module, source: LazyPath) void {
+pub fn addAssemblyFile(m: *Module, source: AsmSourceFile) void {
     const b = m.owner;
-    m.link_objects.append(b.allocator, .{ .assembly_file = source.dupe(b) }) catch @panic("OOM");
-    addLazyPathDependenciesOnly(m, source);
+    const source_file = b.allocator.create(AsmSourceFile) catch @panic("OOM");
+    source_file.* = source.dupe(b);
+    m.link_objects.append(b.allocator, .{ .assembly_file = source_file }) catch @panic("OOM");
+    addLazyPathDependenciesOnly(m, source.file);
 }
 
 pub fn addObjectFile(m: *Module, object: LazyPath) void {

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1824,6 +1824,7 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
 
 fn finalize(step: *Step) !void {
     const compile: *Compile = @fieldParentPtr("step", step);
+    const b = step.owner;
 
     {
         // Fully recursive iteration including dynamic libraries to detect
@@ -1841,6 +1842,67 @@ fn finalize(step: *Step) !void {
         const link_objects = it.next().?.module.link_objects;
         assert(link_objects.items.len == 1 and link_objects.items[0] == .c_source_file);
         assert(it.next() == null);
+    }
+
+    // add additional compile steps for precompiled headers
+    for (compile.root_module.link_objects.items) |*link_object| {
+        const pch_ptr: *Module.PrecompiledHeader, const flags: []const []const u8 = blk: {
+            switch (link_object.*) {
+                .c_source_file => |src| {
+                    if (src.precompiled_header) |*pch| break :blk .{ pch, src.flags };
+                },
+                .c_source_files => |src| {
+                    if (src.precompiled_header) |*pch| break :blk .{ pch, src.flags };
+                },
+                else => {},
+            }
+
+            continue;
+        };
+
+        switch (pch_ptr.*) {
+            .pch_step => {
+                // step customized by the user, nothing to do.
+            },
+            .source_header => |src| {
+                const name = switch (src.path) {
+                    .src_path => |sp| fs.path.basename(sp.sub_path),
+                    .cwd_relative => |p| fs.path.basename(p),
+                    .generated => "generated",
+                    .dependency => "dependency",
+                };
+
+                const step_name = b.fmt("zig build-pch {s}{s} {s}", .{
+                    name,
+                    @tagName(compile.root_module.optimize orelse .Debug),
+                    compile.root_module.resolved_target.?.query.zigTriple(b.allocator) catch @panic("OOM"),
+                });
+
+                // We generate a new compile step for each use,
+                // leveraging the cache system to reuse the generated pch file when possible.
+                const compile_pch = b.allocator.create(Compile) catch @panic("OOM");
+
+                // For robustness, suppose all options have an impact on the header compilation.
+                // (instead of auditing each llvm version for flags observable from header compilation)
+                // So, copy everything and minimally adjust as needed:
+                compile_pch.* = compile.*;
+
+                compile_pch.kind = .pch;
+                compile_pch.step.name = step_name;
+                compile_pch.name = name;
+                compile_pch.out_filename = std.fmt.allocPrint(b.allocator, "{s}.pch", .{name}) catch @panic("OOM");
+                compile_pch.installed_headers = .init(b.allocator);
+                compile_pch.force_undefined_symbols = .init(b.allocator);
+
+                compile_pch.root_module.link_objects = .{};
+                compile_pch.addCSourceFile(.{ .file = src.path, .lang = src.lang, .flags = flags });
+
+                // finalize the parent compile step by modifying it to use the generated pch compile step
+                pch_ptr.* = .{ .pch_step = compile_pch };
+                _ = compile_pch.getEmittedBin(); // Indicate there is a dependency on the outputted binary.
+                compile.root_module.addStepDependenciesOnly(&compile_pch.step);
+            },
+        }
     }
 }
 

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1290,7 +1290,7 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                     .c_source_file => |c_source_file| l: {
                         if (!my_responsibility) break :l;
 
-                        if (c_source_file.flags.len == 0) {
+                        if (c_source_file.flags.len == 0 and c_source_file.precompiled_header == null) {
                             if (prev_has_cflags) {
                                 try zig_args.append("-cflags");
                                 try zig_args.append("--");
@@ -1300,6 +1300,11 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                             try zig_args.append("-cflags");
                             for (c_source_file.flags) |arg| {
                                 try zig_args.append(arg);
+                            }
+                            if (c_source_file.precompiled_header) |pch| {
+                                try zig_args.append("-include-pch");
+                                try zig_args.append(pch.getPath(b));
+                                try zig_args.append("-fpch-validate-input-files-content");
                             }
                             try zig_args.append("--");
                             prev_has_cflags = true;
@@ -1322,7 +1327,7 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                     .c_source_files => |c_source_files| l: {
                         if (!my_responsibility) break :l;
 
-                        if (c_source_files.flags.len == 0) {
+                        if (c_source_files.flags.len == 0 and c_source_files.precompiled_header == null) {
                             if (prev_has_cflags) {
                                 try zig_args.append("-cflags");
                                 try zig_args.append("--");
@@ -1333,6 +1338,13 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                             for (c_source_files.flags) |flag| {
                                 try zig_args.append(flag);
                             }
+
+                            if (c_source_files.precompiled_header) |pch| {
+                                try zig_args.append("-include-pch");
+                                try zig_args.append(pch.getPath(b));
+                                try zig_args.append("-fpch-validate-input-files-content");
+                            }
+
                             try zig_args.append("--");
                             prev_has_cflags = true;
                         }

--- a/lib/std/Build/Step/InstallArtifact.zig
+++ b/lib/std/Build/Step/InstallArtifact.zig
@@ -56,7 +56,7 @@ pub fn create(owner: *std.Build, artifact: *Step.Compile, options: Options) *Ins
     const dest_dir: ?InstallDir = switch (options.dest_dir) {
         .disabled => null,
         .default => switch (artifact.kind) {
-            .obj => @panic("object files have no standard installation procedure"),
+            .obj, .pch => @panic("object files have no standard installation procedure"),
             .exe, .@"test" => .bin,
             .lib => if (artifact.isDll()) .bin else .lib,
         },

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4794,11 +4794,11 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
             else
                 "/dev/null";
 
-            try argv.ensureUnusedCapacity(6);
+            try argv.ensureUnusedCapacity(7);
             switch (comp.clang_preprocessor_mode) {
                 .no => argv.appendSliceAssumeCapacity(&.{ "-c", "-o", out_obj_path }),
                 .yes => argv.appendSliceAssumeCapacity(&.{ "-E", "-o", out_obj_path }),
-                .pch => argv.appendSliceAssumeCapacity(&.{ "-Xclang", "-emit-pch", "-o", out_obj_path }),
+                .pch => argv.appendSliceAssumeCapacity(&.{ "-Xclang", "-emit-pch", "-fpch-validate-input-files-content", "-o", out_obj_path }),
                 .stdout => argv.appendAssumeCapacity("-E"),
             }
 
@@ -4837,11 +4837,11 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
         try argv.appendSlice(c_object.src.extra_flags);
         try argv.appendSlice(c_object.src.cache_exempt_flags);
 
-        try argv.ensureUnusedCapacity(6);
+        try argv.ensureUnusedCapacity(7);
         switch (comp.clang_preprocessor_mode) {
             .no => argv.appendSliceAssumeCapacity(&.{ "-c", "-o", out_obj_path }),
             .yes => argv.appendSliceAssumeCapacity(&.{ "-E", "-o", out_obj_path }),
-            .pch => argv.appendSliceAssumeCapacity(&.{ "-Xclang", "-emit-pch", "-o", out_obj_path }),
+            .pch => argv.appendSliceAssumeCapacity(&.{ "-Xclang", "-emit-pch", "-fpch-validate-input-files-content", "-o", out_obj_path }),
             .stdout => argv.appendAssumeCapacity("-E"),
         }
         if (out_diag_path) |diag_file_path| {

--- a/test/link/link.zig
+++ b/test/link/link.zig
@@ -119,7 +119,7 @@ fn addCompileStep(
         });
     }
     if (overlay.asm_source_bytes) |bytes| {
-        compile_step.addAssemblyFile(b.addWriteFiles().add("a.s", bytes));
+        compile_step.addAssemblyFile(.{ .file = b.addWriteFiles().add("a.s", bytes) });
     }
     return compile_step;
 }
@@ -147,7 +147,7 @@ pub fn addAsmSourceBytes(comp: *Compile, bytes: []const u8) void {
     const b = comp.step.owner;
     const actual_bytes = std.fmt.allocPrint(b.allocator, "{s}\n", .{bytes}) catch @panic("OOM");
     const file = WriteFile.create(b).add("a.s", actual_bytes);
-    comp.addAssemblyFile(file);
+    comp.addAssemblyFile(.{ .file = file });
 }
 
 pub fn expectLinkErrors(comp: *Compile, test_step: *Step, expected_errors: Compile.ExpectedCompileErrors) void {

--- a/test/src/CompareOutput.zig
+++ b/test/src/CompareOutput.zig
@@ -101,7 +101,7 @@ pub fn addCase(self: *CompareOutput, case: TestCase) void {
                 .target = b.graph.host,
                 .optimize = .Debug,
             });
-            exe.addAssemblyFile(first_file);
+            exe.addAssemblyFile(.{ .file = first_file });
 
             const run = b.addRunArtifact(exe);
             run.setName(annotated_case_name);

--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -126,6 +126,9 @@
         .c_compiler = .{
             .path = "c_compiler",
         },
+        .c_header = .{
+            .path = "c_header",
+        },
         .pie = .{
             .path = "pie",
         },

--- a/test/standalone/c_header/build.zig
+++ b/test/standalone/c_header/build.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // single-file c-header library
+    {
+        const exe = b.addExecutable(.{
+            .name = "single-file-library",
+            .root_source_file = b.path("main.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+
+        exe.linkLibC();
+        exe.addIncludePath(b.path("."));
+        exe.addCSourceFile(.{
+            .file = b.path("single_file_library.h"),
+            .lang = .c,
+            .flags = &.{"-DTSTLIB_IMPLEMENTATION"},
+        });
+
+        test_step.dependOn(&b.addRunArtifact(exe).step);
+    }
+}

--- a/test/standalone/c_header/include_a.h
+++ b/test/standalone/c_header/include_a.h
@@ -9,6 +9,7 @@
 #include <iostream>
 #else
 #include <stdio.h>
+#include <stdbool.h>
 #endif
 
 #define A_INCLUDED 1

--- a/test/standalone/c_header/include_a.h
+++ b/test/standalone/c_header/include_a.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "include_b.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+#if defined(__cplusplus)
+#include <iostream>
+#else
+#include <stdio.h>
+#endif
+
+#define A_INCLUDED 1
+

--- a/test/standalone/c_header/include_b.h
+++ b/test/standalone/c_header/include_b.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <math.h>
+
+typedef double real;
+
+#define B_INCLUDED 1

--- a/test/standalone/c_header/main.zig
+++ b/test/standalone/c_header/main.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+const C = @cImport({
+    @cInclude("single_file_library.h");
+});
+
+pub fn main() !void {
+    const msg = "hello";
+    const val = C.tstlib_len(msg);
+    if (val != msg.len)
+        std.process.exit(1);
+}

--- a/test/standalone/c_header/single_file_library.h
+++ b/test/standalone/c_header/single_file_library.h
@@ -1,0 +1,14 @@
+// library header:
+extern unsigned tstlib_len(const char* msg);
+
+// library implementation:
+#ifdef TSTLIB_IMPLEMENTATION
+
+#include <string.h>
+
+unsigned tstlib_len(const char* msg)
+{
+    return strlen(msg);
+}
+
+#endif

--- a/test/standalone/c_header/test.c
+++ b/test/standalone/c_header/test.c
@@ -1,0 +1,22 @@
+
+// includes commented out to make sure the symbols come from the precompiled header.
+//#include "include_a.h"
+//#include "include_b.h"
+
+#ifndef A_INCLUDED
+#error "pch not included"
+#endif
+#ifndef B_INCLUDED
+#error "pch not included"
+#endif
+
+int main(int argc, char *argv[])
+{
+	real a = 0.123;
+
+	if (argc > 1) {
+		fprintf(stdout, "abs(%g)=%g\n", a, fabs(a));
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/test/standalone/c_header/test.c2
+++ b/test/standalone/c_header/test.c2
@@ -10,10 +10,11 @@
 #error "pch not included"
 #endif
 
-extern int func(real a, bool cond);
-
-int main(int argc, char *argv[])
+int func(real a, bool cond)
 {
-	real a = 0.123;
-	return func(a, (argc > 1));
+	if (cond) {
+		fprintf(stdout, "abs(%g)=%g\n", a, fabs(a));
+	}
+
+	return EXIT_SUCCESS;
 }

--- a/test/standalone/c_header/test.cpp
+++ b/test/standalone/c_header/test.cpp
@@ -1,0 +1,23 @@
+
+// includes commented out to make sure the symbols come from the precompiled header.
+//#include "includeA.h"
+//#include "includeB.h"
+
+#ifndef A_INCLUDED
+#error "pch not included"
+#endif
+#ifndef B_INCLUDED
+#error "pch not included"
+#endif
+
+int main(int argc, char *argv[])
+{
+	real a = -0.123;
+
+	if (argc > 1) {
+		std::cout << "abs(" << a << ")=" << fabs(a) << "\n";
+	}
+
+	return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
This is a follow-up to #17956 (included here as well), that exposes a simpler interface to use precompiled headers.

It is now possible to simply add the name of the header file to precompile:
```zig
exe.addCSourceFiles(.{
            .files = &.{"file.c", ...},
            .flags = ...,
            .precompiled_header = .{ .source_header = .{.path = b.path("all.h")} },
        });
```

In order to do this, 
 * I added an extra `finalize()` function to the build steps, 
 * created new build steps not explicitly requested by the user, 
 * as well as altered the compile steps after the user as initialised them. 
I don't know if that fits the general design of the build system or if there's an other way to achieve this.

---

updated example patch for https://github.com/allyourcodebase/cpython:
```diff
--- a/build.zig
+++ b/build.zig
@@ -664,7 +664,6 @@ pub fn build(b: *std.Build) void {
         "Modules/getbuildinfo.c",
         "Modules/itertoolsmodule.c",
         "Modules/main.c",
-        "Modules/mathmodule.c",
         "Modules/md5module.c",
         "Modules/sha1module.c",
         "Modules/sha256module.c",
@@ -805,7 +804,19 @@ pub fn build(b: *std.Build) void {
         "-std=c11",
         "-fvisibility=hidden",
         "-DPy_BUILD_CORE",
-    } });
+    }, .precompiled_header = .{ .source_header = .{ .path = b.path("Include/Python.h") } } });
+
+    // files that includes Python.h with NEEDS_PY_IDENTIFIER defined
+    exe.addCSourceFiles(.{ .files = &.{
+        "Modules/mathmodule.c",
+    }, .flags = &.{
+        "-fwrapv",
+        "-std=c11",
+        "-fvisibility=hidden",
+        "-DPy_BUILD_CORE",
+        "-DNEEDS_PY_IDENTIFIER",
+    }, .precompiled_header = .{ .source_header = .{ .path = b.path("Include/Python.h") } } });
+
     exe.addCSourceFiles(.{ .files = &.{
         "Modules/getpath.c",
     }, .flags = &.{
```
