### PR TITLE
cmake: add ZIG_EXTRA_BUILD_ARGS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -945,6 +945,11 @@ set(ZIG_BUILD_ARGS
   -Dno-langref
 )
 
+option(ZIG_EXTRA_BUILD_ARGS "Extra zig build args")
+if(ZIG_EXTRA_BUILD_ARGS)
+  list(APPEND ZIG_BUILD_ARGS ${ZIG_EXTRA_BUILD_ARGS})
+endif()
+
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   list(APPEND ZIG_BUILD_ARGS -Doptimize=Debug)
 elseif("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")


### PR DESCRIPTION
Adds ZIG_EXTRA_BUILD_ARGS which provides a way to add additional stage3 args.

For example:  `-DZIG_EXTRA_BUILD_ARGS="--maxrss;34359738368"`