### PR TITLE
Add length range to FuzzInputOptions

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -1165,6 +1165,10 @@ pub fn refAllDeclsRecursive(comptime T: type) void {
 
 pub const FuzzInputOptions = struct {
     corpus: []const []const u8 = &.{},
+    len_range: struct {
+        min: usize = 0,
+        max: usize = 200,
+    } = .{},
 };
 
 /// Inline to avoid coverage instrumentation.


### PR DESCRIPTION
Closes #20816

Example test case, fuzzing f64 printing.

```zig
test "fuzz example" {
    const Context = struct {
        fn testOne(context: @This(), input: []const u8) anyerror!void {
            _ = context;
            // Try passing `--fuzz` to `zig build test` and see if it manages to fail this test case!
            try std.testing.expect(!std.mem.eql(u8, "canyoufindme", input));
        }
    };
    try std.testing.fuzz(Context{}, Context.testOne, .{ .len_range = .{
        .min = 12,
        .max = 12,
    } });
}

```

The first run of the fuzzer is seeded with random bytes, with length equal to the minimum allowed length. 