### PR TITLE
Compilation: Mark .c++ files as having C++ extension

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -6073,6 +6073,7 @@ pub fn hasCppExt(filename: []const u8) bool {
         mem.endsWith(u8, filename, ".cc") or
         mem.endsWith(u8, filename, ".cpp") or
         mem.endsWith(u8, filename, ".cxx") or
+        mem.endsWith(u8, filename, ".c++") or
         mem.endsWith(u8, filename, ".stub");
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -387,27 +387,27 @@ const usage_build_generic =
     \\       zig translate-c [options] [file]
     \\
     \\Supported file types:
-    \\                    .zig    Zig source code
-    \\                      .o    ELF object file
-    \\                      .o    Mach-O (macOS) object file
-    \\                      .o    WebAssembly object file
-    \\                    .obj    COFF (Windows) object file
-    \\                    .lib    COFF (Windows) static library
-    \\                      .a    ELF static library
-    \\                      .a    Mach-O (macOS) static library
-    \\                      .a    WebAssembly static library
-    \\                     .so    ELF shared object (dynamic link)
-    \\                    .dll    Windows Dynamic Link Library
-    \\                  .dylib    Mach-O (macOS) dynamic library
-    \\                    .tbd    (macOS) text-based dylib definition
-    \\                      .s    Target-specific assembly source code
-    \\                      .S    Assembly with C preprocessor (requires LLVM extensions)
-    \\                      .c    C source code (requires LLVM extensions)
-    \\  .cxx .cc .C .cpp .stub    C++ source code (requires LLVM extensions)
-    \\                      .m    Objective-C source code (requires LLVM extensions)
-    \\                     .mm    Objective-C++ source code (requires LLVM extensions)
-    \\                     .bc    LLVM IR Module (requires LLVM extensions)
-    \\                     .cu    Cuda source code (requires LLVM extensions)
+    \\                         .zig    Zig source code
+    \\                           .o    ELF object file
+    \\                           .o    Mach-O (macOS) object file
+    \\                           .o    WebAssembly object file
+    \\                         .obj    COFF (Windows) object file
+    \\                         .lib    COFF (Windows) static library
+    \\                           .a    ELF static library
+    \\                           .a    Mach-O (macOS) static library
+    \\                           .a    WebAssembly static library
+    \\                          .so    ELF shared object (dynamic link)
+    \\                         .dll    Windows Dynamic Link Library
+    \\                       .dylib    Mach-O (macOS) dynamic library
+    \\                         .tbd    (macOS) text-based dylib definition
+    \\                           .s    Target-specific assembly source code
+    \\                           .S    Assembly with C preprocessor (requires LLVM extensions)
+    \\                           .c    C source code (requires LLVM extensions)
+    \\  .cxx .cc .C .cpp .c++ .stub    C++ source code (requires LLVM extensions)
+    \\                           .m    Objective-C source code (requires LLVM extensions)
+    \\                          .mm    Objective-C++ source code (requires LLVM extensions)
+    \\                          .bc    LLVM IR Module (requires LLVM extensions)
+    \\                          .cu    Cuda source code (requires LLVM extensions)
     \\
     \\General Options:
     \\  -h, --help                Print this help and exit


### PR DESCRIPTION
Some projects, such as Cap'n Proto, use .c++ as their filenames. Without this, compiling them fails because zig c++ will fall back to using the linker.