### PR TITLE
`musl`: Disable warnings in all compilations.

### DIFF
--- a/src/musl.zig
+++ b/src/musl.zig
@@ -32,9 +32,6 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progre
         .crti_o => {
             var args = std.ArrayList([]const u8).init(arena);
             try addCcArgs(comp, arena, &args, false);
-            try args.appendSlice(&[_][]const u8{
-                "-Qunused-arguments",
-            });
             var files = [_]Compilation.CSourceFile{
                 .{
                     .src_path = try start_asm_path(comp, arena, "crti.s"),
@@ -47,9 +44,6 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progre
         .crtn_o => {
             var args = std.ArrayList([]const u8).init(arena);
             try addCcArgs(comp, arena, &args, false);
-            try args.appendSlice(&[_][]const u8{
-                "-Qunused-arguments",
-            });
             var files = [_]Compilation.CSourceFile{
                 .{
                     .src_path = try start_asm_path(comp, arena, "crtn.s"),
@@ -189,10 +183,6 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progre
 
                 var args = std.ArrayList([]const u8).init(arena);
                 try addCcArgs(comp, arena, &args, ext == .o3);
-                try args.appendSlice(&[_][]const u8{
-                    "-Qunused-arguments",
-                    "-w", // disable all warnings
-                });
                 const c_source_file = try c_source_files.addOne();
                 c_source_file.* = .{
                     .src_path = try comp.zig_lib_directory.join(arena, &[_][]const u8{ "libc", src_file }),
@@ -427,6 +417,9 @@ fn addCcArgs(
         "-fno-asynchronous-unwind-tables",
         "-ffunction-sections",
         "-fdata-sections",
+
+        "-Qunused-arguments",
+        "-w", // disable all warnings
     });
 }
 


### PR DESCRIPTION
This is what upstream's configure does: https://git.musl-libc.org/cgit/musl/tree/configure#n537

Previously, we only disabled warnings in some musl compilations, with `rcrt1.o` notably being one for which we didn't. This resulted in a warning in `dlstart.c` which is included in `rcrt1.c`. So let's just be consistent and disable warnings for all musl code.

Closes #13385.