### PR TITLE
Ecdsa cross compilation fix + api change

### DIFF
--- a/lib/std/crypto/ecdsa.zig
+++ b/lib/std/crypto/ecdsa.zig
@@ -289,18 +289,18 @@ pub fn Ecdsa(comptime Curve: type, comptime Hash: type) type {
             /// Secret scalar.
             secret_key: SecretKey,
 
+            /// Create a new random key pair. `crypto.random.bytes` must be supported for the target.
+            pub fn generate() IdentityElementError!KeyPair {
+                var random_seed: [seed_length]u8 = undefined;
+                crypto.random.bytes(&random_seed);
+                return create(random_seed);
+            }
+
             /// Create a new key pair. The seed must be secret and indistinguishable from random.
-            /// The seed can also be left to null in order to generate a random key pair.
-            pub fn create(seed: ?[seed_length]u8) IdentityElementError!KeyPair {
-                var seed_ = seed;
-                if (seed_ == null) {
-                    var random_seed: [seed_length]u8 = undefined;
-                    crypto.random.bytes(&random_seed);
-                    seed_ = random_seed;
-                }
+            pub fn create(seed: [seed_length]u8) IdentityElementError!KeyPair {
                 const h = [_]u8{0x00} ** Hash.digest_length;
                 const k0 = [_]u8{0x01} ** SecretKey.encoded_length;
-                const secret_key = deterministicScalar(h, k0, seed_).toBytes(.big);
+                const secret_key = deterministicScalar(h, k0, seed).toBytes(.big);
                 return fromSecretKey(SecretKey{ .bytes = secret_key });
             }
 
@@ -380,7 +380,7 @@ test "Basic operations over EcdsaP384Sha384" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
 
     const Scheme = EcdsaP384Sha384;
-    const kp = try Scheme.KeyPair.create(null);
+    const kp = try Scheme.KeyPair.generate();
     const msg = "test";
 
     var noise: [Scheme.noise_length]u8 = undefined;
@@ -396,7 +396,7 @@ test "Basic operations over Secp256k1" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
 
     const Scheme = EcdsaSecp256k1Sha256oSha256;
-    const kp = try Scheme.KeyPair.create(null);
+    const kp = try Scheme.KeyPair.generate();
     const msg = "test";
 
     var noise: [Scheme.noise_length]u8 = undefined;
@@ -412,7 +412,7 @@ test "Basic operations over EcdsaP384Sha256" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
 
     const Scheme = Ecdsa(crypto.ecc.P384, crypto.hash.sha2.Sha256);
-    const kp = try Scheme.KeyPair.create(null);
+    const kp = try Scheme.KeyPair.generate();
     const msg = "test";
 
     var noise: [Scheme.noise_length]u8 = undefined;
@@ -886,7 +886,7 @@ test "Sec1 encoding/decoding" {
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
 
     const Scheme = EcdsaP384Sha384;
-    const kp = try Scheme.KeyPair.create(null);
+    const kp = try Scheme.KeyPair.generate();
     const pk = kp.public_key;
     const pk_compressed_sec1 = pk.toCompressedSec1();
     const pk_recovered1 = try Scheme.PublicKey.fromSec1(&pk_compressed_sec1);

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -7175,7 +7175,7 @@ pub const perf_event_attr = extern struct {
     /// Defines size of the user stack to dump on samples.
     sample_stack_user: u32 = 0,
 
-    clockid: clockid_t = .REALTIME,
+    clockid: clockid_t = 0,
     /// Defines set of regs to dump for each sample
     /// state captured on:
     ///  - precise = 0: PMU interrupt

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -7175,7 +7175,7 @@ pub const perf_event_attr = extern struct {
     /// Defines size of the user stack to dump on samples.
     sample_stack_user: u32 = 0,
 
-    clockid: clockid_t = 0,
+    clockid: clockid_t = .REALTIME,
     /// Defines set of regs to dump for each sample
     /// state captured on:
     ///  - precise = 0: PMU interrupt


### PR DESCRIPTION
Dude to the `std.crypto.ecdsa.KeyPair.create` taking and optional of seed, even if the seed is generated, cross-compiling to the environments without standard random source (eg. wasm) (`std.crypto.random.bytes`) will fail to compile.

This PR changes the API of the problematic function and moves the random seed generation to a new utility function.

The simplest workaround is copying the ECDSA file to my project and making the changes (to enjoy microscopic crypto wasm binary).