### PR TITLE
stdlib : base64 encode to writer

### DIFF
--- a/lib/std/base64.zig
+++ b/lib/std/base64.zig
@@ -102,7 +102,7 @@ pub const Base64Encoder = struct {
     pub fn encodeWriter(encoder: *const Base64Encoder, dest: anytype, source: []const u8) !void {
         var temp = [_]u8{0} ** 5;
         var chunker = window(u8, source, 3, 3);
-        while(chunker.next()) |chunk| {
+        while (chunker.next()) |chunk| {
             const s = encoder.encode(&temp, chunk);
             try dest.writeAll(s);
         }
@@ -497,7 +497,6 @@ fn testAllApis(codecs: Codecs, expected_decoded: []const u8, expected_encoded: [
         try codecs.Encoder.encodeWriter(list.writer(), expected_decoded);
         try testing.expectEqualSlices(u8, expected_encoded, list.slice());
     }
-
 
     // Base64Decoder
     {

--- a/lib/std/base64.zig
+++ b/lib/std/base64.zig
@@ -101,9 +101,9 @@ pub const Base64Encoder = struct {
 
     // dest must be compatible with std.io.Writer's writeAll interface
     pub fn encodeWriter(encoder: *const Base64Encoder, dest: anytype, source: []const u8) !void {
-        var temp = [_]u8{0} ** 5;
         var chunker = window(u8, source, 3, 3);
         while (chunker.next()) |chunk| {
+            var temp: [5]u8 = undefined;
             const s = encoder.encode(&temp, chunk);
             try dest.writeAll(s);
         }

--- a/lib/std/base64.zig
+++ b/lib/std/base64.zig
@@ -369,7 +369,7 @@ pub const Base64DecoderWithIgnore = struct {
 test "base64" {
     @setEvalBranchQuota(8000);
     try testBase64();
-    try testAllApis(standard, "comptime", "Y29tcHRpbWU=");
+    try comptime testAllApis(standard, "comptime", "Y29tcHRpbWU=");
 }
 
 test "base64 padding dest overflow" {
@@ -389,7 +389,7 @@ test "base64 padding dest overflow" {
 test "base64 url_safe_no_pad" {
     @setEvalBranchQuota(8000);
     try testBase64UrlSafeNoPad();
-    try testAllApis(url_safe_no_pad, "comptime", "Y29tcHRpbWU");
+    try comptime testAllApis(url_safe_no_pad, "comptime", "Y29tcHRpbWU");
 }
 
 fn testBase64() !void {
@@ -493,10 +493,9 @@ fn testAllApis(codecs: Codecs, expected_decoded: []const u8, expected_encoded: [
         try testing.expectEqualSlices(u8, expected_encoded, encoded);
 
         // stream encode
-        var list = std.ArrayList(u8).init(testing.allocator);
-        defer list.deinit();
+        var list = try std.BoundedArray(u8, 0x100).init(0);
         try codecs.Encoder.encodeWriter(list.writer(), expected_decoded);
-        try testing.expectEqualSlices(u8, expected_encoded, list.items);
+        try testing.expectEqualSlices(u8, expected_encoded, list.slice());
     }
 
 

--- a/lib/std/base64.zig
+++ b/lib/std/base64.zig
@@ -112,13 +112,14 @@ pub const Base64Encoder = struct {
     // destWriter must be compatible with std.io.Writer's writeAll interface
     // sourceReader must be compatible with std.io.Reader's read interface
     pub fn encodeFromReaderToWriter(encoder: *const Base64Encoder, destWriter: anytype, sourceReader: anytype) !void {
-        var temp = [_]u8{0} ** 5;
-        var tempSource = [_]u8{0} ** 3;
         while (true) {
+            var tempSource: [3]u8 = undefined;
             const bytesRead = try sourceReader.read(&tempSource);
             if (bytesRead == 0) {
                 break;
             }
+
+            var temp: [5]u8 = undefined;
             const s = encoder.encode(&temp, tempSource[0..bytesRead]);
             try destWriter.writeAll(s);
         }


### PR DESCRIPTION
Hello,

The current base64 interface only allows encoding to slices, making it impractical (although not impossible) to use when encoding dynamically to a document (such as a json string, as an example).

This PR adds the `encodeWriter` API to `Base64Encoder`, relying on the destination having the `writeAll` interface of `Writer`. As it is possible to encode base64 data by chunks of 3 bytes, it progressively encodes the source data in the stream without unnecessary heap allocations.
