### PR TITLE
update_cpu_features: Fixes and updates

### DIFF
--- a/lib/std/Target/arm.zig
+++ b/lib/std/Target/arm.zig
@@ -86,6 +86,7 @@ pub const Feature = enum {
     has_v9_2a,
     has_v9_3a,
     has_v9_4a,
+    has_v9_5a,
     has_v9a,
     hwdiv,
     hwdiv_arm,
@@ -752,6 +753,13 @@ pub const all_features = blk: {
         .dependencies = featureSet(&[_]Feature{
             .has_v8_9a,
             .has_v9_3a,
+        }),
+    };
+    result[@intFromEnum(Feature.has_v9_5a)] = .{
+        .llvm_name = "v9.5a",
+        .description = "Support ARM v9.5a instructions",
+        .dependencies = featureSet(&[_]Feature{
+            .has_v9_4a,
         }),
     };
     result[@intFromEnum(Feature.has_v9a)] = .{
@@ -1582,18 +1590,11 @@ pub const all_features = blk: {
             .db,
             .dsp,
             .fp_armv8,
+            .has_v9_5a,
             .mp,
             .ras,
             .trustzone,
-            .v9_5a,
             .virtualization,
-        }),
-    };
-    result[@intFromEnum(Feature.v9_5a)] = .{
-        .llvm_name = "v9.5a",
-        .description = "Support ARM v9.5a instructions",
-        .dependencies = featureSet(&[_]Feature{
-            .has_v9_4a,
         }),
     };
     result[@intFromEnum(Feature.v9a)] = .{

--- a/lib/std/Target/riscv.zig
+++ b/lib/std/Target/riscv.zig
@@ -78,6 +78,7 @@ pub const Feature = enum {
     svnapot,
     svpbmt,
     tagged_globals,
+    unaligned_scalar_mem,
     use_postra_scheduler,
     v,
     ventana_veyron,
@@ -582,6 +583,11 @@ pub const all_features = blk: {
     result[@intFromEnum(Feature.tagged_globals)] = .{
         .llvm_name = "tagged-globals",
         .description = "Use an instruction sequence for taking the address of a global that allows a memory tag in the upper address bits",
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.unaligned_scalar_mem)] = .{
+        .llvm_name = "unaligned-scalar-mem",
+        .description = "Has reasonably performant unaligned scalar loads and stores",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_postra_scheduler)] = .{

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -809,6 +809,10 @@ const llvm_targets = [_]LlvmTarget{
                 .llvm_name = "v9.4a",
                 .zig_name = "has_v9_4a",
             },
+            .{
+                .llvm_name = "v9.5a",
+                .zig_name = "has_v9_5a",
+            },
         },
         // LLVM removed support for v2 and v3 but zig wants to support targeting old hardware
         .extra_features = &.{
@@ -990,6 +994,7 @@ const llvm_targets = [_]LlvmTarget{
             "icelake_client",
             "icelake_server",
             "graniterapids_d",
+            "arrowlake_s",
         },
     },
     .{


### PR DESCRIPTION
- Before this PR, the name `v9_5a` in `Target/arm.zig` was being used for two different features, and one was overwriting the other in the `all_features` array.
- `arrowlake_s` is an alias for `arrowlake-s`
- RISCV unaligned-scalar-mem was added in LLVM 18.1.6