### PR TITLE
aro-translate-c improvements

### DIFF
--- a/lib/compiler/aro_translate_c.zig
+++ b/lib/compiler/aro_translate_c.zig
@@ -971,7 +971,9 @@ fn transFnType(
 }
 
 fn transStmt(c: *Context, node: NodeIndex) TransError!ZigNode {
-    return transExpr(c, node, .unused);
+    _ = c;
+    _ = node;
+    return error.UnsupportedTranslation;
 }
 
 fn transCompoundStmtInline(c: *Context, compound: NodeIndex, block: *Scope.Block) TransError!void {

--- a/lib/compiler/aro_translate_c.zig
+++ b/lib/compiler/aro_translate_c.zig
@@ -681,8 +681,16 @@ fn transType(c: *Context, scope: *Scope, raw_ty: Type, qual_handling: Type.QualH
         .float80 => return ZigTag.type.create(c.arena, "f80"),
         .float128 => return ZigTag.type.create(c.arena, "f128"),
         .@"enum" => @panic("TODO"),
-        .pointer, .incomplete_array => @panic("todo"),
+        .pointer => @panic("todo"),
         .unspecified_variable_len_array,
+        .incomplete_array => {
+            const child_type = ty.elemType();
+            const is_const = child_type.qual.@"const";
+            const is_volatile = child_type.qual.@"volatile";
+            const elem_type = try transType(c, scope, child_type, qual_handling, source_loc);
+
+            return ZigTag.c_pointer.create(c.arena, .{ .is_const = is_const, .is_volatile = is_volatile, .elem_type = elem_type });
+        },
         .array,
         .static_array,
         => {

--- a/lib/compiler/aro_translate_c.zig
+++ b/lib/compiler/aro_translate_c.zig
@@ -398,6 +398,11 @@ fn transRecordDecl(c: *Context, scope: *Scope, record_ty: Type) Error!void {
 
     const is_pub = toplevel and !is_unnamed;
     const init_node = blk: {
+        if (record_decl.isIncomplete()) {
+            try c.opaque_demotes.put(c.gpa, @intFromPtr(record_decl), {});
+            break :blk ZigTag.opaque_literal.init();
+        }
+
         var fields = try std.ArrayList(ast.Payload.Record.Field).initCapacity(c.gpa, record_decl.fields.len);
         defer fields.deinit();
 

--- a/lib/compiler/aro_translate_c.zig
+++ b/lib/compiler/aro_translate_c.zig
@@ -681,12 +681,15 @@ fn transType(c: *Context, scope: *Scope, raw_ty: Type, qual_handling: Type.QualH
         .float80 => return ZigTag.type.create(c.arena, "f80"),
         .float128 => return ZigTag.type.create(c.arena, "f128"),
         .@"enum" => @panic("TODO"),
-        .pointer,
+        .pointer, .incomplete_array => @panic("todo"),
         .unspecified_variable_len_array,
         .array,
         .static_array,
-        .incomplete_array,
-        => @panic("TODO"),
+        => {
+            const size = ty.arrayLen().?;
+            const elem_type = try transType(c, scope, ty.elemType(), qual_handling, source_loc);
+            return ZigTag.array_type.create(c.arena, .{ .len = size, .elem_type = elem_type });
+        },
         .func,
         .var_args_func,
         .old_style_func,

--- a/lib/compiler/aro_translate_c.zig
+++ b/lib/compiler/aro_translate_c.zig
@@ -358,8 +358,6 @@ fn transTypeDef(c: *Context, scope: *Scope, typedef_decl: NodeIndex) Error!void 
             try bs.discardVariable(c, name);
         }
     }
-
-
 }
 
 fn mangleWeakGlobalName(c: *Context, want_name: []const u8) ![]const u8 {

--- a/lib/compiler/aro_translate_c.zig
+++ b/lib/compiler/aro_translate_c.zig
@@ -304,7 +304,7 @@ fn transDecl(c: *Context, scope: *Scope, decl: NodeIndex) !void {
         .threadlocal_extern_var,
         .threadlocal_static_var,
         => {
-            try transVarDecl(c, decl, null);
+            try transVarDecl(c, decl);
         },
         .static_assert => try warn(c, &c.global_scope.base, 0, "ignoring _Static_assert declaration", .{}),
         else => unreachable,
@@ -566,8 +566,10 @@ fn transFnDecl(c: *Context, fn_decl: NodeIndex) Error!void {
     return addTopLevelDecl(c, fn_name, proto_node);
 }
 
-fn transVarDecl(_: *Context, _: NodeIndex, _: ?usize) Error!void {
-    @panic("TODO");
+fn transVarDecl(c: *Context, node: NodeIndex) Error!void {
+    const data = c.tree.nodes.items(.data)[@intFromEnum(node)];
+    const name = c.tree.tokSlice(data.decl.name);
+    return failDecl(c, data.decl.name, name, "unable to translate variable declaration", .{});
 }
 
 fn transEnumDecl(c: *Context, scope: *Scope, enum_decl: NodeIndex, field_nodes: []const NodeIndex) Error!void {

--- a/lib/compiler/aro_translate_c.zig
+++ b/lib/compiler/aro_translate_c.zig
@@ -297,7 +297,7 @@ fn transDecl(c: *Context, scope: *Scope, decl: NodeIndex) !void {
         .inline_fn_def,
         .inline_static_fn_def,
         => {
-            try transFnDecl(c, decl);
+            try transFnDecl(c, decl, true);
         },
 
         .@"var",
@@ -476,7 +476,7 @@ fn transRecordDecl(c: *Context, scope: *Scope, record_node: NodeIndex, field_nod
     }
 }
 
-fn transFnDecl(c: *Context, fn_decl: NodeIndex) Error!void {
+fn transFnDecl(c: *Context, fn_decl: NodeIndex, is_pub: bool) Error!void {
     const raw_ty = c.tree.nodes.items(.ty)[@intFromEnum(fn_decl)];
     const fn_ty = raw_ty.canonicalize(.standard);
     const node_data = c.tree.nodes.items(.data)[@intFromEnum(fn_decl)];
@@ -501,6 +501,7 @@ fn transFnDecl(c: *Context, fn_decl: NodeIndex) Error!void {
 
             else => unreachable,
         },
+        .is_pub = is_pub,
     };
 
     const proto_node = transFnType(c, &c.global_scope.base, raw_ty, fn_ty, fn_decl_loc, proto_ctx) catch |err| switch (err) {

--- a/test/cases/translate_c/atomic types.c
+++ b/test/cases/translate_c/atomic types.c
@@ -1,0 +1,8 @@
+typedef _Atomic(int) AtomicInt;
+
+// translate-c
+// target=x86_64-linux
+// c_frontend=aro
+//
+// tmp.c:1:22: warning: unsupported type: '_Atomic(int)'
+// pub const AtomicInt = @compileError("unable to resolve typedef child type");

--- a/test/cases/translate_c/empty declaration.c
+++ b/test/cases/translate_c/empty declaration.c
@@ -1,0 +1,6 @@
+;
+
+// translate-c
+// c_frontend=clang,aro
+//
+//

--- a/test/cases/translate_c/function prototype with parenthesis.c
+++ b/test/cases/translate_c/function prototype with parenthesis.c
@@ -1,0 +1,10 @@
+void (f0) (void *L);
+void ((f1)) (void *L);
+void (((f2))) (void *L);
+
+// translate-c
+// c_frontend=clang,aro
+//
+// pub extern fn f0(L: ?*anyopaque) void;
+// pub extern fn f1(L: ?*anyopaque) void;
+// pub extern fn f2(L: ?*anyopaque) void;

--- a/test/cases/translate_c/noreturn attribute.c
+++ b/test/cases/translate_c/noreturn attribute.c
@@ -1,0 +1,6 @@
+void foo(void) __attribute__((noreturn));
+
+// translate-c
+// c_frontend=aro,clang
+//
+// pub extern fn foo() noreturn;

--- a/test/cases/translate_c/simple function prototypes.c
+++ b/test/cases/translate_c/simple function prototypes.c
@@ -1,0 +1,8 @@
+void __attribute__((noreturn)) foo(void);
+int bar(void);
+
+// translate-c
+// c_frontend=clang,aro
+//
+// pub extern fn foo() noreturn;
+// pub extern fn bar() c_int;

--- a/test/cases/translate_c/struct prototype used in func.c
+++ b/test/cases/translate_c/struct prototype used in func.c
@@ -1,0 +1,10 @@
+struct Foo;
+struct Foo *some_func(struct Foo *foo, int x);
+
+// translate-c
+// c_frontend=clang,aro
+//
+// pub const struct_Foo = opaque {};
+// pub extern fn some_func(foo: ?*struct_Foo, x: c_int) ?*struct_Foo;
+//
+// pub const Foo = struct_Foo;

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -519,10 +519,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\};
     });
 
-    cases.add("empty declaration",
-        \\;
-    , &[_][]const u8{""});
-
     cases.add("#define hex literal with capital X",
         \\#define VAL 0XF00D
     , &[_][]const u8{

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -879,17 +879,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub const Foo = struct_Foo;
     });
 
-    cases.add("struct prototype used in func",
-        \\struct Foo;
-        \\struct Foo *some_func(struct Foo *foo, int x);
-    , &[_][]const u8{
-        \\pub const struct_Foo = opaque {};
-        ,
-        \\pub extern fn some_func(foo: ?*struct_Foo, x: c_int) ?*struct_Foo;
-        ,
-        \\pub const Foo = struct_Foo;
-    });
-
     cases.add("#define an unsigned integer literal",
         \\#define CHANNEL_COUNT 24
     , &[_][]const u8{

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -644,14 +644,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub export fn my_fn() linksection("NEAR,.data") void {}
     });
 
-    cases.add("simple function prototypes",
-        \\void __attribute__((noreturn)) foo(void);
-        \\int bar(void);
-    , &[_][]const u8{
-        \\pub extern fn foo() noreturn;
-        \\pub extern fn bar() c_int;
-    });
-
     cases.add("simple var decls",
         \\void foo(void) {
         \\    int a;

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -494,16 +494,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\};
     });
 
-    cases.add("function prototype with parenthesis",
-        \\void (f0) (void *L);
-        \\void ((f1)) (void *L);
-        \\void (((f2))) (void *L);
-    , &[_][]const u8{
-        \\pub extern fn f0(L: ?*anyopaque) void;
-        \\pub extern fn f1(L: ?*anyopaque) void;
-        \\pub extern fn f2(L: ?*anyopaque) void;
-    });
-
     cases.add("array initializer w/ typedef",
         \\typedef unsigned char uuid_t[16];
         \\static const uuid_t UUID_NULL __attribute__ ((unused)) = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -774,12 +774,6 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\}
     });
 
-    cases.add("noreturn attribute",
-        \\void foo(void) __attribute__((noreturn));
-    , &[_][]const u8{
-        \\pub extern fn foo() noreturn;
-    });
-
     cases.add("always_inline attribute",
         \\__attribute__((always_inline)) int foo() {
         \\    return 5;


### PR DESCRIPTION
This PR attempts to make aro-translate-c more useful by removing some common panics and improving type translation. See individual commits for details; a quick summary:

- Statement translation is not supported, so emit function definitions as extern prototypes instead of crashing
- Global variable declarations are not supported, so emit `@compileError` for them instead.
- Add support for pointer and array types
- Add basic support for typedef translation
- Improve record translation - most record types should be translatable now (bitfields, `_Atomic` fields, and flexible array members currently not supported)
- Translate enum types
- Move some tests to the manifest format instead of `test/translate_c.zig`