### PR TITLE
stdlib: json, expose some internals for jsonStringify users

### DIFF
--- a/lib/std/json/stringify.zig
+++ b/lib/std/json/stringify.zig
@@ -332,7 +332,7 @@ pub fn WriteStream(
             try self.stream.writeByteNTimes(char, n_chars);
         }
 
-        fn valueStart(self: *Self) !void {
+        pub fn valueStart(self: *Self) !void {
             if (self.isObjectKeyExpected()) |is_it| assert(!is_it); // Call objectField*(), not write(), for object keys.
             return self.valueStartAssumeTypeOk();
         }
@@ -363,7 +363,7 @@ pub fn WriteStream(
                 },
             }
         }
-        fn valueDone(self: *Self) void {
+        pub fn valueDone(self: *Self) void {
             self.next_punctuation = .comma;
         }
 


### PR DESCRIPTION
the json library allows custom representations if an object possesses the `jsonStringify` interface.

Some of the internals of the json library are exposed for users of this functionality, such as `beginObject`, `beginArray` ... But nothing is available when the goal is to push a raw value (such as a string) directly into the stream.

This commit makes public `valueStart` and `valueDone` to avoid people having to reimplement by themselves (and follow the developments) of some of the json lib.

I was specifically in this case on https://github.com/Arwalk/zig-protobuf when trying to implement json parsing/encoding : bytes field are supposed to be base64 encoded, meaning i had to reimplement `valueStart` and `valueDone` just to be able to make my encoding.