### PR TITLE
Make `Type.intAbiAlignment` match the LLVM alignment for x86-windows target

### DIFF
--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1563,7 +1563,11 @@ pub fn intAbiAlignment(bits: u16, target: Target, use_llvm: bool) Alignment {
             0 => .none,
             1...8 => .@"1",
             9...16 => .@"2",
-            17...64 => .@"4",
+            17...32 => .@"4",
+            33...64 => switch (target.os.tag) {
+                .uefi, .windows => .@"8",
+                else => .@"4",
+            },
             else => .@"16",
         },
         .x86_64 => switch (bits) {


### PR DESCRIPTION
This may not be the totally correct fix, but I'm hoping this gets the ball rolling towards finding the correct fix. I'm also unsure what the source of truth is for these alignment values.

---

During the LLVM 18 upgrade, two changes were made that changed `@alignOf(u64)` from 8 to 4 for the x86-windows target:

- `Type.maxIntAlignment` was made to return 16 for x86 (200e06b). Before that commit, `maxIntAlignment` was 8 for windows/uefi and 4 for everything else
- `Type.intAbiAlignment` was made to return 4 for 33...64 (7e1cba7 + e89d6fc). Before those commits, `intAbiAlignment` would return 8, since the maxIntAlignment for x86-windows was 8 (and for other targets, the `maxIntAlignment` of 4 would clamp the `intAbiAlignment` to 4)

However, `src/codegen/llvm.zig` has its own alignment calculations that no longer matches the new values returned from the `Type` functions. For the x86-windows target, this loop:

https://github.com/ziglang/zig/blob/ddcb7b1c11f88c4ae150b36807033060a469dcb5/src/codegen/llvm.zig#L558-L567

when the `size` is 64, will set `abi` and `pref` to 64 (meaning an align of 8 bytes), which doesn't match the `Type` alignment of 4.

This commit makes `Type.intAbiAlignment` match the alignment calculated in `codegen/llvm.zig` (meaning `@alignOf(u64)` is now 8 again for x86-windows).

Fixes #20047
Fixes #20466
Fixes #20469

---

Before, std lib tests panic:

```
> zig test lib\std\std.zig --zig-lib-dir lib -target x86-windows
thread 14660 panic: integer overflow
Panicked during a panic. Aborting.
```

After, std lib tests pass except for an unrelated f80 failure:

```
> zig test lib\std\std.zig --zig-lib-dir lib -target x86-windows
expected 907682844368439810595840, found 907682844368439810596864
737/2740 fmt.format_float.test.format f80...FAIL (TestExpectedEqual)
C:\Users\Ryan\Programming\Zig\zig\lib\std\testing.zig:97:17: 0x91d48f in expectEqualInner__anon_44988 (test.exe.obj)
                return error.TestExpectedEqual;
                ^
C:\Users\Ryan\Programming\Zig\zig\lib\std\fmt\format_float.zig:1534:9: 0x91fbe1 in check__anon_44998 (test.exe.obj)
        try std.testing.expectEqual(value_bits, o_bits);
        ^
C:\Users\Ryan\Programming\Zig\zig\lib\std\fmt\format_float.zig:1659:5: 0x92141f in test.format f80 (test.exe.obj)
    try check(f80, -2.109808898695963e16, "-2.109808898695963e16");
    ^
2672 passed; 67 skipped; 1 failed.
```

The reproductions in https://github.com/ziglang/zig/issues/20047 and https://github.com/ziglang/zig/issues/20466 also now pass.  The demonstration of the mismatch in https://github.com/ziglang/zig/issues/20469 now outputs:

```
pointer: 8
value: 0
35650784
35650784
```

(which matches the output of `zig 0.12`, before this mismatch was introduced)