### PR TITLE
`std.Target`: Bump baseline CPU for sparc32 to v9; add `sparcv9-linux-gnu` to `process_headers.zig`

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -1502,7 +1502,7 @@ pub const Cpu = struct {
                 .x86 => &x86.cpu.pentium4,
                 .nvptx, .nvptx64 => &nvptx.cpu.sm_20,
                 .s390x => &s390x.cpu.arch8,
-                .sparc => &sparc.cpu.v8,
+                .sparc => &sparc.cpu.v9, // glibc does not work with 'plain' v8.
                 .loongarch64 => &loongarch.cpu.loongarch64,
 
                 else => generic(arch),

--- a/tools/process_headers.zig
+++ b/tools/process_headers.zig
@@ -174,12 +174,11 @@ const glibc_targets = [_]LibCTarget{
         .arch = MultiArch{ .specific = Arch.s390x },
         .abi = MultiAbi{ .specific = Abi.gnu },
     },
-    // It's unclear which zig target this glibc sparcv9 target maps to.
-    //LibCTarget{
-    //    .name = "sparcv9-linux-gnu",
-    //    .arch = MultiArch{ .specific = Arch.sparc },
-    //    .abi = MultiAbi{ .specific = Abi.gnu },
-    //},
+    LibCTarget{
+        .name = "sparcv9-linux-gnu",
+        .arch = MultiArch{ .specific = Arch.sparc },
+        .abi = MultiAbi{ .specific = Abi.gnu },
+    },
     LibCTarget{
         .name = "sparc64-linux-gnu",
         .arch = MultiArch{ .specific = Arch.sparc64 },


### PR DESCRIPTION
It is impossible to even build projects like glibc when targeting a generic SPARC v8 CPU; LEON3 is effectively considered the baseline for `sparc-linux-gnu` now, particularly due to it supporting a CASA instruction similar to the one in SPARC v9. However, it's slightly incompatible with SPARC v9 due to having a different ASI tag, so resulting binaries would not be portable to regular SPARC CPUs. So, as the least bad option, make v9 the baseline for sparc32.

https://sourceware.org/git/?p=glibc.git;a=blob;f=scripts/build-many-glibcs.py;h=8bfe29876d8a137be7622a1a00c8566829a1365d;hb=HEAD#l460