### PR TITLE
allows custom zig build args on cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -932,7 +932,7 @@ endif()
 
 # To obtain this document, run `zig build` against stage3 rather than stage2.
 # Note that the `langref` step can be used to isolate this task.
-set(ZIG_BUILD_ARGS
+list(APPEND ZIG_BUILD_ARGS
   --zig-lib-dir "${PROJECT_SOURCE_DIR}/lib"
 
   "-Dversion-string=${RESOLVED_ZIG_VERSION}"


### PR DESCRIPTION
Very minor suggestion to allow passing custom zig args in  to cmake. Ex
`cmake ..  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DZIG_BUILD_ARGS="-Ddev=full;-Ddebug-extensions=true"`

I'm not the most avid CMake user so there might be a way of doing this already and I couldn't find out. If so, please, just tell me and close this.