### PR TITLE
tools: Add tool for checking size and alignment of C types

### DIFF
--- a/test/standalone/build.zig
+++ b/test/standalone/build.zig
@@ -34,6 +34,7 @@ pub fn build(b: *std.Build) void {
         "../../tools/gen_outline_atomics.zig",
         "../../tools/gen_spirv_spec.zig",
         "../../tools/gen_stubs.zig",
+        "../../tools/generate_c_size_and_align_checks.zig",
         "../../tools/generate_linux_syscalls.zig",
         "../../tools/process_headers.zig",
         "../../tools/update-linux-headers.zig",

--- a/tools/generate_c_size_and_align_checks.zig
+++ b/tools/generate_c_size_and_align_checks.zig
@@ -53,5 +53,9 @@ pub fn main() !void {
             c_name(c_type),
             target.c_type_alignment(c_type),
         });
+        try stdout.print("_Static_assert(__alignof({0s}) == {1d}, \"__alignof({0s}) == {1d}\");\n\n", .{
+            c_name(c_type),
+            target.c_type_preferred_alignment(c_type),
+        });
     }
 }

--- a/tools/generate_c_size_and_align_checks.zig
+++ b/tools/generate_c_size_and_align_checks.zig
@@ -1,0 +1,57 @@
+//! Usage: zig run tools/generate_c_size_and_align_checks.zig -- [target_triple]
+//! e.g. zig run tools/generate_c_size_and_align_checks.zig -- x86_64-linux-gnu
+//!
+//! Prints _Static_asserts for the size and alignment of all the basic built-in C
+//! types. The output can be run through a compiler for the specified target to
+//! verify that Zig's values are the same as those used by a C compiler for the
+//! target.
+
+const std = @import("std");
+
+fn c_name(ty: std.Target.CType) []const u8 {
+    return switch (ty) {
+        .char => "char",
+        .short => "short",
+        .ushort => "unsigned short",
+        .int => "int",
+        .uint => "unsigned int",
+        .long => "long",
+        .ulong => "unsigned long",
+        .longlong => "long long",
+        .ulonglong => "unsigned long long",
+        .float => "float",
+        .double => "double",
+        .longdouble => "long double",
+    };
+}
+
+var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+
+pub fn main() !void {
+    const gpa = general_purpose_allocator.allocator();
+    defer std.debug.assert(general_purpose_allocator.deinit() == .ok);
+
+    const args = try std.process.argsAlloc(gpa);
+    defer std.process.argsFree(gpa, args);
+
+    if (args.len != 2) {
+        std.debug.print("Usage: {s} [target_triple]\n", .{args[0]});
+        std.process.exit(1);
+    }
+
+    const query = try std.Target.Query.parse(.{ .arch_os_abi = args[1] });
+    const target = try std.zig.system.resolveTargetQuery(query);
+
+    const stdout = std.io.getStdOut().writer();
+    inline for (@typeInfo(std.Target.CType).Enum.fields) |field| {
+        const c_type: std.Target.CType = @enumFromInt(field.value);
+        try stdout.print("_Static_assert(sizeof({s}) == {d}, \"\");\n", .{
+            c_name(c_type),
+            target.c_type_byte_size(c_type),
+        });
+        try stdout.print("_Static_assert(_Alignof({s}) == {d}, \"\");\n\n", .{
+            c_name(c_type),
+            target.c_type_alignment(c_type),
+        });
+    }
+}

--- a/tools/generate_c_size_and_align_checks.zig
+++ b/tools/generate_c_size_and_align_checks.zig
@@ -45,11 +45,11 @@ pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
     inline for (@typeInfo(std.Target.CType).Enum.fields) |field| {
         const c_type: std.Target.CType = @enumFromInt(field.value);
-        try stdout.print("_Static_assert(sizeof({s}) == {d}, \"\");\n", .{
+        try stdout.print("_Static_assert(sizeof({0s}) == {1d}, \"sizeof({0s}) == {1d}\");\n", .{
             c_name(c_type),
             target.c_type_byte_size(c_type),
         });
-        try stdout.print("_Static_assert(_Alignof({s}) == {d}, \"\");\n\n", .{
+        try stdout.print("_Static_assert(_Alignof({0s}) == {1d}, \"_Alignof({0s}) == {1d}\");\n\n", .{
             c_name(c_type),
             target.c_type_alignment(c_type),
         });


### PR DESCRIPTION
Requested by @alexrp 

Prints _Static_asserts for the size and alignment of all the basic built-in C types.

The output can be run through a compiler for the specified target to verify that Zig's values are the same as those used by a C compiler for the target.

Example output for `x86_64-linux-gnu`:
```c
_Static_assert(sizeof(char) == 1, "");
_Static_assert(_Alignof(char) == 1, "");

_Static_assert(sizeof(short) == 2, "");
_Static_assert(_Alignof(short) == 2, "");

_Static_assert(sizeof(unsigned short) == 2, "");
_Static_assert(_Alignof(unsigned short) == 2, "");

_Static_assert(sizeof(int) == 4, "");
_Static_assert(_Alignof(int) == 4, "");

_Static_assert(sizeof(unsigned int) == 4, "");
_Static_assert(_Alignof(unsigned int) == 4, "");

_Static_assert(sizeof(long) == 8, "");
_Static_assert(_Alignof(long) == 8, "");

_Static_assert(sizeof(unsigned long) == 8, "");
_Static_assert(_Alignof(unsigned long) == 8, "");

_Static_assert(sizeof(long long) == 8, "");
_Static_assert(_Alignof(long long) == 8, "");

_Static_assert(sizeof(unsigned long long) == 8, "");
_Static_assert(_Alignof(unsigned long long) == 8, "");

_Static_assert(sizeof(float) == 4, "");
_Static_assert(_Alignof(float) == 4, "");

_Static_assert(sizeof(double) == 8, "");
_Static_assert(_Alignof(double) == 8, "");

_Static_assert(sizeof(long double) == 16, "");
_Static_assert(_Alignof(long double) == 16, "");
```