### PR TITLE
`ci`: Add stage3/4 diff to Linux (aarch64) and windows (aarch64, x86_64) release scripts.

### DIFF
--- a/ci/aarch64-linux-release.sh
+++ b/ci/aarch64-linux-release.sh
@@ -64,6 +64,22 @@ stage3-release/bin/zig build test docs \
   --zig-lib-dir "$PWD/../lib" \
   -Denable-tidy
 
+# Ensure that stage3 and stage4 are byte-for-byte identical.
+stage3-release/bin/zig build \
+  --prefix stage4-release \
+  -Denable-llvm \
+  -Dno-lib \
+  -Doptimize=ReleaseFast \
+  -Dstrip \
+  -Dtarget=$TARGET \
+  -Duse-zig-libcxx \
+  -Dversion-string="$(stage3-release/bin/zig version)"
+
+# diff returns an error code if the files differ.
+echo "If the following command fails, it means nondeterminism has been"
+echo "introduced, making stage3 and stage4 no longer byte-for-byte identical."
+diff stage3-release/bin/zig stage4-release/bin/zig
+
 # Ensure that updating the wasm binary from this commit will result in a viable build.
 stage3-release/bin/zig build update-zig1
 

--- a/ci/aarch64-windows.ps1
+++ b/ci/aarch64-windows.ps1
@@ -69,3 +69,22 @@ Write-Output "Main test suite..."
   -Dskip-non-native `
   -Denable-symlinks-windows
 CheckLastExitCode
+
+# Ensure that stage3 and stage4 are byte-for-byte identical.
+Write-Output "Build and compare stage4..."
+& "stage3-release\bin\zig.exe" build `
+  --prefix stage4-release `
+  -Denable-llvm `
+  -Dno-lib `
+  -Doptimize=ReleaseFast `
+  -Dstrip `
+  -Dtarget="$TARGET" `
+  -Duse-zig-libcxx `
+  -Dversion-string="$(stage3-release\bin\zig version)"
+CheckLastExitCode
+
+# Compare-Object returns an error code if the files differ.
+Write-Output "If the following command fails, it means nondeterminism has been"
+Write-Output "introduced, making stage3 and stage4 no longer byte-for-byte identical."
+Compare-Object (Get-Content stage3-release\bin\zig.exe) (Get-Content stage4-release\bin\zig.exe)
+CheckLastExitCode

--- a/ci/x86_64-windows-release.ps1
+++ b/ci/x86_64-windows-release.ps1
@@ -70,6 +70,25 @@ Write-Output "Main test suite..."
   -Denable-symlinks-windows
 CheckLastExitCode
 
+# Ensure that stage3 and stage4 are byte-for-byte identical.
+Write-Output "Build and compare stage4..."
+& "stage3-release\bin\zig.exe" build `
+  --prefix stage4-release `
+  -Denable-llvm `
+  -Dno-lib `
+  -Doptimize=ReleaseFast `
+  -Dstrip `
+  -Dtarget="$TARGET" `
+  -Duse-zig-libcxx `
+  -Dversion-string="$(stage3-release\bin\zig version)"
+CheckLastExitCode
+
+# Compare-Object returns an error code if the files differ.
+Write-Output "If the following command fails, it means nondeterminism has been"
+Write-Output "introduced, making stage3 and stage4 no longer byte-for-byte identical."
+Compare-Object (Get-Content stage3-release\bin\zig.exe) (Get-Content stage4-release\bin\zig.exe)
+CheckLastExitCode
+
 Write-Output "Build x86_64-windows-msvc behavior tests using the C backend..."
 & "stage3-release\bin\zig.exe" test `
   ..\test\behavior.zig `


### PR DESCRIPTION
Closes #9432.