### PR TITLE
`llvm`: For UEFI, use LLVM's `uefi` OS tag instead of `windows`

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -118,7 +118,7 @@ pub fn targetTriple(allocator: Allocator, target: std.Target) ![]const u8 {
         .hurd => "hurd",
         .wasi => "wasi",
         .emscripten => "emscripten",
-        .uefi => "windows",
+        .uefi => "uefi",
         .macos => "macosx",
         .ios => "ios",
         .tvos => "tvos",


### PR DESCRIPTION
I can't find any indication in the Git history as to why this was using `windows`. LLVM actually has what looks like proper support for a `uefi` tag.